### PR TITLE
fix: 更新版本号至0.1.9并添加axios依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Hermes Agent Web UI - Chat and Job Management Dashboard",
   "repository": {
     "type": "git",
@@ -27,6 +27,7 @@
     "@koa/bodyparser": "^5.0.0",
     "@koa/cors": "^5.0.0",
     "@koa/router": "^13.1.0",
+    "axios": "^1.15.0",
     "highlight.js": "^11.11.1",
     "js-yaml": "^4.1.1",
     "koa": "^2.15.3",


### PR DESCRIPTION
之前0.1.8版本缺少 axios依赖报错了
<img width="1834" height="1380" alt="CleanShot 2026-04-13 at 16 35 36@2x" src="https://github.com/user-attachments/assets/0d1629c7-e05f-44b5-9988-fc50f428315e" />
