### PR TITLE
feat: support UPSTREAM_API_KEY for auto-injecting auth header

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os'
 export const config = {
   port: parseInt(process.env.PORT || '8648', 10),
   upstream: process.env.UPSTREAM || 'http://127.0.0.1:8642',
+  upstreamApiKey: process.env.UPSTREAM_API_KEY || '',
   uploadDir: process.env.UPLOAD_DIR || resolve(tmpdir(), 'hermes-uploads'),
   dataDir: resolve(__dirname, '..', 'data'),
   corsOrigins: process.env.CORS_ORIGINS || '*',

--- a/server/src/routes/proxy-handler.ts
+++ b/server/src/routes/proxy-handler.ts
@@ -25,6 +25,11 @@ export async function proxy(ctx: Context) {
     headers['cache-control'] = 'no-cache'
   }
 
+  // Auto-inject upstream API key if configured and not already present
+  if (!headers['authorization'] && !headers['Authorization'] && config.upstreamApiKey) {
+    headers['Authorization'] = `Bearer ${config.upstreamApiKey}`
+  }
+
   try {
     // Build request body from raw body
     let body: string | undefined


### PR DESCRIPTION
## Problem

When Hermes API Server has authentication enabled (`API_SERVER_KEY` set in `.env`), the BFF proxy forwards requests without an `Authorization` header, resulting in 401 errors:

```
Error: API Error 401: {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}}
```

The Web UI has no way to configure an API key for the upstream Hermes API server.

## Solution

Add `UPSTREAM_API_KEY` environment variable support:

- **config.ts**: Add `upstreamApiKey` field reading from `UPSTREAM_API_KEY`
- **proxy-handler.ts**: Auto-inject `Authorization: Bearer <key>` header when the key is configured and no auth header is already present from the client

## Usage

```bash
UPSTREAM_API_KEY=your-api-key hermes-web-ui start
```

Or set it persistently in the startup script.

## Behavior

- If `UPSTREAM_API_KEY` is set, the BFF proxy automatically adds `Authorization: Bearer <key>` to all proxied requests to the upstream Hermes API server
- If the client already provides an `Authorization` header, the injection is skipped (preserving per-request auth override)
- If `UPSTREAM_API_KEY` is empty or unset, behavior is unchanged (no auth header injected)

## Files Changed

- `server/src/config.ts` — add `upstreamApiKey` config field
- `server/src/routes/proxy-handler.ts` — add auth header injection logic

## Testing

```bash
# Without UPSTREAM_API_KEY — 401 on authenticated Hermes
hermes-web-ui start

# With UPSTREAM_API_KEY — works correctly
UPSTREAM_API_KEY=c56b753***********e991e49 hermes-web-ui start
```