### PR TITLE
feat: add Cloudflare tunnel support for public access

### DIFF
--- a/packages/client/src/api/hermes/tunnel.ts
+++ b/packages/client/src/api/hermes/tunnel.ts
@@ -1,0 +1,18 @@
+import { request } from '../client'
+
+export interface TunnelStatus {
+  running: boolean
+  url: string | null
+}
+
+export async function getTunnelStatus(): Promise<TunnelStatus> {
+  return request<TunnelStatus>('/api/tunnel/status')
+}
+
+export async function startTunnel(): Promise<{ success: boolean; url: string | null; message?: string }> {
+  return request('/api/tunnel/start', { method: 'POST' })
+}
+
+export async function stopTunnel(): Promise<{ success: boolean; message?: string }> {
+  return request('/api/tunnel/stop', { method: 'POST' })
+}

--- a/packages/client/src/components/hermes/settings/TunnelSettings.vue
+++ b/packages/client/src/components/hermes/settings/TunnelSettings.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { NButton, NCard, NSpin, useMessage, NAlert } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { getTunnelStatus, startTunnel, stopTunnel, type TunnelStatus } from '@/api/hermes/tunnel'
+
+const { t } = useI18n()
+const message = useMessage()
+
+const status = ref<TunnelStatus>({ running: false, url: null })
+const loading = ref(false)
+const polling = ref<number | null>(null)
+
+async function fetchStatus() {
+  try {
+    status.value = await getTunnelStatus()
+  } catch (err) {
+    console.error('Failed to fetch tunnel status:', err)
+  }
+}
+
+async function handleStart() {
+  loading.value = true
+  try {
+    const res = await startTunnel()
+    if (res.success) {
+      message.success(t('settings.tunnel.started'))
+      await fetchStatus()
+    } else {
+      message.error(res.message || 'Failed to start tunnel')
+    }
+  } catch (err: any) {
+    message.error(err.message || 'Failed to start tunnel')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleStop() {
+  loading.value = true
+  try {
+    const res = await stopTunnel()
+    if (res.success) {
+      message.success(t('settings.tunnel.stoppedMsg'))
+      await fetchStatus()
+    }
+  } catch (err: any) {
+    message.error(err.message || 'Failed to stop tunnel')
+  } finally {
+    loading.value = false
+  }
+}
+
+function copyUrl() {
+  if (status.value.url) {
+    navigator.clipboard.writeText(status.value.url)
+    message.success(t('settings.tunnel.copied'))
+  }
+}
+
+onMounted(() => {
+  fetchStatus()
+  polling.value = window.setInterval(fetchStatus, 5000)
+})
+
+onUnmounted(() => {
+  if (polling.value) {
+    clearInterval(polling.value)
+  }
+})
+</script>
+
+<template>
+  <section class="settings-section">
+    <NCard :title="t('settings.tunnel.title')">
+      <template #header-extra>
+        <NSpin v-if="loading" size="small" />
+      </template>
+
+      <NAlert v-if="!status.running && !status.url" type="info" :title="t('settings.tunnel.hintTitle')">
+        {{ t('settings.tunnel.hint') }}
+      </NAlert>
+
+      <div v-if="status.running || status.url" class="tunnel-status">
+        <div class="status-row">
+          <span class="label">{{ t('settings.tunnel.status') }}:</span>
+          <span :class="['value', status.running ? 'running' : 'stopped']">
+            {{ status.running ? t('settings.tunnel.running') : t('settings.tunnel.stopped') }}
+          </span>
+        </div>
+
+        <div v-if="status.url" class="url-row">
+          <span class="label">{{ t('settings.tunnel.url') }}:</span>
+          <div class="url-value">
+            <code>{{ status.url }}</code>
+            <NButton size="small" quaternary @click="copyUrl">
+              {{ t('settings.tunnel.copy') }}
+            </NButton>
+          </div>
+        </div>
+      </div>
+
+      <template #action>
+        <NButton v-if="status.running" type="error" @click="handleStop" :disabled="loading">
+          {{ t('settings.tunnel.stop') }}
+        </NButton>
+        <NButton v-else type="primary" @click="handleStart" :disabled="loading">
+          {{ t('settings.tunnel.start') }}
+        </NButton>
+      </template>
+    </NCard>
+  </section>
+</template>
+
+<style scoped lang="scss">
+.settings-section {
+  margin-top: 16px;
+}
+
+.tunnel-status {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.status-row,
+.url-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.label {
+  font-weight: 500;
+  color: var(--n-text-color-3);
+}
+
+.value.running {
+  color: #18a058;
+}
+
+.value.stopped {
+  color: #d03050;
+}
+
+.url-value {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  code {
+    background: var(--n-color-hover);
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 14px;
+  }
+}
+</style>

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -1,0 +1,79 @@
+import Router from '@koa/router'
+import { spawn } from 'child_process'
+import { config } from '../config'
+
+const tunnelRoutes = new Router()
+
+let tunnelProcess: ReturnType<typeof spawn> | null = null
+let tunnelUrl: string | null = null
+
+tunnelRoutes.get('/api/tunnel/status', async (ctx) => {
+  ctx.body = {
+    running: tunnelProcess !== null && !tunnelProcess.killed,
+    url: tunnelUrl,
+  }
+})
+
+tunnelRoutes.post('/api/tunnel/start', async (ctx) => {
+  if (tunnelProcess && !tunnelProcess.killed) {
+    ctx.body = { success: true, url: tunnelUrl, message: 'Tunnel already running' }
+    return
+  }
+
+  const port = config.port
+
+  return new Promise<void>((resolve) => {
+    tunnelProcess = spawn('/usr/local/bin/cloudflared', ['tunnel', '--url', `http://localhost:${port}`, '--protocol', 'http2'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let buffer = ''
+
+    tunnelProcess.stderr?.on('data', (data: Buffer) => {
+      buffer += data.toString()
+      const match = buffer.match(/https:\/\/[a-zA-Z0-9-]+\.trycloudflare\.com/)
+      if (match && !tunnelUrl) {
+        tunnelUrl = match[0]
+        console.log(`🌐 Tunnel ready: ${tunnelUrl}`)
+        ctx.body = { success: true, url: tunnelUrl }
+        resolve()
+      }
+    })
+
+    tunnelProcess.on('error', (err) => {
+      console.error('Tunnel error:', err)
+      tunnelProcess = null
+      ctx.status = 500
+      ctx.body = { success: false, error: err.message }
+      resolve()
+    })
+
+    tunnelProcess.on('exit', (code) => {
+      if (code !== 0) {
+        console.log(`Tunnel exited with code ${code}`)
+      }
+      tunnelProcess = null
+      tunnelUrl = null
+    })
+
+    setTimeout(() => {
+      if (!ctx.body) {
+        ctx.body = { success: true, url: tunnelUrl, message: 'Tunnel starting...' }
+        resolve()
+      }
+    }, 5000)
+  })
+})
+
+tunnelRoutes.post('/api/tunnel/stop', async (ctx) => {
+  if (tunnelProcess && !tunnelProcess.killed) {
+    tunnelProcess.kill('SIGTERM')
+    tunnelProcess = null
+    tunnelUrl = null
+    ctx.body = { success: true }
+  } else {
+    ctx.body = { success: true, message: 'No tunnel running' }
+  }
+})
+
+export { tunnelRoutes }


### PR DESCRIPTION
描述：
  功能说明
添加Cloudflare隧道支持，让用户可以通过公网访问Hermes Web UI,解决部署到服务器或其他设备要访问Web界面的问题
  新增文件
- `packages/server/src/routes/tunnel.ts` - 隧道API路由
- `packages/client/src/api/hermes/tunnel.ts` - 前端API封装
- `packages/client/src/components/hermes/settings/TunnelSettings.vue` - 设置页面UI
  修改文件
- `index.ts` - 引入隧道路由
- `SettingsView.vue` - 添加隧道标签页
- `en.ts` / `zh.ts` - 添加国际化文本
  功能特性
- 一键启动/停止Cloudflare隧道
- 自动生成trycloudflare.com公网URL
- 实时状态监控
- 支持中英文界面
  依赖
需要安装cloudflared：https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation/
