### PR TITLE
fix: auto-install dependencies on start/update

### DIFF
--- a/bin/hermes-web-ui.mjs
+++ b/bin/hermes-web-ui.mjs
@@ -26,6 +26,27 @@ function ensureNativeModules() {
   } catch {}
 }
 
+// ─── Auto-install missing production dependencies ─────────────
+// After `npm install -g` upgrade, node_modules may be stale or missing.
+// This check verifies a critical runtime dependency (koa) is resolvable;
+// if not, runs `npm install --omit=dev` to restore them.
+function ensureDependencies() {
+  const nmDir = join(pkgDir, 'node_modules')
+  const koaPath = join(nmDir, 'koa')
+  try {
+    statSync(koaPath)
+  } catch {
+    console.log('  ⚠ Dependencies missing, installing...')
+    try {
+      execSync('npm install --omit=dev', { cwd: pkgDir, stdio: 'pipe', timeout: 120000 })
+      console.log('  ✓ Dependencies installed')
+    } catch (err) {
+      console.error('  ✗ Failed to install dependencies:', err.message)
+      process.exit(1)
+    }
+  }
+}
+
 function getToken() {
   try {
     return readFileSync(TOKEN_FILE, 'utf-8').trim()
@@ -115,6 +136,7 @@ function startDaemon(port) {
 
   mkdirSync(PID_DIR, { recursive: true })
 
+  ensureDependencies()
   ensureNativeModules()
   const token = ensureToken()
 
@@ -296,6 +318,9 @@ function doUpdate() {
     if (code === 0) {
       console.log('  ✓ Update complete, restarting...')
       stopDaemon()
+      // After npm upgrade, node_modules may be stale — clear to force ensureDependencies() reinstall
+      const nmDir = join(pkgDir, 'node_modules')
+      try { execSync(`rm -rf "${nmDir}"`) } catch {}
       setTimeout(() => startDaemon(getPort()), 500)
     } else {
       console.log('  ✗ Update failed')


### PR DESCRIPTION
## Problem

After `npm install -g hermes-web-ui@latest` upgrade, the server fails to start with `MODULE_NOT_FOUND` (e.g. `Cannot find module 'koa'`).

**Root cause:** The published npm package only includes `bin/` and `dist/` (per `package.json` `files` field). Production dependencies in `node_modules/` may become stale or missing after an upgrade, but the bin script has no mechanism to restore them — it immediately spawns the server which crashes.

## Fix

- Add `ensureDependencies()`: checks if `node_modules/koa` exists as a sentinel for production deps; if missing, runs `npm install --omit=dev` automatically before spawning the server.
- Call `ensureDependencies()` in `startDaemon()` before `ensureNativeModules()`.
- In `doUpdate()`, clear `node_modules` after upgrade so `ensureDependencies()` is forced to reinstall on the subsequent restart.

## Verification

1. Removed `node_modules/` entirely (simulating post-upgrade state)
2. Ran `hermes-web-ui start` — detected missing deps, auto-installed, server started successfully
3. Confirmed `http://localhost:8648/health` returns 200 and `/` returns 2706 bytes of HTML