### PR TITLE
feat(chat): polish syntax highlighting and tool payload rendering

### DIFF
--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -2,32 +2,29 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import MarkdownIt from 'markdown-it'
-import hljs from 'highlight.js'
+import { handleCodeBlockCopyClick, renderHighlightedCodeBlock } from './highlight'
 
 const props = defineProps<{ content: string }>()
 const { t } = useI18n()
 
-const md: MarkdownIt = new MarkdownIt({
+const md = computed(() => new MarkdownIt({
   html: false,
   linkify: true,
   typographer: true,
   highlight(str: string, lang: string): string {
-    if (lang && hljs.getLanguage(lang)) {
-      try {
-        return `<pre class="hljs-code-block"><div class="code-header"><span class="code-lang">${lang}</span><button class="copy-btn" onclick="navigator.clipboard.writeText(this.closest('.hljs-code-block').querySelector('code').textContent)">${t('common.copy')}</button></div><code class="hljs language-${lang}">${hljs.highlight(str, { language: lang, ignoreIllegals: true }).value}</code></pre>`
-      } catch {
-        // fall through
-      }
-    }
-    return `<pre class="hljs-code-block"><div class="code-header"><button class="copy-btn" onclick="navigator.clipboard.writeText(this.closest('.hljs-code-block').querySelector('code').textContent)">${t('common.copy')}</button></div><code class="hljs">${md.utils.escapeHtml(str)}</code></pre>`
+    return renderHighlightedCodeBlock(str, lang, t('common.copy'))
   },
-})
+}))
 
-const renderedHtml = computed(() => md.render(props.content))
+const renderedHtml = computed(() => md.value.render(props.content))
+
+function handleMarkdownClick(event: MouseEvent): void {
+  void handleCodeBlockCopyClick(event)
+}
 </script>
 
 <template>
-  <div class="markdown-body" v-html="renderedHtml"></div>
+  <div class="markdown-body" v-html="renderedHtml" @click="handleMarkdownClick"></div>
 </template>
 
 <style lang="scss">
@@ -121,88 +118,4 @@ const renderedHtml = computed(() => md.render(props.content))
     margin: 12px 0;
   }
 }
-
-.hljs-code-block {
-  margin: 8px 0;
-  border-radius: $radius-sm;
-  overflow: hidden;
-  background: $code-bg;
-  border: 1px solid $border-color;
-
-  .code-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 6px 12px;
-    background: rgba(0, 0, 0, 0.03);
-    border-bottom: 1px solid $border-color;
-
-    .code-lang {
-      font-size: 11px;
-      color: $text-muted;
-      text-transform: uppercase;
-    }
-
-    .copy-btn {
-      font-size: 11px;
-      color: $text-muted;
-      background: none;
-      border: none;
-      cursor: pointer;
-      padding: 2px 6px;
-      border-radius: 3px;
-      transition: all $transition-fast;
-
-      &:hover {
-        color: $text-primary;
-        background: rgba(0, 0, 0, 0.05);
-      }
-    }
-  }
-
-  code.hljs {
-    display: block;
-    padding: 12px;
-    font-family: $font-code;
-    font-size: 13px;
-    line-height: 1.5;
-    overflow-x: auto;
-  }
-}
-
-// highlight.js theme override — pure ink B&W
-.hljs {
-  color: #2a2a2a;
-  background: none;
-}
-
-.hljs-keyword,
-.hljs-selector-tag { color: #1a1a1a; font-weight: 600; }
-.hljs-string,
-.hljs-attr { color: #555555; }
-.hljs-number { color: #333333; }
-.hljs-comment { color: #999999; font-style: italic; }
-.hljs-built_in { color: #444444; }
-.hljs-type { color: #3a3a3a; }
-.hljs-variable { color: #1a1a1a; }
-.hljs-title,
-.hljs-title\.function_ { color: #1a1a1a; }
-.hljs-params { color: #2a2a2a; }
-.hljs-meta { color: #999999; }
-
-// Dark mode highlight.js — inverted pure ink
-.dark .hljs { color: #d0d0d0; }
-.dark .hljs-keyword,
-.dark .hljs-selector-tag { color: #f0f0f0; font-weight: 600; }
-.dark .hljs-string,
-.dark .hljs-attr { color: #aaaaaa; }
-.dark .hljs-number { color: #cccccc; }
-.dark .hljs-comment { color: #666666; font-style: italic; }
-.dark .hljs-built_in { color: #bbbbbb; }
-.dark .hljs-type { color: #c6c6c6; }
-.dark .hljs-variable { color: #f0f0f0; }
-.dark .hljs-title,
-.dark .hljs-title\.function_ { color: #f0f0f0; }
-.dark .hljs-params { color: #d0d0d0; }
-.dark .hljs-meta { color: #666666; }
 </style>

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -7,16 +7,16 @@ import { handleCodeBlockCopyClick, renderHighlightedCodeBlock } from './highligh
 const props = defineProps<{ content: string }>()
 const { t } = useI18n()
 
-const md = computed(() => new MarkdownIt({
+const md: MarkdownIt = new MarkdownIt({
   html: false,
   linkify: true,
   typographer: true,
   highlight(str: string, lang: string): string {
     return renderHighlightedCodeBlock(str, lang, t('common.copy'))
   },
-}))
+})
 
-const renderedHtml = computed(() => md.value.render(props.content))
+const renderedHtml = computed(() => md.render(props.content))
 
 function handleMarkdownClick(event: MouseEvent): void {
   void handleCodeBlockCopyClick(event)

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -3,7 +3,13 @@ import type { Message } from "@/stores/hermes/chat";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import MarkdownRenderer from "./MarkdownRenderer.vue";
-import { handleCodeBlockCopyClick, inferStructuredLanguage, renderHighlightedCodeBlock } from "./highlight";
+import {
+  copyTextToClipboard,
+  handleCodeBlockCopyClick,
+  renderHighlightedCodeBlock,
+} from "./highlight";
+
+const TOOL_PAYLOAD_DISPLAY_LIMIT = 2000;
 
 const props = defineProps<{ message: Message }>();
 const { t } = useI18n();
@@ -26,40 +32,64 @@ function formatSize(bytes: number): string {
   return (bytes / (1024 * 1024)).toFixed(1) + " MB";
 }
 
+type ToolPayload = {
+  full: string;
+  display: string;
+  language?: string;
+};
+
+function formatToolPayload(raw?: string): ToolPayload {
+  if (!raw) {
+    return { full: "", display: "" };
+  }
+
+  try {
+    const full = JSON.stringify(JSON.parse(raw), null, 2);
+    return {
+      full,
+      display:
+        full.length > TOOL_PAYLOAD_DISPLAY_LIMIT
+          ? full.slice(0, TOOL_PAYLOAD_DISPLAY_LIMIT) + "\n" + t("chat.truncated")
+          : full,
+      language: "json",
+    };
+  } catch {
+    return {
+      full: raw,
+      display:
+        raw.length > TOOL_PAYLOAD_DISPLAY_LIMIT
+          ? raw.slice(0, TOOL_PAYLOAD_DISPLAY_LIMIT) + "\n" + t("chat.truncated")
+          : raw,
+    };
+  }
+}
+
 function renderToolPayload(content: string, language?: string): string {
   return renderHighlightedCodeBlock(content, language, t("common.copy"), {
-    maxHighlightLength: 2000,
+    maxHighlightLength: TOOL_PAYLOAD_DISPLAY_LIMIT,
   });
 }
 
-async function copyText(text: string): Promise<void> {
-  try {
-    await navigator.clipboard?.writeText?.(text)
-  } catch {
-    // Ignore clipboard failures; the code block still renders safely.
-  }
-}
-
 async function handleToolDetailClick(event: MouseEvent): Promise<void> {
-  const target = event.target
-  if (!(target instanceof HTMLElement)) return
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
 
-  const button = target.closest<HTMLElement>('[data-copy-code="true"]')
-  if (!button) return
+  const button = target.closest<HTMLElement>("[data-copy-code=\"true\"]");
+  if (!button) return;
 
-  event.preventDefault()
+  event.preventDefault();
 
-  const source = button.closest<HTMLElement>('[data-copy-source]')?.dataset.copySource
-  if (source === 'tool-args' && formattedToolArgs.value) {
-    await copyText(formattedToolArgs.value)
-    return
+  const source = button.closest<HTMLElement>("[data-copy-source]")?.dataset.copySource;
+  if (source === "tool-args" && fullToolArgs.value) {
+    await copyTextToClipboard(fullToolArgs.value);
+    return;
   }
-  if (source === 'tool-result' && fullToolResult.value) {
-    await copyText(fullToolResult.value)
-    return
+  if (source === "tool-result" && fullToolResult.value) {
+    await copyTextToClipboard(fullToolResult.value);
+    return;
   }
 
-  await handleCodeBlockCopyClick(event)
+  await handleCodeBlockCopyClick(event);
 }
 
 const hasAttachments = computed(
@@ -70,36 +100,19 @@ const hasToolDetails = computed(
   () => !!(props.message.toolArgs || props.message.toolResult),
 );
 
-const formattedToolArgs = computed(() => {
-  if (!props.message.toolArgs) return "";
-  try {
-    return JSON.stringify(JSON.parse(props.message.toolArgs), null, 2);
-  } catch {
-    return props.message.toolArgs;
-  }
-});
+const toolArgsPayload = computed(() => formatToolPayload(props.message.toolArgs));
+const toolResultPayload = computed(() => formatToolPayload(props.message.toolResult));
 
-const fullToolResult = computed(() => {
-  if (!props.message.toolResult) return "";
-  try {
-    return JSON.stringify(JSON.parse(props.message.toolResult), null, 2);
-  } catch {
-    return props.message.toolResult;
-  }
-});
-
-const formattedToolResult = computed(() => {
-  if (!fullToolResult.value) return "";
-  if (fullToolResult.value.length > 2000)
-    return fullToolResult.value.slice(0, 2000) + "\n" + t("chat.truncated");
-  return fullToolResult.value;
-});
+const fullToolArgs = computed(() => toolArgsPayload.value.full);
+const formattedToolArgs = computed(() => toolArgsPayload.value.display);
+const fullToolResult = computed(() => toolResultPayload.value.full);
+const formattedToolResult = computed(() => toolResultPayload.value.display);
 
 const renderedToolArgs = computed(() => {
   if (!formattedToolArgs.value) return "";
   return renderToolPayload(
     formattedToolArgs.value,
-    props.message.toolArgs ? inferStructuredLanguage(props.message.toolArgs) : undefined,
+    toolArgsPayload.value.language,
   );
 });
 
@@ -107,7 +120,7 @@ const renderedToolResult = computed(() => {
   if (!formattedToolResult.value) return "";
   return renderToolPayload(
     formattedToolResult.value,
-    props.message.toolResult ? inferStructuredLanguage(props.message.toolResult) : undefined,
+    toolResultPayload.value.language,
   );
 });
 </script>

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -3,6 +3,7 @@ import type { Message } from "@/stores/hermes/chat";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import MarkdownRenderer from "./MarkdownRenderer.vue";
+import { handleCodeBlockCopyClick, inferStructuredLanguage, renderHighlightedCodeBlock } from "./highlight";
 
 const props = defineProps<{ message: Message }>();
 const { t } = useI18n();
@@ -25,6 +26,42 @@ function formatSize(bytes: number): string {
   return (bytes / (1024 * 1024)).toFixed(1) + " MB";
 }
 
+function renderToolPayload(content: string, language?: string): string {
+  return renderHighlightedCodeBlock(content, language, t("common.copy"), {
+    maxHighlightLength: 2000,
+  });
+}
+
+async function copyText(text: string): Promise<void> {
+  try {
+    await navigator.clipboard?.writeText?.(text)
+  } catch {
+    // Ignore clipboard failures; the code block still renders safely.
+  }
+}
+
+async function handleToolDetailClick(event: MouseEvent): Promise<void> {
+  const target = event.target
+  if (!(target instanceof HTMLElement)) return
+
+  const button = target.closest<HTMLElement>('[data-copy-code="true"]')
+  if (!button) return
+
+  event.preventDefault()
+
+  const source = button.closest<HTMLElement>('[data-copy-source]')?.dataset.copySource
+  if (source === 'tool-args' && formattedToolArgs.value) {
+    await copyText(formattedToolArgs.value)
+    return
+  }
+  if (source === 'tool-result' && fullToolResult.value) {
+    await copyText(fullToolResult.value)
+    return
+  }
+
+  await handleCodeBlockCopyClick(event)
+}
+
 const hasAttachments = computed(
   () => (props.message.attachments?.length ?? 0) > 0,
 );
@@ -42,21 +79,36 @@ const formattedToolArgs = computed(() => {
   }
 });
 
-const formattedToolResult = computed(() => {
+const fullToolResult = computed(() => {
   if (!props.message.toolResult) return "";
   try {
-    const parsed = JSON.parse(props.message.toolResult);
-    const str = JSON.stringify(parsed, null, 2);
-    // Truncate very long output
-    if (str.length > 2000)
-      return str.slice(0, 2000) + "\n" + t("chat.truncated");
-    return str;
+    return JSON.stringify(JSON.parse(props.message.toolResult), null, 2);
   } catch {
-    const raw = props.message.toolResult;
-    if (raw.length > 2000)
-      return raw.slice(0, 2000) + "\n" + t("chat.truncated");
-    return raw;
+    return props.message.toolResult;
   }
+});
+
+const formattedToolResult = computed(() => {
+  if (!fullToolResult.value) return "";
+  if (fullToolResult.value.length > 2000)
+    return fullToolResult.value.slice(0, 2000) + "\n" + t("chat.truncated");
+  return fullToolResult.value;
+});
+
+const renderedToolArgs = computed(() => {
+  if (!formattedToolArgs.value) return "";
+  return renderToolPayload(
+    formattedToolArgs.value,
+    props.message.toolArgs ? inferStructuredLanguage(props.message.toolArgs) : undefined,
+  );
+});
+
+const renderedToolResult = computed(() => {
+  if (!formattedToolResult.value) return "";
+  return renderToolPayload(
+    formattedToolResult.value,
+    props.message.toolResult ? inferStructuredLanguage(props.message.toolResult) : undefined,
+  );
 });
 </script>
 
@@ -109,14 +161,14 @@ const formattedToolResult = computed(() => {
           t("chat.error")
         }}</span>
       </div>
-      <div v-if="toolExpanded && hasToolDetails" class="tool-details">
-        <div v-if="formattedToolArgs" class="tool-detail-section">
+      <div v-if="toolExpanded && hasToolDetails" class="tool-details" @click="handleToolDetailClick">
+        <div v-if="formattedToolArgs" class="tool-detail-section" data-copy-source="tool-args">
           <div class="tool-detail-label">{{ t("chat.arguments") }}</div>
-          <pre class="tool-detail-code">{{ formattedToolArgs }}</pre>
+          <div class="tool-detail-code-block" v-html="renderedToolArgs"></div>
         </div>
-        <div v-if="formattedToolResult" class="tool-detail-section">
+        <div v-if="formattedToolResult" class="tool-detail-section" data-copy-source="tool-result">
           <div class="tool-detail-label">{{ t("chat.result") }}</div>
-          <pre class="tool-detail-code">{{ formattedToolResult }}</pre>
+          <div class="tool-detail-code-block" v-html="renderedToolResult"></div>
         </div>
       </div>
     </template>
@@ -400,20 +452,22 @@ const formattedToolResult = computed(() => {
   margin-bottom: 2px;
 }
 
-.tool-detail-code {
-  font-family: $font-code;
-  font-size: 11px;
-  line-height: 1.5;
-  color: $text-secondary;
-  background: $code-bg;
-  border-radius: $radius-sm;
-  padding: 6px 8px;
-  margin: 0;
-  overflow-x: auto;
-  max-height: 300px;
-  overflow-y: auto;
-  white-space: pre-wrap;
-  word-break: break-all;
+.tool-detail-code-block {
+  :deep(.hljs-code-block) {
+    margin: 0;
+  }
+
+  :deep(.code-header) {
+    background: rgba(0, 0, 0, 0.02);
+  }
+
+  :deep(code.hljs) {
+    font-size: 11px;
+    max-height: 300px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
 }
 
 @keyframes spin {

--- a/packages/client/src/components/hermes/chat/highlight.ts
+++ b/packages/client/src/components/hermes/chat/highlight.ts
@@ -1,0 +1,102 @@
+import hljs from 'highlight.js'
+
+const LANGUAGE_ALIASES: Record<string, string> = {
+  shellscript: 'bash',
+  sh: 'bash',
+  zsh: 'bash',
+  yml: 'yaml',
+  vue: 'xml',
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
+
+function sanitizeLanguageClass(value: string): string {
+  return value.replace(/[^a-z0-9_-]/gi, '-') || 'plain'
+}
+
+export function normalizeHighlightLanguage(lang?: string): string {
+  const normalized = lang?.trim().toLowerCase() || ''
+  return LANGUAGE_ALIASES[normalized] || normalized
+}
+
+export function inferStructuredLanguage(content: string): string | undefined {
+  try {
+    JSON.parse(content)
+    return 'json'
+  } catch {
+    return undefined
+  }
+}
+
+type RenderHighlightedCodeBlockOptions = {
+  maxHighlightLength?: number
+}
+
+export function renderHighlightedCodeBlock(
+  content: string,
+  lang: string | undefined,
+  copyLabel: string,
+  options: RenderHighlightedCodeBlockOptions = {},
+): string {
+  const requestedLanguage = lang?.trim().toLowerCase() || ''
+  const normalizedLanguage = normalizeHighlightLanguage(requestedLanguage)
+  const highlightLimit = options.maxHighlightLength ?? Number.POSITIVE_INFINITY
+
+  let highlighted = ''
+  let codeClassLanguage = normalizedLanguage || requestedLanguage || 'plain'
+  let labelLanguage = requestedLanguage
+
+  try {
+    if (normalizedLanguage && hljs.getLanguage(normalizedLanguage) && content.length <= highlightLimit) {
+      highlighted = hljs.highlight(content, {
+        language: normalizedLanguage,
+        ignoreIllegals: true,
+      }).value
+      codeClassLanguage = normalizedLanguage
+    } else {
+      highlighted = escapeHtml(content)
+      if (!labelLanguage) {
+        labelLanguage = 'text'
+      }
+    }
+  } catch {
+    highlighted = escapeHtml(content)
+    if (!labelLanguage) {
+      labelLanguage = 'text'
+    }
+  }
+
+  const languageLabelHtml = labelLanguage
+    ? `<span class="code-lang">${escapeHtml(labelLanguage)}</span>`
+    : ''
+
+  return `<pre class="hljs-code-block"><div class="code-header">${languageLabelHtml}<button type="button" class="copy-btn" data-copy-code="true">${escapeHtml(copyLabel)}</button></div><code class="hljs language-${sanitizeLanguageClass(codeClassLanguage)}">${highlighted}</code></pre>`
+}
+
+export async function handleCodeBlockCopyClick(event: MouseEvent): Promise<void> {
+  const target = event.target
+  if (!(target instanceof HTMLElement)) return
+
+  const button = target.closest<HTMLElement>('[data-copy-code="true"]')
+  if (!button) return
+
+  event.preventDefault()
+
+  const block = button.closest('.hljs-code-block')
+  const code = block?.querySelector('code')
+  const text = code?.textContent ?? ''
+  if (!text) return
+
+  try {
+    await navigator.clipboard?.writeText?.(text)
+  } catch {
+    // Ignore clipboard failures; the code block still renders safely.
+  }
+}

--- a/packages/client/src/components/hermes/chat/highlight.ts
+++ b/packages/client/src/components/hermes/chat/highlight.ts
@@ -80,6 +80,14 @@ export function renderHighlightedCodeBlock(
   return `<pre class="hljs-code-block"><div class="code-header">${languageLabelHtml}<button type="button" class="copy-btn" data-copy-code="true">${escapeHtml(copyLabel)}</button></div><code class="hljs language-${sanitizeLanguageClass(codeClassLanguage)}">${highlighted}</code></pre>`
 }
 
+export async function copyTextToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard?.writeText?.(text)
+  } catch {
+    // Ignore clipboard failures; the code block still renders safely.
+  }
+}
+
 export async function handleCodeBlockCopyClick(event: MouseEvent): Promise<void> {
   const target = event.target
   if (!(target instanceof HTMLElement)) return
@@ -94,9 +102,5 @@ export async function handleCodeBlockCopyClick(event: MouseEvent): Promise<void>
   const text = code?.textContent ?? ''
   if (!text) return
 
-  try {
-    await navigator.clipboard?.writeText?.(text)
-  } catch {
-    // Ignore clipboard failures; the code block still renders safely.
-  }
+  await copyTextToClipboard(text)
 }

--- a/packages/client/src/styles/code-block.scss
+++ b/packages/client/src/styles/code-block.scss
@@ -53,114 +53,118 @@
 }
 
 // highlight.js theme override — higher-contrast, still calm
-.hljs {
-  color: #1f2937;
-  background: none;
-}
+.hljs-code-block {
+  .hljs {
+    color: #1f2937;
+    background: none;
+  }
 
-.hljs-keyword,
-.hljs-selector-tag,
-.hljs-meta .hljs-keyword {
-  color: #7c3aed;
-  font-weight: 600;
-}
+  .hljs-keyword,
+  .hljs-selector-tag,
+  .hljs-meta .hljs-keyword {
+    color: #7c3aed;
+    font-weight: 600;
+  }
 
-.hljs-string,
-.hljs-attr,
-.hljs-regexp,
-.hljs-template-variable {
-  color: #0f766e;
-}
+  .hljs-string,
+  .hljs-attr,
+  .hljs-regexp,
+  .hljs-template-variable {
+    color: #0f766e;
+  }
 
-.hljs-number,
-.hljs-literal,
-.hljs-symbol,
-.hljs-bullet {
-  color: #b45309;
-}
+  .hljs-number,
+  .hljs-literal,
+  .hljs-symbol,
+  .hljs-bullet {
+    color: #b45309;
+  }
 
-.hljs-comment,
-.hljs-quote {
-  color: #6b7280;
-  font-style: italic;
-}
+  .hljs-comment,
+  .hljs-quote {
+    color: #6b7280;
+    font-style: italic;
+  }
 
-.hljs-built_in,
-.hljs-title.class_,
-.hljs-title.function_ {
-  color: #2563eb;
-}
+  .hljs-built_in,
+  .hljs-title.class_,
+  .hljs-title.function_ {
+    color: #2563eb;
+  }
 
-.hljs-type,
-.hljs-variable,
-.hljs-property,
-.hljs-params {
-  color: #b91c1c;
-}
+  .hljs-type,
+  .hljs-variable,
+  .hljs-property,
+  .hljs-params {
+    color: #b91c1c;
+  }
 
-.hljs-tag,
-.hljs-name,
-.hljs-section,
-.hljs-title {
-  color: #1f2937;
-}
+  .hljs-tag,
+  .hljs-name,
+  .hljs-section,
+  .hljs-title {
+    color: #1f2937;
+  }
 
-.hljs-meta {
-  color: #6b7280;
+  .hljs-meta {
+    color: #6b7280;
+  }
 }
 
 // Dark mode highlight.js — clearer separation without neon
-.dark .hljs {
-  color: #e5e7eb;
-}
+.dark .hljs-code-block {
+  .hljs {
+    color: #e5e7eb;
+  }
 
-.dark .hljs-keyword,
-.dark .hljs-selector-tag,
-.dark .hljs-meta .hljs-keyword {
-  color: #c084fc;
-  font-weight: 600;
-}
+  .hljs-keyword,
+  .hljs-selector-tag,
+  .hljs-meta .hljs-keyword {
+    color: #c084fc;
+    font-weight: 600;
+  }
 
-.dark .hljs-string,
-.dark .hljs-attr,
-.dark .hljs-regexp,
-.dark .hljs-template-variable {
-  color: #5eead4;
-}
+  .hljs-string,
+  .hljs-attr,
+  .hljs-regexp,
+  .hljs-template-variable {
+    color: #5eead4;
+  }
 
-.dark .hljs-number,
-.dark .hljs-literal,
-.dark .hljs-symbol,
-.dark .hljs-bullet {
-  color: #fbbf24;
-}
+  .hljs-number,
+  .hljs-literal,
+  .hljs-symbol,
+  .hljs-bullet {
+    color: #fbbf24;
+  }
 
-.dark .hljs-comment,
-.dark .hljs-quote {
-  color: #94a3b8;
-  font-style: italic;
-}
+  .hljs-comment,
+  .hljs-quote {
+    color: #94a3b8;
+    font-style: italic;
+  }
 
-.dark .hljs-built_in,
-.dark .hljs-title.class_,
-.dark .hljs-title.function_ {
-  color: #93c5fd;
-}
+  .hljs-built_in,
+  .hljs-title.class_,
+  .hljs-title.function_ {
+    color: #93c5fd;
+  }
 
-.dark .hljs-type,
-.dark .hljs-variable,
-.dark .hljs-property,
-.dark .hljs-params {
-  color: #fca5a5;
-}
+  .hljs-type,
+  .hljs-variable,
+  .hljs-property,
+  .hljs-params {
+    color: #fca5a5;
+  }
 
-.dark .hljs-tag,
-.dark .hljs-name,
-.dark .hljs-section,
-.dark .hljs-title {
-  color: #f3f4f6;
-}
+  .hljs-tag,
+  .hljs-name,
+  .hljs-section,
+  .hljs-title {
+    color: #f3f4f6;
+  }
 
-.dark .hljs-meta {
-  color: #94a3b8;
+  .hljs-meta {
+    color: #94a3b8;
+  }
 }

--- a/packages/client/src/styles/code-block.scss
+++ b/packages/client/src/styles/code-block.scss
@@ -1,0 +1,166 @@
+@use 'variables' as *;
+
+// Shared code-block styles used by markdown rendering and tool payload details.
+// Keep these global so v-html output in both MarkdownRenderer.vue and MessageItem.vue
+// stays styled even though the HTML is not compiled as Vue template content.
+
+.hljs-code-block {
+  margin: 8px 0;
+  border-radius: $radius-sm;
+  overflow: hidden;
+  background: $code-bg;
+  border: 1px solid $border-color;
+
+  .code-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 6px 12px;
+    background: rgba(0, 0, 0, 0.03);
+    border-bottom: 1px solid $border-color;
+
+    .code-lang {
+      font-size: 11px;
+      color: $text-muted;
+      text-transform: uppercase;
+    }
+
+    .copy-btn {
+      font-size: 11px;
+      color: $text-muted;
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 2px 6px;
+      border-radius: 3px;
+      transition: all $transition-fast;
+
+      &:hover {
+        color: $text-primary;
+        background: rgba(0, 0, 0, 0.05);
+      }
+    }
+  }
+
+  code.hljs {
+    display: block;
+    padding: 12px;
+    font-family: $font-code;
+    font-size: 13px;
+    line-height: 1.5;
+    overflow-x: auto;
+  }
+}
+
+// highlight.js theme override — higher-contrast, still calm
+.hljs {
+  color: #1f2937;
+  background: none;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-meta .hljs-keyword {
+  color: #7c3aed;
+  font-weight: 600;
+}
+
+.hljs-string,
+.hljs-attr,
+.hljs-regexp,
+.hljs-template-variable {
+  color: #0f766e;
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-symbol,
+.hljs-bullet {
+  color: #b45309;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #6b7280;
+  font-style: italic;
+}
+
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-title.function_ {
+  color: #2563eb;
+}
+
+.hljs-type,
+.hljs-variable,
+.hljs-property,
+.hljs-params {
+  color: #b91c1c;
+}
+
+.hljs-tag,
+.hljs-name,
+.hljs-section,
+.hljs-title {
+  color: #1f2937;
+}
+
+.hljs-meta {
+  color: #6b7280;
+}
+
+// Dark mode highlight.js — clearer separation without neon
+.dark .hljs {
+  color: #e5e7eb;
+}
+
+.dark .hljs-keyword,
+.dark .hljs-selector-tag,
+.dark .hljs-meta .hljs-keyword {
+  color: #c084fc;
+  font-weight: 600;
+}
+
+.dark .hljs-string,
+.dark .hljs-attr,
+.dark .hljs-regexp,
+.dark .hljs-template-variable {
+  color: #5eead4;
+}
+
+.dark .hljs-number,
+.dark .hljs-literal,
+.dark .hljs-symbol,
+.dark .hljs-bullet {
+  color: #fbbf24;
+}
+
+.dark .hljs-comment,
+.dark .hljs-quote {
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.dark .hljs-built_in,
+.dark .hljs-title.class_,
+.dark .hljs-title.function_ {
+  color: #93c5fd;
+}
+
+.dark .hljs-type,
+.dark .hljs-variable,
+.dark .hljs-property,
+.dark .hljs-params {
+  color: #fca5a5;
+}
+
+.dark .hljs-tag,
+.dark .hljs-name,
+.dark .hljs-section,
+.dark .hljs-title {
+  color: #f3f4f6;
+}
+
+.dark .hljs-meta {
+  color: #94a3b8;
+}

--- a/packages/client/src/styles/global.scss
+++ b/packages/client/src/styles/global.scss
@@ -1,4 +1,5 @@
 @use 'variables' as *;
+@use 'code-block';
 
 *,
 *::before,

--- a/tests/client/highlight-helper.test.ts
+++ b/tests/client/highlight-helper.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const highlightJsMock = vi.hoisted(() => ({
+  getLanguage: vi.fn((lang?: string) => ['shell', 'xml', 'yaml', 'bash', 'json'].includes(lang || '')),
+  highlight: vi.fn((content: string, { language }: { language: string }) => ({
+    value: `<span class="mock-${language}">${content}</span>`,
+  })),
+}))
+
+vi.mock('highlight.js', () => ({
+  default: highlightJsMock,
+}))
+
+import { renderHighlightedCodeBlock } from '@/components/hermes/chat/highlight'
+
+describe('highlight helper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    highlightJsMock.getLanguage.mockImplementation((lang?: string) => ['shell', 'xml', 'yaml', 'bash', 'json'].includes(lang || ''))
+    highlightJsMock.highlight.mockImplementation((content: string, { language }: { language: string }) => ({
+      value: `<span class="mock-${language}">${content}</span>`,
+    }))
+  })
+
+  it('uses a delegated copy attribute instead of inline javascript', () => {
+    const html = renderHighlightedCodeBlock('x', 'json', 'Copy')
+
+    expect(html).toContain('data-copy-code="true"')
+    expect(html).not.toContain('onclick=')
+  })
+
+  it('preserves shell-session highlighting instead of remapping shell fences to bash', () => {
+    const html = renderHighlightedCodeBlock('$ ls\nfoo.txt\n', 'shell', 'Copy')
+
+    expect(highlightJsMock.highlight).toHaveBeenCalledWith('$ ls\nfoo.txt\n', {
+      language: 'shell',
+      ignoreIllegals: true,
+    })
+    expect(html).toContain('class="code-lang">shell</span>')
+  })
+
+  it('skips highlighting for large known-language blocks when a render limit is set', () => {
+    const html = renderHighlightedCodeBlock('x'.repeat(5000), 'vue', 'Copy', {
+      maxHighlightLength: 2000,
+    })
+
+    expect(highlightJsMock.highlight).not.toHaveBeenCalled()
+    expect(html).toContain('class="code-lang">vue</span>')
+  })
+
+  it('falls back to escaped plaintext for unsupported fence labels', () => {
+    const html = renderHighlightedCodeBlock('<tag>', 'unknown', 'Copy')
+
+    expect(highlightJsMock.highlight).not.toHaveBeenCalled()
+    expect(html).toContain('&lt;tag&gt;')
+    expect(html).toContain('class="code-lang">unknown</span>')
+  })
+
+  it('falls back to escaped plaintext when direct highlighting throws', () => {
+    highlightJsMock.highlight.mockImplementationOnce(() => {
+      throw new Error('boom')
+    })
+
+    const html = renderHighlightedCodeBlock('<tag>', 'vue', 'Copy')
+
+    expect(html).toContain('&lt;tag&gt;')
+    expect(html).toContain('class="code-lang">vue</span>')
+  })
+})

--- a/tests/client/highlight-helper.test.ts
+++ b/tests/client/highlight-helper.test.ts
@@ -11,7 +11,7 @@ vi.mock('highlight.js', () => ({
   default: highlightJsMock,
 }))
 
-import { renderHighlightedCodeBlock } from '@/components/hermes/chat/highlight'
+import { normalizeHighlightLanguage, renderHighlightedCodeBlock } from '@/components/hermes/chat/highlight'
 
 describe('highlight helper', () => {
   beforeEach(() => {
@@ -20,6 +20,17 @@ describe('highlight helper', () => {
     highlightJsMock.highlight.mockImplementation((content: string, { language }: { language: string }) => ({
       value: `<span class="mock-${language}">${content}</span>`,
     }))
+  })
+
+  it.each([
+    ['vue', 'xml'],
+    ['yml', 'yaml'],
+    ['sh', 'bash'],
+    ['zsh', 'bash'],
+    ['shellscript', 'bash'],
+    ['shell', 'shell'],
+  ])('normalizes %s to %s', (input, expected) => {
+    expect(normalizeHighlightLanguage(input)).toBe(expected)
   })
 
   it('uses a delegated copy attribute instead of inline javascript', () => {

--- a/tests/client/highlight-safety.test.ts
+++ b/tests/client/highlight-safety.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderHighlightedCodeBlock } from '@/components/hermes/chat/highlight'
+
+describe('highlight safety', () => {
+  it('escapes large unknown code content', () => {
+    const html = renderHighlightedCodeBlock('<img src=x onerror=alert(1)>'.repeat(100), 'unknown', 'Copy')
+
+    expect(html).toContain('&lt;img')
+    expect(html).not.toContain('<img')
+  })
+
+  it('escapes the language label', () => {
+    const html = renderHighlightedCodeBlock('x'.repeat(5000), '<script>alert(1)</script>', 'Copy')
+
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(html).not.toContain('<script>')
+  })
+
+  it('sanitizes the language class', () => {
+    const html = renderHighlightedCodeBlock('x'.repeat(5000), 'foo bar"><img', 'Copy')
+
+    expect(html).toContain('language-foo-bar---img')
+  })
+
+  it('escapes the copy label', () => {
+    const html = renderHighlightedCodeBlock('x', 'json', 'Copy <now>')
+
+    expect(html).toContain('Copy &lt;now&gt;')
+    expect(html).not.toContain('Copy <now>')
+  })
+})

--- a/tests/client/highlight-safety.test.ts
+++ b/tests/client/highlight-safety.test.ts
@@ -10,6 +10,13 @@ describe('highlight safety', () => {
     expect(html).not.toContain('<img')
   })
 
+  it('does not emit executable HTML for known-language code', () => {
+    const html = renderHighlightedCodeBlock('<script>alert(1)</script>', 'xml', 'Copy')
+
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;')
+  })
+
   it('escapes the language label', () => {
     const html = renderHighlightedCodeBlock('x'.repeat(5000), '<script>alert(1)</script>', 'Copy')
 

--- a/tests/client/markdown-rendering.test.ts
+++ b/tests/client/markdown-rendering.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+import MarkdownRenderer from '@/components/hermes/chat/MarkdownRenderer.vue'
+
+describe('MarkdownRenderer', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+  })
+
+  it('highlights vue fenced blocks instead of rendering them as plain text', () => {
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: '```vue\n<template><div>Hello</div></template>\n```',
+      },
+    })
+
+    expect(wrapper.find('.code-lang').text()).toBe('vue')
+    expect(wrapper.find('code.hljs').html()).toContain('hljs-tag')
+  })
+
+  it('keeps shell-session fences on the shell grammar', () => {
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: '```shell\n$ ls\nfoo.txt\n```',
+      },
+    })
+
+    expect(wrapper.find('.code-lang').text()).toBe('shell')
+    expect(wrapper.find('code.hljs').html()).toContain('hljs-meta')
+  })
+
+  it('still highlights long supported code fences', () => {
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: `\`\`\`json\n${JSON.stringify({ content: 'x'.repeat(2500), ok: true })}\n\`\`\``,
+      },
+    })
+
+    expect(wrapper.find('.code-lang').text()).toBe('json')
+    expect(wrapper.find('code.hljs').html()).toMatch(/hljs-(attr|string|punctuation)/)
+  })
+
+  it('falls back to plain escaped text when a fence language is unsupported', () => {
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: '```foobar\n{"answer":42,"ok":true}\n```',
+      },
+    })
+
+    expect(wrapper.find('.code-lang').text()).toBe('foobar')
+    expect(wrapper.find('code.hljs').findAll('span')).toHaveLength(0)
+    expect(wrapper.find('code.hljs').text()).toContain('{"answer":42,"ok":true}')
+  })
+
+  it('keeps unlabeled code fences as plain text instead of guessing a grammar', () => {
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: '```\nINFO Starting server\nConnected to 127.0.0.1\nDone\n```',
+      },
+    })
+
+    expect(wrapper.find('.code-lang').text()).toBe('text')
+    expect(wrapper.find('code.hljs').findAll('span')).toHaveLength(0)
+    expect(wrapper.find('code.hljs').text()).toContain('INFO Starting server')
+  })
+
+  it('copies code through the delegated click handler', async () => {
+    const writeText = vi.mocked(navigator.clipboard.writeText)
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: '```ts\nconst answer = 42\n```',
+      },
+    })
+
+    const expected = wrapper.find('code.hljs').element.textContent ?? ''
+    await wrapper.find('[data-copy-code="true"]').trigger('click')
+
+    expect(writeText).toHaveBeenCalledWith(expected)
+  })
+})

--- a/tests/client/message-item-highlight.test.ts
+++ b/tests/client/message-item-highlight.test.ts
@@ -69,7 +69,7 @@ describe('MessageItem tool details', () => {
     expect(writeText).toHaveBeenCalledWith(expected)
   })
 
-  it('keeps full large tool arguments labeled as json and copyable', async () => {
+  it('truncates large tool arguments for display but copies the full formatted payload', async () => {
     const writeText = vi.mocked(navigator.clipboard.writeText)
     const message = {
       content: 'x'.repeat(4000),
@@ -92,8 +92,10 @@ describe('MessageItem tool details', () => {
     await wrapper.find('.tool-line').trigger('click')
 
     const expected = JSON.stringify(message, null, 2)
+    const code = wrapper.find('.tool-details code.hljs')
     expect(wrapper.find('.tool-details .code-lang').text()).toBe('json')
-    expect(wrapper.html()).not.toContain('chat.truncated')
+    expect(wrapper.html()).toContain('chat.truncated')
+    expect(code.findAll('span')).toHaveLength(0)
 
     await wrapper.find('.tool-details [data-copy-code="true"]').trigger('click')
     expect(writeText).toHaveBeenCalledWith(expected)
@@ -123,6 +125,7 @@ describe('MessageItem tool details', () => {
 
     expect(wrapper.find('.tool-details .code-lang').text()).toBe('json')
     expect(wrapper.html()).toContain('chat.truncated')
+    expect(wrapper.find('.tool-details code.hljs').findAll('span')).toHaveLength(0)
 
     await wrapper.find('.tool-details [data-copy-code="true"]').trigger('click')
     expect(writeText).toHaveBeenCalledWith(JSON.stringify(fullResult, null, 2))
@@ -149,6 +152,7 @@ describe('MessageItem tool details', () => {
 
     expect(wrapper.find('.tool-details .code-lang').text()).toBe('text')
     expect(wrapper.html()).toContain('chat.truncated')
+    expect(wrapper.find('.tool-details code.hljs').findAll('span')).toHaveLength(0)
 
     await wrapper.find('.tool-details [data-copy-code="true"]').trigger('click')
     expect(writeText).toHaveBeenCalledWith(fullResult)

--- a/tests/client/message-item-highlight.test.ts
+++ b/tests/client/message-item-highlight.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+import MessageItem from '@/components/hermes/chat/MessageItem.vue'
+import type { Message } from '@/stores/hermes/chat'
+
+describe('MessageItem tool details', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+  })
+
+  it('renders highlighted code blocks for tool arguments and tool results', async () => {
+    const wrapper = mount(MessageItem, {
+      props: {
+        message: {
+          id: 'tool-1',
+          role: 'tool',
+          content: '',
+          timestamp: Date.now(),
+          toolName: 'web_search',
+          toolArgs: '{"query":"syntax highlighting"}',
+          toolResult: '{"results":[{"title":"Done"}]}',
+          toolStatus: 'done',
+        } satisfies Message,
+      },
+    })
+
+    await wrapper.find('.tool-line').trigger('click')
+
+    const blocks = wrapper.findAll('.tool-details .hljs-code-block')
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0].find('.code-lang').text()).toBe('json')
+    expect(blocks[1].find('.code-lang').text()).toBe('json')
+  })
+
+  it('copies tool detail code through the delegated click handler', async () => {
+    const writeText = vi.mocked(navigator.clipboard.writeText)
+    const wrapper = mount(MessageItem, {
+      props: {
+        message: {
+          id: 'tool-copy',
+          role: 'tool',
+          content: '',
+          timestamp: Date.now(),
+          toolName: 'web_search',
+          toolArgs: '{"query":"syntax highlighting"}',
+          toolStatus: 'done',
+        } satisfies Message,
+      },
+    })
+
+    await wrapper.find('.tool-line').trigger('click')
+
+    const expected = wrapper.find('.tool-details code.hljs').text()
+    await wrapper.find('.tool-details [data-copy-code="true"]').trigger('click')
+
+    expect(writeText).toHaveBeenCalledWith(expected)
+  })
+
+  it('keeps full large tool arguments labeled as json and copyable', async () => {
+    const writeText = vi.mocked(navigator.clipboard.writeText)
+    const message = {
+      content: 'x'.repeat(4000),
+      ok: true,
+    }
+    const wrapper = mount(MessageItem, {
+      props: {
+        message: {
+          id: 'tool-args-large',
+          role: 'tool',
+          content: '',
+          timestamp: Date.now(),
+          toolName: 'write_file',
+          toolArgs: JSON.stringify(message),
+          toolStatus: 'done',
+        } satisfies Message,
+      },
+    })
+
+    await wrapper.find('.tool-line').trigger('click')
+
+    const expected = JSON.stringify(message, null, 2)
+    expect(wrapper.find('.tool-details .code-lang').text()).toBe('json')
+    expect(wrapper.html()).not.toContain('chat.truncated')
+
+    await wrapper.find('.tool-details [data-copy-code="true"]').trigger('click')
+    expect(writeText).toHaveBeenCalledWith(expected)
+  })
+
+  it('copies the full large JSON tool result even when the display is truncated', async () => {
+    const writeText = vi.mocked(navigator.clipboard.writeText)
+    const fullResult = {
+      content: 'x'.repeat(4000),
+      ok: true,
+    }
+    const wrapper = mount(MessageItem, {
+      props: {
+        message: {
+          id: 'tool-2',
+          role: 'tool',
+          content: '',
+          timestamp: Date.now(),
+          toolName: 'read_file',
+          toolResult: JSON.stringify(fullResult),
+          toolStatus: 'done',
+        } satisfies Message,
+      },
+    })
+
+    await wrapper.find('.tool-line').trigger('click')
+
+    expect(wrapper.find('.tool-details .code-lang').text()).toBe('json')
+    expect(wrapper.html()).toContain('chat.truncated')
+
+    await wrapper.find('.tool-details [data-copy-code="true"]').trigger('click')
+    expect(writeText).toHaveBeenCalledWith(JSON.stringify(fullResult, null, 2))
+  })
+
+  it('copies the full large raw tool result even when the display is truncated', async () => {
+    const writeText = vi.mocked(navigator.clipboard.writeText)
+    const fullResult = 'line\n'.repeat(1200)
+    const wrapper = mount(MessageItem, {
+      props: {
+        message: {
+          id: 'tool-raw',
+          role: 'tool',
+          content: '',
+          timestamp: Date.now(),
+          toolName: 'read_file',
+          toolResult: fullResult,
+          toolStatus: 'done',
+        } satisfies Message,
+      },
+    })
+
+    await wrapper.find('.tool-line').trigger('click')
+
+    expect(wrapper.find('.tool-details .code-lang').text()).toBe('text')
+    expect(wrapper.html()).toContain('chat.truncated')
+
+    await wrapper.find('.tool-details [data-copy-code="true"]').trigger('click')
+    expect(writeText).toHaveBeenCalledWith(fullResult)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, 'packages/client/src'),
+      '/logo.png': resolve(__dirname, 'packages/client/src/assets/logo.png'),
     },
   },
   test: {


### PR DESCRIPTION
Title: feat(chat): polish syntax highlighting and tool payload rendering

## Summary
- extract shared code-block rendering/copy logic into a helper
- render expanded tool args/results as code blocks too
- preserve supported-fence highlighting, including long supported blocks
- normalize `vue` fences and preserve shell-session handling for `shell` fences
- keep unsupported/unlabeled fences as escaped plain text instead of guessing a grammar
- replace inline copy handlers with delegated handling
- move shared code-block styles into a global stylesheet and improve contrast in dark mode
- render large tool payloads as truncated escaped previews without Highlight.js work, while copy still returns the full formatted content
- alias `/logo.png` in Vitest config so chat components can mount in client tests

## Why
The Web UI already supports syntax highlighting, but a few common cases still felt rough:
- `vue` fences were not recognized directly
- tool payloads were still plain `<pre>` blocks
- copy behavior lived in inline HTML handlers
- dark-mode syntax colors were flatter than they should be

This patch keeps the behavior conservative:
- supported fences highlight
- unsupported/unlabeled fences stay plain text
- `shell` fences keep shell-session semantics
- large tool payloads render as truncated escaped previews without Highlight.js work, while copy still returns the full formatted content

## Validation
- `npx vitest run tests/client/markdown-rendering.test.ts tests/client/message-item-highlight.test.ts tests/client/highlight-helper.test.ts tests/client/highlight-safety.test.ts`
- `npm run build`

## Full-suite note
`npm test` is still red on this repo, but the same failures were present before and after this patch:
- `tests/client/chat-panel.test.ts`
- `tests/client/chat-store.test.ts`
- `tests/server/proxy-handler.test.ts`
