### PR TITLE
fix(docker): correct volume mount path and update Node.js to 23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-yaml \
     make \
     g++ \
-    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_23.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "${PORT:-6060}:${PORT:-6060}"
     volumes:
       - ${HERMES_DATA_DIR:-./hermes_data}:/home/agent/.hermes
-      - ${HERMES_DATA_DIR:-./hermes_data}/hermes-web-ui:/root/.hermes-web-ui
+      - ${HERMES_DATA_DIR:-./hermes_data}/hermes-web-ui:/home/agent/.hermes-web-ui
       - hermes-agent-src:/opt/hermes
     environment:
       - PORT=${PORT:-6060}


### PR DESCRIPTION
## Summary
- Fix webui volume mount: `/root/.hermes-web-ui` → `/home/agent/.hermes-web-ui` — container runs as `agent` user, `homedir()` returns `/home/agent`, so token/log files were written to the wrong path and not persisted to host
- Update Node.js from 22 to 23 in Dockerfile to match project requirements

## Test plan
- [ ] `docker compose up -d` and verify `hermes_data/hermes-web-ui/.token` exists on host
- [ ] Verify server logs directory persists across container restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)