### PR TITLE
fix: use process.cwd() for SPA dist path (port 8648 not serving frontend)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -59,7 +59,7 @@ export async function bootstrap() {
   }
 
   // SPA fallback
-  const distDir = resolve(__dirname, '..', 'client')
+  const distDir = resolve(process.cwd(), 'dist', 'client')
   app.use(serve(distDir))
   app.use(async (ctx) => {
     if (!ctx.path.startsWith('/api') &&


### PR DESCRIPTION
## Bug

Opening port 8648 (the Koa server) returns:
```
ENOENT: no such file or directory, stat 'packages/server/client/index.html'
```

## Root Cause

`packages/server/src/index.ts` uses `resolve(__dirname, '..', 'client')` for the SPA dist directory. When running with `ts-node`, `__dirname` equals the source directory (`packages/server/src/`), so this resolves to `packages/server/client/` — a non-existent path. The actual built frontend lives at `dist/client/` (where vite outputs by default).

## Fix

Replace `__dirname`-relative path with `resolve(process.cwd(), 'dist', 'client')`. This correctly resolves to the project root, which is the working directory when running `npm run dev` (ts-node runs from the project root). After running `vite build`, the SPA is served correctly from port 8648.

## Testing

1. `npm run dev` → frontend available on port 5173
2. `vite build` → frontend built to `dist/client/`
3. Visit port 8648 (Koa server) → SPA served correctly (no 404)

## Files changed

- `packages/server/src/index.ts`: SPA fallback path