### PR TITLE
fix(docker): use tar.gz instead of tar.xz for Node.js binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
     g++ \
     && ARCH=$(dpkg --print-architecture) \
-    && curl -fsSL "https://nodejs.org/dist/v23.11.0/node-v23.11.0-linux-${ARCH}.tar.xz" \
-       | tar -xJ -C /usr/local --strip-components=1 \
+    && curl -fsSL "https://nodejs.org/dist/v23.11.0/node-v23.11.0-linux-${ARCH}.tar.gz" \
+       | tar -xz -C /usr/local --strip-components=1 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Use `.tar.gz` format instead of `.tar.xz` for Node.js binary download
- `xz-utils` is not installed in the base image, causing build failure: "File format not recognized"

🤖 Generated with [Claude Code](https://claude.com/claude-code)