### PR TITLE
fix(docker): map amd64 to x64 for Node.js download URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN ARCH=$(dpkg --print-architecture) \
-    && echo "Downloading Node.js v23.11.0 for ${ARCH}" \
-    && curl -fsSL "https://nodejs.org/dist/v23.11.0/node-v23.11.0-linux-${ARCH}.tar.gz" \
+    && NODE_ARCH=${ARCH/amd64/x64} \
+    && echo "Downloading Node.js v23.11.0 for ${NODE_ARCH}" \
+    && curl -fsSL "https://nodejs.org/dist/v23.11.0/node-v23.11.0-linux-${NODE_ARCH}.tar.gz" \
        -o /tmp/node.tar.gz \
     && tar -xzf /tmp/node.tar.gz -C /usr/local --strip-components=1 \
     && rm -f /tmp/node.tar.gz \


### PR DESCRIPTION
## Summary
- `dpkg --print-architecture` returns `amd64`, but nodejs.org tarballs use `x64`
- Add shell substitution `${ARCH/amd64/x64}` to map correctly
- Fixes AMD64 build failing with curl 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)