### PR TITLE
fix(docker): use if/else to map amd64 to x64 for Node.js download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN ARCH=$(dpkg --print-architecture) \
-    && NODE_ARCH=${ARCH/amd64/x64} \
+    && if [ "$ARCH" = "amd64" ]; then NODE_ARCH="x64"; else NODE_ARCH="$ARCH"; fi \
     && echo "Downloading Node.js v23.11.0 for ${NODE_ARCH}" \
     && curl -fsSL "https://nodejs.org/dist/v23.11.0/node-v23.11.0-linux-${NODE_ARCH}.tar.gz" \
        -o /tmp/node.tar.gz \


### PR DESCRIPTION
## Summary
- Use explicit `if/else` to map `amd64` → `x64` for nodejs.org tarball filenames
- Previous shell substitution `${ARCH/amd64/x64}` may not work in all shell environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)