### PR TITLE
feat: add public access tunnel via Cloudflare

### DIFF
--- a/bin/hermes-web-ui.mjs
+++ b/bin/hermes-web-ui.mjs
@@ -324,9 +324,10 @@ switch (command) {
   default:
     ensureNativeModules()
     const port = !isNaN(command) ? parseInt(command) : DEFAULT_PORT
+    const token = ensureToken()
     const child = spawn(process.execPath, [serverEntry], {
       stdio: 'inherit',
-      env: { ...process.env, PORT: String(port) },
+      env: { ...process.env, PORT: String(port), AUTH_TOKEN: token },
       windowsHide: true,
     })
     child.on('exit', (code) => process.exit(code ?? 1))

--- a/packages/client/src/api/hermes/tunnel.ts
+++ b/packages/client/src/api/hermes/tunnel.ts
@@ -1,0 +1,28 @@
+import { request } from '@/api/client'
+
+export interface TunnelStatus {
+  running: boolean
+  url: string | null
+  cloudflaredInstalled: boolean
+  error?: string
+}
+
+export interface TunnelToken {
+  token: string
+}
+
+export function getTunnelStatus(): Promise<TunnelStatus> {
+  return request<TunnelStatus>('/api/hermes/tunnel/status')
+}
+
+export function startTunnel(): Promise<{ success: boolean; url?: string; message?: string; error?: string }> {
+  return request('/api/hermes/tunnel/start', { method: 'POST' })
+}
+
+export function stopTunnel(): Promise<{ success: boolean; message?: string }> {
+  return request('/api/hermes/tunnel/stop', { method: 'POST' })
+}
+
+export function getTunnelToken(): Promise<TunnelToken> {
+  return request<TunnelToken>('/api/hermes/tunnel/token')
+}

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -165,6 +165,14 @@ async function handleUpdate() {
             </svg>
             <span>{{ t("sidebar.terminal") }}</span>
           </button>
+          <button class="nav-item" :class="{ active: selectedKey === 'hermes.tunnel' }" @click="handleNav('hermes.tunnel')">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 2L2 7l10 5 10-5-10-5z" />
+              <path d="M2 17l10 5 10-5" />
+              <path d="M2 12l10 5 10-5" />
+            </svg>
+            <span>{{ t("sidebar.tunnel") }}</span>
+          </button>
         </div>
       </div>
 

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -49,6 +49,7 @@ export default {
     usage: 'Nutzung',
     channels: 'Kanale',
     terminal: 'Terminal',
+    tunnel: 'Öffentlicher Zugang',
     settings: 'Einstellungen',
     connected: 'Verbunden',
     disconnected: 'Getrennt',
@@ -58,6 +59,20 @@ export default {
     updateSuccess: 'Aktualisierung abgeschlossen, bitte Server neu starten',
     updateFailed: 'Aktualisierung fehlgeschlagen',
   },
+
+  // Tunnel
+  tunnel: {
+    running: 'Läuft',
+    stopped: 'Gestoppt',
+    start: 'Tunnel starten',
+    stop: 'Tunnel stoppen',
+    copy: 'Kopieren',
+    copyFull: 'Vollständige URL kopieren',
+    notInstalled: 'cloudflared nicht installiert',
+    installHint: 'Installieren Sie zuerst cloudflared, um den Tunnel zu nutzen:',
+    tokenTitle: 'Zugriffstoken',
+  },
+
 
   // Chat
   chat: {

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -52,6 +52,7 @@ export default {
     channels: 'Channels',
     gateways: 'Gateways',
     terminal: 'Terminal',
+    tunnel: 'Public Access',
     groupConversation: 'Conversation',
     groupPlatform: 'Platform',
     groupAgent: 'Agent',
@@ -68,6 +69,19 @@ export default {
     updating: 'Updating...',
     updateSuccess: 'Update complete, please restart the server',
     updateFailed: 'Update failed',
+  },
+
+  // Tunnel
+  tunnel: {
+    running: 'Running',
+    stopped: 'Stopped',
+    start: 'Start Tunnel',
+    stop: 'Stop Tunnel',
+    copy: 'Copy',
+    copyFull: 'Copy Full URL',
+    notInstalled: 'cloudflared not installed',
+    installHint: 'Install cloudflared first to use tunnel:',
+    tokenTitle: 'Access Token',
   },
 
   // Chat

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -49,6 +49,7 @@ export default {
     usage: 'Uso',
     channels: 'Canales',
     terminal: 'Terminal',
+    tunnel: 'Acceso Público',
     settings: 'Configuracion',
     connected: 'Conectado',
     disconnected: 'Desconectado',
@@ -58,6 +59,20 @@ export default {
     updateSuccess: 'Actualizacion completa, por favor reinicia el servidor',
     updateFailed: 'Error al actualizar',
   },
+
+  // Túnel
+  tunnel: {
+    running: 'Ejecutándose',
+    stopped: 'Detenido',
+    start: 'Iniciar Túnel',
+    stop: 'Detener Túnel',
+    copy: 'Copiar',
+    copyFull: 'Copiar URL Completa',
+    notInstalled: 'cloudflared no instalado',
+    installHint: 'Instala cloudflared primero para usar el túnel:',
+    tokenTitle: 'Token de Acceso',
+  },
+
 
   // Chat
   chat: {

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -49,6 +49,7 @@ export default {
     usage: 'Utilisation',
     channels: 'Canaux',
     terminal: 'Terminal',
+    tunnel: 'Accès Public',
     settings: 'Parametres',
     connected: 'Connecte',
     disconnected: 'Deconnecte',
@@ -58,6 +59,20 @@ export default {
     updateSuccess: 'Mise a jour terminee, veuillez redemarrer le serveur',
     updateFailed: 'Echec de la mise a jour',
   },
+
+  // Tunnel
+  tunnel: {
+    running: 'En cours',
+    stopped: 'Arrêté',
+    start: 'Démarrer le Tunnel',
+    stop: 'Arrêter le Tunnel',
+    copy: 'Copier',
+    copyFull: "Copier l'URL complète",
+    notInstalled: 'cloudflared non installé',
+    installHint: "Installez d'abord cloudflared pour utiliser le tunnel :",
+    tokenTitle: "Jeton d'accès",
+  },
+
 
   // Chat
   chat: {

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -49,6 +49,7 @@ export default {
     usage: '使用量',
     channels: 'チャンネル',
     terminal: 'ターミナル',
+    tunnel: '公開アクセス',
     settings: '設定',
     connected: '接続済み',
     disconnected: '未接続',
@@ -58,6 +59,20 @@ export default {
     updateSuccess: '更新が完了しました。サーバーを再起動してください',
     updateFailed: '更新に失敗しました',
   },
+
+  // トンネル
+  tunnel: {
+    running: '実行中',
+    stopped: '停止中',
+    start: 'トンネル開始',
+    stop: 'トンネル停止',
+    copy: 'コピー',
+    copyFull: '完全なURLをコピー',
+    notInstalled: 'cloudflared がインストールされていません',
+    installHint: 'トンネル機能を使用するには cloudflared をインストールしてください：',
+    tokenTitle: 'アクセストークン',
+  },
+
 
   // チャット
   chat: {

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -49,6 +49,7 @@ export default {
     usage: '사용량',
     channels: '채널',
     terminal: '터미널',
+    tunnel: '공개 접근',
     settings: '설정',
     connected: '연결됨',
     disconnected: '연결 끊김',
@@ -58,6 +59,20 @@ export default {
     updateSuccess: '업데이트 완료, 서버를 재시작해 주세요',
     updateFailed: '업데이트 실패',
   },
+
+  // 터널
+  tunnel: {
+    running: '실행 중',
+    stopped: '중지됨',
+    start: '터널 시작',
+    stop: '터널 중지',
+    copy: '복사',
+    copyFull: '전체 URL 복사',
+    notInstalled: 'cloudflared가 설치되지 않음',
+    installHint: '터널 기능을 사용하려면 cloudflared를 설치하세요:',
+    tokenTitle: '액세스 토큰',
+  },
+
 
   // 채팅
   chat: {

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -49,6 +49,7 @@ export default {
     usage: 'Uso',
     channels: 'Canais',
     terminal: 'Terminal',
+    tunnel: 'Acesso Público',
     settings: 'Configuracoes',
     connected: 'Conectado',
     disconnected: 'Desconectado',
@@ -58,6 +59,20 @@ export default {
     updateSuccess: 'Atualizacao concluida, por favor reinicie o servidor',
     updateFailed: 'Falha na atualizacao',
   },
+
+  // Túnel
+  tunnel: {
+    running: 'Executando',
+    stopped: 'Parado',
+    start: 'Iniciar Túnel',
+    stop: 'Parar Túnel',
+    copy: 'Copiar',
+    copyFull: 'Copiar URL Completa',
+    notInstalled: 'cloudflared não instalado',
+    installHint: 'Instale o cloudflared primeiro para usar o túnel:',
+    tokenTitle: 'Token de Acesso',
+  },
+
 
   // Chat
   chat: {

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -52,6 +52,7 @@ export default {
     channels: '频道',
     gateways: '网关',
     terminal: '终端',
+    tunnel: '公网访问',
     groupConversation: '对话',
     groupPlatform: '平台',
     groupAgent: '代理',
@@ -68,6 +69,19 @@ export default {
     updating: '正在更新...',
     updateSuccess: '更新完成，请重启服务',
     updateFailed: '更新失败',
+  },
+
+  // 隧道
+  tunnel: {
+    running: '运行中',
+    stopped: '已停止',
+    start: '启动隧道',
+    stop: '停止隧道',
+    copy: '复制',
+    copyFull: '复制完整链接',
+    notInstalled: 'cloudflared 未安装',
+    installHint: '请先安装 cloudflared 才能使用隧道功能：',
+    tokenTitle: '访问 Token',
   },
 
   // 对话

--- a/packages/client/src/router/index.ts
+++ b/packages/client/src/router/index.ts
@@ -70,6 +70,11 @@ const router = createRouter({
       name: 'hermes.terminal',
       component: () => import('@/views/hermes/TerminalView.vue'),
     },
+    {
+      path: '/hermes/tunnel',
+      name: 'hermes.tunnel',
+      component: () => import('@/views/hermes/TunnelView.vue'),
+    },
   ],
 })
 

--- a/packages/client/src/views/hermes/TunnelView.vue
+++ b/packages/client/src/views/hermes/TunnelView.vue
@@ -1,0 +1,335 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from "vue";
+import {
+  NCard,
+  NButton,
+  NSpace,
+  NAlert,
+  NSpin,
+  useMessage,
+} from "naive-ui";
+import { useI18n } from "vue-i18n";
+import {
+  getTunnelStatus,
+  startTunnel,
+  stopTunnel,
+  getTunnelToken,
+} from "@/api/hermes/tunnel";
+
+const { t } = useI18n();
+const message = useMessage();
+
+const running = ref(false);
+const url = ref<string | null>(null);
+const token = ref("");
+const cloudflaredInstalled = ref(false);
+const installError = ref("");
+const loading = ref(false);
+const polling = ref(false);
+
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+async function fetchStatus() {
+  try {
+    const s = await getTunnelStatus();
+    running.value = s.running;
+    url.value = s.url;
+    cloudflaredInstalled.value = s.cloudflaredInstalled;
+    installError.value = s.error || "";
+  } catch (e: any) {
+    console.error("Tunnel status error:", e);
+  }
+}
+
+async function fetchToken() {
+  try {
+    const r = await getTunnelToken();
+    token.value = r.token;
+  } catch (e: any) {
+    console.error("Tunnel token error:", e);
+  }
+}
+
+function copyText(text: string, label: string) {
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.style.position = "fixed";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  document.execCommand("copy");
+  document.body.removeChild(ta);
+  message.success(`${label} 已复制`);
+}
+
+function copyUrl() {
+  if (url.value) copyText(url.value, "链接");
+}
+
+function copyToken() {
+  if (token.value) copyText(token.value, "Token");
+}
+
+function copyFullUrl() {
+  if (!url.value || !token.value) return;
+  const sep = url.value.includes("?") ? "&" : "?";
+  copyText(`${url.value}${sep}token=${token.value}`, "完整链接");
+}
+
+function startPolling() {
+  if (pollTimer) return;
+  polling.value = true;
+  pollTimer = setInterval(async () => {
+    await fetchStatus();
+    if (running.value && url.value) {
+      stopPolling();
+    }
+  }, 2000);
+  // Timeout after 15s
+  setTimeout(() => stopPolling(), 15000);
+}
+
+function stopPolling() {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+  polling.value = false;
+}
+
+async function handleStart() {
+  loading.value = true;
+  try {
+    const r = await startTunnel();
+    if (r.success && r.url) {
+      url.value = r.url;
+      running.value = true;
+      message.success("隧道已启动");
+    } else if (r.success) {
+      message.info("隧道启动中...");
+      startPolling();
+    } else {
+      message.error(r.error || "启动失败");
+    }
+  } catch (e: any) {
+    message.error(e.message || "启动失败");
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function handleStop() {
+  loading.value = true;
+  try {
+    await stopTunnel();
+    running.value = false;
+    url.value = null;
+    message.success("隧道已停止");
+  } catch (e: any) {
+    message.error(e.message || "停止失败");
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  fetchStatus();
+  fetchToken();
+});
+
+onUnmounted(() => {
+  stopPolling();
+});
+</script>
+
+<template>
+  <div class="tunnel-view">
+    <header class="page-header">
+      <h2 class="header-title">{{ t("sidebar.tunnel") }}</h2>
+    </header>
+
+    <div class="tunnel-content">
+      <!-- Not installed -->
+      <NCard v-if="!cloudflaredInstalled" class="tunnel-card">
+        <NAlert type="error" :title="t('tunnel.notInstalled')">
+          <p>{{ installError || t("tunnel.installHint") }}</p>
+          <p class="install-cmd">
+            curl -L
+            https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
+            -o ~/.local/bin/cloudflared && chmod +x ~/.local/bin/cloudflared
+          </p>
+        </NAlert>
+      </NCard>
+
+      <!-- Main card -->
+      <NCard v-else class="tunnel-card">
+        <NSpin :show="loading || polling">
+          <div class="tunnel-status">
+            <div class="status-badge" :class="{ active: running }">
+              <span class="dot"></span>
+              <span>{{ running ? t("tunnel.running") : t("tunnel.stopped") }}</span>
+            </div>
+          </div>
+
+          <!-- URL display -->
+          <div v-if="url" class="url-section">
+            <div class="url-row">
+              <code class="url-value">{{ url }}</code>
+              <NButton size="small" @click="copyUrl">
+                {{ t("tunnel.copy") }}
+              </NButton>
+            </div>
+            <div class="url-row">
+              <code class="url-value url-full">{{ url }}{{ url.includes('?') ? '&' : '?' }}token={{ token }}</code>
+              <NButton size="small" type="primary" @click="copyFullUrl">
+                {{ t("tunnel.copyFull") }}
+              </NButton>
+            </div>
+          </div>
+
+          <!-- Actions -->
+          <NSpace class="actions">
+            <NButton
+              v-if="!running"
+              type="primary"
+              :loading="loading || polling"
+              @click="handleStart"
+            >
+              {{ t("tunnel.start") }}
+            </NButton>
+            <NButton
+              v-else
+              type="error"
+              :loading="loading"
+              @click="handleStop"
+            >
+              {{ t("tunnel.stop") }}
+            </NButton>
+          </NSpace>
+        </NSpin>
+      </NCard>
+
+      <!-- Token card -->
+      <NCard class="tunnel-card" :title="t('tunnel.tokenTitle')">
+        <div class="url-row">
+          <code class="url-value token-value">{{ token || '...' }}</code>
+          <NButton size="small" @click="copyToken" :disabled="!token">
+            {{ t("tunnel.copy") }}
+          </NButton>
+        </div>
+      </NCard>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use "@/styles/variables" as *;
+
+.tunnel-view {
+  height: calc(100 * var(--vh));
+  display: flex;
+  flex-direction: column;
+}
+
+.tunnel-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 640px;
+}
+
+.tunnel-card {
+  width: 100%;
+}
+
+.tunnel-status {
+  margin-bottom: 16px;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 500;
+  background: rgba(0, 0, 0, 0.06);
+
+  .dark & {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: $error;
+  }
+
+  &.active .dot {
+    background: $success;
+    box-shadow: 0 0 6px rgba(var(--success-rgb), 0.5);
+  }
+}
+
+.url-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.url-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.url-value {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.04);
+  font-size: 12px;
+  word-break: break-all;
+  overflow-wrap: anywhere;
+  line-height: 1.5;
+
+  .dark & {
+    background: rgba(255, 255, 255, 0.06);
+  }
+}
+
+.url-full {
+  font-size: 11px;
+}
+
+.token-value {
+  font-family: monospace;
+}
+
+.actions {
+  margin-top: 8px;
+}
+
+.install-cmd {
+  margin-top: 8px;
+  padding: 8px 12px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 6px;
+  font-family: monospace;
+  font-size: 12px;
+  word-break: break-all;
+  line-height: 1.6;
+
+  .dark & {
+    background: rgba(255, 255, 255, 0.06);
+  }
+}
+</style>

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -5,6 +5,7 @@ import { healthRoutes } from './health'
 import { webhookRoutes } from './webhook'
 import { uploadRoutes } from './upload'
 import { updateRoutes } from './update'
+import { tunnelRoutes } from './tunnel'
 
 // Hermes route modules
 import { sessionRoutes } from './hermes/sessions'
@@ -35,6 +36,7 @@ export function registerRoutes(app: any, requireAuth: (ctx: Context, next: Next)
 
   // --- Protected routes (auth required) ---
   app.use(uploadRoutes.routes())
+  app.use(tunnelRoutes.routes())
   app.use(updateRoutes.routes())           // Must be before proxy (proxy catch-all matches everything)
   app.use(sessionRoutes.routes())
   app.use(profileRoutes.routes())

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -1,0 +1,184 @@
+import Router from '@koa/router'
+import { spawn, execSync } from 'child_process'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+import { config } from '../config'
+
+export const tunnelRoutes = new Router()
+
+let tunnelProcess: ReturnType<typeof spawn> | null = null
+let tunnelUrl: string | null = null
+
+/** Clean up tunnel process (called on server shutdown) */
+export function cleanupTunnel(): void {
+  if (tunnelProcess && !tunnelProcess.killed) {
+    tunnelProcess.kill('SIGTERM')
+    tunnelProcess = null
+    tunnelUrl = null
+    console.log('✓ Tunnel process cleaned up')
+  }
+}
+
+function checkCloudflared(): { available: boolean; error?: string } {
+  try {
+    execSync('which cloudflared', { stdio: 'ignore' })
+    return { available: true }
+  } catch {
+    return {
+      available: false,
+      error:
+        'cloudflared not found. Install it: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/',
+    }
+  }
+}
+
+tunnelRoutes.get('/api/hermes/tunnel/status', async (ctx) => {
+  const check = checkCloudflared()
+  ctx.body = {
+    running: tunnelProcess !== null && !tunnelProcess.killed,
+    url: tunnelUrl,
+    cloudflaredInstalled: check.available,
+    error: check.error,
+  }
+})
+
+tunnelRoutes.post('/api/hermes/tunnel/start', async (ctx) => {
+  if (tunnelProcess && !tunnelProcess.killed) {
+    ctx.body = { success: true, url: tunnelUrl, message: 'Tunnel already running' }
+    return
+  }
+
+  const check = checkCloudflared()
+  if (!check.available) {
+    ctx.status = 400
+    ctx.body = { success: false, error: check.error }
+    return
+  }
+
+  const port = config.port
+  let resolved = false
+
+  return new Promise<void>((resolve) => {
+    tunnelProcess = spawn(
+      'cloudflared',
+      ['tunnel', '--url', `http://localhost:${port}`, '--protocol', 'http2'],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    )
+
+    let stdoutBuffer = ''
+    let stderrBuffer = ''
+    const MAX_BUF = 65536
+
+    const checkUrl = () => {
+      if (resolved) return
+      const fullBuffer = stdoutBuffer + stderrBuffer
+      const match = fullBuffer.match(/https:\/\/[a-zA-Z0-9-]+\.trycloudflare\.com/)
+      if (match && !tunnelUrl) {
+        tunnelUrl = match[0]
+        console.log(`Tunnel ready: ${tunnelUrl}`)
+        ctx.body = { success: true, url: tunnelUrl }
+        resolved = true
+        resolve()
+      }
+    }
+
+    tunnelProcess.stdout?.on('data', (data: Buffer) => {
+      stdoutBuffer += data.toString()
+      if (stdoutBuffer.length > MAX_BUF) stdoutBuffer = stdoutBuffer.slice(-MAX_BUF)
+      checkUrl()
+    })
+
+    tunnelProcess.stderr?.on('data', (data: Buffer) => {
+      stderrBuffer += data.toString()
+      if (stderrBuffer.length > MAX_BUF) stderrBuffer = stderrBuffer.slice(-MAX_BUF)
+      checkUrl()
+    })
+
+    tunnelProcess.on('error', (err: Error) => {
+      console.error('Tunnel error:', err)
+      tunnelProcess = null
+      tunnelUrl = null
+      if (!resolved) {
+        ctx.status = 500
+        ctx.body = { success: false, error: err.message }
+        resolved = true
+        resolve()
+      }
+    })
+
+    tunnelProcess.on('exit', (code: number | null) => {
+      if (code !== 0 && !resolved) {
+        console.log(`Tunnel exited with code ${code}`)
+        ctx.body = { success: false, error: `cloudflared exited with code ${code}` }
+        resolved = true
+        resolve()
+      }
+      tunnelProcess = null
+      if (!tunnelUrl || (resolved && !(ctx.body as any)?.success)) {
+        tunnelUrl = null
+      }
+    })
+
+    setTimeout(() => {
+      if (!resolved) {
+        if (tunnelProcess && !tunnelProcess.killed) {
+          tunnelProcess.kill('SIGTERM')
+          tunnelProcess = null
+        }
+        tunnelUrl = null
+        ctx.status = 504
+        ctx.body = { success: false, error: 'Tunnel timed out — cloudflared did not return a URL within 10s' }
+        resolved = true
+        resolve()
+      }
+    }, 10000)
+  })
+})
+
+tunnelRoutes.post('/api/hermes/tunnel/stop', async (ctx) => {
+  if (tunnelProcess && !tunnelProcess.killed) {
+    const proc = tunnelProcess
+    tunnelProcess = null
+    tunnelUrl = null
+    await new Promise<void>((resolve) => {
+      proc.on('exit', resolve)
+      proc.kill('SIGTERM')
+      setTimeout(() => {
+        if (!proc.killed) {
+          try { proc.kill('SIGKILL') } catch {}
+        }
+        resolve()
+      }, 5000)
+    })
+    ctx.body = { success: true }
+  } else {
+    // Clean up any orphaned cloudflared processes
+    try {
+      const pids = execSync("pgrep -f 'cloudflared tunnel'", { encoding: 'utf-8' }).trim()
+      if (pids) {
+        for (const pid of pids.split('\n')) {
+          try { process.kill(parseInt(pid), 'SIGTERM') } catch {}
+        }
+      }
+    } catch {}
+    tunnelProcess = null
+    tunnelUrl = null
+    ctx.body = { success: true, message: 'No tunnel running' }
+  }
+})
+
+tunnelRoutes.get('/api/hermes/tunnel/token', async (ctx) => {
+  // Prefer env var (consistent with auth.ts)
+  if (process.env.AUTH_TOKEN) {
+    ctx.body = { token: process.env.AUTH_TOKEN }
+    return
+  }
+  // Fallback: read from file
+  try {
+    const tokenPath = join(config.dataDir, '.token')
+    const token = await readFile(tokenPath, 'utf-8')
+    ctx.body = { token: token.trim() }
+  } catch {
+    ctx.body = { token: '' }
+  }
+})

--- a/packages/server/src/services/shutdown.ts
+++ b/packages/server/src/services/shutdown.ts
@@ -1,4 +1,5 @@
 import { logger } from './logger'
+import { cleanupTunnel } from '../routes/tunnel'
 
 export function bindShutdown(server: any): void {
   let isShuttingDown = false
@@ -8,6 +9,8 @@ export function bindShutdown(server: any): void {
     isShuttingDown = true
 
     logger.info('Shutting down (%s)...', signal)
+
+    cleanupTunnel()
 
     try {
       if (server) {


### PR DESCRIPTION
通过 Cloudflare 快速隧道将本地 hermes-web-ui 暴露到公网，无需配置域名/端口转发。

### 改动

**服务端**
- 新增 `routes/tunnel.ts`：start/stop/status/token 四个 API
- 停止时等待进程真正退出才返回（防残留）
- 超时自动清理孤儿 cloudflared 进程
- 关机时自动清理隧道进程

**客户端**
- 新增 `TunnelView.vue`：公网访问页面
- 侧边栏 Tools 分组新增「Public Access」入口
- 支持启动/停止/复制 URL/复制完整链接（含 token）

**CLI**
- 修复 tunnel/default 命令未传递 AUTH_TOKEN 的问题

**i18n**
- 8 个语言全部翻译