### PR TITLE
fix: specify TS_NODE_PROJECT for dev:server

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "start": "vite --host --port 8648",
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
     "dev:client": "vite --host",
-    "dev:server": "nodemon --signal SIGTERM --watch packages/server/src -e ts,tsx --exec node -r ts-node/register packages/server/src/index.ts",
+    "dev:server": "nodemon --signal SIGTERM --watch packages/server/src -e ts,tsx --exec TS_NODE_PROJECT=packages/server/tsconfig.json node -r ts-node/register packages/server/src/index.ts",
     "build": "vue-tsc -b && vite build && tsc --noEmit -p packages/server/tsconfig.json && node scripts/build-server.mjs",
     "preview": "vite preview",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Fix `ts-node` resolving the wrong tsconfig during `npm run dev:server`, which caused TS2802 (`MapIterator` spread not supported) because the root solution-style `tsconfig.json` has no `compilerOptions` and target defaults to ES3
- Add `TS_NODE_PROJECT=packages/server/tsconfig.json` env var to the nodemon exec command

## Test plan
- [x] Run `npm run dev:server` — no TS2802 errors
- [ ] Verify session search (FTS5 / MapIterator spread) works in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)