### PR TITLE
chore: optimize npm keywords for GitHub search discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hermes-web-ui",
   "version": "0.4.3",
-  "description": "Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics & channel configuration (Telegram, Discord, Slack, WhatsApp)",
+  "description": "Self-hosted AI chat dashboard for Hermes Agent — multi-model (Claude, GPT, Gemini, DeepSeek) web UI with Telegram, Discord, Slack, WhatsApp integration",
   "repository": {
     "type": "git",
     "url": "https://github.com/EKKOLearnAI/hermes-web-ui.git"
@@ -13,10 +13,23 @@
   },
   "keywords": [
     "hermes",
+    "hermes-agent",
+    "hermes-web",
+    "agent",
+    "ai",
     "ai-agent",
+    "ai-chat",
+    "ai-dashboard",
+    "chatgpt",
+    "claude",
+    "openai",
+    "gemini",
+    "deepseek",
     "llm",
+    "multi-model",
     "chat-ui",
     "dashboard",
+    "self-hosted",
     "telegram",
     "discord",
     "slack",
@@ -26,8 +39,7 @@
     "weixin",
     "multi-platform",
     "vue3",
-    "typescript",
-    "naive-ui"
+    "typescript"
   ],
   "bin": {
     "hermes-web-ui": "./bin/hermes-web-ui.mjs"


### PR DESCRIPTION
## Summary
- Update `description` to include high-traffic model names (Claude, GPT, Gemini, DeepSeek)
- Expand `keywords` from 16 to 28, adding: `hermes-agent`, `hermes-web`, `agent`, `ai`, `ai-chat`, `ai-dashboard`, `chatgpt`, `claude`, `openai`, `gemini`, `deepseek`, `multi-model`, `self-hosted`
- Remove low-search-value keyword `naive-ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)