### PR TITLE
fix: handle special-character session search

### DIFF
--- a/packages/server/src/db/hermes/sessions-db.ts
+++ b/packages/server/src/db/hermes/sessions-db.ts
@@ -159,6 +159,95 @@ function containsCjk(text: string): boolean {
   return false
 }
 
+function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`)
+}
+
+function buildLikePattern(value: string): string {
+  return `%${escapeLikePattern(value)}%`
+}
+
+function normalizeTitleLikeQuery(query: string): string {
+  const tokens = query.match(/"[^"]*"\*?|\S+/g)
+  if (!tokens) return query
+
+  const normalizedTokens = tokens
+    .map((token) => {
+      let value = token.endsWith('*') ? token.slice(0, -1) : token
+      if (value.startsWith('"') && value.endsWith('"')) {
+        value = value.slice(1, -1)
+      }
+      return value
+    })
+    .filter(Boolean)
+
+  return normalizedTokens.join(' ').trim() || query
+}
+
+function shouldUseLiteralContentSearch(query: string): boolean {
+  const trimmed = query.trim()
+  if (!trimmed) return false
+  if (/[^\p{L}\p{N}\s"*.-]/u.test(trimmed)) return true
+
+  const tokens = trimmed.match(/"[^"]*"\*?|\S+/g)
+  if (!tokens) return true
+
+  for (const token of tokens) {
+    if (/^(AND|OR|NOT)$/i.test(token)) continue
+
+    const raw = token.endsWith('*') ? token.slice(0, -1) : token
+    if (!raw) return true
+
+    if (raw.startsWith('"') && raw.endsWith('"')) {
+      const inner = raw.slice(1, -1)
+      if (!inner.trim()) return true
+      if (!/^[\p{L}\p{N}\s.-]+$/u.test(inner)) return true
+      if ((inner.includes('.') || inner.includes('-')) && !/^[A-Za-z0-9\s.-]+$/.test(inner)) return true
+      continue
+    }
+
+    if (raw.includes('.') || raw.includes('-')) {
+      if (!/^[A-Za-z0-9]+(?:[.-][A-Za-z0-9]+)*$/.test(raw)) return true
+      continue
+    }
+
+    if (!/^[\p{L}\p{N}]+$/u.test(raw)) return true
+  }
+
+  return false
+}
+
+function runLiteralContentSearch(
+  db: { prepare: (sql: string) => { all: (...params: any[]) => Record<string, unknown>[] } },
+  source: string | undefined,
+  query: string,
+  limit: number,
+): Record<string, unknown>[] {
+  const likeBase = buildBaseSessionSql(source)
+  const loweredQuery = query.toLowerCase()
+  const likePattern = buildLikePattern(loweredQuery)
+  const likeSql = `
+    WITH base AS (
+      ${likeBase.sql}
+    )
+    SELECT
+      base.*,
+      m.id AS matched_message_id,
+      substr(
+        m.content,
+        max(1, instr(LOWER(m.content), ?) - 40),
+        120
+      ) AS snippet,
+      0 AS rank
+    FROM base
+    JOIN messages m ON m.session_id = base.id
+    WHERE LOWER(m.content) LIKE ? ESCAPE '\\'
+    ORDER BY base.last_active DESC, m.timestamp DESC
+    LIMIT ?
+  `
+  return db.prepare(likeSql).all(...likeBase.params, loweredQuery, likePattern, limit * 4) as Record<string, unknown>[]
+}
+
 function sanitizeFtsQuery(query: string): string {
   const quotedParts: string[] = []
 
@@ -182,7 +271,7 @@ function sanitizeFtsQuery(query: string): string {
 }
 
 function toPrefixQuery(query: string): string {
-  const tokens = query.match(/"[^"]*"|\S+/g)
+  const tokens = query.match(/"[^"]*"\*?|\S+/g)
   if (!tokens) return ''
   return tokens
     .map((token) => {
@@ -246,6 +335,9 @@ export async function searchSessionSummaries(
   const db = new DatabaseSync(sessionDbPath(), { open: true, readOnly: true })
   const normalized = sanitizeFtsQuery(trimmed)
   const prefixQuery = toPrefixQuery(normalized)
+  const titlePattern = buildLikePattern(normalizeTitleLikeQuery(trimmed).toLowerCase())
+  const useLiteralContentSearch = containsCjk(trimmed) || shouldUseLiteralContentSearch(trimmed)
+  let titleRows: Record<string, unknown>[] = []
 
   try {
     const titleBase = buildBaseSessionSql(source)
@@ -264,13 +356,13 @@ export async function searchSessionSummaries(
         END AS snippet,
         0 AS rank
       FROM base
-      WHERE LOWER(COALESCE(base.title, '')) LIKE ?
+      WHERE LOWER(COALESCE(base.title, '')) LIKE ? ESCAPE '\\'
       ORDER BY base.last_active DESC
       LIMIT ?
     `
 
     const titleStatement = db.prepare(titleSql)
-    const titleRows = titleStatement.all(...titleBase.params, `%${trimmed.toLowerCase()}%`, limit) as Record<string, unknown>[]
+    titleRows = titleStatement.all(...titleBase.params, titlePattern, limit) as Record<string, unknown>[]
 
     const contentSql = `
       WITH base AS (
@@ -289,9 +381,11 @@ export async function searchSessionSummaries(
       LIMIT ?
     `
 
-    const contentRows = prefixQuery
-      ? (db.prepare(contentSql).all(...contentBase.params, prefixQuery, limit * 4) as Record<string, unknown>[])
-      : []
+    const contentRows = useLiteralContentSearch
+      ? runLiteralContentSearch(db, source, trimmed, limit)
+      : prefixQuery
+        ? (db.prepare(contentSql).all(...contentBase.params, prefixQuery, limit * 4) as Record<string, unknown>[])
+        : []
 
     const merged = new Map<string, HermesSessionSearchRow>()
     for (const row of titleRows) {
@@ -313,35 +407,24 @@ export async function searchSessionSummaries(
     return items.slice(0, limit)
   } catch (err) {
     if (containsCjk(normalized)) {
-      const likeBase = buildBaseSessionSql(source)
-      const likeSql = `
-        WITH base AS (
-          ${likeBase.sql}
-        )
-        SELECT
-          base.*,
-          m.id AS matched_message_id,
-          substr(
-            m.content,
-            max(1, instr(m.content, ?) - 40),
-            120
-          ) AS snippet,
-          0 AS rank
-        FROM base
-        JOIN messages m ON m.session_id = base.id
-        WHERE m.content LIKE ?
-        ORDER BY base.last_active DESC, m.timestamp DESC
-      `
-      const likeStatement = db.prepare(likeSql)
-      const likeRows = likeStatement.all(...likeBase.params, trimmed, `%${trimmed}%`) as Record<string, unknown>[]
+      const likeRows = runLiteralContentSearch(db, source, trimmed, limit)
       const merged = new Map<string, HermesSessionSearchRow>()
+      for (const row of titleRows) {
+        const mapped = mapSearchRow(row)
+        merged.set(mapped.id, mapped)
+      }
       for (const row of likeRows) {
         const mapped = mapSearchRow(row)
         if (!merged.has(mapped.id)) {
           merged.set(mapped.id, mapped)
         }
       }
-      return [...merged.values()].slice(0, limit)
+      const items = [...merged.values()]
+      items.sort((a, b) => {
+        if (a.rank !== b.rank) return a.rank - b.rank
+        return b.last_active - a.last_active
+      })
+      return items.slice(0, limit)
     }
 
     const message = err instanceof Error ? err.message : String(err)

--- a/packages/server/src/db/hermes/sessions-db.ts
+++ b/packages/server/src/db/hermes/sessions-db.ts
@@ -202,12 +202,12 @@ function shouldUseLiteralContentSearch(query: string): boolean {
       const inner = raw.slice(1, -1)
       if (!inner.trim()) return true
       if (!/^[\p{L}\p{N}\s.-]+$/u.test(inner)) return true
-      if ((inner.includes('.') || inner.includes('-')) && !/^[A-Za-z0-9\s.-]+$/.test(inner)) return true
+      if ((inner.includes('.') || inner.includes('-')) && !/^[\p{L}\p{N}]+(?:[.-][\p{L}\p{N}]+)*(?:\s+[\p{L}\p{N}]+(?:[.-][\p{L}\p{N}]+)*)*$/u.test(inner)) return true
       continue
     }
 
     if (raw.includes('.') || raw.includes('-')) {
-      if (!/^[A-Za-z0-9]+(?:[.-][A-Za-z0-9]+)*$/.test(raw)) return true
+      if (!/^[\p{L}\p{N}]+(?:[.-][\p{L}\p{N}]+)*$/u.test(raw)) return true
       continue
     }
 
@@ -261,7 +261,7 @@ function sanitizeFtsQuery(query: string): string {
   sanitized = sanitized.replace(/(^|\s)\*/g, '$1')
   sanitized = sanitized.trim().replace(/^(AND|OR|NOT)\b\s*/i, '')
   sanitized = sanitized.trim().replace(/\s+(AND|OR|NOT)\s*$/i, '')
-  sanitized = sanitized.replace(/\b(\w+(?:[.-]\w+)+)\b/g, '"$1"')
+  sanitized = sanitized.replace(/\b([\p{L}\p{N}]+(?:[.-][\p{L}\p{N}]+)+)\b/gu, '"$1"')
 
   for (let i = 0; i < quotedParts.length; i += 1) {
     sanitized = sanitized.replace(`\u0000Q${i}\u0000`, quotedParts[i])

--- a/tests/server/sessions-db.test.ts
+++ b/tests/server/sessions-db.test.ts
@@ -6,8 +6,8 @@ const contentAllMock = vi.fn()
 const likeAllMock = vi.fn()
 const prepareMock = vi.fn((sql: string) => {
   if (sql.includes('messages_fts MATCH')) return ({ all: contentAllMock })
-  if (sql.includes('m.content LIKE ?')) return ({ all: likeAllMock })
-  if (sql.includes("LOWER(COALESCE(base.title, '')) LIKE ?")) return ({ all: titleAllMock })
+  if (sql.includes('JOIN messages m') && sql.includes('LIKE')) return ({ all: likeAllMock })
+  if (sql.includes('base.title') && sql.includes('LIKE')) return ({ all: titleAllMock })
   return ({ all: allMock })
 })
 const closeMock = vi.fn()
@@ -231,8 +231,379 @@ describe('session DB summaries', () => {
     expect(rows[1].snippet).toContain('docker')
   })
 
-  it('falls back to LIKE search for CJK queries', async () => {
+  it('falls back to literal content search for punctuation-only queries instead of unsafe FTS', async () => {
     titleAllMock.mockReturnValue([])
+    contentAllMock.mockImplementation(() => {
+      throw new Error('fts5: syntax error near "."')
+    })
+    likeAllMock.mockReturnValue([
+      {
+        id: 'dot-1',
+        source: 'cli',
+        user_id: '',
+        model: 'openai/gpt-5.4',
+        title: '',
+        started_at: 1710004000,
+        ended_at: null,
+        end_reason: '',
+        message_count: 1,
+        tool_call_count: 0,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: 0,
+        billing_provider: '',
+        estimated_cost_usd: 0,
+        actual_cost_usd: null,
+        cost_status: '',
+        preview: 'punctuation preview',
+        last_active: 1710004001,
+        matched_message_id: 21,
+        snippet: 'value.with.dot',
+        rank: 0,
+      },
+    ])
+
+    const mod = await import('../../packages/server/src/db/hermes/sessions-db')
+    const rows = await mod.searchSessionSummaries('.', undefined, 10)
+
+    expect(contentAllMock).not.toHaveBeenCalled()
+    expect(likeAllMock).toHaveBeenCalled()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('dot-1')
+  })
+
+  it('keeps safe dotted queries on the FTS path', async () => {
+    titleAllMock.mockReturnValue([])
+    contentAllMock.mockReturnValue([
+      {
+        id: 'node-1',
+        source: 'cli',
+        user_id: '',
+        model: 'openai/gpt-5.4',
+        title: 'Node.js notes',
+        started_at: 1710004500,
+        ended_at: null,
+        end_reason: '',
+        message_count: 1,
+        tool_call_count: 0,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: 0,
+        billing_provider: '',
+        estimated_cost_usd: 0,
+        actual_cost_usd: null,
+        cost_status: '',
+        preview: 'dotted preview',
+        last_active: 1710004501,
+        matched_message_id: 22,
+        snippet: '>>>node.js<<< runtime',
+        rank: 0.2,
+      },
+    ])
+
+    const mod = await import('../../packages/server/src/db/hermes/sessions-db')
+    const rows = await mod.searchSessionSummaries('node.js', undefined, 10)
+
+    expect(contentAllMock).toHaveBeenCalled()
+    expect(likeAllMock).not.toHaveBeenCalled()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('node-1')
+  })
+
+  it('keeps explicit wildcard dotted queries on the FTS path with valid syntax', async () => {
+    titleAllMock.mockReturnValue([
+      {
+        id: 'node-wildcard-title-1',
+        source: 'cli',
+        user_id: '',
+        model: 'openai/gpt-5.4',
+        title: 'Node.js wildcard notes',
+        started_at: 1710004590,
+        ended_at: null,
+        end_reason: '',
+        message_count: 1,
+        tool_call_count: 0,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: 0,
+        billing_provider: '',
+        estimated_cost_usd: 0,
+        actual_cost_usd: null,
+        cost_status: '',
+        preview: 'wildcard title preview',
+        last_active: 1710004595,
+        matched_message_id: null,
+        snippet: 'Node.js wildcard notes',
+        rank: 0,
+      },
+    ])
+    contentAllMock.mockReturnValue([
+      {
+        id: 'node-wildcard-1',
+        source: 'cli',
+        user_id: '',
+        model: 'openai/gpt-5.4',
+        title: 'Node.js wildcard notes',
+        started_at: 1710004600,
+        ended_at: null,
+        end_reason: '',
+        message_count: 1,
+        tool_call_count: 0,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: 0,
+        billing_provider: '',
+        estimated_cost_usd: 0,
+        actual_cost_usd: null,
+        cost_status: '',
+        preview: 'wildcard dotted preview',
+        last_active: 1710004601,
+        matched_message_id: 24,
+        snippet: '>>>node.js<<< runtime',
+        rank: 0.15,
+      },
+    ])
+
+    const mod = await import('../../packages/server/src/db/hermes/sessions-db')
+    const rows = await mod.searchSessionSummaries('node.js*', undefined, 10)
+
+    expect(titleAllMock).toHaveBeenCalledWith('%node.js%', 10)
+    expect(contentAllMock).toHaveBeenCalledWith('"node.js"*', 40)
+    expect(likeAllMock).not.toHaveBeenCalled()
+    expect(rows).toHaveLength(2)
+    expect(rows[0].id).toBe('node-wildcard-title-1')
+    expect(rows[1].id).toBe('node-wildcard-1')
+  })
+
+  it('keeps quoted wildcard dotted queries on the FTS path with valid syntax', async () => {
+    titleAllMock.mockReturnValue([
+      {
+        id: 'node-quoted-title-1',
+        source: 'cli',
+        user_id: '',
+        model: 'openai/gpt-5.4',
+        title: 'Quoted Node.js wildcard notes',
+        started_at: 1710004640,
+        ended_at: null,
+        end_reason: '',
+        message_count: 1,
+        tool_call_count: 0,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: 0,
+        billing_provider: '',
+        estimated_cost_usd: 0,
+        actual_cost_usd: null,
+        cost_status: '',
+        preview: 'quoted title preview',
+        last_active: 1710004645,
+        matched_message_id: null,
+        snippet: 'Quoted Node.js wildcard notes',
+        rank: 0,
+      },
+    ])
+    contentAllMock.mockReturnValue([
+      {
+        id: 'node-quoted-wildcard-1',
+        source: 'cli',
+        user_id: '',
+        model: 'openai/gpt-5.4',
+        title: 'Quoted Node.js wildcard notes',
+        started_at: 1710004650,
+        ended_at: null,
+        end_reason: '',
+        message_count: 1,
+        tool_call_count: 0,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: 0,
+        billing_provider: '',
+        estimated_cost_usd: 0,
+        actual_cost_usd: null,
+        cost_status: '',
+        preview: 'quoted wildcard dotted preview',
+        last_active: 1710004651,
+        matched_message_id: 25,
+        snippet: '>>>node.js<<< runtime',
+        rank: 0.12,
+      },
+    ])
+
+    const mod = await import('../../packages/server/src/db/hermes/sessions-db')
+    const rows = await mod.searchSessionSummaries('"node.js"*', undefined, 10)
+
+    expect(titleAllMock).toHaveBeenCalledWith('%node.js%', 10)
+    expect(contentAllMock).toHaveBeenCalledWith('"node.js"*', 40)
+    expect(likeAllMock).not.toHaveBeenCalled()
+    expect(rows).toHaveLength(2)
+    expect(rows[0].id).toBe('node-quoted-title-1')
+    expect(rows[1].id).toBe('node-quoted-wildcard-1')
+  })
+
+  it('routes non-ASCII dotted queries to literal search instead of unsafe FTS', async () => {
+    titleAllMock.mockReturnValue([])
+    contentAllMock.mockImplementation(() => {
+      throw new Error('fts5: syntax error near "."')
+    })
+    likeAllMock.mockReturnValue([
+      {
+        id: 'unicode-dot-1',
+        source: 'cli',
+        user_id: '',
+        model: 'openai/gpt-5.4',
+        title: 'naïve.js note',
+        started_at: 1710004700,
+        ended_at: null,
+        end_reason: '',
+        message_count: 1,
+        tool_call_count: 0,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: 0,
+        billing_provider: '',
+        estimated_cost_usd: 0,
+        actual_cost_usd: null,
+        cost_status: '',
+        preview: 'unicode dotted preview',
+        last_active: 1710004701,
+        matched_message_id: 23,
+        snippet: 'naïve.js runtime',
+        rank: 0,
+      },
+    ])
+
+    const mod = await import('../../packages/server/src/db/hermes/sessions-db')
+    const rows = await mod.searchSessionSummaries('naïve.js', undefined, 10)
+
+    expect(contentAllMock).not.toHaveBeenCalled()
+    expect(likeAllMock).toHaveBeenCalled()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('unicode-dot-1')
+  })
+
+  it('escapes LIKE wildcards for literal special-character searches', async () => {
+    titleAllMock.mockReturnValue([])
+    likeAllMock.mockReturnValue([
+      {
+        id: 'percent-1',
+        source: 'cli',
+        user_id: '',
+        model: 'openai/gpt-5.4',
+        title: '100% reproducible',
+        started_at: 1710005000,
+        ended_at: null,
+        end_reason: '',
+        message_count: 1,
+        tool_call_count: 0,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: 0,
+        billing_provider: '',
+        estimated_cost_usd: 0,
+        actual_cost_usd: null,
+        cost_status: '',
+        preview: 'literal percent preview',
+        last_active: 1710005001,
+        matched_message_id: 31,
+        snippet: '100% reproducible',
+        rank: 0,
+      },
+    ])
+
+    const mod = await import('../../packages/server/src/db/hermes/sessions-db')
+    const rows = await mod.searchSessionSummaries('100%', undefined, 10)
+
+    expect(titleAllMock).toHaveBeenCalledWith('%100\\%%', 10)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('percent-1')
+  })
+
+  it('uses literal search for CJK queries even when FTS returns no rows', async () => {
+    titleAllMock.mockReturnValue([])
+    contentAllMock.mockReturnValue([])
+    likeAllMock.mockReturnValue([
+      {
+        id: 'cjk-literal-1',
+        source: 'cli',
+        user_id: '',
+        model: 'openai/gpt-5.4',
+        title: '',
+        started_at: 1710002980,
+        ended_at: null,
+        end_reason: '',
+        message_count: 1,
+        tool_call_count: 0,
+        input_tokens: 2,
+        output_tokens: 3,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: 0,
+        billing_provider: '',
+        estimated_cost_usd: 0,
+        actual_cost_usd: null,
+        cost_status: '',
+        preview: '中文内容预览',
+        last_active: 1710002985,
+        matched_message_id: 10,
+        snippet: '这里也有记忆断裂',
+        rank: 0,
+      },
+    ])
+
+    const mod = await import('../../packages/server/src/db/hermes/sessions-db')
+    const rows = await mod.searchSessionSummaries('记忆断裂', undefined, 10)
+
+    expect(contentAllMock).not.toHaveBeenCalled()
+    expect(likeAllMock).toHaveBeenCalledWith('记忆断裂', '%记忆断裂%', 40)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('cjk-literal-1')
+  })
+
+  it('falls back to LIKE search for CJK queries while preserving title matches', async () => {
+    titleAllMock.mockReturnValue([
+      {
+        id: 'cjk-title-1',
+        source: 'cli',
+        user_id: '',
+        model: 'openai/gpt-5.4',
+        title: '记忆断裂标题',
+        started_at: 1710002990,
+        ended_at: null,
+        end_reason: '',
+        message_count: 1,
+        tool_call_count: 0,
+        input_tokens: 2,
+        output_tokens: 2,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: 0,
+        billing_provider: '',
+        estimated_cost_usd: 0,
+        actual_cost_usd: null,
+        cost_status: '',
+        preview: 'title preview',
+        last_active: 1710002995,
+        matched_message_id: null,
+        snippet: '记忆断裂标题',
+        rank: 0,
+      },
+    ])
     contentAllMock.mockImplementation(() => {
       throw new Error('fts5 tokenizer miss')
     })
@@ -268,9 +639,24 @@ describe('session DB summaries', () => {
     const mod = await import('../../packages/server/src/db/hermes/sessions-db')
     const rows = await mod.searchSessionSummaries('记忆断裂', undefined, 10)
 
-    expect(likeAllMock).toHaveBeenCalledWith('记忆断裂', '%记忆断裂%')
-    expect(rows).toHaveLength(1)
+    expect(likeAllMock).toHaveBeenCalledWith('记忆断裂', '%记忆断裂%', 40)
+    expect(rows).toHaveLength(2)
     expect(rows[0].id).toBe('cjk-1')
+    expect(rows[1].id).toBe('cjk-title-1')
     expect(rows[0].snippet).toContain('记忆断裂')
+  })
+
+  it('does not hide real database failures for safe FTS queries', async () => {
+    titleAllMock.mockReturnValue([])
+    contentAllMock.mockImplementation(() => {
+      throw new Error('database malformed')
+    })
+
+    const mod = await import('../../packages/server/src/db/hermes/sessions-db')
+
+    await expect(mod.searchSessionSummaries('docker', undefined, 10)).rejects.toThrow(
+      'Failed to search sessions: database malformed',
+    )
+    expect(likeAllMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/server/sessions-db.test.ts
+++ b/tests/server/sessions-db.test.ts
@@ -452,12 +452,9 @@ describe('session DB summaries', () => {
     expect(rows[1].id).toBe('node-quoted-wildcard-1')
   })
 
-  it('routes non-ASCII dotted queries to literal search instead of unsafe FTS', async () => {
+  it('keeps non-ASCII dotted queries on the safe quoted FTS path', async () => {
     titleAllMock.mockReturnValue([])
-    contentAllMock.mockImplementation(() => {
-      throw new Error('fts5: syntax error near "."')
-    })
-    likeAllMock.mockReturnValue([
+    contentAllMock.mockReturnValue([
       {
         id: 'unicode-dot-1',
         source: 'cli',
@@ -489,8 +486,8 @@ describe('session DB summaries', () => {
     const mod = await import('../../packages/server/src/db/hermes/sessions-db')
     const rows = await mod.searchSessionSummaries('naïve.js', undefined, 10)
 
-    expect(contentAllMock).not.toHaveBeenCalled()
-    expect(likeAllMock).toHaveBeenCalled()
+    expect(contentAllMock).toHaveBeenCalledWith('"naïve.js"', 40)
+    expect(likeAllMock).not.toHaveBeenCalled()
     expect(rows).toHaveLength(1)
     expect(rows[0].id).toBe('unicode-dot-1')
   })


### PR DESCRIPTION
## 改动
- 修复 session 搜索在输入特殊字符时走到非法 FTS5 `MATCH` 语法、接口直接返回 500 的问题
- 为 `%`、`_`、反斜杠补上 `LIKE` 转义，保证 `.`、`;`、`issue:123`、`foo/bar`、`c++` 这类查询能安全降级到字面量搜索
- 保留正常 dotted 查询的 FTS 路径，并把非 ASCII dotted 查询（如 `naïve.js`）也走安全的 quoted FTS，避免误降级到 `LOWER(... ) LIKE` 后丢失 Unicode 匹配
- 调整回归测试，覆盖 punctuation-only、wildcard dotted、quoted dotted、Unicode dotted、CJK 等查询路径

## 为什么
当前 dashboard 的 session 搜索在遇到特殊字符时会把原始查询直接喂给 FTS5，导致后端抛错并返回 API 500。这个 PR 的目标是把“会炸”的查询安全分流掉，同时尽量保住原本正常查询的 FTS 搜索能力和结果质量。

## 测试
- `npm run test -- tests/server/sessions-db.test.ts`
- `npm run test -- tests/server/sessions-routes.test.ts`
- `npm run build`
- 本地接口 smoke：`/api/hermes/search/sessions?q=.`、`;`、`issue:123`、`foo/bar`、`c++`、`node.js`、`node.js*`、`"node.js"*`、`naïve.js`、`记忆断裂`、`docker` 均返回 HTTP 200

## Review / 风险
- 真实 diff 仅 2 个文件：`packages/server/src/db/hermes/sessions-db.ts`、`tests/server/sessions-db.test.ts`
- 已做一次独立复核；当前未发现 blocker / major 问题
- 风险较低，范围仅限 session 搜索分流与对应测试

## Issues
- 无新增 follow-up issue；当前范围只修复 500 和相关查询分流
