### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     stdin_open: true
     tty: true
     restart: unless-stopped
+    command: gateway run
     ports:
       - "8642-8670:8642-8670"
 


### PR DESCRIPTION
docs: update Hermes Agent to start in gateway mode

## Summary

This PR updates the startup command for the Hermes Agent to use gateway mode. By explicitly setting the command to gateway run, the agent avoids initializing in the default CLI chat mode, which previously generated unnecessary startup logs and overhead.

## Type of Change

- [ ] Feature (new functionality)
- [x ] Bug fix
- [ ] Refactor (no functional change)
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Changes

Added command: gateway run to the service configuration.
Changed the default startup behavior from CLI chat mode to Gateway mode.

## Test Plan

<!-- How did you test? What should reviewers verify? -->

- [ ] Build passes (`npm run build`)
- [x] Tested manually

## Screenshots (if applicable)

no
## Related Issues

no
