### PR TITLE
fix: add periodic log rotation to prevent unbounded log growth

### DIFF
--- a/packages/server/src/services/logger.ts
+++ b/packages/server/src/services/logger.ts
@@ -4,25 +4,33 @@ import { mkdirSync, statSync, truncateSync, openSync, readSync, closeSync, write
 import { homedir } from 'os'
 
 const MAX_LOG_SIZE = 3 * 1024 * 1024 // 3MB
+const CHECK_INTERVAL = 60_000 // Check every minute
 
 const logDir = resolve(homedir(), '.hermes-web-ui', 'logs')
 mkdirSync(logDir, { recursive: true })
 
 const logFile = resolve(logDir, 'server.log')
 
-// Rotate log if it exceeds MAX_LOG_SIZE — truncate to keep the last half
-try {
-  const stat = statSync(logFile)
-  if (stat.size > MAX_LOG_SIZE) {
-    const keepSize = Math.floor(MAX_LOG_SIZE / 2)
-    const fd = openSync(logFile, 'r')
-    const buf = Buffer.alloc(keepSize)
-    readSync(fd, buf, 0, keepSize, stat.size - keepSize)
-    closeSync(fd)
-    truncateSync(logFile, 0)
-    writeFileSync(logFile, buf)
-  }
-} catch {}
+function rotateIfNeeded() {
+  try {
+    const stat = statSync(logFile)
+    if (stat.size > MAX_LOG_SIZE) {
+      const keepSize = Math.floor(MAX_LOG_SIZE / 2)
+      const fd = openSync(logFile, 'r')
+      const buf = Buffer.alloc(keepSize)
+      readSync(fd, buf, 0, keepSize, stat.size - keepSize)
+      closeSync(fd)
+      truncateSync(logFile, 0)
+      writeFileSync(logFile, buf)
+    }
+  } catch {}
+}
+
+// Rotate on startup
+rotateIfNeeded()
+
+// Periodic rotation check — prevents unbounded log growth
+setInterval(rotateIfNeeded, CHECK_INTERVAL)
 
 export const logger = pino({
   level: process.env.LOG_LEVEL || 'info',


### PR DESCRIPTION
## Summary
- Log rotation previously only ran at process startup, causing logs to grow indefinitely on long-running processes (reported up to 71GB/day in #155)
- Added `setInterval` to check log size every 60 seconds and truncate when exceeding 3MB

## Test plan
- [x] Build passes
- [x] Verified rotation logic triggers periodically

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)