### PR TITLE
fix: clear all localStorage on logout

### DIFF
--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -13,7 +13,6 @@ import danceVideoLight from "@/assets/dance-light.mp4";
 import danceVideoDark from "@/assets/dance-dark.mp4";
 
 import { useTheme } from "@/composables/useTheme";
-import { clearApiKey } from "@/api/client";
 import { changelog } from "@/data/changelog";
 
 const { t } = useI18n();
@@ -50,7 +49,7 @@ async function handleUpdate() {
 }
 
 function handleLogout() {
-  clearApiKey();
+  localStorage.clear();
   router.replace({ name: 'login' });
 }
 


### PR DESCRIPTION
## Summary
- Previously `handleLogout` only cleared the auth token (`hermes_api_key`), leaving server URL, active profile, chat caches and other data in localStorage
- Now calls `localStorage.clear()` to wipe everything on logout

## Test plan
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)