### PR TITLE
fix: context-length API returns 200K instead of actual model context

### DIFF
--- a/packages/client/src/api/hermes/system.ts
+++ b/packages/client/src/api/hermes/system.ts
@@ -45,6 +45,7 @@ export interface CustomProvider {
   base_url: string
   api_key: string
   model: string
+  context_length?: number
   providerKey?: string | null
 }
 

--- a/packages/client/src/components/hermes/models/ProviderFormModal.vue
+++ b/packages/client/src/components/hermes/models/ProviderFormModal.vue
@@ -29,6 +29,7 @@ const formData = ref({
   base_url: '',
   api_key: '',
   model: '',
+  context_length: '',
 })
 
 const modelOptions = ref<Array<{ label: string; value: string }>>([])
@@ -75,7 +76,7 @@ watch(() => formData.value.base_url, (url) => {
 
 watch(providerType, () => {
   modelOptions.value = []
-  formData.value = { name: '', base_url: '', api_key: '', model: '' }
+  formData.value = { name: '', base_url: '', api_key: '', model: '', context_length: '' }
   selectedPreset.value = null
 })
 
@@ -154,11 +155,13 @@ async function handleSave() {
       ? selectedPreset.value
       : null
 
+    const contextLength = formData.value.context_length ? parseInt(formData.value.context_length, 10) : undefined
     await modelsStore.addProvider({
       name: formData.value.name.trim(),
       base_url: formData.value.base_url.trim(),
       api_key: formData.value.api_key.trim(),
       model: formData.value.model,
+      context_length: contextLength,
       providerKey,
     })
     message.success(t('models.providerAdded'))
@@ -269,6 +272,14 @@ function handleClose() {
             {{ t('common.fetch') }}
           </NButton>
         </div>
+      </NFormItem>
+
+      <NFormItem v-if="providerType === 'custom'" :label="t('models.contextLength')">
+        <NInput
+          v-model:value="formData.context_length"
+          :placeholder="t('models.contextLengthPlaceholder')"
+          type="number"
+        />
       </NFormItem>
     </NForm>
 

--- a/packages/client/src/components/hermes/models/ProviderFormModal.vue
+++ b/packages/client/src/components/hermes/models/ProviderFormModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, computed, onMounted } from 'vue'
-import { NModal, NForm, NFormItem, NInput, NButton, NSelect, useMessage } from 'naive-ui'
+import { NModal, NForm, NFormItem, NInput, NInputNumber, NButton, NSelect, useMessage } from 'naive-ui'
 import { useModelsStore } from '@/stores/hermes/models'
 import { useI18n } from 'vue-i18n'
 import CodexLoginModal from './CodexLoginModal.vue'
@@ -29,7 +29,7 @@ const formData = ref({
   base_url: '',
   api_key: '',
   model: '',
-  context_length: '',
+  context_length: null as number | null,
 })
 
 const modelOptions = ref<Array<{ label: string; value: string }>>([])
@@ -76,7 +76,7 @@ watch(() => formData.value.base_url, (url) => {
 
 watch(providerType, () => {
   modelOptions.value = []
-  formData.value = { name: '', base_url: '', api_key: '', model: '', context_length: '' }
+  formData.value = { name: '', base_url: '', api_key: '', model: '', context_length: null }
   selectedPreset.value = null
 })
 
@@ -155,7 +155,7 @@ async function handleSave() {
       ? selectedPreset.value
       : null
 
-    const contextLength = formData.value.context_length ? parseInt(formData.value.context_length, 10) : undefined
+    const contextLength = formData.value.context_length ?? undefined
     await modelsStore.addProvider({
       name: formData.value.name.trim(),
       base_url: formData.value.base_url.trim(),
@@ -275,10 +275,12 @@ function handleClose() {
       </NFormItem>
 
       <NFormItem v-if="providerType === 'custom'" :label="t('models.contextLength')">
-        <NInput
-          v-model:value="formData.context_length"
+        <NInputNumber
+          v-model:value="formData.context_length as number | null"
           :placeholder="t('models.contextLengthPlaceholder')"
-          type="number"
+          :min="0"
+          clearable
+          style="width: 100%"
         />
       </NFormItem>
     </NForm>

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -255,6 +255,8 @@ export default {
     builtIn: 'Integriert',
     customType: 'Benutzerdefiniert',
     provider: 'Anbieter',
+    contextLength: 'Kontextlange',
+    contextLengthPlaceholder: 'z.B. 200000 (optional)',
     local: 'Lokal ({host})',
     selectProviderRequired: 'Bitte wahlen Sie einen Anbieter',
     baseUrlRequired: 'Basis-URL ist erforderlich',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -280,6 +280,8 @@ export default {
     builtIn: 'Built-in',
     customType: 'Custom',
     provider: 'Provider',
+    contextLength: 'Context Length',
+    contextLengthPlaceholder: 'e.g. 200000 (optional)',
     local: 'Local ({host})',
     selectProviderRequired: 'Please select a provider',
     baseUrlRequired: 'Base URL is required',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -255,6 +255,8 @@ export default {
     builtIn: 'Integrado',
     customType: 'Personalizado',
     provider: 'Proveedor',
+    contextLength: 'Longitud del contexto',
+    contextLengthPlaceholder: 'ej. 200000 (opcional)',
     local: 'Local ({host})',
     selectProviderRequired: 'Por favor, selecciona un proveedor',
     baseUrlRequired: 'La URL base es obligatoria',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -255,6 +255,8 @@ export default {
     builtIn: 'Integre',
     customType: 'Personnalise',
     provider: 'Fournisseur',
+    contextLength: 'Longueur du contexte',
+    contextLengthPlaceholder: 'ex. 200000 (facultatif)',
     local: 'Local ({host})',
     selectProviderRequired: 'Veuillez selectionner un fournisseur',
     baseUrlRequired: 'L\'URL de base est requise',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -255,6 +255,8 @@ export default {
     builtIn: '組み込み',
     customType: 'カスタム',
     provider: 'プロバイダー',
+    contextLength: 'コンテキスト長',
+    contextLengthPlaceholder: '例: 200000（任意）',
     local: 'ローカル ({host})',
     selectProviderRequired: 'プロバイダーを選択してください',
     baseUrlRequired: 'ベース URL は必須です',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -255,6 +255,8 @@ export default {
     builtIn: '내장',
     customType: '사용자 지정',
     provider: 'Provider',
+    contextLength: '컨텍스트 길이',
+    contextLengthPlaceholder: '예: 200000 (선택사항)',
     local: '로컬 ({host})',
     selectProviderRequired: 'Provider를 선택해 주세요',
     baseUrlRequired: 'Base URL을 입력해 주세요',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -255,6 +255,8 @@ export default {
     builtIn: 'Integrado',
     customType: 'Personalizado',
     provider: 'Provedor',
+    contextLength: 'Tamanho do contexto',
+    contextLengthPlaceholder: 'ex: 200000 (opcional)',
     local: 'Local ({host})',
     selectProviderRequired: 'Por favor, selecione um provedor',
     baseUrlRequired: 'A URL base e obrigatoria',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -281,6 +281,8 @@ export default {
     builtIn: '内置',
     customType: '自定义',
     provider: 'Provider',
+    contextLength: '上下文长度',
+    contextLengthPlaceholder: '例如 200000（可选）',
     local: '本地 ({host})',
     selectProviderRequired: '请选择 Provider',
     baseUrlRequired: 'Base URL 为必填项',

--- a/packages/server/src/controllers/hermes/providers.ts
+++ b/packages/server/src/controllers/hermes/providers.ts
@@ -5,9 +5,17 @@ import * as hermesCli from '../../services/hermes/hermes-cli'
 import { readConfigYaml, writeConfigYaml, saveEnvValue, PROVIDER_ENV_MAP } from '../../services/config-helpers'
 import { logger } from '../../services/logger'
 
+function buildProviderEntry(name: string, base_url: string, api_key: string, model: string, context_length?: number) {
+  const entry: any = { name, base_url, api_key, model }
+  if (context_length && context_length > 0) {
+    entry.models = { [model]: { context_length } }
+  }
+  return entry
+}
+
 export async function create(ctx: any) {
-  const { name, base_url, api_key, model, providerKey } = ctx.request.body as {
-    name: string; base_url: string; api_key: string; model: string; providerKey?: string | null
+  const { name, base_url, api_key, model, context_length, providerKey } = ctx.request.body as {
+    name: string; base_url: string; api_key: string; model: string; context_length?: number; providerKey?: string | null
   }
   console.log(name, base_url, api_key, model, providerKey)
   if (!name || !base_url || !model) {
@@ -30,8 +38,13 @@ export async function create(ctx: any) {
         existing.base_url = base_url
         existing.api_key = api_key
         existing.model = model
+        if (context_length && context_length > 0) {
+          if (!existing.models) existing.models = {}
+          existing.models[model] = existing.models[model] || {}
+          existing.models[model].context_length = context_length
+        }
       } else {
-        config.custom_providers.push({ name: name.trim().toLowerCase().replace(/ /g, '-'), base_url, api_key, model })
+        config.custom_providers.push(buildProviderEntry(name.trim().toLowerCase().replace(/ /g, '-'), base_url, api_key, model, context_length))
       }
       config.model.default = model
       config.model.provider = poolKey
@@ -51,8 +64,13 @@ export async function create(ctx: any) {
           existing.base_url = base_url
           existing.api_key = api_key
           existing.model = model
+          if (context_length && context_length > 0) {
+            if (!existing.models) existing.models = {}
+            existing.models[model] = existing.models[model] || {}
+            existing.models[model].context_length = context_length
+          }
         } else {
-          config.custom_providers.push({ name: poolKey, base_url, api_key, model })
+          config.custom_providers.push(buildProviderEntry(poolKey, base_url, api_key, model, context_length))
         }
         config.model.default = model
         config.model.provider = `custom:${poolKey}`

--- a/packages/server/src/services/hermes/model-context.ts
+++ b/packages/server/src/services/hermes/model-context.ts
@@ -1,6 +1,7 @@
 import { resolve, join } from 'path'
 import { homedir } from 'os'
 import { readFileSync, existsSync, statSync } from 'fs'
+import yaml from 'js-yaml'
 
 const HERMES_BASE = resolve(homedir(), '.hermes')
 const MODELS_DEV_CACHE = resolve(HERMES_BASE, 'models_dev_cache.json')
@@ -19,6 +20,18 @@ interface ModelEntry {
 
 interface ProviderEntry {
   models?: Record<string, ModelEntry>
+}
+
+// --- Config YAML helpers (js-yaml) ---
+
+function loadConfig(profileDir: string): any | null {
+  const configPath = join(profileDir, 'config.yaml')
+  if (!existsSync(configPath)) return null
+  try {
+    return yaml.load(readFileSync(configPath, 'utf-8')) as any
+  } catch {
+    return null
+  }
 }
 
 // --- In-memory cache: parsed models_dev_cache (1.7MB), invalidated by mtime ---
@@ -55,60 +68,59 @@ function getProfileDir(profile?: string): string {
   return existsSync(dir) ? dir : HERMES_BASE
 }
 
-function getDefaultModel(profileDir: string): string | null {
-  const configPath = join(profileDir, 'config.yaml')
-  if (!existsSync(configPath)) return null
-  try {
-    const content = readFileSync(configPath, 'utf-8')
-    const match = content.match(/^model:\s*\n\s+default:\s*(.+)$/m)
-    return match ? match[1].trim() : null
-  } catch {
-    return null
-  }
+function getDefaultModel(config: any): string | null {
+  const model = config?.model
+  if (!model || typeof model !== 'object') return null
+  return typeof model.default === 'string' ? model.default.trim() || null : null
+}
+
+function getDefaultProvider(config: any): string | null {
+  const model = config?.model
+  if (!model || typeof model !== 'object') return null
+  return typeof model.provider === 'string' ? model.provider.trim() || null : null
 }
 
 /**
- * Extract the default model name from config.yaml, handling cases where
- * other keys (api_key, base_url, etc.) appear before "default" under "model:".
- * The original getDefaultModel regex assumes "default" is the first child key,
- * which fails when api_key/base_url come first.
+ * Read context_length from config.yaml, only as a sibling of default.
+ * e.g. model:\n  default: gpt-5.4\n  context_length: 200000
  */
-function getDefaultModelRobust(profileDir: string): string | null {
-  const configPath = join(profileDir, 'config.yaml')
-  if (!existsSync(configPath)) return null
-  try {
-    const content = readFileSync(configPath, 'utf-8')
-    // Extract the entire model: block, then search for default: within it
-    const blockMatch = content.match(/^model:\s*\n([\s\S]*?)(?=^\w)/m)
-    if (!blockMatch) return null
-    const modelBlock = blockMatch[1]
-    const defaultMatch = modelBlock.match(/default:\s*(.+)$/m)
-    return defaultMatch ? defaultMatch[1].trim() : null
-  } catch {
-    return null
-  }
+function getConfigContextLength(config: any): number | null {
+  const model = config?.model
+  if (!model || typeof model !== 'object') return null
+  const val = model.context_length
+  if (typeof val !== 'number' || !Number.isFinite(val) || val <= 0) return null
+  return val
 }
 
 /**
- * Read model.context_length from config.yaml as a fallback when
- * models_dev_cache.json is unavailable or doesn't contain the model.
- * This matches the hermes-agent behavior where config.yaml's
- * model.context_length is the highest-priority override.
+ * Lookup context_length from custom_providers in config.yaml.
+ * - "custom:xxx" → strip prefix, match by name
+ * - "custom" → match by model name
  */
-function getConfigContextLength(profileDir: string): number | null {
-  const configPath = join(profileDir, 'config.yaml')
-  if (!existsSync(configPath)) return null
-  try {
-    const content = readFileSync(configPath, 'utf-8')
-    const match = content.match(/context_length:\s*(\d+)/)
-    if (match) {
-      const val = parseInt(match[1], 10)
-      if (Number.isFinite(val) && val > 0) return val
-    }
-  } catch {
-    // ignore
+function lookupCustomProviderContextLength(config: any, modelName: string, provider: string | null): number | null {
+  const providers: any[] = Array.isArray(config?.custom_providers) ? config.custom_providers : []
+  if (!provider || !provider.startsWith('custom')) return null
+
+  let matched: any = null
+
+  if (provider === 'custom') {
+    matched = providers.find((cp: any) => cp.model === modelName)
+  } else {
+    const suffix = provider.slice('custom:'.length)
+    matched = providers.find((cp: any) => cp.name === suffix)
   }
-  return null
+
+  if (!matched) return null
+
+  const models = matched.models
+  if (!models || typeof models !== 'object') return null
+
+  const modelEntry = models[modelName]
+  if (!modelEntry || typeof modelEntry !== 'object') return null
+
+  const val = modelEntry.context_length
+  if (typeof val !== 'number' || !Number.isFinite(val) || val <= 0) return null
+  return val
 }
 
 // --- Context lookup ---
@@ -140,20 +152,32 @@ function lookupContextFromCache(modelName: string): number | null {
 /**
  * Get the context length for the current profile's default model.
  * Resolution order:
- *   1. models_dev_cache.json (existing behavior)
- *   2. config.yaml model.context_length (matches hermes-agent priority)
- *   3. DEFAULT_CONTEXT_LENGTH (200K hardcoded fallback)
+ *   1. config.yaml model.context_length (highest priority, user override)
+ *   2. custom_providers models.<model>.context_length
+ *   3. models_dev_cache.json (built-in model database)
+ *   4. DEFAULT_CONTEXT_LENGTH (200K hardcoded fallback)
  */
 export function getModelContextLength(profile?: string): number {
   const profileDir = getProfileDir(profile)
-  const model = getDefaultModelRobust(profileDir) || getDefaultModel(profileDir)
+  const config = loadConfig(profileDir)
+  if (!config) return DEFAULT_CONTEXT_LENGTH
+
+  const model = getDefaultModel(config)
   if (!model) return DEFAULT_CONTEXT_LENGTH
 
+  // 1. Global context_length override in config.yaml
+  const configCtx = getConfigContextLength(config)
+  if (configCtx && configCtx > 0) return configCtx
+
+  // 2. Custom provider context_length
+  const provider = getDefaultProvider(config)
+  const customCtx = lookupCustomProviderContextLength(config, model, provider)
+  if (customCtx && customCtx > 0) return customCtx
+
+  // 3. models_dev_cache.json
   const cached = lookupContextFromCache(model)
   if (cached) return cached
 
-  const configCtx = getConfigContextLength(profileDir)
-  if (configCtx && configCtx > 0) return configCtx
-
+  // 4. Fallback
   return DEFAULT_CONTEXT_LENGTH
 }

--- a/packages/server/src/services/hermes/model-context.ts
+++ b/packages/server/src/services/hermes/model-context.ts
@@ -67,6 +67,50 @@ function getDefaultModel(profileDir: string): string | null {
   }
 }
 
+/**
+ * Extract the default model name from config.yaml, handling cases where
+ * other keys (api_key, base_url, etc.) appear before "default" under "model:".
+ * The original getDefaultModel regex assumes "default" is the first child key,
+ * which fails when api_key/base_url come first.
+ */
+function getDefaultModelRobust(profileDir: string): string | null {
+  const configPath = join(profileDir, 'config.yaml')
+  if (!existsSync(configPath)) return null
+  try {
+    const content = readFileSync(configPath, 'utf-8')
+    // Extract the entire model: block, then search for default: within it
+    const blockMatch = content.match(/^model:\s*\n([\s\S]*?)(?=^\w)/m)
+    if (!blockMatch) return null
+    const modelBlock = blockMatch[1]
+    const defaultMatch = modelBlock.match(/default:\s*(.+)$/m)
+    return defaultMatch ? defaultMatch[1].trim() : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read model.context_length from config.yaml as a fallback when
+ * models_dev_cache.json is unavailable or doesn't contain the model.
+ * This matches the hermes-agent behavior where config.yaml's
+ * model.context_length is the highest-priority override.
+ */
+function getConfigContextLength(profileDir: string): number | null {
+  const configPath = join(profileDir, 'config.yaml')
+  if (!existsSync(configPath)) return null
+  try {
+    const content = readFileSync(configPath, 'utf-8')
+    const match = content.match(/context_length:\s*(\d+)/)
+    if (match) {
+      const val = parseInt(match[1], 10)
+      if (Number.isFinite(val) && val > 0) return val
+    }
+  } catch {
+    // ignore
+  }
+  return null
+}
+
 // --- Context lookup ---
 
 function lookupContextFromCache(modelName: string): number | null {
@@ -95,12 +139,21 @@ function lookupContextFromCache(modelName: string): number | null {
 
 /**
  * Get the context length for the current profile's default model.
- * Results are cached in memory (5min TTL) and invalidated by file mtime.
+ * Resolution order:
+ *   1. models_dev_cache.json (existing behavior)
+ *   2. config.yaml model.context_length (matches hermes-agent priority)
+ *   3. DEFAULT_CONTEXT_LENGTH (200K hardcoded fallback)
  */
 export function getModelContextLength(profile?: string): number {
   const profileDir = getProfileDir(profile)
-  const model = getDefaultModel(profileDir)
+  const model = getDefaultModelRobust(profileDir) || getDefaultModel(profileDir)
   if (!model) return DEFAULT_CONTEXT_LENGTH
 
-  return lookupContextFromCache(model) || DEFAULT_CONTEXT_LENGTH
+  const cached = lookupContextFromCache(model)
+  if (cached) return cached
+
+  const configCtx = getConfigContextLength(profileDir)
+  if (configCtx && configCtx > 0) return configCtx
+
+  return DEFAULT_CONTEXT_LENGTH
 }


### PR DESCRIPTION
## Summary

Fixes two bugs causing `/api/hermes/sessions/context-length` to always return `DEFAULT_CONTEXT_LENGTH` (200K) instead of the actual model context length. Closes #169

## Bug 1: `getModelContextLength` ignores `config.yaml` context_length

The function only checks `models_dev_cache.json` (which doesn't exist in default installations) and falls back to the hardcoded 200K default, completely ignoring the user's explicit `model.context_length` setting in `config.yaml`.

This is inconsistent with hermes-agent, where `config.yaml`'s `model.context_length` is the highest-priority override (resolution step 0 in a 9-level chain).

## Bug 2: `getDefaultModel` regex fails when `api_key`/`base_url` come before `default`

The regex assumes `default` is the first child key under `model:`:

```javascript
const match = content.match(/^model:\s*\n\s+default:\s*(.+)$/m)
```

This fails when other fields appear before `default` in config.yaml:

```yaml
model:
  api_key: '1'
  base_url: http://192.168.199.66:18080/v1
  default: Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled.Q4_K_M
  context_length: 64000
```

When `getDefaultModel` returns `null`, `getModelContextLength` short-circuits to `DEFAULT_CONTEXT_LENGTH` (200K) **before even reaching the cache lookup or config fallback**. This means Bug 2 alone is sufficient to cause the 200K issue.

## Changes

1. **`getDefaultModelRobust()`** — extracts the entire `model:` block first, then searches for `default:` within it. Used as primary model name extractor, with the original `getDefaultModel` as fallback.

2. **`getConfigContextLength()`** — reads `model.context_length` from `config.yaml` as a fallback when `models_dev_cache.json` is unavailable or doesn't contain the model.

3. **Updated `getModelContextLength()`** — new resolution order:
   - `models_dev_cache.json` (existing behavior)
   - `config.yaml` `model.context_length` (new — matches hermes-agent priority)
   - `DEFAULT_CONTEXT_LENGTH` (existing fallback)

## Verified Result

```
Before fix: GET /api/hermes/sessions/context-length → {"context_length": 200000}
After fix:  GET /api/hermes/sessions/context-length → {"context_length": 64000}
```

## Files Changed

- `packages/server/src/services/hermes/model-context.ts` (+56/-3)
