### PR TITLE
refactor: replace jobs proxy with local controller and optimize model loading

### DIFF
--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -66,7 +66,7 @@ function openChangelog() {
     <div class="sidebar-logo" @click="router.push('/hermes/chat')">
       <img :src="logoPath" alt="Hermes" class="logo-img" />
       <span class="logo-text">Hermes</span>
-      <video class="logo-dance" :src="isDark ? danceVideoDark : danceVideoLight" autoplay loop muted playsinline />
+      <!-- <video class="logo-dance" :src="isDark ? danceVideoDark : danceVideoLight" autoplay loop muted playsinline /> -->
     </div>
 
     <nav class="sidebar-nav">

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -9,14 +9,9 @@ import ProfileSelector from "./ProfileSelector.vue";
 import LanguageSwitch from "./LanguageSwitch.vue";
 import ThemeSwitch from "./ThemeSwitch.vue";
 import { useSessionSearch } from '@/composables/useSessionSearch'
-import danceVideoLight from "@/assets/dance-light.mp4";
-import danceVideoDark from "@/assets/dance-dark.mp4";
-
-import { useTheme } from "@/composables/useTheme";
 import { changelog } from "@/data/changelog";
 
 const { t } = useI18n();
-const { isDark } = useTheme();
 const message = useMessage();
 const route = useRoute();
 const router = useRouter();

--- a/packages/client/src/stores/hermes/app.ts
+++ b/packages/client/src/stores/hermes/app.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { checkHealth, fetchAvailableModels, updateDefaultModel, triggerUpdate, type AvailableModelGroup } from '@/api/hermes/system'
+import { checkHealth, fetchConfigModels, updateDefaultModel, triggerUpdate, type AvailableModelGroup } from '@/api/hermes/system'
 
 const WEB_UI_VERSION = __APP_VERSION__
 
@@ -57,10 +57,10 @@ export const useAppStore = defineStore('app', () => {
 
   async function loadModels() {
     try {
-      const res = await fetchAvailableModels()
+      const res = await fetchConfigModels()
       modelGroups.value = res.groups
       selectedModel.value = res.default
-      selectedProvider.value = res.default_provider || ''
+      selectedProvider.value = ''
     } catch {
       // ignore
     }

--- a/packages/client/src/stores/hermes/app.ts
+++ b/packages/client/src/stores/hermes/app.ts
@@ -58,7 +58,13 @@ export const useAppStore = defineStore('app', () => {
   async function loadModels() {
     try {
       const res = await fetchConfigModels()
-      modelGroups.value = res.groups
+      modelGroups.value = res.groups.map(g => ({
+        provider: g.provider,
+        label: g.provider,
+        base_url: '',
+        models: g.models.map(m => typeof m === 'string' ? m : m.id),
+        api_key: '',
+      }))
       selectedModel.value = res.default
       selectedProvider.value = ''
     } catch {

--- a/packages/server/src/controllers/hermes/jobs.ts
+++ b/packages/server/src/controllers/hermes/jobs.ts
@@ -1,0 +1,90 @@
+import type { Context } from 'koa'
+import { getGatewayManagerInstance } from '../../services/gateway-bootstrap'
+import { config } from '../../config'
+
+function getUpstream(profile: string): string {
+  const mgr = getGatewayManagerInstance()
+  return mgr ? mgr.getUpstream(profile) : config.upstream.replace(/\/$/, '')
+}
+
+function getApiKey(profile: string): string | null {
+  const mgr = getGatewayManagerInstance()
+  return mgr?.getApiKey(profile) ?? null
+}
+
+function resolveProfile(ctx: Context): string {
+  return ctx.get('x-hermes-profile') || (ctx.query.profile as string) || 'default'
+}
+
+function buildHeaders(profile: string): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  const apiKey = getApiKey(profile)
+  if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`
+  return headers
+}
+
+const TIMEOUT_MS = 30_000
+
+async function proxyRequest(ctx: Context, upstreamPath: string, method?: string): Promise<void> {
+  const profile = resolveProfile(ctx)
+  const upstream = getUpstream(profile)
+  const params = new URLSearchParams(ctx.search || '')
+  params.delete('token')
+  const search = params.toString()
+  const url = `${upstream}${upstreamPath}${search ? `?${search}` : ''}`
+
+  const headers = buildHeaders(profile)
+  const body = ctx.req.method !== 'GET' && ctx.req.method !== 'HEAD'
+    ? JSON.stringify(ctx.request.body || {})
+    : undefined
+
+  const res = await fetch(url, {
+    method: method || ctx.req.method,
+    headers,
+    body,
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  })
+
+  if (!res.ok) {
+    ctx.status = 502
+    ctx.set('Content-Type', 'application/json')
+    ctx.body = { error: { message: `Upstream error: ${res.status} ${res.statusText}` } }
+    return
+  }
+
+  ctx.status = res.status
+  ctx.set('Content-Type', res.headers.get('content-type') || 'application/json')
+  ctx.body = await res.json()
+}
+
+export async function list(ctx: Context) {
+  await proxyRequest(ctx, '/api/jobs')
+}
+
+export async function get(ctx: Context) {
+  await proxyRequest(ctx, `/api/jobs/${ctx.params.id}`)
+}
+
+export async function create(ctx: Context) {
+  await proxyRequest(ctx, '/api/jobs')
+}
+
+export async function update(ctx: Context) {
+  await proxyRequest(ctx, `/api/jobs/${ctx.params.id}`)
+}
+
+export async function remove(ctx: Context) {
+  await proxyRequest(ctx, `/api/jobs/${ctx.params.id}`)
+}
+
+export async function pause(ctx: Context) {
+  await proxyRequest(ctx, `/api/jobs/${ctx.params.id}/pause`)
+}
+
+export async function resume(ctx: Context) {
+  await proxyRequest(ctx, `/api/jobs/${ctx.params.id}/resume`)
+}
+
+export async function run(ctx: Context) {
+  await proxyRequest(ctx, `/api/jobs/${ctx.params.id}/run`)
+}

--- a/packages/server/src/routes/hermes/jobs.ts
+++ b/packages/server/src/routes/hermes/jobs.ts
@@ -1,0 +1,13 @@
+import Router from '@koa/router'
+import * as ctrl from '../../controllers/hermes/jobs'
+
+export const jobRoutes = new Router()
+
+jobRoutes.get('/api/hermes/jobs', ctrl.list)
+jobRoutes.get('/api/hermes/jobs/:id', ctrl.get)
+jobRoutes.post('/api/hermes/jobs', ctrl.create)
+jobRoutes.patch('/api/hermes/jobs/:id', ctrl.update)
+jobRoutes.delete('/api/hermes/jobs/:id', ctrl.remove)
+jobRoutes.post('/api/hermes/jobs/:id/pause', ctrl.pause)
+jobRoutes.post('/api/hermes/jobs/:id/resume', ctrl.resume)
+jobRoutes.post('/api/hermes/jobs/:id/run', ctrl.run)

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -22,6 +22,7 @@ import { gatewayRoutes } from './hermes/gateways'
 import { weixinRoutes } from './hermes/weixin'
 import { fileRoutes } from './hermes/files'
 import { downloadRoutes } from './hermes/download'
+import { jobRoutes } from './hermes/jobs'
 import { proxyRoutes, proxyMiddleware } from './hermes/proxy'
 
 /**
@@ -56,6 +57,7 @@ export function registerRoutes(app: any, requireAuth: (ctx: Context, next: Next)
   app.use(weixinRoutes.routes())
   app.use(fileRoutes.routes())              // Must be before proxy (proxy catch-all matches everything)
   app.use(downloadRoutes.routes())          // Must be before proxy
+  app.use(jobRoutes.routes())               // Must be before proxy
   app.use(proxyRoutes.routes())
 
   // Proxy catch-all middleware (must be last)


### PR DESCRIPTION
## Summary

- **Jobs 本地 controller**: 新增 `controllers/hermes/jobs.ts`，直接 fetch 上游 gateway，支持 profile 区分（upstream URL + API key），30s 超时，上游错误返回 502。替代不可靠的反代 catch-all
- **模型加载优化**: `loadModels()` 从 `fetchAvailableModels`（遍历所有 provider API 拉模型列表，慢）改为 `fetchConfigModels`（只读 config.yaml，秒返回）
- **隐藏 sidebar logo 视频**: 注释掉 dance video

## 改动文件

| 文件 | 说明 |
|------|------|
| `packages/server/src/controllers/hermes/jobs.ts` | 新建 - jobs 本地 controller |
| `packages/server/src/routes/hermes/jobs.ts` | 新建 - jobs 路由注册 |
| `packages/server/src/routes/index.ts` | 在 proxy catch-all 前注册 jobRoutes |
| `packages/client/src/stores/hermes/app.ts` | loadModels 改用 fetchConfigModels |
| `packages/client/src/components/layout/AppSidebar.vue` | 隐藏 logo dance video |

## Test plan

- [ ] Jobs 页面加载正常，任务列表显示
- [ ] 暂停/恢复/立即执行/删除操作正常
- [ ] 切换 profile 后 jobs 请求走对应 upstream
- [ ] App 启动时模型加载不再卡顿
- [ ] Models 设置页面仍能按需加载完整模型列表

🤖 Generated with [Claude Code](https://claude.com/claude-code)