### PR TITLE
fix: add gpt-5.5 to OpenAI Codex model list

### DIFF
--- a/packages/client/src/shared/providers.ts
+++ b/packages/client/src/shared/providers.ts
@@ -225,7 +225,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     label: 'OpenAI Codex',
     value: 'openai-codex',
     base_url: 'https://chatgpt.com/backend-api/codex',
-    models: ['gpt-5.4-mini', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.1-codex-max', 'gpt-5.1-codex-mini'],
+    models: ['gpt-5.5', 'gpt-5.4-mini', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.1-codex-max', 'gpt-5.1-codex-mini'],
   },
   {
     label: 'Arcee AI',

--- a/packages/server/src/shared/providers.ts
+++ b/packages/server/src/shared/providers.ts
@@ -240,7 +240,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     value: 'openai-codex',
     builtin: true,
     base_url: 'https://chatgpt.com/backend-api/codex',
-    models: ['gpt-5.4-mini', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.1-codex-max', 'gpt-5.1-codex-mini'],
+    models: ['gpt-5.5', 'gpt-5.4-mini', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.1-codex-max', 'gpt-5.1-codex-mini'],
   },
   {
     label: 'Arcee AI',

--- a/tests/shared/provider-presets.test.ts
+++ b/tests/shared/provider-presets.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  PROVIDER_PRESETS as SERVER_PROVIDER_PRESETS,
+  buildProviderModelMap as buildServerProviderModelMap,
+} from '../../packages/server/src/shared/providers'
+import {
+  PROVIDER_PRESETS as CLIENT_PROVIDER_PRESETS,
+  buildProviderModelMap as buildClientProviderModelMap,
+} from '../../packages/client/src/shared/providers'
+
+const OPENAI_CODEX_PROVIDER = 'openai-codex'
+const GPT_5_5_MODEL = 'gpt-5.5'
+
+function modelsForProvider(providerPresets: Array<{ value: string; models: string[] }>, provider: string): string[] {
+  const preset = providerPresets.find((candidate) => candidate.value === provider)
+  expect(preset).toBeDefined()
+  return preset?.models ?? []
+}
+
+describe('provider presets', () => {
+  it('lists GPT-5.5 for OpenAI Codex on both client and server', () => {
+    expect(modelsForProvider(CLIENT_PROVIDER_PRESETS, OPENAI_CODEX_PROVIDER)).toContain(GPT_5_5_MODEL)
+    expect(modelsForProvider(SERVER_PROVIDER_PRESETS, OPENAI_CODEX_PROVIDER)).toContain(GPT_5_5_MODEL)
+  })
+
+  it('exposes GPT-5.5 through provider model maps', () => {
+    expect(buildClientProviderModelMap()[OPENAI_CODEX_PROVIDER]).toContain(GPT_5_5_MODEL)
+    expect(buildServerProviderModelMap()[OPENAI_CODEX_PROVIDER]).toContain(GPT_5_5_MODEL)
+  })
+})


### PR DESCRIPTION
## 摘要
- 在 client/server 两份 OpenAI Codex provider preset 里补上 `gpt-5.5`。
- 增加共享 provider preset 回归测试，覆盖 preset 本身和 `buildProviderModelMap()` 输出。

## 原因
当前配置默认值可以是 `openai-codex/gpt-5.5`，但 `/api/hermes/available-models` 和前端模型选择器使用的静态 provider catalog 没有列出 `gpt-5.5`，导致默认模型存在但列表不可选。

## 验证
- ✅ `npm test -- tests/shared/provider-presets.test.ts`
- ✅ `npm run build`
- ⚠️ `npm test` 仍有现有基线失败；我在暂存本次改动后复跑过干净基线，失败项一致，和这次 catalog 改动无关：
  - `tests/server/sessions-db.test.ts` 的 numeric query error 断言
  - `tests/client/markdown-rendering.test.ts` / `tests/client/message-item-highlight.test.ts` 缺少 Naive UI message provider

## Review
- 已跑独立代码 review：通过；无 blocker/major/nit。