### PR TITLE
fix: getApiKey reads config.yaml + correct port/host from config upstream

### DIFF
--- a/packages/server/src/routes/hermes/proxy-handler.ts
+++ b/packages/server/src/routes/hermes/proxy-handler.ts
@@ -72,7 +72,7 @@ function buildProxyHeaders(ctx: Context, upstream: string): Record<string, strin
     const lower = key.toLowerCase()
     if (lower === 'host') {
       headers['host'] = new URL(upstream).host
-    } else if (lower === 'origin' || lower === 'referer' || lower === 'connection') {
+    } else if (lower === 'origin' || lower === 'referer' || lower === 'connection' || lower === 'authorization') {
       continue
     } else {
       const v = Array.isArray(value) ? value[0] : value

--- a/packages/server/src/routes/hermes/proxy-handler.ts
+++ b/packages/server/src/routes/hermes/proxy-handler.ts
@@ -72,7 +72,7 @@ function buildProxyHeaders(ctx: Context, upstream: string): Record<string, strin
     const lower = key.toLowerCase()
     if (lower === 'host') {
       headers['host'] = new URL(upstream).host
-    } else if (lower === 'origin' || lower === 'referer' || lower === 'connection' || lower === 'authorization') {
+    } else if (lower === 'origin' || lower === 'referer' || lower === 'connection') {
       continue
     } else {
       const v = Array.isArray(value) ? value[0] : value

--- a/packages/server/src/services/hermes/gateway-manager.ts
+++ b/packages/server/src/services/hermes/gateway-manager.ts
@@ -591,11 +591,21 @@ export class GatewayManager {
     }
 
     // Phase 2: 并行启动
+    const { config } = await import('../../config')
     const tasks = toStart.map(async (name) => {
       try {
         await this.start(name)
       } catch (err: any) {
         logger.error(err, '%s: failed to start', name)
+        // 嵌入式网关启动失败时，如果 config.upstream 指向的网关已经健康，
+        // 直接注册它作为该 profile 的上游（支持外部网关模式）
+        const { port, host } = this.readProfilePort(name)
+        const configUpstream = config.upstream.replace(/\/$/, '')
+        const healthOk = await this.checkHealth(configUpstream, 2000)
+        if (healthOk) {
+          logger.info('%s: embedded gateway failed, using config upstream %s', name, configUpstream)
+          this.gateways.set(name, { port, host, url: configUpstream })
+        }
       }
     })
 

--- a/packages/server/src/services/hermes/gateway-manager.ts
+++ b/packages/server/src/services/hermes/gateway-manager.ts
@@ -314,15 +314,25 @@ export class GatewayManager {
     return `http://${host}:${port}`
   }
 
-  /** 读取 profile 的 API_SERVER_KEY（从 .env 文件） */
+  /** 读取 profile 的 API_SERVER_KEY（优先 .env，回退到 config.yaml） */
   getApiKey(profileName?: string): string | null {
     const name = profileName || this.activeProfile
     try {
+      // 优先从 .env 读取
       const envPath = join(this.profileDir(name), '.env')
-      if (!existsSync(envPath)) return null
-      const content = readFileSync(envPath, 'utf-8')
-      const match = content.match(/^API_SERVER_KEY\s*=\s*"?([^"\n]+)"?/m)
-      return match?.[1]?.trim() || null
+      if (existsSync(envPath)) {
+        const content = readFileSync(envPath, 'utf-8')
+        const match = content.match(/^API_SERVER_KEY\s*=\s*"?([^"\n]+)"?/m)
+        if (match?.[1]?.trim()) return match[1].trim()
+      }
+      // 回退到 config.yaml 的 platforms.api_server.key
+      const configPath = join(this.profileDir(name), 'config.yaml')
+      if (existsSync(configPath)) {
+        const cfg = yaml.load(readFileSync(configPath, 'utf-8')) as any
+        const key = cfg?.platforms?.api_server?.key
+        if (key) return String(key)
+      }
+      return null
     } catch {
       return null
     }
@@ -599,10 +609,12 @@ export class GatewayManager {
         logger.error(err, '%s: failed to start', name)
         // 嵌入式网关启动失败时，如果 config.upstream 指向的网关已经健康，
         // 直接注册它作为该 profile 的上游（支持外部网关模式）
-        const { port, host } = this.readProfilePort(name)
         const configUpstream = config.upstream.replace(/\/$/, '')
         const healthOk = await this.checkHealth(configUpstream, 2000)
         if (healthOk) {
+          const urlObj = new URL(configUpstream)
+          const port = parseInt(urlObj.port) || 8642
+          const host = urlObj.hostname || '127.0.0.1'
           logger.info('%s: embedded gateway failed, using config upstream %s', name, configUpstream)
           this.gateways.set(name, { port, host, url: configUpstream })
         }


### PR DESCRIPTION
## Summary

Two fixes for external Hermes gateway mode in hermes-web-ui:

### Bug 1 — getApiKey() returns null without .env

`mgr.getApiKey()` only read from `.env` files. External gateway mode has no `.env`, so the proxy always sent no auth token (401/502).

**Fix:** `getApiKey()` now falls back to reading `platforms.api_server.key` from `config.yaml`.

### Bug 2 — Embedded gateway failure leaves stale port/host

When the embedded gateway fails to start, the `gateways` map was populated with `port`/`host` from the failed embedded instance (wrong port) but `url` from `config.upstream` (correct). Other code reading `port`/`host` got wrong values.

**Fix:** Parse `port`/`host` from `config.upstream` URL when registering the fallback upstream.

### Note

The original `authorization` header passthrough approach was reverted — the browser sends WebUI token, not the gateway API key. Correct auth is now injected via the improved `getApiKey()`.

## Files changed

- `gateway-manager.ts` — getApiKey() config.yaml fallback + correct upstream port/host parsing
