### PR TITLE
feat(chat): add reasoning trace sidebar with normalized frame sync and i18n support

### DIFF
--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -33,6 +33,34 @@ export interface RunEvent {
     output_tokens: number
     total_tokens: number
   }
+  frame?: AgentFrame
+  trace_id?: string
+  seq?: number
+  payload?: Record<string, any>
+  data?: Record<string, any>
+  type?: string
+  tool_call_id?: string
+  args?: unknown
+  result?: unknown
+  artifact?: Record<string, any>
+}
+
+export type AgentFrameType =
+  | 'THOUGHT'
+  | 'TOOL_CALL'
+  | 'ARTIFACT'
+  | 'RESPONSE'
+  | 'STATUS'
+  | 'ERROR'
+  | 'SUBAGENT'
+  | 'HEARTBEAT'
+  | string
+
+export interface AgentFrame {
+  type: AgentFrameType
+  seq: number
+  trace_id: string
+  payload: Record<string, any>
 }
 
 export async function startRun(body: StartRunRequest): Promise<StartRunResponse> {

--- a/packages/client/src/api/hermes/config.ts
+++ b/packages/client/src/api/hermes/config.ts
@@ -7,6 +7,7 @@ export interface DisplayConfig {
   busy_input_mode?: string
   bell_on_complete?: boolean
   show_reasoning?: boolean
+  show_reasoning_panel?: boolean
   streaming?: boolean
   inline_diffs?: boolean
   show_cost?: boolean

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -3,11 +3,14 @@ import { ref, computed, watch, nextTick } from "vue";
 import { useI18n } from "vue-i18n";
 import MessageItem from "./MessageItem.vue";
 import { useChatStore } from "@/stores/hermes/chat";
+import { useSettingsStore } from "@/stores/hermes/settings";
 import thinkingVideoLight from "@/assets/thinking-light.mp4";
 import thinkingVideoDark from "@/assets/thinking-dark.mp4";
 import { useTheme } from "@/composables/useTheme";
+import ReasoningTrace from "./ReasoningTrace.vue";
 
 const chatStore = useChatStore();
+const settingsStore = useSettingsStore();
 const { t } = useI18n();
 const { isDark } = useTheme();
 const listRef = ref<HTMLElement>();
@@ -30,6 +33,10 @@ const currentToolCalls = computed(() => {
   const tools = msgs.filter((m, i) => m.role === "tool" && i > lastUserIdx);
   return [...tools].reverse();
 });
+
+const showReasoningSidebar = computed(() =>
+  settingsStore.display.show_reasoning_panel ?? true,
+);
 
 function isNearBottom(threshold = 200): boolean {
   const el = listRef.value;
@@ -109,66 +116,83 @@ watch(currentToolCalls, () => {
 </script>
 
 <template>
-  <div ref="listRef" class="message-list">
-    <div v-if="chatStore.messages.length === 0" class="empty-state">
-      <img src="/logo.png" alt="Hermes" class="empty-logo" />
-      <p>{{ t("chat.emptyState") }}</p>
-    </div>
-    <MessageItem
-      v-for="msg in displayMessages"
-      :key="msg.id"
-      :message="msg"
-      :highlight="chatStore.focusMessageId === msg.id"
-    />
-    <Transition name="fade">
-      <div v-if="chatStore.isRunActive" class="streaming-indicator">
-        <video
-          :src="isDark ? thinkingVideoDark : thinkingVideoLight"
-          autoplay
-          loop
-          muted
-          playsinline
-          class="thinking-video"
-        />
-        <div v-if="currentToolCalls.length > 0" class="tool-calls-panel">
-          <div
-            v-for="tc in currentToolCalls"
-            :key="tc.id"
-            class="tool-call-item"
-          >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              class="tool-call-icon"
+  <div class="message-layout">
+    <div ref="listRef" class="message-list">
+      <div v-if="chatStore.messages.length === 0" class="empty-state">
+        <img src="/logo.png" alt="Hermes" class="empty-logo" />
+        <p>{{ t("chat.emptyState") }}</p>
+      </div>
+      <MessageItem
+        v-for="msg in displayMessages"
+        :key="msg.id"
+        :message="msg"
+        :highlight="chatStore.focusMessageId === msg.id"
+      />
+      <Transition name="fade">
+        <div v-if="chatStore.isRunActive" class="streaming-indicator">
+          <video
+            :src="isDark ? thinkingVideoDark : thinkingVideoLight"
+            autoplay
+            loop
+            muted
+            playsinline
+            class="thinking-video"
+          />
+          <div v-if="currentToolCalls.length > 0" class="tool-calls-panel">
+            <div
+              v-for="tc in currentToolCalls"
+              :key="tc.id"
+              class="tool-call-item"
             >
-              <path
-                d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"
-              />
-            </svg>
-            <span class="tool-call-name">{{ tc.toolName }}</span>
-            <span v-if="tc.toolPreview" class="tool-call-preview">{{
-              tc.toolPreview
-            }}</span>
-            <span
-              v-if="tc.toolStatus === 'running'"
-              class="tool-call-spinner"
-            ></span>
-            <span v-if="tc.toolStatus === 'error'" class="tool-call-error">{{
-              t("chat.error")
-            }}</span>
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                class="tool-call-icon"
+              >
+                <path
+                  d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"
+                />
+              </svg>
+              <span class="tool-call-name">{{ tc.toolName }}</span>
+              <span v-if="tc.toolPreview" class="tool-call-preview">{{
+                tc.toolPreview
+              }}</span>
+              <span
+                v-if="tc.toolStatus === 'running'"
+                class="tool-call-spinner"
+              ></span>
+              <span v-if="tc.toolStatus === 'error'" class="tool-call-error">{{
+                t("chat.error")
+              }}</span>
+            </div>
           </div>
         </div>
-      </div>
-    </Transition>
+      </Transition>
+    </div>
+    <ReasoningTrace
+      v-if="showReasoningSidebar"
+      :frames="chatStore.reasoningFrames"
+      :trace-user-inputs="chatStore.traceUserInputs"
+      :tool-messages="chatStore.messages.filter(m => m.role === 'tool')"
+      :active="chatStore.isRunActive"
+      :session-id="chatStore.activeSessionId || undefined"
+    />
   </div>
 </template>
 
 <style scoped lang="scss">
 @use "@/styles/variables" as *;
+
+.message-layout {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+}
 
 .message-list {
   flex: 1;
@@ -181,6 +205,12 @@ watch(currentToolCalls, () => {
 
   .dark & {
     background-color: #333333;
+  }
+}
+
+@media (max-width: $breakpoint-mobile) {
+  .message-layout {
+    flex-direction: column;
   }
 }
 

--- a/packages/client/src/components/hermes/chat/ReasoningTrace.vue
+++ b/packages/client/src/components/hermes/chat/ReasoningTrace.vue
@@ -1,0 +1,867 @@
+<script setup lang="ts">
+import type { AgentFrame } from '@/api/hermes/chat'
+import type { Message } from '@/stores/hermes/chat'
+import { computed, nextTick, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps<{
+  frames: AgentFrame[]
+  traceUserInputs: Record<string, string>
+  toolMessages: Message[]
+  active: boolean
+  sessionId?: string
+}>()
+
+const { t } = useI18n()
+const listRef = ref<HTMLElement | null>(null)
+const isAtBottom = ref(true)
+const scrollTop = ref(0)
+const viewMode = ref<'reasoning' | 'tools'>('reasoning')
+const collapsed = ref(false)
+const hasAutoScrolledForSession = ref(false)
+const cachedScrollTop = ref(0)
+const cachedWasAtBottom = ref(true)
+
+const STICKY_BOTTOM_THRESHOLD_PX = 48
+const VIRTUALIZE_THRESHOLD_FRAMES = 180
+const OVERSCAN_PX = 480
+const CARD_BASE_HEIGHT = 46
+const CARD_VERTICAL_GAP = 8
+
+type TraceGroup = { traceId: string, frames: AgentFrame[] }
+
+function shortTraceId(traceId: string): string {
+  return traceId.length > 28 ? `${traceId.slice(0, 14)}…${traceId.slice(-10)}` : traceId
+}
+
+function frameTypeLabel(type: string): string {
+  if (type === 'TOOL_CALL') return 'TOOL_CALL'
+  if (type === 'THOUGHT') return 'THOUGHT'
+  if (type === 'ARTIFACT') return 'ARTIFACT'
+  return type
+}
+
+function mergeStreamingFrames(frames: AgentFrame[]): AgentFrame[] {
+  const merged: AgentFrame[] = []
+  for (const frame of frames) {
+    const prev = merged[merged.length - 1]
+    const canMergeThought =
+      frame.type === 'THOUGHT'
+      && prev?.type === 'THOUGHT'
+      && frame.trace_id === prev.trace_id
+      && (frame.payload?.source ?? 'reasoning') === (prev.payload?.source ?? 'reasoning')
+    const canMergeResponseDelta =
+      frame.type === 'RESPONSE'
+      && prev?.type === 'RESPONSE'
+      && frame.trace_id === prev.trace_id
+      && !Boolean(frame.payload?.final)
+      && !Boolean(prev.payload?.final)
+      && frame.payload?.role === prev.payload?.role
+
+    if (canMergeThought || canMergeResponseDelta) {
+      merged[merged.length - 1] = {
+        ...prev,
+        payload: {
+          ...prev.payload,
+          content: `${String(prev.payload?.content ?? '')}${String(frame.payload?.content ?? '')}`,
+        },
+      }
+      continue
+    }
+    merged.push(frame)
+  }
+  return merged
+}
+
+function groupDisplayFramesByTraceId(frames: AgentFrame[]): TraceGroup[] {
+  const map = new Map<string, AgentFrame[]>()
+  const order: string[] = []
+  for (const frame of frames) {
+    if (!map.has(frame.trace_id)) {
+      map.set(frame.trace_id, [])
+      order.push(frame.trace_id)
+    }
+    map.get(frame.trace_id)!.push(frame)
+  }
+  return order.map(traceId => ({ traceId, frames: map.get(traceId)! }))
+}
+
+function estimateCardHeight(frame: AgentFrame): number {
+  const payloadStr = JSON.stringify(frame.payload, null, 2)
+  const lineCount = payloadStr.split('\n').length
+  return CARD_BASE_HEIGHT + lineCount * 18 + CARD_VERTICAL_GAP
+}
+
+function toPrettyJson(value: unknown): string {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if ((trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']'))) {
+      try {
+        return JSON.stringify(JSON.parse(trimmed), null, 2)
+      } catch {
+        return value
+      }
+    }
+    return value
+  }
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+const displayFrames = computed(() =>
+  mergeStreamingFrames(
+    props.frames.filter(frame =>
+      frame.type === 'THOUGHT' || frame.type === 'TOOL_CALL' || frame.type === 'ARTIFACT',
+    ),
+  ),
+)
+
+const dedupedDisplayFrames = computed(() => {
+  const frames = displayFrames.value
+  // If a TOOL_CALL with same trace_id + tool_call_id later has non-null result,
+  // hide the earlier placeholder card whose result is null.
+  return frames.filter((frame, index) => {
+    if (frame.type !== 'TOOL_CALL') return true
+    const toolCallId = String(frame.payload?.tool_call_id || '')
+    if (!toolCallId) return true
+    const result = frame.payload?.result
+    if (result != null) return true
+    const hasLaterCompleted = frames.slice(index + 1).some(next =>
+      next.type === 'TOOL_CALL'
+      && next.trace_id === frame.trace_id
+      && String(next.payload?.tool_call_id || '') === toolCallId
+      && next.payload?.result != null,
+    )
+    return !hasLaterCompleted
+  })
+})
+
+const groupedFrames = computed(() => groupDisplayFramesByTraceId(dedupedDisplayFrames.value))
+const shouldVirtualize = computed(() => dedupedDisplayFrames.value.length >= VIRTUALIZE_THRESHOLD_FRAMES)
+const toolLogs = computed(() => [...props.toolMessages].reverse())
+
+const estimatedHeights = computed(() => dedupedDisplayFrames.value.map(frame => estimateCardHeight(frame)))
+const offsets = computed(() => {
+  const list: number[] = new Array(dedupedDisplayFrames.value.length)
+  let acc = 0
+  for (let i = 0; i < dedupedDisplayFrames.value.length; i += 1) {
+    list[i] = acc
+    acc += estimatedHeights.value[i] ?? 0
+  }
+  return { list, total: acc }
+})
+
+const visibleRange = computed(() => {
+  if (!shouldVirtualize.value) return { start: 0, end: dedupedDisplayFrames.value.length }
+  const viewportHeight = listRef.value?.clientHeight ?? 0
+  const top = Math.max(0, scrollTop.value - OVERSCAN_PX)
+  const bottom = scrollTop.value + viewportHeight + OVERSCAN_PX
+  let start = 0
+  let end = dedupedDisplayFrames.value.length
+
+  for (let i = 0; i < offsets.value.list.length; i += 1) {
+    const itemTop = offsets.value.list[i]
+    const itemBottom = itemTop + (estimatedHeights.value[i] ?? 0)
+    if (itemBottom >= top) {
+      start = i
+      break
+    }
+  }
+  for (let i = start; i < offsets.value.list.length; i += 1) {
+    const itemTop = offsets.value.list[i]
+    if (itemTop > bottom) {
+      end = i
+      break
+    }
+  }
+  return { start, end }
+})
+
+function onScroll() {
+  const el = listRef.value
+  if (!el) return
+  scrollTop.value = el.scrollTop
+  const remaining = el.scrollHeight - (el.scrollTop + el.clientHeight)
+  isAtBottom.value = remaining <= STICKY_BOTTOM_THRESHOLD_PX
+}
+
+function scrollToBottom(behavior: ScrollBehavior = 'auto') {
+  nextTick(() => {
+    const el = listRef.value
+    if (!el) return
+    el.scrollTo({ top: el.scrollHeight, behavior })
+  })
+}
+
+function handleToggleCollapsed() {
+  const el = listRef.value
+  if (!collapsed.value) {
+    cachedScrollTop.value = el?.scrollTop ?? scrollTop.value
+    cachedWasAtBottom.value = isAtBottom.value
+    collapsed.value = true
+    return
+  }
+
+  collapsed.value = false
+  nextTick(() => {
+    const nextEl = listRef.value
+    if (!nextEl) return
+    if (cachedWasAtBottom.value) {
+      nextEl.scrollTo({ top: nextEl.scrollHeight, behavior: 'auto' })
+      scrollTop.value = nextEl.scrollTop
+      isAtBottom.value = true
+      return
+    }
+    nextEl.scrollTo({ top: Math.max(0, cachedScrollTop.value), behavior: 'auto' })
+    onScroll()
+  })
+}
+
+watch(() => props.frames.length, () => {
+  if (props.active && isAtBottom.value) scrollToBottom()
+})
+
+watch(
+  () => props.sessionId,
+  () => {
+    hasAutoScrolledForSession.value = false
+    isAtBottom.value = true
+    scrollTop.value = 0
+    scrollToBottom()
+  },
+  { immediate: true },
+)
+
+watch(
+  () => dedupedDisplayFrames.value.length,
+  (len) => {
+    if (len <= 0) return
+    if (hasAutoScrolledForSession.value) return
+    hasAutoScrolledForSession.value = true
+    isAtBottom.value = true
+    scrollToBottom()
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <aside class="reasoning-trace" :class="{ collapsed }">
+    <button
+      type="button"
+      class="reasoning-trace__toggle-handle"
+      :title="collapsed ? t('chat.reasoningTitle') : t('common.collapse')"
+      :data-tip="collapsed ? `展开${t('chat.reasoningTitle')}` : t('common.collapse')"
+      :aria-label="collapsed ? t('common.expand') : t('common.collapse')"
+      @click="handleToggleCollapsed"
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        aria-hidden="true"
+      >
+        <path v-if="collapsed" d="M15 6l-6 6 6 6" />
+        <path v-else d="M9 6l6 6-6 6" />
+      </svg>
+    </button>
+
+    <header v-if="!collapsed" class="reasoning-trace__header">
+      <span v-if="!collapsed">{{ t('chat.reasoningTitle') }}</span>
+      <div class="reasoning-trace__tabs">
+        <template v-if="!collapsed">
+          <button
+          type="button"
+          class="reasoning-trace__tab"
+          :class="{ active: viewMode === 'reasoning' }"
+          @click="viewMode = 'reasoning'"
+        >
+          {{ t('chat.reasoningTitle') }}
+          </button>
+          <button
+          type="button"
+          class="reasoning-trace__tab"
+          :class="{ active: viewMode === 'tools' }"
+          @click="viewMode = 'tools'"
+        >
+          {{ t('chat.tool') }}
+          </button>
+        </template>
+      </div>
+    </header>
+    <div v-if="!collapsed" ref="listRef" class="reasoning-trace__body" @scroll="onScroll">
+      <div v-if="viewMode === 'reasoning' && groupedFrames.length === 0" class="reasoning-trace__empty">
+        {{ t('chat.reasoningTraceEmpty') }}
+      </div>
+
+      <template v-else-if="viewMode === 'reasoning' && !shouldVirtualize">
+        <section
+          v-for="(group, index) in groupedFrames"
+          :key="group.traceId"
+          class="reasoning-turn"
+        >
+          <div class="reasoning-turn__meta">
+            <span class="reasoning-turn__badge">{{ t('chat.reasoningTraceRound', { n: index + 1 }) }}</span>
+            <span v-if="index === groupedFrames.length - 1" class="reasoning-turn__latest">{{ t('chat.reasoningTraceLatest') }}</span>
+            <span class="reasoning-turn__trace-id" :title="group.traceId">{{ shortTraceId(group.traceId) }}</span>
+          </div>
+          <p class="reasoning-turn__label">{{ t('chat.reasoningTraceTriggeredBy') }}</p>
+          <div class="reasoning-turn__user-shell">
+            <svg class="reasoning-turn__user-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+            </svg>
+            <div class="reasoning-turn__user">
+              {{ traceUserInputs[group.traceId] || t('chat.reasoningTraceNoUserMatch') }}
+            </div>
+          </div>
+
+          <article
+            v-for="frame in group.frames"
+            :key="`${frame.trace_id}-${frame.seq}`"
+            class="trace-card"
+            :class="`trace-card--${frame.type.toLowerCase()}`"
+          >
+            <div class="trace-card__header">
+              <svg v-if="frame.type === 'TOOL_CALL'" class="trace-card__tool-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+                <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+              </svg>
+              <span class="trace-card__type">{{ frameTypeLabel(frame.type) }}</span>
+              <span class="trace-card__seq">#{{ frame.seq }}</span>
+            </div>
+            <template v-if="frame.type === 'THOUGHT'">
+              <div class="trace-card__source">
+                source: {{ String(frame.payload?.source ?? 'reasoning') }}
+              </div>
+              <div class="trace-card__content">{{ String(frame.payload?.content ?? '') }}</div>
+            </template>
+            <template v-else-if="frame.type === 'TOOL_CALL'">
+              <div class="trace-card__tool">
+                <span class="trace-card__tool-name">{{ String(frame.payload?.name ?? 'tool') }}</span>
+                <span class="trace-card__tool-id">{{ String(frame.payload?.tool_call_id ?? '—') }}</span>
+              </div>
+              <div class="trace-card__section">{{ t('chat.arguments') }}</div>
+              <pre class="trace-card__code">{{ toPrettyJson(frame.payload?.args ?? {}) }}</pre>
+              <div class="trace-card__section">{{ t('chat.result') }}</div>
+              <pre class="trace-card__code">{{ toPrettyJson(frame.payload?.result ?? null) }}</pre>
+            </template>
+            <template v-else-if="frame.type === 'ARTIFACT'">
+              <div class="trace-card__artifact-grid">
+                <span>artifact_id</span><span>{{ String(frame.payload?.artifact_id ?? '—') }}</span>
+                <span>source_tool</span><span>{{ String(frame.payload?.source_tool ?? '—') }}</span>
+                <span>artifact_type</span><span>{{ String(frame.payload?.artifact_type ?? '—') }}</span>
+                <span>mime</span><span>{{ String(frame.payload?.mime ?? '—') }}</span>
+              </div>
+              <pre class="trace-card__code">{{ toPrettyJson(frame.payload ?? {}) }}</pre>
+            </template>
+          </article>
+        </section>
+      </template>
+
+      <template v-else-if="viewMode === 'reasoning'">
+        <div :style="{ height: `${offsets.list[visibleRange.start] ?? 0}px` }"></div>
+        <article
+          v-for="frame in dedupedDisplayFrames.slice(visibleRange.start, visibleRange.end)"
+          :key="`${frame.trace_id}-${frame.seq}`"
+          class="trace-card"
+          :class="`trace-card--${frame.type.toLowerCase()}`"
+        >
+          <div class="trace-card__header">
+            <svg v-if="frame.type === 'TOOL_CALL'" class="trace-card__tool-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+              <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+            </svg>
+            <span class="trace-card__type">{{ frameTypeLabel(frame.type) }}</span>
+            <span class="trace-card__seq">#{{ frame.seq }}</span>
+          </div>
+          <template v-if="frame.type === 'THOUGHT'">
+            <div class="trace-card__source">
+              source: {{ String(frame.payload?.source ?? 'reasoning') }}
+            </div>
+            <div class="trace-card__content">{{ String(frame.payload?.content ?? '') }}</div>
+          </template>
+          <template v-else-if="frame.type === 'TOOL_CALL'">
+            <div class="trace-card__tool">
+              <span class="trace-card__tool-name">{{ String(frame.payload?.name ?? 'tool') }}</span>
+              <span class="trace-card__tool-id">{{ String(frame.payload?.tool_call_id ?? '—') }}</span>
+            </div>
+            <div class="trace-card__section">{{ t('chat.arguments') }}</div>
+            <pre class="trace-card__code">{{ toPrettyJson(frame.payload?.args ?? {}) }}</pre>
+            <div class="trace-card__section">{{ t('chat.result') }}</div>
+            <pre class="trace-card__code">{{ toPrettyJson(frame.payload?.result ?? null) }}</pre>
+          </template>
+          <template v-else-if="frame.type === 'ARTIFACT'">
+            <div class="trace-card__artifact-grid">
+              <span>artifact_id</span><span>{{ String(frame.payload?.artifact_id ?? '—') }}</span>
+              <span>source_tool</span><span>{{ String(frame.payload?.source_tool ?? '—') }}</span>
+              <span>artifact_type</span><span>{{ String(frame.payload?.artifact_type ?? '—') }}</span>
+              <span>mime</span><span>{{ String(frame.payload?.mime ?? '—') }}</span>
+            </div>
+            <pre class="trace-card__code">{{ toPrettyJson(frame.payload ?? {}) }}</pre>
+          </template>
+        </article>
+        <div
+          :style="{
+            height: `${Math.max(0, offsets.total - (offsets.list[visibleRange.end] ?? offsets.total))}px`,
+          }"
+        ></div>
+      </template>
+
+      <template v-else>
+        <div v-if="toolLogs.length === 0" class="reasoning-trace__empty">
+          {{ t('chat.noData') }}
+        </div>
+        <section v-for="tool in toolLogs" :key="tool.id" class="tool-log-card">
+          <div class="tool-log-card__head">
+            <span class="tool-log-card__name">{{ tool.toolName || 'tool' }}</span>
+            <span class="tool-log-card__status" :class="`status-${tool.toolStatus || 'done'}`">
+              {{ tool.toolStatus || 'done' }}
+            </span>
+          </div>
+          <div v-if="tool.toolPreview" class="tool-log-card__preview">{{ tool.toolPreview }}</div>
+          <div class="trace-card__section">{{ t('chat.arguments') }}</div>
+          <pre class="trace-card__code">{{ toPrettyJson(tool.toolArgs || '{}') }}</pre>
+          <div class="trace-card__section">{{ t('chat.result') }}</div>
+          <pre class="trace-card__code">{{ toPrettyJson(tool.toolResult || 'null') }}</pre>
+        </section>
+      </template>
+    </div>
+
+    <button
+      v-if="!collapsed && !isAtBottom"
+      class="reasoning-trace__to-bottom"
+      type="button"
+      title="Scroll to bottom"
+      aria-label="Scroll to bottom"
+      @click="scrollToBottom('smooth')"
+    >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" aria-hidden="true">
+        <path d="M6 9l6 6 6-6" />
+      </svg>
+    </button>
+  </aside>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/variables' as *;
+
+.reasoning-trace {
+  width: 340px;
+  min-width: 280px;
+  border-left: 1px solid $border-color;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  transition: width $transition-fast, min-width $transition-fast;
+}
+
+.reasoning-trace.collapsed {
+  width: 0;
+  min-width: 0;
+  border-left: 0;
+  overflow: visible;
+}
+
+.reasoning-trace__toggle-handle {
+  position: absolute;
+  left: -13px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 26px;
+  height: 44px;
+  border: 1px solid rgba(var(--text-primary-rgb), 0.18);
+  border-radius: 999px;
+  background: $bg-card;
+  color: $text-muted;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 20;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+  transition: all $transition-fast;
+}
+
+.reasoning-trace.collapsed .reasoning-trace__toggle-handle {
+  left: -18px;
+}
+
+.reasoning-trace.collapsed .reasoning-trace__toggle-handle::after {
+  content: attr(data-tip);
+  position: absolute;
+  left: -8px;
+  top: 50%;
+  transform: translate(-100%, -50%);
+  white-space: nowrap;
+  font-size: 11px;
+  line-height: 1;
+  color: $text-primary;
+  background: $bg-card;
+  border: 1px solid rgba(var(--text-primary-rgb), 0.18);
+  border-radius: 999px;
+  padding: 6px 10px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity $transition-fast, transform $transition-fast;
+}
+
+.reasoning-trace.collapsed .reasoning-trace__toggle-handle:hover::after {
+  opacity: 1;
+  transform: translate(calc(-100% - 6px), -50%);
+}
+
+.reasoning-trace__toggle-handle:hover {
+  color: $text-primary;
+  border-color: rgba(var(--text-primary-rgb), 0.3);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.14);
+}
+
+.reasoning-trace__header {
+  padding: 10px 10px 9px;
+  border-bottom: 1px solid $border-color;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: $text-primary;
+  background: rgba(var(--text-primary-rgb), 0.02);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 40px;
+}
+
+.reasoning-trace__tabs {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.reasoning-trace__tab {
+  border: 1px solid rgba(var(--text-primary-rgb), 0.18);
+  background: transparent;
+  color: $text-muted;
+  border-radius: 999px;
+  font-size: 10px;
+  padding: 2px 8px;
+  cursor: pointer;
+}
+
+.reasoning-trace__tab.active {
+  color: $text-primary;
+  background: rgba(var(--text-primary-rgb), 0.12);
+}
+
+.reasoning-trace__body {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 10px;
+}
+
+.reasoning-trace__empty {
+  font-size: 12px;
+  color: $text-muted;
+  text-align: center;
+  padding: 24px 8px;
+}
+
+.reasoning-turn {
+  margin-bottom: 12px;
+  border: 1px solid rgba(var(--text-primary-rgb), 0.12);
+  border-radius: 16px;
+  padding: 12px;
+  // background:
+  //   linear-gradient(145deg, rgba(255, 255, 255, 0.05) 0%, rgba(255, 255, 255, 0.01) 45%, transparent 100%),
+  //   linear-gradient(180deg, rgba(var(--text-primary-rgb), 0.04), transparent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.reasoning-turn__meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.reasoning-turn__badge,
+.reasoning-turn__latest {
+  font-size: 10px;
+  padding: 2px 8px 1px;
+  border-radius: 999px;
+  font-weight: 600;
+  border: 1px solid rgba(var(--text-primary-rgb), 0.25);
+  background: rgba(var(--text-primary-rgb), 0.1);
+  color: $text-primary;
+}
+
+.reasoning-turn__badge::before {
+  content: '✦';
+  margin-right: 4px;
+  opacity: 0.8;
+}
+
+.reasoning-turn__trace-id {
+  margin-left: auto;
+  max-width: 120px;
+  font-size: 10px;
+  color: $text-muted;
+  font-family: $font-code;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.reasoning-turn__label {
+  font-size: 10px;
+  color: $text-muted;
+  margin: 10px 0 6px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.reasoning-turn__user-shell {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+  border: 1px solid rgba(var(--text-primary-rgb), 0.1);
+  background: rgba(var(--text-primary-rgb), 0.04);
+  padding: 10px 10px 10px 12px;
+  margin-bottom: 12px;
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.reasoning-turn__user {
+  font-size: 13px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  color: $text-primary;
+}
+
+.reasoning-turn__user-icon {
+  margin-top: 2px;
+  flex-shrink: 0;
+  color: $text-muted;
+}
+
+.trace-card {
+  background: rgba(var(--text-primary-rgb), 0.03);
+  border: 1px solid rgba(var(--text-primary-rgb), 0.12);
+  border-radius: 12px;
+  padding: 9px 11px 10px;
+  margin-top: 10px;
+  opacity: 0;
+  transform: translateY(4px);
+  animation: trace-fade-in 0.16s ease-out forwards;
+}
+
+.trace-card__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.trace-card__tool-icon {
+  color: $text-muted;
+  flex-shrink: 0;
+}
+
+.trace-card__type {
+  font-size: 12px;
+  font-weight: 600;
+  color: $text-primary;
+  letter-spacing: 0.02em;
+}
+
+.trace-card__seq {
+  margin-left: auto;
+  font-size: 10px;
+  color: $text-muted;
+  font-family: $font-code;
+}
+
+.trace-card__source {
+  width: fit-content;
+  font-size: 10px;
+  color: $text-muted;
+  border: 1px solid rgba(var(--text-primary-rgb), 0.16);
+  border-radius: 999px;
+  padding: 1px 6px;
+  margin-bottom: 8px;
+  font-family: $font-code;
+}
+
+.trace-card__content {
+  font-size: 12px;
+  white-space: pre-wrap;
+  line-height: 1.6;
+  color: $text-secondary;
+}
+
+.trace-card__tool {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-bottom: 10px;
+}
+
+.trace-card__tool-name {
+  font-size: 12px;
+  font-weight: 600;
+  color: $text-primary;
+}
+
+.trace-card__tool-id {
+  font-size: 10px;
+  color: $text-muted;
+  font-family: $font-code;
+}
+
+.trace-card__section {
+  font-size: 10px;
+  text-transform: uppercase;
+  color: $text-muted;
+  margin-top: 10px;
+  margin-bottom: 6px;
+}
+
+.trace-card__code {
+  margin: 0;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: rgba(var(--text-primary-rgb), 0.07);
+  border: 1px solid rgba(var(--text-primary-rgb), 0.12);
+  border-radius: 8px;
+  padding: 9px;
+  line-height: 1.5;
+  color: $text-primary;
+}
+
+.trace-card__artifact-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3px 8px;
+  font-size: 10px;
+  color: $text-muted;
+  margin-bottom: 8px;
+}
+
+.trace-card__artifact-grid span:nth-child(2n) {
+  text-align: right;
+  color: $text-secondary;
+  font-family: $font-code;
+}
+
+.trace-card--thought,
+.trace-card--tool_call,
+.trace-card--artifact {
+  border-left: 1px solid rgba(var(--text-primary-rgb), 0.12);
+}
+
+.reasoning-trace__to-bottom {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  width: 34px;
+  height: 34px;
+  border: 1px solid rgba(var(--text-primary-rgb), 0.18);
+  border-radius: 50%;
+  background: rgba(var(--bg-secondary-rgb, 26, 26, 26), 0.88);
+  cursor: pointer;
+  color: $text-primary;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.16);
+  transition: all $transition-fast;
+}
+
+.reasoning-trace__to-bottom:hover {
+  background: rgba(var(--text-primary-rgb), 0.18);
+  transform: translateY(-1px);
+  border-color: rgba(var(--text-primary-rgb), 0.28);
+}
+
+.tool-log-card {
+  margin-bottom: 10px;
+  border: 1px solid rgba(var(--text-primary-rgb), 0.12);
+  border-radius: 12px;
+  padding: 10px;
+  background: rgba(var(--text-primary-rgb), 0.03);
+}
+
+.tool-log-card__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.tool-log-card__name {
+  font-size: 12px;
+  font-weight: 600;
+  color: $text-primary;
+  font-family: $font-code;
+}
+
+.tool-log-card__status {
+  font-size: 10px;
+  border-radius: 999px;
+  padding: 1px 7px;
+  border: 1px solid rgba(var(--text-primary-rgb), 0.18);
+}
+
+.tool-log-card__status.status-running {
+  color: $text-primary;
+}
+
+.tool-log-card__status.status-error {
+  color: $error;
+  border-color: rgba(var(--error-rgb), 0.35);
+  background: rgba(var(--error-rgb), 0.08);
+}
+
+.tool-log-card__preview {
+  font-size: 11px;
+  color: $text-secondary;
+  margin-bottom: 8px;
+}
+
+@keyframes trace-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1200px) {
+  .reasoning-trace {
+    width: 300px;
+    min-width: 240px;
+  }
+}
+
+@media (max-width: $breakpoint-mobile) {
+  .reasoning-trace {
+    width: 100%;
+    min-width: 0;
+    border-left: 0;
+    border-top: 1px solid $border-color;
+    max-height: 45%;
+  }
+}
+</style>

--- a/packages/client/src/components/hermes/chat/ReasoningTrace.vue
+++ b/packages/client/src/components/hermes/chat/ReasoningTrace.vue
@@ -141,7 +141,7 @@ const dedupedDisplayFrames = computed(() => {
 
 const groupedFrames = computed(() => groupDisplayFramesByTraceId(dedupedDisplayFrames.value))
 const shouldVirtualize = computed(() => dedupedDisplayFrames.value.length >= VIRTUALIZE_THRESHOLD_FRAMES)
-const toolLogs = computed(() => [...props.toolMessages].reverse())
+const toolLogs = computed(() => props.toolMessages)
 
 const estimatedHeights = computed(() => dedupedDisplayFrames.value.map(frame => estimateCardHeight(frame)))
 const offsets = computed(() => {

--- a/packages/client/src/components/hermes/settings/DisplaySettings.vue
+++ b/packages/client/src/components/hermes/settings/DisplaySettings.vue
@@ -46,6 +46,9 @@ function handleThemeChange(val: string) {
     <SettingRow :label="t('settings.display.showReasoning')" :hint="t('settings.display.showReasoningHint')">
       <NSwitch :value="settingsStore.display.show_reasoning" @update:value="v => save({ show_reasoning: v })" />
     </SettingRow>
+    <SettingRow :label="t('settings.display.showReasoningPanel')" :hint="t('settings.display.showReasoningPanelHint')">
+      <NSwitch :value="settingsStore.display.show_reasoning_panel ?? true" @update:value="v => save({ show_reasoning_panel: v })" />
+    </SettingRow>
     <SettingRow :label="t('settings.display.showCost')" :hint="t('settings.display.showCostHint')">
       <NSwitch :value="settingsStore.display.show_cost" @update:value="v => save({ show_cost: v })" />
     </SettingRow>

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -128,6 +128,12 @@ export default {
     arguments: 'Argumente',
     result: 'Ergebnis',
     truncated: '... (abgeschnitten)',
+    reasoningTitle: 'Denkspur',
+    reasoningTraceRound: 'Runde {n}',
+    reasoningTraceLatest: 'Neueste',
+    reasoningTraceTriggeredBy: 'Denkprozess durch diese Nachricht ausgelöst',
+    reasoningTraceNoUserMatch: '(Keine passende Benutzernachricht für diese Spur gefunden)',
+    reasoningTraceEmpty: 'Noch keine Denk-Frames (Gedanken, Werkzeuge usw. erscheinen hier)',
   },
 
   // Jobs
@@ -348,6 +354,8 @@ export default {
       compactHint: 'Nachrichtenabstand reduzieren',
       showReasoning: 'Schlussfolgerung anzeigen',
       showReasoningHint: 'Denkprozess des Modells anzeigen',
+      showReasoningPanel: 'Reasoning-Seitenleiste anzeigen',
+      showReasoningPanelHint: 'Ein- oder ausblenden von Reasoning-Trace und Tool-Log',
       showCost: 'Kosten anzeigen',
       showCostHint: 'Token-Nutzung in Antworten anzeigen',
       inlineDiffs: 'Inline-Diffs',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -152,6 +152,12 @@ export default {
     arguments: 'Arguments',
     result: 'Result',
     truncated: '... (truncated)',
+    reasoningTitle: 'Reasoning Trace',
+    reasoningTraceRound: 'Turn {n}',
+    reasoningTraceLatest: 'Latest',
+    reasoningTraceTriggeredBy: 'Reasoning triggered by this message',
+    reasoningTraceNoUserMatch: '(No user message matched for this trace)',
+    reasoningTraceEmpty: 'No reasoning frames yet (thoughts, tools, etc. appear here)',
   },
 
   // Jobs
@@ -390,6 +396,8 @@ export default {
       compactHint: 'Reduce message spacing',
       showReasoning: 'Show Reasoning',
       showReasoningHint: 'Show model thinking process',
+      showReasoningPanel: 'Show Reasoning Sidebar',
+      showReasoningPanelHint: 'Toggle reasoning trace and tool call log sidebar',
       showCost: 'Show Cost',
       showCostHint: 'Show token usage in replies',
       inlineDiffs: 'Inline Diffs',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -128,6 +128,12 @@ export default {
     arguments: 'Argumentos',
     result: 'Resultado',
     truncated: '... (truncado)',
+    reasoningTitle: 'Traza de razonamiento',
+    reasoningTraceRound: 'Turno {n}',
+    reasoningTraceLatest: 'Mas reciente',
+    reasoningTraceTriggeredBy: 'Razonamiento activado por este mensaje',
+    reasoningTraceNoUserMatch: '(No se encontro ningun mensaje de usuario para esta traza)',
+    reasoningTraceEmpty: 'Aun no hay marcos de razonamiento (pensamientos, herramientas, etc. aparecen aqui)',
   },
 
   // Jobs
@@ -348,6 +354,8 @@ export default {
       compactHint: 'Reducir el espaciado entre mensajes',
       showReasoning: 'Mostrar razonamiento',
       showReasoningHint: 'Mostrar el proceso de pensamiento del modelo',
+      showReasoningPanel: 'Mostrar barra lateral de razonamiento',
+      showReasoningPanelHint: 'Alternar barra de traza de razonamiento y registro de herramientas',
       showCost: 'Mostrar costo',
       showCostHint: 'Mostrar uso de tokens en las respuestas',
       inlineDiffs: 'Diffs en linea',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -128,6 +128,12 @@ export default {
     arguments: 'Arguments',
     result: 'Resultat',
     truncated: '... (tronque)',
+    reasoningTitle: 'Trace de raisonnement',
+    reasoningTraceRound: 'Tour {n}',
+    reasoningTraceLatest: 'Le plus recent',
+    reasoningTraceTriggeredBy: 'Raisonnement declenche par ce message',
+    reasoningTraceNoUserMatch: '(Aucun message utilisateur correspondant pour cette trace)',
+    reasoningTraceEmpty: 'Aucun cadre de raisonnement pour le moment (pensees, outils, etc. apparaissent ici)',
   },
 
   // Jobs
@@ -348,6 +354,8 @@ export default {
       compactHint: 'Reduire l\'espacement des messages',
       showReasoning: 'Afficher le raisonnement',
       showReasoningHint: 'Afficher le processus de reflexion du modele',
+      showReasoningPanel: 'Afficher le panneau de raisonnement',
+      showReasoningPanelHint: 'Afficher/masquer la trace de raisonnement et le journal des outils',
       showCost: 'Afficher le cout',
       showCostHint: 'Afficher l\'utilisation des jetons dans les reponses',
       inlineDiffs: 'Diffs en ligne',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -128,6 +128,12 @@ export default {
     arguments: '引数',
     result: '結果',
     truncated: '... (省略)',
+    reasoningTitle: '推論トレース',
+    reasoningTraceRound: 'ターン {n}',
+    reasoningTraceLatest: '最新',
+    reasoningTraceTriggeredBy: 'このメッセージで推論がトリガーされました',
+    reasoningTraceNoUserMatch: '（このトレースに対応するユーザーメッセージが見つかりません）',
+    reasoningTraceEmpty: '推論フレームはまだありません（思考、ツールなどがここに表示されます）',
   },
 
   // スケジュールジョブ
@@ -348,6 +354,8 @@ export default {
       compactHint: 'メッセージの間隔を狭める',
       showReasoning: '推論過程を表示',
       showReasoningHint: 'モデルの思考プロセスを表示',
+      showReasoningPanel: '推理サイドバーを表示',
+      showReasoningPanelHint: '推理トレースとツールログのサイドバー表示を切り替え',
       showCost: 'コストを表示',
       showCostHint: '返信にトークン使用量を表示',
       inlineDiffs: 'インライン差分',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -128,6 +128,12 @@ export default {
     arguments: '인수',
     result: '결과',
     truncated: '... (잘림)',
+    reasoningTitle: '추론 트레이스',
+    reasoningTraceRound: '턴 {n}',
+    reasoningTraceLatest: '최신',
+    reasoningTraceTriggeredBy: '이 메시지로 인해 추론이 시작되었습니다',
+    reasoningTraceNoUserMatch: '(이 트레이스와 일치하는 사용자 메시지가 없습니다)',
+    reasoningTraceEmpty: '아직 추론 프레임이 없습니다 (생각, 도구 등은 여기에 표시됩니다)',
   },
 
   // 예약 작업
@@ -348,6 +354,8 @@ export default {
       compactHint: '메시지 간격 줄이기',
       showReasoning: '추론 과정 표시',
       showReasoningHint: '모델의 생각 과정 표시',
+      showReasoningPanel: '추론 사이드바 표시',
+      showReasoningPanelHint: '추론 추적 및 도구 로그 사이드바 표시 전환',
       showCost: '비용 표시',
       showCostHint: '응답에 토큰 사용량 표시',
       inlineDiffs: '인라인 변경사항',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -128,6 +128,12 @@ export default {
     arguments: 'Argumentos',
     result: 'Resultado',
     truncated: '... (truncado)',
+    reasoningTitle: 'Rastro de raciocinio',
+    reasoningTraceRound: 'Turno {n}',
+    reasoningTraceLatest: 'Mais recente',
+    reasoningTraceTriggeredBy: 'Raciocinio acionado por esta mensagem',
+    reasoningTraceNoUserMatch: '(Nenhuma mensagem de usuario corresponde a este rastro)',
+    reasoningTraceEmpty: 'Ainda nao ha quadros de raciocinio (pensamentos, ferramentas etc. aparecem aqui)',
   },
 
   // Jobs
@@ -348,6 +354,8 @@ export default {
       compactHint: 'Reduzir espacamento entre mensagens',
       showReasoning: 'Mostrar raciocinio',
       showReasoningHint: 'Mostrar processo de pensamento do modelo',
+      showReasoningPanel: 'Mostrar barra lateral de raciocinio',
+      showReasoningPanelHint: 'Alternar barra de rastreio de raciocinio e log de ferramentas',
       showCost: 'Mostrar custo',
       showCostHint: 'Mostrar uso de tokens nas respostas',
       inlineDiffs: 'Diffs em linha',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -152,6 +152,12 @@ export default {
     arguments: '参数',
     result: '结果',
     truncated: '... (已截断)',
+    reasoningTitle: '推理轨迹',
+    reasoningTraceRound: '第 {n} 轮',
+    reasoningTraceLatest: '当前',
+    reasoningTraceTriggeredBy: '由此用户消息触发的推理',
+    reasoningTraceNoUserMatch: '（未匹配到会话中的用户原文）',
+    reasoningTraceEmpty: '暂无推理帧（思考、工具调用等会显示在这里）',
   },
 
   // 定时任务
@@ -382,6 +388,8 @@ export default {
       compactHint: '减少消息间距',
       showReasoning: '显示推理过程',
       showReasoningHint: '展示模型思考过程',
+      showReasoningPanel: '显示推理轨迹侧栏',
+      showReasoningPanelHint: '控制是否展示推理轨迹和工具调用日志',
       showCost: '显示费用',
       showCostHint: '在回复中显示 token 使用量',
       inlineDiffs: '内联差异',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1,7 +1,8 @@
-import { startRun, streamRunEvents, type ChatMessage, type RunEvent } from '@/api/hermes/chat'
+import { startRun, streamRunEvents, type AgentFrame, type ChatMessage, type RunEvent } from '@/api/hermes/chat'
 import { deleteSession as deleteSessionApi, fetchSession, fetchSessions, fetchSessionUsageSingle, type HermesMessage, type SessionSummary } from '@/api/hermes/sessions'
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
+import { appendReasoningFrame, deriveTraceState, nextReasoningSeq, normalizeFramesFromEvent, type TraceState } from './frame-normalizer'
 import { useAppStore } from './app'
 import { useProfilesStore } from './profiles'
 
@@ -42,6 +43,8 @@ export interface Session {
   outputTokens?: number
   endedAt?: number | null
   lastActiveAt?: number
+  reasoningFrames: AgentFrame[]
+  traceUserInputs: Record<string, string>
 }
 
 function uid(): string {
@@ -159,7 +162,19 @@ function mapHermesSession(s: SessionSummary): Session {
     messageCount: s.message_count,
     endedAt: s.ended_at != null ? Math.round(s.ended_at * 1000) : null,
     lastActiveAt: s.last_active != null ? Math.round(s.last_active * 1000) : undefined,
+    reasoningFrames: [],
+    traceUserInputs: {},
   }
+}
+
+function applyServerSessionSnapshot(target: Session, detail: Awaited<ReturnType<typeof fetchSession>>) {
+  if (!detail) return
+  const mapped = mapHermesMessages(detail.messages || [])
+  const traceState = deriveTraceState(detail.messages || [])
+  target.messages = mapped
+  target.reasoningFrames = traceState.frames
+  target.traceUserInputs = traceState.traceUserInputs
+  if (detail.title) target.title = detail.title
 }
 
 // Cache keys for stale-while-revalidate loading of sessions / messages.
@@ -174,6 +189,7 @@ const IN_FLIGHT_TTL_MS = 15 * 60 * 1000 // Give up after 15 minutes
 const POLL_INTERVAL_MS = 2000
 const POLL_STABLE_EXITS = 3 // 3 × 2s = 6s of no change → assume run finished
 const LIVE_BADGE_WINDOW_MS = 5 * 60 * 1000
+const REASONING_SYNC_INTERVAL_MS = 1200
 
 // 获取当前 profile 名称，用于隔离缓存。
 // 从 profiles store 的 activeProfileName（同步 localStorage）读取，
@@ -305,6 +321,18 @@ function sanitizeForCache(msgs: Message[]): Message[] {
   })
 }
 
+function sanitizeTraceStateForCache(state: TraceState): TraceState {
+  return {
+    frames: state.frames.map(frame => ({
+      type: frame.type,
+      seq: frame.seq,
+      trace_id: frame.trace_id,
+      payload: frame.payload && typeof frame.payload === 'object' ? frame.payload : {},
+    })),
+    traceUserInputs: { ...state.traceUserInputs },
+  }
+}
+
 export const useChatStore = defineStore('chat', () => {
   const sessions = ref<Session[]>([])
   const activeSessionId = ref<string | null>(null)
@@ -324,9 +352,12 @@ export const useChatStore = defineStore('chat', () => {
   )
   const pollTimers = new Map<string, ReturnType<typeof setInterval>>()
   const pollSignatures = new Map<string, { sig: string, stableTicks: number }>()
+  const reasoningSyncTimers = new Map<string, ReturnType<typeof setInterval>>()
 
   const activeSession = ref<Session | null>(null)
   const messages = computed<Message[]>(() => activeSession.value?.messages || [])
+  const reasoningFrames = computed<AgentFrame[]>(() => activeSession.value?.reasoningFrames || [])
+  const traceUserInputs = computed<Record<string, string>>(() => activeSession.value?.traceUserInputs || {})
 
   function isSessionLive(sessionId: string): boolean {
     if (streamStates.value.has(sessionId) || resumingRuns.value.has(sessionId)) return true
@@ -349,7 +380,18 @@ export const useChatStore = defineStore('chat', () => {
     const sid = activeSessionId.value
     if (!sid) return
     const s = sessions.value.find(sess => sess.id === sid)
-    if (s) saveJsonWithLegacy(msgsCacheKey(sid), sanitizeForCache(s.messages), legacyMsgsCacheKey(sid))
+  if (!s) return
+  saveJsonWithLegacy(
+    msgsCacheKey(sid),
+    {
+      messages: sanitizeForCache(s.messages),
+      traceState: sanitizeTraceStateForCache({
+        frames: s.reasoningFrames,
+        traceUserInputs: s.traceUserInputs,
+      }),
+    },
+    legacyMsgsCacheKey(sid),
+  )
   }
 
   function markInFlight(sid: string, runId: string) {
@@ -380,6 +422,37 @@ export const useChatStore = defineStore('chat', () => {
     resumingRuns.value = new Set([...resumingRuns.value].filter(x => x !== sid))
   }
 
+  function stopReasoningSync(sid: string) {
+    const timer = reasoningSyncTimers.get(sid)
+    if (!timer) return
+    clearInterval(timer)
+    reasoningSyncTimers.delete(sid)
+  }
+
+  function startReasoningSync(sid: string) {
+    if (reasoningSyncTimers.has(sid)) return
+    const timer = setInterval(async () => {
+      if (!streamStates.value.has(sid)) {
+        stopReasoningSync(sid)
+        return
+      }
+      try {
+        const detail = await fetchSession(sid)
+        if (!detail) return
+        const target = sessions.value.find(s => s.id === sid)
+        if (!target) return
+        const traceState = deriveTraceState(detail.messages || [])
+        target.reasoningFrames = traceState.frames
+        target.traceUserInputs = traceState.traceUserInputs
+        if (detail.title && !target.title) target.title = detail.title
+        if (sid === activeSessionId.value) persistActiveMessages()
+      } catch {
+        // transient errors are expected during streaming
+      }
+    }, REASONING_SYNC_INTERVAL_MS)
+    reasoningSyncTimers.set(sid, timer)
+  }
+
   // Poll fetchSession while an in-flight run is recovering. Exits when the
   // server's message signature is stable for POLL_STABLE_EXITS ticks (run
   // presumed done), TTL elapses, or the user explicitly starts streaming.
@@ -401,6 +474,7 @@ export const useChatStore = defineStore('chat', () => {
         const detail = await fetchSession(sid)
         if (!detail) return
         const mapped = mapHermesMessages(detail.messages || [])
+        const traceState = deriveTraceState(detail.messages || [])
         const target = sessions.value.find(s => s.id === sid)
         if (!target) return
         // Use the same "content-aware" comparison as switchSession: server
@@ -422,6 +496,8 @@ export const useChatStore = defineStore('chat', () => {
           || (serverUsers === localUsers && serverAssistantLen >= localAssistantLen)
         if (serverIsAhead) {
           target.messages = mapped
+          target.reasoningFrames = traceState.frames
+          target.traceUserInputs = traceState.traceUserInputs
           if (detail.title && !target.title) target.title = detail.title
           if (sid === activeSessionId.value) persistActiveMessages()
         }
@@ -465,13 +541,26 @@ export const useChatStore = defineStore('chat', () => {
       // 从 profile 对应的缓存中恢复，实现 instant render
       const cachedSessions = loadJsonWithFallback<Session[]>(sessionsCacheKey(), legacySessionsCacheKey())
       if (cachedSessions?.length) {
-        sessions.value = cachedSessions
+        sessions.value = cachedSessions.map(s => ({
+          ...s,
+          reasoningFrames: s.reasoningFrames || [],
+          traceUserInputs: s.traceUserInputs || {},
+        }))
         const savedId = localStorage.getItem(storageKey()) || (legacyStorageKey() ? localStorage.getItem(legacyStorageKey()!) : null)
         if (savedId) {
           const cachedActive = cachedSessions.find(s => s.id === savedId) || null
           if (cachedActive) {
-            const cachedMsgs = loadJsonWithFallback<Message[]>(msgsCacheKey(savedId), legacyMsgsCacheKey(savedId))
-            if (cachedMsgs) cachedActive.messages = cachedMsgs
+            const cachedPayload = loadJsonWithFallback<{ messages?: Message[], traceState?: TraceState } | Message[]>(
+              msgsCacheKey(savedId),
+              legacyMsgsCacheKey(savedId),
+            )
+            if (Array.isArray(cachedPayload)) {
+              cachedActive.messages = cachedPayload
+            } else if (cachedPayload?.messages) {
+              cachedActive.messages = cachedPayload.messages
+              cachedActive.reasoningFrames = cachedPayload.traceState?.frames || []
+              cachedActive.traceUserInputs = cachedPayload.traceState?.traceUserInputs || {}
+            }
             activeSession.value = cachedActive
             activeSessionId.value = savedId
           }
@@ -493,7 +582,11 @@ export const useChatStore = defineStore('chat', () => {
       // this, refreshing mid-run would wipe the session and fall back to
       // sessions[0], which is exactly what the user reported.
       const localOnly = sessions.value.filter(s => !freshIds.has(s.id))
-      sessions.value = [...localOnly, ...fresh]
+      sessions.value = [...localOnly, ...fresh].map(s => ({
+        ...s,
+        reasoningFrames: s.reasoningFrames || [],
+        traceUserInputs: s.traceUserInputs || {},
+      }))
       persistSessionsList()
 
       // Restore last active session, fallback to most recent
@@ -523,9 +616,7 @@ export const useChatStore = defineStore('chat', () => {
       if (!detail) return false
       const target = sessions.value.find(s => s.id === sid)
       if (!target) return false
-      const mapped = mapHermesMessages(detail.messages || [])
-      target.messages = mapped
-      if (detail.title) target.title = detail.title
+      applyServerSessionSnapshot(target, detail)
       persistActiveMessages()
       return true
     } catch (err) {
@@ -543,6 +634,8 @@ export const useChatStore = defineStore('chat', () => {
       messages: [],
       createdAt: Date.now(),
       updatedAt: Date.now(),
+      reasoningFrames: [],
+      traceUserInputs: {},
     }
     sessions.value.unshift(session)
     // Persist immediately so a refresh before run.completed can still find
@@ -566,9 +659,16 @@ export const useChatStore = defineStore('chat', () => {
     // loading state while we fetch.
     const hasLocalMessages = activeSession.value.messages.length > 0
     if (!hasLocalMessages) {
-      const cachedMsgs = loadJsonWithFallback<Message[]>(msgsCacheKey(sessionId), legacyMsgsCacheKey(sessionId))
-      if (cachedMsgs?.length) {
-        activeSession.value.messages = cachedMsgs
+      const cachedPayload = loadJsonWithFallback<{ messages?: Message[], traceState?: TraceState } | Message[]>(
+        msgsCacheKey(sessionId),
+        legacyMsgsCacheKey(sessionId),
+      )
+      if (Array.isArray(cachedPayload) && cachedPayload.length) {
+        activeSession.value.messages = cachedPayload
+      } else if (!Array.isArray(cachedPayload) && cachedPayload?.messages?.length) {
+        activeSession.value.messages = cachedPayload.messages
+        activeSession.value.reasoningFrames = cachedPayload.traceState?.frames || []
+        activeSession.value.traceUserInputs = cachedPayload.traceState?.traceUserInputs || {}
       }
     }
 
@@ -579,6 +679,7 @@ export const useChatStore = defineStore('chat', () => {
       const detail = await fetchSession(sessionId)
       if (detail && detail.messages) {
         const mapped = mapHermesMessages(detail.messages)
+        const traceState = deriveTraceState(detail.messages)
         // Pick whichever view has more information. Simple length comparison
         // is wrong because mapHermesMessages folds tool_call-only assistant
         // msgs and matches them with tool-result msgs — so post-fold `mapped`
@@ -608,6 +709,8 @@ export const useChatStore = defineStore('chat', () => {
           || (serverUsers === localUsers && serverAssistantLen >= localAssistantLen)
         if (serverIsAhead) {
           activeSession.value.messages = mapped
+          activeSession.value.reasoningFrames = traceState.frames
+          activeSession.value.traceUserInputs = traceState.traceUserInputs
         }
         // Update title: use Hermes title, or fallback to first user message
         if (detail.title) {
@@ -783,10 +886,13 @@ export const useChatStore = defineStore('chat', () => {
       // polling an earlier run), cancel that polling — the new SSE stream is
       // the authoritative live source.
       stopPolling(sid)
+      stopReasoningSync(sid)
+      startReasoningSync(sid)
 
       // Helper to clean up this session's stream state
       const cleanup = () => {
         streamStates.value.delete(sid)
+        stopReasoningSync(sid)
         if (persistTimer) {
           clearTimeout(persistTimer)
           persistTimer = null
@@ -810,6 +916,16 @@ export const useChatStore = defineStore('chat', () => {
         runId,
         // onEvent
         (evt: RunEvent) => {
+          const targetSession = sessions.value.find(s => s.id === sid)
+          const latestUserText = userMsg.content
+          const fallbackTraceId = `turn:${userMsg.id}`
+          const eventFrames = targetSession
+            ? normalizeFramesFromEvent(evt, fallbackTraceId, nextReasoningSeq(targetSession))
+            : []
+          if (targetSession && eventFrames.length) {
+            eventFrames.forEach(frame => appendReasoningFrame(targetSession, frame, latestUserText))
+            schedulePersist()
+          }
           switch (evt.event) {
             case 'run.started':
               break
@@ -877,6 +993,19 @@ export const useChatStore = defineStore('chat', () => {
                   target.outputTokens = evt.usage.output_tokens
                 }
               }
+              // 对齐 hermes-agent-ui：run 结束后用服务端消息快照回填
+              // reasoning/tool_call，确保轨迹里稳定可见“思考过程 + 工具调用”。
+              void (async () => {
+                try {
+                  const detail = await fetchSession(sid)
+                  const target = sessions.value.find(s => s.id === sid)
+                  if (target && detail) {
+                    applyServerSessionSnapshot(target, detail)
+                  }
+                } finally {
+                  if (sid === activeSessionId.value) persistActiveMessages()
+                }
+              })()
               cleanup()
               updateSessionTitle(sid)
               // the in-flight marker. If the browser is reloading right now
@@ -887,6 +1016,7 @@ export const useChatStore = defineStore('chat', () => {
               if (sid === activeSessionId.value) persistActiveMessages()
               clearInFlight(sid)
               stopPolling(sid)
+              stopReasoningSync(sid)
               break
             }
 
@@ -916,6 +1046,7 @@ export const useChatStore = defineStore('chat', () => {
               if (sid === activeSessionId.value) persistActiveMessages()
               clearInFlight(sid)
               stopPolling(sid)
+              stopReasoningSync(sid)
               break
             }
           }
@@ -989,6 +1120,7 @@ export const useChatStore = defineStore('chat', () => {
       streamStates.value.delete(sid)
       clearInFlight(sid)
       stopPolling(sid)
+      stopReasoningSync(sid)
     }
   }
 
@@ -1010,6 +1142,8 @@ export const useChatStore = defineStore('chat', () => {
     activeSession,
     focusMessageId,
     messages,
+    reasoningFrames,
+    traceUserInputs,
     isStreaming,
     isRunActive,
     isSessionLive,

--- a/packages/client/src/stores/hermes/frame-normalizer.ts
+++ b/packages/client/src/stores/hermes/frame-normalizer.ts
@@ -1,0 +1,218 @@
+import type { AgentFrame, RunEvent } from '@/api/hermes/chat'
+import type { HermesMessage } from '@/api/hermes/sessions'
+
+export type TraceState = {
+  frames: AgentFrame[]
+  traceUserInputs: Record<string, string>
+}
+
+export type ReasoningSessionLike = {
+  reasoningFrames: AgentFrame[]
+  traceUserInputs: Record<string, string>
+}
+
+function ensureFrame(frame: unknown, fallbackTraceId?: string, fallbackSeq?: number): AgentFrame | null {
+  if (!frame || typeof frame !== 'object') return null
+  const raw = frame as Record<string, unknown>
+  const type = typeof raw.type === 'string'
+    ? raw.type
+    : (typeof raw.frame_type === 'string' ? raw.frame_type : '')
+  const traceId = typeof raw.trace_id === 'string' && raw.trace_id.trim()
+    ? raw.trace_id
+    : (fallbackTraceId || '')
+  const seq = typeof raw.seq === 'number'
+    ? raw.seq
+    : (typeof fallbackSeq === 'number' ? fallbackSeq : NaN)
+  const payload = (raw.payload && typeof raw.payload === 'object') ? raw.payload as Record<string, any> : {}
+  if (!type || !traceId || Number.isNaN(seq)) return null
+  return { type, trace_id: traceId, seq, payload }
+}
+
+export function normalizeFramesFromEvent(evt: RunEvent, fallbackTraceId: string, nextSeq: number): AgentFrame[] {
+  const eventName = String(evt.event || '').toLowerCase()
+  const payloadAny = (evt.payload || {}) as Record<string, any>
+  const dataAny = (evt.data || {}) as Record<string, any>
+  const candidates: unknown[] = [
+    evt.frame,
+    payloadAny.frame,
+    dataAny.frame,
+    evt.payload,
+    evt.data,
+    evt,
+  ]
+
+  const parsed: AgentFrame[] = []
+  for (const candidate of candidates) {
+    const frame = ensureFrame(candidate, fallbackTraceId, nextSeq + parsed.length)
+    if (frame) parsed.push(frame)
+  }
+  const frameLists: unknown[][] = [
+    Array.isArray(payloadAny.frames) ? payloadAny.frames : [],
+    Array.isArray(dataAny.frames) ? dataAny.frames : [],
+  ]
+  for (const list of frameLists) {
+    for (const item of list) {
+      const frame = ensureFrame(item, fallbackTraceId, nextSeq + parsed.length)
+      if (frame) parsed.push(frame)
+    }
+  }
+  if (parsed.length > 0) return parsed
+
+  if (eventName.includes('tool') && (eventName.includes('start') || eventName.includes('begin'))) {
+    return [{
+      type: 'TOOL_CALL',
+      seq: nextSeq,
+      trace_id: fallbackTraceId,
+      payload: {
+        tool_call_id: evt.tool_call_id || evt.payload?.tool_call_id || undefined,
+        name: evt.tool || evt.name || evt.payload?.name || 'tool',
+        args: evt.args ?? evt.payload?.args ?? {},
+        result: null,
+      },
+    }]
+  }
+
+  if (eventName.includes('tool') && (eventName.includes('complete') || eventName.includes('finish') || eventName.includes('done'))) {
+    return [{
+      type: 'TOOL_CALL',
+      seq: nextSeq,
+      trace_id: fallbackTraceId,
+      payload: {
+        tool_call_id: evt.tool_call_id || evt.payload?.tool_call_id || undefined,
+        name: evt.tool || evt.name || evt.payload?.name || 'tool',
+        args: evt.args ?? evt.payload?.args ?? {},
+        result: evt.result ?? evt.payload?.result ?? null,
+      },
+    }]
+  }
+
+  if (eventName.includes('artifact')) {
+    return [{
+      type: 'ARTIFACT',
+      seq: nextSeq,
+      trace_id: fallbackTraceId,
+      payload: evt.artifact || evt.payload || {},
+    }]
+  }
+
+  const thoughtDelta = (evt as any).reasoning_delta
+    ?? (evt as any).thought_delta
+    ?? (evt as any).reasoning
+    ?? evt.payload?.reasoning_delta
+    ?? evt.payload?.thought_delta
+    ?? evt.payload?.reasoning
+  if (typeof thoughtDelta === 'string' && thoughtDelta.trim()) {
+    return [{
+      type: 'THOUGHT',
+      seq: nextSeq,
+      trace_id: fallbackTraceId,
+      payload: { content: thoughtDelta, source: 'reasoning' },
+    }]
+  }
+
+  if (eventName.includes('thought') || eventName.includes('reason')) {
+    const content = String((evt.payload as any)?.content ?? (evt.payload as any)?.delta ?? '')
+    if (content.trim()) {
+      return [{
+        type: 'THOUGHT',
+        seq: nextSeq,
+        trace_id: fallbackTraceId,
+        payload: { content, source: 'reasoning' },
+      }]
+    }
+  }
+
+  return []
+}
+
+export function appendReasoningFrame(session: ReasoningSessionLike, frame: AgentFrame, fallbackUserText?: string) {
+  const exists = session.reasoningFrames.some(item => item.trace_id === frame.trace_id && item.seq === frame.seq)
+  if (exists) return
+  session.reasoningFrames.push(frame)
+  session.reasoningFrames.sort((a, b) => a.seq - b.seq)
+  if (fallbackUserText && !session.traceUserInputs[frame.trace_id]) {
+    session.traceUserInputs[frame.trace_id] = fallbackUserText
+  }
+}
+
+export function nextReasoningSeq(session: ReasoningSessionLike): number {
+  const last = session.reasoningFrames[session.reasoningFrames.length - 1]
+  return (last?.seq ?? 0) + 1
+}
+
+export function deriveTraceState(msgs: HermesMessage[]): TraceState {
+  const frames: AgentFrame[] = []
+  const traceUserInputs: Record<string, string> = {}
+  const toolNameMap = new Map<string, string>()
+  const toolArgsMap = new Map<string, string>()
+  let seq = 1
+  let currentTraceId = 'trace:0'
+  let userTurnIndex = 0
+
+  for (const msg of msgs) {
+    if (msg.role === 'user') {
+      userTurnIndex += 1
+      currentTraceId = `turn:${msg.id || userTurnIndex}`
+      if (msg.content?.trim()) traceUserInputs[currentTraceId] = msg.content
+      continue
+    }
+
+    if (msg.role === 'assistant' && msg.tool_calls?.length) {
+      for (const tc of msg.tool_calls) {
+        const tcId = String(tc?.id || '')
+        const name = String(tc?.function?.name || 'tool')
+        const argsRaw = tc?.function?.arguments
+        if (tcId) {
+          toolNameMap.set(tcId, name)
+          if (typeof argsRaw === 'string') toolArgsMap.set(tcId, argsRaw)
+        }
+        frames.push({
+          type: 'TOOL_CALL',
+          seq: seq++,
+          trace_id: currentTraceId,
+          payload: {
+            tool_call_id: tcId || undefined,
+            name,
+            args: typeof argsRaw === 'string' ? argsRaw : argsRaw ?? {},
+            result: null,
+          },
+        })
+      }
+    }
+
+    if (msg.role === 'assistant' && msg.reasoning?.trim()) {
+      frames.push({
+        type: 'THOUGHT',
+        seq: seq++,
+        trace_id: currentTraceId,
+        payload: { content: msg.reasoning, source: 'reasoning' },
+      })
+    }
+
+    if (msg.role === 'tool') {
+      const tcId = msg.tool_call_id || ''
+      frames.push({
+        type: 'TOOL_CALL',
+        seq: seq++,
+        trace_id: currentTraceId,
+        payload: {
+          tool_call_id: tcId || undefined,
+          name: msg.tool_name || toolNameMap.get(tcId) || 'tool',
+          args: toolArgsMap.get(tcId) || {},
+          result: msg.content || null,
+        },
+      })
+    }
+
+    if (msg.role === 'assistant' && msg.content?.trim()) {
+      frames.push({
+        type: 'RESPONSE',
+        seq: seq++,
+        trace_id: currentTraceId,
+        payload: { role: 'assistant', content: msg.content, final: true },
+      })
+    }
+  }
+
+  return { frames, traceUserInputs }
+}


### PR DESCRIPTION
## Summary
This PR introduces a dedicated Reasoning Trace experience in chat, making model reasoning/tool activity visible and easier to inspect during and after streaming runs.

### What’s included
- Added a new `ReasoningTrace` sidebar component in chat.
- Added frame normalization logic to unify reasoning/tool-related event shapes.
- Synced reasoning frames with session snapshots to keep trace data stable after run completion/reload.
- Added a user-facing display toggle: `show_reasoning_panel`.
- Added i18n strings for the new reasoning UI in all supported locales (EN/ZH/DE/ES/FR/JA/KO/PT).

## Why
Previously, reasoning/tool-call visibility could be fragmented across streaming and persisted session states.  
This change improves transparency and debugging UX by presenting a consistent, timeline-like trace view.

## Implementation notes
- Extended chat event typing to support frame/trace-related fields.
- Updated chat store state to persist and restore reasoning frames + trace-to-user-message mapping.
- Added post-run snapshot backfill to ensure final trace consistency.
- Integrated the reasoning panel into `MessageList` with responsive layout behavior.
- Added display setting wiring in `DisplaySettings`.

## User impact
- Users can inspect model reasoning and tool activity more reliably.
- Users can hide/show the reasoning panel based on preference.
- No breaking API behavior for existing chat usage.

## Why reasoning trace matters
The new Reasoning Trace panel gives users direct visibility into how the assistant reaches an answer:

- **Transparent reasoning flow**: users can see the model’s step-by-step thought progression (at a safe, structured level), not just the final output.
- **Tool-call observability**: users can inspect which tools were called, in what order, and with what outcomes.
- **Faster debugging**: when outputs are wrong or incomplete, users can quickly locate whether the issue is in reasoning, tool selection, or tool results.
- **Higher trust**: visible intermediate reasoning/tool activity makes behavior easier to verify and reduces “black box” uncertainty.
- **Better iteration speed**: developers and prompt engineers can tune prompts/configs faster by understanding execution traces across turns.

## Risk and compatibility
- Main risk is backend event-shape variance; normalization includes fallback handling.
- Change is backward-compatible and scoped to chat reasoning display/state sync.

## Screenshots
<img width="1451" height="570" alt="ScreenShot_2026-04-24_140536_512" src="https://github.com/user-attachments/assets/ea271aed-7dc0-4b00-a095-35ce81f05c2b" />
<img width="1449" height="819" alt="ScreenShot_2026-04-24_140656_690" src="https://github.com/user-attachments/assets/e76134b7-23f7-45e0-84c9-879776235aa9" />
<img width="1445" height="817" alt="ScreenShot_2026-04-24_140712_587" src="https://github.com/user-attachments/assets/5f72d7ad-1561-40c9-8e49-56bf7c844e97" />
<img width="1443" height="823" alt="ScreenShot_2026-04-24_140725_424" src="https://github.com/user-attachments/assets/00
<img width="1458" height="813" alt="ScreenShot_2026-04-24_140744_702" src="https://github.com/user-attachments/assets/3f8c2b37-cfd7-4dae-b857-59de5c7ef8c3" />
84ee61-eb44-4329-8e4c-77f216212852" />
<img width="1678" height="904" alt="ScreenShot_2026-04-24_140800_128" src="https://github.com/user-attachments/assets/cbe82a79-2c46-4a02-8826-beb9a52bb3f6" />


