### PR TITLE
fix: restore fetchAvailableModels to fix provider lost as custom

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Self-hosted AI chat dashboard for Hermes Agent — multi-model (Claude, GPT, Gemini, DeepSeek) web UI with Telegram, Discord, Slack, WhatsApp integration",
   "repository": {
     "type": "git",

--- a/packages/client/src/stores/hermes/app.ts
+++ b/packages/client/src/stores/hermes/app.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { checkHealth, fetchConfigModels, updateDefaultModel, triggerUpdate, type AvailableModelGroup } from '@/api/hermes/system'
+import { checkHealth, fetchAvailableModels, updateDefaultModel, triggerUpdate, type AvailableModelGroup } from '@/api/hermes/system'
 
 const WEB_UI_VERSION = __APP_VERSION__
 
@@ -57,16 +57,10 @@ export const useAppStore = defineStore('app', () => {
 
   async function loadModels() {
     try {
-      const res = await fetchConfigModels()
-      modelGroups.value = res.groups.map(g => ({
-        provider: g.provider,
-        label: g.provider,
-        base_url: '',
-        models: g.models.map(m => typeof m === 'string' ? m : m.id),
-        api_key: '',
-      }))
+      const res = await fetchAvailableModels()
+      modelGroups.value = res.groups
       selectedModel.value = res.default
-      selectedProvider.value = ''
+      selectedProvider.value = res.default_provider || ''
     } catch {
       // ignore
     }


### PR DESCRIPTION
## Summary
- Reverts the `fetchConfigModels` change from #174 back to `fetchAvailableModels`
- Restores `default_provider` assignment so `selectedProvider` is correctly set on load
- Fixes all models showing as "custom" in the model selector sidebar

## Root cause
#174 replaced `fetchAvailableModels` (`/api/hermes/available-models`) with `fetchConfigModels` (`/api/hermes/config/models`). The config endpoint returns a simpler `ModelGroup` structure that lacks `default_provider`, `label`, `base_url`, and `api_key`. The manual `.map()` in #174 set `selectedProvider = ''` and used raw provider ID as label, causing the model selector to lose provider context and mark everything as custom.

## Test plan
- [ ] Verify model selector shows correct provider groups with proper labels
- [ ] Verify default model and provider are highlighted on load
- [ ] Verify custom models still work correctly
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)