### PR TITLE
fix(docker): skip prepare script during npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN ARCH=$(dpkg --print-architecture) \
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install
+RUN npm install --ignore-scripts
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` to `npm install` in Dockerfile to skip the `prepare` script
- The `prepare` script (added in #142) triggers `npm run build` when `dist/` is missing, but during Docker build source files and tsconfig.json haven't been copied yet

## Test plan
- [ ] Docker build succeeds on both amd64 and arm64
- [ ] Local `npm install` still works normally (prepare runs as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)