### PR TITLE
fix: skip remote profiles in startAll() to prevent startup hang

### DIFF
--- a/packages/server/src/services/hermes/gateway-manager.ts
+++ b/packages/server/src/services/hermes/gateway-manager.ts
@@ -579,6 +579,14 @@ export class GatewayManager {
       }
 
       await this.resolvePort(name)
+
+      // Skip remote profiles — local hermes command cannot start remote gateways
+      const { host } = this.readProfilePort(name)
+      if (host && host !== '127.0.0.1' && host !== 'localhost') {
+        logger.info('%s: remote profile (host=%s), skipping auto-start', name, host)
+        continue
+      }
+
       toStart.push(name)
     }
 


### PR DESCRIPTION
## Problem

When a remote profile exists in `~/.hermes/profiles/` (e.g., a profile with `host: 192.168.x.36`), the `startAll()` method in `gateway-manager.ts` attempts to start it by running `hermes gateway start` locally. This hangs indefinitely because a local process cannot start a gateway on a remote machine.

**Steps to reproduce:**
1. Create a remote profile: `~/.hermes/profiles/o5h/config.yaml` with `host: 192.168.x.36`
2. Start hermes-web-ui
3. Server hangs, never binds to port 8648

## Fix

Added a check in `startAll()` to detect remote profiles by reading the host from the profile's port config. Remote profiles (host != 127.0.0.1/localhost) are skipped with a log message:

```typescript
// Skip remote profiles — local hermes command cannot start remote gateways
const { host } = this.readProfilePort(name)
if (host && host !== '127.0.0.1' && host !== 'localhost') {
  logger.info('%s: remote profile (host=%s), skipping auto-start', name, host)
  continue
}
```

## Testing

- Verified with a remote profile: `o5h: remote profile (host=192.168.x.36), skipping auto-start`
- Local profiles still start normally
- Server binds to port 8648 without hanging

Fixes #195