### PR TITLE
fix(chat): clamp context remaining tokens to 0 instead of negative

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -44,7 +44,7 @@ const totalTokens = computed(() => {
   return input + output
 })
 
-const remainingTokens = computed(() => contextLength.value - totalTokens.value)
+const remainingTokens = computed(() => Math.max(0, contextLength.value - totalTokens.value))
 
 const usagePercent = computed(() =>
   Math.min((totalTokens.value / contextLength.value) * 100, 100),


### PR DESCRIPTION
## Summary
- Clamp `remainingTokens` to 0 with `Math.max(0, ...)` so it never displays a negative value when total usage exceeds the model's context length

## Test plan
- [ ] Use a model where total token usage exceeds context length
- [ ] Verify remaining shows `0` instead of a negative number

🤖 Generated with [Claude Code](https://claude.com/claude-code)