### PR TITLE
feat: cross-machine profile switching with remote backend support

### DIFF
--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -28,19 +28,30 @@ export function hasApiKey(): boolean {
 
 /**
  * Get the effective base URL and API key.
- * Always routes through the local BFF — the BFF resolves the correct
- * upstream backend per profile (via X-Hermes-Profile header).
- * This prevents the browser from needing direct access to remote backends.
+ * If the active profile has a backend_url, route directly to that remote backend.
+ * Otherwise, route through the local BFF.
  */
 function getEffectiveConfig(): { baseUrl: string; apiKey: string } {
+  const backendUrl = localStorage.getItem('hermes_profile_backend_url')
+  const backendToken = localStorage.getItem('hermes_profile_backend_token')
+
+  if (backendUrl) {
+    return {
+      baseUrl: backendUrl,
+      apiKey: backendToken || getApiKey(),
+    }
+  }
+
   return {
     baseUrl: getBaseUrl(),
     apiKey: getApiKey(),
   }
 }
 
-export async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const { baseUrl, apiKey } = getEffectiveConfig()
+export async function request<T>(path: string, options: RequestInit & { forceLocal?: boolean } = {}): Promise<T> {
+  const { baseUrl: effectiveBaseUrl, apiKey: effectiveApiKey } = getEffectiveConfig()
+  const baseUrl = options.forceLocal ? getBaseUrl() : effectiveBaseUrl
+  const apiKey = options.forceLocal ? getApiKey() : effectiveApiKey
   const url = `${baseUrl}${path}`
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -27,31 +27,19 @@ export function hasApiKey(): boolean {
 }
 
 /**
- * Get the effective base URL and API key.
- * If the active profile has a backend_url, route directly to that remote backend.
- * Otherwise, route through the local BFF.
+ * Get the API key for the remote backend if configured.
+ * Used by proxy handler to set Bearer token when forwarding to remote backends.
  */
-function getEffectiveConfig(): { baseUrl: string; apiKey: string } {
-  const backendUrl = localStorage.getItem('hermes_profile_backend_url')
+function getEffectiveApiKey(): string {
   const backendToken = localStorage.getItem('hermes_profile_backend_token')
-
-  if (backendUrl) {
-    return {
-      baseUrl: backendUrl,
-      apiKey: backendToken || getApiKey(),
-    }
-  }
-
-  return {
-    baseUrl: getBaseUrl(),
-    apiKey: getApiKey(),
-  }
+  if (backendToken) return backendToken
+  return getApiKey()
 }
 
 export async function request<T>(path: string, options: RequestInit & { forceLocal?: boolean } = {}): Promise<T> {
-  const { baseUrl: effectiveBaseUrl, apiKey: effectiveApiKey } = getEffectiveConfig()
-  const baseUrl = options.forceLocal ? getBaseUrl() : effectiveBaseUrl
-  const apiKey = options.forceLocal ? getApiKey() : effectiveApiKey
+  // Always use local BFF URL — proxy handler routes based on X-Hermes-Profile header
+  const baseUrl = options.forceLocal ? getBaseUrl() : getBaseUrl()
+  const apiKey = options.forceLocal ? getApiKey() : getApiKey()
   const url = `${baseUrl}${path}`
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -95,3 +83,5 @@ export async function request<T>(path: string, options: RequestInit & { forceLoc
 export function getBaseUrlValue(): string {
   return getBaseUrl()
 }
+
+export { getEffectiveApiKey }

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -26,15 +26,27 @@ export function hasApiKey(): boolean {
   return !!getApiKey()
 }
 
+/**
+ * Get the effective base URL and API key.
+ * Always routes through the local BFF — the BFF resolves the correct
+ * upstream backend per profile (via X-Hermes-Profile header).
+ * This prevents the browser from needing direct access to remote backends.
+ */
+function getEffectiveConfig(): { baseUrl: string; apiKey: string } {
+  return {
+    baseUrl: getBaseUrl(),
+    apiKey: getApiKey(),
+  }
+}
+
 export async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const base = getBaseUrl()
-  const url = `${base}${path}`
+  const { baseUrl, apiKey } = getEffectiveConfig()
+  const url = `${baseUrl}${path}`
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     ...options.headers as Record<string, string>,
   }
 
-  const apiKey = getApiKey()
   if (apiKey) {
     headers['Authorization'] = `Bearer ${apiKey}`
   }

--- a/packages/client/src/api/hermes/gateways.ts
+++ b/packages/client/src/api/hermes/gateways.ts
@@ -10,20 +10,20 @@ export interface GatewayStatus {
 }
 
 export async function fetchGateways(): Promise<GatewayStatus[]> {
-  const res = await request<{ gateways: GatewayStatus[] }>('/api/hermes/gateways')
+  const res = await request<{ gateways: GatewayStatus[] }>('/api/hermes/gateways', { forceLocal: true })
   return res.gateways
 }
 
 export async function startGateway(name: string): Promise<GatewayStatus> {
-  const res = await request<{ success: boolean; gateway: GatewayStatus }>(`/api/hermes/gateways/${name}/start`, { method: 'POST' })
+  const res = await request<{ success: boolean; gateway: GatewayStatus }>(`/api/hermes/gateways/${name}/start`, { method: 'POST', forceLocal: true })
   return res.gateway
 }
 
 export async function stopGateway(name: string): Promise<void> {
-  await request(`/api/hermes/gateways/${name}/stop`, { method: 'POST' })
+  await request(`/api/hermes/gateways/${name}/stop`, { method: 'POST', forceLocal: true })
 }
 
 export async function checkGatewayHealth(name: string): Promise<GatewayStatus> {
-  const res = await request<{ gateway: GatewayStatus }>(`/api/hermes/gateways/${name}/health`)
+  const res = await request<{ gateway: GatewayStatus }>(`/api/hermes/gateways/${name}/health`, { forceLocal: true })
   return res.gateway
 }

--- a/packages/client/src/api/hermes/profiles.ts
+++ b/packages/client/src/api/hermes/profiles.ts
@@ -6,6 +6,8 @@ export interface HermesProfile {
   model: string
   gateway: string
   alias: string
+  backend_url?: string
+  backend_token?: string
 }
 
 export interface HermesProfileDetail {

--- a/packages/client/src/api/hermes/profiles.ts
+++ b/packages/client/src/api/hermes/profiles.ts
@@ -22,12 +22,12 @@ export interface HermesProfileDetail {
 }
 
 export async function fetchProfiles(): Promise<HermesProfile[]> {
-  const res = await request<{ profiles: HermesProfile[] }>('/api/hermes/profiles')
+  const res = await request<{ profiles: HermesProfile[] }>('/api/hermes/profiles', { forceLocal: true })
   return res.profiles
 }
 
 export async function fetchProfileDetail(name: string): Promise<HermesProfileDetail> {
-  const res = await request<{ profile: HermesProfileDetail }>(`/api/hermes/profiles/${encodeURIComponent(name)}`)
+  const res = await request<{ profile: HermesProfileDetail }>(`/api/hermes/profiles/${encodeURIComponent(name)}`, { forceLocal: true })
   return res.profile
 }
 
@@ -36,6 +36,7 @@ export async function createProfile(name: string, clone?: boolean): Promise<bool
     await request('/api/hermes/profiles', {
       method: 'POST',
       body: JSON.stringify({ name, clone }),
+      forceLocal: true,
     })
     return true
   } catch {
@@ -45,7 +46,7 @@ export async function createProfile(name: string, clone?: boolean): Promise<bool
 
 export async function deleteProfile(name: string): Promise<boolean> {
   try {
-    await request(`/api/hermes/profiles/${encodeURIComponent(name)}`, { method: 'DELETE' })
+    await request(`/api/hermes/profiles/${encodeURIComponent(name)}`, { method: 'DELETE', forceLocal: true })
     return true
   } catch {
     return false
@@ -57,6 +58,7 @@ export async function renameProfile(name: string, newName: string): Promise<bool
     await request(`/api/hermes/profiles/${encodeURIComponent(name)}/rename`, {
       method: 'POST',
       body: JSON.stringify({ new_name: newName }),
+      forceLocal: true,
     })
     return true
   } catch {
@@ -69,6 +71,7 @@ export async function switchProfile(name: string): Promise<boolean> {
     await request('/api/hermes/profiles/active', {
       method: 'PUT',
       body: JSON.stringify({ name }),
+      forceLocal: true,
     })
     return true
   } catch {

--- a/packages/client/src/api/hermes/profiles.ts
+++ b/packages/client/src/api/hermes/profiles.ts
@@ -8,6 +8,8 @@ export interface HermesProfile {
   alias: string
   backend_url?: string
   backend_token?: string
+  bff_url?: string
+  bff_token?: string
 }
 
 export interface HermesProfileDetail {

--- a/packages/client/src/api/hermes/system.ts
+++ b/packages/client/src/api/hermes/system.ts
@@ -50,19 +50,19 @@ export interface CustomProvider {
 }
 
 export async function checkHealth(): Promise<HealthResponse> {
-  return request<HealthResponse>('/health')
+  return request<HealthResponse>('/health', { forceLocal: true })
 }
 
 export async function triggerUpdate(): Promise<{ success: boolean; message: string }> {
-  return request<{ success: boolean; message: string }>('/api/hermes/update', { method: 'POST' })
+  return request<{ success: boolean; message: string }>('/api/hermes/update', { method: 'POST', forceLocal: true })
 }
 
 export async function fetchConfigModels(): Promise<ConfigModelsResponse> {
-  return request<ConfigModelsResponse>('/api/hermes/config/models')
+  return request<ConfigModelsResponse>('/api/hermes/config/models', { forceLocal: true })
 }
 
 export async function fetchAvailableModels(): Promise<AvailableModelsResponse> {
-  return request<AvailableModelsResponse>('/api/hermes/available-models')
+  return request<AvailableModelsResponse>('/api/hermes/available-models', { forceLocal: true })
 }
 
 export async function updateDefaultModel(data: {
@@ -74,6 +74,7 @@ export async function updateDefaultModel(data: {
   await request('/api/hermes/config/model', {
     method: 'PUT',
     body: JSON.stringify(data),
+    forceLocal: true,
   })
 }
 
@@ -81,12 +82,14 @@ export async function addCustomProvider(data: CustomProvider): Promise<void> {
   await request('/api/hermes/config/providers', {
     method: 'POST',
     body: JSON.stringify(data),
+    forceLocal: true,
   })
 }
 
 export async function removeCustomProvider(name: string): Promise<void> {
   await request(`/api/hermes/config/providers/${encodeURIComponent(name)}`, {
     method: 'DELETE',
+    forceLocal: true,
   })
 }
 
@@ -99,5 +102,6 @@ export async function updateProvider(poolKey: string, data: {
   await request(`/api/hermes/config/providers/${encodeURIComponent(poolKey)}`, {
     method: 'PUT',
     body: JSON.stringify(data),
+    forceLocal: true,
   })
 }

--- a/packages/client/src/components/hermes/profiles/ProfileCard.vue
+++ b/packages/client/src/components/hermes/profiles/ProfileCard.vue
@@ -99,6 +99,10 @@ async function handleExport() {
         <span class="info-label">{{ t('profiles.gateway') }}</span>
         <code class="info-value mono">{{ profile.gateway }}</code>
       </div>
+      <div v-if="profile.backend_url" class="info-row">
+        <span class="info-label">Backend</span>
+        <code class="info-value mono backend-url">{{ profile.backend_url }}</code>
+      </div>
     </div>
 
     <div class="card-detail-toggle" @click="toggleDetail">

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -5,7 +5,7 @@ import { useI18n } from "vue-i18n";
 import { NButton, NModal, useMessage } from "naive-ui";
 import { useAppStore } from "@/stores/hermes/app";
 import ModelSelector from "./ModelSelector.vue";
-import ProfileSelector from "./ProfileSelector.vue";
+import GatewayTabs from "./GatewayTabs.vue";
 import LanguageSwitch from "./LanguageSwitch.vue";
 import ThemeSwitch from "./ThemeSwitch.vue";
 import { useSessionSearch } from '@/composables/useSessionSearch'
@@ -247,7 +247,7 @@ function openChangelog() {
       </div>
     </nav>
 
-    <ProfileSelector />
+    <GatewayTabs />
     <ModelSelector />
 
     <div class="sidebar-footer">

--- a/packages/client/src/components/layout/GatewayTabs.vue
+++ b/packages/client/src/components/layout/GatewayTabs.vue
@@ -1,0 +1,424 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, nextTick } from 'vue'
+import { NButton, NTooltip, NDropdown, NModal, NInput, NEmpty, useMessage } from 'naive-ui'
+import { useProfilesStore } from '@/stores/hermes/profiles'
+import { useChatStore } from '@/stores/hermes/chat'
+import { useI18n } from 'vue-i18n'
+
+const emit = defineEmits<{
+  (e: 'switch', name: string): void
+}>()
+
+const { t } = useI18n()
+const message = useMessage()
+const profilesStore = useProfilesStore()
+const chatStore = useChatStore()
+
+// ─── Create modal state ──────────────────────────────────────
+const showCreateModal = ref(false)
+const newProfileName = ref('')
+const creating = ref(false)
+
+// ─── Rename modal state ──────────────────────────────────────
+const showRenameModal = ref(false)
+const renameTarget = ref('')
+const renameNewName = ref('')
+const renaming = ref(false)
+
+// ─── Computed ────────────────────────────────────────────────
+const activeName = computed(() => profilesStore.activeProfileName ?? '')
+
+// ─── Context menu options ────────────────────────────────────
+function contextMenuOptions(profileName: string) {
+  return [
+    {
+      label: t('gatewayTabs.rename', 'Rename'),
+      key: 'rename',
+      props: {
+        onClick: () => openRenameModal(profileName),
+      },
+    },
+    {
+      label: t('gatewayTabs.export', 'Export'),
+      key: 'export',
+      props: {
+        onClick: () => handleExport(profileName),
+      },
+    },
+    {
+      type: 'divider',
+      key: 'd1',
+    },
+    {
+      label: t('gatewayTabs.delete', 'Delete'),
+      key: 'delete',
+      props: {
+        style: { color: 'var(--error)' },
+        onClick: () => handleDelete(profileName),
+      },
+    },
+  ]
+}
+
+// ─── Switch profile (smooth, no reload) ─────────────────────
+async function handleSwitch(name: string) {
+  if (name === activeName.value || profilesStore.switching) return
+  const ok = await profilesStore.switchProfileSmooth(name)
+  if (ok) {
+    // Smooth switch: save current chat state, load new profile's state
+    await chatStore.switchChatProfile(name)
+    message.success(t('profiles.switchSuccess', { name }))
+    emit('switch', name)
+  }
+}
+
+// ─── Create profile ─────────────────────────────────────────
+function openCreateModal() {
+  newProfileName.value = ''
+  showCreateModal.value = true
+  nextTick(() => {
+    const input = document.querySelector('.create-profile-input input') as HTMLInputElement
+    input?.focus()
+  })
+}
+
+async function handleCreate() {
+  const name = newProfileName.value.trim()
+  if (!name) {
+    message.warning(t('gatewayTabs.nameRequired', 'Profile name is required'))
+    return
+  }
+  creating.value = true
+  try {
+    const ok = await profilesStore.createProfile(name)
+    if (ok) {
+      message.success(t('gatewayTabs.created', { name }))
+      showCreateModal.value = false
+    } else {
+      message.error(t('gatewayTabs.createFailed', 'Failed to create profile'))
+    }
+  } finally {
+    creating.value = false
+  }
+}
+
+// ─── Rename profile ─────────────────────────────────────────
+function openRenameModal(profileName: string) {
+  renameTarget.value = profileName
+  renameNewName.value = profileName
+  showRenameModal.value = true
+  nextTick(() => {
+    const input = document.querySelector('.rename-profile-input input') as HTMLInputElement
+    input?.focus()
+    input?.select()
+  })
+}
+
+async function handleRename() {
+  const newName = renameNewName.value.trim()
+  if (!newName) {
+    message.warning(t('gatewayTabs.nameRequired', 'Profile name is required'))
+    return
+  }
+  if (newName === renameTarget.value) {
+    showRenameModal.value = false
+    return
+  }
+  renaming.value = true
+  try {
+    const ok = await profilesStore.renameProfile(renameTarget.value, newName)
+    if (ok) {
+      message.success(t('gatewayTabs.renamed', { from: renameTarget.value, to: newName }))
+      showRenameModal.value = false
+    } else {
+      message.error(t('gatewayTabs.renameFailed', 'Failed to rename profile'))
+    }
+  } finally {
+    renaming.value = false
+  }
+}
+
+// ─── Delete profile ─────────────────────────────────────────
+async function handleDelete(name: string) {
+  if (name === activeName.value) {
+    message.warning(t('gatewayTabs.cannotDeleteActive', 'Cannot delete the active profile'))
+    return
+  }
+  const ok = await profilesStore.deleteProfile(name)
+  if (ok) {
+    message.success(t('gatewayTabs.deleted', { name }))
+  } else {
+    message.error(t('gatewayTabs.deleteFailed', 'Failed to delete profile'))
+  }
+}
+
+// ─── Export profile ─────────────────────────────────────────
+async function handleExport(name: string) {
+  try {
+    const ok = await profilesStore.exportProfile(name)
+    if (!ok) {
+      message.error(t('gatewayTabs.exportFailed', 'Failed to export profile'))
+      return
+    }
+    message.success(t('gatewayTabs.exported', { name }))
+  } catch {
+    message.error(t('gatewayTabs.exportFailed', 'Failed to export profile'))
+  }
+}
+
+// ─── Init ───────────────────────────────────────────────────
+onMounted(() => {
+  if (profilesStore.profiles.length === 0) {
+    profilesStore.fetchProfiles()
+  }
+})
+</script>
+
+<template>
+  <div class="gateway-tabs">
+    <div class="tabs-label">{{ t('sidebar.profiles') }}</div>
+
+    <div class="tabs-scroll">
+      <div class="tabs-list">
+        <NDropdown
+          v-for="profile in profilesStore.profiles"
+          :key="profile.name"
+          :options="contextMenuOptions(profile.name)"
+          :trigger="('contextmenu' as any)"
+          placement="bottom-start"
+        >
+          <NTooltip :delay="400" placement="top">
+            <template #trigger>
+              <button
+                class="tab-btn"
+                :class="{
+                  active: profile.name === activeName,
+                  switching: profilesStore.switching && profile.name === activeName,
+                }"
+                :disabled="profilesStore.switching"
+                @click="handleSwitch(profile.name)"
+              >
+                <span class="tab-dot" :class="profile.active ? 'running' : 'unknown'" />
+                <span class="tab-name" :title="profile.alias || profile.name">
+                  {{ profile.alias || profile.name }}
+                </span>
+              </button>
+            </template>
+            <div class="tab-tooltip">
+              <div class="tooltip-name">{{ profile.name }}</div>
+              <div class="tooltip-detail">{{ profile.model }}</div>
+              <div class="tooltip-detail">{{ profile.gateway }}</div>
+              <div v-if="profile.backend_url" class="tooltip-detail tooltip-backend">→ {{ profile.backend_url }}</div>
+            </div>
+          </NTooltip>
+        </NDropdown>
+
+        <NEmpty
+          v-if="profilesStore.profiles.length === 0 && !profilesStore.loading"
+          :description="t('gatewayTabs.noProfiles', 'No profiles')"
+          size="small"
+          class="tabs-empty"
+        />
+      </div>
+
+      <NTooltip placement="top">
+        <template #trigger>
+          <NButton
+            class="add-btn"
+            size="tiny"
+            quaternary
+            circle
+            @click="openCreateModal"
+          >
+            <template #icon>
+              <span class="add-icon">+</span>
+            </template>
+          </NButton>
+        </template>
+        {{ t('gatewayTabs.newProfile', 'New Profile') }}
+      </NTooltip>
+    </div>
+
+    <!-- Create modal -->
+    <NModal
+      v-model:show="showCreateModal"
+      :title="t('gatewayTabs.createTitle', 'Create Profile')"
+      preset="dialog"
+      :positive-text="t('common.confirm', 'Confirm')"
+      :negative-text="t('common.cancel', 'Cancel')"
+      :loading="creating"
+      @positive-click="handleCreate"
+    >
+      <NInput
+        v-model:value="newProfileName"
+        class="create-profile-input"
+        :placeholder="t('gatewayTabs.namePlaceholder', 'Enter profile name')"
+        @keydown.enter="handleCreate"
+      />
+    </NModal>
+
+    <!-- Rename modal -->
+    <NModal
+      v-model:show="showRenameModal"
+      :title="t('gatewayTabs.renameTitle', 'Rename Profile')"
+      preset="dialog"
+      :positive-text="t('common.confirm', 'Confirm')"
+      :negative-text="t('common.cancel', 'Cancel')"
+      :loading="renaming"
+      @positive-click="handleRename"
+    >
+      <NInput
+        v-model:value="renameNewName"
+        class="rename-profile-input"
+        :placeholder="t('gatewayTabs.namePlaceholder', 'Enter new name')"
+        @keydown.enter="handleRename"
+      />
+    </NModal>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/variables' as *;
+
+.gateway-tabs {
+  padding: 0 12px;
+  margin-bottom: 8px;
+}
+
+.tabs-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: $text-muted;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+}
+
+.tabs-scroll {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.tabs-list {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  overflow-x: auto;
+  flex: 1;
+  min-width: 0;
+
+  // Hide scrollbar but keep scrollable
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.tabs-empty {
+  flex: 1;
+  min-width: 0;
+}
+
+.tab-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border: 1px solid transparent;
+  border-radius: $radius-sm;
+  background: transparent;
+  color: $text-secondary;
+  font-size: 12px;
+  font-family: $font-ui;
+  cursor: pointer;
+  white-space: nowrap;
+  max-width: 130px;
+  transition: all $transition-fast;
+  flex-shrink: 0;
+
+  &:hover:not(:disabled) {
+    background: var(--bg-card-hover);
+    color: $text-primary;
+  }
+
+  &.active {
+    background: var(--accent-primary);
+    color: var(--text-on-accent);
+    border-color: var(--accent-primary);
+
+    .tab-dot {
+      border-color: var(--text-on-accent);
+    }
+  }
+
+  &.switching {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+}
+
+.tab-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 1px solid var(--border-color);
+  transition: background $transition-fast;
+
+  &.running {
+    background: var(--success);
+  }
+
+  &.starting {
+    background: var(--warning);
+  }
+
+  &.stopped {
+    background: var(--error);
+  }
+
+  &.unknown {
+    background: var(--text-muted);
+  }
+}
+
+.tab-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.add-btn {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  font-size: 16px;
+  color: $text-muted;
+
+  &:hover {
+    color: $text-primary;
+  }
+}
+
+.add-icon {
+  line-height: 1;
+}
+
+.tab-tooltip {
+  .tooltip-name {
+    font-weight: 600;
+    margin-bottom: 2px;
+  }
+
+  .tooltip-detail {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.7);
+  }
+}
+</style>

--- a/packages/client/src/components/layout/GatewayTabs.vue
+++ b/packages/client/src/components/layout/GatewayTabs.vue
@@ -308,12 +308,21 @@ onMounted(() => {
   flex: 1;
   min-width: 0;
 
-  // Hide scrollbar but keep scrollable
+  // Subtle scrollbar on desktop — thin enough to not clutter, visible enough to signal scrollability
   &::-webkit-scrollbar {
-    display: none;
+    height: 3px;
   }
-  -ms-overflow-style: none;
-  scrollbar-width: none;
+  &::-webkit-scrollbar-thumb {
+    background: rgba(128, 128, 128, 0.3);
+    border-radius: 2px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  scrollbar-width: thin;
+
+  // iOS: enable momentum touch scrolling
+  -webkit-overflow-scrolling: touch;
 }
 
 .tabs-empty {
@@ -336,7 +345,10 @@ onMounted(() => {
   white-space: nowrap;
   max-width: 130px;
   transition: all $transition-fast;
-  flex-shrink: 0;
+
+  // Allow buttons to shrink when space is tight, text will be ellipsized by .tab-name
+  flex-shrink: 1;
+  min-width: 0;
 
   &:hover:not(:disabled) {
     background: var(--bg-card-hover);
@@ -360,6 +372,11 @@ onMounted(() => {
 
   &:disabled {
     cursor: not-allowed;
+  }
+
+  // Ensure min tap target size on mobile (48px touch target)
+  @media (max-width: 768px) {
+    min-height: 32px;
   }
 }
 
@@ -392,6 +409,7 @@ onMounted(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
 }
 
 .add-btn {
@@ -419,6 +437,16 @@ onMounted(() => {
   .tooltip-detail {
     font-size: 11px;
     color: rgba(255, 255, 255, 0.7);
+  }
+}
+
+// Mobile: hide scrollbar for clean look, rely on touch momentum scrolling
+@media (max-width: 768px) {
+  .tabs-list {
+    &::-webkit-scrollbar {
+      height: 0;
+    }
+    scrollbar-width: none;
   }
 }
 </style>

--- a/packages/client/src/components/layout/ProfileSelector.vue
+++ b/packages/client/src/components/layout/ProfileSelector.vue
@@ -10,21 +10,19 @@ const profilesStore = useProfilesStore()
 
 const options = computed(() =>
   profilesStore.profiles.map(p => ({
-    label: p.name,
+    label: p.backend_url ? `${p.name} → ${p.backend_url}` : p.name,
     value: p.name,
   })),
 )
 
 const activeName = computed(() => profilesStore.activeProfile?.name ?? '')
 
-function handleChange(value: string | number | Array<string | number>) {
+async function handleChange(value: string | number | Array<string | number>) {
   if (typeof value === 'string' && value !== activeName.value) {
-    profilesStore.switchProfile(value).then(ok => {
-      if (ok) {
-        message.success(t('profiles.switchSuccess', { name: value }))
-        window.location.reload()
-      }
-    })
+    const ok = await profilesStore.switchProfileSmooth(value)
+    if (ok) {
+      message.success(t('profiles.switchSuccess', { name: value }))
+    }
   }
 }
 

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1197,8 +1197,7 @@ export const useChatStore = defineStore('chat', () => {
     messages: Map<string, Message[]>
   }>>(new Map())
 
-  function saveCurrentProfileState() {
-    const profileName = getProfileName()
+  function saveProfileState(profileName: string) {
     // Build a messages map from the current sessions
     const msgsMap = new Map<string, Message[]>()
     for (const s of sessions.value) {
@@ -1211,6 +1210,10 @@ export const useChatStore = defineStore('chat', () => {
       activeSessionId: activeSessionId.value,
       messages: msgsMap,
     })
+  }
+
+  function saveCurrentProfileState() {
+    saveProfileState(getProfileName())
   }
 
   function loadProfileState(profileName: string) {
@@ -1236,9 +1239,17 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  async function switchChatProfile(profileName: string) {
-    // 1. Save current profile's in-memory state
-    saveCurrentProfileState()
+  async function switchChatProfile(profileName: string, fromProfile?: string) {
+    // 1. Save current profile's in-memory state under the OLD profile name.
+    //    When called from ChatView's watcher, `fromProfile` is the previous
+    //    profile name (before activeProfileName changed). Without this,
+    //    saveCurrentProfileState() would use the already-changed activeProfileName
+    //    and save the old profile's data under the wrong key.
+    if (fromProfile) {
+      saveProfileState(fromProfile)
+    } else {
+      saveCurrentProfileState()
+    }
     // 2. Load the target profile's state from the map (or empty)
     loadProfileState(profileName)
     // 3. Refresh sessions from the API for the new profile

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1188,6 +1188,63 @@ export const useChatStore = defineStore('chat', () => {
     thinkingObservation.clear()
   }
 
+  // ── Multi-profile state switching ──────────────────────────────────────
+  // In-memory map that caches each profile's sessions/activeSessionId/messages
+  // so switching profiles is instant without a page reload.
+  const profileStateMap = ref<Map<string, {
+    sessions: Session[]
+    activeSessionId: string | null
+    messages: Map<string, Message[]>
+  }>>(new Map())
+
+  function saveCurrentProfileState() {
+    const profileName = getProfileName()
+    // Build a messages map from the current sessions
+    const msgsMap = new Map<string, Message[]>()
+    for (const s of sessions.value) {
+      if (s.messages.length > 0) {
+        msgsMap.set(s.id, [...s.messages])
+      }
+    }
+    profileStateMap.value.set(profileName, {
+      sessions: sessions.value.map(s => ({ ...s, messages: [] })),
+      activeSessionId: activeSessionId.value,
+      messages: msgsMap,
+    })
+  }
+
+  function loadProfileState(profileName: string) {
+    const cached = profileStateMap.value.get(profileName)
+    if (cached) {
+      // Restore sessions with their messages from the in-memory cache
+      sessions.value = cached.sessions.map(s => ({
+        ...s,
+        messages: cached.messages.get(s.id) || [],
+      }))
+      activeSessionId.value = cached.activeSessionId
+      // Restore activeSession ref
+      if (cached.activeSessionId) {
+        activeSession.value = sessions.value.find(s => s.id === cached.activeSessionId) || null
+      } else {
+        activeSession.value = null
+      }
+    } else {
+      // No cached state — start fresh
+      sessions.value = []
+      activeSessionId.value = null
+      activeSession.value = null
+    }
+  }
+
+  async function switchChatProfile(profileName: string) {
+    // 1. Save current profile's in-memory state
+    saveCurrentProfileState()
+    // 2. Load the target profile's state from the map (or empty)
+    loadProfileState(profileName)
+    // 3. Refresh sessions from the API for the new profile
+    await loadSessions()
+  }
+
   return {
     sessions,
     activeSessionId,
@@ -1214,5 +1271,6 @@ export const useChatStore = defineStore('chat', () => {
     noteReasoningStart,
     noteReasoningEnd,
     clearThinkingObservationFor,
+    switchChatProfile,
   }
 })

--- a/packages/client/src/stores/hermes/profiles.ts
+++ b/packages/client/src/stores/hermes/profiles.ts
@@ -13,6 +13,10 @@ export const useProfilesStore = defineStore('profiles', () => {
   const detailMap = ref<Record<string, HermesProfileDetail>>({})
   const loading = ref(false)
   const switching = ref(false)
+  // Guard: when true, fetchProfiles() must NOT overwrite activeProfileName.
+  // Set by switchProfileSmooth to prevent the watcher in ChatView from
+  // firing multiple times during a profile switch.
+  let _suppressActiveoverwrite = false
 
   async function fetchProfiles() {
     loading.value = true
@@ -20,9 +24,12 @@ export const useProfilesStore = defineStore('profiles', () => {
       profiles.value = await profilesApi.fetchProfiles()
       activeProfile.value = profiles.value.find(p => p.active) ?? null
       // 同步缓存 profile name，供其他 store 启动时读取
-      if (activeProfile.value) {
+      // Skip if a smooth switch is in progress — the caller sets the correct value.
+      if (!_suppressActiveoverwrite && activeProfile.value) {
         activeProfileName.value = activeProfile.value.name
         localStorage.setItem(ACTIVE_PROFILE_STORAGE_KEY, activeProfile.value.name)
+        // Also update backend config for the active profile
+        updateProfileBackendConfig(activeProfile.value.name)
       }
     } catch (err) {
       console.error('Failed to fetch profiles:', err)
@@ -99,6 +106,60 @@ export const useProfilesStore = defineStore('profiles', () => {
     }
   }
 
+  /**
+   * Smooth profile switch — no page reload.
+   * Calls the API, updates local state & localStorage, then returns.
+   * The caller (chat store) is responsible for refreshing sessions.
+   */
+  async function switchProfileSmooth(name: string): Promise<boolean> {
+    if (name === activeProfileName.value) return true
+    switching.value = true
+    _suppressActiveoverwrite = true
+    try {
+      const ok = await profilesApi.switchProfile(name)
+      if (!ok) return false
+
+      // Update backend config FIRST — before activeProfileName changes,
+      // so ChatView's watcher reads the correct backend_url from localStorage.
+      updateProfileBackendConfig(name)
+
+      // Persist for other stores / cold-start
+      localStorage.setItem(ACTIVE_PROFILE_STORAGE_KEY, name)
+
+      // Update local reactive state — this triggers ChatView's watcher
+      activeProfileName.value = name
+      activeProfile.value = profiles.value.find(p => p.name === name) ?? null
+
+      // Refresh the profiles list so the "active" flag is correct server-side.
+      // fetchProfiles() will NOT overwrite activeProfileName because the guard is set.
+      await fetchProfiles()
+
+      return true
+    } catch (err) {
+      console.error('Smooth profile switch failed:', err)
+      return false
+    } finally {
+      _suppressActiveoverwrite = false
+      switching.value = false
+    }
+  }
+
+  /**
+   * Update localStorage with the backend config for the given profile.
+   * If the profile has a backend_url, all API requests will be sent there.
+   * If not, requests go to the default server URL (local BFF).
+   */
+  function updateProfileBackendConfig(name: string) {
+    const profile = profiles.value.find(p => p.name === name)
+    if (profile?.backend_url) {
+      localStorage.setItem('hermes_profile_backend_url', profile.backend_url)
+      localStorage.setItem('hermes_profile_backend_token', profile.backend_token || '')
+    } else {
+      localStorage.removeItem('hermes_profile_backend_url')
+      localStorage.removeItem('hermes_profile_backend_token')
+    }
+  }
+
   async function exportProfile(name: string) {
     return profilesApi.exportProfile(name)
   }
@@ -122,7 +183,9 @@ export const useProfilesStore = defineStore('profiles', () => {
     deleteProfile,
     renameProfile,
     switchProfile,
+    switchProfileSmooth,
     exportProfile,
     importProfile,
+    updateProfileBackendConfig,
   }
 })

--- a/packages/client/src/views/hermes/ChatView.vue
+++ b/packages/client/src/views/hermes/ChatView.vue
@@ -25,7 +25,10 @@ watch(
   async (newName, oldName) => {
     if (newName && newName !== oldName) {
       const seq = ++_switchSeq
-      await chatStore.switchChatProfile(newName)
+      // Pass oldName so switchChatProfile saves the old profile's state
+      // under the correct key (activeProfileName is already changed by
+      // the time this watcher fires).
+      await chatStore.switchChatProfile(newName, oldName ?? undefined)
       // If another switch happened while we were loading, skip stale result
       if (seq !== _switchSeq) return
       // Re-fetch models from the new profile's gateway

--- a/packages/client/src/views/hermes/ChatView.vue
+++ b/packages/client/src/views/hermes/ChatView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, watch } from 'vue'
 import ChatPanel from '@/components/hermes/chat/ChatPanel.vue'
 import { useAppStore } from '@/stores/hermes/app'
 import { useChatStore } from '@/stores/hermes/chat'
@@ -9,12 +9,30 @@ const appStore = useAppStore()
 const chatStore = useChatStore()
 const profilesStore = useProfilesStore()
 
+// Guard against overlapping switchChatProfile calls
+let _switchSeq = 0
+
 onMounted(async () => {
   appStore.loadModels()
   // 先加载 profile，确保缓存 key 使用正确的 profile name
   await profilesStore.fetchProfiles()
   chatStore.loadSessions()
 })
+
+// Profile 切换时保存当前状态并加载新 profile 的会话和模型列表
+watch(
+  () => profilesStore.activeProfileName,
+  async (newName, oldName) => {
+    if (newName && newName !== oldName) {
+      const seq = ++_switchSeq
+      await chatStore.switchChatProfile(newName)
+      // If another switch happened while we were loading, skip stale result
+      if (seq !== _switchSeq) return
+      // Re-fetch models from the new profile's gateway
+      appStore.loadModels()
+    }
+  },
+)
 </script>
 
 <template>

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -1,4 +1,5 @@
 import * as hermesCli from '../../services/hermes/hermes-cli'
+import { readProfileBackendUrl, normalizeProfileName } from '../../routes/hermes/proxy-handler'
 import { getConversationDetail, listConversationSummaries } from '../../services/hermes/conversations'
 import {
   getConversationDetailFromDb,
@@ -98,6 +99,34 @@ export async function getConversationMessages(ctx: any) {
 export async function list(ctx: any) {
   const source = (ctx.query.source as string) || undefined
   const limit = ctx.query.limit ? parseInt(ctx.query.limit as string, 10) : undefined
+
+  // Check if active profile is remote — proxy to remote BFF
+  // Priority: X-Hermes-Profile header > active_profile file
+  const profileName = normalizeProfileName((ctx.headers['x-hermes-profile'] as string) || getActiveProfileName())
+  if (profileName && profileName !== 'default') {
+    try {
+      // Use bff_url (remote BFF) for session requests, not backend.url (gateway)
+      const backend = readProfileBackendUrl(profileName)
+      const bffUrl = backend.bff_url || backend.url
+      const bffToken = backend.bff_token || backend.token
+      if (bffUrl) {
+        const url = `${bffUrl}/api/hermes/sessions?limit=${limit || 2000}`
+        const headers: Record<string, string> = {}
+        if (bffToken) headers['Authorization'] = `Bearer ${bffToken}`
+        const res = await fetch(url, {
+          headers,
+          signal: AbortSignal.timeout(5000),
+        })
+        if (res.ok) {
+          const data = await res.json()
+          ctx.body = { sessions: data.sessions || [] }
+          return
+        }
+      }
+    } catch (err) {
+      logger.warn(err, 'Remote sessions fetch failed, falling back to local')
+    }
+  }
 
   try {
     const sessions = await listSessionSummaries(source, limit && limit > 0 ? limit : 2000)

--- a/packages/server/src/routes/hermes/proxy-handler.ts
+++ b/packages/server/src/routes/hermes/proxy-handler.ts
@@ -2,6 +2,10 @@ import type { Context } from 'koa'
 import { config } from '../../config'
 import { getGatewayManagerInstance } from '../../services/gateway-bootstrap'
 import { updateUsage } from '../../db/hermes/usage-store'
+import { readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import yaml from 'js-yaml'
 
 function getGatewayManager() { return getGatewayManagerInstance() }
 
@@ -17,6 +21,53 @@ export function setRunSession(runId: string, sessionId: string): void {
 
 function getSessionForRun(runId: string): string | undefined {
   return runSessionMap.get(runId)
+}
+
+// --- Profile backend_url resolution ---
+
+const HERMES_BASE = join(homedir(), '.hermes')
+
+/** Read backend.url and backend.token from a profile's config.yaml */
+function readProfileBackendUrl(profileName: string): { url: string; token: string } {
+  const configPath = profileName === 'default'
+    ? join(HERMES_BASE, 'config.yaml')
+    : join(HERMES_BASE, 'profiles', profileName, 'config.yaml')
+  if (!existsSync(configPath)) return { url: '', token: '' }
+  try {
+    const content = readFileSync(configPath, 'utf-8')
+    const cfg = yaml.load(content) as any || {}
+    const url = cfg?.backend?.url?.trim() || ''
+    const token = cfg?.backend?.token?.trim() || ''
+    return { url, token }
+  } catch {
+    return { url: '', token: '' }
+  }
+}
+
+/** Resolve profile name from request */
+function resolveProfile(ctx: Context): string {
+  return ctx.get('x-hermes-profile') || (ctx.query.profile as string) || 'default'
+}
+
+/** Resolve upstream URL for a request based on profile header/query */
+function resolveUpstream(ctx: Context): string {
+  const profile = resolveProfile(ctx)
+
+  // 1. Check profile's backend.url (remote backend configured in config.yaml)
+  const { url: backendUrl } = readProfileBackendUrl(profile)
+  if (backendUrl) return backendUrl.replace(/\/$/, '')
+
+  // 2. Fall back to GatewayManager (local gateway)
+  const mgr = getGatewayManager()
+  if (mgr) {
+    if (profile && profile !== 'default') {
+      return mgr.getUpstream(profile)
+    }
+    return mgr.getUpstream()
+  }
+
+  // 3. Default upstream
+  return config.upstream.replace(/\/$/, '')
 }
 
 // --- Helpers ---
@@ -47,23 +98,7 @@ async function waitForGatewayReady(upstream: string, timeoutMs: number = 5000): 
   return false
 }
 
-/** Resolve profile name from request */
-function resolveProfile(ctx: Context): string {
-  return ctx.get('x-hermes-profile') || (ctx.query.profile as string) || 'default'
-}
 
-/** Resolve upstream URL for a request based on profile header/query */
-function resolveUpstream(ctx: Context): string {
-  const mgr = getGatewayManager()
-  if (mgr) {
-    const profile = resolveProfile(ctx)
-    if (profile && profile !== 'default') {
-      return mgr.getUpstream(profile)
-    }
-    return mgr.getUpstream()
-  }
-  return config.upstream.replace(/\/$/, '')
-}
 
 function buildProxyHeaders(ctx: Context, upstream: string): Record<string, string> {
   const headers: Record<string, string> = {}
@@ -80,11 +115,20 @@ function buildProxyHeaders(ctx: Context, upstream: string): Record<string, strin
     }
   }
 
+  const profile = resolveProfile(ctx)
   const mgr = getGatewayManager()
   if (mgr) {
-    const apiKey = mgr.getApiKey(resolveProfile(ctx))
+    const apiKey = mgr.getApiKey(profile)
     if (apiKey) {
       headers['authorization'] = `Bearer ${apiKey}`
+    }
+  }
+
+  // Fall back to profile's backend.token for remote backends
+  if (!headers['authorization']) {
+    const { token } = readProfileBackendUrl(profile)
+    if (token) {
+      headers['authorization'] = `Bearer ${token}`
     }
   }
 

--- a/packages/server/src/routes/hermes/proxy-handler.ts
+++ b/packages/server/src/routes/hermes/proxy-handler.ts
@@ -27,26 +27,40 @@ function getSessionForRun(runId: string): string | undefined {
 
 const HERMES_BASE = join(homedir(), '.hermes')
 
-/** Read backend.url and backend.token from a profile's config.yaml */
-function readProfileBackendUrl(profileName: string): { url: string; token: string } {
+/** Read backend config from a profile's config.yaml. Exported for use by sessions controller. */
+export function readProfileBackendUrl(profileName: string): { url: string; token: string; bff_url: string; bff_token: string } {
   const configPath = profileName === 'default'
     ? join(HERMES_BASE, 'config.yaml')
     : join(HERMES_BASE, 'profiles', profileName, 'config.yaml')
-  if (!existsSync(configPath)) return { url: '', token: '' }
+  if (!existsSync(configPath)) return { url: '', token: '', bff_url: '', bff_token: '' }
   try {
     const content = readFileSync(configPath, 'utf-8')
     const cfg = yaml.load(content) as any || {}
     const url = cfg?.backend?.url?.trim() || ''
     const token = cfg?.backend?.token?.trim() || ''
-    return { url, token }
+    const bff_url = cfg?.backend?.bff_url?.trim() || ''
+    const bff_token = cfg?.backend?.bff_token?.trim() || ''
+    return { url, token, bff_url, bff_token }
   } catch {
-    return { url: '', token: '' }
+    return { url: '', token: '', bff_url: '', bff_token: '' }
   }
 }
 
-/** Resolve profile name from request */
+/** Normalize profile name to match actual directory name (case-insensitive). Exported for sessions controller. */
+export function normalizeProfileName(name: string): string {
+  if (name === 'default') return name
+  const exactDir = join(HERMES_BASE, 'profiles', name)
+  if (existsSync(exactDir)) return name
+  const lower = name.toLowerCase()
+  const lowerDir = join(HERMES_BASE, 'profiles', lower)
+  if (existsSync(lowerDir)) return lower
+  return name
+}
+
+/** Resolve profile name from request (normalizes to match actual directory name) */
 function resolveProfile(ctx: Context): string {
-  return ctx.get('x-hermes-profile') || (ctx.query.profile as string) || 'default'
+  const raw = ctx.get('x-hermes-profile') || (ctx.query.profile as string) || 'default'
+  return normalizeProfileName(raw)
 }
 
 /** Resolve upstream URL for a request based on profile header/query */

--- a/packages/server/src/services/hermes/gateway-manager.ts
+++ b/packages/server/src/services/hermes/gateway-manager.ts
@@ -578,14 +578,15 @@ export class GatewayManager {
         try { await this.stop(name) } catch { }
       }
 
-      await this.resolvePort(name)
-
       // Skip remote profiles — local hermes command cannot start remote gateways
+      // Must check BEFORE resolvePort to avoid trying to find free ports on local machine
       const { host } = this.readProfilePort(name)
       if (host && host !== '127.0.0.1' && host !== 'localhost') {
         logger.info('%s: remote profile (host=%s), skipping auto-start', name, host)
         continue
       }
+
+      await this.resolvePort(name)
 
       toStart.push(name)
     }

--- a/packages/server/src/services/hermes/hermes-cli.ts
+++ b/packages/server/src/services/hermes/hermes-cli.ts
@@ -1,5 +1,7 @@
 import { execFile, spawn } from 'child_process'
-import { existsSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
 import { promisify } from 'util'
 import { logger } from '../logger'
 
@@ -364,6 +366,8 @@ export interface HermesProfile {
   model: string
   gateway: string
   alias: string
+  backend_url?: string
+  backend_token?: string
 }
 
 export interface HermesProfileDetail {
@@ -389,6 +393,7 @@ export async function listProfiles(): Promise<HermesProfile[]> {
 
     const lines = stdout.trim().split('\n').filter(Boolean)
     const profiles: HermesProfile[] = []
+    const hermesBase = join(homedir(), '.hermes')
 
     // Skip header lines (starts with " Profile" or " ─")
     for (const line of lines) {
@@ -396,13 +401,30 @@ export async function listProfiles(): Promise<HermesProfile[]> {
 
       const match = line.match(/^\s+(◆)?(\S+)\s{2,}(\S+)\s{2,}(\S+)\s{2,}(.*)$/)
       if (match) {
-        profiles.push({
-          name: match[2],
+        const name = match[2]
+        const profile: HermesProfile = {
+          name,
           active: !!match[1],
           model: match[3],
           gateway: match[4],
           alias: match[5].trim() === '—' ? '' : match[5].trim(),
-        })
+        }
+
+        // Read backend config from profile's config.yaml
+        const configPath = name === 'default'
+          ? join(hermesBase, 'config.yaml')
+          : join(hermesBase, 'profiles', name, 'config.yaml')
+        if (existsSync(configPath)) {
+          try {
+            const content = readFileSync(configPath, 'utf-8')
+            const urlMatch = content.match(/(?:^|\n)\s+url:\s*(.+)$/m)
+            const tokenMatch = content.match(/(?:^|\n)\s+token:\s*(.+)$/m)
+            if (urlMatch) profile.backend_url = urlMatch[1].trim()
+            if (tokenMatch) profile.backend_token = tokenMatch[1].trim()
+          } catch { /* ignore parse errors */ }
+        }
+
+        profiles.push(profile)
       }
     }
 

--- a/packages/server/src/services/hermes/hermes-cli.ts
+++ b/packages/server/src/services/hermes/hermes-cli.ts
@@ -368,6 +368,8 @@ export interface HermesProfile {
   alias: string
   backend_url?: string
   backend_token?: string
+  bff_url?: string
+  bff_token?: string
 }
 
 export interface HermesProfileDetail {
@@ -419,8 +421,12 @@ export async function listProfiles(): Promise<HermesProfile[]> {
             const content = readFileSync(configPath, 'utf-8')
             const urlMatch = content.match(/(?:^|\n)\s+url:\s*(.+)$/m)
             const tokenMatch = content.match(/(?:^|\n)\s+token:\s*(.+)$/m)
+            const bffUrlMatch = content.match(/(?:^|\n)\s+bff_url:\s*(.+)$/m)
+            const bffTokenMatch = content.match(/(?:^|\n)\s+bff_token:\s*(.+)$/m)
             if (urlMatch) profile.backend_url = urlMatch[1].trim()
             if (tokenMatch) profile.backend_token = tokenMatch[1].trim()
+            if (bffUrlMatch) profile.bff_url = bffUrlMatch[1].trim()
+            if (bffTokenMatch) profile.bff_token = bffTokenMatch[1].trim()
           } catch { /* ignore parse errors */ }
         }
 


### PR DESCRIPTION
## Summary

Allow a single hermes-web-ui instance to connect to multiple Hermes Agent backends (local or remote) by switching profiles **without page reload**.

## Motivation

In multi-machine setups (e.g., home lab with multiple Hermes instances), users need to switch between different backends from a single Web UI. Currently, switching profiles requires a full page reload, loses chat state, and doesn't support remote backends at all. This PR adds:

1. **Remote backend routing** — profiles can have `backend.url`, `backend.token`, `bff_url`, and `bff_token` in their `config.yaml`, and the BFF proxy routes requests to the correct upstream
2. **Smooth profile switching** — no page reload, chat state is cached in memory per profile
3. **Model list refresh** — switching profiles automatically fetches the new profile's available models
4. **GatewayTabs UI** — tab-style profile selector with context menu (rename/export/delete)

## Architecture

### Server-side routing (`proxy-handler.ts`)
- `normalizeProfileName()` — case-insensitive profile name matching (`O5H` → `o5h`) to handle browser localStorage vs Linux filesystem case sensitivity
- `readProfileBackendUrl()` — reads `backend.url`, `backend.token`, `bff_url`, `bff_token` from profile `config.yaml`
- `resolveUpstream()` — priority: profile config → GatewayManager → default upstream
- `buildProxyHeaders()` — falls back to profile's `backend.token` for remote backends

### Server-side sessions (`sessions.ts`)
- Detects remote profile via `X-Hermes-Profile` header
- Proxies session list to remote BFF (`bff_url`) instead of gateway (`backend.url`)
- Falls back to local sessions on failure

### Client-side profile switching (`profiles.ts` store)
- `switchProfileSmooth()`: API call → update localStorage → update reactive state (no reload)
- `_suppressActiveOverwrite` guard prevents `fetchProfiles()` from overwriting the active profile during a switch
- `updateProfileBackendConfig()` syncs `backend_url`/`backend_token` to localStorage

### Client-side chat state (`chat.ts` store)
- In-memory `profileStateMap` caches sessions/messages per profile
- `switchChatProfile(profileName, fromProfile)`: saves old state under explicit `fromProfile` key → loads cached state → refreshes from API
- **Fixes session loss bug**: without `fromProfile`, the state was saved under the new profile's key because `activeProfileName` changes before the watcher fires

### SSE authentication (`chat.ts` — `streamRunEvents`)
- Uses BFF token (`getApiKey()`) for SSE EventSource auth, not gateway API key
- BFF proxy handler injects the correct gateway token when forwarding to remote backends
- **Fixes 401 Unauthorized** when streaming chat responses from remote profiles

### UI (`GatewayTabs.vue`)
- Tab-style profile selector replacing the old dropdown
- Right-click context menu for rename/export/delete
- Shows profile alias, model, gateway in tooltip
- Backend URL displayed for remote profiles

## Config format

Remote profile config (`~/.hermes/profiles/o5h/config.yaml`):
```yaml
backend:
  url: http://192.168.31.36:8642        # Gateway API (for /v1/* requests)
  token: o5h-hermes-2026                 # Gateway API key
  bff_url: http://192.168.31.36:8648    # Remote BFF (for /api/* session requests)
  bff_token: <remote-bff-auth-token>    # Remote BFF auth token
```

## Files changed

| File | Change |
|------|--------|
| `packages/client/src/api/client.ts` | Streamlined to always route through local BFF; exports `getEffectiveApiKey()` |
| `packages/client/src/api/hermes/profiles.ts` | Added `bff_url`/`bff_token` fields |
| `packages/client/src/components/layout/GatewayTabs.vue` | **New** tab-style profile selector |
| `packages/client/src/stores/hermes/chat.ts` | Profile state caching + `fromProfile` fix + SSE auth fix |
| `packages/client/src/stores/hermes/profiles.ts` | `switchProfileSmooth` + backend config sync |
| `packages/client/src/views/hermes/ChatView.vue` | Profile watcher passes `oldName` + calls `loadModels()` |
| `packages/server/src/controllers/hermes/sessions.ts` | Remote BFF session proxy |
| `packages/server/src/routes/hermes/proxy-handler.ts` | `normalizeProfileName()` + `bff_url`/`bff_token` support |
| `packages/server/src/services/hermes/gateway-manager.ts` | Skip `resolvePort` for remote profiles |
| `packages/server/src/services/hermes/hermes-cli.ts` | Parse `bff_url`/`bff_token` from config |

## Testing

- [x] Type check passes (`vue-tsc --noEmit`)
- [x] Tested with 2 profiles: default (local) + O5H (remote, 192.168.31.36)
- [x] Profile switching preserves chat state in memory
- [x] Model list refreshes on profile switch
- [x] Session list correctly loaded from remote BFF
- [x] Case-insensitive profile name matching (`O5H` ↔ `o5h`)
- [x] SSE chat streaming works from remote profile
- [x] No 401 errors when switching between profiles

---

> ⚠️ **Note:** This PR was authored by an AI agent (Hermes Agent). All code changes require strict human review before merging.