### PR TITLE
fix: group chat UX polish and model switch cleanup

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -44,7 +44,7 @@ const totalTokens = computed(() => {
   return input + output
 })
 
-const remainingTokens = computed(() => contextLength.value - totalTokens.value)
+const remainingTokens = computed(() => Math.max(0, contextLength.value - totalTokens.value))
 
 const usagePercent = computed(() =>
   Math.min((totalTokens.value / contextLength.value) * 100, 100),

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -90,9 +90,6 @@ function updateMentionState() {
     document.body.removeChild(mirror)
 
     dropdownX.value = rect.left + mirrorRect.width - el.scrollLeft
-    // Estimate Y based on newlines before @ and line height
-    const linesBeforeAt = text.slice(0, atPos + 1).split('\n').length - 1
-    const lineHeight = parseFloat(style.lineHeight) || parseFloat(style.fontSize) * 1.2
     dropdownY.value = rect.top - el.scrollTop - 8
 
     mentionActive.value = filteredAgents.value.length > 0

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -93,7 +93,7 @@ function updateMentionState() {
     // Estimate Y based on newlines before @ and line height
     const linesBeforeAt = text.slice(0, atPos + 1).split('\n').length - 1
     const lineHeight = parseFloat(style.lineHeight) || parseFloat(style.fontSize) * 1.2
-    dropdownY.value = rect.top + linesBeforeAt * lineHeight - el.scrollTop + lineHeight + 4
+    dropdownY.value = rect.top - el.scrollTop - 8
 
     mentionActive.value = filteredAgents.value.length > 0
 }

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -122,12 +122,13 @@ const mentionNames = computed(() => props.agents.map(a => a.name).filter(Boolean
         color: $text-muted;
         font-style: italic;
     }
+}
 
-    .msg-time {
-        font-size: 11px;
-        color: $text-muted;
-        margin-top: 2px;
-    }
+.msg-time {
+    font-size: 12px;
+    color: var(--text-muted);
+    opacity: 0.6;
+    margin-top: 2px;
 }
 
 .msg-content {

--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -139,6 +139,8 @@ export async function setConfigModel(ctx: any) {
     const config = await readConfigYaml()
     if (typeof config.model !== 'object' || config.model === null) { config.model = {} }
     config.model.default = defaultModel
+    delete config.model.base_url
+    delete config.model.api_key
     if (reqProvider) { config.model.provider = reqProvider }
     await writeConfigYaml(config)
     ctx.body = { success: true }


### PR DESCRIPTION
## Summary
- Move @ mention dropdown above the input area so it doesn't block the textarea
- Fix `.msg-time` CSS scoping bug (was nested inside `.msg-header`, never applied)
- Make timestamp smaller (12px) and more subtle (opacity 0.6)
- Clean up stale `base_url`/`api_key` from `config.yaml` when switching models

Closes #204

## Test plan
- [ ] Open group chat, type `@` and verify popup appears above input
- [ ] Verify message timestamps are smaller and more subtle
- [ ] Switch models and verify config.yaml no longer has stale base_url/api_key

🤖 Generated with [Claude Code](https://claude.com/claude-code)