### PR TITLE
fix(chat): surface silently-swallowed run errors with a system message

### DIFF
--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -30,6 +30,9 @@ export interface RunEvent {
   preview?: string
   timestamp?: number
   error?: string
+  /** Final response text on `run.completed`. May be empty/null if the agent
+   * silently swallowed an upstream error — see chat store for fallback. */
+  output?: string | null
   usage?: {
     input_tokens: number
     output_tokens: number

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -834,6 +834,15 @@ export const useChatStore = defineStore('chat', () => {
       // the partial reply. 800ms keeps quota pressure low while guaranteeing
       // at most ~1s of unsaved delta on reload.
       let persistTimer: ReturnType<typeof setTimeout> | null = null
+      // Per-run flags used to detect silently-swallowed errors at run.completed.
+      // hermes-agent occasionally emits run.completed with empty output and no
+      // usage when the agent layer caught an upstream error (e.g. invalid API
+      // key). We need to distinguish: (a) run with assistant text produced,
+      // (b) run with only tool activity, (c) run with truly nothing visible.
+      // Reset per send() call — closures captured by SSE callbacks are scoped
+      // to this run, so there is no cross-run contamination.
+      let runProducedAssistantText = false
+      let runHadToolActivity = false
       const schedulePersist = () => {
         if (sid !== activeSessionId.value || persistTimer) return
         persistTimer = setTimeout(() => {
@@ -855,6 +864,7 @@ export const useChatStore = defineStore('chat', () => {
             case 'thinking.delta': {
               const text = evt.text || evt.delta || ''
               if (!text) break
+              runProducedAssistantText = true
               const msgs = getSessionMsgs(sid)
               const last = msgs[msgs.length - 1]
               if (last?.role === 'assistant' && last.isStreaming) {
@@ -894,6 +904,7 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'message.delta': {
+              if (evt.delta) runProducedAssistantText = true
               const msgs = getSessionMsgs(sid)
               const last = msgs[msgs.length - 1]
               if (last?.role === 'assistant' && last.isStreaming) {
@@ -920,6 +931,7 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'tool.started': {
+              runHadToolActivity = true
               const msgs = getSessionMsgs(sid)
               const last = msgs[msgs.length - 1]
               if (last?.isStreaming) {
@@ -939,6 +951,7 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'tool.completed': {
+              runHadToolActivity = true
               const msgs = getSessionMsgs(sid)
               const toolMsgs = msgs.filter(
                 m => m.role === 'tool' && m.toolStatus === 'running',
@@ -963,6 +976,44 @@ export const useChatStore = defineStore('chat', () => {
                   target.inputTokens = evt.usage.input_tokens
                   target.outputTokens = evt.usage.output_tokens
                 }
+              }
+              // Belt-and-suspenders: some providers may deliver the final
+              // assistant text only via run.completed.output (no message.delta
+              // stream). If we never produced assistant text but the gateway
+              // reports a non-empty output, fall back to rendering it as a
+              // single assistant message so the user actually sees the reply.
+              const finalOutput =
+                typeof evt.output === 'string' ? evt.output : ''
+              const finalOutputTrimmed = finalOutput.trim()
+              if (!runProducedAssistantText && finalOutputTrimmed !== '') {
+                addMessage(sid, {
+                  id: uid(),
+                  role: 'assistant',
+                  content: finalOutput,
+                  timestamp: Date.now(),
+                })
+                runProducedAssistantText = true
+              }
+              // Workaround for upstream hermes-agent bug: when the agent
+              // layer silently swallows an error (e.g. invalid API key,
+              // unsupported model), the gateway still emits run.completed
+              // with an empty output. Without surfacing it here the chat UI
+              // looks frozen / "succeeded with no reply". Detect by the
+              // combination of: no assistant text AND no tool activity AND
+              // empty final output. Usage being zero is a *supporting*
+              // signal but not required, since some providers/local models
+              // legitimately omit usage.
+              const swallowedError =
+                !runProducedAssistantText &&
+                !runHadToolActivity &&
+                finalOutputTrimmed === ''
+              if (swallowedError) {
+                addMessage(sid, {
+                  id: uid(),
+                  role: 'system',
+                  content: 'Error: Agent returned no output. The model call may have failed (e.g. invalid API key, model not supported by provider, or context exceeded). Check the hermes-agent logs for details.',
+                  timestamp: Date.now(),
+                })
               }
               cleanup()
               updateSessionTitle(sid)


### PR DESCRIPTION
## Problem

When the upstream `hermes-agent` swallows an LLM error (e.g. invalid API key, model not supported by the configured provider), the gateway still emits `run.completed` — but with `output: ""` and `usage: {0,0,0}`. The web UI treats this as a successful run and **shows nothing**: no error toast, no system message, no indication that anything went wrong. The user just sees their own message hanging there.

Repro: configure a provider with an invalid API key (or a model the provider doesn't support), send a message. Chat looks frozen. `~/.hermes/logs/agent.log` has the 401, but the UI is silent.

The root cause is upstream (agent layer catches the exception instead of letting `run_conversation` raise so gateway can emit `run.failed`). This PR adds a defensive workaround on the web-ui side so users at least get a visible hint until the upstream fix lands.

## Changes

`packages/client/src/stores/hermes/chat.ts`
- Add two per-run flags inside `send()`:
  - `runProducedAssistantText` — flipped on `reasoning.delta` / `thinking.delta` / `message.delta`
  - `runHadToolActivity` — flipped on `tool.started` / `tool.completed`
- On `run.completed`:
  1. **Fallback rendering**: if no assistant text was streamed but `evt.output` is non-empty, render it as an assistant message. Defends against providers that may deliver the final reply only via `run.completed.output`.
  2. **Swallowed-error detection**: if `!runProducedAssistantText && !runHadToolActivity && output is empty`, append a system message asking the user to check the hermes-agent logs. `usage.total_tokens === 0` is **not** part of the condition because some providers / local models legitimately omit usage.

`packages/client/src/api/hermes/chat.ts`
- Add `output?: string | null` to `RunEvent` interface (was already sent by the gateway, just not typed).

## Test plan

- [x] Configure deepseek with an invalid API key, send a message → system message appears with the hint, the spinner stops, the input is re-enabled.
- [x] Normal session with a working provider → no false positive, assistant reply renders normally.
- [x] Session with only tool calls and no final assistant text → no false positive (tool activity counts).
- [x] `vue-tsc -b` passes.

## Notes

- This is a workaround. The proper fix lives in `hermes-agent` (`gateway/platforms/api_server.py`), where `run_conversation` should propagate / surface upstream LLM errors instead of returning `final_response=""`. I'll open a separate issue/PR there.
- Thanks to the rubber-duck reviewer who caught two important issues with the first version: tool-only runs were being misclassified as errors, and `usage===0` was too strong a condition.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
