### PR TITLE
支持全屏拖拽添加聊天附件

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -5,7 +5,7 @@ import { useAppStore } from '@/stores/hermes/app'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import { fetchContextLength } from '@/api/hermes/sessions'
 import { NButton, NTooltip } from 'naive-ui'
-import { computed, ref, onMounted, watch } from 'vue'
+import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const chatStore = useChatStore()
@@ -15,7 +15,6 @@ const textareaRef = ref<HTMLTextAreaElement>()
 const fileInputRef = ref<HTMLInputElement>()
 const attachments = ref<Attachment[]>([])
 const isDragging = ref(false)
-const dragCounter = ref(0)
 const isComposing = ref(false)
 
 const canSend = computed(() => inputText.value.trim() || attachments.value.length > 0)
@@ -114,14 +113,20 @@ function handleDragEnter(e: DragEvent) {
   if (!isFileDrag(e)) return
 
   e.preventDefault()
-  dragCounter.value++
   isDragging.value = true
 }
 
-function handleDragLeave() {
-  dragCounter.value--
-  if (dragCounter.value <= 0) {
-    dragCounter.value = 0
+function handleDragLeave(e: DragEvent) {
+  if (!isFileDrag(e)) return
+
+  // Window-level drags fire dragleave while crossing child elements. Only hide
+  // the affordance when the pointer actually leaves the viewport.
+  if (
+    e.clientX <= 0
+    || e.clientY <= 0
+    || e.clientX >= window.innerWidth
+    || e.clientY >= window.innerHeight
+  ) {
     isDragging.value = false
   }
 }
@@ -130,13 +135,26 @@ function handleDrop(e: DragEvent) {
   if (!isFileDrag(e)) return
 
   e.preventDefault()
-  dragCounter.value = 0
   isDragging.value = false
   const files = Array.from(e.dataTransfer?.files || [])
   if (!files.length) return
   for (const file of files) addFile(file)
   textareaRef.value?.focus()
 }
+
+onMounted(() => {
+  window.addEventListener('dragover', handleDragOver, true)
+  window.addEventListener('dragenter', handleDragEnter, true)
+  window.addEventListener('dragleave', handleDragLeave, true)
+  window.addEventListener('drop', handleDrop, true)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('dragover', handleDragOver, true)
+  window.removeEventListener('dragenter', handleDragEnter, true)
+  window.removeEventListener('dragleave', handleDragLeave, true)
+  window.removeEventListener('drop', handleDrop, true)
+})
 
 // --- Send ---
 
@@ -204,10 +222,6 @@ function isImage(type: string): boolean {
   <div
     class="chat-input-area"
     :class="{ 'drag-over': isDragging }"
-    @dragover="handleDragOver"
-    @dragenter="handleDragEnter"
-    @dragleave="handleDragLeave"
-    @drop="handleDrop"
   >
     <div v-if="isDragging" class="drop-overlay" aria-live="polite">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 16V4"/><path d="m7 9 5-5 5 5"/><path d="M20 16.5V19a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-2.5"/></svg>
@@ -323,9 +337,9 @@ function isImage(type: string): boolean {
 }
 
 .drop-overlay {
-  position: absolute;
-  inset: 8px 16px;
-  z-index: 2;
+  position: fixed;
+  inset: 16px;
+  z-index: 1000;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -101,16 +101,21 @@ function handlePaste(e: ClipboardEvent) {
 
 // --- Drag and drop ---
 
+function isFileDrag(e: DragEvent): boolean {
+  return Array.from(e.dataTransfer?.types || []).includes('Files')
+}
+
 function handleDragOver(e: DragEvent) {
+  if (!isFileDrag(e)) return
   e.preventDefault()
 }
 
 function handleDragEnter(e: DragEvent) {
+  if (!isFileDrag(e)) return
+
   e.preventDefault()
-  if (e.dataTransfer?.types.includes('Files')) {
-    dragCounter.value++
-    isDragging.value = true
-  }
+  dragCounter.value++
+  isDragging.value = true
 }
 
 function handleDragLeave() {
@@ -122,6 +127,8 @@ function handleDragLeave() {
 }
 
 function handleDrop(e: DragEvent) {
+  if (!isFileDrag(e)) return
+
   e.preventDefault()
   dragCounter.value = 0
   isDragging.value = false
@@ -194,7 +201,18 @@ function isImage(type: string): boolean {
 </script>
 
 <template>
-  <div class="chat-input-area">
+  <div
+    class="chat-input-area"
+    :class="{ 'drag-over': isDragging }"
+    @dragover="handleDragOver"
+    @dragenter="handleDragEnter"
+    @dragleave="handleDragLeave"
+    @drop="handleDrop"
+  >
+    <div v-if="isDragging" class="drop-overlay" aria-live="polite">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 16V4"/><path d="m7 9 5-5 5 5"/><path d="M20 16.5V19a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-2.5"/></svg>
+      <span>{{ t('chat.dropFilesToAttach') }}</span>
+    </div>
     <!-- Top bar: attach + context info -->
     <div class="input-top-bar">
       <NTooltip trigger="hover">
@@ -249,10 +267,6 @@ function isImage(type: string): boolean {
     <div
       class="input-wrapper"
       :class="{ 'drag-over': isDragging }"
-      @dragover="handleDragOver"
-      @dragenter="handleDragEnter"
-      @dragleave="handleDragLeave"
-      @drop="handleDrop"
     >
       <input
         ref="fileInputRef"
@@ -302,9 +316,27 @@ function isImage(type: string): boolean {
 @use '@/styles/variables' as *;
 
 .chat-input-area {
+  position: relative;
   padding: 12px 20px 16px;
   border-top: 1px solid $border-color;
   flex-shrink: 0;
+}
+
+.drop-overlay {
+  position: absolute;
+  inset: 8px 16px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1px dashed var(--accent-info);
+  border-radius: $radius-md;
+  background-color: rgba(var(--accent-info-rgb), 0.08);
+  color: var(--accent-info);
+  font-size: 13px;
+  font-weight: 500;
+  pointer-events: none;
 }
 
 .input-top-bar {

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -99,6 +99,7 @@ export default {
     emptyState: 'Starten Sie eine Konversation mit Hermes Agent',
     inputPlaceholder: 'Nachricht eingeben... (Enter zum Senden, Shift+Enter fur neue Zeile)',
     attachFiles: 'Dateien anhangen',
+    dropFilesToAttach: 'Dateien zum Anhangen ablegen',
     stop: 'Stopp',
     send: 'Senden',
     contextUsed: 'Kontext verwendet:',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -110,6 +110,7 @@ export default {
     emptyState: 'Start a conversation with Hermes Agent',
     inputPlaceholder: 'Type a message... (Enter to send, Shift+Enter for new line)',
     attachFiles: 'Attach files',
+    dropFilesToAttach: 'Drop files to attach',
     stop: 'Stop',
     start: 'Start',
     stopGateway: 'Stop Gateway',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -99,6 +99,7 @@ export default {
     emptyState: 'Inicia una conversacion con Hermes Agent',
     inputPlaceholder: 'Escribe un mensaje... (Enter para enviar, Shift+Enter para nueva linea)',
     attachFiles: 'Adjuntar archivos',
+    dropFilesToAttach: 'Suelta archivos para adjuntarlos',
     stop: 'Detener',
     send: 'Enviar',
     contextUsed: 'Contexto utilizado:',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -99,6 +99,7 @@ export default {
     emptyState: 'Demarrer une conversation avec Hermes Agent',
     inputPlaceholder: 'Tapez un message... (Entree pour envoyer, Shift+Entree pour un saut de ligne)',
     attachFiles: 'Joindre des fichiers',
+    dropFilesToAttach: 'Deposez des fichiers a joindre',
     stop: 'Arreter',
     send: 'Envoyer',
     contextUsed: 'Contexte utilise :',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -99,6 +99,7 @@ export default {
     emptyState: 'Hermes Agent と会話を開始しましょう',
     inputPlaceholder: 'メッセージを入力... (Enter で送信、Shift+Enter で改行)',
     attachFiles: 'ファイルを添付',
+    dropFilesToAttach: 'ファイルをドロップして添付',
     stop: '停止',
     send: '送信',
     contextUsed: 'コンテキスト使用量:',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -99,6 +99,7 @@ export default {
     emptyState: 'Hermes Agent와 대화를 시작하세요',
     inputPlaceholder: '메시지를 입력하세요... (Enter로 전송, Shift+Enter로 줄바꿈)',
     attachFiles: '파일 첨부',
+    dropFilesToAttach: '파일을 드롭하여 첨부',
     stop: '중지',
     send: '전송',
     contextUsed: '사용된 컨텍스트:',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -99,6 +99,7 @@ export default {
     emptyState: 'Inicie uma conversa com o Hermes Agent',
     inputPlaceholder: 'Digite uma mensagem... (Enter para enviar, Shift+Enter para nova linha)',
     attachFiles: 'Anexar arquivos',
+    dropFilesToAttach: 'Solte arquivos para anexar',
     stop: 'Parar',
     send: 'Enviar',
     contextUsed: 'Contexto utilizado:',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -110,6 +110,7 @@ export default {
     emptyState: '开始与 Hermes Agent 对话',
     inputPlaceholder: '输入消息... (Enter 发送，Shift+Enter 换行)',
     attachFiles: '添加附件',
+    dropFilesToAttach: '拖放文件以添加附件',
     stop: '停止',
     start: '启动',
     stopGateway: '停止网关',

--- a/tests/client/chat-input-drag-drop.test.ts
+++ b/tests/client/chat-input-drag-drop.test.ts
@@ -83,11 +83,11 @@ describe('ChatInput drag-in attachments', () => {
     })
   })
 
-  it('shows the drag affordance when files enter the full composer area', async () => {
+  it('shows the drag affordance when files enter anywhere in the window', async () => {
     const wrapper = mountInput()
     const composer = wrapper.find('.chat-input-area')
 
-    fireDragEvent(composer.element, 'dragenter', {
+    fireDragEvent(document.body, 'dragenter', {
       types: ['Files'],
       files: [] as any,
     })
@@ -98,13 +98,13 @@ describe('ChatInput drag-in attachments', () => {
     expect(wrapper.text()).toContain('chat.dropFilesToAttach')
   })
 
-  it('attaches files dropped on the full composer area', async () => {
+  it('attaches files dropped anywhere in the window', async () => {
     const wrapper = mountInput()
     const composer = wrapper.find('.chat-input-area')
     const textFile = new File(['hello'], 'notes.txt', { type: 'text/plain' })
     const imageFile = new File(['png'], 'diagram.png', { type: 'image/png' })
 
-    fireDragEvent(composer.element, 'drop', {
+    fireDragEvent(document.body, 'drop', {
       types: ['Files'],
       files: [textFile, imageFile] as any,
     })
@@ -115,11 +115,28 @@ describe('ChatInput drag-in attachments', () => {
     expect(composer.classes()).not.toContain('drag-over')
   })
 
-  it('ignores non-file drags over the composer area', async () => {
+  it('attaches files even when an inner page element stops drag event bubbling', async () => {
+    const wrapper = mountInput()
+    const blocker = document.createElement('div')
+    document.body.appendChild(blocker)
+    blocker.addEventListener('drop', event => event.stopPropagation())
+
+    const blockedFile = new File(['blocked'], 'blocked.txt', { type: 'text/plain' })
+    fireDragEvent(blocker, 'drop', {
+      types: ['Files'],
+      files: [blockedFile] as any,
+    })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('blocked.txt')
+    blocker.remove()
+  })
+
+  it('ignores non-file drags over the window', async () => {
     const wrapper = mountInput()
     const composer = wrapper.find('.chat-input-area')
 
-    fireDragEvent(composer.element, 'dragenter', {
+    fireDragEvent(document.body, 'dragenter', {
       types: ['text/plain'],
       files: [] as any,
     })
@@ -129,13 +146,12 @@ describe('ChatInput drag-in attachments', () => {
     expect(wrapper.find('.drop-overlay').exists()).toBe(false)
   })
 
-  it('keeps existing duplicate-name attachment behavior for composer drops', async () => {
+  it('keeps existing duplicate-name attachment behavior for window drops', async () => {
     const wrapper = mountInput()
-    const composer = wrapper.find('.chat-input-area')
     const first = new File(['first'], 'same.txt', { type: 'text/plain' })
     const second = new File(['second'], 'same.txt', { type: 'text/plain' })
 
-    fireDragEvent(composer.element, 'drop', {
+    fireDragEvent(document.body, 'drop', {
       types: ['Files'],
       files: [first, second] as any,
     })

--- a/tests/client/chat-input-drag-drop.test.ts
+++ b/tests/client/chat-input-drag-drop.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+const mockChatStore = vi.hoisted(() => ({
+  activeSession: null as Record<string, any> | null,
+  isStreaming: false,
+  sendMessage: vi.fn(),
+  stopStreaming: vi.fn(),
+}))
+
+const mockAppStore = vi.hoisted(() => ({
+  selectedModel: 'gpt-5.5',
+}))
+
+const mockProfilesStore = vi.hoisted(() => ({
+  activeProfileName: 'default' as string | null,
+}))
+
+vi.mock('@/stores/hermes/chat', () => ({
+  useChatStore: () => mockChatStore,
+}))
+
+vi.mock('@/stores/hermes/app', () => ({
+  useAppStore: () => mockAppStore,
+}))
+
+vi.mock('@/stores/hermes/profiles', () => ({
+  useProfilesStore: () => mockProfilesStore,
+}))
+
+vi.mock('@/api/hermes/sessions', () => ({
+  fetchContextLength: vi.fn(async () => 200000),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+import ChatInput from '@/components/hermes/chat/ChatInput.vue'
+
+function mountInput() {
+  return mount(ChatInput, {
+    global: {
+      stubs: {
+        NButton: {
+          template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot name="icon" /><slot /></button>',
+          props: ['disabled'],
+        },
+        NTooltip: {
+          template: '<div><slot name="trigger" /><slot /></div>',
+        },
+      },
+    },
+  })
+}
+
+function fireDragEvent(
+  element: Element,
+  type: string,
+  dataTransfer: Partial<DataTransfer>,
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as DragEvent
+  Object.defineProperty(event, 'dataTransfer', {
+    value: dataTransfer,
+  })
+  element.dispatchEvent(event)
+  return event
+}
+
+describe('ChatInput drag-in attachments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockChatStore.activeSession = null
+    mockChatStore.isStreaming = false
+
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:attachment'),
+      revokeObjectURL: vi.fn(),
+    })
+  })
+
+  it('shows the drag affordance when files enter the full composer area', async () => {
+    const wrapper = mountInput()
+    const composer = wrapper.find('.chat-input-area')
+
+    fireDragEvent(composer.element, 'dragenter', {
+      types: ['Files'],
+      files: [] as any,
+    })
+    await wrapper.vm.$nextTick()
+
+    expect(composer.classes()).toContain('drag-over')
+    expect(wrapper.find('.drop-overlay').exists()).toBe(true)
+    expect(wrapper.text()).toContain('chat.dropFilesToAttach')
+  })
+
+  it('attaches files dropped on the full composer area', async () => {
+    const wrapper = mountInput()
+    const composer = wrapper.find('.chat-input-area')
+    const textFile = new File(['hello'], 'notes.txt', { type: 'text/plain' })
+    const imageFile = new File(['png'], 'diagram.png', { type: 'image/png' })
+
+    fireDragEvent(composer.element, 'drop', {
+      types: ['Files'],
+      files: [textFile, imageFile] as any,
+    })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('notes.txt')
+    expect(wrapper.find('img[alt="diagram.png"]').exists()).toBe(true)
+    expect(composer.classes()).not.toContain('drag-over')
+  })
+
+  it('ignores non-file drags over the composer area', async () => {
+    const wrapper = mountInput()
+    const composer = wrapper.find('.chat-input-area')
+
+    fireDragEvent(composer.element, 'dragenter', {
+      types: ['text/plain'],
+      files: [] as any,
+    })
+    await wrapper.vm.$nextTick()
+
+    expect(composer.classes()).not.toContain('drag-over')
+    expect(wrapper.find('.drop-overlay').exists()).toBe(false)
+  })
+
+  it('keeps existing duplicate-name attachment behavior for composer drops', async () => {
+    const wrapper = mountInput()
+    const composer = wrapper.find('.chat-input-area')
+    const first = new File(['first'], 'same.txt', { type: 'text/plain' })
+    const second = new File(['second'], 'same.txt', { type: 'text/plain' })
+
+    fireDragEvent(composer.element, 'drop', {
+      types: ['Files'],
+      files: [first, second] as any,
+    })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.findAll('.attachment-preview')).toHaveLength(1)
+    expect(wrapper.text()).toContain('same.txt')
+  })
+})


### PR DESCRIPTION
聊天附件拖拽从输入框区域扩到页面级；上传和发送语义保持不变。

## 改动

- 文件可拖到聊天页面任意位置添加为附件。
- 文件拖入页面时显示全屏 drop overlay。
- 全局 drag/drop 监听使用 capture phase，避免内部元素拦截导致失效。
- 非文件拖拽不触发附件状态，也不拦截。
- 保持回形针上传、附件预览、发送逻辑、重复文件名行为不变。
- 组件卸载时清理全局拖拽监听。
- 补充拖拽附件相关 Vitest 覆盖，并补齐新增文案的 i18n key。

## 验证

已通过：

```bash
npm run test -- tests/client/chat-input-drag-drop.test.ts tests/client/i18n-coverage.test.ts
npm run build
```

## 说明

- 未改后端上传/发送语义。
- 未改既有重复文件名判定逻辑。
