### PR TITLE
fix: make context meter compact-aware

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -5,6 +5,7 @@ import { useAppStore } from '@/stores/hermes/app'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import { fetchContextLength } from '@/api/hermes/sessions'
 import { NButton, NTooltip } from 'naive-ui'
+import { selectContextMeterTokens } from '@/utils/context-meter'
 import { computed, ref, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -38,16 +39,12 @@ onMounted(loadContextLength)
 watch(() => useProfilesStore().activeProfileName, loadContextLength)
 watch(() => useAppStore().selectedModel, loadContextLength)
 
-const totalTokens = computed(() => {
-  const input = chatStore.activeSession?.inputTokens ?? 0
-  const output = chatStore.activeSession?.outputTokens ?? 0
-  return input + output
-})
+const contextTokens = computed(() => selectContextMeterTokens(chatStore.messages))
 
-const remainingTokens = computed(() => Math.max(0, contextLength.value - totalTokens.value))
+const remainingTokens = computed(() => Math.max(0, contextLength.value - contextTokens.value))
 
 const usagePercent = computed(() =>
-  Math.min((totalTokens.value / contextLength.value) * 100, 100),
+  Math.min((contextTokens.value / contextLength.value) * 100, 100),
 )
 
 function formatTokens(n: number): string {
@@ -207,10 +204,10 @@ function isImage(type: string): boolean {
         </template>
         {{ t('chat.attachFiles') }}
       </NTooltip>
-      <span v-if="totalTokens > 0" class="context-info" :class="{ 'context-warning': usagePercent > 80 }">
-        {{ formatTokens(totalTokens) }} / {{ formatTokens(contextLength) }} · {{ t('chat.contextRemaining') }} {{ formatTokens(remainingTokens) }}
+      <span v-if="contextTokens > 0" class="context-info" :class="{ 'context-warning': usagePercent > 80 }">
+        {{ formatTokens(contextTokens) }} / {{ formatTokens(contextLength) }} · {{ t('chat.contextRemaining') }} {{ formatTokens(remainingTokens) }}
       </span>
-      <div v-if="totalTokens > 0" class="context-bar">
+      <div v-if="contextTokens > 0" class="context-bar">
         <div
           class="context-bar-fill"
           :class="{

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -32,6 +32,7 @@ export interface Message {
   //   2) 流式：由 reasoning.delta / thinking.delta / reasoning.available 事件累加
   // 不含 <think> 包裹标签；内容自身可以为多段纯文本。
   reasoning?: string
+  tokenCount?: number
 }
 
 export interface Session {
@@ -148,6 +149,7 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
       content: msg.content || '',
       timestamp: Math.round(msg.timestamp * 1000),
       reasoning: msg.reasoning ? msg.reasoning : undefined,
+      tokenCount: typeof msg.token_count === 'number' ? msg.token_count : undefined,
     })
   }
   return result

--- a/packages/client/src/utils/context-meter.ts
+++ b/packages/client/src/utils/context-meter.ts
@@ -1,0 +1,36 @@
+import type { Message } from '@/stores/hermes/chat'
+
+/**
+ * Lightweight UI-only estimate for the prompt-sized context currently loaded in
+ * the active session. This is deliberately not billing usage: input/output usage
+ * is cumulative over model calls and grows even after Hermes compacts a session.
+ */
+export function estimateTextTokens(text: string): number {
+  if (!text) return 0
+  const cjkChars = (text.match(/[\u3400-\u9fff\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]/g) || []).length
+  const otherChars = text.length - cjkChars
+  return Math.ceil(cjkChars * 1.5 + otherChars * 0.25)
+}
+
+export function estimateActiveContextTokens(messages: Array<Pick<Message, 'content' | 'reasoning' | 'toolArgs' | 'toolResult' | 'toolPreview' | 'tokenCount'>>): number {
+  return messages.reduce((sum, message) => {
+    if (typeof message.tokenCount === 'number' && Number.isFinite(message.tokenCount) && message.tokenCount > 0) {
+      return sum + message.tokenCount
+    }
+
+    return sum + estimateTextTokens([
+      message.content,
+      message.reasoning,
+      message.toolArgs,
+      message.toolResult,
+      message.toolPreview,
+    ].filter(Boolean).join('\n'))
+  }, 0)
+}
+
+export function selectContextMeterTokens(
+  messages: Array<Pick<Message, 'content' | 'reasoning' | 'toolArgs' | 'toolResult' | 'toolPreview' | 'tokenCount'>>,
+): number {
+  if (messages.length === 0) return 0
+  return estimateActiveContextTokens(messages)
+}

--- a/tests/client/context-meter.test.ts
+++ b/tests/client/context-meter.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { estimateActiveContextTokens, selectContextMeterTokens } from '@/utils/context-meter'
+
+describe('context meter token accounting', () => {
+  it('uses loaded active-session messages instead of cumulative billing usage', () => {
+    const messages = [
+      { id: 'u1', role: 'user' as const, content: 'hello world', timestamp: 1 },
+      { id: 'a1', role: 'assistant' as const, content: 'short answer', timestamp: 2 },
+    ]
+
+    expect(selectContextMeterTokens(messages)).toBe(
+      estimateActiveContextTokens(messages),
+    )
+  })
+
+  it('hides the meter instead of falling back to cumulative billing usage when no messages are loaded', () => {
+    expect(selectContextMeterTokens([])).toBe(0)
+  })
+
+  it('uses Hermes token_count when available and estimates missing streaming/local messages', () => {
+    const messages = [
+      { id: 'u1', role: 'user' as const, content: 'this exact content should not matter', timestamp: 1, tokenCount: 123 },
+      { id: 'a1', role: 'assistant' as const, content: 'abcd', timestamp: 2 },
+    ]
+
+    expect(estimateActiveContextTokens(messages)).toBe(124)
+  })
+})


### PR DESCRIPTION
## Summary
- Stop using cumulative billing `inputTokens + outputTokens` as the chat context-limit meter.
- Estimate the active context from the loaded active-session messages, preferring Hermes `token_count` when present.
- Hide the meter while no messages are loaded instead of falling back to stale/cumulative billing usage.

## Diagnosis
Hermes compactification makes billing usage and active context diverge. Billing usage continues to grow across model calls and compacted continuations, while the prompt sent to the model has been compacted. WUI was displaying billing usage as if it were current context size, causing false over-limit/negative-remaining indicators after compaction.

For session `20260424_135312_afbd77`, Hermes export shows the original session ended with `end_reason: compression` and continuation children (`20260424_135850_df5057`, `20260424_135850_737f0b`, `20260424_140429_10062c`). That confirms this is a compacted-session path, not just a model context-length metadata issue.

## Tests
- `npm test -- --run tests/client/context-meter.test.ts tests/client/chat-store.test.ts`
- `npm run build`

## Review
- Static security scan of added lines: no findings.
- Independent blocker-only review: passed, no security concerns or logic errors.
