### PR TITLE
fix: reset entire config.model on model switch

### DIFF
--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -137,10 +137,8 @@ export async function setConfigModel(ctx: any) {
   }
   try {
     const config = await readConfigYaml()
-    if (typeof config.model !== 'object' || config.model === null) { config.model = {} }
+    config.model = {}
     config.model.default = defaultModel
-    delete config.model.base_url
-    delete config.model.api_key
     if (reqProvider) { config.model.provider = reqProvider }
     await writeConfigYaml(config)
     ctx.body = { success: true }


### PR DESCRIPTION
## Summary
- Replace config.model with a fresh object on model switch instead of patching in place, preventing stale fields from persisting

🤖 Generated with [Claude Code](https://claude.com/claude-code)