### PR TITLE
fix: model switch reset, custom provider resolution and base_url_env cleanup

### DIFF
--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -137,10 +137,8 @@ export async function setConfigModel(ctx: any) {
   }
   try {
     const config = await readConfigYaml()
-    if (typeof config.model !== 'object' || config.model === null) { config.model = {} }
+    config.model = {}
     config.model.default = defaultModel
-    delete config.model.base_url
-    delete config.model.api_key
     if (reqProvider) { config.model.provider = reqProvider }
     await writeConfigYaml(config)
     ctx.body = { success: true }

--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -15,6 +15,18 @@ export async function getAvailable(ctx: any) {
     if (typeof modelSection === 'object' && modelSection !== null) {
       currentDefault = String(modelSection.default || '').trim()
       currentDefaultProvider = String(modelSection.provider || '').trim()
+      // When hermes CLI sets provider: custom, resolve to custom:name
+      // by matching base_url + model against custom_providers
+      if (currentDefaultProvider === 'custom' && currentDefault) {
+        const cps = Array.isArray(config.custom_providers) ? config.custom_providers as any[] : []
+        const match = cps.find(
+          (cp: any) => cp.base_url?.replace(/\/+$/, '') === String(modelSection.base_url || '').replace(/\/+$/, '')
+            && cp.model === currentDefault,
+        )
+        if (match) {
+          currentDefaultProvider = `custom:${match.name.trim().toLowerCase().replace(/ /g, '-')}`
+        }
+      }
     } else if (typeof modelSection === 'string') {
       currentDefault = modelSection.trim()
     }

--- a/packages/server/src/controllers/hermes/providers.ts
+++ b/packages/server/src/controllers/hermes/providers.ts
@@ -143,6 +143,7 @@ export async function remove(ctx: any) {
       const envMapping = PROVIDER_ENV_MAP[poolKey]
       if (envMapping?.api_key_env) {
         await saveEnvValue(envMapping.api_key_env, '')
+        if (envMapping.base_url_env) { await saveEnvValue(envMapping.base_url_env, '') }
       } else if (!envMapping?.api_key_env) {
         try {
           const authPath = getActiveAuthPath()


### PR DESCRIPTION
## Summary
- Reset entire `config.model` object on model switch to prevent stale fields
- Resolve `provider: custom` (set by hermes CLI) to `custom:name` by matching `base_url` + `model` against `custom_providers`
- Clear `base_url_env` from `.env` when deleting a builtin provider

## Test plan
- [ ] Use hermes CLI to set a custom model, verify `getAvailable` returns correct `custom:name` as `default_provider`
- [ ] Delete a builtin provider with `base_url_env` configured, verify `.env` entry is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)