### PR TITLE
fix: align group chat room sidebar background with session list

### DIFF
--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -519,7 +519,6 @@ export default defineComponent({ components: { CreateRoomForm } })
 .room-sidebar {
     width: 220px;
     flex-shrink: 0;
-    background-color: $bg-sidebar;
     border-right: 1px solid $border-color;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Remove explicit `background-color: $bg-sidebar` from `.room-sidebar` so it matches the single chat session list background

🤖 Generated with [Claude Code](https://claude.com/claude-code)