### PR TITLE
fix(busy-input): implement interrupt mode for busy input feature

### DIFF
--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -94,6 +94,10 @@ export function streamRunEvents(
       if (!closed) {
         closed = true
         source.close()
+        // Trigger onError so the store can clean up stream state and flush
+        // any pending busy-input message. Use a distinct error so the store
+        // can skip server-resync (the run is being interrupted intentionally).
+        onError(new Error('aborted'))
       }
     },
   } as unknown as AbortController

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -20,6 +20,13 @@ const isComposing = ref(false)
 
 const canSend = computed(() => inputText.value.trim() || attachments.value.length > 0)
 
+// Whether the send button should be enabled (respects busy input mode)
+const canSendNow = computed(() => {
+  if (!canSend.value) return false
+  if (!chatStore.isStreaming) return true
+  return chatStore.busyInputMode
+})
+
 // --- Context info ---
 
 const contextLength = ref(200000)
@@ -265,7 +272,7 @@ function isImage(type: string): boolean {
         ref="textareaRef"
         v-model="inputText"
         class="input-textarea"
-        :placeholder="t('chat.inputPlaceholder')"
+        :placeholder="chatStore.isStreaming && chatStore.busyInputMode ? t('chat.interruptPlaceholder') : t('chat.inputPlaceholder')"
         rows="1"
         @keydown="handleKeydown"
         @compositionstart="handleCompositionStart"
@@ -284,14 +291,15 @@ function isImage(type: string): boolean {
         </NButton>
         <NButton
           size="small"
-          type="primary"
-          :disabled="!canSend || chatStore.isStreaming"
+          :type="chatStore.isStreaming && chatStore.busyInputMode ? 'warning' : 'primary'"
+          :disabled="!canSendNow"
           @click="handleSend"
         >
           <template #icon>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+            <svg v-if="chatStore.isStreaming && chatStore.busyInputMode" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+            <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
           </template>
-          {{ t('chat.send') }}
+          {{ chatStore.isStreaming && chatStore.busyInputMode ? t('chat.interrupt') : t('chat.send') }}
         </NButton>
       </div>
     </div>

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -101,6 +101,8 @@ export default {
     attachFiles: 'Dateien anhangen',
     stop: 'Stopp',
     send: 'Senden',
+    interrupt: 'Unterbrechen',
+    interruptPlaceholder: 'Tippen Sie, um die KI zu unterbrechen... (Enter unterbrechen, Esc abbrechen)',
     contextUsed: 'Kontext verwendet:',
     sessions: 'Sitzungen',
     noSessions: 'Keine Sitzungen',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -114,6 +114,8 @@ export default {
     start: 'Start',
     stopGateway: 'Stop Gateway',
     send: 'Send',
+    interrupt: 'Interrupt',
+    interruptPlaceholder: 'Type to interrupt AI... (Enter to interrupt, Esc to cancel)',
     contextUsed: 'Context used:',
     sessions: 'Sessions',
     noSessions: 'No sessions',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -101,6 +101,8 @@ export default {
     attachFiles: 'Adjuntar archivos',
     stop: 'Detener',
     send: 'Enviar',
+    interrupt: 'Interrumpir',
+    interruptPlaceholder: 'Escriba para interrumpir la IA... (Enter interrumpir, Esc cancelar)',
     contextUsed: 'Contexto utilizado:',
     sessions: 'Sesiones',
     noSessions: 'Sin sesiones',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -101,6 +101,8 @@ export default {
     attachFiles: 'Joindre des fichiers',
     stop: 'Arreter',
     send: 'Envoyer',
+    interrupt: 'Interrompre',
+    interruptPlaceholder: 'Tapez pour interrompre l\'IA... (Entree interrompre, Esc annuler)',
     contextUsed: 'Contexte utilise :',
     sessions: 'Sessions',
     noSessions: 'Aucune session',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -101,6 +101,8 @@ export default {
     attachFiles: 'ファイルを添付',
     stop: '停止',
     send: '送信',
+    interrupt: '中断',
+    interruptPlaceholder: '入力してAIを中断... (Enter で中断, Esc でキャンセル)',
     contextUsed: 'コンテキスト使用量:',
     sessions: 'セッション',
     noSessions: 'セッションがありません',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -101,6 +101,8 @@ export default {
     attachFiles: '파일 첨부',
     stop: '중지',
     send: '전송',
+    interrupt: '중단',
+    interruptPlaceholder: '입력하여 AI 중단... (Enter 중단, Esc 취소)',
     contextUsed: '사용된 컨텍스트:',
     sessions: '세션',
     noSessions: '세션 없음',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -101,6 +101,8 @@ export default {
     attachFiles: 'Anexar arquivos',
     stop: 'Parar',
     send: 'Enviar',
+    interrupt: 'Interromper',
+    interruptPlaceholder: 'Digite para interromper a IA... (Enter interromper, Esc cancelar)',
     contextUsed: 'Contexto utilizado:',
     sessions: 'Sessoes',
     noSessions: 'Sem sessoes',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -114,6 +114,8 @@ export default {
     start: '启动',
     stopGateway: '停止网关',
     send: '发送',
+    interrupt: '插话',
+    interruptPlaceholder: '输入以中断 AI... (Enter 中断, Esc 取消)',
     contextUsed: '上下文已用:',
     sessions: '会话',
     noSessions: '暂无会话',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { useAppStore } from './app'
 import { useProfilesStore } from './profiles'
+import { useSettingsStore } from './settings'
 import { detectThinkingBoundary } from '@/utils/thinking-parser'
 
 export interface Attachment {
@@ -349,6 +350,22 @@ export const useChatStore = defineStore('chat', () => {
     isStreaming.value
     || (activeSessionId.value != null && resumingRuns.value.has(activeSessionId.value))
   )
+
+  // --- Busy input mode: queue messages during streaming ---
+  // When the user sends a message while streaming, we:
+  // 1. Immediately show the user message in the chat (so it's visible)
+  // 2. Abort the current SSE stream (triggers gateway's agent.interrupt())
+  // 3. When the run ends (onDone/onError), start a new run with the queued content
+  const pendingMessage = ref<{ content: string; attachments?: Attachment[] } | null>(null)
+  const busyInputMode = computed(() => {
+    try {
+      const settings = useSettingsStore()
+      return settings.display.busy_input_mode === 'interrupt'
+    } catch {
+      return false
+    }
+  })
+
   const pollTimers = new Map<string, ReturnType<typeof setInterval>>()
   const pollSignatures = new Map<string, { sig: string, stableTicks: number }>()
 
@@ -750,8 +767,57 @@ export const useChatStore = defineStore('chat', () => {
     target.updatedAt = Date.now()
   }
 
-  async function sendMessage(content: string, attachments?: Attachment[]) {
-    if ((!content.trim() && !(attachments && attachments.length > 0)) || isStreaming.value) return
+  // Flush any pending message queued during busy input mode.
+  // The user message is already visible in the chat (added immediately in
+  // sendMessage's interrupt branch). This only starts the new run.
+  // skipUserMessage=true tells sendMessage to skip adding the user message
+  // again (it's already in the chat).
+  function flushPendingMessage() {
+    const pending = pendingMessage.value
+    if (!pending) return
+    pendingMessage.value = null
+    // Small delay to let the stream cleanup finish before starting a new run
+    setTimeout(() => {
+      void sendMessage(pending.content, pending.attachments, { skipUserMessage: true })
+    }, 100)
+  }
+
+  async function sendMessage(content: string, attachments?: Attachment[], opts?: { skipUserMessage?: boolean }) {
+    if (!content.trim() && !(attachments && attachments.length > 0)) return
+
+    // Busy input mode: if streaming, immediately show the user message,
+    // abort the current run, and queue a new run for after the abort completes.
+    if (isStreaming.value) {
+      if (busyInputMode.value) {
+        // 1. Immediately add the user message to the chat so it's visible
+        if (!activeSession.value) {
+          const session = createSession()
+          switchSession(session.id)
+        }
+        const sid = activeSessionId.value!
+        const userMsg: Message = {
+          id: uid(),
+          role: 'user',
+          content: content.trim(),
+          timestamp: Date.now(),
+          attachments: attachments && attachments.length > 0 ? attachments : undefined,
+        }
+        addMessage(sid, userMsg)
+        updateSessionTitle(sid)
+        if (sid === activeSessionId.value) {
+          persistActiveMessages()
+          persistSessionsList()
+        }
+
+        // 2. Save the message content for the new run (after abort completes)
+        pendingMessage.value = { content, attachments }
+
+        // 3. Abort SSE — this triggers gateway's agent.interrupt() on disconnect
+        const ctrl = streamStates.value.get(sid)
+        if (ctrl) ctrl.abort()
+      }
+      return
+    }
 
     if (!activeSession.value) {
       const session = createSession()
@@ -761,21 +827,24 @@ export const useChatStore = defineStore('chat', () => {
     // Capture session ID at send time — all callbacks use this, not activeSessionId
     const sid = activeSessionId.value!
 
-    const userMsg: Message = {
-      id: uid(),
-      role: 'user',
-      content: content.trim(),
-      timestamp: Date.now(),
-      attachments: attachments && attachments.length > 0 ? attachments : undefined,
-    }
-    addMessage(sid, userMsg)
-    updateSessionTitle(sid)
-    // Persist immediately so a refresh before the first SSE event (e.g. the
-    // user closes the tab right after sending) still has the user's message
-    // and session title in the cache.
-    if (sid === activeSessionId.value) {
-      persistActiveMessages()
-      persistSessionsList()
+    // Skip adding user message if it was already added during interrupt
+    if (!opts?.skipUserMessage) {
+      const userMsg: Message = {
+        id: uid(),
+        role: 'user',
+        content: content.trim(),
+        timestamp: Date.now(),
+        attachments: attachments && attachments.length > 0 ? attachments : undefined,
+      }
+      addMessage(sid, userMsg)
+      updateSessionTitle(sid)
+      // Persist immediately so a refresh before the first SSE event (e.g. the
+      // user closes the tab right after sending) still has the user's message
+      // and session title in the cache.
+      if (sid === activeSessionId.value) {
+        persistActiveMessages()
+        persistSessionsList()
+      }
     }
 
     try {
@@ -1067,6 +1136,8 @@ export const useChatStore = defineStore('chat', () => {
           }
           cleanup()
           updateSessionTitle(sid)
+          // Send pending message if busy input mode queued one during this run
+          flushPendingMessage()
         },
         // onError
         // Mobile browsers drop EventSource when the tab backgrounds / screen
@@ -1076,7 +1147,10 @@ export const useChatStore = defineStore('chat', () => {
         // the real final answer. If the server fetch itself fails, we leave
         // whatever text we already streamed in place — no visible error.
         (err) => {
-          console.warn('SSE connection dropped, resyncing from server:', err.message)
+          const isAbort = err.message === 'aborted'
+          if (!isAbort) {
+            console.warn('SSE connection dropped, resyncing from server:', err.message)
+          }
           const msgs = getSessionMsgs(sid)
           const last = msgs[msgs.length - 1]
           if (last?.isStreaming) {
@@ -1090,15 +1164,19 @@ export const useChatStore = defineStore('chat', () => {
             }
           })
           cleanup()
-          if (sid === activeSessionId.value) {
+          // Skip server resync on intentional abort — the run was interrupted
+          // by the user and a new run is about to start.
+          if (!isAbort && sid === activeSessionId.value) {
             void refreshActiveSession()
           }
           // The run might still be going on the server side (SSE drop doesn't
           // abort it). If we still have an in-flight record, fall back to
           // polling fetchSession to keep the user updated.
-          if (readInFlight(sid)) {
+          if (!isAbort && readInFlight(sid)) {
             startPolling(sid)
           }
+          // Send pending message if busy input mode queued one during this run
+          flushPendingMessage()
         },
       )
 
@@ -1200,6 +1278,8 @@ export const useChatStore = defineStore('chat', () => {
     isLoadingSessions,
     sessionsLoaded,
     isLoadingMessages,
+    busyInputMode,
+    pendingMessage,
 
     newChat,
     switchSession,

--- a/packages/client/src/views/hermes/ChatView.vue
+++ b/packages/client/src/views/hermes/ChatView.vue
@@ -4,12 +4,16 @@ import ChatPanel from '@/components/hermes/chat/ChatPanel.vue'
 import { useAppStore } from '@/stores/hermes/app'
 import { useChatStore } from '@/stores/hermes/chat'
 import { useProfilesStore } from '@/stores/hermes/profiles'
+import { useSettingsStore } from '@/stores/hermes/settings'
 
 const appStore = useAppStore()
 const chatStore = useChatStore()
 const profilesStore = useProfilesStore()
+const settingsStore = useSettingsStore()
 
 onMounted(async () => {
+  // Load settings first so busyInputMode is available immediately
+  settingsStore.fetchSettings()
   appStore.loadModels()
   // 先加载 profile，确保缓存 key 使用正确的 profile name
   await profilesStore.fetchProfiles()


### PR DESCRIPTION
## Summary

The **Busy Input Mode** setting existed in the UI (Settings → Display → Busy Input Mode) but was completely non-functional. When a user typed during AI streaming and pressed Enter, the message was silently discarded. This PR implements the full interrupt flow, matching the behavior of the Hermes CLI terminal.

## Root Cause

| Layer | Issue |
|-------|-------|
|  (store) |  returned immediately when  was true — message discarded |
|  (API) |  only closed EventSource without triggering  callback |
|  (store) |  was never flushed after run completion |
|  |  was never called on mount, so  was always  |
|  | Send button was disabled during streaming, but textarea was editable (misleading) |

## What This PR Does

### Interrupt Flow
```
User types message → Enter
  ├─ Not streaming → normal send
  └─ Streaming + busyInputMode=interrupt:
       1. User message immediately appears in chat ✅
       2. Abort SSE → triggers gateway agent.interrupt()
       3. Current run ends (onDone/onError)
       4. flushPendingMessage → auto-starts new run
```

### Files Changed (12 files, +137 / -25)

| File | Change |
|------|--------|
| `stores/hermes/chat.ts` | Interrupt branch, pendingMessage logic, `skipUserMessage` flag |
| `api/hermes/chat.ts` | `abort()` triggers `onError(new Error('aborted'))` |
| `ChatInput.vue` | `canSendNow` computed, ⚡ Interrupt button, streaming placeholder |
| `ChatView.vue` | `fetchSettings()` on mount to load busy input mode |
| `i18n` (8 locales) | `interrupt` and `interruptPlaceholder` keys |

### Key Design Decisions

1. **User message is immediately visible** — no invisible pending state. The user sees their message in the chat right away.
2. **Abort triggers cleanup chain** — `onError('aborted')` → `cleanup()` → `flushPendingMessage()`. The `onError` handler skips refresh/polling for abort errors to avoid interfering with the upcoming new run.
3. **Settings loaded on mount** — `fetchSettings()` is called in `ChatView.onMounted()` so `busyInputMode` is available before any streaming starts.

## Testing

1. Enable **Settings → Display → Busy Input Mode**
2. Send a message to start AI streaming
3. During streaming, type a new message and press Enter
4. Verify: user message appears immediately, AI stops current task, new message is processed

## ⚠️ Note

**This PR was submitted by an AI Agent (Hermes). All code changes require strict human review before merging.**