### PR TITLE
fix: use Hermes session endpoint for login token validation

### DIFF
--- a/packages/client/src/views/LoginView.vue
+++ b/packages/client/src/views/LoginView.vue
@@ -57,7 +57,7 @@ async function handleTokenLogin() {
   errorMsg.value = "";
 
   try {
-    const res = await fetch("/api/sessions", {
+    const res = await fetch("/api/hermes/sessions", {
       headers: { Authorization: `Bearer ${key}` },
     });
 

--- a/tests/client/login-view.test.ts
+++ b/tests/client/login-view.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+const mockReplace = vi.hoisted(() => vi.fn())
+const mockFetchAuthStatus = vi.hoisted(() => vi.fn())
+const mockLoginWithPassword = vi.hoisted(() => vi.fn())
+const mockSetApiKey = vi.hoisted(() => vi.fn())
+const mockHasApiKey = vi.hoisted(() => vi.fn())
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('@/api/client', () => ({
+  setApiKey: mockSetApiKey,
+  hasApiKey: mockHasApiKey,
+}))
+
+vi.mock('@/api/auth', () => ({
+  fetchAuthStatus: mockFetchAuthStatus,
+  loginWithPassword: mockLoginWithPassword,
+}))
+
+import LoginView from '@/views/LoginView.vue'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+describe('LoginView token login', () => {
+  beforeEach(() => {
+    delete (window as any).__LOGIN_TOKEN__
+    vi.clearAllMocks()
+    mockHasApiKey.mockReturnValue(false)
+    mockFetchAuthStatus.mockResolvedValue({ hasPasswordLogin: false })
+    mockFetch.mockResolvedValue({ ok: true, status: 200 })
+  })
+
+  it('validates token login against the Hermes sessions endpoint', async () => {
+    const wrapper = mount(LoginView)
+
+    await wrapper.find('input.login-input').setValue('secret-token')
+    await wrapper.find('form.login-form').trigger('submit')
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    expect(mockFetch).toHaveBeenCalledWith('/api/hermes/sessions', {
+      headers: { Authorization: 'Bearer secret-token' },
+    })
+    expect(mockSetApiKey).toHaveBeenCalledWith('secret-token')
+    expect(mockReplace).toHaveBeenCalledWith('/hermes/chat')
+  })
+
+  it('keeps the existing invalid-token behavior on 401', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401 })
+    const wrapper = mount(LoginView)
+
+    await wrapper.find('input.login-input').setValue('bad-token')
+    await wrapper.find('form.login-form').trigger('submit')
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/hermes/sessions', {
+      headers: { Authorization: 'Bearer bad-token' },
+    })
+    expect(wrapper.find('.login-error').text()).toBe('login.invalidToken')
+    expect(mockSetApiKey).not.toHaveBeenCalled()
+    expect(mockReplace).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Follow-up to #148

Login token validation 还在 probe `/api/sessions`，但 server 侧 session route 是 `/api/hermes/sessions`。这里边界很窄：只把登录页的 token validation 接到现有 route，不加 `/api/sessions` alias，也不改 session 语义。

## 改动
- `LoginView.vue` token validation 改用 `/api/hermes/sessions`
- 保持原来的 `Authorization: Bearer <token>` header
- 保持 401 时显示 invalid token、不保存 token、不跳转的行为
- 补 `LoginView` 回归测试，避免再请求不存在的 `/api/sessions`

## 验证
已通过：

```bash
npm run test -- tests/client/login-view.test.ts
npm run build
git diff --check
```

结果：
- `tests/client/login-view.test.ts`: 2 passed
- build passed
- diff check clean

已知：
- `npm test` 仍有既有 i18n coverage 失败，缺少 `changelog.new_0_4_1_1` / `changelog.new_0_4_3_1`..`new_0_4_3_4` 对应 locale keys；和这次 login route 改动无关。

## 附加说明
#148 已经关闭，但 current main 里 upstream fix 没有落到代码里：登录页仍请求 `/api/sessions`，server 仍只暴露 `/api/hermes/sessions` 这一组 session route。#148 thread 里的可用修法更像是本地 installed-package patch，不是已合并的 upstream fix。

所以这个 PR选择改 client probe 到现有 namespaced route，而不是新增 `/api/sessions` alias，主要是避免扩大旧的 endpoint surface。
