### PR TITLE
fix: report web ui version in dev health checks

### DIFF
--- a/packages/server/src/controllers/health.ts
+++ b/packages/server/src/controllers/health.ts
@@ -1,24 +1,61 @@
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
 import * as hermesCli from '../services/hermes/hermes-cli'
 import { getGatewayManagerInstance } from '../services/gateway-bootstrap'
 import { config } from '../config'
 
 declare const __APP_VERSION__: string
+
+type PackageInfo = {
+  name: string
+  version: string
+}
+
+function readPackageInfo(): PackageInfo | null {
+  const candidatePaths = [
+    // ts-node dev: packages/server/src/controllers -> repo root
+    resolve(__dirname, '../../../../package.json'),
+    // bundled server: dist/server -> repo root/package root
+    resolve(__dirname, '../../package.json'),
+    // fallback for dev/test processes started at the repo root
+    resolve(process.cwd(), 'package.json'),
+  ]
+
+  for (const packagePath of candidatePaths) {
+    if (!existsSync(packagePath)) continue
+
+    try {
+      const pkg = JSON.parse(readFileSync(packagePath, 'utf-8'))
+      if (pkg?.name && pkg?.version) {
+        return {
+          name: String(pkg.name),
+          version: String(pkg.version),
+        }
+      }
+    } catch {
+      // Try the next candidate path.
+    }
+  }
+
+  return null
+}
+
+const PACKAGE_INFO = readPackageInfo()
 const LOCAL_VERSION = typeof __APP_VERSION__ !== 'undefined'
   ? __APP_VERSION__
-  : (() => { try { const { readFileSync } = require('fs'); const { resolve } = require('path'); return JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf-8')).version } catch { return '0.0.0' } })()
+  : PACKAGE_INFO?.version || ''
 
 let cachedLatestVersion = ''
 
 export async function checkLatestVersion(): Promise<void> {
   try {
-    const { readFileSync } = require('fs')
-    const pkg = JSON.parse(readFileSync(resolve(require('path').join(__dirname, '../../package.json')), 'utf-8'))
-    const name = pkg.name
-    const res = await fetch(`https://registry.npmjs.org/${name}/latest`, { signal: AbortSignal.timeout(10000) })
+    const packageName = PACKAGE_INFO?.name || 'hermes-web-ui'
+    const registryName = encodeURIComponent(packageName)
+    const res = await fetch(`https://registry.npmjs.org/${registryName}/latest`, { signal: AbortSignal.timeout(10000) })
     if (res.ok) {
       const data = await res.json() as { version: string }
       cachedLatestVersion = data.version
-      if (cachedLatestVersion !== LOCAL_VERSION) {
+      if (LOCAL_VERSION && cachedLatestVersion !== LOCAL_VERSION) {
         console.log(`Update available: ${LOCAL_VERSION} → ${cachedLatestVersion}`)
       }
     }
@@ -47,9 +84,7 @@ export async function healthCheck(ctx: any) {
     gateway: gatewayOk ? 'running' : 'stopped',
     webui_version: LOCAL_VERSION,
     webui_latest: cachedLatestVersion,
-    webui_update_available: cachedLatestVersion && cachedLatestVersion !== LOCAL_VERSION,
+    webui_update_available: Boolean(LOCAL_VERSION && cachedLatestVersion && cachedLatestVersion !== LOCAL_VERSION),
     node_version: process.versions.node,
   }
 }
-
-function resolve(p: string) { return p }

--- a/tests/server/health-controller.test.ts
+++ b/tests/server/health-controller.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+function readRootPackage() {
+  return JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf-8')) as {
+    name: string
+    version: string
+  }
+}
+
+async function loadHealthControllerWithoutInjectedVersion() {
+  vi.resetModules()
+  delete (globalThis as any).__APP_VERSION__
+
+  vi.doMock('../../packages/server/src/services/hermes/hermes-cli', () => ({
+    getVersion: vi.fn().mockResolvedValue('Hermes Agent v0.11.0\n'),
+  }))
+
+  vi.doMock('../../packages/server/src/services/gateway-bootstrap', () => ({
+    getGatewayManagerInstance: vi.fn(() => ({
+      getUpstream: () => 'http://127.0.0.1:9999',
+    })),
+  }))
+
+  return import('../../packages/server/src/controllers/health')
+}
+
+async function loadHealthControllerWithInjectedVersion(version: string) {
+  vi.resetModules()
+  ;(globalThis as any).__APP_VERSION__ = version
+
+  vi.doMock('../../packages/server/src/services/hermes/hermes-cli', () => ({
+    getVersion: vi.fn().mockResolvedValue('Hermes Agent v0.11.0\n'),
+  }))
+
+  vi.doMock('../../packages/server/src/services/gateway-bootstrap', () => ({
+    getGatewayManagerInstance: vi.fn(() => ({
+      getUpstream: () => 'http://127.0.0.1:9999',
+    })),
+  }))
+
+  return import('../../packages/server/src/controllers/health')
+}
+
+function createMockCtx() {
+  return {
+    body: null as any,
+  }
+}
+
+describe('health controller version metadata', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+    ;(globalThis as any).__APP_VERSION__ = 'test'
+  })
+
+  it('reads the root package version in ts-node/dev mode instead of falling back to 0.0.0', async () => {
+    const pkg = readRootPackage()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }))
+
+    const { healthCheck } = await loadHealthControllerWithoutInjectedVersion()
+    const ctx = createMockCtx()
+
+    await healthCheck(ctx)
+
+    expect(ctx.body.webui_version).toBe(pkg.version)
+    expect(ctx.body.webui_version).not.toBe('0.0.0')
+  })
+
+  it('uses the injected build version when available', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }))
+
+    const { healthCheck } = await loadHealthControllerWithInjectedVersion('9.9.9-test')
+    const ctx = createMockCtx()
+
+    await healthCheck(ctx)
+
+    expect(ctx.body.webui_version).toBe('9.9.9-test')
+  })
+
+  it('checks npm latest using the root package name', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const pkg = readRootPackage()
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ version: '99.99.99' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { checkLatestVersion, healthCheck } = await loadHealthControllerWithoutInjectedVersion()
+
+    await checkLatestVersion()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://registry.npmjs.org/${pkg.name}/latest`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+
+    const ctx = createMockCtx()
+    await healthCheck(ctx)
+
+    expect(ctx.body.webui_latest).toBe('99.99.99')
+    expect(ctx.body.webui_update_available).toBe(true)
+  })
+
+  it('does not throw when latest-version lookup fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+
+    const { checkLatestVersion } = await loadHealthControllerWithoutInjectedVersion()
+
+    await expect(checkLatestVersion()).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
`/health` 里的 Web UI version 现在会在 dev/source 模式下从 repo root `package.json` 正确读取，不再因为 `packages/server/package.json` 不存在而回退成 `0.0.0`。这个 PR 只处理 health metadata；changelog、sidebar UI 和 self-update flow 不放进来。

## Changes
- 把 `health.ts` 里的 package metadata 读取集中到一个 helper，覆盖 ts-node dev、bundled server 和 repo-root cwd 三种路径。
- `__APP_VERSION__` 仍然优先，用于 bundled build 注入版本。
- npm latest check 复用同一个 package name，并对 registry URL 做 encode。
- local version 读不到时不再用假的 `0.0.0`，也不会产生假的 update-available 状态。
- 补 server controller tests，覆盖 dev fallback、build-time injected version、npm latest lookup 和 lookup failure。

## Verification
已通过：

```bash
npm run test -- --run tests/server/health-controller.test.ts tests/server/update-controller.test.ts --reporter=dot
npm run build
```

Runtime probe 也通过：

```json
{
  "webui_version": "0.4.7",
  "webui_latest": "0.4.7",
  "webui_update_available": false
}
```

已知：`npm run test -- --run --reporter=dot` 在当前 main 上已有 i18n coverage failure（缺 `changelog.new_0_4_1_1` / `new_0_4_3_*` keys）；stash 后单跑 `tests/client/i18n-coverage.test.ts` 复现同样失败，不是这个 PR 引入。
