### PR TITLE
chore: remove old changelog entries

### DIFF
--- a/packages/client/src/data/changelog.ts
+++ b/packages/client/src/data/changelog.ts
@@ -15,19 +15,4 @@ export const changelog: ChangelogEntry[] = [
     date: '2026-04-24',
     changes: ['changelog.new_0_4_5_1', 'changelog.new_0_4_5_2', 'changelog.new_0_4_5_3', 'changelog.new_0_4_5_4', 'changelog.new_0_4_5_5', 'changelog.new_0_4_5_6', 'changelog.new_0_4_5_7', 'changelog.new_0_4_5_8'],
   },
-  {
-    version: '0.4.2',
-    date: '2026-04-22',
-    changes: ['changelog.new_0_4_3_1', 'changelog.new_0_4_3_2', 'changelog.new_0_4_3_3', 'changelog.new_0_4_3_4'],
-  },
-  {
-    version: '0.4.2',
-    date: '2026-04-22',
-    changes: ['changelog.new_0_4_2_1', 'changelog.new_0_4_2_2', 'changelog.new_0_4_2_3', 'changelog.new_0_4_2_4', 'changelog.new_0_4_2_5'],
-  },
-  {
-    version: '0.4.1',
-    date: '2026-04-21',
-    changes: ['changelog.new_0_4_1_1'],
-  },
 ]


### PR DESCRIPTION
## Summary
- Remove v0.4.1, v0.4.2, v0.4.3 entries from changelog (keep v0.4.5 and v0.4.7)
- Fixes i18n coverage test failures caused by missing translation keys for removed versions

## Test plan
- [x] `npm run test -- --run -t i18n` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)