### PR TITLE
chore: v0.4.9 - remove transition overlay, fix blob URL and image preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Self-hosted AI chat dashboard for Hermes Agent — multi-model (Claude, GPT, Gemini, DeepSeek) web UI with Telegram, Discord, Slack, WhatsApp integration",
   "repository": {
     "type": "git",

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -11,8 +11,6 @@ const chatStore = useChatStore();
 const { t } = useI18n();
 const { isDark } = useTheme();
 const listRef = ref<HTMLElement>();
-const isTransitioning = ref(false);
-let transitionTimer: ReturnType<typeof setTimeout> | null = null;
 
 const displayMessages = computed(() =>
   chatStore.messages.filter((m) => m.role !== "tool"),
@@ -56,59 +54,18 @@ function scrollToMessage(messageId: string) {
   });
 }
 
-// Scroll to bottom once when messages are first loaded after session switch
-let pendingScrollToBottom = false
-let isInitialLoad = true
-
-function showTransition(): void {
-  if (isInitialLoad) return
-  if (transitionTimer) clearTimeout(transitionTimer)
-  isTransitioning.value = true
-}
-
-function hideTransition(): void {
-  if (transitionTimer) clearTimeout(transitionTimer)
-  transitionTimer = setTimeout(() => {
-    isTransitioning.value = false
-    transitionTimer = null
-  }, 100)
-}
-
+// Scroll to bottom on session switch
 watch(
   () => chatStore.activeSessionId,
   (id) => {
     if (!id) return;
-    if (isInitialLoad) {
-      isInitialLoad = false
-      if (!chatStore.focusMessageId) {
-        nextTick(() => scrollToBottom())
-      } else {
-        nextTick(() => scrollToMessage(chatStore.focusMessageId!))
-      }
-      return;
-    }
     if (chatStore.focusMessageId) {
       nextTick(() => scrollToMessage(chatStore.focusMessageId!));
       return;
     }
-    pendingScrollToBottom = true
-    showTransition()
+    nextTick(() => scrollToBottom());
   },
   { immediate: true },
-);
-
-// Safety: ensure overlay is always removed once messages load
-watch(
-  () => chatStore.messages.length,
-  () => {
-    if (pendingScrollToBottom && chatStore.messages.length > 0) {
-      pendingScrollToBottom = false
-      setTimeout(() => {
-        scrollToBottom()
-        hideTransition()
-      }, 300)
-    }
-  },
 );
 
 watch(
@@ -135,15 +92,6 @@ watch(
       scrollToMessage(chatStore.focusMessageId);
       return;
     }
-    if (pendingScrollToBottom) {
-      pendingScrollToBottom = false
-      // Wait a moment for mermaid diagrams to render, then reveal and scroll
-      setTimeout(() => {
-        scrollToBottom()
-        hideTransition()
-      }, 300)
-      return
-    }
     if (!isNearBottom()) return;
     scrollToBottom();
   },
@@ -159,8 +107,8 @@ watch(currentToolCalls, () => {
 </script>
 
 <template>
-  <div ref="listRef" class="message-list" :class="{ 'is-transitioning': isTransitioning }">
-    <div v-if="chatStore.messages.length === 0 && !isTransitioning" class="empty-state">
+  <div ref="listRef" class="message-list">
+    <div v-if="chatStore.messages.length === 0" class="empty-state">
       <img src="/logo.png" alt="Hermes" class="empty-logo" />
       <p>{{ t("chat.emptyState") }}</p>
     </div>
@@ -228,15 +176,9 @@ watch(currentToolCalls, () => {
   flex-direction: column;
   gap: 16px;
   background-color: $bg-card;
-  transition: opacity 0.15s ease;
 
   .dark & {
     background-color: #333333;
-  }
-
-  &.is-transitioning {
-    opacity: 0;
-    pointer-events: none;
   }
 }
 

--- a/packages/client/src/data/changelog.ts
+++ b/packages/client/src/data/changelog.ts
@@ -6,9 +6,9 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
-    version: '0.4.8',
+    version: '0.4.9',
     date: '2026-04-26',
-    changes: ['changelog.new_0_4_8_1', 'changelog.new_0_4_8_2', 'changelog.new_0_4_8_3', 'changelog.new_0_4_8_4', 'changelog.new_0_4_8_5', 'changelog.new_0_4_8_6', 'changelog.new_0_4_8_7', 'changelog.new_0_4_8_8', 'changelog.new_0_4_8_9', 'changelog.new_0_4_8_10'],
+    changes: ['changelog.new_0_4_8_1', 'changelog.new_0_4_8_2', 'changelog.new_0_4_8_3', 'changelog.new_0_4_8_4', 'changelog.new_0_4_8_5', 'changelog.new_0_4_8_7', 'changelog.new_0_4_8_8', 'changelog.new_0_4_8_9', 'changelog.new_0_4_8_10'],
   },
   {
     version: '0.4.7',


### PR DESCRIPTION
## Summary
- Remove session switch transition overlay that caused intermittent white screen
- Replace blob URLs with persistent download URLs (image attachments survive page refresh)
- Add click-to-preview for image attachments
- Move upload directory from `/tmp` to `~/.hermes-web-ui/upload`
- Bump TypeScript lib target to ES2025
- Bump version to 0.4.9

## Test plan
- [ ] Switch between sessions rapidly — no white screen
- [ ] Send an image attachment, refresh page — image still displays
- [ ] Click image attachment — fullscreen preview opens
- [ ] Upload a file — saved to `~/.hermes-web-ui/upload`

🤖 Generated with [Claude Code](https://claude.com/claude-code)