### PR TITLE
fix: add X-Hermes-Session-Id header to preserve tool context across turns

### DIFF
--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -41,9 +41,14 @@ export interface RunEvent {
 }
 
 export async function startRun(body: StartRunRequest): Promise<StartRunResponse> {
+  const headers: Record<string, string> = {}
+  if (body.session_id) {
+    headers['X-Hermes-Session-Id'] = body.session_id
+  }
   return request<StartRunResponse>('/api/hermes/v1/runs', {
     method: 'POST',
     body: JSON.stringify(body),
+    headers,
   })
 }
 


### PR DESCRIPTION
## Summary

Fixes #237

**Root cause:** When `X-Hermes-Session-Id` header is missing, the gateway uses the request body history which only contains user/assistant messages, losing tool call context. The agent sees no prior tool interactions and defaults to text-only responses.

**Fix:** Add `X-Hermes-Session-Id` header to `startRun()` so the gateway loads full session history from the session DB (including tool messages). This preserves the complete tool interaction context throughout the conversation.

**Fix from this PR:** `packages/client/src/api/hermes/chat.ts` — add `X-Hermes-Session-Id` header when `session_id` is available.

## ⚠️ Note

**This fix is based on code/logic analysis only, not on tested reproduction of the bug.**

The intermittent nature of the issue makes it difficult to reliably reproduce and verify. The fix addresses the only logical code path that could cause the reported behavior, but has not been verified against a live reproduction of the bug.

## Verification

- [ ] Reproduce the original bug (intermittent — may require multiple conversations)
- [ ] Confirm that with the fix, the agent executes tool calls consistently across long conversations
- [ ] Verify `X-Hermes-Session-Id` header is present in network requests
- [ ] Test with both API Server mode (web-ui) and CLI mode to confirm no regression