### PR TITLE
fix: include tool messages in conversation_history to fix agent lazy behavior

### DIFF
--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -1,7 +1,7 @@
 import { request, getBaseUrlValue, getApiKey } from '../client'
 
 export interface ChatMessage {
-  role: 'user' | 'assistant' | 'system'
+  role: 'user' | 'assistant' | 'system' | 'tool'
   content: string
 }
 

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -791,8 +791,8 @@ export const useChatStore = defineStore('chat', () => {
       // Build conversation history from past messages
       const sessionMsgs = getSessionMsgs(sid)
       const history: ChatMessage[] = sessionMsgs
-        .filter(m => (m.role === 'user' || m.role === 'assistant') && m.content.trim())
-        .map(m => ({ role: m.role as 'user' | 'assistant' | 'system', content: m.content }))
+        .filter(m => (m.role === 'user' || m.role === 'assistant' || m.role === 'tool') && m.content.trim())
+        .map(m => ({ role: m.role as 'user' | 'assistant' | 'system' | 'tool', content: m.content }))
 
       // Upload attachments and build input with file paths
       let inputText = content.trim()


### PR DESCRIPTION
## Problem

The agent exhibits "lazy" behavior — responding with text only instead of calling tools, especially after tool results were returned in previous turns.

## Root Cause

 filtered  to only / messages, stripping all  messages. This caused the LLM to lose context about previous tool calls.

## Fix

- Added  to the  type in 
- Added  to the conversation history filter and type assertion in 

Addresses #237 (client-side fix; gateway-side fix needed for full resolution).