### PR TITLE
fix(chat): prevent duplicate user messages

### DIFF
--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -777,6 +777,14 @@ export const useChatStore = defineStore('chat', () => {
       timestamp: Date.now(),
       attachments: attachments && attachments.length > 0 ? attachments : undefined,
     }
+    // Build conversation history BEFORE adding the new message, so the
+    // user's current message appears only in `input` — not duplicated in
+    // `conversation_history` as well.
+    const sessionMsgs = getSessionMsgs(sid)
+    const history: ChatMessage[] = sessionMsgs
+      .filter(m => (m.role === 'user' || m.role === 'assistant') && m.content.trim())
+      .map(m => ({ role: m.role as 'user' | 'assistant' | 'system', content: m.content }))
+
     addMessage(sid, userMsg)
     updateSessionTitle(sid)
     // Persist immediately so a refresh before the first SSE event (e.g. the
@@ -788,11 +796,6 @@ export const useChatStore = defineStore('chat', () => {
     }
 
     try {
-      // Build conversation history from past messages
-      const sessionMsgs = getSessionMsgs(sid)
-      const history: ChatMessage[] = sessionMsgs
-        .filter(m => (m.role === 'user' || m.role === 'assistant') && m.content.trim())
-        .map(m => ({ role: m.role as 'user' | 'assistant' | 'system', content: m.content }))
 
       // Upload attachments and build input with file paths
       let inputText = content.trim()


### PR DESCRIPTION
## Summary
- Fix #257 — 用户发送消息时后端收到两份相同消息
- 将 `conversation_history` 的构建移到 `addMessage` 之前，避免用户消息同时出现在 `input` 和 `conversation_history` 中

## Root Cause
`sendMessage()` 先将用户消息加入 session，再从 session 取历史构建 `conversation_history`，导致同一条消息在 `input` 和 `conversation_history` 中各出现一次，后端收到两份。

## Fix
在 `addMessage` 之前构建 `conversation_history`，确保用户消息只通过 `input` 字段发送一次。

## Test plan
- [ ] 发送普通消息，确认后端只收到一次
- [ ] 发送带附件的消息，确认不重复
- [ ] 在已有对话中继续发送，确认历史消息正常

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)