### PR TITLE
feat: Add agent mood animations for multiple emotional states

### DIFF
--- a/packages/client/src/components/hermes/chat/AgentMood.vue
+++ b/packages/client/src/components/hermes/chat/AgentMood.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useTheme } from '@/composables/useTheme'
+import type { AgentMood } from '@/stores/hermes/chat'
+import thinkingVideoLight from '@/assets/thinking-light.mp4'
+import thinkingVideoDark from '@/assets/thinking-dark.mp4'
+
+const props = defineProps<{ mood: AgentMood }>()
+
+const { isDark } = useTheme()
+
+const thinkingSrc = computed(() => (isDark.value ? thinkingVideoDark : thinkingVideoLight))
+
+const moodEmoji: Record<Exclude<AgentMood, 'idle' | 'thinking'>, string> = {
+  success: '✅',
+  failed: '❌',
+  happy: '😊',
+  curious: '🤔',
+  excited: '🎉',
+  sad: '😢',
+}
+</script>
+
+<template>
+  <Transition name="mood" mode="out-in">
+    <video
+      v-if="mood === 'thinking'"
+      key="thinking"
+      :src="thinkingSrc"
+      width="120"
+      height="213"
+      autoplay
+      loop
+      muted
+      playsinline
+      class="mood-video"
+    />
+    <span
+      v-else-if="mood !== 'idle'"
+      :key="mood"
+      class="mood-emoji"
+      :class="`anim-${mood}`"
+    >{{ moodEmoji[mood as keyof typeof moodEmoji] }}</span>
+  </Transition>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/variables' as *;
+
+.mood-video {
+  flex-shrink: 0;
+  border-radius: $radius-md;
+  object-fit: contain;
+}
+
+.mood-emoji {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 88px;
+  line-height: 1;
+  width: 120px;
+  height: 213px;
+  flex-shrink: 0;
+  border-radius: $radius-md;
+  background: rgba(0, 0, 0, 0.03);
+  user-select: none;
+
+  .dark & {
+    background: rgba(255, 255, 255, 0.06);
+  }
+}
+
+// ── Mood animations ────────────────────────────────────────────
+
+.anim-success {
+  animation: scale-glow 1.2s ease-in-out infinite;
+}
+
+.anim-failed {
+  animation: shake 0.6s ease-in-out infinite;
+}
+
+.anim-happy {
+  animation: gentle-bounce 1.6s ease-in-out infinite;
+}
+
+.anim-curious {
+  animation: tilt-rock 2s ease-in-out infinite;
+}
+
+.anim-excited {
+  animation: rapid-bounce 0.6s ease-in-out infinite;
+}
+
+.anim-sad {
+  animation: slow-drop 2s ease-in-out infinite;
+}
+
+// ── Keyframes ──────────────────────────────────────────────────
+
+@keyframes scale-glow {
+  0%, 100% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 0px transparent);
+  }
+  50% {
+    transform: scale(1.12);
+    filter: drop-shadow(0 0 12px rgba(var(--success-rgb), 0.5));
+  }
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-6px) rotate(-2deg); }
+  40% { transform: translateX(6px) rotate(2deg); }
+  60% { transform: translateX(-4px) rotate(-1deg); }
+  80% { transform: translateX(4px) rotate(1deg); }
+}
+
+@keyframes gentle-bounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-10px); }
+}
+
+@keyframes tilt-rock {
+  0%, 100% { transform: rotate(0deg); }
+  25% { transform: rotate(10deg); }
+  75% { transform: rotate(-10deg); }
+}
+
+@keyframes rapid-bounce {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-14px) scale(1.08); }
+}
+
+@keyframes slow-drop {
+  0% { transform: translateY(0); opacity: 1; }
+  60% { transform: translateY(10px); opacity: 0.5; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+
+// ── Transition between moods ───────────────────────────────────
+
+.mood-enter-active,
+.mood-leave-active {
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.mood-enter-from {
+  opacity: 0;
+  transform: scale(0.7);
+}
+
+.mood-leave-to {
+  opacity: 0;
+  transform: scale(0.8);
+}
+</style>

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -2,14 +2,10 @@
 import { ref, computed, watch, nextTick } from "vue";
 import { useI18n } from "vue-i18n";
 import MessageItem from "./MessageItem.vue";
+import AgentMood from "./AgentMood.vue";
 import { useChatStore } from "@/stores/hermes/chat";
-import thinkingVideoLight from "@/assets/thinking-light.mp4";
-import thinkingVideoDark from "@/assets/thinking-dark.mp4";
-import { useTheme } from "@/composables/useTheme";
-
 const chatStore = useChatStore();
 const { t } = useI18n();
-const { isDark } = useTheme();
 const listRef = ref<HTMLElement>();
 
 const displayMessages = computed(() =>
@@ -119,15 +115,8 @@ watch(currentToolCalls, () => {
       :highlight="chatStore.focusMessageId === msg.id"
     />
     <Transition name="fade">
-      <div v-if="chatStore.isRunActive" class="streaming-indicator">
-        <video
-          :src="isDark ? thinkingVideoDark : thinkingVideoLight"
-          autoplay
-          loop
-          muted
-          playsinline
-          class="thinking-video"
-        />
+      <div v-if="chatStore.isRunActive || chatStore.agentMood !== 'idle'" class="streaming-indicator">
+        <AgentMood :mood="chatStore.agentMood" />
         <div v-if="currentToolCalls.length > 0" class="tool-calls-panel">
           <div
             v-for="tc in currentToolCalls"
@@ -216,13 +205,6 @@ watch(currentToolCalls, () => {
   align-items: flex-start;
   gap: 12px;
   padding: 4px;
-  .thinking-video {
-    width: 120px;
-    height: 213px;
-    border-radius: $radius-md;
-    object-fit: contain;
-    flex-shrink: 0;
-  }
 }
 
 .tool-calls-panel {

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -165,6 +165,17 @@ export default {
     copyFailed: 'Copy failed',
   },
 
+  // Agent moods
+  moods: {
+    thinking: 'Thinking',
+    success: 'Done',
+    failed: 'Failed',
+    happy: 'Happy',
+    curious: 'Curious',
+    excited: 'Excited',
+    sad: 'Sad',
+  },
+
   // Jobs
   jobs: {
     title: 'Scheduled Jobs',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -165,6 +165,17 @@ export default {
     copyFailed: '复制失败',
   },
 
+  // 代理情绪
+  moods: {
+    thinking: '思考中',
+    success: '完成',
+    failed: '失败',
+    happy: '开心',
+    curious: '好奇',
+    excited: '兴奋',
+    sad: '难过',
+  },
+
   // 定时任务
   jobs: {
     title: '定时任务',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -333,6 +333,10 @@ function scrubBuggyReasoningInCache(msgs: Message[] | null | undefined): Message
   })
 }
 
+export type AgentMood = 'idle' | 'thinking' | 'success' | 'failed' | 'happy' | 'curious' | 'excited' | 'sad'
+
+const POSITIVE_WORDS = /\b(success|done|great|complete|perfect|excellent|awesome|搞定|完成|成功|太好了|完美)\b/i
+
 export const useChatStore = defineStore('chat', () => {
   const sessions = ref<Session[]>([])
   const activeSessionId = ref<string | null>(null)
@@ -342,6 +346,24 @@ export const useChatStore = defineStore('chat', () => {
   const isLoadingSessions = ref(false)
   const sessionsLoaded = ref(false)
   const isLoadingMessages = ref(false)
+
+  const agentMood = ref<AgentMood>('idle')
+  const completedToolCount = ref(0)
+  let moodResetTimer: ReturnType<typeof setTimeout> | null = null
+
+  function setMood(mood: AgentMood, autoReset = false) {
+    if (moodResetTimer) {
+      clearTimeout(moodResetTimer)
+      moodResetTimer = null
+    }
+    agentMood.value = mood
+    if (autoReset && mood !== 'idle') {
+      moodResetTimer = setTimeout(() => {
+        agentMood.value = 'idle'
+        moodResetTimer = null
+      }, 3000)
+    }
+  }
   // tmux-like resume state: true when we recovered an in-flight run from
   // localStorage after a refresh and are polling fetchSession for progress.
   // UI shows the thinking indicator while this is set.
@@ -884,6 +906,8 @@ export const useChatStore = defineStore('chat', () => {
         (evt: RunEvent) => {
           switch (evt.event) {
             case 'run.started':
+              completedToolCount.value = 0
+              setMood('thinking')
               break
 
             case 'reasoning.delta':
@@ -958,6 +982,7 @@ export const useChatStore = defineStore('chat', () => {
 
             case 'tool.started': {
               runHadToolActivity = true
+              if (agentMood.value === 'thinking') setMood('curious')
               const msgs = getSessionMsgs(sid)
               const last = msgs[msgs.length - 1]
               if (last?.isStreaming) {
@@ -978,6 +1003,7 @@ export const useChatStore = defineStore('chat', () => {
 
             case 'tool.completed': {
               runHadToolActivity = true
+              completedToolCount.value += 1
               const msgs = getSessionMsgs(sid)
               const toolMsgs = msgs.filter(
                 m => m.role === 'tool' && m.toolStatus === 'running',
@@ -1041,6 +1067,20 @@ export const useChatStore = defineStore('chat', () => {
                   timestamp: Date.now(),
                 })
               }
+
+              // Determine final mood based on outcome
+              if (swallowedError) {
+                setMood('failed', true)
+              } else if (completedToolCount.value >= 3) {
+                setMood('excited', true)
+              } else {
+                const lastAssistant = [...getSessionMsgs(sid)].reverse().find(m => m.role === 'assistant')
+                if (lastAssistant?.content && POSITIVE_WORDS.test(lastAssistant.content)) {
+                  setMood('happy', true)
+                } else {
+                  setMood('success', true)
+                }
+              }
               cleanup()
               updateSessionTitle(sid)
               // the in-flight marker. If the browser is reloading right now
@@ -1055,6 +1095,7 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'run.failed': {
+              setMood('failed', true)
               const msgs = getSessionMsgs(sid)
               const lastErr = msgs[msgs.length - 1]
               if (lastErr?.isStreaming) {
@@ -1240,6 +1281,7 @@ export const useChatStore = defineStore('chat', () => {
     isLoadingSessions,
     sessionsLoaded,
     isLoadingMessages,
+    agentMood,
 
     newChat,
     switchSession,


### PR DESCRIPTION
## Summary

Adds dynamic mood indicators to the chat UI that reflect the agent's current emotional/task state, replacing the single static 'thinking' animation with a richer set of expressive animations.

## Changes

### New Component: `AgentMood.vue`
- Animated emoji component supporting 7 mood states
- Smooth crossfade transitions between moods
- Respects light/dark theme

### Mood States
| Mood | Trigger | Animation | Emoji |
|------|---------|-----------|-------|
| thinking | run.started | Existing video (unchanged) | 🎬 |
| success | run.completed (normal) | Scale + glow pulse | ✅ |
| failed | run.failed / swallowed error | Shake | ❌ |
| happy | run.completed with positive words | Gentle bounce | 😊 |
| curious | tool.started | Tilt rock | 🤔 |
| excited | run.completed with 3+ tool calls | Rapid bounce | 🎉 |
| sad | - | Slow drop + fade | 😢 |

### Chat Store
- Added `AgentMood` type and `agentMood` reactive ref
- Mood auto-resets to 'idle' after 3 seconds for result moods
- Positive word detection for 'happy' mood (supports en/zh)

### i18n
- Added mood labels in both English and Chinese

## Demo
The mood indicator appears in the bottom-left of the chat during and after agent responses:
- **During streaming**: shows thinking video or curious emoji when tools are running
- **After completion**: briefly shows success/happy/excited/failed emoji for 3 seconds

## Testing
- ✅ TypeScript compilation passes
- ✅ Full build succeeds  
- ✅ 43/44 tests pass (1 pre-existing failure unrelated to this change)

Closes #273