### PR TITLE
fix: strip HERMES_HOME from hermes CLI child process env

### DIFF
--- a/packages/server/src/services/hermes/hermes-cli.ts
+++ b/packages/server/src/services/hermes/hermes-cli.ts
@@ -5,7 +5,7 @@ import { logger } from '../logger'
 
 const execFileAsync = promisify(execFile)
 
-const execOpts = { windowsHide: true }
+const execOpts = { windowsHide: true, env: Object.fromEntries(Object.entries(process.env).filter(([key]) => key !== 'HERMES_HOME')) }
 const isDocker = existsSync('/.dockerenv')
 
 function resolveHermesBin(): string {


### PR DESCRIPTION
## Problem

When the WebUI inherits HERMES_HOME from its parent shell, all hermes CLI child processes also inherit it. After profile switching clears the active_profile file, the inherited HERMES_HOME still overrides profile resolution.

## Fix

Filter HERMES_HOME from execOpts in hermes-cli.ts.