### PR TITLE
feat: read persona.md as fallback for SOUL.md

### DIFF
--- a/packages/server/src/controllers/hermes/memory.ts
+++ b/packages/server/src/controllers/hermes/memory.ts
@@ -1,4 +1,4 @@
-import { writeFile } from 'fs/promises'
+import { writeFile, existsSync } from 'fs/promises'
 import { join } from 'path'
 import { safeReadFile, safeStat, getHermesDir } from '../../services/config-helpers'
 
@@ -7,10 +7,15 @@ export async function get(ctx: any) {
   const memoryPath = join(hd, 'memories', 'MEMORY.md')
   const userPath = join(hd, 'memories', 'USER.md')
   const soulPath = join(hd, 'SOUL.md')
-  const [memory, user, soul, memoryStat, userStat, soulStat] = await Promise.all([
-    safeReadFile(memoryPath), safeReadFile(userPath), safeReadFile(soulPath),
-    safeStat(memoryPath), safeStat(userPath), safeStat(soulPath),
+  const personaPath = join(hd, 'persona.md')
+  let [memory, user, soul, persona, memoryStat, userStat, soulStat, personaStat] = await Promise.all([
+    safeReadFile(memoryPath), safeReadFile(userPath), safeReadFile(soulPath), safeReadFile(personaPath),
+    safeStat(memoryPath), safeStat(userPath), safeStat(soulPath), safeStat(personaPath),
   ])
+  if (!soul && persona) {
+    soul = persona
+    soulStat = personaStat
+  }
   ctx.body = {
     memory: memory || '', user: user || '', soul: soul || '',
     memory_mtime: memoryStat?.mtime || null, user_mtime: userStat?.mtime || null, soul_mtime: soulStat?.mtime || null,
@@ -38,6 +43,12 @@ export async function save(ctx: any) {
   }
   try {
     await writeFile(filePath, content, 'utf-8')
+    if (section === 'soul') {
+      const personaPath = join(getHermesDir(), 'persona.md')
+      if (existsSync(personaPath)) {
+        await writeFile(personaPath, content, 'utf-8')
+      }
+    }
     ctx.body = { success: true }
   } catch (err: any) {
     ctx.status = 500


### PR DESCRIPTION
## Summary

- The memory GET endpoint now falls back to reading `persona.md` when `SOUL.md` is empty or missing, so the web UI displays the agent's actual persona configuration
- When saving the soul section, if `persona.md` exists, it is also updated to keep both files in sync

## Why

Hermes Agent users may customize their agent personality via `~/.hermes/persona.md` rather than `SOUL.md`. The web UI currently only reads `SOUL.md`, so the displayed persona doesn't match the one the agent actually uses. This patch bridges that gap by reading `persona.md` as a fallback.

## Test Plan

- With only `SOUL.md` present: behavior unchanged
- With only `persona.md` present (no `SOUL.md`): web UI now shows persona content
- With both present: `SOUL.md` takes precedence (no behavior change)
- Saving soul via web UI updates both `SOUL.md` and `persona.md` (if it exists)