### PR TITLE
feat: crash recovery system — watchdog + protocol

### DIFF
--- a/CRASH-RECOVERY-PROTOCOL.md
+++ b/CRASH-RECOVERY-PROTOCOL.md
@@ -1,0 +1,234 @@
+# Crash Recovery Protocol
+
+Standardized crash diagnosis and recovery guide for `hermes-web-ui`. Any AI agent can follow this protocol to diagnose and fix crashes.
+
+**Platform Support:** Linux (systemd) + macOS (launchd)
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Recovery Layers                         │
+├─────────────────────────────────────────────────────────────┤
+│  Level 1: watchdog (auto-restart, 3 retries)                │
+│           ↓ fails                                            │
+│  Level 2: Known Patterns (deterministic fix recipes)        │
+│           ↓ no match                                         │
+│  Level 3: Agent-Assisted (structured investigation)         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Level 1: Auto-Restart (watchdog)
+
+The watchdog health-checks every 30s and auto-restarts on failure.
+
+- **Max retries:** 3 consecutive failures
+- **Crash logs:** `~/.hermes-web-ui/crash-logs/`
+- **Signal file:** `~/.hermes-web-ui/CRASH_SIGNAL` (created when auto-recovery fails)
+
+When `CRASH_SIGNAL` exists, any AI agent should intervene.
+
+### Service Management
+
+| Platform | Status | Logs | Start/Stop |
+|----------|--------|------|------------|
+| Linux | `systemctl status hermes-web-ui-watchdog` | `journalctl -u hermes-web-ui-watchdog -f` | `systemctl start/stop hermes-web-ui-watchdog` |
+| macOS | `launchctl list \| grep hermes` | `cat ~/.hermes-web-ui/watchdog-stdout.log` | `launchctl start/stop com.hermes-web-ui.watchdog` |
+
+---
+
+## Level 2: Known Error Patterns
+
+### 2.1 EADDRINUSE (Port Conflict)
+
+**Symptom:** `Error: listen EADDRINUSE :::8648`
+
+**Fix (Linux):**
+```bash
+lsof -i :8648 | grep LISTEN
+kill -9 <PID>
+systemctl restart hermes-web-ui
+```
+
+**Fix (macOS):**
+```bash
+lsof -i :8648 | grep LISTEN
+kill -9 <PID>
+```
+
+**Root cause:** Previous instance didn't exit cleanly.
+
+---
+
+### 2.2 OOM (Out of Memory)
+
+**Symptom:** Exit code 137, or `FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed`
+
+**Diagnosis:**
+```bash
+# Linux
+free -h
+cat /proc/$(pgrep -f hermes-web-ui)/status | grep VmRSS
+
+# macOS
+vm_stat
+ps -eo pid,rss,command | grep hermes-web-ui
+```
+
+**Fix:**
+```bash
+# Option A: Increase Node.js heap
+export NODE_OPTIONS="--max-old-space-size=512"
+
+# Option B: Add swap (Linux only)
+sudo fallocate -l 2G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+```
+
+---
+
+### 2.3 MODULE_NOT_FOUND (Missing Dependency)
+
+**Symptom:** `Error: Cannot find module 'xxx'`
+
+**Fix:**
+```bash
+cd /path/to/hermes-web-ui-src
+npm install
+
+# If node_modules corrupted
+rm -rf node_modules package-lock.json
+npm install
+```
+
+---
+
+### 2.4 EACCES (Permission Denied)
+
+**Symptom:** `EACCES: permission denied, open '/path/to/file'`
+
+**Fix:**
+```bash
+chown -R $(whoami):$(id -gn) ~/.hermes-web-ui/
+chmod -R 755 ~/.hermes-web-ui/
+```
+
+---
+
+### 2.5 ENOSPC (Disk Full)
+
+**Symptom:** `ENOSPC: no space left on device`
+
+**Fix:**
+```bash
+df -h
+du -sh ~/.hermes-web-ui/* | sort -rh | head -10
+find ~/.hermes-web-ui/crash-logs -mtime +7 -delete
+```
+
+---
+
+### 2.6 Upstream Hermes Agent Down
+
+**Symptom:** Health check returns 502/503, or `ECONNREFUSED` to gateway
+
+**Diagnosis:**
+```bash
+curl -s http://127.0.0.1:8642/health
+pgrep -af hermes
+```
+
+**Fix:**
+```bash
+# Linux
+systemctl restart hermes-agent
+
+# Or via OpenClaw
+cd /home/o2/.openclaw
+openclaw restart
+```
+
+---
+
+### 2.7 Corrupted node_modules
+
+**Symptom:** Random module errors, `TypeError: xxx is not a function`
+
+**Fix:**
+```bash
+cd /path/to/hermes-web-ui-src
+rm -rf node_modules package-lock.json
+npm install
+npm run build
+```
+
+---
+
+### 2.8 Gateway Connection Timeout
+
+**Symptom:** `ETIMEDOUT`, requests hang
+
+**Fix:**
+```bash
+# Increase timeout in .env
+GATEWAY_TIMEOUT=60000
+```
+
+---
+
+## Level 3: Agent-Assisted (Unknown Errors)
+
+### Step 1: Read Crash Context
+```bash
+cat ~/.hermes-web-ui/CRASH_SIGNAL
+ls -t ~/.hermes-web-ui/crash-logs/*.log | head -1 | xargs cat
+
+# Linux
+journalctl -u hermes-web-ui --since "10 minutes ago" --no-pager
+# macOS
+tail -100 ~/.hermes-web-ui/watchdog-stdout.log
+```
+
+### Step 2: Classify Error
+- Node.js error? (stack trace shows node_modules)
+- System error? (EACCES, ENOSPC, OOM)
+- Network error? (ECONNREFUSED, ETIMEDOUT)
+
+### Step 3: Reason About Root Cause
+1. Check recent changes: `git log --oneline -5`
+2. Check config: `cat ~/.hermes-web-ui/.env`
+3. Check disk/memory
+4. Check port conflicts: `lsof -i :8648`
+
+### Step 4: Apply Fix → Verify → Document
+
+---
+
+## Quick Reference
+
+| Error | Exit Code | Auto-fix? | Command |
+|-------|-----------|-----------|---------|
+| EADDRINUSE | 1 | Yes | `lsof -i :8648 \| awk 'NR>1{print $2}' \| xargs kill` |
+| OOM | 137 | Partial | Add swap / increase heap |
+| MODULE_NOT_FOUND | 1 | Yes | `npm install` |
+| EACCES | 1 | Yes | `chown -R $(whoami):$(id -gn) ~/.hermes-web-ui` |
+| ENOSPC | 1 | No | Clean disk manually |
+| Gateway down | - | No | Restart hermes-agent |
+
+---
+
+## File Locations
+
+| File | Path |
+|------|------|
+| Crash signal | `~/.hermes-web-ui/CRASH_SIGNAL` |
+| Crash logs | `~/.hermes-web-ui/crash-logs/` |
+| Watchdog log | `~/.hermes-web-ui/watchdog.log` |
+| Service (Linux) | `/etc/systemd/system/hermes-web-ui-watchdog.service` |
+| Service (macOS) | `~/Library/LaunchAgents/com.hermes-web-ui.watchdog.plist` |

--- a/scripts/hermes-web-ui-watchdog.service
+++ b/scripts/hermes-web-ui-watchdog.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=hermes-web-ui watchdog
+After=network.target
+Wants=network.target
+
+[Service]
+Type=simple
+# User/Group set by install-watchdog.sh
+ExecStart=/bin/bash /path/to/watchdog.sh
+Restart=always
+RestartSec=10
+
+Environment=HEALTH_URL=http://127.0.0.1:8648/health
+Environment=CHECK_INTERVAL=30
+Environment=MAX_RETRIES=3
+Environment=HERMES_WEB_UI_DATA=/home/user/.hermes-web-ui
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hermes-web-ui-watchdog
+
+NoNewPrivileges=true
+ProtectSystem=full
+ReadWritePaths=/home/user/.hermes-web-ui
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/install-watchdog.sh
+++ b/scripts/install-watchdog.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# =============================================================================
+# hermes-web-ui watchdog installer — Linux (systemd) + macOS (launchd)
+# Usage: bash scripts/install-watchdog.sh
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+OS="$(uname -s)"
+case "$OS" in
+    Linux*)  PLATFORM="linux";;
+    Darwin*) PLATFORM="macos";;
+    *)       echo "Unsupported: $OS"; exit 1;;
+esac
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*"; exit 1; }
+
+TARGET_USER="${SUDO_USER:-$(whoami)}"
+TARGET_HOME=$(eval echo "~$TARGET_USER")
+DATA_DIR="$TARGET_HOME/.hermes-web-ui"
+
+info "Installing hermes-web-ui watchdog"
+info "  Platform: $PLATFORM"
+info "  User: $TARGET_USER"
+info "  Data dir: $DATA_DIR"
+
+[[ -f "$SCRIPT_DIR/watchdog.sh" ]] || error "watchdog.sh not found"
+
+mkdir -p "$DATA_DIR/crash-logs"
+chown -R "$TARGET_USER:$(id -gn "$TARGET_USER" 2>/dev/null || echo "$TARGET_USER")" "$DATA_DIR" 2>/dev/null || true
+chmod +x "$SCRIPT_DIR/watchdog.sh"
+
+# =============================================================================
+# Linux: systemd
+# =============================================================================
+install_systemd() {
+    local SERVICE_NAME="hermes-web-ui-watchdog"
+    local SYSTEMD_DIR="/etc/systemd/system"
+    [[ $EUID -eq 0 ]] || error "Run as root: sudo bash scripts/install-watchdog.sh"
+
+    cat > "/tmp/$SERVICE_NAME.service" <<EOF
+[Unit]
+Description=hermes-web-ui watchdog
+After=network.target
+Wants=network.target
+
+[Service]
+Type=simple
+User=$TARGET_USER
+Group=$(id -gn "$TARGET_USER" 2>/dev/null || echo "$TARGET_USER")
+ExecStart=/bin/bash $SCRIPT_DIR/watchdog.sh
+Restart=always
+RestartSec=10
+Environment=HEALTH_URL=http://127.0.0.1:8648/health
+Environment=CHECK_INTERVAL=30
+Environment=MAX_RETRIES=3
+Environment=HERMES_WEB_UI_DATA=$DATA_DIR
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hermes-web-ui-watchdog
+NoNewPrivileges=true
+ProtectSystem=full
+ReadWritePaths=$DATA_DIR $TARGET_HOME/.npm-global $PROJECT_DIR
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    cp "/tmp/$SERVICE_NAME.service" "$SYSTEMD_DIR/$SERVICE_NAME.service"
+    rm -f "/tmp/$SERVICE_NAME.service"
+
+    systemctl daemon-reload
+    systemctl enable "$SERVICE_NAME"
+    systemctl restart "$SERVICE_NAME" 2>/dev/null || systemctl start "$SERVICE_NAME"
+
+    sleep 2
+    systemctl is-active --quiet "$SERVICE_NAME" && info "✅ Watchdog installed and running" || warn "Check: journalctl -u $SERVICE_NAME -n 50"
+
+    echo ""
+    echo "========================================="
+    echo "  hermes-web-ui watchdog (systemd)"
+    echo "========================================="
+    echo "  Status:    systemctl status $SERVICE_NAME"
+    echo "  Logs:      journalctl -u $SERVICE_NAME -f"
+    echo "  Stop:      systemctl stop $SERVICE_NAME"
+    echo "  Disable:   systemctl disable $SERVICE_NAME"
+}
+
+# =============================================================================
+# macOS: launchd
+# =============================================================================
+install_launchd() {
+    local PLIST_NAME="com.hermes-web-ui.watchdog"
+    local PLIST_DIR="$TARGET_HOME/Library/LaunchAgents"
+    local PLIST_FILE="$PLIST_DIR/$PLIST_NAME.plist"
+
+    mkdir -p "$PLIST_DIR"
+    [[ -f "$PLIST_FILE" ]] && launchctl unload "$PLIST_FILE" 2>/dev/null || true
+
+    cat > "$PLIST_FILE" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>$PLIST_NAME</string>
+    <key>ProgramArguments</key>
+    <array><string>/bin/bash</string><string>$SCRIPT_DIR/watchdog.sh</string></array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HEALTH_URL</key><string>http://127.0.0.1:8648/health</string>
+        <key>CHECK_INTERVAL</key><string>30</string>
+        <key>MAX_RETRIES</key><string>3</string>
+        <key>HERMES_WEB_UI_DATA</key><string>$DATA_DIR</string>
+        <key>PATH</key><string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><dict><key>SuccessfulExit</key><false/></dict>
+    <key>ThrottleInterval</key><integer>10</integer>
+    <key>StandardOutPath</key><string>$DATA_DIR/watchdog-stdout.log</string>
+    <key>StandardErrorPath</key><string>$DATA_DIR/watchdog-stderr.log</string>
+    <key>WorkingDirectory</key><string>$TARGET_HOME</string>
+</dict>
+</plist>
+EOF
+
+    launchctl load "$PLIST_FILE" 2>/dev/null || true
+    launchctl start "$PLIST_NAME" 2>/dev/null || true
+
+    sleep 2
+    launchctl list | grep -q "$PLIST_NAME" && info "✅ Watchdog installed and running" || warn "Check: launchctl list | grep hermes"
+
+    echo ""
+    echo "========================================="
+    echo "  hermes-web-ui watchdog (launchd)"
+    echo "========================================="
+    echo "  Status:    launchctl list | grep hermes"
+    echo "  Logs:      cat $DATA_DIR/watchdog-stdout.log"
+    echo "  Stop:      launchctl stop $PLIST_NAME"
+    echo "  Unload:    launchctl unload $PLIST_FILE"
+}
+
+# =============================================================================
+case "$PLATFORM" in
+    linux) install_systemd ;;
+    macos) install_launchd ;;
+esac
+
+echo "  Crash dir: $DATA_DIR/crash-logs/"
+echo "  Signal:    $DATA_DIR/CRASH_SIGNAL"
+echo "  Protocol:  $PROJECT_DIR/CRASH-RECOVERY-PROTOCOL.md"
+echo ""

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# =============================================================================
+# hermes-web-ui watchdog — Cross-platform (Linux + macOS)
+# Health-checks every 30s, auto-restarts on failure (max 3 retries)
+# =============================================================================
+
+set -euo pipefail
+
+# --- Configuration ---
+APP_NAME="hermes-web-ui"
+HEALTH_URL="${HEALTH_URL:-http://127.0.0.1:8648/health}"
+CHECK_INTERVAL="${CHECK_INTERVAL:-30}"
+MAX_RETRIES="${MAX_RETRIES:-3}"
+DATA_DIR="${HERMES_WEB_UI_DATA:-$HOME/.hermes-web-ui}"
+CRASH_DIR="$DATA_DIR/crash-logs"
+CRASH_SIGNAL="$DATA_DIR/CRASH_SIGNAL"
+LOG_FILE="$DATA_DIR/watchdog.log"
+
+# --- Platform Detection ---
+OS="$(uname -s)"
+case "$OS" in
+    Linux*)  PLATFORM="linux";;
+    Darwin*) PLATFORM="macos";;
+    *)       PLATFORM="unknown";;
+esac
+
+# --- Helpers ---
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+ensure_dirs() { mkdir -p "$CRASH_DIR"; }
+
+get_server_pid() {
+    pgrep -f "hermes-web-ui.*server" 2>/dev/null || \
+    pgrep -f "node.*hermes-web-ui" 2>/dev/null || echo ""
+}
+
+health_check() {
+    local code
+    code=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "$HEALTH_URL" 2>/dev/null || echo "000")
+    [[ "$code" == "200" ]]
+}
+
+collect_system_state() {
+    echo "=== SYSTEM STATE ==="
+    echo "Platform: $PLATFORM"
+    echo ""
+    echo "--- Memory ---"
+    if [[ "$PLATFORM" == "linux" ]]; then
+        free -h 2>/dev/null || head -5 /proc/meminfo
+    else
+        vm_stat 2>/dev/null || echo "vm_stat not available"
+    fi
+    echo ""
+    echo "--- Disk ---"
+    df -h / 2>/dev/null || echo "df not available"
+    echo ""
+    echo "--- Load ---"
+    uptime
+    echo ""
+    echo "--- Processes ---"
+    if [[ "$PLATFORM" == "linux" ]]; then
+        ps aux | grep -E "(hermes|node)" | grep -v grep || true
+    else
+        ps -eo pid,user,%cpu,%mem,command | grep -E "(hermes|node)" | grep -v grep || true
+    fi
+}
+
+save_crash_log() {
+    local crash_file="$CRASH_DIR/crash-$(date '+%Y%m%d-%H%M%S').log"
+    {
+        echo "=== CRASH REPORT ==="
+        echo "Timestamp: $(date -Iseconds 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S%z')"
+        echo "Exit Code: $1"
+        echo "Watchdog Retries: $consecutive_failures"
+        echo ""
+        collect_system_state
+        echo ""
+        echo "--- Server Log (last 100 lines) ---"
+        tail -100 "$DATA_DIR/server.log" 2>/dev/null || echo "server.log not found"
+    } > "$crash_file"
+    log "Crash log saved: $crash_file"
+}
+
+write_crash_signal() {
+    cat > "$CRASH_SIGNAL" <<EOF
+CRASH_TIMESTAMP=$(date -Iseconds 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S%z')
+CRASH_REASON=$1
+WATCHDOG_PID=$$
+APP_NAME=$APP_NAME
+HEALTH_URL=$HEALTH_URL
+CONSECUTIVE_FAILURES=$consecutive_failures
+LAST_CRASH_LOG=$(ls -t "$CRASH_DIR"/*.log 2>/dev/null | head -1)
+EOF
+    log "CRASH_SIGNAL written: $1"
+}
+
+clear_crash_signal() { rm -f "$CRASH_SIGNAL"; }
+
+start_server() {
+    log "Starting $APP_NAME..."
+    if [[ "$PLATFORM" == "linux" ]] && command -v systemctl &>/dev/null && systemctl is-enabled "$APP_NAME" &>/dev/null; then
+        systemctl start "$APP_NAME"
+    else
+        local dir
+        dir=$(npm root -g 2>/dev/null)/hermes-web-ui
+        if [[ -d "$dir" ]]; then
+            cd "$dir"
+            node dist/server/index.js >> "$DATA_DIR/server.log" 2>&1 &
+            log "Started via node (PID: $!)"
+        else
+            log "ERROR: Cannot find hermes-web-ui"
+            return 1
+        fi
+    fi
+}
+
+stop_server() {
+    log "Stopping $APP_NAME..."
+    if [[ "$PLATFORM" == "linux" ]] && command -v systemctl &>/dev/null && systemctl is-active "$APP_NAME" &>/dev/null; then
+        systemctl stop "$APP_NAME"
+    else
+        local pid
+        pid=$(get_server_pid)
+        if [[ -n "$pid" ]]; then
+            kill "$pid" 2>/dev/null || true
+            sleep 2
+            kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
+        fi
+    fi
+}
+
+# --- Main ---
+ensure_dirs
+log "Watchdog starting (PID: $$)"
+log "Platform: $PLATFORM | Health: $HEALTH_URL | Interval: ${CHECK_INTERVAL}s | Max retries: $MAX_RETRIES"
+
+consecutive_failures=0
+exit_code="unknown"
+server_pid=""
+
+while true; do
+    if health_check; then
+        if [[ $consecutive_failures -gt 0 ]]; then
+            log "Health check recovered after $consecutive_failures failure(s)"
+        fi
+        consecutive_failures=0
+        clear_crash_signal
+    else
+        consecutive_failures=$((consecutive_failures + 1))
+        log "Health check failed ($consecutive_failures/$MAX_RETRIES)"
+
+        if [[ $consecutive_failures -ge $MAX_RETRIES ]]; then
+            log "Max retries reached — collecting crash data"
+            exit_code="unknown"
+            server_pid=$(get_server_pid)
+            [[ -z "$server_pid" ]] && exit_code="process_not_found"
+            save_crash_log "$exit_code"
+
+            if [[ $consecutive_failures -eq $MAX_RETRIES ]]; then
+                log "Attempting restart..."
+                stop_server
+                sleep 2
+                if start_server; then
+                    sleep 10
+                    if health_check; then
+                        log "Restart successful"
+                        consecutive_failures=0
+                        clear_crash_signal
+                        continue
+                    fi
+                fi
+            fi
+            write_crash_signal "AUTO_RECOVERY_FAILED"
+            log "Auto-recovery failed. Waiting for agent intervention."
+            consecutive_failures=$((MAX_RETRIES + 1))
+        fi
+    fi
+    sleep "$CHECK_INTERVAL"
+done


### PR DESCRIPTION
## Summary

Adds a standardized crash recovery system for hermes-web-ui. This enables any AI agent (regardless of model capability) to diagnose and fix web-ui crashes by following a structured protocol.

## What's New

### 📋 CRASH-RECOVERY-PROTOCOL.md
A standardized crash diagnosis guide with:
- **Level 1 (Auto-Restart):** Process exits, OOM — watchdog handles automatically
- **Level 2 (Known Patterns):** Fix recipes for common errors:
  - EADDRINUSE (port conflict)
  - OOM (out of memory)
  - MODULE_NOT_FOUND (missing dependency)
  - EACCES (permission denied)
  - ENOSPC (disk full)
  - Upstream Hermes Agent down
  - Corrupted node_modules
  - Gateway connection timeout
- **Level 3 (Agent-Assisted):** Structured steps for unknown errors — read logs, classify, reason, fix

### 🐕 watchdog.sh
Cross-platform process monitor (Linux + macOS):
- Health-checks every 30 seconds
- Auto-restarts on failure (up to 3 retries)
- Saves crash logs with system state (memory, disk, processes)
- Writes CRASH_SIGNAL file when auto-recovery fails
- Any AI agent can detect this signal and intervene

### ⚙️ systemd Service + Install Script
-  — systemd unit template
-  — one-command setup:
  - Linux: [0;32m[INFO][0m Installing hermes-web-ui watchdog
[0;32m[INFO][0m   Platform: linux
[0;32m[INFO][0m   User: o2
[0;32m[INFO][0m   Data dir: /home/o2/.hermes-web-ui
[0;32m[INFO][0m ✅ Watchdog installed and running

=========================================
  hermes-web-ui watchdog (systemd)
=========================================
  Status:    systemctl status hermes-web-ui-watchdog
  Logs:      journalctl -u hermes-web-ui-watchdog -f
  Stop:      systemctl stop hermes-web-ui-watchdog
  Disable:   systemctl disable hermes-web-ui-watchdog
  Crash dir: /home/o2/.hermes-web-ui/crash-logs/
  Signal:    /home/o2/.hermes-web-ui/CRASH_SIGNAL
  Protocol:  /home/o2/hermes-web-ui-src/CRASH-RECOVERY-PROTOCOL.md
  - macOS: [0;32m[INFO][0m Installing hermes-web-ui watchdog
[0;32m[INFO][0m   Platform: linux
[0;32m[INFO][0m   User: o2
[0;32m[INFO][0m   Data dir: /home/o2/.hermes-web-ui
[0;31m[ERROR][0m Run as root: sudo bash scripts/install-watchdog.sh

## Design Philosophy

Different AI models have different capabilities. Instead of relying on one model's reasoning, the protocol provides deterministic fix recipes that any model can execute step-by-step. For unknown errors, it provides a structured investigation path.

The watchdog acts as the first line of defense, while the protocol ensures any AI agent can serve as the second.

## Testing

- ✅ Watchdog auto-restarts server after `kill -9`
- ✅ Platform detection (Linux verified)
- ✅ Cross-platform commands (free/vm_stat, ps aux/ps -eo)
- ✅ Bash syntax validation

## Platform Support

| Feature | Linux | macOS |
|---------|-------|-------|
| Watchdog | systemd | launchd |
| Memory info | free -h | vm_stat |
| Process list | ps aux | ps -eo |
| Service mgmt | systemctl | launchctl |