### PR TITLE
fix：修复用户消息(cron任务信息)代码块单行超长导致的界面展示异常问题

### DIFF
--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -545,6 +545,7 @@ const renderedToolResult = computed(() => {
   line-height: 1.65;
   word-break: break-word;
   border-radius: 10px;
+  max-width: 100%;
 }
 
 .msg-attachments {


### PR DESCRIPTION
## Summary

修复用户消息(cron任务信息)代码块单行超长导致的界面展示异常问题

## Type of Change

- [ ] Feature (new functionality)
- [x] Bug fix
- [ ] Refactor (no functional change)
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Changes

MessageItem.vue样式调整

## Test Plan

- [ ] Build passes (`npm run build`)
- [x] Tested manually

## Screenshots (if applicable)

before:
<img width="1861" height="434" alt="1777426685150_d" src="https://github.com/user-attachments/assets/e3298432-af7e-4489-9e4b-f986a7871a7d" />
after:
<img width="1672" height="476" alt="image" src="https://github.com/user-attachments/assets/4c9f7ff0-1bfe-43c6-a223-a59aa7e620e4" />


## Related Issues

None
