### PR TITLE
fix(chat): ensure tool_call_id is always included for tool messages

### DIFF
--- a/packages/server/src/services/hermes/chat-run-socket.ts
+++ b/packages/server/src/services/hermes/chat-run-socket.ts
@@ -134,7 +134,9 @@ export class ChatRunSocket {
                   timestamp: m.timestamp,
                 }
                 if (m.tool_calls?.length) msg.tool_calls = m.tool_calls
-                if (m.tool_call_id) msg.tool_call_id = m.tool_call_id
+                // Always include tool_call_id for role='tool' messages (required by OpenAI API)
+                if (m.role === 'tool') msg.tool_call_id = m.tool_call_id || ''
+                else if (m.tool_call_id) msg.tool_call_id = m.tool_call_id
                 if (m.tool_name) msg.tool_name = m.tool_name
                 if (m.reasoning) msg.reasoning = m.reasoning
                 return msg
@@ -283,7 +285,9 @@ export class ChatRunSocket {
               ).map(m => {
                 const msg: any = { role: m.role, content: m.content || '' }
                 if (m.tool_calls?.length) msg.tool_calls = m.tool_calls
-                if (m.tool_call_id) msg.tool_call_id = m.tool_call_id
+                // Always include tool_call_id for role='tool' messages (required by OpenAI API)
+                if (m.role === 'tool') msg.tool_call_id = m.tool_call_id || ''
+                else if (m.tool_call_id) msg.tool_call_id = m.tool_call_id
                 if (m.tool_name) msg.name = m.tool_name
                 return msg
               })


### PR DESCRIPTION
Fixes #298

## Problem
更新到 v0.5.0 后聊天报错：
``
ERROR root: Non-retryable client error: Error code: 400
{'error': {'message': "bad request: messages[3] 角色为 'tool' 时必须提供 'tool_call_id'"}}
``

## Root Cause
在  中，当从数据库加载会话历史时，tool 类型的消息只在  有值时才添加该字段：

``typescript
if (m.tool_call_id) msg.tool_call_id = m.tool_call_id
``

但 OpenAI API 要求：**当  时，必须提供  字段**（即使为 null 或空字符串）

## Solution
修改两处代码逻辑：
1. 第 137 行附近（从本地 DB 加载会话）
2. 第 286 行附近（从 Hermes DB 加载会话）

改为：
``typescript
// Always include tool_call_id for role='tool' messages (required by OpenAI API)
if (m.role === 'tool') msg.tool_call_id = m.tool_call_id || ''
else if (m.tool_call_id) msg.tool_call_id = m.tool_call_id
``

## Test Plan
- [x] 代码修复完成
- [ ] 等待 CI 检查通过
- [ ] 用户测试验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)
