### PR TITLE
fix(session-sync): handle missing estimated_cost_usd column in old Hermes state.db

### DIFF
--- a/packages/server/src/services/hermes/session-sync.ts
+++ b/packages/server/src/services/hermes/session-sync.ts
@@ -113,7 +113,7 @@ function syncProfileSessions(profile: string): {
 
     try {
       // Check if sessions table has estimated_cost_usd column
-      const tableInfo = db.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>[]
+      const tableInfo = db.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>
       const hasEstimatedCost = tableInfo.some(col => col.name === 'estimated_cost_usd')
 
       // Build SELECT query - only include estimated_cost_usd if column exists

--- a/packages/server/src/services/hermes/session-sync.ts
+++ b/packages/server/src/services/hermes/session-sync.ts
@@ -112,6 +112,13 @@ function syncProfileSessions(profile: string): {
     const db = openHermesStateDb(profile)
 
     try {
+      // Check if sessions table has estimated_cost_usd column
+      const tableInfo = db.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>[]
+      const hasEstimatedCost = tableInfo.some(col => col.name === 'estimated_cost_usd')
+
+      // Build SELECT query - only include estimated_cost_usd if column exists
+      const estimatedCostCol = hasEstimatedCost ? ', COALESCE(estimated_cost_usd, 0) AS estimated_cost_usd' : ', 0 AS estimated_cost_usd'
+
       // Get all api_server sessions
       const sessions = db.prepare(`
         SELECT
@@ -128,8 +135,7 @@ function syncProfileSessions(profile: string): {
           output_tokens,
           cache_read_tokens,
           cache_write_tokens,
-          reasoning_tokens,
-          estimated_cost_usd
+          reasoning_tokens${estimatedCostCol}
         FROM sessions
         WHERE source = 'api_server'
         ORDER BY started_at ASC
@@ -218,7 +224,7 @@ function syncProfileSessions(profile: string): {
             cache_read_tokens: hermesSession.cache_read_tokens,
             cache_write_tokens: hermesSession.cache_write_tokens,
             reasoning_tokens: hermesSession.reasoning_tokens,
-            estimated_cost_usd: hermesSession.estimated_cost_usd,
+            estimated_cost_usd: hermesSession.estimated_cost_usd || 0,
             last_active: hermesSession.started_at, // Use started_at as fallback since last_active doesn't exist in Hermes state.db
             preview,
           })


### PR DESCRIPTION
## 概要
修复 issue #308 - 版本升级后历史会话无法导入的问题，解决 `NOT NULL constraint failed: sessions.estimated_cost_usd` 错误。

## 问题分析

### 根本原因
- 旧版本 Hermes 的 `state.db` 没有 `estimated_cost_usd` 列
- 会话同步时直接查询该列导致 SQL 错误
- 整个同步过程失败，导致历史会话和新增会话都无法导入

### 影响范围
- 从旧版本升级的用户无法导入历史会话
- 即使删除数据库重启，新会话也无法同步（因为同步逻辑失败）

## 解决方案

### 核心思路
动态检测 Hermes state.db 的表结构，根据是否有 `estimated_cost_usd` 列构建不同的查询语句。

### 实现细节
1. 使用 `PRAGMA table_info(sessions)` 检测列是否存在
2. **旧版 DB**（无此列）：
   - 查询时使用 `, 0 AS estimated_cost_usd` 返回默认值
   - 避免查询不存在的列导致 SQL 错误
3. **新版 DB**（有此列）：
   - 查询时使用 `, COALESCE(estimated_cost_usd, 0) AS estimated_cost_usd`
   - 处理可能的 NULL 值，确保返回有效的数字

### 兼容性
✅ **完全向后兼容**
- 旧版 Hermes（无 `estimated_cost_usd` 列）：正常同步，成本默认为 0
- 新版 Hermes（有 `estimated_cost_usd` 列）：正常同步，保留实际成本数据
- 部署场景（新版 web-ui + 旧版 Hermes）：正常工作
- 升级场景（旧版 web-ui → 新版 web-ui）：自动适配

## 测试
- ✅ 单元测试通过（`tests/server/session-sync.test.ts`）
- ✅ 兼容性测试：旧版 state.db 和新版 state.db 都能正常同步

## 修复后效果
- 历史会话可以正常导入
- 新会话可以正常同步
- 不会出现 `NOT NULL constraint failed` 错误
- 与旧版本 Hermes 完全兼容

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)