### PR TITLE
chore: add v0.5.1 changelog and version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Self-hosted AI chat dashboard for Hermes Agent — multi-model (Claude, GPT, Gemini, DeepSeek) web UI with Telegram, Discord, Slack, WhatsApp integration",
   "repository": {
     "type": "git",

--- a/packages/client/src/data/changelog.ts
+++ b/packages/client/src/data/changelog.ts
@@ -6,6 +6,21 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.5.1',
+    date: '2026-04-29',
+    changes: [
+      'changelog.new_0_5_1_1',
+      'changelog.new_0_5_1_2',
+      'changelog.new_0_5_1_3',
+      'changelog.new_0_5_1_4',
+      'changelog.new_0_5_1_5',
+      'changelog.new_0_5_1_6',
+      'changelog.new_0_5_1_7',
+      'changelog.new_0_5_1_8',
+      'changelog.new_0_5_1_9',
+    ],
+  },
+  {
     version: '0.5.0',
     date: '2025-04-29',
     changes: ['changelog.new_0_5_0_1', 'changelog.new_0_5_0_2'],

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -555,6 +555,15 @@ export default {
 
   // Anderungsprotokoll
   changelog: {
+    new_0_5_1_1: 'Auto-sync Hermes history sessions on first startup',
+    new_0_5_1_2: 'Fix session sync failure with old Hermes versions (backward compatible)',
+    new_0_5_1_3: 'Smart cleanup of exclusive platform credentials on profile clone (Telegram, Discord, Slack, etc.)',
+    new_0_5_1_4: 'Auto-normalize profile names to lowercase to avoid backend validation errors',
+    new_0_5_1_5: 'Fix tool_call_id missing in tool messages for OpenAI API compatibility',
+    new_0_5_1_6: 'Unify SQLite table schema management and initialization',
+    new_0_5_1_7: 'Optimize model list layout in Provider cards (fixed height, tag alignment)',
+    new_0_5_1_8: 'Fix display issue with single-line long code blocks in user messages',
+    new_0_5_1_9: 'Fix web terminal rendering errors in Docker deployment',
     new_0_5_0_1: 'Self-built chat database and context compression: empty chat history on first entry is expected',
     new_0_5_0_2: 'Sessions use WebSocket form, enhanced resume capability',
     new_0_4_8_1: 'Safe Mermaid diagram rendering with async render and timeout fallback',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -719,6 +719,15 @@ export default {
 
   // Changelog
   changelog: {
+    new_0_5_1_1: 'Auto-sync Hermes history sessions on first startup',
+    new_0_5_1_2: 'Fix session sync failure with old Hermes versions (backward compatible)',
+    new_0_5_1_3: 'Smart cleanup of exclusive platform credentials on profile clone (Telegram, Discord, Slack, etc.)',
+    new_0_5_1_4: 'Auto-normalize profile names to lowercase to avoid backend validation errors',
+    new_0_5_1_5: 'Fix tool_call_id missing in tool messages for OpenAI API compatibility',
+    new_0_5_1_6: 'Unify SQLite table schema management and initialization',
+    new_0_5_1_7: 'Optimize model list layout in Provider cards (fixed height, tag alignment)',
+    new_0_5_1_8: 'Fix display issue with single-line long code blocks in user messages',
+    new_0_5_1_9: 'Fix web terminal rendering errors in Docker deployment',
     new_0_5_0_1: 'Self-built chat database and context compression',
     new_0_5_0_2: 'Sessions use WebSocket form, enhanced resume capability',
     new_0_4_8_1: 'Safe Mermaid diagram rendering with async render and timeout fallback',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -555,6 +555,15 @@ export default {
 
   // Registro de cambios
   changelog: {
+    new_0_5_1_1: 'Auto-sync Hermes history sessions on first startup',
+    new_0_5_1_2: 'Fix session sync failure with old Hermes versions (backward compatible)',
+    new_0_5_1_3: 'Smart cleanup of exclusive platform credentials on profile clone (Telegram, Discord, Slack, etc.)',
+    new_0_5_1_4: 'Auto-normalize profile names to lowercase to avoid backend validation errors',
+    new_0_5_1_5: 'Fix tool_call_id missing in tool messages for OpenAI API compatibility',
+    new_0_5_1_6: 'Unify SQLite table schema management and initialization',
+    new_0_5_1_7: 'Optimize model list layout in Provider cards (fixed height, tag alignment)',
+    new_0_5_1_8: 'Fix display issue with single-line long code blocks in user messages',
+    new_0_5_1_9: 'Fix web terminal rendering errors in Docker deployment',
     new_0_5_0_1: 'Self-built chat database and context compression: empty chat history on first entry is expected',
     new_0_5_0_2: 'Sessions use WebSocket form, enhanced resume capability',
     new_0_4_8_1: 'Safe Mermaid diagram rendering with async render and timeout fallback',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -555,6 +555,15 @@ export default {
 
   // Journal des modifications
   changelog: {
+    new_0_5_1_1: 'Auto-sync Hermes history sessions on first startup',
+    new_0_5_1_2: 'Fix session sync failure with old Hermes versions (backward compatible)',
+    new_0_5_1_3: 'Smart cleanup of exclusive platform credentials on profile clone (Telegram, Discord, Slack, etc.)',
+    new_0_5_1_4: 'Auto-normalize profile names to lowercase to avoid backend validation errors',
+    new_0_5_1_5: 'Fix tool_call_id missing in tool messages for OpenAI API compatibility',
+    new_0_5_1_6: 'Unify SQLite table schema management and initialization',
+    new_0_5_1_7: 'Optimize model list layout in Provider cards (fixed height, tag alignment)',
+    new_0_5_1_8: 'Fix display issue with single-line long code blocks in user messages',
+    new_0_5_1_9: 'Fix web terminal rendering errors in Docker deployment',
     new_0_5_0_1: 'Self-built chat database and context compression: empty chat history on first entry is expected',
     new_0_5_0_2: 'Sessions use WebSocket form, enhanced resume capability',
     new_0_4_8_1: 'Safe Mermaid diagram rendering with async render and timeout fallback',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -555,6 +555,15 @@ export default {
 
   // 更新履歴
   changelog: {
+    new_0_5_1_1: 'Auto-sync Hermes history sessions on first startup',
+    new_0_5_1_2: 'Fix session sync failure with old Hermes versions (backward compatible)',
+    new_0_5_1_3: 'Smart cleanup of exclusive platform credentials on profile clone (Telegram, Discord, Slack, etc.)',
+    new_0_5_1_4: 'Auto-normalize profile names to lowercase to avoid backend validation errors',
+    new_0_5_1_5: 'Fix tool_call_id missing in tool messages for OpenAI API compatibility',
+    new_0_5_1_6: 'Unify SQLite table schema management and initialization',
+    new_0_5_1_7: 'Optimize model list layout in Provider cards (fixed height, tag alignment)',
+    new_0_5_1_8: 'Fix display issue with single-line long code blocks in user messages',
+    new_0_5_1_9: 'Fix web terminal rendering errors in Docker deployment',
     new_0_5_0_1: 'Self-built chat database and context compression: empty chat history on first entry is expected',
     new_0_5_0_2: 'Sessions use WebSocket form, enhanced resume capability',
     new_0_4_8_1: 'Safe Mermaid diagram rendering with async render and timeout fallback',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -555,6 +555,15 @@ export default {
 
   // 변경 이력
   changelog: {
+    new_0_5_1_1: 'Auto-sync Hermes history sessions on first startup',
+    new_0_5_1_2: 'Fix session sync failure with old Hermes versions (backward compatible)',
+    new_0_5_1_3: 'Smart cleanup of exclusive platform credentials on profile clone (Telegram, Discord, Slack, etc.)',
+    new_0_5_1_4: 'Auto-normalize profile names to lowercase to avoid backend validation errors',
+    new_0_5_1_5: 'Fix tool_call_id missing in tool messages for OpenAI API compatibility',
+    new_0_5_1_6: 'Unify SQLite table schema management and initialization',
+    new_0_5_1_7: 'Optimize model list layout in Provider cards (fixed height, tag alignment)',
+    new_0_5_1_8: 'Fix display issue with single-line long code blocks in user messages',
+    new_0_5_1_9: 'Fix web terminal rendering errors in Docker deployment',
     new_0_5_0_1: 'Self-built chat database and context compression: empty chat history on first entry is expected',
     new_0_5_0_2: 'Sessions use WebSocket form, enhanced resume capability',
     new_0_4_8_1: 'Safe Mermaid diagram rendering with async render and timeout fallback',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -555,6 +555,15 @@ export default {
 
   // Registro de alteracoes
   changelog: {
+    new_0_5_1_1: 'Auto-sync Hermes history sessions on first startup',
+    new_0_5_1_2: 'Fix session sync failure with old Hermes versions (backward compatible)',
+    new_0_5_1_3: 'Smart cleanup of exclusive platform credentials on profile clone (Telegram, Discord, Slack, etc.)',
+    new_0_5_1_4: 'Auto-normalize profile names to lowercase to avoid backend validation errors',
+    new_0_5_1_5: 'Fix tool_call_id missing in tool messages for OpenAI API compatibility',
+    new_0_5_1_6: 'Unify SQLite table schema management and initialization',
+    new_0_5_1_7: 'Optimize model list layout in Provider cards (fixed height, tag alignment)',
+    new_0_5_1_8: 'Fix display issue with single-line long code blocks in user messages',
+    new_0_5_1_9: 'Fix web terminal rendering errors in Docker deployment',
     new_0_5_0_1: 'Self-built chat database and context compression: empty chat history on first entry is expected',
     new_0_5_0_2: 'Sessions use WebSocket form, enhanced resume capability',
     new_0_4_8_1: 'Safe Mermaid diagram rendering with async render and timeout fallback',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -721,6 +721,15 @@ export default {
 
   // 更新日志
   changelog: {
+    new_0_5_1_1: '首次启动时自动同步 Hermes 历史会话',
+    new_0_5_1_2: '修复旧版本 Hermes 会话同步失败问题（向后兼容）',
+    new_0_5_1_3: 'Profile 克隆时智能清理独占平台凭据（Telegram、Discord、Slack 等）',
+    new_0_5_1_4: 'Profile 名称输入自动转小写，避免后端验证失败',
+    new_0_5_1_5: '修复 tool 消息缺少 tool_call_id 导致的 OpenAI API 兼容性问题',
+    new_0_5_1_6: '统一 SQLite 数据库表结构管理和初始化',
+    new_0_5_1_7: '优化 Provider 卡片中模型列表布局（固定高度、标签对齐）',
+    new_0_5_1_8: '修复用户消息中长代码块单行超长的显示问题',
+    new_0_5_1_9: '修复 Web 终端在 Docker 部署后的展示报错',
     new_0_5_0_1: '自建聊天数据库和上下文压缩',
     new_0_5_0_2: '会话使用websocket形式，增强断点续传',
     new_0_4_8_1: '安全渲染 Mermaid 图表，支持异步渲染和超时降级',


### PR DESCRIPTION
## 概要
添加 v0.5.1 版本更新日志，包含从 v0.5.0 到现在的 9 个重要更新。

## 版本变更
- package.json: `0.5.0` → `0.5.1`

## 更新内容

### 功能新增
1. **会话同步** - 首次启动时自动同步 Hermes 历史会话

### Bug 修复
2. **向后兼容** - 修复旧版本 Hermes 会话同步失败问题
3. **Profile 克隆** - 智能清理独占平台凭据（Telegram、Discord、Slack 等）
4. **Profile 命名** - 自动转小写，避免后端验证失败
5. **OpenAI 兼容性** - 修复 tool 消息缺少 tool_call_id 的问题
6. **数据库管理** - 统一 SQLite 表结构管理和初始化
7. **UI 优化** - 优化 Provider 卡片中模型列表布局
8. **显示修复** - 修复用户消息中长代码块显示问题
9. **部署修复** - 修复 Web 终端在 Docker 部署后的报错

## 多语言支持
已添加到全部 8 种语言：
- 英文、中文、德文、西班牙文、法文、日文、韩文、葡萄牙文
- 非英语语言使用英文作为占位符，方便后续翻译

🤖 Generated with [Claude Code](https://claude.com/claude-code)