### PR TITLE
fix(sse): use Authorization header instead of query token for EventSource

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Self-hosted AI chat dashboard for Hermes Agent — multi-model (Claude, GPT, Gemini, DeepSeek) web UI with Telegram, Discord, Slack, WhatsApp integration",
   "repository": {
     "type": "git",

--- a/packages/server/src/lib/context-compressor/index.ts
+++ b/packages/server/src/lib/context-compressor/index.ts
@@ -316,9 +316,20 @@ async function callSummarizer(
     }, timeoutMs)
 
     const eventsUrl = new URL(`${upstream}/v1/runs/${run_id}/events`)
-    if (apiKey) eventsUrl.searchParams.set('token', apiKey)
 
-    const source = new EventSource(eventsUrl.toString())
+    // Use Authorization header instead of query parameter for better compatibility
+    const eventSourceInit: any = apiKey ? {
+      fetch: (url: string, init: any = {}) => fetch(url, {
+        ...init,
+        headers: {
+          ...(init.headers || {}),
+          Authorization: `Bearer ${apiKey}`,
+        },
+      }),
+    } : {}
+
+    // @ts-ignore - eventsource library types are too strict
+    const source = new EventSource(eventsUrl.toString(), eventSourceInit)
 
     source.onmessage = (event: MessageEvent) => {
       try {

--- a/packages/server/src/services/hermes/chat-run-socket.ts
+++ b/packages/server/src/services/hermes/chat-run-socket.ts
@@ -571,9 +571,20 @@ export class ChatRunSocket {
 
       // Stream upstream events via EventSource — survives socket disconnect
       const eventsUrl = new URL(`${upstream}/v1/runs/${runId}/events`)
-      if (apiKey) eventsUrl.searchParams.set('token', apiKey)
 
-      const source = new EventSource(eventsUrl.toString())
+      // Use Authorization header instead of query parameter for better compatibility
+      const eventSourceInit: any = apiKey ? {
+        fetch: (url: string, init: any = {}) => fetch(url, {
+          ...init,
+          headers: {
+            ...(init.headers || {}),
+            Authorization: `Bearer ${apiKey}`,
+          },
+        }),
+      } : {}
+
+      // @ts-ignore - eventsource library types are too strict
+      const source = new EventSource(eventsUrl.toString(), eventSourceInit)
 
       source.onmessage = (event: MessageEvent) => {
         try {

--- a/packages/server/src/services/hermes/context-engine/gateway-client.ts
+++ b/packages/server/src/services/hermes/context-engine/gateway-client.ts
@@ -87,9 +87,20 @@ export class GatewaySummarizer implements GatewayCaller {
             }, this.timeoutMs)
 
             const eventsUrl = new URL(`${upstream}/v1/runs/${runId}/events`)
-            if (apiKey) eventsUrl.searchParams.set('token', apiKey)
 
-            const source = new EventSource(eventsUrl.toString())
+            // Use Authorization header instead of query parameter for better compatibility
+            const eventSourceInit: any = apiKey ? {
+                fetch: (url: string, init: any = {}) => fetch(url, {
+                  ...init,
+                  headers: {
+                    ...(init.headers || {}),
+                    Authorization: `Bearer ${apiKey}`,
+                  },
+                }),
+              } : {}
+
+            // @ts-ignore - eventsource library types are too strict
+            const source = new EventSource(eventsUrl.toString(), eventSourceInit)
 
             source.onmessage = async (event: MessageEvent) => {
                 try {

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -333,9 +333,21 @@ class AgentClient {
 
             // Stream events from Hermes
             const eventsUrl = new URL(`${upstream}/v1/runs/${run_id}/events`)
-            if (apiKey) eventsUrl.searchParams.set('token', apiKey)
             logger.debug(`[AgentClients] ${this.name}: streaming events from ${eventsUrl}`)
-            const source = new EventSource(eventsUrl.toString())
+
+            // Use Authorization header instead of query parameter for better compatibility
+            const eventSourceInit: any = apiKey ? {
+                fetch: (url: string, init: any = {}) => fetch(url, {
+                  ...init,
+                  headers: {
+                    ...(init.headers || {}),
+                    Authorization: `Bearer ${apiKey}`,
+                  },
+                }),
+              } : {}
+
+            // @ts-ignore - eventsource library types are too strict
+            const source = new EventSource(eventsUrl.toString(), eventSourceInit)
 
             let fullContent = ''
 


### PR DESCRIPTION
## 概要
修复 issue #315 - EventSource 连接丢失问题。将 SSE 事件流的认证方式从查询参数改为 Authorization Bearer 头。

## 问题分析

### 根本原因
- Web UI v0.5.1 中，普通 API 调用使用 \`Authorization: Bearer <token>\` 头
- 但 SSE（Server-Sent Events）事件流使用 \`?token=\` 查询参数
- Hermes Gateway 期望所有端点（包括 SSE）使用 Bearer token 认证
- 认证方式不匹配导致 EventSource 连接失败，显示 "EventSource connection lost"

### 影响范围
问题在长对话/长响应时更明显，因为：
1. 请求创建成功（POST \`/v1/runs\` 使用 Bearer token）
2. 但事件流立即断开（\`/v1/runs/{id}/events\` 使用查询参数）
3. 用户看到：响应完成但 UI 显示连接丢失错误

## 解决方案

### 技术实现
使用 \`eventsource\` 库的 \`fetch\` 选项覆盖默认网络请求，传递 Authorization 头：

\`\`\`typescript
const eventSourceInit: any = apiKey ? {
  fetch: (url: string, init: any = {}) => fetch(url, {
    ...init,
    headers: {
      ...(init.headers || {}),
      Authorization: \`Bearer \${apiKey}\`,
    },
  }),
} : {}

const source = new EventSource(eventsUrl.toString(), eventSourceInit)
\`\`\`

### 修复文件
1. **chat-run-socket.ts** - 主聊天运行事件流（最重要）
2. **group-chat/agent-clients.ts** - 群聊 Agent 事件流
3. **context-compressor/index.ts** - 上下文压缩事件流
4. **context-engine/gateway-client.ts** - 上下文引擎事件流

### 优势
- ✅ 统一认证方式（所有 API 端点都使用 Bearer token）
- ✅ 与 Hermes Gateway 完全兼容
- ✅ 修复 SSE 流断连问题
- ✅ 改善长对话的用户体验

## 测试
- ✅ 构建通过
- ⏳ 需要实际环境测试：长对话不应再显示 "EventSource connection lost"

## 备注
- 添加了 \`@ts-ignore\` 注释，因为 \`eventsource\` 库的类型定义比实际 fetch API 能力更严格
- 修复基于 issue #315 用户提供的工作验证

Fixes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)