### PR TITLE
修复 Hermes 会话同步和飞书显示

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -121,16 +121,23 @@ function toggleGroup(source: string) {
   localStorage.setItem('hermes_collapsed_groups', JSON.stringify([...collapsedGroups.value]))
 }
 
-watch(groupedSessions, groups => {
+watch(groupedSessions, () => {
   if (localStorage.getItem('hermes_collapsed_groups') !== null) {
     const activeSource = chatStore.activeSession?.source
-    if (activeSource && collapsedGroups.value.has(activeSource)) {
-      collapsedGroups.value = new Set([...collapsedGroups.value].filter(source => source !== activeSource))
+    const nextCollapsed = new Set(
+      [...collapsedGroups.value].filter(source => source !== 'feishu'),
+    )
+    if (activeSource && nextCollapsed.has(activeSource)) {
+      nextCollapsed.delete(activeSource)
+    }
+    if (nextCollapsed.size !== collapsedGroups.value.size) {
+      collapsedGroups.value = nextCollapsed
       localStorage.setItem('hermes_collapsed_groups', JSON.stringify([...collapsedGroups.value]))
     }
     return
   }
-  collapsedGroups.value = new Set(groups.slice(1).map(group => group.source))
+  // Default to expanded groups so non-api_server sources like feishu stay visible.
+  collapsedGroups.value = new Set()
   localStorage.setItem('hermes_collapsed_groups', JSON.stringify([...collapsedGroups.value]))
 }, { once: true })
 

--- a/packages/server/src/db/hermes/session-store.ts
+++ b/packages/server/src/db/hermes/session-store.ts
@@ -129,13 +129,14 @@ function mapMessageRow(row: Record<string, unknown>): HermesMessageRow {
 export function createSession(data: {
   id: string
   profile?: string
+  source?: string
   model?: string
   title?: string
 }): HermesSessionRow {
   const now = Math.floor(Date.now() / 1000)
   if (!isSqliteAvailable()) {
     return {
-      id: data.id, profile: data.profile || 'default', source: 'api_server',
+      id: data.id, profile: data.profile || 'default', source: data.source || 'api_server',
       user_id: null, model: data.model || '', title: data.title || null,
       started_at: now, ended_at: null, end_reason: null,
       message_count: 0, tool_call_count: 0,
@@ -147,8 +148,8 @@ export function createSession(data: {
   const db = getDb()!
   db.prepare(
     `INSERT INTO ${SESSIONS_TABLE} (id, profile, source, model, title, started_at, last_active)
-     VALUES (?, ?, 'api_server', ?, ?, ?, ?)`,
-  ).run(data.id, data.profile || 'default', data.model || '', data.title || null, now, now)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(data.id, data.profile || 'default', data.source || 'api_server', data.model || '', data.title || null, now, now)
   return getSession(data.id)!
 }
 

--- a/packages/server/src/services/hermes/gateway-manager.ts
+++ b/packages/server/src/services/hermes/gateway-manager.ts
@@ -103,6 +103,11 @@ export class GatewayManager {
     return join(HERMES_BASE, 'profiles', name)
   }
 
+  /** 构造显式 profile 的 hermes CLI 参数，避免受当前 active_profile 污染 */
+  private hermesArgs(name: string, args: string[]): string[] {
+    return ['--profile', name, ...args]
+  }
+
   /**
    * 从 profile 的 config.yaml 读取 api_server 端口和主机
    * 读取路径：platforms.api_server.extra.port / extra.host
@@ -339,7 +344,7 @@ export class GatewayManager {
   /** 列出所有已知 profile 名称（通过 hermes CLI 或文件系统扫描） */
   async listProfiles(): Promise<string[]> {
     try {
-      const { stdout } = await execFileAsync(HERMES_BIN, ['profile', 'list'], {
+      const { stdout } = await execFileAsync(HERMES_BIN, this.hermesArgs('default', ['profile', 'list']), {
         timeout: 10000,
         windowsHide: true,
       })
@@ -411,30 +416,14 @@ export class GatewayManager {
 
     if (needsRunMode) {
       // WSL / Docker：无 systemd/launchd，用 "gateway run" 作为 detached 子进程
-      return new Promise((resolve, reject) => {
-        const env = { ...process.env, HERMES_HOME: hermesHome }
-        const child = spawn(HERMES_BIN, ['gateway', 'run', '--replace'], {
-          detached: true,
-          stdio: 'ignore',
-          windowsHide: true,
-          env,
-        })
-        child.unref()
-
-        const pid = child.pid ?? 0
-        logger.info('Starting gateway for profile "%s" (run mode, PID: %d, port: %d)', name, pid, port)
-
-        this.waitForReady(name, pid, port, host, url)
-          .then(resolve)
-          .catch(reject)
-      })
+      return this.startDetached(name, hermesHome, port, host, url)
     }
 
     // 正常系统：先 start，失败则 restart（处理服务已运行的情况）
     logger.info('Starting gateway for profile "%s" (start mode, port: %d)', name, port)
     const env = { ...process.env, HERMES_HOME: hermesHome }
     try {
-      const { stdout } = await execFileAsync(HERMES_BIN, ['gateway', 'start'], {
+      const { stdout } = await execFileAsync(HERMES_BIN, this.hermesArgs(name, ['gateway', 'start']), {
         timeout: 30000,
         env,
         windowsHide: true,
@@ -443,7 +432,7 @@ export class GatewayManager {
     } catch {
       // start 失败（可能服务已运行），用 restart
       try {
-        const { stdout } = await execFileAsync(HERMES_BIN, ['gateway', 'restart'], {
+        const { stdout } = await execFileAsync(HERMES_BIN, this.hermesArgs(name, ['gateway', 'restart']), {
           timeout: 30000,
           env,
           windowsHide: true,
@@ -454,7 +443,35 @@ export class GatewayManager {
       }
     }
 
-    return this.waitForReady(name, 0, port, host, url)
+    try {
+      return await this.waitForReady(name, 0, port, host, url)
+    } catch (err: any) {
+      logger.warn(err, 'gateway service mode failed for profile "%s", falling back to detached run mode', name)
+      try {
+        await this.stop(name, 3000)
+      } catch { }
+      return this.startDetached(name, hermesHome, port, host, url)
+    }
+  }
+
+  private startDetached(name: string, hermesHome: string, port: number, host: string, url: string): Promise<GatewayStatus> {
+    return new Promise((resolve, reject) => {
+      const env = { ...process.env, HERMES_HOME: hermesHome }
+      const child = spawn(HERMES_BIN, this.hermesArgs(name, ['gateway', 'run', '--replace']), {
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true,
+        env,
+      })
+      child.unref()
+
+      const pid = child.pid ?? 0
+      logger.info('Starting gateway for profile "%s" (run mode, PID: %d, port: %d)', name, pid, port)
+
+      this.waitForReady(name, pid, port, host, url)
+        .then(resolve)
+        .catch(reject)
+    })
   }
 
   /** 等待网关健康检查通过，最多 15 秒 */
@@ -493,7 +510,7 @@ export class GatewayManager {
       try {
         const hermesHome = this.profileDir(name)
         const env = { ...process.env, HERMES_HOME: hermesHome }
-        await execFileAsync(HERMES_BIN, ['gateway', 'stop'], {
+        await execFileAsync(HERMES_BIN, this.hermesArgs(name, ['gateway', 'stop']), {
           timeout: 10000,
           env,
           windowsHide: true,

--- a/packages/server/src/services/hermes/hermes-cli.ts
+++ b/packages/server/src/services/hermes/hermes-cli.ts
@@ -2,6 +2,7 @@ import { execFile, spawn } from 'child_process'
 import { existsSync } from 'fs'
 import { promisify } from 'util'
 import { logger } from '../logger'
+import { normalizeActiveProfile } from './hermes-profile'
 
 const execFileAsync = promisify(execFile)
 
@@ -15,6 +16,19 @@ function resolveHermesBin(): string {
 }
 
 const HERMES_BIN = resolveHermesBin()
+
+async function execHermes(args: string[], options: Record<string, any> = {}) {
+  normalizeActiveProfile()
+  return execFileAsync(HERMES_BIN, args, {
+    ...options,
+    ...execOpts,
+  })
+}
+
+function spawnHermes(args: string[], options: Record<string, any> = {}) {
+  normalizeActiveProfile()
+  return spawn(HERMES_BIN, args, options)
+}
 
 export interface HermesSession {
   id: string
@@ -86,10 +100,9 @@ export async function exportSessionsRaw(source?: string): Promise<HermesSessionF
   if (source) args.push('--source', source)
 
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, args, {
+    const { stdout } = await execHermes(args, {
       maxBuffer: 50 * 1024 * 1024, // 50MB
       timeout: 30000,
-      ...execOpts,
     })
     return parseSessionExport(stdout)
   } catch (err: any) {
@@ -153,10 +166,9 @@ export async function getSession(id: string): Promise<HermesSession | null> {
   const args = ['sessions', 'export', '-', '--session-id', id]
 
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, args, {
+    const { stdout } = await execHermes(args, {
       maxBuffer: 50 * 1024 * 1024,
       timeout: 30000,
-      ...execOpts,
     })
 
     const raws = parseSessionExport(stdout)
@@ -197,9 +209,8 @@ export async function getSession(id: string): Promise<HermesSession | null> {
  */
 export async function deleteSession(id: string): Promise<boolean> {
   try {
-    await execFileAsync(HERMES_BIN, ['sessions', 'delete', id, '--yes'], {
+    await execHermes(['sessions', 'delete', id, '--yes'], {
       timeout: 10000,
-      ...execOpts,
     })
     return true
   } catch (err: any) {
@@ -213,9 +224,8 @@ export async function deleteSession(id: string): Promise<boolean> {
  */
 export async function renameSession(id: string, title: string): Promise<boolean> {
   try {
-    await execFileAsync(HERMES_BIN, ['sessions', 'rename', id, title], {
+    await execHermes(['sessions', 'rename', id, title], {
       timeout: 10000,
-      ...execOpts,
     })
     return true
   } catch (err: any) {
@@ -235,7 +245,7 @@ export interface LogFileInfo {
  */
 export async function getVersion(): Promise<string> {
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, ['--version'], { timeout: 5000, ...execOpts })
+    const { stdout } = await execHermes(['--version'], { timeout: 5000 })
     return stdout.trim()
   } catch {
     return ''
@@ -251,9 +261,8 @@ export async function startGateway(): Promise<string> {
     return pid ? `Gateway started (PID: ${pid})` : 'Gateway start triggered'
   }
 
-  const { stdout, stderr } = await execFileAsync(HERMES_BIN, ['gateway', 'start'], {
+  const { stdout, stderr } = await execHermes(['gateway', 'start'], {
     timeout: 30000,
-    ...execOpts,
   })
   return stdout || stderr
 }
@@ -263,7 +272,7 @@ export async function startGateway(): Promise<string> {
  * Uses "hermes gateway run" as a detached background process
  */
 export async function startGatewayBackground(): Promise<number | null> {
-  const child = spawn(HERMES_BIN, ['gateway', 'run'], {
+  const child = spawnHermes(['gateway', 'run'], {
     detached: true,
     stdio: 'ignore',
     windowsHide: true,
@@ -282,9 +291,8 @@ export async function restartGateway(): Promise<string> {
     return pid ? `Gateway restarted (PID: ${pid})` : 'Gateway restart triggered'
   }
 
-  const { stdout, stderr } = await execFileAsync(HERMES_BIN, ['gateway', 'restart'], {
+  const { stdout, stderr } = await execHermes(['gateway', 'restart'], {
     timeout: 30000,
-    ...execOpts,
   })
   return stdout || stderr
 }
@@ -293,9 +301,8 @@ export async function restartGateway(): Promise<string> {
  * Stop Hermes gateway
  */
 export async function stopGateway(): Promise<string> {
-  const { stdout, stderr } = await execFileAsync(HERMES_BIN, ['gateway', 'stop'], {
+  const { stdout, stderr } = await execHermes(['gateway', 'stop'], {
     timeout: 30000,
-    ...execOpts,
   })
   return stdout || stderr
 }
@@ -305,9 +312,8 @@ export async function stopGateway(): Promise<string> {
  */
 export async function listLogFiles(): Promise<LogFileInfo[]> {
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, ['logs', 'list'], {
+    const { stdout } = await execHermes(['logs', 'list'], {
       timeout: 10000,
-      ...execOpts,
     })
     const files: LogFileInfo[] = []
     const lines = stdout.trim().split('\n').filter(l => l.includes('.log'))
@@ -344,10 +350,9 @@ export async function readLogs(
   if (since) args.push('--since', since)
 
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, args, {
+    const { stdout } = await execHermes(args, {
       maxBuffer: 10 * 1024 * 1024,
       timeout: 15000,
-      ...execOpts,
     })
     return stdout
   } catch (err: any) {
@@ -382,9 +387,8 @@ export interface HermesProfileDetail {
  */
 export async function listProfiles(): Promise<HermesProfile[]> {
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, ['profile', 'list'], {
+    const { stdout } = await execHermes(['profile', 'list'], {
       timeout: 10000,
-      ...execOpts,
     })
 
     const lines = stdout.trim().split('\n').filter(Boolean)
@@ -418,9 +422,8 @@ export async function listProfiles(): Promise<HermesProfile[]> {
  */
 export async function getProfile(name: string): Promise<HermesProfileDetail> {
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, ['profile', 'show', name], {
+    const { stdout } = await execHermes(['profile', 'show', name], {
       timeout: 10000,
-      ...execOpts,
     })
 
     const result: Record<string, string> = {}
@@ -462,9 +465,8 @@ export async function createProfile(name: string, clone?: boolean): Promise<stri
   if (clone) args.push('--clone')
 
   try {
-    const { stdout, stderr } = await execFileAsync(HERMES_BIN, args, {
+    const { stdout, stderr } = await execHermes(args, {
       timeout: 15000,
-      ...execOpts,
     })
     return stdout || stderr
   } catch (err: any) {
@@ -478,9 +480,8 @@ export async function createProfile(name: string, clone?: boolean): Promise<stri
  */
 export async function deleteProfile(name: string): Promise<boolean> {
   try {
-    await execFileAsync(HERMES_BIN, ['profile', 'delete', name, '--yes'], {
+    await execHermes(['profile', 'delete', name, '--yes'], {
       timeout: 10000,
-      ...execOpts,
     })
     return true
   } catch (err: any) {
@@ -494,9 +495,8 @@ export async function deleteProfile(name: string): Promise<boolean> {
  */
 export async function renameProfile(oldName: string, newName: string): Promise<boolean> {
   try {
-    await execFileAsync(HERMES_BIN, ['profile', 'rename', oldName, newName], {
+    await execHermes(['profile', 'rename', oldName, newName], {
       timeout: 10000,
-      ...execOpts,
     })
     return true
   } catch (err: any) {
@@ -510,9 +510,8 @@ export async function renameProfile(oldName: string, newName: string): Promise<b
  */
 export async function useProfile(name: string): Promise<string> {
   try {
-    const { stdout, stderr } = await execFileAsync(HERMES_BIN, ['profile', 'use', name], {
+    const { stdout, stderr } = await execHermes(['profile', 'use', name], {
       timeout: 10000,
-      ...execOpts,
     })
     return stdout || stderr
   } catch (err: any) {
@@ -529,9 +528,8 @@ export async function exportProfile(name: string, outputPath?: string): Promise<
   if (outputPath) args.push('--output', outputPath)
 
   try {
-    const { stdout, stderr } = await execFileAsync(HERMES_BIN, args, {
+    const { stdout, stderr } = await execHermes(args, {
       timeout: 60000,
-      ...execOpts,
     })
     return stdout || stderr
   } catch (err: any) {
@@ -545,9 +543,8 @@ export async function exportProfile(name: string, outputPath?: string): Promise<
  */
 export async function setupReset(): Promise<string> {
   try {
-    const { stdout, stderr } = await execFileAsync(HERMES_BIN, ['setup', '--non-interactive', '--reset'], {
+    const { stdout, stderr } = await execHermes(['setup', '--non-interactive', '--reset'], {
       timeout: 30000,
-      ...execOpts,
     })
     return stdout || stderr
   } catch (err: any) {
@@ -564,9 +561,8 @@ export async function importProfile(archivePath: string, name?: string): Promise
   if (name) args.push('--name', name)
 
   try {
-    const { stdout, stderr } = await execFileAsync(HERMES_BIN, args, {
+    const { stdout, stderr } = await execHermes(args, {
       timeout: 60000,
-      ...execOpts,
     })
     return stdout || stderr
   } catch (err: any) {

--- a/packages/server/src/services/hermes/hermes-profile.ts
+++ b/packages/server/src/services/hermes/hermes-profile.ts
@@ -1,8 +1,29 @@
 import { resolve, join } from 'path'
 import { homedir } from 'os'
-import { readFileSync, existsSync } from 'fs'
+import { readFileSync, existsSync, writeFileSync } from 'fs'
 
 const HERMES_BASE = resolve(homedir(), '.hermes')
+
+function activeProfileFile(): string {
+  return join(HERMES_BASE, 'active_profile')
+}
+
+function profileDir(name: string): string {
+  return name === 'default' ? HERMES_BASE : join(HERMES_BASE, 'profiles', name)
+}
+
+export function normalizeActiveProfile(): string {
+  const activeFile = activeProfileFile()
+  try {
+    const name = readFileSync(activeFile, 'utf-8').trim()
+    if (!name || name === 'default') return 'default'
+    if (existsSync(profileDir(name))) return name
+    writeFileSync(activeFile, 'default\n', 'utf-8')
+    return 'default'
+  } catch {
+    return 'default'
+  }
+}
 
 /**
  * Get the active profile's home directory.
@@ -10,15 +31,7 @@ const HERMES_BASE = resolve(homedir(), '.hermes')
  * other   → ~/.hermes/profiles/{name}/
  */
 export function getActiveProfileDir(): string {
-  const activeFile = join(HERMES_BASE, 'active_profile')
-  try {
-    const name = readFileSync(activeFile, 'utf-8').trim()
-    if (name && name !== 'default') {
-      const dir = join(HERMES_BASE, 'profiles', name)
-      if (existsSync(dir)) return dir
-    }
-  } catch { }
-  return HERMES_BASE
+  return profileDir(normalizeActiveProfile())
 }
 
 /**
@@ -46,13 +59,7 @@ export function getActiveEnvPath(): string {
  * Get the active profile name.
  */
 export function getActiveProfileName(): string {
-  const activeFile = join(HERMES_BASE, 'active_profile')
-  try {
-    const name = readFileSync(activeFile, 'utf-8').trim()
-    return name || 'default'
-  } catch {
-    return 'default'
-  }
+  return normalizeActiveProfile()
 }
 
 /**

--- a/packages/server/src/services/hermes/session-sync.ts
+++ b/packages/server/src/services/hermes/session-sync.ts
@@ -1,33 +1,16 @@
 /**
  * Sync Hermes sessions from all profiles on startup.
- * Reads api_server sessions from Hermes state.db and imports into local DB.
- * Only runs when local DB is empty (first startup).
+ * Reads Hermes state.db sessions from every profile and imports them into the
+ * web-ui local DB with their original source preserved.
  */
 import { readdirSync, existsSync } from 'fs'
 import { resolve, join } from 'path'
 import { homedir } from 'os'
 import { DatabaseSync } from 'node:sqlite'
-import { randomBytes } from 'crypto'
 import { getProfileDir } from './hermes-profile'
 import { createSession, addMessage, updateSession, getSession } from '../../db/hermes/session-store'
 import { getDb } from '../../db/index'
 import { logger } from '../logger'
-
-/**
- * Generate a UUID v4 without external dependencies
- */
-function generateUuid(): string {
-  const bytes = randomBytes(16)
-  bytes[6] = (bytes[6]! & 0x0f) | 0x40 // Version 4
-  bytes[8] = (bytes[8]! & 0x3f) | 0x80 // Variant 10
-  return [
-    bytes.subarray(0, 4).toString('hex'),
-    bytes.subarray(4, 6).toString('hex'),
-    bytes.subarray(6, 8).toString('hex'),
-    bytes.subarray(8, 10).toString('hex'),
-    bytes.subarray(10, 16).toString('hex'),
-  ].join('-')
-}
 
 const HERMES_BASE = resolve(homedir(), '.hermes')
 const PROFILES_DIR = join(HERMES_BASE, 'profiles')
@@ -99,7 +82,7 @@ function openHermesStateDb(profile: string): DatabaseSync {
 }
 
 /**
- * Sync api_server sessions from a single profile
+ * Sync Hermes sessions from a single profile.
  */
 function syncProfileSessions(profile: string): {
   synced: number
@@ -119,7 +102,7 @@ function syncProfileSessions(profile: string): {
       // Build SELECT query - only include estimated_cost_usd if column exists
       const estimatedCostCol = hasEstimatedCost ? ', COALESCE(estimated_cost_usd, 0) AS estimated_cost_usd' : ', 0 AS estimated_cost_usd'
 
-      // Get all api_server sessions
+      // Get all Hermes sessions except tool/compression internals.
       const sessions = db.prepare(`
         SELECT
           id,
@@ -137,27 +120,26 @@ function syncProfileSessions(profile: string): {
           cache_write_tokens,
           reasoning_tokens${estimatedCostCol}
         FROM sessions
-        WHERE source = 'api_server'
+        WHERE source != 'tool'
+          AND source != 'api_server'
         ORDER BY started_at ASC
       `).all() as unknown as Omit<HermesSessionRow, 'preview' | 'last_active'>[]
 
-      logger.info(`[session-sync] profile '${profile}': found ${sessions.length} api_server sessions`)
+      logger.info(`[session-sync] profile '${profile}': found ${sessions.length} Hermes sessions to import`)
       for (const hermesSession of sessions) {
         try {
-          // Check if this Hermes session ID already exists in local DB
+          // Use the Hermes session ID as the local ID so sync stays idempotent.
           const existing = getSession(hermesSession.id)
           if (existing) {
             result.skipped++
             continue
           }
 
-          // Generate new session ID
-          const newSessionId = generateUuid()
-
           // Create session in local DB
           createSession({
-            id: newSessionId,
+            id: hermesSession.id,
             profile,
+            source: hermesSession.source,
             model: hermesSession.model,
             title: hermesSession.title || undefined,
           })
@@ -187,7 +169,7 @@ function syncProfileSessions(profile: string): {
           // Insert all messages
           for (const msg of messages) {
             addMessage({
-              session_id: newSessionId,
+              session_id: hermesSession.id,
               role: msg.role,
               content: msg.content,
               tool_call_id: msg.tool_call_id,
@@ -219,7 +201,7 @@ function syncProfileSessions(profile: string): {
             ? hermesSession.estimated_cost_usd
             : 0
 
-          updateSession(newSessionId, {
+          updateSession(hermesSession.id, {
             started_at: hermesSession.started_at,
             ended_at: hermesSession.ended_at,
             end_reason: hermesSession.end_reason,
@@ -234,7 +216,7 @@ function syncProfileSessions(profile: string): {
           })
 
           result.synced++
-          logger.info(`[session-sync] synced Hermes session ${hermesSession.id} -> ${newSessionId} (${messages.length} messages)`)
+          logger.info(`[session-sync] synced Hermes session ${hermesSession.id} (${messages.length} messages)`)
         } catch (err: any) {
           result.errors.push(`session ${hermesSession.id}: ${err.message}`)
           logger.warn(err, `[session-sync] failed to sync session ${hermesSession.id}`)
@@ -254,26 +236,17 @@ function syncProfileSessions(profile: string): {
 }
 
 /**
- * Main entry point: sync all profiles on startup
- * Only runs if local DB is empty (first startup or after DB reset)
+ * Main entry point: sync all profiles on startup.
+ * Keeps importing Hermes sessions into the local UI DB and preserves their source.
  */
 export function syncAllHermesSessionsOnStartup(): void {
-  // Check if local DB has any sessions - only sync if completely empty
   const db = getDb()
   if (!db) {
     logger.info('[session-sync] SQLite not available, skipping Hermes sync')
     return
   }
-
   const countResult = db.prepare('SELECT COUNT(*) as count FROM sessions').get() as { count: number } | undefined
-  const hasExistingSessions = countResult && countResult.count > 0
-
-  if (hasExistingSessions) {
-    logger.info('[session-sync] local DB has %d sessions, skipping Hermes sync', countResult!.count)
-    return
-  }
-
-  logger.info('[session-sync] local DB is empty, starting Hermes session sync...')
+  logger.info('[session-sync] local DB has %d sessions, starting Hermes session sync...', countResult?.count || 0)
 
   const profiles = getAllProfiles()
   logger.info(`[session-sync] found ${profiles.length} profiles: ${profiles.join(', ')}`)

--- a/tests/server/hermes-profile.test.ts
+++ b/tests/server/hermes-profile.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const readFileSyncMock = vi.fn()
+const existsSyncMock = vi.fn()
+const writeFileSyncMock = vi.fn()
+
+vi.mock('os', () => ({
+  homedir: () => '/tmp/test-home',
+}))
+
+vi.mock('fs', () => ({
+  readFileSync: readFileSyncMock,
+  existsSync: existsSyncMock,
+  writeFileSync: writeFileSyncMock,
+}))
+
+describe('hermes-profile helpers', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    readFileSyncMock.mockReset()
+    existsSyncMock.mockReset()
+    writeFileSyncMock.mockReset()
+  })
+
+  it('falls back to default and repairs active_profile when the sticky profile no longer exists', async () => {
+    readFileSyncMock.mockReturnValue('cog\n')
+    existsSyncMock.mockReturnValue(false)
+
+    const mod = await import('../../packages/server/src/services/hermes/hermes-profile')
+
+    expect(mod.getActiveProfileName()).toBe('default')
+    expect(mod.getActiveProfileDir()).toBe('/tmp/test-home/.hermes')
+    expect(writeFileSyncMock).toHaveBeenCalledWith('/tmp/test-home/.hermes/active_profile', 'default\n', 'utf-8')
+  })
+
+  it('keeps a valid sticky profile unchanged', async () => {
+    readFileSyncMock.mockReturnValue('wiki\n')
+    existsSyncMock.mockImplementation((path: string) => path === '/tmp/test-home/.hermes/profiles/wiki')
+
+    const mod = await import('../../packages/server/src/services/hermes/hermes-profile')
+
+    expect(mod.getActiveProfileName()).toBe('wiki')
+    expect(mod.getActiveProfileDir()).toBe('/tmp/test-home/.hermes/profiles/wiki')
+    expect(writeFileSyncMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/server/session-sync.test.ts
+++ b/tests/server/session-sync.test.ts
@@ -2,11 +2,13 @@
  * Tests for session-sync service
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { getDb, ensureTable } from '../../packages/server/src/db/index'
+import { getDb } from '../../packages/server/src/db/index'
+import { initAllHermesTables } from '../../packages/server/src/db/hermes/schemas'
 import { syncAllHermesSessionsOnStartup } from '../../packages/server/src/services/hermes/session-sync'
 
 describe('session-sync', () => {
   beforeEach(() => {
+    initAllHermesTables()
     // Reset database before each test
     const db = getDb()
     if (db) {
@@ -16,6 +18,7 @@ describe('session-sync', () => {
   })
 
   afterEach(() => {
+    initAllHermesTables()
     // Cleanup after each test
     const db = getDb()
     if (db) {
@@ -24,7 +27,7 @@ describe('session-sync', () => {
     }
   })
 
-  it('should skip sync when local DB is not empty', () => {
+  it('should preserve existing local sessions when sync runs', () => {
     const db = getDb()
     expect(db).not.toBeNull()
 
@@ -38,12 +41,12 @@ describe('session-sync', () => {
     const countResult = db!.prepare('SELECT COUNT(*) as count FROM sessions').get() as { count: number }
     expect(countResult.count).toBe(1)
 
-    // Run sync - should skip because DB is not empty
+    // Run sync - should keep existing local data intact and may import Hermes sessions
     syncAllHermesSessionsOnStartup()
 
-    // Verify session still exists (no changes)
+    // Verify the local session still exists
     const countAfter = db!.prepare('SELECT COUNT(*) as count FROM sessions').get() as { count: number }
-    expect(countAfter.count).toBe(1)
+    expect(countAfter.count).toBeGreaterThanOrEqual(1)
   })
 
   it('should attempt sync when local DB is empty', () => {


### PR DESCRIPTION
把 Hermes 会话同步到 web-ui 本地库时保留原始 source，避免飞书会话只剩 api_server。