### PR TITLE
整理 Hermes 兼容补丁

### DIFF
--- a/packages/server/src/services/hermes/gateway-manager.ts
+++ b/packages/server/src/services/hermes/gateway-manager.ts
@@ -103,6 +103,11 @@ export class GatewayManager {
     return join(HERMES_BASE, 'profiles', name)
   }
 
+  /** 构造显式 profile 的 hermes CLI 参数，避免受当前 active_profile 污染 */
+  private hermesArgs(name: string, args: string[]): string[] {
+    return ['--profile', name, ...args]
+  }
+
   /**
    * 从 profile 的 config.yaml 读取 api_server 端口和主机
    * 读取路径：platforms.api_server.extra.port / extra.host
@@ -339,7 +344,7 @@ export class GatewayManager {
   /** 列出所有已知 profile 名称（通过 hermes CLI 或文件系统扫描） */
   async listProfiles(): Promise<string[]> {
     try {
-      const { stdout } = await execFileAsync(HERMES_BIN, ['profile', 'list'], {
+      const { stdout } = await execFileAsync(HERMES_BIN, this.hermesArgs('default', ['profile', 'list']), {
         timeout: 10000,
         windowsHide: true,
       })
@@ -411,30 +416,14 @@ export class GatewayManager {
 
     if (needsRunMode) {
       // WSL / Docker：无 systemd/launchd，用 "gateway run" 作为 detached 子进程
-      return new Promise((resolve, reject) => {
-        const env = { ...process.env, HERMES_HOME: hermesHome }
-        const child = spawn(HERMES_BIN, ['gateway', 'run', '--replace'], {
-          detached: true,
-          stdio: 'ignore',
-          windowsHide: true,
-          env,
-        })
-        child.unref()
-
-        const pid = child.pid ?? 0
-        logger.info('Starting gateway for profile "%s" (run mode, PID: %d, port: %d)', name, pid, port)
-
-        this.waitForReady(name, pid, port, host, url)
-          .then(resolve)
-          .catch(reject)
-      })
+      return this.startDetached(name, hermesHome, port, host, url)
     }
 
     // 正常系统：先 start，失败则 restart（处理服务已运行的情况）
     logger.info('Starting gateway for profile "%s" (start mode, port: %d)', name, port)
     const env = { ...process.env, HERMES_HOME: hermesHome }
     try {
-      const { stdout } = await execFileAsync(HERMES_BIN, ['gateway', 'start'], {
+      const { stdout } = await execFileAsync(HERMES_BIN, this.hermesArgs(name, ['gateway', 'start']), {
         timeout: 30000,
         env,
         windowsHide: true,
@@ -443,7 +432,7 @@ export class GatewayManager {
     } catch {
       // start 失败（可能服务已运行），用 restart
       try {
-        const { stdout } = await execFileAsync(HERMES_BIN, ['gateway', 'restart'], {
+        const { stdout } = await execFileAsync(HERMES_BIN, this.hermesArgs(name, ['gateway', 'restart']), {
           timeout: 30000,
           env,
           windowsHide: true,
@@ -454,7 +443,35 @@ export class GatewayManager {
       }
     }
 
-    return this.waitForReady(name, 0, port, host, url)
+    try {
+      return await this.waitForReady(name, 0, port, host, url)
+    } catch (err: any) {
+      logger.warn(err, 'gateway service mode failed for profile "%s", falling back to detached run mode', name)
+      try {
+        await this.stop(name, 3000)
+      } catch { }
+      return this.startDetached(name, hermesHome, port, host, url)
+    }
+  }
+
+  private startDetached(name: string, hermesHome: string, port: number, host: string, url: string): Promise<GatewayStatus> {
+    return new Promise((resolve, reject) => {
+      const env = { ...process.env, HERMES_HOME: hermesHome }
+      const child = spawn(HERMES_BIN, this.hermesArgs(name, ['gateway', 'run', '--replace']), {
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true,
+        env,
+      })
+      child.unref()
+
+      const pid = child.pid ?? 0
+      logger.info('Starting gateway for profile "%s" (run mode, PID: %d, port: %d)', name, pid, port)
+
+      this.waitForReady(name, pid, port, host, url)
+        .then(resolve)
+        .catch(reject)
+    })
   }
 
   /** 等待网关健康检查通过，最多 15 秒 */
@@ -493,7 +510,7 @@ export class GatewayManager {
       try {
         const hermesHome = this.profileDir(name)
         const env = { ...process.env, HERMES_HOME: hermesHome }
-        await execFileAsync(HERMES_BIN, ['gateway', 'stop'], {
+        await execFileAsync(HERMES_BIN, this.hermesArgs(name, ['gateway', 'stop']), {
           timeout: 10000,
           env,
           windowsHide: true,

--- a/packages/server/src/services/hermes/hermes-cli.ts
+++ b/packages/server/src/services/hermes/hermes-cli.ts
@@ -2,6 +2,7 @@ import { execFile, spawn } from 'child_process'
 import { existsSync } from 'fs'
 import { promisify } from 'util'
 import { logger } from '../logger'
+import { normalizeActiveProfile } from './hermes-profile'
 
 const execFileAsync = promisify(execFile)
 
@@ -15,6 +16,19 @@ function resolveHermesBin(): string {
 }
 
 const HERMES_BIN = resolveHermesBin()
+
+async function execHermes(args: string[], options: Record<string, any> = {}) {
+  normalizeActiveProfile()
+  return execFileAsync(HERMES_BIN, args, {
+    ...options,
+    ...execOpts,
+  })
+}
+
+function spawnHermes(args: string[], options: Record<string, any> = {}) {
+  normalizeActiveProfile()
+  return spawn(HERMES_BIN, args, options)
+}
 
 export interface HermesSession {
   id: string
@@ -86,10 +100,9 @@ export async function exportSessionsRaw(source?: string): Promise<HermesSessionF
   if (source) args.push('--source', source)
 
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, args, {
+    const { stdout } = await execHermes(args, {
       maxBuffer: 50 * 1024 * 1024, // 50MB
       timeout: 30000,
-      ...execOpts,
     })
     return parseSessionExport(stdout)
   } catch (err: any) {
@@ -153,10 +166,9 @@ export async function getSession(id: string): Promise<HermesSession | null> {
   const args = ['sessions', 'export', '-', '--session-id', id]
 
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, args, {
+    const { stdout } = await execHermes(args, {
       maxBuffer: 50 * 1024 * 1024,
       timeout: 30000,
-      ...execOpts,
     })
 
     const raws = parseSessionExport(stdout)
@@ -197,9 +209,8 @@ export async function getSession(id: string): Promise<HermesSession | null> {
  */
 export async function deleteSession(id: string): Promise<boolean> {
   try {
-    await execFileAsync(HERMES_BIN, ['sessions', 'delete', id, '--yes'], {
+    await execHermes(['sessions', 'delete', id, '--yes'], {
       timeout: 10000,
-      ...execOpts,
     })
     return true
   } catch (err: any) {
@@ -213,9 +224,8 @@ export async function deleteSession(id: string): Promise<boolean> {
  */
 export async function renameSession(id: string, title: string): Promise<boolean> {
   try {
-    await execFileAsync(HERMES_BIN, ['sessions', 'rename', id, title], {
+    await execHermes(['sessions', 'rename', id, title], {
       timeout: 10000,
-      ...execOpts,
     })
     return true
   } catch (err: any) {
@@ -235,7 +245,7 @@ export interface LogFileInfo {
  */
 export async function getVersion(): Promise<string> {
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, ['--version'], { timeout: 5000, ...execOpts })
+    const { stdout } = await execHermes(['--version'], { timeout: 5000 })
     return stdout.trim()
   } catch {
     return ''
@@ -251,9 +261,8 @@ export async function startGateway(): Promise<string> {
     return pid ? `Gateway started (PID: ${pid})` : 'Gateway start triggered'
   }
 
-  const { stdout, stderr } = await execFileAsync(HERMES_BIN, ['gateway', 'start'], {
+  const { stdout, stderr } = await execHermes(['gateway', 'start'], {
     timeout: 30000,
-    ...execOpts,
   })
   return stdout || stderr
 }
@@ -263,7 +272,7 @@ export async function startGateway(): Promise<string> {
  * Uses "hermes gateway run" as a detached background process
  */
 export async function startGatewayBackground(): Promise<number | null> {
-  const child = spawn(HERMES_BIN, ['gateway', 'run'], {
+  const child = spawnHermes(['gateway', 'run'], {
     detached: true,
     stdio: 'ignore',
     windowsHide: true,
@@ -282,9 +291,8 @@ export async function restartGateway(): Promise<string> {
     return pid ? `Gateway restarted (PID: ${pid})` : 'Gateway restart triggered'
   }
 
-  const { stdout, stderr } = await execFileAsync(HERMES_BIN, ['gateway', 'restart'], {
+  const { stdout, stderr } = await execHermes(['gateway', 'restart'], {
     timeout: 30000,
-    ...execOpts,
   })
   return stdout || stderr
 }
@@ -293,9 +301,8 @@ export async function restartGateway(): Promise<string> {
  * Stop Hermes gateway
  */
 export async function stopGateway(): Promise<string> {
-  const { stdout, stderr } = await execFileAsync(HERMES_BIN, ['gateway', 'stop'], {
+  const { stdout, stderr } = await execHermes(['gateway', 'stop'], {
     timeout: 30000,
-    ...execOpts,
   })
   return stdout || stderr
 }
@@ -305,9 +312,8 @@ export async function stopGateway(): Promise<string> {
  */
 export async function listLogFiles(): Promise<LogFileInfo[]> {
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, ['logs', 'list'], {
+    const { stdout } = await execHermes(['logs', 'list'], {
       timeout: 10000,
-      ...execOpts,
     })
     const files: LogFileInfo[] = []
     const lines = stdout.trim().split('\n').filter(l => l.includes('.log'))
@@ -344,10 +350,9 @@ export async function readLogs(
   if (since) args.push('--since', since)
 
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, args, {
+    const { stdout } = await execHermes(args, {
       maxBuffer: 10 * 1024 * 1024,
       timeout: 15000,
-      ...execOpts,
     })
     return stdout
   } catch (err: any) {
@@ -382,9 +387,8 @@ export interface HermesProfileDetail {
  */
 export async function listProfiles(): Promise<HermesProfile[]> {
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, ['profile', 'list'], {
+    const { stdout } = await execHermes(['profile', 'list'], {
       timeout: 10000,
-      ...execOpts,
     })
 
     const lines = stdout.trim().split('\n').filter(Boolean)
@@ -418,9 +422,8 @@ export async function listProfiles(): Promise<HermesProfile[]> {
  */
 export async function getProfile(name: string): Promise<HermesProfileDetail> {
   try {
-    const { stdout } = await execFileAsync(HERMES_BIN, ['profile', 'show', name], {
+    const { stdout } = await execHermes(['profile', 'show', name], {
       timeout: 10000,
-      ...execOpts,
     })
 
     const result: Record<string, string> = {}
@@ -462,9 +465,8 @@ export async function createProfile(name: string, clone?: boolean): Promise<stri
   if (clone) args.push('--clone')
 
   try {
-    const { stdout, stderr } = await execFileAsync(HERMES_BIN, args, {
+    const { stdout, stderr } = await execHermes(args, {
       timeout: 15000,
-      ...execOpts,
     })
     return stdout || stderr
   } catch (err: any) {
@@ -478,9 +480,8 @@ export async function createProfile(name: string, clone?: boolean): Promise<stri
  */
 export async function deleteProfile(name: string): Promise<boolean> {
   try {
-    await execFileAsync(HERMES_BIN, ['profile', 'delete', name, '--yes'], {
+    await execHermes(['profile', 'delete', name, '--yes'], {
       timeout: 10000,
-      ...execOpts,
     })
     return true
   } catch (err: any) {
@@ -494,9 +495,8 @@ export async function deleteProfile(name: string): Promise<boolean> {
  */
 export async function renameProfile(oldName: string, newName: string): Promise<boolean> {
   try {
-    await execFileAsync(HERMES_BIN, ['profile', 'rename', oldName, newName], {
+    await execHermes(['profile', 'rename', oldName, newName], {
       timeout: 10000,
-      ...execOpts,
     })
     return true
   } catch (err: any) {
@@ -510,9 +510,8 @@ export async function renameProfile(oldName: string, newName: string): Promise<b
  */
 export async function useProfile(name: string): Promise<string> {
   try {
-    const { stdout, stderr } = await execFileAsync(HERMES_BIN, ['profile', 'use', name], {
+    const { stdout, stderr } = await execHermes(['profile', 'use', name], {
       timeout: 10000,
-      ...execOpts,
     })
     return stdout || stderr
   } catch (err: any) {
@@ -529,9 +528,8 @@ export async function exportProfile(name: string, outputPath?: string): Promise<
   if (outputPath) args.push('--output', outputPath)
 
   try {
-    const { stdout, stderr } = await execFileAsync(HERMES_BIN, args, {
+    const { stdout, stderr } = await execHermes(args, {
       timeout: 60000,
-      ...execOpts,
     })
     return stdout || stderr
   } catch (err: any) {
@@ -545,9 +543,8 @@ export async function exportProfile(name: string, outputPath?: string): Promise<
  */
 export async function setupReset(): Promise<string> {
   try {
-    const { stdout, stderr } = await execFileAsync(HERMES_BIN, ['setup', '--non-interactive', '--reset'], {
+    const { stdout, stderr } = await execHermes(['setup', '--non-interactive', '--reset'], {
       timeout: 30000,
-      ...execOpts,
     })
     return stdout || stderr
   } catch (err: any) {
@@ -564,9 +561,8 @@ export async function importProfile(archivePath: string, name?: string): Promise
   if (name) args.push('--name', name)
 
   try {
-    const { stdout, stderr } = await execFileAsync(HERMES_BIN, args, {
+    const { stdout, stderr } = await execHermes(args, {
       timeout: 60000,
-      ...execOpts,
     })
     return stdout || stderr
   } catch (err: any) {

--- a/packages/server/src/services/hermes/hermes-profile.ts
+++ b/packages/server/src/services/hermes/hermes-profile.ts
@@ -1,8 +1,29 @@
 import { resolve, join } from 'path'
 import { homedir } from 'os'
-import { readFileSync, existsSync } from 'fs'
+import { readFileSync, existsSync, writeFileSync } from 'fs'
 
 const HERMES_BASE = process.env.HERMES_HOME || resolve(homedir(), '.hermes')
+
+function activeProfileFile(): string {
+  return join(HERMES_BASE, 'active_profile')
+}
+
+function profileDir(name: string): string {
+  return name === 'default' ? HERMES_BASE : join(HERMES_BASE, 'profiles', name)
+}
+
+export function normalizeActiveProfile(): string {
+  const activeFile = activeProfileFile()
+  try {
+    const name = readFileSync(activeFile, 'utf-8').trim()
+    if (!name || name === 'default') return 'default'
+    if (existsSync(profileDir(name))) return name
+    writeFileSync(activeFile, 'default\n', 'utf-8')
+    return 'default'
+  } catch {
+    return 'default'
+  }
+}
 
 /**
  * Get the active profile's home directory.
@@ -10,15 +31,7 @@ const HERMES_BASE = process.env.HERMES_HOME || resolve(homedir(), '.hermes')
  * other   → ~/.hermes/profiles/{name}/
  */
 export function getActiveProfileDir(): string {
-  const activeFile = join(HERMES_BASE, 'active_profile')
-  try {
-    const name = readFileSync(activeFile, 'utf-8').trim()
-    if (name && name !== 'default') {
-      const dir = join(HERMES_BASE, 'profiles', name)
-      if (existsSync(dir)) return dir
-    }
-  } catch { }
-  return HERMES_BASE
+  return profileDir(normalizeActiveProfile())
 }
 
 /**
@@ -46,13 +59,7 @@ export function getActiveEnvPath(): string {
  * Get the active profile name.
  */
 export function getActiveProfileName(): string {
-  const activeFile = join(HERMES_BASE, 'active_profile')
-  try {
-    const name = readFileSync(activeFile, 'utf-8').trim()
-    return name || 'default'
-  } catch {
-    return 'default'
-  }
+  return normalizeActiveProfile()
 }
 
 /**

--- a/tests/server/hermes-profile.test.ts
+++ b/tests/server/hermes-profile.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const readFileSyncMock = vi.fn()
+const existsSyncMock = vi.fn()
+const writeFileSyncMock = vi.fn()
+
+vi.mock('os', () => ({
+  homedir: () => '/tmp/test-home',
+}))
+
+vi.mock('fs', () => ({
+  readFileSync: readFileSyncMock,
+  existsSync: existsSyncMock,
+  writeFileSync: writeFileSyncMock,
+}))
+
+describe('hermes-profile helpers', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    readFileSyncMock.mockReset()
+    existsSyncMock.mockReset()
+    writeFileSyncMock.mockReset()
+  })
+
+  it('falls back to default and repairs active_profile when the sticky profile no longer exists', async () => {
+    readFileSyncMock.mockReturnValue('cog\n')
+    existsSyncMock.mockReturnValue(false)
+
+    const mod = await import('../../packages/server/src/services/hermes/hermes-profile')
+
+    expect(mod.getActiveProfileName()).toBe('default')
+    expect(mod.getActiveProfileDir()).toBe('/tmp/test-home/.hermes')
+    expect(writeFileSyncMock).toHaveBeenCalledWith('/tmp/test-home/.hermes/active_profile', 'default\n', 'utf-8')
+  })
+
+  it('keeps a valid sticky profile unchanged', async () => {
+    readFileSyncMock.mockReturnValue('wiki\n')
+    existsSyncMock.mockImplementation((path: string) => path === '/tmp/test-home/.hermes/profiles/wiki')
+
+    const mod = await import('../../packages/server/src/services/hermes/hermes-profile')
+
+    expect(mod.getActiveProfileName()).toBe('wiki')
+    expect(mod.getActiveProfileDir()).toBe('/tmp/test-home/.hermes/profiles/wiki')
+    expect(writeFileSyncMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
把 Hermes profile / gateway / CLI 的兼容修复单独拆出来，避免和飞书会话同步混在一起。