### PR TITLE
feat: add sidebar collapse toggle for compact icon-rail mode

### DIFF
--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -57,12 +57,19 @@ function openChangelog() {
 </script>
 
 <template>
-  <aside class="sidebar" :class="{ open: appStore.sidebarOpen }">
+  <aside class="sidebar" :class="{ open: appStore.sidebarOpen, collapsed: appStore.sidebarCollapsed }">
     <div class="sidebar-logo" @click="router.push('/hermes/chat')">
       <img :src="logoPath" alt="Hermes" class="logo-img" />
       <span class="logo-text">Hermes</span>
       <!-- <video class="logo-dance" :src="isDark ? danceVideoDark : danceVideoLight" autoplay loop muted playsinline /> -->
     </div>
+
+    <button class="collapse-btn" @click="appStore.toggleSidebarCollapsed()" :title="appStore.sidebarCollapsed ? t('sidebar.expand') : t('sidebar.collapse')">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline v-if="appStore.sidebarCollapsed" points="9 18 15 12 9 6" />
+        <polyline v-else points="15 18 9 12 15 6" />
+      </svg>
+    </button>
 
     <nav class="sidebar-nav">
       <!-- Conversation -->
@@ -309,6 +316,7 @@ function openChangelog() {
 @use "@/styles/variables" as *;
 
 .sidebar {
+  position: relative;
   width: $sidebar-width;
   height: calc(100 * var(--vh));
   background-color: $bg-sidebar;
@@ -593,6 +601,112 @@ function openChangelog() {
       background: $text-muted;
     }
   }
+}
+
+// ─── Collapsed sidebar (icon-rail mode) ─────────────────────────
+
+.sidebar.collapsed {
+  width: $sidebar-collapsed-width;
+  padding: 0 8px 12px;
+  overflow: hidden;
+
+  .sidebar-logo {
+    padding: 12px 4px 8px;
+    margin: 0 -8px;
+    justify-content: center;
+    gap: 0;
+
+    .logo-text {
+      display: none;
+    }
+  }
+
+  .collapse-btn {
+    display: flex;
+    margin: 0 auto 8px;
+  }
+
+  .nav-group-label {
+    display: none;
+  }
+
+  .nav-item {
+    justify-content: center;
+    padding: 10px 4px;
+    gap: 0;
+
+    span {
+      display: none;
+    }
+
+    svg {
+      flex-shrink: 0;
+    }
+  }
+
+  // Keep group children visible — user can still see icons
+  .nav-group > div {
+    display: flex !important;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  // Hide selectors and footer text, keep theme switch
+  :deep(.profile-selector),
+  :deep(.model-selector) {
+    display: none;
+  }
+
+  .sidebar-footer {
+    .logout-item span {
+      display: none;
+    }
+
+    .status-text {
+      display: none;
+    }
+
+    .version-text,
+    .github-link {
+      display: none;
+    }
+
+    .status-row {
+      justify-content: center;
+    }
+  }
+}
+
+// ─── Collapse button ────────────────────────────────────────────
+
+.collapse-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: none;
+  color: $text-muted;
+  border-radius: $radius-sm;
+  cursor: pointer;
+  flex-shrink: 0;
+  margin-left: auto;
+  margin-right: 0;
+  transition: all $transition-fast;
+
+  &:hover {
+    color: $text-primary;
+    background-color: rgba(var(--accent-primary-rgb), 0.08);
+  }
+}
+
+// In expanded mode, overlap the top-right of the logo area
+.sidebar:not(.collapsed) .collapse-btn {
+  position: absolute;
+  top: 18px;
+  right: 16px;
+  z-index: 5;
 }
 
 @media (max-width: $breakpoint-mobile) {


### PR DESCRIPTION
## Summary

Add a collapse button at the top of the left sidebar that toggles between full-width (240px, icons + labels) and compact icon-only mode (64px). The collapse state is persisted to localStorage and survives page refreshes.

## Motivation

The left sidebar occupies 240px of horizontal space at all times on desktop, which is problematic for:
- **Tablets and handheld devices** where screen real estate is limited
- **Split-screen workflows** where the user wants more space for the chat/editor panel
- Users who primarily navigate by icon recognition and don't need the text labels

This significantly improves browsing experience on tablets and other handheld devices by freeing up ~176px of horizontal space on demand.

## Changes

- **Template**: Added a collapse toggle button (chevron icon) between the logo and nav area, bound to `appStore.sidebarCollapsed`
- **CSS**: Added `.sidebar.collapsed` rules — narrows width to 64px, centers nav icons, hides all text labels / group headers / footer text / model and profile selectors
- **Backend**: No changes needed — the Pinia store (`sidebarCollapsed`, `toggleSidebarCollapsed()`, localStorage persistence) and SCSS variable (`$sidebar-collapsed-width`) were already defined but never wired into the template

## Behavior

| Feature | Expanded (default) | Collapsed |
|---|---|---|
| Width | 240px | 64px |
| Nav items | Icon + label | Icon only (centered) |
| Group labels | Visible | Hidden |
| Model/Profile selectors | Visible | Hidden |
| Footer | Full (status, version, theme) | Status dot + theme switch only |
| Group collapsing | Functional | Ignored (all icons visible) |
| State persistence | — | localStorage (`hermes_sidebar_collapsed`) |

## File changed

- `packages/client/src/components/layout/AppSidebar.vue` (+115, -1)
