### PR TITLE
fix(sessions): guard syncFromHermes vs SessionDeleter race + import all sources on startup

### DIFF
--- a/packages/server/src/services/hermes/chat-run-socket.ts
+++ b/packages/server/src/services/hermes/chat-run-socket.ts
@@ -26,6 +26,7 @@ import { getSessionDetailFromDb } from '../../db/hermes/sessions-db'
 import { getModelContextLength } from './model-context'
 import { ChatContextCompressor, countTokens, SUMMARY_PREFIX } from '../../lib/context-compressor'
 import { getCompressionSnapshot } from '../../db/hermes/compression-snapshot'
+import { inFlightHermesSessionIds } from './session-deleter'
 import { logger } from '../logger'
 
 const compressor = new ChatContextCompressor()
@@ -1201,10 +1202,16 @@ export class ChatRunSocket {
    * After sync, enqueues the ephemeral session for deletion.
    */
   private syncFromHermes(socket: Socket, localSessionId: string, hermesSessionId: string, profile?: string) {
+    // Mark this Hermes session as in-flight so SessionDeleter.drain will defer
+    // any pending deletion until after we finish reading messages — see #352.
+    inFlightHermesSessionIds.add(hermesSessionId)
     getSessionDetailFromDb(hermesSessionId)
       .then((detail) => {
         if (!detail || !detail.messages?.length) {
           logger.warn('[chat-run-socket] syncFromHermes: no data for Hermes session %s', hermesSessionId)
+          // No data to sync — drop the in-flight guard so the empty Hermes
+          // session can still be cleaned up by drain on its own schedule.
+          inFlightHermesSessionIds.delete(hermesSessionId)
           return
         }
 
@@ -1307,10 +1314,18 @@ export class ChatRunSocket {
           this.calcAndUpdateUsage(localSessionId, state, emit)
         }
 
-        // Enqueue ephemeral session for deferred deletion
+        // Enqueue ephemeral session for deferred deletion.
+        // IMPORTANT: enqueue BEFORE clearing the in-flight guard so the drain
+        // loop never sees the row without the guard — see #352.
         this.enqueueEphemeralDelete(hermesSessionId, profile)
+        inFlightHermesSessionIds.delete(hermesSessionId)
       })
       .catch((err: any) => {
+        // Release the guard so a stuck id doesn't block deletion forever.
+        // We deliberately do NOT enqueue on failure; if the run truly produced
+        // a Hermes session worth deleting, the next successful sync (or a
+        // restart-time scan) will pick it up.
+        inFlightHermesSessionIds.delete(hermesSessionId)
         logger.warn(err, '[chat-run-socket] syncFromHermes failed for session %s (hermesId: %s, profile: %s)', localSessionId, hermesSessionId, profile || 'default')
       })
   }

--- a/packages/server/src/services/hermes/session-deleter.ts
+++ b/packages/server/src/services/hermes/session-deleter.ts
@@ -4,6 +4,14 @@
  * Reads from gc_pending_session_deletes table, executes deletion via
  * Hermes CLI, tracks failures (max 3 attempts), and auto-drains on
  * a timer + profile switch.
+ *
+ * Race-condition guard: callers that are still ASYNCHRONOUSLY reading
+ * a Hermes session (e.g. chat-run-socket.syncFromHermes) must register
+ * the hermes session id in `inFlightHermesSessionIds` BEFORE the read
+ * starts and remove it AFTER the read completes (success or failure).
+ * The drain loop will skip any id present in that set, so the periodic
+ * timer / profile-switch tick cannot delete a session out from under
+ * an in-flight reader. See issue #352.
  */
 import { getDb } from '../../db/index'
 import { deleteSession as hermesDeleteSession } from './hermes-cli'
@@ -11,6 +19,18 @@ import { logger } from '../logger'
 
 const MAX_ATTEMPTS = 3
 const DRAIN_INTERVAL_MS = 300_000
+
+/**
+ * Hermes session ids currently being read by an async consumer
+ * (e.g. syncFromHermes). The drain loop skips any id in this set so
+ * that periodic deletion cannot race with an in-flight read and leave
+ * the local DB missing assistant/tool messages. See issue #352.
+ *
+ * Producers must:
+ *   inFlightHermesSessionIds.add(id)
+ *   try { ...read... } finally { inFlightHermesSessionIds.delete(id) }
+ */
+export const inFlightHermesSessionIds = new Set<string>()
 
 export class SessionDeleter {
   private static _instance: SessionDeleter | null = null
@@ -74,11 +94,30 @@ export class SessionDeleter {
 
     if (rows.length === 0) return { deleted: [], skipped: [], failed: [] }
 
+    // Skip any session that an async reader (e.g. syncFromHermes) is still
+    // pulling messages out of. Without this guard, drain can delete a session
+    // before the reader finishes, dropping assistant/tool messages from the
+    // local mirror — see issue #352.
+    const eligibleRows = rows.filter(r => !inFlightHermesSessionIds.has(r.session_id))
+    if (eligibleRows.length === 0) {
+      logger.debug(
+        '[SessionDeleter] all %d candidate(s) deferred (in-flight reads in progress)',
+        rows.length,
+      )
+      return { deleted: [], skipped: rows.map(r => r.session_id), failed: [] }
+    }
+    if (eligibleRows.length < rows.length) {
+      logger.debug(
+        '[SessionDeleter] deferred %d candidate(s) due to in-flight reads',
+        rows.length - eligibleRows.length,
+      )
+    }
+
     const deleted: string[] = []
     const skipped: string[] = []
     const failed: string[] = []
 
-    for (const row of rows) {
+    for (const row of eligibleRows) {
       try {
         const ok = await hermesDeleteSession(row.session_id)
         if (ok) {

--- a/packages/server/src/services/hermes/session-sync.ts
+++ b/packages/server/src/services/hermes/session-sync.ts
@@ -1,9 +1,11 @@
 /**
  * Sync Hermes sessions from all profiles on startup.
- * Reads api_server sessions from Hermes state.db and imports into local DB.
+ * Reads sessions from ALL sources (cli, api_server, telegram, discord, etc.)
+ * out of Hermes state.db and imports into local DB.
  * Only runs when local DB is empty (first startup).
  *
- * Uses sessions-db.ts query logic to properly aggregate session chains.
+ * Uses sessions-db.ts query logic to properly aggregate session chains
+ * (parent_session_id roots only, with descendants merged).
  */
 import { readdirSync, existsSync } from 'fs'
 import { resolve, join } from 'path'
@@ -62,8 +64,11 @@ async function syncProfileSessions(profile: string): Promise<{
 
   try {
     // Use listSessionSummaries to get aggregated session chains
-    // This returns only root sessions with aggregated stats from the entire chain
-    const summaries = await listHermesSessionSummaries('api_server', 10000, profile)
+    // This returns only root sessions with aggregated stats from the entire chain.
+    // Pass `undefined` for source to import sessions from ALL sources (cli, api_server,
+    // telegram, discord, etc.) — previously hardcoded 'api_server' silently dropped
+    // CLI conversations and any other channels on first-startup sync.
+    const summaries = await listHermesSessionSummaries(undefined, 10000, profile)
 
     logger.info(`[session-sync] profile '${profile}': found ${summaries.length} aggregated session chains`)
 


### PR DESCRIPTION
Closes #352.

## Summary

Two related bugs in the v0.5.3 session pipeline:

### Bug 1 — SessionDeleter race condition (#352)

`chat-run-socket.syncFromHermes` asynchronously reads a Hermes session and writes its assistant/tool messages into the local mirror, then enqueues the Hermes session id into `gc_pending_session_deletes`. `SessionDeleter` drains that queue on a 5-minute timer, on profile switch, and immediately on start — with no coordination against in-flight reads. A drain that fires while a sync is mid-flight deletes the Hermes session out from under the reader, and assistant/tool messages never make it into the local DB.

**Visible symptom:** switching away and back to a session shows assistant replies vanishing; `message_count` decrements over time (6 → 5 → 4 …).

**Fix:** introduce an in-memory `inFlightHermesSessionIds: Set<string>` exported from `session-deleter.ts`. `syncFromHermes` adds the id BEFORE awaiting the read and removes it after the read completes — handling all three exit paths:
- Successful sync → enqueue delete, then release guard (ordering matters: the row must exist in the queue before drain can observe a guard-less candidate)
- Empty-detail early return → release guard, do not enqueue
- `.catch()` → release guard, do not enqueue (next successful sync will pick it up)

`drain()` filters out any candidate currently in the set, so periodic / profile-switch ticks defer deletion until the read is done.

### Bug 2 — Startup sync silently drops CLI sessions

`syncProfileSessions` hardcoded `'api_server'` as the source filter on `listHermesSessionSummaries`, so first-startup sync only imported chat sessions originated by the WebUI itself. CLI conversations (`source='cli'`), Telegram, Discord, Slack, etc. were never synced into the local DB and stayed invisible in the sidebar forever (sync only runs when the local DB is empty, so they couldn't be recovered without dropping the DB).

As a side effect, long CLI conversations that had been compressed into a `parent_session_id` chain weren't aggregated either, since they weren't synced at all.

**Fix:** pass `undefined` to `listSessionSummaries` so it returns roots from ALL sources. That function already filters out `tool` / `compress_*` sessions and aggregates `parent_session_id` chains, so no other change is needed.

## Files changed

- `packages/server/src/services/hermes/session-deleter.ts` — export `inFlightHermesSessionIds`, filter eligible rows in `drain()`
- `packages/server/src/services/hermes/chat-run-socket.ts` — register/release guard around `syncFromHermes`
- `packages/server/src/services/hermes/session-sync.ts` — import all sources, not just `api_server`

3 files, +65 / −6 lines.

## Test plan

- [x] Local clean re-sync against a Hermes `state.db` containing mixed `api_server` + `cli` sessions across 4 profiles → imported 11 chains (previously 0 from this code path), correctly aggregating multi-step chains (max `thread_session_count=5`) into single sidebar entries.
- [x] `npm run build` passes (vue-tsc + tsc + esbuild).
- [x] Server starts cleanly, `[session-sync] sync complete: synced=11, errors=0` in logs.
- [ ] Maintainer to verify: chat run → switch session → wait > 5 min → switch back → assistant messages should still be present.

## Notes

- The guard is intentionally a process-local in-memory set rather than a DB column. Drain only runs in this process, and `syncFromHermes` only registers in this process, so a Set is sufficient and avoids schema migration.
- Ordering inside the success path (`enqueue → then release`) is load-bearing — reversing it reintroduces a small window where drain could miss the guard. This is documented in the code with a `// IMPORTANT:` comment referencing the issue.