### PR TITLE
fix: 修复 cron job 编辑时的 schedule payload

### DIFF
--- a/packages/client/src/api/hermes/jobs.ts
+++ b/packages/client/src/api/hermes/jobs.ts
@@ -1,5 +1,24 @@
 import { request } from '../client'
 
+export type JobSchedule =
+  | string
+  | { kind: 'interval'; minutes: number; display: string }
+  | { kind: 'cron'; expr: string; display: string }
+  | { kind: 'once'; run_at: string; display: string }
+
+export function scheduleToEditableInput(schedule: JobSchedule, fallback = ''): string {
+  if (typeof schedule === 'string') return schedule
+  if (schedule.kind === 'cron') return schedule.expr
+  if (schedule.kind === 'once') return schedule.run_at
+  return schedule.display || fallback
+}
+
+export function scheduleToDisplayText(schedule: JobSchedule, fallback = '—'): string {
+  if (typeof schedule === 'string') return schedule
+  if (schedule.kind === 'cron') return schedule.expr || schedule.display || fallback
+  return schedule.display || fallback
+}
+
 export interface Job {
   job_id: string
   id: string
@@ -12,7 +31,7 @@ export interface Job {
   provider: string | null
   base_url: string | null
   script: string | null
-  schedule: string | { kind: string; expr: string; display: string }
+  schedule: JobSchedule
   schedule_display: string
   repeat: string | { times: number | null; completed: number }
   enabled: boolean
@@ -45,7 +64,7 @@ export interface CreateJobRequest {
 
 export interface UpdateJobRequest {
   name?: string
-  schedule?: string | { kind: string; expr: string; display: string }
+  schedule?: string
   prompt?: string
   deliver?: string
   skills?: string[]

--- a/packages/client/src/components/hermes/jobs/JobCard.vue
+++ b/packages/client/src/components/hermes/jobs/JobCard.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { NButton, NTooltip, useMessage } from 'naive-ui'
 import type { Job } from '@/api/hermes/jobs'
+import { scheduleToDisplayText } from '@/api/hermes/jobs'
 import { useJobsStore } from '@/stores/hermes/jobs'
 import { useI18n } from 'vue-i18n'
 
@@ -35,11 +36,7 @@ const statusType = computed(() => {
   return 'success' as const
 })
 
-const scheduleExpr = computed(() => {
-  const s = props.job.schedule
-  if (typeof s === 'string') return s
-  return s?.expr || props.job.schedule_display || '—'
-})
+const scheduleExpr = computed(() => scheduleToDisplayText(props.job.schedule, props.job.schedule_display || '—'))
 
 const formatTime = (t?: string | null) => {
   if (!t) return '—'

--- a/packages/client/src/components/hermes/jobs/JobFormModal.vue
+++ b/packages/client/src/components/hermes/jobs/JobFormModal.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, computed } from 'vue'
 import { NModal, NForm, NFormItem, NInput, NButton, NSelect, NInputNumber, useMessage } from 'naive-ui'
 import { useJobsStore } from '@/stores/hermes/jobs'
+import { scheduleToEditableInput } from '@/api/hermes/jobs'
 import type { CreateJobRequest, UpdateJobRequest } from '@/api/hermes/jobs'
 import { useI18n } from 'vue-i18n'
 
@@ -49,8 +50,6 @@ const targetOptions = computed(() => [
   { label: t('jobs.local'), value: 'local' },
 ])
 
-const originalSchedule = ref<{ kind: string; expr: string; display: string } | null>(null)
-
 onMounted(async () => {
   if (props.jobId) {
     try {
@@ -58,13 +57,10 @@ onMounted(async () => {
       const job = await getJob(props.jobId)
       formData.value = {
         name: job.name,
-        schedule: typeof job.schedule === 'string' ? job.schedule : (job.schedule?.expr || job.schedule_display || ''),
+        schedule: scheduleToEditableInput(job.schedule, job.schedule_display),
         prompt: job.prompt,
         deliver: job.deliver || 'origin',
         repeat_times: typeof job.repeat === 'number' ? job.repeat : (typeof job.repeat === 'object' ? job.repeat.times : null),
-      }
-      if (typeof job.schedule === 'object' && job.schedule) {
-        originalSchedule.value = job.schedule
       }
     } catch (e: any) {
       message.error(t('jobs.loadFailed') + ': ' + e.message)
@@ -90,15 +86,7 @@ async function handleSave() {
         prompt: formData.value.prompt,
         deliver: formData.value.deliver,
         repeat: formData.value.repeat_times ?? undefined,
-      }
-      if (originalSchedule.value) {
-        payload.schedule = {
-          kind: originalSchedule.value.kind,
-          expr: formData.value.schedule,
-          display: formData.value.schedule,
-        }
-      } else {
-        payload.schedule = formData.value.schedule
+        schedule: formData.value.schedule,
       }
       await jobsStore.updateJob(props.jobId!, payload)
       message.success(t('jobs.jobUpdated'))

--- a/tests/client/jobs.test.ts
+++ b/tests/client/jobs.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const mockGetJob = vi.hoisted(() => vi.fn())
+const mockJobsStore = vi.hoisted(() => ({
+  createJob: vi.fn(),
+  updateJob: vi.fn(),
+  pauseJob: vi.fn(),
+  resumeJob: vi.fn(),
+  runJob: vi.fn(),
+  deleteJob: vi.fn(),
+}))
+const mockMessage = vi.hoisted(() => ({
+  success: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/jobs', async () => {
+  const actual = await vi.importActual<typeof import('@/api/hermes/jobs')>('@/api/hermes/jobs')
+  return {
+    ...actual,
+    getJob: mockGetJob,
+  }
+})
+
+vi.mock('@/stores/hermes/jobs', () => ({
+  useJobsStore: () => mockJobsStore,
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NModal: { template: '<div><slot /><slot name="footer" /></div>' },
+  NForm: { template: '<form><slot /></form>' },
+  NFormItem: { template: '<label><slot /></label>' },
+  NInput: { props: ['value'], emits: ['update:value'], template: '<input :value="value" />' },
+  NInputNumber: { props: ['value'], emits: ['update:value'], template: '<input :value="value" />' },
+  NSelect: { props: ['value', 'options'], emits: ['update:value'], template: '<select />' },
+  NButton: { inheritAttrs: false, emits: ['click'], template: '<button @click="$emit(\'click\')"><slot /></button>' },
+  useMessage: () => mockMessage,
+}))
+
+import {
+  scheduleToDisplayText,
+  scheduleToEditableInput,
+  type JobSchedule,
+} from '@/api/hermes/jobs'
+import JobFormModal from '@/components/hermes/jobs/JobFormModal.vue'
+
+describe('job schedule helpers', () => {
+  it('maps structured schedules to editable strings without inventing invalid shapes', () => {
+    const interval: JobSchedule = { kind: 'interval', minutes: 7200, display: 'every 7200m' }
+    const cron: JobSchedule = { kind: 'cron', expr: '0 9 * * *', display: '0 9 * * *' }
+    const once: JobSchedule = {
+      kind: 'once',
+      run_at: '2026-02-03T14:00:00+01:00',
+      display: 'once at 2026-02-03 14:00',
+    }
+
+    expect(scheduleToEditableInput(interval)).toBe('every 7200m')
+    expect(scheduleToEditableInput(cron)).toBe('0 9 * * *')
+    expect(scheduleToEditableInput(once)).toBe('2026-02-03T14:00:00+01:00')
+  })
+
+  it('uses display text for non-cron structured schedules in cards', () => {
+    expect(scheduleToDisplayText({ kind: 'interval', minutes: 7200, display: 'every 7200m' })).toBe('every 7200m')
+    expect(scheduleToDisplayText({
+      kind: 'once',
+      run_at: '2026-02-03T14:00:00+01:00',
+      display: 'once at 2026-02-03 14:00',
+    })).toBe('once at 2026-02-03 14:00')
+  })
+})
+
+describe('JobFormModal cron edit payload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockJobsStore.updateJob.mockResolvedValue({})
+  })
+
+  it('submits edited interval schedules as strings so the backend re-parses them', async () => {
+    mockGetJob.mockResolvedValue({
+      id: 'job-1',
+      job_id: 'job-1',
+      name: 'Interval job',
+      schedule: { kind: 'interval', minutes: 7200, display: 'every 7200m' },
+      schedule_display: 'every 7200m',
+      prompt: 'ping',
+      deliver: 'origin',
+      repeat: { times: null, completed: 0 },
+    })
+
+    const wrapper = mount(JobFormModal, { props: { jobId: 'job-1' } })
+    await flushPromises()
+
+    const saveButton = wrapper.findAll('button').at(-1)
+    expect(saveButton).toBeTruthy()
+    await saveButton!.trigger('click')
+    await flushPromises()
+
+    expect(mockJobsStore.updateJob).toHaveBeenCalledOnce()
+    const [, payload] = mockJobsStore.updateJob.mock.calls[0]
+    expect(payload.schedule).toBe('every 7200m')
+    expect(typeof payload.schedule).toBe('string')
+    expect(payload).not.toEqual(expect.objectContaining({
+      schedule: expect.objectContaining({ kind: 'interval', expr: 'every 7200m' }),
+    }))
+  })
+})


### PR DESCRIPTION
Cron job 编辑时的 schedule payload 已改成 string。interval / once / cron 的结构化返回值只在前端转成可编辑/展示文本，保存时交给 Hermes backend 重新 parse，避免 interval 被重构成缺少 `minutes` 的对象。

## 改动
- 补 `JobSchedule` union，区分 interval / cron / once 的真实结构。
- 编辑表单加载结构化 schedule 时转成可编辑字符串；保存时 `UpdateJobRequest.schedule` 只发送 string。
- JobCard 对 interval / once 使用 `display` 展示，不再假设所有结构化 schedule 都有 `expr`。
- 增加 `tests/client/jobs.test.ts`，覆盖 interval 编辑 payload 必须是 string，以及不同 schedule 类型的前端转换。

## 验证
已通过：

```bash
git diff --check origin/main...HEAD
npm test -- tests/client/jobs.test.ts
```

结果：`tests/client/jobs.test.ts` 3 tests passed。

GitHub Actions：`build` passed。

已知：
- 本地 `npm run build` 仍失败在当前环境的 `MarkdownRenderer.vue` / `mermaid` 类型问题，不是这个 PR 引入：
  - `Cannot find module 'mermaid' or its corresponding type declarations.`
  - `'result' is of type 'unknown'.`
