### PR TITLE
fix: sync all session sources and add Jobs API configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,3 +283,34 @@ The BFF layer handles API proxy (with path rewriting), SSE streaming, file uploa
 ## License
 
 [MIT](./LICENSE)
+
+## Configuration
+
+### API Server Key for Jobs API
+
+Web UI requires `API_SERVER_KEY` to authenticate with Hermes Gateway's Jobs API. 
+
+**For default profile**, create `~/.hermes/.env`:
+```bash
+API_SERVER_KEY="your-api-server-key"
+```
+
+**For other profiles**, create `~/.hermes/profiles/<profile-name>/.env`:
+```bash
+API_SERVER_KEY="your-api-server-key"
+```
+
+The API key is configured in `~/.hermes/config.yaml`:
+```yaml
+platforms:
+  api_server:
+    enabled: true
+    key: "your-api-server-key"  # Copy this value to .env
+    extra:
+      host: 127.0.0.1
+      port: 8642
+```
+
+### Why is this needed?
+
+Web UI's `gateway-manager.ts` reads `API_SERVER_KEY` from `.env` file to authenticate proxy requests to Hermes Gateway's `/api/jobs` endpoint. Without this configuration, the Jobs page will return `Invalid API key` error.

--- a/packages/server/src/db/hermes/session-store.ts
+++ b/packages/server/src/db/hermes/session-store.ts
@@ -134,11 +134,12 @@ export function createSession(data: {
   model?: string
   title?: string
   workspace?: string
+  source?: string
 }): HermesSessionRow {
   const now = Math.floor(Date.now() / 1000)
   if (!isSqliteAvailable()) {
     return {
-      id: data.id, profile: data.profile || 'default', source: 'api_server',
+      id: data.id, profile: data.profile || 'default', source: data.source || 'api_server',
       user_id: null, model: data.model || '', title: data.title || null,
       started_at: now, ended_at: null, end_reason: null,
       message_count: 0, tool_call_count: 0,
@@ -150,8 +151,8 @@ export function createSession(data: {
   const db = getDb()!
   db.prepare(
     `INSERT INTO ${SESSIONS_TABLE} (id, profile, source, model, title, started_at, last_active, workspace)
-     VALUES (?, ?, 'api_server', ?, ?, ?, ?, ?)`,
-  ).run(data.id, data.profile || 'default', data.model || '', data.title || null, now, now, data.workspace || null)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(data.id, data.profile || 'default', data.source || 'api_server', data.model || '', data.title || null, now, now, data.workspace || null)
   return getSession(data.id)!
 }
 

--- a/packages/server/src/services/hermes/session-sync.ts
+++ b/packages/server/src/services/hermes/session-sync.ts
@@ -63,7 +63,7 @@ async function syncProfileSessions(profile: string): Promise<{
   try {
     // Use listSessionSummaries to get aggregated session chains
     // This returns only root sessions with aggregated stats from the entire chain
-    const summaries = await listHermesSessionSummaries('api_server', 10000, profile)
+    const summaries = await listHermesSessionSummaries(undefined, 10000, profile)
 
     logger.info(`[session-sync] profile '${profile}': found ${summaries.length} aggregated session chains`)
 
@@ -77,6 +77,7 @@ async function syncProfileSessions(profile: string): Promise<{
           id: newSessionId,
           profile,
           model: hermesSession.model,
+          source: hermesSession.source,
           title: hermesSession.title || undefined,
         })
 


### PR DESCRIPTION
## Summary

Fixes two critical bugs preventing Web UI from displaying session records and cron jobs.

### Bug #1: Session Sync Filtering

**Problem**: session-sync.ts hardcoded listHermesSessionSummaries('api_server', ...) which only fetched sessions with source='api_server'. Hermes Agent sessions have sources like cli, telegram, weixin, feishu, wecom, qqbot, cron — never api_server.

**Fix**: Changed to listHermesSessionSummaries(undefined, ...) to sync all sources.

**Files changed**:
- packages/server/src/services/hermes/session-sync.ts

### Bug #2: Session Source Override

**Problem**: createSession() hardcoded source: 'api_server' overriding actual source values from Hermes.

**Fix**: Added source?: string to CreateSessionData interface and changed to source: data.source || 'api_server' to preserve original source.

**Files changed**:
- packages/server/src/db/hermes/session-store.ts
- packages/server/src/services/hermes/session-sync.ts

### Bug #3: Jobs API Authentication

**Problem**: Jobs page returned Invalid API key because Web UI couldn't find API_SERVER_KEY.

**Fix**: Document that API_SERVER_KEY must be in ~/.hermes/.env (for default profile) or ~/.hermes/profiles/<name>/.env (for other profiles).

**Files changed**:
- README.md — Added configuration documentation

## Configuration Required

After deploying this fix, users need to create .env file:

**Default profile** (~/.hermes/.env):
```bash
API_SERVER_KEY="your-api-server-key"
```

**Other profiles** (~/.hermes/profiles/<profile-name>/.env):
```bash
API_SERVER_KEY="your-api-server-key"
```

The API key is found in ~/.hermes/config.yaml:
```yaml
platforms:
  api_server:
    key: "your-api-server-key"  # Copy this value to .env
```

## Test Plan

1. Create ~/.hermes/.env with API_SERVER_KEY
2. Restart Web UI
3. Verify Sessions page shows all sources (cli, telegram, weixin, etc.)
4. Verify Jobs page shows all cron jobs
5. Verify source badges display correctly

Closes #368
