### PR TITLE
feat(xiaomi): 动态获取 Xiaomi MiMo 模型列表

### DIFF
--- a/packages/client/src/shared/providers.ts
+++ b/packages/client/src/shared/providers.ts
@@ -159,7 +159,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     label: 'Xiaomi MiMo',
     value: 'xiaomi',
     base_url: 'https://api.xiaomimimo.com/v1',
-    models: ['mimo-v2-pro', 'mimo-v2-omni', 'mimo-v2-flash'],
+    models: ['mimo-v2.5-pro', 'mimo-v2.5', 'mimo-v2-pro', 'mimo-v2-omni', 'mimo-v2-flash'],
   },
   {
     label: 'Kilo Code',

--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'fs/promises'
 import { existsSync, readFileSync } from 'fs'
 import { getActiveEnvPath, getActiveAuthPath } from '../../services/hermes/hermes-profile'
-import { readConfigYaml, writeConfigYaml, fetchProviderModels, buildModelGroups, PROVIDER_ENV_MAP } from '../../services/config-helpers'
+import { readConfigYaml, writeConfigYaml, fetchProviderModels, fetchXiaomiModels, buildModelGroups, PROVIDER_ENV_MAP } from '../../services/config-helpers'
 import { buildProviderModelMap, PROVIDER_PRESETS } from '../../shared/providers'
 import { getCopilotModelsDetailed, resolveCopilotOAuthToken, type CopilotModelMeta } from '../../services/hermes/copilot-models'
 import { readAppConfig } from '../../services/app-config'
@@ -143,6 +143,17 @@ export async function getAvailable(ctx: any) {
               const fetched = await fetchProviderModels(baseUrl, orKey, true)
               if (fetched.length > 0) modelsList = fetched
             } catch { /* ignore — leave empty, won't show */ }
+          }
+        }
+      } else if (providerKey === 'xiaomi') {
+        // Xiaomi uses api-key header — fetch dynamically, fall back to hardcoded
+        if (envMapping.api_key_env) {
+          const xiaomiKey = envGetValue(envMapping.api_key_env)
+          if (xiaomiKey) {
+            try {
+              const fetched = await fetchXiaomiModels(baseUrl, xiaomiKey)
+              if (fetched.length > 0) modelsList = fetched
+            } catch { /* ignore — leave hardcoded fallback */ }
           }
         }
       }

--- a/packages/server/src/services/config-helpers.ts
+++ b/packages/server/src/services/config-helpers.ts
@@ -209,6 +209,50 @@ export async function fetchProviderModels(baseUrl: string, apiKey: string, freeO
   }
 }
 
+/** Models returned by Xiaomi's /v1/models that are NOT usable in chat/agent mode. */
+const XIAOMI_NON_CHAT_MODEL_PATTERNS = ['-tts', '-voiceclone', '-voicedesign']
+
+/**
+ * Fetch available models from Xiaomi MiMo's /v1/models endpoint.
+ *
+ * Unlike most OpenAI-compatible providers, Xiaomi uses an `api-key` header
+ * instead of `Authorization: Bearer`.  Non-chat models (TTS, voice clone, etc.)
+ * are filtered out so the picker only shows models usable by the agent.
+ *
+ * Returns an empty array on any failure so the caller can fall back to the
+ * hardcoded catalog.
+ */
+/** CN token-plan endpoint — used automatically when the API key starts with `tp-`. */
+const XIAOMI_TOKEN_PLAN_BASE_URL = 'https://token-plan-cn.xiaomimimo.com/v1'
+
+export async function fetchXiaomiModels(baseUrl: string, apiKey: string): Promise<string[]> {
+  // tp-* keys must hit the CN token-plan endpoint; sk-* keys use the default
+  const effectiveBase = apiKey.startsWith('tp-') ? XIAOMI_TOKEN_PLAN_BASE_URL : baseUrl.replace(/\/+$/, '')
+  const modelsUrl = `${effectiveBase}/models`
+  try {
+    const res = await fetch(modelsUrl, {
+      headers: { 'api-key': apiKey },
+      signal: AbortSignal.timeout(8000),
+    })
+    if (!res.ok) {
+      logger.warn('xiaomi-models %s returned %d', modelsUrl, res.status)
+      return []
+    }
+    const data = await res.json() as { data?: Array<{ id: string }> }
+    if (!Array.isArray(data.data)) {
+      logger.warn('xiaomi-models %s returned unexpected format', modelsUrl)
+      return []
+    }
+    const models = data.data
+      .map(m => m.id)
+      .filter(id => !XIAOMI_NON_CHAT_MODEL_PATTERNS.some(p => id.includes(p)))
+    return models.sort()
+  } catch (err: any) {
+    logger.error(err, 'xiaomi-models %s failed', modelsUrl)
+    return []
+  }
+}
+
 export function buildModelGroups(config: Record<string, any>): { default: string; groups: ModelGroup[] } {
   let defaultModel = ''
   const groups: ModelGroup[] = []

--- a/packages/server/src/shared/providers.ts
+++ b/packages/server/src/shared/providers.ts
@@ -170,7 +170,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     value: 'xiaomi',
     builtin: true,
     base_url: 'https://api.xiaomimimo.com/v1',
-    models: ['mimo-v2-pro', 'mimo-v2-omni', 'mimo-v2-flash'],
+    models: ['mimo-v2.5-pro', 'mimo-v2.5', 'mimo-v2-pro', 'mimo-v2-omni', 'mimo-v2-flash'],
   },
   {
     label: 'Kilo Code',


### PR DESCRIPTION
## Summary

Xiaomi MiMo provider 的模型列表之前是硬编码的（仅 3 个老模型），本 PR 使其通过调用 Xiaomi /v1/models API 动态获取可用模型，失败时回退到硬编码列表。

## Changes

- **config-helpers.ts** — 新增 fetchXiaomiModels，使用小米特有的 api-key header 请求 /v1/models，自动过滤 TTS/voiceclone/voicedesign 等非对话模型；根据 key 前缀自动选择正确的 endpoint：
  - sk-* key → https://api.xiaomimimo.com/v1
  - tp-* key → https://token-plan-cn.xiaomimimo.com/v1
- **models.ts controller** — 新增 providerKey === xiaomi 分支，动态拉取模型列表，失败时 fallback 到硬编码列表
- **两个 providers.ts** — 硬编码 fallback 从 3 个更新为 5 个（新增 mimo-v2.5-pro、mimo-v2.5），与 hermes-agent 上游对齐

## Motivation

用户配置 XIAOMI_API_KEY 后，模型选择弹窗只能看到 3 个老模型（mimo-v2-pro/omni/flash），缺少最新的 v2.5 系列。通过 API 动态获取可以自动展示所有可用模型。

## Verification

- vue-tsc / tsc 类型检查通过
- 两种 key 类型（sk- 和 tp-）均已验证正确请求对应 endpoint