### PR TITLE
fix: 修复固定会话 ID 漂移

### DIFF
--- a/packages/client/src/api/hermes/sessions.ts
+++ b/packages/client/src/api/hermes/sessions.ts
@@ -56,6 +56,15 @@ export async function fetchSessions(source?: string, limit?: number): Promise<Se
   return res.sessions
 }
 
+export async function fetchSessionAliases(): Promise<Record<string, string>> {
+  try {
+    const res = await request<{ aliases: Record<string, string> }>('/api/hermes/sessions/aliases')
+    return res.aliases || {}
+  } catch {
+    return {}
+  }
+}
+
 /**
  * Fetch Hermes sessions only (exclude api_server source)
  */

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1,10 +1,11 @@
 import { startRunViaSocket, resumeSession, registerSessionHandlers, unregisterSessionHandlers, type RunEvent } from '@/api/hermes/chat'
-import { deleteSession as deleteSessionApi, fetchSession, fetchSessions, type HermesMessage, type SessionSummary } from '@/api/hermes/sessions'
+import { deleteSession as deleteSessionApi, fetchSession, fetchSessionAliases, fetchSessions, type HermesMessage, type SessionSummary } from '@/api/hermes/sessions'
 import { getApiKey } from '@/api/client'
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { useAppStore } from './app'
 import { useProfilesStore } from './profiles'
+import { useSessionBrowserPrefsStore } from './session-browser-prefs'
 import { detectThinkingBoundary } from '@/utils/thinking-parser'
 
 export interface Attachment {
@@ -352,7 +353,8 @@ export const useChatStore = defineStore('chat', () => {
   async function loadSessions() {
     isLoadingSessions.value = true
     try {
-      const list = await fetchSessions()
+      const [list, aliases] = await Promise.all([fetchSessions(), fetchSessionAliases()])
+      useSessionBrowserPrefsStore().migratePinnedAliases(aliases)
       const fresh = list.map(mapHermesSession)
       const freshIds = new Set(fresh.map(s => s.id))
       // Preserve already-loaded messages for sessions that are still present,
@@ -378,8 +380,9 @@ export const useChatStore = defineStore('chat', () => {
 
       // Restore last active session, fallback to most recent
       const savedId = activeSessionId.value
-      const targetId = savedId && sessions.value.some(s => s.id === savedId)
-        ? savedId
+      const resolvedSavedId = savedId ? aliases[savedId] || savedId : null
+      const targetId = resolvedSavedId && sessions.value.some(s => s.id === resolvedSavedId)
+        ? resolvedSavedId
         : sessions.value[0]?.id
       if (targetId) {
         await switchSession(targetId)
@@ -520,6 +523,7 @@ export const useChatStore = defineStore('chat', () => {
   async function deleteSession(sessionId: string) {
     await deleteSessionApi(sessionId)
     sessions.value = sessions.value.filter(s => s.id !== sessionId)
+    useSessionBrowserPrefsStore().removePinned(sessionId)
     if (activeSessionId.value === sessionId) {
       if (sessions.value.length > 0) {
         await switchSession(sessions.value[0].id)

--- a/packages/client/src/stores/hermes/session-browser-prefs.ts
+++ b/packages/client/src/stores/hermes/session-browser-prefs.ts
@@ -87,10 +87,26 @@ export const useSessionBrowserPrefsStore = defineStore('session-browser-prefs', 
     persistHumanOnly()
   }
 
-  function pruneMissingSessions(existingIds: string[]): boolean {
+  function pruneMissingSessions(existingIds: string[], options?: { confirmedDelete?: boolean }): boolean {
+    if (!options?.confirmedDelete) return false
     if (existingIds.length === 0) return false
     const existing = new Set(existingIds)
     const nextPinnedIds = pinnedIds.value.filter(id => existing.has(id))
+    if (sameIds(nextPinnedIds, pinnedIds.value)) return false
+    pinnedIds.value = nextPinnedIds
+    persistPins()
+    return true
+  }
+
+  function migratePinnedAliases(aliases: Record<string, string>): boolean {
+    const nextPinnedIds: string[] = []
+    const seen = new Set<string>()
+    for (const id of pinnedIds.value) {
+      const resolved = aliases[id] || id
+      if (seen.has(resolved)) continue
+      seen.add(resolved)
+      nextPinnedIds.push(resolved)
+    }
     if (sameIds(nextPinnedIds, pinnedIds.value)) return false
     pinnedIds.value = nextPinnedIds
     persistPins()
@@ -112,5 +128,6 @@ export const useSessionBrowserPrefsStore = defineStore('session-browser-prefs', 
     removePinned,
     setHumanOnly,
     pruneMissingSessions,
+    migratePinnedAliases,
   }
 })

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -8,6 +8,8 @@ import {
   getSessionDetail as localGetSessionDetail,
   deleteSession as localDeleteSession,
   renameSession as localRenameSession,
+  resolveSessionId as localResolveSessionId,
+  listSessionIdAliases as localListSessionIdAliases,
   useLocalSessionStore,
 } from '../../db/hermes/session-store'
 import { deleteUsage, getUsage, getUsageBatch, getLocalUsageStats } from '../../db/hermes/usage-store'
@@ -85,7 +87,9 @@ export async function getConversationMessages(ctx: any) {
   const humanOnly = (ctx.query.humanOnly as string) !== 'false' && ctx.query.humanOnly !== '0'
 
   if (useLocalSessionStore()) {
-    const detail = localGetSessionDetail(ctx.params.id)
+    const profile = getActiveProfileName()
+    const resolvedId = localResolveSessionId(ctx.params.id, profile)
+    const detail = localGetSessionDetail(resolvedId, profile)
     if (!detail) {
       ctx.status = 404
       ctx.body = { error: 'Conversation not found' }
@@ -105,7 +109,8 @@ export async function getConversationMessages(ctx: any) {
         timestamp: m.timestamp,
       }))
     ctx.body = {
-      session_id: ctx.params.id,
+      session_id: resolvedId,
+      requested_session_id: ctx.params.id,
       messages,
       visible_count: messages.length,
       thread_session_count: 1,
@@ -180,6 +185,15 @@ export async function listHermesSessions(ctx: any) {
   ctx.body = { sessions: filterPendingDeletedSessions(sessions.filter(s => s.source !== 'api_server')) }
 }
 
+export async function listSessionAliases(ctx: any) {
+  if (!useLocalSessionStore()) {
+    ctx.body = { aliases: {} }
+    return
+  }
+  const profile = getActiveProfileName()
+  ctx.body = { aliases: localListSessionIdAliases(profile) }
+}
+
 export async function search(ctx: any) {
   if (useLocalSessionStore()) {
     const q = typeof ctx.query.q === 'string' ? ctx.query.q : ''
@@ -208,13 +222,15 @@ export async function search(ctx: any) {
 
 export async function get(ctx: any) {
   if (useLocalSessionStore()) {
-    const session = localGetSessionDetail(ctx.params.id)
+    const profile = getActiveProfileName()
+    const resolvedId = localResolveSessionId(ctx.params.id, profile)
+    const session = localGetSessionDetail(resolvedId, profile)
     if (!session) {
       ctx.status = 404
       ctx.body = { error: 'Session not found' }
       return
     }
-    ctx.body = { session }
+    ctx.body = { session: { ...session, requested_id: ctx.params.id } }
     return
   }
 
@@ -250,7 +266,8 @@ export async function getHermesSession(ctx: any) {
 
 export async function remove(ctx: any) {
   if (useLocalSessionStore()) {
-    const sessionId = ctx.params.id
+    const profile = getActiveProfileName()
+    const sessionId = localResolveSessionId(ctx.params.id, profile)
     const ok = localDeleteSession(sessionId)
     if (!ok) {
       ctx.status = 500
@@ -284,7 +301,10 @@ export async function usageBatch(ctx: any) {
 }
 
 export async function usageSingle(ctx: any) {
-  const result = getUsage(ctx.params.id)
+  const id = useLocalSessionStore()
+    ? localResolveSessionId(ctx.params.id, getActiveProfileName())
+    : ctx.params.id
+  const result = getUsage(id)
   if (!result) {
     ctx.body = { input_tokens: 0, output_tokens: 0 }
     return
@@ -300,7 +320,8 @@ export async function rename(ctx: any) {
       ctx.body = { error: 'title is required' }
       return
     }
-    const ok = localRenameSession(ctx.params.id, title.trim())
+    const profile = getActiveProfileName()
+    const ok = localRenameSession(localResolveSessionId(ctx.params.id, profile), title.trim())
     if (!ok) {
       ctx.status = 500
       ctx.body = { error: 'Failed to rename session' }
@@ -334,11 +355,11 @@ export async function setWorkspace(ctx: any) {
   }
   if (useLocalSessionStore()) {
     const { updateSession, getSession, createSession } = await import('../../db/hermes/session-store')
-    const { getActiveProfileName } = await import('../../services/hermes/hermes-profile')
-    const id = ctx.params.id
+    const profile = getActiveProfileName()
+    const id = localResolveSessionId(ctx.params.id, profile)
     // Create session if it doesn't exist yet (user may set workspace before sending first message)
     if (!getSession(id)) {
-      createSession({ id, profile: getActiveProfileName(), title: '' })
+      createSession({ id, profile, title: '' })
     }
     updateSession(id, { workspace: workspace || null } as any)
     ctx.body = { ok: true }
@@ -487,7 +508,8 @@ export async function getConversationMessagesPaginated(ctx: any) {
 
   if (useLocalSessionStore()) {
     const { getSessionDetailPaginated } = await import('../../db/hermes/session-store')
-    const result = getSessionDetailPaginated(ctx.params.id, offset, limit)
+    const profile = getActiveProfileName()
+    const result = getSessionDetailPaginated(ctx.params.id, offset, limit, profile)
 
     if (!result) {
       ctx.status = 404

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -75,6 +75,16 @@ export const MESSAGES_SCHEMA: Record<string, string> = {
 
 export const MESSAGES_INDEX = 'CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id)'
 
+export const SESSION_ID_ALIASES_TABLE = 'session_id_aliases'
+
+export const SESSION_ID_ALIASES_SCHEMA: Record<string, string> = {
+  alias_id: 'TEXT NOT NULL',
+  profile: 'TEXT NOT NULL DEFAULT \'default\'',
+  session_id: 'TEXT NOT NULL',
+  reason: 'TEXT NOT NULL DEFAULT \'\'',
+  created_at: 'INTEGER NOT NULL',
+}
+
 // ============================================================================
 // Compression Snapshot (compression-snapshot.ts)
 // ============================================================================
@@ -463,6 +473,12 @@ export function initAllHermesTables(retryCount = 0): void {
     syncTable(SESSIONS_TABLE, SESSIONS_SCHEMA)
     syncTable(MESSAGES_TABLE, MESSAGES_SCHEMA)
     db.exec(MESSAGES_INDEX)
+    syncTable(SESSION_ID_ALIASES_TABLE, SESSION_ID_ALIASES_SCHEMA, {
+      primaryKey: 'alias_id, profile',
+      indexes: {
+        idx_session_id_aliases_session_profile: 'CREATE INDEX idx_session_id_aliases_session_profile ON session_id_aliases(session_id, profile)',
+      },
+    })
 
     // Compression snapshot
     syncTable(COMPRESSION_SNAPSHOT_TABLE, COMPRESSION_SNAPSHOT_SCHEMA)

--- a/packages/server/src/db/hermes/session-store.ts
+++ b/packages/server/src/db/hermes/session-store.ts
@@ -3,7 +3,15 @@
  * Uses the same ensureTable/getDb pattern as usage-store.ts.
  */
 import { isSqliteAvailable, getDb } from '../index'
-import { SESSIONS_TABLE, MESSAGES_TABLE } from './schemas'
+import {
+  COMPRESSION_SNAPSHOT_TABLE,
+  GC_PENDING_SESSION_DELETES_TABLE,
+  GC_SESSION_PROFILES_TABLE,
+  MESSAGES_TABLE,
+  SESSION_ID_ALIASES_TABLE,
+  SESSIONS_TABLE,
+  USAGE_TABLE,
+} from './schemas'
 
 // Re-export types for compatibility with sessions-db.ts consumers
 export interface HermesSessionRow {
@@ -57,6 +65,14 @@ export interface HermesSessionSearchRow extends HermesSessionRow {
 export interface HermesSessionDetailRow extends HermesSessionRow {
   messages: HermesMessageRow[]
   thread_session_count: number
+}
+
+export interface SessionIdAliasRow {
+  alias_id: string
+  profile: string
+  session_id: string
+  reason: string
+  created_at: number
 }
 
 // Note: Table schemas and initialization are now centralized in schemas.ts
@@ -155,13 +171,179 @@ export function createSession(data: {
   return getSession(data.id)!
 }
 
-export function getSession(id: string): HermesSessionRow | null {
+export function getSession(id: string, profile?: string): HermesSessionRow | null {
   if (!isSqliteAvailable()) return null
   const db = getDb()!
-  const row = db.prepare(
-    `SELECT * FROM ${SESSIONS_TABLE} WHERE id = ?`,
-  ).get(id) as Record<string, unknown> | undefined
+  const row = profile
+    ? db.prepare(`SELECT * FROM ${SESSIONS_TABLE} WHERE id = ? AND profile = ?`).get(id, profile) as Record<string, unknown> | undefined
+    : db.prepare(`SELECT * FROM ${SESSIONS_TABLE} WHERE id = ?`).get(id) as Record<string, unknown> | undefined
   return row ? mapSessionRow(row) : null
+}
+
+export function resolveSessionId(id: string, profile?: string): string {
+  if (!isSqliteAvailable()) return id
+  const db = getDb()!
+  const alias = profile
+    ? db.prepare(
+      `SELECT a.session_id
+       FROM ${SESSION_ID_ALIASES_TABLE} a
+       INNER JOIN ${SESSIONS_TABLE} s ON s.id = a.session_id AND s.profile = a.profile
+       WHERE a.alias_id = ? AND a.profile = ?`,
+    ).get(id, profile) as { session_id: string } | undefined
+    : db.prepare(
+      `SELECT a.session_id
+       FROM ${SESSION_ID_ALIASES_TABLE} a
+       INNER JOIN ${SESSIONS_TABLE} s ON s.id = a.session_id AND s.profile = a.profile
+       WHERE a.alias_id = ?
+       ORDER BY a.created_at DESC LIMIT 1`,
+    ).get(id) as { session_id: string } | undefined
+  if (alias?.session_id) return alias.session_id
+
+  const session = profile
+    ? db.prepare(`SELECT id FROM ${SESSIONS_TABLE} WHERE id = ? AND profile = ?`).get(id, profile) as { id: string } | undefined
+    : db.prepare(`SELECT id FROM ${SESSIONS_TABLE} WHERE id = ?`).get(id) as { id: string } | undefined
+  return session?.id || id
+}
+
+function upsertSessionAlias(
+  db: NonNullable<ReturnType<typeof getDb>>,
+  aliasId: string,
+  sessionId: string,
+  profile: string,
+  reason: string,
+): boolean {
+  if (!aliasId || !sessionId || aliasId === sessionId) return false
+  db.prepare(
+    `INSERT INTO ${SESSION_ID_ALIASES_TABLE} (alias_id, profile, session_id, reason, created_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(alias_id, profile) DO UPDATE SET
+       session_id = excluded.session_id,
+       reason = excluded.reason,
+       created_at = excluded.created_at`,
+  ).run(aliasId, profile, sessionId, reason, Math.floor(Date.now() / 1000))
+  return true
+}
+
+export function createSessionAlias(aliasId: string, sessionId: string, profile = 'default', reason = ''): boolean {
+  if (!isSqliteAvailable()) return false
+  return upsertSessionAlias(getDb()!, aliasId, sessionId, profile, reason)
+}
+
+export function listSessionIdAliases(profile: string): Record<string, string> {
+  if (!isSqliteAvailable()) return {}
+  const db = getDb()!
+  const rows = db.prepare(
+    `SELECT a.alias_id, a.session_id
+     FROM ${SESSION_ID_ALIASES_TABLE} a
+     INNER JOIN ${SESSIONS_TABLE} s ON s.id = a.session_id AND s.profile = a.profile
+     WHERE a.profile = ?`,
+  ).all(profile) as Array<{ alias_id: string; session_id: string }>
+  const aliases: Record<string, string> = {}
+  for (const row of rows) {
+    if (row.alias_id && row.session_id && row.alias_id !== row.session_id) {
+      aliases[row.alias_id] = row.session_id
+    }
+  }
+  return aliases
+}
+
+type MessageFingerprintInput = Array<{ role?: string | null; content?: string | null; timestamp?: number | null }>
+
+function normalizeMessageForFingerprint(message?: { role?: string | null; content?: string | null; timestamp?: number | null }): string {
+  if (!message) return ''
+  return JSON.stringify({
+    role: message.role || '',
+    content: message.content || '',
+    timestamp: Number(message.timestamp || 0),
+  })
+}
+
+function localMessageFingerprint(db: NonNullable<ReturnType<typeof getDb>>, sessionId: string): string {
+  const first = db.prepare(
+    `SELECT role, content, timestamp FROM ${MESSAGES_TABLE} WHERE session_id = ? ORDER BY timestamp ASC, id ASC LIMIT 1`,
+  ).get(sessionId) as { role: string | null; content: string | null; timestamp: number | null } | undefined
+  const last = db.prepare(
+    `SELECT role, content, timestamp FROM ${MESSAGES_TABLE} WHERE session_id = ? ORDER BY timestamp DESC, id DESC LIMIT 1`,
+  ).get(sessionId) as { role: string | null; content: string | null; timestamp: number | null } | undefined
+  return `${normalizeMessageForFingerprint(first)}|${normalizeMessageForFingerprint(last)}`
+}
+
+function sourceMessageFingerprint(messages?: MessageFingerprintInput): string | null {
+  if (!messages || messages.length === 0) return null
+  return `${normalizeMessageForFingerprint(messages[0])}|${normalizeMessageForFingerprint(messages[messages.length - 1])}`
+}
+
+export function findHermesImportedSessionCandidate(
+  profile: string,
+  hermesSession: { id: string; source?: string; title?: string | null; started_at?: number | null },
+  messageCount: number,
+  messages?: MessageFingerprintInput,
+): { id: string } | null {
+  if (!isSqliteAvailable()) return null
+  const db = getDb()!
+  const title = hermesSession.title || ''
+  const startedAt = Number(hermesSession.started_at || 0)
+  const rows = db.prepare(
+    `SELECT s.id, COUNT(m.id) AS actual_message_count
+     FROM ${SESSIONS_TABLE} s
+     LEFT JOIN ${MESSAGES_TABLE} m ON m.session_id = s.id
+     WHERE s.profile = ?
+       AND s.source = ?
+       AND s.id <> ?
+       AND COALESCE(s.title, '') = ?
+       AND ABS(s.started_at - ?) <= 1
+     GROUP BY s.id
+     HAVING actual_message_count = ?
+     LIMIT 2`,
+  ).all(profile, hermesSession.source || 'api_server', hermesSession.id, title, startedAt, messageCount) as Array<{ id: string }>
+  if (rows.length !== 1) return null
+
+  const sourceFingerprint = sourceMessageFingerprint(messages)
+  if (sourceFingerprint && localMessageFingerprint(db, rows[0]!.id) !== sourceFingerprint) {
+    return null
+  }
+
+  return { id: rows[0]!.id }
+}
+
+export function rekeySession(oldId: string, newId: string, profile = 'default', reason = 'session-rekey'): boolean {
+  if (!isSqliteAvailable() || oldId === newId) return false
+  const db = getDb()!
+  db.exec('BEGIN')
+  try {
+    const source = db.prepare(`SELECT id FROM ${SESSIONS_TABLE} WHERE id = ? AND profile = ?`).get(oldId, profile) as { id: string } | undefined
+    if (!source) {
+      db.exec('ROLLBACK')
+      return false
+    }
+    const target = db.prepare(`SELECT id FROM ${SESSIONS_TABLE} WHERE id = ? AND profile = ?`).get(newId, profile) as { id: string } | undefined
+    if (target) {
+      upsertSessionAlias(db, oldId, newId, profile, reason)
+      db.exec('COMMIT')
+      return false
+    }
+
+    db.prepare(`UPDATE ${SESSIONS_TABLE} SET id = ? WHERE id = ? AND profile = ?`).run(newId, oldId, profile)
+    db.prepare(`UPDATE ${MESSAGES_TABLE} SET session_id = ? WHERE session_id = ?`).run(newId, oldId)
+    for (const table of [COMPRESSION_SNAPSHOT_TABLE, GC_PENDING_SESSION_DELETES_TABLE, GC_SESSION_PROFILES_TABLE]) {
+      try {
+        db.prepare(`UPDATE ${table} SET session_id = ? WHERE session_id = ?`).run(newId, oldId)
+      } catch {
+        // Optional tables may not exist in older or partially initialized databases.
+      }
+    }
+    try {
+      db.prepare(`UPDATE ${USAGE_TABLE} SET session_id = ? WHERE session_id = ? AND profile = ?`).run(newId, oldId, profile)
+    } catch {
+      // Usage table may not exist in older or partially initialized databases.
+    }
+    upsertSessionAlias(db, oldId, newId, profile, reason)
+    db.exec('COMMIT')
+    return true
+  } catch (err) {
+    try { db.exec('ROLLBACK') } catch {}
+    throw err
+  }
 }
 
 export function updateSession(id: string, data: Partial<Omit<HermesSessionRow, 'id' | 'profile'>>): void {
@@ -197,6 +379,7 @@ export function deleteSession(id: string): boolean {
   if (!isSqliteAvailable()) return false
   const db = getDb()!
   db.prepare(`DELETE FROM ${MESSAGES_TABLE} WHERE session_id = ?`).run(id)
+  db.prepare(`DELETE FROM ${SESSION_ID_ALIASES_TABLE} WHERE session_id = ? OR alias_id = ?`).run(id, id)
   const result = db.prepare(`DELETE FROM ${SESSIONS_TABLE} WHERE id = ?`).run(id)
   return result.changes > 0
 }
@@ -312,14 +495,17 @@ export interface PaginatedSessionDetailResult {
   hasMore: boolean
 }
 
-export function getSessionDetail(id: string): HermesSessionDetailRow | null {
+export function getSessionDetail(id: string, profile?: string): HermesSessionDetailRow | null {
   if (!isSqliteAvailable()) return null
   const db = getDb()!
-  const sessionRow = db.prepare(`SELECT * FROM ${SESSIONS_TABLE} WHERE id = ?`).get(id) as Record<string, unknown> | undefined
+  const resolvedId = resolveSessionId(id, profile)
+  const sessionRow = profile
+    ? db.prepare(`SELECT * FROM ${SESSIONS_TABLE} WHERE id = ? AND profile = ?`).get(resolvedId, profile) as Record<string, unknown> | undefined
+    : db.prepare(`SELECT * FROM ${SESSIONS_TABLE} WHERE id = ?`).get(resolvedId) as Record<string, unknown> | undefined
   if (!sessionRow) return null
   const msgRows = db.prepare(
     `SELECT * FROM ${MESSAGES_TABLE} WHERE session_id = ? ORDER BY timestamp, id`,
-  ).all(id) as Record<string, unknown>[]
+  ).all(resolvedId) as Record<string, unknown>[]
   const session = mapSessionRow(sessionRow)
   return {
     ...session,
@@ -428,27 +614,31 @@ export function getSessionDetailPaginated(
   id: string,
   offset = 0,
   limit = 500,
+  profile?: string,
 ): PaginatedSessionDetailResult | null {
   if (!isSqliteAvailable()) {
     return null
   }
 
   const db = getDb()!
+  const resolvedId = resolveSessionId(id, profile)
 
   // Get session info
-  const sessionRow = db.prepare(`SELECT * FROM ${SESSIONS_TABLE} WHERE id = ?`).get(id) as Record<string, unknown> | undefined
+  const sessionRow = profile
+    ? db.prepare(`SELECT * FROM ${SESSIONS_TABLE} WHERE id = ? AND profile = ?`).get(resolvedId, profile) as Record<string, unknown> | undefined
+    : db.prepare(`SELECT * FROM ${SESSIONS_TABLE} WHERE id = ?`).get(resolvedId) as Record<string, unknown> | undefined
   if (!sessionRow) return null
 
   // Get total message count
   const countResult = db.prepare(
     `SELECT COUNT(*) as total FROM ${MESSAGES_TABLE} WHERE session_id = ?`,
-  ).get(id) as { total: number } | undefined
+  ).get(resolvedId) as { total: number } | undefined
   const total = countResult?.total || 0
 
   // Get paginated messages (newest first from DB, then reverse)
   const msgRows = db.prepare(
     `SELECT * FROM ${MESSAGES_TABLE} WHERE session_id = ? ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?`,
-  ).all(id, limit, offset) as Record<string, unknown>[]
+  ).all(resolvedId, limit, offset) as Record<string, unknown>[]
 
   const session = mapSessionRow(sessionRow)
   const messages = msgRows.map(mapMessageRow).reverse()  // Reverse to show oldest first

--- a/packages/server/src/routes/hermes/sessions.ts
+++ b/packages/server/src/routes/hermes/sessions.ts
@@ -9,6 +9,7 @@ sessionRoutes.get('/api/hermes/sessions/conversations/:id/messages/paginated', c
 sessionRoutes.get('/api/hermes/sessions', ctrl.list)
 sessionRoutes.get('/api/hermes/sessions/hermes', ctrl.listHermesSessions)
 sessionRoutes.get('/api/hermes/sessions/hermes/:id', ctrl.getHermesSession)
+sessionRoutes.get('/api/hermes/sessions/aliases', ctrl.listSessionAliases)
 sessionRoutes.get('/api/hermes/search/sessions', ctrl.search)
 sessionRoutes.get('/api/hermes/sessions/search', ctrl.search)
 sessionRoutes.get('/api/hermes/sessions/usage', ctrl.usageBatch)

--- a/packages/server/src/services/hermes/chat-run-socket.ts
+++ b/packages/server/src/services/hermes/chat-run-socket.ts
@@ -20,6 +20,7 @@ import {
   addMessage,
   updateSessionStats,
   useLocalSessionStore,
+  resolveSessionId,
 } from '../../db/hermes/session-store'
 import { getDb } from '../../db/index'
 import { getSessionDetailFromDb } from '../../db/hermes/sessions-db'
@@ -203,15 +204,17 @@ export class ChatRunSocket {
 
     socket.on('resume', async (data: { session_id?: string }) => {
       if (!data.session_id) return
-      const sid = data.session_id
-      const room = `session:${sid}`
-      socket.join(room)
-      this.resumeSession(socket, sid)
+      const requestedSid = data.session_id
+      const sid = useLocalSessionStore() ? resolveSessionId(requestedSid, profile) : requestedSid
+      socket.join(`session:${requestedSid}`)
+      if (sid !== requestedSid) socket.join(`session:${sid}`)
+      this.resumeSession(socket, sid, profile)
     })
 
     socket.on('abort', (data: { session_id?: string }) => {
       if (data.session_id) {
-        this.handleAbort(socket, data.session_id)
+        const sid = useLocalSessionStore() ? resolveSessionId(data.session_id, profile) : data.session_id
+        this.handleAbort(socket, sid)
       }
     })
   }
@@ -361,17 +364,18 @@ export class ChatRunSocket {
     }
     return _messages
   }
-  private async resumeSession(socket: Socket, sid: string) {
+  private async resumeSession(socket: Socket, sid: string, profile = 'default') {
     let state = this.sessionMap.get(sid)
     if (!state) {
       try {
         const detail = useLocalSessionStore()
-          ? getSessionDetailPaginated(sid)
+          ? getSessionDetailPaginated(sid, 0, 500, profile)
           : await getSessionDetailFromDb(sid)
-        const messages = detail?.messages ? this.handleMessage(detail.messages, sid) : []
+        const canonicalSid = detail && 'session' in detail ? detail.session.id : detail?.id || sid
+        const messages = detail?.messages ? this.handleMessage(detail.messages, canonicalSid) : []
         // Calculate context tokens — aware of compression snapshot
         let inputTokens: number
-        const snapshot = getCompressionSnapshot(sid)
+        const snapshot = getCompressionSnapshot(canonicalSid)
         if (snapshot) {
           const newMessages = messages.slice(snapshot.lastMessageIndex + 1)
           inputTokens = countTokens(SUMMARY_PREFIX + snapshot.summary) +
@@ -388,6 +392,7 @@ export class ChatRunSocket {
           events: [],
           inputTokens,
           outputTokens,
+          profile,
         }
         this.sessionMap.set(sid, state)
         logger.info('[chat-run-socket] loaded session %s from DB (%d messages)', sid, messages.length)
@@ -416,7 +421,10 @@ export class ChatRunSocket {
     data: { input: string; session_id?: string; model?: string; instructions?: string },
     profile: string,
   ) {
-    const { input, session_id, model, instructions } = data
+    const { input, session_id: requestedSessionId, model, instructions } = data
+    const session_id = requestedSessionId && useLocalSessionStore()
+      ? resolveSessionId(requestedSessionId, profile)
+      : requestedSessionId
     const upstream = this.gatewayManager.getUpstream(profile).replace(/\/$/, '')
     const apiKey = this.gatewayManager.getApiKey(profile) || undefined
 
@@ -442,7 +450,7 @@ export class ChatRunSocket {
       })
 
       // Create session in local DB if it doesn't exist
-      if (!getSession(session_id)) {
+      if (!getSession(session_id, profile)) {
         const preview = input.replace(/[\r\n]/g, ' ').substring(0, 100)
         createSession({ id: session_id, profile, model, title: preview })
       }
@@ -477,7 +485,7 @@ export class ChatRunSocket {
 
       // Inject workspace context if set for this session
       if (session_id) {
-        const sessionRow = getSession(session_id)
+        const sessionRow = getSession(session_id, profile)
         if (sessionRow?.workspace) {
           const workspaceCtx = `[Current working directory: ${sessionRow.workspace}]`
           body.instructions = body.instructions
@@ -490,7 +498,7 @@ export class ChatRunSocket {
       if (session_id) {
         try {
           const detail = useLocalSessionStore()
-            ? getSessionDetail(session_id)
+            ? getSessionDetail(session_id, profile)
             : await getSessionDetailFromDb(session_id)
           if (detail?.messages?.length) {
             // Filter valid messages
@@ -1077,12 +1085,12 @@ export class ChatRunSocket {
   ): Promise<{ inputTokens: number; outputTokens: number }> {
     try {
       const detail = useLocalSessionStore()
-        ? getSessionDetail(sid)
+        ? getSessionDetail(sid, state.profile || 'default')
         : await getSessionDetailFromDb(sid)
       const msgs = detail?.messages
         ?.filter(m => m.role === 'user' || m.role === 'assistant' || m.role === 'tool') || []
 
-      const snapshot = getCompressionSnapshot(sid)
+      const snapshot = getCompressionSnapshot(detail?.id || sid)
       let inputTokens: number
       if (snapshot && msgs.length) {
         const newMessages = msgs.slice(snapshot.lastMessageIndex + 1)

--- a/packages/server/src/services/hermes/session-sync.ts
+++ b/packages/server/src/services/hermes/session-sync.ts
@@ -1,16 +1,23 @@
 /**
  * Sync Hermes sessions from all profiles on startup.
- * Reads api_server sessions from Hermes state.db and imports into local DB.
- * Only runs when local DB is empty (first startup).
+ * Reads api_server sessions from Hermes state.db and mirrors them into the local DB.
+ * Missing sessions are imported only when the local DB is empty; existing generated-id
+ * imports are repaired on every startup by rekeying them to canonical Hermes ids.
  *
  * Uses sessions-db.ts query logic to properly aggregate session chains.
  */
 import { readdirSync, existsSync } from 'fs'
 import { resolve, join } from 'path'
 import { homedir } from 'os'
-import { randomBytes } from 'crypto'
-import { getProfileDir } from './hermes-profile'
-import { createSession, addMessage, updateSession } from '../../db/hermes/session-store'
+import {
+  addMessages,
+  createSession,
+  findHermesImportedSessionCandidate,
+  getSession,
+  rekeySession,
+  updateSession,
+  updateSessionStats,
+} from '../../db/hermes/session-store'
 import { getDb } from '../../db/index'
 import { logger } from '../logger'
 import { listSessionSummaries as listHermesSessionSummaries } from '../../db/hermes/sessions-db'
@@ -18,20 +25,8 @@ import { listSessionSummaries as listHermesSessionSummaries } from '../../db/her
 const HERMES_BASE = resolve(homedir(), '.hermes')
 const PROFILES_DIR = join(HERMES_BASE, 'profiles')
 
-/**
- * Generate a UUID v4 without external dependencies
- */
-function generateUuid(): string {
-  const bytes = randomBytes(16)
-  bytes[6] = (bytes[6]! & 0x0f) | 0x40 // Version 4
-  bytes[8] = (bytes[8]! & 0x3f) | 0x80 // Variant 10
-  return [
-    bytes.subarray(0, 4).toString('hex'),
-    bytes.subarray(4, 6).toString('hex'),
-    bytes.subarray(6, 8).toString('hex'),
-    bytes.subarray(8, 10).toString('hex'),
-    bytes.subarray(10, 16).toString('hex'),
-  ].join('-')
+interface SyncProfileOptions {
+  importMissing: boolean
 }
 
 /**
@@ -54,7 +49,7 @@ function getAllProfiles(): string[] {
  * Sync api_server sessions from a single profile.
  * Uses sessions-db.ts query logic to properly aggregate session chains.
  */
-async function syncProfileSessions(profile: string): Promise<{
+async function syncProfileSessions(profile: string, options: SyncProfileOptions): Promise<{
   synced: number
   errors: string[]
 }> {
@@ -69,17 +64,6 @@ async function syncProfileSessions(profile: string): Promise<{
 
     for (const hermesSession of summaries) {
       try {
-        // Generate new session ID for local DB
-        const newSessionId = generateUuid()
-
-        // Create session in local DB
-        createSession({
-          id: newSessionId,
-          profile,
-          model: hermesSession.model,
-          title: hermesSession.title || undefined,
-        })
-
         // Get full detail including all messages from the session chain
         const { getSessionDetailFromDbWithProfile } = await import('../../db/hermes/sessions-db')
         const detail = await getSessionDetailFromDbWithProfile(hermesSession.id, profile)
@@ -90,30 +74,12 @@ async function syncProfileSessions(profile: string): Promise<{
           continue
         }
 
-        // Insert all messages from the entire chain
-        for (const msg of detail.messages) {
-          addMessage({
-            session_id: newSessionId,
-            role: msg.role,
-            content: msg.content,
-            tool_call_id: msg.tool_call_id,
-            tool_calls: msg.tool_calls,
-            tool_name: msg.tool_name,
-            timestamp: msg.timestamp,
-            token_count: msg.token_count,
-            finish_reason: msg.finish_reason,
-            reasoning: msg.reasoning,
-            reasoning_details: msg.reasoning_details,
-            reasoning_content: msg.reasoning_content,
-            codex_reasoning_items: msg.codex_reasoning_items,
-          })
-        }
-
-        // Update session with aggregated stats from Hermes
-        updateSession(newSessionId, {
+        const canonicalSessionId = hermesSession.id
+        const sessionStats = {
           started_at: hermesSession.started_at,
           ended_at: hermesSession.ended_at,
           end_reason: hermesSession.end_reason,
+          message_count: detail.messages.length,
           input_tokens: hermesSession.input_tokens,
           output_tokens: hermesSession.output_tokens,
           cache_read_tokens: hermesSession.cache_read_tokens,
@@ -122,10 +88,64 @@ async function syncProfileSessions(profile: string): Promise<{
           estimated_cost_usd: hermesSession.estimated_cost_usd,
           last_active: hermesSession.last_active,
           preview: hermesSession.preview,
+        }
+
+        const existing = getSession(canonicalSessionId, profile)
+        if (existing) {
+          updateSession(canonicalSessionId, sessionStats)
+          updateSessionStats(canonicalSessionId)
+          result.synced++
+          logger.info(`[session-sync] refreshed existing Hermes session ${canonicalSessionId}`)
+          continue
+        }
+
+        const candidate = findHermesImportedSessionCandidate(profile, hermesSession, detail.messages.length, detail.messages)
+        if (candidate) {
+          rekeySession(candidate.id, canonicalSessionId, profile, 'hermes-import-rekey')
+          updateSession(canonicalSessionId, sessionStats)
+          updateSessionStats(canonicalSessionId)
+          result.synced++
+          logger.info(`[session-sync] rekeyed imported Hermes session ${candidate.id} -> ${canonicalSessionId}`)
+          continue
+        }
+
+        if (!options.importMissing) {
+          logger.info(`[session-sync] skipping missing Hermes session ${canonicalSessionId}; local DB is not empty`)
+          continue
+        }
+
+        // Preserve the canonical Hermes session id in the local DB. Browser pins,
+        // CLI links, and API detail routes all use this id as the stable identity.
+        createSession({
+          id: canonicalSessionId,
+          profile,
+          model: hermesSession.model,
+          title: hermesSession.title || undefined,
         })
 
+        // Insert all messages from the entire chain
+        addMessages(detail.messages.map((msg: any) => ({
+          session_id: canonicalSessionId,
+          role: msg.role,
+          content: msg.content,
+          tool_call_id: msg.tool_call_id,
+          tool_calls: msg.tool_calls,
+          tool_name: msg.tool_name,
+          timestamp: msg.timestamp,
+          token_count: msg.token_count,
+          finish_reason: msg.finish_reason,
+          reasoning: msg.reasoning,
+          reasoning_details: msg.reasoning_details,
+          reasoning_content: msg.reasoning_content,
+          codex_reasoning_items: msg.codex_reasoning_items,
+        })))
+
+        // Update session with aggregated stats from Hermes
+        updateSession(canonicalSessionId, sessionStats)
+        updateSessionStats(canonicalSessionId)
+
         result.synced++
-        logger.info(`[session-sync] synced Hermes session ${hermesSession.id} -> ${newSessionId} (${detail.messages.length} messages, thread_session_count=${detail.thread_session_count})`)
+        logger.info(`[session-sync] synced Hermes session ${canonicalSessionId} (${detail.messages.length} messages, thread_session_count=${detail.thread_session_count})`)
       } catch (err: any) {
         result.errors.push(`session ${hermesSession.id}: ${err.message}`)
         logger.warn(err, `[session-sync] failed to sync session ${hermesSession.id}`)
@@ -142,11 +162,13 @@ async function syncProfileSessions(profile: string): Promise<{
 }
 
 /**
- * Main entry point: sync all profiles on startup
- * Only runs if local DB is empty (first startup or after DB reset)
+ * Main entry point: sync all profiles on startup.
+ * Imports missing sessions only when the local DB is empty, but always checks
+ * existing imported Hermes sessions for generated-id repairs.
  */
 export async function syncAllHermesSessionsOnStartup(): Promise<void> {
-  // Check if local DB has any sessions - only sync if completely empty
+  // Import brand-new missing sessions only on an empty local DB. Generated-id
+  // repairs still run below when existing sessions are present.
   const db = getDb()
   if (!db) {
     logger.info('[session-sync] SQLite not available, skipping Hermes sync')
@@ -157,11 +179,10 @@ export async function syncAllHermesSessionsOnStartup(): Promise<void> {
   const hasExistingSessions = countResult && countResult.count > 0
 
   if (hasExistingSessions) {
-    logger.info('[session-sync] local DB has %d sessions, skipping Hermes sync', countResult!.count)
-    return
+    logger.info('[session-sync] local DB has %d sessions; checking for Hermes id repairs without importing new missing sessions', countResult!.count)
+  } else {
+    logger.info('[session-sync] local DB is empty, starting Hermes session sync...')
   }
-
-  logger.info('[session-sync] local DB is empty, starting Hermes session sync...')
 
   const profiles = getAllProfiles()
   logger.info(`[session-sync] found ${profiles.length} profiles: ${profiles.join(', ')}`)
@@ -170,7 +191,7 @@ export async function syncAllHermesSessionsOnStartup(): Promise<void> {
   let totalErrors = 0
 
   for (const profile of profiles) {
-    const result = await syncProfileSessions(profile)
+    const result = await syncProfileSessions(profile, { importMissing: !hasExistingSessions })
     totalSynced += result.synced
     totalErrors += result.errors.length
 

--- a/tests/client/session-browser-prefs.test.ts
+++ b/tests/client/session-browser-prefs.test.ts
@@ -11,7 +11,7 @@ describe('session browser prefs store', () => {
     window.localStorage.clear()
   })
 
-  it('persists pins per profile and prunes missing sessions', () => {
+  it('persists pins per profile and only prunes after confirmed deletion', () => {
     const profilesStore = useProfilesStore()
     profilesStore.activeProfileName = 'default'
 
@@ -23,7 +23,10 @@ describe('session browser prefs store', () => {
     expect(store.pinnedIds).toEqual(['session-1', 'session-2'])
     expect(JSON.parse(window.localStorage.getItem('hermes_session_pins_v1_default') || '[]')).toEqual(['session-1', 'session-2'])
 
-    expect(store.pruneMissingSessions(['session-2'])).toBe(true)
+    expect(store.pruneMissingSessions(['session-2'])).toBe(false)
+    expect(store.pinnedIds).toEqual(['session-1', 'session-2'])
+
+    expect(store.pruneMissingSessions(['session-2'], { confirmedDelete: true })).toBe(true)
     expect(store.pinnedIds).toEqual(['session-2'])
     expect(JSON.parse(window.localStorage.getItem('hermes_session_pins_v1_default') || '[]')).toEqual(['session-2'])
   })
@@ -37,6 +40,24 @@ describe('session browser prefs store', () => {
     expect(store.pruneMissingSessions([])).toBe(false)
     expect(store.pinnedIds).toEqual(['session-1'])
     expect(JSON.parse(window.localStorage.getItem('hermes_session_pins_v1_default') || '[]')).toEqual(['session-1'])
+  })
+
+  it('migrates pinned alias ids to canonical session ids without duplicates', () => {
+    const profilesStore = useProfilesStore()
+    profilesStore.activeProfileName = 'default'
+    const store = useSessionBrowserPrefsStore()
+
+    store.togglePinned('legacy-session-id')
+    store.togglePinned('canonical-session-id')
+    store.togglePinned('unrelated-session-id')
+
+    expect(store.migratePinnedAliases({ 'legacy-session-id': 'canonical-session-id' })).toBe(true)
+    expect(store.pinnedIds).toEqual(['canonical-session-id', 'unrelated-session-id'])
+    expect(JSON.parse(window.localStorage.getItem('hermes_session_pins_v1_default') || '[]')).toEqual(['canonical-session-id', 'unrelated-session-id'])
+
+    setActivePinia(createPinia())
+    const reloadedStore = useSessionBrowserPrefsStore()
+    expect(reloadedStore.pinnedIds).toEqual(['canonical-session-id', 'unrelated-session-id'])
   })
 
   it('reloads pin and human-only preferences automatically when the active profile changes', async () => {

--- a/tests/server/session-sync.test.ts
+++ b/tests/server/session-sync.test.ts
@@ -1,73 +1,174 @@
 /**
  * Tests for session-sync service
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { getDb, ensureTable } from '../../packages/server/src/db/index'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  listSessionSummaries: vi.fn(),
+  getSessionDetailFromDbWithProfile: vi.fn(),
+}))
+
+vi.mock('../../packages/server/src/db/hermes/sessions-db', () => ({
+  listSessionSummaries: mocks.listSessionSummaries,
+  getSessionDetailFromDbWithProfile: mocks.getSessionDetailFromDbWithProfile,
+}))
+
+import { getDb } from '../../packages/server/src/db/index'
+import { initAllStores } from '../../packages/server/src/db/hermes/init'
+import {
+  addMessages,
+  createSession,
+  createSessionAlias,
+  getSession,
+  getSessionDetail,
+  listSessionIdAliases,
+  resolveSessionId,
+} from '../../packages/server/src/db/hermes/session-store'
 import { syncAllHermesSessionsOnStartup } from '../../packages/server/src/services/hermes/session-sync'
+
+const canonicalSummary = {
+  id: 'hermes-canonical-session',
+  source: 'api_server',
+  user_id: null,
+  model: 'gpt-5.5',
+  title: 'Pinned session identity',
+  started_at: 1_710_000_000,
+  ended_at: null,
+  end_reason: null,
+  message_count: 2,
+  tool_call_count: 0,
+  input_tokens: 11,
+  output_tokens: 22,
+  cache_read_tokens: 0,
+  cache_write_tokens: 0,
+  reasoning_tokens: 0,
+  billing_provider: null,
+  estimated_cost_usd: 0.01,
+  actual_cost_usd: null,
+  cost_status: 'estimated',
+  preview: 'first user message',
+  last_active: 1_710_000_010,
+}
+
+const canonicalMessages = [
+  {
+    role: 'user',
+    content: 'first user message',
+    timestamp: 1_710_000_000,
+  },
+  {
+    role: 'assistant',
+    content: 'first assistant answer',
+    timestamp: 1_710_000_001,
+  },
+]
+
+function resetDb() {
+  initAllStores()
+  const db = getDb()
+  if (!db) return
+  db.exec('DELETE FROM session_id_aliases')
+  db.exec('DELETE FROM messages')
+  db.exec('DELETE FROM sessions')
+}
+
+function mockHermesSource(summaries: any[] = [canonicalSummary], messages: any[] = canonicalMessages) {
+  mocks.listSessionSummaries.mockImplementation(async (_source: string, _limit: number, profile: string) => (
+    profile === 'default' ? summaries : []
+  ))
+  mocks.getSessionDetailFromDbWithProfile.mockImplementation(async (id: string, profile: string) => {
+    if (profile !== 'default' || !summaries.some(summary => summary.id === id)) return null
+    return {
+      ...canonicalSummary,
+      id,
+      messages,
+      thread_session_count: 1,
+    }
+  })
+}
 
 describe('session-sync', () => {
   beforeEach(() => {
-    // Reset database before each test
-    const db = getDb()
-    if (db) {
-      db.exec('DELETE FROM sessions')
-      db.exec('DELETE FROM messages')
-    }
+    resetDb()
+    vi.clearAllMocks()
+    mockHermesSource()
   })
 
   afterEach(() => {
-    // Cleanup after each test
-    const db = getDb()
-    if (db) {
-      db.exec('DELETE FROM sessions')
-      db.exec('DELETE FROM messages')
-    }
+    resetDb()
   })
 
-  it('should skip sync when local DB is not empty', () => {
-    const db = getDb()
-    expect(db).not.toBeNull()
+  it('imports missing Hermes sessions using canonical session ids', async () => {
+    await syncAllHermesSessionsOnStartup()
 
-    // Insert a test session
-    db!.prepare(`
-      INSERT INTO sessions (id, profile, source, model, title, started_at, last_active)
-      VALUES ('test-session-1', 'default', 'api_server', 'gpt-4', 'Test Session', ${Date.now()}, ${Date.now()})
-    `).run()
+    const session = getSession(canonicalSummary.id, 'default')
+    expect(session).not.toBeNull()
+    expect(session?.id).toBe(canonicalSummary.id)
+    expect(session?.message_count).toBe(2)
 
-    // Check that session exists
-    const countResult = db!.prepare('SELECT COUNT(*) as count FROM sessions').get() as { count: number }
-    expect(countResult.count).toBe(1)
-
-    // Run sync - should skip because DB is not empty
-    syncAllHermesSessionsOnStartup()
-
-    // Verify session still exists (no changes)
-    const countAfter = db!.prepare('SELECT COUNT(*) as count FROM sessions').get() as { count: number }
-    expect(countAfter.count).toBe(1)
+    const detail = getSessionDetail(canonicalSummary.id, 'default')
+    expect(detail?.messages.map(message => message.session_id)).toEqual([
+      canonicalSummary.id,
+      canonicalSummary.id,
+    ])
+    expect(listSessionIdAliases('default')).toEqual({})
   })
 
-  it('should attempt sync when local DB is empty', () => {
-    const db = getDb()
-    expect(db).not.toBeNull()
+  it('repairs generated UUID imports to canonical Hermes ids when local DB is not empty', async () => {
+    const legacyId = '220c2949-7120-42d8-b557-e6139a78a9d3'
+    createSession({
+      id: legacyId,
+      profile: 'default',
+      model: canonicalSummary.model,
+      title: canonicalSummary.title,
+    })
+    const db = getDb()!
+    db.prepare('UPDATE sessions SET started_at = ?, last_active = ? WHERE id = ?').run(
+      canonicalSummary.started_at,
+      canonicalSummary.last_active,
+      legacyId,
+    )
+    addMessages(canonicalMessages.map(message => ({
+      session_id: legacyId,
+      role: message.role,
+      content: message.content,
+      timestamp: message.timestamp,
+    })))
 
-    // Verify DB is empty
-    const countBefore = db!.prepare('SELECT COUNT(*) as count FROM sessions').get() as { count: number }
-    expect(countBefore.count).toBe(0)
+    await syncAllHermesSessionsOnStartup()
 
-    // Run sync - should attempt to sync from Hermes
-    syncAllHermesSessionsOnStartup()
+    expect(getSession(legacyId, 'default')).toBeNull()
+    expect(getSession(canonicalSummary.id, 'default')?.id).toBe(canonicalSummary.id)
+    expect(resolveSessionId(legacyId, 'default')).toBe(canonicalSummary.id)
+    expect(listSessionIdAliases('default')).toEqual({
+      [legacyId]: canonicalSummary.id,
+    })
 
-    // Note: Whether sessions are actually imported depends on whether
-    // Hermes state.db exists and has api_server sessions
-    // This test mainly verifies the function doesn't crash when DB is empty
-    expect(true).toBe(true)
+    const detailFromAlias = getSessionDetail(legacyId, 'default')
+    expect(detailFromAlias?.id).toBe(canonicalSummary.id)
+    expect(detailFromAlias?.messages.map(message => message.session_id)).toEqual([
+      canonicalSummary.id,
+      canonicalSummary.id,
+    ])
   })
 
-  it('should handle case when SQLite is not available', () => {
-    // This test verifies the function handles the case when getDb() returns null
-    // Since we can't easily mock getDb(), we just verify it doesn't crash
-    expect(() => {
-      syncAllHermesSessionsOnStartup()
-    }).not.toThrow()
+  it('resolves live aliases before same-id local rows can shadow canonical sessions', () => {
+    const legacyId = 'legacy-shadow-id'
+    createSession({ id: canonicalSummary.id, profile: 'default', model: canonicalSummary.model, title: canonicalSummary.title })
+    createSession({ id: legacyId, profile: 'default', model: canonicalSummary.model, title: 'stale duplicate' })
+    createSessionAlias(legacyId, canonicalSummary.id, 'default', 'test-shadow')
+
+    expect(resolveSessionId(legacyId, 'default')).toBe(canonicalSummary.id)
+    expect(getSessionDetail(legacyId, 'default')?.id).toBe(canonicalSummary.id)
+  })
+
+  it('handles empty Hermes source without crashing', async () => {
+    mockHermesSource([])
+
+    await expect(syncAllHermesSessionsOnStartup()).resolves.toBeUndefined()
+
+    const db = getDb()!
+    const countAfter = db.prepare('SELECT COUNT(*) as count FROM sessions').get() as { count: number }
+    expect(countAfter.count).toBe(0)
   })
 })

--- a/tests/server/sessions-routes.test.ts
+++ b/tests/server/sessions-routes.test.ts
@@ -6,6 +6,7 @@ const getConversationMessagesPaginatedMock = vi.fn(async (ctx: any) => { ctx.bod
 const listMock = vi.fn(async (ctx: any) => { ctx.body = { sessions: [{ id: 's1' }] } })
 const listHermesSessionsMock = vi.fn(async (ctx: any) => { ctx.body = { sessions: [{ id: 'hermes-1' }] } })
 const getHermesSessionMock = vi.fn(async (ctx: any) => { ctx.body = { session: { id: ctx.params.id } } })
+const listSessionAliasesMock = vi.fn(async (ctx: any) => { ctx.body = { aliases: {} } })
 const searchMock = vi.fn(async (ctx: any) => { ctx.body = { results: [{ id: 'search-1' }] } })
 const getMock = vi.fn(async (ctx: any) => { ctx.body = { session: { id: ctx.params.id } } })
 const removeMock = vi.fn(async (ctx: any) => { ctx.body = { ok: true } })
@@ -24,6 +25,7 @@ vi.mock('../../packages/server/src/controllers/hermes/sessions', () => ({
   list: listMock,
   listHermesSessions: listHermesSessionsMock,
   getHermesSession: getHermesSessionMock,
+  listSessionAliases: listSessionAliasesMock,
   search: searchMock,
   get: getMock,
   remove: removeMock,
@@ -43,6 +45,7 @@ describe('session routes', () => {
     getConversationMessagesMock.mockClear()
     getConversationMessagesPaginatedMock.mockClear()
     listMock.mockClear()
+    listSessionAliasesMock.mockClear()
     searchMock.mockClear()
     getMock.mockClear()
     removeMock.mockClear()
@@ -58,6 +61,7 @@ describe('session routes', () => {
       '/api/hermes/sessions/conversations/:id/messages',
       '/api/hermes/sessions/conversations/:id/messages/paginated',
       '/api/hermes/sessions',
+      '/api/hermes/sessions/aliases',
       '/api/hermes/search/sessions',
       '/api/hermes/sessions/search',
       '/api/hermes/sessions/usage',


### PR DESCRIPTION
## 概要
- 导入 Hermes 会话时保留 canonical session ID，不再为 `api_server` 会话生成本地 UUID
- 新增 `session_id_aliases`，让旧的本地 UUID 继续解析到 canonical Hermes session ID
- 客户端通过 alias map 迁移已固定/当前会话 ID，避免固定会话指向错误条目
- 会话详情、消息路由、socket resume/write 路径改为 alias-aware、profile-aware
- 避免用临时/局部/空的会话列表误删 fixed pins

## 根因
Web UI 在同步 Hermes `api_server` 会话到本地 DB 时使用了新生成的 UUID，而不是 Hermes canonical session ID。

固定会话保存在浏览器 localStorage，值是 session ID。因此升级/同步后，固定列表可能指向错误或不存在的本地行；同时 Web UI 显示的 ID 也无法和 CLI / Hermes `state.db` 的 canonical ID 对齐。

## 修复
- 新导入会话直接使用 Hermes canonical ID
- 启动同步时识别旧的 generated-UUID 导入记录，并 rekey 到 canonical ID
- 为旧 UUID 留下 alias，保持兼容
- 详情/消息/API/socket 写入路径先解析 alias，再读写本地会话
- 客户端拉取 alias map 后迁移 pinned/active session ID
- pin pruning 只在确认删除时执行，避免 transient session list 清空用户固定项

## 相关上下文
Fixes #392

没有找到完全相同的“固定会话 canonical/local ID 漂移”报告。已检查相邻的 session/sync 相关工作：#118、#354、#373、#322、#285。

## 验证
- `git diff --cached --check`
- `npm test -- --run tests/client/session-browser-prefs.test.ts tests/server/session-sync.test.ts tests/server/sessions-routes.test.ts`
- `npm test -- --run`
- `npm run build`

另外，alias-aware socket 写入路径修复后，已做独立 staged diff review；未发现剩余 blocking correctness/security 问题。
