### PR TITLE
fix: add missing i18n key and unify session data source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - base
 
 jobs:
   build:

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -130,6 +130,7 @@ export default {
     renamed: 'Umbenannt',
     renameFailed: 'Umbenennung fehlgeschlagen',
     renameSession: 'Sitzung umbenennen',
+    sessionNotFound: 'Sitzung nicht gefunden',
     enterNewTitle: 'Neuen Titel eingeben',
     other: 'Sonstige',
     runFailed: 'Ausfuhrung fehlgeschlagen',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -153,6 +153,7 @@ export default {
     renamed: 'Renamed',
     renameFailed: 'Rename failed',
     renameSession: 'Rename Session',
+    sessionNotFound: 'Session not found',
     enterNewTitle: 'Enter new title',
     workspace: 'Workspace',
     setWorkspace: 'Set Workspace',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -130,6 +130,7 @@ export default {
     renamed: 'Renombrada',
     renameFailed: 'Error al renombrar',
     renameSession: 'Renombrar sesion',
+    sessionNotFound: 'Sesion no encontrada',
     enterNewTitle: 'Introduce un nuevo titulo',
     other: 'Otro',
     runFailed: 'Error en la ejecucion',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -130,6 +130,7 @@ export default {
     renamed: 'Renomme',
     renameFailed: 'Echec du renommage',
     renameSession: 'Renommer la session',
+    sessionNotFound: 'Session non trouvee',
     enterNewTitle: 'Entrez un nouveau titre',
     other: 'Autre',
     runFailed: 'Echec de l\'execution',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -130,6 +130,7 @@ export default {
     renamed: '名前を変更しました',
     renameFailed: '名前の変更に失敗しました',
     renameSession: 'セッション名の変更',
+    sessionNotFound: 'セッションが見つかりません',
     enterNewTitle: '新しいタイトルを入力',
     other: 'その他',
     runFailed: '実行に失敗しました',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -130,6 +130,7 @@ export default {
     renamed: '이름이 변경되었습니다',
     renameFailed: '이름 변경 실패',
     renameSession: '세션 이름 변경',
+    sessionNotFound: '세션을 찾을 수 없습니다',
     enterNewTitle: '새 제목을 입력하세요',
     other: '기타',
     runFailed: '실행 실패',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -130,6 +130,7 @@ export default {
     renamed: 'Renomeado',
     renameFailed: 'Falha ao renomear',
     renameSession: 'Renomear sessao',
+    sessionNotFound: 'Sessao nao encontrada',
     enterNewTitle: 'Digite um novo titulo',
     other: 'Outro',
     runFailed: 'Falha na execucao',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -153,6 +153,7 @@ export default {
     renamed: '已重命名',
     renameFailed: '重命名失败',
     renameSession: '重命名会话',
+    sessionNotFound: '会话未找到',
     enterNewTitle: '输入新标题',
     workspace: '工作区',
     setWorkspace: '设置工作区',

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -1,7 +1,7 @@
 import * as hermesCli from '../../services/hermes/hermes-cli'
 import { listConversationSummaries, getConversationDetail } from '../../services/hermes/conversations'
 import { listConversationSummariesFromDb, getConversationDetailFromDb } from '../../db/hermes/conversations-db'
-import { listSessionSummaries, searchSessionSummaries, getUsageStatsFromDb } from '../../db/hermes/sessions-db'
+import { listSessionSummaries, searchSessionSummaries, getUsageStatsFromDb, getSessionDetailFromDb } from '../../db/hermes/sessions-db'
 import {
   listSessions as localListSessions,
   searchSessions as localSearchSessions,
@@ -232,7 +232,18 @@ export async function get(ctx: any) {
  * GET /api/hermes/sessions/hermes/:id
  */
 export async function getHermesSession(ctx: any) {
+  // Try database first (consistent with listHermesSessions)
+  try {
+    const session = await getSessionDetailFromDb(ctx.params.id)
+    if (session && session.source !== 'api_server' && session.source !== 'cron') {
+      ctx.body = { session }
+      return
+    }
+  } catch (err) {
+    logger.warn(err, 'Hermes Session DB: detail query failed, falling back to CLI')
+  }
 
+  // Fallback to CLI
   const session = await hermesCli.getSession(ctx.params.id)
   if (!session) {
     ctx.status = 404

--- a/packages/server/src/db/hermes/sessions-db.ts
+++ b/packages/server/src/db/hermes/sessions-db.ts
@@ -573,7 +573,6 @@ async function openSessionDb() {
   }
   const { DatabaseSync } = await import('node:sqlite')
   const dbPath = sessionDbPath()
-  console.log(`[sessions-db] Opening session db: ${dbPath}`)
   try {
     return new DatabaseSync(dbPath, { open: true, readOnly: true })
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- Add `chat.sessionNotFound` translation key to all 8 locales
- Fix history page data source inconsistency where sessions appear in list but detail returns 404
- Update `getHermesSession` to prioritize database over CLI (consistent with `listHermesSessions`)
- Update CI workflow to trigger on base branch PRs
- Remove debug log from sessions-db

## Test plan
- [ ] Verified `chat.sessionNotFound` key works in all 8 languages
- [ ] Tested history page loads session details correctly
- [ ] Confirmed list and detail APIs use same data source priority
- [ ] CI workflow triggers on base branch PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)