### PR TITLE
fix: filter special characters and emoji in speech playback

### DIFF
--- a/packages/client/src/composables/useSpeech.ts
+++ b/packages/client/src/composables/useSpeech.ts
@@ -59,6 +59,11 @@ export function useSpeech() {
     // 移除 HTML 标签
     text = text.replace(/<[^>]+>/g, '')
 
+    // 只保留：字母、数字、空格、常用标点、中文
+    // 保留的标点：。!?;,，。！？；：、""''（）【】《》
+    // 移除：*# 等特殊符号、表情符号、emoji 等
+    text = text.replace(/[^\p{L}\p{N}\s。!?;,，。！？；：、""''（）【】《》\n一-鿿㐀-䶿]/gu, '')
+
     // 移除多余的空白
     text = text.replace(/\s+/g, ' ').trim()
 


### PR DESCRIPTION
## Summary
- Filter special characters (*# etc.) and emoji in speech synthesis
- Only keep common punctuation marks for better TTS readability
- Update `extractReadableText` function in useSpeech composable

## Changes
- Modified character filter to only allow: letters, numbers, spaces, Chinese characters, and common punctuation
- Removed special unicode characters, symbols, and emoji from speech text

## Test plan
- [ ] Tested speech playback with text containing *# symbols
- [ ] Verified emoji and special characters are filtered
- [ ] Confirmed common punctuation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)