### PR TITLE
feat: add drawer panel with mobile sidebar support and customizable button

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -1012,7 +1012,7 @@ async function handleWorkspaceConfirm() {
   box-shadow:
     0 0 10px rgba(255, 107, 107, 0.4),
     0 0 20px rgba(255, 107, 107, 0.2);
-  animation: rainbow-glow 4s linear infinite;
+  animation: rainbow-glow 8s linear infinite;
   transition: all $transition-fast;
 
   &:hover {

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -1,24 +1,35 @@
 <script setup lang="ts">
-import { renameSession, setSessionWorkspace } from '@/api/hermes/sessions'
-import { useChatStore, type Session } from '@/stores/hermes/chat'
-import { useSessionBrowserPrefsStore } from '@/stores/hermes/session-browser-prefs'
-import { NButton, NDropdown, NInput, NModal, NTooltip, useMessage } from 'naive-ui'
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { getSourceLabel } from '@/shared/session-display'
-import { copyToClipboard } from '@/utils/clipboard'
-import FolderPicker from './FolderPicker.vue'
-import ChatInput from './ChatInput.vue'
-import ConversationMonitorPane from './ConversationMonitorPane.vue'
-import MessageList from './MessageList.vue'
-import SessionListItem from './SessionListItem.vue'
+import { renameSession, setSessionWorkspace } from "@/api/hermes/sessions";
+import { useChatStore, type Session } from "@/stores/hermes/chat";
+import { useSessionBrowserPrefsStore } from "@/stores/hermes/session-browser-prefs";
+import {
+  NButton,
+  NDropdown,
+  NInput,
+  NModal,
+  NTooltip,
+  useMessage,
+} from "naive-ui";
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { getSourceLabel } from "@/shared/session-display";
+import { copyToClipboard } from "@/utils/clipboard";
+import FolderPicker from "./FolderPicker.vue";
+import ChatInput from "./ChatInput.vue";
+import ConversationMonitorPane from "./ConversationMonitorPane.vue";
+import MessageList from "./MessageList.vue";
+import SessionListItem from "./SessionListItem.vue";
+import DrawerPanel from "./DrawerPanel.vue";
 
-const chatStore = useChatStore()
-const sessionBrowserPrefsStore = useSessionBrowserPrefsStore()
-const message = useMessage()
-const { t } = useI18n()
+const chatStore = useChatStore();
+const sessionBrowserPrefsStore = useSessionBrowserPrefsStore();
+const message = useMessage();
+const { t } = useI18n();
 
-const currentMode = ref<'chat' | 'live'>('chat')
+const showDrawer = ref(false);
+const drawerActiveTab = ref<"terminal" | "files">("files");
+
+const currentMode = ref<"chat" | "live">("chat");
 
 // Initialize synchronously from the media query so first paint is correct.
 // On narrow viewports the session list is an absolute-positioned overlay
@@ -27,275 +38,363 @@ const currentMode = ref<'chat' | 'live'>('chat')
 // where the session list covers the chat content ("auto-fixes after a
 // moment" — that was the race).
 const showSessions = ref(
-  typeof window === 'undefined' || !window.matchMedia('(max-width: 768px)').matches,
-)
-let mobileQuery: MediaQueryList | null = null
-const isMobile = ref(false)
+  typeof window === "undefined" ||
+    !window.matchMedia("(max-width: 768px)").matches,
+);
+let mobileQuery: MediaQueryList | null = null;
+const isMobile = ref(false);
 
 function handleSessionClick(sessionId: string) {
-  chatStore.switchSession(sessionId)
-  if (mobileQuery?.matches) showSessions.value = false
+  chatStore.switchSession(sessionId);
+  if (mobileQuery?.matches) showSessions.value = false;
 }
 
 function handleMobileChange(e: MediaQueryListEvent | MediaQueryList) {
-  isMobile.value = e.matches
+  isMobile.value = e.matches;
   if (e.matches && showSessions.value) {
-    showSessions.value = false
+    showSessions.value = false;
   }
 }
 
 onMounted(() => {
-  mobileQuery = window.matchMedia('(max-width: 768px)')
-  handleMobileChange(mobileQuery)
-  mobileQuery.addEventListener('change', handleMobileChange)
-})
+  mobileQuery = window.matchMedia("(max-width: 768px)");
+  handleMobileChange(mobileQuery);
+  mobileQuery.addEventListener("change", handleMobileChange);
+});
 
 onUnmounted(() => {
-  mobileQuery?.removeEventListener('change', handleMobileChange)
-})
-const showRenameModal = ref(false)
-const renameValue = ref('')
-const renameSessionId = ref<string | null>(null)
-const renameInputRef = ref<InstanceType<typeof NInput> | null>(null)
-const collapsedGroups = ref<Set<string>>(new Set(JSON.parse(localStorage.getItem('hermes_collapsed_groups') || '[]')))
+  mobileQuery?.removeEventListener("change", handleMobileChange);
+});
+const showRenameModal = ref(false);
+const renameValue = ref("");
+const renameSessionId = ref<string | null>(null);
+const renameInputRef = ref<InstanceType<typeof NInput> | null>(null);
+const collapsedGroups = ref<Set<string>>(
+  new Set(JSON.parse(localStorage.getItem("hermes_collapsed_groups") || "[]")),
+);
 
 // Source sort order: api_server first, cron last, others alphabetical
 function sourceSortKey(source: string): number {
-  if (source === 'api_server') return -1
-  if (source === 'cron') return 999
-  return 0
+  if (source === "api_server") return -1;
+  if (source === "cron") return 999;
+  return 0;
 }
 
 function sortSessionsWithActiveFirst(items: Session[]): Session[] {
   return [...items].sort((a, b) => {
-    return (b.updatedAt || 0) - (a.updatedAt || 0)
-  })
+    return (b.updatedAt || 0) - (a.updatedAt || 0);
+  });
 }
 
 // Group sessions by source, with sort order
 interface SessionGroup {
-  source: string
-  label: string
-  sessions: Session[]
+  source: string;
+  label: string;
+  sessions: Session[];
 }
 
 const pinnedSessions = computed(() =>
-  sortSessionsWithActiveFirst(chatStore.sessions.filter(session => sessionBrowserPrefsStore.isPinned(session.id))),
-)
+  sortSessionsWithActiveFirst(
+    chatStore.sessions.filter((session) =>
+      sessionBrowserPrefsStore.isPinned(session.id),
+    ),
+  ),
+);
 
 const groupedSessions = computed<SessionGroup[]>(() => {
-  const map = new Map<string, Session[]>()
+  const map = new Map<string, Session[]>();
   for (const s of chatStore.sessions) {
-    if (sessionBrowserPrefsStore.isPinned(s.id)) continue
-    const key = s.source || ''
-    if (!map.has(key)) map.set(key, [])
-    map.get(key)!.push(s)
+    if (sessionBrowserPrefsStore.isPinned(s.id)) continue;
+    const key = s.source || "";
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(s);
   }
 
   const keys = [...map.keys()].sort((a, b) => {
-    const ka = sourceSortKey(a)
-    const kb = sourceSortKey(b)
-    if (ka !== kb) return ka - kb
-    return a.localeCompare(b)
-  })
+    const ka = sourceSortKey(a);
+    const kb = sourceSortKey(b);
+    if (ka !== kb) return ka - kb;
+    return a.localeCompare(b);
+  });
 
-  return keys.map(key => ({
+  return keys.map((key) => ({
     source: key,
-    label: key ? getSourceLabel(key) : t('chat.other'),
+    label: key ? getSourceLabel(key) : t("chat.other"),
     sessions: sortSessionsWithActiveFirst(map.get(key)!),
-  }))
-})
+  }));
+});
 
 function toggleGroup(source: string) {
-  const isExpanded = !collapsedGroups.value.has(source)
+  const isExpanded = !collapsedGroups.value.has(source);
   if (isExpanded) {
-    collapsedGroups.value = new Set([...collapsedGroups.value, source])
+    collapsedGroups.value = new Set([...collapsedGroups.value, source]);
   } else {
     collapsedGroups.value = new Set(
-      groupedSessions.value.map(g => g.source).filter(s => s !== source),
-    )
-    const group = groupedSessions.value.find(g => g.source === source)
+      groupedSessions.value.map((g) => g.source).filter((s) => s !== source),
+    );
+    const group = groupedSessions.value.find((g) => g.source === source);
     if (group?.sessions.length) {
-      chatStore.switchSession(group.sessions[0].id)
+      chatStore.switchSession(group.sessions[0].id);
     }
   }
-  localStorage.setItem('hermes_collapsed_groups', JSON.stringify([...collapsedGroups.value]))
+  localStorage.setItem(
+    "hermes_collapsed_groups",
+    JSON.stringify([...collapsedGroups.value]),
+  );
 }
 
-watch(groupedSessions, groups => {
-  if (localStorage.getItem('hermes_collapsed_groups') !== null) {
-    const activeSource = chatStore.activeSession?.source
-    if (activeSource && collapsedGroups.value.has(activeSource)) {
-      collapsedGroups.value = new Set([...collapsedGroups.value].filter(source => source !== activeSource))
-      localStorage.setItem('hermes_collapsed_groups', JSON.stringify([...collapsedGroups.value]))
+watch(
+  groupedSessions,
+  (groups) => {
+    if (localStorage.getItem("hermes_collapsed_groups") !== null) {
+      const activeSource = chatStore.activeSession?.source;
+      if (activeSource && collapsedGroups.value.has(activeSource)) {
+        collapsedGroups.value = new Set(
+          [...collapsedGroups.value].filter(
+            (source) => source !== activeSource,
+          ),
+        );
+        localStorage.setItem(
+          "hermes_collapsed_groups",
+          JSON.stringify([...collapsedGroups.value]),
+        );
+      }
+      return;
     }
-    return
-  }
-  collapsedGroups.value = new Set(groups.slice(1).map(group => group.source))
-  localStorage.setItem('hermes_collapsed_groups', JSON.stringify([...collapsedGroups.value]))
-}, { once: true })
+    collapsedGroups.value = new Set(
+      groups.slice(1).map((group) => group.source),
+    );
+    localStorage.setItem(
+      "hermes_collapsed_groups",
+      JSON.stringify([...collapsedGroups.value]),
+    );
+  },
+  { once: true },
+);
 
 watch(
-  () => [chatStore.sessionsLoaded, ...chatStore.sessions.map(session => session.id)],
-  value => {
-    const sessionIds = value.slice(1) as string[]
-    if (!value[0] || sessionIds.length === 0) return
-    sessionBrowserPrefsStore.pruneMissingSessions(sessionIds)
+  () => [
+    chatStore.sessionsLoaded,
+    ...chatStore.sessions.map((session) => session.id),
+  ],
+  (value) => {
+    const sessionIds = value.slice(1) as string[];
+    if (!value[0] || sessionIds.length === 0) return;
+    sessionBrowserPrefsStore.pruneMissingSessions(sessionIds);
   },
   { immediate: true },
-)
+);
 
-const activeSessionTitle = computed(() =>
-  chatStore.activeSession?.title || t('chat.newChat'),
-)
+const activeSessionTitle = computed(
+  () => chatStore.activeSession?.title || t("chat.newChat"),
+);
 
 const headerTitle = computed(() =>
-  currentMode.value === 'live' ? t('chat.liveSessions') : activeSessionTitle.value,
-)
+  currentMode.value === "live"
+    ? t("chat.liveSessions")
+    : activeSessionTitle.value,
+);
 
 const activeSessionSource = computed(() =>
-  currentMode.value === 'chat' ? (chatStore.activeSession?.source || '') : '',
-)
+  currentMode.value === "chat" ? chatStore.activeSession?.source || "" : "",
+);
 
 function handleNewChat() {
-  chatStore.newChat()
+  chatStore.newChat();
 }
 
 async function copySessionId(id?: string) {
-  const sessionId = id || chatStore.activeSessionId
+  const sessionId = id || chatStore.activeSessionId;
   if (sessionId) {
-    const ok = await copyToClipboard(sessionId)
-    if (ok) message.success(t('common.copied'))
-    else message.error(t('common.copied') + ' ✗')
+    const ok = await copyToClipboard(sessionId);
+    if (ok) message.success(t("common.copied"));
+    else message.error(t("common.copied") + " ✗");
   }
 }
 
 function handleDeleteSession(id: string) {
-  sessionBrowserPrefsStore.removePinned(id)
-  chatStore.deleteSession(id)
-  message.success(t('chat.sessionDeleted'))
+  sessionBrowserPrefsStore.removePinned(id);
+  chatStore.deleteSession(id);
+  message.success(t("chat.sessionDeleted"));
 }
 
-const contextSessionId = ref<string | null>(null)
+const contextSessionId = ref<string | null>(null);
 const contextSessionPinned = computed(() =>
-  contextSessionId.value ? sessionBrowserPrefsStore.isPinned(contextSessionId.value) : false,
-)
+  contextSessionId.value
+    ? sessionBrowserPrefsStore.isPinned(contextSessionId.value)
+    : false,
+);
 
 const contextMenuOptions = computed(() => [
-  { label: t(contextSessionPinned.value ? 'chat.unpin' : 'chat.pin'), key: 'pin' },
-  { label: t('chat.rename'), key: 'rename' },
-  { label: t('chat.setWorkspace'), key: 'workspace' },
-  { label: t('chat.copySessionId'), key: 'copy-id' },
-])
+  {
+    label: t(contextSessionPinned.value ? "chat.unpin" : "chat.pin"),
+    key: "pin",
+  },
+  { label: t("chat.rename"), key: "rename" },
+  { label: t("chat.setWorkspace"), key: "workspace" },
+  { label: t("chat.copySessionId"), key: "copy-id" },
+]);
 
 function handleContextMenu(e: MouseEvent, sessionId: string) {
-  e.preventDefault()
-  contextSessionId.value = sessionId
-  showContextMenu.value = true
-  contextMenuX.value = e.clientX
-  contextMenuY.value = e.clientY
+  e.preventDefault();
+  contextSessionId.value = sessionId;
+  showContextMenu.value = true;
+  contextMenuX.value = e.clientX;
+  contextMenuY.value = e.clientY;
 }
 
-const showContextMenu = ref(false)
-const contextMenuX = ref(0)
-const contextMenuY = ref(0)
+const showContextMenu = ref(false);
+const contextMenuX = ref(0);
+const contextMenuY = ref(0);
 
 function handleContextMenuSelect(key: string) {
-  showContextMenu.value = false
-  if (!contextSessionId.value) return
-  if (key === 'pin') {
-    sessionBrowserPrefsStore.togglePinned(contextSessionId.value)
-    return
+  showContextMenu.value = false;
+  if (!contextSessionId.value) return;
+  if (key === "pin") {
+    sessionBrowserPrefsStore.togglePinned(contextSessionId.value);
+    return;
   }
-  if (key === 'copy-id') {
-    copySessionId(contextSessionId.value)
-  } else if (key === 'workspace') {
-    const session = chatStore.sessions.find(s => s.id === contextSessionId.value)
-    workspaceSessionId.value = contextSessionId.value
-    workspaceValue.value = session?.workspace || ''
-    showWorkspaceModal.value = true
-  } else if (key === 'rename') {
-    const session = chatStore.sessions.find(s => s.id === contextSessionId.value)
-    renameSessionId.value = contextSessionId.value
-    renameValue.value = session?.title || ''
-    showRenameModal.value = true
+  if (key === "copy-id") {
+    copySessionId(contextSessionId.value);
+  } else if (key === "workspace") {
+    const session = chatStore.sessions.find(
+      (s) => s.id === contextSessionId.value,
+    );
+    workspaceSessionId.value = contextSessionId.value;
+    workspaceValue.value = session?.workspace || "";
+    showWorkspaceModal.value = true;
+  } else if (key === "rename") {
+    const session = chatStore.sessions.find(
+      (s) => s.id === contextSessionId.value,
+    );
+    renameSessionId.value = contextSessionId.value;
+    renameValue.value = session?.title || "";
+    showRenameModal.value = true;
     nextTick(() => {
-      renameInputRef.value?.focus()
-    })
+      renameInputRef.value?.focus();
+    });
   }
 }
 
 function handleClickOutside() {
-  showContextMenu.value = false
+  showContextMenu.value = false;
 }
 
 async function handleRenameConfirm() {
-  if (!renameSessionId.value || !renameValue.value.trim()) return
-  const ok = await renameSession(renameSessionId.value, renameValue.value.trim())
+  if (!renameSessionId.value || !renameValue.value.trim()) return;
+  const ok = await renameSession(
+    renameSessionId.value,
+    renameValue.value.trim(),
+  );
   if (ok) {
-    const session = chatStore.sessions.find(s => s.id === renameSessionId.value)
-    if (session) session.title = renameValue.value.trim()
+    const session = chatStore.sessions.find(
+      (s) => s.id === renameSessionId.value,
+    );
+    if (session) session.title = renameValue.value.trim();
     if (chatStore.activeSession?.id === renameSessionId.value) {
-      chatStore.activeSession.title = renameValue.value.trim()
+      chatStore.activeSession.title = renameValue.value.trim();
     }
-    message.success(t('chat.renamed'))
+    message.success(t("chat.renamed"));
   } else {
-    message.error(t('chat.renameFailed'))
+    message.error(t("chat.renameFailed"));
   }
-  showRenameModal.value = false
+  showRenameModal.value = false;
 }
 
-const showWorkspaceModal = ref(false)
-const workspaceValue = ref('')
-const workspaceSessionId = ref<string | null>(null)
+const showWorkspaceModal = ref(false);
+const workspaceValue = ref("");
+const workspaceSessionId = ref<string | null>(null);
 
 async function handleWorkspaceConfirm() {
-  if (!workspaceSessionId.value) return
-  const ok = await setSessionWorkspace(workspaceSessionId.value, workspaceValue.value || null)
+  if (!workspaceSessionId.value) return;
+  const ok = await setSessionWorkspace(
+    workspaceSessionId.value,
+    workspaceValue.value || null,
+  );
   if (ok) {
-    const session = chatStore.sessions.find(s => s.id === workspaceSessionId.value)
-    if (session) session.workspace = workspaceValue.value || null
+    const session = chatStore.sessions.find(
+      (s) => s.id === workspaceSessionId.value,
+    );
+    if (session) session.workspace = workspaceValue.value || null;
     if (chatStore.activeSession?.id === workspaceSessionId.value) {
-      chatStore.activeSession.workspace = workspaceValue.value || null
+      chatStore.activeSession.workspace = workspaceValue.value || null;
     }
-    message.success(t('chat.workspaceSet'))
+    message.success(t("chat.workspaceSet"));
   } else {
-    message.error(t('chat.workspaceSetFailed'))
+    message.error(t("chat.workspaceSetFailed"));
   }
-  showWorkspaceModal.value = false
+  showWorkspaceModal.value = false;
 }
 </script>
 
 <template>
   <div class="chat-panel">
-    <div v-if="currentMode === 'chat'" class="session-backdrop" :class="{ active: showSessions }" @click="showSessions = false" />
-    <aside v-if="currentMode === 'chat'" class="session-list" :class="{ collapsed: !showSessions }">
+    <div
+      v-if="currentMode === 'chat'"
+      class="session-backdrop"
+      :class="{ active: showSessions }"
+      @click="showSessions = false"
+    />
+    <aside
+      v-if="currentMode === 'chat'"
+      class="session-list"
+      :class="{ collapsed: !showSessions }"
+    >
       <div class="session-list-header">
-        <span v-if="showSessions" class="session-list-title">{{ t('chat.webUiSessions') }}</span>
+        <span v-if="showSessions" class="session-list-title">{{
+          t("chat.webUiSessions")
+        }}</span>
         <div class="session-list-actions">
           <button class="session-close-btn" @click="showSessions = false">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
           </button>
           <NButton quaternary size="tiny" @click="handleNewChat" circle>
             <template #icon>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
             </template>
           </NButton>
         </div>
       </div>
       <div v-if="showSessions" class="session-scope-note">
-        <span>{{ t('chat.sessionScopeHint') }}</span>
+        <span>{{ t("chat.sessionScopeHint") }}</span>
         <RouterLink class="session-scope-link" :to="{ name: 'hermes.history' }">
-          {{ t('chat.openHistory') }}
+          {{ t("chat.openHistory") }}
         </RouterLink>
       </div>
       <div v-if="showSessions" class="session-items">
-        <div v-if="chatStore.isLoadingSessions && chatStore.sessions.length === 0" class="session-loading">{{ t('common.loading') }}</div>
-        <div v-else-if="chatStore.sessions.length === 0" class="session-empty">{{ t('chat.noSessions') }}</div>
+        <div
+          v-if="chatStore.isLoadingSessions && chatStore.sessions.length === 0"
+          class="session-loading"
+        >
+          {{ t("common.loading") }}
+        </div>
+        <div v-else-if="chatStore.sessions.length === 0" class="session-empty">
+          {{ t("chat.noSessions") }}
+        </div>
 
         <template v-if="pinnedSessions.length > 0">
           <div class="session-group-header session-group-header--static">
-            <span class="session-group-label">{{ t('chat.pinned') }}</span>
+            <span class="session-group-label">{{ t("chat.pinned") }}</span>
             <span class="session-group-count">{{ pinnedSessions.length }}</span>
           </div>
           <SessionListItem
@@ -304,7 +403,10 @@ async function handleWorkspaceConfirm() {
             :session="s"
             :active="s.id === chatStore.activeSessionId"
             :pinned="true"
-            :can-delete="s.id !== chatStore.activeSessionId || chatStore.sessions.length > 1"
+            :can-delete="
+              s.id !== chatStore.activeSessionId ||
+              chatStore.sessions.length > 1
+            "
             :streaming="chatStore.isSessionLive(s.id)"
             @select="handleSessionClick(s.id)"
             @contextmenu="handleContextMenu($event, s.id)"
@@ -314,7 +416,18 @@ async function handleWorkspaceConfirm() {
 
         <template v-for="group in groupedSessions" :key="group.source">
           <div class="session-group-header" @click="toggleGroup(group.source)">
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="group-chevron" :class="{ collapsed: collapsedGroups.has(group.source) }"><polyline points="9 18 15 12 9 6"/></svg>
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              class="group-chevron"
+              :class="{ collapsed: collapsedGroups.has(group.source) }"
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
             <span class="session-group-label">{{ group.label }}</span>
             <span class="session-group-count">{{ group.sessions.length }}</span>
           </div>
@@ -325,7 +438,10 @@ async function handleWorkspaceConfirm() {
               :session="s"
               :active="s.id === chatStore.activeSessionId"
               :pinned="false"
-              :can-delete="s.id !== chatStore.activeSessionId || chatStore.sessions.length > 1"
+              :can-delete="
+                s.id !== chatStore.activeSessionId ||
+                chatStore.sessions.length > 1
+              "
               :streaming="chatStore.isSessionLive(s.id)"
               @select="handleSessionClick(s.id)"
               @contextmenu="handleContextMenu($event, s.id)"
@@ -378,33 +494,89 @@ async function handleWorkspaceConfirm() {
     <div class="chat-main">
       <header class="chat-header">
         <div class="header-left">
-          <NButton v-if="currentMode === 'chat'" quaternary size="small" @click="showSessions = !showSessions" circle>
+          <NButton
+            v-if="currentMode === 'chat'"
+            quaternary
+            size="small"
+            @click="showSessions = !showSessions"
+            circle
+          >
             <template #icon>
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+              >
+                <rect x="3" y="3" width="7" height="7" />
+                <rect x="14" y="3" width="7" height="7" />
+                <rect x="3" y="14" width="7" height="7" />
+                <rect x="14" y="14" width="7" height="7" />
+              </svg>
             </template>
           </NButton>
           <span class="header-session-title">{{ headerTitle }}</span>
-          <span v-if="activeSessionSource" class="source-badge">{{ getSourceLabel(activeSessionSource) }}</span>
-          <span v-if="chatStore.activeSession?.workspace" class="workspace-badge" :title="chatStore.activeSession.workspace">📁 {{ chatStore.activeSession.workspace.split('/').pop() || chatStore.activeSession.workspace }}</span>
+          <span v-if="activeSessionSource" class="source-badge">{{
+            getSourceLabel(activeSessionSource)
+          }}</span>
+          <span
+            v-if="chatStore.activeSession?.workspace"
+            class="workspace-badge"
+            :title="chatStore.activeSession.workspace"
+            >📁
+            {{
+              chatStore.activeSession.workspace.split("/").pop() ||
+              chatStore.activeSession.workspace
+            }}</span
+          >
         </div>
         <div class="header-actions">
           <!-- chat/live mode toggle hidden -->
           <template v-if="currentMode === 'chat'">
             <NTooltip trigger="hover">
               <template #trigger>
-                <NButton quaternary size="small" @click="copySessionId()" circle>
+                <NButton
+                  quaternary
+                  size="small"
+                  @click="copySessionId()"
+                  circle
+                >
                   <template #icon>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                    >
+                      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                      <path
+                        d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+                      />
+                    </svg>
                   </template>
                 </NButton>
               </template>
-              {{ t('chat.copySessionId') }}
+              {{ t("chat.copySessionId") }}
             </NTooltip>
             <NButton size="small" :circle="isMobile" @click="handleNewChat">
               <template #icon>
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <line x1="12" y1="5" x2="12" y2="19" />
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                </svg>
               </template>
-              <template v-if="!isMobile">{{ t('chat.newChat') }}</template>
+              <template v-if="!isMobile">{{ t("chat.newChat") }}</template>
             </NButton>
           </template>
         </div>
@@ -414,13 +586,41 @@ async function handleWorkspaceConfirm() {
         <MessageList />
         <ChatInput />
       </template>
-      <ConversationMonitorPane v-else :human-only="sessionBrowserPrefsStore.humanOnly" />
+      <ConversationMonitorPane
+        v-else
+        :human-only="sessionBrowserPrefsStore.humanOnly"
+      />
     </div>
+
+    <!-- Floating drawer button -->
+    <div class="drawer-button-wrapper">
+      <NTooltip placement="left">
+        <template #trigger>
+          <div class="drawer-button" @click="showDrawer = true">
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+            >
+              <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+              <line x1="9" y1="3" x2="9" y2="21" />
+              <line x1="15" y1="3" x2="15" y2="21" />
+            </svg>
+          </div>
+        </template>
+        <span>Terminal & Files</span>
+      </NTooltip>
+    </div>
+
+    <DrawerPanel v-model:show="showDrawer" :active-tab="drawerActiveTab" />
   </div>
 </template>
 
 <style scoped lang="scss">
-@use '@/styles/variables' as *;
+@use "@/styles/variables" as *;
 
 .chat-panel {
   display: flex;
@@ -434,7 +634,9 @@ async function handleWorkspaceConfirm() {
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
-  transition: width $transition-normal, opacity $transition-normal;
+  transition:
+    width $transition-normal,
+    opacity $transition-normal;
   overflow: hidden;
 
   &.collapsed {
@@ -659,8 +861,12 @@ async function handleWorkspaceConfirm() {
 }
 
 @keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 :deep(.session-item-pin) {
@@ -791,5 +997,126 @@ async function handleWorkspaceConfirm() {
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: default;
+}
+
+// ─── Drawer button ─────────────────────────────────────────────
+
+.drawer-button-wrapper {
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 100;
+  background: $bg-card;
+  border-radius: 50%;
+  box-shadow:
+    0 0 10px rgba(255, 107, 107, 0.4),
+    0 0 20px rgba(255, 107, 107, 0.2);
+  animation: rainbow-glow 4s linear infinite;
+  transition: all $transition-fast;
+
+  &:hover {
+    animation-play-state: paused;
+    box-shadow:
+      0 0 15px rgba(255, 107, 107, 0.6),
+      0 0 30px rgba(255, 107, 107, 0.3);
+  }
+}
+
+.drawer-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(var(--accent-primary-rgb), 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all $transition-fast;
+
+  svg {
+    width: 18px;
+    height: 18px;
+    color: var(--accent-primary);
+  }
+
+  &:hover {
+    transform: scale(1.1);
+  }
+}
+
+@keyframes rainbow-glow {
+  0% {
+    box-shadow:
+      0 0 0 2px #ff6b6b,
+      0 0 10px rgba(255, 107, 107, 0.4),
+      0 0 20px rgba(255, 107, 107, 0.2);
+    border-color: #ff6b6b;
+    color: #ff6b6b;
+  }
+  16.66% {
+    box-shadow:
+      0 0 0 2px #feca57,
+      0 0 10px rgba(254, 202, 87, 0.4),
+      0 0 20px rgba(254, 202, 87, 0.2);
+    border-color: #feca57;
+    color: #feca57;
+  }
+  33.33% {
+    box-shadow:
+      0 0 0 2px #48dbfb,
+      0 0 10px rgba(72, 219, 251, 0.4),
+      0 0 20px rgba(72, 219, 251, 0.2);
+    border-color: #48dbfb;
+    color: #48dbfb;
+  }
+  50% {
+    box-shadow:
+      0 0 0 2px #ff9ff3,
+      0 0 10px rgba(255, 159, 243, 0.4),
+      0 0 20px rgba(255, 159, 243, 0.2);
+    border-color: #ff9ff3;
+    color: #ff9ff3;
+  }
+  66.66% {
+    box-shadow:
+      0 0 0 2px #54a0ff,
+      0 0 10px rgba(84, 160, 255, 0.4),
+      0 0 20px rgba(84, 160, 255, 0.2);
+    border-color: #54a0ff;
+    color: #54a0ff;
+  }
+  83.33% {
+    box-shadow:
+      0 0 0 2px #5f27cd,
+      0 0 10px rgba(95, 39, 205, 0.4),
+      0 0 20px rgba(95, 39, 205, 0.2);
+    border-color: #5f27cd;
+    color: #5f27cd;
+  }
+  100% {
+    box-shadow:
+      0 0 0 2px #ff6b6b,
+      0 0 10px rgba(255, 107, 107, 0.4),
+      0 0 20px rgba(255, 107, 107, 0.2);
+    border-color: #ff6b6b;
+    color: #ff6b6b;
+  }
+}
+
+@media (max-width: $breakpoint-mobile) {
+  .drawer-button-wrapper {
+    right: 12px;
+  }
+
+  .drawer-button {
+    width: 36px;
+    height: 36px;
+
+    svg {
+      width: 16px;
+      height: 16px;
+    }
+  }
 }
 </style>

--- a/packages/client/src/components/hermes/chat/DrawerPanel.vue
+++ b/packages/client/src/components/hermes/chat/DrawerPanel.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import TerminalPanel from './TerminalPanel.vue'
+import FilesPanel from './FilesPanel.vue'
+
+interface Props {
+  show: boolean
+  activeTab?: 'terminal' | 'files'
+}
+
+interface Emits {
+  (e: 'update:show', value: boolean): void
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  activeTab: 'files'
+})
+
+const emit = defineEmits<Emits>()
+const { t } = useI18n()
+
+const activeTab = ref<'terminal' | 'files'>(props.activeTab)
+
+watch(() => props.activeTab, (newVal) => {
+  if (newVal) activeTab.value = newVal
+})
+
+function handleClose() {
+  emit('update:show', false)
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="show" class="drawer-overlay" @click="handleClose"></div>
+    <div :class="['drawer-panel', { show }]">
+      <div class="drawer-header">
+        <div class="drawer-tabs">
+          <button
+            :class="['tab-button', { active: activeTab === 'files' }]"
+            @click="activeTab = 'files'"
+          >
+            {{ t('drawer.files') }}
+          </button>
+          <button
+            :class="['tab-button', { active: activeTab === 'terminal' }]"
+            @click="activeTab = 'terminal'"
+          >
+            {{ t('drawer.terminal') }}
+          </button>
+        </div>
+        <button class="close-button" @click="handleClose">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+
+      <div class="drawer-content">
+        <div v-show="activeTab === 'files'" class="drawer-pane">
+          <FilesPanel />
+        </div>
+        <div v-show="activeTab === 'terminal'" class="drawer-pane">
+          <TerminalPanel />
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped lang="scss">
+@use "@/styles/variables" as *;
+
+.drawer-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 999;
+}
+
+.drawer-panel {
+  position: fixed;
+  top: 0;
+  right: -900px;
+  width: 900px;
+  height: 100vh;
+  background: $bg-card;
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.15);
+  display: flex;
+  flex-direction: column;
+  z-index: 1000;
+  transition: right 0.3s ease;
+
+  &.show {
+    right: 0;
+  }
+
+  @media (max-width: $breakpoint-mobile) {
+    width: 100%;
+    right: -100%;
+
+    &.show {
+      right: 0;
+    }
+  }
+}
+
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  border-bottom: 1px solid $border-color;
+  flex-shrink: 0;
+}
+
+.drawer-tabs {
+  display: flex;
+  gap: 8px;
+}
+
+.tab-button {
+  padding: 8px 16px;
+  border: none;
+  background: transparent;
+  color: $text-secondary;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  border-bottom: 2px solid transparent;
+  transition: all 0.2s;
+  flex-shrink: 0;
+  white-space: nowrap;
+  border-radius: $radius-sm;
+
+  &:hover {
+    color: $text-primary;
+    background: rgba(var(--accent-primary-rgb), 0.05);
+  }
+
+  &.active {
+    color: var(--accent-primary);
+    background: rgba(var(--accent-primary-rgb), 0.1);
+  }
+}
+
+.close-button {
+  padding: 8px;
+  border: none;
+  background: rgba(var(--accent-primary-rgb), 0.08);
+  color: $text-secondary;
+  cursor: pointer;
+  border-radius: $radius-sm;
+  transition: all 0.2s;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    color: $text-primary;
+    background: rgba(var(--accent-primary-rgb), 0.15);
+  }
+}
+
+.drawer-content {
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+  min-height: 0;
+}
+
+.drawer-pane {
+  height: 100%;
+  overflow: auto;
+}
+</style>
+
+

--- a/packages/client/src/components/hermes/chat/FilesPanel.vue
+++ b/packages/client/src/components/hermes/chat/FilesPanel.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useFilesStore } from '@/stores/hermes/files'
+import { useI18n } from 'vue-i18n'
+import { NButton } from 'naive-ui'
+import FileTree from '@/components/hermes/files/FileTree.vue'
+import FileBreadcrumb from '@/components/hermes/files/FileBreadcrumb.vue'
+import FileToolbar from '@/components/hermes/files/FileToolbar.vue'
+import FileList from '@/components/hermes/files/FileList.vue'
+import FileContextMenu from '@/components/hermes/files/FileContextMenu.vue'
+import FileEditor from '@/components/hermes/files/FileEditor.vue'
+import FilePreview from '@/components/hermes/files/FilePreview.vue'
+import FileUploadModal from '@/components/hermes/files/FileUploadModal.vue'
+import FileRenameModal from '@/components/hermes/files/FileRenameModal.vue'
+import type { FileEntry } from '@/api/hermes/files'
+
+const filesStore = useFilesStore()
+const { t } = useI18n()
+
+const contextMenuRef = ref<InstanceType<typeof FileContextMenu> | null>(null)
+const showUpload = ref(false)
+const showRenameModal = ref(false)
+const renameMode = ref<'newFile' | 'newFolder' | 'rename'>('newFile')
+const renameEntry = ref<FileEntry | null>(null)
+const showSidebar = ref(false)
+
+function handleContextMenu(e: MouseEvent, entry: FileEntry) {
+  contextMenuRef.value?.show(e, entry)
+}
+
+function handleShowNewFile() {
+  renameMode.value = 'newFile'
+  renameEntry.value = null
+  showRenameModal.value = true
+}
+
+function handleShowNewFolder() {
+  renameMode.value = 'newFolder'
+  renameEntry.value = null
+  showRenameModal.value = true
+}
+
+function handleRename(entry: FileEntry) {
+  renameMode.value = 'rename'
+  renameEntry.value = entry
+  showRenameModal.value = true
+}
+
+onMounted(() => {
+  filesStore.fetchEntries('')
+})
+</script>
+
+<template>
+  <div class="files-panel-drawer">
+    <div
+      v-if="showSidebar"
+      class="sidebar-overlay"
+      @click="showSidebar = false"
+    ></div>
+    <div
+      class="files-tree-panel"
+      :class="{ 'mobile-visible': showSidebar }"
+    >
+      <FileTree />
+    </div>
+    <div class="files-main-panel">
+      <div class="main-toolbar">
+        <NButton
+          size="small"
+          @click="showSidebar = !showSidebar"
+          class="sidebar-toggle"
+        >
+          <template #icon>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <rect x="3" y="3" width="18" height="18" rx="2" />
+              <line x1="9" y1="3" x2="9" y2="21" />
+            </svg>
+          </template>
+          {{ t('files.fileTree') }}
+        </NButton>
+        <FileToolbar
+          @show-new-file="handleShowNewFile"
+          @show-new-folder="handleShowNewFolder"
+          @show-upload="showUpload = true"
+        />
+      </div>
+      <FileBreadcrumb />
+      <div class="files-content">
+        <FileEditor v-if="filesStore.editingFile" />
+        <FilePreview v-else-if="filesStore.previewFile" />
+        <FileList v-else @contextmenu-entry="handleContextMenu" />
+      </div>
+    </div>
+    <FileContextMenu ref="contextMenuRef" @rename="handleRename" />
+    <FileUploadModal v-model:show="showUpload" />
+    <FileRenameModal v-model:show="showRenameModal" :mode="renameMode" :entry="renameEntry" />
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use "@/styles/variables" as *;
+
+.files-panel-drawer {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.sidebar-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 50;
+
+  @media (min-width: $breakpoint-mobile + 1) {
+    display: none;
+  }
+}
+
+.files-tree-panel {
+  width: 200px;
+  min-width: 150px;
+  max-width: 300px;
+  border-right: 1px solid $border-color;
+  overflow-y: auto;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+
+  @media (max-width: $breakpoint-mobile) {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 80%;
+    max-width: 300px;
+    z-index: 51;
+    background: $bg-card;
+    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+
+    &.mobile-visible {
+      transform: translateX(0);
+    }
+  }
+}
+
+.files-main-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.main-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid $border-color;
+  flex-shrink: 0;
+
+  @media (max-width: $breakpoint-mobile) {
+    gap: 4px;
+    padding: 8px 8px;
+    flex-wrap: wrap;
+  }
+}
+
+.sidebar-toggle {
+  @media (min-width: $breakpoint-mobile + 1) {
+    display: none;
+  }
+
+  @media (max-width: $breakpoint-mobile) {
+    font-size: 12px;
+    padding: 0 8px;
+    height: 32px;
+  }
+}
+
+.files-content {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}
+</style>

--- a/packages/client/src/components/hermes/chat/TerminalPanel.vue
+++ b/packages/client/src/components/hermes/chat/TerminalPanel.vue
@@ -1,0 +1,788 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, computed } from "vue";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import "@xterm/xterm/css/xterm.css";
+import { getApiKey, getBaseUrlValue } from "@/api/client";
+import { NButton, NPopconfirm, NTooltip, NSelect, useMessage } from "naive-ui";
+import { useI18n } from "vue-i18n";
+import type { ITheme } from "@xterm/xterm";
+
+const { t } = useI18n();
+const message = useMessage();
+
+// ─── Terminal themes ────────────────────────────────────────────
+
+const TERMINAL_THEMES: Record<string, { label: string; theme: ITheme }> = {
+  default: {
+    label: "Default",
+    theme: {
+      background: "#1a1a2e",
+      foreground: "#e0e0e0",
+      cursor: "#4cc9f0",
+      cursorAccent: "#1a1a2e",
+      selectionBackground: "rgba(76, 201, 240, 0.3)",
+      black: "#000000", red: "#e06c75", green: "#98c379", yellow: "#e5c07b",
+      blue: "#61afef", magenta: "#c678dd", cyan: "#56b6c2", white: "#abb2bf",
+      brightBlack: "#5c6370", brightRed: "#e06c75", brightGreen: "#98c379",
+      brightYellow: "#e5c07b", brightBlue: "#61afef", brightMagenta: "#c678dd",
+      brightCyan: "#56b6c2", brightWhite: "#ffffff",
+    },
+  },
+  "solarized-dark": {
+    label: "Solarized Dark",
+    theme: {
+      background: "#002b36", foreground: "#839496",
+      cursor: "#93a1a1", cursorAccent: "#002b36",
+      selectionBackground: "rgba(147, 161, 161, 0.3)",
+      black: "#073642", red: "#dc322f", green: "#859900", yellow: "#b58900",
+      blue: "#268bd2", magenta: "#d33682", cyan: "#2aa198", white: "#eee8d5",
+      brightBlack: "#002b36", brightRed: "#cb4b16", brightGreen: "#586e75",
+      brightYellow: "#657b83", brightBlue: "#839496", brightMagenta: "#6c71c4",
+      brightCyan: "#93a1a1", brightWhite: "#fdf6e3",
+    },
+  },
+  "tokyo-night": {
+    label: "Tokyo Night",
+    theme: {
+      background: "#1a1b26", foreground: "#a9b1d6",
+      cursor: "#c0caf5", cursorAccent: "#1a1b26",
+      selectionBackground: "rgba(192, 202, 245, 0.2)",
+      black: "#15161e", red: "#f7768e", green: "#9ece6a", yellow: "#e0af68",
+      blue: "#7aa2f7", magenta: "#bb9af7", cyan: "#7dcfff", white: "#a9b1d6",
+      brightBlack: "#414868", brightRed: "#f7768e", brightGreen: "#9ece6a",
+      brightYellow: "#e0af68", brightBlue: "#7aa2f7", brightMagenta: "#bb9af7",
+      brightCyan: "#7dcfff", brightWhite: "#c0caf5",
+    },
+  },
+  "github-dark": {
+    label: "GitHub Dark",
+    theme: {
+      background: "#0d1117", foreground: "#c9d1d9",
+      cursor: "#58a6ff", cursorAccent: "#0d1117",
+      selectionBackground: "rgba(88, 166, 255, 0.25)",
+      black: "#484f58", red: "#ff7b72", green: "#7ee787", yellow: "#ffa657",
+      blue: "#79c0ff", magenta: "#d2a8ff", cyan: "#a5d6ff", white: "#c9d1d9",
+      brightBlack: "#6e7681", brightRed: "#ffa198", brightGreen: "#56d364",
+      brightYellow: "#e3b341", brightBlue: "#58a6ff", brightMagenta: "#bc8cff",
+      brightCyan: "#79c0ff", brightWhite: "#f0f6fc",
+    },
+  },
+};
+
+const STORAGE_KEY_THEME = "hermes_terminal_theme";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+interface SessionInfo {
+  id: string;
+  shell: string;
+  pid: number;
+  title: string;
+  createdAt: number;
+  exited: boolean;
+}
+
+// ─── State ──────────────────────────────────────────────────────
+
+const terminalRef = ref<HTMLDivElement | null>(null);
+const sessions = ref<SessionInfo[]>([]);
+const activeSessionId = ref<string | null>(null);
+const selectedTheme = ref(localStorage.getItem(STORAGE_KEY_THEME) || "default");
+const connectionError = ref<string | null>(null);
+const isConnecting = ref(false);
+const showSidebar = ref(false);
+
+let ws: WebSocket | null = null;
+const termMap = new Map<string, { term: Terminal; fitAddon: FitAddon; opened: boolean }>();
+let activeTerm: Terminal | null = null;
+let activeFitAddon: FitAddon | null = null;
+let resizeObserver: ResizeObserver | null = null;
+let reconnectAttempts = 0;
+const MAX_RECONNECT_ATTEMPTS = 3;
+
+// ─── Computed ──────────────────────────────────────────────────
+
+const activeSession = computed(
+  () => sessions.value.find((s) => s.id === activeSessionId.value) || null,
+);
+
+const themeOptions = computed(() =>
+  Object.entries(TERMINAL_THEMES).map(([key, val]) => ({
+    label: val.label,
+    value: key,
+  })),
+);
+
+const terminalBg = computed(
+  () => TERMINAL_THEMES[selectedTheme.value]?.theme.background ?? "#1a1a2e",
+);
+
+// ─── WebSocket ──────────────────────────────────────────────────
+
+function buildWsUrl(): string {
+  const token = getApiKey();
+  const base = getBaseUrlValue();
+  const wsProtocol = base
+    ? base.startsWith("https")
+      ? "wss:"
+      : "ws:"
+    : location.protocol === "https:"
+      ? "wss:"
+      : "ws:";
+
+  if (base) {
+    return `${wsProtocol}//${new URL(base).host}/api/hermes/terminal${token ? `?token=${encodeURIComponent(token)}` : ""}`;
+  }
+
+  const host = import.meta.env.DEV
+    ? `${location.hostname}:8648`
+    : location.host;
+  return `${wsProtocol}//${host}/api/hermes/terminal${token ? `?token=${encodeURIComponent(token)}` : ""}`;
+}
+
+function connect() {
+  if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+    connectionError.value = t('terminal.connectionFailed');
+    isConnecting.value = false;
+    return;
+  }
+
+  const url = buildWsUrl();
+  connectionError.value = null;
+  isConnecting.value = true;
+  reconnectAttempts++;
+
+  ws = new WebSocket(url);
+
+  ws.onopen = () => {
+    reconnectAttempts = 0;
+    isConnecting.value = false;
+    connectionError.value = null;
+    // Server auto-creates the first session
+  };
+
+  ws.onmessage = (event) => {
+    const data = typeof event.data === "string" ? event.data : "";
+    if (data.charCodeAt(0) === 0x7b) {
+      try {
+        handleControl(JSON.parse(data));
+      } catch {}
+    } else {
+      activeTerm?.write(data);
+    }
+  };
+
+  ws.onclose = (event) => {
+    isConnecting.value = false;
+
+    // 如果是正常关闭（code 1000）或认证失败，不重连
+    if (event.code === 1000 || event.code === 1003 || event.code === 1008) {
+      connectionError.value = t('terminal.connectionClosed');
+      return;
+    }
+
+    // 其他情况尝试重连
+    setTimeout(connect, 3000);
+  };
+
+  ws.onerror = (error) => {
+    console.error('[Terminal] WebSocket error:', error);
+    connectionError.value = t('terminal.connectionError');
+  };
+}
+
+function send(data: object | string) {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(typeof data === "string" ? data : JSON.stringify(data));
+}
+
+// ─── Control message handlers ──────────────────────────────────
+
+function handleControl(msg: any) {
+  switch (msg.type) {
+    case "created":
+      sessions.value.push({
+        id: msg.id,
+        shell: msg.shell,
+        pid: msg.pid,
+        title: `${msg.shell} #${sessions.value.length + 1}`,
+        createdAt: Date.now(),
+        exited: false,
+      });
+      switchSession(msg.id);
+      break;
+
+    case "exited": {
+      const s = sessions.value.find((s) => s.id === msg.id);
+      if (s) {
+        s.exited = true;
+        if (activeSessionId.value === msg.id) {
+          activeTerm?.write(
+            `\r\n\x1b[90m[${t("terminal.processExited", { code: msg.exitCode })}]\x1b[0m\r\n`,
+          );
+        }
+      }
+      break;
+    }
+
+    case "error":
+      message.error(msg.message);
+      break;
+  }
+}
+
+// ─── Session actions ────────────────────────────────────────────
+
+function createSession() {
+  send({ type: "create" });
+}
+
+function getOrCreateTerm(id: string): { term: Terminal; fitAddon: FitAddon } {
+  let entry = termMap.get(id);
+  if (!entry) {
+    const term = new Terminal({
+      cursorBlink: true,
+      fontSize: 14,
+      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      theme: { ...TERMINAL_THEMES[selectedTheme.value].theme },
+    });
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.loadAddon(new WebLinksAddon());
+    term.onData((data) => {
+      if (ws?.readyState === WebSocket.OPEN) {
+        ws.send(data);
+      }
+    });
+    entry = { term, fitAddon, opened: false };
+    termMap.set(id, entry);
+  }
+  return entry;
+}
+
+function switchSession(id: string) {
+  if (activeSessionId.value === id) return;
+  activeSessionId.value = id;
+  const entry = getOrCreateTerm(id);
+  activeTerm = entry.term;
+  activeFitAddon = entry.fitAddon;
+  mountActiveTerminal();
+  send({ type: "switch", sessionId: id });
+}
+
+function closeSession(id: string) {
+  send({ type: "close", sessionId: id });
+  sessions.value = sessions.value.filter((s) => s.id !== id);
+  const entry = termMap.get(id);
+  if (entry) {
+    entry.term.dispose();
+    termMap.delete(id);
+  }
+  if (activeSessionId.value === id) {
+    activeSessionId.value = sessions.value.length > 0 ? sessions.value[0].id : null;
+    activeTerm = null;
+    activeFitAddon = null;
+    if (activeSessionId.value) {
+      switchSession(activeSessionId.value);
+    } else {
+      unmountActiveTerminal();
+      createSession();
+    }
+  }
+}
+
+// ─── Terminal mount/unmount ─────────────────────────────────────
+
+function mountActiveTerminal() {
+  if (!terminalRef.value) return;
+  const container = terminalRef.value;
+  while (container.firstChild) container.removeChild(container.firstChild);
+
+  const entry = termMap.get(activeSessionId.value!);
+  if (!entry) return;
+
+  if (!entry.opened) {
+    entry.term.open(container);
+    entry.opened = true;
+  } else {
+    const termEl = entry.term.element;
+    if (termEl) {
+      container.appendChild(termEl);
+    }
+  }
+
+  resizeObserver?.disconnect();
+  resizeObserver = new ResizeObserver(() => {
+    tryFit();
+    sendResize();
+  });
+  resizeObserver.observe(terminalRef.value);
+
+  setTimeout(() => tryFit(), 50);
+  setTimeout(() => tryFit(), 200);
+}
+
+function unmountActiveTerminal() {
+  if (!terminalRef.value) return;
+  const container = terminalRef.value;
+  while (container.firstChild) container.removeChild(container.firstChild);
+}
+
+function tryFit() {
+  if (!activeFitAddon) return;
+  try {
+    activeFitAddon.fit();
+  } catch {}
+}
+
+function sendResize() {
+  if (!activeTerm || !ws || ws.readyState !== WebSocket.OPEN) return;
+  try {
+    send({
+      type: "resize",
+      cols: activeTerm.cols,
+      rows: activeTerm.rows,
+    });
+  } catch {}
+}
+
+// ─── Theme ───────────────────────────────────────────────────────
+
+function applyTheme(themeName: string) {
+  selectedTheme.value = themeName;
+  localStorage.setItem(STORAGE_KEY_THEME, themeName);
+  const themeObj = TERMINAL_THEMES[themeName]?.theme;
+  if (!themeObj) return;
+  for (const entry of termMap.values()) {
+    entry.term.options.theme = { ...themeObj };
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function formatTime(ts: number) {
+  const d = new Date(ts);
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+// ─── Lifecycle ──────────────────────────────────────────────────
+
+onMounted(() => {
+  connect();
+});
+
+onUnmounted(() => {
+  unmountActiveTerminal();
+  for (const entry of termMap.values()) {
+    entry.term.dispose();
+  }
+  termMap.clear();
+  activeTerm = null;
+  activeFitAddon = null;
+  ws?.close();
+  ws = null;
+});
+</script>
+
+<template>
+  <div class="terminal-panel-drawer">
+    <div
+      v-if="showSidebar"
+      class="sidebar-overlay"
+      @click="showSidebar = false"
+    ></div>
+    <div
+      class="terminal-sidebar"
+      :class="{ 'mobile-visible': showSidebar }"
+    >
+      <div class="sidebar-header">
+        <span class="sidebar-title">{{ t("terminal.sessions") }}</span>
+        <NTooltip trigger="hover">
+          <template #trigger>
+            <NButton quaternary size="tiny" @click="createSession" circle>
+              <template #icon>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <line x1="12" y1="5" x2="12" y2="19" />
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                </svg>
+              </template>
+            </NButton>
+          </template>
+          {{ t("terminal.newTab") }}
+        </NTooltip>
+      </div>
+      <div class="session-list">
+        <div v-if="connectionError" class="session-error">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          <span>{{ connectionError }}</span>
+          <NButton size="tiny" @click="connect">{{ t("common.retry") }}</NButton>
+        </div>
+        <div v-else-if="sessions.length === 0" class="session-empty">
+          <template v-if="isConnecting">
+            {{ t("common.loading") }}
+          </template>
+          <template v-else>
+            {{ t("terminal.noSessions") }}
+          </template>
+        </div>
+        <button
+          v-for="s in sessions"
+          :key="s.id"
+          class="session-item"
+          :class="{ active: s.id === activeSessionId, exited: s.exited }"
+          @click="switchSession(s.id)"
+        >
+          <div class="session-item-content">
+            <span class="session-item-title">{{ s.title }}</span>
+            <span class="session-item-meta">
+              <span class="session-item-shell">{{ s.shell }}</span>
+              <span v-if="s.exited" class="session-item-status">{{
+                t("terminal.sessionExited")
+              }}</span>
+              <span v-else class="session-item-time">{{
+                formatTime(s.createdAt)
+              }}</span>
+            </span>
+          </div>
+          <NPopconfirm v-if="sessions.length > 1" @positive-click="closeSession(s.id)">
+            <template #trigger>
+              <button class="session-item-delete" @click.stop>
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </template>
+            {{ t("terminal.closeSession") }}
+          </NPopconfirm>
+        </button>
+      </div>
+    </div>
+
+    <div class="terminal-main">
+      <header class="terminal-header">
+        <span v-if="activeSession" class="header-session-title">{{
+          activeSession.title
+        }}</span>
+        <div class="header-actions">
+          <NButton
+            size="small"
+            @click="showSidebar = !showSidebar"
+            class="sidebar-toggle"
+          >
+            <template #icon>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="3" y="3" width="18" height="18" rx="2" />
+                <line x1="9" y1="3" x2="9" y2="21" />
+              </svg>
+            </template>
+            {{ t("terminal.sessions") }}
+          </NButton>
+          <NSelect
+            :value="selectedTheme"
+            :options="themeOptions"
+            size="small"
+            :consistent-menu-width="false"
+            class="theme-select"
+            @update:value="applyTheme"
+          />
+          <NButton size="small" @click="createSession">
+            <template #icon>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+            </template>
+            {{ t("terminal.newTab") }}
+          </NButton>
+        </div>
+      </header>
+      <div class="terminal-container">
+        <div ref="terminalRef" class="terminal-xterm" :style="{ backgroundColor: terminalBg }" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use "@/styles/variables" as *;
+
+.terminal-panel-drawer {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  position: relative;
+}
+
+.sidebar-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 50;
+
+  @media (min-width: $breakpoint-mobile + 1) {
+    display: none;
+  }
+}
+
+.terminal-sidebar {
+  width: 180px;
+  border-right: 1px solid $border-color;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+
+  @media (max-width: $breakpoint-mobile) {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 80%;
+    max-width: 300px;
+    z-index: 51;
+    background: $bg-card;
+    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+
+    &.mobile-visible {
+      transform: translateX(0);
+    }
+  }
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px;
+  flex-shrink: 0;
+  border-bottom: 1px solid $border-color;
+}
+
+.sidebar-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: $text-muted;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.session-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.session-empty {
+  padding: 16px 8px;
+  font-size: 12px;
+  color: $text-muted;
+  text-align: center;
+}
+
+.session-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 20px 12px;
+  font-size: 12px;
+  color: $error;
+  text-align: center;
+
+  svg {
+    width: 32px;
+    height: 32px;
+    opacity: 0.8;
+  }
+
+  span {
+    flex: 1;
+  }
+}
+
+.session-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  background: none;
+  border-radius: $radius-sm;
+  cursor: pointer;
+  text-align: left;
+  color: $text-secondary;
+  transition: all $transition-fast;
+  margin-bottom: 2px;
+
+  &:hover {
+    background: rgba(var(--accent-primary-rgb), 0.06);
+    color: $text-primary;
+
+    .session-item-delete {
+      opacity: 1;
+    }
+  }
+
+  &.active {
+    background: rgba(var(--accent-primary-rgb), 0.1);
+    color: $text-primary;
+    font-weight: 500;
+  }
+
+  &.exited {
+    opacity: 0.5;
+  }
+}
+
+.session-item-content {
+  flex: 1;
+  overflow: hidden;
+}
+
+.session-item-title {
+  display: block;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-item-meta {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.session-item-shell {
+  font-size: 9px;
+  color: $accent-primary;
+  background: rgba(var(--accent-primary-rgb), 0.08);
+  padding: 0 4px;
+  border-radius: 3px;
+  line-height: 14px;
+}
+
+.session-item-time,
+.session-item-status {
+  font-size: 10px;
+  color: $text-muted;
+}
+
+.session-item-delete {
+  flex-shrink: 0;
+  opacity: 0.5;
+  padding: 2px;
+  border: none;
+  background: none;
+  color: $text-muted;
+  cursor: pointer;
+  border-radius: 3px;
+  transition: all $transition-fast;
+
+  &:hover {
+    color: $error;
+    background: rgba(var(--error-rgb), 0.1);
+  }
+}
+
+.terminal-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.terminal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid $border-color;
+  flex-shrink: 0;
+}
+
+.header-session-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: $text-primary;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.theme-select {
+  width: 120px;
+}
+
+.sidebar-toggle {
+  @media (min-width: $breakpoint-mobile + 1) {
+    display: none;
+  }
+}
+
+.terminal-container {
+  flex: 1;
+  margin: 8px;
+  overflow: hidden;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.terminal-xterm {
+  flex: 1;
+  border-radius: $radius-md;
+  overflow: hidden;
+  border: 1px solid $border-color;
+
+  :deep(.xterm) {
+    height: 100%;
+    padding: 8px;
+  }
+
+  :deep(.xterm-viewport) {
+    overflow-y: scroll !important;
+    scrollbar-width: none !important;
+    -ms-overflow-style: none !important;
+    background-color: transparent !important;
+  }
+
+  :deep(.xterm-viewport::-webkit-scrollbar) {
+    display: none !important;
+  }
+
+  :deep(.xterm-screen) {
+    background-color: transparent !important;
+  }
+
+  :deep(.xterm-scrollable-element) {
+    scrollbar-width: none !important;
+    -ms-overflow-style: none !important;
+  }
+
+  :deep(.xterm-scrollable-element::-webkit-scrollbar) {
+    display: none !important;
+  }
+}
+</style>

--- a/packages/client/src/components/hermes/files/FileEditor.vue
+++ b/packages/client/src/components/hermes/files/FileEditor.vue
@@ -126,6 +126,12 @@ function handleClose() {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  max-width: 300px;
+
+  @media (max-width: $breakpoint-mobile) {
+    max-width: 120px;
+    font-size: 12px;
+  }
 }
 
 .editor-container {

--- a/packages/client/src/components/hermes/files/FileToolbar.vue
+++ b/packages/client/src/components/hermes/files/FileToolbar.vue
@@ -24,17 +24,17 @@ async function handleRefresh() {
 
 <template>
   <div class="file-toolbar">
-    <NSpace>
-      <NButton size="small" @click="emit('showNewFile')">
+    <NSpace :size="8" :wrap="true" class="toolbar-space">
+      <NButton size="small" @click="emit('showNewFile')" class="toolbar-btn">
         {{ t('files.newFile') }}
       </NButton>
-      <NButton size="small" @click="emit('showNewFolder')">
+      <NButton size="small" @click="emit('showNewFolder')" class="toolbar-btn">
         {{ t('files.newFolder') }}
       </NButton>
-      <NButton size="small" @click="emit('showUpload')">
+      <NButton size="small" @click="emit('showUpload')" class="toolbar-btn">
         {{ t('files.upload') }}
       </NButton>
-      <NButton size="small" @click="handleRefresh">
+      <NButton size="small" @click="handleRefresh" class="toolbar-btn">
         {{ t('files.refresh') }}
       </NButton>
     </NSpace>
@@ -42,8 +42,31 @@ async function handleRefresh() {
 </template>
 
 <style scoped lang="scss">
+@use '@/styles/variables' as *;
+
 .file-toolbar {
   padding: 12px 16px;
   border-bottom: 1px solid var(--border-color);
+
+  @media (max-width: $breakpoint-mobile) {
+    padding: 8px 4px;
+  }
+}
+
+.toolbar-space {
+  @media (max-width: $breakpoint-mobile) {
+    :deep(.n-space) {
+      gap: 4px !important;
+    }
+  }
+}
+
+.toolbar-btn {
+  @media (max-width: $breakpoint-mobile) {
+    font-size: 12px;
+    padding: 0 8px;
+    height: 32px;
+    white-space: nowrap;
+  }
 }
 </style>

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -200,31 +200,6 @@ function openChangelog() {
         </div>
       </div>
 
-      <!-- Tools -->
-      <div class="nav-group">
-        <div class="nav-group-label" @click="toggleGroup('tools')">
-          <span>{{ t("sidebar.groupTools") }}</span>
-          <svg class="nav-group-arrow" :class="{ collapsed: isGroupCollapsed('tools') }" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <polyline points="6 9 12 15 18 9" />
-          </svg>
-        </div>
-        <div v-show="!isGroupCollapsed('tools')">
-          <button class="nav-item" :class="{ active: selectedKey === 'hermes.terminal' }" @click="handleNav('hermes.terminal')">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="4 17 10 11 4 5" />
-              <line x1="12" y1="19" x2="20" y2="19" />
-            </svg>
-            <span>{{ t("sidebar.terminal") }}</span>
-          </button>
-          <button class="nav-item" :class="{ active: selectedKey === 'hermes.files' }" @click="handleNav('hermes.files')">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
-            </svg>
-            <span>{{ t("sidebar.files") }}</span>
-          </button>
-        </div>
-      </div>
-
       <!-- System -->
       <div class="nav-group">
         <div class="nav-group-label" @click="toggleGroup('system')">

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -95,6 +95,12 @@ export default {
     noChangelog: 'Kein Anderungsprotokoll verfugbar',
   },
 
+  // Drawer
+  drawer: {
+    terminal: 'Terminal',
+    files: 'Arbeitsbereich',
+  },
+
   // Chat
   chat: {
     contextRemaining: 'übrig',
@@ -562,6 +568,10 @@ jobTriggered: 'Job ausgelost',
     closeSession: 'Diese Sitzung schliessen?',
     sessionExited: 'Beendet',
     processExited: 'Prozess beendet mit Code {code}',
+    noSessions: 'Keine Terminal-Sitzungen',
+    connectionFailed: 'Terminaldienstverbindung fehlgeschlagen',
+    connectionClosed: 'Terminalverbindung geschlossen',
+    connectionError: 'Terminalverbindungsfehler',
   },
 
   // Usage

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -105,6 +105,12 @@ export default {
     noChangelog: 'No changelog available',
   },
 
+  // Drawer
+  drawer: {
+    terminal: 'Terminal',
+    files: 'Workspace',
+  },
+
   // Chat
   chat: {
     contextRemaining: 'remaining',
@@ -622,6 +628,10 @@ export default {
     closeSession: 'Close this session?',
     sessionExited: 'Exited',
     processExited: 'Process exited with code {code}',
+    noSessions: 'No terminal sessions',
+    connectionFailed: 'Terminal service connection failed',
+    connectionClosed: 'Terminal connection closed',
+    connectionError: 'Terminal connection error',
   },
 
   // Group Chat
@@ -698,6 +708,7 @@ export default {
   // Files
   files: {
     title: 'Files',
+    fileTree: 'File Tree',
     tree: 'Directory Tree',
     list: 'File List',
     breadcrumbRoot: 'Home',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -95,6 +95,12 @@ export default {
     noChangelog: 'No hay registro de cambios',
   },
 
+  // Drawer
+  drawer: {
+    terminal: 'Terminal',
+    files: 'Espacio de trabajo',
+  },
+
   // Chat
   chat: {
     contextRemaining: 'restante',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -95,6 +95,12 @@ export default {
     noChangelog: 'Aucun journal disponible',
   },
 
+  // Drawer
+  drawer: {
+    terminal: 'Terminal',
+    files: 'Espace de travail',
+  },
+
   // Chat
   chat: {
     contextRemaining: 'restant',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -95,6 +95,12 @@ export default {
     noChangelog: '更新履歴はありません',
   },
 
+  // ドロワー
+  drawer: {
+    terminal: 'ターミナル',
+    files: 'ワークスペース',
+  },
+
   // チャット
   chat: {
     contextRemaining: '残り',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -95,6 +95,12 @@ export default {
     noChangelog: '변경 이력이 없습니다',
   },
 
+  // 서랍
+  drawer: {
+    terminal: '터미널',
+    files: '작업 공간',
+  },
+
   // 채팅
   chat: {
     contextRemaining: '남음',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -95,6 +95,12 @@ export default {
     noChangelog: 'Nenhum registro disponivel',
   },
 
+  // Gaveta
+  drawer: {
+    terminal: 'Terminal',
+    files: 'Espaço de trabalho',
+  },
+
   // Chat
   chat: {
     contextRemaining: 'restante',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -105,6 +105,12 @@ export default {
     noChangelog: '暂无更新日志',
   },
 
+  // 抽屉
+  drawer: {
+    terminal: '终端',
+    files: '工作区',
+  },
+
   // 对话
   chat: {
     contextRemaining: '剩余',
@@ -624,6 +630,10 @@ export default {
     closeSession: '关闭此会话？',
     sessionExited: '已退出',
     processExited: '进程已退出，代码 {code}',
+    noSessions: '暂无终端会话',
+    connectionFailed: '终端服务连接失败',
+    connectionClosed: '终端连接已关闭',
+    connectionError: '终端连接错误',
   },
 
   // 群聊
@@ -700,6 +710,7 @@ export default {
   // 文件管理
   files: {
     title: '文件',
+    fileTree: '文件树',
     tree: '目录树',
     list: '文件列表',
     breadcrumbRoot: '根目录',

--- a/packages/client/src/styles/global.scss
+++ b/packages/client/src/styles/global.scss
@@ -116,7 +116,7 @@ a {
   position: fixed;
   top: 16px;
   left: 12px;
-  z-index: 1001;
+  z-index: 99;
   width: 36px;
   height: 36px;
   border: none;


### PR DESCRIPTION
## Summary
- Add DrawerPanel component with Terminal and Files tabs
- Extract TerminalPanel and FilesPanel from existing views
- Add mobile sidebar toggle functionality with overlay
- Customize drawer button with semi-circle shape and rainbow arc border
- Remove Tools section from AppSidebar (Terminal/Files entries)
- Add i18n support for drawer and file tree
- Optimize mobile button layout and spacing
- Fix z-index hierarchy for proper layering
- Add responsive sidebar behavior (PC: always visible, Mobile: toggle)

## Key Features
1. **Drawer Panel**: Right-side sliding drawer with Terminal and Workspace tabs
2. **Mobile Support**: Toggle sidebars on mobile with overlay and smooth animations
3. **Custom Button**: Semi-circle button贴着右边with rainbow arc border animation
4. **Responsive Design**: Full-width drawer on mobile, optimized spacing
5. **Breathing Light**: 8s rainbow animation (红→黄→蓝→粉→蓝→紫)

## Test plan
- [x] Test drawer open/close functionality
- [x] Test mobile sidebar toggle with overlay
- [x] Verify PC sidebar visibility (always shown)
- [x] Test mobile responsiveness
- [x] Verify rainbow animation synchronization
- [x] Check z-index layering (drawer > drawer button > hamburger menu)
- [x] Test i18n translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)