### PR TITLE
fix: resolve profile switching state sync issue (#414)

### DIFF
--- a/packages/client/src/components/hermes/profiles/ProfileCard.vue
+++ b/packages/client/src/components/hermes/profiles/ProfileCard.vue
@@ -40,7 +40,9 @@ async function handleSwitch() {
   try {
     const ok = await profilesStore.switchProfile(props.profile.name)
     if (ok) {
-      window.location.reload()
+      message.success(t('profiles.switchSuccess', { name: props.profile.name }))
+      // Reload to refresh all profile-dependent data
+      setTimeout(() => window.location.reload(), 500)
     } else {
       message.error(t('profiles.switchFailed'))
     }

--- a/packages/client/src/components/layout/ProfileSelector.vue
+++ b/packages/client/src/components/layout/ProfileSelector.vue
@@ -17,14 +17,16 @@ const options = computed(() =>
 
 const activeName = computed(() => profilesStore.activeProfileName ?? '')
 
-function handleChange(value: string | number | Array<string | number>) {
+async function handleChange(value: string | number | Array<string | number>) {
   if (typeof value === 'string' && value !== activeName.value) {
-    profilesStore.switchProfile(value).then(ok => {
-      if (ok) {
-        message.success(t('profiles.switchSuccess', { name: value }))
-        window.location.reload()
-      }
-    })
+    const ok = await profilesStore.switchProfile(value)
+    if (ok) {
+      message.success(t('profiles.switchSuccess', { name: value }))
+      // Reload to refresh all profile-dependent data
+      window.location.reload()
+    } else {
+      message.error(t('profiles.switchFailed'))
+    }
   }
 }
 

--- a/packages/client/src/components/layout/ProfileSelector.vue
+++ b/packages/client/src/components/layout/ProfileSelector.vue
@@ -15,7 +15,7 @@ const options = computed(() =>
   })),
 )
 
-const activeName = computed(() => profilesStore.activeProfile?.name ?? '')
+const activeName = computed(() => profilesStore.activeProfileName ?? '')
 
 function handleChange(value: string | number | Array<string | number>) {
   if (typeof value === 'string' && value !== activeName.value) {

--- a/packages/client/src/stores/hermes/profiles.ts
+++ b/packages/client/src/stores/hermes/profiles.ts
@@ -83,7 +83,13 @@ export const useProfilesStore = defineStore('profiles', () => {
         // 不要完全依赖 fetchProfiles 的返回值，以防后端数据同步延迟
         activeProfileName.value = name
         localStorage.setItem(ACTIVE_PROFILE_STORAGE_KEY, name)
-        await fetchProfiles()
+        // 尝试刷新 profiles 列表，但不让它影响切换结果
+        try {
+          await fetchProfiles()
+        } catch (err) {
+          // fetchProfiles 失败不影响切换结果，activeProfileName 已经正确设置
+          console.warn('Failed to refresh profiles list after switch, but profile was switched successfully:', err)
+        }
       }
       return ok
     } finally {

--- a/packages/client/src/stores/hermes/profiles.ts
+++ b/packages/client/src/stores/hermes/profiles.ts
@@ -106,6 +106,7 @@ export const useProfilesStore = defineStore('profiles', () => {
             } else {
               localStorage.removeItem(ACTIVE_PROFILE_STORAGE_KEY)
             }
+            // 返回 false 以触发 UI 错误提示
             return false
           }
         } catch (err) {

--- a/packages/client/src/stores/hermes/profiles.ts
+++ b/packages/client/src/stores/hermes/profiles.ts
@@ -78,7 +78,13 @@ export const useProfilesStore = defineStore('profiles', () => {
     switching.value = true
     try {
       const ok = await profilesApi.switchProfile(name)
-      if (ok) await fetchProfiles()
+      if (ok) {
+        // 立即更新 activeProfileName，确保前端显示正确
+        // 不要完全依赖 fetchProfiles 的返回值，以防后端数据同步延迟
+        activeProfileName.value = name
+        localStorage.setItem(ACTIVE_PROFILE_STORAGE_KEY, name)
+        await fetchProfiles()
+      }
       return ok
     } finally {
       switching.value = false

--- a/packages/client/src/stores/hermes/profiles.ts
+++ b/packages/client/src/stores/hermes/profiles.ts
@@ -79,16 +79,39 @@ export const useProfilesStore = defineStore('profiles', () => {
     try {
       const ok = await profilesApi.switchProfile(name)
       if (ok) {
+        // 保存旧值，用于可能的回滚
+        const oldName = activeProfileName.value
+
         // 立即更新 activeProfileName，确保前端显示正确
         // 不要完全依赖 fetchProfiles 的返回值，以防后端数据同步延迟
         activeProfileName.value = name
         localStorage.setItem(ACTIVE_PROFILE_STORAGE_KEY, name)
-        // 尝试刷新 profiles 列表，但不让它影响切换结果
+
+        // 尝试刷新 profiles 列表并验证
         try {
           await fetchProfiles()
+
+          // 验证：检查后端返回的 active profile 是否与我们期望的一致
+          // 如果不一致，说明后端实际上没有切换成功，需要回滚
+          const actualActive = profiles.value.find(p => p.active)
+          if (actualActive && actualActive.name !== name) {
+            console.warn(
+              `[switchProfile] Backend verification failed: expected active profile "${name}", ` +
+              `but backend reports "${actualActive.name}". Rolling back frontend state.`
+            )
+            // 回滚到旧值
+            activeProfileName.value = oldName
+            if (oldName) {
+              localStorage.setItem(ACTIVE_PROFILE_STORAGE_KEY, oldName)
+            } else {
+              localStorage.removeItem(ACTIVE_PROFILE_STORAGE_KEY)
+            }
+            return false
+          }
         } catch (err) {
-          // fetchProfiles 失败不影响切换结果，activeProfileName 已经正确设置
-          console.warn('Failed to refresh profiles list after switch, but profile was switched successfully:', err)
+          // fetchProfiles 失败，无法验证
+          // 假设切换成功（API 返回了 200），保持已设置的状态
+          console.warn('Failed to refresh profiles list after switch, assuming switch succeeded:', err)
         }
       }
       return ok

--- a/tests/client/profiles-store.test.ts
+++ b/tests/client/profiles-store.test.ts
@@ -103,4 +103,20 @@ describe('Profiles Store', () => {
     await switchPromise
     expect(store.switching).toBe(false)
   })
+
+  it('switchProfile updates activeProfileName immediately', async () => {
+    mockProfilesApi.switchProfile.mockResolvedValue(true)
+    mockProfilesApi.fetchProfiles.mockResolvedValue([
+      { name: 'default', active: false, model: 'gpt-4', gateway: 'stopped', alias: '' },
+      { name: 'dev', active: true, model: 'gpt-4', gateway: 'running', alias: '' },
+    ])
+
+    const store = useProfilesStore()
+    await store.switchProfile('dev')
+
+    // activeProfileName should be updated immediately
+    expect(store.activeProfileName).toBe('dev')
+    // localStorage should also be updated
+    expect(localStorage.getItem('hermes_active_profile_name')).toBe('dev')
+  })
 })

--- a/tests/client/profiles-store.test.ts
+++ b/tests/client/profiles-store.test.ts
@@ -119,4 +119,41 @@ describe('Profiles Store', () => {
     // localStorage should also be updated
     expect(localStorage.getItem('hermes_active_profile_name')).toBe('dev')
   })
+
+  it('switchProfile does not update state when API fails', async () => {
+    const initialName = 'default'
+    localStorage.setItem('hermes_active_profile_name', initialName)
+
+    mockProfilesApi.switchProfile.mockResolvedValue(false)  // API failed
+
+    const store = useProfilesStore()
+    store.activeProfileName = initialName
+    const result = await store.switchProfile('dev')
+
+    // Should return false
+    expect(result).toBe(false)
+    // activeProfileName should NOT change
+    expect(store.activeProfileName).toBe(initialName)
+    // localStorage should NOT change
+    expect(localStorage.getItem('hermes_active_profile_name')).toBe(initialName)
+  })
+
+  it('switchProfile keeps activeProfileName even if fetchProfiles fails', async () => {
+    const initialName = 'default'
+    localStorage.setItem('hermes_active_profile_name', initialName)
+
+    mockProfilesApi.switchProfile.mockResolvedValue(true)
+    mockProfilesApi.fetchProfiles.mockRejectedValue(new Error('Network error'))
+
+    const store = useProfilesStore()
+    store.activeProfileName = initialName
+    const result = await store.switchProfile('dev')
+
+    // Should return true (API succeeded)
+    expect(result).toBe(true)
+    // activeProfileName should be updated even though fetchProfiles failed
+    expect(store.activeProfileName).toBe('dev')
+    // localStorage should be updated
+    expect(localStorage.getItem('hermes_active_profile_name')).toBe('dev')
+  })
 })

--- a/tests/client/profiles-store.test.ts
+++ b/tests/client/profiles-store.test.ts
@@ -156,4 +156,27 @@ describe('Profiles Store', () => {
     // localStorage should be updated
     expect(localStorage.getItem('hermes_active_profile_name')).toBe('dev')
   })
+
+  it('switchProfile rolls back if backend reports different active profile', async () => {
+    const initialName = 'default'
+    localStorage.setItem('hermes_active_profile_name', initialName)
+
+    mockProfilesApi.switchProfile.mockResolvedValue(true)
+    // Backend returns success, but active profile is still default (not the one we switched to)
+    mockProfilesApi.fetchProfiles.mockResolvedValue([
+      { name: 'default', active: true, model: 'gpt-4', gateway: 'running', alias: '' },
+      { name: 'dev', active: false, model: 'gpt-4', gateway: 'stopped', alias: '' },
+    ])
+
+    const store = useProfilesStore()
+    store.activeProfileName = initialName
+    const result = await store.switchProfile('dev')
+
+    // Should return false (backend verification failed)
+    expect(result).toBe(false)
+    // activeProfileName should be rolled back to default
+    expect(store.activeProfileName).toBe('default')
+    // localStorage should be rolled back
+    expect(localStorage.getItem('hermes_active_profile_name')).toBe('default')
+  })
 })


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes #414 - Profile switching display sync issue

### Problem

When switching to a different profile (e.g., from `default` to `qinghe`):
- ❌ UI still showed `default` as the active profile
- ❌ Unable to switch back to `default` profile
- ❌ Console error: `chat.sessionNotFound`

### Root Cause

The frontend relied entirely on `fetchProfiles()` return value to determine the active profile. However, the backend Hermes CLI may return stale `active` flags due to timing issues:

1. `hermes profile use <name>` writes to `~/.hermes/active_profile`
2. `hermes profile list` reads the active profile file
3. File system caching or internal CLI state caching may cause `list` to return old data
4. Frontend receives wrong `active` flag and sets `activeProfileName` incorrectly

### Solution

**Immediate state update + Backend verification**: Set `activeProfileName` immediately when `switchProfile()` API succeeds, then verify with backend.

```typescript
// Before: relied entirely on fetchProfiles() result
async function switchProfile(name: string) {
  const ok = await profilesApi.switchProfile(name)
  if (ok) await fetchProfiles()  // ⚠️ Might have stale data
}

// After: set immediately, then verify with backend
async function switchProfile(name: string) {
  const ok = await profilesApi.switchProfile(name)
  if (ok) {
    const oldName = activeProfileName.value
    // ✅ Set immediately based on user action
    activeProfileName.value = name
    localStorage.setItem(ACTIVE_PROFILE_STORAGE_KEY, name)
    
    // Verify with backend
    try {
      await fetchProfiles()
      const actualActive = profiles.value.find(p => p.active)
      if (actualActive && actualActive.name !== name) {
        // ⚠️ Backend didn't actually switch, rollback
        activeProfileName.value = oldName
        localStorage.setItem(ACTIVE_PROFILE_STORAGE_KEY, oldName)
        return false
      }
    } catch {
      // fetchProfiles failed, assume success (API returned 200)
    }
  }
  return ok
}
```

### Error Handling

Comprehensive handling for all scenarios:

| Scenario | API Result | fetchProfiles | Backend Verification | activeProfileName | Result |
|----------|-----------|---------------|---------------------|-------------------|--------|
| Normal success | ✅ 200 | ✅ success | ✅ matches | Updated | ✅ Success |
| fetchProfiles fails | ✅ 200 | ❌ error | N/A | Updated | ✅ Success (assumed) |
| Backend verification fails | ✅ 200 | ✅ success | ❌ mismatch | **Rolled back** | ✅ Returns false |
| API fails | ❌ 4xx/5xx | N/A | N/A | Unchanged | ✅ Returns false |

**Rollback mechanism**: If API returns success but backend reports a different active profile, frontend state is rolled back to prevent UI showing wrong profile.

### Changes

- **profiles store**: 
  - Set `activeProfileName` immediately after successful `switchProfile` API call
  - Add backend verification after `fetchProfiles()`
  - Rollback frontend state if verification fails
  - Add try-catch for `fetchProfiles()` to handle failures gracefully
- **ProfileSelector**: Use `activeProfileName` instead of `activeProfile?.name` for consistency
- **Tests**: Add 3 test cases covering all failure scenarios and rollback

### Testing

✅ All 10 tests pass (6 existing + 4 new)
- Normal switch with immediate state update
- API failure doesn't change state
- fetchProfiles failure keeps switch result
- Backend verification mismatch triggers rollback

✅ Manual testing in Docker environment confirmed fix

### Note on deleteProfile

`deleteProfile` also calls `fetchProfiles()` but doesn't need the same rollback mechanism because:
- Frontend prevents deleting active profile (button disabled)
- Even if fetchProfiles returns stale data, only the list is wrong, not the active profile state
- Much lower impact than switchProfile

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)