### PR TITLE
fix: improve profile list parsing to handle long profile names (#423)

### DIFF
--- a/packages/server/src/services/hermes/gateway-manager.ts
+++ b/packages/server/src/services/hermes/gateway-manager.ts
@@ -346,7 +346,7 @@ export class GatewayManager {
       const profiles: string[] = []
       for (const line of stdout.trim().split('\n')) {
         if (line.startsWith(' Profile') || line.match(/^ ─/)) continue
-        const match = line.match(/^\s+(?:◆)?(\S+)\s{2,}/)
+        const match = line.match(/^\s+(?:◆)?(.+?)\s+/)
         if (match) profiles.push(match[1])
       }
       return profiles

--- a/packages/server/src/services/hermes/hermes-cli.ts
+++ b/packages/server/src/services/hermes/hermes-cli.ts
@@ -394,7 +394,7 @@ export async function listProfiles(): Promise<HermesProfile[]> {
     for (const line of lines) {
       if (line.startsWith(' Profile') || line.match(/^ ─/)) continue
 
-      const match = line.match(/^\s+(◆)?(\S+)\s{2,}(\S+)\s{2,}(\S+)\s{2,}(.*)$/)
+      const match = line.match(/^\s+(◆)?(.+?)\s+(\S+)\s{2,}(\S+)\s{2,}(.*)$/)
       if (match) {
         profiles.push({
           name: match[2],


### PR DESCRIPTION
## Summary
Fixes issues #423 and #417 where long profile names were omitted from the Profiles page due to fragile Hermes profile list table parsing.

## Root cause
The Web UI parses the text table output of `hermes profile list` with a regex that requires at least two spaces between columns:
```regex
/^\s+(◆)?(\S+)\s{2,}(\S+)\s{2,}(\S+)\s{2,}(.*)$/
```

For long profile names, the Hermes CLI table can overflow the expected column width and output only one space between the profile name and model columns, causing the regex to fail and the profile to be silently dropped.

## Changes
- **gateway-manager.ts**: Use `.+?` instead of `\S+` to match profile names, allowing names that overflow table column width
- **hermes-cli.ts**: Use `\s+` instead of `\s{2,}` for the first delimiter to handle cases where long profile names reduce spacing to 1 space

The new regex:
```regex
/^\s+(◆)?(.+?)\s+(\S+)\s{2,}(\S+)\s{2,}(.*)$/
```

## Test plan
- [x] Run existing profile store tests (all 10 tests pass)
- [x] Build project successfully with no type errors
- [ ] Manual testing with long profile names (e.g., `opportunity-researcher`)

## Example
Before: `opportunity-researcher gpt-5.5 stopped` → parsing failed (only 1 space)
After: `opportunity-researcher gpt-5.5 stopped` → parsing succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)