### PR TITLE
fix(profiles): derive active flag from GatewayManager in /api/hermes/profiles

### DIFF
--- a/packages/server/src/controllers/hermes/profiles.ts
+++ b/packages/server/src/controllers/hermes/profiles.ts
@@ -11,6 +11,15 @@ import { smartCloneCleanup } from '../../services/hermes/profile-credentials'
 export async function list(ctx: any) {
   try {
     const profiles = await hermesCli.listProfiles()
+    const mgr = getGatewayManagerInstance()
+    const activeProfile = mgr?.getActiveProfile?.() || null
+
+    if (activeProfile) {
+      for (const profile of profiles) {
+        profile.active = profile.name === activeProfile
+      }
+    }
+
     ctx.body = { profiles }
   } catch (err: any) {
     ctx.status = 500

--- a/tests/server/profiles-controller.test.ts
+++ b/tests/server/profiles-controller.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+async function loadProfilesController(options?: {
+  profiles?: Array<{ name: string; active: boolean; model?: string; gateway?: string; alias?: string }>
+  activeProfile?: string | null
+}) {
+  vi.resetModules()
+
+  vi.doMock('../../packages/server/src/services/hermes/hermes-cli', () => ({
+    listProfiles: vi.fn().mockResolvedValue(options?.profiles ?? []),
+  }))
+
+  vi.doMock('../../packages/server/src/services/gateway-bootstrap', () => ({
+    getGatewayManagerInstance: vi.fn(() => {
+      if (options?.activeProfile === undefined) return null
+      return {
+        getActiveProfile: () => options.activeProfile,
+      }
+    }),
+  }))
+
+  return import('../../packages/server/src/controllers/hermes/profiles')
+}
+
+function createMockCtx() {
+  return {
+    status: 200,
+    body: null as any,
+  }
+}
+
+describe('profiles controller list()', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('overrides stale active flags using GatewayManager active profile', async () => {
+    const { list } = await loadProfilesController({
+      profiles: [
+        { name: 'default', active: true, model: 'gpt-5.4', gateway: 'running', alias: '' },
+        { name: 'secondary', active: false, model: 'gpt-5.4', gateway: 'running', alias: 'secondary' },
+      ],
+      activeProfile: 'secondary',
+    })
+    const ctx = createMockCtx()
+
+    await list(ctx)
+
+    expect(ctx.body).toEqual({
+      profiles: [
+        { name: 'default', active: false, model: 'gpt-5.4', gateway: 'running', alias: '' },
+        { name: 'secondary', active: true, model: 'gpt-5.4', gateway: 'running', alias: 'secondary' },
+      ],
+    })
+  })
+
+  it('keeps CLI flags unchanged when no gateway manager is available', async () => {
+    const { list } = await loadProfilesController({
+      profiles: [
+        { name: 'default', active: true, model: 'gpt-5.4', gateway: 'running', alias: '' },
+        { name: 'secondary', active: false, model: 'gpt-5.4', gateway: 'running', alias: 'secondary' },
+      ],
+    })
+    const ctx = createMockCtx()
+
+    await list(ctx)
+
+    expect(ctx.body).toEqual({
+      profiles: [
+        { name: 'default', active: true, model: 'gpt-5.4', gateway: 'running', alias: '' },
+        { name: 'secondary', active: false, model: 'gpt-5.4', gateway: 'running', alias: 'secondary' },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
## Summary

This fixes a backend consistency issue in `/api/hermes/profiles`.

After switching profiles, the frontend may already reflect the new profile locally,
but the backend profiles API can still report the wrong `active` flag because it relies
only on `hermes profile list` output.

In practice this can leave the UI and API out of sync:
- profile switch API returns success
- `/health` is `ok`
- but `/api/hermes/profiles` may still mark `default` as active

## Root cause

`packages/server/src/controllers/hermes/profiles.ts:list()` currently returns the raw
result from `hermesCli.listProfiles()`.

That parser depends on the CLI `◆` marker from `hermes profile list`, but the Web UI
already has a stronger runtime truth source: `GatewayManager.getActiveProfile()`.

## Fix

In `list()`:
- fetch profiles from `hermesCli.listProfiles()`
- read the active profile from `getGatewayManagerInstance()?.getActiveProfile?.()`
- override each returned `profile.active` before responding

This keeps the API consistent with the currently active runtime profile managed by Web UI.

## Why this belongs in backend too

#415 improved frontend state sync, but `/api/hermes/profiles` is still used as a source
of truth during refresh and verification. If the backend returns stale `active`, clients
still see conflicting state.

This patch makes the backend response authoritative and aligned with the running gateway manager.

## Tests

- added a server-side test covering stale CLI flags overridden by `GatewayManager`
- added a server-side test covering the fallback path when no gateway manager is available

## Scope

Small backend-only change.
No behavior change except correcting API state.
