### PR TITLE
feat: Enhance Markdown Media Rendering (Image/Video/File Support)

### DIFF
--- a/docs/AI_OUTPUT_FORMAT_GUIDE.md
+++ b/docs/AI_OUTPUT_FORMAT_GUIDE.md
@@ -1,0 +1,143 @@
+# AI 输出格式规范
+
+为了让前端正确渲染大模型返回的图片、文件等内容，需要在系统提示词中定义以下格式约束。
+
+## 系统提示词模板
+
+将以下内容添加到你的系统提示词或 Agent 配置中：
+
+```
+当你的回复中包含图片或文件引用时，请遵循以下格式规范：
+
+## 图片格式
+使用 Markdown 图片语法，路径必须是本地绝对路径（以 / 开头）：
+`
+![图片描述](/tmp/screenshot.png)
+`
+示例：
+`
+![Sub2API Dashboard](/tmp/sub2api-dashboard.png)
+`
+
+## 文件链接格式
+使用 Markdown 链接语法，路径必须是本地绝对路径（以 / 开头）：
+[文件名](/tmp/report.pdf)
+示例：
+[下载报告](/tmp/monthly-report.pdf)
+
+## 注意事项
+1. 图片和文件路径必须以 / 开头的绝对路径
+2. 图片会自动显示在对话中
+3. 文件链接点击后会自动下载
+4. 不要使用相对路径（如 ./file.png）
+5. 不要使用 http:// 或 https:// 开头的远程链接表示本地文件
+```
+
+## 完整示例
+
+### 推荐：添加到 Hermes 配置文件
+
+在你的 Hermes 配置文件（`~/.hermes/config.yaml` 或项目配置）中添加：
+
+```yaml
+agents:
+  your_agent_name:
+    system_prompt: |
+      你是一个智能助手。
+
+      当你的回复中包含图片或文件引用时，请遵循以下格式规范：
+
+      ## 图片格式
+      使用 Markdown 图片语法：
+      ![图片描述](/tmp/screenshot.png)
+
+      ## 文件链接格式
+      使用 Markdown 链接语法：
+      [文件名](/tmp/report.pdf)
+
+      ## 注意事项
+      - 图片和文件路径必须以 / 开头的绝对路径
+      - 图片会自动显示在对话中
+      - 文件链接点击后会自动下载
+```
+
+### 或者：在 Web UI 中配置
+
+1. 打开 Hermes Web UI
+2. 进入 **Settings** → **Model Settings**
+3. 在 **System Instructions** 或 **Agent Instructions** 中添加上述提示词内容
+
+## 支持的内容格式
+
+| 类型 | Markdown 语法 | 前端渲染效果 |
+|------|--------------|------------|
+| 🖼️ 图片 | `
+![描述](/tmp/file.png)
+` | 自动显示图片，通过 download 接口加载 |
+| 📄 文件下载 | `[文件名](/tmp/file.pdf)` | 可点击链接，点击后下载文件 |
+| 🔗 外部链接 | `[文本](https://example.com)` | 在新标签页打开 |
+| 💻 代码块 | ` ```language\ncode\n``` ` | 语法高亮显示，支持一键复制 |
+
+## 调试技巧
+
+如果图片或文件没有正确显示，检查：
+
+1. **路径格式**：确保路径以 `/` 开头（如 `/tmp/file.png`）
+2. **Markdown 语法**：确保使用正确的 Markdown 语法
+3. **文件存在**：确保文件确实存在于服务器上
+4. **下载接口**：检查 `/api/hermes/download` 接口是否正常工作
+
+## 示例对话
+
+### 正确格式 ✅
+
+**用户**：帮我截个屏
+**AI**：
+```
+截图成功！这是当前页面的截图：
+
+![Screenshot](//tmp/screenshot-20250104-143020.png)
+```
+
+### 错误格式 ❌
+
+**AI**：
+```
+截图保存在 /tmp/screenshot.png
+```
+→ 这不会显示图片，因为没有使用 Markdown 图片语法
+
+## 高级用法
+
+### ContentBlock 格式
+
+如果需要更复杂的消息结构，可以使用 JSON ContentBlock 格式：
+
+```json
+[
+  {
+    "type": "text",
+    "text": "这是分析结果："
+  },
+  {
+    "type": "image",
+    "name": "screenshot.png",
+    "path": "/tmp/screenshot.png",
+    "media_type": "image/png"
+  },
+  {
+    "type": "file",
+    "name": "report.pdf",
+    "path": "/tmp/report.pdf",
+    "media_type": "application/pdf"
+  }
+]
+```
+
+前端会自动解析并渲染这种格式。
+
+## 相关文件
+
+- 前端渲染逻辑：`packages/client/src/components/hermes/chat/MarkdownRenderer.vue`
+- 下载接口：`packages/server/src/controllers/hermes/sessions.ts`
+- API 层：`packages/client/src/api/hermes/download.ts`

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -61,13 +61,13 @@ const renderedHtml = computed(() => {
 
   // Replace image src paths with download URLs
   // Replace both src="/path" and src='/path' formats
-  html = html.replace(/src="\/([^"]+)"/g, (match, path) => {
+  html = html.replace(/src="\/([^"]+)"/g, (_match, path) => {
     const originalPath = '/' + path
     const downloadUrl = getDownloadUrl(originalPath)
     return `src="${downloadUrl}"`
   })
 
-  html = html.replace(/src='\/([^']+)'/g, (match, path) => {
+  html = html.replace(/src='\/([^']+)'/g, (_match, path) => {
     const originalPath = '/' + path
     const downloadUrl = getDownloadUrl(originalPath)
     return `src='${downloadUrl}'`

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -14,7 +14,7 @@ import {
   isMermaidFence,
   renderMermaidPlaceholder,
 } from './mermaidRenderer'
-import { downloadFile } from '@/api/hermes/download'
+import { downloadFile, getDownloadUrl } from '@/api/hermes/download'
 
 const props = withDefaults(defineProps<{
     content: string
@@ -52,11 +52,65 @@ md.renderer.rules.fence = (tokens, idx, options, env, self) => {
 
 const markdownBody = ref<HTMLElement | null>(null)
 const componentId = `hermes-mermaid-${Math.random().toString(36).slice(2)}`
+const previewUrl = ref<string | null>(null)
 let renderGeneration = 0
 let unmounted = false
 
 const renderedHtml = computed(() => {
   let html = md.render(repairNestedMarkdownFences(props.content))
+
+  // Replace image src paths with download URLs
+  // Replace both src="/path" and src='/path' formats
+  html = html.replace(/src="\/([^"]+)"/g, (match, path) => {
+    const originalPath = '/' + path
+    const downloadUrl = getDownloadUrl(originalPath)
+    return `src="${downloadUrl}"`
+  })
+
+  html = html.replace(/src='\/([^']+)'/g, (match, path) => {
+    const originalPath = '/' + path
+    const downloadUrl = getDownloadUrl(originalPath)
+    return `src='${downloadUrl}'`
+  })
+
+  // Replace local file links with file card UI or video player
+  // Match <a href="/tmp/file.pdf">filename</a> or <a href="/tmp/video.mp4">filename</a>
+  html = html.replace(/<a href="(\/[^"]+)">([^<]+)<\/a>/g, (match, path, filename) => {
+    // Only replace local file paths (starting with /)
+    if (!path.startsWith('/')) return match
+
+    const fileName = filename.trim()
+    const ext = path.split('.').pop()?.toLowerCase()
+
+    // Video files: render as video player
+    if (ext === 'mp4' || ext === 'webm') {
+      const downloadUrl = getDownloadUrl(path)
+      return `<div class="markdown-video-container">
+        <video class="markdown-video" controls preload="metadata" src="${downloadUrl}"></video>
+        <div class="markdown-video-footer">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+            <polygon points="5 3 19 12 5 21 5 3"/>
+          </svg>
+          <span class="att-name">${fileName}</span>
+        </div>
+      </div>`
+    }
+
+    // Other files: render as file card
+    return `<div class="markdown-file-card" data-path="${path}" data-filename="${fileName}" title="${t('download.downloadFile')}">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+      </svg>
+      <span class="att-name">${fileName}</span>
+      <svg class="att-download-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+        <polyline points="7 10 12 15 17 10" />
+        <line x1="12" y1="15" x2="12" y2="3" />
+      </svg>
+    </div>`
+  })
+
   if (props.mentionNames && props.mentionNames.length > 0) {
     const escaped = props.mentionNames.map(n => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
     const re = new RegExp(`(?<=[\\s>]|^)@(${escaped.join('|')})(?=\\s|$)`, 'gi')
@@ -210,8 +264,33 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
     return
   }
 
-  // Handle file path link clicks for download
   const target = event.target as HTMLElement
+
+  // Handle image clicks for preview
+  const img = target.closest('img') as HTMLImageElement | null
+  if (img) {
+    event.preventDefault()
+    previewUrl.value = img.src
+    return
+  }
+
+  // Handle file card clicks for download
+  const fileCard = target.closest('.markdown-file-card') as HTMLElement | null
+  if (fileCard) {
+    event.preventDefault()
+    event.stopPropagation()
+    const path = fileCard.getAttribute('data-path')
+    const fileName = fileCard.getAttribute('data-filename')
+    if (path) {
+      message.info(t('download.downloading'))
+      downloadFile(path, fileName || undefined).catch((err: Error) => {
+        message.error(err.message || t('download.downloadFailed'))
+      })
+    }
+    return
+  }
+
+  // Handle file path link clicks for download
   const link = target.closest('a') as HTMLAnchorElement | null
   if (!link) return
 
@@ -242,6 +321,11 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
 
 <template>
   <div ref="markdownBody" class="markdown-body" v-html="renderedHtml" @click="handleMarkdownClick"></div>
+  <Teleport to="body">
+    <div v-if="previewUrl" class="image-preview-overlay" @click.self="previewUrl = null">
+      <img :src="previewUrl" class="image-preview-img" @click="previewUrl = null" />
+    </div>
+  </Teleport>
 </template>
 
 <style lang="scss">
@@ -288,6 +372,86 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
 
     &:hover {
       color: $accent-hover;
+    }
+  }
+
+  img {
+    display: block;
+    max-width: 200px;
+    max-height: 160px;
+    object-fit: contain;
+    cursor: pointer;
+    border-radius: 4px;
+    margin: 8px 0;
+  }
+
+  .markdown-video-container {
+    margin: 12px 0;
+    border-radius: $radius-sm;
+    overflow: hidden;
+    background: #000;
+    border: 1px solid $border-color;
+  }
+
+  .markdown-video {
+    display: block;
+    width: 100%;
+    max-width: 640px;
+    max-height: 480px;
+    object-fit: contain;
+  }
+
+  .markdown-video-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: rgba(0, 0, 0, 0.85);
+    color: #fff;
+    font-size: 12px;
+
+    .att-name {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .markdown-file-card {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    font-size: 12px;
+    color: $text-secondary;
+    background-color: rgba(0, 0, 0, 0.04);
+    border: 1px solid $border-light;
+    border-radius: $radius-sm;
+    margin: 8px 0;
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.08);
+      border-color: $border-color;
+    }
+
+    .att-name {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 160px;
+    }
+
+    .att-download-icon {
+      flex-shrink: 0;
+      opacity: 0.6;
+      transition: opacity 0.15s ease;
+    }
+
+    &:hover .att-download-icon {
+      opacity: 1;
     }
   }
 
@@ -363,5 +527,24 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
     align-items: center;
     justify-content: center;
   }
+}
+
+.image-preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.image-preview-img {
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: 4px;
+  cursor: pointer;
 }
 </style>

--- a/packages/server/src/lib/llm-prompt.ts
+++ b/packages/server/src/lib/llm-prompt.ts
@@ -1,0 +1,74 @@
+/**
+ * LLM System Prompts and Instructions
+ *
+ * This module contains system prompts and format guidelines for LLM agents.
+ * These prompts ensure that AI outputs are correctly rendered by the frontend.
+ */
+
+/**
+ * System prompt for AI output format guidelines
+ * Add this to your agent's system prompt to ensure proper formatting
+ */
+export const AI_OUTPUT_FORMAT_GUIDELINES = `
+# 输出格式规范
+
+当你的回复中包含图片、视频或文件引用时，请遵循以下格式规范：
+
+## 图片格式
+使用 Markdown 图片语法，路径必须是本地绝对路径（以 / 开头）：
+\`\`\`
+![图片描述](/tmp/screenshot.png)
+\`\`\`
+示例：
+\`\`\`
+![Sub2API Dashboard](/tmp/sub2api-dashboard.png)
+\`\`\`
+
+## 视频格式
+使用 Markdown 链接语法，路径必须是本地绝对路径（以 / 开头），支持的格式：mp4, webm
+\`\`\`
+[视频名称](/tmp/recording.mp4)
+\`\`\`
+示例：
+\`\`\`
+[屏幕录制](/tmp/screen-recording.mp4)
+[操作演示](/tmp/demo.webm)
+\`\`\`
+
+## 文件链接格式
+使用 Markdown 链接语法，路径必须是本地绝对路径（以 / 开头）：
+\`\`\`
+[文件名](/tmp/report.pdf)
+\`\`\`
+示例：
+\`\`\`
+[下载报告](/tmp/monthly-report.pdf)
+\`\`\`
+
+## 注意事项
+1. 图片和文件路径必须以 / 开头的绝对路径
+2. 图片会自动显示在对话中，缩略图尺寸 200x160px
+3. 视频和文件链接点击后会自动下载
+4. 视频文件大小建议不超过 200MB
+5. 不要使用相对路径（如 ./file.png）
+6. 不要使用 http:// 或 https:// 开头的远程链接表示本地文件
+7. 视频支持格式：.mp4, .webm
+`;
+
+/**
+ * Get the complete system prompt with format guidelines
+ * @param customPrompt - Optional custom system prompt to prepend
+ * @returns Complete system prompt string
+ */
+export function getSystemPrompt(customPrompt?: string): string {
+  const parts: string[] = [];
+
+  if (customPrompt) {
+    parts.push(customPrompt);
+  }
+
+  parts.push(AI_OUTPUT_FORMAT_GUIDELINES);
+
+  return parts.join('\n\n');
+}
+

--- a/packages/server/src/services/hermes/file-provider.ts
+++ b/packages/server/src/services/hermes/file-provider.ts
@@ -9,8 +9,8 @@ import { getActiveProfileDir, getActiveEnvPath } from './hermes-profile'
 
 const execFileAsync = promisify(execFile)
 
-// Max download file size (default 100MB)
-const MAX_DOWNLOAD_SIZE = parseInt(process.env.MAX_DOWNLOAD_SIZE || '', 10) || 100 * 1024 * 1024
+// Max download file size (default 200MB)
+const MAX_DOWNLOAD_SIZE = parseInt(process.env.MAX_DOWNLOAD_SIZE || '', 10) || 200 * 1024 * 1024
 // Backend command timeout (default 30s)
 const BACKEND_TIMEOUT = 30_000
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive media rendering support for AI responses in the chat interface, enabling images, videos, and files to be displayed as interactive elements instead of plain text links.

## Changes

### Frontend (MarkdownRenderer.vue)
- **Image Display**: Images render as 200x160px thumbnails with click-to-fullscreen preview
- **Video Playback**: Native HTML5 video player for `.mp4` and `.webm` files (640x480 max)
- **File Cards**: Downloadable files display as styled cards with file icon and download button
- **Auto-Conversion**: Local file paths (`/tmp/*`) automatically convert to authenticated download URLs

### Backend (llm-prompt.ts & file-provider.ts)
- **System Prompt Module**: New `llm-prompt.ts` with AI output format guidelines
- **Increased File Size Limit**: Max download size raised from 100MB to 200MB
- **Format Guidelines**: Structured prompts for AI to follow when returning media

### Documentation
- **AI Output Format Guide**: Complete documentation for media format conventions

## Test Plan
- [ ] Image display and preview functionality
- [ ] Video playback for .mp4 and .webm files
- [ ] File card display and download
- [ ] Large file downloads (>100MB)
- [ ] AI follows format guidelines in responses

## Examples

### Before (plain text)
```
Download the report: /tmp/report.pdf
View screenshot: /tmp/screenshot.png
```

### After (interactive media)
- Images show as clickable thumbnails
- Videos embed with native player controls
- Files display as download cards with icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)