### PR TITLE
feat: automate Docker image build on GitHub release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,7 +1,9 @@
 name: Build and Push Docker Image to Docker Hub
 
 on:
-  workflow_dispatch:    # 仅手动触发
+  workflow_dispatch:    # 手动触发
+  release:
+    types: [published]  # 发布 release 时自动触发
 
 jobs:
   build-and-push:
@@ -38,3 +40,4 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:${{ github.sha }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:${{ github.ref_name || github.event.release.tag_name }}


### PR DESCRIPTION
## Summary

- Add `release:published` trigger to auto-build Docker images when releases are published
- Add versioned tags (e.g., `:v0.5.9`) alongside `:latest` and commit SHA tags
- Users can now pin specific versions in docker-compose.yml

## Type of Change

- [x] Feature (new functionality)

## Changes

- Modified `.github/workflows/docker-publish.yml` to trigger on GitHub release publication
- Added version tag support using `github.ref_name` (resolves to `v0.5.9`, `v0.5.10`, etc.)
- Users can now use `image: ekkoye8888/hermes-web-ui:v0.5.9` to pin specific versions

## Test Plan

- [x] Build passes (`npm run build`)
- [ ] Tested manually (will be tested when merged and next release is published)

## Related Issues

Resolves #441

## Example Usage

After this PR is merged, users can pin specific versions:

```yaml
# docker-compose.yml
services:
  hermes-webui:
    image: ekkoye8888/hermes-web-ui:v0.5.9  # Fixed version
    # or
    image: ekkoye8888/hermes-web-ui:latest  # Always latest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)