### PR TITLE
[codex] Clean chat frontend debug logs

### DIFF
--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -367,13 +367,9 @@ const isPausedThisMessage = computed(() => {
 
 function handleSpeechToggle() {
   if (!canPlaySpeech.value) {
-    console.log('Speech not supported or no content')
     return
   }
   const content = props.message.content || ''
-  console.log('Toggling speech for message:', props.message.id)
-  console.log('Current playing:', speech.currentMessageId.value, speech.isPlaying.value)
-  console.log('Call stack:', new Error().stack)
 
   // 尝试获取男声语音包
   const allVoices = speech.getAllVoices()
@@ -397,8 +393,6 @@ function handleSpeechToggle() {
     }
   }
 
-  console.log('Selected male voice:', maleVoice?.name, maleVoice?.lang)
-
   // 快速男声：语速快、音调低
   speech.toggle(props.message.id, content, {
     pitch: 0.5,   // 低沉
@@ -414,7 +408,6 @@ onMounted(() => {
   autoPlayHandler = (e: Event) => {
     const customEvent = e as CustomEvent<{ messageId: string; content: string }>
     if (customEvent.detail.messageId === props.message.id && canPlaySpeech.value) {
-      console.log('Auto-play triggered for message:', props.message.id)
       handleSpeechToggle()
     }
   }

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -637,10 +637,8 @@ export const useChatStore = defineStore('chat', () => {
 
       // Helper to clean up this session's stream state
       const cleanup = () => {
-        console.log('[sendMessage] cleanup called, deleting stream state for sid:', sid)
         streamStates.value.delete(sid)
         serverWorking.value.delete(sid)
-        console.log('[sendMessage] cleanup done, isStreaming now:', isStreaming.value)
       }
 
       // Per-run flags used to detect silently-swallowed errors at run.completed.
@@ -692,13 +690,11 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'abort.started': {
-              console.log('[chat abort] pause started', evt)
               setAbortState({ aborting: true, synced: null })
               break
             }
 
             case 'abort.completed': {
-              console.log('[chat abort] pause completed', evt)
               setAbortState({ aborting: false, synced: (evt as any).synced ?? false })
               const msgs = getSessionMsgs(sid)
               const lastMsg = msgs[msgs.length - 1]
@@ -903,7 +899,6 @@ export const useChatStore = defineStore('chat', () => {
               }
 
               // 自动播放语音
-              console.log('[run.completed] autoPlaySpeechEnabled:', autoPlaySpeechEnabled.value)
               if (autoPlaySpeechEnabled.value) {
                 const msgs = getSessionMsgs(sid)
                 const lastAssistant = [...msgs].reverse().find(m => m.role === 'assistant')
@@ -958,7 +953,6 @@ export const useChatStore = defineStore('chat', () => {
         },
         // onDone
         () => {
-          console.log('[sendMessage] onDone callback called, cleaning up stream state')
           const msgs = getSessionMsgs(sid)
           const last = msgs[msgs.length - 1]
           if (last?.isStreaming) {
@@ -1061,13 +1055,11 @@ export const useChatStore = defineStore('chat', () => {
         }
 
         case 'abort.started': {
-          console.log('[chat abort] resumed pause started', evt)
           setAbortState({ aborting: true, synced: null })
           break
         }
 
         case 'abort.completed': {
-          console.log('[chat abort] resumed pause completed', evt)
           setAbortState({ aborting: false, synced: (evt as any).synced ?? false })
           const msgs = getSessionMsgs(sid)
           const lastMsg = msgs[msgs.length - 1]
@@ -1317,7 +1309,6 @@ export const useChatStore = defineStore('chat', () => {
     if (isAborting.value) return
     const ctrl = streamStates.value.get(sid)
     if (ctrl) {
-      console.log('[chat abort] stop requested', { sessionId: sid })
       setAbortState({ aborting: true, synced: null })
       ctrl.abort()
       const msgs = getSessionMsgs(sid)


### PR DESCRIPTION
## Summary
- Remove leftover chat stream debug logging from the chat store
- Remove speech playback debug logging from message rendering
- Keep storage recovery logging intact because it reports localStorage cleanup

## Validation
- npx vue-tsc -b --pretty false