### PR TITLE
feat: add Termux/proot environment compatibility

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -39,6 +39,18 @@ process.on('unhandledRejection', (reason) => {
 let server: any = null
 let chatRunServer: any = null
 
+/**
+ * 安全获取网络接口信息（兼容 Termux/proot 环境）
+ * 在 proot 环境中 os.networkInterfaces() 会抛出权限错误（errno 13）
+ */
+function safeNetworkInterfaces() {
+  try {
+    return os.networkInterfaces()
+  } catch {
+    return {}
+  }
+}
+
 export async function bootstrap() {
   console.log(`hermes-web-ui v${APP_VERSION} starting...`)
   await mkdir(config.uploadDir, { recursive: true })
@@ -123,7 +135,7 @@ export async function bootstrap() {
   })
 
   server.on('listening', () => {
-    const interfaces = os.networkInterfaces()
+    const interfaces = safeNetworkInterfaces()
     const localIp = Object.values(interfaces).flat().find(i => i?.family === 'IPv4' && !i?.internal)?.address || 'localhost'
     console.log(`Server: http://localhost:${config.port} (LAN: http://${localIp}:${config.port})`)
     console.log(`Upstream: ${config.upstream}`)

--- a/packages/server/src/services/hermes/gateway-manager.ts
+++ b/packages/server/src/services/hermes/gateway-manager.ts
@@ -49,10 +49,49 @@ const execFileAsync = promisify(execFile)
 const HERMES_BASE = resolve(homedir(), '.hermes')
 const HERMES_BIN = process.env.HERMES_BIN?.trim() || 'hermes'
 
-// WSL / Docker 没有 systemd 或 launchd，需要用 "gateway run" 代替 "gateway start"
-const isWsl = existsSync('/proc/version') && readFileSync('/proc/version', 'utf-8').toLowerCase().includes('microsoft')
-const isDocker = existsSync('/.dockerenv')
-const needsRunMode = isWsl || isDocker
+/**
+ * 检测系统的 init 系统（服务管理器）
+ * - macOS → launchd
+ * - Windows → windows-service
+ * - Linux → systemd / sysvinit / other
+ *
+ * 没有 systemd/launchd/windows-service 的环境需要用 "gateway run" 代替 "gateway start"
+ * （适用于 WSL/Docker/Termux/proot 等无服务管理器的环境）
+ */
+function detectInitSystem(): string {
+  const platform = process.platform
+
+  // macOS → launchd
+  if (platform === 'darwin') {
+    return 'launchd'
+  }
+
+  // Windows → Service Manager
+  if (platform === 'win32') {
+    return 'windows-service'
+  }
+
+  // Linux 才检查 /proc
+  if (platform === 'linux') {
+    try {
+      const comm = readFileSync('/proc/1/comm', 'utf-8').trim()
+
+      if (comm === 'systemd') return 'systemd'
+      if (comm === 'init') return 'sysvinit'
+
+      return 'other'
+    } catch {
+      return 'unknown'
+    }
+  }
+
+  return 'unknown'
+}
+
+const initSystem = detectInitSystem()
+const needsRunMode = !['systemd', 'launchd', 'windows-service'].includes(initSystem)
+// 启动时输出 init 系统检测结果（方便调试）
+logger.debug('Detected init system: %s (needsRunMode: %s)', initSystem, needsRunMode)
 
 // ============================
 // 类型定义


### PR DESCRIPTION
## Summary

- **Init system detection**: Detect systemd/launchd/windows-service to determine gateway startup mode
- **Auto fallback**: Use `gateway run` for environments without service managers (WSL/Docker/Termux/proot)
- **Network interface safety**: Wrap `os.networkInterfaces()` to handle proot permission errors (errno 13)

## Problem

In Termux/proot environments:
1. No systemd/launchd available → `gateway start` fails
2. `os.networkInterfaces()` throws `ERR_SYSTEM_ERROR (errno 13)` due to restricted system calls
3. Server crashes on startup when trying to display LAN IP

## Solution

**gateway-manager.ts**:
- Add `detectInitSystem()` to detect available service managers
- Set `needsRunMode` for WSL/Docker/Termux/proot automatically
- No need to enumerate special environments explicitly

**index.ts**:
- Add `safeNetworkInterfaces()` wrapper with try-catch
- Gracefully fallback to empty object when uv_interface_addresses fails
- Server displays `localhost` instead of crashing

## Test plan

- [x] Build succeeds
- [x] Works on macOS (launchd → `gateway start`)
- [x] Works on normal Linux (systemd → `gateway start`)
- [x] Works on Termux/proot (no init system → `gateway run`, no network interface crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)