### PR TITLE
fix: use process.argv[1] for getCliBin to support Homebrew Node.js

### DIFF
--- a/bin/hermes-web-ui.mjs
+++ b/bin/hermes-web-ui.mjs
@@ -57,7 +57,7 @@ function getNpmBin() {
 }
 
 function getCliBin() {
-  return join(getNodeBinDir(), process.platform === 'win32' ? 'hermes-web-ui.cmd' : 'hermes-web-ui')
+  return process.argv[1]
 }
 
 function getWindowsShell() {

--- a/packages/server/src/controllers/update.ts
+++ b/packages/server/src/controllers/update.ts
@@ -10,7 +10,7 @@ function getNpmBin() {
 }
 
 function getCliBin() {
-  return join(getNodeBinDir(), process.platform === 'win32' ? 'hermes-web-ui.cmd' : 'hermes-web-ui')
+  return process.argv[1]
 }
 
 function getWindowsShell() {


### PR DESCRIPTION
## Summary

- Fix `spawn ENOENT` error when running `hermes-web-ui update` on macOS with Homebrew-installed Node.js
- Root cause: `getCliBin()` used `dirname(process.execPath)` to locate the CLI binary, but Homebrew stores npm global bins in `/opt/homebrew/bin` while node lives in the versioned Cellar directory
- Fix: use `process.argv[1]` which resolves to the actual script path regardless of where node binary lives

## Files changed

- `bin/hermes-web-ui.mjs` — CLI entry point
- `packages/server/src/controllers/update.ts` — server-side update handler

## Related

Fixes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)