### PR TITLE
Fix IPv6 listen default

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -34,6 +34,7 @@ All key runtime settings are configured from compose variables.
 | Variable | Default | Description |
 |---|---|---|
 | `PORT` | `6060` | Web UI listen port |
+| `BIND_HOST` | Node default | Optional Web UI bind host. Leave unset for IPv6 dual-stack when available, or set `0.0.0.0` / `::` explicitly. |
 | `UPSTREAM` | `http://hermes-agent:8642` | Hermes gateway URL (container internal) |
 | `HERMES_BIN` | `/opt/hermes/.venv/bin/hermes` | Path to Hermes CLI binary |
 | `HERMES_AGENT_IMAGE` | `nousresearch/hermes-agent:latest` | Hermes Agent base image |

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,8 +1,16 @@
 import { resolve } from 'path'
 import { homedir } from 'os'
 
+export function getListenHost(env: Record<string, string | undefined> = process.env): string | undefined {
+  const host = env.BIND_HOST?.trim()
+  return host || undefined
+}
+
 export const config = {
   port: parseInt(process.env.PORT || '8648', 10),
+  // Leave host undefined by default so Node binds to IPv6 when available,
+  // falling back to IPv4 on systems without IPv6 support.
+  host: getListenHost(),
   upstream: process.env.UPSTREAM || 'http://127.0.0.1:8642',
   uploadDir: process.env.UPLOAD_DIR || resolve(homedir(), '.hermes-web-ui', 'upload'),
   dataDir: resolve(__dirname, '..', 'data'),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -102,8 +102,10 @@ export async function bootstrap() {
   console.log('[bootstrap] SPA fallback registered')
 
   // Start server
-  console.log(`[bootstrap] listening on port ${config.port}`)
-  server = app.listen(config.port, '0.0.0.0')
+  console.log(`[bootstrap] listening on ${config.host || 'default host'}:${config.port}`)
+  server = config.host
+    ? app.listen(config.port, config.host)
+    : app.listen(config.port)
   console.log('[bootstrap] app.listen called')
 
   setupTerminalWebSocket(server)

--- a/tests/server/config.test.ts
+++ b/tests/server/config.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { getListenHost } from '../../packages/server/src/config'
+
+describe('server config', () => {
+  it('does not force an IPv4 bind host by default', () => {
+    expect(getListenHost({})).toBeUndefined()
+  })
+
+  it('uses BIND_HOST when provided', () => {
+    expect(getListenHost({ BIND_HOST: ' :: ' })).toBe('::')
+  })
+
+  it('ignores blank BIND_HOST values', () => {
+    expect(getListenHost({ BIND_HOST: ' ' })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Stop forcing the Koa BFF server to bind to IPv4 0.0.0.0.
- Leave the bind host undefined by default so Node listens on IPv6 (::) when available and falls back to IPv4 otherwise.
- Add BIND_HOST as an explicit override and document it for Docker users.

Fixes #469

## Tests
- ../../node_modules/.bin/vitest run tests/server/config.test.ts
- npm run build
- temporary Node listen smoke check returned {"address":"::","family":"IPv6"}