### PR TITLE
fix: filter out ephemeral sessions during startup sync

### DIFF
--- a/packages/server/src/services/hermes/session-sync.ts
+++ b/packages/server/src/services/hermes/session-sync.ts
@@ -68,6 +68,8 @@ async function syncProfileSessions(profile: string): Promise<{
     logger.info(`[session-sync] profile '${profile}': found ${summaries.length} aggregated session chains`)
 
     for (const hermesSession of summaries) {
+      // Skip ephemeral sessions (created internally by chat-run-socket)
+      if (hermesSession.id.startsWith('eph_')) continue
       try {
         // Generate new session ID for local DB
         const newSessionId = generateUuid()


### PR DESCRIPTION
## Summary
- Skip `eph_` prefixed sessions in startup session sync to avoid importing internal ephemeral sessions created by `chat-run-socket`

## Test plan
- [ ] Verify startup sync no longer imports `eph_*` sessions
- [ ] Confirm regular sessions still sync normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)