### PR TITLE
feat: add edit button to user messages for quick re-editing

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -6,7 +6,7 @@ import { useProfilesStore } from '@/stores/hermes/profiles'
 import { fetchContextLength } from '@/api/hermes/sessions'
 import { setModelContext } from '@/api/hermes/model-context'
 import { NButton, NTooltip, NSwitch, NModal, NInputNumber, useMessage } from 'naive-ui'
-import { computed, ref, onMounted, watch } from 'vue'
+import { computed, ref, onMounted, watch, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const chatStore = useChatStore()
@@ -38,6 +38,16 @@ watch(autoPlaySpeech, (value) => {
   localStorage.setItem('autoPlaySpeech', String(value))
   // 通知 chat store
   chatStore.setAutoPlaySpeech(value)
+})
+
+// 监听编辑请求 — 点击消息编辑按钮时填充输入框
+watch(() => chatStore.pendingEditContent, (content) => {
+  if (content == null) return
+  inputText.value = content
+  chatStore.pendingEditContent = null
+  nextTick(() => {
+    textareaRef.value?.focus()
+  })
 })
 
 const canSend = computed(() => inputText.value.trim() || attachments.value.length > 0)

--- a/packages/client/src/components/hermes/chat/HistoryMessageList.vue
+++ b/packages/client/src/components/hermes/chat/HistoryMessageList.vue
@@ -102,6 +102,7 @@ watch(
       :key="msg.id"
       :message="msg"
       :highlight="chatStore.focusMessageId === msg.id"
+      :readonly="true"
     />
   </div>
 </template>

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -19,7 +19,7 @@ import { useGlobalSpeech } from "@/composables/useSpeech";
 
 const TOOL_PAYLOAD_DISPLAY_LIMIT = 2000;
 
-const props = defineProps<{ message: Message; highlight?: boolean }>();
+const props = defineProps<{ message: Message; highlight?: boolean; readonly?: boolean }>();
 const { t } = useI18n();
 const toast = useMessage();
 
@@ -97,6 +97,12 @@ async function copyBubbleContent() {
     return
   }
   toast.error(t('chat.copyFailed'))
+}
+
+function editBubbleContent() {
+  const text = displayText.value || props.message.content || ''
+  if (!text.trim()) return
+  chatStore.pendingEditContent = text
 }
 
 const parsedThinking = computed(() =>
@@ -663,6 +669,17 @@ onBeforeUnmount(() => {
                 <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
               </svg>
             </button>
+            <button
+              v-if="message.role === 'user' && !readonly"
+              class="edit-bubble-btn"
+              @click="editBubbleContent"
+              :title="t('chat.editBubble')"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+              </svg>
+            </button>
             <span class="message-time">{{ timeStr }}</span>
           </div>
         </div>
@@ -963,7 +980,8 @@ onBeforeUnmount(() => {
 }
 
 .copy-bubble-btn,
-.speech-bubble-btn {
+.speech-bubble-btn,
+.edit-bubble-btn {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -176,6 +176,7 @@ export default {
     thinkingDuration: 'Beobachtet {duration}',
     thinkingChars: '{count} Zeichen',
     copyBubble: 'Nachricht kopieren',
+    editBubble: 'Nachricht bearbeiten',
     copiedBubble: 'Nachricht kopiert',
     copyFailed: 'Kopieren fehlgeschlagen',
     playSpeech: 'Sprache abspielen',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -206,6 +206,7 @@ export default {
     thinkingDuration: 'Observed {duration}',
     thinkingChars: '{count} chars',
     copyBubble: 'Copy message',
+    editBubble: 'Edit message',
     copiedBubble: 'Message copied',
     copyFailed: 'Copy failed',
     playSpeech: 'Play voice',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -176,6 +176,7 @@ export default {
     thinkingDuration: 'Observado {duration}',
     thinkingChars: '{count} caracteres',
     copyBubble: 'Copiar mensaje',
+    editBubble: 'Editar mensaje',
     copiedBubble: 'Mensaje copiado',
     copyFailed: 'Error al copiar',
     playSpeech: 'Reproducir voz',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -176,6 +176,7 @@ export default {
     thinkingDuration: 'Observé {duration}',
     thinkingChars: '{count} caractères',
     copyBubble: 'Copier le message',
+    editBubble: 'Modifier le message',
     copiedBubble: 'Message copié',
     copyFailed: 'Échec de la copie',
     playSpeech: 'Lire à voix haute',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -176,6 +176,7 @@ export default {
     thinkingDuration: '観測 {duration}',
     thinkingChars: '{count} 文字',
     copyBubble: 'メッセージをコピー',
+    editBubble: 'メッセージを編集',
     copiedBubble: 'コピーしました',
     copyFailed: 'コピーに失敗しました',
     playSpeech: '音声を読み上げ',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -176,6 +176,7 @@ export default {
     thinkingDuration: '관측 {duration}',
     thinkingChars: '{count}자',
     copyBubble: '메시지 복사',
+    editBubble: '메시지 편집',
     copiedBubble: '복사됨',
     copyFailed: '복사 실패',
     playSpeech: '음성 재생',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -176,6 +176,7 @@ export default {
     thinkingDuration: 'Observado {duration}',
     thinkingChars: '{count} caracteres',
     copyBubble: 'Copiar mensagem',
+    editBubble: 'Editar mensagem',
     copiedBubble: 'Mensagem copiada',
     copyFailed: 'Falha ao copiar',
     playSpeech: 'Reproduzir voz',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -206,6 +206,7 @@ export default {
     thinkingDuration: '已观察 {duration}',
     thinkingChars: '{count} 字',
     copyBubble: '复制消息',
+    editBubble: '编辑消息',
     copiedBubble: '已复制',
     copyFailed: '复制失败',
     playSpeech: '播放语音',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -332,6 +332,7 @@ export const useChatStore = defineStore('chat', () => {
   const isLoadingSessions = ref(false)
   const sessionsLoaded = ref(false)
   const isLoadingMessages = ref(false)
+  const pendingEditContent = ref<string | null>(null)
   const isRunActive = computed(() => isStreaming.value)
 
   // Compression state
@@ -1678,5 +1679,7 @@ export const useChatStore = defineStore('chat', () => {
     clearThinkingObservationFor,
     setAutoPlaySpeech,
     playMessageSpeech,
+
+    pendingEditContent,
   }
 })


### PR DESCRIPTION
在消息的元信息栏中添加一个“铅笔编辑按钮”（与复制按钮和时间显示并列），仅对用户消息生效。点击该按钮后，会将消息内容重新填入聊天输入框，方便用户快速修改并重新发送。

  - 用户消息气泡下方新增铅笔编辑图标，与复制按钮、时间戳同排
  - 点击后将消息原文回填到输入框并自动聚焦，用户可直接编辑后重新发送
  - 历史页面（只读查看）不显示编辑按钮
  - 8 种语言均已翻译 tooltip
<img width="2553" height="1308" alt="image" src="https://github.com/user-attachments/assets/5a782ac5-4a25-48e3-868a-40b61b1417f5" />
