### PR TITLE
fix: preserve context_length and case-insensitive custom: provider strip on model switch

### DIFF
--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -228,9 +228,19 @@ export async function setConfigModel(ctx: any) {
   }
   try {
     const config = await readConfigYaml()
+    const prevContextLength = config.model?.context_length
     config.model = {}
     config.model.default = defaultModel
-    if (reqProvider) { config.model.provider = reqProvider }
+    if (reqProvider) {
+      const bareName = reqProvider.startsWith('custom:') ? reqProvider.slice(7) : reqProvider
+      const matchedKey = Object.keys(config.providers || {}).find(
+        k => k.toLowerCase() === bareName.toLowerCase()
+      )
+      config.model.provider = matchedKey || reqProvider
+    }
+    if (prevContextLength !== undefined) {
+      config.model.context_length = prevContextLength
+    }
     await writeConfigYaml(config)
     ctx.body = { success: true }
   } catch (err: any) {


### PR DESCRIPTION
# PR: fix: preserve context_length and handle custom: prefix in setConfigModel

## 问题

`PUT /api/hermes/config/model` (`setConfigModel`) 有两个 bug：

### 1. context_length 丢失

第 231 行 `config.model = {}` 清空了整个 model 对象。`context_length` 在切换模型后丢失。

### 2. custom: 前缀未处理

从 Web UI 切换模型时，provider 字段传的是 `custom:Ollama`（或 `custom:ollama`），但：
- 代码直接写入 `config.model.provider = reqProvider`，gateway 不识别 `custom:Ollama`（大小写敏感）
- 应该剥离 `custom:` 前缀，大小写不敏感匹配 `config.providers` 的键名

## 修复

文件：`packages/server/src/controllers/hermes/models.ts`

```typescript
// 修改前：
config.model = {}
config.model.default = defaultModel
if (reqProvider) { config.model.provider = reqProvider }

// 修改后：
const prevContextLength = config.model?.context_length
config.model = {}
config.model.default = defaultModel
if (reqProvider) {
  // Strip "custom:" prefix and case-insensitively match against configured providers
  const bareName = reqProvider.startsWith('custom:') ? reqProvider.slice(7) : reqProvider
  const matchedKey = Object.keys(config.providers || {}).find(
    k => k.toLowerCase() === bareName.toLowerCase()
  )
  config.model.provider = matchedKey || reqProvider
}
if (prevContextLength !== undefined) {
  config.model.context_length = prevContextLength
}
```

## 测试方法

1. Web UI 切换模型到自定义 provider（如 Ollama 的 qwen3:8b）
2. 检查 `~/.hermes/config.yaml` 中 `model.provider` 应为 `ollama`（无 `custom:` 前缀）
3. Web UI 切换模型到内置 provider（如 DeepSeek）
4. 检查 `model.context_length` 在前一步手动设置的值是否保留
5. 启动聊天，确认模型调用成功

## 相关 Issue

#204 修复了 stale base_url/api_key 问题，但未解决 context_length 丢失和 custom: 前缀处理。
