### PR TITLE
fix: lazy-connect terminal and cap reconnect attempts

### DIFF
--- a/packages/client/src/components/hermes/chat/DrawerPanel.vue
+++ b/packages/client/src/components/hermes/chat/DrawerPanel.vue
@@ -63,7 +63,7 @@ function handleClose() {
           <FilesPanel />
         </div>
         <div v-show="activeTab === 'terminal'" class="drawer-pane">
-          <TerminalPanel />
+          <TerminalPanel :visible="activeTab === 'terminal' && show" />
         </div>
       </div>
     </div>

--- a/packages/client/src/components/hermes/chat/TerminalPanel.vue
+++ b/packages/client/src/components/hermes/chat/TerminalPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, computed } from "vue";
+import { ref, onUnmounted, computed, watch } from "vue";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -11,6 +11,8 @@ import type { ITheme } from "@xterm/xterm";
 
 const { t } = useI18n();
 const message = useMessage();
+
+const props = defineProps<{ visible?: boolean }>();
 
 // ─── Terminal themes ────────────────────────────────────────────
 
@@ -164,10 +166,8 @@ function connect() {
   ws = new WebSocket(url);
 
   ws.onopen = () => {
-    reconnectAttempts = 0;
     isConnecting.value = false;
     connectionError.value = null;
-    // Server auto-creates the first session
   };
 
   ws.onmessage = (event) => {
@@ -210,6 +210,7 @@ function send(data: object | string) {
 function handleControl(msg: any) {
   switch (msg.type) {
     case "created":
+      reconnectAttempts = 0;
       sessions.value.push({
         id: msg.id,
         shell: msg.shell,
@@ -376,9 +377,14 @@ function formatTime(ts: number) {
 
 // ─── Lifecycle ──────────────────────────────────────────────────
 
-onMounted(() => {
-  connect();
-});
+let hasConnected = false;
+
+watch(() => props.visible, (visible) => {
+  if (visible && !hasConnected && !ws) {
+    hasConnected = true;
+    connect();
+  }
+}, { immediate: true });
 
 onUnmounted(() => {
   unmountActiveTerminal();


### PR DESCRIPTION
## Summary
- Pass `visible` prop to TerminalPanel, only connect WebSocket when terminal tab is actually shown in the drawer
- Move `reconnectAttempts = 0` from `ws.onopen` to the `"created"` handler — only a successful PTY session resets the counter
- Remove unused `onMounted` import

## Root cause
TerminalPanel connected on mount regardless of whether the drawer was open or the terminal tab was active. When PTY spawn failed, the WebSocket would close, trigger reconnect after 3s, open successfully (resetting the counter to 0), fail again — creating an infinite loop that spawned PTY processes until system limits were hit.

Fixes #509

## Test plan
- [ ] Open chat page — no WebSocket connection to terminal until drawer is opened
- [ ] Open drawer → terminal tab — connects and creates PTY session
- [ ] Close and reopen drawer — terminal persists (v-show, not v-if)
- [ ] On a system with broken node-pty — shows error toast, stops after 3 attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)