### PR TITLE
fix: normalize hermes download links

### DIFF
--- a/packages/client/src/api/hermes/download.ts
+++ b/packages/client/src/api/hermes/download.ts
@@ -6,6 +6,19 @@ import { getApiKey, getBaseUrlValue } from '../client'
  */
 export function getDownloadUrl(filePath: string, fileName?: string): string {
   const base = getBaseUrlValue()
+
+  // Guard: if filePath is already a full download URL, extract the real path
+  // to prevent double-wrapping (/api/hermes/download?path=/api/hermes/download?path=...)
+  if (filePath.startsWith('/api/hermes/download?')) {
+    try {
+      const parsed = new URL(filePath, 'http://localhost')
+      const realPath = parsed.searchParams.get('path')
+      if (realPath) filePath = realPath
+    } catch {
+      // fall through with original filePath
+    }
+  }
+
   // Decode the path first in case it's already encoded (e.g., from AI responses)
   // URLSearchParams will encode it again, so we need to start with decoded text
   const decodedPath = decodeURIComponent(filePath)

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -305,6 +305,22 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
     return
   }
 
+  // Full download URL: open directly (already has /api/hermes/download?path=...)
+  if (href.startsWith('/api/hermes/download?')) {
+    event.preventDefault()
+    event.stopPropagation()
+    const linkText = link.textContent || ''
+    const fileName = linkText.startsWith('File: ') ? linkText.slice(6).trim() : linkText.trim()
+    message.info(t('download.downloading'))
+    // Parse the real file path from the existing query param
+    const url = new URL(href, window.location.origin)
+    const realPath = url.searchParams.get('path') || href
+    downloadFile(realPath, fileName || undefined).catch((err: Error) => {
+      message.error(err.message || t('download.downloadFailed'))
+    })
+    return
+  }
+
   // File path links: intercept and download
   if (href.startsWith('/')) {
     event.preventDefault()


### PR DESCRIPTION
## Summary
- add a guard in `getDownloadUrl()` to unwrap already-formed `/api/hermes/download` links before re-encoding
- handle markdown links that already point to the download endpoint by extracting the real `path` query param before calling `downloadFile`
- fix double-wrapped download URLs in Hermes markdown-rendered file links

## Test plan
- [ ] click markdown file links rendered from plain file paths
- [ ] click markdown file links already rendered as `/api/hermes/download?...`
- [ ] verify downloads succeed and filenames are preserved