### PR TITLE
fix: group-chat use dynamic port instead of hardcoded 8648

### DIFF
--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -91,10 +91,11 @@ class AgentClient {
         this.storage = storage
     }
 
-    async connect(port = 8648): Promise<void> {
+    async connect(port?: number): Promise<void> {
+        const actualPort = port ?? parseInt(process.env.PORT || '8648', 10)
         const token = await getToken()
 
-        this.socket = io(`http://127.0.0.1:${port}/group-chat`, {
+        this.socket = io(`http://127.0.0.1:${actualPort}/group-chat`, {
             auth: {
                 token: token || undefined,
                 name: this.name,


### PR DESCRIPTION
## Summary
- Fix `agent-clients.ts` `connect()` method hardcoded default port 8648
- Now reads `process.env.PORT` dynamically, matching the actual server listen port

## Root Cause
`agent-clients.ts:94` had `async connect(port = 8648)` — when `createAgent()` was called without passing a port (which is the case for `restoreAgents()` and route handlers), it always connected to 8648 regardless of the actual server port.

## Test plan
- [ ] Start with custom port: `hermes-web-ui start 80`
- [ ] Create a group chat room and add an agent
- [ ] Verify agent connects successfully (no ECONNREFUSED on port 8648)

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)