### PR TITLE
[codex] add website homepage metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/EKKOLearnAI/hermes-web-ui.git"
   },
-  "homepage": "https://github.com/EKKOLearnAI/hermes-web-ui",
+  "homepage": "https://ekkolearnai.com",
   "license": "MIT",
   "engines": {
     "node": ">=23.0.0"


### PR DESCRIPTION
## What changed
- updated the npm package `homepage` field to the official website
- aligned package metadata with the GitHub repository homepage setting

## Why
The project now has a canonical website and the published metadata should point users there instead of the repository homepage.

## Validation
- verified `package.json` homepage points to `https://ekkolearnai.com`
- verified the GitHub repository homepage is also set to `https://ekkolearnai.com`
