### PR TITLE
fix: 加固 Web UI 自更新重启路径

### DIFF
--- a/packages/client/src/stores/hermes/app.ts
+++ b/packages/client/src/stores/hermes/app.ts
@@ -37,6 +37,9 @@ export const useAppStore = defineStore('app', () => {
         await checkConnection()
       }
       return res.success
+    } catch (err) {
+      console.error('Failed to update Hermes Web UI:', err)
+      return false
     } finally {
       updating.value = false
     }

--- a/packages/server/src/controllers/update.ts
+++ b/packages/server/src/controllers/update.ts
@@ -1,42 +1,75 @@
 import { execFileSync, spawn } from 'child_process'
-import { join } from 'path'
+import { existsSync } from 'fs'
+import { delimiter, dirname, join } from 'path'
 
-function getNpmBin() {
-  return process.platform === 'win32' ? 'npm.cmd' : 'npm'
+function getNodeBinDir() {
+  return dirname(process.execPath)
 }
 
-function getGlobalPrefix() {
-  return execFileSync(getNpmBin(), ['prefix', '-g'], {
+function getNodePrefix() {
+  return process.platform === 'win32' ? getNodeBinDir() : dirname(getNodeBinDir())
+}
+
+function getNpmCliPath() {
+  const prefix = getNodePrefix()
+  const candidates = process.platform === 'win32'
+    ? [
+        join(prefix, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+        join(getNodeBinDir(), 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+      ]
+    : [join(prefix, 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js')]
+  const npmCli = candidates.find(existsSync)
+
+  if (!npmCli) {
+    throw new Error(`Unable to locate npm CLI for ${process.execPath}; checked ${candidates.join(', ')}`)
+  }
+
+  return npmCli
+}
+
+function getGlobalPackageBin(prefix: string) {
+  return process.platform === 'win32'
+    ? join(prefix, 'node_modules', 'hermes-web-ui', 'bin', 'hermes-web-ui.mjs')
+    : join(prefix, 'lib', 'node_modules', 'hermes-web-ui', 'bin', 'hermes-web-ui.mjs')
+}
+
+function getCurrentNodeEnv() {
+  return {
+    ...process.env,
+    PATH: [getNodeBinDir(), process.env.PATH].filter(Boolean).join(delimiter),
+    npm_node_execpath: process.execPath,
+  }
+}
+
+function runNpm(args: string[], options: { timeout?: number } = {}) {
+  return execFileSync(process.execPath, [getNpmCliPath(), ...args], {
     encoding: 'utf-8',
+    timeout: options.timeout,
     stdio: ['pipe', 'pipe', 'pipe'],
+    env: getCurrentNodeEnv(),
   }).trim()
 }
 
-function getGlobalCliBin() {
-  const prefix = getGlobalPrefix()
+function getGlobalPrefix() {
+  return runNpm(['prefix', '-g'])
+}
 
-  if (process.platform === 'win32') {
-    return join(prefix, 'hermes-web-ui.cmd')
-  }
-
-  return join(prefix, 'bin', 'hermes-web-ui')
+function getGlobalCliScript() {
+  return getGlobalPackageBin(getGlobalPrefix())
 }
 
 function runUpdateInstall() {
-  return execFileSync(getNpmBin(), ['install', '-g', 'hermes-web-ui@latest'], {
-    encoding: 'utf-8',
-    timeout: 10 * 60 * 1000,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  })
+  return runNpm(['install', '-g', 'hermes-web-ui@latest'], { timeout: 10 * 60 * 1000 })
 }
 
 function spawnRestart(port: string) {
-  const cli = getGlobalCliBin()
+  const cli = getGlobalCliScript()
 
-  return spawn(cli, ['restart', '--port', port], {
+  return spawn(process.execPath, [cli, 'restart', '--port', port], {
     detached: true,
     stdio: 'ignore',
     windowsHide: true,
+    env: getCurrentNodeEnv(),
   })
 }
 

--- a/tests/client/app-store.test.ts
+++ b/tests/client/app-store.test.ts
@@ -33,4 +33,17 @@ describe('App Store', () => {
     expect(store.sidebarCollapsed).toBe(false)
     expect(window.localStorage.getItem('hermes_sidebar_collapsed')).toBe('0')
   })
+
+  it('clears the updating state and reports failure when self-update request fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockSystemApi.triggerUpdate.mockRejectedValue(new Error('install failed'))
+    const store = useAppStore()
+
+    const ok = await store.doUpdate()
+
+    expect(ok).toBe(false)
+    expect(store.updating).toBe(false)
+    expect(consoleError).toHaveBeenCalledWith('Failed to update Hermes Web UI:', expect.any(Error))
+    consoleError.mockRestore()
+  })
 })

--- a/tests/server/update-controller.test.ts
+++ b/tests/server/update-controller.test.ts
@@ -1,24 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { dirname, join } from 'path'
+import { delimiter, dirname, join } from 'path'
 
-type ChildProcessMocks = {
+type UpdateControllerMocks = {
   execFileSync: ReturnType<typeof vi.fn>
   spawn: ReturnType<typeof vi.fn>
   unref: ReturnType<typeof vi.fn>
+  existsSync: ReturnType<typeof vi.fn>
 }
 
-async function loadUpdateController(overrides: Partial<ChildProcessMocks> = {}) {
+async function loadUpdateController(overrides: Partial<UpdateControllerMocks> = {}) {
   const execFileSync = overrides.execFileSync ?? vi.fn().mockReturnValue('updated')
   const unref = overrides.unref ?? vi.fn()
   const spawn = overrides.spawn ?? vi.fn(() => ({ unref }))
+  const existsSync = overrides.existsSync ?? vi.fn(() => true)
 
   vi.resetModules()
   vi.doMock('child_process', () => ({ execFileSync, spawn }))
+  vi.doMock('fs', () => ({ existsSync }))
 
   const mod = await import('../../packages/server/src/controllers/update')
   return {
     ...mod,
-    mocks: { execFileSync, spawn, unref },
+    mocks: { execFileSync, spawn, unref, existsSync },
   }
 }
 
@@ -27,6 +30,27 @@ function createMockCtx() {
     status: 200,
     body: null as unknown,
   }
+}
+
+function getNodeBinDir() {
+  return dirname(process.execPath)
+}
+
+function getNodePrefix() {
+  return process.platform === 'win32' ? getNodeBinDir() : dirname(getNodeBinDir())
+}
+
+function getNpmCliPath() {
+  const prefix = getNodePrefix()
+  return process.platform === 'win32'
+    ? join(prefix, 'node_modules', 'npm', 'bin', 'npm-cli.js')
+    : join(prefix, 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js')
+}
+
+function getGlobalCliScript(prefix: string) {
+  return process.platform === 'win32'
+    ? join(prefix, 'node_modules', 'hermes-web-ui', 'bin', 'hermes-web-ui.mjs')
+    : join(prefix, 'lib', 'node_modules', 'hermes-web-ui', 'bin', 'hermes-web-ui.mjs')
 }
 
 describe('update controller', () => {
@@ -40,6 +64,8 @@ describe('update controller', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.doUnmock('child_process')
+    vi.doUnmock('fs')
     if (originalPort === undefined) {
       delete process.env.PORT
     } else {
@@ -47,35 +73,56 @@ describe('update controller', () => {
     }
   })
 
-  it('updates using npm from PATH and restarts via global prefix', async () => {
+  it('updates and restarts through the running Node executable, not PATH shims', async () => {
     process.env.PORT = '9129'
-    const { handleUpdate, mocks } = await loadUpdateController()
+    const nodeBinDir = getNodeBinDir()
+    const npmCli = getNpmCliPath()
+    const globalPrefix = getNodePrefix()
+    const cliScript = getGlobalCliScript(globalPrefix)
+    const execFileSync = vi.fn((_command: string, args: string[]) => {
+      if (args[1] === 'prefix') return globalPrefix
+      return 'updated'
+    })
+    const { handleUpdate, mocks } = await loadUpdateController({ execFileSync })
     const ctx = createMockCtx()
 
     await handleUpdate(ctx)
 
     expect(mocks.execFileSync).toHaveBeenCalledWith(
-      process.platform === 'win32' ? 'npm.cmd' : 'npm',
-      ['install', '-g', 'hermes-web-ui@latest'],
-      {
+      process.execPath,
+      [npmCli, 'install', '-g', 'hermes-web-ui@latest'],
+      expect.objectContaining({
         encoding: 'utf-8',
         timeout: 10 * 60 * 1000,
         stdio: ['pipe', 'pipe', 'pipe'],
-      },
+        env: expect.objectContaining({
+          npm_node_execpath: process.execPath,
+          PATH: expect.stringContaining(`${nodeBinDir}${delimiter}`),
+        }),
+      }),
     )
     expect(ctx.body).toEqual({ success: true, message: 'updated' })
 
     vi.runAllTimers()
 
-    // Note: spawn is called with getGlobalCliBin() result
+    expect(mocks.execFileSync).toHaveBeenCalledWith(
+      process.execPath,
+      [npmCli, 'prefix', '-g'],
+      expect.objectContaining({
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: expect.objectContaining({ npm_node_execpath: process.execPath }),
+      }),
+    )
     expect(mocks.spawn).toHaveBeenCalledWith(
-      expect.any(String), // Dynamic path based on npm prefix -g
-      ['restart', '--port', '9129'],
-      {
+      process.execPath,
+      [cliScript, 'restart', '--port', '9129'],
+      expect.objectContaining({
         detached: true,
         stdio: 'ignore',
         windowsHide: true,
-      },
+        env: expect.objectContaining({ npm_node_execpath: process.execPath }),
+      }),
     )
     expect(mocks.unref).toHaveBeenCalledOnce()
     expect(exitSpy).toHaveBeenCalledWith(0)
@@ -90,8 +137,8 @@ describe('update controller', () => {
     vi.runAllTimers()
 
     expect(mocks.spawn).toHaveBeenCalledWith(
-      expect.any(String),
-      ['restart', '--port', '8648'],
+      process.execPath,
+      [expect.any(String), 'restart', '--port', '8648'],
       expect.objectContaining({ detached: true, stdio: 'ignore', windowsHide: true }),
     )
   })
@@ -109,6 +156,22 @@ describe('update controller', () => {
 
     expect(ctx.status).toBe(500)
     expect(ctx.body).toEqual({ success: false, message: 'engine mismatch' })
+    expect(mocks.spawn).not.toHaveBeenCalled()
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('fails closed instead of falling back to PATH npm when the current Node install has no npm CLI', async () => {
+    const { handleUpdate, mocks } = await loadUpdateController({ existsSync: vi.fn(() => false) })
+    const ctx = createMockCtx()
+
+    await handleUpdate(ctx)
+
+    expect(ctx.status).toBe(500)
+    expect(ctx.body).toEqual({
+      success: false,
+      message: expect.stringContaining(`Unable to locate npm CLI for ${process.execPath}`),
+    })
+    expect(mocks.execFileSync).not.toHaveBeenCalled()
     expect(mocks.spawn).not.toHaveBeenCalled()
     expect(exitSpy).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## 这次改了什么

- Web UI 的 `/api/update` 自更新不再直接执行 `npm`/`npm.cmd` 或全局 `hermes-web-ui` shim。
- 服务端改为用当前运行进程的 `process.execPath` 执行同一 Node 安装下的 `npm-cli.js`，并用同一个 Node 启动全局包里的 `bin/hermes-web-ui.mjs` 重启。
- 找不到当前 Node 安装自带的 npm CLI 时失败关闭，不再回退到环境里的 `PATH npm`。
- 前端 `doUpdate()` 捕获更新请求 rejection，返回 `false` 并恢复 `updating` 状态，避免点击后 promise 直接冒泡导致按钮状态/反馈不可靠。

## 根因证据

复现到一个关键路径问题：即使执行的是当前 Node 目录下的绝对 `npm` 文件，它的 shebang 仍然可能是 `#!/usr/bin/env node`，会重新从环境 `PATH` 解析 `node`。

本地验证：把假的 `node` 放到 `PATH` 最前面后执行绝对 npm：

```text
absolute_npm=/Users/hanzhicheng/.nvm/versions/node/v24.15.0/bin/npm
exit_code=42
stdout=FAKE_NODE_INVOKED:/tmp/hermes-webui-fake-node.../node:/Users/hanzhicheng/.nvm/versions/node/v24.15.0/bin/npm --version
```

改为 `process.execPath npm-cli.js ...` 后，同样的污染 `PATH` 不会触发假 node，`npm prefix -g` 正常返回当前 Node 前缀。

## 相关问题 / 重复排查

- Fixes #460
- Fixes #410
- 相关但未合并：#461 只处理了 Homebrew CLI 路径方向；本 PR 进一步避免 npm/CLI shim 通过 shebang 再落回污染的 `PATH node`。
- 相关历史修复：#123 曾修过 self-update 重启到旧安装的问题，本 PR 补上当前仍可复现的 Node/shebang/PATH 边界。

## 验证

- `npm test -- --run tests/server/update-controller.test.ts tests/client/app-store.test.ts` — 通过，2 个测试文件 / 6 个测试
- `npm run build` — 通过
- `npm test` — 通过，63 个测试文件，396 passed / 2 skipped
- `git diff --check` — 通过
- added-line secret / shell / eval scan — 无发现
- 独立代码审查子代理 — 无 blocker / major issue
