### PR TITLE
fix(website): improve mobile responsiveness

### DIFF
--- a/packages/website/src/components/docs/DocContent.vue
+++ b/packages/website/src/components/docs/DocContent.vue
@@ -119,6 +119,20 @@ const sections = computed<DocSection[]>(() => {
     color: var(--text-secondary);
     vertical-align: top;
   }
+
+  @media (max-width: $breakpoint-mobile) {
+    display: block;
+
+    tr {
+      display: block;
+      padding: 10px 0;
+    }
+
+    td {
+      display: block;
+      padding: 2px 0;
+    }
+  }
 }
 
 .doc-table-key {
@@ -131,6 +145,12 @@ const sections = computed<DocSection[]>(() => {
     padding: 2px 8px;
     border-radius: 4px;
     font-size: 13px;
+  }
+
+  @media (max-width: $breakpoint-mobile) {
+    white-space: normal;
+    width: auto;
+    margin-bottom: 4px;
   }
 }
 </style>

--- a/packages/website/src/components/landing/HeroSection.vue
+++ b/packages/website/src/components/landing/HeroSection.vue
@@ -267,11 +267,24 @@ onMounted(() => {
   border: 1px solid var(--border-color);
   border-radius: $radius-md;
   padding: 12px 20px;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 
   code {
     font-size: 14px;
     background: transparent;
     padding: 0;
+    white-space: nowrap;
+  }
+
+  @media (max-width: $breakpoint-mobile) {
+    padding: 10px 14px;
+    gap: 8px;
+
+    code {
+      font-size: 12px;
+    }
   }
 }
 

--- a/packages/website/src/components/landing/InstallSection.vue
+++ b/packages/website/src/components/landing/InstallSection.vue
@@ -62,6 +62,10 @@ function copyText(text: string) {
   background: var(--bg-card);
   border: 1px solid var(--border-color);
   border-radius: $radius-lg;
+
+  @media (max-width: $breakpoint-mobile) {
+    padding: 24px 16px;
+  }
 }
 
 .panel-title {
@@ -118,6 +122,8 @@ function copyText(text: string) {
   margin-bottom: 8px;
   cursor: pointer;
   transition: border-color $transition-fast;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 
   &:hover {
     border-color: var(--text-muted);
@@ -127,6 +133,7 @@ function copyText(text: string) {
     font-size: 14px;
     background: transparent;
     padding: 0;
+    white-space: nowrap;
   }
 }
 

--- a/packages/website/src/components/landing/PlatformsSection.vue
+++ b/packages/website/src/components/landing/PlatformsSection.vue
@@ -56,6 +56,10 @@ const platforms = [
   flex-wrap: wrap;
   justify-content: center;
   gap: 24px;
+
+  @media (max-width: $breakpoint-mobile) {
+    gap: 16px;
+  }
 }
 
 .platform-item {
@@ -64,6 +68,11 @@ const platforms = [
   align-items: center;
   gap: 10px;
   width: 120px;
+
+  @media (max-width: $breakpoint-mobile) {
+    width: 80px;
+    gap: 6px;
+  }
 }
 
 .platform-icon {
@@ -86,11 +95,25 @@ const platforms = [
     width: 24px;
     height: 24px;
   }
+
+  @media (max-width: $breakpoint-mobile) {
+    width: 44px;
+    height: 44px;
+
+    svg {
+      width: 20px;
+      height: 20px;
+    }
+  }
 }
 
 .platform-name {
   font-size: 13px;
   color: var(--text-secondary);
   text-align: center;
+
+  @media (max-width: $breakpoint-mobile) {
+    font-size: 12px;
+  }
 }
 </style>

--- a/packages/website/src/components/landing/ScreenshotsSection.vue
+++ b/packages/website/src/components/landing/ScreenshotsSection.vue
@@ -98,6 +98,12 @@ onUnmounted(() => {
   padding: 0 24px;
   margin-top: 48px;
   margin-bottom: 24px;
+
+  @media (max-width: $breakpoint-mobile) {
+    padding: 0 12px;
+    margin-top: 32px;
+    margin-bottom: 16px;
+  }
 }
 
 .screenshots-inner {

--- a/packages/website/src/components/landing/StarHistorySection.vue
+++ b/packages/website/src/components/landing/StarHistorySection.vue
@@ -80,6 +80,10 @@ onMounted(async () => {
   border-radius: $radius-lg;
   display: flex;
   flex-direction: column;
+
+  @media (max-width: $breakpoint-mobile) {
+    padding: 24px 16px;
+  }
 }
 
 .panel-title {

--- a/packages/website/src/components/layout/SiteHeader.vue
+++ b/packages/website/src/components/layout/SiteHeader.vue
@@ -86,8 +86,31 @@ function goHome() {
         <a class="mobile-link" @click.prevent="navigateTo('docs.getting-started')">{{ t('nav.docs') }}</a>
         <a class="mobile-link" href="https://github.com/EKKOLearnAI/hermes-web-ui" target="_blank" rel="noopener">{{ t('nav.github') }}</a>
         <div class="mobile-actions">
-          <button class="icon-btn" @click="switchLocale">{{ locale === 'en' ? '中文' : 'English' }}</button>
-          <button class="icon-btn" @click="toggleTheme">{{ isDark ? 'Light Mode' : 'Dark Mode' }}</button>
+          <button class="mobile-action-btn" @click="switchLocale">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="action-icon">
+              <circle cx="12" cy="12" r="10" />
+              <line x1="2" y1="12" x2="22" y2="12" />
+              <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+            </svg>
+            {{ locale === 'en' ? '中文' : 'English' }}
+          </button>
+          <button class="mobile-action-btn" @click="toggleTheme">
+            <svg v-if="isDark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="action-icon">
+              <circle cx="12" cy="12" r="5" />
+              <line x1="12" y1="1" x2="12" y2="3" />
+              <line x1="12" y1="21" x2="12" y2="23" />
+              <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+              <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+              <line x1="1" y1="12" x2="3" y2="12" />
+              <line x1="21" y1="12" x2="23" y2="12" />
+              <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+              <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+            </svg>
+            <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="action-icon">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+            </svg>
+            {{ isDark ? 'Light Mode' : 'Dark Mode' }}
+          </button>
         </div>
       </div>
     </div>
@@ -243,6 +266,32 @@ function goHome() {
   display: flex;
   gap: 8px;
   padding-top: 12px;
+}
+
+.mobile-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: $radius-sm;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all $transition-fast;
+
+  &:active {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+  }
+}
+
+.action-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
 }
 
 @media (max-width: $breakpoint-mobile) {

--- a/packages/website/src/views/DocsView.vue
+++ b/packages/website/src/views/DocsView.vue
@@ -1,15 +1,41 @@
 <script setup lang="ts">
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import DocSidebar from '@/components/docs/DocSidebar.vue'
 import DocContent from '@/components/docs/DocContent.vue'
 
 const route = useRoute()
+const router = useRouter()
+const { t } = useI18n()
+
+const pages = [
+  { key: 'gettingStarted', name: 'docs.getting-started' },
+  { key: 'configuration', name: 'docs.configuration' },
+  { key: 'features', name: 'docs.features' },
+  { key: 'platforms', name: 'docs.platforms' },
+  { key: 'api', name: 'docs.api' },
+]
+
+function navigate(name: string) {
+  router.push({ name })
+}
 </script>
 
 <template>
   <div class="docs-layout">
     <DocSidebar v-if="route.meta.page" />
     <div class="docs-main">
+      <nav v-if="route.meta.page" class="mobile-doc-tabs">
+        <button
+          v-for="p in pages"
+          :key="p.key"
+          class="mobile-tab"
+          :class="{ active: route.name === p.name }"
+          @click="navigate(p.name)"
+        >
+          {{ t(`docs.sidebar.${p.key}`) }}
+        </button>
+      </nav>
       <router-view />
       <DocContent v-if="route.meta.page" />
       <div v-else class="docs-placeholder">
@@ -37,5 +63,50 @@ const route = useRoute()
   color: var(--text-muted);
   font-size: 16px;
   text-align: center;
+}
+
+// ─── Mobile doc tabs ────────────────────────────
+
+.mobile-doc-tabs {
+  display: none;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  gap: 4px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-card);
+  position: sticky;
+  top: 60px;
+  z-index: 10;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.mobile-tab {
+  flex-shrink: 0;
+  padding: 6px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: $radius-sm;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all $transition-fast;
+  white-space: nowrap;
+
+  &.active {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border-color: var(--text-muted);
+  }
+}
+
+@media (max-width: $breakpoint-mobile) {
+  .mobile-doc-tabs {
+    display: flex;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- improve mobile layout for docs pages and landing sections
- add mobile docs tab navigation and better header actions
- make command/code blocks and doc tables scroll or wrap correctly on small screens

## Testing
- not run (UI changes only)