### PR TITLE
fix: lower context compression message threshold to 150

### DIFF
--- a/packages/server/src/services/hermes/chat-run-socket.ts
+++ b/packages/server/src/services/hermes/chat-run-socket.ts
@@ -660,7 +660,7 @@ export class ChatRunSocket {
               logger.info('[context-compress] session=%s: snapshot at %d, %d new messages, assembled ~%d tokens (threshold %d)',
                 session_id, snapshot.lastMessageIndex, newMessages.length, totalTokens, triggerTokens)
               // triggerTokens
-              if (totalTokens <= triggerTokens && newMessages.length <= 200) {
+              if (totalTokens <= triggerTokens && newMessages.length <= 150) {
                 // Under threshold — use assembled context directly, no LLM call needed
                 history = [
                   { role: 'user', content: SUMMARY_PREFIX + '\n\n' + snapshot.summary },
@@ -766,7 +766,7 @@ export class ChatRunSocket {
             } else if (history.length > 4) {
               // No snapshot — check if raw history exceeds threshold
 
-              if (totalTokens <= triggerTokens && history.length <= 200) {
+              if (totalTokens <= triggerTokens && history.length <= 150) {
                 // Under threshold — use raw history as-is
                 logger.info('[context-compress] session=%s: %d messages, ~%d tokens — under threshold, skip', session_id, history.length, totalTokens)
               } else {


### PR DESCRIPTION
## Summary
- Lower the message count threshold for context compression from 200 to 150
- Prevents excessively long conversation histories before compression triggers

## Test plan
- [ ] Verify compression still triggers correctly when messages exceed 150
- [ ] Verify compression with existing snapshot works as expected
- [ ] Verify chat sessions still work normally below the threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)