### PR TITLE
fix: prevent terminal popup on Windows from gh/docker/ssh calls

### DIFF
--- a/packages/server/src/services/hermes/copilot-models.ts
+++ b/packages/server/src/services/hermes/copilot-models.ts
@@ -125,7 +125,7 @@ export async function resolveCopilotOAuthTokenWithSource(
   const appsToken = await readGhAppsToken()
   if (appsToken) return { token: appsToken, source: 'apps-json' }
   try {
-    const { stdout } = await execFileAsync('gh', ['auth', 'token'], { timeout: 3000 })
+    const { stdout } = await execFileAsync('gh', ['auth', 'token'], { timeout: 3000, windowsHide: true })
     const v = stdout.trim()
     if (isUsableOAuthToken(v)) return { token: v, source: 'gh-cli' }
   } catch { /* ignore */ }

--- a/packages/server/src/services/hermes/file-provider.ts
+++ b/packages/server/src/services/hermes/file-provider.ts
@@ -8,6 +8,7 @@ import { config } from '../../config'
 import { getActiveProfileDir, getActiveEnvPath } from './hermes-profile'
 
 const execFileAsync = promisify(execFile)
+const execOpts = { windowsHide: true }
 
 // Max download file size (default 200MB)
 const MAX_DOWNLOAD_SIZE = parseInt(process.env.MAX_DOWNLOAD_SIZE || '', 10) || 200 * 1024 * 1024


### PR DESCRIPTION
## Summary
- Add `windowsHide: true` to `gh auth token` call in copilot-models.ts
- Add shared `execOpts` with `windowsHide: true` to file-provider.ts for all docker/ssh/singularity calls

Fixes Windows terminal popup window appearing when provider/models page loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)