### PR TITLE
fix: skip model API requests when no auth token

### DIFF
--- a/packages/client/src/stores/hermes/app.ts
+++ b/packages/client/src/stores/hermes/app.ts
@@ -12,6 +12,7 @@ import {
   type ModelVisibility,
   type ModelVisibilityRule,
 } from '@/api/hermes/system'
+import { hasApiKey } from '@/api/client'
 
 const WEB_UI_VERSION = __APP_VERSION__
 
@@ -125,6 +126,7 @@ export const useAppStore = defineStore('app', () => {
   }
 
   async function loadModels() {
+    if (!hasApiKey()) return
     try {
       const res = await fetchAvailableModels()
       applyAvailableModelsResponse(res)

--- a/packages/client/src/stores/hermes/models.ts
+++ b/packages/client/src/stores/hermes/models.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import * as systemApi from '@/api/hermes/system'
 import type { AvailableModelGroup, CustomProvider } from '@/api/hermes/system'
+import { hasApiKey } from '@/api/client'
 import { useAppStore } from './app'
 
 export const useModelsStore = defineStore('models', () => {
@@ -31,6 +32,7 @@ export const useModelsStore = defineStore('models', () => {
   )
 
   async function fetchProviders() {
+    if (!hasApiKey()) return
     loading.value = true
     try {
       const res = await systemApi.fetchAvailableModels()

--- a/tests/client/app-store.test.ts
+++ b/tests/client/app-store.test.ts
@@ -12,6 +12,7 @@ const mockSystemApi = vi.hoisted(() => ({
 }))
 
 vi.mock('@/api/hermes/system', () => mockSystemApi)
+vi.mock('@/api/client', () => ({ hasApiKey: () => true }))
 
 import { useAppStore } from '@/stores/hermes/app'
 

--- a/tests/client/models-store.test.ts
+++ b/tests/client/models-store.test.ts
@@ -10,6 +10,7 @@ const mockSystemApi = vi.hoisted(() => ({
 }))
 
 vi.mock('@/api/hermes/system', () => mockSystemApi)
+vi.mock('@/api/client', () => ({ hasApiKey: () => true }))
 
 import { useAppStore } from '@/stores/hermes/app'
 import { useModelsStore } from '@/stores/hermes/models'


### PR DESCRIPTION
## Summary
- `loadModels()` and `fetchProviders()` now return early when `hasApiKey()` is false, preventing unauthenticated requests to `/api/hermes/available-models`
- Fixes infinite retry loop that triggers server-side 429 rate limiting when accessing the app without a token

## Test plan
- [x] All 447 existing tests pass (added `@/api/client` mock to `hasApiKey: true` in affected test files)
- [ ] Manual: access `/` without token, verify no `/api/hermes/available-models` requests are made
- [ ] Manual: login normally, verify models load as expected

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #606