### PR TITLE
fix(docker): resolve gateway startup failure in Docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - HERMES_HOME=/home/agent/.hermes
       - HERMES_BIN=${HERMES_BIN:-/opt/hermes/.venv/bin/hermes}
       - AUTH_DISABLED=${AUTH_DISABLED:-false}
+      - HERMES_ALLOW_ROOT_GATEWAY=${HERMES_ALLOW_ROOT_GATEWAY:-1}
       - PATH=/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     restart: unless-stopped
 

--- a/packages/server/src/services/hermes/gateway-manager.ts
+++ b/packages/server/src/services/hermes/gateway-manager.ts
@@ -181,7 +181,7 @@ export class GatewayManager {
    */
   private readProfilePort(name: string): { port: number; host: string } {
     const configPath = join(this.profileDir(name), 'config.yaml')
-    const defaultHost = initSystem === 'container' ? 'hermes-agent' : '127.0.0.1'
+    const defaultHost = process.env.GATEWAY_HOST || '127.0.0.1'
 
     if (!existsSync(configPath)) return { port: 8642, host: defaultHost }
 


### PR DESCRIPTION
## 问题
docker-compose 部署时点击启动网关报错：
\`API Error 500: {"error":"Gateway process exited unexpectedly (PID: 25)"}\`

## 原因

两个独立问题：

**1. 网关被跳过，从未启动**

\`gateway-manager.ts\` 在容器环境中将 \`defaultHost\` 设为 \`'hermes-agent'\`。
\`startAll()\` 有一个守卫逻辑会跳过所有非 \`127.0.0.1\` 的 host（注释为"remote profile"），
导致网关进程从未被启动，代理请求发往不可达的 \`http://hermes-agent:8642\`。

实际上 \`hermes-webui\` 容器通过共享 volume 自带 hermes 二进制，完全可以自己启动网关。

**2. hermes 拒绝以 root 身份运行网关**

\`hermes-webui\` 的 entrypoint 直接运行 \`node\`，绕过了官方镜像中负责降权的
\`/opt/hermes/docker/entrypoint.sh\`，导致 Node 进程以 root 运行。hermes 检测到后拒绝启动：
\`\`\`
✗ Refusing to run the Hermes gateway as root inside the official Docker image.
\`\`\`

## 修复

- \`gateway-manager.ts\`：将 \`defaultHost\` 改为 \`process.env.GATEWAY_HOST || '127.0.0.1'\`，移除对容器环境的特殊判断，让 webui 容器自己管理网关。仍可通过 \`GATEWAY_HOST\` 环境变量指向外部网关。
- \`docker-compose.yml\`：添加 \`HERMES_ALLOW_ROOT_GATEWAY=1\`，允许在 root 运行的容器中启动网关。

## 影响范围

非 Docker 环境（macOS / Linux / Windows / WSL）完全不受影响，这些环境的 \`initSystem\` 从不返回 \`'container'\`，行为与之前完全一致。