### PR TITLE
fix: guard model selector search against null values

### DIFF
--- a/packages/client/src/components/layout/ModelSelector.vue
+++ b/packages/client/src/components/layout/ModelSelector.vue
@@ -39,18 +39,22 @@ async function removeCustomModel(model: string, provider: string) {
   await appStore.removeCustomModel(model, provider)
 }
 
+function safeLower(value: unknown) {
+  return typeof value === 'string' ? value.toLowerCase() : ''
+}
+
 const filteredGroups = computed(() => {
-  const q = searchQuery.value.toLowerCase().trim()
+  const q = safeLower(searchQuery.value).trim()
   if (!q) return modelGroupsWithCustom.value
   return modelGroupsWithCustom.value
     .map(g => ({
       ...g,
       models: g.models.filter(m => {
         const displayName = appStore.displayModelName(m, g.provider)
-        return m.toLowerCase().includes(q) || displayName.toLowerCase().includes(q)
+        return safeLower(m).includes(q) || safeLower(displayName).includes(q)
       }),
     }))
-    .filter(g => g.models.length > 0 || g.label.toLowerCase().includes(q))
+    .filter(g => g.models.length > 0 || safeLower(g.label).includes(q))
 })
 
 function toggleGroup(provider: string) {


### PR DESCRIPTION
## Bug

Model selector search crashes with `TypeError: Cannot read properties of null (reading 'toLowerCase')` when `displayModelName()` or `group.label` returns a null/undefined value.

This can happen when:
- A model alias resolves to `null` or `undefined`
- Provider group label is unexpectedly empty

## Fix

Added a `safeLower()` helper that guards against non-string values before calling `.toLowerCase()`. Applied to all 4 search filter paths in `ModelSelector.vue`:

- `searchQuery.value` — user input
- `m` — model ID
- `displayName` — from `displayModelName()`
- `g.label` — provider group label