### PR TITLE
refactor(docker): merge two-container setup into single container

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Single-container deployment with integrated Hermes Agent:
 
 ```bash
 # Use pre-built image (Recommended)
-WEBUI_IMAGE=ekkoye8888/hermes-web-ui:latest docker compose up -d
+WEBUI_IMAGE=ekkoye8888/hermes-web-ui docker compose up -d
 
 # Or build from source
 docker compose up -d --build

--- a/README.md
+++ b/README.md
@@ -184,14 +184,14 @@ hermes-web-ui start
 
 ### Docker Compose
 
-Run Web UI together with Hermes Agent:
+Single-container deployment with integrated Hermes Agent:
 
 ```bash
 # Use pre-built image (Recommended)
-WEBUI_IMAGE=ekkoye8888/hermes-web-ui:latest docker compose up -d hermes-agent hermes-webui
+WEBUI_IMAGE=ekkoye8888/hermes-web-ui:latest docker compose up -d
 
 # Or build from source
-docker compose up -d --build hermes-agent hermes-webui
+docker compose up -d --build
 
 docker compose logs -f hermes-webui
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -192,14 +192,14 @@ hermes-web-ui start
 
 ### Docker Compose
 
-使用仓库内置的 compose 文件联合运行 Hermes Agent + Web UI：
+单容器部署，内置 Hermes Agent 运行时：
 
 ```bash
 # 使用预构建镜像（推荐）
-WEBUI_IMAGE=ekkoye8888/hermes-web-ui:latest docker compose up -d hermes-agent hermes-webui
+WEBUI_IMAGE=ekkoye8888/hermes-web-ui:latest docker compose up -d
 
 # 或从源码构建
-docker compose up -d --build hermes-agent hermes-webui
+docker compose up -d --build
 
 docker compose logs -f hermes-webui
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -196,7 +196,7 @@ hermes-web-ui start
 
 ```bash
 # 使用预构建镜像（推荐）
-WEBUI_IMAGE=ekkoye8888/hermes-web-ui:latest docker compose up -d
+WEBUI_IMAGE=ekkoye8888/hermes-web-ui docker compose up -d
 
 # 或从源码构建
 docker compose up -d --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,43 +1,21 @@
 services:
-  hermes-agent:
-    image: ${HERMES_AGENT_IMAGE:-nousresearch/hermes-agent:latest}
-    container_name: ${HERMES_AGENT_CONTAINER_NAME:-hermes-agent}
-    volumes:
-      - ${HERMES_DATA_DIR:-./hermes_data}:/home/agent/.hermes
-      - hermes-agent-src:/opt/hermes
-    environment:
-      - HERMES_HOME=/home/agent/.hermes
-    stdin_open: true
-    tty: true
-    restart: unless-stopped
-    ports:
-      - "8642-8670:8642-8670"
-
   hermes-webui:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        BASE_IMAGE: ${HERMES_AGENT_IMAGE:-nousresearch/hermes-agent:latest}
     image: ${WEBUI_IMAGE:-hermes-web-ui-local:latest}
     container_name: ${WEBUI_CONTAINER_NAME:-hermes-webui}
-    entrypoint: ["node", "dist/server/index.js"]
-    depends_on:
-      - hermes-agent
     ports:
       - "${PORT:-6060}:${PORT:-6060}"
     volumes:
       - ${HERMES_DATA_DIR:-./hermes_data}:/home/agent/.hermes
       - ${HERMES_DATA_DIR:-./hermes_data}/hermes-web-ui:/home/agent/.hermes-web-ui
-      - hermes-agent-src:/opt/hermes
     environment:
       - PORT=${PORT:-6060}
       - HERMES_HOME=/home/agent/.hermes
-      - HERMES_BIN=${HERMES_BIN:-/opt/hermes/.venv/bin/hermes}
+      - HERMES_BIN=/opt/hermes/.venv/bin/hermes
       - AUTH_DISABLED=${AUTH_DISABLED:-false}
-      - HERMES_ALLOW_ROOT_GATEWAY=${HERMES_ALLOW_ROOT_GATEWAY:-1}
-      - PATH=/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - HERMES_ALLOW_ROOT_GATEWAY=1
     restart: unless-stopped
-
-volumes:
-  hermes-agent-src:
+    stdin_open: true
+    tty: true

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,7 +7,7 @@ This repository ships an environment-variable driven Docker Compose setup.
 ### Pull pre-built image (Recommended)
 
 ```bash
-WEBUI_IMAGE=ekkoye8888/hermes-web-ui:latest docker compose up -d hermes-agent hermes-webui
+WEBUI_IMAGE=ekkoye8888/hermes-web-ui:latest docker compose up -d
 docker compose logs -f hermes-webui
 ```
 
@@ -16,16 +16,17 @@ Open: `http://localhost:6060`
 ### Build from source
 
 ```bash
-docker compose up -d --build hermes-agent hermes-webui
+docker compose up -d --build
 docker compose logs -f hermes-webui
 ```
 
 ## Services
 
-This compose file runs two services:
+This compose file runs a single service:
 
-- `hermes-agent` — Hermes Agent runtime (image: `nousresearch/hermes-agent`)
-- `hermes-webui` — Web UI dashboard (pre-built image or built from source)
+- `hermes-webui` — Web UI dashboard with integrated Hermes Agent runtime (pre-built image or built from source)
+
+The Web UI container is built on the `nousresearch/hermes-agent` base image and internally manages the Hermes Agent gateway lifecycle via `GatewayManager`.
 
 ## Environment Variables
 
@@ -36,7 +37,7 @@ All key runtime settings are configured from compose variables.
 | `PORT` | `6060` | Web UI listen port |
 | `BIND_HOST` | `0.0.0.0` | Optional Web UI bind host. Defaults to IPv4 for stable WSL/Windows access. Set `::` explicitly if you want IPv6 listening. |
 | `HERMES_BIN` | `/opt/hermes/.venv/bin/hermes` | Path to Hermes CLI binary |
-| `HERMES_AGENT_IMAGE` | `nousresearch/hermes-agent:latest` | Hermes Agent base image |
+| `HERMES_AGENT_IMAGE` | `nousresearch/hermes-agent:latest` | Hermes Agent base image (used only during build) |
 | `WEBUI_IMAGE` | `hermes-web-ui-local:latest` | Web UI image (set to `ekkoye8888/hermes-web-ui:latest` to use pre-built) |
 | `HERMES_DATA_DIR` | `./hermes_data` | Hermes runtime data directory |
 | `AUTH_DISABLED` | `false` | Set to `true` to disable login authentication |
@@ -46,7 +47,7 @@ Override variables directly from shell:
 ```bash
 PORT=16060 \
 AUTH_DISABLED=true \
-docker compose up -d hermes-agent hermes-webui
+docker compose up -d
 ```
 
 Or create a `.env` file in the project root:
@@ -65,29 +66,31 @@ AUTH_DISABLED=false
 | `${HERMES_DATA_DIR}/hermes-web-ui` | Web UI data (auth token, etc.) |
 
 - Hermes data persists in `./hermes_data`, mapped to `/home/agent/.hermes` in the container.
-- Web UI data persists in `./hermes_data/hermes-web-ui/`, mapped to `/root/.hermes-web-ui` in the container.
+- Web UI data persists in `./hermes_data/hermes-web-ui/`, mapped to `/home/agent/.hermes-web-ui` in the container.
 - When `AUTH_DISABLED=false`, the auth token is auto-generated on first run and printed to container logs.
 - Deleting the token file and restarting will generate a new one.
 
 ## Port Mapping
 
-| Port | Service | Description |
-|---|---|---|
-| `${PORT}` (6060) | hermes-webui | Web UI dashboard |
-| 8642-8670 | hermes-agent | Hermes Agent gateway ports (for multi-profile) |
+| Port | Description |
+|---|---|
+| `${PORT}` (6060) | Web UI dashboard |
+
+Hermes Agent gateway ports (8642-8670) are used internally within the container and are not exposed to the host.
 
 ## Code Runtime Behavior
 
 - Hermes CLI binary comes from `HERMES_BIN` env (`packages/server/src/services/hermes-cli.ts`).
 - If `HERMES_BIN` is not provided, code falls back to `hermes` in `PATH`.
 - Profile switching dynamically resolves upstream URLs via `GatewayManager`.
+- The Web UI automatically starts and manages the Hermes Agent gateway process on startup.
 
 ## Common Operations
 
-Recreate webui:
+Recreate:
 
 ```bash
-docker compose up -d --no-deps --force-recreate hermes-webui
+docker compose up -d --force-recreate
 ```
 
 View auth token:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,7 +7,7 @@ This repository ships an environment-variable driven Docker Compose setup.
 ### Pull pre-built image (Recommended)
 
 ```bash
-WEBUI_IMAGE=ekkoye8888/hermes-web-ui:latest docker compose up -d
+WEBUI_IMAGE=ekkoye8888/hermes-web-ui docker compose up -d
 docker compose logs -f hermes-webui
 ```
 
@@ -38,7 +38,7 @@ All key runtime settings are configured from compose variables.
 | `BIND_HOST` | `0.0.0.0` | Optional Web UI bind host. Defaults to IPv4 for stable WSL/Windows access. Set `::` explicitly if you want IPv6 listening. |
 | `HERMES_BIN` | `/opt/hermes/.venv/bin/hermes` | Path to Hermes CLI binary |
 | `HERMES_AGENT_IMAGE` | `nousresearch/hermes-agent:latest` | Hermes Agent base image (used only during build) |
-| `WEBUI_IMAGE` | `hermes-web-ui-local:latest` | Web UI image (set to `ekkoye8888/hermes-web-ui:latest` to use pre-built) |
+| `WEBUI_IMAGE` | `hermes-web-ui-local:latest` | Web UI image (set to `ekkoye8888/hermes-web-ui` to use pre-built) |
 | `HERMES_DATA_DIR` | `./hermes_data` | Hermes runtime data directory |
 | `AUTH_DISABLED` | `false` | Set to `true` to disable login authentication |
 
@@ -53,7 +53,7 @@ docker compose up -d
 Or create a `.env` file in the project root:
 
 ```
-WEBUI_IMAGE=ekkoye8888/hermes-web-ui:latest
+WEBUI_IMAGE=ekkoye8888/hermes-web-ui
 PORT=6060
 AUTH_DISABLED=false
 ```


### PR DESCRIPTION
## Summary

- Merge the two-container docker-compose setup (hermes-agent + hermes-webui) into a single hermes-webui container
- The Web UI already manages the Hermes Agent gateway lifecycle internally via `GatewayManager` (spawns `hermes gateway run --replace`), making the separate hermes-agent container redundant
- The Dockerfile is built on the `nousresearch/hermes-agent` base image, so all CLI tooling is already included
- Remove gateway port mapping (8642-8670) — used internally only, no need to expose
- Update all docs (docker.md, README.md, README_zh.md)

## Test plan

- [ ] `WEBUI_IMAGE=ekkoye8888/hermes-web-ui:v0.5.18 docker compose up -d` starts successfully
- [ ] Web UI accessible on `http://localhost:6060`
- [ ] Gateway starts internally and chat works
- [ ] `docker compose down` cleans up properly
- [ ] Build from source works: `docker compose up -d --build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)