### PR TITLE
Fix Windows test path isolation

### DIFF
--- a/tests/client/i18n-coverage.test.ts
+++ b/tests/client/i18n-coverage.test.ts
@@ -12,7 +12,7 @@ function walkFiles(dir: string, files: string[] = []): string[] {
     const path = join(dir, entry.name)
     if (entry.isDirectory()) {
       walkFiles(path, files)
-    } else if (/\.(ts|vue)$/.test(entry.name) && !path.includes('/i18n/locales/')) {
+    } else if (/\.(ts|vue)$/.test(entry.name) && !path.replace(/\\/g, '/').includes('/i18n/locales/')) {
       files.push(path)
     }
   }
@@ -76,6 +76,6 @@ describe('i18n locale coverage', () => {
   })
 
   it('keeps the coverage scanner rooted in client source files', () => {
-    expect(relative(process.cwd(), SOURCE_ROOT)).toBe('packages/client/src')
+    expect(relative(process.cwd(), SOURCE_ROOT)).toBe(join('packages', 'client', 'src'))
   })
 })

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { join } from 'path'
 
 type FsMocks = {
   readFile: ReturnType<typeof vi.fn>
@@ -20,8 +21,8 @@ async function loadAuth(overrides: Partial<FsMocks> & { home?: string } = {}) {
   return {
     ...mod,
     mocks: { readFile, writeFile, mkdir },
-    appHome: `${home}/.hermes-web-ui`,
-    tokenFile: `${home}/.hermes-web-ui/.token`,
+    appHome: join(home, '.hermes-web-ui'),
+    tokenFile: join(home, '.hermes-web-ui', '.token'),
   }
 }
 
@@ -94,12 +95,14 @@ describe('Auth Service', () => {
 
       const token = await getToken()
 
+      const expectedWriteOptions = process.platform === 'win32' ? {} : { mode: 0o600 }
+
       expect(token).toMatch(/^[a-f0-9]{64}$/)
       expect(mkdir).toHaveBeenCalledWith(appHome, { recursive: true })
       expect(writeFile).toHaveBeenCalledWith(
         tokenFile,
         expect.stringMatching(/^[a-f0-9]{64}\n$/),
-        { mode: 0o600 },
+        expectedWriteOptions,
       )
     })
   })

--- a/tests/server/model-context.test.ts
+++ b/tests/server/model-context.test.ts
@@ -4,6 +4,9 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 
 let homeDir = ''
+const originalHermesHome = process.env.HERMES_HOME
+const originalLocalAppData = process.env.LOCALAPPDATA
+const originalAppData = process.env.APPDATA
 
 function hermesPath(...parts: string[]) {
   return join(homeDir, '.hermes', ...parts)
@@ -20,6 +23,9 @@ function writeModelsCache(data: Record<string, unknown>) {
 }
 
 async function loadModelContext() {
+  process.env.HERMES_HOME = hermesPath()
+  delete process.env.LOCALAPPDATA
+  delete process.env.APPDATA
   vi.resetModules()
   vi.doMock('os', async () => ({
     ...(await vi.importActual<typeof import('os')>('os')),
@@ -43,6 +49,12 @@ describe('getModelContextLength', () => {
 
   afterEach(() => {
     vi.doUnmock('os')
+    if (originalHermesHome === undefined) delete process.env.HERMES_HOME
+    else process.env.HERMES_HOME = originalHermesHome
+    if (originalLocalAppData === undefined) delete process.env.LOCALAPPDATA
+    else process.env.LOCALAPPDATA = originalLocalAppData
+    if (originalAppData === undefined) delete process.env.APPDATA
+    else process.env.APPDATA = originalAppData
     if (homeDir) rmSync(homeDir, { recursive: true, force: true })
     homeDir = ''
   })


### PR DESCRIPTION
# Fix Windows test path isolation

## Summary
This PR fixes Windows-specific test failures caused by POSIX path assumptions and incomplete Hermes home isolation in tests.

## Root cause
- `auth.test.ts` expected POSIX-style `/tmp/...` paths while the production code correctly uses `path.join()`, which returns Windows separators on Windows.
- `model-context.test.ts` mocked `os.homedir()`, but the production Hermes path resolver uses `HERMES_HOME` first and then `%LOCALAPPDATA%` / `%APPDATA%` on Windows. The test wrote fixtures under the mocked home directory while the implementation read from a different Hermes home.
- `i18n-coverage.test.ts` asserted a POSIX relative path and used a POSIX-only substring check while scanning source files.

## Changes
- Build auth test expected paths with `path.join()`.
- Make auth token write option expectations match platform behavior: Windows gets `{}`, non-Windows gets `{ mode: 0o600 }`.
- Set `HERMES_HOME` in `model-context.test.ts` so production path resolution reads the same temp fixture directory used by the test.
- Restore `HERMES_HOME`, `LOCALAPPDATA`, and `APPDATA` after each model-context test.
- Make the i18n coverage root assertion and locale exclusion cross-platform.

## Validation
- `npx vitest run tests/server/auth.test.ts tests/server/model-context.test.ts --reporter verbose` — 32/32 passed
- `npx vitest run tests/client/i18n-coverage.test.ts --reporter verbose` — 3/3 passed
- `npm test` — 66 files passed, 450 tests passed, 2 skipped
- `npm run build` — passed

## Scope
This PR only changes tests. It does not change production behavior.
