### PR TITLE
fix: skip gateway shutdown during dev restarts

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -5,7 +5,8 @@
     "ts": "node -r ts-node/register"
   },
   "env": {
-    "TS_NODE_PROJECT": "packages/server/tsconfig.json"
+    "TS_NODE_PROJECT": "packages/server/tsconfig.json",
+    "HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN": "0"
   },
   "exec": "node -r ts-node/register packages/server/src/index.ts",
   "nodeArgs": ["--no-warnings"],

--- a/packages/server/src/services/shutdown.ts
+++ b/packages/server/src/services/shutdown.ts
@@ -3,8 +3,8 @@ import { closeDb } from '../db'
 import { getGatewayManagerInstance } from './gateway-bootstrap'
 
 function shouldStopGatewaysOnShutdown(signal: string): boolean {
-  // 总是停止网关，无论是开发环境还是生产环境
-  // 这样可以避免 nodemon 重启时的孤儿进程问题
+  // nodemon may use SIGTERM on Windows restarts, so dev mode opts out via env.
+  // Production keeps stopping owned gateways by default.
   const override = process.env.HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN?.trim()
   if (override === '0' || override === 'false') return false
   if (override === '1' || override === 'true') return true


### PR DESCRIPTION
## Summary
- Set `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN=0` in `nodemon.json` so nodemon restarts don't kill running gateways
- Update shutdown comment to clarify env var purpose
- Production behavior unchanged (stops owned gateways by default)

## Test plan
- [ ] `npm run dev:server` — modify a file, verify gateway stays alive across nodemon restart
- [ ] Production: `docker compose up` → `docker compose down` — gateway still stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)