### PR TITLE
fix: parse .env and SOUL.md fields from profile show output

### DIFF
--- a/packages/server/src/services/hermes/hermes-cli.ts
+++ b/packages/server/src/services/hermes/hermes-cli.ts
@@ -428,7 +428,7 @@ export async function getProfile(name: string): Promise<HermesProfileDetail> {
 
     const result: Record<string, string> = {}
     for (const line of stdout.trim().split('\n')) {
-      const match = line.match(/^(\w[\w\s]*?):\s+(.+)$/)
+      const match = line.match(/^([^\s:]+):\s+(.+)$/)
       if (match) {
         result[match[1].trim().toLowerCase().replace(/\s+/g, '_')] = match[2].trim()
       }
@@ -446,7 +446,7 @@ export async function getProfile(name: string): Promise<HermesProfileDetail> {
       gateway: result.gateway || '',
       skills: parseInt(result.skills || '0', 10),
       hasEnv: result['.env'] === 'exists',
-      hasSoulMd: result.soul_md === 'exists',
+      hasSoulMd: result['soul.md'] === 'exists',
     }
   } catch (err: any) {
     if (err.code === 1 || err.status === 1) {


### PR DESCRIPTION
## Summary
- `hermes profile show` outputs keys like `.env:` and `SOUL.md:` which contain dots
- The parsing regex `^(\w[\w\s]*?)` only matches `[a-zA-Z0-9_]` so both keys were silently skipped
- Changed regex to `^([^\s:]+)` to allow dots and other non-whitespace characters in keys
- Fixed `result.soul_md` → `result['soul.md']` to match the actual lowercased key

## Test plan
- [ ] Run `hermes profile show default` and confirm `.env: exists` and `SOUL.md: exists` appear
- [ ] Open Profiles page, expand a profile detail, verify hasEnv and hasSoulMd show "Yes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)