### PR TITLE
修复 Docker gateway env 配置和 proxy auth 不一致

### DIFF
--- a/packages/server/src/services/hermes/gateway-manager.ts
+++ b/packages/server/src/services/hermes/gateway-manager.ts
@@ -134,6 +134,15 @@ interface ResolvedGatewayEndpoint {
   host: string
 }
 
+type GatewayConfigSource = 'process-env' | 'profile-env' | 'config' | 'default'
+
+interface ResolvedGatewayRuntimeConfig extends ResolvedGatewayEndpoint {
+  apiKey: string | null
+  portSource: GatewayConfigSource
+  hostSource: GatewayConfigSource
+  apiKeySource: GatewayConfigSource | null
+}
+
 function formatHostForUrl(host: string): string {
   if (host.startsWith('[') && host.endsWith(']')) return host
   return host.includes(':') ? `[${host}]` : host
@@ -145,6 +154,39 @@ function buildHttpUrl(host: string, port: number): string {
 
 function isLocalHost(host: string): boolean {
   return ['127.0.0.1', 'localhost', '::1', '[::1]', '0.0.0.0'].includes(host)
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
+function parsePort(value: unknown): number | null {
+  if (value === undefined || value === null || value === '') return null
+  if (typeof value === 'string' && !/^\d+$/.test(value.trim())) return null
+  const port = typeof value === 'number' ? value : Number(String(value).trim())
+  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : null
+}
+
+function parseBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') return value
+  if (typeof value !== 'string') return false
+  return ['true', '1', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
+function parseDotEnvValue(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed) return ''
+
+  const quote = trimmed[0]
+  if (quote === '"' || quote === "'") {
+    const end = trimmed.indexOf(quote, 1)
+    return (end === -1 ? trimmed.slice(1) : trimmed.slice(1, end)).trim()
+  }
+
+  const commentIndex = trimmed.search(/\s+#/)
+  return (commentIndex === -1 ? trimmed : trimmed.slice(0, commentIndex)).trim()
 }
 
 function shouldDetachGatewayProcess(): boolean {
@@ -190,29 +232,108 @@ export class GatewayManager {
     return join(HERMES_BASE, 'profiles', name)
   }
 
-  /**
-   * 从 profile 的 config.yaml 读取 api_server 端口和主机
-   * 读取路径：platforms.api_server.extra.port / extra.host
-   */
-  private readProfilePort(name: string): { port: number; host: string } {
+  private readProfileConfig(name: string): any {
     const configPath = join(this.profileDir(name), 'config.yaml')
-    const defaultHost = process.env.GATEWAY_HOST || '127.0.0.1'
-
-    if (!existsSync(configPath)) return { port: 8642, host: defaultHost }
+    if (!existsSync(configPath)) return {}
 
     try {
       const content = readFileSync(configPath, 'utf-8')
-      const cfg = yaml.load(content, { json: true }) as any || {}
-
-      const extra = cfg?.platforms?.api_server?.extra
-      const rawPort = extra?.port || 8642
-      const port = typeof rawPort === 'number' ? rawPort : parseInt(rawPort, 10) || 8642
-      const host = extra?.host || defaultHost
-      // 端口超出合法范围时回退到默认值
-      return { port: port > 0 && port <= 65535 ? port : 8642, host }
+      return (yaml.load(content, { json: true }) as any) || {}
     } catch {
-      return { port: 8642, host: defaultHost }
+      return {}
     }
+  }
+
+  private readProfileEnvValue(name: string, key: string): string | null {
+    try {
+      const envPath = join(this.profileDir(name), '.env')
+      if (!existsSync(envPath)) return null
+      const content = readFileSync(envPath, 'utf-8')
+      const pattern = new RegExp(`^\\s*(?:export\\s+)?${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*=\\s*(.*)$`, 'm')
+      const match = content.match(pattern)
+      return match ? parseDotEnvValue(match[1]) || null : null
+    } catch {
+      return null
+    }
+  }
+
+  private isApiServerEnvOverrideActive(name: string): boolean {
+    return Boolean(
+      parseBoolean(process.env.API_SERVER_ENABLED) ||
+      nonEmptyString(process.env.API_SERVER_HOST) ||
+      nonEmptyString(process.env.API_SERVER_PORT) ||
+      nonEmptyString(process.env.API_SERVER_KEY) ||
+      parseBoolean(this.readProfileEnvValue(name, 'API_SERVER_ENABLED')) ||
+      nonEmptyString(this.readProfileEnvValue(name, 'API_SERVER_HOST')) ||
+      nonEmptyString(this.readProfileEnvValue(name, 'API_SERVER_PORT')) ||
+      nonEmptyString(this.readProfileEnvValue(name, 'API_SERVER_KEY')),
+    )
+  }
+
+  /**
+   * Resolve the effective API server endpoint and key exactly as the spawned
+   * Hermes gateway process will see them: container/process env first, then
+   * profile .env, then config.yaml, then WUI defaults.
+   */
+  private resolveGatewayRuntimeConfig(name: string): ResolvedGatewayRuntimeConfig {
+    const cfg = this.readProfileConfig(name)
+    const apiServer = cfg?.platforms?.api_server || {}
+    const extra = apiServer?.extra || {}
+    const defaultHost = nonEmptyString(process.env.GATEWAY_HOST) || '127.0.0.1'
+    const envOverridesActive = this.isApiServerEnvOverrideActive(name)
+
+    const configuredPort = parsePort(extra?.port ?? apiServer?.port)
+    const profileEnvPort = (envOverridesActive || configuredPort === null)
+      ? parsePort(this.readProfileEnvValue(name, 'API_SERVER_PORT'))
+      : null
+    const processEnvPort = (envOverridesActive || configuredPort === null)
+      ? parsePort(process.env.API_SERVER_PORT)
+      : null
+    const configPort = configuredPort ?? 8642
+    const port = processEnvPort ?? profileEnvPort ?? configPort
+    const portSource: GatewayConfigSource = processEnvPort !== null
+      ? 'process-env'
+      : profileEnvPort !== null
+        ? 'profile-env'
+        : (configuredPort !== null ? 'config' : 'default')
+
+    const configuredHost = nonEmptyString(extra?.host) ?? nonEmptyString(apiServer?.host)
+    const profileEnvHost = (envOverridesActive || configuredHost === null)
+      ? nonEmptyString(this.readProfileEnvValue(name, 'API_SERVER_HOST'))
+      : null
+    const processEnvHost = (envOverridesActive || configuredHost === null)
+      ? nonEmptyString(process.env.API_SERVER_HOST)
+      : null
+    const configHost = configuredHost ?? defaultHost
+    const host = processEnvHost ?? profileEnvHost ?? configHost
+    const hostSource: GatewayConfigSource = processEnvHost
+      ? 'process-env'
+      : profileEnvHost
+        ? 'profile-env'
+        : (configuredHost ? 'config' : 'default')
+
+    const configKey = nonEmptyString(extra?.key) ?? nonEmptyString(apiServer?.key) ?? nonEmptyString(apiServer?.api_key)
+    const profileEnvKey = this.readProfileEnvValue(name, 'API_SERVER_KEY')
+    const processEnvKey = nonEmptyString(process.env.API_SERVER_KEY)
+    const apiKey = processEnvKey ?? profileEnvKey ?? configKey ?? null
+    const apiKeySource: GatewayConfigSource | null = processEnvKey
+      ? 'process-env'
+      : profileEnvKey
+        ? 'profile-env'
+        : configKey
+          ? 'config'
+          : null
+
+    return { port, host, apiKey, portSource, hostSource, apiKeySource }
+  }
+
+  /**
+   * 从 profile 的有效运行时配置读取 api_server 端口和主机。
+   * 读取顺序：process env → profile .env → config.yaml → defaults。
+   */
+  private readProfilePort(name: string): { port: number; host: string } {
+    const { port, host } = this.resolveGatewayRuntimeConfig(name)
+    return { port, host }
   }
 
   /** Read a profile gateway PID, falling back to runtime state when gateway.pid is missing. */
@@ -319,11 +440,10 @@ export class GatewayManager {
    *   platforms:
    *     api_server:
    *       enabled: true
-   *       key: ''
-   *       cors_origins: '*'
    *       extra:
    *         port: <port>
    *         host: <host>
+   * 只更新端口/主机，保留用户已有的 key/cors_origins 等安全配置。
    * 同时清理旧的顶层 port/host（避免 Hermes 读取错误）
    */
   private writeProfilePort(name: string, port: number, host: string): void {
@@ -338,8 +458,6 @@ export class GatewayManager {
       if (!cfg.platforms.api_server.extra) cfg.platforms.api_server.extra = {}
 
       cfg.platforms.api_server.enabled = true
-      cfg.platforms.api_server.key = ''
-      cfg.platforms.api_server.cors_origins = '*'
       cfg.platforms.api_server.extra.port = port
       cfg.platforms.api_server.extra.host = host
 
@@ -406,7 +524,10 @@ export class GatewayManager {
       }
     }
 
-    const port = await this.findFreePort(8642, host, usedPorts)
+    const runtimeConfig = this.resolveGatewayRuntimeConfig(name)
+    const port = (runtimeConfig.portSource === 'process-env' || runtimeConfig.portSource === 'profile-env')
+      ? configuredPort
+      : await this.findFreePort(8642, host, usedPorts)
     if (configuredPort !== port) {
       logger.info('Assigning port for profile "%s": %d → %d', name, configuredPort, port)
     } else {
@@ -431,18 +552,10 @@ export class GatewayManager {
     return buildHttpUrl(host, port)
   }
 
-  /** 读取 profile 的 API_SERVER_KEY（从 .env 文件） */
+  /** 读取 profile 的有效 API_SERVER_KEY（process env → .env → config.yaml） */
   getApiKey(profileName?: string): string | null {
     const name = profileName || this.activeProfile
-    try {
-      const envPath = join(this.profileDir(name), '.env')
-      if (!existsSync(envPath)) return null
-      const content = readFileSync(envPath, 'utf-8')
-      const match = content.match(/^API_SERVER_KEY\s*=\s*"?([^"\n]+)"?/m)
-      return match?.[1]?.trim() || null
-    } catch {
-      return null
-    }
+    return this.resolveGatewayRuntimeConfig(name).apiKey
   }
 
   getActiveProfile(): string {

--- a/tests/server/gateway-manager.test.ts
+++ b/tests/server/gateway-manager.test.ts
@@ -4,6 +4,10 @@ import { join } from 'path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const originalHermesHome = process.env.HERMES_HOME
+const originalApiServerEnabled = process.env.API_SERVER_ENABLED
+const originalApiServerHost = process.env.API_SERVER_HOST
+const originalApiServerPort = process.env.API_SERVER_PORT
+const originalApiServerKey = process.env.API_SERVER_KEY
 const tempHomes: string[] = []
 
 function createHermesHome(): string {
@@ -27,6 +31,18 @@ afterEach(() => {
   } else {
     process.env.HERMES_HOME = originalHermesHome
   }
+
+  if (originalApiServerEnabled === undefined) delete process.env.API_SERVER_ENABLED
+  else process.env.API_SERVER_ENABLED = originalApiServerEnabled
+
+  if (originalApiServerHost === undefined) delete process.env.API_SERVER_HOST
+  else process.env.API_SERVER_HOST = originalApiServerHost
+
+  if (originalApiServerPort === undefined) delete process.env.API_SERVER_PORT
+  else process.env.API_SERVER_PORT = originalApiServerPort
+
+  if (originalApiServerKey === undefined) delete process.env.API_SERVER_KEY
+  else process.env.API_SERVER_KEY = originalApiServerKey
 
   for (const home of tempHomes.splice(0)) {
     rmSync(home, { recursive: true, force: true })
@@ -93,5 +109,125 @@ describe('GatewayManager Windows process recovery', () => {
     const manager = await createManager(home)
 
     expect(manager.readPidFile('work')).toBe(33333)
+  })
+})
+
+describe('GatewayManager effective API server config', () => {
+  it('uses API_SERVER_PORT and API_SERVER_HOST env overrides when resolving the upstream', async () => {
+    const home = createHermesHome()
+    writeFileSync(join(home, 'config.yaml'), [
+      'platforms:',
+      '  api_server:',
+      '    enabled: true',
+      '    extra:',
+      '      host: 127.0.0.1',
+      '      port: 8642',
+      '',
+    ].join('\n'))
+    process.env.API_SERVER_HOST = '0.0.0.0'
+    process.env.API_SERVER_PORT = '8655'
+
+    const manager = await createManager(home)
+
+    expect(manager.getUpstream()).toBe('http://0.0.0.0:8655')
+    expect(manager.readProfilePort('default')).toEqual({ host: '0.0.0.0', port: 8655 })
+  })
+
+  it('ignores invalid API_SERVER_PORT env values and keeps the configured port', async () => {
+    const home = createHermesHome()
+    writeFileSync(join(home, 'config.yaml'), [
+      'platforms:',
+      '  api_server:',
+      '    enabled: true',
+      '    extra:',
+      '      host: 127.0.0.1',
+      '      port: 8650',
+      '',
+    ].join('\n'))
+    process.env.API_SERVER_PORT = 'not-a-port'
+
+    const manager = await createManager(home)
+
+    expect(manager.getUpstream()).toBe('http://127.0.0.1:8650')
+  })
+
+  it('uses API_SERVER_PORT env as a fallback when config has no port', async () => {
+    const home = createHermesHome()
+    writeFileSync(join(home, 'config.yaml'), [
+      'platforms:',
+      '  api_server:',
+      '    enabled: true',
+      '    extra: {}',
+      '',
+    ].join('\n'))
+    process.env.API_SERVER_PORT = '8655'
+
+    const manager = await createManager(home)
+
+    expect(manager.getUpstream()).toBe('http://127.0.0.1:8655')
+  })
+
+  it('uses API_SERVER_KEY from process env for proxy authentication', async () => {
+    process.env.API_SERVER_KEY = 'env-secret'
+
+    const manager = await createManager(createHermesHome())
+
+    expect(manager.getApiKey()).toBe('env-secret')
+  })
+
+  it('uses API_SERVER_KEY from profile .env when process env is not set', async () => {
+    const home = createHermesHome()
+    writeFileSync(join(home, '.env'), 'API_SERVER_KEY="file-secret"\n')
+
+    const manager = await createManager(home)
+
+    expect(manager.getApiKey()).toBe('file-secret')
+  })
+
+  it('reads API server key from Hermes config when env files are absent', async () => {
+    const home = createHermesHome()
+    writeFileSync(join(home, 'config.yaml'), [
+      'platforms:',
+      '  api_server:',
+      '    enabled: true',
+      '    extra:',
+      '      key: config-secret',
+      '',
+    ].join('\n'))
+
+    const manager = await createManager(home)
+
+    expect(manager.getApiKey()).toBe('config-secret')
+  })
+
+  it('preserves existing API server key and CORS settings when writing the port', async () => {
+    const home = createHermesHome()
+    writeFileSync(join(home, 'config.yaml'), [
+      'platforms:',
+      '  api_server:',
+      '    enabled: true',
+      '    key: legacy-key',
+      '    cors_origins:',
+      '      - https://example.test',
+      '    extra:',
+      '      key: extra-secret',
+      '      cors_origins:',
+      '        - https://api.example.test',
+      '',
+    ].join('\n'))
+
+    const manager = await createManager(home)
+    manager.writeProfilePort('default', 8655, '127.0.0.1')
+
+    const { default: yaml } = await import('js-yaml')
+    const { readFileSync } = await import('fs')
+    const cfg = yaml.load(readFileSync(join(home, 'config.yaml'), 'utf-8')) as any
+
+    expect(cfg.platforms.api_server.key).toBe('legacy-key')
+    expect(cfg.platforms.api_server.cors_origins).toEqual(['https://example.test'])
+    expect(cfg.platforms.api_server.extra.key).toBe('extra-secret')
+    expect(cfg.platforms.api_server.extra.cors_origins).toEqual(['https://api.example.test'])
+    expect(cfg.platforms.api_server.extra.port).toBe(8655)
+    expect(cfg.platforms.api_server.extra.host).toBe('127.0.0.1')
   })
 })

--- a/tests/server/proxy-handler.test.ts
+++ b/tests/server/proxy-handler.test.ts
@@ -1,16 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
+const { mockUpdateUsage, mockGatewayManager } = vi.hoisted(() => ({
+  mockUpdateUsage: vi.fn(),
+  mockGatewayManager: {
+    getUpstream: vi.fn(() => 'http://127.0.0.1:8642'),
+    getApiKey: vi.fn(() => null as string | null),
+  },
+}))
+
 vi.mock('../../packages/server/src/services/gateway-bootstrap', () => ({
-  getGatewayManagerInstance: () => ({
-    getUpstream: () => 'http://127.0.0.1:8642',
-    getApiKey: () => null,
-  }),
+  getGatewayManagerInstance: () => mockGatewayManager,
 }))
 
 // Mock updateUsage so we can assert calls without real DB
-const { mockUpdateUsage } = vi.hoisted(() => ({
-  mockUpdateUsage: vi.fn(),
-}))
 vi.mock('../../packages/server/src/db/hermes/usage-store', () => ({
   updateUsage: mockUpdateUsage,
 }))
@@ -70,6 +72,8 @@ function createSSEBody(events: string[]): ReadableStream<Uint8Array> {
 describe('Proxy Handler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockGatewayManager.getUpstream.mockReturnValue('http://127.0.0.1:8642')
+    mockGatewayManager.getApiKey.mockReturnValue(null)
   })
 
   it('rewrites /api/hermes/v1/* to /v1/*', async () => {
@@ -120,6 +124,25 @@ describe('Proxy Handler', () => {
 
     const [, options] = mockFetch.mock.calls[0]
     expect(options.headers.authorization).toBeUndefined()
+  })
+
+
+  it('replaces browser authorization with the effective Hermes API key', async () => {
+    mockGatewayManager.getApiKey.mockReturnValue('gateway-secret')
+    mockFetch.mockResolvedValue({
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      body: null,
+      json: () => Promise.resolve({}),
+    })
+
+    const ctx = createMockCtx({
+      headers: { host: 'localhost:8648', authorization: 'Bearer web-ui-token' },
+    })
+    await proxy(ctx)
+
+    const [, options] = mockFetch.mock.calls[0]
+    expect(options.headers.authorization).toBe('Bearer gateway-secret')
   })
 
   it('replaces host header with upstream host', async () => {


### PR DESCRIPTION
Fixes #547

相关：#549、#607、#656

Docker single-container 下的 gateway 连接路径已补齐：Hermes Web UI 启动、探测、proxy 现在用同一套 API server host / port / key 解析，不再因为 env 和 `config.yaml` 不一致而打到错端口，或者在 gateway 已设置 `API_SERVER_KEY` 时漏掉 upstream bearer key。

旧发布里的双容器问题还是要等包含 single-container 的镜像/标签才会真正对用户可见；这个 PR 只处理 current main 里剩下的运行时配置一致性问题。

## 改动
- `GatewayManager` 统一解析有效的 API server 配置：process env → profile `.env` → `config.yaml` → default。
- proxy 转发 Hermes gateway 请求时，先去掉浏览器侧 `Authorization`，再按有效 `API_SERVER_KEY` 注入 upstream bearer token。
- `API_SERVER_PORT` / `API_SERVER_HOST` 通过 Docker env 设置时，Web UI 的 health/proxy 也会跟随同一个端口和 host。
- `writeProfilePort` 只更新 `extra.port` / `extra.host`，保留已有 `key`、`api_key`、`cors_origins` 等安全配置。
- 补了 env key、profile `.env` key、config key、env port/host、配置保留、proxy header 替换的回归测试。

## 验证
已通过：

```bash
npm test -- tests/server/gateway-manager.test.ts tests/server/proxy-handler.test.ts
npx tsc --noEmit -p packages/server/tsconfig.json
npm run build
```

结果：29 个相关测试通过；server typecheck 通过；production build 通过。

Docker smoke 也过了两组：
- `API_SERVER_KEY` 只通过 container env 设置：proxied `/api/hermes/v1/models` 返回 200；container 内 direct no-auth `/v1/models` 返回 401；direct bearer auth 返回 200。
- `API_SERVER_PORT=8655` 只通过 container env 设置：proxied `/api/hermes/v1/models` 返回 200；container 内 `127.0.0.1:8655/health` 返回 200；`127.0.0.1:8642/health` 不再监听。

已知：
- `npm run build` 仍会打印现有的大 chunk warning；这次没有改 frontend chunking。
- 当前 `package.json` 版本号还是 `0.5.17`。single-container 能不能被用户拉到，取决于后续镜像/标签发布。