### PR TITLE
fix: add missing models for OpenCode Go provider

### DIFF
--- a/packages/client/src/shared/providers.ts
+++ b/packages/client/src/shared/providers.ts
@@ -252,7 +252,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     label: 'OpenCode Go',
     value: 'opencode-go',
     base_url: 'https://opencode.ai/zen/go/v1',
-    models: ['glm-5.1', 'glm-5', 'kimi-k2.5', 'kimi-k2.6', 'deepseek-v4-pro', 'deepseek-v4-flash', 'mimo-v2-pro', 'mimo-v2-omni', 'mimo-v2.5-pro', 'mimo-v2.5', 'minimax-m2.7', 'minimax-m2.5', 'qwen3.6-plus', 'qwen3.5-plus'],
+    models: ['glm-5.1', 'glm-5', 'kimi-k2.5', 'kimi-k2.6', 'deepseek-v4-pro', 'deepseek-v4-flash', 'mimo-v2.5-pro', 'mimo-v2.5', 'minimax-m2.7', 'minimax-m2.5', 'qwen3.6-plus', 'qwen3.5-plus'],
   },
   {
     label: 'OpenAI Codex',

--- a/packages/client/src/shared/providers.ts
+++ b/packages/client/src/shared/providers.ts
@@ -252,7 +252,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     label: 'OpenCode Go',
     value: 'opencode-go',
     base_url: 'https://opencode.ai/zen/go/v1',
-    models: ['glm-5.1', 'glm-5', 'kimi-k2.5', 'mimo-v2-pro', 'mimo-v2-omni', 'minimax-m2.7', 'minimax-m2.5'],
+    models: ['glm-5.1', 'glm-5', 'kimi-k2.5', 'kimi-k2.6', 'deepseek-v4-pro', 'deepseek-v4-flash', 'mimo-v2-pro', 'mimo-v2-omni', 'mimo-v2.5-pro', 'mimo-v2.5', 'minimax-m2.7', 'minimax-m2.5', 'qwen3.6-plus', 'qwen3.5-plus'],
   },
   {
     label: 'OpenAI Codex',

--- a/packages/server/src/shared/providers.ts
+++ b/packages/server/src/shared/providers.ts
@@ -320,7 +320,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     value: 'opencode-go',
     builtin: true,
     base_url: 'https://opencode.ai/zen/go/v1',
-    models: ['glm-5.1', 'glm-5', 'kimi-k2.5', 'kimi-k2.6', 'deepseek-v4-pro', 'deepseek-v4-flash', 'mimo-v2-pro', 'mimo-v2-omni', 'mimo-v2.5-pro', 'mimo-v2.5', 'minimax-m2.7', 'minimax-m2.5', 'qwen3.6-plus', 'qwen3.5-plus'],
+    models: ['glm-5.1', 'glm-5', 'kimi-k2.5', 'kimi-k2.6', 'deepseek-v4-pro', 'deepseek-v4-flash', 'mimo-v2.5-pro', 'mimo-v2.5', 'minimax-m2.7', 'minimax-m2.5', 'qwen3.6-plus', 'qwen3.5-plus'],
   },
   {
     label: 'LongCat',

--- a/packages/server/src/shared/providers.ts
+++ b/packages/server/src/shared/providers.ts
@@ -320,7 +320,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     value: 'opencode-go',
     builtin: true,
     base_url: 'https://opencode.ai/zen/go/v1',
-    models: ['glm-5.1', 'glm-5', 'kimi-k2.5', 'mimo-v2-pro', 'mimo-v2-omni', 'minimax-m2.7', 'minimax-m2.5'],
+    models: ['glm-5.1', 'glm-5', 'kimi-k2.5', 'kimi-k2.6', 'deepseek-v4-pro', 'deepseek-v4-flash', 'mimo-v2-pro', 'mimo-v2-omni', 'mimo-v2.5-pro', 'mimo-v2.5', 'minimax-m2.7', 'minimax-m2.5', 'qwen3.6-plus', 'qwen3.5-plus'],
   },
   {
     label: 'LongCat',


### PR DESCRIPTION
## Summary

Add missing model entries to the OpenCode Go provider preset list in both server and client providers.ts.

## Changes

- Added: `kimi-k2.6`, `deepseek-v4-pro`, `deepseek-v4-flash`, `mimo-v2.5-pro`, `mimo-v2.5`, `qwen3.6-plus`, `qwen3.5-plus`

## Files Modified

- `packages/server/src/shared/providers.ts`
- `packages/client/src/shared/providers.ts`