### PR TITLE
feat: add Ollama Cloud provider preset

### DIFF
--- a/packages/client/src/shared/providers.ts
+++ b/packages/client/src/shared/providers.ts
@@ -267,6 +267,12 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     models: ['trinity-large-thinking', 'trinity-large-preview', 'trinity-mini'],
   },
   {
+    label: 'Ollama Cloud',
+    value: 'ollama-cloud',
+    base_url: 'https://ollama.com/v1',
+    models: [],
+  },
+  {
     label: 'OpenRouter',
     value: 'openrouter',
     base_url: 'https://openrouter.ai/api/v1',

--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -250,7 +250,7 @@ export async function getAvailable(ctx: any) {
           }
           if (Object.keys(modelMeta).length === 0) modelMeta = undefined
         }
-      } else if (providerKey === 'openrouter' || providerKey === 'cliproxyapi') {
+      } else if (providerKey === 'openrouter' || providerKey === 'cliproxyapi' || providerKey === 'ollama-cloud') {
         // OpenRouter and local CLIProxyAPI expose dynamic OpenAI-compatible /models catalogs.
         if (envMapping.api_key_env) {
           const apiKey = envGetValue(envMapping.api_key_env)

--- a/packages/server/src/services/config-helpers.ts
+++ b/packages/server/src/services/config-helpers.ts
@@ -33,6 +33,7 @@ export const PROVIDER_ENV_MAP: Record<string, { api_key_env: string; base_url_en
   huggingface: { api_key_env: 'HF_TOKEN', base_url_env: '' },
   arcee: { api_key_env: 'ARCEE_API_KEY', base_url_env: '' },
   stepfun: { api_key_env: 'STEPFUN_API_KEY', base_url_env: '' },
+  'ollama-cloud': { api_key_env: 'OLLAMA_API_KEY', base_url_env: 'OLLAMA_BASE_URL' },
   nous: { api_key_env: '', base_url_env: '' },
   'openai-codex': { api_key_env: '', base_url_env: '' },
   copilot: { api_key_env: '', base_url_env: '' },

--- a/packages/server/src/shared/providers.ts
+++ b/packages/server/src/shared/providers.ts
@@ -388,6 +388,13 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     models: ['step-3.5-flash', 'step-3.5-flash-2603'],
   },
   {
+    label: 'Ollama Cloud',
+    value: 'ollama-cloud',
+    builtin: true,
+    base_url: 'https://ollama.com/v1',
+    models: [],
+  },
+  {
     label: 'OpenRouter',
     value: 'openrouter',
     builtin: true,


### PR DESCRIPTION
## Summary

- Add Ollama Cloud (`ollama-cloud`) provider preset to both client and server provider catalogs
- Enable dynamic model catalog fetching for the `ollama-cloud` provider (alongside `openrouter` and `cliproxyapi`)
- Add `OLLAMA_API_KEY` and `OLLAMA_BASE_URL` environment variable mappings for the new provider