### PR TITLE
feat:聊天对话内容大纲

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -21,6 +21,7 @@ import ConversationMonitorPane from "./ConversationMonitorPane.vue";
 import MessageList from "./MessageList.vue";
 import SessionListItem from "./SessionListItem.vue";
 import DrawerPanel from "./DrawerPanel.vue";
+import OutlinePanel from "./OutlinePanel.vue";
 
 const chatStore = useChatStore();
 const sessionBrowserPrefsStore = useSessionBrowserPrefsStore();
@@ -29,6 +30,7 @@ const { t } = useI18n();
 
 const showDrawer = ref(false);
 const drawerActiveTab = ref<"terminal" | "files">("files");
+const showOutline = ref(true);
 
 const currentMode = ref<"chat" | "live">("chat");
 
@@ -695,105 +697,132 @@ async function handleWorkspaceConfirm() {
       <FolderPicker v-model="workspaceValue" />
     </NModal>
 
-    <div class="chat-main">
-      <header class="chat-header">
-        <div class="header-left">
-          <NButton
-            v-if="currentMode === 'chat'"
-            quaternary
-            size="small"
-            @click="showSessions = !showSessions"
-            circle
-          >
-            <template #icon>
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-              >
-                <rect x="3" y="3" width="7" height="7" />
-                <rect x="14" y="3" width="7" height="7" />
-                <rect x="3" y="14" width="7" height="7" />
-                <rect x="14" y="14" width="7" height="7" />
-              </svg>
-            </template>
-          </NButton>
-          <span class="header-session-title">{{ headerTitle }}</span>
-          <span v-if="activeSessionSource" class="source-badge">{{
-            getSourceLabel(activeSessionSource)
-          }}</span>
-          <span
-            v-if="chatStore.activeSession?.workspace"
-            class="workspace-badge"
-            :title="chatStore.activeSession.workspace"
-            >📁
-            {{
-              chatStore.activeSession.workspace.split("/").pop() ||
-              chatStore.activeSession.workspace
-            }}</span
-          >
-        </div>
-        <div class="header-actions">
-          <!-- chat/live mode toggle hidden -->
-          <template v-if="currentMode === 'chat'">
-            <NTooltip trigger="hover">
-              <template #trigger>
-                <NButton
-                  quaternary
-                  size="small"
-                  @click="copySessionId()"
-                  circle
-                >
-                  <template #icon>
-                    <svg
-                      width="14"
-                      height="14"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.5"
-                    >
-                      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-                      <path
-                        d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
-                      />
-                    </svg>
-                  </template>
-                </NButton>
-              </template>
-              {{ t("chat.copySessionId") }}
-            </NTooltip>
-            <NButton size="small" :circle="isMobile" @click="handleNewChat">
+    <div class="chat-wrapper">
+      <div class="chat-main">
+        <header class="chat-header">
+          <div class="header-left">
+            <NButton
+              v-if="currentMode === 'chat'"
+              quaternary
+              size="small"
+              @click="showSessions = !showSessions"
+              circle
+            >
               <template #icon>
                 <svg
-                  width="14"
-                  height="14"
+                  width="16"
+                  height="16"
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
-                  stroke-width="2"
+                  stroke-width="1.5"
                 >
-                  <line x1="12" y1="5" x2="12" y2="19" />
-                  <line x1="5" y1="12" x2="19" y2="12" />
+                  <rect x="3" y="3" width="7" height="7" />
+                  <rect x="14" y="3" width="7" height="7" />
+                  <rect x="3" y="14" width="7" height="7" />
+                  <rect x="14" y="14" width="7" height="7" />
                 </svg>
               </template>
-              <template v-if="!isMobile">{{ t("chat.newChat") }}</template>
             </NButton>
-          </template>
-        </div>
-      </header>
+            <span class="header-session-title">{{ headerTitle }}</span>
+            <span v-if="activeSessionSource" class="source-badge">{{
+              getSourceLabel(activeSessionSource)
+            }}</span>
+            <span
+              v-if="chatStore.activeSession?.workspace"
+              class="workspace-badge"
+              :title="chatStore.activeSession.workspace"
+              >📁
+              {{
+                chatStore.activeSession.workspace.split("/").pop() ||
+                chatStore.activeSession.workspace
+              }}</span
+            >
+          </div>
+          <div class="header-actions">
+            <!-- chat/live mode toggle hidden -->
+            <template v-if="currentMode === 'chat'">
+                <NTooltip trigger="hover">
+                  <template #trigger>
+                    <NButton
+                      quaternary
+                      size="small"
+                      @click="showOutline = !showOutline"
+                      circle
+                    >
+                      <template #icon>
+                        <svg
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="1.5"
+                        >
+                          <path d="M3 12h18M3 6h18M3 18h18" />
+                        </svg>
+                      </template>
+                    </NButton>
+                  </template>
+                  会话大纲
+                </NTooltip>
+                <NTooltip trigger="hover">
+                  <template #trigger>
+                    <NButton
+                      quaternary
+                      size="small"
+                      @click="copySessionId()"
+                      circle
+                    >
+                      <template #icon>
+                        <svg
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="1.5"
+                        >
+                          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                          <path
+                            d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+                          />
+                        </svg>
+                      </template>
+                    </NButton>
+                  </template>
+                  {{ t("chat.copySessionId") }}
+                </NTooltip>
+                <NButton size="small" :circle="isMobile" @click="handleNewChat">
+                <template #icon>
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <line x1="12" y1="5" x2="12" y2="19" />
+                    <line x1="5" y1="12" x2="19" y2="12" />
+                  </svg>
+                </template>
+                <template v-if="!isMobile">{{ t("chat.newChat") }}</template>
+              </NButton>
+            </template>
+          </div>
+        </header>
 
-      <template v-if="currentMode === 'chat'">
-        <MessageList />
-        <ChatInput />
-      </template>
-      <ConversationMonitorPane
-        v-else
-        :human-only="sessionBrowserPrefsStore.humanOnly"
-      />
+        <template v-if="currentMode === 'chat'">
+          <MessageList />
+          <ChatInput />
+        </template>
+        <ConversationMonitorPane
+          v-else
+          :human-only="sessionBrowserPrefsStore.humanOnly"
+        />
+      </div>
+      <OutlinePanel v-if="showOutline && currentMode === 'chat'" :messages="chatStore.messages" />
     </div>
 
     <!-- Floating drawer button -->
@@ -1132,6 +1161,13 @@ async function handleWorkspaceConfirm() {
     color: $error;
     background: rgba($error, 0.1);
   }
+}
+
+.chat-wrapper {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+  min-width: 0;
 }
 
 .chat-main {

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -19,8 +19,10 @@ import { downloadFile, getDownloadUrl } from '@/api/hermes/download'
 const props = withDefaults(defineProps<{
     content: string
     mentionNames?: string[]
+    headingIdPrefix?: string
 }>(), {
     mentionNames: () => [],
+    headingIdPrefix: '',
 })
 
 const { t } = useI18n()
@@ -58,6 +60,29 @@ let unmounted = false
 
 const renderedHtml = computed(() => {
   let html = md.render(repairNestedMarkdownFences(props.content))
+
+  // Add IDs to headings for anchor links
+  const prefix = props.headingIdPrefix ? `${props.headingIdPrefix}-` : ''
+  let headingCounter = 0
+  // Match any h1-h6 tags, with or without attributes
+  html = html.replace(/<(h[1-6])([^>]*)>/g, (match, tag, attrs) => {
+    headingCounter++
+    const id = `${prefix}heading-${headingCounter}`
+    
+    // Check if id attribute already exists
+    if (attrs.includes('id=')) {
+      // Replace existing id
+      return match.replace(/id="[^"]*"/, `id="${id}"`).replace(/id='[^']*'/, `id="${id}"`)
+    }
+    
+    // Add new id
+    if (attrs.trim() === '') {
+      return `<${tag} id="${id}">`
+    }
+    return `<${tag} ${attrs.trim()} id="${id}">`
+  })
+  
+  console.log('Generated HTML with heading IDs:', prefix, headingCounter)
 
   // Replace image src paths with download URLs
   // Replace both src="/path" and src='/path' formats

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -21,11 +21,13 @@ import { speedToEdgeRate, hzToEdgePitch } from "@/utils/ttsHelpers";
 
 const TOOL_PAYLOAD_DISPLAY_LIMIT = 2000;
 
-const props = defineProps<{ message: Message; highlight?: boolean }>();
+const props = defineProps<{ message: Message; highlight?: boolean; headingIdPrefix?: string }>();
 const { t } = useI18n();
 const toast = useMessage();
 
 const isSystem = computed(() => props.message.role === "system");
+
+const effectiveHeadingIdPrefix = computed(() => props.headingIdPrefix || `msg-${props.message.id}`);
 
 // Parse ContentBlock[] from JSON string
 const contentBlocks = computed(() => {
@@ -654,6 +656,7 @@ onBeforeUnmount(() => {
             <MarkdownRenderer
               v-if="parsedThinking.body && message.role === 'assistant'"
               :content="parsedThinking.body"
+              :heading-id-prefix="effectiveHeadingIdPrefix"
             />
 
             <!-- Render user message content -->
@@ -691,16 +694,17 @@ onBeforeUnmount(() => {
                     </template>
                   </div>
                 </div>
-                <MarkdownRenderer v-if="displayText" :content="displayText" />
+                <MarkdownRenderer v-if="displayText" :content="displayText" :heading-id-prefix="message.role === 'assistant' ? effectiveHeadingIdPrefix : ''" />
               </template>
               <!-- Plain text format -->
-              <MarkdownRenderer v-else-if="message.content" :content="message.content" />
+              <MarkdownRenderer v-else-if="message.content" :content="message.content" :heading-id-prefix="message.role === 'assistant' ? effectiveHeadingIdPrefix : ''" />
             </template>
 
             <!-- Render assistant message content -->
             <MarkdownRenderer
               v-if="message.role === 'assistant' && message.content && !parsedThinking.body"
               :content="message.content"
+              :heading-id-prefix="effectiveHeadingIdPrefix"
             />
 
             <span v-if="message.isStreaming && !message.content" class="streaming-dots">

--- a/packages/client/src/components/hermes/chat/OutlinePanel.vue
+++ b/packages/client/src/components/hermes/chat/OutlinePanel.vue
@@ -1,0 +1,298 @@
+<script setup lang="ts">
+import { computed, nextTick } from 'vue'
+import type { Message } from '@/stores/hermes/chat'
+
+interface OutlineItem {
+  id: string
+  type: 'user' | 'outline'
+  content: string
+  messageId: string
+  level: number
+  anchorId: string
+}
+
+const props = defineProps<{
+  messages: Message[]
+}>()
+
+function extractAllHeadings(text: string, messageId: string): OutlineItem[] {
+  const items: OutlineItem[] = []
+  let cleanedText = text.replace(/<think>[\s\S]*?<\/think>/g, '')
+  const lines = cleanedText.split('\n')
+  
+  let headingIndex = 0
+  for (const line of lines) {
+    const trimmed = line.trim()
+    const h1Match = trimmed.match(/^#\s+(.+)/)
+    const h2Match = trimmed.match(/^##\s+(.+)/)
+    const h3Match = trimmed.match(/^###\s+(.+)/)
+    
+    if (h1Match) {
+      headingIndex++
+      items.push({
+        id: `outline-${messageId}-h${headingIndex}`,
+        type: 'outline',
+        content: h1Match[1].trim(),
+        messageId,
+        level: 1,
+        anchorId: `msg-${messageId}-heading-${headingIndex}`
+      })
+    } else if (h2Match) {
+      headingIndex++
+      items.push({
+        id: `outline-${messageId}-h${headingIndex}`,
+        type: 'outline',
+        content: h2Match[1].trim(),
+        messageId,
+        level: 2,
+        anchorId: `msg-${messageId}-heading-${headingIndex}`
+      })
+    } else if (h3Match) {
+      headingIndex++
+      items.push({
+        id: `outline-${messageId}-h${headingIndex}`,
+        type: 'outline',
+        content: h3Match[1].trim(),
+        messageId,
+        level: 3,
+        anchorId: `msg-${messageId}-heading-${headingIndex}`
+      })
+    }
+  }
+  
+  return items
+}
+
+function extractUserQuestion(text: string): string {
+  const cleanedText = text.replace(/<think>[\s\S]*?<\/think>/g, '')
+  const firstLine = cleanedText.split('\n')[0] || ''
+  if (firstLine.length > 50) {
+    return firstLine.slice(0, 50) + '...'
+  }
+  return firstLine || '用户问题'
+}
+
+const outlineItems = computed<OutlineItem[]>(() => {
+  const items: OutlineItem[] = []
+  let i = 0
+  const filteredMessages = props.messages.filter(m => m.role === 'user' || m.role === 'assistant')
+  
+  while (i < filteredMessages.length) {
+    const msg = filteredMessages[i]
+    if (msg.role === 'user') {
+      items.push({
+        id: `user-${msg.id}`,
+        type: 'user',
+        content: extractUserQuestion(msg.content || ''),
+        messageId: msg.id,
+        level: 0,
+        anchorId: `message-${msg.id}`
+      })
+      i++
+      while (i < filteredMessages.length && filteredMessages[i].role !== 'assistant') {
+        i++
+      }
+      if (i < filteredMessages.length) {
+        const assistantMsg = filteredMessages[i]
+        const headings = extractAllHeadings(assistantMsg.content || '', assistantMsg.id)
+        items.push(...headings)
+      }
+    }
+    i++
+  }
+  return items
+})
+
+function scrollToTarget(anchorId: string) {
+  console.log('Attempting to scroll to anchor:', anchorId)
+  nextTick(() => {
+    const el = document.getElementById(anchorId)
+    console.log('Found element:', el)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    } else {
+      // Debug: log all heading elements with IDs
+      console.log('All heading elements on page:')
+      document.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(el => {
+        console.log('  -', el.id, ':', el.textContent?.slice(0, 50))
+      })
+    }
+  })
+}
+</script>
+
+<template>
+  <div class="outline-panel">
+    <div class="outline-header">
+      <span class="outline-title">会话大纲</span>
+    </div>
+    <div class="outline-content">
+      <template v-if="outlineItems.length > 0">
+        <template v-for="item in outlineItems" :key="item.id">
+          <div
+            v-if="item.type === 'user'"
+            class="outline-item user-item"
+            @click="scrollToTarget(item.anchorId)"
+          >
+            <div class="user-question">
+              <span class="q-label">Q:</span>
+              <span class="q-text">{{ item.content }}</span>
+            </div>
+          </div>
+          <div
+            v-else
+            class="outline-item outline-heading-item"
+            :class="`level-${item.level}`"
+            @click="scrollToTarget(item.anchorId)"
+          >
+            <div class="heading-item">
+              <span class="heading-text">{{ item.content }}</span>
+            </div>
+          </div>
+        </template>
+      </template>
+      <div v-else class="outline-empty">暂无会话内容</div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use "@/styles/variables" as *;
+
+.outline-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: $bg-card;
+  border-left: 1px solid $border-color;
+  width: 280px;
+  flex-shrink: 0;
+}
+
+.outline-header {
+  padding: 16px;
+  border-bottom: 1px solid $border-color;
+  flex-shrink: 0;
+}
+
+.outline-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: $text-primary;
+}
+
+.outline-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.outline-item {
+  margin-bottom: 4px;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+.user-item {
+  margin-bottom: 6px;
+}
+
+.user-question {
+  background-color: #1a1a1a;
+  color: #ffffff;
+  padding: 8px 12px;
+  border-radius: 8px;
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+
+  .q-label {
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+
+  .q-text {
+    font-size: 13px;
+    line-height: 1.4;
+    word-break: break-word;
+  }
+}
+
+.outline-heading-item {
+  &.level-1 {
+    padding-left: 0;
+  }
+
+  &.level-2 {
+    padding-left: 12px;
+  }
+
+  &.level-3 {
+    padding-left: 24px;
+  }
+}
+
+.heading-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.04);
+
+    .dark & {
+      background-color: rgba(255, 255, 255, 0.06);
+    }
+  }
+
+  .level-1 & {
+    .heading-marker {
+      color: $text-primary;
+      font-weight: 600;
+    }
+    .heading-text {
+      color: $text-primary;
+      font-weight: 500;
+    }
+  }
+
+  .level-2 & {
+    .heading-marker {
+      color: $text-secondary;
+    }
+    .heading-text {
+      color: $text-secondary;
+    }
+  }
+
+  .level-3 & {
+    .heading-marker {
+      color: $text-muted;
+    }
+    .heading-text {
+      color: $text-muted;
+      font-size: 12px;
+    }
+  }
+}
+
+.heading-text {
+  font-size: 13px;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.outline-empty {
+  text-align: center;
+  color: $text-muted;
+  font-size: 13px;
+  padding: 20px 0;
+}
+</style>

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -11,6 +11,7 @@ import { copyToClipboard } from '@/utils/clipboard'
 import FolderPicker from '@/components/hermes/chat/FolderPicker.vue'
 import HistoryMessageList from '@/components/hermes/chat/HistoryMessageList.vue'
 import SessionListItem from '@/components/hermes/chat/SessionListItem.vue'
+import OutlinePanel from '@/components/hermes/chat/OutlinePanel.vue'
 import { renameSession, setSessionWorkspace, fetchHermesSessions, fetchHermesSession, exportSession, type SessionSummary } from '@/api/hermes/sessions'
 
 const chatStore = useChatStore()
@@ -27,6 +28,7 @@ const hermesSessionsLoaded = ref(false)
 // History page's own selected session (independent from chatStore)
 const historySessionId = ref<string | null>(null)
 const historySession = ref<Session | null>(null)
+const showOutline = ref(true)
 
 async function loadHermesSessions() {
   if (hermesSessionsLoading.value) return
@@ -496,33 +498,56 @@ async function handleWorkspaceConfirm() {
       <FolderPicker v-model="workspaceValue" />
     </NModal>
 
-    <div class="chat-main">
-      <header class="chat-header">
-        <div class="header-left">
-          <NButton quaternary size="small" @click="showSessions = !showSessions" circle>
-            <template #icon>
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
-            </template>
-          </NButton>
-          <span class="header-session-title">{{ activeSessionTitle }}</span>
-          <span v-if="activeSessionSource" class="source-badge">{{ getSourceLabel(activeSessionSource) }}</span>
-          <span v-if="historySession?.workspace" class="workspace-badge" :title="historySession.workspace">📁 {{ historySession.workspace.split('/').pop() || historySession.workspace }}</span>
-        </div>
-        <div class="header-actions">
-          <NTooltip trigger="hover">
-            <template #trigger>
-              <NButton quaternary size="small" @click="copySessionId()" circle>
-                <template #icon>
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                </template>
-              </NButton>
-            </template>
-            {{ t('chat.copySessionId') }}
-          </NTooltip>
-        </div>
-      </header>
+    <div class="history-wrapper">
+      <div class="chat-main">
+        <header class="chat-header">
+          <div class="header-left">
+            <NButton quaternary size="small" @click="showSessions = !showSessions" circle>
+              <template #icon>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                  <rect x="3" y="3" width="7" height="7"/>
+                  <rect x="14" y="3" width="7" height="7"/>
+                  <rect x="3" y="14" width="7" height="7"/>
+                  <rect x="14" y="14" width="7" height="7"/>
+                </svg>
+              </template>
+            </NButton>
+            <span class="header-session-title">{{ activeSessionTitle }}</span>
+            <span v-if="activeSessionSource" class="source-badge">{{ getSourceLabel(activeSessionSource) }}</span>
+            <span v-if="historySession?.workspace" class="workspace-badge" :title="historySession.workspace">📁 {{ historySession.workspace.split('/').pop() || historySession.workspace }}</span>
+          </div>
+          <div class="header-actions">
+            <NTooltip trigger="hover">
+              <template #trigger>
+                <NButton quaternary size="small" @click="showOutline = !showOutline" circle>
+                  <template #icon>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                      <path d="M3 12h18M3 6h18M3 18h18" />
+                    </svg>
+                  </template>
+                </NButton>
+              </template>
+              会话大纲
+            </NTooltip>
+            <NTooltip trigger="hover">
+              <template #trigger>
+                <NButton quaternary size="small" @click="copySessionId()" circle>
+                  <template #icon>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                    </svg>
+                  </template>
+                </NButton>
+              </template>
+              {{ t("chat.copySessionId") }}
+            </NTooltip>
+          </div>
+        </header>
 
-      <HistoryMessageList :session="historySession" />
+        <HistoryMessageList :session="historySession" />
+      </div>
+      <OutlinePanel v-if="showOutline && historySession" :messages="historySession.messages" />
     </div>
   </div>
 </template>
@@ -534,6 +559,13 @@ async function handleWorkspaceConfirm() {
   display: flex;
   height: 100%;
   position: relative;
+}
+
+.history-wrapper {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+  min-width: 0;
 }
 
 .session-list {


### PR DESCRIPTION
新增聊天界面内容大纲
<img width="1044" height="373" alt="image" src="https://github.com/user-attachments/assets/a63ddc1a-db64-4115-9b52-166bec320ea3" />
1.点击大纲标题可跳转到内容区对应位置
2.大纲可收起
