### PR TITLE
fix: pass HERMES_HOME to plugins Python bridge

### DIFF
--- a/packages/server/src/services/hermes/plugins.ts
+++ b/packages/server/src/services/hermes/plugins.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'fs'
 import { dirname, join, resolve } from 'path'
 import { homedir } from 'os'
 import { promisify } from 'util'
+import { getActiveProfileDir } from './hermes-profile'
 
 const execFileAsync = promisify(execFile)
 
@@ -312,6 +313,7 @@ export async function listHermesPlugins(): Promise<HermesPluginsResponse> {
   const env = {
     ...process.env,
     HERMES_AGENT_ROOT_RESOLVED: agentRoot,
+    HERMES_HOME: getActiveProfileDir(),
   }
 
   const errors: string[] = []


### PR DESCRIPTION
## Summary
- 插件页面的 Python bridge 脚本没有传 `HERMES_HOME`，导致 hermes-agent 的 `get_hermes_home()` fallback 到 `~/.hermes`（default profile），切换到非 default profile 时触发 fallback 警告
- 修复方式：在 `execFileAsync` 的 env 中加入 `HERMES_HOME: getActiveProfileDir()`

Fixes #689

## Root cause
`plugins.ts` 的 `listHermesPlugins()` 通过 `python -c` 执行 hermes-agent 的 plugin 模块，但没有传 `HERMES_HOME`。Python 侧 `get_hermes_home()` 读不到环境变量就 fallback 到默认目录，与实际激活的 profile 不一致。

Related: [NousResearch/hermes-agent#18594](https://github.com/NousResearch/hermes-agent/issues/18594)

## Test plan
- [ ] 切换到非 default profile，访问插件页面，确认不再出现 `[HERMES_HOME fallback]` 警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)