### PR TITLE
fix: comment out group chat pending session delete

### DIFF
--- a/packages/server/src/controllers/hermes/profiles.ts
+++ b/packages/server/src/controllers/hermes/profiles.ts
@@ -235,18 +235,19 @@ export async function switchProfile(ctx: any) {
       logger.error(err, 'Ensure config failed')
     }
 
-    const drainResult = await SessionDeleter.getInstance().drain(name)
+    // TODO: re-enable pending session delete drain after confirming safety
+    // const drainResult = await SessionDeleter.getInstance().drain(name)
     SessionDeleter.getInstance().switchProfile(name)
-    logger.info('[switchProfile] drain result for profile "%s": %d deleted, %d failed', name, drainResult.deleted.length, drainResult.failed.length)
-    if (drainResult.failed.length > 0) {
-      logger.warn({ profile: name, failed: drainResult.failed }, 'Failed to drain some pending session deletes after profile switch')
-    }
+    logger.info('[switchProfile] switched session deleter to profile "%s"', name)
+    // if (drainResult.failed.length > 0) {
+    //   logger.warn({ profile: name, failed: drainResult.failed }, 'Failed to drain some pending session deletes after profile switch')
+    // }
 
     ctx.body = {
       success: true,
       message: output.trim(),
-      drained_session_deletes: drainResult.deleted.length,
-      failed_session_deletes: drainResult.failed.length,
+      // drained_session_deletes: drainResult.deleted.length,
+      // failed_session_deletes: drainResult.failed.length,
     }
   } catch (err: any) {
     ctx.status = 500

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -448,13 +448,15 @@ export class GroupChatServer {
         const contextEngine = new ContextEngine({
             messageFetcher: this.storage,
             sessionCleaner: async (sessionId: string) => {
-                try {
-                    const profile = this.storage.getSessionProfile(sessionId)
-                    const profileName = profile?.profile_name || 'default'
-                    this.storage.enqueuePendingSessionDelete(sessionId, profileName)
-                } catch (err: any) {
-                    logger.warn(`[GroupChat] failed to enqueue compression session delete ${sessionId}: ${err.message}`)
-                }
+                // TODO: re-enable session deletion after confirming it doesn't
+                // accidentally remove user-created sessions outside group chat.
+                // try {
+                //     const profile = this.storage.getSessionProfile(sessionId)
+                //     const profileName = profile?.profile_name || 'default'
+                //     this.storage.enqueuePendingSessionDelete(sessionId, profileName)
+                // } catch (err: any) {
+                //     logger.warn(`[GroupChat] failed to enqueue compression session delete ${sessionId}: ${err.message}`)
+                // }
             },
         })
         this.agentClients.setContextEngine(contextEngine)


### PR DESCRIPTION
## Summary
- 注释掉群聊上下文压缩时的 hermes session 删除操作（`sessionCleaner`）
- 注释掉切换 profile 时的 pending session delete drain

群聊压缩产生的 hermes session 不应被自动删除，需要确认安全性后再启用。

## Test plan
- [ ] 群聊对话后触发上下文压缩，确认 hermes CLI 侧 session 记录仍保留
- [ ] 切换 profile 后确认不会 drain pending session deletes

🤖 Generated with [Claude Code](https://claude.com/claude-code)