### PR TITLE
fix: resolve ENOENT on hermes-web-ui update restart (macOS/Linux)

### DIFF
--- a/bin/hermes-web-ui.mjs
+++ b/bin/hermes-web-ui.mjs
@@ -57,6 +57,12 @@ function getNpmBin() {
 }
 
 function getCliBin() {
+  // On macOS/Linux, global npm bins are often in a different directory than
+  // Node itself (e.g. /opt/homebrew/bin vs /opt/homebrew/Cellar/node/.../bin).
+  // process.argv[1] is the real path to this CLI script.
+  if (process.platform !== 'win32' && process.argv[1]) {
+    return process.argv[1]
+  }
   return join(getNodeBinDir(), process.platform === 'win32' ? 'hermes-web-ui.cmd' : 'hermes-web-ui')
 }
 


### PR DESCRIPTION
## Problem

On macOS (especially with Homebrew-installed Node.js), running `hermes-web-ui update` fails during the restart phase with:

```\nError: spawn /opt/homebrew/Cellar/node/25.7.0/bin/hermes-web-ui ENOENT
```\n
This happens because `getCliBin()` assumes the CLI binary lives in the same directory as the `node` executable, which is not true for global npm packages on Homebrew.

## Solution

Use `process.argv[1]` on non-Windows platforms to reliably locate the currently executing CLI script, since it always resolves to the real file path (including symlinks).

Windows behavior is unchanged.

## Changes

- `bin/hermes-web-ui.mjs`: updated `getCliBin()` to prefer `process.argv[1]` on macOS/Linux

## Testing

- [ ] Run `hermes-web-ui update` on macOS with Homebrew Node.js
- [ ] Verify restart succeeds after update

Fixes #708