### PR TITLE
fix: pass default headers to agent bridge

### DIFF
--- a/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
@@ -397,6 +397,7 @@ class AgentPool:
                     acp_command=runtime.get("command"),
                     acp_args=runtime.get("args"),
                     credential_pool=runtime.get("credential_pool"),
+                    default_headers=runtime.get("default_headers"),
                     quiet_mode=True,
                     verbose_logging=False,
                     reasoning_config=_load_reasoning_config(),


### PR DESCRIPTION
## Summary
- Pass runtime default_headers into the agent bridge client configuration.
- Preserve configured request headers when creating agent pool clients.

## Tests
- Not run (one-line configuration forwarding change).