### PR TITLE
fix: add connected channels to job deliver target dropdown

### DIFF
--- a/bin/hermes-web-ui.mjs
+++ b/bin/hermes-web-ui.mjs
@@ -79,6 +79,11 @@ function getGlobalCliBin() {
     : join(prefix, 'bin', 'hermes-web-ui')
 }
 
+function getCliBin() {
+  return process.argv[1]
+}
+}
+
 function getWindowsShell() {
   const systemRoot = process.env.SystemRoot || 'C:\\Windows'
   const candidates = [

--- a/packages/client/src/components/hermes/jobs/JobFormModal.vue
+++ b/packages/client/src/components/hermes/jobs/JobFormModal.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, computed } from 'vue'
 import { NModal, NForm, NFormItem, NInput, NButton, NSelect, NInputNumber, useMessage } from 'naive-ui'
 import { useJobsStore } from '@/stores/hermes/jobs'
+import { useSettingsStore } from '@/stores/hermes/settings'
 import {
   buildJobUpdateRequest,
   getJob,
@@ -23,6 +24,7 @@ const emit = defineEmits<{
 }>()
 
 const jobsStore = useJobsStore()
+const settingsStore = useSettingsStore()
 const message = useMessage()
 
 const showModal = ref(true)
@@ -50,10 +52,30 @@ const schedulePresets = computed(() => [
   { label: t('jobs.presetEveryMonth'), value: '0 9 1 * *' },
 ])
 
-const targetOptions = computed(() => [
-  { label: t('jobs.origin'), value: 'origin' },
-  { label: t('jobs.local'), value: 'local' },
-])
+const targetOptions = computed(() => {
+  const options: Array<{ label: string; value: string }> = [
+    { label: t('jobs.origin'), value: 'origin' },
+    { label: t('jobs.local'), value: 'local' },
+  ]
+  const channels = [
+    { key: 'telegram', label: 'Telegram' },
+    { key: 'discord', label: 'Discord' },
+    { key: 'slack', label: 'Slack' },
+    { key: 'whatsapp', label: 'WhatsApp' },
+    { key: 'matrix', label: 'Matrix' },
+    { key: 'weixin', label: 'WeChat' },
+    { key: 'wecom', label: 'WeCom' },
+    { key: 'feishu', label: 'Feishu' },
+    { key: 'dingtalk', label: 'DingTalk' },
+  ]
+  for (const ch of channels) {
+    const config = settingsStore.platforms[ch.key] || {}
+    if (Object.keys(config).length > 0) {
+      options.push({ label: ch.label, value: ch.key })
+    }
+  }
+  return options
+})
 
 const originalJob = ref<Job | null>(null)
 

--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -277,16 +277,11 @@ export async function getAvailable(ctx: any) {
         if (!cp.base_url) return null
         const providerKey = `custom:${cp.name.trim().toLowerCase().replace(/ /g, '-')}`
         const baseUrl = cp.base_url.replace(/\/+$/, '')
-        const bareKey = cp.name.trim().toLowerCase().replace(/ /g, '-')
-        const builtinPreset = PROVIDER_PRESETS.find(p => p.value === bareKey)
-        let models = builtinPreset?.models?.length ? [...builtinPreset.models] : [cp.model]
-        // Skip dynamic fetch for builtin presets — their model list is maintained in providers.ts
-        if (!builtinPreset && cp.api_key) {
+        let models = [cp.model]
+        if (cp.api_key) {
           try { const fetched = await fetchProviderModels(baseUrl, cp.api_key); if (fetched.length > 0) models = [...new Set([cp.model, ...fetched])] } catch { }
         }
-        const label = builtinPreset?.label || cp.name
-        const presetBaseUrl = builtinPreset?.base_url || ''
-        return { providerKey, label, base_url: presetBaseUrl || baseUrl, models, api_key: cp.api_key || '', builtin: !!builtinPreset }
+        return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '' }
       }),
     )
 

--- a/packages/server/src/controllers/update.ts
+++ b/packages/server/src/controllers/update.ts
@@ -47,6 +47,11 @@ function getGlobalPackageBin(root: string) {
   return join(root, 'hermes-web-ui', 'bin', 'hermes-web-ui.mjs')
 }
 
+function getCliBin() {
+  return process.argv[1]
+}
+}
+
 function getCurrentNodeEnv() {
   return {
     ...process.env,


### PR DESCRIPTION
## Summary

### fix: dynamic deliver target options in job form
- Job 表单的投递选项硬编码只有"来源"和"本地"两个值
- Hermes gateway 实际支持投递到任何已连接的渠道（WeChat、Telegram、Discord 等）
- 动态从 settings store 获取已连接的渠道，添加到投递下拉选项中

### fix: always treat custom_providers as custom, not builtin
- 当用户在 `config.yaml` 的 `custom_providers` 中配置的 provider 名称（如 `minimax`、`qwen`）与 `PROVIDER_PRESETS` 中的内置预设同名时，会被错误地识别为内置 provider
- 导致 `base_url` 被覆盖为官方 API 地址，模型显示为"官方"而非"本地"
- 修复后 `custom_providers` 始终使用用户配置的 `base_url`，不会受内置预设干扰

## Test plan
- [ ] 配置了微信渠道的用户可以看到 WeChat 出现在 job 投递选项中
- [ ] 未配置任何渠道时 job 投递只显示"来源"和"本地"
- [ ] 编辑已有任务时 deliver 字段正确加载
- [ ] `custom_providers` 中使用 `minimax`/`qwen` 等与预设同名的名称时，base_url 正确显示为本地 IP 而非官方 URL
- [ ] 同名自定义 provider 不会被标记为 builtin

🤖 Generated with [Claude Code](https://claude.com/claude-code)