### PR TITLE
fix: preserve newlines in chat message markdown rendering

### DIFF
--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -28,6 +28,7 @@ const message = useMessage()
 
 const md: MarkdownIt = new MarkdownItConstructor({
   html: false,
+  breaks: true,
   linkify: true,
   typographer: true,
   highlight(str: string, lang: string): string {


### PR DESCRIPTION
## Problem

聊天输入框提示 "Shift+Enter 换行"，但用户按提示操作后，发送的消息中所有换行都消失了，内容合并成一段显示。这是功能不完整——UI 承诺了可以换行，但渲染层没有兑现。

## Root Cause

`MarkdownRenderer.vue` 初始化 markdown-it 时没有设置 `breaks: true`。标准 Markdown 规范中单个 `\n` 被视为软换行（等价于空格），只有双 `\n`（空行）才产生新段落。这对 LLM 生成的内容没问题，但用户手动在输入框中输入换行时，每个换行都应该被保留。

## Fix

在 `MarkdownRenderer.vue` 的 markdown-it 选项中添加 `breaks: true`，将输入内容中的单个 `\n` 转换为 `<br>` 标签，保留用户输入中的显式换行。

## Changes

- `packages/client/src/components/hermes/chat/MarkdownRenderer.vue`: 在 `html: false,` 之后添加一行 `breaks: true,`
