### PR TITLE
feat(chat): add custom drag-resize handle on input top border

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -260,6 +260,8 @@ function handleKeydown(e: KeyboardEvent) {
 }
 
 function handleInput(e: Event) {
+  // 用户手动拖拽自定义高度时，不覆盖
+  if (textareaHeight.value !== null) return
   const el = e.target as HTMLTextAreaElement
   el.style.height = 'auto'
   el.style.height = Math.min(el.scrollHeight, 100) + 'px'

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -20,6 +20,37 @@ const isDragging = ref(false)
 const dragCounter = ref(0)
 const isComposing = ref(false)
 
+// 自定义高度拖拽
+const textareaHeight = ref<number | null>(null) // null = auto
+
+function startResize(e: MouseEvent) {
+  e.preventDefault()
+  const el = textareaRef.value
+  if (!el) return
+  // 如果当前是 auto，用实际 clientHeight 作为起始值
+  const startHeight = el.clientHeight
+  const startY = e.clientY
+
+  function onMouseMove(e: MouseEvent) {
+    const deltaY = e.clientY - startY
+    // 往上拖 (deltaY < 0) → 高度增加
+    const newHeight = startHeight - deltaY
+    textareaHeight.value = Math.max(20, Math.min(400, Math.round(newHeight)))
+  }
+
+  function onMouseUp() {
+    document.removeEventListener('mousemove', onMouseMove)
+    document.removeEventListener('mouseup', onMouseUp)
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+  }
+
+  document.body.style.cursor = 'row-resize'
+  document.body.style.userSelect = 'none'
+  document.addEventListener('mousemove', onMouseMove)
+  document.addEventListener('mouseup', onMouseUp)
+}
+
 // 自动播放语音开关
 const autoPlaySpeech = ref(false)
 
@@ -349,10 +380,12 @@ function isImage(type: string): boolean {
         class="file-input-hidden"
         @change="handleFileChange"
       />
+      <div class="resize-handle" @mousedown="startResize"></div>
       <textarea
         ref="textareaRef"
         v-model="inputText"
         class="input-textarea"
+        :style="textareaHeight ? { height: textareaHeight + 'px' } : {}"
         :placeholder="t('chat.inputPlaceholder')"
         rows="1"
         @keydown="handleKeydown"
@@ -594,6 +627,7 @@ function isImage(type: string): boolean {
   border: 1px solid $border-color;
   border-radius: $radius-md;
   padding: 10px 12px;
+  position: relative;
   transition: border-color $transition-fast, background-color $transition-fast;
 
   &:focus-within {
@@ -602,6 +636,21 @@ function isImage(type: string): boolean {
 
   .dark & {
     background-color: #333333;
+  }
+}
+
+.resize-handle {
+  position: absolute;
+  top: -4px;
+  left: 0;
+  right: 0;
+  height: 8px;
+  cursor: row-resize;
+  z-index: 2;
+
+  &:hover {
+    background: rgba($accent-primary, 0.15);
+    border-radius: 4px;
   }
 }
 
@@ -615,7 +664,7 @@ function isImage(type: string): boolean {
   font-size: 14px;
   line-height: 1.5;
   resize: none;
-  max-height: 100px;
+  max-height: 400px;
   min-height: 20px;
   overflow-y: auto;
 

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -154,8 +154,10 @@ function selectMention(name: string) {
             const newPos = before.length + name.length + 2
             el.setSelectionRange(newPos, newPos)
             el.focus()
-            el.style.height = 'auto'
-            el.style.height = Math.min(el.scrollHeight, 100) + 'px'
+            if (textareaHeight.value === null) {
+                el.style.height = 'auto'
+                el.style.height = Math.min(el.scrollHeight, 100) + 'px'
+            }
         }
     })
 }
@@ -202,15 +204,12 @@ function handleSend() {
     emit('send', content)
     inputText.value = ''
     mentionActive.value = false
-
-    nextTick(() => {
-        if (textareaRef.value) {
-            textareaRef.value.style.height = 'auto'
-        }
-    })
+    // 发送后重置到自定义高度（不清除拖拽状态）
 }
 
 function handleInput(e: Event) {
+    // 用户手动拖拽自定义高度时，不覆盖
+    if (textareaHeight.value !== null) return
     store.emitTyping()
     const el = e.target as HTMLTextAreaElement
     el.style.height = 'auto'

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -13,6 +13,35 @@ const textareaRef = ref<HTMLTextAreaElement>()
 const dropdownRef = ref<HTMLDivElement>()
 const isComposing = ref(false)
 
+// 自定义高度拖拽
+const textareaHeight = ref<number | null>(null)
+
+function startResize(e: MouseEvent) {
+  e.preventDefault()
+  const el = textareaRef.value
+  if (!el) return
+  const startHeight = el.clientHeight
+  const startY = e.clientY
+
+  function onMouseMove(e: MouseEvent) {
+    const deltaY = e.clientY - startY
+    const newHeight = startHeight - deltaY
+    textareaHeight.value = Math.max(20, Math.min(400, Math.round(newHeight)))
+  }
+
+  function onMouseUp() {
+    document.removeEventListener('mousemove', onMouseMove)
+    document.removeEventListener('mouseup', onMouseUp)
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+  }
+
+  document.body.style.cursor = 'row-resize'
+  document.body.style.userSelect = 'none'
+  document.addEventListener('mousemove', onMouseMove)
+  document.addEventListener('mouseup', onMouseUp)
+}
+
 // ─── Mention State ───────────────────────────────────────
 
 const mentionActive = ref(false)
@@ -233,10 +262,12 @@ function handleCompositionEnd() {
 <template>
     <div class="chat-input-area">
         <div class="input-wrapper">
+            <div class="resize-handle" @mousedown="startResize"></div>
             <textarea
                 ref="textareaRef"
                 v-model="inputText"
                 class="input-textarea"
+                :style="textareaHeight ? { height: textareaHeight + 'px' } : {}"
                 :placeholder="t('groupChat.inputPlaceholder')"
                 rows="1"
                 @keydown="handleKeydown"
@@ -326,6 +357,7 @@ function handleCompositionEnd() {
     border: 1px solid $border-color;
     border-radius: $radius-md;
     padding: 10px 12px;
+    position: relative;
     transition: border-color $transition-fast, background-color $transition-fast;
 
     &:focus-within {
@@ -334,6 +366,21 @@ function handleCompositionEnd() {
 
     .dark & {
         background-color: #333333;
+    }
+}
+
+.resize-handle {
+    position: absolute;
+    top: -4px;
+    left: 0;
+    right: 0;
+    height: 8px;
+    cursor: row-resize;
+    z-index: 2;
+
+    &:hover {
+        background: rgba($accent-primary, 0.15);
+        border-radius: 4px;
     }
 }
 
@@ -347,7 +394,7 @@ function handleCompositionEnd() {
     font-size: 14px;
     line-height: 1.5;
     resize: none;
-    max-height: 100px;
+    max-height: 400px;
     min-height: 20px;
     overflow-y: auto;
 


### PR DESCRIPTION
相关 #587 中关于输入框高度的需求

## 改动说明

为聊天输入框（ChatInput + GroupChatInput）添加自定义顶部拖拽手柄，替代 CSS `resize: vertical`。

### 交互逻辑
- 拖拽输入框顶部边框区域（8px 高透明手柄），鼠标悬停变蓝高亮
- 往上拖 = 输入框变大，往下拖 = 缩小
- 高度范围：20px（最小）~ 400px（最大）
- 拖拽时全局锁定鼠标样式为 row-resize，防止拖出手感丢失

### 改动文件
- `packages/client/src/components/hermes/chat/ChatInput.vue` — 脚本+模板+样式
- `packages/client/src/components/hermes/group-chat/GroupChatInput.vue` — 同上
