### PR TITLE
Fix bridge agent initialization compatibility

### DIFF
--- a/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
@@ -397,7 +397,6 @@ class AgentPool:
                     acp_command=runtime.get("command"),
                     acp_args=runtime.get("args"),
                     credential_pool=runtime.get("credential_pool"),
-                    default_headers=runtime.get("default_headers"),
                     quiet_mode=True,
                     verbose_logging=False,
                     reasoning_config=_load_reasoning_config(),


### PR DESCRIPTION
## Summary
- remove the unsupported default_headers keyword from bridge AIAgent initialization
- restores compatibility with hermes-agent versions whose AIAgent constructor does not accept default_headers

## Tests
- python3 -m py_compile packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
- npm run build