### PR TITLE
fix: remove gateway startup debug log

### DIFF
--- a/packages/server/src/services/gateway-bootstrap.ts
+++ b/packages/server/src/services/gateway-bootstrap.ts
@@ -12,5 +12,4 @@ export async function initGatewayManager(): Promise<void> {
 
   await gatewayManager.detectAllOnStartup()
   await gatewayManager.startAll()
-  console.log("startall")
 }


### PR DESCRIPTION
## Summary
- Remove a leftover `console.log("startall")` debug message from gateway startup.

## Test Plan
- npm run build
