### PR TITLE
fix: reserve Web UI port for gateway allocation

### DIFF
--- a/packages/server/src/services/hermes/gateway-manager.ts
+++ b/packages/server/src/services/hermes/gateway-manager.ts
@@ -49,6 +49,7 @@ const execFileAsync = promisify(execFile)
 
 const HERMES_BASE = detectHermesHome()
 const HERMES_BIN = getHermesBin()
+const DEFAULT_WEB_UI_PORT = 8648
 
 /**
  * 检测系统的 init 系统（服务管理器）
@@ -172,6 +173,11 @@ export function buildGatewayProcessEnv(profileName: string, hermesHome: string):
     ...base,
     HERMES_HOME: hermesHome,
   }
+}
+
+function getWebUiPort(): number | null {
+  const port = parseInt(process.env.PORT || String(DEFAULT_WEB_UI_PORT), 10)
+  return port > 0 && port <= 65535 ? port : null
 }
 
 // ============================
@@ -472,6 +478,8 @@ export class GatewayManager {
         usedPorts.add(gw.port)
       }
     }
+    const webUiPort = getWebUiPort()
+    if (webUiPort !== null) usedPorts.add(webUiPort)
 
     const port = await this.findFreePort(8642, host, usedPorts)
     if (configuredPort !== port) {

--- a/tests/server/gateway-manager.test.ts
+++ b/tests/server/gateway-manager.test.ts
@@ -170,3 +170,20 @@ describe('GatewayManager gateway process env', () => {
     expect(env.CUSTOM_GATEWAY_SETTING).toBe('from-parent')
   })
 })
+
+describe('GatewayManager gateway port allocation', () => {
+  it('skips the Web UI listen port when assigning gateway ports', async () => {
+    const home = createHermesHome()
+    mkdirSync(join(home, 'profiles', 'work'), { recursive: true })
+    process.env.HERMES_HOME = home
+    process.env.PORT = '8648'
+    vi.resetModules()
+    const { GatewayManager } = await import('../../packages/server/src/services/hermes/gateway-manager')
+    const manager = new GatewayManager('default') as any
+    manager.allocatedPorts = new Set([8642, 8643, 8644, 8645, 8646, 8647])
+
+    const endpoint = await manager.resolvePort('work')
+
+    expect(endpoint.port).toBe(8649)
+  })
+})


### PR DESCRIPTION
## Summary
- Reserve the Web UI listen port during gateway port allocation.
- Use the configured `PORT` value when present, falling back to the default Web UI port `8648`.
- Add coverage for the 8642-8648 collision case so the next gateway is assigned 8649.

## Why
Gateway startup currently happens before the Web UI server begins listening, so system port checks cannot see that the Web UI will later bind its configured port. With enough profiles, a gateway can claim 8648 first and make Web UI startup fail with EADDRINUSE.

Fixes #744

## Validation
- `npx vitest run tests/server/gateway-manager.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm test`