### PR TITLE
[codex] fix command compression token estimate

### DIFF
--- a/packages/server/src/services/hermes/run-chat/compression.ts
+++ b/packages/server/src/services/hermes/run-chat/compression.ts
@@ -66,6 +66,24 @@ export async function buildDbHistory(
   }).filter((m): m is ChatMessage => m !== null)
 }
 
+export function estimateSnapshotAwareHistoryUsage(
+  sessionId: string,
+  history: ChatMessage[],
+): { messageCount: number; tokenCount: number } {
+  const snapshot = getCompressionSnapshot(sessionId)
+  const messages = snapshot
+    ? [
+        { role: 'user', content: SUMMARY_PREFIX + snapshot.summary },
+        ...history.slice(snapshot.lastMessageIndex + 1),
+      ]
+    : history
+  const usage = estimateUsageTokensFromMessages(messages)
+  return {
+    messageCount: messages.length,
+    tokenCount: usage.inputTokens + usage.outputTokens,
+  }
+}
+
 export async function buildCompressedHistory(
   sessionId: string,
   profile: string,
@@ -210,12 +228,13 @@ export async function forceCompressBridgeHistory(
 
   const upstream = getUpstream(profile).replace(/\/$/, '')
   const apiKey = getApiKey(profile) || undefined
-  const beforeUsage = estimateUsageTokensFromMessages(history)
-  const totalTokens = beforeUsage.inputTokens + beforeUsage.outputTokens
+  const beforeUsage = estimateSnapshotAwareHistoryUsage(sessionId, history)
+  const totalTokens = beforeUsage.tokenCount
   bridgeLogger.info({
     sessionId,
     profile,
     historyMessages: history.length,
+    snapshotAwareMessages: beforeUsage.messageCount,
     bridgeProvidedMessages: Array.isArray(_messages) ? _messages.length : 0,
     tokenEstimate: totalTokens,
     snapshotAware: true,

--- a/packages/server/src/services/hermes/run-chat/session-command.ts
+++ b/packages/server/src/services/hermes/run-chat/session-command.ts
@@ -3,9 +3,9 @@ import { addMessage, clearSessionMessages, createSession, getSession, renameSess
 import { logger } from '../../logger'
 import type { AgentBridgeClient } from '../agent-bridge'
 import { flushBridgePendingToDb } from './bridge-message'
-import { buildDbHistory, forceCompressBridgeHistory, getOrCreateSession, replaceState } from './compression'
+import { buildDbHistory, estimateSnapshotAwareHistoryUsage, forceCompressBridgeHistory, getOrCreateSession, replaceState } from './compression'
 import { handleAbort } from './abort'
-import { calcAndUpdateUsage, estimateUsageTokensFromMessages } from './usage'
+import { calcAndUpdateUsage } from './usage'
 import type { ContentBlock, QueuedRun, SessionState } from './types'
 
 type CommandName =
@@ -232,12 +232,11 @@ export async function handleSessionCommand(
       const emit = (event: string, payload: any) => emitToSession(ctx.nsp, ctx.socket, sessionId, event, payload)
       try {
         const history = await buildDbHistory(sessionId, { excludeLastUser: true })
-        const usageEstimate = estimateUsageTokensFromMessages(history)
-        const tokenEstimate = usageEstimate.inputTokens + usageEstimate.outputTokens
+        const usageEstimate = estimateSnapshotAwareHistoryUsage(sessionId, history)
         emit('compression.started', {
           event: 'compression.started',
-          message_count: history.length,
-          token_count: tokenEstimate,
+          message_count: usageEstimate.messageCount,
+          token_count: usageEstimate.tokenCount,
           source: 'command',
         })
         const result = await forceCompressBridgeHistory(


### PR DESCRIPTION
## Summary

- Make `/compress` started/completed token counts snapshot-aware.
- Estimate forced compression beforeTokens from the assembled snapshot summary plus new messages instead of the full DB history.
- Keep the actual compression flow unchanged; this fixes misleading command/UI token output after a session was already compressed.

## Root Cause

The command compression path built full DB history for display and calculated beforeTokens from that full history. The compressor itself still reads the compression snapshot internally, so actual compression was incremental, but the command output could show a much larger token count than resumed session usage.

## Validation

- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npx vitest run tests/server/run-chat-usage.test.ts tests/server/context-compressor.test.ts`