### PR TITLE
fix: prevent yaml corruption when saving model config via web UI

### DIFF
--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -424,7 +424,11 @@ export async function setConfigModel(ctx: any) {
   }
   try {
     const config = await readConfigYaml()
-    config.model = {}
+    // Preserve existing model sub-keys (base_url, context_length, api_mode, etc.)
+    // by spreading the existing model dict. This prevents silent deletion of
+    // keys when the CLI (which stores model as a dict) reads back the config.
+    if (typeof config.model !== 'object' || config.model === null) { config.model = {} }
+    config.model = { ...config.model } // defensive copy to avoid mutation surprises
     config.model.default = defaultModel
     if (reqProvider) { config.model.provider = reqProvider }
     await writeConfigYaml(config)

--- a/packages/server/src/services/config-helpers.ts
+++ b/packages/server/src/services/config-helpers.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, copyFile, chmod } from 'fs/promises'
+import { readFile, writeFile, copyFile, rename, chmod } from 'fs/promises'
 import { readdir, stat } from 'fs/promises'
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
@@ -80,12 +80,23 @@ export async function readConfigYaml(): Promise<Record<string, any>> {
 export async function writeConfigYaml(config: Record<string, any>): Promise<void> {
   const cp = configPath()
   await copyFile(cp, cp + '.bak')
+
+  // Write to temp file first, then atomically rename.
+  // This prevents concurrent readers (other Hermes processes) from
+  // seeing a partially-written config when multiple code paths write
+  // to the same config.yaml simultaneously.
+  const tmpPath = cp + '.tmp'
   const yamlStr = YAML.dump(config, {
     lineWidth: -1,
     noRefs: true,
-    quotingType: '"',
+    // Intentionally omitting quotingType to let js-yaml choose
+    // quoting naturally. Forcing all strings to be double-quoted
+    // with quotingType: '"' produces YAML that differs from
+    // Python's PyYAML output, causing misalignment when CLI
+    // tools and web UI write to the same file.
   })
-  await writeFile(cp, yamlStr, 'utf-8')
+  await writeFile(tmpPath, yamlStr, 'utf-8')
+  await rename(tmpPath, cp)
 }
 
 // --- .env helpers ---


### PR DESCRIPTION
## Problem

When using the Hermes Desktop Web UI to change model/provider settings, ~/.hermes/config.yaml gets corrupted with garbage characters, making the entire config unparseable.

## Root Causes

Two independent root causes were identified:

### 1. Non-atomic file write (writeConfigYaml)

The function writes directly to the config file via writeFile(cp, ...). If another Hermes process (CLI web_server, TUI gateway) writes to the same file simultaneously, the output is interleaved - producing broken YAML.

Fix: Write to a temp file first, then atomically rename() to the target path.

### 2. Incompatible YAML quoting (writeConfigYaml)

js-yaml was configured with quotingType that forces ALL string values to be double-quoted. Python's PyYAML (used by the Hermes CLI) does not do this. The round-trip between libraries produces inconsistent formatting and can misalign subsequent writes.

Fix: Remove quotingType and let js-yaml choose quoting naturally, matching PyYAML's behavior.

### 3. Model sub-key deletion (setConfigModel)

The function unconditionally does config.model = {} before setting default and provider, which silently deletes base_url, context_length, and other sub-keys that the CLI depends on.

Fix: Preserve existing model sub-keys by using spread before overwriting.