### PR TITLE
fix: 收紧 self-update 的 npm fallback

### DIFF
--- a/packages/server/src/controllers/update.ts
+++ b/packages/server/src/controllers/update.ts
@@ -39,8 +39,13 @@ function getNpmCliPath() {
   return npmCli || null
 }
 
-function getNpmBin() {
-  return process.platform === 'win32' ? 'npm.cmd' : 'npm'
+function getNpmBinCandidate() {
+  return join(getNodeBinDir(), process.platform === 'win32' ? 'npm.cmd' : 'npm')
+}
+
+function getNpmBinPath() {
+  const npmBin = getNpmBinCandidate()
+  return existsSync(npmBin) ? npmBin : null
 }
 
 function getGlobalPackageBin(root: string) {
@@ -55,12 +60,33 @@ function getCurrentNodeEnv() {
   }
 }
 
-function runNpm(args: string[], options: { timeout?: number } = {}) {
-  const npmCli = getNpmCliPath()
-  const command = npmCli ? process.execPath : getNpmBin()
-  const commandArgs = npmCli ? [npmCli, ...args] : args
+function quoteCmdArg(value: string) {
+  return /[\s&()^|<>"]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value
+}
 
-  return execFileSync(command, commandArgs, {
+function getNpmInvocation(args: string[]) {
+  const npmCli = getNpmCliPath()
+  if (npmCli) {
+    return { command: process.execPath, args: [npmCli, ...args] }
+  }
+
+  const npmBin = getNpmBinPath()
+  if (!npmBin) {
+    throw new Error(`Unable to locate npm for ${process.execPath}`)
+  }
+
+  if (process.platform === 'win32') {
+    const comspec = process.env.ComSpec || process.env.COMSPEC || 'cmd.exe'
+    return { command: comspec, args: ['/d', '/s', '/c', [npmBin, ...args].map(quoteCmdArg).join(' ')] }
+  }
+
+  return { command: npmBin, args }
+}
+
+function runNpm(args: string[], options: { timeout?: number } = {}) {
+  const npm = getNpmInvocation(args)
+
+  return execFileSync(npm.command, npm.args, {
     encoding: 'utf-8',
     timeout: options.timeout,
     stdio: ['pipe', 'pipe', 'pipe'],

--- a/tests/server/update-controller.test.ts
+++ b/tests/server/update-controller.test.ts
@@ -1,29 +1,30 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { delimiter, dirname, join } from 'path'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as nodePath from 'path'
 
 type UpdateControllerMocks = {
   execFileSync: ReturnType<typeof vi.fn>
   spawn: ReturnType<typeof vi.fn>
   unref: ReturnType<typeof vi.fn>
+  on: ReturnType<typeof vi.fn>
   existsSync: ReturnType<typeof vi.fn>
 }
 
-async function loadUpdateController(overrides: Partial<UpdateControllerMocks> = {}) {
-  const execFileSync = overrides.execFileSync ?? vi.fn().mockReturnValue('updated')
-  const unref = overrides.unref ?? vi.fn()
-  const spawn = overrides.spawn ?? vi.fn(() => ({ unref, on: vi.fn() }))
-  const existsSync = overrides.existsSync ?? vi.fn(() => true)
+type PathApi = Pick<typeof nodePath, 'delimiter' | 'dirname' | 'join'>
 
-  vi.resetModules()
-  vi.doMock('child_process', () => ({ execFileSync, spawn }))
-  vi.doMock('fs', () => ({ existsSync }))
-
-  const mod = await import('../../packages/server/src/controllers/update')
-  return {
-    ...mod,
-    mocks: { execFileSync, spawn, unref, existsSync },
-  }
+type LoadOptions = {
+  platform?: NodeJS.Platform
+  execPath?: string
+  pathApi?: PathApi
+  execFileSync?: ReturnType<typeof vi.fn>
+  spawn?: ReturnType<typeof vi.fn>
+  existsSync?: ReturnType<typeof vi.fn>
 }
+
+const originalPort = process.env.PORT
+const originalPath = process.env.PATH
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+const originalExecPathDescriptor = Object.getOwnPropertyDescriptor(process, 'execPath')
+const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
 
 function createMockCtx() {
   return {
@@ -32,76 +33,135 @@ function createMockCtx() {
   }
 }
 
-function getNodeBinDir() {
-  return dirname(process.execPath)
+function mockChildProcess() {
+  const child = {
+    unref: vi.fn(),
+    on: vi.fn(),
+  }
+  child.on.mockReturnValue(child)
+  return child
 }
 
-function getNodePrefix() {
-  return process.platform === 'win32' ? getNodeBinDir() : dirname(getNodeBinDir())
+function mockExistingPaths(paths: string[]) {
+  const existing = new Set(paths)
+  return vi.fn((candidate: string) => existing.has(candidate))
 }
 
-function getNpmCliPath() {
-  const prefix = getNodePrefix()
-  return process.platform === 'win32'
-    ? join(prefix, 'node_modules', 'npm', 'bin', 'npm-cli.js')
-    : join(prefix, 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js')
+function setProcessRuntime(platform: NodeJS.Platform, execPath: string) {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+  Object.defineProperty(process, 'execPath', {
+    configurable: true,
+    value: execPath,
+  })
 }
 
-function getGlobalCliScript(prefix: string) {
-  return process.platform === 'win32'
-    ? join(prefix, 'node_modules', 'hermes-web-ui', 'bin', 'hermes-web-ui.mjs')
-    : join(prefix, 'lib', 'node_modules', 'hermes-web-ui', 'bin', 'hermes-web-ui.mjs')
+function restoreProcessRuntime() {
+  if (originalPlatformDescriptor) Object.defineProperty(process, 'platform', originalPlatformDescriptor)
+  if (originalExecPathDescriptor) Object.defineProperty(process, 'execPath', originalExecPathDescriptor)
+}
+
+async function loadUpdateController(options: LoadOptions = {}) {
+  const platform = options.platform ?? process.platform
+  const execPath = options.execPath ?? process.execPath
+  const pathApi = options.pathApi ?? nodePath
+  const restart = mockChildProcess()
+  const execFileSync = options.execFileSync ?? vi.fn().mockReturnValue('updated')
+  const spawn = options.spawn ?? vi.fn(() => restart)
+  const existsSync = options.existsSync ?? vi.fn(() => true)
+
+  vi.resetModules()
+  setProcessRuntime(platform, execPath)
+  vi.doMock('child_process', () => ({ execFileSync, spawn }))
+  vi.doMock('fs', () => ({ existsSync }))
+  vi.doMock('path', () => ({
+    delimiter: pathApi.delimiter,
+    dirname: pathApi.dirname,
+    join: pathApi.join,
+  }))
+
+  const mod = await import('../../packages/server/src/controllers/update')
+  return {
+    ...mod,
+    mocks: { execFileSync, spawn, unref: restart.unref, on: restart.on, existsSync } as UpdateControllerMocks,
+  }
+}
+
+function makeNpmExecutor(globalRoot: string) {
+  return vi.fn((_command: string, args: string[]) => {
+    const joinedArgs = args.join(' ')
+    if (args.includes('cache') || /\bcache\b/.test(joinedArgs)) return ''
+    if (args.includes('root') || /\broot\b/.test(joinedArgs)) return globalRoot
+    if (args.includes('install') || /\binstall\b/.test(joinedArgs)) return 'updated'
+    throw new Error(`unexpected npm args: ${joinedArgs}`)
+  })
+}
+
+function expectPathChecked(mock: ReturnType<typeof vi.fn>, expectedPath: string) {
+  expect(mock.mock.calls.some(([candidate]) => candidate === expectedPath)).toBe(true)
 }
 
 describe('update controller', () => {
-  const originalPort = process.env.PORT
-  const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
-
   beforeEach(() => {
     vi.useFakeTimers()
     vi.clearAllMocks()
+    process.env.PATH = '/usr/local/bin:/usr/bin:/bin'
   })
 
   afterEach(() => {
     vi.useRealTimers()
     vi.doUnmock('child_process')
     vi.doUnmock('fs')
+    vi.doUnmock('path')
+    restoreProcessRuntime()
     if (originalPort === undefined) {
       delete process.env.PORT
     } else {
       process.env.PORT = originalPort
     }
+    if (originalPath === undefined) {
+      delete process.env.PATH
+    } else {
+      process.env.PATH = originalPath
+    }
   })
 
-  it('updates and restarts through the running Node executable, not PATH shims', async () => {
+  afterAll(() => {
+    exitSpy.mockRestore()
+  })
+
+  it('installs through the current Node npm-cli and restarts the updated global package script', async () => {
     process.env.PORT = '9129'
-    const nodeBinDir = getNodeBinDir()
-    const npmCli = getNpmCliPath()
-    const globalPrefix = getNodePrefix()
-    const cliScript = getGlobalCliScript(globalPrefix)
-    const execFileSync = vi.fn((_command: string, args: string[]) => {
-      if (args[1] === 'root') {
-        return process.platform === 'win32'
-          ? join(globalPrefix, 'node_modules')
-          : join(globalPrefix, 'lib', 'node_modules')
-      }
-      return 'updated'
+    const pathApi = nodePath.posix
+    const execPath = '/opt/node/bin/node'
+    const npmCli = '/opt/node/lib/node_modules/npm/bin/npm-cli.js'
+    const globalRoot = '/opt/node/lib/node_modules'
+    const cliScript = '/opt/node/lib/node_modules/hermes-web-ui/bin/hermes-web-ui.mjs'
+    const execFileSync = makeNpmExecutor(globalRoot)
+
+    const { handleUpdate, mocks } = await loadUpdateController({
+      platform: 'linux',
+      execPath,
+      pathApi,
+      execFileSync,
+      existsSync: mockExistingPaths([npmCli, cliScript]),
     })
-    const { handleUpdate, mocks } = await loadUpdateController({ execFileSync })
     const ctx = createMockCtx()
 
     await handleUpdate(ctx)
 
     expect(mocks.execFileSync).toHaveBeenCalledWith(
-      process.execPath,
+      execPath,
       [npmCli, 'install', '-g', 'hermes-web-ui@latest'],
       expect.objectContaining({
         encoding: 'utf-8',
         timeout: 10 * 60 * 1000,
         stdio: ['pipe', 'pipe', 'pipe'],
         env: expect.objectContaining({
-          npm_node_execpath: process.execPath,
-          PATH: expect.stringContaining(`${nodeBinDir}${delimiter}`),
+          npm_node_execpath: execPath,
+          PATH: expect.stringMatching(new RegExp(`^${escapeRegExp(pathApi.dirname(execPath))}${pathApi.delimiter}`)),
         }),
       }),
     )
@@ -110,26 +170,21 @@ describe('update controller', () => {
     vi.runAllTimers()
 
     expect(mocks.execFileSync).toHaveBeenCalledWith(
-      process.execPath,
+      execPath,
       [npmCli, 'root', '-g'],
-      expect.objectContaining({
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-        env: expect.objectContaining({ npm_node_execpath: process.execPath }),
-      }),
+      expect.objectContaining({ env: expect.objectContaining({ npm_node_execpath: execPath }) }),
     )
     expect(mocks.spawn).toHaveBeenCalledWith(
-      process.execPath,
+      execPath,
       [cliScript, 'restart', '--port', '9129'],
-      expect.objectContaining({
-        detached: true,
-        stdio: 'ignore',
-        windowsHide: true,
-        env: expect.objectContaining({ npm_node_execpath: process.execPath }),
-      }),
+      expect.objectContaining({ detached: true, stdio: 'ignore', windowsHide: true }),
     )
+    expect(mocks.on).toHaveBeenCalledWith('error', expect.any(Function))
+    expect(mocks.on).toHaveBeenCalledWith('exit', expect.any(Function))
     expect(mocks.unref).toHaveBeenCalledOnce()
+    expect(exitSpy).not.toHaveBeenCalled()
   })
+
 
   it('falls back to the default port when PORT is not set', async () => {
     delete process.env.PORT
@@ -149,16 +204,15 @@ describe('update controller', () => {
   it('does not log a restart error when the restart helper exits successfully', async () => {
     const handlers = new Map<string, (...args: any[]) => void>()
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    const unref = vi.fn()
     const restart = {
-      unref,
+      unref: vi.fn(),
       on: vi.fn((event: string, handler: (...args: any[]) => void) => {
         handlers.set(event, handler)
         return restart
       }),
     }
     const spawn = vi.fn(() => restart)
-    const { handleUpdate } = await loadUpdateController({ spawn, unref })
+    const { handleUpdate } = await loadUpdateController({ spawn })
     const ctx = createMockCtx()
 
     await handleUpdate(ctx)
@@ -169,21 +223,254 @@ describe('update controller', () => {
     errorSpy.mockRestore()
   })
 
-  it('returns a 500 with stderr when installation fails', async () => {
-    const execFileSync = vi.fn(() => {
-      const error = new Error('install failed') as Error & { stderr?: string }
-      error.stderr = 'engine mismatch'
-      throw error
+  it('finds Homebrew npm-cli outside the Node Cellar path before resolving the global package root', async () => {
+    const pathApi = nodePath.posix
+    const execPath = '/opt/homebrew/Cellar/node/25.7.0/bin/node'
+    const cellarNpmCli = '/opt/homebrew/Cellar/node/25.7.0/lib/node_modules/npm/bin/npm-cli.js'
+    const homebrewNpmCli = '/opt/homebrew/lib/node_modules/npm/bin/npm-cli.js'
+    const globalRoot = '/opt/homebrew/lib/node_modules'
+    const cliScript = '/opt/homebrew/lib/node_modules/hermes-web-ui/bin/hermes-web-ui.mjs'
+    const execFileSync = makeNpmExecutor(globalRoot)
+
+    const { handleUpdate, mocks } = await loadUpdateController({
+      platform: 'darwin',
+      execPath,
+      pathApi,
+      execFileSync,
+      existsSync: mockExistingPaths([homebrewNpmCli, cliScript]),
     })
-    const { handleUpdate, mocks } = await loadUpdateController({ execFileSync })
+
+    await handleUpdate(createMockCtx())
+    vi.runAllTimers()
+
+    expectPathChecked(mocks.existsSync, cellarNpmCli)
+    expectPathChecked(mocks.existsSync, homebrewNpmCli)
+    expect(mocks.execFileSync).toHaveBeenCalledWith(
+      execPath,
+      [homebrewNpmCli, 'install', '-g', 'hermes-web-ui@latest'],
+      expect.any(Object),
+    )
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      execPath,
+      [cliScript, 'restart', '--port', '8648'],
+      expect.any(Object),
+    )
+  })
+
+  it('uses a co-located Windows npm.cmd fallback through cmd.exe and restarts the package script without invoking a cmd shim', async () => {
+    process.env.PORT = '9444'
+    const pathApi = nodePath.win32
+    const execPath = 'C:\\Program Files\\nodejs\\node.exe'
+    const nodeBinDir = pathApi.dirname(execPath)
+    const npmCmd = pathApi.join(nodeBinDir, 'npm.cmd')
+    const globalRoot = 'C:\\Users\\han\\AppData\\Roaming\\npm\\node_modules'
+    const cliScript = pathApi.join(globalRoot, 'hermes-web-ui', 'bin', 'hermes-web-ui.mjs')
+    const execFileSync = makeNpmExecutor(globalRoot)
+
+    const { handleUpdate, mocks } = await loadUpdateController({
+      platform: 'win32',
+      execPath,
+      pathApi,
+      execFileSync,
+      existsSync: mockExistingPaths([npmCmd, cliScript]),
+    })
+
+    await handleUpdate(createMockCtx())
+    vi.runAllTimers()
+
+    expect(mocks.execFileSync).toHaveBeenCalledWith(
+      'cmd.exe',
+      ['/d', '/s', '/c', `"${npmCmd}" install -g hermes-web-ui@latest`],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          npm_node_execpath: execPath,
+          PATH: expect.stringMatching(new RegExp(`^${escapeRegExp(nodeBinDir)}${pathApi.delimiter}`)),
+        }),
+      }),
+    )
+    expect(mocks.execFileSync).toHaveBeenCalledWith(
+      'cmd.exe',
+      ['/d', '/s', '/c', `"${npmCmd}" root -g`],
+      expect.any(Object),
+    )
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      execPath,
+      [cliScript, 'restart', '--port', '9444'],
+      expect.objectContaining({ windowsHide: true }),
+    )
+  })
+
+  it('uses Termux npm-cli and npm root -g to avoid hard-coded lib/node_modules guesses', async () => {
+    const pathApi = nodePath.posix
+    const execPath = '/data/data/com.termux/files/usr/bin/node'
+    const npmCli = '/data/data/com.termux/files/usr/lib/node_modules/npm/bin/npm-cli.js'
+    const globalRoot = '/data/data/com.termux/files/usr/lib/node_modules'
+    const cliScript = '/data/data/com.termux/files/usr/lib/node_modules/hermes-web-ui/bin/hermes-web-ui.mjs'
+    const execFileSync = makeNpmExecutor(globalRoot)
+
+    const { handleUpdate, mocks } = await loadUpdateController({
+      platform: 'linux',
+      execPath,
+      pathApi,
+      execFileSync,
+      existsSync: mockExistingPaths([npmCli, cliScript]),
+    })
+
+    await handleUpdate(createMockCtx())
+    vi.runAllTimers()
+
+    expect(mocks.execFileSync).toHaveBeenCalledWith(
+      execPath,
+      [npmCli, 'root', '-g'],
+      expect.any(Object),
+    )
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      execPath,
+      [cliScript, 'restart', '--port', '8648'],
+      expect.any(Object),
+    )
+  })
+
+  it('uses a co-located Linux npm executable fallback without resolving npm from PATH', async () => {
+    const pathApi = nodePath.posix
+    const execPath = '/usr/bin/node'
+    const npmBin = '/usr/bin/npm'
+    const globalRoot = '/usr/lib/node_modules'
+    const cliScript = '/usr/lib/node_modules/hermes-web-ui/bin/hermes-web-ui.mjs'
+    const execFileSync = makeNpmExecutor(globalRoot)
+
+    const { handleUpdate, mocks } = await loadUpdateController({
+      platform: 'linux',
+      execPath,
+      pathApi,
+      execFileSync,
+      existsSync: mockExistingPaths([npmBin, cliScript]),
+    })
+
+    await handleUpdate(createMockCtx())
+    vi.runAllTimers()
+
+    expect(mocks.execFileSync).toHaveBeenCalledWith(
+      npmBin,
+      ['install', '-g', 'hermes-web-ui@latest'],
+      expect.any(Object),
+    )
+    expect(mocks.execFileSync).toHaveBeenCalledWith(
+      npmBin,
+      ['root', '-g'],
+      expect.any(Object),
+    )
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      execPath,
+      [cliScript, 'restart', '--port', '8648'],
+      expect.any(Object),
+    )
+  })
+
+  it('fails closed when neither npm-cli nor a co-located npm executable exists', async () => {
+    const execPath = '/isolated/node/bin/node'
+    const { handleUpdate, mocks } = await loadUpdateController({
+      platform: 'linux',
+      execPath,
+      pathApi: nodePath.posix,
+      existsSync: mockExistingPaths([]),
+    })
     const ctx = createMockCtx()
 
     await handleUpdate(ctx)
 
     expect(ctx.status).toBe(500)
-    expect(ctx.body).toEqual({ success: false, message: 'engine mismatch' })
+    expect(ctx.body).toEqual({
+      success: false,
+      message: expect.stringContaining(`Unable to locate npm for ${execPath}`),
+    })
+    expect(mocks.execFileSync).not.toHaveBeenCalled()
     expect(mocks.spawn).not.toHaveBeenCalled()
     expect(exitSpy).not.toHaveBeenCalled()
   })
 
+  it('does not kill the current server when the updated CLI script cannot be resolved after install', async () => {
+    const execPath = '/opt/node/bin/node'
+    const npmCli = '/opt/node/lib/node_modules/npm/bin/npm-cli.js'
+    const execFileSync = makeNpmExecutor('/opt/node/lib/node_modules')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { handleUpdate, mocks } = await loadUpdateController({
+      platform: 'linux',
+      execPath,
+      pathApi: nodePath.posix,
+      execFileSync,
+      existsSync: mockExistingPaths([npmCli]),
+    })
+    const ctx = createMockCtx()
+
+    await handleUpdate(ctx)
+    vi.runAllTimers()
+
+    expect(ctx.body).toEqual({ success: true, message: 'updated' })
+    expect(mocks.spawn).not.toHaveBeenCalled()
+    expect(exitSpy).not.toHaveBeenCalled()
+    expect(consoleError).toHaveBeenCalledWith('[update] failed to spawn restart:', expect.any(Error))
+    consoleError.mockRestore()
+  })
+
+  it('rejects duplicate in-app update requests until the delegated restart finishes or fails', async () => {
+    const execPath = '/opt/node/bin/node'
+    const npmCli = '/opt/node/lib/node_modules/npm/bin/npm-cli.js'
+    const globalRoot = '/opt/node/lib/node_modules'
+    const cliScript = '/opt/node/lib/node_modules/hermes-web-ui/bin/hermes-web-ui.mjs'
+    const execFileSync = makeNpmExecutor(globalRoot)
+    const { handleUpdate, mocks } = await loadUpdateController({
+      platform: 'linux',
+      execPath,
+      pathApi: nodePath.posix,
+      execFileSync,
+      existsSync: mockExistingPaths([npmCli, cliScript]),
+    })
+    const first = createMockCtx()
+    const second = createMockCtx()
+
+    await handleUpdate(first)
+    await handleUpdate(second)
+
+    expect(second.status).toBe(409)
+    expect(second.body).toEqual({
+      success: false,
+      message: 'hermes-web-ui update is already in progress',
+    })
+
+    vi.runAllTimers()
+    const exitHandler = mocks.on.mock.calls.find(([event]) => event === 'exit')?.[1] as (code: number, signal: string | null) => void
+    exitHandler(1, null)
+
+    const third = createMockCtx()
+    await handleUpdate(third)
+    expect(third.status).toBe(200)
+    expect(third.body).toEqual({ success: true, message: 'updated' })
+  })
+
+  it('returns a 500 with stderr and resets the update lock when installation fails', async () => {
+    const execFileSync = vi.fn(() => {
+      const error = new Error('install failed') as Error & { stderr?: Buffer }
+      error.stderr = Buffer.from('engine mismatch')
+      throw error
+    })
+    const { handleUpdate, mocks } = await loadUpdateController({ execFileSync })
+    const failed = createMockCtx()
+
+    await handleUpdate(failed)
+
+    expect(failed.status).toBe(500)
+    expect(failed.body).toEqual({ success: false, message: 'engine mismatch' })
+    expect(mocks.spawn).not.toHaveBeenCalled()
+    expect(exitSpy).not.toHaveBeenCalled()
+
+    const retry = createMockCtx()
+    await handleUpdate(retry)
+    expect(retry.status).toBe(500)
+    expect(retry.body).toEqual({ success: false, message: 'engine mismatch' })
+  })
 })
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}


### PR DESCRIPTION
Fixes #596
Fixes #708

相关：#707, #552

self-update 的 npm 执行路径已收紧：找不到当前 Node 对应的 `npm-cli.js` 时，只回退到同目录的 `npm` / `npm.cmd`，不再依赖系统 PATH。Windows 的 `npm.cmd` 改为通过 `cmd.exe` 启动，避免直接把 `.cmd` 当成可执行文件调用。

## 改动
- npm 调用统一走 `getNpmInvocation`，优先使用 `process.execPath + npm-cli.js`。
- npm-cli 不存在时，只接受 current Node bin 目录里的 `npm` / `npm.cmd`；找不到就 fail closed。
- Windows `.cmd` fallback 通过 `cmd.exe /d /s /c` 执行，并继续带上 current Node 的环境。
- restart 目标继续用 `npm root -g` 找到已安装 package，再通过 `process.execPath <globalRoot>/hermes-web-ui/bin/hermes-web-ui.mjs restart` 启动。
- update controller 测试覆盖 Homebrew、Termux、Windows、Linux fallback、缺 npm fail closed、restart 失败保留当前 server、重复 update lock。

## 验证
已通过：

```bash
npm test -- --run tests/server/update-controller.test.ts --reporter=verbose
npm run build
git diff --check
```

结果：
- update-controller: 11 tests passed
- build passed（保留现有 large chunk warning）
- diff whitespace check passed

本机 macOS 额外跑了真实 upgrade 按钮验证：
- 本地候选服务显示 `Web UI v0.5.22` / `Upgrade to v0.5.24`。
- 浏览器点击真实 upgrade 按钮后，`POST /api/hermes/update` 返回 200，npm 全局安装完成。
- restart 后同端口重新可用，`/health` 返回 `webui_version: 0.5.24`。
- 全局 `hermes-web-ui --version` 从 v0.5.22 更新到 v0.5.24。

已知：
- 这里没有在 Windows 或 Termux 真机执行 destructive global update；这些环境主要由 controller-level regression tests 覆盖。
