### PR TITLE
test: 启用测试覆盖率基线

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Test
-        run: npm test
+      - name: Test with coverage
+        run: npm run test:coverage
 
       - name: Build
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ package-lock.json
 node_modules
 dist
 dist-ssr
+coverage
 __pycache__/
 *.py[cod]
 server/dist

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/qrcode": "^1.5.6",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-vue": "^6.0.5",
+    "@vitest/coverage-v8": "^3.2.4",
     "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.9.1",
     "@xterm/addon-fit": "^0.11.0",


### PR DESCRIPTION
## 改动

测试覆盖率命令已接入现有 PR 构建流程。

- 补上 Vitest V8 coverage provider 依赖，让 `npm run test:coverage` 不再缺包失败
- PR 构建中的测试步骤改为运行 `npm run test:coverage`，保留完整测试 gate，同时输出覆盖率基线
- 忽略本地生成的 `coverage` 目录，避免覆盖率产物进入提交

## 验证

- `npm install --package-lock=false`：通过
- `npm run test:coverage`：通过，73 个测试文件通过，487 个测试通过，2 个跳过
- `npm run build`：通过
- `npm test`：通过，73 个测试文件通过，487 个测试通过，2 个跳过
- `git diff --check`：通过
- 独立代码审查：通过

## 说明

暂不加覆盖率阈值。这个改动只先恢复覆盖率基线采集，避免在没有稳定基线前引入硬阈值。