### PR TITLE
test: 覆盖 Terminal 浏览器契约

### DIFF
--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -248,3 +248,82 @@ export default { io }
     })
   })
 }
+
+export async function mockTerminalWebSocket(page: Page) {
+  await page.addInitScript(() => {
+    const state = (window as any).__PW_TERMINAL_WS__ = {
+      sockets: [] as any[],
+      sent: [] as any[],
+      createdCount: 0,
+      latest: null as any,
+    }
+    const RealEvent = window.Event
+    const RealMessageEvent = window.MessageEvent
+
+    class MockTerminalWebSocket extends EventTarget {
+      static CONNECTING = 0
+      static OPEN = 1
+      static CLOSING = 2
+      static CLOSED = 3
+
+      readonly CONNECTING = 0
+      readonly OPEN = 1
+      readonly CLOSING = 2
+      readonly CLOSED = 3
+      binaryType: BinaryType = 'blob'
+      bufferedAmount = 0
+      extensions = ''
+      protocol = ''
+      readyState = MockTerminalWebSocket.CONNECTING
+      onopen: ((event: Event) => void) | null = null
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: ((event: Event) => void) | null = null
+      onclose: ((event: CloseEvent) => void) | null = null
+
+      constructor(readonly url: string | URL) {
+        super()
+        state.sockets.push(this)
+        state.latest = this
+        setTimeout(() => {
+          this.readyState = MockTerminalWebSocket.OPEN
+          const openEvent = new RealEvent('open')
+          this.onopen?.(openEvent)
+          this.dispatchEvent(openEvent)
+          this.__createSession('term-1', 'zsh', 101)
+        }, 0)
+      }
+
+      send(data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+        const normalized = typeof data === 'string' ? data : String(data)
+        state.sent.push({ socket: this.url.toString(), data: normalized })
+        if (normalized.charCodeAt(0) !== 0x7B) return
+        try {
+          const message = JSON.parse(normalized)
+          if (message.type === 'create') {
+            this.__createSession(`term-${state.createdCount + 1}`, 'bash', 200 + state.createdCount)
+          }
+          if (message.type === 'switch') {
+            this.__emitMessage(JSON.stringify({ type: 'switched', id: message.sessionId }))
+          }
+        } catch {}
+      }
+
+      close() {
+        this.readyState = MockTerminalWebSocket.CLOSED
+      }
+
+      __createSession(id: string, shell: string, pid: number) {
+        state.createdCount += 1
+        this.__emitMessage(JSON.stringify({ type: 'created', id, shell, pid }))
+      }
+
+      __emitMessage(data: string) {
+        const event = new RealMessageEvent('message', { data })
+        this.onmessage?.(event)
+        this.dispatchEvent(event)
+      }
+    }
+
+    ;(window as any).WebSocket = MockTerminalWebSocket
+  })
+}

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test'
+import { authenticate, mockHermesApi, mockTerminalWebSocket, TEST_ACCESS_KEY } from './fixtures'
+
+test('opens terminal websocket session and forwards user input', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  const api = await mockHermesApi(page)
+  await mockTerminalWebSocket(page)
+
+  await page.goto('/#/hermes/terminal')
+
+  await expect(page.getByText('Sessions')).toBeVisible()
+  await expect(page.locator('.session-item-title', { hasText: 'zsh #1' })).toBeVisible()
+
+  const terminalState = await page.waitForFunction(() => {
+    const state = (window as any).__PW_TERMINAL_WS__
+    return state?.sockets?.length
+      ? {
+          url: state.latest.url,
+          sent: state.sent,
+        }
+      : null
+  })
+  const initialState = await terminalState.jsonValue() as any
+  const terminalUrl = new URL(initialState.url)
+  expect(terminalUrl.pathname).toBe('/api/hermes/terminal')
+  expect(terminalUrl.searchParams.get('token')).toBe(TEST_ACCESS_KEY)
+
+  await page.locator('.terminal-header .header-actions button').last().click()
+  await expect(page.locator('.session-item-title', { hasText: 'bash #2' })).toBeVisible()
+
+  await page.locator('.terminal-xterm').click()
+  await page.keyboard.type('pwd')
+  await page.keyboard.press('Enter')
+
+  await expect.poll(async () => page.evaluate(() => {
+    const state = (window as any).__PW_TERMINAL_WS__
+    return state.sent
+      .map((item: any) => item.data)
+      .filter((data: string) => !data.startsWith('{'))
+      .join('')
+  })).toContain('pwd')
+
+  await expect.poll(async () => page.evaluate(() => {
+    const state = (window as any).__PW_TERMINAL_WS__
+    return state.sent
+      .map((item: any) => item.data)
+      .filter((data: string) => data.startsWith('{'))
+      .map((data: string) => JSON.parse(data))
+      .some((message: any) => message.type === 'resize' && message.cols > 0 && message.rows > 0)
+  })).toBe(true)
+
+  const finalState = await page.evaluate(() => (window as any).__PW_TERMINAL_WS__)
+  const controlMessages = finalState.sent
+    .map((item: any) => item.data)
+    .filter((data: string) => data.startsWith('{'))
+    .map((data: string) => JSON.parse(data))
+
+  expect(controlMessages.some((message: any) => message.type === 'create')).toBe(true)
+  expect(api.unexpectedRequests).toEqual([])
+})


### PR DESCRIPTION
## 改动

补上 Terminal 页面的浏览器契约测试，覆盖终端 WebSocket 主路径。

- 新增 `terminal.spec.ts`，在真实浏览器中打开 `/hermes/terminal`。
- 通过 Playwright fixture mock `window.WebSocket`，不连接真实 Hermes Agent、node-pty 或本机 shell。
- 验证 Terminal WebSocket 连接地址为 `/api/hermes/terminal`，并携带 access token query。
- 验证初始 session 渲染、新建 tab 控制消息、resize 控制消息。
- 验证用户键盘输入会作为 raw terminal frame 发送给 WebSocket。

## 验证

- `npm run test:e2e -- tests/e2e/terminal.spec.ts`
- `npm run test:e2e`
- `npm test`
- `npm run test:coverage`
- `npm run build`
- `git diff --check`
- 静态敏感信息扫描：none
- 独立 review：passed

## 风险控制

- 不依赖真实后端、PTY、shell、账号或外部服务。
- mock 仅用于 browser contract，目标是捕捉前端 WebSocket 契约漂移和终端输入转发回归。
- 仍未覆盖 reconnect、close、exit、multi-session buffered output 等更深路径，后续可单独补。