### PR TITLE
fix(server): stop crashing on unhandled rejections, add gateway child process cleanup

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -38,10 +38,14 @@ process.on('uncaughtException', (err) => {
 })
 
 process.on('unhandledRejection', (reason) => {
-  console.error('FATAL: Unhandled rejection')
+  console.error('Unhandled rejection (non-fatal — server continues)')
   console.error(reason)
   logger.error(reason, 'Unhandled rejection')
-  process.exit(1)
+  // Do NOT call process.exit(1) here — most unhandled rejections are transient
+  // (ECONNRESET during gateway restart, brief network hiccups) that the server
+  // can safely recover from. Killing the entire process forces users to manually
+  // restart hermes-web-ui even though the gateway itself recovers fine.
+  // See https://github.com/EKKOLearnAI/hermes-web-ui/issues/737
 })
 
 let server: any = null

--- a/packages/server/src/services/hermes/gateway-manager.ts
+++ b/packages/server/src/services/hermes/gateway-manager.ts
@@ -664,6 +664,23 @@ export class GatewayManager {
         child.unref()
       }
 
+      // Clean up gateway state when child process exits or errors
+      child.on('exit', (code, signal) => {
+        const entry = this.gateways.get(name)
+        if (entry?.process === child) {
+          this.gateways.delete(name)
+          logger.warn('Gateway child process for profile "%s" exited (code: %s, signal: %s) — removed from gateways map', name, code, signal)
+        }
+      })
+
+      child.on('error', (err) => {
+        logger.error(err, 'Gateway child process for profile "%s" errored', name)
+        const entry = this.gateways.get(name)
+        if (entry?.process === child) {
+          this.gateways.delete(name)
+        }
+      })
+
       const pid = child.pid ?? 0
       logger.info('Starting gateway for profile "%s" (run mode, PID: %d, port: %d, detached: %s)', name, pid, port, detachGateway)
 


### PR DESCRIPTION
## Summary

- Replace `process.exit(1)` in `unhandledRejection` handler with logging-only. Most unhandled rejections are transient (ECONNRESET during gateway restart, brief network hiccups) that the server can safely recover from. Killing the process forces users to manually restart even though the gateway itself recovers fine.
- Add `exit`/`error` event handlers on spawned gateway child processes in `GatewayManager`. Previously, when a gateway child process crashed, the orphaned process entry remained in the gateways map — a state leak. Now the entry is cleaned up and logged.

## Changes

1. **`packages/server/src/index.ts`**: Remove `process.exit(1)` from `unhandledRejection` handler, change log prefix from "FATAL" to "non-fatal"
2. **`packages/server/src/services/hermes/gateway-manager.ts`**: Add `child.on("exit")` and `child.on("error")` handlers to clean up the gateways map when gateway child processes die

## Testing

Tested locally by the issue reporter (see #737).

Fixes #737