### PR TITLE
docs: 补充 README 功能说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 - Session search — Ctrl+K search across the Web UI local session database; read-only Hermes history sessions are not included
 - Global model selector — discovers models from `~/.hermes/auth.json` credential pool
 - Per-session model display badge and context token usage
+- Unified `/chat-run` pipeline — `source=api_server` routes through the active Hermes Gateway `/v1/responses`; `source=cli` routes through the Agent Bridge to an in-process Hermes AIAgent
 
 ### Platform Channels
 
@@ -81,6 +82,10 @@ Unified configuration for **8 platforms** in one page:
 - Trigger immediate execution
 - Cron expression quick presets
 
+### Kanban / Task Board
+
+- Board-based task management with status columns, assignees, comments, task links, diagnostics, dispatch, and session/artifact integration
+
 ### Model Management
 
 - Auto-discover models from credential pool (`~/.hermes/auth.json`)
@@ -89,6 +94,13 @@ Unified configuration for **8 platforms** in one page:
 - OpenAI Codex & Nous Portal OAuth login
 - Provider URL auto-detection for non-v1 API versions (e.g. `/v4`)
 - Provider-level model grouping with default model switching
+- OpenAI-compatible proxy routes — `/v1/*` and unmatched `/api/hermes/*` requests forward to the active Hermes Gateway profile
+
+### TTS
+
+- Text-to-speech generation with native Web UI playback
+- Built-in endpoint at `/api/hermes/tts`
+- OpenAI-compatible speech endpoint at `/api/tts/proxy/audio/speech`
 
 ### Multi-Profile & Gateway
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -54,6 +54,7 @@
 - 会话搜索 — Ctrl+K 搜索 Web UI 本地会话库；不包含只读 Hermes 历史会话
 - 全局模型选择器 — 自动从 `~/.hermes/auth.json` 凭证池发现可用模型
 - 每个会话显示模型标签和上下文 Token 用量
+- 统一 `/chat-run` 管线 — `source=api_server` 通过当前 Profile 的 Hermes Gateway `/v1/responses`；`source=cli` 通过 Agent Bridge 连接进程内 Hermes AIAgent
 
 ### 平台渠道
 
@@ -89,6 +90,10 @@
 - 立即触发执行
 - Cron 表达式快捷预设
 
+### 看板 / 任务管理
+
+- 支持按看板管理任务，包含状态列、负责人、评论、任务关联、诊断、调度，以及会话/产物关联
+
 ### 模型管理
 
 - 从凭证池自动发现模型（`~/.hermes/auth.json`）
@@ -97,6 +102,13 @@
 - OpenAI Codex 和 Nous Portal OAuth 登录
 - Provider URL 自动检测，支持非 v1 API 版本（如 `/v4`）
 - Provider 级别模型分组，支持切换默认模型
+- OpenAI 兼容代理 — `/v1/*` 与未被本地路由处理的 `/api/hermes/*` 请求转发到当前 Profile 的 Hermes Gateway
+
+### 语音合成 TTS
+
+- 支持文本转语音和 Web UI 内播放
+- 内置接口 `/api/hermes/tts`
+- 提供 OpenAI 兼容语音接口 `/api/tts/proxy/audio/speech`
 
 ### 多配置文件与网关
 


### PR DESCRIPTION
README 里的功能清单缺少几个已存在能力。本次补齐说明，不改运行逻辑。

## 改动
- 补充 `/chat-run` 双路径说明：API Server 路径走当前 Hermes Gateway，Bridge 路径走 Agent Bridge。
- 补充 Kanban / 任务看板能力摘要。
- 补充 OpenAI 兼容代理范围：`/v1/*` 与未被本地路由处理的 `/api/hermes/*`。
- 补充 TTS 接口：`/api/hermes/tts` 与 `/api/tts/proxy/audio/speech`。
- README 与 README_zh 保持同步。

## 验证
- `git diff --check docs/session-search-scope...HEAD` 通过。
- `npm run build` 通过。
- `npm run build:website` 通过。

## 说明
这是基于 #774 的 stacked PR；合入顺序应先父 PR，再合入本 PR。
