### PR TITLE
[codex] proxy provider model fetches

### DIFF
--- a/packages/client/src/api/hermes/system.ts
+++ b/packages/client/src/api/hermes/system.ts
@@ -80,6 +80,17 @@ export async function fetchAvailableModels(): Promise<AvailableModelsResponse> {
   return request<AvailableModelsResponse>('/api/hermes/available-models')
 }
 
+export async function fetchProviderModels(data: {
+  base_url: string
+  api_key?: string
+  freeOnly?: boolean
+}): Promise<{ models: string[] }> {
+  return request<{ models: string[] }>('/api/hermes/provider-models', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
 export async function updateDefaultModel(data: {
   default: string
   provider?: string

--- a/packages/client/src/components/hermes/models/ProviderFormModal.vue
+++ b/packages/client/src/components/hermes/models/ProviderFormModal.vue
@@ -7,6 +7,7 @@ import CodexLoginModal from './CodexLoginModal.vue'
 import NousLoginModal from './NousLoginModal.vue'
 import CopilotLoginModal from './CopilotLoginModal.vue'
 import { checkCopilotToken, enableCopilot, type CopilotTokenSource } from '@/api/hermes/copilot-auth'
+import { fetchProviderModels } from '@/api/hermes/system'
 
 const { t } = useI18n()
 
@@ -129,18 +130,11 @@ async function fetchModels() {
 
   fetchingModels.value = true
   try {
-    const base = base_url.replace(/\/+$/, '')
-    const url = /\/v\d+\/?$/.test(base) ? `${base}/models` : `${base}/v1/models`
-    const headers: Record<string, string> = {}
-    if (formData.value.api_key.trim()) {
-      headers['Authorization'] = `Bearer ${formData.value.api_key.trim()}`
-    }
-    const res = await fetch(url, { headers, signal: AbortSignal.timeout(8000) })
-    if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    const data = await res.json() as { data?: Array<{ id: string }> }
-    if (!Array.isArray(data.data)) throw new Error(t('models.unexpectedFormat'))
-
-    modelOptions.value = data.data.map(m => ({ label: m.id, value: m.id }))
+    const data = await fetchProviderModels({
+      base_url: base_url.trim(),
+      api_key: formData.value.api_key.trim(),
+    })
+    modelOptions.value = data.models.map(m => ({ label: m, value: m }))
     if (modelOptions.value.length > 0 && !formData.value.model) {
       formData.value.model = modelOptions.value[0].value
     }

--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -356,6 +356,66 @@ export async function getAvailable(ctx: any) {
   }
 }
 
+export async function fetchProviderModelList(ctx: any) {
+  try {
+    const body = ctx.request.body as { base_url?: string; api_key?: string; freeOnly?: boolean }
+    const baseUrl = String(body?.base_url || '').trim()
+    const apiKey = String(body?.api_key || '').trim()
+    const freeOnly = body?.freeOnly === true
+
+    if (!baseUrl) {
+      ctx.status = 400
+      ctx.body = { error: 'Missing base_url' }
+      return
+    }
+
+    let parsed: URL
+    try {
+      parsed = new URL(baseUrl)
+    } catch {
+      ctx.status = 400
+      ctx.body = { error: 'Invalid base_url' }
+      return
+    }
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      ctx.status = 400
+      ctx.body = { error: 'base_url must use http or https' }
+      return
+    }
+
+    const base = baseUrl.replace(/\/+$/, '')
+    const modelsUrl = /\/v\d+\/?$/.test(base) ? `${base}/models` : `${base}/v1/models`
+    const headers: Record<string, string> = {}
+    if (apiKey) headers.Authorization = `Bearer ${apiKey}`
+
+    const res = await fetch(modelsUrl, {
+      headers,
+      signal: AbortSignal.timeout(8000),
+    })
+    if (!res.ok) {
+      ctx.status = 502
+      ctx.body = { error: `Provider returned HTTP ${res.status}` }
+      return
+    }
+
+    const data = await res.json() as { data?: Array<{ id?: unknown }> }
+    if (!Array.isArray(data.data)) {
+      ctx.status = 502
+      ctx.body = { error: 'Provider returned unexpected format' }
+      return
+    }
+
+    let models = data.data
+      .map(m => String(m?.id || '').trim())
+      .filter(Boolean)
+    if (freeOnly) models = models.filter(m => m.endsWith(':free'))
+    ctx.body = { models: Array.from(new Set(models)).sort() }
+  } catch (err: any) {
+    ctx.status = err?.name === 'TimeoutError' ? 504 : 502
+    ctx.body = { error: err?.message || 'Failed to fetch provider models' }
+  }
+}
+
 
 export async function setModelAlias(ctx: any) {
   const body = ctx.request.body

--- a/packages/server/src/routes/hermes/models.ts
+++ b/packages/server/src/routes/hermes/models.ts
@@ -4,6 +4,7 @@ import * as ctrl from '../../controllers/hermes/models'
 export const modelRoutes = new Router()
 
 modelRoutes.get('/api/hermes/available-models', ctrl.getAvailable)
+modelRoutes.post('/api/hermes/provider-models', ctrl.fetchProviderModelList)
 modelRoutes.get('/api/hermes/config/models', ctrl.getConfigModels)
 modelRoutes.put('/api/hermes/config/model', ctrl.setConfigModel)
 modelRoutes.put('/api/hermes/model-alias', ctrl.setModelAlias)

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -141,6 +141,11 @@ export async function mockHermesApi(page: Page, options: MockHermesApiOptions = 
       return
     }
 
+    if (pathname === '/api/hermes/provider-models') {
+      await route.fulfill(jsonResponse({ models: ['proxy-model-a', 'proxy-model-b'] }))
+      return
+    }
+
     if (pathname === '/api/hermes/profiles') {
       await route.fulfill(jsonResponse({
         profiles: [

--- a/tests/e2e/provider-models.spec.ts
+++ b/tests/e2e/provider-models.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test'
+import { authenticate, mockHermesApi, TEST_ACCESS_KEY } from './fixtures'
+
+test('fetches custom provider models through the backend proxy', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY)
+  const api = await mockHermesApi(page)
+
+  const thirdPartyRequests: string[] = []
+  page.on('request', (request) => {
+    const url = request.url()
+    if (url.startsWith('https://provider.example.test')) {
+      thirdPartyRequests.push(url)
+    }
+  })
+
+  await page.goto('/#/hermes/models')
+
+  await page.getByRole('button', { name: 'Add Provider' }).click()
+  await page.getByRole('button', { name: 'Custom' }).click()
+  await page.getByPlaceholder('e.g. https://api.example.com/v1').fill('https://provider.example.test/v1')
+  await page.getByPlaceholder('sk-...').fill('test-provider-key')
+  await page.getByRole('button', { name: 'Fetch' }).click()
+
+  await expect(page.getByText('Found 2 models')).toBeVisible()
+  await expect(page.getByText('proxy-model-a')).toBeVisible()
+
+  const proxyRequest = api.requests.find((request) => request.pathname === '/api/hermes/provider-models')
+  expect(proxyRequest).toBeTruthy()
+  expect(proxyRequest?.method).toBe('POST')
+  expect(proxyRequest?.headers.authorization).toBe(`Bearer ${TEST_ACCESS_KEY}`)
+  expect(JSON.parse(proxyRequest?.postData || '{}')).toMatchObject({
+    base_url: 'https://provider.example.test/v1',
+    api_key: 'test-provider-key',
+  })
+  expect(thirdPartyRequests).toEqual([])
+  expect(api.unexpectedRequests).toEqual([])
+})


### PR DESCRIPTION
## Summary

- Add a backend `POST /api/hermes/provider-models` endpoint that fetches OpenAI-compatible provider model lists server-side.
- Update the add-provider modal to call the backend proxy instead of fetching third-party `/models` URLs from the browser.
- Keep the existing model selection behavior while avoiding browser CORS failures.

## Why

Custom provider model discovery currently runs in the frontend, so providers that do not allow browser origins fail with CORS errors. Moving the `/models` request to the Web UI server avoids that class of failure.

## Validation

- `npx vue-tsc -b`
- `npx tsc --noEmit -p packages/server/tsconfig.json`

Closes #765

