### PR TITLE
fix: custom_providers base_url and dynamic deliver targets

### DIFF
--- a/packages/client/src/components/hermes/jobs/JobFormModal.vue
+++ b/packages/client/src/components/hermes/jobs/JobFormModal.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, computed } from 'vue'
 import { NModal, NForm, NFormItem, NInput, NButton, NSelect, NInputNumber, useMessage } from 'naive-ui'
 import { useJobsStore } from '@/stores/hermes/jobs'
+import { useSettingsStore } from '@/stores/hermes/settings'
 import {
   buildJobUpdateRequest,
   getJob,
@@ -23,6 +24,7 @@ const emit = defineEmits<{
 }>()
 
 const jobsStore = useJobsStore()
+const settingsStore = useSettingsStore()
 const message = useMessage()
 
 const showModal = ref(true)
@@ -50,10 +52,30 @@ const schedulePresets = computed(() => [
   { label: t('jobs.presetEveryMonth'), value: '0 9 1 * *' },
 ])
 
-const targetOptions = computed(() => [
-  { label: t('jobs.origin'), value: 'origin' },
-  { label: t('jobs.local'), value: 'local' },
-])
+const targetOptions = computed(() => {
+  const options: Array<{ label: string; value: string }> = [
+    { label: t('jobs.origin'), value: 'origin' },
+    { label: t('jobs.local'), value: 'local' },
+  ]
+  const channels = [
+    { key: 'telegram', label: 'Telegram' },
+    { key: 'discord', label: 'Discord' },
+    { key: 'slack', label: 'Slack' },
+    { key: 'whatsapp', label: 'WhatsApp' },
+    { key: 'matrix', label: 'Matrix' },
+    { key: 'weixin', label: 'WeChat' },
+    { key: 'wecom', label: 'WeCom' },
+    { key: 'feishu', label: 'Feishu' },
+    { key: 'dingtalk', label: 'DingTalk' },
+  ]
+  for (const ch of channels) {
+    const config = settingsStore.platforms[ch.key] || {}
+    if (Object.keys(config).length > 0) {
+      options.push({ label: ch.label, value: ch.key })
+    }
+  }
+  return options
+})
 
 const originalJob = ref<Job | null>(null)
 

--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -277,16 +277,11 @@ export async function getAvailable(ctx: any) {
         if (!cp.base_url) return null
         const providerKey = `custom:${cp.name.trim().toLowerCase().replace(/ /g, '-')}`
         const baseUrl = cp.base_url.replace(/\/+$/, '')
-        const bareKey = cp.name.trim().toLowerCase().replace(/ /g, '-')
-        const builtinPreset = PROVIDER_PRESETS.find(p => p.value === bareKey)
-        let models = builtinPreset?.models?.length ? [...builtinPreset.models] : [cp.model]
-        // Skip dynamic fetch for builtin presets — their model list is maintained in providers.ts
-        if (!builtinPreset && cp.api_key) {
+        let models = [cp.model]
+        if (cp.api_key) {
           try { const fetched = await fetchProviderModels(baseUrl, cp.api_key); if (fetched.length > 0) models = [...new Set([cp.model, ...fetched])] } catch { }
         }
-        const label = builtinPreset?.label || cp.name
-        const presetBaseUrl = builtinPreset?.base_url || ''
-        return { providerKey, label, base_url: presetBaseUrl || baseUrl, models, api_key: cp.api_key || '', builtin: !!builtinPreset }
+        return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '' }
       }),
     )
 


### PR DESCRIPTION
## Summary
- **custom_providers**: 当用户配置的 provider 名称（如 `minimax`、`qwen`）与 `PROVIDER_PRESETS` 同名时，`base_url` 被覆盖为官方 API 地址。修复后始终使用用户配置的 `base_url`
- **JobFormModal**: 投递目标下拉框只硬编码"来源"和"本地"，动态添加已连接的平台渠道（Telegram, Discord, Slack, WhatsApp, Matrix, WeChat, WeCom, Feishu, DingTalk）

## Test plan
- [ ] `custom_providers` 中使用 `minimax`/`qwen` 等与预设同名的名称时，base_url 正确显示为本地 IP
- [ ] 配置了微信渠道的用户可以看到 WeChat 出现在 job 投递选项中
- [ ] 未配置任何渠道时 job 投递只显示"来源"和"本地"

🤖 Generated with [Claude Code](https://claude.com/claude-code)