### PR TITLE
[codex] Harden env parsing and writes

### DIFF
--- a/packages/server/src/services/config-helpers.ts
+++ b/packages/server/src/services/config-helpers.ts
@@ -88,7 +88,14 @@ export async function updateConfigYaml<T = void>(
 
 // --- .env helpers ---
 
+function assertValidEnvKey(key: string): void {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+    throw new Error(`Invalid .env key: ${JSON.stringify(key)}`)
+  }
+}
+
 export async function saveEnvValue(key: string, value: string): Promise<void> {
+  assertValidEnvKey(key)
   const envPath = getActiveEnvPath()
   await safeFileStore.updateText(envPath, (raw) => {
     const remove = !value

--- a/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
@@ -185,29 +185,27 @@ def _profile_home(profile: str | None) -> Path:
 def _read_dotenv(path: Path) -> dict[str, str]:
     if not path.exists():
         return {}
+    values: dict[str, str] = {}
     try:
-        from dotenv import dotenv_values
-
-        values = dotenv_values(path)
-        return {str(k): str(v) for k, v in values.items() if k and v is not None}
-    except Exception:
-        values: dict[str, str] = {}
-        try:
-            for line in path.read_text(encoding="utf-8").splitlines():
-                stripped = line.strip()
-                if not stripped or stripped.startswith("#") or "=" not in stripped:
-                    continue
-                key, value = stripped.split("=", 1)
-                key = key.strip()
-                value = value.strip()
-                if not key:
-                    continue
-                if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
-                    value = value[1:-1]
-                values[key] = value
-        except Exception:
-            return {}
+        for line in path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#") or "=" not in stripped:
+                continue
+            if stripped.startswith("export "):
+                stripped = stripped[7:].strip()
+            key, value = stripped.split("=", 1)
+            key = key.strip()
+            if not key or not (key[0].isalpha() or key[0] == "_"):
+                continue
+            if not all(ch.isalnum() or ch == "_" for ch in key):
+                continue
+            value = value.strip()
+            if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
+                value = value[1:-1]
+            values[key] = value
         return values
+    except Exception:
+        return {}
 
 
 def _profile_dotenv_keys() -> set[str]:

--- a/tests/server/config-helpers-file-lock.test.ts
+++ b/tests/server/config-helpers-file-lock.test.ts
@@ -67,6 +67,19 @@ describe('config-helpers locked file updates', () => {
     expect(env).toContain('MOONSHOT_API_KEY=moonshot')
   })
 
+  it('rejects invalid .env keys instead of writing keyless lines', async () => {
+    const envPath = join(hermesHome, '.env')
+    await writeFile(envPath, 'OPENROUTER_API_KEY=keep\n', 'utf-8')
+    const { saveEnvValue } = await loadHelpers()
+
+    await expect(saveEnvValue('', 'leaked-value')).rejects.toThrow('Invalid .env key')
+    await expect(saveEnvValue('=BROKEN', 'leaked-value')).rejects.toThrow('Invalid .env key')
+
+    const env = await readFile(envPath, 'utf-8')
+    expect(env).toBe('OPENROUTER_API_KEY=keep\n')
+    expect(env).not.toContain('=leaked-value')
+  })
+
   it('skips writing config.yaml when an updater returns write false', async () => {
     const configPath = join(hermesHome, 'config.yaml')
     await writeFile(configPath, 'model:\n  default: old\n', 'utf-8')


### PR DESCRIPTION
## Summary

- Validate `.env` keys before writing through `saveEnvValue`, preventing keyless `=value` lines.
- Make the bridge profile `.env` loader skip invalid lines without invoking noisy `python-dotenv` parsing.
- Add a regression test for invalid `.env` keys.

## Root Cause

`saveEnvValue` previously trusted callers to pass a valid env key. If an empty or malformed key reached the helper, it could write a keyless `.env` line such as `=secret`. Separately, the bridge used `python-dotenv` for profile env loading, so existing malformed lines produced warnings on every run.

## Validation

- `npm test -- tests/server/config-helpers-file-lock.test.ts tests/server/config-controller-file-lock.test.ts tests/server/provider-delete-controller.test.ts tests/server/copilot-auth-controller.test.ts`
