### PR TITLE
fix: route fun-codex through responses api

### DIFF
--- a/packages/server/src/shared/providers.ts
+++ b/packages/server/src/shared/providers.ts
@@ -9,7 +9,7 @@ export interface ProviderPreset {
   base_url: string
   models: string[]
   builtin: boolean
-  api_mode?: 'openai' | 'anthropic' | 'anthropic_messages'
+  api_mode?: 'chat_completions' | 'codex_responses' | 'anthropic_messages' | 'bedrock_converse' | 'codex_app_server'
 }
 
 export const PROVIDER_PRESETS: ProviderPreset[] = [
@@ -18,6 +18,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     value: 'fun-codex',
     builtin: true,
     base_url: 'https://api.apikey.fun/v1',
+    api_mode: 'codex_responses',
     models: [
       'gpt-5.5',
       'gpt-5.4',

--- a/tests/shared/provider-presets.test.ts
+++ b/tests/shared/provider-presets.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../packages/server/src/shared/providers'
 
 const OPENAI_CODEX_PROVIDER = 'openai-codex'
+const FUN_CODEX_PROVIDER = 'fun-codex'
 const GPT_5_5_MODEL = 'gpt-5.5'
 
 function modelsForProvider(providerPresets: Array<{ value: string; models: string[] }>, provider: string): string[] {
@@ -15,6 +16,11 @@ function modelsForProvider(providerPresets: Array<{ value: string; models: strin
 }
 
 describe('provider presets', () => {
+  it('routes apikey.fun Codex through the Responses transport', () => {
+    const preset = SERVER_PROVIDER_PRESETS.find((candidate) => candidate.value === FUN_CODEX_PROVIDER)
+    expect(preset?.api_mode).toBe('codex_responses')
+  })
+
   it('lists GPT-5.5 for OpenAI Codex', () => {
     expect(modelsForProvider(SERVER_PROVIDER_PRESETS, OPENAI_CODEX_PROVIDER)).toContain(GPT_5_5_MODEL)
   })


### PR DESCRIPTION
## Summary
- set the fun-codex provider preset api_mode to codex_responses
- expand the provider preset api_mode type to the Hermes agent transport values
- add a regression test that fun-codex uses the Responses transport

## Tests
- npm test -- tests/shared/provider-presets.test.ts
- npx tsc --noEmit -p packages/server/tsconfig.json