### PR TITLE
修复 Z.AI 模型选择器目录不完整

### DIFF
--- a/packages/server/src/shared/providers.ts
+++ b/packages/server/src/shared/providers.ts
@@ -12,6 +12,32 @@ export interface ProviderPreset {
   api_mode?: 'chat_completions' | 'codex_responses' | 'anthropic_messages' | 'bedrock_converse' | 'codex_app_server'
 }
 
+// Mirrors Hermes Agent's models.dev-backed provider picker for Z.AI.
+// Keep models.dev order: fresh catalog entries first, curated-only fallbacks appended if needed.
+const ZAI_MODELS = [
+  'glm-5.1',
+  'glm-5v-turbo',
+  'glm-4.7-flashx',
+  'glm-4.5-air',
+  'glm-4.5v',
+  'glm-4.7-flash',
+  'glm-4.6',
+  'glm-4.5',
+  'glm-4.5-flash',
+  'glm-5-turbo',
+  'glm-4.7',
+  'glm-5',
+  'glm-4.6v',
+]
+
+const ZAI_CODING_PLAN_MODELS = [
+  'glm-5.1',
+  'glm-4.5-air',
+  'glm-5-turbo',
+  'glm-4.7',
+  'glm-5v-turbo',
+]
+
 export const PROVIDER_PRESETS: ProviderPreset[] = [
   {
     label: 'Codex-apikey.fun',
@@ -80,14 +106,14 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     value: 'zai',
     builtin: true,
     base_url: 'https://api.z.ai/api/paas/v4',
-    models: ['glm-5.1', 'glm-5', 'glm-5v-turbo', 'glm-5-turbo', 'glm-4.7', 'glm-4.5', 'glm-4.5-flash'],
+    models: ZAI_MODELS,
   },
   {
     label: 'GLM-Coding-Plan',
     value: 'glm-coding-plan',
     builtin: true,
     base_url: 'https://api.z.ai/api/anthropic',
-    models: ['glm-5.1', 'glm-5', 'glm-5v-turbo', 'glm-5-turbo', 'glm-4.7', 'glm-4.5', 'glm-4.5-flash'],
+    models: ZAI_CODING_PLAN_MODELS,
   },
   {
     label: 'Kimi for Coding',

--- a/packages/server/src/shared/providers.ts
+++ b/packages/server/src/shared/providers.ts
@@ -12,32 +12,6 @@ export interface ProviderPreset {
   api_mode?: 'chat_completions' | 'codex_responses' | 'anthropic_messages' | 'bedrock_converse' | 'codex_app_server'
 }
 
-// Mirrors Hermes Agent's models.dev-backed provider picker for Z.AI.
-// Keep models.dev order: fresh catalog entries first, curated-only fallbacks appended if needed.
-const ZAI_MODELS = [
-  'glm-5.1',
-  'glm-5v-turbo',
-  'glm-4.7-flashx',
-  'glm-4.5-air',
-  'glm-4.5v',
-  'glm-4.7-flash',
-  'glm-4.6',
-  'glm-4.5',
-  'glm-4.5-flash',
-  'glm-5-turbo',
-  'glm-4.7',
-  'glm-5',
-  'glm-4.6v',
-]
-
-const ZAI_CODING_PLAN_MODELS = [
-  'glm-5.1',
-  'glm-4.5-air',
-  'glm-5-turbo',
-  'glm-4.7',
-  'glm-5v-turbo',
-]
-
 export const PROVIDER_PRESETS: ProviderPreset[] = [
   {
     label: 'Codex-apikey.fun',
@@ -106,14 +80,36 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     value: 'zai',
     builtin: true,
     base_url: 'https://api.z.ai/api/paas/v4',
-    models: ZAI_MODELS,
+    models: [
+      // Mirrors Hermes Agent's models.dev-backed provider picker for Z.AI.
+      // Keep models.dev order: fresh catalog entries first, curated-only fallbacks appended if needed.
+      'glm-5.1',
+      'glm-5v-turbo',
+      'glm-4.7-flashx',
+      'glm-4.5-air',
+      'glm-4.5v',
+      'glm-4.7-flash',
+      'glm-4.6',
+      'glm-4.5',
+      'glm-4.5-flash',
+      'glm-5-turbo',
+      'glm-4.7',
+      'glm-5',
+      'glm-4.6v',
+    ],
   },
   {
     label: 'GLM-Coding-Plan',
     value: 'glm-coding-plan',
     builtin: true,
     base_url: 'https://api.z.ai/api/anthropic',
-    models: ZAI_CODING_PLAN_MODELS,
+    models: [
+      'glm-5.1',
+      'glm-4.5-air',
+      'glm-5-turbo',
+      'glm-4.7',
+      'glm-5v-turbo',
+    ],
   },
   {
     label: 'Kimi for Coding',

--- a/tests/shared/provider-presets.test.ts
+++ b/tests/shared/provider-presets.test.ts
@@ -7,7 +7,33 @@ import {
 
 const OPENAI_CODEX_PROVIDER = 'openai-codex'
 const FUN_CODEX_PROVIDER = 'fun-codex'
+const ZAI_PROVIDER = 'zai'
+const GLM_CODING_PLAN_PROVIDER = 'glm-coding-plan'
 const GPT_5_5_MODEL = 'gpt-5.5'
+
+const MODELS_DEV_ZAI_MODELS = [
+  'glm-5.1',
+  'glm-5v-turbo',
+  'glm-4.7-flashx',
+  'glm-4.5-air',
+  'glm-4.5v',
+  'glm-4.7-flash',
+  'glm-4.6',
+  'glm-4.5',
+  'glm-4.5-flash',
+  'glm-5-turbo',
+  'glm-4.7',
+  'glm-5',
+  'glm-4.6v',
+]
+
+const MODELS_DEV_ZAI_CODING_PLAN_MODELS = [
+  'glm-5.1',
+  'glm-4.5-air',
+  'glm-5-turbo',
+  'glm-4.7',
+  'glm-5v-turbo',
+]
 
 function modelsForProvider(providerPresets: Array<{ value: string; models: string[] }>, provider: string): string[] {
   const preset = providerPresets.find((candidate) => candidate.value === provider)
@@ -27,5 +53,15 @@ describe('provider presets', () => {
 
   it('exposes GPT-5.5 through provider model maps', () => {
     expect(buildServerProviderModelMap()[OPENAI_CODEX_PROVIDER]).toContain(GPT_5_5_MODEL)
+  })
+
+  it('keeps the Z.AI direct catalog aligned with models.dev order', () => {
+    expect(modelsForProvider(SERVER_PROVIDER_PRESETS, ZAI_PROVIDER)).toEqual(MODELS_DEV_ZAI_MODELS)
+    expect(buildServerProviderModelMap()[ZAI_PROVIDER]).toEqual(MODELS_DEV_ZAI_MODELS)
+  })
+
+  it('keeps the GLM coding-plan catalog aligned with the models.dev Z.AI coding-plan subset', () => {
+    expect(modelsForProvider(SERVER_PROVIDER_PRESETS, GLM_CODING_PLAN_PROVIDER)).toEqual(MODELS_DEV_ZAI_CODING_PLAN_MODELS)
+    expect(buildServerProviderModelMap()[GLM_CODING_PLAN_PROVIDER]).toEqual(MODELS_DEV_ZAI_CODING_PLAN_MODELS)
   })
 })


### PR DESCRIPTION
## 改动

Z.AI 直连 provider 的内置模型目录补齐到 models.dev 当前目录，并保留 models.dev 顺序，模型选择器不再只显示旧的 7 个条目。

GLM-Coding-Plan 不再复用 Z.AI 直连目录，改为使用 models.dev 的 Z.AI coding-plan 子集；provider key、base URL 和认证方式不变。

新增 provider preset 测试，覆盖 `PROVIDER_PRESETS` 和 `buildProviderModelMap()` 两条路径，防止模型选择器和后端 provider map 再次漂移。

## 验证

- `npm test -- tests/shared/provider-presets.test.ts`：新增断言先失败，修复后通过
- `npm test -- tests/shared/provider-presets.test.ts tests/server/model-visibility-controller.test.ts`：通过，13 项测试
- `npm test`：通过，86 个测试文件，535 项通过，2 项跳过
- `npm run build`：通过
- 独立 review：通过，无 security concerns / logic errors

## 说明

Fixes #759
