### PR TITLE
fix: raise mobile session drawer overlay

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -1430,7 +1430,7 @@ async function handleSessionModelCustomSubmit() {
     left: 0;
     top: 0;
     height: 100%;
-    z-index: 10;
+    z-index: 120;
     background: $bg-card;
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
     width: 280px;
@@ -1451,7 +1451,7 @@ async function handleSessionModelCustomSubmit() {
     position: absolute;
     inset: 0;
     background: rgba(0, 0, 0, 0.4);
-    z-index: 9;
+    z-index: 110;
     opacity: 0;
     pointer-events: none;
     transition: opacity $transition-fast;

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -446,7 +446,7 @@ async function handleDeleteSession(id: string) {
     left: 0;
     top: 0;
     height: 100%;
-    z-index: 10;
+    z-index: 120;
     background: $bg-card;
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
     width: 280px;
@@ -467,7 +467,7 @@ async function handleDeleteSession(id: string) {
     position: absolute;
     inset: 0;
     background: rgba(0, 0, 0, 0.4);
-    z-index: 9;
+    z-index: 110;
     opacity: 0;
     pointer-events: none;
     transition: opacity $transition-fast;


### PR DESCRIPTION
## Summary
- Raise the mobile session drawer z-index in Chat and History views.
- Keep the drawer backdrop above the global hamburger button so session headers and controls are not obscured.

## Testing
- Not run; CSS-only layering change.