### PR TITLE
fix(profile switch): After switching profiles, chat records, including search results of chat records, will be isolated

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -311,7 +311,7 @@ async function handleBatchDelete() {
 
       // Remove deleted sessions from local store (without calling API again)
       // Use loadSessions to refresh from server instead of manual filtering
-      await chatStore.loadSessions();
+      await chatStore.loadSessions(sessionProfileFilter.value || profilesStore.activeProfileName);
 
       message.success(t("chat.batchDeleteSuccess", { count: result.deleted }));
       if (result.failed > 0) {

--- a/packages/client/src/components/hermes/chat/SessionSearchModal.vue
+++ b/packages/client/src/components/hermes/chat/SessionSearchModal.vue
@@ -5,12 +5,14 @@ import { NButton, NInput, NModal, NSpin, useMessage } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import { fetchSessions, searchSessions, type SessionSearchResult, type SessionSummary } from '@/api/hermes/sessions'
 import { useChatStore } from '@/stores/hermes/chat'
+import { useProfilesStore } from '@/stores/hermes/profiles'
 import { useSessionSearch } from '@/composables/useSessionSearch'
 
 const { t } = useI18n()
 const message = useMessage()
 const router = useRouter()
 const chatStore = useChatStore()
+const profilesStore = useProfilesStore()
 const { sessionSearchOpen } = useSessionSearch()
 
 const query = ref('')
@@ -79,7 +81,7 @@ async function loadRecentSessions() {
   const seq = ++requestSeq
   loading.value = true
   try {
-    const sessions = await fetchSessions(undefined, 8)
+    const sessions = await fetchSessions(undefined, 8, profilesStore.activeProfileName || undefined)
     if (seq !== requestSeq) return
     recentSessions.value = sessions
     searchResults.value = []

--- a/packages/client/src/views/hermes/ChatView.vue
+++ b/packages/client/src/views/hermes/ChatView.vue
@@ -19,7 +19,7 @@ onMounted(async () => {
     profilesStore.fetchProfiles(),
     settingsStore.fetchSettings(),
   ])
-  chatStore.loadSessions()
+  chatStore.loadSessions(profilesStore.activeProfileName)
 })
 </script>
 


### PR DESCRIPTION
## Summary
Fixes the bug where chat history was not isolated by profile. When loading chat sessions, no profile parameter was passed to the backend, resulting in all sessions from all profiles being returned instead of only those belonging to the active profile.

Root cause:
In `ChatView.vue:22`, `chatStore.loadSessions()` was called without the current profile as an argument. The backend handler at `sessions.ts:139-141` then received `undefined` for `ctx.query.profile`, so the `profileFilter` in `localListSessions()` was not applied, and the SQL query omitted the `AND s.profile = ?` condition.

## Changes
- `ChatView.vue:22`: Pass the current profile to `chatStore.loadSessions()` when loading the chat list.
- `ChatPanel.vue:314`: Pass the current profile when refreshing sessions after bulk deletion.
- `SessionSearchModal.vue`: Pass the current profile when loading recent sessions in the search modal.

## Test plan
Verified the fix by switching between multiple profiles: chat history now correctly loads and displays only the sessions belonging to the active profile. Bulk deletion and session search also work as expected with profile isolation.