### PR TITLE
fix: discover models from configured providers

### DIFF
--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -2,7 +2,7 @@ import { readFile } from 'fs/promises'
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { getActiveEnvPath, getActiveAuthPath, getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../../services/hermes/hermes-profile'
-import { readConfigYaml, readConfigYamlForProfile, updateConfigYaml, fetchProviderModels, buildModelGroups, PROVIDER_ENV_MAP } from '../../services/config-helpers'
+import { readConfigYaml, readConfigYamlForProfile, updateConfigYaml, fetchProviderModels, buildModelGroups, listConfiguredProviderModels, PROVIDER_ENV_MAP } from '../../services/config-helpers'
 import { buildProviderModelMap, PROVIDER_PRESETS } from '../../shared/providers'
 import { getCopilotModelsDetailed, resolveCopilotOAuthToken, type CopilotModelMeta } from '../../services/hermes/copilot-models'
 import { readAppConfig, writeAppConfig, type ModelVisibilityRule } from '../../services/app-config'
@@ -208,7 +208,7 @@ async function buildAvailableForProfile(
   let currentDefault = ''
   let currentDefaultProvider = ''
   if (typeof modelSection === 'object' && modelSection !== null) {
-    currentDefault = String(modelSection.default || '').trim()
+    currentDefault = String(modelSection.default || modelSection.model || '').trim()
     currentDefaultProvider = String(modelSection.provider || '').trim()
     if (currentDefaultProvider === 'custom' && currentDefault) {
       const cps = Array.isArray(config.custom_providers) ? config.custom_providers as any[] : []
@@ -252,9 +252,20 @@ async function buildAvailableForProfile(
   const groups: AvailableGroup[] = []
   const seenProviders = new Set<string>()
   const addGroup = (provider: string, label: string, base_url: string, models: string[], api_key: string, builtin?: boolean, model_meta?: Record<string, ModelMeta>) => {
-    if (seenProviders.has(provider)) return
-    seenProviders.add(provider)
     const availableModels = [...new Set(models)]
+    const existing = groups.find(group => group.provider === provider)
+    if (existing) {
+      existing.models = [...new Set([...existing.models, ...availableModels])]
+      existing.available_models = [...new Set([...(existing.available_models || existing.models), ...availableModels])]
+      existing.label = existing.label || label
+      existing.base_url = existing.base_url || base_url
+      existing.api_key = existing.api_key || api_key
+      existing.builtin = existing.builtin || builtin
+      existing.model_meta = { ...(existing.model_meta || {}), ...(model_meta || {}) }
+      if (existing.model_meta && Object.keys(existing.model_meta).length === 0) delete existing.model_meta
+      return
+    }
+    seenProviders.add(provider)
     groups.push({ provider, label, base_url, models: availableModels, available_models: availableModels, api_key, ...(builtin ? { builtin: true } : {}), ...(model_meta ? { model_meta } : {}) })
   }
 
@@ -311,6 +322,12 @@ async function buildAvailableForProfile(
       const apiKey = envMapping.api_key_env ? envGetValue(envMapping.api_key_env) : ''
       addGroup(providerKey, label, baseUrl, modelsList, apiKey, true, modelMeta)
     }
+  }
+
+  const configuredProviders = listConfiguredProviderModels(config)
+  for (const provider of configuredProviders) {
+    const apiKey = provider.key_env ? envGetValue(provider.key_env) : ''
+    addGroup(provider.provider, provider.label, provider.base_url, provider.models, apiKey)
   }
 
   const customProviders = Array.isArray(config.custom_providers)
@@ -436,7 +453,7 @@ export async function getAvailable(ctx: any) {
     let currentDefault = ''
     let currentDefaultProvider = ''
     if (typeof modelSection === 'object' && modelSection !== null) {
-      currentDefault = String(modelSection.default || '').trim()
+      currentDefault = String(modelSection.default || modelSection.model || '').trim()
       currentDefaultProvider = String(modelSection.provider || '').trim()
       // When hermes CLI sets provider: custom, resolve to custom:name
       // by matching base_url + model against custom_providers

--- a/packages/server/src/services/config-helpers.ts
+++ b/packages/server/src/services/config-helpers.ts
@@ -235,6 +235,67 @@ export async function fetchProviderModels(baseUrl: string, apiKey: string, freeO
   }
 }
 
+function normalizeEnvKey(key: unknown): string {
+  const trimmed = String(key || '').trim()
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(trimmed) ? trimmed : ''
+}
+
+export function extractConfiguredProviderModels(
+  config: Record<string, any>,
+  providerKey: string,
+): { label: string; base_url: string; key_env: string; models: string[] } | null {
+  if (!providerKey || !config.providers || typeof config.providers !== 'object' || Array.isArray(config.providers)) {
+    return null
+  }
+  const entry = config.providers[providerKey]
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null
+
+  const models: string[] = []
+  if (entry.models && typeof entry.models === 'object' && !Array.isArray(entry.models)) {
+    for (const model of Object.keys(entry.models)) {
+      const trimmed = String(model || '').trim()
+      if (trimmed) models.push(trimmed)
+    }
+  } else if (Array.isArray(entry.models)) {
+    for (const model of entry.models) {
+      const trimmed = String(model || '').trim()
+      if (trimmed) models.push(trimmed)
+    }
+  }
+
+  const defaultModel = String(entry.default_model || '').trim()
+  if (defaultModel) models.push(defaultModel)
+
+  const modelSection = config.model
+  if (typeof modelSection === 'object' && modelSection !== null) {
+    const currentProvider = String(modelSection.provider || '').trim()
+    const currentDefault = String(modelSection.default || modelSection.model || '').trim()
+    if (currentProvider === providerKey && currentDefault) models.push(currentDefault)
+  }
+
+  const uniqueModels = Array.from(new Set(models))
+  if (uniqueModels.length === 0) return null
+
+  return {
+    label: String(entry.name || providerKey).trim() || providerKey,
+    base_url: String(entry.base_url || entry.api || '').trim(),
+    key_env: normalizeEnvKey(entry.key_env),
+    models: uniqueModels,
+  }
+}
+
+export function listConfiguredProviderModels(config: Record<string, any>): Array<{ provider: string; label: string; base_url: string; key_env: string; models: string[] }> {
+  if (!config.providers || typeof config.providers !== 'object' || Array.isArray(config.providers)) return []
+  const result: Array<{ provider: string; label: string; base_url: string; key_env: string; models: string[] }> = []
+  for (const providerKey of Object.keys(config.providers)) {
+    const provider = String(providerKey || '').trim()
+    if (!provider) continue
+    const extracted = extractConfiguredProviderModels(config, provider)
+    if (extracted) result.push({ provider, ...extracted })
+  }
+  return result
+}
+
 export function buildModelGroups(config: Record<string, any>): { default: string; groups: ModelGroup[] } {
   let defaultModel = ''
   const groups: ModelGroup[] = []
@@ -242,12 +303,20 @@ export function buildModelGroups(config: Record<string, any>): { default: string
   // 1. Extract current model
   const modelSection = config.model
   if (typeof modelSection === 'object' && modelSection !== null) {
-    defaultModel = String(modelSection.default || '').trim()
+    defaultModel = String(modelSection.default || modelSection.model || '').trim()
   } else if (typeof modelSection === 'string') {
     defaultModel = modelSection.trim()
   }
 
-  // 2. Extract custom_providers section
+  // 2. Extract providers section written by newer Hermes Agent configs
+  for (const provider of listConfiguredProviderModels(config)) {
+    groups.push({
+      provider: provider.provider,
+      models: provider.models.map(model => ({ id: model, label: `${provider.label}: ${model}` })),
+    })
+  }
+
+  // 3. Extract custom_providers section
   const customProviders = config.custom_providers
   if (Array.isArray(customProviders)) {
     const customModels: ModelInfo[] = []

--- a/tests/server/config-helpers-file-lock.test.ts
+++ b/tests/server/config-helpers-file-lock.test.ts
@@ -143,4 +143,65 @@ describe('config-helpers locked file updates', () => {
     expect(result.changed).toBe(true)
     expect(result.config).toEqual({})
   })
+
+  it('extracts model groups from newer Hermes providers config entries', async () => {
+    const { listConfiguredProviderModels, buildModelGroups } = await loadHelpers()
+    const config = {
+      model: { default: 'custom-model-pro', provider: 'customrelay' },
+      providers: {
+        customrelay: {
+          name: 'Custom Relay',
+          base_url: 'https://relay.example/v1',
+          key_env: 'CUSTOM_RELAY_API_KEY',
+          default_model: 'custom-model-pro',
+          models: {
+            'custom-model-pro': { reasoning_effort: 'xhigh' },
+            'custom-model-lite': {},
+          },
+        },
+      },
+    }
+
+    expect(listConfiguredProviderModels(config)).toEqual([
+      {
+        provider: 'customrelay',
+        label: 'Custom Relay',
+        base_url: 'https://relay.example/v1',
+        key_env: 'CUSTOM_RELAY_API_KEY',
+        models: ['custom-model-pro', 'custom-model-lite'],
+      },
+    ])
+    expect(buildModelGroups(config)).toEqual({
+      default: 'custom-model-pro',
+      groups: [
+        {
+          provider: 'customrelay',
+          models: [
+            { id: 'custom-model-pro', label: 'Custom Relay: custom-model-pro' },
+            { id: 'custom-model-lite', label: 'Custom Relay: custom-model-lite' },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('normalizes configured providers without trusting invalid key_env names', async () => {
+    const { listConfiguredProviderModels } = await loadHelpers()
+    expect(listConfiguredProviderModels({
+      model: { model: 'fallback-model', provider: 'relay' },
+      providers: {
+        relay: {
+          key_env: 'CUSTOM_RELAY_API_KEY|MALICIOUS',
+        },
+      },
+    })).toEqual([
+      {
+        provider: 'relay',
+        label: 'relay',
+        base_url: '',
+        key_env: '',
+        models: ['fallback-model'],
+      },
+    ])
+  })
 })

--- a/tests/server/model-visibility-controller.test.ts
+++ b/tests/server/model-visibility-controller.test.ts
@@ -1,11 +1,33 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockReadFile, mockReadConfigYaml, mockReadConfigYamlForProfile, mockFetchProviderModels, mockBuildModelGroups, mockReadAppConfig, mockWriteAppConfig, mockExistsSync, mockReadFileSync } = vi.hoisted(() => ({
+const { mockReadFile, mockReadConfigYaml, mockReadConfigYamlForProfile, mockFetchProviderModels, mockBuildModelGroups, mockListConfiguredProviderModels, mockReadAppConfig, mockWriteAppConfig, mockExistsSync, mockReadFileSync } = vi.hoisted(() => ({
   mockReadFile: vi.fn(),
   mockReadConfigYaml: vi.fn(),
   mockReadConfigYamlForProfile: vi.fn(),
   mockFetchProviderModels: vi.fn(),
   mockBuildModelGroups: vi.fn(() => ({ default: '', groups: [] })),
+  mockListConfiguredProviderModels: vi.fn((config: any) => {
+    if (!config?.providers || typeof config.providers !== 'object' || Array.isArray(config.providers)) return []
+    return Object.entries(config.providers).flatMap(([provider, raw]: [string, any]) => {
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return []
+      const models = new Set<string>()
+      if (raw.models && typeof raw.models === 'object' && !Array.isArray(raw.models)) {
+        Object.keys(raw.models).forEach(model => { if (model) models.add(model) })
+      } else if (Array.isArray(raw.models)) {
+        raw.models.forEach((model: any) => { if (model) models.add(String(model)) })
+      }
+      if (raw.default_model) models.add(String(raw.default_model))
+      if (config.model?.provider === provider && (config.model?.default || config.model?.model)) models.add(String(config.model.default || config.model.model))
+      const keyEnv = String(raw.key_env || '').trim()
+      return models.size > 0 ? [{
+        provider,
+        label: raw.name || provider,
+        base_url: raw.base_url || raw.api || '',
+        key_env: /^[A-Za-z_][A-Za-z0-9_]*$/.test(keyEnv) ? keyEnv : '',
+        models: [...models],
+      }] : []
+    })
+  }),
   mockReadAppConfig: vi.fn(),
   mockWriteAppConfig: vi.fn(),
   mockExistsSync: vi.fn(() => false),
@@ -35,6 +57,7 @@ vi.mock('../../packages/server/src/services/config-helpers', () => ({
   writeConfigYaml: vi.fn(),
   fetchProviderModels: mockFetchProviderModels,
   buildModelGroups: mockBuildModelGroups,
+  listConfiguredProviderModels: mockListConfiguredProviderModels,
   PROVIDER_ENV_MAP: {
     deepseek: { api_key_env: 'DEEPSEEK_API_KEY' },
     'xai-oauth': { api_key_env: '', base_url_env: 'XAI_BASE_URL' },
@@ -100,6 +123,7 @@ beforeEach(() => {
   mockReadConfigYaml.mockResolvedValue({ model: { default: 'deepseek-chat', provider: 'deepseek' } })
   mockReadConfigYamlForProfile.mockResolvedValue({ model: { default: 'deepseek-chat', provider: 'deepseek' } })
   mockBuildModelGroups.mockReturnValue({ default: '', groups: [] })
+  mockListConfiguredProviderModels.mockClear()
   mockReadAppConfig.mockResolvedValue({})
   mockWriteAppConfig.mockImplementation(async patch => patch)
   mockExistsSync.mockReturnValue(false)
@@ -176,7 +200,131 @@ describe('models controller — model visibility', () => {
     ]))
   })
 
+  it('discovers available models from Hermes config.providers entries', async () => {
+    mockReadFile.mockResolvedValue('CUSTOM_RELAY_API_KEY=sk-test\n')
+    mockReadConfigYamlForProfile.mockResolvedValue({
+      model: { default: 'custom-model-pro', provider: 'customrelay' },
+      providers: {
+        customrelay: {
+          name: 'Custom Relay',
+          base_url: 'https://relay.example/v1',
+          key_env: 'CUSTOM_RELAY_API_KEY',
+          default_model: 'custom-model-pro',
+          models: {
+            'custom-model-pro': { reasoning_effort: 'xhigh' },
+            'custom-model-lite': {},
+          },
+        },
+      },
+    })
 
+    const ctx = makeCtx()
+    await ctrl.getAvailable(ctx)
+
+    expect(ctx.status).toBe(200)
+    expect(ctx.body.default).toBe('custom-model-pro')
+    expect(ctx.body.default_provider).toBe('customrelay')
+    expect(ctx.body.groups).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        provider: 'customrelay',
+        label: 'Custom Relay',
+        base_url: 'https://relay.example/v1',
+        models: ['custom-model-pro', 'custom-model-lite'],
+        available_models: ['custom-model-pro', 'custom-model-lite'],
+        api_key: 'sk-test',
+      }),
+    ]))
+    expect(ctx.body.profiles[0]).toEqual(expect.objectContaining({
+      profile: 'default',
+      default: 'custom-model-pro',
+      default_provider: 'customrelay',
+      groups: expect.arrayContaining([
+        expect.objectContaining({ provider: 'customrelay' }),
+      ]),
+    }))
+  })
+
+  it('merges config.providers models into matching builtin provider groups', async () => {
+    mockReadFile.mockResolvedValue('DEEPSEEK_API_KEY=sk-test\n')
+    mockReadConfigYamlForProfile.mockResolvedValue({
+      model: { default: 'deepseek-coder-v3', provider: 'deepseek' },
+      providers: {
+        deepseek: {
+          key_env: 'DEEPSEEK_API_KEY',
+          default_model: 'deepseek-coder-v3',
+          models: {
+            'deepseek-coder-v3': {},
+          },
+        },
+      },
+    })
+
+    const ctx = makeCtx()
+    await ctrl.getAvailable(ctx)
+
+    const group = ctx.body.groups.find((g: any) => g.provider === 'deepseek')
+    expect(group).toMatchObject({
+      provider: 'deepseek',
+      label: 'DeepSeek',
+      base_url: 'https://api.deepseek.com/v1',
+      api_key: 'sk-test',
+      builtin: true,
+    })
+    expect(group.models).toEqual(['deepseek-chat', 'deepseek-reasoner', 'deepseek-coder-v3'])
+    expect(group.available_models).toEqual(['deepseek-chat', 'deepseek-reasoner', 'deepseek-coder-v3'])
+    expect(ctx.body.default).toBe('deepseek-coder-v3')
+    expect(ctx.body.default_provider).toBe('deepseek')
+  })
+
+  it('ignores invalid key_env names from config.providers entries', async () => {
+    mockReadFile.mockResolvedValue('CUSTOM_RELAY_API_KEY=sk-test\n')
+    mockReadConfigYamlForProfile.mockResolvedValue({
+      model: { default: 'relay-model', provider: 'relay' },
+      providers: {
+        relay: {
+          key_env: 'CUSTOM_RELAY_API_KEY|MALICIOUS',
+          models: { 'relay-model': {} },
+        },
+      },
+    })
+
+    const ctx = makeCtx()
+    await ctrl.getAvailable(ctx)
+
+    expect(ctx.status).toBe(200)
+    expect(ctx.body.groups).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        provider: 'relay',
+        models: ['relay-model'],
+        api_key: '',
+      }),
+    ]))
+  })
+
+  it('uses model.model as the visible default for config.providers entries', async () => {
+    mockReadFile.mockResolvedValue('CUSTOM_RELAY_API_KEY=sk-test\n')
+    mockReadConfigYamlForProfile.mockResolvedValue({
+      model: { model: 'relay-model', provider: 'relay' },
+      providers: {
+        relay: {
+          key_env: 'CUSTOM_RELAY_API_KEY',
+        },
+      },
+    })
+
+    const ctx = makeCtx()
+    await ctrl.getAvailable(ctx)
+
+    expect(ctx.status).toBe(200)
+    expect(ctx.body.default).toBe('relay-model')
+    expect(ctx.body.default_provider).toBe('relay')
+    expect(ctx.body.groups).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        provider: 'relay',
+        models: ['relay-model'],
+      }),
+    ]))
+  })
 
   it('fails open for stale include rules so a provider can be recovered in the UI', async () => {
     mockReadAppConfig.mockResolvedValue({


### PR DESCRIPTION
## Summary

- Discover available model groups from Hermes Agent's newer `config.providers.<name>` entries.
- Merge configured provider models with existing provider groups instead of dropping models when provider keys overlap.
- Support default model fallbacks from `default_model`, `model.default`, and `model.model`.
- Validate `key_env` names before reading environment variables.

## Why

Hermes Agent can load configurations where custom providers are declared under `providers`, for example:

```yaml
model:
  default: custom-model-pro
  provider: customrelay
providers:
  customrelay:
    key_env: CUSTOM_RELAY_API_KEY
    default_model: custom-model-pro
    models:
      custom-model-pro: {}
```

The server config endpoint could read this shape, but `/api/hermes/available-models` did not expose the configured provider/model group. That left the model selector empty even though the active Hermes config was valid.

## Duplicate check

I checked existing related issues/PRs before opening this:

- #822 provider dynamic model discovery — related, but focused on provider APIs/built-ins.
- #881 profile-scoped model selection — related UI/model selection work.
- #522 provider metadata/API relay — related provider metadata topic.
- #34 custom provider manual model input — related custom provider workflow.

I did not find an existing issue/PR specifically covering `config.providers.<name>` discovery in `/api/hermes/available-models`.

## Test plan

Local verification performed:

- `git diff --check`
- `npx vitest run tests/server/model-visibility-controller.test.ts tests/server/config-helpers-file-lock.test.ts tests/server/health-controller.test.ts tests/client/models-store.test.ts`
  - 4 test files passed
  - 25 tests passed
- `npm run build`

Live verification against a local service using the newer Hermes config shape:

- `/health` returned HTTP 200
- `/api/hermes/profiles` returned HTTP 200
- `/api/hermes/available-models` returned the configured custom provider group and its default model.
