### PR TITLE
fix: per-user bridge socket isolation for multi-user systems

### DIFF
--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -1,6 +1,6 @@
 import { setTimeout as delay } from 'timers/promises'
 import { createConnection, type Socket } from 'net'
-import { tmpdir } from 'os'
+import { tmpdir, userInfo as osUserInfo } from 'os'
 import { URL } from 'url'
 import { join } from 'path'
 import { bridgeLogger } from '../../logger'
@@ -12,9 +12,18 @@ function resolveDefaultAgentBridgeEndpoint(): string {
       ? `tcp://127.0.0.1:${28000 + (process.pid % 10000)}`
       : `ipc://${join(tmpdir(), `hermes-agent-bridge-test-${process.pid}.sock`)}`
   }
-  return process.platform === 'win32'
-    ? 'tcp://127.0.0.1:18765'
-    : 'ipc:///tmp/hermes-agent-bridge.sock'
+  if (process.platform === 'win32') {
+    return 'tcp://127.0.0.1:18765'
+  }
+  // Per-user socket to avoid conflicts on multi-user systems.
+  // Falls back to USER env var, then USERNAME, then 'unknown'.
+  let username = 'unknown'
+  try { username = osUserInfo().username } catch {}
+  if (!username || username === 'unknown') {
+    username = process.env.USER || process.env.USERNAME || 'unknown'
+  }
+  username = username.replace(/[^a-zA-Z0-9_-]/g, '_')
+  return `ipc:///tmp/hermes-agent-bridge-${username}.sock`
 }
 
 export const DEFAULT_AGENT_BRIDGE_ENDPOINT = resolveDefaultAgentBridgeEndpoint()

--- a/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
@@ -1676,7 +1676,11 @@ def _worker_endpoint(profile: str) -> str:
     if os.name == "nt":
         port_base = int(os.environ.get("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE", "18780"))
         return f"tcp://127.0.0.1:{port_base + int(safe[:4], 16) % 1000}"
-    root = Path(tempfile.gettempdir()) / "hermes-agent-bridge-workers"
+    # Per-user worker directory to avoid conflicts on multi-user systems
+    # where different users share the same profile name (e.g., "default").
+    user = os.environ.get("USER") or os.environ.get("USERNAME") or "unknown"
+    user = re.sub(r"[^a-zA-Z0-9_-]", "_", user)
+    root = Path(tempfile.gettempdir()) / f"hermes-agent-bridge-workers-{user}"
     return f"ipc://{root / f'{safe}.sock'}"
 
 


### PR DESCRIPTION
## Summary

Two bugs cause agent bridge socket conflicts when multiple users run hermes-web-ui on the same Linux host.

### Bug 1: Broker default endpoint shared by all users

**File:** `packages/server/src/services/hermes/agent-bridge/client.ts`

`resolveDefaultAgentBridgeEndpoint()` hardcodes `ipc:///tmp/hermes-agent-bridge.sock` as the default. Multiple users share the same socket path.

**Fix:** Derive username from `os.userInfo()` and include it:
- Before: `ipc:///tmp/hermes-agent-bridge.sock`
- After: `ipc:///tmp/hermes-agent-bridge-<username>.sock`

Backward-compatible: `HERMES_AGENT_BRIDGE_ENDPOINT` env var still overrides.

### Bug 2: Worker socket hash collision across users

**File:** `packages/server/src/services/hermes/agent-bridge/hermes_bridge.py`

`_worker_endpoint()` computes socket path as:
`/tmp/hermes-agent-bridge-workers/<sha256(profile)[:16]>.sock`

Different users with the same profile name (e.g. "default") get the identical hash (`37a8eec1ce19687d`). The second process `unlink()`s the first's socket, causing ECONNRESET errors.

**Fix:** Per-user worker directory:
- Before: `/tmp/hermes-agent-bridge-workers/<hash>.sock`
- After: `/tmp/hermes-agent-bridge-workers-<user>/<hash>.sock`

### Reproduction

System: Linux (Ubuntu 22.04), multiple users (Pbpf, xjwu) each with separate hermes-agent installations.

- Broker conflict: prevented only by manual `HERMES_AGENT_BRIDGE_ENDPOINT` workaround
- Worker conflict: confirmed — both users' workers bound to same socket; restarting one stole the other's socket

### Testing

Verified on the affected multi-user system. Each user's broker and worker now use isolated socket paths. No regression on single-user systems.

### Files changed

```
.../agent-bridge/client.ts        | 14 ++++++++++--
.../agent-bridge/hermes_bridge.py |  6 ++++-
2 files changed, 17 insertions(+), 3 deletions(-)
```
