### PR TITLE
fix: add long-lived cache headers for Vite hashed static assets

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -147,14 +147,25 @@ export async function bootstrap() {
     logger.info('Auth enabled — token: %s', authToken)
   }
 
-  // SPA fallback
+  // SPA fallback — serve Vite production build
   const distDir = resolve(__dirname, '..', 'client')
-  app.use(serve(distDir))
+
+  // Serve hashed static assets with long-lived cache (Vite uses content hashes
+  // in filenames so they are safe to cache permanently; index.html is excluded
+  // because it is served by the SPA fallback below with no-cache semantics).
+  app.use(serve(distDir, {
+    maxAge: 365 * 24 * 60 * 60 * 1000, // 1 year in ms (koa-static divides by 1000)
+    immutable: true,
+  }))
+
+  // SPA fallback — always revalidate index.html so users get the latest
+  // entry point that references current hashed asset filenames.
   app.use(async (ctx) => {
     if (!ctx.path.startsWith('/api') &&
       ctx.path !== '/health' &&
       ctx.path !== '/upload' &&
       ctx.path !== '/webhook') {
+      ctx.set('Cache-Control', 'no-cache')
       await send(ctx, 'index.html', { root: distDir })
     }
   })

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -150,12 +150,18 @@ export async function bootstrap() {
   // SPA fallback — serve Vite production build
   const distDir = resolve(__dirname, '..', 'client')
 
-  // Serve hashed static assets with long-lived cache (Vite uses content hashes
-  // in filenames so they are safe to cache permanently; index.html is excluded
-  // because it is served by the SPA fallback below with no-cache semantics).
+  // Vite emits content-hashed files under /assets, so those can be cached
+  // aggressively. Keep index.html revalidated so clients pick up new asset URLs
+  // after a deploy.
   app.use(serve(distDir, {
-    maxAge: 365 * 24 * 60 * 60 * 1000, // 1 year in ms (koa-static divides by 1000)
-    immutable: true,
+    setHeaders: (res, servedPath) => {
+      const normalizedPath = servedPath.replace(/\\/g, '/')
+      if (normalizedPath.includes('/assets/')) {
+        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
+      } else if (normalizedPath.endsWith('/index.html')) {
+        res.setHeader('Cache-Control', 'no-cache')
+      }
+    },
   }))
 
   // SPA fallback — always revalidate index.html so users get the latest


### PR DESCRIPTION
## Problem

`koa-static` defaults to `Cache-Control: max-age=0`, forcing browsers to re-download all JS/CSS assets (~3MB+ including mermaid) on every page load.

Since Vite uses content hashes in asset filenames (e.g., `mermaid-LgQgRHhf.js`), they are safe to cache permanently — the filename changes when the content changes.

## Changes

- **`/assets/*`** (hashed static files): `Cache-Control: max-age=31536000, immutable` — cache for 1 year
- **`index.html`** (SPA fallback): `Cache-Control: no-cache` — always revalidate to get latest asset references

## Before

```
$ curl -sI http://localhost:8648/assets/js/mermaid-LgQgRHhf.js
Cache-Control: max-age=0          ← no caching
Content-Length: 2920745           ← 2.9MB re-downloaded every visit
```

## After

```
$ curl -sI http://localhost:8648/assets/js/mermaid-LgQgRHhf.js
Cache-Control: max-age=31536000, immutable   ← cached for 1 year
Content-Length: 2920745

$ curl -sI http://localhost:8648/
Cache-Control: no-cache           ← always revalidate
```