### PR TITLE
[codex] fix session native links profile filtering

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -61,11 +61,9 @@ let mobileQuery: MediaQueryList | null = null;
 const isMobile = ref(false);
 
 function sessionHref(sessionId: string) {
-  const profile = sessionProfile(sessionId);
   return router.resolve({
     name: "hermes.session",
     params: { sessionId },
-    query: profile ? { profile } : undefined,
   }).href;
 }
 
@@ -75,11 +73,9 @@ function openSessionInNewTab(sessionId: string) {
 }
 
 async function handleSessionClick(sessionId: string) {
-  const session = chatStore.sessions.find((item) => item.id === sessionId);
   await router.push({
     name: "hermes.session",
     params: { sessionId },
-    query: session?.profile ? { profile: session.profile } : undefined,
   });
   if (mobileQuery?.matches) showSessions.value = false;
 }
@@ -283,7 +279,6 @@ async function confirmNewChat() {
   await router.push({
     name: "hermes.session",
     params: { sessionId: session.id },
-    query: session.profile ? { profile: session.profile } : undefined,
   });
   showNewChatModal.value = false;
 }

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -273,7 +273,7 @@ export default {
     monitorRoleUser: 'Benutzer',
     monitorRoleAssistant: 'Assistent',
     copySessionLink: 'Sitzungslink kopieren',
-    openSessionInNewTab: 'Open in new tab',
+    openSessionInNewTab: 'In neuem Tab öffnen',
     sessionLinkCopied: 'Session link copied',
     copySessionId: 'Sitzungs-ID kopieren',
     export: 'Exportieren',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -273,7 +273,7 @@ export default {
     monitorRoleUser: 'Usuario',
     monitorRoleAssistant: 'Asistente',
     copySessionLink: 'Copiar enlace de sesión',
-    openSessionInNewTab: 'Open in new tab',
+    openSessionInNewTab: 'Abrir en una nueva pestaña',
     sessionLinkCopied: 'Session link copied',
     copySessionId: 'Copiar ID de sesión',
     export: 'Exportar',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -273,7 +273,7 @@ export default {
     monitorRoleUser: 'Utilisateur',
     monitorRoleAssistant: 'Assistant',
     copySessionLink: 'Copier le lien de session',
-    openSessionInNewTab: 'Open in new tab',
+    openSessionInNewTab: 'Ouvrir dans un nouvel onglet',
     sessionLinkCopied: 'Session link copied',
     copySessionId: "Copier l'ID de session",
     export: 'Exporter',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -273,7 +273,7 @@ export default {
     monitorRoleUser: 'ユーザー',
     monitorRoleAssistant: 'アシスタント',
     copySessionLink: 'セッションリンクをコピー',
-    openSessionInNewTab: 'Open in new tab',
+    openSessionInNewTab: '新しいタブで開く',
     sessionLinkCopied: 'Session link copied',
     copySessionId: 'セッション ID をコピー',
     export: 'エクスポート',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -273,7 +273,7 @@ export default {
     monitorRoleUser: '사용자',
     monitorRoleAssistant: '어시스턴트',
     copySessionLink: '세션 링크 복사',
-    openSessionInNewTab: 'Open in new tab',
+    openSessionInNewTab: '새 탭에서 열기',
     sessionLinkCopied: 'Session link copied',
     copySessionId: '세션 ID 복사',
     export: '내보내기',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -273,7 +273,7 @@ export default {
     monitorRoleUser: 'Usuário',
     monitorRoleAssistant: 'Assistente',
     copySessionLink: 'Copiar link da sessão',
-    openSessionInNewTab: 'Open in new tab',
+    openSessionInNewTab: 'Abrir em nova aba',
     sessionLinkCopied: 'Session link copied',
     copySessionId: 'Copiar ID da sessão',
     export: 'Exportar',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -287,7 +287,7 @@ export default {
     monitorRoleUser: '使用者',
     monitorRoleAssistant: '助手',
     copySessionLink: '複製工作階段連結',
-    openSessionInNewTab: 'Open in new tab',
+    openSessionInNewTab: '在新分頁開啟',
     sessionLinkCopied: 'Session link copied',
     copySessionId: '複製工作階段 ID',
     export: '匯出',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -289,7 +289,7 @@ export default {
     monitorRoleUser: '用户',
     monitorRoleAssistant: '助手',
     copySessionLink: '复制会话链接',
-    openSessionInNewTab: 'Open in new tab',
+    openSessionInNewTab: '在新标签页打开',
     sessionLinkCopied: 'Session link copied',
     copySessionId: '复制会话 ID',
     export: '导出',

--- a/packages/client/src/views/hermes/ChatView.vue
+++ b/packages/client/src/views/hermes/ChatView.vue
@@ -25,7 +25,7 @@ const routeProfile = computed(() => {
 })
 
 async function loadRouteSession() {
-  await chatStore.loadSessions(routeProfile.value, routeSessionId.value)
+  await chatStore.loadSessions(chatStore.sessionProfileFilter, routeSessionId.value)
   if (routeSessionId.value && chatStore.activeSessionId !== routeSessionId.value) {
     await router.replace({ name: 'hermes.chat' })
   }
@@ -45,19 +45,14 @@ onMounted(async () => {
 watch([routeSessionId, routeProfile], async ([sessionId]) => {
   if (!chatStore.sessionsLoaded) return
   if (!sessionId) {
-    await chatStore.loadSessions(routeProfile.value)
+    await chatStore.loadSessions(chatStore.sessionProfileFilter)
     return
   }
-  if (chatStore.activeSessionId === sessionId && (!routeProfile.value || chatStore.activeSession?.profile === routeProfile.value)) return
-
-  if (routeProfile.value) {
-    await loadRouteSession()
-    return
-  }
+  if (chatStore.activeSessionId === sessionId) return
 
   const exists = chatStore.sessions.some(session => session.id === sessionId)
   if (!exists) {
-    await router.replace({ name: 'hermes.chat' })
+    await loadRouteSession()
     return
   }
 

--- a/tests/e2e/native-navigation.spec.ts
+++ b/tests/e2e/native-navigation.spec.ts
@@ -32,6 +32,6 @@ test('session rows expose native session links', async ({ page }) => {
   await page.goto('/#/hermes/chat')
 
   const sessionLink = page.locator('.session-items a.session-item').first()
-  await expect(sessionLink).toHaveAttribute('href', '#/hermes/session/session-native-1?profile=research')
+  await expect(sessionLink).toHaveAttribute('href', '#/hermes/session/session-native-1')
   await expect(sessionLink).toContainText('Native Link Session')
 })


### PR DESCRIPTION
## Summary

- Stop normal chat session navigation from adding `?profile=` to session URLs.
- Keep the session list loading from the explicit sidebar profile filter instead of route query profile.
- Update the native navigation e2e expectation for profile-free session row links.
- Translate `openSessionInNewTab` across supported locales instead of leaving English placeholders.

## Root Cause

PR #973 converted session rows to native links and included each session profile in the row href. That conflicted with the current session list behavior where the default list should show every profile available to the account, and profile filtering should only happen through the explicit session profile filter.

## Validation

- `npx vitest run tests/client/i18n-coverage.test.ts tests/client/session-list-item.test.ts tests/client/route-link-item.test.ts`
- `npx vue-tsc -b --pretty false`
- `git diff --check`
