### PR TITLE
fix: dispatch unknown slash commands to the agent bridge (/plan, /spike, /goal, …)

### DIFF
--- a/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
@@ -17,8 +17,10 @@ import hashlib
 import importlib.util
 import json
 import locale
+import logging
 import os
 import queue
+import re
 import signal
 import shutil
 import socket
@@ -33,7 +35,10 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlparse
-from typing import Any, Callable
+from typing import Any, Callable, Optional
+
+
+logger = logging.getLogger("hermes_bridge")
 
 
 DEFAULT_ENDPOINT = "tcp://127.0.0.1:18765" if os.name == "nt" else "ipc:///tmp/hermes-agent-bridge.sock"
@@ -1298,6 +1303,88 @@ class AgentPool:
                     pass
                 self._prepersist_user_message(session, message, storage_message, conversation_history, profile, source)
                 db_count_after_prepersist = self._session_db_message_count(session.session_id, profile)
+
+                # --- Skill / bundle slash command resolution -----------------
+                # When the message is a "/skill-name [args]" string, replace it with
+                # the SKILL.md-derived user message before invoking the agent.
+                # This mirrors what cli.py and gateway/run.py do, so /plan, /spike,
+                # /goal, /tdd etc. work the same way they do in the CLI/gateway.
+                # Pure-additive: any failure (skill not found, import error) silently
+                # falls back to the original message.
+                #
+                # NOTE: this must run AFTER _prepersist_user_message so the literal
+                # "/plan" text is what gets stored in the session DB (matching CLI
+                # behavior where the user's typed command is preserved in history),
+                # while the resolved skill content is what the model sees.
+                try:
+                    if isinstance(message, str) and message.startswith("/"):
+                        _slash_text = message.strip()
+                        if _slash_text.startswith("/") and len(_slash_text) > 1:
+                            _slash_match = re.match(r"^/([a-zA-Z][\w-]*)(?:\s+([\s\S]*))?$", _slash_text)
+                            if _slash_match:
+                                _cmd_raw = _slash_match.group(1)
+                                _cmd_args = (_slash_match.group(2) or "").strip()
+                                _resolved_msg: Optional[str] = None
+
+                                # 1) Skill bundles first (mirrors gateway/run.py order)
+                                try:
+                                    from agent.skill_bundles import (
+                                        build_bundle_invocation_message,
+                                        resolve_bundle_command_key,
+                                    )
+                                    _bundle_key = resolve_bundle_command_key(_cmd_raw)
+                                    if _bundle_key is not None:
+                                        _bundle_result = build_bundle_invocation_message(
+                                            _bundle_key, _cmd_args, task_id=session.session_id
+                                        )
+                                        if _bundle_result:
+                                            _bundle_msg, _loaded_bundle, _missing_bundle = _bundle_result
+                                            if _bundle_msg:
+                                                _resolved_msg = _bundle_msg
+                                                if _missing_bundle:
+                                                    logger.info(
+                                                        "Bundle /%s skipped missing skills: %s",
+                                                        _cmd_raw, ", ".join(_missing_bundle),
+                                                    )
+                                except Exception as _bundle_exc:
+                                    logger.debug(
+                                        "Skill bundle dispatch failed (non-fatal) for /%s: %s",
+                                        _cmd_raw, _bundle_exc,
+                                    )
+
+                                # 2) Individual skill command
+                                if _resolved_msg is None:
+                                    try:
+                                        from agent.skill_commands import (
+                                            build_skill_invocation_message,
+                                            resolve_skill_command_key,
+                                        )
+                                        _cmd_key = resolve_skill_command_key(_cmd_raw)
+                                        if _cmd_key is not None:
+                                            _skill_msg = build_skill_invocation_message(
+                                                _cmd_key, _cmd_args, task_id=session.session_id
+                                            )
+                                            if _skill_msg:
+                                                _resolved_msg = _skill_msg
+                                    except Exception as _skill_exc:
+                                        logger.debug(
+                                            "Skill command dispatch failed (non-fatal) for /%s: %s",
+                                            _cmd_raw, _skill_exc,
+                                        )
+
+                                if _resolved_msg:
+                                    logger.info(
+                                        "Resolved /%s slash command for session %s (%d chars)",
+                                        _cmd_raw, session.session_id, len(_resolved_msg),
+                                    )
+                                    message = _resolved_msg
+                except Exception as _slash_exc:
+                    # Defensive: any unexpected failure must not break the run.
+                    logger.warning(
+                        "Slash command resolution failed (non-fatal): %s", _slash_exc,
+                    )
+                # --- end skill / bundle slash command resolution -------------
+
                 if force_compress:
                     compress = getattr(session.agent, "_compress_context", None)
                     if callable(compress):

--- a/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
@@ -41,6 +41,45 @@ from typing import Any, Callable, Optional
 logger = logging.getLogger("hermes_bridge")
 
 
+# --- Slash command resolution: hoisted imports ----------------------------
+# Resolve skill / bundle helpers once at module load instead of on every
+# chat message. Both modules live in hermes-agent (added to sys.path at
+# bridge startup via --agent-root). When unavailable (missing install or
+# unexpected module shape), we keep the symbols as None and skip resolution
+# gracefully — operators see a single WARNING in startup logs instead of
+# silent per-request DEBUG noise.
+try:
+    from agent.skill_bundles import (  # type: ignore[import-not-found]
+        build_bundle_invocation_message as _build_bundle_invocation_message,
+        resolve_bundle_command_key as _resolve_bundle_command_key,
+    )
+except Exception as _bundle_import_exc:  # pragma: no cover - defensive
+    _build_bundle_invocation_message = None
+    _resolve_bundle_command_key = None
+    logger.warning(
+        "Skill bundle support unavailable; /<bundle> commands will fall back "
+        "to plain user input: %s",
+        _bundle_import_exc,
+    )
+
+try:
+    from agent.skill_commands import (  # type: ignore[import-not-found]
+        build_skill_invocation_message as _build_skill_invocation_message,
+        resolve_skill_command_key as _resolve_skill_command_key,
+    )
+except Exception as _skill_import_exc:  # pragma: no cover - defensive
+    _build_skill_invocation_message = None
+    _resolve_skill_command_key = None
+    logger.warning(
+        "Skill command support unavailable; /<skill> commands will fall back "
+        "to plain user input: %s",
+        _skill_import_exc,
+    )
+
+# Compile once: matches "/name" or "/name args..." (name = letter then word chars/hyphens)
+_SLASH_COMMAND_RE = re.compile(r"^/([a-zA-Z][\w-]*)(?:\s+([\s\S]*))?$")
+
+
 DEFAULT_ENDPOINT = "tcp://127.0.0.1:18765" if os.name == "nt" else "ipc:///tmp/hermes-agent-bridge.sock"
 DEFAULT_AGENT_ROOT = "~/.hermes/hermes-agent"
 DEFAULT_HERMES_HOME = "~/.hermes"
@@ -1305,84 +1344,75 @@ class AgentPool:
                 db_count_after_prepersist = self._session_db_message_count(session.session_id, profile)
 
                 # --- Skill / bundle slash command resolution -----------------
-                # When the message is a "/skill-name [args]" string, replace it with
-                # the SKILL.md-derived user message before invoking the agent.
-                # This mirrors what cli.py and gateway/run.py do, so /plan, /spike,
-                # /goal, /tdd etc. work the same way they do in the CLI/gateway.
-                # Pure-additive: any failure (skill not found, import error) silently
-                # falls back to the original message.
+                # When the message is a "/skill-name [args]" string, replace it
+                # with the SKILL.md-derived user message before invoking the
+                # agent. Mirrors what cli.py and gateway/run.py do, so /plan,
+                # /spike, /goal, /tdd etc. work the same way they do in the
+                # CLI/gateway.
                 #
-                # NOTE: this must run AFTER _prepersist_user_message so the literal
-                # "/plan" text is what gets stored in the session DB (matching CLI
-                # behavior where the user's typed command is preserved in history),
-                # while the resolved skill content is what the model sees.
-                try:
-                    if isinstance(message, str) and message.startswith("/"):
-                        _slash_text = message.strip()
-                        if _slash_text.startswith("/") and len(_slash_text) > 1:
-                            _slash_match = re.match(r"^/([a-zA-Z][\w-]*)(?:\s+([\s\S]*))?$", _slash_text)
-                            if _slash_match:
-                                _cmd_raw = _slash_match.group(1)
-                                _cmd_args = (_slash_match.group(2) or "").strip()
-                                _resolved_msg: Optional[str] = None
+                # Pure-additive: any failure (skill not found, lookup error)
+                # silently falls back to the original message. Module-level
+                # ImportError already surfaced as a startup WARNING; per-request
+                # exceptions stay at DEBUG to avoid log spam on /unknown inputs
+                # that happen to hit a malformed skill.
+                #
+                # NOTE: this must run AFTER _prepersist_user_message so the
+                # literal "/plan" text is what gets stored in the session DB
+                # (matching CLI behavior where the user's typed command is
+                # preserved in history), while the resolved skill content is
+                # what the model actually sees.
+                if isinstance(message, str):
+                    _slash_match = _SLASH_COMMAND_RE.match(message.strip())
+                    if _slash_match:
+                        _cmd_raw = _slash_match.group(1)
+                        _cmd_args = (_slash_match.group(2) or "").strip()
+                        _resolved_msg: Optional[str] = None
 
-                                # 1) Skill bundles first (mirrors gateway/run.py order)
-                                try:
-                                    from agent.skill_bundles import (
-                                        build_bundle_invocation_message,
-                                        resolve_bundle_command_key,
+                        # 1) Skill bundles first (mirrors gateway/run.py order).
+                        if _resolve_bundle_command_key is not None and _build_bundle_invocation_message is not None:
+                            try:
+                                _bundle_key = _resolve_bundle_command_key(_cmd_raw)
+                                if _bundle_key is not None:
+                                    _bundle_result = _build_bundle_invocation_message(
+                                        _bundle_key, _cmd_args, task_id=session.session_id
                                     )
-                                    _bundle_key = resolve_bundle_command_key(_cmd_raw)
-                                    if _bundle_key is not None:
-                                        _bundle_result = build_bundle_invocation_message(
-                                            _bundle_key, _cmd_args, task_id=session.session_id
-                                        )
-                                        if _bundle_result:
-                                            _bundle_msg, _loaded_bundle, _missing_bundle = _bundle_result
-                                            if _bundle_msg:
-                                                _resolved_msg = _bundle_msg
-                                                if _missing_bundle:
-                                                    logger.info(
-                                                        "Bundle /%s skipped missing skills: %s",
-                                                        _cmd_raw, ", ".join(_missing_bundle),
-                                                    )
-                                except Exception as _bundle_exc:
-                                    logger.debug(
-                                        "Skill bundle dispatch failed (non-fatal) for /%s: %s",
-                                        _cmd_raw, _bundle_exc,
-                                    )
+                                    if _bundle_result:
+                                        _bundle_msg, _loaded_bundle, _missing_bundle = _bundle_result
+                                        if _bundle_msg:
+                                            _resolved_msg = _bundle_msg
+                                            if _missing_bundle:
+                                                logger.info(
+                                                    "Bundle /%s skipped missing skills: %s",
+                                                    _cmd_raw, ", ".join(_missing_bundle),
+                                                )
+                            except (AttributeError, KeyError, TypeError, ValueError) as _bundle_exc:
+                                logger.debug(
+                                    "Skill bundle dispatch failed (non-fatal) for /%s: %s",
+                                    _cmd_raw, _bundle_exc, exc_info=True,
+                                )
 
-                                # 2) Individual skill command
-                                if _resolved_msg is None:
-                                    try:
-                                        from agent.skill_commands import (
-                                            build_skill_invocation_message,
-                                            resolve_skill_command_key,
-                                        )
-                                        _cmd_key = resolve_skill_command_key(_cmd_raw)
-                                        if _cmd_key is not None:
-                                            _skill_msg = build_skill_invocation_message(
-                                                _cmd_key, _cmd_args, task_id=session.session_id
-                                            )
-                                            if _skill_msg:
-                                                _resolved_msg = _skill_msg
-                                    except Exception as _skill_exc:
-                                        logger.debug(
-                                            "Skill command dispatch failed (non-fatal) for /%s: %s",
-                                            _cmd_raw, _skill_exc,
-                                        )
-
-                                if _resolved_msg:
-                                    logger.info(
-                                        "Resolved /%s slash command for session %s (%d chars)",
-                                        _cmd_raw, session.session_id, len(_resolved_msg),
+                        # 2) Individual skill command.
+                        if _resolved_msg is None and _resolve_skill_command_key is not None and _build_skill_invocation_message is not None:
+                            try:
+                                _cmd_key = _resolve_skill_command_key(_cmd_raw)
+                                if _cmd_key is not None:
+                                    _skill_msg = _build_skill_invocation_message(
+                                        _cmd_key, _cmd_args, task_id=session.session_id
                                     )
-                                    message = _resolved_msg
-                except Exception as _slash_exc:
-                    # Defensive: any unexpected failure must not break the run.
-                    logger.warning(
-                        "Slash command resolution failed (non-fatal): %s", _slash_exc,
-                    )
+                                    if _skill_msg:
+                                        _resolved_msg = _skill_msg
+                            except (AttributeError, KeyError, TypeError, ValueError) as _skill_exc:
+                                logger.debug(
+                                    "Skill command dispatch failed (non-fatal) for /%s: %s",
+                                    _cmd_raw, _skill_exc, exc_info=True,
+                                )
+
+                        if _resolved_msg:
+                            logger.info(
+                                "Resolved /%s slash command for session %s (%d chars)",
+                                _cmd_raw, session.session_id, len(_resolved_msg),
+                            )
+                            message = _resolved_msg
                 # --- end skill / bundle slash command resolution -------------
 
                 if force_compress:

--- a/packages/server/src/services/hermes/run-chat/session-command.ts
+++ b/packages/server/src/services/hermes/run-chat/session-command.ts
@@ -58,7 +58,11 @@ export function parseSessionCommand(input: string | ContentBlock[]): ParsedSessi
   if (!match) return null
   const rawName = match[1].toLowerCase()
   const name = COMMAND_ALIASES[rawName]
-  if (!name) return { name: 'status', rawName, args: match[2]?.trim() || '' }
+  // Only return a parsed command for KNOWN bridge-level aliases. Unknown
+  // slash inputs (e.g. /plan, /spike, /goal, /tdd) must fall through to
+  // handleBridgeRun so the Python bridge can resolve them as skill
+  // commands or surface them to the agent as regular user input.
+  if (!name) return null
   return { name, rawName, args: match[2]?.trim() || '' }
 }
 


### PR DESCRIPTION
## Summary

The Web UI was eating any `/something` input that wasn't one of the nine hard-coded "session commands" (`/usage`, `/clear`, `/title`, `/abort`, `/queue`, `/compress`, `/steer`, `/destroy`, `/status`). Skill commands like `/plan`, `/spike`, `/tdd`, plus persistent commands like `/goal`, never reached the Python bridge — they were rewritten to `{name: 'status', rawName: 'plan'}` and the gateway answered with `Unknown bridge command: /plan`.

The CLI (`cli.py::process_command`) and gateway adapters (`gateway/run.py::_handle_message`) resolve these the right way, using the canonical helpers in `hermes-agent`. The Web UI just never grew the same hook. This PR adds the missing dispatch.

## Repro (before)

In Web UI:
```
/plan write a function that adds two numbers
```
→ Server logs: `Unknown bridge command: /plan`. Skill never loaded.

## Fix (two layers)

**1. `session-command.ts::parseSessionCommand`** returns `null` for unknown aliases instead of fabricating `{name: 'status', rawName: 'plan'}`. Unknown slash inputs now fall through to `handleBridgeRun` like any normal user message.

```diff
   const rawName = match[1].toLowerCase()
   const name = COMMAND_ALIASES[rawName]
-  if (!name) return { name: 'status', rawName, args: match[2]?.trim() || '' }
+  // Only return a parsed command for KNOWN bridge-level aliases. Unknown
+  // slash inputs (e.g. /plan, /spike, /goal, /tdd) must fall through to
+  // handleBridgeRun so the Python bridge can resolve them as skill
+  // commands or surface them to the agent as regular user input.
+  if (!name) return null
   return { name, rawName, args: match[2]?.trim() || '' }
```

**2. `hermes_bridge.py::_run_chat`** resolves `/skill-name` (and `/bundle-name`) inputs **after** prepersisting the literal slash command to the session DB and **before** calling `AIAgent.run_conversation()`. Resolution uses upstream helpers (`agent.skill_commands.build_skill_invocation_message`, `agent.skill_bundles.build_bundle_invocation_message`) so the Web UI shares the canonical injection logic with the CLI and gateway — no duplicated SKILL.md parsing, no drift if those helpers change.

The Python hook is pure-additive and wrapped in defensive try/except so import failures or missing skills silently fall back to the original message — never breaks a run.

## Behavior after

| Input | Before | After |
|-------|--------|-------|
| `/plan criar plano de aula` | `Unknown bridge command: /plan` | DB sees `/plan ...`; model receives full SKILL.md content + instruction (matches CLI/Telegram/Discord) |
| `/spike` / `/tdd` / `/goal` / any of the 88+ skill commands | Same error | Resolved as the corresponding skill |
| `/foobar` (unknown, not a skill) | Same error | Flows through as a plain user message (matches CLI behavior) |
| `/usage`, `/clear`, `/abort`, `/title`, `/compress`, `/steer`, `/queue`, `/destroy` | Worked | Worked (untouched) |

## Verification

Tested live on a self-hosted Hermes Web UI v0.6.0 deployment with the kiro-go profile (88 skill commands, including `/plan`):

- `/plan verifique se a correção dos comandos está funcionando` → SKILL.md was injected as user message with the standard `[IMPORTANT: The user has invoked the "plan" skill...]` activation header, plus the trailing user instruction. The model executed plan-mode behavior identical to CLI.
- Bridge logs confirmed: `Resolved /plan slash command for session <sid> (2519 chars)`.
- Existing bridge commands (`/usage`, `/clear`) keep working unchanged.

## Risk

Low. The TS change tightens behavior (less false-positive command parsing) without removing any working code path. The Python change is additive — a try/except wrapper around two helper calls — and falls back to the original message on any failure.

## Notes for reviewers

- The Python helpers (`agent.skill_commands`, `agent.skill_bundles`) are part of `hermes-agent` proper and are already imported elsewhere in `hermes_bridge.py`'s runtime path. They're stable upstream APIs (used by `cli.py` and `gateway/run.py`).
- The `_run_chat` hook runs **after** `_prepersist_user_message` so the user's literal `/plan` text is what gets stored in session history (matching CLI behavior where the typed command is preserved in transcripts), while the resolved skill content is what the model sees.
- No new dependencies. No config changes. No schema changes.
