### PR TITLE
[codex] increase login lock threshold

### DIFF
--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -16,6 +16,8 @@ export default {
     credentialsRequired: 'Bitte Benutzername und Passwort eingeben',
     invalidCredentials: 'Ungultiger Benutzername oder Passwort',
     tooManyAttempts: 'Zu viele fehlgeschlagene Versuche, bitte versuchen Sie es spater erneut',
+    lockResetHint: 'Wenn dies Ihr Server ist, heben Sie die Login-Sperre auf mit:',
+    defaultLoginResetHint: 'Um das Standard-Admin-Passwort zuruckzusetzen, fuhren Sie aus:',
     sessionExpired: 'Die Anmeldung ist abgelaufen. Bitte melden Sie sich erneut an.',
     accessDenied: 'Sie haben keine Berechtigung fur diese Ressource.',
     passwordMismatch: 'Passworter stimmen nicht uberein',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -16,6 +16,8 @@ export default {
     credentialsRequired: 'Please enter username and password',
     invalidCredentials: 'Invalid username or password',
     tooManyAttempts: 'Too many failed attempts, please try again later',
+    lockResetHint: 'If this is your server, clear the login lock with:',
+    defaultLoginResetHint: 'To reset the default admin password, run:',
     sessionExpired: 'Login expired. Please sign in again.',
     accessDenied: 'You do not have permission to access this resource.',
     passwordMismatch: 'Passwords do not match',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -16,6 +16,8 @@ export default {
     credentialsRequired: 'Por favor, introduzca nombre de usuario y contrasena',
     invalidCredentials: 'Nombre de usuario o contrasena incorrectos',
     tooManyAttempts: 'Demasiados intentos fallidos, por favor intente mas tarde',
+    lockResetHint: 'Si este es su servidor, borre el bloqueo de inicio de sesion con:',
+    defaultLoginResetHint: 'Para restablecer la contrasena admin predeterminada, ejecute:',
     sessionExpired: 'La sesion expiro. Inicia sesion de nuevo.',
     accessDenied: 'No tienes permiso para acceder a este recurso.',
     passwordMismatch: 'Las contrasenas no coinciden',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -16,6 +16,8 @@ export default {
     credentialsRequired: 'Veuillez entrer le nom d\'utilisateur et le mot de passe',
     invalidCredentials: 'Nom d\'utilisateur ou mot de passe incorrect',
     tooManyAttempts: 'Trop de tentatives echouees, veuillez reessayer plus tard',
+    lockResetHint: 'Si c est votre serveur, supprimez le verrouillage de connexion avec :',
+    defaultLoginResetHint: 'Pour reinitialiser le mot de passe admin par defaut, executez :',
     sessionExpired: 'La session a expire. Veuillez vous reconnecter.',
     accessDenied: 'Vous n\'avez pas l\'autorisation d\'acceder a cette ressource.',
     passwordMismatch: 'Les mots de passe ne correspondent pas',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -16,6 +16,8 @@ export default {
     credentialsRequired: 'ユーザー名とパスワードを入力してください',
     invalidCredentials: 'ユーザー名またはパスワードが正しくありません',
     tooManyAttempts: 'ログイン試行回数が多すぎます。しばらくしてからお試しください',
+    lockResetHint: '自分のサーバーの場合は、次のコマンドでログインロックを解除できます:',
+    defaultLoginResetHint: '既定の admin パスワードをリセットするには、次を実行してください:',
     sessionExpired: 'ログインの有効期限が切れました。再度ログインしてください。',
     accessDenied: 'このリソースにアクセスする権限がありません。',
     passwordMismatch: 'パスワードが一致しません',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -16,6 +16,8 @@ export default {
     credentialsRequired: '사용자 이름과 비밀번호를 입력해 주세요',
     invalidCredentials: '사용자 이름 또는 비밀번호가 올바르지 않습니다',
     tooManyAttempts: '로그인 시도 횟수가 너무 많습니다. 잠시 후 다시 시도해 주세요',
+    lockResetHint: '본인 서버라면 다음 명령으로 로그인 잠금을 해제할 수 있습니다:',
+    defaultLoginResetHint: '기본 admin 비밀번호를 재설정하려면 다음을 실행하세요:',
     sessionExpired: '로그인이 만료되었습니다. 다시 로그인해 주세요.',
     accessDenied: '이 리소스에 접근할 권한이 없습니다.',
     passwordMismatch: '비밀번호가 일치하지 않습니다',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -16,6 +16,8 @@ export default {
     credentialsRequired: 'Por favor, insira nome de usuario e senha',
     invalidCredentials: 'Nome de usuario ou senha incorretos',
     tooManyAttempts: 'Muitas tentativas falhadas, por favor tente novamente mais tarde',
+    lockResetHint: 'Se este for seu servidor, limpe o bloqueio de login com:',
+    defaultLoginResetHint: 'Para redefinir a senha admin padrao, execute:',
     sessionExpired: 'Login expirado. Entre novamente.',
     accessDenied: 'Voce nao tem permissao para acessar este recurso.',
     passwordMismatch: 'As senhas nao conferem',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -16,6 +16,8 @@ export default {
     credentialsRequired: '請輸入使用者名稱和密碼',
     invalidCredentials: '使用者名稱或密碼錯誤',
     tooManyAttempts: '登入失敗次數過多，請稍後再試',
+    lockResetHint: '如果這是你的伺服器，可以執行以下命令清除登入鎖定：',
+    defaultLoginResetHint: '如需重置預設 admin 密碼，可以執行：',
     sessionExpired: '登入已過期，請重新登入',
     accessDenied: '你沒有權限存取此資源',
     passwordMismatch: '兩次密碼不一致',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -16,6 +16,8 @@ export default {
     credentialsRequired: '请输入用户名和密码',
     invalidCredentials: '用户名或密码错误',
     tooManyAttempts: '登录失败次数过多，请稍后重试',
+    lockResetHint: '如果这是你的服务器，可以执行以下命令清除登录锁定：',
+    defaultLoginResetHint: '如需重置默认 admin 密码，可以执行：',
     sessionExpired: '登录已过期，请重新登录',
     accessDenied: '你没有权限访问该资源',
     passwordMismatch: '两次密码不一致',

--- a/packages/client/src/views/LoginView.vue
+++ b/packages/client/src/views/LoginView.vue
@@ -12,6 +12,7 @@ const username = ref("");
 const password = ref("");
 const loading = ref(false);
 const errorMsg = ref("");
+const showLockResetHint = ref(false);
 
 // If already has a key, try to go to main page
 if (hasApiKey()) {
@@ -38,6 +39,7 @@ async function handlePasswordLogin() {
 
   loading.value = true;
   errorMsg.value = "";
+  showLockResetHint.value = false;
 
   try {
     const sessionToken = await loginWithPassword(username.value.trim(), password.value);
@@ -46,6 +48,7 @@ async function handlePasswordLogin() {
   } catch (err: any) {
     if (err.status === 429 || err.status === 503) {
       errorMsg.value = t("login.tooManyAttempts");
+      showLockResetHint.value = true;
     } else {
       errorMsg.value = err.message || t("login.invalidCredentials");
     }
@@ -82,6 +85,12 @@ async function handlePasswordLogin() {
         />
 
         <div v-if="errorMsg" class="login-error">{{ errorMsg }}</div>
+        <div v-if="showLockResetHint" class="login-lock-hint">
+          <span>{{ t("login.lockResetHint") }}</span>
+          <code>hermes-web-ui clear-login-locks --restart</code>
+          <span>{{ t("login.defaultLoginResetHint") }}</span>
+          <code>hermes-web-ui reset-default-login</code>
+        </div>
         <button type="submit" class="login-btn" :disabled="loading">
           {{ loading ? "..." : t("login.submit") }}
         </button>
@@ -172,6 +181,25 @@ async function handlePasswordLogin() {
   font-size: 13px;
   color: $error;
   text-align: left;
+}
+
+.login-lock-hint {
+  padding: 10px 12px;
+  border: 1px solid rgba(var(--warning-rgb), 0.35);
+  border-radius: $radius-sm;
+  background: rgba(var(--warning-rgb), 0.08);
+  color: $text-secondary;
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: left;
+
+  code {
+    display: block;
+    margin-top: 4px;
+    color: $text-primary;
+    font-family: $font-code;
+    word-break: break-all;
+  }
 }
 
 .login-btn {

--- a/packages/server/src/services/login-limiter.ts
+++ b/packages/server/src/services/login-limiter.ts
@@ -7,7 +7,7 @@ const APP_HOME = config.appHome
 const LOCK_FILE = join(APP_HOME, '.login-lock.json')
 
 // Per-IP settings
-const IP_MAX_FAILURES = 3
+const IP_MAX_FAILURES = 10
 const IP_FAILURE_WINDOW_MS = 15 * 60_000 // 15 minutes
 const IP_LOCK_DURATION_MS = 60 * 60_000 // 1 hour
 const IP_MAP_MAX_SIZE = 10000

--- a/tests/client/login-view.test.ts
+++ b/tests/client/login-view.test.ts
@@ -73,4 +73,25 @@ describe('LoginView password login', () => {
     expect(mockSetApiKey).not.toHaveBeenCalled()
     expect(mockReplace).not.toHaveBeenCalled()
   })
+
+  it('shows the reset command hint when the login IP is locked', async () => {
+    const err: any = new Error('Too many login attempts')
+    err.status = 429
+    mockLoginWithPassword.mockRejectedValue(err)
+    const wrapper = mount(LoginView)
+
+    const inputs = wrapper.findAll('input.login-input')
+    await inputs[0].setValue('admin')
+    await inputs[1].setValue('123456')
+    await wrapper.find('form.login-form').trigger('submit')
+
+    expect(wrapper.find('.login-error').text()).toBe('login.tooManyAttempts')
+    expect(wrapper.find('.login-lock-hint').text()).toContain('login.lockResetHint')
+    expect(wrapper.find('.login-lock-hint').text()).toContain('login.defaultLoginResetHint')
+    const commands = wrapper.findAll('.login-lock-hint code').map(command => command.text())
+    expect(commands).toEqual([
+      'hermes-web-ui clear-login-locks --restart',
+      'hermes-web-ui reset-default-login',
+    ])
+  })
 })

--- a/tests/server/login-limiter.test.ts
+++ b/tests/server/login-limiter.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function loadLimiter() {
+  vi.resetModules()
+  vi.doMock('fs/promises', () => ({
+    readFile: vi.fn().mockRejectedValue(new Error('ENOENT')),
+    writeFile: vi.fn(),
+    mkdir: vi.fn(),
+  }))
+  vi.doMock('fs', () => ({ writeFileSync: vi.fn() }))
+  vi.doMock('../../packages/server/src/config', () => ({
+    config: { appHome: '/tmp/hermes-web-ui-test' },
+  }))
+  return import('../../packages/server/src/services/login-limiter')
+}
+
+describe('login limiter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-24T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.doUnmock('fs/promises')
+    vi.doUnmock('fs')
+    vi.doUnmock('../../packages/server/src/config')
+    vi.resetModules()
+  })
+
+  it('locks password login on the tenth failed attempt from the same IP', async () => {
+    const limiter = await loadLimiter()
+    const ip = '192.0.2.10'
+
+    for (let i = 0; i < 9; i++) {
+      expect(limiter.checkPassword(ip)).toEqual({ allowed: true })
+      limiter.recordPasswordFailure(ip)
+    }
+
+    expect(limiter.checkPassword(ip)).toEqual({ allowed: true })
+    limiter.recordPasswordFailure(ip)
+
+    expect(limiter.checkPassword(ip)).toEqual({ allowed: false, status: 429 })
+    expect(limiter.getLockedIps()).toEqual([
+      expect.objectContaining({ ip, type: 'password', failures: 10 }),
+    ])
+  })
+
+  it('locks token auth on the tenth failed attempt from the same IP', async () => {
+    const limiter = await loadLimiter()
+    const ip = '192.0.2.20'
+
+    for (let i = 0; i < 9; i++) {
+      expect(limiter.checkToken(ip)).toEqual({ allowed: true })
+      limiter.recordTokenFailure(ip)
+    }
+
+    expect(limiter.checkToken(ip)).toEqual({ allowed: true })
+    limiter.recordTokenFailure(ip)
+
+    expect(limiter.checkToken(ip)).toEqual({ allowed: false, status: 429 })
+    expect(limiter.getLockedIps()).toEqual([
+      expect.objectContaining({ ip, type: 'token', failures: 10 }),
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- raise the per-IP login lock threshold from 3 failures to 10 failures
- show recovery commands on the login page when the server returns 429/503 for too many attempts
- include both lock clearing and default admin password reset commands in the hint
- add tests for limiter threshold and the login-page recovery hint

## Validation

- `npx vitest run tests/client/login-view.test.ts tests/client/i18n-coverage.test.ts tests/server/login-limiter.test.ts`
- `npx vue-tsc -b --pretty false`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `git diff --check`
