### PR TITLE
fix(web): keep session alive across transient socket disconnects (mobile background)

### DIFF
--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -583,6 +583,24 @@ export function startRunViaSocket(
 
   let closed = false
   const socket = connectChatRun(body.profile)
+
+  // Disconnect reasons that are TRANSIENT — the socket.io client will
+  // auto-reconnect (reconnection: true, attempts: Infinity). We must NOT
+  // tear down the session in these cases, otherwise mobile background
+  // suspension (iOS suspends the WebView in ~30s) leaves a sticky
+  // "Socket disconnected" error that survives even after the user
+  // reopens the app, because closed=true is permanent and event handlers
+  // get deleted from sessionEventHandlers.
+  //
+  // The agent run keeps streaming on the server side; once the client
+  // reconnects we re-join the session room via 'resume' (see below).
+  const TRANSIENT_DISCONNECT_REASONS = new Set<string>([
+    'transport close',
+    'transport error',
+    'ping timeout',
+    'parse error',
+  ])
+
   const handleSocketError = (err: Error) => {
     if (closed) return
     closed = true
@@ -592,13 +610,48 @@ export function startRunViaSocket(
   socket.once('connect_error', handleSocketError)
   const handleSocketDisconnect = (reason: string) => {
     if (closed || reason === 'io client disconnect') return
+    if (TRANSIENT_DISCONNECT_REASONS.has(reason)) {
+      // Stay alive — socket.io will reconnect; on 'connect' we re-emit 'resume'.
+      return
+    }
     handleSocketError(new Error(`Socket disconnected: ${reason}`))
   }
-  socket.once('disconnect', handleSocketDisconnect)
+  socket.on('disconnect', handleSocketDisconnect)
+
+  // After a transient disconnect, socket.io reconnects and fires 'connect'
+  // again. Re-join the session room and pull the latest state so the UI
+  // catches up on any messages/tool events that arrived while we were
+  // backgrounded.
+  //
+  // We don't listen for the 'resumed' response here — its main side effect
+  // (server-side socket.join) is what we need; the messages array would
+  // duplicate what the UI already has from initial load + delta stream.
+  // Components that want to refresh from the resumed payload should call
+  // resumeSession() directly.
+  let isFirstConnect = true
+  const handleSocketReconnect = () => {
+    if (closed) return
+    if (isFirstConnect) {
+      // Initial connect happens before this listener is registered most of
+      // the time, but covers the case where startRunViaSocket is called
+      // before the socket is connected. We don't want to send resume on
+      // the FIRST connect — only on RE-connects (after a disconnect).
+      isFirstConnect = false
+      return
+    }
+    socket.emit('resume', { session_id: sid, ...(body.profile ? { profile: body.profile } : {}) })
+  }
+  // Mark first-connect already passed if socket is already connected when
+  // we enter startRunViaSocket (the typical path).
+  if (socket.connected) {
+    isFirstConnect = false
+  }
+  socket.on('connect', handleSocketReconnect)
 
   const removeTerminalSocketListeners = () => {
     removeSocketListener(socket, 'connect_error', handleSocketError)
     removeSocketListener(socket, 'disconnect', handleSocketDisconnect)
+    removeSocketListener(socket, 'connect', handleSocketReconnect)
   }
 
   if (sessionEventHandlers.has(sid)) {

--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -601,9 +601,19 @@ export function startRunViaSocket(
     'parse error',
   ])
 
+  // Forward declaration so handleSocketError can call it. Defined below
+  // once all three listeners (connect_error, disconnect, connect) exist.
+  let removeTerminalSocketListeners: () => void = () => {}
+
   const handleSocketError = (err: Error) => {
     if (closed) return
     closed = true
+    // Remove our persistent listeners BEFORE surfacing the error. The
+    // chat-run socket is a module-level singleton (see chatRunSocket in
+    // connectChatRun), so without this cleanup every fatal-error path
+    // would leak the disconnect/connect closures onto the shared socket
+    // for the lifetime of the page.
+    removeTerminalSocketListeners()
     sessionEventHandlers.delete(sid)
     onError(err)
   }
@@ -648,7 +658,7 @@ export function startRunViaSocket(
   }
   socket.on('connect', handleSocketReconnect)
 
-  const removeTerminalSocketListeners = () => {
+  removeTerminalSocketListeners = () => {
     removeSocketListener(socket, 'connect_error', handleSocketError)
     removeSocketListener(socket, 'disconnect', handleSocketDisconnect)
     removeSocketListener(socket, 'connect', handleSocketReconnect)


### PR DESCRIPTION
## Summary

Mobile users — particularly on iOS Safari and the iOS Hermes Web UI app wrapper — see `Error: Socket disconnected: ping timeout` whenever they background the app for more than ~30s. The error stays sticky even after they reopen the app: the chat session won't update, run streaming is dead, and the only fix is to manually reload the session via the side panel.

The agent run on the server keeps streaming the whole time. The bug is purely client-side: every disconnect (transient or not) is treated as fatal and tears down the session's event handlers permanently.

## Repro

1. Start a long-running agent task (anything that takes 60s+) on Web UI from a phone.
2. Lock the phone or switch to another app for ~30s.
3. Return to Hermes Web UI.

**Before:** "Error: Socket disconnected: ping timeout" pinned to the message. No new tokens or tool events arrive even though the run is still going on the server. Selecting the same session from the sidebar manually does refresh — but only via an explicit `resumeSession()` call, not the running stream.

**After:** the in-progress run keeps streaming as if nothing happened. The user sees the latest tokens / tool events when they come back to the foreground.

## Root cause

In `packages/client/src/api/hermes/chat.ts::startRunViaSocket`, every `disconnect` event (other than `'io client disconnect'`) calls `handleSocketError`, which sets `closed = true`, deletes the session from `sessionEventHandlers`, and surfaces the error to the UI:

```ts
const handleSocketDisconnect = (reason: string) => {
  if (closed || reason === 'io client disconnect') return
  handleSocketError(new Error(`Socket disconnected: ${reason}`))
}
socket.once('disconnect', handleSocketDisconnect)
```

But socket.io is configured with `reconnection: true, reconnectionAttempts: Infinity` — it WILL come back. The client just refuses to recognize it. Once `closed = true`, the per-event guards (`if (closed) return`) drop every subsequent `message.delta`, `tool.completed`, etc. on the floor.

iOS makes this trivially reproducible because the OS suspends WebView JavaScript after ~30s in background, so `ping timeout` happens basically every time the user switches apps.

## Fix

Two-part client-only change in `packages/client/src/api/hermes/chat.ts`:

1. **Whitelist transient disconnect reasons.** `transport close`, `transport error`, `ping timeout`, `parse error` are now treated as recoverable: the handler logs nothing and lets socket.io reconnect on its own.
2. **Re-emit `resume` on reconnect.** When socket.io fires `connect` after a transient disconnect, the client emits `resume` so the server re-joins the session room (`socket.join('session:<sid>')`) and starts forwarding events to this socket again. The server-side `socket.on('resume')` handler already exists for explicit page-reload flows — we just hook into it.

The first-connect-vs-reconnect distinction uses `socket.connected` to skip emitting on the initial connect (when `startRunViaSocket` enters with an already-open socket, which is the typical path).

## Why no server change

The server side is fine. `_run_chat` in `hermes_bridge.py` is a worker thread that streams to whoever's currently in the `session:<sid>` room. The room membership is what gets lost on reconnect — and `socket.on('resume')` rebuilds it. Adding the client emit is the only missing piece.

## Behavior matrix

| Disconnect reason | Before | After |
|---|---|---|
| `ping timeout` (mobile bg) | Sticky error, dead stream | Silent reconnect, stream continues |
| `transport close` (network blip) | Sticky error | Silent reconnect |
| `transport error` (TLS/proxy hiccup) | Sticky error | Silent reconnect |
| `parse error` (rare) | Sticky error | Silent reconnect |
| `io server disconnect` (auth fail, kick) | Surfaced as error | Surfaced as error (unchanged) |
| `io client disconnect` (page nav, deliberate close) | Silent | Silent (unchanged) |

## Risk

Very low. The change exclusively narrows what gets treated as a fatal error — anything that's not in the transient list still surfaces exactly as before. socket.io's reconnect machinery is already configured for `Infinity` attempts, so the only thing missing was the client trusting it.

## Verification

Tested live on:
- iOS Safari → Web UI on remote VM behind nginx WebSocket proxy. Background app for 5 minutes → return → in-progress run still streaming.
- Android Chrome → same setup, same result.
- Brief Wi-Fi-to-cellular handoff → no visible interruption.
- Genuine server kick (kill the gateway PID mid-run) → still surfaces a fatal error in the UI as expected.

## Notes for reviewers

- No new dependencies, no API changes, no config changes.
- Server's `socket.on('resume')` handler is at `packages/server/src/services/hermes/run-chat/index.ts:211` — same handler used by the standalone `resumeSession()` export in chat.ts, so we share the proven path.
- We deliberately don't listen for the `resumed` reply in this code path — its main side effect (server-side `socket.join`) is what we need; the messages array would duplicate what the UI already has from the initial load + delta stream.
