### PR TITLE
fix: handle agent-bridge worker restart gracefully (no more 'unknown run' UI errors)

### DIFF
--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -430,7 +430,23 @@ export class AgentBridgeClient {
     let cursor = 0
     let eventCursor = 0
     for (;;) {
-      const chunk = await this.getOutput(runId, cursor, eventCursor, options)
+      let chunk: AgentBridgeOutput
+      try {
+        chunk = await this.getOutput(runId, cursor, eventCursor, options)
+      } catch (err) {
+        // The bridge worker keeps run state in-memory only — if it has been
+        // restarted (deploy, OOM, crash) any in-flight run becomes unknown.
+        // Surface a typed error so callers can handle gracefully instead of
+        // looping or showing the raw KeyError to users.
+        const message = err instanceof Error ? err.message : String(err ?? '')
+        if (/unknown run\b/i.test(message)) {
+          const restartErr: any = new Error(`bridge worker restarted; run ${runId} no longer tracked`)
+          restartErr.code = 'BRIDGE_RUN_LOST'
+          restartErr.runId = runId
+          throw restartErr
+        }
+        throw err
+      }
       cursor = chunk.cursor
       eventCursor = chunk.event_cursor
       if (chunk.delta || chunk.done || (chunk.events && chunk.events.length > 0)) yield chunk

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -44,6 +44,22 @@ function looksLikeAgentFailure(value: string): boolean {
     || /\b(?:401|403|429|500|502|503|504)\b/.test(value) && /\b(?:unauthorized|forbidden|rate limit|unavailable|failed|error)\b/i.test(value)
 }
 
+/**
+ * Detect "unknown run" errors raised when the agent bridge worker has been
+ * restarted (e.g. systemd unit restart, OOM, crash recovery). The Python
+ * bridge keeps run state purely in-memory, so any subsequent `get_output` /
+ * `get_result` poll on a run started before the restart returns
+ * `unknown run: <id>`. We translate this to a friendly message and treat
+ * the run as cleanly terminated so the UI can recover.
+ */
+export function isBridgeUnknownRunError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err ?? '')
+  return /unknown run\b/i.test(message)
+}
+
+const BRIDGE_RESTART_USER_MESSAGE =
+  'A conexão com o agente foi reiniciada (geralmente por um deploy ou reinicialização do serviço). Sua mensagem foi salva — basta enviar de novo para continuar.'
+
 export function bridgeTerminalError(chunk: Pick<AgentBridgeOutput, 'status' | 'error' | 'result'>): string | null {
   const result = chunk.result && typeof chunk.result === 'object' && !Array.isArray(chunk.result)
     ? chunk.result as Record<string, unknown>
@@ -309,6 +325,7 @@ export async function handleBridgeRun(
     if (state.activeRunMarker !== runMarker) return
     if (!state.isWorking) return
     const queueLen = state.queue?.length ?? 0
+    const bridgeRestarted = isBridgeUnknownRunError(err)
     state.isWorking = false
     state.isAborting = false
     state.profile = undefined
@@ -318,7 +335,15 @@ export async function handleBridgeRun(
     state.bridgePendingToolCallMarkup = undefined
     flushBridgePendingToDb(state, session_id)
     updateSessionStats(session_id)
-    const message = err instanceof Error ? err.message : String(err)
+    const rawMessage = err instanceof Error ? err.message : String(err)
+    const message = bridgeRestarted ? BRIDGE_RESTART_USER_MESSAGE : rawMessage
+    if (bridgeRestarted) {
+      bridgeLogger.warn({
+        sessionId: session_id,
+        runId: state.runId,
+        rawError: rawMessage,
+      }, '[chat-run-socket] bridge worker restarted mid-run; recovering session')
+    }
     const errUsage = await calcAndUpdateUsage(session_id, state, emit)
     const errContextTokens = await refreshFinalContextUsage({
       sessionId: session_id,


### PR DESCRIPTION
## Problema

Quando o `agent-bridge` Python worker reinicia (deploy via `systemctl restart`, OOM kill, crash recovery), todos os runs em vôo são perdidos porque o estado de runs é mantido **apenas em memória** em `hermes_bridge.py`:

```python
self._runs: dict[str, _RunRecord] = {}  # in-process only
```

O próximo poll de `get_output` retorna `KeyError: unknown run: <id>` que vaza direto pro usuário como:

```
Error: 'unknown run: 4c8bcf97879348b6bf41e164aa190283'
```

O que congela a sessão sem feedback útil — a mensagem do usuário sumiu visualmente, mas continua persistida no DB.

## Reprodução

1. Iniciar uma conversa via Web UI (`/api/chat-run` socket).
2. Em outro terminal, `systemctl restart hermes-web-ui` durante o run em andamento (ou `pkill -TERM -f hermes_bridge.py`).
3. Cliente recebe `Error: 'unknown run: <hex>'` e a sessão fica travada.

Logs do `bridge.log`:
```
{"level":40, "response":{"ok":false,"error":"'unknown run: 4c8bcf...'"}, "msg":"[agent-bridge-client] request rejected"}
```

## Fix

1. **`agent-bridge/client.ts → streamOutput`**: detecta a rejeição `unknown run` no poll e converte numa exceção tipada `BRIDGE_RUN_LOST` em vez de loopar ou propagar o `KeyError` cru.

2. **`run-chat/handle-bridge-run.ts`**: o catch reconhece a condição via `isBridgeUnknownRunError` e emite uma mensagem amigável em pt-BR explicando que a conexão foi reiniciada e que basta reenviar — preservando o estado da sessão.

3. **Logging estruturado**: `bridgeLogger.warn` registra `sessionId`/`runId`/erro original para o operador correlacionar com restarts.

A mensagem original do usuário já está no DB (persistida por `_prepersist_user_message` antes do `chat()` do bridge), então um único reenvio continua a conversa.

## Test plan

- [x] Rebuild + restart `hermes-web-ui.service` enquanto há um run ativo no Web UI mobile/desktop.
- [x] Confirmar que a UI agora mostra a mensagem amigável em vez de `unknown run: <hex>`.
- [x] Confirmar que reenviar a mesma mensagem funciona.

## Notes

- Não muda o comportamento do bridge Python — mantém estado em memória por design (latência baixa, sem disco).
- Só transforma a falha de "raw KeyError leak" em "soft fail recoverable".
- Solução durável também seria persistir `_runs` em SQLite no bridge, mas isso é mudança maior e não bloqueante pra esse fix.
