### PR TITLE
fix: don't drop pending tool-call-marker prefix on tool.started/run.done (text getting cut around tool calls)

### DIFF
--- a/packages/server/src/services/hermes/run-chat/bridge-delta.ts
+++ b/packages/server/src/services/hermes/run-chat/bridge-delta.ts
@@ -5,6 +5,27 @@ export interface BridgeDeltaFilterState {
 const TOOL_CALL_MARKER = '[Calling tool:'
 const MAX_PENDING_TOOL_MARKUP_LENGTH = 100_000
 
+/**
+ * Flush any partial-prefix that was held back waiting to see if it would
+ * become a `[Calling tool: ...]` marker. Call this when the streaming
+ * context guarantees no marker can follow (e.g. on `tool.started`,
+ * `tool.completed`, run completion, run failure, abort).
+ *
+ * Without this, deltas that legitimately end with `[`, `[C`, `[Ca`, ...,
+ * `[Calling tool` are silently dropped from the user-visible stream
+ * because the filter expected the buffered chars to either complete the
+ * marker (and be discarded) or be released by a follow-up delta — but
+ * follow-up deltas don't always come for the SAME assistant message.
+ *
+ * Returns the buffered text so callers can forward it to the client as
+ * a regular `message.delta` payload.
+ */
+export function flushPendingToolCallMarkup(state: BridgeDeltaFilterState): string {
+  const pending = state.bridgePendingToolCallMarkup || ''
+  state.bridgePendingToolCallMarkup = ''
+  return pending
+}
+
 function findToolMarkupEnd(text: string, start: number): number {
   let depth = 0
   let inString = false

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -30,7 +30,7 @@ import { summarizeToolArguments } from './response-utils'
 import type { ContentBlock, SessionState } from './types'
 import type { ChatMessage } from '../../../lib/context-compressor'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
-import { filterBridgeToolCallMarkupDelta } from './bridge-delta'
+import { filterBridgeToolCallMarkupDelta, flushPendingToolCallMarkup } from './bridge-delta'
 
 const BRIDGE_USAGE_FLUSH_DELAY_MS = 200
 
@@ -464,6 +464,26 @@ async function applyBridgeChunkAsync(
         usage,
       )
     } else if (evType === 'tool.started') {
+      // Flush any partial tool-call-marker prefix that was held back by
+      // the markup filter. Without this, deltas ending in `[`, `[C`,
+      // `[Ca`, etc. are silently dropped because no follow-up delta will
+      // come for this assistant message — the next chunk is the tool call
+      // itself. See bridge-delta.ts for full rationale.
+      const pendingMarkup = flushPendingToolCallMarkup(state)
+      if (pendingMarkup) {
+        state.bridgeOutput = (state.bridgeOutput || '') + pendingMarkup
+        state.bridgePendingAssistantContent = (state.bridgePendingAssistantContent || '') + pendingMarkup
+        const last = [...state.messages].reverse().find(m => m.runMarker === runMarker && m.role === 'assistant' && m.finish_reason == null)
+        if (last) {
+          last.content += pendingMarkup
+        }
+        emit('message.delta', {
+          event: 'message.delta',
+          run_id: chunk.run_id,
+          delta: pendingMarkup,
+          output: state.bridgeOutput,
+        })
+      }
       flushBridgePendingToDb(state, sessionId, runMarker)
       const toolName = (ev.tool_name as string) || ''
       const args = ev.args as Record<string, unknown> | undefined
@@ -715,6 +735,24 @@ async function applyBridgeChunkAsync(
   }
 
   flushBridgePendingToDb(state, sessionId)
+  // If the run terminated while we still had a partial tool-call-marker
+  // prefix buffered, flush it to the user-visible stream now. Discarding
+  // it (which the line below was doing implicitly) silently drops the
+  // final characters of the assistant message.
+  const pendingFinalMarkup = flushPendingToolCallMarkup(state)
+  if (pendingFinalMarkup) {
+    state.bridgeOutput = (state.bridgeOutput || '') + pendingFinalMarkup
+    const last = [...state.messages].reverse().find(m => m.runMarker === runMarker && m.role === 'assistant' && m.finish_reason == null)
+    if (last) {
+      last.content += pendingFinalMarkup
+    }
+    emit('message.delta', {
+      event: 'message.delta',
+      run_id: chunk.run_id,
+      delta: pendingFinalMarkup,
+      output: state.bridgeOutput,
+    })
+  }
   state.bridgePendingToolCallMarkup = undefined
   updateSessionStats(sessionId)
   await delay(BRIDGE_USAGE_FLUSH_DELAY_MS)


### PR DESCRIPTION
## Sintoma

No Hermes Web UI rodando contra o agente CLI via bridge, todo run que invoca uma ferramenta deixa cortes visíveis no texto do assistente, sempre na fronteira de `tool.started` e na finalização do run. De 1 a 13 caracteres simplesmente desaparecem do stream visto pelo usuário.

Exemplos reais coletados de uma conversa contínua de 6h+ com várias chamadas a `terminal`, `read_file`, `write_file`, `patch`, `process`:

- `"ut v0.6.0 -b fix/"` (esperado: `"git checkout v0.6.0 -b fix/..."`)
- `"Aguar"` (esperado: `"Aguardando o build..."`)
- `"ar comando a co"` (esperado: cortado dos dois lados em volta de chamada `terminal`)
- `"ick \`925b9b5\`)\`. Esse branch está correto pro PR"` (início cortado depois de chamada `git push`)

O usuário descreveu o padrão como _"os cortes acontecem sempre depois de alguma chamada de ferramenta — terminal, read, write"_. Bingo: causa raiz exatamente nesse limite.

## Causa raiz

`packages/server/src/services/hermes/run-chat/bridge-delta.ts → filterBridgeToolCallMarkupDelta`

O filtro segura intencionalmente qualquer texto que termine em prefixo parcial do marcador `[Calling tool:` (`[`, `[C`, `[Ca`, ..., `[Calling tool`) num buffer `state.bridgePendingToolCallMarkup`, esperando ver se a próxima delta:

- Completa o marcador → o bloco inteiro é descartado (correto: o user não vê o markup interno do bridge).
- NÃO completa o marcador → os chars buferizados são liberados na próxima delta.

A premissa "a próxima delta libera o buffer" QUEBRA em dois cenários:

### 1. `tool.started` interrompe o stream de texto

Quando o modelo emite `Vou executar [` e o próximo evento do bridge é `tool.started` (a ferramenta foi de fato chamada), NÃO vem outra delta de texto pra essa mensagem do assistente — o stream pula direto pro tool call. O `[` (e qualquer prefixo de até 13 chars) fica preso no buffer até ser silenciosamente sobrescrito no run-done.

### 2. Run completion descarta o buffer sem flush

`packages/server/src/services/hermes/run-chat/handle-bridge-run.ts:743` fazia:

```ts
state.bridgePendingToolCallMarkup = undefined
```

…sem antes verificar se havia conteúdo pendente. Se o último delta da run terminava em `[` ou similar, esses chars eram descartados na finalização também.

## Fix

Patch cirúrgico, sem mudar a lógica de detecção do marcador:

1. **`bridge-delta.ts`**: novo helper `flushPendingToolCallMarkup(state)` que devolve o buffer pendente e zera o estado. Nada mais.

2. **`handle-bridge-run.ts → applyBridgeChunkAsync` branch `tool.started`**: chama `flushPendingToolCallMarkup` ANTES de gravar a chamada de ferramenta. Se houver buffer pendente, ele é:
   - Anexado à mensagem aberta do assistente (`messages[].content`)
   - Emitido como `message.delta` normal pro cliente
   - Adicionado ao `bridgeOutput` e `bridgePendingAssistantContent` pra coerência com o flush pro DB

3. **`handle-bridge-run.ts` → run-done**: mesma lógica de flush ANTES de zerar o buffer.

## Por que não muda comportamento dos casos válidos

Se o conteúdo buferizado for de fato o início de um `[Calling tool: ...]` real que ainda não completou no chunk atual, o ramo `markerIdx >= 0` do filtro continua tratando isso na próxima delta — o flush só acontece nos pontos onde sabemos que NÃO virá mais delta de texto pra mesma mensagem (`tool.started` e run-done).

A única mudança comportamental: casos órfãos (texto que termina com `[` mas não vira marcador) deixam de ser silenciosamente descartados. Que é exatamente o bug.

## Test plan

Manual:

- [x] Rebuild + restart `hermes-web-ui.service`
- [x] Conversa longa de teste com múltiplas chamadas a `terminal`, `patch`, `write_file`, `process` — o usuário confirmou: _"Não tem nenhuma perda ou quebra no texto"_

Automatizado (recomendado, não incluído neste PR):

- Test em `bridge-delta.spec.ts` cobrindo:
  - Texto terminando em `[` sem follow-up → `flushPendingToolCallMarkup` devolve `[`
  - Texto terminando em `[Calling tool` sem follow-up → flush devolve `[Calling tool`
  - Texto contendo `[Calling tool: terminal]\n` real → marcador detectado e descartado
  - Texto chunked que cruza fronteira do marcador → marcador detectado entre chunks

## Files changed

- `packages/server/src/services/hermes/run-chat/bridge-delta.ts` (+21, helper exportado)
- `packages/server/src/services/hermes/run-chat/handle-bridge-run.ts` (+39, dois pontos de flush)
