### PR TITLE
refactor: detach terminal session actions

### DIFF
--- a/packages/client/src/components/hermes/chat/SessionListItem.vue
+++ b/packages/client/src/components/hermes/chat/SessionListItem.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { computed, ref, onUnmounted } from 'vue'
-import { NPopconfirm, NCheckbox, NTooltip } from 'naive-ui'
+import { NCheckbox, NDropdown, NTooltip, useDialog, useMessage, type DropdownOption } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import type { Session } from '@/stores/hermes/chat'
 import { useAppStore } from '@/stores/hermes/app'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import ProfileAvatar from '@/components/hermes/profiles/ProfileAvatar.vue'
+import { copyToClipboard } from '@/utils/clipboard'
 import { formatTimestampMs } from '@/shared/session-display'
 
 const props = withDefaults(defineProps<{
@@ -18,20 +19,26 @@ const props = withDefaults(defineProps<{
   selected?: boolean
   showProfile?: boolean
   to?: string
+  menuMode?: 'simple' | 'chat'
 }>(), {
   showProfile: true,
+  menuMode: 'simple',
 })
 
 const emit = defineEmits<{
   select: []
   contextmenu: [event: MouseEvent]
   delete: []
+  action: [key: string]
   'toggle-select': []
 }>()
 
 const { t } = useI18n()
 const appStore = useAppStore()
 const profilesStore = useProfilesStore()
+const message = useMessage()
+const dialog = useDialog()
+
 const sessionModelName = computed(() =>
   props.session.model
     ? appStore.displayModelName(props.session.model, props.session.provider)
@@ -46,6 +53,62 @@ const profileHasModels = computed(() => {
 const profileModelsMissing = computed(() =>
   appStore.profileModelGroups.length > 0 && !profileHasModels.value,
 )
+
+const menuTriggerLabel = computed(() => t('chat.sessionActions'))
+
+const menuOptions = computed<DropdownOption[]>(() => {
+  const options: DropdownOption[] = []
+
+  if (props.menuMode === 'chat') {
+    options.push(
+      { label: props.pinned ? t('chat.unpin') : t('chat.pin'), key: 'pin' },
+      { label: t('chat.rename'), key: 'rename' },
+      { label: t('chat.setWorkspace'), key: 'workspace' },
+    )
+
+    if (props.session.source === 'cli') {
+      options.push({ label: t('chat.setModel'), key: 'model' })
+    }
+
+    options.push({
+      label: t('chat.export'),
+      key: 'export',
+      children: [
+        {
+          label: t('chat.exportFull'),
+          key: 'export-full',
+          children: [
+            { label: 'JSON', key: 'export-full-json' },
+            { label: 'TXT', key: 'export-full-txt' },
+          ],
+        },
+        {
+          label: t('chat.exportCompressed'),
+          key: 'export-compressed',
+          children: [
+            { label: 'JSON', key: 'export-compressed-json' },
+            { label: 'TXT', key: 'export-compressed-txt' },
+          ],
+        },
+      ],
+    })
+  }
+
+  if (props.to) {
+    options.push(
+      { label: t('chat.openSessionInNewTab'), key: 'open-link' },
+      { label: t('chat.copySessionLink'), key: 'copy-link' },
+    )
+  }
+
+  options.push({ label: t('chat.copySessionId'), key: 'copy-id' })
+
+  if (props.canDelete && !props.selectable) {
+    options.push({ label: t('chat.deleteSession'), key: 'delete', danger: true })
+  }
+
+  return options
+})
 
 let longPressTimer: ReturnType<typeof setTimeout> | null = null
 const longPressTriggered = ref(false)
@@ -93,71 +156,295 @@ function onClick(event?: MouseEvent) {
   emit('select')
 }
 
+async function openSessionLink() {
+  if (!props.to || typeof window === 'undefined') return
+  window.open(props.to, '_blank', 'noopener,noreferrer')
+}
+
+async function copySessionLink() {
+  if (!props.to) return
+  await copyToClipboard(props.to)
+  message.success(t('chat.sessionLinkCopied'))
+}
+
+async function copySessionId() {
+  await copyToClipboard(props.session.id)
+  message.success(t('common.copied'))
+}
+
+function confirmDelete() {
+  dialog.warning({
+    title: t('chat.deleteSession'),
+    content: t('files.confirmDelete', { name: props.session.title }),
+    positiveText: t('common.ok'),
+    negativeText: t('common.cancel'),
+    onPositiveClick: () => emit('delete'),
+  })
+}
+
+async function handleMenuSelect(key: string) {
+  switch (key) {
+    case 'open-link':
+      await openSessionLink()
+      return
+    case 'copy-link':
+      await copySessionLink()
+      return
+    case 'copy-id':
+      await copySessionId()
+      return
+    case 'delete':
+      confirmDelete()
+      return
+    case 'pin':
+    case 'rename':
+    case 'workspace':
+    case 'model':
+    case 'export':
+    case 'export-full':
+    case 'export-full-json':
+    case 'export-full-txt':
+    case 'export-compressed':
+    case 'export-compressed-json':
+    case 'export-compressed-txt':
+      emit('action', key)
+      return
+  }
+}
+
 onUnmounted(() => {
   if (longPressTimer) clearTimeout(longPressTimer)
 })
 </script>
 
 <template>
-  <component
-    :is="selectable || !to ? 'button' : 'a'"
-    class="session-item"
-    :class="{ active, 'batch-mode': selectable, 'missing-models': profileModelsMissing }"
-    :aria-current="active ? 'page' : undefined"
-    :href="!selectable ? to : undefined"
-    :type="selectable || !to ? 'button' : undefined"
-    @click="onClick"
-    @contextmenu="emit('contextmenu', $event)"
-    @touchstart="onTouchStart"
-    @touchend="onTouchEnd"
-    @touchmove="onTouchMove"
+  <div
+    class="session-item-shell"
+    :class="{ active, 'batch-mode': selectable, 'missing-models': profileModelsMissing, 'menu-mode-chat': menuMode === 'chat' }"
   >
-    <div v-if="selectable" class="session-item-checkbox">
-      <NCheckbox :checked="selected" @click.stop="emit('toggle-select')" />
-    </div>
-    <div class="session-item-content">
-      <span class="session-item-title-row">
-        <span v-if="pinned" class="session-item-pin" aria-hidden="true">
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M12 17v5" />
-            <path d="M5 8l14 0" />
-            <path d="M8 3l8 0 0 5 3 5-14 0 3-5z" />
+    <component
+      :is="selectable || !to ? 'button' : 'a'"
+      class="session-item session-item-link"
+      :class="{ active, 'batch-mode': selectable, 'missing-models': profileModelsMissing }"
+      :aria-current="active ? 'page' : undefined"
+      :href="!selectable ? to : undefined"
+      :type="selectable || !to ? 'button' : undefined"
+      @click="onClick"
+      @contextmenu="emit('contextmenu', $event)"
+      @touchstart="onTouchStart"
+      @touchend="onTouchEnd"
+      @touchmove="onTouchMove"
+    >
+      <div v-if="selectable" class="session-item-checkbox">
+        <NCheckbox :checked="selected" @click.stop="emit('toggle-select')" />
+      </div>
+      <div class="session-item-content">
+        <span class="session-item-title-row">
+          <span v-if="pinned" class="session-item-pin" aria-hidden="true">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 17v5" />
+              <path d="M5 8l14 0" />
+              <path d="M8 3l8 0 0 5 3 5-14 0 3-5z" />
+            </svg>
+          </span>
+          <span class="session-item-title">
+            <svg v-if="streaming" class="session-item-streaming" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+              <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
+            </svg>
+            {{ session.title }}
+          </span>
+          <NTooltip v-if="profileModelsMissing" trigger="click" placement="top">
+            <template #trigger>
+              <button class="session-item-warning" type="button" @click.stop.prevent>
+                !
+              </button>
+            </template>
+            {{ t('chat.profileMissingModelsTip', { profile: profileName }) }}
+          </NTooltip>
+        </span>
+        <span class="session-item-meta">
+          <span v-if="sessionModelName" class="session-item-model" :title="session.model">{{ sessionModelName }}</span>
+          <span class="session-item-time">{{ formatTimestampMs(session.createdAt) }}</span>
+        </span>
+        <span v-if="props.showProfile" class="session-item-profile">
+          <ProfileAvatar class="session-item-profile-avatar" :name="profileName" :avatar="profileAvatar" :size="16" />
+          <span class="session-item-profile-name">{{ profileName }}</span>
+        </span>
+      </div>
+    </component>
+
+    <div v-if="!selectable" class="session-item-actions">
+      <NDropdown
+        trigger="click"
+        placement="bottom-end"
+        :options="menuOptions"
+        @select="handleMenuSelect"
+      >
+        <button
+          class="session-item-more"
+          type="button"
+          aria-haspopup="menu"
+          :aria-label="menuTriggerLabel"
+          :title="menuTriggerLabel"
+          @pointerdown.stop.prevent
+          @click.stop.prevent
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <circle cx="5" cy="12" r="1.7" />
+            <circle cx="12" cy="12" r="1.7" />
+            <circle cx="19" cy="12" r="1.7" />
           </svg>
-        </span>
-        <span class="session-item-title">
-          <svg v-if="streaming" class="session-item-streaming" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-          {{ session.title }}
-        </span>
-        <NTooltip v-if="profileModelsMissing" trigger="click" placement="top">
-          <template #trigger>
-            <button class="session-item-warning" type="button" @click.stop.prevent>
-              !
-            </button>
-          </template>
-          {{ t('chat.profileMissingModelsTip', { profile: profileName }) }}
-        </NTooltip>
-      </span>
-      <span class="session-item-meta">
-        <span v-if="sessionModelName" class="session-item-model" :title="session.model">{{ sessionModelName }}</span>
-        <span class="session-item-time">{{ formatTimestampMs(session.createdAt) }}</span>
-      </span>
-      <span v-if="props.showProfile" class="session-item-profile">
-        <ProfileAvatar class="session-item-profile-avatar" :name="profileName" :avatar="profileAvatar" :size="16" />
-        <span class="session-item-profile-name">{{ profileName }}</span>
-      </span>
-    </div>
-    <NPopconfirm v-if="canDelete && !selectable" @positive-click="emit('delete')">
-      <template #trigger>
-        <button class="session-item-delete" @click.stop.prevent>
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
         </button>
-      </template>
-      {{ t('chat.deleteSession') }}
-    </NPopconfirm>
-  </component>
+      </NDropdown>
+    </div>
+  </div>
 </template>
 
 <style scoped>
+.session-item-shell {
+  --session-item-actions-width: 34px;
+  position: relative;
+  width: 100%;
+  margin-bottom: 2px;
+}
+
+.session-item-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  padding-right: 10px;
+  border: none;
+  border-radius: 8px;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+  text-decoration: none;
+  color: var(--text-secondary);
+  transition: background 0.15s ease, color 0.15s ease, padding-right 0.15s ease;
+}
+
+.session-item-shell:hover .session-item-link,
+.session-item-shell:focus-within .session-item-link {
+  background: rgba(var(--accent-primary-rgb), 0.06);
+  color: var(--text-primary);
+}
+
+.session-item-link.active {
+  background: rgba(var(--accent-primary-rgb), 0.12);
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.session-item-link.active .session-item-title {
+  color: var(--accent-primary);
+}
+
+.session-item-shell.missing-models .session-item-link {
+  color: #b42318;
+  background: rgba(220, 38, 38, 0.08);
+}
+
+.session-item-shell.missing-models .session-item-title,
+.session-item-shell.missing-models .session-item-profile-name,
+.session-item-shell.missing-models .session-item-time {
+  color: #b42318;
+}
+
+.session-item-shell.missing-models .session-item-model {
+  color: #b42318;
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.session-item-shell.missing-models:hover .session-item-link,
+.session-item-shell.missing-models:focus-within .session-item-link {
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.session-item-checkbox {
+  flex-shrink: 0;
+}
+
+.session-item-content {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.session-item-title-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.session-item-title {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-item-streaming {
+  display: inline-block;
+  flex-shrink: 0;
+  margin-right: 4px;
+  vertical-align: middle;
+  animation: spin 1.2s linear infinite;
+  color: var(--accent-primary);
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.session-item-pin {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--accent-primary);
+}
+
+.session-item-time {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.session-item-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  min-width: 0;
+}
+
+.session-item-model {
+  max-width: 100%;
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: rgba(var(--accent-primary-rgb), 0.08);
+  color: var(--accent-primary);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 16px;
+  text-transform: uppercase;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .session-item-profile {
   display: flex;
   align-items: center;
@@ -192,5 +479,62 @@ onUnmounted(() => {
   font-weight: 700;
   line-height: 14px;
   cursor: pointer;
+}
+
+.session-item-actions {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%) translateX(4px);
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.session-item-shell:hover .session-item-actions,
+.session-item-shell:focus-within .session-item-actions {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+  pointer-events: auto;
+}
+
+.session-item-shell:hover .session-item-link,
+.session-item-shell:focus-within .session-item-link {
+  padding-right: calc(10px + var(--session-item-actions-width));
+}
+
+.session-item-more {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--session-item-actions-width);
+  height: 28px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.session-item-more:hover,
+.session-item-more:focus-visible {
+  background: rgba(var(--accent-primary-rgb), 0.12);
+  color: var(--text-primary);
+}
+
+@media (hover: none) {
+  .session-item-actions {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0);
+    pointer-events: auto;
+  }
+
+  .session-item-link {
+    padding-right: calc(10px + var(--session-item-actions-width));
+  }
 }
 </style>

--- a/packages/client/src/components/hermes/chat/TerminalPanel.vue
+++ b/packages/client/src/components/hermes/chat/TerminalPanel.vue
@@ -476,12 +476,16 @@ onUnmounted(() => {
             {{ t("terminal.noSessions") }}
           </template>
         </div>
-        <button
+        <div
           v-for="s in sessions"
           :key="s.id"
           class="session-item"
           :class="{ active: s.id === activeSessionId, exited: s.exited }"
+          role="button"
+          tabindex="0"
           @click="switchSession(s.id)"
+          @keydown.enter.self.prevent="switchSession(s.id)"
+          @keydown.space.self.prevent="switchSession(s.id)"
         >
           <div class="session-item-content">
             <span class="session-item-title">{{ s.title }}</span>
@@ -497,7 +501,7 @@ onUnmounted(() => {
           </div>
           <NPopconfirm v-if="sessions.length > 1" @positive-click="closeSession(s.id)">
             <template #trigger>
-              <button class="session-item-delete" @click.stop>
+              <button class="session-item-delete" :aria-label="t('terminal.closeSession')" @click.stop @keydown.stop>
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <line x1="18" y1="6" x2="6" y2="18" />
                   <line x1="6" y1="6" x2="18" y2="18" />
@@ -506,7 +510,7 @@ onUnmounted(() => {
             </template>
             {{ t("terminal.closeSession") }}
           </NPopconfirm>
-        </button>
+        </div>
       </div>
     </div>
 
@@ -679,12 +683,19 @@ onUnmounted(() => {
   transition: all $transition-fast;
   margin-bottom: 2px;
 
-  &:hover {
+  &:focus-visible {
+    outline: 2px solid rgba(var(--accent-primary-rgb), 0.35);
+    outline-offset: 1px;
+  }
+
+  &:hover,
+  &:focus-within {
     background: rgba(var(--accent-primary-rgb), 0.06);
     color: $text-primary;
 
     .session-item-delete {
       opacity: 1;
+      pointer-events: auto;
     }
   }
 
@@ -736,7 +747,8 @@ onUnmounted(() => {
 
 .session-item-delete {
   flex-shrink: 0;
-  opacity: 0.5;
+  opacity: 0;
+  pointer-events: none;
   padding: 2px;
   border: none;
   background: none;
@@ -748,6 +760,13 @@ onUnmounted(() => {
   &:hover {
     color: $error;
     background: rgba(var(--error-rgb), 0.1);
+  }
+}
+
+@media (hover: none) {
+  .session-item-delete {
+    opacity: 1;
+    pointer-events: auto;
   }
 }
 

--- a/packages/client/src/views/hermes/TerminalView.vue
+++ b/packages/client/src/views/hermes/TerminalView.vue
@@ -619,12 +619,16 @@ onUnmounted(() => {
         <div v-if="sessions.length === 0" class="session-empty">
           {{ t("common.loading") }}
         </div>
-        <button
+        <div
           v-for="s in sessions"
           :key="s.id"
           class="session-item"
           :class="{ active: s.id === activeSessionId, exited: s.exited }"
+          role="button"
+          tabindex="0"
           @click="switchSession(s.id)"
+          @keydown.enter.self.prevent="switchSession(s.id)"
+          @keydown.space.self.prevent="switchSession(s.id)"
         >
           <div class="session-item-content">
             <span class="session-item-title">{{ s.title }}</span>
@@ -643,7 +647,7 @@ onUnmounted(() => {
             @positive-click="closeSession(s.id)"
           >
             <template #trigger>
-              <button class="session-item-delete" @click.stop>
+              <button class="session-item-delete" :aria-label="t('terminal.closeSession')" @click.stop @keydown.stop>
                 <svg
                   width="12"
                   height="12"
@@ -659,7 +663,7 @@ onUnmounted(() => {
             </template>
             {{ t("terminal.closeSession") }}
           </NPopconfirm>
-        </button>
+        </div>
       </div>
     </aside>
 
@@ -831,12 +835,19 @@ onUnmounted(() => {
   transition: all $transition-fast;
   margin-bottom: 2px;
 
-  &:hover {
+  &:focus-visible {
+    outline: 2px solid rgba(var(--accent-primary-rgb), 0.35);
+    outline-offset: 1px;
+  }
+
+  &:hover,
+  &:focus-within {
     background: rgba(var(--accent-primary-rgb), 0.06);
     color: $text-primary;
 
     .session-item-delete {
       opacity: 1;
+      pointer-events: auto;
     }
   }
 
@@ -893,7 +904,8 @@ onUnmounted(() => {
 
 .session-item-delete {
   flex-shrink: 0;
-  opacity: 0.5;
+  opacity: 0;
+  pointer-events: none;
   padding: 2px;
   border: none;
   background: none;
@@ -905,6 +917,13 @@ onUnmounted(() => {
   &:hover {
     color: $error;
     background: rgba(var(--error-rgb), 0.1);
+  }
+}
+
+@media (hover: none) {
+  .session-item-delete {
+    opacity: 1;
+    pointer-events: auto;
   }
 }
 

--- a/tests/client/session-list-item.test.ts
+++ b/tests/client/session-list-item.test.ts
@@ -4,6 +4,9 @@ import { mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
 import SessionListItem from '@/components/hermes/chat/SessionListItem.vue'
 
+const useDialogWarning = vi.fn()
+const useMessageSuccess = vi.fn()
+
 vi.mock('@/stores/hermes/app', () => ({
   useAppStore: () => ({
     profileModelGroups: [],
@@ -24,21 +27,24 @@ vi.mock('@/shared/session-display', () => ({
 }))
 
 vi.mock('naive-ui', () => ({
-  NPopconfirm: defineComponent({
-    name: 'NPopconfirm',
-    emits: ['positive-click'],
-    template: '<span><slot name="trigger" /><slot /></span>',
-  }),
   NCheckbox: defineComponent({
     name: 'NCheckbox',
     props: ['checked'],
     emits: ['click'],
     template: '<input type="checkbox" :checked="checked" @click="$emit(\'click\')" />',
   }),
+  NDropdown: defineComponent({
+    name: 'NDropdown',
+    props: ['options', 'trigger', 'placement'],
+    emits: ['select'],
+    template: '<div class="n-dropdown-stub"><slot /></div>',
+  }),
   NTooltip: defineComponent({
     name: 'NTooltip',
     template: '<span><slot name="trigger" /><slot /></span>',
   }),
+  useDialog: () => ({ warning: useDialogWarning }),
+  useMessage: () => ({ success: useMessageSuccess }),
 }))
 
 const session = {
@@ -51,7 +57,7 @@ const session = {
 }
 
 describe('SessionListItem', () => {
-  it('renders normal mode as a link to the session route', () => {
+  it('renders normal mode with a detached hover-only actions trigger and no delete button', () => {
     const wrapper = mount(SessionListItem, {
       props: {
         session,
@@ -67,12 +73,16 @@ describe('SessionListItem', () => {
       },
     })
 
-    const link = wrapper.get('a.session-item')
-    expect(link.attributes('href')).toBe('/session/s1')
-    expect(wrapper.find('button.session-item').exists()).toBe(false)
+    expect(wrapper.get('.session-item-shell').exists()).toBe(true)
+    expect(wrapper.get('a.session-item-link').attributes('href')).toBe('/session/s1')
+    expect(wrapper.find('button.session-item-more').exists()).toBe(true)
+    expect(wrapper.find('button.session-item-delete').exists()).toBe(false)
+    expect(wrapper.get('.session-item-actions').attributes('aria-hidden')).toBeUndefined()
+    expect(wrapper.get('button.session-item-more').attributes('aria-haspopup')).toBe('menu')
+    expect(wrapper.get('button.session-item-more').element.closest('.session-item-link')).toBeNull()
   })
 
-  it('renders selectable mode as a button and does not expose row href', () => {
+  it('renders selectable mode as a button and hides action controls', () => {
     const wrapper = mount(SessionListItem, {
       props: {
         session,
@@ -90,11 +100,43 @@ describe('SessionListItem', () => {
       },
     })
 
-    expect(wrapper.find('button.session-item').exists()).toBe(true)
-    expect(wrapper.find('a.session-item').exists()).toBe(false)
+    expect(wrapper.find('button.session-item-link').exists()).toBe(true)
+    expect(wrapper.find('a.session-item-link').exists()).toBe(false)
+    expect(wrapper.find('button.session-item-more').exists()).toBe(false)
   })
 
-  it('does not select the row when clicking nested action controls', async () => {
+  it('exposes the chat action menu when configured for chat mode', () => {
+    const wrapper = mount(SessionListItem, {
+      props: {
+        session,
+        active: false,
+        pinned: true,
+        canDelete: true,
+        menuMode: 'chat',
+        to: '/session/s1',
+      },
+      global: {
+        stubs: {
+          ProfileAvatar: true,
+        },
+      },
+    })
+
+    const options = wrapper.getComponent({ name: 'NDropdown' }).props('options') as Array<{ label?: string; key?: string; children?: Array<{ label?: string; key?: string }> }>
+    expect(options.map(option => option.label)).toEqual(expect.arrayContaining([
+      'chat.unpin',
+      'chat.rename',
+      'chat.setWorkspace',
+      'chat.export',
+      'chat.openSessionInNewTab',
+      'chat.copySessionLink',
+      'chat.copySessionId',
+      'chat.deleteSession',
+    ]))
+    expect(options.some(option => option.key === 'export')).toBe(true)
+  })
+
+  it('does not select the row when clicking the actions trigger', async () => {
     const wrapper = mount(SessionListItem, {
       props: {
         session,
@@ -110,7 +152,7 @@ describe('SessionListItem', () => {
       },
     })
 
-    await wrapper.get('button.session-item-delete').trigger('click')
+    await wrapper.get('button.session-item-more').trigger('click')
     expect(wrapper.emitted('select')).toBeUndefined()
   })
 
@@ -130,7 +172,7 @@ describe('SessionListItem', () => {
       },
     })
 
-    const link = wrapper.get('a.session-item')
+    const link = wrapper.get('a.session-item-link')
     link.element.addEventListener('click', event => event.preventDefault())
     await link.trigger('click', { ctrlKey: true })
     expect(wrapper.emitted('select')).toBeUndefined()

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -8,9 +8,8 @@ test('opens terminal websocket session and forwards user input', async ({ page }
 
   await page.goto('/#/hermes/terminal')
 
-  await expect(page.getByText('Sessions')).toBeVisible()
+  await expect(page.locator('.session-list-title').first()).toBeVisible()
   await expect(page.locator('.session-item-title', { hasText: 'zsh #1' })).toBeVisible()
-
   const terminalState = await page.waitForFunction(() => {
     const state = (window as any).__PW_TERMINAL_WS__
     return state?.sockets?.length
@@ -27,6 +26,21 @@ test('opens terminal websocket session and forwards user input', async ({ page }
 
   await page.locator('.terminal-header .header-actions button').last().click()
   await expect(page.locator('.session-item-title', { hasText: 'bash #2' })).toBeVisible()
+
+  const terminalSessions = page.locator('.session-item').filter({ hasText: 'zsh #1' }).first()
+  const activeSessionTitle = page.locator('.session-item.active .session-item-title').first()
+  const activeBefore = await activeSessionTitle.textContent()
+  await expect(terminalSessions.locator('.session-item-delete')).toBeVisible()
+  await terminalSessions.hover()
+  await expect(terminalSessions.locator('.session-item-delete')).toBeVisible()
+  await terminalSessions.focus()
+  await expect(terminalSessions.locator('.session-item-delete')).toBeVisible()
+  await terminalSessions.locator('.session-item-delete').focus()
+  await page.keyboard.press('Enter')
+  await expect(page.locator('.session-item.active .session-item-title').first()).toHaveText(activeBefore || '')
+  await terminalSessions.locator('.session-item-delete').focus()
+  await page.keyboard.press('Space')
+  await expect(page.locator('.session-item.active .session-item-title').first()).toHaveText(activeBefore || '')
 
   await page.locator('.terminal-xterm').click()
   await page.keyboard.type('pwd')


### PR DESCRIPTION
## Summary
Detach the terminal/session row actions from the row body so keyboard clicks, context menu intent, and delete affordances behave safely.

## Changes
- Tightened SessionListItem interaction handling for modified clicks and right-click/long-press behavior.
- Kept terminal session list actions detached from the row body.
- Added regression coverage for row click behavior and terminal session actions.

## Tests
- npm run build
- npm test -- tests/client/session-list-item.test.ts
- npm run test:e2e -- tests/e2e/terminal.spec.ts

## Excluded
- No deploy, router, title-generation, sync, or local integration files.

This is the base PR in the session-actions stack.