### PR TITLE
refactor: share session action menu

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -12,8 +12,8 @@ import {
   NSelect,
   NTooltip,
   NPopconfirm,
+  useDialog,
   useMessage,
-  type DropdownOption,
 } from "naive-ui";
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
@@ -26,6 +26,7 @@ import MessageList from "./MessageList.vue";
 import SessionListItem from "./SessionListItem.vue";
 import DrawerPanel from "./DrawerPanel.vue";
 import OutlinePanel from "./OutlinePanel.vue";
+import { createSessionActionOptions, promptSessionDelete } from './session-action-menu';
 
 const chatStore = useChatStore();
 const appStore = useAppStore();
@@ -33,6 +34,7 @@ const profilesStore = useProfilesStore();
 const sessionBrowserPrefsStore = useSessionBrowserPrefsStore();
 const router = useRouter();
 const message = useMessage();
+const dialog = useDialog();
 const { t } = useI18n();
 
 const showDrawer = ref(false);
@@ -59,6 +61,10 @@ const showSessions = ref(
 );
 let mobileQuery: MediaQueryList | null = null;
 const isMobile = ref(false);
+
+function sessionProfile(sessionId: string): string | null {
+  return chatStore.sessions.find((session) => session.id === sessionId)?.profile || null;
+}
 
 function sessionHref(sessionId: string) {
   return router.resolve({
@@ -164,17 +170,6 @@ const headerTitle = computed(() =>
 
 const activeApproval = computed(() => chatStore.activePendingApproval);
 const visibleApproval = computed(() => activeApproval.value);
-
-const activeClarify = computed(() => chatStore.activePendingClarify);
-const visibleClarify = computed(() => activeClarify.value);
-const clarifyResponse = ref('');
-
-function handleClarify(response?: string) {
-  const finalResponse = response !== undefined ? response : clarifyResponse.value.trim();
-  chatStore.respondToClarify(finalResponse);
-  clarifyResponse.value = '';
-}
-
 const showNewChatModal = ref(false);
 const newChatProfile = ref<string>("default");
 const newChatProvider = ref<string>("");
@@ -287,17 +282,13 @@ function handleApproval(choice: "once" | "session" | "always" | "deny") {
   chatStore.respondApproval(choice);
 }
 
-function sessionProfile(sessionId: string): string | null {
-  return chatStore.sessions.find((session) => session.id === sessionId)?.profile || null;
-}
-
 function buildSessionUrl(sessionId: string, profile?: string | null): string {
   const href = router.resolve({
     name: "hermes.session",
     params: { sessionId },
     query: profile ? { profile } : undefined,
   }).href;
-  return `${window.location.origin}${window.location.pathname}${href}`;
+  return `${window.location.origin}${href}`;
 }
 
 async function copySessionLink(id?: string) {
@@ -417,45 +408,17 @@ const contextSession = computed(() =>
     : null,
 );
 
-const contextMenuOptions = computed(() => {
-  const options: DropdownOption[] = [{
-    label: t(contextSessionPinned.value ? "chat.unpin" : "chat.pin"),
-    key: "pin",
-  },
-  { label: t("chat.rename"), key: "rename" },
-  { label: t("chat.setWorkspace"), key: "workspace" }]
-
-  if (contextSession.value?.source === "cli") {
-    options.push({ label: t("chat.setModel"), key: "model" })
-  }
-
-  options.push({
-    label: t("chat.export"),
-    key: "export",
-    children: [
-      {
-        label: t("chat.exportFull"),
-        key: "export-full",
-        children: [
-          { label: "JSON", key: "export-full-json" },
-          { label: "TXT", key: "export-full-txt" },
-        ],
-      },
-      {
-        label: t("chat.exportCompressed"),
-        key: "export-compressed",
-        children: [
-          { label: "JSON", key: "export-compressed-json" },
-          { label: "TXT", key: "export-compressed-txt" },
-        ],
-      },
-    ],
-  })
-  options.push({ label: t("chat.openSessionInNewTab"), key: "open-link" })
-  options.push({ label: t("chat.copySessionLink"), key: "copy-link" })
-  options.push({ label: t("chat.copySessionId"), key: "copy-id" })
-  return options
-});
+const contextMenuOptions = computed(() =>
+  createSessionActionOptions(t, {
+    mode: 'chat',
+    pinned: contextSessionPinned.value,
+    canDelete: contextSessionId.value
+      ? contextSessionId.value !== chatStore.activeSessionId || chatStore.sessions.length > 1
+      : false,
+    to: contextSessionId.value ? sessionHref(contextSessionId.value) : null,
+    source: contextSession.value?.source || null,
+  }),
+);
 
 function handleContextMenu(e: MouseEvent, sessionId: string) {
   e.preventDefault();
@@ -480,8 +443,20 @@ function parseExportKey(key: string): { mode: 'full' | 'compressed'; ext: 'json'
 async function handleContextMenuSelect(key: string) {
   showContextMenu.value = false;
   if (!contextSessionId.value) return;
+  const session = chatStore.sessions.find(
+    (s) => s.id === contextSessionId.value,
+  );
   if (key === "pin") {
     sessionBrowserPrefsStore.togglePinned(contextSessionId.value);
+    return;
+  }
+  if (key === "delete") {
+    promptSessionDelete(
+      dialog,
+      t,
+      session?.title || t("common.delete"),
+      () => handleDeleteSession(contextSessionId.value!),
+    );
     return;
   }
   if (key === "copy-link") {
@@ -502,18 +477,12 @@ async function handleContextMenuSelect(key: string) {
       message.error(t("chat.exportFailed"));
     }
   } else if (key === "workspace") {
-    const session = chatStore.sessions.find(
-      (s) => s.id === contextSessionId.value,
-    );
     workspaceSessionId.value = contextSessionId.value;
     workspaceValue.value = session?.workspace || "";
     showWorkspaceModal.value = true;
   } else if (key === "model") {
     await openSessionModelModal(contextSessionId.value);
   } else if (key === "rename") {
-    const session = chatStore.sessions.find(
-      (s) => s.id === contextSessionId.value,
-    );
     renameSessionId.value = contextSessionId.value;
     renameValue.value = session?.title || "";
     showRenameModal.value = true;
@@ -521,6 +490,11 @@ async function handleContextMenuSelect(key: string) {
       renameInputRef.value?.focus();
     });
   }
+}
+
+function handleSessionAction(sessionId: string, key: string) {
+  contextSessionId.value = sessionId;
+  void handleContextMenuSelect(key);
 }
 
 function handleClickOutside() {
@@ -859,8 +833,10 @@ async function handleSessionModelCustomSubmit() {
             :selected="isSessionSelected(s.id)"
             :show-profile="true"
             :to="sessionHref(s.id)"
+            :menu-mode="'chat'"
             @select="handleSessionClick(s.id)"
             @contextmenu="handleContextMenu($event, s.id)"
+            @action="handleSessionAction(s.id, $event)"
             @delete="handleDeleteSession(s.id)"
             @toggle-select="toggleSessionSelection(s.id)"
           />
@@ -881,8 +857,10 @@ async function handleSessionModelCustomSubmit() {
           :selected="isSessionSelected(s.id)"
           :show-profile="true"
           :to="sessionHref(s.id)"
+          :menu-mode="'chat'"
           @select="handleSessionClick(s.id)"
           @contextmenu="handleContextMenu($event, s.id)"
+          @action="handleSessionAction(s.id, $event)"
           @delete="handleDeleteSession(s.id)"
           @toggle-select="toggleSessionSelection(s.id)"
         />
@@ -1252,63 +1230,6 @@ async function handleSessionModelCustomSubmit() {
               >
                 {{ t("chat.approvalDeny") }}
               </NButton>
-            </div>
-          </div>
-        </div>
-        <div v-if="visibleClarify" class="clarify-bar">
-          <div class="clarify-icon" aria-hidden="true">
-            <svg
-              width="18"
-              height="18"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <circle cx="12" cy="12" r="10" />
-              <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
-              <line x1="12" y1="17" x2="12.01" y2="17" />
-            </svg>
-          </div>
-          <div class="clarify-content">
-            <div class="clarify-main">
-              <div class="clarify-kicker">{{ t('chat.clarifyKicker') }}</div>
-              <div class="clarify-title">{{ t('chat.clarifyTitle') }}</div>
-              <div class="clarify-desc">{{ visibleClarify.question }}</div>
-            </div>
-            <div v-if="visibleClarify.choices && visibleClarify.choices.length" class="clarify-actions">
-              <NButton
-                v-for="choice in visibleClarify.choices"
-                :key="choice"
-                size="small"
-                type="primary"
-                @click="handleClarify(choice)"
-              >
-                {{ choice }}
-              </NButton>
-              <NButton
-                size="small"
-                type="error"
-                secondary
-                @click="handleClarify('')"
-              >
-                {{ t('chat.clarifyDismiss') }}
-              </NButton>
-            </div>
-            <div v-else class="clarify-actions">
-              <div class="clarify-input-row">
-                <NInput
-                  v-model:value="clarifyResponse"
-                  size="small"
-                  :placeholder="t('chat.clarifyPlaceholder')"
-                  @keyup.enter="handleClarify()"
-                />
-                <NButton size="small" type="primary" @click="handleClarify()">
-                  {{ t('chat.clarifySubmit') }}
-                </NButton>
-              </div>
             </div>
           </div>
         </div>
@@ -2088,83 +2009,6 @@ async function handleSessionModelCustomSubmit() {
   border-top: 1px solid $border-color;
 }
 
-
-.clarify-bar {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  margin: 0 16px 12px;
-  padding: 12px;
-  border: 1px solid $border-color;
-  border-radius: 8px;
-  background: $bg-card;
-  box-shadow: none;
-}
-
-.clarify-icon {
-  display: grid;
-  place-items: center;
-  flex: 0 0 32px;
-  width: 32px;
-  height: 32px;
-  color: var(--accent-primary);
-  background: rgba(var(--accent-primary-rgb), 0.12);
-  border: 1px solid rgba(var(--accent-primary-rgb), 0.2);
-  border-radius: 8px;
-}
-
-.clarify-content {
-  flex: 1;
-  min-width: 0;
-}
-
-.clarify-main {
-  min-width: 0;
-}
-
-.clarify-kicker {
-  margin-bottom: 2px;
-  font-size: 10px;
-  font-weight: 700;
-  line-height: 1.2;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--accent-primary);
-}
-
-.clarify-title {
-  font-size: 14px;
-  font-weight: 700;
-  line-height: 1.3;
-  color: $text-primary;
-}
-
-.clarify-desc {
-  margin-top: 4px;
-  font-size: 12px;
-  line-height: 1.45;
-  color: $text-secondary;
-}
-
-.clarify-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid $border-color;
-}
-
-.clarify-input-row {
-  display: flex;
-  flex: 1;
-  gap: 8px;
-  align-items: center;
-
-  .n-input {
-    flex: 1;
-  }
-}
 @media (max-width: 768px) {
   .approval-bar {
     margin: 0 10px 10px;
@@ -2185,26 +2029,6 @@ async function handleSessionModelCustomSubmit() {
   .approval-actions :deep(.n-button) {
     width: 100%;
   }
-
-  .clarify-bar {
-    margin: 0 10px 10px;
-    padding: 10px;
-  }
-
-  .clarify-icon {
-    flex-basis: 28px;
-    width: 28px;
-    height: 28px;
-  }
-
-  .clarify-actions {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .clarify-actions :deep(.n-button) {
-    width: 100%;
-  }
 }
 
 @media (max-width: 420px) {
@@ -2213,14 +2037,6 @@ async function handleSessionModelCustomSubmit() {
   }
 
   .approval-actions {
-    grid-template-columns: 1fr;
-  }
-
-  .clarify-bar {
-    gap: 8px;
-  }
-
-  .clarify-actions {
     grid-template-columns: 1fr;
   }
 }

--- a/packages/client/src/components/hermes/chat/SessionListItem.vue
+++ b/packages/client/src/components/hermes/chat/SessionListItem.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { computed, ref, onUnmounted } from 'vue'
-import { NPopconfirm, NCheckbox, NTooltip } from 'naive-ui'
+import { NCheckbox, NDropdown, NTooltip, useDialog, useMessage, type DropdownOption } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import type { Session } from '@/stores/hermes/chat'
 import { useAppStore } from '@/stores/hermes/app'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import ProfileAvatar from '@/components/hermes/profiles/ProfileAvatar.vue'
+import { copyToClipboard } from '@/utils/clipboard'
 import { formatTimestampMs } from '@/shared/session-display'
 
 const props = withDefaults(defineProps<{
@@ -18,20 +19,26 @@ const props = withDefaults(defineProps<{
   selected?: boolean
   showProfile?: boolean
   to?: string
+  menuMode?: 'simple' | 'chat'
 }>(), {
   showProfile: true,
+  menuMode: 'simple',
 })
 
 const emit = defineEmits<{
   select: []
   contextmenu: [event: MouseEvent]
   delete: []
+  action: [key: string]
   'toggle-select': []
 }>()
 
 const { t } = useI18n()
 const appStore = useAppStore()
 const profilesStore = useProfilesStore()
+const message = useMessage()
+const dialog = useDialog()
+
 const sessionModelName = computed(() =>
   props.session.model
     ? appStore.displayModelName(props.session.model, props.session.provider)
@@ -46,6 +53,62 @@ const profileHasModels = computed(() => {
 const profileModelsMissing = computed(() =>
   appStore.profileModelGroups.length > 0 && !profileHasModels.value,
 )
+
+const menuTriggerLabel = computed(() => t('chat.sessionActions'))
+
+const menuOptions = computed<DropdownOption[]>(() => {
+  const options: DropdownOption[] = []
+
+  if (props.menuMode === 'chat') {
+    options.push(
+      { label: props.pinned ? t('chat.unpin') : t('chat.pin'), key: 'pin' },
+      { label: t('chat.rename'), key: 'rename' },
+      { label: t('chat.setWorkspace'), key: 'workspace' },
+    )
+
+    if (props.session.source === 'cli') {
+      options.push({ label: t('chat.setModel'), key: 'model' })
+    }
+
+    options.push({
+      label: t('chat.export'),
+      key: 'export',
+      children: [
+        {
+          label: t('chat.exportFull'),
+          key: 'export-full',
+          children: [
+            { label: 'JSON', key: 'export-full-json' },
+            { label: 'TXT', key: 'export-full-txt' },
+          ],
+        },
+        {
+          label: t('chat.exportCompressed'),
+          key: 'export-compressed',
+          children: [
+            { label: 'JSON', key: 'export-compressed-json' },
+            { label: 'TXT', key: 'export-compressed-txt' },
+          ],
+        },
+      ],
+    })
+  }
+
+  if (props.to) {
+    options.push(
+      { label: t('chat.openSessionInNewTab'), key: 'open-link' },
+      { label: t('chat.copySessionLink'), key: 'copy-link' },
+    )
+  }
+
+  options.push({ label: t('chat.copySessionId'), key: 'copy-id' })
+
+  if (props.canDelete && !props.selectable) {
+    options.push({ label: t('chat.deleteSession'), key: 'delete', danger: true })
+  }
+
+  return options
+})
 
 let longPressTimer: ReturnType<typeof setTimeout> | null = null
 const longPressTriggered = ref(false)
@@ -93,71 +156,295 @@ function onClick(event?: MouseEvent) {
   emit('select')
 }
 
+async function openSessionLink() {
+  if (!props.to || typeof window === 'undefined') return
+  window.open(props.to, '_blank', 'noopener,noreferrer')
+}
+
+async function copySessionLink() {
+  if (!props.to) return
+  await copyToClipboard(props.to)
+  message.success(t('chat.sessionLinkCopied'))
+}
+
+async function copySessionId() {
+  await copyToClipboard(props.session.id)
+  message.success(t('common.copied'))
+}
+
+function confirmDelete() {
+  dialog.warning({
+    title: t('chat.deleteSession'),
+    content: t('files.confirmDelete', { name: props.session.title }),
+    positiveText: t('common.ok'),
+    negativeText: t('common.cancel'),
+    onPositiveClick: () => emit('delete'),
+  })
+}
+
+async function handleMenuSelect(key: string) {
+  switch (key) {
+    case 'open-link':
+      await openSessionLink()
+      return
+    case 'copy-link':
+      await copySessionLink()
+      return
+    case 'copy-id':
+      await copySessionId()
+      return
+    case 'delete':
+      confirmDelete()
+      return
+    case 'pin':
+    case 'rename':
+    case 'workspace':
+    case 'model':
+    case 'export':
+    case 'export-full':
+    case 'export-full-json':
+    case 'export-full-txt':
+    case 'export-compressed':
+    case 'export-compressed-json':
+    case 'export-compressed-txt':
+      emit('action', key)
+      return
+  }
+}
+
 onUnmounted(() => {
   if (longPressTimer) clearTimeout(longPressTimer)
 })
 </script>
 
 <template>
-  <component
-    :is="selectable || !to ? 'button' : 'a'"
-    class="session-item"
-    :class="{ active, 'batch-mode': selectable, 'missing-models': profileModelsMissing }"
-    :aria-current="active ? 'page' : undefined"
-    :href="!selectable ? to : undefined"
-    :type="selectable || !to ? 'button' : undefined"
-    @click="onClick"
-    @contextmenu="emit('contextmenu', $event)"
-    @touchstart="onTouchStart"
-    @touchend="onTouchEnd"
-    @touchmove="onTouchMove"
+  <div
+    class="session-item-shell"
+    :class="{ active, 'batch-mode': selectable, 'missing-models': profileModelsMissing, 'menu-mode-chat': menuMode === 'chat' }"
   >
-    <div v-if="selectable" class="session-item-checkbox">
-      <NCheckbox :checked="selected" @click.stop="emit('toggle-select')" />
-    </div>
-    <div class="session-item-content">
-      <span class="session-item-title-row">
-        <span v-if="pinned" class="session-item-pin" aria-hidden="true">
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M12 17v5" />
-            <path d="M5 8l14 0" />
-            <path d="M8 3l8 0 0 5 3 5-14 0 3-5z" />
+    <component
+      :is="selectable || !to ? 'button' : 'a'"
+      class="session-item session-item-link"
+      :class="{ active, 'batch-mode': selectable, 'missing-models': profileModelsMissing }"
+      :aria-current="active ? 'page' : undefined"
+      :href="!selectable ? to : undefined"
+      :type="selectable || !to ? 'button' : undefined"
+      @click="onClick"
+      @contextmenu="emit('contextmenu', $event)"
+      @touchstart="onTouchStart"
+      @touchend="onTouchEnd"
+      @touchmove="onTouchMove"
+    >
+      <div v-if="selectable" class="session-item-checkbox">
+        <NCheckbox :checked="selected" @click.stop="emit('toggle-select')" />
+      </div>
+      <div class="session-item-content">
+        <span class="session-item-title-row">
+          <span v-if="pinned" class="session-item-pin" aria-hidden="true">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 17v5" />
+              <path d="M5 8l14 0" />
+              <path d="M8 3l8 0 0 5 3 5-14 0 3-5z" />
+            </svg>
+          </span>
+          <span class="session-item-title">
+            <svg v-if="streaming" class="session-item-streaming" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+              <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
+            </svg>
+            {{ session.title }}
+          </span>
+          <NTooltip v-if="profileModelsMissing" trigger="click" placement="top">
+            <template #trigger>
+              <button class="session-item-warning" type="button" @click.stop.prevent>
+                !
+              </button>
+            </template>
+            {{ t('chat.profileMissingModelsTip', { profile: profileName }) }}
+          </NTooltip>
+        </span>
+        <span class="session-item-meta">
+          <span v-if="sessionModelName" class="session-item-model" :title="session.model">{{ sessionModelName }}</span>
+          <span class="session-item-time">{{ formatTimestampMs(session.createdAt) }}</span>
+        </span>
+        <span v-if="props.showProfile" class="session-item-profile">
+          <ProfileAvatar class="session-item-profile-avatar" :name="profileName" :avatar="profileAvatar" :size="16" />
+          <span class="session-item-profile-name">{{ profileName }}</span>
+        </span>
+      </div>
+    </component>
+
+    <div v-if="!selectable" class="session-item-actions">
+      <NDropdown
+        trigger="click"
+        placement="bottom-end"
+        :options="menuOptions"
+        @select="handleMenuSelect"
+      >
+        <button
+          class="session-item-more"
+          type="button"
+          aria-haspopup="menu"
+          :aria-label="menuTriggerLabel"
+          :title="menuTriggerLabel"
+          @pointerdown.stop.prevent
+          @click.stop.prevent
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <circle cx="5" cy="12" r="1.7" />
+            <circle cx="12" cy="12" r="1.7" />
+            <circle cx="19" cy="12" r="1.7" />
           </svg>
-        </span>
-        <span class="session-item-title">
-          <svg v-if="streaming" class="session-item-streaming" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-          {{ session.title }}
-        </span>
-        <NTooltip v-if="profileModelsMissing" trigger="click" placement="top">
-          <template #trigger>
-            <button class="session-item-warning" type="button" @click.stop.prevent>
-              !
-            </button>
-          </template>
-          {{ t('chat.profileMissingModelsTip', { profile: profileName }) }}
-        </NTooltip>
-      </span>
-      <span class="session-item-meta">
-        <span v-if="sessionModelName" class="session-item-model" :title="session.model">{{ sessionModelName }}</span>
-        <span class="session-item-time">{{ formatTimestampMs(session.createdAt) }}</span>
-      </span>
-      <span v-if="props.showProfile" class="session-item-profile">
-        <ProfileAvatar class="session-item-profile-avatar" :name="profileName" :avatar="profileAvatar" :size="16" />
-        <span class="session-item-profile-name">{{ profileName }}</span>
-      </span>
-    </div>
-    <NPopconfirm v-if="canDelete && !selectable" @positive-click="emit('delete')">
-      <template #trigger>
-        <button class="session-item-delete" @click.stop.prevent>
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
         </button>
-      </template>
-      {{ t('chat.deleteSession') }}
-    </NPopconfirm>
-  </component>
+      </NDropdown>
+    </div>
+  </div>
 </template>
 
 <style scoped>
+.session-item-shell {
+  --session-item-actions-width: 34px;
+  position: relative;
+  width: 100%;
+  margin-bottom: 2px;
+}
+
+.session-item-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  padding-right: 10px;
+  border: none;
+  border-radius: 8px;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+  text-decoration: none;
+  color: var(--text-secondary);
+  transition: background 0.15s ease, color 0.15s ease, padding-right 0.15s ease;
+}
+
+.session-item-shell:hover .session-item-link,
+.session-item-shell:focus-within .session-item-link {
+  background: rgba(var(--accent-primary-rgb), 0.06);
+  color: var(--text-primary);
+}
+
+.session-item-link.active {
+  background: rgba(var(--accent-primary-rgb), 0.12);
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.session-item-link.active .session-item-title {
+  color: var(--accent-primary);
+}
+
+.session-item-shell.missing-models .session-item-link {
+  color: #b42318;
+  background: rgba(220, 38, 38, 0.08);
+}
+
+.session-item-shell.missing-models .session-item-title,
+.session-item-shell.missing-models .session-item-profile-name,
+.session-item-shell.missing-models .session-item-time {
+  color: #b42318;
+}
+
+.session-item-shell.missing-models .session-item-model {
+  color: #b42318;
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.session-item-shell.missing-models:hover .session-item-link,
+.session-item-shell.missing-models:focus-within .session-item-link {
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.session-item-checkbox {
+  flex-shrink: 0;
+}
+
+.session-item-content {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.session-item-title-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.session-item-title {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-item-streaming {
+  display: inline-block;
+  flex-shrink: 0;
+  margin-right: 4px;
+  vertical-align: middle;
+  animation: spin 1.2s linear infinite;
+  color: var(--accent-primary);
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.session-item-pin {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--accent-primary);
+}
+
+.session-item-time {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.session-item-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  min-width: 0;
+}
+
+.session-item-model {
+  max-width: 100%;
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: rgba(var(--accent-primary-rgb), 0.08);
+  color: var(--accent-primary);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 16px;
+  text-transform: uppercase;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .session-item-profile {
   display: flex;
   align-items: center;
@@ -192,5 +479,62 @@ onUnmounted(() => {
   font-weight: 700;
   line-height: 14px;
   cursor: pointer;
+}
+
+.session-item-actions {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%) translateX(4px);
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.session-item-shell:hover .session-item-actions,
+.session-item-shell:focus-within .session-item-actions {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+  pointer-events: auto;
+}
+
+.session-item-shell:hover .session-item-link,
+.session-item-shell:focus-within .session-item-link {
+  padding-right: calc(10px + var(--session-item-actions-width));
+}
+
+.session-item-more {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--session-item-actions-width);
+  height: 28px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.session-item-more:hover,
+.session-item-more:focus-visible {
+  background: rgba(var(--accent-primary-rgb), 0.12);
+  color: var(--text-primary);
+}
+
+@media (hover: none) {
+  .session-item-actions {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0);
+    pointer-events: auto;
+  }
+
+  .session-item-link {
+    padding-right: calc(10px + var(--session-item-actions-width));
+  }
 }
 </style>

--- a/packages/client/src/components/hermes/chat/SessionListItem.vue
+++ b/packages/client/src/components/hermes/chat/SessionListItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, onUnmounted } from 'vue'
-import { NCheckbox, NDropdown, NTooltip, useDialog, useMessage, type DropdownOption } from 'naive-ui'
+import { NCheckbox, NDropdown, NTooltip, useDialog, useMessage } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import type { Session } from '@/stores/hermes/chat'
 import { useAppStore } from '@/stores/hermes/app'
@@ -8,6 +8,7 @@ import { useProfilesStore } from '@/stores/hermes/profiles'
 import ProfileAvatar from '@/components/hermes/profiles/ProfileAvatar.vue'
 import { copyToClipboard } from '@/utils/clipboard'
 import { formatTimestampMs } from '@/shared/session-display'
+import { createSessionActionOptions, promptSessionDelete } from './session-action-menu'
 
 const props = withDefaults(defineProps<{
   session: Session
@@ -56,59 +57,15 @@ const profileModelsMissing = computed(() =>
 
 const menuTriggerLabel = computed(() => t('chat.sessionActions'))
 
-const menuOptions = computed<DropdownOption[]>(() => {
-  const options: DropdownOption[] = []
-
-  if (props.menuMode === 'chat') {
-    options.push(
-      { label: props.pinned ? t('chat.unpin') : t('chat.pin'), key: 'pin' },
-      { label: t('chat.rename'), key: 'rename' },
-      { label: t('chat.setWorkspace'), key: 'workspace' },
-    )
-
-    if (props.session.source === 'cli') {
-      options.push({ label: t('chat.setModel'), key: 'model' })
-    }
-
-    options.push({
-      label: t('chat.export'),
-      key: 'export',
-      children: [
-        {
-          label: t('chat.exportFull'),
-          key: 'export-full',
-          children: [
-            { label: 'JSON', key: 'export-full-json' },
-            { label: 'TXT', key: 'export-full-txt' },
-          ],
-        },
-        {
-          label: t('chat.exportCompressed'),
-          key: 'export-compressed',
-          children: [
-            { label: 'JSON', key: 'export-compressed-json' },
-            { label: 'TXT', key: 'export-compressed-txt' },
-          ],
-        },
-      ],
-    })
-  }
-
-  if (props.to) {
-    options.push(
-      { label: t('chat.openSessionInNewTab'), key: 'open-link' },
-      { label: t('chat.copySessionLink'), key: 'copy-link' },
-    )
-  }
-
-  options.push({ label: t('chat.copySessionId'), key: 'copy-id' })
-
-  if (props.canDelete && !props.selectable) {
-    options.push({ label: t('chat.deleteSession'), key: 'delete', danger: true })
-  }
-
-  return options
-})
+const menuOptions = computed(() =>
+  createSessionActionOptions(t, {
+    mode: props.menuMode,
+    pinned: props.pinned,
+    canDelete: props.canDelete && !props.selectable,
+    to: props.to,
+    source: props.session.source,
+  }),
+)
 
 let longPressTimer: ReturnType<typeof setTimeout> | null = null
 const longPressTriggered = ref(false)
@@ -173,13 +130,7 @@ async function copySessionId() {
 }
 
 function confirmDelete() {
-  dialog.warning({
-    title: t('chat.deleteSession'),
-    content: t('files.confirmDelete', { name: props.session.title }),
-    positiveText: t('common.ok'),
-    negativeText: t('common.cancel'),
-    onPositiveClick: () => emit('delete'),
-  })
+  promptSessionDelete(dialog, t, props.session.title, () => emit('delete'))
 }
 
 async function handleMenuSelect(key: string) {

--- a/packages/client/src/components/hermes/chat/TerminalPanel.vue
+++ b/packages/client/src/components/hermes/chat/TerminalPanel.vue
@@ -476,12 +476,16 @@ onUnmounted(() => {
             {{ t("terminal.noSessions") }}
           </template>
         </div>
-        <button
+        <div
           v-for="s in sessions"
           :key="s.id"
           class="session-item"
           :class="{ active: s.id === activeSessionId, exited: s.exited }"
+          role="button"
+          tabindex="0"
           @click="switchSession(s.id)"
+          @keydown.enter.self.prevent="switchSession(s.id)"
+          @keydown.space.self.prevent="switchSession(s.id)"
         >
           <div class="session-item-content">
             <span class="session-item-title">{{ s.title }}</span>
@@ -497,7 +501,7 @@ onUnmounted(() => {
           </div>
           <NPopconfirm v-if="sessions.length > 1" @positive-click="closeSession(s.id)">
             <template #trigger>
-              <button class="session-item-delete" @click.stop>
+              <button class="session-item-delete" :aria-label="t('terminal.closeSession')" @click.stop @keydown.stop>
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <line x1="18" y1="6" x2="6" y2="18" />
                   <line x1="6" y1="6" x2="18" y2="18" />
@@ -506,7 +510,7 @@ onUnmounted(() => {
             </template>
             {{ t("terminal.closeSession") }}
           </NPopconfirm>
-        </button>
+        </div>
       </div>
     </div>
 
@@ -679,12 +683,19 @@ onUnmounted(() => {
   transition: all $transition-fast;
   margin-bottom: 2px;
 
-  &:hover {
+  &:focus-visible {
+    outline: 2px solid rgba(var(--accent-primary-rgb), 0.35);
+    outline-offset: 1px;
+  }
+
+  &:hover,
+  &:focus-within {
     background: rgba(var(--accent-primary-rgb), 0.06);
     color: $text-primary;
 
     .session-item-delete {
       opacity: 1;
+      pointer-events: auto;
     }
   }
 
@@ -736,7 +747,8 @@ onUnmounted(() => {
 
 .session-item-delete {
   flex-shrink: 0;
-  opacity: 0.5;
+  opacity: 0;
+  pointer-events: none;
   padding: 2px;
   border: none;
   background: none;
@@ -748,6 +760,13 @@ onUnmounted(() => {
   &:hover {
     color: $error;
     background: rgba(var(--error-rgb), 0.1);
+  }
+}
+
+@media (hover: none) {
+  .session-item-delete {
+    opacity: 1;
+    pointer-events: auto;
   }
 }
 

--- a/packages/client/src/components/hermes/chat/session-action-menu.ts
+++ b/packages/client/src/components/hermes/chat/session-action-menu.ts
@@ -1,0 +1,113 @@
+import { h } from 'vue'
+import type { DropdownOption } from 'naive-ui'
+
+export type SessionActionMenuMode = 'simple' | 'chat'
+
+export type SessionActionKey =
+  | 'pin'
+  | 'rename'
+  | 'workspace'
+  | 'model'
+  | 'export'
+  | 'export-full'
+  | 'export-full-json'
+  | 'export-full-txt'
+  | 'export-compressed'
+  | 'export-compressed-json'
+  | 'export-compressed-txt'
+  | 'open-link'
+  | 'copy-link'
+  | 'copy-id'
+  | 'delete'
+
+export type SessionActionTranslator = (key: string, params?: Record<string, unknown>) => string
+
+export interface SessionActionMenuContext {
+  mode?: SessionActionMenuMode
+  pinned: boolean
+  canDelete: boolean
+  to?: string | null
+  source?: string | null
+}
+
+export interface SessionDeleteDialog {
+  warning: (options: Record<string, unknown>) => void
+}
+
+export function createSessionActionOptions(
+  t: SessionActionTranslator,
+  context: SessionActionMenuContext,
+): DropdownOption[] {
+  const options: DropdownOption[] = []
+  const { mode = 'simple', pinned, canDelete, to, source } = context
+
+  if (mode === 'chat') {
+    options.push(
+      { label: t(pinned ? 'chat.unpin' : 'chat.pin'), key: 'pin' },
+      { label: t('chat.rename'), key: 'rename' },
+      { label: t('chat.setWorkspace'), key: 'workspace' },
+    )
+
+    if (source === 'cli') {
+      options.push({ label: t('chat.setModel'), key: 'model' })
+    }
+
+    options.push({
+      label: t('chat.export'),
+      key: 'export',
+      children: [
+        {
+          label: t('chat.exportFull'),
+          key: 'export-full',
+          children: [
+            { label: 'JSON', key: 'export-full-json' },
+            { label: 'TXT', key: 'export-full-txt' },
+          ],
+        },
+        {
+          label: t('chat.exportCompressed'),
+          key: 'export-compressed',
+          children: [
+            { label: 'JSON', key: 'export-compressed-json' },
+            { label: 'TXT', key: 'export-compressed-txt' },
+          ],
+        },
+      ],
+    })
+  }
+
+  if (to) {
+    options.push(
+      { label: t('chat.openSessionInNewTab'), key: 'open-link' },
+      { label: t('chat.copySessionLink'), key: 'copy-link' },
+    )
+  }
+
+  options.push({ label: t('chat.copySessionId'), key: 'copy-id' })
+
+  if (canDelete) {
+    options.push({ label: t('common.delete'), key: 'delete', danger: true })
+  }
+
+  return options
+}
+
+export function promptSessionDelete(
+  dialog: SessionDeleteDialog,
+  t: SessionActionTranslator,
+  sessionTitle: string,
+  onPositiveClick: () => void | Promise<void>,
+) {
+  dialog.warning({
+    title: sessionTitle,
+    content: () => h(
+      'span',
+      { style: 'color: var(--error); font-weight: 600;' },
+      t('common.delete'),
+    ),
+    positiveText: t('common.delete'),
+    negativeText: t('common.cancel'),
+    positiveButtonProps: { type: 'error' },
+    onPositiveClick,
+  })
+}

--- a/packages/client/src/views/hermes/TerminalView.vue
+++ b/packages/client/src/views/hermes/TerminalView.vue
@@ -619,12 +619,16 @@ onUnmounted(() => {
         <div v-if="sessions.length === 0" class="session-empty">
           {{ t("common.loading") }}
         </div>
-        <button
+        <div
           v-for="s in sessions"
           :key="s.id"
           class="session-item"
           :class="{ active: s.id === activeSessionId, exited: s.exited }"
+          role="button"
+          tabindex="0"
           @click="switchSession(s.id)"
+          @keydown.enter.self.prevent="switchSession(s.id)"
+          @keydown.space.self.prevent="switchSession(s.id)"
         >
           <div class="session-item-content">
             <span class="session-item-title">{{ s.title }}</span>
@@ -643,7 +647,7 @@ onUnmounted(() => {
             @positive-click="closeSession(s.id)"
           >
             <template #trigger>
-              <button class="session-item-delete" @click.stop>
+              <button class="session-item-delete" :aria-label="t('terminal.closeSession')" @click.stop @keydown.stop>
                 <svg
                   width="12"
                   height="12"
@@ -659,7 +663,7 @@ onUnmounted(() => {
             </template>
             {{ t("terminal.closeSession") }}
           </NPopconfirm>
-        </button>
+        </div>
       </div>
     </aside>
 
@@ -831,12 +835,19 @@ onUnmounted(() => {
   transition: all $transition-fast;
   margin-bottom: 2px;
 
-  &:hover {
+  &:focus-visible {
+    outline: 2px solid rgba(var(--accent-primary-rgb), 0.35);
+    outline-offset: 1px;
+  }
+
+  &:hover,
+  &:focus-within {
     background: rgba(var(--accent-primary-rgb), 0.06);
     color: $text-primary;
 
     .session-item-delete {
       opacity: 1;
+      pointer-events: auto;
     }
   }
 
@@ -893,7 +904,8 @@ onUnmounted(() => {
 
 .session-item-delete {
   flex-shrink: 0;
-  opacity: 0.5;
+  opacity: 0;
+  pointer-events: none;
   padding: 2px;
   border: none;
   background: none;
@@ -905,6 +917,13 @@ onUnmounted(() => {
   &:hover {
     color: $error;
     background: rgba(var(--error-rgb), 0.1);
+  }
+}
+
+@media (hover: none) {
+  .session-item-delete {
+    opacity: 1;
+    pointer-events: auto;
   }
 }
 

--- a/tests/client/session-list-item.test.ts
+++ b/tests/client/session-list-item.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
 import SessionListItem from '@/components/hermes/chat/SessionListItem.vue'
+import { createSessionActionOptions, promptSessionDelete } from '@/components/hermes/chat/session-action-menu'
 
 const useDialogWarning = vi.fn()
 const useMessageSuccess = vi.fn()
@@ -131,9 +132,44 @@ describe('SessionListItem', () => {
       'chat.openSessionInNewTab',
       'chat.copySessionLink',
       'chat.copySessionId',
-      'chat.deleteSession',
+      'common.delete',
     ]))
     expect(options.some(option => option.key === 'export')).toBe(true)
+  })
+
+  it('builds the shared chat action menu and delete confirm with a short destructive label', () => {
+    const options = createSessionActionOptions((key) => key, {
+      mode: 'chat',
+      pinned: true,
+      canDelete: true,
+      to: '/session/s1',
+      source: 'cli',
+    })
+
+    expect(options.map(option => option.label)).toEqual(expect.arrayContaining([
+      'chat.unpin',
+      'chat.rename',
+      'chat.setWorkspace',
+      'chat.setModel',
+      'chat.export',
+      'chat.openSessionInNewTab',
+      'chat.copySessionLink',
+      'chat.copySessionId',
+      'common.delete',
+    ]))
+
+    const warning = vi.fn()
+    promptSessionDelete({ warning } as any, (key) => key, 'Session One', vi.fn())
+
+    expect(warning).toHaveBeenCalledTimes(1)
+    const [dialogOptions] = warning.mock.calls[0] as [Record<string, any>]
+    expect(dialogOptions.title).toBe('Session One')
+    expect(dialogOptions.positiveText).toBe('common.delete')
+    expect(dialogOptions.negativeText).toBe('common.cancel')
+    const contentNode = dialogOptions.content()
+    expect(contentNode.type).toBe('span')
+    expect(contentNode.props.style).toContain('var(--error)')
+    expect(contentNode.children).toBe('common.delete')
   })
 
   it('does not select the row when clicking the actions trigger', async () => {

--- a/tests/client/session-list-item.test.ts
+++ b/tests/client/session-list-item.test.ts
@@ -4,6 +4,9 @@ import { mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
 import SessionListItem from '@/components/hermes/chat/SessionListItem.vue'
 
+const useDialogWarning = vi.fn()
+const useMessageSuccess = vi.fn()
+
 vi.mock('@/stores/hermes/app', () => ({
   useAppStore: () => ({
     profileModelGroups: [],
@@ -24,21 +27,24 @@ vi.mock('@/shared/session-display', () => ({
 }))
 
 vi.mock('naive-ui', () => ({
-  NPopconfirm: defineComponent({
-    name: 'NPopconfirm',
-    emits: ['positive-click'],
-    template: '<span><slot name="trigger" /><slot /></span>',
-  }),
   NCheckbox: defineComponent({
     name: 'NCheckbox',
     props: ['checked'],
     emits: ['click'],
     template: '<input type="checkbox" :checked="checked" @click="$emit(\'click\')" />',
   }),
+  NDropdown: defineComponent({
+    name: 'NDropdown',
+    props: ['options', 'trigger', 'placement'],
+    emits: ['select'],
+    template: '<div class="n-dropdown-stub"><slot /></div>',
+  }),
   NTooltip: defineComponent({
     name: 'NTooltip',
     template: '<span><slot name="trigger" /><slot /></span>',
   }),
+  useDialog: () => ({ warning: useDialogWarning }),
+  useMessage: () => ({ success: useMessageSuccess }),
 }))
 
 const session = {
@@ -51,7 +57,7 @@ const session = {
 }
 
 describe('SessionListItem', () => {
-  it('renders normal mode as a link to the session route', () => {
+  it('renders normal mode with a detached hover-only actions trigger and no delete button', () => {
     const wrapper = mount(SessionListItem, {
       props: {
         session,
@@ -67,12 +73,16 @@ describe('SessionListItem', () => {
       },
     })
 
-    const link = wrapper.get('a.session-item')
-    expect(link.attributes('href')).toBe('/session/s1')
-    expect(wrapper.find('button.session-item').exists()).toBe(false)
+    expect(wrapper.get('.session-item-shell').exists()).toBe(true)
+    expect(wrapper.get('a.session-item-link').attributes('href')).toBe('/session/s1')
+    expect(wrapper.find('button.session-item-more').exists()).toBe(true)
+    expect(wrapper.find('button.session-item-delete').exists()).toBe(false)
+    expect(wrapper.get('.session-item-actions').attributes('aria-hidden')).toBeUndefined()
+    expect(wrapper.get('button.session-item-more').attributes('aria-haspopup')).toBe('menu')
+    expect(wrapper.get('button.session-item-more').element.closest('.session-item-link')).toBeNull()
   })
 
-  it('renders selectable mode as a button and does not expose row href', () => {
+  it('renders selectable mode as a button and hides action controls', () => {
     const wrapper = mount(SessionListItem, {
       props: {
         session,
@@ -90,11 +100,43 @@ describe('SessionListItem', () => {
       },
     })
 
-    expect(wrapper.find('button.session-item').exists()).toBe(true)
-    expect(wrapper.find('a.session-item').exists()).toBe(false)
+    expect(wrapper.find('button.session-item-link').exists()).toBe(true)
+    expect(wrapper.find('a.session-item-link').exists()).toBe(false)
+    expect(wrapper.find('button.session-item-more').exists()).toBe(false)
   })
 
-  it('does not select the row when clicking nested action controls', async () => {
+  it('exposes the chat action menu when configured for chat mode', () => {
+    const wrapper = mount(SessionListItem, {
+      props: {
+        session,
+        active: false,
+        pinned: true,
+        canDelete: true,
+        menuMode: 'chat',
+        to: '/session/s1',
+      },
+      global: {
+        stubs: {
+          ProfileAvatar: true,
+        },
+      },
+    })
+
+    const options = wrapper.getComponent({ name: 'NDropdown' }).props('options') as Array<{ label?: string; key?: string; children?: Array<{ label?: string; key?: string }> }>
+    expect(options.map(option => option.label)).toEqual(expect.arrayContaining([
+      'chat.unpin',
+      'chat.rename',
+      'chat.setWorkspace',
+      'chat.export',
+      'chat.openSessionInNewTab',
+      'chat.copySessionLink',
+      'chat.copySessionId',
+      'chat.deleteSession',
+    ]))
+    expect(options.some(option => option.key === 'export')).toBe(true)
+  })
+
+  it('does not select the row when clicking the actions trigger', async () => {
     const wrapper = mount(SessionListItem, {
       props: {
         session,
@@ -110,7 +152,7 @@ describe('SessionListItem', () => {
       },
     })
 
-    await wrapper.get('button.session-item-delete').trigger('click')
+    await wrapper.get('button.session-item-more').trigger('click')
     expect(wrapper.emitted('select')).toBeUndefined()
   })
 
@@ -130,7 +172,7 @@ describe('SessionListItem', () => {
       },
     })
 
-    const link = wrapper.get('a.session-item')
+    const link = wrapper.get('a.session-item-link')
     link.element.addEventListener('click', event => event.preventDefault())
     await link.trigger('click', { ctrlKey: true })
     expect(wrapper.emitted('select')).toBeUndefined()

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -8,9 +8,8 @@ test('opens terminal websocket session and forwards user input', async ({ page }
 
   await page.goto('/#/hermes/terminal')
 
-  await expect(page.getByText('Sessions')).toBeVisible()
+  await expect(page.locator('.session-list-title').first()).toBeVisible()
   await expect(page.locator('.session-item-title', { hasText: 'zsh #1' })).toBeVisible()
-
   const terminalState = await page.waitForFunction(() => {
     const state = (window as any).__PW_TERMINAL_WS__
     return state?.sockets?.length
@@ -27,6 +26,21 @@ test('opens terminal websocket session and forwards user input', async ({ page }
 
   await page.locator('.terminal-header .header-actions button').last().click()
   await expect(page.locator('.session-item-title', { hasText: 'bash #2' })).toBeVisible()
+
+  const terminalSessions = page.locator('.session-item').filter({ hasText: 'zsh #1' }).first()
+  const activeSessionTitle = page.locator('.session-item.active .session-item-title').first()
+  const activeBefore = await activeSessionTitle.textContent()
+  await expect(terminalSessions.locator('.session-item-delete')).toBeVisible()
+  await terminalSessions.hover()
+  await expect(terminalSessions.locator('.session-item-delete')).toBeVisible()
+  await terminalSessions.focus()
+  await expect(terminalSessions.locator('.session-item-delete')).toBeVisible()
+  await terminalSessions.locator('.session-item-delete').focus()
+  await page.keyboard.press('Enter')
+  await expect(page.locator('.session-item.active .session-item-title').first()).toHaveText(activeBefore || '')
+  await terminalSessions.locator('.session-item-delete').focus()
+  await page.keyboard.press('Space')
+  await expect(page.locator('.session-item.active .session-item-title').first()).toHaveText(activeBefore || '')
 
   await page.locator('.terminal-xterm').click()
   await page.keyboard.type('pwd')

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -8,7 +8,7 @@ test('opens terminal websocket session and forwards user input', async ({ page }
 
   await page.goto('/#/hermes/terminal')
 
-  await expect(page.locator('.session-list-title').first()).toBeVisible()
+  await expect(page.getByText('Sessions')).toBeVisible()
   await expect(page.locator('.session-item-title', { hasText: 'zsh #1' })).toBeVisible()
   const terminalState = await page.waitForFunction(() => {
     const state = (window as any).__PW_TERMINAL_WS__


### PR DESCRIPTION
## Summary
Extract the shared session action menu helper and wire ChatPanel/SessionListItem to it so the ellipsis/right-click actions and delete confirm live in one place.

## Changes
- Added `session-action-menu.ts` with shared option construction and delete confirmation helper.
- Swapped `ChatPanel` and `SessionListItem` to the shared menu model.
- Kept the terminal row affordance coverage in the base PR.

## Tests
- npm run build
- npm test -- tests/client/session-list-item.test.ts
- npm run test:e2e -- tests/e2e/terminal.spec.ts

## Notes
This draft is intended to follow PR #999. Merge the base PR first, then rebase this branch if needed before marking ready.