### PR TITLE
[codex] fix bridge tool marker flush persistence

### DIFF
--- a/packages/server/src/services/hermes/run-chat/bridge-delta.ts
+++ b/packages/server/src/services/hermes/run-chat/bridge-delta.ts
@@ -5,6 +5,27 @@ export interface BridgeDeltaFilterState {
 const TOOL_CALL_MARKER = '[Calling tool:'
 const MAX_PENDING_TOOL_MARKUP_LENGTH = 100_000
 
+/**
+ * Flush any partial-prefix that was held back waiting to see if it would
+ * become a `[Calling tool: ...]` marker. Call this when the streaming
+ * context guarantees no marker can follow (e.g. on `tool.started`,
+ * `tool.completed`, run completion, run failure, abort).
+ *
+ * Without this, deltas that legitimately end with `[`, `[C`, `[Ca`, ...,
+ * `[Calling tool` are silently dropped from the user-visible stream
+ * because the filter expected the buffered chars to either complete the
+ * marker (and be discarded) or be released by a follow-up delta — but
+ * follow-up deltas don't always come for the SAME assistant message.
+ *
+ * Returns the buffered text so callers can forward it to the client as
+ * a regular `message.delta` payload.
+ */
+export function flushPendingToolCallMarkup(state: BridgeDeltaFilterState): string {
+  const pending = state.bridgePendingToolCallMarkup || ''
+  state.bridgePendingToolCallMarkup = ''
+  return pending
+}
+
 function findToolMarkupEnd(text: string, start: number): number {
   let depth = 0
   let inString = false

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -69,6 +69,38 @@ export function bridgeTerminalError(chunk: Pick<AgentBridgeOutput, 'status' | 'e
   return null
 }
 
+function findOpenAssistantMessage(state: SessionState, runMarker: string) {
+  for (let i = state.messages.length - 1; i >= 0; i -= 1) {
+    const message = state.messages[i]
+    if (message.runMarker === runMarker && message.role === 'assistant' && message.finish_reason == null) return message
+  }
+  return undefined
+}
+
+function flushPendingToolMarkupToAssistant(
+  state: SessionState,
+  runMarker: string,
+  runId: string,
+  emit: (event: string, payload: any) => void,
+): string {
+  const pendingMarkup = flushPendingToolCallMarkup(state)
+  if (!pendingMarkup) return ''
+
+  state.bridgeOutput = (state.bridgeOutput || '') + pendingMarkup
+  state.bridgePendingAssistantContent = (state.bridgePendingAssistantContent || '') + pendingMarkup
+  const last = findOpenAssistantMessage(state, runMarker)
+  if (last) {
+    last.content += pendingMarkup
+  }
+  emit('message.delta', {
+    event: 'message.delta',
+    run_id: runId,
+    delta: pendingMarkup,
+    output: state.bridgeOutput,
+  })
+  return pendingMarkup
+}
+
 function finiteToken(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0
     ? Math.floor(value)
@@ -469,21 +501,7 @@ async function applyBridgeChunkAsync(
       // `[Ca`, etc. are silently dropped because no follow-up delta will
       // come for this assistant message — the next chunk is the tool call
       // itself. See bridge-delta.ts for full rationale.
-      const pendingMarkup = flushPendingToolCallMarkup(state)
-      if (pendingMarkup) {
-        state.bridgeOutput = (state.bridgeOutput || '') + pendingMarkup
-        state.bridgePendingAssistantContent = (state.bridgePendingAssistantContent || '') + pendingMarkup
-        const last = [...state.messages].reverse().find(m => m.runMarker === runMarker && m.role === 'assistant' && m.finish_reason == null)
-        if (last) {
-          last.content += pendingMarkup
-        }
-        emit('message.delta', {
-          event: 'message.delta',
-          run_id: chunk.run_id,
-          delta: pendingMarkup,
-          output: state.bridgeOutput,
-        })
-      }
+      flushPendingToolMarkupToAssistant(state, runMarker, chunk.run_id, emit)
       flushBridgePendingToDb(state, sessionId, runMarker)
       const toolName = (ev.tool_name as string) || ''
       const args = ev.args as Record<string, unknown> | undefined
@@ -734,25 +752,12 @@ async function applyBridgeChunkAsync(
     return
   }
 
-  flushBridgePendingToDb(state, sessionId)
   // If the run terminated while we still had a partial tool-call-marker
   // prefix buffered, flush it to the user-visible stream now. Discarding
   // it (which the line below was doing implicitly) silently drops the
   // final characters of the assistant message.
-  const pendingFinalMarkup = flushPendingToolCallMarkup(state)
-  if (pendingFinalMarkup) {
-    state.bridgeOutput = (state.bridgeOutput || '') + pendingFinalMarkup
-    const last = [...state.messages].reverse().find(m => m.runMarker === runMarker && m.role === 'assistant' && m.finish_reason == null)
-    if (last) {
-      last.content += pendingFinalMarkup
-    }
-    emit('message.delta', {
-      event: 'message.delta',
-      run_id: chunk.run_id,
-      delta: pendingFinalMarkup,
-      output: state.bridgeOutput,
-    })
-  }
+  flushPendingToolMarkupToAssistant(state, runMarker, chunk.run_id, emit)
+  flushBridgePendingToDb(state, sessionId)
   state.bridgePendingToolCallMarkup = undefined
   updateSessionStats(sessionId)
   await delay(BRIDGE_USAGE_FLUSH_DELAY_MS)

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -30,7 +30,7 @@ import { summarizeToolArguments } from './response-utils'
 import type { ContentBlock, SessionState } from './types'
 import type { ChatMessage } from '../../../lib/context-compressor'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
-import { filterBridgeToolCallMarkupDelta } from './bridge-delta'
+import { filterBridgeToolCallMarkupDelta, flushPendingToolCallMarkup } from './bridge-delta'
 
 const BRIDGE_USAGE_FLUSH_DELAY_MS = 200
 
@@ -464,6 +464,26 @@ async function applyBridgeChunkAsync(
         usage,
       )
     } else if (evType === 'tool.started') {
+      // Flush any partial tool-call-marker prefix that was held back by
+      // the markup filter. Without this, deltas ending in `[`, `[C`,
+      // `[Ca`, etc. are silently dropped because no follow-up delta will
+      // come for this assistant message — the next chunk is the tool call
+      // itself. See bridge-delta.ts for full rationale.
+      const pendingMarkup = flushPendingToolCallMarkup(state)
+      if (pendingMarkup) {
+        state.bridgeOutput = (state.bridgeOutput || '') + pendingMarkup
+        state.bridgePendingAssistantContent = (state.bridgePendingAssistantContent || '') + pendingMarkup
+        const last = [...state.messages].reverse().find(m => m.runMarker === runMarker && m.role === 'assistant' && m.finish_reason == null)
+        if (last) {
+          last.content += pendingMarkup
+        }
+        emit('message.delta', {
+          event: 'message.delta',
+          run_id: chunk.run_id,
+          delta: pendingMarkup,
+          output: state.bridgeOutput,
+        })
+      }
       flushBridgePendingToDb(state, sessionId, runMarker)
       const toolName = (ev.tool_name as string) || ''
       const args = ev.args as Record<string, unknown> | undefined
@@ -715,6 +735,24 @@ async function applyBridgeChunkAsync(
   }
 
   flushBridgePendingToDb(state, sessionId)
+  // If the run terminated while we still had a partial tool-call-marker
+  // prefix buffered, flush it to the user-visible stream now. Discarding
+  // it (which the line below was doing implicitly) silently drops the
+  // final characters of the assistant message.
+  const pendingFinalMarkup = flushPendingToolCallMarkup(state)
+  if (pendingFinalMarkup) {
+    state.bridgeOutput = (state.bridgeOutput || '') + pendingFinalMarkup
+    const last = [...state.messages].reverse().find(m => m.runMarker === runMarker && m.role === 'assistant' && m.finish_reason == null)
+    if (last) {
+      last.content += pendingFinalMarkup
+    }
+    emit('message.delta', {
+      event: 'message.delta',
+      run_id: chunk.run_id,
+      delta: pendingFinalMarkup,
+      output: state.bridgeOutput,
+    })
+  }
   state.bridgePendingToolCallMarkup = undefined
   updateSessionStats(sessionId)
   await delay(BRIDGE_USAGE_FLUSH_DELAY_MS)

--- a/tests/server/run-chat-bridge-delta.test.ts
+++ b/tests/server/run-chat-bridge-delta.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { filterBridgeToolCallMarkupDelta } from '../../packages/server/src/services/hermes/run-chat/bridge-delta'
+import { filterBridgeToolCallMarkupDelta, flushPendingToolCallMarkup } from '../../packages/server/src/services/hermes/run-chat/bridge-delta'
 
 describe('run-chat bridge delta filtering', () => {
   it('keeps ordinary assistant text', () => {
@@ -36,5 +36,13 @@ describe('run-chat bridge delta filtering', () => {
 
     expect(filterBridgeToolCallMarkupDelta(state, 'Text [Call')).toBe('Text ')
     expect(filterBridgeToolCallMarkupDelta(state, 'ing tool: terminal with arguments: {}]\nDone')).toBe('Done')
+  })
+
+  it('flushes an orphan partial marker suffix when no text chunk follows', () => {
+    const state = {}
+
+    expect(filterBridgeToolCallMarkupDelta(state, 'Text [Call')).toBe('Text ')
+    expect(flushPendingToolCallMarkup(state)).toBe('[Call')
+    expect(flushPendingToolCallMarkup(state)).toBe('')
   })
 })

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -232,6 +232,73 @@ describe('bridge run final context usage', () => {
     }))
   })
 
+  it('persists pending tool marker text before a bridge run completes', async () => {
+    const emit = vi.fn()
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    const state = makeState()
+    const persistedContent: string[] = []
+    flushBridgePendingToDbMock.mockImplementation((targetState: any) => {
+      persistedContent.push(targetState.bridgePendingAssistantContent || '')
+      targetState.bridgePendingAssistantContent = ''
+    })
+    ensureOpenBridgeAssistantMessageMock.mockImplementation((targetState: any, sessionId: string, runMarker: string) => {
+      let message = [...targetState.messages].reverse().find((m: any) => m.runMarker === runMarker && m.role === 'assistant' && m.finish_reason == null)
+      if (!message) {
+        message = {
+          id: targetState.messages.length + 1,
+          session_id: sessionId,
+          runMarker,
+          role: 'assistant',
+          content: '',
+          timestamp: Math.floor(Date.now() / 1000),
+        }
+        targetState.messages.push(message)
+      }
+      return message
+    })
+    const sessionMap = new Map([['session-1', state]])
+    const bridge = {
+      chat: vi.fn().mockResolvedValue({ run_id: 'run-1', status: 'started' }),
+      contextEstimate: vi.fn().mockResolvedValue({
+        token_count: 12345,
+        message_count: 2,
+        tool_count: 4,
+        system_prompt_chars: 13,
+      }),
+      streamOutput: vi.fn(async function* () {
+        yield { run_id: 'run-1', done: false, status: 'running', delta: 'Text [Call', events: [] }
+        yield { run_id: 'run-1', done: true, status: 'completed', output: '', events: [] }
+      }),
+    } as any
+
+    const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    await handleBridgeRun(
+      nsp,
+      socket,
+      { input: 'hello', session_id: 'session-1' },
+      'default',
+      sessionMap,
+      bridge,
+      false,
+      vi.fn(),
+      vi.fn(),
+    )
+
+    expect(persistedContent).toContain('Text [Call')
+    expect(emit).toHaveBeenCalledWith('message.delta', expect.objectContaining({
+      delta: 'Text ',
+      output: 'Text ',
+    }))
+    expect(emit).toHaveBeenCalledWith('message.delta', expect.objectContaining({
+      delta: '[Call',
+      output: 'Text [Call',
+    }))
+    expect(emit).toHaveBeenCalledWith('run.completed', expect.objectContaining({
+      output: 'Text [Call',
+    }))
+  })
+
   it('refreshes full context tokens when a bridge run fails', async () => {
     const emit = vi.fn()
     const nsp = makeNamespace(emit)


### PR DESCRIPTION
## Summary

- Preserve the original #990 bridge marker flush fix by cherry-picking the contributor commit.
- Fix the run-completion flush order so final pending marker-prefix text is added to `bridgePendingAssistantContent` before DB flush.
- Share the pending-marker flush path between `tool.started` and run completion, and add regression coverage for orphan partial markers and persistence.

## Why

#990 correctly identifies that partial `[Calling tool:` marker prefixes can be held back by the bridge delta filter and dropped at tool/run boundaries. The run-completion path still flushed to DB before adding the final pending text, so the live client could see recovered characters while persisted history remained truncated after refresh.

## Validation

- `npx vitest run tests/server/run-chat-bridge-delta.test.ts tests/server/run-chat-bridge-final-context.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `git diff --check`
