### PR TITLE
fix: forward clarify events from bridge to Web Chat UI

### DIFF
--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -612,10 +612,10 @@ async function applyBridgeChunkAsync(
         run_id: chunk.run_id,
         clarify_id: ev.clarify_id,
         question: ev.question,
-        choices: ev.choices,
+        choices: Array.isArray(ev.choices) ? ev.choices : null,
         timeout_ms: ev.timeout_ms,
       }
-      pushState(sessionMap, sessionId, 'clarify.requested', payload)
+      replaceState(sessionMap, sessionId, 'clarify.requested', payload)
       emit('clarify.requested', payload)
     } else if (evType === 'clarify.resolved') {
       const payload = {
@@ -623,7 +623,7 @@ async function applyBridgeChunkAsync(
         run_id: chunk.run_id,
         clarify_id: ev.clarify_id,
       }
-      pushState(sessionMap, sessionId, 'clarify.resolved', payload)
+      replaceState(sessionMap, sessionId, 'clarify.resolved', payload)
       emit('clarify.resolved', payload)
     } else if (evType === 'bridge.compression.requested') {
       const bridgeHistory = await buildDbHistory(sessionId, { excludeLastUser: true })

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -606,6 +606,25 @@ async function applyBridgeChunkAsync(
       }
       replaceState(sessionMap, sessionId, 'approval.resolved', payload)
       emit('approval.resolved', payload)
+    } else if (evType === 'clarify.requested') {
+      const payload = {
+        event: 'clarify.requested',
+        run_id: chunk.run_id,
+        clarify_id: ev.clarify_id,
+        question: ev.question,
+        choices: ev.choices,
+        timeout_ms: ev.timeout_ms,
+      }
+      pushState(sessionMap, sessionId, 'clarify.requested', payload)
+      emit('clarify.requested', payload)
+    } else if (evType === 'clarify.resolved') {
+      const payload = {
+        event: 'clarify.resolved',
+        run_id: chunk.run_id,
+        clarify_id: ev.clarify_id,
+      }
+      pushState(sessionMap, sessionId, 'clarify.resolved', payload)
+      emit('clarify.resolved', payload)
     } else if (evType === 'bridge.compression.requested') {
       const bridgeHistory = await buildDbHistory(sessionId, { excludeLastUser: true })
       const bridgeUsage = estimateUsageTokensFromMessages(bridgeHistory)


### PR DESCRIPTION
## Summary

Web Chat UI fails to render clarify() popups because the bridge agent does not forward `clarify.requested` and `clarify.resolved` events to the Web Chat frontend.

## Bug

When the AI agent calls `clarify()` with a question and choices, the event is received by the bridge but silently dropped — the Web Chat frontend never gets notified. The user sees no popup, and the conversation stalls until the 5-minute clarify timeout expires.

## Root Cause

`handle-bridge-run.ts` only forwards `approval.requested` / `approval.resolved` events. Clarify events have the same bridge→UI forwarding requirement but were missing.

## Fix

Added two event branches in `applyBridgeChunkAsync()`, mirroring the approval pattern:
- `clarify.requested` — forwards question, choices, clarify_id, timeout_ms to the UI
- `clarify.resolved` — forwards clarify_id resolution to the UI

Both use `pushState()` + `emit()`, consistent with the existing approval handler.

## Changed Files

- `packages/server/src/services/hermes/run-chat/handle-bridge-run.ts` (+19 lines)

## Test Plan

1. Start Web Chat with a profile that uses bridge mode
2. Trigger a scenario where the agent calls clarify()
3. Verify the clarify popup renders with question text and clickable choices
4. Select a choice and verify the conversation continues