### PR TITLE
fix(auth): 移除公开端点 /api/auth/status 中的用户名泄露

### DIFF
--- a/packages/client/src/api/auth.ts
+++ b/packages/client/src/api/auth.ts
@@ -2,7 +2,6 @@ import { request } from './client'
 
 export interface AuthStatus {
   hasPasswordLogin: boolean
-  username: string | null
   hasUsers?: boolean
 }
 

--- a/packages/server/src/controllers/auth.ts
+++ b/packages/server/src/controllers/auth.ts
@@ -8,7 +8,6 @@ import {
   countUsers,
   createUser,
   deleteUser,
-  findFirstUser,
   findUserById,
   findUserByUsername,
   listUsers,
@@ -27,10 +26,8 @@ import { listProfileNamesFromDisk } from '../services/hermes/hermes-profile'
  * Check if username/password login is configured (public).
  */
 export async function authStatus(ctx: Context) {
-  const firstUser = findFirstUser()
   ctx.body = {
     hasPasswordLogin: true,
-    username: firstUser?.username || DEFAULT_USERNAME,
     hasUsers: countUsers() > 0,
   }
 }


### PR DESCRIPTION
`GET /api/auth/status` 是一个无需认证的公开端点，当前返回了 `users` 表中第一个用户的 `username`，导致任何未认证访问者都能获取到至少一个有效用户名，可用于定向攻击。

实际上这个字段前端完全没用——`LoginView.vue` 里的 `fetchAuthStatus()` 只用作连通性检查，返回值直接被丢弃了。

**改动**（2 个文件，删 4 行）：

- `server`: `authStatus()` 返回体中移除 `username` 字段，顺便移除不再需要的 `findFirstUser` 导入
- `client`: `AuthStatus` 接口移除 `username: string | null` 类型声明

**影响范围**：该端点不再返回 `username`，仅保留 `hasPasswordLogin` 和 `hasUsers`。这两个字段前端同样没在用，不影响任何现有功能。