### PR TITLE
docs: update 0.6.3 changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Self-hosted AI chat dashboard for Hermes Agent — multi-model web UI with multi-platform integration",
   "repository": {
     "type": "git",

--- a/packages/client/src/data/changelog.ts
+++ b/packages/client/src/data/changelog.ts
@@ -6,6 +6,19 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.6.3',
+    date: '2026-05-27',
+    changes: [
+      'changelog.new_0_6_3_1',
+      'changelog.new_0_6_3_2',
+      'changelog.new_0_6_3_3',
+      'changelog.new_0_6_3_4',
+      'changelog.new_0_6_3_5',
+      'changelog.new_0_6_3_6',
+      'changelog.new_0_6_3_7',
+    ],
+  },
+  {
     version: '0.6.2',
     date: '2026-05-26',
     changes: [

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -1074,6 +1074,13 @@ jobTriggered: 'Job ausgelost',
 
   // Anderungsprotokoll
   changelog: {
+    new_0_6_3_1: 'Bridge-Spinner-Status wird nicht mehr als Modell-Reasoning gespeichert und verschmutzt dadurch keinen späteren Kontext',
+    new_0_6_3_2: 'History bietet jetzt Controls zum Import von Hermes-CLI-Sessions in die lokale Web-UI-Historie mit sichererer Nachrichten-Normalisierung',
+    new_0_6_3_3: 'Provider-Setup unterstützt editierbare eingebaute Base URLs, LM Studio als eingebauten Provider und Live-Erkennung über LM Studio /models',
+    new_0_6_3_4: 'OpenRouter-Anfragen über die Web-UI-Bridge enthalten jetzt Hermes Web UI App-Attribution-Header',
+    new_0_6_3_5: 'Der öffentliche auth status endpoint gibt den ersten Benutzernamen nicht mehr an nicht authentifizierte Anfragen aus',
+    new_0_6_3_6: 'DingTalk-Einstellungen enthalten jetzt ein AI Card Template ID Feld, gespeichert als DINGTALK_CARD_TEMPLATE_ID',
+    new_0_6_3_7: 'Bridge-Socket-JSON-Ausgaben bereinigen isolierte Unicode-Surrogate und verhindern dadurch SSE-Abstürze im Chat',
     new_0_6_2_1: 'Web Bridge unterstützt jetzt /plan-Befehle mit korrektem Run-Start und sichtbarem Befehlsstatus',
     new_0_6_2_2: 'Das Befehlsmenü im Chat-Eingabefeld enthält jetzt /goal und /subgoal mit Status, Pause, Resume, Done und Clear',
     new_0_6_2_3: 'Goal- und Subgoal-Workflows sind jetzt in Chat-Sessions integriert, inklusive Ziel-Fortsetzungen und Statusupdates',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -1296,6 +1296,13 @@ export default {
 
   // Changelog
   changelog: {
+    new_0_6_3_1: 'Bridge spinner status is no longer stored as model reasoning, preventing decorative thinking text from contaminating future context',
+    new_0_6_3_2: 'History now includes controls to import Hermes CLI sessions into the Web UI local history with safer message normalization',
+    new_0_6_3_3: 'Provider setup now supports editable built-in base URLs, LM Studio as a built-in provider, and live LM Studio /models discovery',
+    new_0_6_3_4: 'OpenRouter requests sent through the Web UI bridge now include Hermes Web UI app attribution headers',
+    new_0_6_3_5: 'The public auth status endpoint no longer exposes the first username to unauthenticated requests',
+    new_0_6_3_6: 'DingTalk settings now include an AI Card Template ID field persisted as DINGTALK_CARD_TEMPLATE_ID',
+    new_0_6_3_7: 'Bridge socket JSON output now sanitizes lone Unicode surrogate characters to prevent SSE crashes during chat',
     new_0_6_2_1: 'Web Bridge now supports /plan commands with correct run startup and visible command state',
     new_0_6_2_2: 'The chat input command menu now includes /goal and /subgoal commands, including status, pause, resume, done, and clear actions',
     new_0_6_2_3: 'Goal and subgoal workflows now integrate with chat sessions, including goal continuations and status updates',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -1074,6 +1074,13 @@ jobTriggered: 'Job ejecutado',
 
   // Registro de cambios
   changelog: {
+    new_0_6_3_1: 'El estado del spinner de Bridge ya no se guarda como reasoning del modelo, evitando que texto decorativo de thinking contamine el contexto futuro',
+    new_0_6_3_2: 'History ahora incluye controles para importar sesiones de Hermes CLI al historial local de Web UI con normalizacion de mensajes mas segura',
+    new_0_6_3_3: 'La configuracion de Provider admite base URLs integradas editables, LM Studio como provider integrado y descubrimiento en vivo desde LM Studio /models',
+    new_0_6_3_4: 'Las solicitudes OpenRouter enviadas por el bridge de Web UI ahora incluyen headers de atribucion de la app Hermes Web UI',
+    new_0_6_3_5: 'El endpoint publico de auth status ya no expone el primer nombre de usuario a solicitudes no autenticadas',
+    new_0_6_3_6: 'La configuracion de DingTalk ahora incluye un campo AI Card Template ID persistido como DINGTALK_CARD_TEMPLATE_ID',
+    new_0_6_3_7: 'La salida JSON del socket Bridge limpia caracteres Unicode surrogate aislados para evitar caidas de SSE durante el chat',
     new_0_6_2_1: 'Web Bridge ahora soporta comandos /plan con inicio correcto del run y estado visible del comando',
     new_0_6_2_2: 'El menú de comandos del input de chat ahora incluye /goal y /subgoal, con acciones de estado, pausa, reanudar, finalizar y limpiar',
     new_0_6_2_3: 'Los flujos de Goal y subgoal se integran con sesiones de chat, incluyendo continuaciones de objetivos y actualizaciones de estado',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -1074,6 +1074,13 @@ jobTriggered: 'Job declenche',
 
   // Journal des modifications
   changelog: {
+    new_0_6_3_1: 'Le statut du spinner Bridge n est plus stocke comme reasoning du modele, evitant que du texte thinking decoratif contamine le contexte futur',
+    new_0_6_3_2: 'History ajoute des controles pour importer les sessions Hermes CLI dans l historique local Web UI avec une normalisation de messages plus sure',
+    new_0_6_3_3: 'La configuration Provider prend en charge les base URLs integrees editables, LM Studio comme provider integre et la decouverte live via LM Studio /models',
+    new_0_6_3_4: 'Les requetes OpenRouter envoyees par le bridge Web UI incluent maintenant les headers d attribution Hermes Web UI',
+    new_0_6_3_5: 'L endpoint public auth status n expose plus le premier nom utilisateur aux requetes non authentifiees',
+    new_0_6_3_6: 'Les reglages DingTalk incluent maintenant un champ AI Card Template ID persiste en DINGTALK_CARD_TEMPLATE_ID',
+    new_0_6_3_7: 'La sortie JSON du socket Bridge nettoie les caracteres Unicode surrogate isoles afin d eviter les crashs SSE du chat',
     new_0_6_2_1: 'Web Bridge prend désormais en charge les commandes /plan avec démarrage correct du run et état de commande visible',
     new_0_6_2_2: 'Le menu de commandes du champ de chat inclut maintenant /goal et /subgoal, avec les actions état, pause, reprise, terminé et effacer',
     new_0_6_2_3: 'Les workflows Goal et subgoal sont intégrés aux sessions de chat, avec reprises de goal et mises à jour de statut',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -1074,6 +1074,13 @@ export default {
 
   // 更新履歴
   changelog: {
+    new_0_6_3_1: 'Bridge spinner の状態をモデル reasoning として保存しないようにし、装飾的な thinking テキストが後続コンテキストを汚染しないようにしました',
+    new_0_6_3_2: 'History に Hermes CLI セッションを Web UI のローカル履歴へインポートする操作を追加し、メッセージ構造をより安全に正規化します',
+    new_0_6_3_3: 'Provider 設定で組み込み base URL を編集できるようになり、LM Studio を組み込み Provider として追加し、LM Studio /models のライブ取得に対応しました',
+    new_0_6_3_4: 'Web UI bridge 経由の OpenRouter リクエストに Hermes Web UI のアプリ attribution headers を付与するようになりました',
+    new_0_6_3_5: '公開 auth status endpoint が未認証リクエストに最初のユーザー名を返さないようにしました',
+    new_0_6_3_6: 'DingTalk 設定に AI Card Template ID フィールドを追加し、DINGTALK_CARD_TEMPLATE_ID として保存します',
+    new_0_6_3_7: 'Bridge socket JSON 出力で孤立した Unicode surrogate 文字をサニタイズし、チャット SSE のクラッシュを防ぎます',
     new_0_6_2_1: 'Web Bridge が /plan コマンドに対応し、run の開始とコマンド状態の表示が正しく動作するようになりました',
     new_0_6_2_2: 'チャット入力のコマンドメニューに /goal と /subgoal を追加し、status、pause、resume、done、clear 操作に対応しました',
     new_0_6_2_3: 'Goal と subgoal のワークフローをチャットセッションに統合し、目標の継続とステータス更新に対応しました',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -1074,6 +1074,13 @@ export default {
 
   // 변경 이력
   changelog: {
+    new_0_6_3_1: 'Bridge spinner 상태를 더 이상 모델 reasoning 으로 저장하지 않아 장식용 thinking 텍스트가 이후 컨텍스트를 오염시키지 않습니다',
+    new_0_6_3_2: 'History 에 Hermes CLI 세션을 Web UI 로컬 기록으로 가져오는 컨트롤을 추가하고 메시지 구조를 더 안전하게 정규화합니다',
+    new_0_6_3_3: 'Provider 설정에서 기본 base URL 편집을 지원하고 LM Studio 를 내장 Provider 로 추가했으며 LM Studio /models 실시간 검색을 지원합니다',
+    new_0_6_3_4: 'Web UI bridge 를 통해 전송되는 OpenRouter 요청에 Hermes Web UI 앱 attribution headers 가 포함됩니다',
+    new_0_6_3_5: '공개 auth status endpoint 가 인증되지 않은 요청에 첫 번째 사용자 이름을 더 이상 노출하지 않습니다',
+    new_0_6_3_6: 'DingTalk 설정에 AI Card Template ID 필드를 추가하고 DINGTALK_CARD_TEMPLATE_ID 로 저장합니다',
+    new_0_6_3_7: 'Bridge socket JSON 출력이 고립된 Unicode surrogate 문자를 정리하여 채팅 SSE 충돌을 방지합니다',
     new_0_6_2_1: 'Web Bridge가 /plan 명령을 지원하며 run 시작과 명령 상태 표시가 올바르게 동작합니다',
     new_0_6_2_2: '채팅 입력 명령 메뉴에 /goal 및 /subgoal이 추가되어 상태, 일시정지, 재개, 완료, 초기화 작업을 지원합니다',
     new_0_6_2_3: 'Goal 및 subgoal 워크플로가 채팅 세션에 통합되어 목표 이어가기와 상태 업데이트를 지원합니다',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -1074,6 +1074,13 @@ jobTriggered: 'Job acionado',
 
   // Registro de alteracoes
   changelog: {
+    new_0_6_3_1: 'O status do spinner do Bridge nao e mais salvo como reasoning do modelo, evitando que texto thinking decorativo contamine o contexto futuro',
+    new_0_6_3_2: 'History agora inclui controles para importar sessoes Hermes CLI para o historico local da Web UI com normalizacao de mensagens mais segura',
+    new_0_6_3_3: 'A configuracao de Provider suporta base URLs integradas editaveis, LM Studio como provider integrado e descoberta ao vivo via LM Studio /models',
+    new_0_6_3_4: 'Requests OpenRouter enviados pelo bridge da Web UI agora incluem headers de atribuicao do app Hermes Web UI',
+    new_0_6_3_5: 'O endpoint publico de auth status nao expoe mais o primeiro nome de usuario para requests nao autenticados',
+    new_0_6_3_6: 'As configuracoes do DingTalk agora incluem um campo AI Card Template ID persistido como DINGTALK_CARD_TEMPLATE_ID',
+    new_0_6_3_7: 'A saida JSON do socket Bridge sanitiza caracteres Unicode surrogate isolados para evitar falhas SSE durante o chat',
     new_0_6_2_1: 'Web Bridge agora suporta comandos /plan com início correto do run e estado visível do comando',
     new_0_6_2_2: 'O menu de comandos no input do chat agora inclui /goal e /subgoal, com ações de status, pausar, retomar, concluir e limpar',
     new_0_6_2_3: 'Workflows de Goal e subgoal agora integram sessões de chat, incluindo continuações de objetivo e atualizações de status',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -1301,6 +1301,13 @@ export default {
 
   // 更新日誌
   changelog: {
+    new_0_6_3_1: 'Bridge spinner 狀態不再寫入模型 reasoning，避免裝飾性 thinking 文字污染後續上下文',
+    new_0_6_3_2: 'History 新增 Hermes CLI 工作階段匯入控制，並在匯入時更安全地規範化訊息結構',
+    new_0_6_3_3: 'Provider 設定支援編輯內建 base URL，新增 LM Studio 內建 Provider，並支援從 LM Studio /models 即時發現模型',
+    new_0_6_3_4: '透過 Web UI bridge 發起的 OpenRouter 請求會攜帶 Hermes Web UI 應用歸因 headers',
+    new_0_6_3_5: '公開 auth status 介面不再向未登入請求暴露第一個使用者名稱',
+    new_0_6_3_6: '釘釘設定新增 AI Card Template ID，並持久化為 DINGTALK_CARD_TEMPLATE_ID',
+    new_0_6_3_7: 'Bridge socket JSON 輸出會清洗孤立 Unicode surrogate 字元，避免聊天 SSE 崩潰',
     new_0_6_2_1: 'Web Bridge 支援 /plan 命令，計畫命令會正確啟動並顯示執行狀態',
     new_0_6_2_2: '聊天輸入框指令選單新增 /goal 和 /subgoal，支援狀態、暫停、恢復、完成和清空等操作',
     new_0_6_2_3: 'Goal 與 subgoal 工作流接入聊天工作階段，支援目標延續與狀態更新',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -1298,6 +1298,13 @@ export default {
 
   // 更新日志
   changelog: {
+    new_0_6_3_1: 'Bridge spinner 状态不再写入模型 reasoning，避免装饰性 thinking 文案污染后续上下文',
+    new_0_6_3_2: 'History 新增 Hermes CLI 会话导入控制，并在导入时更安全地规范化消息结构',
+    new_0_6_3_3: 'Provider 配置支持编辑内置 base URL，新增 LM Studio 内置 Provider，并支持从 LM Studio /models 实时发现模型',
+    new_0_6_3_4: '通过 Web UI bridge 发起的 OpenRouter 请求会携带 Hermes Web UI 应用归因 headers',
+    new_0_6_3_5: '公开 auth status 接口不再向未登录请求暴露第一个用户名',
+    new_0_6_3_6: '钉钉设置新增 AI Card Template ID，并持久化为 DINGTALK_CARD_TEMPLATE_ID',
+    new_0_6_3_7: 'Bridge socket JSON 输出会清洗孤立 Unicode surrogate 字符，避免聊天 SSE 崩溃',
     new_0_6_2_1: 'Web Bridge 支持 /plan 命令，计划命令会正确启动并展示运行状态',
     new_0_6_2_2: '聊天输入框指令菜单新增 /goal 和 /subgoal，支持状态、暂停、恢复、完成和清空等操作',
     new_0_6_2_3: 'Goal 和 subgoal 工作流接入聊天会话，支持目标延续和状态更新',


### PR DESCRIPTION
## Summary

- add a 0.6.3 changelog entry for all PRs merged after v0.6.2
- add localized changelog strings across all supported locales

Included PRs:
- #1051 bridge spinner thinking cleanup
- #1053 History Hermes CLI session import controls
- #1054 provider base URL handling and LM Studio support
- #1057 OpenRouter Web UI app attribution headers
- #1055 auth status username leak fix
- #1056 DingTalk AI Card Template ID setting
- #1059 bridge JSON surrogate sanitization

## Validation

- `npx vitest run tests/client/i18n-coverage.test.ts`
