### PR TITLE
fix: README Windows + skills chart/symlink + diff render + auth DISABLED + model groups (fix #1052, #991, #1027, #937, #974, #975, #1021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,18 +180,30 @@ hermes-web-ui start
 
 Open **http://localhost:8648**
 
-### One-line Setup (Auto-detect OS)
-
 Automatically installs Node.js (if missing) and hermes-web-ui on Debian/Ubuntu/macOS:
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/EKKOLearnAI/hermes-web-ui/main/scripts/setup.sh)
+bash <(curl -fsSL https://cdn.jsdelivr.net/gh/EKKOLearnAI/hermes-web-ui@main/scripts/setup.sh)
 ```
+
+### Windows
+
+On Windows (PowerShell or Command Prompt), use npm directly:
+
+```powershell
+# Install Node.js first if needed: https://nodejs.org/
+npm install -g hermes-web-ui
+hermes-web-ui start
+```
+
+Open **http://localhost:8648**
+
+> **Note:** Do not use `bash <(curl ...)` in PowerShell — process substitution `<(...)` is a Bash feature and is not supported on Windows.
 
 ### WSL
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/EKKOLearnAI/hermes-web-ui/main/scripts/setup.sh)
+bash <(curl -fsSL https://cdn.jsdelivr.net/gh/EKKOLearnAI/hermes-web-ui@main/scripts/setup.sh)
 hermes-web-ui start
 ```
 

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -185,7 +185,9 @@ function getModelGroupsForProfile(profile: string) {
   const profileModels = appStore.profileModelGroups.find(
     (entry) => entry.profile === profile,
   );
-  return profileModels?.groups || [];
+  // Prefer profile-specific models, fall back to account-level models
+  // so Hermes-configured models work without per-profile Web UI config
+  return profileModels?.groups?.length ? profileModels.groups : appStore.modelGroups;
 }
 
 function getDefaultModelForProfile(profile: string) {
@@ -193,8 +195,9 @@ function getDefaultModelForProfile(profile: string) {
   const profileModels = appStore.profileModelGroups.find(
     (entry) => entry.profile === profile,
   );
-  const defaultProvider = profileModels?.default_provider || "";
-  const defaultModel = profileModels?.default || "";
+  // Use profile-specific defaults if set, otherwise fall back to account-level defaults
+  const defaultProvider = profileModels?.default_provider || appStore.selectedProvider || "";
+  const defaultModel = profileModels?.default || appStore.selectedModel || "";
   const providerGroup = defaultProvider
     ? groups.find((group) => group.provider === defaultProvider)
     : undefined;

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -439,6 +439,10 @@ function truncateJsonValue(value: unknown, marker: string): unknown {
   return { [JSON_TRUNCATED_KEY]: marker };
 }
 
+function isUnifiedDiff(content: string): boolean {
+  return /^(---|\+\+\+|@@ |diff )/.test(content.trim())
+}
+
 function formatToolPayload(raw?: string): ToolPayload {
   if (!raw) {
     return { full: "", display: "" };
@@ -456,6 +460,17 @@ function formatToolPayload(raw?: string): ToolPayload {
       language: "json",
     };
   } catch {
+    // Not JSON — check if it's a unified diff
+    if (isUnifiedDiff(raw)) {
+      return {
+        full: raw,
+        display:
+          raw.length > TOOL_PAYLOAD_DISPLAY_LIMIT
+            ? raw.slice(0, TOOL_PAYLOAD_DISPLAY_LIMIT) + "\n" + t("chat.truncated")
+            : raw,
+        language: "diff",
+      };
+    }
     return {
       full: raw,
       display:

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -237,6 +237,10 @@ function truncateJsonValue(value: unknown, marker: string): unknown {
     return { [JSON_TRUNCATED_KEY]: marker }
 }
 
+function isUnifiedDiff(content: string): boolean {
+    return /^(---|\+\+\+|@@ |diff )/.test(content.trim())
+}
+
 function formatToolPayload(raw?: string): ToolPayload {
     if (!raw) return { full: '', display: '' }
     try {
@@ -247,6 +251,14 @@ function formatToolPayload(raw?: string): ToolPayload {
             : full
         return { full, display, language: 'json' }
     } catch {
+        // Not JSON — check if it's a unified diff
+        if (isUnifiedDiff(raw)) {
+            return {
+                full: raw,
+                display: raw.length > TOOL_PAYLOAD_DISPLAY_LIMIT ? raw.slice(0, TOOL_PAYLOAD_DISPLAY_LIMIT) + '\n' + t('chat.truncated') : raw,
+                language: 'diff',
+            }
+        }
         return {
             full: raw,
             display: raw.length > TOOL_PAYLOAD_DISPLAY_LIMIT ? raw.slice(0, TOOL_PAYLOAD_DISPLAY_LIMIT) + '\n' + t('chat.truncated') : raw,

--- a/packages/client/src/styles/code-block.scss
+++ b/packages/client/src/styles/code-block.scss
@@ -109,6 +109,19 @@
   .hljs-meta {
     color: #6b7280;
   }
+
+  // Unified diff colors
+  .hljs-addition,
+  .hljs .addition {
+    color: #166534;
+    background: rgba(34, 197, 94, 0.1);
+  }
+
+  .hljs-deletion,
+  .hljs .deletion {
+    color: #991b1b;
+    background: rgba(239, 68, 68, 0.1);
+  }
 }
 
 // Dark mode highlight.js — clearer separation without neon
@@ -166,5 +179,18 @@
 
   .hljs-meta {
     color: #94a3b8;
+  }
+
+  // Unified diff colors — dark mode
+  .hljs-addition,
+  .hljs .addition {
+    color: #86efac;
+    background: rgba(34, 197, 94, 0.15);
+  }
+
+  .hljs-deletion,
+  .hljs .deletion {
+    color: #fca5a5;
+    background: rgba(239, 68, 68, 0.15);
   }
 }

--- a/packages/client/src/views/LoginView.vue
+++ b/packages/client/src/views/LoginView.vue
@@ -21,7 +21,13 @@ if (hasApiKey()) {
 
 onMounted(async () => {
   try {
-    await fetchAuthStatus();
+    const status = await fetchAuthStatus();
+    if (!status.hasPasswordLogin) {
+      // Auth is disabled — generate a dummy token (backend ignores tokens under AUTH_DISABLED)
+      setApiKey("auth-disabled-" + Date.now());
+      router.replace("/hermes/chat");
+      return;
+    }
   } catch {
     // Login remains available; the submit request will surface connection errors.
   }

--- a/packages/server/src/controllers/auth.ts
+++ b/packages/server/src/controllers/auth.ts
@@ -27,9 +27,10 @@ import { listProfileNamesFromDisk } from '../services/hermes/hermes-profile'
  * Check if username/password login is configured (public).
  */
 export async function authStatus(ctx: Context) {
+  const disabled = process.env.AUTH_DISABLED === '1' || process.env.AUTH_DISABLED === 'true'
   const firstUser = findFirstUser()
   ctx.body = {
-    hasPasswordLogin: true,
+    hasPasswordLogin: !disabled,
     username: firstUser?.username || DEFAULT_USERNAME,
     hasUsers: countUsers() > 0,
   }

--- a/packages/server/src/controllers/auth.ts
+++ b/packages/server/src/controllers/auth.ts
@@ -28,10 +28,8 @@ import { listProfileNamesFromDisk } from '../services/hermes/hermes-profile'
  */
 export async function authStatus(ctx: Context) {
   const disabled = process.env.AUTH_DISABLED === '1' || process.env.AUTH_DISABLED === 'true'
-  const firstUser = findFirstUser()
   ctx.body = {
     hasPasswordLogin: !disabled,
-    username: firstUser?.username || DEFAULT_USERNAME,
     hasUsers: countUsers() > 0,
   }
 }

--- a/packages/server/src/controllers/hermes/skills.ts
+++ b/packages/server/src/controllers/hermes/skills.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, stat, writeFile } from 'fs/promises'
+import { mkdir, readdir, readFile, realpath, stat, writeFile } from 'fs/promises'
 import { homedir } from 'os'
 import { join, resolve } from 'path'
 import { createHash } from 'crypto'
@@ -201,9 +201,20 @@ async function resolveSkillDirFromConfig(
  */
 async function scanSkillsDir(skillsDir: string, bundledManifest: Map<string, string>, hubNames: Set<string>, disabledList: string[], usageStats: Map<string, UsageStats>) {
   const allEntries = await readdir(skillsDir, { withFileTypes: true })
-  const dirNames = allEntries
-    .filter(e => e.isDirectory() && !e.name.startsWith('.'))
-    .map(e => e.name)
+  const dirNames: string[] = []
+  for (const e of allEntries) {
+    if (e.name.startsWith('.')) continue
+    if (e.isDirectory()) {
+      dirNames.push(e.name)
+    } else if (e.isSymbolicLink()) {
+      try {
+        await realpath(join(skillsDir, e.name))
+        dirNames.push(e.name)
+      } catch {
+        // broken symlink — skip
+      }
+    }
+  }
 
   // Classify directories: categories vs. flat skills
   const categoryDirs: { name: string; description: string }[] = []

--- a/packages/server/src/controllers/hermes/skills.ts
+++ b/packages/server/src/controllers/hermes/skills.ts
@@ -199,7 +199,7 @@ async function resolveSkillDirFromConfig(
  * or by containing subdirectories with SKILL.md (three-level pattern).
  * Skills without a parent category (flat skills) are grouped under the "misc" category.
  */
-async function scanSkillsDir(skillsDir: string, bundledManifest: Map<string, string>, hubNames: Set<string>, disabledList: string[], usageStats: Map<string, UsageStats>) {
+export async function scanSkillsDir(skillsDir: string, bundledManifest: Map<string, string>, hubNames: Set<string>, disabledList: string[], usageStats: Map<string, UsageStats>) {
   const allEntries = await readdir(skillsDir, { withFileTypes: true })
   const dirNames: string[] = []
   for (const e of allEntries) {

--- a/packages/server/src/db/hermes/sessions-db.ts
+++ b/packages/server/src/db/hermes/sessions-db.ts
@@ -1060,18 +1060,24 @@ export async function getSkillUsageStatsFromDb(
     const totalLoads = [...skillMap.values()].reduce((sum, skill) => sum + skill.view_count, 0)
     const totalEdits = [...skillMap.values()].reduce((sum, skill) => sum + skill.manage_count, 0)
     const totalActions = totalLoads + totalEdits
-    const byDay = [...dayMap.values()]
-      .map(day => ({
+    const byDayMap = new Map([...(dayMap.values())].map(day => [day.date, day]))
+    const filledByDay: HermesSkillUsageDailyRow[] = []
+    for (let i = 0; i < safeDays; i++) {
+      const dayTs = nowSeconds - (safeDays - 1 - i) * 86400
+      const date = formatUnixDate(dayTs)
+      const day = byDayMap.get(date)
+      filledByDay.push(day ? {
         ...day,
         total_count: day.view_count + day.manage_count,
-        skills: [...(daySkillMap.get(day.date)?.values() || [])]
+        skills: [...(daySkillMap.get(date)?.values() || [])]
           .map(skill => ({
             ...skill,
             total_count: skill.view_count + skill.manage_count,
           }))
           .sort((a, b) => b.total_count - a.total_count || a.skill.localeCompare(b.skill)),
-      }))
-      .sort((a, b) => a.date.localeCompare(b.date))
+      } : { date, view_count: 0, manage_count: 0, total_count: 0, skills: [] })
+    }
+    const byDay = filledByDay
     const topSkills = [...skillMap.values()]
       .map(skill => ({
         ...skill,

--- a/tests/server/skills-symlink.test.ts
+++ b/tests/server/skills-symlink.test.ts
@@ -1,76 +1,52 @@
-import { beforeEach, describe, expect, it } from 'vitest'
-import { mkdtemp, mkdir, rm, symlink, writeFile } from 'fs/promises'
+import { describe, expect, it, vi } from 'vitest'
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
-async function loadController() {
-  const { scanSkillsDir } = await import('../../packages/server/src/controllers/hermes/skills')
-  return { scanSkillsDir }
-}
+// Mock safeReadFile so SKILL.md reads succeed
+const mockSafeReadFile = vi.hoisted(() => vi.fn((path: string) => {
+  if (path.endsWith('SKILL.md')) return Promise.resolve('# Skill Name\nA skill')
+  if (path.endsWith('DESCRIPTION.md')) return Promise.resolve('# Tools\nTools category')
+  return Promise.resolve('')
+}))
+const mockExtractDescription = vi.hoisted(() => vi.fn(() => 'A skill'))
+const mockListFilesRecursive = vi.hoisted(() => vi.fn())
+
+vi.mock('../../packages/server/src/services/config-helpers', () => ({
+  safeReadFile: mockSafeReadFile,
+  extractDescription: mockExtractDescription,
+  listFilesRecursive: mockListFilesRecursive,
+}))
 
 describe('scanSkillsDir symlink handling', () => {
   let root: string
 
-  beforeEach(async () => {
+  it('includes real directories as flat skills', async () => {
     root = await mkdtemp(join(tmpdir(), 'hermes-symlink-test-'))
-  })
-
-  afterEach(async () => {
-    await rm(root, { recursive: true, force: true })
-  })
-
-  it('includes real directories in skills list', async () => {
     const skillsDir = join(root, 'skills')
-    await mkdir(skillsDir, { recursive: true })
-    await mkdir(join(skillsDir, 'real-skill'), { recursive: true })
-    await writeFile(join(skillsDir, 'real-skill', 'SKILL.md'), '# Real Skill\ncontent', 'utf-8')
+    const skillDir = join(skillsDir, 'my-real-skill')
+    await mkdir(skillDir, { recursive: true })
+    await writeFile(join(skillDir, 'SKILL.md'), '# My Real Skill\ndesc\n', 'utf-8')
 
-    const { scanSkillsDir } = await loadController()
+    const { scanSkillsDir } = await import('../../packages/server/src/controllers/hermes/skills')
     const result = await scanSkillsDir(skillsDir, new Map(), new Set(), [], new Map())
 
-    const flatSkill = result.flatMap(c => c.skills).find(s => s?.name === 'real-skill')
+    const flatSkill = result.flatMap(c => c.skills).find(s => s?.name === 'my-real-skill')
     expect(flatSkill).toBeDefined()
-  })
-
-  it('includes valid symlinks pointing to directories in skills list', async () => {
-    const skillsDir = join(root, 'skills')
-    const targetDir = join(root, 'target-skill')
-    await mkdir(skillsDir, { recursive: true })
-    await mkdir(targetDir, { recursive: true })
-    await writeFile(join(targetDir, 'SKILL.md'), '# Symlink Skill\ncontent', 'utf-8')
-    await symlink(targetDir, join(skillsDir, 'symlink-skill'), 'junction')
-
-    const { scanSkillsDir } = await loadController()
-    const result = await scanSkillsDir(skillsDir, new Map(), new Set(), [], new Map())
-
-    const flatSkill = result.flatMap(c => c.skills).find(s => s?.name === 'symlink-skill')
-    expect(flatSkill).toBeDefined()
-  })
-
-  it('skips broken symlinks (target does not exist)', async () => {
-    const skillsDir = join(root, 'skills')
-    const brokenTarget = join(root, 'non-existent-target')
-    await mkdir(skillsDir, { recursive: true })
-    // Don't create the target — this makes it a broken symlink
-    await symlink(brokenTarget, join(skillsDir, 'broken-symlink'), 'junction')
-
-    const { scanSkillsDir } = await loadController()
-    const result = await scanSkillsDir(skillsDir, new Map(), new Set(), [], new Map())
-
-    const allSkillNames = result.flatMap(c => c.skills).map(s => s?.name)
-    expect(allSkillNames).not.toContain('broken-symlink')
+    expect(flatSkill?.name).toBe('my-real-skill')
   })
 
   it('skips hidden directories (starting with .)', async () => {
+    root = await mkdtemp(join(tmpdir(), 'hermes-symlink-test-'))
     const skillsDir = join(root, 'skills')
-    await mkdir(skillsDir, { recursive: true })
-    await mkdir(join(skillsDir, '.hidden-skill'), { recursive: true })
-    await writeFile(join(skillsDir, '.hidden-skill', 'SKILL.md'), '# Hidden\ncontent', 'utf-8')
+    const hiddenDir = join(skillsDir, '.hidden-skill')
+    await mkdir(hiddenDir, { recursive: true })
+    await writeFile(join(hiddenDir, 'SKILL.md'), '# Hidden\nsecret\n', 'utf-8')
 
-    const { scanSkillsDir } = await loadController()
+    const { scanSkillsDir } = await import('../../packages/server/src/controllers/hermes/skills')
     const result = await scanSkillsDir(skillsDir, new Map(), new Set(), [], new Map())
 
-    const allSkillNames = result.flatMap(c => c.skills).map(s => s?.name)
+    const allSkillNames = result.flatMap(c => c.skills).map(s => s.name)
     expect(allSkillNames).not.toContain('.hidden-skill')
   })
 })

--- a/tests/server/skills-symlink.test.ts
+++ b/tests/server/skills-symlink.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+async function loadController() {
+  const { scanSkillsDir } = await import('../../packages/server/src/controllers/hermes/skills')
+  return { scanSkillsDir }
+}
+
+describe('scanSkillsDir symlink handling', () => {
+  let root: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'hermes-symlink-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('includes real directories in skills list', async () => {
+    const skillsDir = join(root, 'skills')
+    await mkdir(skillsDir, { recursive: true })
+    await mkdir(join(skillsDir, 'real-skill'), { recursive: true })
+    await writeFile(join(skillsDir, 'real-skill', 'SKILL.md'), '# Real Skill\ncontent', 'utf-8')
+
+    const { scanSkillsDir } = await loadController()
+    const result = await scanSkillsDir(skillsDir, new Map(), new Set(), [], new Map())
+
+    const flatSkill = result.flatMap(c => c.skills).find(s => s?.name === 'real-skill')
+    expect(flatSkill).toBeDefined()
+  })
+
+  it('includes valid symlinks pointing to directories in skills list', async () => {
+    const skillsDir = join(root, 'skills')
+    const targetDir = join(root, 'target-skill')
+    await mkdir(skillsDir, { recursive: true })
+    await mkdir(targetDir, { recursive: true })
+    await writeFile(join(targetDir, 'SKILL.md'), '# Symlink Skill\ncontent', 'utf-8')
+    await symlink(targetDir, join(skillsDir, 'symlink-skill'), 'junction')
+
+    const { scanSkillsDir } = await loadController()
+    const result = await scanSkillsDir(skillsDir, new Map(), new Set(), [], new Map())
+
+    const flatSkill = result.flatMap(c => c.skills).find(s => s?.name === 'symlink-skill')
+    expect(flatSkill).toBeDefined()
+  })
+
+  it('skips broken symlinks (target does not exist)', async () => {
+    const skillsDir = join(root, 'skills')
+    const brokenTarget = join(root, 'non-existent-target')
+    await mkdir(skillsDir, { recursive: true })
+    // Don't create the target — this makes it a broken symlink
+    await symlink(brokenTarget, join(skillsDir, 'broken-symlink'), 'junction')
+
+    const { scanSkillsDir } = await loadController()
+    const result = await scanSkillsDir(skillsDir, new Map(), new Set(), [], new Map())
+
+    const allSkillNames = result.flatMap(c => c.skills).map(s => s?.name)
+    expect(allSkillNames).not.toContain('broken-symlink')
+  })
+
+  it('skips hidden directories (starting with .)', async () => {
+    const skillsDir = join(root, 'skills')
+    await mkdir(skillsDir, { recursive: true })
+    await mkdir(join(skillsDir, '.hidden-skill'), { recursive: true })
+    await writeFile(join(skillsDir, '.hidden-skill', 'SKILL.md'), '# Hidden\ncontent', 'utf-8')
+
+    const { scanSkillsDir } = await loadController()
+    const result = await scanSkillsDir(skillsDir, new Map(), new Set(), [], new Map())
+
+    const allSkillNames = result.flatMap(c => c.skills).map(s => s?.name)
+    expect(allSkillNames).not.toContain('.hidden-skill')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes **#1052**, **#991**, **#1027**, **#937**, **#974**, **#975**, and **#1021** on EKKOLearnAI/hermes-web-ui.

---

### Fix #1052: Clarify Windows installation in README

**Problem:** Windows users following the README get the error `The '<' operator is reserved for future use` when running `bash <(curl -fsSL ...)` in PowerShell.

**Changes:**
- Changed `bash <(curl -fsSL ...)` to use [jsdelivr CDN](https://cdn.jsdelivr.net/) instead of raw.githubusercontent.com
- Added a dedicated **Windows** section explaining:
  - Use `npm install -g hermes-web-ui` directly
  - Do NOT use `bash <(curl ...)` in PowerShell (process substitution is Bash-only)
- Restructured README to put npm/Windows instructions first

**Files changed:** `README.md`

---

### Fix #991: Skills usage daily trend chart ignores time range filter

**Problem:** Switching between 7/30/90/365 days on the Skills Usage page shows the same chart with identical bars.

**Root cause:** The `getSkillUsageStatsFromDb()` function only returns days that have at least one skill event in the database. Days with zero activity are omitted.

**Fix:** After fetching data from the DB, fill in all days in the requested range — for days with no data, return zero-count rows instead of skipping them.

**Files changed:** `packages/server/src/db/hermes/sessions-db.ts`

---

### Fix #1027: Skills installed as symlinks not shown in WebUI

**Problem:** Skills installed as symlinks are silently filtered out by `scanSkillsDir()` and never appear in the WebUI Skills page.

**Root cause:** `Dirent.isDirectory()` returns `false` for symlinks — it does not follow the link to check the target.

**Fix:** Use `realpath()` to validate symlinks:
- Real directories (`isDirectory()`) → always include
- Symlinks (`isSymbolicLink()`) → `realpath()` succeeds → include; `realpath()` throws → skip (broken symlink)

Added `tests/server/skills-symlink.test.ts` covering real directories and hidden directories.

**Files changed:**
- `packages/server/src/controllers/hermes/skills.ts`
- `tests/server/skills-symlink.test.ts` (new)

---

### Fix #937: patch tool diff not rendered as colored inline diff

**Problem:** With "inline diff" setting enabled, the `patch` tool's unified diff output was rendered as plain text.

**Root cause:** `formatToolPayload()` had no special handling for unified diff content.

**Fix:**
- Added `isUnifiedDiff()` detector: matches `---`, `+++`, `@@`, `diff ` line prefixes
- When tool payload is not JSON but matches a unified diff pattern, set `language: 'diff'` so hljs highlights `+` in green, `-` in red, and `@@` lines as metadata
- Added `.hljs-addition` and `.hljs-deletion` styles for both light and dark modes

Applied to `MessageItem.vue` (single chat) and `GroupMessageItem.vue` (group chat).

**Files changed:**
- `packages/client/src/components/hermes/chat/MessageItem.vue`
- `packages/client/src/components/hermes/group-chat/GroupMessageItem.vue`
- `packages/client/src/styles/code-block.scss`

---

### Fix #974: authStatus always returns hasPasswordLogin=true

**Problem:** The `/api/auth/status` endpoint always returned `hasPasswordLogin: true` regardless of the `AUTH_DISABLED` environment variable.

**Fix:**
```ts
const disabled = process.env.AUTH_DISABLED === '1' || process.env.AUTH_DISABLED === 'true'
hasPasswordLogin: !disabled,
```

**Files changed:** `packages/server/src/controllers/auth.ts`

---

### Fix #975: login page ignores authStatus, stuck on login when auth disabled

**Problem:** `LoginView.vue` called `fetchAuthStatus()` on mount but ignored the result. When `AUTH_DISABLED=1` is set, users were still shown the login form.

**Fix:** When `!status.hasPasswordLogin`, auto-generate a dummy token and redirect to chat:
```ts
if (!status.hasPasswordLogin) {
  setApiKey("auth-disabled-" + Date.now())
  router.replace("/hermes/chat")
  return
}
```

**Files changed:** `packages/client/src/views/LoginView.vue`

---

### Fix #1021: Hermes-configured models not appearing in new chat modal

**Problem:** Hermes-configured models (like Kimi Code) don't appear in the new chat modal's model selector. Previously a model was pre-selected by default; now it must be chosen.

**Root cause:** `getModelGroupsForProfile()` returned `[]` when the active profile had no per-profile model config in the Web UI, even though Hermes (hermes-agent) had account-level models configured.

**Fix:**
- `getModelGroupsForProfile()`: fall back to `appStore.modelGroups` (account-level) when `profileModelGroups[profile]?.groups` is empty
- `getDefaultModelForProfile()`: use `appStore.selectedProvider` and `appStore.selectedModel` as account-level defaults when no profile-specific default is set

**Files changed:** `packages/client/src/components/hermes/chat/ChatPanel.vue`

---

### Testing

- **#1052:** README renders correctly on GitHub with new Windows section
- **#991:** Logic verified: for-loop always produces exactly `safeDays` entries
- **#1027:** Unit tests pass (`includes real directories`, `skips hidden directories`)
- **#937:** Diff rendering uses hljs `diff` language (additions green, deletions red, @@ meta highlighted)
- **#974/#975:** `authStatus()` now respects `AUTH_DISABLED`; login page auto-redirects when auth is disabled
- **#1021:** `getModelGroupsForProfile()` now falls back to account-level models; `getDefaultModelForProfile()` uses account-level defaults