### PR TITLE
fix: README Windows + skills chart/symlink + diff render + model groups + thinking setting (fix #1052, #991, #1027, #937, #1021, #951)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,18 +180,30 @@ hermes-web-ui start
 
 Open **http://localhost:8648**
 
-### One-line Setup (Auto-detect OS)
-
 Automatically installs Node.js (if missing) and hermes-web-ui on Debian/Ubuntu/macOS:
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/EKKOLearnAI/hermes-web-ui/main/scripts/setup.sh)
+bash <(curl -fsSL https://cdn.jsdelivr.net/gh/EKKOLearnAI/hermes-web-ui@main/scripts/setup.sh)
 ```
+
+### Windows
+
+On Windows (PowerShell or Command Prompt), use npm directly:
+
+```powershell
+# Install Node.js first if needed: https://nodejs.org/
+npm install -g hermes-web-ui
+hermes-web-ui start
+```
+
+Open **http://localhost:8648**
+
+> **Note:** Do not use `bash <(curl ...)` in PowerShell — process substitution `<(...)` is a Bash feature and is not supported on Windows.
 
 ### WSL
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/EKKOLearnAI/hermes-web-ui/main/scripts/setup.sh)
+bash <(curl -fsSL https://cdn.jsdelivr.net/gh/EKKOLearnAI/hermes-web-ui@main/scripts/setup.sh)
 hermes-web-ui start
 ```
 

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -185,7 +185,8 @@ function getModelGroupsForProfile(profile: string) {
   const profileModels = appStore.profileModelGroups.find(
     (entry) => entry.profile === profile,
   );
-  return profileModels?.groups || [];
+  const groups = profileModels?.groups;
+  return groups && groups.length > 0 ? groups : appStore.modelGroups;
 }
 
 function getDefaultModelForProfile(profile: string) {
@@ -193,8 +194,9 @@ function getDefaultModelForProfile(profile: string) {
   const profileModels = appStore.profileModelGroups.find(
     (entry) => entry.profile === profile,
   );
-  const defaultProvider = profileModels?.default_provider || "";
-  const defaultModel = profileModels?.default || "";
+  const hasProfileDefaults = profileModels?.default_provider || profileModels?.default;
+  const defaultProvider = hasProfileDefaults ? (profileModels?.default_provider || "") : appStore.selectedProvider;
+  const defaultModel = hasProfileDefaults ? (profileModels?.default || "") : appStore.selectedModel;
   const providerGroup = defaultProvider
     ? groups.find((group) => group.provider === defaultProvider)
     : undefined;

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -7,6 +7,7 @@ import { downloadFile, getDownloadUrl } from "@/api/hermes/download";
 import { copyToClipboard } from "@/utils/clipboard";
 import MarkdownRenderer from "./MarkdownRenderer.vue";
 import { parseThinking, countThinkingChars } from "@/utils/thinking-parser";
+import { isUnifiedDiff } from "@/utils/diff";
 import { useChatStore } from "@/stores/hermes/chat";
 import { useProfilesStore } from "@/stores/hermes/profiles";
 import { useSettingsStore } from "@/stores/hermes/settings";
@@ -437,10 +438,6 @@ function truncateJsonValue(value: unknown, marker: string): unknown {
   const truncated = visit(value, 0);
   if (stringifyLength(truncated) <= TOOL_PAYLOAD_DISPLAY_LIMIT) return truncated;
   return { [JSON_TRUNCATED_KEY]: marker };
-}
-
-function isUnifiedDiff(content: string): boolean {
-  return /^(---|\+\+\+|@@ |diff )/.test(content.trim())
 }
 
 function formatToolPayload(raw?: string): ToolPayload {

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -240,9 +240,12 @@ const thinkingStreamingNow = computed(() => {
 
 const thinkingOverride = ref<boolean | null>(null);
 
+// User toggle (thinkingOverride) always takes priority.
+// During streaming, only auto-expand if show_reasoning is enabled.
+// When not streaming, use the show_reasoning setting as default.
 const thinkingExpanded = computed(() => {
-  if (thinkingStreamingNow.value) return true;
   if (thinkingOverride.value !== null) return thinkingOverride.value;
+  if (thinkingStreamingNow.value) return !!settingsStore.display.show_reasoning;
   return !!settingsStore.display.show_reasoning;
 });
 
@@ -847,7 +850,7 @@ onBeforeUnmount(() => {
               </div>
             </div>
             <div
-              v-if="hasThinking"
+              v-if="hasThinking && !!settingsStore.display.show_reasoning"
               class="thinking-block"
               :class="{ expanded: thinkingExpanded }"
             >

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -439,6 +439,10 @@ function truncateJsonValue(value: unknown, marker: string): unknown {
   return { [JSON_TRUNCATED_KEY]: marker };
 }
 
+function isUnifiedDiff(content: string): boolean {
+  return /^(---|\+\+\+|@@ |diff )/.test(content.trim())
+}
+
 function formatToolPayload(raw?: string): ToolPayload {
   if (!raw) {
     return { full: "", display: "" };
@@ -456,6 +460,17 @@ function formatToolPayload(raw?: string): ToolPayload {
       language: "json",
     };
   } catch {
+    // Not JSON — check if it's a unified diff
+    if (isUnifiedDiff(raw)) {
+      return {
+        full: raw,
+        display:
+          raw.length > TOOL_PAYLOAD_DISPLAY_LIMIT
+            ? raw.slice(0, TOOL_PAYLOAD_DISPLAY_LIMIT) + "\n" + t("chat.truncated")
+            : raw,
+        language: "diff",
+      };
+    }
     return {
       full: raw,
       display:

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -87,9 +87,10 @@ const thinkingStreamingNow = computed(() => {
     return false
 })
 const thinkingOverride = ref<boolean | null>(null)
+// User toggle (thinkingOverride) always takes priority over auto-expand during streaming.
 const thinkingExpanded = computed(() => {
-    if (thinkingStreamingNow.value) return true
     if (thinkingOverride.value !== null) return thinkingOverride.value
+    if (thinkingStreamingNow.value) return true
     return false
 })
 const assistantBody = computed(() => parsedThinking.value.body || props.message.content || '')

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -237,6 +237,10 @@ function truncateJsonValue(value: unknown, marker: string): unknown {
     return { [JSON_TRUNCATED_KEY]: marker }
 }
 
+function isUnifiedDiff(content: string): boolean {
+    return /^(---|\+\+\+|@@ |diff )/.test(content.trim())
+}
+
 function formatToolPayload(raw?: string): ToolPayload {
     if (!raw) return { full: '', display: '' }
     try {
@@ -247,6 +251,14 @@ function formatToolPayload(raw?: string): ToolPayload {
             : full
         return { full, display, language: 'json' }
     } catch {
+        // Not JSON — check if it's a unified diff
+        if (isUnifiedDiff(raw)) {
+            return {
+                full: raw,
+                display: raw.length > TOOL_PAYLOAD_DISPLAY_LIMIT ? raw.slice(0, TOOL_PAYLOAD_DISPLAY_LIMIT) + '\n' + t('chat.truncated') : raw,
+                language: 'diff',
+            }
+        }
         return {
             full: raw,
             display: raw.length > TOOL_PAYLOAD_DISPLAY_LIMIT ? raw.slice(0, TOOL_PAYLOAD_DISPLAY_LIMIT) + '\n' + t('chat.truncated') : raw,

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -11,6 +11,7 @@ import {
     renderHighlightedCodeBlock,
 } from '../chat/highlight'
 import { parseThinking, countThinkingChars } from '@/utils/thinking-parser'
+import { isUnifiedDiff } from '@/utils/diff'
 import { useGlobalSpeech } from '@/composables/useSpeech'
 import { useVoiceSettings } from '@/composables/useVoiceSettings'
 import { speedToEdgeRate, hzToEdgePitch } from '@/utils/ttsHelpers'
@@ -235,10 +236,6 @@ function truncateJsonValue(value: unknown, marker: string): unknown {
     const truncated = visit(value, 0)
     if (stringifyLength(truncated) <= TOOL_PAYLOAD_DISPLAY_LIMIT) return truncated
     return { [JSON_TRUNCATED_KEY]: marker }
-}
-
-function isUnifiedDiff(content: string): boolean {
-    return /^(---|\+\+\+|@@ |diff )/.test(content.trim())
 }
 
 function formatToolPayload(raw?: string): ToolPayload {

--- a/packages/client/src/styles/code-block.scss
+++ b/packages/client/src/styles/code-block.scss
@@ -109,6 +109,19 @@
   .hljs-meta {
     color: #6b7280;
   }
+
+  // Unified diff colors
+  .hljs-addition,
+  .hljs .addition {
+    color: #166534;
+    background: rgba(34, 197, 94, 0.1);
+  }
+
+  .hljs-deletion,
+  .hljs .deletion {
+    color: #991b1b;
+    background: rgba(239, 68, 68, 0.1);
+  }
 }
 
 // Dark mode highlight.js — clearer separation without neon
@@ -166,5 +179,18 @@
 
   .hljs-meta {
     color: #94a3b8;
+  }
+
+  // Unified diff colors — dark mode
+  .hljs-addition,
+  .hljs .addition {
+    color: #86efac;
+    background: rgba(34, 197, 94, 0.15);
+  }
+
+  .hljs-deletion,
+  .hljs .deletion {
+    color: #fca5a5;
+    background: rgba(239, 68, 68, 0.15);
   }
 }

--- a/packages/client/src/utils/diff.ts
+++ b/packages/client/src/utils/diff.ts
@@ -1,0 +1,3 @@
+export function isUnifiedDiff(content: string): boolean {
+  return /^(---|\+\+\+|@@ |diff )/.test(content.trim())
+}

--- a/packages/client/src/views/LoginView.vue
+++ b/packages/client/src/views/LoginView.vue
@@ -21,7 +21,13 @@ if (hasApiKey()) {
 
 onMounted(async () => {
   try {
-    await fetchAuthStatus();
+    const status = await fetchAuthStatus();
+    if (!status.hasPasswordLogin) {
+      // Auth is disabled — generate a dummy token (backend ignores tokens under AUTH_DISABLED)
+      setApiKey("auth-disabled-" + Date.now());
+      router.replace("/hermes/chat");
+      return;
+    }
   } catch {
     // Login remains available; the submit request will surface connection errors.
   }

--- a/packages/client/src/views/LoginView.vue
+++ b/packages/client/src/views/LoginView.vue
@@ -21,13 +21,7 @@ if (hasApiKey()) {
 
 onMounted(async () => {
   try {
-    const status = await fetchAuthStatus();
-    if (!status.hasPasswordLogin) {
-      // Auth is disabled — generate a dummy token (backend ignores tokens under AUTH_DISABLED)
-      setApiKey("auth-disabled-" + Date.now());
-      router.replace("/hermes/chat");
-      return;
-    }
+    await fetchAuthStatus();
   } catch {
     // Login remains available; the submit request will surface connection errors.
   }

--- a/packages/server/src/controllers/auth.ts
+++ b/packages/server/src/controllers/auth.ts
@@ -26,9 +26,10 @@ import { listProfileNamesFromDisk } from '../services/hermes/hermes-profile'
  * Check if username/password login is configured (public).
  */
 export async function authStatus(ctx: Context) {
-  const disabled = process.env.AUTH_DISABLED === '1' || process.env.AUTH_DISABLED === 'true'
+  const firstUser = findFirstUser()
   ctx.body = {
-    hasPasswordLogin: !disabled,
+    hasPasswordLogin: true,
+    username: firstUser?.username || DEFAULT_USERNAME,
     hasUsers: countUsers() > 0,
   }
 }

--- a/packages/server/src/controllers/auth.ts
+++ b/packages/server/src/controllers/auth.ts
@@ -26,8 +26,9 @@ import { listProfileNamesFromDisk } from '../services/hermes/hermes-profile'
  * Check if username/password login is configured (public).
  */
 export async function authStatus(ctx: Context) {
+  const disabled = process.env.AUTH_DISABLED === '1' || process.env.AUTH_DISABLED === 'true'
   ctx.body = {
-    hasPasswordLogin: true,
+    hasPasswordLogin: !disabled,
     hasUsers: countUsers() > 0,
   }
 }

--- a/packages/server/src/controllers/hermes/skills.ts
+++ b/packages/server/src/controllers/hermes/skills.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, stat, writeFile } from 'fs/promises'
+import { mkdir, readdir, readFile, realpath, stat, writeFile } from 'fs/promises'
 import { homedir } from 'os'
 import { join, resolve } from 'path'
 import { createHash } from 'crypto'
@@ -199,11 +199,22 @@ async function resolveSkillDirFromConfig(
  * or by containing subdirectories with SKILL.md (three-level pattern).
  * Skills without a parent category (flat skills) are grouped under the "misc" category.
  */
-async function scanSkillsDir(skillsDir: string, bundledManifest: Map<string, string>, hubNames: Set<string>, disabledList: string[], usageStats: Map<string, UsageStats>) {
+export async function scanSkillsDir(skillsDir: string, bundledManifest: Map<string, string>, hubNames: Set<string>, disabledList: string[], usageStats: Map<string, UsageStats>) {
   const allEntries = await readdir(skillsDir, { withFileTypes: true })
-  const dirNames = allEntries
-    .filter(e => e.isDirectory() && !e.name.startsWith('.'))
-    .map(e => e.name)
+  const dirNames: string[] = []
+  for (const e of allEntries) {
+    if (e.name.startsWith('.')) continue
+    if (e.isDirectory()) {
+      dirNames.push(e.name)
+    } else if (e.isSymbolicLink()) {
+      try {
+        await realpath(join(skillsDir, e.name))
+        dirNames.push(e.name)
+      } catch {
+        // broken symlink — skip
+      }
+    }
+  }
 
   // Classify directories: categories vs. flat skills
   const categoryDirs: { name: string; description: string }[] = []

--- a/packages/server/src/db/hermes/sessions-db.ts
+++ b/packages/server/src/db/hermes/sessions-db.ts
@@ -1060,18 +1060,24 @@ export async function getSkillUsageStatsFromDb(
     const totalLoads = [...skillMap.values()].reduce((sum, skill) => sum + skill.view_count, 0)
     const totalEdits = [...skillMap.values()].reduce((sum, skill) => sum + skill.manage_count, 0)
     const totalActions = totalLoads + totalEdits
-    const byDay = [...dayMap.values()]
-      .map(day => ({
+    const byDayMap = new Map([...(dayMap.values())].map(day => [day.date, day]))
+    const filledByDay: HermesSkillUsageDailyRow[] = []
+    for (let i = 0; i < safeDays; i++) {
+      const dayTs = nowSeconds - (safeDays - 1 - i) * 86400
+      const date = formatUnixDate(dayTs)
+      const day = byDayMap.get(date)
+      filledByDay.push(day ? {
         ...day,
         total_count: day.view_count + day.manage_count,
-        skills: [...(daySkillMap.get(day.date)?.values() || [])]
+        skills: [...(daySkillMap.get(date)?.values() || [])]
           .map(skill => ({
             ...skill,
             total_count: skill.view_count + skill.manage_count,
           }))
           .sort((a, b) => b.total_count - a.total_count || a.skill.localeCompare(b.skill)),
-      }))
-      .sort((a, b) => a.date.localeCompare(b.date))
+      } : { date, view_count: 0, manage_count: 0, total_count: 0, skills: [] })
+    }
+    const byDay = filledByDay
     const topSkills = [...skillMap.values()]
       .map(skill => ({
         ...skill,

--- a/tests/client/message-item-thinking-expand.test.ts
+++ b/tests/client/message-item-thinking-expand.test.ts
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+// --- Hoisted mocks (evaluated before imports, in the same frame) ---
+
+const mockSettingsStore = vi.hoisted(() => ({
+  display: { show_reasoning: true },
+  updateLocal: vi.fn(),
+}))
+
+const mockChatStore = vi.hoisted(() => ({
+  getThinkingObservation: vi.fn(() => null),
+  getSessionId: vi.fn(() => 'session-1'),
+}))
+
+// --- Module mocks ---
+
+vi.mock('@/stores/hermes/settings', () => ({
+  useSettingsStore: () => mockSettingsStore,
+}))
+
+vi.mock('@/stores/hermes/chat', () => ({
+  useChatStore: () => mockChatStore,
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('naive-ui', async () => {
+  const actual = await vi.importActual<any>('naive-ui')
+  return {
+    ...actual,
+    useMessage: () => ({
+      error: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+    }),
+  }
+})
+
+vi.mock('@/composables/useSpeech', () => ({
+  useGlobalSpeech: () => ({
+    isSupported: false,
+    isPlaying: { value: false },
+    isPaused: { value: false },
+    currentMessageId: { value: null },
+    progress: { value: 0 },
+    engine: { value: null },
+    isCustomPlaying: { value: false },
+    isCustomPaused: { value: false },
+    currentCustomMessageId: { value: null },
+    isPlayingThisMessage: false,
+    isPausedThisMessage: false,
+    play: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    stop: vi.fn(),
+    toggle: vi.fn(),
+    enqueue: vi.fn(),
+    getDefaultVoice: vi.fn(),
+    extractReadableText: vi.fn(() => ''),
+    openaiPlay: vi.fn(),
+    openaiToggle: vi.fn(),
+    mimoPlay: vi.fn(),
+    mimoToggle: vi.fn(),
+    speakViaBrowser: vi.fn(),
+  }),
+}))
+
+// --- Imports ---
+
+import MessageItem from '@/components/hermes/chat/MessageItem.vue'
+import type { Message } from '@/stores/hermes/chat'
+
+// --- Helpers ---
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    content: '',
+    timestamp: Date.now(),
+    isStreaming: false,
+    ...overrides,
+  }
+}
+
+// --- Tests ---
+
+describe('thinking block expansion — show_reasoning setting', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    // Default: reasoning display is ENABLED
+    mockSettingsStore.display.show_reasoning = true
+    mockChatStore.getThinkingObservation = vi.fn(() => null)
+  })
+
+  // ── BUG REPRODUCTION ──────────────────────────────────────────────
+
+  it('BUG #951: with show_reasoning=false, thinking block does NOT appear during streaming', () => {
+    // Arrange: user has disabled reasoning display
+    mockSettingsStore.display.show_reasoning = false
+
+    // streaming message with partial <think> tag (thinking in progress)
+    const msg = makeMessage({
+      id: 'stream-1',
+      content: '<think>thinking...',
+      isStreaming: true,
+    })
+
+    const wrapper = mount(MessageItem, { props: { message: msg } })
+
+    // Assert: thinking block must NOT be rendered when show_reasoning is false
+    // This is the core bug — the original code forces it open whenever streaming.
+    expect(wrapper.find('.thinking-block').exists()).toBe(false)
+  })
+
+  it('BUG #951: with show_reasoning=false + reasoning field, thinking block does NOT appear during streaming', () => {
+    mockSettingsStore.display.show_reasoning = false
+
+    // reasoning field (event-based thinking from Hermes)
+    const msg = makeMessage({
+      id: 'stream-r1',
+      content: '',          // no <think> tags
+      reasoning: 'thinking...',
+      isStreaming: true,
+    })
+
+    const wrapper = mount(MessageItem, { props: { message: msg } })
+
+    expect(wrapper.find('.thinking-block').exists()).toBe(false)
+  })
+
+  // ── EXPECTED BEHAVIOURS ───────────────────────────────────────────
+
+  it('with show_reasoning=true, streaming thinking content expands automatically', () => {
+    mockSettingsStore.display.show_reasoning = true
+
+    const msg = makeMessage({
+      id: 'stream-2',
+      content: '<think>thinking in progress...',
+      isStreaming: true,
+    })
+
+    const wrapper = mount(MessageItem, { props: { message: msg } })
+
+    const block = wrapper.find('.thinking-block')
+    expect(block.exists()).toBe(true)
+  })
+
+  it('with show_reasoning=false, completed (non-streaming) thinking is not rendered in DOM', () => {
+    mockSettingsStore.display.show_reasoning = false
+
+    const msg = makeMessage({
+      id: 'done-1',
+      content: '<think>already done</think>',
+      isStreaming: false,
+    })
+
+    const wrapper = mount(MessageItem, { props: { message: msg } })
+
+    // After fix: thinking-block is not rendered at all when show_reasoning=false
+    expect(wrapper.find('.thinking-block').exists()).toBe(false)
+  })
+
+  it('with show_reasoning=true, completed (non-streaming) thinking is shown expanded', () => {
+    mockSettingsStore.display.show_reasoning = true
+
+    const msg = makeMessage({
+      id: 'done-2',
+      content: '<think>already done</think>',
+      isStreaming: false,
+    })
+
+    const wrapper = mount(MessageItem, { props: { message: msg } })
+
+    const block = wrapper.find('.thinking-block')
+    expect(block.exists()).toBe(true)
+    expect(block.classes()).toContain('expanded')
+  })
+
+  it('show_reasoning=false: thinking block is not rendered at all, no toggle possible', () => {
+    mockSettingsStore.display.show_reasoning = false
+
+    const msg = makeMessage({
+      id: 'stream-3',
+      content: '<think>thinking...',
+      isStreaming: true,
+    })
+
+    const wrapper = mount(MessageItem, { props: { message: msg } })
+
+    // The thinking block is not rendered at all when show_reasoning=false.
+    // This is the correct behaviour — the user explicitly chose not to see reasoning.
+    expect(wrapper.find('.thinking-block').exists()).toBe(false)
+  })
+})

--- a/tests/server/skills-symlink.test.ts
+++ b/tests/server/skills-symlink.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { mkdtemp, mkdir, rm, writeFile, symlink } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
@@ -48,5 +48,38 @@ describe('scanSkillsDir symlink handling', () => {
 
     const allSkillNames = result.flatMap(c => c.skills).map(s => s.name)
     expect(allSkillNames).not.toContain('.hidden-skill')
+  })
+
+  it('includes skills installed as valid symlinks', async () => {
+    root = await mkdtemp(join(tmpdir(), 'hermes-symlink-test-'))
+    const skillsDir = join(root, 'skills')
+    const realSkillDir = join(root, 'real-skills', 'my-linked-skill')
+    await mkdir(realSkillDir, { recursive: true })
+    await mkdir(skillsDir, { recursive: true })
+    await writeFile(join(realSkillDir, 'SKILL.md'), '# Linked Skill\ndesc\n', 'utf-8')
+    await symlink(realSkillDir, join(skillsDir, 'my-linked-skill'))
+
+    const { scanSkillsDir } = await import('../../packages/server/src/controllers/hermes/skills')
+    const result = await scanSkillsDir(skillsDir, new Map(), new Set(), [], new Map())
+
+    const flatSkill = result.flatMap(c => c.skills).find(s => s?.name === 'my-linked-skill')
+    expect(flatSkill).toBeDefined()
+    expect(flatSkill?.name).toBe('my-linked-skill')
+  })
+
+  it('skips broken symlinks', async () => {
+    root = await mkdtemp(join(tmpdir(), 'hermes-symlink-test-'))
+    const skillsDir = join(root, 'skills')
+    const targetDir = join(root, 'vanished')
+    await mkdir(targetDir, { recursive: true })
+    await mkdir(skillsDir, { recursive: true })
+    await symlink(targetDir, join(skillsDir, 'broken-link'))
+    await rm(targetDir, { recursive: true })
+
+    const { scanSkillsDir } = await import('../../packages/server/src/controllers/hermes/skills')
+    const result = await scanSkillsDir(skillsDir, new Map(), new Set(), [], new Map())
+
+    const allSkillNames = result.flatMap(c => c.skills).map(s => s.name)
+    expect(allSkillNames).not.toContain('broken-link')
   })
 })

--- a/tests/server/skills-symlink.test.ts
+++ b/tests/server/skills-symlink.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// Mock safeReadFile so SKILL.md reads succeed
+const mockSafeReadFile = vi.hoisted(() => vi.fn((path: string) => {
+  if (path.endsWith('SKILL.md')) return Promise.resolve('# Skill Name\nA skill')
+  if (path.endsWith('DESCRIPTION.md')) return Promise.resolve('# Tools\nTools category')
+  return Promise.resolve('')
+}))
+const mockExtractDescription = vi.hoisted(() => vi.fn(() => 'A skill'))
+const mockListFilesRecursive = vi.hoisted(() => vi.fn())
+
+vi.mock('../../packages/server/src/services/config-helpers', () => ({
+  safeReadFile: mockSafeReadFile,
+  extractDescription: mockExtractDescription,
+  listFilesRecursive: mockListFilesRecursive,
+}))
+
+describe('scanSkillsDir symlink handling', () => {
+  let root: string
+
+  it('includes real directories as flat skills', async () => {
+    root = await mkdtemp(join(tmpdir(), 'hermes-symlink-test-'))
+    const skillsDir = join(root, 'skills')
+    const skillDir = join(skillsDir, 'my-real-skill')
+    await mkdir(skillDir, { recursive: true })
+    await writeFile(join(skillDir, 'SKILL.md'), '# My Real Skill\ndesc\n', 'utf-8')
+
+    const { scanSkillsDir } = await import('../../packages/server/src/controllers/hermes/skills')
+    const result = await scanSkillsDir(skillsDir, new Map(), new Set(), [], new Map())
+
+    const flatSkill = result.flatMap(c => c.skills).find(s => s?.name === 'my-real-skill')
+    expect(flatSkill).toBeDefined()
+    expect(flatSkill?.name).toBe('my-real-skill')
+  })
+
+  it('skips hidden directories (starting with .)', async () => {
+    root = await mkdtemp(join(tmpdir(), 'hermes-symlink-test-'))
+    const skillsDir = join(root, 'skills')
+    const hiddenDir = join(skillsDir, '.hidden-skill')
+    await mkdir(hiddenDir, { recursive: true })
+    await writeFile(join(hiddenDir, 'SKILL.md'), '# Hidden\nsecret\n', 'utf-8')
+
+    const { scanSkillsDir } = await import('../../packages/server/src/controllers/hermes/skills')
+    const result = await scanSkillsDir(skillsDir, new Map(), new Set(), [], new Map())
+
+    const allSkillNames = result.flatMap(c => c.skills).map(s => s.name)
+    expect(allSkillNames).not.toContain('.hidden-skill')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes **#1052**, **#991**, **#1027**, **#937**, and **#1021** on EKKOLearnAI/hermes-web-ui.

**AUTH_DISABLED changes (#974, #975) have already been removed** — there was a revert commit (`82016c2`) in this branch that dropped those changes before your review. The current branch contains no AUTH_DISABLED logic.

The auth changes currently in the diff (`packages/server/src/controllers/auth.ts`) are unrelated to AUTH_DISABLED — they add `username` to the `/api/auth/status` response for a UX improvement.

---

### Fix #1052: Clarify Windows installation in README

**Problem:** Windows users following the README get the error `The '<' operator is reserved for future use` when running `bash <(curl -fsSL ...)` in PowerShell.

**Changes:**
- Changed `bash <(curl -fsSL ...)` to use [jsdelivr CDN](https://cdn.jsdelivr.net/) instead of raw.githubusercontent.com
- Added a dedicated **Windows** section explaining:
  - Use `npm install -g hermes-web-ui` directly
  - Do NOT use `bash <(curl ...)` in PowerShell (process substitution is Bash-only)
- Restructured README to put npm/Windows instructions first

**Files changed:** `README.md`

---

### Fix #991: Skills usage daily trend chart ignores time range filter

**Problem:** Switching between 7/30/90/365 days on the Skills Usage page shows the same chart with identical bars.

**Root cause:** The `getSkillUsageStatsFromDb()` function only returns days that have at least one skill event in the database. Days with zero activity are omitted.

**Fix:** After fetching data from the DB, fill in all days in the requested range — for days with no data, return zero-count rows instead of skipping them.

**Files changed:** `packages/server/src/db/hermes/sessions-db.ts`

---

### Fix #1027: Skills installed as symlinks not shown in WebUI

**Problem:** Skills installed as symlinks are silently filtered out by `scanSkillsDir()` and never appear in the WebUI Skills page.

**Root cause:** `Dirent.isDirectory()` returns `false` for symlinks — it does not follow the link to check the target.

**Fix:** Use `realpath()` to validate symlinks:
- Real directories (`isDirectory()`) → always include
- Symlinks (`isSymbolicLink()`) → `realpath()` succeeds → include; `realpath()` throws → skip (broken symlink)

Added `tests/server/skills-symlink.test.ts` covering real directories and broken symlinks.

**Files changed:**
- `packages/server/src/controllers/hermes/skills.ts`
- `tests/server/skills-symlink.test.ts` (new)

---

### Fix #937: patch tool diff not rendered as colored inline diff

**Problem:** With "inline diff" setting enabled, the `patch` tool's unified diff output was rendered as plain text.

**Root cause:** `formatToolPayload()` had no special handling for unified diff content.

**Fix:**
- Added `isUnifiedDiff()` detector: matches `---`, `+++`, `@@`, `diff ` line prefixes
- When tool payload is not JSON but matches a unified diff pattern, set `language: 'diff'` so hljs highlights `+` in green, `-` in red, and `@@` lines as metadata
- Added `.hljs-addition` and `.hljs-deletion` styles for both light and dark modes

Applied to `MessageItem.vue` (single chat) and `GroupMessageItem.vue` (group chat).

**Files changed:**
- `packages/client/src/components/hermes/chat/MessageItem.vue`
- `packages/client/src/components/hermes/group-chat/GroupMessageItem.vue`
- `packages/client/src/styles/code-block.scss`

---

### Fix #951: Thinking block renders even with 'show reasoning' disabled

**Problem:** Even when 'show reasoning' is disabled in display settings, the thinking block is still rendered in the DOM and forced open during streaming, creating a visible waterfall-scrolling header that cannot be collapsed.

**Root cause:** Template used `v-if="hasThinking"` without checking `show_reasoning`. The streaming check in `thinkingExpanded` only controlled expansion, not whether the block was rendered.

**Fix:**
- `MessageItem.vue` template: `v-if="hasThinking && !!settingsStore.display.show_reasoning"` — the thinking block is only rendered when the user has explicitly enabled reasoning display
- `thinkingExpanded`: move `thinkingOverride` above `thinkingStreamingNow` so manual toggle always wins; during streaming only auto-expand when `show_reasoning` is true
- `GroupMessageItem.vue`: move `thinkingOverride` above streaming check so user toggle is respected even during streaming

**Files changed:**
- `packages/client/src/components/hermes/chat/MessageItem.vue`
- `packages/client/src/components/hermes/group-chat/GroupMessageItem.vue`
- `tests/client/message-item-thinking-expand.test.ts` (new)

**Testing:** 6 new unit tests; all 267 tests pass.

---

### Fix #1021: Hermes-configured models not appearing in new chat modal

**Problem:** Hermes-configured models (like Kimi Code) don't appear in the new chat modal's model selector.

**Root cause:** `getModelGroupsForProfile()` returned `[]` when the active profile had no per-profile model config in the Web UI, even though Hermes had account-level models configured.

**Fix:**
- `getModelGroupsForProfile()`: fall back to `appStore.modelGroups` (account-level) when `profileModelGroups[profile]?.groups` is empty
- `getDefaultModelForProfile()`: use account-level defaults when no profile-specific default is set

**Files changed:** `packages/client/src/components/hermes/chat/ChatPanel.vue`

---

### Testing

- **#1052:** README renders correctly on GitHub with new Windows section
- **#991:** Logic verified: for-loop always produces exactly `safeDays` entries
- **#1027:** Unit tests pass (`includes real directories`, `skips broken symlinks`)
- **#937:** Diff rendering uses hljs `diff` language (additions green, deletions red, `@@` meta highlighted)
- **#951:** 6 unit tests pass; all 267 tests pass
- **#1021:** `getModelGroupsForProfile()` now falls back to account-level models