### PR TITLE
[codex] Run Docker publish only on releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,22 +1,6 @@
 name: Build and Push Docker Image to Docker Hub
 
 on:
-  pull_request:
-    branches:
-      - main
-      - base
-    paths:
-      - .dockerignore
-      - Dockerfile
-      - package.json
-      - package-lock.json
-      - tsconfig*.json
-      - vite.config*.ts
-      - packages/**
-      - bin/**
-      - scripts/**
-      - .github/workflows/docker-publish.yml
-  workflow_dispatch:
   release:
     types: [published]
 
@@ -24,11 +8,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: docker-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
-env:
-  IMAGE_NAME: hermes-web-ui
+  group: docker-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build-and-push:
@@ -40,68 +21,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build PR image
-        if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          load: true
-          push: false
-          tags: ${{ env.IMAGE_NAME }}:ci
-
-      - name: Smoke test PR image
-        if: github.event_name == 'pull_request'
-        run: |
-          set -euo pipefail
-          cid=""
-          cleanup() {
-            if [ -n "$cid" ]; then
-              docker logs "$cid" || true
-              docker rm -f "$cid" || true
-            fi
-          }
-          trap cleanup EXIT
-
-          cid=$(docker run -d \
-            -e PORT=6060 \
-            -e BIND_HOST=0.0.0.0 \
-            -e HERMES_WEB_UI_HOME=/tmp/hermes-web-ui \
-            -e HERMES_HOME=/home/agent/.hermes \
-            -p 6060:6060 \
-            "${IMAGE_NAME}:ci")
-
-          for attempt in $(seq 1 60); do
-            if curl -fsS http://127.0.0.1:6060/health | grep -q '"status":"ok"'; then
-              echo "Docker image smoke test passed."
-              exit 0
-            fi
-            if ! docker ps --quiet --no-trunc | grep -q "$cid"; then
-              echo "Container exited before becoming healthy." >&2
-              exit 1
-            fi
-            sleep 2
-          done
-
-          echo "Timed out waiting for /health." >&2
-          exit 1
-
       - name: Build and push Docker image
-        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -111,4 +42,4 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:${{ github.sha }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:${{ github.event.release.tag_name || github.ref_name }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:${{ github.event.release.tag_name }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,7 @@
 name: Build and Push Docker Image to Docker Hub
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 
@@ -42,4 +43,4 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:${{ github.sha }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:${{ github.event.release.tag_name }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:${{ github.event.release.tag_name || github.ref_name }}


### PR DESCRIPTION
## Summary
- Remove pull_request and workflow_dispatch triggers from the Docker publish workflow.
- Remove PR-only Docker image build and smoke test steps.
- Keep Docker Hub build and push limited to published GitHub releases.

## Impact
Normal PRs and merges to main no longer spend CI time building Docker images. Docker images are still built and pushed when a release is published.

## Validation
- git diff --check