### PR TITLE
[codex] fix session bottom scroll alignment

### DIFF
--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -14,6 +14,7 @@ const { t } = useI18n();
 const { isDark } = useTheme();
 const { toolTraceVisible } = useToolTraceVisibility();
 const listRef = ref<InstanceType<typeof VirtualMessageList> | null>(null);
+const pendingBottomSessionId = ref<string | null>(null);
 
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
@@ -115,6 +116,7 @@ watch(
   () => chatStore.activeSessionId,
   (id) => {
     if (!id) return;
+    pendingBottomSessionId.value = id;
     if (chatStore.focusMessageId) {
       scrollToMessage(chatStore.focusMessageId);
       return;
@@ -122,6 +124,20 @@ watch(
     scrollToBottom();
   },
   { immediate: true },
+);
+
+watch(
+  () => [chatStore.activeSessionId, chatStore.messages.length] as const,
+  ([id, length]) => {
+    if (!id || pendingBottomSessionId.value !== id || length === 0) return;
+    pendingBottomSessionId.value = null;
+    if (chatStore.focusMessageId) {
+      scrollToMessage(chatStore.focusMessageId);
+      return;
+    }
+    scrollToBottom();
+  },
+  { flush: "post" },
 );
 
 watch(

--- a/packages/client/src/components/hermes/chat/VirtualMessageList.vue
+++ b/packages/client/src/components/hermes/chat/VirtualMessageList.vue
@@ -39,6 +39,8 @@ const heightVersion = ref(0);
 const measuredHeights = new Map<string, number>();
 const observedElements = new Map<string, HTMLElement>();
 const observers = new Map<string, ResizeObserver>();
+let keepBottomUntil = 0;
+let bottomFrame: number | null = null;
 
 const messageKeys = computed(() => props.messages.map(messageKey));
 
@@ -58,9 +60,10 @@ function setMeasuredHeight(key: string, height: number) {
   const oldHeight = itemHeight(key);
   if (oldHeight === height) return;
 
+  const el = scrollerRef.value;
+  const shouldKeepBottom = !!el && (Date.now() < keepBottomUntil || isNearBottom(64));
   const index = messageKeys.value.indexOf(key);
-  if (index >= 0) {
-    const el = scrollerRef.value;
+  if (index >= 0 && !shouldKeepBottom) {
     const rowTop = layout.value.offsets[index] || 0;
     const delta = height - oldHeight;
     if (el && rowTop < scrollTop.value && delta !== 0) {
@@ -71,6 +74,7 @@ function setMeasuredHeight(key: string, height: number) {
 
   measuredHeights.set(key, height);
   heightVersion.value += 1;
+  if (shouldKeepBottom) scheduleScrollToBottom(2);
 }
 
 const layout = computed(() => {
@@ -167,12 +171,32 @@ function isNearBottom(threshold = 200): boolean {
 }
 
 function scrollToBottom() {
+  keepBottomUntil = Date.now() + 700;
   nextTick(() => {
-    const el = scrollerRef.value;
-    if (!el) return;
-    el.scrollTop = el.scrollHeight;
-    syncViewport();
+    scheduleScrollToBottom(3);
   });
+}
+
+function setScrollToBottomNow() {
+  const el = scrollerRef.value;
+  if (!el) return;
+  el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+  syncViewport();
+}
+
+function scheduleScrollToBottom(frames = 1) {
+  if (bottomFrame != null) cancelAnimationFrame(bottomFrame);
+
+  const step = (remaining: number) => {
+    setScrollToBottomNow();
+    if (remaining <= 1) {
+      bottomFrame = null;
+      return;
+    }
+    bottomFrame = requestAnimationFrame(() => step(remaining - 1));
+  };
+
+  bottomFrame = requestAnimationFrame(() => step(frames));
 }
 
 function scrollToMessage(messageId: string) {
@@ -237,6 +261,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  if (bottomFrame != null) cancelAnimationFrame(bottomFrame);
   resizeObserver?.disconnect();
   for (const observer of observers.values()) observer.disconnect();
   observers.clear();


### PR DESCRIPTION
## Summary

- Keep the virtualized chat list pinned to the real bottom while row height measurements settle after session changes.
- Trigger a second bottom scroll after resumed session messages arrive, unless a focused message jump is active.
- Leave conversation outline / message anchor scrolling behavior unchanged.

## Root Cause

When switching sessions, the bottom scroll could run before the resumed message batch and before virtual row measurements had stabilized. For large unrendered histories, later measurement updates changed the scrollable height and left the viewport a few messages above the bottom.

## Validation

- `npx vue-tsc -b`
- `npm test -- tests/client/tool-trace-visibility.test.ts tests/client/kanban-task-drawer.test.ts`
