### PR TITLE
fix(agent-bridge): force TCP loopback for worker endpoints (fixes macOS SIGKILL)

### DIFF
--- a/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
@@ -2416,11 +2416,14 @@ class WorkerProcess:
 def _worker_endpoint(key: str, namespace: str | None = None) -> str:
     namespace_key = f"{namespace or ''}\0{key}"
     safe = hashlib.sha256(namespace_key.encode("utf-8")).hexdigest()[:16]
-    if os.name == "nt":
-        port_base = int(os.environ.get("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE", "18780"))
-        return f"tcp://127.0.0.1:{port_base + int(safe[:4], 16) % 1000}"
-    root = Path(tempfile.gettempdir()) / "hermes-agent-bridge-workers"
-    return f"ipc://{root / f'{safe}.sock'}"
+    # Always use TCP loopback. Unix domain sockets in /tmp are rejected by
+    # some macOS EDR/sandbox configurations when the broker is spawned from
+    # an unsigned Electron child — the worker is SIGKILL'd within ~150ms of
+    # bind() before it can emit a "ready" event. TCP loopback bypasses this
+    # entirely and is performance-equivalent to AF_UNIX on macOS/Linux
+    # (kernel zero-copy in both cases).
+    port_base = int(os.environ.get("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE", "18780"))
+    return f"tcp://127.0.0.1:{port_base + int(safe[:4], 16) % 1000}"
 
 
 def _connect_bridge_socket(endpoint: str, timeout: float) -> socket.socket:


### PR DESCRIPTION
Per discussion in #1091.

## Problem

`_worker_endpoint()` returns `ipc:///tmp/hermes-agent-bridge-workers/<hash>.sock` on non-Windows. When the agent-bridge broker is spawned by an unsigned Electron child (e.g. a desktop application bundling hermes-web-ui), and the resulting Python worker tries to `bind()` that unix socket, **macOS EDR / sandbox policies kill the worker process within ~150ms of the bind call**.

The kill is a `SIGKILL` issued from outside the process — Python's signal handlers can't catch it, no traceback is logged, and the failure surfaces in the broker as:

```
[bridge-broker] profile worker <name> exited before ready
```

The user-visible error in chat is then `Error: connect ECONNREFUSED <addr>` because no socket ever gets created. Reproducible on:

- macOS 14 (Apple silicon)
- macOS 13 / 15-intel
- With and without third-party EDR (corporate Aliab EDR is one trigger; the macOS 14 Endpoint Security framework alone seems sufficient on some hardware)

## Fix

Have `_worker_endpoint()` return a TCP loopback URI (`tcp://127.0.0.1:<port>`) unconditionally, matching the existing `if os.name == "nt":` branch behavior.

```diff
-    if os.name == "nt":
-        port_base = int(os.environ.get("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE", "18780"))
-        return f"tcp://127.0.0.1:{port_base + int(safe[:4], 16) % 1000}"
-    root = Path(tempfile.gettempdir()) / "hermes-agent-bridge-workers"
-    return f"ipc://{root / f'{safe}.sock'}"
+    # Always use TCP loopback. Unix domain sockets in /tmp are rejected by
+    # some macOS EDR/sandbox configurations when the broker is spawned from
+    # an unsigned Electron child — the worker is SIGKILL'd within ~150ms of
+    # bind() before it can emit a "ready" event. TCP loopback bypasses this
+    # entirely and is performance-equivalent to AF_UNIX on macOS/Linux
+    # (kernel zero-copy in both cases).
+    port_base = int(os.environ.get("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE", "18780"))
+    return f"tcp://127.0.0.1:{port_base + int(safe[:4], 16) % 1000}"
```

## Why this is safe

- **No API change.** `_worker_endpoint()` signature unchanged; `_connect_bridge_socket()` and `_make_listen_socket()` already handle both `ipc://` and `tcp://` schemes.
- **No new ports allocated by default.** Same `HERMES_AGENT_BRIDGE_WORKER_PORT_BASE` env var (default `18780`) used by the Windows branch.
- **Performance neutral.** `127.0.0.1` traffic on macOS / Linux goes through the kernel's loopback fast path with zero copies — same path AF_UNIX uses.
- **Backwards compatible.** Existing brokers/workers that connect via the broker's `endpoint` are unaffected. Only the per-worker socket changes.

## Tested in

[`sir1st/hermes-desktop`](https://github.com/sir1st/hermes-desktop) has been running this exact patch (applied via `scripts/apply-webui-patches.mjs#worker-tcp-everywhere`) since v0.0.8. End-to-end chat (Web UI → broker → worker → hermes-agent → DeepSeek/Anthropic) works on:

- macOS 14 arm64 (M-series)
- macOS 15 Intel
- Linux x64 / arm64
- Windows x64

No regressions observed.

## Closes

Discussion in #1091.

---

If you'd prefer a different name (e.g. add an env-var override `HERMES_AGENT_BRIDGE_WORKER_TRANSPORT=tcp|ipc` instead of switching unconditionally), happy to refactor.
