### PR TITLE
feat(version-check): HERMES_WEB_UI_DISABLE_UPDATE_CHECK env var to suppress update prompt

### DIFF
--- a/packages/server/src/controllers/health.ts
+++ b/packages/server/src/controllers/health.ts
@@ -45,7 +45,23 @@ const LOCAL_VERSION = typeof __APP_VERSION__ !== 'undefined'
 
 let cachedLatestVersion = ''
 
+/**
+ * Whether the periodic npm-registry version check is disabled.
+ *
+ * Useful when hermes-web-ui is bundled inside a packaged distribution
+ * (e.g. a desktop app) where the user can't `npm install -g hermes-web-ui@latest`
+ * to upgrade — the "update available" prompt would be misleading and
+ * the periodic outbound HTTP request to the npm registry is unnecessary.
+ *
+ * Set HERMES_WEB_UI_DISABLE_UPDATE_CHECK=true (or 1, on, yes) to disable.
+ */
+function isUpdateCheckDisabled(): boolean {
+  const raw = (process.env.HERMES_WEB_UI_DISABLE_UPDATE_CHECK || '').trim().toLowerCase()
+  return raw === 'true' || raw === '1' || raw === 'on' || raw === 'yes'
+}
+
 export async function checkLatestVersion(): Promise<void> {
+  if (isUpdateCheckDisabled()) return
   try {
     const packageName = PACKAGE_INFO?.name || 'hermes-web-ui'
     const registryName = encodeURIComponent(packageName)
@@ -61,6 +77,7 @@ export async function checkLatestVersion(): Promise<void> {
 }
 
 export function startVersionCheck(): void {
+  if (isUpdateCheckDisabled()) return
   setTimeout(checkLatestVersion, 5000)
   setInterval(checkLatestVersion, 30 * 60 * 1000)
 }
@@ -74,8 +91,10 @@ export async function healthCheck(ctx: any) {
     version: hermesVersion,
     gateway: 'running',
     webui_version: LOCAL_VERSION,
-    webui_latest: cachedLatestVersion,
-    webui_update_available: Boolean(LOCAL_VERSION && cachedLatestVersion && cachedLatestVersion !== LOCAL_VERSION),
+    webui_latest: isUpdateCheckDisabled() ? '' : cachedLatestVersion,
+    webui_update_available: isUpdateCheckDisabled()
+      ? false
+      : Boolean(LOCAL_VERSION && cachedLatestVersion && cachedLatestVersion !== LOCAL_VERSION),
     node_version: process.versions.node,
   }
 }


### PR DESCRIPTION
Adds an opt-in environment variable, `HERMES_WEB_UI_DISABLE_UPDATE_CHECK`, that suppresses the npm-registry update check at three layers:

| Layer | Behavior when disabled |
|-------|------------------------|
| `checkLatestVersion()` | returns immediately; no outbound HTTP call to `registry.npmjs.org` |
| `startVersionCheck()` | does not arm the 30-minute interval (saves a recurring fetch) |
| `/api/health` response | `webui_latest: ''` and `webui_update_available: false` (so the bottom-left "new version available" banner stops firing in the client) |

## Why

Per discussion in #1091. When hermes-web-ui is bundled inside a packaged distribution (e.g. a desktop app that vendors a specific submodule SHA), the user can't run `npm install -g hermes-web-ui@latest` to apply the suggested upgrade — the wrapper application has to ship a new release first. The "update available" prompt is therefore misleading, and the recurring `https://registry.npmjs.org/hermes-web-ui/latest` request is unnecessary noise (and an unwanted outbound connection in air-gapped or corporate-firewall scenarios).

## Behavior

- Default: **unchanged** — env var unset, version check runs as before.
- `HERMES_WEB_UI_DISABLE_UPDATE_CHECK=true` (also accepts `1`, `on`, `yes`, case-insensitive) → disabled.
- Anything else → treated as not set.

## Diff scope

Single file: `packages/server/src/controllers/health.ts` (one helper + 3 short-circuit calls).

## Tested

Locally with both modes:

```sh
# Disabled
HERMES_WEB_UI_DISABLE_UPDATE_CHECK=true hermes-web-ui
# /api/health → webui_update_available: false (always)
# Server log: no "checkLatestVersion" runs

# Default (unchanged)
hermes-web-ui
# /api/health → webui_update_available: <existing logic>
# Server log: usual periodic checks
```

If you'd prefer a different env-var name (e.g. `HERMES_WEB_UI_NO_UPDATE_CHECK` or split into two flags `_DISABLE_FETCH` + `_DISABLE_PROMPT`), happy to refactor.

Closes thread on #1091.
