### PR TITLE
[codex] 修复模型 provider 的 builtin 标记

### DIFF
--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -99,6 +99,7 @@ function providerPresetToGroup(p: any, models?: string[]): AvailableGroup {
     base_url: p.base_url,
     models: models || p.models,
     api_key: '',
+    ...(p.builtin ? { builtin: true } : {}),
     ...(envMapping?.base_url_env ? { base_url_env: envMapping.base_url_env } : {}),
   }
 }
@@ -179,6 +180,15 @@ function envReader(envContent: string) {
 
 function providerKeyForCustom(name: string): string {
   return `custom:${name.trim().toLowerCase().replace(/ /g, '-')}`
+}
+
+function providerKeyWithoutCustomPrefix(providerKey: string): string {
+  return providerKey.startsWith('custom:') ? providerKey.slice('custom:'.length) : providerKey
+}
+
+function isBuiltinProviderKey(providerKey: string): boolean {
+  const normalized = providerKeyWithoutCustomPrefix(providerKey)
+  return PROVIDER_PRESETS.some((preset: any) => preset.value === normalized && preset.builtin === true)
 }
 
 function providerShouldFetchLiveModels(providerKey: string): boolean {
@@ -402,13 +412,13 @@ async function buildAvailableForProfile(
         const fetched = await cachedProviderModels(fetchCache, baseUrl, cp.api_key)
         if (fetched.length > 0) models = [...new Set([...models, ...fetched])]
       }
-      return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '' }
+      return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '', builtin: isBuiltinProviderKey(providerKey) }
     }),
   )
   for (const result of customFetches) {
     if (result.status === 'fulfilled' && result.value?.models.length) {
-      const { providerKey, label, base_url, models, api_key } = result.value
-      addGroup(providerKey, label, base_url, models, api_key)
+      const { providerKey, label, base_url, models, api_key, builtin } = result.value
+      addGroup(providerKey, label, base_url, models, api_key, builtin)
     }
   }
 
@@ -655,7 +665,7 @@ export async function getAvailable(ctx: any) {
         if (cp.api_key) {
           try { const fetched = await fetchProviderModels(baseUrl, cp.api_key); if (fetched.length > 0) models = [...new Set([cp.model, ...fetched])] } catch { }
         }
-        return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '' }
+        return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '', builtin: isBuiltinProviderKey(providerKey) }
       }),
     )
 

--- a/packages/server/src/shared/providers.ts
+++ b/packages/server/src/shared/providers.ts
@@ -34,6 +34,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     base_url: 'https://api.apikey.fun',
     api_mode: "anthropic_messages",
     models: [
+      'claude-opus-4-8',
       'claude-opus-4-7',
       'claude-opus-4-6',
       'claude-sonnet-4-6',

--- a/tests/server/model-visibility-controller.test.ts
+++ b/tests/server/model-visibility-controller.test.ts
@@ -42,6 +42,7 @@ vi.mock('../../packages/server/src/services/config-helpers', () => ({
   fetchProviderModels: mockFetchProviderModels,
   buildModelGroups: mockBuildModelGroups,
   PROVIDER_ENV_MAP: {
+    'fun-codex': { api_key_env: '', base_url_env: '' },
     deepseek: { api_key_env: 'DEEPSEEK_API_KEY', base_url_env: 'DEEPSEEK_BASE_URL' },
     lmstudio: { api_key_env: 'LM_API_KEY', base_url_env: 'LM_BASE_URL' },
     'xai-oauth': { api_key_env: '', base_url_env: '' },
@@ -57,28 +58,39 @@ vi.mock('../../packages/server/src/shared/providers', () => ({
   }),
   PROVIDER_PRESETS: [
     {
+      value: 'fun-codex',
+      label: 'Codex-apikey.fun',
+      base_url: 'https://api.apikey.fun/v1',
+      models: ['gpt-5.5'],
+      builtin: true,
+    },
+    {
       value: 'deepseek',
       label: 'DeepSeek',
       base_url: 'https://api.deepseek.com/v1',
       models: ['deepseek-chat', 'deepseek-reasoner'],
+      builtin: true,
     },
     {
       value: 'openrouter',
       label: 'OpenRouter',
       base_url: 'https://openrouter.ai/api/v1',
       models: ['openrouter/auto'],
+      builtin: true,
     },
     {
       value: 'lmstudio',
       label: 'LM Studio',
       base_url: 'http://127.0.0.1:1234/v1',
       models: [],
+      builtin: true,
     },
     {
       value: 'xai-oauth',
       label: 'xAI Grok OAuth (SuperGrok Subscription)',
       base_url: 'https://api.x.ai/v1',
       models: ['grok-4.3', 'grok-4.20-0309-reasoning'],
+      builtin: true,
     },
   ],
 }))
@@ -277,11 +289,37 @@ describe('models controller — model visibility', () => {
     expect(ctx.body.allProviders).toEqual(expect.arrayContaining([
       expect.objectContaining({
         provider: 'deepseek',
+        builtin: true,
         base_url_env: 'DEEPSEEK_BASE_URL',
       }),
       expect.not.objectContaining({
         provider: 'xai-oauth',
         base_url_env: expect.any(String),
+      }),
+    ]))
+  })
+
+  it('marks custom-prefixed providers as builtin when their provider key matches a preset', async () => {
+    mockReadConfigYamlForProfile.mockResolvedValue({
+      model: { default: 'gpt-5.5', provider: 'custom:fun-codex' },
+      custom_providers: [
+        {
+          name: 'fun-codex',
+          base_url: 'https://proxy.example.com/v1',
+          model: 'gpt-5.5',
+          api_key: 'sk-test',
+        },
+      ],
+    })
+
+    const ctx = makeCtx()
+    ctx.query = { profile: 'default' }
+    await ctrl.getAvailable(ctx)
+
+    expect(ctx.body.groups).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        provider: 'custom:fun-codex',
+        builtin: true,
       }),
     ]))
   })


### PR DESCRIPTION
## 变更内容

- `allProviders` 现在会透传硬编码 provider preset 的 `builtin: true`。
- `custom:xxx` provider 会先去掉 `custom:` 前缀，再用 `xxx` 匹配硬编码 `PROVIDER_PRESETS.value`，命中后返回 `builtin: true`。
- 不按 `base_url` 匹配，避免代理地址或自定义地址误判。
- 为 `fun-claude` 补充 `claude-opus-4-8` 模型。
- 增加 controller 测试覆盖 `allProviders` 和 `custom:fun-codex` 场景。

## 验证

- `npx vitest run tests/server/model-visibility-controller.test.ts`
- `npm run build`
