### PR TITLE
feat(bridge): 前端显示当前上下文真实token消耗，/usage命令结果与cli格式同步

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -251,6 +251,11 @@ watch(
 )
 
 const totalTokens = computed(() => {
+  // Prefer upstream API input_tokens when available (bridge mode).
+  // It already includes system prompt + tools + messages — the
+  // actual context window consumption reported by the model provider.
+  const apiInput = chatStore.activeSession?.apiUsage?.inputTokens
+  if (typeof apiInput === 'number' && apiInput > 0) return apiInput
   const context = chatStore.activeSession?.contextTokens
   if (typeof context === 'number' && Number.isFinite(context) && context > 0) return context
   const input = chatStore.activeSession?.inputTokens ?? 0

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -994,7 +994,13 @@ export const useChatStore = defineStore('chat', () => {
     if (action === 'usage' && target) {
       target.inputTokens = (evt as any).inputTokens
       target.outputTokens = (evt as any).outputTokens
-      if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
+      // Use API input_tokens for the progress bar when available;
+      // it already includes system prompt + tools + messages.
+      if ((evt as any).totalTokens != null) {
+        target.contextTokens = (evt as any).inputTokens
+      } else if ((evt as any).contextTokens != null) {
+        target.contextTokens = (evt as any).contextTokens
+      }
       // Save full upstream API usage data when available (from bridge agent result)
       if ((evt as any).totalTokens != null) {
         target.apiUsage = {
@@ -1646,7 +1652,7 @@ export const useChatStore = defineStore('chat', () => {
               })
               if ((evt as any).contextTokens != null) {
                 const target = sessions.value.find(s => s.id === sid)
-                if (target) target.contextTokens = (evt as any).contextTokens
+                if (target && !target.apiUsage) target.contextTokens = (evt as any).contextTokens
               }
               // Auto-clear after 5s
               setTimeout(() => {
@@ -1874,7 +1880,14 @@ export const useChatStore = defineStore('chat', () => {
                     target.inputTokens = (evt as any).inputTokens
                     target.outputTokens = (evt as any).outputTokens
                   }
-                  if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
+                  // When API-level usage is available, use input_tokens as
+                  // contextTokens (it already includes system prompt + tools
+                  // + messages — the actual context window consumption).
+                  if (apiUsage) {
+                    target.contextTokens = apiUsage.inputTokens
+                  } else if ((evt as any).contextTokens != null) {
+                    target.contextTokens = (evt as any).contextTokens
+                  }
                 }
               }
               // Belt-and-suspenders: some providers may deliver the final
@@ -1991,9 +2004,17 @@ export const useChatStore = defineStore('chat', () => {
             case 'usage.updated': {
               const target = sessions.value.find(s => s.id === sid)
               if (target) {
-                target.inputTokens = (evt as any).inputTokens
-                target.outputTokens = (evt as any).outputTokens
-                if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
+                // Only update from server estimates when upstream API data
+                // isn't already available (avoid downgrading real → estimated).
+                if (!target.apiUsage) {
+                  target.inputTokens = (evt as any).inputTokens
+                  target.outputTokens = (evt as any).outputTokens
+                }
+                if (target.apiUsage) {
+                  target.contextTokens = target.apiUsage.inputTokens
+                } else if ((evt as any).contextTokens != null) {
+                  target.contextTokens = (evt as any).contextTokens
+                }
               }
               break
             }
@@ -2138,7 +2159,7 @@ export const useChatStore = defineStore('chat', () => {
           })
           if ((evt as any).contextTokens != null) {
             const target = sessions.value.find(s => s.id === sid)
-            if (target) target.contextTokens = (evt as any).contextTokens
+            if (target && !target.apiUsage) target.contextTokens = (evt as any).contextTokens
           }
           setTimeout(() => {
             const state = compressionStates.value.get(sid)
@@ -2146,6 +2167,11 @@ export const useChatStore = defineStore('chat', () => {
               setCompressionState(sid, null)
             }
           }, 5000)
+          // Fall through to check if run completes (some compression events
+          // also carry terminal run status)
+          break
+        }
+        case 'compression.completed':
           break
         }
 
@@ -2361,7 +2387,14 @@ export const useChatStore = defineStore('chat', () => {
                 target.inputTokens = (evt as any).inputTokens
                 target.outputTokens = (evt as any).outputTokens
               }
-              if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
+              // When API-level usage is available, use input_tokens as
+              // contextTokens (it already includes system prompt + tools
+              // + messages — the actual context window consumption).
+              if (apiUsage) {
+                target.contextTokens = apiUsage.inputTokens
+              } else if ((evt as any).contextTokens != null) {
+                target.contextTokens = (evt as any).contextTokens
+              }
             }
           }
           // Check if backend provided parsed content (from stringified array format)
@@ -2462,9 +2495,17 @@ export const useChatStore = defineStore('chat', () => {
         case 'usage.updated': {
           const target = sessions.value.find(s => s.id === sid)
           if (target) {
-            target.inputTokens = (evt as any).inputTokens
-            target.outputTokens = (evt as any).outputTokens
-            if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
+            // Only update from server estimates when upstream API data
+            // isn't already available (avoid downgrading real → estimated).
+            if (!target.apiUsage) {
+              target.inputTokens = (evt as any).inputTokens
+              target.outputTokens = (evt as any).outputTokens
+            }
+            if (target.apiUsage) {
+              target.contextTokens = target.apiUsage.inputTokens
+            } else if ((evt as any).contextTokens != null) {
+              target.contextTokens = (evt as any).contextTokens
+            }
           }
           break
         }

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -994,13 +994,7 @@ export const useChatStore = defineStore('chat', () => {
     if (action === 'usage' && target) {
       target.inputTokens = (evt as any).inputTokens
       target.outputTokens = (evt as any).outputTokens
-      // Use API input_tokens for the progress bar when available;
-      // it already includes system prompt + tools + messages.
-      if ((evt as any).totalTokens != null) {
-        target.contextTokens = (evt as any).inputTokens
-      } else if ((evt as any).contextTokens != null) {
-        target.contextTokens = (evt as any).contextTokens
-      }
+      if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
       // Save full upstream API usage data when available (from bridge agent result)
       if ((evt as any).totalTokens != null) {
         target.apiUsage = {
@@ -1652,7 +1646,7 @@ export const useChatStore = defineStore('chat', () => {
               })
               if ((evt as any).contextTokens != null) {
                 const target = sessions.value.find(s => s.id === sid)
-                if (target && !target.apiUsage) target.contextTokens = (evt as any).contextTokens
+                if (target) target.contextTokens = (evt as any).contextTokens
               }
               // Auto-clear after 5s
               setTimeout(() => {
@@ -1880,14 +1874,7 @@ export const useChatStore = defineStore('chat', () => {
                     target.inputTokens = (evt as any).inputTokens
                     target.outputTokens = (evt as any).outputTokens
                   }
-                  // When API-level usage is available, use input_tokens as
-                  // contextTokens (it already includes system prompt + tools
-                  // + messages — the actual context window consumption).
-                  if (apiUsage) {
-                    target.contextTokens = apiUsage.inputTokens
-                  } else if ((evt as any).contextTokens != null) {
-                    target.contextTokens = (evt as any).contextTokens
-                  }
+                  if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
                 }
               }
               // Belt-and-suspenders: some providers may deliver the final
@@ -2004,17 +1991,9 @@ export const useChatStore = defineStore('chat', () => {
             case 'usage.updated': {
               const target = sessions.value.find(s => s.id === sid)
               if (target) {
-                // Only update from server estimates when upstream API data
-                // isn't already available (avoid downgrading real → estimated).
-                if (!target.apiUsage) {
-                  target.inputTokens = (evt as any).inputTokens
-                  target.outputTokens = (evt as any).outputTokens
-                }
-                if (target.apiUsage) {
-                  target.contextTokens = target.apiUsage.inputTokens
-                } else if ((evt as any).contextTokens != null) {
-                  target.contextTokens = (evt as any).contextTokens
-                }
+                target.inputTokens = (evt as any).inputTokens
+                target.outputTokens = (evt as any).outputTokens
+                if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
               }
               break
             }
@@ -2159,7 +2138,7 @@ export const useChatStore = defineStore('chat', () => {
           })
           if ((evt as any).contextTokens != null) {
             const target = sessions.value.find(s => s.id === sid)
-            if (target && !target.apiUsage) target.contextTokens = (evt as any).contextTokens
+            if (target) target.contextTokens = (evt as any).contextTokens
           }
           setTimeout(() => {
             const state = compressionStates.value.get(sid)
@@ -2167,11 +2146,6 @@ export const useChatStore = defineStore('chat', () => {
               setCompressionState(sid, null)
             }
           }, 5000)
-          // Fall through to check if run completes (some compression events
-          // also carry terminal run status)
-          break
-        }
-        case 'compression.completed':
           break
         }
 
@@ -2387,14 +2361,7 @@ export const useChatStore = defineStore('chat', () => {
                 target.inputTokens = (evt as any).inputTokens
                 target.outputTokens = (evt as any).outputTokens
               }
-              // When API-level usage is available, use input_tokens as
-              // contextTokens (it already includes system prompt + tools
-              // + messages — the actual context window consumption).
-              if (apiUsage) {
-                target.contextTokens = apiUsage.inputTokens
-              } else if ((evt as any).contextTokens != null) {
-                target.contextTokens = (evt as any).contextTokens
-              }
+              if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
             }
           }
           // Check if backend provided parsed content (from stringified array format)
@@ -2495,17 +2462,9 @@ export const useChatStore = defineStore('chat', () => {
         case 'usage.updated': {
           const target = sessions.value.find(s => s.id === sid)
           if (target) {
-            // Only update from server estimates when upstream API data
-            // isn't already available (avoid downgrading real → estimated).
-            if (!target.apiUsage) {
-              target.inputTokens = (evt as any).inputTokens
-              target.outputTokens = (evt as any).outputTokens
-            }
-            if (target.apiUsage) {
-              target.contextTokens = target.apiUsage.inputTokens
-            } else if ((evt as any).contextTokens != null) {
-              target.contextTokens = (evt as any).contextTokens
-            }
+            target.inputTokens = (evt as any).inputTokens
+            target.outputTokens = (evt as any).outputTokens
+            if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
           }
           break
         }

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -87,6 +87,18 @@ export interface Session {
   endedAt?: number | null
   lastActiveAt?: number
   workspace?: string | null
+  apiUsage?: {
+    inputTokens: number
+    outputTokens: number
+    cacheReadTokens?: number
+    cacheWriteTokens?: number
+    reasoningTokens?: number
+    totalTokens?: number
+    model?: string
+    costStatus?: string
+    actualCostUsd?: number
+    estimatedCostUsd?: number
+  }
 }
 
 interface CompressionState {
@@ -983,6 +995,21 @@ export const useChatStore = defineStore('chat', () => {
       target.inputTokens = (evt as any).inputTokens
       target.outputTokens = (evt as any).outputTokens
       if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
+      // Save full upstream API usage data when available (from bridge agent result)
+      if ((evt as any).totalTokens != null) {
+        target.apiUsage = {
+          inputTokens: (evt as any).inputTokens,
+          outputTokens: (evt as any).outputTokens,
+          cacheReadTokens: (evt as any).cacheReadTokens,
+          cacheWriteTokens: (evt as any).cacheWriteTokens,
+          reasoningTokens: (evt as any).reasoningTokens,
+          totalTokens: (evt as any).totalTokens,
+          model: (evt as any).model,
+          costStatus: (evt as any).costStatus,
+          actualCostUsd: (evt as any).actualCostUsd,
+          estimatedCostUsd: (evt as any).estimatedCostUsd,
+        }
+      }
     }
 
     if (action === 'destroy') {
@@ -1837,8 +1864,16 @@ export const useChatStore = defineStore('chat', () => {
               if ((evt as any).inputTokens != null) {
                 const target = sessions.value.find(s => s.id === sid)
                 if (target) {
-                  target.inputTokens = (evt as any).inputTokens
-                  target.outputTokens = (evt as any).outputTokens
+                  // Prefer upstream API-level usage when available (bridge mode)
+                  const apiUsage = (evt as any).apiUsage
+                  if (apiUsage) {
+                    target.inputTokens = apiUsage.inputTokens
+                    target.outputTokens = apiUsage.outputTokens
+                    target.apiUsage = apiUsage
+                  } else {
+                    target.inputTokens = (evt as any).inputTokens
+                    target.outputTokens = (evt as any).outputTokens
+                  }
                   if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
                 }
               }
@@ -2316,8 +2351,16 @@ export const useChatStore = defineStore('chat', () => {
           if ((evt as any).inputTokens != null) {
             const target = sessions.value.find(s => s.id === sid)
             if (target) {
-              target.inputTokens = (evt as any).inputTokens
-              target.outputTokens = (evt as any).outputTokens
+              // Prefer upstream API-level usage when available (bridge mode)
+              const apiUsage = (evt as any).apiUsage
+              if (apiUsage) {
+                target.inputTokens = apiUsage.inputTokens
+                target.outputTokens = apiUsage.outputTokens
+                target.apiUsage = apiUsage
+              } else {
+                target.inputTokens = (evt as any).inputTokens
+                target.outputTokens = (evt as any).outputTokens
+              }
               if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
             }
           }

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -123,6 +123,7 @@ function extractBridgeUsage(result: unknown): BridgeUsageState | undefined {
     apiCalls: finiteToken(r.api_calls) ?? 0,
     model: typeof r.model === 'string' ? r.model : undefined,
     estimatedCostUsd: typeof r.estimated_cost_usd === 'number' ? r.estimated_cost_usd : undefined,
+    actualCostUsd: typeof r.actual_cost_usd === 'number' ? r.actual_cost_usd : undefined,
     costStatus: typeof r.cost_status === 'string' ? r.cost_status : undefined,
     costSource: typeof r.cost_source === 'string' ? r.cost_source : undefined,
   }

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -26,7 +26,7 @@ import {
   recordBridgeToolCompleted,
 } from './bridge-message'
 import { summarizeToolArguments } from './response-utils'
-import type { ContentBlock, QueuedRun, SessionState } from './types'
+import type { ContentBlock, QueuedRun, SessionState, BridgeUsageState } from './types'
 import type { ChatMessage } from '../../../lib/context-compressor'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
 import { filterBridgeToolCallMarkupDelta, flushPendingToolCallMarkup } from './bridge-delta'
@@ -104,6 +104,28 @@ function finiteToken(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0
     ? Math.floor(value)
     : undefined
+}
+
+function extractBridgeUsage(result: unknown): BridgeUsageState | undefined {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) return undefined
+  const r = result as Record<string, unknown>
+  const inputTokens = finiteToken(r.input_tokens)
+  if (inputTokens == null) return undefined
+  return {
+    inputTokens,
+    outputTokens: finiteToken(r.output_tokens) ?? 0,
+    cacheReadTokens: finiteToken(r.cache_read_tokens) ?? 0,
+    cacheWriteTokens: finiteToken(r.cache_write_tokens) ?? 0,
+    reasoningTokens: finiteToken(r.reasoning_tokens) ?? 0,
+    promptTokens: finiteToken(r.prompt_tokens) ?? 0,
+    completionTokens: finiteToken(r.completion_tokens) ?? 0,
+    totalTokens: finiteToken(r.total_tokens) ?? 0,
+    apiCalls: finiteToken(r.api_calls) ?? 0,
+    model: typeof r.model === 'string' ? r.model : undefined,
+    estimatedCostUsd: typeof r.estimated_cost_usd === 'number' ? r.estimated_cost_usd : undefined,
+    costStatus: typeof r.cost_status === 'string' ? r.cost_status : undefined,
+    costSource: typeof r.cost_source === 'string' ? r.cost_source : undefined,
+  }
 }
 
 function cacheBridgeContext(state: SessionState, data: Record<string, unknown> | AgentBridgeContextEstimate) {
@@ -453,6 +475,7 @@ export async function handleBridgeRun(
       inputTokens: errUsage.inputTokens,
       outputTokens: errUsage.outputTokens,
       contextTokens: errContextTokens,
+      apiUsage: state.bridgeUsage,
       queue_remaining: queueLen,
     })
     if (queueLen > 0) dequeueNextQueuedRun(socket, session_id)
@@ -904,6 +927,10 @@ async function applyBridgeChunkAsync(
     outputTokens: usage.outputTokens,
     profile: state.profile,
   })
+  // Extract upstream API token usage from bridge result (hermes agent's
+  // conversation_loop.py already includes input_tokens, output_tokens,
+  // cache_*, reasoning_*, total_tokens, api_calls, and cost fields).
+  state.bridgeUsage = extractBridgeUsage(chunk.result)
   const terminalError = bridgeTerminalError(chunk)
   const hadQueuedRunBeforeGoalEvaluation = state.queue.length > 0
   state.isWorking = hadQueuedRunBeforeGoalEvaluation
@@ -923,6 +950,7 @@ async function applyBridgeChunkAsync(
     inputTokens: usage.inputTokens,
     outputTokens: usage.outputTokens,
     contextTokens,
+    apiUsage: state.bridgeUsage,
     queue_remaining: state.queue.length,
   }
   emit(eventName, payload)

--- a/packages/server/src/services/hermes/run-chat/session-command.ts
+++ b/packages/server/src/services/hermes/run-chat/session-command.ts
@@ -121,7 +121,7 @@ export async function handleSessionCommand(
         // Use upstream API-level token data from the bridge agent result
         const model = bu.model || ctx.model || getSession(sessionId)?.model || 'unknown'
         const modelCtxLen = getModelContextLength({ profile: ctx.profile, model })
-        const contextForDisplay = state.contextTokens ?? (localUsage.inputTokens + localUsage.outputTokens)
+        const contextForDisplay = bu.inputTokens ?? state.contextTokens ?? (localUsage.inputTokens + localUsage.outputTokens)
         const contextPct = modelCtxLen > 0
           ? `${((contextForDisplay / modelCtxLen) * 100).toFixed(0)}%`
           : 'N/A'

--- a/packages/server/src/services/hermes/run-chat/session-command.ts
+++ b/packages/server/src/services/hermes/run-chat/session-command.ts
@@ -8,6 +8,8 @@ import { handleAbort } from './abort'
 import { calcAndUpdateUsage, contextTokensWithCachedOverhead, updateMessageContextTokenUsage } from './usage'
 import { contentBlocksToString } from './content-blocks'
 import type { ContentBlock, QueuedRun, SessionState } from './types'
+import { getModelContextLength } from '../model-context'
+import { getCompressionSnapshot } from '../../../db/hermes/compression-snapshot'
 
 type CommandName =
   | 'usage'
@@ -111,15 +113,79 @@ export async function handleSessionCommand(
 
   switch (command.name) {
     case 'usage': {
-      const usage = await calcAndUpdateUsage(sessionId, state, (event, payload) => {
+      const localUsage = await calcAndUpdateUsage(sessionId, state, (event, payload) => {
         emitToSession(ctx.nsp, ctx.socket, sessionId, event, payload)
       })
+      const bu = state.bridgeUsage
+      if (bu) {
+        // Use upstream API-level token data from the bridge agent result
+        const model = bu.model || ctx.model || getSession(sessionId)?.model || 'unknown'
+        const modelCtxLen = getModelContextLength({ profile: ctx.profile, model })
+        const contextForDisplay = state.contextTokens ?? (localUsage.inputTokens + localUsage.outputTokens)
+        const contextPct = modelCtxLen > 0
+          ? `${((contextForDisplay / modelCtxLen) * 100).toFixed(0)}%`
+          : 'N/A'
+        const cost = bu.actualCostUsd != null
+          ? `$${bu.actualCostUsd.toFixed(6)}`
+          : bu.estimatedCostUsd && bu.estimatedCostUsd > 0
+            ? `~$${bu.estimatedCostUsd.toFixed(6)} (estimated)`
+            : 'n/a'
+        const sessionRow = getSession(sessionId)
+        const sessionDuration = sessionRow
+          ? `${Math.max(0, Math.floor((sessionRow.last_active || Date.now() / 1000) - (sessionRow.started_at || sessionRow.last_active || Date.now() / 1000)))}s`
+          : 'N/A'
+        const compressionCount = getCompressionSnapshot(sessionId) ? 1 : 0  // approximate
+        const note = bu.costStatus === 'unknown' && model
+          ? `Pricing unknown for ${model}`
+          : ''
+
+        emitCommand({
+          action: 'usage',
+          terminal: !state.isWorking,
+          message: [
+            '📊 Session Token Usage',
+            '────────────────────────────────────────',
+            `Model:                     ${model}`,
+            `Input tokens:              ${bu.inputTokens.toLocaleString()}`,
+            `Cache read tokens:         ${bu.cacheReadTokens.toLocaleString()}`,
+            `Cache write tokens:        ${bu.cacheWriteTokens.toLocaleString()}`,
+            `Output tokens:             ${bu.outputTokens.toLocaleString()}`,
+            `Reasoning tokens:          ${bu.reasoningTokens.toLocaleString()}`,
+            `Prompt tokens (total):     ${bu.promptTokens.toLocaleString()}`,
+            `Completion tokens:         ${bu.completionTokens.toLocaleString()}`,
+            `Total tokens:              ${bu.totalTokens.toLocaleString()}`,
+            `API calls:                 ${bu.apiCalls}`,
+            `Session duration:          ${sessionDuration}`,
+            `Cost status:               ${bu.costStatus || 'unknown'}`,
+            `Cost source:               ${bu.costSource || 'none'}`,
+            `Total cost:                ${cost}`,
+            '────────────────────────────────────────',
+            `Current context:  ${contextForDisplay.toLocaleString()} / ${modelCtxLen.toLocaleString()} (${contextPct})`,
+            `Messages:         ${state.messages.length}`,
+            `Compressions:     ${compressionCount}`,
+            note,
+          ].filter(line => line !== '').join('\n'),
+          inputTokens: bu.inputTokens,
+          outputTokens: bu.outputTokens,
+          cacheReadTokens: bu.cacheReadTokens,
+          cacheWriteTokens: bu.cacheWriteTokens,
+          reasoningTokens: bu.reasoningTokens,
+          totalTokens: bu.totalTokens,
+          contextTokens: contextForDisplay,
+          model,
+          costStatus: bu.costStatus,
+          actualCostUsd: bu.actualCostUsd,
+          estimatedCostUsd: bu.estimatedCostUsd,
+        })
+        return
+      }
+      // Fallback: local tiktoken estimate when bridge agent data not yet available
       emitCommand({
         action: 'usage',
         terminal: !state.isWorking,
-        message: `Usage: input ${usage.inputTokens}, output ${usage.outputTokens}, total ${usage.inputTokens + usage.outputTokens} tokens.`,
-        inputTokens: usage.inputTokens,
-        outputTokens: usage.outputTokens,
+        message: `Usage: input ${localUsage.inputTokens}, output ${localUsage.outputTokens}, total ${localUsage.inputTokens + localUsage.outputTokens} tokens.`,
+        inputTokens: localUsage.inputTokens,
+        outputTokens: localUsage.outputTokens,
       })
       return
     }

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -109,6 +109,7 @@ export interface BridgeUsageState {
   apiCalls: number
   model?: string
   estimatedCostUsd?: number
+  actualCostUsd?: number
   costStatus?: string
   costSource?: string
 }

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -57,6 +57,7 @@ export interface SessionState {
   outputTokens?: number
   contextTokens?: number
   bridgeContext?: BridgeContextState
+  bridgeUsage?: BridgeUsageState
   isAborting?: boolean
   queue: QueuedRun[]
   responseRun?: ResponseRunState
@@ -95,6 +96,22 @@ export interface BridgeContextState {
 }
 
 export type ChatRunSource = 'api_server' | 'cli'
+
+export interface BridgeUsageState {
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+  reasoningTokens: number
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+  apiCalls: number
+  model?: string
+  estimatedCostUsd?: number
+  costStatus?: string
+  costSource?: string
+}
 
 export interface BridgeCompressionResult {
   messages: ChatMessage[]


### PR DESCRIPTION
## 问题

Web UI bridge 模式下，前端显示的 token 数和 /usage 命令都使用本地 tiktoken 估算，
而非上游 API 返回的真实消耗。

## 根因

hermes agent conversation_loop.py:4156 的返回值已包含完整的上游 token 数据
（input/output/cache/reasoning/total/api_calls/cost），bridge 原样透传到 chunk.result，
但 TypeScript 端此前只用本地 countTokens() 重新估算。

## 方案

在 TS 端提取已有数据。

## 效果

<img width="815" height="929" alt="image" src="https://github.com/user-attachments/assets/b6f8a3b9-1f41-45ba-a66a-b7c15a3e9a25" />

无桥数据时自动 fallback 到原有逻辑。
