### PR TITLE
[codex] fix virtual list empty state centering

### DIFF
--- a/packages/client/src/components/hermes/chat/VirtualMessageList.vue
+++ b/packages/client/src/components/hermes/chat/VirtualMessageList.vue
@@ -313,9 +313,6 @@ defineExpose({
       @resize="handleResize"
       @visible="syncViewport"
     >
-      <template #empty>
-        <slot name="empty" />
-      </template>
       <template #before>
         <slot v-if="messages.length > 0" name="before" />
       </template>
@@ -333,6 +330,9 @@ defineExpose({
         <slot v-if="messages.length > 0" name="after" />
       </template>
     </DynamicScroller>
+    <div v-if="messages.length === 0 && $slots.empty" class="virtual-message-list-empty">
+      <slot name="empty" />
+    </div>
   </div>
 </template>
 
@@ -343,6 +343,7 @@ defineExpose({
   flex: 1;
   min-height: 0;
   display: flex;
+  position: relative;
 }
 
 .virtual-message-list {
@@ -360,5 +361,21 @@ defineExpose({
 .virtual-row {
   box-sizing: border-box;
   padding-bottom: var(--virtual-row-gap);
+}
+
+.virtual-message-list-empty {
+  position: absolute;
+  inset: var(--virtual-list-padding);
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  min-height: 0;
+  pointer-events: auto;
+}
+
+.virtual-message-list-empty :deep(.empty-state) {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
 }
 </style>


### PR DESCRIPTION
## Summary
- Move the virtual message list empty state out of the DynamicScroller empty slot into a host-level overlay
- Size the overlay to the list padding box so the existing empty-state flex layout can center correctly
- Keep the fix shared for chat, history, and group chat message lists

## Root Cause
`vue-virtual-scroller` renders the empty slot inside its item wrapper, which does not provide the stretchable viewport height that the existing `.empty-state { flex: 1 }` styles expected.

## Validation
- `npx vue-tsc -b`
- `git diff --check`

Note: I started a mocked browser layout check, but stopped when you asked me to submit the PR.