### PR TITLE
fix(auth): use path.dirname for credential dir on Windows

### DIFF
--- a/packages/server/src/controllers/hermes/codex-auth.ts
+++ b/packages/server/src/controllers/hermes/codex-auth.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto'
-import { join } from 'path'
+import { join, dirname } from 'path'
 import { homedir } from 'os'
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs'
 import { getActiveAuthPath } from '../../services/hermes/hermes-profile'
@@ -47,7 +47,7 @@ function loadAuthJson(authPath: string): AuthJson {
 
 function saveAuthJson(authPath: string, data: AuthJson): void {
   data.updated_at = new Date().toISOString()
-  const dir = authPath.substring(0, authPath.lastIndexOf('/'))
+  const dir = dirname(authPath)
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
   writeFileSync(authPath, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 })
 }
@@ -55,7 +55,7 @@ function saveAuthJson(authPath: string, data: AuthJson): void {
 function saveCodexCliTokens(accessToken: string, refreshToken: string): void {
   const codexHome = process.env.CODEX_HOME || CODEX_HOME
   const codexAuthPath = join(codexHome, 'auth.json')
-  const dir = codexAuthPath.substring(0, codexAuthPath.lastIndexOf('/'))
+  const dir = dirname(codexAuthPath)
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
   writeFileSync(codexAuthPath, JSON.stringify({ tokens: { access_token: accessToken, refresh_token: refreshToken }, last_refresh: new Date().toISOString() }, null, 2) + '\n', { mode: 0o600 })
 }

--- a/packages/server/src/controllers/hermes/nous-auth.ts
+++ b/packages/server/src/controllers/hermes/nous-auth.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto'
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs'
+import { dirname } from 'path'
 import { getActiveAuthPath } from '../../services/hermes/hermes-profile'
 import { logger } from '../../services/logger'
 
@@ -46,7 +47,7 @@ function loadAuthJson(authPath: string): AuthJson {
 
 function saveAuthJson(authPath: string, data: AuthJson): void {
   data.updated_at = new Date().toISOString()
-  const dir = authPath.substring(0, authPath.lastIndexOf('/'))
+  const dir = dirname(authPath)
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
   writeFileSync(authPath, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 })
 }

--- a/packages/server/src/controllers/hermes/xai-auth.ts
+++ b/packages/server/src/controllers/hermes/xai-auth.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes, randomUUID } from 'crypto'
 import { createServer, type Server } from 'http'
 import { request as httpsRequest, type RequestOptions } from 'https'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { dirname } from 'path'
 import { URL } from 'url'
 import { getActiveAuthPath } from '../../services/hermes/hermes-profile'
 import { logger } from '../../services/logger'
@@ -153,7 +154,7 @@ function loadAuthJson(authPath: string): AuthJson {
 
 function saveAuthJson(authPath: string, data: AuthJson): void {
   data.updated_at = new Date().toISOString()
-  const dir = authPath.substring(0, authPath.lastIndexOf('/'))
+  const dir = dirname(authPath)
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
   writeFileSync(authPath, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 })
 }


### PR DESCRIPTION
## Summary

Provider OAuth login fails on **Windows** with:

```
ENOENT: no such file or directory, mkdir ''
```

The auth controllers compute the credential directory by hand:

```ts
const dir = authPath.substring(0, authPath.lastIndexOf('/'))
if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
```

On Windows, paths use backslashes, so `lastIndexOf('/')` returns `-1`,
`substring(0, -1)` yields `''`, and `mkdirSync('')` throws. This breaks
the OpenAI Codex / xAI / Nous login flows on Windows right after
authorization.

## Fix

Use the cross-platform `path.dirname()` instead of manual slicing, in:

- `codex-auth.ts` — `saveAuthJson` (auth.json) and `saveCodexCliTokens` (~/.codex/auth.json)
- `xai-auth.ts` — `saveAuthJson`
- `nous-auth.ts` — `saveAuthJson`

No behavior change on POSIX; correct directory resolution on Windows.

## Validation

- `tsc --noEmit -p packages/server/tsconfig.json` passes.
- Reported downstream as a Codex login failure on Windows (`mkdir ''`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)