### PR TITLE
fix(server): raise body parser limit so avatar upload doesn't 413

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -133,7 +133,10 @@ export async function bootstrap() {
   console.log('[bootstrap] all stores initialized')
 
   app.use(cors({ origin: config.corsOrigins }))
-  app.use(bodyParser())
+  // Raise JSON/text limits above the default 1mb: profile avatars are posted
+  // as base64 data URLs (up to ~1MB raw → ~1.37MB base64), which otherwise
+  // tripped a 413 in the body parser before reaching the handler.
+  app.use(bodyParser({ encoding: 'utf-8', jsonLimit: '4mb', textLimit: '4mb' }))
   console.log('[bootstrap] cors + bodyParser registered')
 
   // Register all routes (handles auth internally)


### PR DESCRIPTION
## Summary

Custom profile avatar upload **always fails with HTTP 413**.

Avatars are posted to `/profiles/:name/avatar` as base64 image **data URLs in a JSON body** (`{ type: 'image', dataUrl }`). The handler explicitly allows up to **1MB of raw image data**:

```ts
if (buffer.length > 1024 * 1024) throw new Error('Avatar image must be 1MB or smaller')
```

But 1MB of image is **~1.37MB once base64-encoded**, which exceeds `@koa/bodyparser`'s default `jsonLimit` of `1mb`. So the body parser rejects the request with **413 before the handler ever runs** — the 1MB allowance is effectively unreachable.

## Fix

```ts
app.use(bodyParser({ encoding: 'utf-8', jsonLimit: '4mb', textLimit: '4mb' }))
```

Large binary uploads are unaffected — they go through the separate streamed multipart endpoint (`controllers/upload.ts`, 50MB cap), not the JSON body parser. The handler's own 1MB raw-size check remains the authoritative limit, now returning a clear `400` instead of a confusing `413`.

## Validation

- `tsc --noEmit -p packages/server/tsconfig.json` passes.
- Reported downstream as "custom avatar upload always fails with 413".

🤖 Generated with [Claude Code](https://claude.com/claude-code)