### PR TITLE
docs: sync mobile preview section to English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@
 </p>
 
 <p align="center">
+  <strong>Mobile</strong>
+</p>
+
+<p align="center">
+  <video src="https://github.com/EKKOLearnAI/hermes-web-ui/blob/main/packages/client/src/assets/video.mp4?raw=true" width="360" controls></video>
+</p>
+
+<p align="center">
   <a href="https://www.npmjs.com/package/hermes-web-ui"><img src="https://img.shields.io/npm/v/hermes-web-ui?style=flat-square&color=blue" alt="npm version"/></a>
   <a href="https://github.com/EKKOLearnAI/hermes-web-ui/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/hermes-web-ui?style=flat-square" alt="license"/></a>
   <a href="https://github.com/EKKOLearnAI/hermes-web-ui/stargazers"><img src="https://img.shields.io/github/stars/EKKOLearnAI/hermes-web-ui?style=flat-square" alt="stars"/></a>


### PR DESCRIPTION
## Summary
The Chinese README has a mobile preview section (with a demo video) right after the desktop screenshots, but the English README is missing the equivalent block. This PR brings the English README in line with `README_zh.md`.

## Change
Adds the `Mobile` heading + the video embed to `README.md`, using the same `packages/client/src/assets/video.mp4` asset that `README_zh.md` already references.

## Test plan
- [x] Markdown renders correctly on GitHub
- [x] Video URL matches the one used in `README_zh.md`
- [x] No other content changed