### PR TITLE
Fix desktop release artifact globs

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -29,26 +29,45 @@ jobs:
             target_os: darwin
             target_arch: arm64
             electron_target: "--mac dmg --arm64"
+            artifact_files: |
+              packages/desktop/release/*.dmg
+              packages/desktop/release/*.dmg.blockmap
+              packages/desktop/release/latest*.yml
           - label: macOS x64
             runner: macos-15-intel
             target_os: darwin
             target_arch: x64
             electron_target: "--mac dmg --x64"
+            artifact_files: |
+              packages/desktop/release/*.dmg
+              packages/desktop/release/*.dmg.blockmap
+              packages/desktop/release/latest*.yml
           - label: Windows x64
             runner: windows-latest
             target_os: win32
             target_arch: x64
             electron_target: "--win nsis --x64"
+            artifact_files: |
+              packages/desktop/release/*.exe
+              packages/desktop/release/*.exe.blockmap
+              packages/desktop/release/latest*.yml
           - label: Linux x64
             runner: ubuntu-22.04
             target_os: linux
             target_arch: x64
             electron_target: "--linux AppImage deb --x64"
+            artifact_files: |
+              packages/desktop/release/*.AppImage
+              packages/desktop/release/*.deb
+              packages/desktop/release/latest*.yml
           - label: Linux arm64
             runner: ubuntu-22.04-arm
             target_os: linux
             target_arch: arm64
             electron_target: "--linux AppImage --arm64"
+            artifact_files: |
+              packages/desktop/release/*.AppImage
+              packages/desktop/release/latest*.yml
 
     steps:
       - name: Checkout repository
@@ -102,11 +121,4 @@ jobs:
         with:
           tag_name: ${{ github.event.release.tag_name || github.event.inputs.tag }}
           fail_on_unmatched_files: true
-          files: |
-            packages/desktop/release/*.dmg
-            packages/desktop/release/*.dmg.blockmap
-            packages/desktop/release/*.exe
-            packages/desktop/release/*.exe.blockmap
-            packages/desktop/release/*.AppImage
-            packages/desktop/release/*.deb
-            packages/desktop/release/latest*.yml
+          files: ${{ matrix.artifact_files }}


### PR DESCRIPTION
## Summary
- split desktop release upload globs by matrix target platform
- keep `fail_on_unmatched_files: true` so each platform still fails if its expected artifact is missing
- prevent Windows release jobs from requiring macOS `.dmg` artifacts
- add a lightweight repository harness for coding agents: `AGENTS.md`, `ARCHITECTURE.md`, `docs/harness/*`, and `npm run harness:check`
- run the harness check in the Build workflow before tests

## Fixes
- Failing job: https://github.com/EKKOLearnAI/hermes-web-ui/actions/runs/26678940838/job/78635787094

## Validation
- `npm run harness:check`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f); puts "yaml ok #{f}" }'`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/build.yml .github/workflows/desktop-release.yml`\n- `git diff --check`\n\n## Notes\n- Local `node_modules` is not present in this worktree, so full `npm run build` is left to PR CI after dependency installation.\n