### PR TITLE
Fix desktop release artifact uploads

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -32,7 +32,6 @@ jobs:
             artifact_files: |
               packages/desktop/release/*.dmg
               packages/desktop/release/*.dmg.blockmap
-              packages/desktop/release/latest*.yml
           - label: macOS x64
             runner: macos-15-intel
             target_os: darwin
@@ -41,7 +40,6 @@ jobs:
             artifact_files: |
               packages/desktop/release/*.dmg
               packages/desktop/release/*.dmg.blockmap
-              packages/desktop/release/latest*.yml
           - label: Windows x64
             runner: windows-latest
             target_os: win32
@@ -50,7 +48,6 @@ jobs:
             artifact_files: |
               packages/desktop/release/*.exe
               packages/desktop/release/*.exe.blockmap
-              packages/desktop/release/latest*.yml
           - label: Linux x64
             runner: ubuntu-22.04
             target_os: linux
@@ -59,7 +56,6 @@ jobs:
             artifact_files: |
               packages/desktop/release/*.AppImage
               packages/desktop/release/*.deb
-              packages/desktop/release/latest*.yml
           - label: Linux arm64
             runner: ubuntu-22.04-arm
             target_os: linux
@@ -67,7 +63,6 @@ jobs:
             electron_target: "--linux AppImage --arm64"
             artifact_files: |
               packages/desktop/release/*.AppImage
-              packages/desktop/release/latest*.yml
 
     steps:
       - name: Checkout repository

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-web-ui",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "BSL-1.1",
       "dependencies": {
         "@vscode/markdown-it-katex": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Self-hosted AI chat dashboard for Hermes Agent — multi-model web UI with multi-platform integration",
   "repository": {
     "type": "git",

--- a/packages/desktop/package-lock.json
+++ b/packages/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-studio",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-studio",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.3.9"

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-studio",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Hermes Studio desktop distribution with bundled Python runtime and hermes-agent",
   "homepage": "https://ekkolearnai.com",
   "author": {


### PR DESCRIPTION
## Summary
- bump package versions to 0.6.6 for the desktop release tag
- remove optional latest*.yml metadata from required desktop release upload globs
- keep required platform artifacts strict: dmg/blockmap, exe/blockmap, AppImage/deb as applicable

## Context
Electron Builder is not producing latest*.yml in the current --publish never release jobs, so softprops/action-gh-release fails with fail_on_unmatched_files even after the platform-specific artifact globs fix.

## Verification
- git diff --check