### PR TITLE
[codex] skip production data dir creation

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -14,7 +14,7 @@ import { homedir } from 'os'
  * - HERMES_WEBUI_STATE_DIR: Compatibility alias for HERMES_WEB_UI_HOME.
  *   Default: join(homedir(), '.hermes-web-ui').
  * - UPLOAD_DIR: Upload directory override. Default: join(HERMES_WEB_UI_HOME, 'upload').
- * - dataDir: Internal Web UI runtime data directory. Default: join(HERMES_WEB_UI_HOME, 'data').
+ * - dataDir: Development-only internal Web UI runtime data directory.
  *
  * Auth:
  * - AUTH_TOKEN: Explicit bearer token. If unset, Web UI stores an auto-generated token under HERMES_WEB_UI_HOME.
@@ -42,8 +42,8 @@ export function getWebUiHome(env: Record<string, string | undefined> = process.e
   return appHome ? resolve(appHome) : join(homedir(), '.hermes-web-ui')
 }
 
-export function getWebUiDataDir(env: Record<string, string | undefined> = process.env): string {
-  return join(getWebUiHome(env), 'data')
+export function shouldCreateWebUiDataDir(env: Record<string, string | undefined> = process.env): boolean {
+  return env.NODE_ENV !== 'production'
 }
 
 const appHome = getWebUiHome()
@@ -54,6 +54,6 @@ export const config = {
   host: getListenHost(),
   appHome,
   uploadDir: process.env.UPLOAD_DIR || join(appHome, 'upload'),
-  dataDir: getWebUiDataDir(),
+  dataDir: resolve(__dirname, '..', 'data'),
   corsOrigins: process.env.CORS_ORIGINS || '*',
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,7 +7,7 @@ import os from 'os'
 import { resolve } from 'path'
 import { mkdir } from 'fs/promises'
 import { readFileSync } from 'fs'
-import { config } from './config'
+import { config, shouldCreateWebUiDataDir } from './config'
 import { initLoginLimiter } from './services/login-limiter'
 import { bindShutdown } from './services/shutdown'
 import { setupTerminalWebSocket } from './routes/hermes/terminal'
@@ -84,7 +84,9 @@ function safeNetworkInterfaces() {
 export async function bootstrap() {
   console.log(`hermes-web-ui v${APP_VERSION} starting...`)
   await mkdir(config.uploadDir, { recursive: true })
-  await mkdir(config.dataDir, { recursive: true })
+  if (shouldCreateWebUiDataDir()) {
+    await mkdir(config.dataDir, { recursive: true })
+  }
 
   await initLoginLimiter()
   try {

--- a/tests/server/config.test.ts
+++ b/tests/server/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { homedir } from 'os'
 import { join, resolve } from 'path'
-import { getListenHost, getWebUiDataDir, getWebUiHome } from '../../packages/server/src/config'
+import { getListenHost, getWebUiHome, shouldCreateWebUiDataDir } from '../../packages/server/src/config'
 
 describe('server config', () => {
   it('defaults to an IPv4 bind host', () => {
@@ -28,7 +28,8 @@ describe('server config', () => {
     expect(getWebUiHome({ HERMES_WEBUI_STATE_DIR: ' ./tmp/hermes-state ' })).toBe(resolve('./tmp/hermes-state'))
   })
 
-  it('keeps runtime data under the web-ui home', () => {
-    expect(getWebUiDataDir({ HERMES_WEB_UI_HOME: ' ./tmp/hermes-ui ' })).toBe(resolve('./tmp/hermes-ui/data'))
+  it('only creates the development data directory outside production', () => {
+    expect(shouldCreateWebUiDataDir({ NODE_ENV: 'development' })).toBe(true)
+    expect(shouldCreateWebUiDataDir({ NODE_ENV: 'production' })).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- Keep `config.dataDir` on the original code-relative `data` directory.
- Skip creating that development data directory when `NODE_ENV=production`.
- Add config coverage for the production guard.

## Validation
- `npm run test -- tests/server/config.test.ts`
- `npm run build`
