### PR TITLE
[codex] Update 0.6.7 changelog and provider URL handling

### DIFF
--- a/packages/client/src/components/hermes/models/ProviderFormModal.vue
+++ b/packages/client/src/components/hermes/models/ProviderFormModal.vue
@@ -9,6 +9,7 @@ import CopilotLoginModal from './CopilotLoginModal.vue'
 import XaiOAuthLoginModal from './XaiOAuthLoginModal.vue'
 import { checkCopilotToken, enableCopilot, type CopilotTokenSource } from '@/api/hermes/copilot-auth'
 import { fetchProviderModels } from '@/api/hermes/system'
+import { normalizeCustomProviderBaseUrl } from '@/utils/providerBaseUrl'
 
 const { t } = useI18n()
 
@@ -205,9 +206,13 @@ async function handleSave() {
       : null
 
     const contextLength = formData.value.context_length ?? undefined
+    const baseUrl = providerType.value === 'custom'
+      ? normalizeCustomProviderBaseUrl(formData.value.base_url)
+      : formData.value.base_url.trim()
+
     await modelsStore.addProvider({
       name: formData.value.name.trim(),
-      base_url: formData.value.base_url.trim(),
+      base_url: baseUrl,
       api_key: formData.value.api_key.trim(),
       model: formData.value.model,
       context_length: contextLength,

--- a/packages/client/src/data/changelog.ts
+++ b/packages/client/src/data/changelog.ts
@@ -6,6 +6,21 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.6.7',
+    date: '2026-05-31',
+    changes: [
+      'changelog.new_0_6_7_1',
+      'changelog.new_0_6_7_9',
+      'changelog.new_0_6_7_2',
+      'changelog.new_0_6_7_3',
+      'changelog.new_0_6_7_4',
+      'changelog.new_0_6_7_5',
+      'changelog.new_0_6_7_6',
+      'changelog.new_0_6_7_7',
+      'changelog.new_0_6_7_8',
+    ],
+  },
+  {
     version: '0.6.5',
     date: '2026-05-29',
     changes: [

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -1260,6 +1260,15 @@ jobTriggered: 'Job ausgelost',
 
   // Anderungsprotokoll
   changelog: {
+    new_0_6_7_1: 'Die Desktop-App nutzt jetzt standardmäßig Port 8748, unterstützt Zugriff im lokalen Netzwerk und kann direkt im lokalen Browser geöffnet werden',
+    new_0_6_7_9: 'Desktop-Download-Links sind jetzt auf der offiziellen Website https://ekkolearnai.com/ verfügbar, aktuelle Installer bleiben außerdem über GitHub Releases verfügbar',
+    new_0_6_7_2: 'MCP-Tools sind vollständiger: Bridge Tool Discovery, MCP-Management-Lifecycle und Tool-Sichtbarkeit pro Modell im Manager wurden verbessert',
+    new_0_6_7_3: 'Nachrichtenlisten zentrieren leere Zustände korrekt, reduzieren Scroll-Jitter, zeigen beim Laden von History keine Live-Chat-Nachrichten mehr, behalten Scrollpositionen pro Session und blenden beim Session-Wechsel 1,5 Sekunden ein',
+    new_0_6_7_4: 'Bridge und Runtime sind stabiler durch erhaltene Text/tool-call-Reihenfolge, korrektes Profile runtime status loading, bessere Node/npm-Erkennung und übersprungene Produktionsdatenverzeichnis-Erstellung',
+    new_0_6_7_5: 'Desktop-Distribution umfasst Electron-Packaging, App-Naming, Preload-Builds, Release-Artifact-Uploads, Windows Hermes CLI Start, Linux-Icons und beschreibbare Datenpfade, macOS ohne Signing-Zertifikate und versteckte Windows-Startup-Subprozesse',
+    new_0_6_7_6: 'Die Website hat Download- und Deploy-Workflows, und Deploys funktionieren auch in Umgebungen ohne rsync',
+    new_0_6_7_7: 'Server- und Auth-Fixes nutzen dirname für Windows-Credential-Verzeichnisse und erhöhen das Avatar-Upload-Limit gegen 413-Fehler bei größeren Bildern',
+    new_0_6_7_8: 'Repository-Harness, Validierungsdokumente und Agent-Guides für Coding Agents wurden ergänzt, alte Setup-Script-Dokumente entfernt',
     new_0_6_4_1: 'CI wurde mit festem npm-Installationsverhalten und Docker-Smoke-Coverage für PRs gehärtet',
     new_0_6_4_2: 'Chat nutzt jetzt virtualisierte Pagination, damit lange Gespräche zuverlässiger scrollen und laden',
     new_0_6_4_3: 'Docker-Image-Publishing läuft jetzt nur noch für Releases statt für normale PR-Checks',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -1482,6 +1482,15 @@ export default {
 
   // Changelog
   changelog: {
+    new_0_6_7_1: 'The desktop app now defaults to port 8748, supports LAN access, and can be opened directly from a local browser',
+    new_0_6_7_9: 'Desktop download links are now available on the official website at https://ekkolearnai.com/, and the latest installers remain available from GitHub Releases',
+    new_0_6_7_2: 'MCP tooling is more complete with bridge tool discovery fixes, MCP management lifecycle fixes, and per-model tool visibility controls in the manager',
+    new_0_6_7_3: 'Message lists now center empty states correctly, reduce scroll jitter, avoid leaking live chat messages into History while loading, preserve per-session scroll positions, and fade in over 1.5 seconds on session switches',
+    new_0_6_7_4: 'Bridge and runtime stability improved by preserving text/tool-call ordering, fixing Profile runtime status loading, improving Node/npm detection, and skipping production data directory creation',
+    new_0_6_7_5: 'Desktop distribution now covers Electron packaging, app naming, preload builds, release artifact uploads, Windows Hermes CLI launch, Linux icons and writable data paths, macOS unsigned release handling, and hidden Windows startup subprocesses',
+    new_0_6_7_6: 'The website now has downloads and deploy workflows, with deploys fixed for environments that do not provide rsync',
+    new_0_6_7_7: 'Server and auth fixes use dirname for Windows credential directories and raise the avatar upload body limit to avoid 413 errors on larger images',
+    new_0_6_7_8: 'Repository harness, validation docs, and agent guidance were added for coding agents, while stale setup script docs were removed',
     new_0_6_4_1: 'CI is hardened with pinned npm install behavior and PR Docker smoke coverage',
     new_0_6_4_2: 'Chat now uses virtualized pagination so long conversations scroll and load more reliably',
     new_0_6_4_3: 'Docker image publishing now runs only for releases instead of ordinary PR checks',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -1260,6 +1260,15 @@ jobTriggered: 'Job ejecutado',
 
   // Registro de cambios
   changelog: {
+    new_0_6_7_1: 'La app de escritorio ahora usa el puerto 8748 por defecto, permite acceso desde la red local y puede abrirse directamente desde un navegador local',
+    new_0_6_7_9: 'Los enlaces de descarga de escritorio ya están disponibles en el sitio oficial https://ekkolearnai.com/, y los instaladores más recientes siguen disponibles en GitHub Releases',
+    new_0_6_7_2: 'Las herramientas MCP quedan más completas con arreglos de discovery en bridge, ciclo de vida de gestión MCP y controles de visibilidad por modelo en el gestor',
+    new_0_6_7_3: 'Las listas de mensajes centran mejor el estado vacío, reducen saltos de scroll, evitan mostrar mensajes del chat activo mientras carga History, preservan la posición por sesión y hacen fade-in de 1,5 segundos al cambiar de sesión',
+    new_0_6_7_4: 'Bridge y runtime son más estables al preservar el orden texto/tool-call, corregir la carga de estado runtime de Profile, mejorar detección Node/npm y evitar crear directorios de datos en producción',
+    new_0_6_7_5: 'La distribución Desktop cubre empaquetado Electron, nombre de app, builds preload, subida de artifacts, inicio Hermes CLI en Windows, iconos Linux y rutas de datos escribibles, macOS sin certificados de firma y subprocesos ocultos al iniciar en Windows',
+    new_0_6_7_6: 'El sitio web suma página de descargas y workflow de deploy, con deploy corregido en entornos sin rsync',
+    new_0_6_7_7: 'Arreglos de servidor y auth usan dirname para credenciales en Windows y suben el límite de avatar para evitar errores 413 con imágenes grandes',
+    new_0_6_7_8: 'Se agregan harness del repositorio, documentación de validación y guías de agentes para Coding Agents, y se eliminan docs antiguas de setup scripts',
     new_0_6_4_1: 'CI se refuerza con instalación npm fijada y cobertura Docker smoke para PRs',
     new_0_6_4_2: 'El chat ahora usa paginación virtualizada para que conversaciones largas se desplacen y carguen con más fiabilidad',
     new_0_6_4_3: 'La publicación de imágenes Docker ahora solo se ejecuta en releases, no en checks normales de PR',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -1260,6 +1260,15 @@ jobTriggered: 'Job declenche',
 
   // Journal des modifications
   changelog: {
+    new_0_6_7_1: 'L application desktop utilise maintenant le port 8748 par défaut, prend en charge l accès LAN et peut être ouverte directement depuis un navigateur local',
+    new_0_6_7_9: 'Les liens de téléchargement desktop sont maintenant disponibles sur le site officiel https://ekkolearnai.com/, et les derniers installateurs restent disponibles via GitHub Releases',
+    new_0_6_7_2: 'Les outils MCP sont plus complets avec des corrections de découverte bridge, de cycle de vie MCP et des contrôles de visibilité par modèle dans le gestionnaire',
+    new_0_6_7_3: 'Les listes de messages centrent mieux les états vides, réduisent les sauts de scroll, évitent d afficher le chat actif pendant le chargement de History, conservent la position par session et ajoutent un fondu de 1,5 seconde au changement de session',
+    new_0_6_7_4: 'Bridge et runtime sont plus stables avec ordre texte/tool-call préservé, chargement du statut runtime de Profile corrigé, meilleure détection Node/npm et création du dossier de données production évitée',
+    new_0_6_7_5: 'La distribution Desktop couvre packaging Electron, nom d application, builds preload, uploads des artifacts, lancement Hermes CLI sous Windows, icônes Linux et chemins de données inscriptibles, macOS sans certificat de signature et sous-processus Windows masqués au démarrage',
+    new_0_6_7_6: 'Le site web ajoute les téléchargements et le workflow de déploiement, avec déploiement corrigé pour les environnements sans rsync',
+    new_0_6_7_7: 'Les corrections serveur et auth utilisent dirname pour les dossiers de credentials Windows et augmentent la limite d upload avatar afin d éviter les erreurs 413 sur les grandes images',
+    new_0_6_7_8: 'Le harness du dépôt, les docs de validation et les guides agent pour Coding Agents ont été ajoutés, tandis que les anciens docs de setup script ont été retirés',
     new_0_6_4_1: 'CI est renforcé avec une installation npm figée et une couverture Docker smoke pour les PR',
     new_0_6_4_2: 'Le chat utilise maintenant une pagination virtualisée pour rendre les longues conversations plus fiables au scroll et au chargement',
     new_0_6_4_3: 'La publication des images Docker ne s exécute désormais que pour les releases, pas pour les checks PR ordinaires',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -1259,6 +1259,15 @@ export default {
 
   // 更新履歴
   changelog: {
+    new_0_6_7_1: 'Desktop アプリは既定で port 8748 を使用し、LAN アクセスとローカルブラウザからの直接アクセスに対応しました',
+    new_0_6_7_9: 'Desktop のダウンロードリンクを公式サイト https://ekkolearnai.com/ に追加し、最新インストーラーは引き続き GitHub Releases からも取得できます',
+    new_0_6_7_2: 'MCP ツールは bridge の tool discovery 修正、MCP 管理ライフサイクル修正、管理画面のモデル別 tool visibility によりさらに整備されました',
+    new_0_6_7_3: 'メッセージ一覧は empty state の中央揃え、scroll jitter、History 読み込み中のライブチャット混入を修正し、セッション別スクロール位置保持と 1.5 秒のフェードインに対応しました',
+    new_0_6_7_4: 'Bridge と runtime は text/tool-call の順序保持、Profile runtime status loading 修正、Node/npm 検出改善、本番 data directory 作成スキップで安定しました',
+    new_0_6_7_5: 'Desktop 配布は Electron packaging、アプリ名、preload build、release artifact upload、Windows Hermes CLI 起動、Linux icon と書き込み可能 data path、macOS 未署名対応、Windows 起動時の非表示 subprocess に対応しました',
+    new_0_6_7_6: 'Web サイトに downloads と deploy workflow を追加し、rsync がない環境での deploy 失敗を修正しました',
+    new_0_6_7_7: 'Server と auth は Windows credential directory に dirname を使い、大きな avatar 画像で 413 にならないよう body limit を引き上げました',
+    new_0_6_7_8: 'Coding Agents 向けに repository harness、validation docs、agent guidance を追加し、古い setup script docs を削除しました',
     new_0_6_4_1: 'CI を強化し、npm install の挙動を固定して PR の Docker smoke チェックを追加しました',
     new_0_6_4_2: 'チャットに仮想ページングを追加し、長い会話のスクロールと読み込みをより安定させました',
     new_0_6_4_3: 'Docker イメージ公開は通常の PR チェックではなく release の場合のみ実行されます',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -1259,6 +1259,15 @@ export default {
 
   // 변경 이력
   changelog: {
+    new_0_6_7_1: 'Desktop 앱은 기본적으로 8748 포트를 사용하며 LAN 접근과 로컬 브라우저 직접 열기를 지원합니다',
+    new_0_6_7_9: 'Desktop 다운로드 링크가 공식 웹사이트 https://ekkolearnai.com/ 에 추가되었으며 최신 설치 파일은 GitHub Releases 에서도 계속 받을 수 있습니다',
+    new_0_6_7_2: 'MCP 도구는 bridge tool discovery 수정, MCP 관리 라이프사이클 수정, 관리자 화면의 모델별 tool visibility 제어로 더 완성되었습니다',
+    new_0_6_7_3: '메시지 목록은 빈 상태 중앙 정렬, 스크롤 튐, History 로딩 중 라이브 채팅 메시지 노출을 수정하고 세션별 스크롤 위치 보존과 1.5초 페이드인을 지원합니다',
+    new_0_6_7_4: 'Bridge 와 runtime 은 text/tool-call 순서 보존, Profile runtime status loading 수정, Node/npm 감지 개선, 운영 데이터 디렉터리 생성 생략으로 더 안정적입니다',
+    new_0_6_7_5: 'Desktop 배포는 Electron packaging, 앱 이름, preload build, release artifact upload, Windows Hermes CLI 시작, Linux 아이콘과 쓰기 가능한 데이터 경로, macOS 서명 인증서 없음 처리, Windows 시작 시 숨김 subprocess 를 포함합니다',
+    new_0_6_7_6: '웹사이트에 downloads 와 deploy workflow 를 추가하고 rsync 가 없는 환경의 deploy 실패를 수정했습니다',
+    new_0_6_7_7: 'Server 와 auth 는 Windows credential directory 에 dirname 을 사용하고 큰 avatar 이미지의 413 오류를 피하도록 body limit 를 높였습니다',
+    new_0_6_7_8: 'Coding Agents 를 위한 repository harness, validation docs, agent guidance 를 추가하고 오래된 setup script docs 를 제거했습니다',
     new_0_6_4_1: 'CI를 강화해 npm install 동작을 고정하고 PR Docker smoke 검사를 추가했습니다',
     new_0_6_4_2: '채팅에 가상 페이지네이션을 적용해 긴 대화의 스크롤과 로딩을 더 안정적으로 만들었습니다',
     new_0_6_4_3: 'Docker 이미지 배포는 일반 PR 검사 대신 release 에서만 실행됩니다',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -1260,6 +1260,15 @@ jobTriggered: 'Job acionado',
 
   // Registro de alteracoes
   changelog: {
+    new_0_6_7_1: 'O app desktop agora usa a porta 8748 por padrão, permite acesso pela rede local e pode ser aberto diretamente em um navegador local',
+    new_0_6_7_9: 'Links de download do desktop agora estão disponíveis no site oficial https://ekkolearnai.com/, e os instaladores mais recentes continuam disponíveis no GitHub Releases',
+    new_0_6_7_2: 'As ferramentas MCP ficam mais completas com correções de discovery no bridge, ciclo de vida de gestão MCP e controles de visibilidade por modelo no gestor',
+    new_0_6_7_3: 'Listas de mensagens centralizam melhor estados vazios, reduzem saltos de rolagem, evitam mostrar o chat ativo enquanto History carrega, preservam posição por sessão e fazem fade-in de 1,5 segundo ao trocar sessão',
+    new_0_6_7_4: 'Bridge e runtime ficam mais estáveis preservando a ordem texto/tool-call, corrigindo carregamento de status runtime de Profile, melhorando detecção Node/npm e evitando criação de diretório de dados em produção',
+    new_0_6_7_5: 'A distribuição Desktop cobre empacotamento Electron, nome do app, builds preload, upload de artifacts, início do Hermes CLI no Windows, ícones Linux e caminhos de dados graváveis, macOS sem certificado de assinatura e subprocessos Windows ocultos no início',
+    new_0_6_7_6: 'O site agora tem página de downloads e workflow de deploy, com deploy corrigido em ambientes sem rsync',
+    new_0_6_7_7: 'Correções de servidor e auth usam dirname para diretórios de credenciais no Windows e aumentam o limite de upload de avatar para evitar erros 413 com imagens grandes',
+    new_0_6_7_8: 'Harness do repositório, docs de validação e guias de agente para Coding Agents foram adicionados, enquanto docs antigos de setup script foram removidos',
     new_0_6_4_1: 'CI foi reforçado com comportamento npm install fixo e cobertura Docker smoke para PRs',
     new_0_6_4_2: 'O chat agora usa paginação virtualizada para rolar e carregar conversas longas com mais estabilidade',
     new_0_6_4_3: 'A publicação de imagens Docker agora roda apenas em releases, não em checks comuns de PR',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -1487,6 +1487,15 @@ export default {
 
   // 更新日誌
   changelog: {
+    new_0_6_7_1: '桌面版預設使用 8748 連接埠，支援區域網路內存取，也可以直接用本機瀏覽器開啟 Web UI',
+    new_0_6_7_9: '桌面端下載入口已補充到官網 https://ekkolearnai.com/，也可以繼續從 GitHub Releases 取得最新安裝包',
+    new_0_6_7_2: 'MCP 工具鏈繼續完善：修復 bridge 工具發現與 MCP 管理生命週期，並在管理頁支援按模型控制工具可見性',
+    new_0_6_7_3: '訊息列表體驗優化：修復空狀態置中、捲動抖動、歷史會話載入串訊息，並在切換會話時保留捲動位置與 1.5 秒淡入效果',
+    new_0_6_7_4: 'Bridge 與執行狀態更穩定：保持文字和 tool-call 順序、修復 Profile runtime 狀態載入、改進 Node/npm 偵測，並避免正式環境自動建立資料目錄',
+    new_0_6_7_5: 'Desktop 發佈鏈路補齊 Electron 打包、應用命名、preload 建置、release artifact 上傳、Windows Hermes CLI 啟動、Linux 圖示與可寫資料路徑、macOS 無憑證跳過簽名和 Windows 啟動無視窗體驗',
+    new_0_6_7_6: '官網發佈支援下載頁和部署工作流，並修復沒有 rsync 的環境下部署失敗的問題',
+    new_0_6_7_7: '服務端與認證修復：Windows 憑據目錄使用 dirname 解析，頭像上傳 body 限制提高，避免大圖觸發 413',
+    new_0_6_7_8: '補充 coding agents 倉庫 harness、驗證文件和 agent 指南，同時移除過期 setup script 文件',
     new_0_6_4_1: 'CI 流程加固：PR 檢查固定 npm 安裝路徑，並補齊 Docker smoke 校驗',
     new_0_6_4_2: '聊天訊息列表新增虛擬分頁，長工作階段捲動與載入更穩定',
     new_0_6_4_3: 'Docker 映像發布改為僅在 release 場景執行，避免一般 PR 觸發發布流程',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -1484,6 +1484,15 @@ export default {
 
   // 更新日志
   changelog: {
+    new_0_6_7_1: '桌面版默认使用 8748 端口，支持局域网内访问，也可以直接用本机浏览器打开 Web UI',
+    new_0_6_7_9: '桌面端下载入口已补充到官网 https://ekkolearnai.com/，也可以继续从 GitHub Releases 获取最新安装包',
+    new_0_6_7_2: 'MCP 工具链继续完善：修复 bridge 工具发现与 MCP 管理生命周期，并在管理页支持按模型控制工具可见性',
+    new_0_6_7_3: '消息列表体验优化：修复空状态居中、滚动抖动、历史会话加载串消息，并在切换会话时保留滚动位置与 1.5 秒淡入效果',
+    new_0_6_7_4: 'Bridge 与运行态更稳定：保持文本和 tool-call 顺序、修复 Profile runtime 状态加载、改进 Node/npm 检测，并避免生产环境自动创建数据目录',
+    new_0_6_7_5: 'Desktop 分发链路补齐 Electron 打包、应用命名、preload 构建、release artifact 上传、Windows Hermes CLI 启动、Linux 图标与可写数据路径、macOS 无证书跳过签名和 Windows 启动无窗口体验',
+    new_0_6_7_6: '官网发布支持下载页和部署工作流，并修复没有 rsync 的环境下部署失败的问题',
+    new_0_6_7_7: '服务端与认证修复：Windows 凭据目录使用 dirname 解析，头像上传 body 限制提高，避免大图触发 413',
+    new_0_6_7_8: '补充 coding agents 仓库 harness、验证文档和 agent 指南，同时移除过期 setup script 文档',
     new_0_6_4_1: 'CI 流程加固：PR 检查固定 npm 安装路径，并补齐 Docker smoke 校验',
     new_0_6_4_2: '聊天消息列表新增虚拟分页，长会话滚动和加载更稳定',
     new_0_6_4_3: 'Docker 镜像发布改为仅在 release 场景执行，避免普通 PR 触发发布流程',

--- a/packages/client/src/utils/providerBaseUrl.ts
+++ b/packages/client/src/utils/providerBaseUrl.ts
@@ -1,0 +1,16 @@
+const APIKEY_FUN_BASE_URL = 'https://api.apikey.fun/v1'
+
+export function normalizeCustomProviderBaseUrl(baseUrl: string): string {
+  const value = baseUrl.trim()
+  if (!value) return value
+
+  try {
+    const parsed = new URL(value)
+    if (parsed.hostname.toLowerCase() === 'api.apikey.fun') return APIKEY_FUN_BASE_URL
+  } catch {
+    // Fall back to a string match so partially typed values still normalize on submit.
+    if (/^https:\/\/api\.apikey\.fun(?:\/|$)/i.test(value)) return APIKEY_FUN_BASE_URL
+  }
+
+  return value
+}

--- a/tests/client/provider-base-url.test.ts
+++ b/tests/client/provider-base-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeCustomProviderBaseUrl } from '@/utils/providerBaseUrl'
+
+describe('normalizeCustomProviderBaseUrl', () => {
+  it('normalizes api.apikey.fun custom provider URLs to the OpenAI-compatible v1 endpoint', () => {
+    expect(normalizeCustomProviderBaseUrl('https://api.apikey.fun')).toBe('https://api.apikey.fun/v1')
+    expect(normalizeCustomProviderBaseUrl('https://api.apikey.fun/')).toBe('https://api.apikey.fun/v1')
+    expect(normalizeCustomProviderBaseUrl('https://api.apikey.fun/anything')).toBe('https://api.apikey.fun/v1')
+    expect(normalizeCustomProviderBaseUrl('  https://api.apikey.fun/v2/chat  ')).toBe('https://api.apikey.fun/v1')
+  })
+
+  it('leaves unrelated provider URLs unchanged apart from trimming', () => {
+    expect(normalizeCustomProviderBaseUrl(' https://api.example.com/v1 ')).toBe('https://api.example.com/v1')
+    expect(normalizeCustomProviderBaseUrl('https://not-api.apikey.fun/v1')).toBe('https://not-api.apikey.fun/v1')
+  })
+})


### PR DESCRIPTION
## Summary
- add a 0.6.7 changelog entry covering changes since 0.6.5 across all locales
- call out desktop port 8748 LAN/local-browser access and the official website desktop download entry at https://ekkolearnai.com/
- normalize custom provider submissions for api.apikey.fun to https://api.apikey.fun/v1 while leaving preset providers untouched

## Why
The release notes needed to cover the current changes after 0.6.5, and custom providers using api.apikey.fun should consistently save the OpenAI-compatible /v1 endpoint regardless of the entered path.

## Validation
- `npm run test -- tests/client/provider-base-url.test.ts`
- `npm run build`
- `git diff --check`