### PR TITLE
[codex] Bump package versions to 0.6.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-web-ui",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "BSL-1.1",
       "dependencies": {
         "@vscode/markdown-it-katex": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Self-hosted AI chat dashboard for Hermes Agent — multi-model web UI with multi-platform integration",
   "repository": {
     "type": "git",

--- a/packages/desktop/package-lock.json
+++ b/packages/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-studio",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-studio",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.3.9"

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-studio",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Hermes Studio desktop distribution with bundled Python runtime and hermes-agent",
   "homepage": "https://ekkolearnai.com",
   "author": {


### PR DESCRIPTION
## Summary
- bump root package metadata to 0.6.7
- bump package-lock metadata to 0.6.7
- bump desktop package and lockfile metadata to 0.6.7

## Why
The 0.6.7 changelog was merged, but package metadata still needed to match the release version.

## Validation
- `npm run build`
- `git diff --check`