### PR TITLE
[codex] Sequence website deploy after desktop release

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -13,26 +13,36 @@ on:
       - tsconfig.website.json
       - vite.config.website.ts
       - .github/workflows/website-deploy.yml
-  release:
+  workflow_run:
+    workflows:
+      - Publish Desktop Artifacts to Release
     types:
-      - published
+      - completed
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: website-${{ github.event.pull_request.number || github.ref }}
+  group: website-${{ github.event.pull_request.number || github.event.workflow_run.id || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
     name: Build website
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
+        if: github.event_name != 'workflow_run'
         uses: actions/checkout@v4
+
+      - name: Checkout desktop release ref
+        if: github.event_name == 'workflow_run'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.event.workflow_run.head_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -51,7 +61,7 @@ jobs:
         run: npm run build:website
 
       - name: Prepare SSH
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch'
         env:
           WEBSITE_SSH_KEY: ${{ secrets.WEBSITE_SSH_KEY }}
           WEBSITE_SSH_KNOWN_HOSTS: ${{ secrets.WEBSITE_SSH_KNOWN_HOSTS }}
@@ -66,7 +76,7 @@ jobs:
           fi
 
       - name: Deploy website
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch'
         env:
           WEBSITE_SSH_USER: ${{ secrets.WEBSITE_SSH_USER }}
           WEBSITE_SSH_PORT: ${{ secrets.WEBSITE_SSH_PORT }}


### PR DESCRIPTION
## Summary
- Change the Website workflow release path to wait for the desktop release workflow to complete successfully.
- Keep PR website checks and manual website deploys available.
- Checkout the completed desktop release ref for the delayed website deploy.

## Validation
- npx vue-tsc -p tsconfig.website.json --noEmit
- npm run build:website