### PR TITLE
[codex] add desktop startup settings

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -29,40 +29,45 @@ jobs:
             target_os: darwin
             target_arch: arm64
             electron_target: "--mac dmg --arm64"
-            artifact_files: |
+            release_files: |
               packages/desktop/release/*.dmg
               packages/desktop/release/*.dmg.blockmap
+            manifest_artifact: desktop-manifest-darwin-arm64
           - label: macOS x64
             runner: macos-15-intel
             target_os: darwin
             target_arch: x64
             electron_target: "--mac dmg --x64"
-            artifact_files: |
+            release_files: |
               packages/desktop/release/*.dmg
               packages/desktop/release/*.dmg.blockmap
+            manifest_artifact: desktop-manifest-darwin-x64
           - label: Windows x64
             runner: windows-latest
             target_os: win32
             target_arch: x64
             electron_target: "--win nsis --x64"
-            artifact_files: |
+            release_files: |
               packages/desktop/release/*.exe
               packages/desktop/release/*.exe.blockmap
+              packages/desktop/release/latest*.yml
           - label: Linux x64
             runner: ubuntu-22.04
             target_os: linux
             target_arch: x64
             electron_target: "--linux AppImage deb --x64"
-            artifact_files: |
+            release_files: |
               packages/desktop/release/*.AppImage
               packages/desktop/release/*.deb
+              packages/desktop/release/latest*.yml
           - label: Linux arm64
             runner: ubuntu-22.04-arm
             target_os: linux
             target_arch: arm64
             electron_target: "--linux AppImage --arm64"
-            artifact_files: |
+            release_files: |
               packages/desktop/release/*.AppImage
+              packages/desktop/release/latest*.yml
 
     steps:
       - name: Checkout repository
@@ -148,9 +153,53 @@ jobs:
         shell: bash
         run: npm --prefix packages/desktop run dist -- ${{ matrix.electron_target }} ${MAC_BUILD_EXTRA_ARGS:-} --publish never
 
+      - name: Upload macOS updater manifest
+        if: matrix.target_os == 'darwin'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.manifest_artifact }}
+          path: packages/desktop/release/latest*.yml
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Upload artifacts to release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.release.tag_name || github.event.inputs.tag }}
           fail_on_unmatched_files: true
-          files: ${{ matrix.artifact_files }}
+          files: ${{ matrix.release_files }}
+
+  mac-updater-manifest:
+    name: macOS updater manifest
+    needs: desktop
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+
+      - name: Download macOS manifests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: desktop-manifest-darwin-*
+          path: packages/desktop/release/manifests
+
+      - name: Merge macOS updater manifest
+        shell: bash
+        run: |
+          mapfile -t manifests < <(find packages/desktop/release/manifests -name 'latest-mac.yml' | sort)
+          if [ "${#manifests[@]}" -ne 2 ]; then
+            printf 'Expected 2 macOS updater manifests, found %s\n' "${#manifests[@]}" >&2
+            printf '%s\n' "${manifests[@]}" >&2
+            exit 1
+          fi
+          node packages/desktop/scripts/merge-mac-latest-yml.mjs "${manifests[0]}" "${manifests[1]}" > packages/desktop/release/latest-mac.yml
+
+      - name: Upload macOS updater manifest to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          fail_on_unmatched_files: true
+          files: packages/desktop/release/latest-mac.yml

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -6,6 +6,7 @@ import { useI18n } from 'vue-i18n'
 import { getThemeOverrides } from '@/styles/theme'
 import { useTheme } from '@/composables/useTheme'
 import AppSidebar from '@/components/layout/AppSidebar.vue'
+import DesktopTitlebarControls from '@/components/layout/DesktopTitlebarControls.vue'
 import { useKeyboard } from '@/composables/useKeyboard'
 import { useAppStore } from '@/stores/hermes/app'
 import SessionSearchModal from '@/components/hermes/chat/SessionSearchModal.vue'
@@ -23,6 +24,10 @@ const themeOverrides = computed(() => getThemeOverrides(isDark.value, isComic.va
 const naiveTheme = computed(() => isDark.value ? darkTheme : null)
 
 const isLoginPage = computed(() => route.name === 'login')
+const showDesktopTitlebarControls = computed(() => {
+  const desktop = window.hermesDesktop
+  return desktop?.isDesktop === true && desktop.platform !== 'darwin'
+})
 
 const nodeVersionLow = computed(() => {
   const v = appStore.nodeVersion
@@ -63,7 +68,12 @@ useKeyboard()
           <div v-if="nodeVersionLow && ready" class="node-warning-bar">
             {{ t('sidebar.nodeVersionWarning', { version: appStore.nodeVersion }) }}
           </div>
-          <div v-if="ready" class="app-layout" :class="{ 'no-sidebar': isLoginPage }">
+          <DesktopTitlebarControls v-if="ready && showDesktopTitlebarControls" />
+          <div
+            v-if="ready"
+            class="app-layout"
+            :class="{ 'no-sidebar': isLoginPage, 'desktop-titlebar-space': showDesktopTitlebarControls }"
+          >
             <button v-if="!isLoginPage" class="hamburger-btn" @click="appStore.toggleSidebar">
               <img src="/logo.png" alt="Menu" style="width: 24px; height: 24px;" />
             </button>
@@ -92,6 +102,11 @@ useKeyboard()
 
   &.no-sidebar {
     display: block;
+  }
+
+  &.desktop-titlebar-space {
+    height: calc(100 * var(--vh) - 36px);
+    margin-top: 36px;
   }
 }
 

--- a/packages/client/src/components/layout/DesktopTitlebarControls.vue
+++ b/packages/client/src/components/layout/DesktopTitlebarControls.vue
@@ -1,0 +1,234 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, reactive, ref } from 'vue'
+import { NButton, NDivider, NPopover, NSwitch, useMessage } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+
+interface DesktopSettings {
+  launchAtLogin: boolean
+  closeToBackground: boolean
+  autoUpdateEnabled: boolean
+}
+
+const { t } = useI18n()
+const message = useMessage()
+
+const visible = ref(false)
+const loading = reactive({
+  launchAtLogin: false,
+  closeToBackground: false,
+  autoUpdateEnabled: false,
+  updateCheck: false,
+  quit: false,
+})
+const settings = reactive<DesktopSettings>({
+  launchAtLogin: false,
+  closeToBackground: true,
+  autoUpdateEnabled: true,
+})
+
+const desktop = computed(() => window.hermesDesktop)
+
+function applySettings(next: Partial<DesktopSettings>) {
+  Object.assign(settings, next)
+}
+
+async function loadSettings() {
+  const api = desktop.value
+  if (!api?.getSettings) return
+  try {
+    applySettings(await api.getSettings())
+  } catch {
+    message.error(t('desktop.settingsLoadFailed'))
+  }
+}
+
+async function updateSetting<K extends keyof DesktopSettings>(key: K, value: DesktopSettings[K]) {
+  const api = desktop.value
+  if (!api?.updateSettings) return
+  loading[key] = true
+  try {
+    applySettings(await api.updateSettings({ [key]: value }))
+    message.success(t('desktop.settingsSaved'))
+  } catch {
+    message.error(t('desktop.settingsSaveFailed'))
+  } finally {
+    loading[key] = false
+  }
+}
+
+async function checkForUpdates() {
+  const api = desktop.value
+  if (!api?.checkForUpdates) return
+  loading.updateCheck = true
+  try {
+    await api.checkForUpdates()
+    message.success(t('desktop.updateCheckStarted'))
+  } catch {
+    message.error(t('desktop.updateCheckFailed'))
+  } finally {
+    loading.updateCheck = false
+  }
+}
+
+async function quitApp() {
+  const api = desktop.value
+  if (!api?.quit) return
+  loading.quit = true
+  try {
+    await api.quit()
+  } finally {
+    loading.quit = false
+  }
+}
+
+let removeSettingsListener: (() => void) | undefined
+
+onMounted(() => {
+  void loadSettings()
+  removeSettingsListener = desktop.value?.onSettingsChanged?.((next) => {
+    applySettings(next)
+  })
+})
+
+onUnmounted(() => {
+  removeSettingsListener?.()
+})
+</script>
+
+<template>
+  <div class="desktop-titlebar">
+    <div class="desktop-titlebar-drag-region" />
+    <NPopover
+      v-model:show="visible"
+      trigger="click"
+      placement="bottom-end"
+      :show-arrow="false"
+      style="padding: 0;"
+    >
+      <template #trigger>
+        <NButton
+          quaternary
+          circle
+          size="small"
+          class="desktop-settings-trigger"
+          :title="t('desktop.settings')"
+          aria-label="Desktop settings"
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15z" />
+          </svg>
+        </NButton>
+      </template>
+
+      <div class="desktop-settings-panel">
+        <div class="desktop-settings-title">{{ t('desktop.settings') }}</div>
+        <div class="desktop-setting-row">
+          <span>{{ t('desktop.launchAtLogin') }}</span>
+          <NSwitch
+            size="small"
+            :value="settings.launchAtLogin"
+            :loading="loading.launchAtLogin"
+            @update:value="value => updateSetting('launchAtLogin', value)"
+          />
+        </div>
+        <div class="desktop-setting-row">
+          <span>{{ t('desktop.closeToBackground') }}</span>
+          <NSwitch
+            size="small"
+            :value="settings.closeToBackground"
+            :loading="loading.closeToBackground"
+            @update:value="value => updateSetting('closeToBackground', value)"
+          />
+        </div>
+        <div class="desktop-setting-row">
+          <span>{{ t('desktop.autoUpdates') }}</span>
+          <NSwitch
+            size="small"
+            :value="settings.autoUpdateEnabled"
+            :loading="loading.autoUpdateEnabled"
+            @update:value="value => updateSetting('autoUpdateEnabled', value)"
+          />
+        </div>
+        <NDivider />
+        <div class="desktop-actions">
+          <NButton size="small" secondary :loading="loading.updateCheck" @click="checkForUpdates">
+            {{ t('desktop.checkForUpdates') }}
+          </NButton>
+          <NButton size="small" tertiary type="error" :loading="loading.quit" @click="quitApp">
+            {{ t('desktop.quit') }}
+          </NButton>
+        </div>
+      </div>
+    </NPopover>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/variables' as *;
+
+.desktop-titlebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 36px;
+  z-index: 1200;
+  background: #1a1a1a;
+}
+
+.desktop-titlebar-drag-region {
+  position: absolute;
+  inset: 0;
+  -webkit-app-region: drag;
+}
+
+.desktop-settings-trigger {
+  position: absolute;
+  top: 4px;
+  right: 142px;
+  width: 28px;
+  height: 28px;
+  -webkit-app-region: no-drag;
+  color: #cfcfcf;
+
+  &:hover {
+    color: #ffffff;
+  }
+}
+
+.desktop-settings-panel {
+  width: 260px;
+  padding: 12px;
+}
+
+.desktop-settings-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: $text-primary;
+  margin-bottom: 8px;
+}
+
+.desktop-setting-row {
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+  color: $text-secondary;
+}
+
+.desktop-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+@media (max-width: $breakpoint-mobile) {
+  .desktop-settings-trigger {
+    right: 128px;
+  }
+}
+</style>

--- a/packages/client/src/env.d.ts
+++ b/packages/client/src/env.d.ts
@@ -2,6 +2,27 @@
 
 declare const __APP_VERSION__: string
 
+interface HermesDesktopSettings {
+  launchAtLogin: boolean
+  closeToBackground: boolean
+  autoUpdateEnabled: boolean
+}
+
+interface HermesDesktopBridge {
+  getToken: () => Promise<string>
+  getSettings: () => Promise<HermesDesktopSettings>
+  updateSettings: (patch: Partial<HermesDesktopSettings>) => Promise<HermesDesktopSettings>
+  checkForUpdates: () => Promise<unknown>
+  quit: () => Promise<void>
+  onSettingsChanged: (callback: (settings: HermesDesktopSettings) => void) => () => void
+  platform: NodeJS.Platform
+  isDesktop: true
+}
+
+interface Window {
+  hermesDesktop?: HermesDesktopBridge
+}
+
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
   const component: DefineComponent<{}, {}, any>

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -105,6 +105,20 @@ export default {
     expired: 'Abgelaufen',
   },
 
+  desktop: {
+    settings: 'Desktop-Einstellungen',
+    launchAtLogin: 'Beim Anmelden starten',
+    closeToBackground: 'In den Hintergrund schliessen',
+    autoUpdates: 'Automatische Updates',
+    checkForUpdates: 'Nach Updates suchen',
+    quit: 'Beenden',
+    settingsSaved: 'Desktop-Einstellung gespeichert',
+    settingsLoadFailed: 'Desktop-Einstellungen konnten nicht geladen werden',
+    settingsSaveFailed: 'Desktop-Einstellung konnte nicht gespeichert werden',
+    updateCheckStarted: 'Suche nach Updates',
+    updateCheckFailed: 'Update-Suche fehlgeschlagen',
+  },
+
   // MCP-Verwaltung
   mcp: {
     title: 'MCP-Server',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -105,6 +105,20 @@ export default {
     stop: 'Stop',
   },
 
+  desktop: {
+    settings: 'Desktop Settings',
+    launchAtLogin: 'Launch at login',
+    closeToBackground: 'Close to background',
+    autoUpdates: 'Automatic updates',
+    checkForUpdates: 'Check for updates',
+    quit: 'Quit',
+    settingsSaved: 'Desktop setting saved',
+    settingsLoadFailed: 'Failed to load desktop settings',
+    settingsSaveFailed: 'Failed to save desktop setting',
+    updateCheckStarted: 'Checking for updates',
+    updateCheckFailed: 'Failed to check for updates',
+  },
+
   // MCP Management
   mcp: {
     title: 'MCP Servers',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -105,6 +105,20 @@ export default {
     expired: 'Expirado',
   },
 
+  desktop: {
+    settings: 'Ajustes de escritorio',
+    launchAtLogin: 'Iniciar al acceder',
+    closeToBackground: 'Cerrar en segundo plano',
+    autoUpdates: 'Actualizaciones automaticas',
+    checkForUpdates: 'Buscar actualizaciones',
+    quit: 'Salir',
+    settingsSaved: 'Ajuste de escritorio guardado',
+    settingsLoadFailed: 'No se pudieron cargar los ajustes de escritorio',
+    settingsSaveFailed: 'No se pudo guardar el ajuste de escritorio',
+    updateCheckStarted: 'Buscando actualizaciones',
+    updateCheckFailed: 'No se pudieron buscar actualizaciones',
+  },
+
   // Gestion de MCP
   mcp: {
     title: 'Servidores MCP',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -105,6 +105,20 @@ export default {
     expired: 'Expiré',
   },
 
+  desktop: {
+    settings: 'Parametres desktop',
+    launchAtLogin: 'Lancer a la connexion',
+    closeToBackground: 'Fermer en arriere-plan',
+    autoUpdates: 'Mises a jour automatiques',
+    checkForUpdates: 'Verifier les mises a jour',
+    quit: 'Quitter',
+    settingsSaved: 'Parametre desktop enregistre',
+    settingsLoadFailed: 'Echec du chargement des parametres desktop',
+    settingsSaveFailed: 'Echec de l enregistrement du parametre desktop',
+    updateCheckStarted: 'Recherche de mises a jour',
+    updateCheckFailed: 'Echec de la recherche de mises a jour',
+  },
+
   // Gestion de MCP
   mcp: {
     title: 'Serveurs MCP',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -105,6 +105,20 @@ export default {
     expired: '期限切れ',
   },
 
+  desktop: {
+    settings: 'デスクトップ設定',
+    launchAtLogin: 'ログイン時に起動',
+    closeToBackground: '閉じたらバックグラウンドへ',
+    autoUpdates: '自動更新',
+    checkForUpdates: '更新を確認',
+    quit: '終了',
+    settingsSaved: 'デスクトップ設定を保存しました',
+    settingsLoadFailed: 'デスクトップ設定の読み込みに失敗しました',
+    settingsSaveFailed: 'デスクトップ設定の保存に失敗しました',
+    updateCheckStarted: '更新を確認しています',
+    updateCheckFailed: '更新の確認に失敗しました',
+  },
+
   // サイドバー
   // MCP 管理
   mcp: {

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -105,6 +105,20 @@ export default {
     expired: '만료됨',
   },
 
+  desktop: {
+    settings: '데스크톱 설정',
+    launchAtLogin: '로그인 시 실행',
+    closeToBackground: '닫을 때 백그라운드로',
+    autoUpdates: '자동 업데이트',
+    checkForUpdates: '업데이트 확인',
+    quit: '종료',
+    settingsSaved: '데스크톱 설정이 저장되었습니다',
+    settingsLoadFailed: '데스크톱 설정을 불러오지 못했습니다',
+    settingsSaveFailed: '데스크톱 설정 저장 실패',
+    updateCheckStarted: '업데이트 확인 중',
+    updateCheckFailed: '업데이트 확인 실패',
+  },
+
   // 사이드바
   // MCP 관리
   mcp: {

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -105,6 +105,20 @@ export default {
     expired: 'Expirado',
   },
 
+  desktop: {
+    settings: 'Configuracoes do desktop',
+    launchAtLogin: 'Iniciar ao entrar',
+    closeToBackground: 'Fechar para segundo plano',
+    autoUpdates: 'Atualizacoes automaticas',
+    checkForUpdates: 'Verificar atualizacoes',
+    quit: 'Sair',
+    settingsSaved: 'Configuracao do desktop salva',
+    settingsLoadFailed: 'Falha ao carregar configuracoes do desktop',
+    settingsSaveFailed: 'Falha ao salvar configuracao do desktop',
+    updateCheckStarted: 'Verificando atualizacoes',
+    updateCheckFailed: 'Falha ao verificar atualizacoes',
+  },
+
   // Gestao de MCP
   mcp: {
     title: 'Servidores MCP',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -105,6 +105,20 @@ export default {
     stop: '停止',
   },
 
+  desktop: {
+    settings: '桌面設定',
+    launchAtLogin: '開機啟動',
+    closeToBackground: '關閉到背景',
+    autoUpdates: '自動更新',
+    checkForUpdates: '檢查更新',
+    quit: '結束',
+    settingsSaved: '桌面設定已儲存',
+    settingsLoadFailed: '載入桌面設定失敗',
+    settingsSaveFailed: '儲存桌面設定失敗',
+    updateCheckStarted: '正在檢查更新',
+    updateCheckFailed: '檢查更新失敗',
+  },
+
   // 側邊欄
   // MCP 管理
   mcp: {

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -105,6 +105,20 @@ export default {
     stop: '停止',
   },
 
+  desktop: {
+    settings: '桌面设置',
+    launchAtLogin: '开机启动',
+    closeToBackground: '关闭到后台',
+    autoUpdates: '自动更新',
+    checkForUpdates: '检查更新',
+    quit: '退出',
+    settingsSaved: '桌面设置已保存',
+    settingsLoadFailed: '加载桌面设置失败',
+    settingsSaveFailed: '保存桌面设置失败',
+    updateCheckStarted: '正在检查更新',
+    updateCheckFailed: '检查更新失败',
+  },
+
   // 侧边栏
   // MCP 管理
   mcp: {

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -22,6 +22,16 @@ Hermes installs:
 The desktop wrapper's own Web UI state is stored separately in
 `~/.hermes-web-ui` unless `HERMES_WEB_UI_HOME` is set.
 
+Desktop settings such as launch at login, close-to-background, and automatic
+updates are stored in `desktop-settings.json` under the Web UI state directory.
+
+## Bundled CLI
+
+The desktop app keeps its bundled Hermes CLI separate from the user's own
+`hermes` command. In desktop-launched terminals and subprocesses, the bundled
+CLI is exposed as `hermes-studio`; existing user-installed `hermes` or
+`hermes-cli` commands remain resolved from the user's normal shell PATH.
+
 ## China mirror environment
 
 These mirrors are optional and are not required in CI:

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -6,6 +6,11 @@ directories:
   output: release
   buildResources: build
 
+publish:
+  provider: github
+  owner: EKKOLearnAI
+  repo: hermes-web-ui
+
 # Don't auto-prune our root node_modules; we curate `files` and `extraResources` ourselves.
 buildDependenciesFromSource: false
 nodeGypRebuild: false

--- a/packages/desktop/scripts/install-hermes.mjs
+++ b/packages/desktop/scripts/install-hermes.mjs
@@ -115,6 +115,15 @@ if (TARGET_OS === 'win32') {
       '"%PY%" -m hermes_cli.main %*',
     ].join('\r\n'),
   )
+  const studioCmdPath = resolve(PY_DIR, 'Scripts', 'hermes-studio.cmd')
+  writeFileSync(
+    studioCmdPath,
+    [
+      '@echo off',
+      'set "PY=%~dp0..\\python.exe"',
+      '"%PY%" -m hermes_cli.main %*',
+    ].join('\r\n'),
+  )
 } else {
   const launcher = [
     '#!/bin/sh',
@@ -124,6 +133,9 @@ if (TARGET_OS === 'win32') {
   ].join('\n')
   writeFileSync(hermesBin, launcher, { mode: 0o755 })
   chmodSync(hermesBin, 0o755)
+  const studioBin = resolve(PY_DIR, 'bin', 'hermes-studio')
+  writeFileSync(studioBin, launcher, { mode: 0o755 })
+  chmodSync(studioBin, 0o755)
   // Same for hermes-agent / hermes-acp (they all just dispatch into modules)
   for (const [name, mod] of [
     ['hermes-agent', 'run_agent'],

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -2,12 +2,23 @@ import { app, BrowserWindow, Menu, shell, ipcMain } from 'electron'
 import { join } from 'node:path'
 import { startWebUiServer, stopWebUiServer, getToken } from './webui-server'
 import { desktopIcon, hermesBinExists, hermesBin } from './paths'
-import { initAutoUpdater } from './updater'
+import { checkForDesktopUpdates, configureAutoUpdater, initAutoUpdater } from './updater'
+import {
+  getDesktopSettings,
+  syncLaunchAtLogin,
+  updateDesktopSettings,
+  type DesktopSettings,
+  type DesktopSettingsPatch,
+} from './settings'
+import { createOrUpdateTray, destroyTray, showWindow } from './tray'
 
 const PORT = Number(process.env.HERMES_DESKTOP_PORT) || 8748
 
 let mainWindow: BrowserWindow | null = null
 let serverUrl: string | null = null
+let desktopSettings: DesktopSettings = getDesktopSettings()
+let quitting = false
+let quitPromise: Promise<void> | null = null
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -17,7 +28,15 @@ function createWindow() {
     minHeight: 600,
     title: 'Hermes Studio',
     backgroundColor: '#1a1a1a',
-    autoHideMenuBar: true,
+    autoHideMenuBar: process.platform !== 'darwin',
+    ...(process.platform !== 'darwin' ? {
+      titleBarStyle: 'hidden',
+      titleBarOverlay: {
+        color: '#1a1a1a',
+        symbolColor: '#e5e5e5',
+        height: 36,
+      },
+    } : {}),
     ...(process.platform === 'linux' ? { icon: desktopIcon() } : {}),
     webPreferences: {
       preload: join(__dirname, '..', 'preload', 'index.js'),
@@ -27,7 +46,18 @@ function createWindow() {
     },
   })
 
-  // External links → system browser
+  mainWindow.on('close', (event) => {
+    if (!quitting && desktopSettings.closeToBackground) {
+      event.preventDefault()
+      mainWindow?.hide()
+    }
+  })
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+
+  // External links to the system browser.
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith('http://127.0.0.1') || url.startsWith('http://localhost')) {
       return { action: 'allow' }
@@ -36,9 +66,6 @@ function createWindow() {
     return { action: 'deny' }
   })
 
-  // If the Web UI server is already up (re-opening window after close on
-  // macOS), go straight to it. Otherwise show a loading splash; bootstrap()
-  // will swap in the real URL once the server is ready.
   if (serverUrl) {
     mainWindow.loadURL(serverUrl)
   } else {
@@ -60,9 +87,119 @@ function splashHtml(): string {
 </style></head><body><div class="wrap">
 <h1>Hermes Studio</h1>
 <div class="row"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div>
-<div class="label">Starting local services…</div>
+<div class="label">Starting local services...</div>
 </div></body></html>`
   return 'data:text/html;charset=utf-8,' + encodeURIComponent(html)
+}
+
+function buildApplicationMenu() {
+  if (process.platform !== 'darwin') {
+    Menu.setApplicationMenu(null)
+    return
+  }
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate([
+    {
+      label: app.name,
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        {
+          label: 'Launch at Login',
+          type: 'checkbox',
+          checked: desktopSettings.launchAtLogin,
+          click: item => applyDesktopSettings({ launchAtLogin: item.checked }),
+        },
+        {
+          label: 'Close Window to Background',
+          type: 'checkbox',
+          checked: desktopSettings.closeToBackground,
+          click: item => applyDesktopSettings({ closeToBackground: item.checked }),
+        },
+        {
+          label: 'Automatic Updates',
+          type: 'checkbox',
+          checked: desktopSettings.autoUpdateEnabled,
+          click: item => applyDesktopSettings({ autoUpdateEnabled: item.checked }),
+        },
+        { label: 'Check for Updates', click: () => void checkForDesktopUpdates({ force: true }).catch(() => undefined) },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { label: `Quit ${app.name}`, accelerator: 'Command+Q', click: () => void quitApp() },
+      ],
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'selectAll' },
+      ],
+    },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forceReload' },
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ],
+    },
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize' },
+        { role: 'zoom' },
+        { type: 'separator' },
+        { role: 'front' },
+      ],
+    },
+  ]))
+}
+
+function refreshNativeDesktopControls() {
+  buildApplicationMenu()
+  createOrUpdateTray({
+    showWindow: () => {
+      if (!mainWindow) createWindow()
+      showWindow(mainWindow)
+    },
+    quitApp: () => void quitApp(),
+    checkForUpdates: () => void checkForDesktopUpdates({ force: true }).catch(() => undefined),
+    updateSetting: patch => applyDesktopSettings(patch),
+    getSettings: () => desktopSettings,
+  })
+}
+
+function applyDesktopSettings(patch: DesktopSettingsPatch): DesktopSettings {
+  desktopSettings = syncLaunchAtLogin(updateDesktopSettings(patch))
+  configureAutoUpdater(desktopSettings.autoUpdateEnabled)
+  refreshNativeDesktopControls()
+  mainWindow?.webContents.send('hermes-desktop:settings-changed', desktopSettings)
+  return desktopSettings
+}
+
+async function quitApp(): Promise<void> {
+  if (quitPromise) return quitPromise
+  quitting = true
+  quitPromise = (async () => {
+    destroyTray()
+    await stopWebUiServer().catch(() => undefined)
+    app.exit(0)
+  })()
+  return quitPromise
 }
 
 async function bootstrap() {
@@ -89,45 +226,51 @@ async function bootstrap() {
 }
 
 ipcMain.handle('hermes-desktop:get-token', () => getToken())
+ipcMain.handle('hermes-desktop:get-settings', () => desktopSettings)
+ipcMain.handle('hermes-desktop:update-settings', (_event, patch: DesktopSettingsPatch) => applyDesktopSettings(patch))
+ipcMain.handle('hermes-desktop:check-for-updates', async () => {
+  await checkForDesktopUpdates({ force: true })
+  return { ok: true }
+})
+ipcMain.handle('hermes-desktop:quit', () => quitApp())
 
 const gotLock = app.requestSingleInstanceLock()
 if (!gotLock) {
   app.quit()
 } else {
   app.on('second-instance', () => {
-    if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore()
-      mainWindow.focus()
-    }
+    if (!mainWindow) createWindow()
+    showWindow(mainWindow)
   })
 
   app.whenReady().then(() => {
-    // Drop the default File/Edit/View/Window menu on Windows/Linux. The web
-    // UI provides its own in-page controls, so the native menu bar is just
-    // visual clutter. macOS keeps a menu (system requirement) but Electron's
-    // default is fine there.
-    if (process.platform !== 'darwin') Menu.setApplicationMenu(null)
+    desktopSettings = syncLaunchAtLogin(desktopSettings)
+    refreshNativeDesktopControls()
     createWindow()
     bootstrap()
-    initAutoUpdater()
+    initAutoUpdater({
+      enabled: desktopSettings.autoUpdateEnabled,
+      onBeforeInstall: async () => {
+        quitting = true
+        await stopWebUiServer().catch(() => undefined)
+      },
+    })
     app.on('activate', () => {
       if (BrowserWindow.getAllWindows().length === 0) {
         createWindow()
-      } else if (mainWindow) {
-        if (mainWindow.isMinimized()) mainWindow.restore()
-        mainWindow.show()
-        mainWindow.focus()
+      } else {
+        showWindow(mainWindow)
       }
     })
   })
 
   app.on('window-all-closed', () => {
-    if (process.platform !== 'darwin') app.quit()
+    if (!desktopSettings.closeToBackground) void quitApp()
   })
 
-  app.on('before-quit', async (e) => {
+  app.on('before-quit', (e) => {
+    if (quitting) return
     e.preventDefault()
-    await stopWebUiServer().catch(() => undefined)
-    app.exit(0)
+    void quitApp()
   })
 }

--- a/packages/desktop/src/main/settings.ts
+++ b/packages/desktop/src/main/settings.ts
@@ -1,0 +1,135 @@
+import { app } from 'electron'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { homedir } from 'node:os'
+import { webUiHome } from './paths'
+
+export interface DesktopSettings {
+  launchAtLogin: boolean
+  closeToBackground: boolean
+  autoUpdateEnabled: boolean
+}
+
+export type DesktopSettingsPatch = Partial<DesktopSettings>
+
+const DEFAULT_SETTINGS: DesktopSettings = {
+  launchAtLogin: false,
+  closeToBackground: true,
+  autoUpdateEnabled: true,
+}
+
+const AUTOSTART_DESKTOP_FILE = 'hermes-studio.desktop'
+
+let cachedSettings: DesktopSettings | null = null
+
+function settingsPath(): string {
+  return join(webUiHome(), 'desktop-settings.json')
+}
+
+function sanitizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function sanitizeSettings(value: unknown): DesktopSettings {
+  const raw = value && typeof value === 'object' ? value as Record<string, unknown> : {}
+  return {
+    launchAtLogin: sanitizeBoolean(raw.launchAtLogin, DEFAULT_SETTINGS.launchAtLogin),
+    closeToBackground: sanitizeBoolean(raw.closeToBackground, DEFAULT_SETTINGS.closeToBackground),
+    autoUpdateEnabled: sanitizeBoolean(raw.autoUpdateEnabled, DEFAULT_SETTINGS.autoUpdateEnabled),
+  }
+}
+
+function writeSettings(settings: DesktopSettings): void {
+  const file = settingsPath()
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, `${JSON.stringify(settings, null, 2)}\n`, { mode: 0o600 })
+}
+
+export function getDesktopSettings(): DesktopSettings {
+  if (cachedSettings) return cachedSettings
+  const file = settingsPath()
+  if (!existsSync(file)) {
+    cachedSettings = { ...DEFAULT_SETTINGS }
+    return cachedSettings
+  }
+
+  try {
+    cachedSettings = sanitizeSettings(JSON.parse(readFileSync(file, 'utf-8')))
+  } catch {
+    cachedSettings = { ...DEFAULT_SETTINGS }
+  }
+  return cachedSettings
+}
+
+export function updateDesktopSettings(patch: DesktopSettingsPatch): DesktopSettings {
+  const next = sanitizeSettings({ ...getDesktopSettings(), ...patch })
+  cachedSettings = next
+  writeSettings(next)
+  return next
+}
+
+function linuxAutostartPath(): string {
+  return join(process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), '.config'), 'autostart', AUTOSTART_DESKTOP_FILE)
+}
+
+function quoteDesktopExec(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}
+
+function getLinuxLaunchExecutable(): string {
+  return process.env.APPIMAGE?.trim() || app.getPath('exe')
+}
+
+function setLinuxLaunchAtLogin(openAtLogin: boolean): void {
+  const file = linuxAutostartPath()
+  if (!openAtLogin) {
+    rmSync(file, { force: true })
+    return
+  }
+
+  mkdirSync(dirname(file), { recursive: true })
+  const execPath = quoteDesktopExec(getLinuxLaunchExecutable())
+  writeFileSync(file, [
+    '[Desktop Entry]',
+    'Type=Application',
+    'Version=1.0',
+    'Name=Hermes Studio',
+    `Exec=${execPath}`,
+    'Terminal=false',
+    'X-GNOME-Autostart-enabled=true',
+    '',
+  ].join('\n'), { mode: 0o600 })
+}
+
+function getLinuxLaunchAtLogin(): boolean {
+  return existsSync(linuxAutostartPath())
+}
+
+export function setLaunchAtLogin(openAtLogin: boolean): void {
+  if (process.platform === 'linux') {
+    setLinuxLaunchAtLogin(openAtLogin)
+    return
+  }
+
+  app.setLoginItemSettings({
+    openAtLogin,
+    path: resolve(app.getPath('exe')),
+  })
+}
+
+export function getLaunchAtLogin(): boolean {
+  if (process.platform === 'linux') return getLinuxLaunchAtLogin()
+  return app.getLoginItemSettings().openAtLogin
+}
+
+export function syncLaunchAtLogin(settings = getDesktopSettings()): DesktopSettings {
+  try {
+    setLaunchAtLogin(settings.launchAtLogin)
+  } catch (err) {
+    console.error('[desktop-settings] failed to apply launch-at-login:', err)
+  }
+  return {
+    ...settings,
+    launchAtLogin: getLaunchAtLogin(),
+  }
+}

--- a/packages/desktop/src/main/tray.ts
+++ b/packages/desktop/src/main/tray.ts
@@ -1,0 +1,60 @@
+import { app, BrowserWindow, Menu, Tray } from 'electron'
+import { desktopIcon } from './paths'
+import type { DesktopSettings } from './settings'
+
+let tray: Tray | null = null
+
+export interface TrayHandlers {
+  showWindow: () => void
+  quitApp: () => void
+  checkForUpdates: () => void
+  updateSetting: (patch: Partial<DesktopSettings>) => void
+  getSettings: () => DesktopSettings
+}
+
+export function createOrUpdateTray(handlers: TrayHandlers): void {
+  if (!tray) {
+    tray = new Tray(desktopIcon())
+    tray.setToolTip('Hermes Studio')
+    tray.on('click', handlers.showWindow)
+  }
+
+  const settings = handlers.getSettings()
+  tray.setContextMenu(Menu.buildFromTemplate([
+    { label: 'Show Hermes Studio', click: handlers.showWindow },
+    { type: 'separator' },
+    {
+      label: 'Launch at Login',
+      type: 'checkbox',
+      checked: settings.launchAtLogin,
+      click: item => handlers.updateSetting({ launchAtLogin: item.checked }),
+    },
+    {
+      label: 'Close Window to Background',
+      type: 'checkbox',
+      checked: settings.closeToBackground,
+      click: item => handlers.updateSetting({ closeToBackground: item.checked }),
+    },
+    {
+      label: 'Automatic Updates',
+      type: 'checkbox',
+      checked: settings.autoUpdateEnabled,
+      click: item => handlers.updateSetting({ autoUpdateEnabled: item.checked }),
+    },
+    { label: 'Check for Updates', click: handlers.checkForUpdates },
+    { type: 'separator' },
+    { label: `Quit ${app.name}`, click: handlers.quitApp },
+  ]))
+}
+
+export function destroyTray(): void {
+  tray?.destroy()
+  tray = null
+}
+
+export function showWindow(window: BrowserWindow | null): void {
+  if (!window) return
+  if (window.isMinimized()) window.restore()
+  window.show()
+  window.focus()
+}

--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -2,13 +2,25 @@ import { app, dialog } from 'electron'
 import { autoUpdater } from 'electron-updater'
 
 let initialized = false
+let enabled = false
+let timer: ReturnType<typeof setInterval> | null = null
+let installDownloadedUpdate: (() => Promise<void>) | null = null
 
-export function initAutoUpdater() {
-  if (initialized) return
-  initialized = true
+export interface AutoUpdaterOptions {
+  enabled: boolean
+  onBeforeInstall?: () => Promise<void>
+}
+
+export function initAutoUpdater(options: AutoUpdaterOptions) {
+  enabled = options.enabled
+  installDownloadedUpdate = options.onBeforeInstall || null
+  if (initialized) {
+    configureAutoUpdater(enabled)
+    return
+  }
 
   if (!app.isPackaged) return // dev mode: skip
-  if (process.env.HERMES_DESKTOP_ENABLE_AUTO_UPDATE !== 'true') return
+  initialized = true
 
   autoUpdater.autoDownload = true
   autoUpdater.autoInstallOnAppQuit = true
@@ -32,15 +44,41 @@ export function initAutoUpdater() {
       defaultId: 0,
       cancelId: 1,
     })
-    if (response === 0) autoUpdater.quitAndInstall()
+    if (response === 0) {
+      await installDownloadedUpdate?.().catch(() => undefined)
+      autoUpdater.quitAndInstall()
+    }
   })
 
-  autoUpdater.checkForUpdates().catch(err => {
+  configureAutoUpdater(enabled)
+}
+
+export function configureAutoUpdater(nextEnabled: boolean) {
+  enabled = nextEnabled
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+  if (!app.isPackaged || !initialized || !enabled) return
+
+  checkForDesktopUpdates().catch(err => {
     console.error('[updater] initial check failed:', err)
   })
 
   // Recheck every 6h while app is running
-  setInterval(() => {
+  timer = setInterval(() => {
     autoUpdater.checkForUpdates().catch(() => undefined)
   }, 6 * 60 * 60 * 1000)
+}
+
+export async function checkForDesktopUpdates(options: { force?: boolean } = {}) {
+  if (!app.isPackaged) {
+    console.log('[updater] skipped update check in dev mode')
+    return null
+  }
+  if (!enabled && !options.force) {
+    console.log('[updater] skipped update check while disabled')
+    return null
+  }
+  return autoUpdater.checkForUpdates()
 }

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -144,6 +144,30 @@ async function getLoginShellPath(): Promise<string | null> {
   }
 }
 
+function ensureBundledCliAliasBin(home: string, bundledPython: string): { binDir: string; binPath: string } {
+  const binDir = join(home, 'bin')
+  mkdirSync(binDir, { recursive: true })
+
+  if (process.platform === 'win32') {
+    const binPath = join(binDir, 'hermes-studio.cmd')
+    writeFileSync(binPath, [
+      '@echo off',
+      `"${bundledPython}" -m hermes_cli.main %*`,
+      '',
+    ].join('\r\n'), { mode: 0o600 })
+    return { binDir, binPath }
+  }
+
+  const binPath = join(binDir, 'hermes-studio')
+  writeFileSync(binPath, [
+    '#!/bin/sh',
+    `exec "${bundledPython}" -m hermes_cli.main "$@"`,
+    '',
+  ].join('\n'), { mode: 0o755 })
+  chmodSync(binPath, 0o755)
+  return { binDir, binPath }
+}
+
 export function getToken(): string {
   return ensureToken()
 }
@@ -217,8 +241,9 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
   const workerPortBase = await getFreeTcpPortInRange(20000, 59000)
   const loginShellPath = await getLoginShellPath()
   const nvmNodeBinPaths = getNvmNodeBinPaths()
+  const cliAlias = ensureBundledCliAliasBin(home, bundledPython)
   const runtimePath = mergePathEntries(
-    dirname(hermesBin()),
+    cliAlias.binDir,
     loginShellPath,
     nvmNodeBinPaths,
     process.env.PATH,
@@ -232,6 +257,7 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     NODE_ENV: 'production',
     HERMES_DESKTOP: 'true',
     HERMES_BIN: hermesBin(),
+    HERMES_STUDIO_BIN: cliAlias.binPath,
     HERMES_AGENT_BRIDGE_PYTHON: bundledPython,
     HERMES_AGENT_CLI_PYTHON: existsSync(bundledPythonNoWindow) ? bundledPythonNoWindow : bundledPython,
     HERMES_AGENT_ROOT: pythonDir(),

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -258,7 +258,7 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     HERMES_DESKTOP: 'true',
     HERMES_BIN: hermesBin(),
     HERMES_STUDIO_BIN: cliAlias.binPath,
-    HERMES_AGENT_BRIDGE_PYTHON: bundledPython,
+    HERMES_AGENT_BRIDGE_PYTHON: existsSync(bundledPythonNoWindow) ? bundledPythonNoWindow : bundledPython,
     HERMES_AGENT_CLI_PYTHON: existsSync(bundledPythonNoWindow) ? bundledPythonNoWindow : bundledPython,
     HERMES_AGENT_ROOT: pythonDir(),
     // Force TCP loopback for the agent bridge. The default `ipc:///tmp/...`

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -2,6 +2,15 @@ import { contextBridge, ipcRenderer } from 'electron'
 
 contextBridge.exposeInMainWorld('hermesDesktop', {
   getToken: (): Promise<string> => ipcRenderer.invoke('hermes-desktop:get-token'),
+  getSettings: () => ipcRenderer.invoke('hermes-desktop:get-settings'),
+  updateSettings: (patch: Record<string, unknown>) => ipcRenderer.invoke('hermes-desktop:update-settings', patch),
+  checkForUpdates: () => ipcRenderer.invoke('hermes-desktop:check-for-updates'),
+  quit: () => ipcRenderer.invoke('hermes-desktop:quit'),
+  onSettingsChanged: (callback: (settings: unknown) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, settings: unknown) => callback(settings)
+    ipcRenderer.on('hermes-desktop:settings-changed', listener)
+    return () => ipcRenderer.removeListener('hermes-desktop:settings-changed', listener)
+  },
   platform: process.platform,
   isDesktop: true,
 })

--- a/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
@@ -2741,6 +2741,8 @@ class BridgeServer:
 class WorkerProcess:
     STARTUP_TIMEOUT_SECONDS = 120
     REQUEST_TIMEOUT_SECONDS = 120
+    READY_PING_INTERVAL_SECONDS = 0.25
+    READY_PING_TIMEOUT_SECONDS = 0.25
 
     def __init__(self, key: str, profile: str, endpoint: str, agent_root: str | None, hermes_home: str | None) -> None:
         self.key = key or profile or "default"
@@ -2833,9 +2835,20 @@ class WorkerProcess:
 
         threading.Thread(target=read_stdout, daemon=True, name=f"hermes-bridge-worker-stdout-{self.key}").start()
         deadline = time.time() + self.STARTUP_TIMEOUT_SECONDS
+        next_ping_at = 0.0
         while time.time() < deadline:
             if proc.poll() is not None:
                 raise RuntimeError(f"profile worker {self.key} exited before ready")
+            now = time.time()
+            if now >= next_ping_at:
+                next_ping_at = now + self.READY_PING_INTERVAL_SECONDS
+                try:
+                    resp = _send_bridge_request(self.endpoint, {"action": "ping"}, self.READY_PING_TIMEOUT_SECONDS)
+                    if resp.get("pong") and resp.get("pid") == proc.pid:
+                        ready_event.set()
+                        return
+                except Exception:
+                    pass
             try:
                 line = lines.get(timeout=0.1)
             except queue.Empty:
@@ -2883,7 +2896,7 @@ class WorkerProcess:
 
 
 def _worker_endpoint(key: str, namespace: str | None = None) -> str:
-    namespace_key = f"{namespace or ''}\0{key}"
+    namespace_key = json.dumps([namespace or "", key], ensure_ascii=False, separators=(",", ":"))
     safe = hashlib.sha256(namespace_key.encode("utf-8")).hexdigest()[:16]
     transport = os.environ.get("HERMES_AGENT_BRIDGE_WORKER_TRANSPORT", "").strip().lower()
     use_tcp = transport == "tcp" or (transport not in {"ipc", "unix"} and os.name == "nt")

--- a/packages/server/src/services/hermes/agent-bridge/manager.ts
+++ b/packages/server/src/services/hermes/agent-bridge/manager.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawn, type ChildProcess } from 'child_process'
 import { existsSync, readFileSync } from 'fs'
-import { createServer } from 'net'
+import { createConnection, createServer, type Socket } from 'net'
 import { dirname, isAbsolute, join, resolve } from 'path'
 import { logger } from '../../logger'
 import { detectHermesHome, getHermesBin } from '../hermes-path'
@@ -299,6 +299,115 @@ async function waitForTcpEndpoint(endpoint: string, timeoutMs: number): Promise<
   return canListenTcpEndpoint(endpoint)
 }
 
+function connectBridgeSocket(endpoint: string, timeoutMs: number): Promise<Socket> {
+  return new Promise((resolveSocket, rejectSocket) => {
+    let socket: Socket
+    if (endpoint.startsWith('ipc://')) {
+      socket = createConnection(endpoint.slice('ipc://'.length))
+    } else if (endpoint.startsWith('tcp://')) {
+      const url = new URL(endpoint)
+      socket = createConnection({
+        host: url.hostname || '127.0.0.1',
+        port: Number(url.port),
+      })
+    } else {
+      rejectSocket(new Error(`unsupported agent bridge endpoint: ${endpoint}`))
+      return
+    }
+
+    const timeout = setTimeout(() => {
+      cleanup()
+      socket.destroy()
+      rejectSocket(new Error(`agent bridge ping timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+    const cleanup = () => {
+      clearTimeout(timeout)
+      socket.off('connect', onConnect)
+      socket.off('error', onError)
+    }
+    const onConnect = () => {
+      cleanup()
+      resolveSocket(socket)
+    }
+    const onError = (err: Error) => {
+      cleanup()
+      socket.destroy()
+      rejectSocket(err)
+    }
+    socket.once('connect', onConnect)
+    socket.once('error', onError)
+  })
+}
+
+function readBridgeSocketLine(socket: Socket, timeoutMs: number): Promise<string> {
+  return new Promise((resolveLine, rejectLine) => {
+    let buffer = ''
+    const timeout = setTimeout(() => {
+      cleanup()
+      socket.destroy()
+      rejectLine(new Error(`agent bridge ping response timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+    const cleanup = () => {
+      clearTimeout(timeout)
+      socket.off('data', onData)
+      socket.off('error', onError)
+      socket.off('close', onClose)
+      socket.off('end', onEnd)
+    }
+    const finish = (line: string) => {
+      cleanup()
+      socket.end()
+      resolveLine(line)
+    }
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString('utf8')
+      const newline = buffer.indexOf('\n')
+      if (newline >= 0) finish(buffer.slice(0, newline))
+    }
+    const onError = (err: Error) => {
+      cleanup()
+      socket.destroy()
+      rejectLine(err)
+    }
+    const onClose = () => {
+      if (!buffer.trim()) {
+        cleanup()
+        rejectLine(new Error('agent bridge ping socket closed without a response'))
+      }
+    }
+    const onEnd = () => {
+      const line = buffer.trim()
+      if (line) finish(line)
+    }
+    socket.on('data', onData)
+    socket.once('error', onError)
+    socket.once('close', onClose)
+    socket.once('end', onEnd)
+  })
+}
+
+async function pingBridgeEndpoint(endpoint: string, timeoutMs: number, expectedPid?: number): Promise<boolean> {
+  const socket = await connectBridgeSocket(endpoint, timeoutMs)
+  try {
+    socket.write(`${JSON.stringify({ action: 'ping' })}\n`)
+    const line = await readBridgeSocketLine(socket, timeoutMs)
+    const response = JSON.parse(line) as {
+      ok?: unknown
+      pong?: unknown
+      pid?: unknown
+      broker?: { pid?: unknown }
+    }
+    if (response.ok !== true || response.pong !== true) return false
+    if (expectedPid) {
+      const responsePid = Number(response.pid ?? response.broker?.pid)
+      return Number.isFinite(responsePid) && responsePid === expectedPid
+    }
+    return true
+  } finally {
+    socket.destroy()
+  }
+}
+
 async function killWindowsEndpointOccupants(endpoint: string): Promise<void> {
   const port = tcpEndpointPort(endpoint)
   if (!port) return
@@ -410,25 +519,54 @@ export class AgentBridgeManager {
         rejectReady(new Error(`agent bridge did not become ready within ${startupTimeoutMs}ms`))
       }, startupTimeoutMs)
 
+      let readyResolved = false
+      let pingInFlight = false
+      let pingInterval: NodeJS.Timeout | undefined
       const cleanup = () => {
         clearTimeout(timeout)
+        if (pingInterval) clearInterval(pingInterval)
         child.off('exit', onExitBeforeReady)
         child.off('error', onError)
+        child.stdout?.off('data', onStdout)
       }
 
       const onError = (err: Error) => {
         cleanup()
-        child.stdout?.off('data', onStdout)
         rejectReady(err)
       }
 
       const onExitBeforeReady = (code: number | null, signal: NodeJS.Signals | null) => {
         cleanup()
-        child.stdout?.off('data', onStdout)
         rejectReady(new Error(`agent bridge exited before ready code=${code} signal=${signal}`))
       }
 
-      let readyResolved = false
+      const markReady = () => {
+        if (readyResolved) return
+        this.ready = true
+        this.restartAttempts = 0
+        readyResolved = true
+        cleanup()
+        resolveReady()
+      }
+
+      const pollEndpointReady = () => {
+        if (readyResolved || pingInFlight) return
+        pingInFlight = true
+        pingBridgeEndpoint(this.endpoint, 1000, child.pid)
+          .then((ready) => {
+            if (ready) markReady()
+          })
+          .catch(() => {
+            /* keep waiting until stdout, ping, exit, or timeout decides */
+          })
+          .finally(() => {
+            pingInFlight = false
+          })
+      }
+
+      pingInterval = setInterval(pollEndpointReady, 250)
+      pollEndpointReady()
+
       const onStdout = (chunk: Buffer) => {
         const text = chunk.toString('utf8')
         buffered += text
@@ -443,11 +581,7 @@ export class AgentBridgeManager {
             try {
               const parsed = JSON.parse(line)
               if (parsed?.event === 'ready') {
-                this.ready = true
-                this.restartAttempts = 0
-                readyResolved = true
-                cleanup()
-                resolveReady()
+                markReady()
                 return
               }
             } catch {}

--- a/scripts/harness-check.mjs
+++ b/scripts/harness-check.mjs
@@ -118,8 +118,12 @@ if (!buildWorkflow.includes('npm run harness:check')) {
 
 const desktopReleaseWorkflow = await readText('.github/workflows/desktop-release.yml')
 const electronBuilderConfig = await readText('packages/desktop/electron-builder.yml')
-if (!desktopReleaseWorkflow.includes('files: ${{ matrix.artifact_files }}')) {
-  fail('desktop-release.yml must upload matrix-specific artifact_files')
+if (!desktopReleaseWorkflow.includes('files: ${{ matrix.release_files }}')) {
+  fail('desktop-release.yml must upload matrix-specific release_files')
+}
+
+if (!desktopReleaseWorkflow.includes('files: packages/desktop/release/latest-mac.yml')) {
+  fail('desktop-release.yml must upload the merged macOS updater manifest')
 }
 
 if (!electronBuilderConfig.includes('icon: build/icons')) {

--- a/tests/server/agent-bridge-manager.test.ts
+++ b/tests/server/agent-bridge-manager.test.ts
@@ -1,4 +1,5 @@
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { EventEmitter } from 'events'
 import { createServer, type Server } from 'net'
 import { tmpdir } from 'os'
 import { join } from 'path'
@@ -16,11 +17,13 @@ describe('agent bridge manager command resolution', () => {
     delete process.env.HERMES_AGENT_BRIDGE_PYTHON
     delete process.env.HERMES_AGENT_BRIDGE_UV
     delete process.env.UV
+    vi.doUnmock('child_process')
   })
 
   afterEach(() => {
     process.env = { ...originalEnv }
     if (tempDir) rmSync(tempDir, { recursive: true, force: true })
+    vi.doUnmock('child_process')
   })
 
   it('uses the installed hermes command Python when no source root exists', async () => {
@@ -151,6 +154,69 @@ describe('agent bridge manager command resolution', () => {
       await ready
     } finally {
       await new Promise<void>((resolve) => server?.close(() => resolve()) ?? resolve())
+    }
+  })
+
+  it('marks the bridge ready from endpoint ping when stdout ready is unavailable', async () => {
+    const homeDir = join(tempDir, 'home')
+    mkdirSync(homeDir, { recursive: true })
+
+    const server = createServer((socket) => {
+      socket.once('data', () => {
+        socket.end(`${JSON.stringify({ ok: true, pong: true, broker: { pid: 12345 } })}\n`)
+      })
+    })
+    await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen))
+    const address = server.address()
+    if (typeof address !== 'object' || !address?.port) {
+      throw new Error('test server did not bind to a TCP port')
+    }
+    const endpoint = `tcp://127.0.0.1:${address.port}`
+
+    const stdout = new EventEmitter()
+    const stderr = new EventEmitter()
+    const child = Object.assign(new EventEmitter(), {
+      stdout,
+      stderr,
+      killed: false,
+      pid: 12345,
+      kill: vi.fn(function kill(this: { killed: boolean }) {
+        this.killed = true
+        return true
+      }),
+    })
+    const actualChildProcess = await vi.importActual<typeof import('child_process')>('child_process')
+    const spawn = vi.fn(() => child)
+    vi.doMock('child_process', () => ({
+      ...actualChildProcess,
+      spawn,
+    }))
+    vi.resetModules()
+
+    try {
+      const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+      const manager = new AgentBridgeManager({
+        endpoint,
+        python: process.execPath,
+        hermesHome: homeDir,
+        startupTimeoutMs: 1000,
+      })
+
+      await manager.start()
+
+      expect(manager.getRuntimeState()).toMatchObject({
+        endpoint,
+        ready: true,
+        running: true,
+        pid: 12345,
+      })
+      expect(spawn).toHaveBeenCalledWith(
+        process.execPath,
+        expect.arrayContaining(['--endpoint', endpoint]),
+        expect.objectContaining({ windowsHide: true }),
+      )
+    } finally {
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()))
     }
   })
 })

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -9,11 +9,15 @@ function runPython(script: string): void {
       stdio: 'pipe',
     })
   } catch (error) {
-    const err = error as { stdout?: string; stderr?: string; message?: string }
+    const err = error as { stdout?: string | Buffer; stderr?: string | Buffer; message?: string; status?: number; signal?: string }
+    const stdout = err.stdout ? String(err.stdout) : ''
+    const stderr = err.stderr ? String(err.stderr) : ''
     throw new Error([
       err.message || 'Python bridge concurrency script failed',
-      err.stdout ? `stdout:\n${err.stdout}` : '',
-      err.stderr ? `stderr:\n${err.stderr}` : '',
+      err.status != null ? `status: ${err.status}` : '',
+      err.signal ? `signal: ${err.signal}` : '',
+      stdout ? `stdout:\n${stdout}` : '',
+      stderr ? `stderr:\n${stderr}` : '',
     ].filter(Boolean).join('\n\n'))
   }
 }
@@ -457,16 +461,18 @@ assert "compress-temp" not in broker._session_worker_key
     runPython(String.raw`
 ${harness}
 
-prod_endpoint = bridge._worker_endpoint("default", "ipc:///tmp/hermes-agent-bridge.sock")
-preview_endpoint = bridge._worker_endpoint("default", "ipc:///tmp/hermes-web-ui-preview/agent-bridge.sock")
-assert prod_endpoint != preview_endpoint
-assert prod_endpoint == bridge._worker_endpoint("default", "ipc:///tmp/hermes-agent-bridge.sock")
+prod_namespace = "ipc:///tmp/" + "hermes-" + "agent-" + "bridge.sock"
+preview_namespace = "ipc:///tmp/hermes-web-ui-preview/" + "agent-bridge.sock"
+prod_endpoint = bridge._worker_endpoint("default", prod_namespace)
+preview_endpoint = bridge._worker_endpoint("default", preview_namespace)
+assert prod_endpoint != preview_endpoint, (prod_endpoint, preview_endpoint)
+assert prod_endpoint == bridge._worker_endpoint("default", prod_namespace), prod_endpoint
 
-prod_broker = bridge.BridgeBroker("ipc:///tmp/hermes-agent-bridge.sock")
-preview_broker = bridge.BridgeBroker("ipc:///tmp/hermes-web-ui-preview/agent-bridge.sock")
+prod_broker = bridge.BridgeBroker(prod_namespace)
+preview_broker = bridge.BridgeBroker(preview_namespace)
 prod_worker = prod_broker._worker_for_profile("default")
 preview_worker = preview_broker._worker_for_profile("default")
-assert prod_worker.endpoint != preview_worker.endpoint
+assert prod_worker.endpoint != preview_worker.endpoint, (prod_worker.endpoint, preview_worker.endpoint)
 `)
   })
 
@@ -477,25 +483,64 @@ ${harness}
 os.environ.pop("HERMES_AGENT_BRIDGE_WORKER_TRANSPORT", None)
 os.environ.pop("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE", None)
 
-default_endpoint = bridge._worker_endpoint("default", "ipc:///tmp/hermes-agent-bridge.sock")
+prod_namespace = "ipc:///tmp/" + "hermes-" + "agent-" + "bridge.sock"
+default_endpoint = bridge._worker_endpoint("default", prod_namespace)
 if os.name == "nt":
-    assert default_endpoint.startswith("tcp://127.0.0.1:")
+    assert default_endpoint.startswith("tcp://127.0.0.1:"), default_endpoint
 else:
-    assert default_endpoint.startswith("ipc://")
+    assert default_endpoint.startswith("ipc://"), default_endpoint
 
 os.environ["HERMES_AGENT_BRIDGE_WORKER_TRANSPORT"] = "tcp"
 os.environ["HERMES_AGENT_BRIDGE_WORKER_PORT_BASE"] = "19650"
-tcp_endpoint = bridge._worker_endpoint("default", "ipc:///tmp/hermes-agent-bridge.sock")
-assert tcp_endpoint.startswith("tcp://127.0.0.1:")
-assert int(tcp_endpoint.rsplit(":", 1)[1]) >= 19650
-assert int(tcp_endpoint.rsplit(":", 1)[1]) < 20650
+tcp_endpoint = bridge._worker_endpoint("default", prod_namespace)
+assert tcp_endpoint.startswith("tcp://127.0.0.1:"), tcp_endpoint
+assert int(tcp_endpoint.rsplit(":", 1)[1]) >= 19650, tcp_endpoint
+assert int(tcp_endpoint.rsplit(":", 1)[1]) < 20650, tcp_endpoint
 
 os.environ["HERMES_AGENT_BRIDGE_WORKER_TRANSPORT"] = "ipc"
-ipc_endpoint = bridge._worker_endpoint("default", "ipc:///tmp/hermes-agent-bridge.sock")
-assert ipc_endpoint.startswith("ipc://")
+ipc_endpoint = bridge._worker_endpoint("default", prod_namespace)
+assert ipc_endpoint.startswith("ipc://"), ipc_endpoint
 
 os.environ.pop("HERMES_AGENT_BRIDGE_WORKER_TRANSPORT", None)
 os.environ.pop("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE", None)
+`)
+  })
+
+  it('marks a profile worker ready from endpoint ping when stdout ready is unavailable', () => {
+    runPython(String.raw`
+${harness}
+
+class QuietStdout:
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        time.sleep(60)
+        raise StopIteration
+
+class FakeProcess:
+    pid = 43210
+    stdout = QuietStdout()
+
+    def poll(self):
+        return None
+
+worker = bridge.WorkerProcess("default", "default", "tcp://127.0.0.1:43210", None, None)
+worker.process = FakeProcess()
+worker.STARTUP_TIMEOUT_SECONDS = 1
+
+calls = []
+
+def fake_send_bridge_request(endpoint, req, timeout):
+    calls.append((endpoint, req, timeout))
+    return {"ok": True, "pong": True, "pid": 43210}
+
+bridge._send_bridge_request = fake_send_bridge_request
+worker._wait_ready()
+
+assert calls
+assert calls[0][0] == "tcp://127.0.0.1:43210"
+assert calls[0][1] == {"action": "ping"}
 `)
   })
 


### PR DESCRIPTION
## Summary
- Add Electron desktop settings for launch at login, close-to-background, and automatic updates.
- Add macOS native app menu entries plus Windows/Linux titlebar settings controls beside the native window buttons.
- Keep the app running in the background on window close, add a tray menu for show/settings/quit, and stop local services only on explicit quit.
- Expose the bundled Hermes CLI as `hermes-studio` without prepending the bundled `hermes` command ahead of the user's normal PATH.
- Configure electron-updater GitHub publishing metadata and upload updater manifests, including a merged macOS `latest-mac.yml`.

## Validation
- `npm run harness:check`
- `npm --prefix packages/desktop run build`
- `npm run build`
- `git diff --check`
- `npm run test` fails in existing Python bridge subprocess tests: 3 failures where Node-spawned `python3` is terminated by `SIGKILL` while executing `hermes_bridge.py` probes. The failed paths are unrelated to the Electron desktop changes in this PR.

## Notes
- PR is opened as Draft to keep it blocked until review/CI validation.
