### PR TITLE
fix(file-provider): SSH 后端文件操作支持自定义端口（TERMINAL_SSH_PORT）

### DIFF
--- a/packages/server/src/services/hermes/file-provider.ts
+++ b/packages/server/src/services/hermes/file-provider.ts
@@ -61,6 +61,7 @@ export interface TerminalConfig {
   docker_container_name?: string
   cwd?: string
   singularity_image?: string
+  ssh_port?: number
 }
 
 /**
@@ -421,18 +422,20 @@ export class SSHFileProvider implements FileProvider {
   private host: string
   private user: string
   private keyPath?: string
+  private port?: number
   private homeDir: string
 
-  constructor(host: string, user: string, keyPath?: string, homeDir = getActiveProfileDir()) {
+  constructor(host: string, user: string, keyPath?: string, homeDir = getActiveProfileDir(), port?: number) {
     this.host = host
     this.user = user
     this.keyPath = keyPath
+    this.port = port
     this.homeDir = homeDir
   }
 
   private sshArgs(): string[] {
-    // StrictHostKeyChecking disabled for automated tooling with user-configured hosts
     const args = ['-o', 'StrictHostKeyChecking=no', '-o', 'BatchMode=yes']
+    if (this.port) args.push('-p', String(this.port))
     if (this.keyPath) args.push('-i', this.keyPath)
     args.push(`${this.user}@${this.host}`)
     return args
@@ -740,7 +743,7 @@ export function getTerminalConfig(profile?: string): TerminalConfig {
 /**
  * Read SSH env vars from hermes .env file.
  */
-function getSSHEnvVars(profile?: string): { host?: string; user?: string; key?: string } {
+function getSSHEnvVars(profile?: string): { host?: string; user?: string; key?: string; port?: number } {
   try {
     const envPath = envPathForProfile(profile)
     if (!existsSync(envPath)) return {}
@@ -761,6 +764,7 @@ function getSSHEnvVars(profile?: string): { host?: string; user?: string; key?: 
       host: vars.TERMINAL_SSH_HOST,
       user: vars.TERMINAL_SSH_USER,
       key: vars.TERMINAL_SSH_KEY,
+      port: vars.TERMINAL_SSH_PORT ? parseInt(vars.TERMINAL_SSH_PORT, 10) : undefined,
     }
   } catch {
     return {}
@@ -827,7 +831,7 @@ export async function createFileProvider(profile?: string): Promise<FileProvider
           { code: 'backend_error' },
         )
       }
-      provider = new SSHFileProvider(ssh.host, ssh.user, ssh.key, homeDir)
+      provider = new SSHFileProvider(ssh.host, ssh.user, ssh.key, homeDir, ssh.port)
       break
     }
     case 'singularity': {


### PR DESCRIPTION
## 问题

当 hermes 后端配置为 SSH 模式时，前端文件浏览器（读/写/列表/删除/重命名等所有文件操作）完全忽略 `.env` 中配置的 SSH 端口，始终使用默认端口 22。

## 根因

`SSHFileProvider` 的 `sshArgs()` 方法构建 SSH 命令参数时，只拼了 `user@host`，从未加入 `-p <port>`：

```typescript
// 修复前
private sshArgs(): string[] {
    const args = ["-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes"]
    if (this.keyPath) args.push("-i", this.keyPath)
    args.push(`${this.user}@${this.host}`)  // 没有 -p
    return args
}
```

整个调用链 4 个环节都缺失端口支持：

1. `TerminalConfig` 接口 — 无 `ssh_port` 字段
2. `getSSHEnvVars()` — 不读取 `TERMINAL_SSH_PORT`
3. `SSHFileProvider` 构造函数 — 不接收 `port` 参数
4. `createFileProvider()` 工厂 — 不传入 `port`

## 修复

- `getSSHEnvVars()` 新增读取 `TERMINAL_SSH_PORT` 环境变量并解析为整数
- `SSHFileProvider` 构造函数新增 `port` 可选参数，`sshArgs()` 在 port 存在时追加 `-p <port>`
- `createFileProvider()` 工厂函数将 `ssh.port` 传入构造

## 向后兼容

未配置 `TERMINAL_SSH_PORT` 时行为不变，`port` 为 `undefined`，不产生 `-p` 参数，SSH 使用默认 22。