### PR TITLE
[codex] Align profiles header height

### DIFF
--- a/packages/client/src/views/hermes/ProfilesView.vue
+++ b/packages/client/src/views/hermes/ProfilesView.vue
@@ -93,22 +93,9 @@ function handleImported() {
   flex-direction: column;
 }
 
-.page-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px 20px;
-  border-bottom: 1px solid $border-color;
-}
-
-.header-title {
-  font-size: 16px;
-  font-weight: 600;
-  color: $text-primary;
-}
-
 .header-actions {
   display: flex;
+  align-items: center;
   gap: 8px;
 }
 


### PR DESCRIPTION
## Summary
- Remove the profiles page-specific page header override so it uses the shared header spacing.
- Keep the profiles header actions vertically centered with the shared header layout.

## Validation
- npx vue-tsc -b
- npm run build