### PR TITLE
fix(memory): saving empty "My Notes" content fails with 400 error

### DIFF
--- a/packages/server/src/controllers/hermes/memory.ts
+++ b/packages/server/src/controllers/hermes/memory.ts
@@ -28,7 +28,7 @@ export async function get(ctx: any) {
 
 export async function save(ctx: any) {
   const { section, content } = ctx.request.body as { section: string; content: string }
-  if (!section || !content) {
+  if (!section || content === undefined || content === null) {
     ctx.status = 400
     ctx.body = { error: 'Missing section or content' }
     return


### PR DESCRIPTION
    Bug

    When a user clears all content in "My Notes" and clicks Save, the
    operation fails with:
    
    API Error 400: Missing section or content
    
    Root Cause
    
    Backend validation used !content which treats empty string "" as
    falsy in JavaScript. Clearing notes sends content: "", which was
    incorrectly rejected as a missing value.
    
    Fix
    
    Changed the check to content === undefined || content === null.
    Empty strings are now accepted (user intentionally cleared notes),
    while truly missing values are still rejected.