### PR TITLE
fix(client): fix mobile layout width overflow on virtual keyboard toggle

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -87,7 +87,8 @@ useKeyboard()
 .app-layout {
   display: flex;
   height: calc(100 * var(--vh));
-  width: 100vw;
+  width: 100%;
+  max-width: 100%;
   overflow: hidden;
 
   &.no-sidebar {

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -971,6 +971,10 @@ function isImage(type: string): boolean {
   min-height: 20px;
   overflow-y: auto;
 
+  @media (max-width: 768px) {
+    font-size: 16px;
+  }
+
   &::placeholder {
     color: $text-muted;
     white-space: nowrap;

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -686,6 +686,10 @@ function isImage(type: string): boolean {
     min-height: 20px;
     overflow-y: auto;
 
+    @media (max-width: 768px) {
+        font-size: 16px;
+    }
+
     &::placeholder {
         color: $text-muted;
         white-space: nowrap;

--- a/packages/client/src/styles/global.scss
+++ b/packages/client/src/styles/global.scss
@@ -84,7 +84,16 @@ html.theme-transitioning *::after {
               box-shadow 0.3s ease, fill 0.3s ease, stroke 0.3s ease !important;
 }
 
-html, body, #app {
+html, body {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+#app {
   height: 100%;
   width: 100%;
   overflow: hidden;
@@ -203,5 +212,18 @@ a {
   .input-md,
   .input-lg {
     width: 100%;
+  }
+}
+
+// Prevent iOS Safari auto-zoom on input focus by ensuring font-size is at least 16px
+@media (max-width: 768px) {
+  input,
+  textarea,
+  select,
+  .n-input,
+  .n-input__input-element,
+  .n-input__textarea-el,
+  .n-input__textarea-element {
+    font-size: 16px !important;
   }
 }


### PR DESCRIPTION
This PR fixes the mobile layout width overflow issues that occur when the virtual keyboard is shown/hidden by implementing the following improvements:

1. **Auto-zoom Prevention**: Sets the native input, textarea, and select element font sizes to 16px on screens below 768px. This completely prevents iOS Safari and other mobile browsers from triggering automatic zoom on element focus.
2. **Container Containment**: Changes `.app-layout` width from 100vw to 100% / max-width: 100% so it behaves correctly within the parent container's bounds when the viewport width is modified by browser zoom or keyboard overlays.
3. **Viewport Shift Prevention**: Locks the outer `html` and `body` position to `fixed` so that keyboard scroll offsets cannot displace the global layout.