### PR TITLE
[codex] fix Windows bridge logs and mobile headers

### DIFF
--- a/packages/client/src/views/hermes/KanbanView.vue
+++ b/packages/client/src/views/hermes/KanbanView.vue
@@ -494,8 +494,12 @@ async function handleArchiveSelectedBoard() {
 @media (max-width: $breakpoint-mobile) {
   .page-header {
     padding: 16px 12px 16px 52px;
+    position: sticky;
+    top: 0;
+    z-index: 20;
     flex-direction: column;
     align-items: flex-start;
+    background: $bg-primary;
     gap: 10px;
   }
 

--- a/packages/client/src/views/hermes/PerformanceView.vue
+++ b/packages/client/src/views/hermes/PerformanceView.vue
@@ -466,6 +466,13 @@ onBeforeUnmount(() => {
     flex-direction: column;
   }
 
+  .page-header {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: $bg-primary;
+  }
+
   .header-actions {
     width: 100%;
   }

--- a/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
@@ -2825,6 +2825,8 @@ class WorkerProcess:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 bufsize=1,
                 **_hidden_subprocess_kwargs(),
             )

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -600,6 +600,8 @@ class FakeProcess:
 def fake_popen(args, **kwargs):
     created["args"] = args
     created["env"] = kwargs["env"]
+    created["encoding"] = kwargs.get("encoding")
+    created["errors"] = kwargs.get("errors")
     return FakeProcess()
 
 original_popen = bridge.subprocess.Popen
@@ -617,6 +619,8 @@ finally:
 
 assert created["env"]["HERMES_AGENT_BRIDGE_BROKER_PID"] == "4242"
 assert created["env"]["HERMES_AGENT_BRIDGE_WORKER_PROFILE"] == "default"
+assert created["encoding"] == "utf-8"
+assert created["errors"] == "replace"
 
 stop_event = threading.Event()
 seen_pids = []


### PR DESCRIPTION
## Summary
- Decode Windows desktop bridge worker stdout/stderr as UTF-8 with replacement so non-GBK log bytes cannot crash the worker pipe threads.
- Keep the bridge worker subprocess encoding behavior covered by the existing Python concurrency test harness.
- Pin the Kanban and Performance page headers to the top on mobile with sticky positioning and a page background.

## Root Cause
Windows packaged runs can receive UTF-8 or otherwise non-GBK bytes on worker stderr. The worker process was opened with `text=True` but no explicit encoding, so Python used the system default codec and could raise `UnicodeDecodeError` while reading logs.

## Validation
- `npx vitest run tests/server/agent-bridge-python-concurrency.test.ts tests/server/agent-bridge-profile-env.test.ts --reporter=dot`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run build`
- `npm run harness:check`
- `git diff --check`

## Notes
- I could not run the packaged Windows desktop app in this environment; this fixes the decoded log path shown in the Windows desktop logs and keeps invalid bytes non-fatal.
