### PR TITLE
fix(client): add safe area top offsets for mobile header, sidebar and hamburger button

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -1959,7 +1959,7 @@ async function handleSessionModelCustomSubmit() {
 
 @media (max-width: $breakpoint-mobile) {
   .chat-header {
-    padding: 16px 12px 16px 52px;
+    padding: calc(16px + env(safe-area-inset-top, 0px)) 12px 16px 52px;
   }
 }
 

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -893,6 +893,7 @@ function openChangelog() {
     z-index: 1000;
     transform: translateX(-100%);
     transition: transform $transition-normal;
+    padding-top: env(safe-area-inset-top, 0px);
 
     &.open {
       transform: translateX(0);

--- a/packages/client/src/styles/global.scss
+++ b/packages/client/src/styles/global.scss
@@ -180,7 +180,7 @@ a {
 .hamburger-btn {
   display: none;
   position: fixed;
-  top: 10px;
+  top: calc(10px + env(safe-area-inset-top, 0px));
   left: 12px;
   z-index: 99;
   width: 36px;
@@ -205,7 +205,7 @@ a {
   }
 
   .page-header {
-    padding: 16px 12px 16px 52px !important;
+    padding: calc(16px + env(safe-area-inset-top, 0px)) 12px 16px 52px !important;
   }
 
   .input-sm,


### PR DESCRIPTION
This PR resolves the mobile viewport safe-area overlap issue by adding top paddings/offsets based on the hardware safe area inset top:

1. **Hamburger Button**: Added `env(safe-area-inset-top)` offset to top position.
2. **Chat Header**: Added `env(safe-area-inset-top)` offset to top padding under mobile breakpoint.
3. **Mobile Sidebar**: Added `env(safe-area-inset-top)` top padding under mobile breakpoint.
4. **Page Header**: Added `env(safe-area-inset-top)` offset to top padding under mobile breakpoint.