### PR TITLE
fix(agent-bridge): augment PATH for stdio MCP CLIs in Studio

### DIFF
--- a/packages/server/src/services/hermes/agent-bridge/bridge-path.ts
+++ b/packages/server/src/services/hermes/agent-bridge/bridge-path.ts
@@ -1,0 +1,54 @@
+import { execFileSync } from 'child_process'
+import { homedir } from 'os'
+import { delimiter, dirname, join } from 'path'
+
+function resolveNpmGlobalBin(): string | undefined {
+  try {
+    const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    const prefix = execFileSync(npm, ['prefix', '-g'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      env: {
+        ...process.env,
+        PATH: [dirname(process.execPath), process.env.PATH].filter(Boolean).join(delimiter),
+      },
+      windowsHide: true,
+    }).trim()
+    if (!prefix) return undefined
+    return process.platform === 'win32' ? prefix : join(prefix, 'bin')
+  } catch {
+    return undefined
+  }
+}
+
+/** Common install locations for stdio MCP CLIs (codegraph, etc.) in GUI/desktop runtimes. */
+export function mcpCliPathPrefixes(homeDir = homedir()): string[] {
+  const prefixes = [
+    dirname(process.execPath),
+    resolveNpmGlobalBin(),
+    join(homeDir, '.npm-global', 'bin'),
+    join(homeDir, '.local', 'bin'),
+  ]
+  if (process.platform === 'darwin') {
+    prefixes.push('/opt/homebrew/bin', '/usr/local/bin')
+  }
+  return prefixes.filter((entry): entry is string => !!entry && entry.length > 0)
+}
+
+export function prependPathEntries(existing: string | undefined, prefixes: string[]): string {
+  const parts: string[] = []
+  const seen = new Set<string>()
+  for (const entry of [...prefixes, ...(existing || '').split(delimiter)]) {
+    const trimmed = entry.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    parts.push(trimmed)
+  }
+  return parts.join(delimiter)
+}
+
+export function augmentBridgePath(env: NodeJS.ProcessEnv, homeDir = homedir()): string {
+  const pathKey = Object.keys(env).find(key => key.toLowerCase() === 'path') || 'PATH'
+  const current = env[pathKey] ?? env.PATH ?? ''
+  return prependPathEntries(String(current), mcpCliPathPrefixes(homeDir))
+}

--- a/packages/server/src/services/hermes/agent-bridge/bridge-path.ts
+++ b/packages/server/src/services/hermes/agent-bridge/bridge-path.ts
@@ -2,9 +2,14 @@ import { execFileSync } from 'child_process'
 import { homedir } from 'os'
 import { delimiter, dirname, join } from 'path'
 
-function resolveNpmGlobalBin(): string | undefined {
+export interface McpCliPathOptions {
+  platform?: NodeJS.Platform
+  resolveNpmGlobalBin?: () => string | undefined
+}
+
+function resolveNpmGlobalBinForPlatform(platform: NodeJS.Platform): string | undefined {
   try {
-    const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    const npm = platform === 'win32' ? 'npm.cmd' : 'npm'
     const prefix = execFileSync(npm, ['prefix', '-g'], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
@@ -15,40 +20,47 @@ function resolveNpmGlobalBin(): string | undefined {
       windowsHide: true,
     }).trim()
     if (!prefix) return undefined
-    return process.platform === 'win32' ? prefix : join(prefix, 'bin')
+    return platform === 'win32' ? prefix : join(prefix, 'bin')
   } catch {
     return undefined
   }
 }
 
 /** Common install locations for stdio MCP CLIs (codegraph, etc.) in GUI/desktop runtimes. */
-export function mcpCliPathPrefixes(homeDir = homedir()): string[] {
+export function mcpCliPathPrefixes(homeDir = homedir(), options: McpCliPathOptions = {}): string[] {
+  const platform = options.platform ?? process.platform
+  const npmGlobalBin = options.resolveNpmGlobalBin?.() ?? resolveNpmGlobalBinForPlatform(platform)
   const prefixes = [
     dirname(process.execPath),
-    resolveNpmGlobalBin(),
+    npmGlobalBin,
     join(homeDir, '.npm-global', 'bin'),
     join(homeDir, '.local', 'bin'),
   ]
-  if (process.platform === 'darwin') {
+  if (platform === 'darwin') {
     prefixes.push('/opt/homebrew/bin', '/usr/local/bin')
   }
   return prefixes.filter((entry): entry is string => !!entry && entry.length > 0)
 }
 
-export function prependPathEntries(existing: string | undefined, prefixes: string[]): string {
+export function prependPathEntries(existing: string | undefined, prefixes: string[], pathDelimiter = delimiter): string {
   const parts: string[] = []
   const seen = new Set<string>()
-  for (const entry of [...prefixes, ...(existing || '').split(delimiter)]) {
+  for (const entry of [...prefixes, ...(existing || '').split(pathDelimiter)]) {
     const trimmed = entry.trim()
     if (!trimmed || seen.has(trimmed)) continue
     seen.add(trimmed)
     parts.push(trimmed)
   }
-  return parts.join(delimiter)
+  return parts.join(pathDelimiter)
 }
 
-export function augmentBridgePath(env: NodeJS.ProcessEnv, homeDir = homedir()): string {
+export function augmentBridgePath(
+  env: NodeJS.ProcessEnv,
+  homeDir = homedir(),
+  options: McpCliPathOptions = {},
+): string {
   const pathKey = Object.keys(env).find(key => key.toLowerCase() === 'path') || 'PATH'
   const current = env[pathKey] ?? env.PATH ?? ''
-  return prependPathEntries(String(current), mcpCliPathPrefixes(homeDir))
+  const pathDelimiter = (options.platform ?? process.platform) === 'win32' ? ';' : delimiter
+  return prependPathEntries(String(current), mcpCliPathPrefixes(homeDir, options), pathDelimiter)
 }

--- a/packages/server/src/services/hermes/agent-bridge/manager.ts
+++ b/packages/server/src/services/hermes/agent-bridge/manager.ts
@@ -4,6 +4,7 @@ import { createConnection, createServer } from 'net'
 import { dirname, isAbsolute, join, resolve } from 'path'
 import { logger } from '../../logger'
 import { detectHermesHome, getHermesBin } from '../hermes-path'
+import { augmentBridgePath } from './bridge-path'
 import { DEFAULT_AGENT_BRIDGE_ENDPOINT } from './client'
 
 const DEFAULT_AGENT_BRIDGE_STARTUP_TIMEOUT_MS = 120000
@@ -49,7 +50,7 @@ function envPositiveInt(name: string): number | undefined {
 }
 
 export function buildAgentBridgeProcessEnv(endpoint: string, hermesHome: string | undefined, agentRoot: string | undefined): NodeJS.ProcessEnv {
-  return {
+  const env: NodeJS.ProcessEnv = {
     ...process.env,
     HERMES_AGENT_BRIDGE_ENDPOINT: endpoint,
     HERMES_HOME: hermesHome,
@@ -58,6 +59,9 @@ export function buildAgentBridgeProcessEnv(endpoint: string, hermesHome: string 
     HERMES_OPENROUTER_APP_CATEGORIES: process.env.HERMES_OPENROUTER_APP_CATEGORIES || OPENROUTER_WEB_UI_ATTRIBUTION_ENV.HERMES_OPENROUTER_APP_CATEGORIES,
     ...(agentRoot ? { HERMES_AGENT_ROOT: agentRoot } : {}),
   }
+  const pathKey = Object.keys(env).find(key => key.toLowerCase() === 'path') || 'PATH'
+  env[pathKey] = augmentBridgePath(env)
+  return env
 }
 
 function pathCandidates(agentRoot?: string): string[] {

--- a/tests/server/agent-bridge-manager.test.ts
+++ b/tests/server/agent-bridge-manager.test.ts
@@ -1,6 +1,6 @@
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { createServer, type Server } from 'net'
-import { tmpdir } from 'os'
+import { homedir, tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -100,6 +100,7 @@ describe('agent bridge manager command resolution', () => {
     expect(env.HERMES_OPENROUTER_APP_REFERER).toBe('https://ekkolearnai.com')
     expect(env.HERMES_OPENROUTER_APP_TITLE).toBe('Hermes Web UI')
     expect(env.HERMES_OPENROUTER_APP_CATEGORIES).toBe('cli-agent,personal-agent')
+    expect(env.PATH).toContain(join(homedir(), '.npm-global', 'bin'))
   })
 
   it('keeps explicit OpenRouter attribution env values when starting the bridge', async () => {
@@ -113,6 +114,7 @@ describe('agent bridge manager command resolution', () => {
     expect(env.HERMES_OPENROUTER_APP_REFERER).toBe('https://example.invalid/app')
     expect(env.HERMES_OPENROUTER_APP_TITLE).toBe('Custom App')
     expect(env.HERMES_OPENROUTER_APP_CATEGORIES).toBe('custom-category')
+    expect(env.PATH).toContain(join(homedir(), '.npm-global', 'bin'))
   })
 
   it('uses an isolated default bridge endpoint while running under Vitest', async () => {

--- a/tests/server/agent-bridge-process-env.test.ts
+++ b/tests/server/agent-bridge-process-env.test.ts
@@ -1,0 +1,46 @@
+import { delimiter, join } from 'path'
+import { homedir } from 'os'
+import { describe, expect, it } from 'vitest'
+import {
+  augmentBridgePath,
+  mcpCliPathPrefixes,
+  prependPathEntries,
+} from '../../packages/server/src/services/hermes/agent-bridge/bridge-path'
+import { buildAgentBridgeProcessEnv } from '../../packages/server/src/services/hermes/agent-bridge/manager'
+
+describe('agent bridge PATH augmentation', () => {
+  it('prepends MCP CLI prefixes without dropping existing entries', () => {
+    const merged = prependPathEntries('/usr/bin:/bin', ['/Users/test/.npm-global/bin', '/usr/bin'])
+    expect(merged.startsWith('/Users/test/.npm-global/bin')).toBe(true)
+    expect(merged).toContain('/usr/bin')
+    expect(merged).toContain('/bin')
+    expect(merged.split(delimiter).filter(entry => entry === '/usr/bin')).toHaveLength(1)
+  })
+
+  it('includes npm-global and local bin in default prefix list', () => {
+    const prefixes = mcpCliPathPrefixes('/Users/test')
+    expect(prefixes).toContain('/Users/test/.npm-global/bin')
+    expect(prefixes).toContain('/Users/test/.local/bin')
+  })
+
+  it('augments a stripped desktop-style PATH for MCP stdio commands', () => {
+    const env = { PATH: '/usr/local/bin:/usr/bin:/bin' }
+    const augmented = augmentBridgePath(env, '/Users/test')
+    expect(augmented).toContain('/Users/test/.npm-global/bin')
+    expect(augmented).toContain('/usr/bin')
+  })
+
+  it('buildAgentBridgeProcessEnv injects augmented PATH for bridge workers', () => {
+    const previousPath = process.env.PATH
+    process.env.PATH = '/usr/local/bin:/usr/bin:/bin'
+    try {
+      const env = buildAgentBridgeProcessEnv('ipc:///tmp/hermes-agent-bridge.sock', '/Users/test/.hermes', undefined)
+      expect(env.PATH).toContain(join(homedir(), '.npm-global', 'bin'))
+      expect(env.PATH).toContain('/usr/bin')
+      expect(env.HERMES_AGENT_BRIDGE_ENDPOINT).toBe('ipc:///tmp/hermes-agent-bridge.sock')
+      expect(env.HERMES_HOME).toBe('/Users/test/.hermes')
+    } finally {
+      process.env.PATH = previousPath
+    }
+  })
+})

--- a/tests/server/agent-bridge-process-env.test.ts
+++ b/tests/server/agent-bridge-process-env.test.ts
@@ -1,6 +1,8 @@
+import { execFileSync } from 'child_process'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { homedir, tmpdir } from 'os'
 import { delimiter, join } from 'path'
-import { homedir } from 'os'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   augmentBridgePath,
   mcpCliPathPrefixes,
@@ -8,7 +10,16 @@ import {
 } from '../../packages/server/src/services/hermes/agent-bridge/bridge-path'
 import { buildAgentBridgeProcessEnv } from '../../packages/server/src/services/hermes/agent-bridge/manager'
 
+function assignBridgePath(env: NodeJS.ProcessEnv, homeDir = homedir(), options = {}): NodeJS.ProcessEnv {
+  const pathKey = Object.keys(env).find(key => key.toLowerCase() === 'path') || 'PATH'
+  return { ...env, [pathKey]: augmentBridgePath(env, homeDir, options) }
+}
+
 describe('agent bridge PATH augmentation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('prepends MCP CLI prefixes without dropping existing entries', () => {
     const merged = prependPathEntries('/usr/bin:/bin', ['/Users/test/.npm-global/bin', '/usr/bin'])
     expect(merged.startsWith('/Users/test/.npm-global/bin')).toBe(true)
@@ -17,17 +28,108 @@ describe('agent bridge PATH augmentation', () => {
     expect(merged.split(delimiter).filter(entry => entry === '/usr/bin')).toHaveLength(1)
   })
 
+  it('joins Windows-style PATH segments with semicolons', () => {
+    const merged = prependPathEntries(
+      'C:\\Windows\\System32;C:\\Windows',
+      ['C:\\Users\\test\\AppData\\Roaming\\npm'],
+      ';',
+    )
+    expect(merged).toContain('C:\\Users\\test\\AppData\\Roaming\\npm')
+    expect(merged).toContain('C:\\Windows\\System32')
+    expect(merged.split(';').filter(entry => entry === 'C:\\Windows\\System32')).toHaveLength(1)
+  })
+
   it('includes npm-global and local bin in default prefix list', () => {
-    const prefixes = mcpCliPathPrefixes('/Users/test')
+    const prefixes = mcpCliPathPrefixes('/Users/test', { resolveNpmGlobalBin: () => undefined })
+    expect(prefixes).toContain('/Users/test/.npm-global/bin')
+    expect(prefixes).toContain('/Users/test/.local/bin')
+  })
+
+  it('adds Homebrew paths only on darwin', () => {
+    const darwinPrefixes = mcpCliPathPrefixes('/Users/test', {
+      platform: 'darwin',
+      resolveNpmGlobalBin: () => undefined,
+    })
+    expect(darwinPrefixes).toContain('/opt/homebrew/bin')
+    expect(darwinPrefixes).toContain('/usr/local/bin')
+
+    const linuxPrefixes = mcpCliPathPrefixes('/Users/test', {
+      platform: 'linux',
+      resolveNpmGlobalBin: () => undefined,
+    })
+    expect(linuxPrefixes).not.toContain('/opt/homebrew/bin')
+  })
+
+  it('uses npm global prefix directly on win32', () => {
+    const prefixes = mcpCliPathPrefixes('C:\\Users\\test', {
+      platform: 'win32',
+      resolveNpmGlobalBin: () => 'C:\\Users\\test\\AppData\\Roaming\\npm',
+    })
+    expect(prefixes).toContain('C:\\Users\\test\\AppData\\Roaming\\npm')
+    expect(prefixes).not.toContain('C:\\Users\\test\\AppData\\Roaming\\npm\\bin')
+  })
+
+  it('skips npm global bin gracefully when npm is unavailable', () => {
+    const prefixes = mcpCliPathPrefixes('/Users/test', { resolveNpmGlobalBin: () => undefined })
+    expect(prefixes.every(entry => typeof entry === 'string' && entry.length > 0)).toBe(true)
     expect(prefixes).toContain('/Users/test/.npm-global/bin')
     expect(prefixes).toContain('/Users/test/.local/bin')
   })
 
   it('augments a stripped desktop-style PATH for MCP stdio commands', () => {
     const env = { PATH: '/usr/local/bin:/usr/bin:/bin' }
-    const augmented = augmentBridgePath(env, '/Users/test')
+    const augmented = augmentBridgePath(env, '/Users/test', { resolveNpmGlobalBin: () => undefined })
     expect(augmented).toContain('/Users/test/.npm-global/bin')
     expect(augmented).toContain('/usr/bin')
+  })
+
+  it('handles missing or empty PATH without stray delimiters', () => {
+    const fromEmptyObject = augmentBridgePath({}, '/Users/test', { resolveNpmGlobalBin: () => undefined })
+    expect(fromEmptyObject).toContain('/Users/test/.npm-global/bin')
+    expect(fromEmptyObject).not.toMatch(new RegExp(`^${delimiter}|${delimiter}$`))
+
+    const fromEmptyString = augmentBridgePath({ PATH: '' }, '/Users/test', { resolveNpmGlobalBin: () => undefined })
+    expect(fromEmptyString).toContain('/Users/test/.npm-global/bin')
+    expect(fromEmptyString).not.toMatch(new RegExp(`^${delimiter}|${delimiter}$`))
+  })
+
+  it('preserves Windows-style Path key without creating a duplicate PATH key', () => {
+    const homeDir = 'C:\\Users\\test'
+    const env: NodeJS.ProcessEnv = { Path: 'C:\\Windows\\System32' }
+    const updated = assignBridgePath(env, homeDir, {
+      platform: 'win32',
+      resolveNpmGlobalBin: () => undefined,
+    })
+
+    expect(updated.Path).toContain(join(homeDir, '.npm-global', 'bin'))
+    expect(updated.Path).toContain('C:\\Windows\\System32')
+    expect(updated.PATH).toBeUndefined()
+  })
+
+  it('resolves a prepended MCP CLI on unix after augmentation', () => {
+    if (process.platform === 'win32') return
+
+    const homeDir = mkdtempSync(join(tmpdir(), 'hermes-bridge-path-'))
+    const cliName = `hermes-mcp-probe-${process.pid}`
+    try {
+      const npmGlobalBin = join(homeDir, '.npm-global', 'bin')
+      mkdirSync(npmGlobalBin, { recursive: true })
+      const cliPath = join(npmGlobalBin, cliName)
+      writeFileSync(cliPath, '#!/bin/sh\nexit 0\n')
+      chmodSync(cliPath, 0o755)
+
+      const augmented = augmentBridgePath({ PATH: '/usr/bin:/bin' }, homeDir, {
+        resolveNpmGlobalBin: () => undefined,
+      })
+      const resolved = execFileSync('which', [cliName], {
+        encoding: 'utf-8',
+        env: { PATH: augmented },
+      }).trim()
+
+      expect(resolved).toBe(cliPath)
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true })
+    }
   })
 
   it('buildAgentBridgeProcessEnv injects augmented PATH for bridge workers', () => {


### PR DESCRIPTION
## Summary

- Prepend common MCP CLI install directories to the agent bridge child `PATH` when `buildAgentBridgeProcessEnv()` runs, so Hermes Studio can resolve stdio MCP commands such as `codegraph` without absolute paths in `~/.hermes/config.yaml`.
- Add `bridge-path.ts` with deduplicating PATH merge logic (Node bin dir, npm global `bin`, `~/.npm-global/bin`, `~/.local/bin`, Homebrew paths on macOS).
- Expand Vitest coverage for win32 delimiter/`Path` key handling, npm-unavailable fallback, empty PATH, and unix CLI resolution via `which`.

## Why

Desktop/GUI runtimes spawn the Python agent bridge with a stripped `PATH`. MCP stdio servers read `command` from profile config and fail with `ENOENT` even when the same CLI works in an interactive terminal.

## Impact

- **Users:** npm-global MCP CLIs (e.g. CodeGraph) can use short command names in Hermes Studio after upgrade.
- **Developers:** Focused server tests under `tests/server/agent-bridge-process-env.test.ts` (11) plus PATH assertions in `agent-bridge-manager.test.ts`.

## Validation

- `npm run test:coverage`
- `npm run build`
- `npx vitest run tests/server/agent-bridge-process-env.test.ts tests/server/agent-bridge-manager.test.ts` (18 passed)
- **pr-test-analyzer (re-audit):** PASS — prior gaps closed

## Known limitations

- Bridge PATH does not yet mirror `coding-agents.ts` NVM bins for `HERMES_DESKTOP`; follow-up if reported.
- Manual: Studio with `mcp_servers.codegraph.command: codegraph` after release.