### PR TITLE
[codex] hide desktop Python subprocesses on login

### DIFF
--- a/packages/desktop/scripts/apply-hermes-patches.mjs
+++ b/packages/desktop/scripts/apply-hermes-patches.mjs
@@ -194,15 +194,76 @@ except Exception:
     pass
 `
 
-const sitecustomize = existsSync(sitecustomizePath) ? readFileSync(sitecustomizePath, 'utf-8') : ''
-if (sitecustomize.includes(brotlicffiCompatMarker)) {
-  console.log('  · brotlicffi-error-compat  (already applied)')
-  skipped++
-} else {
-  const nextSitecustomize = `${sitecustomize.replace(/\s*$/, '')}\n${brotlicffiCompat.trim()}\n`
+const desktopHiddenSubprocessMarker = '# patch:desktop-hidden-subprocess-defaults'
+const desktopHiddenSubprocessDefaults = `
+${desktopHiddenSubprocessMarker}
+try:
+    import os as _hermes_os
+    if _hermes_os.name == "nt" and _hermes_os.environ.get("HERMES_DESKTOP", "").strip().lower() == "true":
+        import asyncio as _hermes_asyncio
+        import subprocess as _hermes_subprocess
+        if not getattr(_hermes_subprocess, "_hermes_desktop_hidden_defaults_installed", False):
+            _hermes_create_no_window = getattr(_hermes_subprocess, "CREATE_NO_WINDOW", 0) or 0x08000000
+
+            def _hermes_apply_hidden_process_options(kwargs):
+                flags = kwargs.get("creationflags", 0) or 0
+                try:
+                    kwargs["creationflags"] = int(flags) | _hermes_create_no_window
+                except Exception:
+                    kwargs["creationflags"] = _hermes_create_no_window
+
+                startupinfo = kwargs.get("startupinfo")
+                if startupinfo is None:
+                    try:
+                        startupinfo = _hermes_subprocess.STARTUPINFO()
+                    except Exception:
+                        return
+                    kwargs["startupinfo"] = startupinfo
+                try:
+                    startupinfo.dwFlags |= getattr(_hermes_subprocess, "STARTF_USESHOWWINDOW", 1)
+                    startupinfo.wShowWindow = getattr(_hermes_subprocess, "SW_HIDE", 0)
+                except Exception:
+                    pass
+
+            _hermes_original_popen = _hermes_subprocess.Popen
+            _hermes_original_create_subprocess_exec = _hermes_asyncio.create_subprocess_exec
+            _hermes_original_create_subprocess_shell = _hermes_asyncio.create_subprocess_shell
+
+            class _HermesHiddenPopen(_hermes_original_popen):
+                def __init__(self, *args, **kwargs):
+                    _hermes_apply_hidden_process_options(kwargs)
+                    super().__init__(*args, **kwargs)
+
+            async def _hermes_hidden_create_subprocess_exec(*args, **kwargs):
+                _hermes_apply_hidden_process_options(kwargs)
+                return await _hermes_original_create_subprocess_exec(*args, **kwargs)
+
+            async def _hermes_hidden_create_subprocess_shell(*args, **kwargs):
+                _hermes_apply_hidden_process_options(kwargs)
+                return await _hermes_original_create_subprocess_shell(*args, **kwargs)
+
+            _hermes_subprocess.Popen = _HermesHiddenPopen
+            _hermes_asyncio.create_subprocess_exec = _hermes_hidden_create_subprocess_exec
+            _hermes_asyncio.create_subprocess_shell = _hermes_hidden_create_subprocess_shell
+            _hermes_subprocess._hermes_desktop_hidden_defaults_installed = True
+except Exception:
+    pass
+`
+
+function appendSitecustomizePatch(id, marker, body) {
+  const sitecustomize = existsSync(sitecustomizePath) ? readFileSync(sitecustomizePath, 'utf-8') : ''
+  if (sitecustomize.includes(marker)) {
+    console.log(`  · ${id}  (already applied)`)
+    skipped++
+    return
+  }
+  const nextSitecustomize = `${sitecustomize.replace(/\s*$/, '')}\n${body.trim()}\n`
   writeFileSync(sitecustomizePath, nextSitecustomize)
-  console.log('  ✓ brotlicffi-error-compat')
+  console.log(`  ✓ ${id}`)
   applied++
 }
+
+appendSitecustomizePatch('brotlicffi-error-compat', brotlicffiCompatMarker, brotlicffiCompat)
+appendSitecustomizePatch('desktop-hidden-subprocess-defaults', desktopHiddenSubprocessMarker, desktopHiddenSubprocessDefaults)
 
 console.log(`Done. Applied ${applied}, skipped ${skipped}.`)


### PR DESCRIPTION
## Summary
- extend the bundled Python sitecustomize patch with desktop-only hidden subprocess defaults
- apply CREATE_NO_WINDOW and STARTUPINFO/SW_HIDE to subprocess.Popen and asyncio subprocess helpers
- keep the behavior gated behind HERMES_DESKTOP=true so npm/CLI runs are unaffected
- preserve the existing brotlicffi compatibility patch while allowing multiple sitecustomize patches to be appended idempotently

## Root Cause
The bridge worker popup fix only runs inside hermes_bridge.py. During Windows login/startup, gateway autostart and Hermes CLI code can run in separate bundled Python processes before bridge workers are involved. Those Python processes inherit HERMES_DESKTOP=true but did not have a global child-process hiding shim, so any nested console executable could still flash a Python/console window.

## Validation
- HERMES_AGENT_SITE_PACKAGES=<temp> node packages/desktop/scripts/apply-hermes-patches.mjs
- npm --prefix packages/desktop run build
- npm run harness:check
- git diff --check