### PR TITLE
[codex] use standard Hermes home for desktop

### DIFF
--- a/packages/desktop/src/main/paths.ts
+++ b/packages/desktop/src/main/paths.ts
@@ -72,11 +72,6 @@ export function hermesHome(): string {
   const override = process.env.HERMES_HOME?.trim()
   if (override) return resolve(override)
 
-  if (isWin) {
-    const localAppData = process.env.LOCALAPPDATA?.trim() || process.env.APPDATA?.trim()
-    if (localAppData) return resolve(localAppData, 'hermes')
-  }
-
   return resolve(homedir(), '.hermes')
 }
 

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -278,8 +278,8 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     // HERMES_HOME/.env or by configuring per-platform allowlists.
     GATEWAY_ALLOW_ALL_USERS: process.env.GATEWAY_ALLOW_ALL_USERS ?? 'true',
     // Keep the bundled Hermes Agent, bridge, gateway, and Web UI path helpers
-    // on the same data directory. Native Windows uses %LOCALAPPDATA%\hermes;
-    // macOS/Linux keep the standard ~/.hermes layout.
+    // on the same Agent data directory. Desktop uses HERMES_HOME when set,
+    // otherwise the standard ~/.hermes layout on every platform.
     HERMES_HOME: agentHome,
     HERMES_WEB_UI_HOME: home,
     HERMES_WEBUI_STATE_DIR: home,


### PR DESCRIPTION
## Summary
- Use the standard `~/.hermes` Agent home fallback for desktop on every platform when `HERMES_HOME` is not set.
- Update the desktop server comment so it no longer claims Windows defaults to `%LOCALAPPDATA%\hermes`.

## Why
The desktop wrapper already passes `HERMES_HOME` into the bundled Web UI server. With the previous Windows-specific branch, clean Windows installs used `%LOCALAPPDATA%\hermes` while macOS/Linux used `~/.hermes`, which made desktop Agent state placement inconsistent across platforms.

## Impact
Windows desktop installs now align with the standard Hermes Agent home layout unless the user explicitly sets `HERMES_HOME`.

## Validation
- `npm run build:main --prefix packages/desktop`
- `npm run harness:check`