### PR TITLE
[codex] bundle Hermes desktop browser runtime

### DIFF
--- a/packages/desktop/scripts/install-hermes.mjs
+++ b/packages/desktop/scripts/install-hermes.mjs
@@ -1,7 +1,17 @@
 #!/usr/bin/env node
 // Install hermes-agent into the bundled Python at resources/python/<os>-<arch>/.
 // Prefers `uv` (10-100x faster, more deterministic) and falls back to pip.
-import { existsSync } from 'node:fs'
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
@@ -12,11 +22,19 @@ const ROOT = resolve(__dirname, '..')
 
 const TARGET_OS = process.env.TARGET_OS || osPlatform()
 const TARGET_ARCH = process.env.TARGET_ARCH || osArch()
-const HERMES_VERSION = process.env.HERMES_VERSION || '0.15.1'
+const HERMES_VERSION = process.env.HERMES_VERSION || '0.15.2'
 const HERMES_PACKAGE = process.env.HERMES_PACKAGE || `hermes-agent[mcp]==${HERMES_VERSION}`
+const EXTRA_PYTHON_PACKAGES = splitPackageList(process.env.HERMES_EXTRA_PYTHON_PACKAGES || 'websockets')
+const BROWSER_PACKAGES = splitPackageList(
+  process.env.HERMES_BROWSER_PACKAGES || 'agent-browser@^0.26.0 @askjo/camofox-browser@^1.5.2',
+)
+const SKIP_BROWSER_RUNTIME = process.env.HERMES_SKIP_BROWSER_RUNTIME === '1'
+  || process.env.HERMES_SKIP_BROWSER_RUNTIME?.toLowerCase() === 'true'
 
 const OS_LABEL = TARGET_OS === 'win32' ? 'win' : TARGET_OS === 'darwin' ? 'mac' : TARGET_OS
 const PY_DIR = resolve(ROOT, 'resources', 'python', `${OS_LABEL}-${TARGET_ARCH}`)
+const NODE_PREFIX = resolve(PY_DIR, 'node')
+const PLAYWRIGHT_BROWSERS_PATH = resolve(PY_DIR, 'ms-playwright')
 
 const pyBin = TARGET_OS === 'win32'
   ? resolve(PY_DIR, 'python.exe')
@@ -32,33 +50,154 @@ function hasUv() {
   return r.status === 0
 }
 
-let r
-if (hasUv()) {
-  console.log(`→ Installing ${HERMES_PACKAGE} via uv`)
-  r = spawnSync('uv', [
+function splitPackageList(value) {
+  return value
+    .split(/[,\s]+/)
+    .map(part => part.trim())
+    .filter(Boolean)
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { stdio: 'inherit', ...options })
+  if (result.status !== 0) process.exit(result.status ?? 1)
+  return result
+}
+
+function optionalRun(command, args, options = {}) {
+  return spawnSync(command, args, { stdio: 'inherit', ...options })
+}
+
+function installPythonPackages(packages, label) {
+  if (packages.length === 0) return
+  if (hasUv()) {
+    console.log(`→ Installing ${label} via uv: ${packages.join(' ')}`)
+    run('uv', [
     'pip', 'install',
     '--python', pyBin,
-    HERMES_PACKAGE,
-  ], { stdio: 'inherit' })
-} else {
-  console.log(`→ Installing ${HERMES_PACKAGE} via pip`)
-  r = spawnSync(pyBin, [
-    '-m', 'pip', 'install',
-    HERMES_PACKAGE,
-    '--no-warn-script-location',
-    '--disable-pip-version-check',
-  ], { stdio: 'inherit' })
+      ...packages,
+    ])
+  } else {
+    console.log(`→ Installing ${label} via pip: ${packages.join(' ')}`)
+    run(pyBin, [
+      '-m', 'pip', 'install',
+      ...packages,
+      '--no-warn-script-location',
+      '--disable-pip-version-check',
+    ])
+  }
 }
-if (r.status !== 0) process.exit(r.status ?? 1)
 
-r = spawnSync(pyBin, [
-  '-c',
-  'import mcp; import tools.mcp_tool as t; assert t._MCP_AVAILABLE',
-], { stdio: 'inherit' })
-if (r.status !== 0) {
-  console.error('MCP Python SDK sanity check failed')
-  process.exit(r.status ?? 1)
+function npmCommand() {
+  const candidates = TARGET_OS === 'win32'
+    ? ['npm.cmd', 'npm.exe', 'npm']
+    : ['npm']
+  for (const candidate of candidates) {
+    const result = optionalRun(candidate, ['--version'], { stdio: 'ignore' })
+    if (result.status === 0) return candidate
+  }
+  return null
 }
+
+function agentBrowserCommand() {
+  if (TARGET_OS === 'win32') {
+    return resolve(NODE_PREFIX, 'agent-browser.cmd')
+  }
+  return resolve(NODE_PREFIX, 'bin', 'agent-browser')
+}
+
+function browserRuntimeEnv() {
+  const nodePath = TARGET_OS === 'win32'
+    ? NODE_PREFIX
+    : resolve(NODE_PREFIX, 'bin')
+  return {
+    ...process.env,
+    PATH: [nodePath, process.env.PATH].filter(Boolean).join(TARGET_OS === 'win32' ? ';' : ':'),
+    PLAYWRIGHT_BROWSERS_PATH,
+  }
+}
+
+function sitePackagesDir() {
+  if (TARGET_OS === 'win32') {
+    return resolve(PY_DIR, 'Lib', 'site-packages')
+  }
+  const libDir = resolve(PY_DIR, 'lib')
+  const py = readdirSync(libDir).find(n => /^python\d+\.\d+$/.test(n))
+  if (!py) throw new Error(`Could not locate pythonX.Y under ${libDir}`)
+  return resolve(libDir, py, 'site-packages')
+}
+
+function pythonModuleExists(moduleName) {
+  const result = optionalRun(pyBin, [
+    '-c',
+    `import importlib.util, sys; sys.exit(0 if importlib.util.find_spec(${JSON.stringify(moduleName)}) else 1)`,
+  ], { stdio: 'ignore' })
+  return result.status === 0
+}
+
+function removeBrokenDashboardAuthPlugin() {
+  if (pythonModuleExists('hermes_cli.dashboard_auth')) return
+
+  const pluginDir = resolve(sitePackagesDir(), 'plugins', 'dashboard_auth', 'nous')
+  if (!existsSync(pluginDir)) return
+
+  rmSync(pluginDir, { recursive: true, force: true })
+  console.warn(
+    '! Removed bundled dashboard_auth/nous plugin because hermes_cli.dashboard_auth is missing from the hermes-agent package',
+  )
+}
+
+function installBrowserRuntime() {
+  if (SKIP_BROWSER_RUNTIME) {
+    console.warn('! Skipping bundled browser runtime because HERMES_SKIP_BROWSER_RUNTIME is set')
+    return
+  }
+  if (BROWSER_PACKAGES.length === 0) {
+    console.warn('! Skipping bundled browser runtime because HERMES_BROWSER_PACKAGES is empty')
+    return
+  }
+
+  const npm = npmCommand()
+  if (!npm) {
+    console.error('npm not found; bundled browser runtime requires Node.js/npm')
+    process.exit(1)
+  }
+
+  console.log(`→ Installing browser runtime via npm prefix ${NODE_PREFIX}`)
+  run(npm, [
+    'install',
+    '-g',
+    '--prefix',
+    NODE_PREFIX,
+    '--silent',
+    '--ignore-scripts',
+    ...BROWSER_PACKAGES,
+  ])
+
+  const ab = agentBrowserCommand()
+  if (!existsSync(ab)) {
+    console.error(`agent-browser binary not found at ${ab} after npm install`)
+    process.exit(1)
+  }
+
+  console.log(`→ Installing Chromium for bundled agent-browser at ${PLAYWRIGHT_BROWSERS_PATH}`)
+  run(ab, ['install'], { env: browserRuntimeEnv() })
+}
+
+installPythonPackages([HERMES_PACKAGE], 'hermes-agent')
+installPythonPackages(EXTRA_PYTHON_PACKAGES, 'extra Python runtime packages')
+removeBrokenDashboardAuthPlugin()
+installBrowserRuntime()
+
+run(pyBin, [
+  '-c',
+  [
+    'import importlib.util',
+    'import mcp',
+    'import tools.mcp_tool as t',
+    'assert t._MCP_AVAILABLE',
+    'assert importlib.util.find_spec("websockets") is not None',
+  ].join('; '),
+])
 
 const hermesBin = TARGET_OS === 'win32'
   ? resolve(PY_DIR, 'Scripts', 'hermes.exe')
@@ -76,14 +215,11 @@ if (!existsSync(hermesBin)) {
 // it at the venv root with a *relative* symlink so the venv stays portable when copied
 // into the packaged .app/.exe (an absolute symlink would break the moment the bundle
 // is moved to /Applications/...).
-const { readdirSync, symlinkSync, copyFileSync, unlinkSync, lstatSync } = await import('node:fs')
 function siteRunAgentRelative() {
   if (TARGET_OS === 'win32') {
     return ['Lib', 'site-packages', 'run_agent.py'].join('\\')
   }
-  const libDir = resolve(PY_DIR, 'lib')
-  const py = readdirSync(libDir).find(n => /^python\d+\.\d+$/.test(n))
-  return ['lib', py, 'site-packages', 'run_agent.py'].join('/')
+  return `${sitePackagesDir().slice(PY_DIR.length + 1)}/run_agent.py`
 }
 {
   const relSrc = siteRunAgentRelative()
@@ -102,7 +238,6 @@ function siteRunAgentRelative() {
 // Relocate: replace the pip-generated launcher (which embeds an absolute
 // shebang to the build-time Python path) with a relative wrapper so the
 // bundled venv works after being moved into the .app/.exe payload.
-const { writeFileSync, chmodSync } = await import('node:fs')
 if (TARGET_OS === 'win32') {
   // Windows: pip generates a .exe launcher that embeds a relative shebang
   // already. Add a .cmd wrapper that prefers the colocated python.exe.
@@ -139,8 +274,19 @@ if (TARGET_OS === 'win32') {
 
 console.log(`✓ hermes installed at ${hermesBin} (relocatable launcher)`)
 
-r = spawnSync(hermesCheckCommand, hermesCheckArgs, { stdio: 'inherit' })
-if (r.status !== 0) {
-  console.error('hermes --version failed')
-  process.exit(r.status ?? 1)
+run(hermesCheckCommand, hermesCheckArgs)
+
+if (!SKIP_BROWSER_RUNTIME) {
+  run(pyBin, [
+    '-c',
+    [
+      'import os, shutil',
+      `os.environ["PLAYWRIGHT_BROWSERS_PATH"] = ${JSON.stringify(PLAYWRIGHT_BROWSERS_PATH)}`,
+      'from tools.browser_tool import _chromium_installed',
+      'assert shutil.which("agent-browser") is not None',
+      'assert _chromium_installed()',
+    ].join('; '),
+  ], { env: browserRuntimeEnv() })
 }
+
+console.log('✓ hermes Python, MCP, websockets, agent-browser, and Chromium checks passed')

--- a/packages/desktop/scripts/install-hermes.mjs
+++ b/packages/desktop/scripts/install-hermes.mjs
@@ -12,7 +12,7 @@ const ROOT = resolve(__dirname, '..')
 
 const TARGET_OS = process.env.TARGET_OS || osPlatform()
 const TARGET_ARCH = process.env.TARGET_ARCH || osArch()
-const HERMES_VERSION = process.env.HERMES_VERSION || '0.15.2'
+const HERMES_VERSION = process.env.HERMES_VERSION || '0.15.1'
 const HERMES_PACKAGE = process.env.HERMES_PACKAGE || `hermes-agent[mcp]==${HERMES_VERSION}`
 
 const OS_LABEL = TARGET_OS === 'win32' ? 'win' : TARGET_OS === 'darwin' ? 'mac' : TARGET_OS

--- a/packages/desktop/src/main/paths.ts
+++ b/packages/desktop/src/main/paths.ts
@@ -63,12 +63,23 @@ export function hermesHome(): string {
   const override = process.env.HERMES_HOME?.trim()
   if (override) return resolve(override)
 
+  const defaultHome = resolve(homedir(), '.hermes')
+
   if (isWin) {
-    const localAppData = process.env.LOCALAPPDATA?.trim() || process.env.APPDATA?.trim()
-    if (localAppData) return resolve(localAppData, 'hermes')
+    const candidates = [
+      process.env.LOCALAPPDATA,
+      process.env.APPDATA,
+    ]
+      .map(value => value?.trim())
+      .filter((value): value is string => !!value)
+      .map(value => resolve(value, 'hermes'))
+
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) return candidate
+    }
   }
 
-  return resolve(homedir(), '.hermes')
+  return defaultHome
 }
 
 export function tokenFile(): string {

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -287,12 +287,16 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
   const bundledPython = isWin
     ? join(pythonDir(), 'python.exe')
     : join(pythonDir(), 'bin', 'python3')
+  const bundledNodeBin = isWin
+    ? join(pythonDir(), 'node')
+    : join(pythonDir(), 'node', 'bin')
   const bridgePort = await getFreeTcpPort()
   const workerPortBase = await getFreeTcpPortInRange(20000, 59000)
   const loginShellPath = await getLoginShellPath()
   const nvmNodeBinPaths = getNvmNodeBinPaths()
   const runtimePath = mergePathEntries(
     dirname(hermesBin()),
+    bundledNodeBin,
     loginShellPath,
     nvmNodeBinPaths,
     process.env.PATH,
@@ -312,6 +316,7 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     HERMES_AGENT_BRIDGE_PYTHON: bundledPython,
     HERMES_AGENT_CLI_PYTHON: bundledPython,
     HERMES_AGENT_ROOT: pythonDir(),
+    PLAYWRIGHT_BROWSERS_PATH: process.env.PLAYWRIGHT_BROWSERS_PATH || join(pythonDir(), 'ms-playwright'),
     // Force TCP loopback for the agent bridge. The default `ipc:///tmp/...`
     // unix socket is rejected on macOS in some EDR/sandbox setups (silent
     // SIGKILL of the bridge child within ~150ms). TCP on 127.0.0.1 works

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -10,6 +10,8 @@ import { webuiServerEntry, webuiDir, hermesBin, webUiHome, hermesHome, tokenFile
 
 const DEFAULT_PORT = 8748
 const DEFAULT_READY_TIMEOUT_MS = 30_000
+const AGENT_BRIDGE_STARTED_MARKER = '[bootstrap] agent bridge started'
+const AGENT_BRIDGE_FAILED_MARKER = '[bootstrap] agent bridge failed to start'
 const execFileAsync = promisify(execFile)
 
 let serverProc: ChildProcess | null = null
@@ -45,6 +47,60 @@ function envPositiveInt(name: string): number | undefined {
 
 function readyTimeoutMs(): number {
   return envPositiveInt('HERMES_DESKTOP_READY_TIMEOUT_MS') || DEFAULT_READY_TIMEOUT_MS
+}
+
+function createAgentBridgeStartupTracker(): {
+  observe: (chunk: Buffer) => void
+  wait: (timeoutMs: number) => Promise<void>
+} {
+  let output = ''
+  let state: 'pending' | 'started' | 'failed' = 'pending'
+  let resolveReady: (() => void) | null = null
+  let rejectReady: ((err: Error) => void) | null = null
+
+  const settle = (nextState: 'started' | 'failed') => {
+    if (state !== 'pending') return
+    state = nextState
+    if (nextState === 'started') {
+      resolveReady?.()
+    } else {
+      rejectReady?.(new Error('Agent bridge failed to start'))
+    }
+  }
+
+  const observe = (chunk: Buffer) => {
+    if (state !== 'pending') return
+    output = (output + chunk.toString('utf-8')).slice(-4096)
+    if (output.includes(AGENT_BRIDGE_STARTED_MARKER)) {
+      settle('started')
+    } else if (output.includes(AGENT_BRIDGE_FAILED_MARKER)) {
+      settle('failed')
+    }
+  }
+
+  const wait = (timeoutMs: number) => {
+    if (state === 'started') return Promise.resolve()
+    if (state === 'failed') return Promise.reject(new Error('Agent bridge failed to start'))
+
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (state !== 'pending') return
+        state = 'failed'
+        reject(new Error(`Agent bridge did not become ready within ${timeoutMs}ms`))
+      }, timeoutMs)
+
+      resolveReady = () => {
+        clearTimeout(timer)
+        resolve()
+      }
+      rejectReady = (err) => {
+        clearTimeout(timer)
+        reject(err)
+      }
+    })
+  }
+
+  return { observe, wait }
 }
 
 function ensureToken(): string {
@@ -261,6 +317,10 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     // SIGKILL of the bridge child within ~150ms). TCP on 127.0.0.1 works
     // identically and avoids the issue cross-platform.
     HERMES_AGENT_BRIDGE_ENDPOINT: `tcp://127.0.0.1:${bridgePort}`,
+    // Desktop opens the UI as soon as the Web UI HTTP server is ready, while
+    // the Python bridge starts in the background. Let the first chat/context
+    // request wait for broker readiness instead of failing during cold start.
+    HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS: process.env.HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS ?? '120000',
     // Force TCP for worker endpoints too (upstream #1106). Same EDR/sandbox
     // reason as above — default ipc:// unix sockets in /tmp get killed.
     HERMES_AGENT_BRIDGE_WORKER_TRANSPORT: 'tcp',
@@ -278,8 +338,9 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     // HERMES_HOME/.env or by configuring per-platform allowlists.
     GATEWAY_ALLOW_ALL_USERS: process.env.GATEWAY_ALLOW_ALL_USERS ?? 'true',
     // Keep the bundled Hermes Agent, bridge, gateway, and Web UI path helpers
-    // on the same data directory. Native Windows uses %LOCALAPPDATA%\hermes;
-    // macOS/Linux keep the standard ~/.hermes layout.
+    // on the same data directory. Native Windows uses an existing
+    // %LOCALAPPDATA%\hermes or %APPDATA%\hermes; otherwise all platforms keep
+    // the standard ~/.hermes layout.
     HERMES_HOME: agentHome,
     HERMES_WEB_UI_HOME: home,
     HERMES_WEBUI_STATE_DIR: home,
@@ -295,10 +356,14 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     windowsHide: true,
   })
 
+  const bridgeStartup = createAgentBridgeStartupTracker()
+
   serverProc.stdout?.on('data', (chunk: Buffer) => {
+    bridgeStartup.observe(chunk)
     process.stdout.write(`[webui] ${chunk}`)
   })
   serverProc.stderr?.on('data', (chunk: Buffer) => {
+    bridgeStartup.observe(chunk)
     process.stderr.write(`[webui] ${chunk}`)
   })
   serverProc.on('exit', (code, signal) => {
@@ -309,7 +374,11 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     }
   })
 
-  await waitForReady(port, readyTimeoutMs())
+  const timeoutMs = readyTimeoutMs()
+  await Promise.all([
+    waitForReady(port, timeoutMs),
+    bridgeStartup.wait(timeoutMs),
+  ])
   return getServerUrl(port)
 }
 

--- a/packages/server/src/controllers/hermes/logs.ts
+++ b/packages/server/src/controllers/hermes/logs.ts
@@ -23,6 +23,7 @@ function appendPinoContext(message: string, obj: any): string {
     parts.push(`profile=${obj.profile}`)
   }
   if (obj.request?.action) parts.push(`action=${obj.request.action}`)
+  if (obj.err?.message) parts.push(`error=${obj.err.message}`)
   if (obj.sessionId) parts.push(`session=${obj.sessionId}`)
   if (obj.runId) parts.push(`run=${obj.runId}`)
   if (obj.status) parts.push(`status=${obj.status}`)

--- a/packages/server/src/services/hermes/hermes-path.ts
+++ b/packages/server/src/services/hermes/hermes-path.ts
@@ -2,11 +2,12 @@
  * Hermes 路径检测工具 - 跨平台兼容
  *
  * Hermes 数据目录在不同平台上的位置：
- * - Windows 原生安装: %LOCALAPPDATA%\hermes
+ * - Windows 原生安装: %LOCALAPPDATA%\hermes when it exists
  * - Linux/macOS/WSL2: ~/.hermes
  * - 用户自定义: HERMES_HOME 环境变量
  */
 
+import { existsSync } from 'fs'
 import { basename, dirname, isAbsolute, relative, resolve, join } from 'path'
 import { homedir } from 'os'
 
@@ -15,7 +16,7 @@ import { homedir } from 'os'
  *
  * 检测优先级：
  * 1. HERMES_HOME 环境变量（用户自定义）
- * 2. Windows: %LOCALAPPDATA%\hermes（原生安装）
+ * 2. Windows: existing %LOCALAPPDATA%\hermes or %APPDATA%\hermes
  * 3. 默认: ~/.hermes（Linux/macOS/WSL2）
  *
  * @returns Hermes 数据目录的绝对路径
@@ -26,16 +27,25 @@ export function detectHermesHome(): string {
     return resolve(process.env.HERMES_HOME)
   }
 
-  // 2. Windows：直接使用 %LOCALAPPDATA%\hermes
+  const defaultHome = resolve(homedir(), '.hermes')
+
+  // 2. Windows：优先使用存在的原生安装数据目录；不存在时回退到 ~/.hermes。
   if (process.platform === 'win32') {
-    const localAppData = process.env.LOCALAPPDATA || process.env.APPDATA
-    if (localAppData) {
-      return join(localAppData, 'hermes')
+    const candidates = [
+      process.env.LOCALAPPDATA,
+      process.env.APPDATA,
+    ]
+      .map(value => value?.trim())
+      .filter((value): value is string => !!value)
+      .map(value => resolve(value, 'hermes'))
+
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) return candidate
     }
   }
 
   // 3. Linux/macOS：~/.hermes
-  return resolve(homedir(), '.hermes')
+  return defaultHome
 }
 
 /**

--- a/scripts/harness-check.mjs
+++ b/scripts/harness-check.mjs
@@ -118,6 +118,8 @@ if (!buildWorkflow.includes('npm run harness:check')) {
 
 const desktopReleaseWorkflow = await readText('.github/workflows/desktop-release.yml')
 const electronBuilderConfig = await readText('packages/desktop/electron-builder.yml')
+const desktopInstallHermes = await readText('packages/desktop/scripts/install-hermes.mjs')
+const desktopWebuiServer = await readText('packages/desktop/src/main/webui-server.ts')
 if (!desktopReleaseWorkflow.includes('files: ${{ matrix.artifact_files }}')) {
   fail('desktop-release.yml must upload matrix-specific artifact_files')
 }
@@ -140,6 +142,28 @@ for (const expectedGlob of ['*.dmg', '*.exe', '*.AppImage']) {
 
 if (!desktopReleaseWorkflow.includes('fail_on_unmatched_files: true')) {
   fail('desktop-release.yml must keep fail_on_unmatched_files: true')
+}
+
+for (const phrase of [
+  'websockets',
+  'agent-browser@^0.26.0',
+  'PLAYWRIGHT_BROWSERS_PATH',
+  'ms-playwright',
+  'removeBrokenDashboardAuthPlugin',
+]) {
+  if (!desktopInstallHermes.includes(phrase)) {
+    fail(`install-hermes.mjs must bundle Hermes browser runtime support: ${phrase}`)
+  }
+}
+
+for (const phrase of [
+  'bundledNodeBin',
+  'PLAYWRIGHT_BROWSERS_PATH',
+  'ms-playwright',
+]) {
+  if (!desktopWebuiServer.includes(phrase)) {
+    fail(`desktop webui server must expose bundled browser runtime: ${phrase}`)
+  }
 }
 
 if (failures.length > 0) {

--- a/tests/server/agent-bridge-manager.test.ts
+++ b/tests/server/agent-bridge-manager.test.ts
@@ -122,6 +122,15 @@ describe('agent bridge manager command resolution', () => {
     expect(DEFAULT_AGENT_BRIDGE_ENDPOINT).not.toBe('ipc:///tmp/hermes-agent-bridge.sock')
   })
 
+  it('honors the bridge connect retry environment override', async () => {
+    process.env.HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS = '120000'
+
+    const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+    const client = new AgentBridgeClient({ endpoint: 'tcp://127.0.0.1:1' })
+
+    expect(client.connectRetryMs).toBe(120000)
+  })
+
   it('waits briefly for a restarting bridge socket before failing', async () => {
     const endpoint = process.platform === 'win32'
       ? `tcp://127.0.0.1:${32000 + (process.pid % 10000)}`

--- a/tests/server/hermes-path.test.ts
+++ b/tests/server/hermes-path.test.ts
@@ -1,0 +1,61 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'fs'
+import { homedir, tmpdir } from 'os'
+import { join, resolve } from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { detectHermesHome } from '../../packages/server/src/services/hermes/hermes-path'
+
+describe('Hermes path detection', () => {
+  const originalEnv = { ...process.env }
+  const originalPlatform = process.platform
+  let tempDir = ''
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'hermes-path-'))
+    process.env = { ...originalEnv }
+    delete process.env.HERMES_HOME
+    delete process.env.LOCALAPPDATA
+    delete process.env.APPDATA
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+    process.env = { ...originalEnv }
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true })
+    tempDir = ''
+  })
+
+  it('keeps explicit HERMES_HOME even when the path does not exist', () => {
+    process.env.HERMES_HOME = join(tempDir, 'custom-home')
+
+    expect(detectHermesHome()).toBe(resolve(tempDir, 'custom-home'))
+  })
+
+  it('falls back to ~/.hermes on Windows when LOCALAPPDATA hermes is missing', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    process.env.LOCALAPPDATA = join(tempDir, 'Local')
+
+    expect(detectHermesHome()).toBe(resolve(homedir(), '.hermes'))
+  })
+
+  it('uses existing Windows LOCALAPPDATA hermes before APPDATA', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    const localHermes = join(tempDir, 'Local', 'hermes')
+    const roamingHermes = join(tempDir, 'Roaming', 'hermes')
+    mkdirSync(localHermes, { recursive: true })
+    mkdirSync(roamingHermes, { recursive: true })
+    process.env.LOCALAPPDATA = join(tempDir, 'Local')
+    process.env.APPDATA = join(tempDir, 'Roaming')
+
+    expect(detectHermesHome()).toBe(resolve(localHermes))
+  })
+
+  it('falls back to existing Windows APPDATA hermes when LOCALAPPDATA hermes is missing', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    const roamingHermes = join(tempDir, 'Roaming', 'hermes')
+    mkdirSync(roamingHermes, { recursive: true })
+    process.env.LOCALAPPDATA = join(tempDir, 'Local')
+    process.env.APPDATA = join(tempDir, 'Roaming')
+
+    expect(detectHermesHome()).toBe(resolve(roamingHermes))
+  })
+})


### PR DESCRIPTION
## Summary
- Upgrade the bundled desktop Hermes Agent default to 0.15.2 and install the missing websockets runtime dependency.
- Bundle agent-browser plus its Chromium cache into the desktop Python resources and expose both on PATH/PLAYWRIGHT_BROWSERS_PATH at runtime.
- Remove the broken dashboard_auth/nous plugin during packaging when the upstream wheel lacks hermes_cli.dashboard_auth, and add harness checks for these desktop runtime invariants.

## Validation
- `node --check packages/desktop/scripts/install-hermes.mjs`
- `npm run harness:check`
- `npm --prefix packages/desktop run build`
- `npm run build`

## Notes
- The current hermes-agent 0.15.2 wheel/sdist includes plugins/dashboard_auth/nous but not hermes_cli.dashboard_auth, so this PR prunes that broken plugin only when the core package is missing. If upstream restores the core package, the plugin is kept automatically.