### PR TITLE
providers: add MiniMax-M3 to MiniMax official endpoints

### DIFF
--- a/packages/server/src/shared/providers.ts
+++ b/packages/server/src/shared/providers.ts
@@ -174,14 +174,14 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     value: 'minimax',
     builtin: true,
     base_url: 'https://api.minimax.io/anthropic/v1',
-    models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed', 'MiniMax-M2.1', 'MiniMax-M2.1-highspeed', 'MiniMax-M2', 'MiniMax-M2-highspeed'],
+    models: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed', 'MiniMax-M2.1', 'MiniMax-M2.1-highspeed', 'MiniMax-M2', 'MiniMax-M2-highspeed'],
   },
   {
     label: 'MiniMax (China)',
     value: 'minimax-cn',
     builtin: true,
     base_url: 'https://api.minimaxi.com/v1',
-    models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed', 'MiniMax-M2.1', 'MiniMax-M2.1-highspeed', 'MiniMax-M2', 'MiniMax-M2-highspeed'],
+    models: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed', 'MiniMax-M2.1', 'MiniMax-M2.1-highspeed', 'MiniMax-M2', 'MiniMax-M2-highspeed'],
   },
   {
     label: 'Alibaba Cloud',


### PR DESCRIPTION
## Summary

- Adds **MiniMax-M3** to the model lists of the built-in `MiniMax` (api.minimax.io) and `MiniMax (China)` (api.minimaxi.com) provider presets, so the new frontier coding model is selectable from the Hermes Web UI without routing through a third-party gateway.
- M3 is placed at the head of both lists, ahead of the existing M2.7 / M2.5 / M2.1 / M2 (and their `-highspeed` siblings).

## Why

Per the official MiniMax docs and the Hermes Agent integration guide, MiniMax-M3 is the recommended default for Hermes Agent users on the MiniMax Token Plan, and it has no `-highspeed` variant:

- https://platform.minimaxi.com/docs/token-plan/hermes-agent ("选择 MiniMax-M3 作为模型")
- https://platform.minimaxi.com/docs/guides/models-intro ("MiniMax-M3 — 原生多模态、1M 上下文的 Frontier Coding 模型")

Right now `packages/server/src/shared/providers.ts` only lists M2.7 and older for the two official MiniMax endpoints, so users have to pick a third-party gateway (Vercel AI Gateway, Nous Portal, OpenCode Zen, etc.) just to use M3 via Hermes Web UI. This PR fixes that.

## Files Changed

- `packages/server/src/shared/providers.ts` — prepend `MiniMax-M3` to the `models` array of the `minimax` and `minimax-cn` presets.

## Verification

- `tsc --noEmit -p packages/server/tsconfig.json` — clean
- `npx vitest run` — **138 files / 871 tests passed**, 2 skipped (no regressions)

## Notes

- `MiniMax-M3-highspeed` is intentionally **not** added: MiniMax did not release a highspeed variant for M3 (verified against the official model catalog).
- No other files needed changes: `config-helpers.ts` env-var mapping is unchanged, the frontend reads the model list from `PROVIDER_PRESETS` dynamically, and no docs/i18n hard-code the model names.