### PR TITLE
[codex] fix mac desktop signing file limit

### DIFF
--- a/.github/workflows/desktop-manual-build.yml
+++ b/.github/workflows/desktop-manual-build.yml
@@ -188,7 +188,12 @@ jobs:
 
       - name: Build desktop artifact
         shell: bash
-        run: npm --prefix packages/desktop run dist -- ${{ needs.validate.outputs.electron_target }} ${MAC_BUILD_EXTRA_ARGS:-} --publish never
+        run: |
+          if [ "${{ needs.validate.outputs.target_os }}" = "darwin" ]; then
+            ulimit -n 10240 || true
+            echo "File descriptor limit: $(ulimit -n)"
+          fi
+          npm --prefix packages/desktop run dist -- ${{ needs.validate.outputs.electron_target }} ${MAC_BUILD_EXTRA_ARGS:-} --publish never
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -153,7 +153,12 @@ jobs:
 
       - name: Build desktop artifact
         shell: bash
-        run: npm --prefix packages/desktop run dist -- ${{ matrix.electron_target }} ${MAC_BUILD_EXTRA_ARGS:-} --publish never
+        run: |
+          if [ "${{ matrix.target_os }}" = "darwin" ]; then
+            ulimit -n 10240 || true
+            echo "File descriptor limit: $(ulimit -n)"
+          fi
+          npm --prefix packages/desktop run dist -- ${{ matrix.electron_target }} ${MAC_BUILD_EXTRA_ARGS:-} --publish never
 
       - name: Upload macOS update manifest artifact
         if: matrix.target_os == 'darwin'


### PR DESCRIPTION
## Summary
- raise the macOS file descriptor limit before electron-builder signs desktop artifacts
- apply the same limit adjustment to manual desktop builds and release desktop builds

## Root Cause
- macOS arm64 manual packaging failed during electron-builder signing with EMFILE: too many open files while walking the bundled Python tree.

## Validation
- npm run harness:check
- Manual Desktop Build macOS arm64 was triggered for this branch but was manually cancelled before completion: https://github.com/EKKOLearnAI/hermes-web-ui/actions/runs/26758839072

## Notes
- Needs a full macOS arm64 manual desktop build rerun before marking ready.
