### PR TITLE
Fix runtime workflow checkout ref

### DIFF
--- a/.github/workflows/desktop-runtime.yml
+++ b/.github/workflows/desktop-runtime.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
 
       - name: Resolve runtime asset names
         id: names


### PR DESCRIPTION
## Summary
- checkout the workflow source ref for manual runtime builds instead of the runtime release tag
- keep the input tag only for checking/uploading runtime release assets

## Validation
- npm run harness:check
- git diff --check origin/main...HEAD