### PR TITLE
Prevent runtime releases becoming latest

### DIFF
--- a/.github/workflows/desktop-runtime.yml
+++ b/.github/workflows/desktop-runtime.yml
@@ -118,6 +118,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          make_latest: false
           fail_on_unmatched_files: true
           files: |
             packages/desktop/release/runtime/${{ steps.names.outputs.asset }}


### PR DESCRIPTION
## Summary
- set runtime release uploads to make_latest: false so runtime-only releases do not replace the latest app release

## Validation
- npm run harness:check
- git diff --check origin/main...HEAD