### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/packages/server/src/shared/providers.ts
+++ b/packages/server/src/shared/providers.ts
@@ -174,14 +174,14 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     value: 'minimax',
     builtin: true,
     base_url: 'https://api.minimax.io/anthropic/v1',
-    models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed', 'MiniMax-M2.1', 'MiniMax-M2.1-highspeed', 'MiniMax-M2', 'MiniMax-M2-highspeed'],
+    models: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
   },
   {
     label: 'MiniMax (China)',
     value: 'minimax-cn',
     builtin: true,
     base_url: 'https://api.minimaxi.com/v1',
-    models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed', 'MiniMax-M2.1', 'MiniMax-M2.1-highspeed', 'MiniMax-M2', 'MiniMax-M2-highspeed'],
+    models: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
   },
   {
     label: 'Alibaba Cloud',


### PR DESCRIPTION
## Summary

Refresh the `minimax` and `minimax-cn` provider presets in `packages/server/src/shared/providers.ts` so the MiniMax lineup matches the current upstream catalog: `MiniMax-M3` becomes the new default and the deprecated M2.5/M2.1/M2 family is dropped.

## Changes

`packages/server/src/shared/providers.ts`

- Add `MiniMax-M3` to both `minimax` (international) and `minimax-cn` (China) `models` arrays
- Place `MiniMax-M3` first so it becomes the default selection
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` for users that still depend on the previous default
- Remove `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.1`, `MiniMax-M2.1-highspeed`, `MiniMax-M2`, `MiniMax-M2-highspeed`

Other providers that incidentally reference legacy MiniMax IDs (`alibaba`, `alibaba-coding-plan`, `huggingface`, `ai-gateway`, `opencode-zen`, `opencode-go`, `nous`) are left untouched — those entries reflect what each gateway actually serves, not what the MiniMax vendor publishes.

## Why

`MiniMax-M3` is MiniMax's new flagship and the M2.5/M2.1/M2 generations are no longer the right defaults to expose in a fresh UI dropdown. Keeping `M2.7` and `M2.7-highspeed` preserves the latest highspeed path that #17 introduced, so users with existing chats keep working while new sessions default to M3. No API URL, environment-variable mapping, or other provider entries are touched, matching the "keep changes scoped to the requested behavior" rule from `DEVELOPMENT.md` and the PR self-review checklist.

> Heads-up: the header comment notes this file is synced from `hermes-agent` `hermes_cli/models.py _PROVIDER_MODELS`. If maintainers prefer to drive the change from upstream first, happy to coordinate.

## Testing

- `npm run harness:check` — passes
- `tsc --noEmit` on `packages/server/src/shared/providers.ts` — passes (validates the array literal stays well-typed against `ProviderPreset`)
- Diff is data-only inside `PROVIDER_PRESETS`; no runtime/lookup paths changed