### PR TITLE
[codex] fix desktop update check rate limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Self-hosted AI chat dashboard for Hermes Agent — multi-model web UI with multi-platform integration",
   "repository": {
     "type": "git",

--- a/packages/desktop/package-lock.json
+++ b/packages/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-studio",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-studio",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "BSL-1.1",
       "dependencies": {
         "electron-updater": "^6.3.9"

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-studio",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Hermes Studio desktop distribution with bundled Python runtime and hermes-agent",
   "homepage": "https://ekkolearnai.com",
   "author": {

--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -6,12 +6,8 @@ let initialized = false
 let checking = false
 let updateDownloaded = false
 
-const LATEST_RELEASE_URL = 'https://api.github.com/repos/EKKOLearnAI/hermes-web-ui/releases/latest'
+const LATEST_RELEASE_DOWNLOAD_URL = 'https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest/download'
 const CLOUDFLARE_DOWNLOAD_BASE_URL = 'https://download.ekkolearnai.com'
-
-interface GitHubRelease {
-  tag_name?: string
-}
 
 class MissingUpdateInfoError extends Error {
   constructor(public readonly url: string) {
@@ -26,18 +22,25 @@ interface AutoUpdaterOptions {
 
 let options: AutoUpdaterOptions = {}
 
-async function getLatestReleaseTag(): Promise<string> {
-  const res = await fetch(LATEST_RELEASE_URL, {
+async function getLatestReleaseTag(assetName: string): Promise<string> {
+  const res = await fetch(`${LATEST_RELEASE_DOWNLOAD_URL}/${encodeURIComponent(assetName)}`, {
+    method: 'HEAD',
+    redirect: 'manual',
     headers: {
-      Accept: 'application/vnd.github+json',
       'User-Agent': `Hermes-Studio/${app.getVersion()}`,
     },
   })
-  if (!res.ok) throw new Error(`GitHub returned ${res.status}`)
 
-  const release = await res.json() as GitHubRelease
-  const tag = release.tag_name?.trim()
-  if (!tag) throw new Error('Latest release response did not include a tag')
+  if (res.status < 300 || res.status >= 400) throw new Error(`GitHub returned ${res.status}`)
+
+  const location = res.headers.get('location')
+  if (!location) throw new Error('Latest release redirect did not include a location')
+
+  const redirectUrl = new URL(location, LATEST_RELEASE_DOWNLOAD_URL)
+  const parts = redirectUrl.pathname.split('/')
+  const downloadIndex = parts.indexOf('download')
+  const tag = downloadIndex >= 0 ? parts[downloadIndex + 1]?.trim() : ''
+  if (!tag) throw new Error('Latest release redirect did not include a tag')
   return tag
 }
 
@@ -60,7 +63,7 @@ async function assertUpdateManifestExists(feedUrl: string): Promise<void> {
 }
 
 async function configureFeedFromLatestRelease(): Promise<void> {
-  const tag = await getLatestReleaseTag()
+  const tag = await getLatestReleaseTag(updateManifestFile())
   const feedUrl = `${CLOUDFLARE_DOWNLOAD_BASE_URL}/${tag}`
   await assertUpdateManifestExists(feedUrl)
   autoUpdater.setFeedURL({


### PR DESCRIPTION
## Summary

- Avoid the GitHub REST `/releases/latest` API when resolving the latest desktop updater feed.
- Resolve the latest release tag from the GitHub release download redirect for the platform manifest.
- Keep Cloudflare as the actual updater feed and artifact host after the tag is resolved.
- Bump root and desktop package versions to `0.6.9`.

## Root Cause

Manual desktop update checks could fail before reaching the Cloudflare updater feed because unauthenticated GitHub REST API requests are rate limited by source IP.

## Validation

- `npm --prefix packages/desktop run build`
