### PR TITLE
[codex] Add runtime download source selection

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -198,24 +198,50 @@ function splashHtml(): string {
 function runtimeSourceHtml(errorMessage?: string): string {
   const safeError = errorMessage?.replace(/[<>]/g, '')
   const errorBlock = safeError
-    ? `<pre style="box-sizing:border-box;width:min(680px,calc(100vw - 48px));max-height:180px;overflow:auto;white-space:pre-wrap;margin:0;color:#ff9b9b;background:#241b1b;border:1px solid #553232;border-radius:6px;padding:12px">${safeError}</pre>`
+    ? `<section class="error" aria-live="polite">
+        <div class="error-title">Download failed</div>
+        <pre>${safeError}</pre>
+       </section>`
     : ''
   const html = `<!doctype html><html><head><meta charset="utf-8"><title>Hermes Studio</title>
 <style>
-  html,body{margin:0;height:100%;background:#1a1a1a;color:#e5e5e5;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;}
-  .wrap{box-sizing:border-box;min-height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:18px;padding:32px;text-align:center}
-  h1{font-weight:500;margin:0;font-size:20px}
-  .label{font-size:14px;color:#b8b8b8}
-  .actions{display:flex;gap:12px;flex-wrap:wrap;justify-content:center}
-  button{min-width:150px;padding:10px 14px;border:1px solid #555;border-radius:6px;background:#2b2b2b;color:#eee;cursor:pointer;font-size:14px}
-  button:hover{background:#343434}
-</style></head><body><div class="wrap">
-<h1>Hermes Studio</h1>
-<div class="label">Select a Hermes runtime download source.</div>
+  :root{color-scheme:dark}
+  *{box-sizing:border-box}
+  html,body{margin:0;min-height:100%;background:#191919;color:#f1f1f1;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;}
+  body{display:grid;place-items:center;padding:32px}
+  .wrap{width:min(720px,100%);display:flex;flex-direction:column;align-items:center;gap:22px;text-align:center}
+  .brand{display:flex;align-items:center;gap:10px;color:#f6f6f6}
+  .mark{width:32px;height:32px;border-radius:7px;background:#f0f0f0;color:#171717;display:grid;place-items:center;font-weight:700;font-size:16px}
+  h1{font-weight:560;margin:0;font-size:22px;line-height:1.25}
+  .label{max-width:520px;font-size:14px;line-height:1.6;color:#b9b9b9;margin:0}
+  .actions{width:100%;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+  button{min-height:86px;border:1px solid #4c4c4c;border-radius:8px;background:#242424;color:#f2f2f2;cursor:pointer;padding:16px;text-align:left;display:flex;flex-direction:column;gap:7px;transition:background .14s ease,border-color .14s ease,transform .14s ease}
+  button:hover{background:#2d2d2d;border-color:#747474;transform:translateY(-1px)}
+  button:active{transform:translateY(0)}
+  button:focus-visible{outline:2px solid #dcdcdc;outline-offset:3px}
+  .button-title{font-size:15px;font-weight:650;line-height:1.2}
+  .button-detail{font-size:12px;line-height:1.45;color:#aaaaaa}
+  .error{width:100%;text-align:left;background:#241b1b;border:1px solid #6b3939;border-radius:8px;padding:14px}
+  .error-title{font-size:13px;font-weight:650;color:#ffc3c3;margin-bottom:8px}
+  pre{width:100%;max-height:180px;overflow:auto;white-space:pre-wrap;margin:0;color:#ffaaaa;font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+  @media (max-width:560px){
+    body{padding:24px}
+    .actions{grid-template-columns:1fr}
+    button{min-height:78px}
+  }
+</style></head><body><main class="wrap">
+<div class="brand"><div class="mark">H</div><h1>Hermes Studio</h1></div>
+<p class="label">Select a runtime download source to start local services.</p>
 ${errorBlock}
 <div class="actions">
-  <button id="cf">Download from Cloudflare</button>
-  <button id="github">Download from GitHub</button>
+  <button id="cf">
+    <span class="button-title">Download from Cloudflare</span>
+    <span class="button-detail">Use the Hermes Studio download proxy.</span>
+  </button>
+  <button id="github">
+    <span class="button-title">Download from GitHub</span>
+    <span class="button-detail">Use the release asset directly from GitHub.</span>
+  </button>
 </div>
 <script>
   document.getElementById('cf')?.addEventListener('click', () => {
@@ -225,7 +251,7 @@ ${errorBlock}
     window.hermesDesktop?.retryBootstrap?.('github')
   })
 </script>
-</div></body></html>`
+</main></body></html>`
   return 'data:text/html;charset=utf-8,' + encodeURIComponent(html)
 }
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -6,7 +6,12 @@ import { checkForDesktopUpdates, initAutoUpdater } from './updater'
 import { t } from './desktop-i18n'
 import { installHermesStudioCliShim } from './cli-shim'
 import { parseHermesCliArgs, runBundledHermesCli } from './hermes-cli'
-import { ensureDesktopRuntime, type RuntimeProgress } from './runtime-manager'
+import {
+  ensureDesktopRuntime,
+  isDesktopRuntimeReady,
+  type RuntimeDownloadSource,
+  type RuntimeProgress,
+} from './runtime-manager'
 
 const PORT = Number(process.env.HERMES_DESKTOP_PORT) || 8748
 const START_HIDDEN = process.argv.includes('--hidden')
@@ -190,6 +195,45 @@ function splashHtml(): string {
   return 'data:text/html;charset=utf-8,' + encodeURIComponent(html)
 }
 
+function runtimeSourceHtml(errorMessage?: string): string {
+  const safeError = errorMessage?.replace(/[<>]/g, '')
+  const errorBlock = safeError
+    ? `<pre style="box-sizing:border-box;width:min(680px,calc(100vw - 48px));max-height:180px;overflow:auto;white-space:pre-wrap;margin:0;color:#ff9b9b;background:#241b1b;border:1px solid #553232;border-radius:6px;padding:12px">${safeError}</pre>`
+    : ''
+  const html = `<!doctype html><html><head><meta charset="utf-8"><title>Hermes Studio</title>
+<style>
+  html,body{margin:0;height:100%;background:#1a1a1a;color:#e5e5e5;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;}
+  .wrap{box-sizing:border-box;min-height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:18px;padding:32px;text-align:center}
+  h1{font-weight:500;margin:0;font-size:20px}
+  .label{font-size:14px;color:#b8b8b8}
+  .actions{display:flex;gap:12px;flex-wrap:wrap;justify-content:center}
+  button{min-width:150px;padding:10px 14px;border:1px solid #555;border-radius:6px;background:#2b2b2b;color:#eee;cursor:pointer;font-size:14px}
+  button:hover{background:#343434}
+</style></head><body><div class="wrap">
+<h1>Hermes Studio</h1>
+<div class="label">Select a Hermes runtime download source.</div>
+${errorBlock}
+<div class="actions">
+  <button id="cf">Download from Cloudflare</button>
+  <button id="github">Download from GitHub</button>
+</div>
+<script>
+  document.getElementById('cf')?.addEventListener('click', () => {
+    window.hermesDesktop?.retryBootstrap?.('cf')
+  })
+  document.getElementById('github')?.addEventListener('click', () => {
+    window.hermesDesktop?.retryBootstrap?.('github')
+  })
+</script>
+</div></body></html>`
+  return 'data:text/html;charset=utf-8,' + encodeURIComponent(html)
+}
+
+function envRuntimeDownloadSource(): RuntimeDownloadSource | undefined {
+  const source = process.env.HERMES_DESKTOP_RUNTIME_SOURCE?.trim().toLowerCase()
+  return source === 'cf' || source === 'github' ? source : undefined
+}
+
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
   const units = ['KB', 'MB', 'GB']
@@ -226,27 +270,29 @@ function updateSplash(progress: RuntimeProgress) {
   `).catch(() => undefined)
 }
 
-async function bootstrap() {
+async function bootstrap(source?: RuntimeDownloadSource) {
   if (isBootstrapping) return
   isBootstrapping = true
 
   try {
-    await ensureDesktopRuntime(updateSplash)
+    const selectedSource = source || envRuntimeDownloadSource()
+    const runtimeUrlOverride = !!process.env.HERMES_DESKTOP_RUNTIME_URL?.trim()
+    const manifestOverride = !!process.env.HERMES_DESKTOP_RUNTIME_MANIFEST_URL?.trim()
+    const forceUpdate = !!process.env.HERMES_DESKTOP_RUNTIME_FORCE_UPDATE
+
+    if (!isDesktopRuntimeReady() || forceUpdate || runtimeUrlOverride || manifestOverride) {
+      if (!selectedSource && !runtimeUrlOverride && !manifestOverride) {
+        if (mainWindow) await mainWindow.loadURL(runtimeSourceHtml())
+        isBootstrapping = false
+        return
+      }
+      await ensureDesktopRuntime(updateSplash, selectedSource)
+    }
   } catch (err) {
     console.error('Failed to prepare Hermes runtime:', err)
     if (mainWindow) {
-      const msg = String(err instanceof Error ? err.message : err).replace(/[<>]/g, '')
-      mainWindow.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(
-        `<html><body style="font-family:system-ui;padding:32px;background:#1a1a1a;color:#eee">
-         <h2>Failed to prepare Hermes runtime</h2><pre style="white-space:pre-wrap;color:#f88">${msg}</pre>
-         <button id="retry" style="margin-top:16px;padding:8px 14px;border:1px solid #555;border-radius:6px;background:#2b2b2b;color:#eee;cursor:pointer">Retry</button>
-         <script>
-           document.getElementById('retry')?.addEventListener('click', () => {
-             window.hermesDesktop?.retryBootstrap?.()
-           })
-         </script>
-         </body></html>`,
-      ))
+      const msg = String(err instanceof Error ? err.message : err)
+      await mainWindow.loadURL(runtimeSourceHtml(`Failed to prepare Hermes runtime\n\n${msg}`))
     }
     isBootstrapping = false
     return
@@ -277,13 +323,14 @@ async function bootstrap() {
 }
 
 ipcMain.handle('hermes-desktop:get-token', () => getToken())
-ipcMain.handle('hermes-desktop:retry-bootstrap', async () => {
+ipcMain.handle('hermes-desktop:retry-bootstrap', async (_event, source?: RuntimeDownloadSource) => {
   if (serverUrl) {
     await mainWindow?.loadURL(serverUrl)
     return
   }
+  const selectedSource = source === 'cf' || source === 'github' ? source : undefined
   await mainWindow?.loadURL(splashHtml())
-  await bootstrap()
+  await bootstrap(selectedSource)
 })
 
 function runDesktopApp() {

--- a/packages/desktop/src/main/runtime-manager.ts
+++ b/packages/desktop/src/main/runtime-manager.ts
@@ -26,8 +26,11 @@ import {
 
 const execFileAsync = promisify(execFile)
 const DEFAULT_RUNTIME_BASE_URL = 'https://download.ekkolearnai.com'
+const DEFAULT_RUNTIME_GITHUB_REPO = 'EKKOLearnAI/hermes-web-ui'
 const RUNTIME_MANIFEST_NAME = 'runtime-manifest.json'
 const PACKAGED_RUNTIME_RELEASE_NAME = 'runtime-release.json'
+
+export type RuntimeDownloadSource = 'cf' | 'github'
 
 type RuntimeManifest = {
   schema: number
@@ -58,6 +61,13 @@ export type RuntimeProgress = {
 
 type RuntimeProgressHandler = (progress: RuntimeProgress) => void
 
+function runtimeDownloadSource(source?: RuntimeDownloadSource): RuntimeDownloadSource | null {
+  if (source) return source
+  const value = process.env.HERMES_DESKTOP_RUNTIME_SOURCE?.trim().toLowerCase()
+  if (value === 'github' || value === 'cf') return value
+  return null
+}
+
 function requiredRuntimeFiles(root: string): string[] {
   const pythonBin = process.platform === 'win32'
     ? join(root, 'python', 'python.exe')
@@ -80,6 +90,10 @@ function missingRuntimeFiles(root: string): string[] {
 function runtimeReady(): boolean {
   const gitReady = process.platform !== 'win32' || !!bundledGit()
   return hermesBinExists() && existsSync(bundledNode()) && gitReady
+}
+
+export function isDesktopRuntimeReady(): boolean {
+  return runtimeReady()
 }
 
 function releaseTagCandidates(): string[] {
@@ -107,9 +121,9 @@ function packagedRuntimeReleaseTag(): string | null {
   return null
 }
 
-function runtimeAssetUrl(assetName: string, tag: string): string {
-  const repo = process.env.HERMES_DESKTOP_RUNTIME_REPO?.trim()
-  if (repo) {
+function runtimeAssetUrl(assetName: string, tag: string, source: RuntimeDownloadSource): string {
+  if (source === 'github') {
+    const repo = process.env.HERMES_DESKTOP_RUNTIME_REPO?.trim() || DEFAULT_RUNTIME_GITHUB_REPO
     if (tag === 'latest') {
       return `https://github.com/${repo}/releases/latest/download/${encodeURIComponent(assetName)}`
     }
@@ -126,35 +140,49 @@ function runtimeAssetUrl(assetName: string, tag: string): string {
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url)
-  if (!response.ok) {
-    throw new Error(`GET ${url} returned ${response.status}`)
+  try {
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`GET ${url} returned ${response.status}`)
+    }
+    return await response.json() as T
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith(`GET ${url}`)) throw err
+    throw new Error(`GET ${url} failed: ${err instanceof Error ? err.message : String(err)}`)
   }
-  return await response.json() as T
 }
 
-async function resolveRuntimeDescriptor(): Promise<RuntimeDescriptor> {
+async function resolveRuntimeDescriptor(source?: RuntimeDownloadSource): Promise<RuntimeDescriptor> {
   const directUrl = process.env.HERMES_DESKTOP_RUNTIME_URL?.trim()
   if (directUrl) {
     return { name: basename(new URL(directUrl).pathname) || 'hermes-runtime.tar.gz', url: directUrl }
   }
 
+  const downloadSource = runtimeDownloadSource(source)
   const platformManifestName = `hermes-runtime-${runtimePlatformKey()}.json`
   const manifestOverride = process.env.HERMES_DESKTOP_RUNTIME_MANIFEST_URL?.trim()
+  if (!downloadSource && !manifestOverride) {
+    throw new Error('Hermes runtime download source is not selected')
+  }
+
   const candidates = manifestOverride
     ? [{ tag: '', url: manifestOverride }]
-    : releaseTagCandidates().map(tag => ({ tag, url: runtimeAssetUrl(platformManifestName, tag) }))
+    : releaseTagCandidates().map(tag => ({ tag, url: runtimeAssetUrl(platformManifestName, tag, downloadSource!) }))
 
   let lastError: Error | null = null
   for (const candidate of candidates) {
     try {
+      console.log(`[runtime] resolving Hermes runtime from ${downloadSource || 'custom'}: ${candidate.url}`)
       const manifest = await fetchJson<RuntimeManifest>(candidate.url)
       if (!manifest.asset?.name) {
         throw new Error(`runtime manifest is missing asset.name: ${candidate.url}`)
       }
+      if (!manifest.asset.url && !downloadSource) {
+        throw new Error(`runtime manifest is missing asset.url and no download source was selected: ${candidate.url}`)
+      }
       return {
         name: manifest.asset.name,
-        url: manifest.asset.url || runtimeAssetUrl(manifest.asset.name, candidate.tag),
+        url: manifest.asset.url || runtimeAssetUrl(manifest.asset.name, candidate.tag, downloadSource!),
         sha256: manifest.asset.sha256,
         hermesAgentVersion: manifest.hermesAgentVersion,
       }
@@ -224,7 +252,9 @@ function downloadFile(
       file.on('finish', () => file.close(() => resolve()))
       file.on('error', reject)
     })
-    req.on('error', reject)
+    req.on('error', err => {
+      reject(new Error(`GET ${url} failed: ${err instanceof Error ? err.message : String(err)}`))
+    })
   })
 }
 
@@ -262,14 +292,17 @@ async function extractRuntimeArchive(archive: string, targetRoot: string): Promi
   }
 }
 
-export async function ensureDesktopRuntime(onProgress?: RuntimeProgressHandler): Promise<void> {
+export async function ensureDesktopRuntime(
+  onProgress?: RuntimeProgressHandler,
+  source?: RuntimeDownloadSource,
+): Promise<void> {
   const runtimeRoot = desktopRuntimeDir()
   mkdirSync(runtimeRoot, { recursive: true })
 
   let descriptor: RuntimeDescriptor
   try {
     onProgress?.({ stage: 'resolve', message: 'Checking Hermes runtime...' })
-    descriptor = await resolveRuntimeDescriptor()
+    descriptor = await resolveRuntimeDescriptor(source)
   } catch (err) {
     if (runtimeReady() && !process.env.HERMES_DESKTOP_RUNTIME_FORCE_UPDATE) {
       console.warn(`[runtime] using cached Hermes runtime because update check failed: ${err instanceof Error ? err.message : String(err)}`)

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -2,7 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 
 contextBridge.exposeInMainWorld('hermesDesktop', {
   getToken: (): Promise<string> => ipcRenderer.invoke('hermes-desktop:get-token'),
-  retryBootstrap: (): Promise<void> => ipcRenderer.invoke('hermes-desktop:retry-bootstrap'),
+  retryBootstrap: (source?: 'cf' | 'github'): Promise<void> => ipcRenderer.invoke('hermes-desktop:retry-bootstrap', source),
   platform: process.platform,
   isDesktop: true,
 })


### PR DESCRIPTION
## Summary
- Adds an explicit runtime download source selection screen for Hermes Studio.
- Lets users choose Cloudflare or GitHub before runtime download starts.
- Keeps both source buttons visible after a runtime download failure and shows the failing URL/error.

## Why
Some users can reach only one of the runtime download sources. The desktop app should not silently default to one source when no runtime is installed.

## Validation
- npm --prefix packages/desktop run build