### PR TITLE
[codex] Avoid exposing Git Unix tools on desktop PATH

### DIFF
--- a/packages/desktop/src/main/paths.ts
+++ b/packages/desktop/src/main/paths.ts
@@ -78,7 +78,10 @@ export function gitPathDirs(): string[] {
   return [
     join(dir, 'cmd'),
     join(dir, 'mingw64', 'bin'),
-    join(dir, 'usr', 'bin'),
+    // Do not expose Git for Windows' Unix toolchain on PATH. Its usr/bin
+    // includes GNU tools like du.exe/find.exe, which can be picked up by
+    // Hermes or subprocesses and recursively scan Windows profile/AppData
+    // trees. We pass git.exe explicitly via HERMES_AGENT_GIT instead.
   ].filter(existsSync)
 }
 


### PR DESCRIPTION
## Summary
- Removes Git for Windows `usr/bin` from the desktop child-process PATH.
- Keeps `git/cmd` and `git/mingw64/bin` available, while continuing to pass `git.exe` explicitly through `HERMES_AGENT_GIT`.
- Reduces the chance that Hermes subprocesses accidentally pick up GNU tools such as `du.exe` and recursively scan Windows profile/AppData trees.

## Why
Git for Windows bundles Unix tools under `usr/bin`. Exposing that directory globally lets unrelated Hermes subprocesses discover tools like `du.exe`, which can behave poorly on Windows drive/junction layouts.

## Validation
- npm --prefix packages/desktop run build