### PR TITLE
[codex] fix desktop runtime cache path

### DIFF
--- a/packages/desktop/scripts/write-runtime-release.mjs
+++ b/packages/desktop/scripts/write-runtime-release.mjs
@@ -2,13 +2,14 @@
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { runtimeReleaseTag } from './runtime-config.mjs'
+import { hermesVersion, runtimeReleaseTag } from './runtime-config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '..')
 const outFile = resolve(ROOT, 'build', 'runtime-release.json')
 const tag = runtimeReleaseTag()
+const hermesAgentVersion = hermesVersion()
 
 mkdirSync(dirname(outFile), { recursive: true })
-writeFileSync(outFile, JSON.stringify({ tag }, null, 2) + '\n')
+writeFileSync(outFile, JSON.stringify({ tag, hermesAgentVersion }, null, 2) + '\n')
 console.log(`Runtime release metadata: ${tag}`)

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import { t } from './desktop-i18n'
 import { installHermesStudioCliShim } from './cli-shim'
 import { parseHermesCliArgs, runBundledHermesCli } from './hermes-cli'
 import {
+  cachedRuntimeNeedsPackagedReleaseUpdate,
   ensureDesktopRuntime,
   isDesktopRuntimeReady,
   type RuntimeDownloadSource,
@@ -305,14 +306,18 @@ async function bootstrap(source?: RuntimeDownloadSource) {
     const runtimeUrlOverride = !!process.env.HERMES_DESKTOP_RUNTIME_URL?.trim()
     const manifestOverride = !!process.env.HERMES_DESKTOP_RUNTIME_MANIFEST_URL?.trim()
     const forceUpdate = !!process.env.HERMES_DESKTOP_RUNTIME_FORCE_UPDATE
+    const runtimeReady = isDesktopRuntimeReady()
+    const packagedRuntimeUpdate = app.isPackaged && runtimeReady && cachedRuntimeNeedsPackagedReleaseUpdate()
+    const shouldCheckRuntime = !runtimeReady || forceUpdate || runtimeUrlOverride || manifestOverride || packagedRuntimeUpdate
+    const runtimeSource = selectedSource || (packagedRuntimeUpdate ? 'cf' : undefined)
 
-    if (!isDesktopRuntimeReady() || forceUpdate || runtimeUrlOverride || manifestOverride) {
-      if (!selectedSource && !runtimeUrlOverride && !manifestOverride) {
+    if (shouldCheckRuntime) {
+      if (!runtimeSource && !runtimeUrlOverride && !manifestOverride) {
         if (mainWindow) await mainWindow.loadURL(runtimeSourceHtml())
         isBootstrapping = false
         return
       }
-      await ensureDesktopRuntime(updateSplash, selectedSource)
+      await ensureDesktopRuntime(updateSplash, runtimeSource)
     }
   } catch (err) {
     console.error('Failed to prepare Hermes runtime:', err)

--- a/packages/desktop/src/main/paths.ts
+++ b/packages/desktop/src/main/paths.ts
@@ -1,11 +1,14 @@
 import { app } from 'electron'
 import { existsSync, readdirSync } from 'node:fs'
 import { join, resolve } from 'node:path'
-import { homedir, platform, arch } from 'node:os'
+import { homedir, platform } from 'node:os'
+import {
+  resolveRuntimeResourceDir,
+  runtimePlatformKey,
+  type DesktopRuntimeResource,
+} from './runtime-paths'
 
 const isWin = platform() === 'win32'
-const osLabel = isWin ? 'win' : platform() === 'darwin' ? 'mac' : platform() // mac | linux | win
-const archLabel = arch() // arm64 | x64
 
 export function isPackaged() {
   return app.isPackaged
@@ -23,9 +26,7 @@ export function webuiServerEntry(): string {
   return join(webuiDir(), 'dist', 'server', 'index.js')
 }
 
-export function runtimePlatformKey(): string {
-  return `${osLabel}-${archLabel}`
-}
+export { runtimePlatformKey }
 
 export function desktopRuntimeDir(): string {
   const override = process.env.HERMES_DESKTOP_RUNTIME_DIR?.trim()
@@ -33,26 +34,18 @@ export function desktopRuntimeDir(): string {
   return join(webUiHome(), 'desktop-runtime', runtimePlatformKey())
 }
 
-function packagedResourceDir(name: string): string {
-  return resolve(process.resourcesPath, name)
+export function runtimeResourceDir(name: DesktopRuntimeResource, packaged: boolean, appPath = app.getAppPath()): string {
+  return resolveRuntimeResourceDir(name, packaged, appPath, desktopRuntimeDir(), runtimePlatformKey())
 }
 
 // dev:  packages/desktop/resources/python/<os>-<arch>
-// prod: <resources>/python when present, otherwise downloaded runtime cache.
+// prod: downloaded runtime cache under Web UI home.
 export function pythonDir(): string {
-  if (app.isPackaged) {
-    const packaged = packagedResourceDir('python')
-    return existsSync(packaged) ? packaged : join(desktopRuntimeDir(), 'python')
-  }
-  return resolve(app.getAppPath(), 'resources', 'python', runtimePlatformKey())
+  return runtimeResourceDir('python', app.isPackaged)
 }
 
 export function nodeDir(): string {
-  if (app.isPackaged) {
-    const packaged = packagedResourceDir('node')
-    return existsSync(packaged) ? packaged : join(desktopRuntimeDir(), 'node')
-  }
-  return resolve(app.getAppPath(), 'resources', 'node', runtimePlatformKey())
+  return runtimeResourceDir('node', app.isPackaged)
 }
 
 export function nodeBinDir(): string {
@@ -65,11 +58,7 @@ export function bundledNode(): string {
 }
 
 export function gitDir(): string {
-  if (app.isPackaged) {
-    const packaged = packagedResourceDir('git')
-    return existsSync(packaged) ? packaged : join(desktopRuntimeDir(), 'git')
-  }
-  return resolve(app.getAppPath(), 'resources', 'git', runtimePlatformKey())
+  return runtimeResourceDir('git', app.isPackaged)
 }
 
 export function gitPathDirs(): string[] {

--- a/packages/desktop/src/main/runtime-manager.ts
+++ b/packages/desktop/src/main/runtime-manager.ts
@@ -19,10 +19,15 @@ import { app } from 'electron'
 import {
   bundledGit,
   bundledNode,
+  bundledPython,
   desktopRuntimeDir,
   hermesBinExists,
   runtimePlatformKey,
 } from './paths'
+import {
+  hermesAgentVersionFromRuntimeTag,
+  runtimeManifestMatchesHermesAgentVersion,
+} from './runtime-version'
 
 const execFileAsync = promisify(execFile)
 const DEFAULT_RUNTIME_BASE_URL = 'https://download.ekkolearnai.com'
@@ -48,6 +53,11 @@ type RuntimeDescriptor = {
   name: string
   url: string
   sha256?: string
+  hermesAgentVersion?: string
+}
+
+type PackagedRuntimeRelease = {
+  tag?: string
   hermesAgentVersion?: string
 }
 
@@ -89,7 +99,7 @@ function missingRuntimeFiles(root: string): string[] {
 
 function runtimeReady(): boolean {
   const gitReady = process.platform !== 'win32' || !!bundledGit()
-  return hermesBinExists() && existsSync(bundledNode()) && gitReady
+  return existsSync(bundledPython()) && hermesBinExists() && existsSync(bundledNode()) && gitReady
 }
 
 export function isDesktopRuntimeReady(): boolean {
@@ -105,7 +115,7 @@ function releaseTagCandidates(): string[] {
   return Array.from(new Set(candidates.filter((tag): tag is string => typeof tag === 'string' && tag.length > 0)))
 }
 
-function packagedRuntimeReleaseTag(): string | null {
+function packagedRuntimeReleaseMetadata(): PackagedRuntimeRelease | null {
   const candidates = app.isPackaged
     ? [join(process.resourcesPath, 'build', PACKAGED_RUNTIME_RELEASE_NAME)]
     : [join(app.getAppPath(), 'build', PACKAGED_RUNTIME_RELEASE_NAME)]
@@ -113,12 +123,33 @@ function packagedRuntimeReleaseTag(): string | null {
   for (const candidate of candidates) {
     if (!existsSync(candidate)) continue
     try {
-      const metadata = JSON.parse(readFileSync(candidate, 'utf-8')) as { tag?: unknown }
-      if (typeof metadata.tag === 'string' && metadata.tag.trim()) return metadata.tag.trim()
+      const metadata = JSON.parse(readFileSync(candidate, 'utf-8')) as { tag?: unknown; hermesAgentVersion?: unknown }
+      return {
+        tag: typeof metadata.tag === 'string' && metadata.tag.trim() ? metadata.tag.trim() : undefined,
+        hermesAgentVersion: typeof metadata.hermesAgentVersion === 'string' && metadata.hermesAgentVersion.trim()
+          ? metadata.hermesAgentVersion.trim()
+          : undefined,
+      }
     } catch {}
   }
 
   return null
+}
+
+function packagedRuntimeReleaseTag(): string | null {
+  const metadata = packagedRuntimeReleaseMetadata()
+  if (metadata?.tag) return metadata.tag
+  return null
+}
+
+export function cachedRuntimeNeedsPackagedReleaseUpdate(): boolean {
+  const metadata = packagedRuntimeReleaseMetadata()
+  const expectedVersion = process.env.HERMES_DESKTOP_RUNTIME_RELEASE_TAG
+    ? hermesAgentVersionFromRuntimeTag(process.env.HERMES_DESKTOP_RUNTIME_RELEASE_TAG)
+    : metadata?.hermesAgentVersion || hermesAgentVersionFromRuntimeTag(metadata?.tag)
+  if (!expectedVersion) return false
+  const match = runtimeManifestMatchesHermesAgentVersion(readCachedRuntimeManifest(desktopRuntimeDir()), expectedVersion)
+  return match === false
 }
 
 function runtimeAssetUrl(assetName: string, tag: string, source: RuntimeDownloadSource): string {

--- a/packages/desktop/src/main/runtime-paths.ts
+++ b/packages/desktop/src/main/runtime-paths.ts
@@ -1,0 +1,20 @@
+import { arch, platform } from 'node:os'
+import { join, resolve } from 'node:path'
+
+export type DesktopRuntimeResource = 'python' | 'node' | 'git'
+
+export function runtimePlatformKey(platformName = platform(), archName = arch()): string {
+  const osLabel = platformName === 'win32' ? 'win' : platformName === 'darwin' ? 'mac' : platformName
+  return `${osLabel}-${archName}`
+}
+
+export function resolveRuntimeResourceDir(
+  name: DesktopRuntimeResource,
+  packaged: boolean,
+  appPath: string,
+  runtimeRoot: string,
+  platformKey = runtimePlatformKey(),
+): string {
+  if (packaged) return join(runtimeRoot, name)
+  return resolve(appPath, 'resources', name, platformKey)
+}

--- a/packages/desktop/src/main/runtime-version.ts
+++ b/packages/desktop/src/main/runtime-version.ts
@@ -1,0 +1,24 @@
+export type RuntimeManifestVersionMetadata = {
+  hermesAgentVersion?: string
+  asset?: {
+    name?: string
+  }
+}
+
+export function hermesAgentVersionFromRuntimeTag(tag?: string | null): string | null {
+  const value = tag?.trim()
+  if (!value) return null
+  const match = value.match(/^hermes-(.+)-runtime$/)
+  return match?.[1] || null
+}
+
+export function runtimeManifestMatchesHermesAgentVersion(
+  manifest: RuntimeManifestVersionMetadata | null,
+  expectedVersion: string,
+): boolean | null {
+  if (!manifest) return null
+  if (manifest.hermesAgentVersion) return manifest.hermesAgentVersion === expectedVersion
+  const assetName = manifest.asset?.name
+  if (assetName) return assetName.includes(`hermes-agent-${expectedVersion}-`)
+  return null
+}

--- a/tests/desktop/runtime-manager-version.test.ts
+++ b/tests/desktop/runtime-manager-version.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import {
+  hermesAgentVersionFromRuntimeTag,
+  runtimeManifestMatchesHermesAgentVersion,
+} from '../../packages/desktop/src/main/runtime-version'
+
+describe('desktop runtime version checks', () => {
+  it('derives the Hermes Agent version from the runtime release tag', () => {
+    expect(hermesAgentVersionFromRuntimeTag('hermes-0.15.2-runtime')).toBe('0.15.2')
+    expect(hermesAgentVersionFromRuntimeTag('latest')).toBeNull()
+  })
+
+  it('compares cached runtime manifests to the expected Hermes Agent version', () => {
+    expect(runtimeManifestMatchesHermesAgentVersion({ hermesAgentVersion: '0.15.2' }, '0.15.2')).toBe(true)
+    expect(runtimeManifestMatchesHermesAgentVersion({ hermesAgentVersion: '0.15.1' }, '0.15.2')).toBe(false)
+    expect(runtimeManifestMatchesHermesAgentVersion({ asset: { name: 'hermes-runtime-hermes-agent-0.15.2-win-x64.tar.gz' } }, '0.15.2')).toBe(true)
+    expect(runtimeManifestMatchesHermesAgentVersion({}, '0.15.2')).toBeNull()
+  })
+})

--- a/tests/desktop/runtime-paths.test.ts
+++ b/tests/desktop/runtime-paths.test.ts
@@ -1,0 +1,52 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const originalEnv = { ...process.env }
+const tempDirs: string[] = []
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hermes-desktop-runtime-paths-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+describe('desktop runtime paths', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    const resourcesPath = tempDir()
+    process.resourcesPath = resourcesPath
+    process.env.HERMES_WEB_UI_HOME = tempDir()
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('uses the downloaded runtime in packaged builds even when stale install resources exist', async () => {
+    mkdirSync(join(process.resourcesPath, 'python'), { recursive: true })
+    mkdirSync(join(process.resourcesPath, 'node'), { recursive: true })
+    mkdirSync(join(process.resourcesPath, 'git'), { recursive: true })
+
+    const { resolveRuntimeResourceDir } = await import('../../packages/desktop/src/main/runtime-paths')
+    const runtimeRoot = tempDir()
+
+    expect(resolveRuntimeResourceDir('python', true, process.resourcesPath, runtimeRoot)).toBe(join(runtimeRoot, 'python'))
+    expect(resolveRuntimeResourceDir('node', true, process.resourcesPath, runtimeRoot)).toBe(join(runtimeRoot, 'node'))
+    expect(resolveRuntimeResourceDir('git', true, process.resourcesPath, runtimeRoot)).toBe(join(runtimeRoot, 'git'))
+  })
+
+  it('uses app resources for development runtime paths', async () => {
+    const appPath = tempDir()
+    const { resolveRuntimeResourceDir, runtimePlatformKey } = await import('../../packages/desktop/src/main/runtime-paths')
+    const runtimeRoot = tempDir()
+
+    expect(resolveRuntimeResourceDir('python', false, appPath, runtimeRoot)).toBe(join(appPath, 'resources', 'python', runtimePlatformKey()))
+    expect(resolveRuntimeResourceDir('node', false, appPath, runtimeRoot)).toBe(join(appPath, 'resources', 'node', runtimePlatformKey()))
+    expect(resolveRuntimeResourceDir('git', false, appPath, runtimeRoot)).toBe(join(appPath, 'resources', 'git', runtimePlatformKey()))
+  })
+})


### PR DESCRIPTION
## Summary
- Make packaged desktop runtime paths resolve to the Web UI home runtime cache instead of stale install-directory resources.
- Check cached runtime manifest metadata locally before requesting runtime update manifests, so normal starts do not add unnecessary network requests.
- Add focused desktop runtime path and version matching tests.

Closes #1248

## Validation
- `npm run test -- tests/desktop/runtime-paths.test.ts tests/desktop/runtime-manager-version.test.ts`
- `npm run test -- tests/server/agent-bridge-manager.test.ts tests/server/hermes-process.test.ts`
- `npm --prefix packages/desktop run build:main`
- `npm run harness:check`