### PR TITLE
[codex] fix Windows Hermes Studio CLI launch

### DIFF
--- a/packages/desktop/src/main/cli-shim.ts
+++ b/packages/desktop/src/main/cli-shim.ts
@@ -66,18 +66,33 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
-export function createShimContent(executablePath: string, platform: NodeJS.Platform = process.platform): string {
+function windowsRuntimePlatformKey(archName: string): string {
+  return `win-${archName}`
+}
+
+export function createShimContent(
+  executablePath: string,
+  platform: NodeJS.Platform = process.platform,
+  archName: string = process.arch,
+): string {
   if (platform === 'win32') {
+    const runtimePlatform = windowsRuntimePlatformKey(archName)
     return [
       '@echo off',
       `rem ${SHIM_MARKER}`,
       `set "APP=${executablePath}"`,
-      'if not exist "%APP%" (',
-      '  echo Hermes Studio executable not found at "%APP%" 1>&2',
+      'set "WEBUI_HOME=%HERMES_WEB_UI_HOME%"',
+      'if "%WEBUI_HOME%"=="" set "WEBUI_HOME=%HERMES_WEBUI_STATE_DIR%"',
+      'if "%WEBUI_HOME%"=="" set "WEBUI_HOME=%USERPROFILE%\\.hermes-web-ui"',
+      'set "RUNTIME=%HERMES_DESKTOP_RUNTIME_DIR%"',
+      `if "%RUNTIME%"=="" set "RUNTIME=%WEBUI_HOME%\\desktop-runtime\\${runtimePlatform}"`,
+      'set "PYTHON=%RUNTIME%\\python\\python.exe"',
+      'if not exist "%PYTHON%" (',
+      '  echo Hermes Studio Python runtime not found at "%PYTHON%" 1>&2',
+      '  echo Open Hermes Studio once to finish runtime setup, then retry hermes-studio. 1>&2',
       '  exit /b 127',
       ')',
-      'set ELECTRON_RUN_AS_NODE=',
-      `"${'%APP%'}" -- ${HERMES_CLI_ARG} %*`,
+      '"%PYTHON%" -m hermes_cli.main %*',
       'exit /b %ERRORLEVEL%',
       '',
     ].join('\r\n')
@@ -98,7 +113,7 @@ export function createShimContent(executablePath: string, platform: NodeJS.Platf
 }
 
 function isManagedShim(content: string): boolean {
-  return content.includes(SHIM_MARKER) && content.includes(HERMES_CLI_ARG)
+  return content.includes(SHIM_MARKER)
 }
 
 function writeShim(shimPath: string, content: string, platform: NodeJS.Platform): ShimInstallStatus {

--- a/packages/desktop/src/main/hermes-cli-invocation.ts
+++ b/packages/desktop/src/main/hermes-cli-invocation.ts
@@ -1,0 +1,15 @@
+export interface DesktopHermesCliInvocation {
+  command: string
+  argsPrefix: string[]
+}
+
+export function resolveDesktopHermesCliInvocation(
+  platform: NodeJS.Platform,
+  hermesBin: string,
+  python: string,
+): DesktopHermesCliInvocation {
+  if (platform === 'win32') {
+    return { command: python, argsPrefix: ['-m', 'hermes_cli.main'] }
+  }
+  return { command: hermesBin, argsPrefix: [] }
+}

--- a/packages/desktop/src/main/hermes-cli.ts
+++ b/packages/desktop/src/main/hermes-cli.ts
@@ -15,6 +15,7 @@ import {
 } from './paths'
 import { HERMES_CLI_ARG } from './cli-constants'
 import { ensureDesktopRuntime } from './runtime-manager'
+import { resolveDesktopHermesCliInvocation } from './hermes-cli-invocation'
 
 export function parseHermesCliArgs(argv: string[] = process.argv): string[] | null {
   const index = argv.indexOf(HERMES_CLI_ARG)
@@ -30,9 +31,16 @@ export async function runBundledHermesCli(args: string[]): Promise<number> {
     return 1
   }
 
-  const command = hermesBin()
-  if (!existsSync(command)) {
-    console.error(`hermes binary missing at ${command}`)
+  const hermesCommand = hermesBin()
+  const pythonCommand = bundledPython()
+  const invocation = resolveDesktopHermesCliInvocation(process.platform, hermesCommand, pythonCommand)
+  if (!existsSync(hermesCommand)) {
+    console.error(`hermes binary missing at ${hermesCommand}`)
+    console.error('Run: npm run prepare:runtime (to build a local Hermes runtime)')
+    return 127
+  }
+  if (!existsSync(invocation.command)) {
+    console.error(`Hermes CLI runtime missing at ${invocation.command}`)
     console.error('Run: npm run prepare:runtime (to build a local Hermes runtime)')
     return 127
   }
@@ -40,7 +48,7 @@ export async function runBundledHermesCli(args: string[]): Promise<number> {
   mkdirSync(webUiHome(), { recursive: true })
   mkdirSync(hermesHome(), { recursive: true })
 
-  const binDir = dirname(command)
+  const binDir = dirname(hermesCommand)
   const bundledNodeBin = nodeBinDir()
   const bundledAgentBrowserBin = process.platform === 'win32'
     ? join(pythonDir(), 'node')
@@ -58,9 +66,9 @@ export async function runBundledHermesCli(args: string[]): Promise<number> {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     HERMES_DESKTOP: 'true',
-    HERMES_BIN: command,
-    HERMES_AGENT_BRIDGE_PYTHON: bundledPython(),
-    HERMES_AGENT_CLI_PYTHON: bundledPython(),
+    HERMES_BIN: hermesCommand,
+    HERMES_AGENT_BRIDGE_PYTHON: pythonCommand,
+    HERMES_AGENT_CLI_PYTHON: pythonCommand,
     HERMES_AGENT_ROOT: pythonDir(),
     HERMES_AGENT_NODE: bundledNode(),
     HERMES_AGENT_NODE_ROOT: process.platform === 'win32' ? bundledNodeBin : dirname(bundledNodeBin),
@@ -75,7 +83,7 @@ export async function runBundledHermesCli(args: string[]): Promise<number> {
   }
 
   return await new Promise(resolve => {
-    const child = spawn(command, args, {
+    const child = spawn(invocation.command, [...invocation.argsPrefix, ...args], {
       env,
       stdio: 'inherit',
       windowsHide: false,

--- a/tests/desktop/cli-shim.test.ts
+++ b/tests/desktop/cli-shim.test.ts
@@ -34,11 +34,17 @@ describe('Hermes Studio CLI shim', () => {
     expect(content).toContain('exec "$APP" -- --hermes-cli "$@"')
   })
 
-  it('clears Electron Node mode in Windows shims before launching the app', () => {
-    const content = createShimContent('C:\\Users\\Example\\AppData\\Local\\Programs\\Hermes Studio\\Hermes Studio.exe', 'win32')
+  it('runs the bundled Python Hermes CLI directly in Windows shims', () => {
+    const content = createShimContent(
+      'C:\\Users\\Example\\AppData\\Local\\Programs\\Hermes Studio\\Hermes Studio.exe',
+      'win32',
+      'x64',
+    )
 
-    expect(content).toContain('set ELECTRON_RUN_AS_NODE=')
-    expect(content).toContain('"%APP%" -- --hermes-cli %*')
+    expect(content).toContain('desktop-runtime\\win-x64')
+    expect(content).toContain('set "PYTHON=%RUNTIME%\\python\\python.exe"')
+    expect(content).toContain('"%PYTHON%" -m hermes_cli.main %*')
+    expect(content).not.toContain('"%APP%" -- --hermes-cli')
   })
 
   it('detects user bin paths with platform-specific separators', () => {

--- a/tests/desktop/hermes-cli-invocation.test.ts
+++ b/tests/desktop/hermes-cli-invocation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { resolveDesktopHermesCliInvocation } from '../../packages/desktop/src/main/hermes-cli-invocation'
+
+describe('desktop Hermes CLI invocation', () => {
+  it('bypasses the uv hermes.exe trampoline on Windows', () => {
+    expect(resolveDesktopHermesCliInvocation(
+      'win32',
+      'C:\\Users\\Administrator\\.hermes-web-ui\\desktop-runtime\\win-x64\\python\\Scripts\\hermes.exe',
+      'C:\\Users\\Administrator\\.hermes-web-ui\\desktop-runtime\\win-x64\\python\\python.exe',
+    )).toEqual({
+      command: 'C:\\Users\\Administrator\\.hermes-web-ui\\desktop-runtime\\win-x64\\python\\python.exe',
+      argsPrefix: ['-m', 'hermes_cli.main'],
+    })
+  })
+
+  it('keeps normal launcher execution on non-Windows platforms', () => {
+    expect(resolveDesktopHermesCliInvocation(
+      'darwin',
+      '/Users/example/.hermes-web-ui/desktop-runtime/mac-arm64/python/bin/hermes',
+      '/Users/example/.hermes-web-ui/desktop-runtime/mac-arm64/python/bin/python3',
+    )).toEqual({
+      command: '/Users/example/.hermes-web-ui/desktop-runtime/mac-arm64/python/bin/hermes',
+      argsPrefix: [],
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Run the bundled Windows Hermes CLI through `python.exe -m hermes_cli.main` instead of the `hermes.exe` uv trampoline.
- Keep macOS and Linux CLI execution unchanged.
- Add focused invocation coverage for Windows argument passthrough.

## Root Cause
The `hermes-studio` shim forwards CLI arguments into the desktop app, and the desktop app directly spawned `Scripts/hermes.exe`. On Windows that executable can be a uv trampoline and fail with `uv trampoline failed to canonicalize script path` in cached desktop runtime installs.

## Validation
- `npm run test -- tests/desktop/cli-shim.test.ts tests/desktop/hermes-cli-invocation.test.ts`
- `npm --prefix packages/desktop run build:main`
- `npm run harness:check`