### PR TITLE
feat: add workspace text file previews

### DIFF
--- a/packages/client/src/components/hermes/files/FileContextMenu.vue
+++ b/packages/client/src/components/hermes/files/FileContextMenu.vue
@@ -2,7 +2,7 @@
 import { ref, nextTick } from 'vue'
 import { NDropdown, useMessage, useDialog } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
-import { useFilesStore, isTextFile, isImageFile, isMarkdownFile } from '@/stores/hermes/files'
+import { useFilesStore, isTextFile, isPreviewableFile } from '@/stores/hermes/files'
 import { downloadFile } from '@/api/hermes/download'
 import type { FileEntry } from '@/api/hermes/files'
 import { copyToClipboard } from '@/utils/clipboard'
@@ -43,7 +43,7 @@ function getOptions() {
     if (isTextFile(entry.name)) {
       options.push({ label: t('files.edit'), key: 'edit' })
     }
-    if (isImageFile(entry.name) || isMarkdownFile(entry.name)) {
+    if (isPreviewableFile(entry.name)) {
       options.push({ label: t('files.preview'), key: 'preview' })
     }
     options.push({ label: t('files.download'), key: 'download' })

--- a/packages/client/src/components/hermes/files/FileList.vue
+++ b/packages/client/src/components/hermes/files/FileList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { NButton, NSpin, NEmpty, useMessage } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
-import { useFilesStore, isImageFile, isMarkdownFile, isTextFile } from '@/stores/hermes/files'
+import { useFilesStore, isPreviewableFile, isTextFile } from '@/stores/hermes/files'
 import { downloadFile } from '@/api/hermes/download'
 import type { FileEntry } from '@/api/hermes/files'
 
@@ -45,13 +45,21 @@ function getFileIcon(entry: FileEntry): string {
   return iconMap[ext] || '📄'
 }
 
-function handleDoubleClick(entry: FileEntry) {
+async function handlePreview(entry: FileEntry) {
+  try {
+    await filesStore.openPreview(entry)
+  } catch {
+    message.error(t('files.backendError'))
+  }
+}
+
+async function handleDoubleClick(entry: FileEntry) {
   if (entry.isDir) {
     filesStore.navigateTo(entry.path)
   } else if (isTextFile(entry.name)) {
-    filesStore.openEditor(entry.path)
-  } else if (isImageFile(entry.name) || isMarkdownFile(entry.name)) {
-    filesStore.openPreview(entry)
+    await filesStore.openEditor(entry.path)
+  } else if (isPreviewableFile(entry.name)) {
+    await handlePreview(entry)
   }
 }
 
@@ -103,6 +111,7 @@ async function handleDownload(entry: FileEntry) {
           <div class="file-size">{{ entry.isDir ? '—' : formatSize(entry.size) }}</div>
           <div class="file-date">{{ formatDate(entry.modTime) }}</div>
           <div class="file-actions">
+            <NButton v-if="isPreviewableFile(entry.name) && !entry.isDir" size="tiny" quaternary @click.stop="handlePreview(entry)" :title="t('files.preview')">👁️</NButton>
             <NButton v-if="isTextFile(entry.name) && !entry.isDir" size="tiny" quaternary @click.stop="filesStore.openEditor(entry.path)" :title="t('files.edit')">✏️</NButton>
             <NButton v-if="!entry.isDir" size="tiny" quaternary @click.stop="handleDownload(entry)" :title="t('files.download')">⬇️</NButton>
           </div>

--- a/packages/client/src/components/hermes/files/FilePreview.vue
+++ b/packages/client/src/components/hermes/files/FilePreview.vue
@@ -1,17 +1,36 @@
 <script setup lang="ts">
-import { h } from 'vue'
-import { NButton, NIcon } from 'naive-ui'
+import { computed, h } from 'vue'
+import { NButton, NIcon, useMessage } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import { useFilesStore } from '@/stores/hermes/files'
 import { getFileDownloadUrl } from '@/api/hermes/files'
 import MarkdownRenderer from '@/components/hermes/chat/MarkdownRenderer.vue'
+import { handleCodeBlockCopyClick, renderHighlightedCodeBlock } from '@/components/hermes/chat/highlight'
 
 const { t } = useI18n()
+const message = useMessage()
 const filesStore = useFilesStore()
 
 function getImageUrl(): string {
   if (!filesStore.previewFile) return ''
   return getFileDownloadUrl(filesStore.previewFile.path)
+}
+
+const highlightedPreview = computed(() => {
+  const previewFile = filesStore.previewFile
+  if (!previewFile || previewFile.type !== 'text') return ''
+  return renderHighlightedCodeBlock(previewFile.content || '', previewFile.language, t('common.copy'), {
+    maxHighlightLength: 200_000,
+  })
+})
+
+async function handlePreviewClick(event: MouseEvent) {
+  const copyResult = await handleCodeBlockCopyClick(event)
+  if (copyResult) {
+    message.success(t('common.copied'))
+  } else if (copyResult === false) {
+    message.error(t('chat.copyFailed'))
+  }
 }
 
 const CloseIcon = () =>
@@ -43,6 +62,12 @@ const CloseIcon = () =>
       <div v-else-if="filesStore.previewFile.type === 'markdown'" class="preview-markdown">
         <MarkdownRenderer :content="filesStore.previewFile.content || ''" />
       </div>
+      <div
+        v-else-if="filesStore.previewFile.type === 'text'"
+        class="preview-code"
+        v-html="highlightedPreview"
+        @click="handlePreviewClick"
+      />
     </div>
   </div>
 </template>
@@ -86,5 +111,13 @@ const CloseIcon = () =>
 .preview-markdown {
   max-width: 800px;
   width: 100%;
+}
+
+.preview-code {
+  width: 100%;
+
+  :deep(.hljs-code-block) {
+    margin: 0;
+  }
 }
 </style>

--- a/packages/client/src/stores/hermes/files.ts
+++ b/packages/client/src/stores/hermes/files.ts
@@ -34,11 +34,47 @@ const EXT_LANG_MAP: Record<string, string> = {
   '.kt': 'kotlin',
 }
 
-function getLanguageFromPath(filePath: string): string {
+const SPECIAL_FILE_LANG_MAP: Record<string, string> = {
+  Dockerfile: 'dockerfile',
+  Makefile: 'makefile',
+  'CMakeLists.txt': 'cmake',
+  '.gitignore': 'gitignore',
+  '.dockerignore': 'gitignore',
+}
+
+const TEXT_BASENAMES = new Set([
+  ...Object.keys(SPECIAL_FILE_LANG_MAP),
+  'README',
+  'LICENSE',
+  'NOTICE',
+  'CHANGELOG',
+  'CONTRIBUTING',
+])
+
+const TEXT_EXTS = new Set([
+  '.txt', '.text', '.log', '.csv', '.tsv',
+  '.js', '.jsx', '.mjs', '.cjs',
+  '.ts', '.tsx', '.mts', '.cts',
+  '.json', '.jsonc',
+  '.html', '.htm', '.css', '.scss', '.less',
+  '.md', '.markdown',
+  '.py', '.pyw',
+  '.yaml', '.yml', '.xml',
+  '.sh', '.bash', '.zsh', '.fish',
+  '.sql', '.go', '.rs', '.java',
+  '.c', '.h', '.cpp', '.hpp', '.cc', '.cxx', '.hh', '.hxx',
+  '.toml', '.ini', '.env', '.conf', '.cfg', '.properties',
+  '.vue', '.svelte', '.astro',
+  '.dockerfile', '.graphql', '.gql',
+  '.lua', '.r', '.rb', '.php', '.swift', '.kt', '.kts',
+  '.diff', '.patch', '.lock',
+])
+
+export function getLanguageFromPath(filePath: string): string {
   const name = filePath.split('/').pop() || ''
-  if (name === 'Dockerfile') return 'dockerfile'
-  if (name === 'Makefile') return 'makefile'
-  const ext = '.' + name.split('.').pop()?.toLowerCase()
+  const specialLanguage = SPECIAL_FILE_LANG_MAP[name]
+  if (specialLanguage) return specialLanguage
+  const ext = getFileExt(name)
   return EXT_LANG_MAP[ext] || 'plaintext'
 }
 
@@ -59,8 +95,13 @@ export function isMarkdownFile(name: string): boolean {
 }
 
 export function isTextFile(name: string): boolean {
-  const binaryExts = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico', '.zip', '.gz', '.tar', '.7z', '.rar', '.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.mp3', '.mp4', '.wav', '.webm', '.avi', '.mov', '.exe', '.dll', '.so', '.dylib', '.bin', '.dat', '.db', '.sqlite'])
-  return !binaryExts.has(getFileExt(name))
+  const basename = name.split('/').pop() || ''
+  if (TEXT_BASENAMES.has(basename) || basename.startsWith('.env.')) return true
+  return TEXT_EXTS.has(getFileExt(basename))
+}
+
+export function isPreviewableFile(name: string): boolean {
+  return isImageFile(name) || isMarkdownFile(name) || isTextFile(name)
 }
 
 // Returns true if `targetPath` is the same as `changedPath` or lives inside it
@@ -88,8 +129,9 @@ export const useFilesStore = defineStore('files', () => {
 
   const previewFile = ref<{
     path: string
-    type: 'image' | 'markdown'
+    type: 'image' | 'markdown' | 'text'
     content?: string
+    language?: string
   } | null>(null)
 
   const pathSegments = computed(() => {
@@ -163,6 +205,14 @@ export const useFilesStore = defineStore('files', () => {
     } else if (isMarkdownFile(entry.name)) {
       const result = await filesApi.readFile(entry.path)
       previewFile.value = { path: entry.path, type: 'markdown', content: result.content }
+    } else if (isTextFile(entry.name)) {
+      const result = await filesApi.readFile(entry.path)
+      previewFile.value = {
+        path: entry.path,
+        type: 'text',
+        content: result.content,
+        language: getLanguageFromPath(entry.path),
+      }
     }
   }
 

--- a/tests/client/file-context-menu.test.ts
+++ b/tests/client/file-context-menu.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import type { FileEntry } from '@/api/hermes/files'
+
+const mockMessage = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+}))
+
+const mockDialog = vi.hoisted(() => ({
+  warning: vi.fn(),
+}))
+
+const downloadFileMock = vi.hoisted(() => vi.fn())
+const copyToClipboardMock = vi.hoisted(() => vi.fn())
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('naive-ui', async () => {
+  const { defineComponent, h } = await import('vue')
+
+  return {
+    NDropdown: defineComponent({
+      name: 'NDropdown',
+      props: {
+        show: { type: Boolean, default: false },
+        options: { type: Array, default: () => [] },
+      },
+      emits: ['select', 'clickoutside'],
+      setup(props, { emit }) {
+        return () => h('div', { 'data-show': props.show ? 'true' : 'false' },
+          (props.options as Array<any>).map(option => h(
+            'button',
+            {
+              type: 'button',
+              'data-key': option.key,
+              onClick: () => emit('select', option.key),
+            },
+            option.label ?? option.type ?? option.key,
+          )),
+        )
+      },
+    }),
+    useMessage: () => mockMessage,
+    useDialog: () => mockDialog,
+  }
+})
+
+vi.mock('@/api/hermes/download', () => ({
+  downloadFile: downloadFileMock,
+}))
+
+vi.mock('@/utils/clipboard', () => ({
+  copyToClipboard: copyToClipboardMock,
+}))
+
+vi.mock('@/utils/file-path', () => ({
+  getClipboardPathForEntry: (entry: FileEntry) => entry.path,
+}))
+
+import FileContextMenu from '@/components/hermes/files/FileContextMenu.vue'
+import { useFilesStore } from '@/stores/hermes/files'
+
+describe('FileContextMenu', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  async function showMenu(wrapper: ReturnType<typeof mount>, entry: FileEntry) {
+    ;(wrapper.vm as any).show(new MouseEvent('contextmenu', { clientX: 12, clientY: 34 }), entry)
+    await flushPromises()
+  }
+
+  it('offers both edit and preview for previewable text files', async () => {
+    const wrapper = mount(FileContextMenu)
+    const entry: FileEntry = {
+      name: 'Dockerfile',
+      path: 'Dockerfile',
+      isDir: false,
+      size: 42,
+      modTime: '2026-06-02T00:00:00.000Z',
+    }
+
+    await showMenu(wrapper, entry)
+
+    const keys = wrapper.findAll('[data-key]').map(node => node.attributes('data-key'))
+    expect(keys).toContain('edit')
+    expect(keys).toContain('preview')
+    expect(keys).toContain('download')
+  })
+
+  it('invokes the store preview action from the preview menu item', async () => {
+    const store = useFilesStore()
+    const openPreviewSpy = vi.spyOn(store, 'openPreview').mockResolvedValue(undefined)
+    const wrapper = mount(FileContextMenu)
+    const entry: FileEntry = {
+      name: 'README',
+      path: 'README',
+      isDir: false,
+      size: 12,
+      modTime: '2026-06-02T00:00:00.000Z',
+    }
+
+    await showMenu(wrapper, entry)
+    await wrapper.get('[data-key="preview"]').trigger('click')
+    await flushPromises()
+
+    expect(openPreviewSpy).toHaveBeenCalledWith(entry)
+    expect(mockMessage.error).not.toHaveBeenCalled()
+  })
+
+  it('does not offer preview for non-previewable binary files', async () => {
+    const wrapper = mount(FileContextMenu)
+    const entry: FileEntry = {
+      name: 'archive.zip',
+      path: 'archive.zip',
+      isDir: false,
+      size: 128,
+      modTime: '2026-06-02T00:00:00.000Z',
+    }
+
+    await showMenu(wrapper, entry)
+
+    const keys = wrapper.findAll('[data-key]').map(node => node.attributes('data-key'))
+    expect(keys).not.toContain('preview')
+    expect(keys).not.toContain('edit')
+    expect(keys).toContain('download')
+  })
+})

--- a/tests/client/files-store.test.ts
+++ b/tests/client/files-store.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+const mockFilesApi = vi.hoisted(() => ({
+  listFiles: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  deleteFile: vi.fn(),
+  renameFile: vi.fn(),
+  mkDir: vi.fn(),
+  copyFile: vi.fn(),
+  uploadFiles: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/files', () => mockFilesApi)
+
+import { getLanguageFromPath, isPreviewableFile, isTextFile, useFilesStore } from '@/stores/hermes/files'
+import type { FileEntry } from '@/api/hermes/files'
+
+describe('files store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('detects special workspace filenames and extensionless text files', () => {
+    expect(getLanguageFromPath('Dockerfile')).toBe('dockerfile')
+    expect(getLanguageFromPath('Makefile')).toBe('makefile')
+    expect(getLanguageFromPath('CMakeLists.txt')).toBe('cmake')
+    expect(getLanguageFromPath('.gitignore')).toBe('gitignore')
+    expect(getLanguageFromPath('.dockerignore')).toBe('gitignore')
+    expect(getLanguageFromPath('README')).toBe('plaintext')
+
+    expect(isTextFile('README')).toBe(true)
+    expect(isTextFile('LICENSE')).toBe(true)
+    expect(isTextFile('.env.local')).toBe(true)
+    expect(isTextFile('script.ts')).toBe(true)
+    expect(isTextFile('unknown-extensionless-binary')).toBe(false)
+    expect(isPreviewableFile('README')).toBe(true)
+    expect(isPreviewableFile('archive.zip')).toBe(false)
+    expect(isPreviewableFile('font.woff2')).toBe(false)
+    expect(isPreviewableFile('module.wasm')).toBe(false)
+  })
+
+  it('opens text previews with detected syntax language', async () => {
+    mockFilesApi.readFile.mockResolvedValue({
+      content: 'FROM node:20\nRUN npm test\n',
+      path: 'Dockerfile',
+      size: 27,
+    })
+
+    const store = useFilesStore()
+    const entry: FileEntry = {
+      name: 'Dockerfile',
+      path: 'Dockerfile',
+      isDir: false,
+      size: 27,
+      modTime: '2026-06-02T00:00:00.000Z',
+    }
+
+    await store.openPreview(entry)
+
+    expect(mockFilesApi.readFile).toHaveBeenCalledWith('Dockerfile')
+    expect(store.previewFile).toEqual({
+      path: 'Dockerfile',
+      type: 'text',
+      content: 'FROM node:20\nRUN npm test\n',
+      language: 'dockerfile',
+    })
+  })
+
+  it('opens image previews without reading file contents', async () => {
+    const store = useFilesStore()
+    const entry: FileEntry = {
+      name: 'diagram.png',
+      path: 'diagram.png',
+      isDir: false,
+      size: 128,
+      modTime: '2026-06-02T00:00:00.000Z',
+    }
+
+    await store.openPreview(entry)
+
+    expect(mockFilesApi.readFile).not.toHaveBeenCalled()
+    expect(store.previewFile).toEqual({
+      path: 'diagram.png',
+      type: 'image',
+    })
+  })
+})


### PR DESCRIPTION
Files 面板现在可以直接预览常见 text/code 文件；二进制文件仍不会被当成 text preview 打开。

## 改动
- text/code 文件增加 Preview 入口，文件列表和右键菜单里都能直接打开预览。
- preview 里复用现有代码块高亮和 Copy 行为，文本内容不进入编辑器也能快速查看。
- Dockerfile、Makefile、CMakeLists.txt、`.gitignore`、`.dockerignore` 这类特殊文件名会按文本文件处理，并带对应 language label。
- text preview 判断改成正向 allowlist，避免 `.woff2`、`.wasm`、unknown extensionless binary 之类文件被误当成可预览文本。

## 验证
已通过：

```bash
npm run test -- tests/client/files-store.test.ts tests/client/file-context-menu.test.ts tests/client/highlight-helper.test.ts tests/client/highlight-safety.test.ts
npm run build
```

结果：4 个 test files / 22 个 tests passed；build passed。