### PR TITLE
[codex] route apikey.fun providers to presets

### DIFF
--- a/packages/client/src/components/hermes/models/ProviderFormModal.vue
+++ b/packages/client/src/components/hermes/models/ProviderFormModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, computed, onMounted } from 'vue'
+import { ref, watch, computed, onMounted, nextTick } from 'vue'
 import { NModal, NForm, NFormItem, NInput, NInputNumber, NButton, NSelect, NRadioGroup, NRadioButton, useMessage, useDialog } from 'naive-ui'
 import { useModelsStore } from '@/stores/hermes/models'
 import { useI18n } from 'vue-i18n'
@@ -9,7 +9,7 @@ import CopilotLoginModal from './CopilotLoginModal.vue'
 import XaiOAuthLoginModal from './XaiOAuthLoginModal.vue'
 import { checkCopilotToken, enableCopilot, type CopilotTokenSource } from '@/api/hermes/copilot-auth'
 import { fetchProviderModels } from '@/api/hermes/system'
-import { normalizeCustomProviderBaseUrl } from '@/utils/providerBaseUrl'
+import { inferApiKeyFunPresetProvider, isApiKeyFunBaseUrl, type ApiKeyFunPresetProvider } from '@/utils/providerBaseUrl'
 
 const { t } = useI18n()
 
@@ -77,6 +77,31 @@ const FUN_LINK_MAP: Record<string, string> = {
 
 const funProviderLink = computed(() => selectedPreset.value ? FUN_LINK_MAP[selectedPreset.value] || '' : '')
 
+async function switchToApiKeyFunPreset(providerKey: ApiKeyFunPresetProvider, preferredModel: string) {
+  const apiKey = formData.value.api_key
+  const contextLength = formData.value.context_length
+  providerType.value = 'preset'
+  await nextTick()
+  selectedPreset.value = providerKey
+  await nextTick()
+  formData.value.api_key = apiKey
+  formData.value.context_length = contextLength
+  if (preferredModel) {
+    if (!modelOptions.value.some(option => option.value === preferredModel)) {
+      modelOptions.value = [{ label: preferredModel, value: preferredModel }, ...modelOptions.value]
+    }
+    formData.value.model = preferredModel
+  }
+}
+
+async function routeApiKeyFunCustomProvider(model: string) {
+  if (providerType.value !== 'custom') return
+  if (!isApiKeyFunBaseUrl(formData.value.base_url)) return
+  const providerKey = inferApiKeyFunPresetProvider(model)
+  if (!providerKey) return
+  await switchToApiKeyFunPreset(providerKey, model)
+}
+
 function autoGenerateName(url: string): string {
   const clean = url.replace(/^https?:\/\//, '').replace(/\/v1\/?$/, '')
   const host = clean.split('/')[0]
@@ -118,6 +143,10 @@ watch(() => formData.value.base_url, (url) => {
   if (providerType.value === 'custom' && url.trim() && !formData.value.name) {
     formData.value.name = autoGenerateName(url.trim())
   }
+})
+
+watch(() => formData.value.model, (model) => {
+  void routeApiKeyFunCustomProvider(model)
 })
 
 watch(providerType, () => {
@@ -201,17 +230,21 @@ async function handleSave() {
 
   loading.value = true
   try {
+    const contextLength = formData.value.context_length ?? undefined
+    const apiKeyFunPreset = providerType.value === 'custom' && isApiKeyFunBaseUrl(formData.value.base_url)
+      ? inferApiKeyFunPresetProvider(formData.value.model)
+      : null
     const providerKey = providerType.value === 'preset'
       ? selectedPreset.value
+      : apiKeyFunPreset
+    const presetProvider = apiKeyFunPreset
+      ? modelsStore.allProviders.find(group => group.provider === apiKeyFunPreset)
       : null
-
-    const contextLength = formData.value.context_length ?? undefined
-    const baseUrl = providerType.value === 'custom'
-      ? normalizeCustomProviderBaseUrl(formData.value.base_url)
-      : formData.value.base_url.trim()
+    const baseUrl = presetProvider?.base_url || formData.value.base_url.trim()
+    const providerName = presetProvider?.label || formData.value.name.trim()
 
     await modelsStore.addProvider({
-      name: formData.value.name.trim(),
+      name: providerName,
       base_url: baseUrl,
       api_key: formData.value.api_key.trim(),
       model: formData.value.model,

--- a/packages/client/src/utils/providerBaseUrl.ts
+++ b/packages/client/src/utils/providerBaseUrl.ts
@@ -1,16 +1,24 @@
-const APIKEY_FUN_BASE_URL = 'https://api.apikey.fun/v1'
+export type ApiKeyFunPresetProvider = 'fun-codex' | 'fun-claude'
 
-export function normalizeCustomProviderBaseUrl(baseUrl: string): string {
+export function isApiKeyFunBaseUrl(baseUrl: string): boolean {
   const value = baseUrl.trim()
-  if (!value) return value
+  if (!value) return false
 
   try {
     const parsed = new URL(value)
-    if (parsed.hostname.toLowerCase() === 'api.apikey.fun') return APIKEY_FUN_BASE_URL
+    const hostname = parsed.hostname.toLowerCase()
+    return hostname === 'apikey.fun' || hostname.endsWith('.apikey.fun')
   } catch {
-    // Fall back to a string match so partially typed values still normalize on submit.
-    if (/^https:\/\/api\.apikey\.fun(?:\/|$)/i.test(value)) return APIKEY_FUN_BASE_URL
+    // Fall back to a string match so partially typed values still route on submit.
+    return /^(?:https?:\/\/)?(?:[a-z0-9-]+\.)*apikey\.fun(?:\/|$)/i.test(value)
   }
+}
 
-  return value
+export function inferApiKeyFunPresetProvider(model: string): ApiKeyFunPresetProvider | null {
+  const normalized = model.trim().toLowerCase()
+  if (!normalized) return null
+  if (normalized.startsWith('claude')) return 'fun-claude'
+  if (normalized.startsWith('gpt') || normalized.includes('codex')) return 'fun-codex'
+
+  return null
 }

--- a/tests/client/provider-base-url.test.ts
+++ b/tests/client/provider-base-url.test.ts
@@ -1,16 +1,27 @@
 import { describe, expect, it } from 'vitest'
-import { normalizeCustomProviderBaseUrl } from '@/utils/providerBaseUrl'
+import { inferApiKeyFunPresetProvider, isApiKeyFunBaseUrl } from '@/utils/providerBaseUrl'
 
-describe('normalizeCustomProviderBaseUrl', () => {
-  it('normalizes api.apikey.fun custom provider URLs to the OpenAI-compatible v1 endpoint', () => {
-    expect(normalizeCustomProviderBaseUrl('https://api.apikey.fun')).toBe('https://api.apikey.fun/v1')
-    expect(normalizeCustomProviderBaseUrl('https://api.apikey.fun/')).toBe('https://api.apikey.fun/v1')
-    expect(normalizeCustomProviderBaseUrl('https://api.apikey.fun/anything')).toBe('https://api.apikey.fun/v1')
-    expect(normalizeCustomProviderBaseUrl('  https://api.apikey.fun/v2/chat  ')).toBe('https://api.apikey.fun/v1')
+describe('apikey.fun provider routing', () => {
+  it('detects apikey.fun custom provider URLs without normalizing their path', () => {
+    expect(isApiKeyFunBaseUrl('https://apikey.fun')).toBe(true)
+    expect(isApiKeyFunBaseUrl('apikey.fun')).toBe(true)
+    expect(isApiKeyFunBaseUrl('https://api.apikey.fun')).toBe(true)
+    expect(isApiKeyFunBaseUrl('https://api.apikey.fun/')).toBe(true)
+    expect(isApiKeyFunBaseUrl('https://api.apikey.fun/anything')).toBe(true)
+    expect(isApiKeyFunBaseUrl('  https://api.apikey.fun/v2/chat  ')).toBe(true)
+    expect(isApiKeyFunBaseUrl('https://not-api.apikey.fun/v1')).toBe(true)
   })
 
-  it('leaves unrelated provider URLs unchanged apart from trimming', () => {
-    expect(normalizeCustomProviderBaseUrl(' https://api.example.com/v1 ')).toBe('https://api.example.com/v1')
-    expect(normalizeCustomProviderBaseUrl('https://not-api.apikey.fun/v1')).toBe('https://not-api.apikey.fun/v1')
+  it('does not match unrelated provider URLs', () => {
+    expect(isApiKeyFunBaseUrl(' https://api.example.com/v1 ')).toBe(false)
+    expect(isApiKeyFunBaseUrl('https://example.com/apikey.fun/v1')).toBe(false)
+    expect(isApiKeyFunBaseUrl('https://aistudio.google.com/apikey')).toBe(false)
+  })
+
+  it('routes apikey.fun models to the matching built-in provider key', () => {
+    expect(inferApiKeyFunPresetProvider('claude-sonnet-4-6')).toBe('fun-claude')
+    expect(inferApiKeyFunPresetProvider('gpt-5.5')).toBe('fun-codex')
+    expect(inferApiKeyFunPresetProvider('gpt-5.3-codex')).toBe('fun-codex')
+    expect(inferApiKeyFunPresetProvider('unknown-model')).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- Route custom apikey.fun provider entries to the built-in fun-claude or fun-codex presets based on the selected model.
- Preserve the entered API key, context length, and selected model when switching from custom provider input to a preset.
- Replace custom base URL normalization with apikey.fun domain detection, including apikey.fun subdomains without matching unrelated URLs.

## Root Cause

The previous frontend flow only normalized api.apikey.fun custom URLs on save, so fetching models and selecting a Claude/GPT model did not move the user into the matching built-in provider flow.

## Validation

- npm run test -- tests/client/provider-base-url.test.ts
- git diff --check