### PR TITLE
[codex] Sync bridge approval allowlist

### DIFF
--- a/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
@@ -692,6 +692,16 @@ def _refresh_terminal_env() -> None:
         )
 
 
+def _refresh_approval_allowlist() -> None:
+    """Reload command_allowlist into tools.approval's process-local cache."""
+    try:
+        from tools.approval import load_permanent_allowlist
+
+        load_permanent_allowlist()
+    except Exception:
+        pass
+
+
 def _resolve_model(cfg: dict[str, Any]) -> str:
     env_model = (
         os.environ.get("HERMES_MODEL", "")
@@ -957,6 +967,7 @@ class AgentPool:
 
             with _profile_env(profile):
                 _refresh_worker_profile_env()
+                _refresh_approval_allowlist()
                 discovered_mcp_tools = _discover_bridge_mcp_tools()
                 cfg = _load_cfg()
                 resolved_model = requested_model or _resolve_model(cfg)
@@ -986,6 +997,7 @@ class AgentPool:
                     status_callback=self._status_callback(session_id),
                     thinking_callback=self._make_thinking_callback(session_id),
                     reasoning_callback=self._text_event_callback(session_id, "reasoning.delta"),
+                    stream_delta_callback=self._stream_delta_callback(session_id),
                     tool_progress_callback=self._tool_progress_callback(session_id),
                     tool_start_callback=self._tool_start_callback(session_id),
                     tool_complete_callback=self._tool_complete_callback(session_id),
@@ -1352,11 +1364,9 @@ class AgentPool:
                     "event": "turn.boundary",
                 })
                 return
-            if delta:
-                self._append_event(session_id, {
-                    "event": "stream.delta",
-                    "delta": str(delta),
-                })
+            # Text deltas are already captured by the per-run stream_callback
+            # passed to run_conversation.  Only consume boundary signals here
+            # so registering this callback does not duplicate assistant text.
 
         return callback
 
@@ -1634,6 +1644,7 @@ class AgentPool:
 
     def _run_chat(self, session: AgentSession, record: RunRecord, message: Any, storage_message: Any | None = None, instructions: str | None = None, conversation_history: list[dict[str, Any]] | None = None, profile: str | None = None, force_compress: bool = False, source: str | None = None) -> None:
         with _profile_env(profile):
+            _refresh_approval_allowlist()
             def stream_callback(delta: str) -> None:
                 with self._lock:
                     text = str(delta)

--- a/tests/server/agent-bridge-profile-env.test.ts
+++ b/tests/server/agent-bridge-profile-env.test.ts
@@ -519,6 +519,187 @@ print(json.dumps({
     })
   })
 
+  it('forwards agent turn-boundary callbacks without duplicating streamed text', async () => {
+    await writeFile(join(tempDir, 'config.yaml'), 'model:\n  default: fake-model\n', 'utf-8')
+
+    const result = await runBridgeProbe(`
+import importlib.util
+import json
+import os
+import sys
+import time
+import types
+
+spec = importlib.util.spec_from_file_location("hermes_bridge", os.environ["BRIDGE_PATH"])
+bridge = importlib.util.module_from_spec(spec)
+sys.modules["hermes_bridge"] = bridge
+spec.loader.exec_module(bridge)
+
+root = os.environ["TEST_HERMES_HOME"]
+os.environ["HERMES_HOME"] = root
+os.environ["HERMES_AGENT_BRIDGE_BASE_HOME"] = root
+
+run_agent = types.ModuleType("run_agent")
+class FakeAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+
+    def run_conversation(self, message, **kwargs):
+        stream_callback = kwargs.get("stream_callback")
+        if stream_callback:
+            stream_callback("hello")
+        if self.stream_delta_callback:
+            self.stream_delta_callback("ignored-duplicate-text")
+            self.stream_delta_callback(None)
+        return {
+            "final_response": "hello",
+            "messages": [
+                {"role": "user", "content": message},
+                {"role": "assistant", "content": "hello"},
+            ],
+        }
+run_agent.AIAgent = FakeAgent
+sys.modules["run_agent"] = run_agent
+
+class FakeDbHolder:
+    error = None
+    def get_for_profile(self, profile):
+        return None
+
+bridge._ensure_agent_imports = lambda: None
+bridge._load_cfg = lambda: {"model": {"default": "fake-model"}, "agent": {}}
+bridge._resolve_runtime = lambda model, provider=None: {"provider": "fake"}
+bridge._load_enabled_toolsets = lambda: []
+bridge._discover_bridge_mcp_tools = lambda: []
+bridge._load_reasoning_config = lambda: None
+bridge._load_service_tier = lambda: None
+
+pool = bridge.AgentPool()
+pool._db = FakeDbHolder()
+record = pool.start_chat("session-1", "hi", profile="default")
+deadline = time.time() + 2
+while record.status == "running" and time.time() < deadline:
+    time.sleep(0.01)
+
+output = pool.get_output(record.run_id)
+print(json.dumps({
+    "status": output["status"],
+    "delta": output["delta"],
+    "events": output["events"],
+}))
+`)
+
+    expect(result.status).toBe('complete')
+    expect(result.delta).toBe('hello')
+    expect(result.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ event: 'stream.delta', delta: 'hello' }),
+      expect.objectContaining({ event: 'turn.boundary' }),
+    ]))
+    expect(result.events).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ event: 'stream.delta', delta: 'ignored-duplicate-text' }),
+    ]))
+  })
+
+  it('reloads command allowlist for bridge agent creation and runs', async () => {
+    await writeFile(join(tempDir, 'config.yaml'), 'model:\n  default: fake-model\n', 'utf-8')
+
+    const result = await runBridgeProbe(`
+import importlib.util
+import json
+import os
+import sys
+import time
+import types
+
+spec = importlib.util.spec_from_file_location("hermes_bridge", os.environ["BRIDGE_PATH"])
+bridge = importlib.util.module_from_spec(spec)
+sys.modules["hermes_bridge"] = bridge
+spec.loader.exec_module(bridge)
+
+root = os.environ["TEST_HERMES_HOME"]
+os.environ["HERMES_HOME"] = root
+os.environ["HERMES_AGENT_BRIDGE_BASE_HOME"] = root
+
+allowlist_homes = []
+tools_pkg = types.ModuleType("tools")
+tools_pkg.__path__ = []
+sys.modules["tools"] = tools_pkg
+
+approval = types.ModuleType("tools.approval")
+def load_permanent_allowlist():
+    allowlist_homes.append(os.environ.get("HERMES_HOME", ""))
+    return {"script execution via -e/-c flag"}
+def set_current_session_key(session_key):
+    return None
+def register_gateway_notify(session_key, callback):
+    pass
+def reset_current_session_key(token):
+    pass
+def unregister_gateway_notify(session_key):
+    pass
+approval.load_permanent_allowlist = load_permanent_allowlist
+approval.set_current_session_key = set_current_session_key
+approval.register_gateway_notify = register_gateway_notify
+approval.reset_current_session_key = reset_current_session_key
+approval.unregister_gateway_notify = unregister_gateway_notify
+sys.modules["tools.approval"] = approval
+
+terminal_tool = types.ModuleType("tools.terminal_tool")
+terminal_tool.set_approval_callback = lambda callback: None
+sys.modules["tools.terminal_tool"] = terminal_tool
+
+run_agent = types.ModuleType("run_agent")
+class FakeAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, **kwargs):
+        stream_callback = kwargs.get("stream_callback")
+        if stream_callback:
+            stream_callback("ok")
+        return {
+            "final_response": "ok",
+            "messages": [
+                {"role": "user", "content": message},
+                {"role": "assistant", "content": "ok"},
+            ],
+        }
+run_agent.AIAgent = FakeAgent
+sys.modules["run_agent"] = run_agent
+
+class FakeDbHolder:
+    error = None
+    def get_for_profile(self, profile):
+        return None
+
+bridge._ensure_agent_imports = lambda: None
+bridge._load_cfg = lambda: {"model": {"default": "fake-model"}, "agent": {}}
+bridge._resolve_runtime = lambda model, provider=None: {"provider": "fake"}
+bridge._load_enabled_toolsets = lambda: []
+bridge._discover_bridge_mcp_tools = lambda: []
+bridge._load_reasoning_config = lambda: None
+bridge._load_service_tier = lambda: None
+
+pool = bridge.AgentPool()
+pool._db = FakeDbHolder()
+record = pool.start_chat("session-allowlist", "hi", profile="default")
+deadline = time.time() + 2
+while record.status == "running" and time.time() < deadline:
+    time.sleep(0.01)
+
+print(json.dumps({
+    "status": record.status,
+    "allowlist_homes": allowlist_homes,
+}))
+`)
+
+    const expectedHome = await realpath(tempDir)
+    expect(result.status).toBe('complete')
+    expect(result.allowlist_homes.length).toBeGreaterThanOrEqual(2)
+    expect(result.allowlist_homes.every((home: string) => home === expectedHome)).toBe(true)
+  })
+
   it('handles Windows netstat output decode failures without crashing', async () => {
     const result = await runBridgeProbe(`
 import importlib.util


### PR DESCRIPTION
## Summary
- reload Hermes `command_allowlist` into the long-lived bridge approval cache when creating agents and before each run
- wire bridge stream delta callbacks for turn-boundary events without duplicating assistant text
- add bridge regression coverage for allowlist reloads and stream-boundary forwarding

## Root Cause
The Web UI agent bridge is a long-lived Python process, while Hermes stores permanent command approvals in a module-local `tools.approval` cache. When `command_allowlist` was changed on disk by an `always` approval, the bridge could keep using stale in-memory approval state until restart.

## Impact
Permanent terminal approvals made through Hermes are now picked up by Web UI bridge runs without requiring a bridge restart. Session-scoped approvals continue to use Hermes session state and context propagation.

Closes #1151

## Validation
- `npm run test -- tests/server/agent-bridge-profile-env.test.ts tests/server/agent-bridge-python-concurrency.test.ts`
- `git diff --check`