### PR TITLE
fix: auto-scroll to bottom when new messages arrive in chat view

### DIFF
--- a/packages/client/src/components/hermes/chat/VirtualMessageList.vue
+++ b/packages/client/src/components/hermes/chat/VirtualMessageList.vue
@@ -38,12 +38,16 @@ const props = withDefaults(defineProps<{
   rowGap?: number;
   padding?: string;
   topThreshold?: number;
+  autoScroll?: boolean;
+  autoScrollThreshold?: number;
 }>(), {
   estimatedItemHeight: 180,
   overscan: 8,
   rowGap: 16,
   padding: "20px",
   topThreshold: 120,
+  autoScroll: true,
+  autoScrollThreshold: 200,
 });
 
 const emit = defineEmits<{
@@ -361,9 +365,18 @@ onBeforeUnmount(() => {
   resizeObserver?.disconnect();
 });
 
-watch(messageKeys, () => {
+watch(messageKeys, (newKeys, oldKeys) => {
   cancelAnchorAlignment();
-  nextTick(syncViewport);
+  nextTick(() => {
+    syncViewport();
+    // Auto-scroll to bottom when new messages are added and autoScroll is enabled
+    if (props.autoScroll && oldKeys && newKeys.length > oldKeys.length) {
+      // Only auto-scroll if the user was already near the bottom
+      if (isNearBottom(props.autoScrollThreshold)) {
+        scrollToBottom({ frames: 3, keepAliveMs: 1000 });
+      }
+    }
+  });
 });
 
 defineExpose({


### PR DESCRIPTION
## Summary

Fixes #37811 - Chat view auto-scrolls up / fails to follow latest message during multi-turn conversations.

## Problem

During a conversation session in the Desktop App GUI, the chat view frequently scrolls upward automatically, failing to stay pinned to the latest message. Users have to manually scroll down to see new content.

## Root Cause

The VirtualMessageList component did not auto-scroll to bottom when new messages arrived. It only synced viewport position, causing the view to "jump away" from the latest message as the list grew.

## Solution

- Add `autoScroll` and `autoScrollThreshold` props to VirtualMessageList (both enabled by default)
- Auto-scroll to bottom when new messages arrive if user is near bottom (within 200px)
- This matches standard chat app behavior where the view follows the latest message unless the user manually scrolls up

## Changes

- `packages/client/src/components/hermes/chat/VirtualMessageList.vue`:
  - Added `autoScroll` prop (default: true)
  - Added `autoScrollThreshold` prop (default: 200px)
  - Enhanced `watch(messageKeys)` to auto-scroll when new messages are added and user is near bottom

## Testing

- Verified that when new messages arrive and the user is near the bottom, the view auto-scrolls to show the latest message
- Verified that when the user has scrolled up (away from bottom), the view stays at current position
- Verified that existing functionality (scroll to message, scroll to anchor, etc.) continues to work correctly