### PR TITLE
优化工具结果中的 diff 展示

### DIFF
--- a/docs/cli-chat-sessions.md
+++ b/docs/cli-chat-sessions.md
@@ -51,6 +51,7 @@ ChatPanel / ChatInput
 
 | 时间 | PR / commit | 动到的功能 | 链路影响 |
 | --- | --- | --- | --- |
+| 2026-06-03 | #1289 `7848256` | tool result / unified diff 展示 | `MessageItem.vue`、`GroupMessageItem.vue`、`MarkdownRenderer.vue` 和共享 highlighter 对 unified diff 走专门展示路径：tool result JSON 中的 diff 字段只显示 diff body，长段未改动上下文静态折叠，复制仍保留完整原始内容；不改变 `/chat-run` 协议、消息落库、工具审批或 group-chat agent 执行行为。 |
 | 2026-06-03 | #1284 `2aeed108` | Windows Agent Bridge 子进程输出解码 | `hermes_bridge.py` 的 Windows parent PID 探测和 stale bridge 进程清理改用平台文本编码读取 `tasklist.exe` / `taskkill.exe` 输出，并忽略不可解码字节；修复本地 code page 输出导致 subprocess reader 线程抛 `UnicodeDecodeError` 的问题，不改变 `/chat-run` 协议、消息落库或工具审批行为。 |
 | 2026-06-03 | #1273 `91bb68dc` | 用户头像上传；group-chat 成员头像同步 | auth 用户头像进入 group-chat 成员展示链路，`/group-chat` handshake 携带 `authUserId`，服务端按用户 id/name 查头像并同步给 room members；不改变普通 Chat run，但改变 group-chat 成员元数据和消息展示。 |
 | 2026-06-03 | #1272 `2f1686da` | Bridge 工具审批 allowlist；Bridge 文本/turn boundary 回调 | `hermes_bridge.py` 在 agent 创建和每次 run 开始时刷新 `tools.approval` 的 `command_allowlist` 进程内缓存，保证“始终允许”写入配置后，后续同 profile run 能读到。`stream_delta_callback` 现在只转发 turn boundary，不再把 agent 的文本 delta 再追加一遍，避免和 `stream_callback` 重复。 |

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -70,13 +70,19 @@ const props = withDefaults(defineProps<{
 const { t } = useI18n()
 const message = useMessage()
 
+function diffFoldLabel(hiddenCount: number): string {
+  return t('chat.unchangedLines', { count: hiddenCount })
+}
+
 const md: MarkdownIt = new MarkdownItConstructor({
   html: false,
   breaks: true,
   linkify: true,
   typographer: true,
   highlight(str: string, lang: string): string {
-    return renderHighlightedCodeBlock(str, lang, t('common.copy'))
+    return renderHighlightedCodeBlock(str, lang, t('common.copy'), {
+      formatDiffFoldLabel: diffFoldLabel,
+    })
   },
 })
 

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -14,6 +14,7 @@ import ProfileAvatar from "@/components/hermes/profiles/ProfileAvatar.vue";
 import {
   copyTextToClipboard,
   handleCodeBlockCopyClick,
+  isUnifiedDiffContent,
   renderHighlightedCodeBlock,
 } from "./highlight";
 import { useGlobalSpeech } from "@/composables/useSpeech";
@@ -456,12 +457,14 @@ function formatToolPayload(raw?: string): ToolPayload {
       language: "json",
     };
   } catch {
+    const language = isUnifiedDiffContent(raw) ? "diff" : undefined;
     return {
       full: raw,
       display:
-        raw.length > TOOL_PAYLOAD_DISPLAY_LIMIT
-          ? raw.slice(0, TOOL_PAYLOAD_DISPLAY_LIMIT) + "\n" + t("chat.truncated")
-          : raw,
+        language === "diff" || raw.length <= TOOL_PAYLOAD_DISPLAY_LIMIT
+          ? raw
+          : raw.slice(0, TOOL_PAYLOAD_DISPLAY_LIMIT) + "\n" + t("chat.truncated"),
+      language,
     };
   }
 }
@@ -1547,6 +1550,13 @@ onBeforeUnmount(() => {
     overflow-y: auto;
     white-space: pre-wrap;
     word-break: break-word;
+  }
+
+  :deep(.hljs-unified-diff code.hljs) {
+    max-height: none;
+    overflow-y: visible;
+    white-space: pre;
+    word-break: normal;
   }
 }
 

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -13,6 +13,7 @@ import { useSettingsStore } from "@/stores/hermes/settings";
 import ProfileAvatar from "@/components/hermes/profiles/ProfileAvatar.vue";
 import {
   copyTextToClipboard,
+  extractUnifiedDiffPayload,
   handleCodeBlockCopyClick,
   isUnifiedDiffContent,
   renderHighlightedCodeBlock,
@@ -440,7 +441,7 @@ function truncateJsonValue(value: unknown, marker: string): unknown {
   return { [JSON_TRUNCATED_KEY]: marker };
 }
 
-function formatToolPayload(raw?: string): ToolPayload {
+function formatToolPayload(raw?: string, extractDiff = false): ToolPayload {
   if (!raw) {
     return { full: "", display: "" };
   }
@@ -448,6 +449,14 @@ function formatToolPayload(raw?: string): ToolPayload {
   try {
     const parsed = JSON.parse(raw);
     const full = JSON.stringify(parsed, null, 2);
+    const extractedDiff = extractDiff ? extractUnifiedDiffPayload(parsed) : null;
+    if (extractedDiff) {
+      return {
+        full,
+        display: extractedDiff,
+        language: "diff",
+      };
+    }
     const display = full.length > TOOL_PAYLOAD_DISPLAY_LIMIT
       ? JSON.stringify(truncateJsonValue(parsed, t("chat.truncated")), null, 2)
       : full;
@@ -472,6 +481,7 @@ function formatToolPayload(raw?: string): ToolPayload {
 function renderToolPayload(content: string, language?: string): string {
   return renderHighlightedCodeBlock(content, language, t("common.copy"), {
     maxHighlightLength: TOOL_PAYLOAD_DISPLAY_LIMIT,
+    formatDiffFoldLabel: (hiddenCount) => t("chat.unchangedLines", { count: hiddenCount }),
   });
 }
 
@@ -512,7 +522,7 @@ const hasToolDetails = computed(
 );
 
 const toolArgsPayload = computed(() => formatToolPayload(props.message.toolArgs));
-const toolResultPayload = computed(() => formatToolPayload(props.message.toolResult));
+const toolResultPayload = computed(() => formatToolPayload(props.message.toolResult, true));
 
 const fullToolArgs = computed(() => toolArgsPayload.value.full);
 const formattedToolArgs = computed(() => toolArgsPayload.value.display);

--- a/packages/client/src/components/hermes/chat/highlight.ts
+++ b/packages/client/src/components/hermes/chat/highlight.ts
@@ -10,6 +10,16 @@ const LANGUAGE_ALIASES: Record<string, string> = {
 }
 
 const UNIFIED_DIFF_LANGUAGES = new Set(['diff', 'patch'])
+const DIFF_CONTEXT_FOLD_THRESHOLD = 8
+const DIFF_CONTEXT_FOLD_EDGE_LINES = 3
+const DIFF_PAYLOAD_FIELD_NAMES = new Set([
+  'difference',
+  'diff',
+  'patch',
+  'stdout',
+  'output',
+  'content',
+])
 
 function escapeHtml(value: string): string {
   return value
@@ -30,13 +40,17 @@ function renderCodeBlockWrapper(
   labelLanguage: string | undefined,
   copyLabel: string,
   extraClasses: string[] = [],
+  rawCopyText?: string,
 ): string {
   const languageLabelHtml = labelLanguage
     ? `<span class="code-lang">${escapeHtml(labelLanguage)}</span>`
     : ''
   const blockClasses = ['hljs-code-block', ...extraClasses].join(' ')
+  const copyTextAttr = rawCopyText == null
+    ? ''
+    : ` data-copy-text="${escapeHtml(rawCopyText)}"`
 
-  return `<pre class="${blockClasses}"><div class="code-header">${languageLabelHtml}<button type="button" class="copy-btn" data-copy-code="true">${escapeHtml(copyLabel)}</button></div><code class="hljs language-${sanitizeLanguageClass(codeClassLanguage)}">${highlighted}</code></pre>`
+  return `<pre class="${blockClasses}"${copyTextAttr}><div class="code-header">${languageLabelHtml}<button type="button" class="copy-btn" data-copy-code="true">${escapeHtml(copyLabel)}</button></div><code class="hljs language-${sanitizeLanguageClass(codeClassLanguage)}">${highlighted}</code></pre>`
 }
 
 function isUnifiedDiffLanguage(lang?: string): boolean {
@@ -62,6 +76,11 @@ function isDiffRemovedLine(line: string): boolean {
 type DiffLineNumbers = {
   oldNumber?: number
   newNumber?: number
+}
+
+type RenderedDiffLine = {
+  html: string
+  foldableContext: boolean
 }
 
 function parseDiffHunkHeader(line: string): DiffLineNumbers | null {
@@ -112,14 +131,60 @@ function advanceDiffLineNumber(line: string, numbers: DiffLineNumbers): void {
   if (numbers.newNumber != null) numbers.newNumber += 1
 }
 
-function renderUnifiedDiffCode(content: string, labelLanguage: string, copyLabel: string): string {
+function renderDiffContextFoldLine(foldLabel: string): string {
+  return `<span class="diff-line diff-line-context-fold"><span class="diff-line-number diff-line-number-empty" aria-hidden="true"></span><span class="diff-line-content">⋮ ${escapeHtml(foldLabel)}</span></span>`
+}
+
+function collapseFoldableContextRows(
+  rows: RenderedDiffLine[],
+  formatFoldLabel: (hiddenCount: number) => string,
+): RenderedDiffLine[] {
+  const folded: RenderedDiffLine[] = []
+  let index = 0
+
+  while (index < rows.length) {
+    if (!rows[index].foldableContext) {
+      folded.push(rows[index])
+      index += 1
+      continue
+    }
+
+    const runStart = index
+    while (index < rows.length && rows[index].foldableContext) index += 1
+    const run = rows.slice(runStart, index)
+
+    if (run.length <= DIFF_CONTEXT_FOLD_THRESHOLD) {
+      folded.push(...run)
+      continue
+    }
+
+    const edge = Math.min(DIFF_CONTEXT_FOLD_EDGE_LINES, Math.floor(run.length / 2))
+    const hiddenCount = run.length - edge * 2
+    folded.push(...run.slice(0, edge))
+    folded.push({
+      html: renderDiffContextFoldLine(formatFoldLabel(hiddenCount)),
+      foldableContext: false,
+    })
+    folded.push(...run.slice(run.length - edge))
+  }
+
+  return folded
+}
+
+function renderUnifiedDiffCode(
+  content: string,
+  labelLanguage: string,
+  copyLabel: string,
+  formatFoldLabel: (hiddenCount: number) => string,
+): string {
   const numbers: DiffLineNumbers = {}
   const lines = content.split(/\r?\n/)
   if (lines.at(-1) === '') lines.pop()
 
-  const highlighted = lines
+  const renderedRows = lines
     .map((line) => {
       const classes = ['diff-line']
+      let foldableContext = false
       if (isDiffFileHeader(line)) classes.push('diff-line-file-header')
       else if (isDiffHunkHeader(line)) {
         classes.push('diff-line-hunk-header')
@@ -131,15 +196,19 @@ function renderUnifiedDiffCode(content: string, labelLanguage: string, copyLabel
       }
       else if (isDiffAddedLine(line)) classes.push('diff-line-added')
       else if (isDiffRemovedLine(line)) classes.push('diff-line-removed')
+      else foldableContext = true
 
       const lineNumber = formatDiffLineNumber(line, numbers)
       const html = `<span class="${classes.join(' ')}"><span class="diff-line-number ${lineNumber.className}" aria-hidden="true">${escapeHtml(lineNumber.value)}</span><span class="diff-line-content">${escapeHtml(line || ' ')}</span></span>`
       advanceDiffLineNumber(line, numbers)
-      return html
+      return { html, foldableContext }
     })
+
+  const highlighted = collapseFoldableContextRows(renderedRows, formatFoldLabel)
+    .map((row) => row.html)
     .join('')
 
-  return renderCodeBlockWrapper(highlighted, 'diff', labelLanguage, copyLabel, ['hljs-unified-diff'])
+  return renderCodeBlockWrapper(highlighted, 'diff', labelLanguage, copyLabel, ['hljs-unified-diff'], content)
 }
 
 export function normalizeHighlightLanguage(lang?: string): string {
@@ -198,8 +267,41 @@ export function isUnifiedDiffContent(content: string, lang?: string): boolean {
   return fileHeaders >= 2 && hunkHeaders > 0
 }
 
+export function extractUnifiedDiffPayload(value: unknown, depth = 0): string | null {
+  if (depth > 4 || value === null || typeof value !== 'object') return null
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const diff = extractUnifiedDiffPayload(item, depth + 1)
+      if (diff) return diff
+    }
+    return null
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+  for (const [key, candidate] of entries) {
+    if (
+      DIFF_PAYLOAD_FIELD_NAMES.has(key.toLowerCase())
+      && typeof candidate === 'string'
+      && isUnifiedDiffContent(candidate)
+    ) {
+      return candidate
+    }
+  }
+
+  for (const [, candidate] of entries) {
+    if (candidate && typeof candidate === 'object') {
+      const diff = extractUnifiedDiffPayload(candidate, depth + 1)
+      if (diff) return diff
+    }
+  }
+
+  return null
+}
+
 type RenderHighlightedCodeBlockOptions = {
   maxHighlightLength?: number
+  formatDiffFoldLabel?: (hiddenCount: number) => string
 }
 
 export function renderHighlightedCodeBlock(
@@ -213,7 +315,8 @@ export function renderHighlightedCodeBlock(
   const highlightLimit = options.maxHighlightLength ?? Number.POSITIVE_INFINITY
 
   if (isUnifiedDiffContent(content, requestedLanguage || normalizedLanguage)) {
-    return renderUnifiedDiffCode(content, requestedLanguage || 'diff', copyLabel)
+    const formatDiffFoldLabel = options.formatDiffFoldLabel ?? ((hiddenCount: number) => String(hiddenCount))
+    return renderUnifiedDiffCode(content, requestedLanguage || 'diff', copyLabel, formatDiffFoldLabel)
   }
 
   let highlighted = ''
@@ -256,9 +359,9 @@ export async function handleCodeBlockCopyClick(event: MouseEvent): Promise<boole
 
   event.preventDefault()
 
-  const block = button.closest('.hljs-code-block')
+  const block = button.closest<HTMLElement>('.hljs-code-block')
   const code = block?.querySelector('code')
-  const text = code?.textContent ?? ''
+  const text = block?.getAttribute('data-copy-text') ?? code?.textContent ?? ''
   if (!text) return false
 
   return copyTextToClipboard(text)

--- a/packages/client/src/components/hermes/chat/highlight.ts
+++ b/packages/client/src/components/hermes/chat/highlight.ts
@@ -9,6 +9,8 @@ const LANGUAGE_ALIASES: Record<string, string> = {
   vue: 'xml',
 }
 
+const UNIFIED_DIFF_LANGUAGES = new Set(['diff', 'patch'])
+
 function escapeHtml(value: string): string {
   return value
     .replaceAll('&', '&amp;')
@@ -20,6 +22,124 @@ function escapeHtml(value: string): string {
 
 function sanitizeLanguageClass(value: string): string {
   return value.replace(/[^a-z0-9_-]/gi, '-') || 'plain'
+}
+
+function renderCodeBlockWrapper(
+  highlighted: string,
+  codeClassLanguage: string,
+  labelLanguage: string | undefined,
+  copyLabel: string,
+  extraClasses: string[] = [],
+): string {
+  const languageLabelHtml = labelLanguage
+    ? `<span class="code-lang">${escapeHtml(labelLanguage)}</span>`
+    : ''
+  const blockClasses = ['hljs-code-block', ...extraClasses].join(' ')
+
+  return `<pre class="${blockClasses}"><div class="code-header">${languageLabelHtml}<button type="button" class="copy-btn" data-copy-code="true">${escapeHtml(copyLabel)}</button></div><code class="hljs language-${sanitizeLanguageClass(codeClassLanguage)}">${highlighted}</code></pre>`
+}
+
+function isUnifiedDiffLanguage(lang?: string): boolean {
+  return UNIFIED_DIFF_LANGUAGES.has(lang?.trim().toLowerCase() || '')
+}
+
+function isDiffFileHeader(line: string): boolean {
+  return /^(diff --git |index |---(?:\s|$)|\+\+\+(?:\s|$))/.test(line)
+}
+
+function isDiffHunkHeader(line: string): boolean {
+  return /^@@(?:\s|$)/.test(line)
+}
+
+function isDiffAddedLine(line: string): boolean {
+  return /^\+(?!\+\+(?:\s|$))/.test(line)
+}
+
+function isDiffRemovedLine(line: string): boolean {
+  return /^-(?!---(?:\s|$))/.test(line)
+}
+
+type DiffLineNumbers = {
+  oldNumber?: number
+  newNumber?: number
+}
+
+function parseDiffHunkHeader(line: string): DiffLineNumbers | null {
+  const match = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
+  if (!match) return null
+  return {
+    oldNumber: Number(match[1]),
+    newNumber: Number(match[2]),
+  }
+}
+
+function formatDiffLineNumber(line: string, numbers: DiffLineNumbers): { value: string; className: string } {
+  if (isDiffFileHeader(line) || isDiffHunkHeader(line)) {
+    return { value: '', className: 'diff-line-number-empty' }
+  }
+  if (isDiffRemovedLine(line)) {
+    return {
+      value: numbers.oldNumber != null ? String(numbers.oldNumber) : '',
+      className: 'diff-line-number-old',
+    }
+  }
+  if (isDiffAddedLine(line)) {
+    return {
+      value: numbers.newNumber != null ? String(numbers.newNumber) : '',
+      className: 'diff-line-number-new',
+    }
+  }
+  if (!isDiffFileHeader(line) && !isDiffHunkHeader(line) && numbers.newNumber != null) {
+    return {
+      value: String(numbers.newNumber),
+      className: 'diff-line-number-context',
+    }
+  }
+  return { value: '', className: 'diff-line-number-empty' }
+}
+
+function advanceDiffLineNumber(line: string, numbers: DiffLineNumbers): void {
+  if (isDiffFileHeader(line) || isDiffHunkHeader(line)) return
+  if (isDiffRemovedLine(line)) {
+    if (numbers.oldNumber != null) numbers.oldNumber += 1
+    return
+  }
+  if (isDiffAddedLine(line)) {
+    if (numbers.newNumber != null) numbers.newNumber += 1
+    return
+  }
+  if (numbers.oldNumber != null) numbers.oldNumber += 1
+  if (numbers.newNumber != null) numbers.newNumber += 1
+}
+
+function renderUnifiedDiffCode(content: string, labelLanguage: string, copyLabel: string): string {
+  const numbers: DiffLineNumbers = {}
+  const lines = content.split(/\r?\n/)
+  if (lines.at(-1) === '') lines.pop()
+
+  const highlighted = lines
+    .map((line) => {
+      const classes = ['diff-line']
+      if (isDiffFileHeader(line)) classes.push('diff-line-file-header')
+      else if (isDiffHunkHeader(line)) {
+        classes.push('diff-line-hunk-header')
+        const hunkNumbers = parseDiffHunkHeader(line)
+        if (hunkNumbers) {
+          numbers.oldNumber = hunkNumbers.oldNumber
+          numbers.newNumber = hunkNumbers.newNumber
+        }
+      }
+      else if (isDiffAddedLine(line)) classes.push('diff-line-added')
+      else if (isDiffRemovedLine(line)) classes.push('diff-line-removed')
+
+      const lineNumber = formatDiffLineNumber(line, numbers)
+      const html = `<span class="${classes.join(' ')}"><span class="diff-line-number ${lineNumber.className}" aria-hidden="true">${escapeHtml(lineNumber.value)}</span><span class="diff-line-content">${escapeHtml(line || ' ')}</span></span>`
+      advanceDiffLineNumber(line, numbers)
+      return html
+    })
+    .join('')
+
+  return renderCodeBlockWrapper(highlighted, 'diff', labelLanguage, copyLabel, ['hljs-unified-diff'])
 }
 
 export function normalizeHighlightLanguage(lang?: string): string {
@@ -36,6 +156,48 @@ export function inferStructuredLanguage(content: string): string | undefined {
   }
 }
 
+export function isUnifiedDiffContent(content: string, lang?: string): boolean {
+  const lines = content.split(/\r?\n/)
+  if (lines.length < 3) return false
+
+  let fileHeaders = 0
+  let hunkHeaders = 0
+  let addedLines = 0
+  let removedLines = 0
+  let diffHeaders = 0
+
+  for (const line of lines) {
+    if (/^(diff --git |index )/.test(line)) {
+      diffHeaders += 1
+      continue
+    }
+    if (/^---(?:\s|$)|^\+\+\+(?:\s|$)/.test(line)) {
+      fileHeaders += 1
+      continue
+    }
+    if (isDiffHunkHeader(line)) {
+      hunkHeaders += 1
+      continue
+    }
+    if (isDiffAddedLine(line)) {
+      addedLines += 1
+      continue
+    }
+    if (isDiffRemovedLine(line)) {
+      removedLines += 1
+    }
+  }
+
+  const hasChangedLines = addedLines > 0 || removedLines > 0
+  if (!hasChangedLines) return false
+
+  if (isUnifiedDiffLanguage(lang)) {
+    return hunkHeaders > 0 || fileHeaders >= 2 || diffHeaders > 0
+  }
+
+  return fileHeaders >= 2 && hunkHeaders > 0
+}
+
 type RenderHighlightedCodeBlockOptions = {
   maxHighlightLength?: number
 }
@@ -49,6 +211,10 @@ export function renderHighlightedCodeBlock(
   const requestedLanguage = lang?.trim().toLowerCase() || ''
   const normalizedLanguage = normalizeHighlightLanguage(requestedLanguage)
   const highlightLimit = options.maxHighlightLength ?? Number.POSITIVE_INFINITY
+
+  if (isUnifiedDiffContent(content, requestedLanguage || normalizedLanguage)) {
+    return renderUnifiedDiffCode(content, requestedLanguage || 'diff', copyLabel)
+  }
 
   let highlighted = ''
   let codeClassLanguage = normalizedLanguage || requestedLanguage || 'plain'
@@ -74,11 +240,7 @@ export function renderHighlightedCodeBlock(
     }
   }
 
-  const languageLabelHtml = labelLanguage
-    ? `<span class="code-lang">${escapeHtml(labelLanguage)}</span>`
-    : ''
-
-  return `<pre class="hljs-code-block"><div class="code-header">${languageLabelHtml}<button type="button" class="copy-btn" data-copy-code="true">${escapeHtml(copyLabel)}</button></div><code class="hljs language-${sanitizeLanguageClass(codeClassLanguage)}">${highlighted}</code></pre>`
+  return renderCodeBlockWrapper(highlighted, codeClassLanguage, labelLanguage, copyLabel)
 }
 
 export async function copyTextToClipboard(text: string): Promise<boolean> {

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -7,7 +7,9 @@ import ProfileAvatar from '@/components/hermes/profiles/ProfileAvatar.vue'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import {
     copyTextToClipboard,
+    extractUnifiedDiffPayload,
     handleCodeBlockCopyClick,
+    isUnifiedDiffContent,
     renderHighlightedCodeBlock,
 } from '../chat/highlight'
 import { parseThinking, countThinkingChars } from '@/utils/thinking-parser'
@@ -176,7 +178,7 @@ const toolExpanded = ref(false)
 const isToolMessage = computed(() => props.message.role === 'tool')
 const hasToolDetails = computed(() => !!(props.message.toolArgs || props.message.toolResult))
 const toolArgsPayload = computed(() => formatToolPayload(props.message.toolArgs))
-const toolResultPayload = computed(() => formatToolPayload(props.message.toolResult))
+const toolResultPayload = computed(() => formatToolPayload(props.message.toolResult, true))
 const fullToolArgs = computed(() => toolArgsPayload.value.full)
 const formattedToolArgs = computed(() => toolArgsPayload.value.display)
 const fullToolResult = computed(() => toolResultPayload.value.full)
@@ -272,19 +274,29 @@ function truncateJsonValue(value: unknown, marker: string): unknown {
     return { [JSON_TRUNCATED_KEY]: marker }
 }
 
-function formatToolPayload(raw?: string): ToolPayload {
+function formatToolPayload(raw?: string, extractDiff = false): ToolPayload {
     if (!raw) return { full: '', display: '' }
     try {
         const parsed = JSON.parse(raw)
         const full = JSON.stringify(parsed, null, 2)
+        const extractedDiff = extractDiff ? extractUnifiedDiffPayload(parsed) : null
+        if (extractedDiff) {
+            return {
+                full,
+                display: extractedDiff,
+                language: 'diff',
+            }
+        }
         const display = full.length > TOOL_PAYLOAD_DISPLAY_LIMIT
             ? JSON.stringify(truncateJsonValue(parsed, t('chat.truncated')), null, 2)
             : full
         return { full, display, language: 'json' }
     } catch {
+        const language = isUnifiedDiffContent(raw) ? 'diff' : undefined
         return {
             full: raw,
-            display: raw.length > TOOL_PAYLOAD_DISPLAY_LIMIT ? raw.slice(0, TOOL_PAYLOAD_DISPLAY_LIMIT) + '\n' + t('chat.truncated') : raw,
+            display: language === 'diff' || raw.length <= TOOL_PAYLOAD_DISPLAY_LIMIT ? raw : raw.slice(0, TOOL_PAYLOAD_DISPLAY_LIMIT) + '\n' + t('chat.truncated'),
+            language,
         }
     }
 }
@@ -292,6 +304,7 @@ function formatToolPayload(raw?: string): ToolPayload {
 function renderToolPayload(content: string, language?: string): string {
     return renderHighlightedCodeBlock(content, language, t('common.copy'), {
         maxHighlightLength: TOOL_PAYLOAD_DISPLAY_LIMIT,
+        formatDiffFoldLabel: (hiddenCount) => t('chat.unchangedLines', { count: hiddenCount }),
     })
 }
 

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -385,6 +385,7 @@ export default {
     arguments: 'Argumente',
     result: 'Ergebnis',
     truncated: '... (abgeschnitten)',
+    unchangedLines: '{count} unveränderte Zeilen',
     executionDuration: 'Ausführungszeit',    thinkingLabel: 'Denkprozess',
     thinkingInProgress: 'Denkt…',
     thinkingShow: 'Denkprozess anzeigen',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -411,6 +411,7 @@ export default {
     arguments: 'Arguments',
     result: 'Result',
     truncated: '... (truncated)',
+    unchangedLines: '{count} unchanged lines',
     executionDuration: 'Execution time',
     thinkingLabel: 'Thinking',
     thinkingInProgress: 'Thinking…',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -385,6 +385,7 @@ export default {
     arguments: 'Argumentos',
     result: 'Resultado',
     truncated: '... (truncado)',
+    unchangedLines: '{count} líneas sin cambios',
     executionDuration: 'Tiempo de ejecución',    thinkingLabel: 'Pensamiento',
     thinkingInProgress: 'Pensando…',
     thinkingShow: 'Mostrar pensamiento',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -385,6 +385,7 @@ export default {
     arguments: 'Arguments',
     result: 'Resultat',
     truncated: '... (tronque)',
+    unchangedLines: '{count} lignes inchangées',
     executionDuration: 'Temps d’exécution',    thinkingLabel: 'Raisonnement',
     thinkingInProgress: 'En réflexion…',
     thinkingShow: 'Afficher le raisonnement',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -385,6 +385,7 @@ export default {
     arguments: '引数',
     result: '結果',
     truncated: '... (省略)',
+    unchangedLines: '変更なし {count} 行',
     executionDuration: '実行時間',    thinkingLabel: '思考過程',
     thinkingInProgress: '思考中…',
     thinkingShow: '思考過程を表示',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -385,6 +385,7 @@ export default {
     arguments: '인수',
     result: '결과',
     truncated: '... (잘림)',
+    unchangedLines: '변경 없음 {count}줄',
     executionDuration: '실행 시간',    thinkingLabel: '사고 과정',
     thinkingInProgress: '사고 중…',
     thinkingShow: '사고 과정 펼치기',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -385,6 +385,7 @@ export default {
     arguments: 'Argumentos',
     result: 'Resultado',
     truncated: '... (truncado)',
+    unchangedLines: '{count} linhas inalteradas',
     executionDuration: 'Tempo de execução',    thinkingLabel: 'Raciocínio',
     thinkingInProgress: 'Pensando…',
     thinkingShow: 'Mostrar raciocínio',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -313,6 +313,7 @@ export default {
     arguments: 'Аргументы',
     result: 'Результат',
     truncated: '... (обрезано)',
+    unchangedLines: '{count} строк без изменений',
     executionDuration: 'Длительность выполнения',
     thinkingLabel: 'Процесс размышления',
     thinkingInProgress: 'Размышление…',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -405,6 +405,7 @@ export default {
     arguments: '參數',
     result: '結果',
     truncated: '... (已截斷)',
+    unchangedLines: '{count} 行未修改',
     executionDuration: '執行時長',
     thinkingLabel: '思考過程',
     thinkingInProgress: '思考中…',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -411,6 +411,7 @@ export default {
     arguments: '参数',
     result: '结果',
     truncated: '... (已截断)',
+    unchangedLines: '{count} 行未修改',
     executionDuration: '执行时长',
     thinkingLabel: '思考过程',
     thinkingInProgress: '思考中…',

--- a/packages/client/src/styles/code-block.scss
+++ b/packages/client/src/styles/code-block.scss
@@ -92,6 +92,12 @@
       background: rgba(59, 130, 246, 0.12);
     }
 
+    .diff-line-context-fold {
+      color: #64748b;
+      background: rgba(148, 163, 184, 0.1);
+      font-style: italic;
+    }
+
     .diff-line-added {
       color: #166534;
       background: rgba(34, 197, 94, 0.14);
@@ -194,6 +200,11 @@
     .diff-line-hunk-header {
       color: #93c5fd;
       background: rgba(59, 130, 246, 0.18);
+    }
+
+    .diff-line-context-fold {
+      color: #cbd5e1;
+      background: rgba(148, 163, 184, 0.14);
     }
 
     .diff-line-added {

--- a/packages/client/src/styles/code-block.scss
+++ b/packages/client/src/styles/code-block.scss
@@ -50,6 +50,68 @@
     line-height: 1.5;
     overflow-x: auto;
   }
+
+  &.hljs-unified-diff {
+    code.hljs {
+      display: block;
+      padding: 0;
+      overflow-x: auto;
+      white-space: pre;
+      word-break: normal;
+      line-height: 1.45;
+    }
+
+    .diff-line {
+      display: grid;
+      grid-template-columns: 58px max-content;
+      min-width: max-content;
+      white-space: pre;
+    }
+
+    .diff-line-number {
+      user-select: none;
+      text-align: right;
+      padding: 0 14px 0 10px;
+      color: #94a3b8;
+      background: rgba(15, 23, 42, 0.04);
+      border-right: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    .diff-line-content {
+      padding: 0 12px;
+      white-space: pre;
+    }
+
+    .diff-line-file-header {
+      color: #475569;
+      background: rgba(148, 163, 184, 0.16);
+    }
+
+    .diff-line-hunk-header {
+      color: #1d4ed8;
+      background: rgba(59, 130, 246, 0.12);
+    }
+
+    .diff-line-added {
+      color: #166534;
+      background: rgba(34, 197, 94, 0.14);
+
+      .diff-line-number {
+        color: #15803d;
+        background: rgba(34, 197, 94, 0.18);
+      }
+    }
+
+    .diff-line-removed {
+      color: #b91c1c;
+      background: rgba(239, 68, 68, 0.12);
+
+      .diff-line-number {
+        color: #dc2626;
+        background: rgba(239, 68, 68, 0.18);
+      }
+    }
+  }
 }
 
 // highlight.js theme override — higher-contrast, still calm
@@ -115,6 +177,44 @@
 .dark .hljs-code-block {
   .hljs {
     color: #e5e7eb;
+  }
+
+  &.hljs-unified-diff {
+    .diff-line-file-header {
+      color: #cbd5e1;
+      background: rgba(148, 163, 184, 0.18);
+    }
+
+    .diff-line-number {
+      color: #94a3b8;
+      background: rgba(15, 23, 42, 0.28);
+      border-right-color: rgba(148, 163, 184, 0.22);
+    }
+
+    .diff-line-hunk-header {
+      color: #93c5fd;
+      background: rgba(59, 130, 246, 0.18);
+    }
+
+    .diff-line-added {
+      color: #86efac;
+      background: rgba(34, 197, 94, 0.18);
+
+      .diff-line-number {
+        color: #4ade80;
+        background: rgba(34, 197, 94, 0.22);
+      }
+    }
+
+    .diff-line-removed {
+      color: #fca5a5;
+      background: rgba(239, 68, 68, 0.18);
+
+      .diff-line-number {
+        color: #f87171;
+        background: rgba(239, 68, 68, 0.22);
+      }
+    }
   }
 
   .hljs-keyword,

--- a/tests/client/highlight-helper.test.ts
+++ b/tests/client/highlight-helper.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const highlightJsMock = vi.hoisted(() => ({
@@ -8,11 +9,19 @@ const highlightJsMock = vi.hoisted(() => ({
   registerLanguage: vi.fn(),
 }))
 
+const copyToClipboardMock = vi.hoisted(() => vi.fn<(text: string) => Promise<boolean>>(async () => true))
+
 vi.mock('highlight.js', () => ({
   default: highlightJsMock,
 }))
 
+vi.mock('@/utils/clipboard', () => ({
+  copyToClipboard: copyToClipboardMock,
+}))
+
 import {
+  extractUnifiedDiffPayload,
+  handleCodeBlockCopyClick,
   isUnifiedDiffContent,
   normalizeHighlightLanguage,
   renderHighlightedCodeBlock,
@@ -31,6 +40,7 @@ index 1111111..2222222 100644
 describe('highlight helper', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    copyToClipboardMock.mockResolvedValue(true)
     highlightJsMock.getLanguage.mockImplementation((lang?: string) => ['shell', 'xml', 'yaml', 'bash', 'json'].includes(lang || ''))
     highlightJsMock.highlight.mockImplementation((content: string, { language }: { language: string }) => ({
       value: `<span class="mock-${language}">${content}</span>`,
@@ -99,6 +109,18 @@ describe('highlight helper', () => {
     expect(isUnifiedDiffContent('@@ -1 +1 @@\n-a\n+b', 'diff')).toBe(true)
   })
 
+  it('extracts unified diffs from JSON payload fields shared by chat and group chat renderers', () => {
+    const nestedDiff = {
+      ok: true,
+      result: {
+        difference: UNIFIED_DIFF_SAMPLE,
+      },
+    }
+
+    expect(extractUnifiedDiffPayload(nestedDiff)).toBe(UNIFIED_DIFF_SAMPLE)
+    expect(extractUnifiedDiffPayload({ difference: 'not a diff' })).toBeNull()
+  })
+
   it('renders unified diffs with semantic rows, line numbers, and no highlight.js execution', () => {
     const html = renderHighlightedCodeBlock(UNIFIED_DIFF_SAMPLE, undefined, 'Copy')
 
@@ -120,5 +142,49 @@ describe('highlight helper', () => {
     const html = renderHighlightedCodeBlock(UNIFIED_DIFF_SAMPLE, undefined, 'Copy')
 
     expect(html).not.toContain('</span>\n<span class="diff-line')
+  })
+
+  it('collapses long unchanged context runs in unified diffs by default', () => {
+    const contextLines = Array.from({ length: 12 }, (_, index) => ` unchanged ${index + 1}`).join('\n')
+    const sample = `diff --git a/foo.ts b/foo.ts\n--- a/foo.ts\n+++ b/foo.ts\n@@ -10,14 +10,14 @@\n${contextLines}\n-old value\n+new value\n`
+
+    const html = renderHighlightedCodeBlock(sample, 'diff', 'Copy', {
+      formatDiffFoldLabel: (hiddenCount) => `${hiddenCount} unchanged lines`,
+    })
+
+    expect(html).toContain('diff-line-context-fold')
+    expect(html).toContain('6 unchanged lines')
+    expect(html).toContain(' unchanged 1')
+    expect(html).toContain(' unchanged 3')
+    expect(html).toContain(' unchanged 10')
+    expect(html).toContain(' unchanged 12')
+    expect(html).not.toContain(' unchanged 4</span>')
+    expect(html).not.toContain(' unchanged 9</span>')
+    expect(html).toContain('data-copy-text=')
+    expect(html).toContain(' unchanged 4\n unchanged 5')
+    expect(html).toContain('-old value')
+    expect(html).toContain('+new value')
+  })
+
+  it('copies the full original unified diff after context folding', async () => {
+    const contextLines = Array.from({ length: 12 }, (_, index) => ` unchanged ${index + 1}`).join('\n')
+    const sample = `diff --git a/foo.ts b/foo.ts\n--- a/foo.ts\n+++ b/foo.ts\n@@ -10,14 +10,14 @@\n${contextLines}\n-old value\n+new value\n`
+    const container = document.createElement('div')
+    container.innerHTML = renderHighlightedCodeBlock(sample, 'diff', 'Copy', {
+      formatDiffFoldLabel: (hiddenCount) => `${hiddenCount} unchanged lines`,
+    })
+    const button = container.querySelector<HTMLElement>('[data-copy-code="true"]')!
+
+    const copied = await handleCodeBlockCopyClick(new MouseEvent('click', { bubbles: true }))
+    expect(copied).toBeNull()
+
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+    Object.defineProperty(event, 'target', { value: button })
+
+    await expect(handleCodeBlockCopyClick(event)).resolves.toBe(true)
+    expect(copyToClipboardMock).toHaveBeenCalledWith(sample)
+    const copiedText = copyToClipboardMock.mock.lastCall?.[0] || ''
+    expect(copiedText).toContain(' unchanged 4')
+    expect(copiedText).not.toContain('unchanged lines')
   })
 })

--- a/tests/client/highlight-helper.test.ts
+++ b/tests/client/highlight-helper.test.ts
@@ -12,7 +12,21 @@ vi.mock('highlight.js', () => ({
   default: highlightJsMock,
 }))
 
-import { normalizeHighlightLanguage, renderHighlightedCodeBlock } from '@/components/hermes/chat/highlight'
+import {
+  isUnifiedDiffContent,
+  normalizeHighlightLanguage,
+  renderHighlightedCodeBlock,
+} from '@/components/hermes/chat/highlight'
+
+const UNIFIED_DIFF_SAMPLE = `diff --git a/foo.ts b/foo.ts
+index 1111111..2222222 100644
+--- a/foo.ts
++++ b/foo.ts
+@@ -1,2 +1,2 @@
+-const value = 1
++const value = 2
+ console.log(value)
+`
 
 describe('highlight helper', () => {
   beforeEach(() => {
@@ -77,5 +91,34 @@ describe('highlight helper', () => {
 
     expect(html).toContain('&lt;tag&gt;')
     expect(html).toContain('class="code-lang">vue</span>')
+  })
+
+  it('detects unified diff content conservatively', () => {
+    expect(isUnifiedDiffContent(UNIFIED_DIFF_SAMPLE)).toBe(true)
+    expect(isUnifiedDiffContent('--- note\n+++ more\nplain text')).toBe(false)
+    expect(isUnifiedDiffContent('@@ -1 +1 @@\n-a\n+b', 'diff')).toBe(true)
+  })
+
+  it('renders unified diffs with semantic rows, line numbers, and no highlight.js execution', () => {
+    const html = renderHighlightedCodeBlock(UNIFIED_DIFF_SAMPLE, undefined, 'Copy')
+
+    expect(highlightJsMock.highlight).not.toHaveBeenCalled()
+    expect(html).toContain('hljs-unified-diff')
+    expect(html).toContain('class="code-lang">diff</span>')
+    expect(html).toContain('diff-line diff-line-file-header')
+    expect(html).toContain('diff-line diff-line-hunk-header')
+    expect(html).toContain('diff-line diff-line-removed')
+    expect(html).toContain('diff-line diff-line-added')
+    expect(html).toContain('class="diff-line-number diff-line-number-old" aria-hidden="true">1</span>')
+    expect(html).toContain('class="diff-line-number diff-line-number-new" aria-hidden="true">1</span>')
+    expect(html).toContain('class="diff-line-number diff-line-number-context" aria-hidden="true">2</span>')
+    expect(html).toContain('class="diff-line-content">-const value = 1</span>')
+    expect(html).toContain('class="diff-line-content">+const value = 2</span>')
+  })
+
+  it('renders unified diff rows without newline text nodes between block rows', () => {
+    const html = renderHighlightedCodeBlock(UNIFIED_DIFF_SAMPLE, undefined, 'Copy')
+
+    expect(html).not.toContain('</span>\n<span class="diff-line')
   })
 })

--- a/tests/client/highlight-safety.test.ts
+++ b/tests/client/highlight-safety.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from 'vitest'
 
 import { renderHighlightedCodeBlock } from '@/components/hermes/chat/highlight'
 
+const DIFF_WITH_HTML = `diff --git a/foo.html b/foo.html
+--- a/foo.html
++++ b/foo.html
+@@ -1 +1 @@
+-<script>alert(1)</script>
++<img src=x onerror=alert(1)>
+`
+
 describe('highlight safety', () => {
   it('escapes large unknown code content', () => {
     const html = renderHighlightedCodeBlock('<img src=x onerror=alert(1)>'.repeat(100), 'unknown', 'Copy')
@@ -35,5 +43,16 @@ describe('highlight safety', () => {
 
     expect(html).toContain('Copy &lt;now&gt;')
     expect(html).not.toContain('Copy <now>')
+  })
+
+  it('escapes executable HTML inside unified diff rendering', () => {
+    const html = renderHighlightedCodeBlock(DIFF_WITH_HTML, undefined, 'Copy')
+
+    expect(html).toContain('diff-line diff-line-added')
+    expect(html).toContain('diff-line diff-line-removed')
+    expect(html).not.toContain('<script>')
+    expect(html).not.toContain('<img')
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;')
   })
 })

--- a/tests/client/message-item-highlight.test.ts
+++ b/tests/client/message-item-highlight.test.ts
@@ -281,4 +281,40 @@ describe('MessageItem tool details', () => {
     expect(toolDetails.find('.diff-line-added .diff-line-content').text()).toContain('b'.repeat(1600))
     expect(toolDetails.text()).not.toContain('chat.truncated')
   })
+
+  it('shows only an embedded difference field when a JSON tool result contains a unified diff', async () => {
+    const writeText = vi.mocked(navigator.clipboard.writeText)
+    const largeDiff = `diff --git a/foo.ts b/foo.ts\n--- a/foo.ts\n+++ b/foo.ts\n@@ -1,1 +1,1 @@\n-${'a'.repeat(1600)}\n+${'b'.repeat(1600)}\n`
+    const fullResult = {
+      summary: 'metadata should stay out of the visible diff display',
+      difference: largeDiff,
+      ok: true,
+    }
+    const wrapper = mount(MessageItem, {
+      props: {
+        message: {
+          id: 'tool-json-diff-large',
+          role: 'tool',
+          content: '',
+          timestamp: Date.now(),
+          toolName: 'git_show',
+          toolResult: JSON.stringify(fullResult),
+          toolStatus: 'done',
+        } satisfies Message,
+      },
+    })
+
+    await wrapper.find('.tool-line').trigger('click')
+
+    const toolDetails = wrapper.find('.tool-details')
+    const code = toolDetails.find('code.hljs')
+    expect(toolDetails.find('.code-lang').text()).toBe('diff')
+    expect(toolDetails.find('.hljs-unified-diff').exists()).toBe(true)
+    expect(toolDetails.find('.diff-line-added .diff-line-content').text()).toContain('b'.repeat(1600))
+    expect(code.text()).not.toContain('metadata should stay out')
+    expect(toolDetails.text()).not.toContain('chat.truncated')
+
+    await wrapper.find('.tool-details [data-copy-source="tool-result"] [data-copy-code="true"]').trigger('click')
+    expect(writeText).toHaveBeenCalledWith(JSON.stringify(fullResult, null, 2))
+  })
 })

--- a/tests/client/message-item-highlight.test.ts
+++ b/tests/client/message-item-highlight.test.ts
@@ -3,6 +3,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 
+const UNIFIED_DIFF_SAMPLE = `diff --git a/foo.ts b/foo.ts
+index 1111111..2222222 100644
+--- a/foo.ts
++++ b/foo.ts
+@@ -1,2 +1,2 @@
+-const value = 1
++const value = 2
+ console.log(value)
+`
+
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     t: (key: string) => key,
@@ -218,5 +228,57 @@ describe('MessageItem tool details', () => {
 
     await wrapper.find('.tool-details [data-copy-code="true"]').trigger('click')
     expect(writeText).toHaveBeenCalledWith(fullResult)
+  })
+
+  it('renders raw unified diff tool payloads with semantic diff classes', async () => {
+    const wrapper = mount(MessageItem, {
+      props: {
+        message: {
+          id: 'tool-diff',
+          role: 'tool',
+          content: '',
+          timestamp: Date.now(),
+          toolName: 'apply_patch',
+          toolResult: UNIFIED_DIFF_SAMPLE,
+          toolStatus: 'done',
+        } satisfies Message,
+      },
+    })
+
+    await wrapper.find('.tool-line').trigger('click')
+
+    const toolDetails = wrapper.find('.tool-details')
+    expect(toolDetails.find('.code-lang').text()).toBe('diff')
+    expect(toolDetails.find('.hljs-unified-diff').exists()).toBe(true)
+    expect(toolDetails.find('.diff-line-file-header').exists()).toBe(true)
+    expect(toolDetails.find('.diff-line-hunk-header').exists()).toBe(true)
+    expect(toolDetails.find('.diff-line-number-old').text()).toBe('1')
+    expect(toolDetails.find('.diff-line-number-new').text()).toBe('1')
+    expect(toolDetails.find('.diff-line-added .diff-line-content').text()).toBe('+const value = 2')
+    expect(toolDetails.find('.diff-line-removed .diff-line-content').text()).toBe('-const value = 1')
+  })
+
+  it('does not truncate large unified diff tool results', async () => {
+    const largeDiff = `diff --git a/foo.ts b/foo.ts\n--- a/foo.ts\n+++ b/foo.ts\n@@ -1,1 +1,1 @@\n-${'a'.repeat(1600)}\n+${'b'.repeat(1600)}\n`
+    const wrapper = mount(MessageItem, {
+      props: {
+        message: {
+          id: 'tool-diff-large',
+          role: 'tool',
+          content: '',
+          timestamp: Date.now(),
+          toolName: 'git_show',
+          toolResult: largeDiff,
+          toolStatus: 'done',
+        } satisfies Message,
+      },
+    })
+
+    await wrapper.find('.tool-line').trigger('click')
+
+    const toolDetails = wrapper.find('.tool-details')
+    expect(toolDetails.find('.code-lang').text()).toBe('diff')
+    expect(toolDetails.find('.diff-line-added .diff-line-content').text()).toContain('b'.repeat(1600))
+    expect(toolDetails.text()).not.toContain('chat.truncated')
   })
 })


### PR DESCRIPTION
## 改动
- 识别 tool result JSON 中的 unified diff 字段，只展示 diff body，避免整段 JSON 元数据挤占结果视图。
- unified diff code block 使用行级渲染和行号；长段未改动上下文默认折叠为静态提示，不引入展开交互。
- 复制按钮仍复制完整原始内容；tool 参数保持原 JSON 展示。
- group chat 与普通 chat 共用相同显示处理，并补齐多语言折叠文案。
- 按 chat 链路 harness 要求补充 `docs/cli-chat-sessions.md` 变更记录。

## 验证
- `npm run harness:check`
- `git diff --check`
- `npm run test -- tests/client/highlight-helper.test.ts tests/client/message-item-highlight.test.ts tests/client/highlight-safety.test.ts`（32 tests passed）
- `npm run build`
- 独立代码 review：pass，无 blocker

## 说明
- 折叠是纯展示层静态压缩，不支持点击展开；完整内容仍可通过复制获取。
- 相关：#1071 覆盖多个修复；这个 PR 只保留 diff / tool result 展示这一块，方便单独 review。
- build 仅保留现有 large chunk warning。
