### PR TITLE
[codex] bundle Hermes plugin dependencies

### DIFF
--- a/packages/desktop/scripts/install-hermes.mjs
+++ b/packages/desktop/scripts/install-hermes.mjs
@@ -35,6 +35,8 @@ const HERMES_VERSION = hermesVersion()
 // the channel extras below.
 const HERMES_EXTRAS = [
   'mcp',
+  'hindsight',
+  'honcho',
   'messaging',
   'slack',
   'wecom',
@@ -45,6 +47,14 @@ const HERMES_PACKAGE = process.env.HERMES_PACKAGE || `hermes-agent[${HERMES_EXTR
 const EXTRA_PYTHON_PACKAGES = splitPackageList(
   process.env.HERMES_EXTRA_PYTHON_PACKAGES || [
     'websockets',
+    // Bundled plugin runtime deps. Keep these in sync with hermes-agent
+    // plugins/*/plugin.yaml and the bundled plugin imports.
+    'hindsight-client==0.6.1',
+    'honcho-ai==2.0.1',
+    'mem0ai==2.0.4',
+    'supermemory==3.45.0',
+    'numpy==2.4.3',
+    'playwright==1.60.0',
     'mautrix==0.21.0',
     'Markdown==3.10.2',
     'aiosqlite==0.22.1',
@@ -364,6 +374,9 @@ function installBrowserRuntime() {
     process.exit(1)
   }
   console.log(`✓ bundled Chrome executable available at ${browserExecutable}`)
+
+  console.log(`→ Installing Python Playwright Chromium at ${PLAYWRIGHT_BROWSERS_PATH}`)
+  run(pyBin, ['-m', 'playwright', 'install', 'chromium'], { env: browserRuntimeEnv() })
 }
 
 installPythonPackages([HERMES_PACKAGE], 'hermes-agent')
@@ -377,6 +390,12 @@ run(pyBin, [
     'import importlib.util',
     'import mcp',
     'import tools.mcp_tool as t',
+    'import hindsight_client',
+    'import honcho',
+    'import mem0',
+    'import supermemory',
+    'import numpy',
+    'import playwright',
     'assert t._MCP_AVAILABLE',
     'assert importlib.util.find_spec("websockets") is not None',
   ].join('; '),


### PR DESCRIPTION
## Summary
- Add Hindsight and Honcho Hermes extras to the desktop runtime install.
- Bundle Python dependencies used by built-in memory providers and Google Meet runtime support.
- Install Python Playwright Chromium during desktop runtime setup and verify plugin dependency imports.

## Why
The bundled runtime shipped plugin source directories, but provider-specific packages such as `hindsight-client` were not installed, so configured memory providers could fail availability checks and never expose their tools.

## Impact
Desktop runtime rebuilds should include the Python dependencies needed for bundled memory providers such as Hindsight, Honcho, Mem0, Supermemory, and Holographic, plus Python Playwright support for Google Meet.

## Validation
- `node --check packages/desktop/scripts/install-hermes.mjs`
- `npm run harness:check`
- `packages/desktop/resources/python/mac-arm64/bin/python3 -m pip install --dry-run 'hindsight-client==0.6.1' 'honcho-ai==2.0.1' 'mem0ai==2.0.4' 'supermemory==3.45.0' 'numpy==2.4.3' 'playwright==1.60.0'`

## Notes
- ByteRover still requires its external `brv` CLI installer; it is not a pip dependency.
- Providers still require their normal configuration, for example `memory.provider: hindsight`, before their tools appear.
