### PR TITLE
feat: reflect session title in browser tab

### DIFF
--- a/packages/client/src/views/hermes/ChatView.vue
+++ b/packages/client/src/views/hermes/ChatView.vue
@@ -24,6 +24,12 @@ const routeProfile = computed(() => {
   return typeof value === 'string' && value.trim() ? value : null
 })
 
+const tabTitle = computed(() => chatStore.activeSession?.title?.trim() || 'Hermes Studio')
+
+watch(tabTitle, (value) => {
+  document.title = value
+}, { immediate: true })
+
 async function loadRouteSession() {
   await chatStore.loadSessions(chatStore.sessionProfileFilter, routeSessionId.value)
   if (routeSessionId.value && chatStore.activeSessionId !== routeSessionId.value) {

--- a/packages/client/src/views/hermes/ChatView.vue
+++ b/packages/client/src/views/hermes/ChatView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, watch } from 'vue'
+import { computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import ChatPanel from '@/components/hermes/chat/ChatPanel.vue'
 import { useAppStore } from '@/stores/hermes/app'
@@ -24,11 +24,19 @@ const routeProfile = computed(() => {
   return typeof value === 'string' && value.trim() ? value : null
 })
 
-const tabTitle = computed(() => chatStore.activeSession?.title?.trim() || 'Hermes Studio')
+const productTitle = 'Hermes Studio'
+const tabTitle = computed(() => {
+  if (route.name !== 'hermes.session') return productTitle
+  return chatStore.activeSession?.title?.trim() || productTitle
+})
 
 watch(tabTitle, (value) => {
   document.title = value
 }, { immediate: true })
+
+onUnmounted(() => {
+  document.title = productTitle
+})
 
 async function loadRouteSession() {
   await chatStore.loadSessions(chatStore.sessionProfileFilter, routeSessionId.value)

--- a/tests/client/chat-view-tab-title.test.ts
+++ b/tests/client/chat-view-tab-title.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+import ChatView from '@/views/hermes/ChatView.vue'
+import { useAppStore } from '@/stores/hermes/app'
+import { useChatStore, type Session } from '@/stores/hermes/chat'
+import { useProfilesStore } from '@/stores/hermes/profiles'
+import { useSettingsStore } from '@/stores/hermes/settings'
+
+vi.mock('@/components/hermes/chat/ChatPanel.vue', () => ({
+  default: { template: '<div data-testid="chat-panel" />' },
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: {}, query: {} }),
+  useRouter: () => ({ replace: vi.fn() }),
+}))
+
+vi.mock('@/api/hermes/chat', () => ({
+  startRunViaSocket: vi.fn(),
+  resumeSession: vi.fn(),
+  registerSessionHandlers: vi.fn(),
+  unregisterSessionHandlers: vi.fn(),
+  getChatRunSocket: vi.fn(() => ({ emit: vi.fn() })),
+  respondToolApproval: vi.fn(),
+  respondClarify: vi.fn(),
+  onPeerUserMessage: vi.fn(() => vi.fn()),
+  onSessionCommand: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('@/api/hermes/sessions', () => ({
+  fetchSessions: vi.fn(),
+  fetchSessionMessagesPage: vi.fn(),
+  deleteSession: vi.fn(),
+  setSessionModel: vi.fn(),
+}))
+
+vi.mock('@/api/client', () => ({
+  getActiveProfileName: () => 'default',
+}))
+
+vi.mock('@/api/hermes/download', () => ({
+  getDownloadUrl: (_path: string, name: string) => `/download/${name}`,
+}))
+
+vi.mock('@/utils/completion-sound', () => ({
+  primeCompletionSound: vi.fn(),
+  playCompletionSound: vi.fn(),
+}))
+
+vi.mock('@/utils/session-sync', () => ({
+  subscribeSessionSync: vi.fn(() => vi.fn()),
+  publishSessionSync: vi.fn(),
+}))
+
+function makeSession(title: string): Session {
+  return {
+    id: 'session-1',
+    profile: 'default',
+    title,
+    messages: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  }
+}
+
+describe('ChatView tab title', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.title = 'Hermes Studio'
+    setActivePinia(createPinia())
+
+    const appStore = useAppStore()
+    const profilesStore = useProfilesStore()
+    const settingsStore = useSettingsStore()
+    const chatStore = useChatStore()
+
+    vi.spyOn(appStore, 'loadModels').mockImplementation(() => undefined)
+    vi.spyOn(profilesStore, 'fetchProfiles').mockResolvedValue()
+    vi.spyOn(settingsStore, 'fetchSettings').mockResolvedValue(undefined as any)
+    vi.spyOn(chatStore, 'loadSessions').mockResolvedValue()
+  })
+
+  it('reflects the active session title in the browser tab', async () => {
+    const chatStore = useChatStore()
+    chatStore.activeSession = makeSession('Research Plan')
+
+    const wrapper = mount(ChatView)
+    expect(document.title).toBe('Research Plan')
+
+    chatStore.activeSession = makeSession('Implementation Notes')
+    await nextTick()
+
+    expect(document.title).toBe('Implementation Notes')
+    wrapper.unmount()
+  })
+
+  it('falls back to the product title when the session title is blank', () => {
+    const chatStore = useChatStore()
+    chatStore.activeSession = makeSession('   ')
+
+    const wrapper = mount(ChatView)
+
+    expect(document.title).toBe('Hermes Studio')
+    wrapper.unmount()
+  })
+})

--- a/tests/client/chat-view-tab-title.test.ts
+++ b/tests/client/chat-view-tab-title.test.ts
@@ -13,8 +13,14 @@ vi.mock('@/components/hermes/chat/ChatPanel.vue', () => ({
   default: { template: '<div data-testid="chat-panel" />' },
 }))
 
+const mockRoute = {
+  name: 'hermes.session',
+  params: {},
+  query: {},
+}
+
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ params: {}, query: {} }),
+  useRoute: () => mockRoute,
   useRouter: () => ({ replace: vi.fn() }),
 }))
 
@@ -94,7 +100,9 @@ describe('ChatView tab title', () => {
     await nextTick()
 
     expect(document.title).toBe('Implementation Notes')
+
     wrapper.unmount()
+    expect(document.title).toBe('Hermes Studio')
   })
 
   it('falls back to the product title when the session title is blank', () => {


### PR DESCRIPTION
## Summary
- Reflect the active session title in the browser tab title.
- Add regression coverage for tab-title updates.

## Motivation
The active session name should be visible in the browser tab so the current chat is easier to identify.

## Changes
- Update `packages/client/src/views/hermes/ChatView.vue` to keep the document title in sync with the active session.
- Add `tests/client/chat-view-tab-title.test.ts` to cover the tab-title behavior.

## Test Plan
- [x] `npm test -- tests/client/chat-view-tab-title.test.ts`
- [x] Verified the PR diff only touches the component and its test file.

## Screenshots / Examples
<img width="271" height="33" alt="image" src="https://github.com/user-attachments/assets/0c3d17a9-ea61-4d63-a51a-15b795ecf743" />
<img width="231" height="90" alt="image" src="https://github.com/user-attachments/assets/7370f965-d107-4368-80df-fc19dab678cd" />

