### PR TITLE
fix chat bridge resume after web restart

### DIFF
--- a/packages/server/src/services/hermes/agent-bridge/manager.ts
+++ b/packages/server/src/services/hermes/agent-bridge/manager.ts
@@ -4,7 +4,7 @@ import { createConnection, createServer } from 'net'
 import { dirname, isAbsolute, join, resolve } from 'path'
 import { logger } from '../../logger'
 import { detectHermesHome, getHermesBin } from '../hermes-path'
-import { DEFAULT_AGENT_BRIDGE_ENDPOINT } from './client'
+import { AgentBridgeClient, DEFAULT_AGENT_BRIDGE_ENDPOINT } from './client'
 
 const DEFAULT_AGENT_BRIDGE_STARTUP_TIMEOUT_MS = 120000
 const DEFAULT_AGENT_BRIDGE_RESTART_DELAY_MS = 1000
@@ -34,6 +34,7 @@ export interface AgentBridgeManagerRuntimeState {
   endpoint: string
   running: boolean
   ready: boolean
+  attached: boolean
   pid?: number
   starting: boolean
   stopping: boolean
@@ -249,6 +250,11 @@ function isDesktopRuntime(): boolean {
   return String(process.env.HERMES_DESKTOP || '').trim().toLowerCase() === 'true'
 }
 
+function shouldKillStaleIpcBridgeProcesses(): boolean {
+  const raw = String(process.env.HERMES_AGENT_BRIDGE_KILL_STALE_IPC || '').trim().toLowerCase()
+  return ['1', 'true', 'yes', 'on'].includes(raw)
+}
+
 async function canListenTcpEndpoint(endpoint: string): Promise<boolean> {
   const url = new URL(endpoint)
   const host = url.hostname || '127.0.0.1'
@@ -339,11 +345,74 @@ async function killWindowsEndpointOccupants(endpoint: string): Promise<void> {
   await waitForTcpEndpoint(endpoint, 3000)
 }
 
+/**
+ * Find and kill stale bridge broker/worker processes that are still connected
+ * to the given IPC socket path.  This happens after a `systemctl restart` with
+ * KillMode=process where the Node parent is killed but bridge Python children
+ * survive as orphans.
+ */
+async function killStaleIpcBridgeProcesses(endpoint: string): Promise<void> {
+  const sockPath = endpoint.replace(/^ipc:\/\//, '')
+  if (!sockPath) return
+
+  const isWorkerSock = sockPath.includes('hermes-agent-bridge-workers')
+  // Also derive the worker socket path so we can kill worker orphans too.
+  const workerSockDir = `${sockPath.replace(/\/[^/]+$/, '')}`.replace(
+    /hermes-agent-bridge-workers$/,
+    'hermes-agent-bridge-workers',
+  )
+  const socketsToCheck = [sockPath]
+  if (!isWorkerSock) {
+    // broker socket — also check worker sockets under the same namespace
+    const workerDir = require('path').join(require('path').dirname(sockPath), 'hermes-agent-bridge-workers')
+    try {
+      const fs = await import('fs')
+      for (const entry of await fs.promises.readdir(workerDir)) {
+        socketsToCheck.push(require('path').join(workerDir, entry))
+      }
+    } catch { /* dir may not exist */ }
+  }
+
+  const pidsToKill = new Set<number>()
+  for (const sock of socketsToCheck) {
+    try {
+      // lsof finds processes with the Unix socket open (listening or connected)
+      const out = execFileSync('lsof', ['-F', 'p', '-U', '--', sock], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim()
+      for (const line of out.split('\n')) {
+        const pid = Number(line.replace(/^p/, ''))
+        if (Number.isFinite(pid) && pid > 0 && pid !== process.pid) {
+          pidsToKill.add(pid)
+        }
+      }
+    } catch {
+      // lsof exits non-zero when nothing found — that's fine
+    }
+  }
+
+  if (!pidsToKill.size) return
+
+  for (const pid of pidsToKill) {
+    try {
+      logger.warn('[agent-bridge] killing stale bridge process pid=%d on IPC socket %s', pid, sockPath)
+      process.kill(pid, 'SIGKILL')
+    } catch (err) {
+      logger.warn(err, '[agent-bridge] failed to kill stale bridge process pid=%d', pid)
+    }
+  }
+  // Give processes time to exit
+  await new Promise(resolve => setTimeout(resolve, 500))
+}
+
 export class AgentBridgeManager {
   endpoint: string
   private readonly options: AgentBridgeManagerOptions
   private readonly explicitEndpoint: boolean
   private child: ChildProcess | null = null
+  private attached = false
   private starting: Promise<void> | null = null
   private ready = false
   private stopping = false
@@ -357,7 +426,7 @@ export class AgentBridgeManager {
   }
 
   get running(): boolean {
-    return !!this.child && !this.child.killed && this.ready
+    return this.ready && (this.attached || (!!this.child && !this.child.killed))
   }
 
   getRuntimeState(): AgentBridgeManagerRuntimeState {
@@ -365,6 +434,7 @@ export class AgentBridgeManager {
       endpoint: this.endpoint,
       running: this.running,
       ready: this.ready,
+      attached: this.attached,
       pid: this.child?.pid,
       starting: !!this.starting,
       stopping: this.stopping,
@@ -390,6 +460,10 @@ export class AgentBridgeManager {
   }
 
   private async startProcess(): Promise<void> {
+    if (await this.attachExistingBridge()) {
+      return
+    }
+
     const script = bridgeScriptPath()
     const command = resolveAgentBridgeCommand(this.options)
     await this.prepareEndpoint()
@@ -405,10 +479,12 @@ export class AgentBridgeManager {
     const child = spawn(command.command, args, {
       env,
       cwd: process.cwd(),
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ['ignore', 'ignore', 'ignore'],
+      detached: process.platform !== 'win32',
       windowsHide: true,
     })
     this.child = child
+    this.attached = false
     this.ready = false
 
     child.once('exit', (code, signal) => {
@@ -419,13 +495,7 @@ export class AgentBridgeManager {
       if (shouldRestart) this.scheduleRestart(code, signal)
     })
 
-    child.stderr?.on('data', chunk => {
-      const text = String(chunk).trim()
-      if (text) logger.warn('[agent-bridge] %s', text)
-    })
-
     await new Promise<void>((resolveReady, rejectReady) => {
-      let buffered = ''
       const startupTimeoutMs = this.options.startupTimeoutMs
         ?? envPositiveInt('HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS')
         ?? DEFAULT_AGENT_BRIDGE_STARTUP_TIMEOUT_MS
@@ -446,64 +516,69 @@ export class AgentBridgeManager {
         this.restartAttempts = 0
         readyResolved = true
         cleanup()
-        child.stdout?.off('data', onStdout)
         resolveReady()
       }
 
       const onError = (err: Error) => {
         cleanup()
-        child.stdout?.off('data', onStdout)
         rejectReady(err)
       }
 
       const onExitBeforeReady = (code: number | null, signal: NodeJS.Signals | null) => {
         cleanup()
-        child.stdout?.off('data', onStdout)
         rejectReady(new Error(`agent bridge exited before ready code=${code} signal=${signal}`))
       }
 
       let readyResolved = false
-      const onStdout = (chunk: Buffer) => {
-        const text = chunk.toString('utf8')
-        buffered += text
-        for (;;) {
-          const newline = buffered.indexOf('\n')
-          if (newline < 0) break
-          const line = buffered.slice(0, newline).trim()
-          buffered = buffered.slice(newline + 1)
-          if (!line) continue
-          logger.info('[agent-bridge] %s', line)
-          if (!readyResolved) {
-            try {
-              const parsed = JSON.parse(line)
-              if (parsed?.event === 'ready') {
-                markReady()
-                return
-              }
-            } catch {}
-          }
-        }
-      }
 
       child.once('error', onError)
       child.once('exit', onExitBeforeReady)
-      child.stdout?.on('data', onStdout)
 
-      if (isDesktopRuntime() && isTcpEndpoint(this.endpoint)) {
-        const probe = async () => {
-          while (!readyResolved && !child.killed) {
-            if (await canConnectTcpEndpoint(this.endpoint)) {
-              markReady()
-              return
-            }
+      const probe = async () => {
+        const client = new AgentBridgeClient({
+          endpoint: this.endpoint,
+          timeoutMs: 1000,
+          connectRetryMs: 0,
+        })
+        while (!readyResolved && !child.killed) {
+          try {
+            await client.ping()
+            markReady()
+            return
+          } catch {
             await new Promise(resolve => setTimeout(resolve, 100))
           }
         }
-        probe().catch(onError)
       }
+      probe().catch(onError)
     })
 
     logger.info('[agent-bridge] ready at %s', this.endpoint)
+    if (process.platform !== 'win32') {
+      child.unref()
+    }
+  }
+
+  private async attachExistingBridge(): Promise<boolean> {
+    try {
+      const client = new AgentBridgeClient({
+        endpoint: this.endpoint,
+        timeoutMs: envPositiveInt('HERMES_AGENT_BRIDGE_ATTACH_TIMEOUT_MS') ?? 5000,
+        connectRetryMs: envPositiveInt('HERMES_AGENT_BRIDGE_ATTACH_RETRY_MS') ?? 5000,
+      })
+      await client.ping()
+      this.child = null
+      this.attached = true
+      this.ready = true
+      this.restartAttempts = 0
+      logger.info('[agent-bridge] attached to existing bridge at %s', this.endpoint)
+      return true
+    } catch (err) {
+      logger.debug(err, '[agent-bridge] no reusable bridge at %s', this.endpoint)
+      this.attached = false
+      this.ready = false
+      return false
+    }
   }
 
   private async prepareEndpoint(): Promise<void> {
@@ -511,6 +586,12 @@ export class AgentBridgeManager {
       if (!(await canListenTcpEndpoint(this.endpoint))) {
         await killWindowsEndpointOccupants(this.endpoint)
       }
+    }
+    // Preserve surviving bridge processes by default so Web UI restarts do not
+    // terminate active conversations. Operators can opt in to cleanup for
+    // known-stale sockets with HERMES_AGENT_BRIDGE_KILL_STALE_IPC=1.
+    if (this.endpoint.startsWith('ipc://') && process.platform !== 'win32' && shouldKillStaleIpcBridgeProcesses()) {
+      await killStaleIpcBridgeProcesses(this.endpoint)
     }
     process.env.HERMES_AGENT_BRIDGE_ENDPOINT = this.endpoint
   }
@@ -552,15 +633,22 @@ export class AgentBridgeManager {
       this.restartTimer = null
     }
     const child = this.child
-    if (!child) return
+    if (!child) {
+      this.ready = false
+      this.attached = false
+      return
+    }
     this.ready = false
+    this.attached = false
     this.child = null
 
     await new Promise<void>((resolveStop) => {
+      // Allow enough time for the broker to gracefully stop its worker
+      // subprocesses (WorkerProcess.stop uses a 3s timeout per worker).
       const timeout = setTimeout(() => {
         if (!child.killed) child.kill('SIGKILL')
         resolveStop()
-      }, 1500)
+      }, 10_000)
       child.once('exit', () => {
         clearTimeout(timeout)
         resolveStop()

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -495,6 +495,147 @@ export async function handleBridgeRun(
   }
 }
 
+function latestAssistantText(state: SessionState): string {
+  for (let i = state.messages.length - 1; i >= 0; i -= 1) {
+    const message = state.messages[i]
+    if (message.role === 'assistant') return message.content || ''
+  }
+  return ''
+}
+
+export async function resumeBridgeRun(
+  nsp: ReturnType<Server['of']>,
+  socket: Socket,
+  args: {
+    sessionId: string
+    runId: string
+    profile: string
+    instructions: string
+    model?: string | null
+    provider?: string | null
+  },
+  sessionMap: Map<string, SessionState>,
+  bridge: AgentBridgeClient,
+  dequeueNextQueuedRun: (socket: Socket, sessionId: string, fallbackProfile?: string) => void,
+) {
+  const { sessionId, runId, profile, instructions } = args
+  let state = sessionMap.get(sessionId)
+  if (!state) {
+    state = { messages: [], isWorking: false, events: [], queue: [] }
+    sessionMap.set(sessionId, state)
+  }
+
+  const runMarker = state.activeRunMarker || `cli_resume_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+  state.isWorking = true
+  state.isAborting = false
+  state.profile = profile
+  state.source = 'cli'
+  state.runId = runId
+  state.activeRunMarker = runMarker
+  state.bridgeOutput = state.bridgeOutput || latestAssistantText(state)
+  state.bridgePendingAssistantContent = state.bridgePendingAssistantContent || ''
+  state.bridgePendingReasoningContent = state.bridgePendingReasoningContent || ''
+  state.bridgePendingToolCallMarkup = state.bridgePendingToolCallMarkup || ''
+  state.bridgePendingTools = state.bridgePendingTools || []
+  state.bridgeToolCounter = state.bridgeToolCounter || 0
+
+  const emit = (event: string, payload: any) => {
+    const tagged = { ...payload, session_id: sessionId }
+    nsp.to(`session:${sessionId}`).emit(event, tagged)
+    if (!nsp.adapter.rooms.get(`session:${sessionId}`)?.size && socket.connected) {
+      socket.emit(event, tagged)
+    }
+  }
+
+  let cursor = 0
+  let eventCursor = 0
+  try {
+    const snapshot = await bridge.getResult(runId)
+    const deltas = Array.isArray(snapshot.deltas) ? snapshot.deltas.map(String) : []
+    const output = typeof snapshot.output === 'string' ? snapshot.output : deltas.join('')
+    const persisted = state.bridgeOutput || ''
+    const missingOutput = output && output.startsWith(persisted) ? output.slice(persisted.length) : ''
+    if (missingOutput) {
+      await applyBridgeChunkAsync(
+        nsp,
+        socket,
+        state,
+        sessionId,
+        runMarker,
+        {
+          ok: true,
+          run_id: runId,
+          session_id: sessionId,
+          status: 'running',
+          delta: missingOutput,
+          cursor: deltas.length,
+          output,
+          done: false,
+          events: [],
+          event_cursor: Array.isArray(snapshot.events) ? snapshot.events.length : 0,
+          error: null,
+        },
+        emit,
+        profile,
+        sessionMap,
+        bridge,
+        dequeueNextQueuedRun,
+        instructions,
+        { model: args.model, provider: args.provider },
+      )
+    }
+    cursor = deltas.length
+    eventCursor = Array.isArray(snapshot.events) ? snapshot.events.length : 0
+  } catch (err) {
+    bridgeLogger.warn({
+      err: err instanceof Error ? { message: err.message, name: err.name } : err,
+      sessionId,
+      runId,
+    }, '[chat-run-socket] failed to snapshot running bridge run before resume')
+  }
+
+  try {
+    for (;;) {
+      const chunk = await bridge.getOutput(runId, cursor, eventCursor)
+      cursor = chunk.cursor
+      eventCursor = chunk.event_cursor
+      if (chunk.delta || chunk.done || (chunk.events && chunk.events.length > 0)) {
+        await applyBridgeChunkAsync(
+          nsp,
+          socket,
+          state,
+          sessionId,
+          runMarker,
+          chunk,
+          emit,
+          profile,
+          sessionMap,
+          bridge,
+          dequeueNextQueuedRun,
+          instructions,
+          { model: args.model, provider: args.provider },
+        )
+      }
+      if (chunk.done) return
+      await delay(100)
+    }
+  } catch (err) {
+    if (state.activeRunMarker !== runMarker) return
+    state.isWorking = false
+    state.isAborting = false
+    state.profile = undefined
+    state.runId = undefined
+    state.activeRunMarker = undefined
+    state.events = []
+    emit('run.failed', {
+      event: 'run.failed',
+      run_id: runId,
+      error: err instanceof Error ? err.message : String(err),
+      resumed: true,
+    })
+  }
+}
+
 async function refreshFinalContextUsage(args: {
   sessionId: string
   profile: string

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -15,7 +15,7 @@ import { getSession } from '../../../db/hermes/session-store'
 import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../hermes-profile'
 import { AgentBridgeClient } from '../agent-bridge'
 import { handleApiRun, resolveRunSource, loadSessionStateFromDb } from './handle-api-run'
-import { handleBridgeRun } from './handle-bridge-run'
+import { handleBridgeRun, resumeBridgeRun } from './handle-bridge-run'
 import { handleAbort } from './abort'
 import { getOrCreateSession } from './compression'
 import { handleSessionCommand, isSessionCommand, parseSessionCommand } from './session-command'
@@ -26,11 +26,19 @@ import { userCanAccessProfile } from '../../../db/hermes/users-store'
 
 export type { ContentBlock } from './types'
 
+function currentProfileFromSocket(socket: Socket): string {
+  const socketProfile = typeof socket.handshake.query?.profile === 'string'
+    ? socket.handshake.query.profile.trim()
+    : ''
+  return socketProfile || getActiveProfileName() || 'default'
+}
+
 export class ChatRunSocket {
   private nsp: ReturnType<Server['of']>
   private bridge = new AgentBridgeClient()
   /** sessionId → session state (messages, working status, events, run tracking) */
   private sessionMap = new Map<string, SessionState>()
+  private bridgeResumePolls = new Set<string>()
 
   constructor(io: Server) {
     this.nsp = io.of('/chat-run')
@@ -218,7 +226,7 @@ export class ChatRunSocket {
       if (!data.session_id) return
       const sid = data.session_id
       socket.join(`session:${sid}`)
-      this.resumeSession(socket, sid)
+      await this.resumeSession(socket, sid)
     })
 
     socket.on('abort', (data: { session_id?: string }) => {
@@ -331,6 +339,7 @@ export class ChatRunSocket {
       state = await loadSessionStateFromDb(sid, this.sessionMap)
       this.sessionMap.set(sid, state)
     }
+    await this.reattachBridgeRun(socket, sid, state)
     socket.emit('resumed', {
       session_id: sid,
       messages: state.messages,
@@ -350,6 +359,57 @@ export class ChatRunSocket {
 
     logger.info('[chat-run-socket] socket %s resumed session %s (working: %s, messages: %d)',
       socket.id, sid, state.isWorking, state.messages.length)
+  }
+
+  private async reattachBridgeRun(socket: Socket, sid: string, state: SessionState) {
+    if (state.runId && state.isWorking) return
+    const session = getSession(sid)
+    const profile = session?.profile || currentProfileFromSocket(socket)
+    try {
+      const status = await this.bridge.status(sid, profile) as Record<string, unknown>
+      const running = status.running === true
+      const runId = typeof status.current_run_id === 'string' ? status.current_run_id : ''
+      if (!running || !runId) return
+      state.isWorking = true
+      state.isAborting = false
+      state.runId = runId
+      state.profile = profile
+      state.source = 'cli'
+      state.events = []
+      const pollKey = `${sid}:${runId}`
+      if (this.bridgeResumePolls.has(pollKey)) return
+      this.bridgeResumePolls.add(pollKey)
+      const instructions = this.resumeInstructionsForSession(sid)
+      void resumeBridgeRun(
+        this.nsp,
+        socket,
+        {
+          sessionId: sid,
+          runId,
+          profile,
+          instructions,
+          model: session?.model,
+          provider: session?.provider,
+        },
+        this.sessionMap,
+        this.bridge,
+        this.dequeueNextQueuedRun.bind(this),
+      ).finally(() => {
+        this.bridgeResumePolls.delete(pollKey)
+      })
+      logger.info('[chat-run-socket] reattached running bridge run %s for session %s', runId, sid)
+    } catch (err) {
+      logger.warn(err, '[chat-run-socket] bridge status lookup failed while resuming session %s', sid)
+    }
+  }
+
+  private resumeInstructionsForSession(sessionId: string): string {
+    let fullInstructions = getSystemPrompt()
+    const sessionRow = getSession(sessionId)
+    if (sessionRow?.workspace) {
+      fullInstructions = `\n[Current working directory: ${sessionRow.workspace}]\n${fullInstructions}`
+    }
+    return fullInstructions
   }
 
   // --- Queue ---

--- a/packages/server/src/services/shutdown.ts
+++ b/packages/server/src/services/shutdown.ts
@@ -2,6 +2,11 @@ import { logger } from './logger'
 import { closeDb } from '../db'
 import { stopPreviewRuntime } from '../controllers/update'
 
+function shouldStopAgentBridgeOnShutdown(): boolean {
+  const raw = String(process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN || '').trim().toLowerCase()
+  return ['1', 'true', 'yes', 'on'].includes(raw)
+}
+
 export function bindShutdown(server: any, groupChatServer?: any, chatRunServer?: any, agentBridgeManager?: any): void {
   let isShuttingDown = false
 
@@ -23,16 +28,19 @@ export function bindShutdown(server: any, groupChatServer?: any, chatRunServer?:
         logger.warn(err, 'Failed to stop preview runtime (non-fatal)')
       }
 
-      if (agentBridgeManager) {
+      if (agentBridgeManager && shouldStopAgentBridgeOnShutdown()) {
         try {
           await agentBridgeManager.stop()
           logger.info('Agent bridge stopped')
         } catch (err) {
           logger.warn(err, 'Failed to stop agent bridge (non-fatal)')
         }
+      } else if (agentBridgeManager) {
+        logger.info('Leaving agent bridge running across Web UI shutdown')
       }
 
-      // Close ChatRunSocket first to abort all active runs and close EventSource connections
+      // Close ChatRunSocket first to release WebSocket state. CLI bridge runs
+      // keep running in the external bridge and are reattached after restart.
       if (chatRunServer) {
         chatRunServer.close()
         logger.info('ChatRunSocket closed')

--- a/tests/server/agent-bridge-manager.test.ts
+++ b/tests/server/agent-bridge-manager.test.ts
@@ -132,9 +132,7 @@ describe('agent bridge manager command resolution', () => {
   })
 
   it('waits briefly for a restarting bridge socket before failing', async () => {
-    const endpoint = process.platform === 'win32'
-      ? `tcp://127.0.0.1:${32000 + (process.pid % 10000)}`
-      : `ipc://${join(tempDir, 'late-bridge.sock')}`
+    const endpoint = `tcp://127.0.0.1:${32000 + (process.pid % 10000)}`
     let server: Server | undefined
 
     const ready = new Promise<void>((resolve) => {
@@ -160,6 +158,52 @@ describe('agent bridge manager command resolution', () => {
       await ready
     } finally {
       await new Promise<void>((resolve) => server?.close(() => resolve()) ?? resolve())
+    }
+  })
+
+  it('attaches to an already running bridge instead of spawning a replacement', async () => {
+    const endpoint = `tcp://127.0.0.1:${34000 + (process.pid % 10000)}`
+    let requestCount = 0
+    const server = createServer((socket) => {
+      socket.once('data', (chunk) => {
+        requestCount += 1
+        const request = JSON.parse(chunk.toString('utf8').trim())
+        expect(request).toMatchObject({ action: 'ping' })
+        socket.end(`${JSON.stringify({ ok: true, pong: true })}\n`)
+      })
+    })
+
+    await new Promise<void>((resolve) => {
+      if (endpoint.startsWith('ipc://')) {
+        server.listen(endpoint.slice('ipc://'.length), resolve)
+      } else {
+        const url = new URL(endpoint)
+        server.listen(Number(url.port), url.hostname, resolve)
+      }
+    })
+
+    try {
+      const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+      const manager = new AgentBridgeManager({ endpoint, startupTimeoutMs: 100 })
+
+      await manager.start()
+
+      expect(requestCount).toBe(1)
+      expect(manager.getRuntimeState()).toMatchObject({
+        endpoint,
+        ready: true,
+        running: true,
+        attached: true,
+        pid: undefined,
+      })
+      await manager.stop()
+      expect(manager.getRuntimeState()).toMatchObject({
+        ready: false,
+        running: false,
+        attached: false,
+      })
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
     }
   })
 })

--- a/tests/server/run-chat-bridge-resume.test.ts
+++ b/tests/server/run-chat-bridge-resume.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const addMessageMock = vi.fn()
+const updateSessionStatsMock = vi.fn()
+const updateUsageMock = vi.fn()
+const calcAndUpdateUsageMock = vi.fn()
+const buildDbHistoryMock = vi.fn()
+const buildSnapshotAwareHistoryMock = vi.fn()
+const estimateUsageTokensFromMessagesMock = vi.fn()
+
+vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
+  addMessage: addMessageMock,
+  createSession: vi.fn(),
+  getSession: vi.fn(() => ({ id: 'session-resume', profile: 'default', model: 'gpt-test', provider: 'openai' })),
+  updateSession: vi.fn(),
+  updateSessionStats: updateSessionStatsMock,
+}))
+
+vi.mock('../../packages/server/src/db/hermes/usage-store', () => ({
+  updateUsage: updateUsageMock,
+}))
+
+vi.mock('../../packages/server/src/services/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  bridgeLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
+  getSystemPrompt: vi.fn(() => 'system prompt'),
+}))
+
+vi.mock('../../packages/server/src/lib/context-compressor', () => ({
+  countTokens: vi.fn(() => 1),
+  SUMMARY_PREFIX: '[Summary] ',
+}))
+
+vi.mock('../../packages/server/src/db/hermes/compression-snapshot', () => ({
+  getCompressionSnapshot: vi.fn(),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/compression', async () => {
+  const actual = await vi.importActual<any>('../../packages/server/src/services/hermes/run-chat/compression')
+  return {
+    ...actual,
+    buildDbHistory: buildDbHistoryMock,
+    buildSnapshotAwareHistory: buildSnapshotAwareHistoryMock,
+    buildCompressedHistory: vi.fn(),
+    forceCompressBridgeHistory: vi.fn(),
+  }
+})
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/usage', () => ({
+  calcAndUpdateUsage: calcAndUpdateUsageMock,
+  contextTokensWithCachedOverhead: vi.fn((_state, tokens) => tokens),
+  estimateUsageTokensFromMessages: estimateUsageTokensFromMessagesMock,
+  getCachedBridgeContextOverhead: vi.fn(() => undefined),
+  updateMessageContextTokenUsage: vi.fn((_sid, state, _emit, tokens) => {
+    state.contextTokens = tokens
+    return tokens
+  }),
+}))
+
+function createNamespace() {
+  const emitted: Array<{ event: string; payload: any }> = []
+  return {
+    emitted,
+    nsp: {
+      adapter: { rooms: { get: vi.fn(() => new Set(['socket-1'])) } },
+      to: vi.fn(() => ({
+        emit: vi.fn((event: string, payload: any) => emitted.push({ event, payload })),
+      })),
+    },
+  }
+}
+
+describe('resumeBridgeRun', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    addMessageMock.mockReturnValue(42)
+    calcAndUpdateUsageMock.mockResolvedValue({ inputTokens: 3, outputTokens: 2 })
+    buildDbHistoryMock.mockResolvedValue([
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'Hello world' },
+    ])
+    buildSnapshotAwareHistoryMock.mockResolvedValue([
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'Hello world' },
+    ])
+    estimateUsageTokensFromMessagesMock.mockReturnValue({ inputTokens: 3, outputTokens: 2 })
+  })
+
+  it('continues polling an existing bridge run after web server state is recreated', async () => {
+    const { resumeBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    const { nsp, emitted } = createNamespace()
+    const socket = { id: 'socket-1', connected: true, emit: vi.fn() }
+    const sessionMap = new Map<string, any>()
+    sessionMap.set('session-resume', {
+      messages: [
+        { id: 1, session_id: 'session-resume', role: 'user', content: 'hello', timestamp: 1 },
+        { id: 2, session_id: 'session-resume', role: 'assistant', content: 'Hello', timestamp: 2 },
+      ],
+      isWorking: true,
+      events: [],
+      queue: [],
+    })
+
+    const bridge = {
+      getResult: vi.fn(async () => ({
+        ok: true,
+        run_id: 'run-resume',
+        session_id: 'session-resume',
+        status: 'running',
+        output: 'Hello',
+        deltas: ['Hello'],
+        events: [],
+      })),
+      getOutput: vi.fn(async () => ({
+        ok: true,
+        run_id: 'run-resume',
+        session_id: 'session-resume',
+        status: 'complete',
+        delta: ' world',
+        cursor: 2,
+        output: 'Hello world',
+        done: true,
+        result: { final_response: 'Hello world' },
+        error: null,
+        events: [],
+        event_cursor: 0,
+      })),
+      contextEstimate: vi.fn(async () => ({
+        ok: true,
+        session_id: 'session-resume',
+        fixed_context_tokens: 0,
+        system_prompt_tokens: 0,
+        tool_tokens: 0,
+        message_count: 0,
+        tool_count: 0,
+        system_prompt_chars: 0,
+      })),
+      goalEvaluate: vi.fn(async () => ({
+        ok: true,
+        session_id: 'session-resume',
+        handled: true,
+        should_continue: false,
+      })),
+    }
+
+    await resumeBridgeRun(
+      nsp as any,
+      socket as any,
+      {
+        sessionId: 'session-resume',
+        runId: 'run-resume',
+        profile: 'default',
+        instructions: 'system prompt',
+        model: 'gpt-test',
+        provider: 'openai',
+      },
+      sessionMap,
+      bridge as any,
+      vi.fn(),
+    )
+
+    expect(bridge.getResult).toHaveBeenCalledWith('run-resume')
+    expect(bridge.getOutput).toHaveBeenCalledWith('run-resume', 1, 0)
+    expect(emitted).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        event: 'message.delta',
+        payload: expect.objectContaining({ delta: ' world', session_id: 'session-resume' }),
+      }),
+      expect.objectContaining({
+        event: 'run.completed',
+        payload: expect.objectContaining({ output: 'Hello world', session_id: 'session-resume' }),
+      }),
+    ]))
+    expect(sessionMap.get('session-resume').isWorking).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
  - keep the agent bridge alive across Web UI shutdowns by default
  - reattach to existing bridge runs when a chat session resumes after restart
  - add bridge manager and resume polling coverage

  ## Tests
  - npx tsc -p packages/server/tsconfig.json --noEmit
  - npx vitest run tests/server/run-chat-bridge-resume.test.ts tests/server/agent-bridge-manager.test.ts
  - real 8648 login smoke test with admin / 123456