### PR TITLE
feat: allow disabling gateway autostart and skill injection

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -86,13 +86,30 @@ function isDesktopRuntime(): boolean {
   return String(process.env.HERMES_DESKTOP || '').trim().toLowerCase() === 'true'
 }
 
+function envFlagEnabled(name: string): boolean {
+  const value = String(process.env[name] || '').trim().toLowerCase()
+  return ['1', 'true', 'yes', 'on'].includes(value)
+}
+
+function gatewayAutostartDisabled(): boolean {
+  return envFlagEnabled('HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART')
+}
+
+function skillInjectionDisabled(): boolean {
+  return envFlagEnabled('HERMES_WEB_UI_DISABLE_SKILL_INJECTION')
+}
+
 async function startRuntimeServicesBeforeListen(): Promise<void> {
-  try {
-    await ensureProfileGatewaysRunning()
-    console.log('[bootstrap] profile gateways checked')
-  } catch (err) {
-    logger.warn(err, '[bootstrap] failed to ensure profile gateways')
-    console.warn('[bootstrap] failed to ensure profile gateways:', err instanceof Error ? err.message : err)
+  if (gatewayAutostartDisabled()) {
+    console.log('[bootstrap] profile gateway check disabled by HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART')
+  } else {
+    try {
+      await ensureProfileGatewaysRunning()
+      console.log('[bootstrap] profile gateways checked')
+    } catch (err) {
+      logger.warn(err, '[bootstrap] failed to ensure profile gateways')
+      console.warn('[bootstrap] failed to ensure profile gateways:', err instanceof Error ? err.message : err)
+    }
   }
 
   try {
@@ -105,15 +122,19 @@ async function startRuntimeServicesBeforeListen(): Promise<void> {
 }
 
 function startRuntimeServicesAfterListen(): void {
-  void (async () => {
-    try {
-      await ensureProfileGatewaysRunning()
-      console.log('[bootstrap] profile gateways checked')
-    } catch (err) {
-      logger.warn(err, '[bootstrap] failed to ensure profile gateways')
-      console.warn('[bootstrap] failed to ensure profile gateways:', err instanceof Error ? err.message : err)
-    }
-  })()
+  if (gatewayAutostartDisabled()) {
+    console.log('[bootstrap] profile gateway check disabled by HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART')
+  } else {
+    void (async () => {
+      try {
+        await ensureProfileGatewaysRunning()
+        console.log('[bootstrap] profile gateways checked')
+      } catch (err) {
+        logger.warn(err, '[bootstrap] failed to ensure profile gateways')
+        console.warn('[bootstrap] failed to ensure profile gateways:', err instanceof Error ? err.message : err)
+      }
+    })()
+  }
 
   void (async () => {
     try {
@@ -134,24 +155,28 @@ export async function bootstrap() {
   }
 
   await initLoginLimiter()
-  try {
-    const skillInjector = new HermesSkillInjector()
-    const injectionResult = await skillInjector.injectMissingSkills()
-    if (injectionResult.injected.length > 0) {
-      logger.info({
-        injected: [...new Set(injectionResult.injected)],
-        targetCount: injectionResult.targets.length,
-      }, '[bootstrap] bundled skills injected')
+  if (skillInjectionDisabled()) {
+    console.log('[bootstrap] bundled skill injection disabled by HERMES_WEB_UI_DISABLE_SKILL_INJECTION')
+  } else {
+    try {
+      const skillInjector = new HermesSkillInjector()
+      const injectionResult = await skillInjector.injectMissingSkills()
+      if (injectionResult.injected.length > 0) {
+        logger.info({
+          injected: [...new Set(injectionResult.injected)],
+          targetCount: injectionResult.targets.length,
+        }, '[bootstrap] bundled skills injected')
+      }
+      if (injectionResult.updated.length > 0) {
+        logger.info({
+          updated: [...new Set(injectionResult.updated)],
+          targetCount: injectionResult.targets.length,
+        }, '[bootstrap] bundled skills updated')
+      }
+    } catch (err) {
+      logger.warn(err, '[bootstrap] failed to inject bundled skills')
+      console.warn('[bootstrap] failed to inject bundled skills:', err instanceof Error ? err.message : err)
     }
-    if (injectionResult.updated.length > 0) {
-      logger.info({
-        updated: [...new Set(injectionResult.updated)],
-        targetCount: injectionResult.targets.length,
-      }, '[bootstrap] bundled skills updated')
-    }
-  } catch (err) {
-    logger.warn(err, '[bootstrap] failed to inject bundled skills')
-    console.warn('[bootstrap] failed to inject bundled skills:', err instanceof Error ? err.message : err)
   }
 
   if (!isDesktopRuntime()) {


### PR DESCRIPTION
## Summary

Adds two explicit startup opt-out flags for dashboard-only/self-hosted deployments:

- `HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART=1`
- `HERMES_WEB_UI_DISABLE_SKILL_INJECTION=1`

When set, the server skips gateway autostart checks and bundled skill injection during bootstrap while preserving current default behavior when the flags are unset.

This addresses #1300.

## Why

Some deployments mount `hermes-web-ui` against existing Hermes Agent homes where gateway lifecycle and skills are managed outside the Web UI. In those setups, startup-side effects can compete with production gateways or overwrite curated bundled-skill directories.

## Validation

- `git diff --check`
- `npm ci --ignore-scripts`
- `npm run build`
- Verified with Homebrew `node v26.0.0` and `npm 11.12.1` on macOS
- Verified against current upstream `main` at `1d19be2aeaba466c7b348260d4b1acc416fc6f9d`
- Local deployment validation: these flags keep `hermes-web-ui` healthy in dashboard-only Docker deployments next to existing Hermes Agent containers/gateways, without mutating gateway lifecycle or runtime skills at startup.

Note: a separate verification attempt on a host with Node `v18.19.1` failed before evaluating this patch because the project requires Node `>=23.0.0` and Vite requires Node `20.19+` / `22.12+`.

Disclosure: this PR was prepared with AI assistance (OpenAI Codex).
