### PR TITLE
[codex] fix mac update manifest repair flow

### DIFF
--- a/.github/workflows/desktop-mac-update-manifest.yml
+++ b/.github/workflows/desktop-mac-update-manifest.yml
@@ -1,0 +1,111 @@
+name: Repair macOS Update Manifest
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to update (e.g. v0.6.11)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: desktop-mac-update-manifest-${{ github.event.inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  repair:
+    name: Generate and upload latest-mac.yml
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download macOS release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/hermes-mac-assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern 'Hermes.Studio-*-arm64.zip' --dir /tmp/hermes-mac-assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern 'Hermes.Studio-*-arm64.dmg' --dir /tmp/hermes-mac-assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern 'Hermes.Studio-*-x64.zip' --dir /tmp/hermes-mac-assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern 'Hermes.Studio-*-x64.dmg' --dir /tmp/hermes-mac-assets
+          ls -lh /tmp/hermes-mac-assets
+
+      - name: Generate merged latest-mac.yml
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const { createHash } = require('node:crypto')
+          const { readdirSync, readFileSync, statSync, writeFileSync } = require('node:fs')
+          const { join } = require('node:path')
+
+          const dir = '/tmp/hermes-mac-assets'
+          const names = readdirSync(dir)
+          const byKey = new Map()
+          let version = null
+
+          for (const name of names) {
+            const match = /^Hermes\.Studio-(.+)-(arm64|x64)\.(zip|dmg)$/.exec(name)
+            if (!match) continue
+            if (version && version !== match[1]) {
+              throw new Error(`Mixed macOS asset versions: ${version} and ${match[1]}`)
+            }
+            version = match[1]
+            byKey.set(`${match[2]}.${match[3]}`, name)
+          }
+
+          if (!version) throw new Error('No macOS release assets found')
+
+          const order = ['arm64.zip', 'arm64.dmg', 'x64.zip', 'x64.dmg']
+          const missing = order.filter(key => !byKey.has(key))
+          if (missing.length > 0) {
+            throw new Error(`Missing macOS release assets: ${missing.join(', ')}`)
+          }
+
+          const entries = order.map(key => {
+            const name = byKey.get(key)
+            const file = join(dir, name)
+            return {
+              url: name,
+              sha512: createHash('sha512').update(readFileSync(file)).digest('base64'),
+              size: statSync(file).size,
+            }
+          })
+
+          const head = entries[0]
+          const lines = [`version: ${version}`, 'files:']
+          for (const entry of entries) {
+            lines.push(`  - url: ${entry.url}`)
+            lines.push(`    sha512: ${entry.sha512}`)
+            lines.push(`    size: ${entry.size}`)
+          }
+          lines.push(`path: ${head.url}`)
+          lines.push(`sha512: ${head.sha512}`)
+          lines.push(`releaseDate: '${new Date().toISOString()}'`)
+          writeFileSync('/tmp/latest-mac.yml', `${lines.join('\n')}\n`)
+          NODE
+          cat /tmp/latest-mac.yml
+
+      - name: Upload merged macOS update manifest to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" /tmp/latest-mac.yml --repo "$GITHUB_REPOSITORY" --clobber
+
+          asset_url="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[] | select(.name == "latest-mac.yml") | .apiUrl')"
+          if [ -z "$asset_url" ]; then
+            echo "Uploaded latest-mac.yml was not found on release ${TAG}" >&2
+            exit 1
+          fi
+          curl -fsSL \
+            -H "Accept: application/octet-stream" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            "$asset_url" > /tmp/latest-mac-uploaded.yml
+          diff -u /tmp/latest-mac.yml /tmp/latest-mac-uploaded.yml

--- a/.github/workflows/desktop-manual-build.yml
+++ b/.github/workflows/desktop-manual-build.yml
@@ -79,16 +79,14 @@ jobs:
                 "packages/desktop/release/*.dmg" \
                 "packages/desktop/release/*.dmg.blockmap" \
                 "packages/desktop/release/*.zip" \
-                "packages/desktop/release/*.zip.blockmap" \
-                "packages/desktop/release/latest*.yml"
+                "packages/desktop/release/*.zip.blockmap"
               ;;
             darwin-x64)
               write_common_outputs "macOS x64" "macos-15-intel" "--mac dmg zip --x64" "desktop-darwin-x64" \
                 "packages/desktop/release/*.dmg" \
                 "packages/desktop/release/*.dmg.blockmap" \
                 "packages/desktop/release/*.zip" \
-                "packages/desktop/release/*.zip.blockmap" \
-                "packages/desktop/release/latest*.yml"
+                "packages/desktop/release/*.zip.blockmap"
               ;;
             linux-x64)
               write_common_outputs "Linux x64" "ubuntu-22.04" "--linux AppImage deb --x64" "desktop-linux-x64" \
@@ -211,3 +209,119 @@ jobs:
           tag_name: ${{ github.event.inputs.release_tag }}
           fail_on_unmatched_files: true
           files: ${{ needs.validate.outputs.artifact_files }}
+
+  mac-update-manifest:
+    name: Repair macOS update manifest
+    needs: [validate, desktop]
+    if: needs.validate.outputs.target_os == 'darwin' && github.event.inputs.release_tag != ''
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check macOS release asset completeness
+        id: check
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          assets="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
+          missing=0
+          for pattern in \
+            '^Hermes\.Studio-.+-arm64\.zip$' \
+            '^Hermes\.Studio-.+-arm64\.dmg$' \
+            '^Hermes\.Studio-.+-x64\.zip$' \
+            '^Hermes\.Studio-.+-x64\.dmg$'
+          do
+            if ! printf '%s\n' "$assets" | grep -E "$pattern" >/dev/null; then
+              missing=1
+              echo "Missing macOS release asset matching ${pattern}"
+            fi
+          done
+          if [ "$missing" -eq 0 ]; then
+            echo "complete=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "complete=false" >> "$GITHUB_OUTPUT"
+            echo "Both macOS architectures are not available yet; leaving latest-mac.yml unchanged."
+          fi
+
+      - name: Download macOS release assets
+        if: steps.check.outputs.complete == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/hermes-mac-assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern 'Hermes.Studio-*-arm64.zip' --dir /tmp/hermes-mac-assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern 'Hermes.Studio-*-arm64.dmg' --dir /tmp/hermes-mac-assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern 'Hermes.Studio-*-x64.zip' --dir /tmp/hermes-mac-assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern 'Hermes.Studio-*-x64.dmg' --dir /tmp/hermes-mac-assets
+          ls -lh /tmp/hermes-mac-assets
+
+      - name: Generate merged latest-mac.yml
+        if: steps.check.outputs.complete == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const { createHash } = require('node:crypto')
+          const { readdirSync, readFileSync, statSync, writeFileSync } = require('node:fs')
+          const { join } = require('node:path')
+
+          const dir = '/tmp/hermes-mac-assets'
+          const names = readdirSync(dir)
+          const byKey = new Map()
+          let version = null
+
+          for (const name of names) {
+            const match = /^Hermes\.Studio-(.+)-(arm64|x64)\.(zip|dmg)$/.exec(name)
+            if (!match) continue
+            if (version && version !== match[1]) {
+              throw new Error(`Mixed macOS asset versions: ${version} and ${match[1]}`)
+            }
+            version = match[1]
+            byKey.set(`${match[2]}.${match[3]}`, name)
+          }
+
+          if (!version) throw new Error('No macOS release assets found')
+
+          const order = ['arm64.zip', 'arm64.dmg', 'x64.zip', 'x64.dmg']
+          const missing = order.filter(key => !byKey.has(key))
+          if (missing.length > 0) {
+            throw new Error(`Missing macOS release assets: ${missing.join(', ')}`)
+          }
+
+          const entries = order.map(key => {
+            const name = byKey.get(key)
+            const file = join(dir, name)
+            return {
+              url: name,
+              sha512: createHash('sha512').update(readFileSync(file)).digest('base64'),
+              size: statSync(file).size,
+            }
+          })
+
+          const head = entries[0]
+          const lines = [`version: ${version}`, 'files:']
+          for (const entry of entries) {
+            lines.push(`  - url: ${entry.url}`)
+            lines.push(`    sha512: ${entry.sha512}`)
+            lines.push(`    size: ${entry.size}`)
+          }
+          lines.push(`path: ${head.url}`)
+          lines.push(`sha512: ${head.sha512}`)
+          lines.push(`releaseDate: '${new Date().toISOString()}'`)
+          writeFileSync('/tmp/latest-mac.yml', `${lines.join('\n')}\n`)
+          NODE
+          cat /tmp/latest-mac.yml
+
+      - name: Upload merged macOS update manifest to release
+        if: steps.check.outputs.complete == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" /tmp/latest-mac.yml --repo "$GITHUB_REPOSITORY" --clobber

--- a/scripts/harness-check.mjs
+++ b/scripts/harness-check.mjs
@@ -214,6 +214,8 @@ if (changedChatChainFiles.length > 0 && !changedFiles.includes('docs/cli-chat-se
 }
 
 const desktopReleaseWorkflow = await readText('.github/workflows/desktop-release.yml')
+const desktopManualBuildWorkflow = await readText('.github/workflows/desktop-manual-build.yml')
+const desktopMacUpdateManifestWorkflow = await readText('.github/workflows/desktop-mac-update-manifest.yml')
 const desktopRuntimeWorkflow = await readText('.github/workflows/desktop-runtime.yml')
 const electronBuilderConfig = await readText('packages/desktop/electron-builder.yml')
 const desktopPackageJson = await readText('packages/desktop/package.json')
@@ -244,6 +246,49 @@ for (const expectedGlob of ['*.dmg', '*.exe', '*.AppImage']) {
 
 if (!desktopReleaseWorkflow.includes('fail_on_unmatched_files: true')) {
   fail('desktop-release.yml must keep fail_on_unmatched_files: true')
+}
+
+function workflowCaseBody(text, caseLabel) {
+  const start = text.indexOf(`${caseLabel})`)
+  if (start < 0) fail(`desktop-manual-build.yml is missing ${caseLabel} case`)
+  const end = text.indexOf(';;', start)
+  if (end < 0) fail(`desktop-manual-build.yml ${caseLabel} case is missing terminator`)
+  return text.slice(start, end)
+}
+
+for (const macCase of ['darwin-arm64', 'darwin-x64']) {
+  const body = workflowCaseBody(desktopManualBuildWorkflow, macCase)
+  if (body.includes('latest*.yml')) {
+    fail(`desktop-manual-build.yml must not publish single-arch macOS update manifests from ${macCase}`)
+  }
+  for (const glob of ['*.dmg.blockmap', '*.zip.blockmap']) {
+    if (!body.includes(glob)) {
+      fail(`desktop-manual-build.yml ${macCase} must keep uploading ${glob}`)
+    }
+  }
+}
+
+for (const phrase of [
+  'mac-update-manifest:',
+  "if: needs.validate.outputs.target_os == 'darwin' && github.event.inputs.release_tag != ''",
+  'Both macOS architectures are not available yet; leaving latest-mac.yml unchanged.',
+  'gh release upload "$TAG" /tmp/latest-mac.yml',
+]) {
+  if (!desktopManualBuildWorkflow.includes(phrase)) {
+    fail(`desktop-manual-build.yml must include macOS manifest repair behavior: ${phrase}`)
+  }
+}
+
+if (!desktopMacUpdateManifestWorkflow.includes('Repair macOS Update Manifest')) {
+  fail('desktop-mac-update-manifest.yml must provide a manual macOS manifest repair workflow')
+}
+
+if (!desktopMacUpdateManifestWorkflow.includes("gh release download \"$TAG\"") || !desktopMacUpdateManifestWorkflow.includes('/tmp/latest-mac.yml')) {
+  fail('desktop-mac-update-manifest.yml must generate latest-mac.yml from release assets')
+}
+
+if (!desktopMacUpdateManifestWorkflow.includes('gh release upload "$TAG" /tmp/latest-mac.yml')) {
+  fail('desktop-mac-update-manifest.yml must upload the merged latest-mac.yml to the release')
 }
 
 for (const phrase of [


### PR DESCRIPTION
## Summary
- Stop manual macOS desktop builds from uploading single-arch `latest*.yml` manifests while keeping `.dmg`, `.zip`, and both blockmap uploads.
- Add a post-build repair job to `desktop-manual-build.yml` that regenerates `latest-mac.yml` only after both macOS architectures are present on the release.
- Add a standalone `Repair macOS Update Manifest` workflow for manually rebuilding `latest-mac.yml` from release assets.
- Extend the harness to enforce the macOS manifest guardrails.

## Root Cause
A manual macOS x64 rebuild uploaded its single-arch `latest-mac.yml` to the release, replacing the merged arm64+x64 manifest. Apple Silicon clients were then directed to the x64 app and downloaded the x64 runtime.

## Impact
Manual macOS rebuilds can still upload installers and blockmaps, but they no longer publish a broken single-arch update manifest. Once both macOS architectures are available, the workflow can regenerate a merged manifest automatically or via the new manual repair workflow.

## Validation
- `npm run harness:check`
- `git diff --check`
- `actionlint` not run locally because it is not installed
