### PR TITLE
[codex] Add Hermes native session title sync

### DIFF
--- a/docs/cli-chat-sessions.md
+++ b/docs/cli-chat-sessions.md
@@ -51,6 +51,7 @@ ChatPanel / ChatInput
 
 | 时间 | PR / commit | 动到的功能 | 链路影响 |
 | --- | --- | --- | --- |
+| 2026-06-04 | local | Hermes 原生 AI session title 回传 | `hermes_bridge.py` 在 bridge run 完成后后台调用 Hermes 原生 `maybe_auto_title()` 写入 Hermes `state.db`，并提示标题语言跟随用户首条消息；Node 在 `run.completed` 后后台按 `session_id` 短轮询 `get_session_title`，同步 Web UI 本地 `sessions.title` 并推给前端。只在本地标题仍为空或等于首条消息/preview fallback 时应用，用户手动改过的标题不会被覆盖；不阻塞最终回复、usage、goal continuation 或队列执行，也不改 run 生命周期。 |
 | 2026-06-03 | #1289 `7848256` | tool result / unified diff 展示 | `MessageItem.vue`、`GroupMessageItem.vue`、`MarkdownRenderer.vue` 和共享 highlighter 对 unified diff 走专门展示路径：tool result JSON 中的 diff 字段只显示 diff body，长段未改动上下文静态折叠，复制仍保留完整原始内容；不改变 `/chat-run` 协议、消息落库、工具审批或 group-chat agent 执行行为。 |
 | 2026-06-03 | #1284 `2aeed108` | Windows Agent Bridge 子进程输出解码 | `hermes_bridge.py` 的 Windows parent PID 探测和 stale bridge 进程清理改用平台文本编码读取 `tasklist.exe` / `taskkill.exe` 输出，并忽略不可解码字节；修复本地 code page 输出导致 subprocess reader 线程抛 `UnicodeDecodeError` 的问题，不改变 `/chat-run` 协议、消息落库或工具审批行为。 |
 | 2026-06-03 | #1273 `91bb68dc` | 用户头像上传；group-chat 成员头像同步 | auth 用户头像进入 group-chat 成员展示链路，`/group-chat` handshake 携带 `authUserId`，服务端按用户 id/name 查头像并同步给 room members；不改变普通 Chat run，但改变 group-chat 成员元数据和消息展示。 |

--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -50,6 +50,8 @@ export interface RunEvent {
   }
   /** session_id tag added by server for client-side filtering */
   session_id?: string
+  /** Generated session title from session.title.updated. */
+  title?: string
   /** Queue length from run.queued event */
   queue_length?: number
   /** Queue item that was just removed because it is starting now. */
@@ -125,6 +127,7 @@ const sessionEventHandlers = new Map<string, {
   onUsageUpdated: (event: RunEvent) => void
   onAgentEvent?: (event: RunEvent) => void
   onSessionCommand?: (event: RunEvent) => void
+  onSessionTitleUpdated?: (event: RunEvent) => void
   onRunQueued?: (event: RunEvent) => void
   onApprovalRequested?: (event: RunEvent) => void
   onApprovalResolved?: (event: RunEvent) => void
@@ -135,6 +138,7 @@ const sessionEventHandlers = new Map<string, {
 
 const peerUserMessageHandlers = new Set<(event: RunEvent) => void>()
 const sessionCommandHandlers = new Set<(event: RunEvent) => void>()
+const sessionTitleUpdatedHandlers = new Set<(event: RunEvent) => void>()
 
 /**
  * Global message.delta event handler
@@ -369,6 +373,20 @@ function globalSessionCommandHandler(event: RunEvent): void {
   }
 }
 
+function globalSessionTitleUpdatedHandler(event: RunEvent): void {
+  const sid = event.session_id
+  if (!sid) return
+
+  const handlers = sessionEventHandlers.get(sid)
+  if (handlers) {
+    handlers.onSessionTitleUpdated?.(event)
+  }
+
+  for (const handler of sessionTitleUpdatedHandlers) {
+    handler(event)
+  }
+}
+
 function globalAgentEventHandler(event: RunEvent): void {
   const sid = event.session_id
   if (!sid) return
@@ -459,6 +477,7 @@ export function registerSessionHandlers(
     onUsageUpdated: (event: RunEvent) => void
     onAgentEvent?: (event: RunEvent) => void
     onSessionCommand?: (event: RunEvent) => void
+    onSessionTitleUpdated?: (event: RunEvent) => void
     onRunQueued?: (event: RunEvent) => void
     onApprovalRequested?: (event: RunEvent) => void
     onApprovalResolved?: (event: RunEvent) => void
@@ -494,6 +513,13 @@ export function onSessionCommand(handler: (event: RunEvent) => void): () => void
   sessionCommandHandlers.add(handler)
   return () => {
     sessionCommandHandlers.delete(handler)
+  }
+}
+
+export function onSessionTitleUpdated(handler: (event: RunEvent) => void): () => void {
+  sessionTitleUpdatedHandlers.add(handler)
+  return () => {
+    sessionTitleUpdatedHandlers.delete(handler)
   }
 }
 
@@ -607,6 +633,7 @@ export function connectChatRun(requestedProfile?: string | null): Socket {
     chatRunSocket.on('usage.updated', globalUsageUpdatedHandler)
     chatRunSocket.on('agent.event', globalAgentEventHandler)
     chatRunSocket.on('session.command', globalSessionCommandHandler)
+    chatRunSocket.on('session.title.updated', globalSessionTitleUpdatedHandler)
 
     globalListenersRegistered = true
   }
@@ -831,6 +858,9 @@ export function startRunViaSocket(
       removeTerminalSocketListeners()
       sessionEventHandlers.delete(sid)
       onDone()
+    },
+    onSessionTitleUpdated: (evt: RunEvent) => {
+      onEvent(evt)
     },
     onRunQueued: (evt: RunEvent) => {
       if (closed) return

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1,4 +1,4 @@
-import { startRunViaSocket, resumeSession, registerSessionHandlers, unregisterSessionHandlers, getChatRunSocket, respondToolApproval, onPeerUserMessage, onSessionCommand, respondClarify, type RunEvent, type ResumeSessionPayload, type ContentBlock as ContentBlockImport } from '@/api/hermes/chat'
+import { startRunViaSocket, resumeSession, registerSessionHandlers, unregisterSessionHandlers, getChatRunSocket, respondToolApproval, onPeerUserMessage, onSessionCommand, onSessionTitleUpdated, respondClarify, type RunEvent, type ResumeSessionPayload, type ContentBlock as ContentBlockImport } from '@/api/hermes/chat'
 import { deleteSession as deleteSessionApi, fetchSessionMessagesPage, fetchSessions, setSessionModel, type HermesMessage, type SessionSummary } from '@/api/hermes/sessions'
 import { getActiveProfileName } from '@/api/client'
 import { getDownloadUrl } from '@/api/hermes/download'
@@ -1315,6 +1315,20 @@ export const useChatStore = defineStore('chat', () => {
     target.updatedAt = Date.now()
   }
 
+  function applyGeneratedSessionTitle(evt: RunEvent) {
+    const sid = evt.session_id
+    const title = typeof (evt as any).title === 'string' ? (evt as any).title.trim() : ''
+    if (!sid || !title) return
+    const target = sessions.value.find(s => s.id === sid)
+    if (target) {
+      target.title = title
+      target.updatedAt = Date.now()
+    }
+    if (activeSession.value?.id === sid) {
+      activeSession.value.title = title
+    }
+  }
+
   function primeCompletionBellIfEnabled() {
     if (useSettingsStore().display.bell_on_complete) {
       primeCompletionSound()
@@ -1732,6 +1746,11 @@ export const useChatStore = defineStore('chat', () => {
                 activeAssistantMessageId = newId
               }
 
+              break
+            }
+
+            case 'session.title.updated': {
+              applyGeneratedSessionTitle(evt)
               break
             }
 
@@ -2210,6 +2229,11 @@ export const useChatStore = defineStore('chat', () => {
           break
         }
 
+        case 'session.title.updated': {
+          applyGeneratedSessionTitle(evt)
+          break
+        }
+
         case 'tool.started': {
           runHadToolActivity = true
           const msgs = getSessionMsgs(sid)
@@ -2522,6 +2546,8 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   onSessionCommand(handleGlobalSessionCommand)
+
+  onSessionTitleUpdated(applyGeneratedSessionTitle)
 
   function stopStreaming() {
     const sid = activeSessionId.value

--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -91,6 +91,11 @@ export interface AgentBridgeRunResult extends AgentBridgeResponse {
   error?: string | null
 }
 
+export interface AgentBridgeSessionTitle extends AgentBridgeResponse {
+  session_id: string
+  title: string
+}
+
 export interface AgentBridgeContextEstimate extends AgentBridgeResponse {
   session_id: string
   token_count?: number | null
@@ -460,6 +465,14 @@ export class AgentBridgeClient {
       run_id: runId,
       cursor,
       event_cursor: eventCursor,
+    }, options)
+  }
+
+  getSessionTitle(sessionId: string, profile?: string, options: AgentBridgeRequestOptions = {}): Promise<AgentBridgeSessionTitle> {
+    return this.request<AgentBridgeSessionTitle>({
+      action: 'get_session_title',
+      session_id: sessionId,
+      ...(profile ? { profile } : {}),
     }, options)
   }
 

--- a/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
@@ -66,6 +66,29 @@ def _positive_int(value: str | None) -> int | None:
     return parsed if parsed > 0 else None
 
 
+def _title_user_message(message: Any) -> str:
+    if isinstance(message, list):
+        parts: list[str] = []
+        for block in message:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    parts.append(str(block.get("text") or ""))
+                elif block.get("name"):
+                    parts.append(str(block.get("name") or ""))
+            else:
+                parts.append(str(block))
+        text = "\n".join(part for part in parts if part).strip()
+    else:
+        text = str(message or "").strip()
+    if not text:
+        return ""
+    return (
+        f"{text}\n\n"
+        "[Title language: use the same language as the user's message. "
+        "Do not translate the title to English unless the user's message is English.]"
+    )
+
+
 def _hidden_subprocess_kwargs() -> dict[str, Any]:
     if os.name != "nt":
         return {}
@@ -1720,6 +1743,47 @@ class AgentPool:
                     profile,
                     db_count_after_prepersist,
                 )
+                final_response = str(
+                    result.get("final_response")
+                    or result.get("response")
+                    or result.get("output")
+                    or "".join(record.deltas)
+                    or ""
+                ).strip()
+                title_db = self._db.get_for_profile(profile)
+                if title_db is not None and final_response and not result.get("failed") and not result.get("partial"):
+                    try:
+                        from agent.title_generator import maybe_auto_title
+
+                        def title_callback(title: str) -> None:
+                            cleaned = str(title or "").strip()
+                            if not cleaned:
+                                return
+                            with self._lock:
+                                record.events.append(_jsonable({
+                                    "event": "session.title.updated",
+                                    "session_id": session.session_id,
+                                    "title": cleaned,
+                                }))
+
+                        maybe_auto_title(
+                            title_db,
+                            session.session_id,
+                            _title_user_message(message),
+                            final_response,
+                            result.get("messages", []) if isinstance(result.get("messages"), list) else [],
+                            failure_callback=getattr(session.agent, "_emit_auxiliary_failure", None),
+                            main_runtime={
+                                "model": getattr(session.agent, "model", None),
+                                "provider": getattr(session.agent, "provider", None),
+                                "base_url": getattr(session.agent, "base_url", None),
+                                "api_key": getattr(session.agent, "api_key", None),
+                                "api_mode": getattr(session.agent, "api_mode", None),
+                            },
+                            title_callback=title_callback,
+                        )
+                    except Exception:
+                        pass
                 with session.lock:
                     if isinstance(result.get("messages"), list):
                         session.history = result["messages"]
@@ -1832,6 +1896,18 @@ class AgentPool:
             raise KeyError(f"unknown session: {session_id}")
         with session.lock:
             return {"session_id": session_id, "history": copy.deepcopy(session.history)}
+
+    def get_session_title(self, session_id: str, profile: str | None = None) -> dict[str, Any]:
+        if not session_id:
+            raise ValueError("session_id is required")
+        db = self._db.get_for_profile(profile)
+        title = None
+        if db is not None and hasattr(db, "get_session_title"):
+            try:
+                title = db.get_session_title(session_id)
+            except Exception:
+                title = None
+        return {"session_id": session_id, "title": str(title or "")}
 
     def dispatch_command(self, session_id: str, command: str, profile: str | None = None) -> dict[str, Any]:
         raw = str(command or "").strip()
@@ -2358,6 +2434,12 @@ class BridgeServer:
 
         if action == "get_history":
             return self.pool.get_history(str(req.get("session_id") or ""))
+
+        if action == "get_session_title":
+            return self.pool.get_session_title(
+                str(req.get("session_id") or ""),
+                req.get("profile"),
+            )
 
         if action == "command":
             session_id = str(req.get("session_id") or "").strip()
@@ -3367,7 +3449,7 @@ class BridgeBroker:
             profile, worker_key = self._route_for_run(str(req.get("run_id") or ""))
             return self._forward(profile, req, worker_key)
 
-        if action in {"interrupt", "steer", "command", "goal_evaluate", "goal_pause", "status", "get_history", "destroy"}:
+        if action in {"interrupt", "steer", "command", "goal_evaluate", "goal_pause", "status", "get_history", "get_session_title", "destroy"}:
             session_id = str(req.get("session_id") or "")
             profile, worker_key = self._route_for_session(session_id, req.get("profile"), req.get("worker_key") if "worker_key" in req else None)
             resp = self._forward(profile, req, worker_key)

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -5,7 +5,7 @@
 
 import type { Server, Socket } from 'socket.io'
 import { getSystemPrompt } from '../../../lib/llm-prompt'
-import { getSession, createSession, addMessage, updateSession, updateSessionStats } from '../../../db/hermes/session-store'
+import { getSession, getSessionDetail, createSession, addMessage, updateSession, updateSessionStats } from '../../../db/hermes/session-store'
 import { updateUsage } from '../../../db/hermes/usage-store'
 import { logger, bridgeLogger } from '../../logger'
 import { AgentBridgeClient, type AgentBridgeContextEstimate, type AgentBridgeMessage, type AgentBridgeOutput } from '../agent-bridge'
@@ -32,9 +32,77 @@ import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
 import { filterBridgeToolCallMarkupDelta, flushPendingToolCallMarkup } from './bridge-delta'
 
 const BRIDGE_USAGE_FLUSH_DELAY_MS = 200
+const BRIDGE_TITLE_EVENT_POLL_INTERVAL_MS = 500
+const BRIDGE_TITLE_EVENT_POLL_TIMEOUT_MS = 45_000
 
 function stringValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeTitleText(value: unknown): string {
+  return String(value || '').replace(/\s+/g, ' ').trim()
+}
+
+function fallbackTitleFromText(text: string, limit: number, ellipsis: boolean): string {
+  const normalized = normalizeTitleText(text)
+  if (!normalized) return ''
+  if (normalized.length <= limit) return normalized
+  return ellipsis ? `${normalized.slice(0, limit)}...` : normalized.slice(0, limit)
+}
+
+function isReplaceableLocalTitle(sessionId: string): boolean {
+  const detail = getSessionDetail(sessionId)
+  if (!detail) return false
+  const current = normalizeTitleText(detail.title)
+  if (!current) return true
+  const variants = new Set<string>([''])
+  const preview = normalizeTitleText(detail.preview)
+  if (preview) {
+    variants.add(preview)
+    variants.add(fallbackTitleFromText(preview, 40, true))
+    variants.add(fallbackTitleFromText(preview, 63, false))
+    variants.add(fallbackTitleFromText(preview, 100, false))
+  }
+  const firstUser = detail.messages.find(message => message.role === 'user' && normalizeTitleText(message.content))
+  const firstUserText = normalizeTitleText(firstUser?.content)
+  if (firstUserText) {
+    variants.add(firstUserText)
+    variants.add(fallbackTitleFromText(firstUserText, 40, true))
+    variants.add(fallbackTitleFromText(firstUserText, 63, false))
+    variants.add(fallbackTitleFromText(firstUserText, 100, false))
+  }
+  return variants.has(current)
+}
+
+function syncBridgeGeneratedTitle(sessionId: string, title: unknown, emit: (event: string, payload: any) => void): boolean {
+  const nextTitle = normalizeTitleText(title)
+  if (!nextTitle) return false
+  const session = getSession(sessionId)
+  if (!session || session.source !== 'cli') return false
+  if (!isReplaceableLocalTitle(sessionId)) {
+    logger.info('[chat-run-socket] skipped Hermes generated title for manually titled session %s', sessionId)
+    return false
+  }
+  if (normalizeTitleText(session.title) === nextTitle) return false
+  updateSession(sessionId, {
+    title: nextTitle,
+    last_active: Math.floor(Date.now() / 1000),
+  } as any)
+  emit('session.title.updated', {
+    event: 'session.title.updated',
+    session_id: sessionId,
+    title: nextTitle,
+  })
+  return true
+}
+
+function shouldPollBridgeGeneratedTitle(sessionId: string): boolean {
+  const session = getSession(sessionId)
+  if (!session || session.source !== 'cli') return false
+  const detail = getSessionDetail(sessionId)
+  if (!detail) return false
+  const userMessageCount = detail.messages.filter(message => message.role === 'user').length
+  return userMessageCount <= 2 && isReplaceableLocalTitle(sessionId)
 }
 
 function looksLikeAgentFailure(value: string): boolean {
@@ -450,7 +518,10 @@ export async function handleBridgeRun(
         shouldPersistUserMessage && displayRole === 'user',
         data.model_groups,
       )
-      if (chunk.done) break
+      if (chunk.done) {
+        void pollBridgeGeneratedTitleAfterRun(bridge, session_id, profile, emit)
+        break
+      }
     }
   } catch (err: any) {
     if (state.activeRunMarker !== runMarker) return
@@ -621,7 +692,9 @@ async function applyBridgeChunkAsync(
       processBridgeTextDelta(state, sessionId, runMarker, chunk.run_id, String((ev as any).delta || ''), emit)
       continue
     }
-    if (evType === 'bridge.context.ready') {
+    if (evType === 'session.title.updated') {
+      syncBridgeGeneratedTitle(sessionId, (ev as any).title, emit)
+    } else if (evType === 'bridge.context.ready') {
       cacheBridgeContext(state, ev)
       const usage = await calcAndUpdateUsage(sessionId, state, emit)
       const snapshotAware = await estimateSnapshotAwareMessageTokens({
@@ -1002,6 +1075,31 @@ async function applyBridgeChunkAsync(
   } else if (!state.activeRunMarker) {
     state.isWorking = false
     state.profile = undefined
+  }
+}
+
+async function pollBridgeGeneratedTitleAfterRun(
+  bridge: AgentBridgeClient,
+  sessionId: string,
+  profile: string,
+  emit: (event: string, payload: any) => void,
+) {
+  if (!shouldPollBridgeGeneratedTitle(sessionId)) return
+  const deadline = Date.now() + BRIDGE_TITLE_EVENT_POLL_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    await delay(BRIDGE_TITLE_EVENT_POLL_INTERVAL_MS)
+    let title = ''
+    try {
+      const result = await bridge.getSessionTitle(sessionId, profile, { timeoutMs: 2000 })
+      title = normalizeTitleText(result.title)
+    } catch (err) {
+      logger.debug(err, '[chat-run-socket] stopped polling bridge generated title for session %s', sessionId)
+      return
+    }
+    if (title) {
+      syncBridgeGeneratedTitle(sessionId, title, emit)
+      return
+    }
   }
 }
 

--- a/tests/client/chat-store-compression-state.test.ts
+++ b/tests/client/chat-store-compression-state.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/api/hermes/chat', () => ({
   respondClarify: vi.fn(),
   onPeerUserMessage: vi.fn(() => vi.fn()),
   onSessionCommand: vi.fn(() => vi.fn()),
+  onSessionTitleUpdated: vi.fn(() => vi.fn()),
 }))
 
 vi.mock('@/api/client', () => ({

--- a/tests/client/chat-store-session-command.test.ts
+++ b/tests/client/chat-store-session-command.test.ts
@@ -8,6 +8,7 @@ const chatApi = vi.hoisted(() => ({
   getChatRunSocket: vi.fn(() => ({ emit: vi.fn() })),
   sessionCommandHandlers: [] as Array<(event: any) => void>,
   peerUserMessageHandlers: [] as Array<(event: any) => void>,
+  sessionTitleUpdatedHandlers: [] as Array<(event: any) => void>,
 }))
 
 vi.mock('@/api/hermes/chat', () => ({
@@ -24,6 +25,10 @@ vi.mock('@/api/hermes/chat', () => ({
   }),
   onSessionCommand: vi.fn((handler: (event: any) => void) => {
     chatApi.sessionCommandHandlers.push(handler)
+    return vi.fn()
+  }),
+  onSessionTitleUpdated: vi.fn((handler: (event: any) => void) => {
+    chatApi.sessionTitleUpdatedHandlers.push(handler)
     return vi.fn()
   }),
 }))
@@ -65,6 +70,7 @@ describe('chat store session.command fanout', () => {
     vi.resetAllMocks()
     chatApi.sessionCommandHandlers = []
     chatApi.peerUserMessageHandlers = []
+    chatApi.sessionTitleUpdatedHandlers = []
     setActivePinia(createPinia())
   })
 
@@ -128,5 +134,24 @@ describe('chat store session.command fanout', () => {
         commandAction: 'clear',
       }),
     ])
+  })
+
+  it('updates session title from the global generated-title event', () => {
+    const store = useChatStore()
+    const session = makeSession()
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    expect(chatApi.sessionTitleUpdatedHandlers).toHaveLength(1)
+
+    chatApi.sessionTitleUpdatedHandlers[0]({
+      event: 'session.title.updated',
+      session_id: 'session-1',
+      title: 'Generated Title',
+    })
+
+    expect(store.sessions[0].title).toBe('Generated Title')
+    expect(store.activeSession?.title).toBe('Generated Title')
   })
 })

--- a/tests/client/chat-view-tab-title.test.ts
+++ b/tests/client/chat-view-tab-title.test.ts
@@ -34,6 +34,7 @@ vi.mock('@/api/hermes/chat', () => ({
   respondClarify: vi.fn(),
   onPeerUserMessage: vi.fn(() => vi.fn()),
   onSessionCommand: vi.fn(() => vi.fn()),
+  onSessionTitleUpdated: vi.fn(() => vi.fn()),
 }))
 
 vi.mock('@/api/hermes/sessions', () => ({


### PR DESCRIPTION
## Summary
- call Hermes native `maybe_auto_title()` after CLI bridge runs and sync generated titles back into Web UI session rows
- poll generated titles by `session_id` instead of extending or depending on run lifecycle
- add global frontend handling for `session.title.updated` so titles refresh after run handlers are cleaned up
- keep generated title language aligned with the user's first message and avoid overwriting manually edited local titles

## Root Cause
Web UI did not call Hermes native title generation for bridge sessions, and title updates generated after `run.completed` were not reliably delivered through per-run handlers.

## Validation
- `python3 -m py_compile packages/server/src/services/hermes/agent-bridge/hermes_bridge.py`
- `git diff --check`
- `npm run harness:check`
- `npm run test -- tests/client/chat-view-tab-title.test.ts tests/client/chat-store-session-command.test.ts tests/client/chat-store-compression-state.test.ts tests/server/run-chat-bridge-final-context.test.ts`
- `npm run build`