### PR TITLE
[codex] Document startup opt-out env flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ These variables configure Hermes Web UI, its local Hermes runtime integration, a
 | `HERMES_OPENROUTER_APP_TITLE` | `Hermes Web UI` | OpenRouter attribution title sent by bridge runs. |
 | `HERMES_OPENROUTER_APP_CATEGORIES` | `cli-agent,personal-agent` | OpenRouter attribution categories sent by bridge runs. |
 | `HERMES_WEB_UI_MANAGED_GATEWAY` | platform/runtime dependent | Force managed legacy gateway process handling. Set `1`, `true`, `yes`, or `on` to enable. |
+| `HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART` | unset | Skip startup gateway checks/autostart. Set `1`, `true`, `yes`, or `on` for dashboard-only deployments where another service owns Hermes gateway lifecycle. |
+| `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | unset | Skip startup bundled skill injection. Set `1`, `true`, `yes`, or `on` when bundled skills are managed outside Web UI or target skill directories must not be overwritten. |
 | `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | enabled in production | Controls whether Web UI shutdown also stops managed gateway processes. Set `0` or `false` to detach them. |
 | `GATEWAY_HOST` | `127.0.0.1` | Default gateway host written into profile config for legacy gateway compatibility. |
 | `HERMES_WEB_UI_PREVIEW_REPO` | package repository | GitHub repository used by Version Preview. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -278,6 +278,8 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `HERMES_OPENROUTER_APP_TITLE` | `Hermes Web UI` | bridge 运行发送给 OpenRouter 的 attribution title。 |
 | `HERMES_OPENROUTER_APP_CATEGORIES` | `cli-agent,personal-agent` | bridge 运行发送给 OpenRouter 的 attribution categories。 |
 | `HERMES_WEB_UI_MANAGED_GATEWAY` | 由平台/运行环境决定 | 强制启用旧 gateway 进程托管；设为 `1`、`true`、`yes` 或 `on` 开启。 |
+| `HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART` | 未设置 | 跳过启动时的 gateway 检查/自动启动；dashboard-only 部署中如果由其它服务管理 Hermes gateway，可设为 `1`、`true`、`yes` 或 `on`。 |
+| `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | 未设置 | 跳过启动时的内置 skill 注入；如果内置 skills 由 Web UI 外部管理，或不希望覆盖同名目标目录，可设为 `1`、`true`、`yes` 或 `on`。 |
 | `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | 生产环境默认开启 | Web UI 关闭时是否同时停止托管的 gateway 进程；设为 `0` 或 `false` 可让 gateway 分离运行。 |
 | `GATEWAY_HOST` | `127.0.0.1` | 旧 gateway 兼容配置中写入 profile 的默认 gateway host。 |
 | `HERMES_WEB_UI_PREVIEW_REPO` | package repository | Version Preview 使用的 GitHub 仓库。 |

--- a/docs/cli-chat-sessions.md
+++ b/docs/cli-chat-sessions.md
@@ -891,6 +891,8 @@ Bridge 启动失败不会阻止 Web UI server 启动，但普通 Chat run 会在
 | `HERMES_AGENT_BRIDGE_PLATFORM` | bridge 传给 Hermes Agent 的 platform，默认 `cli`。 |
 | `HERMES_BRIDGE_PROVIDER` | 覆盖 bridge provider。 |
 | `HERMES_BRIDGE_MAX_TURNS` | 覆盖 bridge 最大轮数。 |
+| `HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART` | 跳过启动时的 gateway 检查/自动启动；dashboard-only 部署可用。 |
+| `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | 跳过启动时的内置 skill 注入；外部管理 skills 时可用。 |
 | `HERMES_WEB_UI_PREVIEW_AGENT_BRIDGE_TRANSPORT` | Version Preview bridge transport。 |
 | `HERMES_WEB_UI_PREVIEW_AGENT_BRIDGE_ENDPOINT` | Version Preview bridge endpoint。 |
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -26,7 +26,7 @@ This compose file runs a single service:
 
 - `hermes-webui` — Web UI dashboard with integrated Hermes Agent runtime (pre-built image or built from source)
 
-The Web UI container is built on the `nousresearch/hermes-agent` base image and uses the Hermes CLI / agent bridge runtime for chat execution. It does not start or manage a separate Hermes gateway process.
+The Web UI container is built on the `nousresearch/hermes-agent` base image and uses the Hermes CLI / agent bridge runtime for chat execution. By default it performs startup gateway checks/autostart for profiles, but no Hermes gateway ports are exposed by this compose setup.
 
 ## Environment Variables
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -86,13 +86,30 @@ function isDesktopRuntime(): boolean {
   return String(process.env.HERMES_DESKTOP || '').trim().toLowerCase() === 'true'
 }
 
+function envFlagEnabled(name: string): boolean {
+  const value = String(process.env[name] || '').trim().toLowerCase()
+  return ['1', 'true', 'yes', 'on'].includes(value)
+}
+
+function gatewayAutostartDisabled(): boolean {
+  return envFlagEnabled('HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART')
+}
+
+function skillInjectionDisabled(): boolean {
+  return envFlagEnabled('HERMES_WEB_UI_DISABLE_SKILL_INJECTION')
+}
+
 async function startRuntimeServicesBeforeListen(): Promise<void> {
-  try {
-    await ensureProfileGatewaysRunning()
-    console.log('[bootstrap] profile gateways checked')
-  } catch (err) {
-    logger.warn(err, '[bootstrap] failed to ensure profile gateways')
-    console.warn('[bootstrap] failed to ensure profile gateways:', err instanceof Error ? err.message : err)
+  if (gatewayAutostartDisabled()) {
+    console.log('[bootstrap] profile gateway check disabled by HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART')
+  } else {
+    try {
+      await ensureProfileGatewaysRunning()
+      console.log('[bootstrap] profile gateways checked')
+    } catch (err) {
+      logger.warn(err, '[bootstrap] failed to ensure profile gateways')
+      console.warn('[bootstrap] failed to ensure profile gateways:', err instanceof Error ? err.message : err)
+    }
   }
 
   try {
@@ -105,15 +122,19 @@ async function startRuntimeServicesBeforeListen(): Promise<void> {
 }
 
 function startRuntimeServicesAfterListen(): void {
-  void (async () => {
-    try {
-      await ensureProfileGatewaysRunning()
-      console.log('[bootstrap] profile gateways checked')
-    } catch (err) {
-      logger.warn(err, '[bootstrap] failed to ensure profile gateways')
-      console.warn('[bootstrap] failed to ensure profile gateways:', err instanceof Error ? err.message : err)
-    }
-  })()
+  if (gatewayAutostartDisabled()) {
+    console.log('[bootstrap] profile gateway check disabled by HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART')
+  } else {
+    void (async () => {
+      try {
+        await ensureProfileGatewaysRunning()
+        console.log('[bootstrap] profile gateways checked')
+      } catch (err) {
+        logger.warn(err, '[bootstrap] failed to ensure profile gateways')
+        console.warn('[bootstrap] failed to ensure profile gateways:', err instanceof Error ? err.message : err)
+      }
+    })()
+  }
 
   void (async () => {
     try {
@@ -134,24 +155,28 @@ export async function bootstrap() {
   }
 
   await initLoginLimiter()
-  try {
-    const skillInjector = new HermesSkillInjector()
-    const injectionResult = await skillInjector.injectMissingSkills()
-    if (injectionResult.injected.length > 0) {
-      logger.info({
-        injected: [...new Set(injectionResult.injected)],
-        targetCount: injectionResult.targets.length,
-      }, '[bootstrap] bundled skills injected')
+  if (skillInjectionDisabled()) {
+    console.log('[bootstrap] bundled skill injection disabled by HERMES_WEB_UI_DISABLE_SKILL_INJECTION')
+  } else {
+    try {
+      const skillInjector = new HermesSkillInjector()
+      const injectionResult = await skillInjector.injectMissingSkills()
+      if (injectionResult.injected.length > 0) {
+        logger.info({
+          injected: [...new Set(injectionResult.injected)],
+          targetCount: injectionResult.targets.length,
+        }, '[bootstrap] bundled skills injected')
+      }
+      if (injectionResult.updated.length > 0) {
+        logger.info({
+          updated: [...new Set(injectionResult.updated)],
+          targetCount: injectionResult.targets.length,
+        }, '[bootstrap] bundled skills updated')
+      }
+    } catch (err) {
+      logger.warn(err, '[bootstrap] failed to inject bundled skills')
+      console.warn('[bootstrap] failed to inject bundled skills:', err instanceof Error ? err.message : err)
     }
-    if (injectionResult.updated.length > 0) {
-      logger.info({
-        updated: [...new Set(injectionResult.updated)],
-        targetCount: injectionResult.targets.length,
-      }, '[bootstrap] bundled skills updated')
-    }
-  } catch (err) {
-    logger.warn(err, '[bootstrap] failed to inject bundled skills')
-    console.warn('[bootstrap] failed to inject bundled skills:', err instanceof Error ? err.message : err)
   }
 
   if (!isDesktopRuntime()) {

--- a/packages/website/src/i18n/en.ts
+++ b/packages/website/src/i18n/en.ts
@@ -243,6 +243,8 @@ export default {
           ['HERMES_OPENROUTER_APP_TITLE', 'OpenRouter attribution title sent by bridge runs'],
           ['HERMES_OPENROUTER_APP_CATEGORIES', 'OpenRouter attribution categories sent by bridge runs'],
           ['HERMES_WEB_UI_MANAGED_GATEWAY', 'Force managed legacy gateway process handling'],
+          ['HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART', 'Skip startup gateway checks/autostart for dashboard-only deployments where another service owns Hermes gateway lifecycle'],
+          ['HERMES_WEB_UI_DISABLE_SKILL_INJECTION', 'Skip startup bundled skill injection when skills are managed outside Web UI or target skill directories must not be overwritten'],
           ['HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN', 'Controls whether Hermes Studio shutdown also stops managed gateway processes'],
           ['GATEWAY_HOST', 'Default gateway host written into profile config for legacy gateway compatibility'],
           ['HERMES_WEB_UI_PREVIEW_REPO', 'GitHub repository used by Version Preview'],

--- a/packages/website/src/i18n/zh.ts
+++ b/packages/website/src/i18n/zh.ts
@@ -243,6 +243,8 @@ export default {
           ['HERMES_OPENROUTER_APP_TITLE', 'bridge 运行发送给 OpenRouter 的 attribution title'],
           ['HERMES_OPENROUTER_APP_CATEGORIES', 'bridge 运行发送给 OpenRouter 的 attribution categories'],
           ['HERMES_WEB_UI_MANAGED_GATEWAY', '强制启用旧 gateway 进程托管'],
+          ['HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART', '跳过启动时的 gateway 检查/自动启动；适用于由其它服务管理 Hermes gateway 的 dashboard-only 部署'],
+          ['HERMES_WEB_UI_DISABLE_SKILL_INJECTION', '跳过启动时的内置 skill 注入；适用于由 Web UI 外部管理 skills 或不希望覆盖同名目标目录的部署'],
           ['HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN', 'Hermes Studio 关闭时是否同时停止托管的 gateway 进程'],
           ['GATEWAY_HOST', '旧 gateway 兼容配置中写入 profile 的默认 gateway host'],
           ['HERMES_WEB_UI_PREVIEW_REPO', 'Version Preview 使用的 GitHub 仓库'],


### PR DESCRIPTION
## Summary
- cherry-pick #1301 to add startup opt-out flags for gateway autostart and bundled skill injection
- document the new env vars in README, README_zh, internal chat/session docs, and the official website i18n docs
- keep stock docker-compose unchanged; Docker docs only clarify default startup behavior without advertising unsupported `.env` pass-through

## Validation
- `git diff --check`
- `npm run harness:check`
- `npm run build:website`
- `npm run build`

## Notes
This branch intentionally includes the original #1301 commit, then adds a separate documentation consistency commit.