### PR TITLE
[codex] fix bridge abort timeout handling

### DIFF
--- a/docs/cli-chat-sessions.md
+++ b/docs/cli-chat-sessions.md
@@ -51,6 +51,7 @@ ChatPanel / ChatInput
 
 | 时间 | PR / commit | 动到的功能 | 链路影响 |
 | --- | --- | --- | --- |
+| 2026-06-04 | local | CLI bridge abort 超时同步 | `/chat-run` abort 路径在 Hermes Agent 协作式 interrupt 未能在 bridge 同步窗口内完成时，不再提前清理 Web UI `isWorking/runId` 或启动队列，而是发送 `abort.timeout` 并保持 session locked/aborting；同会话新消息继续进入队列，避免旧 Agent run 尚未退出时触发 `session ... is already running`。当前端后续收到 bridge terminal chunk 时再发送 `abort.completed` 并释放状态。前端新增 `abort.timeout` 事件展示“仍在停止中”，并移除本地 20s 自动清 running 兜底。 |
 | 2026-06-04 | #1320 `237fd954` | Agent Bridge restart/resume；shutdown/stop timing | Web UI `restart`/页面内升级通过 `SIGUSR2` 保留 Agent Bridge，server 重启后 `ChatRunSocket.resume` 会查询 bridge status 并通过 `resumeBridgeRun()` 继续 poll 既有 `run_id` 的 delta/events。真实 `stop`/`SIGTERM` 仍会请求 bridge shutdown；非桌面 shutdown 兜底延长到 15s 以覆盖 worker 清理窗口，桌面 `HERMES_DESKTOP=true` 默认仍保持 3s。CLI `restart` 仍使用 5s grace，CLI `stop` 最长等 15s 且进程退出后立即返回。 |
 | 2026-06-04 | local | OpenRouter attribution title | `manager.ts` 的 bridge 默认 OpenRouter attribution title 从 `Hermes Web UI` 改为 `Hermes Studio`，与 `https://hermes-studio.ai` referer 品牌保持一致；只影响 OpenRouter dashboard attribution，不改变 `/chat-run` 协议、消息落库、模型调用或 run 生命周期。 |
 | 2026-06-04 | local | Hermes 原生 AI session title 回传 | `hermes_bridge.py` 在 bridge run 完成后后台调用 Hermes 原生 `maybe_auto_title()` 写入 Hermes `state.db`，并提示标题语言跟随用户首条消息；Node 在 `run.completed` 后后台按 `session_id` 短轮询 `get_session_title`，同步 Web UI 本地 `sessions.title` 并推给前端。只在本地标题仍为空或等于首条消息/preview fallback 时应用，用户手动改过的标题不会被覆盖；不阻塞最终回复、usage、goal continuation 或队列执行，也不改 run 生命周期。 |

--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -123,6 +123,7 @@ const sessionEventHandlers = new Map<string, {
   onCompressionStarted: (event: RunEvent) => void
   onCompressionCompleted: (event: RunEvent) => void
   onAbortStarted: (event: RunEvent) => void
+  onAbortTimeout?: (event: RunEvent) => void
   onAbortCompleted: (event: RunEvent) => void
   onUsageUpdated: (event: RunEvent) => void
   onAgentEvent?: (event: RunEvent) => void
@@ -329,6 +330,19 @@ function globalAbortStartedHandler(event: RunEvent): void {
 }
 
 /**
+ * Global abort.timeout event handler
+ */
+function globalAbortTimeoutHandler(event: RunEvent): void {
+  const sid = event.session_id
+  if (!sid) return
+
+  const handlers = sessionEventHandlers.get(sid)
+  if (handlers?.onAbortTimeout) {
+    handlers.onAbortTimeout(event)
+  }
+}
+
+/**
  * Global abort.completed event handler
  */
 function globalAbortCompletedHandler(event: RunEvent): void {
@@ -473,6 +487,7 @@ export function registerSessionHandlers(
     onCompressionStarted: (event: RunEvent) => void
     onCompressionCompleted: (event: RunEvent) => void
     onAbortStarted: (event: RunEvent) => void
+    onAbortTimeout?: (event: RunEvent) => void
     onAbortCompleted: (event: RunEvent) => void
     onUsageUpdated: (event: RunEvent) => void
     onAgentEvent?: (event: RunEvent) => void
@@ -627,6 +642,7 @@ export function connectChatRun(requestedProfile?: string | null): Socket {
     chatRunSocket.on('compression.started', globalCompressionStartedHandler)
     chatRunSocket.on('compression.completed', globalCompressionCompletedHandler)
     chatRunSocket.on('abort.started', globalAbortStartedHandler)
+    chatRunSocket.on('abort.timeout', globalAbortTimeoutHandler)
     chatRunSocket.on('abort.completed', globalAbortCompletedHandler)
 
     // Usage events
@@ -831,6 +847,10 @@ export function startRunViaSocket(
       onEvent(evt)
     },
     onAbortStarted: (evt: RunEvent) => {
+      if (closed) return
+      onEvent(evt)
+    },
+    onAbortTimeout: (evt: RunEvent) => {
       if (closed) return
       onEvent(evt)
     },

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -288,7 +288,9 @@ defineExpose({
             <span class="tool-call-name">
               {{
                 chatStore.abortState.aborting
-                  ? 'Pausing... waiting for the run to stop and sync'
+                  ? chatStore.abortState.timedOut
+                    ? (chatStore.abortState.message || 'Still stopping... new messages will be queued')
+                    : 'Pausing... waiting for the run to stop and sync'
                   : chatStore.abortState.synced
                     ? 'Paused and synced'
                     : 'Paused'

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -444,6 +444,8 @@ export const useChatStore = defineStore('chat', () => {
   const abortState = ref<{
     aborting: boolean
     synced: boolean | null
+    timedOut?: boolean
+    message?: string
     error?: string
   } | null>(null)
   const isAborting = computed(() => abortState.value?.aborting === true)
@@ -670,6 +672,8 @@ export const useChatStore = defineStore('chat', () => {
                 if (e.contextTokens != null) target.contextTokens = e.contextTokens
               } else if (e.event === 'abort.started') {
                 setAbortState({ aborting: true, synced: null })
+              } else if (e.event === 'abort.timeout') {
+                setAbortState({ aborting: true, synced: false, timedOut: true, message: (e as any).message })
               } else if (e.event === 'abort.completed') {
                 setAbortState({ aborting: false, synced: e.synced ?? false })
               } else if (e.event === 'approval.requested') {
@@ -1541,6 +1545,9 @@ export const useChatStore = defineStore('chat', () => {
               case 'abort.started':
                 setAbortState({ aborting: true, synced: null })
                 break
+              case 'abort.timeout':
+                setAbortState({ aborting: true, synced: false, timedOut: true, message: (e as any).message })
+                break
               case 'abort.completed':
                 setAbortState({ aborting: false, synced: (e as any).synced ?? false })
                 break
@@ -1647,6 +1654,11 @@ export const useChatStore = defineStore('chat', () => {
 
             case 'abort.started': {
               setAbortState({ aborting: true, synced: null })
+              break
+            }
+
+            case 'abort.timeout': {
+              setAbortState({ aborting: true, synced: false, timedOut: true, message: (evt as any).message })
               break
             }
 
@@ -2138,6 +2150,11 @@ export const useChatStore = defineStore('chat', () => {
           break
         }
 
+        case 'abort.timeout': {
+          setAbortState({ aborting: true, synced: false, timedOut: true, message: (evt as any).message })
+          break
+        }
+
         case 'abort.completed': {
           setAbortState({ aborting: false, synced: (evt as any).synced ?? false })
           clearPendingInteractions(sid)
@@ -2467,6 +2484,7 @@ export const useChatStore = defineStore('chat', () => {
       onCompressionStarted: (evt) => handleEvent(evt),
       onCompressionCompleted: (evt) => handleEvent(evt),
       onAbortStarted: (evt) => handleEvent(evt),
+      onAbortTimeout: (evt) => handleEvent(evt),
       onAbortCompleted: (evt) => handleEvent(evt),
       onUsageUpdated: (evt) => handleEvent(evt),
       onAgentEvent: (evt) => handleEvent(evt),
@@ -2563,13 +2581,6 @@ export const useChatStore = defineStore('chat', () => {
       if (lastMsg?.isStreaming) {
         updateMessage(sid, lastMsg.id, { isStreaming: false })
       }
-      window.setTimeout(() => {
-        if (activeSessionId.value === sid && abortState.value?.aborting) {
-          streamStates.value.delete(sid)
-          serverWorking.value.delete(sid)
-          setAbortState(null)
-        }
-      }, 20_000)
     }
   }
 

--- a/packages/server/src/services/hermes/run-chat/abort.ts
+++ b/packages/server/src/services/hermes/run-chat/abort.ts
@@ -11,6 +11,8 @@ import { replaceState } from './compression'
 import { calcAndUpdateUsage } from './usage'
 import type { QueuedRun, SessionState } from './types'
 
+const ABORT_BRIDGE_SYNC_TIMEOUT_MESSAGE = 'Hermes Agent is still stopping. New messages will be queued until the current run exits.'
+
 export async function handleAbort(
   nsp: ReturnType<Server['of']>,
   socket: Socket,
@@ -59,8 +61,9 @@ export async function handleAbort(
   }
 
   if (state.source === 'cli') {
+    let interruptResult: any = null
     try {
-      await bridge.interrupt(sessionId, 'Aborted by user', state.profile)
+      interruptResult = await bridge.interrupt(sessionId, 'Aborted by user', state.profile)
     } catch (err) {
       logger.warn(err, '[chat-run-socket][abort] failed to interrupt CLI bridge for session %s', sessionId)
     }
@@ -69,6 +72,22 @@ export async function handleAbort(
       state.queue = state.queue.filter(item => !item.goalContinuation)
     } catch (err) {
       logger.debug(err, '[chat-run-socket][abort] goal pause-on-interrupt skipped for session %s', sessionId)
+    }
+    if (interruptResult?.synced === false) {
+      replaceState(sessionMap, sessionId, 'abort.timeout', {
+        event: 'abort.timeout',
+        run_id: runId,
+        synced: false,
+        message: ABORT_BRIDGE_SYNC_TIMEOUT_MESSAGE,
+      })
+      emitToSession(nsp, socket, sessionId, 'abort.timeout', {
+        event: 'abort.timeout',
+        run_id: runId,
+        synced: false,
+        message: ABORT_BRIDGE_SYNC_TIMEOUT_MESSAGE,
+      })
+      logger.warn({ sessionId, runId }, '[chat-run-socket][abort] CLI bridge interrupt did not sync before timeout')
+      return
     }
   } else if (state.abortController) {
     state.abortController.abort()

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -30,6 +30,7 @@ import type { ContentBlock, QueuedRun, SessionState } from './types'
 import type { ChatMessage } from '../../../lib/context-compressor'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
 import { filterBridgeToolCallMarkupDelta, flushPendingToolCallMarkup } from './bridge-delta'
+import { markAbortCompleted } from './abort'
 
 const BRIDGE_USAGE_FLUSH_DELAY_MS = 200
 const BRIDGE_TITLE_EVENT_POLL_INTERVAL_MS = 500
@@ -598,7 +599,7 @@ export async function resumeBridgeRun(
 
   const runMarker = state.activeRunMarker || `cli_resume_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
   state.isWorking = true
-  state.isAborting = false
+  state.isAborting = state.isAborting === true
   state.profile = profile
   state.source = 'cli'
   state.runId = runId
@@ -1139,7 +1140,19 @@ async function applyBridgeChunkAsync(
       sessionId,
       runId: chunk.run_id,
       status: chunk.status,
-    }, '[chat-run-socket][abort] suppressing CLI bridge terminal chunk during abort')
+    }, '[chat-run-socket][abort] completing CLI bridge abort after terminal chunk')
+    await markAbortCompleted(
+      nsp,
+      socket,
+      sessionId,
+      chunk.run_id || runMarker,
+      sessionMap,
+      (queuedSocket, queuedSessionId, nextQueuedRun, fallbackProfile) => {
+        const queuedState = sessionMap.get(queuedSessionId)
+        if (queuedState) queuedState.queue.unshift(nextQueuedRun)
+        dequeueNextQueuedRun(queuedSocket, queuedSessionId, fallbackProfile)
+      },
+    )
     return
   }
 

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -371,7 +371,7 @@ export class ChatRunSocket {
       const runId = typeof status.current_run_id === 'string' ? status.current_run_id : ''
       if (!running || !runId) return
       state.isWorking = true
-      state.isAborting = false
+      state.isAborting = state.isAborting === true
       state.runId = runId
       state.profile = profile
       state.source = 'cli'

--- a/tests/server/run-chat-abort-goal.test.ts
+++ b/tests/server/run-chat-abort-goal.test.ts
@@ -85,4 +85,45 @@ describe('run chat abort goal handling', () => {
       synced: true,
     }))
   })
+
+  it('keeps the session locked when a CLI interrupt does not sync before timeout', async () => {
+    const { handleAbort } = await import('../../packages/server/src/services/hermes/run-chat/abort')
+    const { emit, nsp, socket } = makeHarness()
+    const state = {
+      messages: [],
+      isWorking: true,
+      isAborting: false,
+      events: [],
+      queue: [
+        { queue_id: 'goal-1', input: 'continue goal', profile: 'default', goalContinuation: true },
+        { queue_id: 'user-1', input: 'normal follow-up', profile: 'default', source: 'cli' },
+      ],
+      runId: 'run-1',
+      profile: 'default',
+      source: 'cli',
+    } as any
+    const sessionMap = new Map([['session-1', state]])
+    const bridge = {
+      interrupt: vi.fn().mockResolvedValue({ ok: true, synced: false }),
+      goalPause: vi.fn().mockResolvedValue({ handled: true, status: 'paused', reason: 'user-interrupted' }),
+    }
+    const runQueuedItem = vi.fn()
+
+    await handleAbort(nsp as any, socket as any, 'session-1', sessionMap, bridge, runQueuedItem)
+
+    expect(runQueuedItem).not.toHaveBeenCalled()
+    expect(calcAndUpdateUsageMock).not.toHaveBeenCalled()
+    expect(state.isWorking).toBe(true)
+    expect(state.isAborting).toBe(true)
+    expect(state.runId).toBe('run-1')
+    expect(state.queue).toEqual([
+      { queue_id: 'user-1', input: 'normal follow-up', profile: 'default', source: 'cli' },
+    ])
+    expect(emit).toHaveBeenCalledWith('abort.timeout', expect.objectContaining({
+      session_id: 'session-1',
+      run_id: 'run-1',
+      synced: false,
+    }))
+    expect(emit).not.toHaveBeenCalledWith('abort.completed', expect.anything())
+  })
 })

--- a/tests/server/run-chat-bridge-resume.test.ts
+++ b/tests/server/run-chat-bridge-resume.test.ts
@@ -176,4 +176,79 @@ describe('resumeBridgeRun', () => {
     ]))
     expect(sessionMap.get('session-resume').isWorking).toBe(false)
   })
+
+  it('completes a timed-out abort when the resumed bridge run reaches a terminal state', async () => {
+    const { resumeBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    const { nsp, emitted } = createNamespace()
+    const socket = { id: 'socket-1', connected: true, emit: vi.fn() }
+    const sessionMap = new Map<string, any>()
+    sessionMap.set('session-resume', {
+      messages: [
+        { id: 1, session_id: 'session-resume', role: 'user', content: 'hello', timestamp: 1 },
+        { id: 2, session_id: 'session-resume', role: 'assistant', content: 'Hello', timestamp: 2, isStreaming: true },
+      ],
+      isWorking: true,
+      isAborting: true,
+      runId: 'run-resume',
+      profile: 'default',
+      source: 'cli',
+      events: [],
+      queue: [],
+    })
+
+    const bridge = {
+      getResult: vi.fn(async () => ({
+        ok: true,
+        run_id: 'run-resume',
+        session_id: 'session-resume',
+        status: 'running',
+        output: 'Hello',
+        deltas: ['Hello'],
+        events: [],
+      })),
+      getOutput: vi.fn(async () => ({
+        ok: true,
+        run_id: 'run-resume',
+        session_id: 'session-resume',
+        status: 'interrupted',
+        delta: '',
+        cursor: 1,
+        output: 'Hello',
+        done: true,
+        result: { interrupted: true, completed: false, final_response: 'Operation interrupted' },
+        error: null,
+        events: [],
+        event_cursor: 0,
+      })),
+    }
+
+    await resumeBridgeRun(
+      nsp as any,
+      socket as any,
+      {
+        sessionId: 'session-resume',
+        runId: 'run-resume',
+        profile: 'default',
+        instructions: 'system prompt',
+        model: 'gpt-test',
+        provider: 'openai',
+      },
+      sessionMap,
+      bridge as any,
+      vi.fn(),
+    )
+
+    expect(emitted).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        event: 'abort.completed',
+        payload: expect.objectContaining({ session_id: 'session-resume', run_id: 'run-resume', synced: true }),
+      }),
+    ]))
+    expect(emitted.some(item => item.event === 'run.failed')).toBe(false)
+    expect(sessionMap.get('session-resume')).toEqual(expect.objectContaining({
+      isWorking: false,
+      isAborting: false,
+      runId: undefined,
+    }))
+  })
 })


### PR DESCRIPTION
## Summary
- Keep CLI bridge sessions locked when Hermes Agent interrupt does not sync before the bridge timeout.
- Add an `abort.timeout` event so the frontend shows that the run is still stopping instead of clearing local running state early.
- Complete abort cleanup when the bridge later emits a terminal chunk, then release queued messages safely.

Fixes #1313

## Root Cause
Hermes Agent interruption is cooperative. When `bridge.interrupt()` returned `synced: false`, Web UI still cleared `isWorking`/`runId` and could start the next queued run while the same bridge session was still running, producing `session ... is already running`.

## Impact
Users can click Stop during a long CLI bridge run without the UI prematurely unlocking the session. New same-session messages remain queued until Hermes Agent actually exits the current run.

## Validation
- `npm run harness:check`
- `npx vitest run tests/server/run-chat-abort-goal.test.ts tests/server/run-chat-bridge-resume.test.ts`
- `npm run build`