### PR TITLE
feat: add Quant Lab rolling performance

### DIFF
--- a/packages/client/src/api/hermes/quant-lab.ts
+++ b/packages/client/src/api/hermes/quant-lab.ts
@@ -1,0 +1,12 @@
+import { request } from '../client'
+
+export interface QuantLabStatus {
+  ok: boolean
+  feature: 'quant-lab'
+  status: 'foundation'
+  capabilities: string[]
+}
+
+export async function fetchQuantLabStatus(): Promise<QuantLabStatus> {
+  return request<QuantLabStatus>('/api/hermes/quant-lab/status')
+}

--- a/packages/client/src/api/hermes/quant-lab.ts
+++ b/packages/client/src/api/hermes/quant-lab.ts
@@ -7,6 +7,52 @@ export interface QuantLabStatus {
   capabilities: string[]
 }
 
+export interface QuantLabRollingPerformance {
+  date: string
+  generatedAt: string
+  policy: string
+  snapshotCount: number
+  avgReturn1d: number | null
+  winRate1d: number | null
+  sampleCount1d: number
+  avgReturn5d: number | null
+  winRate5d: number | null
+  sampleCount5d: number
+  avgReturn10d: number | null
+  winRate10d: number | null
+  sampleCount10d: number
+  avgReturn20d: number | null
+  winRate20d: number | null
+  sampleCount20d: number
+  dailySampleCount: number
+  dailyAvgReturn: number | null
+  dailyWinRate: number | null
+  dailyVol: number | null
+  dailySharpeProxy: number | null
+  avgTurnover: number | null
+  latestTurnover: number | null
+  latestAdded: string[]
+  latestRemoved: string[]
+  latestKept: string[]
+  sourceFile: string
+  sourceDate: string
+}
+
+export interface QuantLabRollingPerformanceResponse {
+  ok: boolean
+  generatedAt: string
+  root: string
+  summaries: {
+    wf: QuantLabRollingPerformance | null
+    aiBottleneck: QuantLabRollingPerformance | null
+    youziCycle: QuantLabRollingPerformance | null
+  }
+}
+
 export async function fetchQuantLabStatus(): Promise<QuantLabStatus> {
   return request<QuantLabStatus>('/api/hermes/quant-lab/status')
+}
+
+export async function fetchQuantLabRollingPerformance(): Promise<QuantLabRollingPerformanceResponse> {
+  return request<QuantLabRollingPerformanceResponse>('/api/hermes/quant-lab/rolling-performance')
 }

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -275,6 +275,13 @@ function openChangelog() {
           </svg>
         </div>
         <div v-show="!isGroupCollapsed('tools')" class="nav-group-items">
+          <RouteLinkItem v-if="hasRoute('hermes.quantLab')" class="nav-item" :to="{ name: 'hermes.quantLab' }" :active="selectedKey === 'hermes.quantLab'">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M3 3v18h18" />
+              <path d="M7 15l4-4 3 3 5-7" />
+            </svg>
+            <span>Quant Lab</span>
+          </RouteLinkItem>
           <RouteLinkItem v-if="hasRoute('hermes.codingAgents')" class="nav-item" :to="{ name: 'hermes.codingAgents' }" :active="selectedKey === 'hermes.codingAgents'">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
               <polyline points="16 18 22 12 16 6" />

--- a/packages/client/src/router/index.ts
+++ b/packages/client/src/router/index.ts
@@ -68,6 +68,11 @@ const router = createRouter({
       meta: { requiresSuperAdmin: true },
     },
     {
+      path: '/hermes/quant-lab',
+      name: 'hermes.quantLab',
+      component: () => import('@/views/hermes/QuantLabView.vue'),
+    },
+    {
       path: '/hermes/skills-usage',
       name: 'hermes.skillsUsage',
       component: () => import('@/views/hermes/SkillsUsageView.vue'),

--- a/packages/client/src/views/hermes/QuantLabView.vue
+++ b/packages/client/src/views/hermes/QuantLabView.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { fetchQuantLabStatus, type QuantLabStatus } from '@/api/hermes/quant-lab'
+
+const loading = ref(false)
+const error = ref('')
+const status = ref<QuantLabStatus | null>(null)
+
+async function loadStatus() {
+  loading.value = true
+  error.value = ''
+
+  try {
+    status.value = await fetchQuantLabStatus()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load Quant Lab status'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  void loadStatus()
+})
+</script>
+
+<template>
+  <main class="quant-lab-view">
+    <section class="hero-card">
+      <div>
+        <p class="eyebrow">Hermes Quant Lab</p>
+        <h1>Quant Lab</h1>
+        <p class="subtitle">
+          Foundation surface for future market research, signal ranking, and valuation workflows.
+        </p>
+      </div>
+      <button class="refresh-button" :disabled="loading" @click="loadStatus">
+        {{ loading ? 'Refreshing…' : 'Refresh status' }}
+      </button>
+    </section>
+
+    <section class="status-card">
+      <div class="status-header">
+        <h2>Service status</h2>
+        <span class="status-pill" :class="{ ready: status?.ok }">
+          {{ status?.ok ? 'Ready' : loading ? 'Loading' : 'Unavailable' }}
+        </span>
+      </div>
+
+      <p v-if="error" class="error-message">{{ error }}</p>
+      <dl v-else class="status-grid">
+        <div>
+          <dt>Feature</dt>
+          <dd>{{ status?.feature ?? 'quant-lab' }}</dd>
+        </div>
+        <div>
+          <dt>Stage</dt>
+          <dd>{{ status?.status ?? 'foundation' }}</dd>
+        </div>
+        <div>
+          <dt>Capabilities</dt>
+          <dd>{{ status?.capabilities?.join(', ') || 'status' }}</dd>
+        </div>
+      </dl>
+    </section>
+  </main>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/variables' as *;
+
+.quant-lab-view {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-height: calc(100 * var(--vh));
+  padding: 32px;
+  background: $bg-primary;
+  color: $text-primary;
+}
+
+.hero-card,
+.status-card {
+  border: 1px solid $border-color;
+  border-radius: $radius-lg;
+  background: $bg-card;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.hero-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: $accent-primary;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 32px;
+  line-height: 1.15;
+}
+
+.subtitle {
+  max-width: 680px;
+  margin-top: 12px;
+  color: $text-secondary;
+  line-height: 1.6;
+}
+
+.refresh-button {
+  border: 1px solid $accent-primary;
+  border-radius: $radius-md;
+  padding: 10px 14px;
+  background: transparent;
+  color: $accent-primary;
+  cursor: pointer;
+  font-weight: 600;
+
+  &:disabled {
+    cursor: wait;
+    opacity: 0.65;
+  }
+}
+
+.status-card {
+  padding: 24px;
+}
+
+.status-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.status-pill {
+  border-radius: 999px;
+  padding: 4px 10px;
+  background: $bg-secondary;
+  color: $text-secondary;
+  font-size: 12px;
+  font-weight: 700;
+
+  &.ready {
+    background: rgba(34, 197, 94, 0.14);
+    color: #16a34a;
+  }
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  margin: 0;
+}
+
+dt {
+  color: $text-secondary;
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+dd {
+  margin: 6px 0 0;
+  font-weight: 600;
+}
+
+.error-message {
+  color: $error;
+}
+</style>

--- a/packages/client/src/views/hermes/QuantLabView.vue
+++ b/packages/client/src/views/hermes/QuantLabView.vue
@@ -1,17 +1,48 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
-import { fetchQuantLabStatus, type QuantLabStatus } from '@/api/hermes/quant-lab'
+import { computed, onMounted, ref } from 'vue'
+import {
+  fetchQuantLabRollingPerformance,
+  fetchQuantLabStatus,
+  type QuantLabRollingPerformance,
+  type QuantLabRollingPerformanceResponse,
+  type QuantLabStatus,
+} from '@/api/hermes/quant-lab'
 
 const loading = ref(false)
 const error = ref('')
 const status = ref<QuantLabStatus | null>(null)
+const rollingPerformance = ref<QuantLabRollingPerformanceResponse | null>(null)
+
+const rollingCards = computed(() => [
+  { key: 'wf', label: 'WF Top5', data: rollingPerformance.value?.summaries.wf ?? null },
+  { key: 'aiBottleneck', label: 'AI Bottleneck', data: rollingPerformance.value?.summaries.aiBottleneck ?? null },
+  { key: 'youziCycle', label: 'Youzi Cycle', data: rollingPerformance.value?.summaries.youziCycle ?? null },
+])
+
+function formatPercent(value: number | null | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 'n/a'
+  return `${(value * 100).toFixed(2)}%`
+}
+
+function formatList(items: string[]): string {
+  return items.length ? items.join(', ') : 'none'
+}
+
+function latestChangeText(summary: QuantLabRollingPerformance): string {
+  return `Added ${formatList(summary.latestAdded)} · Removed ${formatList(summary.latestRemoved)} · Kept ${formatList(summary.latestKept)}`
+}
 
 async function loadStatus() {
   loading.value = true
   error.value = ''
 
   try {
-    status.value = await fetchQuantLabStatus()
+    const [statusResponse, rollingResponse] = await Promise.all([
+      fetchQuantLabStatus(),
+      fetchQuantLabRollingPerformance(),
+    ])
+    status.value = statusResponse
+    rollingPerformance.value = rollingResponse
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to load Quant Lab status'
   } finally {
@@ -31,7 +62,7 @@ onMounted(() => {
         <p class="eyebrow">Hermes Quant Lab</p>
         <h1>Quant Lab</h1>
         <p class="subtitle">
-          Foundation surface for future market research, signal ranking, and valuation workflows.
+          Foundation surface for market research, signal ranking, valuation workflows, and rolling paper performance.
         </p>
       </div>
       <button class="refresh-button" :disabled="loading" @click="loadStatus">
@@ -62,6 +93,52 @@ onMounted(() => {
           <dd>{{ status?.capabilities?.join(', ') || 'status' }}</dd>
         </div>
       </dl>
+    </section>
+
+    <section class="status-card rolling-card">
+      <div class="status-header">
+        <div>
+          <h2>Rolling paper performance</h2>
+          <p class="muted">Latest summaries from Hermes Knowledge quant-simulation outputs.</p>
+        </div>
+        <span class="status-pill" :class="{ ready: rollingPerformance?.ok }">
+          {{ rollingPerformance?.ok ? 'Loaded' : loading ? 'Loading' : 'No data' }}
+        </span>
+      </div>
+
+      <div class="rolling-grid">
+        <article v-for="card in rollingCards" :key="card.key" class="rolling-summary">
+          <div class="rolling-summary-header">
+            <h3>{{ card.label }}</h3>
+            <span>{{ card.data ? `${card.data.snapshotCount} snapshots` : 'no data' }}</span>
+          </div>
+
+          <template v-if="card.data">
+            <p class="policy">{{ card.data.policy }} · {{ card.data.sourceDate }}</p>
+            <dl class="metrics-grid">
+              <div>
+                <dt>1D Avg</dt>
+                <dd>{{ formatPercent(card.data.avgReturn1d) }}</dd>
+              </div>
+              <div>
+                <dt>5D Avg</dt>
+                <dd>{{ formatPercent(card.data.avgReturn5d) }}</dd>
+              </div>
+              <div>
+                <dt>10D Avg</dt>
+                <dd>{{ formatPercent(card.data.avgReturn10d) }}</dd>
+              </div>
+              <div>
+                <dt>Turnover</dt>
+                <dd>{{ formatPercent(card.data.latestTurnover) }}</dd>
+              </div>
+            </dl>
+            <p class="change-text">{{ latestChangeText(card.data) }}</p>
+            <p class="muted">Source: {{ card.data.sourceFile }}</p>
+          </template>
+          <p v-else class="muted">No rolling performance summary found yet.</p>
+        </article>
+      </div>
     </section>
   </main>
 </template>
@@ -106,6 +183,7 @@ onMounted(() => {
 
 h1,
 h2,
+h3,
 p {
   margin: 0;
 }
@@ -163,11 +241,59 @@ h1 {
   }
 }
 
-.status-grid {
+.status-grid,
+.metrics-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 16px;
   margin: 0;
+}
+
+.rolling-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.rolling-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.rolling-summary {
+  border: 1px solid $border-color;
+  border-radius: $radius-md;
+  padding: 16px;
+  background: $bg-secondary;
+}
+
+.rolling-summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+
+  span {
+    color: $text-secondary;
+    font-size: 12px;
+    font-weight: 700;
+  }
+}
+
+.policy,
+.change-text,
+.muted {
+  color: $text-secondary;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.policy,
+.metrics-grid,
+.change-text {
+  margin-top: 12px;
 }
 
 dt {

--- a/packages/server/src/routes/hermes/quant-lab.ts
+++ b/packages/server/src/routes/hermes/quant-lab.ts
@@ -1,0 +1,24 @@
+import Router from '@koa/router'
+import type { Context } from 'koa'
+
+export interface QuantLabStatusResponse {
+  ok: true
+  feature: 'quant-lab'
+  status: 'foundation'
+  capabilities: string[]
+}
+
+export const quantLabRoutes = new Router()
+
+quantLabRoutes.get('/api/hermes/quant-lab/status', async (ctx: Context) => {
+  const body: QuantLabStatusResponse = {
+    ok: true,
+    feature: 'quant-lab',
+    status: 'foundation',
+    capabilities: [
+      'status',
+    ],
+  }
+
+  ctx.body = body
+})

--- a/packages/server/src/routes/hermes/quant-lab.ts
+++ b/packages/server/src/routes/hermes/quant-lab.ts
@@ -1,5 +1,9 @@
 import Router from '@koa/router'
 import type { Context } from 'koa'
+import { existsSync } from 'fs'
+import { readdir, readFile } from 'fs/promises'
+import { homedir } from 'os'
+import { basename, resolve } from 'path'
 
 export interface QuantLabStatusResponse {
   ok: true
@@ -8,7 +12,133 @@ export interface QuantLabStatusResponse {
   capabilities: string[]
 }
 
+type RollingPerformanceKey = 'wf' | 'aiBottleneck' | 'youziCycle'
+
+interface QuantLabRollingPerformance {
+  date: string
+  generatedAt: string
+  policy: string
+  snapshotCount: number
+  avgReturn1d: number | null
+  winRate1d: number | null
+  sampleCount1d: number
+  avgReturn5d: number | null
+  winRate5d: number | null
+  sampleCount5d: number
+  avgReturn10d: number | null
+  winRate10d: number | null
+  sampleCount10d: number
+  avgReturn20d: number | null
+  winRate20d: number | null
+  sampleCount20d: number
+  dailySampleCount: number
+  dailyAvgReturn: number | null
+  dailyWinRate: number | null
+  dailyVol: number | null
+  dailySharpeProxy: number | null
+  avgTurnover: number | null
+  latestTurnover: number | null
+  latestAdded: string[]
+  latestRemoved: string[]
+  latestKept: string[]
+  sourceFile: string
+  sourceDate: string
+}
+
+interface QuantLabRollingPerformanceResponse {
+  ok: true
+  generatedAt: string
+  root: string
+  summaries: Record<RollingPerformanceKey, QuantLabRollingPerformance | null>
+}
+
 export const quantLabRoutes = new Router()
+
+function resolveKnowledgeRoot(): string {
+  return process.env.WIKI_PATH ||
+    process.env.HERMES_KNOWLEDGE_PATH ||
+    resolve(homedir(), 'Documents', 'KK-Obsidian', 'Hermes-Knowledge')
+}
+
+function parseNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value !== 'string') return null
+  const normalized = value.trim().replace(/,/g, '').replace(/%$/, '')
+  if (!normalized) return null
+  const parsed = Number(normalized)
+  if (!Number.isFinite(parsed)) return null
+  return value.trim().endsWith('%') ? parsed / 100 : parsed
+}
+
+function parseInteger(value: unknown): number {
+  const parsed = parseNumber(value)
+  return Number.isFinite(parsed) ? Math.trunc(Number(parsed)) : 0
+}
+
+function parseStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.map(item => String(item).trim()).filter(Boolean)
+}
+
+async function readLatestRollingPerformanceSummary(
+  suffix: string,
+  defaultPolicy: string,
+): Promise<QuantLabRollingPerformance | null> {
+  const rawDir = resolve(resolveKnowledgeRoot(), 'raw', 'market', 'quant-simulation')
+  if (!existsSync(rawDir)) return null
+
+  const files = (await readdir(rawDir))
+    .filter(name => name.endsWith(suffix))
+    .sort()
+  const latest = files[files.length - 1]
+  if (!latest) return null
+
+  const sourceDate = latest.replace(suffix, '')
+  const sourceFile = resolve(rawDir, latest)
+  const raw = JSON.parse(await readFile(sourceFile, 'utf-8')) as Record<string, unknown>
+
+  return {
+    date: String(raw.date || sourceDate),
+    generatedAt: String(raw.generated_at || raw.generatedAt || ''),
+    policy: String(raw.policy || defaultPolicy),
+    snapshotCount: parseInteger(raw.snapshot_count),
+    avgReturn1d: parseNumber(raw.avg_return_1d),
+    winRate1d: parseNumber(raw.win_rate_1d),
+    sampleCount1d: parseInteger(raw.sample_count_1d),
+    avgReturn5d: parseNumber(raw.avg_return_5d),
+    winRate5d: parseNumber(raw.win_rate_5d),
+    sampleCount5d: parseInteger(raw.sample_count_5d),
+    avgReturn10d: parseNumber(raw.avg_return_10d),
+    winRate10d: parseNumber(raw.win_rate_10d),
+    sampleCount10d: parseInteger(raw.sample_count_10d),
+    avgReturn20d: parseNumber(raw.avg_return_20d),
+    winRate20d: parseNumber(raw.win_rate_20d),
+    sampleCount20d: parseInteger(raw.sample_count_20d),
+    dailySampleCount: parseInteger(raw.daily_sample_count),
+    dailyAvgReturn: parseNumber(raw.daily_avg_return),
+    dailyWinRate: parseNumber(raw.daily_win_rate),
+    dailyVol: parseNumber(raw.daily_vol),
+    dailySharpeProxy: parseNumber(raw.daily_sharpe_proxy),
+    avgTurnover: parseNumber(raw.avg_turnover),
+    latestTurnover: parseNumber(raw.latest_turnover),
+    latestAdded: parseStringList(raw.latest_added),
+    latestRemoved: parseStringList(raw.latest_removed),
+    latestKept: parseStringList(raw.latest_kept),
+    sourceFile: basename(sourceFile),
+    sourceDate,
+  }
+}
+
+async function safeReadLatestRollingPerformanceSummary(
+  suffix: string,
+  defaultPolicy: string,
+): Promise<QuantLabRollingPerformance | null> {
+  try {
+    return await readLatestRollingPerformanceSummary(suffix, defaultPolicy)
+  } catch {
+    return null
+  }
+}
 
 quantLabRoutes.get('/api/hermes/quant-lab/status', async (ctx: Context) => {
   const body: QuantLabStatusResponse = {
@@ -17,7 +147,29 @@ quantLabRoutes.get('/api/hermes/quant-lab/status', async (ctx: Context) => {
     status: 'foundation',
     capabilities: [
       'status',
+      'rolling-performance',
     ],
+  }
+
+  ctx.body = body
+})
+
+quantLabRoutes.get('/api/hermes/quant-lab/rolling-performance', async (ctx: Context) => {
+  const [wf, aiBottleneck, youziCycle] = await Promise.all([
+    safeReadLatestRollingPerformanceSummary('-wf-rolling-performance-summary.json', 'wf-top5-equal-weight'),
+    safeReadLatestRollingPerformanceSummary('-ai-bottleneck-rolling-performance-summary.json', 'ai-bottleneck-top5-equal-weight'),
+    safeReadLatestRollingPerformanceSummary('-youzi-cycle-rolling-performance-summary.json', 'youzi-cycle-top5-equal-weight'),
+  ])
+
+  const body: QuantLabRollingPerformanceResponse = {
+    ok: true,
+    generatedAt: new Date().toISOString(),
+    root: resolveKnowledgeRoot(),
+    summaries: {
+      wf,
+      aiBottleneck,
+      youziCycle,
+    },
   }
 
   ctx.body = body

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -35,6 +35,7 @@ import { mediaRoutes } from './hermes/media'
 import { proxyRoutes, proxyMiddleware } from './hermes/proxy'
 import { groupChatRoutes, setGroupChatServer } from './hermes/group-chat'
 import { performanceMonitorRoutes } from './hermes/performance-monitor'
+import { quantLabRoutes } from './hermes/quant-lab'
 import { mcpRoutes } from './hermes/mcp'
 
 /**
@@ -81,6 +82,7 @@ export function registerRoutes(app: any, authMiddleware: Array<(ctx: Context, ne
   app.use(kanbanRoutes.routes())             // Must be before proxy
   app.use(mediaRoutes.routes())              // Must be before proxy
   app.use(performanceMonitorRoutes.routes())  // Must be before proxy
+  app.use(quantLabRoutes.routes())            // Must be before proxy
   app.use(mcpRoutes.routes())                   // MCP management
   app.use(proxyRoutes.routes())
 


### PR DESCRIPTION
## Summary
- add a Quant Lab rolling-performance endpoint that reads the latest Hermes Knowledge quant-simulation summaries
- surface WF Top5, AI Bottleneck, and Youzi Cycle rolling metrics in the Quant Lab view
- keep the slice data-only/lightweight so future signal ranking and valuation UI can land separately

## Dependency
- Stacked after #1330 because this account cannot merge upstream PRs directly. Once #1330 lands, this PR can be rebased to show only the rolling-performance commit.

## Verification
- npm run build