### PR TITLE
修复群聊 socket 重连后未重新加入房间

### DIFF
--- a/docs/cli-chat-sessions.md
+++ b/docs/cli-chat-sessions.md
@@ -51,6 +51,7 @@ ChatPanel / ChatInput
 
 | 时间 | PR / commit | 动到的功能 | 链路影响 |
 | --- | --- | --- | --- |
+| 2026-06-04 | #1337 | Group Chat socket reconnect/rejoin | `/group-chat` 前端 store 在 socket reconnect 后会重新 join 当前 room，并合并 join ack 中返回的消息以补回断线期间错过的内容；同时恢复 members/agents/typing/context status。若用户在 ack 返回前切换房间，会忽略旧 room ack；join ack 中的 `rooms` 字符串列表不会覆盖前端 `RoomInfo[]` 房间列表，避免路由和侧边栏状态被污染。 |
 | 2026-06-04 | #1333 | reasoning 多轮合并为单条 assistant 消息 | `chat.ts` 用独立的 reasoning 目标合并 `reasoning.delta` / `thinking.delta`，所以同一 run 内跨 tool cycle 的 thinking 会收敛到同一条 assistant 气泡；`tool.started` 仍会切断正文流目标，后续 `message.delta` 会在 tool 后新建 assistant，避免最终正文插回工具前。 |
 | 2026-06-04 | local | CLI bridge abort 超时同步 | `/chat-run` abort 路径在 Hermes Agent 协作式 interrupt 未能在 bridge 同步窗口内完成时，不再提前清理 Web UI `isWorking/runId` 或启动队列，而是发送 `abort.timeout` 并保持 session locked/aborting；同会话新消息继续进入队列，避免旧 Agent run 尚未退出时触发 `session ... is already running`。当前端后续收到 bridge terminal chunk 时再发送 `abort.completed` 并释放状态。前端新增 `abort.timeout` 事件展示“仍在停止中”，并移除本地 20s 自动清 running 兜底。 |
 | 2026-06-04 | #1320 `237fd954` | Agent Bridge restart/resume；shutdown/stop timing | Web UI `restart`/页面内升级通过 `SIGUSR2` 保留 Agent Bridge，server 重启后 `ChatRunSocket.resume` 会查询 bridge status 并通过 `resumeBridgeRun()` 继续 poll 既有 `run_id` 的 delta/events。真实 `stop`/`SIGTERM` 仍会请求 bridge shutdown；非桌面 shutdown 兜底延长到 15s 以覆盖 worker 清理窗口，桌面 `HERMES_DESKTOP=true` 默认仍保持 3s。CLI `restart` 仍使用 5s grace，CLI `stop` 最长等 15s 且进程退出后立即返回。 |

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -197,6 +197,70 @@ const currentUserAvatar = ref('')
     const userId = ref(getStoredUserId())
     const userName = ref(getStoredUserName() || '')
 
+    function applyRealtimeJoinState(res: any, options: { syncMessages?: boolean } = {}) {
+        members.value = res.members || []
+        if (res.agents) agents.value = res.agents
+        if (res.roomName) roomName.value = res.roomName
+        if (options.syncMessages && Array.isArray(res.messages)) {
+            const byId = new Map(messages.value.map(message => [message.id, message]))
+            for (const message of res.messages) {
+                const existing = byId.get(message.id)
+                byId.set(message.id, existing ? { ...existing, ...message } : message)
+            }
+            messages.value = Array.from(byId.values()).sort((a, b) => a.timestamp - b.timestamp)
+            if (typeof res.total === 'number' || typeof res.hasMore === 'boolean') {
+                applyMessagePaging(res)
+            } else {
+                loadedMessageCount.value = Math.max(loadedMessageCount.value, messages.value.length)
+                totalMessages.value = Math.max(totalMessages.value, loadedMessageCount.value)
+            }
+        }
+
+        // Restore typing state from server. Replace the local transient map so
+        // a reconnect cannot leave stale typers from the pre-reconnect socket.
+        for (const entry of typingUsers.value.values()) clearTimeout(entry.timer)
+        typingUsers.value.clear()
+        if (res.typingUsers) {
+            for (const u of res.typingUsers) {
+                const timer = setTimeout(() => typingUsers.value.delete(u.userId), 5000)
+                typingUsers.value.set(u.userId, { name: u.userName, timer })
+            }
+        }
+
+        // Restore context statuses from server
+        if (res.contextStatuses) {
+            contextStatuses.value = new Map(
+                res.contextStatuses.map((s: any) => [s.agentName, s])
+            )
+        } else {
+            contextStatuses.value.clear()
+        }
+    }
+
+    async function joinRealtimeRoom(roomId: string, options: { syncMessages?: boolean } = {}) {
+        const socket = getSocket()
+        if (!socket) return
+
+        await new Promise<void>((resolve) => {
+            socket.emit('join', {
+                roomId,
+                name: userName.value || undefined,
+                description: localStorage.getItem('gc_user_description') || undefined,
+            }, (res: any) => {
+                if (currentRoomId.value !== roomId) {
+                    resolve()
+                    return
+                }
+                if (!res?.error) {
+                    applyRealtimeJoinState(res, options)
+                } else {
+                    error.value = res.error
+                }
+                resolve()
+            })
+        })
+    }
+
     // ─── Computed ───────────────────────────────────────────
     const sortedMessages = computed(() => mapGroupMessages([...messages.value].sort((a, b) => a.timestamp - b.timestamp)))
 
@@ -235,6 +299,12 @@ const currentUserAvatar = ref('')
             console.log('[GroupChat] connected, socket id:', socket.id)
             connected.value = true
             error.value = null
+            const roomId = currentRoomId.value
+            if (roomId) {
+                void joinRealtimeRoom(roomId, { syncMessages: true }).catch((err: any) => {
+                    error.value = err.message
+                })
+            }
         })
 
         socket.on('disconnect', (reason) => {
@@ -478,40 +548,9 @@ const currentUserAvatar = ref('')
             isJoining.value = false
         }
 
-        // Join via socket for real-time updates
-        const socket = getSocket()
-        if (socket) {
-            await new Promise<void>((resolve) => {
-                socket.emit('join', {
-                    roomId,
-                    name: userName.value || undefined,
-                    description: localStorage.getItem('gc_user_description') || undefined,
-                }, (res: any) => {
-                    if (!res?.error) {
-                        members.value = res.members || []
-                        if (res.agents) agents.value = res.agents
-
-                        // Restore typing state from server
-                        if (res.typingUsers) {
-                            for (const u of res.typingUsers) {
-                                if (!typingUsers.value.has(u.userId)) {
-                                    const timer = setTimeout(() => typingUsers.value.delete(u.userId), 5000)
-                                    typingUsers.value.set(u.userId, { name: u.userName, timer })
-                                }
-                            }
-                        }
-
-                        // Restore context statuses from server
-                        if (res.contextStatuses) {
-                            contextStatuses.value = new Map(
-                                res.contextStatuses.map((s: any) => [s.agentName, s])
-                            )
-                        }
-                    }
-                    resolve()
-                })
-            })
-        }
+        // Join via socket for real-time updates. Reconnect uses the same path
+        // so the browser socket is a room member before the next send.
+        await joinRealtimeRoom(roomId)
     }
 
     async function loadOlderMessages(): Promise<boolean> {

--- a/tests/client/group-chat-store-streaming.test.ts
+++ b/tests/client/group-chat-store-streaming.test.ts
@@ -97,7 +97,11 @@ describe('group chat store streaming merge', () => {
     groupChatApiMock.getStoredUserId.mockReturnValue('user-1')
     groupChatApiMock.getStoredUserName.mockReturnValue('tester')
     groupChatApiMock.socket.on.mockClear()
-    groupChatApiMock.socket.emit.mockClear()
+    groupChatApiMock.socket.emit.mockReset()
+    groupChatApiMock.socket.emit.mockImplementation((event: string, _data?: unknown, ack?: Function) => {
+      if (event === 'join' && ack) ack({ members: [], agents: [], typingUsers: [], contextStatuses: [] })
+      return groupChatApiMock.socket
+    })
     groupChatApiMock.socket.disconnect.mockClear()
   })
 
@@ -245,5 +249,93 @@ describe('group chat store streaming merge', () => {
       toolResult: { ok: true },
       toolStatus: 'done',
     })
+  })
+
+  it('rejoins the active room after socket reconnect and restores transient room state', async () => {
+    const store = await createJoinedStore()
+    store.loadedMessageCount = 300
+    store.totalMessages = 500
+    store.hasMoreBefore = true
+    store.rooms = [room]
+    groupChatApiMock.socket.emit.mockClear()
+    groupChatApiMock.socket.emit.mockImplementation((event: string, data?: any, ack?: Function) => {
+      if (event === 'join' && ack) {
+        ack({
+          members: [{ id: 'human-1', name: 'Human', online: true }],
+          agents: [{ id: 'agent-row-1', agentId: 'agent-1', profile: 'worker', name: 'Worker' }],
+          rooms: ['room-1', 'room-2'],
+          messages: [assistantMessage({ id: 'missed-1', content: 'missed while offline', timestamp: 2 })],
+          typingUsers: [{ userId: 'agent-1', userName: 'Worker' }],
+          contextStatuses: [{ agentName: 'Worker', status: 'replying' }],
+        })
+      }
+      return groupChatApiMock.socket
+    })
+
+    emitSocket('connect', undefined)
+    await Promise.resolve()
+
+    expect(groupChatApiMock.socket.emit).toHaveBeenCalledWith(
+      'join',
+      expect.objectContaining({ roomId: 'room-1', name: 'tester' }),
+      expect.any(Function),
+    )
+    expect(store.members).toEqual([expect.objectContaining({ id: 'human-1', name: 'Human' })])
+    expect(store.agents).toEqual([expect.objectContaining({ profile: 'worker', name: 'Worker' })])
+    expect(store.rooms).toEqual([room])
+    expect(store.messages).toEqual([expect.objectContaining({ id: 'missed-1', content: 'missed while offline' })])
+    expect(store.loadedMessageCount).toBe(300)
+    expect(store.totalMessages).toBe(500)
+    expect(store.hasMoreBefore).toBe(true)
+    expect(store.typingNames).toEqual(['Worker'])
+    expect(store.contextStatus).toEqual(expect.objectContaining({ agentName: 'Worker', status: 'replying' }))
+  })
+
+  it('ignores a stale reconnect join ack after the user switches rooms', async () => {
+    const store = await createJoinedStore()
+    let joinAck: Function | undefined
+    groupChatApiMock.socket.emit.mockClear()
+    groupChatApiMock.socket.emit.mockImplementation((event: string, data?: any, ack?: Function) => {
+      if (event === 'join') joinAck = ack
+      return groupChatApiMock.socket
+    })
+
+    emitSocket('connect', undefined)
+    await Promise.resolve()
+    expect(joinAck).toBeDefined()
+
+    const roomTwoMessage = assistantMessage({ id: 'room-2-msg', roomId: 'room-2', content: 'current room', timestamp: 3 })
+    store.currentRoomId = 'room-2'
+    store.members = [{ id: 'human-2', name: 'Room 2 Human', online: true }]
+    store.messages = [roomTwoMessage]
+
+    joinAck?.({
+      members: [{ id: 'human-1', name: 'Old Room Human', online: true }],
+      messages: [assistantMessage({ id: 'old-room-msg', content: 'old room', timestamp: 2 })],
+      typingUsers: [{ userId: 'agent-1', userName: 'Worker' }],
+      contextStatuses: [{ agentName: 'Worker', status: 'replying' }],
+    })
+    await Promise.resolve()
+
+    expect(store.currentRoomId).toBe('room-2')
+    expect(store.members).toEqual([expect.objectContaining({ id: 'human-2', name: 'Room 2 Human' })])
+    expect(store.messages).toEqual([roomTwoMessage])
+    expect(store.typingNames).toEqual([])
+  })
+
+  it('does not rejoin when socket connects without an active room', async () => {
+    const { useGroupChatStore } = await import('@/stores/hermes/group-chat')
+    const store = useGroupChatStore()
+    await store.connect()
+    groupChatApiMock.socket.emit.mockClear()
+
+    emitSocket('connect', undefined)
+    await Promise.resolve()
+
+    expect(groupChatApiMock.socket.emit).not.toHaveBeenCalledWith(
+      'join',
+      expect.anything(),
+      expect.any(Function),
+    )
   })
 })


### PR DESCRIPTION
## Summary

- socket 重连后自动重新加入当前群聊房间。
- 初次加入和重连加入复用同一条 realtime join 路径。
- 合并重连 join ack 返回的消息，补回断线期间错过的消息。
- 从服务端 join ack 恢复成员、agent、typing 和 context status 等临时状态。
- 用户在重连 ack 返回前切换房间时，忽略旧房间的过期 ack，避免污染当前房间状态。

Refs #652.
Refs #673.

## Scope

本 PR 只做群聊客户端 reconnect/rejoin 稳定性修复。不修改 agent mention routing、tool-call 执行，也不修改群聊权限逻辑。

## Verification

- `git diff --check`
- `npm run harness:check`
- `npm test -- tests/client/group-chat-store-streaming.test.ts` — 10 tests passed
- `npm run build`
