### PR TITLE
[codex] merge reasoning across tool cycles without breaking tool boundaries

### DIFF
--- a/docs/cli-chat-sessions.md
+++ b/docs/cli-chat-sessions.md
@@ -51,7 +51,7 @@ ChatPanel / ChatInput
 
 | 时间 | PR / commit | 动到的功能 | 链路影响 |
 | --- | --- | --- | --- |
-| 2026-06-04 | #1333 | reasoning 多轮合并为单条 assistant 消息 | `chat.ts` 不再在 `tool.started` 时清空 `activeAssistantMessageId`；`reasoning.delta` / `thinking.delta` 回退跳过 `isStreaming` 检查，对同一条 assistant 消息持续追加 reasoning。一个 run 内所有 thinking 收敛到同一条 assistant 气泡，不再拆分。不影响 run boundary 或历史消息回放协议。 |
+| 2026-06-04 | #1333 | reasoning 多轮合并为单条 assistant 消息 | `chat.ts` 用独立的 reasoning 目标合并 `reasoning.delta` / `thinking.delta`，所以同一 run 内跨 tool cycle 的 thinking 会收敛到同一条 assistant 气泡；`tool.started` 仍会切断正文流目标，后续 `message.delta` 会在 tool 后新建 assistant，避免最终正文插回工具前。 |
 | 2026-06-04 | local | CLI bridge abort 超时同步 | `/chat-run` abort 路径在 Hermes Agent 协作式 interrupt 未能在 bridge 同步窗口内完成时，不再提前清理 Web UI `isWorking/runId` 或启动队列，而是发送 `abort.timeout` 并保持 session locked/aborting；同会话新消息继续进入队列，避免旧 Agent run 尚未退出时触发 `session ... is already running`。当前端后续收到 bridge terminal chunk 时再发送 `abort.completed` 并释放状态。前端新增 `abort.timeout` 事件展示“仍在停止中”，并移除本地 20s 自动清 running 兜底。 |
 | 2026-06-04 | #1320 `237fd954` | Agent Bridge restart/resume；shutdown/stop timing | Web UI `restart`/页面内升级通过 `SIGUSR2` 保留 Agent Bridge，server 重启后 `ChatRunSocket.resume` 会查询 bridge status 并通过 `resumeBridgeRun()` 继续 poll 既有 `run_id` 的 delta/events。真实 `stop`/`SIGTERM` 仍会请求 bridge shutdown；非桌面 shutdown 兜底延长到 15s 以覆盖 worker 清理窗口，桌面 `HERMES_DESKTOP=true` 默认仍保持 3s。CLI `restart` 仍使用 5s grace，CLI `stop` 最长等 15s 且进程退出后立即返回。 |
 | 2026-06-04 | #1303 | Chat / Group Chat 工具详情与完成事件边界 | 前端 message item 和 store mapping 现在保留 object / array / number / boolean 工具 payload，`0` / `false` 不再因为 falsy 判断被隐藏；普通文本结果继续按 TEXT 展示。空 `run.completed.parsed_content` 只会保留当前流式 assistant 内容，不会把旧 assistant 消息误当成本次输出。 |

--- a/docs/cli-chat-sessions.md
+++ b/docs/cli-chat-sessions.md
@@ -51,6 +51,7 @@ ChatPanel / ChatInput
 
 | 时间 | PR / commit | 动到的功能 | 链路影响 |
 | --- | --- | --- | --- |
+| 2026-06-04 | #1333 | reasoning 多轮合并为单条 assistant 消息 | `chat.ts` 不再在 `tool.started` 时清空 `activeAssistantMessageId`；`reasoning.delta` / `thinking.delta` 回退跳过 `isStreaming` 检查，对同一条 assistant 消息持续追加 reasoning。一个 run 内所有 thinking 收敛到同一条 assistant 气泡，不再拆分。不影响 run boundary 或历史消息回放协议。 |
 | 2026-06-04 | local | CLI bridge abort 超时同步 | `/chat-run` abort 路径在 Hermes Agent 协作式 interrupt 未能在 bridge 同步窗口内完成时，不再提前清理 Web UI `isWorking/runId` 或启动队列，而是发送 `abort.timeout` 并保持 session locked/aborting；同会话新消息继续进入队列，避免旧 Agent run 尚未退出时触发 `session ... is already running`。当前端后续收到 bridge terminal chunk 时再发送 `abort.completed` 并释放状态。前端新增 `abort.timeout` 事件展示“仍在停止中”，并移除本地 20s 自动清 running 兜底。 |
 | 2026-06-04 | #1320 `237fd954` | Agent Bridge restart/resume；shutdown/stop timing | Web UI `restart`/页面内升级通过 `SIGUSR2` 保留 Agent Bridge，server 重启后 `ChatRunSocket.resume` 会查询 bridge status 并通过 `resumeBridgeRun()` 继续 poll 既有 `run_id` 的 delta/events。真实 `stop`/`SIGTERM` 仍会请求 bridge shutdown；非桌面 shutdown 兜底延长到 15s 以覆盖 worker 清理窗口，桌面 `HERMES_DESKTOP=true` 默认仍保持 3s。CLI `restart` 仍使用 5s grace，CLI `stop` 最长等 15s 且进程退出后立即返回。 |
 | 2026-06-04 | #1303 | Chat / Group Chat 工具详情与完成事件边界 | 前端 message item 和 store mapping 现在保留 object / array / number / boolean 工具 payload，`0` / `false` 不再因为 falsy 判断被隐藏；普通文本结果继续按 TEXT 展示。空 `run.completed.parsed_content` 只会保留当前流式 assistant 内容，不会把旧 assistant 消息误当成本次输出。 |

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1485,6 +1485,7 @@ export const useChatStore = defineStore('chat', () => {
       let runProducedAssistantText = false
       let runHadToolActivity = false
       let activeAssistantMessageId: string | null = null
+      let reasoningAssistantMessageId: string | null = null
 
       const closeStreamingAssistant = () => {
         const msgs = getSessionMsgs(sid)
@@ -1494,6 +1495,7 @@ export const useChatStore = defineStore('chat', () => {
           }
         })
         activeAssistantMessageId = null
+        reasoningAssistantMessageId = null
       }
 
       const applyReconnectResume = (data: ResumeSessionPayload) => {
@@ -1537,9 +1539,11 @@ export const useChatStore = defineStore('chat', () => {
           if (data.isWorking && lastAssistant) {
             lastAssistant.isStreaming = true
             activeAssistantMessageId = lastAssistant.id
+            reasoningAssistantMessageId = lastAssistant.id
             if (lastAssistant.reasoning) noteReasoningStart(lastAssistant.id)
           } else {
             activeAssistantMessageId = null
+            reasoningAssistantMessageId = null
           }
         }
 
@@ -1718,15 +1722,13 @@ export const useChatStore = defineStore('chat', () => {
               if (!text) break
               runProducedAssistantText = true
               const msgs = getSessionMsgs(sid)
-              const last = activeAssistantMessageId
-                ? msgs.find(m => m.id === activeAssistantMessageId)
+              const reasoningTargetId = reasoningAssistantMessageId || activeAssistantMessageId
+              const last = reasoningTargetId
+                ? msgs.find(m => m.id === reasoningTargetId)
                 : null
               if (last?.role === 'assistant') {
-                // Resume streaming on a message paused by tool.started
-                if (!last.isStreaming) {
-                  updateMessage(sid, last.id, { isStreaming: true })
-                }
                 last.reasoning = (last.reasoning || '') + text
+                reasoningAssistantMessageId = last.id
                 noteReasoningStart(last.id)
               } else {
                 const newId = uid()
@@ -1739,6 +1741,7 @@ export const useChatStore = defineStore('chat', () => {
                   reasoning: text,
                 })
                 activeAssistantMessageId = newId
+                reasoningAssistantMessageId = newId
                 noteReasoningStart(newId)
               }
 
@@ -1807,6 +1810,7 @@ export const useChatStore = defineStore('chat', () => {
               if (last?.isStreaming) {
                 updateMessage(sid, last.id, { isStreaming: false })
               }
+              activeAssistantMessageId = null
               const existingTool = toolCallId
                 ? msgs.find(m => m.role === 'tool' && m.toolCallId === toolCallId)
                 : null
@@ -2000,6 +2004,7 @@ export const useChatStore = defineStore('chat', () => {
                 cleanup()
               }
               activeAssistantMessageId = null
+              reasoningAssistantMessageId = null
               updateSessionTitle(sid)
               break
             }
@@ -2101,6 +2106,7 @@ export const useChatStore = defineStore('chat', () => {
     let runProducedAssistantText = false
     let runHadToolActivity = false
     let activeAssistantMessageId: string | null = null
+    let reasoningAssistantMessageId: string | null = null
 
     const cleanup = () => {
       if (closed) return
@@ -2119,6 +2125,7 @@ export const useChatStore = defineStore('chat', () => {
         }
       })
       activeAssistantMessageId = null
+      reasoningAssistantMessageId = null
     }
 
     // Shared event handler — filters by session_id tag
@@ -2229,15 +2236,13 @@ export const useChatStore = defineStore('chat', () => {
           if (!text) break
           runProducedAssistantText = true
           const msgs = getSessionMsgs(sid)
-          const last = activeAssistantMessageId
-            ? msgs.find(m => m.id === activeAssistantMessageId)
+          const reasoningTargetId = reasoningAssistantMessageId || activeAssistantMessageId
+          const last = reasoningTargetId
+            ? msgs.find(m => m.id === reasoningTargetId)
             : null
           if (last?.role === 'assistant') {
-            // Resume streaming on a message paused by tool.started
-            if (!last.isStreaming) {
-              updateMessage(sid, last.id, { isStreaming: true })
-            }
             last.reasoning = (last.reasoning || '') + text
+            reasoningAssistantMessageId = last.id
             noteReasoningStart(last.id)
           } else {
             const newId = uid()
@@ -2250,6 +2255,7 @@ export const useChatStore = defineStore('chat', () => {
               reasoning: text,
             })
             activeAssistantMessageId = newId
+            reasoningAssistantMessageId = newId
             noteReasoningStart(newId)
           }
 
@@ -2310,6 +2316,7 @@ export const useChatStore = defineStore('chat', () => {
           if (last?.isStreaming) {
             updateMessage(sid, last.id, { isStreaming: false })
           }
+          activeAssistantMessageId = null
           const existingTool = toolCallId
             ? msgs.find(m => m.role === 'tool' && m.toolCallId === toolCallId)
             : null
@@ -2483,9 +2490,11 @@ export const useChatStore = defineStore('chat', () => {
           if (!hasQueue) {
             cleanup()
             activeAssistantMessageId = null
+            reasoningAssistantMessageId = null
           } else {
             // More runs pending — reset for next run but don't cleanup
             activeAssistantMessageId = null
+            reasoningAssistantMessageId = null
           }
           updateSessionTitle(sid)
           break

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1721,7 +1721,11 @@ export const useChatStore = defineStore('chat', () => {
               const last = activeAssistantMessageId
                 ? msgs.find(m => m.id === activeAssistantMessageId)
                 : null
-              if (last?.role === 'assistant' && last.isStreaming) {
+              if (last?.role === 'assistant') {
+                // Resume streaming on a message paused by tool.started
+                if (!last.isStreaming) {
+                  updateMessage(sid, last.id, { isStreaming: true })
+                }
                 last.reasoning = (last.reasoning || '') + text
                 noteReasoningStart(last.id)
               } else {
@@ -1803,7 +1807,6 @@ export const useChatStore = defineStore('chat', () => {
               if (last?.isStreaming) {
                 updateMessage(sid, last.id, { isStreaming: false })
               }
-              activeAssistantMessageId = null
               const existingTool = toolCallId
                 ? msgs.find(m => m.role === 'tool' && m.toolCallId === toolCallId)
                 : null
@@ -2229,7 +2232,11 @@ export const useChatStore = defineStore('chat', () => {
           const last = activeAssistantMessageId
             ? msgs.find(m => m.id === activeAssistantMessageId)
             : null
-          if (last?.role === 'assistant' && last.isStreaming) {
+          if (last?.role === 'assistant') {
+            // Resume streaming on a message paused by tool.started
+            if (!last.isStreaming) {
+              updateMessage(sid, last.id, { isStreaming: true })
+            }
             last.reasoning = (last.reasoning || '') + text
             noteReasoningStart(last.id)
           } else {
@@ -2303,7 +2310,6 @@ export const useChatStore = defineStore('chat', () => {
           if (last?.isStreaming) {
             updateMessage(sid, last.id, { isStreaming: false })
           }
-          activeAssistantMessageId = null
           const existingTool = toolCallId
             ? msgs.find(m => m.role === 'tool' && m.toolCallId === toolCallId)
             : null

--- a/tests/client/chat-store-reasoning-tool-boundary.test.ts
+++ b/tests/client/chat-store-reasoning-tool-boundary.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+const chatApi = vi.hoisted(() => ({
+  startRunViaSocket: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/chat', () => ({
+  startRunViaSocket: chatApi.startRunViaSocket,
+  resumeSession: vi.fn(),
+  registerSessionHandlers: vi.fn(),
+  unregisterSessionHandlers: vi.fn(),
+  getChatRunSocket: vi.fn(() => ({ emit: vi.fn() })),
+  respondToolApproval: vi.fn(),
+  respondClarify: vi.fn(),
+  onPeerUserMessage: vi.fn(() => vi.fn()),
+  onSessionCommand: vi.fn(() => vi.fn()),
+  onSessionTitleUpdated: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('@/api/client', () => ({
+  getActiveProfileName: () => 'default',
+  hasApiKey: () => false,
+}))
+
+vi.mock('@/api/hermes/sessions', () => ({
+  deleteSession: vi.fn(),
+  fetchSessionMessagesPage: vi.fn(),
+  fetchSessions: vi.fn(),
+  setSessionModel: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/download', () => ({
+  getDownloadUrl: (_path: string, name: string) => `/download/${name}`,
+}))
+
+vi.mock('@/api/hermes/system', () => ({
+  checkHealth: vi.fn(),
+  fetchAvailableModels: vi.fn(),
+  addCustomModel: vi.fn(),
+  removeCustomModel: vi.fn(),
+  updateDefaultModel: vi.fn(),
+  updateModelVisibility: vi.fn(),
+  triggerUpdate: vi.fn(),
+  updateModelAlias: vi.fn(),
+}))
+
+vi.mock('@/utils/completion-sound', () => ({
+  primeCompletionSound: vi.fn(),
+  playCompletionSound: vi.fn(),
+}))
+
+import { useChatStore, type Session } from '@/stores/hermes/chat'
+import type { RunEvent } from '@/api/hermes/chat'
+
+function makeSession(): Session {
+  return {
+    id: 'session-1',
+    title: 'session',
+    messages: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  }
+}
+
+describe('chat store reasoning/tool boundaries', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    setActivePinia(createPinia())
+    chatApi.startRunViaSocket.mockReturnValue({ abort: vi.fn() })
+  })
+
+  it('merges reasoning across tool cycles without appending post-tool text before the tool', async () => {
+    const store = useChatStore()
+    const session = makeSession()
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    await store.sendMessage('run a tool')
+
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: RunEvent) => void
+    onEvent({ event: 'run.started', session_id: 'session-1' })
+    onEvent({ event: 'reasoning.delta', session_id: 'session-1', delta: 'think before. ' })
+    onEvent({ event: 'message.delta', session_id: 'session-1', delta: 'Before tool.' })
+    onEvent({
+      event: 'tool.started',
+      session_id: 'session-1',
+      tool_call_id: 'tool-1',
+      tool: 'shell',
+      arguments: '{}',
+    } as RunEvent)
+    onEvent({ event: 'reasoning.delta', session_id: 'session-1', delta: 'think after. ' })
+    onEvent({
+      event: 'tool.completed',
+      session_id: 'session-1',
+      tool_call_id: 'tool-1',
+      output: 'tool output',
+    } as RunEvent)
+    onEvent({ event: 'message.delta', session_id: 'session-1', delta: 'After tool.' })
+
+    expect(store.messages.map(message => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'assistant',
+    ])
+    expect(store.messages[1]).toEqual(expect.objectContaining({
+      role: 'assistant',
+      content: 'Before tool.',
+      reasoning: 'think before. think after. ',
+      isStreaming: false,
+    }))
+    expect(store.messages[2]).toEqual(expect.objectContaining({
+      role: 'tool',
+      toolStatus: 'done',
+      toolResult: 'tool output',
+    }))
+    expect(store.messages[3]).toEqual(expect.objectContaining({
+      role: 'assistant',
+      content: 'After tool.',
+      isStreaming: true,
+    }))
+  })
+})


### PR DESCRIPTION
## Summary

- Cherry-picks #1333's reasoning merge fix so one run can keep reasoning/thinking in a single assistant message across tool cycles.
- Separates the reasoning target from the active text-stream target so `tool.started` still breaks the assistant text boundary.
- Adds regression coverage for `reasoning.delta -> message.delta -> tool.started -> reasoning.delta -> tool.completed -> message.delta`, ensuring post-tool text renders after the tool message.

## Why

The original #1333 fix kept `activeAssistantMessageId` alive across tool cycles. That merged reasoning correctly, but it could also make post-tool `message.delta` append to the pre-tool assistant message, visually moving tool output under the wrong body text.

## Validation

- `npm run test -- tests/client/chat-store-reasoning-tool-boundary.test.ts tests/client/chat-store-compression-state.test.ts tests/client/chat-store-session-command.test.ts tests/client/chat-store-thinking.test.ts`
- `npm run harness:check`
- `npm run build`

Based on #1333; original author commit is preserved in the branch history.