### PR TITLE
[codex] avoid bridge worker startup on resume

### DIFF
--- a/docs/cli-chat-sessions.md
+++ b/docs/cli-chat-sessions.md
@@ -51,6 +51,7 @@ ChatPanel / ChatInput
 
 | 时间 | PR / commit | 动到的功能 | 链路影响 |
 | --- | --- | --- | --- |
+| 2026-06-05 | local | Chat resume bridge status 探测 | `ChatRunSocket.resume` 改用 broker 的 `status_if_loaded` 查询，只在对应 profile worker 已存在时转发为 worker `status`，不会因为进入/切换会话而冷启动 profile worker。若 worker 已加载且原 run 仍在运行，仍会通过 `resumeBridgeRun()` 继续接回 `run_id` 的 delta/events；不存在的 session status 不会污染 broker session route。 |
 | 2026-06-04 | #1337 | Group Chat socket reconnect/rejoin | `/group-chat` 前端 store 在 socket reconnect 后会重新 join 当前 room，并合并 join ack 中返回的消息以补回断线期间错过的内容；同时恢复 members/agents/typing/context status。若用户在 ack 返回前切换房间，会忽略旧 room ack；join ack 中的 `rooms` 字符串列表不会覆盖前端 `RoomInfo[]` 房间列表，避免路由和侧边栏状态被污染。 |
 | 2026-06-04 | #1333 | reasoning 多轮合并为单条 assistant 消息 | `chat.ts` 用独立的 reasoning 目标合并 `reasoning.delta` / `thinking.delta`，所以同一 run 内跨 tool cycle 的 thinking 会收敛到同一条 assistant 气泡；`tool.started` 仍会切断正文流目标，后续 `message.delta` 会在 tool 后新建 assistant，避免最终正文插回工具前。 |
 | 2026-06-04 | local | CLI bridge abort 超时同步 | `/chat-run` abort 路径在 Hermes Agent 协作式 interrupt 未能在 bridge 同步窗口内完成时，不再提前清理 Web UI `isWorking/runId` 或启动队列，而是发送 `abort.timeout` 并保持 session locked/aborting；同会话新消息继续进入队列，避免旧 Agent run 尚未退出时触发 `session ... is already running`。当前端后续收到 bridge terminal chunk 时再发送 `abort.completed` 并释放状态。前端新增 `abort.timeout` 事件展示“仍在停止中”，并移除本地 20s 自动清 running 兜底。 |

--- a/docs/cli-chat-sessions.md
+++ b/docs/cli-chat-sessions.md
@@ -51,7 +51,7 @@ ChatPanel / ChatInput
 
 | 时间 | PR / commit | 动到的功能 | 链路影响 |
 | --- | --- | --- | --- |
-| 2026-06-05 | local | Chat resume bridge status 探测 | `ChatRunSocket.resume` 改用 broker 的 `status_if_loaded` 查询，只在对应 profile worker 已存在时转发为 worker `status`，不会因为进入/切换会话而冷启动 profile worker。若 worker 已加载且原 run 仍在运行，仍会通过 `resumeBridgeRun()` 继续接回 `run_id` 的 delta/events；不存在的 session status 不会污染 broker session route。 |
+| 2026-06-05 | #1344 | Chat resume bridge status 探测 | `ChatRunSocket.resume` 改用 broker 的 `status_if_loaded` 查询，只在对应 profile worker 已存在时转发为 worker `status`，不会因为进入/切换会话而冷启动 profile worker。若 worker 已加载且原 run 仍在运行，仍会通过 `resumeBridgeRun()` 继续接回 `run_id` 的 delta/events；不存在的 session status 不会污染 broker session route。 |
 | 2026-06-04 | #1337 | Group Chat socket reconnect/rejoin | `/group-chat` 前端 store 在 socket reconnect 后会重新 join 当前 room，并合并 join ack 中返回的消息以补回断线期间错过的内容；同时恢复 members/agents/typing/context status。若用户在 ack 返回前切换房间，会忽略旧 room ack；join ack 中的 `rooms` 字符串列表不会覆盖前端 `RoomInfo[]` 房间列表，避免路由和侧边栏状态被污染。 |
 | 2026-06-04 | #1333 | reasoning 多轮合并为单条 assistant 消息 | `chat.ts` 用独立的 reasoning 目标合并 `reasoning.delta` / `thinking.delta`，所以同一 run 内跨 tool cycle 的 thinking 会收敛到同一条 assistant 气泡；`tool.started` 仍会切断正文流目标，后续 `message.delta` 会在 tool 后新建 assistant，避免最终正文插回工具前。 |
 | 2026-06-04 | local | CLI bridge abort 超时同步 | `/chat-run` abort 路径在 Hermes Agent 协作式 interrupt 未能在 bridge 同步窗口内完成时，不再提前清理 Web UI `isWorking/runId` 或启动队列，而是发送 `abort.timeout` 并保持 session locked/aborting；同会话新消息继续进入队列，避免旧 Agent run 尚未退出时触发 `session ... is already running`。当前端后续收到 bridge terminal chunk 时再发送 `abort.completed` 并释放状态。前端新增 `abort.timeout` 事件展示“仍在停止中”，并移除本地 20s 自动清 running 兜底。 |

--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -583,6 +583,14 @@ export class AgentBridgeClient {
     })
   }
 
+  statusIfLoaded(sessionId: string, profile?: string): Promise<AgentBridgeResponse> {
+    return this.request({
+      action: 'status_if_loaded',
+      session_id: sessionId,
+      ...(profile ? { profile } : {}),
+    })
+  }
+
   destroy(sessionId: string, profile?: string, workerKey?: string): Promise<AgentBridgeResponse> {
     return this.request({
       action: 'destroy',

--- a/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
@@ -3387,6 +3387,37 @@ class BridgeBroker:
             return WorkerProcess.REQUEST_TIMEOUT_SECONDS
         return max(WorkerProcess.REQUEST_TIMEOUT_SECONDS, timeout + 10)
 
+    def _status_if_loaded(self, req: dict[str, Any]) -> dict[str, Any]:
+        session_id = str(req.get("session_id") or "")
+        with self._lock:
+            profile = self._session_profile.get(session_id)
+            worker_key = self._session_worker_key.get(session_id)
+            if profile:
+                key = self._normalize_worker_key(profile, req.get("worker_key")) if "worker_key" in req else worker_key
+            else:
+                fallback_profile = req.get("profile")
+                if fallback_profile is None:
+                    return {"ok": True, "session_id": session_id, "exists": False, "running": False, "loaded": False}
+                profile = self._normalize_profile(fallback_profile)
+                key = self._normalize_worker_key(profile, req.get("worker_key") if "worker_key" in req else None)
+            worker = self._workers.get(key or profile)
+
+        if worker is None or not getattr(worker, "running", False):
+            return {"ok": True, "session_id": session_id, "exists": False, "running": False, "loaded": False}
+
+        forwarded = dict(req)
+        forwarded["action"] = "status"
+        forwarded["profile"] = profile
+        forwarded.pop("worker_key", None)
+        try:
+            resp = worker.request(forwarded, self._worker_request_timeout(req))
+            if resp.get("exists") is not False:
+                self._record_response_routes(profile, key or profile, resp)
+            resp.setdefault("loaded", True)
+            return resp
+        except RuntimeError as e:
+            return {"ok": False, "error": str(e)}
+
     def handle(self, req: dict[str, Any]) -> dict[str, Any]:
         action = str(req.get("action") or "").strip()
         if not action:
@@ -3448,6 +3479,9 @@ class BridgeBroker:
         if action in {"get_result", "get_output"}:
             profile, worker_key = self._route_for_run(str(req.get("run_id") or ""))
             return self._forward(profile, req, worker_key)
+
+        if action == "status_if_loaded":
+            return self._status_if_loaded(req)
 
         if action in {"interrupt", "steer", "command", "goal_evaluate", "goal_pause", "status", "get_history", "get_session_title", "destroy"}:
             session_id = str(req.get("session_id") or "")

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -366,7 +366,7 @@ export class ChatRunSocket {
     const session = getSession(sid)
     const profile = session?.profile || currentProfileFromSocket(socket)
     try {
-      const status = await this.bridge.status(sid, profile) as Record<string, unknown>
+      const status = await this.bridge.statusIfLoaded(sid, profile) as Record<string, unknown>
       const running = status.running === true
       const runId = typeof status.current_run_id === 'string' ? status.current_run_id : ''
       if (!running || !runId) return

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -390,6 +390,108 @@ assert resp["running_sessions_by_profile"] == {"default": 1}
 `)
   })
 
+  it('does not start a worker for unloaded broker status checks', () => {
+    runPython(String.raw`
+${harness}
+
+broker = bridge.BridgeBroker("ipc:///tmp/unused.sock")
+resp = broker.handle({
+    "action": "status_if_loaded",
+    "session_id": "session-a",
+    "profile": "default",
+})
+
+assert resp["session_id"] == "session-a"
+assert resp["running"] is False
+assert resp["loaded"] is False
+assert broker._workers == {}
+`)
+  })
+
+  it('forwards unloaded-safe status checks to an existing routed worker', () => {
+    runPython(String.raw`
+${harness}
+
+class StatusWorker:
+    running = True
+    pid = 12345
+    endpoint = "ipc:///tmp/worker.sock"
+    last_used_at = 12.5
+
+    def __init__(self):
+        self.profile = "default"
+        self.key = "default"
+        self.requests = []
+
+    def request(self, req, timeout=None):
+        self.requests.append(req)
+        assert req["action"] == "status"
+        assert "worker_key" not in req
+        return {
+            "ok": True,
+            "session_id": req["session_id"],
+            "exists": True,
+            "running": True,
+            "current_run_id": "run-a",
+        }
+
+broker = bridge.BridgeBroker("ipc:///tmp/unused.sock")
+worker = StatusWorker()
+broker._workers["default"] = worker
+broker._session_profile["session-a"] = "default"
+broker._session_worker_key["session-a"] = "default"
+
+resp = broker.handle({
+    "action": "status_if_loaded",
+    "session_id": "session-a",
+    "profile": "default",
+})
+
+assert resp["running"] is True
+assert resp["current_run_id"] == "run-a"
+assert resp["loaded"] is True
+assert len(worker.requests) == 1
+assert len(broker._workers) == 1
+`)
+  })
+
+  it('does not record a route for missing sessions during unloaded-safe status checks', () => {
+    runPython(String.raw`
+${harness}
+
+class StatusWorker:
+    running = True
+    pid = 12345
+    endpoint = "ipc:///tmp/worker.sock"
+    last_used_at = 12.5
+    profile = "default"
+    key = "default"
+
+    def request(self, req, timeout=None):
+        return {
+            "ok": True,
+            "session_id": req["session_id"],
+            "exists": False,
+            "running": False,
+            "message_count": 0,
+        }
+
+broker = bridge.BridgeBroker("ipc:///tmp/unused.sock")
+broker._workers["default"] = StatusWorker()
+
+resp = broker.handle({
+    "action": "status_if_loaded",
+    "session_id": "missing-session",
+    "profile": "default",
+})
+
+assert resp["exists"] is False
+assert resp["loaded"] is True
+assert broker._session_profile == {}
+assert broker._session_worker_key == {}
+`)
+  })
+
   it('routes worker-keyed broker requests without stopping the worker on session destroy', () => {
     runPython(String.raw`
 ${harness}

--- a/tests/server/run-chat-clarify-respond.test.ts
+++ b/tests/server/run-chat-clarify-respond.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const bridgeMock = vi.hoisted(() => ({
   clarifyRespond: vi.fn(),
+  statusIfLoaded: vi.fn(),
 }))
 
 vi.mock('../../packages/server/src/services/hermes/agent-bridge', () => ({
@@ -65,6 +66,8 @@ describe('ChatRunSocket clarify responses', () => {
   beforeEach(() => {
     vi.resetModules()
     bridgeMock.clarifyRespond.mockReset()
+    bridgeMock.statusIfLoaded.mockReset()
+    bridgeMock.statusIfLoaded.mockResolvedValue({ ok: true, exists: false, running: false, loaded: false })
   })
 
   it('forwards clarify.respond events to the bridge and emits clarify.resolved', async () => {

--- a/tests/server/run-chat-queued-item.test.ts
+++ b/tests/server/run-chat-queued-item.test.ts
@@ -1,15 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const handleBridgeRunMock = vi.hoisted(() => vi.fn(async () => {}))
+const resumeBridgeRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const handleApiRunMock = vi.hoisted(() => vi.fn(async () => {}))
+const loadSessionStateFromDbMock = vi.hoisted(() => vi.fn())
+const bridgeMock = vi.hoisted(() => ({
+  status: vi.fn(),
+  statusIfLoaded: vi.fn(),
+}))
 
 vi.mock('../../packages/server/src/services/hermes/run-chat/handle-bridge-run', () => ({
   handleBridgeRun: handleBridgeRunMock,
+  resumeBridgeRun: resumeBridgeRunMock,
 }))
 
 vi.mock('../../packages/server/src/services/hermes/run-chat/handle-api-run', () => ({
   handleApiRun: handleApiRunMock,
-  loadSessionStateFromDb: vi.fn(),
+  loadSessionStateFromDb: loadSessionStateFromDbMock,
   resolveRunSource: vi.fn((source?: string) => source || 'cli'),
 }))
 
@@ -20,7 +27,7 @@ vi.mock('../../packages/server/src/services/hermes/run-chat/session-command', ()
 }))
 
 vi.mock('../../packages/server/src/services/hermes/agent-bridge', () => ({
-  AgentBridgeClient: vi.fn(() => ({})),
+  AgentBridgeClient: vi.fn(() => bridgeMock),
 }))
 
 vi.mock('../../packages/server/src/services/logger', () => ({
@@ -51,6 +58,7 @@ vi.mock('../../packages/server/src/db/hermes/users-store', () => ({
 }))
 
 function makeServerHarness() {
+  const handlers = new Map<string, Function>()
   const namespace = {
     adapter: { rooms: new Map() },
     to: vi.fn(() => ({ emit: vi.fn() })),
@@ -66,14 +74,24 @@ function makeServerHarness() {
     emit: vi.fn(),
     join: vi.fn(),
     to: vi.fn(() => ({ emit: vi.fn() })),
-    on: vi.fn(),
+    on: vi.fn((event: string, handler: Function) => {
+      handlers.set(event, handler)
+    }),
   }
-  return { io, namespace, socket }
+  return { handlers, io, namespace, socket }
 }
 
 describe('ChatRunSocket queued bridge runs', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    bridgeMock.statusIfLoaded.mockResolvedValue({ ok: true, exists: false, running: false, loaded: false })
+    loadSessionStateFromDbMock.mockResolvedValue({
+      messages: [],
+      isWorking: false,
+      isAborting: false,
+      events: [],
+      queue: [],
+    })
   })
 
   it('persists normal queued bridge messages when they are dequeued', async () => {
@@ -124,5 +142,51 @@ describe('ChatRunSocket queued bridge runs', () => {
       queue_id: 'queue-plan',
     }))
     expect(call[6]).toBe(false)
+  })
+
+  it('checks bridge resume status without cold-starting the profile worker', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('resume')?.({ session_id: 'session-1' })
+
+    expect(bridgeMock.statusIfLoaded).toHaveBeenCalledWith('session-1', 'default')
+    expect(bridgeMock.status).not.toHaveBeenCalled()
+    expect(resumeBridgeRunMock).not.toHaveBeenCalled()
+    expect(socket.emit).toHaveBeenCalledWith('resumed', expect.objectContaining({
+      session_id: 'session-1',
+      isWorking: false,
+    }))
+  })
+
+  it('reattaches a loaded running bridge run during resume', async () => {
+    bridgeMock.statusIfLoaded.mockResolvedValueOnce({
+      ok: true,
+      exists: true,
+      running: true,
+      current_run_id: 'run-1',
+      loaded: true,
+    })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('resume')?.({ session_id: 'session-1' })
+
+    expect(resumeBridgeRunMock).toHaveBeenCalledWith(
+      expect.anything(),
+      socket,
+      expect.objectContaining({
+        sessionId: 'session-1',
+        runId: 'run-1',
+        profile: 'default',
+      }),
+      expect.any(Map),
+      bridgeMock,
+      expect.any(Function),
+    )
   })
 })


### PR DESCRIPTION
## Summary
- add a broker `status_if_loaded` action that checks loaded profile workers without creating one
- switch chat resume reattach probing to `statusIfLoaded` so entering a session does not cold-start the profile worker
- cover unloaded status checks and resume reattach behavior with focused tests

## Why
Chat resume was using broker `status`, which falls back to the session profile and starts a profile worker when no route is loaded. That made entering the chat page or switching sessions expensive even when there was no active run to recover.

## Impact
- Resume still reattaches to an already-loaded running bridge run after server restart.
- Resume no longer starts a profile worker just to discover there is no running run.
- Missing-session status checks no longer write broker session routes.

## Validation
- `npm run test -- tests/server/run-chat-queued-item.test.ts tests/server/run-chat-clarify-respond.test.ts tests/server/agent-bridge-python-concurrency.test.ts`
- `npm run test -- tests/server/run-chat-bridge-resume.test.ts`
- `npm run harness:check`
- `npm run build`
- `git diff --check`
