### PR TITLE
[codex] fix chat streaming scroll lock and desktop fade

### DIFF
--- a/docs/chat-chain-changes/2026-06-05-pending-chat-scroll-desktop-fade.md
+++ b/docs/chat-chain-changes/2026-06-05-pending-chat-scroll-desktop-fade.md
@@ -1,0 +1,10 @@
+---
+date: 2026-06-05
+pr: pending
+feature: Chat 流式滚动和桌面启动淡入
+impact: 用户滚离底部后流式输出不再强制拉回底部，Windows 桌面窗口显示恢复 ready 后淡入。
+---
+
+`MessageList` 和 `VirtualMessageList` 收紧自动贴底策略：流式更新只在用户仍接近底部时做单帧滚动，用户手动滚离底部会取消 pending bottom frames；切 session 的初始定位使用短保活，减少虚拟列表重建后的抖动。
+
+桌面主窗口改为默认隐藏，ready 后通过统一显示路径在 Windows 上淡入；自动更新重启和托盘打开窗口都复用同一逻辑。

--- a/docs/chat-chain-changes/2026-06-05-pr1347-chat-scroll-desktop-fade.md
+++ b/docs/chat-chain-changes/2026-06-05-pr1347-chat-scroll-desktop-fade.md
@@ -5,6 +5,6 @@ feature: Chat 流式滚动和桌面启动淡入
 impact: 用户滚离底部后流式输出不再强制拉回底部，Windows 桌面窗口显示恢复 ready 后淡入。
 ---
 
-`MessageList` 和 `VirtualMessageList` 收紧自动贴底策略：流式更新只在用户仍接近底部时做单帧滚动，用户手动滚离底部会取消 pending bottom frames；切 session 和 run start 的初始定位使用有限保活，减少虚拟列表重建后的抖动。
+`MessageList` 和 `VirtualMessageList` 收紧自动贴底策略：流式更新只在用户仍接近底部且没有主动上滚时做单帧滚动，用户手动上滚会立即锁住 auto-follow 并取消 pending bottom frames，直到用户回到底部附近才恢复；切 session 和 run start 的初始定位使用有限保活，减少虚拟列表重建后的抖动。
 
 桌面主窗口改为默认隐藏，ready 后通过统一显示路径在 Windows 上淡入；自动更新重启和托盘打开窗口都复用同一逻辑。

--- a/docs/chat-chain-changes/2026-06-05-pr1347-chat-scroll-desktop-fade.md
+++ b/docs/chat-chain-changes/2026-06-05-pr1347-chat-scroll-desktop-fade.md
@@ -5,6 +5,6 @@ feature: Chat 流式滚动和桌面启动淡入
 impact: 用户滚离底部后流式输出不再强制拉回底部，Windows 桌面窗口显示恢复 ready 后淡入。
 ---
 
-`MessageList` 和 `VirtualMessageList` 收紧自动贴底策略：流式更新只在用户仍接近底部时做单帧滚动，用户手动滚离底部会取消 pending bottom frames；切 session 的初始定位使用短保活，减少虚拟列表重建后的抖动。
+`MessageList` 和 `VirtualMessageList` 收紧自动贴底策略：流式更新只在用户仍接近底部时做单帧滚动，用户手动滚离底部会取消 pending bottom frames；切 session 和 run start 的初始定位使用有限保活，减少虚拟列表重建后的抖动。
 
 桌面主窗口改为默认隐藏，ready 后通过统一显示路径在 Windows 上淡入；自动更新重启和托盘打开窗口都复用同一逻辑。

--- a/docs/chat-chain-changes/2026-06-05-pr1347-chat-scroll-desktop-fade.md
+++ b/docs/chat-chain-changes/2026-06-05-pr1347-chat-scroll-desktop-fade.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-05
-pr: pending
+pr: 1347
 feature: Chat 流式滚动和桌面启动淡入
 impact: 用户滚离底部后流式输出不再强制拉回底部，Windows 桌面窗口显示恢复 ready 后淡入。
 ---

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -135,14 +135,14 @@ function applyInitialSessionScroll(sessionId: string) {
   if (snapshot) {
     pendingInitialScrollSessionId.value = null;
     if (snapshot.wasNearBottom) {
-      scrollToBottom({ frames: 3, keepAliveMs: 200 });
+      scrollToBottom({ frames: 4, keepAliveMs: 400 });
     } else {
       listRef.value?.restoreViewportPosition(snapshot);
     }
     return;
   }
 
-  scrollToBottom({ frames: 3, keepAliveMs: 200 });
+  scrollToBottom({ frames: 4, keepAliveMs: 400 });
   if (chatStore.messages.length > 0) pendingInitialScrollSessionId.value = null;
 }
 
@@ -189,7 +189,7 @@ watch(
 watch(
   () => chatStore.isRunActive,
   (v) => {
-    if (v) scrollToBottom({ frames: 2, keepAliveMs: 180 });
+    if (v) scrollToBottom({ frames: 3, keepAliveMs: 400 });
   },
 );
 

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -101,8 +101,8 @@ function queuedPreview(content: string): string {
   return normalized.length > 48 ? `${normalized.slice(0, 48)}...` : normalized;
 }
 
-function isNearBottom(threshold = 200): boolean {
-  return listRef.value?.isNearBottom(threshold) ?? true;
+function shouldAutoFollowBottom(threshold = 200): boolean {
+  return listRef.value?.shouldAutoFollowBottom(threshold) ?? true;
 }
 
 function scrollToBottom(options?: BottomScrollOptions) {
@@ -202,7 +202,7 @@ watch(
       scrollToMessage(chatStore.focusMessageId);
       return;
     }
-    if (!isNearBottom()) return;
+    if (!shouldAutoFollowBottom()) return;
     scrollToBottom({ frames: 1, keepAliveMs: 0 });
   },
 );
@@ -212,7 +212,7 @@ watch(currentToolCalls, () => {
     scrollToMessage(chatStore.focusMessageId);
     return;
   }
-  if (!isNearBottom()) return;
+  if (!shouldAutoFollowBottom()) return;
   scrollToBottom({ frames: 1, keepAliveMs: 0 });
 });
 

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -6,6 +6,11 @@ type SessionScrollSnapshot = {
   wasNearBottom: boolean;
 }
 
+type BottomScrollOptions = number | {
+  frames?: number;
+  keepAliveMs?: number;
+}
+
 const sessionScrollPositions = new Map<string, SessionScrollSnapshot>();
 </script>
 
@@ -100,8 +105,8 @@ function isNearBottom(threshold = 200): boolean {
   return listRef.value?.isNearBottom(threshold) ?? true;
 }
 
-function scrollToBottom() {
-  listRef.value?.scrollToBottom();
+function scrollToBottom(options?: BottomScrollOptions) {
+  listRef.value?.scrollToBottom(options);
 }
 
 function scrollToMessage(messageId: string) {
@@ -130,14 +135,14 @@ function applyInitialSessionScroll(sessionId: string) {
   if (snapshot) {
     pendingInitialScrollSessionId.value = null;
     if (snapshot.wasNearBottom) {
-      scrollToBottom();
+      scrollToBottom({ frames: 3, keepAliveMs: 200 });
     } else {
       listRef.value?.restoreViewportPosition(snapshot);
     }
     return;
   }
 
-  scrollToBottom();
+  scrollToBottom({ frames: 3, keepAliveMs: 200 });
   if (chatStore.messages.length > 0) pendingInitialScrollSessionId.value = null;
 }
 
@@ -184,7 +189,7 @@ watch(
 watch(
   () => chatStore.isRunActive,
   (v) => {
-    if (v) scrollToBottom();
+    if (v) scrollToBottom({ frames: 2, keepAliveMs: 180 });
   },
 );
 
@@ -198,7 +203,7 @@ watch(
       return;
     }
     if (!isNearBottom()) return;
-    scrollToBottom();
+    scrollToBottom({ frames: 1, keepAliveMs: 0 });
   },
 );
 watch(currentToolCalls, () => {
@@ -208,7 +213,7 @@ watch(currentToolCalls, () => {
     return;
   }
   if (!isNearBottom()) return;
-  scrollToBottom();
+  scrollToBottom({ frames: 1, keepAliveMs: 0 });
 });
 
 onBeforeUnmount(() => {

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -101,7 +101,7 @@ function queuedPreview(content: string): string {
   return normalized.length > 48 ? `${normalized.slice(0, 48)}...` : normalized;
 }
 
-function shouldAutoFollowBottom(threshold = 200): boolean {
+function shouldAutoFollowBottom(threshold = 100): boolean {
   return listRef.value?.shouldAutoFollowBottom(threshold) ?? true;
 }
 

--- a/packages/client/src/components/hermes/chat/VirtualMessageList.vue
+++ b/packages/client/src/components/hermes/chat/VirtualMessageList.vue
@@ -66,6 +66,7 @@ let keepBottomUntil = 0;
 let bottomFrame: number | null = null;
 let bottomFrameRemaining = 0;
 let bottomFrameAttempts = 0;
+let programmaticScrollUntil = 0;
 let anchorFrame: number | null = null;
 let anchorToken = 0;
 let activeAnchorTarget: AnchorTarget | null = null;
@@ -89,8 +90,29 @@ function syncViewport() {
   viewportHeight.value = el.clientHeight;
 }
 
+function markProgrammaticScroll(ms = 120) {
+  programmaticScrollUntil = Date.now() + ms;
+}
+
+function isProgrammaticScroll(): boolean {
+  return Date.now() < programmaticScrollUntil;
+}
+
+function cancelBottomScroll() {
+  keepBottomUntil = 0;
+  if (bottomFrame != null) {
+    cancelAnimationFrame(bottomFrame);
+    bottomFrame = null;
+  }
+  bottomFrameRemaining = 0;
+  bottomFrameAttempts = 0;
+}
+
 function handleScroll() {
   syncViewport();
+  if (!isProgrammaticScroll() && !isNearBottom(96)) {
+    cancelBottomScroll();
+  }
   emit("scroll");
   if (scrollTop.value <= props.topThreshold) emit("topReach");
 }
@@ -108,8 +130,8 @@ function isNearBottom(threshold = 200): boolean {
 }
 
 function scrollToBottom(options: BottomScrollOptions = {}) {
-  const frames = typeof options === "number" ? options : options.frames ?? 5;
-  const keepAliveMs = typeof options === "number" ? 700 : options.keepAliveMs ?? 700;
+  const frames = typeof options === "number" ? options : options.frames ?? 2;
+  const keepAliveMs = typeof options === "number" ? 250 : options.keepAliveMs ?? 250;
   keepBottomUntil = Date.now() + keepAliveMs;
   nextTick(() => {
     scheduleScrollToBottom(frames);
@@ -118,6 +140,7 @@ function scrollToBottom(options: BottomScrollOptions = {}) {
 
 function setScrollToBottomNow(): boolean {
   const el = getScrollerElement();
+  markProgrammaticScroll();
   scrollerRef.value?.scrollToBottom();
   if (el) {
     el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
@@ -181,12 +204,14 @@ function alignElement(targetEl: HTMLElement, align: AnchorAlign) {
     : targetRect.top - scrollerRect.top - 24;
 
   if (Math.abs(delta) > 1) {
+    markProgrammaticScroll();
     el.scrollTop = Math.max(0, el.scrollTop + delta);
   }
   syncViewport();
 }
 
 function scrollToItem(index: number, options?: ScrollToOptions) {
+  markProgrammaticScroll();
   scrollerRef.value?.scrollToItem(index, options);
   syncViewport();
 }
@@ -286,6 +311,7 @@ function restoreScrollPosition(snapshot: { scrollTop: number; scrollHeight: numb
     const el = getScrollerElement();
     if (!el) return;
     const nextScrollTop = Math.max(0, el.scrollHeight - snapshot.scrollHeight + snapshot.scrollTop);
+    markProgrammaticScroll();
     scrollerRef.value?.scrollToPosition(nextScrollTop);
     el.scrollTop = nextScrollTop;
     syncViewport();
@@ -305,13 +331,7 @@ function captureViewportPosition(): ViewportScrollSnapshot | null {
 
 function restoreViewportPosition(snapshot: ViewportScrollSnapshot | null, frames = 4) {
   if (!snapshot) return;
-  keepBottomUntil = 0;
-  if (bottomFrame != null) {
-    cancelAnimationFrame(bottomFrame);
-    bottomFrame = null;
-    bottomFrameRemaining = 0;
-    bottomFrameAttempts = 0;
-  }
+  cancelBottomScroll();
   if (viewportRestoreFrame != null) cancelAnimationFrame(viewportRestoreFrame);
 
   nextTick(() => {
@@ -324,6 +344,7 @@ function restoreViewportPosition(snapshot: ViewportScrollSnapshot | null, frames
       }
       const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
       const nextScrollTop = Math.min(maxScrollTop, Math.max(0, snapshot.scrollTop));
+      markProgrammaticScroll();
       scrollerRef.value?.scrollToPosition(nextScrollTop);
       el.scrollTop = nextScrollTop;
       syncViewport();
@@ -353,9 +374,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-  if (bottomFrame != null) cancelAnimationFrame(bottomFrame);
-  bottomFrameRemaining = 0;
-  bottomFrameAttempts = 0;
+  cancelBottomScroll();
   if (anchorFrame != null) cancelAnimationFrame(anchorFrame);
   if (viewportRestoreFrame != null) cancelAnimationFrame(viewportRestoreFrame);
   resizeObserver?.disconnect();

--- a/packages/client/src/components/hermes/chat/VirtualMessageList.vue
+++ b/packages/client/src/components/hermes/chat/VirtualMessageList.vue
@@ -67,6 +67,7 @@ let bottomFrame: number | null = null;
 let bottomFrameRemaining = 0;
 let bottomFrameAttempts = 0;
 let programmaticScrollUntil = 0;
+let userDetachedFromBottom = false;
 let anchorFrame: number | null = null;
 let anchorToken = 0;
 let activeAnchorTarget: AnchorTarget | null = null;
@@ -109,9 +110,18 @@ function cancelBottomScroll() {
 }
 
 function handleScroll() {
+  const previousScrollTop = scrollTop.value;
   syncViewport();
-  if (!isProgrammaticScroll() && !isNearBottom(96)) {
-    cancelBottomScroll();
+  if (!isProgrammaticScroll()) {
+    const delta = scrollTop.value - previousScrollTop;
+    if (delta < -1) {
+      userDetachedFromBottom = true;
+    } else if (isNearBottom(32)) {
+      userDetachedFromBottom = false;
+    }
+    if (userDetachedFromBottom || !isNearBottom(96)) {
+      cancelBottomScroll();
+    }
   }
   emit("scroll");
   if (scrollTop.value <= props.topThreshold) emit("topReach");
@@ -129,9 +139,14 @@ function isNearBottom(threshold = 200): boolean {
   return el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
 }
 
+function shouldAutoFollowBottom(threshold = 200): boolean {
+  return !userDetachedFromBottom && isNearBottom(threshold);
+}
+
 function scrollToBottom(options: BottomScrollOptions = {}) {
   const frames = typeof options === "number" ? options : options.frames ?? 2;
   const keepAliveMs = typeof options === "number" ? 400 : options.keepAliveMs ?? 400;
+  userDetachedFromBottom = false;
   keepBottomUntil = Date.now() + keepAliveMs;
   nextTick(() => {
     scheduleScrollToBottom(frames);
@@ -332,6 +347,7 @@ function captureViewportPosition(): ViewportScrollSnapshot | null {
 function restoreViewportPosition(snapshot: ViewportScrollSnapshot | null, frames = 4) {
   if (!snapshot) return;
   cancelBottomScroll();
+  userDetachedFromBottom = !snapshot.wasNearBottom;
   if (viewportRestoreFrame != null) cancelAnimationFrame(viewportRestoreFrame);
 
   nextTick(() => {
@@ -387,6 +403,7 @@ watch(messageKeys, () => {
 
 defineExpose({
   isNearBottom,
+  shouldAutoFollowBottom,
   scrollToBottom,
   scrollToMessage,
   scrollToAnchor,

--- a/packages/client/src/components/hermes/chat/VirtualMessageList.vue
+++ b/packages/client/src/components/hermes/chat/VirtualMessageList.vue
@@ -131,7 +131,7 @@ function isNearBottom(threshold = 200): boolean {
 
 function scrollToBottom(options: BottomScrollOptions = {}) {
   const frames = typeof options === "number" ? options : options.frames ?? 2;
-  const keepAliveMs = typeof options === "number" ? 250 : options.keepAliveMs ?? 250;
+  const keepAliveMs = typeof options === "number" ? 400 : options.keepAliveMs ?? 400;
   keepBottomUntil = Date.now() + keepAliveMs;
   nextTick(() => {
     scheduleScrollToBottom(frames);

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -23,15 +23,52 @@ let serverUrl: string | null = null
 let tray: Tray | null = null
 let isQuitting = false
 let isBootstrapping = false
+let windowFadeTimer: NodeJS.Timeout | null = null
+
+function cancelWindowFade() {
+  if (windowFadeTimer) {
+    clearInterval(windowFadeTimer)
+    windowFadeTimer = null
+  }
+}
+
+function showWindowWithFade(focus = true) {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  if (mainWindow.isMinimized()) mainWindow.restore()
+
+  cancelWindowFade()
+  if (process.platform !== 'win32' || mainWindow.isVisible()) {
+    mainWindow.setOpacity(1)
+    mainWindow.show()
+    if (focus) mainWindow.focus()
+    return
+  }
+
+  const durationMs = 180
+  const startedAt = Date.now()
+  mainWindow.setOpacity(0)
+  mainWindow.show()
+  if (focus) mainWindow.focus()
+  windowFadeTimer = setInterval(() => {
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      cancelWindowFade()
+      return
+    }
+    const progress = Math.min(1, (Date.now() - startedAt) / durationMs)
+    mainWindow.setOpacity(progress)
+    if (progress >= 1) {
+      mainWindow.setOpacity(1)
+      cancelWindowFade()
+    }
+  }, 16)
+}
 
 function showMainWindow() {
   if (!mainWindow) {
     createWindow()
   }
   if (!mainWindow) return
-  if (mainWindow.isMinimized()) mainWindow.restore()
-  mainWindow.show()
-  mainWindow.focus()
+  showWindowWithFade(true)
 }
 
 function quitApp() {
@@ -132,7 +169,7 @@ function createWindow() {
     title: 'Hermes Studio',
     backgroundColor: '#1a1a1a',
     autoHideMenuBar: true,
-    show: !START_HIDDEN,
+    show: false,
     ...(process.platform === 'linux' ? { icon: desktopIcon() } : {}),
     webPreferences: {
       preload: join(__dirname, '..', 'preload', 'index.js'),
@@ -142,9 +179,14 @@ function createWindow() {
     },
   })
 
+  mainWindow.once('ready-to-show', () => {
+    if (!START_HIDDEN) showWindowWithFade(true)
+  })
+
   mainWindow.on('close', (event) => {
     if (isQuitting) return
     event.preventDefault()
+    cancelWindowFade()
     mainWindow?.hide()
     updateTrayMenu()
   })
@@ -439,6 +481,7 @@ function runDesktopApp() {
       return
     }
     e.preventDefault()
+    cancelWindowFade()
     await stopWebUiServer().catch(() => undefined)
     app.exit(0)
   })

--- a/tests/client/message-list-scroll-position.test.ts
+++ b/tests/client/message-list-scroll-position.test.ts
@@ -128,4 +128,53 @@ describe('MessageList session scroll position', () => {
     expect(mockRestoreViewportPosition).toHaveBeenCalledWith(sessionASnapshot)
     expect(mockScrollToBottom).not.toHaveBeenCalled()
   })
+
+  it('does not force the bottom while streaming after the user scrolls away', async () => {
+    const chatStore = useChatStore()
+    chatStore.activeSessionId = 'stream-session'
+    chatStore.activeSession = makeSession('stream-session')
+    chatStore.activeSession.messages = [
+      makeMessage('user-message'),
+      { id: 'assistant-message', role: 'assistant', content: 'first', timestamp: Date.now(), isStreaming: true },
+    ]
+    mockIsNearBottom.mockReturnValue(false)
+
+    mount(MessageList, {
+      global: {
+        stubs: { Transition: false },
+      },
+    })
+    await flushSessionScroll()
+    vi.clearAllMocks()
+
+    chatStore.activeSession.messages[1].content = 'first second'
+    await nextTick()
+
+    expect(mockIsNearBottom).toHaveBeenCalled()
+    expect(mockScrollToBottom).not.toHaveBeenCalled()
+  })
+
+  it('uses a single non-sticky bottom scroll for streaming updates near the bottom', async () => {
+    const chatStore = useChatStore()
+    chatStore.activeSessionId = 'stream-bottom-session'
+    chatStore.activeSession = makeSession('stream-bottom-session')
+    chatStore.activeSession.messages = [
+      makeMessage('user-message'),
+      { id: 'assistant-message', role: 'assistant', content: 'first', timestamp: Date.now(), isStreaming: true },
+    ]
+    mockIsNearBottom.mockReturnValue(true)
+
+    mount(MessageList, {
+      global: {
+        stubs: { Transition: false },
+      },
+    })
+    await flushSessionScroll()
+    vi.clearAllMocks()
+
+    chatStore.activeSession.messages[1].content = 'first second'
+    await nextTick()
+
+    expect(mockScrollToBottom).toHaveBeenCalledWith({ frames: 1, keepAliveMs: 0 })
+  })
 })

--- a/tests/client/message-list-scroll-position.test.ts
+++ b/tests/client/message-list-scroll-position.test.ts
@@ -12,6 +12,7 @@ const mockRestoreViewportPosition = vi.hoisted(() => vi.fn())
 const mockCaptureScrollPosition = vi.hoisted(() => vi.fn())
 const mockRestoreScrollPosition = vi.hoisted(() => vi.fn())
 const mockIsNearBottom = vi.hoisted(() => vi.fn(() => true))
+const mockShouldAutoFollowBottom = vi.hoisted(() => vi.fn(() => true))
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
@@ -40,6 +41,7 @@ vi.mock('@/components/hermes/chat/VirtualMessageList.vue', () => ({
         restoreScrollPosition: mockRestoreScrollPosition,
         captureViewportPosition: mockCaptureViewportPosition,
         restoreViewportPosition: mockRestoreViewportPosition,
+        shouldAutoFollowBottom: mockShouldAutoFollowBottom,
       })
     },
     template: `
@@ -85,6 +87,7 @@ describe('MessageList session scroll position', () => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
     mockIsNearBottom.mockReturnValue(true)
+    mockShouldAutoFollowBottom.mockReturnValue(true)
   })
 
   it('restores a previous session scroll position instead of forcing the bottom', async () => {
@@ -137,7 +140,7 @@ describe('MessageList session scroll position', () => {
       makeMessage('user-message'),
       { id: 'assistant-message', role: 'assistant', content: 'first', timestamp: Date.now(), isStreaming: true },
     ]
-    mockIsNearBottom.mockReturnValue(false)
+    mockShouldAutoFollowBottom.mockReturnValue(false)
 
     mount(MessageList, {
       global: {
@@ -150,7 +153,7 @@ describe('MessageList session scroll position', () => {
     chatStore.activeSession.messages[1].content = 'first second'
     await nextTick()
 
-    expect(mockIsNearBottom).toHaveBeenCalled()
+    expect(mockShouldAutoFollowBottom).toHaveBeenCalled()
     expect(mockScrollToBottom).not.toHaveBeenCalled()
   })
 

--- a/tests/client/virtual-message-list-scroll.test.ts
+++ b/tests/client/virtual-message-list-scroll.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, nextTick } from 'vue'
+
+const dynamicScrollToBottomMock = vi.hoisted(() => vi.fn())
+const dynamicScrollToPositionMock = vi.hoisted(() => vi.fn())
+const dynamicScrollToItemMock = vi.hoisted(() => vi.fn())
+
+vi.mock('vue-virtual-scroller', () => ({
+  DynamicScroller: defineComponent({
+    name: 'DynamicScroller',
+    props: {
+      items: { type: Array, default: () => [] },
+    },
+    emits: ['scroll', 'resize', 'visible'],
+    setup(_props, { expose }) {
+      expose({
+        scrollToBottom: dynamicScrollToBottomMock,
+        scrollToPosition: dynamicScrollToPositionMock,
+        scrollToItem: dynamicScrollToItemMock,
+      })
+    },
+    template: `
+      <div class="virtual-message-list" @scroll="$emit('scroll')">
+        <slot name="before" />
+        <slot v-for="(item, index) in items" :item="item" :index="index" :active="true" />
+        <slot name="after" />
+      </div>
+    `,
+  }),
+  DynamicScrollerItem: defineComponent({
+    name: 'DynamicScrollerItem',
+    props: {
+      item: { type: Object, required: true },
+      index: { type: Number, required: true },
+      active: { type: Boolean, default: true },
+    },
+    template: '<div class="virtual-row"><slot /></div>',
+  }),
+}))
+
+import VirtualMessageList from '@/components/hermes/chat/VirtualMessageList.vue'
+
+function setScrollerMetrics(el: HTMLElement, metrics: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, value: metrics.scrollHeight })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, value: metrics.clientHeight })
+  el.scrollTop = metrics.scrollTop
+}
+
+describe('VirtualMessageList scroll behavior', () => {
+  let rafCallbacks: FrameRequestCallback[]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rafCallbacks = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      rafCallbacks.push(callback)
+      return rafCallbacks.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      rafCallbacks[id - 1] = () => undefined
+    })
+  })
+
+  it('cancels queued bottom scrolling when the user scrolls away from the bottom', async () => {
+    const wrapper = mount(VirtualMessageList, {
+      props: {
+        messages: [{ id: 'message-1' }],
+      },
+      slots: {
+        item: '<div>message</div>',
+      },
+    })
+    await nextTick()
+
+    const scroller = wrapper.find<HTMLElement>('.virtual-message-list')
+    setScrollerMetrics(scroller.element, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 600,
+    })
+
+    ;(wrapper.vm as any).scrollToBottom({ frames: 5, keepAliveMs: 700 })
+    await nextTick()
+    expect(rafCallbacks.length).toBeGreaterThan(0)
+
+    scroller.element.scrollTop = 120
+    await scroller.trigger('scroll')
+    rafCallbacks.splice(0).forEach(callback => callback(performance.now()))
+
+    expect(dynamicScrollToBottomMock).not.toHaveBeenCalled()
+    expect(scroller.element.scrollTop).toBe(120)
+  })
+})

--- a/tests/client/virtual-message-list-scroll.test.ts
+++ b/tests/client/virtual-message-list-scroll.test.ts
@@ -92,4 +92,35 @@ describe('VirtualMessageList scroll behavior', () => {
     expect(dynamicScrollToBottomMock).not.toHaveBeenCalled()
     expect(scroller.element.scrollTop).toBe(120)
   })
+
+  it('locks auto-follow as soon as the user scrolls upward during streaming', async () => {
+    const wrapper = mount(VirtualMessageList, {
+      props: {
+        messages: [{ id: 'message-1' }],
+      },
+      slots: {
+        item: '<div>message</div>',
+      },
+    })
+    await nextTick()
+
+    const scroller = wrapper.find<HTMLElement>('.virtual-message-list')
+    setScrollerMetrics(scroller.element, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 600,
+    })
+    await scroller.trigger('scroll')
+
+    scroller.element.scrollTop = 580
+    await scroller.trigger('scroll')
+
+    expect((wrapper.vm as any).isNearBottom(200)).toBe(true)
+    expect((wrapper.vm as any).shouldAutoFollowBottom(200)).toBe(false)
+
+    scroller.element.scrollTop = 600
+    await scroller.trigger('scroll')
+
+    expect((wrapper.vm as any).shouldAutoFollowBottom(200)).toBe(true)
+  })
 })

--- a/tests/client/virtual-message-list-scroll.test.ts
+++ b/tests/client/virtual-message-list-scroll.test.ts
@@ -115,12 +115,12 @@ describe('VirtualMessageList scroll behavior', () => {
     scroller.element.scrollTop = 580
     await scroller.trigger('scroll')
 
-    expect((wrapper.vm as any).isNearBottom(200)).toBe(true)
-    expect((wrapper.vm as any).shouldAutoFollowBottom(200)).toBe(false)
+    expect((wrapper.vm as any).isNearBottom(100)).toBe(true)
+    expect((wrapper.vm as any).shouldAutoFollowBottom(100)).toBe(false)
 
     scroller.element.scrollTop = 600
     await scroller.trigger('scroll')
 
-    expect((wrapper.vm as any).shouldAutoFollowBottom(200)).toBe(true)
+    expect((wrapper.vm as any).shouldAutoFollowBottom(100)).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- stop queued virtual-list bottom scrolling when the user scrolls away during streaming
- reduce sticky auto-scroll windows so streaming updates only follow when the user is still near the bottom
- restore a Windows desktop ready-to-show fade path for normal launch, update restart, and tray show

Fixes #1332

## Why
The virtual message list kept multi-frame bottom scrolling alive after programmatic scroll calls. During long streamed replies, those queued frames could pull the user back to the bottom after they manually scrolled upward. Session switches also used longer sticky bottom windows, which made virtual-list height remeasurement more visible.

## Impact
- Users can scroll up during AI streaming without being forced back to the bottom.
- Streaming still follows the reply when the user remains near the bottom.
- Session initial positioning uses shorter bottom retention to reduce visible jitter.
- Windows desktop windows are shown after `ready-to-show` with a short fade, including after auto-update restart.

## Validation
- `npm run test -- tests/client/message-list-scroll-position.test.ts tests/client/virtual-message-list-scroll.test.ts`
- `npm run harness:check`
- `git diff --check`
- `npm run build`
- `npm --prefix packages/desktop run build`
- `npx playwright test tests/e2e/chat-streaming.spec.ts --workers=1`
