### PR TITLE
[codex] fix dev terminal websocket proxy

### DIFF
--- a/tests/server/vite-proxy-config.test.ts
+++ b/tests/server/vite-proxy-config.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+
+describe('vite proxy config', () => {
+  it('strips browser origin headers from proxied http and websocket requests', () => {
+    const source = readFileSync('vite.config.ts', 'utf8')
+
+    expect(source).toContain("proxy.on('proxyReq'")
+    expect(source).toContain("proxy.on('proxyReqWs'")
+
+    const httpProxyBlock = source.match(/proxy\.on\('proxyReq'[\s\S]*?\n\s*\}\)/)?.[0] || ''
+    const wsProxyBlock = source.match(/proxy\.on\('proxyReqWs'[\s\S]*?\n\s*\}\)/)?.[0] || ''
+
+    for (const block of [httpProxyBlock, wsProxyBlock]) {
+      expect(block).toContain("removeHeader('origin')")
+      expect(block).toContain("removeHeader('referer')")
+    }
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,10 @@ function createProxyConfig(): ProxyOptions {
         proxyReq.removeHeader('origin')
         proxyReq.removeHeader('referer')
       })
+      proxy.on('proxyReqWs', (proxyReq) => {
+        proxyReq.removeHeader('origin')
+        proxyReq.removeHeader('referer')
+      })
       proxy.on('proxyRes', (proxyRes) => {
         proxyRes.headers['cache-control'] = 'no-cache'
         proxyRes.headers['x-accel-buffering'] = 'no'


### PR DESCRIPTION
## Summary

- Strip Origin/Referer from proxied Vite WebSocket upgrade requests, matching the existing HTTP proxy behavior.
- Keep dev terminal WebSocket traffic compatible with the hardened backend origin policy.
- Add a focused test that checks both HTTP and WebSocket proxy handlers remove browser origin headers.

## Root cause

The terminal connected to the Vite dev server on port 8649, which proxies WebSocket upgrades to the backend. The HTTP proxy removed Origin/Referer, but the WebSocket proxy path did not, so the backend origin hardening rejected the terminal upgrade as cross-origin.

## Validation

- npm run test -- tests/server/vite-proxy-config.test.ts tests/server/security-policy.test.ts
- git diff --check
