### PR TITLE
[codex] Fix chat initial bottom scroll

### DIFF
--- a/docs/chat-chain-changes/2026-06-06-local-chat-initial-bottom-scroll.md
+++ b/docs/chat-chain-changes/2026-06-06-local-chat-initial-bottom-scroll.md
@@ -1,0 +1,10 @@
+---
+date: 2026-06-06
+pr: pending
+feature: Chat initial bottom scroll
+impact: First session entry keeps bottom-follow active until the initial message load and virtual list measurement settle.
+---
+
+Fixes a race where the chat page could scroll before resumed messages and
+virtualized row heights were fully rendered, leaving the first view slightly
+above the newest message.

--- a/docs/chat-chain-changes/2026-06-06-local-chat-initial-bottom-scroll.md
+++ b/docs/chat-chain-changes/2026-06-06-local-chat-initial-bottom-scroll.md
@@ -8,3 +8,7 @@ impact: First session entry keeps bottom-follow active until the initial message
 Fixes a race where the chat page could scroll before resumed messages and
 virtualized row heights were fully rendered, leaving the first view slightly
 above the newest message.
+
+When messages are already present and the session is not in a loading state,
+the initial-scroll pending gate is released after scheduling the bottom scroll
+so later streaming updates can still run their normal auto-follow checks.

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -144,6 +144,9 @@ function applyInitialSessionScroll(sessionId: string) {
   }
 
   scrollToBottom(initialBottomScrollOptions);
+  if (chatStore.messages.length > 0 && !chatStore.isLoadingMessages) {
+    pendingInitialScrollSessionId.value = null;
+  }
 }
 
 async function handleTopReach() {

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -31,6 +31,7 @@ const { isDark } = useTheme();
 const { toolTraceVisible } = useToolTraceVisibility();
 const listRef = ref<InstanceType<typeof VirtualMessageList> | null>(null);
 const pendingInitialScrollSessionId = ref<string | null>(null);
+const initialBottomScrollOptions = { frames: 8, keepAliveMs: 1200 };
 
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
@@ -135,15 +136,14 @@ function applyInitialSessionScroll(sessionId: string) {
   if (snapshot) {
     pendingInitialScrollSessionId.value = null;
     if (snapshot.wasNearBottom) {
-      scrollToBottom({ frames: 4, keepAliveMs: 400 });
+      scrollToBottom(initialBottomScrollOptions);
     } else {
       listRef.value?.restoreViewportPosition(snapshot);
     }
     return;
   }
 
-  scrollToBottom({ frames: 4, keepAliveMs: 400 });
-  if (chatStore.messages.length > 0) pendingInitialScrollSessionId.value = null;
+  scrollToBottom(initialBottomScrollOptions);
 }
 
 async function handleTopReach() {
@@ -173,6 +173,24 @@ watch(
   ([id, length]) => {
     if (!id || pendingInitialScrollSessionId.value !== id || length === 0) return;
     applyInitialSessionScroll(id);
+  },
+  { flush: "post" },
+);
+
+watch(
+  () => chatStore.isLoadingMessages,
+  async (isLoading, wasLoading) => {
+    if (isLoading || !wasLoading) return;
+    const id = chatStore.activeSessionId;
+    if (!id || pendingInitialScrollSessionId.value !== id) return;
+    if (chatStore.focusMessageId) {
+      pendingInitialScrollSessionId.value = null;
+      return;
+    }
+    await nextTick();
+    if (chatStore.activeSessionId !== id) return;
+    scrollToBottom(initialBottomScrollOptions);
+    pendingInitialScrollSessionId.value = null;
   },
   { flush: "post" },
 );

--- a/packages/client/src/components/hermes/chat/VirtualMessageList.vue
+++ b/packages/client/src/components/hermes/chat/VirtualMessageList.vue
@@ -127,6 +127,13 @@ function handleScroll() {
   if (scrollTop.value <= props.topThreshold) emit("topReach");
 }
 
+function handleWheel(event: WheelEvent) {
+  if (event.deltaY < -1) {
+    userDetachedFromBottom = true;
+    cancelBottomScroll();
+  }
+}
+
 function handleResize() {
   syncViewport();
   if (Date.now() < keepBottomUntil || isNearBottom(64)) scheduleScrollToBottom(2);
@@ -177,7 +184,7 @@ function scheduleScrollToBottom(frames = 1) {
     } else {
       bottomFrameAttempts += 1;
     }
-    if (bottomFrameRemaining <= 0) {
+    if (bottomFrameRemaining <= 0 && Date.now() >= keepBottomUntil) {
       bottomFrame = null;
       bottomFrameRemaining = 0;
       bottomFrameAttempts = 0;
@@ -430,6 +437,7 @@ defineExpose({
       :flow-mode="true"
       :prerender="overscan"
       @scroll.passive="handleScroll"
+      @wheel.passive="handleWheel"
       @resize="handleResize"
       @visible="syncViewport"
     >


### PR DESCRIPTION
## Summary

- Keep initial chat bottom-follow alive longer while resumed messages and virtual list heights settle.
- Add a final bottom-scroll pass after message loading completes for first session entry.
- Cancel the initial bottom-follow immediately when the user wheels upward.

## Root Cause

The first session-entry scroll could run before resumed messages and DynamicScroller row measurements had stabilized, so later height changes could leave the viewport slightly above the newest message.

## Validation

- npm run harness:check
- git diff --check
- npm run build
