### PR TITLE
[codex] fix skill usage stats source

### DIFF
--- a/packages/server/src/db/hermes/sessions-db.ts
+++ b/packages/server/src/db/hermes/sessions-db.ts
@@ -1,6 +1,7 @@
 import { getActiveProfileDir, getProfileDir } from '../../services/hermes/hermes-profile'
 import { join } from 'path'
 import type { LocalUsageStats } from './usage-store'
+import { getDb } from '../index'
 
 const SQLITE_AVAILABLE = (() => {
   const [major, minor] = process.versions.node.split('.').map(Number)
@@ -1013,147 +1014,152 @@ export async function getSkillUsageStatsFromDb(
   const normalizedDays = Number.isFinite(days) ? days : 7
   const safeDays = Math.max(1, Math.floor(normalizedDays))
   const since = nowSeconds - safeDays * 24 * 60 * 60
-  const db = await openSessionDb(profile)
+  const db = getDb()
+  if (!db) throw new Error('SQLite is not available')
 
-  try {
-    const hasStartedIndex = db.prepare("PRAGMA index_list(sessions)").all()
-      .some(index => String(index.name || '') === 'idx_sessions_started')
-    const hasMessagesIndex = db.prepare("PRAGMA index_list(messages)").all()
-      .some(index => String(index.name || '') === 'idx_messages_session')
-    const sessionsTable = hasStartedIndex ? 'sessions s INDEXED BY idx_sessions_started' : 'sessions s'
-    const messagesTable = hasMessagesIndex ? 'messages m INDEXED BY idx_messages_session' : 'messages m'
-    const toolPredicate = `
-      m.role = 'tool'
-      AND (
-        m.tool_name IN ('skill_view', 'skill_manage')
+  const profileName = profile?.trim()
+  const profilePredicate = profileName ? 'AND s.profile = ?' : ''
+  const profileParams = profileName ? [profileName] : []
+  const skillContentExpression = `
+    CASE
+      WHEN m.tool_name IN ('skill_view', 'skill_manage')
         OR m.content LIKE '[skill_view]%'
         OR m.content LIKE '[skill_manage]%'
-        OR m.tool_call_id IS NOT NULL
-      )
-    `
-    const recentRows = db.prepare(`
-      SELECT
-        m.tool_name,
-        m.tool_call_id,
-        SUBSTR(m.content, 1, 300) AS content,
-        COALESCE(m.timestamp, s.started_at) AS timestamp,
-        (
-          SELECT a.tool_calls
-          FROM messages a
-          WHERE a.session_id = m.session_id
-            AND a.role = 'assistant'
-            AND m.tool_call_id IS NOT NULL
-            AND a.tool_calls LIKE '%' || m.tool_call_id || '%'
-          ORDER BY a.timestamp DESC
-          LIMIT 1
-        ) AS assistant_tool_calls
-      FROM ${sessionsTable}
-      JOIN ${messagesTable} ON m.session_id = s.id
-      WHERE s.started_at > ?
-        AND ${toolPredicate}
-    `).all(since) as Record<string, unknown>[]
-    const lateRows = db.prepare(`
-      SELECT
-        m.tool_name,
-        m.tool_call_id,
-        SUBSTR(m.content, 1, 300) AS content,
-        COALESCE(m.timestamp, s.started_at) AS timestamp,
-        (
-          SELECT a.tool_calls
-          FROM messages a
-          WHERE a.session_id = m.session_id
-            AND a.role = 'assistant'
-            AND m.tool_call_id IS NOT NULL
-            AND a.tool_calls LIKE '%' || m.tool_call_id || '%'
-          ORDER BY a.timestamp DESC
-          LIMIT 1
-        ) AS assistant_tool_calls
-      FROM ${sessionsTable}
-      JOIN ${messagesTable} ON m.session_id = s.id
-      WHERE s.started_at <= ?
-        AND COALESCE(m.timestamp, s.started_at) > ?
-        AND ${toolPredicate}
-    `).all(since, since) as Record<string, unknown>[]
+      THEN m.content
+      ELSE ''
+    END
+  `
+  const toolPredicate = `
+    m.role = 'tool'
+    AND (
+      m.tool_name IN ('skill_view', 'skill_manage')
+      OR m.content LIKE '[skill_view]%'
+      OR m.content LIKE '[skill_manage]%'
+      OR m.tool_call_id IS NOT NULL
+    )
+  `
+  const recentRows = db.prepare(`
+    SELECT
+      m.tool_name,
+      m.tool_call_id,
+      ${skillContentExpression} AS content,
+      COALESCE(m.timestamp, s.started_at) AS timestamp,
+      (
+        SELECT a.tool_calls
+        FROM messages a
+        WHERE a.session_id = m.session_id
+          AND a.role = 'assistant'
+          AND m.tool_call_id IS NOT NULL
+          AND a.tool_calls LIKE '%' || m.tool_call_id || '%'
+        ORDER BY a.timestamp DESC
+        LIMIT 1
+      ) AS assistant_tool_calls
+    FROM sessions s
+    JOIN messages m ON m.session_id = s.id
+    WHERE ${toolPredicate}
+      ${profilePredicate}
+      AND s.started_at > ?
+  `).all(...profileParams, since) as Record<string, unknown>[]
+  const lateRows = db.prepare(`
+    SELECT
+      m.tool_name,
+      m.tool_call_id,
+      ${skillContentExpression} AS content,
+      COALESCE(m.timestamp, s.started_at) AS timestamp,
+      (
+        SELECT a.tool_calls
+        FROM messages a
+        WHERE a.session_id = m.session_id
+          AND a.role = 'assistant'
+          AND m.tool_call_id IS NOT NULL
+          AND a.tool_calls LIKE '%' || m.tool_call_id || '%'
+        ORDER BY a.timestamp DESC
+        LIMIT 1
+      ) AS assistant_tool_calls
+    FROM sessions s
+    JOIN messages m ON m.session_id = s.id
+    WHERE ${toolPredicate}
+      ${profilePredicate}
+      AND s.started_at <= ?
+      AND COALESCE(m.timestamp, s.started_at) > ?
+  `).all(...profileParams, since, since) as Record<string, unknown>[]
 
-    const skillMap = new Map<string, { skill: string; view_count: number; manage_count: number; last_used_at: number | null }>()
-    const dayMap = new Map<string, { date: string; view_count: number; manage_count: number }>()
-    const daySkillMap = new Map<string, Map<string, { skill: string; view_count: number; manage_count: number }>>()
+  const skillMap = new Map<string, { skill: string; view_count: number; manage_count: number; last_used_at: number | null }>()
+  const dayMap = new Map<string, { date: string; view_count: number; manage_count: number }>()
+  const daySkillMap = new Map<string, Map<string, { skill: string; view_count: number; manage_count: number }>>()
 
-    for (const row of [...recentRows, ...lateRows]) {
-      const event = mapSkillUsageEvent(row)
-      if (!event) continue
+  for (const row of [...recentRows, ...lateRows]) {
+    const event = mapSkillUsageEvent(row)
+    if (!event) continue
 
-      const entry = skillMap.get(event.skill) || {
-        skill: event.skill,
-        view_count: 0,
-        manage_count: 0,
-        last_used_at: null,
-      }
-      if (event.action === 'view') entry.view_count += 1
-      else entry.manage_count += 1
-      if (event.timestamp != null && (entry.last_used_at == null || event.timestamp > entry.last_used_at)) {
-        entry.last_used_at = event.timestamp
-      }
-      skillMap.set(event.skill, entry)
-
-      const date = formatUnixDate(event.timestamp)
-      if (date) {
-        const day = dayMap.get(date) || { date, view_count: 0, manage_count: 0 }
-        if (event.action === 'view') day.view_count += 1
-        else day.manage_count += 1
-        dayMap.set(date, day)
-
-        const skillsForDay = daySkillMap.get(date) || new Map<string, { skill: string; view_count: number; manage_count: number }>()
-        const skillForDay = skillsForDay.get(event.skill) || { skill: event.skill, view_count: 0, manage_count: 0 }
-        if (event.action === 'view') skillForDay.view_count += 1
-        else skillForDay.manage_count += 1
-        skillsForDay.set(event.skill, skillForDay)
-        daySkillMap.set(date, skillsForDay)
-      }
+    const entry = skillMap.get(event.skill) || {
+      skill: event.skill,
+      view_count: 0,
+      manage_count: 0,
+      last_used_at: null,
     }
-
-    const totalLoads = [...skillMap.values()].reduce((sum, skill) => sum + skill.view_count, 0)
-    const totalEdits = [...skillMap.values()].reduce((sum, skill) => sum + skill.manage_count, 0)
-    const totalActions = totalLoads + totalEdits
-    const byDay = [...dayMap.values()]
-      .map(day => ({
-        ...day,
-        total_count: day.view_count + day.manage_count,
-        skills: [...(daySkillMap.get(day.date)?.values() || [])]
-          .map(skill => ({
-            ...skill,
-            total_count: skill.view_count + skill.manage_count,
-          }))
-          .sort((a, b) => b.total_count - a.total_count || a.skill.localeCompare(b.skill)),
-      }))
-      .sort((a, b) => a.date.localeCompare(b.date))
-    const topSkills = [...skillMap.values()]
-      .map(skill => ({
-        ...skill,
-        total_count: skill.view_count + skill.manage_count,
-        percentage: totalActions > 0 ? (skill.view_count + skill.manage_count) / totalActions * 100 : 0,
-      }))
-      .sort((a, b) =>
-        b.total_count - a.total_count ||
-        b.view_count - a.view_count ||
-        b.manage_count - a.manage_count ||
-        (b.last_used_at || 0) - (a.last_used_at || 0) ||
-        a.skill.localeCompare(b.skill),
-      )
-
-    return {
-      period_days: safeDays,
-      summary: {
-        total_skill_loads: totalLoads,
-        total_skill_edits: totalEdits,
-        total_skill_actions: totalActions,
-        distinct_skills_used: skillMap.size,
-      },
-      by_day: byDay,
-      top_skills: topSkills,
+    if (event.action === 'view') entry.view_count += 1
+    else entry.manage_count += 1
+    if (event.timestamp != null && (entry.last_used_at == null || event.timestamp > entry.last_used_at)) {
+      entry.last_used_at = event.timestamp
     }
-  } finally {
-    db.close()
+    skillMap.set(event.skill, entry)
+
+    const date = formatUnixDate(event.timestamp)
+    if (date) {
+      const day = dayMap.get(date) || { date, view_count: 0, manage_count: 0 }
+      if (event.action === 'view') day.view_count += 1
+      else day.manage_count += 1
+      dayMap.set(date, day)
+
+      const skillsForDay = daySkillMap.get(date) || new Map<string, { skill: string; view_count: number; manage_count: number }>()
+      const skillForDay = skillsForDay.get(event.skill) || { skill: event.skill, view_count: 0, manage_count: 0 }
+      if (event.action === 'view') skillForDay.view_count += 1
+      else skillForDay.manage_count += 1
+      skillsForDay.set(event.skill, skillForDay)
+      daySkillMap.set(date, skillsForDay)
+    }
+  }
+
+  const totalLoads = [...skillMap.values()].reduce((sum, skill) => sum + skill.view_count, 0)
+  const totalEdits = [...skillMap.values()].reduce((sum, skill) => sum + skill.manage_count, 0)
+  const totalActions = totalLoads + totalEdits
+  const byDay = [...dayMap.values()]
+    .map(day => ({
+      ...day,
+      total_count: day.view_count + day.manage_count,
+      skills: [...(daySkillMap.get(day.date)?.values() || [])]
+        .map(skill => ({
+          ...skill,
+          total_count: skill.view_count + skill.manage_count,
+        }))
+        .sort((a, b) => b.total_count - a.total_count || a.skill.localeCompare(b.skill)),
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date))
+  const topSkills = [...skillMap.values()]
+    .map(skill => ({
+      ...skill,
+      total_count: skill.view_count + skill.manage_count,
+      percentage: totalActions > 0 ? (skill.view_count + skill.manage_count) / totalActions * 100 : 0,
+    }))
+    .sort((a, b) =>
+      b.total_count - a.total_count ||
+      b.view_count - a.view_count ||
+      b.manage_count - a.manage_count ||
+      (b.last_used_at || 0) - (a.last_used_at || 0) ||
+      a.skill.localeCompare(b.skill),
+    )
+
+  return {
+    period_days: safeDays,
+    summary: {
+      total_skill_loads: totalLoads,
+      total_skill_edits: totalEdits,
+      total_skill_actions: totalActions,
+      distinct_skills_used: skillMap.size,
+    },
+    by_day: byDay,
+    top_skills: topSkills,
   }
 }
 

--- a/tests/server/skill-usage-stats-db.test.ts
+++ b/tests/server/skill-usage-stats-db.test.ts
@@ -1,28 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 
-const profileMock = vi.hoisted(() => ({
-  getActiveProfileDir: vi.fn(),
+const dbMock = vi.hoisted(() => ({
+  current: null as DatabaseSync | null,
 }))
 
-vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
-  getActiveProfileDir: profileMock.getActiveProfileDir,
-  getProfileDir: vi.fn(),
+vi.mock('../../packages/server/src/db/index', () => ({
+  getDb: () => dbMock.current,
 }))
 
-function createStateDb(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'hermes-skill-usage-'))
-  const db = new DatabaseSync(join(dir, 'state.db'))
+function createWebUiDb(): DatabaseSync {
+  const db = new DatabaseSync(':memory:')
   db.exec(`
     CREATE TABLE sessions (
       id TEXT PRIMARY KEY,
+      profile TEXT NOT NULL DEFAULT 'default',
       source TEXT,
       started_at INTEGER
     );
-    CREATE INDEX idx_sessions_started ON sessions(started_at);
     CREATE TABLE messages (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       session_id TEXT,
@@ -33,92 +28,92 @@ function createStateDb(): string {
       tool_name TEXT,
       timestamp INTEGER
     );
-    CREATE INDEX idx_messages_session ON messages(session_id, timestamp);
+    CREATE INDEX idx_messages_session_id ON messages(session_id);
   `)
-  db.close()
-  return dir
+  return db
 }
 
-function insertSession(dir: string, row: { id: string; source?: string; started_at: number }) {
-  const db = new DatabaseSync(join(dir, 'state.db'))
-  db.prepare('INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)')
-    .run(row.id, row.source ?? 'cli', row.started_at)
-  db.close()
+function insertSession(db: DatabaseSync, row: { id: string; profile?: string; source?: string; started_at: number }) {
+  db.prepare('INSERT INTO sessions (id, profile, source, started_at) VALUES (?, ?, ?, ?)')
+    .run(row.id, row.profile ?? 'default', row.source ?? 'api_server', row.started_at)
 }
 
-function insertToolResult(dir: string, row: {
+function insertToolResult(db: DatabaseSync, row: {
   sessionId: string
   timestamp: number
   toolName?: string | null
   toolCallId?: string | null
   content: string
 }) {
-  const db = new DatabaseSync(join(dir, 'state.db'))
   db.prepare('INSERT INTO messages (session_id, role, content, tool_call_id, tool_name, timestamp) VALUES (?, ?, ?, ?, ?, ?)')
     .run(row.sessionId, 'tool', row.content, row.toolCallId ?? null, row.toolName ?? null, row.timestamp)
-  db.close()
 }
 
-function insertAssistantToolCalls(dir: string, sessionId: string, timestamp: number, toolCalls: unknown) {
-  const db = new DatabaseSync(join(dir, 'state.db'))
-  db.prepare('INSERT INTO messages (session_id, role, tool_calls, timestamp) VALUES (?, ?, ?, ?)')
-    .run(sessionId, 'assistant', JSON.stringify(toolCalls), timestamp)
-  db.close()
+function insertAssistantToolCalls(db: DatabaseSync, sessionId: string, timestamp: number, toolCalls: unknown) {
+  db.prepare('INSERT INTO messages (session_id, role, content, tool_calls, timestamp) VALUES (?, ?, ?, ?, ?)')
+    .run(sessionId, 'assistant', '', JSON.stringify(toolCalls), timestamp)
 }
 
 describe('Hermes skill usage analytics DB aggregation', () => {
-  let profileDir: string | null = null
-
   beforeEach(() => {
     vi.resetModules()
-    profileMock.getActiveProfileDir.mockReset()
+    dbMock.current = createWebUiDb()
   })
 
   afterEach(() => {
-    if (profileDir) rmSync(profileDir, { recursive: true, force: true })
-    profileDir = null
+    dbMock.current?.close()
+    dbMock.current = null
   })
 
-  it('counts completed skill loads and edits from compact tool result rows across CLI and API-server sessions inside the requested period', async () => {
+  it('counts completed skill loads and edits from Web UI sessions inside the requested profile and period', async () => {
     const now = 1_700_000_000
-    profileDir = createStateDb()
-    profileMock.getActiveProfileDir.mockReturnValue(profileDir)
+    const db = dbMock.current!
 
-    insertSession(profileDir, { id: 'recent-cli', source: 'cli', started_at: now - 60 })
-    insertToolResult(profileDir, {
-      sessionId: 'recent-cli',
+    insertSession(db, { id: 'recent-chat', started_at: now - 60 })
+    insertToolResult(db, {
+      sessionId: 'recent-chat',
       timestamp: now - 50,
       content: '[skill_view] name=hermes-agent (64,764 chars)',
     })
-    insertToolResult(profileDir, {
-      sessionId: 'recent-cli',
+    insertToolResult(db, {
+      sessionId: 'recent-chat',
       timestamp: now - 45,
       toolName: 'skill_view',
       content: '[skill_view] name=hermes-agent (64,764 chars)',
     })
-    insertToolResult(profileDir, {
-      sessionId: 'recent-cli',
+    insertToolResult(db, {
+      sessionId: 'recent-chat',
       timestamp: now - 40,
       toolName: 'skill_manage',
       content: JSON.stringify({ success: true, message: "Patched SKILL.md in skill 'hermes-agent' (1 replacement)." }),
     })
-    insertToolResult(profileDir, {
-      sessionId: 'recent-cli',
+    insertToolResult(db, {
+      sessionId: 'recent-chat',
       timestamp: now - 35,
       content: '[skill_view] name=github-pr-workflow (22,106 chars)',
     })
-    insertAssistantToolCalls(profileDir, 'recent-cli', now - 30, [
+    insertToolResult(db, {
+      sessionId: 'recent-chat',
+      timestamp: now - 32,
+      toolName: 'skill_view',
+      content: JSON.stringify({
+        success: true,
+        name: 'github-project-analysis',
+        description: 'x'.repeat(512),
+      }),
+    })
+    insertAssistantToolCalls(db, 'recent-chat', now - 30, [
       { function: { name: 'skill_view', arguments: JSON.stringify({ name: 'planned-but-not-counted' }) } },
     ])
-    insertToolResult(profileDir, {
-      sessionId: 'recent-cli',
+    insertToolResult(db, {
+      sessionId: 'recent-chat',
       timestamp: now - 25,
       toolName: 'terminal',
       content: 'noop',
     })
 
-    insertSession(profileDir, { id: 'web-api-session', source: 'api_server', started_at: now - 30 })
-    insertAssistantToolCalls(profileDir, 'web-api-session', now - 22, [
+    insertSession(db, { id: 'web-api-session', started_at: now - 30 })
+    insertAssistantToolCalls(db, 'web-api-session', now - 22, [
       {
         id: 'call_api_skill_view',
         call_id: 'call_api_skill_view',
@@ -126,48 +121,56 @@ describe('Hermes skill usage analytics DB aggregation', () => {
         function: { name: 'skill_view', arguments: JSON.stringify({ name: 'api-server-skill' }) },
       },
     ])
-    insertToolResult(profileDir, {
+    insertToolResult(db, {
       sessionId: 'web-api-session',
       timestamp: now - 20,
       toolCallId: 'call_api_skill_view',
       content: JSON.stringify({ success: true, name: 'api-server-skill', description: 'API-server JSON tool result' }),
     })
 
-    insertSession(profileDir, { id: 'old-cli', source: 'cli', started_at: now - 10 * 86400 })
-    insertToolResult(profileDir, {
-      sessionId: 'old-cli',
+    insertSession(db, { id: 'old-chat', started_at: now - 10 * 86400 })
+    insertToolResult(db, {
+      sessionId: 'old-chat',
       timestamp: now - 10 * 86400,
       content: '[skill_view] name=old-skill (1 chars)',
     })
 
-    insertSession(profileDir, { id: 'long-running-cli', source: 'cli', started_at: now - 10 * 86400 })
-    insertToolResult(profileDir, {
-      sessionId: 'long-running-cli',
+    insertSession(db, { id: 'long-running-chat', started_at: now - 10 * 86400 })
+    insertToolResult(db, {
+      sessionId: 'long-running-chat',
       timestamp: now - 40,
       content: '[skill_view] name=late-session-skill (1 chars)',
     })
 
+    insertSession(db, { id: 'other-profile-chat', profile: 'tester', started_at: now - 30 })
+    insertToolResult(db, {
+      sessionId: 'other-profile-chat',
+      timestamp: now - 20,
+      content: '[skill_view] name=other-profile-skill (1 chars)',
+    })
+
     const mod = await import('../../packages/server/src/db/hermes/sessions-db')
-    const result = await mod.getSkillUsageStatsFromDb(7, now)
+    const result = await mod.getSkillUsageStatsFromDb(7, now, 'default')
 
     expect(result).toEqual({
       period_days: 7,
       summary: {
-        total_skill_loads: 5,
+        total_skill_loads: 6,
         total_skill_edits: 1,
-        total_skill_actions: 6,
-        distinct_skills_used: 4,
+        total_skill_actions: 7,
+        distinct_skills_used: 5,
       },
       by_day: [
         {
           date: '2023-11-14',
-          view_count: 5,
+          view_count: 6,
           manage_count: 1,
-          total_count: 6,
+          total_count: 7,
           skills: [
             { skill: 'hermes-agent', view_count: 2, manage_count: 1, total_count: 3 },
             { skill: 'api-server-skill', view_count: 1, manage_count: 0, total_count: 1 },
             { skill: 'github-pr-workflow', view_count: 1, manage_count: 0, total_count: 1 },
+            { skill: 'github-project-analysis', view_count: 1, manage_count: 0, total_count: 1 },
             { skill: 'late-session-skill', view_count: 1, manage_count: 0, total_count: 1 },
           ],
         },
@@ -178,7 +181,7 @@ describe('Hermes skill usage analytics DB aggregation', () => {
           view_count: 2,
           manage_count: 1,
           total_count: 3,
-          percentage: 50,
+          percentage: 3 / 7 * 100,
           last_used_at: now - 40,
         },
         {
@@ -186,15 +189,23 @@ describe('Hermes skill usage analytics DB aggregation', () => {
           view_count: 1,
           manage_count: 0,
           total_count: 1,
-          percentage: 1 / 6 * 100,
+          percentage: 1 / 7 * 100,
           last_used_at: now - 20,
+        },
+        {
+          skill: 'github-project-analysis',
+          view_count: 1,
+          manage_count: 0,
+          total_count: 1,
+          percentage: 1 / 7 * 100,
+          last_used_at: now - 32,
         },
         {
           skill: 'github-pr-workflow',
           view_count: 1,
           manage_count: 0,
           total_count: 1,
-          percentage: 1 / 6 * 100,
+          percentage: 1 / 7 * 100,
           last_used_at: now - 35,
         },
         {
@@ -202,7 +213,7 @@ describe('Hermes skill usage analytics DB aggregation', () => {
           view_count: 1,
           manage_count: 0,
           total_count: 1,
-          percentage: 1 / 6 * 100,
+          percentage: 1 / 7 * 100,
           last_used_at: now - 40,
         },
       ],


### PR DESCRIPTION
## Summary
- read skill usage analytics from the Web UI sessions/messages database instead of Hermes profile state.db
- filter usage rows by the requested Web UI session profile
- preserve full skill_view/skill_manage result content so long JSON tool results can expose the skill name
- keep assistant tool_call matching for API-server skill tool results without parsing large non-skill tool outputs

## Validation
- npm run test -- tests/server/skill-usage-stats-db.test.ts tests/server/skills-controller.test.ts
- git diff --check
- npm run harness:check
- npm run build
- local API check returned github-project-analysis from /api/hermes/skills/usage/stats?days=365 after the fix