### PR TITLE
[codex] sync desktop artifacts to R2

### DIFF
--- a/.github/workflows/desktop-mac-update-manifest.yml
+++ b/.github/workflows/desktop-mac-update-manifest.yml
@@ -20,6 +20,9 @@ jobs:
     name: Generate and upload latest-mac.yml
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download macOS release assets
         shell: bash
         env:
@@ -109,3 +112,15 @@ jobs:
             -H "Authorization: Bearer ${GH_TOKEN}" \
             "$asset_url" > /tmp/latest-mac-uploaded.yml
           diff -u /tmp/latest-mac.yml /tmp/latest-mac-uploaded.yml
+
+      - name: Upload merged macOS update manifest to R2
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID || secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ vars.R2_BUCKET || secrets.R2_BUCKET }}
+          R2_PREFIX: ${{ github.event.inputs.tag }}
+          R2_FILES: /tmp/latest-mac.yml
+        run: bash scripts/upload-r2-artifacts.sh

--- a/.github/workflows/desktop-manual-build.yml
+++ b/.github/workflows/desktop-manual-build.yml
@@ -210,6 +210,19 @@ jobs:
           fail_on_unmatched_files: true
           files: ${{ needs.validate.outputs.artifact_files }}
 
+      - name: Upload artifacts to R2
+        if: github.event.inputs.release_tag != ''
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID || secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ vars.R2_BUCKET || secrets.R2_BUCKET }}
+          R2_PREFIX: ${{ github.event.inputs.release_tag }}
+          R2_FILES: ${{ needs.validate.outputs.artifact_files }}
+        run: bash scripts/upload-r2-artifacts.sh
+
   mac-update-manifest:
     name: Repair macOS update manifest
     needs: [validate, desktop]
@@ -325,3 +338,16 @@ jobs:
         run: |
           set -euo pipefail
           gh release upload "$TAG" /tmp/latest-mac.yml --repo "$GITHUB_REPOSITORY" --clobber
+
+      - name: Upload merged macOS update manifest to R2
+        if: steps.check.outputs.complete == 'true'
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID || secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ vars.R2_BUCKET || secrets.R2_BUCKET }}
+          R2_PREFIX: ${{ github.event.inputs.release_tag }}
+          R2_FILES: /tmp/latest-mac.yml
+        run: bash scripts/upload-r2-artifacts.sh

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -173,6 +173,18 @@ jobs:
           fail_on_unmatched_files: true
           files: ${{ matrix.artifact_files }}
 
+      - name: Upload artifacts to R2
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID || secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ vars.R2_BUCKET || secrets.R2_BUCKET }}
+          R2_PREFIX: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          R2_FILES: ${{ matrix.artifact_files }}
+        run: bash scripts/upload-r2-artifacts.sh
+
   mac-update-manifest:
     name: Merge macOS updater manifest
     needs: desktop
@@ -204,3 +216,15 @@ jobs:
           tag_name: ${{ github.event.release.tag_name || github.event.inputs.tag }}
           fail_on_unmatched_files: true
           files: /tmp/latest-mac.yml
+
+      - name: Upload merged macOS updater manifest to R2
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID || secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ vars.R2_BUCKET || secrets.R2_BUCKET }}
+          R2_PREFIX: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          R2_FILES: /tmp/latest-mac.yml
+        run: bash scripts/upload-r2-artifacts.sh

--- a/.github/workflows/desktop-runtime.yml
+++ b/.github/workflows/desktop-runtime.yml
@@ -121,3 +121,31 @@ jobs:
             packages/desktop/release/runtime/${{ steps.names.outputs.asset }}
             packages/desktop/release/runtime/${{ steps.names.outputs.asset }}.sha256
             packages/desktop/release/runtime/${{ steps.names.outputs.manifest }}
+
+      - name: Download existing runtime assets for R2
+        if: steps.check.outputs.missing == 'false'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p packages/desktop/release/runtime
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern '${{ steps.names.outputs.asset }}' --dir packages/desktop/release/runtime
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern '${{ steps.names.outputs.asset }}.sha256' --dir packages/desktop/release/runtime
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern '${{ steps.names.outputs.manifest }}' --dir packages/desktop/release/runtime
+
+      - name: Upload runtime assets to R2
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID || secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ vars.R2_BUCKET || secrets.R2_BUCKET }}
+          R2_PREFIX: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          R2_FILES: |
+            packages/desktop/release/runtime/${{ steps.names.outputs.asset }}
+            packages/desktop/release/runtime/${{ steps.names.outputs.asset }}.sha256
+            packages/desktop/release/runtime/${{ steps.names.outputs.manifest }}
+        run: bash scripts/upload-r2-artifacts.sh

--- a/scripts/upload-r2-artifacts.sh
+++ b/scripts/upload-r2-artifacts.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${R2_ACCOUNT_ID:?Missing R2_ACCOUNT_ID}"
+: "${R2_BUCKET:?Missing R2_BUCKET}"
+: "${R2_PREFIX:?Missing R2_PREFIX}"
+: "${R2_FILES:?Missing R2_FILES}"
+
+endpoint="${R2_ENDPOINT_URL:-https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com}"
+cache_control="${R2_CACHE_CONTROL:-public, max-age=3600}"
+prefix="${R2_PREFIX#/}"
+prefix="${prefix%/}"
+uploaded=0
+
+shopt -s nullglob
+
+while IFS= read -r pattern; do
+  [ -n "$pattern" ] || continue
+  matches=( $pattern )
+  if [ "${#matches[@]}" -eq 0 ]; then
+    echo "No files matched R2 upload pattern: ${pattern}" >&2
+    exit 1
+  fi
+
+  for file in "${matches[@]}"; do
+    [ -f "$file" ] || continue
+    name="$(basename "$file")"
+    aws s3 cp "$file" "s3://${R2_BUCKET}/${prefix}/${name}" \
+      --endpoint-url "$endpoint" \
+      --cache-control "$cache_control"
+    uploaded=$((uploaded + 1))
+  done
+done <<< "$R2_FILES"
+
+if [ "$uploaded" -eq 0 ]; then
+  echo "No files were uploaded to R2." >&2
+  exit 1
+fi
+
+echo "Uploaded ${uploaded} file(s) to r2://${R2_BUCKET}/${prefix}/"


### PR DESCRIPTION
## Summary
- Add a reusable R2 upload script for release artifacts using the R2 S3-compatible endpoint.
- Sync desktop release, manual build, macOS update manifest repair, and desktop runtime assets to the configured R2 bucket under the release tag prefix.
- Support runtime backfill by downloading existing GitHub Release runtime assets before uploading them to R2.

## Impact
- GitHub Release uploads remain in place.
- `download.ekkolearnai.com/<tag>/<asset>` can be served from R2 once the Worker is updated to prefer R2 before GitHub fallback.
- Requires the existing repository secrets/variables: `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ACCOUNT_ID`, and `R2_BUCKET`.

## Validation
- `bash -n scripts/upload-r2-artifacts.sh`
- `npm run harness:check`

## Notes
- `actionlint` was not available locally.
- R2 credentials and bucket variables were configured in the repository before opening this PR.
