### PR TITLE
[codex] fix group chat mentions after resize

### DIFF
--- a/docs/chat-chain-changes/2026-06-06-pr1368-group-chat-mentions.md
+++ b/docs/chat-chain-changes/2026-06-06-pr1368-group-chat-mentions.md
@@ -1,0 +1,10 @@
+---
+date: 2026-06-06
+pr: 1368
+feature: Group Chat mention input
+impact: Group Chat mention suggestions continue updating after users manually resize the message input.
+---
+
+`GroupChatInput` now updates typing and mention state before skipping textarea
+auto-height changes for a custom resized input, so later `@` mentions still
+open the agent picker.

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -228,16 +228,16 @@ function handleSend() {
 }
 
 function handleInput(e: Event) {
-    // 用户手动拖拽自定义高度时，不覆盖
-    if (textareaHeight.value !== null) return
     store.emitTyping()
-    const el = e.target as HTMLTextAreaElement
-    el.style.height = 'auto'
-    el.style.height = Math.min(el.scrollHeight, 100) + 'px'
-
     if (!isComposing.value) {
         updateMentionState()
     }
+
+    // 用户手动拖拽自定义高度时，不覆盖
+    if (textareaHeight.value !== null) return
+    const el = e.target as HTMLTextAreaElement
+    el.style.height = 'auto'
+    el.style.height = Math.min(el.scrollHeight, 100) + 'px'
 }
 
 function handleMentionClick(option: MentionOption) {

--- a/tests/client/group-chat-input-mentions.test.ts
+++ b/tests/client/group-chat-input-mentions.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+import { nextTick } from 'vue'
+import GroupChatInput from '@/components/hermes/group-chat/GroupChatInput.vue'
+import { useGroupChatStore } from '@/stores/hermes/group-chat'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NButton: { template: '<button type="button" v-bind="$attrs"><slot /><slot name="icon" /></button>' },
+  NTooltip: { template: '<div><slot name="trigger" /><slot /></div>' },
+  NSwitch: { template: '<button type="button"></button>' },
+}))
+
+vi.mock('@/composables/useToolTraceVisibility', () => ({
+  useToolTraceVisibility: () => ({ toolTraceVisible: { value: true }, toggleToolTraceVisible: vi.fn() }),
+}))
+
+describe('GroupChatInput mentions', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('updates mention suggestions after the textarea has a custom height', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    const store = useGroupChatStore()
+    store.agents = [{ id: 'agent-1', agentId: 'agent-1', profile: 'worker', name: 'Worker', roomId: 'room-1', description: '', invited: 1 }]
+    store.emitTyping = vi.fn()
+
+    const wrapper = mount(GroupChatInput, {
+      attachTo: document.body,
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+
+    const textarea = wrapper.get('textarea')
+    const resizeHandle = wrapper.get('.resize-handle')
+    await resizeHandle.trigger('mousedown', { clientY: 100 })
+    document.dispatchEvent(new MouseEvent('mousemove', { clientY: 50 }))
+    document.dispatchEvent(new MouseEvent('mouseup'))
+    await nextTick()
+
+    await textarea.setValue('@')
+    await nextTick()
+    expect(wrapper.find('.mention-dropdown').exists()).toBe(true)
+    expect(wrapper.find('.mention-dropdown').text()).toContain('@Worker')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes a group chat input regression where mention suggestions stopped updating after the textarea had a custom resized height.

## Root Cause

`GroupChatInput` returned early from `handleInput` when `textareaHeight` was set. That protected custom height from auto-resizing, but also skipped `emitTyping()` and `updateMentionState()`, so later `@` input could stop showing mention options.

## Changes

- Update mention state and typing status before skipping auto-height logic.
- Add a jsdom component regression test covering mention suggestions after textarea resize.

## Validation

- `npm run test -- tests/client/group-chat-input-mentions.test.ts tests/client/group-chat-mention-options.test.ts`
- `npm run test -- tests/server/group-chat-mention-routing.test.ts`
