### PR TITLE
[codex] add LAN pairing HTTP fallback

### DIFF
--- a/packages/server/src/controllers/devices.ts
+++ b/packages/server/src/controllers/devices.ts
@@ -14,6 +14,7 @@ import { getLanDiscoveryCache, getLanEndpointKind, scanLanDevices, type LanDevic
 import { getLanPeerSocketManager } from '../services/lan-peer-socket'
 import { getLanPeerToolsService } from '../services/lan-peer-tools'
 import { createDeviceSignature, getPublicSystemInfo, verifyDeviceSignature } from '../services/system-info'
+import { describeLanJsonPostError, postLanJson } from '../services/lan-http-client'
 import { config } from '../config'
 import { randomUUID } from 'crypto'
 
@@ -47,28 +48,18 @@ async function fetchRemoteLinkStatus(device: LanDeviceInfo): Promise<DeviceOutbo
   const nonce = randomUUID()
   const localInfo = await getPublicSystemInfo()
   const signature = await createDeviceSignature(nonce, timestamp)
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 1500)
   try {
-    const response = await fetch(`${device.url.replace(/\/$/, '')}/api/devices/link-status`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        device_id: localInfo.device_id,
-        device_public_key: localInfo.device_public_key,
-        timestamp,
-        nonce,
-        signature,
-      }),
-      signal: controller.signal,
-    })
-    const data = await response.json().catch(() => ({})) as { status?: unknown }
+    const response = await postLanJson(`${device.url.replace(/\/$/, '')}/api/devices/link-status`, {
+      device_id: localInfo.device_id,
+      device_public_key: localInfo.device_public_key,
+      timestamp,
+      nonce,
+      signature,
+    }, 1500)
     if (!response.ok) return null
-    return parseRemoteStatus(data.status)
+    return parseRemoteStatus(response.data.status)
   } catch {
     return null
-  } finally {
-    clearTimeout(timeout)
   }
 }
 
@@ -484,16 +475,9 @@ export async function requestDevicePairing(ctx: any) {
     signature,
   }
 
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 5000)
   try {
-    const response = await fetch(`${target.url.replace(/\/$/, '')}/api/devices/link-request`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    })
-    const data = await response.json().catch(() => ({})) as { status?: unknown; error?: unknown }
+    const response = await postLanJson(`${target.url.replace(/\/$/, '')}/api/devices/link-request`, body, 5000)
+    const data = response.data as { status?: unknown; error?: unknown }
     if (!response.ok) {
       ctx.status = response.status === 409 ? 409 : 502
       ctx.body = { error: typeof data.error === 'string' ? data.error : `Request failed: ${response.status}` }
@@ -503,9 +487,11 @@ export async function requestDevicePairing(ctx: any) {
     if (remoteStatus !== 'none') updateOutboundStatus(target.id, remoteStatus, target)
     ctx.body = await devicesPayload()
   } catch (err: any) {
+    const detail = describeLanJsonPostError(err)
     ctx.status = 502
-    ctx.body = { error: err?.message || 'Failed to request device pairing' }
-  } finally {
-    clearTimeout(timeout)
+    ctx.body = {
+      error: err?.message ? `Failed to request device pairing: ${err.message}` : 'Failed to request device pairing',
+      detail,
+    }
   }
 }

--- a/packages/server/src/services/lan-http-client.ts
+++ b/packages/server/src/services/lan-http-client.ts
@@ -1,0 +1,140 @@
+import http from 'http'
+import https from 'https'
+
+export type LanJsonTransport = 'fetch' | 'node-http'
+
+export type LanNetworkErrorDetail = {
+  name: string
+  message: string
+  code?: string
+  syscall?: string
+  address?: string
+  port?: number
+}
+
+export type LanJsonPostResponse = {
+  ok: boolean
+  status: number
+  data: Record<string, unknown>
+  transport: LanJsonTransport
+  primaryError?: LanNetworkErrorDetail
+}
+
+export class LanJsonPostError extends Error {
+  primaryError: LanNetworkErrorDetail
+  fallbackError: LanNetworkErrorDetail
+
+  constructor(primaryError: LanNetworkErrorDetail, fallbackError: LanNetworkErrorDetail) {
+    super(`fetch failed: ${primaryError.message}; node-http fallback failed: ${fallbackError.message}`)
+    this.name = 'LanJsonPostError'
+    this.primaryError = primaryError
+    this.fallbackError = fallbackError
+  }
+}
+
+function networkErrorDetail(err: any): LanNetworkErrorDetail {
+  return {
+    name: String(err?.name || 'Error'),
+    message: String(err?.message || err || 'request failed'),
+    code: typeof err?.code === 'string' ? err.code : undefined,
+    syscall: typeof err?.syscall === 'string' ? err.syscall : undefined,
+    address: typeof err?.address === 'string' ? err.address : undefined,
+    port: typeof err?.port === 'number' ? err.port : undefined,
+  }
+}
+
+async function postJsonWithFetch(url: string, body: unknown, timeoutMs: number): Promise<LanJsonPostResponse> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    })
+    const data = await response.json().catch(() => ({})) as Record<string, unknown>
+    return {
+      ok: response.ok,
+      status: response.status,
+      data,
+      transport: 'fetch',
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function parseJsonObject(raw: string): Record<string, unknown> {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function postJsonWithNodeHttp(url: string, body: unknown, timeoutMs: number, primaryError: LanNetworkErrorDetail): Promise<LanJsonPostResponse> {
+  const target = new URL(url)
+  const payload = JSON.stringify(body)
+  const client = target.protocol === 'https:' ? https : http
+
+  return new Promise((resolve, reject) => {
+    const req = client.request(target, {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+      },
+      timeout: timeoutMs,
+    }, (res) => {
+      const chunks: Buffer[] = []
+      res.on('data', chunk => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)))
+      res.on('end', () => {
+        const status = res.statusCode || 0
+        resolve({
+          ok: status >= 200 && status < 300,
+          status,
+          data: parseJsonObject(Buffer.concat(chunks).toString('utf-8')),
+          transport: 'node-http',
+          primaryError,
+        })
+      })
+    })
+
+    req.on('timeout', () => {
+      const err = new Error(`request timed out after ${timeoutMs}ms`) as Error & { code?: string }
+      err.code = 'ETIMEDOUT'
+      req.destroy(err)
+    })
+    req.on('error', reject)
+    req.end(payload)
+  })
+}
+
+export async function postLanJson(url: string, body: unknown, timeoutMs = 5000): Promise<LanJsonPostResponse> {
+  try {
+    return await postJsonWithFetch(url, body, timeoutMs)
+  } catch (err: any) {
+    const primaryError = networkErrorDetail(err)
+    try {
+      return await postJsonWithNodeHttp(url, body, timeoutMs, primaryError)
+    } catch (fallbackErr: any) {
+      throw new LanJsonPostError(primaryError, networkErrorDetail(fallbackErr))
+    }
+  }
+}
+
+export function describeLanJsonPostError(err: any): Record<string, unknown> | null {
+  if (err instanceof LanJsonPostError) {
+    return {
+      message: err.message,
+      primary: err.primaryError,
+      fallback: err.fallbackError,
+    }
+  }
+  if (!err) return null
+  return { message: String(err?.message || err) }
+}

--- a/tests/server/devices-controller.test.ts
+++ b/tests/server/devices-controller.test.ts
@@ -1,4 +1,5 @@
 import { createHash, generateKeyPairSync, sign } from 'crypto'
+import { createServer, type Server } from 'http'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { LanDeviceInfo } from '../../packages/server/src/services/lan-discovery'
 
@@ -47,6 +48,7 @@ describe('devices controller', () => {
   afterEach(() => {
     db?.close()
     db = null
+    vi.unstubAllGlobals()
     vi.doUnmock('../../packages/server/src/db/index')
     vi.resetModules()
   })
@@ -165,5 +167,102 @@ describe('devices controller', () => {
       'http://192.168.1.20:8648/api/devices/link-request',
       expect.objectContaining({ method: 'POST' }),
     )
+  })
+
+  it('falls back to the native HTTP client when fetch cannot reach a LAN peer', async () => {
+    let receivedRequest: any = null
+    let server: Server | null = null
+
+    await new Promise<void>((resolve) => {
+      server = createServer((req, res) => {
+        const chunks: Buffer[] = []
+        req.on('data', chunk => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)))
+        req.on('end', () => {
+          if (req.url === '/api/devices/link-request') {
+            receivedRequest = JSON.parse(Buffer.concat(chunks).toString('utf-8'))
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ status: 'pending' }))
+        })
+      })
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    const address = server!.address()
+    const port = typeof address === 'object' && address ? address.port : 0
+    const fallbackDevice: LanDeviceInfo = {
+      ...device,
+      ip: '127.0.0.1',
+      http_port: port,
+      url: `http://127.0.0.1:${port}`,
+    }
+
+    try {
+      vi.doMock('../../packages/server/src/services/lan-discovery', async () => {
+        const actual = await vi.importActual<typeof import('../../packages/server/src/services/lan-discovery')>(
+          '../../packages/server/src/services/lan-discovery',
+        )
+        return {
+          ...actual,
+          getLanDiscoveryCache: () => ({
+            scanning: false,
+            last_scanned_at: new Date().toISOString(),
+            devices: [fallbackDevice],
+          }),
+        }
+      })
+      vi.doMock('../../packages/server/src/services/system-info', async () => {
+        const actual = await vi.importActual<typeof import('../../packages/server/src/services/system-info')>(
+          '../../packages/server/src/services/system-info',
+        )
+        return {
+          ...actual,
+          getPublicSystemInfo: async () => ({
+            device_id: 'hwui_local',
+            device_public_key: keyPair.publicKey,
+            computer_name: 'local',
+            os: { type: 'TestOS', platform: 'darwin', release: '1', arch: 'arm64' },
+            hermes_agent_version: 'v1',
+            hermes_web_ui_version: '1',
+          }),
+          createDeviceSignature: async () => 'signature',
+        }
+      })
+
+      const fetchMock = vi.fn(async () => {
+        throw Object.assign(new Error(`connect EHOSTUNREACH ${fallbackDevice.ip}:${fallbackDevice.http_port}`), {
+          code: 'EHOSTUNREACH',
+          syscall: 'connect',
+          address: fallbackDevice.ip,
+          port: fallbackDevice.http_port,
+        })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const { getDeviceRelation } = await import('../../packages/server/src/db/hermes/devices-store')
+      const { requestDevicePairing } = await import('../../packages/server/src/controllers/devices')
+      const ctx: any = {
+        params: { id: fallbackDevice.id },
+        request: { body: {} },
+      }
+
+      await requestDevicePairing(ctx)
+
+      const relation = getDeviceRelation(fallbackDevice.id)
+      expect(ctx.status).toBeUndefined()
+      expect(relation?.outbound_status).toBe('pending')
+      expect(receivedRequest).toEqual(expect.objectContaining({
+        device_id: 'hwui_local',
+        signature: 'signature',
+      }))
+      expect(fetchMock).toHaveBeenCalledWith(
+        `http://127.0.0.1:${port}/api/devices/link-request`,
+        expect.objectContaining({ method: 'POST' }),
+      )
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server!.close(err => err ? reject(err) : resolve())
+      })
+    }
   })
 })


### PR DESCRIPTION
## Summary

Adds a LAN JSON POST helper for device pairing requests. The helper keeps `fetch` as the primary transport, then falls back to Node native `http`/`https.request` when `fetch` throws a network-level error such as `EHOSTUNREACH`.

## Root Cause

The device pairing flow depended on a single backend `fetch` call from Hermes Studio to the peer device. On some macOS packaged-runtime environments, that process-level fetch path can fail even when curl or an external Node process can reach the same LAN peer, causing the UI to show a vague `API Error 502: fetch failed`.

## Changes

- Add `postLanJson()` with `fetch` primary transport and native HTTP fallback.
- Use the helper for LAN `link-request` and `link-status` POSTs.
- Preserve normal HTTP responses such as duplicate pairing `409` without retrying the business request.
- Return structured network details when both transports fail.
- Add a server regression test where `fetch` throws `EHOSTUNREACH` but the native HTTP fallback succeeds.

## Validation

- `npm run test -- tests/server/devices-controller.test.ts`
- `npm run harness:check`
- `npm run build`
