### PR TITLE
fix: use page reload on logout to clear Pinia store data

### DIFF
--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -124,7 +124,7 @@ export async function request<T>(path: string, options: RequestInit = {}): Promi
     clearApiKey()
     emitAuthNotice('expired')
     if (router.currentRoute.value.name !== 'login') {
-      router.replace({ name: 'login' })
+      window.location.href = ''
     }
     throw new Error('Unauthorized')
   }
@@ -136,7 +136,7 @@ export async function request<T>(path: string, options: RequestInit = {}): Promi
         clearApiKey()
         emitAuthNotice('expired')
         if (router.currentRoute.value.name !== 'login') {
-          router.replace({ name: 'login' })
+          window.location.href = ''
         }
       } else {
         emitAuthNotice('forbidden')

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -70,7 +70,7 @@ function handleReloadClient() {
 
 function handleLogout() {
   localStorage.clear();
-  router.replace({ name: 'login' });
+  window.location.href = '';
 }
 
 // Changelog


### PR DESCRIPTION
## Summary
- Replace `router.replace` with `window.location.href = ""` in logout handler
- Force full page reload to clear all Pinia store state
- Prevent stale data when switching between accounts

## Problem
When users logout and login with a different account, Pinia store data from the previous session persists in memory. This can cause minor issues with stale state.

## Solution
Use `window.location.href = ""` instead of `router.replace({ name: "login" })` to trigger a full page reload. This ensures all Pinia stores are completely reset when switching accounts.

## Impact
- Users will experience a brief page reload on logout
- Clean state guaranteed for each new login session
- No more stale data issues when switching accounts

## Validation
- [x] Tested logout flow
- [x] Verified page reload clears all store state
- [x] Confirmed login works correctly after reload