### PR TITLE
show current username next to sidebar logout button

### DIFF
--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -53,6 +53,20 @@ export function isStoredSuperAdmin(): boolean {
   return getStoredUserRole() === 'super_admin'
 }
 
+export function getStoredUsername(): string | null {
+  const token = getApiKey()
+  const payload = token.split('.')[1]
+  if (!payload) return null
+  try {
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
+    const data = JSON.parse(atob(padded)) as { username?: unknown }
+    return typeof data.username === 'string' && data.username.length > 0 ? data.username : null
+  } catch {
+    return null
+  }
+}
+
 export function getActiveProfileName(): string | null {
   return localStorage.getItem('hermes_active_profile_name')
 }

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -12,7 +12,7 @@ import { useSessionSearch } from '@/composables/useSessionSearch'
 import { usePersistentRecord } from '@/composables/usePersistentRecord'
 import RouteLinkItem from '@/components/common/RouteLinkItem.vue'
 import { changelog } from "@/data/changelog";
-import { isStoredSuperAdmin } from "@/api/client";
+import { isStoredSuperAdmin, getStoredUsername } from "@/api/client";
 
 const { t } = useI18n();
 const message = useMessage();
@@ -27,6 +27,7 @@ const selectedKey = computed(() => {
   return route.name as string;
 });
 const isSuperAdmin = computed(() => isStoredSuperAdmin());
+const currentUsername = computed(() => getStoredUsername());
 const isVersionPreview = import.meta.env.VITE_HERMES_PREVIEW === '1';
 
 function isNavActive(...names: string[]) {
@@ -345,6 +346,7 @@ function openChangelog() {
           <line x1="21" y1="12" x2="9" y2="12" />
         </svg>
         <span>{{ t("sidebar.logout") }}</span>
+        <span v-if="currentUsername" class="logout-username" :title="currentUsername">{{ currentUsername }}</span>
       </button>
       <div class="status-row">
         <div
@@ -581,6 +583,16 @@ function openChangelog() {
   &:hover {
     color: $error;
     background: rgba(var(--error-rgb, 239, 68, 68), 0.06);
+  }
+
+  .logout-username {
+    margin-left: auto;
+    max-width: 140px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 12px;
+    color: $text-muted;
   }
 }
 


### PR DESCRIPTION
## 背景
侧边栏底部"退出登录"按钮当前只展示文案和图标，无法看出当前登录的是哪个账户。在多账户切换场景下不太直观。

## 改动
- 在 `packages/client/src/api/client.ts` 新增 `getStoredUsername()`，按既有 `getStoredUserRole()` 的方式从 JWT payload 中解出 `username` 字段（服务端 `signUserJwt` 已写入该字段，见 `packages/server/src/middleware/user-auth.ts`）。
- 在 `AppSidebar.vue` 的退出登录按钮内追加一个 `.logout-username` 文案，靠 `margin-left: auto` 推到按钮右侧，超长时省略号截断，并通过 `:title` 提供完整 hover 提示。
- 折叠侧边栏时复用已有的 `.logout-item span { display: none }` 规则自动隐藏，无需额外样式。

## 效果
- 展开态：`[→ 退出登录                <username>]`
- 折叠态：仅剩图标，与原行为一致
- token 缺失或解析失败时 `v-if` 退化为不渲染，不会显示 `null`

