### PR TITLE
修复 Studio MCP 自动注入对 PATH 的依赖

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "socket.io-client": "^4.8.3"
       },
       "bin": {
-        "hermes-web-ui": "bin/hermes-web-ui.mjs"
+        "hermes-web-ui": "bin/hermes-web-ui.mjs",
+        "hermes-web-ui-mcp": "bin/hermes-web-ui-mcp.mjs"
       },
       "devDependencies": {
         "@koa/bodyparser": "^5.0.0",

--- a/packages/server/src/services/hermes/studio-mcp-autoinject.ts
+++ b/packages/server/src/services/hermes/studio-mcp-autoinject.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 import { config } from '../../config'
 import { updateConfigYamlForProfile } from '../config-helpers'
 import { logger } from '../logger'
@@ -35,8 +37,31 @@ function isDesktopRuntime(): boolean {
   return String(process.env.HERMES_DESKTOP || '').trim().toLowerCase() === 'true'
 }
 
-function managedCommand(): string {
-  return isDesktopRuntime() ? 'hermes-studio-mcp' : 'hermes-web-ui-mcp'
+function candidateBundledMcpScripts(): string[] {
+  return [
+    process.env.HERMES_WEB_UI_MCP_BIN,
+    join(process.cwd(), 'bin/hermes-web-ui-mcp.mjs'),
+    join(__dirname, '../../bin/hermes-web-ui-mcp.mjs'),
+    join(__dirname, '../../../../../bin/hermes-web-ui-mcp.mjs'),
+  ].filter((value): value is string => !!value)
+}
+
+function bundledMcpScriptPath(): string | null {
+  return candidateBundledMcpScripts().find(candidate => existsSync(candidate)) || null
+}
+
+function managedCommandConfig(): Record<string, unknown> {
+  if (isDesktopRuntime()) {
+    return { command: 'hermes-studio-mcp' }
+  }
+
+  const bundledScript = bundledMcpScriptPath()
+  if (bundledScript) {
+    return { command: process.execPath, args: [bundledScript] }
+  }
+
+  logger.warn({ candidates: candidateBundledMcpScripts() }, '[mcp-autoinject] bundled MCP script not found; falling back to PATH command')
+  return { command: 'hermes-web-ui-mcp' }
 }
 
 function managedConfig(): Record<string, unknown> {
@@ -48,7 +73,7 @@ function managedConfig(): Record<string, unknown> {
   }
 
   return {
-    command: managedCommand(),
+    ...managedCommandConfig(),
     env,
     enabled: true,
   }
@@ -64,9 +89,18 @@ function isManagedServer(server: unknown): boolean {
   return typeof server.command === 'string' && LEGACY_COMMANDS.has(server.command)
 }
 
+function sameArgs(existing: Record<string, any>, desired: Record<string, unknown>): boolean {
+  const desiredArgs = Array.isArray(desired.args) ? desired.args : undefined
+  const existingArgs = Array.isArray(existing.args) ? existing.args : undefined
+  if (!desiredArgs && !existingArgs) return true
+  if (!desiredArgs || !existingArgs) return false
+  return desiredArgs.length === existingArgs.length && desiredArgs.every((arg, index) => existingArgs[index] === arg)
+}
+
 function sameConfig(existing: Record<string, any>, desired: Record<string, unknown>): boolean {
   const desiredEnv = desired.env as Record<string, string>
   return existing.command === desired.command &&
+    sameArgs(existing, desired) &&
     existing.enabled !== false &&
     isRecord(existing.env) &&
     existing.env.HERMES_WEB_UI_URL === desiredEnv.HERMES_WEB_UI_URL &&

--- a/tests/server/studio-mcp-autoinject.test.ts
+++ b/tests/server/studio-mcp-autoinject.test.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const updateConfigYamlForProfileMock = vi.fn()
@@ -39,7 +40,7 @@ describe('studio MCP autoinject', () => {
     })
   })
 
-  it('injects bundled MCP server into every profile without bridge calls', async () => {
+  it('injects bundled MCP server into every profile without relying on a global PATH shim', async () => {
     const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
 
     const result = await injectBundledMcpServer()
@@ -48,7 +49,8 @@ describe('studio MCP autoinject', () => {
     expect(updateConfigYamlForProfileMock).toHaveBeenCalledTimes(2)
     const injectedDefault = await updateConfigYamlForProfileMock.mock.calls[0][1]({})
     expect(injectedDefault.data.mcp_servers['hermes-studio']).toEqual({
-      command: 'hermes-web-ui-mcp',
+      command: process.execPath,
+      args: [join(process.cwd(), 'bin/hermes-web-ui-mcp.mjs')],
       env: {
         HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
         HERMES_WEB_UI_HOME: '/tmp/hermes-web-ui-home',
@@ -57,6 +59,31 @@ describe('studio MCP autoinject', () => {
       },
       enabled: true,
     })
+    expect(result.command).toBe(process.execPath)
+  })
+
+  it('updates old managed PATH-only MCP entries to the bundled node script', async () => {
+    const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
+
+    await injectBundledMcpServer()
+
+    const updated = await updateConfigYamlForProfileMock.mock.calls[0][1]({
+      mcp_servers: {
+        'hermes-studio': {
+          command: 'hermes-web-ui-mcp',
+          env: {
+            HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
+            HERMES_WEB_UI_HOME: '/tmp/hermes-web-ui-home',
+            HERMES_WEBUI_STATE_DIR: '/tmp/hermes-web-ui-home',
+            HERMES_WEB_UI_MANAGED_MCP: '1',
+          },
+          enabled: true,
+        },
+      },
+    })
+    expect(updated.result.status).toBe('updated')
+    expect(updated.data.mcp_servers['hermes-studio'].command).toBe(process.execPath)
+    expect(updated.data.mcp_servers['hermes-studio'].args).toEqual([join(process.cwd(), 'bin/hermes-web-ui-mcp.mjs')])
   })
 
   it('uses the desktop command in desktop runtime', async () => {


### PR DESCRIPTION
## 改动说明

- 管理型 `hermes-studio` MCP 不再写入裸 `command: hermes-web-ui-mcp`，避免依赖用户 PATH 里的全局 shim。
- 非 Desktop 运行时改为通过当前 Node 可执行文件启动随 Web UI 打包的 `bin/hermes-web-ui-mcp.mjs`：`command: process.execPath` + `args: [bundled script]`。
- `sameConfig` 增加 `args` 比较，让旧的 managed PATH-only 配置在下一次 autoinject 时自动更新。
- Desktop 运行时继续使用现有 `hermes-studio-mcp` shim，不改变桌面版路径。
- 同步 `package-lock.json` 顶层 bin metadata，补齐 `hermes-web-ui-mcp`。

## 背景

如果 Web UI 自动注入 `mcp_servers.hermes-studio.command: hermes-web-ui-mcp`，但本机 PATH 中不存在这个 shim，Hermes MCP reload 会报 `No such file or directory: 'hermes-web-ui-mcp'`，并导致 Studio MCP tools 不可用。

这类失败在源码运行、本地包运行，或全局 `hermes-web-ui` 版本较旧时容易出现。因为 `hermes-studio` 是 Web UI 自带的 managed MCP server，Web UI 可以写入自包含的 Node + script 配置，而不应依赖外部全局 PATH。

## 验证

- `npm test -- tests/server/studio-mcp-autoinject.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run build`
- `git diff --check`
- independent review: passed

## 关联

- 与 #1205 互补：#1205 处理 agent bridge 对任意第三方 stdio MCP CLI 的 PATH 增强；本 PR 只修复 Web UI 自带的 managed `hermes-studio` MCP 配置。