### PR TITLE
fix(files): 对齐 file list columns

### DIFF
--- a/packages/client/src/components/hermes/files/FileList.vue
+++ b/packages/client/src/components/hermes/files/FileList.vue
@@ -82,7 +82,7 @@ async function handleDownload(entry: FileEntry) {
     <NSpin :show="filesStore.loading">
       <NEmpty v-if="!filesStore.loading && filesStore.sortedEntries.length === 0" :description="t('files.emptyDir')" />
       <div v-else class="file-list-items">
-        <div class="file-list-header">
+        <div class="file-list-header file-list-grid">
           <div class="file-name sort-header" @click="filesStore.setSort('name')">
             {{ t('files.name') }}
             <span v-if="filesStore.sortBy === 'name'" class="sort-indicator">{{ filesStore.sortOrder === 'asc' ? '↑' : '↓' }}</span>
@@ -100,13 +100,13 @@ async function handleDownload(entry: FileEntry) {
         <div
           v-for="entry in filesStore.sortedEntries"
           :key="entry.path"
-          class="file-list-row"
+          class="file-list-row file-list-grid"
           @dblclick="handleDoubleClick(entry)"
           @contextmenu="handleContextMenu($event, entry)"
         >
           <div class="file-name">
             <span class="file-icon">{{ getFileIcon(entry) }}</span>
-            <span>{{ entry.name }}</span>
+            <span class="file-label">{{ entry.name }}</span>
           </div>
           <div class="file-size">{{ entry.isDir ? '—' : formatSize(entry.size) }}</div>
           <div class="file-date">{{ formatDate(entry.modTime) }}</div>
@@ -128,11 +128,15 @@ async function handleDownload(entry: FileEntry) {
   padding: 8px 16px;
 }
 
-.file-list-header {
-  display: flex;
+.file-list-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 80px 160px 60px;
   align-items: center;
+  column-gap: 16px;
+}
+
+.file-list-header {
   padding: 6px 12px;
-  gap: 16px;
   font-size: 12px;
   font-weight: 500;
   color: $text-muted;
@@ -155,17 +159,13 @@ async function handleDownload(entry: FileEntry) {
 }
 
 .file-actions-placeholder {
-  width: 60px;
-  flex-shrink: 0;
+  min-width: 0;
 }
 
 .file-list-row {
-  display: flex;
-  align-items: center;
   padding: 8px 12px;
   border-radius: $radius-sm;
   cursor: pointer;
-  gap: 16px;
   font-size: 13px;
 
   &:hover {
@@ -178,43 +178,47 @@ async function handleDownload(entry: FileEntry) {
 }
 
 .file-name {
-  flex: 1;
   display: flex;
   align-items: center;
   gap: 8px;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .file-icon {
   flex-shrink: 0;
 }
 
+.file-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .file-size {
-  width: 80px;
   text-align: right;
   color: $text-secondary;
-  flex-shrink: 0;
 }
 
 .file-date {
-  width: 160px;
   color: $text-secondary;
-  flex-shrink: 0;
 }
 
 .file-actions {
   opacity: 0;
   transition: opacity $transition-fast;
   display: flex;
+  justify-content: flex-end;
   gap: 4px;
-  flex-shrink: 0;
 }
 
 @media (max-width: $breakpoint-mobile) {
-  .file-size, .file-date {
+  .file-list-grid {
+    grid-template-columns: minmax(0, 1fr) 60px;
+  }
+
+  .file-size,
+  .file-date {
     display: none;
   }
 }

--- a/tests/client/file-list-layout.test.ts
+++ b/tests/client/file-list-layout.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import FileList from '@/components/hermes/files/FileList.vue'
+import { useFilesStore } from '@/stores/hermes/files'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NButton: { template: '<button type="button" v-bind="$attrs"><slot /></button>' },
+  NSpin: { props: ['show'], template: '<div><slot /></div>' },
+  NEmpty: { props: ['description'], template: '<div class="empty">{{ description }}</div>' },
+  useMessage: () => ({ error: vi.fn() }),
+}))
+
+describe('FileList layout', () => {
+  beforeEach(() => {
+    createTestingPinia({ stubActions: false, createSpy: vi.fn })
+  })
+
+  it('uses the same column grid for header and rows', () => {
+    const store = useFilesStore()
+    store.entries = [
+      {
+        name: 'very-long-file-name-that-should-not-push-size-or-date-columns.md',
+        path: '/workspace/very-long-file-name-that-should-not-push-size-or-date-columns.md',
+        isDir: false,
+        size: 2048,
+        modTime: '2026-06-06T08:00:00.000Z',
+      },
+    ]
+
+    const wrapper = mount(FileList)
+
+    expect(wrapper.find('.file-list-header').classes()).toContain('file-list-grid')
+    expect(wrapper.find('.file-list-row').classes()).toContain('file-list-grid')
+    expect(wrapper.find('.file-name .file-label').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## 改动
- 通过共享 grid class 对齐 workspace file list 的 header 和 row columns。
- 防止 name / size / modified / actions 四列在 header 与文件行之间漂移。
- 增加聚焦的布局回归测试。

## Issue
Refs #1365

## 验证
- PASS: `npm test -- tests/client/file-list-layout.test.ts`
- PASS: `npm run build`
- PASS: `git diff --check origin/main..HEAD`

## UAT
- 已在最新 `origin/main` rebase 后通过：使用临时 Web UI/Hermes home 启动 production build，打开 `/hermes/files`，放入长文件名 fixture，并验证 header 与 file row 的 computed grid columns 一致（`556px 80px 160px 60px`）。
- 截图 artifact：`uat-1365-files.png`。

## Scope
- 只改 UI layout。
- 不改 file API、upload/download、workspace data model 或 backend 行为。
