### PR TITLE
fix(markdown): inline 渲染本地 audio links

### DIFF
--- a/docs/chat-chain-changes/2026-06-06-pr1377-inline-audio-links.md
+++ b/docs/chat-chain-changes/2026-06-06-pr1377-inline-audio-links.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-06
+pr: 1377
+feature: Markdown 音频链接内联播放
+impact: Chat markdown 渲染会把本地音频链接显示为内联播放控件，而不是通用文件卡片。
+---
+
+`MarkdownRenderer` 现在将音频扩展名单独分类；`mp3` 等本地音频附件会渲染为内联 `<audio>` 控件，不再落到通用文件卡片路径。

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -134,6 +134,15 @@ function normalizeLocalFilePath(path: string): string {
   return /^[a-zA-Z]:\\/.test(path) ? path.replace(/\\/g, '/') : path
 }
 
+const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'mov'])
+const AUDIO_EXTENSIONS = new Set(['mp3', 'wav', 'ogg', 'm4a', 'aac', 'flac'])
+
+function hasExtension(path: string, extensions: Set<string>): boolean {
+  const clean = path.split('?')[0].split('#')[0]
+  const ext = clean.split('.').pop()?.toLowerCase()
+  return !!ext && extensions.has(ext)
+}
+
 const renderedHtml = computed(() => {
   let html = md.render(repairNestedMarkdownFences(props.content))
 
@@ -172,16 +181,31 @@ const renderedHtml = computed(() => {
 
     const path = normalizeLocalFilePath(rawPath)
     const fileName = filename.trim()
-    const ext = path.split('.').pop()?.toLowerCase()
 
     // Video files: render as video player
-    if (ext === 'mp4' || ext === 'webm' || ext === 'mov') {
+    if (hasExtension(path, VIDEO_EXTENSIONS)) {
       const downloadUrl = getDownloadUrl(path)
       return `<div class="markdown-video-container">
         <video class="markdown-video" controls preload="metadata" src="${downloadUrl}"></video>
         <div class="markdown-video-footer">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
             <polygon points="5 3 19 12 5 21 5 3"/>
+          </svg>
+          <span class="att-name">${fileName}</span>
+        </div>
+      </div>`
+    }
+
+    // Audio files: render as inline audio player
+    if (hasExtension(path, AUDIO_EXTENSIONS)) {
+      const downloadUrl = getDownloadUrl(path)
+      return `<div class="markdown-audio-container">
+        <audio class="markdown-audio" controls preload="metadata" src="${downloadUrl}"></audio>
+        <div class="markdown-audio-footer">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+            <path d="M9 18V5l12-2v13" />
+            <circle cx="6" cy="18" r="3" />
+            <circle cx="18" cy="16" r="3" />
           </svg>
           <span class="att-name">${fileName}</span>
         </div>
@@ -581,6 +605,36 @@ function closeTextPreview(): void {
     padding: 8px 12px;
     background: rgba(0, 0, 0, 0.85);
     color: #fff;
+    font-size: 12px;
+
+    .att-name {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .markdown-audio-container {
+    margin: 12px 0;
+    padding: 10px 12px;
+    border: 1px solid $border-light;
+    border-radius: $radius-sm;
+    background-color: rgba(0, 0, 0, 0.04);
+  }
+
+  .markdown-audio {
+    display: block;
+    width: 100%;
+    max-width: 420px;
+  }
+
+  .markdown-audio-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 6px;
+    color: $text-secondary;
     font-size: 12px;
 
     .att-name {

--- a/tests/client/markdown-rendering.test.ts
+++ b/tests/client/markdown-rendering.test.ts
@@ -267,6 +267,24 @@ describe('MarkdownRenderer', () => {
     expect(wrapper.find('.markdown-video-footer .att-name').text()).toBe('录屏2026-05-08 15.19.46.mov')
   })
 
+  it('renders local mp3 links as inline audio players', () => {
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: '[song.mp3](/tmp/song.mp3)',
+      },
+    })
+
+    const audio = wrapper.find('audio.markdown-audio')
+    expect(audio.exists()).toBe(true)
+    expect(audio.attributes('controls')).toBeDefined()
+    expect(audio.attributes('preload')).toBe('metadata')
+    expect(audio.attributes('src')).toContain('/api/hermes/download?path=')
+    const src = new URL(audio.attributes('src'))
+    expect(decodeURIComponent(src.searchParams.get('path') || '')).toBe('/tmp/song.mp3')
+    expect(wrapper.find('.markdown-audio-footer .att-name').text()).toBe('song.mp3')
+    expect(wrapper.find('.markdown-file-card').exists()).toBe(false)
+  })
+
   it('renders MSYS-style Windows image paths through the download endpoint', () => {
     const wrapper = mount(MarkdownRenderer, {
       props: {


### PR DESCRIPTION
## 改动
- 将本地 audio attachment 渲染为带 `controls` / `preload="metadata"` 的 inline `<audio>`，不再只显示 downloadable file card。
- 保留现有 download URL 路径，并保持非本地 link 处理不变。
- 增加 Markdown renderer 对本地 `.mp3` attachment 的回归覆盖。

## Issue
Refs #1204

## 验证
- PASS: `npm test -- tests/client/markdown-rendering.test.ts`
- PASS: `npm run build`
- PASS: `git diff --check origin/main..HEAD`

## UAT
- 已在最新 `origin/main` rebase 后通过：使用临时 Web UI/Hermes home 启动 production build，打开包含 `[song.mp3](/tmp/song.mp3)` 的本地 session，并验证它渲染为 `audio.markdown-audio`，带 controls，且仍使用现有 `/api/hermes/download?path=` route。
- 截图 artifact：`uat-1204-audio.png`。

## Scope
- 只改 Markdown attachment rendering。
- 不改 upload、download endpoint、backend file serving 或 chat runtime 行为。
