### PR TITLE
fix(sidebar): 将 Memory 移到 Conversation group

### DIFF
--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -119,6 +119,14 @@ function openChangelog() {
             </svg>
             <span>{{ t("sidebar.history") }}</span>
           </RouteLinkItem>
+          <RouteLinkItem class="nav-item" :to="{ name: 'hermes.memory' }" :active="selectedKey === 'hermes.memory'">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M9 18h6" />
+              <path d="M10 22h4" />
+              <path d="M12 2a7 7 0 0 0-4 12.7V17h8v-2.3A7 7 0 0 0 12 2z" />
+            </svg>
+            <span>{{ t("sidebar.memory") }}</span>
+          </RouteLinkItem>
           <RouteLinkItem class="nav-item" :to="{ name: 'hermes.groupChat' }" :active="isNavActive('hermes.groupChat', 'hermes.groupChatRoom')">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
               <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
@@ -197,14 +205,6 @@ function openChangelog() {
               <rect x="4" y="7" width="16" height="7" rx="2" />
             </svg>
             <span>{{ t("sidebar.mcp") }}</span>
-          </RouteLinkItem>
-          <RouteLinkItem class="nav-item" :to="{ name: 'hermes.memory' }" :active="selectedKey === 'hermes.memory'">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M9 18h6" />
-              <path d="M10 22h4" />
-              <path d="M12 2a7 7 0 0 0-4 12.7V17h8v-2.3A7 7 0 0 0 12 2z" />
-            </svg>
-            <span>{{ t("sidebar.memory") }}</span>
           </RouteLinkItem>
           <RouteLinkItem class="nav-item" :to="{ name: 'hermes.models' }" :active="selectedKey === 'hermes.models'">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">

--- a/tests/client/sidebar-search.test.ts
+++ b/tests/client/sidebar-search.test.ts
@@ -153,6 +153,29 @@ describe('AppSidebar search entry', () => {
     expect(mockAppStore.reloadClient).toHaveBeenCalledTimes(1)
   })
 
+  it('surfaces Memory with the primary conversation links instead of burying it in Agent', () => {
+    const wrapper = mount(AppSidebar, {
+      global: {
+        stubs: {
+          ProfileSelector: true,
+          ModelSelector: true,
+          LanguageSwitch: true,
+          ThemeSwitch: true,
+          NButton: true,
+        },
+      },
+    })
+
+    const groups = wrapper.findAll('.nav-group')
+    const conversationLinks = groups[0].findAll('.nav-item span').map(node => node.text())
+    const agentLinks = groups[1].findAll('.nav-item span').map(node => node.text())
+
+    expect(conversationLinks).toContain('sidebar.memory')
+    expect(conversationLinks.indexOf('sidebar.memory')).toBeGreaterThan(conversationLinks.indexOf('sidebar.history'))
+    expect(conversationLinks.indexOf('sidebar.memory')).toBeLessThan(conversationLinks.indexOf('sidebar.groupChat(beta)'))
+    expect(agentLinks).not.toContain('sidebar.memory')
+  })
+
   it('uses short group labels and keeps group folding active when collapsed', async () => {
     mockAppStore.sidebarCollapsed = true
     const wrapper = mount(AppSidebar, {


### PR DESCRIPTION
## 改动
- 将 Memory 从 Agent sidebar group 移到 Conversation group。
- 将 Memory 放在 History 之后、Group Chat 之前，提高 discoverability。
- 增加 sidebar grouping/order 回归覆盖。

## Issue
Refs #1346

## 验证
- PASS: `npm test -- tests/client/sidebar-search.test.ts`
- PASS: `npm run build`
- PASS: `git diff --check origin/main..HEAD`

## UAT
- 已在最新 `origin/main` rebase 后通过：使用临时 Web UI/Hermes home 启动 production build，打开 `/hermes/chat`，验证 Memory 出现在 Conversation sidebar group，并且不再出现在 Agent group。
- 截图 artifact：`uat-1346-sidebar.png`。

## Scope
- 只改 sidebar grouping/discoverability。
- 不改 route、backend、permissions 或 Memory 实现。
