### PR TITLE
[codex] refine sidebar logout username

### DIFF
--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -53,6 +53,20 @@ export function isStoredSuperAdmin(): boolean {
   return getStoredUserRole() === 'super_admin'
 }
 
+export function getStoredUsername(): string | null {
+  const token = getApiKey()
+  const payload = token.split('.')[1]
+  if (!payload) return null
+  try {
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
+    const data = JSON.parse(atob(padded)) as { username?: unknown }
+    return typeof data.username === 'string' && data.username.length > 0 ? data.username : null
+  } catch {
+    return null
+  }
+}
+
 export function getActiveProfileName(): string | null {
   return localStorage.getItem('hermes_active_profile_name')
 }

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -12,7 +12,7 @@ import { useSessionSearch } from '@/composables/useSessionSearch'
 import { usePersistentRecord } from '@/composables/usePersistentRecord'
 import RouteLinkItem from '@/components/common/RouteLinkItem.vue'
 import { changelog } from "@/data/changelog";
-import { isStoredSuperAdmin } from "@/api/client";
+import { isStoredSuperAdmin, getStoredUsername } from "@/api/client";
 
 const { t } = useI18n();
 const message = useMessage();
@@ -27,6 +27,7 @@ const selectedKey = computed(() => {
   return route.name as string;
 });
 const isSuperAdmin = computed(() => isStoredSuperAdmin());
+const currentUsername = computed(() => getStoredUsername());
 const isVersionPreview = import.meta.env.VITE_HERMES_PREVIEW === '1';
 
 function isNavActive(...names: string[]) {
@@ -345,6 +346,7 @@ function openChangelog() {
           <line x1="21" y1="12" x2="9" y2="12" />
         </svg>
         <span>{{ t("sidebar.logout") }}</span>
+        <span v-if="currentUsername" class="logout-username" :title="currentUsername">{{ currentUsername }}</span>
       </button>
       <div class="status-row">
         <div
@@ -581,6 +583,16 @@ function openChangelog() {
   &:hover {
     color: $error;
     background: rgba(var(--error-rgb, 239, 68, 68), 0.06);
+  }
+
+  .logout-username {
+    margin-left: auto;
+    max-width: 140px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 12px;
+    color: $text-muted;
   }
 }
 

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -71,7 +71,7 @@ function handleReloadClient() {
 
 function handleLogout() {
   localStorage.clear();
-  router.replace({ name: 'login' });
+  window.location.reload();
 }
 
 // Changelog
@@ -580,6 +580,11 @@ function openChangelog() {
   font-size: 13px;
   color: $text-muted;
 
+  > svg,
+  > span:not(.logout-username) {
+    flex-shrink: 0;
+  }
+
   &:hover {
     color: $error;
     background: rgba(var(--error-rgb, 239, 68, 68), 0.06);
@@ -587,10 +592,14 @@ function openChangelog() {
 
   .logout-username {
     margin-left: auto;
-    max-width: 140px;
+    width: 96px;
+    min-width: 0;
+    max-width: 40%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    text-align: right;
+    flex: 0 1 96px;
     font-size: 12px;
     color: $text-muted;
   }


### PR DESCRIPTION
## Summary
- Show the current username next to the sidebar logout button from the JWT payload
- Keep the username in a fixed right-aligned area with ellipsis so it does not squeeze the logout label
- Reload the page after logout so in-memory Pinia state is cleared

## Validation
- `npm run build`
- `npm run harness:check`

Refs #1372
