### PR TITLE
Scope Web UI agent bridge endpoint to runtime home

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ These variables configure Hermes Web UI, its local Hermes runtime integration, a
 | `HERMES_AGENT_BRIDGE_UV` | auto-discovered | `uv` executable used to launch the agent bridge when available. |
 | `UV` | auto-discovered | Fallback `uv` executable path. |
 | `PYTHON` | auto-discovered | Fallback Python executable for the agent bridge. |
-| `HERMES_AGENT_BRIDGE_ENDPOINT` | platform default | Agent bridge broker endpoint. Windows defaults to `tcp://127.0.0.1:18765`; macOS/Linux defaults to `ipc:///tmp/hermes-agent-bridge.sock`. |
+| `HERMES_AGENT_BRIDGE_ENDPOINT` | runtime-home scoped default | Explicit agent bridge broker endpoint override. If unset, Web UI derives an endpoint from `HERMES_WEB_UI_HOME` to avoid cross-instance bridge attachment. |
 | `HERMES_AGENT_BRIDGE_TIMEOUT_MS` | `120000` | Timeout for Node requests to the bridge broker. |
 | `HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS` | `5000` | Short retry window for connecting to the bridge socket. |
 | `HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS` | `120000` | Timeout while waiting for the Python bridge to become ready. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -269,7 +269,7 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `HERMES_AGENT_BRIDGE_UV` | 自动发现 | 可用时用于启动 agent bridge 的 `uv` 可执行文件。 |
 | `UV` | 自动发现 | `uv` 可执行文件 fallback。 |
 | `PYTHON` | 自动发现 | agent bridge 的 Python 可执行文件 fallback。 |
-| `HERMES_AGENT_BRIDGE_ENDPOINT` | 平台默认值 | Agent bridge broker endpoint。Windows 默认 `tcp://127.0.0.1:18765`；macOS/Linux 默认 `ipc:///tmp/hermes-agent-bridge.sock`。 |
+| `HERMES_AGENT_BRIDGE_ENDPOINT` | 运行目录派生默认值 | 显式 agent bridge broker endpoint 覆盖；未设置时 Web UI 会从 `HERMES_WEB_UI_HOME` 派生 endpoint，避免跨实例 bridge 串接。 |
 | `HERMES_AGENT_BRIDGE_TIMEOUT_MS` | `120000` | Node 请求 bridge broker 的响应超时。 |
 | `HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS` | `5000` | 连接 bridge socket 失败时的短重试窗口。 |
 | `HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS` | `120000` | 等待 Python bridge ready 的超时。 |

--- a/README_zh.md
+++ b/README_zh.md
@@ -269,7 +269,7 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `HERMES_AGENT_BRIDGE_UV` | 自动发现 | 可用时用于启动 agent bridge 的 `uv` 可执行文件。 |
 | `UV` | 自动发现 | `uv` 可执行文件 fallback。 |
 | `PYTHON` | 自动发现 | agent bridge 的 Python 可执行文件 fallback。 |
-| `HERMES_AGENT_BRIDGE_ENDPOINT` | 运行目录派生默认值 | 显式 agent bridge broker endpoint 覆盖；未设置时 Web UI 会从 `HERMES_WEB_UI_HOME` 派生 endpoint，避免跨实例 bridge 串接。 |
+| `HERMES_AGENT_BRIDGE_ENDPOINT` | 运行目录派生默认值 | 显式覆盖 Agent Bridge 代理地址；未设置时 Web UI 会从 `HERMES_WEB_UI_HOME` 派生地址，避免跨实例串接到同一个 bridge。 |
 | `HERMES_AGENT_BRIDGE_TIMEOUT_MS` | `120000` | Node 请求 bridge broker 的响应超时。 |
 | `HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS` | `5000` | 连接 bridge socket 失败时的短重试窗口。 |
 | `HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS` | `120000` | 等待 Python bridge ready 的超时。 |

--- a/docs/chat-chain-changes/2026-06-07-pr1389-agent-bridge-endpoint-scope.md
+++ b/docs/chat-chain-changes/2026-06-07-pr1389-agent-bridge-endpoint-scope.md
@@ -6,3 +6,5 @@ impact: Web UI-managed bridge brokers now derive their default endpoint from the
 ---
 
 The explicit `HERMES_AGENT_BRIDGE_ENDPOINT` override remains supported. Windows Web UI-managed broker defaults use a runtime-home-derived port range below Version Preview and worker endpoint ranges.
+
+中文摘要：Web UI 管理的 Agent Bridge 默认地址现在从运行目录派生，不再复用全局 socket 或固定 Windows 端口；显式 `HERMES_AGENT_BRIDGE_ENDPOINT` 覆盖仍然生效。

--- a/docs/chat-chain-changes/2026-06-07-pr1389-agent-bridge-endpoint-scope.md
+++ b/docs/chat-chain-changes/2026-06-07-pr1389-agent-bridge-endpoint-scope.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-07
+pr: 1389
+feature: Agent Bridge endpoint isolation
+impact: Web UI-managed bridge brokers now derive their default endpoint from the Web UI runtime home to avoid cross-instance broker attachment.
+---
+
+The explicit `HERMES_AGENT_BRIDGE_ENDPOINT` override remains supported. Windows Web UI-managed broker defaults use a runtime-home-derived port range below Version Preview and worker endpoint ranges.

--- a/docs/cli-chat-sessions.md
+++ b/docs/cli-chat-sessions.md
@@ -453,12 +453,12 @@ for await (const chunk of bridge.streamOutput(run_id)) {
 python hermes_bridge.py --endpoint <endpoint> --agent-root <root> --hermes-home <home>
 ```
 
-默认 endpoint：
+Web UI 管理的默认 endpoint：
 
 | 平台 | 默认 |
 | --- | --- |
-| Windows | `tcp://127.0.0.1:18765` |
-| macOS/Linux | `ipc:///tmp/hermes-agent-bridge.sock` |
+| Windows | 从 `HERMES_WEB_UI_HOME` 派生的 `tcp://127.0.0.1:<port>` |
+| macOS/Linux | `ipc://<HERMES_WEB_UI_HOME>/agent-bridge.sock` |
 
 broker 会再按 profile 路由到 worker。worker 里维护实际 `AIAgent` 会话池。
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -22,6 +22,9 @@ import { homedir } from 'os'
  * Runtime behavior:
  * - PROFILE: Initial Hermes profile name. Default: default.
  * - GATEWAY_HOST: Default gateway host written into profile config. Default: 127.0.0.1.
+ * - HERMES_AGENT_BRIDGE_ENDPOINT: Explicit agent bridge endpoint override. If unset,
+ *   Web UI uses an endpoint scoped to HERMES_WEB_UI_HOME to avoid cross-instance
+ *   bridge attachment.
  * - HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN: Whether Web UI shutdown also stops gateways.
  * - HERMES_LAN_DISCOVERY_ENABLED: Set false/0/off to disable UDP LAN discovery responder.
  * - HERMES_LAN_DISCOVERY_HTTP_PORTS: HTTP ports to probe during UDP discovery scans. Default: 8648,8748 plus current PORT.

--- a/packages/server/src/services/hermes/agent-bridge/README.md
+++ b/packages/server/src/services/hermes/agent-bridge/README.md
@@ -11,19 +11,16 @@ This is intentionally separate from the current Web UI chat path.
 python packages/server/src/services/hermes/agent-bridge/hermes_bridge.py
 ```
 
-Default endpoint:
+When launched by the Web UI server, Node passes an explicit endpoint to the
+Python bridge:
 
-```text
-ipc:///tmp/hermes-agent-bridge.sock
-```
+- Unix-like platforms: `ipc://<HERMES_WEB_UI_HOME>/agent-bridge.sock`
+- Windows: `tcp://127.0.0.1:<port>`, where `<port>` is derived from
+  `HERMES_WEB_UI_HOME` in the 16650-17649 range
 
-On Windows, the default endpoint is TCP because Python may not support Unix
-domain sockets there:
-
-```text
-tcp://127.0.0.1:18765
-```
-
+This Web UI-managed endpoint is scoped to the runtime home so separate instances
+do not attach to each other's bridge broker. Directly running this Python script
+without `--endpoint` still uses the script's standalone fallback endpoint.
 Override with:
 
 ```bash

--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -1,21 +1,41 @@
 import { setTimeout as delay } from 'timers/promises'
 import { createConnection, type Socket } from 'net'
+import { createHash } from 'crypto'
 import { tmpdir } from 'os'
 import { URL } from 'url'
 import { join } from 'path'
+import { getWebUiHome } from '../../../config'
 import { bridgeLogger } from '../../logger'
 import { getActiveProfileName, getProfileDir } from '../hermes-profile'
 import type { McpActionResponse } from '../mcp-types'
 
-function resolveDefaultAgentBridgeEndpoint(): string {
-  if (process.env.VITEST) {
-    return process.platform === 'win32'
-      ? `tcp://127.0.0.1:${28000 + (process.pid % 10000)}`
-      : `ipc://${join(tmpdir(), `hermes-agent-bridge-test-${process.pid}.sock`)}`
+export function resolveDefaultAgentBridgeEndpoint(
+  env: Record<string, string | undefined> = process.env,
+  platform = process.platform,
+  pid = process.pid,
+): string {
+  if (env.VITEST) {
+    return platform === 'win32'
+      ? `tcp://127.0.0.1:${28000 + (pid % 10000)}`
+      : `ipc://${join(tmpdir(), `hermes-agent-bridge-test-${pid}.sock`)}`
   }
-  return process.platform === 'win32'
-    ? 'tcp://127.0.0.1:18765'
-    : 'ipc:///tmp/hermes-agent-bridge.sock'
+
+  const webUiHome = getWebUiHome(env)
+  if (platform === 'win32') {
+    // Windows uses TCP for the bridge.  Scope the default port to the Web UI
+    // home so multiple Web UI runtimes do not silently attach to each other's
+    // broker on the historic fixed port. Keep this range below both the
+    // Version Preview broker port (18650) and the default worker TCP range
+    // (18780-19779) so the main broker cannot collide with either endpoint.
+    const hash = createHash('sha256').update(webUiHome).digest().readUInt16BE(0)
+    return `tcp://127.0.0.1:${16650 + (hash % 1000)}`
+  }
+
+  // Keep the broker endpoint under the Web UI runtime home, not global /tmp.
+  // A global socket lets unrelated Web UI previews or Hermes bridge processes
+  // attach to each other after restarts/reloads, which can surface as opaque
+  // bridge errors from the wrong broker.
+  return `ipc://${join(webUiHome, 'agent-bridge.sock')}`
 }
 
 export const DEFAULT_AGENT_BRIDGE_ENDPOINT = resolveDefaultAgentBridgeEndpoint()

--- a/packages/website/src/i18n/en.ts
+++ b/packages/website/src/i18n/en.ts
@@ -226,7 +226,7 @@ export default {
           ['HERMES_AGENT_BRIDGE_UV', 'uv executable used to launch the agent bridge when available'],
           ['UV', 'Fallback uv executable path'],
           ['PYTHON', 'Fallback Python executable for the agent bridge'],
-          ['HERMES_AGENT_BRIDGE_ENDPOINT', 'Agent bridge broker endpoint. Windows defaults to tcp://127.0.0.1:18765; macOS/Linux defaults to ipc:///tmp/hermes-agent-bridge.sock'],
+          ['HERMES_AGENT_BRIDGE_ENDPOINT', 'Explicit agent bridge broker endpoint override. If unset, Web UI derives a runtime-home-scoped endpoint to avoid cross-instance bridge attachment'],
           ['HERMES_AGENT_BRIDGE_TIMEOUT_MS', 'Timeout for Node requests to the bridge broker'],
           ['HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS', 'Short retry window for connecting to the bridge socket'],
           ['HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS', 'Timeout while waiting for the Python bridge to become ready'],

--- a/packages/website/src/i18n/zh.ts
+++ b/packages/website/src/i18n/zh.ts
@@ -226,7 +226,7 @@ export default {
           ['HERMES_AGENT_BRIDGE_UV', '可用时用于启动 agent bridge 的 uv 可执行文件'],
           ['UV', 'uv 可执行文件 fallback'],
           ['PYTHON', 'agent bridge 的 Python 可执行文件 fallback'],
-          ['HERMES_AGENT_BRIDGE_ENDPOINT', 'Agent bridge broker endpoint。Windows 默认 tcp://127.0.0.1:18765；macOS/Linux 默认 ipc:///tmp/hermes-agent-bridge.sock'],
+          ['HERMES_AGENT_BRIDGE_ENDPOINT', '显式 agent bridge broker endpoint 覆盖；未设置时 Web UI 会按运行目录派生 endpoint，避免跨实例 bridge 串接'],
           ['HERMES_AGENT_BRIDGE_TIMEOUT_MS', 'Node 请求 bridge broker 的响应超时'],
           ['HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS', '连接 bridge socket 失败时的短重试窗口'],
           ['HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS', '等待 Python bridge ready 的超时'],

--- a/packages/website/src/i18n/zh.ts
+++ b/packages/website/src/i18n/zh.ts
@@ -226,7 +226,7 @@ export default {
           ['HERMES_AGENT_BRIDGE_UV', '可用时用于启动 agent bridge 的 uv 可执行文件'],
           ['UV', 'uv 可执行文件 fallback'],
           ['PYTHON', 'agent bridge 的 Python 可执行文件 fallback'],
-          ['HERMES_AGENT_BRIDGE_ENDPOINT', '显式 agent bridge broker endpoint 覆盖；未设置时 Web UI 会按运行目录派生 endpoint，避免跨实例 bridge 串接'],
+          ['HERMES_AGENT_BRIDGE_ENDPOINT', '显式覆盖 Agent Bridge 代理地址；未设置时 Web UI 会按运行目录派生地址，避免跨实例串接到同一个 bridge'],
           ['HERMES_AGENT_BRIDGE_TIMEOUT_MS', 'Node 请求 bridge broker 的响应超时'],
           ['HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS', '连接 bridge socket 失败时的短重试窗口'],
           ['HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS', '等待 Python bridge ready 的超时'],
@@ -256,7 +256,7 @@ export default {
       },
       gateway: {
         title: 'Agent Bridge 运行时',
-        content: '聊天运行通过 Hermes agent bridge 处理。它随 Hermes Studio 服务一起运行，并直接连接 Hermes Agent runtime。HERMES_AGENT_BRIDGE_ENDPOINT 控制 Node 与 bridge broker 的连接地址；HERMES_AGENT_BRIDGE_WORKER_TRANSPORT 控制 broker 与各 Profile worker 的连接方式。前端切换 Hermes Profile 只影响后续请求上下文，不会重启 bridge 或清理其他正在运行的任务。',
+        content: '聊天运行通过 Hermes Agent Bridge 处理。它随 Hermes Studio 服务一起运行，并直接连接 Hermes Agent 运行时。HERMES_AGENT_BRIDGE_ENDPOINT 控制 Node 到 bridge broker 的连接地址；HERMES_AGENT_BRIDGE_WORKER_TRANSPORT 控制 broker 到各 Profile worker 的连接方式。前端切换 Hermes Profile 只影响后续请求上下文，不会重启 bridge 或清理其他正在运行的任务。',
       },
       profiles: {
         title: '配置文件',

--- a/tests/server/agent-bridge-manager.test.ts
+++ b/tests/server/agent-bridge-manager.test.ts
@@ -122,6 +122,54 @@ describe('agent bridge manager command resolution', () => {
     expect(DEFAULT_AGENT_BRIDGE_ENDPOINT).not.toBe('ipc:///tmp/hermes-agent-bridge.sock')
   })
 
+  it('scopes the non-test Unix default bridge endpoint to the Web UI home', async () => {
+    const homeDir = join(tempDir, 'webui-home')
+    const { resolveDefaultAgentBridgeEndpoint } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+
+    const endpoint = resolveDefaultAgentBridgeEndpoint({ HERMES_WEB_UI_HOME: homeDir }, 'darwin', 12345)
+
+    expect(endpoint).toBe(`ipc://${join(homeDir, 'agent-bridge.sock')}`)
+    expect(endpoint).not.toBe('ipc:///tmp/hermes-agent-bridge.sock')
+  })
+
+  it('honors the legacy Web UI state dir alias when deriving the default bridge endpoint', async () => {
+    const homeDir = join(tempDir, 'legacy-webui-home')
+    const { resolveDefaultAgentBridgeEndpoint } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+
+    const endpoint = resolveDefaultAgentBridgeEndpoint({ HERMES_WEBUI_STATE_DIR: homeDir }, 'darwin', 12345)
+
+    expect(endpoint).toBe(`ipc://${join(homeDir, 'agent-bridge.sock')}`)
+  })
+
+  it('scopes the non-test Windows default bridge endpoint by Web UI home', async () => {
+    const { resolveDefaultAgentBridgeEndpoint } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+
+    const first = resolveDefaultAgentBridgeEndpoint({ HERMES_WEB_UI_HOME: 'C:\\Hermes\\one' }, 'win32', 12345)
+    const second = resolveDefaultAgentBridgeEndpoint({ HERMES_WEB_UI_HOME: 'C:\\Hermes\\two' }, 'win32', 12345)
+    const firstPort = Number(new URL(first).port)
+    const secondPort = Number(new URL(second).port)
+
+    expect(first).toMatch(/^tcp:\/\/127\.0\.0\.1:\d+$/)
+    expect(second).toMatch(/^tcp:\/\/127\.0\.0\.1:\d+$/)
+    expect(first).not.toBe(second)
+    expect(first).not.toBe('tcp://127.0.0.1:18765')
+    expect(first).not.toBe('tcp://127.0.0.1:18650')
+    expect(second).not.toBe('tcp://127.0.0.1:18650')
+    expect(firstPort).toBeGreaterThanOrEqual(16650)
+    expect(firstPort).toBeLessThan(17650)
+    expect(secondPort).toBeGreaterThanOrEqual(16650)
+    expect(secondPort).toBeLessThan(17650)
+  })
+
+  it('still honors an explicit bridge endpoint override in the client', async () => {
+    process.env.HERMES_AGENT_BRIDGE_ENDPOINT = 'ipc:///tmp/explicit-agent-bridge.sock'
+    const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+
+    const client = new AgentBridgeClient()
+
+    expect(client.endpoint).toBe('ipc:///tmp/explicit-agent-bridge.sock')
+  })
+
   it('honors the bridge connect retry environment override', async () => {
     process.env.HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS = '120000'
 


### PR DESCRIPTION
## Summary

- 将 Web UI 管理的默认 Agent Bridge endpoint 从全局 socket / 固定端口改为按 `HERMES_WEB_UI_HOME` scoped 的 runtime endpoint，避免多个实例/preview 互相串到同一个 bridge。
- 保留显式 `HERMES_AGENT_BRIDGE_ENDPOINT` override；Windows 默认 broker 端口改为从 Web UI home 派生的 `16650..17649`，避开 Version Preview broker `18650` 和默认 worker 端口段 `18780..19779`。
- 补充 manager 测试，并同步 README/docs/website i18n，区分 Web UI-managed endpoint 与直接运行 Python bridge 脚本的 standalone fallback。

## Verification

- `npm test -- --run tests/server/agent-bridge-manager.test.ts` → passed, 14/14 tests
- `npm test -- --run tests/server/agent-bridge-python-concurrency.test.ts` → passed, 15/15 tests
- `npx tsc --noEmit -p packages/server/tsconfig.json` → passed
- `npm run build:website` → passed
- Production-like isolated runtime smoke: `/health` OK；默认 endpoint 落到 isolated Web UI home 下的 `agent-bridge.sock`；`ping`、`worker_ping`、`context_estimate`、`chat` bridge requests 均返回 OK。
- Independent review: PASS；无 blocker。已特别复核 Windows broker/worker/Version Preview 端口段不冲突，以及 README 对直接运行 Python bridge 的说明不再误导。

## Notes

这只修复 Agent Bridge endpoint isolation，不包含 voice/STT/TTS UI 改动。
