### PR TITLE
fix: resolve custom provider name without custom: prefix

### DIFF
--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -319,6 +319,19 @@ async function buildAvailableForProfile(
           && cp.model === currentDefault,
       )
       if (match) currentDefaultProvider = providerKeyForCustom(String(match.name || ''))
+    } else if (currentDefaultProvider && !currentDefaultProvider.startsWith('custom:')) {
+      // If the provider isn't a builtin key and doesn't already have the custom:
+      // prefix, try to match it against custom_providers[].name.  This handles
+      // the common case of `provider: qwen3` (without the custom: prefix) that
+      // tools like cc-switch or hand-edited configs produce.
+      const builtinKey = Object.keys(PROVIDER_ENV_MAP).find(k => k.toLowerCase() === currentDefaultProvider.toLowerCase())
+      if (!builtinKey) {
+        const cps = Array.isArray(config.custom_providers) ? config.custom_providers as any[] : []
+        const match = cps.find(
+          (cp: any) => String(cp.name || '').trim().toLowerCase() === currentDefaultProvider.toLowerCase(),
+        )
+        if (match) currentDefaultProvider = providerKeyForCustom(String(match.name || ''))
+      }
     }
   } else if (typeof modelSection === 'string') {
     currentDefault = modelSection.trim()


### PR DESCRIPTION
## Problem

When `model.provider` is set to a bare name like `qwen3` (without the `custom:` prefix), the Web UI backend fails to match it against `custom_providers[].name` because the resolution logic only triggers when `provider === 'custom'`.

This commonly happens when:
- Tools like CC Switch write `provider: qwen3` instead of `provider: custom:qwen3`
- Users hand-edit config.yaml without knowing about the `custom:` prefix convention

**Result:** The new-chat modal falls through to the first available provider (often `copilot`) instead of the user's intended custom provider.

## Fix

Added a fallback path in `buildAvailableForProfile`: if the provider is not a builtin key and doesn't start with `custom:`, match it case-insensitively against `custom_providers[].name` and prepend the `custom:` prefix.

## Changes

- `packages/server/src/controllers/hermes/models.ts` — added custom provider name resolution fallback