### PR TITLE
fix: 避免临时 Studio MCP 自动注入反复触发 reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ These variables configure Hermes Web UI, its local Hermes runtime integration, a
 | `BIND_HOST` | `0.0.0.0` | Web UI bind host. Set `::` explicitly for IPv6. |
 | `HERMES_WEB_UI_HOME` | `~/.hermes-web-ui` | Web UI data home for auth token, credentials, logs, DB, and default uploads. `HERMES_WEBUI_STATE_DIR` is also supported as a compatibility alias. |
 | `HERMES_WEBUI_STATE_DIR` | unset | Compatibility alias for `HERMES_WEB_UI_HOME`. |
+| `HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT` | unset | Disable startup injection of the managed `hermes-studio` MCP server into Hermes profile configs. |
+| `HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT` | unset | Allow managed MCP injection when `HERMES_WEB_UI_HOME` is under a temporary directory, such as Version Preview runtimes. |
 | `UPLOAD_DIR` | `$HERMES_WEB_UI_HOME/upload` | Upload root override. Files are stored below profile-scoped subdirectories. |
 | `CORS_ORIGINS` | same host only | Comma- or space-separated cross-origin allowlist for HTTP, Socket.IO, and WebSocket requests. Set `*` only when you intentionally need legacy wildcard CORS. |
 | `AUTH_TOKEN` | auto-generated | Explicit bearer token. If unset, Web UI creates one under `HERMES_WEB_UI_HOME`. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -252,6 +252,8 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `BIND_HOST` | `0.0.0.0` | Web UI 绑定地址。如需 IPv6，可显式设置为 `::`。 |
 | `HERMES_WEB_UI_HOME` | `~/.hermes-web-ui` | Web UI 数据目录，用于认证 token、登录凭据、日志、数据库和默认上传目录。兼容支持 `HERMES_WEBUI_STATE_DIR` 作为别名。 |
 | `HERMES_WEBUI_STATE_DIR` | 未设置 | `HERMES_WEB_UI_HOME` 的兼容别名。 |
+| `HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT` | 未设置 | 关闭启动时向 Hermes profile 配置自动注入托管的 `hermes-studio` MCP server。 |
+| `HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT` | 未设置 | 当 `HERMES_WEB_UI_HOME` 位于临时目录（例如 Version Preview runtime）时，仍允许托管 MCP 自动注入。 |
 | `UPLOAD_DIR` | `$HERMES_WEB_UI_HOME/upload` | 覆盖上传根目录。文件会保存在按 Profile 隔离的子目录下。 |
 | `CORS_ORIGINS` | 仅同 host | HTTP、Socket.IO、WebSocket 跨源 allowlist，支持逗号或空格分隔。只有明确需要旧版 wildcard CORS 时才设置为 `*`。 |
 | `AUTH_TOKEN` | 自动生成 | 显式指定 bearer token。未设置时，Web UI 会在 `HERMES_WEB_UI_HOME` 下自动生成。 |

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -23,6 +23,8 @@ import { homedir } from 'os'
  * - PROFILE: Initial Hermes profile name. Default: default.
  * - GATEWAY_HOST: Default gateway host written into profile config. Default: 127.0.0.1.
  * - HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN: Whether Web UI shutdown also stops gateways.
+ * - HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT: Disable Hermes Studio MCP config injection.
+ * - HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT: Allow MCP injection when HERMES_WEB_UI_HOME is under a temp dir.
  * - HERMES_LAN_DISCOVERY_ENABLED: Set false/0/off to disable UDP LAN discovery responder.
  * - HERMES_LAN_DISCOVERY_HTTP_PORTS: HTTP ports to probe during UDP discovery scans. Default: 8648,8748 plus current PORT.
  * - WORKSPACE_BASE: Base directory for workspace browsing. Default: /opt/data/workspace.

--- a/packages/server/src/services/hermes/studio-mcp-autoinject.ts
+++ b/packages/server/src/services/hermes/studio-mcp-autoinject.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { config } from '../../config'
 import { updateConfigYamlForProfile } from '../config-helpers'
@@ -28,9 +29,32 @@ export interface BundledMcpInjectionResult {
   targets: BundledMcpInjectionTargetResult[]
 }
 
+function isEnabledEnv(value: string | undefined): boolean {
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase())
+}
+
 function isDisabled(): boolean {
-  const value = String(process.env.HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT || '').trim().toLowerCase()
-  return ['1', 'true', 'yes', 'on'].includes(value)
+  return isEnabledEnv(process.env.HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT)
+}
+
+function allowTransientAutoinject(): boolean {
+  return isEnabledEnv(process.env.HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT)
+}
+
+function normalizedPathPrefix(pathname: string): string {
+  return pathname.replace(/\/+$/, '') + '/'
+}
+
+function isTransientAppHome(appHome: string): boolean {
+  const normalized = normalizedPathPrefix(appHome)
+  const transientRoots = [tmpdir(), '/tmp', '/private/tmp']
+    .filter(Boolean)
+    .map(root => normalizedPathPrefix(root))
+  return transientRoots.some(root => normalized.startsWith(root))
+}
+
+function shouldSkipTransientAutoinject(): boolean {
+  return isTransientAppHome(config.appHome) && !allowTransientAutoinject()
 }
 
 function isDesktopRuntime(): boolean {
@@ -133,6 +157,18 @@ async function injectIntoProfile(profile: string, desired: Record<string, unknow
       }
     }
 
+    if (isRecord(existing) && existing.enabled === false) {
+      return {
+        data: cfg,
+        write: false,
+        result: {
+          profile,
+          status: 'skipped',
+          reason: `existing ${SERVER_NAME} MCP server is disabled by user`,
+        } satisfies BundledMcpInjectionTargetResult,
+      }
+    }
+
     if (sameConfig(existing, desired)) {
       return {
         data: cfg,
@@ -156,6 +192,11 @@ export async function injectBundledMcpServer(): Promise<BundledMcpInjectionResul
 
   if (isDisabled()) {
     logger.info('[mcp-autoinject] disabled by HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT')
+    return result
+  }
+
+  if (shouldSkipTransientAutoinject()) {
+    logger.info({ appHome: config.appHome }, '[mcp-autoinject] skipped for transient Web UI home')
     return result
   }
 

--- a/packages/website/src/i18n/en.ts
+++ b/packages/website/src/i18n/en.ts
@@ -209,6 +209,8 @@ export default {
           ['BIND_HOST', 'Server bind host (default: 0.0.0.0). Set :: explicitly to enable IPv6 listening.'],
           ['HERMES_WEB_UI_HOME', 'Hermes Studio data home for auth token, credentials, logs, DB, and default uploads'],
           ['HERMES_WEBUI_STATE_DIR', 'Compatibility alias for HERMES_WEB_UI_HOME'],
+          ['HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT', 'Disable startup injection of the managed hermes-studio MCP server into Hermes profile configs'],
+          ['HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT', 'Allow managed MCP injection when HERMES_WEB_UI_HOME is under a temporary directory, such as Version Preview runtimes'],
           ['UPLOAD_DIR', 'Custom upload root. Uploaded files are stored below profile-scoped subdirectories.'],
           ['CORS_ORIGINS', 'Cross-origin allowlist for HTTP, Socket.IO, and WebSocket requests (default: same host only; set * only for intentional legacy wildcard CORS)'],
           ['AUTH_TOKEN', 'Custom bearer token; overrides the auto-generated token'],

--- a/packages/website/src/i18n/zh.ts
+++ b/packages/website/src/i18n/zh.ts
@@ -209,6 +209,8 @@ export default {
           ['BIND_HOST', '服务器绑定地址（默认：0.0.0.0）。如需 IPv6，请显式设置为 ::。'],
           ['HERMES_WEB_UI_HOME', 'Hermes Studio 数据目录，用于认证 token、登录凭据、日志、数据库和默认上传目录'],
           ['HERMES_WEBUI_STATE_DIR', 'HERMES_WEB_UI_HOME 的兼容别名'],
+          ['HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT', '关闭启动时向 Hermes profile 配置自动注入托管的 hermes-studio MCP server'],
+          ['HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT', '当 HERMES_WEB_UI_HOME 位于临时目录（例如 Version Preview runtime）时，仍允许托管 MCP 自动注入'],
           ['UPLOAD_DIR', '自定义上传根目录。文件会保存在按 Profile 隔离的子目录下'],
           ['CORS_ORIGINS', 'HTTP、Socket.IO、WebSocket 跨源 allowlist（默认：仅同 host；只有明确需要旧版 wildcard CORS 时才设置为 *）'],
           ['AUTH_TOKEN', '自定义 bearer token，会覆盖自动生成的 token'],

--- a/tests/server/studio-mcp-autoinject.test.ts
+++ b/tests/server/studio-mcp-autoinject.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const updateConfigYamlForProfileMock = vi.fn()
 const listProfileNamesFromDiskMock = vi.fn()
+const configMock = vi.hoisted(() => ({
+  port: 8648,
+  appHome: '/Users/test/.hermes-web-ui',
+}))
 
 vi.mock('../../packages/server/src/services/config-helpers', () => ({
   updateConfigYamlForProfile: updateConfigYamlForProfileMock,
@@ -13,10 +17,7 @@ vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
 }))
 
 vi.mock('../../packages/server/src/config', () => ({
-  config: {
-    port: 8648,
-    appHome: '/tmp/hermes-web-ui-home',
-  },
+  config: configMock,
 }))
 
 vi.mock('../../packages/server/src/services/logger', () => ({
@@ -33,6 +34,9 @@ describe('studio MCP autoinject', () => {
     delete process.env.HERMES_DESKTOP
     delete process.env.AUTH_TOKEN
     delete process.env.HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT
+    delete process.env.HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT
+    configMock.port = 8648
+    configMock.appHome = '/Users/test/.hermes-web-ui'
     listProfileNamesFromDiskMock.mockReturnValue(['default', 'work'])
     updateConfigYamlForProfileMock.mockImplementation(async (_profile: string, updater: any) => {
       const updated = await updater({})
@@ -53,13 +57,62 @@ describe('studio MCP autoinject', () => {
       args: [join(process.cwd(), 'bin/hermes-web-ui-mcp.mjs')],
       env: {
         HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
-        HERMES_WEB_UI_HOME: '/tmp/hermes-web-ui-home',
-        HERMES_WEBUI_STATE_DIR: '/tmp/hermes-web-ui-home',
+        HERMES_WEB_UI_HOME: '/Users/test/.hermes-web-ui',
+        HERMES_WEBUI_STATE_DIR: '/Users/test/.hermes-web-ui',
         HERMES_WEB_UI_MANAGED_MCP: '1',
       },
       enabled: true,
     })
     expect(result.command).toBe(process.execPath)
+  })
+
+  it('skips autoinject for transient preview homes by default', async () => {
+    configMock.appHome = '/private/tmp/wui-preview-home'
+    const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
+
+    const result = await injectBundledMcpServer()
+
+    expect(result.targets).toEqual([])
+    expect(updateConfigYamlForProfileMock).not.toHaveBeenCalled()
+  })
+
+  it('allows transient preview autoinject when explicitly requested', async () => {
+    configMock.appHome = '/private/tmp/wui-preview-home'
+    process.env.HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT = '1'
+    const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
+
+    await injectBundledMcpServer()
+
+    expect(updateConfigYamlForProfileMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('respects a user-disabled managed MCP server entry', async () => {
+    const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
+
+    await injectBundledMcpServer()
+
+    const updated = await updateConfigYamlForProfileMock.mock.calls[0][1]({
+      mcp_servers: {
+        'hermes-studio': {
+          command: process.execPath,
+          args: [join(process.cwd(), 'bin/hermes-web-ui-mcp.mjs')],
+          env: {
+            HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
+            HERMES_WEB_UI_HOME: '/Users/test/.hermes-web-ui',
+            HERMES_WEBUI_STATE_DIR: '/Users/test/.hermes-web-ui',
+            HERMES_WEB_UI_MANAGED_MCP: '1',
+          },
+          enabled: false,
+        },
+      },
+    })
+
+    expect(updated.write).toBe(false)
+    expect(updated.result).toMatchObject({
+      status: 'skipped',
+      reason: 'existing hermes-studio MCP server is disabled by user',
+    })
+    expect(updated.data.mcp_servers['hermes-studio'].enabled).toBe(false)
   })
 
   it('updates old managed PATH-only MCP entries to the bundled node script', async () => {


### PR DESCRIPTION
## Summary

- 临时 preview/runtime 的 `HERMES_WEB_UI_HOME` 默认跳过 Studio MCP autoinject，避免把短生命周期端口和 home 写进 Hermes 全局配置并触发 CLI reload spam。
- 新增 `HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT=1`，保留需要调试 transient preview 注入时的显式 opt-in。
- 已存在且由用户设为 `enabled: false` 的 managed `hermes-studio` entry 不再被自动改写回 enabled。

## UAT / Verification

- `npm test -- --run tests/server/studio-mcp-autoinject.test.ts`
  - 8 tests passed
- `npx tsc --noEmit -p packages/server/tsconfig.json`
  - passed
- Production-server UAT with isolated Hermes homes:
  - transient Web UI home: `/health` ready, startup log reports transient autoinject skip, default and secondary profile configs unchanged
  - transient Web UI home with `HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT=1`: `/health` ready, managed `hermes-studio` injected into default and secondary profile configs
  - existing managed `hermes-studio` with `enabled: false`: `/health` ready, config remains unchanged and disabled entry stays disabled

## Notes

- Related prior Studio MCP packaging hardening: #1375
- No broad MCP lifecycle redesign here; this is intentionally the minimal Hermes Web UI-side guard for transient preview config churn.
