### PR TITLE
保护 bundled skill 注入避免覆盖本地修改

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ These variables configure Hermes Web UI, its local Hermes runtime integration, a
 | `HERMES_OPENROUTER_APP_CATEGORIES` | `cli-agent,personal-agent` | OpenRouter attribution categories sent by bridge runs. |
 | `HERMES_WEB_UI_MANAGED_GATEWAY` | platform/runtime dependent | Force managed legacy gateway process handling. Set `1`, `true`, `yes`, or `on` to enable. |
 | `HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART` | unset | Skip startup gateway checks/autostart. Set `1`, `true`, `yes`, or `on` for dashboard-only deployments where another service owns Hermes gateway lifecycle. |
-| `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | unset | Skip startup bundled skill injection. Set `1`, `true`, `yes`, or `on` when bundled skills are managed outside Web UI or target skill directories must not be overwritten. |
+| `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | unset | Skip startup bundled skill injection. Set `1`, `true`, `yes`, or `on` when bundled skills are managed outside Hermes Web UI. When injection is enabled, Web UI updates only skills it previously installed or identical existing bundled copies; local edits and user-owned same-name skills are skipped. |
 | `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | enabled in production | Controls whether Web UI shutdown also stops managed gateway processes. Set `0` or `false` to detach them. |
 | `GATEWAY_HOST` | `127.0.0.1` | Default gateway host written into profile config for legacy gateway compatibility. |
 | `HERMES_WEB_UI_PREVIEW_REPO` | package repository | GitHub repository used by Version Preview. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -287,7 +287,7 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `HERMES_OPENROUTER_APP_CATEGORIES` | `cli-agent,personal-agent` | bridge 运行发送给 OpenRouter 的 attribution categories。 |
 | `HERMES_WEB_UI_MANAGED_GATEWAY` | 由平台/运行环境决定 | 强制启用旧 gateway 进程托管；设为 `1`、`true`、`yes` 或 `on` 开启。 |
 | `HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART` | 未设置 | 跳过启动时的 gateway 检查/自动启动；dashboard-only 部署中如果由其它服务管理 Hermes gateway，可设为 `1`、`true`、`yes` 或 `on`。 |
-| `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | 未设置 | 跳过启动时的内置 skill 注入；如果内置 skills 由 Web UI 外部管理，或不希望覆盖同名目标目录，可设为 `1`、`true`、`yes` 或 `on`。 |
+| `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | 未设置 | 跳过启动时的内置 skill 注入；如果内置 skills 由 Hermes Web UI 外部管理，可设为 `1`、`true`、`yes` 或 `on`。启用注入时，Web UI 只更新自己此前安装的 skills 或内容完全相同的既有内置副本；本地修改和用户拥有的同名 skills 会跳过。 |
 | `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | 生产环境默认开启 | Web UI 关闭时是否同时停止托管的 gateway 进程；设为 `0` 或 `false` 可让 gateway 分离运行。 |
 | `GATEWAY_HOST` | `127.0.0.1` | 旧 gateway 兼容配置中写入 profile 的默认 gateway host。 |
 | `HERMES_WEB_UI_PREVIEW_REPO` | package repository | Version Preview 使用的 GitHub 仓库。 |

--- a/docs/cli-chat-sessions.md
+++ b/docs/cli-chat-sessions.md
@@ -896,7 +896,7 @@ Bridge 启动失败不会阻止 Web UI server 启动，但普通 Chat run 会在
 | `HERMES_BRIDGE_PROVIDER` | 覆盖 bridge provider。 |
 | `HERMES_BRIDGE_MAX_TURNS` | 覆盖 bridge 最大轮数。 |
 | `HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART` | 跳过启动时的 gateway 检查/自动启动；dashboard-only 部署可用。 |
-| `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | 跳过启动时的内置 skill 注入；外部管理 skills 时可用。 |
+| `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | 跳过启动时的内置 skill 注入；外部管理 skills 时可用。默认注入只更新 Web UI 管理或完全相同的内置副本，用户修改的同名 skills 会跳过。 |
 | `HERMES_WEB_UI_PREVIEW_AGENT_BRIDGE_TRANSPORT` | Version Preview bridge transport。 |
 | `HERMES_WEB_UI_PREVIEW_AGENT_BRIDGE_ENDPOINT` | Version Preview bridge endpoint。 |
 

--- a/packages/server/src/services/hermes/skill-injector.ts
+++ b/packages/server/src/services/hermes/skill-injector.ts
@@ -1,8 +1,25 @@
-import { copyFile, mkdir, readdir, rm, stat } from 'fs/promises'
+import { copyFile, mkdir, readdir, readFile, rm, stat, writeFile } from 'fs/promises'
 import { existsSync, readdirSync } from 'fs'
+import { createHash } from 'crypto'
 import { join, resolve } from 'path'
 import { detectHermesRootHome } from './hermes-path'
 import { logger } from '../logger'
+
+const MANIFEST_FILENAME = '.webui-managed-skills.json'
+const MANIFEST_OWNER = 'hermes-web-ui'
+const HASH_IGNORED_FILENAMES = new Set([
+  '.DS_Store',
+  'Thumbs.db',
+  '.wui-managed.json', // legacy per-skill marker; do not treat it as skill payload
+])
+
+interface ManagedSkillManifestEntry {
+  owner?: string
+  source_hash?: string
+  installed_hash?: string
+}
+
+type ManagedSkillManifest = Record<string, ManagedSkillManifestEntry>
 
 export interface SkillInjectionTargetResult {
   profile?: string
@@ -140,28 +157,118 @@ export class HermesSkillInjector {
     }
 
     await mkdir(targetDir, { recursive: true })
+    const manifest = await this.readManifest(targetDir)
+    let manifestChanged = false
+
     for (const entry of entries) {
       if (!entry.isDirectory() || entry.name.startsWith('.')) continue
       const sourceSkillDir = join(this.sourceDir, entry.name)
       const targetSkillDir = join(targetDir, entry.name)
+      const sourceHash = await this.hashDir(sourceSkillDir)
       const existed = existsSync(targetSkillDir)
-      if (existsSync(targetSkillDir)) {
-        await rm(targetSkillDir, { recursive: true, force: true })
+
+      if (!existed) {
+        const installedHash = await this.installManagedSkill(sourceSkillDir, targetSkillDir)
+        manifest[entry.name] = { owner: MANIFEST_OWNER, source_hash: sourceHash, installed_hash: installedHash }
+        manifestChanged = true
+        result.injected.push(entry.name)
+        continue
       }
-      await this.copyDir(sourceSkillDir, targetSkillDir)
-      if (existed) result.updated.push(entry.name)
-      else result.injected.push(entry.name)
+
+      const currentHash = await this.hashDir(targetSkillDir)
+      const manifestEntry = manifest[entry.name]
+      const isManaged = manifestEntry?.owner === MANIFEST_OWNER
+      const isUnchangedManagedCopy = isManaged && manifestEntry?.installed_hash === currentHash
+      const isExistingBundledCopy = !manifestEntry && currentHash === sourceHash
+
+      if (isUnchangedManagedCopy) {
+        if (manifestEntry?.source_hash !== sourceHash) {
+          const installedHash = await this.installManagedSkill(sourceSkillDir, targetSkillDir)
+          manifest[entry.name] = { owner: MANIFEST_OWNER, source_hash: sourceHash, installed_hash: installedHash }
+          manifestChanged = true
+          result.updated.push(entry.name)
+        }
+        continue
+      }
+
+      if (isExistingBundledCopy) {
+        manifest[entry.name] = { owner: MANIFEST_OWNER, source_hash: sourceHash, installed_hash: currentHash }
+        manifestChanged = true
+        result.updated.push(entry.name)
+        continue
+      }
+
+      result.skipped.push(entry.name)
+      logger.warn({
+        profile,
+        skill: entry.name,
+        targetSkillDir,
+      }, '[skill-injector] skipped bundled skill because target was not an unchanged Web UI-managed copy')
     }
 
-    if (result.injected.length > 0 || result.updated.length > 0) {
+    if (manifestChanged) await this.writeManifest(targetDir, manifest)
+
+    if (result.injected.length > 0 || result.updated.length > 0 || result.skipped.length > 0) {
       logger.info({
         profile,
         injected: result.injected,
         updated: result.updated,
+        skipped: result.skipped,
         targetDir,
       }, '[skill-injector] synced bundled skills')
     }
     return result
+  }
+
+  private async installManagedSkill(sourceSkillDir: string, targetSkillDir: string): Promise<string> {
+    if (existsSync(targetSkillDir)) {
+      await rm(targetSkillDir, { recursive: true, force: true })
+    }
+    await this.copyDir(sourceSkillDir, targetSkillDir)
+    return await this.hashDir(targetSkillDir)
+  }
+
+  private async readManifest(targetDir: string): Promise<ManagedSkillManifest> {
+    try {
+      const raw = await readFile(join(targetDir, MANIFEST_FILENAME), 'utf-8')
+      const parsed = JSON.parse(raw)
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as ManagedSkillManifest : {}
+    } catch {
+      return {}
+    }
+  }
+
+  private async writeManifest(targetDir: string, manifest: ManagedSkillManifest): Promise<void> {
+    const sorted: ManagedSkillManifest = {}
+    for (const key of Object.keys(manifest).sort()) {
+      sorted[key] = manifest[key]
+    }
+    await writeFile(join(targetDir, MANIFEST_FILENAME), `${JSON.stringify(sorted, null, 2)}\n`, 'utf-8')
+  }
+
+  private async hashDir(dir: string): Promise<string> {
+    const hash = createHash('sha256')
+    await this.hashDirInto(hash, dir, '')
+    return hash.digest('hex')
+  }
+
+  private async hashDirInto(hash: ReturnType<typeof createHash>, dir: string, relativeDir: string): Promise<void> {
+    const entries = (await readdir(dir, { withFileTypes: true }))
+      .filter(entry => !HASH_IGNORED_FILENAMES.has(entry.name))
+      .sort((a, b) => a.name.localeCompare(b.name))
+
+    for (const entry of entries) {
+      const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name
+      const fullPath = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        hash.update(`dir\0${relativePath}\0`)
+        await this.hashDirInto(hash, fullPath, relativePath)
+      } else if (entry.isFile()) {
+        hash.update(`file\0${relativePath}\0`)
+        hash.update(await readFile(fullPath))
+        hash.update('\0')
+      }
+    }
   }
 
   private async isDirectory(path: string): Promise<boolean> {

--- a/packages/website/src/i18n/en.ts
+++ b/packages/website/src/i18n/en.ts
@@ -244,7 +244,7 @@ export default {
           ['HERMES_OPENROUTER_APP_CATEGORIES', 'OpenRouter attribution categories sent by bridge runs'],
           ['HERMES_WEB_UI_MANAGED_GATEWAY', 'Force managed legacy gateway process handling'],
           ['HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART', 'Skip startup gateway checks/autostart for dashboard-only deployments where another service owns Hermes gateway lifecycle'],
-          ['HERMES_WEB_UI_DISABLE_SKILL_INJECTION', 'Skip startup bundled skill injection when skills are managed outside Web UI or target skill directories must not be overwritten'],
+          ['HERMES_WEB_UI_DISABLE_SKILL_INJECTION', 'Skip startup bundled skill injection when skills are managed outside Hermes Web UI. Enabled injection only updates Web UI-managed or identical bundled copies; local edits are skipped'],
           ['HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN', 'Controls whether Hermes Studio shutdown also stops managed gateway processes'],
           ['GATEWAY_HOST', 'Default gateway host written into profile config for legacy gateway compatibility'],
           ['HERMES_WEB_UI_PREVIEW_REPO', 'GitHub repository used by Version Preview'],

--- a/packages/website/src/i18n/zh.ts
+++ b/packages/website/src/i18n/zh.ts
@@ -244,7 +244,7 @@ export default {
           ['HERMES_OPENROUTER_APP_CATEGORIES', 'bridge 运行发送给 OpenRouter 的 attribution categories'],
           ['HERMES_WEB_UI_MANAGED_GATEWAY', '强制启用旧 gateway 进程托管'],
           ['HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART', '跳过启动时的 gateway 检查/自动启动；适用于由其它服务管理 Hermes gateway 的 dashboard-only 部署'],
-          ['HERMES_WEB_UI_DISABLE_SKILL_INJECTION', '跳过启动时的内置 skill 注入；适用于由 Web UI 外部管理 skills 或不希望覆盖同名目标目录的部署'],
+          ['HERMES_WEB_UI_DISABLE_SKILL_INJECTION', '跳过启动时的内置 skill 注入；适用于由 Hermes Web UI 外部管理 skills 的部署。启用注入时只更新 Web UI 管理或完全相同的内置副本，本地修改会跳过'],
           ['HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN', 'Hermes Studio 关闭时是否同时停止托管的 gateway 进程'],
           ['GATEWAY_HOST', '旧 gateway 兼容配置中写入 profile 的默认 gateway host'],
           ['HERMES_WEB_UI_PREVIEW_REPO', 'Version Preview 使用的 GitHub 仓库'],

--- a/tests/server/skill-injector.test.ts
+++ b/tests/server/skill-injector.test.ts
@@ -1,4 +1,5 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { existsSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -11,6 +12,10 @@ async function tempDir(prefix: string): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), prefix))
   tempDirs.push(dir)
   return dir
+}
+
+async function readManifest(skillsDir: string) {
+  return JSON.parse(await readFile(join(skillsDir, '.webui-managed-skills.json'), 'utf-8'))
 }
 
 afterEach(async () => {
@@ -39,7 +44,7 @@ describe('HermesSkillInjector', () => {
     expect(HermesSkillInjector.resolveSourceDir({} as any, join(root, 'packages', 'server', 'src', 'services', 'hermes'))).toBe(devSkills)
   })
 
-  it('syncs bundled skills and replaces existing bundled copies', async () => {
+  it('injects missing skills but skips existing user-owned skills with the same name', async () => {
     const source = await tempDir('hermes-skill-source-')
     const hermesHome = await tempDir('hermes-skill-home-')
     process.env.HERMES_HOME = hermesHome
@@ -56,13 +61,79 @@ describe('HermesSkillInjector', () => {
     const result = await new HermesSkillInjector(source).injectMissingSkills()
 
     expect(result.injected).toEqual(['new-skill'])
-    expect(result.updated).toEqual(['existing-skill'])
-    expect(result.skipped).toEqual([])
+    expect(result.updated).toEqual([])
+    expect(result.skipped).toEqual(['existing-skill'])
     await expect(readFile(join(hermesHome, 'skills', 'new-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# New Skill\n')
-    await expect(readFile(join(hermesHome, 'skills', 'existing-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# Bundled Existing\n')
+    await expect(readFile(join(hermesHome, 'skills', 'existing-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# User Existing\n')
+    await expect(readManifest(join(hermesHome, 'skills'))).resolves.toMatchObject({ 'new-skill': { owner: 'hermes-web-ui' } })
+    expect(existsSync(join(hermesHome, 'skills', 'new-skill', '.wui-managed.json'))).toBe(false)
+    expect(existsSync(join(hermesHome, 'skills', 'existing-skill', '.wui-managed.json'))).toBe(false)
   })
 
-  it('syncs bundled skills into default and named profiles only touching bundled names', async () => {
+  it('updates existing Web UI-managed bundled copies', async () => {
+    const sourceV1 = await tempDir('hermes-skill-source-v1-')
+    const sourceV2 = await tempDir('hermes-skill-source-v2-')
+    const hermesHome = await tempDir('hermes-skill-home-')
+    process.env.HERMES_HOME = hermesHome
+
+    await mkdir(join(sourceV1, 'webui-skill'), { recursive: true })
+    await writeFile(join(sourceV1, 'webui-skill', 'SKILL.md'), '# WebUI Skill v1\n', 'utf-8')
+    await mkdir(join(sourceV2, 'webui-skill'), { recursive: true })
+    await writeFile(join(sourceV2, 'webui-skill', 'SKILL.md'), '# WebUI Skill v2\n', 'utf-8')
+
+    const { HermesSkillInjector } = await import('../../packages/server/src/services/hermes/skill-injector')
+    await new HermesSkillInjector(sourceV1).injectMissingSkills()
+    const result = await new HermesSkillInjector(sourceV2).injectMissingSkills()
+
+    expect(result.injected).toEqual([])
+    expect(result.updated).toEqual(['webui-skill'])
+    expect(result.skipped).toEqual([])
+    await expect(readFile(join(hermesHome, 'skills', 'webui-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# WebUI Skill v2\n')
+    await expect(readManifest(join(hermesHome, 'skills'))).resolves.toMatchObject({ 'webui-skill': { owner: 'hermes-web-ui' } })
+  })
+
+  it('ignores common OS metadata files when deciding whether a managed copy can update', async () => {
+    const sourceV1 = await tempDir('hermes-skill-source-v1-')
+    const sourceV2 = await tempDir('hermes-skill-source-v2-')
+    const hermesHome = await tempDir('hermes-skill-home-')
+    process.env.HERMES_HOME = hermesHome
+
+    await mkdir(join(sourceV1, 'webui-skill'), { recursive: true })
+    await writeFile(join(sourceV1, 'webui-skill', 'SKILL.md'), '# WebUI Skill v1\n', 'utf-8')
+    await mkdir(join(sourceV2, 'webui-skill'), { recursive: true })
+    await writeFile(join(sourceV2, 'webui-skill', 'SKILL.md'), '# WebUI Skill v2\n', 'utf-8')
+
+    const { HermesSkillInjector } = await import('../../packages/server/src/services/hermes/skill-injector')
+    await new HermesSkillInjector(sourceV1).injectMissingSkills()
+    await writeFile(join(hermesHome, 'skills', 'webui-skill', '.DS_Store'), 'finder metadata', 'utf-8')
+    const result = await new HermesSkillInjector(sourceV2).injectMissingSkills()
+
+    expect(result.updated).toEqual(['webui-skill'])
+    expect(result.skipped).toEqual([])
+    await expect(readFile(join(hermesHome, 'skills', 'webui-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# WebUI Skill v2\n')
+  })
+
+  it('adopts identical existing bundled copies without overwriting local files', async () => {
+    const source = await tempDir('hermes-skill-source-')
+    const hermesHome = await tempDir('hermes-skill-home-')
+    process.env.HERMES_HOME = hermesHome
+
+    await mkdir(join(source, 'webui-skill'), { recursive: true })
+    await writeFile(join(source, 'webui-skill', 'SKILL.md'), '# WebUI Skill\n', 'utf-8')
+    await mkdir(join(hermesHome, 'skills', 'webui-skill'), { recursive: true })
+    await writeFile(join(hermesHome, 'skills', 'webui-skill', 'SKILL.md'), '# WebUI Skill\n', 'utf-8')
+
+    const { HermesSkillInjector } = await import('../../packages/server/src/services/hermes/skill-injector')
+    const result = await new HermesSkillInjector(source).injectMissingSkills()
+
+    expect(result.injected).toEqual([])
+    expect(result.updated).toEqual(['webui-skill'])
+    expect(result.skipped).toEqual([])
+    await expect(readFile(join(hermesHome, 'skills', 'webui-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# WebUI Skill\n')
+    await expect(readManifest(join(hermesHome, 'skills'))).resolves.toMatchObject({ 'webui-skill': { owner: 'hermes-web-ui' } })
+  })
+
+  it('syncs bundled skills into default and named profiles without overwriting user-owned conflicts', async () => {
     const source = await tempDir('hermes-skill-source-')
     const hermesHome = await tempDir('hermes-skill-home-')
     process.env.HERMES_HOME = hermesHome
@@ -71,7 +142,7 @@ describe('HermesSkillInjector', () => {
     await writeFile(join(source, 'webui-skill', 'SKILL.md'), '# WebUI Skill\n', 'utf-8')
 
     await mkdir(join(hermesHome, 'skills', 'webui-skill'), { recursive: true })
-    await writeFile(join(hermesHome, 'skills', 'webui-skill', 'SKILL.md'), '# Old WebUI Skill\n', 'utf-8')
+    await writeFile(join(hermesHome, 'skills', 'webui-skill', 'SKILL.md'), '# User WebUI Skill\n', 'utf-8')
     await mkdir(join(hermesHome, 'skills', 'local-skill'), { recursive: true })
     await writeFile(join(hermesHome, 'skills', 'local-skill', 'SKILL.md'), '# Local Skill\n', 'utf-8')
 
@@ -90,11 +161,12 @@ describe('HermesSkillInjector', () => {
       join(hermesHome, 'profiles', 'beta', 'skills'),
     ])
     expect(result.injected).toEqual(['webui-skill'])
-    expect(result.updated).toEqual(['webui-skill', 'webui-skill'])
+    expect(result.updated).toEqual([])
+    expect(result.skipped).toEqual(['webui-skill', 'webui-skill'])
 
-    await expect(readFile(join(hermesHome, 'skills', 'webui-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# WebUI Skill\n')
+    await expect(readFile(join(hermesHome, 'skills', 'webui-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# User WebUI Skill\n')
     await expect(readFile(join(hermesHome, 'profiles', 'alpha', 'skills', 'webui-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# WebUI Skill\n')
-    await expect(readFile(join(hermesHome, 'profiles', 'beta', 'skills', 'webui-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# WebUI Skill\n')
+    await expect(readFile(join(hermesHome, 'profiles', 'beta', 'skills', 'webui-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# Old Profile Skill\n')
     await expect(readFile(join(hermesHome, 'skills', 'local-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# Local Skill\n')
     await expect(readFile(join(hermesHome, 'profiles', 'beta', 'skills', 'profile-local', 'SKILL.md'), 'utf-8')).resolves.toBe('# Profile Local\n')
   })


### PR DESCRIPTION
## 改动说明

- 防止 Hermes Web UI 启动时的 bundled skill 注入覆盖用户拥有或本地修改过的同名 skills。
- 为每个 skills 目录增加轻量根级 `.webui-managed-skills.json` 管理索引，只跟踪 Web UI 自己安装的 bundled skill 副本。
- 仅在目标是未改动的 Web UI-managed 副本，或内容与 bundled source 完全相同的既有副本时更新；检测到冲突时跳过并记录 warning。
- 更新文档，说明默认注入现在会保护本地修改，同时保留 `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` 给外部管理 skills 的部署使用。

## 验证

- `npm ci --no-audit --no-fund` → passed；install lifecycle 成功运行 `npm run build`
- `npm test -- --run tests/server/skill-injector.test.ts` → passed，6/6 tests
- `npm test -- --run tests/server/skill-injector.test.ts tests/server/profiles-routes.test.ts` → passed，17/17 tests
- `npx tsc --noEmit -p packages/server/tsconfig.json` → passed
- `npm run build` → passed
- `git diff --check` → passed

## 备注

管理索引放在 skills 目录根部，不写入单个 skill 目录，因此不会作为 skill support file 暴露。hash 检查会忽略 `.DS_Store`、`Thumbs.db` 等常见 OS metadata，避免这类噪音阻断后续 bundled skill 更新。
