### PR TITLE
fix(agent-bridge): 暴露运行时 readiness 到 health 和 chat

### DIFF
--- a/docs/chat-chain-changes/2026-06-07-pr-pending-agent-bridge-runtime-readiness.md
+++ b/docs/chat-chain-changes/2026-06-07-pr-pending-agent-bridge-runtime-readiness.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-07
+pr: pending
+feature: Agent Bridge runtime readiness
+impact: Chat resume and new CLI runs now distinguish bridge readiness from base server health, surface sanitized bridge failures, and avoid destructive recovery on chat-path checks.
+---
+
+`/health` keeps its top-level compatibility status while adding nested `agent_bridge` readiness. New CLI chat runs perform a non-destructive readiness gate before dispatch. Resume uncertainty emits a non-terminal `run.reattach_failed` warning that is replayed in the `resumed` payload so the UI can show the user why bridge status could not be confirmed without marking the run failed.

--- a/docs/chat-chain-changes/2026-06-07-pr-pending-agent-bridge-runtime-readiness.md
+++ b/docs/chat-chain-changes/2026-06-07-pr-pending-agent-bridge-runtime-readiness.md
@@ -6,3 +6,5 @@ impact: Chat resume and new CLI runs now distinguish bridge readiness from base 
 ---
 
 `/health` keeps its top-level compatibility status while adding nested `agent_bridge` readiness. New CLI chat runs perform a non-destructive readiness gate before dispatch. Resume uncertainty emits a non-terminal `run.reattach_failed` warning that is replayed in the `resumed` payload so the UI can show the user why bridge status could not be confirmed without marking the run failed.
+
+Queued CLI runs that fail the readiness gate before dispatch now report the remaining queue length and continue dequeuing the next queued item, matching the existing bridge terminal failure path.

--- a/docs/chat-chain-changes/2026-06-07-pr-pending-agent-bridge-runtime-readiness.md
+++ b/docs/chat-chain-changes/2026-06-07-pr-pending-agent-bridge-runtime-readiness.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-07
-pr: pending
+pr: 1393
 feature: Agent Bridge runtime readiness
 impact: Chat resume and new CLI runs now distinguish bridge readiness from base server health, surface sanitized bridge failures, and avoid destructive recovery on chat-path checks.
 ---

--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -411,6 +411,16 @@ function globalAgentEventHandler(event: RunEvent): void {
   }
 }
 
+function globalRunReattachFailedHandler(event: RunEvent): void {
+  const sid = event.session_id
+  if (!sid) return
+
+  const handlers = sessionEventHandlers.get(sid)
+  if (handlers?.onAgentEvent) {
+    handlers.onAgentEvent(event)
+  }
+}
+
 function globalApprovalRequestedHandler(event: RunEvent): void {
   const sid = event.session_id
   if (!sid) return
@@ -648,6 +658,7 @@ export function connectChatRun(requestedProfile?: string | null): Socket {
     // Usage events
     chatRunSocket.on('usage.updated', globalUsageUpdatedHandler)
     chatRunSocket.on('agent.event', globalAgentEventHandler)
+    chatRunSocket.on('run.reattach_failed', globalRunReattachFailedHandler)
     chatRunSocket.on('session.command', globalSessionCommandHandler)
     chatRunSocket.on('session.title.updated', globalSessionTitleUpdatedHandler)
 

--- a/packages/client/src/api/hermes/system.ts
+++ b/packages/client/src/api/hermes/system.ts
@@ -2,11 +2,27 @@ import { request } from '../client'
 
 export interface HealthResponse {
   status: string
+  platform?: string
   version?: string
+  gateway?: string
   webui_version?: string
   webui_latest?: string
   webui_update_available?: boolean
   node_version?: string
+  agent_bridge?: {
+    status: string
+    reachable: boolean
+    ready?: boolean
+    running?: boolean
+    attached?: boolean
+    starting?: boolean
+    stopping?: boolean
+    restart_scheduled?: boolean
+    restart_attempts?: number
+    endpoint_kind?: 'ipc' | 'tcp' | 'unknown'
+    pid?: number
+    error?: string
+  }
 }
 
 export interface PreviewTag {

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -715,6 +715,8 @@ export const useChatStore = defineStore('chat', () => {
                 addAgentErrorMessage(sessionId, e.error)
                 serverWorking.value.delete(sessionId)
                 queueLengths.value.delete(sessionId)
+              } else if (e.event === 'agent.event' || e.event === 'run.reattach_failed') {
+                handleAgentEvent(e)
               } else if (e.event === 'tool.started') {
                 const msgs = getSessionMsgs(sessionId)
                 const toolCallId = e.tool_call_id as string | undefined
@@ -1648,6 +1650,11 @@ export const useChatStore = defineStore('chat', () => {
               break
             }
 
+            case 'run.reattach_failed': {
+              handleAgentEvent(evt)
+              break
+            }
+
             case 'compression.started': {
               setCompressionState(sid, {
                 compressing: true,
@@ -2145,6 +2152,11 @@ export const useChatStore = defineStore('chat', () => {
         }
 
         case 'agent.event': {
+          handleAgentEvent(evt)
+          break
+        }
+
+        case 'run.reattach_failed': {
           handleAgentEvent(evt)
           break
         }

--- a/packages/server/src/controllers/health.ts
+++ b/packages/server/src/controllers/health.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'fs'
 import { resolve } from 'path'
 import * as hermesCli from '../services/hermes/hermes-cli'
 import { getAgentBridgeManager } from '../services/hermes/agent-bridge/manager'
+import { redactAgentBridgeError } from '../services/hermes/agent-bridge/redact'
 
 declare const __APP_VERSION__: string
 
@@ -45,6 +46,26 @@ const LOCAL_VERSION = typeof __APP_VERSION__ !== 'undefined'
   : PACKAGE_INFO?.version || ''
 
 let cachedLatestVersion = ''
+const AGENT_BRIDGE_HEALTH_CACHE_TTL_MS = 250
+const AGENT_BRIDGE_HEALTH_FIRST_WAIT_MS = 75
+
+type AgentBridgeHealthPayload = {
+  status: string
+  reachable: boolean
+  ready?: boolean
+  running?: boolean
+  attached?: boolean
+  starting?: boolean
+  stopping?: boolean
+  restart_scheduled?: boolean
+  restart_attempts?: number
+  endpoint_kind?: 'ipc' | 'tcp' | 'unknown'
+  pid?: number
+  error?: string
+}
+
+let cachedAgentBridgeHealth: { value: AgentBridgeHealthPayload; expiresAt: number } | null = null
+let pendingAgentBridgeHealthRefresh: Promise<AgentBridgeHealthPayload> | null = null
 
 /**
  * Whether the periodic npm-registry version check is disabled.
@@ -84,15 +105,42 @@ export function startVersionCheck(): void {
 }
 
 async function getAgentBridgeHealth() {
-  const manager = getAgentBridgeManager()
-  const endpoint = typeof manager.getRuntimeState === 'function'
-    ? manager.getRuntimeState().endpoint
-    : undefined
+  const now = Date.now()
+  if (cachedAgentBridgeHealth && cachedAgentBridgeHealth.expiresAt > now) {
+    return cachedAgentBridgeHealth.value
+  }
+
+  if (!pendingAgentBridgeHealthRefresh) {
+    pendingAgentBridgeHealthRefresh = refreshAgentBridgeHealth().finally(() => {
+      pendingAgentBridgeHealthRefresh = null
+    })
+  }
+
+  if (cachedAgentBridgeHealth) {
+    return cachedAgentBridgeHealth.value
+  }
+
+  const firstResult = await Promise.race([
+    pendingAgentBridgeHealthRefresh,
+    new Promise<AgentBridgeHealthPayload>((resolve) => {
+      setTimeout(() => resolve({ status: 'unknown', reachable: false }), AGENT_BRIDGE_HEALTH_FIRST_WAIT_MS)
+    }),
+  ])
+
+  return firstResult
+}
+
+async function refreshAgentBridgeHealth(): Promise<AgentBridgeHealthPayload> {
+  let endpoint: string | undefined
 
   try {
-    const readiness = await manager.checkReadiness({ timeoutMs: 750, connectRetryMs: 0 })
-    const error = redactAgentBridgeError(readiness.error, readiness.endpoint)
-    return {
+    const manager = getAgentBridgeManager()
+    endpoint = typeof manager.getRuntimeState === 'function'
+      ? manager.getRuntimeState().endpoint
+      : undefined
+
+    const readiness = await manager.checkReadiness({ timeoutMs: AGENT_BRIDGE_HEALTH_FIRST_WAIT_MS, connectRetryMs: 0 })
+    const value: AgentBridgeHealthPayload = {
       status: readiness.status,
       reachable: readiness.reachable,
       ready: readiness.ready,
@@ -104,39 +152,19 @@ async function getAgentBridgeHealth() {
       restart_attempts: readiness.restartAttempts,
       endpoint_kind: readiness.endpointKind,
       pid: readiness.pid,
-      error,
+      error: redactAgentBridgeError(readiness.error, readiness.endpoint),
     }
+    cachedAgentBridgeHealth = { value, expiresAt: Date.now() + AGENT_BRIDGE_HEALTH_CACHE_TTL_MS }
+    return value
   } catch (err) {
-    return {
+    const value: AgentBridgeHealthPayload = {
       status: 'unknown',
       reachable: false,
       error: redactAgentBridgeError(err instanceof Error ? err.message : String(err), endpoint),
     }
+    cachedAgentBridgeHealth = { value, expiresAt: Date.now() + AGENT_BRIDGE_HEALTH_CACHE_TTL_MS }
+    return value
   }
-}
-
-function redactAgentBridgeError(error: string | undefined, endpoint?: string): string | undefined {
-  if (!error) return undefined
-  if (!endpoint) return error
-
-  const candidates = [endpoint]
-
-  if (endpoint.startsWith('ipc://')) {
-    candidates.push(endpoint.slice('ipc://'.length))
-  }
-
-  if (endpoint.startsWith('tcp://')) {
-    try {
-      const url = new URL(endpoint)
-      candidates.push(url.host)
-    } catch {
-      // Ignore malformed endpoints and fall back to the original string.
-    }
-  }
-
-  return candidates
-    .filter(candidate => candidate)
-    .reduce((message, candidate) => message.split(candidate).join('[redacted endpoint]'), error)
 }
 
 export async function healthCheck(ctx: any) {

--- a/packages/server/src/controllers/health.ts
+++ b/packages/server/src/controllers/health.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'fs'
 import { resolve } from 'path'
 import * as hermesCli from '../services/hermes/hermes-cli'
+import { getAgentBridgeManager } from '../services/hermes/agent-bridge/manager'
 
 declare const __APP_VERSION__: string
 
@@ -82,9 +83,66 @@ export function startVersionCheck(): void {
   setInterval(checkLatestVersion, 30 * 60 * 1000)
 }
 
+async function getAgentBridgeHealth() {
+  const manager = getAgentBridgeManager()
+  const endpoint = typeof manager.getRuntimeState === 'function'
+    ? manager.getRuntimeState().endpoint
+    : undefined
+
+  try {
+    const readiness = await manager.checkReadiness({ timeoutMs: 750, connectRetryMs: 0 })
+    const error = redactAgentBridgeError(readiness.error, readiness.endpoint)
+    return {
+      status: readiness.status,
+      reachable: readiness.reachable,
+      ready: readiness.ready,
+      running: readiness.running,
+      attached: readiness.attached,
+      starting: readiness.starting,
+      stopping: readiness.stopping,
+      restart_scheduled: readiness.restartScheduled,
+      restart_attempts: readiness.restartAttempts,
+      endpoint_kind: readiness.endpointKind,
+      pid: readiness.pid,
+      error,
+    }
+  } catch (err) {
+    return {
+      status: 'unknown',
+      reachable: false,
+      error: redactAgentBridgeError(err instanceof Error ? err.message : String(err), endpoint),
+    }
+  }
+}
+
+function redactAgentBridgeError(error: string | undefined, endpoint?: string): string | undefined {
+  if (!error) return undefined
+  if (!endpoint) return error
+
+  const candidates = [endpoint]
+
+  if (endpoint.startsWith('ipc://')) {
+    candidates.push(endpoint.slice('ipc://'.length))
+  }
+
+  if (endpoint.startsWith('tcp://')) {
+    try {
+      const url = new URL(endpoint)
+      candidates.push(url.host)
+    } catch {
+      // Ignore malformed endpoints and fall back to the original string.
+    }
+  }
+
+  return candidates
+    .filter(candidate => candidate)
+    .reduce((message, candidate) => message.split(candidate).join('[redacted endpoint]'), error)
+}
+
 export async function healthCheck(ctx: any) {
   const raw = await hermesCli.getVersion()
   const hermesVersion = raw.split('\n')[0].replace('Hermes Agent ', '') || ''
+  const agentBridge = await getAgentBridgeHealth()
   ctx.body = {
     status: 'ok',
     platform: 'hermes-agent',
@@ -96,5 +154,6 @@ export async function healthCheck(ctx: any) {
       ? false
       : Boolean(LOCAL_VERSION && cachedLatestVersion && cachedLatestVersion !== LOCAL_VERSION),
     node_version: process.versions.node,
+    agent_bridge: agentBridge,
   }
 }

--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -583,12 +583,12 @@ export class AgentBridgeClient {
     })
   }
 
-  statusIfLoaded(sessionId: string, profile?: string): Promise<AgentBridgeResponse> {
+  statusIfLoaded(sessionId: string, profile?: string, options: AgentBridgeRequestOptions = {}): Promise<AgentBridgeResponse> {
     return this.request({
       action: 'status_if_loaded',
       session_id: sessionId,
       ...(profile ? { profile } : {}),
-    })
+    }, options)
   }
 
   destroy(sessionId: string, profile?: string, workerKey?: string): Promise<AgentBridgeResponse> {

--- a/packages/server/src/services/hermes/agent-bridge/manager.ts
+++ b/packages/server/src/services/hermes/agent-bridge/manager.ts
@@ -46,7 +46,7 @@ export interface AgentBridgeManagerRuntimeState {
 
 export type AgentBridgeEndpointKind = 'ipc' | 'tcp' | 'unknown'
 
-export type AgentBridgeReadinessStatus = 'ready' | 'starting' | 'stopping' | 'restarting' | 'unreachable'
+export type AgentBridgeReadinessStatus = 'ready' | 'starting' | 'recovering' | 'stopping' | 'restarting' | 'unreachable'
 
 export interface AgentBridgeReadinessOptions {
   timeoutMs?: number
@@ -78,6 +78,13 @@ function envPositiveInt(name: string): number | undefined {
   if (!raw) return undefined
   const value = Number(raw)
   return Number.isFinite(value) && value > 0 ? value : undefined
+}
+
+function isLegacyGlobalDefaultEndpoint(endpoint: string): boolean {
+  const normalized = endpoint.trim().toLowerCase()
+  return normalized === 'ipc:///tmp/hermes-agent-bridge.sock' ||
+    normalized === 'tcp://127.0.0.1:18765' ||
+    normalized === 'tcp://localhost:18765'
 }
 
 export function buildAgentBridgeProcessEnv(endpoint: string, hermesHome: string | undefined, agentRoot: string | undefined): NodeJS.ProcessEnv {
@@ -476,6 +483,7 @@ export class AgentBridgeManager {
   private child: ChildProcess | null = null
   private attached = false
   private starting: Promise<void> | null = null
+  private recovery: Promise<AgentBridgeReadiness> | null = null
   private ready = false
   private stopping = false
   private stopGeneration = 0
@@ -506,7 +514,88 @@ export class AgentBridgeManager {
     }
   }
 
-  async checkReadiness(options: AgentBridgeReadinessOptions = {}): Promise<AgentBridgeReadiness> {
+  private transientReadiness(status: AgentBridgeReadinessStatus, error?: string): AgentBridgeReadiness {
+    const state = this.getRuntimeState()
+    const endpoint = state.endpoint
+    const readiness: AgentBridgeReadiness = {
+      endpoint,
+      endpointKind: classifyEndpointKind(endpoint),
+      status,
+      reachable: false,
+      ready: false,
+      running: false,
+      attached: state.attached,
+      starting: state.starting,
+      stopping: state.stopping,
+      restartScheduled: state.restartScheduled,
+      restartAttempts: state.restartAttempts,
+      pid: state.pid,
+    }
+    return error ? { ...readiness, error } : readiness
+  }
+
+  private async waitForPromiseSettlementWithin(promise: Promise<unknown>, timeoutMs?: number): Promise<boolean> {
+    if (!timeoutMs || timeoutMs <= 0) {
+      try {
+        await promise
+      } catch {}
+      return true
+    }
+
+    return new Promise<boolean>((resolve) => {
+      let settled = false
+      const timeout = setTimeout(() => {
+        if (settled) return
+        settled = true
+        resolve(false)
+      }, timeoutMs)
+
+      promise.finally(() => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        resolve(true)
+      }).catch(() => {})
+    })
+  }
+
+  private async waitForReadinessWithin(
+    promise: Promise<AgentBridgeReadiness>,
+    timeoutMs?: number,
+  ): Promise<AgentBridgeReadiness | null> {
+    if (!timeoutMs || timeoutMs <= 0) {
+      return promise
+    }
+
+    return new Promise<AgentBridgeReadiness | null>((resolve) => {
+      let settled = false
+      const timeout = setTimeout(() => {
+        if (settled) return
+        settled = true
+        resolve(null)
+      }, timeoutMs)
+
+      promise.then(
+        (value) => {
+          if (settled) return
+          settled = true
+          clearTimeout(timeout)
+          resolve(value)
+        },
+        (err) => {
+          if (settled) return
+          settled = true
+          clearTimeout(timeout)
+          resolve(this.transientReadiness('recovering', normalizeReadinessError(this.endpoint, err)))
+        },
+      )
+    })
+  }
+
+  private async checkReadinessInternal(
+    options: AgentBridgeReadinessOptions = {},
+    ignoreRecovery = false,
+  ): Promise<AgentBridgeReadiness> {
     const state = this.getRuntimeState()
     const endpoint = state.endpoint
     const endpointKind = classifyEndpointKind(endpoint)
@@ -529,6 +618,16 @@ export class AgentBridgeManager {
       return {
         ...readiness,
         status: 'stopping',
+        reachable: false,
+        ready: false,
+        running: false,
+      }
+    }
+
+    if (!ignoreRecovery && this.recovery) {
+      return {
+        ...readiness,
+        status: 'recovering',
         reachable: false,
         ready: false,
         running: false,
@@ -588,21 +687,67 @@ export class AgentBridgeManager {
     }
   }
 
+  async checkReadiness(options: AgentBridgeReadinessOptions = {}): Promise<AgentBridgeReadiness> {
+    return this.checkReadinessInternal(options)
+  }
+
+  private async performManagedRecovery(
+    child: ChildProcess,
+    options: AgentBridgeEnsureReadyOptions,
+  ): Promise<AgentBridgeReadiness> {
+    const recoveryStopGeneration = this.stopGeneration
+    this.ready = false
+
+    const exited = await this.waitForManagedChildExit(child)
+    if (!exited) {
+      const message = `managed child pid=${child.pid} did not exit after SIGTERM/SIGKILL during recovery`
+      const recoveryReadiness = await this.checkReadinessInternal({ ...options, connectRetryMs: 0 }, true)
+      return {
+        ...recoveryReadiness,
+        status: 'unreachable',
+        reachable: false,
+        ready: false,
+        running: false,
+        error: recoveryReadiness.error ? `${message}; ${recoveryReadiness.error}` : message,
+      }
+    }
+
+    if (this.stopGeneration !== recoveryStopGeneration || this.stopping) {
+      return this.checkReadinessInternal({ ...options, connectRetryMs: 0 }, true)
+    }
+
+    try {
+      await this.start()
+      return await this.checkReadinessInternal(options, true)
+    } catch (err) {
+      const recoveredReadiness = await this.checkReadinessInternal({ ...options, connectRetryMs: 0 }, true)
+      const error = mergeStartFailureReadinessError(recoveredReadiness, err)
+      return error
+        ? { ...recoveredReadiness, error }
+        : recoveredReadiness
+    }
+  }
+
   async ensureReady(options: AgentBridgeEnsureReadyOptions = {}): Promise<AgentBridgeReadiness> {
     const readiness = await this.checkReadiness(options)
     if (readiness.reachable) {
       return readiness
     }
 
-    if (readiness.status === 'starting' && this.starting) {
-      try {
-        await this.starting
-      } catch {}
-      return this.checkReadiness(options)
-    }
-
     if (options.recover === false) {
       return readiness
+    }
+
+    if (this.recovery) {
+      const recovered = await this.waitForReadinessWithin(this.recovery, options.timeoutMs)
+      return recovered ?? this.transientReadiness('recovering')
+    }
+
+    if (readiness.status === 'starting' && this.starting) {
+      const completed = await this.waitForPromiseSettlementWithin(this.starting, options.timeoutMs)
+      return completed
+        ? this.checkReadiness(options)
+        : this.transientReadiness('starting')
     }
 
     if (readiness.status !== 'unreachable') {
@@ -615,25 +760,25 @@ export class AgentBridgeManager {
       return readiness
     }
 
-    const recoveryStopGeneration = this.stopGeneration
-    this.ready = false
-    this.child = null
-    await this.waitForManagedChildExit(child)
-
-    if (this.stopGeneration !== recoveryStopGeneration || this.stopping) {
-      return this.checkReadiness({ ...options, connectRetryMs: 0 })
+    if (isLegacyGlobalDefaultEndpoint(this.endpoint)) {
+      this.ready = false
+      const message = 'managed bridge recovery is disabled for legacy global default endpoint; merge endpoint scoping before enabling recovery'
+      return {
+        ...readiness,
+        error: readiness.error ? `${readiness.error}; ${message}` : message,
+      }
     }
 
-    try {
-      await this.start()
-      return await this.checkReadiness(options)
-    } catch (err) {
-      const recoveredReadiness = await this.checkReadiness({ ...options, connectRetryMs: 0 })
-      const error = mergeStartFailureReadinessError(recoveredReadiness, err)
-      return error
-        ? { ...recoveredReadiness, error }
-        : recoveredReadiness
-    }
+    let recoveryPromise: Promise<AgentBridgeReadiness>
+    recoveryPromise = this.performManagedRecovery(child, options).finally(() => {
+      if (this.recovery === recoveryPromise) {
+        this.recovery = null
+      }
+    })
+    this.recovery = recoveryPromise
+
+    const recovered = await this.waitForReadinessWithin(recoveryPromise, options.timeoutMs)
+    return recovered ?? this.transientReadiness('recovering')
   }
 
   async start(): Promise<void> {
@@ -652,8 +797,8 @@ export class AgentBridgeManager {
     }
   }
 
-  private async waitForManagedChildExit(child: ChildProcess): Promise<void> {
-    await new Promise<void>((resolve) => {
+  private async waitForManagedChildExit(child: ChildProcess): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
       const gracefulTimeoutMs = envPositiveInt('HERMES_AGENT_BRIDGE_RECOVERY_EXIT_TIMEOUT_MS')
         ?? DEFAULT_AGENT_BRIDGE_RECOVERY_EXIT_TIMEOUT_MS
       const sigkillWaitMs = envPositiveInt('HERMES_AGENT_BRIDGE_RECOVERY_SIGKILL_WAIT_MS')
@@ -669,23 +814,36 @@ export class AgentBridgeManager {
         child.off('exit', onExit)
       }
 
-      const finish = () => {
+      const finish = (exited: boolean) => {
         if (settled) return
         settled = true
         cleanup()
-        resolve()
+        resolve(exited)
       }
 
       const onExit = () => {
-        finish()
+        if (this.child === child) {
+          this.child = null
+        }
+        finish(true)
       }
 
       const sendSignal = (signal: NodeJS.Signals) => {
         try {
-          child.kill(signal)
+          // Node marks child.killed=true after a signal is successfully sent, not
+          // after the process has actually exited. Recovery must still be able to
+          // escalate SIGTERM -> SIGKILL while waiting for an observed exit.
+          if (signal === 'SIGKILL' || !child.killed) {
+            child.kill(signal)
+          }
         } catch (err) {
           logger.warn(err, '[agent-bridge] failed to signal managed child pid=%s signal=%s', child.pid, signal)
         }
+      }
+
+      if (child.exitCode != null || child.signalCode != null) {
+        onExit()
+        return
       }
 
       child.once('exit', onExit)
@@ -701,11 +859,11 @@ export class AgentBridgeManager {
         sigkillTimeout = setTimeout(() => {
           if (settled) return
           logger.warn(
-            '[agent-bridge] managed child pid=%s still has not exited %dms after SIGKILL; continuing recovery',
+            '[agent-bridge] managed child pid=%s still has not exited %dms after SIGKILL; not starting a replacement',
             child.pid,
             sigkillWaitMs,
           )
-          finish()
+          finish(false)
         }, sigkillWaitMs)
       }, gracefulTimeoutMs)
 
@@ -919,7 +1077,11 @@ export class AgentBridgeManager {
       // Allow enough time for the broker to gracefully stop its worker
       // subprocesses (WorkerProcess.stop uses a 3s timeout per worker).
       const timeout = setTimeout(() => {
-        if (!child.killed) child.kill('SIGKILL')
+        // `child.killed` only means a signal was sent. Escalate on shutdown
+        // timeout even if SIGTERM was already sent by recovery.
+        try {
+          child.kill('SIGKILL')
+        } catch {}
         resolveStop()
       }, 10_000)
       child.once('exit', () => {

--- a/packages/server/src/services/hermes/agent-bridge/manager.ts
+++ b/packages/server/src/services/hermes/agent-bridge/manager.ts
@@ -42,6 +42,31 @@ export interface AgentBridgeManagerRuntimeState {
   restartAttempts: number
 }
 
+export type AgentBridgeEndpointKind = 'ipc' | 'tcp' | 'unknown'
+
+export type AgentBridgeReadinessStatus = 'ready' | 'starting' | 'stopping' | 'restarting' | 'unreachable'
+
+export interface AgentBridgeReadinessOptions {
+  timeoutMs?: number
+  connectRetryMs?: number
+}
+
+export interface AgentBridgeReadiness {
+  endpoint: string
+  endpointKind: AgentBridgeEndpointKind
+  status: AgentBridgeReadinessStatus
+  reachable: boolean
+  ready: boolean
+  running: boolean
+  attached: boolean
+  starting: boolean
+  stopping: boolean
+  restartScheduled: boolean
+  restartAttempts: number
+  pid?: number
+  error?: string
+}
+
 function envPositiveInt(name: string): number | undefined {
   const raw = process.env[name]
   if (!raw) return undefined
@@ -246,6 +271,23 @@ function isTcpEndpoint(endpoint: string): boolean {
   return endpoint.startsWith('tcp://')
 }
 
+function classifyEndpointKind(endpoint: string): AgentBridgeEndpointKind {
+  if (endpoint.startsWith('ipc://')) return 'ipc'
+  if (endpoint.startsWith('tcp://')) return 'tcp'
+  return 'unknown'
+}
+
+function normalizeReadinessError(endpoint: string, err: unknown): string {
+  if (!endpoint.trim()) return 'agent bridge endpoint is not configured'
+  const message = err instanceof Error
+    ? err.message
+    : typeof err === 'string'
+      ? err
+      : undefined
+  const normalized = message?.replace(/^Error:\s*/, '').trim()
+  return normalized || 'agent bridge is unreachable'
+}
+
 function isDesktopRuntime(): boolean {
   return String(process.env.HERMES_DESKTOP || '').trim().toLowerCase() === 'true'
 }
@@ -440,6 +482,88 @@ export class AgentBridgeManager {
       stopping: this.stopping,
       restartScheduled: !!this.restartTimer,
       restartAttempts: this.restartAttempts,
+    }
+  }
+
+  async checkReadiness(options: AgentBridgeReadinessOptions = {}): Promise<AgentBridgeReadiness> {
+    const state = this.getRuntimeState()
+    const endpoint = state.endpoint
+    const endpointKind = classifyEndpointKind(endpoint)
+    const readiness: AgentBridgeReadiness = {
+      endpoint,
+      endpointKind,
+      status: 'unreachable',
+      reachable: false,
+      ready: state.ready,
+      running: state.running,
+      attached: state.attached,
+      starting: state.starting,
+      stopping: state.stopping,
+      restartScheduled: state.restartScheduled,
+      restartAttempts: state.restartAttempts,
+      pid: state.pid,
+    }
+
+    if (state.stopping) {
+      return {
+        ...readiness,
+        status: 'stopping',
+        reachable: false,
+        ready: false,
+        running: false,
+      }
+    }
+
+    if (state.starting) {
+      return {
+        ...readiness,
+        status: 'starting',
+        reachable: false,
+        ready: false,
+        running: false,
+      }
+    }
+
+    if (state.restartScheduled) {
+      return {
+        ...readiness,
+        status: 'restarting',
+        reachable: false,
+        ready: false,
+        running: false,
+      }
+    }
+
+    if (!endpoint.trim()) {
+      return {
+        ...readiness,
+        ready: false,
+        running: false,
+        error: normalizeReadinessError(endpoint, undefined),
+      }
+    }
+
+    try {
+      const client = new AgentBridgeClient({
+        endpoint,
+        timeoutMs: options.timeoutMs ?? 1000,
+        connectRetryMs: options.connectRetryMs ?? 0,
+      })
+      await client.ping()
+      return {
+        ...readiness,
+        status: 'ready',
+        reachable: true,
+        ready: true,
+        running: true,
+      }
+    } catch (err) {
+      return {
+        ...readiness,
+        ready: false,
+        running: false,
+        error: normalizeReadinessError(endpoint, err),
+      }
     }
   }
 
@@ -648,6 +772,7 @@ export class AgentBridgeManager {
       }
       this.ready = false
       this.attached = false
+      this.stopping = false
       return
     }
     this.ready = false
@@ -669,6 +794,7 @@ export class AgentBridgeManager {
         child.kill('SIGTERM')
       }
     })
+    this.stopping = false
   }
 }
 

--- a/packages/server/src/services/hermes/agent-bridge/manager.ts
+++ b/packages/server/src/services/hermes/agent-bridge/manager.ts
@@ -9,6 +9,8 @@ import { AgentBridgeClient, DEFAULT_AGENT_BRIDGE_ENDPOINT } from './client'
 const DEFAULT_AGENT_BRIDGE_STARTUP_TIMEOUT_MS = 120000
 const DEFAULT_AGENT_BRIDGE_RESTART_DELAY_MS = 1000
 const MAX_AGENT_BRIDGE_RESTART_DELAY_MS = 30000
+const DEFAULT_AGENT_BRIDGE_RECOVERY_EXIT_TIMEOUT_MS = 5000
+const DEFAULT_AGENT_BRIDGE_RECOVERY_SIGKILL_WAIT_MS = 250
 const OPENROUTER_WEB_UI_ATTRIBUTION_ENV = {
   HERMES_OPENROUTER_APP_REFERER: 'https://hermes-studio.ai',
   HERMES_OPENROUTER_APP_TITLE: 'Hermes Studio',
@@ -476,6 +478,7 @@ export class AgentBridgeManager {
   private starting: Promise<void> | null = null
   private ready = false
   private stopping = false
+  private stopGeneration = 0
   private restartTimer: NodeJS.Timeout | null = null
   private restartAttempts = 0
 
@@ -612,14 +615,14 @@ export class AgentBridgeManager {
       return readiness
     }
 
+    const recoveryStopGeneration = this.stopGeneration
     this.ready = false
     this.child = null
+    await this.waitForManagedChildExit(child)
 
-    if (!child.killed) {
-      child.kill('SIGTERM')
+    if (this.stopGeneration !== recoveryStopGeneration || this.stopping) {
+      return this.checkReadiness({ ...options, connectRetryMs: 0 })
     }
-
-    await new Promise(resolve => setTimeout(resolve, 100))
 
     try {
       await this.start()
@@ -647,6 +650,67 @@ export class AgentBridgeManager {
     } finally {
       this.starting = null
     }
+  }
+
+  private async waitForManagedChildExit(child: ChildProcess): Promise<void> {
+    await new Promise<void>((resolve) => {
+      const gracefulTimeoutMs = envPositiveInt('HERMES_AGENT_BRIDGE_RECOVERY_EXIT_TIMEOUT_MS')
+        ?? DEFAULT_AGENT_BRIDGE_RECOVERY_EXIT_TIMEOUT_MS
+      const sigkillWaitMs = envPositiveInt('HERMES_AGENT_BRIDGE_RECOVERY_SIGKILL_WAIT_MS')
+        ?? DEFAULT_AGENT_BRIDGE_RECOVERY_SIGKILL_WAIT_MS
+
+      let settled = false
+      let gracefulTimeout: NodeJS.Timeout | null = null
+      let sigkillTimeout: NodeJS.Timeout | null = null
+
+      const cleanup = () => {
+        if (gracefulTimeout) clearTimeout(gracefulTimeout)
+        if (sigkillTimeout) clearTimeout(sigkillTimeout)
+        child.off('exit', onExit)
+      }
+
+      const finish = () => {
+        if (settled) return
+        settled = true
+        cleanup()
+        resolve()
+      }
+
+      const onExit = () => {
+        finish()
+      }
+
+      const sendSignal = (signal: NodeJS.Signals) => {
+        try {
+          child.kill(signal)
+        } catch (err) {
+          logger.warn(err, '[agent-bridge] failed to signal managed child pid=%s signal=%s', child.pid, signal)
+        }
+      }
+
+      child.once('exit', onExit)
+
+      gracefulTimeout = setTimeout(() => {
+        if (settled) return
+        logger.warn(
+          '[agent-bridge] managed child pid=%s did not exit after SIGTERM within %dms; sending SIGKILL',
+          child.pid,
+          gracefulTimeoutMs,
+        )
+        sendSignal('SIGKILL')
+        sigkillTimeout = setTimeout(() => {
+          if (settled) return
+          logger.warn(
+            '[agent-bridge] managed child pid=%s still has not exited %dms after SIGKILL; continuing recovery',
+            child.pid,
+            sigkillWaitMs,
+          )
+          finish()
+        }, sigkillWaitMs)
+      }, gracefulTimeoutMs)
+
+      sendSignal('SIGTERM')
+    })
   }
 
   private async startProcess(): Promise<void> {
@@ -678,10 +742,15 @@ export class AgentBridgeManager {
     this.ready = false
 
     child.once('exit', (code, signal) => {
-      const shouldRestart = this.ready && !this.stopping && this.child === child && this.autoRestartEnabled()
+      const isCurrentChild = this.child === child
+      if (!isCurrentChild) {
+        logger.warn('[agent-bridge] stale managed child exit ignored code=%s signal=%s pid=%s', code, signal, child.pid)
+        return
+      }
+      const shouldRestart = this.ready && !this.stopping && this.autoRestartEnabled()
       logger.warn('[agent-bridge] exited code=%s signal=%s', code, signal)
       this.ready = false
-      if (this.child === child) this.child = null
+      this.child = null
       if (shouldRestart) this.scheduleRestart(code, signal)
     })
 
@@ -817,6 +886,7 @@ export class AgentBridgeManager {
   }
 
   async stop(): Promise<void> {
+    this.stopGeneration += 1
     this.stopping = true
     if (this.restartTimer) {
       clearTimeout(this.restartTimer)

--- a/packages/server/src/services/hermes/agent-bridge/manager.ts
+++ b/packages/server/src/services/hermes/agent-bridge/manager.ts
@@ -51,6 +51,10 @@ export interface AgentBridgeReadinessOptions {
   connectRetryMs?: number
 }
 
+export interface AgentBridgeEnsureReadyOptions extends AgentBridgeReadinessOptions {
+  recover?: boolean
+}
+
 export interface AgentBridgeReadiness {
   endpoint: string
   endpointKind: AgentBridgeEndpointKind
@@ -286,6 +290,20 @@ function normalizeReadinessError(endpoint: string, err: unknown): string {
       : undefined
   const normalized = message?.replace(/^Error:\s*/, '').trim()
   return normalized || 'agent bridge is unreachable'
+}
+
+function mergeStartFailureReadinessError(readiness: AgentBridgeReadiness, err: unknown): string | undefined {
+  if (readiness.reachable) {
+    return undefined
+  }
+
+  const readinessError = readiness.error?.trim()
+  const startError = normalizeReadinessError(readiness.endpoint, err)
+  if (readinessError && readinessError !== startError) {
+    return `${readinessError}; start failed: ${startError}`
+  }
+
+  return readinessError || startError
 }
 
 function isDesktopRuntime(): boolean {
@@ -564,6 +582,54 @@ export class AgentBridgeManager {
         running: false,
         error: normalizeReadinessError(endpoint, err),
       }
+    }
+  }
+
+  async ensureReady(options: AgentBridgeEnsureReadyOptions = {}): Promise<AgentBridgeReadiness> {
+    const readiness = await this.checkReadiness(options)
+    if (readiness.reachable) {
+      return readiness
+    }
+
+    if (readiness.status === 'starting' && this.starting) {
+      try {
+        await this.starting
+      } catch {}
+      return this.checkReadiness(options)
+    }
+
+    if (options.recover === false) {
+      return readiness
+    }
+
+    if (readiness.status !== 'unreachable') {
+      return readiness
+    }
+
+    const child = this.child
+    if (!child || this.attached) {
+      this.ready = false
+      return readiness
+    }
+
+    this.ready = false
+    this.child = null
+
+    if (!child.killed) {
+      child.kill('SIGTERM')
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    try {
+      await this.start()
+      return await this.checkReadiness(options)
+    } catch (err) {
+      const recoveredReadiness = await this.checkReadiness({ ...options, connectRetryMs: 0 })
+      const error = mergeStartFailureReadinessError(recoveredReadiness, err)
+      return error
+        ? { ...recoveredReadiness, error }
+        : recoveredReadiness
     }
   }
 

--- a/packages/server/src/services/hermes/agent-bridge/redact.ts
+++ b/packages/server/src/services/hermes/agent-bridge/redact.ts
@@ -1,0 +1,37 @@
+export function redactAgentBridgeError(
+  error: string | undefined,
+  endpoint?: string,
+  replacement = '[redacted endpoint]',
+): string | undefined {
+  if (!error) return error
+
+  let redacted = error
+  const configuredEndpoint = endpoint?.trim()
+  const candidates = new Set<string>()
+
+  if (configuredEndpoint) {
+    candidates.add(configuredEndpoint)
+
+    if (configuredEndpoint.startsWith('ipc://')) {
+      const barePath = configuredEndpoint.slice('ipc://'.length)
+      if (barePath) candidates.add(barePath)
+    }
+
+    if (configuredEndpoint.startsWith('tcp://')) {
+      try {
+        const url = new URL(configuredEndpoint)
+        if (url.host) candidates.add(url.host)
+      } catch {
+        // Ignore malformed configured endpoints and fall back to literal replacement.
+      }
+    }
+  }
+
+  for (const candidate of candidates) {
+    redacted = redacted.split(candidate).join(replacement)
+  }
+
+  return redacted
+    .replace(/ipc:\/\/[^\s),;]+/g, replacement)
+    .replace(/(?:[A-Za-z]:)?[^\s),;]*agent-bridge\.sock/g, replacement)
+}

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -15,6 +15,7 @@ import { getSession } from '../../../db/hermes/session-store'
 import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../hermes-profile'
 import { AgentBridgeClient } from '../agent-bridge'
 import { getAgentBridgeManager } from '../agent-bridge/manager'
+import { redactAgentBridgeError } from '../agent-bridge/redact'
 import { handleApiRun, resolveRunSource, loadSessionStateFromDb } from './handle-api-run'
 import { handleBridgeRun, resumeBridgeRun } from './handle-bridge-run'
 import { handleAbort } from './abort'
@@ -34,43 +35,14 @@ function currentProfileFromSocket(socket: Socket): string {
   return socketProfile || getActiveProfileName() || 'default'
 }
 
-function redactConfiguredTcpLoopbackEndpoint(error: string, endpoint?: string): string {
-  if (!endpoint?.startsWith('tcp://')) return error
-
-  try {
-    const url = new URL(endpoint)
-    if (!url.port) return error
-    const hosts = new Set<string>()
-    if (url.hostname === '127.0.0.1' || url.hostname === 'localhost' || url.hostname === '::1') {
-      hosts.add(`127.0.0.1:${url.port}`)
-      hosts.add(`localhost:${url.port}`)
-      hosts.add(`::1:${url.port}`)
-      hosts.add(`[::1]:${url.port}`)
-    }
-
-    let redacted = error
-    for (const host of hosts) {
-      redacted = redacted.split(host).join('configured endpoint')
-    }
-    return redacted
-  } catch {
-    return error
-  }
-}
-
 function redactBridgeReadyError(error: string, endpoint?: string): string {
   const normalized = error.replace(/^Error:\s*/, '').trim() || 'unknown error'
-  let redacted = normalized
-  if (endpoint?.trim()) {
-    redacted = redacted.split(endpoint).join('configured endpoint')
-  }
-  redacted = redactConfiguredTcpLoopbackEndpoint(redacted, endpoint)
-  return redacted.replace(/ipc:\/\/[^\s),;]+/g, 'IPC endpoint')
+  return redactAgentBridgeError(normalized, endpoint, 'configured endpoint') || 'unknown error'
 }
 
 export async function ensureBridgeReadyForChatRun(): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
-    const readiness = await getAgentBridgeManager().ensureReady({ timeoutMs: 1000, connectRetryMs: 0 })
+    const readiness = await getAgentBridgeManager().ensureReady({ timeoutMs: 1000, connectRetryMs: 0, recover: false })
     if (readiness.reachable) {
       return { ok: true }
     }
@@ -410,6 +382,9 @@ export class ChatRunSocket {
       this.sessionMap.set(sid, state)
     }
     await this.reattachBridgeRun(socket, sid, state)
+    const resumeEvents = state.isWorking
+      ? state.events
+      : (state.events || []).filter(evt => evt?.event === 'run.reattach_failed')
     socket.emit('resumed', {
       session_id: sid,
       messages: state.messages,
@@ -419,7 +394,7 @@ export class ChatRunSocket {
       hasMoreBefore: state.hasMoreBefore,
       isWorking: state.isWorking,
       isAborting: state.isAborting || false,
-      events: state.isWorking ? state.events : [],
+      events: resumeEvents,
       inputTokens: state.inputTokens,
       outputTokens: state.outputTokens,
       contextTokens: state.contextTokens,
@@ -437,24 +412,13 @@ export class ChatRunSocket {
     const profile = session?.profile || currentProfileFromSocket(socket)
     let pollKey: string | undefined
     try {
-      const status = await this.bridge.statusIfLoaded(sid, profile) as Record<string, unknown>
+      const status = await this.bridge.statusIfLoaded(sid, profile, { timeoutMs: 1000 }) as Record<string, unknown>
       const running = status.running === true
       const runId = typeof status.current_run_id === 'string' ? status.current_run_id : ''
       if (!running || !runId) return
       pollKey = `${sid}:${runId}`
       if (this.bridgeResumePolls.has(pollKey)) return
       this.bridgeResumePolls.add(pollKey)
-      const bridgeReady = await ensureBridgeReadyForChatRun()
-      if (!bridgeReady.ok) {
-        this.bridgeResumePolls.delete(pollKey)
-        this.rollbackBridgeReattachState(state)
-        this.emitToSession(socket, sid, 'run.failed', {
-          event: 'run.failed',
-          session_id: sid,
-          error: `Agent Bridge is not reachable: ${bridgeReady.error}`,
-        })
-        return
-      }
       state.isWorking = true
       state.isAborting = state.isAborting === true
       state.runId = runId
@@ -483,26 +447,24 @@ export class ChatRunSocket {
       logger.info('[chat-run-socket] reattached running bridge run %s for session %s', runId, sid)
     } catch (err) {
       if (pollKey) this.bridgeResumePolls.delete(pollKey)
-      this.rollbackBridgeReattachState(state)
       logger.warn(err, '[chat-run-socket] bridge status lookup failed while resuming session %s', sid)
       const endpoint = getAgentBridgeManager().getRuntimeState?.().endpoint
       const error = redactBridgeReadyError(err instanceof Error ? err.message : String(err), endpoint)
-      this.emitToSession(socket, sid, 'run.failed', {
-        event: 'run.failed',
+      const payload = {
+        event: 'run.reattach_failed',
         session_id: sid,
-        error: `Agent Bridge is not reachable: ${error}`,
-      })
+        error,
+        message: `Unable to confirm Agent Bridge status while resuming: ${error}`,
+        text: `Unable to confirm Agent Bridge status while resuming: ${error}`,
+      }
+      const nextEvents = [...(state.events || [])]
+      const lastEvent = nextEvents[nextEvents.length - 1]
+      if (lastEvent?.event !== 'run.reattach_failed' || lastEvent?.data?.error !== error) {
+        nextEvents.push({ event: 'run.reattach_failed', data: payload })
+        state.events = nextEvents
+      }
+      this.emitToSession(socket, sid, 'run.reattach_failed', payload)
     }
-  }
-
-  private rollbackBridgeReattachState(state: SessionState) {
-    state.isWorking = false
-    state.isAborting = false
-    state.runId = undefined
-    state.activeRunMarker = undefined
-    state.profile = undefined
-    state.source = undefined
-    state.events = []
   }
 
   private resumeInstructionsForSession(sessionId: string): string {

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -14,6 +14,7 @@ import { getSystemPrompt } from '../../../lib/llm-prompt'
 import { getSession } from '../../../db/hermes/session-store'
 import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../hermes-profile'
 import { AgentBridgeClient } from '../agent-bridge'
+import { getAgentBridgeManager } from '../agent-bridge/manager'
 import { handleApiRun, resolveRunSource, loadSessionStateFromDb } from './handle-api-run'
 import { handleBridgeRun, resumeBridgeRun } from './handle-bridge-run'
 import { handleAbort } from './abort'
@@ -31,6 +32,33 @@ function currentProfileFromSocket(socket: Socket): string {
     ? socket.handshake.query.profile.trim()
     : ''
   return socketProfile || getActiveProfileName() || 'default'
+}
+
+function redactBridgeReadyError(error: string, endpoint?: string): string {
+  const normalized = error.replace(/^Error:\s*/, '').trim() || 'unknown error'
+  let redacted = normalized
+  if (endpoint?.trim()) {
+    redacted = redacted.split(endpoint).join('configured endpoint')
+  }
+  return redacted.replace(/ipc:\/\/[^\s),;]+/g, 'IPC endpoint')
+}
+
+export async function ensureBridgeReadyForChatRun(): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const readiness = await getAgentBridgeManager().ensureReady({ timeoutMs: 1000, connectRetryMs: 0 })
+    if (readiness.reachable) {
+      return { ok: true }
+    }
+    return {
+      ok: false,
+      error: redactBridgeReadyError(readiness.error || `Agent Bridge is ${readiness.status}`, readiness.endpoint),
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      error: redactBridgeReadyError(err instanceof Error ? err.message : String(err)),
+    }
+  }
 }
 
 export class ChatRunSocket {
@@ -302,6 +330,23 @@ export class ChatRunSocket {
     if (data.session_id && source === 'cli' && isSessionCommand(data.input)) return
 
     if (source === 'cli') {
+      const bridgeReady = await ensureBridgeReadyForChatRun()
+      if (!bridgeReady.ok) {
+        if (data.session_id) {
+          const state = this.sessionMap.get(data.session_id)
+          if (state && !state.runId && !state.abortController && !state.activeRunMarker) {
+            state.isWorking = false
+            state.profile = undefined
+          }
+        }
+        socket.emit('run.failed', {
+          event: 'run.failed',
+          session_id: data.session_id,
+          error: `Agent Bridge is not reachable: ${bridgeReady.error}`,
+        })
+        return
+      }
+
       let fullInstructions = data.instructions
         ? `${getSystemPrompt()}\n${data.instructions}`
         : getSystemPrompt()
@@ -365,20 +410,34 @@ export class ChatRunSocket {
     if (state.runId && state.isWorking) return
     const session = getSession(sid)
     const profile = session?.profile || currentProfileFromSocket(socket)
+    let reattachedStateApplied = false
     try {
       const status = await this.bridge.statusIfLoaded(sid, profile) as Record<string, unknown>
       const running = status.running === true
       const runId = typeof status.current_run_id === 'string' ? status.current_run_id : ''
       if (!running || !runId) return
-      state.isWorking = true
-      state.isAborting = state.isAborting === true
-      state.runId = runId
-      state.profile = profile
-      state.source = 'cli'
-      state.events = []
       const pollKey = `${sid}:${runId}`
       if (this.bridgeResumePolls.has(pollKey)) return
       this.bridgeResumePolls.add(pollKey)
+      const bridgeReady = await ensureBridgeReadyForChatRun()
+      if (!bridgeReady.ok) {
+        this.bridgeResumePolls.delete(pollKey)
+        this.rollbackBridgeReattachState(state)
+        this.emitToSession(socket, sid, 'run.failed', {
+          event: 'run.failed',
+          session_id: sid,
+          error: `Agent Bridge is not reachable: ${bridgeReady.error}`,
+        })
+        return
+      }
+      state.isWorking = true
+      state.isAborting = state.isAborting === true
+      state.runId = runId
+      state.activeRunMarker = undefined
+      state.profile = profile
+      state.source = 'cli'
+      state.events = []
+      reattachedStateApplied = true
       const instructions = this.resumeInstructionsForSession(sid)
       void resumeBridgeRun(
         this.nsp,
@@ -399,8 +458,20 @@ export class ChatRunSocket {
       })
       logger.info('[chat-run-socket] reattached running bridge run %s for session %s', runId, sid)
     } catch (err) {
+      if (reattachedStateApplied) {
+        this.rollbackBridgeReattachState(state)
+      }
       logger.warn(err, '[chat-run-socket] bridge status lookup failed while resuming session %s', sid)
     }
+  }
+
+  private rollbackBridgeReattachState(state: SessionState) {
+    state.isWorking = false
+    state.runId = undefined
+    state.activeRunMarker = undefined
+    state.profile = undefined
+    state.source = undefined
+    state.events = []
   }
 
   private resumeInstructionsForSession(sessionId: string): string {

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -329,18 +329,40 @@ export class ChatRunSocket {
     if (source === 'cli') {
       const bridgeReady = await ensureBridgeReadyForChatRun()
       if (!bridgeReady.ok) {
+        let shouldDequeueNext = false
+        let queueRemaining = 0
         if (data.session_id) {
           const state = this.sessionMap.get(data.session_id)
-          if (state && !state.runId && !state.abortController && !state.activeRunMarker) {
-            state.isWorking = false
-            state.profile = undefined
+          queueRemaining = state?.queue?.length ?? 0
+          const canReleaseCurrentRun = state && !state.runId && !state.abortController && !state.activeRunMarker
+          if (canReleaseCurrentRun) {
+            if (queueRemaining > 0) {
+              const nextQueuedRun = state.queue[0]
+              state.isWorking = true
+              state.profile = nextQueuedRun?.profile || profile
+              state.source = nextQueuedRun?.source
+              shouldDequeueNext = true
+            } else {
+              state.isWorking = false
+              state.profile = undefined
+            }
           }
         }
-        socket.emit('run.failed', {
+        const payload: {
+          event: 'run.failed'
+          session_id?: string
+          error: string
+          queue_remaining?: number
+        } = {
           event: 'run.failed',
           session_id: data.session_id,
           error: `Agent Bridge is not reachable: ${bridgeReady.error}`,
-        })
+        }
+        if (queueRemaining > 0) payload.queue_remaining = queueRemaining
+        socket.emit('run.failed', payload)
+        if (data.session_id && shouldDequeueNext) {
+          this.dequeueNextQueuedRun(socket, data.session_id, profile)
+        }
         return
       }
 

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -34,12 +34,37 @@ function currentProfileFromSocket(socket: Socket): string {
   return socketProfile || getActiveProfileName() || 'default'
 }
 
+function redactConfiguredTcpLoopbackEndpoint(error: string, endpoint?: string): string {
+  if (!endpoint?.startsWith('tcp://')) return error
+
+  try {
+    const url = new URL(endpoint)
+    if (!url.port) return error
+    const hosts = new Set<string>()
+    if (url.hostname === '127.0.0.1' || url.hostname === 'localhost' || url.hostname === '::1') {
+      hosts.add(`127.0.0.1:${url.port}`)
+      hosts.add(`localhost:${url.port}`)
+      hosts.add(`::1:${url.port}`)
+      hosts.add(`[::1]:${url.port}`)
+    }
+
+    let redacted = error
+    for (const host of hosts) {
+      redacted = redacted.split(host).join('configured endpoint')
+    }
+    return redacted
+  } catch {
+    return error
+  }
+}
+
 function redactBridgeReadyError(error: string, endpoint?: string): string {
   const normalized = error.replace(/^Error:\s*/, '').trim() || 'unknown error'
   let redacted = normalized
   if (endpoint?.trim()) {
     redacted = redacted.split(endpoint).join('configured endpoint')
   }
+  redacted = redactConfiguredTcpLoopbackEndpoint(redacted, endpoint)
   return redacted.replace(/ipc:\/\/[^\s),;]+/g, 'IPC endpoint')
 }
 
@@ -410,13 +435,13 @@ export class ChatRunSocket {
     if (state.runId && state.isWorking) return
     const session = getSession(sid)
     const profile = session?.profile || currentProfileFromSocket(socket)
-    let reattachedStateApplied = false
+    let pollKey: string | undefined
     try {
       const status = await this.bridge.statusIfLoaded(sid, profile) as Record<string, unknown>
       const running = status.running === true
       const runId = typeof status.current_run_id === 'string' ? status.current_run_id : ''
       if (!running || !runId) return
-      const pollKey = `${sid}:${runId}`
+      pollKey = `${sid}:${runId}`
       if (this.bridgeResumePolls.has(pollKey)) return
       this.bridgeResumePolls.add(pollKey)
       const bridgeReady = await ensureBridgeReadyForChatRun()
@@ -437,7 +462,6 @@ export class ChatRunSocket {
       state.profile = profile
       state.source = 'cli'
       state.events = []
-      reattachedStateApplied = true
       const instructions = this.resumeInstructionsForSession(sid)
       void resumeBridgeRun(
         this.nsp,
@@ -454,19 +478,26 @@ export class ChatRunSocket {
         this.bridge,
         this.dequeueNextQueuedRun.bind(this),
       ).finally(() => {
-        this.bridgeResumePolls.delete(pollKey)
+        if (pollKey) this.bridgeResumePolls.delete(pollKey!)
       })
       logger.info('[chat-run-socket] reattached running bridge run %s for session %s', runId, sid)
     } catch (err) {
-      if (reattachedStateApplied) {
-        this.rollbackBridgeReattachState(state)
-      }
+      if (pollKey) this.bridgeResumePolls.delete(pollKey)
+      this.rollbackBridgeReattachState(state)
       logger.warn(err, '[chat-run-socket] bridge status lookup failed while resuming session %s', sid)
+      const endpoint = getAgentBridgeManager().getRuntimeState?.().endpoint
+      const error = redactBridgeReadyError(err instanceof Error ? err.message : String(err), endpoint)
+      this.emitToSession(socket, sid, 'run.failed', {
+        event: 'run.failed',
+        session_id: sid,
+        error: `Agent Bridge is not reachable: ${error}`,
+      })
     }
   }
 
   private rollbackBridgeReattachState(state: SessionState) {
     state.isWorking = false
+    state.isAborting = false
     state.runId = undefined
     state.activeRunMarker = undefined
     state.profile = undefined

--- a/tests/client/chat-store-compression-state.test.ts
+++ b/tests/client/chat-store-compression-state.test.ts
@@ -42,7 +42,7 @@ vi.mock('@/utils/completion-sound', () => ({
   playCompletionSound: vi.fn(),
 }))
 
-import { useChatStore, type Session } from '@/stores/hermes/chat'
+import { useChatStore, type Message, type Session } from '@/stores/hermes/chat'
 
 function makeSession(id: string): Session {
   return {
@@ -103,6 +103,40 @@ describe('chat store compression state', () => {
     }))
   })
 
+  it('surfaces non-terminal reattach warnings replayed in a non-working resume payload', async () => {
+    chatApi.resumeSession.mockImplementationOnce((sessionId: string, onResumed: (data: any) => void) => {
+      onResumed({
+        session_id: sessionId,
+        messages: [],
+        isWorking: false,
+        events: [{
+          event: 'run.reattach_failed',
+          data: {
+            event: 'run.reattach_failed',
+            session_id: sessionId,
+            error: 'connect ECONNREFUSED configured endpoint',
+            message: 'Unable to confirm Agent Bridge status while resuming: connect ECONNREFUSED configured endpoint',
+            text: 'Unable to confirm Agent Bridge status while resuming: connect ECONNREFUSED configured endpoint',
+          },
+        }],
+      })
+      return {} as any
+    })
+    const store = useChatStore()
+    store.sessions = [makeSession('session-reattach')]
+
+    await store.switchSession('session-reattach')
+    await nextTick()
+
+    expect(store.activeSession?.messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        role: 'system',
+        commandAction: 'agent.event',
+        content: 'Unable to confirm Agent Bridge status while resuming: connect ECONNREFUSED configured endpoint',
+      }),
+    ]))
+  })
+
   it('preserves streamed content when run.completed parsed_content is blank', async () => {
     const store = useChatStore()
     store.sessions = [makeSession('session-1')]
@@ -118,11 +152,11 @@ describe('chat store compression state', () => {
     handlers.onRunCompleted({ event: 'run.completed', parsed_content: '', output: '', run_id: 'run-1' })
     await nextTick()
 
-    const assistant = store.activeSession?.messages.find(message => message.id === 'a1')
+    const assistant = store.activeSession?.messages.find((message: Message) => message.id === 'a1')
     expect(assistant?.content).toBe('final answer')
     expect(assistant?.isStreaming).toBe(false)
     expect(store.activeSession?.messages.some(
-      message => message.role === 'system' && message.content.includes('Agent returned no output'),
+      (message: Message) => message.role === 'system' && message.content.includes('Agent returned no output'),
     )).toBe(false)
   })
 
@@ -141,9 +175,9 @@ describe('chat store compression state', () => {
     handlers.onRunCompleted({ event: 'run.completed', parsed_content: '', output: '', run_id: 'run-2' })
     await nextTick()
 
-    expect(store.activeSession?.messages.find(message => message.id === 'old-a1')?.content).toBe('previous answer')
+    expect(store.activeSession?.messages.find((message: Message) => message.id === 'old-a1')?.content).toBe('previous answer')
     expect(store.activeSession?.messages.some(
-      message => message.role === 'system' && message.content.includes('Agent returned no output'),
+      (message: Message) => message.role === 'system' && message.content.includes('Agent returned no output'),
     )).toBe(true)
   })
 
@@ -163,7 +197,7 @@ describe('chat store compression state', () => {
     handlers.onToolCompleted({ event: 'tool.completed', tool_call_id: 'call-1', output: { ok: true }, run_id: 'run-1' })
     await nextTick()
 
-    const tool = store.activeSession?.messages.find(message => message.id === 'tool-1')
+    const tool = store.activeSession?.messages.find((message: Message) => message.id === 'tool-1')
     expect(tool?.toolStatus).toBe('done')
     expect(tool?.toolResult).toEqual({ ok: true })
   })

--- a/tests/server/agent-bridge-manager.test.ts
+++ b/tests/server/agent-bridge-manager.test.ts
@@ -557,6 +557,130 @@ describe('agent bridge manager command resolution', () => {
     expect(startSpy).not.toHaveBeenCalled()
   })
 
+  it('bounds an in-flight start by caller timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+      const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6565' })
+      ;(manager as any).starting = new Promise<void>(() => {})
+      const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+        .mockResolvedValueOnce({
+          endpoint: 'tcp://127.0.0.1:6565',
+          endpointKind: 'tcp',
+          status: 'starting',
+          reachable: false,
+          ready: false,
+          running: false,
+          attached: false,
+          starting: true,
+          stopping: false,
+          restartScheduled: false,
+          restartAttempts: 0,
+        })
+
+      const ensureReadyPromise = manager.ensureReady({ timeoutMs: 25 })
+      await vi.advanceTimersByTimeAsync(25)
+
+      await expect(ensureReadyPromise).resolves.toMatchObject({
+        endpoint: 'tcp://127.0.0.1:6565',
+        status: 'starting',
+        reachable: false,
+      })
+      expect(checkReadinessSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('coalesces callers onto an existing managed recovery', async () => {
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6566' })
+    const child = createMockManagedChild(45666)
+    ;(manager as any).child = child
+    ;(manager as any).ready = true
+    ;(manager as any).attached = false
+
+    const unreachable = {
+      endpoint: 'tcp://127.0.0.1:6566',
+      endpointKind: 'tcp' as const,
+      status: 'unreachable' as const,
+      reachable: false,
+      ready: false,
+      running: false,
+      attached: false,
+      starting: false,
+      stopping: false,
+      restartScheduled: false,
+      restartAttempts: 0,
+      pid: 45666,
+      error: 'connect ECONNREFUSED',
+    }
+    const recovered = {
+      ...unreachable,
+      status: 'ready' as const,
+      reachable: true,
+      ready: true,
+      running: true,
+      error: undefined,
+    }
+    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness').mockResolvedValue(unreachable)
+    let resolveRecovery: ((value: typeof recovered) => void) | undefined
+    const recoveryDeferred = new Promise<typeof recovered>((resolve) => {
+      resolveRecovery = resolve
+    })
+    const performRecoverySpy = vi.spyOn(manager as any, 'performManagedRecovery').mockReturnValue(recoveryDeferred)
+
+    const first = manager.ensureReady()
+    await Promise.resolve()
+    await Promise.resolve()
+    const second = manager.ensureReady()
+    await Promise.resolve()
+    resolveRecovery?.(recovered)
+
+    await expect(first).resolves.toBe(recovered)
+    await expect(second).resolves.toBe(recovered)
+    expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
+    expect(performRecoverySpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not run destructive managed recovery on legacy global default endpoints', async () => {
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const manager = new AgentBridgeManager({ endpoint: 'ipc:///tmp/hermes-agent-bridge.sock' })
+    const child = createMockManagedChild(45667)
+    ;(manager as any).child = child
+    ;(manager as any).ready = true
+    ;(manager as any).attached = false
+
+    vi.spyOn(manager, 'checkReadiness').mockResolvedValue({
+      endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+      endpointKind: 'ipc',
+      status: 'unreachable',
+      reachable: false,
+      ready: false,
+      running: false,
+      attached: false,
+      starting: false,
+      stopping: false,
+      restartScheduled: false,
+      restartAttempts: 0,
+      pid: 45667,
+      error: 'connect ENOENT /tmp/hermes-agent-bridge.sock',
+    })
+    const performRecoverySpy = vi.spyOn(manager as any, 'performManagedRecovery')
+    const startSpy = vi.spyOn(manager, 'start').mockResolvedValue()
+
+    await expect(manager.ensureReady()).resolves.toMatchObject({
+      endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+      status: 'unreachable',
+      reachable: false,
+      error: expect.stringContaining('merge endpoint scoping before enabling recovery'),
+    })
+    expect(child.kill).not.toHaveBeenCalled()
+    expect(performRecoverySpy).not.toHaveBeenCalled()
+    expect(startSpy).not.toHaveBeenCalled()
+    expect((manager as any).child).toBe(child)
+  })
+
   it('waits for the old managed child to exit before starting replacement recovery', async () => {
     const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
     const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6557' })
@@ -566,7 +690,7 @@ describe('agent bridge manager command resolution', () => {
     ;(manager as any).ready = true
     ;(manager as any).attached = false
 
-    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+    const checkReadinessSpy = vi.spyOn(manager as any, 'checkReadinessInternal')
       .mockResolvedValueOnce({
         endpoint: 'tcp://127.0.0.1:6557',
         endpointKind: 'tcp',
@@ -599,6 +723,8 @@ describe('agent bridge manager command resolution', () => {
 
     const ensureReadyPromise = manager.ensureReady()
     await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
 
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
     expect(startSpy).not.toHaveBeenCalled()
@@ -624,7 +750,7 @@ describe('agent bridge manager command resolution', () => {
     ;(manager as any).ready = true
     ;(manager as any).attached = false
 
-    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+    const checkReadinessSpy = vi.spyOn(manager as any, 'checkReadinessInternal')
       .mockResolvedValueOnce({
         endpoint: 'tcp://127.0.0.1:6564',
         endpointKind: 'tcp',
@@ -658,12 +784,16 @@ describe('agent bridge manager command resolution', () => {
 
     const ensureReadyPromise = manager.ensureReady()
     await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
 
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
     expect(startSpy).not.toHaveBeenCalled()
 
-    await manager.stop()
+    const stopPromise = manager.stop()
+    await Promise.resolve()
     child.emit('exit', 0, 'SIGTERM')
+    await stopPromise
 
     await expect(ensureReadyPromise).resolves.toMatchObject({
       endpoint: 'tcp://127.0.0.1:6564',
@@ -674,7 +804,7 @@ describe('agent bridge manager command resolution', () => {
     })
     expect(startSpy).not.toHaveBeenCalled()
     expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
-    expect(checkReadinessSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ connectRetryMs: 0 }))
+    expect(checkReadinessSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ connectRetryMs: 0 }), true)
     expect((manager as any).child).toBeNull()
     expect(manager.getRuntimeState()).toMatchObject({
       ready: false,
@@ -696,7 +826,7 @@ describe('agent bridge manager command resolution', () => {
       ;(manager as any).ready = true
       ;(manager as any).attached = false
 
-      const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+      const checkReadinessSpy = vi.spyOn(manager as any, 'checkReadinessInternal')
         .mockResolvedValueOnce({
           endpoint: 'tcp://127.0.0.1:6563',
           endpointKind: 'tcp',
@@ -715,19 +845,23 @@ describe('agent bridge manager command resolution', () => {
         .mockResolvedValueOnce({
           endpoint: 'tcp://127.0.0.1:6563',
           endpointKind: 'tcp',
-          status: 'ready',
-          reachable: true,
-          ready: true,
-          running: true,
+          status: 'unreachable',
+          reachable: false,
+          ready: false,
+          running: false,
           attached: false,
           starting: false,
           stopping: false,
           restartScheduled: false,
           restartAttempts: 0,
+          pid: 12346,
+          error: 'connect ECONNREFUSED',
         })
       const startSpy = vi.spyOn(manager, 'start').mockResolvedValue()
 
       const ensureReadyPromise = manager.ensureReady()
+      await Promise.resolve()
+      await Promise.resolve()
       await Promise.resolve()
 
       expect(child.kill).toHaveBeenNthCalledWith(1, 'SIGTERM')
@@ -741,10 +875,13 @@ describe('agent bridge manager command resolution', () => {
 
       await expect(ensureReadyPromise).resolves.toMatchObject({
         endpoint: 'tcp://127.0.0.1:6563',
-        status: 'ready',
-        reachable: true,
+        status: 'unreachable',
+        reachable: false,
+        ready: false,
+        running: false,
+        error: expect.stringContaining('did not exit after SIGTERM/SIGKILL'),
       })
-      expect(startSpy).toHaveBeenCalledTimes(1)
+      expect(startSpy).not.toHaveBeenCalled()
       expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()
@@ -789,7 +926,7 @@ describe('agent bridge manager command resolution', () => {
       pid: 45671,
     })
 
-    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+    const checkReadinessSpy = vi.spyOn(manager as any, 'checkReadinessInternal')
       .mockResolvedValueOnce({
         endpoint: 'tcp://127.0.0.1:6562',
         endpointKind: 'tcp',
@@ -821,6 +958,8 @@ describe('agent bridge manager command resolution', () => {
       })
 
     const ensureReadyPromise = manager.ensureReady()
+    await Promise.resolve()
+    await Promise.resolve()
     await Promise.resolve()
 
     expect(oldChild.kill).toHaveBeenCalledWith('SIGTERM')
@@ -870,7 +1009,7 @@ describe('agent bridge manager command resolution', () => {
     ;(manager as any).ready = true
     ;(manager as any).attached = false
 
-    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+    const checkReadinessSpy = vi.spyOn(manager as any, 'checkReadinessInternal')
       .mockResolvedValueOnce({
         endpoint: 'tcp://127.0.0.1:6558',
         endpointKind: 'tcp',
@@ -891,13 +1030,15 @@ describe('agent bridge manager command resolution', () => {
 
     const ensureReadyPromise = manager.ensureReady()
     await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
     child.emit('exit', 0, 'SIGTERM')
 
     await expect(ensureReadyPromise).resolves.toEqual(recoveredReadiness)
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
     expect(startSpy).toHaveBeenCalledTimes(1)
     expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
-    expect(checkReadinessSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ connectRetryMs: 0 }))
+    expect(checkReadinessSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ connectRetryMs: 0 }), true)
     expect((manager as any).child).toBeNull()
   })
 
@@ -910,7 +1051,7 @@ describe('agent bridge manager command resolution', () => {
     ;(manager as any).ready = true
     ;(manager as any).attached = false
 
-    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+    const checkReadinessSpy = vi.spyOn(manager as any, 'checkReadinessInternal')
       .mockResolvedValueOnce({
         endpoint: 'tcp://127.0.0.1:6559',
         endpointKind: 'tcp',
@@ -945,6 +1086,8 @@ describe('agent bridge manager command resolution', () => {
 
     const ensureReadyPromise = manager.ensureReady()
     await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
     child.emit('exit', 0, 'SIGTERM')
 
     await expect(ensureReadyPromise).resolves.toMatchObject({
@@ -958,7 +1101,7 @@ describe('agent bridge manager command resolution', () => {
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
     expect(startSpy).toHaveBeenCalledTimes(1)
     expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
-    expect(checkReadinessSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ connectRetryMs: 0 }))
+    expect(checkReadinessSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ connectRetryMs: 0 }), true)
     expect((manager as any).child).toBeNull()
   })
 
@@ -985,7 +1128,7 @@ describe('agent bridge manager command resolution', () => {
     ;(manager as any).attached = true
     ;(manager as any).ready = true
 
-    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness').mockResolvedValue(readiness)
+    const checkReadinessSpy = vi.spyOn(manager as any, 'checkReadinessInternal').mockResolvedValue(readiness)
     const startSpy = vi.spyOn(manager, 'start').mockResolvedValue()
     const shutdownSpy = vi.spyOn(AgentBridgeClient.prototype, 'shutdown').mockResolvedValue({ ok: true })
 

--- a/tests/server/agent-bridge-manager.test.ts
+++ b/tests/server/agent-bridge-manager.test.ts
@@ -161,6 +161,143 @@ describe('agent bridge manager command resolution', () => {
     }
   })
 
+  it('reports readiness when a fake TCP server answers ping with pong', async () => {
+    const endpoint = `tcp://127.0.0.1:${33000 + (process.pid % 10000)}`
+    const server = createServer((socket) => {
+      socket.once('data', () => {
+        socket.end(`${JSON.stringify({ ok: true, pong: true })}\n`)
+      })
+    })
+
+    await new Promise<void>((resolve) => {
+      const url = new URL(endpoint)
+      server.listen(Number(url.port), url.hostname, resolve)
+    })
+
+    try {
+      const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+      const manager = new AgentBridgeManager({ endpoint })
+
+      await expect(manager.checkReadiness({ timeoutMs: 250, connectRetryMs: 0 })).resolves.toMatchObject({
+        endpoint,
+        endpointKind: 'tcp',
+        status: 'ready',
+        reachable: true,
+        ready: true,
+        running: true,
+        attached: false,
+        starting: false,
+        stopping: false,
+        restartScheduled: false,
+        restartAttempts: 0,
+      })
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('reports unreachable instead of throwing when endpoint is missing', async () => {
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const manager = new AgentBridgeManager()
+    manager.endpoint = ''
+
+    await expect(manager.checkReadiness()).resolves.toMatchObject({
+      endpoint: '',
+      endpointKind: 'unknown',
+      status: 'unreachable',
+      reachable: false,
+      ready: false,
+      running: false,
+      attached: false,
+      starting: false,
+      stopping: false,
+      restartScheduled: false,
+      restartAttempts: 0,
+      error: 'agent bridge endpoint is not configured',
+    })
+  })
+
+  it('reports starting readiness without pinging the bridge', async () => {
+    const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const pingSpy = vi.spyOn(AgentBridgeClient.prototype, 'ping')
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6553' })
+
+    ;(manager as any).starting = Promise.resolve()
+
+    await expect(manager.checkReadiness()).resolves.toMatchObject({
+      endpoint: 'tcp://127.0.0.1:6553',
+      endpointKind: 'tcp',
+      status: 'starting',
+      reachable: false,
+      ready: false,
+      running: false,
+      attached: false,
+      starting: true,
+      stopping: false,
+      restartScheduled: false,
+      restartAttempts: 0,
+    })
+    expect(pingSpy).not.toHaveBeenCalled()
+  })
+
+  it('reports stopping readiness without pinging the bridge', async () => {
+    const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const pingSpy = vi.spyOn(AgentBridgeClient.prototype, 'ping')
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6554' })
+
+    ;(manager as any).attached = true
+    ;(manager as any).ready = true
+    ;(manager as any).stopping = true
+
+    await expect(manager.checkReadiness()).resolves.toMatchObject({
+      endpoint: 'tcp://127.0.0.1:6554',
+      endpointKind: 'tcp',
+      status: 'stopping',
+      reachable: false,
+      ready: false,
+      running: false,
+      attached: true,
+      starting: false,
+      stopping: true,
+      restartScheduled: false,
+      restartAttempts: 0,
+    })
+    expect(pingSpy).not.toHaveBeenCalled()
+  })
+
+  it('reports restarting readiness without pinging the bridge', async () => {
+    const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const pingSpy = vi.spyOn(AgentBridgeClient.prototype, 'ping')
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6555' })
+
+    ;(manager as any).restartAttempts = 2
+    ;(manager as any).restartTimer = setTimeout(() => undefined, 1000)
+
+    try {
+      await expect(manager.checkReadiness()).resolves.toMatchObject({
+        endpoint: 'tcp://127.0.0.1:6555',
+        endpointKind: 'tcp',
+        status: 'restarting',
+        reachable: false,
+        ready: false,
+        running: false,
+        attached: false,
+        starting: false,
+        stopping: false,
+        restartScheduled: true,
+        restartAttempts: 2,
+      })
+    } finally {
+      clearTimeout((manager as any).restartTimer)
+      ;(manager as any).restartTimer = null
+    }
+
+    expect(pingSpy).not.toHaveBeenCalled()
+  })
+
   it('attaches to an already running bridge instead of spawning a replacement', async () => {
     const endpoint = `tcp://127.0.0.1:${34000 + (process.pid % 10000)}`
     const actions: string[] = []
@@ -238,6 +375,62 @@ describe('agent bridge manager command resolution', () => {
       })
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('clears stopping after stop completes for an attached bridge', async () => {
+    const endpoint = `tcp://127.0.0.1:${36000 + (process.pid % 10000)}`
+    const actions: string[] = []
+    const server = createServer((socket) => {
+      socket.once('data', (chunk) => {
+        const request = JSON.parse(chunk.toString('utf8').trim())
+        actions.push(request.action)
+        socket.end(`${JSON.stringify({ ok: true, pong: request.action === 'ping' })}\n`, () => {
+          if (request.action === 'shutdown') {
+            server.close()
+          }
+        })
+      })
+    })
+    const serverClosed = new Promise<void>((resolve) => server.once('close', () => resolve()))
+
+    await new Promise<void>((resolve) => {
+      const url = new URL(endpoint)
+      server.listen(Number(url.port), url.hostname, resolve)
+    })
+
+    try {
+      const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+      const manager = new AgentBridgeManager({ endpoint, startupTimeoutMs: 100 })
+
+      await manager.start()
+      await manager.stop()
+      await serverClosed
+
+      expect(actions).toEqual(['ping', 'shutdown'])
+      expect(manager.getRuntimeState()).toMatchObject({
+        ready: false,
+        running: false,
+        attached: false,
+        stopping: false,
+      })
+      await expect(manager.checkReadiness({ timeoutMs: 250, connectRetryMs: 0 })).resolves.toMatchObject({
+        endpoint,
+        endpointKind: 'tcp',
+        status: 'unreachable',
+        reachable: false,
+        ready: false,
+        running: false,
+        attached: false,
+        starting: false,
+        stopping: false,
+        restartScheduled: false,
+        restartAttempts: 0,
+      })
+    } finally {
+      if (server.listening) {
+        await new Promise<void>((resolve) => server.close(() => resolve()))
+      }
     }
   })
 })

--- a/tests/server/agent-bridge-manager.test.ts
+++ b/tests/server/agent-bridge-manager.test.ts
@@ -433,4 +433,330 @@ describe('agent bridge manager command resolution', () => {
       }
     }
   })
+
+  it('returns unreachable without attempting recovery when recover is false', async () => {
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6556' })
+    const readiness = {
+      endpoint: 'tcp://127.0.0.1:6556',
+      endpointKind: 'tcp' as const,
+      status: 'unreachable' as const,
+      reachable: false,
+      ready: false,
+      running: false,
+      attached: false,
+      starting: false,
+      stopping: false,
+      restartScheduled: false,
+      restartAttempts: 0,
+      error: 'connect ECONNREFUSED',
+    }
+    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness').mockResolvedValue(readiness)
+    const startSpy = vi.spyOn(manager, 'start').mockResolvedValue()
+
+    await expect(manager.ensureReady({ recover: false })).resolves.toEqual(readiness)
+    expect(checkReadinessSpy).toHaveBeenCalledTimes(1)
+    expect(startSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns immediately when the bridge is already reachable', async () => {
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6560' })
+    const readiness = {
+      endpoint: 'tcp://127.0.0.1:6560',
+      endpointKind: 'tcp' as const,
+      status: 'ready' as const,
+      reachable: true,
+      ready: true,
+      running: true,
+      attached: false,
+      starting: false,
+      stopping: false,
+      restartScheduled: false,
+      restartAttempts: 0,
+    }
+    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness').mockResolvedValue(readiness)
+    const startSpy = vi.spyOn(manager, 'start').mockResolvedValue()
+
+    await expect(manager.ensureReady()).resolves.toEqual(readiness)
+    expect(checkReadinessSpy).toHaveBeenCalledTimes(1)
+    expect(startSpy).not.toHaveBeenCalled()
+  })
+
+  it('waits for an in-flight start before re-checking readiness', async () => {
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6561' })
+    let resolveStarting: (() => void) | undefined
+    ;(manager as any).starting = new Promise<void>((resolve) => {
+      resolveStarting = resolve
+    })
+
+    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+      .mockResolvedValueOnce({
+        endpoint: 'tcp://127.0.0.1:6561',
+        endpointKind: 'tcp',
+        status: 'starting',
+        reachable: false,
+        ready: false,
+        running: false,
+        attached: false,
+        starting: true,
+        stopping: false,
+        restartScheduled: false,
+        restartAttempts: 0,
+      })
+      .mockResolvedValueOnce({
+        endpoint: 'tcp://127.0.0.1:6561',
+        endpointKind: 'tcp',
+        status: 'ready',
+        reachable: true,
+        ready: true,
+        running: true,
+        attached: false,
+        starting: false,
+        stopping: false,
+        restartScheduled: false,
+        restartAttempts: 0,
+      })
+    const startSpy = vi.spyOn(manager, 'start').mockResolvedValue()
+
+    const ensureReadyPromise = manager.ensureReady()
+    await Promise.resolve()
+
+    expect(checkReadinessSpy).toHaveBeenCalledTimes(1)
+    expect(startSpy).not.toHaveBeenCalled()
+
+    resolveStarting?.()
+
+    await expect(ensureReadyPromise).resolves.toMatchObject({
+      endpoint: 'tcp://127.0.0.1:6561',
+      status: 'ready',
+      reachable: true,
+    })
+    expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
+    expect(startSpy).not.toHaveBeenCalled()
+  })
+
+  it('restarts a managed child once when the bridge endpoint is unreachable', async () => {
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6557' })
+    const child = {
+      killed: false,
+      kill: vi.fn((signal: string) => {
+        child.killed = signal === 'SIGTERM'
+        return true
+      }),
+      pid: 12345,
+    }
+
+    ;(manager as any).child = child
+    ;(manager as any).ready = true
+    ;(manager as any).attached = false
+
+    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+      .mockResolvedValueOnce({
+        endpoint: 'tcp://127.0.0.1:6557',
+        endpointKind: 'tcp',
+        status: 'unreachable',
+        reachable: false,
+        ready: false,
+        running: false,
+        attached: false,
+        starting: false,
+        stopping: false,
+        restartScheduled: false,
+        restartAttempts: 0,
+        pid: 12345,
+        error: 'connect ECONNREFUSED',
+      })
+      .mockResolvedValueOnce({
+        endpoint: 'tcp://127.0.0.1:6557',
+        endpointKind: 'tcp',
+        status: 'ready',
+        reachable: true,
+        ready: true,
+        running: true,
+        attached: false,
+        starting: false,
+        stopping: false,
+        restartScheduled: false,
+        restartAttempts: 0,
+      })
+    const startSpy = vi.spyOn(manager, 'start').mockResolvedValue()
+
+    await expect(manager.ensureReady()).resolves.toMatchObject({
+      endpoint: 'tcp://127.0.0.1:6557',
+      status: 'ready',
+      reachable: true,
+    })
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(startSpy).toHaveBeenCalledTimes(1)
+    expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
+    expect((manager as any).child).toBeNull()
+  })
+
+  it('returns follow-up reachable readiness when restart fails after the bridge comes up', async () => {
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6558' })
+    const child = {
+      killed: false,
+      kill: vi.fn((signal: string) => {
+        child.killed = signal === 'SIGTERM'
+        return true
+      }),
+      pid: 23456,
+    }
+    const recoveredReadiness = {
+      endpoint: 'tcp://127.0.0.1:6558',
+      endpointKind: 'tcp' as const,
+      status: 'ready' as const,
+      reachable: true,
+      ready: true,
+      running: true,
+      attached: false,
+      starting: false,
+      stopping: false,
+      restartScheduled: false,
+      restartAttempts: 0,
+      pid: 23456,
+    }
+
+    ;(manager as any).child = child
+    ;(manager as any).ready = true
+    ;(manager as any).attached = false
+
+    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+      .mockResolvedValueOnce({
+        endpoint: 'tcp://127.0.0.1:6558',
+        endpointKind: 'tcp',
+        status: 'unreachable',
+        reachable: false,
+        ready: false,
+        running: false,
+        attached: false,
+        starting: false,
+        stopping: false,
+        restartScheduled: false,
+        restartAttempts: 0,
+        pid: 23456,
+        error: 'connect ECONNREFUSED',
+      })
+      .mockResolvedValueOnce(recoveredReadiness)
+    const startSpy = vi.spyOn(manager, 'start').mockRejectedValue(new Error('spawn EADDRINUSE'))
+
+    await expect(manager.ensureReady()).resolves.toEqual(recoveredReadiness)
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(startSpy).toHaveBeenCalledTimes(1)
+    expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
+    expect(checkReadinessSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ connectRetryMs: 0 }))
+    expect((manager as any).child).toBeNull()
+  })
+
+  it('keeps follow-up unreachable readiness while adding restart failure context', async () => {
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6559' })
+    const child = {
+      killed: false,
+      kill: vi.fn((signal: string) => {
+        child.killed = signal === 'SIGTERM'
+        return true
+      }),
+      pid: 34567,
+    }
+
+    ;(manager as any).child = child
+    ;(manager as any).ready = true
+    ;(manager as any).attached = false
+
+    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+      .mockResolvedValueOnce({
+        endpoint: 'tcp://127.0.0.1:6559',
+        endpointKind: 'tcp',
+        status: 'unreachable',
+        reachable: false,
+        ready: false,
+        running: false,
+        attached: false,
+        starting: false,
+        stopping: false,
+        restartScheduled: false,
+        restartAttempts: 0,
+        pid: 34567,
+        error: 'connect ECONNREFUSED',
+      })
+      .mockResolvedValueOnce({
+        endpoint: 'tcp://127.0.0.1:6559',
+        endpointKind: 'tcp',
+        status: 'starting',
+        reachable: false,
+        ready: false,
+        running: false,
+        attached: false,
+        starting: true,
+        stopping: false,
+        restartScheduled: false,
+        restartAttempts: 1,
+        pid: 34568,
+        error: 'bridge ping timed out',
+      })
+    const startSpy = vi.spyOn(manager, 'start').mockRejectedValue(new Error('spawn ENOENT'))
+
+    await expect(manager.ensureReady()).resolves.toMatchObject({
+      endpoint: 'tcp://127.0.0.1:6559',
+      status: 'starting',
+      reachable: false,
+      ready: false,
+      running: false,
+      error: 'bridge ping timed out; start failed: spawn ENOENT',
+    })
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(startSpy).toHaveBeenCalledTimes(1)
+    expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
+    expect(checkReadinessSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ connectRetryMs: 0 }))
+    expect((manager as any).child).toBeNull()
+  })
+
+  it('preserves attached external bridge state when readiness becomes unreachable', async () => {
+    const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6558' })
+    const readiness = {
+      endpoint: 'tcp://127.0.0.1:6558',
+      endpointKind: 'tcp' as const,
+      status: 'unreachable' as const,
+      reachable: false,
+      ready: false,
+      running: false,
+      attached: true,
+      starting: false,
+      stopping: false,
+      restartScheduled: false,
+      restartAttempts: 0,
+      error: 'connect ECONNREFUSED',
+    }
+
+    ;(manager as any).child = null
+    ;(manager as any).attached = true
+    ;(manager as any).ready = true
+
+    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness').mockResolvedValue(readiness)
+    const startSpy = vi.spyOn(manager, 'start').mockResolvedValue()
+    const shutdownSpy = vi.spyOn(AgentBridgeClient.prototype, 'shutdown').mockResolvedValue({ ok: true })
+
+    await expect(manager.ensureReady()).resolves.toEqual(readiness)
+    expect(startSpy).not.toHaveBeenCalled()
+    expect(checkReadinessSpy).toHaveBeenCalledTimes(1)
+    expect(shutdownSpy).not.toHaveBeenCalled()
+    expect((manager as any).child).toBeNull()
+    expect(manager.getRuntimeState()).toMatchObject({
+      ready: false,
+      running: false,
+      attached: true,
+      pid: undefined,
+    })
+
+    await manager.stop()
+
+    expect(shutdownSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/server/agent-bridge-manager.test.ts
+++ b/tests/server/agent-bridge-manager.test.ts
@@ -1,8 +1,28 @@
+import { EventEmitter } from 'events'
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { createServer, type Server } from 'net'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type MockManagedChild = EventEmitter & {
+  pid: number
+  killed: boolean
+  kill: ReturnType<typeof vi.fn>
+  unref: ReturnType<typeof vi.fn>
+}
+
+function createMockManagedChild(pid: number): MockManagedChild {
+  const child = new EventEmitter() as MockManagedChild
+  child.pid = pid
+  child.killed = false
+  child.kill = vi.fn((signal: string) => {
+    child.killed = signal === 'SIGTERM' || signal === 'SIGKILL'
+    return true
+  })
+  child.unref = vi.fn()
+  return child
+}
 
 describe('agent bridge manager command resolution', () => {
   const originalEnv = { ...process.env }
@@ -537,17 +557,10 @@ describe('agent bridge manager command resolution', () => {
     expect(startSpy).not.toHaveBeenCalled()
   })
 
-  it('restarts a managed child once when the bridge endpoint is unreachable', async () => {
+  it('waits for the old managed child to exit before starting replacement recovery', async () => {
     const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
     const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6557' })
-    const child = {
-      killed: false,
-      kill: vi.fn((signal: string) => {
-        child.killed = signal === 'SIGTERM'
-        return true
-      }),
-      pid: 12345,
-    }
+    const child = createMockManagedChild(12345)
 
     ;(manager as any).child = child
     ;(manager as any).ready = true
@@ -584,28 +597,260 @@ describe('agent bridge manager command resolution', () => {
       })
     const startSpy = vi.spyOn(manager, 'start').mockResolvedValue()
 
-    await expect(manager.ensureReady()).resolves.toMatchObject({
+    const ensureReadyPromise = manager.ensureReady()
+    await Promise.resolve()
+
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(startSpy).not.toHaveBeenCalled()
+
+    child.emit('exit', 0, 'SIGTERM')
+
+    await expect(ensureReadyPromise).resolves.toMatchObject({
       endpoint: 'tcp://127.0.0.1:6557',
       status: 'ready',
       reachable: true,
     })
-    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
     expect(startSpy).toHaveBeenCalledTimes(1)
     expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
     expect((manager as any).child).toBeNull()
   })
 
+  it('does not restart managed recovery after an explicit stop wins the race', async () => {
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6564' })
+    const child = createMockManagedChild(12347)
+
+    ;(manager as any).child = child
+    ;(manager as any).ready = true
+    ;(manager as any).attached = false
+
+    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+      .mockResolvedValueOnce({
+        endpoint: 'tcp://127.0.0.1:6564',
+        endpointKind: 'tcp',
+        status: 'unreachable',
+        reachable: false,
+        ready: false,
+        running: false,
+        attached: false,
+        starting: false,
+        stopping: false,
+        restartScheduled: false,
+        restartAttempts: 0,
+        pid: 12347,
+        error: 'connect ECONNREFUSED',
+      })
+      .mockResolvedValueOnce({
+        endpoint: 'tcp://127.0.0.1:6564',
+        endpointKind: 'tcp',
+        status: 'unreachable',
+        reachable: false,
+        ready: false,
+        running: false,
+        attached: false,
+        starting: false,
+        stopping: false,
+        restartScheduled: false,
+        restartAttempts: 0,
+        error: 'connect ECONNREFUSED',
+      })
+    const startSpy = vi.spyOn(manager, 'start').mockResolvedValue()
+
+    const ensureReadyPromise = manager.ensureReady()
+    await Promise.resolve()
+
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(startSpy).not.toHaveBeenCalled()
+
+    await manager.stop()
+    child.emit('exit', 0, 'SIGTERM')
+
+    await expect(ensureReadyPromise).resolves.toMatchObject({
+      endpoint: 'tcp://127.0.0.1:6564',
+      status: 'unreachable',
+      reachable: false,
+      ready: false,
+      running: false,
+    })
+    expect(startSpy).not.toHaveBeenCalled()
+    expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
+    expect(checkReadinessSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ connectRetryMs: 0 }))
+    expect((manager as any).child).toBeNull()
+    expect(manager.getRuntimeState()).toMatchObject({
+      ready: false,
+      running: false,
+      attached: false,
+      stopping: false,
+    })
+  })
+
+  it('bounds managed-child recovery by escalating to SIGKILL before starting replacement', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+      const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6563' })
+      const child = createMockManagedChild(12346)
+
+      ;(manager as any).child = child
+      ;(manager as any).ready = true
+      ;(manager as any).attached = false
+
+      const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+        .mockResolvedValueOnce({
+          endpoint: 'tcp://127.0.0.1:6563',
+          endpointKind: 'tcp',
+          status: 'unreachable',
+          reachable: false,
+          ready: false,
+          running: false,
+          attached: false,
+          starting: false,
+          stopping: false,
+          restartScheduled: false,
+          restartAttempts: 0,
+          pid: 12346,
+          error: 'connect ECONNREFUSED',
+        })
+        .mockResolvedValueOnce({
+          endpoint: 'tcp://127.0.0.1:6563',
+          endpointKind: 'tcp',
+          status: 'ready',
+          reachable: true,
+          ready: true,
+          running: true,
+          attached: false,
+          starting: false,
+          stopping: false,
+          restartScheduled: false,
+          restartAttempts: 0,
+        })
+      const startSpy = vi.spyOn(manager, 'start').mockResolvedValue()
+
+      const ensureReadyPromise = manager.ensureReady()
+      await Promise.resolve()
+
+      expect(child.kill).toHaveBeenNthCalledWith(1, 'SIGTERM')
+      expect(startSpy).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(child.kill).toHaveBeenNthCalledWith(2, 'SIGKILL')
+      expect(startSpy).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(250)
+
+      await expect(ensureReadyPromise).resolves.toMatchObject({
+        endpoint: 'tcp://127.0.0.1:6563',
+        status: 'ready',
+        reachable: true,
+      })
+      expect(startSpy).toHaveBeenCalledTimes(1)
+      expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores the exiting stale managed child while delaying replacement until exit', async () => {
+    const oldChild = createMockManagedChild(45671)
+    const replacementChild = createMockManagedChild(45672)
+    const spawnMock = vi.fn()
+      .mockReturnValueOnce(oldChild)
+      .mockReturnValueOnce(replacementChild)
+
+    vi.doMock('child_process', async () => {
+      const actual = await vi.importActual<typeof import('child_process')>('child_process')
+      return {
+        ...actual,
+        spawn: spawnMock,
+      }
+    })
+
+    const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const pingSpy = vi.spyOn(AgentBridgeClient.prototype, 'ping')
+    let pingCalls = 0
+    pingSpy.mockImplementation(async () => {
+      pingCalls += 1
+      if (pingCalls === 1 || pingCalls === 3) {
+        throw new Error('bridge offline')
+      }
+      return { ok: true, pong: true } as any
+    })
+
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6562', startupTimeoutMs: 100 })
+    await manager.start()
+
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    expect(manager.getRuntimeState()).toMatchObject({
+      ready: true,
+      running: true,
+      attached: false,
+      pid: 45671,
+    })
+
+    const checkReadinessSpy = vi.spyOn(manager, 'checkReadiness')
+      .mockResolvedValueOnce({
+        endpoint: 'tcp://127.0.0.1:6562',
+        endpointKind: 'tcp',
+        status: 'unreachable',
+        reachable: false,
+        ready: false,
+        running: false,
+        attached: false,
+        starting: false,
+        stopping: false,
+        restartScheduled: false,
+        restartAttempts: 0,
+        pid: 45671,
+        error: 'connect ECONNREFUSED',
+      })
+      .mockResolvedValueOnce({
+        endpoint: 'tcp://127.0.0.1:6562',
+        endpointKind: 'tcp',
+        status: 'ready',
+        reachable: true,
+        ready: true,
+        running: true,
+        attached: false,
+        starting: false,
+        stopping: false,
+        restartScheduled: false,
+        restartAttempts: 0,
+        pid: 45672,
+      })
+
+    const ensureReadyPromise = manager.ensureReady()
+    await Promise.resolve()
+
+    expect(oldChild.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+
+    oldChild.emit('exit', 0, 'SIGTERM')
+
+    await expect(ensureReadyPromise).resolves.toMatchObject({
+      endpoint: 'tcp://127.0.0.1:6562',
+      status: 'ready',
+      reachable: true,
+      pid: 45672,
+    })
+    expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
+    expect(spawnMock).toHaveBeenCalledTimes(2)
+    expect((manager as any).child).toBe(replacementChild)
+    expect(manager.getRuntimeState()).toMatchObject({
+      ready: true,
+      running: true,
+      attached: false,
+      pid: 45672,
+      restartScheduled: false,
+      restartAttempts: 0,
+    })
+  })
+
   it('returns follow-up reachable readiness when restart fails after the bridge comes up', async () => {
     const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
     const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6558' })
-    const child = {
-      killed: false,
-      kill: vi.fn((signal: string) => {
-        child.killed = signal === 'SIGTERM'
-        return true
-      }),
-      pid: 23456,
-    }
+    const child = createMockManagedChild(23456)
     const recoveredReadiness = {
       endpoint: 'tcp://127.0.0.1:6558',
       endpointKind: 'tcp' as const,
@@ -644,7 +889,11 @@ describe('agent bridge manager command resolution', () => {
       .mockResolvedValueOnce(recoveredReadiness)
     const startSpy = vi.spyOn(manager, 'start').mockRejectedValue(new Error('spawn EADDRINUSE'))
 
-    await expect(manager.ensureReady()).resolves.toEqual(recoveredReadiness)
+    const ensureReadyPromise = manager.ensureReady()
+    await Promise.resolve()
+    child.emit('exit', 0, 'SIGTERM')
+
+    await expect(ensureReadyPromise).resolves.toEqual(recoveredReadiness)
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
     expect(startSpy).toHaveBeenCalledTimes(1)
     expect(checkReadinessSpy).toHaveBeenCalledTimes(2)
@@ -655,14 +904,7 @@ describe('agent bridge manager command resolution', () => {
   it('keeps follow-up unreachable readiness while adding restart failure context', async () => {
     const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
     const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6559' })
-    const child = {
-      killed: false,
-      kill: vi.fn((signal: string) => {
-        child.killed = signal === 'SIGTERM'
-        return true
-      }),
-      pid: 34567,
-    }
+    const child = createMockManagedChild(34567)
 
     ;(manager as any).child = child
     ;(manager as any).ready = true
@@ -701,7 +943,11 @@ describe('agent bridge manager command resolution', () => {
       })
     const startSpy = vi.spyOn(manager, 'start').mockRejectedValue(new Error('spawn ENOENT'))
 
-    await expect(manager.ensureReady()).resolves.toMatchObject({
+    const ensureReadyPromise = manager.ensureReady()
+    await Promise.resolve()
+    child.emit('exit', 0, 'SIGTERM')
+
+    await expect(ensureReadyPromise).resolves.toMatchObject({
       endpoint: 'tcp://127.0.0.1:6559',
       status: 'starting',
       reachable: false,

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -98,6 +98,14 @@ function makeServerHarness() {
 describe('ensureBridgeReadyForChatRun', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    ensureReadyMock.mockReset()
+    getRuntimeStateMock.mockReset()
+    bridgeMock.status.mockReset()
+    bridgeMock.statusIfLoaded.mockReset()
+    handleBridgeRunMock.mockReset()
+    resumeBridgeRunMock.mockReset()
+    handleApiRunMock.mockReset()
+    loadSessionStateFromDbMock.mockReset()
     ensureReadyMock.mockResolvedValue({
       reachable: true,
       status: 'ready',
@@ -110,7 +118,7 @@ describe('ensureBridgeReadyForChatRun', () => {
     const { ensureBridgeReadyForChatRun } = await import('../../packages/server/src/services/hermes/run-chat')
 
     await expect(ensureBridgeReadyForChatRun()).resolves.toEqual({ ok: true })
-    expect(ensureReadyMock).toHaveBeenCalledWith({ timeoutMs: 1000, connectRetryMs: 0 })
+    expect(ensureReadyMock).toHaveBeenCalledWith({ timeoutMs: 1000, connectRetryMs: 0, recover: false })
   })
 
   it('returns a visible error when the bridge is unreachable', async () => {
@@ -128,12 +136,12 @@ describe('ensureBridgeReadyForChatRun', () => {
     })
   })
 
-  it('redacts configured loopback tcp host:port when the bridge is unreachable', async () => {
+  it('redacts configured tcp host:port when the bridge is unreachable', async () => {
     ensureReadyMock.mockResolvedValueOnce({
       reachable: false,
       status: 'unreachable',
-      endpoint: 'tcp://127.0.0.1:43123',
-      error: 'connect ECONNREFUSED 127.0.0.1:43123',
+      endpoint: 'tcp://example.internal:43123',
+      error: 'connect ECONNREFUSED example.internal:43123',
     })
     const { ensureBridgeReadyForChatRun } = await import('../../packages/server/src/services/hermes/run-chat')
 
@@ -157,6 +165,14 @@ describe('ensureBridgeReadyForChatRun', () => {
 describe('ChatRunSocket bridge readiness gating', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    ensureReadyMock.mockReset()
+    getRuntimeStateMock.mockReset()
+    bridgeMock.status.mockReset()
+    bridgeMock.statusIfLoaded.mockReset()
+    handleBridgeRunMock.mockReset()
+    resumeBridgeRunMock.mockReset()
+    handleApiRunMock.mockReset()
+    loadSessionStateFromDbMock.mockReset()
     ensureReadyMock.mockResolvedValue({
       reachable: true,
       status: 'ready',
@@ -213,13 +229,7 @@ describe('ChatRunSocket bridge readiness gating', () => {
     expect(socket.emit).not.toHaveBeenCalledWith('run.failed', expect.anything())
   })
 
-  it('emits run.failed before resumeBridgeRun when the bridge is unreachable', async () => {
-    ensureReadyMock.mockResolvedValueOnce({
-      reachable: false,
-      status: 'unreachable',
-      endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
-      error: 'bridge offline',
-    })
+  it('reattaches a loaded running bridge run without probing manager readiness again', async () => {
     bridgeMock.statusIfLoaded
       .mockResolvedValueOnce({
         ok: true,
@@ -242,37 +252,26 @@ describe('ChatRunSocket bridge readiness gating', () => {
     ;(server as any).onConnection(socket)
     await handlers.get('resume')?.({ session_id: 'session-1' })
 
-    expect(resumeBridgeRunMock).not.toHaveBeenCalled()
+    expect(ensureReadyMock).not.toHaveBeenCalled()
+    expect(resumeBridgeRunMock).toHaveBeenCalledTimes(1)
     expect(socket.emit).toHaveBeenCalledWith('resumed', expect.objectContaining({
       session_id: 'session-1',
-      isWorking: false,
-      events: [],
+      isWorking: true,
     }))
-    expect(emitted).toContainEqual({
-      room: 'session:session-1',
-      event: 'run.failed',
-      payload: {
-        event: 'run.failed',
-        session_id: 'session-1',
-        error: 'Agent Bridge is not reachable: bridge offline',
-      },
-    })
+    expect(emitted.some(({ event }) => event === 'run.failed')).toBe(false)
     expect((server as any).sessionMap.get('session-1')).toEqual(expect.objectContaining({
-      isWorking: false,
-      runId: undefined,
+      isWorking: true,
+      isAborting: false,
+      runId: 'run-1',
       activeRunMarker: undefined,
-      profile: undefined,
-      source: undefined,
+      profile: 'default',
+      source: 'cli',
       events: [],
     }))
     expect((server as any).bridgeResumePolls.size).toBe(0)
-
-    await handlers.get('resume')?.({ session_id: 'session-1' })
-
-    expect(resumeBridgeRunMock).toHaveBeenCalledTimes(1)
   })
 
-  it('emits run.failed and clears stale state when bridge status lookup throws during resume', async () => {
+  it('emits a non-terminal reattach warning and preserves stale state when bridge status lookup throws during resume', async () => {
     bridgeMock.statusIfLoaded.mockRejectedValueOnce(new Error('connect ECONNREFUSED ipc:///tmp/hermes-agent-bridge.sock'))
     loadSessionStateFromDbMock.mockResolvedValueOnce({
       messages: [],
@@ -296,32 +295,42 @@ describe('ChatRunSocket bridge readiness gating', () => {
     expect(resumeBridgeRunMock).not.toHaveBeenCalled()
     expect(emitted).toContainEqual({
       room: 'session:session-1',
-      event: 'run.failed',
+      event: 'run.reattach_failed',
       payload: {
-        event: 'run.failed',
+        event: 'run.reattach_failed',
         session_id: 'session-1',
-        error: 'Agent Bridge is not reachable: connect ECONNREFUSED configured endpoint',
+        error: 'connect ECONNREFUSED configured endpoint',
+        message: 'Unable to confirm Agent Bridge status while resuming: connect ECONNREFUSED configured endpoint',
+        text: 'Unable to confirm Agent Bridge status while resuming: connect ECONNREFUSED configured endpoint',
       },
-    })
-    expect(socket.emit).toHaveBeenCalledWith('run.failed', {
-      event: 'run.failed',
-      session_id: 'session-1',
-      error: 'Agent Bridge is not reachable: connect ECONNREFUSED configured endpoint',
     })
     expect(socket.emit).toHaveBeenCalledWith('resumed', expect.objectContaining({
       session_id: 'session-1',
       isWorking: false,
-      isAborting: false,
-      events: [],
+      isAborting: true,
+      events: [expect.objectContaining({
+        event: 'run.reattach_failed',
+        data: expect.objectContaining({
+          error: 'connect ECONNREFUSED configured endpoint',
+        }),
+      })],
     }))
     expect((server as any).sessionMap.get('session-1')).toEqual(expect.objectContaining({
       isWorking: false,
-      isAborting: false,
-      runId: undefined,
-      activeRunMarker: undefined,
-      profile: undefined,
-      source: undefined,
-      events: [],
+      isAborting: true,
+      runId: 'stale-run',
+      activeRunMarker: 'marker-1',
+      profile: 'default',
+      source: 'cli',
+      events: expect.arrayContaining([
+        expect.objectContaining({ event: 'run.started' }),
+        expect.objectContaining({
+          event: 'run.reattach_failed',
+          data: expect.objectContaining({
+            error: 'connect ECONNREFUSED configured endpoint',
+          }),
+        }),
+      ]),
     }))
     expect((server as any).bridgeResumePolls.size).toBe(0)
   })

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handleBridgeRunMock = vi.hoisted(() => vi.fn(async () => {}))
+const resumeBridgeRunMock = vi.hoisted(() => vi.fn(async () => {}))
+const handleApiRunMock = vi.hoisted(() => vi.fn(async () => {}))
+const loadSessionStateFromDbMock = vi.hoisted(() => vi.fn())
+const ensureReadyMock = vi.hoisted(() => vi.fn())
+const bridgeMock = vi.hoisted(() => ({
+  status: vi.fn(),
+  statusIfLoaded: vi.fn(),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/handle-bridge-run', () => ({
+  handleBridgeRun: handleBridgeRunMock,
+  resumeBridgeRun: resumeBridgeRunMock,
+}))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/handle-api-run', () => ({
+  handleApiRun: handleApiRunMock,
+  loadSessionStateFromDb: loadSessionStateFromDbMock,
+  resolveRunSource: vi.fn((source?: string) => source || 'cli'),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/session-command', () => ({
+  handleSessionCommand: vi.fn(),
+  isSessionCommand: vi.fn(() => false),
+  parseSessionCommand: vi.fn(() => null),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/agent-bridge', () => ({
+  AgentBridgeClient: vi.fn(() => bridgeMock),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/agent-bridge/manager', () => ({
+  getAgentBridgeManager: vi.fn(() => ({
+    ensureReady: ensureReadyMock,
+  })),
+}))
+
+vi.mock('../../packages/server/src/services/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
+  getSystemPrompt: vi.fn(() => 'system prompt'),
+}))
+
+vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
+  getSession: vi.fn((sessionId?: string) => sessionId
+    ? { id: sessionId, profile: 'default', source: 'cli', model: 'gpt-test', provider: 'openai' }
+    : undefined),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+  getActiveProfileName: vi.fn(() => 'default'),
+  getProfileDir: vi.fn(() => '/tmp/hermes-default'),
+  listProfileNamesFromDisk: vi.fn(() => ['default']),
+}))
+
+vi.mock('../../packages/server/src/middleware/user-auth', () => ({
+  authenticateUserToken: vi.fn(),
+  isAuthEnabled: vi.fn(async () => false),
+}))
+
+vi.mock('../../packages/server/src/db/hermes/users-store', () => ({
+  userCanAccessProfile: vi.fn(() => true),
+}))
+
+function makeServerHarness() {
+  const handlers = new Map<string, Function>()
+  const emitted: Array<{ room: string; event: string; payload: any }> = []
+  const namespace = {
+    adapter: { rooms: new Map() },
+    to: vi.fn((room: string) => ({
+      emit: vi.fn((event: string, payload: any) => emitted.push({ room, event, payload })),
+    })),
+    use: vi.fn(),
+    on: vi.fn(),
+  }
+  const io = { of: vi.fn(() => namespace) }
+  const socket = {
+    id: 'socket-1',
+    connected: true,
+    handshake: { auth: {}, query: { profile: 'default' } },
+    data: {},
+    emit: vi.fn(),
+    join: vi.fn(),
+    to: vi.fn(() => ({ emit: vi.fn() })),
+    on: vi.fn((event: string, handler: Function) => {
+      handlers.set(event, handler)
+    }),
+  }
+  return { emitted, handlers, io, namespace, socket }
+}
+
+describe('ensureBridgeReadyForChatRun', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ensureReadyMock.mockResolvedValue({
+      reachable: true,
+      status: 'ready',
+      endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+    })
+  })
+
+  it('allows reachable bridge readiness', async () => {
+    const { ensureBridgeReadyForChatRun } = await import('../../packages/server/src/services/hermes/run-chat')
+
+    await expect(ensureBridgeReadyForChatRun()).resolves.toEqual({ ok: true })
+    expect(ensureReadyMock).toHaveBeenCalledWith({ timeoutMs: 1000, connectRetryMs: 0 })
+  })
+
+  it('returns a visible error when the bridge is unreachable', async () => {
+    ensureReadyMock.mockResolvedValueOnce({
+      reachable: false,
+      status: 'unreachable',
+      endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+      error: 'connect ECONNREFUSED ipc:///tmp/hermes-agent-bridge.sock',
+    })
+    const { ensureBridgeReadyForChatRun } = await import('../../packages/server/src/services/hermes/run-chat')
+
+    await expect(ensureBridgeReadyForChatRun()).resolves.toEqual({
+      ok: false,
+      error: 'connect ECONNREFUSED configured endpoint',
+    })
+  })
+
+  it('handles thrown ensureReady failures', async () => {
+    ensureReadyMock.mockRejectedValueOnce(new Error('bridge startup timed out'))
+    const { ensureBridgeReadyForChatRun } = await import('../../packages/server/src/services/hermes/run-chat')
+
+    await expect(ensureBridgeReadyForChatRun()).resolves.toEqual({
+      ok: false,
+      error: 'bridge startup timed out',
+    })
+  })
+})
+
+describe('ChatRunSocket bridge readiness gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ensureReadyMock.mockResolvedValue({
+      reachable: true,
+      status: 'ready',
+      endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+    })
+    bridgeMock.statusIfLoaded.mockResolvedValue({ ok: true, exists: false, running: false, loaded: false })
+    loadSessionStateFromDbMock.mockResolvedValue({
+      messages: [],
+      isWorking: false,
+      isAborting: false,
+      events: [],
+      queue: [],
+    })
+  })
+
+  it('emits run.failed before starting a cli run when the bridge is unreachable', async () => {
+    ensureReadyMock.mockResolvedValueOnce({
+      reachable: false,
+      status: 'unreachable',
+      endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+      error: 'bridge offline',
+    })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('run')?.({ input: 'hello', session_id: 'session-1', source: 'cli' })
+
+    expect(handleBridgeRunMock).not.toHaveBeenCalled()
+    expect(socket.emit).toHaveBeenCalledWith('run.failed', {
+      event: 'run.failed',
+      session_id: 'session-1',
+      error: 'Agent Bridge is not reachable: bridge offline',
+    })
+    expect((server as any).sessionMap.get('session-1')).toEqual(expect.objectContaining({
+      isWorking: false,
+      profile: undefined,
+    }))
+  })
+
+  it('does not gate runs when resolveRunSource resolves api_server in tests', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('run')?.({ input: 'hello', session_id: 'session-1', source: 'api_server' })
+
+    expect(ensureReadyMock).not.toHaveBeenCalled()
+    expect(handleApiRunMock).toHaveBeenCalledTimes(1)
+    expect(handleBridgeRunMock).not.toHaveBeenCalled()
+    expect(socket.emit).not.toHaveBeenCalledWith('run.failed', expect.anything())
+  })
+
+  it('emits run.failed before resumeBridgeRun when the bridge is unreachable', async () => {
+    ensureReadyMock.mockResolvedValueOnce({
+      reachable: false,
+      status: 'unreachable',
+      endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+      error: 'bridge offline',
+    })
+    bridgeMock.statusIfLoaded
+      .mockResolvedValueOnce({
+        ok: true,
+        exists: true,
+        running: true,
+        current_run_id: 'run-1',
+        loaded: true,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        exists: true,
+        running: true,
+        current_run_id: 'run-1',
+        loaded: true,
+      })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { emitted, handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('resume')?.({ session_id: 'session-1' })
+
+    expect(resumeBridgeRunMock).not.toHaveBeenCalled()
+    expect(socket.emit).toHaveBeenCalledWith('resumed', expect.objectContaining({
+      session_id: 'session-1',
+      isWorking: false,
+      events: [],
+    }))
+    expect(emitted).toContainEqual({
+      room: 'session:session-1',
+      event: 'run.failed',
+      payload: {
+        event: 'run.failed',
+        session_id: 'session-1',
+        error: 'Agent Bridge is not reachable: bridge offline',
+      },
+    })
+    expect((server as any).sessionMap.get('session-1')).toEqual(expect.objectContaining({
+      isWorking: false,
+      runId: undefined,
+      activeRunMarker: undefined,
+      profile: undefined,
+      source: undefined,
+      events: [],
+    }))
+    expect((server as any).bridgeResumePolls.size).toBe(0)
+
+    await handlers.get('resume')?.({ session_id: 'session-1' })
+
+    expect(resumeBridgeRunMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -5,6 +5,7 @@ const resumeBridgeRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const handleApiRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const loadSessionStateFromDbMock = vi.hoisted(() => vi.fn())
 const ensureReadyMock = vi.hoisted(() => vi.fn())
+const getRuntimeStateMock = vi.hoisted(() => vi.fn())
 const bridgeMock = vi.hoisted(() => ({
   status: vi.fn(),
   statusIfLoaded: vi.fn(),
@@ -34,6 +35,7 @@ vi.mock('../../packages/server/src/services/hermes/agent-bridge', () => ({
 vi.mock('../../packages/server/src/services/hermes/agent-bridge/manager', () => ({
   getAgentBridgeManager: vi.fn(() => ({
     ensureReady: ensureReadyMock,
+    getRuntimeState: getRuntimeStateMock,
   })),
 }))
 
@@ -101,6 +103,7 @@ describe('ensureBridgeReadyForChatRun', () => {
       status: 'ready',
       endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
     })
+    getRuntimeStateMock.mockReturnValue({ endpoint: 'ipc:///tmp/hermes-agent-bridge.sock' })
   })
 
   it('allows reachable bridge readiness', async () => {
@@ -116,6 +119,21 @@ describe('ensureBridgeReadyForChatRun', () => {
       status: 'unreachable',
       endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
       error: 'connect ECONNREFUSED ipc:///tmp/hermes-agent-bridge.sock',
+    })
+    const { ensureBridgeReadyForChatRun } = await import('../../packages/server/src/services/hermes/run-chat')
+
+    await expect(ensureBridgeReadyForChatRun()).resolves.toEqual({
+      ok: false,
+      error: 'connect ECONNREFUSED configured endpoint',
+    })
+  })
+
+  it('redacts configured loopback tcp host:port when the bridge is unreachable', async () => {
+    ensureReadyMock.mockResolvedValueOnce({
+      reachable: false,
+      status: 'unreachable',
+      endpoint: 'tcp://127.0.0.1:43123',
+      error: 'connect ECONNREFUSED 127.0.0.1:43123',
     })
     const { ensureBridgeReadyForChatRun } = await import('../../packages/server/src/services/hermes/run-chat')
 
@@ -144,6 +162,7 @@ describe('ChatRunSocket bridge readiness gating', () => {
       status: 'ready',
       endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
     })
+    getRuntimeStateMock.mockReturnValue({ endpoint: 'ipc:///tmp/hermes-agent-bridge.sock' })
     bridgeMock.statusIfLoaded.mockResolvedValue({ ok: true, exists: false, running: false, loaded: false })
     loadSessionStateFromDbMock.mockResolvedValue({
       messages: [],
@@ -251,5 +270,59 @@ describe('ChatRunSocket bridge readiness gating', () => {
     await handlers.get('resume')?.({ session_id: 'session-1' })
 
     expect(resumeBridgeRunMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits run.failed and clears stale state when bridge status lookup throws during resume', async () => {
+    bridgeMock.statusIfLoaded.mockRejectedValueOnce(new Error('connect ECONNREFUSED ipc:///tmp/hermes-agent-bridge.sock'))
+    loadSessionStateFromDbMock.mockResolvedValueOnce({
+      messages: [],
+      isWorking: false,
+      isAborting: true,
+      runId: 'stale-run',
+      activeRunMarker: 'marker-1',
+      profile: 'default',
+      source: 'cli',
+      events: [{ event: 'run.started', data: { run_id: 'stale-run' } }],
+      queue: [],
+    })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { emitted, handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('resume')?.({ session_id: 'session-1' })
+
+    expect(ensureReadyMock).not.toHaveBeenCalled()
+    expect(resumeBridgeRunMock).not.toHaveBeenCalled()
+    expect(emitted).toContainEqual({
+      room: 'session:session-1',
+      event: 'run.failed',
+      payload: {
+        event: 'run.failed',
+        session_id: 'session-1',
+        error: 'Agent Bridge is not reachable: connect ECONNREFUSED configured endpoint',
+      },
+    })
+    expect(socket.emit).toHaveBeenCalledWith('run.failed', {
+      event: 'run.failed',
+      session_id: 'session-1',
+      error: 'Agent Bridge is not reachable: connect ECONNREFUSED configured endpoint',
+    })
+    expect(socket.emit).toHaveBeenCalledWith('resumed', expect.objectContaining({
+      session_id: 'session-1',
+      isWorking: false,
+      isAborting: false,
+      events: [],
+    }))
+    expect((server as any).sessionMap.get('session-1')).toEqual(expect.objectContaining({
+      isWorking: false,
+      isAborting: false,
+      runId: undefined,
+      activeRunMarker: undefined,
+      profile: undefined,
+      source: undefined,
+      events: [],
+    }))
+    expect((server as any).bridgeResumePolls.size).toBe(0)
   })
 })

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -229,6 +229,69 @@ describe('ChatRunSocket bridge readiness gating', () => {
     expect(socket.emit).not.toHaveBeenCalledWith('run.failed', expect.anything())
   })
 
+  it('continues with remaining queued bridge runs when readiness fails before a dequeued run starts', async () => {
+    ensureReadyMock
+      .mockResolvedValueOnce({
+        reachable: false,
+        status: 'unreachable',
+        endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+        error: 'bridge offline',
+      })
+      .mockResolvedValueOnce({
+        reachable: true,
+        status: 'ready',
+        endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+      })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { emitted, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).sessionMap.set('session-1', {
+      messages: [],
+      isWorking: true,
+      isAborting: false,
+      events: [],
+      queue: [{
+        queue_id: 'queue-next',
+        input: 'second queued message',
+        source: 'cli',
+        profile: 'default',
+      }],
+      profile: 'default',
+      source: 'cli',
+    })
+
+    ;(server as any).runQueuedItem(socket, 'session-1', {
+      queue_id: 'queue-failed',
+      input: 'first queued message',
+      source: 'cli',
+      profile: 'default',
+    }, 'default')
+
+    await vi.waitFor(() => expect(ensureReadyMock).toHaveBeenCalledTimes(2))
+    expect(handleBridgeRunMock).toHaveBeenCalledTimes(1)
+    expect(handleBridgeRunMock.mock.calls[0][2]).toEqual(expect.objectContaining({
+      input: 'second queued message',
+      queue_id: 'queue-next',
+    }))
+    expect(socket.emit).toHaveBeenCalledWith('run.failed', {
+      event: 'run.failed',
+      session_id: 'session-1',
+      error: 'Agent Bridge is not reachable: bridge offline',
+      queue_remaining: 1,
+    })
+    expect(emitted).toContainEqual({
+      room: 'session:session-1',
+      event: 'run.queued',
+      payload: expect.objectContaining({
+        event: 'run.queued',
+        session_id: 'session-1',
+        queue_length: 0,
+        dequeued_queue_id: 'queue-next',
+      }),
+    })
+  })
+
   it('reattaches a loaded running bridge run without probing manager readiness again', async () => {
     bridgeMock.statusIfLoaded
       .mockResolvedValueOnce({

--- a/tests/server/health-controller.test.ts
+++ b/tests/server/health-controller.test.ts
@@ -13,6 +13,8 @@ type LoadHealthControllerOptions = {
   injectedVersion?: string
   bridgeReadiness?: any
   bridgeReadinessError?: Error
+  managerError?: Error
+  runtimeStateError?: Error
 }
 
 const defaultBridgeReadiness = {
@@ -46,10 +48,14 @@ async function loadHealthController(options: LoadHealthControllerOptions = {}) {
   const checkReadiness = options.bridgeReadinessError
     ? vi.fn().mockRejectedValue(options.bridgeReadinessError)
     : vi.fn().mockResolvedValue(options.bridgeReadiness || defaultBridgeReadiness)
-  const getRuntimeState = vi.fn(() => ({
-    endpoint: options.bridgeReadiness?.endpoint || 'ipc:///tmp/hermes-agent-bridge.sock',
-  }))
-  const getAgentBridgeManager = vi.fn(() => ({ checkReadiness, getRuntimeState }))
+  const getRuntimeState = options.runtimeStateError
+    ? vi.fn(() => { throw options.runtimeStateError })
+    : vi.fn(() => ({
+        endpoint: options.bridgeReadiness?.endpoint || 'ipc:///tmp/hermes-agent-bridge.sock',
+      }))
+  const getAgentBridgeManager = options.managerError
+    ? vi.fn(() => { throw options.managerError })
+    : vi.fn(() => ({ checkReadiness, getRuntimeState }))
 
   vi.doMock('../../packages/server/src/services/hermes/agent-bridge/manager', () => ({
     getAgentBridgeManager,
@@ -168,7 +174,7 @@ describe('health controller version metadata', () => {
     await healthCheck(ctx)
 
     expect(getAgentBridgeManager).toHaveBeenCalledTimes(1)
-    expect(checkReadiness).toHaveBeenCalledWith({ timeoutMs: 750, connectRetryMs: 0 })
+    expect(checkReadiness).toHaveBeenCalledWith({ timeoutMs: 75, connectRetryMs: 0 })
     expect(ctx.body.agent_bridge).toEqual({
       status: 'unreachable',
       reachable: false,
@@ -197,7 +203,7 @@ describe('health controller version metadata', () => {
 
     await expect(healthCheck(ctx)).resolves.toBeUndefined()
 
-    expect(checkReadiness).toHaveBeenCalledWith({ timeoutMs: 750, connectRetryMs: 0 })
+    expect(checkReadiness).toHaveBeenCalledWith({ timeoutMs: 75, connectRetryMs: 0 })
     expect(getRuntimeState).toHaveBeenCalledTimes(1)
     expect(ctx.body.status).toBe('ok')
     expect(ctx.body.gateway).toBe('running')
@@ -209,4 +215,45 @@ describe('health controller version metadata', () => {
     expect(JSON.stringify(ctx.body.agent_bridge)).not.toContain('/tmp/hermes-agent-bridge.sock')
     expect(JSON.stringify(ctx.body.agent_bridge)).not.toContain('ipc:///tmp/hermes-agent-bridge.sock')
   })
+
+  it('handles manager construction errors without failing the base health check', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }))
+
+    const { healthCheck, getAgentBridgeManager, checkReadiness } = await loadHealthControllerWithoutInjectedVersion({
+      managerError: new Error('bad bridge config /tmp/hermes-agent-bridge.sock'),
+    })
+    const ctx = createMockCtx()
+
+    await expect(healthCheck(ctx)).resolves.toBeUndefined()
+
+    expect(getAgentBridgeManager).toHaveBeenCalledTimes(1)
+    expect(checkReadiness).not.toHaveBeenCalled()
+    expect(ctx.body.status).toBe('ok')
+    expect(ctx.body.agent_bridge).toEqual({
+      status: 'unknown',
+      reachable: false,
+      error: 'bad bridge config [redacted endpoint]',
+    })
+  })
+
+  it('handles runtime-state errors without failing the base health check', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }))
+
+    const { healthCheck, getRuntimeState, checkReadiness } = await loadHealthControllerWithoutInjectedVersion({
+      runtimeStateError: new Error('runtime state unavailable'),
+    })
+    const ctx = createMockCtx()
+
+    await expect(healthCheck(ctx)).resolves.toBeUndefined()
+
+    expect(getRuntimeState).toHaveBeenCalledTimes(1)
+    expect(checkReadiness).not.toHaveBeenCalled()
+    expect(ctx.body.status).toBe('ok')
+    expect(ctx.body.agent_bridge).toEqual({
+      status: 'unknown',
+      reachable: false,
+      error: 'runtime state unavailable',
+    })
+  })
+
 })

--- a/tests/server/health-controller.test.ts
+++ b/tests/server/health-controller.test.ts
@@ -9,26 +9,68 @@ function readRootPackage() {
   }
 }
 
-async function loadHealthControllerWithoutInjectedVersion() {
+type LoadHealthControllerOptions = {
+  injectedVersion?: string
+  bridgeReadiness?: any
+  bridgeReadinessError?: Error
+}
+
+const defaultBridgeReadiness = {
+  endpoint: 'tcp://127.0.0.1:8123',
+  endpointKind: 'tcp',
+  status: 'ready',
+  reachable: true,
+  ready: true,
+  running: true,
+  attached: false,
+  starting: false,
+  stopping: false,
+  restartScheduled: false,
+  restartAttempts: 0,
+  pid: 4321,
+}
+
+async function loadHealthController(options: LoadHealthControllerOptions = {}) {
   vi.resetModules()
-  delete (globalThis as any).__APP_VERSION__
+
+  if (typeof options.injectedVersion === 'string') {
+    ;(globalThis as any).__APP_VERSION__ = options.injectedVersion
+  } else {
+    delete (globalThis as any).__APP_VERSION__
+  }
 
   vi.doMock('../../packages/server/src/services/hermes/hermes-cli', () => ({
     getVersion: vi.fn().mockResolvedValue('Hermes Agent v0.11.0\n'),
   }))
 
-  return import('../../packages/server/src/controllers/health')
+  const checkReadiness = options.bridgeReadinessError
+    ? vi.fn().mockRejectedValue(options.bridgeReadinessError)
+    : vi.fn().mockResolvedValue(options.bridgeReadiness || defaultBridgeReadiness)
+  const getRuntimeState = vi.fn(() => ({
+    endpoint: options.bridgeReadiness?.endpoint || 'ipc:///tmp/hermes-agent-bridge.sock',
+  }))
+  const getAgentBridgeManager = vi.fn(() => ({ checkReadiness, getRuntimeState }))
+
+  vi.doMock('../../packages/server/src/services/hermes/agent-bridge/manager', () => ({
+    getAgentBridgeManager,
+  }))
+
+  const health = await import('../../packages/server/src/controllers/health')
+
+  return {
+    ...health,
+    getAgentBridgeManager,
+    checkReadiness,
+    getRuntimeState,
+  }
+}
+
+async function loadHealthControllerWithoutInjectedVersion(options: Omit<LoadHealthControllerOptions, 'injectedVersion'> = {}) {
+  return loadHealthController(options)
 }
 
 async function loadHealthControllerWithInjectedVersion(version: string) {
-  vi.resetModules()
-  ;(globalThis as any).__APP_VERSION__ = version
-
-  vi.doMock('../../packages/server/src/services/hermes/hermes-cli', () => ({
-    getVersion: vi.fn().mockResolvedValue('Hermes Agent v0.11.0\n'),
-  }))
-
-  return import('../../packages/server/src/controllers/health')
+  return loadHealthController({ injectedVersion: version })
 }
 
 function createMockCtx() {
@@ -99,5 +141,72 @@ describe('health controller version metadata', () => {
     const { checkLatestVersion } = await loadHealthControllerWithoutInjectedVersion()
 
     await expect(checkLatestVersion()).resolves.toBeUndefined()
+  })
+
+  it('includes sanitized agent bridge readiness fields without leaking the endpoint path', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }))
+
+    const { healthCheck, getAgentBridgeManager, checkReadiness } = await loadHealthControllerWithoutInjectedVersion({
+      bridgeReadiness: {
+        endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+        endpointKind: 'ipc',
+        status: 'unreachable',
+        reachable: false,
+        ready: false,
+        running: false,
+        attached: false,
+        starting: false,
+        stopping: false,
+        restartScheduled: true,
+        restartAttempts: 3,
+        pid: 9876,
+        error: 'connect ENOENT /tmp/hermes-agent-bridge.sock',
+      },
+    })
+    const ctx = createMockCtx()
+
+    await healthCheck(ctx)
+
+    expect(getAgentBridgeManager).toHaveBeenCalledTimes(1)
+    expect(checkReadiness).toHaveBeenCalledWith({ timeoutMs: 750, connectRetryMs: 0 })
+    expect(ctx.body.agent_bridge).toEqual({
+      status: 'unreachable',
+      reachable: false,
+      ready: false,
+      running: false,
+      attached: false,
+      starting: false,
+      stopping: false,
+      restart_scheduled: true,
+      restart_attempts: 3,
+      endpoint_kind: 'ipc',
+      pid: 9876,
+      error: 'connect ENOENT [redacted endpoint]',
+    })
+    expect(ctx.body.agent_bridge).not.toHaveProperty('endpoint')
+    expect(JSON.stringify(ctx.body.agent_bridge)).not.toContain('/tmp/hermes-agent-bridge.sock')
+  })
+
+  it('handles agent bridge readiness probe errors without failing the health check', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }))
+
+    const { healthCheck, checkReadiness, getRuntimeState } = await loadHealthControllerWithoutInjectedVersion({
+      bridgeReadinessError: new Error('bridge manager unavailable at ipc:///tmp/hermes-agent-bridge.sock (ENOENT /tmp/hermes-agent-bridge.sock)'),
+    })
+    const ctx = createMockCtx()
+
+    await expect(healthCheck(ctx)).resolves.toBeUndefined()
+
+    expect(checkReadiness).toHaveBeenCalledWith({ timeoutMs: 750, connectRetryMs: 0 })
+    expect(getRuntimeState).toHaveBeenCalledTimes(1)
+    expect(ctx.body.status).toBe('ok')
+    expect(ctx.body.gateway).toBe('running')
+    expect(ctx.body.agent_bridge).toEqual({
+      status: 'unknown',
+      reachable: false,
+      error: 'bridge manager unavailable at [redacted endpoint] (ENOENT [redacted endpoint])',
+    })
+    expect(JSON.stringify(ctx.body.agent_bridge)).not.toContain('/tmp/hermes-agent-bridge.sock')
+    expect(JSON.stringify(ctx.body.agent_bridge)).not.toContain('ipc:///tmp/hermes-agent-bridge.sock')
   })
 })

--- a/tests/server/run-chat-queued-item.test.ts
+++ b/tests/server/run-chat-queued-item.test.ts
@@ -4,6 +4,7 @@ const handleBridgeRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const resumeBridgeRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const handleApiRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const loadSessionStateFromDbMock = vi.hoisted(() => vi.fn())
+const ensureReadyMock = vi.hoisted(() => vi.fn())
 const bridgeMock = vi.hoisted(() => ({
   status: vi.fn(),
   statusIfLoaded: vi.fn(),
@@ -28,6 +29,12 @@ vi.mock('../../packages/server/src/services/hermes/run-chat/session-command', ()
 
 vi.mock('../../packages/server/src/services/hermes/agent-bridge', () => ({
   AgentBridgeClient: vi.fn(() => bridgeMock),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/agent-bridge/manager', () => ({
+  getAgentBridgeManager: vi.fn(() => ({
+    ensureReady: ensureReadyMock,
+  })),
 }))
 
 vi.mock('../../packages/server/src/services/logger', () => ({
@@ -84,6 +91,11 @@ function makeServerHarness() {
 describe('ChatRunSocket queued bridge runs', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    ensureReadyMock.mockResolvedValue({
+      reachable: true,
+      status: 'ready',
+      endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+    })
     bridgeMock.statusIfLoaded.mockResolvedValue({ ok: true, exists: false, running: false, loaded: false })
     loadSessionStateFromDbMock.mockResolvedValue({
       messages: [],

--- a/tests/server/run-chat-queued-item.test.ts
+++ b/tests/server/run-chat-queued-item.test.ts
@@ -164,7 +164,7 @@ describe('ChatRunSocket queued bridge runs', () => {
     ;(server as any).onConnection(socket)
     await handlers.get('resume')?.({ session_id: 'session-1' })
 
-    expect(bridgeMock.statusIfLoaded).toHaveBeenCalledWith('session-1', 'default')
+    expect(bridgeMock.statusIfLoaded).toHaveBeenCalledWith('session-1', 'default', { timeoutMs: 1000 })
     expect(bridgeMock.status).not.toHaveBeenCalled()
     expect(resumeBridgeRunMock).not.toHaveBeenCalled()
     expect(socket.emit).toHaveBeenCalledWith('resumed', expect.objectContaining({


### PR DESCRIPTION
## Summary

- 增加服务端 Agent Bridge readiness 探测，并在 `/health` 的嵌套 `agent_bridge` 字段里返回脱敏后的 readiness 状态，同时保持顶层 health 兼容。
- 将 chat 路径的非破坏性 readiness 检查与 manager-owned recovery 分离：新 CLI run 在 bridge 不可达时会显式失败，但不会同步 kill/restart 共享 bridge。
- 加固 managed bridge recovery：single-flight recovery、caller-timeout-bounded wait、旧 child 退出观测、stop/recovery race 处理，以及旧 child 未退出时不拉起 replacement。
- 将 resume/reattach uncertainty 视为非终态：保留 run identity/state，并发出 `run.reattach_failed`，而不是终态 `run.failed`。
- 集中 bridge endpoint redaction，覆盖 `/health` 与 chat error 中的 bare IPC path、`ipc://...`、`agent-bridge.sock` 路径和配置的 TCP host:port。

## Existing coverage / related PRs

- 补充 #1389。#1389 负责把默认 bridge endpoint scope 到 `HERMES_WEB_UI_HOME`，避免全局 `/tmp` 跨实例 attach；本 PR 不重复实现 endpoint scoping，而是在 legacy global default endpoint 下 runtime-guard managed destructive recovery。
- 基于已合并的 #862，其已处理 Agent Bridge child-process exit/restart window。
- 不实现 #989 的 unknown-run persistence/recovery；因此本 PR 明确把 resume uncertainty 处理为非终态。

## Verification

- `npm test -- --run tests/server/agent-bridge-manager.test.ts tests/server/health-controller.test.ts tests/server/chat-run-bridge-readiness.test.ts tests/server/run-chat-queued-item.test.ts tests/server/run-chat-bridge-terminal-error.test.ts tests/server/run-chat-bridge-resume.test.ts tests/client/chat-store-compression-state.test.ts` → passed, 62/62 tests
- `npm run harness:check` → passed
- `npx tsc --noEmit -p packages/server/tsconfig.json` → passed
- `npx vue-tsc -b --pretty false` → passed
- `npm run build` → passed
- `git diff --check origin/main...HEAD` → clean
- Production-built smoke on `PORT=8765` with temp `HERMES_WEB_UI_HOME` and explicit unreachable `HERMES_AGENT_BRIDGE_ENDPOINT=tcp://127.0.0.1:1`:
  - `/health` stayed HTTP 200 / `status: "ok"`
  - nested `agent_bridge.status` was `"unreachable"`, `reachable: false`, `endpoint_kind: "tcp"`
  - nested error was sanitized as `connect ECONNREFUSED [redacted endpoint]`; response did not contain the configured endpoint literal
- Browser UAT against the same production build with unreachable bridge:
  - login succeeded
  - chat page loaded and connected
  - sending a CLI chat message with unreachable bridge produced visible error: `Agent Bridge is not reachable: connect ECONNREFUSED configured endpoint`
  - no local endpoint literal was shown in the user-visible error
- Additional production browser UAT with reachable managed bridge on `PORT=8766` / `HERMES_AGENT_BRIDGE_ENDPOINT=tcp://127.0.0.1:18777`:
  - `/health` reported nested `agent_bridge.status: "ready"`, `reachable: true`, `endpoint_kind: "tcp"`
  - login succeeded and chat page connected
  - normal CLI chat completed successfully; model response contained `NORMAL_CHAT_OK`
  - browser reload/session restore showed the session title/message and no `Error:` state
  - `/health` remained ready after the chat run
  - browser console had no JS errors
  - smoke server and bridge listener ports were cleaned up after UAT

## Notes

- `/health` intentionally remains HTTP 200 / `status: "ok"` for compatibility with existing uptime monitors; bridge readiness is reported in the nested `agent_bridge` object.
- `/health` bridge probing is cached/bounded and exception-isolated so bridge collection cannot break base health.
- Production `resolveRunSource()` still resolves to `cli`; this PR does not re-enable or broaden API-source routing.
