### PR TITLE
添加 STT provider 基础设施

### DIFF
--- a/docs/chat-chain-changes/2026-06-08-stt-provider-infra.md
+++ b/docs/chat-chain-changes/2026-06-08-stt-provider-infra.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-08
+pr: pending
+feature: STT provider infrastructure
+impact: Adds authenticated speech-to-text provider settings and transcription routes used by later chat voice-input flows.
+---
+
+This branch adds the backend and client API foundation for browser/custom/OpenAI-compatible transcription without changing chat composer behavior yet.

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -110,8 +110,9 @@ function emitAuthNotice(kind: 'expired' | 'forbidden') {
 export async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   const base = getBaseUrl()
   const url = `${base}${path}`
+  const isFormDataBody = typeof FormData !== 'undefined' && options.body instanceof FormData
   const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
+    ...(isFormDataBody ? {} : { 'Content-Type': 'application/json' }),
     ...options.headers as Record<string, string>,
   }
 

--- a/packages/client/src/api/hermes/stt-settings.ts
+++ b/packages/client/src/api/hermes/stt-settings.ts
@@ -1,0 +1,131 @@
+import { request } from '../client'
+
+export type SttProvider = 'browser' | 'openai' | 'custom'
+export type StoredSttProvider = Exclude<SttProvider, 'browser'>
+
+export interface SttStoredSettings {
+  baseUrl?: string
+  baseUrlPresets?: string[]
+  model?: string
+  language?: string
+  prompt?: string
+}
+
+export interface SttStoredSecretsInput {
+  apiKey?: string
+}
+
+export interface SttStoredSecretsResponse {
+  apiKey?: '[stored]'
+}
+
+export interface SttProviderSettingsResponse {
+  provider: StoredSttProvider
+  settings: SttStoredSettings
+  secrets: SttStoredSecretsResponse
+  createdAt?: number
+  updatedAt: number
+}
+
+export interface FetchSttSettingsResponse {
+  providers: SttProviderSettingsResponse[]
+  activeProvider?: SttProvider | null
+}
+
+function normalizeActiveProvider(value: unknown): SttProvider | null {
+  return value === 'browser' || value === 'openai' || value === 'custom' ? value : null
+}
+
+function normalizeProviders(body: unknown): FetchSttSettingsResponse {
+  if (body && typeof body === 'object') {
+    const payload = body as {
+      providers?: unknown
+      settings?: unknown
+      activeProvider?: unknown
+    }
+    const activeProvider = normalizeActiveProvider(payload.activeProvider)
+
+    if (Array.isArray(payload.providers)) {
+      return { providers: payload.providers as SttProviderSettingsResponse[], activeProvider }
+    }
+
+    if (Array.isArray(payload.settings)) {
+      return { providers: payload.settings as SttProviderSettingsResponse[], activeProvider }
+    }
+  }
+
+  return { providers: [], activeProvider: null }
+}
+
+export async function fetchSttSettings(): Promise<FetchSttSettingsResponse> {
+  const body = await request<{ providers?: SttProviderSettingsResponse[]; settings?: SttProviderSettingsResponse[]; activeProvider?: SttProvider | null }>(
+    '/api/hermes/stt/settings',
+  )
+  return normalizeProviders(body)
+}
+
+export async function saveSttSettings(
+  provider: StoredSttProvider,
+  payload: { settings?: SttStoredSettings; secrets?: SttStoredSecretsInput; activeProvider?: SttProvider },
+): Promise<SttProviderSettingsResponse> {
+  const body = await request<SttProviderSettingsResponse | { setting: SttProviderSettingsResponse }>(
+    `/api/hermes/stt/settings/${provider}`,
+    {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    },
+  )
+  return typeof body === 'object' && body !== null && 'setting' in body ? body.setting : body
+}
+
+export async function saveActiveSttProvider(provider: SttProvider): Promise<SttProvider> {
+  const body = await request<{ activeProvider: SttProvider }>(
+    '/api/hermes/stt/settings/active',
+    {
+      method: 'PUT',
+      body: JSON.stringify({ provider }),
+    },
+  )
+  return body.activeProvider
+}
+
+export async function clearSttSecret(
+  provider: StoredSttProvider,
+  secretName: keyof SttStoredSecretsInput,
+): Promise<SttProviderSettingsResponse | null> {
+  const body = await request<
+    SttProviderSettingsResponse |
+    { setting: SttProviderSettingsResponse | null } |
+    { success?: boolean; setting: SttProviderSettingsResponse | null }
+  >(
+    `/api/hermes/stt/settings/${provider}/secret/${secretName}`,
+    {
+      method: 'DELETE',
+    },
+  )
+
+  if (body && typeof body === 'object' && 'setting' in body) {
+    return body.setting ?? null
+  }
+
+  return body as SttProviderSettingsResponse
+}
+
+export async function deleteSttBaseUrlPreset(
+  provider: StoredSttProvider,
+  url: string,
+): Promise<SttProviderSettingsResponse | null> {
+  const body = await request<
+    SttProviderSettingsResponse |
+    { success?: boolean; setting: SttProviderSettingsResponse | null }
+  >(
+    `/api/hermes/stt/settings/${provider}/base-url-preset?url=${encodeURIComponent(url)}`,
+    { method: 'DELETE' },
+  )
+
+  if (body && typeof body === 'object' && 'setting' in body) {
+    return body.setting ?? null
+  }
+
+  return body as SttProviderSettingsResponse
+}

--- a/packages/client/src/api/hermes/stt.contract.ts
+++ b/packages/client/src/api/hermes/stt.contract.ts
@@ -1,0 +1,21 @@
+import type { TranscribeSpeechRequest } from './stt'
+
+type Expect<T extends true> = T
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+  ? ((<T>() => T extends B ? 1 : 2) extends (<T>() => T extends A ? 1 : 2) ? true : false)
+  : false
+
+type IsRequiredKey<T, K extends keyof T> = {} extends Pick<T, K> ? false : true
+
+export type TranscribeSpeechRequestKeysContract = Expect<
+  Equal<keyof TranscribeSpeechRequest, 'audio' | 'provider' | 'language' | 'prompt'>
+>
+
+export type TranscribeSpeechRequestAudioRequiredContract = Expect<
+  IsRequiredKey<TranscribeSpeechRequest, 'audio'>
+>
+
+export type TranscribeSpeechRequestProviderRequiredContract = Expect<
+  IsRequiredKey<TranscribeSpeechRequest, 'provider'>
+>

--- a/packages/client/src/api/hermes/stt.ts
+++ b/packages/client/src/api/hermes/stt.ts
@@ -1,0 +1,40 @@
+import { request } from '../client'
+import type { StoredSttProvider } from './stt-settings'
+
+export interface TranscribeSpeechRequest {
+  audio: Blob
+  provider: StoredSttProvider
+  language?: string
+  prompt?: string
+}
+
+export interface TranscribeSpeechResponse {
+  text: string
+  provider: StoredSttProvider
+  model: string
+  language?: string
+  durationMs: number
+}
+
+export async function transcribeSpeech(req: TranscribeSpeechRequest): Promise<TranscribeSpeechResponse> {
+  if (!req.provider) {
+    throw new Error('STT provider is required')
+  }
+
+  const formData = new FormData()
+  formData.append('audio', req.audio, 'speech.webm')
+  formData.append('provider', req.provider)
+
+  if (typeof req.language === 'string' && req.language) {
+    formData.append('language', req.language)
+  }
+
+  if (typeof req.prompt === 'string' && req.prompt) {
+    formData.append('prompt', req.prompt)
+  }
+
+  return request<TranscribeSpeechResponse>('/api/hermes/stt/transcribe', {
+    method: 'POST',
+    body: formData,
+  })
+}

--- a/packages/client/src/composables/useSttSettings.ts
+++ b/packages/client/src/composables/useSttSettings.ts
@@ -1,0 +1,280 @@
+import { ref, watch } from 'vue'
+import { fetchSttSettings } from '@/api/hermes/stt-settings'
+import type {
+  FetchSttSettingsResponse,
+  SttProvider,
+  SttProviderSettingsResponse,
+} from '@/api/hermes/stt-settings'
+
+interface SttSettingsData {
+  provider: SttProvider
+  openaiModel: string
+  openaiLanguage: string
+  openaiPrompt: string
+  customBaseUrl: string
+  customModel: string
+  customLanguage: string
+  customPrompt: string
+}
+
+const STORAGE_KEY = 'hermes-stt-settings-v1'
+
+function browserSttAvailable(): boolean {
+  if (typeof window === 'undefined') return false
+  const browserWindow = window as Window & {
+    SpeechRecognition?: unknown
+    webkitSpeechRecognition?: unknown
+  }
+  return typeof browserWindow.SpeechRecognition !== 'undefined'
+    || typeof browserWindow.webkitSpeechRecognition !== 'undefined'
+}
+
+function defaultProvider(): SttProvider {
+  return browserSttAvailable() ? 'browser' : 'openai'
+}
+
+const DEFAULT: SttSettingsData = {
+  provider: defaultProvider(),
+  openaiModel: 'gpt-4o-transcribe',
+  openaiLanguage: '',
+  openaiPrompt: '',
+  customBaseUrl: '',
+  customModel: 'gpt-4o-transcribe',
+  customLanguage: '',
+  customPrompt: '',
+}
+
+function sanitize(data: Partial<SttSettingsData>): SttSettingsData {
+  const provider = data.provider === 'browser' || data.provider === 'openai' || data.provider === 'custom'
+    ? data.provider
+    : DEFAULT.provider
+
+  return {
+    provider,
+    openaiModel: typeof data.openaiModel === 'string' && data.openaiModel.trim() ? data.openaiModel : DEFAULT.openaiModel,
+    openaiLanguage: typeof data.openaiLanguage === 'string' ? data.openaiLanguage : DEFAULT.openaiLanguage,
+    openaiPrompt: typeof data.openaiPrompt === 'string' ? data.openaiPrompt : DEFAULT.openaiPrompt,
+    customBaseUrl: typeof data.customBaseUrl === 'string' ? data.customBaseUrl : DEFAULT.customBaseUrl,
+    customModel: typeof data.customModel === 'string' && data.customModel.trim() ? data.customModel : DEFAULT.customModel,
+    customLanguage: typeof data.customLanguage === 'string' ? data.customLanguage : DEFAULT.customLanguage,
+    customPrompt: typeof data.customPrompt === 'string' ? data.customPrompt : DEFAULT.customPrompt,
+  }
+}
+
+function load(): SttSettingsData {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      const sanitized = sanitize(JSON.parse(raw))
+      const sanitizedRaw = JSON.stringify(sanitized)
+      if (raw !== sanitizedRaw) {
+        localStorage.setItem(STORAGE_KEY, sanitizedRaw)
+      }
+      return sanitized
+    }
+  } catch {
+    // ignore invalid persisted values
+  }
+  return { ...DEFAULT }
+}
+
+const initial = load()
+
+const provider = ref<SttProvider>(initial.provider)
+
+const openaiModel = ref(initial.openaiModel)
+const openaiLanguage = ref(initial.openaiLanguage)
+const openaiPrompt = ref(initial.openaiPrompt)
+const openaiApiKey = ref('')
+const openaiApiKeyPreview = ref('')
+const openaiHasApiKey = ref(false)
+
+const customBaseUrl = ref(initial.customBaseUrl)
+const customBaseUrlPresets = ref<string[]>([])
+const customModel = ref(initial.customModel)
+const customLanguage = ref(initial.customLanguage)
+const customPrompt = ref(initial.customPrompt)
+const customApiKey = ref('')
+const customApiKeyPreview = ref('')
+const customHasApiKey = ref(false)
+
+function persistedData(): SttSettingsData {
+  return {
+    provider: provider.value,
+    openaiModel: openaiModel.value,
+    openaiLanguage: openaiLanguage.value,
+    openaiPrompt: openaiPrompt.value,
+    customBaseUrl: customBaseUrl.value,
+    customModel: customModel.value,
+    customLanguage: customLanguage.value,
+    customPrompt: customPrompt.value,
+  }
+}
+
+function persist() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(persistedData()))
+  } catch (err) {
+    console.warn('[useSttSettings] Failed to persist STT settings:', err)
+  }
+}
+
+function resetServerBackedState() {
+  openaiModel.value = DEFAULT.openaiModel
+  openaiLanguage.value = DEFAULT.openaiLanguage
+  openaiPrompt.value = DEFAULT.openaiPrompt
+  openaiApiKey.value = ''
+  openaiApiKeyPreview.value = ''
+  openaiHasApiKey.value = false
+
+  customBaseUrl.value = DEFAULT.customBaseUrl
+  customBaseUrlPresets.value = []
+  customModel.value = DEFAULT.customModel
+  customLanguage.value = DEFAULT.customLanguage
+  customPrompt.value = DEFAULT.customPrompt
+  customApiKey.value = ''
+  customApiKeyPreview.value = ''
+  customHasApiKey.value = false
+}
+
+function resetLocalState() {
+  const nextDefault = defaultProvider()
+  provider.value = nextDefault
+  openaiModel.value = DEFAULT.openaiModel
+  openaiLanguage.value = DEFAULT.openaiLanguage
+  openaiPrompt.value = DEFAULT.openaiPrompt
+  customBaseUrl.value = DEFAULT.customBaseUrl
+  customBaseUrlPresets.value = []
+  customModel.value = DEFAULT.customModel
+  customLanguage.value = DEFAULT.customLanguage
+  customPrompt.value = DEFAULT.customPrompt
+}
+
+let serverSettingsLoaded = false
+let serverSettingsPromise: Promise<void> | null = null
+let serverSettingsGeneration = 0
+
+export function clearSttSettingsAuthState() {
+  serverSettingsGeneration += 1
+  serverSettingsLoaded = false
+  serverSettingsPromise = null
+  resetLocalState()
+  resetServerBackedState()
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('hermes-auth-cleared', clearSttSettingsAuthState)
+}
+
+watch(
+  [provider, openaiModel, openaiLanguage, openaiPrompt, customBaseUrl, customModel, customLanguage, customPrompt],
+  persist,
+)
+
+function normalizePresetList(values: unknown): string[] {
+  return Array.isArray(values)
+    ? Array.from(new Set(values.filter((value): value is string => typeof value === 'string' && Boolean(value.trim())).map(value => value.trim())))
+    : []
+}
+
+function applyServerRow(row: SttProviderSettingsResponse) {
+  if (row.provider === 'openai') {
+    openaiModel.value = typeof row.settings.model === 'string' && row.settings.model.trim()
+      ? row.settings.model
+      : openaiModel.value
+    openaiLanguage.value = typeof row.settings.language === 'string' ? row.settings.language : openaiLanguage.value
+    openaiPrompt.value = typeof row.settings.prompt === 'string' ? row.settings.prompt : openaiPrompt.value
+    openaiApiKeyPreview.value = row.secrets.apiKey || ''
+    openaiHasApiKey.value = Boolean(row.secrets.apiKey)
+    openaiApiKey.value = ''
+  }
+
+  if (row.provider === 'custom') {
+    customBaseUrl.value = typeof row.settings.baseUrl === 'string' ? row.settings.baseUrl : customBaseUrl.value
+    customBaseUrlPresets.value = normalizePresetList(row.settings.baseUrlPresets)
+    customModel.value = typeof row.settings.model === 'string' && row.settings.model.trim()
+      ? row.settings.model
+      : customModel.value
+    customLanguage.value = typeof row.settings.language === 'string' ? row.settings.language : customLanguage.value
+    customPrompt.value = typeof row.settings.prompt === 'string' ? row.settings.prompt : customPrompt.value
+    customApiKeyPreview.value = row.secrets.apiKey || ''
+    customHasApiKey.value = Boolean(row.secrets.apiKey)
+    customApiKey.value = ''
+  }
+}
+
+function applyServerSttSettings(response: FetchSttSettingsResponse | SttProviderSettingsResponse[], authoritative = false) {
+  if (authoritative) {
+    resetServerBackedState()
+  }
+  const rows = Array.isArray(response) ? response : response.providers
+  for (const row of rows) {
+    applyServerRow(row)
+  }
+  if (!Array.isArray(response) && response.activeProvider) {
+    provider.value = response.activeProvider
+  }
+}
+
+async function loadServerSttSettings(force = false): Promise<void> {
+  if (serverSettingsLoaded && !force) return
+  if (serverSettingsPromise && !force) return serverSettingsPromise
+
+  const generation = serverSettingsGeneration
+  const promise = fetchSttSettings()
+    .then(response => {
+      if (generation !== serverSettingsGeneration) return
+      applyServerSttSettings(response, true)
+      serverSettingsLoaded = true
+    })
+    .finally(() => {
+      if (serverSettingsPromise === promise) {
+        serverSettingsPromise = null
+      }
+    })
+
+  serverSettingsPromise = promise
+  return promise
+}
+
+export function useSttSettings() {
+  return {
+    provider,
+    openaiModel,
+    openaiLanguage,
+    openaiPrompt,
+    openaiApiKey,
+    openaiApiKeyPreview,
+    openaiHasApiKey,
+    customBaseUrl,
+    customBaseUrlPresets,
+    customModel,
+    customLanguage,
+    customPrompt,
+    customApiKey,
+    customApiKeyPreview,
+    customHasApiKey,
+
+    setProvider(value: SttProvider) { provider.value = value },
+    setOpenaiModel(value: string) { openaiModel.value = value },
+    setOpenaiLanguage(value: string) { openaiLanguage.value = value },
+    setOpenaiPrompt(value: string) { openaiPrompt.value = value },
+    setOpenaiApiKey(value: string) { openaiApiKey.value = value },
+    setCustomBaseUrl(value: string) { customBaseUrl.value = value },
+    setCustomBaseUrlPresets(values: string[]) { customBaseUrlPresets.value = normalizePresetList(values) },
+    setCustomModel(value: string) { customModel.value = value },
+    setCustomLanguage(value: string) { customLanguage.value = value },
+    setCustomPrompt(value: string) { customPrompt.value = value },
+    setCustomApiKey(value: string) { customApiKey.value = value },
+    applyServerSttSettings,
+    loadServerSttSettings,
+    reset() {
+      clearSttSettingsAuthState()
+    },
+  }
+}

--- a/packages/client/src/types/voice-api.ts
+++ b/packages/client/src/types/voice-api.ts
@@ -1,0 +1,47 @@
+import type { TtsProviderId } from '@/api/hermes/tts'
+import type { SttProvider } from '@/api/hermes/stt-settings'
+
+export type VoiceApiKind = 'tts' | 'stt'
+
+export type VoiceApiProvider = TtsProviderId | SttProvider
+export type VoiceApiProviderCompatibility = 'openai-compatible' | 'manual'
+
+export interface VoiceApiPreset {
+  id: string
+  kind: VoiceApiKind
+  provider: VoiceApiProvider
+  label: string
+  description?: string
+  baseUrl?: string
+  defaultModel?: string
+  isBuiltin?: boolean
+  isSecretRequired?: boolean
+  capabilities?: {
+    models?: boolean
+    voices?: boolean
+    rate?: boolean
+    pitch?: boolean
+    stylePrompt?: boolean
+    voiceDesign?: boolean
+    voiceClone?: boolean
+  }
+}
+
+export interface VoiceApiConnection {
+  id: string
+  kind: VoiceApiKind
+  provider: VoiceApiProvider
+  label: string
+  baseUrl?: string
+  model?: string
+  voice?: string
+  settings: Record<string, unknown>
+  hasSecret: boolean
+  isBuiltin?: boolean
+  active?: boolean
+}
+
+export interface VoiceApiSavePayload {
+  settings?: Record<string, unknown>
+  secrets?: Record<string, string>
+}

--- a/packages/server/src/controllers/hermes/stt.ts
+++ b/packages/server/src/controllers/hermes/stt.ts
@@ -1,0 +1,353 @@
+import type { Context } from 'koa'
+import {
+  assertActiveSttProvider,
+  assertStoredSttProvider,
+  clearStoredSttSecret,
+  getActiveSttProvider,
+  getSttProviderSetting,
+  listSttProviderSettings,
+  removeSttBaseUrlPreset,
+  saveActiveSttProvider,
+  saveSttProviderSetting,
+  SttSettingsValidationError,
+  type StoredSttProvider,
+} from '../../db/hermes/stt-settings-store'
+import { SttProviderConfigError, transcribeWithProvider } from '../../services/hermes/stt-providers'
+
+const MAX_STT_UPLOAD_SIZE = 50 * 1024 * 1024
+
+interface ParsedPart {
+  fieldName: string
+  filename: string | null
+  contentType: string | null
+  data: Buffer
+}
+
+interface ParsedMultipartBody {
+  fields: Record<string, string>
+  files: ParsedPart[]
+}
+
+class MultipartParseError extends Error {}
+
+function authUserId(ctx: Context): number | null {
+  const rawUserId = ctx.state.user?.id
+  const userId = typeof rawUserId === 'number' ? rawUserId : Number.NaN
+  if (!Number.isInteger(userId) || userId <= 0) {
+    ctx.status = 401
+    ctx.body = { error: 'Unauthorized' }
+    return null
+  }
+  return userId
+}
+
+function handleSettingsError(ctx: Context, error: unknown): boolean {
+  if (error instanceof SttSettingsValidationError) {
+    ctx.status = 400
+    ctx.body = { error: error.message }
+    return true
+  }
+  return false
+}
+
+function splitMultipart(raw: Buffer, boundary: Buffer): Buffer[] {
+  const parts: Buffer[] = []
+  let start = 0
+  while (true) {
+    const idx = raw.indexOf(boundary, start)
+    if (idx === -1) break
+    if (start > 0) {
+      parts.push(raw.subarray(start + 2, idx))
+    }
+    start = idx + boundary.length
+  }
+  return parts
+}
+
+function parseMultipartPart(part: Buffer): ParsedPart | null {
+  const headerEnd = part.indexOf(Buffer.from('\r\n\r\n'))
+  if (headerEnd === -1) return null
+
+  const header = part.subarray(0, headerEnd).toString('utf-8')
+  const data = part.subarray(headerEnd + 4, part.length - 2)
+  const disposition = header.match(/Content-Disposition:\s*form-data;([^\r\n]*)/i)?.[1]
+  if (!disposition) return null
+
+  const fieldName = disposition.match(/\bname="([^"]+)"/)?.[1]
+  if (!fieldName) return null
+
+  let filename: string | null = null
+  const encodedFilename = disposition.match(/filename\*=UTF-8''([^;]+)/i)?.[1]
+  if (encodedFilename) {
+    try {
+      filename = decodeURIComponent(encodedFilename.trim().replace(/^"|"$/g, ''))
+    } catch {
+      throw new MultipartParseError('Malformed multipart filename')
+    }
+  } else {
+    filename = disposition.match(/\bfilename="([^"]*)"/)?.[1] ?? null
+  }
+
+  const contentType = header.match(/Content-Type:\s*([^\r\n]+)/i)?.[1]?.trim() ?? null
+
+  return {
+    fieldName,
+    filename,
+    contentType,
+    data,
+  }
+}
+
+async function readMultipartBody(ctx: Context): Promise<ParsedMultipartBody | { error: string; status: number }> {
+  const contentType = ctx.get('content-type') || ''
+  if (!contentType.startsWith('multipart/form-data')) {
+    return { error: 'Expected multipart/form-data', status: 400 }
+  }
+
+  const boundaryStr = contentType.split('boundary=')[1]
+  if (!boundaryStr) {
+    return { error: 'Missing boundary', status: 400 }
+  }
+
+  const boundary = Buffer.from(`--${boundaryStr.split(';')[0].trim()}`)
+  const chunks: Buffer[] = []
+  let totalSize = 0
+
+  for await (const chunk of ctx.req) {
+    const bufferChunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    totalSize += bufferChunk.length
+    if (totalSize > MAX_STT_UPLOAD_SIZE) {
+      return { error: `Upload too large (max ${MAX_STT_UPLOAD_SIZE / 1024 / 1024}MB)`, status: 413 }
+    }
+    chunks.push(bufferChunk)
+  }
+
+  const fields: Record<string, string> = {}
+  const files: ParsedPart[] = []
+  const raw = Buffer.concat(chunks)
+
+  for (const part of splitMultipart(raw, boundary)) {
+    let parsed: ParsedPart | null
+    try {
+      parsed = parseMultipartPart(part)
+    } catch (error) {
+      if (error instanceof MultipartParseError) {
+        return { error: error.message, status: 400 }
+      }
+      throw error
+    }
+    if (!parsed) continue
+
+    if (parsed.filename !== null) {
+      files.push(parsed)
+      continue
+    }
+
+    fields[parsed.fieldName] = parsed.data.toString('utf-8').trim()
+  }
+
+  return { fields, files }
+}
+
+function findAudioPart(files: ParsedPart[]): ParsedPart | null {
+  return files.find(part => part.fieldName === 'audio') || null
+}
+
+function isAbortError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError'
+}
+
+function createRequestAbortController(ctx: Context): AbortController {
+  const controller = new AbortController()
+
+  const abort = () => {
+    if (!controller.signal.aborted) {
+      controller.abort()
+    }
+  }
+
+  if (ctx.req?.on) {
+    ctx.req.on('aborted', abort)
+  }
+
+  if (ctx.res?.on) {
+    ctx.res.on('close', () => {
+      if (!ctx.res.writableEnded) {
+        abort()
+      }
+    })
+  }
+
+  return controller
+}
+
+export async function listSettings(ctx: Context) {
+  const userId = authUserId(ctx)
+  if (!userId) return
+
+  try {
+    ctx.body = {
+      settings: listSttProviderSettings(userId),
+      activeProvider: getActiveSttProvider(userId),
+    }
+  } catch (error) {
+    if (handleSettingsError(ctx, error)) return
+    throw error
+  }
+}
+
+export async function saveSettings(ctx: Context) {
+  const userId = authUserId(ctx)
+  if (!userId) return
+
+  const provider = ctx.params.provider || ''
+  const body = ctx.request.body as {
+    settings?: unknown
+    secrets?: unknown
+    activeProvider?: unknown
+  } | undefined
+
+  try {
+    const storedProvider = assertStoredSttProvider(provider)
+    const setting = saveSttProviderSetting(userId, storedProvider, {
+      settings: body?.settings,
+      secrets: body?.secrets,
+    })
+    const activeProvider = body?.activeProvider === undefined
+      ? saveActiveSttProvider(userId, storedProvider)
+      : saveActiveSttProvider(userId, assertActiveSttProvider(String(body.activeProvider)))
+
+    ctx.body = { setting, activeProvider }
+  } catch (error) {
+    if (handleSettingsError(ctx, error)) return
+    throw error
+  }
+}
+
+export async function deleteBaseUrlPreset(ctx: Context) {
+  const userId = authUserId(ctx)
+  if (!userId) return
+
+  const provider = ctx.params.provider || ''
+  const rawUrl = typeof ctx.query.url === 'string' ? ctx.query.url : ''
+  if (!rawUrl.trim()) {
+    ctx.status = 400
+    ctx.body = { error: 'baseUrl is required' }
+    return
+  }
+
+  try {
+    const setting = removeSttBaseUrlPreset(userId, assertStoredSttProvider(provider), rawUrl)
+    ctx.body = { success: true, setting }
+  } catch (error) {
+    if (handleSettingsError(ctx, error)) return
+    throw error
+  }
+}
+
+export async function deleteSecret(ctx: Context) {
+  const userId = authUserId(ctx)
+  if (!userId) return
+
+  const provider = ctx.params.provider || ''
+  const secretName = ctx.params.secretName || ''
+
+  try {
+    const setting = clearStoredSttSecret(userId, assertStoredSttProvider(provider), secretName)
+    ctx.body = { success: true, setting }
+  } catch (error) {
+    if (handleSettingsError(ctx, error)) return
+    throw error
+  }
+}
+
+export async function saveActiveProvider(ctx: Context) {
+  const userId = authUserId(ctx)
+  if (!userId) return
+
+  const body = ctx.request.body as { provider?: unknown } | undefined
+
+  try {
+    const activeProvider = saveActiveSttProvider(userId, assertActiveSttProvider(String(body?.provider || '')))
+    ctx.body = { activeProvider }
+  } catch (error) {
+    if (handleSettingsError(ctx, error)) return
+    throw error
+  }
+}
+
+function resolveStoredProvider(fields: Record<string, string>): StoredSttProvider {
+  return assertStoredSttProvider(fields.provider || '')
+}
+
+export async function transcribe(ctx: Context) {
+  const userId = authUserId(ctx)
+  if (!userId) return
+
+  const parsed = await readMultipartBody(ctx)
+  if ('error' in parsed) {
+    ctx.status = parsed.status
+    ctx.body = { error: parsed.error }
+    return
+  }
+
+  let provider: StoredSttProvider
+  try {
+    provider = resolveStoredProvider(parsed.fields)
+  } catch (error) {
+    if (handleSettingsError(ctx, error)) return
+    throw error
+  }
+
+  const audio = findAudioPart(parsed.files)
+  if (!audio) {
+    ctx.status = 400
+    ctx.body = { error: 'audio is required' }
+    return
+  }
+
+  const storedSetting = getSttProviderSetting(userId, provider, { includeSecrets: true })
+  if (!storedSetting) {
+    ctx.status = 400
+    ctx.body = { error: `STT settings are required for provider ${provider}` }
+    return
+  }
+
+  if (!storedSetting.secrets.apiKey) {
+    ctx.status = 400
+    ctx.body = { error: `STT settings are incomplete for provider ${provider}` }
+    return
+  }
+
+  const controller = createRequestAbortController(ctx)
+
+  try {
+    const result = await transcribeWithProvider({
+      provider,
+      audio: audio.data,
+      fileName: audio.filename || 'audio',
+      mimeType: audio.contentType || 'application/octet-stream',
+      settings: storedSetting.settings,
+      secrets: storedSetting.secrets,
+      signal: controller.signal,
+    })
+
+    ctx.body = result
+  } catch (error) {
+    if (isAbortError(error)) {
+      ctx.status = 499
+      ctx.body = { error: 'STT request aborted' }
+      return
+    }
+
+    if (error instanceof SttProviderConfigError) {
+      ctx.status = 400
+      ctx.body = { error: error.message }
+      return
+    }
+
+    ctx.status = 502
+    const detail = error instanceof Error ? error.message : ''
+    ctx.body = { error: detail ? `STT transcription failed: ${detail}` : 'STT transcription failed' }
+  }
+}

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -172,6 +172,32 @@ export const DEVICES_INDEXES = {
   idx_devices_last_seen: 'CREATE INDEX IF NOT EXISTS idx_devices_last_seen ON devices(last_seen_at)',
 }
 
+export const STT_PROVIDER_SETTINGS_TABLE = 'stt_provider_settings'
+
+export const STT_PROVIDER_SETTINGS_SCHEMA: Record<string, string> = {
+  id: 'INTEGER PRIMARY KEY AUTOINCREMENT',
+  user_id: 'INTEGER NOT NULL',
+  provider: 'TEXT NOT NULL',
+  settings_json: `TEXT NOT NULL DEFAULT '{}'`,
+  secrets_json: `TEXT NOT NULL DEFAULT '{}'`,
+  created_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+  updated_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+}
+
+export const STT_PROVIDER_SETTINGS_INDEXES = {
+  idx_stt_provider_settings_user: 'CREATE INDEX IF NOT EXISTS idx_stt_provider_settings_user ON stt_provider_settings(user_id)',
+  idx_stt_provider_settings_user_provider: 'CREATE UNIQUE INDEX IF NOT EXISTS idx_stt_provider_settings_user_provider ON stt_provider_settings(user_id, provider)',
+}
+
+export const STT_USER_SETTINGS_TABLE = 'stt_user_settings'
+
+export const STT_USER_SETTINGS_SCHEMA: Record<string, string> = {
+  user_id: 'INTEGER PRIMARY KEY',
+  active_provider: "TEXT NOT NULL DEFAULT 'browser'",
+  created_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+  updated_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+}
+
 // ============================================================================
 // Group Chat (services/hermes/group-chat/index.ts)
 // ============================================================================
@@ -335,6 +361,54 @@ function addMissingSafeColumns(
   }
 }
 
+function createIndexes(
+  db: NonNullable<ReturnType<typeof getDb>>,
+  indexes?: Record<string, string>,
+): void {
+  if (!indexes) return
+
+  for (const indexSQL of Object.values(indexes)) {
+    db.exec(indexSQL)
+  }
+}
+
+function migrateLegacySttProviderSettingsUserIdDefault(
+  db: NonNullable<ReturnType<typeof getDb>>,
+): void {
+  if (!tableExists(db, STT_PROVIDER_SETTINGS_TABLE)) return
+
+  const columns = db.prepare(`PRAGMA table_info(${quoteIdentifier(STT_PROVIDER_SETTINGS_TABLE)})`).all() as Array<{
+    name: string
+    dflt_value: string | null
+  }>
+  const userIdColumn = columns.find((column) => column.name === 'user_id')
+
+  if (!userIdColumn || userIdColumn.dflt_value === null) {
+    return
+  }
+
+  const replacementTableName = `${STT_PROVIDER_SETTINGS_TABLE}__rebuilt`
+  const preservedColumns = ['id', 'user_id', 'provider', 'settings_json', 'secrets_json', 'created_at', 'updated_at']
+  const quotedPreservedColumns = preservedColumns.map((column) => quoteIdentifier(column)).join(', ')
+
+  db.exec('BEGIN')
+  try {
+    db.exec(`DROP TABLE IF EXISTS ${quoteIdentifier(replacementTableName)}`)
+    createTable(db, replacementTableName, STT_PROVIDER_SETTINGS_SCHEMA)
+    db.exec(
+      `INSERT INTO ${quoteIdentifier(replacementTableName)} (${quotedPreservedColumns}) ` +
+      `SELECT ${quotedPreservedColumns} FROM ${quoteIdentifier(STT_PROVIDER_SETTINGS_TABLE)}`
+    )
+    db.exec(`DROP TABLE ${quoteIdentifier(STT_PROVIDER_SETTINGS_TABLE)}`)
+    db.exec(`ALTER TABLE ${quoteIdentifier(replacementTableName)} RENAME TO ${quoteIdentifier(STT_PROVIDER_SETTINGS_TABLE)}`)
+    createIndexes(db, STT_PROVIDER_SETTINGS_INDEXES)
+    db.exec('COMMIT')
+  } catch (error) {
+    db.exec('ROLLBACK')
+    throw error
+  }
+}
+
 /**
  * 主同步函数
  * - 表不存在：创建
@@ -356,11 +430,7 @@ export function syncTable(
     createTable(db, tableName, schema, options?.primaryKey)
 
     // 创建索引
-    if (options?.indexes) {
-      for (const indexSQL of Object.values(options.indexes)) {
-        db.exec(indexSQL)
-      }
-    }
+    createIndexes(db, options?.indexes)
     return
   }
 
@@ -410,6 +480,11 @@ export function initAllHermesTables(): void {
     syncTable(DEVICES_TABLE, DEVICES_SCHEMA, {
       indexes: DEVICES_INDEXES,
     })
+    syncTable(STT_PROVIDER_SETTINGS_TABLE, STT_PROVIDER_SETTINGS_SCHEMA, {
+      indexes: STT_PROVIDER_SETTINGS_INDEXES,
+    })
+    syncTable(STT_USER_SETTINGS_TABLE, STT_USER_SETTINGS_SCHEMA)
+    migrateLegacySttProviderSettingsUserIdDefault(db)
 
     // Group chat - basic tables
     syncTable(GC_ROOMS_TABLE, GC_ROOMS_SCHEMA)

--- a/packages/server/src/db/hermes/stt-settings-store.ts
+++ b/packages/server/src/db/hermes/stt-settings-store.ts
@@ -1,0 +1,390 @@
+import { getDb } from '../index'
+import { STT_PROVIDER_SETTINGS_TABLE, STT_USER_SETTINGS_TABLE } from './schemas'
+import { normalizeSafeTtsBaseUrl } from '../../services/hermes/tts-providers/url-safety'
+
+export type StoredSttProvider = 'openai' | 'custom'
+export type ActiveSttProvider = 'browser' | StoredSttProvider
+
+const SETTINGS_KEYS = ['baseUrl', 'baseUrlPresets', 'model', 'language', 'prompt'] as const
+const SECRET_KEYS = ['apiKey'] as const
+
+type SttSettingKey = (typeof SETTINGS_KEYS)[number]
+type SttSecretKey = (typeof SECRET_KEYS)[number]
+
+export type SttStoredSettings = Partial<Record<Exclude<SttSettingKey, 'baseUrlPresets'>, string>> & { baseUrlPresets?: string[] }
+export type SttStoredSecrets = Partial<Record<SttSecretKey, string>>
+
+export interface StoredSttProviderRow {
+  userId: number
+  provider: StoredSttProvider
+  settings: SttStoredSettings
+  secrets: SttStoredSecrets
+  createdAt: number
+  updatedAt: number
+}
+
+export class SttSettingsValidationError extends Error {}
+
+const STORED_MARKER = '[stored]'
+const MAX_PROMPT_LENGTH = 1000
+const MAX_BASE_URL_PRESETS = 20
+const PROVIDERS: StoredSttProvider[] = ['openai', 'custom']
+const ACTIVE_PROVIDERS: ActiveSttProvider[] = ['browser', ...PROVIDERS]
+const PROVIDER_SQL_PLACEHOLDERS = PROVIDERS.map(() => '?').join(', ')
+const PROVIDER_LABELS: Record<StoredSttProvider, string> = {
+  openai: 'OpenAI STT',
+  custom: 'Custom STT',
+}
+type StoredRow = {
+  user_id: number
+  provider: string
+  settings_json: string
+  secrets_json: string
+  created_at: number
+  updated_at: number
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  return isPlainObject(value) ? value : {}
+}
+
+function parseJsonObject(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw)
+    return asObject(parsed)
+  } catch {
+    return {}
+  }
+}
+
+function requireDb() {
+  const db = getDb()
+  if (!db) {
+    throw new Error('STT settings storage unavailable')
+  }
+  return db
+}
+
+function normalizeUserId(userId: number): number {
+  if (!Number.isInteger(userId) || userId <= 0) {
+    throw new SttSettingsValidationError('invalid user id')
+  }
+  return userId
+}
+
+export function isStoredSttProvider(provider: string): provider is StoredSttProvider {
+  return PROVIDERS.includes(provider as StoredSttProvider)
+}
+
+export function isActiveSttProvider(provider: string): provider is ActiveSttProvider {
+  return ACTIVE_PROVIDERS.includes(provider as ActiveSttProvider)
+}
+
+export function assertStoredSttProvider(provider: string): StoredSttProvider {
+  if (!isStoredSttProvider(provider)) {
+    throw new SttSettingsValidationError('unknown STT provider')
+  }
+  return provider
+}
+
+export function assertActiveSttProvider(provider: string): ActiveSttProvider {
+  if (!isActiveSttProvider(provider)) {
+    throw new SttSettingsValidationError('unknown STT provider')
+  }
+  return provider
+}
+
+export function getActiveSttProvider(userId: number): ActiveSttProvider | null {
+  const id = normalizeUserId(userId)
+  const db = getDb()
+  if (!db) return null
+
+  const row = db.prepare(
+    `SELECT active_provider FROM ${STT_USER_SETTINGS_TABLE} WHERE user_id = ?`
+  ).get(id) as { active_provider?: string } | null
+
+  const activeProvider = row?.active_provider
+  return typeof activeProvider === 'string' && isActiveSttProvider(activeProvider) ? activeProvider : null
+}
+
+export function saveActiveSttProvider(userId: number, provider: ActiveSttProvider): ActiveSttProvider {
+  const id = normalizeUserId(userId)
+  const activeProvider = assertActiveSttProvider(provider)
+  const db = requireDb()
+  const now = Date.now()
+
+  db.prepare(
+    `INSERT INTO ${STT_USER_SETTINGS_TABLE} (user_id, active_provider, created_at, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(user_id) DO UPDATE SET
+       active_provider = excluded.active_provider,
+       updated_at = excluded.updated_at`
+  ).run(id, activeProvider, now, now)
+
+  return activeProvider
+}
+
+function assertKnownSecretName(secretName: string): SttSecretKey {
+  if (!SECRET_KEYS.includes(secretName as SttSecretKey)) {
+    throw new SttSettingsValidationError('unknown STT provider secret')
+  }
+  return secretName as SttSecretKey
+}
+
+function readStoredRow(userId: number, provider: StoredSttProvider): StoredRow | null {
+  const db = getDb()
+  if (!db) return null
+  return db.prepare(
+    `SELECT user_id, provider, settings_json, secrets_json, created_at, updated_at FROM ${STT_PROVIDER_SETTINGS_TABLE} WHERE user_id = ? AND provider = ?`
+  ).get(userId, provider) as StoredRow | null
+}
+
+function normalizeBaseUrlPresets(provider: StoredSttProvider, input: unknown): string[] {
+  const values = Array.isArray(input) ? input : []
+  const out: string[] = []
+  const seen = new Set<string>()
+
+  for (const rawValue of values) {
+    if (typeof rawValue !== 'string') continue
+    const value = rawValue.trim()
+    if (!value) continue
+
+    let normalized: string
+    try {
+      normalized = normalizeSafeTtsBaseUrl(value, PROVIDER_LABELS[provider])
+    } catch (error) {
+      throw new SttSettingsValidationError(error instanceof Error ? error.message : String(error))
+    }
+
+    if (seen.has(normalized)) continue
+    seen.add(normalized)
+    out.push(normalized)
+    if (out.length >= MAX_BASE_URL_PRESETS) break
+  }
+
+  return out
+}
+
+function appendBaseUrlPreset(provider: StoredSttProvider, settings: SttStoredSettings): SttStoredSettings {
+  if (!settings.baseUrl) return settings
+  const presets = normalizeBaseUrlPresets(provider, settings.baseUrlPresets || [])
+  if (!presets.includes(settings.baseUrl)) {
+    presets.unshift(settings.baseUrl)
+  }
+  return { ...settings, baseUrlPresets: presets.slice(0, MAX_BASE_URL_PRESETS) }
+}
+
+function sanitizeStoredSettings(provider: StoredSttProvider, input: Record<string, unknown>): SttStoredSettings {
+  const out: SttStoredSettings = {}
+
+  for (const key of SETTINGS_KEYS) {
+    const rawValue = input[key]
+
+    if (key === 'baseUrlPresets') {
+      const presets = normalizeBaseUrlPresets(provider, rawValue)
+      if (presets.length) out.baseUrlPresets = presets
+      continue
+    }
+
+    if (typeof rawValue !== 'string') continue
+    const value = rawValue.trim()
+    if (!value) continue
+
+    if (key === 'baseUrl') {
+      try {
+        out.baseUrl = normalizeSafeTtsBaseUrl(value, PROVIDER_LABELS[provider])
+      } catch (error) {
+        throw new SttSettingsValidationError(error instanceof Error ? error.message : String(error))
+      }
+      continue
+    }
+
+    if (key === 'prompt') {
+      out.prompt = value.slice(0, MAX_PROMPT_LENGTH)
+      continue
+    }
+
+    out[key] = value
+  }
+
+  return out
+}
+
+function sanitizeStoredSecrets(input: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {}
+
+  for (const key of Object.keys(input)) {
+    assertKnownSecretName(key)
+  }
+
+  const rawApiKey = input.apiKey
+  if (typeof rawApiKey !== 'string') {
+    return out
+  }
+
+  const apiKey = rawApiKey.trim()
+  if (!apiKey || apiKey === STORED_MARKER) {
+    return out
+  }
+
+  out.apiKey = apiKey
+  return out
+}
+
+function mergeStoredValues(current: SttStoredSettings, patch: SttStoredSettings): SttStoredSettings {
+  return { ...current, ...patch }
+}
+
+function maskSecrets(secrets: Record<string, string>): Record<string, string> {
+  const masked: Record<string, string> = {}
+  if (secrets.apiKey) {
+    masked.apiKey = STORED_MARKER
+  }
+  return masked
+}
+
+function rowToResult(row: StoredRow, includeSecrets: boolean): StoredSttProviderRow {
+  const provider = assertStoredSttProvider(row.provider)
+  const settings = sanitizeStoredSettings(provider, parseJsonObject(row.settings_json))
+  const secrets = sanitizeStoredSecrets(parseJsonObject(row.secrets_json))
+
+  return {
+    userId: Number(row.user_id),
+    provider,
+    settings,
+    secrets: includeSecrets ? secrets : maskSecrets(secrets),
+    createdAt: Number(row.created_at || 0),
+    updatedAt: Number(row.updated_at || 0),
+  }
+}
+
+export function listSttProviderSettings(userId: number): StoredSttProviderRow[] {
+  const id = normalizeUserId(userId)
+  const db = getDb()
+  if (!db) return []
+
+  const rows = db.prepare(
+    `SELECT user_id, provider, settings_json, secrets_json, created_at, updated_at
+     FROM ${STT_PROVIDER_SETTINGS_TABLE}
+     WHERE user_id = ? AND provider IN (${PROVIDER_SQL_PLACEHOLDERS})
+     ORDER BY provider ASC`
+  ).all(id, ...PROVIDERS) as StoredRow[]
+
+  return rows.map(row => rowToResult(row, false))
+}
+
+export function getSttProviderSetting(
+  userId: number,
+  provider: StoredSttProvider,
+  options?: { includeSecrets?: boolean },
+): StoredSttProviderRow | null {
+  const id = normalizeUserId(userId)
+  const storedProvider = assertStoredSttProvider(provider)
+  const row = readStoredRow(id, storedProvider)
+  return row ? rowToResult(row, options?.includeSecrets === true) : null
+}
+
+export function saveSttProviderSetting(
+  userId: number,
+  provider: StoredSttProvider,
+  input: {
+    settings?: unknown
+    secrets?: unknown
+  },
+): StoredSttProviderRow {
+  const id = normalizeUserId(userId)
+  const storedProvider = assertStoredSttProvider(provider)
+  const db = requireDb()
+  const existing = readStoredRow(id, storedProvider)
+  const existingSettings = existing ? sanitizeStoredSettings(storedProvider, parseJsonObject(existing.settings_json)) : {}
+  const existingSecrets = existing ? sanitizeStoredSecrets(parseJsonObject(existing.secrets_json)) : {}
+  const nextSettings = sanitizeStoredSettings(storedProvider, asObject(input.settings))
+  const nextSecretsObject = asObject(input.secrets)
+
+  for (const key of Object.keys(nextSecretsObject)) {
+    assertKnownSecretName(key)
+  }
+
+  const nextSecrets = sanitizeStoredSecrets(nextSecretsObject)
+  const mergedSettings = appendBaseUrlPreset(storedProvider, mergeStoredValues(existingSettings, nextSettings))
+  const mergedSecrets = mergeStoredValues(existingSecrets, nextSecrets)
+  const now = Date.now()
+
+  db.prepare(
+    `INSERT INTO ${STT_PROVIDER_SETTINGS_TABLE} (user_id, provider, settings_json, secrets_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(user_id, provider) DO UPDATE SET
+       settings_json = excluded.settings_json,
+       secrets_json = excluded.secrets_json,
+       updated_at = excluded.updated_at`
+  ).run(id, storedProvider, JSON.stringify(mergedSettings), JSON.stringify(mergedSecrets), existing?.created_at || now, now)
+
+  return getSttProviderSetting(id, storedProvider) as StoredSttProviderRow
+}
+
+export function removeSttBaseUrlPreset(
+  userId: number,
+  provider: StoredSttProvider,
+  url: string,
+): StoredSttProviderRow | null {
+  const id = normalizeUserId(userId)
+  const storedProvider = assertStoredSttProvider(provider)
+  const normalizedUrl = normalizeSafeTtsBaseUrl(url, PROVIDER_LABELS[storedProvider])
+  const db = requireDb()
+  const existing = readStoredRow(id, storedProvider)
+  if (!existing) {
+    return null
+  }
+
+  const settings = sanitizeStoredSettings(storedProvider, parseJsonObject(existing.settings_json))
+  const secrets = sanitizeStoredSecrets(parseJsonObject(existing.secrets_json))
+  const nextPresets = normalizeBaseUrlPresets(storedProvider, settings.baseUrlPresets || [])
+    .filter(preset => preset !== normalizedUrl)
+
+  if (settings.baseUrl === normalizedUrl) {
+    delete settings.baseUrl
+  }
+
+  if (nextPresets.length) {
+    settings.baseUrlPresets = nextPresets
+  } else {
+    delete settings.baseUrlPresets
+  }
+
+  const now = Date.now()
+  db.prepare(
+    `UPDATE ${STT_PROVIDER_SETTINGS_TABLE} SET settings_json = ?, secrets_json = ?, updated_at = ? WHERE user_id = ? AND provider = ?`
+  ).run(JSON.stringify(settings), JSON.stringify(secrets), now, id, storedProvider)
+
+  return getSttProviderSetting(id, storedProvider)
+}
+
+export function clearStoredSttSecret(
+  userId: number,
+  provider: StoredSttProvider,
+  secretName: string,
+): StoredSttProviderRow | null {
+  const id = normalizeUserId(userId)
+  const storedProvider = assertStoredSttProvider(provider)
+  const secretKey = assertKnownSecretName(secretName)
+  const db = requireDb()
+  const existing = readStoredRow(id, storedProvider)
+  if (!existing) {
+    return null
+  }
+
+  const settings = sanitizeStoredSettings(storedProvider, parseJsonObject(existing.settings_json))
+  const secrets = sanitizeStoredSecrets(parseJsonObject(existing.secrets_json))
+  delete secrets[secretKey]
+  const now = Date.now()
+
+  db.prepare(
+    `UPDATE ${STT_PROVIDER_SETTINGS_TABLE} SET settings_json = ?, secrets_json = ?, updated_at = ? WHERE user_id = ? AND provider = ?`
+  ).run(JSON.stringify(settings), JSON.stringify(secrets), now, id, storedProvider)
+
+  return getSttProviderSetting(id, storedProvider)
+}

--- a/packages/server/src/routes/hermes/stt.ts
+++ b/packages/server/src/routes/hermes/stt.ts
@@ -1,0 +1,11 @@
+import Router from '@koa/router'
+import * as ctrl from '../../controllers/hermes/stt'
+
+export const sttProtectedRoutes = new Router()
+
+sttProtectedRoutes.get('/api/hermes/stt/settings', ctrl.listSettings)
+sttProtectedRoutes.put('/api/hermes/stt/settings/active', ctrl.saveActiveProvider)
+sttProtectedRoutes.put('/api/hermes/stt/settings/:provider', ctrl.saveSettings)
+sttProtectedRoutes.delete('/api/hermes/stt/settings/:provider/base-url-preset', ctrl.deleteBaseUrlPreset)
+sttProtectedRoutes.delete('/api/hermes/stt/settings/:provider/secret/:secretName', ctrl.deleteSecret)
+sttProtectedRoutes.post('/api/hermes/stt/transcribe', ctrl.transcribe)

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -32,6 +32,7 @@ import { jobRoutes } from './hermes/jobs'
 import { cronHistoryRoutes } from './hermes/cron-history'
 import { kanbanRoutes } from './hermes/kanban'
 import { ttsRoutes, ttsProtectedRoutes } from './hermes/tts'
+import { sttProtectedRoutes } from './hermes/stt'
 import { mediaRoutes } from './hermes/media'
 import { proxyRoutes, proxyMiddleware } from './hermes/proxy'
 import { groupChatRoutes, setGroupChatServer } from './hermes/group-chat'
@@ -83,6 +84,7 @@ export function registerRoutes(app: any, authMiddleware: Array<(ctx: Context, ne
   app.use(cronHistoryRoutes.routes())        // Must be before proxy
   app.use(kanbanRoutes.routes())             // Must be before proxy
   app.use(ttsProtectedRoutes.routes())
+  app.use(sttProtectedRoutes.routes())
   app.use(mediaRoutes.routes())              // Must be before proxy
   app.use(performanceMonitorRoutes.routes())  // Must be before proxy
   app.use(mcpRoutes.routes())                   // MCP management

--- a/packages/server/src/services/hermes/stt-providers/index.ts
+++ b/packages/server/src/services/hermes/stt-providers/index.ts
@@ -1,0 +1,15 @@
+import { transcribeOpenAiCompatible } from './openai'
+import type { SttTranscribeInput, SttTranscribeResult } from './types'
+
+export * from './openai'
+export * from './types'
+
+export async function transcribeWithProvider(input: SttTranscribeInput): Promise<SttTranscribeResult> {
+  switch (input.provider) {
+    case 'openai':
+    case 'custom':
+      return transcribeOpenAiCompatible(input)
+    default:
+      throw new Error(`Unsupported STT provider: ${String(input.provider)}`)
+  }
+}

--- a/packages/server/src/services/hermes/stt-providers/openai.ts
+++ b/packages/server/src/services/hermes/stt-providers/openai.ts
@@ -1,0 +1,124 @@
+import type { StoredSttProvider } from '../../../db/hermes/stt-settings-store'
+import { assertSafeResolvedTtsBaseUrl, normalizeSafeTtsBaseUrl } from '../tts-providers/url-safety'
+import type { SttTranscribeInput, SttTranscribeResult } from './types'
+
+export class SttProviderConfigError extends Error {}
+
+export const DEFAULT_OPENAI_STT_URL = 'https://api.openai.com/v1/audio/transcriptions'
+export const DEFAULT_MODEL = 'gpt-4o-transcribe'
+
+const MAX_ERROR_DETAIL_LENGTH = 200
+const MAX_PROMPT_LENGTH = 1000
+
+function getProviderLabel(provider: StoredSttProvider): string {
+  return provider === 'custom' ? 'Custom STT' : 'OpenAI STT'
+}
+
+function buildTranscriptionsUrl(baseUrl: string, providerLabel: string): string {
+  const normalizedBaseUrl = normalizeSafeTtsBaseUrl(baseUrl, providerLabel)
+  const url = new URL(normalizedBaseUrl)
+  const search = url.search
+  url.hash = ''
+
+  const pathname = url.pathname.replace(/\/+$/, '')
+
+  if (!pathname || pathname === '/') {
+    return `${url.origin}/audio/transcriptions${search}`
+  }
+
+  if (pathname.endsWith('/audio/transcriptions')) {
+    return `${url.origin}${pathname}${search}`
+  }
+
+  return `${url.origin}${pathname}/audio/transcriptions${search}`
+}
+
+function resolveBaseUrl(input: SttTranscribeInput): string {
+  if (input.provider === 'custom') {
+    const baseUrl = String(input.settings.baseUrl || '').trim()
+    if (!baseUrl) {
+      throw new SttProviderConfigError('Custom STT baseUrl is required')
+    }
+    return buildTranscriptionsUrl(baseUrl, getProviderLabel(input.provider))
+  }
+
+  return DEFAULT_OPENAI_STT_URL
+}
+
+function requireApiKey(input: SttTranscribeInput): string {
+  const apiKey = String(input.secrets.apiKey || '').trim()
+  if (!apiKey) {
+    throw new SttProviderConfigError('OpenAI-compatible STT API key is required')
+  }
+  return apiKey
+}
+
+function trimOptional(value: string | undefined): string | undefined {
+  const trimmed = String(value || '').trim()
+  return trimmed || undefined
+}
+
+function sanitizeDetail(detail: string, apiKey: string): string {
+  const normalized = String(detail || '').replace(/\s+/g, ' ').trim()
+  if (!normalized) {
+    return ''
+  }
+
+  return normalized.replaceAll(apiKey, '[redacted]').slice(0, MAX_ERROR_DETAIL_LENGTH)
+}
+
+export async function transcribeOpenAiCompatible(input: SttTranscribeInput): Promise<SttTranscribeResult> {
+  const startedAt = Date.now()
+  const apiKey = requireApiKey(input)
+
+  if (!Buffer.isBuffer(input.audio) || input.audio.length === 0) {
+    throw new Error('OpenAI-compatible STT audio is empty')
+  }
+
+  const baseUrl = resolveBaseUrl(input)
+  const model = trimOptional(input.settings.model) || DEFAULT_MODEL
+  const language = trimOptional(input.settings.language)
+  const prompt = trimOptional(input.settings.prompt)?.slice(0, MAX_PROMPT_LENGTH)
+
+  await assertSafeResolvedTtsBaseUrl(new URL(baseUrl), getProviderLabel(input.provider))
+
+  const form = new FormData()
+  const audioBytes = Uint8Array.from(input.audio)
+  form.append('file', new Blob([audioBytes], { type: trimOptional(input.mimeType) || 'application/octet-stream' }), trimOptional(input.fileName) || 'audio')
+  form.append('model', model)
+  if (language) {
+    form.append('language', language)
+  }
+  if (prompt) {
+    form.append('prompt', prompt)
+  }
+
+  const response = await fetch(baseUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: form,
+    redirect: 'manual',
+    signal: input.signal,
+  })
+
+  if (!response.ok) {
+    const detail = sanitizeDetail(await response.text().catch(() => response.statusText || ''), apiKey)
+    throw new Error(`OpenAI-compatible STT returned HTTP ${response.status}${detail ? `: ${detail}` : ''}`)
+  }
+
+  const payload = await response.json() as { text?: unknown }
+  const text = typeof payload.text === 'string' ? payload.text.trim() : ''
+  if (!text) {
+    throw new Error('OpenAI-compatible STT response text is empty')
+  }
+
+  return {
+    text,
+    provider: input.provider,
+    model,
+    language,
+    durationMs: Date.now() - startedAt,
+  }
+}

--- a/packages/server/src/services/hermes/stt-providers/types.ts
+++ b/packages/server/src/services/hermes/stt-providers/types.ts
@@ -1,0 +1,23 @@
+import type {
+  StoredSttProvider,
+  SttStoredSecrets,
+  SttStoredSettings,
+} from '../../../db/hermes/stt-settings-store'
+
+export interface SttTranscribeInput {
+  provider: StoredSttProvider
+  audio: Buffer
+  fileName: string
+  mimeType: string
+  settings: SttStoredSettings
+  secrets: SttStoredSecrets
+  signal?: AbortSignal
+}
+
+export interface SttTranscribeResult {
+  text: string
+  provider: StoredSttProvider
+  model: string
+  language?: string
+  durationMs: number
+}

--- a/packages/server/src/services/hermes/tts-providers/url-safety.ts
+++ b/packages/server/src/services/hermes/tts-providers/url-safety.ts
@@ -1,4 +1,16 @@
+import { lookup as dnsLookup } from 'node:dns/promises'
 import { isIP } from 'node:net'
+
+type DnsLookup = typeof dnsLookup
+let resolveHostname: DnsLookup = dnsLookup
+
+export function setTtsDnsLookupForTests(lookup: DnsLookup) {
+  resolveHostname = lookup
+}
+
+export function resetTtsDnsLookupForTests() {
+  resolveHostname = dnsLookup
+}
 
 function normalizeHostname(hostname: string): string {
   return hostname.trim().toLowerCase().replace(/^\[|\]$/g, '')
@@ -41,9 +53,13 @@ function isBlockedIpv6(hostname: string): boolean {
     return isBlockedIpv4(mappedIpv4)
   }
 
+  const firstHextet = normalized.split(':', 1)[0]
+  const firstHextetValue = firstHextet ? Number.parseInt(firstHextet, 16) : Number.NaN
+  const isLinkLocal = Number.isInteger(firstHextetValue) && (firstHextetValue & 0xffc0) === 0xfe80
+
   return normalized === '::'
     || normalized === '::1'
-    || normalized.startsWith('fe80:')
+    || isLinkLocal
     || normalized.startsWith('fc')
     || normalized.startsWith('fd')
     || normalized.startsWith('ff')
@@ -70,4 +86,32 @@ export function assertSafeTtsBaseUrl(url: URL, providerLabel: string) {
   if (isBlockedHostname(url.hostname) || isBlockedIp(url.hostname)) {
     throw new Error(`${providerLabel} TTS baseUrl cannot target localhost or private network addresses`)
   }
+}
+
+export async function assertSafeResolvedTtsBaseUrl(url: URL, providerLabel: string) {
+  assertSafeTtsBaseUrl(url, providerLabel)
+
+  if (isIP(normalizeHostname(url.hostname))) {
+    return
+  }
+
+  const records = await resolveHostname(url.hostname, { all: true, verbatim: true })
+  if (!records.length) {
+    throw new Error(`${providerLabel} TTS baseUrl hostname did not resolve`)
+  }
+
+  if (records.some(record => isBlockedIp(record.address))) {
+    throw new Error(`${providerLabel} TTS baseUrl resolved to localhost or private network addresses`)
+  }
+}
+
+export function normalizeSafeTtsBaseUrl(baseUrl: string, providerLabel: string): string {
+  const value = String(baseUrl || '').trim()
+  if (!value) {
+    return ''
+  }
+
+  const url = new URL(value)
+  assertSafeTtsBaseUrl(url, providerLabel)
+  return url.toString()
 }

--- a/tests/client/stt-settings-api.test.ts
+++ b/tests/client/stt-settings-api.test.ts
@@ -1,0 +1,379 @@
+// @vitest-environment jsdom
+import { nextTick } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/router', () => ({
+  default: {
+    currentRoute: { value: { name: 'hermes.chat' } },
+    replace: vi.fn(),
+  },
+}))
+
+import router from '@/router'
+import { hasApiKey } from '../../packages/client/src/api/client'
+import { clearSttSecret, deleteSttBaseUrlPreset, fetchSttSettings, saveActiveSttProvider, saveSttSettings } from '../../packages/client/src/api/hermes/stt-settings'
+import { transcribeSpeech } from '../../packages/client/src/api/hermes/stt'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function getHeader(headers: RequestInit['headers'] | undefined, name: string): string | undefined {
+  if (!headers) return undefined
+  if (headers instanceof Headers) return headers.get(name) ?? undefined
+  if (Array.isArray(headers)) {
+    const match = headers.find(([key]) => key.toLowerCase() === name.toLowerCase())
+    return match?.[1]
+  }
+
+  const match = Object.entries(headers).find(([key]) => key.toLowerCase() === name.toLowerCase())
+  return typeof match?.[1] === 'string' ? match[1] : undefined
+}
+
+describe('stt api wrappers', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    vi.clearAllMocks()
+    localStorage.clear()
+    localStorage.setItem('hermes_server_url', 'https://hermes.example')
+    localStorage.setItem('hermes_api_key', 'jwt-token')
+  })
+
+  it('fetches provider settings through the shared client request flow and normalizes settings arrays to providers', async () => {
+    localStorage.setItem('hermes_active_profile_name', 'research')
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        activeProvider: 'custom',
+        settings: [
+          {
+            provider: 'openai',
+            settings: { model: 'gpt-4o-transcribe', language: 'en' },
+            secrets: { apiKey: '[stored]' },
+            updatedAt: 1,
+          },
+        ],
+      }),
+    })
+
+    const result = await fetchSttSettings()
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://hermes.example/api/hermes/stt/settings',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer jwt-token',
+          'Content-Type': 'application/json',
+          'X-Hermes-Profile': 'research',
+        }),
+      }),
+    )
+    expect(result).toEqual({
+      activeProvider: 'custom',
+      providers: [
+        {
+          provider: 'openai',
+          settings: { model: 'gpt-4o-transcribe', language: 'en' },
+          secrets: { apiKey: '[stored]' },
+          updatedAt: 1,
+        },
+      ],
+    })
+  })
+
+  it('uses shared 401 handling for settings requests', async () => {
+    localStorage.setItem('hermes_active_profile_name', 'research')
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve(''),
+    })
+
+    await expect(fetchSttSettings()).rejects.toThrow('Unauthorized')
+
+    expect(hasApiKey()).toBe(false)
+    expect(router.replace).toHaveBeenCalledWith({ name: 'login' })
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://hermes.example/api/hermes/stt/settings',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer jwt-token',
+          'X-Hermes-Profile': 'research',
+        }),
+      }),
+    )
+  })
+
+  it('saves the active STT provider without a provider settings row', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ activeProvider: 'browser' }),
+    })
+
+    const result = await saveActiveSttProvider('browser')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://hermes.example/api/hermes/stt/settings/active',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer jwt-token',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({ provider: 'browser' }),
+      }),
+    )
+    expect(result).toBe('browser')
+  })
+
+  it('saves masked stt settings and unwraps the response setting', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        setting: {
+          provider: 'openai',
+          settings: { model: 'gpt-4o-transcribe' },
+          secrets: { apiKey: '[stored]' },
+          updatedAt: 2,
+        },
+      }),
+    })
+
+    const result = await saveSttSettings('openai', {
+      settings: { model: 'gpt-4o-transcribe' },
+      secrets: { apiKey: 'new-secret' },
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://hermes.example/api/hermes/stt/settings/openai',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer jwt-token',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({
+          settings: { model: 'gpt-4o-transcribe' },
+          secrets: { apiKey: 'new-secret' },
+        }),
+      }),
+    )
+    expect(result).toEqual({
+      provider: 'openai',
+      settings: { model: 'gpt-4o-transcribe' },
+      secrets: { apiKey: '[stored]' },
+      updatedAt: 2,
+    })
+  })
+
+  it('clears stored api keys via the delete secret endpoint', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        success: true,
+        setting: {
+          provider: 'openai',
+          settings: { model: 'gpt-4o-transcribe' },
+          secrets: {},
+          updatedAt: 3,
+        },
+      }),
+    })
+
+    const result = await clearSttSecret('openai', 'apiKey')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://hermes.example/api/hermes/stt/settings/openai/secret/apiKey',
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer jwt-token',
+        }),
+      }),
+    )
+    expect(result).toEqual({
+      provider: 'openai',
+      settings: { model: 'gpt-4o-transcribe' },
+      secrets: {},
+      updatedAt: 3,
+    })
+  })
+
+  it('deletes saved base URL presets via the provider preset endpoint', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        success: true,
+        setting: {
+          provider: 'custom',
+          settings: {
+            baseUrl: 'https://stt.example.test/openai/v1',
+            baseUrlPresets: ['https://stt.example.test/openai/v1'],
+            model: 'whisper-large-v3-turbo',
+          },
+          secrets: { apiKey: '[stored]' },
+          updatedAt: 4,
+        },
+      }),
+    })
+
+    const result = await deleteSttBaseUrlPreset('custom', 'https://api.groq.com/openai/v1')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://hermes.example/api/hermes/stt/settings/custom/base-url-preset?url=https%3A%2F%2Fapi.groq.com%2Fopenai%2Fv1',
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer jwt-token',
+        }),
+      }),
+    )
+    expect(result).toEqual({
+      provider: 'custom',
+      settings: {
+        baseUrl: 'https://stt.example.test/openai/v1',
+        baseUrlPresets: ['https://stt.example.test/openai/v1'],
+        model: 'whisper-large-v3-turbo',
+      },
+      secrets: { apiKey: '[stored]' },
+      updatedAt: 4,
+    })
+  })
+
+  it('rejects transcription requests without a provider', async () => {
+    await expect(transcribeSpeech({
+      audio: new Blob(['audio'], { type: 'audio/webm' }),
+    } as any)).rejects.toThrow('STT provider is required')
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('sends multipart transcription requests without serializing api keys or forcing JSON content type', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        text: 'transcribed text',
+        provider: 'openai',
+        model: 'gpt-4o-transcribe',
+        language: 'en',
+        durationMs: 42,
+      }),
+    })
+
+    const result = await transcribeSpeech({
+      audio: new Blob(['audio'], { type: 'audio/webm' }),
+      provider: 'openai',
+      language: 'en',
+      prompt: 'keep punctuation',
+      baseUrl: 'http://127.0.0.1:8000/v1/audio/transcriptions',
+      apiKey: 'attacker-secret',
+      secrets: { apiKey: 'body-secret' },
+      headers: {
+        Authorization: 'Bearer attacker-secret',
+        'X-Api-Key': 'body-secret',
+      },
+    } as any)
+
+    expect(result).toEqual({
+      text: 'transcribed text',
+      provider: 'openai',
+      model: 'gpt-4o-transcribe',
+      language: 'en',
+      durationMs: 42,
+    })
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://hermes.example/api/hermes/stt/transcribe')
+    expect(init.method).toBe('POST')
+    expect(getHeader(init.headers, 'Authorization')).toBe('Bearer jwt-token')
+    expect(getHeader(init.headers, 'Content-Type')).toBeUndefined()
+    expect(init.body).toBeInstanceOf(FormData)
+
+    const form = init.body as FormData
+    expect(form.get('provider')).toBe('openai')
+    expect(form.get('language')).toBe('en')
+    expect(form.get('prompt')).toBe('keep punctuation')
+    expect(form.get('baseUrl')).toBeNull()
+    expect(form.get('apiKey')).toBeNull()
+    expect(form.get('secrets')).toBeNull()
+    expect(form.get('headers')).toBeNull()
+
+    const keys = Array.from(form.keys())
+    expect(keys).toEqual(expect.arrayContaining(['audio', 'provider', 'language', 'prompt']))
+    expect(keys).not.toContain('baseUrl')
+    expect(keys).not.toContain('apiKey')
+    expect(keys).not.toContain('secrets')
+    expect(keys).not.toContain('headers')
+
+    const upload = form.get('audio')
+    expect(upload).toBeInstanceOf(File)
+    expect((upload as File).name).toBe('speech.webm')
+    expect((upload as File).type).toBe('audio/webm')
+
+    const serialized = JSON.stringify(Array.from(form.entries()).map(([key, value]) => [
+      key,
+      typeof value === 'string'
+        ? value
+        : { name: value.name, type: value.type },
+    ]))
+    expect(serialized).not.toContain('attacker-secret')
+    expect(serialized).not.toContain('body-secret')
+    expect(serialized).not.toContain('127.0.0.1:8000')
+  })
+
+  it('does not persist raw STT API keys to localStorage when composable state changes', async () => {
+    const { clearSttSettingsAuthState, useSttSettings } = await import('../../packages/client/src/composables/useSttSettings')
+
+    clearSttSettingsAuthState()
+    const settings = useSttSettings()
+
+    settings.setOpenaiApiKey('openai-secret-sentinel')
+    settings.setCustomApiKey('custom-secret-sentinel')
+    settings.setOpenaiPrompt('transcribe carefully')
+    settings.setCustomBaseUrl('https://transcribe.example.com/v1')
+    await nextTick()
+
+    const raw = localStorage.getItem('hermes-stt-settings-v1') || '{}'
+    expect(raw).toContain('transcribe carefully')
+    expect(raw).toContain('https://transcribe.example.com/v1')
+    expect(raw).not.toContain('openai-secret-sentinel')
+    expect(raw).not.toContain('custom-secret-sentinel')
+  })
+
+  it('uses shared 401 handling for transcription requests', async () => {
+    localStorage.setItem('hermes_active_profile_name', 'research')
+    const listener = vi.fn()
+    window.addEventListener('hermes-auth-notice', listener)
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve(''),
+    })
+
+    await expect(transcribeSpeech({
+      audio: new Blob(['audio'], { type: 'audio/webm' }),
+      provider: 'openai',
+    })).rejects.toThrow('Unauthorized')
+
+    expect(hasApiKey()).toBe(false)
+    expect(router.replace).toHaveBeenCalledWith({ name: 'login' })
+    expect(listener).toHaveBeenCalledOnce()
+    expect(listener.mock.calls[0][0].detail).toEqual({ kind: 'expired' })
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://hermes.example/api/hermes/stt/transcribe',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer jwt-token',
+          'X-Hermes-Profile': 'research',
+        }),
+      }),
+    )
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(getHeader(init.headers, 'Content-Type')).toBeUndefined()
+    expect(init.body).toBeInstanceOf(FormData)
+    window.removeEventListener('hermes-auth-notice', listener)
+  })
+})

--- a/tests/server/openai-stt-provider.test.ts
+++ b/tests/server/openai-stt-provider.test.ts
@@ -1,0 +1,349 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { transcribeWithProvider } from '../../packages/server/src/services/hermes/stt-providers'
+import { transcribeOpenAiCompatible } from '../../packages/server/src/services/hermes/stt-providers/openai'
+import { setTtsDnsLookupForTests } from '../../packages/server/src/services/hermes/tts-providers/url-safety'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(body: unknown, init: { status?: number; statusText?: string } = {}) {
+  return {
+    ok: (init.status ?? 200) >= 200 && (init.status ?? 200) < 300,
+    status: init.status ?? 200,
+    statusText: init.statusText ?? 'OK',
+    async json() {
+      return body
+    },
+    async text() {
+      return JSON.stringify(body)
+    },
+  }
+}
+
+function textResponse(body: string, init: { status?: number; statusText?: string } = {}) {
+  return {
+    ok: (init.status ?? 500) >= 200 && (init.status ?? 500) < 300,
+    status: init.status ?? 500,
+    statusText: init.statusText ?? 'Error',
+    async json() {
+      return { error: body }
+    },
+    async text() {
+      return body
+    },
+  }
+}
+
+function getHeader(headers: RequestInit['headers'] | undefined, name: string): string | undefined {
+  if (!headers) return undefined
+  if (headers instanceof Headers) return headers.get(name) ?? undefined
+  if (Array.isArray(headers)) {
+    const match = headers.find(([key]) => key.toLowerCase() === name.toLowerCase())
+    return match?.[1]
+  }
+
+  const entries = Object.entries(headers)
+  const match = entries.find(([key]) => key.toLowerCase() === name.toLowerCase())
+  return typeof match?.[1] === 'string' ? match[1] : undefined
+}
+
+function getRequestInit(): RequestInit {
+  const [, init] = mockFetch.mock.calls[0] as [string | URL, RequestInit]
+  return init
+}
+
+function getRequestUrl(): string {
+  const [url] = mockFetch.mock.calls[0] as [string | URL, RequestInit]
+  return typeof url === 'string' ? url : url.toString()
+}
+
+function getFormData(): FormData {
+  const init = getRequestInit()
+  expect(init.body).toBeInstanceOf(FormData)
+  return init.body as FormData
+}
+
+describe('transcribeOpenAiCompatible', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    setTtsDnsLookupForTests(vi.fn(async () => [{ address: '93.184.216.34', family: 4 }]) as any)
+  })
+
+  it('posts multipart audio using server-side API key', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ text: 'hello from voice' }))
+
+    const result = await transcribeOpenAiCompatible({
+      provider: 'openai',
+      audio: Buffer.from('audio'),
+      fileName: 'speech.webm',
+      mimeType: 'audio/webm',
+      settings: {
+        model: 'gpt-4o-transcribe',
+      },
+      secrets: {
+        apiKey: 'server-secret',
+      },
+    })
+
+    expect(result.text).toBe('hello from voice')
+    expect(result.provider).toBe('openai')
+    expect(result.model).toBe('gpt-4o-transcribe')
+    expect(result.language).toBeUndefined()
+    expect(result.durationMs).toEqual(expect.any(Number))
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(getRequestUrl()).toBe('https://api.openai.com/v1/audio/transcriptions')
+
+    const init = getRequestInit()
+    expect(init.method).toBe('POST')
+    expect(init.redirect).toBe('manual')
+    expect(getHeader(init.headers, 'Authorization')).toBe('Bearer server-secret')
+
+    const form = getFormData()
+    expect(form.get('model')).toBe('gpt-4o-transcribe')
+    expect(form.get('language')).toBeNull()
+    expect(form.get('prompt')).toBeNull()
+
+    const file = form.get('file') as File
+    expect(file).toBeTruthy()
+    expect(file.name).toBe('speech.webm')
+    expect(file.type).toBe('audio/webm')
+    expect(Buffer.from(await file.arrayBuffer())).toEqual(Buffer.from('audio'))
+  })
+
+  it('rejects missing API key', async () => {
+    await expect(
+      transcribeOpenAiCompatible({
+        provider: 'openai',
+        audio: Buffer.from('audio'),
+        fileName: 'speech.webm',
+        mimeType: 'audio/webm',
+        settings: {
+          model: 'gpt-4o-transcribe',
+        },
+        secrets: {
+          apiKey: '   ',
+        },
+      }),
+    ).rejects.toThrow('OpenAI-compatible STT API key is required')
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects empty audio before fetch', async () => {
+    await expect(
+      transcribeOpenAiCompatible({
+        provider: 'openai',
+        audio: Buffer.alloc(0),
+        fileName: 'speech.webm',
+        mimeType: 'audio/webm',
+        settings: {
+          model: 'gpt-4o-transcribe',
+        },
+        secrets: {
+          apiKey: 'server-secret',
+        },
+      }),
+    ).rejects.toThrow('OpenAI-compatible STT audio is empty')
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('throws HTTP errors with status but does not leak the raw secret', async () => {
+    mockFetch.mockResolvedValueOnce(textResponse('upstream rejected bearer server-secret', { status: 401, statusText: 'Unauthorized' }))
+
+    const error = await transcribeOpenAiCompatible({
+      provider: 'openai',
+      audio: Buffer.from('audio'),
+      fileName: 'speech.webm',
+      mimeType: 'audio/webm',
+      settings: {
+        model: 'gpt-4o-transcribe',
+      },
+      secrets: {
+        apiKey: 'server-secret',
+      },
+    }).catch(error => error)
+
+    expect(String(error)).toContain('401')
+    expect(String(error)).not.toContain('server-secret')
+  })
+
+  it('rejects successful JSON responses that omit text', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ text: '   ' }))
+
+    await expect(
+      transcribeOpenAiCompatible({
+        provider: 'openai',
+        audio: Buffer.from('audio'),
+        fileName: 'speech.webm',
+        mimeType: 'audio/webm',
+        settings: {
+          model: 'gpt-4o-transcribe',
+        },
+        secrets: {
+          apiKey: 'server-secret',
+        },
+      }),
+    ).rejects.toThrow('OpenAI-compatible STT response text is empty')
+  })
+
+  it('custom provider derives the transcription endpoint from a base URL root', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ text: 'custom transcript' }))
+
+    const result = await transcribeWithProvider({
+      provider: 'custom',
+      audio: Buffer.from('audio'),
+      fileName: 'speech.webm',
+      mimeType: 'audio/webm',
+      settings: {
+        baseUrl: 'https://custom.example.com/v1',
+        model: 'whisper-1',
+        language: 'fr',
+        prompt: '  Summarize the French speech.  ',
+      },
+      secrets: {
+        apiKey: 'server-secret',
+      },
+    })
+
+    expect(result).toMatchObject({
+      text: 'custom transcript',
+      provider: 'custom',
+      model: 'whisper-1',
+      language: 'fr',
+    })
+    expect(getRequestUrl()).toBe('https://custom.example.com/v1/audio/transcriptions')
+    expect(getHeader(getRequestInit().headers, 'Authorization')).toBe('Bearer server-secret')
+
+    const form = getFormData()
+    expect(form.get('language')).toBe('fr')
+    expect(form.get('prompt')).toBe('Summarize the French speech.')
+  })
+
+  it('custom provider does not append a duplicate transcription path', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ text: 'custom transcript' }))
+
+    await transcribeWithProvider({
+      provider: 'custom',
+      audio: Buffer.from('audio'),
+      fileName: 'speech.webm',
+      mimeType: 'audio/webm',
+      settings: {
+        baseUrl: 'https://custom.example.com/v1/audio/transcriptions',
+        model: 'whisper-1',
+      },
+      secrets: {
+        apiKey: 'server-secret',
+      },
+    })
+
+    expect(getRequestUrl()).toBe('https://custom.example.com/v1/audio/transcriptions')
+  })
+
+  it.each([
+    'http://10.0.0.1:8000/v1/audio/transcriptions',
+    'http://172.16.0.1:8000/v1/audio/transcriptions',
+    'http://192.168.1.1:8000/v1/audio/transcriptions',
+    'http://169.254.169.254/latest/meta-data',
+    'http://[::1]:8000/v1/audio/transcriptions',
+    'http://[fd00::1]:8000/v1/audio/transcriptions',
+    'http://[fe90::1]:8000/v1/audio/transcriptions',
+  ])('rejects unsafe custom baseUrl %s before fetch', async (baseUrl) => {
+    await expect(
+      transcribeWithProvider({
+        provider: 'custom',
+        audio: Buffer.from('audio'),
+        fileName: 'speech.webm',
+        mimeType: 'audio/webm',
+        settings: {
+          baseUrl,
+          model: 'whisper-1',
+        },
+        secrets: {
+          apiKey: 'server-secret',
+        },
+      }),
+    ).rejects.toThrow(/Custom STT TTS baseUrl/)
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { records: [{ address: '10.0.0.4', family: 4 }] },
+    { records: [{ address: 'fd00::1', family: 6 }] },
+  ])('rejects DNS results that resolve to private network addresses before fetch: %j', async ({ records }) => {
+    setTtsDnsLookupForTests(vi.fn(async () => records) as any)
+
+    await expect(
+      transcribeWithProvider({
+        provider: 'custom',
+        audio: Buffer.from('audio'),
+        fileName: 'speech.webm',
+        mimeType: 'audio/webm',
+        settings: {
+          baseUrl: 'https://api.example.com/v1',
+          model: 'whisper-1',
+        },
+        secrets: {
+          apiKey: 'server-secret',
+        },
+      }),
+    ).rejects.toThrow('Custom STT TTS baseUrl resolved to localhost or private network addresses')
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('does not follow redirects to unsafe targets when fetch returns 302', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 302,
+      statusText: 'Found',
+      headers: {
+        get(name: string) {
+          return name.toLowerCase() === 'location' ? 'http://127.0.0.1:8000/internal' : null
+        },
+      },
+      async json() {
+        return {}
+      },
+      async text() {
+        return ''
+      },
+    })
+
+    const error = await transcribeOpenAiCompatible({
+      provider: 'openai',
+      audio: Buffer.from('audio'),
+      fileName: 'speech.webm',
+      mimeType: 'audio/webm',
+      settings: {
+        model: 'gpt-4o-transcribe',
+      },
+      secrets: {
+        apiKey: 'server-secret',
+      },
+    }).catch(error => error)
+
+    expect(String(error)).toContain('OpenAI-compatible STT returned HTTP 302')
+    expect(String(error)).not.toContain('127.0.0.1')
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(getRequestUrl()).toBe('https://api.openai.com/v1/audio/transcriptions')
+    expect(getRequestInit().redirect).toBe('manual')
+  })
+
+  it('rejects unsupported providers', async () => {
+    await expect(
+      transcribeWithProvider({
+        provider: 'openai-compatible' as any,
+        audio: Buffer.from('audio'),
+        fileName: 'speech.webm',
+        mimeType: 'audio/webm',
+        settings: {},
+        secrets: {
+          apiKey: 'server-secret',
+        },
+      }),
+    ).rejects.toThrow('Unsupported STT provider: openai-compatible')
+  })
+})

--- a/tests/server/stt-settings-controller.test.ts
+++ b/tests/server/stt-settings-controller.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('stt settings controller', () => {
+  let db: any = null
+
+  beforeEach(async () => {
+    vi.resetModules()
+    const { DatabaseSync } = await import('node:sqlite')
+    db = new DatabaseSync(':memory:')
+    vi.doMock('../../packages/server/src/db/index', () => ({
+      getDb: () => db,
+      getStoragePath: () => ':memory:',
+    }))
+  })
+
+  afterEach(() => {
+    db?.close()
+    db = null
+    vi.doUnmock('../../packages/server/src/db/index')
+    vi.resetModules()
+  })
+
+  async function initController() {
+    const schemas = await import('../../packages/server/src/db/hermes/schemas')
+    schemas.initAllHermesTables()
+    return await import('../../packages/server/src/controllers/hermes/stt')
+  }
+
+  function makeCtx(user: any | null, body: any = {}, params: Record<string, string> = {}, query: Record<string, string> = {}) {
+    return {
+      state: user ? { user } : {},
+      request: { body },
+      params,
+      query,
+      status: 200,
+      body: null,
+      set: vi.fn(),
+      get: vi.fn(() => ''),
+    } as any
+  }
+
+  it('saves masked settings rows and lists them for the authenticated user without leaking secrets', async () => {
+    const ctrl = await initController()
+    const user = { id: 9, username: 'alice', role: 'admin' }
+
+    const saveCtx = makeCtx(user, {
+      settings: {
+        model: 'gpt-4o-transcribe',
+        language: 'en',
+      },
+      secrets: {
+        apiKey: 'server-secret',
+      },
+    }, { provider: 'openai' })
+
+    await ctrl.saveSettings(saveCtx)
+
+    expect(saveCtx.status).toBe(200)
+    expect(saveCtx.body.setting).toMatchObject({
+      provider: 'openai',
+      settings: {
+        model: 'gpt-4o-transcribe',
+        language: 'en',
+      },
+      secrets: {
+        apiKey: '[stored]',
+      },
+    })
+    expect(JSON.stringify(saveCtx.body)).not.toContain('server-secret')
+
+    const listCtx = makeCtx(user)
+    await ctrl.listSettings(listCtx)
+
+    expect(listCtx.status).toBe(200)
+    expect(listCtx.body).toEqual({
+      settings: [saveCtx.body.setting],
+      activeProvider: 'openai',
+    })
+    expect(JSON.stringify(listCtx.body)).not.toContain('server-secret')
+  })
+
+  it('deletes stored secrets while keeping the settings row masked', async () => {
+    const ctrl = await initController()
+    const user = { id: 7, username: 'bob', role: 'admin' }
+
+    const saveCtx = makeCtx(user, {
+      settings: {
+        model: 'gpt-4o-transcribe',
+      },
+      secrets: {
+        apiKey: 'server-secret',
+      },
+    }, { provider: 'openai' })
+    await ctrl.saveSettings(saveCtx)
+
+    const deleteCtx = makeCtx(user, {}, { provider: 'openai', secretName: 'apiKey' })
+    await ctrl.deleteSecret(deleteCtx)
+
+    expect(deleteCtx.status).toBe(200)
+    expect(deleteCtx.body).toEqual({
+      success: true,
+      setting: expect.objectContaining({
+        provider: 'openai',
+        settings: {
+          model: 'gpt-4o-transcribe',
+        },
+        secrets: {},
+      }),
+    })
+    expect(JSON.stringify(deleteCtx.body)).not.toContain('server-secret')
+
+    const listCtx = makeCtx(user)
+    await ctrl.listSettings(listCtx)
+    expect(listCtx.body).toEqual({
+      settings: [deleteCtx.body.setting],
+      activeProvider: 'openai',
+    })
+  })
+
+  it('deletes saved custom base URL presets without deleting the current setting or secret', async () => {
+    const ctrl = await initController()
+    const user = { id: 13, username: 'dana', role: 'admin' }
+
+    const saveFirstCtx = makeCtx(user, {
+      settings: {
+        baseUrl: 'https://api.groq.com/openai/v1',
+        model: 'whisper-large-v3-turbo',
+      },
+      secrets: { apiKey: 'server-secret' },
+    }, { provider: 'custom' })
+    await ctrl.saveSettings(saveFirstCtx)
+
+    const saveSecondCtx = makeCtx(user, {
+      settings: {
+        baseUrl: 'https://stt.example.test/openai/v1',
+        model: 'whisper-large-v3-turbo',
+      },
+    }, { provider: 'custom' })
+    await ctrl.saveSettings(saveSecondCtx)
+    expect(saveSecondCtx.body.setting.settings.baseUrlPresets).toEqual([
+      'https://stt.example.test/openai/v1',
+      'https://api.groq.com/openai/v1',
+    ])
+
+    const deleteCtx = makeCtx(
+      user,
+      {},
+      { provider: 'custom' },
+      { url: 'https://api.groq.com/openai/v1' },
+    )
+    await ctrl.deleteBaseUrlPreset(deleteCtx)
+
+    expect(deleteCtx.status).toBe(200)
+    expect(deleteCtx.body.setting).toMatchObject({
+      provider: 'custom',
+      settings: {
+        baseUrl: 'https://stt.example.test/openai/v1',
+        baseUrlPresets: ['https://stt.example.test/openai/v1'],
+        model: 'whisper-large-v3-turbo',
+      },
+      secrets: { apiKey: '[stored]' },
+    })
+    expect(JSON.stringify(deleteCtx.body)).not.toContain('server-secret')
+
+    const deleteCurrentCtx = makeCtx(
+      user,
+      {},
+      { provider: 'custom' },
+      { url: 'https://stt.example.test/openai/v1' },
+    )
+    await ctrl.deleteBaseUrlPreset(deleteCurrentCtx)
+
+    expect(deleteCurrentCtx.status).toBe(200)
+    expect(deleteCurrentCtx.body.setting).toMatchObject({
+      provider: 'custom',
+      settings: {
+        model: 'whisper-large-v3-turbo',
+      },
+      secrets: { apiKey: '[stored]' },
+    })
+    expect(deleteCurrentCtx.body.setting.settings.baseUrl).toBeUndefined()
+    expect(deleteCurrentCtx.body.setting.settings.baseUrlPresets).toBeUndefined()
+  })
+
+  it('rejects unauthenticated requests and invalid provider inputs', async () => {
+    const ctrl = await initController()
+
+    const listCtx = makeCtx(null)
+    await ctrl.listSettings(listCtx)
+    expect(listCtx.status).toBe(401)
+    expect(listCtx.body).toEqual({ error: 'Unauthorized' })
+
+    const saveCtx = makeCtx(null, {}, { provider: 'openai' })
+    await ctrl.saveSettings(saveCtx)
+    expect(saveCtx.status).toBe(401)
+    expect(saveCtx.body).toEqual({ error: 'Unauthorized' })
+
+    const deletePresetCtx = makeCtx(null, {}, { provider: 'custom' }, { url: 'https://api.groq.com/openai/v1' })
+    await ctrl.deleteBaseUrlPreset(deletePresetCtx)
+    expect(deletePresetCtx.status).toBe(401)
+    expect(deletePresetCtx.body).toEqual({ error: 'Unauthorized' })
+
+    const deleteCtx = makeCtx(null, {}, { provider: 'openai', secretName: 'apiKey' })
+    await ctrl.deleteSecret(deleteCtx)
+    expect(deleteCtx.status).toBe(401)
+    expect(deleteCtx.body).toEqual({ error: 'Unauthorized' })
+
+    const authedUser = { id: 4, username: 'eve', role: 'admin' }
+    const badProviderCtx = makeCtx(authedUser, {}, { provider: 'nope' })
+    await ctrl.saveSettings(badProviderCtx)
+    expect(badProviderCtx.status).toBe(400)
+    expect(badProviderCtx.body).toEqual({ error: 'unknown STT provider' })
+
+    const badSecretCtx = makeCtx(authedUser, {}, { provider: 'openai', secretName: 'token' })
+    await ctrl.deleteSecret(badSecretCtx)
+    expect(badSecretCtx.status).toBe(400)
+    expect(badSecretCtx.body).toEqual({ error: 'unknown STT provider secret' })
+
+    const badActiveCtx = makeCtx(authedUser, { provider: 'nope' })
+    await ctrl.saveActiveProvider(badActiveCtx)
+    expect(badActiveCtx.status).toBe(400)
+    expect(badActiveCtx.body).toEqual({ error: 'unknown STT provider' })
+  })
+
+  it('saves browser as the active STT provider without creating a provider-secret row', async () => {
+    const ctrl = await initController()
+    const user = { id: 11, username: 'carol', role: 'admin' }
+
+    const ctx = makeCtx(user, { provider: 'browser' })
+    await ctrl.saveActiveProvider(ctx)
+    expect(ctx.body).toEqual({ activeProvider: 'browser' })
+
+    const listCtx = makeCtx(user)
+    await ctrl.listSettings(listCtx)
+    expect(listCtx.body).toEqual({ settings: [], activeProvider: 'browser' })
+  })
+})
+
+describe('stt routes', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.doUnmock('../../packages/server/src/routes/hermes/stt')
+    vi.doUnmock('../../packages/server/src/controllers/hermes/stt')
+  })
+
+  it('registers the protected STT settings and transcribe routes', async () => {
+    const listSettings = vi.fn(async (ctx: any) => { ctx.body = { route: 'listSettings' } })
+    const saveActiveProvider = vi.fn(async (ctx: any) => { ctx.body = { route: 'saveActiveProvider' } })
+    const saveSettings = vi.fn(async (ctx: any) => { ctx.body = { route: 'saveSettings' } })
+    const deleteSecret = vi.fn(async (ctx: any) => { ctx.body = { route: 'deleteSecret' } })
+    const deleteBaseUrlPreset = vi.fn(async (ctx: any) => { ctx.body = { route: 'deleteBaseUrlPreset' } })
+    const transcribe = vi.fn(async (ctx: any) => { ctx.body = { route: 'transcribe' } })
+
+    vi.doMock('../../packages/server/src/controllers/hermes/stt', () => ({
+      listSettings,
+      saveActiveProvider,
+      saveSettings,
+      deleteSecret,
+      deleteBaseUrlPreset,
+      transcribe,
+    }))
+
+    const { sttProtectedRoutes } = await import('../../packages/server/src/routes/hermes/stt')
+    const protectedPaths = sttProtectedRoutes.stack.map((entry: any) => entry.path)
+
+    expect(protectedPaths).toEqual(expect.arrayContaining([
+      '/api/hermes/stt/settings',
+      '/api/hermes/stt/settings/active',
+      '/api/hermes/stt/settings/:provider',
+      '/api/hermes/stt/settings/:provider/base-url-preset',
+      '/api/hermes/stt/settings/:provider/secret/:secretName',
+      '/api/hermes/stt/transcribe',
+    ]))
+
+    const transcribeLayer: any = sttProtectedRoutes.stack.find((entry: any) => entry.path === '/api/hermes/stt/transcribe')
+    const ctx: any = { request: { body: {} }, body: null }
+
+    await transcribeLayer.stack[0](ctx, undefined)
+
+    expect(transcribe).toHaveBeenCalledWith(ctx, undefined)
+    expect(ctx.body).toEqual({ route: 'transcribe' })
+  })
+})

--- a/tests/server/stt-settings-store.test.ts
+++ b/tests/server/stt-settings-store.test.ts
@@ -1,0 +1,383 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('STT provider settings schema', () => {
+  let db: any = null
+
+  beforeEach(async () => {
+    vi.resetModules()
+    const { DatabaseSync } = await import('node:sqlite')
+    db = new DatabaseSync(':memory:')
+    vi.doMock('../../packages/server/src/db/index', () => ({
+      getDb: () => db,
+      getStoragePath: () => ':memory:',
+    }))
+  })
+
+  afterEach(() => {
+    db?.close()
+    db = null
+    vi.doUnmock('../../packages/server/src/db/index')
+    vi.resetModules()
+  })
+
+  async function initStores(): Promise<void> {
+    const { initAllStores } = await import('../../packages/server/src/db/hermes/init')
+    initAllStores()
+  }
+
+  function tableNames(): string[] {
+    return db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all().map((row: any) => row.name)
+  }
+
+  it('creates stt_provider_settings table during store init', async () => {
+    await initStores()
+
+    expect(tableNames()).toContain('stt_provider_settings')
+    const columns = db.prepare('PRAGMA table_info(stt_provider_settings)').all().map((row: any) => row.name)
+    expect(columns).toEqual(expect.arrayContaining([
+      'id',
+      'user_id',
+      'provider',
+      'settings_json',
+      'secrets_json',
+      'created_at',
+      'updated_at',
+    ]))
+  })
+
+  it('rejects duplicate provider settings for the same user', async () => {
+    await initStores()
+
+    const insert = db.prepare('INSERT INTO stt_provider_settings (user_id, provider) VALUES (?, ?)')
+    insert.run(1, 'openai')
+
+    expect(() => insert.run(1, 'openai')).toThrow(/UNIQUE constraint failed/)
+  })
+
+  it('allows the same provider for different users', async () => {
+    await initStores()
+
+    const insert = db.prepare('INSERT INTO stt_provider_settings (user_id, provider) VALUES (?, ?)')
+    insert.run(1, 'openai')
+
+    expect(() => insert.run(2, 'openai')).not.toThrow()
+    expect(db.prepare('SELECT COUNT(*) AS count FROM stt_provider_settings WHERE provider = ?').get('openai').count).toBe(2)
+  })
+
+  it('migrates legacy stt_provider_settings tables that still default user_id to 0', async () => {
+    db.exec(`
+      CREATE TABLE stt_provider_settings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL DEFAULT 0,
+        provider TEXT NOT NULL,
+        settings_json TEXT NOT NULL DEFAULT '{}',
+        secrets_json TEXT NOT NULL DEFAULT '{}',
+        created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+        updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+      )
+    `)
+    db.exec('CREATE INDEX idx_stt_provider_settings_user ON stt_provider_settings(user_id)')
+    db.exec('CREATE UNIQUE INDEX idx_stt_provider_settings_user_provider ON stt_provider_settings(user_id, provider)')
+    db.prepare(
+      'INSERT INTO stt_provider_settings (user_id, provider, settings_json, secrets_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(7, 'deepgram', '{"language":"en"}', '{"apiKey":"secret"}', 1710000000, 1710000100)
+
+    await initStores()
+
+    const userIdColumn = db.prepare('PRAGMA table_info(stt_provider_settings)').all().find((row: any) => row.name === 'user_id')
+    expect(userIdColumn?.dflt_value).toBeNull()
+
+    const insertWithoutUserId = db.prepare('INSERT INTO stt_provider_settings (provider) VALUES (?)')
+    expect(() => insertWithoutUserId.run('openai')).toThrow(/NOT NULL constraint failed: stt_provider_settings\.user_id/)
+
+    const preservedRow = db.prepare('SELECT * FROM stt_provider_settings WHERE user_id = ? AND provider = ?').get(7, 'deepgram')
+    expect(preservedRow).toMatchObject({
+      user_id: 7,
+      provider: 'deepgram',
+      settings_json: '{"language":"en"}',
+      secrets_json: '{"apiKey":"secret"}',
+      created_at: 1710000000,
+      updated_at: 1710000100,
+    })
+  })
+
+  it('rejects inserts that omit user_id', async () => {
+    await initStores()
+
+    const insertWithoutUserId = db.prepare('INSERT INTO stt_provider_settings (provider) VALUES (?)')
+
+    expect(() => insertWithoutUserId.run('openai')).toThrow(/NOT NULL constraint failed: stt_provider_settings\.user_id/)
+  })
+})
+
+describe('stt settings store', () => {
+  let db: any = null
+
+  beforeEach(async () => {
+    vi.resetModules()
+    const { DatabaseSync } = await import('node:sqlite')
+    db = new DatabaseSync(':memory:')
+    vi.doMock('../../packages/server/src/db/index', () => ({
+      getDb: () => db,
+      getStoragePath: () => ':memory:',
+    }))
+  })
+
+  afterEach(() => {
+    db?.close()
+    db = null
+    vi.doUnmock('../../packages/server/src/db/index')
+    vi.resetModules()
+  })
+
+  async function initStore() {
+    const schemas = await import('../../packages/server/src/db/hermes/schemas')
+    schemas.initAllHermesTables()
+    return {
+      schemas,
+      store: await import('../../packages/server/src/db/hermes/stt-settings-store'),
+    }
+  }
+
+  it('stores settings and masks secrets on read', async () => {
+    const { store } = await initStore()
+
+    const saved = store.saveSttProviderSetting(7, 'openai', {
+      settings: {
+        baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
+        model: 'gpt-4o-transcribe',
+        language: 'en',
+      },
+      secrets: {
+        apiKey: 'secret-value',
+      },
+    })
+
+    expect(saved).toMatchObject({
+      userId: 7,
+      provider: 'openai',
+      settings: {
+        baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
+        model: 'gpt-4o-transcribe',
+        language: 'en',
+      },
+      secrets: {
+        apiKey: '[stored]',
+      },
+    })
+    expect(JSON.stringify(saved)).not.toContain('secret-value')
+
+    const fetched = store.getSttProviderSetting(7, 'openai')
+    expect(fetched).toEqual(saved)
+    expect(JSON.stringify(fetched)).not.toContain('secret-value')
+  })
+
+  it('returns raw secrets only for backend callers that opt in', async () => {
+    const { store } = await initStore()
+
+    store.saveSttProviderSetting(7, 'openai', {
+      settings: {
+        baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
+        model: 'gpt-4o-transcribe',
+      },
+      secrets: {
+        apiKey: 'secret-value',
+      },
+    })
+
+    expect(store.getSttProviderSetting(7, 'openai', { includeSecrets: true })).toMatchObject({
+      userId: 7,
+      provider: 'openai',
+      settings: {
+        baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
+        model: 'gpt-4o-transcribe',
+      },
+      secrets: {
+        apiKey: 'secret-value',
+      },
+    })
+  })
+
+  it('preserves existing raw secrets when the stored marker is submitted again', async () => {
+    const { store } = await initStore()
+
+    store.saveSttProviderSetting(7, 'openai', {
+      settings: {
+        baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
+        model: 'gpt-4o-transcribe',
+      },
+      secrets: {
+        apiKey: 'secret-value',
+      },
+    })
+
+    const updated = store.saveSttProviderSetting(7, 'openai', {
+      settings: {
+        language: 'en',
+        prompt: 'Transcribe carefully',
+      },
+      secrets: {
+        apiKey: '[stored]',
+      },
+    })
+
+    expect(updated).toMatchObject({
+      userId: 7,
+      provider: 'openai',
+      settings: {
+        baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
+        model: 'gpt-4o-transcribe',
+        language: 'en',
+        prompt: 'Transcribe carefully',
+      },
+      secrets: {
+        apiKey: '[stored]',
+      },
+    })
+
+    expect(store.getSttProviderSetting(7, 'openai', { includeSecrets: true })?.secrets).toEqual({
+      apiKey: 'secret-value',
+    })
+  })
+
+  it('trims and bounds prompt length to 1000 characters', async () => {
+    const { store } = await initStore()
+    const trimmedPrompt = 'x'.repeat(1000)
+
+    const saved = store.saveSttProviderSetting(7, 'openai', {
+      settings: {
+        prompt: `  ${trimmedPrompt}extra  `,
+      },
+    })
+
+    expect(saved.settings.prompt).toBe(trimmedPrompt)
+    expect(saved.settings.prompt).toHaveLength(1000)
+
+    const storedRow = db.prepare(
+      'SELECT settings_json FROM stt_provider_settings WHERE user_id = ? AND provider = ?'
+    ).get(7, 'openai') as { settings_json: string }
+
+    expect(JSON.parse(storedRow.settings_json)).toMatchObject({
+      prompt: trimmedPrompt,
+    })
+  })
+
+  it('clears one stored secret without deleting settings', async () => {
+    const { store } = await initStore()
+
+    store.saveSttProviderSetting(7, 'openai', {
+      settings: {
+        baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
+        model: 'gpt-4o-transcribe',
+        language: 'en',
+      },
+      secrets: {
+        apiKey: 'secret-value',
+      },
+    })
+
+    const cleared = store.clearStoredSttSecret(7, 'openai', 'apiKey')
+    expect(cleared).toMatchObject({
+      userId: 7,
+      provider: 'openai',
+      settings: {
+        baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
+        model: 'gpt-4o-transcribe',
+        language: 'en',
+      },
+      secrets: {},
+    })
+
+    expect(store.getSttProviderSetting(7, 'openai')).toEqual(cleared)
+    expect(store.getSttProviderSetting(7, 'openai', { includeSecrets: true })?.secrets).toEqual({})
+  })
+
+  it('lists only settings for the requested user', async () => {
+    const { store } = await initStore()
+
+    const expected = store.saveSttProviderSetting(7, 'openai', {
+      settings: {
+        baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
+        model: 'gpt-4o-transcribe',
+      },
+      secrets: {
+        apiKey: 'secret-value',
+      },
+    })
+
+    store.saveSttProviderSetting(8, 'custom', {
+      settings: {
+        baseUrl: 'https://transcribe.example.com/v1',
+        model: 'custom-whisper',
+      },
+      secrets: {
+        apiKey: 'other-secret',
+      },
+    })
+
+    expect(store.listSttProviderSettings(7)).toEqual([expected])
+  })
+
+  it('ignores unsupported legacy provider rows when listing settings', async () => {
+    const { store } = await initStore()
+
+    const expected = store.saveSttProviderSetting(7, 'openai', {
+      settings: {
+        baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
+        model: 'gpt-4o-transcribe',
+      },
+      secrets: {
+        apiKey: 'secret-value',
+      },
+    })
+
+    db.prepare(
+      'INSERT INTO stt_provider_settings (user_id, provider, settings_json, secrets_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(7, 'deepgram', '{"language":"en"}', '{"apiKey":"legacy-secret"}', 1710000000, 1710000100)
+
+    expect(() => store.listSttProviderSettings(7)).not.toThrow()
+    expect(store.listSttProviderSettings(7)).toEqual([expected])
+    expect(() => store.getSttProviderSetting(7, 'deepgram' as any)).toThrow(/unknown STT provider/i)
+  })
+
+  it('rejects unsupported providers and secret names', async () => {
+    const { store } = await initStore()
+
+    expect(() => {
+      store.saveSttProviderSetting(7, 'deepgram', {
+        settings: {
+          model: 'nova-2',
+        },
+      })
+    }).toThrow(/unknown STT provider/i)
+
+    expect(() => {
+      store.saveSttProviderSetting(7, 'openai', {
+        secrets: {
+          token: 'secret-value',
+        },
+      })
+    }).toThrow(/unknown STT provider secret/i)
+  })
+
+  it.each([
+    'http://10.0.0.1:8000/v1/audio/transcriptions',
+    'http://172.16.0.1:8000/v1/audio/transcriptions',
+    'http://192.168.1.1:8000/v1/audio/transcriptions',
+    'http://127.0.0.1:8000/v1/audio/transcriptions',
+    'http://169.254.169.254/latest/meta-data',
+    'http://[::1]:8000/v1/audio/transcriptions',
+    'http://[fd00::1]:8000/v1/audio/transcriptions',
+    'http://[fe90::1]:8000/v1/audio/transcriptions',
+  ])('rejects unsafe base urls using the shared url safety rules: %s', async (baseUrl) => {
+    const { store } = await initStore()
+
+    expect(() => {
+      store.saveSttProviderSetting(7, 'openai', {
+        settings: {
+          baseUrl,
+        },
+      })
+    }).toThrow(/baseUrl/)
+  })
+})

--- a/tests/server/stt-transcribe-controller.test.ts
+++ b/tests/server/stt-transcribe-controller.test.ts
@@ -1,0 +1,446 @@
+import { Readable } from 'stream'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetTtsDnsLookupForTests, setTtsDnsLookupForTests } from '../../packages/server/src/services/hermes/tts-providers/url-safety'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(body: unknown, init: { status?: number; statusText?: string } = {}) {
+  return {
+    ok: (init.status ?? 200) >= 200 && (init.status ?? 200) < 300,
+    status: init.status ?? 200,
+    statusText: init.statusText ?? 'OK',
+    async json() {
+      return body
+    },
+    async text() {
+      return JSON.stringify(body)
+    },
+  }
+}
+
+function textResponse(body: string, init: { status?: number; statusText?: string } = {}) {
+  return {
+    ok: (init.status ?? 500) >= 200 && (init.status ?? 500) < 300,
+    status: init.status ?? 500,
+    statusText: init.statusText ?? 'Error',
+    async json() {
+      return { error: body }
+    },
+    async text() {
+      return body
+    },
+  }
+}
+
+function multipartBody(
+  boundary: string,
+  parts: Array<{
+    name: string
+    value: string | Buffer
+    filename?: string
+    filenameStar?: string
+    contentType?: string
+  }>,
+): Buffer {
+  const chunks: Buffer[] = []
+  for (const part of parts) {
+    chunks.push(Buffer.from(`--${boundary}\r\n`))
+    const filename = part.filename ? `; filename="${part.filename}"` : ''
+    const filenameStar = part.filenameStar ? `; filename*=UTF-8''${part.filenameStar}` : ''
+    chunks.push(Buffer.from(`Content-Disposition: form-data; name="${part.name}"${filename}${filenameStar}\r\n`))
+    if (part.contentType) {
+      chunks.push(Buffer.from(`Content-Type: ${part.contentType}\r\n`))
+    }
+    chunks.push(Buffer.from('\r\n'))
+    chunks.push(Buffer.isBuffer(part.value) ? part.value : Buffer.from(part.value))
+    chunks.push(Buffer.from('\r\n'))
+  }
+  chunks.push(Buffer.from(`--${boundary}--\r\n`))
+  return Buffer.concat(chunks)
+}
+
+function getHeader(headers: RequestInit['headers'] | undefined, name: string): string | undefined {
+  if (!headers) return undefined
+  if (headers instanceof Headers) return headers.get(name) ?? undefined
+  if (Array.isArray(headers)) {
+    const match = headers.find(([key]) => key.toLowerCase() === name.toLowerCase())
+    return match?.[1]
+  }
+
+  const match = Object.entries(headers).find(([key]) => key.toLowerCase() === name.toLowerCase())
+  return typeof match?.[1] === 'string' ? match[1] : undefined
+}
+
+describe('stt transcribe controller', () => {
+  let db: any = null
+
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    const { DatabaseSync } = await import('node:sqlite')
+    db = new DatabaseSync(':memory:')
+    vi.doMock('../../packages/server/src/db/index', () => ({
+      getDb: () => db,
+      getStoragePath: () => ':memory:',
+    }))
+    setTtsDnsLookupForTests(vi.fn(async () => [{ address: '93.184.216.34', family: 4 }]) as any)
+  })
+
+  afterEach(() => {
+    resetTtsDnsLookupForTests()
+    db?.close()
+    db = null
+    vi.doUnmock('../../packages/server/src/db/index')
+    vi.resetModules()
+  })
+
+  async function initControllerAndStore() {
+    const schemas = await import('../../packages/server/src/db/hermes/schemas')
+    schemas.initAllHermesTables()
+    return {
+      ctrl: await import('../../packages/server/src/controllers/hermes/stt'),
+      store: await import('../../packages/server/src/db/hermes/stt-settings-store'),
+    }
+  }
+
+  function makeMultipartCtx(
+    user: any | null,
+    parts: Array<{ name: string; value: string | Buffer; filename?: string; filenameStar?: string; contentType?: string }>,
+  ) {
+    const boundary = 'stt-boundary'
+    return {
+      state: user ? { user } : {},
+      request: {},
+      req: Readable.from([multipartBody(boundary, parts)]),
+      params: {},
+      status: 200,
+      body: null,
+      set: vi.fn(),
+      get: vi.fn((header: string) => header.toLowerCase() === 'content-type' ? `multipart/form-data; boundary=${boundary}` : ''),
+    } as any
+  }
+
+  function makeJsonCtx(user: any | null, provider: string, body: unknown) {
+    return {
+      state: user ? { user } : {},
+      request: { body },
+      req: Readable.from([]),
+      params: { provider },
+      status: 200,
+      body: null,
+      set: vi.fn(),
+      get: vi.fn(() => ''),
+    } as any
+  }
+
+  it('transcribes multipart audio using the stored secret and ignores client-supplied api keys', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ text: 'transcribed text' }))
+    const { ctrl, store } = await initControllerAndStore()
+    store.saveSttProviderSetting(7, 'openai', {
+      settings: {
+        model: 'gpt-4o-transcribe',
+        language: 'en',
+      },
+      secrets: {
+        apiKey: 'server-secret',
+      },
+    })
+
+    const ctx = makeMultipartCtx(
+      { id: 7, username: 'han', role: 'admin' },
+      [
+        { name: 'provider', value: 'openai' },
+        { name: 'apiKey', value: 'attacker-secret' },
+        { name: 'secrets', value: '{"apiKey":"body-secret"}' },
+        { name: 'audio', value: Buffer.from('audio-data'), filename: 'speech.webm', contentType: 'audio/webm' },
+      ],
+    )
+
+    await ctrl.transcribe(ctx)
+
+    expect(ctx.status).toBe(200)
+    expect(ctx.body).toMatchObject({
+      text: 'transcribed text',
+      provider: 'openai',
+      model: 'gpt-4o-transcribe',
+      language: 'en',
+    })
+    expect(ctx.body.durationMs).toEqual(expect.any(Number))
+    expect(JSON.stringify(ctx.body)).not.toContain('server-secret')
+    expect(JSON.stringify(ctx.body)).not.toContain('attacker-secret')
+    expect(JSON.stringify(ctx.body)).not.toContain('body-secret')
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [, init] = mockFetch.mock.calls[0] as [string | URL, RequestInit]
+    expect(getHeader(init.headers, 'Authorization')).toBe('Bearer server-secret')
+    expect(getHeader(init.headers, 'Authorization')).not.toContain('attacker-secret')
+    expect(init.body).toBeInstanceOf(FormData)
+
+    const form = init.body as FormData
+    expect(form.get('model')).toBe('gpt-4o-transcribe')
+    expect(form.get('language')).toBe('en')
+  })
+
+  it('masks stored api keys when listing STT settings', async () => {
+    const { ctrl, store } = await initControllerAndStore()
+    store.saveSttProviderSetting(7, 'openai', {
+      settings: {
+        model: 'gpt-4o-transcribe',
+      },
+      secrets: {
+        apiKey: 'server-secret',
+      },
+    })
+
+    const ctx = makeJsonCtx({ id: 7, username: 'han', role: 'admin' }, 'openai', undefined)
+    await ctrl.listSettings(ctx)
+
+    expect(ctx.status).toBe(200)
+    expect(ctx.body).toEqual({
+      settings: [
+        expect.objectContaining({
+          provider: 'openai',
+          secrets: { apiKey: '[stored]' },
+        }),
+      ],
+      activeProvider: null,
+    })
+    expect(JSON.stringify(ctx.body)).not.toContain('server-secret')
+  })
+
+  it('returns 400 when multipart audio is missing', async () => {
+    const { ctrl, store } = await initControllerAndStore()
+    store.saveSttProviderSetting(7, 'openai', {
+      settings: { model: 'gpt-4o-transcribe' },
+      secrets: { apiKey: 'server-secret' },
+    })
+
+    const ctx = makeMultipartCtx(
+      { id: 7, username: 'han', role: 'admin' },
+      [{ name: 'provider', value: 'openai' }],
+    )
+
+    await ctrl.transcribe(ctx)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toEqual({ error: 'audio is required' })
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for malformed multipart filename* without throwing', async () => {
+    const { ctrl, store } = await initControllerAndStore()
+    store.saveSttProviderSetting(7, 'openai', {
+      settings: { model: 'gpt-4o-transcribe' },
+      secrets: { apiKey: 'server-secret' },
+    })
+
+    const ctx = makeMultipartCtx(
+      { id: 7, username: 'han', role: 'admin' },
+      [
+        { name: 'provider', value: 'openai' },
+        {
+          name: 'audio',
+          value: Buffer.from('audio-data'),
+          filenameStar: 'bad%ZZname.webm',
+          contentType: 'audio/webm',
+        },
+      ],
+    )
+
+    await expect(ctrl.transcribe(ctx)).resolves.toBeUndefined()
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toEqual({ error: 'Malformed multipart filename' })
+    expect(JSON.stringify(ctx.body)).not.toContain('URIError')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when no saved STT settings exist for the requested provider', async () => {
+    const { ctrl } = await initControllerAndStore()
+    const ctx = makeMultipartCtx(
+      { id: 7, username: 'han', role: 'admin' },
+      [
+        { name: 'provider', value: 'openai' },
+        { name: 'audio', value: Buffer.from('audio-data'), filename: 'speech.webm', contentType: 'audio/webm' },
+      ],
+    )
+
+    await ctrl.transcribe(ctx)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toEqual({ error: 'STT settings are required for provider openai' })
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for saved custom provider settings missing baseUrl', async () => {
+    const { ctrl, store } = await initControllerAndStore()
+    store.saveSttProviderSetting(7, 'custom', {
+      settings: {
+        model: 'whisper-1',
+      },
+      secrets: {
+        apiKey: 'server-secret',
+      },
+    })
+
+    const ctx = makeMultipartCtx(
+      { id: 7, username: 'han', role: 'admin' },
+      [
+        { name: 'provider', value: 'custom' },
+        { name: 'audio', value: Buffer.from('audio-data'), filename: 'speech.webm', contentType: 'audio/webm' },
+      ],
+    )
+
+    await expect(ctrl.transcribe(ctx)).resolves.toBeUndefined()
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toEqual({ error: 'Custom STT baseUrl is required' })
+    expect(JSON.stringify(ctx.body)).not.toContain('server-secret')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('ignores client-supplied custom baseUrl, apiKey, and headers during transcription', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ text: 'custom transcript' }))
+    const { ctrl, store } = await initControllerAndStore()
+    store.saveSttProviderSetting(7, 'custom', {
+      settings: {
+        baseUrl: 'https://example.com/v1',
+        model: 'whisper-1',
+        language: 'fr',
+      },
+      secrets: {
+        apiKey: 'server-secret',
+      },
+    })
+
+    const ctx = makeMultipartCtx(
+      { id: 7, username: 'han', role: 'admin' },
+      [
+        { name: 'provider', value: 'custom' },
+        { name: 'baseUrl', value: 'http://127.0.0.1:8000/v1/audio/transcriptions' },
+        { name: 'apiKey', value: 'attacker-secret' },
+        { name: 'headers', value: '{"Authorization":"Bearer attacker-secret"}' },
+        { name: 'settings', value: '{"baseUrl":"http://169.254.169.254/latest/meta-data"}' },
+        { name: 'audio', value: Buffer.from('audio-data'), filename: 'speech.webm', contentType: 'audio/webm' },
+      ],
+    )
+
+    await ctrl.transcribe(ctx)
+
+    expect(ctx.status).toBe(200)
+    expect(ctx.body).toMatchObject({
+      text: 'custom transcript',
+      provider: 'custom',
+      model: 'whisper-1',
+      language: 'fr',
+    })
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, init] = mockFetch.mock.calls[0] as [string | URL, RequestInit]
+    expect(String(url)).toBe('https://example.com/v1/audio/transcriptions')
+    expect(getHeader(init.headers, 'Authorization')).toBe('Bearer server-secret')
+    expect(getHeader(init.headers, 'Authorization')).not.toContain('attacker-secret')
+  })
+
+  it.each([
+    'http://10.0.0.1:8000/v1/audio/transcriptions',
+    'http://172.16.0.1:8000/v1/audio/transcriptions',
+    'http://192.168.1.1:8000/v1/audio/transcriptions',
+    'http://127.0.0.1:8000/v1/audio/transcriptions',
+    'http://169.254.169.254/latest/meta-data',
+    'http://[::1]:8000/v1/audio/transcriptions',
+    'http://[fd00::1]:8000/v1/audio/transcriptions',
+    'http://[fe90::1]:8000/v1/audio/transcriptions',
+  ])('rejects unsafe custom baseUrl %s when saving settings', async (baseUrl) => {
+    const { ctrl } = await initControllerAndStore()
+    const ctx = makeJsonCtx(
+      { id: 7, username: 'han', role: 'admin' },
+      'custom',
+      {
+        settings: {
+          baseUrl,
+          model: 'whisper-1',
+        },
+        secrets: {
+          apiKey: 'server-secret',
+        },
+      },
+    )
+
+    await ctrl.saveSettings(ctx)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toEqual({
+      error: 'Custom STT TTS baseUrl cannot target localhost or private network addresses',
+    })
+    expect(JSON.stringify(ctx.body)).not.toContain('server-secret')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 502 without leaking secrets when the provider fails', async () => {
+    mockFetch.mockResolvedValueOnce(textResponse('upstream rejected bearer server-secret', { status: 401, statusText: 'Unauthorized' }))
+    const { ctrl, store } = await initControllerAndStore()
+    store.saveSttProviderSetting(7, 'openai', {
+      settings: { model: 'gpt-4o-transcribe' },
+      secrets: { apiKey: 'server-secret' },
+    })
+
+    const ctx = makeMultipartCtx(
+      { id: 7, username: 'han', role: 'admin' },
+      [
+        { name: 'provider', value: 'openai' },
+        { name: 'audio', value: Buffer.from('audio-data'), filename: 'speech.webm', contentType: 'audio/webm' },
+      ],
+    )
+
+    await ctrl.transcribe(ctx)
+
+    expect(ctx.status).toBe(502)
+    expect(ctx.body).toEqual({
+      error: 'STT transcription failed: OpenAI-compatible STT returned HTTP 401: upstream rejected bearer [redacted]',
+    })
+    expect(JSON.stringify(ctx.body)).not.toContain('server-secret')
+  })
+})
+
+describe('route registration ordering', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.doUnmock('../../packages/server/src/routes/index')
+  })
+
+  it('mounts protected STT routes after requireAuth', async () => {
+    const ttsPublicMiddleware = async () => {}
+    const ttsProtectedMiddleware = async () => {}
+    const sttProtectedMiddleware = async () => {}
+    const proxyMiddleware = async () => {}
+
+    vi.doMock('../../packages/server/src/routes/hermes/tts', () => ({
+      ttsRoutes: { routes: vi.fn(() => ttsPublicMiddleware) },
+      ttsProtectedRoutes: { routes: vi.fn(() => ttsProtectedMiddleware) },
+    }))
+    vi.doMock('../../packages/server/src/routes/hermes/stt', () => ({
+      sttProtectedRoutes: { routes: vi.fn(() => sttProtectedMiddleware) },
+    }))
+    vi.doMock('../../packages/server/src/routes/hermes/proxy', () => ({
+      proxyRoutes: { routes: vi.fn(() => async () => {}) },
+      proxyMiddleware,
+    }))
+
+    const { registerRoutes } = await import('../../packages/server/src/routes/index')
+    const use = vi.fn()
+    const app = { use }
+    const requireAuth = vi.fn(async () => {})
+
+    const returnedProxyMiddleware = registerRoutes(app as any, [requireAuth] as any)
+    const mountedMiddleware = use.mock.calls.map(([middleware]) => middleware)
+
+    expect(mountedMiddleware.indexOf(ttsPublicMiddleware)).toBeGreaterThanOrEqual(0)
+    expect(mountedMiddleware.indexOf(requireAuth)).toBeGreaterThan(mountedMiddleware.indexOf(ttsPublicMiddleware))
+    expect(mountedMiddleware.indexOf(sttProtectedMiddleware)).toBeGreaterThan(mountedMiddleware.indexOf(requireAuth))
+    expect(mountedMiddleware.indexOf(sttProtectedMiddleware)).toBeGreaterThan(mountedMiddleware.indexOf(ttsProtectedMiddleware))
+    expect(returnedProxyMiddleware).toBe(proxyMiddleware)
+  })
+})


### PR DESCRIPTION
## Summary

添加后续语音输入功能需要的 STT provider 基础设施。

- 新增 STT provider 设置和 active provider 持久化。
- 新增受保护的 STT settings 与 transcription routes。
- 新增 OpenAI-compatible transcription provider。
- 新增客户端 STT settings/transcription API 与共享 voice API 类型。
- 为存储的 provider base URL 增加安全规范化。

## Stack

这是 5 个 stacked PR 中的第 1 个，请按以下顺序 review/merge：

1. #1396 — STT provider 基础设施
2. #1397 — 可编辑聊天语音输入
3. #1398 — TTS playback resume 安全性
4. #1399 — voice provider settings cards
5. #1400 — voice provider model discovery flow

当前 PR: #1396 — STT provider 基础设施
当前 PR branch: `voice/stt-provider-infra`
当前 PR base: `main`
## Verification

- `npm test -- --run tests/client/stt-settings-api.test.ts tests/server/openai-stt-provider.test.ts tests/server/stt-settings-controller.test.ts tests/server/stt-settings-store.test.ts tests/server/stt-transcribe-controller.test.ts`
- `npm run harness:check`

Result: passed (72 targeted tests passed; harness check passed).
