### PR TITLE
加强 TTS playback resume 安全性

### DIFF
--- a/docs/chat-chain-changes/2026-06-08-tts-playback-resume.md
+++ b/docs/chat-chain-changes/2026-06-08-tts-playback-resume.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-08
+pr: pending
+feature: TTS playback resume safety
+impact: Preserves run markers and completion state so resumed chat runs do not replay stale assistant audio.
+---
+
+The chat store and server message formatter now preserve finish-reason fields and pass through run markers when they are available, allowing playback logic to distinguish active resumed output from completed historical messages without replaying stale audio.

--- a/packages/client/src/api/hermes/tts.ts
+++ b/packages/client/src/api/hermes/tts.ts
@@ -14,6 +14,18 @@ export interface SynthesizeSpeechRequest {
   signal?: AbortSignal
 }
 
+async function readTtsError(res: Response): Promise<string> {
+  try {
+    const data = await res.clone().json() as { error?: unknown; detail?: unknown }
+    const error = typeof data.error === 'string' ? data.error : 'TTS request failed'
+    const detail = typeof data.detail === 'string' && data.detail.trim() ? data.detail.trim() : ''
+    return detail ? `${error}: ${detail}` : `${error}: ${res.status}`
+  } catch {
+    const text = await res.text().catch(() => '')
+    return text ? `TTS request failed: ${res.status} ${text.slice(0, 300)}` : `TTS request failed: ${res.status}`
+  }
+}
+
 export async function generateSpeech(opts: TtsOptions): Promise<{ audio: Blob; engine: string }> {
   const res = await fetch(
     `${localStorage.getItem('hermes_server_url') || ''}/api/hermes/tts`,
@@ -28,7 +40,7 @@ export async function generateSpeech(opts: TtsOptions): Promise<{ audio: Blob; e
   )
 
   if (!res.ok) {
-    throw new Error(`TTS request failed: ${res.status}`)
+    throw new Error(await readTtsError(res))
   }
 
   const audio = await res.blob()
@@ -57,7 +69,7 @@ export async function synthesizeSpeech(
   )
 
   if (!res.ok) {
-    throw new Error(`TTS request failed: ${res.status}`)
+    throw new Error(await readTtsError(res))
   }
 
   const audio = await res.blob()

--- a/packages/client/src/composables/useSpeech.ts
+++ b/packages/client/src/composables/useSpeech.ts
@@ -23,7 +23,7 @@ export interface OpenaiTtsOptions {
 
 export interface MimoTtsOptions {
   baseUrl: string
-  apiKey: string
+  apiKey?: string
   authMode?: 'api-key' | 'bearer' | 'both'
   model: string
   voice?: string              // preset voice ID (preset mode)
@@ -53,7 +53,18 @@ interface SpeechQueueItem {
  * 优先后端 TTS（Edge → Google），失败降级浏览器 speechSynthesis
  */
 export function useSpeech() {
-  const synth = window.speechSynthesis
+  const synth = window.speechSynthesis ?? {
+    getVoices: () => [],
+    speak: () => {},
+    cancel: () => {},
+    pause: () => {},
+    resume: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    speaking: false,
+    pending: false,
+    paused: false,
+  } as unknown as SpeechSynthesis
   const availableVoices = ref<SpeechSynthesisVoice[]>([])
   const state = ref<SpeechState>({
     isPlaying: false,
@@ -334,7 +345,6 @@ export function useSpeech() {
     provider: TtsProviderId,
     options: Record<string, unknown>,
     token: number,
-    requestErrorMessage: string,
     playbackErrorMessage: string,
   ) {
     currentTtsAbort?.abort()
@@ -369,7 +379,6 @@ export function useSpeech() {
       if (isAbortError(err)) {
         return
       }
-      console.error(requestErrorMessage, err)
       throw err
     } finally {
       if (currentTtsAbort === abortController) {
@@ -396,7 +405,6 @@ export function useSpeech() {
       provider,
       providerOptions as unknown as Record<string, unknown>,
       token,
-      '[useSpeech] OpenAI TTS 请求失败:',
       '[useSpeech] Custom TTS audio playback error',
     )
   }
@@ -432,7 +440,7 @@ export function useSpeech() {
 
   function startCustomPlayback(promise: Promise<void>) {
     void promise.catch(() => {
-      // openaiPlay/mimoPlay already log non-abort failures and clear state.
+      // openaiPlay/mimoPlay already clear state; inline card UI handles failures.
       // Toggle callers are fire-and-forget UI actions; do not leak unhandled rejections.
     })
   }
@@ -468,7 +476,6 @@ export function useSpeech() {
       'mimo',
       opts as unknown as Record<string, unknown>,
       token,
-      '[useSpeech] MiMo TTS 请求失败:',
       '[useSpeech] MiMo TTS audio playback error',
     )
   }

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -45,6 +45,8 @@ export interface Message {
   systemType?: 'command' | 'error'
   commandAction?: string
   commandData?: Record<string, unknown>
+  finishReason?: string | null
+  runMarker?: string | null
 }
 
 export interface PendingApproval {
@@ -203,6 +205,88 @@ function runtimeToolOutputHasError(value: unknown): boolean {
   return typeof value === 'string' && isToolOutputError(value)
 }
 
+function readFinishReason(value: unknown): string | null | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const record = value as Record<string, unknown>
+  if (Object.prototype.hasOwnProperty.call(record, 'finishReason')) {
+    return (record as { finishReason?: string | null }).finishReason
+  }
+  if (Object.prototype.hasOwnProperty.call(record, 'finish_reason')) {
+    return (record as { finish_reason?: string | null }).finish_reason
+  }
+  return undefined
+}
+
+function readRunMarker(value: unknown): string | null | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const record = value as Record<string, unknown>
+  if (Object.prototype.hasOwnProperty.call(record, 'runMarker')) {
+    return typeof record.runMarker === 'string' || record.runMarker == null
+      ? record.runMarker as string | null
+      : undefined
+  }
+  if (Object.prototype.hasOwnProperty.call(record, 'run_marker')) {
+    return typeof record.run_marker === 'string' || record.run_marker == null
+      ? record.run_marker as string | null
+      : undefined
+  }
+  return undefined
+}
+
+function hasAssistantVisibleText(message: Message | null | undefined): boolean {
+  if (!message) return false
+  return message.content.trim() !== '' || (message.reasoning?.trim() ?? '') !== ''
+}
+
+function selectResumedInFlightAssistant(messages: Message[], activeRunMarker?: string | null): Message | null {
+  if (messages.length === 0) return null
+  const lastMessage = messages[messages.length - 1]
+  if (lastMessage?.role !== 'assistant') return null
+  const finishReason = readFinishReason(lastMessage)
+  const runMarker = readRunMarker(lastMessage)
+  const hasMatchingRunMarker = !!activeRunMarker && !!runMarker && runMarker === activeRunMarker
+  return finishReason === null || hasMatchingRunMarker ? lastMessage : null
+}
+
+function getReplayRunMarker(events?: Array<{ event: string; data: RunEvent }>): string | null {
+  if (!Array.isArray(events)) return null
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const runMarker = readRunMarker(events[i]?.data)
+    if (typeof runMarker === 'string' && runMarker.trim() !== '') return runMarker
+  }
+  return null
+}
+
+function resolveResumedAssistantState(
+  messages: Message[],
+  options: {
+    previousActiveAssistantMessageId?: string | null
+    previousReasoningAssistantMessageId?: string | null
+    activeRunMarker?: string | null
+  },
+): {
+  activeAssistant: Message | null
+  reasoningAssistant: Message | null
+  runMarker: string | null
+  hadVisibleText: boolean
+} {
+  const activeAssistant = options.previousActiveAssistantMessageId
+    ? messages.find(m => m.role === 'assistant' && m.id === options.previousActiveAssistantMessageId) || null
+    : null
+  const selectedActiveAssistant = activeAssistant || selectResumedInFlightAssistant(messages, options.activeRunMarker)
+  const reasoningAssistant = options.previousReasoningAssistantMessageId
+    ? messages.find(m => m.role === 'assistant' && m.id === options.previousReasoningAssistantMessageId) || null
+    : null
+  const selectedReasoningAssistant = reasoningAssistant || (selectedActiveAssistant?.reasoning ? selectedActiveAssistant : null)
+  const selectedRunMarker = readRunMarker(selectedActiveAssistant) ?? options.activeRunMarker ?? null
+  return {
+    activeAssistant: selectedActiveAssistant,
+    reasoningAssistant: selectedReasoningAssistant,
+    runMarker: selectedRunMarker,
+    hadVisibleText: hasAssistantVisibleText(selectedActiveAssistant),
+  }
+}
+
 function mapHermesMessages(msgs: HermesMessage[]): Message[] {
   // Filter out assistant messages with no display content unless they carry tool call metadata
   // needed to name later tool result rows when resuming persisted history.
@@ -242,6 +326,8 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
           toolCallId: tc.id,
           toolArgs: runtimeToolPayloadOrUndefined(tc.function?.arguments),
           toolStatus: 'done',
+          finishReason: readFinishReason(msg),
+          runMarker: readRunMarker(msg),
         })
       }
       continue
@@ -283,6 +369,8 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
         toolPreview: typeof preview === 'string' ? preview.slice(0, 100) || undefined : undefined,
         toolResult: runtimeToolPayloadOrUndefined((msg as any).content),
         toolStatus: 'done',
+        finishReason: readFinishReason(msg),
+        runMarker: readRunMarker(msg),
       })
       continue
     }
@@ -295,6 +383,8 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
       timestamp: Math.round(msg.timestamp * 1000),
       reasoning: msg.reasoning ? msg.reasoning : undefined,
       systemType: msg.role === 'command' ? 'command' : undefined,
+      finishReason: readFinishReason(msg),
+      runMarker: readRunMarker(msg),
     })
   }
   return result
@@ -1483,9 +1573,11 @@ export const useChatStore = defineStore('chat', () => {
       // (b) run with only tool activity, (c) run with truly nothing visible.
       // Reset on every run.started because one handler may span multiple queued runs.
       let runProducedAssistantText = false
+      let runProducedAssistantContent = false
       let runHadToolActivity = false
       let activeAssistantMessageId: string | null = null
       let reasoningAssistantMessageId: string | null = null
+      let activeRunMarker: string | null = null
 
       const closeStreamingAssistant = () => {
         const msgs = getSessionMsgs(sid)
@@ -1496,6 +1588,7 @@ export const useChatStore = defineStore('chat', () => {
         })
         activeAssistantMessageId = null
         reasoningAssistantMessageId = null
+        activeRunMarker = null
       }
 
       const applyReconnectResume = (data: ResumeSessionPayload) => {
@@ -1530,19 +1623,44 @@ export const useChatStore = defineStore('chat', () => {
         if (data.contextTokens != null) target.contextTokens = data.contextTokens
 
         if (Array.isArray(data.messages)) {
+          const previousActiveAssistantMessageId = activeAssistantMessageId
+          const previousReasoningAssistantMessageId = reasoningAssistantMessageId
+          const replayRunMarker = getReplayRunMarker(data.events) ?? activeRunMarker
           target.messages = mapHermesMessages(data.messages as any[])
           target.loadedMessageCount = data.messageLoadedCount ?? data.messages.length
           target.messageTotal = data.messageTotal ?? target.messageCount ?? target.loadedMessageCount
           target.messageCount = target.messageTotal
           target.hasMoreBefore = data.hasMoreBefore ?? target.loadedMessageCount < target.messageTotal
-          const lastAssistant = [...target.messages].reverse().find(m => m.role === 'assistant')
-          if (data.isWorking && lastAssistant) {
-            lastAssistant.isStreaming = true
-            activeAssistantMessageId = lastAssistant.id
-            reasoningAssistantMessageId = lastAssistant.id
-            if (lastAssistant.reasoning) noteReasoningStart(lastAssistant.id)
+
+          const resumedAssistantState = data.isWorking
+            ? resolveResumedAssistantState(target.messages, {
+                previousActiveAssistantMessageId,
+                previousReasoningAssistantMessageId,
+                activeRunMarker: replayRunMarker,
+              })
+            : {
+                activeAssistant: null,
+                reasoningAssistant: null,
+                runMarker: null,
+                hadVisibleText: false,
+              }
+
+          const resumedActiveAssistant = resumedAssistantState.activeAssistant
+          const resumedReasoningAssistant = resumedAssistantState.reasoningAssistant
+          activeRunMarker = resumedAssistantState.runMarker
+
+          if (resumedActiveAssistant) {
+            resumedActiveAssistant.isStreaming = true
+            activeAssistantMessageId = resumedActiveAssistant.id
+            if (resumedAssistantState.hadVisibleText) runProducedAssistantText = true
           } else {
             activeAssistantMessageId = null
+          }
+
+          if (resumedReasoningAssistant) {
+            reasoningAssistantMessageId = resumedReasoningAssistant.id
+            if (resumedReasoningAssistant.reasoning) noteReasoningStart(resumedReasoningAssistant.id)
+          } else {
             reasoningAssistantMessageId = null
           }
         }
@@ -1618,14 +1736,18 @@ export const useChatStore = defineStore('chat', () => {
         runPayload,
         // onEvent
         (evt: RunEvent) => {
+          const eventRunMarker = readRunMarker(evt)
+          if (eventRunMarker) activeRunMarker = eventRunMarker
           switch (evt.event) {
             case 'run.started':
               clearAgentEventMessages(sid)
               setAbortState(null)
               setCompressionState(sid, null)
               runProducedAssistantText = false
+              runProducedAssistantContent = false
               runHadToolActivity = false
               closeStreamingAssistant()
+              activeRunMarker = readRunMarker(evt) ?? null
               if ((evt as any).queue_length > 0) {
                 queueLengths.value.set(sid, (evt as any).queue_length)
               } else {
@@ -1766,7 +1888,10 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'message.delta': {
-              if (evt.delta) runProducedAssistantText = true
+              if (evt.delta) {
+                runProducedAssistantText = true
+                runProducedAssistantContent = true
+              }
               const msgs = getSessionMsgs(sid)
               const last = activeAssistantMessageId
                 ? msgs.find(m => m.id === activeAssistantMessageId)
@@ -1926,17 +2051,21 @@ export const useChatStore = defineStore('chat', () => {
                   : completedAssistantMessageId
                     ? msgs.find(m => m.id === completedAssistantMessageId)
                     : undefined
+                const parsedContent = typeof (evt as any).parsed_content === 'string'
+                  ? (evt as any).parsed_content
+                  : ''
+                const parsedContentTrimmed = parsedContent.trim()
                 if (lastAssistant) {
-                  const parsedContent = typeof (evt as any).parsed_content === 'string'
-                    ? (evt as any).parsed_content
-                    : ''
-                  const parsedContentTrimmed = parsedContent.trim()
                   const existingContentTrimmed = lastAssistant.content?.trim() ?? ''
                   if (parsedContentTrimmed || !existingContentTrimmed) {
                     updateMessage(sid, lastAssistant.id, {
                       content: parsedContent,
                     })
                     finalOutputTrimmed = parsedContentTrimmed
+                    if (parsedContentTrimmed) {
+                      runProducedAssistantText = true
+                      runProducedAssistantContent = true
+                    }
                   } else {
                     finalOutputTrimmed = existingContentTrimmed
                     runProducedAssistantText = true
@@ -1946,6 +2075,17 @@ export const useChatStore = defineStore('chat', () => {
                       reasoning: (evt as any).parsed_reasoning,
                     })
                   }
+                } else if (parsedContentTrimmed) {
+                  addMessage(sid, {
+                    id: uid(),
+                    role: 'assistant',
+                    content: parsedContent,
+                    reasoning: typeof (evt as any).parsed_reasoning === 'string' ? (evt as any).parsed_reasoning : undefined,
+                    timestamp: Date.now(),
+                  })
+                  finalOutputTrimmed = parsedContentTrimmed
+                  runProducedAssistantText = true
+                  runProducedAssistantContent = true
                 }
               } else {
                 // Fallback to output field (legacy behavior)
@@ -1960,6 +2100,7 @@ export const useChatStore = defineStore('chat', () => {
                     timestamp: Date.now(),
                   })
                   runProducedAssistantText = true
+                  runProducedAssistantContent = true
                 }
               }
               // Workaround for upstream hermes-agent bug: when the agent
@@ -1987,7 +2128,7 @@ export const useChatStore = defineStore('chat', () => {
               }
 
               // 自动播放语音
-              if (autoPlaySpeechEnabled.value) {
+              if (autoPlaySpeechEnabled.value && runProducedAssistantContent) {
                 const msgs = getSessionMsgs(sid)
                 const lastAssistant = [...msgs].reverse().find(m => m.role === 'assistant')
                 if (lastAssistant?.content) {
@@ -2005,6 +2146,7 @@ export const useChatStore = defineStore('chat', () => {
               }
               activeAssistantMessageId = null
               reasoningAssistantMessageId = null
+              activeRunMarker = null
               updateSessionTitle(sid)
               break
             }
@@ -2031,6 +2173,9 @@ export const useChatStore = defineStore('chat', () => {
               } else {
                 cleanup()
               }
+              activeAssistantMessageId = null
+              reasoningAssistantMessageId = null
+              activeRunMarker = null
               break
             }
 
@@ -2053,6 +2198,9 @@ export const useChatStore = defineStore('chat', () => {
             updateMessage(sid, last.id, { isStreaming: false })
           }
           cleanup()
+          activeAssistantMessageId = null
+          reasoningAssistantMessageId = null
+          activeRunMarker = null
           updateSessionTitle(sid)
         },
         // onError
@@ -2066,6 +2214,9 @@ export const useChatStore = defineStore('chat', () => {
             }
           })
           cleanup()
+          activeAssistantMessageId = null
+          reasoningAssistantMessageId = null
+          activeRunMarker = null
         },
         undefined,
         { onReconnectResume: applyReconnectResume },
@@ -2104,9 +2255,11 @@ export const useChatStore = defineStore('chat', () => {
 
     let closed = false
     let runProducedAssistantText = false
+    let runProducedAssistantContent = false
     let runHadToolActivity = false
     let activeAssistantMessageId: string | null = null
     let reasoningAssistantMessageId: string | null = null
+    let activeRunMarker: string | null = null
 
     const cleanup = () => {
       if (closed) return
@@ -2126,13 +2279,34 @@ export const useChatStore = defineStore('chat', () => {
       })
       activeAssistantMessageId = null
       reasoningAssistantMessageId = null
+      activeRunMarker = null
     }
+
+    const initializeResumedAssistantState = () => {
+      const resumedAssistantState = resolveResumedAssistantState(getSessionMsgs(sid), { activeRunMarker })
+      activeRunMarker = resumedAssistantState.runMarker
+      if (resumedAssistantState.activeAssistant) {
+        resumedAssistantState.activeAssistant.isStreaming = true
+        activeAssistantMessageId = resumedAssistantState.activeAssistant.id
+        if (resumedAssistantState.hadVisibleText) runProducedAssistantText = true
+      }
+      if (resumedAssistantState.reasoningAssistant) {
+        reasoningAssistantMessageId = resumedAssistantState.reasoningAssistant.id
+        if (resumedAssistantState.reasoningAssistant.reasoning) {
+          noteReasoningStart(resumedAssistantState.reasoningAssistant.id)
+        }
+      }
+    }
+
+    initializeResumedAssistantState()
 
     // Shared event handler — filters by session_id tag
     function handleEvent(evt: RunEvent) {
       if (closed) return
       // Filter events for this session (server tags all events with session_id)
       if (evt.session_id && evt.session_id !== sid) return
+      const eventRunMarker = readRunMarker(evt)
+      if (eventRunMarker) activeRunMarker = eventRunMarker
       switch (evt.event) {
         case 'run.queued': {
           handleRunQueuedEvent(sid, evt)
@@ -2154,8 +2328,10 @@ export const useChatStore = defineStore('chat', () => {
           setAbortState(null)
           setCompressionState(sid, null)
           runProducedAssistantText = false
+          runProducedAssistantContent = false
           runHadToolActivity = false
           closeStreamingAssistant()
+          activeRunMarker = readRunMarker(evt) ?? null
           if ((evt as any).queue_length > 0) {
             queueLengths.value.set(sid, (evt as any).queue_length)
           } else {
@@ -2273,7 +2449,10 @@ export const useChatStore = defineStore('chat', () => {
         }
 
         case 'message.delta': {
-          if (evt.delta) runProducedAssistantText = true
+          if (evt.delta) {
+            runProducedAssistantText = true
+            runProducedAssistantContent = true
+          }
           const msgs = getSessionMsgs(sid)
           const last = activeAssistantMessageId
             ? msgs.find(m => m.id === activeAssistantMessageId)
@@ -2430,17 +2609,21 @@ export const useChatStore = defineStore('chat', () => {
               : completedAssistantMessageId
                 ? msgs.find(m => m.id === completedAssistantMessageId)
                 : undefined
+            const parsedContent = typeof (evt as any).parsed_content === 'string'
+              ? (evt as any).parsed_content
+              : ''
+            const parsedContentTrimmed = parsedContent.trim()
             if (lastAssistant) {
-              const parsedContent = typeof (evt as any).parsed_content === 'string'
-                ? (evt as any).parsed_content
-                : ''
-              const parsedContentTrimmed = parsedContent.trim()
               const existingContentTrimmed = lastAssistant.content?.trim() ?? ''
               if (parsedContentTrimmed || !existingContentTrimmed) {
                 updateMessage(sid, lastAssistant.id, {
                   content: parsedContent,
                 })
                 finalOutputTrimmed = parsedContentTrimmed
+                if (parsedContentTrimmed) {
+                  runProducedAssistantText = true
+                  runProducedAssistantContent = true
+                }
               } else {
                 finalOutputTrimmed = existingContentTrimmed
                 runProducedAssistantText = true
@@ -2450,6 +2633,17 @@ export const useChatStore = defineStore('chat', () => {
                   reasoning: (evt as any).parsed_reasoning,
                 })
               }
+            } else if (parsedContentTrimmed) {
+              addMessage(sid, {
+                id: uid(),
+                role: 'assistant',
+                content: parsedContent,
+                reasoning: typeof (evt as any).parsed_reasoning === 'string' ? (evt as any).parsed_reasoning : undefined,
+                timestamp: Date.now(),
+              })
+              finalOutputTrimmed = parsedContentTrimmed
+              runProducedAssistantText = true
+              runProducedAssistantContent = true
             }
           } else {
             // Fallback to output field (legacy behavior)
@@ -2462,6 +2656,8 @@ export const useChatStore = defineStore('chat', () => {
                 content: finalOutput,
                 timestamp: Date.now(),
               })
+              runProducedAssistantText = true
+              runProducedAssistantContent = true
             }
           }
           const swallowedError = !runProducedAssistantText && !runHadToolActivity && finalOutputTrimmed === ''
@@ -2477,7 +2673,7 @@ export const useChatStore = defineStore('chat', () => {
           }
 
           // Auto-play speech for every completed assistant message
-          if (autoPlaySpeechEnabled.value) {
+          if (autoPlaySpeechEnabled.value && runProducedAssistantContent) {
             const msgs = getSessionMsgs(sid)
             const lastAssistant = [...msgs].reverse().find(m => m.role === 'assistant')
             if (lastAssistant?.content) {
@@ -2491,10 +2687,12 @@ export const useChatStore = defineStore('chat', () => {
             cleanup()
             activeAssistantMessageId = null
             reasoningAssistantMessageId = null
+            activeRunMarker = null
           } else {
             // More runs pending — reset for next run but don't cleanup
             activeAssistantMessageId = null
             reasoningAssistantMessageId = null
+            activeRunMarker = null
           }
           updateSessionTitle(sid)
           break
@@ -2526,6 +2724,9 @@ export const useChatStore = defineStore('chat', () => {
           if (!hasQueue) {
             cleanup()
           }
+          activeAssistantMessageId = null
+          reasoningAssistantMessageId = null
+          activeRunMarker = null
           break
         }
 

--- a/packages/server/src/services/hermes/run-chat/message-format.ts
+++ b/packages/server/src/services/hermes/run-chat/message-format.ts
@@ -111,6 +111,10 @@ export function handleMessage(messages: SessionMessage[], sid: string): any[] {
           reasoning: m.reasoning || '',
           timestamp: m.timestamp,
         }
+        if (Object.prototype.hasOwnProperty.call(m, 'finish_reason')) {
+          msg.finish_reason = m.finish_reason ?? null
+        }
+        if (m.runMarker) msg.runMarker = m.runMarker
         // Convert Anthropic format content to OpenAI format
         if (m.role === 'assistant' && typeof m.content === 'string') {
           let contentToParse = m.content

--- a/tests/client/chat-store-compression-state.test.ts
+++ b/tests/client/chat-store-compression-state.test.ts
@@ -4,13 +4,14 @@ import { createPinia, setActivePinia } from 'pinia'
 import { nextTick } from 'vue'
 
 const chatApi = vi.hoisted(() => ({
+  startRunViaSocket: vi.fn(),
   resumeSession: vi.fn(),
   registerSessionHandlers: vi.fn(),
   unregisterSessionHandlers: vi.fn(),
 }))
 
 vi.mock('@/api/hermes/chat', () => ({
-  startRunViaSocket: vi.fn(),
+  startRunViaSocket: chatApi.startRunViaSocket,
   resumeSession: chatApi.resumeSession,
   registerSessionHandlers: chatApi.registerSessionHandlers,
   unregisterSessionHandlers: chatApi.unregisterSessionHandlers,
@@ -24,6 +25,7 @@ vi.mock('@/api/hermes/chat', () => ({
 
 vi.mock('@/api/client', () => ({
   getActiveProfileName: () => 'default',
+  hasApiKey: () => false,
 }))
 
 vi.mock('@/api/hermes/sessions', () => ({
@@ -37,12 +39,23 @@ vi.mock('@/api/hermes/download', () => ({
   getDownloadUrl: (_path: string, name: string) => `/download/${name}`,
 }))
 
+vi.mock('@/api/hermes/system', () => ({
+  checkHealth: vi.fn(),
+  fetchAvailableModels: vi.fn(),
+  addCustomModel: vi.fn(),
+  removeCustomModel: vi.fn(),
+  updateDefaultModel: vi.fn(),
+  updateModelVisibility: vi.fn(),
+  triggerUpdate: vi.fn(),
+  updateModelAlias: vi.fn(),
+}))
+
 vi.mock('@/utils/completion-sound', () => ({
   primeCompletionSound: vi.fn(),
   playCompletionSound: vi.fn(),
 }))
 
-import { useChatStore, type Session } from '@/stores/hermes/chat'
+import { useChatStore, type Message, type Session } from '@/stores/hermes/chat'
 
 function makeSession(id: string): Session {
   return {
@@ -61,6 +74,7 @@ describe('chat store compression state', () => {
     handlers = undefined
     vi.resetAllMocks()
     setActivePinia(createPinia())
+    chatApi.startRunViaSocket.mockReturnValue({ abort: vi.fn() })
     chatApi.resumeSession.mockImplementation((sessionId: string, onResumed: (data: any) => void) => {
       onResumed({
         session_id: sessionId,
@@ -118,7 +132,7 @@ describe('chat store compression state', () => {
     handlers.onRunCompleted({ event: 'run.completed', parsed_content: '', output: '', run_id: 'run-1' })
     await nextTick()
 
-    const assistant = store.activeSession?.messages.find(message => message.id === 'a1')
+    const assistant = store.activeSession?.messages.find((message: Message) => message.id === 'a1')
     expect(assistant?.content).toBe('final answer')
     expect(assistant?.isStreaming).toBe(false)
     expect(store.activeSession?.messages.some(
@@ -126,10 +140,43 @@ describe('chat store compression state', () => {
     )).toBe(false)
   })
 
-  it('does not treat an older assistant message as output for a blank run.completed event', async () => {
+  it('renders parsed_content-only completion as a new assistant message and auto-plays it', async () => {
+    vi.useFakeTimers()
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
     const store = useChatStore()
     store.sessions = [makeSession('session-1')]
     await store.switchSession('session-1')
+    store.setAutoPlaySpeech(true)
+
+    handlers.onRunCompleted({
+      event: 'run.completed',
+      parsed_content: 'final answer',
+      output: '',
+      run_id: 'run-parsed-only',
+    })
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(300)
+
+    const assistantMessages = store.activeSession?.messages.filter((message: Message) => message.role === 'assistant') ?? []
+    expect(assistantMessages).toHaveLength(1)
+    expect(assistantMessages[0]?.content).toBe('final answer')
+    expect(store.activeSession?.messages.some(
+      (message: Message) => message.role === 'system' && message.content.includes('Agent returned no output'),
+    )).toBe(false)
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    const autoPlayEvent = dispatchSpy.mock.calls[0][0] as CustomEvent<{ messageId: string; content: string }>
+    expect(autoPlayEvent.type).toBe('auto-play-speech')
+    expect(autoPlayEvent.detail.content).toBe('final answer')
+    expect(autoPlayEvent.detail.messageId).toBe(assistantMessages[0]?.id)
+    vi.useRealTimers()
+  })
+
+  it('does not treat an older assistant message as output for a blank run.completed event', async () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+    const store = useChatStore()
+    store.sessions = [makeSession('session-1')]
+    await store.switchSession('session-1')
+    store.setAutoPlaySpeech(true)
     store.activeSession!.messages = [{
       id: 'old-a1',
       role: 'assistant',
@@ -141,10 +188,424 @@ describe('chat store compression state', () => {
     handlers.onRunCompleted({ event: 'run.completed', parsed_content: '', output: '', run_id: 'run-2' })
     await nextTick()
 
-    expect(store.activeSession?.messages.find(message => message.id === 'old-a1')?.content).toBe('previous answer')
+    expect(store.activeSession?.messages.find((message: Message) => message.id === 'old-a1')?.content).toBe('previous answer')
     expect(store.activeSession?.messages.some(
-      message => message.role === 'system' && message.content.includes('Agent returned no output'),
+      (message: Message) => message.role === 'system' && message.content.includes('Agent returned no output'),
     )).toBe(true)
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('renders parsed_content-only completion as a new assistant message after reconnect resume and auto-plays it', async () => {
+    vi.useFakeTimers()
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+    const store = useChatStore()
+    const session = makeSession('session-1')
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+    store.setAutoPlaySpeech(true)
+
+    await store.sendMessage('resume run')
+
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: any) => void
+    const reconnectOptions = chatApi.startRunViaSocket.mock.calls[0][5] as { onReconnectResume: (data: any) => void }
+
+    reconnectOptions.onReconnectResume({
+      session_id: 'session-1',
+      isWorking: true,
+      messages: [],
+      events: [],
+    })
+
+    onEvent({
+      event: 'run.completed',
+      session_id: 'session-1',
+      parsed_content: 'final answer',
+      output: '',
+      run_id: 'run-reconnect-parsed-only',
+    })
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(300)
+
+    const assistantMessages = store.activeSession?.messages.filter((message: Message) => message.role === 'assistant') ?? []
+    expect(assistantMessages).toHaveLength(1)
+    expect(assistantMessages[0]?.content).toBe('final answer')
+    expect(store.activeSession?.messages.some(
+      (message: Message) => message.role === 'system' && message.content.includes('Agent returned no output'),
+    )).toBe(false)
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    const autoPlayEvent = dispatchSpy.mock.calls[0][0] as CustomEvent<{ messageId: string; content: string }>
+    expect(autoPlayEvent.type).toBe('auto-play-speech')
+    expect(autoPlayEvent.detail.content).toBe('final answer')
+    expect(autoPlayEvent.detail.messageId).toBe(assistantMessages[0]?.id)
+    vi.useRealTimers()
+  })
+
+  it('appends post-reconnect deltas to a genuine resumed in-flight assistant instead of duplicating it', async () => {
+    const store = useChatStore()
+    const session = makeSession('session-1')
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    await store.sendMessage('resume run')
+
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: any) => void
+    const reconnectOptions = chatApi.startRunViaSocket.mock.calls[0][5] as { onReconnectResume: (data: any) => void }
+
+    reconnectOptions.onReconnectResume({
+      session_id: 'session-1',
+      isWorking: true,
+      messages: [{
+        id: 'current-a1',
+        role: 'assistant',
+        content: 'partial answer',
+        timestamp: Date.now() / 1000,
+        finish_reason: null,
+        runMarker: 'cli_run_current',
+      }],
+      events: [],
+    })
+
+    onEvent({
+      event: 'message.delta',
+      session_id: 'session-1',
+      delta: ' continued',
+      run_id: 'run-reconnect-streaming',
+    })
+    await nextTick()
+
+    const assistantMessages = store.activeSession?.messages.filter((message: Message) => message.role === 'assistant') ?? []
+    expect(assistantMessages).toHaveLength(1)
+    expect(assistantMessages[0]).toEqual(expect.objectContaining({
+      id: 'current-a1',
+      content: 'partial answer continued',
+      isStreaming: true,
+    }))
+  })
+
+  it('closes a genuine resumed in-flight assistant on blank completion without swallowed-error or replay', async () => {
+    vi.useFakeTimers()
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+    const store = useChatStore()
+    const session = makeSession('session-1')
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+    store.setAutoPlaySpeech(true)
+
+    await store.sendMessage('resume run')
+
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: any) => void
+    const reconnectOptions = chatApi.startRunViaSocket.mock.calls[0][5] as { onReconnectResume: (data: any) => void }
+
+    reconnectOptions.onReconnectResume({
+      session_id: 'session-1',
+      isWorking: true,
+      messages: [{
+        id: 'current-a1',
+        role: 'assistant',
+        content: 'partial answer',
+        timestamp: Date.now() / 1000,
+        finish_reason: null,
+        runMarker: 'cli_run_current',
+      }],
+      events: [],
+    })
+
+    onEvent({
+      event: 'run.completed',
+      session_id: 'session-1',
+      parsed_content: '',
+      output: '',
+      run_id: 'run-reconnect-blank-resumed-current',
+    })
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(300)
+
+    const assistantMessages = store.activeSession?.messages.filter((message: Message) => message.role === 'assistant') ?? []
+    expect(assistantMessages).toHaveLength(1)
+    expect(assistantMessages[0]).toEqual(expect.objectContaining({
+      id: 'current-a1',
+      content: 'partial answer',
+      isStreaming: false,
+    }))
+    expect(store.activeSession?.messages.some(
+      (message: Message) => message.role === 'system' && message.content.includes('Agent returned no output'),
+    )).toBe(false)
+    expect(dispatchSpy).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it('finalizes a genuine resumed in-flight assistant with parsed_content instead of appending a second row', async () => {
+    vi.useFakeTimers()
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+    const store = useChatStore()
+    const session = makeSession('session-1')
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+    store.setAutoPlaySpeech(true)
+
+    await store.sendMessage('resume run')
+
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: any) => void
+    const reconnectOptions = chatApi.startRunViaSocket.mock.calls[0][5] as { onReconnectResume: (data: any) => void }
+
+    reconnectOptions.onReconnectResume({
+      session_id: 'session-1',
+      isWorking: true,
+      messages: [{
+        id: 'current-a1',
+        role: 'assistant',
+        content: 'partial answer',
+        timestamp: Date.now() / 1000,
+        finish_reason: null,
+        runMarker: 'cli_run_current',
+      }],
+      events: [],
+    })
+
+    onEvent({
+      event: 'run.completed',
+      session_id: 'session-1',
+      parsed_content: 'final answer',
+      output: '',
+      run_id: 'run-reconnect-current-parsed-content',
+    })
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(300)
+
+    const assistantMessages = store.activeSession?.messages.filter((message: Message) => message.role === 'assistant') ?? []
+    expect(assistantMessages).toHaveLength(1)
+    expect(assistantMessages[0]).toEqual(expect.objectContaining({
+      id: 'current-a1',
+      content: 'final answer',
+      isStreaming: false,
+    }))
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    const autoPlayEvent = dispatchSpy.mock.calls[0][0] as CustomEvent<{ messageId: string; content: string }>
+    expect(autoPlayEvent.type).toBe('auto-play-speech')
+    expect(autoPlayEvent.detail.content).toBe('final answer')
+    expect(autoPlayEvent.detail.messageId).toBe('current-a1')
+    vi.useRealTimers()
+  })
+
+  it('does not auto-play resumed assistant history again on blank completion after reconnect', async () => {
+    vi.useFakeTimers()
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+    const store = useChatStore()
+    const session = makeSession('session-1')
+    session.messages = [{
+      id: 'old-a1',
+      role: 'assistant',
+      content: 'previous answer',
+      timestamp: Date.now(),
+      isStreaming: false,
+    } as any]
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+    store.setAutoPlaySpeech(true)
+
+    await store.sendMessage('resume run')
+
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: any) => void
+    const reconnectOptions = chatApi.startRunViaSocket.mock.calls[0][5] as { onReconnectResume: (data: any) => void }
+
+    reconnectOptions.onReconnectResume({
+      session_id: 'session-1',
+      isWorking: true,
+      messages: [{
+        id: 'old-a1',
+        role: 'assistant',
+        content: 'previous answer',
+        timestamp: Date.now() / 1000,
+        finish_reason: 'stop',
+      }],
+      events: [],
+    })
+
+    onEvent({
+      event: 'run.completed',
+      session_id: 'session-1',
+      parsed_content: '',
+      output: '',
+      run_id: 'run-reconnect-blank',
+    })
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(store.activeSession?.messages.find((message: Message) => message.id === 'old-a1')?.content).toBe('previous answer')
+    expect(dispatchSpy).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it('preserves resumed assistant history when parsed_content arrives after reconnect and auto-plays the new row', async () => {
+    vi.useFakeTimers()
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+    const store = useChatStore()
+    const session = makeSession('session-1')
+    session.messages = [{
+      id: 'old-a1',
+      role: 'assistant',
+      content: 'previous answer',
+      timestamp: Date.now(),
+      isStreaming: false,
+    } as any]
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+    store.setAutoPlaySpeech(true)
+
+    await store.sendMessage('resume run')
+
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: any) => void
+    const reconnectOptions = chatApi.startRunViaSocket.mock.calls[0][5] as { onReconnectResume: (data: any) => void }
+
+    reconnectOptions.onReconnectResume({
+      session_id: 'session-1',
+      isWorking: true,
+      messages: [{
+        id: 'old-a1',
+        role: 'assistant',
+        content: 'previous answer',
+        timestamp: Date.now() / 1000,
+      }],
+      events: [],
+    })
+
+    onEvent({
+      event: 'run.completed',
+      session_id: 'session-1',
+      parsed_content: 'final answer',
+      output: '',
+      run_id: 'run-reconnect-historical-parsed-content',
+    })
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(300)
+
+    const assistantMessages = store.activeSession?.messages.filter((message: Message) => message.role === 'assistant') ?? []
+    expect(assistantMessages).toHaveLength(2)
+    expect(assistantMessages[0]).toEqual(expect.objectContaining({
+      id: 'old-a1',
+      content: 'previous answer',
+    }))
+    expect(assistantMessages[1]).toEqual(expect.objectContaining({
+      content: 'final answer',
+    }))
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    const autoPlayEvent = dispatchSpy.mock.calls[0][0] as CustomEvent<{ messageId: string; content: string }>
+    expect(autoPlayEvent.type).toBe('auto-play-speech')
+    expect(autoPlayEvent.detail.content).toBe('final answer')
+    expect(autoPlayEvent.detail.messageId).toBe(assistantMessages[1]?.id)
+    expect(autoPlayEvent.detail.messageId).not.toBe('old-a1')
+    vi.useRealTimers()
+  })
+
+  it('still auto-plays genuinely new assistant text after reconnect resume', async () => {
+    vi.useFakeTimers()
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+    const store = useChatStore()
+    const session = makeSession('session-1')
+    session.messages = [{
+      id: 'old-a1',
+      role: 'assistant',
+      content: 'previous answer',
+      timestamp: Date.now(),
+      isStreaming: false,
+    } as any]
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+    store.setAutoPlaySpeech(true)
+
+    await store.sendMessage('resume run')
+
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: any) => void
+    const reconnectOptions = chatApi.startRunViaSocket.mock.calls[0][5] as { onReconnectResume: (data: any) => void }
+
+    reconnectOptions.onReconnectResume({
+      session_id: 'session-1',
+      isWorking: true,
+      messages: [{
+        id: 'old-a1',
+        role: 'assistant',
+        content: 'previous answer',
+        timestamp: Date.now() / 1000,
+        finish_reason: 'stop',
+      }],
+      events: [],
+    })
+
+    onEvent({
+      event: 'run.completed',
+      session_id: 'session-1',
+      output: 'new answer',
+      run_id: 'run-reconnect-new-output',
+    })
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    const autoPlayEvent = dispatchSpy.mock.calls[0][0] as CustomEvent<{ messageId: string; content: string }>
+    expect(autoPlayEvent.type).toBe('auto-play-speech')
+    expect(autoPlayEvent.detail.content).toBe('new answer')
+    expect(autoPlayEvent.detail.messageId).not.toBe('old-a1')
+    vi.useRealTimers()
+  })
+
+  it('does not auto-play an older assistant message when a run only emits tool output', async () => {
+    vi.useFakeTimers()
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+    const store = useChatStore()
+    store.sessions = [makeSession('session-1')]
+    await store.switchSession('session-1')
+    store.setAutoPlaySpeech(true)
+    store.activeSession!.messages = [{
+      id: 'old-a1',
+      role: 'assistant',
+      content: 'previous answer',
+      timestamp: Date.now(),
+      isStreaming: false,
+    } as any]
+
+    handlers.onToolStarted({ event: 'tool.started', tool: 'search', tool_call_id: 'tool-1', run_id: 'run-3' })
+    handlers.onToolCompleted({ event: 'tool.completed', tool_call_id: 'tool-1', output: { ok: true }, run_id: 'run-3' })
+    handlers.onRunCompleted({ event: 'run.completed', parsed_content: '', output: '', run_id: 'run-3' })
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(dispatchSpy).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it('auto-plays only the new assistant message when the current run produces one', async () => {
+    vi.useFakeTimers()
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+    const store = useChatStore()
+    store.sessions = [makeSession('session-1')]
+    await store.switchSession('session-1')
+    store.setAutoPlaySpeech(true)
+    store.activeSession!.messages = [{
+      id: 'old-a1',
+      role: 'assistant',
+      content: 'previous answer',
+      timestamp: Date.now(),
+      isStreaming: false,
+    } as any]
+
+    handlers.onMessageDelta({ event: 'message.delta', delta: 'new answer', run_id: 'run-4' })
+    handlers.onRunCompleted({ event: 'run.completed', parsed_content: 'new answer', output: '', run_id: 'run-4' })
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    const autoPlayEvent = dispatchSpy.mock.calls[0][0] as CustomEvent<{ messageId: string; content: string }>
+    expect(autoPlayEvent.type).toBe('auto-play-speech')
+    expect(autoPlayEvent.detail.content).toBe('new answer')
+    expect(autoPlayEvent.detail.messageId).not.toBe('old-a1')
+    vi.useRealTimers()
   })
 
   it('preserves non-string tool.completed outputs in live session handlers', async () => {
@@ -163,7 +624,7 @@ describe('chat store compression state', () => {
     handlers.onToolCompleted({ event: 'tool.completed', tool_call_id: 'call-1', output: { ok: true }, run_id: 'run-1' })
     await nextTick()
 
-    const tool = store.activeSession?.messages.find(message => message.id === 'tool-1')
+    const tool = store.activeSession?.messages.find((message: Message) => message.id === 'tool-1')
     expect(tool?.toolStatus).toBe('done')
     expect(tool?.toolResult).toEqual({ ok: true })
   })

--- a/tests/client/use-speech-tts.test.ts
+++ b/tests/client/use-speech-tts.test.ts
@@ -272,6 +272,31 @@ describe('client TTS unified synthesize flow', () => {
     await pending.catch(() => undefined)
   })
 
+  it('stop(true) clears queued playback and stops the active TTS audio', async () => {
+    mockFetch.mockResolvedValue(new Response(new Blob(['audio'], { type: 'audio/mpeg' }), {
+      status: 200,
+      headers: { 'X-TTS-Engine': 'edge' },
+    }))
+
+    const { useSpeech } = await import('../../packages/client/src/composables/useSpeech')
+    const speech = useSpeech()
+
+    speech.enqueue('msg-1', 'First queued response')
+    await flushPromises()
+    const [firstAudio] = audioInstances
+
+    speech.enqueue('msg-2', 'Second queued response')
+    speech.stop(true)
+    firstAudio.onended?.()
+    await flushPromises()
+
+    expect(firstAudio.pause).toHaveBeenCalledOnce()
+    expect(firstAudio.src).toBe('')
+    expect(audioInstances).toHaveLength(1)
+    expect(speech.currentMessageId.value).toBe(null)
+    expect(speech.isPlaying.value).toBe(false)
+  })
+
   it('handles AbortError silently without console.error and clears custom state', async () => {
     const abortError = Object.assign(new Error('aborted'), { name: 'AbortError' })
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -303,7 +328,7 @@ describe('client TTS unified synthesize flow', () => {
     })
     await flushPromises()
 
-    expect(consoleError).toHaveBeenCalledWith('[useSpeech] OpenAI TTS 请求失败:', expect.any(Error))
+    expect(consoleError).not.toHaveBeenCalled()
     expect(speech.isCustomPlaying.value).toBe(false)
     expect(speech.isCustomPaused.value).toBe(false)
     expect(speech.currentCustomMessageId.value).toBe(null)

--- a/tests/server/run-chat-message-format.test.ts
+++ b/tests/server/run-chat-message-format.test.ts
@@ -56,6 +56,27 @@ describe('run-chat message formatting', () => {
     ])
   })
 
+  it('preserves assistant finish reason and run marker when resuming from database messages', () => {
+    const messages: SessionMessage[] = [
+      {
+        id: 1,
+        session_id: 's1',
+        role: 'assistant',
+        content: 'partial answer',
+        timestamp: 1,
+        finish_reason: null,
+        runMarker: 'cli_run_current',
+      },
+    ]
+
+    expect(handleMessage(messages, 's1')[0]).toEqual(expect.objectContaining({
+      role: 'assistant',
+      content: 'partial answer',
+      finish_reason: null,
+      runMarker: 'cli_run_current',
+    }))
+  })
+
   it('treats assistant tool-call messages as sendable even with empty text', () => {
     expect(isAssistantMessageSendable({
       content: '',


### PR DESCRIPTION
## Summary

加强 assistant TTS playback 在 streaming、reconnect、resumed run 场景下的安全性。

- 在可用时通过 chat message mapping 保留 finish reason 与 run marker。
- 只在当前 run 产出 assistant content 后触发 autoplay。
- 为 resumed in-flight run 恢复 active assistant/reasoning 状态。
- 避免 reconnect 后把已完成的历史输出当作新的音频再次播放。
- 新增 chat-chain fragment 记录 playback resume 行为。

## Stack

这是 5 个 stacked PR 中的第 3 个，请按以下顺序 review/merge：

1. #1396 — STT provider 基础设施
2. #1397 — 可编辑聊天语音输入
3. #1398 — TTS playback resume 安全性
4. #1399 — voice provider settings cards
5. #1400 — voice provider model discovery flow

当前 PR: #1398 — TTS playback resume 安全性
当前 PR branch: `voice/tts-playback-resume`
当前 PR base: `voice/chat-voice-input`
## Verification

- `npm test -- --run tests/client/use-speech-tts.test.ts tests/client/chat-store-compression-state.test.ts tests/server/run-chat-message-format.test.ts`
- `npm run harness:check`

Result: passed (35 targeted tests passed; harness check passed).
