### PR TITLE
添加 voice provider settings cards

### DIFF
--- a/packages/client/src/api/hermes/tts-settings.ts
+++ b/packages/client/src/api/hermes/tts-settings.ts
@@ -1,0 +1,109 @@
+import { request } from '../client'
+import type { TtsProviderId } from './tts'
+
+export type StoredTtsProvider = TtsProviderId
+
+export interface TtsStoredSettings {
+  baseUrl?: string
+  baseUrlPresets?: string[]
+  model?: string
+  voice?: string
+  rate?: string
+  pitch?: string
+  authMode?: string
+  voiceMode?: string
+  voiceDesignDesc?: string
+  voiceCloneFormat?: string
+  stylePrompt?: string
+}
+
+export interface TtsStoredSecretsInput {
+  apiKey?: string
+}
+
+export interface TtsStoredSecretsResponse {
+  apiKey?: '[stored]'
+}
+
+export interface TtsProviderSettingsResponse {
+  provider: StoredTtsProvider
+  settings: TtsStoredSettings
+  secrets: TtsStoredSecretsResponse
+  createdAt?: number
+  updatedAt: number
+}
+
+export interface FetchTtsSettingsResponse {
+  providers: TtsProviderSettingsResponse[]
+}
+
+function normalizeProviders(body: unknown): FetchTtsSettingsResponse {
+  if (body && typeof body === 'object') {
+    const payload = body as { providers?: unknown; settings?: unknown }
+    if (Array.isArray(payload.providers)) {
+      return { providers: payload.providers as TtsProviderSettingsResponse[] }
+    }
+    if (Array.isArray(payload.settings)) {
+      return { providers: payload.settings as TtsProviderSettingsResponse[] }
+    }
+  }
+  return { providers: [] }
+}
+
+export async function fetchTtsSettings(): Promise<FetchTtsSettingsResponse> {
+  const body = await request<{ providers?: TtsProviderSettingsResponse[]; settings?: TtsProviderSettingsResponse[] }>(
+    '/api/hermes/tts/settings',
+  )
+  return normalizeProviders(body)
+}
+
+export async function saveTtsSettings(
+  provider: StoredTtsProvider,
+  payload: { settings?: TtsStoredSettings; secrets?: TtsStoredSecretsInput },
+): Promise<TtsProviderSettingsResponse> {
+  const body = await request<TtsProviderSettingsResponse | { setting: TtsProviderSettingsResponse }>(
+    `/api/hermes/tts/settings/${provider}`,
+    {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    },
+  )
+  return typeof body === 'object' && body !== null && 'setting' in body ? body.setting : body
+}
+
+export async function clearTtsSecret(
+  provider: StoredTtsProvider,
+  secretName: keyof TtsStoredSecretsInput,
+): Promise<TtsProviderSettingsResponse | null> {
+  const body = await request<
+    TtsProviderSettingsResponse |
+    { setting: TtsProviderSettingsResponse | null } |
+    { success?: boolean; setting: TtsProviderSettingsResponse | null }
+  >(
+    `/api/hermes/tts/settings/${provider}/secret/${secretName}`,
+    { method: 'DELETE' },
+  )
+
+  if (body && typeof body === 'object' && 'setting' in body) {
+    return body.setting ?? null
+  }
+  return body as TtsProviderSettingsResponse
+}
+
+export async function deleteTtsBaseUrlPreset(
+  provider: StoredTtsProvider,
+  url: string,
+): Promise<TtsProviderSettingsResponse | null> {
+  const body = await request<
+    { success?: boolean; setting: TtsProviderSettingsResponse | null } |
+    TtsProviderSettingsResponse
+  >(
+    `/api/hermes/tts/settings/${provider}/base-url-preset?url=${encodeURIComponent(url)}`,
+    { method: 'DELETE' },
+  )
+
+  if (body && typeof body === 'object' && 'setting' in body) {
+    return body.setting ?? null
+  }
+  return body as TtsProviderSettingsResponse
+}

--- a/packages/client/src/components/hermes/settings/VoiceSettings.vue
+++ b/packages/client/src/components/hermes/settings/VoiceSettings.vue
@@ -1,659 +1,432 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
-import { NSelect, NInput, NButton, NSlider } from 'naive-ui'
+import { computed, onMounted, ref } from 'vue'
+import { NButton, NInput, NSelect, useMessage } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
-import { useVoiceSettings } from '@/composables/useVoiceSettings'
-import { useSpeech } from '@/composables/useSpeech'
-import { speedToEdgeRate, hzToEdgePitch } from '@/utils/ttsHelpers'
-import SettingRow from './SettingRow.vue'
+import { useSpeech, type MimoTtsOptions, type OpenaiTtsOptions } from '@/composables/useSpeech'
+import { useMicRecorder } from '@/composables/useMicRecorder'
+import { transcribeSpeech } from '@/api/hermes/stt'
+import { useVoiceApiConnections } from '@/composables/useVoiceApiConnections'
+import VoiceApiCard, { type VoiceApiCardTestState } from './voice/VoiceApiCard.vue'
+import VoiceApiFormModal from './voice/VoiceApiFormModal.vue'
+import VoiceApiConfigurator from './voice/VoiceApiConfigurator.vue'
+import type { VoiceApiConnection, VoiceApiKind, VoiceApiProvider, VoiceApiSavePayload } from '@/types/voice-api'
+import type { StoredSttProvider } from '@/api/hermes/stt-settings'
+
+interface VoiceApiFormSavedPayload extends VoiceApiSavePayload {
+  preset: {
+    provider: VoiceApiProvider
+  }
+}
 
 const { t } = useI18n()
-const vs = useVoiceSettings()
+const message = useMessage()
 const speech = useSpeech()
+const voiceApi = useVoiceApiConnections()
 
 const testText = ref(t('settings.voice.testTextDefault'))
-const testPlaying = ref(false)
-const mimoCloneAudioInput = ref<HTMLInputElement | null>(null)
-const MIMO_CLONE_AUDIO_MAX_BYTES = 10 * 1024 * 1024
-const MIMO_CLONE_AUDIO_ACCEPT = 'audio/mpeg,audio/mp3,audio/wav,.mp3,.wav'
+const showAddModal = ref(false)
+const addModalKind = ref<VoiceApiKind>('tts')
+const showConfigurator = ref(false)
+const editingConnection = ref<VoiceApiConnection | null>(null)
+const sttRecorder = useMicRecorder({ maxDurationMs: 30_000 })
+const cardTestStates = ref<Record<string, VoiceApiCardTestState>>({})
 
-const providerOptions = [
-  { label: t('settings.voice.providerWebSpeech'), value: 'webspeech' },
-  { label: t('settings.voice.providerOpenai'), value: 'openai' },
-  { label: t('settings.voice.providerCustom'), value: 'custom' },
-  { label: t('settings.voice.providerEdge'), value: 'edge' },
-  { label: t('settings.voice.providerMimo'), value: 'mimo' },
-]
+const activeTtsDescription = computed(() => voiceApi.activeTtsConnection.value?.label || t('settings.voice.noneSelected'))
+const activeSttDescription = computed(() => voiceApi.activeSttConnection.value?.label || t('settings.voice.noneSelected'))
 
-const openaiModelOptions = [
-  { label: 'tts-1', value: 'tts-1' },
-  { label: 'tts-1-hd', value: 'tts-1-hd' },
-]
-
-const openaiVoiceOptions = [
-  { label: 'Alloy', value: 'alloy' },
-  { label: 'Echo', value: 'echo' },
-  { label: 'Fable', value: 'fable' },
-  { label: 'Nova', value: 'nova' },
-  { label: 'Onyx', value: 'onyx' },
-  { label: 'Shimmer', value: 'shimmer' },
-]
-
-const edgeVoiceOptions = [
-  { label: '晓晓 (zh-CN-XiaoxiaoNeural)', value: 'zh-CN-XiaoxiaoNeural' },
-  { label: '晓萱 (zh-CN-XiaoxuanNeural)', value: 'zh-CN-XiaoxuanNeural' },
-  { label: '云希 (zh-CN-YunxiNeural)', value: 'zh-CN-YunxiNeural' },
-  { label: '云健 (zh-CN-YunjianNeural)', value: 'zh-CN-YunjianNeural' },
-  { label: '云扬 (zh-CN-YunyangNeural)', value: 'zh-CN-YunyangNeural' },
-  { label: '小晨 (zh-TW-HsiaoChenNeural)', value: 'zh-TW-HsiaoChenNeural' },
-  { label: '小宇 (zh-TW-HsiaoYuNeural)', value: 'zh-TW-HsiaoYuNeural' },
-  { label: '云哲 (zh-TW-YunJheNeural)', value: 'zh-TW-YunJheNeural' },
-  { label: '希雅 (zh-HK-HiuGaaiNeural)', value: 'zh-HK-HiuGaaiNeural' },
-  { label: '希文 (zh-HK-HiuMaanNeural)', value: 'zh-HK-HiuMaanNeural' },
-  { label: '文龙 (zh-HK-WanLungNeural)', value: 'zh-HK-WanLungNeural' },
-  { label: 'Jenny (en-US-JennyNeural)', value: 'en-US-JennyNeural' },
-  { label: 'Aria (en-US-AriaNeural)', value: 'en-US-AriaNeural' },
-  { label: 'Guy (en-US-GuyNeural)', value: 'en-US-GuyNeural' },
-  { label: 'Sonia (en-GB-SoniaNeural)', value: 'en-GB-SoniaNeural' },
-  { label: 'Ryan (en-GB-RyanNeural)', value: 'en-GB-RyanNeural' },
-  { label: 'Nanami (ja-JP-NanamiNeural)', value: 'ja-JP-NanamiNeural' },
-  { label: 'Keita (ja-JP-KeitaNeural)', value: 'ja-JP-KeitaNeural' },
-  { label: 'Sun-Hi (ko-KR-SunHiNeural)', value: 'ko-KR-SunHiNeural' },
-  { label: 'InJoon (ko-KR-InJoonNeural)', value: 'ko-KR-InJoonNeural' },
-  { label: 'Denise (fr-FR-DeniseNeural)', value: 'fr-FR-DeniseNeural' },
-  { label: 'Henri (fr-FR-HenriNeural)', value: 'fr-FR-HenriNeural' },
-  { label: 'Katja (de-DE-KatjaNeural)', value: 'de-DE-KatjaNeural' },
-  { label: 'Conrad (de-DE-ConradNeural)', value: 'de-DE-ConradNeural' },
-]
-
-// Get WebSpeech voices list on mount
-const webspeechVoices = ref<SpeechSynthesisVoice[]>([])
-onMounted(() => {
-  if ('speechSynthesis' in window) {
-    const voices = window.speechSynthesis.getVoices()
-    if (voices.length) {
-      webspeechVoices.value = voices
-    }
-    window.speechSynthesis.onvoiceschanged = () => {
-      webspeechVoices.value = window.speechSynthesis.getVoices()
-    }
-  }
+onMounted(async () => {
+  await voiceApi.refresh()
 })
 
-// ── MiMo TTS options ──
-const mimoBaseUrlOptions = [
-  { label: 'https://api.xiaomimimo.com/v1', value: 'https://api.xiaomimimo.com/v1' },
-  { label: 'https://token-plan-cn.xiaomimimo.com/v1', value: 'https://token-plan-cn.xiaomimimo.com/v1' },
-]
-
-const mimoAuthModeOptions = [
-  { label: t('settings.voice.mimoAuthModeBearer'), value: 'bearer' },
-  { label: t('settings.voice.mimoAuthModeApiKey'), value: 'api-key' },
-  { label: t('settings.voice.mimoAuthModeBoth'), value: 'both' },
-]
-
-const mimoModelOptions = [
-  { label: t('settings.voice.mimoModelPreset'), value: 'mimo-v2.5-tts' },
-  { label: t('settings.voice.mimoModelVoiceDesign'), value: 'mimo-v2.5-tts-voicedesign' },
-  { label: t('settings.voice.mimoModelVoiceClone'), value: 'mimo-v2.5-tts-voiceclone' },
-]
-
-const mimoVoiceOptions = [
-  { label: '冰糖 (中文·女)', value: '冰糖' },
-  { label: '茉莉 (中文·女)', value: '茉莉' },
-  { label: '苏打 (中文·男)', value: '苏打' },
-  { label: '白桦 (中文·男)', value: '白桦' },
-  { label: 'Mia (English·Female)', value: 'Mia' },
-  { label: 'Chloe (English·Female)', value: 'Chloe' },
-  { label: 'Milo (English·Male)', value: 'Milo' },
-  { label: 'Dean (English·Male)', value: 'Dean' },
-]
-
-function getMimoVoiceMode(): 'preset' | 'voiceDesign' | 'voiceClone' {
-  if (vs.mimoModel.value === 'mimo-v2.5-tts-voicedesign') return 'voiceDesign'
-  if (vs.mimoModel.value === 'mimo-v2.5-tts-voiceclone') return 'voiceClone'
-  return 'preset'
+function openAddModal(kind: VoiceApiKind) {
+  addModalKind.value = kind
+  showAddModal.value = true
 }
 
-function buildMimoTtsOptions() {
-  const voiceMode = getMimoVoiceMode()
-  return {
-    baseUrl: vs.mimoBaseUrl.value,
-    apiKey: vs.mimoApiKey.value,
-    authMode: vs.mimoAuthMode.value,
-    model: vs.mimoModel.value,
-    voiceMode,
-    voice: voiceMode === 'preset' ? vs.mimoVoice.value : undefined,
-    voiceDesignDesc: voiceMode === 'voiceDesign' ? vs.mimoVoiceDesignDesc.value || undefined : undefined,
-    voiceCloneDataUri: voiceMode === 'voiceClone' ? vs.mimoVoiceCloneDataUri.value || undefined : undefined,
-    voiceCloneFormat: voiceMode === 'voiceClone' ? vs.mimoVoiceCloneFormat.value : undefined,
-    stylePrompt: vs.mimoStylePrompt.value || undefined,
+function setCardTestState(id: string, status: VoiceApiCardTestState['status'], messageText?: string) {
+  cardTestStates.value = {
+    ...cardTestStates.value,
+    [id]: { status, message: messageText },
   }
 }
 
-function inferCloneAudioFormat(file: File): 'mp3' | 'wav' {
-  const name = file.name.toLowerCase()
-  if (file.type.includes('mpeg') || file.type.includes('mp3') || name.endsWith('.mp3')) return 'mp3'
-  return 'wav'
-}
-
-function readFileAsDataUri(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => resolve(String(reader.result || ''))
-    reader.onerror = () => reject(reader.error || new Error('Failed to read audio file'))
-    reader.readAsDataURL(file)
-  })
-}
-
-async function handleMimoCloneAudioChange(event: Event) {
-  const input = event.target as HTMLInputElement
-  const file = input.files?.[0]
-  if (!file) return
-
-  const lowerName = file.name.toLowerCase()
-  const validType = file.type === 'audio/wav'
-    || file.type === 'audio/mpeg'
-    || file.type === 'audio/mp3'
-    || lowerName.endsWith('.wav')
-    || lowerName.endsWith('.mp3')
-  if (!validType) {
-    console.warn('[VoiceSettings] MiMo clone audio must be mp3 or wav')
-    input.value = ''
-    return
-  }
-  if (file.size > MIMO_CLONE_AUDIO_MAX_BYTES) {
-    console.warn('[VoiceSettings] MiMo clone audio is too large')
-    input.value = ''
-    return
-  }
-
-  const dataUri = await readFileAsDataUri(file)
-  vs.setMimoVoiceCloneDataUri(dataUri)
-  vs.setMimoVoiceCloneFileName(file.name)
-  vs.setMimoVoiceCloneFormat(inferCloneAudioFormat(file))
-}
-
-function clearMimoCloneAudio() {
-  vs.setMimoVoiceCloneDataUri('')
-  vs.setMimoVoiceCloneFileName('')
-  vs.setMimoVoiceCloneFormat('wav')
-  if (mimoCloneAudioInput.value) mimoCloneAudioInput.value.value = ''
-}
-
-async function handleTest() {
-  const text = testText.value.trim()
-  if (!text) return
-  testPlaying.value = true
-  try {
-    if (vs.provider.value === 'webspeech') {
-      speech.stop(false)
-      speech.speakViaBrowser('__test__', text, {
-        voiceName: vs.webspeechVoice.value || undefined,
-      })
-    } else if (vs.provider.value === 'openai') {
-      if (!vs.openaiBaseUrl.value) {
-        console.warn('[VoiceSettings] OpenAI base URL empty')
-        return
-      }
-      await speech.openaiPlay('__test__', text, {
-        provider: 'openai',
-        baseUrl: vs.openaiBaseUrl.value,
-        apiKey: vs.openaiApiKey.value || undefined,
-        model: vs.openaiModel.value,
-        voice: vs.openaiVoice.value,
-      })
-    } else if (vs.provider.value === 'custom') {
-      if (!vs.customUrl.value) {
-        console.warn('[VoiceSettings] Custom URL empty')
-        return
-      }
-      await speech.openaiPlay('__test__', text, {
-        provider: 'custom',
-        baseUrl: vs.customUrl.value,
-        apiKey: vs.customApiKey.value || undefined,
-      })
-    } else if (vs.provider.value === 'edge') {
-      await speech.openaiPlay('__test__', text, {
-        provider: 'edge',
-        baseUrl: '/api/tts/proxy',
-        voice: vs.edgeVoice.value,
-        rate: speedToEdgeRate(vs.edgeRate.value),
-        pitch: hzToEdgePitch(vs.edgePitchHz.value),
-      })
-    } else if (vs.provider.value === 'mimo') {
-      if (!vs.mimoApiKey.value) {
-        console.warn('[VoiceSettings] MiMo API Key empty')
-        return
-      }
-      await speech.mimoPlay('__test__', text, buildMimoTtsOptions())
+function clearOtherRecordingStates(id: string) {
+  const next = { ...cardTestStates.value }
+  for (const [key, value] of Object.entries(next)) {
+    if (key !== id && value.status === 'recording') {
+      next[key] = { status: 'idle' }
     }
-  } catch (err) {
-    console.error('[VoiceSettings] Test failed:', err)
-  } finally {
-    testPlaying.value = false
   }
+  cardTestStates.value = next
+}
+
+async function handleAddSaved(data: VoiceApiFormSavedPayload) {
+  try {
+    await voiceApi.saveConnection(addModalKind.value, data.preset.provider, {
+      settings: data.settings,
+      secrets: data.secrets,
+    })
+    showAddModal.value = false
+    message.success(t('settings.voice.ttsSaved'))
+  } catch (err) {
+    message.error(err instanceof Error ? err.message : t('settings.voice.ttsSaveFailed'))
+  }
+}
+
+function openConfigurator(conn: VoiceApiConnection) {
+  editingConnection.value = conn
+  showConfigurator.value = true
+}
+
+async function handleConfigSave(conn: VoiceApiConnection, payload: VoiceApiSavePayload) {
+  try {
+    await voiceApi.saveConnection(conn.kind, conn.provider, payload)
+    showConfigurator.value = false
+    message.success(t('settings.voice.ttsSaved'))
+  } catch (err) {
+    message.error(err instanceof Error ? err.message : t('settings.voice.ttsSaveFailed'))
+  }
+}
+
+async function handleRemove(conn: VoiceApiConnection) {
+  try {
+    await voiceApi.deleteSecret(conn.kind, conn.provider)
+    setCardTestState(conn.id, 'idle')
+    message.success(t('settings.voice.ttsCleared'))
+  } catch (err) {
+    message.error(err instanceof Error ? err.message : t('settings.voice.ttsClearFailed'))
+  }
+}
+
+async function handleSetActive(conn: VoiceApiConnection) {
+  await voiceApi.setActiveConnection(conn.kind, conn.id)
+}
+
+async function handleActiveTtsUpdate(id: string) {
+  await voiceApi.setActiveConnection('tts', id)
+}
+
+async function handleActiveSttUpdate(id: string) {
+  await voiceApi.setActiveConnection('stt', id)
+}
+
+function ttsOptionsFor(connection: VoiceApiConnection): Record<string, unknown> {
+  return {
+    ...connection.settings,
+    baseUrl: connection.baseUrl || connection.settings.baseUrl,
+    model: connection.model || connection.settings.model,
+    voice: connection.voice || connection.settings.voice,
+  }
+}
+
+function openaiOptionsFor(connection: VoiceApiConnection): OpenaiTtsOptions {
+  const options = ttsOptionsFor(connection)
+  const provider = connection.provider === 'edge' || connection.provider === 'openai' || connection.provider === 'custom'
+    ? connection.provider
+    : undefined
+  return {
+    baseUrl: String(options.baseUrl || ''),
+    model: typeof options.model === 'string' ? options.model : undefined,
+    voice: typeof options.voice === 'string' ? options.voice : undefined,
+    rate: typeof options.rate === 'string' ? options.rate : undefined,
+    pitch: typeof options.pitch === 'string' ? options.pitch : undefined,
+    provider,
+  }
+}
+
+function mimoOptionsFor(connection: VoiceApiConnection): MimoTtsOptions {
+  const options = ttsOptionsFor(connection)
+  return {
+    baseUrl: String(options.baseUrl || 'https://api.xiaomimimo.com/v1'),
+    model: String(options.model || 'mimo-v2.5-tts'),
+    voice: typeof options.voice === 'string' ? options.voice : undefined,
+    authMode: options.authMode === 'api-key' || options.authMode === 'bearer' || options.authMode === 'both' ? options.authMode : undefined,
+    voiceMode: options.voiceMode === 'preset' || options.voiceMode === 'voiceDesign' || options.voiceMode === 'voiceClone' ? options.voiceMode : undefined,
+    voiceDesignDesc: typeof options.voiceDesignDesc === 'string' ? options.voiceDesignDesc : undefined,
+    voiceCloneDataUri: typeof options.voiceCloneDataUri === 'string' ? options.voiceCloneDataUri : undefined,
+    voiceCloneFormat: options.voiceCloneFormat === 'mp3' || options.voiceCloneFormat === 'wav' ? options.voiceCloneFormat : undefined,
+    stylePrompt: typeof options.stylePrompt === 'string' ? options.stylePrompt : undefined,
+  }
+}
+
+async function handleTtsTest(connection: VoiceApiConnection) {
+  const text = testText.value.trim()
+  if (!text) {
+    setCardTestState(connection.id, 'error', t('settings.voice.testTextRequired'))
+    return
+  }
+
+  if (!connection.isBuiltin && !connection.hasSecret) {
+    setCardTestState(connection.id, 'error', t('settings.voice.keyMissingForTest'))
+    return
+  }
+
+  setCardTestState(connection.id, 'loading', t('settings.voice.testing'))
+  try {
+    if (connection.provider === 'mimo') {
+      await speech.mimoPlay(connection.id, text, mimoOptionsFor(connection))
+    } else if (connection.provider === 'edge' || connection.provider === 'openai' || connection.provider === 'custom') {
+      await speech.openaiPlay(connection.id, text, openaiOptionsFor(connection))
+    }
+    setCardTestState(connection.id, 'success', t('settings.voice.testSuccess'))
+  } catch (err) {
+    setCardTestState(connection.id, 'error', t('settings.voice.testFailed', { error: err instanceof Error ? err.message : String(err) }))
+  }
+}
+
+async function handleSttTest(connection: VoiceApiConnection) {
+  if (connection.provider === 'browser') {
+    setCardTestState(connection.id, 'success', t('settings.voice.browserSttTestHint'))
+    return
+  }
+
+  if (!connection.hasSecret) {
+    setCardTestState(connection.id, 'error', t('settings.voice.keyMissingForTest'))
+    return
+  }
+
+  if (cardTestStates.value[connection.id]?.status === 'recording') {
+    setCardTestState(connection.id, 'loading', t('settings.voice.transcribing'))
+    try {
+      const audio = await sttRecorder.stop()
+      if (!audio.size) {
+        setCardTestState(connection.id, 'error', t('settings.voice.sttEmptyAudio'))
+        return
+      }
+
+      const result = await transcribeSpeech({
+        audio,
+        provider: connection.provider as StoredSttProvider,
+      })
+      setCardTestState(connection.id, 'success', result.text || t('settings.voice.sttTestSuccess'))
+    } catch (err) {
+      setCardTestState(connection.id, 'error', t('settings.voice.sttTestFailed', { error: err instanceof Error ? err.message : String(err) }))
+    }
+    return
+  }
+
+  try {
+    clearOtherRecordingStates(connection.id)
+    await sttRecorder.start()
+    setCardTestState(connection.id, 'recording', t('settings.voice.sttRecordingHint'))
+  } catch (err) {
+    console.error('[VoiceSettings] Failed to start STT card test recording:', err)
+    setCardTestState(connection.id, 'error', t('settings.voice.sttTestFailed', { error: err instanceof Error ? err.message : String(err) }))
+  }
+}
+
+async function handleCardTest(connection: VoiceApiConnection) {
+  if (connection.kind === 'tts') {
+    await handleTtsTest(connection)
+    return
+  }
+  await handleSttTest(connection)
 }
 </script>
 
 <template>
   <div class="voice-settings">
-    <SettingRow
-      :label="t('settings.voice.ttsProvider')"
-      :hint="t('settings.voice.ttsProviderHint')"
-    >
-      <NSelect
-        :value="vs.provider.value"
-        :options="providerOptions"
-        size="small"
-        style="width: 300px"
-        @update:value="vs.setProvider"
-      />
-    </SettingRow>
-
-    <!-- ════ WebSpeech API ════ -->
-    <template v-if="vs.provider.value === 'webspeech'">
-      <SettingRow
-        :label="t('settings.voice.webspeechVoice')"
-        :hint="t('settings.voice.webspeechVoiceHint')"
-      >
-        <NSelect
-          :value="vs.webspeechVoice.value"
-          size="small"
-          filterable
-          style="width: 320px"
-          :placeholder="t('settings.voice.webspeechVoicePlaceholder')"
-          :consistent-menu-width="false"
-          :options="webspeechVoices.map(v => ({
-            label: `${v.name} (${v.lang})`,
-            value: v.name,
-          }))"
-          @update:value="vs.setWebSpeechVoice"
-        />
-      </SettingRow>
-
-    </template>
-
-    <!-- ════ OpenAI TTS ════ -->
-    <template v-if="vs.provider.value === 'openai'">
-      <SettingRow
-        :label="t('settings.voice.openaiKey')"
-        :hint="t('settings.voice.openaiKeyHint')"
-      >
-        <NInput
-          :value="vs.openaiApiKey.value"
-          type="password"
-          size="small"
-          show-password-on="click"
-          style="width: 360px"
-          placeholder="sk-..."
-          @update:value="vs.setOpenaiApiKey"
-        />
-      </SettingRow>
-
-      <SettingRow
-        :label="t('settings.voice.openaiUrl')"
-        :hint="t('settings.voice.openaiUrlHint')"
-      >
-        <NInput
-          :value="vs.openaiBaseUrl.value"
-          size="small"
-          style="width: 360px"
-          placeholder="https://api.openai.com/v1/audio/speech"
-          @update:value="vs.setOpenaiBaseUrl"
-        />
-      </SettingRow>
-
-      <SettingRow
-        :label="t('settings.voice.openaiModel')"
-        :hint="t('settings.voice.openaiModelHint')"
-      >
-        <NSelect
-          :value="vs.openaiModel.value"
-          :options="openaiModelOptions"
-          size="small"
-          style="width: 200px"
-          @update:value="vs.setOpenaiModel"
-        />
-      </SettingRow>
-
-      <SettingRow
-        :label="t('settings.voice.openaiVoice')"
-        :hint="t('settings.voice.openaiVoiceHint')"
-      >
-        <NSelect
-          :value="vs.openaiVoice.value"
-          :options="openaiVoiceOptions"
-          size="small"
-          style="width: 200px"
-          @update:value="vs.setOpenaiVoice"
-        />
-      </SettingRow>
-
-    </template>
-
-    <!-- ════ Custom Endpoint ════ -->
-    <template v-if="vs.provider.value === 'custom'">
-      <div class="provider-hint">
-        {{ t('settings.voice.customHint') }}
-      </div>
-
-      <SettingRow
-        :label="t('settings.voice.customUrl')"
-        :hint="t('settings.voice.customUrlHint')"
-      >
-        <NInput
-          :value="vs.customUrl.value"
-          size="small"
-          style="width: 360px"
-          :placeholder="t('settings.voice.customUrlPlaceholder')"
-          @update:value="vs.setCustomUrl"
-        />
-      </SettingRow>
-
-      <SettingRow
-        :label="t('settings.voice.customApiKey')"
-        :hint="t('settings.voice.customApiKeyHint')"
-      >
-        <NInput
-          :value="vs.customApiKey.value"
-          type="password"
-          size="small"
-          show-password-on="click"
-          style="width: 360px"
-          :placeholder="t('settings.voice.customApiKeyPlaceholder')"
-          @update:value="vs.setCustomApiKey"
-        />
-      </SettingRow>
-
-
-    </template>
-
-    <!-- ════ Edge TTS ════ -->
-    <template v-if="vs.provider.value === 'edge'">
-      <div class="provider-hint">
-        {{ t('settings.voice.edgeHint') }}
-      </div>
-
-<SettingRow
-        :label="t('settings.voice.edgeVoice')"
-        :hint="t('settings.voice.edgeVoiceHint')"
-      >
-        <NSelect
-          :value="vs.edgeVoice.value"
-          :options="edgeVoiceOptions"
-          size="small"
-          filterable
-          style="width: 320px"
-          :consistent-menu-width="false"
-          @update:value="vs.setEdgeVoice"
-        />
-      </SettingRow>
-
-      <SettingRow
-        :label="t('settings.voice.edgeRate')"
-        :hint="t('settings.voice.edgeRateHint')"
-      >
-        <div class="slider-row">
-          <NSlider
-            :value="vs.edgeRate.value"
-            :min="0.5"
-            :max="2.0"
-            :step="0.05"
-            style="width: 200px"
-            @update:value="vs.setEdgeRate"
-          />
-          <span class="slider-value">{{ vs.edgeRate.value.toFixed(2) }}x ({{ speedToEdgeRate(vs.edgeRate.value) }})</span>
+    <section class="settings-section voice-provider-section" aria-labelledby="tts-providers-title">
+      <header class="section-header">
+        <div class="section-copy">
+          <h4 id="tts-providers-title" class="section-title">{{ t('settings.voice.ttsProvidersTitle') }}</h4>
+          <p class="section-desc">{{ t('settings.voice.ttsProvidersDescription') }}</p>
         </div>
-      </SettingRow>
-
-      <SettingRow
-        :label="t('settings.voice.edgePitch')"
-        :hint="t('settings.voice.edgePitchHint')"
-      >
-        <div class="slider-row">
-          <NSlider
-            :value="vs.edgePitchHz.value"
-            :min="-20"
-            :max="20"
-            :step="1"
-            style="width: 200px"
-            @update:value="vs.setEdgePitchHz"
-          />
-          <span class="slider-value">{{ vs.edgePitchHz.value > 0 ? '+' : '' }}{{ vs.edgePitchHz.value }} Hz ({{ hzToEdgePitch(vs.edgePitchHz.value) }})</span>
-        </div>
-      </SettingRow>
-
-    </template>
-
-    <!-- ════ MiMo TTS ════ -->
-    <template v-if="vs.provider.value === 'mimo'">
-      <div class="provider-hint">
-        {{ t('settings.voice.mimoHint') }}
-      </div>
-
-      <SettingRow
-        :label="t('settings.voice.mimoApiKey')"
-        :hint="t('settings.voice.mimoApiKeyHint')"
-      >
-        <NInput
-          :value="vs.mimoApiKey.value"
-          type="password"
-          size="small"
-          show-password-on="click"
-          style="width: 360px"
-          :placeholder="t('settings.voice.mimoApiKeyPlaceholder')"
-          @update:value="vs.setMimoApiKey"
-        />
-      </SettingRow>
-
-      <SettingRow
-        :label="t('settings.voice.mimoAuthMode')"
-        :hint="t('settings.voice.mimoAuthModeHint')"
-      >
-        <NSelect
-          :value="vs.mimoAuthMode.value"
-          :options="mimoAuthModeOptions"
-          size="small"
-          style="width: 240px"
-          @update:value="vs.setMimoAuthMode"
-        />
-      </SettingRow>
-
-      <SettingRow
-        :label="t('settings.voice.mimoBaseUrl')"
-        :hint="t('settings.voice.mimoBaseUrlHint')"
-      >
-        <NSelect
-          :value="vs.mimoBaseUrl.value"
-          :options="mimoBaseUrlOptions"
-          size="small"
-          filterable
-          tag
-          style="width: 360px"
-          @update:value="vs.setMimoBaseUrl"
-        />
-      </SettingRow>
-
-      <SettingRow
-        :label="t('settings.voice.mimoModel')"
-        :hint="t('settings.voice.mimoModelHint')"
-      >
-        <NSelect
-          :value="vs.mimoModel.value"
-          :options="mimoModelOptions"
-          size="small"
-          style="width: 320px"
-          @update:value="vs.setMimoModel"
-        />
-      </SettingRow>
-
-      <!-- Preset voice mode -->
-      <SettingRow
-        v-if="vs.mimoModel.value === 'mimo-v2.5-tts'"
-        :label="t('settings.voice.mimoVoice')"
-        :hint="t('settings.voice.mimoVoiceHint')"
-      >
-        <NSelect
-          :value="vs.mimoVoice.value"
-          :options="mimoVoiceOptions"
-          size="small"
-          style="width: 200px"
-          @update:value="vs.setMimoVoice"
-        />
-      </SettingRow>
-
-      <!-- Voice design mode -->
-      <SettingRow
-        v-if="vs.mimoModel.value === 'mimo-v2.5-tts-voicedesign'"
-        :label="t('settings.voice.mimoVoiceDesignPrompt')"
-        :hint="t('settings.voice.mimoVoiceDesignPromptHint')"
-      >
-        <NInput
-          :value="vs.mimoVoiceDesignDesc.value"
-          type="textarea"
-          size="small"
-          style="width: 360px"
-          :rows="3"
-          :placeholder="t('settings.voice.mimoVoiceDesignPromptPlaceholder')"
-          @update:value="vs.setMimoVoiceDesignDesc"
-        />
-      </SettingRow>
-
-      <!-- Voice clone mode -->
-      <SettingRow
-        v-if="vs.mimoModel.value === 'mimo-v2.5-tts-voiceclone'"
-        :label="t('settings.voice.mimoCloneAudio')"
-        :hint="t('settings.voice.mimoCloneAudioHint')"
-      >
-        <div class="clone-audio-row">
-          <input
-            ref="mimoCloneAudioInput"
-            type="file"
-            :accept="MIMO_CLONE_AUDIO_ACCEPT"
-            class="hidden-file-input"
-            @change="handleMimoCloneAudioChange"
-          />
-          <NButton size="small" @click="mimoCloneAudioInput?.click()">
-            {{ t('settings.voice.mimoCloneAudioUpload') }}
-          </NButton>
-          <span v-if="vs.mimoVoiceCloneFileName.value" class="clone-audio-name">
-            {{ vs.mimoVoiceCloneFileName.value }} · {{ vs.mimoVoiceCloneFormat.value }}
-          </span>
-          <NButton
-            v-if="vs.mimoVoiceCloneDataUri.value"
-            size="small"
-            tertiary
-            @click="clearMimoCloneAudio"
-          >
-            {{ t('settings.voice.mimoCloneAudioClear') }}
+        <div class="section-controls">
+          <div class="active-select">
+            <span class="active-label">{{ t('settings.voice.activeTtsApi') }}</span>
+            <NSelect
+              :value="voiceApi.activeTtsId.value"
+              :options="voiceApi.ttsConnectionOptions.value"
+              size="small"
+              :aria-label="t('settings.voice.activeTtsApi')"
+              @update:value="handleActiveTtsUpdate"
+            />
+            <span class="active-summary">{{ activeTtsDescription }}</span>
+          </div>
+          <NButton size="small" secondary @click="openAddModal('tts')">
+            {{ t('settings.voice.addTtsApi') }}
           </NButton>
         </div>
-      </SettingRow>
+      </header>
 
-      <!-- Style prompt (available for all models) -->
-      <SettingRow
-        :label="t('settings.voice.mimoStylePrompt')"
-        :hint="t('settings.voice.mimoStylePromptHint')"
-      >
-        <NInput
-          :value="vs.mimoStylePrompt.value"
-          type="textarea"
-          size="small"
-          style="width: 360px"
-          :rows="2"
-          :placeholder="t('settings.voice.mimoStylePromptPlaceholder')"
-          @update:value="vs.setMimoStylePrompt"
-        />
-      </SettingRow>
-    </template>
-
-    <!-- ─── Test / Audition ─── -->
-    <div class="test-section">
-      <h4 class="test-title">{{ t('settings.voice.testTitle') }}</h4>
-      <div class="test-row">
+      <div class="test-copy-row">
         <NInput
           v-model:value="testText"
           size="small"
-          style="width: 360px"
           :placeholder="t('settings.voice.testTextPlaceholder')"
-          :disabled="testPlaying"
-          @keyup.enter="handleTest"
+          data-testid="tts-test-text"
         />
-        <NButton
-          size="small"
-          type="primary"
-          :loading="testPlaying"
-          :disabled="testPlaying"
-          @click="handleTest"
-        >
-          {{ testPlaying ? t('settings.voice.testButtonPlaying') : t('settings.voice.testButton') }}
-        </NButton>
       </div>
-    </div>
+
+      <div class="provider-list">
+        <VoiceApiCard
+          v-for="conn in voiceApi.ttsConnections.value"
+          :key="conn.id"
+          :connection="conn"
+          :test-state="cardTestStates[conn.id]"
+          @set-active="handleSetActive"
+          @test="handleCardTest"
+          @edit="openConfigurator"
+          @connect="openConfigurator"
+          @remove="handleRemove"
+        />
+      </div>
+    </section>
+
+    <section class="settings-section voice-provider-section" aria-labelledby="stt-providers-title">
+      <header class="section-header">
+        <div class="section-copy">
+          <h4 id="stt-providers-title" class="section-title">{{ t('settings.voice.sttProvidersTitle') }}</h4>
+          <p class="section-desc">{{ t('settings.voice.sttProvidersDescription') }}</p>
+        </div>
+        <div class="section-controls">
+          <div class="active-select">
+            <span class="active-label">{{ t('settings.voice.activeSttApi') }}</span>
+            <NSelect
+              :value="voiceApi.activeSttId.value"
+              :options="voiceApi.sttConnectionOptions.value"
+              size="small"
+              :aria-label="t('settings.voice.activeSttApi')"
+              @update:value="handleActiveSttUpdate"
+            />
+            <span class="active-summary">{{ activeSttDescription }}</span>
+          </div>
+          <NButton size="small" secondary @click="openAddModal('stt')">
+            {{ t('settings.voice.addSttApi') }}
+          </NButton>
+        </div>
+      </header>
+
+      <div class="provider-list">
+        <VoiceApiCard
+          v-for="conn in voiceApi.sttConnections.value"
+          :key="conn.id"
+          :connection="conn"
+          :test-state="cardTestStates[conn.id]"
+          @set-active="handleSetActive"
+          @test="handleCardTest"
+          @edit="openConfigurator"
+          @connect="openConfigurator"
+          @remove="handleRemove"
+        />
+      </div>
+    </section>
+
+    <VoiceApiFormModal
+      :show="showAddModal"
+      :kind="addModalKind"
+      @close="showAddModal = false"
+      @saved="handleAddSaved"
+    />
+
+    <VoiceApiConfigurator
+      :show="showConfigurator"
+      :connection="editingConnection"
+      @close="showConfigurator = false"
+      @save="handleConfigSave"
+    />
   </div>
 </template>
 
 <style scoped lang="scss">
+@use '@/styles/variables' as *;
+
 .voice-settings {
+  padding: 8px 0;
+}
+
+.settings-section {
+  margin-top: 16px;
+}
+
+.voice-provider-section + .voice-provider-section {
+  margin-top: 28px;
+  padding-top: 20px;
+  border-top: 1px solid $border-color;
+}
+
+.section-header {
   display: flex;
-  flex-direction: column;
-  gap: 16px;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 14px;
 }
 
-.provider-hint {
-  font-size: 12px;
-  color: #888;
-  line-height: 1.5;
-  padding: 0 0 4px 0;
+.section-copy {
+  min-width: 0;
 }
 
-.test-section {
-  padding-top: 16px;
-
-  .test-title {
-    margin: 0 0 8px 0;
-    font-size: 14px;
-    font-weight: 600;
-  }
-
-  .test-row {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-  }
+.section-title {
+  margin: 0 0 6px;
+  color: $text-primary;
+  font-size: 15px;
+  font-weight: 600;
 }
 
-.slider-row {
-  display: flex;
+.section-desc {
+  margin: 0;
+  max-width: 620px;
+  color: $text-muted;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.section-controls {
+  display: grid;
+  grid-template-columns: 220px 112px;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
+  flex-shrink: 0;
+
+  > .n-button {
+    width: 112px;
+  }
 }
 
-.slider-value {
-  font-size: 12px;
-  color: #999;
-  white-space: nowrap;
-  min-width: 120px;
+.active-select {
+  display: grid;
+  gap: 5px;
+  width: 220px;
+  min-width: 0;
 }
 
-.clone-audio-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
+.active-label,
+.active-summary {
+  color: $text-muted;
+  font-size: 11px;
+  line-height: 1.3;
 }
 
-.hidden-file-input {
-  display: none;
-}
-
-.clone-audio-name {
-  max-width: 240px;
+.active-summary {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 12px;
-  color: #888;
+}
+
+.test-copy-row {
+  max-width: 460px;
+  margin-bottom: 10px;
+}
+
+.provider-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+@media (max-width: 860px) {
+  .section-header,
+  .section-controls {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .section-controls > .n-button,
+  .active-select {
+    width: 100%;
+  }
 }
 </style>

--- a/packages/client/src/components/hermes/settings/voice/ProviderMetaItem.vue
+++ b/packages/client/src/components/hermes/settings/voice/ProviderMetaItem.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+defineProps<{
+  label: string
+  value?: string | number | null
+}>()
+</script>
+
+<template>
+  <div class="provider-meta-item">
+    <dt>{{ label }}</dt>
+    <dd :title="String(value || '—')">{{ value || '—' }}</dd>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/variables' as *;
+
+.provider-meta-item {
+  display: grid;
+  grid-template-columns: 68px minmax(0, 1fr);
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+dt {
+  color: $text-muted;
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+dd {
+  min-width: 0;
+  margin: 0;
+  color: $text-secondary;
+  font-size: 12px;
+  line-height: 1.45;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/packages/client/src/components/hermes/settings/voice/VoiceApiCard.vue
+++ b/packages/client/src/components/hermes/settings/voice/VoiceApiCard.vue
@@ -1,0 +1,474 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { NButton, NDropdown, NTag } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import ProviderMetaItem from './ProviderMetaItem.vue'
+import type { VoiceApiConnection } from '@/types/voice-api'
+
+export type VoiceApiCardTestState = {
+  status: 'idle' | 'recording' | 'loading' | 'success' | 'error'
+  message?: string
+}
+
+const props = defineProps<{
+  connection: VoiceApiConnection
+  testState?: VoiceApiCardTestState
+}>()
+
+const emit = defineEmits<{
+  setActive: [connection: VoiceApiConnection]
+  test: [connection: VoiceApiConnection]
+  edit: [connection: VoiceApiConnection]
+  connect: [connection: VoiceApiConnection]
+  remove: [connection: VoiceApiConnection]
+}>()
+
+const { t } = useI18n()
+const showErrorDetails = ref(false)
+
+watch(() => props.testState?.message, () => {
+  showErrorDetails.value = false
+})
+
+const canEdit = computed(() => !(props.connection.kind === 'stt' && props.connection.provider === 'browser'))
+const requiresKey = computed(() => !props.connection.isBuiltin)
+const keyStateLabel = computed(() => {
+  if (!requiresKey.value) return t('settings.voice.builtin')
+  return props.connection.hasSecret ? t('settings.voice.keyStored') : t('settings.voice.keyMissing')
+})
+
+const providerTypeLabel = computed(() => props.connection.isBuiltin
+  ? t('settings.voice.builtin')
+  : t('settings.voice.customApi'))
+
+const statusType = computed(() => {
+  if (props.connection.active) return 'success'
+  if (requiresKey.value && !props.connection.hasSecret) return 'warning'
+  return 'default'
+})
+
+const statusLabel = computed(() => {
+  if (props.connection.active) return t('settings.voice.active')
+  if (requiresKey.value && !props.connection.hasSecret) return t('settings.voice.keyMissing')
+  return t('settings.voice.connected')
+})
+
+const modelValue = computed(() => props.connection.model || String(props.connection.settings.model || ''))
+const voiceValue = computed(() => props.connection.voice || String(props.connection.settings.voice || ''))
+const sourceValue = computed(() => props.connection.baseUrl || (props.connection.isBuiltin ? t('settings.voice.localBuiltin') : ''))
+const lastTestLabel = computed(() => {
+  const status = props.testState?.status
+  if (status === 'success') return t('settings.voice.testSuccess')
+  if (status === 'error') return t('settings.voice.testFailedShort')
+  if (status === 'loading') return t('settings.voice.testing')
+  if (status === 'recording') return t('settings.voice.recording')
+  return t('settings.voice.notTested')
+})
+
+const actionLabel = computed(() => requiresKey.value && !props.connection.hasSecret
+  ? t('settings.voice.connect')
+  : t('common.edit'))
+const testActionLabel = computed(() => props.testState?.status === 'recording'
+  ? t('settings.voice.sttTestStopButton')
+  : t('settings.voice.testAction'))
+
+const metaItems = computed(() => {
+  if (props.connection.kind === 'tts') {
+    return [
+      { key: 'source', label: t('settings.voice.source'), value: sourceValue.value },
+      { key: 'model', label: t('settings.voice.model'), value: modelValue.value },
+      { key: 'voice', label: t('settings.voice.voice'), value: voiceValue.value },
+      { key: 'api-key', label: t('settings.voice.apiKey'), value: keyStateLabel.value },
+    ]
+  }
+  return [
+    { key: 'source', label: t('settings.voice.source'), value: sourceValue.value },
+    { key: 'model', label: t('settings.voice.model'), value: modelValue.value },
+    { key: 'api-key', label: t('settings.voice.apiKey'), value: keyStateLabel.value },
+    { key: 'last-test', label: t('settings.voice.lastTest'), value: lastTestLabel.value },
+  ]
+})
+
+const hasInlineFeedback = computed(() => {
+  const status = props.testState?.status
+  return !!status && status !== 'idle' && status !== 'error'
+})
+
+const hasError = computed(() => props.testState?.status === 'error')
+const rawErrorMessage = computed(() => props.testState?.message || '')
+
+function parseErrorPayload(raw: string): string | null {
+  const jsonStart = raw.indexOf('{')
+  if (jsonStart < 0) return null
+  try {
+    const parsed = JSON.parse(raw.slice(jsonStart)) as { error?: unknown; message?: unknown; detail?: unknown }
+    const candidate = parsed.error || parsed.message || parsed.detail
+    return typeof candidate === 'string' && candidate.trim() ? candidate.trim() : null
+  } catch {
+    return null
+  }
+}
+
+function stripTechnicalPrefix(raw: string): string {
+  return raw
+    .replace(/^API Error\s+\d+\s*:\s*/i, '')
+    .replace(/^Error\s*:\s*/i, '')
+    .trim()
+}
+
+const friendlyErrorMessage = computed(() => {
+  const raw = rawErrorMessage.value.trim()
+  if (!raw) return t('settings.voice.testFailedSummary')
+  const parsed = parseErrorPayload(raw)
+  const candidate = parsed || stripTechnicalPrefix(raw)
+  if (!candidate || candidate.startsWith('{') || candidate.startsWith('[')) {
+    return t('settings.voice.testFailedSummary')
+  }
+  return candidate.length > 180 ? `${candidate.slice(0, 177).trim()}…` : candidate
+})
+
+const showDetailsToggle = computed(() => {
+  const raw = rawErrorMessage.value.trim()
+  return raw.length > 0 && raw !== friendlyErrorMessage.value
+})
+
+const moreOptions = computed(() => [
+  {
+    label: t('settings.voice.remove'),
+    key: 'remove',
+    disabled: !props.connection.hasSecret,
+  },
+])
+
+function handleEditAction() {
+  if (requiresKey.value && !props.connection.hasSecret) {
+    emit('connect', props.connection)
+    return
+  }
+  emit('edit', props.connection)
+}
+
+function handleMoreSelect(key: string | number) {
+  if (key === 'remove' && props.connection.hasSecret) {
+    emit('remove', props.connection)
+  }
+}
+</script>
+
+<template>
+  <article class="voice-api-card" :class="{ active: connection.active }" :data-state="testState?.status || 'idle'">
+    <div class="card-main">
+      <div class="provider-identity">
+        <div class="provider-icon" aria-hidden="true">
+          {{ connection.kind === 'tts' ? 'T' : 'S' }}
+        </div>
+        <div class="provider-copy">
+          <div class="provider-title-row">
+            <h5 class="provider-title" :title="connection.label">{{ connection.label }}</h5>
+            <span class="provider-kind">{{ providerTypeLabel }}</span>
+          </div>
+          <p class="provider-description">
+            {{ connection.kind === 'tts' ? t('settings.voice.ttsCardHint') : t('settings.voice.sttCardHint') }}
+          </p>
+        </div>
+      </div>
+
+      <dl class="provider-meta">
+        <ProviderMetaItem
+          v-for="item in metaItems"
+          :key="item.key"
+          :label="item.label"
+          :value="item.value"
+        />
+      </dl>
+
+      <div class="provider-control">
+        <NTag class="status-badge" size="small" :type="statusType" round :bordered="false">
+          {{ statusLabel }}
+        </NTag>
+        <div class="card-actions" :aria-label="`${connection.label} actions`">
+          <NButton
+            v-if="!connection.active"
+            size="tiny"
+            secondary
+            @click="emit('setActive', connection)"
+          >
+            {{ t('settings.voice.setActive') }}
+          </NButton>
+          <span v-else class="action-placeholder" aria-hidden="true" />
+          <NButton
+            size="tiny"
+            :loading="testState?.status === 'loading'"
+            :data-testid="`voice-card-test-${connection.id}`"
+            @click="emit('test', connection)"
+          >
+            {{ testActionLabel }}
+          </NButton>
+          <NButton
+            v-if="canEdit"
+            size="tiny"
+            secondary
+            @click="handleEditAction"
+          >
+            {{ actionLabel }}
+          </NButton>
+          <span v-else class="action-placeholder" aria-hidden="true" />
+          <NDropdown
+            v-if="requiresKey"
+            trigger="click"
+            size="small"
+            :options="moreOptions"
+            @select="handleMoreSelect"
+          >
+            <NButton size="tiny" quaternary :aria-label="t('settings.voice.moreActionsFor', { provider: connection.label })">
+              {{ t('settings.voice.moreActions') }}
+            </NButton>
+          </NDropdown>
+          <span v-else class="action-placeholder" aria-hidden="true" />
+        </div>
+      </div>
+    </div>
+
+    <div v-if="hasInlineFeedback" class="feedback-row" :class="testState?.status" role="status">
+      {{ testState?.message || (testState?.status === 'success' ? t('settings.voice.testSuccess') : '') }}
+    </div>
+
+    <div v-if="hasError" class="feedback-row error" role="alert">
+      <div class="error-summary">{{ friendlyErrorMessage }}</div>
+      <NButton
+        v-if="showDetailsToggle"
+        class="details-toggle"
+        text
+        size="tiny"
+        @click="showErrorDetails = !showErrorDetails"
+      >
+        {{ showErrorDetails ? t('settings.voice.hideDetails') : t('settings.voice.showDetails') }}
+      </NButton>
+      <pre v-if="showErrorDetails" class="error-details">{{ rawErrorMessage }}</pre>
+    </div>
+  </article>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/variables' as *;
+
+.voice-api-card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid $border-color;
+  border-radius: $radius-md;
+  background: $bg-card;
+  transition: background $transition-fast;
+
+  &.active::before {
+    content: '';
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 3px;
+    background: $accent-primary;
+  }
+}
+
+.card-main {
+  display: grid;
+  grid-template-columns: minmax(210px, 240px) minmax(0, 1fr) 188px;
+  align-items: start;
+  gap: 16px;
+  min-width: 0;
+  padding: 14px 16px 14px 18px;
+}
+
+.provider-identity {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  min-width: 0;
+}
+
+.provider-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: $radius-sm;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border: 1px solid $border-color;
+  background: $bg-input;
+  color: $text-secondary;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.provider-copy {
+  min-width: 0;
+}
+
+.provider-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.provider-title {
+  min-width: 0;
+  margin: 0;
+  color: $text-primary;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.provider-kind {
+  flex-shrink: 0;
+  color: $text-muted;
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.provider-description {
+  margin: 5px 0 0;
+  color: $text-muted;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.provider-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px 16px;
+  margin: 0;
+  min-width: 0;
+}
+
+.provider-control {
+  display: grid;
+  justify-items: end;
+  gap: 8px;
+  width: 188px;
+  min-width: 0;
+}
+
+.status-badge {
+  max-width: 100%;
+}
+
+.card-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(82px, 1fr));
+  gap: 6px;
+  width: 100%;
+
+  :deep(.n-button) {
+    width: 100%;
+  }
+}
+
+.action-placeholder {
+  min-height: 22px;
+}
+
+.feedback-row {
+  margin: 0 16px 14px 18px;
+  padding: 8px 10px;
+  border-radius: $radius-sm;
+  background: $bg-input;
+  color: $text-muted;
+  font-size: 12px;
+  line-height: 1.45;
+
+  &.success {
+    color: $success;
+  }
+
+  &.error {
+    border: 1px solid rgba(var(--error-rgb), 0.22);
+    background: rgba(var(--error-rgb), 0.06);
+    color: $error;
+  }
+}
+
+.error-summary {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.details-toggle {
+  margin-top: 4px;
+}
+
+.error-details {
+  max-height: 160px;
+  overflow: auto;
+  margin: 6px 0 0;
+  padding: 8px;
+  border-radius: $radius-sm;
+  background: $code-bg;
+  color: $text-secondary;
+  font-family: $font-code;
+  font-size: 11px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+@media (max-width: 1080px) {
+  .card-main {
+    grid-template-columns: minmax(170px, 190px) minmax(0, 1fr) 156px;
+    gap: 14px;
+  }
+
+  .provider-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .provider-control {
+    width: 156px;
+  }
+
+  .card-actions {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 820px) {
+  .card-main {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .provider-control {
+    grid-column: auto;
+    grid-row: auto;
+    width: 100%;
+    justify-items: start;
+  }
+
+  .provider-meta {
+    grid-column: auto;
+    grid-row: auto;
+  }
+
+  .card-actions {
+    grid-template-columns: repeat(2, minmax(0, 120px));
+    width: auto;
+  }
+}
+
+@media (max-width: 520px) {
+  .provider-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .card-actions {
+    grid-template-columns: 1fr;
+    width: 100%;
+  }
+}
+</style>

--- a/packages/client/src/components/hermes/settings/voice/VoiceApiConfigurator.vue
+++ b/packages/client/src/components/hermes/settings/voice/VoiceApiConfigurator.vue
@@ -1,0 +1,224 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { NDrawer, NDrawerContent, NForm, NFormItem, NInput, NSelect, NSlider, NButton, NSpace } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import type { VoiceApiConnection, VoiceApiSavePayload } from '@/types/voice-api'
+import { VOICE_API_PRESETS } from '@/constants/voiceApiPresets'
+import { speedToEdgeRate, hzToEdgePitch } from '@/utils/ttsHelpers'
+
+const props = defineProps<{
+  connection: VoiceApiConnection | null
+  show: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+  save: [connection: VoiceApiConnection, payload: VoiceApiSavePayload]
+}>()
+
+const { t } = useI18n()
+
+const loading = ref(false)
+const formData = ref<Record<string, string | number | undefined>>({})
+const apiKeyInput = ref('')
+
+const preset = computed(() =>
+  props.connection ? VOICE_API_PRESETS.find(p => p.kind === props.connection!.kind && p.provider === props.connection!.provider && (p.baseUrl === props.connection!.baseUrl || !p.baseUrl)) : null
+)
+
+const capabilities = computed(() => preset.value?.capabilities || {})
+
+function setField(key: string, value: string | number | null | undefined) {
+  formData.value[key] = value ?? ''
+}
+
+function stringField(key: string): string {
+  const value = formData.value[key]
+  return typeof value === 'string' ? value : typeof value === 'number' ? String(value) : ''
+}
+
+function numberField(key: string, fallback = 0): number {
+  const value = formData.value[key]
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return fallback
+}
+
+watch(() => props.connection, (conn) => {
+  if (conn) {
+    formData.value = {
+      ...conn.settings,
+      model: conn.model || String(conn.settings.model || ''),
+      voice: conn.voice || String(conn.settings.voice || ''),
+    }
+    if (conn.provider === 'edge') {
+      formData.value.rate = numberField('rate', 1.0)
+      formData.value.pitch = numberField('pitch', 0)
+    }
+    apiKeyInput.value = ''
+  }
+}, { immediate: true })
+
+async function handleSave() {
+  if (!props.connection) return
+
+  loading.value = true
+  try {
+    const apiKey = apiKeyInput.value.trim()
+    emit('save', props.connection, {
+      settings: { ...formData.value },
+      ...(apiKey ? { secrets: { apiKey } } : {}),
+    })
+  } finally {
+    loading.value = false
+  }
+}
+
+const edgeVoiceOptions = [
+  { label: '晓晓 (zh-CN-XiaoxiaoNeural)', value: 'zh-CN-XiaoxiaoNeural' },
+  { label: '晓萱 (zh-CN-XiaoxuanNeural)', value: 'zh-CN-XiaoxuanNeural' },
+  { label: '云希 (zh-CN-YunxiNeural)', value: 'zh-CN-YunxiNeural' },
+  { label: '云健 (zh-CN-YunjianNeural)', value: 'zh-CN-YunjianNeural' },
+  { label: '云扬 (zh-CN-YunyangNeural)', value: 'zh-CN-YunyangNeural' },
+  { label: 'Jenny (en-US-JennyNeural)', value: 'en-US-JennyNeural' },
+  { label: 'Aria (en-US-AriaNeural)', value: 'en-US-AriaNeural' },
+  { label: 'Guy (en-US-GuyNeural)', value: 'en-US-GuyNeural' },
+]
+
+const openaiVoiceOptions = [
+  { label: 'Alloy', value: 'alloy' },
+  { label: 'Echo', value: 'echo' },
+  { label: 'Fable', value: 'fable' },
+  { label: 'Nova', value: 'nova' },
+  { label: 'Onyx', value: 'onyx' },
+  { label: 'Shimmer', value: 'shimmer' },
+]
+
+const mimoVoiceOptions = [
+  { label: '冰糖 (中文·女)', value: '冰糖' },
+  { label: '茉莉 (中文·女)', value: '茉莉' },
+  { label: '苏打 (中文·男)', value: '苏打' },
+  { label: '白桦 (中文·男)', value: '白桦' },
+]
+
+const mimoModelOptions = [
+  { label: t('settings.voice.mimoModelPreset'), value: 'mimo-v2.5-tts' },
+  { label: t('settings.voice.mimoModelVoiceDesign'), value: 'mimo-v2.5-tts-voicedesign' },
+  { label: t('settings.voice.mimoModelVoiceClone'), value: 'mimo-v2.5-tts-voiceclone' },
+]
+</script>
+
+<template>
+  <NDrawer :show="show" :width="400" @update:show="emit('close')">
+    <NDrawerContent :title="connection?.label" closable>
+      <NForm label-placement="top" v-if="connection">
+        <NFormItem v-if="!connection.isBuiltin" :label="t('settings.voice.apiKey')">
+          <NInput
+            v-model:value="apiKeyInput"
+            type="password"
+            show-password-on="click"
+            autocomplete="off"
+            :placeholder="connection.hasSecret ? t('settings.voice.keepStoredKeyPlaceholder') : t('settings.voice.apiKeyPlaceholder')"
+          />
+        </NFormItem>
+
+        <NFormItem :label="t('settings.voice.model')" v-if="capabilities.models">
+          <NSelect
+            v-if="connection.provider === 'mimo'"
+            :value="stringField('model')"
+            :options="mimoModelOptions"
+            @update:value="value => setField('model', value)"
+          />
+          <NInput
+            v-else
+            :value="stringField('model')"
+            :placeholder="t('models.selectOrInput')"
+            @update:value="value => setField('model', value)"
+          />
+        </NFormItem>
+
+        <NFormItem :label="t('settings.voice.voice')" v-if="capabilities.voices">
+          <NSelect
+            v-if="connection.provider === 'edge'"
+            :value="stringField('voice')"
+            :options="edgeVoiceOptions"
+            filterable
+            @update:value="value => setField('voice', value)"
+          />
+          <NSelect
+            v-else-if="connection.provider === 'openai'"
+            :value="stringField('voice')"
+            :options="openaiVoiceOptions"
+            @update:value="value => setField('voice', value)"
+          />
+          <NSelect
+            v-else-if="connection.provider === 'mimo' && stringField('model') === 'mimo-v2.5-tts'"
+            :value="stringField('voice')"
+            :options="mimoVoiceOptions"
+            @update:value="value => setField('voice', value)"
+          />
+          <NInput
+            v-else
+            :value="stringField('voice')"
+            @update:value="value => setField('voice', value)"
+          />
+        </NFormItem>
+
+        <template v-if="connection.provider === 'edge'">
+          <NFormItem :label="t('settings.voice.edgeRate')">
+            <NSpace vertical style="width: 100%">
+              <NSlider
+                :value="numberField('rate', 1)"
+                :min="0.5"
+                :max="2.0"
+                :step="0.05"
+                @update:value="value => setField('rate', Array.isArray(value) ? value[0] : value)"
+              />
+              <span style="font-size: 12px; opacity: 0.6">{{ numberField('rate', 1).toFixed(2) }}x ({{ speedToEdgeRate(numberField('rate', 1)) }})</span>
+            </NSpace>
+          </NFormItem>
+          <NFormItem :label="t('settings.voice.edgePitch')">
+            <NSpace vertical style="width: 100%">
+              <NSlider
+                :value="numberField('pitch', 0)"
+                :min="-20"
+                :max="20"
+                :step="1"
+                @update:value="value => setField('pitch', Array.isArray(value) ? value[0] : value)"
+              />
+              <span style="font-size: 12px; opacity: 0.6">{{ numberField('pitch', 0) > 0 ? '+' : '' }}{{ numberField('pitch', 0) }} Hz ({{ hzToEdgePitch(numberField('pitch', 0)) }})</span>
+            </NSpace>
+          </NFormItem>
+        </template>
+
+        <template v-if="connection.provider === 'mimo'">
+          <NFormItem :label="t('settings.voice.mimoStylePrompt')" v-if="capabilities.stylePrompt">
+            <NInput :value="stringField('stylePrompt')" type="textarea" :rows="2" @update:value="value => setField('stylePrompt', value)" />
+          </NFormItem>
+          <NFormItem :label="t('settings.voice.mimoVoiceDesignPrompt')" v-if="stringField('model') === 'mimo-v2.5-tts-voicedesign'">
+            <NInput :value="stringField('voiceDesignDesc')" type="textarea" :rows="3" @update:value="value => setField('voiceDesignDesc', value)" />
+          </NFormItem>
+        </template>
+
+        <template v-if="connection.kind === 'stt' && connection.provider !== 'browser'">
+          <NFormItem :label="t('settings.voice.sttLanguage')">
+            <NInput :value="stringField('language')" @update:value="value => setField('language', value)" />
+          </NFormItem>
+          <NFormItem :label="t('settings.voice.sttPrompt')">
+            <NInput :value="stringField('prompt')" type="textarea" :rows="2" @update:value="value => setField('prompt', value)" />
+          </NFormItem>
+        </template>
+      </NForm>
+
+      <template #footer>
+        <NSpace justify="end">
+          <NButton @click="emit('close')">{{ t('common.cancel') }}</NButton>
+          <NButton type="primary" :loading="loading" @click="handleSave">{{ t('common.save') }}</NButton>
+        </NSpace>
+      </template>
+    </NDrawerContent>
+  </NDrawer>
+</template>

--- a/packages/client/src/components/hermes/settings/voice/VoiceApiFormModal.vue
+++ b/packages/client/src/components/hermes/settings/voice/VoiceApiFormModal.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { NModal, NForm, NFormItem, NInput, NButton, NSelect } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { VOICE_API_PRESETS } from '@/constants/voiceApiPresets'
+import type { VoiceApiKind } from '@/types/voice-api'
+
+const props = defineProps<{
+  kind: VoiceApiKind
+  show: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+  saved: [payload: {
+    preset: typeof VOICE_API_PRESETS[number]
+    settings: Record<string, string>
+    secrets: Record<string, string>
+  }]
+}>()
+
+const { t } = useI18n()
+
+const selectedPresetId = ref<string | null>(null)
+const formData = ref({ baseUrl: '', apiKey: '', model: '' })
+
+const presetOptions = computed(() =>
+  VOICE_API_PRESETS
+    .filter(p => p.kind === props.kind && !p.isBuiltin)
+    .map(p => ({ label: p.label, value: p.id })),
+)
+
+const selectedPreset = computed(() =>
+  VOICE_API_PRESETS.find(p => p.id === selectedPresetId.value) || null,
+)
+
+const canSave = computed(() => {
+  if (!selectedPreset.value) return false
+  if (selectedPreset.value.isSecretRequired && !formData.value.apiKey.trim()) return false
+  if (selectedPreset.value.baseUrl !== undefined && !formData.value.baseUrl.trim()) return false
+  if (selectedPreset.value.capabilities?.models && !formData.value.model.trim()) return false
+  return true
+})
+
+watch(() => props.show, (show) => {
+  if (show) resetForm()
+})
+
+function resetForm() {
+  selectedPresetId.value = null
+  formData.value = { baseUrl: '', apiKey: '', model: '' }
+}
+
+function handlePresetChange(id: string) {
+  selectedPresetId.value = id
+  const preset = VOICE_API_PRESETS.find(p => p.id === id)
+  formData.value = {
+    baseUrl: preset?.baseUrl || '',
+    apiKey: '',
+    model: preset?.defaultModel || '',
+  }
+}
+
+function save() {
+  if (!selectedPreset.value || !canSave.value) return
+  emit('saved', {
+    preset: selectedPreset.value,
+    settings: {
+      baseUrl: formData.value.baseUrl.trim(),
+      model: formData.value.model.trim(),
+    },
+    secrets: formData.value.apiKey.trim() ? { apiKey: formData.value.apiKey.trim() } : {},
+  })
+}
+</script>
+
+<template>
+  <NModal :show="show" preset="card" class="voice-api-form-modal" :title="t('settings.voice.addApiTitle')" @close="emit('close')">
+    <NForm class="voice-api-form" label-placement="top">
+      <NFormItem :label="t('settings.voice.provider')">
+        <NSelect
+          :value="selectedPresetId"
+          :options="presetOptions"
+          :placeholder="t('settings.voice.chooseProvider')"
+          data-testid="voice-provider-select"
+          @update:value="handlePresetChange"
+        />
+      </NFormItem>
+      <NFormItem v-if="selectedPreset?.baseUrl !== undefined" :label="t('settings.voice.baseUrl')">
+        <NInput v-model:value="formData.baseUrl" data-testid="voice-provider-base-url" />
+      </NFormItem>
+      <NFormItem v-if="selectedPreset?.isSecretRequired" :label="t('settings.voice.apiKey')">
+        <NInput v-model:value="formData.apiKey" type="password" show-password-on="click" data-testid="voice-provider-api-key" />
+      </NFormItem>
+      <NFormItem v-if="selectedPreset?.capabilities?.models" :label="t('settings.voice.model')">
+        <NInput v-model:value="formData.model" data-testid="voice-provider-model" />
+      </NFormItem>
+    </NForm>
+    <template #footer>
+      <div class="modal-actions">
+        <NButton @click="emit('close')">{{ t('common.cancel') }}</NButton>
+        <NButton type="primary" :disabled="!canSave" data-testid="voice-provider-save" @click="save">
+          {{ t('common.save') }}
+        </NButton>
+      </div>
+    </template>
+  </NModal>
+</template>
+
+<style scoped>
+.voice-api-form { display: grid; gap: 12px; }
+.modal-actions { display: flex; justify-content: flex-end; gap: 8px; }
+</style>

--- a/packages/client/src/composables/useVoiceApiConnections.ts
+++ b/packages/client/src/composables/useVoiceApiConnections.ts
@@ -1,0 +1,286 @@
+import { computed, ref } from 'vue'
+import {
+  clearTtsSecret,
+  fetchTtsSettings,
+  saveTtsSettings,
+  type StoredTtsProvider,
+  type TtsStoredSecretsInput,
+  type TtsStoredSettings,
+} from '@/api/hermes/tts-settings'
+import {
+  clearSttSecret,
+  fetchSttSettings,
+  saveActiveSttProvider,
+  saveSttSettings,
+  type StoredSttProvider,
+  type SttProvider,
+  type SttStoredSecretsInput,
+  type SttStoredSettings,
+} from '@/api/hermes/stt-settings'
+import { useVoiceSettings } from '@/composables/useVoiceSettings'
+import { useSttSettings } from '@/composables/useSttSettings'
+import { VOICE_API_PRESETS } from '@/constants/voiceApiPresets'
+import type { VoiceApiConnection, VoiceApiKind, VoiceApiProvider, VoiceApiSavePayload } from '@/types/voice-api'
+
+function isStoredSttProvider(provider: VoiceApiProvider): provider is StoredSttProvider {
+  return provider === 'openai' || provider === 'custom'
+}
+
+function isStoredTtsProvider(provider: VoiceApiProvider): provider is StoredTtsProvider {
+  return provider === 'edge' || provider === 'openai' || provider === 'custom' || provider === 'mimo'
+}
+
+function isSttProvider(provider: VoiceApiProvider): provider is SttProvider {
+  return provider === 'browser' || provider === 'openai' || provider === 'custom'
+}
+
+function isTtsProvider(provider: VoiceApiProvider): provider is StoredTtsProvider {
+  return provider === 'edge' || provider === 'openai' || provider === 'custom' || provider === 'mimo'
+}
+
+function stringSetting(settings: object, key: string): string {
+  const value = (settings as Record<string, unknown>)[key]
+  return typeof value === 'string' ? value : ''
+}
+
+export function useVoiceApiConnections() {
+  const connections = ref<VoiceApiConnection[]>([])
+  const loading = ref(false)
+  const vs = useVoiceSettings()
+  const stt = useSttSettings()
+
+  const activeTtsId = computed(() => `tts-${vs.provider.value === 'webspeech' ? 'edge' : vs.provider.value}`)
+  const activeSttId = computed(() => `stt-${stt.provider.value}`)
+
+  const ttsConnections = computed(() => connections.value.filter(c => c.kind === 'tts'))
+  const sttConnections = computed(() => connections.value.filter(c => c.kind === 'stt'))
+  const activeTtsConnection = computed(() => ttsConnections.value.find(c => c.id === activeTtsId.value) || ttsConnections.value[0] || null)
+  const activeSttConnection = computed(() => sttConnections.value.find(c => c.id === activeSttId.value) || sttConnections.value[0] || null)
+  const ttsConnectionOptions = computed(() => ttsConnections.value.map(c => ({ label: c.label, value: c.id })))
+  const sttConnectionOptions = computed(() => sttConnections.value.map(c => ({ label: c.label, value: c.id })))
+
+  function applyTtsConnectionToLegacyState(connection: VoiceApiConnection) {
+    if (!isTtsProvider(connection.provider)) return
+    vs.setProvider(connection.provider)
+    const settings = connection.settings
+
+    if (connection.provider === 'edge') {
+      vs.setEdgeVoice(stringSetting(settings, 'voice') || connection.voice || vs.edgeVoice.value)
+      const rate = Number(settings.rate)
+      const pitch = Number(settings.pitch)
+      if (Number.isFinite(rate)) vs.setEdgeRate(rate)
+      if (Number.isFinite(pitch)) vs.setEdgePitchHz(pitch)
+      return
+    }
+
+    if (connection.provider === 'openai') {
+      vs.setOpenaiBaseUrl(connection.baseUrl || stringSetting(settings, 'baseUrl'))
+      vs.setOpenaiModel(connection.model || stringSetting(settings, 'model') || vs.openaiModel.value)
+      vs.setOpenaiVoice(connection.voice || stringSetting(settings, 'voice') || vs.openaiVoice.value)
+      return
+    }
+
+    if (connection.provider === 'custom') {
+      vs.setCustomUrl(connection.baseUrl || stringSetting(settings, 'baseUrl'))
+      return
+    }
+
+    if (connection.provider === 'mimo') {
+      vs.setMimoBaseUrl(connection.baseUrl || stringSetting(settings, 'baseUrl') || vs.mimoBaseUrl.value)
+      vs.setMimoModel(connection.model || stringSetting(settings, 'model') || vs.mimoModel.value)
+      vs.setMimoVoice(connection.voice || stringSetting(settings, 'voice') || vs.mimoVoice.value)
+      vs.setMimoStylePrompt(stringSetting(settings, 'stylePrompt'))
+      vs.setMimoVoiceDesignDesc(stringSetting(settings, 'voiceDesignDesc'))
+    }
+  }
+
+  function applySttConnectionToLegacyState(connection: VoiceApiConnection) {
+    if (!isSttProvider(connection.provider)) return
+    stt.setProvider(connection.provider)
+    const settings = connection.settings
+
+    if (connection.provider === 'openai') {
+      stt.setOpenaiModel(connection.model || stringSetting(settings, 'model') || stt.openaiModel.value)
+      stt.setOpenaiLanguage(stringSetting(settings, 'language'))
+      stt.setOpenaiPrompt(stringSetting(settings, 'prompt'))
+      return
+    }
+
+    if (connection.provider === 'custom') {
+      stt.setCustomBaseUrl(connection.baseUrl || stringSetting(settings, 'baseUrl'))
+      stt.setCustomModel(connection.model || stringSetting(settings, 'model') || stt.customModel.value)
+      stt.setCustomLanguage(stringSetting(settings, 'language'))
+      stt.setCustomPrompt(stringSetting(settings, 'prompt'))
+    }
+  }
+
+  function makeTtsConnection(provider: StoredTtsProvider, settings: TtsStoredSettings, hasSecret: boolean): VoiceApiConnection {
+    const preset = VOICE_API_PRESETS.find(pr => pr.kind === 'tts' && pr.provider === provider && (pr.baseUrl === settings.baseUrl || !pr.baseUrl))
+    return {
+      id: `tts-${provider}`,
+      kind: 'tts',
+      provider,
+      label: preset?.label || `${provider} TTS`,
+      baseUrl: settings.baseUrl,
+      model: settings.model,
+      voice: settings.voice,
+      settings: settings as Record<string, unknown>,
+      hasSecret,
+      active: activeTtsId.value === `tts-${provider}`,
+    }
+  }
+
+  function makeSttConnection(provider: StoredSttProvider, settings: SttStoredSettings, hasSecret: boolean): VoiceApiConnection {
+    const preset = VOICE_API_PRESETS.find(pr => pr.kind === 'stt' && pr.provider === provider && (pr.baseUrl === settings.baseUrl || !pr.baseUrl))
+    return {
+      id: `stt-${provider}`,
+      kind: 'stt',
+      provider,
+      label: preset?.label || `${provider} STT`,
+      baseUrl: settings.baseUrl,
+      model: settings.model,
+      settings: settings as Record<string, unknown>,
+      hasSecret,
+      active: activeSttId.value === `stt-${provider}`,
+    }
+  }
+
+  async function refresh() {
+    loading.value = true
+    try {
+      await stt.loadServerSttSettings(true)
+      const [ttsData, sttData] = await Promise.all([
+        fetchTtsSettings(),
+        fetchSttSettings(),
+      ])
+
+      const newConnections: VoiceApiConnection[] = [
+        {
+          id: 'tts-edge',
+          kind: 'tts',
+          provider: 'edge',
+          label: 'Edge TTS',
+          isBuiltin: true,
+          hasSecret: false,
+          active: activeTtsId.value === 'tts-edge',
+          settings: {
+            voice: vs.edgeVoice.value,
+            rate: vs.edgeRate.value,
+            pitch: vs.edgePitchHz.value,
+          },
+          voice: vs.edgeVoice.value,
+        },
+        {
+          id: 'stt-browser',
+          kind: 'stt',
+          provider: 'browser',
+          label: 'Browser STT',
+          isBuiltin: true,
+          hasSecret: false,
+          active: activeSttId.value === 'stt-browser',
+          settings: {},
+        },
+      ]
+
+      for (const row of ttsData.providers) {
+        const connection = makeTtsConnection(row.provider, row.settings, row.secrets?.apiKey === '[stored]')
+        const existingBuiltIn = newConnections.find(c => c.id === connection.id)
+        if (existingBuiltIn) {
+          Object.assign(existingBuiltIn, connection, { isBuiltin: existingBuiltIn.isBuiltin })
+        } else {
+          newConnections.push(connection)
+        }
+      }
+
+      for (const row of sttData.providers) {
+        newConnections.push(makeSttConnection(row.provider, row.settings, row.secrets?.apiKey === '[stored]'))
+      }
+
+      connections.value = newConnections.map(connection => ({
+        ...connection,
+        active: connection.kind === 'tts'
+          ? connection.id === activeTtsId.value
+          : connection.id === activeSttId.value,
+      }))
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function setActiveConnection(kind: VoiceApiKind, id: string) {
+    const connection = connections.value.find(c => c.kind === kind && c.id === id)
+    if (!connection) return
+
+    if (kind === 'tts') {
+      applyTtsConnectionToLegacyState(connection)
+    } else {
+      applySttConnectionToLegacyState(connection)
+      if (isSttProvider(connection.provider)) {
+        await saveActiveSttProvider(connection.provider)
+      }
+    }
+
+    connections.value = connections.value.map(c => ({
+      ...c,
+      active: c.kind === kind ? c.id === id : c.active,
+    }))
+  }
+
+  async function saveConnection(kind: VoiceApiKind, provider: VoiceApiProvider, payload: VoiceApiSavePayload) {
+    if (kind === 'tts') {
+      if (!isStoredTtsProvider(provider)) throw new Error(`Unsupported TTS provider: ${String(provider)}`)
+      const res = await saveTtsSettings(provider, {
+        settings: payload.settings as TtsStoredSettings | undefined,
+        secrets: payload.secrets as TtsStoredSecretsInput | undefined,
+      })
+      await refresh()
+      await setActiveConnection('tts', `tts-${provider}`)
+      return res
+    }
+
+    if (provider === 'browser') {
+      await saveActiveSttProvider('browser')
+      stt.setProvider('browser')
+      await refresh()
+      return null
+    }
+
+    if (!isStoredSttProvider(provider)) throw new Error(`Unsupported STT provider: ${String(provider)}`)
+    const res = await saveSttSettings(provider, {
+      settings: payload.settings as SttStoredSettings | undefined,
+      secrets: payload.secrets as SttStoredSecretsInput | undefined,
+      activeProvider: provider,
+    })
+    await refresh()
+    await setActiveConnection('stt', `stt-${provider}`)
+    return res
+  }
+
+  async function deleteSecret(kind: VoiceApiKind, provider: VoiceApiProvider) {
+    if (kind === 'tts') {
+      if (!isStoredTtsProvider(provider)) return
+      await clearTtsSecret(provider, 'apiKey')
+    } else {
+      if (!isStoredSttProvider(provider)) return
+      await clearSttSecret(provider, 'apiKey')
+    }
+    await refresh()
+  }
+
+  return {
+    connections,
+    ttsConnections,
+    sttConnections,
+    activeTtsId,
+    activeSttId,
+    activeTtsConnection,
+    activeSttConnection,
+    ttsConnectionOptions,
+    sttConnectionOptions,
+    loading,
+    refresh,
+    setActiveConnection,
+    saveConnection,
+    deleteSecret,
+  }
+}

--- a/packages/client/src/constants/voiceApiPresets.ts
+++ b/packages/client/src/constants/voiceApiPresets.ts
@@ -1,0 +1,104 @@
+import type { VoiceApiPreset } from '@/types/voice-api'
+
+export const VOICE_API_PRESETS: VoiceApiPreset[] = [
+  // TTS Presets
+  {
+    id: 'tts-edge',
+    kind: 'tts',
+    provider: 'edge',
+    label: 'Edge TTS',
+    description: 'Free high-quality cloud voices from Microsoft Edge.',
+    isBuiltin: true,
+    isSecretRequired: false,
+    capabilities: {
+      voices: true,
+      rate: true,
+      pitch: true,
+    },
+  },
+  {
+    id: 'tts-openai',
+    kind: 'tts',
+    provider: 'openai',
+    label: 'OpenAI TTS',
+    baseUrl: 'https://api.openai.com/v1/audio/speech',
+    defaultModel: 'tts-1',
+    isSecretRequired: true,
+    capabilities: {
+      models: true,
+      voices: true,
+    },
+  },
+  {
+    id: 'tts-mimo',
+    kind: 'tts',
+    provider: 'mimo',
+    label: 'MiMo TTS',
+    baseUrl: 'https://api.xiaomimimo.com/v1',
+    defaultModel: 'mimo-v2.5-tts',
+    isSecretRequired: true,
+    capabilities: {
+      models: true,
+      voices: true,
+      stylePrompt: true,
+      voiceDesign: true,
+      voiceClone: true,
+    },
+  },
+  {
+    id: 'tts-custom',
+    kind: 'tts',
+    provider: 'custom',
+    label: 'Custom TTS',
+    isSecretRequired: true,
+    capabilities: {
+      models: true,
+    },
+  },
+
+  // STT Presets
+  {
+    id: 'stt-browser',
+    kind: 'stt',
+    provider: 'browser',
+    label: 'Browser STT',
+    description: 'Native browser speech recognition API.',
+    isBuiltin: true,
+    isSecretRequired: false,
+    capabilities: {},
+  },
+  {
+    id: 'stt-openai',
+    kind: 'stt',
+    provider: 'openai',
+    label: 'OpenAI Whisper',
+    baseUrl: 'https://api.openai.com/v1',
+    defaultModel: 'whisper-1',
+    isSecretRequired: true,
+    capabilities: {
+      models: true,
+    },
+  },
+  {
+    id: 'stt-groq',
+    kind: 'stt',
+    provider: 'custom', // Groq uses Custom STT storage with specific URL
+    label: 'Groq STT',
+    baseUrl: 'https://api.groq.com/openai/v1',
+    defaultModel: 'whisper-large-v3',
+    isSecretRequired: true,
+    capabilities: {
+      models: true,
+    },
+  },
+  {
+    id: 'stt-custom',
+    kind: 'stt',
+    provider: 'custom',
+    label: 'Custom STT',
+    isSecretRequired: true,
+    capabilities: {
+      models: true,
+    },
+  },
+]

--- a/packages/server/src/controllers/hermes/tts.ts
+++ b/packages/server/src/controllers/hermes/tts.ts
@@ -1,6 +1,137 @@
 import type { Context } from 'koa'
 import { textToSpeech, openaiCompatibleTts, speedToEdgeRate } from '../../services/hermes/tts'
 import { getTtsProvider } from '../../services/hermes/tts-providers'
+import {
+  assertStoredTtsProvider,
+  clearStoredTtsSecret,
+  getTtsProviderSetting,
+  isStoredTtsProvider,
+  listTtsProviderSettings,
+  removeTtsBaseUrlPreset,
+  saveTtsProviderSetting,
+  TtsSettingsValidationError,
+} from '../../db/hermes/tts-settings-store'
+
+function currentUserId(ctx: Context): number | null {
+  const rawUserId = ctx.state?.user?.id
+  const userId = typeof rawUserId === 'number' ? rawUserId : Number.NaN
+  return Number.isInteger(userId) && userId > 0 ? userId : null
+}
+
+function authUserId(ctx: Context): number | null {
+  const userId = currentUserId(ctx)
+  if (!userId) {
+    ctx.status = 401
+    ctx.body = { error: 'Unauthorized' }
+    return null
+  }
+  return userId
+}
+
+function handleSettingsError(ctx: Context, error: unknown): boolean {
+  if (error instanceof TtsSettingsValidationError) {
+    ctx.status = 400
+    ctx.body = { error: error.message }
+    return true
+  }
+  return false
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? { ...(value as Record<string, unknown>) }
+    : {}
+}
+
+function mergeStoredTtsOptions(ctx: Context, providerName: string, options: Record<string, unknown>): Record<string, unknown> {
+  const userId = currentUserId(ctx)
+  if (!userId || !isStoredTtsProvider(providerName)) {
+    return options
+  }
+
+  const stored = getTtsProviderSetting(userId, providerName, { includeSecrets: true })
+  if (!stored) return options
+
+  const requestOptions = Object.fromEntries(
+    Object.entries(options).filter(([, value]) => value !== '' && value !== undefined && value !== null),
+  )
+
+  return {
+    ...stored.settings,
+    ...stored.secrets,
+    ...requestOptions,
+  }
+}
+
+export async function listSettings(ctx: Context) {
+  const userId = authUserId(ctx)
+  if (!userId) return
+
+  try {
+    ctx.body = {
+      settings: listTtsProviderSettings(userId),
+    }
+  } catch (error) {
+    if (handleSettingsError(ctx, error)) return
+    throw error
+  }
+}
+
+export async function saveSettings(ctx: Context) {
+  const userId = authUserId(ctx)
+  if (!userId) return
+
+  const provider = ctx.params.provider || ''
+  const body = ctx.request.body as { settings?: unknown; secrets?: unknown } | undefined
+
+  try {
+    const setting = saveTtsProviderSetting(userId, assertStoredTtsProvider(provider), {
+      settings: body?.settings,
+      secrets: body?.secrets,
+    })
+    ctx.body = { setting }
+  } catch (error) {
+    if (handleSettingsError(ctx, error)) return
+    throw error
+  }
+}
+
+export async function deleteBaseUrlPreset(ctx: Context) {
+  const userId = authUserId(ctx)
+  if (!userId) return
+
+  const provider = ctx.params.provider || ''
+  const rawUrl = typeof ctx.query.url === 'string' ? ctx.query.url : ''
+  if (!rawUrl.trim()) {
+    ctx.status = 400
+    ctx.body = { error: 'baseUrl is required' }
+    return
+  }
+
+  try {
+    const setting = removeTtsBaseUrlPreset(userId, assertStoredTtsProvider(provider), rawUrl)
+    ctx.body = { success: true, setting }
+  } catch (error) {
+    if (handleSettingsError(ctx, error)) return
+    throw error
+  }
+}
+
+export async function deleteSecret(ctx: Context) {
+  const userId = authUserId(ctx)
+  if (!userId) return
+
+  const provider = ctx.params.provider || ''
+  const secretName = ctx.params.secretName || ''
+
+  try {
+    const setting = clearStoredTtsSecret(userId, assertStoredTtsProvider(provider), secretName)
+    ctx.body = { success: true, setting }
+  } catch (error) {
+    if (handleSettingsError(ctx, error)) return
+    throw error
+  }
+}
 
 export async function generate(ctx: Context) {
   const { text, lang } = ctx.request.body as {
@@ -41,12 +172,14 @@ export async function synthesize(ctx: Context) {
     return
   }
 
-  const options = body.options === undefined ? {} : body.options
-  if (typeof options !== 'object' || options === null || Array.isArray(options)) {
+  if (body.options !== undefined && (typeof body.options !== 'object' || body.options === null || Array.isArray(body.options))) {
     ctx.status = 400
     ctx.body = { error: 'options must be an object' }
     return
   }
+
+  const requestOptions = asRecord(body.options)
+  const options = mergeStoredTtsOptions(ctx, body.provider || '', requestOptions)
 
   const provider = getTtsProvider(body.provider || '')
   if (!provider) {
@@ -55,10 +188,7 @@ export async function synthesize(ctx: Context) {
     return
   }
 
-  const controller = new AbortController()
-  if (ctx.req?.on) {
-    ctx.req.on('close', () => controller.abort())
-  }
+  const controller = createRequestAbortController(ctx)
 
   try {
     const result = await provider.synthesize(
@@ -78,9 +208,70 @@ export async function synthesize(ctx: Context) {
       return
     }
 
-    ctx.status = 502
-    ctx.body = { error: 'TTS synthesis failed' }
+    ctx.status = statusForTtsError(error)
+    ctx.body = {
+      error: 'TTS synthesis failed',
+      detail: sanitizeTtsError(error),
+    }
   }
+}
+
+function statusForTtsError(error: unknown): number {
+  const message = error instanceof Error ? error.message : String(error)
+  const upstreamStatus = /returned\s+(\d{3})/.exec(message)?.[1]
+  const parsedStatus = upstreamStatus ? Number(upstreamStatus) : Number.NaN
+
+  if (Number.isInteger(parsedStatus) && parsedStatus >= 400 && parsedStatus < 500) {
+    return parsedStatus
+  }
+
+  if (/baseUrl|api key|apiKey|model|voice|required|empty/i.test(message)) {
+    return 400
+  }
+
+  return 502
+}
+
+function sanitizeTtsError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error)
+  const redacted = raw
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [redacted]')
+    .replace(/sk-[A-Za-z0-9_-]{12,}/g, 'sk-[redacted]')
+    .replace(/"api[_-]?key"\s*:\s*"[^"]+"/gi, '"apiKey":"[redacted]"')
+    .replace(/'api[_-]?key'\s*:\s*'[^']+'/gi, "'apiKey':'[redacted]'")
+    .replace(/api[_-]?key=[^\s&]+/gi, 'apiKey=[redacted]')
+    .replace(/\*{3,}/g, '[redacted]')
+
+  return redacted.length > 600 ? `${redacted.slice(0, 600)}…` : redacted
+}
+
+function createRequestAbortController(ctx: Context): AbortController {
+  const controller = new AbortController()
+
+  const abort = () => {
+    if (!controller.signal.aborted) {
+      controller.abort()
+    }
+  }
+
+  if (ctx.req?.on) {
+    // IncomingMessage "close" fires after the request body is fully consumed in
+    // normal POSTs, which aborted every TTS test request before synthesis could
+    // complete. Only "aborted" is a reliable client-disconnect signal here.
+    ctx.req.on('aborted', abort)
+  }
+
+  if (ctx.res?.on) {
+    ctx.res.on('close', () => {
+      // ServerResponse "close" also fires after successful completion; abort
+      // only when the response did not finish normally.
+      if (!ctx.res.writableEnded) {
+        abort()
+      }
+    })
+  }
+
+  return controller
 }
 
 function isAbortError(error: unknown): boolean {

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -198,6 +198,23 @@ export const STT_USER_SETTINGS_SCHEMA: Record<string, string> = {
   updated_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
 }
 
+export const TTS_PROVIDER_SETTINGS_TABLE = 'tts_provider_settings'
+
+export const TTS_PROVIDER_SETTINGS_SCHEMA: Record<string, string> = {
+  id: 'INTEGER PRIMARY KEY AUTOINCREMENT',
+  user_id: 'INTEGER NOT NULL',
+  provider: 'TEXT NOT NULL',
+  settings_json: `TEXT NOT NULL DEFAULT '{}'`,
+  secrets_json: `TEXT NOT NULL DEFAULT '{}'`,
+  created_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+  updated_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+}
+
+export const TTS_PROVIDER_SETTINGS_INDEXES = {
+  idx_tts_provider_settings_user: 'CREATE INDEX IF NOT EXISTS idx_tts_provider_settings_user ON tts_provider_settings(user_id)',
+  idx_tts_provider_settings_user_provider: 'CREATE UNIQUE INDEX IF NOT EXISTS idx_tts_provider_settings_user_provider ON tts_provider_settings(user_id, provider)',
+}
+
 // ============================================================================
 // Group Chat (services/hermes/group-chat/index.ts)
 // ============================================================================
@@ -485,6 +502,9 @@ export function initAllHermesTables(): void {
     })
     syncTable(STT_USER_SETTINGS_TABLE, STT_USER_SETTINGS_SCHEMA)
     migrateLegacySttProviderSettingsUserIdDefault(db)
+    syncTable(TTS_PROVIDER_SETTINGS_TABLE, TTS_PROVIDER_SETTINGS_SCHEMA, {
+      indexes: TTS_PROVIDER_SETTINGS_INDEXES,
+    })
 
     // Group chat - basic tables
     syncTable(GC_ROOMS_TABLE, GC_ROOMS_SCHEMA)

--- a/packages/server/src/db/hermes/tts-settings-store.ts
+++ b/packages/server/src/db/hermes/tts-settings-store.ts
@@ -1,0 +1,344 @@
+import { getDb } from '../index'
+import { TTS_PROVIDER_SETTINGS_TABLE } from './schemas'
+import { normalizeSafeTtsBaseUrl } from '../../services/hermes/tts-providers/url-safety'
+
+export type StoredTtsProvider = 'openai' | 'custom' | 'edge' | 'mimo'
+
+const SETTINGS_KEYS = [
+  'baseUrl',
+  'baseUrlPresets',
+  'model',
+  'voice',
+  'rate',
+  'pitch',
+  'authMode',
+  'voiceMode',
+  'voiceDesignDesc',
+  'voiceCloneFormat',
+  'stylePrompt',
+] as const
+const SECRET_KEYS = ['apiKey'] as const
+
+type TtsSettingKey = (typeof SETTINGS_KEYS)[number]
+type TtsSecretKey = (typeof SECRET_KEYS)[number]
+
+export type TtsStoredSettings = Partial<Record<Exclude<TtsSettingKey, 'baseUrlPresets'>, string>> & { baseUrlPresets?: string[] }
+export type TtsStoredSecrets = Partial<Record<TtsSecretKey, string>>
+
+export interface StoredTtsProviderRow {
+  userId: number
+  provider: StoredTtsProvider
+  settings: TtsStoredSettings
+  secrets: TtsStoredSecrets
+  createdAt: number
+  updatedAt: number
+}
+
+export class TtsSettingsValidationError extends Error {}
+
+const STORED_MARKER = '[stored]'
+const MAX_TEXT_SETTING_LENGTH = 2000
+const MAX_BASE_URL_PRESETS = 20
+const PROVIDERS: StoredTtsProvider[] = ['custom', 'edge', 'mimo', 'openai']
+const PROVIDER_SQL_PLACEHOLDERS = PROVIDERS.map(() => '?').join(', ')
+const PROVIDER_LABELS: Record<StoredTtsProvider, string> = {
+  openai: 'OpenAI TTS',
+  custom: 'Custom TTS',
+  edge: 'Edge TTS',
+  mimo: 'MiMo TTS',
+}
+
+type StoredRow = {
+  user_id: number
+  provider: string
+  settings_json: string
+  secrets_json: string
+  created_at: number
+  updated_at: number
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  return isPlainObject(value) ? value : {}
+}
+
+function parseJsonObject(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw)
+    return asObject(parsed)
+  } catch {
+    return {}
+  }
+}
+
+function requireDb() {
+  const db = getDb()
+  if (!db) {
+    throw new Error('TTS settings storage unavailable')
+  }
+  return db
+}
+
+function normalizeUserId(userId: number): number {
+  if (!Number.isInteger(userId) || userId <= 0) {
+    throw new TtsSettingsValidationError('invalid user id')
+  }
+  return userId
+}
+
+export function isStoredTtsProvider(provider: string): provider is StoredTtsProvider {
+  return PROVIDERS.includes(provider as StoredTtsProvider)
+}
+
+export function assertStoredTtsProvider(provider: string): StoredTtsProvider {
+  if (!isStoredTtsProvider(provider)) {
+    throw new TtsSettingsValidationError('unknown TTS provider')
+  }
+  return provider
+}
+
+function assertKnownSecretName(secretName: string): TtsSecretKey {
+  if (!SECRET_KEYS.includes(secretName as TtsSecretKey)) {
+    throw new TtsSettingsValidationError('unknown TTS provider secret')
+  }
+  return secretName as TtsSecretKey
+}
+
+function readStoredRow(userId: number, provider: StoredTtsProvider): StoredRow | null {
+  const db = getDb()
+  if (!db) return null
+  return db.prepare(
+    `SELECT user_id, provider, settings_json, secrets_json, created_at, updated_at FROM ${TTS_PROVIDER_SETTINGS_TABLE} WHERE user_id = ? AND provider = ?`
+  ).get(userId, provider) as StoredRow | null
+}
+
+function normalizeBaseUrlPresets(provider: StoredTtsProvider, input: unknown): string[] {
+  const values = Array.isArray(input) ? input : []
+  const out: string[] = []
+  const seen = new Set<string>()
+
+  for (const rawValue of values) {
+    if (typeof rawValue !== 'string') continue
+    const value = rawValue.trim()
+    if (!value) continue
+
+    let normalized: string
+    try {
+      normalized = normalizeSafeTtsBaseUrl(value, PROVIDER_LABELS[provider])
+    } catch (error) {
+      throw new TtsSettingsValidationError(error instanceof Error ? error.message : String(error))
+    }
+
+    if (seen.has(normalized)) continue
+    seen.add(normalized)
+    out.push(normalized)
+    if (out.length >= MAX_BASE_URL_PRESETS) break
+  }
+
+  return out
+}
+
+function appendBaseUrlPreset(provider: StoredTtsProvider, settings: TtsStoredSettings): TtsStoredSettings {
+  if (!settings.baseUrl) return settings
+  const presets = normalizeBaseUrlPresets(provider, settings.baseUrlPresets || [])
+  if (!presets.includes(settings.baseUrl)) {
+    presets.unshift(settings.baseUrl)
+  }
+  return { ...settings, baseUrlPresets: presets.slice(0, MAX_BASE_URL_PRESETS) }
+}
+
+function sanitizeStoredSettings(provider: StoredTtsProvider, input: Record<string, unknown>): TtsStoredSettings {
+  const out: TtsStoredSettings = {}
+
+  for (const key of SETTINGS_KEYS) {
+    const rawValue = input[key]
+
+    if (key === 'baseUrlPresets') {
+      const presets = normalizeBaseUrlPresets(provider, rawValue)
+      if (presets.length) out.baseUrlPresets = presets
+      continue
+    }
+
+    if (typeof rawValue !== 'string') continue
+    const value = rawValue.trim()
+    if (!value) continue
+
+    if (key === 'baseUrl') {
+      try {
+        out.baseUrl = normalizeSafeTtsBaseUrl(value, PROVIDER_LABELS[provider])
+      } catch (error) {
+        throw new TtsSettingsValidationError(error instanceof Error ? error.message : String(error))
+      }
+      continue
+    }
+
+    out[key] = value.slice(0, MAX_TEXT_SETTING_LENGTH)
+  }
+
+  return out
+}
+
+function sanitizeStoredSecrets(input: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {}
+
+  for (const key of Object.keys(input)) {
+    assertKnownSecretName(key)
+  }
+
+  const rawApiKey = input.apiKey
+  if (typeof rawApiKey !== 'string') {
+    return out
+  }
+
+  const apiKey = rawApiKey.trim()
+  if (!apiKey || apiKey === STORED_MARKER) {
+    return out
+  }
+
+  out.apiKey = apiKey
+  return out
+}
+
+function maskSecrets(secrets: Record<string, string>): Record<string, string> {
+  const masked: Record<string, string> = {}
+  if (secrets.apiKey) masked.apiKey = STORED_MARKER
+  return masked
+}
+
+function rowToResult(row: StoredRow, includeSecrets: boolean): StoredTtsProviderRow {
+  const provider = assertStoredTtsProvider(row.provider)
+  const settings = sanitizeStoredSettings(provider, parseJsonObject(row.settings_json))
+  const secrets = sanitizeStoredSecrets(parseJsonObject(row.secrets_json))
+
+  return {
+    userId: Number(row.user_id),
+    provider,
+    settings,
+    secrets: includeSecrets ? secrets : maskSecrets(secrets),
+    createdAt: Number(row.created_at || 0),
+    updatedAt: Number(row.updated_at || 0),
+  }
+}
+
+export function listTtsProviderSettings(userId: number): StoredTtsProviderRow[] {
+  const id = normalizeUserId(userId)
+  const db = getDb()
+  if (!db) return []
+
+  const rows = db.prepare(
+    `SELECT user_id, provider, settings_json, secrets_json, created_at, updated_at
+     FROM ${TTS_PROVIDER_SETTINGS_TABLE}
+     WHERE user_id = ? AND provider IN (${PROVIDER_SQL_PLACEHOLDERS})
+     ORDER BY provider ASC`
+  ).all(id, ...PROVIDERS) as StoredRow[]
+
+  return rows.map(row => rowToResult(row, false))
+}
+
+export function getTtsProviderSetting(
+  userId: number,
+  provider: StoredTtsProvider,
+  options?: { includeSecrets?: boolean },
+): StoredTtsProviderRow | null {
+  const id = normalizeUserId(userId)
+  const storedProvider = assertStoredTtsProvider(provider)
+  const row = readStoredRow(id, storedProvider)
+  return row ? rowToResult(row, options?.includeSecrets === true) : null
+}
+
+export function saveTtsProviderSetting(
+  userId: number,
+  provider: StoredTtsProvider,
+  input: { settings?: unknown; secrets?: unknown },
+): StoredTtsProviderRow {
+  const id = normalizeUserId(userId)
+  const storedProvider = assertStoredTtsProvider(provider)
+  const db = requireDb()
+  const existing = readStoredRow(id, storedProvider)
+  const existingSettings = existing ? sanitizeStoredSettings(storedProvider, parseJsonObject(existing.settings_json)) : {}
+  const existingSecrets = existing ? sanitizeStoredSecrets(parseJsonObject(existing.secrets_json)) : {}
+  const nextSettings = sanitizeStoredSettings(storedProvider, asObject(input.settings))
+  const nextSecretsObject = asObject(input.secrets)
+
+  for (const key of Object.keys(nextSecretsObject)) {
+    assertKnownSecretName(key)
+  }
+
+  const nextSecrets = sanitizeStoredSecrets(nextSecretsObject)
+  const mergedSettings = appendBaseUrlPreset(storedProvider, { ...existingSettings, ...nextSettings })
+  const mergedSecrets = { ...existingSecrets, ...nextSecrets }
+  const now = Date.now()
+
+  db.prepare(
+    `INSERT INTO ${TTS_PROVIDER_SETTINGS_TABLE} (user_id, provider, settings_json, secrets_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(user_id, provider) DO UPDATE SET
+       settings_json = excluded.settings_json,
+       secrets_json = excluded.secrets_json,
+       updated_at = excluded.updated_at`
+  ).run(id, storedProvider, JSON.stringify(mergedSettings), JSON.stringify(mergedSecrets), existing?.created_at || now, now)
+
+  return getTtsProviderSetting(id, storedProvider) as StoredTtsProviderRow
+}
+
+export function removeTtsBaseUrlPreset(
+  userId: number,
+  provider: StoredTtsProvider,
+  url: string,
+): StoredTtsProviderRow | null {
+  const id = normalizeUserId(userId)
+  const storedProvider = assertStoredTtsProvider(provider)
+  const normalizedUrl = normalizeSafeTtsBaseUrl(url, PROVIDER_LABELS[storedProvider])
+  const db = requireDb()
+  const existing = readStoredRow(id, storedProvider)
+  if (!existing) return null
+
+  const settings = sanitizeStoredSettings(storedProvider, parseJsonObject(existing.settings_json))
+  const secrets = sanitizeStoredSecrets(parseJsonObject(existing.secrets_json))
+  const nextPresets = normalizeBaseUrlPresets(storedProvider, settings.baseUrlPresets || [])
+    .filter(preset => preset !== normalizedUrl)
+
+  if (settings.baseUrl === normalizedUrl) {
+    delete settings.baseUrl
+  }
+
+  if (nextPresets.length) {
+    settings.baseUrlPresets = nextPresets
+  } else {
+    delete settings.baseUrlPresets
+  }
+
+  const now = Date.now()
+  db.prepare(
+    `UPDATE ${TTS_PROVIDER_SETTINGS_TABLE} SET settings_json = ?, secrets_json = ?, updated_at = ? WHERE user_id = ? AND provider = ?`
+  ).run(JSON.stringify(settings), JSON.stringify(secrets), now, id, storedProvider)
+
+  return getTtsProviderSetting(id, storedProvider)
+}
+
+export function clearStoredTtsSecret(
+  userId: number,
+  provider: StoredTtsProvider,
+  secretName: string,
+): StoredTtsProviderRow | null {
+  const id = normalizeUserId(userId)
+  const storedProvider = assertStoredTtsProvider(provider)
+  const secretKey = assertKnownSecretName(secretName)
+  const db = requireDb()
+  const existing = readStoredRow(id, storedProvider)
+  if (!existing) return null
+
+  const settings = sanitizeStoredSettings(storedProvider, parseJsonObject(existing.settings_json))
+  const secrets = sanitizeStoredSecrets(parseJsonObject(existing.secrets_json))
+  delete secrets[secretKey]
+  const now = Date.now()
+
+  db.prepare(
+    `UPDATE ${TTS_PROVIDER_SETTINGS_TABLE} SET settings_json = ?, secrets_json = ?, updated_at = ? WHERE user_id = ? AND provider = ?`
+  ).run(JSON.stringify(settings), JSON.stringify(secrets), now, id, storedProvider)
+
+  return getTtsProviderSetting(id, storedProvider)
+}

--- a/packages/server/src/routes/hermes/tts.ts
+++ b/packages/server/src/routes/hermes/tts.ts
@@ -7,4 +7,8 @@ export const ttsProtectedRoutes = new Router()
 ttsRoutes.post('/api/hermes/tts', ctrl.generate)
 ttsRoutes.post('/api/tts/proxy/audio/speech', ctrl.openaiProxy)
 
+ttsProtectedRoutes.get('/api/hermes/tts/settings', ctrl.listSettings)
+ttsProtectedRoutes.put('/api/hermes/tts/settings/:provider', ctrl.saveSettings)
+ttsProtectedRoutes.delete('/api/hermes/tts/settings/:provider/base-url-preset', ctrl.deleteBaseUrlPreset)
+ttsProtectedRoutes.delete('/api/hermes/tts/settings/:provider/secret/:secretName', ctrl.deleteSecret)
 ttsProtectedRoutes.post('/api/hermes/tts/synthesize', ctrl.synthesize)


### PR DESCRIPTION
## Summary

添加持久化 voice provider settings 页面。

- 新增 TTS provider settings 存储与受保护 settings routes。
- 新增 TTS/STT provider cards。
- 展示 built-in provider 与已保存 provider，并对 stored secret 状态做 masking。
- 新增 provider 配置与清除 secret 的 UI。
- 将 settings 页面连接到持久化的 STT/TTS provider 选择。

## Stack

这是 5 个 stacked PR 中的第 4 个，请按以下顺序 review/merge：

1. #1396 — STT provider 基础设施
2. #1397 — 可编辑聊天语音输入
3. #1398 — TTS playback resume 安全性
4. #1399 — voice provider settings cards
5. #1400 — voice provider model discovery flow

当前 PR: #1399 — voice provider settings cards
当前 PR branch: `voice/provider-settings-cards`
当前 PR base: `voice/tts-playback-resume`
## Verification

- `npx vue-tsc --noEmit -p tsconfig.app.json`
- `npm run build`
- `npm run harness:check`

Result: passed (`vue-tsc`, production build, and harness check passed).
