### PR TITLE
[codex] fix legacy usage updated_at inserts

### DIFF
--- a/packages/server/src/db/hermes/usage-store.ts
+++ b/packages/server/src/db/hermes/usage-store.ts
@@ -12,6 +12,17 @@ export interface UsageRecord {
   created_at: number
 }
 
+function hasUpdatedAtColumn(): boolean {
+  const db = getDb()
+  if (!db) return false
+  try {
+    const rows = db.prepare(`PRAGMA table_info("${TABLE}")`).all() as unknown
+    return Array.isArray(rows) && rows.some((row: any) => row?.name === 'updated_at')
+  } catch {
+    return false
+  }
+}
+
 export function updateUsage(
   sessionId: string,
   data: {
@@ -32,10 +43,37 @@ export function updateUsage(
   const profile = data.profile || 'default'
   if (isSqliteAvailable()) {
     const db = getDb()!
+    const columns = [
+      'session_id',
+      'input_tokens',
+      'output_tokens',
+      'cache_read_tokens',
+      'cache_write_tokens',
+      'reasoning_tokens',
+      'model',
+      'profile',
+      'created_at',
+    ]
+    const values = columns.map(() => '?')
+    const params = [
+      sessionId,
+      data.inputTokens,
+      data.outputTokens,
+      cacheReadTokens,
+      cacheWriteTokens,
+      reasoningTokens,
+      model,
+      profile,
+      now,
+    ]
+    if (hasUpdatedAtColumn()) {
+      columns.push('updated_at')
+      values.push('?')
+      params.push(now)
+    }
     db.prepare(
-      `INSERT INTO ${TABLE} (session_id, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, model, profile, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    ).run(sessionId, data.inputTokens, data.outputTokens, cacheReadTokens, cacheWriteTokens, reasoningTokens, model, profile, now)
+      `INSERT INTO ${TABLE} (${columns.join(', ')}) VALUES (${values.join(', ')})`,
+    ).run(...params)
   } else {
     jsonSet(TABLE, sessionId, {
       input_tokens: data.inputTokens,

--- a/tests/server/usage-store.test.ts
+++ b/tests/server/usage-store.test.ts
@@ -164,6 +164,29 @@ describe('Usage Store (SQLite path)', () => {
     )
   })
 
+  it('updateUsage writes updated_at when a legacy SQLite table has the column', async () => {
+    allMock.mockReturnValueOnce([
+      { name: 'id' },
+      { name: 'session_id' },
+      { name: 'created_at' },
+      { name: 'updated_at' },
+    ])
+    const { updateUsage } = await import('../../packages/server/src/db/hermes/usage-store')
+    updateUsage('s1', { inputTokens: 500, outputTokens: 200 })
+    expect(runMock).toHaveBeenCalledWith(
+      's1',
+      500,
+      200,
+      0, // cacheReadTokens
+      0, // cacheWriteTokens
+      0, // reasoningTokens
+      '', // model
+      'default', // profile
+      expect.any(Number), // created_at
+      expect.any(Number), // updated_at
+    )
+  })
+
   it('getUsage queries by session_id', async () => {
     getMock.mockReturnValue({
       input_tokens: 999,


### PR DESCRIPTION
## Summary
- Keep the canonical `session_usage` schema unchanged.
- Detect legacy SQLite tables that still contain an `updated_at` column and include a timestamp value when inserting usage rows.
- Add focused coverage for the legacy `updated_at` insert path.

## Why
Some local databases can have an old `session_usage.updated_at INTEGER NOT NULL` column even though the current canonical schema no longer includes it. Inserting without that column can fail with `NOT NULL constraint failed: session_usage.updated_at`.

This avoids adopting `updated_at` as a formal schema/API field and preserves the current `session_usage` history model.

Refs #1387

## Validation
- `npm run test -- tests/server/usage-store.test.ts tests/server/schema-sync.test.ts`
- `npm run harness:check`
- `npm run build`