### PR TITLE
fix: 修复 TTS 文本过滤时小数点丢失，导致金额朗读错误 (#1404)

### DIFF
--- a/packages/client/src/composables/useSpeech.ts
+++ b/packages/client/src/composables/useSpeech.ts
@@ -90,7 +90,7 @@ export function useSpeech() {
     // 移除 HTML 标签
     text = text.replace(/<[^>]+>/g, '')
 
-    text = text.replace(/[^\p{L}\p{N}\s。!?;,，。！？；：、""''（）【】《》\n一-鿿㐀-䶿]/gu, '')
+    text = text.replace(/[^\p{L}\p{N}\s.。!?;,，。！？；：、""''（）【】《》\n一-鿿㐀-䶿]/gu, '')
 
     text = text.replace(/\s+/g, ' ').trim()
 


### PR DESCRIPTION
    Bug Description
    
    useSpeech.ts 中的 extractReadableText() 正则表达式过滤掉了小数点，
    导致包含金额的文本（如 123.45）被错误过滤为 12345，TTS 朗读时发音不正确。
    
    Fix
    
    在正则字符类中添加 . 使小数点被保留。
    
    修改前： [^\p{L}\p{N}\s。!?;,...]
    修改后： [^\p{L}\p{N}\s.。!?;,...]
    
    Testing
    
    本地验证：
    - "这个价格是 123.45 元" 修复前输出 "这个价格是 12345 元"，修复后正确保留 123.45
    - "The cost is 3.14 dollars" 修复后正确保留 3.14
    
    Closes #1404