### PR TITLE
[codex] fix Codex tool final text

### DIFF
--- a/docs/chat-chain-changes/2026-06-08-coding-agent-tool-output-storage-limit.md
+++ b/docs/chat-chain-changes/2026-06-08-coding-agent-tool-output-storage-limit.md
@@ -1,4 +1,9 @@
-# Coding Agent Tool Output Storage Limit
+---
+date: 2026-06-08
+pr: pending
+feature: Coding-agent tool output storage
+impact: Claude Code and Codex tool results are truncated before SQLite storage to limit database growth.
+---
 
 - Scope: Claude Code and Codex runs handled by `agent-runner`.
 - Change: truncate `function_call_output` before it enters the shared response stream state and SQLite flush path.

--- a/docs/chat-chain-changes/2026-06-08-coding-agent-tool-output-storage-limit.md
+++ b/docs/chat-chain-changes/2026-06-08-coding-agent-tool-output-storage-limit.md
@@ -1,0 +1,6 @@
+# Coding Agent Tool Output Storage Limit
+
+- Scope: Claude Code and Codex runs handled by `agent-runner`.
+- Change: truncate `function_call_output` before it enters the shared response stream state and SQLite flush path.
+- Limit: keep the first 24 KiB and last 8 KiB of large tool results, with a storage truncation marker in the middle.
+- Non-goals: regular Hermes chat, assistant text, user messages, and tool call arguments are unchanged.

--- a/docs/chat-chain-changes/2026-06-08-local-codex-tool-final-text.md
+++ b/docs/chat-chain-changes/2026-06-08-local-codex-tool-final-text.md
@@ -1,0 +1,11 @@
+---
+date: 2026-06-08
+pr: pending
+feature: Coding-agent Codex response stream
+impact: Codex final assistant messages after tool execution are no longer dropped as duplicate output.
+---
+
+- Touched feature: coding-agent chat sessions.
+- Change: Codex `agent_message` completion text that differs from prior streamed text is appended only when the current run most recently emitted a tool boundary.
+- Behavior impact: turns with an opening assistant message, tool execution, and a distinct final answer persist both assistant messages while still deduplicating replayed Codex snapshots.
+- Validation: focused agent-runner Vitest coverage.

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -1310,7 +1310,22 @@ export class CodingAgentRunManager {
     if (textTrimmed === existingTrimmed || existingTrimmed.endsWith(textTrimmed)) return
     if (textTrimmed.startsWith(existingTrimmed)) {
       this.appendCodexText(run, text.slice(existingTrimmed.length))
+      return
     }
+    if (this.codexLastRunMessageIsToolBoundary(run)) {
+      this.appendCodexText(run, text)
+    }
+  }
+
+  private codexLastRunMessageIsToolBoundary(run: ManagedCodingAgentRun): boolean {
+    const marker = run.runMarker
+    if (!marker) return false
+    for (let index = run.state.messages.length - 1; index >= 0; index--) {
+      const message = run.state.messages[index]
+      if (message.runMarker !== marker) continue
+      return message.role === 'tool' || Boolean(message.tool_calls?.length)
+    }
+    return false
   }
 
   private appendCodexText(run: ManagedCodingAgentRun, text: string) {

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -13,6 +13,9 @@ import { mapCodingAgentResponseEvent } from './coding-agent-event-mapper'
 const DEFAULT_IDLE_MS = 30 * 60 * 1000
 const TERMINAL_OUTPUT_FLUSH_MS = 120
 const MAX_TERMINAL_EVENT_CHARS = 4000
+const CODING_AGENT_TOOL_OUTPUT_STORAGE_LIMIT = 32 * 1024
+const CODING_AGENT_TOOL_OUTPUT_HEAD_CHARS = 24 * 1024
+const CODING_AGENT_TOOL_OUTPUT_TAIL_CHARS = 8 * 1024
 
 let pty: any = null
 
@@ -123,6 +126,59 @@ function isCodexProxyExecToolEvent(event: CanonicalResponsesEvent): boolean {
   }
   const name = String(item.name || item.function?.name || '').trim()
   return name === 'exec_command' || name === 'functions.exec_command'
+}
+
+function truncateCodingAgentToolOutputForStorage(output: unknown): string {
+  const text = typeof output === 'string' ? output : JSON.stringify(output ?? '')
+  if (text.length <= CODING_AGENT_TOOL_OUTPUT_STORAGE_LIMIT) return text
+  const head = text.slice(0, CODING_AGENT_TOOL_OUTPUT_HEAD_CHARS)
+  const tail = text.slice(-CODING_AGENT_TOOL_OUTPUT_TAIL_CHARS)
+  const omitted = text.length - head.length - tail.length
+  return [
+    head,
+    '',
+    `[Hermes Web UI: coding-agent tool output truncated for storage; original_chars=${text.length}; omitted_chars=${omitted}]`,
+    '',
+    tail,
+  ].join('\n')
+}
+
+function truncateCodingAgentToolOutputItem(item: any): any {
+  if (!item || item.type !== 'function_call_output') return item
+  const nextOutput = truncateCodingAgentToolOutputForStorage(item.output)
+  if (nextOutput === item.output) return item
+  return { ...item, output: nextOutput }
+}
+
+function truncateCodingAgentToolOutputEvent(event: CanonicalResponsesEvent): CanonicalResponsesEvent {
+  const data: any = event.data || {}
+  if (event.type === 'response.output_item.done') {
+    const item = data.item || data.output_item || data
+    const nextItem = truncateCodingAgentToolOutputItem(item)
+    if (nextItem === item) return event
+    if (data.item) return { ...event, data: { ...data, item: nextItem } }
+    if (data.output_item) return { ...event, data: { ...data, output_item: nextItem } }
+    return { ...event, data: nextItem }
+  }
+
+  if (event.type === 'response.completed') {
+    const response = data.response || data
+    const output = Array.isArray(response?.output) ? response.output : null
+    if (!output) return event
+    let changed = false
+    const nextOutput = output.map((item: any) => {
+      const nextItem = truncateCodingAgentToolOutputItem(item)
+      if (nextItem !== item) changed = true
+      return nextItem
+    })
+    if (!changed) return event
+    const nextResponse = { ...response, output: nextOutput }
+    return data.response
+      ? { ...event, data: { ...data, response: nextResponse } }
+      : { ...event, data: nextResponse }
+  }
+
+  return event
 }
 
 function isPrintAgent(agentId: string): boolean {
@@ -400,18 +456,19 @@ export class CodingAgentRunManager {
     if (run.launch.agentId === 'codex' && isCodexProxyExecToolEvent(event)) return
     const responseEvent = this.normalizeCodexChatTextEvent(run, event)
     if (!responseEvent) return
+    const storageSafeResponseEvent = truncateCodingAgentToolOutputEvent(responseEvent)
     if (run.launch.agentId === 'claude-code' && run.currentChild && !run.acceptingPrintEvent && !isProxyToolEvent(event)) return
-    if (responseEvent.type === 'response.created') {
+    if (storageSafeResponseEvent.type === 'response.created') {
       if (run.responseStartEmitted) return
       run.responseStartEmitted = true
     }
-    const isTerminalEvent = responseEvent.type === 'response.completed' || responseEvent.type === 'response.failed'
+    const isTerminalEvent = storageSafeResponseEvent.type === 'response.completed' || storageSafeResponseEvent.type === 'response.failed'
     if (
       run.launch.agentId === 'codex' &&
-      responseEvent.type === 'response.completed' &&
+      storageSafeResponseEvent.type === 'response.completed' &&
       childIsRunning(run.currentChild)
     ) {
-      const final = (responseEvent.data as any).response || responseEvent.data
+      const final = (storageSafeResponseEvent.data as any).response || storageSafeResponseEvent.data
       run.codexPendingUsage = final?.usage ?? run.codexPendingUsage
       return
     }
@@ -426,18 +483,18 @@ export class CodingAgentRunManager {
     run.state.profile = run.launch.profile
     run.state.source = 'coding_agent'
     run.state.runId = run.id
-    for (const mappedEvent of mapCodingAgentResponseEvent(responseEvent)) {
+    for (const mappedEvent of mapCodingAgentResponseEvent(storageSafeResponseEvent)) {
       this.emitToChat(run.launch.sessionId, mappedEvent.event, mappedEvent.payload)
     }
-    const mapped = applyResponseStreamEvent(run.state, run.launch.sessionId, run.runMarker, responseEvent.type, responseEvent.data)
+    const mapped = applyResponseStreamEvent(run.state, run.launch.sessionId, run.runMarker, storageSafeResponseEvent.type, storageSafeResponseEvent.data)
     if (mapped) this.emitToChat(run.launch.sessionId, mapped.event, mapped.payload)
     if (isTerminalEvent) {
       flushResponseRunToDb(run.state, run.launch.sessionId)
       run.state.responseRun = undefined
       updateSessionStats(run.launch.sessionId)
-      const final = (responseEvent.data as any).response || responseEvent.data
+      const final = (storageSafeResponseEvent.data as any).response || storageSafeResponseEvent.data
       const finalText = extractResponseText(final)
-      const chatCompletionEvent = responseEvent.type === 'response.completed' ? 'run.completed' : 'run.failed'
+      const chatCompletionEvent = storageSafeResponseEvent.type === 'response.completed' ? 'run.completed' : 'run.failed'
       const chatCompletionPayload: Record<string, unknown> = {
         event: chatCompletionEvent,
         run_id: final?.id,

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -951,6 +951,91 @@ describe('coding agent run state', () => {
     manager.shutdown()
   })
 
+  it('truncates large coding-agent tool outputs before emitting and flushing to SQLite', () => {
+    initAllHermesTables()
+    const manager = new CodingAgentRunManager()
+    const state: any = { messages: [], isWorking: false, events: [], queue: [] }
+    const emitted: Array<{ event: string; payload: any }> = []
+    ;(manager as any).emitToChat = (_sessionId: string, event: string, payload: any) => {
+      emitted.push({ event, payload })
+    }
+    ;(manager as any).markChatRunCompleted = () => {}
+    const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    const agentSessionId = `agent-session-codex-large-tool-${suffix}`
+    const chatSessionId = `chat-session-codex-large-tool-${suffix}`
+    manager.start({
+      agentSessionId,
+      agentId: 'codex',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'gpt-5-codex',
+      sessionId: chatSessionId,
+      command: 'codex',
+      args: ['--model', 'gpt-5-codex'],
+      shellCommand: 'codex --model gpt-5-codex',
+      workspaceDir: process.cwd(),
+      state,
+    })
+    const run = (manager as any).runs.get(agentSessionId)
+    const largeOutput = `HEAD-${'a'.repeat(80 * 1024)}-TAIL`
+
+    ;(manager as any).handleClaudePrintResponseEvent(run, {
+      type: 'response.created',
+      data: { response: { id: 'resp_large_tool', status: 'in_progress', model: 'gpt-5-codex', output: [] } },
+    })
+    ;(manager as any).handleClaudePrintResponseEvent(run, {
+      type: 'response.output_item.added',
+      data: {
+        item: {
+          type: 'function_call',
+          id: 'call_large',
+          call_id: 'call_large',
+          name: 'read_file',
+          arguments: '{"path":"big.log"}',
+        },
+      },
+    })
+    ;(manager as any).handleClaudePrintResponseEvent(run, {
+      type: 'response.output_item.done',
+      data: {
+        item: {
+          type: 'function_call',
+          id: 'call_large',
+          call_id: 'call_large',
+          name: 'read_file',
+          arguments: '{"path":"big.log"}',
+        },
+      },
+    })
+    ;(manager as any).handleClaudePrintResponseEvent(run, {
+      type: 'response.output_item.done',
+      data: {
+        item: {
+          type: 'function_call_output',
+          id: 'call_large',
+          call_id: 'call_large',
+          output: largeOutput,
+        },
+      },
+    })
+    ;(manager as any).handleClaudePrintResponseEvent(run, {
+      type: 'response.completed',
+      data: { response: { id: 'resp_large_tool', status: 'completed', model: 'gpt-5-codex', output: [] } },
+    })
+
+    const toolMessage = state.messages.find((message: any) => message.role === 'tool')
+    const completedPayload = emitted.find(event => event.event === 'tool.completed')?.payload as any
+    const dbToolMessage = (getSessionDetail(chatSessionId)?.messages || []).find(message => message.role === 'tool')
+    for (const output of [toolMessage?.content, completedPayload?.output, dbToolMessage?.content]) {
+      expect(output).toContain('HEAD-')
+      expect(output).toContain('-TAIL')
+      expect(output).toContain('coding-agent tool output truncated for storage')
+      expect(output.length).toBeLessThan(largeOutput.length)
+      expect(output.length).toBeLessThan(34 * 1024)
+    }
+    manager.shutdown()
+  })
+
   it('records Codex thread id so follow-up turns can resume the native session', () => {
     initAllHermesTables()
     const manager = new CodingAgentRunManager()

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -686,6 +686,61 @@ describe('coding agent run state', () => {
     manager.shutdown()
   })
 
+  it('does not append unrelated Codex final text without a tool boundary', () => {
+    initAllHermesTables()
+    const manager = new CodingAgentRunManager()
+    const state: any = { messages: [], isWorking: false, events: [], queue: [] }
+    const emitted: Array<{ event: string; payload: any }> = []
+    ;(manager as any).emitToChat = (_sessionId: string, event: string, payload: any) => {
+      emitted.push({ event, payload })
+    }
+    ;(manager as any).markChatRunCompleted = () => {}
+    const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    const agentSessionId = `agent-session-codex-no-tool-final-${suffix}`
+    const chatSessionId = `chat-session-codex-no-tool-final-${suffix}`
+    manager.start({
+      agentSessionId,
+      agentId: 'codex',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'gpt-5-codex',
+      sessionId: chatSessionId,
+      command: 'codex',
+      args: ['--model', 'gpt-5-codex'],
+      shellCommand: 'codex --model gpt-5-codex',
+      workspaceDir: process.cwd(),
+      state,
+    })
+    const run = (manager as any).runs.get(agentSessionId)
+    run.printResponseId = 'resp_codex_no_tool_final'
+    run.printMessageId = 'msg_resp_codex_no_tool_final'
+    run.printTextStarted = false
+    run.printText = ''
+    run.printCompleted = false
+    run.responseStartEmitted = false
+    run.terminalEventHandled = false
+    run.codexToolBlocks = new Map()
+    ;(manager as any).handleClaudePrintResponseEvent(run, {
+      type: 'response.created',
+      data: { response: { id: 'resp_codex_no_tool_final', status: 'in_progress', model: 'gpt-5-codex', output: [] } },
+    })
+
+    ;(manager as any).handleCodexExecLine(run, JSON.stringify({
+      type: 'item.completed',
+      item: { type: 'agent_message', text: 'Initial assistant text.' },
+    }))
+    ;(manager as any).handleCodexExecLine(run, JSON.stringify({
+      type: 'item.completed',
+      item: { type: 'agent_message', text: 'Different final text without tools.' },
+    }))
+    ;(manager as any).completeCodexExecTurn(run)
+
+    const textMessages = state.messages.filter((message: any) => message.role === 'assistant' && !message.tool_calls?.length)
+    expect(textMessages.map((message: any) => message.content)).toEqual(['Initial assistant text.'])
+    expect(emitted.filter(event => event.event === 'message.delta').map(event => event.payload.delta)).toEqual(['Initial assistant text.'])
+    manager.shutdown()
+  })
+
   it('keeps repeated short Codex streaming deltas', () => {
     initAllHermesTables()
     const manager = new CodingAgentRunManager()
@@ -782,6 +837,16 @@ describe('coding agent run state', () => {
       data: { response: { id: 'resp_codex_tool_final', status: 'in_progress', model: 'gpt-5-codex', output: [] } },
     })
 
+    const openingText = '我会先查看你的桌面目录。'
+    ;(manager as any).handleCodexExecLine(run, JSON.stringify({
+      type: 'item.completed',
+      item: { type: 'agent_message', text: openingText },
+    }))
+    expect(state.messages).toContainEqual(expect.objectContaining({
+      role: 'assistant',
+      content: openingText,
+    }))
+
     manager.handleResponseEvent(agentSessionId, {
       type: 'response.output_item.added',
       data: {
@@ -862,17 +927,15 @@ describe('coding agent run state', () => {
 
     const finalText = '你的桌面上有以下 3 个目录：ai素材、cache、git。'
     ;(manager as any).handleCodexExecLine(run, JSON.stringify({
-      method: 'item/agentMessage/delta',
-      params: { delta: finalText },
+      type: 'item.completed',
+      item: { type: 'agent_message', text: finalText },
     }))
     run.currentChild = undefined
     ;(manager as any).completeCodexExecTurn(run, run.codexPendingUsage)
 
-    expect(state.messages).toContainEqual(expect.objectContaining({
-      role: 'assistant',
-      content: finalText,
-      finish_reason: 'stop',
-    }))
+    const textMessages = state.messages.filter((message: any) => message.role === 'assistant' && !message.tool_calls?.length)
+    expect(textMessages.map((message: any) => message.content)).toEqual([openingText, finalText])
+    expect(textMessages.at(-1)).toEqual(expect.objectContaining({ finish_reason: 'stop' }))
     const dbMessages = getSessionDetail(chatSessionId)?.messages || []
     expect(dbMessages.filter(message => message.role === 'assistant' && message.tool_calls?.length)).toHaveLength(1)
     expect(dbMessages).toContainEqual(expect.objectContaining({


### PR DESCRIPTION
## Summary
- Preserve distinct Codex final assistant text after tool execution instead of dropping it as a duplicate replay.
- Keep existing replay/snapshot dedupe behavior for repeated Codex assistant output when no tool boundary exists.
- Add focused agent-runner coverage and a chat-chain change note.

## Root Cause
Codex `item.completed` assistant messages are routed through `appendCodexFinalText`. That helper correctly deduplicated repeated snapshots, but when a turn had an opening assistant message, then tool output, then a different final answer, the final answer did not match any accepted replay/prefix case and was silently ignored. Completion then reused the earlier `run.printText`, which could make the first and last assistant messages identical.

## Impact
Codex coding-agent turns with tool execution now persist both the pre-tool assistant text and the post-tool final answer, while repeated full-output snapshots continue to be deduplicated.

## Validation
- `npm run test -- tests/server/agent-runner-utils.test.ts`
- `npm run harness:check`
- `git diff --check`
