### PR TITLE
fix(server): parse file delete request bodies

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -226,7 +226,13 @@ export async function bootstrap() {
   app.use(cors({ origin: createCorsOriginResolver(config.corsOrigins) }))
   // Raise body limits above the default 1mb: profile avatars and MiMo voice-clone
   // reference audio are posted as base64 data URLs before reaching handlers.
-  app.use(bodyParser({ encoding: 'utf-8', jsonLimit: '20mb', formLimit: '20mb', textLimit: '20mb' }))
+  app.use(bodyParser({
+    encoding: 'utf-8',
+    jsonLimit: '20mb',
+    formLimit: '20mb',
+    textLimit: '20mb',
+    parsedMethods: ['POST', 'PUT', 'PATCH', 'DELETE'],
+  }))
   console.log('[bootstrap] cors + bodyParser registered')
 
   // Register all routes (handles auth internally)

--- a/packages/server/src/routes/hermes/files.ts
+++ b/packages/server/src/routes/hermes/files.ts
@@ -133,7 +133,7 @@ fileRoutes.put('/api/hermes/files/write', async (ctx) => {
 
 // DELETE /api/hermes/files/delete  body: { path, recursive? }
 fileRoutes.delete('/api/hermes/files/delete', async (ctx) => {
-  const { path: relativePath, recursive } = ctx.request.body as { path?: string; recursive?: boolean }
+  const { path: relativePath, recursive } = (ctx.request.body || {}) as { path?: string; recursive?: boolean }
   if (!relativePath) {
     ctx.status = 400
     ctx.body = { error: 'Missing path parameter', code: 'missing_path' }

--- a/tests/server/bootstrap-body-limit.test.ts
+++ b/tests/server/bootstrap-body-limit.test.ts
@@ -8,4 +8,10 @@ describe('bootstrap body parser limits', () => {
     expect(source).toContain("jsonLimit: '20mb'")
     expect(source).toContain("formLimit: '20mb'")
   })
+
+  it('parses DELETE request bodies for file operations', () => {
+    const source = readFileSync('packages/server/src/index.ts', 'utf8')
+
+    expect(source).toMatch(/parsedMethods:\s*\[\s*'POST',\s*'PUT',\s*'PATCH',\s*'DELETE'\s*\]/)
+  })
 })

--- a/tests/server/files-routes.test.ts
+++ b/tests/server/files-routes.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const provider = {
   listDir: vi.fn(),
   stat: vi.fn(),
+  deleteFile: vi.fn(),
+  deleteDir: vi.fn(),
 }
 const createFileProviderMock = vi.fn(async () => provider)
 const resolveHermesPathMock = vi.fn((relativePath: string) => {
@@ -24,6 +26,8 @@ describe('file routes path metadata', () => {
     resolveHermesPathMock.mockClear()
     provider.listDir.mockReset()
     provider.stat.mockReset()
+    provider.deleteFile.mockReset()
+    provider.deleteDir.mockReset()
   })
 
   it('returns absolute paths for listed entries while preserving relative operation paths', async () => {
@@ -81,5 +85,43 @@ describe('file routes path metadata', () => {
       size: 12,
       modTime: '2026-05-20T00:00:00.000Z',
     })
+  })
+
+  it('deletes files from the parsed request body', async () => {
+    provider.deleteFile.mockResolvedValue(undefined)
+
+    const { fileRoutes } = await import('../../packages/server/src/routes/hermes/files')
+    const layer = fileRoutes.stack.find((entry: any) => entry.path === '/api/hermes/files/delete')
+    const ctx: any = {
+      request: { body: { path: 'workspace/weather.txt', recursive: false } },
+      state: { profile: { name: 'research' } },
+      body: null,
+    }
+
+    await layer.stack[0](ctx)
+
+    expect(createFileProviderMock).toHaveBeenCalledWith('research')
+    expect(resolveHermesPathMock).toHaveBeenCalledWith('workspace/weather.txt', 'research')
+    expect(provider.deleteFile).toHaveBeenCalledWith('/home/agent/.hermes/workspace/weather.txt')
+    expect(provider.deleteDir).not.toHaveBeenCalled()
+    expect(ctx.body).toEqual({ ok: true })
+  })
+
+  it('returns missing_path instead of throwing when delete body is absent', async () => {
+    const { fileRoutes } = await import('../../packages/server/src/routes/hermes/files')
+    const layer = fileRoutes.stack.find((entry: any) => entry.path === '/api/hermes/files/delete')
+    const ctx: any = {
+      request: { body: undefined },
+      state: { profile: { name: 'research' } },
+      body: null,
+    }
+
+    await layer.stack[0](ctx)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toEqual({ error: 'Missing path parameter', code: 'missing_path' })
+    expect(createFileProviderMock).not.toHaveBeenCalled()
+    expect(provider.deleteFile).not.toHaveBeenCalled()
+    expect(provider.deleteDir).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
﻿## Summary
- Parse JSON bodies for DELETE requests so `/api/hermes/files/delete` can read the requested path.
- Guard the file delete route against missing request bodies and return the existing `missing_path` response instead of throwing a 500.

## Validation
- `npm run test -- tests/server/files-routes.test.ts tests/server/bootstrap-body-limit.test.ts`
- `npm run build`
