### PR TITLE
[codex] hide reasoning effort for coding agents

### DIFF
--- a/docs/chat-chain-changes/2026-06-09-reasoning-effort-ui-polish.md
+++ b/docs/chat-chain-changes/2026-06-09-reasoning-effort-ui-polish.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-09
+pr: TBD
+commit: pending
+feature: Per-session reasoning effort selector UI polish
+impact: Keeps the existing per-session reasoning effort override for Hermes CLI chats, hides the selector for Coding Agent sessions, and prevents Coding Agent run payloads from carrying the unsupported reasoning_effort override.
+---
+
+This change adds focused ChatInput coverage for selecting a reasoning effort
+option and for hiding the selector in Coding Agent sessions. It also keeps the
+Coding Agent run payload explicit by omitting reasoning_effort until those
+runners support the setting.

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -25,8 +25,6 @@ const { t } = useI18n()
 const message = useMessage()
 const { toolTraceVisible, toggleToolTraceVisible } = useToolTraceVisibility()
 
-// Local patch (reasoning-effort): per-session reasoning effort selector (brain button).
-// Sends override on every run for the active session.
 const reasoningEffortOptions = computed(() => [
   { label: t('chat.reasoningEffort.options.default'), value: '' },
   { label: t('chat.reasoningEffort.options.none'), value: 'none' },
@@ -752,8 +750,8 @@ function isImage(type: string): boolean {
         {{ t('chat.attachFiles') }}
       </NTooltip>
 
-      <!-- Local patch (reasoning-effort): per-session reasoning effort selector (brain button). -->
       <NPopselect
+        v-if="!isCodingAgentSession"
         :value="currentReasoningEffort"
         :options="reasoningEffortOptions"
         trigger="click"
@@ -1071,7 +1069,6 @@ function isImage(type: string): boolean {
   }
 }
 
-/* Local patch (reasoning-effort): per-session reasoning effort selector. */
 .reasoning-effort-button {
   &.active {
     color: #4caf50;

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -97,7 +97,7 @@ export interface Session {
   endedAt?: number | null
   lastActiveAt?: number
   workspace?: string | null
-  /** Local patch (reasoning-effort): per-session reasoning effort override.
+  /** Per-session reasoning effort override.
    * Empty string / undefined = use config.yaml default.
    * Values: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' */
   reasoningEffort?: string
@@ -1733,8 +1733,9 @@ export const useChatStore = defineStore('chat', () => {
               apiMode: codingAgentMode === 'global' ? undefined : activeSession.value?.apiMode || providerGroup?.api_mode || undefined,
             }
           : {}),
-        // Per-session reasoning effort override.
-        reasoning_effort: activeSession.value?.reasoningEffort || undefined,
+        // Per-session reasoning effort override. Coding Agent runners do not
+        // consume this setting yet, so keep their payloads explicit.
+        reasoning_effort: sessionSource === 'coding_agent' ? undefined : activeSession.value?.reasoningEffort || undefined,
       }
       if (shouldSendInitialSessionConfig && activeSession.value) {
         activeSession.value.messageCount = Math.max(activeSession.value.messageCount || 0, 1)
@@ -3156,7 +3157,6 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  // Local patch (reasoning-effort): per-session reasoning effort.
   // Persisted in localStorage keyed by sessionId so the choice survives
   // page reloads. Cleared on session deletion is NOT implemented (best-effort
   // — orphan keys are tiny and never read again).

--- a/tests/client/chat-input-draft.test.ts
+++ b/tests/client/chat-input-draft.test.ts
@@ -16,7 +16,25 @@ vi.mock('naive-ui', () => ({
   NSwitch: { template: '<button type="button"></button>' },
   NModal: { template: '<div><slot /><slot name="footer" /></div>' },
   NInputNumber: { template: '<input />' },
-  NPopselect: { template: '<div><slot /></div>' },
+  NPopselect: {
+    props: ['value', 'options'],
+    emits: ['update:value'],
+    template: `
+      <div class="n-popselect-stub">
+        <slot />
+        <button
+          v-for="option in options"
+          :key="option.value"
+          type="button"
+          class="n-popselect-option"
+          :data-value="option.value"
+          @click="$emit('update:value', option.value)"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+    `,
+  },
   useMessage: () => ({ error: vi.fn(), success: vi.fn() }),
 }))
 
@@ -97,5 +115,28 @@ describe('ChatInput draft persistence', () => {
 
     expect(wrapper.find('.context-info').exists()).toBe(false)
     expect(wrapper.find('.context-bar').exists()).toBe(false)
+  })
+
+  it('hides reasoning effort selector for coding-agent sessions', async () => {
+    const wrapper = mountForSession('session-codex', {
+      source: 'coding_agent',
+      agent: 'codex',
+      codingAgentId: 'codex',
+    })
+    await nextTick()
+
+    expect(wrapper.find('.n-popselect-stub').exists()).toBe(false)
+    expect(wrapper.find('[data-value="high"]').exists()).toBe(false)
+  })
+
+  it('stores the selected reasoning effort for the active session', async () => {
+    const wrapper = mountForSession('session-reasoning')
+    const store = useChatStore()
+
+    await wrapper.get('[data-value="high"]').trigger('click')
+    await nextTick()
+
+    expect(store.sessions[0].reasoningEffort).toBe('high')
+    expect(localStorage.getItem('hermes:reasoning_effort:session-reasoning')).toBe('high')
   })
 })

--- a/tests/client/chat-store-reasoning-tool-boundary.test.ts
+++ b/tests/client/chat-store-reasoning-tool-boundary.test.ts
@@ -244,6 +244,7 @@ describe('chat store reasoning/tool boundaries', () => {
     session.baseUrl = 'http://example.invalid'
     session.apiKey = 'secret'
     session.apiMode = 'chat_completions'
+    session.reasoningEffort = 'high'
     store.sessions = [session]
     store.activeSessionId = 'session-1'
     store.activeSession = session
@@ -261,6 +262,7 @@ describe('chat store reasoning/tool boundaries', () => {
     expect(body.baseUrl).toBeUndefined()
     expect(body.apiKey).toBeUndefined()
     expect(body.apiMode).toBeUndefined()
+    expect(body.reasoning_effort).toBeUndefined()
   })
 
   it('sends the selected workspace when starting a coding-agent run', async () => {


### PR DESCRIPTION
## Summary
- Hide the per-session reasoning effort selector for Coding Agent sessions.
- Omit `reasoning_effort` from Coding Agent run payloads until those runners support it.
- Add focused client coverage and a chat-chain change fragment.

## Why
Coding Agent sessions currently do not consume the Web UI reasoning effort override. Showing the control there suggests support that does not exist yet, and stale per-session values could otherwise be sent in the run payload.

## Impact
Hermes CLI chats keep the existing reasoning effort selector behavior. Coding Agent chats no longer show the selector and do not send the unsupported override.

## Validation
- `npm test -- --run tests/client/chat-input-draft.test.ts tests/client/chat-store-reasoning-tool-boundary.test.ts tests/client/chat-store-reasoning-effort.test.ts`
- `npm run build`
- `npm run harness:check`