### PR TITLE
[codex] allow manual website version inputs

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -19,6 +19,15 @@ on:
     types:
       - completed
   workflow_dispatch:
+    inputs:
+      hermes_versions:
+        description: "Optional Hermes Agent versions for /versions.json (comma or space separated)"
+        required: false
+        type: string
+      webui_versions:
+        description: "Optional Web UI versions for /versions.json (comma or space separated)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -53,6 +62,30 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
+      - name: Update website version manifest
+        if: github.event_name == 'workflow_dispatch' && (github.event.inputs.hermes_versions != '' || github.event.inputs.webui_versions != '')
+        env:
+          HERMES_VERSIONS: ${{ github.event.inputs.hermes_versions }}
+          WEBUI_VERSIONS: ${{ github.event.inputs.webui_versions }}
+        run: |
+          node - <<'NODE'
+          const { readFileSync, writeFileSync } = require('node:fs')
+          const file = 'packages/website/public/versions.json'
+          const current = JSON.parse(readFileSync(file, 'utf-8'))
+          const splitVersions = (value) => String(value || '')
+            .split(/[,\s]+/)
+            .map(part => part.trim())
+            .filter(Boolean)
+          const hermes = splitVersions(process.env.HERMES_VERSIONS)
+          const webui = splitVersions(process.env.WEBUI_VERSIONS)
+          const next = {
+            schema: 1,
+            hermes: hermes.length ? hermes : current.hermes,
+            webui: webui.length ? webui : current.webui,
+          }
+          writeFileSync(file, JSON.stringify(next, null, 2) + '\n')
+          NODE
 
       - name: Type-check website
         run: npx vue-tsc -p tsconfig.website.json --noEmit

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -20,12 +20,8 @@ on:
       - completed
   workflow_dispatch:
     inputs:
-      hermes_versions:
-        description: "Optional Hermes Agent versions for /versions.json (comma or space separated)"
-        required: false
-        type: string
-      webui_versions:
-        description: "Optional Web UI versions for /versions.json (comma or space separated)"
+      download_version:
+        description: "Optional release/download version used for website download links (defaults to package.json)"
         required: false
         type: string
 
@@ -63,34 +59,12 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Update website version manifest
-        if: github.event_name == 'workflow_dispatch' && (github.event.inputs.hermes_versions != '' || github.event.inputs.webui_versions != '')
-        env:
-          HERMES_VERSIONS: ${{ github.event.inputs.hermes_versions }}
-          WEBUI_VERSIONS: ${{ github.event.inputs.webui_versions }}
-        run: |
-          node - <<'NODE'
-          const { readFileSync, writeFileSync } = require('node:fs')
-          const file = 'packages/website/public/versions.json'
-          const current = JSON.parse(readFileSync(file, 'utf-8'))
-          const splitVersions = (value) => String(value || '')
-            .split(/[,\s]+/)
-            .map(part => part.trim())
-            .filter(Boolean)
-          const hermes = splitVersions(process.env.HERMES_VERSIONS)
-          const webui = splitVersions(process.env.WEBUI_VERSIONS)
-          const next = {
-            schema: 1,
-            hermes: hermes.length ? hermes : current.hermes,
-            webui: webui.length ? webui : current.webui,
-          }
-          writeFileSync(file, JSON.stringify(next, null, 2) + '\n')
-          NODE
-
       - name: Type-check website
         run: npx vue-tsc -p tsconfig.website.json --noEmit
 
       - name: Build website
+        env:
+          WEBSITE_DOWNLOAD_VERSION: ${{ github.event.inputs.download_version }}
         run: npm run build:website
 
       - name: Prepare SSH

--- a/packages/website/src/components/landing/InstallSection.vue
+++ b/packages/website/src/components/landing/InstallSection.vue
@@ -13,7 +13,7 @@ const { t, tm } = useI18n()
 useScrollReveal()
 const activeTab = ref<'desktop' | 'npm' | 'docker' | 'source'>('desktop')
 
-const releaseVersion = __APP_VERSION__.replace(/^v/, '')
+const releaseVersion = __WEBSITE_DOWNLOAD_VERSION__.replace(/^v/, '')
 const releaseTag = `v${releaseVersion}`
 const releaseBaseUrl = 'https://github.com/EKKOLearnAI/hermes-web-ui/releases'
 const releaseUrl = `${releaseBaseUrl}/tag/${releaseTag}`

--- a/packages/website/src/env.d.ts
+++ b/packages/website/src/env.d.ts
@@ -1,3 +1,4 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string
+declare const __WEBSITE_DOWNLOAD_VERSION__: string

--- a/vite.config.website.ts
+++ b/vite.config.website.ts
@@ -3,11 +3,14 @@ import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
 import pkg from './package.json'
 
+const websiteDownloadVersion = process.env.WEBSITE_DOWNLOAD_VERSION?.trim() || pkg.version
+
 export default defineConfig({
   root: 'packages/website',
   plugins: [vue()],
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+    __WEBSITE_DOWNLOAD_VERSION__: JSON.stringify(websiteDownloadVersion),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Add an optional manual `download_version` input to the Website workflow.
- Use that value to build website download links against a specific release tag and desktop artifact version.
- Keep automatic website builds using the repository `package.json` version when no manual value is provided.

## Validation
- `npm run harness:check`
- `npx vue-tsc -p tsconfig.website.json --noEmit`
- `npm run build:website`
