### PR TITLE
fix(server): pass profile to cron job commands

### DIFF
--- a/packages/server/src/controllers/hermes/jobs.ts
+++ b/packages/server/src/controllers/hermes/jobs.ts
@@ -131,6 +131,10 @@ async function runHermesCron(profile: string, args: string[]): Promise<void> {
   }
 }
 
+function getCronArgs(profile: string, command: string, ...args: string[]): string[] {
+  return ['cron', command, '--profile', profile, ...args]
+}
+
 function sendJobNotFound(ctx: Context): void {
   ctx.status = 404
   ctx.body = { error: { message: 'Job not found' } }
@@ -179,7 +183,7 @@ export async function create(ctx: Context) {
   }
 
   const beforeJobs = readJobs(profile, true)
-  const args = ['cron', 'create']
+  const args = getCronArgs(profile, 'create')
   const name = String(body.name || '').trim()
   if (name) args.push('--name', name)
   if (body.deliver != null && String(body.deliver).trim()) args.push('--deliver', String(body.deliver).trim())
@@ -216,7 +220,7 @@ export async function update(ctx: Context) {
   const body = getBody(ctx)
   if (!findJob(profile, ctx.params.id)) return sendJobNotFound(ctx)
 
-  const args = ['cron', 'edit', ctx.params.id]
+  const args = getCronArgs(profile, 'edit', ctx.params.id)
   if (body.schedule != null || body.schedule_display != null) {
     args.push('--schedule', String(body.schedule ?? body.schedule_display))
   }
@@ -261,7 +265,7 @@ export async function remove(ctx: Context) {
   if (!findJob(profile, ctx.params.id)) return sendJobNotFound(ctx)
 
   try {
-    await runHermesCron(profile, ['cron', 'remove', ctx.params.id])
+    await runHermesCron(profile, getCronArgs(profile, 'remove', ctx.params.id))
     ctx.body = { ok: true }
   } catch (error: any) {
     sendCommandError(ctx, error)
@@ -273,7 +277,7 @@ export async function pause(ctx: Context) {
   if (!findJob(profile, ctx.params.id)) return sendJobNotFound(ctx)
 
   try {
-    await runHermesCron(profile, ['cron', 'pause', ctx.params.id])
+    await runHermesCron(profile, getCronArgs(profile, 'pause', ctx.params.id))
     const job = findJob(profile, ctx.params.id)
     ctx.body = { job }
   } catch (error: any) {
@@ -286,7 +290,7 @@ export async function resume(ctx: Context) {
   if (!findJob(profile, ctx.params.id)) return sendJobNotFound(ctx)
 
   try {
-    await runHermesCron(profile, ['cron', 'resume', ctx.params.id])
+    await runHermesCron(profile, getCronArgs(profile, 'resume', ctx.params.id))
     const job = findJob(profile, ctx.params.id)
     ctx.body = { job }
   } catch (error: any) {
@@ -299,7 +303,7 @@ export async function run(ctx: Context) {
   if (!findJob(profile, ctx.params.id)) return sendJobNotFound(ctx)
 
   try {
-    await runHermesCron(profile, ['cron', 'run', ctx.params.id])
+    await runHermesCron(profile, getCronArgs(profile, 'run', ctx.params.id))
     const job = findJob(profile, ctx.params.id)
     ctx.body = { job }
   } catch (error: any) {

--- a/tests/server/jobs-controller.test.ts
+++ b/tests/server/jobs-controller.test.ts
@@ -24,7 +24,7 @@ vi.mock('child_process', () => ({
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
-import { update } from '../../packages/server/src/controllers/hermes/jobs'
+import { create, pause, remove, resume, run as runJob, update } from '../../packages/server/src/controllers/hermes/jobs'
 
 function createMockCtx(overrides: Record<string, any> = {}) {
   const ctx: any = {
@@ -45,6 +45,22 @@ function createMockCtx(overrides: Record<string, any> = {}) {
     return Array.isArray(value) ? value[0] : value || ''
   }
   return ctx
+}
+
+function writeExistingJob(tempDir: string) {
+  const cronDir = join(tempDir, 'cron')
+  mkdirSync(cronDir, { recursive: true })
+  writeFileSync(join(cronDir, 'jobs.json'), JSON.stringify({
+    jobs: [{
+      job_id: 'abc123abc123',
+      id: 'abc123abc123',
+      name: 'daily',
+      schedule: { kind: 'cron', expr: '0 9 * * *', display: '0 9 * * *' },
+      schedule_display: '0 9 * * *',
+      prompt: 'run daily',
+      repeat: { times: 3, completed: 1 },
+    }],
+  }))
 }
 
 describe('Hermes jobs controller', () => {
@@ -94,19 +110,7 @@ describe('Hermes jobs controller', () => {
   })
 
   it('clears repeat by passing repeat 0 to Hermes CLI', async () => {
-    const cronDir = join(tempDir, 'cron')
-    mkdirSync(cronDir, { recursive: true })
-    writeFileSync(join(cronDir, 'jobs.json'), JSON.stringify({
-      jobs: [{
-        job_id: 'abc123abc123',
-        id: 'abc123abc123',
-        name: 'daily',
-        schedule: { kind: 'cron', expr: '0 9 * * *', display: '0 9 * * *' },
-        schedule_display: '0 9 * * *',
-        prompt: 'run daily',
-        repeat: { times: 3, completed: 1 },
-      }],
-    }))
+    writeExistingJob(tempDir)
 
     const ctx = createMockCtx({
       request: { body: { repeat: null } },
@@ -116,12 +120,73 @@ describe('Hermes jobs controller', () => {
     expect(ctx.status).toBe(200)
     expect(testState.execFile).toHaveBeenCalledWith(
       '/fake/bin/hermes',
-      ['cron', 'edit', 'abc123abc123', '--repeat', '0'],
+      ['cron', 'edit', '--profile', 'default', 'abc123abc123', '--repeat', '0'],
       expect.objectContaining({
         env: expect.objectContaining({ HERMES_HOME: tempDir }),
         windowsHide: true,
       }),
       expect.any(Function),
     )
+  })
+
+  it('passes the selected profile to every Hermes cron command', async () => {
+    const profileState = { profile: { name: 'research' } }
+
+    const createCtx = createMockCtx({
+      state: profileState,
+      request: { body: { schedule: '0 9 * * *', prompt: 'daily summary' } },
+    })
+    await create(createCtx)
+    expect(testState.execFile).toHaveBeenLastCalledWith(
+      '/fake/bin/hermes',
+      ['cron', 'create', '--profile', 'research', '0 9 * * *', 'daily summary'],
+      expect.any(Object),
+      expect.any(Function),
+    )
+
+    const commands = [
+      {
+        handler: update,
+        body: { name: 'renamed' },
+        args: ['cron', 'edit', '--profile', 'research', 'abc123abc123', '--name', 'renamed'],
+      },
+      {
+        handler: remove,
+        body: {},
+        args: ['cron', 'remove', '--profile', 'research', 'abc123abc123'],
+      },
+      {
+        handler: pause,
+        body: {},
+        args: ['cron', 'pause', '--profile', 'research', 'abc123abc123'],
+      },
+      {
+        handler: resume,
+        body: {},
+        args: ['cron', 'resume', '--profile', 'research', 'abc123abc123'],
+      },
+      {
+        handler: runJob,
+        body: {},
+        args: ['cron', 'run', '--profile', 'research', 'abc123abc123'],
+      },
+    ]
+
+    for (const command of commands) {
+      writeExistingJob(tempDir)
+      const ctx = createMockCtx({
+        state: profileState,
+        request: { body: command.body },
+      })
+
+      await command.handler(ctx)
+
+      expect(testState.execFile).toHaveBeenLastCalledWith(
+        '/fake/bin/hermes',
+        command.args,
+        expect.any(Object),
+        expect.any(Function),
+      )
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Pass the selected Hermes profile to every cron CLI command invoked by the jobs controller.
- Cover create, edit, remove, pause, resume, and run so scheduled jobs are managed under the intended profile.

## Validation
- `npm run test -- tests/server/jobs-controller.test.ts`
- `npm run build`