### PR TITLE
fix(server): parse multipart upload metadata safely

### DIFF
--- a/packages/server/src/controllers/upload.ts
+++ b/packages/server/src/controllers/upload.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { getActiveProfileName } from '../services/hermes/hermes-profile'
 import { getProfileUploadDir } from '../services/hermes/upload-paths'
+import { MultipartParseError, parseMultipartBoundary, parseMultipartFilename, splitMultipart } from '../lib/multipart'
 
 const MAX_UPLOAD_SIZE = 50 * 1024 * 1024 // 50MB
 
@@ -15,8 +16,8 @@ export async function handleUpload(ctx: any) {
   if (!contentType.startsWith('multipart/form-data')) {
     ctx.status = 400; ctx.body = { error: 'Expected multipart/form-data' }; return
   }
-  const boundary = '--' + contentType.split('boundary=')[1]
-  if (!boundary || boundary === '--undefined') {
+  const boundaryBuf = parseMultipartBoundary(contentType)
+  if (!boundaryBuf) {
     ctx.status = 400; ctx.body = { error: 'Missing boundary' }; return
   }
   const chunks: Buffer[] = []
@@ -29,7 +30,6 @@ export async function handleUpload(ctx: any) {
     chunks.push(chunk)
   }
   const raw = Buffer.concat(chunks)
-  const boundaryBuf = Buffer.from(boundary)
   const parts = splitMultipart(raw, boundaryBuf)
   const results: { name: string; path: string }[] = []
   const uploadDir = getProfileUploadDir(requestedProfile(ctx))
@@ -40,14 +40,16 @@ export async function handleUpload(ctx: any) {
     const headerBuf = part.subarray(0, headerEnd)
     const header = headerBuf.toString('utf-8')
     const data = part.subarray(headerEnd + 4, part.length - 2)
-    let filename = ''
-    const filenameStarMatch = header.match(/filename\*=UTF-8''(.+)/i)
-    if (filenameStarMatch) { filename = decodeURIComponent(filenameStarMatch[1]) }
-    else {
-      const filenameMatch = header.match(/filename="([^"]+)"/)
-      if (!filenameMatch) continue
-      filename = filenameMatch[1]
+    let filename: string | null
+    try {
+      filename = parseMultipartFilename(header)
+    } catch (error) {
+      if (error instanceof MultipartParseError) {
+        ctx.status = 400; ctx.body = { error: error.message }; return
+      }
+      throw error
     }
+    if (!filename) continue
     const ext = filename.includes('.') ? '.' + filename.split('.').pop() : ''
     const savedName = randomBytes(8).toString('hex') + ext
     const savedPath = join(uploadDir, savedName)
@@ -55,16 +57,4 @@ export async function handleUpload(ctx: any) {
     results.push({ name: filename, path: savedPath })
   }
   ctx.body = { files: results }
-}
-
-function splitMultipart(raw: Buffer, boundary: Buffer): Buffer[] {
-  const parts: Buffer[] = []
-  let start = 0
-  while (true) {
-    const idx = raw.indexOf(boundary, start)
-    if (idx === -1) break
-    if (start > 0) { parts.push(raw.subarray(start + 2, idx)) }
-    start = idx + boundary.length
-  }
-  return parts
 }

--- a/packages/server/src/lib/multipart.ts
+++ b/packages/server/src/lib/multipart.ts
@@ -1,0 +1,41 @@
+export class MultipartParseError extends Error {}
+
+export function parseMultipartBoundary(contentType: string): Buffer | null {
+  const match = contentType.match(/(?:^|;)\s*boundary=(?:"([^"]+)"|([^;]+))/i)
+  const boundary = (match?.[1] || match?.[2] || '').trim()
+  return boundary ? Buffer.from(`--${boundary}`) : null
+}
+
+export function splitMultipart(raw: Buffer, boundary: Buffer): Buffer[] {
+  const parts: Buffer[] = []
+  let start = 0
+  while (true) {
+    const idx = raw.indexOf(boundary, start)
+    if (idx === -1) break
+    if (start > 0) {
+      parts.push(raw.subarray(start + 2, idx))
+    }
+    start = idx + boundary.length
+  }
+  return parts
+}
+
+export function parseMultipartFilename(header: string): string | null {
+  const disposition = header.match(/Content-Disposition:\s*form-data;([^\r\n]*)/i)?.[1]
+  if (!disposition) return null
+
+  const encodedFilename = disposition.match(/(?:^|;)\s*filename\*\s*=\s*([^;\r\n]+)/i)?.[1]
+  if (encodedFilename) {
+    const value = encodedFilename.trim().replace(/^"|"$/g, '')
+    const utf8Match = value.match(/^UTF-8''(.+)$/i)
+    if (!utf8Match) return null
+
+    try {
+      return decodeURIComponent(utf8Match[1])
+    } catch {
+      throw new MultipartParseError('Malformed multipart filename')
+    }
+  }
+
+  return disposition.match(/(?:^|;)\s*filename="([^"]*)"/i)?.[1] ?? null
+}

--- a/packages/server/src/routes/hermes/files.ts
+++ b/packages/server/src/routes/hermes/files.ts
@@ -5,6 +5,7 @@ import {
   isSensitivePath,
   MAX_EDIT_SIZE,
 } from '../../services/hermes/file-provider'
+import { MultipartParseError, parseMultipartBoundary, parseMultipartFilename, splitMultipart } from '../../lib/multipart'
 
 function requestedProfile(ctx: any): string | undefined {
   return ctx.state?.profile?.name
@@ -229,8 +230,8 @@ fileRoutes.post('/api/hermes/files/upload', async (ctx) => {
     return
   }
 
-  const boundary = '--' + contentType.split('boundary=')[1]
-  if (!boundary || boundary === '--undefined') {
+  const boundaryBuf = parseMultipartBoundary(contentType)
+  if (!boundaryBuf) {
     ctx.status = 400
     ctx.body = { error: 'Missing boundary', code: 'invalid_request' }
     return
@@ -240,7 +241,6 @@ fileRoutes.post('/api/hermes/files/upload', async (ctx) => {
   for await (const chunk of ctx.req) chunks.push(chunk)
   const raw = Buffer.concat(chunks)
 
-  const boundaryBuf = Buffer.from(boundary)
   const parts = splitMultipart(raw, boundaryBuf)
   const provider = await createRequestFileProvider(ctx)
   const results: { name: string; path: string }[] = []
@@ -252,15 +252,18 @@ fileRoutes.post('/api/hermes/files/upload', async (ctx) => {
     const header = headerBuf.toString('utf-8')
     const data = part.subarray(headerEnd + 4, part.length - 2)
 
-    let filename = ''
-    const filenameStarMatch = header.match(/filename\*=UTF-8''(.+)/i)
-    if (filenameStarMatch) {
-      filename = decodeURIComponent(filenameStarMatch[1])
-    } else {
-      const filenameMatch = header.match(/filename="([^"]+)"/)
-      if (!filenameMatch) continue
-      filename = filenameMatch[1]
+    let filename: string | null
+    try {
+      filename = parseMultipartFilename(header)
+    } catch (error) {
+      if (error instanceof MultipartParseError) {
+        ctx.status = 400
+        ctx.body = { error: error.message, code: 'invalid_request' }
+        return
+      }
+      throw error
     }
+    if (!filename) continue
 
     if (data.length > MAX_EDIT_SIZE) {
       ctx.status = 413
@@ -282,18 +285,3 @@ fileRoutes.post('/api/hermes/files/upload', async (ctx) => {
 
   ctx.body = { files: results }
 })
-
-function splitMultipart(raw: Buffer, boundary: Buffer): Buffer[] {
-  const parts: Buffer[] = []
-  let start = 0
-  while (true) {
-    const idx = raw.indexOf(boundary, start)
-    if (idx === -1) break
-    if (start > 0) {
-      const partStart = start + 2
-      parts.push(raw.subarray(partStart, idx))
-    }
-    start = idx + boundary.length
-  }
-  return parts
-}

--- a/tests/server/files-routes.test.ts
+++ b/tests/server/files-routes.test.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'stream'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const provider = {
@@ -5,6 +6,7 @@ const provider = {
   stat: vi.fn(),
   deleteFile: vi.fn(),
   deleteDir: vi.fn(),
+  writeFile: vi.fn(),
 }
 const createFileProviderMock = vi.fn(async () => provider)
 const resolveHermesPathMock = vi.fn((relativePath: string) => {
@@ -28,6 +30,7 @@ describe('file routes path metadata', () => {
     provider.stat.mockReset()
     provider.deleteFile.mockReset()
     provider.deleteDir.mockReset()
+    provider.writeFile.mockReset()
   })
 
   it('returns absolute paths for listed entries while preserving relative operation paths', async () => {
@@ -123,5 +126,78 @@ describe('file routes path metadata', () => {
     expect(createFileProviderMock).not.toHaveBeenCalled()
     expect(provider.deleteFile).not.toHaveBeenCalled()
     expect(provider.deleteDir).not.toHaveBeenCalled()
+  })
+
+  it('uploads files with boundary parameters and RFC 5987 filenames', async () => {
+    provider.writeFile.mockResolvedValue(undefined)
+    const boundary = 'files-boundary'
+    const body = Buffer.from([
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="file"; filename*=UTF-8\'\'daily%20report.txt',
+      'Content-Type: text/plain',
+      '',
+      'hello',
+      `--${boundary}--`,
+      '',
+    ].join('\r\n'))
+
+    const { fileRoutes } = await import('../../packages/server/src/routes/hermes/files')
+    const layer = fileRoutes.stack.find((entry: any) => entry.path === '/api/hermes/files/upload')
+    const ctx: any = {
+      query: { path: 'workspace' },
+      req: Readable.from([body]),
+      request: {},
+      state: { profile: { name: 'research' } },
+      body: null,
+      status: 200,
+      get: vi.fn((header: string) => header.toLowerCase() === 'content-type'
+        ? `multipart/form-data; boundary=${boundary}; charset=utf-8`
+        : ''),
+    }
+
+    await layer.stack[0](ctx)
+
+    expect(createFileProviderMock).toHaveBeenCalledWith('research')
+    expect(resolveHermesPathMock).toHaveBeenCalledWith('workspace/daily report.txt', 'research')
+    expect(provider.writeFile).toHaveBeenCalledWith(
+      '/home/agent/.hermes/workspace/daily report.txt',
+      Buffer.from('hello'),
+    )
+    expect(ctx.body).toEqual({
+      files: [{ name: 'daily report.txt', path: 'workspace/daily report.txt' }],
+    })
+  })
+
+  it('returns invalid_request for malformed RFC 5987 filenames', async () => {
+    const boundary = 'files-boundary'
+    const body = Buffer.from([
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="file"; filename*=UTF-8\'\'bad%ZZname.txt',
+      'Content-Type: text/plain',
+      '',
+      'hello',
+      `--${boundary}--`,
+      '',
+    ].join('\r\n'))
+
+    const { fileRoutes } = await import('../../packages/server/src/routes/hermes/files')
+    const layer = fileRoutes.stack.find((entry: any) => entry.path === '/api/hermes/files/upload')
+    const ctx: any = {
+      query: { path: 'workspace' },
+      req: Readable.from([body]),
+      request: {},
+      state: { profile: { name: 'research' } },
+      body: null,
+      status: 200,
+      get: vi.fn((header: string) => header.toLowerCase() === 'content-type'
+        ? `multipart/form-data; boundary=${boundary}`
+        : ''),
+    }
+
+    await layer.stack[0](ctx)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toEqual({ error: 'Malformed multipart filename', code: 'invalid_request' })
+    expect(provider.writeFile).not.toHaveBeenCalled()
   })
 })

--- a/tests/server/upload-controller.test.ts
+++ b/tests/server/upload-controller.test.ts
@@ -21,16 +21,25 @@ vi.mock('../../packages/server/src/services/hermes/upload-paths', () => ({
   getProfileUploadDir: vi.fn((profile: string) => `/tmp/hermes-web-ui/upload/${profile}`),
 }))
 
-function multipartBody(boundary: string, name: string, content: string): Buffer {
+function multipartBody(
+  boundary: string,
+  part: { filename?: string; filenameStar?: string; content: string },
+): Buffer {
+  const filename = part.filename ? `; filename="${part.filename}"` : ''
+  const filenameStar = part.filenameStar ? `; filename*=UTF-8''${part.filenameStar}` : ''
   return Buffer.from([
     `--${boundary}`,
-    `Content-Disposition: form-data; name="file"; filename="${name}"`,
+    `Content-Disposition: form-data; name="file"${filename}${filenameStar}`,
     'Content-Type: text/plain',
     '',
-    content,
+    part.content,
     `--${boundary}--`,
     '',
   ].join('\r\n'))
+}
+
+function normalizePath(value: unknown): string {
+  return String(value).replace(/\\/g, '/')
 }
 
 describe('upload controller', () => {
@@ -45,7 +54,7 @@ describe('upload controller', () => {
     const { handleUpload } = await import('../../packages/server/src/controllers/upload')
     const ctx: any = {
       get: vi.fn((header: string) => header === 'content-type' ? `multipart/form-data; boundary=${boundary}` : ''),
-      req: Readable.from([multipartBody(boundary, 'note.txt', 'hello')]),
+      req: Readable.from([multipartBody(boundary, { filename: 'note.txt', content: 'hello' })]),
       state: { profile: { name: 'research' } },
       body: undefined,
       status: 200,
@@ -56,8 +65,48 @@ describe('upload controller', () => {
     expect(mkdirMock).toHaveBeenCalledWith('/tmp/hermes-web-ui/upload/research', { recursive: true })
     expect(writeFileMock).toHaveBeenCalledOnce()
     const [savedPath, data] = writeFileMock.mock.calls[0]
-    expect(savedPath).toMatch(/^\/tmp\/hermes-web-ui\/upload\/research\/[a-f0-9]+\.txt$/)
+    expect(normalizePath(savedPath)).toMatch(/^\/tmp\/hermes-web-ui\/upload\/research\/[a-f0-9]+\.txt$/)
     expect(data.toString('utf-8')).toBe('hello')
     expect(ctx.body.files[0]).toMatchObject({ name: 'note.txt', path: savedPath })
+  })
+
+  it('parses boundary parameters and RFC 5987 filenames for chat uploads', async () => {
+    const boundary = 'test-boundary'
+    const { handleUpload } = await import('../../packages/server/src/controllers/upload')
+    const ctx: any = {
+      get: vi.fn((header: string) => header === 'content-type'
+        ? `multipart/form-data; boundary=${boundary}; charset=utf-8`
+        : ''),
+      req: Readable.from([multipartBody(boundary, { filenameStar: 'daily%20report.txt', content: 'hello' })]),
+      state: { profile: { name: 'research' } },
+      body: undefined,
+      status: 200,
+    }
+
+    await handleUpload(ctx)
+
+    expect(writeFileMock).toHaveBeenCalledOnce()
+    const [savedPath, data] = writeFileMock.mock.calls[0]
+    expect(normalizePath(savedPath)).toMatch(/^\/tmp\/hermes-web-ui\/upload\/research\/[a-f0-9]+\.txt$/)
+    expect(data.toString('utf-8')).toBe('hello')
+    expect(ctx.body.files[0]).toMatchObject({ name: 'daily report.txt', path: savedPath })
+  })
+
+  it('returns 400 for malformed RFC 5987 filenames', async () => {
+    const boundary = 'test-boundary'
+    const { handleUpload } = await import('../../packages/server/src/controllers/upload')
+    const ctx: any = {
+      get: vi.fn((header: string) => header === 'content-type' ? `multipart/form-data; boundary=${boundary}` : ''),
+      req: Readable.from([multipartBody(boundary, { filenameStar: 'bad%ZZname.txt', content: 'hello' })]),
+      state: { profile: { name: 'research' } },
+      body: undefined,
+      status: 200,
+    }
+
+    await handleUpload(ctx)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toEqual({ error: 'Malformed multipart filename' })
+    expect(writeFileMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Parse multipart boundaries without swallowing trailing content-type parameters.
- Decode RFC 5987 `filename*` values safely for workspace and chat uploads, returning 400 for malformed filenames instead of throwing.

## Validation
- `npm run test -- tests/server/files-routes.test.ts tests/server/upload-controller.test.ts`
- `npm run build`