### PR TITLE
fix(client): handle raw percent signs in download URLs

### DIFF
--- a/packages/client/src/api/hermes/download.ts
+++ b/packages/client/src/api/hermes/download.ts
@@ -1,5 +1,13 @@
 import { getActiveProfileName, getApiKey, getBaseUrlValue } from '../client'
 
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
 /**
  * Construct a download URL with auth token as query parameter.
  * Token is passed via query param because <a> tags cannot set headers.
@@ -21,10 +29,10 @@ export function getDownloadUrl(filePath: string, fileName?: string): string {
 
   // Decode the path first in case it's already encoded (e.g., from AI responses)
   // URLSearchParams will encode it again, so we need to start with decoded text
-  const decodedPath = decodeURIComponent(filePath)
+  const decodedPath = safeDecodeURIComponent(filePath)
   const params = new URLSearchParams({ path: decodedPath })
   if (fileName) {
-    const decodedName = decodeURIComponent(fileName)
+    const decodedName = safeDecodeURIComponent(fileName)
     params.set('name', decodedName)
   }
   const profileName = getActiveProfileName()

--- a/tests/client/api.test.ts
+++ b/tests/client/api.test.ts
@@ -181,6 +181,14 @@ describe('API Client', () => {
       expect(url.searchParams.get('profile')).toBe('research')
       expect(url.searchParams.get('token')).toBe('secret-key')
     })
+
+    it('handles raw percent signs in download paths and filenames', () => {
+      const url = new URL(getDownloadUrl('/tmp/100% ready.txt', '100% ready.txt'), 'http://localhost')
+
+      expect(url.pathname).toBe('/api/hermes/download')
+      expect(url.searchParams.get('path')).toBe('/tmp/100% ready.txt')
+      expect(url.searchParams.get('name')).toBe('100% ready.txt')
+    })
   })
 
   describe('file upload', () => {


### PR DESCRIPTION
## Summary
- Avoid throwing when a download path or filename contains a raw percent sign.
- Keep existing decoding behavior for already-encoded values before URLSearchParams encodes the final query string.

## Validation
- `npm run test -- tests/client/api.test.ts`
- `npm run build`