### PR TITLE
fix(client): include active profile in group chat uploads

### DIFF
--- a/docs/chat-chain-changes/2026-06-09-pr1437-group-chat-upload-profile.md
+++ b/docs/chat-chain-changes/2026-06-09-pr1437-group-chat-upload-profile.md
@@ -1,0 +1,10 @@
+---
+date: 2026-06-09
+pr: 1437
+commit: pending
+feature: Group chat attachment upload profile routing
+impact: Sends the active Hermes profile with group chat attachment uploads so files are stored under the same profile used by the room message.
+---
+
+Group chat attachment uploads now include the active profile header alongside
+the existing auth header. Multipart FormData content-type handling is unchanged.

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { getApiKey } from '@/api/client'
+import { getActiveProfileName, getApiKey } from '@/api/client'
 import { fetchCurrentUser } from '@/api/auth'
 import { getDownloadUrl } from '@/api/hermes/download'
 import type { Attachment, ContentBlock } from './chat'
@@ -32,10 +32,14 @@ async function uploadGroupFiles(attachments: Attachment[]): Promise<{ name: stri
         if (att.file) formData.append('file', att.file, att.name)
     }
     const token = getApiKey()
+    const profileName = getActiveProfileName()
+    const headers: Record<string, string> = {}
+    if (token) headers.Authorization = `Bearer ${token}`
+    if (profileName) headers['X-Hermes-Profile'] = profileName
     const res = await fetch('/upload', {
         method: 'POST',
         body: formData,
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        headers,
     })
     if (!res.ok) throw new Error(`Upload failed: ${res.status}`)
     const data = await res.json() as { files: { name: string; path: string }[] }

--- a/tests/client/group-chat-store-streaming.test.ts
+++ b/tests/client/group-chat-store-streaming.test.ts
@@ -40,10 +40,16 @@ const groupChatApiMock = vi.hoisted(() => {
     clearRoomContext: vi.fn(),
   }
 })
+const clientApiMock = vi.hoisted(() => ({
+  getApiKey: vi.fn(() => 'test-token'),
+  getActiveProfileName: vi.fn(() => 'research'),
+}))
+const fetchMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/api/hermes/group-chat', () => groupChatApiMock)
-vi.mock('@/api/client', () => ({ getApiKey: vi.fn(() => 'test-token') }))
+vi.mock('@/api/client', () => clientApiMock)
 vi.mock('@/api/hermes/download', () => ({ getDownloadUrl: vi.fn((path: string) => `/download?path=${path}`) }))
+vi.stubGlobal('fetch', fetchMock)
 
 function emitSocket(event: string, payload: unknown) {
   for (const cb of groupChatApiMock.handlers.get(event) || []) cb(payload)
@@ -96,6 +102,9 @@ describe('group chat store streaming merge', () => {
     groupChatApiMock.getSocket.mockReturnValue(groupChatApiMock.socket)
     groupChatApiMock.getStoredUserId.mockReturnValue('user-1')
     groupChatApiMock.getStoredUserName.mockReturnValue('tester')
+    clientApiMock.getApiKey.mockReturnValue('test-token')
+    clientApiMock.getActiveProfileName.mockReturnValue('research')
+    fetchMock.mockReset()
     groupChatApiMock.socket.on.mockClear()
     groupChatApiMock.socket.emit.mockReset()
     groupChatApiMock.socket.emit.mockImplementation((event: string, _data?: unknown, ack?: Function) => {
@@ -337,5 +346,36 @@ describe('group chat store streaming merge', () => {
       expect.anything(),
       expect.any(Function),
     )
+  })
+
+  it('adds auth and active profile headers to group chat uploads', async () => {
+    const store = await createJoinedStore()
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ files: [{ name: 'note.txt', path: '/tmp/note.txt' }] }),
+    })
+    groupChatApiMock.socket.emit.mockImplementation((event: string, _data?: unknown, ack?: Function) => {
+      if (event === 'join' && ack) ack({ members: [], agents: [], typingUsers: [], contextStatuses: [] })
+      if (event === 'message' && ack) ack({ id: 'msg-server' })
+      return groupChatApiMock.socket
+    })
+
+    await store.sendMessage('hello', [{
+      id: 'file-1',
+      name: 'note.txt',
+      type: 'text/plain',
+      size: 5,
+      url: '',
+      file: new File(['hello'], 'note.txt', { type: 'text/plain' }),
+    }])
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, options] = fetchMock.mock.calls[0]
+    expect(url).toBe('/upload')
+    expect(options.method).toBe('POST')
+    expect(options.headers.Authorization).toBe('Bearer test-token')
+    expect(options.headers['X-Hermes-Profile']).toBe('research')
+    expect(options.body).toBeInstanceOf(FormData)
   })
 })


### PR DESCRIPTION
## Summary
- Add the active Hermes profile header to group chat attachment uploads.
- Keep multipart uploads using browser-managed FormData content types while preserving the existing auth header.

## Validation
- `npm run test -- tests/client/group-chat-store-streaming.test.ts`
- `npm run build`