### PR TITLE
fix(server): include file paths in API content blocks

### DIFF
--- a/docs/chat-chain-changes/2026-06-09-pr1438-api-file-block-path.md
+++ b/docs/chat-chain-changes/2026-06-09-pr1438-api-file-block-path.md
@@ -1,0 +1,10 @@
+---
+date: 2026-06-09
+pr: 1438
+commit: pending
+feature: API file content block path context
+impact: Adds the local file path to API file content block text so non-image attachments can be read by models and tools that need the uploaded file location.
+---
+
+API file content blocks now include a local file path line when the uploaded
+file has a display name. Image content block conversion remains unchanged.

--- a/packages/server/src/services/hermes/run-chat/content-blocks.ts
+++ b/packages/server/src/services/hermes/run-chat/content-blocks.ts
@@ -45,11 +45,18 @@ export async function convertContentBlocks(blocks: ContentBlock[]): Promise<Resp
         parts.push({ type: 'input_text', text: `[Image: ${block.path}]` })
       }
     } else if (block.type === 'file') {
-      parts.push({ type: 'input_text', text: `[File: ${block.name || block.path}]` })
+      parts.push({ type: 'input_text', text: fileBlockToText(block) })
     }
   }
 
   return parts
+}
+
+function fileBlockToText(block: Extract<ContentBlock, { type: 'file' }>): string {
+  const label = block.name || block.path
+  return block.path && block.path !== label
+    ? `[File: ${label}]\nLocal file path: ${block.path}`
+    : `[File: ${label}]`
 }
 
 /**

--- a/tests/server/run-chat-content-blocks.test.ts
+++ b/tests/server/run-chat-content-blocks.test.ts
@@ -31,6 +31,20 @@ describe('run chat content blocks', () => {
     expect(JSON.stringify(parts)).not.toContain('Local image path for tools')
   })
 
+  it('includes local file paths in API file content blocks', async () => {
+    const filePath = join(tempDir, 'notes.txt')
+
+    const parts = await convertContentBlocks([
+      { type: 'text', text: 'read this' },
+      { type: 'file', name: 'notes.txt', path: filePath, media_type: 'text/plain' },
+    ])
+
+    expect(parts).toEqual([
+      { type: 'input_text', text: 'read this' },
+      { type: 'input_text', text: `[File: notes.txt]\nLocal file path: ${filePath}` },
+    ])
+  })
+
   it('adds local file path text for bridge agents while preserving the image data', async () => {
     const imagePath = join(tempDir, 'image.png')
     await writeFile(imagePath, Buffer.from([1, 2, 3]))


### PR DESCRIPTION
## Summary
- Include the local file path when API file content blocks are converted to text input.
- Keep image content block behavior unchanged so API image blocks still send image data without adding local image paths.

## Validation
- `npm run test -- tests/server/run-chat-content-blocks.test.ts`
- `npm run build`