### PR TITLE
fix(client): guard browser speech synthesis usage

### DIFF
--- a/packages/client/src/composables/useSpeech.ts
+++ b/packages/client/src/composables/useSpeech.ts
@@ -53,18 +53,7 @@ interface SpeechQueueItem {
  * 优先后端 TTS（Edge → Google），失败降级浏览器 speechSynthesis
  */
 export function useSpeech() {
-  const synth = window.speechSynthesis ?? {
-    getVoices: () => [],
-    speak: () => {},
-    cancel: () => {},
-    pause: () => {},
-    resume: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    speaking: false,
-    pending: false,
-    paused: false,
-  } as unknown as SpeechSynthesis
+  const synth = typeof window !== 'undefined' ? window.speechSynthesis : undefined
   const availableVoices = ref<SpeechSynthesisVoice[]>([])
   const state = ref<SpeechState>({
     isPlaying: false,
@@ -86,10 +75,16 @@ export function useSpeech() {
 
   // 加载可用语音列表
   function loadVoices() {
-    availableVoices.value = synth.getVoices()
+    try {
+      availableVoices.value = typeof synth?.getVoices === 'function' ? synth.getVoices() : []
+    } catch {
+      availableVoices.value = []
+    }
   }
 
-  synth.addEventListener('voiceschanged', loadVoices)
+  if (typeof synth?.addEventListener === 'function') {
+    synth.addEventListener('voiceschanged', loadVoices)
+  }
   loadVoices()
 
   /**
@@ -119,7 +114,12 @@ export function useSpeech() {
   }
 
   const isSupported = computed(() => {
-    return 'speechSynthesis' in window && 'SpeechSynthesisUtterance' in window
+    return Boolean(
+      typeof window !== 'undefined' &&
+      window.speechSynthesis &&
+      typeof window.speechSynthesis.speak === 'function' &&
+      typeof window.SpeechSynthesisUtterance === 'function',
+    )
   })
 
   function getDefaultVoice(): SpeechSynthesisVoice | null {
@@ -151,7 +151,7 @@ export function useSpeech() {
     stopCustomAudioPlayback()
     clearCustomPlaybackState()
     // Stop browser speech
-    if (synth.speaking || synth.pending || synth.paused) {
+    if (synth && (synth.speaking || synth.pending || synth.paused) && typeof synth.cancel === 'function') {
       synth.cancel()
     }
     utterance = null
@@ -213,7 +213,17 @@ export function useSpeech() {
 
   function speakViaBrowser(messageId: string, text: string, options: SpeechOptions, token?: number) {
     token = token || ++playbackToken
-    utterance = new SpeechSynthesisUtterance(text)
+    if (!isSupported.value || !synth) {
+      state.value = {
+        isPlaying: false,
+        isPaused: false,
+        currentMessageId: null,
+        progress: 0,
+        engine: 'none',
+      }
+      return
+    }
+    utterance = new window.SpeechSynthesisUtterance(text)
     const activeUtterance = utterance
 
     utterance.rate = 1
@@ -571,7 +581,7 @@ export function useSpeech() {
     if (state.value.engine === 'tts' && currentAudio) {
       currentAudio.pause()
       state.value.isPaused = true
-    } else if (state.value.engine === 'browser' && !state.value.isPaused) {
+    } else if (state.value.engine === 'browser' && !state.value.isPaused && typeof synth?.pause === 'function') {
       synth.pause()
       state.value.isPaused = true
     }
@@ -585,7 +595,7 @@ export function useSpeech() {
     if (state.value.isPaused) {
       if (state.value.engine === 'tts' && currentAudio) {
         currentAudio.play()
-      } else {
+      } else if (typeof synth?.resume === 'function') {
         synth.resume()
       }
       state.value.isPaused = false
@@ -606,7 +616,9 @@ export function useSpeech() {
 
   onUnmounted(() => {
     stop()
-    synth.removeEventListener('voiceschanged', loadVoices)
+    if (typeof synth?.removeEventListener === 'function') {
+      synth.removeEventListener('voiceschanged', loadVoices)
+    }
   })
 
   return {

--- a/tests/client/use-speech-webspeech.test.ts
+++ b/tests/client/use-speech-webspeech.test.ts
@@ -110,4 +110,68 @@ describe('useSpeech WebSpeech playback', () => {
 
     wrapper.unmount()
   })
+
+  it('does not crash when Web Speech is unavailable', () => {
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: undefined,
+    })
+    Object.defineProperty(window, 'SpeechSynthesisUtterance', {
+      configurable: true,
+      value: undefined,
+    })
+    Object.defineProperty(globalThis, 'SpeechSynthesisUtterance', {
+      configurable: true,
+      value: undefined,
+    })
+
+    const wrapper = mount(defineComponent({
+      setup() {
+        return {
+          speech: useSpeech(),
+        }
+      },
+      template: '<div />',
+    }))
+    const speech = wrapper.vm.speech
+
+    expect(speech.isSupported.value).toBe(false)
+    expect(() => speech.toggleBrowser('message-unsupported', 'Hello world')).not.toThrow()
+    expect(speech.isPlaying.value).toBe(false)
+
+    expect(() => wrapper.unmount()).not.toThrow()
+  })
+
+  it('does not crash when speechSynthesis listener methods are missing', () => {
+    const synth = {
+      speaking: false,
+      pending: false,
+      paused: false,
+      getVoices: vi.fn(() => []),
+      speak: vi.fn(),
+      cancel: vi.fn(),
+      pause: vi.fn(),
+      resume: vi.fn(),
+    } as unknown as SpeechSynthesis
+
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: synth,
+    })
+
+    const wrapper = mount(defineComponent({
+      setup() {
+        return {
+          speech: useSpeech(),
+        }
+      },
+      template: '<div />',
+    }))
+    const speech = wrapper.vm.speech
+
+    expect(speech.isSupported.value).toBe(true)
+    expect(speech.availableVoices.value).toEqual([])
+
+    expect(() => wrapper.unmount()).not.toThrow()
+  })
 })


### PR DESCRIPTION
## Summary
- Guard browser Web Speech API access when `speechSynthesis` or `SpeechSynthesisUtterance` is missing or partially implemented.
- Keep the speech composable from throwing during mobile message rendering when browser TTS is unavailable.

## Validation
- `npm run test -- tests/client/use-speech-webspeech.test.ts`
- `npm run build`

Fixes #1441
