### PR TITLE
fix(providers): add qwen3.7-plus to Alibaba Coding Plan

### DIFF
--- a/packages/server/src/shared/providers.ts
+++ b/packages/server/src/shared/providers.ts
@@ -219,6 +219,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     base_url: 'https://coding-intl.dashscope.aliyuncs.com/v1',
     models: [
       'qwen3.7-max',
+      'qwen3.7-plus',
       'qwen3.6-plus',
       'qwen3.5-plus',
       'qwen3-coder-plus',

--- a/tests/shared/provider-presets.test.ts
+++ b/tests/shared/provider-presets.test.ts
@@ -11,6 +11,7 @@ const COPILOT_PROVIDER = 'copilot'
 const FUN_CODEX_PROVIDER = 'fun-codex'
 const KIMI_CODING_PROVIDER = 'kimi-coding'
 const KIMI_CODING_CN_PROVIDER = 'kimi-coding-cn'
+const ALIBABA_CODING_PLAN_PROVIDER = 'alibaba-coding-plan'
 const MINIMAX_PROVIDER = 'minimax'
 const MINIMAX_CN_PROVIDER = 'minimax-cn'
 const NOUS_PROVIDER = 'nous'
@@ -60,6 +61,10 @@ describe('provider presets', () => {
     expect(SERVER_PROVIDER_PRESETS.find(candidate => candidate.value === KIMI_CODING_CN_PROVIDER)?.base_url).toBe('https://api.kimi.cn/coding/v1')
     expect(SERVER_PROVIDER_PRESETS.find(candidate => candidate.value === KIMI_CODING_CN_PROVIDER)?.label).toBe('Kimi for Coding China')
     expect(SERVER_PROVIDER_PRESETS.find(candidate => candidate.value === 'moonshot')).toBeUndefined()
+  })
+
+  it('includes Qwen 3.7 Plus in the Alibaba Coding Plan fallback catalog', () => {
+    expect(modelsForProvider(SERVER_PROVIDER_PRESETS, ALIBABA_CODING_PLAN_PROVIDER)).toContain('qwen3.7-plus')
   })
 
   it('does not expose incomplete built-in provider presets', () => {


### PR DESCRIPTION
Summary
- Add qwen3.7-plus to the Alibaba Coding Plan fallback model catalog.
- Add a provider preset regression test so the Coding Plan list keeps exposing the model.

Validation
- npm run test -- tests/shared/provider-presets.test.ts
- npm run build

Fixes #1430