### PR TITLE
[codex] fix Claude Code root permission launch

### DIFF
--- a/docs/chat-chain-changes/2026-06-09-claude-root-permission-mode.md
+++ b/docs/chat-chain-changes/2026-06-09-claude-root-permission-mode.md
@@ -1,0 +1,10 @@
+---
+date: 2026-06-09
+pr: pending
+feature: Claude Code root permission mode
+impact: Claude Code runs started by Web UI avoid the root-only failure from dangerous permission bypass mode.
+---
+
+Non-root launches keep `--dangerously-skip-permissions`. Root launches use
+`--permission-mode auto` because Claude Code refuses dangerous bypass mode under
+root or sudo.

--- a/docs/chat-chain-changes/2026-06-09-claude-root-permission-mode.md
+++ b/docs/chat-chain-changes/2026-06-09-claude-root-permission-mode.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-09
-pr: pending
+pr: 1451
 feature: Claude Code root permission mode
 impact: Claude Code runs started by Web UI avoid the root-only failure from dangerous permission bypass mode.
 ---

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -27,6 +27,8 @@ const NODE_ENVIRONMENT_MISSING_CODE = 'node_environment_missing'
 const POSIX_LAUNCHER_FILE = 'launch.sh'
 const WINDOWS_LAUNCHER_FILE = 'launch.ps1'
 const CODING_AGENT_SCOPED_AUTH_PROVIDERS = new Set(['openai-codex', 'copilot', 'xai-oauth', 'nous'])
+const CLAUDE_CODE_SKIP_PERMISSIONS_ARGS = ['--dangerously-skip-permissions']
+const CLAUDE_CODE_ROOT_PERMISSION_ARGS = ['--permission-mode', 'auto']
 
 interface CommandExecution {
   command: string
@@ -546,6 +548,17 @@ function buildCodexModelCatalog(input: {
       priority: index,
     })),
   }
+}
+
+function hasRootPrivileges(): boolean {
+  if (process.platform === 'win32') return false
+  const uid = typeof process.getuid === 'function' ? process.getuid() : null
+  const euid = typeof process.geteuid === 'function' ? process.geteuid() : null
+  return uid === 0 || euid === 0
+}
+
+function claudeCodePermissionArgs(): string[] {
+  return hasRootPrivileges() ? CLAUDE_CODE_ROOT_PERMISSION_ARGS : CLAUDE_CODE_SKIP_PERMISSIONS_ARGS
 }
 
 function expandHomePath(path: string): string {
@@ -1195,7 +1208,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
   if (mode === 'global') {
     const scope = normalizeConfigScope({ profile: input.profile, provider: 'global' })
     const workspaceDir = resolveLaunchWorkspaceRoot(scope, input.workspace)
-    const args = tool.id === 'claude-code' ? ['--dangerously-skip-permissions'] : []
+    const args = tool.id === 'claude-code' ? claudeCodePermissionArgs() : []
     await mkdir(workspaceDir, { recursive: true })
     const shellCommand = buildLaunchShellCommand({
       workspaceDir,
@@ -1293,7 +1306,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
       ...(input.isolateSettings ? ['--setting-sources', 'local'] : []),
       '--mcp-config',
       mcpPath,
-      '--dangerously-skip-permissions',
+      ...claudeCodePermissionArgs(),
     ]
   } else {
     if (apiMode !== 'chat_completions' && apiMode !== 'codex_responses' && apiMode !== 'anthropic_messages') {

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -1,12 +1,17 @@
 import { mkdtempSync, readFileSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { claudeProxyMessages, claudeProxyModels, registerClaudeCodeProxyTarget } from '../../packages/server/src/services/agent-runner/proxies/claude-code-proxy'
 import { codexProxyModels, codexProxyResponses, registerCodexProxyTarget } from '../../packages/server/src/services/agent-runner/proxies/codex-proxy'
 import { prepareCodingAgentLaunch } from '../../packages/server/src/services/coding-agents'
 
 const homes: string[] = []
+
+function mockProcessUid(uid: number) {
+  vi.spyOn(process, 'getuid').mockReturnValue(uid)
+  vi.spyOn(process, 'geteuid').mockReturnValue(uid)
+}
 
 function makeHome() {
   const home = mkdtempSync(join(tmpdir(), 'hermes-coding-agent-launch-'))
@@ -15,8 +20,13 @@ function makeHome() {
   return home
 }
 
+beforeEach(() => {
+  mockProcessUid(1000)
+})
+
 afterEach(() => {
   delete process.env.HERMES_WEB_UI_HOME
+  vi.restoreAllMocks()
   vi.unstubAllGlobals()
   for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true })
 })
@@ -58,6 +68,25 @@ describe('coding agent launch preparation', () => {
       env: {},
       shellCommand: `cd ${join(home, 'coding-agent', 'workspace', 'default', 'global')} && claude --dangerously-skip-permissions`,
       files: [],
+    })
+  })
+
+  it('uses Claude Code auto permission mode instead of dangerous bypass when running as root', async () => {
+    mockProcessUid(0)
+    const home = makeHome()
+
+    const result = await prepareCodingAgentLaunch('claude-code', {
+      mode: 'global',
+      profile: 'default',
+    })
+
+    expect(result).toMatchObject({
+      agentId: 'claude-code',
+      mode: 'global',
+      rootDir: join(home, 'coding-agent', 'workspace', 'default', 'global'),
+      command: 'claude',
+      args: ['--permission-mode', 'auto'],
+      shellCommand: `cd ${join(home, 'coding-agent', 'workspace', 'default', 'global')} && claude --permission-mode auto`,
     })
   })
 
@@ -176,6 +205,35 @@ describe('coding agent launch preparation', () => {
     expect(result.shellCommand).not.toContain('--setting-sources local')
     const launcher = readFileSync(join(result.rootDir, 'launch.sh'), 'utf-8')
     expect(launcher).toContain('--setting-sources local')
+    expect(result.rootDir).toBe(join(home, 'coding-agent', 'model', 'default', 'openrouter', 'claude-code'))
+  })
+
+  it('uses Claude Code auto permission mode for scoped root launches', async () => {
+    mockProcessUid(0)
+    const home = makeHome()
+
+    const result = await prepareCodingAgentLaunch('claude-code', {
+      profile: 'default',
+      provider: 'openrouter',
+      model: 'anthropic/claude-sonnet-4.6',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      apiKey: 'sk-test',
+      isolateSettings: true,
+    })
+
+    expect(result.args).toEqual([
+      '--settings',
+      join(result.rootDir, 'settings.json'),
+      '--setting-sources',
+      'local',
+      '--mcp-config',
+      join(result.rootDir, 'mcp.json'),
+      '--permission-mode',
+      'auto',
+    ])
+    const launcher = readFileSync(join(result.rootDir, 'launch.sh'), 'utf-8')
+    expect(launcher).toContain('--permission-mode auto')
+    expect(launcher).not.toContain('--dangerously-skip-permissions')
     expect(result.rootDir).toBe(join(home, 'coding-agent', 'model', 'default', 'openrouter', 'claude-code'))
   })
 


### PR DESCRIPTION
## Summary
- keep Claude Code dangerous permission bypass for non-root launches
- use Claude Code auto permission mode when Web UI runs as root, avoiding the root/sudo bypass startup failure
- add launch preparation coverage for root and non-root Claude Code arguments

## Validation
- `npm run test -- tests/server/coding-agents-launch.test.ts`
- `npm run harness:check`