### PR TITLE
[codex] fix mobile chat message overflow

### DIFF
--- a/docs/chat-chain-changes/2026-06-09-group-chat-mobile-overflow.md
+++ b/docs/chat-chain-changes/2026-06-09-group-chat-mobile-overflow.md
@@ -1,0 +1,10 @@
+---
+date: 2026-06-09
+pr: 1452
+feature: Group Chat mobile message overflow
+impact: Group Chat message containers mirror the mobile overflow guards used by the main chat view.
+---
+
+Group Chat now keeps its panel, message list wrapper, message rows, and message
+content shrinkable so long markdown or tool content does not widen the mobile
+viewport.

--- a/docs/chat-chain-changes/2026-06-09-mobile-chat-overflow.md
+++ b/docs/chat-chain-changes/2026-06-09-mobile-chat-overflow.md
@@ -1,0 +1,10 @@
+---
+date: 2026-06-09
+pr: pending
+feature: Mobile chat message overflow
+impact: Chat message containers keep long markdown, links, inline code, and code blocks inside the mobile viewport.
+---
+
+Mobile chat layout now keeps the chat panel, virtual list rows, message
+bubbles, and markdown content shrinkable so long message content does not widen
+the page.

--- a/docs/chat-chain-changes/2026-06-09-mobile-chat-overflow.md
+++ b/docs/chat-chain-changes/2026-06-09-mobile-chat-overflow.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-09
-pr: pending
+pr: 1452
 feature: Mobile chat message overflow
 impact: Chat message containers keep long markdown, links, inline code, and code blocks inside the mobile viewport.
 ---

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -1577,6 +1577,9 @@ async function handleSessionModelCustomSubmit() {
   display: flex;
   height: 100%;
   position: relative;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .session-model-search {
@@ -2150,6 +2153,8 @@ async function handleSessionModelCustomSubmit() {
   display: flex;
   overflow: hidden;
   position: relative;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .chat-main-content {

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -531,13 +531,19 @@ function closeTextPreview(): void {
 .markdown-body {
   font-size: 14px;
   line-height: 1.65;
+  width: 100%;
   min-width: 0;
   max-width: 100%;
   box-sizing: border-box;
   overflow-x: auto;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 
   p {
     margin: 0 0 8px;
+    min-width: 0;
+    max-width: 100%;
+    overflow-wrap: anywhere;
 
     &:last-child {
       margin-bottom: 0;
@@ -551,6 +557,9 @@ function closeTextPreview(): void {
 
   li {
     margin: 2px 0;
+    min-width: 0;
+    max-width: 100%;
+    overflow-wrap: anywhere;
   }
 
   strong {
@@ -566,6 +575,8 @@ function closeTextPreview(): void {
     color: $accent-primary;
     text-decoration: underline;
     text-underline-offset: 2px;
+    overflow-wrap: anywhere;
+    word-break: break-word;
 
     &:hover {
       color: $accent-hover;
@@ -711,10 +722,14 @@ function closeTextPreview(): void {
     font-family: $font-code;
     font-size: 13px;
     color: $accent-primary;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   table {
     width: 100%;
+    max-width: 100%;
     border-collapse: collapse;
     margin: 8px 0;
     display: block;

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -1127,12 +1127,16 @@ onBeforeUnmount(() => {
   align-items: flex-start;
   gap: 8px;
   max-width: 85%;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .msg-content {
   display: flex;
   flex-direction: column;
   min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .message-bubble {
@@ -1140,8 +1144,10 @@ onBeforeUnmount(() => {
   font-size: 14px;
   line-height: 1.65;
   word-break: break-word;
+  overflow-wrap: anywhere;
   border-radius: 10px;
   max-width: 100%;
+  min-width: 0;
   position: relative;
   box-sizing: border-box;
 

--- a/packages/client/src/components/hermes/chat/VirtualMessageList.vue
+++ b/packages/client/src/components/hermes/chat/VirtualMessageList.vue
@@ -470,6 +470,8 @@ defineExpose({
 .virtual-message-list-host {
   flex: 1;
   min-height: 0;
+  min-width: 0;
+  max-width: 100%;
   display: flex;
   position: relative;
   animation: message-list-fade-in 1.5s ease both;
@@ -478,6 +480,8 @@ defineExpose({
 .virtual-message-list {
   flex: 1;
   min-height: 0;
+  min-width: 0;
+  max-width: 100%;
   padding: var(--virtual-list-padding);
   box-sizing: border-box;
   background-color: $bg-card;
@@ -489,6 +493,8 @@ defineExpose({
 
 .virtual-row {
   box-sizing: border-box;
+  min-width: 0;
+  max-width: 100%;
   padding-bottom: var(--virtual-row-gap);
 }
 

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -679,6 +679,8 @@ export default defineComponent({ components: { CreateRoomForm } })
     height: 100%;
     overflow: hidden;
     position: relative;
+    min-width: 0;
+    max-width: 100%;
 }
 
 .sidebar-backdrop {

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -621,6 +621,7 @@ onBeforeUnmount(() => {
     padding: 2px 0;
     min-width: 0;
     max-width: 100%;
+    box-sizing: border-box;
 
     &.self {
         flex-direction: row-reverse;
@@ -796,6 +797,7 @@ onBeforeUnmount(() => {
     flex-direction: column;
     min-width: 0;
     max-width: 85%;
+    box-sizing: border-box;
 }
 
 .msg-header {
@@ -937,8 +939,11 @@ onBeforeUnmount(() => {
     color: $text-primary;
     border-radius: 10px;
     background-color: $msg-user-bg;
+    min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
     word-break: break-word;
-    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
 
     &.speech-playing {
         box-shadow:

--- a/packages/client/src/components/hermes/group-chat/GroupMessageList.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageList.vue
@@ -68,6 +68,7 @@ defineExpose({ scrollToBottom })
 
 <template>
     <VirtualMessageList
+        class="group-message-list"
         ref="listRef"
         :messages="displayMessages"
         :estimated-item-height="170"
@@ -102,6 +103,11 @@ defineExpose({ scrollToBottom })
 
 <style scoped lang="scss">
 @use "@/styles/variables" as *;
+
+.group-message-list {
+    min-width: 0;
+    max-width: 100%;
+}
 
 .empty-state {
     flex: 1;

--- a/tests/client/chat-message-mobile-layout.test.ts
+++ b/tests/client/chat-message-mobile-layout.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+
+describe('chat message mobile layout guards', () => {
+  it('keeps chat message containers shrinkable on narrow screens', () => {
+    const chatPanel = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+    const virtualList = readFileSync('packages/client/src/components/hermes/chat/VirtualMessageList.vue', 'utf8')
+    const messageItem = readFileSync('packages/client/src/components/hermes/chat/MessageItem.vue', 'utf8')
+    const markdownRenderer = readFileSync('packages/client/src/components/hermes/chat/MarkdownRenderer.vue', 'utf8')
+
+    expect(chatPanel).toContain('.chat-panel')
+    expect(chatPanel).toContain('min-width: 0;')
+    expect(chatPanel).toContain('.chat-content-wrapper')
+    expect(chatPanel).toContain('max-width: 100%;')
+
+    expect(virtualList).toContain('.virtual-message-list-host')
+    expect(virtualList).toContain('.virtual-row')
+    expect(virtualList).toContain('min-width: 0;')
+    expect(virtualList).toContain('max-width: 100%;')
+
+    expect(messageItem).toContain('.msg-body')
+    expect(messageItem).toContain('.msg-content')
+    expect(messageItem).toContain('.message-bubble')
+    expect(messageItem).toContain('overflow-wrap: anywhere;')
+
+    expect(markdownRenderer).toContain('.markdown-body')
+    expect(markdownRenderer).toContain('width: 100%;')
+    expect(markdownRenderer).toContain('code:not(.hljs)')
+    expect(markdownRenderer).toContain('white-space: pre-wrap;')
+  })
+})

--- a/tests/client/chat-message-mobile-layout.test.ts
+++ b/tests/client/chat-message-mobile-layout.test.ts
@@ -8,6 +8,9 @@ describe('chat message mobile layout guards', () => {
     const virtualList = readFileSync('packages/client/src/components/hermes/chat/VirtualMessageList.vue', 'utf8')
     const messageItem = readFileSync('packages/client/src/components/hermes/chat/MessageItem.vue', 'utf8')
     const markdownRenderer = readFileSync('packages/client/src/components/hermes/chat/MarkdownRenderer.vue', 'utf8')
+    const groupChatPanel = readFileSync('packages/client/src/components/hermes/group-chat/GroupChatPanel.vue', 'utf8')
+    const groupMessageList = readFileSync('packages/client/src/components/hermes/group-chat/GroupMessageList.vue', 'utf8')
+    const groupMessageItem = readFileSync('packages/client/src/components/hermes/group-chat/GroupMessageItem.vue', 'utf8')
 
     expect(chatPanel).toContain('.chat-panel')
     expect(chatPanel).toContain('min-width: 0;')
@@ -28,5 +31,18 @@ describe('chat message mobile layout guards', () => {
     expect(markdownRenderer).toContain('width: 100%;')
     expect(markdownRenderer).toContain('code:not(.hljs)')
     expect(markdownRenderer).toContain('white-space: pre-wrap;')
+
+    expect(groupChatPanel).toContain('.group-chat-panel')
+    expect(groupChatPanel).toContain('min-width: 0;')
+    expect(groupChatPanel).toContain('max-width: 100%;')
+
+    expect(groupMessageList).toContain('.group-message-list')
+    expect(groupMessageList).toContain('min-width: 0;')
+    expect(groupMessageList).toContain('max-width: 100%;')
+
+    expect(groupMessageItem).toContain('.group-message')
+    expect(groupMessageItem).toContain('.msg-body')
+    expect(groupMessageItem).toContain('.msg-content')
+    expect(groupMessageItem).toContain('overflow-wrap: anywhere;')
   })
 })


### PR DESCRIPTION
## Summary
- constrain chat panel, virtual list rows, message bodies, and bubbles so mobile messages stay inside the viewport
- allow long markdown text, links, inline code, and tables to wrap or scroll within the message instead of widening the page
- add a client layout guard test for the mobile overflow constraints

## Validation
- `npm run test -- tests/client/chat-message-mobile-layout.test.ts tests/client/markdown-rendering.test.ts tests/client/message-item-highlight.test.ts`
- `npm run build`
- `npm run harness:check`