### PR TITLE
fix(files): allow literal dots in validated paths

### DIFF
--- a/packages/server/src/services/hermes/file-provider.ts
+++ b/packages/server/src/services/hermes/file-provider.ts
@@ -75,13 +75,18 @@ export function normalizePlatformPath(filePath: string, platform = process.platf
   return `${drive.toUpperCase()}:\\${rest.replace(/\//g, '\\')}`
 }
 
+function hasTraversalSegment(filePath: string): boolean {
+  return filePath.replace(/\\/g, '/').split('/').some(part => part === '..')
+}
+
 export function validatePath(filePath: string): string {
   if (!filePath) throw Object.assign(new Error('Missing file path'), { code: 'missing_path' })
-  const resolved = resolve(normalizePlatformPath(filePath))
-  const normalized = normalize(resolved)
-  if (normalized.includes('..')) {
+  const platformPath = normalizePlatformPath(filePath)
+  if (hasTraversalSegment(platformPath)) {
     throw Object.assign(new Error('Invalid file path'), { code: 'invalid_path' })
   }
+  const resolved = resolve(platformPath)
+  const normalized = normalize(resolved)
   if (!isAbsolute(normalized)) {
     throw Object.assign(new Error('Path must be absolute'), { code: 'invalid_path' })
   }

--- a/tests/server/file-provider-paths.test.ts
+++ b/tests/server/file-provider-paths.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { normalizePlatformPath } from '../../packages/server/src/services/hermes/file-provider'
+import { join, resolve } from 'path'
+import { tmpdir } from 'os'
+import { normalizePlatformPath, validatePath } from '../../packages/server/src/services/hermes/file-provider'
 import { isPathWithin, relativePathFromBase } from '../../packages/server/src/services/hermes/hermes-path'
 
 describe('file provider platform path normalization', () => {
@@ -20,6 +22,18 @@ describe('file provider platform path normalization', () => {
   it('leaves normal Windows paths unchanged', () => {
     expect(normalizePlatformPath('C:\\Users\\Administrator\\Desktop\\screenshot.png', 'win32'))
       .toBe('C:\\Users\\Administrator\\Desktop\\screenshot.png')
+  })
+
+  it('allows literal double dots inside safe absolute path segments', () => {
+    const filePath = join(tmpdir(), 'foo..bar.txt')
+
+    expect(validatePath(filePath)).toBe(resolve(filePath))
+  })
+
+  it('rejects parent-directory traversal segments', () => {
+    const filePath = `${join(tmpdir(), 'safe')}/../evil.txt`
+
+    expect(() => validatePath(filePath)).toThrow('Invalid file path')
   })
 })
 


### PR DESCRIPTION
## Summary

- Allow safe absolute file paths whose filename/path segment contains literal double dots, such as `foo..bar.txt`.
- Preserve traversal protection by rejecting exact `..` path segments before resolution/normalization can collapse them.
- Add regression coverage for both the accepted literal-dot filename case and a rejected parent-directory traversal segment.

## Validation

- `npm test -- --run tests/server/file-provider-paths.test.ts` (7 passed)
- `npm test -- --run tests/server/files-routes.test.ts` (6 passed)
- `npm run harness:check`
- `npm run build` (passed; existing Vite large chunk warnings only)
- `git diff --check`

## Sprint Gates

- Branch created from latest `upstream/main` (`b2de33a4e9608f3e32d5c697c8d99b892eed7c60`).
- Repo-local git identity: `qdivan / 77005282+qdivan@users.noreply.github.com`.
- Duplicate open PR check: no active duplicate found in the batched open PR list.
- Candidate review: PASS.
- Patch review: PASS after adding the traversal regression.
- Browser validation: not applicable; this is a server path-validation helper change.
