### PR TITLE
fix(skills): reject malformed import filename encoding

### DIFF
--- a/packages/server/src/controllers/hermes/skills.ts
+++ b/packages/server/src/controllers/hermes/skills.ts
@@ -811,7 +811,15 @@ async function readMultipartBody(ctx: any): Promise<{ parts: ParsedPart[] } | { 
   const rawParts = splitMultipart(raw, Buffer.from(boundary))
   const parts: ParsedPart[] = []
   for (const p of rawParts) {
-    const parsed = parsePart(p)
+    let parsed: ParsedPart | null
+    try {
+      parsed = parsePart(p)
+    } catch (err) {
+      if (err instanceof URIError) {
+        return { error: 'Invalid multipart filename encoding', status: 400 }
+      }
+      throw err
+    }
     if (parsed) parts.push(parsed)
   }
   return { parts }

--- a/tests/server/skills-controller.test.ts
+++ b/tests/server/skills-controller.test.ts
@@ -35,11 +35,15 @@ async function loadController() {
   return import('../../packages/server/src/controllers/hermes/skills')
 }
 
-function multipartBody(boundary: string, parts: Array<{ name: string; value: string; filename?: string; contentType?: string }>): Buffer {
+function multipartBody(boundary: string, parts: Array<{ name: string; value: string; filename?: string; filenameStar?: string; contentType?: string }>): Buffer {
   const chunks: Buffer[] = []
   for (const part of parts) {
     chunks.push(Buffer.from(`--${boundary}\r\n`))
-    const filename = part.filename ? `; filename="${part.filename}"` : ''
+    const filename = part.filenameStar
+      ? `; filename*=UTF-8''${part.filenameStar}`
+      : part.filename
+        ? `; filename="${part.filename}"`
+        : ''
     chunks.push(Buffer.from(`Content-Disposition: form-data; name="${part.name}"${filename}\r\n`))
     if (part.contentType) chunks.push(Buffer.from(`Content-Type: ${part.contentType}\r\n`))
     chunks.push(Buffer.from('\r\n'))
@@ -206,6 +210,52 @@ describe('skills controller', () => {
 
       await expect(readFile(join(researchProfileDir, 'skills', 'demo-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# Demo Skill\nresearch copy\n')
       await expect(readFile(join(defaultProfileDir, 'skills', 'demo-skill', 'SKILL.md'), 'utf-8')).rejects.toThrow()
+      expect(ctx.body).toEqual({ success: true, name: 'demo-skill' })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('returns bad request for malformed encoded skill import filenames', async () => {
+    const boundary = '----hermes-skill-import-bad-filename'
+    const ctx: any = {
+      get: vi.fn((header: string) => header.toLowerCase() === 'content-type' ? `multipart/form-data; boundary=${boundary}` : ''),
+      req: Readable.from([multipartBody(boundary, [
+        { name: 'file', filenameStar: '%E0%A4%A', contentType: 'text/markdown', value: '# Demo Skill\n' },
+      ])]),
+      state: { profile: { name: 'research' } },
+      body: null,
+    }
+
+    const { importSkill } = await loadController()
+
+    await importSkill(ctx)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toEqual({ error: 'Invalid multipart filename encoding' })
+  })
+
+  it('imports skills with valid encoded multipart filenames', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hermes-web-ui-import-encoded-filename-'))
+    const profileDir = join(root, 'research')
+    mockGetProfileDir.mockReturnValue(profileDir)
+
+    const boundary = '----hermes-skill-import-encoded-filename'
+    const ctx: any = {
+      get: vi.fn((header: string) => header.toLowerCase() === 'content-type' ? `multipart/form-data; boundary=${boundary}` : ''),
+      req: Readable.from([multipartBody(boundary, [
+        { name: 'file', filenameStar: 'demo-skill%2FSKILL.md', contentType: 'text/markdown', value: '# Demo Skill\nencoded filename\n' },
+      ])]),
+      state: { profile: { name: 'research' } },
+      body: null,
+    }
+
+    try {
+      const { importSkill } = await loadController()
+
+      await importSkill(ctx)
+
+      await expect(readFile(join(profileDir, 'skills', 'demo-skill', 'SKILL.md'), 'utf-8')).resolves.toBe('# Demo Skill\nencoded filename\n')
       expect(ctx.body).toEqual({ success: true, name: 'demo-skill' })
     } finally {
       await rm(root, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

- Convert malformed RFC 5987 multipart `filename*` encoding during skill import into a `400` response.
- Preserve valid encoded `filename*` imports.
- Add regression coverage for both malformed and valid encoded multipart filenames.

## Validation

- Failed first: `npm test -- --run tests/server/skills-controller.test.ts --testNamePattern "malformed encoded skill import filenames"` failed with `URIError: URI malformed`.
- `npm test -- --run tests/server/skills-controller.test.ts --testNamePattern "malformed encoded skill import filenames"` (passed after fix)
- `npm test -- --run tests/server/skills-controller.test.ts` (9 passed)
- `npm test -- --run tests/server/config-mutating-controllers.test.ts` (3 passed)
- `npm run harness:check`
- `npm run build` (passed; existing Vite large chunk warnings only)
- `git diff --check`

## Sprint Gates

- Branch created from latest `upstream/main` (`3e2f9989667ab3bc0d9e9f3cb58d57374e135920`).
- Repo-local git identity: `qdivan / 77005282+qdivan@users.noreply.github.com`.
- Duplicate open PR check: no active duplicate found in the batched open PR list.
- Candidate review: PASS.
- Patch review: PASS.
- Browser validation: not applicable; this is a server multipart parser/controller change.
