### PR TITLE
[codex] adjust release latest workflow policy

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -6,14 +6,12 @@ on:
       tag:
         description: "Existing release tag to attach artifacts to (e.g. v0.6.5)"
         required: true
-  release:
-    types: [published]
 
 permissions:
   contents: write
 
 concurrency:
-  group: desktop-release-${{ github.event.release.tag_name || github.event.inputs.tag || github.ref }}
+  group: desktop-release-${{ github.event.inputs.tag }}
   cancel-in-progress: false
 
 jobs:
@@ -75,7 +73,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          ref: ${{ github.event.inputs.tag }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -169,7 +167,7 @@ jobs:
       - name: Upload artifacts to release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          tag_name: ${{ github.event.inputs.tag }}
           fail_on_unmatched_files: true
           files: ${{ matrix.artifact_files }}
 
@@ -181,7 +179,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          ref: ${{ github.event.inputs.tag }}
 
       - name: Download macOS update manifests
         uses: actions/download-artifact@v4
@@ -201,6 +199,20 @@ jobs:
       - name: Upload merged macOS updater manifest to release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          tag_name: ${{ github.event.inputs.tag }}
           fail_on_unmatched_files: true
           files: /tmp/latest-mac.yml
+
+  mark-latest:
+    name: Mark desktop release as latest
+    needs: mac-update-manifest
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Mark release as latest
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: docker-${{ github.ref }}
@@ -44,3 +44,18 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:${{ github.sha }}
             ${{ secrets.DOCKERHUB_USERNAME }}/hermes-web-ui:${{ github.event.release.tag_name || github.ref_name }}
+
+  keep-release-out-of-latest:
+    name: Keep release out of GitHub latest
+    if: always() && github.event_name == 'release'
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark release as not latest
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --latest=false

--- a/.github/workflows/webui-release.yml
+++ b/.github/workflows/webui-release.yml
@@ -85,8 +85,24 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          make_latest: false
           fail_on_unmatched_files: true
           files: |
             release/webui/${{ steps.package.outputs.asset }}
             release/webui/${{ steps.package.outputs.asset }}.sha256
             release/webui/${{ steps.package.outputs.manifest }}
+
+  keep-release-out-of-latest:
+    name: Keep release out of GitHub latest
+    if: always() && github.event_name == 'release'
+    needs: webui
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Mark release as not latest
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --latest=false

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -71,9 +71,13 @@ Frontend rules:
 Desktop packaging is intentionally split:
 
 - Pull requests run the web UI build and tests in `.github/workflows/build.yml`.
-- Published releases and manual dispatches run desktop artifact packaging in `.github/workflows/desktop-release.yml`
-  and `.github/workflows/desktop-manual-build.yml`.
+- Published GitHub Releases run Web UI artifact packaging and Docker image publishing without
+  marking the release as GitHub latest.
+- Manual dispatches run full desktop artifact packaging in `.github/workflows/desktop-release.yml`.
+- `.github/workflows/desktop-manual-build.yml` builds one desktop target for targeted repairs or re-runs.
 - Each release matrix target uploads only the artifact globs for its own platform.
+- A successful full desktop release marks the target GitHub Release as latest after all desktop artifacts
+  and the merged macOS updater manifest have been uploaded.
 
 Do not make a Windows job require macOS `.dmg` files or a Linux job require
 Windows installers. Keep `fail_on_unmatched_files: true` where platform-specific

--- a/docs/harness/validation.md
+++ b/docs/harness/validation.md
@@ -44,6 +44,15 @@ npm run build
 
 ## Release Workflow Guardrail
 
+Published GitHub Releases should still trigger Web UI artifact packaging and
+Docker image publishing, but those workflows must keep the GitHub Release out
+of latest.
+
+Full desktop packaging is manually dispatched through
+`.github/workflows/desktop-release.yml`; published GitHub Releases must not
+automatically start desktop packaging. After a full desktop release finishes,
+the workflow must mark the target GitHub Release as latest.
+
 Desktop release jobs must upload only the artifacts that their matrix target can
 produce. Keep artifact globs in matrix data and keep `fail_on_unmatched_files:
 true` so missing expected files still fail.

--- a/scripts/harness-check.mjs
+++ b/scripts/harness-check.mjs
@@ -247,6 +247,8 @@ const desktopReleaseWorkflow = await readText('.github/workflows/desktop-release
 const desktopManualBuildWorkflow = await readText('.github/workflows/desktop-manual-build.yml')
 const desktopMacUpdateManifestWorkflow = await readText('.github/workflows/desktop-mac-update-manifest.yml')
 const desktopRuntimeWorkflow = await readText('.github/workflows/desktop-runtime.yml')
+const webuiReleaseWorkflow = await readText('.github/workflows/webui-release.yml')
+const dockerPublishWorkflow = await readText('.github/workflows/docker-publish.yml')
 const electronBuilderConfig = await readText('packages/desktop/electron-builder.yml')
 const desktopPackageJson = await readText('packages/desktop/package.json')
 const desktopInstallHermes = await readText('packages/desktop/scripts/install-hermes.mjs')
@@ -256,6 +258,30 @@ const desktopPaths = await readText('packages/desktop/src/main/paths.ts')
 const desktopRuntimeAssetName = await readText('packages/desktop/scripts/runtime-asset-name.mjs')
 if (!desktopReleaseWorkflow.includes('files: ${{ matrix.artifact_files }}')) {
   fail('desktop-release.yml must upload matrix-specific artifact_files')
+}
+
+if (desktopReleaseWorkflow.includes('types: [published]')) {
+  fail('desktop-release.yml must not run full desktop packaging on every published GitHub Release')
+}
+
+if (!desktopReleaseWorkflow.includes('gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --latest')) {
+  fail('desktop-release.yml must mark successful full desktop releases as GitHub latest')
+}
+
+for (const [file, text] of [
+  ['webui-release.yml', webuiReleaseWorkflow],
+  ['docker-publish.yml', dockerPublishWorkflow],
+]) {
+  if (!text.includes('release:') || !text.includes('types: [published]')) {
+    fail(`${file} must keep running on published GitHub Releases`)
+  }
+  if (!text.includes('gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --latest=false')) {
+    fail(`${file} must keep published GitHub Releases out of latest`)
+  }
+}
+
+if (!webuiReleaseWorkflow.includes('make_latest: false')) {
+  fail('webui-release.yml must not mark release uploads as GitHub latest')
 }
 
 if (!electronBuilderConfig.includes('icon: build/icons')) {


### PR DESCRIPTION
## Summary
- stop full desktop packaging from running on every published GitHub Release
- keep Web UI and Docker release workflows running on published releases while clearing the GitHub Latest marker
- mark manually dispatched full desktop releases as GitHub Latest after all desktop artifacts and the macOS manifest upload successfully
- document and enforce the release policy in harness checks

## Validation
- `npm run harness:check`
- `git diff --check`