### PR TITLE
[codex] fix desktop update shutdown handling

### DIFF
--- a/packages/desktop/build/installer.nsh
+++ b/packages/desktop/build/installer.nsh
@@ -2,7 +2,38 @@
   IfFileExists "$INSTDIR\Hermes Studio.exe" 0 hermesStudioStopDone
     DetailPrint "Stopping Hermes Studio..."
     nsExec::ExecToLog '"$INSTDIR\Hermes Studio.exe" --quit'
-    Sleep 5000
+    Sleep 2000
+
+    InitPluginsDir
+    FileOpen $0 "$PLUGINSDIR\stop-hermes-studio.ps1" w
+    FileWrite $0 "$$ErrorActionPreference = 'SilentlyContinue'$\r$\n"
+    FileWrite $0 "$$target = [System.IO.Path]::GetFullPath($$env:HERMES_STUDIO_EXE)$\r$\n"
+    FileWrite $0 "function Get-HermesStudioProcess {$\r$\n"
+    FileWrite $0 "  Get-CimInstance Win32_Process -Filter $\"Name = 'Hermes Studio.exe'$\" | Where-Object {$\r$\n"
+    FileWrite $0 "    try { [System.IO.Path]::GetFullPath($$_.ExecutablePath) -ieq $$target } catch { $$false }$\r$\n"
+    FileWrite $0 "  }$\r$\n"
+    FileWrite $0 "}$\r$\n"
+    FileWrite $0 "Get-HermesStudioProcess | ForEach-Object {$\r$\n"
+    FileWrite $0 "  try {$\r$\n"
+    FileWrite $0 "    $$process = Get-Process -Id $$_.ProcessId$\r$\n"
+    FileWrite $0 "    if ($$process) { $$process.CloseMainWindow() | Out-Null }$\r$\n"
+    FileWrite $0 "  } catch {}$\r$\n"
+    FileWrite $0 "}$\r$\n"
+    FileWrite $0 "Start-Sleep -Seconds 3$\r$\n"
+    FileWrite $0 "$$deadline = (Get-Date).AddSeconds(20)$\r$\n"
+    FileWrite $0 "while ((Get-Date) -lt $$deadline) {$\r$\n"
+    FileWrite $0 "  $$processes = @(Get-HermesStudioProcess)$\r$\n"
+    FileWrite $0 "  if ($$processes.Count -eq 0) { exit 0 }$\r$\n"
+    FileWrite $0 "  $$processes | ForEach-Object { Stop-Process -Id $$_.ProcessId -Force }$\r$\n"
+    FileWrite $0 "  Start-Sleep -Milliseconds 500$\r$\n"
+    FileWrite $0 "}$\r$\n"
+    FileWrite $0 "if (@(Get-HermesStudioProcess).Count -eq 0) { exit 0 }$\r$\n"
+    FileWrite $0 "exit 1$\r$\n"
+    FileClose $0
+
+    System::Call 'kernel32::SetEnvironmentVariable(t "HERMES_STUDIO_EXE", t "$INSTDIR\Hermes Studio.exe") i .r0'
+    nsExec::ExecToLog '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\stop-hermes-studio.ps1"'
+    System::Call 'kernel32::SetEnvironmentVariable(t "HERMES_STUDIO_EXE", t "") i .r0'
     nsExec::ExecToLog 'taskkill.exe /IM "Hermes Studio.exe" /T /F'
   hermesStudioStopDone:
 !macroend

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -78,6 +78,12 @@ function quitApp() {
   app.quit()
 }
 
+function hasQuitRequest(data: unknown): boolean {
+  return typeof data === 'object'
+    && data !== null
+    && (data as { quit?: unknown }).quit === true
+}
+
 function loginItemOptions() {
   return {
     path: process.execPath,
@@ -425,14 +431,14 @@ ipcMain.handle('hermes-desktop:retry-bootstrap', async (_event, source?: Runtime
 })
 
 function runDesktopApp() {
-  const gotLock = app.requestSingleInstanceLock()
+  const gotLock = app.requestSingleInstanceLock(QUIT_EXISTING ? { quit: true } : undefined)
   if (!gotLock) {
     app.quit()
     return
   }
 
-  app.on('second-instance', (_event, argv) => {
-    if (argv.includes('--quit')) {
+  app.on('second-instance', (_event, argv, _workingDirectory, additionalData) => {
+    if (argv.includes('--quit') || hasQuitRequest(additionalData)) {
       quitApp()
       return
     }

--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -6,16 +6,7 @@ let initialized = false
 let checking = false
 let updateDownloaded = false
 
-const LATEST_RELEASE_DOWNLOAD_URL = 'https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest/download'
-const GITHUB_RELEASE_DOWNLOAD_BASE_URL = 'https://github.com/EKKOLearnAI/hermes-web-ui/releases/download'
-const CLOUDFLARE_DOWNLOAD_BASE_URL = 'https://download.ekkolearnai.com'
-
-class MissingUpdateInfoError extends Error {
-  constructor(public readonly url: string) {
-    super(`Update information is not available at ${url}`)
-    this.name = 'MissingUpdateInfoError'
-  }
-}
+const CLOUDFLARE_LATEST_FEED_URL = 'https://download.ekkolearnai.com/latest'
 
 interface AutoUpdaterOptions {
   beforeQuitAndInstall?: () => void
@@ -23,88 +14,11 @@ interface AutoUpdaterOptions {
 
 let options: AutoUpdaterOptions = {}
 
-async function getLatestReleaseTag(assetName: string): Promise<string> {
-  const res = await fetch(`${LATEST_RELEASE_DOWNLOAD_URL}/${encodeURIComponent(assetName)}`, {
-    method: 'HEAD',
-    redirect: 'manual',
-    headers: {
-      'User-Agent': `Hermes-Studio/${app.getVersion()}`,
-    },
+function configureLatestUpdateFeed(): void {
+  autoUpdater.setFeedURL({
+    provider: 'generic',
+    url: CLOUDFLARE_LATEST_FEED_URL,
   })
-
-  if (res.status < 300 || res.status >= 400) throw new Error(`GitHub returned ${res.status}`)
-
-  const location = res.headers.get('location')
-  if (!location) throw new Error('Latest release redirect did not include a location')
-
-  const redirectUrl = new URL(location, LATEST_RELEASE_DOWNLOAD_URL)
-  const parts = redirectUrl.pathname.split('/')
-  const downloadIndex = parts.indexOf('download')
-  const tag = downloadIndex >= 0 ? parts[downloadIndex + 1]?.trim() : ''
-  if (!tag) throw new Error('Latest release redirect did not include a tag')
-  return tag
-}
-
-function updateManifestFile(): string {
-  if (process.platform === 'darwin') return 'latest-mac.yml'
-  if (process.platform === 'win32') return 'latest.yml'
-  return 'latest-linux.yml'
-}
-
-async function assertUpdateManifestExists(feedUrl: string): Promise<void> {
-  const manifestUrl = `${feedUrl}/${updateManifestFile()}`
-  const res = await fetchUpdateManifest(manifestUrl)
-  if (res.status === 404) throw new MissingUpdateInfoError(manifestUrl)
-  if (!res.ok) throw new Error(`Update feed returned ${res.status}`)
-}
-
-async function fetchUpdateManifest(manifestUrl: string): Promise<Response> {
-  const headers = {
-    'User-Agent': `Hermes-Studio/${app.getVersion()}`,
-  }
-  const res = await fetch(manifestUrl, {
-    method: 'HEAD',
-    headers,
-  })
-  if (res.status !== 403 && res.status !== 405) return res
-  return fetch(manifestUrl, {
-    method: 'GET',
-    headers: {
-      ...headers,
-      Range: 'bytes=0-0',
-    },
-  })
-}
-
-function updateFeedCandidates(tag: string): string[] {
-  const cloudflareFeedUrl = `${CLOUDFLARE_DOWNLOAD_BASE_URL}/${tag}`
-  return [
-    cloudflareFeedUrl,
-    `${GITHUB_RELEASE_DOWNLOAD_BASE_URL}/${tag}`,
-  ]
-}
-
-async function configureFeedFromLatestRelease(): Promise<void> {
-  const tag = await getLatestReleaseTag(updateManifestFile())
-  let lastError: unknown = null
-  for (const feedUrl of updateFeedCandidates(tag)) {
-    try {
-      await assertUpdateManifestExists(feedUrl)
-      autoUpdater.setFeedURL({
-        provider: 'generic',
-        url: feedUrl,
-      })
-      return
-    } catch (err) {
-      lastError = err
-      console.warn(`[updater] update feed unavailable at ${feedUrl}: ${err instanceof Error ? err.message : String(err)}`)
-    }
-  }
-  throw lastError || new MissingUpdateInfoError(`${CLOUDFLARE_DOWNLOAD_BASE_URL}/${tag}/${updateManifestFile()}`)
-}
-
-export const updaterInternals = {
-  updateFeedCandidates,
 }
 
 function showUpToDate(info?: UpdateInfo) {
@@ -118,12 +32,11 @@ function showUpToDate(info?: UpdateInfo) {
   }).catch(() => undefined)
 }
 
-function showUpdateCheckFailed(err: unknown) {
-  const isMissingUpdateInfo = err instanceof MissingUpdateInfoError
+function showUpdateCheckFailed() {
   dialog.showMessageBox({
-    type: isMissingUpdateInfo ? 'info' : 'error',
-    title: isMissingUpdateInfo ? t('update.upToDateTitle') : t('update.failedTitle'),
-    message: isMissingUpdateInfo ? t('update.noUpdateInfoMessage') : t('update.failedMessage'),
+    type: 'error',
+    title: t('update.failedTitle'),
+    message: t('update.failedMessage'),
     buttons: [t('common.ok')],
   }).catch(() => undefined)
 }
@@ -154,7 +67,7 @@ export function initAutoUpdater(nextOptions: AutoUpdaterOptions = {}) {
   })
   autoUpdater.on('error', err => {
     console.error('[updater] error:', err)
-    if (checking) showUpdateCheckFailed(err)
+    if (checking) showUpdateCheckFailed()
   })
   autoUpdater.on('download-progress', (info: ProgressInfo) => {
     console.log(`[updater] download ${Math.round(info.percent)}%`)
@@ -218,10 +131,10 @@ export async function checkForDesktopUpdates(manual: boolean): Promise<void> {
 
   checking = manual
   try {
-    await configureFeedFromLatestRelease()
+    configureLatestUpdateFeed()
     await autoUpdater.checkForUpdates()
   } catch (err) {
-    if (manual) showUpdateCheckFailed(err)
+    if (manual) showUpdateCheckFailed()
     throw err
   } finally {
     checking = false

--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -7,6 +7,7 @@ let checking = false
 let updateDownloaded = false
 
 const LATEST_RELEASE_DOWNLOAD_URL = 'https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest/download'
+const GITHUB_RELEASE_DOWNLOAD_BASE_URL = 'https://github.com/EKKOLearnAI/hermes-web-ui/releases/download'
 const CLOUDFLARE_DOWNLOAD_BASE_URL = 'https://download.ekkolearnai.com'
 
 class MissingUpdateInfoError extends Error {
@@ -52,24 +53,58 @@ function updateManifestFile(): string {
 
 async function assertUpdateManifestExists(feedUrl: string): Promise<void> {
   const manifestUrl = `${feedUrl}/${updateManifestFile()}`
-  const res = await fetch(manifestUrl, {
-    method: 'HEAD',
-    headers: {
-      'User-Agent': `Hermes-Studio/${app.getVersion()}`,
-    },
-  })
+  const res = await fetchUpdateManifest(manifestUrl)
   if (res.status === 404) throw new MissingUpdateInfoError(manifestUrl)
   if (!res.ok) throw new Error(`Update feed returned ${res.status}`)
 }
 
+async function fetchUpdateManifest(manifestUrl: string): Promise<Response> {
+  const headers = {
+    'User-Agent': `Hermes-Studio/${app.getVersion()}`,
+  }
+  const res = await fetch(manifestUrl, {
+    method: 'HEAD',
+    headers,
+  })
+  if (res.status !== 403 && res.status !== 405) return res
+  return fetch(manifestUrl, {
+    method: 'GET',
+    headers: {
+      ...headers,
+      Range: 'bytes=0-0',
+    },
+  })
+}
+
+function updateFeedCandidates(tag: string): string[] {
+  const cloudflareFeedUrl = `${CLOUDFLARE_DOWNLOAD_BASE_URL}/${tag}`
+  return [
+    cloudflareFeedUrl,
+    `${GITHUB_RELEASE_DOWNLOAD_BASE_URL}/${tag}`,
+  ]
+}
+
 async function configureFeedFromLatestRelease(): Promise<void> {
   const tag = await getLatestReleaseTag(updateManifestFile())
-  const feedUrl = `${CLOUDFLARE_DOWNLOAD_BASE_URL}/${tag}`
-  await assertUpdateManifestExists(feedUrl)
-  autoUpdater.setFeedURL({
-    provider: 'generic',
-    url: feedUrl,
-  })
+  let lastError: unknown = null
+  for (const feedUrl of updateFeedCandidates(tag)) {
+    try {
+      await assertUpdateManifestExists(feedUrl)
+      autoUpdater.setFeedURL({
+        provider: 'generic',
+        url: feedUrl,
+      })
+      return
+    } catch (err) {
+      lastError = err
+      console.warn(`[updater] update feed unavailable at ${feedUrl}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+  throw lastError || new MissingUpdateInfoError(`${CLOUDFLARE_DOWNLOAD_BASE_URL}/${tag}/${updateManifestFile()}`)
+}
+
+export const updaterInternals = {
+  updateFeedCandidates,
 }
 
 function showUpToDate(info?: UpdateInfo) {

--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -5,8 +5,10 @@ import { t } from './desktop-i18n'
 let initialized = false
 let checking = false
 let updateDownloaded = false
+let tryingFallbackFeed = false
 
 const CLOUDFLARE_LATEST_FEED_URL = 'https://download.ekkolearnai.com/latest'
+const GITHUB_LATEST_FEED_URL = 'https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest/download'
 
 interface AutoUpdaterOptions {
   beforeQuitAndInstall?: () => void
@@ -14,11 +16,27 @@ interface AutoUpdaterOptions {
 
 let options: AutoUpdaterOptions = {}
 
-function configureLatestUpdateFeed(): void {
+function configureUpdateFeed(url: string): void {
   autoUpdater.setFeedURL({
     provider: 'generic',
-    url: CLOUDFLARE_LATEST_FEED_URL,
+    url,
   })
+}
+
+async function checkForUpdatesWithFallback(): Promise<void> {
+  configureUpdateFeed(CLOUDFLARE_LATEST_FEED_URL)
+  try {
+    await autoUpdater.checkForUpdates()
+  } catch (err) {
+    console.warn(`[updater] Cloudflare update feed failed, trying GitHub: ${err instanceof Error ? err.message : String(err)}`)
+    tryingFallbackFeed = true
+    try {
+      configureUpdateFeed(GITHUB_LATEST_FEED_URL)
+      await autoUpdater.checkForUpdates()
+    } finally {
+      tryingFallbackFeed = false
+    }
+  }
 }
 
 function showUpToDate(info?: UpdateInfo) {
@@ -67,7 +85,7 @@ export function initAutoUpdater(nextOptions: AutoUpdaterOptions = {}) {
   })
   autoUpdater.on('error', err => {
     console.error('[updater] error:', err)
-    if (checking) showUpdateCheckFailed()
+    if (checking && !tryingFallbackFeed) showUpdateCheckFailed()
   })
   autoUpdater.on('download-progress', (info: ProgressInfo) => {
     console.log(`[updater] download ${Math.round(info.percent)}%`)
@@ -131,8 +149,7 @@ export async function checkForDesktopUpdates(manual: boolean): Promise<void> {
 
   checking = manual
   try {
-    configureLatestUpdateFeed()
-    await autoUpdater.checkForUpdates()
+    await checkForUpdatesWithFallback()
   } catch (err) {
     if (manual) showUpdateCheckFailed()
     throw err

--- a/scripts/harness-check.mjs
+++ b/scripts/harness-check.mjs
@@ -253,6 +253,9 @@ const electronBuilderConfig = await readText('packages/desktop/electron-builder.
 const desktopPackageJson = await readText('packages/desktop/package.json')
 const desktopInstallHermes = await readText('packages/desktop/scripts/install-hermes.mjs')
 const desktopWebuiServer = await readText('packages/desktop/src/main/webui-server.ts')
+const desktopMain = await readText('packages/desktop/src/main/index.ts')
+const desktopUpdater = await readText('packages/desktop/src/main/updater.ts')
+const desktopInstallerScript = await readText('packages/desktop/build/installer.nsh')
 const desktopRuntimeManager = await readText('packages/desktop/src/main/runtime-manager.ts')
 const desktopPaths = await readText('packages/desktop/src/main/paths.ts')
 const desktopRuntimeAssetName = await readText('packages/desktop/scripts/runtime-asset-name.mjs')
@@ -406,6 +409,35 @@ for (const phrase of [
 ]) {
   if (!desktopWebuiServer.includes(phrase)) {
     fail(`desktop webui server must expose bundled browser runtime: ${phrase}`)
+  }
+}
+
+for (const phrase of [
+  'requestSingleInstanceLock(QUIT_EXISTING ? { quit: true } : undefined)',
+  'hasQuitRequest(additionalData)',
+]) {
+  if (!desktopMain.includes(phrase)) {
+    fail(`desktop main process must forward --quit to an existing app instance: ${phrase}`)
+  }
+}
+
+for (const phrase of [
+  'HERMES_STUDIO_EXE',
+  'Get-CimInstance Win32_Process',
+  'CloseMainWindow()',
+  'Stop-Process -Id',
+]) {
+  if (!desktopInstallerScript.includes(phrase)) {
+    fail(`desktop installer must close stale Hermes Studio processes by installed executable path: ${phrase}`)
+  }
+}
+
+for (const phrase of [
+  'GITHUB_RELEASE_DOWNLOAD_BASE_URL',
+  'updateFeedCandidates(tag)',
+]) {
+  if (!desktopUpdater.includes(phrase)) {
+    fail(`desktop updater must keep GitHub release feed fallback after Cloudflare: ${phrase}`)
   }
 }
 

--- a/scripts/harness-check.mjs
+++ b/scripts/harness-check.mjs
@@ -433,12 +433,16 @@ for (const phrase of [
 }
 
 for (const phrase of [
-  'GITHUB_RELEASE_DOWNLOAD_BASE_URL',
-  'updateFeedCandidates(tag)',
+  'https://download.ekkolearnai.com/latest',
+  'configureLatestUpdateFeed()',
 ]) {
   if (!desktopUpdater.includes(phrase)) {
-    fail(`desktop updater must keep GitHub release feed fallback after Cloudflare: ${phrase}`)
+    fail(`desktop updater must use the Cloudflare latest update feed directly: ${phrase}`)
   }
+}
+
+if (desktopUpdater.includes('releases/latest/download')) {
+  fail('desktop updater must not call GitHub to resolve the latest release tag')
 }
 
 for (const phrase of [

--- a/scripts/harness-check.mjs
+++ b/scripts/harness-check.mjs
@@ -434,15 +434,16 @@ for (const phrase of [
 
 for (const phrase of [
   'https://download.ekkolearnai.com/latest',
-  'configureLatestUpdateFeed()',
+  'https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest/download',
+  'checkForUpdatesWithFallback()',
 ]) {
   if (!desktopUpdater.includes(phrase)) {
-    fail(`desktop updater must use the Cloudflare latest update feed directly: ${phrase}`)
+    fail(`desktop updater must check Cloudflare first and keep GitHub as fallback: ${phrase}`)
   }
 }
 
-if (desktopUpdater.includes('releases/latest/download')) {
-  fail('desktop updater must not call GitHub to resolve the latest release tag')
+if (desktopUpdater.includes('fetch(')) {
+  fail('desktop updater must not make custom fetch requests to resolve the latest release tag')
 }
 
 for (const phrase of [


### PR DESCRIPTION
## Summary
- make the Windows installer close stale Hermes Studio processes by installed executable path before replacing files
- forward `--quit` requests to an existing desktop instance through Electron single-instance data
- use the Cloudflare latest updater feed first and fall back to GitHub if that feed fails
- add harness checks for the installer shutdown path and updater feed policy

## Cloudflare
- updated `hermes-download-proxy` to support `/latest`, `/latest.yml`, and `/latest/*` paths for updater manifests/assets
- preserved the existing R2 binding and tagged release paths

## Validation
- `npm --prefix packages/desktop run build:main`
- `npm run harness:check`
- `git diff --check`
- Windows x64 artifact build: https://github.com/EKKOLearnAI/hermes-web-ui/actions/runs/27247412950