### PR TITLE
Force website light theme

### DIFF
--- a/packages/website/src/App.vue
+++ b/packages/website/src/App.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
-import { darkTheme } from 'naive-ui'
 import { NConfigProvider, NMessageProvider } from 'naive-ui'
-import { useTheme } from '@/composables/useTheme'
 import { getThemeOverrides } from '@client/styles/theme'
 import SiteHeader from '@/components/layout/SiteHeader.vue'
 import SiteFooter from '@/components/layout/SiteFooter.vue'
-
-const { isDark } = useTheme()
 </script>
 
 <template>
-  <NConfigProvider :theme="isDark ? darkTheme : undefined" :theme-overrides="getThemeOverrides(isDark)">
+  <NConfigProvider :theme-overrides="getThemeOverrides(false)">
     <NMessageProvider>
       <div class="website-app">
         <SiteHeader />

--- a/packages/website/src/components/landing/StarHistorySection.vue
+++ b/packages/website/src/components/landing/StarHistorySection.vue
@@ -2,18 +2,15 @@
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useScrollReveal } from '@/composables/useScrollReveal'
-import { useTheme } from '@/composables/useTheme'
 
 const { t } = useI18n()
-const { isDark } = useTheme()
 useScrollReveal()
 
 const stars = ref<number | null>(null)
 const releaseVersion = __WEBSITE_DOWNLOAD_VERSION__
 
 const chartSrc = computed(() => {
-  const base = 'https://api.star-history.com/svg?repos=EKKOLearnAI%2Fhermes-web-ui&type=Date'
-  return isDark.value ? `${base}&theme=dark` : base
+  return 'https://api.star-history.com/svg?repos=EKKOLearnAI%2Fhermes-web-ui&type=Date'
 })
 
 onMounted(async () => {

--- a/packages/website/src/composables/useTheme.ts
+++ b/packages/website/src/composables/useTheme.ts
@@ -1,48 +1,24 @@
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 
 export type ThemeMode = 'light' | 'dark' | 'system'
 
 const STORAGE_KEY = 'hermes_website_theme'
 
-const mode = ref<ThemeMode>(
-  (localStorage.getItem(STORAGE_KEY) as ThemeMode) || 'system',
-)
-
+const mode = ref<ThemeMode>('light')
 const isDark = ref(false)
 
-function applyTheme(dark: boolean) {
-  isDark.value = dark
-  document.documentElement.classList.toggle('dark', dark)
-}
-
-function resolveDark(m: ThemeMode): boolean {
-  if (m === 'system') {
-    return window.matchMedia('(prefers-color-scheme: dark)').matches
-  }
-  return m === 'dark'
-}
-
-applyTheme(resolveDark(mode.value))
-
-const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-mediaQuery.addEventListener('change', () => {
-  if (mode.value === 'system') {
-    applyTheme(resolveDark('system'))
-  }
-})
-
-watch(mode, (newMode) => {
-  localStorage.setItem(STORAGE_KEY, newMode)
-  applyTheme(resolveDark(newMode))
-})
+localStorage.setItem(STORAGE_KEY, 'light')
+document.documentElement.classList.remove('dark')
 
 export function useTheme() {
-  function setMode(m: ThemeMode) {
-    mode.value = m
+  function setMode(_m: ThemeMode) {
+    mode.value = 'light'
+    localStorage.setItem(STORAGE_KEY, 'light')
+    document.documentElement.classList.remove('dark')
   }
 
   function toggleTheme() {
-    mode.value = isDark.value ? 'light' : 'dark'
+    setMode('light')
   }
 
   return {

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -6,11 +6,8 @@ import App from './App.vue'
 import '@client/styles/variables.scss'
 import './styles/global.scss'
 
-const savedTheme = localStorage.getItem('hermes_website_theme') || 'system'
-const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-if (savedTheme === 'dark' || (savedTheme === 'system' && prefersDark)) {
-  document.documentElement.classList.add('dark')
-}
+localStorage.setItem('hermes_website_theme', 'light')
+document.documentElement.classList.remove('dark')
 
 const app = createApp(App)
 app.use(i18n)


### PR DESCRIPTION
## Summary
- force the website app to use the light theme regardless of previous localStorage or system preference
- remove website Naive UI dark-theme wiring and always use light theme overrides
- keep the star history chart on the light variant

## Testing
- npx vue-tsc -p tsconfig.website.json --noEmit
- npm run build:website