### PR TITLE
fix(profiles): reject reserved rename targets

### DIFF
--- a/packages/server/src/controllers/hermes/profiles.ts
+++ b/packages/server/src/controllers/hermes/profiles.ts
@@ -672,6 +672,11 @@ export async function rename(ctx: any) {
     ctx.body = { error: 'Missing new_name' }
     return
   }
+  if (isForbiddenProfileName(new_name)) {
+    ctx.status = 400
+    ctx.body = { error: `Profile name '${new_name}' is reserved and cannot be used` }
+    return
+  }
   try {
     const ok = await hermesCli.renameProfile(ctx.params.name, new_name)
     if (ok) {

--- a/tests/server/profiles-routes.test.ts
+++ b/tests/server/profiles-routes.test.ts
@@ -120,6 +120,25 @@ describe('Profile Routes', () => {
     })
   })
 
+  describe('profile rename validation', () => {
+    it('rejects reserved profile names before calling Hermes CLI', async () => {
+      vi.mocked(hermesCli.renameProfile).mockResolvedValue(true)
+      const { rename } = await import('../../packages/server/src/controllers/hermes/profiles')
+      const ctx: any = {
+        params: { name: 'work' },
+        request: { body: { new_name: 'hermes' } },
+        status: 200,
+        body: undefined,
+      }
+
+      await rename(ctx)
+
+      expect(ctx.status).toBe(400)
+      expect(ctx.body).toEqual({ error: "Profile name 'hermes' is reserved and cannot be used" })
+      expect(hermesCli.renameProfile).not.toHaveBeenCalled()
+    })
+  })
+
   describe('profile deletion fallback', () => {
     it('removes a reserved profile directory when Hermes CLI refuses to delete it', async () => {
       const hermesHome = await mkdtemp(join(tmpdir(), 'hermes-profile-delete-'))


### PR DESCRIPTION
## Summary

- Reject reserved profile names in the profile rename endpoint before calling the Hermes CLI.
- Add a regression test covering rename to `hermes`.

## Why

Profile create/switch/status flows already treat names such as `hermes` as reserved. Rename was missing the same validation, allowing the Web UI API to create inconsistent reserved profile state.

## Validation

- `npm_config_cache=/tmp/npm-cache-hermes-web-ui npx -y -p node@24 -c 'node -v && npm test -- --run tests/server/profiles-routes.test.ts --testNamePattern "rejects reserved profile names"'`
- `npm_config_cache=/tmp/npm-cache-hermes-web-ui npx -y -p node@24 -c 'node -v && npm test -- --run tests/server/profiles-routes.test.ts'`
- `npm_config_cache=/tmp/npm-cache-hermes-web-ui npx -y -p node@24 -c 'node -v && npm run harness:check'`
- `npm_config_cache=/tmp/npm-cache-hermes-web-ui npx -y -p node@24 -c 'node -v && npm run build'`

Note: local `/usr/local/bin/node` is `v18.20.3` and fails to load the current Vitest/Vite config with `ERR_REQUIRE_ESM`, so validation used `node@24` (`v24.16.0`) as allowed by the repo gates.
