### PR TITLE
feat: add custom desktop title bar

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -6,6 +6,7 @@ import { useI18n } from 'vue-i18n'
 import { getThemeOverrides } from '@/styles/theme'
 import { useTheme } from '@/composables/useTheme'
 import AppSidebar from '@/components/layout/AppSidebar.vue'
+import DesktopTitleBar from '@/components/layout/DesktopTitleBar.vue'
 import { useKeyboard } from '@/composables/useKeyboard'
 import { useAppStore } from '@/stores/hermes/app'
 import SessionSearchModal from '@/components/hermes/chat/SessionSearchModal.vue'
@@ -29,6 +30,10 @@ const nodeVersionLow = computed(() => {
   const major = parseInt(v.split('.')[0], 10)
   return !isNaN(major) && major < 23
 })
+
+const isDesktopShell = computed(() =>
+  (window as typeof window & { hermesDesktop?: { isDesktop?: boolean } }).hermesDesktop?.isDesktop === true,
+)
 
 // Close mobile sidebar on route change
 watch(() => route.path, () => {
@@ -60,18 +65,21 @@ useKeyboard()
       <AuthEventListener />
       <NDialogProvider>
         <NNotificationProvider>
-          <div v-if="nodeVersionLow && ready" class="node-warning-bar">
-            {{ t('sidebar.nodeVersionWarning', { version: appStore.nodeVersion }) }}
-          </div>
-          <div v-if="ready" class="app-layout" :class="{ 'no-sidebar': isLoginPage }">
-            <button v-if="!isLoginPage" class="hamburger-btn" @click="appStore.toggleSidebar">
-              <img src="/logo.png" alt="Menu" style="width: 24px; height: 24px;" />
-            </button>
-            <div v-if="!isLoginPage && appStore.sidebarOpen" class="mobile-backdrop" @click="appStore.closeSidebar" />
-            <AppSidebar v-if="!isLoginPage" />
-            <main class="app-main">
-              <router-view />
-            </main>
+          <div v-if="ready" class="app-shell" :class="{ desktop: isDesktopShell }">
+            <DesktopTitleBar v-if="isDesktopShell" />
+            <div v-if="nodeVersionLow" class="node-warning-bar">
+              {{ t('sidebar.nodeVersionWarning', { version: appStore.nodeVersion }) }}
+            </div>
+            <div class="app-layout" :class="{ 'no-sidebar': isLoginPage }">
+              <button v-if="!isLoginPage" class="hamburger-btn" @click="appStore.toggleSidebar">
+                <img src="/logo.png" alt="Menu" style="width: 24px; height: 24px;" />
+              </button>
+              <div v-if="!isLoginPage && appStore.sidebarOpen" class="mobile-backdrop" @click="appStore.closeSidebar" />
+              <AppSidebar v-if="!isLoginPage" />
+              <main class="app-main">
+                <router-view />
+              </main>
+            </div>
           </div>
           <SessionSearchModal />
           <DefaultCredentialPrompt />
@@ -84,9 +92,20 @@ useKeyboard()
 <style scoped lang="scss">
 @use '@/styles/variables' as *;
 
+.app-shell {
+  height: calc(100 * var(--vh));
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background-color: $bg-primary;
+}
+
 .app-layout {
   display: flex;
-  height: calc(100 * var(--vh));
+  flex: 1;
+  min-height: 0;
   width: 100%;
   max-width: 100%;
   overflow: hidden;
@@ -96,20 +115,23 @@ useKeyboard()
   }
 }
 
+.app-shell.desktop .app-layout {
+  --vh: calc(1vh - 0.36px);
+}
+
 .app-main {
   flex: 1;
+  min-width: 0;
   overflow-y: auto;
   background-color: $bg-primary;
 
   .no-sidebar & {
-    height: calc(100 * var(--vh));
+    height: 100%;
   }
 }
 
 .node-warning-bar {
-  position: absolute;
-  top: 0;
-  left: 0;
+  flex: 0 0 auto;
   width: 100%;
   z-index: 100;
   padding: 4px 16px;

--- a/packages/client/src/components/layout/DesktopTitleBar.vue
+++ b/packages/client/src/components/layout/DesktopTitleBar.vue
@@ -1,0 +1,170 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+
+type WindowControlAction = 'minimize' | 'toggle-maximize' | 'close'
+
+interface HermesDesktopBridge {
+  platform?: string
+  getWindowState?: () => Promise<{ isMaximized: boolean }>
+  windowControl?: (action: WindowControlAction) => Promise<{ isMaximized: boolean }>
+}
+
+type WindowWithHermesDesktop = Window & typeof globalThis & {
+  hermesDesktop?: HermesDesktopBridge
+}
+
+const desktop = (window as WindowWithHermesDesktop).hermesDesktop
+const platform = desktop?.platform
+const isMac = computed(() => platform === 'darwin')
+const showWindowButtons = computed(() => platform === 'win32' || platform === 'linux')
+const isMaximized = ref(false)
+
+async function refreshWindowState() {
+  if (!desktop?.getWindowState) return
+  try {
+    const state = await desktop.getWindowState()
+    isMaximized.value = !!state.isMaximized
+  } catch {
+    /* ignore */
+  }
+}
+
+async function controlWindow(action: WindowControlAction) {
+  if (!desktop?.windowControl) return
+  try {
+    const state = await desktop.windowControl(action)
+    isMaximized.value = !!state.isMaximized
+  } catch {
+    /* ignore */
+  }
+}
+
+onMounted(() => {
+  void refreshWindowState()
+})
+</script>
+
+<template>
+  <header class="desktop-titlebar" :class="{ mac: isMac }" @dblclick="controlWindow('toggle-maximize')">
+    <div class="desktop-titlebar__drag">
+      <div class="desktop-titlebar__brand">
+        <img class="desktop-titlebar__logo" src="/logo.png" alt="" draggable="false">
+        <span class="desktop-titlebar__title">Hermes Studio</span>
+      </div>
+    </div>
+    <div v-if="showWindowButtons" class="desktop-titlebar__controls" @dblclick.stop>
+      <button class="desktop-window-btn" type="button" aria-label="Minimize" @click.stop="controlWindow('minimize')">
+        <svg viewBox="0 0 12 12" aria-hidden="true">
+          <path d="M2 6.5h8" />
+        </svg>
+      </button>
+      <button class="desktop-window-btn" type="button" :aria-label="isMaximized ? 'Restore' : 'Maximize'" @click.stop="controlWindow('toggle-maximize')">
+        <svg v-if="isMaximized" viewBox="0 0 12 12" aria-hidden="true">
+          <path d="M4 3.5h5v5H4z" />
+          <path d="M3 7.5H2.5v-5h5V3" />
+        </svg>
+        <svg v-else viewBox="0 0 12 12" aria-hidden="true">
+          <path d="M2.5 2.5h7v7h-7z" />
+        </svg>
+      </button>
+      <button class="desktop-window-btn close" type="button" aria-label="Close" @click.stop="controlWindow('close')">
+        <svg viewBox="0 0 12 12" aria-hidden="true">
+          <path d="M3 3l6 6M9 3L3 9" />
+        </svg>
+      </button>
+    </div>
+  </header>
+</template>
+
+<style scoped lang="scss">
+@use "@/styles/variables" as *;
+
+.desktop-titlebar {
+  height: 36px;
+  flex: 0 0 36px;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid $border-color;
+  background: $bg-sidebar;
+  color: $text-primary;
+  user-select: none;
+  -webkit-app-region: drag;
+
+  &.mac {
+    padding-left: 82px;
+  }
+}
+
+.desktop-titlebar__drag {
+  min-width: 0;
+  flex: 1;
+  height: 100%;
+  display: flex;
+  align-items: center;
+}
+
+.desktop-titlebar__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 0 12px;
+}
+
+.desktop-titlebar__logo {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+  object-fit: contain;
+}
+
+.desktop-titlebar__title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.desktop-titlebar__controls {
+  height: 100%;
+  display: flex;
+  align-items: stretch;
+  -webkit-app-region: no-drag;
+}
+
+.desktop-window-btn {
+  width: 46px;
+  height: 100%;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  color: $text-secondary;
+  background: transparent;
+  cursor: default;
+
+  svg {
+    width: 12px;
+    height: 12px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.4;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  &:hover {
+    color: $text-primary;
+    background: rgba(var(--text-muted-rgb), 0.14);
+  }
+
+  &.close:hover {
+    color: #ffffff;
+    background: #c42b1c;
+  }
+}
+</style>

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -21,6 +21,7 @@ const PORT = Number(process.env.HERMES_DESKTOP_PORT) || 8748
 const START_HIDDEN = process.argv.includes('--hidden')
 const QUIT_EXISTING = process.argv.includes('--quit')
 const APP_USER_MODEL_ID = 'com.hermeswebui.studio'
+type WindowControlAction = 'minimize' | 'toggle-maximize' | 'close'
 
 let mainWindow: BrowserWindow | null = null
 let serverUrl: string | null = null
@@ -83,6 +84,25 @@ function showMainWindow() {
 function quitApp() {
   isQuitting = true
   app.quit()
+}
+
+function windowState() {
+  return {
+    isMaximized: !!mainWindow?.isMaximized(),
+  }
+}
+
+function handleWindowControl(action: WindowControlAction) {
+  if (!mainWindow || mainWindow.isDestroyed()) return windowState()
+  if (action === 'minimize') {
+    mainWindow.minimize()
+  } else if (action === 'toggle-maximize') {
+    if (mainWindow.isMaximized()) mainWindow.unmaximize()
+    else mainWindow.maximize()
+  } else if (action === 'close') {
+    mainWindow.close()
+  }
+  return windowState()
 }
 
 function hasQuitRequest(data: unknown): boolean {
@@ -185,6 +205,14 @@ function createWindow() {
     backgroundColor: '#1a1a1a',
     autoHideMenuBar: true,
     show: false,
+    ...(process.platform === 'darwin'
+      ? {
+          titleBarStyle: 'hiddenInset' as const,
+          trafficLightPosition: { x: 16, y: 12 },
+        }
+      : {
+          frame: false,
+        }),
     ...(process.platform === 'linux' ? { icon: desktopIcon() } : {}),
     webPreferences: {
       preload: join(__dirname, '..', 'preload', 'index.js'),
@@ -427,6 +455,11 @@ async function bootstrap(source?: RuntimeDownloadSource) {
 }
 
 ipcMain.handle('hermes-desktop:get-token', () => getToken())
+ipcMain.handle('hermes-desktop:get-window-state', () => windowState())
+ipcMain.handle('hermes-desktop:window-control', (_event, action?: unknown) => {
+  if (action !== 'minimize' && action !== 'toggle-maximize' && action !== 'close') return windowState()
+  return handleWindowControl(action)
+})
 function resolveNotificationIcon(icon: unknown): string {
   if (typeof icon !== 'string') return desktopIcon()
   const normalized = icon.trim().replace(/^\/+/, '')

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -4,6 +4,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getToken: (): Promise<string> => ipcRenderer.invoke('hermes-desktop:get-token'),
   retryBootstrap: (source?: 'cf' | 'github'): Promise<void> => ipcRenderer.invoke('hermes-desktop:retry-bootstrap', source),
   notifyCompletion: (payload: { title: string; body?: string; icon?: string; tag?: string }): Promise<boolean> => ipcRenderer.invoke('hermes-desktop:notify-completion', payload),
+  getWindowState: (): Promise<{ isMaximized: boolean }> => ipcRenderer.invoke('hermes-desktop:get-window-state'),
+  windowControl: (action: 'minimize' | 'toggle-maximize' | 'close'): Promise<{ isMaximized: boolean }> => ipcRenderer.invoke('hermes-desktop:window-control', action),
   platform: process.platform,
   isDesktop: true,
 })


### PR DESCRIPTION
## Summary
- hide the native desktop title bar and render an app-themed title bar in the Web UI
- add desktop window control IPC for minimize, maximize/restore, and close
- keep the title bar limited to the Electron shell

## Verification
- npm --prefix packages/desktop run build
- npm run build
- Manual Desktop Build win32/x64 artifact: https://github.com/EKKOLearnAI/hermes-web-ui/actions/runs/27273043150