### PR TITLE
fix: stabilize Linux deb desktop launch path

### DIFF
--- a/packages/desktop/build/linux-after-install.tpl
+++ b/packages/desktop/build/linux-after-install.tpl
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+install_dir='/opt/${sanitizedProductName}'
+compat_dir='/opt/${executable}'
+desktop_file='/usr/share/applications/${executable}.desktop'
+
+if [ "$install_dir" != "$compat_dir" ]; then
+    ln -sfn "$install_dir" "$compat_dir"
+fi
+
+if type update-alternatives 2>/dev/null >&1; then
+    # Remove previous link if it doesn't use update-alternatives.
+    if [ -L '/usr/bin/${executable}' -a -e '/usr/bin/${executable}' -a "`readlink '/usr/bin/${executable}'`" != '/etc/alternatives/${executable}' ]; then
+        rm -f '/usr/bin/${executable}'
+    fi
+    update-alternatives --remove '${executable}' "$install_dir/${executable}" 2>/dev/null || true
+    update-alternatives --install '/usr/bin/${executable}' '${executable}' "$compat_dir/${executable}" 100 || ln -sf "$compat_dir/${executable}" '/usr/bin/${executable}'
+else
+    ln -sf "$compat_dir/${executable}" '/usr/bin/${executable}'
+fi
+
+if [ -f "$desktop_file" ]; then
+    sed -i "s#Exec=\"$install_dir/${executable}\"#Exec=\"$compat_dir/${executable}\"#" "$desktop_file" || true
+    sed -i "s#Exec=$install_dir/${executable}#Exec=$compat_dir/${executable}#" "$desktop_file" || true
+fi
+
+# Check if user namespaces are supported by the kernel and working with a quick test.
+if ! { [[ -L /proc/self/ns/user ]] && unshare --user true; }; then
+    # Use SUID chrome-sandbox only on systems without user namespaces.
+    chmod 4755 "$install_dir/chrome-sandbox" || true
+else
+    chmod 0755 "$install_dir/chrome-sandbox" || true
+fi
+
+if hash update-mime-database 2>/dev/null; then
+    update-mime-database /usr/share/mime || true
+fi
+
+if hash update-desktop-database 2>/dev/null; then
+    update-desktop-database /usr/share/applications || true
+fi

--- a/packages/desktop/build/linux-after-remove.tpl
+++ b/packages/desktop/build/linux-after-remove.tpl
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+install_dir='/opt/${sanitizedProductName}'
+compat_dir='/opt/${executable}'
+
+# Delete the link to the binary.
+if type update-alternatives >/dev/null 2>&1; then
+    update-alternatives --remove '${executable}' "$compat_dir/${executable}" 2>/dev/null || true
+    update-alternatives --remove '${executable}' "$install_dir/${executable}" 2>/dev/null || true
+else
+    rm -f '/usr/bin/${executable}'
+fi
+
+if [ -L "$compat_dir" ] && [ "$(readlink "$compat_dir")" = "$install_dir" ]; then
+    rm -f "$compat_dir"
+fi

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -79,6 +79,10 @@ linux:
   category: Development
   artifactName: "Hermes.Studio-${version}-${arch}.${ext}"
 
+deb:
+  afterInstall: build/linux-after-install.tpl
+  afterRemove: build/linux-after-remove.tpl
+
 nsis:
   oneClick: false
   allowToChangeInstallationDirectory: true


### PR DESCRIPTION
## Summary
- add Deb install/remove scripts that keep the app display name as Hermes Studio while routing Linux Deb launch commands through /opt/hermes-studio
- preserve the hermes-studio command name and update desktop Exec entries to avoid the /opt/Hermes Studio space-sensitive path
- keep Linux arm64 unchanged as AppImage-only

Fixes #1455

## Validation
- `bash -n packages/desktop/build/linux-after-install.tpl`
- `bash -n packages/desktop/build/linux-after-remove.tpl`
- `npm --prefix packages/desktop run build`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "ok #{file}" }' .github/workflows/desktop-release.yml .github/workflows/desktop-manual-build.yml packages/desktop/electron-builder.yml`

## Notes
- Product/display name remains `Hermes Studio`; only the Deb launch path gets a no-space compatibility symlink.
- Linux arm64 remains AppImage-only.
- `actionlint` was not installed locally, so workflow validation was limited to YAML parsing.