### PR TITLE
Avoid Hermes bridge checks for coding agent resumes

### DIFF
--- a/docs/chat-chain-changes/2026-06-11-pr1487-coding-agent-resume-bridge-check.md
+++ b/docs/chat-chain-changes/2026-06-11-pr1487-coding-agent-resume-bridge-check.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-11
+pr: 1487
+feature: Coding agent resume bridge checks
+impact: Coding agent session resume no longer depends on Hermes worker status lookup, while Hermes worker-backed sessions still attempt bridge reattach.
+---
+
+Transient Hermes bridge status lookup timeouts during resume are logged at debug level instead of being emitted as user-visible reattach warnings.

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -41,6 +41,17 @@ function redactBridgeReadyError(error: string, endpoint?: string): string {
   return redactAgentBridgeError(normalized, endpoint, 'configured endpoint') || 'unknown error'
 }
 
+function isBridgeStatusLookupTimeout(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /^Agent bridge request timed out after \d+ms$/.test(message.trim())
+}
+
+function isHermesWorkerBackedSessionSource(source?: string): boolean {
+  // "api_server" is a legacy/default source value; Hermes sessions still use worker-backed runtime.
+  // coding_agent runs have a separate lifecycle.
+  return !source || source === 'cli' || source === 'api_server'
+}
+
 export async function ensureBridgeReadyForChatRun(): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
     const readiness = await getAgentBridgeManager().ensureReady({ timeoutMs: 1000, connectRetryMs: 0, recover: false })
@@ -476,6 +487,8 @@ export class ChatRunSocket {
   private async reattachBridgeRun(socket: Socket, sid: string, state: SessionState) {
     if (state.runId && state.isWorking) return
     const session = getSession(sid)
+    const source = state.source || session?.source
+    if (!isHermesWorkerBackedSessionSource(source)) return
     const profile = session?.profile || currentProfileFromSocket(socket)
     let pollKey: string | undefined
     try {
@@ -514,6 +527,10 @@ export class ChatRunSocket {
       logger.info('[chat-run-socket] reattached running bridge run %s for session %s', runId, sid)
     } catch (err) {
       if (pollKey) this.bridgeResumePolls.delete(pollKey)
+      if (isBridgeStatusLookupTimeout(err)) {
+        logger.debug(err, '[chat-run-socket] bridge status lookup timed out while resuming session %s', sid)
+        return
+      }
       logger.warn(err, '[chat-run-socket] bridge status lookup failed while resuming session %s', sid)
       const endpoint = getAgentBridgeManager().getRuntimeState?.().endpoint
       const error = redactBridgeReadyError(err instanceof Error ? err.message : String(err), endpoint)

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -6,6 +6,9 @@ const handleApiRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const loadSessionStateFromDbMock = vi.hoisted(() => vi.fn())
 const ensureReadyMock = vi.hoisted(() => vi.fn())
 const getRuntimeStateMock = vi.hoisted(() => vi.fn())
+const getSessionMock = vi.hoisted(() => vi.fn((sessionId?: string) => sessionId
+  ? { id: sessionId, profile: 'default', source: 'cli', model: 'gpt-test', provider: 'openai' }
+  : undefined))
 const bridgeMock = vi.hoisted(() => ({
   status: vi.fn(),
   statusIfLoaded: vi.fn(),
@@ -48,9 +51,7 @@ vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
 }))
 
 vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
-  getSession: vi.fn((sessionId?: string) => sessionId
-    ? { id: sessionId, profile: 'default', source: 'cli', model: 'gpt-test', provider: 'openai' }
-    : undefined),
+  getSession: getSessionMock,
 }))
 
 vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
@@ -106,6 +107,10 @@ describe('ensureBridgeReadyForChatRun', () => {
     resumeBridgeRunMock.mockReset()
     handleApiRunMock.mockReset()
     loadSessionStateFromDbMock.mockReset()
+    getSessionMock.mockReset()
+    getSessionMock.mockImplementation((sessionId?: string) => sessionId
+      ? { id: sessionId, profile: 'default', source: 'cli', model: 'gpt-test', provider: 'openai' }
+      : undefined)
     ensureReadyMock.mockResolvedValue({
       reachable: true,
       status: 'ready',
@@ -396,5 +401,112 @@ describe('ChatRunSocket bridge readiness gating', () => {
       ]),
     }))
     expect((server as any).bridgeResumePolls.size).toBe(0)
+  })
+
+  it('suppresses transient bridge status timeout warnings while resuming', async () => {
+    bridgeMock.statusIfLoaded.mockRejectedValueOnce(new Error('Agent bridge request timed out after 1000ms'))
+    loadSessionStateFromDbMock.mockResolvedValueOnce({
+      messages: [],
+      isWorking: false,
+      isAborting: false,
+      runId: undefined,
+      activeRunMarker: undefined,
+      profile: 'default',
+      source: 'cli',
+      events: [],
+      queue: [],
+    })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { emitted, handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('resume')?.({ session_id: 'session-1' })
+
+    expect(ensureReadyMock).not.toHaveBeenCalled()
+    expect(resumeBridgeRunMock).not.toHaveBeenCalled()
+    expect(emitted.some(({ event }) => event === 'run.reattach_failed')).toBe(false)
+    expect(socket.emit).toHaveBeenCalledWith('resumed', expect.objectContaining({
+      session_id: 'session-1',
+      isWorking: false,
+      events: [],
+    }))
+    expect((server as any).sessionMap.get('session-1')).toEqual(expect.objectContaining({
+      isWorking: false,
+      events: [],
+    }))
+    expect((server as any).bridgeResumePolls.size).toBe(0)
+  })
+
+  it('does not query Hermes bridge status when resuming a coding agent session', async () => {
+    getSessionMock.mockImplementation((sessionId?: string) => sessionId
+      ? { id: sessionId, profile: 'default', source: 'coding_agent', model: 'codex', provider: 'codex' }
+      : undefined)
+    loadSessionStateFromDbMock.mockResolvedValueOnce({
+      messages: [],
+      isWorking: false,
+      isAborting: false,
+      runId: undefined,
+      activeRunMarker: undefined,
+      profile: 'default',
+      source: 'coding_agent',
+      events: [],
+      queue: [],
+    })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { emitted, handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('resume')?.({ session_id: 'session-1' })
+
+    expect(ensureReadyMock).not.toHaveBeenCalled()
+    expect(bridgeMock.statusIfLoaded).not.toHaveBeenCalled()
+    expect(resumeBridgeRunMock).not.toHaveBeenCalled()
+    expect(emitted.some(({ event }) => event === 'run.reattach_failed')).toBe(false)
+    expect(socket.emit).toHaveBeenCalledWith('resumed', expect.objectContaining({
+      session_id: 'session-1',
+      isWorking: false,
+      events: [],
+    }))
+  })
+
+  it('checks Hermes bridge status when resuming an api server session', async () => {
+    getSessionMock.mockImplementation((sessionId?: string) => sessionId
+      ? { id: sessionId, profile: 'default', source: 'api_server', model: 'gpt-test', provider: 'openai' }
+      : undefined)
+    bridgeMock.statusIfLoaded.mockResolvedValueOnce({
+      ok: true,
+      exists: false,
+      running: false,
+      loaded: false,
+    })
+    loadSessionStateFromDbMock.mockResolvedValueOnce({
+      messages: [],
+      isWorking: false,
+      isAborting: false,
+      runId: undefined,
+      activeRunMarker: undefined,
+      profile: 'default',
+      source: 'api_server',
+      events: [],
+      queue: [],
+    })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { emitted, handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('resume')?.({ session_id: 'session-1' })
+
+    expect(ensureReadyMock).not.toHaveBeenCalled()
+    expect(bridgeMock.statusIfLoaded).toHaveBeenCalledWith('session-1', 'default', { timeoutMs: 1000 })
+    expect(resumeBridgeRunMock).not.toHaveBeenCalled()
+    expect(emitted.some(({ event }) => event === 'run.reattach_failed')).toBe(false)
+    expect(socket.emit).toHaveBeenCalledWith('resumed', expect.objectContaining({
+      session_id: 'session-1',
+      isWorking: false,
+      events: [],
+    }))
   })
 })


### PR DESCRIPTION
## Summary
- skip Hermes bridge reattach status checks when resuming coding agent sessions
- keep worker-backed Hermes sessions, including legacy/default api_server sources, on the bridge reattach path
- suppress transient bridge status lookup timeouts from user-visible resume warnings

## Validation
- npm run test -- tests/server/chat-run-bridge-readiness.test.ts tests/server/run-chat-queued-item.test.ts tests/server/coding-agent-resume-config.test.ts