### PR TITLE
[codex] fix static asset compression

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -26,6 +26,7 @@ import { refreshConfiguredProviderModelCatalogsInBackground } from './services/h
 import { scanLanDevices, startLanDiscoveryResponder } from './services/lan-discovery'
 import { getLanPeerSocketManager, getLanPeerSocketPath } from './services/lan-peer-socket'
 import { logger } from './services/logger'
+import { createStaticCompressionMiddleware } from './middleware/static-compression'
 import { requireUserJwt, resolveUserProfile } from './middleware/user-auth'
 import { createCorsOriginResolver, securityHeaders } from './security'
 
@@ -241,6 +242,7 @@ export async function bootstrap() {
 
   // SPA fallback
   const distDir = resolve(__dirname, '..', 'client')
+  app.use(createStaticCompressionMiddleware())
   app.use(serve(distDir))
   app.use(async (ctx) => {
     if (!ctx.path.startsWith('/api') &&

--- a/packages/server/src/middleware/static-compression.ts
+++ b/packages/server/src/middleware/static-compression.ts
@@ -1,0 +1,158 @@
+import type { Context, Middleware } from 'koa'
+import type { Readable } from 'stream'
+import {
+  brotliCompressSync,
+  constants as zlibConstants,
+  createBrotliCompress,
+  createGzip,
+  gzipSync,
+} from 'zlib'
+
+export type StaticCompressionEncoding = 'br' | 'gzip'
+
+export interface StaticCompressionOptions {
+  minBytes?: number
+}
+
+const DEFAULT_MIN_BYTES = 1024
+
+const COMPRESSIBLE_TYPES = new Set([
+  'application/ecmascript',
+  'application/javascript',
+  'application/json',
+  'application/ld+json',
+  'application/manifest+json',
+  'application/rss+xml',
+  'application/wasm',
+  'application/xhtml+xml',
+  'application/xml',
+  'application/x-javascript',
+  'image/svg+xml',
+  'text/javascript',
+])
+
+export function isCompressibleContentType(contentType: string): boolean {
+  const normalized = contentType.split(';', 1)[0]?.trim().toLowerCase() || ''
+  if (!normalized) return false
+  return normalized.startsWith('text/') ||
+    COMPRESSIBLE_TYPES.has(normalized) ||
+    normalized.endsWith('+json') ||
+    normalized.endsWith('+xml')
+}
+
+function parseEncodingQuality(header: string, encoding: StaticCompressionEncoding): number {
+  let wildcardQuality: number | null = null
+  let encodingQuality: number | null = null
+
+  for (const rawPart of header.split(',')) {
+    const [rawToken, ...rawParams] = rawPart.split(';')
+    const token = rawToken?.trim().toLowerCase()
+    if (!token) continue
+
+    let quality = 1
+    for (const rawParam of rawParams) {
+      const [rawName, rawValue] = rawParam.split('=')
+      if (rawName?.trim().toLowerCase() !== 'q') continue
+      const parsed = Number(rawValue?.trim())
+      quality = Number.isFinite(parsed) ? Math.max(0, Math.min(parsed, 1)) : 0
+    }
+
+    if (token === encoding) encodingQuality = quality
+    if (token === '*') wildcardQuality = quality
+  }
+
+  return encodingQuality ?? wildcardQuality ?? 0
+}
+
+export function selectStaticCompressionEncoding(acceptEncoding: string): StaticCompressionEncoding | null {
+  const brQuality = parseEncodingQuality(acceptEncoding, 'br')
+  const gzipQuality = parseEncodingQuality(acceptEncoding, 'gzip')
+
+  if (brQuality <= 0 && gzipQuality <= 0) return null
+  return brQuality >= gzipQuality ? 'br' : 'gzip'
+}
+
+function isReadableStream(value: unknown): value is Readable {
+  return !!value && typeof (value as { pipe?: unknown }).pipe === 'function'
+}
+
+function parseBodyLength(ctx: Context, body: unknown): number | null {
+  if (Buffer.isBuffer(body)) return body.byteLength
+  if (typeof body === 'string') return Buffer.byteLength(body)
+
+  const contentLength = Number(ctx.response.get('Content-Length'))
+  return Number.isFinite(contentLength) && contentLength >= 0 ? contentLength : null
+}
+
+function shouldCompress(ctx: Context, minBytes: number): boolean {
+  if (ctx.method === 'HEAD') return false
+  if (ctx.status < 200 || ctx.status >= 300 || ctx.status === 204) return false
+  if (ctx.get('Range')) return false
+  if (ctx.response.get('Content-Encoding')) return false
+  if (!isCompressibleContentType(ctx.response.get('Content-Type') || ctx.type || '')) return false
+
+  const body = ctx.body
+  if (!body || !(Buffer.isBuffer(body) || typeof body === 'string' || isReadableStream(body))) return false
+
+  const bodyLength = parseBodyLength(ctx, body)
+  return bodyLength === null || bodyLength >= minBytes
+}
+
+function compressBuffer(body: Buffer, encoding: StaticCompressionEncoding): Buffer {
+  if (encoding === 'br') {
+    return brotliCompressSync(body, {
+      params: {
+        [zlibConstants.BROTLI_PARAM_QUALITY]: zlibConstants.BROTLI_DEFAULT_QUALITY,
+      },
+    })
+  }
+
+  return gzipSync(body)
+}
+
+function createCompressionStream(encoding: StaticCompressionEncoding) {
+  if (encoding === 'br') {
+    return createBrotliCompress({
+      params: {
+        [zlibConstants.BROTLI_PARAM_QUALITY]: zlibConstants.BROTLI_DEFAULT_QUALITY,
+      },
+    })
+  }
+
+  return createGzip()
+}
+
+export function createStaticCompressionMiddleware(options: StaticCompressionOptions = {}): Middleware {
+  const minBytes = options.minBytes ?? DEFAULT_MIN_BYTES
+
+  return async (ctx, next) => {
+    await next()
+
+    if (!shouldCompress(ctx, minBytes)) return
+
+    const encoding = selectStaticCompressionEncoding(ctx.get('Accept-Encoding'))
+    if (!encoding) return
+
+    ctx.vary('Accept-Encoding')
+    ctx.set('Content-Encoding', encoding)
+
+    const body = ctx.body
+    if (Buffer.isBuffer(body) || typeof body === 'string') {
+      const original = Buffer.isBuffer(body) ? body : Buffer.from(body)
+      const compressed = compressBuffer(original, encoding)
+      if (compressed.byteLength >= original.byteLength) {
+        ctx.remove('Content-Encoding')
+        return
+      }
+
+      ctx.body = compressed
+      ctx.set('Content-Length', String(compressed.byteLength))
+      return
+    }
+
+    if (isReadableStream(body)) {
+      ctx.remove('Content-Length')
+      ctx.body = body.pipe(createCompressionStream(encoding))
+    }
+  }
+}

--- a/tests/server/static-compression.test.ts
+++ b/tests/server/static-compression.test.ts
@@ -1,0 +1,128 @@
+import http from 'http'
+import { brotliDecompressSync, gunzipSync } from 'zlib'
+import { Readable } from 'stream'
+import Koa from 'koa'
+import { describe, expect, it } from 'vitest'
+import {
+  createStaticCompressionMiddleware,
+  isCompressibleContentType,
+  selectStaticCompressionEncoding,
+} from '../../packages/server/src/middleware/static-compression'
+
+interface RawResponse {
+  status: number
+  headers: http.IncomingHttpHeaders
+  body: Buffer
+}
+
+async function requestApp(app: Koa, headers: Record<string, string> = {}): Promise<RawResponse> {
+  const server = http.createServer(app.callback())
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('expected tcp server')
+
+  try {
+    return await new Promise<RawResponse>((resolve, reject) => {
+      const req = http.request({
+        host: '127.0.0.1',
+        port: address.port,
+        path: '/asset.js',
+        headers,
+      }, (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', chunk => chunks.push(Buffer.from(chunk)))
+        res.on('end', () => resolve({
+          status: res.statusCode || 0,
+          headers: res.headers,
+          body: Buffer.concat(chunks),
+        }))
+      })
+      req.on('error', reject)
+      req.end()
+    })
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => err ? reject(err) : resolve())
+    })
+  }
+}
+
+function createAssetApp(contentType: string, body: string | Buffer | Readable, contentLength?: number): Koa {
+  const app = new Koa()
+  app.use(createStaticCompressionMiddleware({ minBytes: 0 }))
+  app.use((ctx) => {
+    ctx.type = contentType
+    if (contentLength !== undefined) ctx.set('Content-Length', String(contentLength))
+    ctx.body = body
+  })
+  return app
+}
+
+describe('static compression middleware', () => {
+  it('prefers Brotli for compressible static responses', async () => {
+    const source = 'const payload = "hermes web ui";\n'.repeat(200)
+    const response = await requestApp(
+      createAssetApp('application/javascript', source),
+      { 'Accept-Encoding': 'gzip, br' },
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers['content-encoding']).toBe('br')
+    expect(response.headers.vary).toContain('Accept-Encoding')
+    expect(brotliDecompressSync(response.body).toString('utf8')).toBe(source)
+    expect(response.body.byteLength).toBeLessThan(Buffer.byteLength(source))
+  })
+
+  it('uses gzip when Brotli is unavailable', async () => {
+    const source = '.button { color: #123456; }\n'.repeat(200)
+    const response = await requestApp(
+      createAssetApp('text/css', source),
+      { 'Accept-Encoding': 'gzip' },
+    )
+
+    expect(response.headers['content-encoding']).toBe('gzip')
+    expect(gunzipSync(response.body).toString('utf8')).toBe(source)
+    expect(response.body.byteLength).toBeLessThan(Buffer.byteLength(source))
+  })
+
+  it('compresses static file streams without preserving the original content length', async () => {
+    const source = 'export const route = "/chat";\n'.repeat(200)
+    const response = await requestApp(
+      createAssetApp('application/javascript', Readable.from([source]), Buffer.byteLength(source)),
+      { 'Accept-Encoding': 'gzip' },
+    )
+
+    expect(response.headers['content-encoding']).toBe('gzip')
+    expect(response.headers['content-length']).toBeUndefined()
+    expect(gunzipSync(response.body).toString('utf8')).toBe(source)
+  })
+
+  it('does not compress already-compressed image assets or byte-range responses', async () => {
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01])
+    const imageResponse = await requestApp(
+      createAssetApp('image/png', pngBytes),
+      { 'Accept-Encoding': 'gzip, br' },
+    )
+    expect(imageResponse.headers['content-encoding']).toBeUndefined()
+    expect(imageResponse.body).toEqual(pngBytes)
+
+    const rangeResponse = await requestApp(
+      createAssetApp('text/javascript', 'const x = 1;\n'.repeat(100)),
+      { 'Accept-Encoding': 'gzip', Range: 'bytes=0-20' },
+    )
+    expect(rangeResponse.headers['content-encoding']).toBeUndefined()
+  })
+
+  it('parses accepted encodings and compressible content types', () => {
+    expect(selectStaticCompressionEncoding('gzip;q=1, br;q=0.5')).toBe('gzip')
+    expect(selectStaticCompressionEncoding('gzip;q=0, br;q=1')).toBe('br')
+    expect(selectStaticCompressionEncoding('*;q=0.8')).toBe('br')
+    expect(selectStaticCompressionEncoding('gzip;q=0, br;q=0')).toBeNull()
+
+    expect(isCompressibleContentType('text/html; charset=utf-8')).toBe(true)
+    expect(isCompressibleContentType('application/manifest+json')).toBe(true)
+    expect(isCompressibleContentType('image/svg+xml')).toBe(true)
+    expect(isCompressibleContentType('image/png')).toBe(false)
+    expect(isCompressibleContentType('font/woff2')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Add a Koa static compression middleware for SPA assets served from `dist/client`.
- Negotiate Brotli first and gzip as a fallback based on `Accept-Encoding`.
- Skip byte-range requests, existing encoded responses, HEAD responses, and already-compressed asset types like PNG/JPEG/WOFF.

Fixes #1482.

## Validation

- `npm run test -- tests/server/static-compression.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run harness:check`
- `npm run build`
