### PR TITLE
[codex] fix desktop Claude Code detection

### DIFF
--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -157,6 +157,7 @@ const CONFIG_FILE_DEFINITIONS: Record<CodingAgentId, Array<Omit<CodingAgentConfi
 const installingTools = new Set<CodingAgentId>()
 const deletingTools = new Set<CodingAgentId>()
 let cachedGlobalNpmBin: string | null | undefined
+let cachedLoginShellPath: string | null | undefined
 const MAX_CONFIG_FILE_SIZE = parseInt(process.env.MAX_EDIT_SIZE || '', 10) || 10 * 1024 * 1024
 
 function getNodeBinDir() {
@@ -222,6 +223,81 @@ function getNvmNodeBinPaths(): string {
       .join(delimiter)
   } catch {
     return ''
+  }
+}
+
+function getLoginShellCandidates(): string[] {
+  if (process.platform === 'win32') return []
+  return [
+    process.env.SHELL || '',
+    '/bin/zsh',
+    '/bin/bash',
+    '/usr/bin/zsh',
+    '/usr/bin/bash',
+  ].filter(Boolean)
+}
+
+function getLoginShell(): string | null {
+  for (const shell of [...new Set(getLoginShellCandidates())]) {
+    if (shell.startsWith('/') && existsSync(shell)) return shell
+  }
+  return null
+}
+
+async function getLoginShellPath(): Promise<string | null> {
+  if (process.env.HERMES_DESKTOP !== 'true' || process.platform === 'win32') return null
+  if (typeof cachedLoginShellPath !== 'undefined') return cachedLoginShellPath
+
+  const shell = getLoginShell()
+  if (!shell) {
+    cachedLoginShellPath = null
+    return cachedLoginShellPath
+  }
+
+  try {
+    const { stdout } = await execFileAsync(shell, ['-lc', 'printf %s "$PATH"'], {
+      encoding: 'utf-8',
+      timeout: 3000,
+      windowsHide: true,
+    })
+    cachedLoginShellPath = stdout.trim() || null
+  } catch {
+    cachedLoginShellPath = null
+  }
+  return cachedLoginShellPath
+}
+
+function getDesktopCommonBinPaths(): string[] {
+  if (process.env.HERMES_DESKTOP !== 'true' || process.platform === 'win32') return []
+  const home = homedir()
+  return [
+    join(home, '.npm-global', 'bin'),
+    join(home, '.local', 'bin'),
+    join(home, '.yarn', 'bin'),
+    join(home, '.config', 'yarn', 'global', 'node_modules', '.bin'),
+    join(home, '.pnpm'),
+    join(home, 'Library', 'pnpm'),
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+  ]
+}
+
+function prependPathEntries(env: NodeJS.ProcessEnv, entries: Array<string | null | undefined>) {
+  const pathKey = Object.keys(env).find(key => key.toLowerCase() === 'path') || 'PATH'
+  const currentPath = env[pathKey] || ''
+  const existing = new Set(currentPath.split(delimiter).filter(Boolean))
+  const prepended: string[] = []
+
+  for (const entry of entries) {
+    if (!entry) continue
+    for (const segment of entry.split(delimiter).map(item => item.trim()).filter(Boolean)) {
+      if (existing.has(segment) || prepended.includes(segment)) continue
+      prepended.push(segment)
+    }
+  }
+
+  if (prepended.length > 0) {
+    env[pathKey] = currentPath ? `${prepended.join(delimiter)}${delimiter}${currentPath}` : prepended.join(delimiter)
   }
 }
 
@@ -967,13 +1043,12 @@ async function getGlobalNpmBin(): Promise<string | null> {
 async function commandEnv(): Promise<NodeJS.ProcessEnv> {
   const env = getCurrentNodeEnv()
   const npmBin = await getGlobalNpmBin()
-  if (npmBin) {
-    const pathKey = Object.keys(env).find(key => key.toLowerCase() === 'path') || 'PATH'
-    const currentPath = env[pathKey] || ''
-    if (!currentPath.split(delimiter).includes(npmBin)) {
-      env[pathKey] = currentPath ? `${npmBin}${delimiter}${currentPath}` : npmBin
-    }
-  }
+  const loginShellPath = await getLoginShellPath()
+  prependPathEntries(env, [
+    npmBin,
+    loginShellPath,
+    ...getDesktopCommonBinPaths(),
+  ])
   return env
 }
 

--- a/tests/server/coding-agents-desktop-path.test.ts
+++ b/tests/server/coding-agents-desktop-path.test.ts
@@ -1,0 +1,93 @@
+import { delimiter } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execState = vi.hoisted(() => {
+  const calls: Array<{ command: string; args: string[]; options: any }> = []
+  const execFile = vi.fn()
+  ;(execFile as any)[Symbol.for('nodejs.util.promisify.custom')] = async (command: string, args: string[], options: any) => {
+    calls.push({ command, args, options })
+
+    if (command === '/bin/zsh') {
+      return {
+        stdout: ['/Users/example/.npm-global/bin', '/opt/homebrew/bin', '/usr/bin'].join(':'),
+        stderr: '',
+      }
+    }
+
+    if (command === 'which' && args[0] === '-a' && args[1] === 'npm') {
+      throw Object.assign(new Error('npm not found'), { code: 'ENOENT' })
+    }
+
+    if (command === 'which' && args[0] === '-a' && args[1] === 'claude') {
+      if (!String(options.env?.PATH || '').split(':').includes('/Users/example/.npm-global/bin')) {
+        throw Object.assign(new Error('claude not found'), { code: 'ENOENT' })
+      }
+      return { stdout: '/Users/example/.npm-global/bin/claude\n', stderr: '' }
+    }
+
+    if (command === 'claude' && args[0] === '--version') {
+      return { stdout: '1.2.3\n', stderr: '' }
+    }
+
+    throw new Error(`unexpected command: ${command} ${args.join(' ')}`)
+  }
+  return { calls, execFile }
+})
+
+vi.mock('child_process', () => ({
+  execFile: execState.execFile,
+}))
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    existsSync: (path: string) => path === '/bin/zsh' || actual.existsSync(path),
+  }
+})
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+const originalPath = process.env.PATH
+const originalShell = process.env.SHELL
+const originalHermesDesktop = process.env.HERMES_DESKTOP
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', { value: platform })
+}
+
+beforeEach(() => {
+  execState.calls.length = 0
+  setPlatform('darwin')
+  process.env.HERMES_DESKTOP = 'true'
+  process.env.SHELL = '/bin/zsh'
+  process.env.PATH = '/usr/bin'
+})
+
+afterEach(() => {
+  if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform)
+  process.env.PATH = originalPath
+  if (typeof originalShell === 'undefined') delete process.env.SHELL
+  else process.env.SHELL = originalShell
+  if (typeof originalHermesDesktop === 'undefined') delete process.env.HERMES_DESKTOP
+  else process.env.HERMES_DESKTOP = originalHermesDesktop
+  vi.resetModules()
+})
+
+describe('coding agent desktop PATH detection', () => {
+  it('detects Claude from the login shell PATH when Electron PATH is minimal', async () => {
+    const { getCodingAgentStatus } = await import('../../packages/server/src/services/coding-agents')
+    const status = await getCodingAgentStatus({
+      id: 'claude-code',
+      name: 'Claude Code',
+      provider: 'Anthropic',
+      command: 'claude',
+      packageName: '@anthropic-ai/claude-code',
+    })
+
+    expect(status.installed).toBe(true)
+    expect(status.version).toBe('1.2.3')
+
+    const versionCall = execState.calls.find(call => call.command === 'claude' && call.args[0] === '--version')
+    expect(versionCall?.options.env.PATH.split(delimiter)).toContain('/Users/example/.npm-global/bin')
+  })
+})


### PR DESCRIPTION
## Summary
- Merge desktop login shell PATH and common user package bin directories into coding-agent command detection.
- Keep the enhanced PATH shared by status checks, npm install/delete follow-up checks, and coding-agent launches.
- Add a server test for Electron-style minimal PATH where Claude is available from the login shell PATH.

## Validation
- `npm run harness:check`
- `npm run test -- tests/server/coding-agents-desktop-path.test.ts tests/server/coding-agents-windows-execution.test.ts`
- `npm run build`

## Notes
- `npm run test -- tests/server/coding-agents-launch.test.ts` currently fails in this environment because the tests expect port 8648 while config resolves 8748.
- A wider coding-agent test run also hits existing `no such table: sessions` failures in `tests/server/coding-agent-run-manager-windows.test.ts`.