### PR TITLE
[codex] fix write approval settings runtime support

### DIFF
--- a/packages/client/src/components/hermes/settings/SessionSettings.vue
+++ b/packages/client/src/components/hermes/settings/SessionSettings.vue
@@ -1,17 +1,14 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
 import { NInputNumber, NSelect, NSwitch, useMessage } from "naive-ui";
 import { useI18n } from "vue-i18n";
 import { useSettingsStore } from "@/stores/hermes/settings";
 import { useSessionBrowserPrefsStore } from "@/stores/hermes/session-browser-prefs";
-import { fetchPendingWrites } from "@/api/hermes/write-gate";
 import SettingRow from "./SettingRow.vue";
 
 const settingsStore = useSettingsStore();
 const sessionBrowserPrefsStore = useSessionBrowserPrefsStore();
 const message = useMessage();
 const { t } = useI18n();
-const writeApprovalSupported = ref(true);
 
 // 防抖保存：每个字段独立定时器，300ms 内只发最后一次 HTTP 请求
 const debounceTimers: Record<string, ReturnType<typeof setTimeout>> = {};
@@ -60,14 +57,6 @@ async function toggleWriteApproval(section: "memory" | "skills", value: boolean)
   }
 }
 
-onMounted(async () => {
-  try {
-    const data = await fetchPendingWrites();
-    writeApprovalSupported.value = data.supported !== false;
-  } catch {
-    writeApprovalSupported.value = true;
-  }
-});
 </script>
 
 <template>
@@ -79,7 +68,6 @@ onMounted(async () => {
       <NSwitch :value="settingsStore.approvals.mode === 'manual'" @update:value="toggleRequireAuth" />
     </SettingRow>
     <SettingRow
-      v-if="writeApprovalSupported"
       :label="t('settings.session.memoryWriteApproval')"
       :hint="t('settings.session.memoryWriteApprovalHint')"
     >
@@ -89,7 +77,6 @@ onMounted(async () => {
       />
     </SettingRow>
     <SettingRow
-      v-if="writeApprovalSupported"
       :label="t('settings.session.skillsWriteApproval')"
       :hint="t('settings.session.skillsWriteApprovalHint')"
     >

--- a/packages/server/src/services/hermes/write-gate.ts
+++ b/packages/server/src/services/hermes/write-gate.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'child_process'
+import { execFile, execFileSync } from 'child_process'
 import { existsSync, readFileSync, realpathSync } from 'fs'
 import { readdir, readFile } from 'fs/promises'
 import { homedir } from 'os'
@@ -10,6 +10,11 @@ import { getHermesBaseDir, getProfileDir } from './hermes-profile'
 const execFileAsync = promisify(execFile)
 const SUBSYSTEMS = new Set(['memory', 'skills'])
 const PENDING_ID_RE = /^[A-Za-z0-9_-]{1,80}$/
+const WRITE_GATE_REQUIRED_FILES = [
+  join('tools', 'write_approval.py'),
+  join('hermes_cli', 'write_approval_commands.py'),
+]
+const WRITE_GATE_IMPORT_CHECK = 'import tools.write_approval; import hermes_cli.write_approval_commands'
 
 export type WriteGateSubsystem = 'memory' | 'skills'
 
@@ -208,6 +213,10 @@ function pendingDir(profile: string, subsystem: WriteGateSubsystem): string {
   return join(getProfileDir(profile || 'default'), 'pending', subsystem)
 }
 
+function hasWriteGateSupportFiles(agentRoot: string): boolean {
+  return WRITE_GATE_REQUIRED_FILES.every(relativePath => existsSync(join(agentRoot, relativePath)))
+}
+
 function normalizeRecord(raw: any, subsystem: WriteGateSubsystem, fallbackId: string): PendingWriteRecord | null {
   const id = typeof raw?.id === 'string' && raw.id.trim() ? raw.id.trim() : fallbackId
   if (!PENDING_ID_RE.test(id)) return null
@@ -263,12 +272,7 @@ export async function listPendingWrites(profile: string): Promise<PendingWritesR
 }
 
 export function isWriteGateSupported(): boolean {
-  try {
-    resolveAgentRoot()
-    return true
-  } catch {
-    return false
-  }
+  return Boolean(tryResolveAgentRoot()) || hasWriteGatePythonImports()
 }
 
 function pathCandidates(command: string): string[] {
@@ -306,12 +310,33 @@ function hermesShebangPython(): string | null {
 
 function agentRootFromPython(python: string | null): string {
   if (!python || !isAbsolute(python)) return ''
-  try {
-    const real = realpathSync(python)
-    const binDir = dirname(real)
+  const candidates: string[] = []
+  const addCandidate = (pythonPath: string) => {
+    const binDir = dirname(pythonPath)
     const venvDir = dirname(binDir)
-    if (basename(venvDir) === 'venv') return dirname(venvDir)
+    if (basename(venvDir) === 'venv') candidates.push(dirname(venvDir))
+  }
+  addCandidate(python)
+  try {
+    addCandidate(realpathSync(python))
   } catch {}
+  return candidates.find(hasWriteGateSupportFiles) || candidates[0] || ''
+}
+
+function agentRootFromHermesBin(): string {
+  for (const candidate of pathCandidates(getHermesBin())) {
+    if (!existsSync(candidate)) continue
+    try {
+      const real = realpathSync(candidate)
+      const binDir = dirname(real)
+      const candidates = [
+        resolve(binDir, '..', '..'),
+        resolve(binDir, '..'),
+      ]
+      const root = candidates.find(hasWriteGateSupportFiles)
+      if (root) return root
+    } catch {}
+  }
   return ''
 }
 
@@ -321,30 +346,63 @@ function agentRootCandidates(): string[] {
     process.env.HERMES_AGENT_ROOT?.trim() || '',
     join(getHermesBaseDir(), 'hermes-agent'),
     join(homedir(), '.hermes', 'hermes-agent'),
+    agentRootFromHermesBin(),
     agentRootFromPython(shebangPython),
   ].filter(Boolean)
 }
 
-function resolveAgentRoot(): string {
+function tryResolveAgentRoot(): string {
   for (const candidate of agentRootCandidates()) {
-    if (existsSync(join(candidate, 'tools', 'write_approval.py'))) return resolve(candidate)
+    if (hasWriteGateSupportFiles(candidate)) return resolve(candidate)
   }
+  return ''
+}
+
+function resolveAgentRoot(): string {
+  const agentRoot = tryResolveAgentRoot()
+  if (agentRoot) return agentRoot
   throw new Error('Hermes Agent source not found. Set HERMES_AGENT_ROOT to enable write approval actions.')
 }
 
-function resolveHermesPython(agentRoot: string): string {
+function resolveHermesPython(agentRoot?: string): string {
   const envPython = process.env.HERMES_AGENT_CLI_PYTHON?.trim()
   if (envPython) return envPython
 
-  const venvPython = process.platform === 'win32'
-    ? join(agentRoot, 'venv', 'Scripts', 'python.exe')
-    : join(agentRoot, 'venv', 'bin', 'python3')
-  if (existsSync(venvPython)) return venvPython
+  if (agentRoot) {
+    const venvPython = process.platform === 'win32'
+      ? join(agentRoot, 'venv', 'Scripts', 'python.exe')
+      : join(agentRoot, 'venv', 'bin', 'python3')
+    if (existsSync(venvPython)) return venvPython
+  }
 
   const shebangPython = hermesShebangPython()
-  if (shebangPython) return shebangPython
+  if (shebangPython && !/[/\\](?:sh|bash|zsh|fish|cmd|powershell|pwsh)(?:\.exe)?$/i.test(shebangPython)) return shebangPython
 
   return process.platform === 'win32' ? 'python' : 'python3'
+}
+
+function hasWriteGatePythonImports(): boolean {
+  const agentRoot = tryResolveAgentRoot()
+  const python = resolveHermesPython(agentRoot)
+  const pythonPath = [agentRoot, process.env.PYTHONPATH || ''].filter(Boolean).join(delimiter)
+  try {
+    execFileSync(
+      python,
+      ['-c', WRITE_GATE_IMPORT_CHECK],
+      {
+        env: {
+          ...process.env,
+          ...(pythonPath ? { PYTHONPATH: pythonPath } : {}),
+        },
+        timeout: 5000,
+        stdio: 'ignore',
+        windowsHide: true,
+      },
+    )
+    return true
+  } catch {
+    return false
+  }
 }
 
 async function runPythonAction(
@@ -358,7 +416,7 @@ async function runPythonAction(
   if (!isWriteGateSupported()) {
     throw new Error('Hermes Agent write approval is not supported by the installed Hermes Agent version.')
   }
-  const agentRoot = resolveAgentRoot()
+  const agentRoot = tryResolveAgentRoot()
   const python = resolveHermesPython(agentRoot)
   const profileDir = getProfileDir(profile || 'default')
   const pythonPath = [agentRoot, process.env.PYTHONPATH || ''].filter(Boolean).join(delimiter)

--- a/tests/client/session-settings.test.ts
+++ b/tests/client/session-settings.test.ts
@@ -2,8 +2,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 
-const mockFetchPendingWrites = vi.hoisted(() => vi.fn())
-
 const mockSettingsStore = vi.hoisted(() => ({
   sessionReset: { mode: 'both', idle_minutes: 60, at_hour: 0 },
   approvals: { mode: 'manual' },
@@ -28,10 +26,6 @@ vi.mock('@/stores/hermes/settings', () => ({
 
 vi.mock('@/stores/hermes/session-browser-prefs', () => ({
   useSessionBrowserPrefsStore: () => mockPrefsStore,
-}))
-
-vi.mock('@/api/hermes/write-gate', () => ({
-  fetchPendingWrites: mockFetchPendingWrites,
 }))
 
 vi.mock('vue-i18n', () => ({
@@ -59,7 +53,6 @@ describe('SessionSettings', () => {
     mockPrefsStore.humanOnly = true
     mockSettingsStore.memory.write_approval = false
     mockSettingsStore.skills.write_approval = true
-    mockFetchPendingWrites.mockResolvedValue({ records: [], counts: { memory: 0, skills: 0 }, supported: true })
   })
 
   it('surfaces the human-only preference in the Session tab', async () => {
@@ -142,9 +135,7 @@ describe('SessionSettings', () => {
     expect(mockSettingsStore.saveSection).toHaveBeenCalledWith('skills', { write_approval: false })
   })
 
-  it('hides write approval toggles when Hermes Agent does not support them', async () => {
-    mockFetchPendingWrites.mockResolvedValue({ records: [], counts: { memory: 0, skills: 0 }, supported: false })
-
+  it('shows write approval toggles without probing Hermes Agent support', async () => {
     const wrapper = mount(SessionSettings, {
       global: {
         stubs: {
@@ -165,7 +156,7 @@ describe('SessionSettings', () => {
 
     await flushPromises()
 
-    expect(wrapper.text()).not.toContain('settings.session.memoryWriteApproval')
-    expect(wrapper.text()).not.toContain('settings.session.skillsWriteApproval')
+    expect(wrapper.text()).toContain('settings.session.memoryWriteApproval')
+    expect(wrapper.text()).toContain('settings.session.skillsWriteApproval')
   })
 })

--- a/tests/server/write-gate-service.test.ts
+++ b/tests/server/write-gate-service.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
 const originalHermesHome = process.env.HERMES_HOME
+const originalHermesAgentRoot = process.env.HERMES_AGENT_ROOT
+const originalHermesBin = process.env.HERMES_BIN
+const originalHermesAgentCliPython = process.env.HERMES_AGENT_CLI_PYTHON
 let hermesHome = ''
 
 async function loadService() {
@@ -20,6 +23,12 @@ afterEach(async () => {
   vi.resetModules()
   if (originalHermesHome === undefined) delete process.env.HERMES_HOME
   else process.env.HERMES_HOME = originalHermesHome
+  if (originalHermesAgentRoot === undefined) delete process.env.HERMES_AGENT_ROOT
+  else process.env.HERMES_AGENT_ROOT = originalHermesAgentRoot
+  if (originalHermesBin === undefined) delete process.env.HERMES_BIN
+  else process.env.HERMES_BIN = originalHermesBin
+  if (originalHermesAgentCliPython === undefined) delete process.env.HERMES_AGENT_CLI_PYTHON
+  else process.env.HERMES_AGENT_CLI_PYTHON = originalHermesAgentCliPython
   await rm(hermesHome, { recursive: true, force: true })
   hermesHome = ''
 })
@@ -64,5 +73,67 @@ describe('write gate service', () => {
 
     await expect(getPendingWriteDiff('default', 'files', 'abc123')).rejects.toThrow('Invalid write gate subsystem')
     await expect(getPendingWriteDiff('default', 'memory', '../abc')).rejects.toThrow('Invalid pending write id')
+  })
+
+  it('detects write approval support from a uv-backed Hermes venv shebang', async () => {
+    const agentRoot = join(hermesHome, 'agent')
+    const venvBin = join(agentRoot, 'venv', 'bin')
+    const externalPythonDir = join(hermesHome, 'uv-python', 'bin')
+    await mkdir(join(agentRoot, 'tools'), { recursive: true })
+    await mkdir(join(agentRoot, 'hermes_cli'), { recursive: true })
+    await mkdir(venvBin, { recursive: true })
+    await mkdir(externalPythonDir, { recursive: true })
+    await writeFile(join(agentRoot, 'tools', 'write_approval.py'), '', 'utf-8')
+    await writeFile(join(agentRoot, 'hermes_cli', 'write_approval_commands.py'), '', 'utf-8')
+    await writeFile(join(externalPythonDir, 'python3'), '', 'utf-8')
+    await symlink(join(externalPythonDir, 'python3'), join(venvBin, 'python3'))
+
+    const hermesBin = join(venvBin, 'hermes')
+    await writeFile(hermesBin, `#!${join(venvBin, 'python3')}\n`, 'utf-8')
+    process.env.HERMES_BIN = hermesBin
+    delete process.env.HERMES_AGENT_ROOT
+
+    const { isWriteGateSupported } = await loadService()
+
+    expect(isWriteGateSupported()).toBe(true)
+  })
+
+  it('detects write approval support from a Windows-style venv Scripts executable path', async () => {
+    const agentRoot = join(hermesHome, 'agent-win')
+    const scriptsDir = join(agentRoot, 'venv', 'Scripts')
+    await mkdir(join(agentRoot, 'tools'), { recursive: true })
+    await mkdir(join(agentRoot, 'hermes_cli'), { recursive: true })
+    await mkdir(scriptsDir, { recursive: true })
+    await writeFile(join(agentRoot, 'tools', 'write_approval.py'), '', 'utf-8')
+    await writeFile(join(agentRoot, 'hermes_cli', 'write_approval_commands.py'), '', 'utf-8')
+
+    const hermesBin = join(scriptsDir, 'hermes.exe')
+    await writeFile(hermesBin, '', 'utf-8')
+    process.env.HERMES_BIN = hermesBin
+    delete process.env.HERMES_AGENT_ROOT
+
+    const { isWriteGateSupported } = await loadService()
+
+    expect(isWriteGateSupported()).toBe(true)
+  })
+
+  it('detects write approval support from a pip-installed runtime Python', async () => {
+    const fakePython = join(hermesHome, 'python')
+    await writeFile(fakePython, [
+      '#!/bin/sh',
+      'case "$2" in',
+      '  *"tools.write_approval"*"hermes_cli.write_approval_commands"*) exit 0 ;;',
+      '  *) exit 1 ;;',
+      'esac',
+      '',
+    ].join('\n'), 'utf-8')
+    await chmod(fakePython, 0o755)
+    process.env.HERMES_AGENT_CLI_PYTHON = fakePython
+    process.env.HERMES_BIN = join(hermesHome, 'missing-hermes')
+    delete process.env.HERMES_AGENT_ROOT
+
+    const { isWriteGateSupported } = await loadService()
+
+    expect(isWriteGateSupported()).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- Always show memory and skills write-approval toggles in the Session settings tab so saving config is not blocked by Agent capability probing.
- Teach write-gate support detection to use the configured Hermes Agent Python runtime, covering desktop pip/runtime installs, while keeping source/venv path detection for local installs.
- Add focused client and server coverage for settings visibility and desktop/runtime detection paths.

## Validation
- `npm run test -- tests/client/session-settings.test.ts`
- `npm run test -- tests/server/write-gate-service.test.ts`