### PR TITLE
fix(media): support configured image providers

### DIFF
--- a/packages/server/src/controllers/hermes/media.ts
+++ b/packages/server/src/controllers/hermes/media.ts
@@ -22,7 +22,8 @@ type AuthJson = {
 
 type ApiKeyImageMode = 'text' | 'image' | 'edit'
 
-type FunCodexProvider = {
+type ApiKeyImageProvider = {
+  name: string
   apiKey: string
   baseUrl: string
   model: string
@@ -79,19 +80,38 @@ function buildApiUrl(baseUrl: string, pathWithV1: string): string {
   return `${base}${apiPath}`
 }
 
-async function resolveFunCodexProvider(profile: string): Promise<FunCodexProvider | null> {
+function normalizeCustomProviderName(value: unknown): string {
+  const name = String(value || '').trim()
+  if (!name) return ''
+  return name.startsWith('custom:') ? name.slice('custom:'.length).trim() : name
+}
+
+function requestedApiKeyImageProviderName(body: any): string {
+  return normalizeCustomProviderName(body?.provider || body?.provider_name || body?.custom_provider) || APIKEY_IMAGE_PROVIDER
+}
+
+function apiKeyFromCustomProvider(provider: any): string {
+  const direct = String(provider?.api_key || '').trim()
+  if (direct) return direct
+  const envName = String(provider?.api_key_env || provider?.key_env || '').trim()
+  return envName ? String(process.env[envName] || '').trim() : ''
+}
+
+async function resolveApiKeyImageProvider(profile: string, providerName = APIKEY_IMAGE_PROVIDER): Promise<ApiKeyImageProvider | null> {
+  const requestedName = normalizeCustomProviderName(providerName) || APIKEY_IMAGE_PROVIDER
   const hermesConfig = await readConfigYamlForProfile(profile)
   const customProviders = Array.isArray(hermesConfig.custom_providers)
     ? hermesConfig.custom_providers as any[]
     : []
-  const provider = customProviders.find(entry => String(entry?.name || '').trim() === APIKEY_IMAGE_PROVIDER)
-  const apiKey = String(provider?.api_key || '').trim()
+  const provider = customProviders.find(entry => normalizeCustomProviderName(entry?.name) === requestedName)
+  const apiKey = apiKeyFromCustomProvider(provider)
   const baseUrl = String(provider?.base_url || '').trim()
   if (!provider || !apiKey || !baseUrl) return null
   return {
+    name: requestedName,
     apiKey,
     baseUrl,
-    model: String(provider?.model || '').trim(),
+    model: String(provider?.model || provider?.default_model || '').trim(),
   }
 }
 
@@ -351,7 +371,7 @@ async function readSseImageResults(res: Response, limit: number): Promise<string
   return images.slice(0, limit)
 }
 
-async function requestApiKeyImage(provider: FunCodexProvider, mode: ApiKeyImageMode, body: any): Promise<string[]> {
+async function requestApiKeyImage(provider: ApiKeyImageProvider, mode: ApiKeyImageMode, body: any): Promise<string[]> {
   const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
   if (!prompt) {
     const err: any = new Error('prompt is required')
@@ -373,7 +393,7 @@ async function requestApiKeyImage(provider: FunCodexProvider, mode: ApiKeyImageM
       headers: { ...headers, 'Content-Type': 'application/json' },
       signal: AbortSignal.timeout(timeoutMs),
       body: JSON.stringify({
-        model: body.model || APIKEY_IMAGE_MODEL,
+        model: body.model || provider.model || APIKEY_IMAGE_MODEL,
         prompt,
         n,
         size: body.size || '1024x1024',
@@ -414,7 +434,7 @@ async function requestApiKeyImage(provider: FunCodexProvider, mode: ApiKeyImageM
     const form = new FormData()
     form.append('image', new Blob([imageBytes.buffer], { type: image.mime }), image.name)
     form.append('prompt', prompt)
-    form.append('model', body.model || APIKEY_IMAGE_MODEL)
+    form.append('model', body.model || provider.model || APIKEY_IMAGE_MODEL)
     form.append('n', String(n))
     form.append('quality', body.quality || 'auto')
     form.append('size', body.size || '1024x1024')
@@ -466,17 +486,19 @@ export async function apiKeyImageGenerate(ctx: Context) {
     return
   }
 
-  const provider = await resolveFunCodexProvider(profile)
+  const body = ctx.request.body as any
+  const providerName = requestedApiKeyImageProviderName(body)
+  const provider = await resolveApiKeyImageProvider(profile, providerName)
   if (!provider) {
     ctx.status = 401
+    const isDefaultProvider = providerName === APIKEY_IMAGE_PROVIDER
     ctx.body = {
-      error: `Missing fun-codex provider in profile "${profile}" config.yaml.`,
-      code: 'missing_fun_codex_provider',
+      error: `Missing ${providerName} provider in profile "${profile}" config.yaml.`,
+      code: isDefaultProvider ? 'missing_fun_codex_provider' : 'missing_apikey_image_provider',
     }
     return
   }
 
-  const body = ctx.request.body as any
   try {
     const mode = normalizeImageMode(body.mode)
     const images = await requestApiKeyImage(provider, mode, body)
@@ -486,7 +508,7 @@ export async function apiKeyImageGenerate(ctx: Context) {
       ok: true,
       mode,
       output_paths: outputPaths,
-      provider: APIKEY_IMAGE_PROVIDER,
+      provider: provider.name,
       base_url: provider.baseUrl,
       profile,
     }

--- a/tests/server/media-controller.test.ts
+++ b/tests/server/media-controller.test.ts
@@ -5,6 +5,10 @@ const originalWebUiHome = process.env.HERMES_WEB_UI_HOME
 const originalWebuiStateDir = process.env.HERMES_WEBUI_STATE_DIR
 
 afterEach(() => {
+  vi.doUnmock('../../packages/server/src/services/hermes/hermes-profile')
+  vi.doUnmock('../../packages/server/src/services/config-helpers')
+  vi.clearAllMocks()
+  vi.unstubAllEnvs()
   vi.resetModules()
   if (originalWebUiHome === undefined) delete process.env.HERMES_WEB_UI_HOME
   else process.env.HERMES_WEB_UI_HOME = originalWebUiHome
@@ -21,5 +25,76 @@ describe('media controller', () => {
     expect(defaultMediaOutputPath('bad/request:id')).toBe(join('/tmp/hermes-web-ui-test-home', 'media', 'bad_request_id.mp4'))
     expect(defaultImageOutputPath('img_123')).toBe(join('/tmp/hermes-web-ui-test-home', 'media', 'img_123.png'))
     expect(defaultImageOutputPath('bad/request:id', 1)).toBe(join('/tmp/hermes-web-ui-test-home', 'media', 'bad_request_id-2.png'))
+  })
+
+  it('generates images through the requested configured custom provider', async () => {
+    vi.stubEnv('AGNES_API_KEY', 'agnes-secret')
+    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+      getActiveProfileName: () => 'default',
+      getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
+      listProfileNamesFromDisk: () => ['default'],
+    }))
+    vi.doMock('../../packages/server/src/services/config-helpers', () => ({
+      readConfigYamlForProfile: vi.fn(async () => ({
+        custom_providers: [{
+          name: 'agnes',
+          base_url: 'https://agnes.example/v1',
+          api_key_env: 'AGNES_API_KEY',
+          model: 'agnes-image-2.1-flash',
+        }],
+      })),
+    }))
+    const fetchMock = vi.fn(async () => new Response(
+      'data: {"data":[{"b64_json":"aW1hZ2UtYnl0ZXM="}]}\n\n',
+      { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+    ))
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchMock as any
+    try {
+      const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx: any = {
+        state: { serverTokenAuth: true },
+        query: {},
+        request: {
+          body: {
+            provider: 'agnes',
+            mode: 'text',
+            prompt: 'make an icon',
+            output_path: '/tmp/hermes-web-ui-agnes-image.png',
+          },
+        },
+        get: vi.fn(() => ''),
+        status: 200,
+        body: undefined,
+      }
+
+      await apiKeyImageGenerate(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body).toMatchObject({
+        ok: true,
+        mode: 'text',
+        provider: 'agnes',
+        base_url: 'https://agnes.example/v1',
+        profile: 'default',
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://agnes.example/v1/images/generations',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer agnes-secret',
+            'Content-Type': 'application/json',
+          }),
+        }),
+      )
+      const requestInit = fetchMock.mock.calls[0][1] as RequestInit
+      expect(JSON.parse(String(requestInit.body))).toMatchObject({
+        model: 'agnes-image-2.1-flash',
+        prompt: 'make an icon',
+      })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 })


### PR DESCRIPTION
## What does this PR do?

Allows `/api/hermes/media/apikey-image-generate` to use a requested configured `custom_providers` entry instead of only the hardcoded `fun-codex` provider. The default remains `fun-codex` for backward compatibility, but callers can now send `provider`, `provider_name`, or `custom_provider` to route image generation through another configured OpenAI-compatible image provider.

Fixes #1483

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `packages/server/src/controllers/hermes/media.ts`: resolves the requested API-key image provider from `custom_providers`, supports `custom:` prefixes, and reads `api_key_env`/`key_env` in addition to direct `api_key`.
- `tests/server/media-controller.test.ts`: adds a regression that routes image generation through a non-`fun-codex` provider and verifies the `/v1/images/generations` request.

## How to Test

1. `PATH=/Users/shangyifan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm exec vitest -- run tests/server/media-controller.test.ts`
2. `git diff --check`
3. `PATH=/Users/shangyifan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run harness:check`
4. `PATH=/Users/shangyifan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run test:coverage`
5. `PATH=/Users/shangyifan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/EKKOLearnAI/hermes-web-ui/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/EKKOLearnAI/hermes-web-ui/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused server test and build gates listed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS with Node v24.14.0 Codex runtime

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no public config shape changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, existing `custom_providers` fields are used
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A, server controller path only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No screenshot required; this is a local server media API routing fix covered by controller tests.

Duplicate search: checked active PRs for `fun-codex`, `apikey-image-generate`, `missing_fun_codex_provider`, `images/generations`, and custom-provider image/video routing. Adjacent PRs #904, #950, #1261, #1071, #1314, and #1407 do not cover this endpoint.
