### PR TITLE
fix: 限制 Skill 详情面板附件文件列表的最大高度，防止附件过多时挤压 SKILL.md 内容区域

### DIFF
--- a/docs/chat-chain-changes/2026-06-06-pr1110-outline-qa-load-all.md
+++ b/docs/chat-chain-changes/2026-06-06-pr1110-outline-qa-load-all.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-06
+pr: 1110
+feature: Session outline Q&A pairs and load-all button
+impact: Outline panel now shows Q&A pairs instead of markdown headings. Added load-all button in chat and history views. Exported mapHermesMessages for outline panel use.
+---
+
+- `OutlinePanel.vue` — rewritten to display user/assistant Q&A pairs as expandable items instead of markdown heading extraction. Supports both ChatView (chatStore-managed) and HistoryView (local ref) contexts. CRON command messages are shown as questions.
+- `ChatPanel.vue` — added "Load All Messages" button using `fetchHermesSession` API for loading full conversation messages.
+- `MessageList.vue` — strips leading command/system messages before the first user message so loaded sessions don't show phantom init content at the top.
+- `HistoryView.vue` — added load-all button support for outline panel since new pagination only loads 300 messages.
+- `chat.ts` — exported `mapHermesMessages` for use in OutlinePanel. Added `hasRuntimeToolPayload` / `runtimePayloadText` / `runtimeToolOutputHasError` helpers.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -85,7 +85,10 @@ function handleOutlineNavigate(target: { messageId: string; anchorId: string }) 
 
 function onOutlineMessagesLoaded(messages: any[]) {
   if (chatStore.activeSession) {
-    chatStore.activeSession.messages = messages;
+    // Skip leading messages before first user message (command/system)
+    const firstUserIdx = messages.findIndex(m => m.role === 'user');
+    const clean = firstUserIdx > 0 ? messages.slice(firstUserIdx) : messages;
+    chatStore.activeSession.messages = clean;
   }
 }
 

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -83,6 +83,12 @@ function handleOutlineNavigate(target: { messageId: string; anchorId: string }) 
   messageListRef.value?.scrollToAnchor(target.messageId, target.anchorId);
 }
 
+function onOutlineMessagesLoaded(messages: any[]) {
+  if (chatStore.activeSession) {
+    chatStore.activeSession.messages = messages;
+  }
+}
+
 async function handleSessionClick(sessionId: string) {
   await router.push({
     name: "hermes.session",
@@ -1421,7 +1427,11 @@ async function handleSessionModelCustomSubmit() {
           <OutlinePanel
             v-if="showOutline"
             :messages="chatStore.messages"
+            :session-id="chatStore.activeSessionId || undefined"
+            :session-profile="chatStore.activeSession ? sessionProfile(chatStore.activeSession.id) : null"
+            :show-load-all="true"
             @navigate="handleOutlineNavigate"
+            @messages-loaded="onOutlineMessagesLoaded"
           />
         </div>
         <div v-if="visibleApproval" class="approval-bar">

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -85,7 +85,8 @@ function handleOutlineNavigate(target: { messageId: string; anchorId: string }) 
 
 function onOutlineMessagesLoaded(messages: any[]) {
   if (chatStore.activeSession) {
-    // Skip leading messages before first user message (command/system)
+    // Skip leading init messages before first user.
+    // CRON sessions in history don't use this handler.
     const firstUserIdx = messages.findIndex(m => m.role === 'user');
     const clean = firstUserIdx > 0 ? messages.slice(firstUserIdx) : messages;
     chatStore.activeSession.messages = clean;

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -92,7 +92,10 @@ const emptyState = computed(() => {
 
 const displayMessages = computed(() => {
   const currentToolIds = new Set(currentToolCalls.value.map((tool) => tool.id));
-  return chatStore.messages.filter((m) => {
+  // Skip leading command/system messages before first user to avoid init noise
+  const firstUserIdx = chatStore.messages.findIndex(m => m.role === 'user');
+
+  return chatStore.messages.filter((m, idx) => {
     if (m.role === "tool") {
       return toolTraceVisible.value && !!m.toolName && !(chatStore.isRunActive && currentToolIds.has(m.id));
     }
@@ -103,6 +106,10 @@ const displayMessages = computed(() => {
       !!m.reasoning?.trim() &&
       currentToolCalls.value.length === 0
     ) {
+      return false;
+    }
+    // Skip command messages before the first user message
+    if (m.role === 'command' && firstUserIdx > 0 && idx < firstUserIdx) {
       return false;
     }
     return true;

--- a/packages/client/src/components/hermes/chat/OutlinePanel.vue
+++ b/packages/client/src/components/hermes/chat/OutlinePanel.vue
@@ -51,7 +51,7 @@ function extractUserQuestion(text: string): string {
   return firstLine || t('chat.outlineUserQuestion')
 }
 
-function extractAnswerSummary(text: string): string {
+function extractAnswerSummary(text: string): string | null {
   const cleanedText = text.replace(/<think>[\s\S]*?<\/think>/g, '')
   const lines = cleanedText.split('\n')
   for (const line of lines) {
@@ -61,7 +61,7 @@ function extractAnswerSummary(text: string): string {
     if (trimmed.length > 80) return trimmed.slice(0, 80) + '...'
     return trimmed
   }
-  return t('chat.outlineAnswer')
+  return null
 }
 
 const outlineItems = computed<OutlineItem[]>(() => {
@@ -83,13 +83,16 @@ const outlineItems = computed<OutlineItem[]>(() => {
       while (i < filteredMessages.length && filteredMessages[i].role !== 'assistant') i++
       if (i < filteredMessages.length) {
         const assistant = filteredMessages[i]
-        items.push({
-          id: `answer-${assistant.id}`,
-          type: 'answer',
-          content: extractAnswerSummary(assistant.content || ''),
-          messageId: assistant.id,
-          anchorId: `message-${assistant.id}`,
-        })
+        const summary = extractAnswerSummary(assistant.content || '')
+        if (summary !== null) {
+          items.push({
+            id: `answer-${assistant.id}`,
+            type: 'answer',
+            content: summary,
+            messageId: assistant.id,
+            anchorId: `message-${assistant.id}`,
+          })
+        }
       }
     } else {
       i++

--- a/packages/client/src/components/hermes/chat/OutlinePanel.vue
+++ b/packages/client/src/components/hermes/chat/OutlinePanel.vue
@@ -66,12 +66,20 @@ function extractAnswerSummary(text: string): string | null {
 
 const outlineItems = computed<OutlineItem[]>(() => {
   const items: OutlineItem[] = []
-  const filteredMessages = props.messages.filter(m => m.role === 'user' || m.role === 'assistant')
+  // Find first user message to skip leading system/command init messages
+  const firstUserIdx = props.messages.findIndex(m =>
+    m.role === 'user' || (m.role === 'command' && m.systemType === 'command')
+  )
+  const visibleMessages = props.messages.slice(Math.max(0, firstUserIdx))
+  // Only include user and assistant messages for outline
+  const filteredMessages = visibleMessages.filter(m =>
+    m.role === 'user' || m.role === 'assistant' || (m.role === 'command' && m.systemType === 'command')
+  )
 
   let i = 0
   while (i < filteredMessages.length) {
     const msg = filteredMessages[i]
-    if (msg.role === 'user') {
+    if (msg.role === 'user' || msg.role === 'command') {
       items.push({
         id: `question-${msg.id}`,
         type: 'question',

--- a/packages/client/src/components/hermes/chat/OutlinePanel.vue
+++ b/packages/client/src/components/hermes/chat/OutlinePanel.vue
@@ -1,111 +1,99 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { NTooltip } from 'naive-ui'
 import type { Message } from '@/stores/hermes/chat'
+import { mapHermesMessages } from '@/stores/hermes/chat'
+import { fetchHermesSession } from '@/api/hermes/sessions'
 
 interface OutlineItem {
   id: string
-  type: 'user' | 'outline'
+  type: 'question' | 'answer'
   content: string
   messageId: string
-  level: number
   anchorId: string
 }
 
 const props = defineProps<{
   messages: Message[]
+  sessionId?: string
+  sessionProfile?: string | null
+  showLoadAll?: boolean
 }>()
 
 const emit = defineEmits<{
   navigate: [target: { messageId: string; anchorId: string }]
+  messagesLoaded: [messages: Message[]]
 }>()
 
 const { t } = useI18n()
+const localFetching = ref(false)
 
-function extractAllHeadings(text: string, messageId: string): OutlineItem[] {
-  const items: OutlineItem[] = []
-  let cleanedText = text.replace(/<think>[\s\S]*?<\/think>/g, '')
-  const lines = cleanedText.split('\n')
-  
-  let headingIndex = 0
-  for (const line of lines) {
-    const trimmed = line.trim()
-    const h1Match = trimmed.match(/^#\s+(.+)/)
-    const h2Match = trimmed.match(/^##\s+(.+)/)
-    const h3Match = trimmed.match(/^###\s+(.+)/)
-    
-    if (h1Match) {
-      headingIndex++
-      items.push({
-        id: `outline-${messageId}-h${headingIndex}`,
-        type: 'outline',
-        content: h1Match[1].trim(),
-        messageId,
-        level: 1,
-        anchorId: `msg-${messageId}-heading-${headingIndex}`
-      })
-    } else if (h2Match) {
-      headingIndex++
-      items.push({
-        id: `outline-${messageId}-h${headingIndex}`,
-        type: 'outline',
-        content: h2Match[1].trim(),
-        messageId,
-        level: 2,
-        anchorId: `msg-${messageId}-heading-${headingIndex}`
-      })
-    } else if (h3Match) {
-      headingIndex++
-      items.push({
-        id: `outline-${messageId}-h${headingIndex}`,
-        type: 'outline',
-        content: h3Match[1].trim(),
-        messageId,
-        level: 3,
-        anchorId: `msg-${messageId}-heading-${headingIndex}`
-      })
+async function handleLoadAll() {
+  if (!props.sessionId) return
+
+  localFetching.value = true
+  try {
+    const sessionDetail = await fetchHermesSession(props.sessionId, props.sessionProfile)
+    if (sessionDetail && sessionDetail.messages) {
+      const mapped = mapHermesMessages(sessionDetail.messages)
+      emit('messagesLoaded', mapped)
     }
+  } finally {
+    localFetching.value = false
   }
-  
-  return items
 }
 
 function extractUserQuestion(text: string): string {
   const cleanedText = text.replace(/<think>[\s\S]*?<\/think>/g, '')
   const firstLine = cleanedText.split('\n')[0] || ''
-  if (firstLine.length > 50) {
-    return firstLine.slice(0, 50) + '...'
-  }
+  if (firstLine.length > 50) return firstLine.slice(0, 50) + '...'
   return firstLine || t('chat.outlineUserQuestion')
+}
+
+function extractAnswerSummary(text: string): string {
+  const cleanedText = text.replace(/<think>[\s\S]*?<\/think>/g, '')
+  const lines = cleanedText.split('\n')
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('```') || trimmed.startsWith('#') || trimmed.startsWith('>')) continue
+    if (trimmed.startsWith('| ') || trimmed.match(/^\|/)) continue
+    if (trimmed.length > 80) return trimmed.slice(0, 80) + '...'
+    return trimmed
+  }
+  return t('chat.outlineAnswer')
 }
 
 const outlineItems = computed<OutlineItem[]>(() => {
   const items: OutlineItem[] = []
-  let i = 0
   const filteredMessages = props.messages.filter(m => m.role === 'user' || m.role === 'assistant')
-  
+
+  let i = 0
   while (i < filteredMessages.length) {
     const msg = filteredMessages[i]
     if (msg.role === 'user') {
       items.push({
-        id: `user-${msg.id}`,
-        type: 'user',
+        id: `question-${msg.id}`,
+        type: 'question',
         content: extractUserQuestion(msg.content || ''),
         messageId: msg.id,
-        level: 0,
-        anchorId: `message-${msg.id}`
+        anchorId: `message-${msg.id}`,
       })
       i++
-      while (i < filteredMessages.length && filteredMessages[i].role !== 'assistant') {
-        i++
-      }
+      while (i < filteredMessages.length && filteredMessages[i].role !== 'assistant') i++
       if (i < filteredMessages.length) {
-        const assistantMsg = filteredMessages[i]
-        const headings = extractAllHeadings(assistantMsg.content || '', assistantMsg.id)
-        items.push(...headings)
+        const assistant = filteredMessages[i]
+        items.push({
+          id: `answer-${assistant.id}`,
+          type: 'answer',
+          content: extractAnswerSummary(assistant.content || ''),
+          messageId: assistant.id,
+          anchorId: `message-${assistant.id}`,
+        })
       }
+    } else {
+      i++
     }
-    i++
   }
   return items
 })
@@ -122,31 +110,60 @@ function scrollToTarget(item: OutlineItem) {
   <div class="outline-panel">
     <div class="outline-header">
       <span class="outline-title">{{ t('chat.outlineTitle') }}</span>
+      <NTooltip v-if="showLoadAll" trigger="hover" placement="top">
+        <template #trigger>
+          <button
+            type="button"
+            class="load-all-btn"
+            :disabled="localFetching"
+            @click="handleLoadAll"
+          >
+            <svg
+              v-if="localFetching"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              class="load-all-spinner"
+            >
+              <path d="M21 12a9 9 0 11-6.219-8.56" />
+            </svg>
+            <svg
+              v-else
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+          </button>
+        </template>
+        {{ t('chat.loadAllMessages') }}
+      </NTooltip>
     </div>
     <div class="outline-content">
       <template v-if="outlineItems.length > 0">
-        <template v-for="item in outlineItems" :key="item.id">
-          <div
-            v-if="item.type === 'user'"
-            class="outline-item user-item"
-            @click="scrollToTarget(item)"
-          >
-            <div class="user-question">
-              <span class="q-label">Q:</span>
-              <span class="q-text">{{ item.content }}</span>
-            </div>
+        <div
+          v-for="item in outlineItems"
+          :key="item.id"
+          class="outline-item"
+          :class="item.type === 'question' ? 'question-item' : 'answer-item'"
+          @click="scrollToTarget(item)"
+        >
+          <div class="outline-text">
+            <span class="outline-label">{{ item.type === 'question' ? 'Q' : 'A' }}:</span>
+            <span class="outline-content">{{ item.content }}</span>
           </div>
-          <div
-            v-else
-            class="outline-item outline-heading-item"
-            :class="`level-${item.level}`"
-            @click="scrollToTarget(item)"
-          >
-            <div class="heading-item">
-              <span class="heading-text">{{ item.content }}</span>
-            </div>
-          </div>
-        </template>
+        </div>
       </template>
       <div v-else class="outline-empty">{{ t('chat.outlineEmpty') }}</div>
     </div>
@@ -180,9 +197,13 @@ function scrollToTarget(item: OutlineItem) {
   padding: 16px;
   border-bottom: 1px solid $border-color;
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .outline-title {
+  flex: 1;
   font-size: 14px;
   font-weight: 600;
   color: $text-primary;
@@ -195,7 +216,7 @@ function scrollToTarget(item: OutlineItem) {
 }
 
 .outline-item {
-  margin-bottom: 4px;
+  margin-bottom: 6px;
   cursor: pointer;
   transition: opacity 0.2s ease;
 
@@ -204,102 +225,54 @@ function scrollToTarget(item: OutlineItem) {
   }
 }
 
-.user-item {
-  margin-bottom: 6px;
-}
-
-.user-question {
-  background-color: $bg-secondary;
-  color: $text-primary;
-  padding: 8px 12px;
-  border-radius: 8px;
+.outline-text {
+  padding: 6px 10px;
+  border-radius: 6px;
   display: flex;
   align-items: flex-start;
   gap: 6px;
+  font-size: 12px;
+  line-height: 1.4;
 
-  .dark & {
-    background-color: $bg-input;
-  }
-
-  .q-label {
+  .outline-label {
     font-weight: 600;
     flex-shrink: 0;
-    font-size: 13px;
-    line-height: 1.4;
   }
 
-  .q-text {
-    font-size: 13px;
-    line-height: 1.4;
+  .outline-content {
     word-break: break-word;
   }
 }
 
-.outline-heading-item {
-  &.level-1 {
-    padding-left: 0;
-  }
-
-  &.level-2 {
-    padding-left: 12px;
-  }
-
-  &.level-3 {
-    padding-left: 24px;
-  }
-}
-
-.heading-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 6px;
-  padding: 4px 8px;
-  border-radius: 4px;
-  transition: background-color 0.15s ease;
-
-  &:hover {
-    background-color: rgba(0, 0, 0, 0.04);
+.question-item {
+  .outline-text {
+    background-color: $bg-secondary;
+    color: $text-primary;
 
     .dark & {
-      background-color: rgba(255, 255, 255, 0.06);
+      background-color: $bg-input;
     }
-  }
 
-  .level-1 & {
-    .heading-marker {
-      color: $text-primary;
-      font-weight: 600;
-    }
-    .heading-text {
-      color: $text-primary;
-      font-weight: 500;
-    }
-  }
-
-  .level-2 & {
-    .heading-marker {
-      color: $text-secondary;
-    }
-    .heading-text {
-      color: $text-secondary;
-    }
-  }
-
-  .level-3 & {
-    .heading-marker {
-      color: $text-muted;
-    }
-    .heading-text {
-      color: $text-muted;
-      font-size: 12px;
+    .outline-label {
+      color: #3b82f6;
     }
   }
 }
 
-.heading-text {
-  font-size: 13px;
-  line-height: 1.4;
-  word-break: break-word;
+.answer-item {
+  margin-top: 2px;
+  .outline-text {
+    background-color: rgba(34, 197, 94, 0.08);
+    color: $text-secondary;
+
+    .dark & {
+      background-color: rgba(34, 197, 94, 0.12);
+    }
+
+    .outline-label {
+      color: #22c55e;
+    }
+  }
 }
 
 .outline-empty {
@@ -307,5 +280,48 @@ function scrollToTarget(item: OutlineItem) {
   color: $text-muted;
   font-size: 13px;
   padding: 20px 0;
+}
+
+.load-all-btn {
+  all: unset;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  color: $text-muted;
+  background: transparent;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+
+  &:hover {
+    color: $text-primary;
+    background: $bg-secondary;
+
+    .dark & {
+      background: $bg-input;
+    }
+  }
+
+  &:active {
+    opacity: 0.7;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.load-all-spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 </style>

--- a/packages/client/src/components/hermes/skills/SkillDetail.vue
+++ b/packages/client/src/components/hermes/skills/SkillDetail.vue
@@ -311,6 +311,8 @@ watch(() => `${props.category}/${props.skill}`, loadSkill, { immediate: true })
   border-top: 1px solid $border-color;
   padding-top: 12px;
   margin-top: 12px;
+  max-height: 30vh;
+  overflow-y: auto;
 }
 
 .files-header {

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -403,6 +403,8 @@ export default {
     outlineTitle: 'Conversation Outline',
     outlineEmpty: 'No conversation content',
     outlineUserQuestion: 'User question',
+    outlineAnswer: 'Answer',
+    loadAllMessages: 'Load All',
     inputPlaceholder: 'Type a message... (Enter to send, Shift+Enter for new line)',
     slashCommandArgs: {
       message: '<message>',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -403,6 +403,8 @@ export default {
     outlineTitle: '会话大纲',
     outlineEmpty: '暂无会话内容',
     outlineUserQuestion: '用户问题',
+    outlineAnswer: '回答',
+    loadAllMessages: '加载所有消息',
     inputPlaceholder: '输入消息... (Enter 发送，Shift+Enter 换行)',
     slashCommandArgs: {
       message: '<消息>',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -322,7 +322,7 @@ function resolveResumedAssistantState(
   }
 }
 
-function mapHermesMessages(msgs: HermesMessage[]): Message[] {
+export function mapHermesMessages(msgs: HermesMessage[]): Message[] {
   // Filter out assistant messages with no display content unless they carry tool call metadata
   // needed to name later tool result rows when resuming persisted history.
   const filteredMsgs = msgs.filter(m => {

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -847,6 +847,8 @@ function handleBatchDeleteConfirm() {
         <OutlinePanel
           v-if="showOutline && historySession"
           :messages="historySession.messages || []"
+          :session-id="historySession.id"
+          :session-profile="historySession.profile || null"
           @navigate="handleOutlineNavigate"
         />
       </div>

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -160,8 +160,10 @@ function sessionFromSummary(summary: SessionSummary, messages: Session['messages
 
 function onHistoryOutlineMessagesLoaded(messages: any[]) {
   if (historySession.value) {
-    const firstUserIdx = messages.findIndex(m => m.role === 'user');
-    const clean = firstUserIdx > 0 ? messages.slice(firstUserIdx) : messages;
+    const firstMeaningfulIdx = messages.findIndex(m =>
+      m.role === 'user' || (m.role === 'command' && m.systemType === 'command')
+    );
+    const clean = firstMeaningfulIdx > 0 ? messages.slice(firstMeaningfulIdx) : messages;
     historySession.value.messages = clean;
   }
 }

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -158,6 +158,14 @@ function sessionFromSummary(summary: SessionSummary, messages: Session['messages
   }
 }
 
+function onHistoryOutlineMessagesLoaded(messages: any[]) {
+  if (historySession.value) {
+    const firstUserIdx = messages.findIndex(m => m.role === 'user');
+    const clean = firstUserIdx > 0 ? messages.slice(firstUserIdx) : messages;
+    historySession.value.messages = clean;
+  }
+}
+
 async function loadHistorySession(sessionId: string, profile?: string | null) {
   const summary = findHistorySession(sessionId)
   const sessionProfile = profile || summary?.profile || null
@@ -849,7 +857,9 @@ function handleBatchDeleteConfirm() {
           :messages="historySession.messages || []"
           :session-id="historySession.id"
           :session-profile="historySession.profile || null"
+          :show-load-all="true"
           @navigate="handleOutlineNavigate"
+          @messages-loaded="onHistoryOutlineMessagesLoaded"
         />
       </div>
     </div>

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -110,7 +110,16 @@ const contextMenuOptions = computed<DropdownOption[]>(() => {
 })
 
 function mapHistoryMessages(messages: HermesMessage[]): Session['messages'] {
-  return messages.map(m => {
+  // Filter out assistant messages with no content — they only carry tool_calls
+  // and mapHistoryMessages doesn't expand tool_calls like mapHermesMessages does.
+  const filtered = messages.filter(m => {
+    if (m.role === 'assistant') {
+      return m.content && m.content.trim() !== ''
+    }
+    return true
+  })
+
+  return filtered.map(m => {
     const msg: Session['messages'][number] = {
       id: String(m.id),
       role: m.role,


### PR DESCRIPTION
## Summary / 摘要

- **限制 Skill 详情面板附件文件列表的最大高度，防止附件过多时挤压 SKILL.md 内容区域**
- **Limit the maximum height of the skill file list in the detail panel to prevent attached files from squeezing the SKILL.md content area when there are many files**

### Problem / 问题
当 Skill 包含较多附件文件时，`.detail-files` 区域设置了 `flex-shrink: 0` 但没有 `max-height`，导致附件列表无限撑大，SKILL.md 的内容被严重挤压，无法正常浏览。

When a Skill has many attached files, the `.detail-files` area had `flex-shrink: 0` without `max-height`, causing the file list to expand indefinitely and squeeze the SKILL.md content area so users couldn't read the skill documentation properly.

### Solution / 解决方案
为 `.detail-files` 添加 `max-height: 30vh` 和 `overflow-y: auto`，使附件列表最多占视口高度的 30%，超出部分内部滚动。

Added `max-height: 30vh` and `overflow-y: auto` to `.detail-files` so the file list takes at most 30% of the viewport height, with internal scrolling for overflow.

### Changed File / 修改文件
- `packages/client/src/components/hermes/skills/SkillDetail.vue` — 2 lines added

## Test plan
- [ ] Open a Skill with many attached files in the skills panel
- [ ] 打开一个附件文件较多的 Skill，确认附件列表可滚动，SKILL.md 内容正常显示
- [ ] Verify SKILL.md content is not squeezed and remains readable
- [ ] 打开附件较少的 Skill，确认无明显变化

🤖 Generated with [Claude Code](https://claude.com/claude-code)