### PR TITLE
fix: strip models/ prefix from Gemini model IDs to prevent 404

### DIFF
--- a/packages/server/src/services/config-helpers.ts
+++ b/packages/server/src/services/config-helpers.ts
@@ -235,6 +235,11 @@ export async function fetchProviderModels(baseUrl: string, apiKey: string, freeO
       return []
     }
     let models = data.data.map(m => m.id)
+    // Gemini returns model IDs with "models/" prefix. Strip to avoid double
+    // prefix when Hermes native adapter constructs .../models/{model}:generateContent
+    if (base.includes('generativelanguage.googleapis.com')) {
+      models = models.map(m => m.startsWith('models/') ? m.slice('models/'.length) : m)
+    }
     if (freeOnly) models = models.filter(m => m.endsWith(':free'))
     return models.sort()
   } catch (err: any) {


### PR DESCRIPTION
## Summary

Google's OpenAI-compatible `/v1/models` endpoint returns model IDs with a `models/` prefix (e.g. `models/gemini-3.1-pro-preview`). Hermes' native Gemini adapter (`GeminiNativeClient`) constructs URLs as `.../models/{model}:generateContent`, so a prefixed model name produces double `models/` → HTTP 404.

## Fix

Strip the `models/` prefix in `fetchProviderModels` when the provider is Gemini.

## Validation

- `npm run harness:check` passed
- `npm run test` 16/16 passed
- `npm run build` client + server passed