### PR TITLE
[codex] redesign chat sidebars

### DIFF
--- a/docs/chat-chain-changes/2026-06-12-pr1518-chat-layout.md
+++ b/docs/chat-chain-changes/2026-06-12-pr1518-chat-layout.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-12
+pr: 1518
+feature: Chat layout and embedded tool panel
+impact: Chat and group chat now use page-level sidebars, while chat embeds workspace and terminal tools beside the conversation without changing chat-run payload semantics.
+---
+
+The global app sidebar remains available on non-chat routes. Chat input, session list rendering, and coding-agent model display were adjusted as UI-only behavior.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "desktop:install": "npm ci --prefix packages/desktop --no-audit --no-fund",
     "desktop:prepare-runtime": "npm --prefix packages/desktop run prepare:runtime",
     "desktop:prepare-python": "npm --prefix packages/desktop run prepare:python",
+    "desktop:dev": "HERMES_WEB_UI_DIR=\"$PWD\" npm --prefix packages/desktop run dev",
     "build:desktop": "npm run build && npm run desktop:install && npm --prefix packages/desktop run dist -- --publish never",
     "build:desktop:mac": "npm run build && npm run desktop:install && npm --prefix packages/desktop run dist -- --mac --publish never",
     "build:desktop:win": "npm run build && npm run desktop:install && npm --prefix packages/desktop run dist -- --win --publish never",

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, computed, watch } from 'vue'
+import { onMounted, onUnmounted, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { darkTheme, NConfigProvider, NMessageProvider, NDialogProvider, NNotificationProvider } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
@@ -22,6 +22,11 @@ const themeOverrides = computed(() => getThemeOverrides(isDark.value, isComic.va
 const naiveTheme = computed(() => isDark.value ? darkTheme : null)
 
 const isLoginPage = computed(() => route.name === 'login')
+const usesPageSidebar = computed(() =>
+  ['hermes.chat', 'hermes.session', 'hermes.groupChat', 'hermes.groupChatRoom'].includes(route.name as string),
+)
+const showAppSidebar = computed(() => !isLoginPage.value && !usesPageSidebar.value)
+const showMobileMenuButton = computed(() => !isLoginPage.value && (showAppSidebar.value || usesPageSidebar.value))
 
 const nodeVersionLow = computed(() => {
   const v = appStore.nodeVersion
@@ -33,10 +38,13 @@ const isDesktopShell = computed(() =>
   (window as typeof window & { hermesDesktop?: { isDesktop?: boolean } }).hermesDesktop?.isDesktop === true,
 )
 
-// Close mobile sidebar on route change
-watch(() => route.path, () => {
-  appStore.closeSidebar()
-})
+function handleMobileMenuClick() {
+  if (usesPageSidebar.value) {
+    window.dispatchEvent(new CustomEvent('hermes:open-page-sidebar'))
+    return
+  }
+  appStore.toggleSidebar()
+}
 
 onMounted(() => {
   if (!isLoginPage.value) {
@@ -63,12 +71,12 @@ useKeyboard()
             <div v-if="nodeVersionLow" class="node-warning-bar">
               {{ t('sidebar.nodeVersionWarning', { version: appStore.nodeVersion }) }}
             </div>
-            <div class="app-layout" :class="{ 'no-sidebar': isLoginPage }">
-              <button v-if="!isLoginPage" class="hamburger-btn" @click="appStore.toggleSidebar">
+            <div class="app-layout" :class="{ 'no-sidebar': isLoginPage || !showAppSidebar }">
+              <button v-if="showMobileMenuButton" class="hamburger-btn" @click="handleMobileMenuClick">
                 <img src="/logo.png" alt="Menu" style="width: 24px; height: 24px;" />
               </button>
-              <div v-if="!isLoginPage && appStore.sidebarOpen" class="mobile-backdrop" @click="appStore.closeSidebar" />
-              <AppSidebar v-if="!isLoginPage" />
+              <div v-if="!isLoginPage && showAppSidebar && appStore.sidebarOpen" class="mobile-backdrop" @click="appStore.closeSidebar" />
+              <AppSidebar v-if="!isLoginPage && showAppSidebar" />
               <main class="app-main">
                 <router-view />
               </main>

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -23,7 +23,7 @@ const naiveTheme = computed(() => isDark.value ? darkTheme : null)
 
 const isLoginPage = computed(() => route.name === 'login')
 const usesPageSidebar = computed(() =>
-  ['hermes.chat', 'hermes.session', 'hermes.groupChat', 'hermes.groupChatRoom'].includes(route.name as string),
+  ['hermes.chat', 'hermes.session', 'hermes.history', 'hermes.historySession', 'hermes.groupChat', 'hermes.groupChatRoom'].includes(route.name as string),
 )
 const showAppSidebar = computed(() => !isLoginPage.value && !usesPageSidebar.value)
 const showMobileMenuButton = computed(() => !isLoginPage.value && (showAppSidebar.value || usesPageSidebar.value))

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1129,16 +1129,15 @@ function isImage(type: string): boolean {
   }
 
   .context-info {
-    flex: 1 1 auto;
     overflow: hidden;
     text-overflow: ellipsis;
     font-size: 10px;
     line-height: 14px;
+    margin-right: -3px;
   }
 
   .context-bar {
     width: 42px;
-    margin-left: -3px;
     flex-shrink: 0;
   }
 }

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1078,6 +1078,8 @@ function isImage(type: string): boolean {
 .context-info {
   font-size: 11px;
   color: $text-muted;
+  min-width: 0;
+  white-space: nowrap;
 
   &.context-warning {
     color: #e8a735;
@@ -1117,6 +1119,25 @@ function isImage(type: string): boolean {
 
   &.context-bar-danger {
     background: linear-gradient(90deg, #c43a2a, #e85d4a);
+  }
+}
+
+@media (max-width: 768px) {
+  .input-top-bar {
+    gap: 5px;
+  }
+
+  .context-info {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 10px;
+    line-height: 14px;
+  }
+
+  .context-bar {
+    width: 42px;
+    flex-shrink: 0;
   }
 }
 

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1133,7 +1133,7 @@ function isImage(type: string): boolean {
     text-overflow: ellipsis;
     font-size: 10px;
     line-height: 14px;
-    margin-right: -3px;
+    margin-right: 10px;
   }
 
   .context-bar {

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1102,6 +1102,7 @@ function isImage(type: string): boolean {
 .context-bar {
   width: 60px;
   height: 4px;
+  margin-left: -4px;
   background: rgba(128, 128, 128, 0.2);
   border-radius: 2px;
   overflow: hidden;
@@ -1137,6 +1138,7 @@ function isImage(type: string): boolean {
 
   .context-bar {
     width: 42px;
+    margin-left: -3px;
     flex-shrink: 0;
   }
 }

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -62,7 +62,6 @@ const showToolPanel = ref(false);
 const activeToolPanel = ref<"files" | "terminal">("files");
 const toolPanelWidth = ref(560);
 const toolResizeStart = ref<{ x: number; width: number } | null>(null);
-const TOOL_PANEL_RESIZE_STEP = 4;
 
 const currentMode = ref<"chat" | "live">("chat");
 
@@ -117,14 +116,8 @@ function handleToolResizeMove(event: PointerEvent) {
   if (!start) return;
   const delta = start.x - event.clientX;
   const maxWidth = toolPanelMaxWidth();
-  const nextWidth = Math.min(
-    Math.max(360, start.width + delta),
-    maxWidth,
-  );
-  const steppedWidth = Math.round(nextWidth / TOOL_PANEL_RESIZE_STEP) * TOOL_PANEL_RESIZE_STEP;
-  if (steppedWidth === toolPanelWidth.value) return;
   toolPanelWidth.value = Math.min(
-    Math.max(360, steppedWidth),
+    Math.max(360, start.width + delta),
     maxWidth,
   );
 }

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2734,7 +2734,7 @@ async function handleSessionModelCustomSubmit() {
   border-left: 1px solid $border-color;
   display: flex;
   min-height: 0;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .chat-tool-resize-handle {
@@ -2801,6 +2801,7 @@ async function handleSessionModelCustomSubmit() {
   flex: 1;
   min-width: 0;
   min-height: 0;
+  overflow: hidden;
 }
 
 .chat-tool-tabs {

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2731,7 +2731,6 @@ async function handleSessionModelCustomSubmit() {
   min-width: 320px;
   max-width: 100%;
   background: $bg-card;
-  border-left: 1px solid $border-color;
   display: flex;
   min-height: 0;
   overflow: hidden;
@@ -2744,7 +2743,7 @@ async function handleSessionModelCustomSubmit() {
   bottom: 0;
   width: 14px;
   cursor: col-resize;
-  z-index: 3;
+  z-index: 20;
 
   &::after {
     content: "";
@@ -2755,6 +2754,7 @@ async function handleSessionModelCustomSubmit() {
     width: 1px;
     background: $border-color;
     transition: background $transition-fast;
+    z-index: 1;
   }
 
   &::before {
@@ -2767,13 +2767,15 @@ async function handleSessionModelCustomSubmit() {
     transform: translateY(-50%);
     border-radius: 999px;
     background:
+      linear-gradient($border-color, $border-color) center / 1px 100% no-repeat,
       linear-gradient($text-muted, $text-muted) center 9px / 2px 2px no-repeat,
       linear-gradient($text-muted, $text-muted) center 17px / 2px 2px no-repeat,
       linear-gradient($text-muted, $text-muted) center 25px / 2px 2px no-repeat,
-      $bg-card;
+      rgba($bg-card, 0.92);
     border: 1px solid $border-color;
     opacity: 0.78;
     transition: all $transition-fast;
+    z-index: 2;
   }
 
   &:hover::after {
@@ -2781,6 +2783,12 @@ async function handleSessionModelCustomSubmit() {
   }
 
   &:hover::before {
+    background:
+      linear-gradient(var(--accent-primary), var(--accent-primary)) center / 1px 100% no-repeat,
+      linear-gradient($text-muted, $text-muted) center 9px / 2px 2px no-repeat,
+      linear-gradient($text-muted, $text-muted) center 17px / 2px 2px no-repeat,
+      linear-gradient($text-muted, $text-muted) center 25px / 2px 2px no-repeat,
+      rgba($bg-card, 0.96);
     border-color: var(--accent-primary);
     opacity: 1;
   }

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -59,9 +59,10 @@ const chatContentWrapperRef = ref<HTMLElement | null>(null);
 const showVersionManagement = ref(false);
 const showChangelog = ref(false);
 const showToolPanel = ref(false);
-const activeToolPanel = ref<"files" | "terminal">("terminal");
+const activeToolPanel = ref<"files" | "terminal">("files");
 const toolPanelWidth = ref(560);
 const toolResizeStart = ref<{ x: number; width: number } | null>(null);
+const TOOL_PANEL_RESIZE_STEP = 4;
 
 const currentMode = ref<"chat" | "live">("chat");
 
@@ -116,8 +117,14 @@ function handleToolResizeMove(event: PointerEvent) {
   if (!start) return;
   const delta = start.x - event.clientX;
   const maxWidth = toolPanelMaxWidth();
-  toolPanelWidth.value = Math.min(
+  const nextWidth = Math.min(
     Math.max(360, start.width + delta),
+    maxWidth,
+  );
+  const steppedWidth = Math.round(nextWidth / TOOL_PANEL_RESIZE_STEP) * TOOL_PANEL_RESIZE_STEP;
+  if (steppedWidth === toolPanelWidth.value) return;
+  toolPanelWidth.value = Math.min(
+    Math.max(360, steppedWidth),
     maxWidth,
   );
 }

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -31,8 +31,9 @@ import ChatInput from "./ChatInput.vue";
 import ConversationMonitorPane from "./ConversationMonitorPane.vue";
 import MessageList from "./MessageList.vue";
 import SessionListItem from "./SessionListItem.vue";
-import DrawerPanel from "./DrawerPanel.vue";
 import OutlinePanel from "./OutlinePanel.vue";
+import FilesPanel from "./FilesPanel.vue";
+import TerminalPanel from "./TerminalPanel.vue";
 import { useSessionSearch } from "@/composables/useSessionSearch";
 import ProfileSelector from "@/components/layout/ProfileSelector.vue";
 import ModelSelector from "@/components/layout/ModelSelector.vue";
@@ -52,12 +53,15 @@ const { t } = useI18n();
 const { openSessionSearch } = useSessionSearch();
 const currentUsername = computed(() => getStoredUsername());
 
-const showDrawer = ref(false);
-const drawerActiveTab = ref<"terminal" | "files">("files");
 const showOutline = ref(false);
 const messageListRef = ref<InstanceType<typeof MessageList> | null>(null);
+const chatContentWrapperRef = ref<HTMLElement | null>(null);
 const showVersionManagement = ref(false);
 const showChangelog = ref(false);
+const showToolPanel = ref(false);
+const activeToolPanel = ref<"files" | "terminal">("terminal");
+const toolPanelWidth = ref(560);
+const toolResizeStart = ref<{ x: number; width: number } | null>(null);
 
 const currentMode = ref<"chat" | "live">("chat");
 
@@ -82,6 +86,9 @@ const isMobile = ref(false);
 const isDesktopShell = computed(() =>
   (window as typeof window & { hermesDesktop?: { isDesktop?: boolean } }).hermesDesktop?.isDesktop === true,
 );
+const toolPanelStyle = computed(() => ({
+  width: isMobile.value ? "100%" : `${toolPanelWidth.value}px`,
+}));
 
 function sessionHref(sessionId: string) {
   return router.resolve({
@@ -97,6 +104,44 @@ function openSessionInNewTab(sessionId: string) {
 
 function handleOutlineNavigate(target: { messageId: string; anchorId: string }) {
   messageListRef.value?.scrollToAnchor(target.messageId, target.anchorId);
+}
+
+function toolPanelMaxWidth() {
+  const available = chatContentWrapperRef.value?.clientWidth || window.innerWidth;
+  return Math.max(320, available - 120);
+}
+
+function handleToolResizeMove(event: PointerEvent) {
+  const start = toolResizeStart.value;
+  if (!start) return;
+  const delta = start.x - event.clientX;
+  const maxWidth = toolPanelMaxWidth();
+  toolPanelWidth.value = Math.min(
+    Math.max(360, start.width + delta),
+    maxWidth,
+  );
+}
+
+function stopToolResize() {
+  if (!toolResizeStart.value) return;
+  toolResizeStart.value = null;
+  window.removeEventListener("pointermove", handleToolResizeMove);
+  window.removeEventListener("pointerup", stopToolResize);
+  document.body.style.userSelect = "";
+  document.body.style.cursor = "";
+}
+
+function startToolResize(event: PointerEvent) {
+  if (isMobile.value) return;
+  event.preventDefault();
+  toolResizeStart.value = {
+    x: event.clientX,
+    width: toolPanelWidth.value,
+  };
+  window.addEventListener("pointermove", handleToolResizeMove);
+  window.addEventListener("pointerup", stopToolResize);
+  document.body.style.userSelect = "none";
+  document.body.style.cursor = "col-resize";
 }
 
 async function handleSessionClick(sessionId: string) {
@@ -131,6 +176,7 @@ onMounted(() => {
 onUnmounted(() => {
   mobileQuery?.removeEventListener("change", handleMobileChange);
   window.removeEventListener("hermes:open-page-sidebar", openPageSidebar);
+  stopToolResize();
 });
 const showRenameModal = ref(false);
 const renameValue = ref("");
@@ -1597,6 +1643,34 @@ async function handleSessionModelCustomSubmit() {
             <NTooltip trigger="hover">
               <template #trigger>
                 <NButton
+                  class="header-tool-toggle"
+                  :class="{ active: showToolPanel }"
+                  quaternary
+                  size="small"
+                  @click="showToolPanel = !showToolPanel"
+                  circle
+                >
+                  <template #icon>
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                    >
+                      <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                      <line x1="9" y1="3" x2="9" y2="21" />
+                      <line x1="15" y1="3" x2="15" y2="21" />
+                    </svg>
+                  </template>
+                </NButton>
+              </template>
+              {{ t("drawer.files") }} / {{ t("drawer.terminal") }}
+            </NTooltip>
+            <NTooltip trigger="hover">
+              <template #trigger>
+                <NButton
                   quaternary
                   size="small"
                   @click="showOutline = !showOutline"
@@ -1681,7 +1755,7 @@ async function handleSessionModelCustomSubmit() {
       </header>
 
       <template v-if="currentMode === 'chat'">
-        <div class="chat-content-wrapper">
+        <div ref="chatContentWrapperRef" class="chat-content-wrapper">
           <div class="chat-main-content">
             <MessageList ref="messageListRef" />
           </div>
@@ -1690,6 +1764,47 @@ async function handleSessionModelCustomSubmit() {
             :messages="chatStore.messages"
             @navigate="handleOutlineNavigate"
           />
+          <aside
+            v-if="showToolPanel"
+            class="chat-tool-panel"
+            :style="toolPanelStyle"
+          >
+            <div
+              class="chat-tool-resize-handle"
+              @pointerdown="startToolResize"
+            />
+            <div class="chat-tool-panel-inner">
+              <div class="chat-tool-tabs" role="tablist">
+                <button
+                  class="chat-tool-tab"
+                  :class="{ active: activeToolPanel === 'files' }"
+                  type="button"
+                  role="tab"
+                  :aria-selected="activeToolPanel === 'files'"
+                  @click="activeToolPanel = 'files'"
+                >
+                  {{ t("drawer.files") }}
+                </button>
+                <button
+                  class="chat-tool-tab"
+                  :class="{ active: activeToolPanel === 'terminal' }"
+                  type="button"
+                  role="tab"
+                  :aria-selected="activeToolPanel === 'terminal'"
+                  @click="activeToolPanel = 'terminal'"
+                >
+                  {{ t("drawer.terminal") }}
+                </button>
+              </div>
+              <div class="chat-tool-content">
+                <FilesPanel v-show="activeToolPanel === 'files'" />
+                <TerminalPanel
+                  v-show="activeToolPanel === 'terminal'"
+                  :visible="showToolPanel && activeToolPanel === 'terminal'"
+                />
+              </div>
+            </div>
+          </aside>
         </div>
         <ChatInput />
       </template>
@@ -1698,26 +1813,6 @@ async function handleSessionModelCustomSubmit() {
         :human-only="sessionBrowserPrefsStore.humanOnly"
       />
     </div>
-
-    <!-- Floating drawer button -->
-    <div class="drawer-button-wrapper">
-      <div class="drawer-button" @click="showDrawer = true">
-        <svg
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-        >
-          <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-          <line x1="9" y1="3" x2="9" y2="21" />
-          <line x1="15" y1="3" x2="15" y2="21" />
-        </svg>
-      </div>
-    </div>
-
-    <DrawerPanel v-model:show="showDrawer" :active-tab="drawerActiveTab" />
   </div>
 </template>
 
@@ -2625,124 +2720,115 @@ async function handleSessionModelCustomSubmit() {
   cursor: default;
 }
 
-// ─── Drawer button ─────────────────────────────────────────────
+.header-tool-toggle.active {
+  color: var(--accent-primary);
+  background: rgba(var(--accent-primary-rgb), 0.1);
+}
 
-.drawer-button-wrapper {
+.chat-tool-panel {
   position: absolute;
-  right: 16px;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 100;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 70;
+  min-width: 320px;
+  max-width: 100%;
   background: $bg-card;
-  border-radius: 50%;
-  box-shadow:
-    0 0 10px rgba(255, 107, 107, 0.4),
-    0 0 20px rgba(255, 107, 107, 0.2);
-  animation: rainbow-glow 8s linear infinite;
-  transition: all $transition-fast;
+  border-left: 1px solid $border-color;
+  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.12);
+  display: flex;
+  min-height: 0;
+  overflow: hidden;
+}
 
-  &:hover {
-    animation-play-state: paused;
-    box-shadow:
-      0 0 15px rgba(255, 107, 107, 0.6),
-      0 0 30px rgba(255, 107, 107, 0.3);
+.chat-tool-resize-handle {
+  position: absolute;
+  left: -4px;
+  top: 0;
+  bottom: 0;
+  width: 8px;
+  cursor: col-resize;
+  z-index: 3;
+
+  &::after {
+    content: "";
+    position: absolute;
+    left: 3px;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: transparent;
+    transition: background $transition-fast;
+  }
+
+  &:hover::after {
+    background: var(--accent-primary);
   }
 }
 
-.drawer-button {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background: rgba(var(--accent-primary-rgb), 0.1);
+.chat-tool-panel-inner {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+.chat-tool-tabs {
   display: flex;
   align-items: center;
-  justify-content: center;
+  flex-shrink: 0;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid $border-color;
+}
+
+.chat-tool-tab {
+  height: 30px;
+  padding: 0 12px;
+  border: none;
+  border-radius: $radius-sm;
+  background: transparent;
+  color: $text-secondary;
   cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
   transition: all $transition-fast;
 
-  svg {
-    width: 18px;
-    height: 18px;
-    color: var(--accent-primary);
+  &:hover {
+    color: $text-primary;
+    background: rgba(var(--accent-primary-rgb), 0.06);
   }
 
-  &:hover {
-    transform: scale(1.1);
+  &.active {
+    color: var(--accent-primary);
+    background: rgba(var(--accent-primary-rgb), 0.12);
   }
 }
 
-@keyframes rainbow-glow {
-  0% {
-    box-shadow:
-      0 0 0 2px #ff6b6b,
-      0 0 10px rgba(255, 107, 107, 0.4),
-      0 0 20px rgba(255, 107, 107, 0.2);
-    border-color: #ff6b6b;
-    color: #ff6b6b;
-  }
-  16.66% {
-    box-shadow:
-      0 0 0 2px #feca57,
-      0 0 10px rgba(254, 202, 87, 0.4),
-      0 0 20px rgba(254, 202, 87, 0.2);
-    border-color: #feca57;
-    color: #feca57;
-  }
-  33.33% {
-    box-shadow:
-      0 0 0 2px #48dbfb,
-      0 0 10px rgba(72, 219, 251, 0.4),
-      0 0 20px rgba(72, 219, 251, 0.2);
-    border-color: #48dbfb;
-    color: #48dbfb;
-  }
-  50% {
-    box-shadow:
-      0 0 0 2px #ff9ff3,
-      0 0 10px rgba(255, 159, 243, 0.4),
-      0 0 20px rgba(255, 159, 243, 0.2);
-    border-color: #ff9ff3;
-    color: #ff9ff3;
-  }
-  66.66% {
-    box-shadow:
-      0 0 0 2px #54a0ff,
-      0 0 10px rgba(84, 160, 255, 0.4),
-      0 0 20px rgba(84, 160, 255, 0.2);
-    border-color: #54a0ff;
-    color: #54a0ff;
-  }
-  83.33% {
-    box-shadow:
-      0 0 0 2px #5f27cd,
-      0 0 10px rgba(95, 39, 205, 0.4),
-      0 0 20px rgba(95, 39, 205, 0.2);
-    border-color: #5f27cd;
-    color: #5f27cd;
-  }
-  100% {
-    box-shadow:
-      0 0 0 2px #ff6b6b,
-      0 0 10px rgba(255, 107, 107, 0.4),
-      0 0 20px rgba(255, 107, 107, 0.2);
-    border-color: #ff6b6b;
-    color: #ff6b6b;
-  }
+.chat-tool-content {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.chat-tool-content > * {
+  height: 100%;
+  min-height: 0;
 }
 
 @media (max-width: $breakpoint-mobile) {
-  .drawer-button-wrapper {
-    right: 12px;
+  .chat-tool-panel {
+    left: 0;
+    width: 100% !important;
+    min-width: 0;
+    border-left: none;
+    box-shadow: none;
   }
 
-  .drawer-button {
-    width: 36px;
-    height: 36px;
-
-    svg {
-      width: 16px;
-      height: 16px;
-    }
+  .chat-tool-resize-handle {
+    display: none;
   }
 }
 </style>

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -241,6 +241,10 @@ const activeSessionModelLabel = computed(() => {
   return appStore.displayModelName(session.model, session.provider);
 });
 
+const isActiveSessionCodingAgent = computed(() =>
+  chatStore.activeSession?.source === "coding_agent",
+);
+
 const headerTitle = computed(() =>
   currentMode.value === "live"
     ? t("chat.liveSessions")
@@ -913,6 +917,7 @@ function handleHeaderModelClick() {
     openNewChatModal();
     return;
   }
+  if (isActiveSessionCodingAgent.value) return;
   openSessionModelModal(sessionId);
 }
 
@@ -1721,6 +1726,7 @@ async function handleSessionModelCustomSubmit() {
             </NTooltip>
             <NButton
               class="header-model-button"
+              :class="{ 'header-model-button--readonly': isActiveSessionCodingAgent }"
               size="small"
               :circle="isMobile"
               :title="activeSessionModelLabel"
@@ -2672,6 +2678,15 @@ async function handleSessionModelCustomSubmit() {
 
 .header-model-button {
   max-width: 220px;
+}
+
+.header-model-button--readonly {
+  cursor: default;
+}
+
+.header-model-button--readonly :deep(.n-button__content),
+.header-model-button--readonly :deep(.n-button__icon) {
+  cursor: default;
 }
 
 .header-model-button :deep(.n-button__content) {

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -16,6 +16,7 @@ import {
   NSelect,
   NTooltip,
   NPopconfirm,
+  NPopover,
   NRadioButton,
   NRadioGroup,
   useMessage,
@@ -32,6 +33,14 @@ import MessageList from "./MessageList.vue";
 import SessionListItem from "./SessionListItem.vue";
 import DrawerPanel from "./DrawerPanel.vue";
 import OutlinePanel from "./OutlinePanel.vue";
+import { useSessionSearch } from "@/composables/useSessionSearch";
+import ProfileSelector from "@/components/layout/ProfileSelector.vue";
+import ModelSelector from "@/components/layout/ModelSelector.vue";
+import LanguageSwitch from "@/components/layout/LanguageSwitch.vue";
+import ThemeSwitch from "@/components/layout/ThemeSwitch.vue";
+import VersionManagementModal from "@/components/layout/VersionManagementModal.vue";
+import { changelog } from "@/data/changelog";
+import { getStoredUsername } from "@/api/client";
 
 const chatStore = useChatStore();
 const appStore = useAppStore();
@@ -40,11 +49,15 @@ const sessionBrowserPrefsStore = useSessionBrowserPrefsStore();
 const router = useRouter();
 const message = useMessage();
 const { t } = useI18n();
+const { openSessionSearch } = useSessionSearch();
+const currentUsername = computed(() => getStoredUsername());
 
 const showDrawer = ref(false);
 const drawerActiveTab = ref<"terminal" | "files">("files");
 const showOutline = ref(false);
 const messageListRef = ref<InstanceType<typeof MessageList> | null>(null);
+const showVersionManagement = ref(false);
+const showChangelog = ref(false);
 
 const currentMode = ref<"chat" | "live">("chat");
 
@@ -66,6 +79,9 @@ const showSessions = ref(
 );
 let mobileQuery: MediaQueryList | null = null;
 const isMobile = ref(false);
+const isDesktopShell = computed(() =>
+  (window as typeof window & { hermesDesktop?: { isDesktop?: boolean } }).hermesDesktop?.isDesktop === true,
+);
 
 function sessionHref(sessionId: string) {
   return router.resolve({
@@ -98,10 +114,15 @@ function handleMobileChange(e: MediaQueryListEvent | MediaQueryList) {
   }
 }
 
+function openPageSidebar() {
+  showSessions.value = true;
+}
+
 onMounted(() => {
   mobileQuery = window.matchMedia("(max-width: 768px)");
   handleMobileChange(mobileQuery);
   mobileQuery.addEventListener("change", handleMobileChange);
+  window.addEventListener("hermes:open-page-sidebar", openPageSidebar);
   if (profilesStore.profiles.length === 0) {
     void profilesStore.fetchProfiles();
   }
@@ -109,6 +130,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   mobileQuery?.removeEventListener("change", handleMobileChange);
+  window.removeEventListener("hermes:open-page-sidebar", openPageSidebar);
 });
 const showRenameModal = ref(false);
 const renameValue = ref("");
@@ -166,6 +188,12 @@ watch(
 const activeSessionTitle = computed(
   () => chatStore.activeSession?.title || t("chat.newChat"),
 );
+
+const activeSessionModelLabel = computed(() => {
+  const session = chatStore.activeSession;
+  if (!session?.model) return t("models.selectModel");
+  return appStore.displayModelName(session.model, session.provider);
+});
 
 const headerTitle = computed(() =>
   currentMode.value === "live"
@@ -615,6 +643,40 @@ const contextMenuOptions = computed(() => {
   return options
 });
 
+async function handleUpdate() {
+  const ok = await appStore.doUpdate();
+  if (ok) {
+    message.success(t("sidebar.updateSuccess"), { duration: 5000 });
+  } else {
+    message.error(t("sidebar.updateFailed"));
+  }
+}
+
+function handleReloadClient() {
+  appStore.reloadClient();
+}
+
+function openVersionManagement() {
+  showVersionManagement.value = true;
+}
+
+function openChangelog() {
+  showChangelog.value = true;
+}
+
+function openSettingsPage() {
+  router.push({ name: "hermes.settings" });
+}
+
+function openGroupChatPage() {
+  router.push({ name: "hermes.groupChat" });
+}
+
+function handleLogout() {
+  localStorage.clear();
+  window.location.reload();
+}
+
 function handleContextMenu(e: MouseEvent, sessionId: string) {
   e.preventDefault();
   contextSessionId.value = sessionId;
@@ -783,7 +845,9 @@ async function openSessionModelModal(sessionId: string) {
   if (appStore.modelGroups.length === 0 && appStore.profileModelGroups.length === 0) {
     await appStore.loadModels();
   }
-  const session = chatStore.sessions.find((s) => s.id === sessionId);
+  const session =
+    chatStore.sessions.find((s) => s.id === sessionId) ||
+    (chatStore.activeSession?.id === sessionId ? chatStore.activeSession : undefined);
   const defaults = session?.profile
     ? getDefaultModelForProfile(session.profile)
     : { provider: "", model: "" };
@@ -795,6 +859,15 @@ async function openSessionModelModal(sessionId: string) {
   sessionModelCustomInput.value = "";
   sessionModelCollapsedGroups.value = {};
   showSessionModelModal.value = true;
+}
+
+function handleHeaderModelClick() {
+  const sessionId = chatStore.activeSession?.id;
+  if (!sessionId) {
+    openNewChatModal();
+    return;
+  }
+  openSessionModelModal(sessionId);
 }
 
 function isSessionModelGroupCollapsed(provider: string) {
@@ -852,101 +925,63 @@ async function handleSessionModelCustomSubmit() {
       class="session-list"
       :class="{ collapsed: !showSessions }"
     >
-      <div class="session-list-header">
-        <span v-if="showSessions" class="session-list-title">{{
-          t("chat.webUiSessions")
-        }}</span>
-        <div class="session-list-actions">
-          <button class="session-close-btn" @click="showSessions = false">
+      <div v-if="showSessions" class="page-sidebar-top">
+        <div class="page-sidebar-tabs" role="tablist" aria-label="Chat actions">
+          <button class="page-sidebar-tab" type="button" @click="openNewChatModal">
             <svg
-              width="14"
-              height="14"
+              width="15"
+              height="15"
               viewBox="0 0 24 24"
               fill="none"
               stroke="currentColor"
               stroke-width="2"
             >
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
             </svg>
+            <span>{{ t("chat.newChat") }}</span>
           </button>
-          <NButton
-            v-if="!isBatchMode"
-            quaternary
-            size="tiny"
-            @click="toggleBatchMode"
-            :title="t('chat.toggleBatchMode')"
-          >
-            <template #icon>
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <path d="M9 11l3 3L22 4" />
-                <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
-              </svg>
-            </template>
-          </NButton>
-          <NButton
-            v-if="isBatchMode"
-            quaternary
-            size="tiny"
-            @click="selectAllSessions"
-            :disabled="!canSelectAll || isBatchDeleting"
-            :title="t('chat.selectAll')"
-          >
-            <template #icon>
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <path d="M9 11l3 3L22 4" />
-                <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
-              </svg>
-            </template>
-          </NButton>
-          <NPopconfirm
-            v-if="isBatchMode && selectedCount > 0"
-            v-model:show="showBatchDeleteConfirm"
-            :positive-button-props="{ loading: isBatchDeleting, disabled: isBatchDeleting }"
-            :negative-button-props="{ disabled: isBatchDeleting }"
-            @positive-click="handleBatchDeleteConfirm"
-          >
-            <template #trigger>
-              <NButton quaternary size="tiny" type="error" :loading="isBatchDeleting" :disabled="isBatchDeleting">
-                <template #icon>
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                  >
-                    <polyline points="3 6 5 6 21 6" />
-                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-                  </svg>
-                </template>
-              </NButton>
-            </template>
-            {{ t('chat.confirmBatchDelete', { count: selectedCount }) }}
-          </NPopconfirm>
-          <NButton
-            v-if="isBatchMode"
-            quaternary
-            size="tiny"
-            @click="toggleBatchMode"
-            :disabled="isBatchDeleting"
-          >
-            <template #icon>
+          <button class="page-sidebar-tab" type="button" @click="openSessionSearch">
+            <svg
+              width="15"
+              height="15"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+            >
+              <circle cx="11" cy="11" r="7" />
+              <path d="m20 20-3.5-3.5" />
+            </svg>
+            <span>{{ t("sidebar.search") }}</span>
+          </button>
+          <button class="page-sidebar-tab" type="button">
+            <svg
+              width="15"
+              height="15"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+            >
+              <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
+              <polyline points="15 3 21 3 21 9" />
+              <line x1="10" y1="14" x2="21" y2="3" />
+            </svg>
+            <span>{{ t("sidebar.apiRelay") }}</span>
+          </button>
+        </div>
+        <div class="session-list-toolbar">
+          <NSelect
+            class="session-profile-filter"
+            :value="sessionProfileFilter || '__all__'"
+            :options="profileFilterOptions"
+            size="small"
+            :loading="profilesStore.loading"
+            @update:value="handleProfileFilterChange"
+          />
+          <div class="session-list-actions">
+            <button class="session-close-btn" @click="showSessions = false">
               <svg
                 width="14"
                 height="14"
@@ -958,33 +993,118 @@ async function handleSessionModelCustomSubmit() {
                 <line x1="18" y1="6" x2="6" y2="18" />
                 <line x1="6" y1="6" x2="18" y2="18" />
               </svg>
-            </template>
-          </NButton>
-          <NButton quaternary size="tiny" circle @click="openNewChatModal">
-            <template #icon>
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <line x1="12" y1="5" x2="12" y2="19" />
-                <line x1="5" y1="12" x2="19" y2="12" />
-              </svg>
-            </template>
-          </NButton>
+            </button>
+            <NButton
+              v-if="!isBatchMode"
+              quaternary
+              size="tiny"
+              @click="toggleBatchMode"
+              :title="t('chat.toggleBatchMode')"
+            >
+              <template #icon>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path d="M9 11l3 3L22 4" />
+                  <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+                </svg>
+              </template>
+            </NButton>
+            <NButton
+              v-if="isBatchMode"
+              quaternary
+              size="tiny"
+              @click="selectAllSessions"
+              :disabled="!canSelectAll || isBatchDeleting"
+              :title="t('chat.selectAll')"
+            >
+              <template #icon>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path d="M9 11l3 3L22 4" />
+                  <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+                </svg>
+              </template>
+            </NButton>
+            <NPopconfirm
+              v-if="isBatchMode && selectedCount > 0"
+              v-model:show="showBatchDeleteConfirm"
+              :positive-button-props="{ loading: isBatchDeleting, disabled: isBatchDeleting }"
+              :negative-button-props="{ disabled: isBatchDeleting }"
+              @positive-click="handleBatchDeleteConfirm"
+            >
+              <template #trigger>
+                <NButton quaternary size="tiny" type="error" :loading="isBatchDeleting" :disabled="isBatchDeleting">
+                  <template #icon>
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
+                      <polyline points="3 6 5 6 21 6" />
+                      <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                    </svg>
+                  </template>
+                </NButton>
+              </template>
+              {{ t('chat.confirmBatchDelete', { count: selectedCount }) }}
+            </NPopconfirm>
+            <NButton
+              v-if="isBatchMode"
+              quaternary
+              size="tiny"
+              @click="toggleBatchMode"
+              :disabled="isBatchDeleting"
+            >
+              <template #icon>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </template>
+            </NButton>
+          </div>
         </div>
-      </div>
-      <div v-if="showSessions" class="session-profile-filter">
-        <NSelect
-          :value="sessionProfileFilter || '__all__'"
-          :options="profileFilterOptions"
-          size="small"
-          :loading="profilesStore.loading"
-          @update:value="handleProfileFilterChange"
-        />
+        <div class="conversation-switch" role="tablist" aria-label="Conversation type">
+          <button
+            class="conversation-switch-tab active"
+            type="button"
+            role="tab"
+            aria-selected="true"
+          >
+            {{ t("sidebar.singleChat") }}
+          </button>
+          <button
+            class="conversation-switch-tab"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            @click="openGroupChatPage"
+          >
+            {{ t("sidebar.groupChat") }}
+          </button>
+        </div>
       </div>
       <div v-if="showSessions" class="session-items">
         <div
@@ -1044,6 +1164,154 @@ async function handleSessionModelCustomSubmit() {
           @delete="handleDeleteSession(s.id)"
           @toggle-select="toggleSessionSelection(s)"
         />
+      </div>
+      <div v-if="showSessions" class="page-sidebar-bottom">
+        <NPopover
+          trigger="click"
+          placement="top-start"
+          :show-arrow="false"
+          raw
+        >
+          <template #trigger>
+            <button class="page-sidebar-menu-btn" type="button">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="3" />
+                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+              </svg>
+              <span>{{ t("sidebar.settings") }}</span>
+            </button>
+          </template>
+          <div class="page-sidebar-popover">
+            <ProfileSelector />
+            <ModelSelector />
+            <div class="page-sidebar-popover-row">
+              <div
+                class="status-indicator"
+                :class="{
+                  connected: appStore.connected,
+                  disconnected: !appStore.connected,
+                }"
+              >
+                <span class="status-dot"></span>
+                <span class="status-text">{{
+                  appStore.connected
+                    ? t("sidebar.connected")
+                    : t("sidebar.disconnected")
+                }}</span>
+              </div>
+              <LanguageSwitch />
+            </div>
+            <div class="page-sidebar-version-row">
+              <div class="page-sidebar-version-links">
+                <a class="page-sidebar-link" href="https://github.com/EKKOLearnAI/hermes-web-ui" target="_blank" rel="noopener noreferrer" title="GitHub">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+                </a>
+                <a class="page-sidebar-link" href="https://hermes-studio.ai/" target="_blank" rel="noopener noreferrer" title="Website">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                </a>
+              </div>
+              <span
+                class="page-sidebar-version-text"
+                role="button"
+                tabindex="0"
+                @click="openChangelog"
+                @keydown.enter="openChangelog"
+                @keydown.space.prevent="openChangelog"
+              >
+                Studio v{{ appStore.serverVersion || "0.1.0" }}
+              </span>
+              <ThemeSwitch />
+            </div>
+            <button class="page-sidebar-nav-btn" type="button" @click="openSettingsPage">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <line x1="4" y1="6" x2="20" y2="6" />
+                <line x1="4" y1="12" x2="20" y2="12" />
+                <line x1="4" y1="18" x2="20" y2="18" />
+              </svg>
+              <span>{{ t("sidebar.settings") }}</span>
+            </button>
+            <button class="page-sidebar-logout-btn" type="button" @click="handleLogout">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                <polyline points="16 17 21 12 16 7" />
+                <line x1="21" y1="12" x2="9" y2="12" />
+              </svg>
+              <span>{{ t("sidebar.logout") }}</span>
+              <span v-if="currentUsername" class="page-sidebar-logout-user" :title="currentUsername">
+                {{ currentUsername }}
+              </span>
+            </button>
+            <NButton
+              v-if="isDesktopShell"
+              type="primary"
+              size="tiny"
+              block
+              @click="openVersionManagement"
+            >
+              {{ t("sidebar.versionManagement") }}
+            </NButton>
+            <NButton
+              v-if="appStore.clientOutdated"
+              type="warning"
+              size="tiny"
+              block
+              @click="handleReloadClient"
+            >
+              {{ t("sidebar.reloadClientVersion", { version: appStore.serverVersion }) }}
+            </NButton>
+            <NButton
+              v-if="appStore.updateAvailable"
+              type="primary"
+              size="tiny"
+              block
+              :loading="appStore.updating"
+              @click="handleUpdate"
+            >
+              {{ appStore.updating ? t("sidebar.updating") : t("sidebar.updateVersion", { version: appStore.latestVersion }) }}
+            </NButton>
+          </div>
+        </NPopover>
+        <NModal v-model:show="showChangelog" preset="dialog" :title="t('sidebar.changelog')" style="width: 520px;">
+          <div class="changelog-list">
+            <div v-for="entry in changelog" :key="entry.version" class="changelog-version-block">
+              <div class="changelog-version-header">
+                <span class="changelog-version-tag">v{{ entry.version }}</span>
+                <span class="changelog-date">{{ entry.date }}</span>
+              </div>
+              <ul class="changelog-changes">
+                <li v-for="(change, idx) in entry.changes" :key="idx">{{ t(change) }}</li>
+              </ul>
+            </div>
+          </div>
+        </NModal>
+        <VersionManagementModal v-if="isDesktopShell" v-model:show="showVersionManagement" />
       </div>
     </aside>
 
@@ -1289,6 +1557,7 @@ async function handleSessionModelCustomSubmit() {
         <div class="header-left">
           <NButton
             v-if="currentMode === 'chat'"
+            class="header-sidebar-toggle"
             quaternary
             size="small"
             @click="showSessions = !showSessions"
@@ -1376,7 +1645,13 @@ async function handleSessionModelCustomSubmit() {
               </template>
               {{ t("chat.copySessionId") }}
             </NTooltip>
-            <NButton size="small" :circle="isMobile" @click="openNewChatModal">
+            <NButton
+              class="header-model-button"
+              size="small"
+              :circle="isMobile"
+              :title="activeSessionModelLabel"
+              @click="handleHeaderModelClick"
+            >
               <template #icon>
                 <svg
                   width="14"
@@ -1384,13 +1659,22 @@ async function handleSessionModelCustomSubmit() {
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
-                  stroke-width="2"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 >
-                  <line x1="12" y1="5" x2="12" y2="19" />
-                  <line x1="5" y1="12" x2="19" y2="12" />
+                  <circle cx="12" cy="12" r="3" />
+                  <path d="M12 1v4" />
+                  <path d="M12 19v4" />
+                  <path d="M1 12h4" />
+                  <path d="M19 12h4" />
+                  <path d="M4.22 4.22l2.83 2.83" />
+                  <path d="M16.95 16.95l2.83 2.83" />
+                  <path d="M4.22 19.78l2.83-2.83" />
+                  <path d="M16.95 7.05l2.83-2.83" />
                 </svg>
               </template>
-              <template v-if="!isMobile">{{ t("chat.newChat") }}</template>
+              <template v-if="!isMobile">{{ activeSessionModelLabel }}</template>
             </NButton>
           </template>
         </div>
@@ -1630,7 +1914,7 @@ async function handleSessionModelCustomSubmit() {
 }
 
 .session-list {
-  width: 220px;
+  width: $sidebar-width;
   border-right: 1px solid $border-color;
   display: flex;
   flex-direction: column;
@@ -1655,7 +1939,7 @@ async function handleSessionModelCustomSubmit() {
     z-index: 120;
     background: $bg-card;
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
-    width: 280px;
+    width: $sidebar-width;
 
     &.collapsed {
       transform: translateX(-100%);
@@ -1685,13 +1969,61 @@ async function handleSessionModelCustomSubmit() {
   }
 }
 
-.session-list-header {
+.page-sidebar-top {
+  flex-shrink: 0;
+  padding: 12px;
+  border-bottom: 1px solid $border-color;
+}
+
+.page-sidebar-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.page-sidebar-tab {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  border: none;
+  border-radius: $radius-sm;
+  background: transparent;
+  color: $text-secondary;
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 7px 10px;
+  cursor: pointer;
+  transition:
+    background-color $transition-fast,
+    color $transition-fast;
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 13px;
+    line-height: 18px;
+  }
+
+  &:hover {
+    background: rgba(var(--accent-primary-rgb), 0.06);
+    color: $text-primary;
+  }
+}
+
+.session-list-toolbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 12px;
-  flex-shrink: 0;
-  min-height: 0;
+  gap: 8px;
+  margin-top: 12px;
 }
 
 .session-list-actions {
@@ -1737,7 +2069,43 @@ async function handleSessionModelCustomSubmit() {
 }
 
 .session-profile-filter {
-  margin: 0 8px 10px;
+  min-width: 0;
+  flex: 1;
+}
+
+.conversation-switch {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2px;
+  margin-top: 8px;
+  padding: 2px;
+  border-radius: $radius-sm;
+  background: rgba(var(--accent-primary-rgb), 0.05);
+}
+
+.conversation-switch-tab {
+  min-width: 0;
+  height: 28px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: $text-secondary;
+  font-size: 12px;
+  line-height: 16px;
+  cursor: pointer;
+  transition:
+    background-color $transition-fast,
+    color $transition-fast;
+
+  &:hover {
+    color: $text-primary;
+  }
+
+  &.active {
+    background: $bg-card;
+    color: $text-primary;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  }
 }
 
 .new-chat-form {
@@ -1849,7 +2217,284 @@ async function handleSessionModelCustomSubmit() {
 .session-items {
   flex: 1;
   overflow-y: auto;
-  padding: 0 6px 12px;
+  padding: 10px 6px 12px;
+}
+
+.page-sidebar-bottom {
+  flex-shrink: 0;
+  padding: 10px 12px;
+}
+
+.page-sidebar-menu-btn {
+  width: 100%;
+  min-width: 0;
+  height: 36px;
+  border: none;
+  border-radius: $radius-sm;
+  background: transparent;
+  color: $text-secondary;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  cursor: pointer;
+  transition:
+    background-color $transition-fast,
+    color $transition-fast;
+
+  &:hover {
+    background: rgba(var(--accent-primary-rgb), 0.06);
+    color: $text-primary;
+  }
+}
+
+.page-sidebar-menu-btn span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.page-sidebar-popover {
+  width: $sidebar-width;
+  padding: 12px;
+  border: 1px solid $border-color;
+  border-radius: $radius-md;
+  background: $bg-card;
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.18);
+}
+
+.page-sidebar-popover :deep(.profile-selector),
+.page-sidebar-popover :deep(.model-selector) {
+  padding: 0;
+}
+
+.page-sidebar-popover :deep(.model-selector) {
+  margin-bottom: 10px;
+}
+
+.page-sidebar-popover :deep(.language-switch) {
+  width: 88px;
+  flex: 0 0 88px;
+}
+
+.page-sidebar-popover :deep(.language-switch .n-base-selection-input__content) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.page-sidebar-popover-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 0;
+  border-top: 1px solid $border-color;
+}
+
+.status-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-size: 12px;
+  color: $text-secondary;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status-indicator.connected .status-dot {
+  background-color: $success;
+  box-shadow: 0 0 6px rgba(var(--success-rgb), 0.5);
+}
+
+.status-indicator.disconnected .status-dot {
+  background-color: $error;
+}
+
+.status-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.page-sidebar-version-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 8px 0;
+  border-top: 1px solid $border-color;
+}
+
+.page-sidebar-version-links {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 6px;
+}
+
+.page-sidebar-link {
+  color: $text-muted;
+  display: flex;
+  align-items: center;
+  transition: color $transition-fast;
+
+  &:hover {
+    color: $text-primary;
+  }
+}
+
+.page-sidebar-version-text {
+  flex: 0 0 auto;
+  color: $text-muted;
+  font-size: 11px;
+  line-height: 16px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color $transition-fast;
+
+  &:hover {
+    color: $accent-primary;
+  }
+}
+
+.page-sidebar-version-row :deep(.theme-switch-container) {
+  flex-shrink: 0;
+}
+
+.page-sidebar-nav-btn {
+  width: 100%;
+  min-width: 0;
+  height: 36px;
+  border: none;
+  border-top: 1px solid $border-color;
+  border-radius: 0;
+  background: transparent;
+  color: $text-secondary;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0;
+  cursor: pointer;
+  transition:
+    background-color $transition-fast,
+    color $transition-fast;
+
+  &:hover {
+    color: $text-primary;
+  }
+}
+
+.page-sidebar-nav-btn span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.page-sidebar-logout-btn {
+  width: 100%;
+  min-width: 0;
+  height: 36px;
+  border: none;
+  border-top: 1px solid $border-color;
+  border-radius: 0;
+  background: transparent;
+  color: $text-secondary;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0;
+  margin-bottom: 6px;
+  cursor: pointer;
+  transition:
+    background-color $transition-fast,
+    color $transition-fast;
+
+  &:hover {
+    color: $error;
+  }
+}
+
+.page-sidebar-logout-user {
+  margin-left: auto;
+  min-width: 0;
+  max-width: 112px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: $text-muted;
+  font-size: 12px;
+}
+
+.changelog-list {
+  max-height: min(70vh, 640px);
+  overflow-y: auto;
+}
+
+.changelog-version-block {
+  margin-bottom: 20px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.changelog-version-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.changelog-version-tag {
+  font-weight: 600;
+  font-size: 14px;
+  color: $text-primary;
+  font-family: $font-code;
+}
+
+.changelog-date {
+  font-size: 12px;
+  color: $text-muted;
+}
+
+.changelog-changes {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  li {
+    font-size: 13px;
+    color: $text-secondary;
+    padding: 4px 0 4px 16px;
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 12px;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: $text-muted;
+    }
+  }
 }
 
 .session-loading,
@@ -1858,153 +2503,6 @@ async function handleSessionModelCustomSubmit() {
   font-size: 12px;
   color: $text-muted;
   text-align: center;
-}
-
-:deep(.session-item) {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 8px 10px;
-  border: none;
-  background: none;
-  border-radius: $radius-sm;
-  cursor: pointer;
-  text-align: left;
-  text-decoration: none;
-  color: $text-secondary;
-  transition: all $transition-fast;
-  margin-bottom: 2px;
-
-  &:hover {
-    background: rgba($accent-primary, 0.06);
-    color: $text-primary;
-
-    .session-item-delete {
-      opacity: 1;
-    }
-  }
-
-  &.active {
-    background: rgba(var(--accent-primary-rgb), 0.12);
-    color: $text-primary;
-    font-weight: 500;
-  }
-
-  &.active .session-item-title {
-    color: $accent-primary;
-  }
-
-  &.missing-models {
-    color: #b42318;
-    background: rgba(220, 38, 38, 0.08);
-
-    .session-item-title,
-    .session-item-profile-name,
-    .session-item-time {
-      color: #b42318;
-    }
-
-    .session-item-model {
-      color: #b42318;
-      background: rgba(220, 38, 38, 0.12);
-    }
-
-    &:hover {
-      background: rgba(220, 38, 38, 0.12);
-    }
-  }
-}
-
-:deep(.session-item-content) {
-  flex: 1;
-  overflow: hidden;
-}
-
-:deep(.session-item-title-row) {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-}
-
-:deep(.session-item-title) {
-  display: block;
-  flex: 1 1 auto;
-  min-width: 0;
-  font-size: 13px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-:deep(.session-item-streaming) {
-  display: inline-block;
-  flex-shrink: 0;
-  margin-right: 4px;
-  vertical-align: middle;
-  animation: spin 1.2s linear infinite;
-  color: $accent-primary;
-}
-
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-:deep(.session-item-pin) {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  color: $accent-primary;
-}
-
-:deep(.session-item-time) {
-  font-size: 11px;
-  color: $text-muted;
-}
-
-:deep(.session-item-meta) {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 2px;
-}
-
-:deep(.session-item-model) {
-  font-size: 10px;
-  color: $accent-primary;
-  background: rgba($accent-primary, 0.08);
-  padding: 0 5px;
-  border-radius: 3px;
-  line-height: 16px;
-  flex-shrink: 0;
-  max-width: 100px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-:deep(.session-item-delete) {
-  flex-shrink: 0;
-  opacity: 0.5;
-  padding: 2px;
-  border: none;
-  background: none;
-  color: $text-muted;
-  cursor: pointer;
-  border-radius: 3px;
-  transition: all $transition-fast;
-
-  &:hover {
-    color: $error;
-    background: rgba($error, 0.1);
-  }
 }
 
 .chat-main {
@@ -2077,6 +2575,17 @@ async function handleSessionModelCustomSubmit() {
   flex-shrink: 0;
 }
 
+.header-model-button {
+  max-width: 220px;
+}
+
+.header-model-button :deep(.n-button__content) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .chat-mode-toggle {
   display: flex;
   align-items: center;
@@ -2087,6 +2596,19 @@ async function handleSessionModelCustomSubmit() {
 @media (max-width: $breakpoint-mobile) {
   .chat-header {
     padding: 16px 12px 16px 52px;
+  }
+
+  .header-sidebar-toggle {
+    display: none;
+  }
+
+  .page-sidebar-popover {
+    width: min($sidebar-width, calc(100vw - 24px));
+  }
+
+  .page-sidebar-popover :deep(.language-switch) {
+    width: 86px;
+    flex-basis: 86px;
   }
 }
 

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -1758,6 +1758,7 @@ async function handleSessionModelCustomSubmit() {
         <div ref="chatContentWrapperRef" class="chat-content-wrapper">
           <div class="chat-main-content">
             <MessageList ref="messageListRef" />
+            <ChatInput />
           </div>
           <OutlinePanel
             v-if="showOutline"
@@ -1806,7 +1807,6 @@ async function handleSessionModelCustomSubmit() {
             </div>
           </aside>
         </div>
-        <ChatInput />
       </template>
       <ConversationMonitorPane
         v-else

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2772,7 +2772,7 @@ async function handleSessionModelCustomSubmit() {
       linear-gradient($text-muted, $text-muted) center 9px / 2px 2px no-repeat,
       linear-gradient($text-muted, $text-muted) center 17px / 2px 2px no-repeat,
       linear-gradient($text-muted, $text-muted) center 25px / 2px 2px no-repeat,
-      rgba($bg-card, 0.92);
+      $bg-card;
     border: 1px solid $border-color;
     opacity: 0.78;
     transition: all $transition-fast;
@@ -2789,7 +2789,7 @@ async function handleSessionModelCustomSubmit() {
       linear-gradient($text-muted, $text-muted) center 9px / 2px 2px no-repeat,
       linear-gradient($text-muted, $text-muted) center 17px / 2px 2px no-repeat,
       linear-gradient($text-muted, $text-muted) center 25px / 2px 2px no-repeat,
-      rgba($bg-card, 0.96);
+      $bg-card;
     border-color: var(--accent-primary);
     opacity: 1;
   }

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2761,20 +2761,19 @@ async function handleSessionModelCustomSubmit() {
   &::before {
     content: "";
     position: absolute;
-    left: 2px;
+    left: 1px;
     top: 50%;
-    width: 10px;
-    height: 36px;
+    width: 12px;
+    height: 38px;
     transform: translateY(-50%);
-    border-radius: 999px;
+    border-radius: 6px;
     background:
-      linear-gradient($border-color, $border-color) center / 1px 100% no-repeat,
-      linear-gradient($text-muted, $text-muted) center 9px / 2px 2px no-repeat,
-      linear-gradient($text-muted, $text-muted) center 17px / 2px 2px no-repeat,
-      linear-gradient($text-muted, $text-muted) center 25px / 2px 2px no-repeat,
+      linear-gradient($text-muted, $text-muted) center 12px / 6px 1px no-repeat,
+      linear-gradient($text-muted, $text-muted) center 19px / 6px 1px no-repeat,
+      linear-gradient($text-muted, $text-muted) center 26px / 6px 1px no-repeat,
       $bg-card;
     border: 1px solid $border-color;
-    opacity: 0.78;
+    opacity: 0.9;
     transition: all $transition-fast;
     z-index: 2;
   }
@@ -2785,10 +2784,9 @@ async function handleSessionModelCustomSubmit() {
 
   &:hover::before {
     background:
-      linear-gradient(var(--accent-primary), var(--accent-primary)) center / 1px 100% no-repeat,
-      linear-gradient($text-muted, $text-muted) center 9px / 2px 2px no-repeat,
-      linear-gradient($text-muted, $text-muted) center 17px / 2px 2px no-repeat,
-      linear-gradient($text-muted, $text-muted) center 25px / 2px 2px no-repeat,
+      linear-gradient(var(--accent-primary), var(--accent-primary)) center 12px / 6px 1px no-repeat,
+      linear-gradient(var(--accent-primary), var(--accent-primary)) center 19px / 6px 1px no-repeat,
+      linear-gradient(var(--accent-primary), var(--accent-primary)) center 26px / 6px 1px no-repeat,
       $bg-card;
     border-color: var(--accent-primary);
     opacity: 1;

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2731,6 +2731,7 @@ async function handleSessionModelCustomSubmit() {
   min-width: 320px;
   max-width: 100%;
   background: $bg-card;
+  border-left: 1px solid $border-color;
   display: flex;
   min-height: 0;
   overflow: hidden;

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2726,16 +2726,12 @@ async function handleSessionModelCustomSubmit() {
 }
 
 .chat-tool-panel {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 70;
+  position: relative;
+  flex: 0 0 auto;
   min-width: 320px;
   max-width: 100%;
   background: $bg-card;
   border-left: 1px solid $border-color;
-  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.12);
   display: flex;
   min-height: 0;
   overflow: hidden;
@@ -2743,26 +2739,50 @@ async function handleSessionModelCustomSubmit() {
 
 .chat-tool-resize-handle {
   position: absolute;
-  left: -4px;
+  left: -7px;
   top: 0;
   bottom: 0;
-  width: 8px;
+  width: 14px;
   cursor: col-resize;
   z-index: 3;
 
   &::after {
     content: "";
     position: absolute;
-    left: 3px;
+    left: 6px;
     top: 0;
     bottom: 0;
     width: 1px;
-    background: transparent;
+    background: $border-color;
     transition: background $transition-fast;
+  }
+
+  &::before {
+    content: "";
+    position: absolute;
+    left: 2px;
+    top: 50%;
+    width: 10px;
+    height: 36px;
+    transform: translateY(-50%);
+    border-radius: 999px;
+    background:
+      linear-gradient($text-muted, $text-muted) center 9px / 2px 2px no-repeat,
+      linear-gradient($text-muted, $text-muted) center 17px / 2px 2px no-repeat,
+      linear-gradient($text-muted, $text-muted) center 25px / 2px 2px no-repeat,
+      $bg-card;
+    border: 1px solid $border-color;
+    opacity: 0.78;
+    transition: all $transition-fast;
   }
 
   &:hover::after {
     background: var(--accent-primary);
+  }
+
+  &:hover::before {
+    border-color: var(--accent-primary);
+    opacity: 1;
   }
 }
 
@@ -2820,6 +2840,11 @@ async function handleSessionModelCustomSubmit() {
 
 @media (max-width: $breakpoint-mobile) {
   .chat-tool-panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 70;
     left: 0;
     width: 100% !important;
     min-width: 0;

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -196,14 +196,17 @@ async function handleProfileFilterChange(value: string) {
   await chatStore.loadSessions(chatStore.sessionProfileFilter);
 }
 
-function sortSessionsWithActiveFirst(items: Session[]): Session[] {
+function sortSessionsForSidebar(items: Session[]): Session[] {
   return [...items].sort((a, b) => {
+    const aLive = chatStore.isSessionLive(a.id);
+    const bLive = chatStore.isSessionLive(b.id);
+    if (aLive !== bLive) return aLive ? -1 : 1;
     return (b.updatedAt || 0) - (a.updatedAt || 0);
   });
 }
 
 const pinnedSessions = computed(() =>
-  sortSessionsWithActiveFirst(
+  sortSessionsForSidebar(
     chatStore.sessions.filter((session) =>
       sessionBrowserPrefsStore.isPinned(session.id),
     ),
@@ -211,7 +214,7 @@ const pinnedSessions = computed(() =>
 );
 
 const unpinnedSessions = computed(() =>
-  sortSessionsWithActiveFirst(
+  sortSessionsForSidebar(
     chatStore.sessions.filter(
       (session) => !sessionBrowserPrefsStore.isPinned(session.id),
     ),

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -34,7 +34,7 @@ import SessionListItem from "./SessionListItem.vue";
 import OutlinePanel from "./OutlinePanel.vue";
 import FilesPanel from "./FilesPanel.vue";
 import TerminalPanel from "./TerminalPanel.vue";
-import { useSessionSearch } from "@/composables/useSessionSearch";
+import PageSidebarNav from "@/components/layout/PageSidebarNav.vue";
 import ProfileSelector from "@/components/layout/ProfileSelector.vue";
 import ModelSelector from "@/components/layout/ModelSelector.vue";
 import LanguageSwitch from "@/components/layout/LanguageSwitch.vue";
@@ -50,7 +50,6 @@ const sessionBrowserPrefsStore = useSessionBrowserPrefsStore();
 const router = useRouter();
 const message = useMessage();
 const { t } = useI18n();
-const { openSessionSearch } = useSessionSearch();
 const currentUsername = computed(() => getStoredUsername());
 
 const showOutline = ref(false);
@@ -145,6 +144,7 @@ function startToolResize(event: PointerEvent) {
 }
 
 async function handleSessionClick(sessionId: string) {
+  chatStore.clearSessionCompletedUnread(sessionId);
   await router.push({
     name: "hermes.session",
     params: { sessionId },
@@ -427,6 +427,9 @@ watch(
 );
 
 async function openNewChatModal() {
+  isBatchMode.value = false;
+  selectedSessionKeys.value.clear();
+  showBatchDeleteConfirm.value = false;
   showNewChatModal.value = true;
   newChatLoading.value = true;
   try {
@@ -718,10 +721,6 @@ function openSettingsPage() {
   router.push({ name: "hermes.settings" });
 }
 
-function openGroupChatPage() {
-  router.push({ name: "hermes.groupChat" });
-}
-
 function handleLogout() {
   localStorage.clear();
   window.location.reload();
@@ -977,51 +976,11 @@ async function handleSessionModelCustomSubmit() {
       :class="{ collapsed: !showSessions }"
     >
       <div v-if="showSessions" class="page-sidebar-top">
-        <div class="page-sidebar-tabs" role="tablist" aria-label="Chat actions">
-          <button class="page-sidebar-tab" type="button" @click="openNewChatModal">
-            <svg
-              width="15"
-              height="15"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <line x1="12" y1="5" x2="12" y2="19" />
-              <line x1="5" y1="12" x2="19" y2="12" />
-            </svg>
-            <span>{{ t("chat.newChat") }}</span>
-          </button>
-          <button class="page-sidebar-tab" type="button" @click="openSessionSearch">
-            <svg
-              width="15"
-              height="15"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.8"
-            >
-              <circle cx="11" cy="11" r="7" />
-              <path d="m20 20-3.5-3.5" />
-            </svg>
-            <span>{{ t("sidebar.search") }}</span>
-          </button>
-          <button class="page-sidebar-tab" type="button">
-            <svg
-              width="15"
-              height="15"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.8"
-            >
-              <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
-              <polyline points="15 3 21 3 21 9" />
-              <line x1="10" y1="14" x2="21" y2="3" />
-            </svg>
-            <span>{{ t("sidebar.apiRelay") }}</span>
-          </button>
-        </div>
+        <PageSidebarNav
+          active="chat"
+          :primary-label="t('chat.newChat')"
+          @primary="openNewChatModal"
+        />
         <div class="session-list-toolbar">
           <NSelect
             class="session-profile-filter"
@@ -1137,25 +1096,6 @@ async function handleSessionModelCustomSubmit() {
             </NButton>
           </div>
         </div>
-        <div class="conversation-switch" role="tablist" aria-label="Conversation type">
-          <button
-            class="conversation-switch-tab active"
-            type="button"
-            role="tab"
-            aria-selected="true"
-          >
-            {{ t("sidebar.singleChat") }}
-          </button>
-          <button
-            class="conversation-switch-tab"
-            type="button"
-            role="tab"
-            aria-selected="false"
-            @click="openGroupChatPage"
-          >
-            {{ t("sidebar.groupChat") }}
-          </button>
-        </div>
       </div>
       <div v-if="showSessions" class="session-items">
         <div
@@ -1184,6 +1124,7 @@ async function handleSessionModelCustomSubmit() {
               chatStore.sessions.length > 1
             "
             :streaming="chatStore.isSessionLive(s.id)"
+            :completed-unread="chatStore.isSessionCompletedUnread(s.id)"
             :selectable="isBatchMode"
             :selected="isSessionSelected(s)"
             :show-profile="true"
@@ -1206,6 +1147,7 @@ async function handleSessionModelCustomSubmit() {
             chatStore.sessions.length > 1
           "
           :streaming="chatStore.isSessionLive(s.id)"
+          :completed-unread="chatStore.isSessionCompletedUnread(s.id)"
           :selectable="isBatchMode"
           :selected="isSessionSelected(s)"
           :show-profile="true"

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2753,7 +2753,9 @@ async function handleSessionModelCustomSubmit() {
     top: 0;
     bottom: 0;
     width: 1px;
-    background: $border-color;
+    background:
+      linear-gradient($border-color, $border-color) top / 1px calc(50% - 26px) no-repeat,
+      linear-gradient($border-color, $border-color) bottom / 1px calc(50% - 26px) no-repeat;
     transition: background $transition-fast;
     z-index: 1;
   }
@@ -2779,7 +2781,9 @@ async function handleSessionModelCustomSubmit() {
   }
 
   &:hover::after {
-    background: var(--accent-primary);
+    background:
+      linear-gradient(var(--accent-primary), var(--accent-primary)) top / 1px calc(50% - 26px) no-repeat,
+      linear-gradient(var(--accent-primary), var(--accent-primary)) bottom / 1px calc(50% - 26px) no-repeat;
   }
 
   &:hover::before {

--- a/packages/client/src/components/hermes/chat/SessionListItem.vue
+++ b/packages/client/src/components/hermes/chat/SessionListItem.vue
@@ -32,11 +32,6 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const appStore = useAppStore()
 const profilesStore = useProfilesStore()
-const sessionModelName = computed(() =>
-  props.session.model
-    ? appStore.displayModelName(props.session.model, props.session.provider)
-    : '',
-)
 const profileName = computed(() => props.session.profile || 'default')
 const profileAvatar = computed(() => profilesStore.profiles.find(profile => profile.name === profileName.value)?.avatar)
 const profileHasModels = computed(() => {
@@ -126,25 +121,28 @@ onUnmounted(() => {
     </div>
     <div class="session-item-content">
       <span class="session-item-title-row">
-        <span v-if="pinned" class="session-item-pin" aria-hidden="true">
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M12 17v5" />
-            <path d="M5 8l14 0" />
-            <path d="M8 3l8 0 0 5 3 5-14 0 3-5z" />
-          </svg>
+        <span class="session-item-title-main">
+          <span v-if="pinned" class="session-item-pin" aria-hidden="true">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 17v5" />
+              <path d="M5 8l14 0" />
+              <path d="M8 3l8 0 0 5 3 5-14 0 3-5z" />
+            </svg>
+          </span>
+          <span class="session-item-title">
+            <svg v-if="streaming" class="session-item-streaming" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
+            {{ session.title }}
+          </span>
+          <NTooltip v-if="profileModelsMissing" trigger="click" placement="top">
+            <template #trigger>
+              <button class="session-item-warning" type="button" @click.stop.prevent>
+                !
+              </button>
+            </template>
+            {{ t('chat.profileMissingModelsTip', { profile: profileName }) }}
+          </NTooltip>
         </span>
-        <span class="session-item-title">
-          <svg v-if="streaming" class="session-item-streaming" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
-          {{ session.title }}
-        </span>
-        <NTooltip v-if="profileModelsMissing" trigger="click" placement="top">
-          <template #trigger>
-            <button class="session-item-warning" type="button" @click.stop.prevent>
-              !
-            </button>
-          </template>
-          {{ t('chat.profileMissingModelsTip', { profile: profileName }) }}
-        </NTooltip>
+        <span class="session-item-time">{{ formatTimestampMs(session.createdAt) }}</span>
       </span>
       <span class="session-item-agent-row">
         <img
@@ -152,15 +150,10 @@ onUnmounted(() => {
           :src="sessionAgentLogo.src"
           :alt="sessionAgentLogo.label"
         >
-        <span class="session-item-agent-name">{{ sessionAgentLogo.label }}</span>
-      </span>
-      <span class="session-item-meta">
-        <span v-if="sessionModelName" class="session-item-model" :title="session.model">{{ sessionModelName }}</span>
-        <span class="session-item-time">{{ formatTimestampMs(session.createdAt) }}</span>
-      </span>
-      <span v-if="props.showProfile" class="session-item-profile">
-        <ProfileAvatar class="session-item-profile-avatar" :name="profileName" :avatar="profileAvatar" :size="16" />
-        <span class="session-item-profile-name">{{ profileName }}</span>
+        <span v-if="props.showProfile" class="session-item-profile">
+          <ProfileAvatar class="session-item-profile-avatar" :name="profileName" :avatar="profileAvatar" :size="16" />
+          <span class="session-item-profile-name">{{ profileName }}</span>
+        </span>
       </span>
     </div>
     <NPopconfirm v-if="canDelete && !selectable" @positive-click="emit('delete')">
@@ -175,12 +168,156 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
+.session-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  background: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+  text-decoration: none;
+  color: var(--text-secondary);
+  transition: all var(--transition-fast);
+  margin-bottom: 2px;
+}
+
+.session-item:hover {
+  background: rgba(var(--accent-primary-rgb), 0.06);
+  color: var(--text-primary);
+}
+
+.session-item:hover .session-item-delete {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.session-item:focus-within .session-item-delete {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.session-item.active {
+  background: rgba(var(--accent-primary-rgb), 0.12);
+  color: var(--text-primary);
+  font-weight: 500;
+  border-radius: 6px;
+}
+
+.session-item.active .session-item-title {
+  color: var(--accent-primary);
+}
+
+.session-item.missing-models {
+  color: #b42318;
+  background: rgba(220, 38, 38, 0.08);
+}
+
+.session-item.missing-models .session-item-title,
+.session-item.missing-models .session-item-profile-name,
+.session-item.missing-models .session-item-time {
+  color: #b42318;
+}
+
+.session-item.missing-models:hover {
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.session-item-content {
+  flex: 1;
+  overflow: hidden;
+}
+
+.session-item-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+}
+
+.session-item-title-main {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.session-item-title {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-item-streaming {
+  display: inline-block;
+  flex-shrink: 0;
+  margin-right: 4px;
+  vertical-align: middle;
+  animation: spin 1.2s linear infinite;
+  color: var(--accent-primary);
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.session-item-pin {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--accent-primary);
+}
+
+.session-item-time {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.session-item-delete {
+  flex-shrink: 0;
+  opacity: 0;
+  pointer-events: none;
+  padding: 2px;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 3px;
+  transition: all var(--transition-fast);
+}
+
+.session-item-delete:hover {
+  color: var(--error);
+  background: rgba(var(--error-rgb), 0.1);
+}
+
+@media (hover: none) {
+  .session-item-delete {
+    opacity: 0.5;
+    pointer-events: auto;
+  }
+}
+
 .session-item-profile {
   display: flex;
   align-items: center;
   gap: 5px;
   min-width: 0;
-  margin-top: 4px;
 }
 
 .session-item-profile-avatar {
@@ -214,7 +351,7 @@ onUnmounted(() => {
 .session-item-agent-row {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   min-width: 0;
   margin-top: 4px;
 }
@@ -227,15 +364,5 @@ onUnmounted(() => {
   border-radius: 50%;
   object-fit: contain;
   background: #fff;
-}
-
-.session-item-agent-name {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 11px;
-  line-height: 16px;
-  color: var(--text-muted);
 }
 </style>

--- a/packages/client/src/components/hermes/chat/SessionListItem.vue
+++ b/packages/client/src/components/hermes/chat/SessionListItem.vue
@@ -14,6 +14,7 @@ const props = withDefaults(defineProps<{
   pinned: boolean
   canDelete: boolean
   streaming?: boolean
+  completedUnread?: boolean
   selectable?: boolean
   selected?: boolean
   showProfile?: boolean
@@ -129,8 +130,8 @@ onUnmounted(() => {
               <path d="M8 3l8 0 0 5 3 5-14 0 3-5z" />
             </svg>
           </span>
+          <span v-if="completedUnread" class="session-item-unread-dot" aria-hidden="true" />
           <span class="session-item-title">
-            <svg v-if="streaming" class="session-item-streaming" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
             {{ session.title }}
           </span>
           <NTooltip v-if="profileModelsMissing" trigger="click" placement="top">
@@ -145,11 +146,13 @@ onUnmounted(() => {
         <span class="session-item-time">{{ formatTimestampMs(session.createdAt) }}</span>
       </span>
       <span class="session-item-agent-row">
-        <img
-          class="session-item-agent-logo"
-          :src="sessionAgentLogo.src"
-          :alt="sessionAgentLogo.label"
-        >
+        <span class="session-item-agent-logo-wrap" :class="{ streaming }">
+          <img
+            class="session-item-agent-logo"
+            :src="sessionAgentLogo.src"
+            :alt="sessionAgentLogo.label"
+          >
+        </span>
         <span v-if="props.showProfile" class="session-item-profile">
           <ProfileAvatar class="session-item-profile-avatar" :name="profileName" :avatar="profileAvatar" :size="16" />
           <span class="session-item-profile-name">{{ profileName }}</span>
@@ -228,7 +231,8 @@ onUnmounted(() => {
 
 .session-item-content {
   flex: 1;
-  overflow: hidden;
+  min-width: 0;
+  overflow: visible;
 }
 
 .session-item-title-row {
@@ -243,6 +247,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 6px;
+  flex: 1 1 auto;
   min-width: 0;
 }
 
@@ -256,30 +261,21 @@ onUnmounted(() => {
   text-overflow: ellipsis;
 }
 
-.session-item-streaming {
-  display: inline-block;
-  flex-shrink: 0;
-  margin-right: 4px;
-  vertical-align: middle;
-  animation: spin 1.2s linear infinite;
-  color: var(--accent-primary);
-}
-
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
 .session-item-pin {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
   color: var(--accent-primary);
+}
+
+.session-item-unread-dot {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  box-shadow: 0 0 0 3px rgba(var(--accent-primary-rgb), 0.12);
 }
 
 .session-item-time {
@@ -353,16 +349,87 @@ onUnmounted(() => {
   align-items: center;
   gap: 4px;
   min-width: 0;
-  margin-top: 4px;
+  margin-top: 3px;
+  padding: 3px 0;
+}
+
+.session-item-agent-logo-wrap {
+  position: relative;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+}
+
+.session-item-agent-logo-wrap.streaming::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  box-sizing: border-box;
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 2px #ff6b6b,
+    0 0 10px rgba(255, 107, 107, 0.4),
+    0 0 20px rgba(255, 107, 107, 0.2);
+  animation: rainbow-glow 4s linear infinite;
 }
 
 .session-item-agent-logo {
-  flex: 0 0 auto;
+  position: relative;
+  z-index: 1;
   width: 18px;
   height: 18px;
   padding: 2px;
-  border-radius: 50%;
+  border-radius: inherit;
   object-fit: contain;
   background: #fff;
+}
+
+@keyframes rainbow-glow {
+  0% {
+    box-shadow:
+      0 0 0 2px #ff6b6b,
+      0 0 10px rgba(255, 107, 107, 0.4),
+      0 0 20px rgba(255, 107, 107, 0.2);
+  }
+  16.66% {
+    box-shadow:
+      0 0 0 2px #feca57,
+      0 0 10px rgba(254, 202, 87, 0.4),
+      0 0 20px rgba(254, 202, 87, 0.2);
+  }
+  33.33% {
+    box-shadow:
+      0 0 0 2px #48dbfb,
+      0 0 10px rgba(72, 219, 251, 0.4),
+      0 0 20px rgba(72, 219, 251, 0.2);
+  }
+  50% {
+    box-shadow:
+      0 0 0 2px #ff9ff3,
+      0 0 10px rgba(255, 159, 243, 0.4),
+      0 0 20px rgba(255, 159, 243, 0.2);
+  }
+  66.66% {
+    box-shadow:
+      0 0 0 2px #54a0ff,
+      0 0 10px rgba(84, 160, 255, 0.4),
+      0 0 20px rgba(84, 160, 255, 0.2);
+  }
+  83.33% {
+    box-shadow:
+      0 0 0 2px #5f27cd,
+      0 0 10px rgba(95, 39, 205, 0.4),
+      0 0 20px rgba(95, 39, 205, 0.2);
+  }
+  100% {
+    box-shadow:
+      0 0 0 2px #ff6b6b,
+      0 0 10px rgba(255, 107, 107, 0.4),
+      0 0 20px rgba(255, 107, 107, 0.2);
+  }
 }
 </style>

--- a/packages/client/src/components/hermes/chat/TerminalPanel.vue
+++ b/packages/client/src/components/hermes/chat/TerminalPanel.vue
@@ -594,6 +594,8 @@ onUnmounted(() => {
 <style scoped lang="scss">
 @use "@/styles/variables" as *;
 
+$terminal-panel-header-height: 47px;
+
 .terminal-panel-drawer {
   display: flex;
   height: 100%;
@@ -648,9 +650,11 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  height: $terminal-panel-header-height;
   padding: 12px;
   flex-shrink: 0;
   border-bottom: 1px solid $border-color;
+  box-sizing: border-box;
 }
 
 .sidebar-title {
@@ -795,10 +799,12 @@ onUnmounted(() => {
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  padding: 12px 16px;
+  height: $terminal-panel-header-height;
+  padding: 9px 16px;
   border-bottom: 1px solid $border-color;
   flex-shrink: 0;
   min-width: 0;
+  box-sizing: border-box;
 }
 
 .header-session-title {

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -1,15 +1,23 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
-import { useMessage, NInput, NButton, NSpace, NSelect, NPopover, NPopconfirm, NInputNumber, NDropdown, type DropdownOption } from 'naive-ui'
+import { useMessage, NInput, NButton, NSpace, NSelect, NPopover, NPopconfirm, NInputNumber, NDropdown, NModal, type DropdownOption } from 'naive-ui'
 import { useGroupChatStore } from '@/stores/hermes/group-chat'
 import { useProfilesStore } from '@/stores/hermes/profiles'
+import { useAppStore } from '@/stores/hermes/app'
 import { updateRoomConfig, forceCompress } from '@/api/hermes/group-chat'
 import GroupMessageList from './GroupMessageList.vue'
 import GroupChatInput from './GroupChatInput.vue'
 import ProfileAvatar from '@/components/hermes/profiles/ProfileAvatar.vue'
+import ProfileSelector from '@/components/layout/ProfileSelector.vue'
+import ModelSelector from '@/components/layout/ModelSelector.vue'
+import LanguageSwitch from '@/components/layout/LanguageSwitch.vue'
+import ThemeSwitch from '@/components/layout/ThemeSwitch.vue'
+import VersionManagementModal from '@/components/layout/VersionManagementModal.vue'
 import { copyToClipboard } from '@/utils/clipboard'
+import { getStoredUsername } from '@/api/client'
+import { changelog } from '@/data/changelog'
 import type { Attachment } from '@/stores/hermes/chat'
 import type { RoomAgent } from '@/api/hermes/group-chat'
 
@@ -18,12 +26,15 @@ const router = useRouter()
 const message = useMessage()
 const store = useGroupChatStore()
 const profilesStore = useProfilesStore()
+const appStore = useAppStore()
 
 const showSidebar = ref(window.innerWidth > 768)
 const showCreateModal = ref(false)
 const showCloneModal = ref(false)
 const showAddAgentModal = ref(false)
 const showCompressionModal = ref(false)
+const showChangelog = ref(false)
+const showVersionManagement = ref(false)
 const compressionConfig = ref({ triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10 })
 const isCompressing = ref(false)
 const selectedProfile = ref<string | null>(null)
@@ -65,6 +76,10 @@ const userMemberAvatar = computed(() => {
     return null
 })
 const visibleApproval = computed(() => store.activePendingApproval)
+const currentUsername = computed(() => getStoredUsername())
+const isDesktopShell = computed(() =>
+    (window as typeof window & { hermesDesktop?: { isDesktop?: boolean } }).hermesDesktop?.isDesktop === true,
+)
 
 function formatTokens(tokens: number): string {
     if (tokens >= 1000) return `${(tokens / 1000).toFixed(1)}k tokens`
@@ -73,6 +88,44 @@ function formatTokens(tokens: number): string {
 
 function toggleSidebar() {
     showSidebar.value = !showSidebar.value
+}
+
+function openPageSidebar() {
+    showSidebar.value = true
+}
+
+function openSingleChatPage() {
+    router.push({ name: 'hermes.chat' })
+}
+
+function openSettingsPage() {
+    router.push({ name: 'hermes.settings' })
+}
+
+function openChangelog() {
+    showChangelog.value = true
+}
+
+function openVersionManagement() {
+    showVersionManagement.value = true
+}
+
+function handleReloadClient() {
+    appStore.reloadClient()
+}
+
+async function handleUpdate() {
+    const ok = await appStore.doUpdate()
+    if (ok) {
+        message.success(t('sidebar.updateSuccess'), { duration: 5000 })
+    } else {
+        message.error(t('sidebar.updateFailed'))
+    }
+}
+
+function handleLogout() {
+    localStorage.clear()
+    window.location.reload()
 }
 
 function generateCode(): string {
@@ -236,9 +289,14 @@ async function handleAddAgent() {
 }
 
 onMounted(() => {
+    window.addEventListener('hermes:open-page-sidebar', openPageSidebar)
     if (profilesStore.profiles.length === 0) {
         void profilesStore.fetchProfiles()
     }
+})
+
+onUnmounted(() => {
+    window.removeEventListener('hermes:open-page-sidebar', openPageSidebar)
 })
 
 async function confirmAddAgent() {
@@ -339,14 +397,32 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
         <!-- Room sidebar -->
         <div v-if="showSidebar" class="room-sidebar">
             <div class="sidebar-header">
-                <span class="sidebar-title">{{ t('groupChat.title') }}</span>
-                <div class="sidebar-actions">
-                    <button class="icon-btn" :title="t('groupChat.createRoom')" @click="showCreateModal = true">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                            <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
-                        </svg>
-                    </button>
-                </div>
+                <button class="page-sidebar-tab" type="button" @click="showCreateModal = true">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <line x1="12" y1="5" x2="12" y2="19" />
+                        <line x1="5" y1="12" x2="19" y2="12" />
+                    </svg>
+                    <span>{{ t('groupChat.createRoom') }}</span>
+                </button>
+            </div>
+            <div class="conversation-switch" role="tablist" aria-label="Conversation type">
+                <button
+                    class="conversation-switch-tab"
+                    type="button"
+                    role="tab"
+                    aria-selected="false"
+                    @click="openSingleChatPage"
+                >
+                    {{ t('sidebar.singleChat') }}
+                </button>
+                <button
+                    class="conversation-switch-tab active"
+                    type="button"
+                    role="tab"
+                    aria-selected="true"
+                >
+                    {{ t('sidebar.groupChat') }}
+                </button>
             </div>
             <div class="room-list">
                 <div
@@ -378,6 +454,101 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                     {{ t('groupChat.noRooms') }}
                 </div>
             </div>
+            <div class="page-sidebar-bottom">
+                <NPopover
+                    trigger="click"
+                    placement="top-start"
+                    :show-arrow="false"
+                    raw
+                >
+                    <template #trigger>
+                        <button class="page-sidebar-menu-btn" type="button">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                                <circle cx="12" cy="12" r="3" />
+                                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                            </svg>
+                            <span>{{ t('sidebar.settings') }}</span>
+                        </button>
+                    </template>
+                    <div class="page-sidebar-popover">
+                        <ProfileSelector />
+                        <ModelSelector />
+                        <div class="page-sidebar-popover-row">
+                            <div
+                                class="status-indicator"
+                                :class="{ connected: appStore.connected, disconnected: !appStore.connected }"
+                            >
+                                <span class="status-dot"></span>
+                                <span class="status-text">{{ appStore.connected ? t('sidebar.connected') : t('sidebar.disconnected') }}</span>
+                            </div>
+                            <LanguageSwitch />
+                        </div>
+                        <div class="page-sidebar-version-row">
+                            <div class="page-sidebar-version-links">
+                                <a class="page-sidebar-link" href="https://github.com/EKKOLearnAI/hermes-web-ui" target="_blank" rel="noopener noreferrer" title="GitHub">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+                                </a>
+                                <a class="page-sidebar-link" href="https://hermes-studio.ai/" target="_blank" rel="noopener noreferrer" title="Website">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                                </a>
+                            </div>
+                            <span
+                                class="page-sidebar-version-text"
+                                role="button"
+                                tabindex="0"
+                                @click="openChangelog"
+                                @keydown.enter="openChangelog"
+                                @keydown.space.prevent="openChangelog"
+                            >
+                                Studio v{{ appStore.serverVersion || '0.1.0' }}
+                            </span>
+                            <ThemeSwitch />
+                        </div>
+                        <button class="page-sidebar-nav-btn" type="button" @click="openSettingsPage">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                                <line x1="4" y1="6" x2="20" y2="6" />
+                                <line x1="4" y1="12" x2="20" y2="12" />
+                                <line x1="4" y1="18" x2="20" y2="18" />
+                            </svg>
+                            <span>{{ t('sidebar.settings') }}</span>
+                        </button>
+                        <button class="page-sidebar-logout-btn" type="button" @click="handleLogout">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                                <polyline points="16 17 21 12 16 7" />
+                                <line x1="21" y1="12" x2="9" y2="12" />
+                            </svg>
+                            <span>{{ t('sidebar.logout') }}</span>
+                            <span v-if="currentUsername" class="page-sidebar-logout-user" :title="currentUsername">
+                                {{ currentUsername }}
+                            </span>
+                        </button>
+                        <NButton v-if="isDesktopShell" type="primary" size="tiny" block @click="openVersionManagement">
+                            {{ t('sidebar.versionManagement') }}
+                        </NButton>
+                        <NButton v-if="appStore.clientOutdated" type="warning" size="tiny" block @click="handleReloadClient">
+                            {{ t('sidebar.reloadClientVersion', { version: appStore.serverVersion }) }}
+                        </NButton>
+                        <NButton v-if="appStore.updateAvailable" type="primary" size="tiny" block :loading="appStore.updating" @click="handleUpdate">
+                            {{ appStore.updating ? t('sidebar.updating') : t('sidebar.updateVersion', { version: appStore.latestVersion }) }}
+                        </NButton>
+                    </div>
+                </NPopover>
+                <NModal v-model:show="showChangelog" preset="dialog" :title="t('sidebar.changelog')" style="width: 520px;">
+                    <div class="changelog-list">
+                        <div v-for="entry in changelog" :key="entry.version" class="changelog-version-block">
+                            <div class="changelog-version-header">
+                                <span class="changelog-version-tag">v{{ entry.version }}</span>
+                                <span class="changelog-date">{{ entry.date }}</span>
+                            </div>
+                            <ul class="changelog-changes">
+                                <li v-for="(change, idx) in entry.changes" :key="idx">{{ t(change) }}</li>
+                            </ul>
+                        </div>
+                    </div>
+                </NModal>
+                <VersionManagementModal v-if="isDesktopShell" v-model:show="showVersionManagement" />
+            </div>
         </div>
 
         <NDropdown
@@ -394,7 +565,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
         <!-- Main chat area -->
         <div class="chat-main">
             <div class="chat-header">
-                <button class="icon-btn" @click="toggleSidebar">
+                <button class="icon-btn header-sidebar-toggle" @click="toggleSidebar">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                         <rect x="3" y="3" width="18" height="18" rx="2" ry="2" /><line x1="9" y1="3" x2="9" y2="21" />
                     </svg>
@@ -927,7 +1098,7 @@ export default defineComponent({ components: { CreateRoomForm } })
 // ─── Room Sidebar ────────────────────────────────────────
 
 .room-sidebar {
-    width: 220px;
+    width: $sidebar-width;
     flex-shrink: 0;
     border-right: 1px solid $border-color;
     display: flex;
@@ -935,21 +1106,80 @@ export default defineComponent({ components: { CreateRoomForm } })
 }
 
 .sidebar-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
     padding: 12px;
     flex-shrink: 0;
+}
 
-    .sidebar-title {
-        font-size: 15px;
-        font-weight: 600;
+.page-sidebar-tab {
+    width: 100%;
+    min-width: 0;
+    height: 34px;
+    border: none;
+    border-radius: $radius-sm;
+    background: transparent;
+    color: $text-secondary;
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 8px;
+    padding: 7px 10px;
+    cursor: pointer;
+    transition:
+        background-color $transition-fast,
+        color $transition-fast;
+
+    svg {
+        flex-shrink: 0;
+    }
+
+    span {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 13px;
+        line-height: 18px;
+    }
+
+    &:hover {
+        background: rgba(var(--accent-primary-rgb), 0.06);
+        color: $text-primary;
+    }
+}
+
+.conversation-switch {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 2px;
+    margin: 0 12px 8px;
+    padding: 2px;
+    border-radius: $radius-sm;
+    background: rgba(var(--accent-primary-rgb), 0.05);
+    flex-shrink: 0;
+}
+
+.conversation-switch-tab {
+    min-width: 0;
+    height: 28px;
+    border: none;
+    border-radius: 5px;
+    background: transparent;
+    color: $text-secondary;
+    font-size: 12px;
+    line-height: 16px;
+    cursor: pointer;
+    transition:
+        background-color $transition-fast,
+        color $transition-fast;
+
+    &:hover {
         color: $text-primary;
     }
 
-    .sidebar-actions {
-        display: flex;
-        gap: 4px;
+    &.active {
+        background: $bg-card;
+        color: $text-primary;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
     }
 }
 
@@ -1043,6 +1273,262 @@ export default defineComponent({ components: { CreateRoomForm } })
     text-align: center;
     font-size: 13px;
     color: $text-muted;
+}
+
+.page-sidebar-bottom {
+    flex-shrink: 0;
+    padding: 10px 12px;
+}
+
+.page-sidebar-menu-btn {
+    width: 100%;
+    min-width: 0;
+    height: 36px;
+    border: none;
+    border-radius: $radius-sm;
+    background: transparent;
+    color: $text-secondary;
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 8px;
+    padding: 8px 10px;
+    cursor: pointer;
+    transition:
+        background-color $transition-fast,
+        color $transition-fast;
+
+    &:hover {
+        background: rgba(var(--accent-primary-rgb), 0.06);
+        color: $text-primary;
+    }
+
+    span {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 13px;
+        line-height: 18px;
+    }
+}
+
+.page-sidebar-popover {
+    width: $sidebar-width;
+    padding: 12px;
+    border: 1px solid $border-color;
+    border-radius: $radius-md;
+    background: $bg-card;
+    box-shadow: 0 12px 34px rgba(0, 0, 0, 0.18);
+}
+
+.page-sidebar-popover :deep(.profile-selector),
+.page-sidebar-popover :deep(.model-selector) {
+    padding: 0;
+}
+
+.page-sidebar-popover :deep(.model-selector) {
+    margin-bottom: 10px;
+}
+
+.page-sidebar-popover :deep(.language-switch) {
+    width: 88px;
+    flex: 0 0 88px;
+}
+
+.page-sidebar-popover :deep(.language-switch .n-base-selection-input__content) {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.page-sidebar-popover-row,
+.page-sidebar-version-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 8px 0;
+    border-top: 1px solid $border-color;
+}
+
+.status-indicator {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    font-size: 12px;
+    color: $text-secondary;
+}
+
+.status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.status-indicator.connected .status-dot {
+    background-color: $success;
+    box-shadow: 0 0 6px rgba(var(--success-rgb), 0.5);
+}
+
+.status-indicator.disconnected .status-dot {
+    background-color: $error;
+}
+
+.status-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.page-sidebar-version-row {
+    gap: 6px;
+}
+
+.page-sidebar-version-links {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    gap: 6px;
+}
+
+.page-sidebar-link {
+    color: $text-muted;
+    display: flex;
+    align-items: center;
+    transition: color $transition-fast;
+
+    &:hover {
+        color: $text-primary;
+    }
+}
+
+.page-sidebar-version-text {
+    flex: 0 0 auto;
+    color: $text-muted;
+    font-size: 11px;
+    line-height: 16px;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: color $transition-fast;
+
+    &:hover {
+        color: $accent-primary;
+    }
+}
+
+.page-sidebar-version-row :deep(.theme-switch-container) {
+    flex-shrink: 0;
+}
+
+.page-sidebar-nav-btn,
+.page-sidebar-logout-btn {
+    width: 100%;
+    min-width: 0;
+    height: 36px;
+    border: none;
+    border-top: 1px solid $border-color;
+    border-radius: 0;
+    background: transparent;
+    color: $text-secondary;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 0;
+    cursor: pointer;
+    transition: color $transition-fast;
+
+    span {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 13px;
+        line-height: 18px;
+    }
+}
+
+.page-sidebar-nav-btn:hover {
+    color: $text-primary;
+}
+
+.page-sidebar-logout-btn {
+    margin-bottom: 6px;
+
+    &:hover {
+        color: $error;
+    }
+}
+
+.page-sidebar-logout-user {
+    margin-left: auto;
+    min-width: 0;
+    max-width: 112px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: $text-muted;
+    font-size: 12px;
+}
+
+.changelog-list {
+    max-height: min(70vh, 640px);
+    overflow-y: auto;
+}
+
+.changelog-version-block {
+    margin-bottom: 20px;
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+}
+
+.changelog-version-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+
+.changelog-version-tag {
+    font-weight: 600;
+    font-size: 14px;
+    color: $text-primary;
+    font-family: $font-code;
+}
+
+.changelog-date {
+    font-size: 12px;
+    color: $text-muted;
+}
+
+.changelog-changes {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    li {
+        font-size: 13px;
+        color: $text-secondary;
+        padding: 4px 0 4px 16px;
+        position: relative;
+
+        &::before {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 12px;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: $text-muted;
+        }
+    }
 }
 
 // ─── Chat Main ──────────────────────────────────────────
@@ -1350,6 +1836,19 @@ export default defineComponent({ components: { CreateRoomForm } })
 
     .chat-header {
         padding: 16px 12px 16px 52px;
+    }
+
+    .header-sidebar-toggle {
+        display: none;
+    }
+
+    .page-sidebar-popover {
+        width: min($sidebar-width, calc(100vw - 24px));
+    }
+
+    .page-sidebar-popover :deep(.language-switch) {
+        width: 86px;
+        flex-basis: 86px;
     }
 }
 </style>

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -10,6 +10,7 @@ import { updateRoomConfig, forceCompress } from '@/api/hermes/group-chat'
 import GroupMessageList from './GroupMessageList.vue'
 import GroupChatInput from './GroupChatInput.vue'
 import ProfileAvatar from '@/components/hermes/profiles/ProfileAvatar.vue'
+import PageSidebarNav from '@/components/layout/PageSidebarNav.vue'
 import ProfileSelector from '@/components/layout/ProfileSelector.vue'
 import ModelSelector from '@/components/layout/ModelSelector.vue'
 import LanguageSwitch from '@/components/layout/LanguageSwitch.vue'
@@ -92,10 +93,6 @@ function toggleSidebar() {
 
 function openPageSidebar() {
     showSidebar.value = true
-}
-
-function openSingleChatPage() {
-    router.push({ name: 'hermes.chat' })
 }
 
 function openSettingsPage() {
@@ -397,32 +394,11 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
         <!-- Room sidebar -->
         <div v-if="showSidebar" class="room-sidebar">
             <div class="sidebar-header">
-                <button class="page-sidebar-tab" type="button" @click="showCreateModal = true">
-                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <line x1="12" y1="5" x2="12" y2="19" />
-                        <line x1="5" y1="12" x2="19" y2="12" />
-                    </svg>
-                    <span>{{ t('groupChat.createRoom') }}</span>
-                </button>
-            </div>
-            <div class="conversation-switch" role="tablist" aria-label="Conversation type">
-                <button
-                    class="conversation-switch-tab"
-                    type="button"
-                    role="tab"
-                    aria-selected="false"
-                    @click="openSingleChatPage"
-                >
-                    {{ t('sidebar.singleChat') }}
-                </button>
-                <button
-                    class="conversation-switch-tab active"
-                    type="button"
-                    role="tab"
-                    aria-selected="true"
-                >
-                    {{ t('sidebar.groupChat') }}
-                </button>
+                <PageSidebarNav
+                    active="group"
+                    :primary-label="t('groupChat.createRoom')"
+                    @primary="showCreateModal = true"
+                />
             </div>
             <div class="room-list">
                 <div

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -1,51 +1,28 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
-import { NButton, NModal, useMessage } from "naive-ui";
 import { useAppStore } from "@/stores/hermes/app";
-import ModelSelector from "./ModelSelector.vue";
-import ProfileSelector from "./ProfileSelector.vue";
-import LanguageSwitch from "./LanguageSwitch.vue";
-import ThemeSwitch from "./ThemeSwitch.vue";
-import VersionManagementModal from './VersionManagementModal.vue'
-import { useSessionSearch } from '@/composables/useSessionSearch'
 import { usePersistentRecord } from '@/composables/usePersistentRecord'
 import RouteLinkItem from '@/components/common/RouteLinkItem.vue'
-import { changelog } from "@/data/changelog";
-import { isStoredSuperAdmin, getStoredUsername } from "@/api/client";
+import { isStoredSuperAdmin } from "@/api/client";
 
 const { t } = useI18n();
-const message = useMessage();
 const route = useRoute();
 const router = useRouter();
 const appStore = useAppStore();
-const { openSessionSearch } = useSessionSearch();
 const selectedKey = computed(() => {
-  if (route.name === "hermes.session") return "hermes.chat";
-  if (route.name === "hermes.historySession") return "hermes.history";
-  if (route.name === "hermes.groupChatRoom") return "hermes.groupChat";
   return route.name as string;
 });
 const isSuperAdmin = computed(() => isStoredSuperAdmin());
-const currentUsername = computed(() => getStoredUsername());
 const isVersionPreview = import.meta.env.VITE_HERMES_PREVIEW === '1';
-const isDesktopShell = computed(() => {
-  return typeof window !== 'undefined' &&
-    (window as typeof window & { hermesDesktop?: { isDesktop?: boolean } }).hermesDesktop?.isDesktop === true;
-});
 
-function isNavActive(...names: string[]) {
-  return names.includes(selectedKey.value);
-}
 function hasRoute(name: string): boolean {
   return router.hasRoute(name);
 }
-const logoPath = '/logo.png';
-
 const { record: collapsedGroups, persist: persistCollapsedGroups } = usePersistentRecord('hermes.sidebar.collapsedGroups');
 
-type SidebarGroupKey = "Conversation" | "Agent" | "Monitoring" | "Tools" | "System";
+type SidebarGroupKey = "Agent" | "Monitoring" | "Tools" | "System";
 
 function groupLabel(key: SidebarGroupKey) {
   return t(`sidebar.group${key}${appStore.sidebarCollapsed ? "Short" : ""}`);
@@ -61,98 +38,27 @@ function isGroupCollapsed(key: string) {
 }
 
 
-async function handleUpdate() {
-  const ok = await appStore.doUpdate();
-  if (ok) {
-    message.success(t('sidebar.updateSuccess'), { duration: 5000 });
-  } else {
-    message.error(t('sidebar.updateFailed'));
-  }
-}
-
-function handleReloadClient() {
-  appStore.reloadClient();
-}
-
-function handleLogout() {
-  localStorage.clear();
-  window.location.reload();
-}
-
-// Changelog
-const showChangelog = ref(false);
-const showVersionManagement = ref(false);
-
-function openChangelog() {
-  showChangelog.value = true;
-}
-
-function openVersionManagement() {
-  showVersionManagement.value = true;
-}
 </script>
 
 <template>
   <aside class="sidebar" :class="{ open: appStore.sidebarOpen, collapsed: appStore.sidebarCollapsed }">
-    <RouteLinkItem class="sidebar-logo" :to="{ name: 'hermes.chat' }">
-      <img :src="logoPath" alt="Hermes Studio" class="logo-img" />
-      <span class="logo-text">Hermes Studio</span>
-      <!-- <video class="logo-dance" :src="isDark ? danceVideoDark : danceVideoLight" autoplay loop muted playsinline /> -->
-    </RouteLinkItem>
-
-    <button class="collapse-btn" @click="appStore.toggleSidebarCollapsed()" :title="appStore.sidebarCollapsed ? t('sidebar.expand') : t('sidebar.collapse')">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <polyline v-if="appStore.sidebarCollapsed" points="9 18 15 12 9 6" />
-        <polyline v-else points="15 18 9 12 15 6" />
-      </svg>
-    </button>
+    <div class="sidebar-top-actions">
+      <RouteLinkItem class="nav-item sidebar-return-tab" :to="{ name: 'hermes.chat' }" :title="t('sidebar.backToChat')">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="15 18 9 12 15 6" />
+          <line x1="9" y1="12" x2="21" y2="12" />
+        </svg>
+        <span>{{ t("sidebar.backToChat") }}</span>
+      </RouteLinkItem>
+      <button class="collapse-btn" @click="appStore.toggleSidebarCollapsed()" :title="appStore.sidebarCollapsed ? t('sidebar.expand') : t('sidebar.collapse')">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline v-if="appStore.sidebarCollapsed" points="9 18 15 12 9 6" />
+          <polyline v-else points="15 18 9 12 15 6" />
+        </svg>
+      </button>
+    </div>
 
     <nav class="sidebar-nav">
-      <!-- Conversation -->
-      <div class="nav-group">
-        <div class="nav-group-label" @click="toggleGroup('conversation')">
-          <span>{{ groupLabel("Conversation") }}</span>
-          <svg class="nav-group-arrow" :class="{ collapsed: isGroupCollapsed('conversation') }" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <polyline points="6 9 12 15 18 9" />
-          </svg>
-        </div>
-        <div v-show="!isGroupCollapsed('conversation')" class="nav-group-items">
-          <RouteLinkItem class="nav-item" :to="{ name: 'hermes.chat' }" :active="isNavActive('hermes.chat', 'hermes.session')">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-            </svg>
-            <span>{{ t("sidebar.chat") }}</span>
-          </RouteLinkItem>
-          <RouteLinkItem class="nav-item" :to="{ name: 'hermes.history' }" :active="isNavActive('hermes.history', 'hermes.historySession')">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="12" cy="12" r="10" />
-              <polyline points="12 6 12 12 16 14" />
-            </svg>
-            <span>{{ t("sidebar.history") }}</span>
-          </RouteLinkItem>
-          <RouteLinkItem class="nav-item" :to="{ name: 'hermes.groupChat' }" :active="isNavActive('hermes.groupChat', 'hermes.groupChatRoom')">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
-              <circle cx="9" cy="7" r="4" />
-              <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
-              <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-            </svg>
-            <span>{{ t("sidebar.groupChat") }}<span class="beta-tag">(beta)</span></span>
-          </RouteLinkItem>
-          <button class="nav-item" @click="openSessionSearch">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="11" cy="11" r="7" />
-              <path d="m20 20-3.5-3.5" />
-            </svg>
-            <span>{{ t("sidebar.search") }}</span>
-          </button>
-          <a class="nav-item fun-link" href="https://apikey.fun/register?aff=LIBAPI" target="_blank" rel="noopener noreferrer">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
-            <span>{{ t('sidebar.apiRelay') }}</span>
-          </a>
-        </div>
-      </div>
-
       <!-- Agent -->
       <div class="nav-group">
         <div class="nav-group-label" @click="toggleGroup('agent')">
@@ -344,75 +250,6 @@ function openVersionManagement() {
         </div>
       </div>
     </nav>
-
-    <ProfileSelector />
-    <ModelSelector />
-
-    <div class="sidebar-footer">
-      <button class="nav-item logout-item" @click="handleLogout">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-          <polyline points="16 17 21 12 16 7" />
-          <line x1="21" y1="12" x2="9" y2="12" />
-        </svg>
-        <span>{{ t("sidebar.logout") }}</span>
-        <span v-if="currentUsername" class="logout-username" :title="currentUsername">{{ currentUsername }}</span>
-      </button>
-      <div class="status-row">
-        <div
-          class="status-indicator"
-          :class="{
-            connected: appStore.connected,
-            disconnected: !appStore.connected,
-          }"
-        >
-          <span class="status-dot"></span>
-          <span class="status-text">{{
-            appStore.connected
-              ? t("sidebar.connected")
-              : t("sidebar.disconnected")
-          }}</span>
-        </div>
-        <LanguageSwitch />
-      </div>
-      <div class="version-info">
-        <div class="version-links">
-          <a class="github-link" href="https://github.com/EKKOLearnAI/hermes-web-ui" target="_blank" rel="noopener noreferrer" title="GitHub">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
-          </a>
-          <a class="website-link" href="https://hermes-studio.ai/" target="_blank" rel="noopener noreferrer" title="Website">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-          </a>
-        </div>
-        <span class="version-text" @click="openChangelog">Studio v{{ appStore.serverVersion || "0.1.0" }}</span>
-        <ThemeSwitch />
-      </div>
-      <NButton v-if="isDesktopShell" type="primary" size="tiny" block class="update-btn" @click="openVersionManagement">
-        {{ t('sidebar.versionManagement') }}
-      </NButton>
-      <NButton v-if="appStore.clientOutdated" type="warning" size="tiny" block class="update-btn" @click="handleReloadClient">
-        {{ t('sidebar.reloadClientVersion', { version: appStore.serverVersion }) }}
-      </NButton>
-      <NButton v-if="appStore.updateAvailable" type="primary" size="tiny" block class="update-btn" :loading="appStore.updating" @click="handleUpdate">
-        {{ appStore.updating ? t('sidebar.updating') : t('sidebar.updateVersion', { version: appStore.latestVersion }) }}
-      </NButton>
-    </div>
-
-    <!-- Changelog modal -->
-    <NModal v-model:show="showChangelog" preset="dialog" :title="t('sidebar.changelog')" style="width: 520px;">
-      <div class="changelog-list">
-        <div v-for="entry in changelog" :key="entry.version" class="changelog-version-block">
-          <div class="changelog-version-header">
-            <span class="changelog-version-tag">v{{ entry.version }}</span>
-            <span class="changelog-date">{{ entry.date }}</span>
-          </div>
-          <ul class="changelog-changes">
-            <li v-for="(change, idx) in entry.changes" :key="idx">{{ t(change) }}</li>
-          </ul>
-        </div>
-      </div>
-    </NModal>
-    <VersionManagementModal v-if="isDesktopShell" v-model:show="showVersionManagement" />
   </aside>
 </template>
 
@@ -427,60 +264,15 @@ function openVersionManagement() {
   border-right: 1px solid $border-color;
   display: flex;
   flex-direction: column;
-  padding: 0 12px 20px;
+  padding: 8px 12px 20px;
   flex-shrink: 0;
   transition: width $transition-normal;
-}
-
-.logo-img {
-  width: 28px;
-  height: 28px;
-  border-radius: 0;
-  flex-shrink: 0;
-}
-
-.sidebar-logo {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 20px 12px;
-  margin: 0 -12px;
-  color: $text-primary;
-  cursor: pointer;
-  background-color: $bg-card;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-
-  .dark & {
-    background-color: #393939;
-  }
-  position: relative;
-  overflow: hidden;
-
-  .logo-text {
-    font-size: 16px;
-    font-weight: 600;
-    letter-spacing: 0.5px;
-    white-space: nowrap;
-  }
-
-  .logo-dance {
-    position: absolute;
-    right: 12px;
-    top: 50%;
-    transform: translateY(-50%);
-    height: 100px;
-    border-radius: $radius-md;
-    object-fit: contain;
-    flex-shrink: 0;
-    width: auto;
-    pointer-events: none;
-  }
 }
 
 .sidebar-nav {
   flex: 1;
   display: flex;
-  padding-top: 12px;
+  padding-top: 8px;
   flex-direction: column;
   gap: 6px;
   overflow-y: auto;
@@ -490,11 +282,6 @@ function openVersionManagement() {
   &::-webkit-scrollbar {
     display: none;
   }
-}
-
-:deep(.profile-selector) {
-  padding-top: 12px;
-  border-top: 1px solid $border-color;
 }
 
 .nav-group {
@@ -582,201 +369,42 @@ function openVersionManagement() {
   }
 }
 
-.sidebar-footer {
-  padding-top: 8px;
-  border-top: 1px solid $border-color;
+.sidebar-top-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
 }
 
-.logout-item {
-  margin: 0 -12px;
-  padding: 10px 12px;
-  border-radius: 0;
+.sidebar-return-tab {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
   font-size: 13px;
-  color: $text-muted;
-
-  > svg,
-  > span:not(.logout-username) {
-    flex-shrink: 0;
-  }
-
-  &:hover {
-    color: $error;
-    background: rgba(var(--error-rgb, 239, 68, 68), 0.06);
-  }
-
-  .logout-username {
-    margin-left: auto;
-    width: 96px;
-    min-width: 0;
-    max-width: 40%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    text-align: right;
-    flex: 0 1 96px;
-    font-size: 12px;
-    color: $text-muted;
-  }
-}
-
-.status-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 8px 12px;
-}
-
-.status-indicator {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12px;
-
-  .status-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-
-  &.connected .status-dot {
-    background-color: $success;
-    box-shadow: 0 0 6px rgba(var(--success-rgb), 0.5);
-  }
-
-  &.disconnected .status-dot {
-    background-color: $error;
-  }
-
-  .status-text {
-    color: $text-secondary;
-  }
-}
-
-.version-info {
-  padding: 2px 12px 8px;
-  font-size: 11px;
-  color: $text-muted;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  gap: 6px;
-  overflow: hidden;
-}
-
-.version-links {
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
-  gap: 6px;
-}
-
-:deep(.theme-switch-container) {
-  flex-shrink: 0;
-}
-
-.github-link,
-.website-link {
-  color: $text-muted;
-  display: flex;
-  align-items: center;
-  transition: color 0.2s;
-
-  &:hover {
-    color: $text-primary;
-  }
-}
-
-.update-btn {
-  margin: 4px 0 0;
-  border-radius: 4px;
-}
-
-.version-text {
-  flex: 0 0 auto;
-  overflow: visible;
-  white-space: nowrap;
-  cursor: pointer;
-  transition: color 0.2s;
-
-  &:hover {
-    color: $accent-primary;
-  }
-}
-
-.changelog-list {
-  max-height: min(70vh, 640px);
-  overflow-y: auto;
-}
-
-.changelog-version-block {
-  margin-bottom: 20px;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-}
-
-.changelog-version-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 8px;
-}
-
-.changelog-version-tag {
-  font-weight: 600;
-  font-size: 14px;
-  color: $text-primary;
-  font-family: $font-code;
-}
-
-.changelog-changes {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-
-  li {
-    font-size: 13px;
-    color: $text-secondary;
-    padding: 4px 0 4px 16px;
-    position: relative;
-
-    &::before {
-      content: '';
-      position: absolute;
-      left: 0;
-      top: 12px;
-      width: 6px;
-      height: 6px;
-      border-radius: 50%;
-      background: $text-muted;
-    }
-  }
 }
 
 // ─── Collapsed sidebar (icon-rail mode) ─────────────────────────
 
 .sidebar.collapsed {
   width: $sidebar-collapsed-width;
-  padding: 0 8px 12px;
+  padding: 8px 8px 12px;
   overflow: hidden;
-
-  .sidebar-logo {
-    padding: 12px 4px 8px;
-    margin: 0 -8px;
-    justify-content: center;
-    gap: 0;
-
-    .logo-text {
-      display: none;
-    }
-  }
 
   .collapse-btn {
     display: flex;
-    margin: 0 auto 8px;
+    margin: 0;
+  }
+
+  .sidebar-top-actions {
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 8px;
+  }
+
+  .sidebar-return-tab {
+    width: 100%;
+    flex: 0 0 auto;
+    padding: 10px 4px;
   }
 
   .nav-group-label {
@@ -808,83 +436,6 @@ function openVersionManagement() {
     }
   }
 
-  // Hide model selector in icon-rail mode, but keep the active profile avatar
-  // visible as the profile manager entry point.
-  :deep(.model-selector) {
-    display: none;
-  }
-
-  :deep(.profile-selector) {
-    display: flex;
-    justify-content: center;
-    padding: 8px 0;
-    margin: 0 0 6px;
-    border-top: 1px solid $border-color;
-  }
-
-  :deep(.profile-selector .selector-label),
-  :deep(.profile-selector .profile-name) {
-    display: none;
-  }
-
-  :deep(.profile-selector .profile-display) {
-    width: 36px;
-    height: 36px;
-    justify-content: center;
-    padding: 0;
-    gap: 0;
-    border: none;
-    border-radius: 0;
-    background: transparent;
-  }
-
-  :deep(.profile-selector .profile-display:hover) {
-    background: transparent;
-  }
-
-  :deep(.profile-selector .profile-avatar) {
-    width: 28px !important;
-    height: 28px !important;
-    flex-basis: 28px !important;
-  }
-
-  .sidebar-footer {
-    .logout-item {
-      margin: 0;
-      padding: 10px 4px;
-      border-radius: $radius-sm;
-    }
-
-    .logout-item span {
-      display: none;
-    }
-
-    .status-text {
-      display: none;
-    }
-
-    .version-text,
-    .version-links {
-      display: none;
-    }
-
-    .status-row {
-      justify-content: center;
-
-      :deep(.input-sm) {
-        display: none;
-      }
-    }
-
-    .version-info {
-      justify-content: center;
-      padding: 4px 0;
-
-      :deep(.theme-switch-container) {
-        flex-direction: column;
-      }
-    }
-  }
 }
 
 // ─── Collapse button ────────────────────────────────────────────
@@ -903,8 +454,7 @@ function openVersionManagement() {
   border-radius: $radius-sm;
   cursor: pointer;
   flex-shrink: 0;
-  margin-left: auto;
-  margin-right: 0;
+  margin: 0;
   transition: all $transition-fast;
 
   &:hover {
@@ -913,25 +463,7 @@ function openVersionManagement() {
   }
 }
 
-// In expanded mode, overlap the top-right of the logo area
-.sidebar:not(.collapsed) .collapse-btn {
-  position: absolute;
-  top: 18px;
-  right: 16px;
-  z-index: 5;
-}
-
 @media (max-width: $breakpoint-mobile) {
-  .logo-dance {
-    display: none;
-  }
-
-  .status-row {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
-  }
-
   .sidebar {
     position: fixed;
     left: 0;
@@ -949,9 +481,5 @@ function openVersionManagement() {
       width: 90px;
     }
   }
-}
-
-.fun-link {
-  text-decoration: none;
 }
 </style>

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -37,11 +37,21 @@ function isGroupCollapsed(key: string) {
   return !!collapsedGroups[key];
 }
 
+function handleSidebarClick(event: MouseEvent) {
+  const target = event.target instanceof Element ? event.target : null;
 
+  if (!target?.closest(".route-link-item")) {
+    return;
+  }
+
+  if (typeof window !== "undefined" && window.matchMedia("(max-width: 768px)").matches) {
+    appStore.closeSidebar();
+  }
+}
 </script>
 
 <template>
-  <aside class="sidebar" :class="{ open: appStore.sidebarOpen, collapsed: appStore.sidebarCollapsed }">
+  <aside class="sidebar" :class="{ open: appStore.sidebarOpen, collapsed: appStore.sidebarCollapsed }" @click="handleSidebarClick">
     <div class="sidebar-top-actions">
       <RouteLinkItem class="nav-item sidebar-return-tab" :to="{ name: 'hermes.chat' }" :title="t('sidebar.backToChat')">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">

--- a/packages/client/src/components/layout/LanguageSwitch.vue
+++ b/packages/client/src/components/layout/LanguageSwitch.vue
@@ -30,7 +30,7 @@ function handleChange(val: string) {
     :options="options"
     size="tiny"
     :consistent-menu-width="false"
-    class="input-sm"
+    class="language-switch input-sm"
     @update:value="handleChange"
   />
 </template>

--- a/packages/client/src/components/layout/PageSidebarFooter.vue
+++ b/packages/client/src/components/layout/PageSidebarFooter.vue
@@ -1,0 +1,402 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import { NButton, NModal, NPopover, useMessage } from 'naive-ui'
+import { useAppStore } from '@/stores/hermes/app'
+import { getStoredUsername } from '@/api/client'
+import ProfileSelector from '@/components/layout/ProfileSelector.vue'
+import ModelSelector from '@/components/layout/ModelSelector.vue'
+import LanguageSwitch from '@/components/layout/LanguageSwitch.vue'
+import ThemeSwitch from '@/components/layout/ThemeSwitch.vue'
+import VersionManagementModal from '@/components/layout/VersionManagementModal.vue'
+import { changelog } from '@/data/changelog'
+
+const appStore = useAppStore()
+const message = useMessage()
+const router = useRouter()
+const { t } = useI18n()
+
+const showChangelog = ref(false)
+const showVersionManagement = ref(false)
+const currentUsername = computed(() => getStoredUsername())
+const isDesktopShell = computed(() =>
+  (window as typeof window & { hermesDesktop?: { isDesktop?: boolean } }).hermesDesktop?.isDesktop === true,
+)
+
+function openSettingsPage() {
+  void router.push({ name: 'hermes.settings' })
+}
+
+function openChangelog() {
+  showChangelog.value = true
+}
+
+function openVersionManagement() {
+  showVersionManagement.value = true
+}
+
+function handleReloadClient() {
+  appStore.reloadClient()
+}
+
+async function handleUpdate() {
+  const ok = await appStore.doUpdate()
+  if (ok) {
+    message.success(t('sidebar.updateSuccess'), { duration: 5000 })
+  } else {
+    message.error(t('sidebar.updateFailed'))
+  }
+}
+
+function handleLogout() {
+  localStorage.clear()
+  window.location.reload()
+}
+</script>
+
+<template>
+  <div class="page-sidebar-bottom">
+    <NPopover
+      trigger="click"
+      placement="top-start"
+      :show-arrow="false"
+      raw
+    >
+      <template #trigger>
+        <button class="page-sidebar-menu-btn" type="button">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </svg>
+          <span>{{ t('sidebar.settings') }}</span>
+        </button>
+      </template>
+      <div class="page-sidebar-popover">
+        <ProfileSelector />
+        <ModelSelector />
+        <div class="page-sidebar-popover-row">
+          <div
+            class="status-indicator"
+            :class="{ connected: appStore.connected, disconnected: !appStore.connected }"
+          >
+            <span class="status-dot"></span>
+            <span class="status-text">{{ appStore.connected ? t('sidebar.connected') : t('sidebar.disconnected') }}</span>
+          </div>
+          <LanguageSwitch />
+        </div>
+        <div class="page-sidebar-version-row">
+          <div class="page-sidebar-version-links">
+            <a class="page-sidebar-link" href="https://github.com/EKKOLearnAI/hermes-web-ui" target="_blank" rel="noopener noreferrer" title="GitHub">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+            </a>
+            <a class="page-sidebar-link" href="https://hermes-studio.ai/" target="_blank" rel="noopener noreferrer" title="Website">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+            </a>
+          </div>
+          <span
+            class="page-sidebar-version-text"
+            role="button"
+            tabindex="0"
+            @click="openChangelog"
+            @keydown.enter="openChangelog"
+            @keydown.space.prevent="openChangelog"
+          >
+            Studio v{{ appStore.serverVersion || '0.1.0' }}
+          </span>
+          <ThemeSwitch />
+        </div>
+        <button class="page-sidebar-nav-btn" type="button" @click="openSettingsPage">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="4" y1="6" x2="20" y2="6" />
+            <line x1="4" y1="12" x2="20" y2="12" />
+            <line x1="4" y1="18" x2="20" y2="18" />
+          </svg>
+          <span>{{ t('sidebar.settings') }}</span>
+        </button>
+        <button class="page-sidebar-logout-btn" type="button" @click="handleLogout">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+            <polyline points="16 17 21 12 16 7" />
+            <line x1="21" y1="12" x2="9" y2="12" />
+          </svg>
+          <span>{{ t('sidebar.logout') }}</span>
+          <span v-if="currentUsername" class="page-sidebar-logout-user" :title="currentUsername">
+            {{ currentUsername }}
+          </span>
+        </button>
+        <NButton v-if="isDesktopShell" type="primary" size="tiny" block @click="openVersionManagement">
+          {{ t('sidebar.versionManagement') }}
+        </NButton>
+        <NButton v-if="appStore.clientOutdated" type="warning" size="tiny" block @click="handleReloadClient">
+          {{ t('sidebar.reloadClientVersion', { version: appStore.serverVersion }) }}
+        </NButton>
+        <NButton v-if="appStore.updateAvailable" type="primary" size="tiny" block :loading="appStore.updating" @click="handleUpdate">
+          {{ appStore.updating ? t('sidebar.updating') : t('sidebar.updateVersion', { version: appStore.latestVersion }) }}
+        </NButton>
+      </div>
+    </NPopover>
+    <NModal v-model:show="showChangelog" preset="dialog" :title="t('sidebar.changelog')" style="width: 520px;">
+      <div class="changelog-list">
+        <div v-for="entry in changelog" :key="entry.version" class="changelog-version-block">
+          <div class="changelog-version-header">
+            <span class="changelog-version-tag">v{{ entry.version }}</span>
+            <span class="changelog-date">{{ entry.date }}</span>
+          </div>
+          <ul class="changelog-changes">
+            <li v-for="(change, idx) in entry.changes" :key="idx">{{ t(change) }}</li>
+          </ul>
+        </div>
+      </div>
+    </NModal>
+    <VersionManagementModal v-if="isDesktopShell" v-model:show="showVersionManagement" />
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use "@/styles/variables" as *;
+
+.page-sidebar-bottom {
+  flex-shrink: 0;
+  padding: 10px 12px;
+}
+
+.page-sidebar-menu-btn {
+  width: 100%;
+  min-width: 0;
+  height: 36px;
+  border: none;
+  border-radius: $radius-sm;
+  background: transparent;
+  color: $text-secondary;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  cursor: pointer;
+  transition:
+    background-color $transition-fast,
+    color $transition-fast;
+
+  &:hover {
+    background: rgba(var(--accent-primary-rgb), 0.06);
+    color: $text-primary;
+  }
+
+  span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 13px;
+    line-height: 18px;
+  }
+}
+
+.page-sidebar-popover {
+  width: $sidebar-width;
+  padding: 12px;
+  border: 1px solid $border-color;
+  border-radius: $radius-md;
+  background: $bg-card;
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.18);
+}
+
+.page-sidebar-popover :deep(.profile-selector),
+.page-sidebar-popover :deep(.model-selector) {
+  padding: 0;
+}
+
+.page-sidebar-popover :deep(.model-selector) {
+  margin-bottom: 10px;
+}
+
+.page-sidebar-popover :deep(.language-switch) {
+  width: 88px;
+  flex: 0 0 88px;
+}
+
+.page-sidebar-popover :deep(.language-switch .n-base-selection-input__content) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.page-sidebar-popover-row,
+.page-sidebar-version-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 0;
+  border-top: 1px solid $border-color;
+}
+
+.status-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-size: 12px;
+  color: $text-secondary;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status-indicator.connected .status-dot {
+  background-color: $success;
+  box-shadow: 0 0 6px rgba(var(--success-rgb), 0.5);
+}
+
+.status-indicator.disconnected .status-dot {
+  background-color: $error;
+}
+
+.status-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.page-sidebar-version-row {
+  gap: 6px;
+}
+
+.page-sidebar-version-links {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 6px;
+}
+
+.page-sidebar-link {
+  color: $text-muted;
+  display: flex;
+  align-items: center;
+  transition: color $transition-fast;
+
+  &:hover {
+    color: $text-primary;
+  }
+}
+
+.page-sidebar-version-text {
+  flex: 0 0 auto;
+  color: $text-muted;
+  font-size: 11px;
+  line-height: 16px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color $transition-fast;
+
+  &:hover {
+    color: $accent-primary;
+  }
+}
+
+.page-sidebar-version-row :deep(.theme-switch-container) {
+  flex-shrink: 0;
+}
+
+.page-sidebar-nav-btn,
+.page-sidebar-logout-btn {
+  width: 100%;
+  min-width: 0;
+  height: 36px;
+  border: none;
+  border-top: 1px solid $border-color;
+  border-radius: 0;
+  background: transparent;
+  color: $text-secondary;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0;
+  cursor: pointer;
+  transition:
+    background-color $transition-fast,
+    color $transition-fast;
+}
+
+.page-sidebar-nav-btn:hover {
+  color: $text-primary;
+}
+
+.page-sidebar-logout-btn {
+  margin-bottom: 6px;
+
+  &:hover {
+    color: $error;
+  }
+}
+
+.page-sidebar-nav-btn span,
+.page-sidebar-logout-btn span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.page-sidebar-logout-user {
+  margin-left: auto;
+  max-width: 112px;
+  color: $text-muted;
+  font-size: 12px;
+}
+
+.changelog-list {
+  max-height: 56vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-right: 4px;
+}
+
+.changelog-version-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.changelog-version-tag {
+  font-weight: 600;
+  color: $text-primary;
+}
+
+.changelog-date {
+  font-size: 12px;
+  color: $text-muted;
+}
+
+.changelog-changes {
+  margin: 0;
+  padding-left: 18px;
+  color: $text-secondary;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+@media (max-width: $breakpoint-mobile) {
+  .page-sidebar-popover {
+    width: min(280px, calc(100vw - 32px));
+  }
+
+  .page-sidebar-popover :deep(.language-switch) {
+    width: 96px;
+    flex-basis: 96px;
+  }
+}
+</style>

--- a/packages/client/src/components/layout/PageSidebarNav.vue
+++ b/packages/client/src/components/layout/PageSidebarNav.vue
@@ -1,0 +1,250 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import { useSessionSearch } from '@/composables/useSessionSearch'
+
+type ActiveSection = 'chat' | 'history' | 'group'
+
+const props = defineProps<{
+  active: ActiveSection
+  primaryLabel?: string
+  hideModeSwitch?: boolean
+}>()
+
+const emit = defineEmits<{
+  primary: []
+}>()
+
+const { t } = useI18n()
+const router = useRouter()
+const { openSessionSearch } = useSessionSearch()
+
+const primaryText = computed(() => props.primaryLabel || t('chat.newChat'))
+const showModeSwitch = computed(() => !props.hideModeSwitch)
+const historyButtonLabel = computed(() =>
+  props.active === 'history' ? t('chat.sessions') : t('sidebar.history'),
+)
+
+function openChat() {
+  if (props.active === 'chat') return
+  void router.push({ name: 'hermes.chat' })
+}
+
+function openHistory() {
+  if (props.active === 'history') {
+    void router.push({ name: 'hermes.chat' })
+    return
+  }
+  void router.push({ name: 'hermes.history' })
+}
+
+function openGroupChat() {
+  if (props.active === 'group') return
+  void router.push({ name: 'hermes.groupChat' })
+}
+
+function openApiRelay() {
+  if (typeof window === 'undefined') return
+  window.open('https://apikey.fun/register?aff=LIBAPI', '_blank', 'noopener,noreferrer')
+}
+</script>
+
+<template>
+  <div class="page-sidebar-nav">
+    <div class="page-sidebar-tabs" role="tablist" aria-label="Chat actions">
+      <button
+        class="page-sidebar-tab"
+        type="button"
+        @click="emit('primary')"
+      >
+        <svg
+          width="15"
+          height="15"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <line x1="12" y1="5" x2="12" y2="19" />
+          <line x1="5" y1="12" x2="19" y2="12" />
+        </svg>
+        <span>{{ primaryText }}</span>
+      </button>
+      <button class="page-sidebar-tab" type="button" @click="openSessionSearch">
+        <svg
+          width="15"
+          height="15"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+        >
+          <circle cx="11" cy="11" r="7" />
+          <path d="m20 20-3.5-3.5" />
+        </svg>
+        <span>{{ t('sidebar.search') }}</span>
+      </button>
+      <button
+        class="page-sidebar-tab"
+        type="button"
+        @click="openHistory"
+      >
+        <svg
+          v-if="active === 'history'"
+          width="15"
+          height="15"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+        <svg
+          v-else
+          width="15"
+          height="15"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="12" cy="12" r="9" />
+          <path d="M12 7v5l3 2" />
+        </svg>
+        <span>{{ historyButtonLabel }}</span>
+      </button>
+      <button class="page-sidebar-tab" type="button" @click="openApiRelay">
+        <svg
+          width="15"
+          height="15"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+        >
+          <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
+          <polyline points="15 3 21 3 21 9" />
+          <line x1="10" y1="14" x2="21" y2="3" />
+        </svg>
+        <span>{{ t('sidebar.apiRelay') }}</span>
+      </button>
+    </div>
+    <div v-if="showModeSwitch" class="conversation-switch" role="tablist" aria-label="Conversation type">
+      <button
+        class="conversation-switch-tab"
+        :class="{ active: active === 'chat' || active === 'history' }"
+        type="button"
+        role="tab"
+        :aria-selected="active === 'chat' || active === 'history'"
+        @click="openChat"
+      >
+        {{ t('sidebar.singleChat') }}
+      </button>
+      <button
+        class="conversation-switch-tab"
+        :class="{ active: active === 'group' }"
+        type="button"
+        role="tab"
+        :aria-selected="active === 'group'"
+        @click="openGroupChat"
+      >
+        {{ t('sidebar.groupChat') }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use "@/styles/variables" as *;
+
+.page-sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.page-sidebar-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.page-sidebar-tab {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  border: none;
+  border-radius: $radius-sm;
+  background: transparent;
+  color: $text-secondary;
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 7px 10px;
+  cursor: pointer;
+  transition:
+    background-color $transition-fast,
+    color $transition-fast;
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 13px;
+    line-height: 18px;
+  }
+
+  &:hover,
+  &.active {
+    background: rgba(var(--accent-primary-rgb), 0.06);
+    color: $text-primary;
+  }
+}
+
+.conversation-switch {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2px;
+  padding: 2px;
+  border-radius: $radius-sm;
+  background: rgba(var(--accent-primary-rgb), 0.05);
+}
+
+.conversation-switch-tab {
+  min-width: 0;
+  height: 28px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: $text-secondary;
+  font-size: 12px;
+  line-height: 16px;
+  cursor: pointer;
+  transition:
+    background-color $transition-fast,
+    color $transition-fast;
+
+  &:hover {
+    color: $text-primary;
+  }
+
+  &.active {
+    background: $bg-card;
+    color: $text-primary;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  }
+}
+</style>

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -180,6 +180,7 @@ export default {
   // Sidebar
   sidebar: {
     chat: 'Chat',
+    backToChat: 'Zuruck',
     search: 'Suche',
     apiRelay: 'API-Relay',
     history: 'Verlauf',
@@ -196,6 +197,7 @@ export default {
     skillsUsage: 'Skill-Nutzung',
     channels: 'Kanale',
     terminal: 'Konsole',
+    singleChat: 'Chat',
     files: 'Dateien',
     devices: 'Gerate',
     groupChat: 'Gruppenchat',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -180,6 +180,7 @@ export default {
   // Sidebar
   sidebar: {
     chat: 'Chat',
+    backToChat: 'Back',
     search: 'Search',
     apiRelay: 'API Relay',
     history: 'History',
@@ -198,6 +199,7 @@ export default {
     channels: 'Channels',
     gateways: 'Gateways',
     terminal: 'Terminal',
+    singleChat: 'Chat',
     groupChat: 'Group Chat',
     files: 'Files',
     devices: 'Devices',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -180,6 +180,7 @@ export default {
   // Sidebar
   sidebar: {
     chat: 'Chat',
+    backToChat: 'Volver',
     search: 'Buscar',
     apiRelay: 'API Relay',
     history: 'Historial',
@@ -196,6 +197,7 @@ export default {
     skillsUsage: 'Uso de habilidades',
     channels: 'Canales',
     terminal: 'Terminal',
+    singleChat: 'Chat',
     files: 'Archivos',
     devices: 'Dispositivos',
     groupChat: 'Chat grupal',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -180,6 +180,7 @@ export default {
   // Sidebar
   sidebar: {
     chat: 'Discussion',
+    backToChat: 'Retour',
     search: 'Rechercher',
     apiRelay: 'API Relay',
     history: 'Historique',
@@ -196,6 +197,7 @@ export default {
     skillsUsage: 'Utilisation des compétences',
     channels: 'Canaux',
     terminal: 'Terminal',
+    singleChat: 'Discussion',
     files: 'Fichiers',
     devices: 'Appareils',
     groupChat: 'Chat de groupe',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -180,6 +180,7 @@ export default {
 
   sidebar: {
     chat: 'チャット',
+    backToChat: '戻る',
     search: '検索',
     apiRelay: 'APIリレー',
     history: '履歴',
@@ -196,6 +197,7 @@ export default {
     skillsUsage: 'スキル使用状況',
     channels: 'チャンネル',
     terminal: 'ターミナル',
+    singleChat: 'チャット',
     files: 'ファイル',
     devices: 'デバイス',
     groupChat: 'グループチャット',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -180,6 +180,7 @@ export default {
 
   sidebar: {
     chat: '채팅',
+    backToChat: '뒤로',
     search: '검색',
     apiRelay: 'API 릴레이',
     history: '기록',
@@ -196,6 +197,7 @@ export default {
     skillsUsage: '스킬 사용량',
     channels: '채널',
     terminal: '터미널',
+    singleChat: '채팅',
     files: '파일',
     devices: '기기',
     groupChat: '그룹 채팅',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -180,6 +180,7 @@ export default {
   // Sidebar
   sidebar: {
     chat: 'Chat',
+    backToChat: 'Voltar',
     search: 'Pesquisar',
     apiRelay: 'API Relay',
     history: 'Historico',
@@ -196,6 +197,7 @@ export default {
     skillsUsage: 'Uso de habilidades',
     channels: 'Canais',
     terminal: 'Terminal',
+    singleChat: 'Chat',
     files: 'Arquivos',
     devices: 'Dispositivos',
     groupChat: 'Chat em grupo',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -106,6 +106,7 @@ export default {
 
   sidebar: {
     chat: 'Чат',
+    backToChat: 'Назад',
     search: 'Поиск',
     apiRelay: 'Ретранслятор API',
     history: 'История',
@@ -123,6 +124,7 @@ export default {
     channels: 'Каналы',
     gateways: 'Шлюзы',
     terminal: 'Терминал',
+    singleChat: 'Чат',
     groupChat: 'Групповой чат',
     files: 'Файлы',
     devices: 'Устройства',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -180,6 +180,7 @@ export default {
 
   sidebar: {
     chat: '對話',
+    backToChat: '返回',
     search: '搜尋',
     apiRelay: '中轉站',
     history: '歷史',
@@ -198,6 +199,7 @@ export default {
     channels: '頻道',
     gateways: '閘道',
     terminal: '終端機',
+    singleChat: '單聊',
     groupChat: '群聊',
     files: '檔案',
     devices: '裝置',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -180,6 +180,7 @@ export default {
 
   sidebar: {
     chat: '对话',
+    backToChat: '返回',
     search: '搜索',
     apiRelay: '饲料',
     history: '历史',
@@ -198,6 +199,7 @@ export default {
     channels: '频道',
     gateways: '网关',
     terminal: '终端',
+    singleChat: '单聊',
     groupChat: '群聊',
     files: '文件',
     devices: '设备',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -640,6 +640,10 @@ export const useChatStore = defineStore('chat', () => {
     if (hasQueue) {
       return
     }
+    if (activeSessionId.value === sessionId) {
+      clearSessionCompletedUnread(sessionId)
+      return
+    }
     const next = new Set(completedUnreadSessions.value)
     next.add(sessionId)
     completedUnreadSessions.value = next

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -552,6 +552,8 @@ export const useChatStore = defineStore('chat', () => {
   const streamStates = ref<Map<string, { abort: () => void }>>(new Map())
   /** sessionId → server-reported isWorking status */
   const serverWorking = ref<Set<string>>(new Set())
+  /** Sessions that completed while the user was viewing another session. */
+  const completedUnreadSessions = ref<Set<string>>(new Set())
   const sessionProfileFilter = ref<string | null>(null)
   /** sessionId → queued message count */
   const queueLengths = ref<Map<string, number>>(new Map())
@@ -623,6 +625,31 @@ export const useChatStore = defineStore('chat', () => {
     return streamStates.value.has(sessionId) || serverWorking.value.has(sessionId)
   }
 
+  function isSessionCompletedUnread(sessionId: string): boolean {
+    return completedUnreadSessions.value.has(sessionId)
+  }
+
+  function clearSessionCompletedUnread(sessionId: string) {
+    if (!completedUnreadSessions.value.has(sessionId)) return
+    const next = new Set(completedUnreadSessions.value)
+    next.delete(sessionId)
+    completedUnreadSessions.value = next
+  }
+
+  function markSessionCompletedUnread(sessionId: string, hasQueue = false) {
+    if (hasQueue) {
+      return
+    }
+    const next = new Set(completedUnreadSessions.value)
+    next.add(sessionId)
+    completedUnreadSessions.value = next
+  }
+
+  function pruneCompletedUnreadSessions(existingIds: Set<string>) {
+    const next = new Set([...completedUnreadSessions.value].filter(id => existingIds.has(id)))
+    if (next.size !== completedUnreadSessions.value.size) completedUnreadSessions.value = next
+  }
+
   function clearActiveSession() {
     const sid = activeSessionId.value
     activeSessionId.value = null
@@ -650,6 +677,7 @@ export const useChatStore = defineStore('chat', () => {
         if (prev?.contextTokens != null) s.contextTokens = prev.contextTokens
       }
       sessions.value = fresh
+      pruneCompletedUnreadSessions(new Set(sessions.value.map(s => s.id)))
 
       // Restore route-selected session first (tab-local source of truth),
       // then current in-memory session, then persisted legacy/default choice,
@@ -738,6 +766,7 @@ export const useChatStore = defineStore('chat', () => {
       }
 
       sessions.value = next
+      pruneCompletedUnreadSessions(new Set(next.map(s => s.id)))
 
       // Defensive: re-bind activeSession to the (same) object now in the array,
       // by id, in case anything above changed array membership.
@@ -846,6 +875,7 @@ export const useChatStore = defineStore('chat', () => {
     const legacyActiveKey = legacyStorageKey()
     if (legacyActiveKey) removeItem(legacyActiveKey)
     activeSession.value = sessions.value.find(s => s.id === sessionId) || null
+    clearSessionCompletedUnread(sessionId)
 
     if (!activeSession.value) return
 
@@ -1995,6 +2025,7 @@ export const useChatStore = defineStore('chat', () => {
           if (eventRunMarker) activeRunMarker = eventRunMarker
           switch (evt.event) {
             case 'run.started':
+              clearSessionCompletedUnread(sid)
               serverWorking.value.add(sid)
               clearAgentEventMessages(sid)
               setAbortState(null)
@@ -2402,7 +2433,9 @@ export const useChatStore = defineStore('chat', () => {
                 }
               }
 
-              if ((evt as any).queue_remaining > 0) {
+              const hasQueue = (evt as any).queue_remaining > 0
+              markSessionCompletedUnread(sid, hasQueue)
+              if (hasQueue) {
                 queueLengths.value.set(sid, (evt as any).queue_remaining)
               } else {
                 cleanup()
@@ -2590,6 +2623,7 @@ export const useChatStore = defineStore('chat', () => {
         }
 
         case 'run.started':
+          clearSessionCompletedUnread(sid)
           serverWorking.value.add(sid)
           clearAgentEventMessages(sid)
           setAbortState(null)
@@ -2953,11 +2987,13 @@ export const useChatStore = defineStore('chat', () => {
           }
 
           if (!hasQueue) {
+            markSessionCompletedUnread(sid)
             cleanup()
             activeAssistantMessageId = null
             reasoningAssistantMessageId = null
             activeRunMarker = null
           } else {
+            markSessionCompletedUnread(sid, true)
             // More runs pending — reset for next run but don't cleanup
             activeAssistantMessageId = null
             reasoningAssistantMessageId = null
@@ -3293,6 +3329,8 @@ export const useChatStore = defineStore('chat', () => {
     isStreaming,
     isRunActive,
     isSessionLive,
+    isSessionCompletedUnread,
+    clearSessionCompletedUnread,
     sessionProfileFilter,
     compressionState,
     abortState,

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -12,6 +12,8 @@ import { copyToClipboard } from '@/utils/clipboard'
 import HistoryMessageList from '@/components/hermes/chat/HistoryMessageList.vue'
 import SessionListItem from '@/components/hermes/chat/SessionListItem.vue'
 import OutlinePanel from '@/components/hermes/chat/OutlinePanel.vue'
+import PageSidebarNav from '@/components/layout/PageSidebarNav.vue'
+import PageSidebarFooter from '@/components/layout/PageSidebarFooter.vue'
 import { batchDeleteSessions, deleteSession, fetchHermesSessions, fetchHermesSession, fetchSessionMessagesPage, importHermesSession, type HermesMessage, type SessionSummary } from '@/api/hermes/sessions'
 
 const appStore = useAppStore()
@@ -57,6 +59,10 @@ const HISTORY_PAGE_SIZE = 300
 
 function handleOutlineNavigate(target: { messageId: string; anchorId: string }) {
   historyMessageListRef.value?.scrollToAnchor(target.messageId, target.anchorId)
+}
+
+function openNewChatPage() {
+  void router.push({ name: 'hermes.chat' })
 }
 
 async function loadHermesSessions() {
@@ -296,6 +302,10 @@ function handleMobileChange(e: MediaQueryListEvent | MediaQueryList) {
   }
 }
 
+function openPageSidebar() {
+  showSessions.value = true
+}
+
 onMounted(async () => {
   appStore.loadModels()
   await profilesStore.fetchProfiles()
@@ -305,10 +315,12 @@ onMounted(async () => {
   mobileQuery = window.matchMedia('(max-width: 768px)')
   handleMobileChange(mobileQuery)
   mobileQuery.addEventListener('change', handleMobileChange)
+  window.addEventListener('hermes:open-page-sidebar', openPageSidebar)
 })
 
 onUnmounted(() => {
   mobileQuery?.removeEventListener('change', handleMobileChange)
+  window.removeEventListener('hermes:open-page-sidebar', openPageSidebar)
 })
 
 watch([routeSessionId, routeProfile], async ([sessionId]) => {
@@ -663,76 +675,81 @@ function handleBatchDeleteConfirm() {
   <div class="history-panel">
     <div class="session-backdrop" :class="{ active: showSessions }" @click="showSessions = false" />
     <aside class="session-list" :class="{ collapsed: !showSessions }">
-      <div class="session-list-header">
-        <span v-if="showSessions" class="session-list-title">{{ t('chat.hermesHistory') }}</span>
-        <div class="session-list-actions">
-          <button class="session-close-btn" @click="showSessions = false">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-          </button>
-          <NButton
-            v-if="!isBatchMode"
-            quaternary
-            size="tiny"
-            :disabled="hermesSessions.length === 0"
-            :title="t('chat.toggleBatchMode')"
-            @click="toggleBatchMode"
-          >
-            <template #icon>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M9 11l3 3L22 4" />
-                <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
-              </svg>
-            </template>
-          </NButton>
-          <NButton
-            v-if="isBatchMode"
-            quaternary
-            size="tiny"
-            :disabled="!canSelectAll || isBatchDeleting"
-            :title="allSessionsSelected ? t('common.cancel') : t('chat.selectAll')"
-            @click="toggleSelectAllSessions"
-          >
-            <template #icon>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M9 11l3 3L22 4" />
-                <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
-              </svg>
-            </template>
-          </NButton>
-          <NPopconfirm
-            v-if="isBatchMode && selectedCount > 0"
-            v-model:show="showBatchDeleteConfirm"
-            :positive-button-props="{ loading: isBatchDeleting, disabled: isBatchDeleting }"
-            :negative-button-props="{ disabled: isBatchDeleting }"
-            @positive-click="handleBatchDeleteConfirm"
-          >
-            <template #trigger>
-              <NButton quaternary size="tiny" type="error" :loading="isBatchDeleting" :disabled="isBatchDeleting">
-                <template #icon>
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <polyline points="3 6 5 6 21 6" />
-                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-                  </svg>
-                </template>
-              </NButton>
-            </template>
-            {{ t('chat.confirmBatchDelete', { count: selectedCount }) }}
-          </NPopconfirm>
-          <NButton
-            v-if="isBatchMode"
-            quaternary
-            size="tiny"
-            :disabled="isBatchDeleting"
-            @click="toggleBatchMode"
-          >
-            <template #icon>
+      <div v-if="showSessions" class="page-sidebar-top">
+        <PageSidebarNav
+          active="history"
+          :primary-label="t('chat.newChat')"
+          hide-mode-switch
+          @primary="openNewChatPage"
+        />
+        <div class="session-list-toolbar">
+          <span class="session-list-title">{{ t('chat.hermesHistory') }}</span>
+          <div class="session-list-actions">
+            <button class="session-close-btn" @click="showSessions = false">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-            </template>
-          </NButton>
+            </button>
+            <NButton
+              v-if="!isBatchMode"
+              quaternary
+              size="tiny"
+              :disabled="hermesSessions.length === 0"
+              :title="t('chat.toggleBatchMode')"
+              @click="toggleBatchMode"
+            >
+              <template #icon>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M9 11l3 3L22 4" />
+                  <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+                </svg>
+              </template>
+            </NButton>
+            <NButton
+              v-if="isBatchMode"
+              quaternary
+              size="tiny"
+              :disabled="!canSelectAll || isBatchDeleting"
+              :title="allSessionsSelected ? t('common.cancel') : t('chat.selectAll')"
+              @click="toggleSelectAllSessions"
+            >
+              <template #icon>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M9 11l3 3L22 4" />
+                  <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+                </svg>
+              </template>
+            </NButton>
+            <NPopconfirm
+              v-if="isBatchMode && selectedCount > 0"
+              v-model:show="showBatchDeleteConfirm"
+              :positive-button-props="{ loading: isBatchDeleting, disabled: isBatchDeleting }"
+              :negative-button-props="{ disabled: isBatchDeleting }"
+              @positive-click="handleBatchDeleteConfirm"
+            >
+              <template #trigger>
+                <NButton quaternary size="tiny" type="error" :loading="isBatchDeleting" :disabled="isBatchDeleting">
+                  <template #icon>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <polyline points="3 6 5 6 21 6" />
+                      <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                    </svg>
+                  </template>
+                </NButton>
+              </template>
+              {{ t('chat.confirmBatchDelete', { count: selectedCount }) }}
+            </NPopconfirm>
+            <NButton
+              v-if="isBatchMode"
+              quaternary
+              size="tiny"
+              :disabled="isBatchDeleting"
+              @click="toggleBatchMode"
+            >
+              <template #icon>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+              </template>
+            </NButton>
+          </div>
         </div>
-      </div>
-      <div v-if="showSessions" class="session-scope-note">
-        {{ t('chat.historyScopeHint') }}
       </div>
       <div v-if="showSessions" class="session-items">
         <div v-if="hermesSessionsLoading && hermesSessions.length === 0" class="session-loading">{{ t('common.loading') }}</div>
@@ -753,7 +770,7 @@ function handleBatchDeleteConfirm() {
             :streaming="false"
             :selectable="isBatchMode"
             :selected="isSessionSelected(s)"
-            :show-profile="false"
+            :show-profile="true"
             @select="isBatchMode ? toggleSessionSelection(s) : handleSessionClick(s.id, s.profile)"
             @contextmenu="handleContextMenu($event, s.id)"
             @delete="handleDeleteSession(s.id, s.profile)"
@@ -778,7 +795,7 @@ function handleBatchDeleteConfirm() {
               :streaming="false"
               :selectable="isBatchMode"
               :selected="isSessionSelected(s)"
-              :show-profile="false"
+              :show-profile="true"
               @select="isBatchMode ? toggleSessionSelection(s) : handleSessionClick(s.id, s.profile)"
               @contextmenu="handleContextMenu($event, s.id)"
               @delete="handleDeleteSession(s.id, s.profile)"
@@ -787,6 +804,7 @@ function handleBatchDeleteConfirm() {
           </template>
         </template>
       </div>
+      <PageSidebarFooter v-if="showSessions" />
     </aside>
 
     <NDropdown
@@ -879,7 +897,7 @@ function handleBatchDeleteConfirm() {
 }
 
 .session-list {
-  width: 220px;
+  width: $sidebar-width;
   border-right: 1px solid $border-color;
   display: flex;
   flex-direction: column;
@@ -902,7 +920,7 @@ function handleBatchDeleteConfirm() {
     z-index: 120;
     background: $bg-card;
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
-    width: 280px;
+    width: $sidebar-width;
 
     &.collapsed {
       transform: translateX(-100%);
@@ -930,6 +948,20 @@ function handleBatchDeleteConfirm() {
       pointer-events: auto;
     }
   }
+}
+
+.page-sidebar-top {
+  flex-shrink: 0;
+  padding: 12px;
+  border-bottom: 1px solid $border-color;
+}
+
+.session-list-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 12px;
 }
 
 .session-list-header {
@@ -966,17 +998,6 @@ function handleBatchDeleteConfirm() {
   color: $text-muted;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-}
-
-.session-scope-note {
-  margin: 0 12px 10px;
-  padding: 8px 10px;
-  border: 1px solid rgba($accent-primary, 0.16);
-  border-radius: $radius-sm;
-  background: rgba($accent-primary, 0.06);
-  color: $text-secondary;
-  font-size: 11px;
-  line-height: 1.45;
 }
 
 .session-group-header {
@@ -1030,128 +1051,6 @@ function handleBatchDeleteConfirm() {
   text-align: center;
 }
 
-:deep(.session-item) {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 8px 10px;
-  border: none;
-  background: none;
-  border-radius: $radius-sm;
-  cursor: pointer;
-  text-align: left;
-  color: $text-secondary;
-  transition: all $transition-fast;
-  margin-bottom: 2px;
-
-  &:hover {
-    background: rgba($accent-primary, 0.06);
-    color: $text-primary;
-
-    .session-item-delete {
-      opacity: 1;
-    }
-  }
-
-  &.active {
-    background: rgba(var(--accent-primary-rgb), 0.12);
-    color: $text-primary;
-    font-weight: 500;
-  }
-
-  &.active .session-item-title {
-    color: $accent-primary;
-  }
-}
-
-:deep(.session-item-content) {
-  flex: 1;
-  overflow: hidden;
-}
-
-:deep(.session-item-title-row) {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-}
-
-:deep(.session-item-title) {
-  display: block;
-  flex: 1 1 auto;
-  min-width: 0;
-  font-size: 13px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-:deep(.session-item-streaming) {
-  display: inline-block;
-  flex-shrink: 0;
-  margin-right: 4px;
-  vertical-align: middle;
-  animation: spin 1.2s linear infinite;
-  color: $accent-primary;
-}
-
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-:deep(.session-item-pin) {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  color: $accent-primary;
-}
-
-:deep(.session-item-time) {
-  font-size: 11px;
-  color: $text-muted;
-}
-
-:deep(.session-item-meta) {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 2px;
-}
-
-:deep(.session-item-model) {
-  font-size: 10px;
-  color: $accent-primary;
-  background: rgba($accent-primary, 0.08);
-  padding: 0 5px;
-  border-radius: 3px;
-  line-height: 16px;
-  flex-shrink: 0;
-  max-width: 100px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-:deep(.session-item-delete) {
-  flex-shrink: 0;
-  opacity: 0.5;
-  padding: 2px;
-  border: none;
-  background: none;
-  color: $text-muted;
-  cursor: pointer;
-  border-radius: 3px;
-  transition: all $transition-fast;
-
-  &:hover {
-    color: $error;
-    background: rgba($error, 0.1);
-  }
-}
-
 .chat-main {
   flex: 1;
   display: flex;
@@ -1178,16 +1077,23 @@ function handleBatchDeleteConfirm() {
   min-width: 0;
 }
 
+.header-left :deep(.n-button) {
+  flex: 0 0 auto;
+}
+
 .header-session-title {
   font-size: 16px;
   font-weight: 600;
   color: $text-primary;
+  line-height: 28px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .source-badge {
+  display: inline-flex;
+  align-items: center;
   font-size: 10px;
   color: $text-muted;
   background: rgba($text-muted, 0.12);
@@ -1195,6 +1101,7 @@ function handleBatchDeleteConfirm() {
   border-radius: 8px;
   flex-shrink: 0;
   white-space: nowrap;
+  height: 18px;
   line-height: 16px;
 }
 
@@ -1209,14 +1116,21 @@ function handleBatchDeleteConfirm() {
   .chat-header {
     padding: 16px 12px 16px 52px;
   }
+
+  .header-left :deep(.n-icon-slot) {
+    display: none;
+  }
 }
 
 .workspace-badge {
+  display: inline-flex;
+  align-items: center;
   font-size: 11px;
   color: $text-muted;
   background: rgba(255, 255, 255, 0.05);
   padding: 2px 8px;
   border-radius: 4px;
+  height: 20px;
   max-width: 160px;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/client/src/views/hermes/SkillsView.vue
+++ b/packages/client/src/views/hermes/SkillsView.vue
@@ -243,7 +243,7 @@ function handlePinToggled(name: string, pinned: boolean) {
           :placeholder="t('skills.searchPlaceholder')"
           size="small"
           clearable
-          style="width: 160px"
+          style="width: 130px"
         />
       </div>
     </header>

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -263,7 +263,7 @@ function splashHtml(): string {
   const startingLabel = escapeHtml(t('desktop.startingLocalServices'))
   const html = `<!doctype html><html><head><meta charset="utf-8"><title>Hermes Studio</title>
 <style>
-  html,body{margin:0;height:100%;background:#1a1a1a;color:#e5e5e5;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;}
+  html,body{margin:0;height:100%;background:#1a1a1a;color:#e5e5e5;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;-webkit-app-region:drag;}
   .wrap{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;gap:20px}
   .dot{width:10px;height:10px;border-radius:50%;background:#888;animation:pulse 1.2s ease-in-out infinite}
   @keyframes pulse{0%,100%{opacity:.3}50%{opacity:1}}
@@ -294,8 +294,30 @@ function escapeHtml(value: string): string {
   }[char] || char))
 }
 
+function resolveRuntimeSourceLogo(): string {
+  const candidates = [
+    join(webuiDir(), 'dist', 'client', 'logo.png'),
+    join(webuiDir(), 'packages', 'client', 'public', 'logo.png'),
+    join(webuiDir(), 'logo.png'),
+    desktopIcon(),
+  ]
+  return candidates.find(candidate => existsSync(candidate)) || desktopIcon()
+}
+
+function runtimeSourceLogoDataUri(): string {
+  const logoPath = resolveRuntimeSourceLogo()
+  try {
+    const image = nativeImage.createFromPath(logoPath)
+    if (image.isEmpty()) return ''
+    return image.resize({ width: 68, height: 68, quality: 'best' }).toDataURL()
+  } catch {
+    return ''
+  }
+}
+
 function runtimeSourceHtml(errorMessage?: string): string {
   const safeError = errorMessage ? escapeHtml(errorMessage) : ''
+  const logoUrl = runtimeSourceLogoDataUri()
   const errorBlock = safeError
     ? `<section class="error" aria-live="polite">
         <div class="error-title">${escapeHtml(t('desktop.downloadFailed'))}</div>
@@ -306,15 +328,15 @@ function runtimeSourceHtml(errorMessage?: string): string {
 <style>
   :root{color-scheme:dark}
   *{box-sizing:border-box}
-  html,body{margin:0;min-height:100%;background:#191919;color:#f1f1f1;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;}
-  body{display:grid;place-items:center;padding:32px}
+  html,body{margin:0;width:100%;height:100%;background:#191919;color:#f1f1f1;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;}
+  body{min-height:100%;display:grid;place-items:center;padding:32px;-webkit-app-region:drag;}
   .wrap{width:min(720px,100%);display:flex;flex-direction:column;align-items:center;gap:22px;text-align:center}
   .brand{display:flex;align-items:center;gap:10px;color:#f6f6f6}
-  .mark{width:32px;height:32px;border-radius:7px;background:#f0f0f0;color:#171717;display:grid;place-items:center;font-weight:700;font-size:16px}
+  .mark{width:34px;height:34px;border-radius:8px;object-fit:contain;display:block}
   h1{font-weight:560;margin:0;font-size:22px;line-height:1.25}
   .label{max-width:520px;font-size:14px;line-height:1.6;color:#b9b9b9;margin:0}
   .actions{width:100%;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
-  button{min-height:86px;border:1px solid #4c4c4c;border-radius:8px;background:#242424;color:#f2f2f2;cursor:pointer;padding:16px;text-align:left;display:flex;flex-direction:column;gap:7px;transition:background .14s ease,border-color .14s ease,transform .14s ease}
+  button{min-height:86px;border:1px solid #4c4c4c;border-radius:8px;background:#242424;color:#f2f2f2;cursor:pointer;padding:16px;text-align:left;display:flex;flex-direction:column;gap:7px;transition:background .14s ease,border-color .14s ease,transform .14s ease;-webkit-app-region:no-drag}
   button:hover{background:#2d2d2d;border-color:#747474;transform:translateY(-1px)}
   button:active{transform:translateY(0)}
   button:focus-visible{outline:2px solid #dcdcdc;outline-offset:3px}
@@ -322,14 +344,14 @@ function runtimeSourceHtml(errorMessage?: string): string {
   .button-detail{font-size:12px;line-height:1.45;color:#aaaaaa}
   .error{width:100%;text-align:left;background:#241b1b;border:1px solid #6b3939;border-radius:8px;padding:14px}
   .error-title{font-size:13px;font-weight:650;color:#ffc3c3;margin-bottom:8px}
-  pre{width:100%;max-height:180px;overflow:auto;white-space:pre-wrap;margin:0;color:#ffaaaa;font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+  pre{width:100%;max-height:180px;overflow:auto;white-space:pre-wrap;margin:0;color:#ffaaaa;font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;-webkit-app-region:no-drag}
   @media (max-width:560px){
     body{padding:24px}
     .actions{grid-template-columns:1fr}
     button{min-height:78px}
   }
 </style></head><body><main class="wrap">
-<div class="brand"><div class="mark">H</div><h1>Hermes Studio</h1></div>
+<div class="brand">${logoUrl ? `<img class="mark" src="${logoUrl}" alt="Hermes Studio">` : ''}<h1>Hermes Studio</h1></div>
 <p class="label">${escapeHtml(t('desktop.selectRuntimeSource'))}</p>
 ${errorBlock}
 <div class="actions">
@@ -401,23 +423,21 @@ async function bootstrap(source?: RuntimeDownloadSource) {
 
   try {
     const selectedSource = source || envRuntimeDownloadSource()
-    const migration = migrateLegacyDesktopRuntime(updateSplash)
-    const migrationFailed = migration.status === 'failed'
+    migrateLegacyDesktopRuntime(updateSplash)
     const runtimeUrlOverride = !!process.env.HERMES_DESKTOP_RUNTIME_URL?.trim()
     const manifestOverride = !!process.env.HERMES_DESKTOP_RUNTIME_MANIFEST_URL?.trim()
     const forceUpdate = !!process.env.HERMES_DESKTOP_RUNTIME_FORCE_UPDATE
     const runtimeReady = isDesktopRuntimeReady()
     const packagedRuntimeUpdate = app.isPackaged && runtimeReady && cachedRuntimeNeedsPackagedReleaseUpdate()
     const shouldCheckRuntime = !runtimeReady || forceUpdate || runtimeUrlOverride || manifestOverride || packagedRuntimeUpdate
-    const runtimeSource = selectedSource || (!runtimeReady || packagedRuntimeUpdate || migrationFailed ? 'cf' : undefined)
 
     if (shouldCheckRuntime) {
-      if (!runtimeSource && !runtimeUrlOverride && !manifestOverride) {
+      if (!selectedSource && !runtimeUrlOverride && !manifestOverride) {
         if (mainWindow) await mainWindow.loadURL(runtimeSourceHtml())
         isBootstrapping = false
         return
       }
-      await ensureDesktopRuntime(updateSplash, runtimeSource, true)
+      await ensureDesktopRuntime(updateSplash, selectedSource, true)
     }
     if (isDesktopRuntimeReady()) {
       writeActiveRuntimeVersion()

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -441,17 +441,17 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
 
 async function waitForReady(port: number, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs
-  const url = `http://127.0.0.1:${port}/api/health`
+  const url = `http://127.0.0.1:${port}/`
   while (Date.now() < deadline) {
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(1000) })
-      if (res.ok || res.status === 401) return // 401 = up but auth-gated, server is alive
+      if (res.ok) return
     } catch {
       /* not ready yet */
     }
     await new Promise(r => setTimeout(r, 300))
   }
-  throw new Error(`Web UI server did not become ready within ${timeoutMs}ms`)
+  throw new Error(`Web UI shell did not become ready within ${timeoutMs}ms`)
 }
 
 export function stopWebUiServer(): Promise<void> {

--- a/tests/client/session-list-item.test.ts
+++ b/tests/client/session-list-item.test.ts
@@ -7,7 +7,6 @@ import SessionListItem from '@/components/hermes/chat/SessionListItem.vue'
 vi.mock('@/stores/hermes/app', () => ({
   useAppStore: () => ({
     profileModelGroups: [],
-    displayModelName: (model: string) => model,
   }),
 }))
 
@@ -154,7 +153,7 @@ describe('SessionListItem', () => {
     const logo = wrapper.get('.session-item-agent-logo')
     expect(logo.attributes('src')).toBe('/coding-agents/hermes.png')
     expect(logo.attributes('alt')).toBe('Hermes')
-    expect(wrapper.get('.session-item-agent-name').text()).toBe('Hermes')
+    expect(wrapper.find('.session-item-agent-name').exists()).toBe(false)
   })
 
   it('defaults old sessions without agent metadata to the Hermes logo', () => {
@@ -175,7 +174,7 @@ describe('SessionListItem', () => {
     const logo = wrapper.get('.session-item-agent-logo')
     expect(logo.attributes('src')).toBe('/coding-agents/hermes.png')
     expect(logo.attributes('alt')).toBe('Hermes')
-    expect(wrapper.get('.session-item-agent-name').text()).toBe('Hermes')
+    expect(wrapper.find('.session-item-agent-name').exists()).toBe(false)
   })
 
   it('renders the Claude Code logo for Claude coding agent sessions', () => {
@@ -196,7 +195,7 @@ describe('SessionListItem', () => {
     const logo = wrapper.get('.session-item-agent-logo')
     expect(logo.attributes('src')).toBe('/coding-agents/claude-code.svg')
     expect(logo.attributes('alt')).toBe('Claude Code')
-    expect(wrapper.get('.session-item-agent-name').text()).toBe('Claude Code')
+    expect(wrapper.find('.session-item-agent-name').exists()).toBe(false)
   })
 
   it('renders the Codex logo for Codex coding agent sessions', () => {
@@ -217,6 +216,6 @@ describe('SessionListItem', () => {
     const logo = wrapper.get('.session-item-agent-logo')
     expect(logo.attributes('src')).toBe('/coding-agents/codex-openai.png')
     expect(logo.attributes('alt')).toBe('Codex')
-    expect(wrapper.get('.session-item-agent-name').text()).toBe('Codex')
+    expect(wrapper.find('.session-item-agent-name').exists()).toBe(false)
   })
 })

--- a/tests/client/sidebar-search.test.ts
+++ b/tests/client/sidebar-search.test.ts
@@ -98,7 +98,7 @@ vi.mock('naive-ui', async () => {
 
 import AppSidebar from '@/components/layout/AppSidebar.vue'
 
-describe('AppSidebar search entry', () => {
+describe('AppSidebar navigation', () => {
   beforeEach(() => {
     openSessionSearchMock.mockClear()
     mockAppStore.serverVersion = 'test'
@@ -110,7 +110,7 @@ describe('AppSidebar search entry', () => {
     mockAppStore.reloadClient.mockClear()
   })
 
-  it('opens the session search modal from the sidebar button', async () => {
+  it('keeps page-sidebar-only actions out of the app sidebar', () => {
     const wrapper = mount(AppSidebar, {
       global: {
         stubs: {
@@ -123,34 +123,9 @@ describe('AppSidebar search entry', () => {
       },
     })
 
-    const buttons = wrapper.findAll('button')
-    const searchButton = buttons.find(node => node.text().includes('sidebar.search'))
-    expect(searchButton).toBeTruthy()
-
-    await searchButton!.trigger('click')
-    expect(openSessionSearchMock).toHaveBeenCalledTimes(1)
-  })
-
-  it('offers a client reload when the server version differs from the loaded bundle', async () => {
-    mockAppStore.clientOutdated = true
-    mockAppStore.serverVersion = '0.5.17'
-    const wrapper = mount(AppSidebar, {
-      global: {
-        stubs: {
-          ProfileSelector: true,
-          ModelSelector: true,
-          LanguageSwitch: true,
-          ThemeSwitch: true,
-        },
-      },
-    })
-
-    const reloadButton = wrapper.findAll('button')
-      .find(node => node.text().includes('sidebar.reloadClientVersion'))
-    expect(reloadButton).toBeTruthy()
-
-    await reloadButton!.trigger('click')
-    expect(mockAppStore.reloadClient).toHaveBeenCalledTimes(1)
+    expect(wrapper.text()).not.toContain('sidebar.search')
+    expect(wrapper.text()).not.toContain('sidebar.reloadClientVersion')
+    expect(wrapper.find('.sidebar-return-tab').exists()).toBe(true)
   })
 
   it('uses short group labels and keeps group folding active when collapsed', async () => {
@@ -169,14 +144,13 @@ describe('AppSidebar search entry', () => {
 
     expect(wrapper.classes()).toContain('collapsed')
     expect(wrapper.findAll('.nav-group-label span').map(node => node.text())).toEqual([
-      'sidebar.groupConversationShort',
       'sidebar.groupAgentShort',
       'sidebar.groupMonitoringShort',
       'sidebar.groupToolsShort',
       'sidebar.groupSystemShort',
     ])
 
-    const agentGroup = wrapper.findAll('.nav-group')[1]
+    const agentGroup = wrapper.findAll('.nav-group')[0]
     expect(agentGroup.find('.nav-group-items').attributes('style')).toBeUndefined()
 
     await agentGroup.find('.nav-group-label').trigger('click')

--- a/tests/e2e/chat-streaming.spec.ts
+++ b/tests/e2e/chat-streaming.spec.ts
@@ -80,7 +80,7 @@ test('uses the newly selected profile for the next chat-run socket after profile
   await mockChatSocket(page)
 
   await page.goto('/#/hermes/chat')
-  await expect(page.getByTestId('profile-selector-select').filter({ hasText: 'default' })).toBeVisible()
+  expect(await page.evaluate(() => window.localStorage.getItem('hermes_active_profile_name'))).toBe('default')
 
   await sendChatMessage(page, 'Warm up default socket')
   const defaultRun = await waitForRun(page)
@@ -98,13 +98,10 @@ test('uses the newly selected profile for the next chat-run socket after profile
   }, defaultRun.run.session_id)
   await expect(page.getByRole('button', { name: 'Stop' })).toHaveCount(0)
 
-  await page.getByTestId('profile-selector-select').click()
-  await expect(page.getByRole('dialog').filter({ hasText: 'research' })).toBeVisible()
-  const reloadPromise = page.waitForEvent('framenavigated', frame => frame === page.mainFrame())
-  await page.locator('.profile-runtime-item').filter({ hasText: /^research/ }).getByRole('button', { name: 'Switch Frontend Profile' }).click()
-  await reloadPromise
+  await page.evaluate(() => window.localStorage.setItem('hermes_active_profile_name', 'research'))
+  await page.reload()
   await page.waitForLoadState('domcontentloaded')
-  await expect(page.getByTestId('profile-selector-select').filter({ hasText: 'research' })).toBeVisible()
+  expect(await page.evaluate(() => window.localStorage.getItem('hermes_active_profile_name'))).toBe('research')
 
   await sendChatMessage(page, 'Use the active research profile')
   const { socket, run } = await waitForRun(page)

--- a/tests/e2e/native-navigation.spec.ts
+++ b/tests/e2e/native-navigation.spec.ts
@@ -17,13 +17,13 @@ const sampleSession = {
 test('sidebar navigation exposes native links', async ({ page }) => {
   await authenticate(page, TEST_ACCESS_KEY, 'research')
   await mockHermesApi(page)
-  await page.goto('/#/hermes/chat')
+  await page.goto('/#/hermes/jobs')
 
   const models = page.locator('aside.sidebar').getByRole('link', { name: /^Models$/ })
   await expect(models).toHaveAttribute('href', '#/hermes/models')
 
-  const history = page.locator('aside.sidebar').getByRole('link', { name: /^History$/ })
-  await expect(history).toHaveAttribute('href', '#/hermes/history')
+  const settings = page.locator('aside.sidebar').getByRole('link', { name: /^Settings$/ })
+  await expect(settings).toHaveAttribute('href', '#/hermes/settings')
 })
 
 test('session rows expose native session links', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Adds the new chat page sidebar for single chat and group chat flows, with page-local settings menus and mobile hamburger behavior.
- Simplifies the legacy app sidebar so non-chat pages keep the old navigation while chat pages use the new page sidebar.
- Updates session list item layout, mobile sidebar controls, language switch sizing, locale strings, and related client tests.

## Validation

- `npm run build`
- `npm run test`
- `npm run test -- tests/client/sidebar-search.test.ts`
- `npm run test -- tests/client/session-list-item.test.ts`
