### PR TITLE
fix(update): avoid blocking install during self-update

### DIFF
--- a/packages/server/src/controllers/update.ts
+++ b/packages/server/src/controllers/update.ts
@@ -333,41 +333,6 @@ function getCurrentNodeEnv() {
   }
 }
 
-function runNpm(args: string[], options: { timeout?: number; cwd?: string; logLabel?: string; env?: NodeJS.ProcessEnv } = {}) {
-  const env = {
-    ...getCurrentNodeEnv(),
-    ...options.env,
-  }
-  const execution = npmExecution(args, env)
-  const label = options.logLabel || ''
-
-  if (label) appendPreviewActionLog(`${label}: ${execution.command} ${execution.args.join(' ')}${options.cwd ? `\ncwd: ${options.cwd}` : ''}`)
-  try {
-    const output = execFileSync(execution.command, execution.args, {
-      encoding: 'utf-8',
-      timeout: options.timeout,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env,
-      cwd: options.cwd,
-      windowsHide: true,
-    }).trim()
-    if (label) {
-      if (output) appendPreviewActionLog(`${label} output:\n${output}`)
-      appendPreviewActionLog(`${label} completed`)
-    }
-    return output
-  } catch (err: any) {
-    if (label) {
-      const stderr = err.stderr?.toString() || ''
-      const stdout = err.stdout?.toString() || ''
-      appendPreviewActionLog(`${label} failed`)
-      if (stdout) appendPreviewActionLog(`${label} stdout:\n${stdout}`)
-      if (stderr) appendPreviewActionLog(`${label} stderr:\n${stderr}`)
-    }
-    throw err
-  }
-}
-
 async function runNpmAsync(args: string[], options: { timeout?: number; cwd?: string; logLabel?: string; env?: NodeJS.ProcessEnv } = {}) {
   const env = {
     ...getCurrentNodeEnv(),
@@ -997,30 +962,30 @@ async function checkoutPreview(ref: string) {
   appendPreviewActionLog(`preview tag ready: ${ref}`)
 }
 
-function getGlobalRoot() {
-  return runNpm(['root', '-g'])
+async function getGlobalRootAsync() {
+  return runNpmAsync(['root', '-g'])
 }
 
-function getGlobalCliScript() {
-  const cli = getGlobalPackageBin(getGlobalRoot())
+async function getGlobalCliScriptAsync() {
+  const cli = getGlobalPackageBin(await getGlobalRootAsync())
   if (!existsSync(cli)) {
     throw new Error(`Updated hermes-web-ui CLI not found: ${cli}`)
   }
   return cli
 }
 
-function runUpdateInstall() {
+async function runUpdateInstall() {
   try {
-    runNpm(['cache', 'clean', '--force'], { timeout: 2 * 60 * 1000 })
+    await runNpmAsync(['cache', 'clean', '--force'], { timeout: 2 * 60 * 1000 })
   } catch (err) {
     console.warn('[update] failed to clean npm cache, continuing update:', err)
   }
 
-  return runNpm(['install', '-g', 'hermes-web-ui@latest'], { timeout: 10 * 60 * 1000 })
+  return runNpmAsync(['install', '-g', 'hermes-web-ui@latest'], { timeout: 10 * 60 * 1000 })
 }
 
-function spawnRestart(port: string) {
-  const cli = getGlobalCliScript()
+async function spawnRestart(port: string) {
+  const cli = await getGlobalCliScriptAsync()
 
   return spawn(process.execPath, [cli, 'restart', '--port', port], {
     detached: true,
@@ -1041,44 +1006,51 @@ export async function handleUpdate(ctx: any) {
   }
 
   updateInProgress = true
+  let keepUpdateLockForRestart = false
 
   try {
-    const output = runUpdateInstall()
+    const output = await runUpdateInstall()
 
     ctx.body = {
       success: true,
       message: output.trim() || 'hermes-web-ui updated successfully',
     }
 
+    keepUpdateLockForRestart = true
     setTimeout(() => {
-      let restart
-      try {
-        restart = spawnRestart(process.env.PORT || '8648')
-      } catch (err) {
-        updateInProgress = false
-        console.error('[update] failed to spawn restart:', err)
-        return
-      }
-
-      restart.on('error', (err) => {
-        updateInProgress = false
-        console.error('[update] restart process failed:', err)
-      })
-      restart.on('exit', (code, signal) => {
-        updateInProgress = false
-        const failed = (typeof code === 'number' && code !== 0) || Boolean(signal)
-        if (failed) {
-          console.error(`[update] restart process exited before replacing server: code=${code} signal=${signal}`)
+      void (async () => {
+        let restart
+        try {
+          restart = await spawnRestart(process.env.PORT || '8648')
+        } catch (err) {
+          updateInProgress = false
+          console.error('[update] failed to spawn restart:', err)
+          return
         }
-      })
-      restart.unref()
+
+        restart.on('error', (err) => {
+          updateInProgress = false
+          console.error('[update] restart process failed:', err)
+        })
+        restart.on('exit', (code, signal) => {
+          updateInProgress = false
+          const failed = (typeof code === 'number' && code !== 0) || Boolean(signal)
+          if (failed) {
+            console.error(`[update] restart process exited before replacing server: code=${code} signal=${signal}`)
+          }
+        })
+        restart.unref()
+      })()
     }, 3000)
   } catch (err: any) {
-    updateInProgress = false
     ctx.status = 500
     ctx.body = {
       success: false,
       message: err.stderr?.toString() || err.message || String(err),
+    }
+  } finally {
+    if (!keepUpdateLockForRestart) {
+      updateInProgress = false
     }
   }
 }

--- a/tests/server/update-controller.test.ts
+++ b/tests/server/update-controller.test.ts
@@ -100,46 +100,47 @@ describe('update controller', () => {
     const npmCli = getNpmCliPath()
     const globalPrefix = getNodePrefix()
     const cliScript = getGlobalCliScript(globalPrefix)
-    const execFileSync = vi.fn((_command: string, args: string[]) => {
+    const execFile = vi.fn((_command: string, args: string[], _options: any, callback: any) => {
       if (args[1] === 'root') {
-        return process.platform === 'win32'
+        callback(null, process.platform === 'win32'
           ? join(globalPrefix, 'node_modules')
-          : join(globalPrefix, 'lib', 'node_modules')
+          : join(globalPrefix, 'lib', 'node_modules'), '')
+        return
       }
-      return 'updated'
+      callback(null, 'updated', '')
     })
-    const { handleUpdate, mocks } = await loadUpdateController({ execFileSync })
+    const { handleUpdate, mocks } = await loadUpdateController({ execFile })
     const ctx = createMockCtx()
 
     await handleUpdate(ctx)
 
-    expect(mocks.execFileSync).toHaveBeenCalledWith(
+    expect(mocks.execFile).toHaveBeenCalledWith(
       process.execPath,
       [npmCli, 'install', '-g', 'hermes-web-ui@latest'],
       expect.objectContaining({
         encoding: 'utf-8',
         timeout: 10 * 60 * 1000,
-        stdio: ['pipe', 'pipe', 'pipe'],
         windowsHide: true,
         env: expect.objectContaining({
           npm_node_execpath: process.execPath,
           PATH: expect.stringContaining(`${nodeBinDir}${delimiter}`),
         }),
       }),
+      expect.any(Function),
     )
     expect(ctx.body).toEqual({ success: true, message: 'updated' })
 
-    vi.runAllTimers()
+    await vi.runAllTimersAsync()
 
-    expect(mocks.execFileSync).toHaveBeenCalledWith(
+    expect(mocks.execFile).toHaveBeenCalledWith(
       process.execPath,
       [npmCli, 'root', '-g'],
       expect.objectContaining({
         encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
         windowsHide: true,
         env: expect.objectContaining({ npm_node_execpath: process.execPath }),
       }),
+      expect.any(Function),
     )
     expect(mocks.spawn).toHaveBeenCalledWith(
       process.execPath,
@@ -154,13 +155,61 @@ describe('update controller', () => {
     expect(mocks.unref).toHaveBeenCalledOnce()
   })
 
+  it('keeps update requests responsive while npm install is pending', async () => {
+    const npmCli = getNpmCliPath()
+    let installCallback: ((error: Error | null, stdout: string, stderr: string) => void) | undefined
+    const execFile = vi.fn((_command: string, args: string[], _options: any, callback: any) => {
+      if (args.includes('install') && args.includes('hermes-web-ui@latest')) {
+        installCallback = callback
+        return
+      }
+      callback(null, '', '')
+    })
+    const execFileSync = vi.fn((_command: string, args: string[]) => {
+      if (args.includes('install') && args.includes('hermes-web-ui@latest')) {
+        throw new Error('global update install must not use execFileSync')
+      }
+      return ''
+    })
+    const { handleUpdate, mocks } = await loadUpdateController({ execFile, execFileSync })
+    const first = createMockCtx()
+    const second = createMockCtx()
+
+    const firstUpdate = handleUpdate(first)
+    await Promise.resolve()
+    await handleUpdate(second)
+
+    expect(installCallback).toBeTypeOf('function')
+    expect(second.status).toBe(409)
+    expect(second.body).toEqual({
+      success: false,
+      message: 'hermes-web-ui update is already in progress',
+    })
+    expect(mocks.execFile).toHaveBeenCalledWith(
+      process.execPath,
+      [npmCli, 'install', '-g', 'hermes-web-ui@latest'],
+      expect.objectContaining({ timeout: 10 * 60 * 1000 }),
+      expect.any(Function),
+    )
+    expect(mocks.execFileSync).not.toHaveBeenCalledWith(
+      process.execPath,
+      [npmCli, 'install', '-g', 'hermes-web-ui@latest'],
+      expect.any(Object),
+    )
+
+    installCallback?.(null, 'updated', '')
+    await firstUpdate
+
+    expect(first.body).toEqual({ success: true, message: 'updated' })
+  })
+
   it('falls back to the default port when PORT is not set', async () => {
     delete process.env.PORT
     const { handleUpdate, mocks } = await loadUpdateController()
     const ctx = createMockCtx()
 
     await handleUpdate(ctx)
-    vi.runAllTimers()
+    await vi.runAllTimersAsync()
 
     expect(mocks.spawn).toHaveBeenCalledWith(
       process.execPath,
@@ -185,7 +234,7 @@ describe('update controller', () => {
     const ctx = createMockCtx()
 
     await handleUpdate(ctx)
-    vi.runAllTimers()
+    await vi.runAllTimersAsync()
     handlers.get('exit')?.(0, null)
 
     expect(errorSpy).not.toHaveBeenCalled()
@@ -193,18 +242,27 @@ describe('update controller', () => {
   })
 
   it('returns a 500 with stderr when installation fails', async () => {
-    const execFileSync = vi.fn(() => {
-      const error = new Error('install failed') as Error & { stderr?: string }
-      error.stderr = 'engine mismatch'
-      throw error
+    const execFile = vi.fn((_command: string, args: string[], _options: any, callback: any) => {
+      if (args.includes('install') && args.includes('hermes-web-ui@latest')) {
+        const error = new Error('install failed') as Error & { stderr?: string }
+        error.stderr = 'engine mismatch'
+        callback(error, '', 'engine mismatch')
+        return
+      }
+      callback(null, '', '')
     })
-    const { handleUpdate, mocks } = await loadUpdateController({ execFileSync })
+    const { handleUpdate, mocks } = await loadUpdateController({ execFile })
     const ctx = createMockCtx()
 
     await handleUpdate(ctx)
 
     expect(ctx.status).toBe(500)
     expect(ctx.body).toEqual({ success: false, message: 'engine mismatch' })
+    expect(mocks.execFileSync).not.toHaveBeenCalledWith(
+      process.execPath,
+      [expect.any(String), 'install', '-g', 'hermes-web-ui@latest'],
+      expect.any(Object),
+    )
     expect(mocks.spawn).not.toHaveBeenCalled()
     expect(exitSpy).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Summary

Fixes EKKOLearnAI/hermes-web-ui#1505.

The self-update endpoint no longer runs the global `npm install -g hermes-web-ui@latest` through `execFileSync`. The update install and follow-up `npm root -g` lookup now use the existing async `execFile` wrapper, so the Node event loop can continue serving requests while npm is pending. The in-process update lock is also released through a `finally` path when installation fails, while successful installs keep the lock until restart handling begins.

## Validation

- Failing-before-fix regression recorded: `npm exec vitest -- run tests/server/update-controller.test.ts` failed because the pending async install callback was absent and the controller still used `execFileSync`.
- `PATH=/Users/shangyifan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm exec vitest -- run tests/server/update-controller.test.ts`
- `git diff --check`
- `PATH=/Users/shangyifan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run harness:check`
- `PATH=/Users/shangyifan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run test:coverage`
- `PATH=/Users/shangyifan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build`

Build completed with the existing Vite large chunk warning only.

## Duplicate Check

- Open PR #1043 touches `update.ts`, but only adds a cwd for the existing `execFileSync` path to address a separate `uv_cwd` systemd failure. It does not replace the synchronous update install.
- Open PR #989 is agent-bridge restart recovery and does not touch the update install path.
- Batch open-PR inventory and read-only candidate/patch review found no active PR replacing the synchronous update install path.

## Browser / Playwright

Not run locally. This is server-controller behavior for `/api/hermes/update`; no visible UI, browser routing, or interaction changed.
