### PR TITLE
fix: 辅助视觉模型编辑器卡死 + 模型下拉框显示 (#1529, #1416)

### DIFF
--- a/packages/client/src/components/hermes/models/AuxiliaryModelsPanel.vue
+++ b/packages/client/src/components/hermes/models/AuxiliaryModelsPanel.vue
@@ -335,7 +335,6 @@ watch(() => form.value.provider, (provider) => {
   border: 1px solid $border-color;
   border-radius: $radius-md;
   margin-bottom: 16px;
-  overflow: hidden;
 }
 
 .auxiliary-header {

--- a/packages/client/src/components/layout/ModelSelector.vue
+++ b/packages/client/src/components/layout/ModelSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { NModal, NInput, NSelect } from 'naive-ui'
 import { useAppStore } from '@/stores/hermes/app'
 import { useProfilesStore } from '@/stores/hermes/profiles'
@@ -25,10 +25,12 @@ const activeModelGroups = computed(() => {
   return profileModels?.groups || []
 })
 
-const providerOptions = computed(() => {
-  const current = appStore.selectedProvider
+const providerOptions = computed(() =>
+  activeModelGroups.value.map(g => ({ label: g.label, value: g.provider }))
+)
+
+watch(() => appStore.selectedProvider, (current) => {
   customProvider.value = current
-  return activeModelGroups.value.map(g => ({ label: g.label, value: g.provider }))
 })
 
 const modelGroupsWithCustom = computed(() =>
@@ -47,11 +49,14 @@ const selectedModelInActiveProfile = computed(() =>
   ),
 )
 
-const selectedDisplayName = computed(() =>
-  selectedModelInActiveProfile.value
-    ? appStore.displayModelName(appStore.selectedModel, appStore.selectedProvider)
-    : '',
-)
+const selectedDisplayName = computed(() => {
+  if (selectedModelInActiveProfile.value)
+    return appStore.displayModelName(appStore.selectedModel, appStore.selectedProvider)
+  // 即使当前模型不在活跃 profile 的模型组中，仍显示原始模型名
+  if (appStore.selectedModel)
+    return appStore.displayModelName(appStore.selectedModel, appStore.selectedProvider)
+  return ''
+})
 
 function isCustomModel(model: string, provider: string) {
   return (appStore.customModels[provider] || []).includes(model)


### PR DESCRIPTION
#1529: 编辑视觉模型时界面卡死
    原因：.auxiliary-panel 样式中的 overflow: hidden 创建了层叠上下文边界，
    裁剪了 NModal 内 NSelect 下拉菜单的渲染区域，导致下拉菜单无法打开、取消按钮
    无响应。修复：移除 overflow: hidden。
    
#1416: 主页面模型下拉框显示为空
    原因：selectedDisplayName 在模型不在当前 profile 模型组中时返回空字符串。
    修复：回退到 displayModelName 显示原始模型名；同时修复 computed 内
    的 side effect 反模式，改用 watch()。
    
  Closes #1529
  Closes #1416
    
    
