### PR TITLE
fix(gateway): respawn gateway process on unexpected exit

### DIFF
--- a/packages/server/src/services/hermes/gateway-runner.ts
+++ b/packages/server/src/services/hermes/gateway-runner.ts
@@ -1,11 +1,68 @@
+import { logger } from '../logger'
 import { getActiveProfileDir } from './hermes-profile'
 import { spawnHermesWithBin } from './hermes-process'
+
+interface SupervisedGateway {
+  pid: number
+  child: ReturnType<typeof spawnHermesWithBin>
+  hermesBin: string
+  profileDir: string
+}
+
+/**
+ * Per-profile state for our supervised gateway.
+ *
+ * - `current` is the most recent child we spawned for this profile. When it
+ *   exits, the exit handler clears this slot.
+ * - `respawnTimer` is a pending respawn that was scheduled because the
+ *   previous child died and no replacement has been started yet. The next
+ *   call to `startGatewayRunManaged` for the same profile clears it: a fresh
+ *   start is already happening, so a respawn would race with it.
+ *
+ * This is what makes `/restart` safe. The flow is:
+ *   1. `/restart` calls `hermes gateway stop` (CLI) which kills our child.
+ *   2. That child's exit handler schedules a respawn timer (step T+0).
+ *   3. `/restart` then calls `startGatewayRunManaged` for the same profile.
+ *   4. That call clears the pending respawn timer (we're starting a new one
+ *      anyway) and registers the fresh child.
+ *
+ * Net result: exactly one new gateway per `/restart`, no orphans.
+ */
+interface ProfileState {
+  current: SupervisedGateway | null
+  respawnTimer: NodeJS.Timeout | null
+}
+
+const profileState = new Map<string, ProfileState>()
+
+/** Delay before respawning a gateway that exited unexpectedly. */
+const RESPAWN_DELAY_MS = 2000
+
+function getOrCreateProfileState(profileDir: string): ProfileState {
+  let state = profileState.get(profileDir)
+  if (!state) {
+    state = { current: null, respawnTimer: null }
+    profileState.set(profileDir, state)
+  }
+  return state
+}
 
 export function startGatewayRunManaged(
   hermesBin: string,
   opts: { profileDir?: string } = {},
 ): { pid: number | null; reused: boolean } {
   const profileDir = opts.profileDir || getActiveProfileDir()
+  const state = getOrCreateProfileState(profileDir)
+
+  // A new spawn for this profile cancels any pending respawn from a previous
+  // unexpected exit. Without this, `/restart` (stop -> start) would race
+  // against the respawn timer and end up with two gateways on the same port.
+  if (state.respawnTimer) {
+    clearTimeout(state.respawnTimer)
+    state.respawnTimer = null
+    logger.info('[gateway-runner] cancelled pending respawn for new start profileDir=%s', profileDir)
+  }
+
   const child = spawnHermesWithBin(hermesBin, ['gateway', 'run', '--replace'], {
     detached: true,
     stdio: 'ignore',
@@ -18,5 +75,38 @@ export function startGatewayRunManaged(
   child.unref()
 
   const pid = child.pid ?? null
+  if (pid) {
+    const entry: SupervisedGateway = { pid, child, hermesBin, profileDir }
+    state.current = entry
+
+    child.on('exit', (code, signal) => {
+      // Only act if this is still the active child for the profile. A new
+      // start for the same profile replaces `state.current` and we don't
+      // want the old child's exit to trigger anything.
+      if (state.current?.pid !== pid) return
+      state.current = null
+
+      logger.warn(
+        '[gateway-runner] gateway exited unexpectedly (profileDir=%s pid=%s code=%s signal=%s), respawning in %dms',
+        profileDir, pid, code, signal, RESPAWN_DELAY_MS,
+      )
+
+      state.respawnTimer = setTimeout(() => {
+        state.respawnTimer = null
+        try {
+          const next = startGatewayRunManaged(hermesBin, { profileDir })
+          logger.info(
+            '[gateway-runner] gateway respawned (oldPid=%s newPid=%s profileDir=%s)',
+            pid, next.pid, profileDir,
+          )
+        } catch (err) {
+          logger.error(err, '[gateway-runner] failed to respawn gateway after unexpected exit')
+        }
+      }, RESPAWN_DELAY_MS)
+      // Don't keep the event loop alive just for a pending respawn.
+      state.respawnTimer.unref()
+    })
+  }
+
   return { pid, reused: false }
 }

--- a/tests/server/gateway-respawn.test.ts
+++ b/tests/server/gateway-respawn.test.ts
@@ -1,0 +1,146 @@
+import { EventEmitter } from 'events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const originalEnv = { ...process.env }
+
+class FakeChild extends EventEmitter {
+  pid: number
+  constructor(pid: number) {
+    super()
+    this.pid = pid
+  }
+  unref() { /* no-op */ }
+  kill() { return true }
+}
+
+let fakeChildren: FakeChild[] = []
+
+vi.mock('../../packages/server/src/services/hermes/hermes-process', () => ({
+  resolveHermesInvocation: (bin: string) => ({ command: bin, argsPrefix: [] }),
+  execHermesWithBin: vi.fn(),
+  execHermes: vi.fn(),
+  spawnHermesWithBin: vi.fn(() => {
+    const pid = 10000 + fakeChildren.length
+    const child = new FakeChild(pid)
+    fakeChildren.push(child)
+    return child
+  }),
+  spawnHermes: vi.fn(),
+  resolveHermesBin: () => 'hermes',
+}))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+  process.env = { ...originalEnv }
+  fakeChildren = []
+})
+
+describe('gateway-runner supervision', () => {
+  it('respawns the gateway when the spawned child dies unexpectedly', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    const { startGatewayRunManaged } = await import(
+      '../../packages/server/src/services/hermes/gateway-runner'
+    )
+
+    const first = startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/fake-a' })
+    expect(first.pid).toBe(10000)
+    expect(fakeChildren).toHaveLength(1)
+
+    // Simulate unexpected exit
+    fakeChildren[0].emit('exit', 1, null)
+
+    // No respawn yet — timer is pending
+    expect(fakeChildren).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(2500)
+
+    // A new spawn should have been issued
+    expect(fakeChildren.length).toBeGreaterThanOrEqual(2)
+    const newPid = fakeChildren[fakeChildren.length - 1].pid
+    expect(newPid).not.toBe(10000)
+
+    vi.useRealTimers()
+  })
+
+  it('cancels a pending respawn when a fresh start is issued for the same profile (the /restart case)', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    const { startGatewayRunManaged } = await import(
+      '../../packages/server/src/services/hermes/gateway-runner'
+    )
+
+    // First start: a gateway is running
+    const first = startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/fake-b' })
+    expect(first.pid).toBe(10000)
+
+    // Simulate `/restart`: old gateway dies, then a new start happens before
+    // the respawn timer fires.
+    fakeChildren[0].emit('exit', 1, null)
+    expect(fakeChildren).toHaveLength(1) // respawn not yet fired
+
+    // New start (the `/restart` second phase) for the same profile. The
+    // pending respawn timer should be cancelled.
+    const second = startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/fake-b' })
+    expect(second.pid).toBe(10001)
+    expect(fakeChildren).toHaveLength(2)
+
+    // Now advance timers past the original respawn delay. The cancelled
+    // respawn must NOT fire — otherwise we'd have a third gateway racing
+    // with the second.
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(fakeChildren).toHaveLength(2)
+
+    vi.useRealTimers()
+  })
+
+  it('tracks respawns independently per profile', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    const { startGatewayRunManaged } = await import(
+      '../../packages/server/src/services/hermes/gateway-runner'
+    )
+
+    startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/profile-x' })
+    startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/profile-y' })
+    expect(fakeChildren).toHaveLength(2)
+
+    // profile-x's gateway dies — only its respawn timer should fire
+    fakeChildren[0].emit('exit', 1, null)
+
+    await vi.advanceTimersByTimeAsync(2500)
+
+    // profile-x was respawned (3rd child), profile-y was untouched
+    expect(fakeChildren).toHaveLength(3)
+    expect(fakeChildren[2].pid).toBe(10002)
+
+    vi.useRealTimers()
+  })
+
+  it('does not respawn if a new start for the same profile has already replaced the dead child', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    const { startGatewayRunManaged } = await import(
+      '../../packages/server/src/services/hermes/gateway-runner'
+    )
+
+    const first = startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/fake-c' })
+    fakeChildren[0].emit('exit', 0, 'SIGTERM')
+
+    // Issue a fresh start BEFORE the respawn timer fires — this clears the
+    // pending respawn. The old child's exit handler then becomes a no-op
+    // because `state.current?.pid !== oldPid` after the new start.
+    const second = startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/fake-c' })
+    expect(second.pid).not.toBe(first.pid)
+
+    // Now the original (now-orphaned) exit listener fires after the timer
+    // window. It should detect the mismatch and not schedule another spawn.
+    await vi.advanceTimersByTimeAsync(5000)
+
+    // Exactly two children total: the original, and the replacement
+    expect(fakeChildren).toHaveLength(2)
+
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
# fix(gateway): respawn gateway process on unexpected exit

## Problem

When the Hermes gateway dies unexpectedly — a crash, an OOM kill, an unhandled signal, or a `/restart` issued from a context where no other code path is about to start a replacement — the Web UI never notices and never respawns it. The spawn site in `gateway-runner.ts` uses `detached: true` + `child.unref()`, so the Node parent has no way to see the child died. In environments without a service manager (containers, nodemon dev mode, WSL), the gateway stays dead.

The fix needs to handle a subtle case: `/restart` is implemented as stop-then-start. The CLI call to `hermes gateway stop` kills our child. We need to respawn on unexpected death, but not produce a *second* orphan gateway when a fresh start is about to happen anyway.

## Related issues

This PR makes the failure mode for #807 ("Gateway restart from agent is a deadlock — agent runs inside gateway and kills itself on stop") recoverable: if the agent dies mid-restart, the gateway comes back in 2s and the user can retry from outside. The full fix for #807 is a larger architectural change (a restart endpoint the agent can call from outside its own process) and is out of scope here. Leaving #807 open.

#805 ("Gateway restart fails in Docker: old restartGateway() doesn't use GatewayManager path") was a related failure mode that the legacy `GatewayManager` removal in #1486 already addressed.

## Fix

Add a 2-second-delayed respawn handler to `gateway-runner.ts:startGatewayRunManaged`, the single spawn site still in use after the legacy `GatewayManager` removal in #1486. State is tracked **per profile dir**, not per PID.

- Each profile has a `ProfileState { current, respawnTimer }`. `current` is the most recent child we spawned; `respawnTimer` is a pending respawn scheduled because that child died and no replacement has been started yet.
- The exit handler on a child only respawns if `state.current?.pid === pid` (this child is still the active one for the profile). If a fresh `startGatewayRunManaged` has already replaced it, the old exit becomes a no-op.
- A new `startGatewayRunManaged` call for the same profile clears any pending respawn timer. This is what makes `/restart` safe: the stop phase kills the old child and the respawn timer is scheduled, but the start phase cancels that timer and registers a fresh child. Net result: exactly one gateway per `/restart`, no orphans.
- The respawn re-enters through the public `startGatewayRunManaged()` entry point, so port resolution and lock cleanup run through the same code path as a normal start.
- The respawn timer uses `unref()` so it doesn't keep the event loop alive.

## Test coverage

`tests/server/gateway-respawn.test.ts` — 4 new tests, all using a mocked `spawnHermesWithBin` so no real processes are spawned:

- Respawns the gateway when the spawned child dies unexpectedly.
- Cancels a pending respawn when a fresh start is issued for the same profile — the `/restart` case. Asserts that the old respawn timer does NOT fire after the new start, so we don't end up with two gateways on the same port.
- Tracks respawns independently per profile (a death in profile A does not respawn profile B's gateway).
- The old child's exit handler becomes a no-op once a fresh start for the same profile has replaced `state.current`.

## Notes

- Did **not** add supervision to `hermes-cli.ts:startGatewayBackground`. That path is only used by the `startGateway()` CLI command (not by `/restart`), and is a different bug. Happy to follow up in a separate PR if desired.
- Did **not** change the health endpoint to actually probe the process instead of reading `gateway_state.json`. That's a related but independent improvement.
- Did **not** change `gateway-runner.ts`'s use of `detached: true` + `unref()`. That's intentional for nodemon dev mode (gateways need to survive server restarts). The exit handler is the right level to fix the lifecycle.

## Verification

```
$ npx tsc --noEmit -p packages/server/tsconfig.json
$ npx vitest run tests/server
Test Files  128 passed (128)
     Tests  1018 passed | 2 skipped (1020)
$ npm run harness:check
Harness check passed
```
