### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ CLI maintenance commands:
 
 ```bash
 # Delete persisted login IP lock records
+
+[![Listed on TakoAPI](https://img.shields.io/badge/Listed%20on-TakoAPI-7c3aed)](https://takoapi.com/agents/ekkolearnai-hermes-web-ui)
+
 hermes-web-ui clear-login-locks
 
 # Delete login locks and restart the running Web UI process


### PR DESCRIPTION
Hi! 👋 **hermes-web-ui** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/ekkolearnai-hermes-web-ui

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building hermes-web-ui! 🙏