### PR TITLE
[codex] stop managed gateways on shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ These variables configure Hermes Web UI, its local Hermes runtime integration, a
 | `HERMES_OPENROUTER_APP_REFERER` | `https://hermes-studio.ai` | OpenRouter attribution referer sent by bridge runs. |
 | `HERMES_OPENROUTER_APP_TITLE` | `Hermes Web UI` | OpenRouter attribution title sent by bridge runs. |
 | `HERMES_OPENROUTER_APP_CATEGORIES` | `cli-agent,personal-agent` | OpenRouter attribution categories sent by bridge runs. |
-| `HERMES_WEB_UI_MANAGED_GATEWAY` | platform/runtime dependent | Force Web UI-managed Hermes gateway process handling. Set `1`, `true`, `yes`, or `on` to enable. |
+| `HERMES_WEB_UI_MANAGED_GATEWAY` | enabled | Controls Web UI-managed Hermes gateway process handling. Set `0`, `false`, `no`, or `off` to use `hermes gateway start` instead. |
 | `HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART` | unset | Skip startup gateway checks/autostart. Set `1`, `true`, `yes`, or `on` for dashboard-only deployments where another service owns Hermes gateway lifecycle. |
 | `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | unset | Skip startup bundled skill injection. Set `1`, `true`, `yes`, or `on` when bundled skills are managed outside Hermes Web UI. When injection is enabled, Web UI updates only skills it previously installed or identical existing bundled copies; local edits and user-owned same-name skills are skipped. |
 | `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | enabled in production | Controls whether Web UI shutdown also stops managed gateway processes. Set `0` or `false` to detach them. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -332,7 +332,7 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `HERMES_OPENROUTER_APP_REFERER` | `https://hermes-studio.ai` | bridge 运行发送给 OpenRouter 的 attribution referer。 |
 | `HERMES_OPENROUTER_APP_TITLE` | `Hermes Web UI` | bridge 运行发送给 OpenRouter 的 attribution title。 |
 | `HERMES_OPENROUTER_APP_CATEGORIES` | `cli-agent,personal-agent` | bridge 运行发送给 OpenRouter 的 attribution categories。 |
-| `HERMES_WEB_UI_MANAGED_GATEWAY` | 由平台/运行环境决定 | 强制启用旧 gateway 进程托管；设为 `1`、`true`、`yes` 或 `on` 开启。 |
+| `HERMES_WEB_UI_MANAGED_GATEWAY` | 默认开启 | 控制 Web UI 托管 Hermes gateway 进程；设为 `0`、`false`、`no` 或 `off` 时改用 `hermes gateway start`。 |
 | `HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART` | 未设置 | 跳过启动时的 gateway 检查/自动启动；dashboard-only 部署中如果由其它服务管理 Hermes gateway，可设为 `1`、`true`、`yes` 或 `on`。 |
 | `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | 未设置 | 跳过启动时的内置 skill 注入；如果内置 skills 由 Hermes Web UI 外部管理，可设为 `1`、`true`、`yes` 或 `on`。启用注入时，Web UI 只更新自己此前安装的 skills 或内容完全相同的既有内置副本；本地修改和用户拥有的同名 skills 会跳过。 |
 | `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | 生产环境默认开启 | Web UI 关闭时是否同时停止托管的 gateway 进程；设为 `0` 或 `false` 可让 gateway 分离运行。 |

--- a/docs/chat-chain-changes/2026-06-14-pr1540-sidebar-profile-modal.md
+++ b/docs/chat-chain-changes/2026-06-14-pr1540-sidebar-profile-modal.md
@@ -1,0 +1,7 @@
+---
+date: 2026-06-14
+pr: 1540
+commit: 84e21c31
+feature: Sidebar profile modal click-outside handling
+impact: Chat and Group Chat settings sidebars now keep the profile manager modal open while users interact with it, matching the existing model selector modal behavior without changing chat-run payloads, message persistence, resume, queue, or group-chat agent execution semantics.
+---

--- a/nodemon.json
+++ b/nodemon.json
@@ -8,7 +8,7 @@
     "NODE_ENV": "development",
     "PORT": "8647",
     "TS_NODE_PROJECT": "packages/server/tsconfig.json",
-    "HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN": "0"
+    "HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN": "1"
   },
   "exec": "node -r ts-node/register packages/server/src/index.ts",
   "nodeArgs": ["--no-warnings"],

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -58,6 +58,7 @@ const chatContentWrapperRef = ref<HTMLElement | null>(null);
 const showVersionManagement = ref(false);
 const showChangelog = ref(false);
 const showSettingsPopover = ref(false);
+const profileModalOpen = ref(false);
 const modelModalOpen = ref(false);
 const showToolPanel = ref(false);
 const activeToolPanel = ref<"files" | "terminal">("files");
@@ -733,7 +734,7 @@ function handleLogout() {
 }
 
 function handleSettingsPopoverShowChange(show: boolean) {
-  if (!show && modelModalOpen.value) return;
+  if (!show && (profileModalOpen.value || modelModalOpen.value)) return;
   showSettingsPopover.value = show;
 }
 
@@ -1197,7 +1198,7 @@ async function handleSessionModelCustomSubmit() {
             </button>
           </template>
           <div class="page-sidebar-popover">
-            <ProfileSelector />
+            <ProfileSelector @modal-show-change="profileModalOpen = $event" />
             <ModelSelector @modal-show-change="modelModalOpen = $event" />
             <div class="page-sidebar-popover-row">
               <div

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -37,6 +37,7 @@ const showCompressionModal = ref(false)
 const showChangelog = ref(false)
 const showVersionManagement = ref(false)
 const showSettingsPopover = ref(false)
+const profileModalOpen = ref(false)
 const modelModalOpen = ref(false)
 const compressionConfig = ref({ triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10 })
 const isCompressing = ref(false)
@@ -128,7 +129,7 @@ function handleLogout() {
 }
 
 function handleSettingsPopoverShowChange(show: boolean) {
-    if (!show && modelModalOpen.value) return
+    if (!show && (profileModalOpen.value || modelModalOpen.value)) return
     showSettingsPopover.value = show
 }
 
@@ -456,7 +457,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                         </button>
                     </template>
                     <div class="page-sidebar-popover">
-                        <ProfileSelector />
+                        <ProfileSelector @modal-show-change="profileModalOpen = $event" />
                         <ModelSelector @modal-show-change="modelModalOpen = $event" />
                         <div class="page-sidebar-popover-row">
                             <div

--- a/packages/client/src/components/layout/PageSidebarFooter.vue
+++ b/packages/client/src/components/layout/PageSidebarFooter.vue
@@ -20,6 +20,7 @@ const { t } = useI18n()
 const showChangelog = ref(false)
 const showVersionManagement = ref(false)
 const showSettingsPopover = ref(false)
+const profileModalOpen = ref(false)
 const modelModalOpen = ref(false)
 const currentUsername = computed(() => getStoredUsername())
 const isDesktopShell = computed(() =>
@@ -57,7 +58,7 @@ function handleLogout() {
 }
 
 function handleSettingsPopoverShowChange(show: boolean) {
-  if (!show && modelModalOpen.value) return
+  if (!show && (profileModalOpen.value || modelModalOpen.value)) return
   showSettingsPopover.value = show
 }
 </script>
@@ -82,7 +83,7 @@ function handleSettingsPopoverShowChange(show: boolean) {
         </button>
       </template>
       <div class="page-sidebar-popover">
-        <ProfileSelector />
+        <ProfileSelector @modal-show-change="profileModalOpen = $event" />
         <ModelSelector @modal-show-change="modelModalOpen = $event" />
         <div class="page-sidebar-popover-row">
           <div

--- a/packages/client/src/components/layout/ProfileSelector.vue
+++ b/packages/client/src/components/layout/ProfileSelector.vue
@@ -13,6 +13,10 @@ import {
 import ProfileAvatarView from '@/components/hermes/profiles/ProfileAvatar.vue'
 import { useI18n } from 'vue-i18n'
 
+const emit = defineEmits<{
+  'modal-show-change': [show: boolean]
+}>()
+
 const { t } = useI18n()
 const message = useMessage()
 const profilesStore = useProfilesStore()
@@ -32,6 +36,11 @@ const profileRestarting = ref<Record<string, boolean>>({})
 const profileSwitching = ref<Record<string, boolean>>({})
 const statusByProfile = computed(() => new Map(runtimeStatuses.value.map(status => [status.profile, status])))
 let runtimeRefreshToken = 0
+
+function setProfileModalShow(show: boolean) {
+  showProfileModal.value = show
+  emit('modal-show-change', show)
+}
 
 async function loadRuntimeStatuses(options: { background?: boolean } = {}): Promise<boolean> {
   const token = ++runtimeRefreshToken
@@ -54,7 +63,7 @@ async function loadRuntimeStatuses(options: { background?: boolean } = {}): Prom
 }
 
 function openProfileModal() {
-  showProfileModal.value = true
+  setProfileModalShow(true)
   void loadRuntimeStatuses().then((refreshing) => {
     if (refreshing) scheduleRuntimeStatusPoll()
   })
@@ -68,6 +77,10 @@ function scheduleRuntimeStatusPoll(attempt = 0) {
       if (refreshing) scheduleRuntimeStatusPoll(attempt + 1)
     })
   }, attempt === 0 ? 700 : 1200)
+}
+
+function handleProfileModalShowChange(show: boolean) {
+  setProfileModalShow(show)
 }
 
 function openAvatarModal(profile: HermesProfile) {
@@ -211,11 +224,12 @@ onMounted(() => {
     </div>
 
     <NModal
-      v-model:show="showProfileModal"
+      :show="showProfileModal"
       preset="card"
       :bordered="false"
       :style="{ width: '720px', maxWidth: 'calc(100vw - 32px)' }"
       class="profile-manager-modal"
+      @update:show="handleProfileModalShowChange"
     >
       <template #header>
         <div class="profile-modal-header">

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -24,7 +24,8 @@ import { homedir } from 'os'
  * - HERMES_GATEWAY_URL / GATEWAY_URL: Explicit Hermes gateway upstream URL for proxy routes.
  * - GATEWAY_HOST: Default Hermes gateway upstream host. Default: 127.0.0.1.
  * - GATEWAY_PORT: Default Hermes gateway upstream port. Default: 8642.
- * - HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN: Whether Web UI shutdown also stops gateways.
+ * - HERMES_WEB_UI_MANAGED_GATEWAY: Web UI-managed Hermes gateway handling. Enabled by default; set 0/false/off to use CLI start.
+ * - HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN: Whether Web UI shutdown also stops managed gateways.
  * - HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT: Disable Hermes Studio MCP config injection.
  * - HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT: Allow MCP injection when HERMES_WEB_UI_HOME is under a temp dir.
  * - HERMES_LAN_DISCOVERY_ENABLED: Set false/0/off to disable UDP LAN discovery responder.

--- a/packages/server/src/services/hermes/gateway-autostart.ts
+++ b/packages/server/src/services/hermes/gateway-autostart.ts
@@ -61,19 +61,9 @@ export function selectProfilesForGatewayAutostart(
   return candidates.filter(name => !exclude.has(name))
 }
 
-function isDockerRuntime(): boolean {
-  return existsSync('/.dockerenv')
-}
-
-function isTermuxRuntime(): boolean {
-  const prefix = process.env.PREFIX || ''
-  return !!process.env.TERMUX_VERSION ||
-    prefix.includes('/com.termux/') ||
-    existsSync('/data/data/com.termux/files/usr')
-}
-
-function envFlagEnabled(name: string): boolean {
-  return envValueFlagEnabled(process.env[name])
+function envFlagDisabled(name: string): boolean {
+  const normalized = String(process.env[name] || '').trim().toLowerCase()
+  return ['0', 'false', 'no', 'off'].includes(normalized)
 }
 
 function envValueFlagEnabled(value: unknown): boolean {
@@ -242,17 +232,12 @@ async function recoverWindowsDesktopGatewayOrphansOnce(): Promise<void> {
 }
 
 export function shouldUseManagedGatewayRun(): boolean {
-  return envFlagEnabled('HERMES_WEB_UI_MANAGED_GATEWAY') ||
-    isDockerRuntime() ||
-    isTermuxRuntime() ||
-    process.platform === 'win32'
+  return !envFlagDisabled('HERMES_WEB_UI_MANAGED_GATEWAY')
 }
 
 export function shouldUseManagedGatewayRunForAutostart(platform: NodeJS.Platform = process.platform): boolean {
-  return envFlagEnabled('HERMES_WEB_UI_MANAGED_GATEWAY') ||
-    isDockerRuntime() ||
-    isTermuxRuntime() ||
-    platform === 'win32'
+  void platform
+  return !envFlagDisabled('HERMES_WEB_UI_MANAGED_GATEWAY')
 }
 
 export function gatewayStatusLooksRunning(output: string): boolean {

--- a/packages/server/src/services/hermes/gateway-runner.ts
+++ b/packages/server/src/services/hermes/gateway-runner.ts
@@ -37,6 +37,13 @@ const profileState = new Map<string, ProfileState>()
 
 /** Delay before respawning a gateway that exited unexpectedly. */
 const RESPAWN_DELAY_MS = 2000
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 2000
+
+export interface ManagedGatewayShutdownResult {
+  signaled: number
+  forced: number
+  errors: number
+}
 
 function getOrCreateProfileState(profileDir: string): ProfileState {
   let state = profileState.get(profileDir)
@@ -45,6 +52,83 @@ function getOrCreateProfileState(profileDir: string): ProfileState {
     profileState.set(profileDir, state)
   }
   return state
+}
+
+function clearRespawnTimer(state: ProfileState, profileDir: string): void {
+  if (!state.respawnTimer) return
+  clearTimeout(state.respawnTimer)
+  state.respawnTimer = null
+  logger.info('[gateway-runner] cancelled pending respawn profileDir=%s', profileDir)
+}
+
+async function stopManagedGateway(entry: SupervisedGateway, timeoutMs: number): Promise<{ forced: boolean; error?: unknown }> {
+  return new Promise(resolve => {
+    let settled = false
+    let forced = false
+
+    const finish = (error?: unknown) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      entry.child.off('exit', onExit)
+      resolve({ forced, error })
+    }
+
+    const onExit = () => finish()
+    const timer = setTimeout(() => {
+      forced = true
+      try {
+        entry.child.kill('SIGKILL')
+      } catch (err) {
+        finish(err)
+        return
+      }
+      finish()
+    }, timeoutMs)
+
+    entry.child.once('exit', onExit)
+
+    try {
+      const signaled = entry.child.kill('SIGTERM')
+      if (!signaled) finish(new Error(`Failed to signal managed gateway pid=${entry.pid}`))
+    } catch (err) {
+      finish(err)
+    }
+  })
+}
+
+export async function shutdownManagedGateways(
+  opts: { timeoutMs?: number } = {},
+): Promise<ManagedGatewayShutdownResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS
+  const stops: Promise<{ forced: boolean; error?: unknown }>[] = []
+  let signaled = 0
+
+  for (const [profileDir, state] of profileState) {
+    clearRespawnTimer(state, profileDir)
+
+    const entry = state.current
+    if (!entry) {
+      profileState.delete(profileDir)
+      continue
+    }
+
+    state.current = null
+    signaled += 1
+    logger.info('[gateway-runner] stopping managed gateway profileDir=%s pid=%s', profileDir, entry.pid)
+    stops.push(stopManagedGateway(entry, timeoutMs))
+    profileState.delete(profileDir)
+  }
+
+  const results = await Promise.all(stops)
+  const forced = results.filter(result => result.forced).length
+  const errors = results.filter(result => result.error).length
+
+  if (signaled > 0) {
+    logger.info('[gateway-runner] managed gateway shutdown complete signaled=%s forced=%s errors=%s', signaled, forced, errors)
+  }
+
+  return { signaled, forced, errors }
 }
 
 export function startGatewayRunManaged(
@@ -57,11 +141,7 @@ export function startGatewayRunManaged(
   // A new spawn for this profile cancels any pending respawn from a previous
   // unexpected exit. Without this, `/restart` (stop -> start) would race
   // against the respawn timer and end up with two gateways on the same port.
-  if (state.respawnTimer) {
-    clearTimeout(state.respawnTimer)
-    state.respawnTimer = null
-    logger.info('[gateway-runner] cancelled pending respawn for new start profileDir=%s', profileDir)
-  }
+  clearRespawnTimer(state, profileDir)
 
   const child = spawnHermesWithBin(hermesBin, ['gateway', 'run', '--replace'], {
     detached: true,

--- a/packages/server/src/services/shutdown.ts
+++ b/packages/server/src/services/shutdown.ts
@@ -2,6 +2,7 @@ import { logger } from './logger'
 import { closeDb } from '../db'
 import { stopPreviewRuntime } from '../controllers/update'
 import { codingAgentRunManager } from './agent-runner/coding-agent-run-manager'
+import { shutdownManagedGateways } from './hermes/gateway-runner'
 
 const DEFAULT_SHUTDOWN_FORCE_EXIT_MS = 15_000
 const DEFAULT_DESKTOP_SHUTDOWN_FORCE_EXIT_MS = 3_000
@@ -29,6 +30,14 @@ export function shouldStopAgentBridgeOnShutdown(signal: string): boolean {
   return signal !== 'SIGUSR2'
 }
 
+export function shouldStopManagedGatewaysOnShutdown(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = String(env.HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN || '').trim().toLowerCase()
+  if (['1', 'true', 'yes', 'on'].includes(raw)) return true
+  if (['0', 'false', 'no', 'off'].includes(raw)) return false
+
+  return String(env.NODE_ENV || '').trim().toLowerCase() === 'production'
+}
+
 export function bindShutdown(server: any, groupChatServer?: any, chatRunServer?: any, agentBridgeManager?: any): void {
   let isShuttingDown = false
 
@@ -49,6 +58,17 @@ export function bindShutdown(server: any, groupChatServer?: any, chatRunServer?:
         logger.info('Preview runtime stopped')
       } catch (err) {
         logger.warn(err, 'Failed to stop preview runtime (non-fatal)')
+      }
+
+      if (shouldStopManagedGatewaysOnShutdown()) {
+        try {
+          const result = await shutdownManagedGateways()
+          logger.info('[shutdown] managed gateways stopped result=%j', result)
+        } catch (err) {
+          logger.warn(err, 'Failed to stop managed gateways (non-fatal)')
+        }
+      } else {
+        logger.info('[shutdown] leaving managed gateways running')
       }
 
       if (agentBridgeManager && shouldStopAgentBridgeOnShutdown(signal)) {

--- a/packages/website/src/i18n/en.ts
+++ b/packages/website/src/i18n/en.ts
@@ -284,7 +284,7 @@ export default {
           ['HERMES_OPENROUTER_APP_REFERER', 'OpenRouter attribution referer sent by bridge runs'],
           ['HERMES_OPENROUTER_APP_TITLE', 'OpenRouter attribution title sent by bridge runs'],
           ['HERMES_OPENROUTER_APP_CATEGORIES', 'OpenRouter attribution categories sent by bridge runs'],
-          ['HERMES_WEB_UI_MANAGED_GATEWAY', 'Force Web UI-managed Hermes gateway process handling'],
+          ['HERMES_WEB_UI_MANAGED_GATEWAY', 'Controls Web UI-managed Hermes gateway handling. Enabled by default; set 0/false/off to use hermes gateway start'],
           ['HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART', 'Skip startup gateway checks/autostart for dashboard-only deployments where another service owns Hermes gateway lifecycle'],
           ['HERMES_WEB_UI_DISABLE_SKILL_INJECTION', 'Skip startup bundled skill injection when skills are managed outside Hermes Web UI. Enabled injection only updates Web UI-managed or identical bundled copies; local edits are skipped'],
           ['HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN', 'Controls whether Hermes Studio shutdown also stops managed gateway processes'],

--- a/packages/website/src/i18n/zh.ts
+++ b/packages/website/src/i18n/zh.ts
@@ -284,7 +284,7 @@ export default {
           ['HERMES_OPENROUTER_APP_REFERER', 'bridge 运行发送给 OpenRouter 的 attribution referer'],
           ['HERMES_OPENROUTER_APP_TITLE', 'bridge 运行发送给 OpenRouter 的 attribution title'],
           ['HERMES_OPENROUTER_APP_CATEGORIES', 'bridge 运行发送给 OpenRouter 的 attribution categories'],
-          ['HERMES_WEB_UI_MANAGED_GATEWAY', '强制启用 Web UI 托管的 Hermes gateway 进程'],
+          ['HERMES_WEB_UI_MANAGED_GATEWAY', '控制 Web UI 托管 Hermes gateway。默认开启；设为 0/false/off 时改用 hermes gateway start'],
           ['HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART', '跳过启动时的 gateway 检查/自动启动；适用于由其它服务管理 Hermes gateway 的 dashboard-only 部署'],
           ['HERMES_WEB_UI_DISABLE_SKILL_INJECTION', '跳过启动时的内置 skill 注入；适用于由 Hermes Web UI 外部管理 skills 的部署。启用注入时只更新 Web UI 管理或完全相同的内置副本，本地修改会跳过'],
           ['HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN', 'Hermes Studio 关闭时是否同时停止托管的 gateway 进程'],

--- a/tests/server/gateway-autostart.test.ts
+++ b/tests/server/gateway-autostart.test.ts
@@ -81,7 +81,21 @@ describe('gateway autostart status parsing', () => {
     expect(gatewayStatusLooksRunning('not running')).toBe(false)
   })
 
-  it('allows managed gateway mode to be forced by environment', () => {
+  it('uses managed gateway mode by default', () => {
+    const previous = process.env.HERMES_WEB_UI_MANAGED_GATEWAY
+    try {
+      delete process.env.HERMES_WEB_UI_MANAGED_GATEWAY
+      expect(shouldUseManagedGatewayRun()).toBe(true)
+      expect(shouldUseManagedGatewayRunForAutostart('darwin')).toBe(true)
+      expect(shouldUseManagedGatewayRunForAutostart('linux')).toBe(true)
+      expect(shouldUseManagedGatewayRunForAutostart('win32')).toBe(true)
+    } finally {
+      if (previous === undefined) delete process.env.HERMES_WEB_UI_MANAGED_GATEWAY
+      else process.env.HERMES_WEB_UI_MANAGED_GATEWAY = previous
+    }
+  })
+
+  it('keeps managed gateway mode enabled when explicitly set', () => {
     const previous = process.env.HERMES_WEB_UI_MANAGED_GATEWAY
     process.env.HERMES_WEB_UI_MANAGED_GATEWAY = '1'
     try {
@@ -93,8 +107,19 @@ describe('gateway autostart status parsing', () => {
     }
   })
 
-  it('uses managed gateway autostart on Windows', () => {
-    expect(shouldUseManagedGatewayRunForAutostart('win32')).toBe(true)
+  it('allows managed gateway mode to be disabled by environment', () => {
+    const previous = process.env.HERMES_WEB_UI_MANAGED_GATEWAY
+    try {
+      for (const value of ['0', 'false', 'no', 'off']) {
+        process.env.HERMES_WEB_UI_MANAGED_GATEWAY = value
+        expect(shouldUseManagedGatewayRun()).toBe(false)
+        expect(shouldUseManagedGatewayRunForAutostart('win32')).toBe(false)
+        expect(shouldUseManagedGatewayRunForAutostart('darwin')).toBe(false)
+      }
+    } finally {
+      if (previous === undefined) delete process.env.HERMES_WEB_UI_MANAGED_GATEWAY
+      else process.env.HERMES_WEB_UI_MANAGED_GATEWAY = previous
+    }
   })
 
   it('only recovers Windows desktop gateway orphans when enabled', () => {

--- a/tests/server/gateway-respawn.test.ts
+++ b/tests/server/gateway-respawn.test.ts
@@ -5,12 +5,16 @@ const originalEnv = { ...process.env }
 
 class FakeChild extends EventEmitter {
   pid: number
+  killSignals: string[] = []
   constructor(pid: number) {
     super()
     this.pid = pid
   }
   unref() { /* no-op */ }
-  kill() { return true }
+  kill(signal?: string) {
+    this.killSignals.push(signal || 'SIGTERM')
+    return true
+  }
 }
 
 let fakeChildren: FakeChild[] = []
@@ -30,6 +34,7 @@ vi.mock('../../packages/server/src/services/hermes/hermes-process', () => ({
 }))
 
 afterEach(() => {
+  vi.useRealTimers()
   vi.restoreAllMocks()
   vi.resetModules()
   process.env = { ...originalEnv }
@@ -60,8 +65,6 @@ describe('gateway-runner supervision', () => {
     expect(fakeChildren.length).toBeGreaterThanOrEqual(2)
     const newPid = fakeChildren[fakeChildren.length - 1].pid
     expect(newPid).not.toBe(10000)
-
-    vi.useRealTimers()
   })
 
   it('cancels a pending respawn when a fresh start is issued for the same profile (the /restart case)', async () => {
@@ -91,8 +94,6 @@ describe('gateway-runner supervision', () => {
     // with the second.
     await vi.advanceTimersByTimeAsync(5000)
     expect(fakeChildren).toHaveLength(2)
-
-    vi.useRealTimers()
   })
 
   it('tracks respawns independently per profile', async () => {
@@ -114,8 +115,6 @@ describe('gateway-runner supervision', () => {
     // profile-x was respawned (3rd child), profile-y was untouched
     expect(fakeChildren).toHaveLength(3)
     expect(fakeChildren[2].pid).toBe(10002)
-
-    vi.useRealTimers()
   })
 
   it('does not respawn if a new start for the same profile has already replaced the dead child', async () => {
@@ -140,7 +139,65 @@ describe('gateway-runner supervision', () => {
 
     // Exactly two children total: the original, and the replacement
     expect(fakeChildren).toHaveLength(2)
+  })
 
-    vi.useRealTimers()
+  it('stops managed gateways on shutdown without respawning them', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    const { shutdownManagedGateways, startGatewayRunManaged } = await import(
+      '../../packages/server/src/services/hermes/gateway-runner'
+    )
+
+    startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/shutdown-a' })
+    startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/shutdown-b' })
+    expect(fakeChildren).toHaveLength(2)
+
+    const shutdown = shutdownManagedGateways({ timeoutMs: 5000 })
+
+    expect(fakeChildren[0].killSignals).toEqual(['SIGTERM'])
+    expect(fakeChildren[1].killSignals).toEqual(['SIGTERM'])
+
+    fakeChildren[0].emit('exit', 0, 'SIGTERM')
+    fakeChildren[1].emit('exit', 0, 'SIGTERM')
+
+    await expect(shutdown).resolves.toEqual({ signaled: 2, forced: 0, errors: 0 })
+    await vi.advanceTimersByTimeAsync(6000)
+
+    expect(fakeChildren).toHaveLength(2)
+  })
+
+  it('cancels pending respawn timers during managed gateway shutdown', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    const { shutdownManagedGateways, startGatewayRunManaged } = await import(
+      '../../packages/server/src/services/hermes/gateway-runner'
+    )
+
+    startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/shutdown-c' })
+    fakeChildren[0].emit('exit', 1, null)
+
+    const result = await shutdownManagedGateways({ timeoutMs: 5000 })
+    expect(result).toEqual({ signaled: 0, forced: 0, errors: 0 })
+
+    await vi.advanceTimersByTimeAsync(6000)
+    expect(fakeChildren).toHaveLength(1)
+  })
+
+  it('forces managed gateway shutdown when children do not exit', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    const { shutdownManagedGateways, startGatewayRunManaged } = await import(
+      '../../packages/server/src/services/hermes/gateway-runner'
+    )
+
+    startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/shutdown-d' })
+
+    const shutdown = shutdownManagedGateways({ timeoutMs: 1000 })
+    expect(fakeChildren[0].killSignals).toEqual(['SIGTERM'])
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    await expect(shutdown).resolves.toEqual({ signaled: 1, forced: 1, errors: 0 })
+    expect(fakeChildren[0].killSignals).toEqual(['SIGTERM', 'SIGKILL'])
   })
 })

--- a/tests/server/shutdown.test.ts
+++ b/tests/server/shutdown.test.ts
@@ -1,14 +1,24 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { getShutdownForceExitMs, shouldStopAgentBridgeOnShutdown } from '../../packages/server/src/services/shutdown'
+import {
+  getShutdownForceExitMs,
+  shouldStopAgentBridgeOnShutdown,
+  shouldStopManagedGatewaysOnShutdown,
+} from '../../packages/server/src/services/shutdown'
 
 describe('shutdown bridge policy', () => {
   const originalValue = process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN
+  const originalGatewayValue = process.env.HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN
+  const originalNodeEnv = process.env.NODE_ENV
   const originalDesktop = process.env.HERMES_DESKTOP
   const originalForceExitMs = process.env.HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS
 
   afterEach(() => {
     if (originalValue === undefined) delete process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN
     else process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN = originalValue
+    if (originalGatewayValue === undefined) delete process.env.HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN
+    else process.env.HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN = originalGatewayValue
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV
+    else process.env.NODE_ENV = originalNodeEnv
     if (originalDesktop === undefined) delete process.env.HERMES_DESKTOP
     else process.env.HERMES_DESKTOP = originalDesktop
     if (originalForceExitMs === undefined) delete process.env.HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS
@@ -29,6 +39,26 @@ describe('shutdown bridge policy', () => {
 
     process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN = '0'
     expect(shouldStopAgentBridgeOnShutdown('SIGTERM')).toBe(false)
+  })
+
+  it('stops managed gateways by default in production only', () => {
+    delete process.env.HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN
+
+    process.env.NODE_ENV = 'development'
+    expect(shouldStopManagedGatewaysOnShutdown()).toBe(false)
+
+    process.env.NODE_ENV = 'production'
+    expect(shouldStopManagedGatewaysOnShutdown()).toBe(true)
+  })
+
+  it('allows operators to force either managed gateway shutdown policy', () => {
+    process.env.NODE_ENV = 'development'
+    process.env.HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN = '1'
+    expect(shouldStopManagedGatewaysOnShutdown()).toBe(true)
+
+    process.env.NODE_ENV = 'production'
+    process.env.HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN = '0'
+    expect(shouldStopManagedGatewaysOnShutdown()).toBe(false)
   })
 
   it('keeps desktop shutdown force-exit timing short by default', () => {


### PR DESCRIPTION
## Summary
- stop Web UI-managed gateway children during server shutdown when the shutdown policy is enabled
- make Web UI-managed gateway mode the default; set HERMES_WEB_UI_MANAGED_GATEWAY=0/false/no/off to use `hermes gateway start` instead
- enable managed gateway shutdown in nodemon dev runs to avoid orphan gateway processes leaking into later production runs
- cancel pending gateway respawn timers before shutdown cleanup so exiting children do not get restarted
- add policy and runner tests for managed-mode defaults, explicit opt-out, production shutdown defaults, graceful stop, forced stop, and pending respawn cancellation

## Root Cause
PR #1537 made managed gateways respawn while the Web UI server is alive, but the managed children were still spawned detached and unref'd. When the server exited, those gateway processes could survive as orphans, which is especially visible on Windows during update/install flows and can also pollute later production runs after local dev.

## Behavior
By default, Web UI now owns gateway lifecycle through managed `gateway run --replace`. Operators can set `HERMES_WEB_UI_MANAGED_GATEWAY=0` to fall back to `hermes gateway start`. Production shutdown stops managed gateways by default, and the nodemon dev config now opts into the same cleanup so development restarts do not leave orphan gateway processes.

## Validation
- npx vitest run tests/server/gateway-autostart.test.ts tests/server/gateway-respawn.test.ts tests/server/shutdown.test.ts
- npx tsc --noEmit -p packages/server/tsconfig.json
- node -e "JSON.parse(require('fs').readFileSync('nodemon.json','utf8')); console.log('nodemon.json ok')"