### PR TITLE
[codex] Fix Windows gateway shutdown cleanup

### DIFF
--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -24,6 +24,7 @@ import {
 const DEFAULT_PORT = 8748
 const DEFAULT_READY_TIMEOUT_MS = 120_000
 const DEFAULT_FULL_STARTUP_WAIT_MS = 0
+const DEFAULT_STOP_TIMEOUT_MS = 20_000
 const AGENT_BRIDGE_STARTED_MARKER = '[bootstrap] agent bridge started'
 const AGENT_BRIDGE_FAILED_MARKER = '[bootstrap] agent bridge failed to start'
 const execFileAsync = promisify(execFile)
@@ -461,7 +462,7 @@ export function stopWebUiServer(): Promise<void> {
     const timer = setTimeout(() => {
       killProcessTree(proc)
       resolve()
-    }, 3000)
+    }, envPositiveInt('HERMES_DESKTOP_STOP_TIMEOUT_MS') || DEFAULT_STOP_TIMEOUT_MS)
     proc.once('exit', () => {
       clearTimeout(timer)
       resolve()

--- a/packages/server/src/services/hermes/gateway-runner.ts
+++ b/packages/server/src/services/hermes/gateway-runner.ts
@@ -1,3 +1,5 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
 import { logger } from '../logger'
 import { getActiveProfileDir } from './hermes-profile'
 import { spawnHermesWithBin } from './hermes-process'
@@ -38,6 +40,7 @@ const profileState = new Map<string, ProfileState>()
 /** Delay before respawning a gateway that exited unexpectedly. */
 const RESPAWN_DELAY_MS = 2000
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 2000
+const execFileAsync = promisify(execFile)
 
 export interface ManagedGatewayShutdownResult {
   signaled: number
@@ -54,6 +57,8 @@ function getOrCreateProfileState(profileDir: string): ProfileState {
   return state
 }
 
+type KillWindowsProcessTree = (pid: number) => Promise<void>
+
 function clearRespawnTimer(state: ProfileState, profileDir: string): void {
   if (!state.respawnTimer) return
   clearTimeout(state.respawnTimer)
@@ -61,7 +66,36 @@ function clearRespawnTimer(state: ProfileState, profileDir: string): void {
   logger.info('[gateway-runner] cancelled pending respawn profileDir=%s', profileDir)
 }
 
-async function stopManagedGateway(entry: SupervisedGateway, timeoutMs: number): Promise<{ forced: boolean; error?: unknown }> {
+async function taskkillWindowsProcessTree(pid: number): Promise<void> {
+  await execFileAsync('taskkill.exe', ['/PID', String(pid), '/T', '/F'], {
+    timeout: 5000,
+    windowsHide: true,
+  })
+}
+
+async function stopManagedGateway(
+  entry: SupervisedGateway,
+  opts: {
+    timeoutMs: number
+    platform: NodeJS.Platform
+    killWindowsProcessTree: KillWindowsProcessTree
+  },
+): Promise<{ forced: boolean; error?: unknown }> {
+  if (opts.platform === 'win32') {
+    try {
+      await opts.killWindowsProcessTree(entry.pid)
+      return { forced: true }
+    } catch (err) {
+      logger.warn(err, '[gateway-runner] taskkill failed for managed gateway pid=%s; falling back to child.kill', entry.pid)
+      try {
+        entry.child.kill('SIGKILL')
+        return { forced: true, error: err }
+      } catch (killErr) {
+        return { forced: true, error: killErr }
+      }
+    }
+  }
+
   return new Promise(resolve => {
     let settled = false
     let forced = false
@@ -84,7 +118,7 @@ async function stopManagedGateway(entry: SupervisedGateway, timeoutMs: number): 
         return
       }
       finish()
-    }, timeoutMs)
+    }, opts.timeoutMs)
 
     entry.child.once('exit', onExit)
 
@@ -98,9 +132,15 @@ async function stopManagedGateway(entry: SupervisedGateway, timeoutMs: number): 
 }
 
 export async function shutdownManagedGateways(
-  opts: { timeoutMs?: number } = {},
+  opts: {
+    timeoutMs?: number
+    platform?: NodeJS.Platform
+    killWindowsProcessTree?: KillWindowsProcessTree
+  } = {},
 ): Promise<ManagedGatewayShutdownResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS
+  const platform = opts.platform ?? process.platform
+  const killWindowsProcessTree = opts.killWindowsProcessTree ?? taskkillWindowsProcessTree
   const stops: Promise<{ forced: boolean; error?: unknown }>[] = []
   let signaled = 0
 
@@ -116,7 +156,7 @@ export async function shutdownManagedGateways(
     state.current = null
     signaled += 1
     logger.info('[gateway-runner] stopping managed gateway profileDir=%s pid=%s', profileDir, entry.pid)
-    stops.push(stopManagedGateway(entry, timeoutMs))
+    stops.push(stopManagedGateway(entry, { timeoutMs, platform, killWindowsProcessTree }))
     profileState.delete(profileDir)
   }
 

--- a/packages/server/src/services/shutdown.ts
+++ b/packages/server/src/services/shutdown.ts
@@ -5,7 +5,7 @@ import { codingAgentRunManager } from './agent-runner/coding-agent-run-manager'
 import { shutdownManagedGateways } from './hermes/gateway-runner'
 
 const DEFAULT_SHUTDOWN_FORCE_EXIT_MS = 15_000
-const DEFAULT_DESKTOP_SHUTDOWN_FORCE_EXIT_MS = 3_000
+const DEFAULT_DESKTOP_SHUTDOWN_FORCE_EXIT_MS = 15_000
 
 function envPositiveInt(name: string): number | undefined {
   const value = Number(process.env[name])

--- a/tests/server/gateway-respawn.test.ts
+++ b/tests/server/gateway-respawn.test.ts
@@ -200,4 +200,22 @@ describe('gateway-runner supervision', () => {
     await expect(shutdown).resolves.toEqual({ signaled: 1, forced: 1, errors: 0 })
     expect(fakeChildren[0].killSignals).toEqual(['SIGTERM', 'SIGKILL'])
   })
+
+  it('kills the managed gateway process tree on Windows shutdown', async () => {
+    vi.resetModules()
+    const killWindowsProcessTree = vi.fn().mockResolvedValue(undefined)
+    const { shutdownManagedGateways, startGatewayRunManaged } = await import(
+      '../../packages/server/src/services/hermes/gateway-runner'
+    )
+
+    startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/shutdown-win' })
+
+    await expect(shutdownManagedGateways({
+      platform: 'win32',
+      killWindowsProcessTree,
+    })).resolves.toEqual({ signaled: 1, forced: 1, errors: 0 })
+
+    expect(killWindowsProcessTree).toHaveBeenCalledWith(10000)
+    expect(fakeChildren[0].killSignals).toEqual([])
+  })
 })

--- a/tests/server/shutdown.test.ts
+++ b/tests/server/shutdown.test.ts
@@ -61,14 +61,14 @@ describe('shutdown bridge policy', () => {
     expect(shouldStopManagedGatewaysOnShutdown()).toBe(false)
   })
 
-  it('keeps desktop shutdown force-exit timing short by default', () => {
+  it('keeps desktop shutdown force-exit timing long enough for runtime cleanup by default', () => {
     delete process.env.HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS
 
     delete process.env.HERMES_DESKTOP
     expect(getShutdownForceExitMs()).toBe(15_000)
 
     process.env.HERMES_DESKTOP = 'true'
-    expect(getShutdownForceExitMs()).toBe(3_000)
+    expect(getShutdownForceExitMs()).toBe(15_000)
   })
 
   it('allows operators to override shutdown force-exit timing', () => {


### PR DESCRIPTION
## Summary

- Stop managed gateways on Windows with `taskkill.exe /T /F` so the whole gateway process tree is removed.
- Increase desktop shutdown force-exit timing so server-side gateway and bridge cleanup can finish before Electron kills the server process.
- Make the outer desktop server stop timeout configurable via `HERMES_DESKTOP_STOP_TIMEOUT_MS` and default it to 20 seconds.
- Add regression coverage for Windows managed gateway shutdown and desktop shutdown timing.

## Why

Desktop runs the Web UI server with `NODE_ENV=production`, so managed gateway cleanup is supposed to run on app quit. On Windows, relying on Node `child.kill()` for a detached Python gateway can leave child processes behind, and the previous 3-second desktop shutdown window could kill the server before runtime cleanup completed.

## Validation

- `npx vitest run tests/server/gateway-respawn.test.ts tests/server/shutdown.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run build` in `packages/desktop`