### PR TITLE
[codex] Limit gateway respawn retries

### DIFF
--- a/packages/server/src/services/hermes/gateway-runner.ts
+++ b/packages/server/src/services/hermes/gateway-runner.ts
@@ -9,6 +9,7 @@ interface SupervisedGateway {
   child: ReturnType<typeof spawnHermesWithBin>
   hermesBin: string
   profileDir: string
+  startedAt: number
 }
 
 /**
@@ -33,12 +34,15 @@ interface SupervisedGateway {
 interface ProfileState {
   current: SupervisedGateway | null
   respawnTimer: NodeJS.Timeout | null
+  respawnAttempts: number
 }
 
 const profileState = new Map<string, ProfileState>()
 
 /** Delay before respawning a gateway that exited unexpectedly. */
 const RESPAWN_DELAY_MS = 2000
+const RESPAWN_STABLE_RUN_MS = 30000
+const MAX_RESPAWN_ATTEMPTS = 3
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 2000
 const execFileAsync = promisify(execFile)
 
@@ -51,7 +55,7 @@ export interface ManagedGatewayShutdownResult {
 function getOrCreateProfileState(profileDir: string): ProfileState {
   let state = profileState.get(profileDir)
   if (!state) {
-    state = { current: null, respawnTimer: null }
+    state = { current: null, respawnTimer: null, respawnAttempts: 0 }
     profileState.set(profileDir, state)
   }
   return state
@@ -175,6 +179,16 @@ export function startGatewayRunManaged(
   hermesBin: string,
   opts: { profileDir?: string } = {},
 ): { pid: number | null; reused: boolean } {
+  return startGatewayRunManagedInternal(hermesBin, {
+    profileDir: opts.profileDir,
+    preserveRespawnAttempts: false,
+  })
+}
+
+function startGatewayRunManagedInternal(
+  hermesBin: string,
+  opts: { profileDir?: string; preserveRespawnAttempts?: boolean } = {},
+): { pid: number | null; reused: boolean } {
   const profileDir = opts.profileDir || getActiveProfileDir()
   const state = getOrCreateProfileState(profileDir)
 
@@ -182,6 +196,9 @@ export function startGatewayRunManaged(
   // unexpected exit. Without this, `/restart` (stop -> start) would race
   // against the respawn timer and end up with two gateways on the same port.
   clearRespawnTimer(state, profileDir)
+  if (!opts.preserveRespawnAttempts) {
+    state.respawnAttempts = 0
+  }
 
   const child = spawnHermesWithBin(hermesBin, ['gateway', 'run', '--replace'], {
     detached: true,
@@ -196,7 +213,7 @@ export function startGatewayRunManaged(
 
   const pid = child.pid ?? null
   if (pid) {
-    const entry: SupervisedGateway = { pid, child, hermesBin, profileDir }
+    const entry: SupervisedGateway = { pid, child, hermesBin, profileDir, startedAt: Date.now() }
     state.current = entry
 
     child.on('exit', (code, signal) => {
@@ -205,19 +222,34 @@ export function startGatewayRunManaged(
       // want the old child's exit to trigger anything.
       if (state.current?.pid !== pid) return
       state.current = null
+      if (Date.now() - entry.startedAt >= RESPAWN_STABLE_RUN_MS) {
+        state.respawnAttempts = 0
+      }
+      state.respawnAttempts += 1
+
+      if (state.respawnAttempts > MAX_RESPAWN_ATTEMPTS) {
+        logger.error(
+          '[gateway-runner] gateway exited unexpectedly and reached respawn limit (profileDir=%s pid=%s code=%s signal=%s attempts=%s maxAttempts=%s)',
+          profileDir, pid, code, signal, state.respawnAttempts - 1, MAX_RESPAWN_ATTEMPTS,
+        )
+        return
+      }
 
       logger.warn(
-        '[gateway-runner] gateway exited unexpectedly (profileDir=%s pid=%s code=%s signal=%s), respawning in %dms',
-        profileDir, pid, code, signal, RESPAWN_DELAY_MS,
+        '[gateway-runner] gateway exited unexpectedly (profileDir=%s pid=%s code=%s signal=%s attempt=%s/%s), respawning in %dms',
+        profileDir, pid, code, signal, state.respawnAttempts, MAX_RESPAWN_ATTEMPTS, RESPAWN_DELAY_MS,
       )
 
       state.respawnTimer = setTimeout(() => {
         state.respawnTimer = null
         try {
-          const next = startGatewayRunManaged(hermesBin, { profileDir })
+          const next = startGatewayRunManagedInternal(hermesBin, {
+            profileDir,
+            preserveRespawnAttempts: true,
+          })
           logger.info(
-            '[gateway-runner] gateway respawned (oldPid=%s newPid=%s profileDir=%s)',
-            pid, next.pid, profileDir,
+            '[gateway-runner] gateway respawned (oldPid=%s newPid=%s profileDir=%s attempt=%s/%s)',
+            pid, next.pid, profileDir, state.respawnAttempts, MAX_RESPAWN_ATTEMPTS,
           )
         } catch (err) {
           logger.error(err, '[gateway-runner] failed to respawn gateway after unexpected exit')

--- a/tests/server/gateway-respawn.test.ts
+++ b/tests/server/gateway-respawn.test.ts
@@ -67,6 +67,60 @@ describe('gateway-runner supervision', () => {
     expect(newPid).not.toBe(10000)
   })
 
+  it('stops respawning after three consecutive quick failures', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    const { startGatewayRunManaged } = await import(
+      '../../packages/server/src/services/hermes/gateway-runner'
+    )
+
+    startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/flapping' })
+    expect(fakeChildren).toHaveLength(1)
+
+    for (let i = 0; i < 3; i += 1) {
+      fakeChildren[fakeChildren.length - 1].emit('exit', 1, null)
+      await vi.advanceTimersByTimeAsync(2500)
+    }
+
+    expect(fakeChildren).toHaveLength(4)
+
+    fakeChildren[fakeChildren.length - 1].emit('exit', 1, null)
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(fakeChildren).toHaveLength(4)
+  })
+
+  it('resets the respawn limit after a stable run', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    const { startGatewayRunManaged } = await import(
+      '../../packages/server/src/services/hermes/gateway-runner'
+    )
+
+    startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/recovered' })
+
+    fakeChildren[0].emit('exit', 1, null)
+    await vi.advanceTimersByTimeAsync(2500)
+    fakeChildren[1].emit('exit', 1, null)
+    await vi.advanceTimersByTimeAsync(2500)
+    expect(fakeChildren).toHaveLength(3)
+
+    await vi.advanceTimersByTimeAsync(31000)
+    fakeChildren[2].emit('exit', 1, null)
+    await vi.advanceTimersByTimeAsync(2500)
+    expect(fakeChildren).toHaveLength(4)
+
+    fakeChildren[3].emit('exit', 1, null)
+    await vi.advanceTimersByTimeAsync(2500)
+    fakeChildren[4].emit('exit', 1, null)
+    await vi.advanceTimersByTimeAsync(2500)
+    expect(fakeChildren).toHaveLength(6)
+
+    fakeChildren[5].emit('exit', 1, null)
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(fakeChildren).toHaveLength(6)
+  })
+
   it('cancels a pending respawn when a fresh start is issued for the same profile (the /restart case)', async () => {
     vi.useFakeTimers()
     vi.resetModules()


### PR DESCRIPTION
## Summary

- Limit managed gateway respawn to three consecutive quick failures per profile.
- Reset the retry counter after a gateway runs stably for 30 seconds.
- Add gateway runner tests for the retry limit and stable-run reset behavior.

## Impact

A broken gateway startup no longer loops forever. Managed gateways still recover from occasional crashes, but repeated startup failures now stop after three retries and log an error.

## Validation

- `npx vitest run tests/server/gateway-respawn.test.ts`
- `npm run build`
