### PR TITLE
[codex] rename repository to hermes-studio

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://github.com/EKKOLearnAI/hermes-web-ui#readme
+    url: https://github.com/EKKOLearnAI/hermes-studio#readme
     about: Please check the documentation first
   - name: GitHub Discussions
-    url: https://github.com/EKKOLearnAI/hermes-web-ui/discussions
+    url: https://github.com/EKKOLearnAI/hermes-studio/discussions
     about: Use GitHub Discussions for questions that don't fit as issues

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest">Download Hermes Studio Desktop</a>
+  <a href="https://github.com/EKKOLearnAI/hermes-studio/releases/latest">Download Hermes Studio Desktop</a>
   ·
   <code>npm install -g hermes-web-ui && hermes-web-ui start</code>
 </p>
 
 <p align="center">
-  <img src="https://github.com/EKKOLearnAI/hermes-web-ui/blob/main/packages/client/src/assets/image.gif" alt="Hermes Web UI Demo" width="680"/>
+  <img src="https://github.com/EKKOLearnAI/hermes-studio/blob/main/packages/client/src/assets/image.gif" alt="Hermes Web UI Demo" width="680"/>
 </p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/hermes-web-ui"><img src="https://img.shields.io/npm/v/hermes-web-ui?style=flat-square&color=blue" alt="npm version"/></a>
-  <a href="https://github.com/EKKOLearnAI/hermes-web-ui/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/hermes-web-ui?style=flat-square" alt="license"/></a>
-  <a href="https://github.com/EKKOLearnAI/hermes-web-ui/stargazers"><img src="https://img.shields.io/github/stars/EKKOLearnAI/hermes-web-ui?style=flat-square" alt="stars"/></a>
+  <a href="https://github.com/EKKOLearnAI/hermes-studio/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/hermes-web-ui?style=flat-square" alt="license"/></a>
+  <a href="https://github.com/EKKOLearnAI/hermes-studio/stargazers"><img src="https://img.shields.io/github/stars/EKKOLearnAI/hermes-studio?style=flat-square" alt="stars"/></a>
 </p>
 
 ## Core Capabilities
@@ -221,7 +221,7 @@ hermes-web-ui reset-default-login
 ### Desktop App (Recommended)
 
 Download the latest **Hermes Studio** desktop installer from
-[GitHub Releases](https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest).
+[GitHub Releases](https://github.com/EKKOLearnAI/hermes-studio/releases/latest).
 
 Desktop builds are published for macOS, Windows, and Linux, with separate
 architecture assets where applicable. The desktop app bundles the Web UI
@@ -236,7 +236,7 @@ The desktop wrapper stores its own Web UI state separately in
 Desktop auto-updates read the latest feed from
 `https://download.ekkolearnai.com/latest` first. If that endpoint is
 unavailable, the updater falls back to
-`https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest/download`.
+`https://github.com/EKKOLearnAI/hermes-studio/releases/latest/download`.
 
 ### npm
 
@@ -365,7 +365,7 @@ On startup the BFF server automatically:
 ## Development
 
 ```bash
-git clone https://github.com/EKKOLearnAI/hermes-web-ui.git
+git clone https://github.com/EKKOLearnAI/hermes-studio.git
 cd hermes-web-ui
 npm install
 npm run dev
@@ -405,9 +405,9 @@ The BFF layer handles Socket.IO chat streaming, the Hermes agent bridge, profile
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=EKKOLearnAI/hermes-web-ui&type=Date)](https://star-history.com/#EKKOLearnAI/hermes-web-ui&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=EKKOLearnAI/hermes-studio&type=Date)](https://star-history.com/#EKKOLearnAI/hermes-studio&Date)
 
-<!-- If the chart above doesn't load, visit https://star-history.com/#EKKOLearnAI/hermes-web-ui -->
+<!-- If the chart above doesn't load, visit https://star-history.com/#EKKOLearnAI/hermes-studio -->
 
 ## License
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,13 +10,13 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest">下载 Hermes Studio 桌面版</a>
+  <a href="https://github.com/EKKOLearnAI/hermes-studio/releases/latest">下载 Hermes Studio 桌面版</a>
   ·
   <code>npm install -g hermes-web-ui && hermes-web-ui start</code>
 </p>
 
 <p align="center">
-  <img src="https://github.com/EKKOLearnAI/hermes-web-ui/blob/main/packages/client/src/assets/image.gif" alt="Hermes Web UI 演示" width="680"/>
+  <img src="https://github.com/EKKOLearnAI/hermes-studio/blob/main/packages/client/src/assets/image.gif" alt="Hermes Web UI 演示" width="680"/>
 </p>
 
 <p align="center">
@@ -24,13 +24,13 @@
 </p>
 
 <p align="center">
-  <video src="https://github.com/EKKOLearnAI/hermes-web-ui/blob/main/packages/client/src/assets/video.mp4?raw=true" width="360" controls></video>
+  <video src="https://github.com/EKKOLearnAI/hermes-studio/blob/main/packages/client/src/assets/video.mp4?raw=true" width="360" controls></video>
 </p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/hermes-web-ui"><img src="https://img.shields.io/npm/v/hermes-web-ui?style=flat-square&color=blue" alt="npm 版本"/></a>
-  <a href="https://github.com/EKKOLearnAI/hermes-web-ui/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/hermes-web-ui?style=flat-square" alt="许可证"/></a>
-  <a href="https://github.com/EKKOLearnAI/hermes-web-ui/stargazers"><img src="https://img.shields.io/github/stars/EKKOLearnAI/hermes-web-ui?style=flat-square" alt="Star"/></a>
+  <a href="https://github.com/EKKOLearnAI/hermes-studio/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/hermes-web-ui?style=flat-square" alt="许可证"/></a>
+  <a href="https://github.com/EKKOLearnAI/hermes-studio/stargazers"><img src="https://img.shields.io/github/stars/EKKOLearnAI/hermes-studio?style=flat-square" alt="Star"/></a>
 </p>
 
 ## 核心能力
@@ -228,7 +228,7 @@ hermes-web-ui reset-default-login
 
 ### 桌面应用（推荐）
 
-从 [GitHub Releases](https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest)
+从 [GitHub Releases](https://github.com/EKKOLearnAI/hermes-studio/releases/latest)
 下载最新的 **Hermes Studio** 桌面安装包。
 
 桌面版会发布 macOS、Windows 和 Linux 构建；适用时会区分不同 CPU 架构。
@@ -242,7 +242,7 @@ hermes-web-ui reset-default-login
 
 桌面自动更新会优先读取 `https://download.ekkolearnai.com/latest`。
 如果该端点不可用，更新器会回退到
-`https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest/download`。
+`https://github.com/EKKOLearnAI/hermes-studio/releases/latest/download`。
 
 ### npm 安装
 
@@ -368,7 +368,7 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 ## 开发
 
 ```bash
-git clone https://github.com/EKKOLearnAI/hermes-web-ui.git
+git clone https://github.com/EKKOLearnAI/hermes-studio.git
 cd hermes-web-ui
 npm install
 npm run dev
@@ -408,9 +408,9 @@ BFF 层负责：Socket.IO 聊天流式推送、Hermes agent bridge、按 Profile
 
 ## Star 历史
 
-[![Star 历史图表](https://api.star-history.com/svg?repos=EKKOLearnAI/hermes-web-ui&type=Date)](https://star-history.com/#EKKOLearnAI/hermes-web-ui&Date)
+[![Star 历史图表](https://api.star-history.com/svg?repos=EKKOLearnAI/hermes-studio&type=Date)](https://star-history.com/#EKKOLearnAI/hermes-studio&Date)
 
-<!-- 如上方图表未加载，可访问 https://star-history.com/#EKKOLearnAI/hermes-web-ui -->
+<!-- 如上方图表未加载，可访问 https://star-history.com/#EKKOLearnAI/hermes-studio -->
 
 ## 许可证
 

--- a/docs/chat-chain-changes/2026-06-14-local-repository-rename.md
+++ b/docs/chat-chain-changes/2026-06-14-local-repository-rename.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-14
+commit: local pending change
+feature: Chat and group chat sidebar GitHub links
+impact: No chat runtime behavior changed; links now point to the renamed EKKOLearnAI/hermes-studio repository.
+---

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Self-hosted AI chat dashboard for Hermes Agent — multi-model web UI with multi-platform integration",
   "repository": {
     "type": "git",
-    "url": "https://github.com/EKKOLearnAI/hermes-web-ui.git"
+    "url": "https://github.com/EKKOLearnAI/hermes-studio.git"
   },
   "homepage": "https://hermes-studio.ai",
   "license": "BSL-1.1",

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -1219,7 +1219,7 @@ async function handleSessionModelCustomSubmit() {
             </div>
             <div class="page-sidebar-version-row">
               <div class="page-sidebar-version-links">
-                <a class="page-sidebar-link" href="https://github.com/EKKOLearnAI/hermes-web-ui" target="_blank" rel="noopener noreferrer" title="GitHub">
+                <a class="page-sidebar-link" href="https://github.com/EKKOLearnAI/hermes-studio" target="_blank" rel="noopener noreferrer" title="GitHub">
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
                 </a>
                 <a class="page-sidebar-link" href="https://hermes-studio.ai/" target="_blank" rel="noopener noreferrer" title="Website">

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -471,7 +471,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                         </div>
                         <div class="page-sidebar-version-row">
                             <div class="page-sidebar-version-links">
-                                <a class="page-sidebar-link" href="https://github.com/EKKOLearnAI/hermes-web-ui" target="_blank" rel="noopener noreferrer" title="GitHub">
+                                <a class="page-sidebar-link" href="https://github.com/EKKOLearnAI/hermes-studio" target="_blank" rel="noopener noreferrer" title="GitHub">
                                     <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
                                 </a>
                                 <a class="page-sidebar-link" href="https://hermes-studio.ai/" target="_blank" rel="noopener noreferrer" title="Website">

--- a/packages/client/src/components/layout/PageSidebarFooter.vue
+++ b/packages/client/src/components/layout/PageSidebarFooter.vue
@@ -97,7 +97,7 @@ function handleSettingsPopoverShowChange(show: boolean) {
         </div>
         <div class="page-sidebar-version-row">
           <div class="page-sidebar-version-links">
-            <a class="page-sidebar-link" href="https://github.com/EKKOLearnAI/hermes-web-ui" target="_blank" rel="noopener noreferrer" title="GitHub">
+            <a class="page-sidebar-link" href="https://github.com/EKKOLearnAI/hermes-studio" target="_blank" rel="noopener noreferrer" title="GitHub">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
             </a>
             <a class="page-sidebar-link" href="https://hermes-studio.ai/" target="_blank" rel="noopener noreferrer" title="Website">

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -6,7 +6,7 @@ Electron desktop distribution for Hermes Studio.
 
 Download the latest macOS, Windows, or Linux installer for your CPU
 architecture from the project
-[GitHub Releases](https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest).
+[GitHub Releases](https://github.com/EKKOLearnAI/hermes-studio/releases/latest).
 
 The desktop app bundles the Web UI runtime and launches it locally from the
 native shell app.

--- a/packages/desktop/src/main/runtime-manager.ts
+++ b/packages/desktop/src/main/runtime-manager.ts
@@ -31,7 +31,7 @@ import { extractTarGzipArchive } from './runtime-archive'
 import { t } from './desktop-i18n'
 
 const DEFAULT_RUNTIME_BASE_URL = 'https://download.ekkolearnai.com'
-const DEFAULT_RUNTIME_GITHUB_REPO = 'EKKOLearnAI/hermes-web-ui'
+const DEFAULT_RUNTIME_GITHUB_REPO = 'EKKOLearnAI/hermes-studio'
 const RUNTIME_MANIFEST_NAME = 'runtime-manifest.json'
 const PACKAGED_RUNTIME_RELEASE_NAME = 'runtime-release.json'
 const ACTIVE_RUNTIME_VERSION_NAME = 'active-version.json'

--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -8,7 +8,7 @@ let updateDownloaded = false
 let tryingFallbackFeed = false
 
 const CLOUDFLARE_LATEST_FEED_URL = 'https://download.ekkolearnai.com/latest'
-const GITHUB_LATEST_FEED_URL = 'https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest/download'
+const GITHUB_LATEST_FEED_URL = 'https://github.com/EKKOLearnAI/hermes-studio/releases/latest/download'
 
 interface AutoUpdaterOptions {
   beforeQuitAndInstall?: () => void

--- a/packages/server/src/services/runtime-version-manager.ts
+++ b/packages/server/src/services/runtime-version-manager.ts
@@ -10,7 +10,7 @@ import { getHermesWebUiVersion } from './system-info'
 const ACTIVE_VERSION_FILE = 'active-version.json'
 const DEFAULT_REMOTE_MANIFEST_URL = 'https://hermes-studio.ai/versions.json'
 const DEFAULT_DOWNLOAD_BASE_URL = 'https://download.ekkolearnai.com'
-const DEFAULT_GITHUB_REPO = 'EKKOLearnAI/hermes-web-ui'
+const DEFAULT_GITHUB_REPO = 'EKKOLearnAI/hermes-studio'
 
 export interface ActiveVersionManifest {
   schema: number

--- a/packages/website/public/docs/hermes-studio-0.6.12-full-cn/index.html
+++ b/packages/website/public/docs/hermes-studio-0.6.12-full-cn/index.html
@@ -354,7 +354,7 @@
         <h3>2.1 核对来源</h3>
         <ul class="source-list">
           <li>Hermes Studio 官方网站：<a href="https://hermes-studio.ai/">https://hermes-studio.ai/</a>，定位为 Hermes 智能体的自托管智能会话控制台。</li>
-          <li>Hermes 网页界面说明文档：<a href="https://github.com/EKKOLearnAI/hermes-web-ui/blob/main/README.md">github.com/EKKOLearnAI/hermes-web-ui/README.md</a>，列出会话、历史、频道、任务、技能、记忆、用量、终端、用户档案、设置等功能。</li>
+          <li>Hermes 网页界面说明文档：<a href="https://github.com/EKKOLearnAI/hermes-studio/blob/main/README.md">github.com/EKKOLearnAI/hermes-studio/README.md</a>，列出会话、历史、频道、任务、技能、记忆、用量、终端、用户档案、设置等功能。</li>
           <li>Hermes 智能体官方文档：<a href="https://hermes-agent.nousresearch.com/docs/">https://hermes-agent.nousresearch.com/docs/</a>，用于核对智能体、网关、技能、记忆、MCP、消息网关和安全能力范围。</li>
           <li>MCP 官方功能页：<a href="https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp">Hermes 智能体 MCP 文档</a>，用于核对 MCP 服务管理范围。</li>
           <li>本机 Hermes Studio 0.6.12 设备接口：用于核对设备发现、扫描、配对状态、活跃连接、远程终端、远程命令和文件传输能力。</li>

--- a/packages/website/src/components/landing/InstallSection.vue
+++ b/packages/website/src/components/landing/InstallSection.vue
@@ -15,7 +15,7 @@ const activeTab = ref<'desktop' | 'npm' | 'docker' | 'source'>('desktop')
 
 const releaseVersion = __WEBSITE_DOWNLOAD_VERSION__.replace(/^v/, '')
 const releaseTag = `v${releaseVersion}`
-const releaseBaseUrl = 'https://github.com/EKKOLearnAI/hermes-web-ui/releases'
+const releaseBaseUrl = 'https://github.com/EKKOLearnAI/hermes-studio/releases'
 const releaseUrl = `${releaseBaseUrl}/tag/${releaseTag}`
 const githubDownloadUrl = `${releaseBaseUrl}/download/${releaseTag}`
 const cloudflareDownloadUrl = `https://download.ekkolearnai.com/${releaseTag}`

--- a/packages/website/src/components/landing/StarHistorySection.vue
+++ b/packages/website/src/components/landing/StarHistorySection.vue
@@ -10,12 +10,12 @@ const stars = ref<number | null>(null)
 const releaseVersion = __WEBSITE_DOWNLOAD_VERSION__
 
 const chartSrc = computed(() => {
-  return 'https://api.star-history.com/svg?repos=EKKOLearnAI%2Fhermes-web-ui&type=Date'
+  return 'https://api.star-history.com/svg?repos=EKKOLearnAI%2Fhermes-studio&type=Date'
 })
 
 onMounted(async () => {
   try {
-    const res = await fetch('https://api.github.com/repos/EKKOLearnAI/hermes-web-ui')
+    const res = await fetch('https://api.github.com/repos/EKKOLearnAI/hermes-studio')
     const data = await res.json()
     stars.value = Number.isFinite(data.stargazers_count) ? data.stargazers_count : null
   } catch {}
@@ -30,7 +30,7 @@ onMounted(async () => {
     <div class="star-badges reveal reveal-delay-1">
       <a
         class="star-btn"
-        href="https://github.com/EKKOLearnAI/hermes-web-ui"
+        href="https://github.com/EKKOLearnAI/hermes-studio"
         target="_blank"
         rel="noopener"
       >
@@ -47,7 +47,7 @@ onMounted(async () => {
 
     <div class="star-chart reveal reveal-delay-2">
       <a
-        href="https://www.star-history.com/?type=date&repos=EKKOLearnAI%2Fhermes-web-ui"
+        href="https://www.star-history.com/?type=date&repos=EKKOLearnAI%2Fhermes-studio"
         target="_blank"
         rel="noopener noreferrer"
         class="chart-link"

--- a/packages/website/src/components/layout/SiteFooter.vue
+++ b/packages/website/src/components/layout/SiteFooter.vue
@@ -20,7 +20,7 @@ const { t } = useI18n()
         <div class="footer-links">
           <a
             class="footer-social"
-            href="https://github.com/EKKOLearnAI/hermes-web-ui"
+            href="https://github.com/EKKOLearnAI/hermes-studio"
             target="_blank"
             rel="noopener"
             :aria-label="t('footer.github')"

--- a/packages/website/src/components/layout/SiteHeader.vue
+++ b/packages/website/src/components/layout/SiteHeader.vue
@@ -37,7 +37,7 @@ function goHome() {
         <a class="nav-link" @click.prevent="navigateTo('docs.getting-started')">{{ t('nav.docs') }}</a>
         <a
           class="nav-link"
-          href="https://github.com/EKKOLearnAI/hermes-web-ui"
+          href="https://github.com/EKKOLearnAI/hermes-studio"
           target="_blank"
           rel="noopener"
         >
@@ -66,7 +66,7 @@ function goHome() {
       <div class="mobile-menu-inner" @click.stop>
         <a class="mobile-link" @click.prevent="navigateTo('landing')">{{ t('nav.home') }}</a>
         <a class="mobile-link" @click.prevent="navigateTo('docs.getting-started')">{{ t('nav.docs') }}</a>
-        <a class="mobile-link" href="https://github.com/EKKOLearnAI/hermes-web-ui" target="_blank" rel="noopener">{{ t('nav.github') }}</a>
+        <a class="mobile-link" href="https://github.com/EKKOLearnAI/hermes-studio" target="_blank" rel="noopener">{{ t('nav.github') }}</a>
         <div class="mobile-actions">
           <button class="mobile-action-btn" @click="switchLocale">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="action-icon">

--- a/packages/website/src/i18n/en.ts
+++ b/packages/website/src/i18n/en.ts
@@ -174,7 +174,7 @@ export default {
     },
     source: {
       title: 'From Source',
-      cmd1: 'git clone https://github.com/EKKOLearnAI/hermes-web-ui.git',
+      cmd1: 'git clone https://github.com/EKKOLearnAI/hermes-studio.git',
       cmd2: 'cd hermes-web-ui && npm install && npm run dev',
     },
     prereq: 'Requires Node.js >= 23',

--- a/packages/website/src/i18n/zh.ts
+++ b/packages/website/src/i18n/zh.ts
@@ -174,7 +174,7 @@ export default {
     },
     source: {
       title: '源码安装',
-      cmd1: 'git clone https://github.com/EKKOLearnAI/hermes-web-ui.git',
+      cmd1: 'git clone https://github.com/EKKOLearnAI/hermes-studio.git',
       cmd2: 'cd hermes-web-ui && npm install && npm run dev',
     },
     prereq: '需要 Node.js >= 23',

--- a/scripts/harness-check.mjs
+++ b/scripts/harness-check.mjs
@@ -434,7 +434,7 @@ for (const phrase of [
 
 for (const phrase of [
   'https://download.ekkolearnai.com/latest',
-  'https://github.com/EKKOLearnAI/hermes-web-ui/releases/latest/download',
+  'https://github.com/EKKOLearnAI/hermes-studio/releases/latest/download',
   'checkForUpdatesWithFallback()',
 ]) {
   if (!desktopUpdater.includes(phrase)) {

--- a/tests/server/update-controller.test.ts
+++ b/tests/server/update-controller.test.ts
@@ -20,7 +20,7 @@ async function loadUpdateController(overrides: Partial<UpdateControllerMocks> = 
   const readFileSync = overrides.readFileSync ?? vi.fn(() => JSON.stringify({
     name: 'hermes-web-ui',
     version: '0.0.0',
-    repository: { url: 'https://github.com/EKKOLearnAI/hermes-web-ui.git' },
+    repository: { url: 'https://github.com/EKKOLearnAI/hermes-studio.git' },
   }))
   const appendFileSync = overrides.appendFileSync ?? vi.fn()
 
@@ -268,7 +268,7 @@ describe('update controller', () => {
   })
 
   it('loads preview tags through async git with a short timeout', async () => {
-    process.env.HERMES_WEB_UI_PREVIEW_REPO = 'https://github.com/EKKOLearnAI/hermes-web-ui'
+    process.env.HERMES_WEB_UI_PREVIEW_REPO = 'https://github.com/EKKOLearnAI/hermes-studio'
     const execFile = vi.fn((_command: string, _args: string[], _options: any, callback: any) => {
       callback(null, [
         'abc123\trefs/tags/v0.6.6',
@@ -291,14 +291,14 @@ describe('update controller', () => {
     })
     expect(mocks.execFile).toHaveBeenCalledWith(
       'git',
-      ['ls-remote', '--tags', '--refs', 'https://github.com/EKKOLearnAI/hermes-web-ui.git'],
+      ['ls-remote', '--tags', '--refs', 'https://github.com/EKKOLearnAI/hermes-studio.git'],
       expect.objectContaining({ timeout: 8000 }),
       expect.any(Function),
     )
   })
 
   it('falls back to GitHub API when async git tag loading fails', async () => {
-    process.env.HERMES_WEB_UI_PREVIEW_REPO = 'https://github.com/EKKOLearnAI/hermes-web-ui'
+    process.env.HERMES_WEB_UI_PREVIEW_REPO = 'https://github.com/EKKOLearnAI/hermes-studio'
     const execFile = vi.fn((_command: string, _args: string[], _options: any, callback: any) => {
       callback(new Error('git timeout'), '', '')
     })
@@ -325,7 +325,7 @@ describe('update controller', () => {
       ],
     })
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.github.com/repos/EKKOLearnAI/hermes-web-ui/tags?per_page=100',
+      'https://api.github.com/repos/EKKOLearnAI/hermes-studio/tags?per_page=100',
       expect.objectContaining({
         headers: { 'User-Agent': 'hermes-web-ui-preview' },
         signal: expect.any(AbortSignal),


### PR DESCRIPTION
## Summary
- Update GitHub repository references from `EKKOLearnAI/hermes-web-ui` to `EKKOLearnAI/hermes-studio` while keeping the npm package and CLI name as `hermes-web-ui`.
- Update desktop/web fallback release URLs, website GitHub links, issue template links, and related tests/harness expectations.
- Add the required chat-chain fragment for sidebar GitHub link changes.

## Impact
- Users see and clone the renamed GitHub repository.
- Desktop update fallback and runtime release lookup use the new GitHub slug.
- The npm package name, CLI commands, Docker image names, and Web UI state paths are unchanged.

## Operational note
- Cloudflare Worker `hermes-download-proxy` was updated separately to use `REPO = "hermes-studio"`; deployed version `a805d784-fb5e-4d7b-acf6-3d4f5f9bd4ef`.

## Validation
- `npm run harness:check`
- `npm run test -- tests/server/update-controller.test.ts`
