### PR TITLE
[codex] left align approval actions

### DIFF
--- a/docs/chat-chain-changes/2026-06-14-local-approval-actions-left-align.md
+++ b/docs/chat-chain-changes/2026-06-14-local-approval-actions-left-align.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-14
+commit: local pending change
+feature: Chat approval action alignment
+impact: Chat and group chat approval action buttons now wrap from the left edge instead of right-aligning on desktop; approval payloads, persistence, resume, and agent execution behavior are unchanged.
+---

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -916,7 +916,7 @@ defineExpose({
 .approval-float-actions {
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 8px;
   margin-top: 10px;
   padding: 10px 4px 0;

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -1012,7 +1012,7 @@ export default defineComponent({ components: { CreateRoomForm } })
 .approval-float-actions {
     display: flex;
     flex-wrap: wrap;
-    justify-content: flex-end;
+    justify-content: flex-start;
     gap: 8px;
     margin-top: 10px;
     padding: 10px 4px 0;


### PR DESCRIPTION
## Summary
- Left-align chat approval action buttons in regular chat and group chat desktop approval panels.
- Add the required chat-chain change fragment for the approval panel layout adjustment.

## Impact
- Approval buttons now wrap from the left edge instead of producing ragged right-aligned rows.
- Mobile two-column button layout is unchanged.
- Approval payloads, persistence, resume, and agent execution behavior are unchanged.

## Validation
- `npm run harness:check`
