### PR TITLE
[codex] Restrict file and terminal admin access

### DIFF
--- a/docs/chat-chain-changes/2026-06-14-local-admin-file-terminal-actions.md
+++ b/docs/chat-chain-changes/2026-06-14-local-admin-file-terminal-actions.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-14
-commit: local pending change
+pr: 1555
 feature: Admin file and terminal access control
 impact: Non-super administrators no longer see the chat header file/terminal tool button, file editor and file mutation API routes require super administrator privileges, and terminal websocket connections reject non-super administrators; chat payloads, persistence, resume, and agent execution behavior are unchanged.
 ---

--- a/docs/chat-chain-changes/2026-06-14-local-admin-file-terminal-actions.md
+++ b/docs/chat-chain-changes/2026-06-14-local-admin-file-terminal-actions.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-14
+commit: local pending change
+feature: Admin file and terminal access control
+impact: Non-super administrators no longer see the chat header file/terminal tool button, file editor and file mutation API routes require super administrator privileges, and terminal websocket connections reject non-super administrators; chat payloads, persistence, resume, and agent execution behavior are unchanged.
+---

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -41,7 +41,7 @@ import LanguageSwitch from "@/components/layout/LanguageSwitch.vue";
 import ThemeSwitch from "@/components/layout/ThemeSwitch.vue";
 import VersionManagementModal from "@/components/layout/VersionManagementModal.vue";
 import { changelog } from "@/data/changelog";
-import { getStoredUsername } from "@/api/client";
+import { getStoredUsername, isStoredSuperAdmin } from "@/api/client";
 
 const chatStore = useChatStore();
 const appStore = useAppStore();
@@ -51,6 +51,7 @@ const router = useRouter();
 const message = useMessage();
 const { t } = useI18n();
 const currentUsername = computed(() => getStoredUsername());
+const isSuperAdmin = computed(() => isStoredSuperAdmin());
 
 const showOutline = ref(false);
 const messageListRef = ref<InstanceType<typeof MessageList> | null>(null);
@@ -1601,7 +1602,7 @@ async function handleSessionModelCustomSubmit() {
         <div class="header-actions">
           <!-- chat/live mode toggle hidden -->
           <template v-if="currentMode === 'chat'">
-            <NTooltip trigger="hover">
+            <NTooltip v-if="isSuperAdmin" trigger="hover">
               <template #trigger>
                 <NButton
                   class="header-tool-toggle"

--- a/packages/client/src/router/index.ts
+++ b/packages/client/src/router/index.ts
@@ -101,6 +101,7 @@ const router = createRouter({
       path: '/hermes/terminal',
       name: 'hermes.terminal',
       component: () => import('@/views/hermes/TerminalView.vue'),
+      meta: { requiresSuperAdmin: true },
     },
     {
       path: '/hermes/devices',

--- a/packages/server/src/routes/hermes/files.ts
+++ b/packages/server/src/routes/hermes/files.ts
@@ -5,6 +5,7 @@ import {
   isSensitivePath,
   MAX_EDIT_SIZE,
 } from '../../services/hermes/file-provider'
+import { requireSuperAdmin } from '../../middleware/user-auth'
 import { MultipartParseError, parseMultipartBoundary, parseMultipartFilename, splitMultipart } from '../../lib/multipart'
 
 function requestedProfile(ctx: any): string | undefined {
@@ -81,7 +82,7 @@ fileRoutes.get('/api/hermes/files/stat', async (ctx) => {
 })
 
 // GET /api/hermes/files/read?path=
-fileRoutes.get('/api/hermes/files/read', async (ctx) => {
+fileRoutes.get('/api/hermes/files/read', requireSuperAdmin, async (ctx) => {
   const relativePath = ctx.query.path as string
   if (!relativePath) {
     ctx.status = 400
@@ -104,7 +105,7 @@ fileRoutes.get('/api/hermes/files/read', async (ctx) => {
 })
 
 // PUT /api/hermes/files/write  body: { path, content }
-fileRoutes.put('/api/hermes/files/write', async (ctx) => {
+fileRoutes.put('/api/hermes/files/write', requireSuperAdmin, async (ctx) => {
   const { path: relativePath, content } = ctx.request.body as { path?: string; content?: string }
   if (!relativePath) {
     ctx.status = 400
@@ -133,7 +134,7 @@ fileRoutes.put('/api/hermes/files/write', async (ctx) => {
 })
 
 // DELETE /api/hermes/files/delete  body: { path, recursive? }
-fileRoutes.delete('/api/hermes/files/delete', async (ctx) => {
+fileRoutes.delete('/api/hermes/files/delete', requireSuperAdmin, async (ctx) => {
   const { path: relativePath, recursive } = (ctx.request.body || {}) as { path?: string; recursive?: boolean }
   if (!relativePath) {
     ctx.status = 400
@@ -160,7 +161,7 @@ fileRoutes.delete('/api/hermes/files/delete', async (ctx) => {
 })
 
 // POST /api/hermes/files/rename  body: { oldPath, newPath }
-fileRoutes.post('/api/hermes/files/rename', async (ctx) => {
+fileRoutes.post('/api/hermes/files/rename', requireSuperAdmin, async (ctx) => {
   const { oldPath, newPath } = ctx.request.body as { oldPath?: string; newPath?: string }
   if (!oldPath || !newPath) {
     ctx.status = 400
@@ -184,7 +185,7 @@ fileRoutes.post('/api/hermes/files/rename', async (ctx) => {
 })
 
 // POST /api/hermes/files/mkdir  body: { path }
-fileRoutes.post('/api/hermes/files/mkdir', async (ctx) => {
+fileRoutes.post('/api/hermes/files/mkdir', requireSuperAdmin, async (ctx) => {
   const { path: relativePath } = ctx.request.body as { path?: string }
   if (!relativePath) {
     ctx.status = 400
@@ -202,7 +203,7 @@ fileRoutes.post('/api/hermes/files/mkdir', async (ctx) => {
 })
 
 // POST /api/hermes/files/copy  body: { srcPath, destPath }
-fileRoutes.post('/api/hermes/files/copy', async (ctx) => {
+fileRoutes.post('/api/hermes/files/copy', requireSuperAdmin, async (ctx) => {
   const { srcPath, destPath } = ctx.request.body as { srcPath?: string; destPath?: string }
   if (!srcPath || !destPath) {
     ctx.status = 400
@@ -221,7 +222,7 @@ fileRoutes.post('/api/hermes/files/copy', async (ctx) => {
 })
 
 // POST /api/hermes/files/upload?path=  (multipart/form-data)
-fileRoutes.post('/api/hermes/files/upload', async (ctx) => {
+fileRoutes.post('/api/hermes/files/upload', requireSuperAdmin, async (ctx) => {
   const targetDir = (ctx.query.path as string) || ''
   const contentType = ctx.get('content-type') || ''
   if (!contentType.startsWith('multipart/form-data')) {

--- a/packages/server/src/routes/hermes/terminal.ts
+++ b/packages/server/src/routes/hermes/terminal.ts
@@ -12,6 +12,10 @@ import { shouldRejectUpgradeOrigin, writeForbiddenOrigin } from '../../security'
 
 let pty: any = null
 
+export function canOpenTerminal(user: { role?: string } | null | undefined): boolean {
+  return user?.role === 'super_admin'
+}
+
 function ensureNodePtySpawnHelperExecutable() {
   if (process.platform !== 'darwin') return
 
@@ -160,8 +164,14 @@ export function setupTerminalWebSocket(httpServers: HttpServer | HttpServer[]) {
       // Auth check
       if (await isAuthEnabled()) {
         const token = url.searchParams.get('token') || ''
-        if (!await authenticateUserToken(token)) {
+        const user = await authenticateUserToken(token)
+        if (!user) {
           socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
+          socket.destroy()
+          return
+        }
+        if (!canOpenTerminal(user)) {
+          socket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
           socket.destroy()
           return
         }

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,6 +1,6 @@
 import type { Page, Request, Route } from '@playwright/test'
 
-export const TEST_ACCESS_KEY = 'playwright-access-key'
+export const TEST_ACCESS_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwidXNlcm5hbWUiOiJwbGF5d3JpZ2h0Iiwicm9sZSI6InN1cGVyX2FkbWluIiwidHlwZSI6ImFjY2VzcyIsImF1ZCI6Imhlcm1lcy13ZWItdWkiLCJpYXQiOjE3NjAwMDAwMDAsImV4cCI6NDEwMjQ0NDgwMH0.playwright-signature'
 
 export interface MockedRequest {
   method: string

--- a/tests/server/files-routes.test.ts
+++ b/tests/server/files-routes.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const provider = {
   listDir: vi.fn(),
   stat: vi.fn(),
+  readFile: vi.fn(),
   deleteFile: vi.fn(),
   deleteDir: vi.fn(),
   writeFile: vi.fn(),
@@ -21,6 +22,30 @@ vi.mock('../../packages/server/src/services/hermes/file-provider', () => ({
   MAX_EDIT_SIZE: 10 * 1024 * 1024,
 }))
 
+async function runFileRoute(path: string, ctx: any) {
+  const { fileRoutes } = await import('../../packages/server/src/routes/hermes/files')
+  const layer = fileRoutes.stack.find((entry: any) => entry.path === path)
+  if (!layer) throw new Error(`Missing file route ${path}`)
+
+  let index = -1
+  async function dispatch(nextIndex: number): Promise<void> {
+    if (nextIndex <= index) throw new Error('next() called multiple times')
+    index = nextIndex
+    const fn = layer.stack[nextIndex]
+    if (!fn) return
+    await fn(ctx, () => dispatch(nextIndex + 1))
+  }
+
+  await dispatch(0)
+}
+
+function superAdminState(profile = 'research') {
+  return {
+    profile: { name: profile },
+    user: { id: 1, username: 'owner', role: 'super_admin' },
+  }
+}
+
 describe('file routes path metadata', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -28,6 +53,7 @@ describe('file routes path metadata', () => {
     resolveHermesPathMock.mockClear()
     provider.listDir.mockReset()
     provider.stat.mockReset()
+    provider.readFile.mockReset()
     provider.deleteFile.mockReset()
     provider.deleteDir.mockReset()
     provider.writeFile.mockReset()
@@ -38,11 +64,9 @@ describe('file routes path metadata', () => {
       { name: 'app.log', path: 'logs/app.log', isDir: false, size: 12, modTime: '2026-05-20T00:00:00.000Z' },
     ])
 
-    const { fileRoutes } = await import('../../packages/server/src/routes/hermes/files')
-    const layer = fileRoutes.stack.find((entry: any) => entry.path === '/api/hermes/files/list')
     const ctx: any = { query: { path: 'logs' }, state: { profile: { name: 'research' } }, body: null }
 
-    await layer.stack[0](ctx)
+    await runFileRoute('/api/hermes/files/list', ctx)
 
     expect(createFileProviderMock).toHaveBeenCalledWith('research')
     expect(resolveHermesPathMock).toHaveBeenCalledWith('logs', 'research')
@@ -72,11 +96,9 @@ describe('file routes path metadata', () => {
       modTime: '2026-05-20T00:00:00.000Z',
     })
 
-    const { fileRoutes } = await import('../../packages/server/src/routes/hermes/files')
-    const layer = fileRoutes.stack.find((entry: any) => entry.path === '/api/hermes/files/stat')
     const ctx: any = { query: { path: 'logs/app.log' }, state: { profile: { name: 'research' } }, body: null }
 
-    await layer.stack[0](ctx)
+    await runFileRoute('/api/hermes/files/stat', ctx)
 
     expect(createFileProviderMock).toHaveBeenCalledWith('research')
     expect(resolveHermesPathMock).toHaveBeenCalledWith('logs/app.log', 'research')
@@ -93,15 +115,13 @@ describe('file routes path metadata', () => {
   it('deletes files from the parsed request body', async () => {
     provider.deleteFile.mockResolvedValue(undefined)
 
-    const { fileRoutes } = await import('../../packages/server/src/routes/hermes/files')
-    const layer = fileRoutes.stack.find((entry: any) => entry.path === '/api/hermes/files/delete')
     const ctx: any = {
       request: { body: { path: 'workspace/weather.txt', recursive: false } },
-      state: { profile: { name: 'research' } },
+      state: superAdminState(),
       body: null,
     }
 
-    await layer.stack[0](ctx)
+    await runFileRoute('/api/hermes/files/delete', ctx)
 
     expect(createFileProviderMock).toHaveBeenCalledWith('research')
     expect(resolveHermesPathMock).toHaveBeenCalledWith('workspace/weather.txt', 'research')
@@ -111,15 +131,13 @@ describe('file routes path metadata', () => {
   })
 
   it('returns missing_path instead of throwing when delete body is absent', async () => {
-    const { fileRoutes } = await import('../../packages/server/src/routes/hermes/files')
-    const layer = fileRoutes.stack.find((entry: any) => entry.path === '/api/hermes/files/delete')
     const ctx: any = {
       request: { body: undefined },
-      state: { profile: { name: 'research' } },
+      state: superAdminState(),
       body: null,
     }
 
-    await layer.stack[0](ctx)
+    await runFileRoute('/api/hermes/files/delete', ctx)
 
     expect(ctx.status).toBe(400)
     expect(ctx.body).toEqual({ error: 'Missing path parameter', code: 'missing_path' })
@@ -141,13 +159,11 @@ describe('file routes path metadata', () => {
       '',
     ].join('\r\n'))
 
-    const { fileRoutes } = await import('../../packages/server/src/routes/hermes/files')
-    const layer = fileRoutes.stack.find((entry: any) => entry.path === '/api/hermes/files/upload')
     const ctx: any = {
       query: { path: 'workspace' },
       req: Readable.from([body]),
       request: {},
-      state: { profile: { name: 'research' } },
+      state: superAdminState(),
       body: null,
       status: 200,
       get: vi.fn((header: string) => header.toLowerCase() === 'content-type'
@@ -155,7 +171,7 @@ describe('file routes path metadata', () => {
         : ''),
     }
 
-    await layer.stack[0](ctx)
+    await runFileRoute('/api/hermes/files/upload', ctx)
 
     expect(createFileProviderMock).toHaveBeenCalledWith('research')
     expect(resolveHermesPathMock).toHaveBeenCalledWith('workspace/daily report.txt', 'research')
@@ -180,13 +196,11 @@ describe('file routes path metadata', () => {
       '',
     ].join('\r\n'))
 
-    const { fileRoutes } = await import('../../packages/server/src/routes/hermes/files')
-    const layer = fileRoutes.stack.find((entry: any) => entry.path === '/api/hermes/files/upload')
     const ctx: any = {
       query: { path: 'workspace' },
       req: Readable.from([body]),
       request: {},
-      state: { profile: { name: 'research' } },
+      state: superAdminState(),
       body: null,
       status: 200,
       get: vi.fn((header: string) => header.toLowerCase() === 'content-type'
@@ -194,10 +208,42 @@ describe('file routes path metadata', () => {
         : ''),
     }
 
-    await layer.stack[0](ctx)
+    await runFileRoute('/api/hermes/files/upload', ctx)
 
     expect(ctx.status).toBe(400)
     expect(ctx.body).toEqual({ error: 'Malformed multipart filename', code: 'invalid_request' })
+    expect(provider.writeFile).not.toHaveBeenCalled()
+  })
+
+  it('requires a super administrator for file editor content and mutations', async () => {
+    const readCtx: any = {
+      query: { path: 'workspace/weather.txt' },
+      state: {
+        profile: { name: 'research' },
+        user: { id: 2, username: 'admin', role: 'admin' },
+      },
+      body: null,
+    }
+
+    await runFileRoute('/api/hermes/files/read', readCtx)
+
+    expect(readCtx.status).toBe(403)
+    expect(readCtx.body).toEqual({ error: 'Super administrator privileges are required' })
+    expect(provider.readFile).not.toHaveBeenCalled()
+
+    const writeCtx: any = {
+      request: { body: { path: 'workspace/weather.txt', content: 'rain' } },
+      state: {
+        profile: { name: 'research' },
+        user: { id: 2, username: 'admin', role: 'admin' },
+      },
+      body: null,
+    }
+
+    await runFileRoute('/api/hermes/files/write', writeCtx)
+
+    expect(writeCtx.status).toBe(403)
+    expect(writeCtx.body).toEqual({ error: 'Super administrator privileges are required' })
     expect(provider.writeFile).not.toHaveBeenCalled()
   })
 })

--- a/tests/server/terminal-cwd.test.ts
+++ b/tests/server/terminal-cwd.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { resolveTerminalCwd } from '../../packages/server/src/routes/hermes/terminal'
+import { canOpenTerminal, resolveTerminalCwd } from '../../packages/server/src/routes/hermes/terminal'
 
 const tmpRoots: string[] = []
 
@@ -37,5 +37,13 @@ describe('terminal cwd resolution', () => {
   it('falls back to the profile directory when configured cwd is missing', () => {
     const profileDir = makeTmpRoot()
     expect(resolveTerminalCwd({ cwd: 'missing' }, profileDir)).toBe(profileDir)
+  })
+})
+
+describe('terminal authorization', () => {
+  it('only allows super administrators to open terminal websocket sessions', () => {
+    expect(canOpenTerminal({ role: 'super_admin' })).toBe(true)
+    expect(canOpenTerminal({ role: 'admin' })).toBe(false)
+    expect(canOpenTerminal(null)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- Require super administrator privileges for file editor reads and mutating file API routes.
- Reject terminal websocket upgrades from non-super administrators while keeping unauthenticated requests as 401.
- Keep the chat header file/terminal entry and standalone terminal route aligned with the same super-admin boundary.

## Validation
- `npm run test -- tests/server/files-routes.test.ts tests/server/terminal-cwd.test.ts`
- `npm run harness:check`
