### PR TITLE
[codex] Start health polling after login

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, computed } from 'vue'
+import { onUnmounted, computed, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { darkTheme, NConfigProvider, NMessageProvider, NDialogProvider, NNotificationProvider } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
@@ -46,11 +46,15 @@ function handleMobileMenuClick() {
   appStore.toggleSidebar()
 }
 
-onMounted(() => {
-  if (!isLoginPage.value) {
-    appStore.loadModels()
-    appStore.startHealthPolling()
+watch(isLoginPage, (loginPage) => {
+  if (loginPage) {
+    appStore.stopHealthPolling()
+    return
   }
+  appStore.loadModels()
+  appStore.startHealthPolling()
+}, {
+  immediate: true,
 })
 
 onUnmounted(() => {

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -37,6 +37,7 @@ test('logs in with password through the BFF before entering the app', async ({ p
 
   await expect(page).toHaveURL(/#\/hermes\/chat$/)
   await expect(page.evaluate(() => window.localStorage.getItem('hermes_api_key'))).resolves.toBe(TEST_ACCESS_KEY)
+  await expect.poll(() => api.requests.some((request) => request.pathname === '/health')).toBe(true)
 
   const loginRequest = api.requests.find((request) => request.pathname === '/api/auth/login')
   expect(loginRequest?.method).toBe('POST')


### PR DESCRIPTION
## Summary
- Start health polling whenever the app leaves the login route instead of only checking once on initial mount.
- Stop health polling while the login route is active.
- Add e2e coverage that verifies a successful login triggers the health check used by the Connected/Disconnected indicator.

## Root Cause
When the app first mounted on the login route, health polling was skipped. After login redirected to the chat route, nothing started polling, so the sidebar status could remain Disconnected indefinitely.

## Validation
- `npm run test:e2e -- tests/e2e/auth.spec.ts`
- `npm run test -- tests/client/app-store.test.ts`
- `npm run harness:check`
