### PR TITLE
[codex] remove auxiliary model clear controls

### DIFF
--- a/packages/client/src/components/hermes/models/AuxiliaryModelsPanel.vue
+++ b/packages/client/src/components/hermes/models/AuxiliaryModelsPanel.vue
@@ -288,7 +288,6 @@ watch(() => form.value.provider, (provider) => {
             :options="providerOptions"
             :placeholder="t('models.chooseProvider')"
             filterable
-            clearable
           />
         </label>
         <label>
@@ -299,16 +298,15 @@ watch(() => form.value.provider, (provider) => {
             :placeholder="t('models.selectModel')"
             :disabled="!form.provider || form.provider === 'auto' || form.provider === 'main'"
             filterable
-            clearable
           />
         </label>
         <label>
           <span>{{ t('models.auxiliaryTimeout') }}</span>
-          <NInputNumber v-model:value="form.timeout" :min="1" :precision="0" clearable />
+          <NInputNumber v-model:value="form.timeout" :min="1" :precision="0" />
         </label>
         <label v-if="isEditingVision">
           <span>{{ t('models.auxiliaryDownloadTimeout') }}</span>
-          <NInputNumber v-model:value="form.download_timeout" :min="1" :precision="0" clearable />
+          <NInputNumber v-model:value="form.download_timeout" :min="1" :precision="0" />
         </label>
         <label class="extra-body-field">
           <span>{{ t('models.auxiliaryExtraBody') }}</span>


### PR DESCRIPTION
## Summary
- Remove the built-in clear icon from the auxiliary model provider and model selects.
- Remove the built-in clear icon from auxiliary model timeout number inputs.

## Why
The auxiliary model editor already has explicit reset behavior, and the inline clear controls are not desired in this form.

## Impact
Users can still choose `Auto` or use the existing row-level clear/reset action, but the modal fields no longer show per-field clear buttons.

## Validation
- `npm run build`