### PR TITLE
[codex] hot switch session model in bridge

### DIFF
--- a/docs/chat-chain-changes/2026-06-15-pending-session-model-hot-switch.md
+++ b/docs/chat-chain-changes/2026-06-15-pending-session-model-hot-switch.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-15
+pr: pending
+feature: Session model hot switch
+impact: Session-scoped model changes still persist to the Web UI session row and now notify a loaded Agent Bridge session to switch its cached agent runtime without recreating the session.
+---
+
+If the loaded bridge session is busy, the model switch is deferred and applied after the active run completes.

--- a/docs/chat-chain-changes/2026-06-15-pending-session-model-hot-switch.md
+++ b/docs/chat-chain-changes/2026-06-15-pending-session-model-hot-switch.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-15
-pr: pending
+pr: 1563
 feature: Session model hot switch
 impact: Session-scoped model changes still persist to the Web UI session row and now notify a loaded Agent Bridge session to switch its cached agent runtime without recreating the session.
 ---

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -1340,7 +1340,7 @@ defineExpose({
   display: flex;
   align-items: center;
   gap: 6px;
-  width: 420px;
+  width: 520px;
   max-width: 100%;
   min-width: 0;
   box-sizing: border-box;

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -1125,6 +1125,10 @@ defineExpose({
       width: 100%;
     }
   }
+
+  .tool-calls-panel .tool-call-item {
+    width: 100%;
+  }
 }
 
 @keyframes queue-spin {
@@ -1336,7 +1340,8 @@ defineExpose({
   display: flex;
   align-items: center;
   gap: 6px;
-  width: 100%;
+  width: 420px;
+  max-width: 100%;
   min-width: 0;
   box-sizing: border-box;
   font-size: 11px;
@@ -1361,8 +1366,11 @@ defineExpose({
 
   .tool-call-name {
     font-family: $font-code;
-    flex-shrink: 0;
+    flex: 0 1 auto;
     min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .tool-call-preview {

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -24,6 +24,7 @@ import type { ConversationSummary } from '../../services/hermes/conversations'
 import { listUserProfiles } from '../../db/hermes/users-store'
 import { readConfigYamlForProfile } from '../../services/config-helpers'
 import { codingAgentRunManager } from '../../services/agent-runner/coding-agent-run-manager'
+import { AgentBridgeClient, getAgentBridgeManager } from '../../services/hermes/agent-bridge'
 
 function getPendingDeletedSessionIds(): Set<string> {
   return getGroupChatServer()?.getStorage().getPendingDeletedSessionIds() || new Set<string>()
@@ -42,6 +43,31 @@ function filterPendingDeletedConversationSummaries(items: ConversationSummary[])
 function requestedProfile(ctx: any): string | undefined {
   const value = ctx.state?.profile?.name || (typeof ctx.query?.profile === 'string' ? ctx.query.profile.trim() : '')
   return value || undefined
+}
+
+function runtimeProvider(provider: string): string {
+  return provider === 'claude-oauth' ? 'anthropic' : provider
+}
+
+async function notifyBridgeSessionModelChanged(
+  sessionId: string,
+  model: string,
+  provider: string,
+  profile?: string,
+): Promise<void> {
+  try {
+    const manager = getAgentBridgeManager()
+    const state = manager.getRuntimeState()
+    if (!state.ready || !state.running) return
+    const bridge = new AgentBridgeClient({
+      endpoint: state.endpoint,
+      timeoutMs: 5000,
+      connectRetryMs: 0,
+    })
+    await bridge.switchSessionModel(sessionId, model, runtimeProvider(provider), profile)
+  } catch (err) {
+    logger.warn(err, '[sessions] failed to notify bridge of session model change')
+  }
 }
 
 function explicitProfileFilter(ctx: any): string | undefined {
@@ -692,10 +718,14 @@ export async function setModel(ctx: any) {
   const id = ctx.params.id
   const existing = getSession(id)
   if (denySessionAccess(ctx, existing)) return
+  const profile = existing?.profile || requestedProfile(ctx) || 'default'
   if (!existing) {
-    createSession({ id, profile: requestedProfile(ctx) || 'default', title: '' })
+    createSession({ id, profile, title: '' })
   }
-  updateSession(id, { model: model.trim(), provider: (provider || '').trim() } as any)
+  const cleanModel = model.trim()
+  const cleanProvider = (provider || '').trim()
+  updateSession(id, { model: cleanModel, provider: cleanProvider } as any)
+  await notifyBridgeSessionModelChanged(id, cleanModel, cleanProvider, profile)
   ctx.body = { ok: true }
 }
 

--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -135,6 +135,16 @@ export interface AgentBridgeCommandResult extends AgentBridgeResponse {
   max_turns?: number
 }
 
+export interface AgentBridgeSessionModelSwitch extends AgentBridgeResponse {
+  session_id: string
+  model: string
+  provider?: string
+  loaded: boolean
+  switched: boolean
+  deferred?: boolean
+  reason?: string
+}
+
 export interface AgentBridgeGoalEvaluation extends AgentBridgeResponse {
   session_id: string
   handled: boolean
@@ -451,6 +461,21 @@ export class AgentBridgeClient {
       action: 'command',
       session_id: sessionId,
       command,
+      ...(profile ? { profile } : {}),
+    })
+  }
+
+  switchSessionModel(
+    sessionId: string,
+    model: string,
+    provider?: string,
+    profile?: string,
+  ): Promise<AgentBridgeSessionModelSwitch> {
+    return this.request<AgentBridgeSessionModelSwitch>({
+      action: 'switch_session_model',
+      session_id: sessionId,
+      model,
+      ...(provider ? { provider } : {}),
       ...(profile ? { profile } : {}),
     })
   }

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_broker.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_broker.py
@@ -256,7 +256,7 @@ class BridgeBroker:
         if action == "status_if_loaded":
             return self._status_if_loaded(req)
 
-        if action in {"interrupt", "steer", "command", "goal_evaluate", "goal_pause", "status", "get_history", "get_session_title", "destroy"}:
+        if action in {"interrupt", "steer", "command", "switch_session_model", "goal_evaluate", "goal_pause", "status", "get_history", "get_session_title", "destroy"}:
             session_id = str(req.get("session_id") or "")
             profile, worker_key = self._route_for_session(session_id, req.get("profile"), req.get("worker_key") if "worker_key" in req else None)
             resp = self._forward(profile, req, worker_key)
@@ -481,4 +481,3 @@ class BridgeBroker:
                     Path(self.endpoint.removeprefix("ipc://")).unlink(missing_ok=True)
                 except OSError:
                     pass
-

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -129,15 +129,44 @@ class AgentPool:
             existing = self._sessions.get(session_id)
             if existing is not None:
                 # If profile changed, destroy old session and recreate
-                config_changed = bool(
-                    (profile and existing.config.get("profile") != profile)
-                    or (requested_model and existing.config.get("model") != requested_model)
+                profile_changed = bool(profile and existing.config.get("profile") != profile)
+                runtime_changed = bool(
+                    (requested_model and existing.config.get("model") != requested_model)
                     or (requested_provider and existing.config.get("provider") != requested_provider)
                 )
+                config_changed = profile_changed or runtime_changed
                 if config_changed:
-                    if not existing.running:
+                    if profile_changed and not existing.running:
                         self._destroy_session(session_id)
+                    elif profile_changed:
+                        existing.last_used_at = time.time()
+                        return existing
+                    elif not existing.running:
+                        try:
+                            self._switch_loaded_session_model(
+                                existing,
+                                requested_model or str(existing.config.get("model") or ""),
+                                requested_provider or str(existing.config.get("provider") or ""),
+                                profile or str(existing.config.get("profile") or "default"),
+                                add_note=False,
+                            )
+                            existing.last_used_at = time.time()
+                            return existing
+                        except Exception as exc:
+                            print(
+                                "[hermes_bridge] session model hot switch failed; recreating "
+                                f"session={session_id} error={exc}",
+                                file=sys.stderr,
+                                flush=True,
+                            )
+                            self._destroy_session(session_id)
                     else:
+                        self._set_pending_session_model_switch(
+                            existing,
+                            requested_model or str(existing.config.get("model") or ""),
+                            requested_provider or str(existing.config.get("provider") or ""),
+                            profile or str(existing.config.get("profile") or "default"),
+                        )
                         existing.last_used_at = time.time()
                         return existing
                 else:
@@ -211,6 +240,175 @@ class AgentPool:
                 )
                 self._sessions[session_id] = session
                 return session
+
+    def _model_switch_note(self, old_model: str, new_model: str, provider: str) -> str:
+        provider_label = provider or "configured provider"
+        return (
+            f"[Note: model was just switched from {old_model or 'unknown'} to {new_model} "
+            f"via {provider_label}. Adjust your self-identification accordingly.]"
+        )
+
+    def _set_pending_session_model_switch(
+        self,
+        session: AgentSession,
+        model: str,
+        provider: str,
+        profile: str | None,
+    ) -> None:
+        requested_model = str(model or "").strip()
+        requested_provider = str(provider or "").strip()
+        if not requested_model:
+            return
+        old_model = str(session.config.get("model") or getattr(session.agent, "model", "") or "")
+        session.config["pending_model_switch"] = {
+            "model": requested_model,
+            "provider": requested_provider,
+            "profile": profile or session.config.get("profile") or "default",
+        }
+        session.config["pending_model_switch_note"] = self._model_switch_note(
+            old_model,
+            requested_model,
+            requested_provider or str(session.config.get("provider") or ""),
+        )
+
+    def _switch_loaded_session_model(
+        self,
+        session: AgentSession,
+        model: str,
+        provider: str,
+        profile: str | None,
+        *,
+        add_note: bool,
+    ) -> dict[str, Any]:
+        requested_model = str(model or "").strip()
+        requested_provider = str(provider or "").strip()
+        if not requested_model:
+            raise ValueError("model is required")
+
+        target_profile = str(profile or session.config.get("profile") or "default")
+        old_model = str(session.config.get("model") or getattr(session.agent, "model", "") or "")
+
+        with _profile_env(target_profile):
+            _refresh_worker_profile_env()
+            runtime = _resolve_runtime(requested_model, requested_provider or None)
+
+        resolved_provider = str(runtime.get("provider") or requested_provider or "")
+        switch_model = getattr(session.agent, "switch_model", None)
+        if not callable(switch_model):
+            raise RuntimeError("loaded agent does not support switch_model")
+
+        switch_model(
+            new_model=requested_model,
+            new_provider=resolved_provider,
+            api_key=runtime.get("api_key") or "",
+            base_url=runtime.get("base_url") or "",
+            api_mode=runtime.get("api_mode") or "",
+        )
+        session.config.update({
+            "profile": target_profile,
+            "model": requested_model,
+            "provider": resolved_provider,
+            "base_url": runtime.get("base_url"),
+            "api_mode": runtime.get("api_mode"),
+        })
+        session.config.pop("pending_model_switch", None)
+        if add_note:
+            session.config["pending_model_switch_note"] = self._model_switch_note(
+                old_model,
+                requested_model,
+                resolved_provider,
+            )
+        session.last_used_at = time.time()
+        print(
+            "[hermes_bridge] session model switched "
+            f"session={session.session_id} model={requested_model} provider={resolved_provider}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return {
+            "session_id": session.session_id,
+            "model": requested_model,
+            "provider": resolved_provider,
+            "loaded": True,
+            "switched": True,
+        }
+
+    def _apply_pending_session_model_switch(self, session: AgentSession) -> None:
+        pending = session.config.get("pending_model_switch")
+        if not isinstance(pending, dict) or session.running:
+            return
+        try:
+            self._switch_loaded_session_model(
+                session,
+                str(pending.get("model") or ""),
+                str(pending.get("provider") or ""),
+                str(pending.get("profile") or session.config.get("profile") or "default"),
+                add_note=False,
+            )
+        except Exception as exc:
+            print(
+                "[hermes_bridge] pending session model switch failed "
+                f"session={session.session_id} error={exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+    def _prepend_pending_model_switch_note(self, session: AgentSession, message: Any) -> Any:
+        note = str(session.config.pop("pending_model_switch_note", "") or "").strip()
+        if not note:
+            return message
+        if isinstance(message, str):
+            return f"{note}\n\n{message}"
+        if isinstance(message, list):
+            return [{"type": "text", "text": note}, *message]
+        return message
+
+    def switch_session_model(
+        self,
+        session_id: str,
+        model: str,
+        provider: str | None = None,
+        profile: str | None = None,
+    ) -> dict[str, Any]:
+        requested_model = str(model or "").strip()
+        requested_provider = str(provider or "").strip()
+        if not requested_model:
+            raise ValueError("model is required")
+        with self._lock:
+            session = self._sessions.get(session_id)
+        if session is None:
+            return {
+                "session_id": session_id,
+                "model": requested_model,
+                "provider": requested_provider,
+                "loaded": False,
+                "switched": False,
+                "reason": "session_not_loaded",
+            }
+        with session.lock:
+            if session.running:
+                self._set_pending_session_model_switch(
+                    session,
+                    requested_model,
+                    requested_provider,
+                    profile or str(session.config.get("profile") or "default"),
+                )
+                return {
+                    "session_id": session_id,
+                    "model": requested_model,
+                    "provider": requested_provider,
+                    "loaded": True,
+                    "switched": False,
+                    "deferred": True,
+                    "reason": "session_running",
+                }
+            return self._switch_loaded_session_model(
+                session,
+                requested_model,
+                requested_provider,
+                profile or str(session.config.get("profile") or "default"),
+                add_note=True,
+            )
 
     def _install_compression_hook(self, agent: Any, session_id: str) -> None:
         original = getattr(agent, "_compress_context", None)
@@ -892,6 +1090,7 @@ class AgentPool:
                     pass
                 self._prepersist_user_message(session, message, storage_message, conversation_history, profile, source)
                 db_count_after_prepersist = self._session_db_message_count(session.session_id, profile)
+                agent_message = self._prepend_pending_model_switch_note(session, message)
                 if force_compress:
                     compress = getattr(session.agent, "_compress_context", None)
                     if callable(compress):
@@ -932,7 +1131,7 @@ class AgentPool:
                         pass
                 try:
                     result = session.agent.run_conversation(
-                        message,
+                        agent_message,
                         **kwargs,
                     )
                 finally:
@@ -998,6 +1197,7 @@ class AgentPool:
                     session.running = False
                     session.current_run_id = None
                     session.last_used_at = time.time()
+                self._apply_pending_session_model_switch(session)
             except Exception as exc:
                 if not tail_synced:
                     try:
@@ -1020,6 +1220,7 @@ class AgentPool:
                     session.running = False
                     session.current_run_id = None
                     session.last_used_at = time.time()
+                self._apply_pending_session_model_switch(session)
             finally:
                 with self._lock:
                     self._approval_handlers.pop(session.session_id, None)

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
@@ -169,6 +169,20 @@ class BridgeServer:
                 req.get("profile"),
             )
 
+        if action == "switch_session_model":
+            session_id = str(req.get("session_id") or "").strip()
+            if not session_id:
+                raise ValueError("session_id is required")
+            model = str(req.get("model") or "").strip()
+            if not model:
+                raise ValueError("model is required")
+            return self.pool.switch_session_model(
+                session_id,
+                model,
+                str(req.get("provider") or "").strip(),
+                req.get("profile"),
+            )
+
         if action == "goal_evaluate":
             session_id = str(req.get("session_id") or "").strip()
             if not session_id:
@@ -624,4 +638,3 @@ class BridgeServer:
                     Path(self.endpoint.removeprefix("ipc://")).unlink(missing_ok=True)
                 except OSError:
                     pass
-

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -183,6 +183,120 @@ def wait_for(condition, timeout=20):
 `
 
 describe('agent bridge Python session concurrency', () => {
+  it('hot-switches a loaded idle session model without recreating the session', () => {
+    runPython(String.raw`
+${harness}
+
+def fake_resolve_runtime(model, provider=None):
+    return {
+        "provider": provider or "openai",
+        "base_url": f"https://{provider or 'openai'}.example/v1",
+        "api_key": f"key:{model}",
+        "api_mode": "chat_completions",
+    }
+
+bridge._resolve_runtime = fake_resolve_runtime
+pool, _fake_db = make_pool()
+
+class SwitchableAgent:
+    def __init__(self):
+        self.model = "old-model"
+        self.provider = "openai"
+        self.base_url = "https://old.example/v1"
+        self.api_key = "old-key"
+        self.api_mode = "chat_completions"
+        self.switch_calls = []
+
+    def switch_model(self, **kwargs):
+        self.switch_calls.append(kwargs)
+        self.model = kwargs["new_model"]
+        self.provider = kwargs["new_provider"]
+        self.base_url = kwargs["base_url"]
+        self.api_key = kwargs["api_key"]
+        self.api_mode = kwargs["api_mode"]
+
+agent = SwitchableAgent()
+session = bridge.AgentSession(
+    session_id="session-model",
+    agent=agent,
+    config={"profile": "default", "model": "old-model", "provider": "openai"},
+)
+pool._sessions["session-model"] = session
+
+result = pool.switch_session_model("session-model", "new-model", "anthropic", "default")
+
+assert result["switched"] is True
+assert pool._sessions["session-model"] is session
+assert agent.switch_calls == [{
+    "new_model": "new-model",
+    "new_provider": "anthropic",
+    "api_key": "key:new-model",
+    "base_url": "https://anthropic.example/v1",
+    "api_mode": "chat_completions",
+}]
+assert session.config["model"] == "new-model"
+assert session.config["provider"] == "anthropic"
+assert "pending_model_switch_note" in session.config
+`)
+  })
+
+  it('defers a loaded session model switch while a run is active and applies it after completion', () => {
+    runPython(String.raw`
+${harness}
+
+def fake_resolve_runtime(model, provider=None):
+    return {
+        "provider": provider or "openai",
+        "base_url": f"https://{provider or 'openai'}.example/v1",
+        "api_key": f"key:{model}",
+        "api_mode": "chat_completions",
+    }
+
+bridge._resolve_runtime = fake_resolve_runtime
+pool, _fake_db = make_pool()
+release = threading.Event()
+
+class RunningAgent:
+    def __init__(self):
+        self.model = "old-model"
+        self.provider = "openai"
+        self.switch_calls = []
+
+    def switch_model(self, **kwargs):
+        self.switch_calls.append(kwargs)
+        self.model = kwargs["new_model"]
+        self.provider = kwargs["new_provider"]
+
+    def run_conversation(self, message, **kwargs):
+        release.wait(timeout=5)
+        return {"messages": [{"role": "assistant", "content": "done"}]}
+
+agent = RunningAgent()
+session, record, thread = start_manual_run(pool, "running-model", agent)
+session.config.update({"profile": "default", "model": "old-model", "provider": "openai"})
+assert wait_for(lambda: session.running)
+
+result = pool.switch_session_model("running-model", "new-model", "anthropic", "default")
+assert result["deferred"] is True
+assert agent.switch_calls == []
+
+release.set()
+thread.join(timeout=5)
+
+assert record.status == "complete"
+assert agent.switch_calls == [{
+    "new_model": "new-model",
+    "new_provider": "anthropic",
+    "api_key": "key:new-model",
+    "base_url": "https://anthropic.example/v1",
+    "api_mode": "chat_completions",
+}]
+assert session.config["model"] == "new-model"
+assert session.config["provider"] == "anthropic"
+assert "pending_model_switch" not in session.config
+`)
+  })
+
   it('syncs generated result tail to the session DB when the agent crashes after generation', () => {
     runPython(String.raw`
 ${harness}

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -27,6 +27,8 @@ const loggerWarnMock = vi.fn()
 const getCompressionSnapshotMock = vi.fn()
 const listUserProfilesMock = vi.fn()
 const readConfigYamlForProfileMock = vi.fn()
+const bridgeSwitchSessionModelMock = vi.fn()
+const bridgeGetRuntimeStateMock = vi.fn()
 const codingAgentRunManagerMock = vi.hoisted(() => ({
   stop: vi.fn(),
 }))
@@ -102,6 +104,15 @@ vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
   listProfileNamesFromDisk: () => ['default', 'travel'],
 }))
 
+vi.mock('../../packages/server/src/services/hermes/agent-bridge', () => ({
+  AgentBridgeClient: vi.fn().mockImplementation(() => ({
+    switchSessionModel: bridgeSwitchSessionModelMock,
+  })),
+  getAgentBridgeManager: vi.fn(() => ({
+    getRuntimeState: bridgeGetRuntimeStateMock,
+  })),
+}))
+
 vi.mock('../../packages/server/src/services/config-helpers', () => ({
   readConfigYamlForProfile: readConfigYamlForProfileMock,
 }))
@@ -159,6 +170,9 @@ describe('session conversations controller', () => {
     listUserProfilesMock.mockReturnValue([])
     readConfigYamlForProfileMock.mockReset()
     readConfigYamlForProfileMock.mockResolvedValue({ model: { default: 'gpt-default', provider: 'openai' } })
+    bridgeSwitchSessionModelMock.mockReset()
+    bridgeGetRuntimeStateMock.mockReset()
+    bridgeGetRuntimeStateMock.mockReturnValue({ ready: false, running: false, endpoint: 'ipc:///tmp/hermes-agent-bridge.sock' })
     codingAgentRunManagerMock.stop.mockReset()
   })
 
@@ -661,6 +675,37 @@ describe('session conversations controller', () => {
 
     expect(localCreateSessionMock).not.toHaveBeenCalled()
     expect(localUpdateSessionMock).toHaveBeenCalledWith('session-1', { model: 'grok-4', provider: 'xai' })
+    expect(bridgeSwitchSessionModelMock).not.toHaveBeenCalled()
+    expect(ctx.body).toEqual({ ok: true })
+  })
+
+  it('notifies a loaded agent bridge session after storing the session model', async () => {
+    bridgeGetRuntimeStateMock.mockReturnValue({ ready: true, running: true, endpoint: 'ipc:///tmp/hermes-agent-bridge.sock' })
+    bridgeSwitchSessionModelMock.mockResolvedValue({
+      ok: true,
+      session_id: 'session-1',
+      model: 'claude-sonnet-4-6',
+      provider: 'anthropic',
+      loaded: true,
+      switched: true,
+    })
+    getSessionMock.mockReturnValue({ id: 'session-1', profile: 'travel' })
+
+    const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+    const ctx: any = {
+      params: { id: 'session-1' },
+      request: { body: { model: 'claude-sonnet-4-6', provider: 'claude-oauth' } },
+      body: null,
+    }
+    await mod.setModel(ctx)
+
+    expect(localUpdateSessionMock).toHaveBeenCalledWith('session-1', { model: 'claude-sonnet-4-6', provider: 'claude-oauth' })
+    expect(bridgeSwitchSessionModelMock).toHaveBeenCalledWith(
+      'session-1',
+      'claude-sonnet-4-6',
+      'anthropic',
+      'travel',
+    )
     expect(ctx.body).toEqual({ ok: true })
   })
 


### PR DESCRIPTION
## Summary
- keep session model changes persisted in the Web UI session row
- notify a loaded Agent Bridge session to switch its cached agent runtime with `agent.switch_model()`
- defer the bridge switch while a run is active, then apply it after completion

Fixes #1560

## Validation
- `npm run test -- tests/server/sessions-controller.test.ts`
- `npm run test -- tests/server/agent-bridge-python-concurrency.test.ts`
- `npm run harness:check`
- `npm run build`