### PR TITLE
fix(config): read v12+ providers dict alongside legacy custom_providers list

### DIFF
--- a/packages/server/src/controllers/hermes/media.ts
+++ b/packages/server/src/controllers/hermes/media.ts
@@ -4,6 +4,7 @@ import { dirname, extname, isAbsolute, join, resolve } from 'path'
 import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../../services/hermes/hermes-profile'
 import { config } from '../../config'
 import { readConfigYamlForProfile } from '../../services/config-helpers'
+import { getCompatibleCustomProviders } from '../../services/hermes/custom-providers-compat'
 
 const XAI_VIDEO_GENERATIONS_URL = 'https://api.x.ai/v1/videos/generations'
 const XAI_VIDEO_STATUS_URL = 'https://api.x.ai/v1/videos'
@@ -81,9 +82,7 @@ function buildApiUrl(baseUrl: string, pathWithV1: string): string {
 
 async function resolveFunCodexProvider(profile: string): Promise<FunCodexProvider | null> {
   const hermesConfig = await readConfigYamlForProfile(profile)
-  const customProviders = Array.isArray(hermesConfig.custom_providers)
-    ? hermesConfig.custom_providers as any[]
-    : []
+  const customProviders = getCompatibleCustomProviders(hermesConfig)
   const provider = customProviders.find(entry => String(entry?.name || '').trim() === APIKEY_IMAGE_PROVIDER)
   const apiKey = String(provider?.api_key || '').trim()
   const baseUrl = String(provider?.base_url || '').trim()

--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { getActiveEnvPath, getActiveAuthPath, getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../../services/hermes/hermes-profile'
 import { readConfigYaml, readConfigYamlForProfile, updateConfigYaml, updateConfigYamlForProfile, fetchProviderModels, buildModelGroups, PROVIDER_ENV_MAP } from '../../services/config-helpers'
+import { getCompatibleCustomProviders } from '../../services/hermes/custom-providers-compat'
 import { buildProviderModelMap, PROVIDER_PRESETS } from '../../shared/providers'
 import { getCopilotModelsDetailed, resolveCopilotOAuthToken, type CopilotModelMeta } from '../../services/hermes/copilot-models'
 import { readAppConfig, writeAppConfig, type ModelVisibilityRule } from '../../services/app-config'
@@ -317,9 +318,9 @@ async function buildAvailableForProfile(
     currentDefault = String(modelSection.default || '').trim()
     currentDefaultProvider = String(modelSection.provider || '').trim()
     if (currentDefaultProvider === 'custom' && currentDefault) {
-      const cps = Array.isArray(config.custom_providers) ? config.custom_providers as any[] : []
+      const cps = getCompatibleCustomProviders(config)
       const match = cps.find(
-        (cp: any) => cp.base_url?.replace(/\/+$/, '') === String(modelSection.base_url || '').replace(/\/+$/, '')
+        (cp) => cp.base_url?.replace(/\/+$/, '') === String(modelSection.base_url || '').replace(/\/+$/, '')
           && cp.model === currentDefault,
       )
       if (match) currentDefaultProvider = providerKeyForCustom(String(match.name || ''))
@@ -391,9 +392,7 @@ async function buildAvailableForProfile(
     }
   }
 
-  const customProviders = Array.isArray(config.custom_providers)
-    ? config.custom_providers as Array<{ name: string; base_url: string; model: string; api_key?: string }>
-    : []
+  const customProviders = getCompatibleCustomProviders(config)
   const customFetches = await Promise.allSettled(
     customProviders.map(async cp => {
       if (!cp.base_url) return null
@@ -404,7 +403,11 @@ async function buildAvailableForProfile(
       const builtinCatalogModels = isBuiltinProviderKey(providerKey)
         ? PROVIDER_MODEL_CATALOG[builtinProviderKey] || builtinPreset?.models || []
         : []
-      let models = [...new Set([cp.model, ...builtinCatalogModels].filter(Boolean))]
+      // Pull configured models from the v12+ providers.<name>.models dict (if any)
+      // alongside the legacy single `model` field; both contribute to what the
+      // UI shows. `models` is normalized to a dict shape regardless of source.
+      const configuredModels = cp.models ? Object.keys(cp.models) : []
+      let models = [...new Set([cp.model, ...configuredModels, ...builtinCatalogModels].filter(Boolean) as string[])]
       const cachedModels = getCachedProviderModels(modelCatalogCache, providerKey, baseUrl)
       if (cachedModels) models = [...new Set([...models, ...cachedModels])]
       return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '', builtin: isBuiltinProviderKey(providerKey) }
@@ -519,9 +522,9 @@ export async function getAvailable(ctx: any) {
       currentDefault = String(modelSection.default || '').trim()
       currentDefaultProvider = String(modelSection.provider || '').trim()
       // When hermes CLI sets provider: custom, resolve to custom:name
-      // by matching base_url + model against custom_providers
+      // by matching base_url + model against custom providers (v12 dict + legacy list).
       if (currentDefaultProvider === 'custom' && currentDefault) {
-        const cps = Array.isArray(config.custom_providers) ? config.custom_providers as any[] : []
+        const cps = getCompatibleCustomProviders(config) as any[]
         const match = cps.find(
           (cp: any) => cp.base_url?.replace(/\/+$/, '') === String(modelSection.base_url || '').replace(/\/+$/, '')
             && cp.model === currentDefault,
@@ -656,18 +659,17 @@ export async function getAvailable(ctx: any) {
       }
     }
 
-    const customProviders = Array.isArray(config.custom_providers)
-      ? config.custom_providers as Array<{ name: string; base_url: string; model: string; api_key?: string }>
-      : []
+    const customProviders = getCompatibleCustomProviders(config)
 
     const customFetches = await Promise.allSettled(
       customProviders.map(async cp => {
         if (!cp.base_url) return null
         const providerKey = `custom:${cp.name.trim().toLowerCase().replace(/ /g, '-')}`
         const baseUrl = cp.base_url.replace(/\/+$/, '')
-        let models = [cp.model]
+        const configuredModels = cp.models ? Object.keys(cp.models) : []
+        let models = [...new Set([cp.model, ...configuredModels].filter(Boolean) as string[])]
         if (cp.api_key) {
-          try { const fetched = await fetchProviderModels(baseUrl, cp.api_key); if (fetched.length > 0) models = [...new Set([cp.model, ...fetched])] } catch { }
+          try { const fetched = await fetchProviderModels(baseUrl, cp.api_key); if (fetched.length > 0) models = [...new Set([...models, ...fetched])] } catch { }
         }
         return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '', builtin: isBuiltinProviderKey(providerKey) }
       }),

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -7,6 +7,7 @@ import { delimiter, dirname, join } from 'path'
 import { promisify } from 'util'
 import { getWebUiHome } from '../config'
 import { PROVIDER_ENV_MAP, readConfigYamlForProfile, safeReadFile } from './config-helpers'
+import { getCompatibleCustomProviders } from './hermes/custom-providers-compat'
 import { registerClaudeCodeProxyTarget } from './agent-runner/proxies/claude-code-proxy'
 import { registerCodexProxyTarget } from './agent-runner/proxies/codex-proxy'
 import type { ApiMode } from './agent-runner/types'
@@ -471,7 +472,7 @@ async function resolveStoredProviderLaunchInput(
   const preset = PROVIDER_PRESETS.find(item => item.value === normalizedProvider)
   const candidates = providerLookupCandidates(provider)
 
-  const customProviders = Array.isArray(config.custom_providers) ? config.custom_providers as any[] : []
+  const customProviders = getCompatibleCustomProviders(config)
   const customEntry = customProviders.find((entry) => {
     const name = slugProviderName(String(entry?.name || ''))
     return candidates.includes(`custom:${name}`) || candidates.includes(`custom_${name}`) || candidates.includes(name)

--- a/packages/server/src/services/config-helpers.ts
+++ b/packages/server/src/services/config-helpers.ts
@@ -3,6 +3,7 @@ import { readdir, stat } from 'fs/promises'
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { getActiveProfileDir, getActiveConfigPath, getActiveEnvPath, getProfileDir } from './hermes/hermes-profile'
+import { getCompatibleCustomProviders } from './hermes/custom-providers-compat'
 import { logger } from './logger'
 import { safeFileStore } from './safe-file-store'
 
@@ -262,22 +263,26 @@ export function buildModelGroups(config: Record<string, any>): { default: string
     defaultModel = modelSection.trim()
   }
 
-  // 2. Extract custom_providers section
-  const customProviders = config.custom_providers
-  if (Array.isArray(customProviders)) {
-    const customModels: ModelInfo[] = []
-    for (const entry of customProviders) {
-      if (entry && typeof entry === 'object') {
-        const cName = String(entry.name || '').trim()
-        const cModel = String(entry.model || '').trim()
-        if (cName && cModel) {
-          customModels.push({ id: cModel, label: `${cName}: ${cModel}` })
-        }
-      }
+  // 2. Aggregate custom providers from both schemas (legacy list + v12+ dict).
+  const customProviders = getCompatibleCustomProviders(config)
+  const customModels: ModelInfo[] = []
+  for (const entry of customProviders) {
+    const cName = entry.name.trim()
+    if (!cName) continue
+    const seen = new Set<string>()
+    const pushModel = (modelId: string) => {
+      const id = modelId.trim()
+      if (!id || seen.has(id)) return
+      seen.add(id)
+      customModels.push({ id, label: `${cName}: ${id}` })
     }
-    if (customModels.length > 0) {
-      groups.push({ provider: 'Custom', models: customModels })
+    if (entry.model) pushModel(entry.model)
+    if (entry.models && typeof entry.models === 'object') {
+      for (const id of Object.keys(entry.models)) pushModel(id)
     }
+  }
+  if (customModels.length > 0) {
+    groups.push({ provider: 'Custom', models: customModels })
   }
 
   return { default: defaultModel, groups }

--- a/packages/server/src/services/hermes/custom-providers-compat.ts
+++ b/packages/server/src/services/hermes/custom-providers-compat.ts
@@ -1,0 +1,230 @@
+/**
+ * Compatibility layer for the two `config.yaml` provider schemas used by Hermes Agent.
+ *
+ * Hermes Agent's v12 migration converts `custom_providers:` (a list of provider
+ * entries) into `providers:` (a dict keyed by provider name) and deletes the list.
+ * Agent itself ships a compatibility helper, `get_compatible_custom_providers()`,
+ * so every consumer in core sees a unified list view across both schemas:
+ *
+ *   https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/config.py
+ *
+ * Studio historically only read the legacy `custom_providers:` list, which makes
+ * v12+ dict-shaped providers invisible in the model picker, catalog, and context
+ * lookups (Issue #1570). This helper mirrors Agent's behavior so Studio can read
+ * both shapes; write paths intentionally still target the legacy list (that's
+ * the canonical write surface Studio's UI manipulates today).
+ */
+
+const KNOWN_KEYS = new Set([
+  'name', 'api', 'url', 'base_url',
+  'api_key', 'key_env', 'api_key_env',
+  'api_mode', 'transport',
+  'model', 'default_model',
+  'models',
+  'context_length', 'rate_limit_delay',
+  'request_timeout_seconds', 'stale_timeout_seconds',
+  'discover_models', 'extra_body',
+])
+
+const CAMEL_ALIASES: Record<string, string> = {
+  apiKey: 'api_key',
+  baseUrl: 'base_url',
+  apiMode: 'api_mode',
+  keyEnv: 'key_env',
+  apiKeyEnv: 'key_env',
+  defaultModel: 'default_model',
+  contextLength: 'context_length',
+  rateLimitDelay: 'rate_limit_delay',
+}
+
+export interface NormalizedCustomProvider {
+  name: string
+  base_url: string
+  provider_key?: string
+  api_key?: string
+  key_env?: string
+  api_mode?: string
+  model?: string
+  models?: Record<string, any>
+  context_length?: number
+  rate_limit_delay?: number
+  discover_models?: boolean
+  extra_body?: Record<string, any>
+}
+
+function looksLikeUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return !!url.protocol && !!url.host
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Translate one provider entry (from either schema) into the unified record
+ * shape Studio's read paths expect. Returns `null` if the entry has no usable
+ * `base_url` or `name` — matching `_normalize_custom_provider_entry()`'s
+ * silent-drop semantics in Agent.
+ */
+export function normalizeCustomProviderEntry(
+  entry: any,
+  providerKey: string = '',
+): NormalizedCustomProvider | null {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null
+
+  const e: Record<string, any> = { ...entry }
+
+  // `api_key_env` is a documented snake_case alias for `key_env` (see
+  // upstream guide for Azure Foundry). Normalize before applying camelCase
+  // aliases so the canonical field always wins.
+  if ('api_key_env' in e && !('key_env' in e)) {
+    e.key_env = e.api_key_env
+  }
+
+  for (const [camel, snake] of Object.entries(CAMEL_ALIASES)) {
+    if (camel in e && !(snake in e)) {
+      e[snake] = e[camel]
+    }
+  }
+
+  // base_url: try base_url, then url, then api — accept first valid URL.
+  let baseUrl = ''
+  for (const key of ['base_url', 'url', 'api'] as const) {
+    const raw = e[key]
+    if (typeof raw === 'string' && raw.trim()) {
+      const candidate = raw.trim()
+      if (looksLikeUrl(candidate)) {
+        baseUrl = candidate
+        break
+      }
+    }
+  }
+  if (!baseUrl) return null
+
+  // name: prefer entry.name, fall back to dict key.
+  let name = ''
+  if (typeof e.name === 'string' && e.name.trim()) {
+    name = e.name.trim()
+  } else if (providerKey && providerKey.trim()) {
+    name = providerKey.trim()
+  }
+  if (!name) return null
+
+  const normalized: NormalizedCustomProvider = { name, base_url: baseUrl }
+
+  if (providerKey && providerKey.trim()) {
+    normalized.provider_key = providerKey.trim()
+  }
+
+  if (typeof e.api_key === 'string' && e.api_key.trim()) {
+    normalized.api_key = e.api_key.trim()
+  }
+  if (typeof e.key_env === 'string' && e.key_env.trim()) {
+    normalized.key_env = e.key_env.trim()
+  }
+
+  const apiMode = e.api_mode || e.transport
+  if (typeof apiMode === 'string' && apiMode.trim()) {
+    normalized.api_mode = apiMode.trim()
+  }
+
+  const modelName = e.model || e.default_model
+  if (typeof modelName === 'string' && modelName.trim()) {
+    normalized.model = modelName.trim()
+  }
+
+  // models: accept dict (v12+ canonical) or list (hand-edited / legacy).
+  if (e.models && typeof e.models === 'object' && !Array.isArray(e.models)) {
+    if (Object.keys(e.models).length > 0) {
+      normalized.models = e.models
+    }
+  } else if (Array.isArray(e.models) && e.models.length > 0) {
+    const dict: Record<string, any> = {}
+    for (const m of e.models) {
+      if (typeof m === 'string' && m.trim()) {
+        dict[m] = {}
+      }
+    }
+    if (Object.keys(dict).length > 0) {
+      normalized.models = dict
+    }
+  }
+
+  if (typeof e.context_length === 'number' && Number.isInteger(e.context_length) && e.context_length > 0) {
+    normalized.context_length = e.context_length
+  }
+  if (typeof e.rate_limit_delay === 'number' && e.rate_limit_delay >= 0) {
+    normalized.rate_limit_delay = e.rate_limit_delay
+  }
+  if (typeof e.discover_models === 'boolean') {
+    normalized.discover_models = e.discover_models
+  }
+  if (e.extra_body && typeof e.extra_body === 'object' && !Array.isArray(e.extra_body)) {
+    normalized.extra_body = { ...e.extra_body }
+  }
+
+  // Surface unknown keys in the logs — same intent as Agent's warning, kept
+  // soft so unfamiliar fields don't break callers.
+  const unknown = Object.keys(e).filter(k => !KNOWN_KEYS.has(k) && !(k in CAMEL_ALIASES))
+  if (unknown.length > 0) {
+    // Use console here to avoid the logger import cycle; this branch is rare
+    // and only fires for hand-edited configs.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[config-helpers] providers.${providerKey || '?'}: unknown config keys ignored: ${unknown.join(', ')}`,
+    )
+  }
+
+  return normalized
+}
+
+/**
+ * Return the full set of custom providers visible to Studio, drawn from both
+ * schemas with name/base_url/model deduplication. Mirrors Hermes Agent's
+ * `get_compatible_custom_providers()`.
+ *
+ * Order: legacy list entries first, then v12+ dict entries — matching Agent's
+ * traversal order so a hand-written list entry takes precedence over a
+ * dict entry with the same identity.
+ */
+export function getCompatibleCustomProviders(config: any): NormalizedCustomProvider[] {
+  if (!config || typeof config !== 'object') return []
+
+  const out: NormalizedCustomProvider[] = []
+  const seenProviderKeys = new Set<string>()
+  const seenIdentityTriples = new Set<string>()
+
+  const appendIfNew = (entry: NormalizedCustomProvider | null): void => {
+    if (!entry) return
+    const providerKey = (entry.provider_key || '').trim().toLowerCase()
+    const name = entry.name.trim().toLowerCase()
+    const baseUrl = entry.base_url.trim().replace(/\/+$/, '').toLowerCase()
+    const model = (entry.model || '').trim().toLowerCase()
+    const triple = `${name}|${baseUrl}|${model}`
+
+    if (providerKey && seenProviderKeys.has(providerKey)) return
+    if (name && baseUrl && seenIdentityTriples.has(triple)) return
+
+    out.push(entry)
+    if (providerKey) seenProviderKeys.add(providerKey)
+    if (name && baseUrl) seenIdentityTriples.add(triple)
+  }
+
+  const legacy = config.custom_providers
+  if (legacy !== undefined) {
+    if (!Array.isArray(legacy)) return [] // matches Agent: malformed legacy block bails out entirely
+    for (const entry of legacy) {
+      appendIfNew(normalizeCustomProviderEntry(entry))
+    }
+  }
+
+  const dict = config.providers
+  if (dict && typeof dict === 'object' && !Array.isArray(dict)) {
+    for (const [key, entry] of Object.entries(dict)) {
+      appendIfNew(normalizeCustomProviderEntry(entry, key))
+    }
+  }
+
+  return out
+}

--- a/packages/server/src/services/hermes/model-catalog-cache.ts
+++ b/packages/server/src/services/hermes/model-catalog-cache.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { config } from '../../config'
 import { PROVIDER_PRESETS } from '../../shared/providers'
 import { fetchProviderModels, PROVIDER_ENV_MAP, readConfigYamlForProfile } from '../config-helpers'
+import { getCompatibleCustomProviders } from './custom-providers-compat'
 import { logger } from '../logger'
 import { safeFileStore } from '../safe-file-store'
 import { getProfileDir, listProfileNamesFromDisk } from './hermes-profile'
@@ -267,19 +268,23 @@ async function collectRefreshCandidates(): Promise<RefreshCandidate[]> {
       })
     }
 
-    const customProviders = Array.isArray(configYaml.custom_providers) ? configYaml.custom_providers as any[] : []
+    const customProviders = getCompatibleCustomProviders(configYaml)
     for (const cp of customProviders) {
-      const name = String(cp?.name || '').trim()
-      const baseUrl = normalizeCatalogBaseUrl(cp?.base_url || '')
+      const name = cp.name
+      const baseUrl = normalizeCatalogBaseUrl(cp.base_url)
       if (!name || !baseUrl) continue
       const provider = providerKeyForCustom(name)
       const presetModels = presetsByProvider.get(name)?.models || []
+      // Respect the configured `models:` whitelist (v12+ dict) when present —
+      // those entries should always be reachable as fallbacks even before a
+      // live `/v1/models` probe runs.
+      const configuredModels = cp.models ? Object.keys(cp.models) : []
       mergeCandidate(candidates, {
         provider,
         label: name,
         base_url: baseUrl,
-        api_key: String(cp?.api_key || '').trim(),
-        fallback_models: uniqueModels([cp?.model, ...presetModels]),
+        api_key: cp.api_key || '',
+        fallback_models: uniqueModels([cp.model, ...configuredModels, ...presetModels]),
         profile,
       })
     }

--- a/packages/server/src/services/hermes/model-context.ts
+++ b/packages/server/src/services/hermes/model-context.ts
@@ -5,6 +5,7 @@ import { PROVIDER_PRESETS } from '../../shared/providers'
 import { getDb } from '../../db'
 import { MODEL_CONTEXT_TABLE } from '../../db/hermes/schemas'
 import { detectHermesHome } from './hermes-path'
+import { getCompatibleCustomProviders } from './custom-providers-compat'
 
 const HERMES_BASE = detectHermesHome()
 const MODELS_DEV_CACHE = resolve(HERMES_BASE, 'models_dev_cache.json')
@@ -186,7 +187,9 @@ function getModelBaseUrl(config: any): string | null {
 }
 
 function getCustomProviders(config: any): CustomProviderEntry[] {
-  return Array.isArray(config?.custom_providers) ? config.custom_providers as CustomProviderEntry[] : []
+  // Read from both legacy `custom_providers:` list and v12+ `providers:` dict
+  // so context-length resolution stays correct after a v11→v12 migration.
+  return getCompatibleCustomProviders(config) as unknown as CustomProviderEntry[]
 }
 
 function resolveCustomProviderEntry(config: any, modelName: string, provider: string | null): CustomProviderEntry | null {

--- a/tests/server/custom-providers-compat.test.ts
+++ b/tests/server/custom-providers-compat.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getCompatibleCustomProviders,
+  normalizeCustomProviderEntry,
+} from '../../packages/server/src/services/hermes/custom-providers-compat'
+
+describe('normalizeCustomProviderEntry', () => {
+  it('returns null for non-objects', () => {
+    expect(normalizeCustomProviderEntry(null)).toBeNull()
+    expect(normalizeCustomProviderEntry('foo')).toBeNull()
+    expect(normalizeCustomProviderEntry([])).toBeNull()
+  })
+
+  it('returns null when no usable URL is present', () => {
+    expect(normalizeCustomProviderEntry({ name: 'foo' })).toBeNull()
+    expect(normalizeCustomProviderEntry({ name: 'foo', base_url: 'not-a-url' })).toBeNull()
+  })
+
+  it('returns null when no name is present and no providerKey is supplied', () => {
+    expect(normalizeCustomProviderEntry({ base_url: 'https://api.example.com' })).toBeNull()
+  })
+
+  it('falls back to providerKey when entry.name is missing', () => {
+    const result = normalizeCustomProviderEntry(
+      { base_url: 'https://api.example.com' },
+      'volcengine-coding',
+    )
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe('volcengine-coding')
+    expect(result!.provider_key).toBe('volcengine-coding')
+  })
+
+  it('accepts base_url, url, and api as URL aliases (first valid wins)', () => {
+    const fromUrl = normalizeCustomProviderEntry({ name: 'a', url: 'https://example.com' })
+    expect(fromUrl?.base_url).toBe('https://example.com')
+    const fromApi = normalizeCustomProviderEntry({ name: 'a', api: 'https://api.example.com' })
+    expect(fromApi?.base_url).toBe('https://api.example.com')
+    const baseWins = normalizeCustomProviderEntry({
+      name: 'a',
+      base_url: 'https://primary.example.com',
+      api: 'https://secondary.example.com',
+    })
+    expect(baseWins?.base_url).toBe('https://primary.example.com')
+  })
+
+  it('maps camelCase aliases to snake_case canonical fields', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      baseUrl: 'https://example.com',
+      apiKey: 'secret',
+      keyEnv: 'P_KEY',
+      defaultModel: 'm-1',
+    })
+    expect(result?.base_url).toBe('https://example.com')
+    expect(result?.api_key).toBe('secret')
+    expect(result?.key_env).toBe('P_KEY')
+    expect(result?.model).toBe('m-1')
+  })
+
+  it('treats api_key_env as a snake_case alias for key_env', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      base_url: 'https://example.com',
+      api_key_env: 'P_KEY',
+    })
+    expect(result?.key_env).toBe('P_KEY')
+  })
+
+  it('preserves transport as api_mode', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      base_url: 'https://example.com',
+      transport: 'chat_completions',
+    })
+    expect(result?.api_mode).toBe('chat_completions')
+  })
+
+  it('converts a list-of-strings models field into the dict shape', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      base_url: 'https://example.com',
+      models: ['m-1', 'm-2', 'm-3'],
+    })
+    expect(result?.models).toEqual({ 'm-1': {}, 'm-2': {}, 'm-3': {} })
+  })
+
+  it('preserves a dict-shaped models field', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      base_url: 'https://example.com',
+      models: { 'm-1': { context_length: 128_000 } },
+    })
+    expect(result?.models).toEqual({ 'm-1': { context_length: 128_000 } })
+  })
+
+  it('preserves discover_models, context_length, rate_limit_delay, extra_body', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      base_url: 'https://example.com',
+      discover_models: false,
+      context_length: 256_000,
+      rate_limit_delay: 0.5,
+      extra_body: { foo: 'bar' },
+    })
+    expect(result?.discover_models).toBe(false)
+    expect(result?.context_length).toBe(256_000)
+    expect(result?.rate_limit_delay).toBe(0.5)
+    expect(result?.extra_body).toEqual({ foo: 'bar' })
+  })
+
+  it('drops invalid context_length / rate_limit_delay values silently', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      base_url: 'https://example.com',
+      context_length: 0,
+      rate_limit_delay: -1,
+    })
+    expect(result?.context_length).toBeUndefined()
+    expect(result?.rate_limit_delay).toBeUndefined()
+  })
+})
+
+describe('getCompatibleCustomProviders', () => {
+  it('returns an empty array for non-config inputs', () => {
+    expect(getCompatibleCustomProviders(null)).toEqual([])
+    expect(getCompatibleCustomProviders(undefined)).toEqual([])
+    expect(getCompatibleCustomProviders('not config')).toEqual([])
+  })
+
+  it('reads entries from the legacy custom_providers list', () => {
+    const config = {
+      custom_providers: [
+        { name: 'volc', base_url: 'https://volc.example.com', model: 'minimax-m3' },
+      ],
+    }
+    const result = getCompatibleCustomProviders(config)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('volc')
+    expect(result[0].model).toBe('minimax-m3')
+  })
+
+  it('reads entries from the v12+ providers dict', () => {
+    const config = {
+      providers: {
+        'volcengine-coding': {
+          api: 'https://ark.cn-beijing.volces.com/api/coding/v3',
+          key_env: 'ARK_CODING_API_KEY',
+          default_model: 'minimax-m3',
+          models: ['minimax-m3', 'kimi-k2.6', 'glm-5.1'],
+          discover_models: false,
+        },
+      },
+    }
+    const result = getCompatibleCustomProviders(config)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('volcengine-coding')
+    expect(result[0].provider_key).toBe('volcengine-coding')
+    expect(result[0].base_url).toBe('https://ark.cn-beijing.volces.com/api/coding/v3')
+    expect(result[0].key_env).toBe('ARK_CODING_API_KEY')
+    expect(result[0].model).toBe('minimax-m3')
+    expect(result[0].models).toEqual({ 'minimax-m3': {}, 'kimi-k2.6': {}, 'glm-5.1': {} })
+    expect(result[0].discover_models).toBe(false)
+  })
+
+  it('merges entries from both schemas, list first', () => {
+    const config = {
+      custom_providers: [
+        { name: 'legacy', base_url: 'https://legacy.example.com', model: 'm-l' },
+      ],
+      providers: {
+        modern: { api: 'https://modern.example.com', default_model: 'm-m' },
+      },
+    }
+    const result = getCompatibleCustomProviders(config)
+    expect(result.map(p => p.name)).toEqual(['legacy', 'modern'])
+  })
+
+  it('deduplicates entries by provider_key (prefers list first)', () => {
+    const config = {
+      custom_providers: [
+        { name: 'shared', base_url: 'https://list.example.com', model: 'list-model' },
+      ],
+      providers: {
+        // Same provider_key as the list entry's name — list entry wins per Hermes Agent semantics.
+        shared: { api: 'https://dict.example.com', default_model: 'dict-model' },
+      },
+    }
+    const result = getCompatibleCustomProviders(config)
+    // The dict entry has provider_key='shared'. The list entry has no provider_key
+    // (its name is just 'shared'). Identity dedup uses (name, base_url, model)
+    // triple — different base_urls, so both should appear.
+    expect(result).toHaveLength(2)
+    expect(result[0].base_url).toBe('https://list.example.com')
+    expect(result[1].base_url).toBe('https://dict.example.com')
+  })
+
+  it('deduplicates true duplicates by name+base_url+model triple', () => {
+    const config = {
+      custom_providers: [
+        { name: 'dup', base_url: 'https://dup.example.com', model: 'm-1' },
+        { name: 'dup', base_url: 'https://dup.example.com/', model: 'm-1' }, // trailing slash
+      ],
+    }
+    const result = getCompatibleCustomProviders(config)
+    expect(result).toHaveLength(1)
+  })
+
+  it('returns empty array when custom_providers is malformed', () => {
+    // Matches Hermes Agent: a non-list custom_providers value bails out entirely.
+    expect(getCompatibleCustomProviders({ custom_providers: 'broken' })).toEqual([])
+  })
+
+  it('skips dict entries without a base_url silently', () => {
+    const config = {
+      providers: {
+        'no-url': { default_model: 'foo' },
+        'with-url': { api: 'https://valid.example.com', default_model: 'bar' },
+      },
+    }
+    const result = getCompatibleCustomProviders(config)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('with-url')
+  })
+
+  it('handles the volcengine-coding example from issue #1570', () => {
+    // This is the exact config shape from the bug report — Studio should now see
+    // the provider with all 5 models.
+    const config = {
+      model: { default: 'minimax-m3', provider: 'volcengine-coding' },
+      providers: {
+        'volcengine-coding': {
+          api: 'https://ark.cn-beijing.volces.com/api/coding/v3',
+          key_env: 'ARK_CODING_API_KEY',
+          default_model: 'minimax-m3',
+          models: ['minimax-m3', 'kimi-k2.6', 'glm-5.1', 'deepseek-v4-pro', 'deepseek-v4-flash'],
+          discover_models: false,
+        },
+      },
+      custom_providers: [],
+    }
+    const result = getCompatibleCustomProviders(config)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('volcengine-coding')
+    expect(Object.keys(result[0].models || {})).toEqual([
+      'minimax-m3', 'kimi-k2.6', 'glm-5.1', 'deepseek-v4-pro', 'deepseek-v4-flash',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- Add `getCompatibleCustomProviders()` (TS port of Hermes Agent's [`get_compatible_custom_providers()`](https://github.com/NousResearch/hermes-agent/commit/c449cd1af58c00225df29364a2c67c203d8b4582)) that reads provider entries from **both** the legacy `custom_providers:` list and the v12+ `providers:` dict, mirrors Agent's field-alias normalization (`apiKey`/`api_key`, `key_env`/`api_key_env`, `model`/`default_model`, list-or-dict `models`, `transport`/`api_mode`), and deduplicates by `provider_key` and `(name, base_url, model)` triple.
- Route Studio's **read** paths through it — model resolution (`controllers/hermes/models.ts`), catalog refresher (`services/hermes/model-catalog-cache.ts`), context-length lookup (`services/hermes/model-context.ts`), coding-agent resolution (`services/coding-agents.ts`), fun-codex media provider lookup (`controllers/hermes/media.ts`), and the `buildModelGroups()` fallback (`services/config-helpers.ts`).
- Write paths in `controllers/hermes/providers.ts` (POST/PUT/DELETE) intentionally **stay on the legacy list** — that's Studio's existing UI write surface and changing it is out of scope for this bug.
- 21 new Vitest cases for the helper, including the exact `volcengine-coding` config from the issue.

## Why

Hermes Agent's v12 migration converts `custom_providers:` (list) into `providers:` (dict) and deletes the list. Agent itself shipped `get_compatible_custom_providers()` so every runtime consumer in core sees a unified list view across both schemas. Studio was the lone holdout — it only read `Array.isArray(config.custom_providers) ? … : []`, which means **any provider declared in the v12+ dict shape is invisible to Studio's model picker, catalog, and context lookup**, even though `hermes` CLI, the dashboard, and the agent loop resolve them fine.

Symptom: `chat.<domain>` Models page shows nothing for a custom provider whose only definition lives under `providers:` (e.g. `volcengine-coding` with a coding-plan model whitelist that doesn't appear in the upstream `/v1/models` listing). The user has to either workaround it by migrating their config back to the legacy list shape, or duplicate the entry through Studio's UI.

## User / developer impact

- **Users on v12+ Hermes configs** (the default for any new install or `hermes config migrate` user) now see their custom providers in Studio's model picker, catalog cache (`provider-model-catalog.json` now includes them), and chat-default resolution.
- **Existing legacy `custom_providers:` users**: zero behavior change — list entries are still read first, dedup keeps the same identity rules (matches Agent's traversal order).
- **Studio's UI write flow**: unchanged. The "Add Custom Provider" form still writes to `custom_providers:`. Hand-editing both schemas is supported (legacy entries take precedence for matching identity triples), matching Agent.

## Validation

```bash
npm run test            # 1579 passed, 2 skipped (across 209 files)
npm run build           # client + server build clean
npm run harness:check   # passes
npx tsc --noEmit -p packages/server/tsconfig.json   # clean
```

New tests in `tests/server/custom-providers-compat.test.ts` (21 cases) cover:

- input validation (non-objects, missing URL, missing name with/without `providerKey`)
- URL aliases (`base_url` / `url` / `api`, first valid wins)
- camelCase aliases, `api_key_env` snake-case alias, `transport`/`api_mode`
- `models` as a list (converted to dict), as a dict (preserved)
- `discover_models` / `context_length` / `rate_limit_delay` / `extra_body` round-trip
- both schemas read individually and merged
- dedup by provider_key and by (name, base_url, model) triple including trailing-slash normalization
- malformed `custom_providers` → empty (matches Agent's bail-out semantics)
- the **exact `volcengine-coding` config** from issue #1570 — Studio now sees the provider with all 5 plan-aliased model names

## Known limitations

- Studio's "Add Custom Provider" UI still writes to `custom_providers:` (list). Migrating the write surface to also recognize/produce the v12 dict is a larger UX change and intentionally out of scope here. Hand-editing the dict in `config.yaml` works correctly today after this fix; the UI just doesn't author the dict shape itself yet.
- The `providers.ts` `attachToCredentialPool` flow likewise still operates on the legacy list. Same reasoning — credential-pool attachment via dict-shaped providers is a separate change.

Closes #1570
Refs NousResearch/hermes-agent@`c449cd1af58c00225df29364a2c67c203d8b4582`
