### PR TITLE
feat: add outbound relay and MCU login flow

### DIFF
--- a/bin/hermes-web-ui-mcp.mjs
+++ b/bin/hermes-web-ui-mcp.mjs
@@ -2,12 +2,39 @@
 import { createInterface } from 'node:readline'
 import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const DEFAULT_PORT = process.env.HERMES_WEB_UI_PORT || process.env.PORT || '8648'
 const DEFAULT_BASE_URL = `http://127.0.0.1:${DEFAULT_PORT}`
 const SERVER_NAME = process.env.HERMES_MCP_SERVER_NAME || 'hermes-web-ui-mcp'
-const VERSION = '0.1.0'
+const ALLOWED_PUBLIC_REQUEST_HEADERS = new Set([
+  'accept',
+  'accept-language',
+  'content-type',
+  'x-request-id',
+])
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+function readPackageVersion() {
+  const candidates = [
+    resolve(__dirname, '../package.json'),
+    resolve(__dirname, '../../package.json'),
+    resolve(process.cwd(), 'package.json'),
+  ]
+  for (const packagePath of candidates) {
+    try {
+      const pkg = JSON.parse(readFileSync(packagePath, 'utf8'))
+      if (typeof pkg.version === 'string' && pkg.version.trim()) return pkg.version.trim()
+    } catch {
+      // Try the next candidate path.
+    }
+  }
+  return '0.0.0'
+}
+
+const VERSION = readPackageVersion()
 
 function printHelp() {
   process.stdout.write(`hermes-web-ui-mcp v${VERSION}
@@ -23,6 +50,7 @@ Environment:
   HERMES_WEB_UI_URL       Web UI base URL. Default: ${DEFAULT_BASE_URL}
   HERMES_WEB_UI_HOME      Web UI state directory. Default: ~/.hermes-web-ui
   HERMES_WEBUI_STATE_DIR  Fallback Web UI state directory.
+  HERMES_WEB_UI_PROFILE   Default Hermes profile when a tool call omits profile.
   HERMES_WEB_UI_TOKEN     Optional explicit API token.
   AUTH_TOKEN              Optional explicit API token fallback.
 
@@ -46,10 +74,30 @@ function appHome() {
     join(homedir(), '.hermes-web-ui')
 }
 
-function readToken(tokenOverride, allowTokenFile = true) {
+function normalizeProfileSegment(profile) {
+  const raw = String(profile || '').trim()
+  if (!raw) return ''
+  const sanitized = raw.replace(/[<>:"/\\|?*\x00-\x1f]/g, '_')
+  if (sanitized === '.' || sanitized === '..' || sanitized.length > 128) return ''
+  return sanitized
+}
+
+function readProfileToken(profile) {
+  const segment = normalizeProfileSegment(profile)
+  if (!segment) return ''
+  try {
+    return readFileSync(join(appHome(), 'profiles', segment, '.model-run-token'), 'utf8').trim()
+  } catch {
+    return ''
+  }
+}
+
+function readToken(tokenOverride, allowTokenFile = true, profile = '') {
   const explicit = tokenOverride || process.env.HERMES_WEB_UI_TOKEN || process.env.AUTH_TOKEN
   if (explicit) return explicit.trim()
   if (!allowTokenFile) return ''
+  const profileToken = readProfileToken(profile)
+  if (profileToken) return profileToken
   try {
     return readFileSync(join(appHome(), '.token'), 'utf8').trim()
   } catch {
@@ -57,8 +105,17 @@ function readToken(tokenOverride, allowTokenFile = true) {
   }
 }
 
+function defaultProfile() {
+  return String(
+    process.env.HERMES_WEB_UI_PROFILE ||
+    process.env.HERMES_PROFILE ||
+    process.env.PROFILE ||
+    '',
+  ).trim()
+}
+
 function authHint() {
-  return `Web UI token was not accepted. Pass a current model run token argument or set HERMES_WEB_UI_TOKEN.`
+  return `Web UI token was not accepted. Pass the current Hermes profile argument so this MCP server can read its temporary token, pass an explicit token argument, or set HERMES_WEB_UI_TOKEN.`
 }
 
 function baseUrl() {
@@ -71,6 +128,16 @@ function jsonText(data) {
   }
 }
 
+function resourceText(uri, data) {
+  return {
+    contents: [{
+      uri,
+      mimeType: 'application/json',
+      text: JSON.stringify(data, null, 2),
+    }],
+  }
+}
+
 function errorText(message) {
   return {
     isError: true,
@@ -79,36 +146,280 @@ function errorText(message) {
 }
 
 async function request(path, options = {}) {
-  const token = readToken(options.token, options.allowTokenFile !== false)
-  const profile = typeof options.profile === 'string' ? options.profile.trim() : ''
+  const envelope = await requestEnvelope(path, options)
+  if (envelope.status < 200 || envelope.status >= 300) {
+    if (envelope.status === 401) {
+      throw new Error(`${envelope.body?.error || 'Unauthorized'}. ${authHint()}`)
+    }
+    throw new Error(envelope.body?.error || envelope.bodyText || `HTTP ${envelope.status}`)
+  }
+  return envelope.body
+}
+
+function appendQuery(path, query) {
+  if (!query || typeof query !== 'object' || Array.isArray(query)) return path
+  const parsed = new URL(path, 'http://hermes-web-ui.local')
+  for (const [key, value] of Object.entries(query)) {
+    if (value == null) continue
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item != null) parsed.searchParams.append(key, String(item))
+      }
+      continue
+    }
+    parsed.searchParams.set(key, String(value))
+  }
+  return `${parsed.pathname}${parsed.search}`
+}
+
+function normalizePublicHeaders(headers) {
+  const normalized = {}
+  if (!headers || typeof headers !== 'object' || Array.isArray(headers)) return normalized
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase()
+    if (!ALLOWED_PUBLIC_REQUEST_HEADERS.has(lower) || value == null) continue
+    normalized[lower] = Array.isArray(value) ? String(value.find(Boolean) || '') : String(value)
+  }
+  return normalized
+}
+
+async function requestEnvelope(path, options = {}) {
+  const profile = typeof options.profile === 'string' && options.profile.trim()
+    ? options.profile.trim()
+    : defaultProfile()
+  const token = readToken(options.token, options.allowTokenFile !== false, profile)
+  const method = options.method || 'GET'
+  const body = method === 'GET' || method === 'HEAD' ? undefined : options.body
   const headers = {
-    ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+    ...normalizePublicHeaders(options.headers),
+    ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
     ...(profile ? { 'X-Hermes-Profile': profile } : {}),
   }
-  const response = await fetch(`${baseUrl()}${path}`, {
-    method: options.method || 'GET',
+  const response = await fetch(`${baseUrl()}${appendQuery(path, options.query)}`, {
+    method,
     headers,
-    body: options.body ? JSON.stringify(options.body) : undefined,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
   })
-  const data = await response.json().catch(() => ({}))
-  if (!response.ok) {
-    if (response.status === 401) {
-      throw new Error(`${data?.error || 'Unauthorized'}. ${authHint()}`)
-    }
-    throw new Error(data?.error || `HTTP ${response.status}`)
+  const responseHeaders = {}
+  response.headers.forEach((value, key) => {
+    responseHeaders[key] = value
+  })
+  if (method === 'HEAD' || response.status === 204) {
+    return { status: response.status, headers: responseHeaders, body: null }
   }
-  return data
+  const contentType = response.headers.get('content-type') || ''
+  const bodyText = await response.text()
+  let parsedBody = bodyText
+  if (contentType.toLowerCase().includes('application/json')) {
+    try {
+      parsedBody = bodyText ? JSON.parse(bodyText) : null
+    } catch {
+      parsedBody = bodyText
+    }
+  }
+  return { status: response.status, headers: responseHeaders, body: parsedBody, bodyText }
+}
+
+function normalizeApiMethod(method) {
+  const value = String(method || 'GET').trim().toUpperCase()
+  return ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD'].includes(value) ? value : null
+}
+
+function normalizeApiPath(path) {
+  const raw = String(path || '').trim()
+  if (!raw || !raw.startsWith('/') || raw.startsWith('//')) return null
+  if (raw === '/v1' || raw.startsWith('/v1/')) return null
+  const parsed = new URL(raw, 'http://hermes-web-ui.local')
+  const normalized = `${parsed.pathname}${parsed.search}`
+  if (parsed.pathname === '/api/openapi.json') return normalized
+  if (parsed.pathname === '/health') return normalized
+  if (parsed.pathname.startsWith('/api/')) return normalized
+  return null
+}
+
+let cachedOpenApiDocument = null
+
+function isRecord(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+async function openApiDocument(options = {}) {
+  if (cachedOpenApiDocument) return cachedOpenApiDocument
+  cachedOpenApiDocument = await request('/api/openapi.json', options)
+  return cachedOpenApiDocument
+}
+
+function pathWithoutQuery(path) {
+  return new URL(path, 'http://hermes-web-ui.local').pathname
+}
+
+function pathTemplateRegex(template) {
+  const escaped = String(template).split('/').map(part => {
+    if (/^\{[^/{}]+\}$/.test(part)) return '[^/]+'
+    return part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  }).join('/')
+  return new RegExp(`^${escaped}$`)
+}
+
+function findOpenApiOperation(openapi, method, path) {
+  const paths = isRecord(openapi?.paths) ? openapi.paths : {}
+  const pathname = pathWithoutQuery(path)
+  const exact = paths[pathname]?.[method.toLowerCase()]
+  if (exact) return { operation: exact, pathTemplate: pathname }
+  for (const [template, methods] of Object.entries(paths)) {
+    if (!pathTemplateRegex(template).test(pathname)) continue
+    const operation = isRecord(methods) ? methods[method.toLowerCase()] : null
+    if (operation) return { operation, pathTemplate: template }
+  }
+  return null
+}
+
+function queryObjectFromPath(path, query) {
+  const parsed = new URL(path, 'http://hermes-web-ui.local')
+  const values = {}
+  for (const [key, value] of parsed.searchParams.entries()) {
+    if (values[key] === undefined) values[key] = value
+    else if (Array.isArray(values[key])) values[key].push(value)
+    else values[key] = [values[key], value]
+  }
+  if (isRecord(query)) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value != null) values[key] = value
+    }
+  }
+  return values
+}
+
+function missingValue(value) {
+  return value === undefined || value === null || value === ''
+}
+
+function validateRequiredObjectFields(schema, value, location) {
+  if (!schema || !Array.isArray(schema.required) || schema.required.length === 0) return null
+  if (!isRecord(value)) return `${location} must be an object with required fields: ${schema.required.join(', ')}`
+  for (const field of schema.required) {
+    if (missingValue(value[field])) return `missing required field ${location}.${field}`
+  }
+  return null
+}
+
+async function validateApiRequest(method, path, args) {
+  if (pathWithoutQuery(path) === '/api/openapi.json' || pathWithoutQuery(path) === '/api/hermes/openapi.json') return null
+  const openapi = await openApiDocument(withAuthArgs(args))
+  const match = findOpenApiOperation(openapi, method, path)
+  if (!match) return `Unknown endpoint in OpenAPI document: ${method} ${pathWithoutQuery(path)}`
+  const { operation } = match
+  const queryValues = queryObjectFromPath(path, args.query)
+  for (const parameter of Array.isArray(operation.parameters) ? operation.parameters : []) {
+    if (!parameter?.required) continue
+    if (parameter.in === 'query' && missingValue(queryValues[parameter.name])) {
+      return `missing required query parameter ${parameter.name}`
+    }
+    if (parameter.in === 'path') {
+      // Path templates are already matched by the request path; no separate path arg exists.
+      continue
+    }
+  }
+  const requestBody = operation.requestBody
+  if (!requestBody) return null
+  const body = args.body
+  if (requestBody.required && body === undefined) return `missing required request body for ${method} ${pathWithoutQuery(path)}`
+  if (body === undefined) return null
+  const schema = requestBody.content?.['application/json']?.schema
+  return validateRequiredObjectFields(schema, body, 'body')
+}
+
+function schemaType(schema) {
+  if (!isRecord(schema)) return undefined
+  if (typeof schema.type === 'string') return schema.type
+  if (Array.isArray(schema.oneOf)) return `oneOf(${schema.oneOf.map(schemaType).filter(Boolean).join('|')})`
+  if (Array.isArray(schema.anyOf)) return `anyOf(${schema.anyOf.map(schemaType).filter(Boolean).join('|')})`
+  if (schema.$ref) return String(schema.$ref).split('/').pop()
+  return undefined
+}
+
+function compactSchemaProperties(schema) {
+  if (!isRecord(schema?.properties)) return undefined
+  const result = {}
+  for (const [name, property] of Object.entries(schema.properties)) {
+    result[name] = {
+      type: schemaType(property) || 'unknown',
+      ...(property?.description ? { description: String(property.description) } : {}),
+      ...(property?.enum ? { enum: property.enum } : {}),
+    }
+  }
+  return result
+}
+
+function compactOperation(path, method, operation) {
+  const parameters = Array.isArray(operation.parameters) ? operation.parameters : []
+  const requestBody = operation.requestBody
+  const bodySchema = requestBody?.content?.['application/json']?.schema
+  const required = {
+    path: parameters.filter(p => p?.in === 'path' && p.required).map(p => p.name),
+    query: parameters.filter(p => p?.in === 'query' && p.required).map(p => p.name),
+    body: Array.isArray(bodySchema?.required) ? bodySchema.required : [],
+  }
+  const hasRequired = required.path.length || required.query.length || required.body.length
+  const properties = compactSchemaProperties(bodySchema)
+  return {
+    method: method.toUpperCase(),
+    path,
+    ...(operation.operationId ? { operationId: operation.operationId } : {}),
+    ...(Array.isArray(operation.tags) && operation.tags.length ? { tags: operation.tags } : {}),
+    ...(operation.summary ? { summary: operation.summary } : {}),
+    ...(operation.description ? { description: operation.description } : {}),
+    ...(hasRequired ? { required } : {}),
+    ...(requestBody ? {
+      requestBody: {
+        required: requestBody.required === true,
+        type: schemaType(bodySchema) || 'object',
+        ...(properties ? { properties } : {}),
+      },
+    } : {}),
+  }
+}
+
+function compactOpenApiDocument(openapi, args = {}) {
+  if (args.full === true) return openapi
+  const filterPath = typeof args.path === 'string' && args.path.trim() ? pathWithoutQuery(args.path.trim()) : ''
+  const filterMethod = normalizeApiMethod(args.method)
+  const filterTag = typeof args.tag === 'string' && args.tag.trim() ? args.tag.trim() : ''
+  const operations = []
+  const paths = isRecord(openapi?.paths) ? openapi.paths : {}
+  for (const [path, methods] of Object.entries(paths)) {
+    if (filterPath && path !== filterPath) continue
+    if (!isRecord(methods)) continue
+    for (const [method, operation] of Object.entries(methods)) {
+      if (!['get', 'post', 'put', 'patch', 'delete', 'head'].includes(method)) continue
+      if (filterMethod && method !== filterMethod.toLowerCase()) continue
+      if (filterTag && !(Array.isArray(operation?.tags) && operation.tags.includes(filterTag))) continue
+      operations.push(compactOperation(path, method, operation))
+    }
+  }
+  return {
+    title: openapi?.info?.title || 'Hermes Studio API',
+    version: openapi?.info?.version || '',
+    usage: 'Call hermes_api_request with method, path, and JSON body/query matching the selected operation. Auth and profile are handled by the MCP server.',
+    filters: {
+      ...(filterPath ? { path: filterPath } : {}),
+      ...(filterMethod ? { method: filterMethod } : {}),
+      ...(filterTag ? { tag: filterTag } : {}),
+    },
+    operationCount: operations.length,
+    operations,
+  }
 }
 
 const authArgumentProperties = {
   token: {
     type: 'string',
-    description: 'Optional Hermes Web UI bearer token. Use the current model run token when one is provided in the run instructions.',
+    description: 'Optional Hermes Web UI bearer token. Usually omit this and pass profile so the MCP server can read the temporary profile token.',
   },
   profile: {
     type: 'string',
-    description: 'Optional Hermes profile name for profile-scoped Web UI requests.',
+    description: 'Hermes profile name for profile-scoped Web UI requests and temporary profile token lookup.',
   },
 }
 
@@ -126,11 +437,64 @@ function withAuthArgs(args, options = {}) {
     ...options,
     token: args.token,
     profile: args.profile,
-    allowTokenFile: false,
   }
 }
 
 const tools = [
+  {
+    name: 'hermes_api_openapi_get',
+    description: 'Return a compact Hermes Studio operation manual generated from OpenAPI. Use optional path/method/tag filters for focused endpoint details before calling hermes_api_request.',
+    inputSchema: inputSchema({
+        path: {
+          type: 'string',
+          description: 'Optional endpoint path filter, for example /api/chat-run/runs.',
+        },
+        method: {
+          type: 'string',
+          enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD'],
+          description: 'Optional HTTP method filter.',
+        },
+        tag: {
+          type: 'string',
+          description: 'Optional OpenAPI tag filter.',
+        },
+        full: {
+          type: 'boolean',
+          description: 'Return the raw full OpenAPI JSON. Defaults to false; prefer compact output for agent use.',
+        },
+      }),
+  },
+  {
+    name: 'hermes_api_request',
+    description: 'Execute a Hermes Studio operation by calling an endpoint path. Use hermes_api_openapi_get first as the operation manual to inspect method, parameters, requestBody, and responses.',
+    inputSchema: inputSchema({
+        method: {
+          type: 'string',
+          enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD'],
+          description: 'HTTP method. Defaults to GET.',
+        },
+        path: {
+          type: 'string',
+          description: 'Relative Hermes Studio endpoint path from the operation manual, for example /api/hermes/sessions?limit=20. Full URLs and // paths are rejected.',
+        },
+        body: {
+          type: ['object', 'array', 'string', 'number', 'boolean', 'null'],
+          description: 'Optional JSON request body for POST/PUT/PATCH/DELETE. GET and HEAD ignore body.',
+        },
+        query: {
+          type: 'object',
+          description: 'Optional query parameters merged into path. Values are serialized as strings; arrays append repeated parameters.',
+          additionalProperties: true,
+        },
+        headers: {
+          type: 'object',
+          description: 'Optional request headers. Allowed names: accept, accept-language, content-type, x-request-id. Authorization and X-Hermes-Profile are filled from token/profile.',
+          additionalProperties: {
+            type: ['string', 'number', 'boolean', 'array'],
+          },
+        },
+      }, ['path']),
+  },
   {
     name: 'hermes_lan_devices_list',
     description: 'List known LAN and remote devices from Hermes Web UI, including pairing and online status.',
@@ -243,6 +607,23 @@ const tools = [
 
 async function callTool(name, args = {}) {
   switch (name) {
+    case 'hermes_api_openapi_get':
+      return jsonText(compactOpenApiDocument(await openApiDocument(withAuthArgs(args)), args))
+    case 'hermes_api_request': {
+      const method = normalizeApiMethod(args.method)
+      const path = normalizeApiPath(args.path)
+      if (!method) return errorText('Invalid method. Allowed: GET, POST, PUT, PATCH, DELETE, HEAD.')
+      if (!path) return errorText('Invalid path. Use a relative /api/... or /health path from hermes_api_openapi_get; full URLs are not allowed.')
+      const validationError = await validateApiRequest(method, path, args)
+      if (validationError) return errorText(`Invalid API request for ${method} ${pathWithoutQuery(path)}: ${validationError}. Use hermes_api_openapi_get to inspect required parameters and requestBody.`)
+      const options = withAuthArgs(args, {
+        method,
+        query: args.query,
+        headers: args.headers,
+        ...(method === 'GET' || method === 'HEAD' ? {} : { body: args.body }),
+      })
+      return jsonText(await requestEnvelope(path, options))
+    }
     case 'hermes_lan_devices_list':
       return jsonText(await request('/api/devices', withAuthArgs(args)))
     case 'hermes_lan_devices_scan':
@@ -294,6 +675,24 @@ async function callTool(name, args = {}) {
   }
 }
 
+const resources = [
+  {
+    uri: 'hermes://openapi.json',
+    name: 'Hermes Studio Operation Manual',
+    description: 'Hermes Studio operation manual encoded as OpenAPI 3.0 JSON, covering endpoints, parameters, request bodies, and responses.',
+    mimeType: 'application/json',
+  },
+]
+
+async function readResource(uri) {
+  switch (uri) {
+    case 'hermes://openapi.json':
+      return resourceText(uri, await request('/api/openapi.json'))
+    default:
+      return null
+  }
+}
+
 async function handle(message) {
   if (!message || message.id === undefined) return null
 
@@ -305,7 +704,7 @@ async function handle(message) {
           id: message.id,
           result: {
             protocolVersion: message.params?.protocolVersion || '2024-11-05',
-            capabilities: { tools: {} },
+            capabilities: { tools: {}, resources: {} },
             serverInfo: { name: SERVER_NAME, version: VERSION },
           },
         }
@@ -317,6 +716,19 @@ async function handle(message) {
           id: message.id,
           result: await callTool(message.params?.name, message.params?.arguments || {}),
         }
+      case 'resources/list':
+        return { jsonrpc: '2.0', id: message.id, result: { resources } }
+      case 'resources/read': {
+        const result = await readResource(message.params?.uri)
+        if (!result) {
+          return {
+            jsonrpc: '2.0',
+            id: message.id,
+            error: { code: -32602, message: `Unknown resource: ${message.params?.uri || ''}` },
+          }
+        }
+        return { jsonrpc: '2.0', id: message.id, result }
+      }
       default:
         return {
           jsonrpc: '2.0',
@@ -325,6 +737,13 @@ async function handle(message) {
         }
     }
   } catch (err) {
+    if (message.method === 'resources/read') {
+      return {
+        jsonrpc: '2.0',
+        id: message.id,
+        error: { code: -32000, message: err?.message || String(err) },
+      }
+    }
     return { jsonrpc: '2.0', id: message.id, result: errorText(err?.message || String(err)) }
   }
 }

--- a/bin/hermes-web-ui-mcp.mjs
+++ b/bin/hermes-web-ui-mcp.mjs
@@ -46,9 +46,10 @@ function appHome() {
     join(homedir(), '.hermes-web-ui')
 }
 
-function readToken() {
-  const explicit = process.env.HERMES_WEB_UI_TOKEN || process.env.AUTH_TOKEN
+function readToken(tokenOverride, allowTokenFile = true) {
+  const explicit = tokenOverride || process.env.HERMES_WEB_UI_TOKEN || process.env.AUTH_TOKEN
   if (explicit) return explicit.trim()
+  if (!allowTokenFile) return ''
   try {
     return readFileSync(join(appHome(), '.token'), 'utf8').trim()
   } catch {
@@ -57,7 +58,7 @@ function readToken() {
 }
 
 function authHint() {
-  return `Web UI token was not accepted. Check HERMES_WEB_UI_TOKEN or ${join(appHome(), '.token')}.`
+  return `Web UI token was not accepted. Pass a current model run token argument or set HERMES_WEB_UI_TOKEN.`
 }
 
 function baseUrl() {
@@ -78,10 +79,12 @@ function errorText(message) {
 }
 
 async function request(path, options = {}) {
-  const token = readToken()
+  const token = readToken(options.token, options.allowTokenFile !== false)
+  const profile = typeof options.profile === 'string' ? options.profile.trim() : ''
   const headers = {
     ...(options.body ? { 'Content-Type': 'application/json' } : {}),
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(profile ? { 'X-Hermes-Profile': profile } : {}),
   }
   const response = await fetch(`${baseUrl()}${path}`, {
     method: options.method || 'GET',
@@ -98,220 +101,194 @@ async function request(path, options = {}) {
   return data
 }
 
+const authArgumentProperties = {
+  token: {
+    type: 'string',
+    description: 'Optional Hermes Web UI bearer token. Use the current model run token when one is provided in the run instructions.',
+  },
+  profile: {
+    type: 'string',
+    description: 'Optional Hermes profile name for profile-scoped Web UI requests.',
+  },
+}
+
+function inputSchema(properties = {}, required = []) {
+  return {
+    type: 'object',
+    properties: { ...authArgumentProperties, ...properties },
+    ...(required.length ? { required } : {}),
+    additionalProperties: false,
+  }
+}
+
+function withAuthArgs(args, options = {}) {
+  return {
+    ...options,
+    token: args.token,
+    profile: args.profile,
+    allowTokenFile: false,
+  }
+}
+
 const tools = [
   {
     name: 'hermes_lan_devices_list',
     description: 'List known LAN and remote devices from Hermes Web UI, including pairing and online status.',
-    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    inputSchema: inputSchema(),
   },
   {
     name: 'hermes_lan_devices_scan',
     description: 'Refresh LAN device discovery cache and return known devices with pairing and online status.',
-    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    inputSchema: inputSchema(),
   },
   {
     name: 'hermes_lan_peer_connect',
     description: 'Connect to a paired LAN device by device id.',
-    inputSchema: {
-      type: 'object',
-      properties: { device_id: { type: 'string' } },
-      required: ['device_id'],
-      additionalProperties: false,
-    },
+    inputSchema: inputSchema({ device_id: { type: 'string' } }, ['device_id']),
   },
   {
     name: 'hermes_lan_peer_connections',
     description: 'List active LAN peer socket connections.',
-    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    inputSchema: inputSchema(),
   },
   {
     name: 'hermes_lan_peer_disconnect',
     description: 'Disconnect an active LAN peer socket connection.',
-    inputSchema: {
-      type: 'object',
-      properties: { connection_id: { type: 'string' } },
-      required: ['connection_id'],
-      additionalProperties: false,
-    },
+    inputSchema: inputSchema({ connection_id: { type: 'string' } }, ['connection_id']),
   },
   {
     name: 'hermes_lan_terminal_create',
     description: 'Create an interactive terminal on a connected LAN peer.',
-    inputSchema: {
-      type: 'object',
-      properties: {
+    inputSchema: inputSchema({
         connection_id: { type: 'string' },
         shell: { type: 'string' },
         cols: { type: 'number' },
         rows: { type: 'number' },
-      },
-      required: ['connection_id'],
-      additionalProperties: false,
-    },
+      }, ['connection_id']),
   },
   {
     name: 'hermes_lan_terminal_list',
     description: 'List interactive terminals tracked for a connected LAN peer, including IDs that can be read or closed.',
-    inputSchema: {
-      type: 'object',
-      properties: {
+    inputSchema: inputSchema({
         connection_id: { type: 'string' },
-      },
-      required: ['connection_id'],
-      additionalProperties: false,
-    },
+      }, ['connection_id']),
   },
   {
     name: 'hermes_lan_terminal_input',
     description: 'Write input to an interactive terminal on a connected LAN peer.',
-    inputSchema: {
-      type: 'object',
-      properties: {
+    inputSchema: inputSchema({
         connection_id: { type: 'string' },
         terminal_id: { type: 'string' },
         data: { type: 'string' },
-      },
-      required: ['connection_id', 'terminal_id', 'data'],
-      additionalProperties: false,
-    },
+      }, ['connection_id', 'terminal_id', 'data']),
   },
   {
     name: 'hermes_lan_terminal_read',
     description: 'Read buffered terminal output from an interactive terminal.',
-    inputSchema: {
-      type: 'object',
-      properties: {
+    inputSchema: inputSchema({
         connection_id: { type: 'string' },
         terminal_id: { type: 'string' },
-      },
-      required: ['connection_id', 'terminal_id'],
-      additionalProperties: false,
-    },
+      }, ['connection_id', 'terminal_id']),
   },
   {
     name: 'hermes_lan_terminal_resize',
     description: 'Resize an interactive terminal on a connected LAN peer.',
-    inputSchema: {
-      type: 'object',
-      properties: {
+    inputSchema: inputSchema({
         connection_id: { type: 'string' },
         terminal_id: { type: 'string' },
         cols: { type: 'number' },
         rows: { type: 'number' },
-      },
-      required: ['connection_id', 'terminal_id', 'cols', 'rows'],
-      additionalProperties: false,
-    },
+      }, ['connection_id', 'terminal_id', 'cols', 'rows']),
   },
   {
     name: 'hermes_lan_terminal_close',
     description: 'Close an interactive terminal on a connected LAN peer.',
-    inputSchema: {
-      type: 'object',
-      properties: {
+    inputSchema: inputSchema({
         connection_id: { type: 'string' },
         terminal_id: { type: 'string' },
-      },
-      required: ['connection_id', 'terminal_id'],
-      additionalProperties: false,
-    },
+      }, ['connection_id', 'terminal_id']),
   },
   {
     name: 'hermes_lan_command_exec',
     description: 'Run a command on a connected LAN peer using command plus args, without shell string execution.',
-    inputSchema: {
-      type: 'object',
-      properties: {
+    inputSchema: inputSchema({
         connection_id: { type: 'string' },
         command: { type: 'string' },
         args: { type: 'array', items: { type: 'string' } },
         cwd: { type: 'string' },
         timeout_ms: { type: 'number' },
-      },
-      required: ['connection_id', 'command'],
-      additionalProperties: false,
-    },
+      }, ['connection_id', 'command']),
   },
   {
     name: 'hermes_lan_file_download',
     description: 'Download a file from a connected LAN peer remote path to a local path on this machine.',
-    inputSchema: {
-      type: 'object',
-      properties: {
+    inputSchema: inputSchema({
         connection_id: { type: 'string' },
         remote_path: { type: 'string' },
         local_path: { type: 'string' },
         timeout_ms: { type: 'number' },
-      },
-      required: ['connection_id', 'remote_path', 'local_path'],
-      additionalProperties: false,
-    },
+      }, ['connection_id', 'remote_path', 'local_path']),
   },
   {
     name: 'hermes_lan_file_upload',
     description: 'Upload a local file path from this machine to a connected LAN peer remote path.',
-    inputSchema: {
-      type: 'object',
-      properties: {
+    inputSchema: inputSchema({
         connection_id: { type: 'string' },
         local_path: { type: 'string' },
         remote_path: { type: 'string' },
         timeout_ms: { type: 'number' },
-      },
-      required: ['connection_id', 'local_path', 'remote_path'],
-      additionalProperties: false,
-    },
+      }, ['connection_id', 'local_path', 'remote_path']),
   },
 ]
 
 async function callTool(name, args = {}) {
   switch (name) {
     case 'hermes_lan_devices_list':
-      return jsonText(await request('/api/devices'))
+      return jsonText(await request('/api/devices', withAuthArgs(args)))
     case 'hermes_lan_devices_scan':
-      return jsonText(await request('/api/devices/scan', { method: 'POST' }))
+      return jsonText(await request('/api/devices/scan', withAuthArgs(args, { method: 'POST' })))
     case 'hermes_lan_peer_connect':
-      return jsonText(await request(`/api/devices/${encodeURIComponent(args.device_id)}/connect`, { method: 'POST' }))
+      return jsonText(await request(`/api/devices/${encodeURIComponent(args.device_id)}/connect`, withAuthArgs(args, { method: 'POST' })))
     case 'hermes_lan_peer_connections':
-      return jsonText(await request('/api/devices/peer-connections'))
+      return jsonText(await request('/api/devices/peer-connections', withAuthArgs(args)))
     case 'hermes_lan_peer_disconnect':
-      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/disconnect`, { method: 'POST' }))
+      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/disconnect`, withAuthArgs(args, { method: 'POST' })))
     case 'hermes_lan_terminal_create':
-      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/terminal`, {
+      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/terminal`, withAuthArgs(args, {
         method: 'POST',
         body: { shell: args.shell, cols: args.cols, rows: args.rows },
-      }))
+      })))
     case 'hermes_lan_terminal_list':
-      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/terminals`))
+      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/terminals`, withAuthArgs(args)))
     case 'hermes_lan_terminal_input':
-      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/terminal/${encodeURIComponent(args.terminal_id)}/input`, {
+      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/terminal/${encodeURIComponent(args.terminal_id)}/input`, withAuthArgs(args, {
         method: 'POST',
         body: { data: args.data },
-      }))
+      })))
     case 'hermes_lan_terminal_read':
-      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/terminal/${encodeURIComponent(args.terminal_id)}/read`))
+      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/terminal/${encodeURIComponent(args.terminal_id)}/read`, withAuthArgs(args)))
     case 'hermes_lan_terminal_resize':
-      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/terminal/${encodeURIComponent(args.terminal_id)}/resize`, {
+      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/terminal/${encodeURIComponent(args.terminal_id)}/resize`, withAuthArgs(args, {
         method: 'POST',
         body: { cols: args.cols, rows: args.rows },
-      }))
+      })))
     case 'hermes_lan_terminal_close':
-      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/terminal/${encodeURIComponent(args.terminal_id)}/close`, { method: 'POST' }))
+      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/terminal/${encodeURIComponent(args.terminal_id)}/close`, withAuthArgs(args, { method: 'POST' })))
     case 'hermes_lan_command_exec':
-      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/exec`, {
+      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/exec`, withAuthArgs(args, {
         method: 'POST',
         body: { command: args.command, args: args.args || [], cwd: args.cwd, timeout_ms: args.timeout_ms },
-      }))
+      })))
     case 'hermes_lan_file_download':
-      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/download`, {
+      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/download`, withAuthArgs(args, {
         method: 'POST',
         body: { remote_path: args.remote_path, local_path: args.local_path, timeout_ms: args.timeout_ms },
-      }))
+      })))
     case 'hermes_lan_file_upload':
-      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/upload`, {
+      return jsonText(await request(`/api/devices/peer-connections/${encodeURIComponent(args.connection_id)}/upload`, withAuthArgs(args, {
         method: 'POST',
         body: { local_path: args.local_path, remote_path: args.remote_path, timeout_ms: args.timeout_ms },
-      }))
+      })))
     default:
       return errorText(`Unknown tool: ${name}`)
   }

--- a/bin/hermes-web-ui-mcp.mjs
+++ b/bin/hermes-web-ui-mcp.mjs
@@ -128,16 +128,6 @@ function jsonText(data) {
   }
 }
 
-function resourceText(uri, data) {
-  return {
-    contents: [{
-      uri,
-      mimeType: 'application/json',
-      text: JSON.stringify(data, null, 2),
-    }],
-  }
-}
-
 function errorText(message) {
   return {
     isError: true,
@@ -339,53 +329,183 @@ function schemaType(schema) {
   return undefined
 }
 
-function compactSchemaProperties(schema) {
-  if (!isRecord(schema?.properties)) return undefined
-  const result = {}
-  for (const [name, property] of Object.entries(schema.properties)) {
-    result[name] = {
-      type: schemaType(property) || 'unknown',
-      ...(property?.description ? { description: String(property.description) } : {}),
-      ...(property?.enum ? { enum: property.enum } : {}),
+function compactParameters(parameters) {
+  const path = []
+  const query = []
+  for (const parameter of Array.isArray(parameters) ? parameters : []) {
+    if (!parameter?.name) continue
+    const item = {
+      name: parameter.name,
+      required: parameter.required === true,
+      type: schemaType(parameter.schema) || 'string',
+      ...(Array.isArray(parameter.schema?.enum) ? { enum: parameter.schema.enum } : {}),
     }
+    if (parameter.in === 'path') path.push(item)
+    if (parameter.in === 'query') query.push(item)
   }
-  return result
+  return { path, query }
+}
+
+function compactBodyFields(requestBody) {
+  const schema = requestBody?.content?.['application/json']?.schema
+  if (!isRecord(schema?.properties)) return []
+  const required = new Set(Array.isArray(schema.required) ? schema.required : [])
+  return Object.entries(schema.properties).map(([name, property]) => {
+    return {
+      name,
+      required: required.has(name),
+      type: schemaType(property) || 'unknown',
+      ...(Array.isArray(property?.enum) ? { enum: property.enum } : {}),
+      ...(property?.description ? { description: String(property.description) } : {}),
+    }
+  })
+}
+
+const moduleHints = {
+  'API Docs': {
+    purpose: 'Discover the Web UI API catalog and generated OpenAPI metadata.',
+    keywords: ['操作手册', '接口文档', 'API 文档', 'openapi', 'route catalog'],
+  },
+  Auth: {
+    purpose: 'Manage Web UI authentication state and tokens.',
+    keywords: ['auth', 'login', 'token', 'session'],
+  },
+  'Chat Run': {
+    purpose: 'Start a chat or coding-agent run through the HTTP bridge and wait for the result.',
+    keywords: ['chat', 'run', 'execute', 'agent', 'model'],
+  },
+  'Coding Agents': {
+    purpose: 'Install, configure, and run coding agents such as Codex or Claude Code.',
+    keywords: ['codex', 'claude', 'coding agent', 'install', 'run'],
+  },
+  Config: {
+    purpose: 'Read and update Hermes Web UI configuration.',
+    keywords: ['config', 'settings', 'preferences'],
+  },
+  Devices: {
+    purpose: 'Discover, pair, and operate LAN peer devices, terminals, commands, and file transfer.',
+    keywords: ['device', 'lan', 'peer', 'terminal', 'file transfer'],
+  },
+  Files: {
+    purpose: 'Browse and operate files exposed through the Hermes file browser.',
+    keywords: ['files', 'browser', 'read', 'list', 'download'],
+  },
+  'Group Chat': {
+    purpose: 'Manage multi-participant group chat rooms and messages.',
+    keywords: ['group chat', 'room', 'participants', 'messages'],
+  },
+  Jobs: {
+    purpose: 'Create, inspect, update, and run scheduled or background jobs.',
+    keywords: ['jobs', 'schedule', 'cron', 'tasks', 'automation'],
+  },
+  Kanban: {
+    purpose: 'Manage boards, columns, cards, and task workflow state.',
+    keywords: ['kanban', 'board', 'task', 'card', 'workflow'],
+  },
+  MCP: {
+    purpose: 'Manage MCP servers, tools, and Web UI MCP integration.',
+    keywords: ['mcp', 'tools', 'server', 'integration'],
+  },
+  Media: {
+    purpose: 'Generate or manage media assets.',
+    keywords: ['media', 'image', 'generation', 'asset'],
+  },
+  Memory: {
+    purpose: 'Read and manage agent memory files.',
+    keywords: ['memory', 'agent memory', 'notes'],
+  },
+  Models: {
+    purpose: 'Inspect and configure model ids available to Hermes.',
+    keywords: ['models', 'model id', 'llm'],
+  },
+  Profiles: {
+    purpose: 'Manage Hermes profiles and profile-scoped runtime state.',
+    keywords: ['profile', 'workspace', 'account'],
+  },
+  Providers: {
+    purpose: 'Manage model provider configuration and credentials metadata.',
+    keywords: ['provider', 'model provider', 'api key', 'base url'],
+  },
+  Sessions: {
+    purpose: 'List, inspect, create, update, and delete chat sessions.',
+    keywords: ['sessions', 'conversation', 'chat history'],
+  },
+  Skills: {
+    purpose: 'Browse and manage skills available to Hermes agents.',
+    keywords: ['skills', 'agent skill', 'capability'],
+  },
+  Terminal: {
+    purpose: 'Open interactive terminal sessions over WebSocket.',
+    keywords: ['terminal', 'shell', 'websocket'],
+  },
+  'Write Gate': {
+    purpose: 'Review and approve Hermes Agent write operations.',
+    keywords: ['approval', 'write gate', 'review'],
+  },
 }
 
 function compactOperation(path, method, operation) {
-  const parameters = Array.isArray(operation.parameters) ? operation.parameters : []
-  const requestBody = operation.requestBody
-  const bodySchema = requestBody?.content?.['application/json']?.schema
-  const required = {
-    path: parameters.filter(p => p?.in === 'path' && p.required).map(p => p.name),
-    query: parameters.filter(p => p?.in === 'query' && p.required).map(p => p.name),
-    body: Array.isArray(bodySchema?.required) ? bodySchema.required : [],
-  }
-  const hasRequired = required.path.length || required.query.length || required.body.length
-  const properties = compactSchemaProperties(bodySchema)
+  const parameters = compactParameters(operation.parameters)
+  const body = compactBodyFields(operation.requestBody)
   return {
     method: method.toUpperCase(),
     path,
     ...(operation.operationId ? { operationId: operation.operationId } : {}),
     ...(Array.isArray(operation.tags) && operation.tags.length ? { tags: operation.tags } : {}),
     ...(operation.summary ? { summary: operation.summary } : {}),
-    ...(operation.description ? { description: operation.description } : {}),
-    ...(hasRequired ? { required } : {}),
-    ...(requestBody ? {
+    ...(parameters.path.length ? { pathParams: parameters.path } : {}),
+    ...(parameters.query.length ? { queryParams: parameters.query } : {}),
+    ...(operation.requestBody ? {
       requestBody: {
-        required: requestBody.required === true,
-        type: schemaType(bodySchema) || 'object',
-        ...(properties ? { properties } : {}),
+        required: operation.requestBody.required === true,
+        fields: body,
       },
     } : {}),
   }
 }
 
+function collectOpenApiModules(openapi) {
+  const descriptions = new Map()
+  for (const tag of Array.isArray(openapi?.tags) ? openapi.tags : []) {
+    if (typeof tag?.name === 'string') descriptions.set(tag.name, String(tag.description || ''))
+  }
+
+  const counts = new Map()
+  const paths = isRecord(openapi?.paths) ? openapi.paths : {}
+  for (const methods of Object.values(paths)) {
+    if (!isRecord(methods)) continue
+    for (const [method, operation] of Object.entries(methods)) {
+      if (!['get', 'post', 'put', 'patch', 'delete', 'head'].includes(method)) continue
+      const tags = Array.isArray(operation?.tags) && operation.tags.length ? operation.tags : ['Untagged']
+      for (const tag of tags) counts.set(tag, (counts.get(tag) || 0) + 1)
+    }
+  }
+
+  return [...counts.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([tag, operationCount]) => ({
+      tag,
+      operationCount,
+      ...(moduleHints[tag]?.purpose ? { purpose: moduleHints[tag].purpose } : {}),
+      ...(moduleHints[tag]?.keywords ? { keywords: moduleHints[tag].keywords } : {}),
+      ...(descriptions.get(tag) ? { description: descriptions.get(tag) } : {}),
+    }))
+}
+
 function compactOpenApiDocument(openapi, args = {}) {
   if (args.full === true) return openapi
   const filterPath = typeof args.path === 'string' && args.path.trim() ? pathWithoutQuery(args.path.trim()) : ''
-  const filterMethod = normalizeApiMethod(args.method)
+  const filterMethod = typeof args.method === 'string' && args.method.trim()
+    ? normalizeApiMethod(args.method)
+    : null
   const filterTag = typeof args.tag === 'string' && args.tag.trim() ? args.tag.trim() : ''
+  const filters = {
+    ...(filterPath ? { path: filterPath } : {}),
+    ...(filterMethod ? { method: filterMethod } : {}),
+    ...(filterTag ? { tag: filterTag } : {}),
+  }
+  const hasFilters = Object.keys(filters).length > 0
+  const modules = collectOpenApiModules(openapi)
   const operations = []
   const paths = isRecord(openapi?.paths) ? openapi.paths : {}
   for (const [path, methods] of Object.entries(paths)) {
@@ -398,17 +518,18 @@ function compactOpenApiDocument(openapi, args = {}) {
       operations.push(compactOperation(path, method, operation))
     }
   }
+
   return {
     title: openapi?.info?.title || 'Hermes Studio API',
     version: openapi?.info?.version || '',
-    usage: 'Call hermes_api_request with method, path, and JSON body/query matching the selected operation. Auth and profile are handled by the MCP server.',
-    filters: {
-      ...(filterPath ? { path: filterPath } : {}),
-      ...(filterMethod ? { method: filterMethod } : {}),
-      ...(filterTag ? { tag: filterTag } : {}),
-    },
+    usage: hasFilters
+      ? 'Use the selected operation details to call hermes_api_request with method, path, query, and body. Auth and profile are handled by the MCP server.'
+      : 'This catalog is large. First read module purpose and keywords to choose the right module, then call hermes_api_openapi_get again with tag, path, or method filters to fetch endpoint details on demand.',
+    moduleCount: modules.length,
+    modules,
+    ...(Object.keys(filters).length ? { filters } : {}),
     operationCount: operations.length,
-    operations,
+    ...(hasFilters ? { operations } : { operationsOmitted: true }),
   }
 }
 
@@ -443,24 +564,24 @@ function withAuthArgs(args, options = {}) {
 const tools = [
   {
     name: 'hermes_api_openapi_get',
-    description: 'Return a compact Hermes Studio operation manual generated from OpenAPI. Use optional path/method/tag filters for focused endpoint details before calling hermes_api_request.',
+    description: 'Return Hermes Studio API documentation as compact JSON. When the user asks to read/check the operation manual, API docs, endpoint docs, 接口文档, 接口手册, or 操作手册, call this tool without filters first to get the outline/module index. Without filters, returns only module purpose, keywords, and operation counts because the full API catalog is large. For endpoint details, call again with tag, path, or method filters, then use hermes_api_request.',
     inputSchema: inputSchema({
         path: {
           type: 'string',
-          description: 'Optional endpoint path filter, for example /api/chat-run/runs.',
+          description: 'Optional exact endpoint path filter for on-demand details, for example /api/chat-run/runs.',
         },
         method: {
           type: 'string',
           enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD'],
-          description: 'Optional HTTP method filter.',
+          description: 'Optional HTTP method filter. Usually combine with path or tag.',
         },
         tag: {
           type: 'string',
-          description: 'Optional OpenAPI tag filter.',
+          description: 'Optional module/tag filter. Recommended flow: call without filters to list modules, then call with one module tag for details.',
         },
         full: {
           type: 'boolean',
-          description: 'Return the raw full OpenAPI JSON. Defaults to false; prefer compact output for agent use.',
+          description: 'Return the raw full OpenAPI JSON. Defaults to false; prefer compact JSON output for agent use.',
         },
       }),
   },
@@ -675,24 +796,6 @@ async function callTool(name, args = {}) {
   }
 }
 
-const resources = [
-  {
-    uri: 'hermes://openapi.json',
-    name: 'Hermes Studio Operation Manual',
-    description: 'Hermes Studio operation manual encoded as OpenAPI 3.0 JSON, covering endpoints, parameters, request bodies, and responses.',
-    mimeType: 'application/json',
-  },
-]
-
-async function readResource(uri) {
-  switch (uri) {
-    case 'hermes://openapi.json':
-      return resourceText(uri, await request('/api/openapi.json'))
-    default:
-      return null
-  }
-}
-
 async function handle(message) {
   if (!message || message.id === undefined) return null
 
@@ -704,7 +807,7 @@ async function handle(message) {
           id: message.id,
           result: {
             protocolVersion: message.params?.protocolVersion || '2024-11-05',
-            capabilities: { tools: {}, resources: {} },
+            capabilities: { tools: {} },
             serverInfo: { name: SERVER_NAME, version: VERSION },
           },
         }
@@ -716,19 +819,6 @@ async function handle(message) {
           id: message.id,
           result: await callTool(message.params?.name, message.params?.arguments || {}),
         }
-      case 'resources/list':
-        return { jsonrpc: '2.0', id: message.id, result: { resources } }
-      case 'resources/read': {
-        const result = await readResource(message.params?.uri)
-        if (!result) {
-          return {
-            jsonrpc: '2.0',
-            id: message.id,
-            error: { code: -32602, message: `Unknown resource: ${message.params?.uri || ''}` },
-          }
-        }
-        return { jsonrpc: '2.0', id: message.id, result }
-      }
       default:
         return {
           jsonrpc: '2.0',
@@ -737,13 +827,6 @@ async function handle(message) {
         }
     }
   } catch (err) {
-    if (message.method === 'resources/read') {
-      return {
-        jsonrpc: '2.0',
-        id: message.id,
-        error: { code: -32000, message: err?.message || String(err) },
-      }
-    }
     return { jsonrpc: '2.0', id: message.id, result: errorText(err?.message || String(err)) }
   }
 }

--- a/docs/chat-chain-changes/2026-06-15-model-run-mcp-auth.md
+++ b/docs/chat-chain-changes/2026-06-15-model-run-mcp-auth.md
@@ -1,0 +1,23 @@
+---
+date: 2026-06-15
+pr: pending
+feature: MCP model-run authentication
+impact: Bridge and coding-agent runs now add a one-hour user JWT to run instructions for MCP/Web UI calls, scoped Claude/Codex launches include the bundled Hermes MCP server, Codex receives Hermes media/file instructions per run instead of through AGENTS.md, and LAN MCP device endpoints require super admin JWT authorization instead of accepting the long-lived server .token.
+---
+
+Authenticated bridge runs include the current Hermes profile and a short-lived
+model-run token in run instructions so MCP tools can pass them as arguments.
+Scoped Claude Code and Codex launches include the bundled Hermes MCP server in
+their generated config, and coding-agent inputs receive the same per-run
+Hermes system prompt plus per-run profile/token prompt before being sent to
+the agent. Claude Code receives the Hermes media/file prompt on every run via
+`--append-system-prompt`. Codex receives the Hermes media/file prompt in each
+run prompt alongside the dynamic profile/token prompt, and Web UI no longer
+writes managed Codex `AGENTS.md` prompt blocks. Managed Claude Code
+`CLAUDE.md` blocks preserve existing user content and replace only the marked
+Hermes Web UI prompt block. This keeps media, image, video, file, and
+absolute-path response formatting consistent without storing the injected prompt
+as the Web UI user message.
+LAN device MCP routes no longer accept the server `.token` fallback, the bundled
+MCP tools no longer read `.token` for LAN tool calls, and those routes are
+protected by super-admin authorization.

--- a/docs/chat-chain-changes/2026-06-15-model-run-mcp-auth.md
+++ b/docs/chat-chain-changes/2026-06-15-model-run-mcp-auth.md
@@ -11,9 +11,10 @@ Scoped Claude Code and Codex launches include the bundled Hermes MCP server in
 their generated config, and coding-agent inputs receive the same per-run
 Hermes system prompt plus per-run profile/token prompt before being sent to
 the agent. Claude Code receives the Hermes media/file prompt on every run via
-`--append-system-prompt`. Codex receives the Hermes media/file prompt in each
-run prompt alongside the dynamic profile/token prompt, and Web UI no longer
-writes managed Codex `AGENTS.md` prompt blocks. Managed Claude Code
+`--append-system-prompt`. Codex receives the Hermes media/file prompt and the
+dynamic profile/token prompt through the `developer_instructions` config on
+each run, so the user prompt stays as the user's original input. Web UI no
+longer writes managed Codex `AGENTS.md` prompt blocks. Managed Claude Code
 `CLAUDE.md` blocks preserve existing user content and replace only the marked
 Hermes Web UI prompt block. This keeps media, image, video, file, and
 absolute-path response formatting consistent without storing the injected prompt

--- a/docs/chat-chain-changes/2026-06-15-model-run-mcp-auth.md
+++ b/docs/chat-chain-changes/2026-06-15-model-run-mcp-auth.md
@@ -14,7 +14,12 @@ the agent. Claude Code receives the Hermes media/file prompt on every run via
 `--append-system-prompt`. Codex receives the Hermes media/file prompt and the
 dynamic profile/token prompt through the `developer_instructions` config on
 each run, so the user prompt stays as the user's original input. Web UI no
-longer writes managed Codex `AGENTS.md` prompt blocks. Managed Claude Code
+longer writes managed Codex `AGENTS.md` prompt blocks. Authenticated Codex
+runs also receive Codex-specific developer instructions that Hermes LAN
+discovery is exposed as MCP tools rather than MCP resources/templates, naming
+`mcp__hermes-studio__hermes_lan_devices_scan` and
+`mcp__hermes-studio__hermes_lan_devices_list` as the tools to call with the
+current `profile` and `token`. Managed Claude Code
 `CLAUDE.md` blocks preserve existing user content and replace only the marked
 Hermes Web UI prompt block. This keeps media, image, video, file, and
 absolute-path response formatting consistent without storing the injected prompt

--- a/docs/chat-chain-changes/2026-06-15-outbound-relay-mcp-openapi.md
+++ b/docs/chat-chain-changes/2026-06-15-outbound-relay-mcp-openapi.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-15
+pr: pending
+feature: Hermes MCP OpenAPI relay
+impact: Model-run auth now writes profile-scoped temporary tokens for the bundled MCP server, and chat/coding-agent runs rely on OpenAPI-guided Hermes API calls instead of embedding bearer tokens in prompts.
+---
+
+Bridge, group-chat, and coding-agent runs continue to receive Hermes MCP
+guidance, but model-run authentication is now stored in the Web UI profile token
+file for the bundled MCP server to read. This avoids placing transient bearer
+tokens in model instructions while preserving profile-scoped Hermes API access
+for MCP tool calls.

--- a/docs/chat-chain-changes/2026-06-15-pending-global-agent-chat.md
+++ b/docs/chat-chain-changes/2026-06-15-pending-global-agent-chat.md
@@ -1,0 +1,10 @@
+---
+date: 2026-06-15
+pr: pending
+feature: Global Agent chat transport
+impact: Adds a global-agent chat route that reuses single-chat UI behavior while isolating sessions with source global_agent and forwarding run-chat events through a local relay.
+---
+
+Global Agent chat uses the same store, session controls, attachment flow, and
+run-chat event names as single chat, but switches the Socket.IO namespace and
+session filtering when the Global Agent route is active.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "title": "Hermes Web UI API",
-    "description": "BFF server API for Hermes Web UI — chat sessions, scheduled jobs, platform channels, model management, skills, memory, logs, file browser, group chat, and terminal.",
-    "version": "0.5.9"
+    "title": "Hermes Studio API",
+    "description": "Hermes Studio API — chat sessions, scheduled jobs, platform channels, model management, skills, memory, logs, file browser, group chat, and terminal.",
+    "version": "0.6.15"
   },
   "servers": [
     {
@@ -12,6 +12,10 @@
     }
   ],
   "tags": [
+    {
+      "name": "Chat Run",
+      "description": "Chat run HTTP and Socket.IO bridge operations"
+    },
     {
       "name": "Codex Auth",
       "description": "OpenAI Codex OAuth"
@@ -95,6 +99,10 @@
     {
       "name": "Auth",
       "description": "Authentication management"
+    },
+    {
+      "name": "API Docs",
+      "description": "OpenAPI route catalog"
     },
     {
       "name": "Proxy",
@@ -378,6 +386,229 @@
           },
           "404": {
             "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/chat-run/runs": {
+      "post": {
+        "tags": [
+          "Chat Run"
+        ],
+        "summary": "Run chat and wait for completion",
+        "description": "Starts a Hermes Studio chat run through the chat-run transport and waits for a terminal result. Use this from HTTP/MCP callers that cannot consume Socket.IO streams.",
+        "operationId": "runChatOnce",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "input"
+                ],
+                "properties": {
+                  "input": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    ],
+                    "description": "User message text or content blocks."
+                  },
+                  "session_id": {
+                    "type": "string",
+                    "description": "Optional session id. Required for CLI/coding-agent style runs and recommended for all chat runs."
+                  },
+                  "profile": {
+                    "type": "string",
+                    "description": "Hermes Studio profile name. Defaults to the authenticated request profile or default."
+                  },
+                  "provider": {
+                    "type": "string",
+                    "description": "Model provider key to use for this run, for example openai, anthropic, deepseek, or a configured custom provider key."
+                  },
+                  "model": {
+                    "type": "string",
+                    "description": "Model id to use for this run, for example gpt-5.1 or deepseek-v4-pro."
+                  },
+                  "model_groups": {
+                    "type": "array",
+                    "description": "Optional provider/model fallback groups.",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "provider",
+                        "models"
+                      ],
+                      "properties": {
+                        "provider": {
+                          "type": "string"
+                        },
+                        "models": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "source": {
+                    "type": "string",
+                    "enum": [
+                      "api_server",
+                      "cli",
+                      "coding_agent",
+                      "global_agent"
+                    ],
+                    "description": "Run backend source. Use cli for Hermes bridge runs, coding_agent for Claude Code/Codex, api_server for direct API-server runs, or global_agent for global-agent sessions."
+                  },
+                  "session_source": {
+                    "type": "string",
+                    "enum": [
+                      "global_agent"
+                    ],
+                    "description": "Marks a coding-agent or bridge session as launched from the global agent."
+                  },
+                  "instructions": {
+                    "type": "string",
+                    "description": "Optional extra run instructions appended after the system prompt."
+                  },
+                  "workspace": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Optional current working directory for the run."
+                  },
+                  "reasoning_effort": {
+                    "type": "string",
+                    "description": "Optional per-run reasoning effort override."
+                  },
+                  "coding_agent_id": {
+                    "type": "string",
+                    "enum": [
+                      "claude-code",
+                      "codex"
+                    ],
+                    "description": "Coding agent id when source is coding_agent."
+                  },
+                  "agent_id": {
+                    "type": "string",
+                    "enum": [
+                      "claude-code",
+                      "codex"
+                    ],
+                    "description": "Alias for coding_agent_id."
+                  },
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "scoped",
+                      "global"
+                    ],
+                    "description": "Coding-agent launch mode."
+                  },
+                  "baseUrl": {
+                    "type": "string",
+                    "description": "Optional provider base URL for coding-agent runs."
+                  },
+                  "apiKey": {
+                    "type": "string",
+                    "description": "Optional provider API key for coding-agent runs."
+                  },
+                  "apiMode": {
+                    "type": "string",
+                    "enum": [
+                      "chat_completions",
+                      "codex_responses",
+                      "anthropic_messages"
+                    ],
+                    "description": "Optional provider wire API mode for coding-agent runs."
+                  },
+                  "timeout_ms": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 1800000,
+                    "default": 300000,
+                    "description": "Maximum time to wait for run.completed or run.failed."
+                  },
+                  "include_events": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Include recorded run events in the HTTP response."
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Run completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "completed"
+                    },
+                    "session_id": {
+                      "type": "string"
+                    },
+                    "run_id": {
+                      "type": "string"
+                    },
+                    "output": {
+                      "type": "string"
+                    },
+                    "reasoning": {
+                      "type": "string"
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "409": {
+            "description": "Run requires approval or clarification"
+          },
+          "500": {
+            "description": "Run failed"
+          },
+          "504": {
+            "description": "Run timed out"
           }
         }
       }
@@ -1070,55 +1301,6 @@
         }
       }
     },
-    "/api/hermes/files/copy": {
-      "post": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Create copy",
-        "description": "POST /api/hermes/files/copy",
-        "operationId": "createCopy",
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/api/hermes/files/delete": {
-      "delete": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Delete delete",
-        "description": "DELETE /api/hermes/files/delete",
-        "operationId": "deleteDelete",
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
     "/api/hermes/files/list": {
       "get": {
         "tags": [
@@ -1145,84 +1327,6 @@
         }
       }
     },
-    "/api/hermes/files/mkdir": {
-      "post": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Create mkdir",
-        "description": "POST /api/hermes/files/mkdir",
-        "operationId": "createMkdir",
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/api/hermes/files/read": {
-      "get": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Get read",
-        "description": "GET /api/hermes/files/read",
-        "operationId": "getRead",
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "description": "Not found"
-          }
-        }
-      }
-    },
-    "/api/hermes/files/rename": {
-      "post": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Create rename",
-        "description": "POST /api/hermes/files/rename",
-        "operationId": "createRename",
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
     "/api/hermes/files/stat": {
       "get": {
         "tags": [
@@ -1245,58 +1349,6 @@
           },
           "404": {
             "description": "Not found"
-          }
-        }
-      }
-    },
-    "/api/hermes/files/upload": {
-      "post": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Create upload",
-        "description": "POST /api/hermes/files/upload",
-        "operationId": "createUpload",
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/api/hermes/files/write": {
-      "put": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Update write",
-        "description": "PUT /api/hermes/files/write",
-        "operationId": "updateWrite",
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }
@@ -2076,6 +2128,32 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/hermes/openapi.json": {
+      "get": {
+        "tags": [
+          "API Docs"
+        ],
+        "summary": "Get openapi.json",
+        "description": "GET /api/hermes/openapi.json",
+        "operationId": "openapi",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
           }
         }
       }
@@ -2973,6 +3051,82 @@
         }
       }
     },
+    "/api/hermes/skills/external-dirs": {
+      "get": {
+        "tags": [
+          "Skills"
+        ],
+        "summary": "Get external-dirs",
+        "description": "GET /api/hermes/skills/external-dirs",
+        "operationId": "listExternalDirs",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Skills"
+        ],
+        "summary": "Update external-dirs",
+        "description": "PUT /api/hermes/skills/external-dirs",
+        "operationId": "updateExternalDirs",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/hermes/skills/import": {
+      "post": {
+        "tags": [
+          "Skills"
+        ],
+        "summary": "Create import",
+        "description": "POST /api/hermes/skills/import",
+        "operationId": "importSkill",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
     "/api/hermes/skills/pin": {
       "put": {
         "tags": [
@@ -3073,6 +3227,29 @@
           },
           "404": {
             "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/hermes/skills/{category}/{skill}": {
+      "delete": {
+        "tags": [
+          "Skills"
+        ],
+        "summary": "Delete :skill",
+        "description": "DELETE /api/hermes/skills/:category/:skill",
+        "operationId": "deleteSkill",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }
@@ -3257,6 +3434,103 @@
             "description": "Not found"
           }
         }
+      },
+      "post": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Create folders",
+        "description": "POST /api/hermes/workspace/folders",
+        "operationId": "createWorkspaceFolder",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Delete folders",
+        "description": "DELETE /api/hermes/workspace/folders",
+        "operationId": "deleteWorkspaceFolder",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/hermes/workspace/folders/rename": {
+      "post": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Create rename",
+        "description": "POST /api/hermes/workspace/folders/rename",
+        "operationId": "renameWorkspaceFolder",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/openapi.json": {
+      "get": {
+        "tags": [
+          "API Docs"
+        ],
+        "summary": "Get openapi.json",
+        "description": "GET /api/openapi.json",
+        "operationId": "openapi",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
       }
     },
     "/health": {
@@ -3402,46 +3676,6 @@
         "summary": "Proxy to upstream Hermes API",
         "description": "Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.",
         "operationId": "proxyHermesDelete",
-        "responses": {
-          "200": {
-            "description": "Proxied response from upstream"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "502": {
-            "description": "Proxy failure"
-          }
-        }
-      }
-    },
-    "/v1/{*any}": {
-      "get": {
-        "tags": [
-          "Proxy"
-        ],
-        "summary": "Proxy to upstream Hermes v1 API",
-        "description": "Forwards /v1/* requests to upstream Hermes gateway. Supports all upstream v1 endpoints.",
-        "operationId": "proxyV1",
-        "responses": {
-          "200": {
-            "description": "Proxied response from upstream"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "502": {
-            "description": "Proxy failure"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Proxy"
-        ],
-        "summary": "Proxy to upstream Hermes v1 API",
-        "description": "Forwards /v1/* requests to upstream Hermes gateway. Supports all upstream v1 endpoints.",
-        "operationId": "proxyV1Post",
         "responses": {
           "200": {
             "description": "Proxied response from upstream"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13,6 +13,10 @@
   ],
   "tags": [
     {
+      "name": "Anthropic Auth",
+      "description": "Anthropic OAuth"
+    },
+    {
       "name": "Chat Run",
       "description": "Chat run HTTP and Socket.IO bridge operations"
     },
@@ -41,12 +45,28 @@
       "description": "Hermes file browser"
     },
     {
+      "name": "Gemini Auth",
+      "description": "Google Gemini OAuth"
+    },
+    {
       "name": "Group Chat",
       "description": "Group chat management"
     },
     {
+      "name": "Kanban",
+      "description": "Kanban board and task management"
+    },
+    {
       "name": "Logs",
       "description": "Log file access"
+    },
+    {
+      "name": "MCP",
+      "description": "MCP server and tool management"
+    },
+    {
+      "name": "Media",
+      "description": "Media generation endpoints"
     },
     {
       "name": "Memory",
@@ -61,12 +81,24 @@
       "description": "Nous Research OAuth"
     },
     {
+      "name": "Performance",
+      "description": "Runtime performance monitoring"
+    },
+    {
+      "name": "Plugins",
+      "description": "Plugin browsing and management"
+    },
+    {
       "name": "Profiles",
       "description": "Hermes profile management"
     },
     {
       "name": "Providers",
       "description": "Model provider management"
+    },
+    {
+      "name": "Runtime Versions",
+      "description": "Runtime and Web UI version management"
     },
     {
       "name": "Sessions",
@@ -77,8 +109,24 @@
       "description": "Skill browsing and management"
     },
     {
+      "name": "STT",
+      "description": "Speech-to-text transcription and settings"
+    },
+    {
+      "name": "TTS",
+      "description": "Text-to-speech generation and settings"
+    },
+    {
       "name": "Weixin",
       "description": "WeChat QR code login"
+    },
+    {
+      "name": "Write Gate",
+      "description": "Hermes Agent write approval review"
+    },
+    {
+      "name": "xAI Auth",
+      "description": "xAI OAuth"
     },
     {
       "name": "Health",
@@ -101,12 +149,16 @@
       "description": "Authentication management"
     },
     {
-      "name": "API Docs",
-      "description": "OpenAPI route catalog"
+      "name": "Devices",
+      "description": "Device pairing and LAN peer operations"
     },
     {
-      "name": "Proxy",
-      "description": "Gateway proxy to upstream Hermes API"
+      "name": "Coding Agents",
+      "description": "Coding agent installation, config, and runs"
+    },
+    {
+      "name": "API Docs",
+      "description": "OpenAPI route catalog"
     },
     {
       "name": "Terminal",
@@ -161,6 +213,22 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "avatar": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -187,6 +255,28 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "currentPassword": {
+                    "type": "string"
+                  },
+                  "newPassword": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "currentPassword",
+                  "newPassword"
+                ]
+              }
+            }
+          }
         }
       }
     },
@@ -212,6 +302,28 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "currentPassword": {
+                    "type": "string"
+                  },
+                  "newUsername": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "currentPassword",
+                  "newUsername"
+                ]
+              }
+            }
           }
         }
       }
@@ -260,7 +372,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "ip",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/auth/login": {
@@ -285,6 +407,28 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "type": "string"
+                  },
+                  "username": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "password",
+                  "username"
+                ]
+              }
+            }
           }
         }
       }
@@ -390,6 +534,191 @@
         }
       }
     },
+    "/api/auth/users": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Get users",
+        "description": "GET /api/auth/users",
+        "operationId": "listManagedUsers",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Create users",
+        "description": "POST /api/auth/users",
+        "operationId": "createManagedUser",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "defaultProfile": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  },
+                  "profiles": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "role": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "status": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "username": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/users/{id}": {
+      "put": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Update :id",
+        "description": "PUT /api/auth/users/:id",
+        "operationId": "updateManagedUser",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "defaultProfile": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  },
+                  "profiles": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "role": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "status": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "username": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Delete :id",
+        "description": "DELETE /api/auth/users/:id",
+        "operationId": "deleteManagedUser",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ]
+      }
+    },
     "/api/chat-run/runs": {
       "post": {
         "tags": [
@@ -430,7 +759,7 @@
                   },
                   "session_id": {
                     "type": "string",
-                    "description": "Optional session id. Required for CLI/coding-agent style runs and recommended for all chat runs."
+                    "description": "Optional session id. For cli/default chat runs, omit this to create a new session automatically. Provide an existing session id to continue that session. Coding-agent runs still require a session id."
                   },
                   "profile": {
                     "type": "string",
@@ -469,12 +798,11 @@
                   "source": {
                     "type": "string",
                     "enum": [
-                      "api_server",
                       "cli",
                       "coding_agent",
                       "global_agent"
                     ],
-                    "description": "Run backend source. Use cli for Hermes bridge runs, coding_agent for Claude Code/Codex, api_server for direct API-server runs, or global_agent for global-agent sessions."
+                    "description": "Run backend source. Use cli for Hermes bridge runs, coding_agent for Claude Code/Codex, or global_agent for global-agent sessions. Omit source for normal Hermes chat runs; do not use the legacy api_server source."
                   },
                   "session_source": {
                     "type": "string",
@@ -613,6 +941,502 @@
         }
       }
     },
+    "/api/coding-agents": {
+      "get": {
+        "tags": [
+          "Coding Agents"
+        ],
+        "summary": "Get coding-agents",
+        "description": "GET /api/coding-agents",
+        "operationId": "status",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/coding-agents/runs/{sessionId}": {
+      "delete": {
+        "tags": [
+          "Coding Agents"
+        ],
+        "summary": "Delete :sessionId",
+        "description": "DELETE /api/coding-agents/runs/:sessionId",
+        "operationId": "stopRun",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/coding-agents/runs/{sessionId}/input": {
+      "post": {
+        "tags": [
+          "Coding Agents"
+        ],
+        "summary": "Create input",
+        "description": "POST /api/coding-agents/runs/:sessionId/input",
+        "operationId": "sendRunInput",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "input": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/coding-agents/{id}": {
+      "delete": {
+        "tags": [
+          "Coding Agents"
+        ],
+        "summary": "Delete :id",
+        "description": "DELETE /api/coding-agents/:id",
+        "operationId": "remove",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/coding-agents/{id}/config-files/{key}": {
+      "get": {
+        "tags": [
+          "Coding Agents"
+        ],
+        "summary": "Get :key",
+        "description": "GET /api/coding-agents/:id/config-files/:key",
+        "operationId": "readConfigFile",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Coding Agents"
+        ],
+        "summary": "Update :key",
+        "description": "PUT /api/coding-agents/:id/config-files/:key",
+        "operationId": "writeConfigFile",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/coding-agents/{id}/install": {
+      "post": {
+        "tags": [
+          "Coding Agents"
+        ],
+        "summary": "Create install",
+        "description": "POST /api/coding-agents/:id/install",
+        "operationId": "install",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/coding-agents/{id}/launch/native": {
+      "post": {
+        "tags": [
+          "Coding Agents"
+        ],
+        "summary": "Create native",
+        "description": "POST /api/coding-agents/:id/launch/native",
+        "operationId": "nativeLaunch",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "apiKey": {
+                    "type": "string"
+                  },
+                  "apiMode": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "baseUrl": {
+                    "type": "string"
+                  },
+                  "mode": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "profile": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/coding-agents/{id}/launch/prepare": {
+      "post": {
+        "tags": [
+          "Coding Agents"
+        ],
+        "summary": "Create prepare",
+        "description": "POST /api/coding-agents/:id/launch/prepare",
+        "operationId": "prepareLaunch",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "apiKey": {
+                    "type": "string"
+                  },
+                  "apiMode": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "baseUrl": {
+                    "type": "string"
+                  },
+                  "mode": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "profile": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/coding-agents/{id}/runs": {
+      "post": {
+        "tags": [
+          "Coding Agents"
+        ],
+        "summary": "Create runs",
+        "description": "POST /api/coding-agents/:id/runs",
+        "operationId": "startRun",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "apiKey": {
+                    "type": "string"
+                  },
+                  "apiMode": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "baseUrl": {
+                    "type": "string"
+                  },
+                  "mode": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "profile": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "sessionId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/cron-history": {
       "get": {
         "tags": [
@@ -636,7 +1460,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/cron-history/{jobId}/{fileName}": {
@@ -661,6 +1495,1132 @@
           },
           "404": {
             "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/devices": {
+      "get": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Get devices",
+        "description": "GET /api/devices",
+        "operationId": "listDevices",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/devices/link-info": {
+      "get": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Get link-info",
+        "description": "GET /api/devices/link-info",
+        "operationId": "deviceLinkInfoController",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/devices/link-request": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create link-request",
+        "description": "POST /api/devices/link-request",
+        "operationId": "requestDeviceLinkController",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nonce": {
+                    "type": "string"
+                  },
+                  "signature": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/devices/link-status": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create link-status",
+        "description": "POST /api/devices/link-status",
+        "operationId": "requestDeviceLinkStatusController",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "device_id": {
+                    "type": "string"
+                  },
+                  "device_public_key": {
+                    "type": "string"
+                  },
+                  "nonce": {
+                    "type": "string"
+                  },
+                  "signature": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/devices/manual-request": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create manual-request",
+        "description": "POST /api/devices/manual-request",
+        "operationId": "requestManualDevicePairing",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/devices/pairing-link": {
+      "get": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Get pairing-link",
+        "description": "GET /api/devices/pairing-link",
+        "operationId": "getDevicePairingLink",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/devices/peer-connections": {
+      "get": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Get peer-connections",
+        "description": "GET /api/devices/peer-connections",
+        "operationId": "listPeerConnections",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/devices/peer-connections/{connectionId}/disconnect": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create disconnect",
+        "description": "POST /api/devices/peer-connections/:connectionId/disconnect",
+        "operationId": "disconnectPeerDevice",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "connectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/devices/peer-connections/{connectionId}/download": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create download",
+        "description": "POST /api/devices/peer-connections/:connectionId/download",
+        "operationId": "downloadPeerFile",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "connectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/devices/peer-connections/{connectionId}/exec": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create exec",
+        "description": "POST /api/devices/peer-connections/:connectionId/exec",
+        "operationId": "execPeerCommand",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "connectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "args": {
+                    "type": "string"
+                  },
+                  "cwd": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/devices/peer-connections/{connectionId}/terminal": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create terminal",
+        "description": "POST /api/devices/peer-connections/:connectionId/terminal",
+        "operationId": "createPeerTerminal",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "connectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "shell": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/devices/peer-connections/{connectionId}/terminal/{terminalId}/close": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create close",
+        "description": "POST /api/devices/peer-connections/:connectionId/terminal/:terminalId/close",
+        "operationId": "closePeerTerminal",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "connectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "terminalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/devices/peer-connections/{connectionId}/terminal/{terminalId}/input": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create input",
+        "description": "POST /api/devices/peer-connections/:connectionId/terminal/:terminalId/input",
+        "operationId": "writePeerTerminal",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "connectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "terminalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/devices/peer-connections/{connectionId}/terminal/{terminalId}/read": {
+      "get": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Get read",
+        "description": "GET /api/devices/peer-connections/:connectionId/terminal/:terminalId/read",
+        "operationId": "readPeerTerminal",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "connectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "terminalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/devices/peer-connections/{connectionId}/terminal/{terminalId}/resize": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create resize",
+        "description": "POST /api/devices/peer-connections/:connectionId/terminal/:terminalId/resize",
+        "operationId": "resizePeerTerminal",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "connectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "terminalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/devices/peer-connections/{connectionId}/terminals": {
+      "get": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Get terminals",
+        "description": "GET /api/devices/peer-connections/:connectionId/terminals",
+        "operationId": "listPeerTerminals",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "connectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/devices/peer-connections/{connectionId}/upload": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create upload",
+        "description": "POST /api/devices/peer-connections/:connectionId/upload",
+        "operationId": "uploadPeerFile",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "connectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/devices/scan": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create scan",
+        "description": "POST /api/devices/scan",
+        "operationId": "scanDevices",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/devices/{id}/approve": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create approve",
+        "description": "POST /api/devices/:id/approve",
+        "operationId": "approveDevice",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/devices/{id}/block": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create block",
+        "description": "POST /api/devices/:id/block",
+        "operationId": "blockDevice",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/devices/{id}/connect": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create connect",
+        "description": "POST /api/devices/:id/connect",
+        "operationId": "connectPeerDevice",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/devices/{id}/reject": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create reject",
+        "description": "POST /api/devices/:id/reject",
+        "operationId": "rejectDevice",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/devices/{id}/request": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create request",
+        "description": "POST /api/devices/:id/request",
+        "operationId": "requestDevicePairing",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pairing_code": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/devices/{id}/request-history": {
+      "delete": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Delete request-history",
+        "description": "DELETE /api/devices/:id/request-history",
+        "operationId": "deleteDeviceRequestHistory",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/devices/{id}/unblock": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Create unblock",
+        "description": "POST /api/devices/:id/unblock",
+        "operationId": "unblockDevice",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/auth/anthropic/start": {
+      "post": {
+        "tags": [
+          "Anthropic Auth"
+        ],
+        "summary": "Create start",
+        "description": "POST /api/hermes/auth/anthropic/start",
+        "operationId": "start",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/hermes/auth/anthropic/status": {
+      "get": {
+        "tags": [
+          "Anthropic Auth"
+        ],
+        "summary": "Get status",
+        "description": "GET /api/hermes/auth/anthropic/status",
+        "operationId": "status",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/hermes/auth/anthropic/submit/{sessionId}": {
+      "post": {
+        "tags": [
+          "Anthropic Auth"
+        ],
+        "summary": "Create :sessionId",
+        "description": "POST /api/hermes/auth/anthropic/submit/:sessionId",
+        "operationId": "submit",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code"
+                ]
+              }
+            }
           }
         }
       }
@@ -688,7 +2648,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/auth/codex/start": {
@@ -844,7 +2814,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/auth/copilot/start": {
@@ -873,6 +2853,94 @@
         }
       }
     },
+    "/api/hermes/auth/gemini/poll/{sessionId}": {
+      "get": {
+        "tags": [
+          "Gemini Auth"
+        ],
+        "summary": "Get :sessionId",
+        "description": "GET /api/hermes/auth/gemini/poll/:sessionId",
+        "operationId": "poll",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/auth/gemini/start": {
+      "post": {
+        "tags": [
+          "Gemini Auth"
+        ],
+        "summary": "Create start",
+        "description": "POST /api/hermes/auth/gemini/start",
+        "operationId": "start",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/hermes/auth/gemini/status": {
+      "get": {
+        "tags": [
+          "Gemini Auth"
+        ],
+        "summary": "Get status",
+        "description": "GET /api/hermes/auth/gemini/status",
+        "operationId": "status",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/api/hermes/auth/nous/poll/{sessionId}": {
       "get": {
         "tags": [
@@ -896,7 +2964,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/auth/nous/start": {
@@ -932,6 +3010,94 @@
         ],
         "summary": "Get status",
         "description": "GET /api/hermes/auth/nous/status",
+        "operationId": "status",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/hermes/auth/xai/poll/{sessionId}": {
+      "get": {
+        "tags": [
+          "xAI Auth"
+        ],
+        "summary": "Get :sessionId",
+        "description": "GET /api/hermes/auth/xai/poll/:sessionId",
+        "operationId": "poll",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/auth/xai/start": {
+      "post": {
+        "tags": [
+          "xAI Auth"
+        ],
+        "summary": "Create start",
+        "description": "POST /api/hermes/auth/xai/start",
+        "operationId": "start",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/hermes/auth/xai/status": {
+      "get": {
+        "tags": [
+          "xAI Auth"
+        ],
+        "summary": "Get status",
+        "description": "GET /api/hermes/auth/xai/status",
         "operationId": "status",
         "security": [
           {
@@ -1000,7 +3166,25 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "section",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sections",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "put": {
         "tags": [
@@ -1023,6 +3207,32 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "restart": {
+                    "type": "boolean"
+                  },
+                  "section": {
+                    "type": "string"
+                  },
+                  "values": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "section",
+                  "values"
+                ]
+              }
+            }
           }
         }
       }
@@ -1074,6 +3284,22 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "auxiliary": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1100,6 +3326,29 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "platform": {
+                    "type": "string"
+                  },
+                  "values": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "platform",
+                  "values"
+                ]
+              }
+            }
+          }
         }
       }
     },
@@ -1125,6 +3374,27 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "default": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "default"
+                ]
+              }
+            }
           }
         }
       }
@@ -1178,6 +3448,43 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "api_key": {
+                    "type": "string"
+                  },
+                  "base_url": {
+                    "type": "string"
+                  },
+                  "context_length": {
+                    "type": "number"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "providerKey": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "api_key",
+                  "base_url",
+                  "model",
+                  "name"
+                ]
+              }
+            }
+          }
         }
       }
     },
@@ -1204,6 +3511,40 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "parameters": [
+          {
+            "name": "poolKey",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "api_key": {
+                    "type": "string"
+                  },
+                  "base_url": {
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
         }
       },
       "delete": {
@@ -1225,7 +3566,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "poolKey",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/custom-model": {
@@ -1251,6 +3602,18 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            }
+          }
         }
       },
       "delete": {
@@ -1272,7 +3635,25 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/download": {
@@ -1297,6 +3678,95 @@
           },
           "404": {
             "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/files/copy": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Create copy",
+        "description": "POST /api/hermes/files/copy",
+        "operationId": "createCopy",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "destPath": {
+                    "type": "string"
+                  },
+                  "srcPath": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "destPath",
+                  "srcPath"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/files/delete": {
+      "delete": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Delete delete",
+        "description": "DELETE /api/hermes/files/delete",
+        "operationId": "deleteDelete",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }
@@ -1324,6 +3794,144 @@
           "404": {
             "description": "Not found"
           }
+        },
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/files/mkdir": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Create mkdir",
+        "description": "POST /api/hermes/files/mkdir",
+        "operationId": "createMkdir",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/files/read": {
+      "get": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Get read",
+        "description": "GET /api/hermes/files/read",
+        "operationId": "getRead",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/files/rename": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Create rename",
+        "description": "POST /api/hermes/files/rename",
+        "operationId": "createRename",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "newPath": {
+                    "type": "string"
+                  },
+                  "oldPath": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "newPath",
+                  "oldPath"
+                ]
+              }
+            }
+          }
         }
       }
     },
@@ -1350,6 +3958,99 @@
           "404": {
             "description": "Not found"
           }
+        },
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/files/upload": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Create upload",
+        "description": "POST /api/hermes/files/upload",
+        "operationId": "createUpload",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/files/write": {
+      "put": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Update write",
+        "description": "PUT /api/hermes/files/write",
+        "operationId": "updateWrite",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            }
+          }
         }
       }
     },
@@ -1375,6 +4076,34 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "agents": {
+                    "type": "boolean"
+                  },
+                  "compression": {
+                    "type": "number"
+                  },
+                  "inviteCode": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "inviteCode",
+                  "name"
+                ]
+              }
+            }
           }
         }
       },
@@ -1426,7 +4155,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/group-chat/rooms/{roomId}": {
@@ -1452,7 +4191,33 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ]
       },
       "delete": {
         "tags": [
@@ -1473,7 +4238,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/group-chat/rooms/{roomId}/agents": {
@@ -1499,6 +4274,43 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "invited": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "profile": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "profile"
+                ]
+              }
+            }
+          }
         }
       },
       "get": {
@@ -1523,7 +4335,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/group-chat/rooms/{roomId}/agents/{agentId}": {
@@ -1546,7 +4368,25 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/group-chat/rooms/{roomId}/clear-context": {
@@ -1572,7 +4412,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/group-chat/rooms/{roomId}/clone": {
@@ -1597,6 +4447,34 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "inviteCode": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -1624,7 +4502,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/group-chat/rooms/{roomId}/config": {
@@ -1649,6 +4537,37 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "maxHistoryTokens": {
+                    "type": "number"
+                  },
+                  "tailMessageCount": {
+                    "type": "number"
+                  },
+                  "triggerTokens": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -1676,6 +4595,34 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "inviteCode": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "inviteCode"
+                ]
+              }
+            }
+          }
         }
       }
     },
@@ -1702,7 +4649,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "include_disabled",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ]
       },
       "post": {
         "tags": [
@@ -1752,7 +4709,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "patch": {
         "tags": [
@@ -1776,7 +4743,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "delete": {
         "tags": [
@@ -1797,7 +4774,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/jobs/{id}/pause": {
@@ -1823,7 +4810,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/jobs/{id}/resume": {
@@ -1849,7 +4846,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/jobs/{id}/run": {
@@ -1874,6 +4881,1366 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/kanban": {
+      "get": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "List kanban",
+        "description": "GET /api/hermes/kanban",
+        "operationId": "list",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "assignee",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeArchived",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tenant",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Create kanban",
+        "description": "POST /api/hermes/kanban",
+        "operationId": "create",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "assignee": {
+                    "type": "string"
+                  },
+                  "body": {
+                    "type": "string"
+                  },
+                  "branch": {
+                    "type": "string"
+                  },
+                  "goalMaxTurns": {
+                    "type": "integer"
+                  },
+                  "goalMode": {
+                    "type": "boolean"
+                  },
+                  "maxRetries": {
+                    "type": "integer"
+                  },
+                  "maxRuntime": {
+                    "type": "string"
+                  },
+                  "priority": {
+                    "type": "integer"
+                  },
+                  "skills": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "tenant": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "triage": {
+                    "type": "boolean"
+                  },
+                  "workspace": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/kanban/artifact": {
+      "get": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Get artifact",
+        "description": "GET /api/hermes/kanban/artifact",
+        "operationId": "readArtifact",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/kanban/assignees": {
+      "get": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Get assignees",
+        "description": "GET /api/hermes/kanban/assignees",
+        "operationId": "assignees",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/kanban/boards": {
+      "get": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Get boards",
+        "description": "GET /api/hermes/kanban/boards",
+        "operationId": "listBoards",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "includeArchived",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Create boards",
+        "description": "POST /api/hermes/kanban/boards",
+        "operationId": "createBoard",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "color": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "slug": {
+                    "type": "string"
+                  },
+                  "switchCurrent": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "slug"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/kanban/boards/{slug}": {
+      "delete": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Delete :slug",
+        "description": "DELETE /api/hermes/kanban/boards/:slug",
+        "operationId": "archiveBoard",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/kanban/capabilities": {
+      "get": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Get capabilities",
+        "description": "GET /api/hermes/kanban/capabilities",
+        "operationId": "capabilities",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/hermes/kanban/complete": {
+      "post": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Create complete",
+        "description": "POST /api/hermes/kanban/complete",
+        "operationId": "complete",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "summary": {
+                    "type": "string"
+                  },
+                  "task_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "task_ids"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/kanban/diagnostics": {
+      "get": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Get diagnostics",
+        "description": "GET /api/hermes/kanban/diagnostics",
+        "operationId": "diagnostics",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "severity",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "warning",
+                "error",
+                "critical"
+              ]
+            }
+          },
+          {
+            "name": "task",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/kanban/dispatch": {
+      "post": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Create dispatch",
+        "description": "POST /api/hermes/kanban/dispatch",
+        "operationId": "dispatch",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dryRun": {
+                    "type": "boolean"
+                  },
+                  "failureLimit": {
+                    "type": "integer"
+                  },
+                  "max": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/kanban/links": {
+      "post": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Create links",
+        "description": "POST /api/hermes/kanban/links",
+        "operationId": "linkTasks",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "child_id": {
+                    "type": "string"
+                  },
+                  "parent_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "child_id",
+                  "parent_id"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Delete links",
+        "description": "DELETE /api/hermes/kanban/links",
+        "operationId": "unlinkTasks",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "child_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "parent_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/kanban/search-sessions": {
+      "get": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Get search-sessions",
+        "description": "GET /api/hermes/kanban/search-sessions",
+        "operationId": "searchSessions",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "profile",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "task_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/kanban/stats": {
+      "get": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Get stats",
+        "description": "GET /api/hermes/kanban/stats",
+        "operationId": "stats",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/kanban/tasks/bulk": {
+      "post": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Create bulk",
+        "description": "POST /api/hermes/kanban/tasks/bulk",
+        "operationId": "bulkUpdateTasks",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "archive": {
+                    "type": "boolean"
+                  },
+                  "assignee": {
+                    "type": "string"
+                  },
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "summary": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "ids"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/kanban/unblock": {
+      "post": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Create unblock",
+        "description": "POST /api/hermes/kanban/unblock",
+        "operationId": "unblock",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "task_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "task_ids"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/kanban/{id}": {
+      "get": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Get :id",
+        "description": "GET /api/hermes/kanban/:id",
+        "operationId": "get",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/kanban/{id}/assign": {
+      "post": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Create assign",
+        "description": "POST /api/hermes/kanban/:id/assign",
+        "operationId": "assign",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "profile"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/kanban/{id}/block": {
+      "post": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Create block",
+        "description": "POST /api/hermes/kanban/:id/block",
+        "operationId": "block",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "reason"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/kanban/{id}/comments": {
+      "post": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Create comments",
+        "description": "POST /api/hermes/kanban/:id/comments",
+        "operationId": "addComment",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "author": {
+                    "type": "string"
+                  },
+                  "body": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "body"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/kanban/{id}/log": {
+      "get": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Get log",
+        "description": "GET /api/hermes/kanban/:id/log",
+        "operationId": "taskLog",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tail",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/kanban/{id}/reassign": {
+      "post": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Create reassign",
+        "description": "POST /api/hermes/kanban/:id/reassign",
+        "operationId": "reassign",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "profile": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "reclaim": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "profile"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/kanban/{id}/reclaim": {
+      "post": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Create reclaim",
+        "description": "POST /api/hermes/kanban/:id/reclaim",
+        "operationId": "reclaim",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/kanban/{id}/specify": {
+      "post": {
+        "tags": [
+          "Kanban"
+        ],
+        "summary": "Create specify",
+        "description": "POST /api/hermes/kanban/:id/specify",
+        "operationId": "specify",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "board",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "author": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -1927,6 +6294,406 @@
           "404": {
             "description": "Not found"
           }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lines",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "session",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/mcp/reload": {
+      "post": {
+        "tags": [
+          "MCP"
+        ],
+        "summary": "Create reload",
+        "description": "POST /api/hermes/mcp/reload",
+        "operationId": "reloadMcp",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "server",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/mcp/servers": {
+      "get": {
+        "tags": [
+          "MCP"
+        ],
+        "summary": "Get servers",
+        "description": "GET /api/hermes/mcp/servers",
+        "operationId": "listServers",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "MCP"
+        ],
+        "summary": "Create servers",
+        "description": "POST /api/hermes/mcp/servers",
+        "operationId": "addServer",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/mcp/servers/{name}": {
+      "patch": {
+        "tags": [
+          "MCP"
+        ],
+        "summary": "Update :name",
+        "description": "PATCH /api/hermes/mcp/servers/:name",
+        "operationId": "updateServer",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "MCP"
+        ],
+        "summary": "Delete :name",
+        "description": "DELETE /api/hermes/mcp/servers/:name",
+        "operationId": "removeServer",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/mcp/servers/{name}/test": {
+      "post": {
+        "tags": [
+          "MCP"
+        ],
+        "summary": "Create test",
+        "description": "POST /api/hermes/mcp/servers/:name/test",
+        "operationId": "testServer",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/mcp/tools": {
+      "get": {
+        "tags": [
+          "MCP"
+        ],
+        "summary": "Get tools",
+        "description": "GET /api/hermes/mcp/tools",
+        "operationId": "listTools",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "raw",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "enum": [
+                "1",
+                "true"
+              ]
+            }
+          },
+          {
+            "name": "server",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/media/apikey-image-generate": {
+      "post": {
+        "tags": [
+          "Media"
+        ],
+        "summary": "Create apikey-image-generate",
+        "description": "POST /api/hermes/media/apikey-image-generate",
+        "operationId": "apiKeyImageGenerate",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string"
+                  },
+                  "output_path": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/media/grok-image-to-video": {
+      "post": {
+        "tags": [
+          "Media"
+        ],
+        "summary": "Create grok-image-to-video",
+        "description": "POST /api/hermes/media/grok-image-to-video",
+        "operationId": "grokImageToVideo",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "duration": {
+                    "type": "string"
+                  },
+                  "output_path": {
+                    "type": "string"
+                  },
+                  "prompt": {
+                    "type": "string"
+                  },
+                  "timeout_ms": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
         }
       }
     },
@@ -1977,6 +6744,28 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "section": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content",
+                  "section"
+                ]
+              }
+            }
+          }
         }
       }
     },
@@ -2002,6 +6791,27 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "alias": {
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -2029,7 +6839,25 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "put": {
         "tags": [
@@ -2052,6 +6880,48 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "context_limit": {
+                    "type": "number"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "context_limit"
+                ]
+              }
+            }
           }
         }
       }
@@ -2079,7 +6949,41 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "model",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "put": {
         "tags": [
@@ -2102,6 +7006,64 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "model",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "context_limit": {
+                    "type": "number"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "context_limit"
+                ]
+              }
+            }
           }
         }
       }
@@ -2129,6 +7091,30 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string"
+                  },
+                  "models": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "provider": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -2140,6 +7126,58 @@
         "summary": "Get openapi.json",
         "description": "GET /api/hermes/openapi.json",
         "operationId": "openapi",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/hermes/performance/runtime": {
+      "get": {
+        "tags": [
+          "Performance"
+        ],
+        "summary": "Get runtime",
+        "description": "GET /api/hermes/performance/runtime",
+        "operationId": "runtime",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/hermes/plugins": {
+      "get": {
+        "tags": [
+          "Plugins"
+        ],
+        "summary": "List plugins",
+        "description": "GET /api/hermes/plugins",
+        "operationId": "list",
         "security": [
           {
             "BearerAuth": []
@@ -2205,6 +7243,71 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "clone": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/profiles/active": {
+      "put": {
+        "tags": [
+          "Profiles"
+        ],
+        "summary": "Update active",
+        "description": "PUT /api/hermes/profiles/active",
+        "operationId": "switchProfile",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
         }
       }
     },
@@ -2257,7 +7360,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "refresh",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/profiles/{name}": {
@@ -2283,7 +7396,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "delete": {
         "tags": [
@@ -2304,7 +7427,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/profiles/{name}/avatar": {
@@ -2330,6 +7463,37 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dataUrl": {
+                    "type": "string"
+                  },
+                  "seed": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
         }
       },
       "delete": {
@@ -2351,7 +7515,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/profiles/{name}/export": {
@@ -2377,7 +7551,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/profiles/{name}/gateway/restart": {
@@ -2403,7 +7587,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/profiles/{name}/rename": {
@@ -2428,6 +7622,34 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "new_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "new_name"
+                ]
+              }
+            }
           }
         }
       }
@@ -2455,7 +7677,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/profiles/{name}/runtime-status": {
@@ -2481,7 +7713,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/provider-models": {
@@ -2506,6 +7748,36 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "api_key": {
+                    "type": "string"
+                  },
+                  "base_url": {
+                    "type": "string"
+                  },
+                  "freeOnly": {
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "update_cache": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -2536,6 +7808,336 @@
         }
       }
     },
+    "/api/hermes/runtime-versions": {
+      "get": {
+        "tags": [
+          "Runtime Versions"
+        ],
+        "summary": "Get runtime-versions",
+        "description": "GET /api/hermes/runtime-versions",
+        "operationId": "status",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/hermes/runtime-versions/active-runtime": {
+      "post": {
+        "tags": [
+          "Runtime Versions"
+        ],
+        "summary": "Create active-runtime",
+        "description": "POST /api/hermes/runtime-versions/active-runtime",
+        "operationId": "activateRuntime",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "version": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/runtime-versions/active-webui": {
+      "post": {
+        "tags": [
+          "Runtime Versions"
+        ],
+        "summary": "Create active-webui",
+        "description": "POST /api/hermes/runtime-versions/active-webui",
+        "operationId": "activateWebUi",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "version": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/runtime-versions/jobs": {
+      "get": {
+        "tags": [
+          "Runtime Versions"
+        ],
+        "summary": "Get jobs",
+        "description": "GET /api/hermes/runtime-versions/jobs",
+        "operationId": "jobs",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/hermes/runtime-versions/jobs/{id}": {
+      "get": {
+        "tags": [
+          "Runtime Versions"
+        ],
+        "summary": "Get :id",
+        "description": "GET /api/hermes/runtime-versions/jobs/:id",
+        "operationId": "job",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/runtime-versions/runtime/download": {
+      "post": {
+        "tags": [
+          "Runtime Versions"
+        ],
+        "summary": "Create download",
+        "description": "POST /api/hermes/runtime-versions/runtime/download",
+        "operationId": "downloadRuntime",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "version": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/runtime-versions/runtime/{version}": {
+      "delete": {
+        "tags": [
+          "Runtime Versions"
+        ],
+        "summary": "Delete :version",
+        "description": "DELETE /api/hermes/runtime-versions/runtime/:version",
+        "operationId": "deleteRuntime",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/runtime-versions/webui/download": {
+      "post": {
+        "tags": [
+          "Runtime Versions"
+        ],
+        "summary": "Create download",
+        "description": "POST /api/hermes/runtime-versions/webui/download",
+        "operationId": "downloadWebUi",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "version": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/runtime-versions/webui/{version}": {
+      "delete": {
+        "tags": [
+          "Runtime Versions"
+        ],
+        "summary": "Delete :version",
+        "description": "DELETE /api/hermes/runtime-versions/webui/:version",
+        "operationId": "deleteWebUi",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
     "/api/hermes/search/sessions": {
       "get": {
         "tags": [
@@ -2559,7 +8161,36 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "string"
+              ]
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions": {
@@ -2585,7 +8216,25 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions/batch-delete": {
@@ -2610,6 +8259,30 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "sessions": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "ids"
+                ]
+              }
+            }
           }
         }
       }
@@ -2637,7 +8310,31 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "string"
+              ]
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "string"
+              ]
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions/conversations": {
@@ -2663,7 +8360,25 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions/conversations/{id}/messages": {
@@ -2689,7 +8404,28 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "humanOnly",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "enum": [
+                "0"
+              ]
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions/conversations/{id}/messages/paginated": {
@@ -2715,7 +8451,33 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions/hermes": {
@@ -2741,7 +8503,25 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions/hermes/{id}": {
@@ -2767,7 +8547,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions/hermes/{id}/import": {
@@ -2793,7 +8583,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions/search": {
@@ -2819,7 +8619,36 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "string"
+              ]
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions/usage": {
@@ -2845,7 +8674,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions/{id}": {
@@ -2871,7 +8710,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "delete": {
         "tags": [
@@ -2892,7 +8741,17 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions/{id}/export": {
@@ -2918,7 +8777,40 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ext",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json",
+                "txt"
+              ]
+            }
+          },
+          {
+            "name": "mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "compressed"
+              ]
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions/{id}/model": {
@@ -2943,6 +8835,37 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "model": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "model"
+                ]
+              }
+            }
           }
         }
       }
@@ -2970,6 +8893,34 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title"
+                ]
+              }
+            }
+          }
         }
       }
     },
@@ -2996,7 +8947,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/sessions/{id}/workspace": {
@@ -3021,6 +8982,31 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "workspace": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -3098,6 +9084,18 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            }
+          }
         }
       }
     },
@@ -3150,6 +9148,27 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "pinned": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
         }
       }
     },
@@ -3175,6 +9194,27 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
           }
         }
       }
@@ -3202,33 +9242,17 @@
           "404": {
             "description": "Not found"
           }
-        }
-      }
-    },
-    "/api/hermes/skills/{*path}": {
-      "get": {
-        "tags": [
-          "Skills"
-        ],
-        "summary": "Get skills by *path",
-        "description": "GET /api/hermes/skills/{*path}",
-        "operationId": "readFile_",
-        "security": [
+        },
+        "parameters": [
           {
-            "BearerAuth": []
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "description": "Not found"
-          }
-        }
+        ]
       }
     },
     "/api/hermes/skills/{category}/{skill}": {
@@ -3251,7 +9275,25 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "category",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "skill",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/skills/{category}/{skill}/files": {
@@ -3276,6 +9318,564 @@
           },
           "404": {
             "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "category",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "skill",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/skills/{path}": {
+      "get": {
+        "tags": [
+          "Skills"
+        ],
+        "summary": "Get skills by *path",
+        "description": "GET /api/hermes/skills/{*path}",
+        "operationId": "readFile_",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/stt/settings": {
+      "get": {
+        "tags": [
+          "STT"
+        ],
+        "summary": "Get settings",
+        "description": "GET /api/hermes/stt/settings",
+        "operationId": "listSettings",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/hermes/stt/settings/active": {
+      "put": {
+        "tags": [
+          "STT"
+        ],
+        "summary": "Update active",
+        "description": "PUT /api/hermes/stt/settings/active",
+        "operationId": "saveActiveProvider",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "provider": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/stt/settings/{provider}": {
+      "put": {
+        "tags": [
+          "STT"
+        ],
+        "summary": "Update :provider",
+        "description": "PUT /api/hermes/stt/settings/:provider",
+        "operationId": "saveSettings",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "activeProvider": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "secrets": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "settings": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/stt/settings/{provider}/base-url-preset": {
+      "delete": {
+        "tags": [
+          "STT"
+        ],
+        "summary": "Delete base-url-preset",
+        "description": "DELETE /api/hermes/stt/settings/:provider/base-url-preset",
+        "operationId": "deleteBaseUrlPreset",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "url",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "string"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/stt/settings/{provider}/secret/{secretName}": {
+      "delete": {
+        "tags": [
+          "STT"
+        ],
+        "summary": "Delete :secretName",
+        "description": "DELETE /api/hermes/stt/settings/:provider/secret/:secretName",
+        "operationId": "deleteSecret",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secretName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/stt/transcribe": {
+      "post": {
+        "tags": [
+          "STT"
+        ],
+        "summary": "Create transcribe",
+        "description": "POST /api/hermes/stt/transcribe",
+        "operationId": "transcribe",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/hermes/tts": {
+      "post": {
+        "tags": [
+          "TTS"
+        ],
+        "summary": "Create tts",
+        "description": "POST /api/hermes/tts",
+        "operationId": "generate",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "lang": {
+                    "type": "string"
+                  },
+                  "text": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "text"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/tts/settings": {
+      "get": {
+        "tags": [
+          "TTS"
+        ],
+        "summary": "Get settings",
+        "description": "GET /api/hermes/tts/settings",
+        "operationId": "listSettings",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/hermes/tts/settings/{provider}": {
+      "put": {
+        "tags": [
+          "TTS"
+        ],
+        "summary": "Update :provider",
+        "description": "PUT /api/hermes/tts/settings/:provider",
+        "operationId": "saveSettings",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "secrets": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "settings": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/tts/settings/{provider}/base-url-preset": {
+      "delete": {
+        "tags": [
+          "TTS"
+        ],
+        "summary": "Delete base-url-preset",
+        "description": "DELETE /api/hermes/tts/settings/:provider/base-url-preset",
+        "operationId": "deleteBaseUrlPreset",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "url",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "string"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/tts/settings/{provider}/secret/{secretName}": {
+      "delete": {
+        "tags": [
+          "TTS"
+        ],
+        "summary": "Delete :secretName",
+        "description": "DELETE /api/hermes/tts/settings/:provider/secret/:secretName",
+        "operationId": "deleteSecret",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secretName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/tts/synthesize": {
+      "post": {
+        "tags": [
+          "TTS"
+        ],
+        "summary": "Create synthesize",
+        "description": "POST /api/hermes/tts/synthesize",
+        "operationId": "synthesize",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "options": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "text": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "text"
+                ]
+              }
+            }
           }
         }
       }
@@ -3306,6 +9906,192 @@
         }
       }
     },
+    "/api/hermes/update/preview": {
+      "get": {
+        "tags": [
+          "Update"
+        ],
+        "summary": "Get preview",
+        "description": "GET /api/hermes/update/preview",
+        "operationId": "previewStatus",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/hermes/update/preview/install": {
+      "post": {
+        "tags": [
+          "Update"
+        ],
+        "summary": "Create install",
+        "description": "POST /api/hermes/update/preview/install",
+        "operationId": "installPreview",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/hermes/update/preview/prepare": {
+      "post": {
+        "tags": [
+          "Update"
+        ],
+        "summary": "Create prepare",
+        "description": "POST /api/hermes/update/preview/prepare",
+        "operationId": "preparePreview",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "tag": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/update/preview/start": {
+      "post": {
+        "tags": [
+          "Update"
+        ],
+        "summary": "Create start",
+        "description": "POST /api/hermes/update/preview/start",
+        "operationId": "startPreview",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "tag": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/update/preview/stop": {
+      "post": {
+        "tags": [
+          "Update"
+        ],
+        "summary": "Create stop",
+        "description": "POST /api/hermes/update/preview/stop",
+        "operationId": "stopPreview",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/hermes/update/preview/tags": {
+      "get": {
+        "tags": [
+          "Update"
+        ],
+        "summary": "Get tags",
+        "description": "GET /api/hermes/update/preview/tags",
+        "operationId": "previewTags",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/api/hermes/usage/stats": {
       "get": {
         "tags": [
@@ -3329,7 +10115,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/weixin/qrcode": {
@@ -3381,7 +10177,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "qrcode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/weixin/save": {
@@ -3406,6 +10212,31 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "account_id": {
+                    "type": "string"
+                  },
+                  "base_url": {
+                    "type": "string"
+                  },
+                  "token": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "account_id",
+                  "token"
+                ]
+              }
+            }
           }
         }
       }
@@ -3433,7 +10264,17 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       },
       "post": {
         "tags": [
@@ -3456,6 +10297,24 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "parentPath": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -3504,7 +10363,186 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            }
+          }
         }
+      }
+    },
+    "/api/hermes/write-gate/pending": {
+      "get": {
+        "tags": [
+          "Write Gate"
+        ],
+        "summary": "List pending",
+        "description": "GET /api/hermes/write-gate/pending",
+        "operationId": "list",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/hermes/write-gate/pending/{subsystem}/{id}/approve": {
+      "post": {
+        "tags": [
+          "Write Gate"
+        ],
+        "summary": "Create approve",
+        "description": "POST /api/hermes/write-gate/pending/:subsystem/:id/approve",
+        "operationId": "approve",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "subsystem",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/write-gate/pending/{subsystem}/{id}/diff": {
+      "get": {
+        "tags": [
+          "Write Gate"
+        ],
+        "summary": "Get diff",
+        "description": "GET /api/hermes/write-gate/pending/:subsystem/:id/diff",
+        "operationId": "diff",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "subsystem",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/write-gate/pending/{subsystem}/{id}/reject": {
+      "post": {
+        "tags": [
+          "Write Gate"
+        ],
+        "summary": "Create reject",
+        "description": "POST /api/hermes/write-gate/pending/:subsystem/:id/reject",
+        "operationId": "reject",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "subsystem",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/openapi.json": {
@@ -3529,6 +10567,103 @@
           },
           "404": {
             "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/tts/proxy/audio/speech": {
+      "post": {
+        "tags": [
+          "TTS"
+        ],
+        "summary": "Create speech",
+        "description": "POST /api/tts/proxy/audio/speech",
+        "operationId": "openaiProxy",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "input": {
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "pitch": {
+                    "type": "string"
+                  },
+                  "rate": {
+                    "type": "string"
+                  },
+                  "speed": {
+                    "type": "number"
+                  },
+                  "voice": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "input"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/voice/providers/probe": {
+      "post": {
+        "tags": [
+          "TTS"
+        ],
+        "summary": "Create probe",
+        "description": "POST /api/voice/providers/probe",
+        "operationId": "probeProvider",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            }
           }
         }
       }
@@ -3608,83 +10743,20 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           }
-        }
-      }
-    },
-    "/api/hermes/{*any}": {
-      "get": {
-        "tags": [
-          "Proxy"
-        ],
-        "summary": "Proxy to upstream Hermes API",
-        "description": "Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.",
-        "operationId": "proxyHermes",
-        "responses": {
-          "200": {
-            "description": "Proxied response from upstream"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "502": {
-            "description": "Proxy failure"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Proxy"
-        ],
-        "summary": "Proxy to upstream Hermes API",
-        "description": "Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.",
-        "operationId": "proxyHermesPost",
-        "responses": {
-          "200": {
-            "description": "Proxied response from upstream"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "502": {
-            "description": "Proxy failure"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Proxy"
-        ],
-        "summary": "Proxy to upstream Hermes API",
-        "description": "Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.",
-        "operationId": "proxyHermesPut",
-        "responses": {
-          "200": {
-            "description": "Proxied response from upstream"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "502": {
-            "description": "Proxy failure"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Proxy"
-        ],
-        "summary": "Proxy to upstream Hermes API",
-        "description": "Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.",
-        "operationId": "proxyHermesDelete",
-        "responses": {
-          "200": {
-            "description": "Proxied response from upstream"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "502": {
-            "description": "Proxy failure"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "event": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -3703,70 +10775,6 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/api/hermes/v1/runs/{runId}/events": {
-      "get": {
-        "tags": [
-          "Chat"
-        ],
-        "summary": "Server-Sent Events for chat streaming",
-        "description": "Stream chat events using Server-Sent Events (SSE). Authentication via `?token=` query parameter.",
-        "operationId": "chatStreamEvents",
-        "parameters": [
-          {
-            "name": "runId",
-            "in": "path",
-            "required": true,
-            "description": "Chat run ID",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "token",
-            "in": "query",
-            "required": true,
-            "description": "Authentication token",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "SSE stream established",
-            "content": {
-              "text/event-stream": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "event": {
-                      "type": "string",
-                      "enum": [
-                        "run.created",
-                        "run.queued",
-                        "run.started",
-                        "run.streaming",
-                        "run.completed",
-                        "run.failed"
-                      ]
-                    },
-                    "data": {
-                      "type": "object"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "description": "Run not found"
           }
         }
       }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -433,6 +433,66 @@
         }
       }
     },
+    "/api/auth/mcu-login": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Create mcu-login",
+        "description": "POST /api/auth/mcu-login",
+        "operationId": "microcontrollerLogin",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "account": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  },
+                  "token": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "account",
+                  "id",
+                  "password",
+                  "token",
+                  "url"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/auth/me": {
       "get": {
         "tags": [
@@ -759,7 +819,7 @@
                   },
                   "session_id": {
                     "type": "string",
-                    "description": "Optional session id. For cli/default chat runs, omit this to create a new session automatically. Provide an existing session id to continue that session. Coding-agent runs still require a session id."
+                    "description": "Optional session id. Omit this to create a new session automatically. Provide an existing session id to continue that session."
                   },
                   "profile": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
     "dev:client": "cross-env HERMES_WEB_UI_BACKEND_PORT=8647 vite --host --port 8649 --strictPort",
     "dev:server": "nodemon",
-    "build": "vue-tsc -b && vite build && tsc --noEmit -p packages/server/tsconfig.json && node scripts/build-server.mjs",
+    "build": "npm run openapi:generate && vue-tsc -b && vite build && tsc --noEmit -p packages/server/tsconfig.json && node scripts/build-server.mjs",
     "harness:check": "node scripts/harness-check.mjs",
     "prepare": "[ -d dist ] || npm run build",
     "preview": "NODE_ENV=production vite preview",

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -23,7 +23,7 @@ const naiveTheme = computed(() => isDark.value ? darkTheme : null)
 
 const isLoginPage = computed(() => route.name === 'login')
 const usesPageSidebar = computed(() =>
-  ['hermes.chat', 'hermes.session', 'hermes.history', 'hermes.historySession', 'hermes.groupChat', 'hermes.groupChatRoom'].includes(route.name as string),
+  ['hermes.chat', 'hermes.session', 'hermes.history', 'hermes.historySession', 'hermes.globalAgent', 'hermes.globalAgentSession', 'hermes.groupChat', 'hermes.groupChatRoom'].includes(route.name as string),
 )
 const showAppSidebar = computed(() => !isLoginPage.value && !usesPageSidebar.value)
 const showMobileMenuButton = computed(() => !isLoginPage.value && (showAppSidebar.value || usesPageSidebar.value))

--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -20,7 +20,8 @@ export interface StartRunRequest {
   provider?: string
   model_groups?: Array<{ provider: string; models: string[] }>
   queue_id?: string
-  source?: 'api_server' | 'cli' | 'coding_agent'
+  source?: 'api_server' | 'cli' | 'coding_agent' | 'global_agent'
+  session_source?: 'global_agent'
   coding_agent_id?: 'claude-code' | 'codex'
   agent_id?: 'claude-code' | 'codex'
   mode?: 'scoped' | 'global'
@@ -111,6 +112,8 @@ export interface ResumeSessionPayload {
 let chatRunSocket: Socket | null = null
 let globalListenersRegistered = false
 let chatRunSocketProfile: string | null = null
+export type ChatRunTransport = 'chat-run' | 'global-agent'
+let chatRunSocketTransport: ChatRunTransport = 'chat-run'
 
 const TRANSIENT_DISCONNECT_REASONS = new Set<string>([
   'transport close',
@@ -565,8 +568,9 @@ export function respondClarify(
   sessionId: string,
   clarifyId: string,
   response: string,
+  transport: ChatRunTransport = 'chat-run',
 ): void {
-  const socket = connectChatRun()
+  const socket = connectChatRun(null, transport)
   socket.emit('clarify.respond', {
     session_id: sessionId,
     clarify_id: clarifyId,
@@ -578,8 +582,9 @@ export function respondToolApproval(
   sessionId: string,
   approvalId: string,
   choice: 'once' | 'session' | 'always' | 'deny',
+  transport: ChatRunTransport = 'chat-run',
 ): void {
-  const socket = connectChatRun()
+  const socket = connectChatRun(null, transport)
   socket.emit('approval.respond', {
     session_id: sessionId,
     approval_id: approvalId,
@@ -587,13 +592,18 @@ export function respondToolApproval(
   })
 }
 
-export function getChatRunSocket(): Socket | null {
+export function getChatRunSocket(transport?: ChatRunTransport): Socket | null {
+  if (transport && chatRunSocketTransport !== transport) return null
   return chatRunSocket
 }
 
-export function connectChatRun(requestedProfile?: string | null): Socket {
+export function connectChatRun(requestedProfile?: string | null, transport: ChatRunTransport = 'chat-run'): Socket {
   const normalizedRequestedProfile = requestedProfile?.trim() || null
-  if (chatRunSocket?.connected && (!normalizedRequestedProfile || chatRunSocketProfile === normalizedRequestedProfile)) {
+  if (
+    chatRunSocket?.connected &&
+    chatRunSocketTransport === transport &&
+    (!normalizedRequestedProfile || chatRunSocketProfile === normalizedRequestedProfile)
+  ) {
     return chatRunSocket
   }
 
@@ -621,8 +631,10 @@ export function connectChatRun(requestedProfile?: string | null): Socket {
     profile = normalizedRequestedProfile || localStorage.getItem('hermes_active_profile_name') || 'default'
   }
   chatRunSocketProfile = profile
+  chatRunSocketTransport = transport
 
-  chatRunSocket = io(`${baseUrl}/chat-run`, {
+  const namespace = transport === 'global-agent' ? '/global-agent' : '/chat-run'
+  chatRunSocket = io(`${baseUrl}${namespace}`, {
     auth: { token },
     query: { profile },
     transports: ['websocket', 'polling'],
@@ -686,6 +698,7 @@ export function disconnectChatRun(): void {
     chatRunSocket.disconnect()
     chatRunSocket = null
     chatRunSocketProfile = null
+    chatRunSocketTransport = 'chat-run'
     globalListenersRegistered = false
     sessionEventHandlers.clear()
   }
@@ -714,8 +727,9 @@ export function resumeSession(
   sessionId: string,
   onResumed: (data: ResumeSessionPayload) => void,
   profile?: string | null,
+  transport: ChatRunTransport = 'chat-run',
 ): Socket {
-  const socket = connectChatRun(profile)
+  const socket = connectChatRun(profile, transport)
 
   const handleResumed = (data: ResumeSessionPayload) => {
     if (data?.session_id !== sessionId) return
@@ -736,6 +750,7 @@ export function startRunViaSocket(
   onStarted?: (runId: string) => void,
   options?: {
     onReconnectResume?: (data: ResumeSessionPayload) => void
+    transport?: ChatRunTransport
   },
 ): { abort: () => void } {
   const sid = body.session_id
@@ -744,7 +759,7 @@ export function startRunViaSocket(
   }
 
   let closed = false
-  const socket = connectChatRun(body.profile)
+  const socket = connectChatRun(body.profile, options?.transport)
   if (sessionEventHandlers.has(sid)) {
     socket.emit('run', body)
     return {

--- a/packages/client/src/api/hermes/global-agent.ts
+++ b/packages/client/src/api/hermes/global-agent.ts
@@ -1,0 +1,132 @@
+import { io, type Socket } from 'socket.io-client'
+import { getApiKey, getBaseUrlValue, getActiveProfileName } from '../client'
+import type { RunEvent, StartRunRequest } from './chat'
+
+export interface GlobalAgentSocketOpenRequest {
+  id: string
+  namespace: '/chat-run'
+  stream?: boolean
+}
+
+export interface GlobalAgentSocketCommand {
+  id: string
+  event: 'run' | 'resume' | 'abort' | 'cancel_queued_run' | 'approval.respond' | 'clarify.respond'
+  stream?: boolean
+  payload?: unknown
+}
+
+export interface GlobalAgentAck {
+  id?: string
+  ok?: boolean
+  namespace?: string
+  event?: string
+  stream?: boolean
+  error?: {
+    code: string
+    message: string
+  }
+}
+
+export interface GlobalAgentSocketEvent {
+  clientId?: string
+  payload?: {
+    id?: string
+    namespace?: string
+    event?: string
+    payload?: RunEvent
+  }
+}
+
+let socket: Socket | null = null
+let socketProfile: string | null = null
+
+function activeProfile(profile?: string | null): string {
+  return profile || getActiveProfileName() || 'default'
+}
+
+export function connectGlobalAgent(profile?: string | null): Socket {
+  const nextProfile = activeProfile(profile)
+  if (socket && socket.connected && socketProfile === nextProfile) return socket
+  if (socket) {
+    socket.disconnect()
+    socket = null
+  }
+
+  socketProfile = nextProfile
+  socket = io(`${getBaseUrlValue()}/global-agent`, {
+    auth: {
+      token: getApiKey(),
+      profile: nextProfile,
+    },
+    transports: ['websocket', 'polling'],
+    reconnection: true,
+    reconnectionAttempts: Infinity,
+    reconnectionDelay: 1000,
+    reconnectionDelayMax: 30000,
+    randomizationFactor: 0.5,
+    timeout: 30000,
+  })
+  return socket
+}
+
+export function disconnectGlobalAgent(): void {
+  socket?.disconnect()
+  socket = null
+  socketProfile = null
+}
+
+function emitWithAck<TRequest, TResponse>(
+  event: string,
+  request: TRequest,
+  profile?: string | null,
+): Promise<TResponse> {
+  const activeSocket = connectGlobalAgent(profile)
+  return new Promise((resolve, reject) => {
+    activeSocket.timeout(30000).emit(event, request, (err: Error | null, response: TResponse) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      const maybeAck = response as GlobalAgentAck
+      if (maybeAck?.error) {
+        reject(new Error(maybeAck.error.message))
+        return
+      }
+      resolve(response)
+    })
+  })
+}
+
+export function openGlobalAgentChatRun(
+  request: GlobalAgentSocketOpenRequest,
+  profile?: string | null,
+): Promise<GlobalAgentAck> {
+  return emitWithAck('socket.open', request, profile)
+}
+
+export function emitGlobalAgentChatRun(
+  request: GlobalAgentSocketCommand,
+  profile?: string | null,
+): Promise<GlobalAgentAck> {
+  return emitWithAck('socket.event', request, profile)
+}
+
+export function closeGlobalAgentChatRun(id: string, profile?: string | null): Promise<GlobalAgentAck> {
+  return emitWithAck('socket.close', { id }, profile)
+}
+
+export function startGlobalAgentRun(
+  bridgeId: string,
+  body: StartRunRequest,
+  options: {
+    profile?: string | null
+    stream?: boolean
+  } = {},
+): Promise<GlobalAgentAck> {
+  return emitGlobalAgentChatRun({
+    id: bridgeId,
+    event: 'run',
+    stream: options.stream,
+    payload: body,
+  }, options.profile)
+}

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -95,7 +95,7 @@ const toolPanelStyle = computed(() => ({
 
 function sessionHref(sessionId: string) {
   return router.resolve({
-    name: "hermes.session",
+    name: chatStore.runtimeMode === "global_agent" ? "hermes.globalAgentSession" : "hermes.session",
     params: { sessionId },
   }).href;
 }
@@ -151,7 +151,7 @@ function startToolResize(event: PointerEvent) {
 async function handleSessionClick(sessionId: string) {
   chatStore.clearSessionCompletedUnread(sessionId);
   await router.push({
-    name: "hermes.session",
+    name: chatStore.runtimeMode === "global_agent" ? "hermes.globalAgentSession" : "hermes.session",
     params: { sessionId },
   });
   if (mobileQuery?.matches) showSessions.value = false;
@@ -514,7 +514,7 @@ async function confirmNewChat() {
     apiMode: source === "coding_agent" && !isGlobalCodingAgent ? newChatApiMode.value : undefined,
   });
   await router.push({
-    name: "hermes.session",
+    name: chatStore.runtimeMode === "global_agent" ? "hermes.globalAgentSession" : "hermes.session",
     params: { sessionId: session.id },
   });
   showNewChatModal.value = false;
@@ -526,7 +526,7 @@ function sessionProfile(sessionId: string): string | null {
 
 function buildSessionUrl(sessionId: string, profile?: string | null): string {
   const href = router.resolve({
-    name: "hermes.session",
+    name: chatStore.runtimeMode === "global_agent" ? "hermes.globalAgentSession" : "hermes.session",
     params: { sessionId },
     query: profile ? { profile } : undefined,
   }).href;
@@ -990,7 +990,7 @@ async function handleSessionModelCustomSubmit() {
     >
       <div v-if="showSessions" class="page-sidebar-top">
         <PageSidebarNav
-          active="chat"
+          :active="chatStore.runtimeMode === 'global_agent' ? 'global' : 'chat'"
           :primary-label="t('chat.newChat')"
           @primary="openNewChatModal"
         />

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -49,6 +49,11 @@ function formatToolDuration(seconds: number): string {
   return `${mins}m ${secs}s`
 }
 
+function toolPreviewText(preview?: string): string {
+  const text = String(preview || '')
+  return text.length > 160 ? `${text.slice(0, 157)}...` : text
+}
+
 function formatElapsed(ms: number): string {
   const totalSeconds = Math.floor(ms / 1000);
   const hours = Math.floor(totalSeconds / 3600);
@@ -538,9 +543,11 @@ defineExpose({
                 />
               </svg>
               <span class="tool-call-name">{{ tc.toolName }}</span>
-              <span v-if="tc.toolPreview" class="tool-call-preview">{{
-                tc.toolPreview
-              }}</span>
+              <span
+                v-if="tc.toolPreview"
+                class="tool-call-preview"
+                :title="tc.toolPreview"
+              >{{ toolPreviewText(tc.toolPreview) }}</span>
               <span
                 v-if="tc.toolDuration && tc.toolStatus !== 'running'"
                 class="tool-call-duration"
@@ -1368,13 +1375,15 @@ defineExpose({
     font-family: $font-code;
     flex: 0 1 auto;
     min-width: 0;
+    max-width: 34%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   .tool-call-preview {
-    flex: 1 1 auto;
+    display: block;
+    flex: 1 1 0;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/packages/client/src/components/hermes/chat/SessionListItem.vue
+++ b/packages/client/src/components/hermes/chat/SessionListItem.vue
@@ -42,6 +42,7 @@ const profileHasModels = computed(() => {
 const profileModelsMissing = computed(() =>
   appStore.profileModelGroups.length > 0 && !profileHasModels.value,
 )
+const isGlobalAgentSession = computed(() => props.session.source === 'global_agent')
 const sessionAgentLogo = computed(() => {
   if (props.session.source === 'coding_agent') {
     if (props.session.codingAgentId === 'codex' || props.session.agent === 'codex') {
@@ -159,6 +160,24 @@ onUnmounted(() => {
         </span>
       </span>
     </div>
+    <svg
+      v-if="isGlobalAgentSession"
+      class="session-item-global-icon"
+      :aria-label="t('sidebar.globalAgent')"
+      :title="t('sidebar.globalAgent')"
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <rect x="7" y="7" width="10" height="10" rx="2" />
+      <path d="M9 1v4M15 1v4M9 19v4M15 19v4M1 9h4M1 15h4M19 9h4M19 15h4" />
+      <path d="M10 10h4v4h-4z" />
+    </svg>
     <NPopconfirm v-if="canDelete && !selectable" @positive-click="emit('delete')">
       <template #trigger>
         <button class="session-item-delete" @click.stop.prevent>
@@ -172,6 +191,7 @@ onUnmounted(() => {
 
 <style scoped>
 .session-item {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -282,6 +302,14 @@ onUnmounted(() => {
   flex: 0 0 auto;
   font-size: 11px;
   color: var(--text-muted);
+}
+
+.session-item-global-icon {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  color: #d6a019;
+  pointer-events: none;
 }
 
 .session-item-delete {

--- a/packages/client/src/components/hermes/chat/SessionSearchModal.vue
+++ b/packages/client/src/components/hermes/chat/SessionSearchModal.vue
@@ -20,6 +20,7 @@ const searchResults = ref<SessionSearchResult[]>([])
 const activeIndex = ref(0)
 const inputRef = ref<InstanceType<typeof NInput> | null>(null)
 const profileFilter = computed(() => chatStore.sessionProfileFilter || undefined)
+const runtimeSource = computed(() => chatStore.runtimeMode === 'global_agent' ? 'global_agent' : undefined)
 
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
 let requestSeq = 0
@@ -54,6 +55,7 @@ function formatSource(source: string): string {
     signal: 'Signal',
     cron: 'Cron',
     weixin: 'WeChat',
+    global_agent: 'Global Agent',
   }
   return map[source] || source
 }
@@ -81,8 +83,8 @@ async function loadRecentSessions() {
   loading.value = true
   try {
     const sessions = profileFilter.value
-      ? await fetchSessions(undefined, 8, profileFilter.value)
-      : await fetchSessions(undefined, 8)
+      ? await fetchSessions(runtimeSource.value, 8, profileFilter.value)
+      : await fetchSessions(runtimeSource.value, 8)
     if (seq !== requestSeq) return
     recentSessions.value = sessions
     searchResults.value = []
@@ -103,8 +105,8 @@ async function runSearch(text: string) {
   try {
     const results = text.trim()
       ? profileFilter.value
-        ? await searchSessions(text.trim(), undefined, 10, profileFilter.value)
-        : await searchSessions(text.trim(), undefined, 10)
+        ? await searchSessions(text.trim(), runtimeSource.value, 10, profileFilter.value)
+        : await searchSessions(text.trim(), runtimeSource.value, 10)
       : []
     if (seq !== requestSeq) return
     searchResults.value = results
@@ -148,8 +150,9 @@ async function openItem(item: SearchItem) {
     })
   }
   await chatStore.switchSession(item.id, messageId)
-  if (router.currentRoute.value.name !== 'hermes.chat') {
-    await router.push({ name: 'hermes.chat' })
+  const routeName = chatStore.runtimeMode === 'global_agent' ? 'hermes.globalAgentSession' : 'hermes.session'
+  if (router.currentRoute.value.name !== routeName || router.currentRoute.value.params.sessionId !== item.id) {
+    await router.push({ name: routeName, params: { sessionId: item.id } })
   }
 }
 

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -210,6 +210,17 @@ function handleSidebarClick(event: MouseEvent) {
             </svg>
             <span>{{ t("sidebar.codingAgents") }}</span>
           </RouteLinkItem>
+          <RouteLinkItem v-if="hasRoute('hermes.globalAgent')" class="nav-item" :to="{ name: 'hermes.globalAgent' }" :active="selectedKey === 'hermes.globalAgent' || selectedKey === 'hermes.globalAgentSession'">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 3v4" />
+              <path d="M12 17v4" />
+              <path d="M3 12h4" />
+              <path d="M17 12h4" />
+              <circle cx="12" cy="12" r="5" />
+              <circle cx="12" cy="12" r="1.5" />
+            </svg>
+            <span>{{ t("sidebar.globalAgent") }}</span>
+          </RouteLinkItem>
           <RouteLinkItem v-if="hasRoute('hermes.versionPreview') && isSuperAdmin && !isVersionPreview" class="nav-item" :to="{ name: 'hermes.versionPreview' }" :active="selectedKey === 'hermes.versionPreview'">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
               <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -210,17 +210,6 @@ function handleSidebarClick(event: MouseEvent) {
             </svg>
             <span>{{ t("sidebar.codingAgents") }}</span>
           </RouteLinkItem>
-          <RouteLinkItem v-if="hasRoute('hermes.globalAgent')" class="nav-item" :to="{ name: 'hermes.globalAgent' }" :active="selectedKey === 'hermes.globalAgent' || selectedKey === 'hermes.globalAgentSession'">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M12 3v4" />
-              <path d="M12 17v4" />
-              <path d="M3 12h4" />
-              <path d="M17 12h4" />
-              <circle cx="12" cy="12" r="5" />
-              <circle cx="12" cy="12" r="1.5" />
-            </svg>
-            <span>{{ t("sidebar.globalAgent") }}</span>
-          </RouteLinkItem>
           <RouteLinkItem v-if="hasRoute('hermes.versionPreview') && isSuperAdmin && !isVersionPreview" class="nav-item" :to="{ name: 'hermes.versionPreview' }" :active="selectedKey === 'hermes.versionPreview'">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
               <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />

--- a/packages/client/src/components/layout/PageSidebarNav.vue
+++ b/packages/client/src/components/layout/PageSidebarNav.vue
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { useSessionSearch } from '@/composables/useSessionSearch'
 
-type ActiveSection = 'chat' | 'history' | 'group'
+type ActiveSection = 'chat' | 'history' | 'group' | 'global'
 
 const props = defineProps<{
   active: ActiveSection
@@ -42,6 +42,11 @@ function openHistory() {
 function openGroupChat() {
   if (props.active === 'group') return
   void router.push({ name: 'hermes.groupChat' })
+}
+
+function openGlobalAgent() {
+  if (props.active === 'global') return
+  void router.push({ name: 'hermes.globalAgent' })
 }
 
 function openApiRelay() {
@@ -135,7 +140,7 @@ function openApiRelay() {
         <span>{{ t('sidebar.apiRelay') }}</span>
       </button>
     </div>
-    <div v-if="showModeSwitch" class="conversation-switch" role="tablist" aria-label="Conversation type">
+    <div v-if="showModeSwitch" class="conversation-switch conversation-switch--three" role="tablist" aria-label="Conversation type">
       <button
         class="conversation-switch-tab"
         :class="{ active: active === 'chat' || active === 'history' }"
@@ -145,6 +150,16 @@ function openApiRelay() {
         @click="openChat"
       >
         {{ t('sidebar.singleChat') }}
+      </button>
+      <button
+        class="conversation-switch-tab"
+        :class="{ active: active === 'global' }"
+        type="button"
+        role="tab"
+        :aria-selected="active === 'global'"
+        @click="openGlobalAgent"
+      >
+        {{ t('sidebar.globalAgent') }}
       </button>
       <button
         class="conversation-switch-tab"
@@ -221,6 +236,10 @@ function openApiRelay() {
   padding: 2px;
   border-radius: $radius-sm;
   background: rgba(var(--accent-primary-rgb), 0.05);
+}
+
+.conversation-switch--three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .conversation-switch-tab {

--- a/packages/client/src/components/layout/PageSidebarNav.vue
+++ b/packages/client/src/components/layout/PageSidebarNav.vue
@@ -44,11 +44,6 @@ function openGroupChat() {
   void router.push({ name: 'hermes.groupChat' })
 }
 
-function openGlobalAgent() {
-  if (props.active === 'global') return
-  void router.push({ name: 'hermes.globalAgent' })
-}
-
 function openApiRelay() {
   if (typeof window === 'undefined') return
   window.open('https://apikey.fun/register?aff=LIBAPI', '_blank', 'noopener,noreferrer')
@@ -140,7 +135,7 @@ function openApiRelay() {
         <span>{{ t('sidebar.apiRelay') }}</span>
       </button>
     </div>
-    <div v-if="showModeSwitch" class="conversation-switch conversation-switch--three" role="tablist" aria-label="Conversation type">
+    <div v-if="showModeSwitch" class="conversation-switch" role="tablist" aria-label="Conversation type">
       <button
         class="conversation-switch-tab"
         :class="{ active: active === 'chat' || active === 'history' }"
@@ -150,16 +145,6 @@ function openApiRelay() {
         @click="openChat"
       >
         {{ t('sidebar.singleChat') }}
-      </button>
-      <button
-        class="conversation-switch-tab"
-        :class="{ active: active === 'global' }"
-        type="button"
-        role="tab"
-        :aria-selected="active === 'global'"
-        @click="openGlobalAgent"
-      >
-        {{ t('sidebar.globalAgent') }}
       </button>
       <button
         class="conversation-switch-tab"

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -198,6 +198,7 @@ export default {
     channels: 'Kanale',
     terminal: 'Konsole',
     singleChat: 'Chat',
+    globalAgent: 'Global Agent',
     files: 'Dateien',
     devices: 'Gerate',
     groupChat: 'Gruppenchat',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -200,6 +200,7 @@ export default {
     gateways: 'Gateways',
     terminal: 'Terminal',
     singleChat: 'Chat',
+    globalAgent: 'Global Agent',
     groupChat: 'Group Chat',
     files: 'Files',
     devices: 'Devices',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -198,6 +198,7 @@ export default {
     channels: 'Canales',
     terminal: 'Terminal',
     singleChat: 'Chat',
+    globalAgent: 'Global Agent',
     files: 'Archivos',
     devices: 'Dispositivos',
     groupChat: 'Chat grupal',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -198,6 +198,7 @@ export default {
     channels: 'Canaux',
     terminal: 'Terminal',
     singleChat: 'Discussion',
+    globalAgent: 'Global Agent',
     files: 'Fichiers',
     devices: 'Appareils',
     groupChat: 'Chat de groupe',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -198,6 +198,7 @@ export default {
     channels: 'チャンネル',
     terminal: 'ターミナル',
     singleChat: 'チャット',
+    globalAgent: 'Global Agent',
     files: 'ファイル',
     devices: 'デバイス',
     groupChat: 'グループチャット',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -198,6 +198,7 @@ export default {
     channels: '채널',
     terminal: '터미널',
     singleChat: '채팅',
+    globalAgent: 'Global Agent',
     files: '파일',
     devices: '기기',
     groupChat: '그룹 채팅',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -198,6 +198,7 @@ export default {
     channels: 'Canais',
     terminal: 'Terminal',
     singleChat: 'Chat',
+    globalAgent: 'Global Agent',
     files: 'Arquivos',
     devices: 'Dispositivos',
     groupChat: 'Chat em grupo',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -125,6 +125,7 @@ export default {
     gateways: 'Шлюзы',
     terminal: 'Терминал',
     singleChat: 'Чат',
+    globalAgent: 'Global Agent',
     groupChat: 'Групповой чат',
     files: 'Файлы',
     devices: 'Устройства',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -200,6 +200,7 @@ export default {
     gateways: '閘道',
     terminal: '終端機',
     singleChat: '單聊',
+    globalAgent: '全局',
     groupChat: '群聊',
     files: '檔案',
     devices: '裝置',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -200,6 +200,7 @@ export default {
     gateways: '网关',
     terminal: '终端',
     singleChat: '单聊',
+    globalAgent: '全局',
     groupChat: '群聊',
     files: '文件',
     devices: '设备',

--- a/packages/client/src/router/index.ts
+++ b/packages/client/src/router/index.ts
@@ -31,6 +31,16 @@ const router = createRouter({
       component: () => import('@/views/hermes/HistoryView.vue'),
     },
     {
+      path: '/hermes/global-agent',
+      name: 'hermes.globalAgent',
+      component: () => import('@/views/hermes/GlobalAgentView.vue'),
+    },
+    {
+      path: '/hermes/global-agent/session/:sessionId',
+      name: 'hermes.globalAgentSession',
+      component: () => import('@/views/hermes/GlobalAgentView.vue'),
+    },
+    {
       path: '/hermes/jobs',
       name: 'hermes.jobs',
       component: () => import('@/views/hermes/JobsView.vue'),

--- a/packages/client/src/shared/session-display.ts
+++ b/packages/client/src/shared/session-display.ts
@@ -3,6 +3,7 @@ const SOURCE_LABELS: Record<string, string> = {
   api_server: 'API Server',
   cli: 'CLI',
   coding_agent: 'Coding Agent',
+  global_agent: 'Global Agent',
   discord: 'Discord',
   slack: 'Slack',
   matrix: 'Matrix',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1,4 +1,4 @@
-import { startRunViaSocket, resumeSession, registerSessionHandlers, unregisterSessionHandlers, getChatRunSocket, respondToolApproval, onPeerUserMessage, onSessionCommand, onSessionTitleUpdated, respondClarify, type RunEvent, type ResumeSessionPayload, type StartRunRequest, type ContentBlock as ContentBlockImport } from '@/api/hermes/chat'
+import { startRunViaSocket, resumeSession, registerSessionHandlers, unregisterSessionHandlers, getChatRunSocket, respondToolApproval, onPeerUserMessage, onSessionCommand, onSessionTitleUpdated, respondClarify, type ChatRunTransport, type RunEvent, type ResumeSessionPayload, type StartRunRequest, type ContentBlock as ContentBlockImport } from '@/api/hermes/chat'
 import { deleteSession as deleteSessionApi, fetchSessionMessagesPage, fetchSessions, setSessionModel, type HermesMessage, type SessionSummary } from '@/api/hermes/sessions'
 import { getActiveProfileName } from '@/api/client'
 import { getDownloadUrl } from '@/api/hermes/download'
@@ -432,7 +432,9 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
 }
 
 function mapHermesSession(s: SessionSummary): Session {
-  const codingAgentMode = s.source === 'coding_agent'
+  const isCodingAgentSession = s.source === 'coding_agent' || s.agent === 'claude' || s.agent === 'codex'
+  const codingAgentId = s.agent === 'codex' ? 'codex' : s.agent === 'claude' ? 'claude-code' : undefined
+  const codingAgentMode = isCodingAgentSession
     ? (s.agent_mode === 'global' || s.agent_mode === 'scoped'
         ? s.agent_mode
         : s.provider === 'global' ? 'global' : 'scoped')
@@ -445,6 +447,7 @@ function mapHermesSession(s: SessionSummary): Session {
     agent: s.agent || undefined,
     agentSessionId: s.agent_session_id || undefined,
     agentNativeSessionId: s.agent_native_session_id || undefined,
+    codingAgentId,
     codingAgentMode,
     messages: [],
     createdAt: Math.round(s.started_at * 1000),
@@ -464,6 +467,8 @@ function mapHermesSession(s: SessionSummary): Session {
 }
 
 const STORAGE_KEY_PREFIX = 'hermes_active_session_'
+type ChatRuntimeMode = 'default' | 'global_agent'
+let activeRuntimeMode: ChatRuntimeMode = 'default'
 const LEGACY_STORAGE_KEY = 'hermes_active_session'
 
 // 获取当前 profile 名称，用于隔离缓存。
@@ -477,8 +482,20 @@ function getProfileName(): string {
   }
 }
 
-function storageKey(): string { return STORAGE_KEY_PREFIX + getProfileName() }
-function legacyStorageKey(): string | null { return getProfileName() === 'default' ? LEGACY_STORAGE_KEY : null }
+function runtimeStoragePrefix(): string {
+  return activeRuntimeMode === 'global_agent' ? `${STORAGE_KEY_PREFIX}global_agent_` : STORAGE_KEY_PREFIX
+}
+
+function storageKey(): string { return runtimeStoragePrefix() + getProfileName() }
+function legacyStorageKey(): string | null { return activeRuntimeMode === 'default' && getProfileName() === 'default' ? LEGACY_STORAGE_KEY : null }
+
+function isCodingAgentLikeSession(session?: Pick<Session, 'source' | 'agent' | 'codingAgentId'> | null): boolean {
+  return session?.source === 'coding_agent' ||
+    session?.codingAgentId === 'claude-code' ||
+    session?.codingAgentId === 'codex' ||
+    session?.agent === 'claude' ||
+    session?.agent === 'codex'
+}
 
 function isQuotaExceededError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false
@@ -550,6 +567,7 @@ function removeItem(key: string) {
 // File objects don't serialize and we only need name/type/size/url for display.
 
 export const useChatStore = defineStore('chat', () => {
+  const runtimeMode = ref<ChatRuntimeMode>(activeRuntimeMode)
   const seenSessionCommandEvents = new WeakSet<RunEvent>()
   const sessions = ref<Session[]>([])
   const activeSessionId = ref<string | null>(null)
@@ -593,6 +611,30 @@ export const useChatStore = defineStore('chat', () => {
   const sessionsLoaded = ref(false)
   const isLoadingMessages = ref(false)
   const isRunActive = computed(() => isStreaming.value)
+
+  function runtimeSessionSource(): string | undefined {
+    return runtimeMode.value === 'global_agent' ? 'global_agent' : undefined
+  }
+
+  function runtimeTransport(): ChatRunTransport {
+    return runtimeMode.value === 'global_agent' ? 'global-agent' : 'chat-run'
+  }
+
+  function setRuntimeMode(mode: ChatRuntimeMode) {
+    if (runtimeMode.value === mode) return
+    activeRuntimeMode = mode
+    runtimeMode.value = mode
+    sessions.value = []
+    completedUnreadSessions.value = new Set()
+    queueLengths.value = new Map()
+    queuedUserMessages.value = new Map()
+    pendingApprovals.value = new Map()
+    pendingClarifies.value = new Map()
+    streamStates.value = new Map()
+    serverWorking.value = new Set()
+    sessionsLoaded.value = false
+    clearActiveSession()
+  }
 
   // Compression state is scoped per session because sockets can stay joined to
   // background sessions while another chat is active.
@@ -672,7 +714,7 @@ export const useChatStore = defineStore('chat', () => {
   async function loadSessions(profile?: string | null, preferredSessionId?: string | null) {
     isLoadingSessions.value = true
     try {
-      const list = await fetchSessions(undefined, undefined, profile || undefined)
+      const list = await fetchSessions(runtimeSessionSource(), undefined, profile || undefined)
       const fresh = list.map(mapHermesSession)
       // Preserve already-loaded messages for sessions that are still present,
       // so we don't blow away the active session's messages on refresh.
@@ -731,7 +773,7 @@ export const useChatStore = defineStore('chat', () => {
     if (isStreaming.value) return
     if (isLoadingSessions.value) return
     try {
-      const list = await fetchSessions(undefined, undefined, profile ?? sessionProfileFilter.value ?? undefined)
+      const list = await fetchSessions(runtimeSessionSource(), undefined, profile ?? sessionProfileFilter.value ?? undefined)
       const incoming = list.map(mapHermesSession)
       const existingById = new Map(sessions.value.map(s => [s.id, s]))
       const incomingIds = new Set(incoming.map(s => s.id))
@@ -820,7 +862,7 @@ export const useChatStore = defineStore('chat', () => {
     profile?: string
     model?: string
     provider?: string
-    source?: 'api_server' | 'cli' | 'coding_agent'
+    source?: 'api_server' | 'cli' | 'coding_agent' | 'global_agent'
     agent?: 'hermes' | 'claude' | 'codex'
     codingAgentId?: 'claude-code' | 'codex'
     codingAgentMode?: 'global' | 'scoped'
@@ -829,15 +871,15 @@ export const useChatStore = defineStore('chat', () => {
     apiKey?: string
     apiMode?: 'chat_completions' | 'codex_responses' | 'anthropic_messages'
   } = {}): Session {
-    const source = options.source || 'cli'
+    const source = runtimeMode.value === 'global_agent' ? 'global_agent' : options.source || 'cli'
     const codingAgentId = options.codingAgentId || (options.agent === 'codex' ? 'codex' : options.agent === 'claude' ? 'claude-code' : undefined)
-    const codingAgentMode = source === 'coding_agent' ? (options.codingAgentMode || 'scoped') : undefined
+    const codingAgentMode = codingAgentId ? (options.codingAgentMode || 'scoped') : undefined
     const session: Session = {
       id: uid(),
       profile: options.profile || useProfilesStore().activeProfileName || 'default',
       title: '',
       source,
-      agent: options.agent || (source === 'coding_agent' ? (codingAgentId === 'codex' ? 'codex' : 'claude') : 'hermes'),
+      agent: options.agent || (codingAgentId ? (codingAgentId === 'codex' ? 'codex' : 'claude') : 'hermes'),
       codingAgentId,
       codingAgentMode,
       messages: [],
@@ -869,7 +911,7 @@ export const useChatStore = defineStore('chat', () => {
     const session: Session = {
       id: `${ts}_${hex}`,
       title: '',
-      source: 'cli',
+      source: runtimeMode.value === 'global_agent' ? 'global_agent' : 'cli',
       agent: 'hermes',
       messages: [],
       createdAt: Date.now(),
@@ -1036,7 +1078,7 @@ export const useChatStore = defineStore('chat', () => {
             }
           }
           resolve()
-        }, activeSession.value?.profile)
+        }, activeSession.value?.profile, runtimeTransport())
       })
     } catch (err) {
       console.error('Failed to load session messages via resume:', err)
@@ -1085,7 +1127,7 @@ export const useChatStore = defineStore('chat', () => {
     profile?: string
     model?: string
     provider?: string
-    source?: 'api_server' | 'cli' | 'coding_agent'
+    source?: 'api_server' | 'cli' | 'coding_agent' | 'global_agent'
     agent?: 'hermes' | 'claude' | 'codex'
     codingAgentId?: 'claude-code' | 'codex'
     codingAgentMode?: 'global' | 'scoped'
@@ -1095,15 +1137,16 @@ export const useChatStore = defineStore('chat', () => {
     apiMode?: 'chat_completions' | 'codex_responses' | 'anthropic_messages'
   } = {}): Session {
     const appStore = useAppStore()
-    const source = options.source || 'cli'
-    const isGlobalCodingAgent = source === 'coding_agent' && options.codingAgentMode === 'global'
+    const storageSource = runtimeMode.value === 'global_agent' ? 'global_agent' : options.source || 'cli'
+    const codingAgentId = options.codingAgentId || (options.agent === 'codex' ? 'codex' : options.agent === 'claude' ? 'claude-code' : undefined)
+    const isGlobalCodingAgent = Boolean(codingAgentId) && options.codingAgentMode === 'global'
     const session = createSession({
       profile: options.profile,
       model: isGlobalCodingAgent ? undefined : options.model || appStore.selectedModel || undefined,
       provider: isGlobalCodingAgent ? '' : options.provider || appStore.selectedProvider || '',
-      source,
+      source: storageSource,
       agent: options.agent,
-      codingAgentId: options.codingAgentId,
+      codingAgentId,
       codingAgentMode: options.codingAgentMode,
       workspace: options.workspace,
       baseUrl: options.baseUrl,
@@ -1421,7 +1464,7 @@ export const useChatStore = defineStore('chat', () => {
 
   function removeQueuedMessage(sessionId: string, messageId: string) {
     if (!dropQueuedUserMessage(sessionId, messageId)) return
-    getChatRunSocket()?.emit('cancel_queued_run', {
+    getChatRunSocket(runtimeTransport())?.emit('cancel_queued_run', {
       session_id: sessionId,
       queue_id: messageId,
     })
@@ -1635,7 +1678,7 @@ export const useChatStore = defineStore('chat', () => {
   function respondToClarify(response: string) {
     const pending = activePendingClarify.value
     if (!pending) return
-    respondClarify(pending.sessionId, pending.clarifyId, response)
+    respondClarify(pending.sessionId, pending.clarifyId, response, runtimeTransport())
     pendingClarifies.value.delete(pending.sessionId)
     pendingClarifies.value = new Map(pendingClarifies.value)
   }
@@ -1644,7 +1687,7 @@ export const useChatStore = defineStore('chat', () => {
   function respondApproval(choice: PendingApproval['choices'][number]) {
     const pending = activePendingApproval.value
     if (!pending) return
-    respondToolApproval(pending.sessionId, pending.approvalId, choice)
+    respondToolApproval(pending.sessionId, pending.approvalId, choice, runtimeTransport())
     pendingApprovals.value.delete(pending.sessionId)
     pendingApprovals.value = new Map(pendingApprovals.value)
   }
@@ -1746,7 +1789,7 @@ export const useChatStore = defineStore('chat', () => {
     const shouldSendInitialSessionConfig = activeSession.value
       ? activeSession.value.messageCount == null || activeSession.value.messageCount === 0
       : false
-    const isCodingAgentSession = activeSession.value?.source === 'coding_agent'
+    const isCodingAgentSession = isCodingAgentLikeSession(activeSession.value)
     const isBridgeSlashCommand = !isCodingAgentSession && content.trim().startsWith('/')
     const isBridgeCompressCommand = isBridgeSlashCommand && /^\/compress(?:\s|$)/i.test(content.trim())
     const isBridgePlanCommand = isBridgeSlashCommand && /^\/plan(?:\s|$)/i.test(content.trim())
@@ -1820,7 +1863,7 @@ export const useChatStore = defineStore('chat', () => {
         : undefined
       const runModelGroups = profileModelGroups?.length ? profileModelGroups : appStore.modelGroups
       const providerGroup = runModelGroups.find(group => group.provider === sessionProvider)
-      const sessionSource: StartRunRequest['source'] = activeSession.value?.source === 'coding_agent' ? 'coding_agent' : 'cli'
+      const sessionSource: StartRunRequest['source'] = isCodingAgentSession ? 'coding_agent' : 'cli'
       const codingAgentId: 'claude-code' | 'codex' =
         activeSession.value?.codingAgentId ||
         (activeSession.value?.agent === 'codex' ? 'codex' : 'claude-code')
@@ -1842,6 +1885,7 @@ export const useChatStore = defineStore('chat', () => {
         queue_id: userMsg.id,
         workspace: activeSession.value?.workspace || undefined,
         source: sessionSource,
+        ...(runtimeMode.value === 'global_agent' ? { session_source: 'global_agent' as const } : {}),
         ...(sessionSource === 'coding_agent'
           ? {
               coding_agent_id: codingAgentId,
@@ -2524,7 +2568,7 @@ export const useChatStore = defineStore('chat', () => {
           activeRunMarker = null
         },
         undefined,
-        { onReconnectResume: applyReconnectResume },
+        { onReconnectResume: applyReconnectResume, transport: runtimeTransport() },
       )
       runSubmitted = true
 
@@ -3088,7 +3132,7 @@ export const useChatStore = defineStore('chat', () => {
     // Mark as streaming so UI shows the indicator and can still abort after refresh.
     streamStates.value.set(sid, {
       abort: () => {
-        getChatRunSocket()?.emit('abort', { session_id: sid })
+        getChatRunSocket(runtimeTransport())?.emit('abort', { session_id: sid })
       },
     })
   }
@@ -3172,7 +3216,7 @@ export const useChatStore = defineStore('chat', () => {
     }
     if (serverWorking.value.has(sid)) {
       setAbortState({ aborting: true, synced: null })
-      getChatRunSocket()?.emit('abort', { session_id: sid })
+      getChatRunSocket(runtimeTransport())?.emit('abort', { session_id: sid })
       const msgs = getSessionMsgs(sid)
       const lastMsg = msgs[msgs.length - 1]
       if (lastMsg?.isStreaming) {
@@ -3213,7 +3257,7 @@ export const useChatStore = defineStore('chat', () => {
               activeSession.value.hasMoreBefore = data.hasMoreBefore ?? activeSession.value.loadedMessageCount < activeSession.value.messageTotal
             }
             resumeServerWorkingRun(sid)
-          }, activeSession.value?.profile)
+          }, activeSession.value?.profile, runtimeTransport())
         }
       }
     })
@@ -3336,6 +3380,7 @@ export const useChatStore = defineStore('chat', () => {
 
   return {
     sessions,
+    runtimeMode,
     activeSessionId,
     activeSession,
     focusMessageId,
@@ -3382,5 +3427,6 @@ export const useChatStore = defineStore('chat', () => {
     setAutoPlaySpeech,
     playMessageSpeech,
     setSessionReasoningEffort,
+    setRuntimeMode,
   }
 })

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -612,8 +612,19 @@ export const useChatStore = defineStore('chat', () => {
   const isLoadingMessages = ref(false)
   const isRunActive = computed(() => isStreaming.value)
 
-  function runtimeSessionSource(): string | undefined {
-    return runtimeMode.value === 'global_agent' ? 'global_agent' : undefined
+  async function fetchRuntimeSessions(profile?: string | null): Promise<SessionSummary[]> {
+    const scopedProfile = profile || undefined
+    if (runtimeMode.value === 'global_agent') return fetchSessions('global_agent', undefined, scopedProfile)
+
+    const [localSessions, globalSessions] = await Promise.all([
+      fetchSessions(undefined, undefined, scopedProfile),
+      fetchSessions('global_agent', undefined, scopedProfile),
+    ])
+    const byId = new Map<string, SessionSummary>()
+    for (const session of [...localSessions, ...globalSessions]) byId.set(session.id, session)
+    return [...byId.values()].sort((a, b) =>
+      (b.last_active || b.ended_at || b.started_at || 0) - (a.last_active || a.ended_at || a.started_at || 0),
+    )
   }
 
   function runtimeTransport(): ChatRunTransport {
@@ -714,7 +725,7 @@ export const useChatStore = defineStore('chat', () => {
   async function loadSessions(profile?: string | null, preferredSessionId?: string | null) {
     isLoadingSessions.value = true
     try {
-      const list = await fetchSessions(runtimeSessionSource(), undefined, profile || undefined)
+      const list = await fetchRuntimeSessions(profile)
       const fresh = list.map(mapHermesSession)
       // Preserve already-loaded messages for sessions that are still present,
       // so we don't blow away the active session's messages on refresh.
@@ -773,7 +784,7 @@ export const useChatStore = defineStore('chat', () => {
     if (isStreaming.value) return
     if (isLoadingSessions.value) return
     try {
-      const list = await fetchSessions(runtimeSessionSource(), undefined, profile ?? sessionProfileFilter.value ?? undefined)
+      const list = await fetchRuntimeSessions(profile ?? sessionProfileFilter.value)
       const incoming = list.map(mapHermesSession)
       const existingById = new Map(sessions.value.map(s => [s.id, s]))
       const incomingIds = new Set(incoming.map(s => s.id))
@@ -1863,7 +1874,11 @@ export const useChatStore = defineStore('chat', () => {
         : undefined
       const runModelGroups = profileModelGroups?.length ? profileModelGroups : appStore.modelGroups
       const providerGroup = runModelGroups.find(group => group.provider === sessionProvider)
-      const sessionSource: StartRunRequest['source'] = isCodingAgentSession ? 'coding_agent' : 'cli'
+      const sessionSource: StartRunRequest['source'] = activeSession.value?.source === 'global_agent'
+        ? 'global_agent'
+        : isCodingAgentSession
+          ? 'coding_agent'
+          : 'cli'
       const codingAgentId: 'claude-code' | 'codex' =
         activeSession.value?.codingAgentId ||
         (activeSession.value?.agent === 'codex' ? 'codex' : 'claude-code')

--- a/packages/client/src/views/hermes/GlobalAgentView.vue
+++ b/packages/client/src/views/hermes/GlobalAgentView.vue
@@ -24,32 +24,16 @@ const routeProfile = computed(() => {
   return typeof value === 'string' && value.trim() ? value : null
 })
 
-const productTitle = 'Hermes Studio'
-const tabTitle = computed(() => {
-  if (route.name !== 'hermes.session') return productTitle
-  return chatStore.activeSession?.title?.trim() || productTitle
-})
-
-watch(tabTitle, (value) => {
-  document.title = value
-}, { immediate: true })
-
-onUnmounted(() => {
-  document.title = productTitle
-})
-
 async function loadRouteSession() {
   await chatStore.loadSessions(chatStore.sessionProfileFilter, routeSessionId.value)
   if (routeSessionId.value && chatStore.activeSessionId !== routeSessionId.value) {
-    await router.replace({ name: 'hermes.chat' })
+    await router.replace({ name: 'hermes.globalAgent' })
   }
 }
 
 onMounted(async () => {
-  chatStore.setRuntimeMode('default')
+  chatStore.setRuntimeMode('global_agent')
   appStore.loadModels()
-  // 先加载 profile，确保缓存 key 使用正确的 profile name；同时预取显示设置，
-  // 让聊天完成提示音不依赖用户先打开 Settings 页面。
   await Promise.all([
     profilesStore.fetchProfiles(),
     settingsStore.fetchSettings(),
@@ -57,8 +41,12 @@ onMounted(async () => {
   await loadRouteSession()
 })
 
+onUnmounted(() => {
+  chatStore.setRuntimeMode('default')
+})
+
 watch([routeSessionId, routeProfile], async ([sessionId]) => {
-  if (!chatStore.sessionsLoaded) return
+  if (chatStore.runtimeMode !== 'global_agent' || !chatStore.sessionsLoaded) return
   if (!sessionId) {
     await chatStore.loadSessions(chatStore.sessionProfileFilter)
     return
@@ -76,13 +64,13 @@ watch([routeSessionId, routeProfile], async ([sessionId]) => {
 </script>
 
 <template>
-  <div class="chat-view">
+  <div class="global-agent-view">
     <ChatPanel />
   </div>
 </template>
 
 <style scoped lang="scss">
-.chat-view {
+.global-agent-view {
   height: calc(100 * var(--vh));
   display: flex;
   flex-direction: column;

--- a/packages/client/src/views/hermes/GroupChatView.vue
+++ b/packages/client/src/views/hermes/GroupChatView.vue
@@ -15,7 +15,12 @@ const routeRoomId = computed(() => {
 
 async function syncRouteRoom() {
     const roomId = routeRoomId.value
-    if (!roomId) return
+    if (!roomId) {
+        if (!store.currentRoomId && store.rooms.length > 0) {
+            await router.replace({ name: 'hermes.groupChatRoom', params: { roomId: store.rooms[0].id } })
+        }
+        return
+    }
 
     if (!store.rooms.some(room => room.id === roomId)) {
         await router.replace({ name: 'hermes.groupChat' })
@@ -33,8 +38,7 @@ onMounted(async () => {
     await syncRouteRoom()
 })
 
-watch(routeRoomId, async (roomId) => {
-    if (!roomId) return
+watch(routeRoomId, async () => {
     if (store.rooms.length === 0) return
     await syncRouteRoom()
 })

--- a/packages/server/src/controllers/api-docs.ts
+++ b/packages/server/src/controllers/api-docs.ts
@@ -1,0 +1,34 @@
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+import type { Context } from 'koa'
+
+function openApiCandidatePaths(): string[] {
+  return [
+    // Dev/test from source tree.
+    resolve(process.cwd(), 'docs/openapi.json'),
+    resolve(__dirname, '../../../../docs/openapi.json'),
+    // Bundled server: scripts/build-server.mjs copies the doc next to index.js.
+    resolve(__dirname, 'openapi.json'),
+    resolve(__dirname, '../openapi.json'),
+  ]
+}
+
+function readOpenApiDocument(): unknown {
+  for (const filePath of openApiCandidatePaths()) {
+    if (!existsSync(filePath)) continue
+    return JSON.parse(readFileSync(filePath, 'utf-8'))
+  }
+  return null
+}
+
+export async function openapi(ctx: Context) {
+  const doc = readOpenApiDocument()
+  if (!doc) {
+    ctx.status = 404
+    ctx.body = { error: 'OpenAPI document is not available' }
+    return
+  }
+
+  ctx.set('Cache-Control', 'no-store')
+  ctx.body = doc
+}

--- a/packages/server/src/controllers/auth.ts
+++ b/packages/server/src/controllers/auth.ts
@@ -11,6 +11,7 @@ import {
   findUserById,
   findUserByUsername,
   getUserAvatar,
+  listUserProfiles,
   listUsers,
   setUserAvatar,
   updateUser,
@@ -18,10 +19,12 @@ import {
   updateUserPassword,
   verifyPassword,
   type UserRole,
+  type UserRecord,
   type UserStatus,
 } from '../db/hermes/users-store'
 import { issueUserJwt } from '../middleware/user-auth'
 import { listProfileNamesFromDisk } from '../services/hermes/hermes-profile'
+import { startOutboundRelayClient } from '../services/global-agent/outbound-relay-client'
 
 /**
  * GET /api/auth/status
@@ -156,6 +159,47 @@ export async function updateMyAvatar(ctx: Context) {
   ctx.body = { success: true, avatar: validation.json }
 }
 
+async function passwordLogin(
+  ctx: Context,
+  username: string,
+  password: string,
+): Promise<{ ok: true; token: string; user: UserRecord } | { ok: false }> {
+  const ip = extractIp(ctx)
+  const result = checkPassword(ip)
+  if (!result.allowed) {
+    ctx.status = result.status
+    ctx.body = { error: 'Too many login attempts, please try again later' }
+    return { ok: false }
+  }
+
+  const existingUserCount = countUsers()
+  const user = existingUserCount === 0
+    ? bootstrapDefaultSuperAdmin(username, password)
+    : findUserByUsername(username)
+
+  if (!user || user.status !== 'active' || (existingUserCount > 0 && !verifyPassword(password, user.password_hash))) {
+    recordPasswordFailure(ip)
+    ctx.status = 401
+    ctx.body = { error: 'Invalid username or password' }
+    return { ok: false }
+  }
+
+  try {
+    const token = await issueUserJwt(user)
+    recordPasswordSuccess(ip)
+    return { ok: true, token, user }
+  } catch (err: any) {
+    ctx.status = 500
+    ctx.body = { error: err?.message || 'Failed to issue login token' }
+    return { ok: false }
+  }
+}
+
+function accessibleProfileNames(user: UserRecord): string[] {
+  if (user.role === 'super_admin') return listProfileNamesFromDisk()
+  return listUserProfiles(user.id).map(profile => profile.profile_name)
+}
+
 /**
  * POST /api/auth/login
  * Authenticate with username/password (public).
@@ -169,37 +213,81 @@ export async function login(ctx: Context) {
     return
   }
 
-  const ip = extractIp(ctx)
-  const result = checkPassword(ip)
-  if (!result.allowed) {
-    ctx.status = result.status
-    ctx.body = { error: 'Too many login attempts, please try again later' }
-    return
-  }
+  const result = await passwordLogin(ctx, username, password)
+  if (!result.ok) return
+  ctx.body = { token: result.token }
+}
 
-  const existingUserCount = countUsers()
-  const user = existingUserCount === 0
-    ? bootstrapDefaultSuperAdmin(username, password)
-    : findUserByUsername(username)
-
-  if (!user || user.status !== 'active' || (existingUserCount > 0 && !verifyPassword(password, user.password_hash))) {
-    recordPasswordFailure(ip)
-    ctx.status = 401
-    ctx.body = { error: 'Invalid username or password' }
-    return
-  }
-
-  let token: string
+function normalizeRelayUrl(input: string): string | null {
   try {
-    token = await issueUserJwt(user)
-  } catch (err: any) {
-    ctx.status = 500
-    ctx.body = { error: err?.message || 'Failed to issue login token' }
+    const url = new URL(input)
+    if (!['http:', 'https:', 'ws:', 'wss:'].includes(url.protocol)) return null
+    url.username = ''
+    url.password = ''
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * POST /api/auth/mcu-login
+ * Authenticate with the existing username/password login and connect this
+ * Hermes Studio instance to the relay URL provided by an MCU/device client.
+ * Body: { token, url, id, account, password }.
+ */
+export async function microcontrollerLogin(ctx: Context) {
+  const {
+    token: relayToken,
+    url,
+    id,
+    account,
+    password,
+  } = ctx.request.body as {
+    token?: string
+    url?: string
+    id?: string
+    account?: string
+    password?: string
+  }
+
+  if (!relayToken || !url || !id || !account || !password) {
+    ctx.status = 400
+    ctx.body = { error: 'token, url, id, account and password are required' }
     return
   }
 
-  recordPasswordSuccess(ip)
-  ctx.body = { token }
+  const relayUrl = normalizeRelayUrl(url)
+  if (!relayUrl) {
+    ctx.status = 400
+    ctx.body = { error: 'url must be a valid http, https, ws, or wss URL' }
+    return
+  }
+
+  const result = await passwordLogin(ctx, account, password)
+  if (!result.ok) return
+
+  const client = startOutboundRelayClient({
+    connectionId: id.trim(),
+    relayUrl,
+    relayToken,
+    instanceId: id.trim(),
+  })
+  if (!client) {
+    ctx.status = 400
+    ctx.body = { error: 'Failed to start relay client' }
+    return
+  }
+
+  ctx.body = {
+    token: result.token,
+    profiles: accessibleProfileNames(result.user),
+    relay: {
+      connected: true,
+      id: id.trim(),
+      url: relayUrl,
+    },
+  }
 }
 
 /**

--- a/packages/server/src/controllers/chat-run.ts
+++ b/packages/server/src/controllers/chat-run.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'koa'
+import { randomUUID } from 'crypto'
 import { io, type Socket } from 'socket.io-client'
 import { config } from '../config'
 
@@ -77,6 +78,16 @@ function userBody(body: ChatRunPayload): Record<string, unknown> {
   return payload
 }
 
+function generatedSessionId(): string {
+  return randomUUID()
+}
+
+function needsGeneratedCliSessionId(payload: Record<string, unknown>): boolean {
+  const source = typeof payload.source === 'string' ? payload.source.trim() : ''
+  const sessionId = typeof payload.session_id === 'string' ? payload.session_id.trim() : ''
+  return !sessionId && (!source || source === 'cli')
+}
+
 export async function runOnce(ctx: Context) {
   const body = (ctx.request.body || {}) as ChatRunPayload
   if (body.input == null) {
@@ -90,6 +101,7 @@ export async function runOnce(ctx: Context) {
   const token = bearerToken(ctx)
   const profile = profileFrom(ctx, body)
   const payload: Record<string, unknown> = { ...userBody(body), profile }
+  if (needsGeneratedCliSessionId(payload)) payload.session_id = generatedSessionId()
 
   ctx.body = await new Promise((resolve) => {
     const events: ChatRunEvent[] = []

--- a/packages/server/src/controllers/chat-run.ts
+++ b/packages/server/src/controllers/chat-run.ts
@@ -1,0 +1,189 @@
+import type { Context } from 'koa'
+import { io, type Socket } from 'socket.io-client'
+import { config } from '../config'
+
+type ChatRunPayload = Record<string, unknown> & {
+  input?: unknown
+  session_id?: unknown
+  profile?: unknown
+  timeout_ms?: unknown
+  include_events?: unknown
+}
+
+type ChatRunEvent = Record<string, unknown> & {
+  event?: string
+  session_id?: string
+  run_id?: string
+  delta?: string
+  text?: string
+  output?: string | null
+  reasoning?: string | null
+  error?: string
+}
+
+const CHAT_RUN_EVENTS = [
+  'run.started',
+  'message.delta',
+  'reasoning.delta',
+  'thinking.delta',
+  'reasoning.available',
+  'tool.started',
+  'tool.completed',
+  'run.completed',
+  'run.failed',
+  'compression.started',
+  'compression.completed',
+  'abort.started',
+  'abort.timeout',
+  'abort.completed',
+  'usage.updated',
+  'agent.event',
+  'subagent.event',
+  'session.command',
+  'session.title.updated',
+  'run.queued',
+  'approval.requested',
+  'approval.resolved',
+  'clarify.requested',
+  'clarify.resolved',
+  'peer.user.message',
+]
+
+const DEFAULT_TIMEOUT_MS = 300_000
+const MAX_TIMEOUT_MS = 1_800_000
+const MAX_RECORDED_EVENTS = 1000
+
+function bearerToken(ctx: Context): string {
+  const match = ctx.get('authorization').match(/^Bearer\s+(.+)$/i)
+  return match?.[1]?.trim() || ''
+}
+
+function requestTimeoutMs(value: unknown): number {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric) || numeric <= 0) return DEFAULT_TIMEOUT_MS
+  return Math.min(Math.floor(numeric), MAX_TIMEOUT_MS)
+}
+
+function chatRunBaseUrl(): string {
+  return (process.env.HERMES_WEB_UI_URL || `http://127.0.0.1:${config.port}`).replace(/\/$/, '')
+}
+
+function profileFrom(ctx: Context, body: ChatRunPayload): string {
+  return String(body.profile || ctx.state.profile?.name || 'default').trim() || 'default'
+}
+
+function userBody(body: ChatRunPayload): Record<string, unknown> {
+  const { timeout_ms: _timeoutMs, include_events: _includeEvents, ...payload } = body
+  return payload
+}
+
+export async function runOnce(ctx: Context) {
+  const body = (ctx.request.body || {}) as ChatRunPayload
+  if (body.input == null) {
+    ctx.status = 400
+    ctx.body = { ok: false, error: 'input is required' }
+    return
+  }
+
+  const timeoutMs = requestTimeoutMs(body.timeout_ms)
+  const includeEvents = body.include_events === true
+  const token = bearerToken(ctx)
+  const profile = profileFrom(ctx, body)
+  const payload: Record<string, unknown> = { ...userBody(body), profile }
+
+  ctx.body = await new Promise((resolve) => {
+    const events: ChatRunEvent[] = []
+    let output = ''
+    let reasoning = ''
+    let runId = ''
+    let settled = false
+
+    const socket: Socket = io(`${chatRunBaseUrl()}/chat-run`, {
+      auth: token ? { token } : {},
+      query: { profile },
+      transports: ['websocket', 'polling'],
+      reconnection: false,
+      timeout: 30_000,
+    })
+
+    const cleanup = () => {
+      clearTimeout(timer)
+      socket.removeAllListeners()
+      socket.disconnect()
+    }
+
+    const finish = (status: number, response: Record<string, unknown>) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      ctx.status = status
+      resolve({
+        ...response,
+        session_id: typeof payload.session_id === 'string' ? payload.session_id : undefined,
+        run_id: runId || undefined,
+        output,
+        ...(reasoning ? { reasoning } : {}),
+        ...(includeEvents ? { events } : {}),
+      })
+    }
+
+    const record = (event: ChatRunEvent) => {
+      if (!includeEvents) return
+      if (events.length >= MAX_RECORDED_EVENTS) events.shift()
+      events.push(event)
+    }
+
+    const timer = setTimeout(() => {
+      finish(504, {
+        ok: false,
+        status: 'timeout',
+        error: `chat-run timed out after ${timeoutMs}ms`,
+      })
+    }, timeoutMs)
+
+    socket.on('connect_error', (err: Error) => {
+      finish(503, {
+        ok: false,
+        status: 'connect_error',
+        error: err.message,
+      })
+    })
+
+    socket.on('connect', () => {
+      socket.emit('run', payload)
+    })
+
+    for (const eventName of CHAT_RUN_EVENTS) {
+      socket.on(eventName, (event: ChatRunEvent = {}) => {
+        const tagged = { ...event, event: event.event || eventName }
+        record(tagged)
+        if (typeof tagged.run_id === 'string' && tagged.run_id) runId = tagged.run_id
+        if (eventName === 'message.delta' && typeof tagged.delta === 'string') output += tagged.delta
+        if ((eventName === 'reasoning.delta' || eventName === 'thinking.delta') && typeof tagged.delta === 'string') reasoning += tagged.delta
+        if (eventName === 'run.completed') {
+          if (typeof tagged.output === 'string' && tagged.output) output = tagged.output
+          if (typeof tagged.reasoning === 'string' && tagged.reasoning) reasoning = tagged.reasoning
+          finish(200, { ok: true, status: 'completed', event: eventName })
+          return
+        }
+        if (eventName === 'run.failed') {
+          finish(500, {
+            ok: false,
+            status: 'failed',
+            event: eventName,
+            error: tagged.error || 'chat-run failed',
+          })
+          return
+        }
+        if (eventName === 'approval.requested' || eventName === 'clarify.requested') {
+          finish(409, {
+            ok: false,
+            status: 'requires_action',
+            event: eventName,
+            action: tagged,
+          })
+        }
+      })
+    }
+  })
+}

--- a/packages/server/src/controllers/chat-run.ts
+++ b/packages/server/src/controllers/chat-run.ts
@@ -82,10 +82,9 @@ function generatedSessionId(): string {
   return randomUUID()
 }
 
-function needsGeneratedCliSessionId(payload: Record<string, unknown>): boolean {
-  const source = typeof payload.source === 'string' ? payload.source.trim() : ''
+function needsGeneratedSessionId(payload: Record<string, unknown>): boolean {
   const sessionId = typeof payload.session_id === 'string' ? payload.session_id.trim() : ''
-  return !sessionId && (!source || source === 'cli')
+  return !sessionId
 }
 
 export async function runOnce(ctx: Context) {
@@ -101,7 +100,7 @@ export async function runOnce(ctx: Context) {
   const token = bearerToken(ctx)
   const profile = profileFrom(ctx, body)
   const payload: Record<string, unknown> = { ...userBody(body), profile }
-  if (needsGeneratedCliSessionId(payload)) payload.session_id = generatedSessionId()
+  if (needsGeneratedSessionId(payload)) payload.session_id = generatedSessionId()
 
   ctx.body = await new Promise((resolve) => {
     const events: ChatRunEvent[] = []

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -99,6 +99,26 @@ function denySessionAccess(ctx: any, session: any | null | undefined): boolean {
   return true
 }
 
+function isVisibleWebUiSessionSource(source?: string | null): boolean {
+  return source === 'api_server' || source === 'cli' || source === 'coding_agent'
+}
+
+function isRequestedSessionSource(source: string | undefined, sessionSource?: string | null): boolean {
+  if (source === 'global_agent') return sessionSource === 'global_agent'
+  return isVisibleWebUiSessionSource(sessionSource)
+}
+
+function isHermesHistorySessionSource(source?: string | null): boolean {
+  return source !== 'api_server' && source !== 'global_agent'
+}
+
+function isCodingAgentSession(session?: { source?: string | null; agent?: string | null; agent_session_id?: string | null } | null): boolean {
+  return session?.source === 'coding_agent' ||
+    session?.agent === 'claude' ||
+    session?.agent === 'codex' ||
+    Boolean(session?.agent_session_id)
+}
+
 interface HermesDeleteResult {
   attempted: boolean
   deleted: boolean
@@ -350,7 +370,7 @@ export async function list(ctx: any) {
   const knownProfiles = profile ? null : new Set(listProfileNamesFromDisk())
   ctx.body = {
     sessions: filterPendingDeletedSessions(filterByAllowedProfiles(ctx, allSessions).filter(s =>
-      (s.source === 'api_server' || s.source === 'cli' || s.source === 'coding_agent') &&
+      isRequestedSessionSource(source, s.source) &&
       (!knownProfiles || knownProfiles.has(s.profile || 'default')),
     )),
   }
@@ -372,18 +392,20 @@ export async function listHermesSessions(ctx: any) {
       ...(profile ? { ...session, profile } : session),
       webui_imported: importedIds.has(session.id),
     }))
-  ctx.body = { sessions: filterPendingDeletedSessions(filterByAllowedProfiles(ctx, allSessions).filter(s => s.source !== 'api_server')) }
+  ctx.body = { sessions: filterPendingDeletedSessions(filterByAllowedProfiles(ctx, allSessions).filter(s => isHermesHistorySessionSource(s.source))) }
 }
 
 export async function search(ctx: any) {
   const q = typeof ctx.query.q === 'string' ? ctx.query.q : ''
+  const source = (ctx.query.source as string) || undefined
   const limit = ctx.query.limit ? parseInt(ctx.query.limit as string, 10) : undefined
   const profile = explicitProfileFilter(ctx)
   const results = localSearchSessions(profile, q, limit && limit > 0 ? limit : 20)
   const knownProfiles = profile ? null : new Set(listProfileNamesFromDisk())
   ctx.body = {
     results: filterPendingDeletedSessions(filterByAllowedProfiles(ctx, results).filter(s =>
-      !knownProfiles || knownProfiles.has(s.profile || 'default'),
+      isRequestedSessionSource(source, s.source) &&
+      (!knownProfiles || knownProfiles.has(s.profile || 'default')),
     )),
   }
 }
@@ -411,7 +433,7 @@ export async function getHermesSession(ctx: any) {
   // used by chat rendering and compression.
   const localSession = localGetSessionDetail(ctx.params.id)
   const localSessionProfile = (localSession?.profile || 'default') as string
-  if (localSession && localSession.source !== 'api_server' && (!profile || localSessionProfile === profile)) {
+  if (localSession && isHermesHistorySessionSource(localSession.source) && (!profile || localSessionProfile === profile)) {
     if (denySessionAccess(ctx, localSession)) return
     ctx.body = { session: localSession }
     return
@@ -422,7 +444,7 @@ export async function getHermesSession(ctx: any) {
     const session = profile
       ? await getSessionDetailFromDbWithProfile(ctx.params.id, profile)
       : await getSessionDetailFromDb(ctx.params.id)
-    if (session && session.source !== 'api_server') {
+    if (session && isHermesHistorySessionSource(session.source)) {
       const sessionWithProfile = profile ? { ...session, profile } : session
       if (denySessionAccess(ctx, sessionWithProfile)) return
       ctx.body = { session: sessionWithProfile }
@@ -439,8 +461,8 @@ export async function getHermesSession(ctx: any) {
     ctx.body = { error: 'Session not found' }
     return
   }
-  // Filter out api_server sessions
-  if (session.source === 'api_server') {
+  // Filter out Web UI-only session sources.
+  if (!isHermesHistorySessionSource(session.source)) {
     ctx.status = 404
     ctx.body = { error: 'Session not found' }
     return
@@ -542,9 +564,9 @@ export async function remove(ctx: any) {
   const existing = localGetSession(sessionId)
   if (denySessionAccess(ctx, existing)) return
   const hermesProfile = requestedProfile(ctx) || existing?.profile || getActiveProfileName()
-  const isCodingAgentSession = existing?.source === 'coding_agent'
-  if (isCodingAgentSession) codingAgentRunManager.stop(sessionId, { reportClosed: false })
-  const hermes = isCodingAgentSession
+  const codingAgentSession = isCodingAgentSession(existing)
+  if (codingAgentSession) codingAgentRunManager.stop(sessionId, { reportClosed: false })
+  const hermes = codingAgentSession
     ? { attempted: false, deleted: false, profile: hermesProfile }
     : await deleteHermesSessionIfPresent(sessionId, hermesProfile)
   const localDeleted = existing ? localDeleteSession(sessionId) : true
@@ -612,9 +634,9 @@ export async function batchRemove(ctx: any) {
       continue
     }
 
-    const isCodingAgentSession = existing?.source === 'coding_agent'
-    if (isCodingAgentSession) codingAgentRunManager.stop(id, { reportClosed: false })
-    const hermes = isCodingAgentSession
+    const codingAgentSession = isCodingAgentSession(existing)
+    if (codingAgentSession) codingAgentRunManager.stop(id, { reportClosed: false })
+    const hermes = codingAgentSession
       ? { attempted: false, deleted: false, profile: targetProfile || 'default' }
       : await deleteHermesSessionIfPresent(id, targetProfile)
     if (hermes.deleted) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -26,6 +26,8 @@ import { ensureProfileGatewaysRunning } from './services/hermes/gateway-autostar
 import { refreshConfiguredProviderModelCatalogsInBackground } from './services/hermes/model-catalog-cache'
 import { scanLanDevices, startLanDiscoveryResponder } from './services/lan-discovery'
 import { getLanPeerSocketManager, getLanPeerSocketPath } from './services/lan-peer-socket'
+import { startGlobalAgentServer } from './services/global-agent/server'
+import { startOutboundRelayClient } from './services/global-agent/outbound-relay-client'
 import { logger } from './services/logger'
 import { createStaticCompressionMiddleware } from './middleware/static-compression'
 import { requireUserJwt, resolveUserProfile } from './middleware/user-auth'
@@ -58,6 +60,8 @@ let chatRunServer: any = null
 let agentBridgeManager: any = null
 let desktopShutdownHandler: ShutdownHandler | null = null
 
+const LOCAL_GLOBAL_AGENT_CONNECTION_ID = 'local-global-agent'
+
 interface ListenResult {
   primary: any
   servers: any[]
@@ -76,6 +80,12 @@ async function listenWithFallback(app: Koa, port: number, host?: string): Promis
   console.log(`[bootstrap] listening on ${bindHost}:${port}`)
   const primary = await listen(app, port, bindHost)
   return { primary, servers: [primary] }
+}
+
+function getLoopbackBaseUrl(httpServer: any): string {
+  const address = httpServer?.address?.()
+  const port = typeof address === 'object' && address?.port ? address.port : config.port
+  return `http://127.0.0.1:${port}`
 }
 
 /**
@@ -330,6 +340,17 @@ export async function bootstrap() {
   chatRunServer = new ChatRunSocket(groupChatServer.getIO())
   setChatRunServer(chatRunServer)
   chatRunServer.init()
+
+  const loopbackBaseUrl = getLoopbackBaseUrl(server)
+  const globalAgentServer = startGlobalAgentServer(groupChatServer.getIO())
+  startOutboundRelayClient({
+    connectionId: LOCAL_GLOBAL_AGENT_CONNECTION_ID,
+    relayUrl: `${loopbackBaseUrl}${globalAgentServer.getNamespace()}`,
+    relayToken: globalAgentServer.getAuthToken(),
+    instanceId: LOCAL_GLOBAL_AGENT_CONNECTION_ID,
+    localBaseUrl: loopbackBaseUrl,
+  })
+  console.log('[bootstrap] local global agent connected')
 
   // Session deleter — periodically drain pending session deletes
   const { SessionDeleter } = await import('./services/hermes/session-deleter')

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -303,8 +303,7 @@ export async function bootstrap() {
   registerDesktopShutdownRoute(app)
 
   // Register all routes (handles auth internally)
-  const proxyMiddleware = registerRoutes(app, [requireUserJwt, resolveUserProfile])
-  app.use(proxyMiddleware)
+  registerRoutes(app, [requireUserJwt, resolveUserProfile])
   console.log('[bootstrap] routes registered')
 
   // SPA fallback

--- a/packages/server/src/lib/llm-prompt.ts
+++ b/packages/server/src/lib/llm-prompt.ts
@@ -74,6 +74,17 @@ export const AI_OUTPUT_FORMAT_GUIDELINES = `
 `;
 
 /**
+ * Stable Hermes Studio MCP usage guidance. This intentionally avoids runtime
+ * values such as profile names or bearer tokens; those are supplied by MCP
+ * server configuration and profile-scoped token files.
+ */
+export const HERMES_MCP_USAGE_GUIDELINES = [
+  'Hermes Studio MCP usage: call hermes_api_openapi_get before calling unfamiliar Web UI endpoints.',
+  'Use hermes_api_request with method, relative path, and JSON body/query fields that match the OpenAPI requestBody and parameters. Do not call full URLs.',
+  'Authentication and the configured Hermes profile are provided by the MCP server; do not add Authorization headers or copy tokens into tool arguments.',
+];
+
+/**
  * Get the complete system prompt with format guidelines
  * @param customPrompt - Optional custom system prompt to prepend
  * @returns Complete system prompt string
@@ -85,6 +96,7 @@ export function getSystemPrompt(customPrompt?: string): string {
     parts.push(customPrompt);
   }
 
+  parts.push(HERMES_MCP_USAGE_GUIDELINES.join('\n'));
   parts.push(AI_OUTPUT_FORMAT_GUIDELINES);
 
   return parts.join('\n\n');

--- a/packages/server/src/lib/llm-prompt.ts
+++ b/packages/server/src/lib/llm-prompt.ts
@@ -79,7 +79,8 @@ export const AI_OUTPUT_FORMAT_GUIDELINES = `
  * server configuration and profile-scoped token files.
  */
 export const HERMES_MCP_USAGE_GUIDELINES = [
-  'Hermes Studio MCP usage: call hermes_api_openapi_get before calling unfamiliar Web UI endpoints.',
+  'Hermes Studio MCP usage: when the user asks to read/check the operation manual, API docs, endpoint docs, 接口文档, 接口手册, or 操作手册, immediately call hermes_api_openapi_get without filters to list API module outlines.',
+  'Use the module purpose and keywords from hermes_api_openapi_get to choose the right module, then call it again with a tag, path, or method filter before calling unfamiliar Web UI endpoints.',
   'Use hermes_api_request with method, relative path, and JSON body/query fields that match the OpenAPI requestBody and parameters. Do not call full URLs.',
   'Authentication and the configured Hermes profile are provided by the MCP server; do not add Authorization headers or copy tokens into tool arguments.',
 ];

--- a/packages/server/src/middleware/user-auth.ts
+++ b/packages/server/src/middleware/user-auth.ts
@@ -41,6 +41,7 @@ declare module 'koa' {
 
 const JWT_AUDIENCE = 'hermes-web-ui'
 const DEFAULT_EXPIRES_SECONDS = 60 * 60 * 24 * 30
+export const MODEL_RUN_EXPIRES_SECONDS = 60 * 60
 
 function base64UrlJson(value: unknown): string {
   return Buffer.from(JSON.stringify(value)).toString('base64url')
@@ -73,19 +74,10 @@ function requestToken(ctx: Context): string {
 const SERVER_TOKEN_EXACT_PATHS = new Set([
   '/api/hermes/media/apikey-image-generate',
   '/api/hermes/media/grok-image-to-video',
-  '/api/devices',
-  '/api/devices/scan',
-  '/api/devices/peer-connections',
 ])
 
 function allowsServerTokenPath(path: string): boolean {
-  if (SERVER_TOKEN_EXACT_PATHS.has(path)) return true
-  return /^\/api\/devices\/[^/]+\/connect$/.test(path) ||
-    /^\/api\/devices\/peer-connections\/[^/]+\/disconnect$/.test(path) ||
-    /^\/api\/devices\/peer-connections\/[^/]+\/terminal$/.test(path) ||
-    /^\/api\/devices\/peer-connections\/[^/]+\/terminals$/.test(path) ||
-    /^\/api\/devices\/peer-connections\/[^/]+\/terminal\/[^/]+\/(read|input|resize|close)$/.test(path) ||
-    /^\/api\/devices\/peer-connections\/[^/]+\/(exec|download|upload)$/.test(path)
+  return SERVER_TOKEN_EXACT_PATHS.has(path)
 }
 
 function isLoopbackRequest(ctx: Context): boolean {
@@ -116,7 +108,12 @@ function isProtectedHttpPath(path: string): boolean {
     lowerPath.startsWith('/upload')
 }
 
-export function signUserJwt(user: Pick<UserRecord, 'id' | 'username' | 'role'>, secret: string, now = Date.now()): string {
+export function signUserJwt(
+  user: Pick<UserRecord, 'id' | 'username' | 'role'>,
+  secret: string,
+  now = Date.now(),
+  expiresSeconds = DEFAULT_EXPIRES_SECONDS,
+): string {
   const iat = Math.floor(now / 1000)
   const payload: JwtPayload = {
     sub: String(user.id),
@@ -125,7 +122,7 @@ export function signUserJwt(user: Pick<UserRecord, 'id' | 'username' | 'role'>, 
     type: 'access',
     aud: JWT_AUDIENCE,
     iat,
-    exp: iat + DEFAULT_EXPIRES_SECONDS,
+    exp: iat + expiresSeconds,
   }
   const header = base64UrlJson({ alg: 'HS256', typ: 'JWT' })
   const body = base64UrlJson(payload)
@@ -155,6 +152,11 @@ export function verifyUserJwt(token: string, secret: string, now = Date.now()): 
 export async function issueUserJwt(user: Pick<UserRecord, 'id' | 'username' | 'role'>): Promise<string> {
   const secret = await getJwtSecret()
   return signUserJwt(user, secret)
+}
+
+export async function issueModelRunJwt(user: Pick<UserRecord, 'id' | 'username' | 'role'>): Promise<string> {
+  const secret = await getJwtSecret()
+  return signUserJwt(user, secret, Date.now(), MODEL_RUN_EXPIRES_SECONDS)
 }
 
 export function toAuthenticatedUser(user: Pick<UserRecord, 'id' | 'username' | 'role'>): AuthenticatedUser {

--- a/packages/server/src/routes/api-docs.ts
+++ b/packages/server/src/routes/api-docs.ts
@@ -1,0 +1,7 @@
+import Router from '@koa/router'
+import * as ctrl from '../controllers/api-docs'
+
+export const apiDocsRoutes = new Router()
+
+apiDocsRoutes.get('/api/openapi.json', ctrl.openapi)
+apiDocsRoutes.get('/api/hermes/openapi.json', ctrl.openapi)

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -6,6 +6,7 @@ import { requireSuperAdmin } from '../middleware/user-auth'
 export const authPublicRoutes = new Router()
 authPublicRoutes.get('/api/auth/status', ctrl.authStatus)
 authPublicRoutes.post('/api/auth/login', ctrl.login)
+authPublicRoutes.post('/api/auth/mcu-login', ctrl.microcontrollerLogin)
 
 // Protected routes (auth required)
 export const authProtectedRoutes = new Router()

--- a/packages/server/src/routes/devices.ts
+++ b/packages/server/src/routes/devices.ts
@@ -1,5 +1,6 @@
 import Router from '@koa/router'
 import * as ctrl from '../controllers/devices'
+import { requireSuperAdmin } from '../middleware/user-auth'
 
 export const devicePublicRoutes = new Router()
 export const deviceRoutes = new Router()
@@ -8,6 +9,7 @@ devicePublicRoutes.post('/api/devices/link-request', ctrl.requestDeviceLinkContr
 devicePublicRoutes.post('/api/devices/link-status', ctrl.requestDeviceLinkStatusController)
 devicePublicRoutes.get('/api/devices/link-info', ctrl.deviceLinkInfoController)
 
+deviceRoutes.use(requireSuperAdmin)
 deviceRoutes.get('/api/devices', ctrl.listDevices)
 deviceRoutes.get('/api/devices/pairing-link', ctrl.getDevicePairingLink)
 deviceRoutes.post('/api/devices/scan', ctrl.scanDevices)

--- a/packages/server/src/routes/hermes/chat-run.ts
+++ b/packages/server/src/routes/hermes/chat-run.ts
@@ -1,6 +1,12 @@
 import type { ChatRunSocket } from '../../services/hermes/run-chat'
+import Router from '@koa/router'
+import * as ctrl from '../../controllers/chat-run'
 
 let chatRunServer: ChatRunSocket | null = null
+
+export const chatRunRoutes = new Router()
+
+chatRunRoutes.post('/api/chat-run/runs', ctrl.runOnce)
 
 export function setChatRunServer(server: ChatRunSocket): void {
   chatRunServer = server

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -37,7 +37,6 @@ import { kanbanRoutes } from './hermes/kanban'
 import { ttsRoutes, ttsProtectedRoutes } from './hermes/tts'
 import { sttProtectedRoutes } from './hermes/stt'
 import { mediaRoutes } from './hermes/media'
-import { proxyRoutes, proxyMiddleware } from './hermes/proxy'
 import { groupChatRoutes, setGroupChatServer } from './hermes/group-chat'
 import { chatRunRoutes } from './hermes/chat-run'
 import { performanceMonitorRoutes } from './hermes/performance-monitor'
@@ -48,7 +47,7 @@ import { writeGateRoutes } from './hermes/write-gate'
 /**
  * Register all routes on the Koa app.
  * Public routes are registered first, then auth middleware,
- * then all protected routes. Returns the proxy middleware (must be mounted last).
+ * then all protected routes.
  */
 export function registerRoutes(app: any, authMiddleware: Array<(ctx: Context, next: Next) => Promise<void>>) {
   // --- Public routes (no auth required) ---
@@ -87,21 +86,17 @@ export function registerRoutes(app: any, authMiddleware: Array<(ctx: Context, ne
   app.use(geminiAuthRoutes.routes())
   app.use(weixinRoutes.routes())
   app.use(chatRunRoutes.routes())
-  app.use(groupChatRoutes.routes())       // Must be before proxy
-  app.use(fileRoutes.routes())              // Must be before proxy (proxy catch-all matches everything)
-  app.use(downloadRoutes.routes())          // Must be before proxy
-  app.use(jobRoutes.routes())               // Must be before proxy
-  app.use(cronHistoryRoutes.routes())        // Must be before proxy
-  app.use(kanbanRoutes.routes())             // Must be before proxy
+  app.use(groupChatRoutes.routes())
+  app.use(fileRoutes.routes())
+  app.use(downloadRoutes.routes())
+  app.use(jobRoutes.routes())
+  app.use(cronHistoryRoutes.routes())
+  app.use(kanbanRoutes.routes())
   app.use(ttsProtectedRoutes.routes())
   app.use(sttProtectedRoutes.routes())
-  app.use(mediaRoutes.routes())              // Must be before proxy
-  app.use(performanceMonitorRoutes.routes())  // Must be before proxy
+  app.use(mediaRoutes.routes())
+  app.use(performanceMonitorRoutes.routes())
   app.use(mcpRoutes.routes())                   // MCP management
   app.use(runtimeVersionRoutes.routes())         // Runtime and version management
   app.use(writeGateRoutes.routes())              // Hermes Agent write approval review
-  app.use(proxyRoutes.routes())
-
-  // Proxy catch-all middleware (must be last)
-  return proxyMiddleware
 }

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -8,6 +8,7 @@ import { updateRoutes } from './update'
 import { authPublicRoutes, authProtectedRoutes } from './auth'
 import { devicePublicRoutes, deviceRoutes } from './devices'
 import { codingAgentRoutes } from './coding-agents'
+import { apiDocsRoutes } from './api-docs'
 import { claudeCodeProxyRoutes } from './claude-code-proxy'
 import { codexProxyRoutes } from './codex-proxy'
 
@@ -38,6 +39,7 @@ import { sttProtectedRoutes } from './hermes/stt'
 import { mediaRoutes } from './hermes/media'
 import { proxyRoutes, proxyMiddleware } from './hermes/proxy'
 import { groupChatRoutes, setGroupChatServer } from './hermes/group-chat'
+import { chatRunRoutes } from './hermes/chat-run'
 import { performanceMonitorRoutes } from './hermes/performance-monitor'
 import { mcpRoutes } from './hermes/mcp'
 import { runtimeVersionRoutes } from './hermes/runtime-versions'
@@ -57,6 +59,7 @@ export function registerRoutes(app: any, authMiddleware: Array<(ctx: Context, ne
   app.use(claudeCodeProxyRoutes.routes())
   app.use(codexProxyRoutes.routes())
   app.use(ttsRoutes.routes())
+  app.use(apiDocsRoutes.routes())
 
   // --- Auth middleware: all routes below require authentication ---
   authMiddleware.forEach((middleware) => app.use(middleware))
@@ -83,6 +86,7 @@ export function registerRoutes(app: any, authMiddleware: Array<(ctx: Context, ne
   app.use(anthropicAuthRoutes.routes())
   app.use(geminiAuthRoutes.routes())
   app.use(weixinRoutes.routes())
+  app.use(chatRunRoutes.routes())
   app.use(groupChatRoutes.routes())       // Must be before proxy
   app.use(fileRoutes.routes())              // Must be before proxy (proxy catch-all matches everything)
   app.use(downloadRoutes.routes())          // Must be before proxy

--- a/packages/server/src/services/agent-runner/adapters/responses-stream.ts
+++ b/packages/server/src/services/agent-runner/adapters/responses-stream.ts
@@ -1,7 +1,9 @@
 import { readSseFrameTexts } from '../sse'
+import { normalizeResponseFunctionCall, responseToolNamespaceForName } from './responses'
 
 export interface ResponsesStreamAdapterTarget {
   model: string
+  annotateMcpToolNamespaces?: boolean
 }
 
 export interface CanonicalResponsesEvent {
@@ -14,6 +16,27 @@ function safeJsonParse(value: string): any {
     return JSON.parse(value)
   } catch {
     return {}
+  }
+}
+
+function functionCallItem(input: {
+  id: string
+  callId?: string
+  name: string
+  arguments: string
+  annotateNamespace?: boolean
+}) {
+  const normalized = input.annotateNamespace
+    ? normalizeResponseFunctionCall(input.name, input.arguments)
+    : { name: input.name, arguments: input.arguments, namespace: undefined }
+  const namespace = input.annotateNamespace ? normalized.namespace || responseToolNamespaceForName(input.name) : undefined
+  return {
+    type: 'function_call',
+    id: input.id,
+    call_id: input.callId || input.id,
+    name: normalized.name,
+    arguments: normalized.arguments,
+    ...(namespace ? { namespace } : {}),
   }
 }
 
@@ -146,13 +169,7 @@ export async function* openAiChatSseToResponsesEvents(
               data: {
                 type: 'response.output_item.added',
                 output_index: textStarted ? index + 1 : index,
-                item: {
-                  type: 'function_call',
-                  id: call.id,
-                  call_id: call.id,
-                  name: call.name,
-                  arguments: '',
-                },
+                item: functionCallItem({ id: call.id, name: call.name, arguments: '', annotateNamespace: target.annotateMcpToolNamespaces }),
               },
             }
           }
@@ -223,13 +240,7 @@ export async function* openAiChatSseToResponsesEvents(
 
   for (const [index, call] of toolCalls.entries()) {
     const outputIndex = textStarted ? index + 1 : index
-    const callItem = {
-      type: 'function_call',
-      id: call.id,
-      call_id: call.id,
-      name: call.name,
-      arguments: call.arguments || '{}',
-    }
+    const callItem = functionCallItem({ id: call.id, name: call.name, arguments: call.arguments || '{}', annotateNamespace: target.annotateMcpToolNamespaces })
     output.push(callItem)
     yield {
       type: 'response.output_item.done',
@@ -340,7 +351,7 @@ export async function* anthropicMessagesSseToResponsesEvents(
         data: {
           type: 'response.output_item.added',
           output_index: textStarted ? index + 1 : index,
-          item: { type: 'function_call', id: block.id, call_id: block.id, name: block.name, arguments: '' },
+          item: functionCallItem({ id: block.id, name: block.name, arguments: '', annotateNamespace: target.annotateMcpToolNamespaces }),
         },
       }
     }
@@ -467,13 +478,7 @@ export async function* anthropicMessagesSseToResponsesEvents(
   }
   for (const [index, block] of toolBlocks.entries()) {
     const outputIndex = textStarted ? index + 1 : index
-    const item = {
-      type: 'function_call',
-      id: block.id,
-      call_id: block.id,
-      name: block.name,
-      arguments: block.arguments || '{}',
-    }
+    const item = functionCallItem({ id: block.id, name: block.name, arguments: block.arguments || '{}', annotateNamespace: target.annotateMcpToolNamespaces })
     output.push(item)
     yield {
       type: 'response.output_item.done',

--- a/packages/server/src/services/agent-runner/adapters/responses.ts
+++ b/packages/server/src/services/agent-runner/adapters/responses.ts
@@ -2,6 +2,239 @@ export interface ResponsesAdapterTarget {
   model: string
 }
 
+const HERMES_STUDIO_NAMESPACE = 'mcp__hermes_studio'
+
+const HERMES_STUDIO_MCP_TOOLS = [
+  {
+    name: 'hermes_lan_devices_list',
+    description: 'List known LAN and remote devices from Hermes Web UI, including pairing and online status.',
+    inputSchema: inputSchema(),
+  },
+  {
+    name: 'hermes_lan_devices_scan',
+    description: 'Refresh LAN device discovery cache and return known devices with pairing and online status.',
+    inputSchema: inputSchema(),
+  },
+  {
+    name: 'hermes_lan_peer_connect',
+    description: 'Connect to a paired LAN device by device id.',
+    inputSchema: inputSchema({ device_id: { type: 'string' } }, ['device_id']),
+  },
+  {
+    name: 'hermes_lan_peer_connections',
+    description: 'List active LAN peer socket connections.',
+    inputSchema: inputSchema(),
+  },
+  {
+    name: 'hermes_lan_peer_disconnect',
+    description: 'Disconnect an active LAN peer socket connection.',
+    inputSchema: inputSchema({ connection_id: { type: 'string' } }, ['connection_id']),
+  },
+  {
+    name: 'hermes_lan_terminal_create',
+    description: 'Create an interactive terminal on a connected LAN peer.',
+    inputSchema: inputSchema({
+      connection_id: { type: 'string' },
+      shell: { type: 'string' },
+      cols: { type: 'number' },
+      rows: { type: 'number' },
+    }, ['connection_id']),
+  },
+  {
+    name: 'hermes_lan_terminal_list',
+    description: 'List interactive terminals tracked for a connected LAN peer, including IDs that can be read or closed.',
+    inputSchema: inputSchema({ connection_id: { type: 'string' } }, ['connection_id']),
+  },
+  {
+    name: 'hermes_lan_terminal_input',
+    description: 'Write input to an interactive terminal on a connected LAN peer.',
+    inputSchema: inputSchema({
+      connection_id: { type: 'string' },
+      terminal_id: { type: 'string' },
+      data: { type: 'string' },
+    }, ['connection_id', 'terminal_id', 'data']),
+  },
+  {
+    name: 'hermes_lan_terminal_read',
+    description: 'Read buffered terminal output from an interactive terminal.',
+    inputSchema: inputSchema({
+      connection_id: { type: 'string' },
+      terminal_id: { type: 'string' },
+    }, ['connection_id', 'terminal_id']),
+  },
+  {
+    name: 'hermes_lan_terminal_resize',
+    description: 'Resize an interactive terminal on a connected LAN peer.',
+    inputSchema: inputSchema({
+      connection_id: { type: 'string' },
+      terminal_id: { type: 'string' },
+      cols: { type: 'number' },
+      rows: { type: 'number' },
+    }, ['connection_id', 'terminal_id', 'cols', 'rows']),
+  },
+  {
+    name: 'hermes_lan_terminal_close',
+    description: 'Close an interactive terminal on a connected LAN peer.',
+    inputSchema: inputSchema({
+      connection_id: { type: 'string' },
+      terminal_id: { type: 'string' },
+    }, ['connection_id', 'terminal_id']),
+  },
+  {
+    name: 'hermes_lan_command_exec',
+    description: 'Run a command on a connected LAN peer using command plus args, without shell string execution.',
+    inputSchema: inputSchema({
+      connection_id: { type: 'string' },
+      command: { type: 'string' },
+      args: { type: 'array', items: { type: 'string' } },
+      cwd: { type: 'string' },
+      timeout_ms: { type: 'number' },
+    }, ['connection_id', 'command']),
+  },
+  {
+    name: 'hermes_lan_file_download',
+    description: 'Download a file from a connected LAN peer remote path to a local path on this machine.',
+    inputSchema: inputSchema({
+      connection_id: { type: 'string' },
+      remote_path: { type: 'string' },
+      local_path: { type: 'string' },
+      timeout_ms: { type: 'number' },
+    }, ['connection_id', 'remote_path', 'local_path']),
+  },
+  {
+    name: 'hermes_lan_file_upload',
+    description: 'Upload a local file path from this machine to a connected LAN peer remote path.',
+    inputSchema: inputSchema({
+      connection_id: { type: 'string' },
+      local_path: { type: 'string' },
+      remote_path: { type: 'string' },
+      timeout_ms: { type: 'number' },
+    }, ['connection_id', 'local_path', 'remote_path']),
+  },
+]
+
+const HERMES_STUDIO_MCP_TOOL_NAMES = new Set(HERMES_STUDIO_MCP_TOOLS.map(tool => tool.name))
+
+function inputSchema(properties: Record<string, unknown> = {}, required: string[] = []) {
+  return {
+    type: 'object',
+    properties: {
+      token: {
+        type: 'string',
+        description: 'Optional Hermes Web UI bearer token. Use the current model run token when one is provided in the run instructions.',
+      },
+      profile: {
+        type: 'string',
+        description: 'Optional Hermes profile name for profile-scoped Web UI requests.',
+      },
+      ...properties,
+    },
+    ...(required.length ? { required } : {}),
+    additionalProperties: false,
+  }
+}
+
+function normalizedNamespaceName(value: unknown): string {
+  return String(value || '').trim().replace(/-/g, '_')
+}
+
+function expandedResponseTools(tools: unknown): any[] {
+  if (!Array.isArray(tools)) return []
+  const mapped: any[] = []
+  const seen = new Set<string>()
+  const addFunctionTool = (tool: any) => {
+    const name = String(tool?.name || '').trim()
+    if (!name || seen.has(name)) return
+    seen.add(name)
+    mapped.push({
+      type: 'function',
+      name,
+      description: String(tool?.description || ''),
+      parameters: tool?.parameters || tool?.inputSchema || { type: 'object', properties: {} },
+      ...(tool?.namespace ? { namespace: tool.namespace } : {}),
+    })
+  }
+  for (const tool of tools) {
+    if (tool?.type === 'function') {
+      addFunctionTool(tool)
+      continue
+    }
+    if (tool?.type === 'namespace' && normalizedNamespaceName(tool?.name) === HERMES_STUDIO_NAMESPACE) {
+      for (const mcpTool of HERMES_STUDIO_MCP_TOOLS) {
+        addFunctionTool({
+          type: 'function',
+          name: mcpTool.name,
+          description: `${mcpTool.description} MCP namespace: ${HERMES_STUDIO_NAMESPACE}.`,
+          parameters: mcpTool.inputSchema,
+          namespace: HERMES_STUDIO_NAMESPACE,
+        })
+      }
+      continue
+    }
+    if (tool?.type === 'namespace') {
+      const namespace = normalizedNamespaceName(tool?.name)
+      if (namespace.startsWith('mcp__')) {
+        addFunctionTool({
+          type: 'function',
+          name: namespace,
+          description: `${String(tool?.description || `Tools in the ${namespace} MCP namespace.`)} Call a tool in this MCP namespace by passing the tool name and its JSON arguments.`,
+          parameters: {
+            type: 'object',
+            properties: {
+              tool: {
+                type: 'string',
+                description: 'Name of the MCP tool to call inside this namespace.',
+              },
+              arguments: {
+                type: 'object',
+                description: 'JSON arguments for the MCP tool.',
+                additionalProperties: true,
+              },
+            },
+            required: ['tool', 'arguments'],
+            additionalProperties: false,
+          },
+          namespace,
+        })
+      }
+    }
+  }
+  return mapped
+}
+
+export function responseToolNamespaceForName(name: unknown): string | undefined {
+  return HERMES_STUDIO_MCP_TOOL_NAMES.has(String(name || '')) ? HERMES_STUDIO_NAMESPACE : undefined
+}
+
+export function normalizeResponseFunctionCall(name: unknown, argumentsValue: unknown): { name: string; arguments: string; namespace?: string } {
+  const rawName = String(name || 'tool')
+  const rawArguments = String(argumentsValue || '{}')
+  const namespace = normalizedNamespaceName(rawName)
+  if (namespace.startsWith('mcp__')) {
+    const parsed = safeJsonParse(rawArguments)
+    const toolName = String(parsed?.tool || parsed?.name || '').trim()
+    if (toolName) {
+      const toolArguments = parsed?.arguments && typeof parsed.arguments === 'object'
+        ? parsed.arguments
+        : parsed?.input && typeof parsed.input === 'object'
+          ? parsed.input
+          : {}
+      return {
+        name: toolName,
+        arguments: JSON.stringify(toolArguments),
+        namespace,
+      }
+    }
+  }
+
+  const knownNamespace = responseToolNamespaceForName(rawName)
+  return {
+    name: rawName,
+    arguments: rawArguments,
+    ...(knownNamespace ? { namespace: knownNamespace } : {}),
+  }
+}
+
 export function stringifyContent(value: unknown): string {
   if (typeof value === 'string') return value
   if (Array.isArray(value)) {
@@ -118,8 +351,7 @@ function responsesInputToChatMessages(body: any): any[] {
 }
 
 function responsesToolsToChatTools(tools: unknown): any[] | undefined {
-  if (!Array.isArray(tools)) return undefined
-  const mapped = tools.map((tool: any) => {
+  const mapped = expandedResponseTools(tools).map((tool: any) => {
     if (tool?.type !== 'function') return null
     return {
       type: 'function',
@@ -205,8 +437,7 @@ function responsesInputToAnthropicMessages(body: any): any[] {
 }
 
 function responsesToolsToAnthropicTools(tools: unknown): any[] | undefined {
-  if (!Array.isArray(tools)) return undefined
-  const mapped = tools.map((tool: any) => {
+  const mapped = expandedResponseTools(tools).map((tool: any) => {
     if (tool?.type !== 'function') return null
     return {
       name: String(tool.name || ''),
@@ -277,12 +508,12 @@ export function openAiChatToResponses(data: any, target: ResponsesAdapterTarget)
   }
 
   for (const call of Array.isArray(message.tool_calls) ? message.tool_calls : []) {
+    const normalizedCall = normalizeResponseFunctionCall(call.function?.name || 'tool', call.function?.arguments || '{}')
     output.push({
       type: 'function_call',
       id: String(call.id || `fc_${output.length}`),
       call_id: String(call.id || `call_${output.length}`),
-      name: String(call.function?.name || 'tool'),
-      arguments: String(call.function?.arguments || '{}'),
+      ...normalizedCall,
     })
   }
 
@@ -306,12 +537,12 @@ export function anthropicMessageToResponses(data: any, target: ResponsesAdapterT
     if (block?.type === 'thinking' && block.thinking) reasoningParts.push(String(block.thinking))
     if (block?.type === 'redacted_thinking') reasoningParts.push('[redacted thinking]')
     if (block?.type === 'tool_use') {
+      const normalizedCall = normalizeResponseFunctionCall(block.name || 'tool', JSON.stringify(block.input || {}))
       output.push({
         type: 'function_call',
         id: String(block.id || `fc_${output.length}`),
         call_id: String(block.id || `call_${output.length}`),
-        name: String(block.name || 'tool'),
-        arguments: JSON.stringify(block.input || {}),
+        ...normalizedCall,
       })
     }
   }

--- a/packages/server/src/services/agent-runner/adapters/responses.ts
+++ b/packages/server/src/services/agent-runner/adapters/responses.ts
@@ -57,32 +57,54 @@ function responsesInputToChatMessages(body: any): any[] {
     return messages
   }
 
+  let pendingToolCalls: Array<{ id: string; type: 'function'; function: { name: string; arguments: string } }> = []
+  let pendingToolOutputs = new Map<string, any>()
+  const flushCompletedToolCalls = () => {
+    if (!pendingToolCalls.length) return
+    const outputs = pendingToolCalls.map(call => pendingToolOutputs.get(call.id))
+    if (outputs.every(Boolean)) {
+      messages.push({
+        role: 'assistant',
+        content: null,
+        tool_calls: pendingToolCalls,
+      })
+      for (let index = 0; index < pendingToolCalls.length; index += 1) {
+        messages.push({
+          role: 'tool',
+          tool_call_id: pendingToolCalls[index].id,
+          content: stringifyContent(outputs[index].output),
+        })
+      }
+    }
+    pendingToolCalls = []
+    pendingToolOutputs = new Map()
+  }
+
   for (const item of Array.isArray(input) ? input : []) {
     if (!item || typeof item !== 'object') continue
     if (item.type === 'function_call') {
       const callId = String(item.call_id || item.id || `call_${messages.length}`)
-      messages.push({
-        role: 'assistant',
-        content: null,
-        tool_calls: [{
-          id: callId,
-          type: 'function',
-          function: {
-            name: String(item.name || 'tool'),
-            arguments: String(item.arguments || '{}'),
-          },
-        }],
+      pendingToolCalls.push({
+        id: callId,
+        type: 'function',
+        function: {
+          name: String(item.name || 'tool'),
+          arguments: String(item.arguments || '{}'),
+        },
       })
       continue
     }
     if (item.type === 'function_call_output') {
-      messages.push({
-        role: 'tool',
-        tool_call_id: String(item.call_id || ''),
-        content: stringifyContent(item.output),
-      })
+      const callId = String(item.call_id || '')
+      if (pendingToolCalls.some(call => call.id === callId)) {
+        pendingToolOutputs.set(callId, item)
+        if (pendingToolCalls.every(call => pendingToolOutputs.has(call.id))) {
+          flushCompletedToolCalls()
+        }
+      }
       continue
     }
+    flushCompletedToolCalls()
     if (item.role) {
       messages.push({
         role: chatRoleForResponsesRole(item.role),
@@ -90,6 +112,7 @@ function responsesInputToChatMessages(body: any): any[] {
       })
     }
   }
+  flushCompletedToolCalls()
 
   return messages.length ? messages : [{ role: 'user', content: '' }]
 }

--- a/packages/server/src/services/agent-runner/adapters/responses.ts
+++ b/packages/server/src/services/agent-runner/adapters/responses.ts
@@ -121,11 +121,11 @@ function inputSchema(properties: Record<string, unknown> = {}, required: string[
     properties: {
       token: {
         type: 'string',
-        description: 'Optional Hermes Web UI bearer token. Use the current model run token when one is provided in the run instructions.',
+        description: 'Optional Hermes Web UI bearer token. Usually omit this and pass profile so the MCP server can read the temporary profile token.',
       },
       profile: {
         type: 'string',
-        description: 'Optional Hermes profile name for profile-scoped Web UI requests.',
+        description: 'Hermes profile name for profile-scoped Web UI requests and temporary profile token lookup.',
       },
       ...properties,
     },

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -191,6 +191,13 @@ function truncateCodingAgentToolOutputEvent(event: CanonicalResponsesEvent): Can
   return event
 }
 
+function redactCodexPromptForLog(prompt: string): string {
+  return prompt
+    .replace(/(\[Current Hermes Web UI model run token: )([^\]\s]+)(\])/g, '$1<redacted>$3')
+    .replace(/\b(hwui_)[A-Za-z0-9._~+/-]+\b/g, '$1<redacted>')
+    .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, '<jwt redacted>')
+}
+
 function isPrintAgent(agentId: string): boolean {
   return agentId === 'claude-code' || agentId === 'codex'
 }
@@ -717,6 +724,13 @@ export class CodingAgentRunManager {
     run.printToolBlocks = new Map()
     run.currentChildStderr = ''
     run.runMarker = undefined
+
+    if (systemPrompt) {
+      console.log([
+        `[coding-agent-run] Codex developer_instructions prompt (${systemPrompt.length} chars, hermesMcpTools=${systemPrompt.includes('mcp__hermes-studio__')})`,
+        redactCodexPromptForLog(systemPrompt),
+      ].join('\n'))
+    }
 
     this.handleClaudePrintResponseEvent(run, {
       type: 'response.created',

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -191,13 +191,6 @@ function truncateCodingAgentToolOutputEvent(event: CanonicalResponsesEvent): Can
   return event
 }
 
-function redactCodexPromptForLog(prompt: string): string {
-  return prompt
-    .replace(/(\[Current Hermes Web UI model run token: )([^\]\s]+)(\])/g, '$1<redacted>$3')
-    .replace(/\b(hwui_)[A-Za-z0-9._~+/-]+\b/g, '$1<redacted>')
-    .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, '<jwt redacted>')
-}
-
 function isPrintAgent(agentId: string): boolean {
   return agentId === 'claude-code' || agentId === 'codex'
 }
@@ -724,13 +717,6 @@ export class CodingAgentRunManager {
     run.printToolBlocks = new Map()
     run.currentChildStderr = ''
     run.runMarker = undefined
-
-    if (systemPrompt) {
-      console.log([
-        `[coding-agent-run] Codex developer_instructions prompt (${systemPrompt.length} chars, hermesMcpTools=${systemPrompt.includes('mcp__hermes-studio__')})`,
-        redactCodexPromptForLog(systemPrompt),
-      ].join('\n'))
-    }
 
     this.handleClaudePrintResponseEvent(run, {
       type: 'response.created',

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -68,6 +68,7 @@ export interface CodingAgentRunLaunch {
   workspaceDir: string
   env?: NodeJS.ProcessEnv
   state?: SessionState
+  sessionSource?: 'global_agent'
 }
 
 interface ManagedCodingAgentRun {
@@ -610,10 +611,11 @@ export class CodingAgentRunManager {
 
   private ensureDbSession(run: ManagedCodingAgentRun) {
     if (getSession(run.launch.sessionId)) return
+    const source = run.launch.sessionSource === 'global_agent' ? 'global_agent' : 'coding_agent'
     createSession({
       id: run.launch.sessionId,
       profile: run.launch.profile,
-        source: 'coding_agent',
+        source,
         agent: run.launch.agentId === 'codex' ? 'codex' : 'claude',
         agent_session_id: run.id,
         agent_native_session_id: run.launch.agentNativeSessionId,

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -1,5 +1,5 @@
 import { dirname, join } from 'path'
-import { existsSync, accessSync, chmodSync, constants as fsConstants } from 'fs'
+import { existsSync, accessSync, chmodSync, constants as fsConstants, readFileSync } from 'fs'
 import { homedir } from 'os'
 import { spawn, type ChildProcess } from 'child_process'
 import { createSession, addMessage, getSession, updateSession, updateSessionStats } from '../../db/hermes/session-store'
@@ -19,6 +19,7 @@ const CODING_AGENT_TOOL_OUTPUT_STORAGE_LIMIT = 32 * 1024
 const CODING_AGENT_TOOL_OUTPUT_HEAD_CHARS = 24 * 1024
 const CODING_AGENT_TOOL_OUTPUT_TAIL_CHARS = 8 * 1024
 const CODEX_REASONING_SUMMARY_ARGS = ['-c', 'model_reasoning_summary="auto"']
+const HERMES_MCP_SERVER_NAME = 'hermes-studio'
 
 let pty: any = null
 
@@ -105,6 +106,10 @@ interface ManagedCodingAgentRun {
   pendingChatCompletionPayload?: Record<string, unknown>
 }
 
+interface CodingAgentRunSendOptions {
+  systemPrompt?: string
+}
+
 function nowSeconds(): number {
   return Math.floor(Date.now() / 1000)
 }
@@ -188,6 +193,18 @@ function truncateCodingAgentToolOutputEvent(event: CanonicalResponsesEvent): Can
 
 function isPrintAgent(agentId: string): boolean {
   return agentId === 'claude-code' || agentId === 'codex'
+}
+
+function hasManagedHermesMcpConfig(run: ManagedCodingAgentRun): boolean {
+  if (run.launch.agentId !== 'codex' || run.launch.mode !== 'scoped') return true
+  const codexHome = String(run.launch.env?.CODEX_HOME || '').trim()
+  if (!codexHome) return false
+  try {
+    const config = readFileSync(join(codexHome, 'config.toml'), 'utf-8')
+    return config.includes(`[mcp_servers.${HERMES_MCP_SERVER_NAME}]`)
+  } catch {
+    return false
+  }
 }
 
 function childIsRunning(child?: ChildProcess): boolean {
@@ -375,6 +392,7 @@ export class CodingAgentRunManager {
       if (provider && run.launch.provider !== provider) return false
       if (model && run.launch.model !== model) return false
     }
+    if (!hasManagedHermesMcpConfig(run)) return false
     return true
   }
 
@@ -478,21 +496,22 @@ export class CodingAgentRunManager {
     return { runId: run.id, pid: proc.pid }
   }
 
-  send(sessionId: string, input: string): { runId: string } {
+  send(sessionId: string, input: string, options: CodingAgentRunSendOptions = {}): { runId: string } {
     const run = this.getBySession(sessionId)
     if (!run) throw new Error('Coding agent session not found')
     const text = String(input || '').trim()
     if (!text) throw new Error('Input is required')
+    const systemPrompt = String(options.systemPrompt || '').trim()
     this.ensureDbSession(run)
     this.addUserMessage(run, text)
     this.touch(run)
     this.emitTerminalStatus(run, 'Input sent to coding agent.')
     if (run.launch.agentId === 'claude-code') {
-      this.startClaudePrintTurn(run, text)
+      this.startClaudePrintTurn(run, text, systemPrompt)
       return { runId: run.id }
     }
     if (run.launch.agentId === 'codex') {
-      this.startCodexExecTurn(run, text)
+      this.startCodexExecTurn(run, systemPrompt ? `${systemPrompt}\n\n${text}` : text)
       return { runId: run.id }
     }
     if (!run.pty) throw new Error('Coding agent terminal is not available')
@@ -682,7 +701,7 @@ export class CodingAgentRunManager {
     }
   }
 
-  private startClaudePrintTurn(run: ManagedCodingAgentRun, input: string) {
+  private startClaudePrintTurn(run: ManagedCodingAgentRun, input: string, systemPrompt = '') {
     if (childIsRunning(run.currentChild)) {
       throw new Error('Claude Code is still processing the previous input')
     }
@@ -715,6 +734,7 @@ export class CodingAgentRunManager {
     const args = [
       ...run.launch.args,
       ...nativeSessionArgs,
+      ...(systemPrompt ? ['--append-system-prompt', systemPrompt] : []),
       '-p',
       '--output-format',
       'stream-json',

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -511,7 +511,7 @@ export class CodingAgentRunManager {
       return { runId: run.id }
     }
     if (run.launch.agentId === 'codex') {
-      this.startCodexExecTurn(run, systemPrompt ? `${systemPrompt}\n\n${text}` : text)
+      this.startCodexExecTurn(run, text, systemPrompt)
       return { runId: run.id }
     }
     if (!run.pty) throw new Error('Coding agent terminal is not available')
@@ -1140,7 +1140,7 @@ export class CodingAgentRunManager {
     })
   }
 
-  private startCodexExecTurn(run: ManagedCodingAgentRun, input: string) {
+  private startCodexExecTurn(run: ManagedCodingAgentRun, input: string, systemPrompt = '') {
     if (childIsRunning(run.currentChild)) {
       throw new Error('Codex is still processing the previous input')
     }
@@ -1170,6 +1170,7 @@ export class CodingAgentRunManager {
     const commonArgs = [
       '--json',
       ...CODEX_REASONING_SUMMARY_ARGS,
+      ...(systemPrompt ? ['-c', `developer_instructions=${JSON.stringify(systemPrompt)}`] : []),
       ...run.launch.args,
       '--skip-git-repo-check',
       '--dangerously-bypass-approvals-and-sandbox',

--- a/packages/server/src/services/agent-runner/proxies/codex-proxy.ts
+++ b/packages/server/src/services/agent-runner/proxies/codex-proxy.ts
@@ -259,7 +259,10 @@ async function openAiChatToResponsesSseStream(target: CodexProxyTarget, body: an
     apiKey: target.apiKey,
     body: chatBody,
   })
-  return responsesEventStream(observableResponsesEvents(target, openAiChatSseToResponsesEvents(stream, target)))
+  return responsesEventStream(observableResponsesEvents(target, openAiChatSseToResponsesEvents(stream, {
+    ...target,
+    annotateMcpToolNamespaces: true,
+  })))
 }
 
 async function anthropicMessagesToResponsesSseStream(target: CodexProxyTarget, body: any): Promise<Readable> {
@@ -280,7 +283,10 @@ async function anthropicMessagesToResponsesSseStream(target: CodexProxyTarget, b
     },
     body: anthropicBody,
   })
-  return responsesEventStream(observableResponsesEvents(target, anthropicMessagesSseToResponsesEvents(stream, target)))
+  return responsesEventStream(observableResponsesEvents(target, anthropicMessagesSseToResponsesEvents(stream, {
+    ...target,
+    annotateMcpToolNamespaces: true,
+  })))
 }
 
 async function openAiResponsesSseStream(target: CodexProxyTarget, body: any): Promise<Readable> {

--- a/packages/server/src/services/agent-runner/proxies/codex-proxy.ts
+++ b/packages/server/src/services/agent-runner/proxies/codex-proxy.ts
@@ -23,7 +23,6 @@ import {
 } from '../adapters/responses-stream'
 import { agentRunGateway } from '../gateway'
 import { codingAgentRunManager } from '../coding-agent-run-manager'
-import { logger } from '../../logger'
 
 export interface CodexProxyTargetInput extends AgentTargetInput {
   profile: string
@@ -79,100 +78,6 @@ function chatCompletionsUrl(target: CodexProxyTarget): string {
   return resolveChatCompletionsUrl(target.baseUrl)
 }
 
-function contentCharLength(content: any): number {
-  if (typeof content === 'string') return content.length
-  if (content == null) return 0
-  try {
-    return JSON.stringify(content).length
-  } catch {
-    return 0
-  }
-}
-
-function summarizeContentBlocks(content: any): any {
-  if (!Array.isArray(content)) return { content_chars: contentCharLength(content) }
-  return {
-    content_blocks: content.map((block: any, index: number) => ({
-      index,
-      type: block?.type,
-      text_chars: typeof block?.text === 'string'
-        ? block.text.length
-        : typeof block?.input_text === 'string'
-          ? block.input_text.length
-          : typeof block?.output_text === 'string'
-            ? block.output_text.length
-            : undefined,
-      tool_use_id: block?.tool_use_id,
-      id: block?.id,
-      name: block?.name,
-      input_chars: contentCharLength(block?.input),
-      content_chars: block?.text == null && block?.input_text == null && block?.output_text == null
-        ? contentCharLength(block?.content)
-        : undefined,
-    })),
-  }
-}
-
-function summarizeTools(tools: any): any[] {
-  if (!Array.isArray(tools)) return []
-  return tools.map((tool: any, index: number) => ({
-    index,
-    type: tool?.type,
-    name: tool?.function?.name || tool?.name,
-    description: tool?.function?.description || tool?.description,
-    parameters: tool?.function?.parameters || tool?.parameters || tool?.input_schema,
-  }))
-}
-
-function summarizeMessages(messages: any[]): any[] {
-  return messages.map((message, index) => ({
-    index,
-    role: message?.role,
-    ...summarizeContentBlocks(message?.content),
-    tool_call_id: message?.tool_call_id,
-    tool_calls: Array.isArray(message?.tool_calls)
-      ? message.tool_calls.map((call: any) => ({
-          id: call?.id,
-          type: call?.type,
-          name: call?.function?.name,
-          arguments_chars: typeof call?.function?.arguments === 'string' ? call.function.arguments.length : 0,
-        }))
-      : undefined,
-  }))
-}
-
-function summarizeResponsesInput(input: any): any {
-  if (!Array.isArray(input)) return { input_chars: contentCharLength(input) }
-  return {
-    input: input.map((item: any, index: number) => ({
-      index,
-      type: item?.type,
-      role: item?.role,
-      id: item?.id,
-      call_id: item?.call_id,
-      name: item?.name,
-      status: item?.status,
-      arguments_chars: typeof item?.arguments === 'string' ? item.arguments.length : contentCharLength(item?.arguments),
-      ...summarizeContentBlocks(item?.content),
-    })),
-  }
-}
-
-function logCodexProxyRequest(target: CodexProxyTarget, route: 'chat_completions' | 'anthropic_messages' | 'codex_responses', url: string, body: any) {
-  logger.info({
-    event: 'codex_proxy_upstream_request',
-    route,
-    provider: target.provider,
-    model: target.model,
-    apiMode: target.apiMode,
-    url,
-    stream: body?.stream === true,
-    messages: Array.isArray(body?.messages) ? summarizeMessages(body.messages) : undefined,
-    ...('input' in Object(body) ? summarizeResponsesInput(body?.input) : {}),
-    tools: summarizeTools(body?.tools),
-  }, '[codex-proxy] upstream request')
-}
-
 function anthropicMessagesUrl(target: CodexProxyTarget): string {
   return resolveAnthropicMessagesUrl(target.baseUrl)
 }
@@ -184,7 +89,6 @@ async function callOpenAiChat(target: CodexProxyTarget, body: any): Promise<any>
     throw err
   }
   const chatBody = responsesToOpenAiChat(body, target)
-  logCodexProxyRequest(target, 'chat_completions', chatCompletionsUrl(target), chatBody)
   return agentRunGateway.completeJson({
     url: chatCompletionsUrl(target),
     apiKey: target.apiKey,
@@ -199,7 +103,6 @@ async function callAnthropicMessages(target: CodexProxyTarget, body: any): Promi
     throw err
   }
   const anthropicBody = responsesToAnthropicMessages(body, target)
-  logCodexProxyRequest(target, 'anthropic_messages', anthropicMessagesUrl(target), anthropicBody)
   return agentRunGateway.completeJson({
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
@@ -218,7 +121,6 @@ async function callOpenAiResponses(target: CodexProxyTarget, body: any): Promise
     throw err
   }
   const responsesBody = { ...body, model: target.model }
-  logCodexProxyRequest(target, 'codex_responses', resolveResponsesUrl(target.baseUrl), responsesBody)
   return agentRunGateway.completeJson({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,
@@ -253,7 +155,6 @@ async function openAiChatToResponsesSseStream(target: CodexProxyTarget, body: an
   }
 
   const chatBody = responsesToOpenAiChat(body, target, true)
-  logCodexProxyRequest(target, 'chat_completions', chatCompletionsUrl(target), chatBody)
   const stream = await agentRunGateway.streamBytes({
     url: chatCompletionsUrl(target),
     apiKey: target.apiKey,
@@ -273,7 +174,6 @@ async function anthropicMessagesToResponsesSseStream(target: CodexProxyTarget, b
   }
 
   const anthropicBody = responsesToAnthropicMessages(body, target, true)
-  logCodexProxyRequest(target, 'anthropic_messages', anthropicMessagesUrl(target), anthropicBody)
   const stream = await agentRunGateway.streamBytes({
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
@@ -297,7 +197,6 @@ async function openAiResponsesSseStream(target: CodexProxyTarget, body: any): Pr
   }
 
   const responsesBody = { ...body, model: target.model, stream: true }
-  logCodexProxyRequest(target, 'codex_responses', resolveResponsesUrl(target.baseUrl), responsesBody)
   const stream = await agentRunGateway.streamBytes({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,

--- a/packages/server/src/services/agent-runner/proxies/codex-proxy.ts
+++ b/packages/server/src/services/agent-runner/proxies/codex-proxy.ts
@@ -23,6 +23,7 @@ import {
 } from '../adapters/responses-stream'
 import { agentRunGateway } from '../gateway'
 import { codingAgentRunManager } from '../coding-agent-run-manager'
+import { logger } from '../../logger'
 
 export interface CodexProxyTargetInput extends AgentTargetInput {
   profile: string
@@ -100,7 +101,7 @@ function summarizeMessages(messages: any[]): any[] {
 }
 
 function logCodexChatRequest(target: CodexProxyTarget, body: any) {
-  console.log(JSON.stringify({
+  logger.info({
     event: 'codex_proxy_chat_request',
     provider: target.provider,
     model: target.model,
@@ -117,7 +118,7 @@ function logCodexChatRequest(target: CodexProxyTarget, body: any) {
           parameters: tool?.function?.parameters,
         }))
       : [],
-  }, null, 2))
+  }, '[codex-proxy] chat request')
 }
 
 function anthropicMessagesUrl(target: CodexProxyTarget): string {

--- a/packages/server/src/services/agent-runner/proxies/codex-proxy.ts
+++ b/packages/server/src/services/agent-runner/proxies/codex-proxy.ts
@@ -79,15 +79,56 @@ function chatCompletionsUrl(target: CodexProxyTarget): string {
   return resolveChatCompletionsUrl(target.baseUrl)
 }
 
+function contentCharLength(content: any): number {
+  if (typeof content === 'string') return content.length
+  if (content == null) return 0
+  try {
+    return JSON.stringify(content).length
+  } catch {
+    return 0
+  }
+}
+
+function summarizeContentBlocks(content: any): any {
+  if (!Array.isArray(content)) return { content_chars: contentCharLength(content) }
+  return {
+    content_blocks: content.map((block: any, index: number) => ({
+      index,
+      type: block?.type,
+      text_chars: typeof block?.text === 'string'
+        ? block.text.length
+        : typeof block?.input_text === 'string'
+          ? block.input_text.length
+          : typeof block?.output_text === 'string'
+            ? block.output_text.length
+            : undefined,
+      tool_use_id: block?.tool_use_id,
+      id: block?.id,
+      name: block?.name,
+      input_chars: contentCharLength(block?.input),
+      content_chars: block?.text == null && block?.input_text == null && block?.output_text == null
+        ? contentCharLength(block?.content)
+        : undefined,
+    })),
+  }
+}
+
+function summarizeTools(tools: any): any[] {
+  if (!Array.isArray(tools)) return []
+  return tools.map((tool: any, index: number) => ({
+    index,
+    type: tool?.type,
+    name: tool?.function?.name || tool?.name,
+    description: tool?.function?.description || tool?.description,
+    parameters: tool?.function?.parameters || tool?.parameters || tool?.input_schema,
+  }))
+}
+
 function summarizeMessages(messages: any[]): any[] {
   return messages.map((message, index) => ({
     index,
     role: message?.role,
-    content_chars: typeof message?.content === 'string'
-      ? message.content.length
-      : message?.content == null
-        ? 0
-        : JSON.stringify(message.content).length,
+    ...summarizeContentBlocks(message?.content),
     tool_call_id: message?.tool_call_id,
     tool_calls: Array.isArray(message?.tool_calls)
       ? message.tool_calls.map((call: any) => ({
@@ -100,25 +141,36 @@ function summarizeMessages(messages: any[]): any[] {
   }))
 }
 
-function logCodexChatRequest(target: CodexProxyTarget, body: any) {
+function summarizeResponsesInput(input: any): any {
+  if (!Array.isArray(input)) return { input_chars: contentCharLength(input) }
+  return {
+    input: input.map((item: any, index: number) => ({
+      index,
+      type: item?.type,
+      role: item?.role,
+      id: item?.id,
+      call_id: item?.call_id,
+      name: item?.name,
+      status: item?.status,
+      arguments_chars: typeof item?.arguments === 'string' ? item.arguments.length : contentCharLength(item?.arguments),
+      ...summarizeContentBlocks(item?.content),
+    })),
+  }
+}
+
+function logCodexProxyRequest(target: CodexProxyTarget, route: 'chat_completions' | 'anthropic_messages' | 'codex_responses', url: string, body: any) {
   logger.info({
-    event: 'codex_proxy_chat_request',
+    event: 'codex_proxy_upstream_request',
+    route,
     provider: target.provider,
     model: target.model,
     apiMode: target.apiMode,
-    url: chatCompletionsUrl(target),
+    url,
     stream: body?.stream === true,
-    messages: summarizeMessages(Array.isArray(body?.messages) ? body.messages : []),
-    tools: Array.isArray(body?.tools)
-      ? body.tools.map((tool: any, index: number) => ({
-          index,
-          type: tool?.type,
-          name: tool?.function?.name,
-          description: tool?.function?.description,
-          parameters: tool?.function?.parameters,
-        }))
-      : [],
-  }, '[codex-proxy] chat request')
+    messages: Array.isArray(body?.messages) ? summarizeMessages(body.messages) : undefined,
+    ...('input' in Object(body) ? summarizeResponsesInput(body?.input) : {}),
+    tools: summarizeTools(body?.tools),
+  }, '[codex-proxy] upstream request')
 }
 
 function anthropicMessagesUrl(target: CodexProxyTarget): string {
@@ -132,7 +184,7 @@ async function callOpenAiChat(target: CodexProxyTarget, body: any): Promise<any>
     throw err
   }
   const chatBody = responsesToOpenAiChat(body, target)
-  logCodexChatRequest(target, chatBody)
+  logCodexProxyRequest(target, 'chat_completions', chatCompletionsUrl(target), chatBody)
   return agentRunGateway.completeJson({
     url: chatCompletionsUrl(target),
     apiKey: target.apiKey,
@@ -146,6 +198,8 @@ async function callAnthropicMessages(target: CodexProxyTarget, body: any): Promi
     ;(err as any).status = 501
     throw err
   }
+  const anthropicBody = responsesToAnthropicMessages(body, target)
+  logCodexProxyRequest(target, 'anthropic_messages', anthropicMessagesUrl(target), anthropicBody)
   return agentRunGateway.completeJson({
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
@@ -153,7 +207,7 @@ async function callAnthropicMessages(target: CodexProxyTarget, body: any): Promi
       'x-api-key': target.apiKey,
       'anthropic-version': '2023-06-01',
     },
-    body: responsesToAnthropicMessages(body, target),
+    body: anthropicBody,
   })
 }
 
@@ -163,10 +217,12 @@ async function callOpenAiResponses(target: CodexProxyTarget, body: any): Promise
     ;(err as any).status = 501
     throw err
   }
+  const responsesBody = { ...body, model: target.model }
+  logCodexProxyRequest(target, 'codex_responses', resolveResponsesUrl(target.baseUrl), responsesBody)
   return agentRunGateway.completeJson({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,
-    body: { ...body, model: target.model },
+    body: responsesBody,
   })
 }
 
@@ -197,7 +253,7 @@ async function openAiChatToResponsesSseStream(target: CodexProxyTarget, body: an
   }
 
   const chatBody = responsesToOpenAiChat(body, target, true)
-  logCodexChatRequest(target, chatBody)
+  logCodexProxyRequest(target, 'chat_completions', chatCompletionsUrl(target), chatBody)
   const stream = await agentRunGateway.streamBytes({
     url: chatCompletionsUrl(target),
     apiKey: target.apiKey,
@@ -213,6 +269,8 @@ async function anthropicMessagesToResponsesSseStream(target: CodexProxyTarget, b
     throw err
   }
 
+  const anthropicBody = responsesToAnthropicMessages(body, target, true)
+  logCodexProxyRequest(target, 'anthropic_messages', anthropicMessagesUrl(target), anthropicBody)
   const stream = await agentRunGateway.streamBytes({
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
@@ -220,7 +278,7 @@ async function anthropicMessagesToResponsesSseStream(target: CodexProxyTarget, b
       'x-api-key': target.apiKey,
       'anthropic-version': '2023-06-01',
     },
-    body: responsesToAnthropicMessages(body, target, true),
+    body: anthropicBody,
   })
   return responsesEventStream(observableResponsesEvents(target, anthropicMessagesSseToResponsesEvents(stream, target)))
 }
@@ -232,10 +290,12 @@ async function openAiResponsesSseStream(target: CodexProxyTarget, body: any): Pr
     throw err
   }
 
+  const responsesBody = { ...body, model: target.model, stream: true }
+  logCodexProxyRequest(target, 'codex_responses', resolveResponsesUrl(target.baseUrl), responsesBody)
   const stream = await agentRunGateway.streamBytes({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,
-    body: { ...body, model: target.model, stream: true },
+    body: responsesBody,
   })
   return responsesEventStream(observableResponsesEvents(target, openAiResponsesSseToResponsesEvents(stream)))
 }

--- a/packages/server/src/services/agent-runner/proxies/codex-proxy.ts
+++ b/packages/server/src/services/agent-runner/proxies/codex-proxy.ts
@@ -78,6 +78,48 @@ function chatCompletionsUrl(target: CodexProxyTarget): string {
   return resolveChatCompletionsUrl(target.baseUrl)
 }
 
+function summarizeMessages(messages: any[]): any[] {
+  return messages.map((message, index) => ({
+    index,
+    role: message?.role,
+    content_chars: typeof message?.content === 'string'
+      ? message.content.length
+      : message?.content == null
+        ? 0
+        : JSON.stringify(message.content).length,
+    tool_call_id: message?.tool_call_id,
+    tool_calls: Array.isArray(message?.tool_calls)
+      ? message.tool_calls.map((call: any) => ({
+          id: call?.id,
+          type: call?.type,
+          name: call?.function?.name,
+          arguments_chars: typeof call?.function?.arguments === 'string' ? call.function.arguments.length : 0,
+        }))
+      : undefined,
+  }))
+}
+
+function logCodexChatRequest(target: CodexProxyTarget, body: any) {
+  console.log(JSON.stringify({
+    event: 'codex_proxy_chat_request',
+    provider: target.provider,
+    model: target.model,
+    apiMode: target.apiMode,
+    url: chatCompletionsUrl(target),
+    stream: body?.stream === true,
+    messages: summarizeMessages(Array.isArray(body?.messages) ? body.messages : []),
+    tools: Array.isArray(body?.tools)
+      ? body.tools.map((tool: any, index: number) => ({
+          index,
+          type: tool?.type,
+          name: tool?.function?.name,
+          description: tool?.function?.description,
+          parameters: tool?.function?.parameters,
+        }))
+      : [],
+  }, null, 2))
+}
+
 function anthropicMessagesUrl(target: CodexProxyTarget): string {
   return resolveAnthropicMessagesUrl(target.baseUrl)
 }
@@ -88,10 +130,12 @@ async function callOpenAiChat(target: CodexProxyTarget, body: any): Promise<any>
     ;(err as any).status = 501
     throw err
   }
+  const chatBody = responsesToOpenAiChat(body, target)
+  logCodexChatRequest(target, chatBody)
   return agentRunGateway.completeJson({
     url: chatCompletionsUrl(target),
     apiKey: target.apiKey,
-    body: responsesToOpenAiChat(body, target),
+    body: chatBody,
   })
 }
 
@@ -151,10 +195,12 @@ async function openAiChatToResponsesSseStream(target: CodexProxyTarget, body: an
     throw err
   }
 
+  const chatBody = responsesToOpenAiChat(body, target, true)
+  logCodexChatRequest(target, chatBody)
   const stream = await agentRunGateway.streamBytes({
     url: chatCompletionsUrl(target),
     apiKey: target.apiKey,
-    body: responsesToOpenAiChat(body, target, true),
+    body: chatBody,
   })
   return responsesEventStream(observableResponsesEvents(target, openAiChatSseToResponsesEvents(stream, target)))
 }

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -96,6 +96,7 @@ export interface CodingAgentLaunchInput extends CodingAgentConfigScope {
   agentSessionId?: string
   agentNativeSessionId?: string
   isolateSettings?: boolean
+  sessionSource?: 'global_agent'
 }
 
 export interface CodingAgentLaunchResult {
@@ -1498,6 +1499,7 @@ export async function startCodingAgentRun(
     throw err
   }
   const existingSession = getSession(sessionId)
+  const sessionSource = input.sessionSource === 'global_agent' ? 'global_agent' : 'coding_agent'
   const existingAgentSessionId = existingSession?.agent_session_id || ''
   const resolvedInput = await resolveStoredProviderLaunchInput(input, existingSession)
   const requestedMode = resolvedInput.mode === 'global' ? 'global' : 'scoped'
@@ -1551,9 +1553,10 @@ export async function startCodingAgentRun(
     workspaceDir: launch.workspaceDir,
     env: runtimeEnv,
     state,
+    sessionSource: sessionSource === 'global_agent' ? 'global_agent' : undefined,
   })
   updateSession(sessionId, {
-    source: 'coding_agent',
+    source: sessionSource,
     agent: launch.agentId === 'codex' ? 'codex' : 'claude',
     agent_mode: launch.mode,
     agent_session_id: agentSessionId,

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -733,6 +733,10 @@ function tomlStringArray(values: string[]): string {
   return `[${values.map(tomlString).join(', ')}]`
 }
 
+function tomlInlineStringTable(values: Record<string, string>): string {
+  return `{ ${Object.entries(values).map(([key, value]) => `${key} = ${tomlString(value)}`).join(', ')} }`
+}
+
 function isDesktopRuntime(): boolean {
   return String(process.env.HERMES_DESKTOP || '').trim().toLowerCase() === 'true'
 }
@@ -783,11 +787,7 @@ function codexMcpConfigToml(): string {
   ]
   if (server.args?.length) lines.push(`args = ${tomlStringArray(server.args)}`)
   lines.push('startup_timeout_sec = 120')
-  lines.push('')
-  lines.push(`[mcp_servers.${HERMES_MCP_SERVER_NAME}.env]`)
-  for (const [key, value] of Object.entries(server.env)) {
-    lines.push(`${key} = ${tomlString(value)}`)
-  }
+  lines.push(`env = ${tomlInlineStringTable(server.env)}`)
   lines.push('')
   return lines.join('\n')
 }

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -13,6 +13,7 @@ import type { ApiMode } from './agent-runner/types'
 import { PROVIDER_PRESETS } from '../shared/providers'
 import { getModelContextLength } from './hermes/model-context'
 import { getProfileDir } from './hermes/hermes-profile'
+import { getSystemPrompt } from '../lib/llm-prompt'
 import { codingAgentRunManager } from './agent-runner/coding-agent-run-manager'
 import { getSession, updateSession, type HermesSessionRow } from '../db/hermes/session-store'
 import type { SessionState } from './hermes/run-chat/types'
@@ -29,6 +30,10 @@ const WINDOWS_LAUNCHER_FILE = 'launch.ps1'
 const CODING_AGENT_SCOPED_AUTH_PROVIDERS = new Set(['openai-codex', 'copilot', 'xai-oauth', 'nous', 'google-gemini-cli', 'claude-oauth'])
 const CLAUDE_CODE_SKIP_PERMISSIONS_ARGS = ['--dangerously-skip-permissions']
 const CLAUDE_CODE_ROOT_PERMISSION_ARGS = ['--permission-mode', 'auto']
+const HERMES_MCP_SERVER_NAME = 'hermes-studio'
+const HERMES_MCP_MANAGED_ENV_KEY = 'HERMES_WEB_UI_MANAGED_MCP'
+const HERMES_PROMPT_BLOCK_BEGIN = '<!-- BEGIN HERMES WEB UI PROMPT -->'
+const HERMES_PROMPT_BLOCK_END = '<!-- END HERMES WEB UI PROMPT -->'
 
 interface CommandExecution {
   command: string
@@ -195,6 +200,10 @@ function getNpmCliPath() {
 
 function getNpmBin() {
   return process.platform === 'win32' ? 'npm.cmd' : 'npm'
+}
+
+function getGlobalConfigHome() {
+  return process.env.HERMES_CODING_AGENT_GLOBAL_HOME?.trim() || homedir()
 }
 
 function compareNodeVersionDesc(left: string, right: string): number {
@@ -652,9 +661,59 @@ function claudeCodePermissionArgs(): string[] {
 }
 
 function expandHomePath(path: string): string {
-  if (path === '~') return homedir()
-  if (path.startsWith('~/')) return join(homedir(), path.slice(2))
+  if (path === '~') return getGlobalConfigHome()
+  if (path.startsWith('~/')) return join(getGlobalConfigHome(), path.slice(2))
   return path
+}
+
+function hermesPromptDocument(): string {
+  return [
+    HERMES_PROMPT_BLOCK_BEGIN,
+    getSystemPrompt().trim(),
+    HERMES_PROMPT_BLOCK_END,
+    '',
+  ].join('\n')
+}
+
+function upsertManagedMarkdownBlock(existing: string, block: string): string {
+  const normalizedBlock = block.endsWith('\n') ? block : `${block}\n`
+  const start = existing.indexOf(HERMES_PROMPT_BLOCK_BEGIN)
+  const end = existing.indexOf(HERMES_PROMPT_BLOCK_END)
+  if (start >= 0 && end >= start) {
+    const afterEnd = end + HERMES_PROMPT_BLOCK_END.length
+    const before = existing.slice(0, start).replace(/\s*$/, '')
+    const after = existing.slice(afterEnd).replace(/^\s*/, '')
+    return [before, normalizedBlock.trimEnd(), after].filter(Boolean).join('\n\n') + '\n'
+  }
+  const trimmedExisting = existing.replace(/\s*$/, '')
+  if (!trimmedExisting) return normalizedBlock
+  return `${trimmedExisting}\n\n${normalizedBlock}`
+}
+
+async function writeManagedPromptFile(definition: CodingAgentConfigFileDefinition): Promise<{ key: string; path: string; absolutePath: string }> {
+  let existing = ''
+  try {
+    existing = await readFile(definition.absolutePath, 'utf-8')
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') throw err
+  }
+  const next = upsertManagedMarkdownBlock(existing, hermesPromptDocument())
+  if (next !== existing) {
+    await mkdir(dirname(definition.absolutePath), { recursive: true })
+    await writeFile(definition.absolutePath, next, 'utf-8')
+  }
+  return {
+    key: definition.key,
+    path: definition.path,
+    absolutePath: definition.absolutePath,
+  }
+}
+
+async function ensureGlobalCodingAgentPromptFile(id: CodingAgentId): Promise<Array<{ key: string; path: string; absolutePath: string }>> {
+  if (id !== 'claude-code') return []
+  const definition = getLiveConfigFileDefinition(id, 'prompt')
+  if (!definition) return []
+  return [await writeManagedPromptFile(definition)]
 }
 
 function shellQuote(value: string): string {
@@ -664,6 +723,73 @@ function shellQuote(value: string): string {
 
 function powerShellQuote(value: string): string {
   return `'${value.replace(/'/g, "''")}'`
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value)
+}
+
+function tomlStringArray(values: string[]): string {
+  return `[${values.map(tomlString).join(', ')}]`
+}
+
+function isDesktopRuntime(): boolean {
+  return String(process.env.HERMES_DESKTOP || '').trim().toLowerCase() === 'true'
+}
+
+function candidateBundledMcpScripts(): string[] {
+  return [
+    process.env.HERMES_WEB_UI_MCP_BIN,
+    join(process.cwd(), 'bin/hermes-web-ui-mcp.mjs'),
+    join(__dirname, '../../bin/hermes-web-ui-mcp.mjs'),
+    join(__dirname, '../../../../../bin/hermes-web-ui-mcp.mjs'),
+  ].filter((value): value is string => !!value)
+}
+
+function bundledMcpScriptPath(): string | null {
+  return candidateBundledMcpScripts().find(candidate => existsSync(candidate)) || null
+}
+
+function hermesMcpCommandConfig(): { command: string; args?: string[] } {
+  if (isDesktopRuntime()) return { command: 'hermes-studio-mcp' }
+  const script = bundledMcpScriptPath()
+  if (script) return { command: process.execPath, args: [script] }
+  return { command: 'hermes-web-ui-mcp' }
+}
+
+function hermesMcpServerConfig(): { command: string; args?: string[]; env: Record<string, string> } {
+  const appHome = getWebUiHome()
+  return {
+    ...hermesMcpCommandConfig(),
+    env: {
+      HERMES_WEB_UI_URL: `http://127.0.0.1:${process.env.PORT || '8648'}`,
+      HERMES_WEB_UI_HOME: appHome,
+      HERMES_WEBUI_STATE_DIR: appHome,
+      HERMES_MCP_SERVER_NAME: 'hermes-studio-mcp',
+      [HERMES_MCP_MANAGED_ENV_KEY]: '1',
+    },
+  }
+}
+
+function claudeMcpConfigJson(): string {
+  return `${JSON.stringify({ mcpServers: { [HERMES_MCP_SERVER_NAME]: hermesMcpServerConfig() } }, null, 2)}\n`
+}
+
+function codexMcpConfigToml(): string {
+  const server = hermesMcpServerConfig()
+  const lines = [
+    `[mcp_servers.${HERMES_MCP_SERVER_NAME}]`,
+    `command = ${tomlString(server.command)}`,
+  ]
+  if (server.args?.length) lines.push(`args = ${tomlStringArray(server.args)}`)
+  lines.push('startup_timeout_sec = 120')
+  lines.push('')
+  lines.push(`[mcp_servers.${HERMES_MCP_SERVER_NAME}.env]`)
+  for (const [key, value] of Object.entries(server.env)) {
+    lines.push(`${key} = ${tomlString(value)}`)
+  }
+  lines.push('')
+  return lines.join('\n')
 }
 
 function buildLaunchShellCommand(input: {
@@ -1299,6 +1425,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
     const workspaceDir = resolveLaunchWorkspaceRoot(scope, input.workspace)
     const args = tool.id === 'claude-code' ? claudeCodePermissionArgs() : []
     await mkdir(workspaceDir, { recursive: true })
+    const files = await ensureGlobalCodingAgentPromptFile(tool.id)
     const shellCommand = buildLaunchShellCommand({
       workspaceDir,
       env: {},
@@ -1317,7 +1444,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
       args,
       env: {},
       shellCommand,
-      files: [],
+      files,
     }
   }
 
@@ -1386,7 +1513,8 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
     }
     env = settings.env
     await writeScopedFile('settings', `${JSON.stringify(settings, null, 2)}\n`)
-    await writeScopedFile('mcp', `${JSON.stringify({ mcpServers: {} }, null, 2)}\n`)
+    await writeScopedFile('mcp', claudeMcpConfigJson())
+    await writeScopedFile('prompt', hermesPromptDocument())
 
     const settingsPath = join(rootDir, 'settings.json')
     const mcpPath = join(rootDir, 'mcp.json')
@@ -1435,6 +1563,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
       'requires_openai_auth = false',
       ...(codexApiKey ? [`experimental_bearer_token = ${JSON.stringify(codexApiKey)}`] : []),
       '',
+      codexMcpConfigToml(),
     ].join('\n')
     const catalog = buildCodexModelCatalog({
       profile: scope.profile,
@@ -1574,8 +1703,8 @@ export async function startCodingAgentRun(
   }
 }
 
-export function sendCodingAgentRunInput(sessionId: string, input: string): { runId: string } {
-  return codingAgentRunManager.send(sessionId, input)
+export function sendCodingAgentRunInput(sessionId: string, input: string, systemPrompt?: string): { runId: string } {
+  return codingAgentRunManager.send(sessionId, input, { systemPrompt })
 }
 
 export function stopCodingAgentRun(sessionId: string): { stopped: boolean } {

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -761,7 +761,7 @@ function hermesMcpCommandConfig(): { command: string; args?: string[] } {
   return { command: 'hermes-web-ui-mcp' }
 }
 
-function hermesMcpServerConfig(): { command: string; args?: string[]; env: Record<string, string> } {
+function hermesMcpServerConfig(profile: string): { command: string; args?: string[]; env: Record<string, string> } {
   const appHome = getWebUiHome()
   return {
     ...hermesMcpCommandConfig(),
@@ -769,18 +769,19 @@ function hermesMcpServerConfig(): { command: string; args?: string[]; env: Recor
       HERMES_WEB_UI_URL: `http://127.0.0.1:${process.env.PORT || '8648'}`,
       HERMES_WEB_UI_HOME: appHome,
       HERMES_WEBUI_STATE_DIR: appHome,
+      HERMES_WEB_UI_PROFILE: profile,
       HERMES_MCP_SERVER_NAME: 'hermes-studio-mcp',
       [HERMES_MCP_MANAGED_ENV_KEY]: '1',
     },
   }
 }
 
-function claudeMcpConfigJson(): string {
-  return `${JSON.stringify({ mcpServers: { [HERMES_MCP_SERVER_NAME]: hermesMcpServerConfig() } }, null, 2)}\n`
+function claudeMcpConfigJson(profile: string): string {
+  return `${JSON.stringify({ mcpServers: { [HERMES_MCP_SERVER_NAME]: hermesMcpServerConfig(profile) } }, null, 2)}\n`
 }
 
-function codexMcpConfigToml(): string {
-  const server = hermesMcpServerConfig()
+function codexMcpConfigToml(profile: string): string {
+  const server = hermesMcpServerConfig(profile)
   const lines = [
     `[mcp_servers.${HERMES_MCP_SERVER_NAME}]`,
     `command = ${tomlString(server.command)}`,
@@ -1513,7 +1514,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
     }
     env = settings.env
     await writeScopedFile('settings', `${JSON.stringify(settings, null, 2)}\n`)
-    await writeScopedFile('mcp', claudeMcpConfigJson())
+    await writeScopedFile('mcp', claudeMcpConfigJson(scope.profile))
     await writeScopedFile('prompt', hermesPromptDocument())
 
     const settingsPath = join(rootDir, 'settings.json')
@@ -1563,7 +1564,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
       'requires_openai_auth = false',
       ...(codexApiKey ? [`experimental_bearer_token = ${JSON.stringify(codexApiKey)}`] : []),
       '',
-      codexMcpConfigToml(),
+      codexMcpConfigToml(scope.profile),
     ].join('\n')
     const catalog = buildCodexModelCatalog({
       profile: scope.profile,

--- a/packages/server/src/services/global-agent/outbound-relay-client.ts
+++ b/packages/server/src/services/global-agent/outbound-relay-client.ts
@@ -1,0 +1,645 @@
+import { io, type Socket } from 'socket.io-client'
+import { config } from '../../config'
+import { logger } from '../logger'
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+const MAX_REQUEST_TIMEOUT_MS = 120_000
+const MAX_REQUEST_BODY_BYTES = 5 * 1024 * 1024
+const MAX_RESPONSE_BODY_BYTES = 10 * 1024 * 1024
+
+const ALLOWED_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD'])
+const ALLOWED_REQUEST_HEADERS = new Set([
+  'accept',
+  'accept-language',
+  'authorization',
+  'content-type',
+  'x-hermes-profile',
+  'x-request-id',
+])
+const TEXTUAL_RESPONSE_TYPES = [
+  'application/json',
+  'application/problem+json',
+  'application/x-ndjson',
+  'application/javascript',
+  'application/xml',
+  'application/x-www-form-urlencoded',
+  'text/',
+]
+const ALLOWED_SOCKET_NAMESPACES = new Set(['/chat-run'])
+const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
+  'run',
+  'resume',
+  'abort',
+  'cancel_queued_run',
+  'approval.respond',
+  'clarify.respond',
+])
+const CHAT_RUN_SERVER_EVENTS = [
+  'run.started',
+  'message.delta',
+  'reasoning.delta',
+  'thinking.delta',
+  'reasoning.available',
+  'tool.started',
+  'tool.completed',
+  'run.completed',
+  'run.failed',
+  'compression.started',
+  'compression.completed',
+  'abort.started',
+  'abort.timeout',
+  'abort.completed',
+  'usage.updated',
+  'agent.event',
+  'subagent.event',
+  'session.command',
+  'session.title.updated',
+  'run.queued',
+  'approval.requested',
+  'approval.resolved',
+  'clarify.requested',
+  'clarify.resolved',
+  'peer.user.message',
+  'resumed',
+]
+const NON_STREAMING_SUPPRESSED_EVENTS = new Set([
+  'message.delta',
+  'reasoning.delta',
+  'thinking.delta',
+  'reasoning.available',
+])
+
+export interface RelayHttpRequest {
+  id?: string
+  method?: string
+  path?: string
+  headers?: Record<string, string | string[] | undefined>
+  body?: unknown
+  bodyBase64?: string
+  timeoutMs?: number
+}
+
+export interface RelayHttpResponse {
+  id?: string
+  status?: number
+  headers?: Record<string, string>
+  body?: string
+  bodyBase64?: string
+  truncated?: boolean
+  error?: {
+    code: string
+    message: string
+  }
+}
+
+export interface RelaySocketOpenRequest {
+  id?: string
+  namespace?: string
+  auth?: Record<string, unknown>
+  query?: Record<string, string | number | boolean | undefined>
+  stream?: boolean
+}
+
+export interface RelaySocketEventRequest {
+  id?: string
+  event?: string
+  payload?: unknown
+  stream?: boolean
+}
+
+export interface RelaySocketCloseRequest {
+  id?: string
+}
+
+export interface RelaySocketResponse {
+  id?: string
+  ok?: boolean
+  namespace?: string
+  event?: string
+  stream?: boolean
+  payload?: unknown
+  error?: {
+    code: string
+    message: string
+  }
+}
+
+interface StartOutboundRelayClientOptions {
+  connectionId?: string
+  relayUrl?: string
+  relayToken?: string
+  instanceId?: string
+  localBaseUrl?: string
+  fetchImpl?: typeof fetch
+}
+
+type OutboundRelayClientOptions = Required<Omit<StartOutboundRelayClientOptions, 'connectionId'>>
+
+interface LocalSocketBridge {
+  id: string
+  namespace: string
+  socket: Socket
+  stream: boolean
+  output: string
+  reasoning: string
+}
+
+interface NormalizedBody {
+  body?: BodyInit
+  contentType?: string
+  byteLength: number
+}
+
+function relayError(id: string | undefined, code: string, message: string, status?: number): RelayHttpResponse {
+  return {
+    id,
+    ...(status ? { status } : {}),
+    error: { code, message },
+  }
+}
+
+function socketRelayError(id: string | undefined, code: string, message: string): RelaySocketResponse {
+  return {
+    id,
+    ok: false,
+    error: { code, message },
+  }
+}
+
+function isRelayHttpResponse(value: NormalizedBody | RelayHttpResponse): value is RelayHttpResponse {
+  return 'error' in value
+}
+
+function normalizeMethod(method?: string): string | null {
+  const normalized = String(method || 'GET').trim().toUpperCase()
+  return ALLOWED_METHODS.has(normalized) ? normalized : null
+}
+
+function normalizeRelayPath(path?: string): string | null {
+  const raw = String(path || '').trim()
+  if (!raw || !raw.startsWith('/') || raw.startsWith('//')) return null
+
+  const parsed = new URL(raw, 'http://hermes-relay.local')
+  const normalized = `${parsed.pathname}${parsed.search}`
+  if (parsed.pathname === '/v1' || parsed.pathname.startsWith('/v1/')) return null
+  return normalized
+}
+
+function normalizeSocketBridgeId(id?: string): string | null {
+  const normalized = String(id || '').trim()
+  if (!normalized || normalized.length > 128) return null
+  return normalized
+}
+
+function normalizeSocketNamespace(namespace?: string): string | null {
+  const normalized = String(namespace || '').trim()
+  return ALLOWED_SOCKET_NAMESPACES.has(normalized) ? normalized : null
+}
+
+function normalizeSocketQuery(query?: RelaySocketOpenRequest['query']): Record<string, string> {
+  const normalized: Record<string, string> = {}
+  for (const [key, value] of Object.entries(query || {})) {
+    if (value == null) continue
+    normalized[key] = String(value)
+  }
+  return normalized
+}
+
+function normalizeSocketAuth(auth?: RelaySocketOpenRequest['auth']): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(auth || {})) {
+    if (value == null) continue
+    normalized[key] = value
+  }
+  return normalized
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function streamMode(value: unknown, fallback = true): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function normalizeTimeout(timeoutMs?: number): number {
+  const value = Number(timeoutMs)
+  if (!Number.isFinite(value) || value <= 0) return DEFAULT_REQUEST_TIMEOUT_MS
+  return Math.min(Math.floor(value), MAX_REQUEST_TIMEOUT_MS)
+}
+
+function normalizeHeaders(headers?: RelayHttpRequest['headers']): Headers {
+  const normalized = new Headers()
+  for (const [name, value] of Object.entries(headers || {})) {
+    const lower = name.toLowerCase()
+    if (!ALLOWED_REQUEST_HEADERS.has(lower) || value == null) continue
+    const headerValue = Array.isArray(value) ? value.find(Boolean) : value
+    if (headerValue) normalized.set(lower, String(headerValue))
+  }
+  return normalized
+}
+
+function normalizeRequestBody(request: RelayHttpRequest, method: string, headers: Headers): NormalizedBody | RelayHttpResponse {
+  if (method === 'GET' || method === 'HEAD') {
+    return { byteLength: 0 }
+  }
+
+  if (typeof request.bodyBase64 === 'string') {
+    const buffer = Buffer.from(request.bodyBase64, 'base64')
+    if (buffer.byteLength > MAX_REQUEST_BODY_BYTES) {
+      return relayError(request.id, 'request_body_too_large', 'Relay request body exceeds the local size limit', 413)
+    }
+    return { body: buffer, byteLength: buffer.byteLength }
+  }
+
+  if (request.body == null) {
+    return { byteLength: 0 }
+  }
+
+  if (typeof request.body === 'string') {
+    const byteLength = Buffer.byteLength(request.body)
+    if (byteLength > MAX_REQUEST_BODY_BYTES) {
+      return relayError(request.id, 'request_body_too_large', 'Relay request body exceeds the local size limit', 413)
+    }
+    return { body: request.body, byteLength }
+  }
+
+  const serialized = JSON.stringify(request.body)
+  const byteLength = Buffer.byteLength(serialized)
+  if (byteLength > MAX_REQUEST_BODY_BYTES) {
+    return relayError(request.id, 'request_body_too_large', 'Relay request body exceeds the local size limit', 413)
+  }
+  if (!headers.has('content-type')) {
+    return { body: serialized, contentType: 'application/json', byteLength }
+  }
+  return { body: serialized, byteLength }
+}
+
+function responseHeaders(response: Response): Record<string, string> {
+  const headers: Record<string, string> = {}
+  response.headers.forEach((value, key) => {
+    const lower = key.toLowerCase()
+    if (lower === 'connection' || lower === 'transfer-encoding') return
+    headers[lower] = value
+  })
+  return headers
+}
+
+function isTextualResponse(contentType: string): boolean {
+  const lower = contentType.toLowerCase()
+  return TEXTUAL_RESPONSE_TYPES.some(prefix => lower.startsWith(prefix) || lower.includes(prefix))
+}
+
+async function readResponseBody(response: Response): Promise<{ body?: string; bodyBase64?: string; truncated?: boolean }> {
+  const contentType = response.headers.get('content-type') || ''
+  if (!response.body) return {}
+
+  const reader = response.body.getReader()
+  const chunks: Buffer[] = []
+  let total = 0
+  let truncated = false
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    const chunk = Buffer.from(value)
+    total += chunk.byteLength
+    if (total > MAX_RESPONSE_BODY_BYTES) {
+      const remaining = Math.max(0, MAX_RESPONSE_BODY_BYTES - (total - chunk.byteLength))
+      if (remaining > 0) chunks.push(chunk.subarray(0, remaining))
+      truncated = true
+      await reader.cancel()
+      break
+    }
+    chunks.push(chunk)
+  }
+
+  const buffer = Buffer.concat(chunks)
+  if (isTextualResponse(contentType)) {
+    return { body: buffer.toString('utf-8'), truncated }
+  }
+  return { bodyBase64: buffer.toString('base64'), truncated }
+}
+
+export class OutboundRelayClient {
+  private socket: Socket | null = null
+  private readonly socketBridges = new Map<string, LocalSocketBridge>()
+  private readonly relayUrl: string
+  private readonly relayToken: string
+  private readonly instanceId: string
+  private readonly localBaseUrl: string
+  private readonly fetchImpl: typeof fetch
+
+  constructor(options: OutboundRelayClientOptions) {
+    this.relayUrl = options.relayUrl
+    this.relayToken = options.relayToken
+    this.instanceId = options.instanceId
+    this.localBaseUrl = options.localBaseUrl.replace(/\/$/, '')
+    this.fetchImpl = options.fetchImpl
+  }
+
+  start(): void {
+    if (this.socket) return
+    this.socket = io(this.relayUrl, {
+      auth: {
+        token: this.relayToken || undefined,
+        instanceId: this.instanceId || undefined,
+        role: 'hermes-web-ui',
+      },
+      transports: ['websocket', 'polling'],
+      reconnection: true,
+      reconnectionAttempts: Infinity,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 30_000,
+      timeout: 30_000,
+    })
+
+    this.socket.on('connect', () => {
+      logger.info({ relayUrl: this.redactedRelayUrl() }, '[outbound-relay] connected')
+      this.socket?.emit('relay.ready', {
+        capabilities: ['http.request.v1', 'socket.chat-run.v1'],
+        instanceId: this.instanceId || undefined,
+      })
+    })
+    this.socket.on('connect_error', (err: Error) => {
+      logger.warn({ err, relayUrl: this.redactedRelayUrl() }, '[outbound-relay] connection failed')
+    })
+    this.socket.on('disconnect', (reason: string) => {
+      logger.info({ reason, relayUrl: this.redactedRelayUrl() }, '[outbound-relay] disconnected')
+    })
+    this.socket.on('http.request', (request: RelayHttpRequest, ack?: (response: RelayHttpResponse) => void) => {
+      void this.handleHttpRequest(request)
+        .then((response) => this.respond(response, ack))
+        .catch((err) => this.respond(relayError(request?.id, 'relay_internal_error', err instanceof Error ? err.message : String(err), 500), ack))
+    })
+    this.socket.on('socket.open', (request: RelaySocketOpenRequest, ack?: (response: RelaySocketResponse) => void) => {
+      this.respondSocket(this.openLocalSocket(request), ack)
+    })
+    this.socket.on('socket.event', (request: RelaySocketEventRequest, ack?: (response: RelaySocketResponse) => void) => {
+      this.respondSocket(this.emitLocalSocketEvent(request), ack)
+    })
+    this.socket.on('socket.close', (request: RelaySocketCloseRequest, ack?: (response: RelaySocketResponse) => void) => {
+      this.respondSocket(this.closeLocalSocket(request), ack)
+    })
+  }
+
+  stop(): void {
+    for (const bridge of this.socketBridges.values()) {
+      bridge.socket.disconnect()
+    }
+    this.socketBridges.clear()
+    this.socket?.disconnect()
+    this.socket = null
+  }
+
+  async handleHttpRequest(request: RelayHttpRequest): Promise<RelayHttpResponse> {
+    const method = normalizeMethod(request.method)
+    if (!method) {
+      return relayError(request.id, 'method_not_allowed', 'Relay request method is not allowed', 405)
+    }
+
+    const path = normalizeRelayPath(request.path)
+    if (!path) {
+      return relayError(request.id, 'path_not_allowed', 'Relay request path is not allowed', 403)
+    }
+
+    const headers = normalizeHeaders(request.headers)
+    const normalizedBody = normalizeRequestBody(request, method, headers)
+    if (isRelayHttpResponse(normalizedBody)) return normalizedBody
+    if (normalizedBody.contentType) headers.set('content-type', normalizedBody.contentType)
+
+    const timeoutMs = normalizeTimeout(request.timeoutMs)
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), timeoutMs)
+
+    try {
+      const response = await this.fetchImpl(`${this.localBaseUrl}${path}`, {
+        method,
+        headers,
+        body: normalizedBody.body,
+        signal: controller.signal,
+      })
+      const body = await readResponseBody(response)
+      return {
+        id: request.id,
+        status: response.status,
+        headers: responseHeaders(response),
+        ...body,
+      }
+    } catch (err) {
+      const aborted = controller.signal.aborted
+      return relayError(
+        request.id,
+        aborted ? 'request_timeout' : 'local_request_failed',
+        aborted ? `Local relay request timed out after ${timeoutMs}ms` : err instanceof Error ? err.message : String(err),
+        aborted ? 504 : 502,
+      )
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  private respond(response: RelayHttpResponse, ack?: (response: RelayHttpResponse) => void): void {
+    if (ack) {
+      ack(response)
+      return
+    }
+    this.socket?.emit('http.response', response)
+  }
+
+  private openLocalSocket(request: RelaySocketOpenRequest): RelaySocketResponse {
+    const id = normalizeSocketBridgeId(request.id)
+    if (!id) return socketRelayError(request.id, 'invalid_socket_id', 'Relay socket id is required')
+
+    const namespace = normalizeSocketNamespace(request.namespace)
+    if (!namespace) return socketRelayError(id, 'namespace_not_allowed', 'Relay socket namespace is not allowed')
+
+    this.closeLocalSocket({ id })
+    const localSocket = io(`${this.localBaseUrl}${namespace}`, {
+      auth: normalizeSocketAuth(request.auth),
+      query: normalizeSocketQuery(request.query),
+      transports: ['websocket', 'polling'],
+      reconnection: true,
+      reconnectionAttempts: Infinity,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 30_000,
+      timeout: 30_000,
+    })
+    const bridge: LocalSocketBridge = {
+      id,
+      namespace,
+      socket: localSocket,
+      stream: streamMode(request.stream),
+      output: '',
+      reasoning: '',
+    }
+    this.socketBridges.set(id, bridge)
+
+    localSocket.on('connect', () => {
+      this.emitSocketEvent({ id, namespace, event: 'connect', payload: { socketId: localSocket.id } })
+    })
+    localSocket.on('connect_error', (err: Error) => {
+      this.emitSocketEvent({ id, namespace, event: 'connect_error', payload: { message: err.message } })
+    })
+    localSocket.on('disconnect', (reason: string) => {
+      this.emitSocketEvent({ id, namespace, event: 'disconnect', payload: { reason } })
+    })
+    for (const event of CHAT_RUN_SERVER_EVENTS) {
+      localSocket.on(event, (payload: unknown) => {
+        this.handleLocalSocketEvent(bridge, event, payload)
+      })
+    }
+
+    return { id, ok: true, namespace, stream: bridge.stream }
+  }
+
+  private emitLocalSocketEvent(request: RelaySocketEventRequest): RelaySocketResponse {
+    const id = normalizeSocketBridgeId(request.id)
+    if (!id) return socketRelayError(request.id, 'invalid_socket_id', 'Relay socket id is required')
+
+    const event = String(request.event || '').trim()
+    if (!ALLOWED_CHAT_RUN_CLIENT_EVENTS.has(event)) {
+      return socketRelayError(id, 'event_not_allowed', 'Relay socket event is not allowed')
+    }
+
+    const bridge = this.socketBridges.get(id)
+    if (!bridge) return socketRelayError(id, 'socket_not_open', 'Relay socket is not open')
+    if (typeof request.stream === 'boolean') {
+      bridge.stream = request.stream
+    }
+    if (event === 'run') {
+      bridge.output = ''
+      bridge.reasoning = ''
+    }
+
+    bridge.socket.emit(event, request.payload)
+    return { id, ok: true, namespace: bridge.namespace, event, stream: bridge.stream }
+  }
+
+  private closeLocalSocket(request: RelaySocketCloseRequest): RelaySocketResponse {
+    const id = normalizeSocketBridgeId(request.id)
+    if (!id) return socketRelayError(request.id, 'invalid_socket_id', 'Relay socket id is required')
+
+    const bridge = this.socketBridges.get(id)
+    if (!bridge) return { id, ok: true }
+    bridge.socket.disconnect()
+    this.socketBridges.delete(id)
+    return { id, ok: true, namespace: bridge.namespace }
+  }
+
+  private emitSocketEvent(event: Required<Pick<RelaySocketResponse, 'id' | 'namespace' | 'event'>> & { payload?: unknown }): void {
+    this.socket?.emit('socket.event', {
+      id: event.id,
+      namespace: event.namespace,
+      event: event.event,
+      payload: event.payload,
+    })
+  }
+
+  private handleLocalSocketEvent(bridge: LocalSocketBridge, event: string, payload: unknown): void {
+    if (!bridge.stream) {
+      if (event === 'message.delta' && isRecord(payload) && typeof payload.delta === 'string') {
+        bridge.output += payload.delta
+        return
+      }
+      if ((event === 'reasoning.delta' || event === 'thinking.delta') && isRecord(payload)) {
+        const delta = typeof payload.delta === 'string' ? payload.delta : typeof payload.text === 'string' ? payload.text : ''
+        bridge.reasoning += delta
+        return
+      }
+      if (NON_STREAMING_SUPPRESSED_EVENTS.has(event)) {
+        return
+      }
+      if (event === 'run.completed') {
+        this.emitSocketEvent({
+          id: bridge.id,
+          namespace: bridge.namespace,
+          event,
+          payload: this.withNonStreamingOutput(payload, bridge),
+        })
+        return
+      }
+    }
+
+    this.emitSocketEvent({ id: bridge.id, namespace: bridge.namespace, event, payload })
+  }
+
+  private withNonStreamingOutput(payload: unknown, bridge: LocalSocketBridge): unknown {
+    if (!isRecord(payload)) {
+      return {
+        output: bridge.output,
+        ...(bridge.reasoning ? { reasoning: bridge.reasoning } : {}),
+      }
+    }
+    return {
+      ...payload,
+      output: typeof payload.output === 'string' && payload.output ? payload.output : bridge.output,
+      ...(bridge.reasoning && typeof payload.reasoning !== 'string' ? { reasoning: bridge.reasoning } : {}),
+    }
+  }
+
+  private respondSocket(response: RelaySocketResponse, ack?: (response: RelaySocketResponse) => void): void {
+    if (ack) {
+      ack(response)
+      return
+    }
+    this.socket?.emit('socket.response', response)
+  }
+
+  private redactedRelayUrl(): string {
+    try {
+      const url = new URL(this.relayUrl)
+      url.username = ''
+      url.password = ''
+      return url.toString()
+    } catch {
+      return '<invalid-url>'
+    }
+  }
+}
+
+const activeClients = new Map<string, OutboundRelayClient>()
+
+function normalizeOutboundRelayConnectionId(options: StartOutboundRelayClientOptions, relayUrl: string): string {
+  return (options.connectionId || options.instanceId || relayUrl).trim()
+}
+
+export function startOutboundRelayClient(options: StartOutboundRelayClientOptions = {}): OutboundRelayClient | null {
+  const relayUrl = (options.relayUrl ?? '').trim()
+  if (!relayUrl) return null
+  const connectionId = normalizeOutboundRelayConnectionId(options, relayUrl)
+  const activeClient = activeClients.get(connectionId)
+  if (activeClient) return activeClient
+
+  const client = new OutboundRelayClient({
+    relayUrl,
+    relayToken: options.relayToken ?? '',
+    instanceId: options.instanceId ?? '',
+    localBaseUrl: options.localBaseUrl ?? `http://127.0.0.1:${config.port}`,
+    fetchImpl: options.fetchImpl ?? fetch,
+  })
+  client.start()
+  activeClients.set(connectionId, client)
+  return client
+}
+
+export function getOutboundRelayClient(connectionId?: string): OutboundRelayClient | null {
+  if (connectionId) return activeClients.get(connectionId) || null
+  return activeClients.values().next().value || null
+}
+
+export function getOutboundRelayClients(): Map<string, OutboundRelayClient> {
+  return new Map(activeClients)
+}
+
+export function stopOutboundRelayClient(connectionId?: string): void {
+  if (connectionId) {
+    activeClients.get(connectionId)?.stop()
+    activeClients.delete(connectionId)
+    return
+  }
+  for (const client of activeClients.values()) {
+    client.stop()
+  }
+  activeClients.clear()
+}

--- a/packages/server/src/services/global-agent/outbound-relay-client.ts
+++ b/packages/server/src/services/global-agent/outbound-relay-client.ts
@@ -344,7 +344,7 @@ export class OutboundRelayClient {
       auth: {
         token: this.relayToken || undefined,
         instanceId: this.instanceId || undefined,
-        role: 'hermes-web-ui',
+        role: 'hermes-studio',
       },
       transports: ['websocket', 'polling'],
       reconnection: true,

--- a/packages/server/src/services/global-agent/outbound-relay-client.ts
+++ b/packages/server/src/services/global-agent/outbound-relay-client.ts
@@ -357,7 +357,7 @@ export class OutboundRelayClient {
     this.socket.on('connect', () => {
       logger.info({ relayUrl: this.redactedRelayUrl() }, '[outbound-relay] connected')
       this.socket?.emit('relay.ready', {
-        capabilities: ['http.request.v1', 'socket.chat-run.v1'],
+        capabilities: ['http.request', 'socket.chat-run'],
         instanceId: this.instanceId || undefined,
       })
     })

--- a/packages/server/src/services/global-agent/server.ts
+++ b/packages/server/src/services/global-agent/server.ts
@@ -1,0 +1,372 @@
+import { randomBytes } from 'crypto'
+import type { Server, Socket } from 'socket.io'
+import { logger } from '../logger'
+import { authenticateUserToken, type AuthenticatedUser } from '../../middleware/user-auth'
+import { userCanAccessProfile } from '../../db/hermes/users-store'
+import type {
+  RelayHttpRequest,
+  RelayHttpResponse,
+  RelaySocketCloseRequest,
+  RelaySocketEventRequest,
+  RelaySocketOpenRequest,
+  RelaySocketResponse,
+} from './outbound-relay-client'
+
+const GLOBAL_AGENT_NAMESPACE = '/global-agent'
+const DEFAULT_GLOBAL_AGENT_TIMEOUT_MS = 30_000
+const SOCKET_IO_RESERVED_EVENTS = new Set([
+  'connect',
+  'connect_error',
+  'disconnect',
+  'disconnecting',
+  'newListener',
+  'removeListener',
+])
+
+interface GlobalAgentRequestOptions {
+  clientId?: string
+  timeoutMs?: number
+}
+
+function timeoutMs(value?: number): number {
+  return Number.isFinite(value) && Number(value) > 0 ? Math.floor(Number(value)) : DEFAULT_GLOBAL_AGENT_TIMEOUT_MS
+}
+
+function responseError<T extends { id?: string; ok?: boolean; error?: { code: string; message: string } }>(
+  id: string | undefined,
+  code: string,
+  message: string,
+): T {
+  return {
+    id,
+    ok: false,
+    error: { code, message },
+  } as T
+}
+
+export class GlobalAgentServer {
+  private readonly nsp: ReturnType<Server['of']>
+  private readonly clients = new Map<string, Socket>()
+  private readonly frontendClients = new Map<string, Socket>()
+  private readonly bridgeOwners = new Map<string, string>()
+  private readonly authToken = randomBytes(32).toString('hex')
+  private initialized = false
+
+  constructor(io: Server) {
+    this.nsp = io.of(GLOBAL_AGENT_NAMESPACE)
+  }
+
+  init(): void {
+    if (this.initialized) return
+    this.initialized = true
+    this.nsp.use(async (socket, next) => {
+      const auth = socket.handshake.auth || {}
+      const token = String(auth.token || '')
+      if (token !== this.authToken) {
+        const user = await authenticateUserToken(token)
+        if (!user) {
+          next(new Error('Unauthorized'))
+          return
+        }
+        const profile = String(auth.profile || socket.handshake.query?.profile || '').trim()
+        if (profile && !this.canAccessProfile(user, profile)) {
+          next(new Error('Profile access denied'))
+          return
+        }
+        socket.data.globalAgentRole = 'frontend'
+        socket.data.user = user
+        socket.data.userToken = token
+        socket.data.profile = profile
+        next()
+        return
+      }
+      socket.data.globalAgentRole = 'agent'
+      next()
+    })
+    this.nsp.on('connection', this.onConnection.bind(this))
+    logger.info('[global-agent] Socket.IO ready at %s', GLOBAL_AGENT_NAMESPACE)
+  }
+
+  getNamespace(): string {
+    return GLOBAL_AGENT_NAMESPACE
+  }
+
+  getAuthToken(): string {
+    return this.authToken
+  }
+
+  getClientIds(): string[] {
+    return Array.from(this.clients.keys())
+  }
+
+  async httpRequest(request: RelayHttpRequest, options: GlobalAgentRequestOptions = {}): Promise<RelayHttpResponse> {
+    const socket = this.resolveClient(options.clientId)
+    if (!socket) {
+      return responseError<RelayHttpResponse>(request.id, 'global_agent_unavailable', 'No global agent client is connected')
+    }
+    return this.emitWithAck<RelayHttpResponse>(socket, 'http.request', request, options.timeoutMs, request.id)
+  }
+
+  async openSocket(request: RelaySocketOpenRequest, options: GlobalAgentRequestOptions = {}): Promise<RelaySocketResponse> {
+    const socket = this.resolveClient(options.clientId)
+    if (!socket) return responseError<RelaySocketResponse>(request.id, 'global_agent_unavailable', 'No global agent client is connected')
+    return this.emitWithAck<RelaySocketResponse>(socket, 'socket.open', request, options.timeoutMs, request.id)
+  }
+
+  async emitSocketEvent(request: RelaySocketEventRequest, options: GlobalAgentRequestOptions = {}): Promise<RelaySocketResponse> {
+    const socket = this.resolveClient(options.clientId)
+    if (!socket) return responseError<RelaySocketResponse>(request.id, 'global_agent_unavailable', 'No global agent client is connected')
+    return this.emitWithAck<RelaySocketResponse>(socket, 'socket.event', request, options.timeoutMs, request.id)
+  }
+
+  async closeSocket(request: RelaySocketCloseRequest, options: GlobalAgentRequestOptions = {}): Promise<RelaySocketResponse> {
+    const socket = this.resolveClient(options.clientId)
+    if (!socket) return responseError<RelaySocketResponse>(request.id, 'global_agent_unavailable', 'No global agent client is connected')
+    return this.emitWithAck<RelaySocketResponse>(socket, 'socket.close', request, options.timeoutMs, request.id)
+  }
+
+  private onConnection(socket: Socket): void {
+    if (socket.data.globalAgentRole === 'frontend') {
+      this.onFrontendConnection(socket)
+      return
+    }
+    this.onAgentConnection(socket)
+  }
+
+  private onAgentConnection(socket: Socket): void {
+    const clientId = String(socket.handshake.auth?.instanceId || socket.id)
+    this.clients.set(clientId, socket)
+    logger.info('[global-agent] client connected id=%s socket=%s', clientId, socket.id)
+
+    socket.on('disconnect', () => {
+      if (this.clients.get(clientId)?.id === socket.id) {
+        this.clients.delete(clientId)
+      }
+      logger.info('[global-agent] client disconnected id=%s socket=%s', clientId, socket.id)
+    })
+    socket.on('relay.ready', (payload: unknown) => {
+      logger.info({ clientId, payload }, '[global-agent] client ready')
+    })
+    socket.on('socket.event', (payload: unknown) => {
+      this.emitFrontendBridgeEvent(clientId, payload)
+      this.nsp.emit('relay.socket.event', { clientId, payload })
+    })
+    socket.on('http.response', (payload: unknown) => {
+      this.nsp.emit('relay.http.response', { clientId, payload })
+    })
+  }
+
+  private onFrontendConnection(socket: Socket): void {
+    this.frontendClients.set(socket.id, socket)
+    logger.info('[global-agent] frontend connected socket=%s user=%s', socket.id, socket.data.user?.id)
+
+    socket.on('http.request', (request: RelayHttpRequest & { clientId?: string }, ack?: (response: RelayHttpResponse) => void) => {
+      void this.httpRequest(
+        this.withFrontendHttpAuth(socket, request),
+        { clientId: request.clientId, timeoutMs: request.timeoutMs },
+      ).then(response => ack?.(response))
+    })
+    socket.on('socket.open', (request: RelaySocketOpenRequest & { clientId?: string; timeoutMs?: number }, ack?: (response: RelaySocketResponse) => void) => {
+      void this.openSocket(
+        this.withFrontendSocketAuth(socket, request),
+        { clientId: request.clientId, timeoutMs: request.timeoutMs },
+      ).then((response) => {
+        const bridgeId = String(request.id || '').trim()
+        if (!response.error && bridgeId) this.bridgeOwners.set(bridgeId, socket.id)
+        ack?.(response)
+      })
+    })
+    socket.on('socket.event', (request: RelaySocketEventRequest & { clientId?: string; timeoutMs?: number }, ack?: (response: RelaySocketResponse) => void) => {
+      if (!this.frontendOwnsBridge(socket, request.id)) {
+        ack?.(responseError<RelaySocketResponse>(request.id, 'socket_not_open', 'Relay socket is not open for this frontend client'))
+        return
+      }
+      void this.emitSocketEvent(
+        this.withFrontendSocketPayload(socket, request),
+        { clientId: request.clientId, timeoutMs: request.timeoutMs },
+      ).then(response => ack?.(response))
+    })
+    socket.on('socket.close', (request: RelaySocketCloseRequest & { clientId?: string; timeoutMs?: number }, ack?: (response: RelaySocketResponse) => void) => {
+      if (!this.frontendOwnsBridge(socket, request.id)) {
+        ack?.(responseError<RelaySocketResponse>(request.id, 'socket_not_open', 'Relay socket is not open for this frontend client'))
+        return
+      }
+      void this.closeSocket(request, { clientId: request.clientId, timeoutMs: request.timeoutMs }).then((response) => {
+        const bridgeId = String(request.id || '').trim()
+        if (bridgeId) this.bridgeOwners.delete(bridgeId)
+        ack?.(response)
+      })
+    })
+    socket.on('run', (payload: unknown) => {
+      void this.emitFrontendChatEvent(socket, 'run', payload)
+    })
+    socket.on('resume', (payload: unknown) => {
+      void this.emitFrontendChatEvent(socket, 'resume', payload)
+    })
+    socket.on('abort', (payload: unknown) => {
+      void this.emitFrontendChatEvent(socket, 'abort', payload)
+    })
+    socket.on('cancel_queued_run', (payload: unknown) => {
+      void this.emitFrontendChatEvent(socket, 'cancel_queued_run', payload)
+    })
+    socket.on('approval.respond', (payload: unknown) => {
+      void this.emitFrontendChatEvent(socket, 'approval.respond', payload)
+    })
+    socket.on('clarify.respond', (payload: unknown) => {
+      void this.emitFrontendChatEvent(socket, 'clarify.respond', payload)
+    })
+    socket.on('disconnect', () => {
+      this.frontendClients.delete(socket.id)
+      for (const [bridgeId, ownerSocketId] of this.bridgeOwners.entries()) {
+        if (ownerSocketId !== socket.id) continue
+        this.bridgeOwners.delete(bridgeId)
+        void this.closeSocket({ id: bridgeId })
+      }
+      logger.info('[global-agent] frontend disconnected socket=%s user=%s', socket.id, socket.data.user?.id)
+    })
+  }
+
+  private resolveClient(clientId?: string): Socket | null {
+    if (clientId) return this.clients.get(clientId) || null
+    return this.clients.values().next().value || null
+  }
+
+  private canAccessProfile(user: AuthenticatedUser, profile: string): boolean {
+    return user.role === 'super_admin' || userCanAccessProfile(user.id, profile)
+  }
+
+  private frontendProfile(socket: Socket): string {
+    return String(socket.data.profile || '').trim()
+  }
+
+  private withFrontendHttpAuth(socket: Socket, request: RelayHttpRequest): RelayHttpRequest {
+    const headers = { ...(request.headers || {}) }
+    headers.authorization = `Bearer ${socket.data.userToken}`
+    const profile = this.frontendProfile(socket)
+    if (profile) headers['x-hermes-profile'] = profile
+    return { ...request, headers }
+  }
+
+  private withFrontendSocketAuth(socket: Socket, request: RelaySocketOpenRequest): RelaySocketOpenRequest {
+    const profile = this.frontendProfile(socket)
+    return {
+      ...request,
+      auth: {
+        ...(request.auth || {}),
+        token: socket.data.userToken,
+      },
+      query: {
+        ...(request.query || {}),
+        ...(profile ? { profile } : {}),
+      },
+    }
+  }
+
+  private withFrontendSocketPayload(socket: Socket, request: RelaySocketEventRequest): RelaySocketEventRequest {
+    const profile = this.frontendProfile(socket)
+    if (!profile || !request.payload || typeof request.payload !== 'object' || Array.isArray(request.payload)) {
+      return request
+    }
+    const payload = request.payload as Record<string, unknown>
+    return {
+      ...request,
+      payload: {
+        ...payload,
+        profile: typeof payload.profile === 'string' && payload.profile ? payload.profile : profile,
+      },
+    }
+  }
+
+  private frontendOwnsBridge(socket: Socket, id?: string): boolean {
+    const bridgeId = String(id || '').trim()
+    return Boolean(bridgeId) && this.bridgeOwners.get(bridgeId) === socket.id
+  }
+
+  private frontendBridgeId(socket: Socket): string {
+    return `frontend:${socket.id}:chat-run`
+  }
+
+  private async ensureFrontendChatBridge(socket: Socket): Promise<string | null> {
+    const id = this.frontendBridgeId(socket)
+    if (this.bridgeOwners.get(id) === socket.id) return id
+
+    const response = await this.openSocket(this.withFrontendSocketAuth(socket, {
+      id,
+      namespace: '/chat-run',
+      stream: true,
+    }))
+    if (response.error) {
+      socket.emit('connect_error', new Error(response.error.message))
+      return null
+    }
+    this.bridgeOwners.set(id, socket.id)
+    return id
+  }
+
+  private async emitFrontendChatEvent(socket: Socket, event: string, payload: unknown): Promise<void> {
+    const id = await this.ensureFrontendChatBridge(socket)
+    if (!id) return
+    const response = await this.emitSocketEvent(this.withFrontendSocketPayload(socket, {
+      id,
+      event,
+      payload,
+    }))
+    if (response.error) {
+      const sessionId = payload && typeof payload === 'object' && !Array.isArray(payload)
+        ? String((payload as Record<string, unknown>).session_id || '')
+        : ''
+      socket.emit('run.failed', {
+        event: 'run.failed',
+        ...(sessionId ? { session_id: sessionId } : {}),
+        error: response.error.message,
+      })
+    }
+  }
+
+  private emitFrontendBridgeEvent(_clientId: string, event: unknown): void {
+    if (!event || typeof event !== 'object' || Array.isArray(event)) return
+    const record = event as {
+      id?: unknown
+      event?: unknown
+      payload?: unknown
+    }
+    const bridgeId = typeof record.id === 'string' ? record.id : ''
+    const eventName = typeof record.event === 'string' ? record.event : ''
+    if (!bridgeId || !eventName) return
+    if (SOCKET_IO_RESERVED_EVENTS.has(eventName)) return
+    const ownerSocketId = this.bridgeOwners.get(bridgeId)
+    if (!ownerSocketId) return
+    this.frontendClients.get(ownerSocketId)?.emit(eventName, record.payload)
+  }
+
+  private emitWithAck<T extends { id?: string; ok?: boolean; error?: { code: string; message: string } }>(
+    socket: Socket,
+    event: string,
+    payload: unknown,
+    requestedTimeoutMs: number | undefined,
+    id: string | undefined,
+  ): Promise<T> {
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        resolve(responseError<T>(id, 'global_agent_timeout', `Global agent request timed out after ${timeoutMs(requestedTimeoutMs)}ms`))
+      }, timeoutMs(requestedTimeoutMs))
+      socket.emit(event, payload, (response: T) => {
+        clearTimeout(timer)
+        resolve(response)
+      })
+    })
+  }
+}
+
+let activeGlobalAgentServer: GlobalAgentServer | null = null
+
+export function startGlobalAgentServer(io: Server): GlobalAgentServer {
+  if (activeGlobalAgentServer) return activeGlobalAgentServer
+  activeGlobalAgentServer = new GlobalAgentServer(io)
+  activeGlobalAgentServer.init()
+  return activeGlobalAgentServer
+}
+
+export function getGlobalAgentServer(): GlobalAgentServer | null {
+  return activeGlobalAgentServer
+}

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -508,10 +508,7 @@ class AgentClient {
                     return { ...block, text: `${routedPrefix}\n\n原始消息：${text || msg.content}` }
                 })
                 : `${routedPrefix}\n\n原始消息：${stripMentionRoutingTokens(msg.content, this.name) || msg.content}`
-            const runPrompt = [
-                `[Current Hermes profile: ${this.profile}]`,
-                'When calling Hermes Web UI endpoints from tools or skills, include the current Hermes profile as the X-Hermes-Profile header if the endpoint supports profile-scoped behavior.',
-            ].join('\n')
+            const runPrompt = 'When calling Hermes Web UI endpoints from tools or skills, include the current Hermes profile as the X-Hermes-Profile header if the endpoint supports profile-scoped behavior.'
             instructions = instructions ? `${runPrompt}\n${instructions}` : runPrompt
             const bridgeInput: AgentBridgeMessage = isContentBlockArray(input)
                 ? await convertContentBlocksForAgent(input)

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -508,11 +508,11 @@ class AgentClient {
                     return { ...block, text: `${routedPrefix}\n\n原始消息：${text || msg.content}` }
                 })
                 : `${routedPrefix}\n\n原始消息：${stripMentionRoutingTokens(msg.content, this.name) || msg.content}`
-            const runContext = [
+            const runPrompt = [
                 `[Current Hermes profile: ${this.profile}]`,
                 'When calling Hermes Web UI endpoints from tools or skills, include the current Hermes profile as the X-Hermes-Profile header if the endpoint supports profile-scoped behavior.',
             ].join('\n')
-            instructions = instructions ? `${runContext}\n${instructions}` : runContext
+            instructions = instructions ? `${runPrompt}\n${instructions}` : runPrompt
             const bridgeInput: AgentBridgeMessage = isContentBlockArray(input)
                 ? await convertContentBlocksForAgent(input)
                 : input

--- a/packages/server/src/services/hermes/run-chat/abort.ts
+++ b/packages/server/src/services/hermes/run-chat/abort.ts
@@ -14,6 +14,10 @@ import type { QueuedRun, SessionState } from './types'
 
 const ABORT_BRIDGE_SYNC_TIMEOUT_MESSAGE = 'Hermes Agent is still stopping. New messages will be queued until the current run exits.'
 
+function isBridgeRunSource(source?: string): boolean {
+  return source === 'cli' || source === 'global_agent'
+}
+
 export async function handleAbort(
   nsp: ReturnType<Server['of']>,
   socket: Socket,
@@ -64,13 +68,13 @@ export async function handleAbort(
   logger.info({ sessionId, runId }, '[chat-run-socket][abort] started')
 
   // Flush in-memory assistant text to DB before aborting the stream.
-  if (activeState.source === 'cli') {
+  if (isBridgeRunSource(activeState.source)) {
     flushBridgePendingToDb(activeState, sessionId)
   } else {
     flushResponseRunToDb(activeState, sessionId)
   }
 
-  if (activeState.source === 'cli') {
+  if (isBridgeRunSource(activeState.source)) {
     let interruptResult: any = null
     try {
       interruptResult = await bridge.interrupt(sessionId, 'Aborted by user', activeState.profile)

--- a/packages/server/src/services/hermes/run-chat/abort.ts
+++ b/packages/server/src/services/hermes/run-chat/abort.ts
@@ -12,7 +12,7 @@ import { replaceState } from './compression'
 import { calcAndUpdateUsage } from './usage'
 import type { QueuedRun, SessionState } from './types'
 
-const ABORT_BRIDGE_SYNC_TIMEOUT_MESSAGE = 'Hermes Agent is still stopping. New messages will be queued until the current run exits.'
+const ABORT_BRIDGE_SYNC_TIMEOUT_MESSAGE = 'Hermes Agent did not confirm stop before timeout. Local run state was released so you can continue.'
 
 function isBridgeRunSource(source?: string): boolean {
   return source === 'cli' || source === 'global_agent'
@@ -101,6 +101,12 @@ export async function handleAbort(
         message: ABORT_BRIDGE_SYNC_TIMEOUT_MESSAGE,
       })
       logger.warn({ sessionId, runId }, '[chat-run-socket][abort] CLI bridge interrupt did not sync before timeout')
+      try {
+        await bridge.destroy?.(sessionId, activeState.profile)
+      } catch (err) {
+        logger.warn(err, '[chat-run-socket][abort] failed to destroy timed-out CLI bridge session %s', sessionId)
+      }
+      await markAbortCompleted(nsp, socket, sessionId, runId || 'bridge_abort_timeout', sessionMap, runQueuedItem, false)
       return
     }
   } else if (activeState.source === 'coding_agent') {
@@ -119,6 +125,7 @@ export async function markAbortCompleted(
   runId: string,
   sessionMap: Map<string, SessionState>,
   runQueuedItem: (socket: Socket, sessionId: string, next: QueuedRun, fallbackProfile?: string) => void,
+  synced = true,
 ) {
   const state = sessionMap.get(sessionId)
   if (!state) return
@@ -149,13 +156,13 @@ export async function markAbortCompleted(
     replaceState(sessionMap, sessionId, 'abort.completed', {
       event: 'abort.completed',
       run_id: runId,
-      synced: true,
+      synced,
       queue_length: state.queue.length + 1,
     })
     emitToSession(nsp, socket, sessionId, 'abort.completed', {
       event: 'abort.completed',
       run_id: runId,
-      synced: true,
+      synced,
       queue_length: state.queue.length + 1,
     })
     emitToSession(nsp, socket, sessionId, 'run.queued', {
@@ -171,9 +178,9 @@ export async function markAbortCompleted(
   emitToSession(nsp, socket, sessionId, 'abort.completed', {
     event: 'abort.completed',
     run_id: runId,
-    synced: true,
+    synced,
   })
-  logger.info({ sessionId, runId, synced: true }, '[chat-run-socket][abort] completed')
+  logger.info({ sessionId, runId, synced }, '[chat-run-socket][abort] completed')
 }
 
 function emitToSession(nsp: ReturnType<Server['of']>, socket: Socket, sessionId: string, event: string, payload: any) {

--- a/packages/server/src/services/hermes/run-chat/handle-api-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-api-run.ts
@@ -26,10 +26,10 @@ import { getCompressionSnapshot } from '../../../db/hermes/compression-snapshot'
 import type { ContentBlock, SessionState, ChatRunSource } from './types'
 
 export function resolveRunSource(source?: string, sessionId?: string): ChatRunSource {
-  if (source === 'api_server' || source === 'cli' || source === 'coding_agent') return source
+  if (source === 'api_server' || source === 'cli' || source === 'coding_agent' || source === 'global_agent') return source
   if (sessionId) {
     const stored = getSession(sessionId)?.source
-    if (stored === 'api_server' || stored === 'cli' || stored === 'coding_agent') return stored
+    if (stored === 'api_server' || stored === 'cli' || stored === 'coding_agent' || stored === 'global_agent') return stored
   }
   return 'cli'
 }
@@ -133,7 +133,8 @@ export async function handleApiRun(
     state.isWorking = true
     state.events = []
     state.profile = profile
-    state.source = 'api_server'
+    const sessionSource: ChatRunSource = data.source === 'global_agent' ? 'global_agent' : 'api_server'
+    state.source = sessionSource
     state.activeRunMarker = runMarker
 
     let peerUserMessage: { id?: number; role: 'user'; content: string; timestamp: number } | null = null
@@ -151,7 +152,7 @@ export async function handleApiRun(
       if (!getSession(session_id)) {
         const previewText = extractTextForPreview(input)
         const preview = previewText.replace(/[\r\n]/g, ' ').substring(0, 100)
-        createSession({ id: session_id, profile, source: 'api_server', model, provider, title: preview, workspace: data.workspace || undefined })
+        createSession({ id: session_id, profile, source: sessionSource, model, provider, title: preview, workspace: data.workspace || undefined })
       }
 
       const messageId = addMessage({
@@ -174,7 +175,7 @@ export async function handleApiRun(
       if (!getSession(session_id)) {
         const previewText = extractTextForPreview(input)
         const preview = previewText.replace(/[\r\n]/g, ' ').substring(0, 100)
-        createSession({ id: session_id, profile, source: 'api_server', model, provider, title: preview, workspace: data.workspace || undefined })
+        createSession({ id: session_id, profile, source: sessionSource, model, provider, title: preview, workspace: data.workspace || undefined })
       }
       const messageId = addMessage({
         session_id,

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -75,11 +75,15 @@ function isReplaceableLocalTitle(sessionId: string): boolean {
   return variants.has(current)
 }
 
+function isBridgeSessionSource(source?: string | null): boolean {
+  return source === 'cli' || source === 'global_agent'
+}
+
 function syncBridgeGeneratedTitle(sessionId: string, title: unknown, emit: (event: string, payload: any) => void): boolean {
   const nextTitle = normalizeTitleText(title)
   if (!nextTitle) return false
   const session = getSession(sessionId)
-  if (!session || session.source !== 'cli') return false
+  if (!session || !isBridgeSessionSource(session.source)) return false
   if (!isReplaceableLocalTitle(sessionId)) {
     logger.info('[chat-run-socket] skipped Hermes generated title for manually titled session %s', sessionId)
     return false
@@ -99,7 +103,7 @@ function syncBridgeGeneratedTitle(sessionId: string, title: unknown, emit: (even
 
 function shouldPollBridgeGeneratedTitle(sessionId: string): boolean {
   const session = getSession(sessionId)
-  if (!session || session.source !== 'cli') return false
+  if (!session || !isBridgeSessionSource(session.source)) return false
   const detail = getSessionDetail(sessionId)
   if (!detail) return false
   const userMessageCount = detail.messages.filter(message => message.role === 'user').length
@@ -290,7 +294,7 @@ async function ensureBridgeFixedContext(args: {
 export async function handleBridgeRun(
   nsp: ReturnType<Server['of']>,
   socket: Socket,
-  data: { input: string | ContentBlock[]; display_input?: string | ContentBlock[] | null; display_role?: 'user' | 'command'; storage_message?: string; session_id?: string; model?: string; provider?: string; model_groups?: RunModelGroup[]; instructions?: string; workspace?: string | null; source?: string; queue_id?: string; peerExcludeSocketId?: string; reasoning_effort?: string },
+  data: { input: string | ContentBlock[]; display_input?: string | ContentBlock[] | null; display_role?: 'user' | 'command'; storage_message?: string; session_id?: string; model?: string; provider?: string; model_groups?: RunModelGroup[]; instructions?: string; workspace?: string | null; source?: string; session_source?: 'global_agent'; queue_id?: string; peerExcludeSocketId?: string; reasoning_effort?: string },
   profile: string,
   sessionMap: Map<string, SessionState>,
   bridge: AgentBridgeClient,
@@ -299,6 +303,7 @@ export async function handleBridgeRun(
   dequeueNextQueuedRun: (socket: Socket, sessionId: string, fallbackProfile?: string) => void,
 ) {
   const { input, session_id, instructions } = data
+  const runSource = data.session_source === 'global_agent' || data.source === 'global_agent' ? 'global_agent' : 'cli'
   if (!session_id) {
     socket.emit('run.failed', { event: 'run.failed', error: 'session_id is required for cli source' })
     return
@@ -346,7 +351,7 @@ export async function handleBridgeRun(
   state.isAborting = false
   state.events = []
   state.profile = profile
-  state.source = 'cli'
+  state.source = runSource
   state.activeRunMarker = runMarker
   state.runId = undefined
   state.abortController = undefined
@@ -387,7 +392,7 @@ export async function handleBridgeRun(
     if (!getSession(session_id)) {
       const previewText = extractTextForPreview(displayInput || input)
       const preview = previewText.replace(/[\r\n]/g, ' ').substring(0, 100)
-      createSession({ id: session_id, profile, source: 'cli', model: resolvedModel, provider: resolvedProvider, title: preview, workspace: data.workspace || undefined })
+      createSession({ id: session_id, profile, source: runSource, model: resolvedModel, provider: resolvedProvider, title: preview, workspace: data.workspace || undefined })
     }
     messageId = addMessage({
       session_id,
@@ -400,7 +405,7 @@ export async function handleBridgeRun(
   } else if (!getSession(session_id)) {
     const previewText = displayInput === null ? extractTextForPreview(input) : extractTextForPreview(displayInput || input)
     const preview = previewText.replace(/[\r\n]/g, ' ').substring(0, 100)
-    createSession({ id: session_id, profile, source: 'cli', model: resolvedModel, provider: resolvedProvider, title: preview, workspace: data.workspace || undefined })
+    createSession({ id: session_id, profile, source: runSource, model: resolvedModel, provider: resolvedProvider, title: preview, workspace: data.workspace || undefined })
   }
 
   socket.join(`session:${session_id}`)
@@ -597,6 +602,7 @@ export async function resumeBridgeRun(
     instructions: string
     model?: string | null
     provider?: string | null
+    source?: string | null
   },
   sessionMap: Map<string, SessionState>,
   bridge: AgentBridgeClient,
@@ -613,7 +619,7 @@ export async function resumeBridgeRun(
   state.isWorking = true
   state.isAborting = state.isAborting === true
   state.profile = profile
-  state.source = 'cli'
+  state.source = args.source === 'global_agent' ? 'global_agent' : 'cli'
   state.runId = runId
   state.activeRunMarker = runMarker
   state.bridgeOutput = state.bridgeOutput || latestAssistantText(state)
@@ -1340,7 +1346,7 @@ async function maybeEnqueueGoalContinuation(args: {
     model_groups: args.modelGroups,
     instructions: undefined,
     profile: args.profile,
-    source: 'cli',
+    source: args.state.source === 'global_agent' ? 'global_agent' : 'cli',
     goalContinuation: true,
   }
   args.state.queue.push(next)

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -31,7 +31,7 @@ import type { ChatMessage } from '../../../lib/context-compressor'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
 import { filterBridgeToolCallMarkupDelta, flushPendingToolCallMarkup } from './bridge-delta'
 import { markAbortCompleted } from './abort'
-import { buildModelRunAuthPrompt } from './model-run-prompt'
+import { writeModelRunProfileToken } from './model-run-prompt'
 import type { AuthenticatedUser } from '../../../middleware/user-auth'
 
 const BRIDGE_USAGE_FLUSH_DELAY_MS = 200
@@ -333,9 +333,8 @@ export async function handleBridgeRun(
     if (Object.keys(updates).length > 0) updateSession(session_id, updates)
   }
   const socketUser = socket.data.user as AuthenticatedUser | undefined
+  await writeModelRunProfileToken(socketUser, profile)
   const runPrompt = [
-    ...await buildModelRunAuthPrompt(socketUser, profile),
-    socketUser ? '' : `[Current Hermes profile: ${profile}]`,
     workspace ? `[Current working directory: ${workspace}]` : '',
     'When calling Hermes Web UI endpoints from tools or skills, include the current Hermes profile as the X-Hermes-Profile header if the endpoint supports profile-scoped behavior.',
   ].filter(Boolean).join('\n')

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -31,6 +31,8 @@ import type { ChatMessage } from '../../../lib/context-compressor'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
 import { filterBridgeToolCallMarkupDelta, flushPendingToolCallMarkup } from './bridge-delta'
 import { markAbortCompleted } from './abort'
+import { buildModelRunAuthPrompt } from './model-run-prompt'
+import type { AuthenticatedUser } from '../../../middleware/user-auth'
 
 const BRIDGE_USAGE_FLUSH_DELAY_MS = 200
 const BRIDGE_TITLE_EVENT_POLL_INTERVAL_MS = 500
@@ -330,12 +332,14 @@ export async function handleBridgeRun(
     if (resolvedProvider && sessionRow.provider !== resolvedProvider) updates.provider = resolvedProvider
     if (Object.keys(updates).length > 0) updateSession(session_id, updates)
   }
-  const runContext = [
-    `[Current Hermes profile: ${profile}]`,
+  const socketUser = socket.data.user as AuthenticatedUser | undefined
+  const runPrompt = [
+    ...await buildModelRunAuthPrompt(socketUser, profile),
+    socketUser ? '' : `[Current Hermes profile: ${profile}]`,
     workspace ? `[Current working directory: ${workspace}]` : '',
     'When calling Hermes Web UI endpoints from tools or skills, include the current Hermes profile as the X-Hermes-Profile header if the endpoint supports profile-scoped behavior.',
   ].filter(Boolean).join('\n')
-  fullInstructions = `\n${runContext}\n${fullInstructions}`
+  fullInstructions = `\n${runPrompt}\n${fullInstructions}`
 
   const runMarker = `cli_run_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
   const now = Math.floor(Date.now() / 1000)

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -37,6 +37,7 @@ import type { AuthenticatedUser } from '../../../middleware/user-auth'
 const BRIDGE_USAGE_FLUSH_DELAY_MS = 200
 const BRIDGE_TITLE_EVENT_POLL_INTERVAL_MS = 500
 const BRIDGE_TITLE_EVENT_POLL_TIMEOUT_MS = 45_000
+const BRIDGE_GOAL_EVALUATE_TIMEOUT_MS = 5_000
 
 function stringValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
@@ -520,7 +521,10 @@ export async function handleBridgeRun(
       queue_length: state.queue.length || 0,
     })
 
+    let lastChunk: AgentBridgeOutput | null = null
+    let sawTerminalChunk = false
     for await (const chunk of bridge.streamOutput(started.run_id)) {
+      lastChunk = chunk
       await applyBridgeChunkAsync(
         nsp,
         socket,
@@ -540,9 +544,48 @@ export async function handleBridgeRun(
         data.model_groups,
       )
       if (chunk.done) {
+        sawTerminalChunk = true
         void pollBridgeGeneratedTitleAfterRun(bridge, session_id, profile, emit)
         break
       }
+    }
+    if (!sawTerminalChunk && state.activeRunMarker === runMarker && state.isWorking) {
+      bridgeLogger.warn({
+        sessionId: session_id,
+        runId: started.run_id,
+      }, '[chat-run-socket] bridge stream ended without terminal chunk; completing local run state')
+      const terminalChunk: AgentBridgeOutput = {
+        ok: true,
+        run_id: lastChunk?.run_id || started.run_id,
+        session_id,
+        status: 'complete',
+        delta: '',
+        cursor: typeof lastChunk?.cursor === 'number' ? lastChunk.cursor : 0,
+        output: lastChunk?.output || state.bridgeOutput || '',
+        done: true,
+        result: lastChunk?.result,
+        error: lastChunk?.error ?? null,
+        events: [],
+        event_cursor: typeof lastChunk?.event_cursor === 'number' ? lastChunk.event_cursor : 0,
+      }
+      await applyBridgeChunkAsync(
+        nsp,
+        socket,
+        state,
+        session_id,
+        runMarker,
+        terminalChunk,
+        emit,
+        profile,
+        sessionMap,
+        bridge,
+        dequeueNextQueuedRun,
+        fullInstructions,
+        { model: resolvedModel, provider: resolvedProvider },
+        currentInputTokens,
+        shouldPersistUserMessage && displayRole === 'user',
+        data.model_groups,
+      )
     }
   } catch (err: any) {
     if (state.activeRunMarker !== runMarker) return
@@ -1310,7 +1353,11 @@ async function maybeEnqueueGoalContinuation(args: {
 
   let decision
   try {
-    decision = await args.bridge.goalEvaluate(args.sessionId, finalResponse, args.profile)
+    decision = await withTimeout(
+      args.bridge.goalEvaluate(args.sessionId, finalResponse, args.profile),
+      BRIDGE_GOAL_EVALUATE_TIMEOUT_MS,
+      'goal evaluation timed out',
+    )
   } catch (err) {
     logger.warn(err, '[chat-run-socket] /goal evaluation failed for session %s', args.sessionId)
     return
@@ -1406,4 +1453,20 @@ function emitGoalStatus(
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms)
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      err => {
+        clearTimeout(timer)
+        reject(err)
+      },
+    )
+  })
 }

--- a/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
@@ -36,13 +36,6 @@ function codingAgentId(data: CodingAgentRunSocketData): CodingAgentId {
   return value === 'codex' ? 'codex' : 'claude-code'
 }
 
-function codexHermesMcpToolPrompt(): string[] {
-  return [
-    'Hermes Web UI LAN device capabilities are MCP tools, not MCP resources or resource templates. Do not use list_mcp_resources or list_mcp_resource_templates to decide whether Hermes LAN tools exist.',
-    'For LAN devices, call mcp__hermes-studio__hermes_lan_devices_scan to refresh discovery and mcp__hermes-studio__hermes_lan_devices_list to list known devices. Include profile and token arguments on each call.',
-  ]
-}
-
 export async function handleCodingAgentRun(
   nsp: ReturnType<Server['of']>,
   socket: Socket,
@@ -100,7 +93,6 @@ export async function handleCodingAgentRun(
     const runPrompt = [
       includeBaseSystemPrompt ? getSystemPrompt() : '',
       ...authPrompt,
-      ...(agentId === 'codex' && authPrompt.length > 0 ? codexHermesMcpToolPrompt() : []),
     ].filter(Boolean).join('\n')
     await sendCodingAgentRunInput(sessionId, inputText, runPrompt)
   } catch (err) {

--- a/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
@@ -25,6 +25,7 @@ export interface CodingAgentRunSocketData {
   api_key?: string
   apiMode?: any
   api_mode?: any
+  session_source?: 'global_agent'
 }
 
 function codingAgentId(data: CodingAgentRunSocketData): CodingAgentId {
@@ -73,6 +74,7 @@ export async function handleCodingAgentRun(
       baseUrl: data.baseUrl || data.base_url,
       apiKey: data.apiKey || data.api_key,
       apiMode: data.apiMode || data.api_mode,
+      sessionSource: data.session_source,
     }, state)
     runId = started.agentSessionId
   }

--- a/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
@@ -8,7 +8,7 @@ import {
 import { getOrCreateSession } from './compression'
 import { contentBlocksToString } from './content-blocks'
 import type { ContentBlock, SessionState } from './types'
-import { buildModelRunAuthPrompt } from './model-run-prompt'
+import { writeModelRunProfileToken } from './model-run-prompt'
 import type { AuthenticatedUser } from '../../../middleware/user-auth'
 import { getSystemPrompt } from '../../../lib/llm-prompt'
 
@@ -88,11 +88,10 @@ export async function handleCodingAgentRun(
   try {
     const inputText = contentBlocksToString(data.input)
     const socketUser = socket.data?.user as AuthenticatedUser | undefined
-    const authPrompt = await buildModelRunAuthPrompt(socketUser, profile)
+    await writeModelRunProfileToken(socketUser, profile)
     const includeBaseSystemPrompt = agentId === 'claude-code' || agentId === 'codex'
     const runPrompt = [
       includeBaseSystemPrompt ? getSystemPrompt() : '',
-      ...authPrompt,
     ].filter(Boolean).join('\n')
     await sendCodingAgentRunInput(sessionId, inputText, runPrompt)
   } catch (err) {

--- a/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
@@ -8,6 +8,9 @@ import {
 import { getOrCreateSession } from './compression'
 import { contentBlocksToString } from './content-blocks'
 import type { ContentBlock, SessionState } from './types'
+import { buildModelRunAuthPrompt } from './model-run-prompt'
+import type { AuthenticatedUser } from '../../../middleware/user-auth'
+import { getSystemPrompt } from '../../../lib/llm-prompt'
 
 export interface CodingAgentRunSocketData {
   input: string | ContentBlock[]
@@ -83,7 +86,15 @@ export async function handleCodingAgentRun(
   state.runId = runId
 
   try {
-    await sendCodingAgentRunInput(sessionId, contentBlocksToString(data.input))
+    const inputText = contentBlocksToString(data.input)
+    const socketUser = socket.data?.user as AuthenticatedUser | undefined
+    const authPrompt = await buildModelRunAuthPrompt(socketUser, profile)
+    const includeBaseSystemPrompt = agentId === 'claude-code' || agentId === 'codex'
+    const runPrompt = [
+      includeBaseSystemPrompt ? getSystemPrompt() : '',
+      ...authPrompt,
+    ].filter(Boolean).join('\n')
+    await sendCodingAgentRunInput(sessionId, inputText, runPrompt)
   } catch (err) {
     if (!codingAgentRunManager.isSessionProcessing(sessionId)) {
       state.isWorking = false

--- a/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
@@ -36,6 +36,13 @@ function codingAgentId(data: CodingAgentRunSocketData): CodingAgentId {
   return value === 'codex' ? 'codex' : 'claude-code'
 }
 
+function codexHermesMcpToolPrompt(): string[] {
+  return [
+    'Hermes Web UI LAN device capabilities are MCP tools, not MCP resources or resource templates. Do not use list_mcp_resources or list_mcp_resource_templates to decide whether Hermes LAN tools exist.',
+    'For LAN devices, call mcp__hermes-studio__hermes_lan_devices_scan to refresh discovery and mcp__hermes-studio__hermes_lan_devices_list to list known devices. Include profile and token arguments on each call.',
+  ]
+}
+
 export async function handleCodingAgentRun(
   nsp: ReturnType<Server['of']>,
   socket: Socket,
@@ -93,6 +100,7 @@ export async function handleCodingAgentRun(
     const runPrompt = [
       includeBaseSystemPrompt ? getSystemPrompt() : '',
       ...authPrompt,
+      ...(agentId === 'codex' && authPrompt.length > 0 ? codexHermesMcpToolPrompt() : []),
     ].filter(Boolean).join('\n')
     await sendCodingAgentRunInput(sessionId, inputText, runPrompt)
   } catch (err) {

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -46,10 +46,18 @@ function isBridgeStatusLookupTimeout(error: unknown): boolean {
   return /^Agent bridge request timed out after \d+ms$/.test(message.trim())
 }
 
-function isHermesWorkerBackedSessionSource(source?: string): boolean {
+function isHermesWorkerBackedSession(session?: { source?: string | null; agent?: string | null; agent_session_id?: string | null }): boolean {
+  const source = session?.source || undefined
   // "api_server" is a legacy/default source value; Hermes sessions still use worker-backed runtime.
   // coding_agent runs have a separate lifecycle.
-  return !source || source === 'cli' || source === 'api_server'
+  if (!source || source === 'cli' || source === 'api_server') return true
+  if (source !== 'global_agent') return false
+  const agent = String(session?.agent || '').trim()
+  return agent !== 'claude' && agent !== 'codex' && !session?.agent_session_id
+}
+
+function isBridgeRunSource(source?: string): boolean {
+  return source === 'cli' || source === 'global_agent'
 }
 
 export async function ensureBridgeReadyForChatRun(): Promise<{ ok: true } | { ok: false; error: string }> {
@@ -155,6 +163,7 @@ export class ChatRunSocket {
       queue_id?: string
       workspace?: string | null
       source?: string
+      session_source?: 'global_agent'
       coding_agent_id?: 'claude-code' | 'codex'
       agent_id?: 'claude-code' | 'codex'
       mode?: 'scoped' | 'global'
@@ -183,7 +192,7 @@ export class ChatRunSocket {
         const state = getOrCreateSession(this.sessionMap, data.session_id)
         const source = resolveRunSource(data.source, data.session_id)
         const command = parseSessionCommand(data.input)
-        if (command && source === 'cli') {
+        if (command && isBridgeRunSource(source)) {
           try {
             await handleSessionCommand(data.session_id, command, {
               nsp: this.nsp,
@@ -221,6 +230,7 @@ export class ChatRunSocket {
             profile: runProfile,
             workspace: data.workspace,
             source,
+            sessionSource: data.session_source,
             codingAgentId: data.coding_agent_id,
             agentId: data.agent_id,
             mode: data.mode,
@@ -352,6 +362,7 @@ export class ChatRunSocket {
       instructions?: string
       workspace?: string | null
       source?: string
+      session_source?: 'global_agent'
       queue_id?: string
       peerExcludeSocketId?: string
       coding_agent_id?: 'claude-code' | 'codex'
@@ -368,9 +379,9 @@ export class ChatRunSocket {
     skipUserMessage = false,
   ) {
     const source = resolveRunSource(data.source, data.session_id)
-    if (data.session_id && source === 'cli' && isSessionCommand(data.input)) return
+    if (data.session_id && isBridgeRunSource(source) && isSessionCommand(data.input)) return
 
-    if (source === 'cli') {
+    if (isBridgeRunSource(source)) {
       const bridgeReady = await ensureBridgeReadyForChatRun()
       if (!bridgeReady.ok) {
         let shouldDequeueNext = false
@@ -488,7 +499,7 @@ export class ChatRunSocket {
     if (state.runId && state.isWorking) return
     const session = getSession(sid)
     const source = state.source || session?.source
-    if (!isHermesWorkerBackedSessionSource(source)) return
+    if (!isHermesWorkerBackedSession({ source, agent: session?.agent, agent_session_id: session?.agent_session_id })) return
     const profile = session?.profile || currentProfileFromSocket(socket)
     let pollKey: string | undefined
     try {
@@ -504,7 +515,7 @@ export class ChatRunSocket {
       state.runId = runId
       state.activeRunMarker = undefined
       state.profile = profile
-      state.source = 'cli'
+      state.source = source === 'global_agent' ? 'global_agent' : 'cli'
       state.events = []
       const instructions = this.resumeInstructionsForSession(sid)
       void resumeBridgeRun(
@@ -517,6 +528,7 @@ export class ChatRunSocket {
           instructions,
           model: session?.model,
           provider: session?.provider,
+          source,
         },
         this.sessionMap,
         this.bridge,
@@ -596,6 +608,7 @@ export class ChatRunSocket {
       instructions: next.instructions,
       workspace: next.workspace,
       source: next.source,
+      session_source: next.sessionSource,
       queue_id: next.queue_id,
       peerExcludeSocketId: next.originSocketId,
       coding_agent_id: next.codingAgentId,

--- a/packages/server/src/services/hermes/run-chat/model-run-prompt.ts
+++ b/packages/server/src/services/hermes/run-chat/model-run-prompt.ts
@@ -1,0 +1,13 @@
+import { issueModelRunJwt, type AuthenticatedUser } from '../../../middleware/user-auth'
+
+export async function buildModelRunAuthPrompt(user: AuthenticatedUser | undefined, profile: string): Promise<string[]> {
+  if (!user) return []
+  const token = await issueModelRunJwt(user)
+  return [
+    `[Current Hermes profile: ${profile}]`,
+    `[Current Hermes Web UI model run token: ${token}]`,
+    'When calling Hermes Web UI MCP tools, pass the current Hermes profile as the profile argument and the current Hermes Web UI model run token as the token argument.',
+    'When calling Hermes Web UI HTTP endpoints from tools or skills, use Authorization: Bearer <current model run token> and X-Hermes-Profile: <current Hermes profile>.',
+    'The current Hermes Web UI model run token expires in 1 hour.',
+  ]
+}

--- a/packages/server/src/services/hermes/run-chat/model-run-prompt.ts
+++ b/packages/server/src/services/hermes/run-chat/model-run-prompt.ts
@@ -1,13 +1,34 @@
+import { mkdir, writeFile } from 'fs/promises'
+import { dirname, join } from 'path'
+import { getWebUiHome } from '../../../config'
 import { issueModelRunJwt, type AuthenticatedUser } from '../../../middleware/user-auth'
 
-export async function buildModelRunAuthPrompt(user: AuthenticatedUser | undefined, profile: string): Promise<string[]> {
-  if (!user) return []
+const MODEL_RUN_TOKEN_FILE = '.model-run-token'
+
+function normalizeProfileSegment(profile: string): string {
+  const sanitized = String(profile || '').trim().replace(/[<>:"/\\|?*\x00-\x1f]/g, '_') || 'default'
+  if (sanitized === '.' || sanitized === '..' || sanitized.length > 128) {
+    const err = new Error('Invalid profile')
+    ;(err as any).status = 400
+    throw err
+  }
+  return sanitized
+}
+
+export function modelRunProfileTokenPath(profile: string): string {
+  return join(getWebUiHome(), 'profiles', normalizeProfileSegment(profile), MODEL_RUN_TOKEN_FILE)
+}
+
+export async function writeModelRunProfileToken(user: AuthenticatedUser | undefined, profile: string): Promise<void> {
+  if (!user) return
   const token = await issueModelRunJwt(user)
-  return [
-    `[Current Hermes profile: ${profile}]`,
-    `[Current Hermes Web UI model run token: ${token}]`,
-    'When calling Hermes Web UI MCP tools, pass the current Hermes profile as the profile argument and the current Hermes Web UI model run token as the token argument.',
-    'When calling Hermes Web UI HTTP endpoints from tools or skills, use Authorization: Bearer <current model run token> and X-Hermes-Profile: <current Hermes profile>.',
-    'The current Hermes Web UI model run token expires in 1 hour.',
-  ]
+  const tokenPath = modelRunProfileTokenPath(profile)
+  const mkdirOptions: any = { recursive: true }
+  const writeOptions: any = {}
+  if (process.platform !== 'win32') {
+    mkdirOptions.mode = 0o700
+    writeOptions.mode = 0o600
+  }
+  await mkdir(dirname(tokenPath), mkdirOptions)
+  await writeFile(tokenPath, `${token}\n`, writeOptions)
 }

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -40,6 +40,7 @@ export interface QueuedRun {
   profile: string
   workspace?: string | null
   source?: ChatRunSource
+  sessionSource?: 'global_agent'
   codingAgentId?: 'claude-code' | 'codex'
   agentId?: 'claude-code' | 'codex'
   mode?: 'scoped' | 'global'
@@ -108,7 +109,7 @@ export interface BridgeContextState {
   provider?: string
 }
 
-export type ChatRunSource = 'api_server' | 'cli' | 'coding_agent'
+export type ChatRunSource = 'api_server' | 'cli' | 'coding_agent' | 'global_agent'
 
 export interface BridgeCompressionResult {
   messages: ChatMessage[]

--- a/packages/server/src/services/hermes/studio-mcp-autoinject.ts
+++ b/packages/server/src/services/hermes/studio-mcp-autoinject.ts
@@ -88,11 +88,12 @@ function managedCommandConfig(): Record<string, unknown> {
   return { command: 'hermes-web-ui-mcp' }
 }
 
-function managedConfig(): Record<string, unknown> {
+function managedConfig(profile: string): Record<string, unknown> {
   const env: Record<string, string> = {
     HERMES_WEB_UI_URL: `http://127.0.0.1:${config.port}`,
     HERMES_WEB_UI_HOME: config.appHome,
     HERMES_WEBUI_STATE_DIR: config.appHome,
+    HERMES_WEB_UI_PROFILE: profile,
     [MANAGED_ENV_KEY]: '1',
   }
 
@@ -130,6 +131,7 @@ function sameConfig(existing: Record<string, any>, desired: Record<string, unkno
     existing.env.HERMES_WEB_UI_URL === desiredEnv.HERMES_WEB_UI_URL &&
     existing.env.HERMES_WEB_UI_HOME === desiredEnv.HERMES_WEB_UI_HOME &&
     existing.env.HERMES_WEBUI_STATE_DIR === desiredEnv.HERMES_WEBUI_STATE_DIR &&
+    existing.env.HERMES_WEB_UI_PROFILE === desiredEnv.HERMES_WEB_UI_PROFILE &&
     existing.env.HERMES_WEB_UI_TOKEN === undefined &&
     existing.env[MANAGED_ENV_KEY] === desiredEnv[MANAGED_ENV_KEY]
 }
@@ -183,10 +185,10 @@ async function injectIntoProfile(profile: string, desired: Record<string, unknow
 }
 
 export async function injectBundledMcpServer(): Promise<BundledMcpInjectionResult> {
-  const desired = managedConfig()
+  const commandInfo = managedConfig('default')
   const result: BundledMcpInjectionResult = {
     serverName: SERVER_NAME,
-    command: String(desired.command),
+    command: String(commandInfo.command),
     targets: [],
   }
 
@@ -201,6 +203,7 @@ export async function injectBundledMcpServer(): Promise<BundledMcpInjectionResul
   }
 
   for (const profile of listProfileNamesFromDisk()) {
+    const desired = managedConfig(profile)
     result.targets.push(await injectIntoProfile(profile, desired))
   }
 
@@ -208,7 +211,7 @@ export async function injectBundledMcpServer(): Promise<BundledMcpInjectionResul
   if (changed.length > 0) {
     logger.info({
       serverName: SERVER_NAME,
-      command: desired.command,
+      command: commandInfo.command,
       targets: changed,
     }, '[mcp-autoinject] synced bundled MCP server')
   }

--- a/packages/server/src/services/shutdown.ts
+++ b/packages/server/src/services/shutdown.ts
@@ -3,6 +3,7 @@ import { closeDb } from '../db'
 import { stopPreviewRuntime } from '../controllers/update'
 import { codingAgentRunManager } from './agent-runner/coding-agent-run-manager'
 import { shutdownManagedGateways } from './hermes/gateway-runner'
+import { stopOutboundRelayClient } from './global-agent/outbound-relay-client'
 
 const DEFAULT_SHUTDOWN_FORCE_EXIT_MS = 15_000
 const DEFAULT_DESKTOP_SHUTDOWN_FORCE_EXIT_MS = 15_000
@@ -90,6 +91,9 @@ export function createShutdownHandler(server: any, groupChatServer?: any, chatRu
         chatRunServer.close()
         logger.info('ChatRunSocket closed')
       }
+
+      stopOutboundRelayClient()
+      logger.info('Outbound relay clients closed')
 
       codingAgentRunManager.shutdown()
       logger.info('Coding agent hidden sessions closed')

--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -38,6 +38,11 @@ for (const fileName of readdirSync(bridgeSrcDir)) {
 }
 chmodSync(resolve(bridgeOutDir, 'hermes_bridge.py'), 0o755)
 
+cpSync(
+  resolve(rootDir, 'docs/openapi.json'),
+  resolve(serverOutDir, 'openapi.json'),
+)
+
 const skillsOutDir = resolve(rootDir, 'dist/skills')
 rmSync(skillsOutDir, { recursive: true, force: true })
 cpSync(

--- a/scripts/generate-openapi.mjs
+++ b/scripts/generate-openapi.mjs
@@ -840,7 +840,7 @@ openapi.paths['/api/chat-run/runs'] = {
               },
               session_id: {
                 type: 'string',
-                description: 'Optional session id. For cli/default chat runs, omit this to create a new session automatically. Provide an existing session id to continue that session. Coding-agent runs still require a session id.',
+                description: 'Optional session id. Omit this to create a new session automatically. Provide an existing session id to continue that session.',
               },
               profile: {
                 type: 'string',

--- a/scripts/generate-openapi.mjs
+++ b/scripts/generate-openapi.mjs
@@ -14,14 +14,15 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url))
 const rootDir = resolve(__dirname, '..')
 const routesDir = join(rootDir, 'packages/server/src/routes')
 const controllersDir = join(rootDir, 'packages/server/src/controllers')
+const packageJson = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf-8'))
 
 // OpenAPI template
 const openapi = {
   openapi: '3.0.3',
   info: {
-    title: 'Hermes Web UI API',
-    description: 'BFF server API for Hermes Web UI — chat sessions, scheduled jobs, platform channels, model management, skills, memory, logs, file browser, group chat, and terminal.',
-    version: '0.5.9',
+    title: 'Hermes Studio API',
+    description: 'Hermes Studio API — chat sessions, scheduled jobs, platform channels, model management, skills, memory, logs, file browser, group chat, and terminal.',
+    version: packageJson.version,
   },
   servers: [
     { url: 'http://localhost:8648', description: 'Local development' },
@@ -58,7 +59,7 @@ const tagMappings = {
   'routes/hermes/nous-auth.ts': { name: 'Nous Auth', description: 'Nous Research OAuth' },
   'routes/hermes/copilot-auth.ts': { name: 'Copilot Auth', description: 'GitHub Copilot OAuth' },
   'routes/hermes/group-chat.ts': { name: 'Group Chat', description: 'Group chat management' },
-  'routes/hermes/chat-run.ts': { name: 'Chat', description: 'Chat run and streaming' },
+  'routes/hermes/chat-run.ts': { name: 'Chat Run', description: 'Chat run HTTP and Socket.IO bridge operations' },
   'routes/hermes/config.ts': { name: 'Config', description: 'Configuration management' },
   'routes/hermes/files.ts': { name: 'Files', description: 'Hermes file browser' },
   'routes/hermes/download.ts': { name: 'Download', description: 'File download' },
@@ -69,6 +70,7 @@ const tagMappings = {
   'routes/upload.ts': { name: 'Upload', description: 'File upload' },
   'routes/webhook.ts': { name: 'Webhook', description: 'Incoming webhooks' },
   'routes/auth.ts': { name: 'Auth', description: 'Authentication management' },
+  'routes/api-docs.ts': { name: 'API Docs', description: 'OpenAPI route catalog' },
 }
 
 // Extract route definitions from route files
@@ -340,31 +342,6 @@ openapi.paths['/api/hermes/{*any}'] = {
   },
 }
 
-openapi.paths['/v1/{*any}'] = {
-  'get': {
-    tags: ['Proxy'],
-    summary: 'Proxy to upstream Hermes v1 API',
-    description: 'Forwards /v1/* requests to upstream Hermes gateway. Supports all upstream v1 endpoints.',
-    operationId: 'proxyV1',
-    responses: {
-      '200': { description: 'Proxied response from upstream' },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '502': { description: 'Proxy failure' },
-    },
-  },
-  'post': {
-    tags: ['Proxy'],
-    summary: 'Proxy to upstream Hermes v1 API',
-    description: 'Forwards /v1/* requests to upstream Hermes gateway. Supports all upstream v1 endpoints.',
-    operationId: 'proxyV1Post',
-    responses: {
-      '200': { description: 'Proxied response from upstream' },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '502': { description: 'Proxy failure' },
-    },
-  },
-}
-
 // Add Proxy tag
 if (!openapi.tags.find(t => t.name === 'Proxy')) {
   openapi.tags.push({ name: 'Proxy', description: 'Gateway proxy to upstream Hermes API' })
@@ -461,6 +438,161 @@ Object.keys(openapi.paths).sort().forEach(key => {
 openapi.paths = sortedPaths
 
 // Add special endpoints after sorting
+// Add non-streaming Chat Run HTTP wrapper endpoint
+openapi.paths['/api/chat-run/runs'] = {
+  post: {
+    tags: ['Chat Run'],
+    summary: 'Run chat and wait for completion',
+    description: 'Starts a Hermes Studio chat run through the chat-run transport and waits for a terminal result. Use this from HTTP/MCP callers that cannot consume Socket.IO streams.',
+    operationId: 'runChatOnce',
+    security: [{ BearerAuth: [] }],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['input'],
+            properties: {
+              input: {
+                oneOf: [
+                  { type: 'string' },
+                  {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      additionalProperties: true,
+                    },
+                  },
+                ],
+                description: 'User message text or content blocks.',
+              },
+              session_id: {
+                type: 'string',
+                description: 'Optional session id. Required for CLI/coding-agent style runs and recommended for all chat runs.',
+              },
+              profile: {
+                type: 'string',
+                description: 'Hermes Studio profile name. Defaults to the authenticated request profile or default.',
+              },
+              provider: {
+                type: 'string',
+                description: 'Model provider key to use for this run, for example openai, anthropic, deepseek, or a configured custom provider key.',
+              },
+              model: {
+                type: 'string',
+                description: 'Model id to use for this run, for example gpt-5.1 or deepseek-v4-pro.',
+              },
+              model_groups: {
+                type: 'array',
+                description: 'Optional provider/model fallback groups.',
+                items: {
+                  type: 'object',
+                  required: ['provider', 'models'],
+                  properties: {
+                    provider: { type: 'string' },
+                    models: { type: 'array', items: { type: 'string' } },
+                  },
+                },
+              },
+              source: {
+                type: 'string',
+                enum: ['api_server', 'cli', 'coding_agent', 'global_agent'],
+                description: 'Run backend source. Use cli for Hermes bridge runs, coding_agent for Claude Code/Codex, api_server for direct API-server runs, or global_agent for global-agent sessions.',
+              },
+              session_source: {
+                type: 'string',
+                enum: ['global_agent'],
+                description: 'Marks a coding-agent or bridge session as launched from the global agent.',
+              },
+              instructions: {
+                type: 'string',
+                description: 'Optional extra run instructions appended after the system prompt.',
+              },
+              workspace: {
+                type: 'string',
+                nullable: true,
+                description: 'Optional current working directory for the run.',
+              },
+              reasoning_effort: {
+                type: 'string',
+                description: 'Optional per-run reasoning effort override.',
+              },
+              coding_agent_id: {
+                type: 'string',
+                enum: ['claude-code', 'codex'],
+                description: 'Coding agent id when source is coding_agent.',
+              },
+              agent_id: {
+                type: 'string',
+                enum: ['claude-code', 'codex'],
+                description: 'Alias for coding_agent_id.',
+              },
+              mode: {
+                type: 'string',
+                enum: ['scoped', 'global'],
+                description: 'Coding-agent launch mode.',
+              },
+              baseUrl: {
+                type: 'string',
+                description: 'Optional provider base URL for coding-agent runs.',
+              },
+              apiKey: {
+                type: 'string',
+                description: 'Optional provider API key for coding-agent runs.',
+              },
+              apiMode: {
+                type: 'string',
+                enum: ['chat_completions', 'codex_responses', 'anthropic_messages'],
+                description: 'Optional provider wire API mode for coding-agent runs.',
+              },
+              timeout_ms: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 1800000,
+                default: 300000,
+                description: 'Maximum time to wait for run.completed or run.failed.',
+              },
+              include_events: {
+                type: 'boolean',
+                default: false,
+                description: 'Include recorded run events in the HTTP response.',
+              },
+            },
+            additionalProperties: true,
+          },
+        },
+      },
+    },
+    responses: {
+      '200': {
+        description: 'Run completed',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                ok: { type: 'boolean', example: true },
+                status: { type: 'string', example: 'completed' },
+                session_id: { type: 'string' },
+                run_id: { type: 'string' },
+                output: { type: 'string' },
+                reasoning: { type: 'string' },
+                events: { type: 'array', items: { type: 'object', additionalProperties: true } },
+              },
+            },
+          },
+        },
+      },
+      '400': { $ref: '#/components/responses/BadRequest' },
+      '401': { $ref: '#/components/responses/Unauthorized' },
+      '409': { description: 'Run requires approval or clarification' },
+      '500': { description: 'Run failed' },
+      '504': { description: 'Run timed out' },
+    },
+  },
+}
+
 // Add proxy endpoints that forward to upstream Hermes API
 openapi.paths['/api/hermes/{*any}'] = {
   'get': {
@@ -501,31 +633,6 @@ openapi.paths['/api/hermes/{*any}'] = {
     summary: 'Proxy to upstream Hermes API',
     description: 'Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.',
     operationId: 'proxyHermesDelete',
-    responses: {
-      '200': { description: 'Proxied response from upstream' },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '502': { description: 'Proxy failure' },
-    },
-  },
-}
-
-openapi.paths['/v1/{*any}'] = {
-  'get': {
-    tags: ['Proxy'],
-    summary: 'Proxy to upstream Hermes v1 API',
-    description: 'Forwards /v1/* requests to upstream Hermes gateway. Supports all upstream v1 endpoints.',
-    operationId: 'proxyV1',
-    responses: {
-      '200': { description: 'Proxied response from upstream' },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '502': { description: 'Proxy failure' },
-    },
-  },
-  'post': {
-    tags: ['Proxy'],
-    summary: 'Proxy to upstream Hermes v1 API',
-    description: 'Forwards /v1/* requests to upstream Hermes gateway. Supports all upstream v1 endpoints.',
-    operationId: 'proxyV1Post',
     responses: {
       '200': { description: 'Proxied response from upstream' },
       '401': { $ref: '#/components/responses/Unauthorized' },

--- a/scripts/generate-openapi.mjs
+++ b/scripts/generate-openapi.mjs
@@ -7,7 +7,7 @@
  */
 
 import { readFileSync, writeFileSync, readdirSync } from 'fs'
-import { resolve, join } from 'path'
+import { dirname, resolve, join } from 'path'
 import { fileURLToPath } from 'url'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
@@ -50,26 +50,39 @@ const tagMappings = {
   'routes/hermes/models.ts': { name: 'Models', description: 'Model configuration' },
   'routes/hermes/providers.ts': { name: 'Providers', description: 'Model provider management' },
   'routes/hermes/skills.ts': { name: 'Skills', description: 'Skill browsing and management' },
+  'routes/hermes/plugins.ts': { name: 'Plugins', description: 'Plugin browsing and management' },
   'routes/hermes/memory.ts': { name: 'Memory', description: 'Agent memory files' },
   'routes/hermes/logs.ts': { name: 'Logs', description: 'Log file access' },
   'routes/hermes/jobs.ts': { name: 'Jobs', description: 'Scheduled job management' },
   'routes/hermes/cron-history.ts': { name: 'Jobs', description: 'Cron job history' },
+  'routes/hermes/kanban.ts': { name: 'Kanban', description: 'Kanban board and task management' },
   'routes/hermes/weixin.ts': { name: 'Weixin', description: 'WeChat QR code login' },
   'routes/hermes/codex-auth.ts': { name: 'Codex Auth', description: 'OpenAI Codex OAuth' },
   'routes/hermes/nous-auth.ts': { name: 'Nous Auth', description: 'Nous Research OAuth' },
   'routes/hermes/copilot-auth.ts': { name: 'Copilot Auth', description: 'GitHub Copilot OAuth' },
+  'routes/hermes/xai-auth.ts': { name: 'xAI Auth', description: 'xAI OAuth' },
+  'routes/hermes/anthropic-auth.ts': { name: 'Anthropic Auth', description: 'Anthropic OAuth' },
+  'routes/hermes/gemini-auth.ts': { name: 'Gemini Auth', description: 'Google Gemini OAuth' },
   'routes/hermes/group-chat.ts': { name: 'Group Chat', description: 'Group chat management' },
   'routes/hermes/chat-run.ts': { name: 'Chat Run', description: 'Chat run HTTP and Socket.IO bridge operations' },
   'routes/hermes/config.ts': { name: 'Config', description: 'Configuration management' },
   'routes/hermes/files.ts': { name: 'Files', description: 'Hermes file browser' },
   'routes/hermes/download.ts': { name: 'Download', description: 'File download' },
+  'routes/hermes/tts.ts': { name: 'TTS', description: 'Text-to-speech generation and settings' },
+  'routes/hermes/stt.ts': { name: 'STT', description: 'Speech-to-text transcription and settings' },
+  'routes/hermes/media.ts': { name: 'Media', description: 'Media generation endpoints' },
+  'routes/hermes/mcp.ts': { name: 'MCP', description: 'MCP server and tool management' },
+  'routes/hermes/runtime-versions.ts': { name: 'Runtime Versions', description: 'Runtime and Web UI version management' },
+  'routes/hermes/write-gate.ts': { name: 'Write Gate', description: 'Hermes Agent write approval review' },
+  'routes/hermes/performance-monitor.ts': { name: 'Performance', description: 'Runtime performance monitoring' },
   'routes/hermes/terminal.ts': { name: 'Terminal', description: 'WebSocket terminal' },
-  'routes/hermes/proxy.ts': { name: 'Proxy', description: 'Gateway proxy' },
   'routes/health.ts': { name: 'Health', description: 'Health check' },
   'routes/update.ts': { name: 'Update', description: 'Self-update management' },
   'routes/upload.ts': { name: 'Upload', description: 'File upload' },
   'routes/webhook.ts': { name: 'Webhook', description: 'Incoming webhooks' },
   'routes/auth.ts': { name: 'Auth', description: 'Authentication management' },
+  'routes/devices.ts': { name: 'Devices', description: 'Device pairing and LAN peer operations' },
+  'routes/coding-agents.ts': { name: 'Coding Agents', description: 'Coding agent installation, config, and runs' },
   'routes/api-docs.ts': { name: 'API Docs', description: 'OpenAPI route catalog' },
 }
 
@@ -106,30 +119,105 @@ function scanRoutes() {
 
 function scanRouteFile(filePath, tagInfo, paths) {
   const content = readFileSync(filePath, 'utf-8')
+  const controllerContent = readControllerContent(filePath, content)
 
-  // Pattern 1: controller functions - sessionRoutes.get('/path', ctrl.method)
-  const ctrlRouteRegex = /\w+Routes?\.(get|post|put|delete|patch)\(['"]([^'"]+)['"],\s*ctrl\.(\w+)/g
+  // Pattern 1: controller functions - sessionRoutes.get('/path', middleware, ctrl.method)
+  const ctrlRouteRegex = /\w+Routes?\.(get|post|put|delete|patch)\(\s*['"]([^'"]+)['"]\s*,[^\n]*?\bctrl\.(\w+)/g
 
   let match
   while ((match = ctrlRouteRegex.exec(content)) !== null) {
     const [, method, path, controllerMethod] = match
-    addEndpoint(paths, method, path, controllerMethod, tagInfo, content, match.index)
+    const controllerSource = controllerContent
+      ? extractFunctionSource(controllerContent, controllerMethod)
+      : ''
+    addEndpoint(paths, method, path, controllerMethod, tagInfo, content, match.index, controllerSource)
   }
 
   // Pattern 2: inline functions - groupChatRoutes.post('/path', async (ctx) => {...})
-  const inlineRouteRegex = /\w+Routes?\.(get|post|put|delete|patch)\(['"]([^'"]+)['"],\s*async\s*\(ctx\)/g
+  const inlineRouteRegex = /\w+Routes?\.(get|post|put|delete|patch)\(\s*['"]([^'"]+)['"]\s*,[^\n]*?async\s*\(ctx\)/g
 
   while ((match = inlineRouteRegex.exec(content)) !== null) {
     const [, method, path] = match
     const controllerMethod = generateOperationIdFromPath(path, method)
-    addEndpoint(paths, method, path, controllerMethod, tagInfo, content, match.index)
+    addEndpoint(paths, method, path, controllerMethod, tagInfo, content, match.index, extractInlineHandlerSource(content, match.index))
   }
 }
 
-function addEndpoint(paths, method, path, controllerMethod, tagInfo, content, matchIndex) {
+function readControllerContent(routeFilePath, routeContent) {
+  const importMatch = routeContent.match(/import\s+\*\s+as\s+ctrl\s+from\s+['"]([^'"]+)['"]/)
+  if (!importMatch) return ''
+
+  const controllerPath = resolve(dirname(routeFilePath), `${importMatch[1]}.ts`)
+  try {
+    return readFileSync(controllerPath, 'utf-8')
+  } catch {
+    return ''
+  }
+}
+
+function extractFunctionSource(content, functionName) {
+  const functionRegex = new RegExp(`export\\s+(?:async\\s+)?function\\s+${functionName}\\b`)
+  const match = functionRegex.exec(content)
+  if (!match) return ''
+
+  const openBrace = content.indexOf('{', match.index)
+  if (openBrace < 0) return ''
+  const closeBrace = findMatchingBrace(content, openBrace)
+  if (closeBrace < 0) return ''
+  return content.slice(match.index, closeBrace + 1)
+}
+
+function extractInlineHandlerSource(content, routeIndex) {
+  const asyncIndex = content.indexOf('async', routeIndex)
+  if (asyncIndex < 0) return ''
+  const openBrace = content.indexOf('{', asyncIndex)
+  if (openBrace < 0) return ''
+  const closeBrace = findMatchingBrace(content, openBrace)
+  if (closeBrace < 0) return ''
+  return content.slice(asyncIndex, closeBrace + 1)
+}
+
+function findMatchingBrace(content, openBrace) {
+  let depth = 0
+  let quote = null
+  let escaped = false
+
+  for (let i = openBrace; i < content.length; i += 1) {
+    const ch = content[i]
+    const prev = content[i - 1]
+
+    if (quote) {
+      if (escaped) {
+        escaped = false
+      } else if (ch === '\\') {
+        escaped = true
+      } else if (ch === quote && (quote !== '`' || prev !== '\\')) {
+        quote = null
+      }
+      continue
+    }
+
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch
+      continue
+    }
+    if (ch === '{') depth += 1
+    if (ch === '}') {
+      depth -= 1
+      if (depth === 0) return i
+    }
+  }
+
+  return -1
+}
+
+function addEndpoint(paths, method, path, controllerMethod, tagInfo, content, matchIndex, controllerSource = '') {
+  if (isInternalProxyRoute(path)) return
+
   // Clean path parameters
   const openapiPath = path
     .replace(/:([^/]+)/g, '{$1}')
+    .replace(/\{\*([^}]+)\}/g, '{$1}')
     .replace(/\*\*([^/]*)/g, '{$1}')
 
   if (!paths[openapiPath]) {
@@ -143,7 +231,7 @@ function addEndpoint(paths, method, path, controllerMethod, tagInfo, content, ma
   const precedingContent = content.substring(Math.max(0, matchIndex - 500), matchIndex)
   const description = extractJsDocDescription(precedingContent) || `${method.toUpperCase()} ${path}`
 
-  paths[openapiPath][method] = {
+  const operation = {
     tags: [tagInfo.name],
     summary: generateSummary(path, method, controllerMethod),
     description,
@@ -151,6 +239,386 @@ function addEndpoint(paths, method, path, controllerMethod, tagInfo, content, ma
     security: [{ BearerAuth: [] }],
     responses: generateResponses(path, method),
   }
+
+  const parameters = generateParameters(openapiPath, controllerSource)
+  if (parameters.length) operation.parameters = parameters
+
+  const requestBody = generateRequestBody(method, controllerSource)
+  if (requestBody) operation.requestBody = requestBody
+
+  paths[openapiPath][method] = operation
+}
+
+function isInternalProxyRoute(path) {
+  return path.startsWith('/api/codex-proxy/') || path.startsWith('/api/claude-code-proxy/')
+}
+
+function generateParameters(openapiPath, source) {
+  const params = []
+  const seen = new Set()
+
+  for (const name of extractPathParamNames(openapiPath)) {
+    seen.add(`path:${name}`)
+    params.push({
+      name,
+      in: 'path',
+      required: true,
+      schema: { type: inferParamType(name, source) },
+    })
+  }
+
+  for (const name of extractQueryParamNames(source)) {
+    const key = `query:${name}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    params.push({
+      name,
+      in: 'query',
+      required: isRequiredQueryParam(name, source),
+      schema: queryParamSchema(name, source),
+    })
+  }
+
+  return params
+}
+
+function extractPathParamNames(openapiPath) {
+  return Array.from(openapiPath.matchAll(/\{([^}]+)\}/g))
+    .map(match => match[1])
+    .filter(name => name && !name.startsWith('*'))
+}
+
+function extractQueryParamNames(source) {
+  const names = new Set()
+  if (!source) return []
+
+  collectMatches(source, /ctx\.query\??\.(\w+)/g, names)
+  collectMatches(source, /ctx\.query\[['"]([^'"]+)['"]\]/g, names)
+
+  for (const match of source.matchAll(/const\s+\{([^}]+)\}\s*=\s*ctx\.query/g)) {
+    for (const name of parseDestructuredNames(match[1])) names.add(name)
+  }
+
+  for (const match of source.matchAll(/ctx\.query\s+as\s*\{([\s\S]*?)\}/g)) {
+    for (const field of parseTypeLiteralFields(match[1])) names.add(field.name)
+  }
+
+  if (/\brequestBoard\(ctx\)/.test(source)) names.add('board')
+
+  return Array.from(names).filter(Boolean).sort()
+}
+
+function collectMatches(source, regex, names) {
+  for (const match of source.matchAll(regex)) names.add(match[1])
+}
+
+function parseDestructuredNames(text) {
+  return parseDestructuredEntries(text).map(entry => entry.name)
+}
+
+function parseDestructuredEntries(text) {
+  return text
+    .split(',')
+    .map(part => {
+      const [rawName, rawLocal] = part.trim().split(':')
+      const name = rawName?.trim()
+      const local = (rawLocal || rawName)?.trim().replace(/\s*=.*$/, '')
+      return { name, local }
+    })
+    .filter(entry => /^[A-Za-z_$][\w$]*$/.test(entry.name) && /^[A-Za-z_$][\w$]*$/.test(entry.local))
+}
+
+function queryParamSchema(name, source) {
+  const type = inferParamType(name, source)
+  const schema = { type }
+
+  const enumValues = inferEnumValues(name, source)
+  if (enumValues.length) schema.enum = enumValues
+
+  return schema
+}
+
+function inferParamType(name, source) {
+  const escaped = escapeRegExp(name)
+  if (new RegExp(`parseInt\\([^)]*\\b${escaped}\\b`).test(source) || new RegExp(`Number\\([^)]*\\b${escaped}\\b`).test(source)) {
+    return 'integer'
+  }
+  if (new RegExp(`\\b${escaped}\\b[^\\n]*(?:===|!==)\\s*['"](?:true|false|0|1)['"]`).test(source)) {
+    return 'boolean'
+  }
+  if (new RegExp(`boolQuery\\([^)]*\\b${escaped}\\b`).test(source)) {
+    return 'boolean'
+  }
+  return 'string'
+}
+
+function isRequiredQueryParam(name, source) {
+  return extractRequiredNamesFromMessages(source).has(name)
+}
+
+function inferEnumValues(name, source) {
+  const escaped = escapeRegExp(name)
+  const values = new Set()
+  const comparisonRegex = new RegExp(`\\b${escaped}\\b\\s*(?:===|!==)\\s*['"]([^'"]+)['"]`, 'g')
+  collectMatches(source, comparisonRegex, values)
+  const allowedRegex = new RegExp(`${escaped}\\s+must be\\s+([^'"\`\\n]+)`, 'i')
+  const allowedMatch = source.match(allowedRegex)
+  if (allowedMatch) {
+    allowedMatch[1]
+      .split(/,|\bor\b/)
+      .map(value => value.trim())
+      .filter(value => /^[A-Za-z0-9_.-]+$/.test(value))
+      .forEach(value => values.add(value))
+  }
+  return Array.from(values)
+}
+
+function generateRequestBody(method, source) {
+  if (!['post', 'put', 'patch'].includes(method)) return null
+  if (!source || !/(ctx\.request\??\.body|requestBody\(ctx\))/.test(source)) return null
+
+  const fields = extractBodyFields(source)
+  const schema = {
+    type: 'object',
+    properties: {},
+  }
+
+  for (const field of fields) {
+    schema.properties[field.name] = field.schema
+  }
+
+  const required = fields.filter(field => field.required).map(field => field.name)
+  if (required.length) schema.required = required
+  if (!fields.length) schema.additionalProperties = true
+
+  return {
+    required: true,
+    content: {
+      'application/json': {
+        schema,
+      },
+    },
+  }
+}
+
+function extractBodyFields(source) {
+  const fields = new Map()
+  const requiredNames = inferRequiredBodyNames(source)
+
+  for (const typeLiteral of extractRequestBodyTypeLiterals(source)) {
+    for (const field of parseTypeLiteralFields(typeLiteral)) {
+      addBodyField(fields, {
+        name: field.name,
+        schema: schemaFromType(field.type),
+        required: requiredNames.has(field.name) || !field.optional,
+      })
+    }
+  }
+
+  for (const name of extractDestructuredBodyNames(source)) {
+    addBodyField(fields, {
+      name,
+      schema: schemaFromName(name, source),
+      required: requiredNames.has(name),
+    })
+  }
+
+  for (const name of extractBodyPropertyNames(source)) {
+    addBodyField(fields, {
+      name,
+      schema: schemaFromName(name, source),
+      required: requiredNames.has(name),
+    })
+  }
+
+  return Array.from(fields.values()).sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function addBodyField(fields, next) {
+  if (!next.name || !/^[A-Za-z_$][\w$]*$/.test(next.name)) return
+  const existing = fields.get(next.name)
+  if (!existing) {
+    fields.set(next.name, next)
+    return
+  }
+  existing.required = existing.required || next.required
+  existing.schema = mergeSchema(existing.schema, next.schema)
+}
+
+function mergeSchema(current, next) {
+  if (current.type === 'object' && Object.keys(current).length === 1) return next
+  if (next.type === 'object' && Object.keys(next).length === 1) return current
+  return current
+}
+
+function extractRequestBodyTypeLiterals(source) {
+  const literals = []
+  const markers = ['ctx.request.body as {', '(ctx.request.body || {}) as {', '(ctx.request?.body || {}) as {']
+
+  for (const marker of markers) {
+    let index = source.indexOf(marker)
+    while (index >= 0) {
+      const openBrace = source.indexOf('{', index)
+      const closeBrace = findMatchingBrace(source, openBrace)
+      if (openBrace >= 0 && closeBrace > openBrace) {
+        literals.push(source.slice(openBrace + 1, closeBrace))
+      }
+      index = source.indexOf(marker, index + marker.length)
+    }
+  }
+
+  return literals
+}
+
+function parseTypeLiteralFields(typeLiteral) {
+  const fields = []
+  for (const entry of splitTopLevel(typeLiteral)) {
+    const match = entry.trim().match(/^([A-Za-z_$][\w$]*)(\?)?\s*:\s*([\s\S]+)$/)
+    if (!match) continue
+    fields.push({
+      name: match[1],
+      optional: Boolean(match[2]),
+      type: match[3].trim().replace(/[,;]$/, ''),
+    })
+  }
+  return fields
+}
+
+function splitTopLevel(text) {
+  const parts = []
+  let start = 0
+  let angleDepth = 0
+  let braceDepth = 0
+  let bracketDepth = 0
+  let parenDepth = 0
+  let quote = null
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i]
+    if (quote) {
+      if (ch === quote && text[i - 1] !== '\\') quote = null
+      continue
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch
+      continue
+    }
+    if (ch === '<') angleDepth += 1
+    if (ch === '>') angleDepth = Math.max(0, angleDepth - 1)
+    if (ch === '{') braceDepth += 1
+    if (ch === '}') braceDepth = Math.max(0, braceDepth - 1)
+    if (ch === '[') bracketDepth += 1
+    if (ch === ']') bracketDepth = Math.max(0, bracketDepth - 1)
+    if (ch === '(') parenDepth += 1
+    if (ch === ')') parenDepth = Math.max(0, parenDepth - 1)
+
+    if ((ch === '\n' || ch === ';' || ch === ',') && angleDepth === 0 && braceDepth === 0 && bracketDepth === 0 && parenDepth === 0) {
+      parts.push(text.slice(start, i))
+      start = i + 1
+    }
+  }
+  parts.push(text.slice(start))
+  return parts.filter(part => part.trim())
+}
+
+function extractDestructuredBodyNames(source) {
+  return extractDestructuredBodyEntries(source).map(entry => entry.name)
+}
+
+function extractDestructuredBodyEntries(source) {
+  const entries = []
+  for (const match of source.matchAll(/const\s+\{([^}]+)\}\s*=\s*(?:\([^)]*\)\s*)?ctx\.request\??\.body/g)) {
+    entries.push(...parseDestructuredEntries(match[1]))
+  }
+  const byName = new Map()
+  for (const entry of entries) byName.set(entry.name, entry)
+  return Array.from(byName.values())
+}
+
+function extractBodyPropertyNames(source) {
+  const names = new Set()
+  const bodyVariableNames = extractBodyVariableNames(source)
+  bodyVariableNames.push('bodyResult.body')
+
+  for (const variableName of bodyVariableNames) {
+    const escaped = escapeRegExp(variableName)
+    collectMatches(source, new RegExp(`\\b${escaped}\\.([A-Za-z_$][\\w$]*)`, 'g'), names)
+  }
+
+  collectMatches(source, /ctx\.request\??\.body\??\.([A-Za-z_$][\w$]*)/g, names)
+  collectMatches(source, /\(ctx\.request\.body as any\)\??\.([A-Za-z_$][\w$]*)/g, names)
+  return Array.from(names)
+}
+
+function extractBodyVariableNames(source) {
+  const names = []
+  for (const match of source.matchAll(/const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:\([^)]*\)\s*)?ctx\.request\??\.body/g)) {
+    names.push(match[1])
+  }
+  for (const match of source.matchAll(/const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:bodyResult\.body|requestBody\(ctx\)\.body)/g)) {
+    names.push(match[1])
+  }
+  return Array.from(new Set(names))
+}
+
+function inferRequiredBodyNames(source) {
+  const names = extractRequiredNamesFromMessages(source)
+  collectMatches(source, /required\w*\([^,]+,\s*['"]([^'"]+)['"]/g, names)
+  for (const entry of extractDestructuredBodyEntries(source)) {
+    const escaped = escapeRegExp(entry.local)
+    if (new RegExp(`if\\s*\\([^)]*!\\s*${escaped}\\b`).test(source)
+      || new RegExp(`\\|\\|\\s*!\\s*${escaped}\\b`).test(source)
+      || new RegExp(`&&\\s*!\\s*${escaped}\\b`).test(source)) {
+      names.add(entry.name)
+    }
+  }
+  return names
+}
+
+function extractRequiredNamesFromMessages(source) {
+  const names = new Set()
+  for (const match of source.matchAll(/['"`]([^'"`]*\brequired\b[^'"`]*)['"`]/gi)) {
+    const message = match[1]
+    const beforeRequired = message.split(/\brequired\b/i)[0] || ''
+    beforeRequired
+      .replace(/\bis\b|\bare\b|\bmust\b|\bbe\b/gi, ' ')
+      .split(/,|\band\b|\/|\s+/)
+      .map(part => part.trim())
+      .filter(part => /^[A-Za-z_$][\w$]*$/.test(part))
+      .forEach(part => {
+        names.add(part)
+        names.add(part.charAt(0).toLowerCase() + part.slice(1))
+      })
+  }
+  return names
+}
+
+function schemaFromName(name, source) {
+  const escaped = escapeRegExp(name)
+  if (new RegExp(`optionalBoolean\\([^,]+,\\s*['"]${escaped}['"]`).test(source)) return { type: 'boolean' }
+  if (new RegExp(`optional(?:Positive)?Integer\\([^,]+,\\s*['"]${escaped}['"]`).test(source)) return { type: 'integer' }
+  if (new RegExp(`(?:optional|required)\\w*StringArray\\([^,]+,\\s*['"]${escaped}['"]`).test(source)) return { type: 'array', items: { type: 'string' } }
+  if (new RegExp(`(?:StringArray|task_ids|ids)`, 'i').test(name)) return { type: 'array', items: { type: 'string' } }
+  return { type: 'string' }
+}
+
+function schemaFromType(type) {
+  const normalized = type.replace(/\s+/g, ' ')
+  const schema = {}
+
+  if (/\bnull\b/.test(normalized)) schema.nullable = true
+  if (/string\[\]|Array<string>/.test(normalized)) {
+    return { ...schema, type: 'array', items: { type: 'string' } }
+  }
+  if (/number/.test(normalized)) return { ...schema, type: 'number' }
+  if (/boolean/.test(normalized)) return { ...schema, type: 'boolean' }
+  if (/Record<|unknown|any|object|\{/.test(normalized)) return { ...schema, type: 'object', additionalProperties: true }
+  if (/string/.test(normalized)) return { ...schema, type: 'string' }
+  return { ...schema, type: 'object' }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 function generateOperationIdFromPath(path, method) {
@@ -294,59 +762,6 @@ openapi.components.responses = {
   },
 }
 
-// Add proxy endpoints that forward to upstream Hermes API
-openapi.paths['/api/hermes/{*any}'] = {
-  'get': {
-    tags: ['Proxy'],
-    summary: 'Proxy to upstream Hermes API',
-    description: 'Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.',
-    operationId: 'proxyHermes',
-    responses: {
-      '200': { description: 'Proxied response from upstream' },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '502': { description: 'Proxy failure' },
-    },
-  },
-  'post': {
-    tags: ['Proxy'],
-    summary: 'Proxy to upstream Hermes API',
-    description: 'Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.',
-    operationId: 'proxyHermesPost',
-    responses: {
-      '200': { description: 'Proxied response from upstream' },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '502': { description: 'Proxy failure' },
-    },
-  },
-  'put': {
-    tags: ['Proxy'],
-    summary: 'Proxy to upstream Hermes API',
-    description: 'Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.',
-    operationId: 'proxyHermesPut',
-    responses: {
-      '200': { description: 'Proxied response from upstream' },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '502': { description: 'Proxy failure' },
-    },
-  },
-  'delete': {
-    tags: ['Proxy'],
-    summary: 'Proxy to upstream Hermes API',
-    description: 'Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.',
-    operationId: 'proxyHermesDelete',
-    responses: {
-      '200': { description: 'Proxied response from upstream' },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '502': { description: 'Proxy failure' },
-    },
-  },
-}
-
-// Add Proxy tag
-if (!openapi.tags.find(t => t.name === 'Proxy')) {
-  openapi.tags.push({ name: 'Proxy', description: 'Gateway proxy to upstream Hermes API' })
-}
-
 // Add WebSocket terminal endpoint
 openapi.paths['/api/hermes/terminal'] = {
   'get': {
@@ -357,50 +772,6 @@ openapi.paths['/api/hermes/terminal'] = {
     responses: {
       '101': { description: 'Switching Protocols - WebSocket connection established' },
       '401': { $ref: '#/components/responses/Unauthorized' },
-    },
-  },
-}
-
-// Add Chat streaming endpoint
-openapi.paths['/api/hermes/v1/runs/{runId}/events'] = {
-  'get': {
-    tags: ['Chat'],
-    summary: 'Server-Sent Events for chat streaming',
-    description: 'Stream chat events using Server-Sent Events (SSE). Authentication via `?token=` query parameter.',
-    operationId: 'chatStreamEvents',
-    parameters: [
-      {
-        name: 'runId',
-        in: 'path',
-        required: true,
-        description: 'Chat run ID',
-        schema: { type: 'string' },
-      },
-      {
-        name: 'token',
-        in: 'query',
-        required: true,
-        description: 'Authentication token',
-        schema: { type: 'string' },
-      },
-    ],
-    responses: {
-      '200': {
-        description: 'SSE stream established',
-        content: {
-          'text/event-stream': {
-            schema: {
-              type: 'object',
-              properties: {
-                event: { type: 'string', enum: ['run.created', 'run.queued', 'run.started', 'run.streaming', 'run.completed', 'run.failed'] },
-                data: { type: 'object' },
-              },
-            },
-          },
-        },
-      },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '404': { description: 'Run not found' },
     },
   },
 }
@@ -469,7 +840,7 @@ openapi.paths['/api/chat-run/runs'] = {
               },
               session_id: {
                 type: 'string',
-                description: 'Optional session id. Required for CLI/coding-agent style runs and recommended for all chat runs.',
+                description: 'Optional session id. For cli/default chat runs, omit this to create a new session automatically. Provide an existing session id to continue that session. Coding-agent runs still require a session id.',
               },
               profile: {
                 type: 'string',
@@ -497,8 +868,8 @@ openapi.paths['/api/chat-run/runs'] = {
               },
               source: {
                 type: 'string',
-                enum: ['api_server', 'cli', 'coding_agent', 'global_agent'],
-                description: 'Run backend source. Use cli for Hermes bridge runs, coding_agent for Claude Code/Codex, api_server for direct API-server runs, or global_agent for global-agent sessions.',
+                enum: ['cli', 'coding_agent', 'global_agent'],
+                description: 'Run backend source. Use cli for Hermes bridge runs, coding_agent for Claude Code/Codex, or global_agent for global-agent sessions. Omit source for normal Hermes chat runs; do not use the legacy api_server source.',
               },
               session_source: {
                 type: 'string',
@@ -593,54 +964,6 @@ openapi.paths['/api/chat-run/runs'] = {
   },
 }
 
-// Add proxy endpoints that forward to upstream Hermes API
-openapi.paths['/api/hermes/{*any}'] = {
-  'get': {
-    tags: ['Proxy'],
-    summary: 'Proxy to upstream Hermes API',
-    description: 'Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.',
-    operationId: 'proxyHermes',
-    responses: {
-      '200': { description: 'Proxied response from upstream' },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '502': { description: 'Proxy failure' },
-    },
-  },
-  'post': {
-    tags: ['Proxy'],
-    summary: 'Proxy to upstream Hermes API',
-    description: 'Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.',
-    operationId: 'proxyHermesPost',
-    responses: {
-      '200': { description: 'Proxied response from upstream' },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '502': { description: 'Proxy failure' },
-    },
-  },
-  'put': {
-    tags: ['Proxy'],
-    summary: 'Proxy to upstream Hermes API',
-    description: 'Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.',
-    operationId: 'proxyHermesPut',
-    responses: {
-      '200': { description: 'Proxied response from upstream' },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '502': { description: 'Proxy failure' },
-    },
-  },
-  'delete': {
-    tags: ['Proxy'],
-    summary: 'Proxy to upstream Hermes API',
-    description: 'Forwards unmatched /api/hermes/* requests to upstream Hermes gateway. Supports all upstream endpoints.',
-    operationId: 'proxyHermesDelete',
-    responses: {
-      '200': { description: 'Proxied response from upstream' },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '502': { description: 'Proxy failure' },
-    },
-  },
-}
-
 // Add WebSocket terminal endpoint
 openapi.paths['/api/hermes/terminal'] = {
   'get': {
@@ -655,54 +978,7 @@ openapi.paths['/api/hermes/terminal'] = {
   },
 }
 
-// Add Chat streaming endpoint
-openapi.paths['/api/hermes/v1/runs/{runId}/events'] = {
-  'get': {
-    tags: ['Chat'],
-    summary: 'Server-Sent Events for chat streaming',
-    description: 'Stream chat events using Server-Sent Events (SSE). Authentication via `?token=` query parameter.',
-    operationId: 'chatStreamEvents',
-    parameters: [
-      {
-        name: 'runId',
-        in: 'path',
-        required: true,
-        description: 'Chat run ID',
-        schema: { type: 'string' },
-      },
-      {
-        name: 'token',
-        in: 'query',
-        required: true,
-        description: 'Authentication token',
-        schema: { type: 'string' },
-      },
-    ],
-    responses: {
-      '200': {
-        description: 'SSE stream established',
-        content: {
-          'text/event-stream': {
-            schema: {
-              type: 'object',
-              properties: {
-                event: { type: 'string', enum: ['run.created', 'run.queued', 'run.started', 'run.streaming', 'run.completed', 'run.failed'] },
-                data: { type: 'object' },
-              },
-            },
-          },
-        },
-      },
-      '401': { $ref: '#/components/responses/Unauthorized' },
-      '404': { description: 'Run not found' },
-    },
-  },
-}
-
-// Add Proxy and Terminal tags
-if (!openapi.tags.find(t => t.name === 'Proxy')) {
-  openapi.tags.push({ name: 'Proxy', description: 'Gateway proxy to upstream Hermes API' })
-}
+// Add Terminal tag
 if (!openapi.tags.find(t => t.name === 'Terminal')) {
   openapi.tags.push({ name: 'Terminal', description: 'WebSocket terminal access' })
 }

--- a/tests/client/chat-message-mobile-layout.test.ts
+++ b/tests/client/chat-message-mobile-layout.test.ts
@@ -21,6 +21,10 @@ describe('chat message mobile layout guards', () => {
     expect(messageList).toContain('.streaming-indicator')
     expect(messageList).toContain('.tool-calls-panel')
     expect(messageList).toContain('.tool-call-preview')
+    expect(messageList).toContain('function toolPreviewText')
+    expect(messageList).toContain(':title="tc.toolPreview"')
+    expect(messageList).toContain('max-width: 34%;')
+    expect(messageList).toContain('flex: 1 1 0;')
     expect(messageList).toContain('width: 100%;')
     expect(messageList).toContain('max-width: none;')
 

--- a/tests/client/session-search.test.ts
+++ b/tests/client/session-search.test.ts
@@ -181,7 +181,7 @@ describe('session search modal', () => {
 
     expect(chatStoreMock.loadSessions).toHaveBeenCalled()
     expect(chatStoreMock.switchSession).toHaveBeenCalledWith('match-1', '17')
-    expect(apiMocks.routerPushMock).toHaveBeenCalledWith({ name: 'hermes.chat' })
+    expect(apiMocks.routerPushMock).toHaveBeenCalledWith({ name: 'hermes.session', params: { sessionId: 'match-1' } })
   })
 })
 

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -144,10 +144,10 @@ test.describe('group chat room deep links', () => {
     await expect(second.getByText('Alpha room message')).toHaveCount(0)
   })
 
-  test('unknown route room id falls back to base group chat route', async ({ page }) => {
+  test('unknown route room id falls back to the first available room', async ({ page }) => {
     await setup(page, '/#/hermes/group-chat/room/missing-room')
 
-    await expect(page).toHaveURL(/#\/hermes\/group-chat$/)
-    await expect(page.getByText('Alpha Room')).toBeVisible()
+    await expect(page).toHaveURL(/#\/hermes\/group-chat\/room\/room-alpha$/)
+    await expect(page.locator('.room-title-text', { hasText: 'Alpha Room' })).toBeVisible()
   })
 })

--- a/tests/server/agent-runner-adapters.test.ts
+++ b/tests/server/agent-runner-adapters.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../../packages/server/src/services/agent-runner/adapters/responses-stream'
 
 const target = { model: 'test-model' }
+const codexTarget = { model: 'test-model', annotateMcpToolNamespaces: true }
 const anthropicTarget = { provider: 'deepseek', model: 'deepseek-reasoner', baseUrl: 'https://api.deepseek.com/v1' }
 
 describe('agent runner Responses adapters', () => {
@@ -147,6 +148,59 @@ describe('agent runner Responses adapters', () => {
     })
   })
 
+  it('expands Hermes MCP namespace tools for Chat and Anthropic providers', () => {
+    const body = {
+      input: [{ role: 'user', content: [{ type: 'input_text', text: 'list devices' }] }],
+      tools: [{ type: 'namespace', name: 'mcp__hermes_studio', description: 'Hermes tools' }],
+    }
+
+    expect(responsesToOpenAiChat(body, target).tools).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'function',
+        function: expect.objectContaining({
+          name: 'hermes_lan_devices_scan',
+          parameters: expect.objectContaining({
+            properties: expect.objectContaining({
+              profile: expect.any(Object),
+              token: expect.any(Object),
+            }),
+          }),
+        }),
+      }),
+    ]))
+
+    expect(responsesToAnthropicMessages(body, target).tools).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'hermes_lan_devices_scan',
+        input_schema: expect.objectContaining({
+          properties: expect.objectContaining({
+            profile: expect.any(Object),
+            token: expect.any(Object),
+          }),
+        }),
+      }),
+    ]))
+  })
+
+  it('keeps unknown MCP namespaces callable through a generic function fallback', () => {
+    const body = {
+      input: [{ role: 'user', content: [{ type: 'input_text', text: 'call custom mcp' }] }],
+      tools: [{ type: 'namespace', name: 'mcp__custom_server', description: 'Custom server tools' }],
+    }
+
+    expect(responsesToOpenAiChat(body, target).tools).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'function',
+        function: expect.objectContaining({
+          name: 'mcp__custom_server',
+          parameters: expect.objectContaining({
+            required: ['tool', 'arguments'],
+          }),
+        }),
+      }),
+    ]))
+  })
+
   it('converts OpenAI Chat responses to Responses output', () => {
     expect(openAiChatToResponses({
       id: 'chatcmpl_1',
@@ -176,6 +230,54 @@ describe('agent runner Responses adapters', () => {
     })
   })
 
+  it('marks expanded Hermes MCP Chat tool calls with their Responses namespace', () => {
+    expect(openAiChatToResponses({
+      id: 'chatcmpl_1',
+      created: 123,
+      choices: [{
+        message: {
+          tool_calls: [{
+            id: 'call_1',
+            function: { name: 'hermes_lan_devices_scan', arguments: '{"profile":"default"}' },
+          }],
+        },
+      }],
+    }, target)).toMatchObject({
+      output: [{
+        type: 'function_call',
+        call_id: 'call_1',
+        name: 'hermes_lan_devices_scan',
+        namespace: 'mcp__hermes_studio',
+      }],
+    })
+  })
+
+  it('normalizes generic MCP namespace function calls back to Responses MCP calls', () => {
+    expect(openAiChatToResponses({
+      id: 'chatcmpl_1',
+      created: 123,
+      choices: [{
+        message: {
+          tool_calls: [{
+            id: 'call_1',
+            function: {
+              name: 'mcp__custom_server',
+              arguments: '{"tool":"custom_lookup","arguments":{"id":1}}',
+            },
+          }],
+        },
+      }],
+    }, target)).toMatchObject({
+      output: [{
+        type: 'function_call',
+        call_id: 'call_1',
+        name: 'custom_lookup',
+        arguments: '{"id":1}',
+        namespace: 'mcp__custom_server',
+      }],
+    })
+  })
+
   it('converts Anthropic messages to Responses output', () => {
     expect(anthropicMessageToResponses({
 	      id: 'msg_1',
@@ -195,6 +297,23 @@ describe('agent runner Responses adapters', () => {
 	        { type: 'function_call', call_id: 'toolu_1', name: 'lookup', arguments: '{"id":1}' },
       ],
       usage: { input_tokens: 4, output_tokens: 5, total_tokens: 9 },
+    })
+  })
+
+  it('marks expanded Hermes MCP Anthropic tool calls with their Responses namespace', () => {
+    expect(anthropicMessageToResponses({
+      id: 'msg_1',
+      content: [
+        { type: 'tool_use', id: 'toolu_1', name: 'hermes_lan_devices_list', input: { profile: 'default' } },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }, target)).toMatchObject({
+      output: [{
+        type: 'function_call',
+        call_id: 'toolu_1',
+        name: 'hermes_lan_devices_list',
+        namespace: 'mcp__hermes_studio',
+      }],
     })
   })
 })
@@ -217,7 +336,7 @@ async function collectAnthropicEvents(events: AsyncIterable<AnthropicStreamEvent
 }
 
 describe('agent runner Responses stream adapters', () => {
-	  it('normalizes OpenAI Chat SSE text and tool calls to Responses events', async () => {
+  it('normalizes OpenAI Chat SSE text and tool calls to Responses events', async () => {
 	    const events = await collectEvents(openAiChatSseToResponsesEvents(encodedChunks([
 	      'data: {"choices":[{"delta":{"reasoning_content":"think"}}]}\n\n',
 	      'data: {"choices":[{"delta":{"content":"he"}}]}\n\n',
@@ -225,7 +344,7 @@ describe('agent runner Responses stream adapters', () => {
       'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"lookup","arguments":"{\\"id\\":"}}]}}]}\n\n',
       'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"1}"}}]}}]}\n\n',
       'data: [DONE]\n\n',
-    ]), target))
+    ]), codexTarget))
 
 	    expect(events.map(event => event.type)).toEqual([
 	      'response.created',
@@ -262,6 +381,27 @@ describe('agent runner Responses stream adapters', () => {
     })
   })
 
+  it('marks expanded Hermes MCP Chat SSE tool calls with their Responses namespace', async () => {
+    const events = await collectEvents(openAiChatSseToResponsesEvents(encodedChunks([
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"hermes_lan_devices_scan","arguments":"{}"}}]}}]}\n\n',
+      'data: [DONE]\n\n',
+    ]), codexTarget))
+
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'response.output_item.done',
+        data: expect.objectContaining({
+          item: expect.objectContaining({
+            type: 'function_call',
+            call_id: 'call_1',
+            name: 'hermes_lan_devices_scan',
+            namespace: 'mcp__hermes_studio',
+          }),
+        }),
+      }),
+    ]))
+  })
+
   it('normalizes Anthropic Messages SSE text and tool calls to Responses events', async () => {
 	    const events = await collectEvents(anthropicMessagesSseToResponsesEvents(encodedChunks([
 	      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1"}}\n\n',
@@ -269,7 +409,7 @@ describe('agent runner Responses stream adapters', () => {
 	      'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}\n\n',
       'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"lookup","input":{}}}\r\n\r\n',
       'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"id\\":1}"}}\n\n',
-    ]), target))
+    ]), codexTarget))
 
 	    expect(events.map(event => event.type)).toEqual([
 	      'response.created',
@@ -300,6 +440,29 @@ describe('agent runner Responses stream adapters', () => {
         ],
       },
     })
+  })
+
+  it('marks expanded Hermes MCP Anthropic SSE tool calls with their Responses namespace', async () => {
+    const events = await collectEvents(anthropicMessagesSseToResponsesEvents(encodedChunks([
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1"}}\n\n',
+      'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"hermes_lan_devices_list","input":{}}}\n\n',
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"profile\\":\\"default\\"}"}}\n\n',
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ]), codexTarget))
+
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'response.output_item.done',
+        data: expect.objectContaining({
+          item: expect.objectContaining({
+            type: 'function_call',
+            call_id: 'toolu_1',
+            name: 'hermes_lan_devices_list',
+            namespace: 'mcp__hermes_studio',
+          }),
+        }),
+      }),
+    ]))
   })
 
   it('passes native Responses SSE events through as canonical events', async () => {

--- a/tests/server/agent-runner-adapters.test.ts
+++ b/tests/server/agent-runner-adapters.test.ts
@@ -70,6 +70,58 @@ describe('agent runner Responses adapters', () => {
     })
   })
 
+  it('groups parallel Responses function calls before Chat tool results', () => {
+    const body = {
+      input: [
+        { role: 'user', content: [{ type: 'input_text', text: 'check repo' }] },
+        { type: 'function_call', call_id: 'call_1', name: 'read_file', arguments: '{"path":"a.ts"}' },
+        { type: 'function_call', call_id: 'call_2', name: 'search', arguments: '{"q":"todo"}' },
+        { type: 'function_call_output', call_id: 'call_2', output: 'matches' },
+        { type: 'function_call_output', call_id: 'call_1', output: 'file text' },
+        { role: 'user', content: [{ type: 'input_text', text: 'continue' }] },
+      ],
+    }
+
+    expect(responsesToOpenAiChat(body, target).messages).toEqual([
+      { role: 'user', content: 'check repo' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'read_file', arguments: '{"path":"a.ts"}' },
+          },
+          {
+            id: 'call_2',
+            type: 'function',
+            function: { name: 'search', arguments: '{"q":"todo"}' },
+          },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: 'file text' },
+      { role: 'tool', tool_call_id: 'call_2', content: 'matches' },
+      { role: 'user', content: 'continue' },
+    ])
+  })
+
+  it('drops incomplete Responses function call history for Chat providers', () => {
+    const body = {
+      input: [
+        { role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+        { type: 'function_call', call_id: 'call_missing', name: 'search', arguments: '{"q":"x"}' },
+        { role: 'user', content: [{ type: 'input_text', text: 'next turn' }] },
+        { type: 'function_call_output', call_id: 'orphan_call', output: 'orphan' },
+      ],
+    }
+
+    expect(responsesToOpenAiChat(body, target).messages).toEqual([
+      { role: 'user', content: 'hello' },
+      { role: 'user', content: 'next turn' },
+    ])
+  })
+
   it('converts Responses input to Anthropic messages', () => {
     const body = {
       instructions: 'system text',

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import {
   anthropicMessagesUrl,
   chatCompletionsUrl,
@@ -178,6 +181,51 @@ describe('coding agent terminal output sanitizer', () => {
 })
 
 describe('coding agent run state', () => {
+  it('marks existing scoped Codex runners incompatible when Hermes MCP config is missing', () => {
+    const codexHome = mkdtempSync(join(tmpdir(), 'hwui-codex-mcp-compat-'))
+    try {
+      writeFileSync(join(codexHome, 'config.toml'), 'model = "gpt-test"\n')
+      const manager = new CodingAgentRunManager()
+      ;(manager as any).ensureDbSession = () => {}
+      ;(manager as any).emitToChat = () => {}
+
+      manager.start({
+        agentSessionId: 'agent-session-1',
+        agentId: 'codex',
+        mode: 'scoped',
+        profile: 'default',
+        provider: 'test-provider',
+        model: 'gpt-test',
+        sessionId: 'chat-session-1',
+        command: 'codex',
+        args: [],
+        shellCommand: 'codex',
+        workspaceDir: process.cwd(),
+        env: { CODEX_HOME: codexHome },
+        state: { messages: [], isWorking: false, events: [], queue: [] },
+      })
+
+      expect(manager.isSessionLaunchCompatible('chat-session-1', {
+        agentId: 'codex',
+        mode: 'scoped',
+        provider: 'test-provider',
+        model: 'gpt-test',
+      })).toBe(false)
+
+      writeFileSync(join(codexHome, 'config.toml'), '[mcp_servers.hermes-studio]\ncommand = "node"\n')
+      expect(manager.isSessionLaunchCompatible('chat-session-1', {
+        agentId: 'codex',
+        mode: 'scoped',
+        provider: 'test-provider',
+        model: 'gpt-test',
+      })).toBe(true)
+
+      manager.shutdown()
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
   it('updates the shared chat session state during streaming', () => {
     const manager = new CodingAgentRunManager()
     const state: any = { messages: [], isWorking: false, events: [], queue: [] }

--- a/tests/server/api-docs-controller.test.ts
+++ b/tests/server/api-docs-controller.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest'
+import { openapi } from '../../packages/server/src/controllers/api-docs'
+
+describe('api docs controller', () => {
+  it('returns the OpenAPI route catalog', async () => {
+    const ctx = {
+      set: vi.fn(),
+      status: 200,
+      body: undefined as any,
+    }
+
+    await openapi(ctx as any)
+
+    expect(ctx.set).toHaveBeenCalledWith('Cache-Control', 'no-store')
+    expect(ctx.body.openapi).toBe('3.0.3')
+    expect(ctx.body.paths['/api/openapi.json']).toBeTruthy()
+  })
+})

--- a/tests/server/api-docs-controller.test.ts
+++ b/tests/server/api-docs-controller.test.ts
@@ -14,5 +14,22 @@ describe('api docs controller', () => {
     expect(ctx.set).toHaveBeenCalledWith('Cache-Control', 'no-store')
     expect(ctx.body.openapi).toBe('3.0.3')
     expect(ctx.body.paths['/api/openapi.json']).toBeTruthy()
+    expect(ctx.body.paths['/api/auth/login'].post.requestBody.content['application/json'].schema.required).toEqual([
+      'password',
+      'username',
+    ])
+    expect(ctx.body.paths['/api/auth/users/{id}'].put.parameters).toEqual([
+      expect.objectContaining({ name: 'id', in: 'path', required: true }),
+    ])
+    expect(ctx.body.paths['/api/hermes/kanban/search-sessions'].get.parameters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'task_id', in: 'query', required: true }),
+        expect.objectContaining({ name: 'profile', in: 'query', required: true }),
+        expect.objectContaining({ name: 'q', in: 'query', required: false }),
+      ]),
+    )
+    expect(
+      ctx.body.paths['/api/chat-run/runs'].post.requestBody.content['application/json'].schema.properties.source.enum,
+    ).toEqual(['cli', 'coding_agent', 'global_agent'])
   })
 })

--- a/tests/server/auth-routes-avatar.test.ts
+++ b/tests/server/auth-routes-avatar.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('../../packages/server/src/controllers/auth', () => ({
   authStatus: vi.fn(async (ctx: any) => { ctx.body = { ok: true } }),
   login: vi.fn(async (ctx: any) => { ctx.body = { token: 'x' } }),
+  microcontrollerLogin: vi.fn(async (ctx: any) => { ctx.body = { token: 'x', profiles: [] } }),
   setupPassword: vi.fn(async (ctx: any) => { ctx.body = { ok: true } }),
   currentUser: vi.fn(async (ctx: any) => { ctx.body = { user: {} } }),
   changePassword: vi.fn(async (ctx: any) => { ctx.body = { ok: true } }),

--- a/tests/server/chat-run-api-controller.test.ts
+++ b/tests/server/chat-run-api-controller.test.ts
@@ -77,7 +77,7 @@ describe('chat-run HTTP API controller', () => {
     expect(ctx.body.events).toHaveLength(3)
   })
 
-  it('generates a session id for cli runs when none is provided', async () => {
+  it('generates a session id when none is provided', async () => {
     const socket = makeSocket()
     ioMock.mockReturnValue(socket)
 
@@ -107,6 +107,42 @@ describe('chat-run HTTP API controller', () => {
       profile: 'default',
     })
     expect(ctx.status).toBe(200)
+    expect(ctx.body).toMatchObject({
+      ok: true,
+      status: 'completed',
+      session_id: emittedPayload.session_id,
+    })
+  })
+
+  it('generates a session id for global-agent runs when none is provided', async () => {
+    const socket = makeSocket()
+    ioMock.mockReturnValue(socket)
+
+    const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
+    const ctx = {
+      get: vi.fn((name: string) => name.toLowerCase() === 'authorization' ? 'Bearer token-1' : ''),
+      state: { profile: { name: 'default' } },
+      request: {
+        body: {
+          source: 'global_agent',
+          input: 'start a global run',
+        },
+      },
+      status: 200,
+      body: undefined as any,
+    }
+
+    const pending = runOnce(ctx as any)
+    socket.emitNative('connect')
+    await pending
+
+    const emittedPayload = socket.emit.mock.calls.find(call => call[0] === 'run')?.[1] as Record<string, unknown>
+    expect(emittedPayload.session_id).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/))
+    expect(emittedPayload).toMatchObject({
+      source: 'global_agent',
+      input: 'start a global run',
+      profile: 'default',
+    })
     expect(ctx.body).toMatchObject({
       ok: true,
       status: 'completed',

--- a/tests/server/chat-run-api-controller.test.ts
+++ b/tests/server/chat-run-api-controller.test.ts
@@ -1,0 +1,79 @@
+import { EventEmitter } from 'events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ioMock = vi.hoisted(() => vi.fn())
+
+vi.mock('socket.io-client', () => ({
+  io: ioMock,
+}))
+
+function makeSocket() {
+  const emitter = new EventEmitter() as EventEmitter & {
+    emit: ReturnType<typeof vi.fn>
+    disconnect: ReturnType<typeof vi.fn>
+    emitNative: (event: string, payload?: unknown) => boolean
+  }
+  const nativeEmit = EventEmitter.prototype.emit.bind(emitter)
+  emitter.emitNative = nativeEmit
+  emitter.emit = vi.fn((event: string, payload?: unknown) => {
+    if (event === 'run') {
+      process.nextTick(() => {
+        nativeEmit('run.started', { event: 'run.started', run_id: 'run-1' })
+        nativeEmit('message.delta', { event: 'message.delta', run_id: 'run-1', delta: 'hello' })
+        nativeEmit('run.completed', { event: 'run.completed', run_id: 'run-1' })
+      })
+    }
+    return true
+  }) as any
+  emitter.disconnect = vi.fn()
+  return emitter
+}
+
+describe('chat-run HTTP API controller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('runs chat-run through Socket.IO and returns a completed HTTP response', async () => {
+    const socket = makeSocket()
+    ioMock.mockReturnValue(socket)
+
+    const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
+    const ctx = {
+      get: vi.fn((name: string) => name.toLowerCase() === 'authorization' ? 'Bearer token-1' : ''),
+      state: { profile: { name: 'default' } },
+      request: {
+        body: {
+          session_id: 'session-1',
+          input: 'hello',
+          include_events: true,
+        },
+      },
+      status: 200,
+      body: undefined as any,
+    }
+
+    const pending = runOnce(ctx as any)
+    socket.emitNative('connect')
+    await pending
+
+    expect(ioMock).toHaveBeenCalledWith(expect.stringContaining('/chat-run'), expect.objectContaining({
+      auth: { token: 'token-1' },
+      query: { profile: 'default' },
+    }))
+    expect(socket.emit).toHaveBeenCalledWith('run', expect.objectContaining({
+      session_id: 'session-1',
+      input: 'hello',
+      profile: 'default',
+    }))
+    expect(ctx.status).toBe(200)
+    expect(ctx.body).toMatchObject({
+      ok: true,
+      status: 'completed',
+      session_id: 'session-1',
+      run_id: 'run-1',
+      output: 'hello',
+    })
+    expect(ctx.body.events).toHaveLength(3)
+  })
+})

--- a/tests/server/chat-run-api-controller.test.ts
+++ b/tests/server/chat-run-api-controller.test.ts
@@ -76,4 +76,41 @@ describe('chat-run HTTP API controller', () => {
     })
     expect(ctx.body.events).toHaveLength(3)
   })
+
+  it('generates a session id for cli runs when none is provided', async () => {
+    const socket = makeSocket()
+    ioMock.mockReturnValue(socket)
+
+    const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
+    const ctx = {
+      get: vi.fn((name: string) => name.toLowerCase() === 'authorization' ? 'Bearer token-1' : ''),
+      state: { profile: { name: 'default' } },
+      request: {
+        body: {
+          source: 'cli',
+          input: 'start a new chat',
+        },
+      },
+      status: 200,
+      body: undefined as any,
+    }
+
+    const pending = runOnce(ctx as any)
+    socket.emitNative('connect')
+    await pending
+
+    const emittedPayload = socket.emit.mock.calls.find(call => call[0] === 'run')?.[1] as Record<string, unknown>
+    expect(emittedPayload.session_id).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/))
+    expect(emittedPayload).toMatchObject({
+      source: 'cli',
+      input: 'start a new chat',
+      profile: 'default',
+    })
+    expect(ctx.status).toBe(200)
+    expect(ctx.body).toMatchObject({
+      ok: true,
+      status: 'completed',
+      session_id: emittedPayload.session_id,
+    })
+  })
 })

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const handleBridgeRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const resumeBridgeRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const handleApiRunMock = vi.hoisted(() => vi.fn(async () => {}))
+const handleCodingAgentRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const loadSessionStateFromDbMock = vi.hoisted(() => vi.fn())
 const ensureReadyMock = vi.hoisted(() => vi.fn())
 const getRuntimeStateMock = vi.hoisted(() => vi.fn())
@@ -23,6 +24,10 @@ vi.mock('../../packages/server/src/services/hermes/run-chat/handle-api-run', () 
   handleApiRun: handleApiRunMock,
   loadSessionStateFromDb: loadSessionStateFromDbMock,
   resolveRunSource: vi.fn((source?: string) => source || 'cli'),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/handle-coding-agent-run', () => ({
+  handleCodingAgentRun: handleCodingAgentRunMock,
 }))
 
 vi.mock('../../packages/server/src/services/hermes/run-chat/session-command', () => ({
@@ -106,6 +111,7 @@ describe('ensureBridgeReadyForChatRun', () => {
     handleBridgeRunMock.mockReset()
     resumeBridgeRunMock.mockReset()
     handleApiRunMock.mockReset()
+    handleCodingAgentRunMock.mockReset()
     loadSessionStateFromDbMock.mockReset()
     getSessionMock.mockReset()
     getSessionMock.mockImplementation((sessionId?: string) => sessionId
@@ -177,6 +183,7 @@ describe('ChatRunSocket bridge readiness gating', () => {
     handleBridgeRunMock.mockReset()
     resumeBridgeRunMock.mockReset()
     handleApiRunMock.mockReset()
+    handleCodingAgentRunMock.mockReset()
     loadSessionStateFromDbMock.mockReset()
     ensureReadyMock.mockResolvedValue({
       reachable: true,
@@ -232,6 +239,59 @@ describe('ChatRunSocket bridge readiness gating', () => {
     expect(handleApiRunMock).toHaveBeenCalledTimes(1)
     expect(handleBridgeRunMock).not.toHaveBeenCalled()
     expect(socket.emit).not.toHaveBeenCalledWith('run.failed', expect.anything())
+  })
+
+  it('routes global-agent Hermes runs through the bridge run path while preserving session source', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('run')?.({
+      input: 'hello',
+      session_id: 'session-1',
+      source: 'cli',
+      session_source: 'global_agent',
+    })
+
+    expect(ensureReadyMock).toHaveBeenCalledTimes(1)
+    expect(handleBridgeRunMock).toHaveBeenCalledTimes(1)
+    expect(handleBridgeRunMock.mock.calls[0][2]).toEqual(expect.objectContaining({
+      source: 'cli',
+      session_source: 'global_agent',
+    }))
+    expect(handleApiRunMock).not.toHaveBeenCalled()
+    expect(socket.emit).not.toHaveBeenCalledWith('run.failed', expect.anything())
+  })
+
+  it('routes global coding-agent runs through the coding-agent path while preserving session source', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('run')?.({
+      input: 'hello',
+      session_id: 'session-1',
+      source: 'coding_agent',
+      session_source: 'global_agent',
+      coding_agent_id: 'codex',
+    })
+
+    expect(ensureReadyMock).not.toHaveBeenCalled()
+    expect(handleCodingAgentRunMock).toHaveBeenCalledWith(
+      expect.anything(),
+      socket,
+      expect.objectContaining({
+        source: 'coding_agent',
+        session_source: 'global_agent',
+        coding_agent_id: 'codex',
+      }),
+      'default',
+      expect.any(Map),
+    )
+    expect(handleBridgeRunMock).not.toHaveBeenCalled()
+    expect(handleApiRunMock).not.toHaveBeenCalled()
   })
 
   it('continues with remaining queued bridge runs when readiness fails before a dequeued run starts', async () => {
@@ -467,6 +527,57 @@ describe('ChatRunSocket bridge readiness gating', () => {
     expect(socket.emit).toHaveBeenCalledWith('resumed', expect.objectContaining({
       session_id: 'session-1',
       isWorking: false,
+      events: [],
+    }))
+  })
+
+  it('reattaches global-agent bridge runs with the global source preserved', async () => {
+    getSessionMock.mockImplementation((sessionId?: string) => sessionId
+      ? { id: sessionId, profile: 'default', source: 'global_agent', model: 'gpt-test', provider: 'openai' }
+      : undefined)
+    bridgeMock.statusIfLoaded.mockResolvedValueOnce({
+      ok: true,
+      exists: true,
+      running: true,
+      loaded: true,
+      current_run_id: 'run-global',
+    })
+    loadSessionStateFromDbMock.mockResolvedValueOnce({
+      messages: [],
+      isWorking: false,
+      isAborting: false,
+      runId: undefined,
+      activeRunMarker: undefined,
+      profile: 'default',
+      source: 'global_agent',
+      events: [],
+      queue: [],
+    })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { emitted, handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('resume')?.({ session_id: 'session-1' })
+
+    expect(ensureReadyMock).not.toHaveBeenCalled()
+    expect(bridgeMock.statusIfLoaded).toHaveBeenCalledWith('session-1', 'default', { timeoutMs: 1000 })
+    expect(resumeBridgeRunMock).toHaveBeenCalledWith(
+      expect.anything(),
+      socket,
+      expect.objectContaining({
+        sessionId: 'session-1',
+        runId: 'run-global',
+        source: 'global_agent',
+      }),
+      expect.any(Map),
+      bridgeMock,
+      expect.any(Function),
+    )
+    expect(emitted.some(({ event }) => event === 'run.reattach_failed')).toBe(false)
+    expect(socket.emit).toHaveBeenCalledWith('resumed', expect.objectContaining({
+      session_id: 'session-1',
+      isWorking: true,
       events: [],
     }))
   })

--- a/tests/server/coding-agent-run-manager-windows.test.ts
+++ b/tests/server/coding-agent-run-manager-windows.test.ts
@@ -135,9 +135,10 @@ describe('coding agent Windows process launch', () => {
     expect(testState.spawnCalls[0].args[3]).toContain('^"exec^"')
     expect(testState.spawnCalls[0].args[3]).toContain('^"-c^"')
     expect(testState.spawnCalls[0].args[3]).toContain('model_reasoning_summary=\\^"auto\\^"')
+    expect(testState.spawnCalls[0].args[3]).toContain('developer_instructions=')
     expect(testState.spawnCalls[0].args[3]).toContain('^"--model^"')
-    expect(testState.spawnCalls[0].args[3]).toContain('^"system^ prompt')
-    expect(testState.spawnCalls[0].args[3]).toContain('test^"')
+    expect(testState.spawnCalls[0].args[3]).toContain('^"test^"')
+    expect(testState.spawnCalls[0].args[3]).not.toContain('system^ prompt\r\n\r\ntest')
     expect(testState.spawnCalls[0].options).toMatchObject({
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsVerbatimArguments: true,

--- a/tests/server/coding-agent-run-manager-windows.test.ts
+++ b/tests/server/coding-agent-run-manager-windows.test.ts
@@ -80,7 +80,7 @@ describe('coding agent Windows process launch', () => {
       state: { messages: [], isWorking: false, events: [], queue: [] },
     })
 
-    manager.send('chat-session-1', 'test')
+    manager.send('chat-session-1', 'test', { systemPrompt: 'system prompt' })
 
     expect(testState.spawnCalls[0]).toMatchObject({
       command: 'cmd.exe',
@@ -88,6 +88,8 @@ describe('coding agent Windows process launch', () => {
     })
     expect(testState.spawnCalls[0].args[3]).toContain('C:\\Users\\Administrator\\AppData\\Roaming\\npm\\claude.cmd')
     expect(testState.spawnCalls[0].args[3]).toContain('^"--settings^"')
+    expect(testState.spawnCalls[0].args[3]).toContain('^"--append-system-prompt^"')
+    expect(testState.spawnCalls[0].args[3]).toContain('^"system^ prompt^"')
     expect(testState.spawnCalls[0].args[3]).toContain('^"test^"')
     expect(testState.spawnCalls[0].options).toMatchObject({
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -123,7 +125,7 @@ describe('coding agent Windows process launch', () => {
       state: { messages: [], isWorking: false, events: [], queue: [] },
     })
 
-    manager.send('chat-session-codex-1', 'test')
+    manager.send('chat-session-codex-1', 'test', { systemPrompt: 'system prompt' })
 
     expect(testState.spawnCalls[0]).toMatchObject({
       command: 'cmd.exe',
@@ -134,7 +136,8 @@ describe('coding agent Windows process launch', () => {
     expect(testState.spawnCalls[0].args[3]).toContain('^"-c^"')
     expect(testState.spawnCalls[0].args[3]).toContain('model_reasoning_summary=\\^"auto\\^"')
     expect(testState.spawnCalls[0].args[3]).toContain('^"--model^"')
-    expect(testState.spawnCalls[0].args[3]).toContain('^"test^"')
+    expect(testState.spawnCalls[0].args[3]).toContain('^"system^ prompt')
+    expect(testState.spawnCalls[0].args[3]).toContain('test^"')
     expect(testState.spawnCalls[0].options).toMatchObject({
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsVerbatimArguments: true,

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -318,9 +318,10 @@ describe('coding agent launch preparation', () => {
     expect(config).toContain('[mcp_servers.hermes-studio]')
     expect(config).toContain(`command = "${process.execPath}"`)
     expect(config).toContain(`args = ["${join(process.cwd(), 'bin/hermes-web-ui-mcp.mjs')}"]`)
-    expect(config).toContain('[mcp_servers.hermes-studio.env]')
+    expect(config).toContain(`env = { HERMES_WEB_UI_URL = "http://127.0.0.1:8648", HERMES_WEB_UI_HOME = "${home}"`)
+    expect(config).toContain('HERMES_WEBUI_STATE_DIR = "')
     expect(config).toContain('HERMES_MCP_SERVER_NAME = "hermes-studio-mcp"')
-    expect(config).toContain(`HERMES_WEB_UI_HOME = "${home}"`)
+    expect(config).toContain('HERMES_WEB_UI_MANAGED_MCP = "1"')
 
     expect(result.files.some(file => file.key === 'agents')).toBe(false)
 

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -211,6 +211,7 @@ describe('coding agent launch preparation', () => {
         HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
         HERMES_WEB_UI_HOME: home,
         HERMES_WEBUI_STATE_DIR: home,
+        HERMES_WEB_UI_PROFILE: 'default',
         HERMES_MCP_SERVER_NAME: 'hermes-studio-mcp',
         HERMES_WEB_UI_MANAGED_MCP: '1',
       },
@@ -320,6 +321,7 @@ describe('coding agent launch preparation', () => {
     expect(config).toContain(`args = ["${join(process.cwd(), 'bin/hermes-web-ui-mcp.mjs')}"]`)
     expect(config).toContain(`env = { HERMES_WEB_UI_URL = "http://127.0.0.1:8648", HERMES_WEB_UI_HOME = "${home}"`)
     expect(config).toContain('HERMES_WEBUI_STATE_DIR = "')
+    expect(config).toContain('HERMES_WEB_UI_PROFILE = "default"')
     expect(config).toContain('HERMES_MCP_SERVER_NAME = "hermes-studio-mcp"')
     expect(config).toContain('HERMES_WEB_UI_MANAGED_MCP = "1"')
 

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
-import { join } from 'path'
+import { dirname, join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { claudeProxyMessages, claudeProxyModels, registerClaudeCodeProxyTarget } from '../../packages/server/src/services/agent-runner/proxies/claude-code-proxy'
 import { codexProxyModels, codexProxyResponses, registerCodexProxyTarget } from '../../packages/server/src/services/agent-runner/proxies/codex-proxy'
@@ -17,6 +17,7 @@ function makeHome() {
   const home = mkdtempSync(join(tmpdir(), 'hermes-coding-agent-launch-'))
   homes.push(home)
   process.env.HERMES_WEB_UI_HOME = home
+  process.env.HERMES_CODING_AGENT_GLOBAL_HOME = join(home, 'global-home')
   return home
 }
 
@@ -26,6 +27,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.HERMES_WEB_UI_HOME
+  delete process.env.HERMES_CODING_AGENT_GLOBAL_HOME
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
   for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true })
@@ -67,8 +69,15 @@ describe('coding agent launch preparation', () => {
       args: ['--dangerously-skip-permissions'],
       env: {},
       shellCommand: `cd ${join(home, 'coding-agent', 'workspace', 'default', 'global')} && claude --dangerously-skip-permissions`,
-      files: [],
+      files: [{
+        key: 'prompt',
+        path: '~/.claude/CLAUDE.md',
+        absolutePath: join(home, 'global-home', '.claude', 'CLAUDE.md'),
+      }],
     })
+    const prompt = readFileSync(join(home, 'global-home', '.claude', 'CLAUDE.md'), 'utf-8')
+    expect(prompt).toContain('<!-- BEGIN HERMES WEB UI PROMPT -->')
+    expect(prompt).toContain('# 输出格式规范')
   })
 
   it('uses Claude Code auto permission mode instead of dangerous bypass when running as root', async () => {
@@ -112,6 +121,20 @@ describe('coding agent launch preparation', () => {
       shellCommand: `cd ${join(home, 'coding-agent', 'workspace', 'default', 'global')} && codex`,
       files: [],
     })
+  })
+
+  it('preserves existing global Claude Code prompt files while updating the Hermes block', async () => {
+    const home = makeHome()
+    const claudePromptPath = join(home, 'global-home', '.claude', 'CLAUDE.md')
+    mkdirSync(dirname(claudePromptPath), { recursive: true })
+    writeFileSync(claudePromptPath, 'Existing Claude notes\n')
+
+    await prepareCodingAgentLaunch('claude-code', { mode: 'global', profile: 'default' })
+    await prepareCodingAgentLaunch('claude-code', { mode: 'global', profile: 'default' })
+
+    const claudePrompt = readFileSync(claudePromptPath, 'utf-8')
+    expect(claudePrompt).toContain('Existing Claude notes')
+    expect(claudePrompt.match(/BEGIN HERMES WEB UI PROMPT/g)).toHaveLength(1)
   })
 
   it('uses a selected workspace directory when launching a coding agent', async () => {
@@ -179,6 +202,23 @@ describe('coding agent launch preparation', () => {
       ANTHROPIC_DEFAULT_OPUS_MODEL_NAME: 'Dolphin Mistral 24b Venice Edition:Free',
     })
     expect(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL).not.toBe('claude-sonnet-4-6')
+
+    const mcp = JSON.parse(readFileSync(join(result.rootDir, 'mcp.json'), 'utf-8'))
+    expect(mcp.mcpServers['hermes-studio']).toMatchObject({
+      command: process.execPath,
+      args: [join(process.cwd(), 'bin/hermes-web-ui-mcp.mjs')],
+      env: {
+        HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
+        HERMES_WEB_UI_HOME: home,
+        HERMES_WEBUI_STATE_DIR: home,
+        HERMES_MCP_SERVER_NAME: 'hermes-studio-mcp',
+        HERMES_WEB_UI_MANAGED_MCP: '1',
+      },
+    })
+
+    const prompt = readFileSync(join(result.rootDir, 'CLAUDE.md'), 'utf-8')
+    expect(prompt).toContain('# 输出格式规范')
+    expect(prompt).toContain('当你的回复中包含图片、视频或文件引用时')
   })
 
   it('isolates Claude Code settings for hidden chat runs only', async () => {
@@ -275,6 +315,14 @@ describe('coding agent launch preparation', () => {
     expect(config).toContain('requires_openai_auth = false')
     expect(config).toContain(`model_catalog_json = "${join(result.rootDir, 'codex-model-catalog.json')}"`)
     expect(config).toContain('model_reasoning_summary = "auto"')
+    expect(config).toContain('[mcp_servers.hermes-studio]')
+    expect(config).toContain(`command = "${process.execPath}"`)
+    expect(config).toContain(`args = ["${join(process.cwd(), 'bin/hermes-web-ui-mcp.mjs')}"]`)
+    expect(config).toContain('[mcp_servers.hermes-studio.env]')
+    expect(config).toContain('HERMES_MCP_SERVER_NAME = "hermes-studio-mcp"')
+    expect(config).toContain(`HERMES_WEB_UI_HOME = "${home}"`)
+
+    expect(result.files.some(file => file.key === 'agents')).toBe(false)
 
     const catalog = JSON.parse(readFileSync(join(result.rootDir, 'codex-model-catalog.json'), 'utf-8'))
     expect(catalog.models.some((entry: any) => entry.slug === 'openai/gpt-oss-20b:free')).toBe(true)

--- a/tests/server/global-agent-server.test.ts
+++ b/tests/server/global-agent-server.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authMocks = vi.hoisted(() => ({
+  authenticateUserToken: vi.fn(),
+  userCanAccessProfile: vi.fn(),
+}))
+
+vi.mock('../../packages/server/src/middleware/user-auth', () => ({
+  authenticateUserToken: authMocks.authenticateUserToken,
+}))
+
+vi.mock('../../packages/server/src/db/hermes/users-store', () => ({
+  userCanAccessProfile: authMocks.userCanAccessProfile,
+}))
+
+function createMockNamespace() {
+  const middleware: Array<(socket: any, next: (err?: Error) => void) => void> = []
+  const handlers = new Map<string, (...args: any[]) => void>()
+  const nsp: any = {
+    use: vi.fn((fn: (socket: any, next: (err?: Error) => void) => void) => {
+      middleware.push(fn)
+      return nsp
+    }),
+    on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+      handlers.set(event, handler)
+      return nsp
+    }),
+    emit: vi.fn(),
+    __middleware: middleware,
+    __handlers: handlers,
+  }
+  return nsp
+}
+
+function createMockSocket(id: string, auth: Record<string, unknown> = {}) {
+  const handlers = new Map<string, (...args: any[]) => void>()
+  const socket: any = {
+    id,
+    data: {},
+    handshake: { auth },
+    on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+      handlers.set(event, handler)
+      return socket
+    }),
+    emit: vi.fn((_event: string, payload: unknown, ack?: (response: unknown) => void) => {
+      ack?.({ id: (payload as any)?.id, status: 200, body: '{"ok":true}' })
+      return socket
+    }),
+    __handlers: handlers,
+  }
+  return socket
+}
+
+describe('GlobalAgentServer', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    authMocks.authenticateUserToken.mockResolvedValue(null)
+    authMocks.userCanAccessProfile.mockReturnValue(false)
+  })
+
+  it('registers a local control namespace with token auth', async () => {
+    const nsp = createMockNamespace()
+    const io = { of: vi.fn(() => nsp) }
+    const { GlobalAgentServer } = await import('../../packages/server/src/services/global-agent/server')
+
+    const server = new GlobalAgentServer(io as any)
+    server.init()
+
+    expect(io.of).toHaveBeenCalledWith('/global-agent')
+    expect(nsp.use).toHaveBeenCalledTimes(1)
+    expect(nsp.on).toHaveBeenCalledWith('connection', expect.any(Function))
+
+    const denied = createMockSocket('socket-denied', { token: 'wrong' })
+    const deniedNext = vi.fn()
+    await nsp.__middleware[0](denied, deniedNext)
+    expect(deniedNext.mock.calls[0][0]).toBeInstanceOf(Error)
+
+    const allowed = createMockSocket('socket-allowed', { token: server.getAuthToken() })
+    const allowedNext = vi.fn()
+    await nsp.__middleware[0](allowed, allowedNext)
+    expect(allowedNext).toHaveBeenCalledWith()
+  })
+
+  it('tracks connected clients and forwards requests with ack', async () => {
+    const nsp = createMockNamespace()
+    const io = { of: vi.fn(() => nsp) }
+    const { GlobalAgentServer } = await import('../../packages/server/src/services/global-agent/server')
+
+    const server = new GlobalAgentServer(io as any)
+    server.init()
+    const socket = createMockSocket('socket-1', { token: server.getAuthToken(), instanceId: 'local-global-agent' })
+    nsp.__handlers.get('connection')?.(socket)
+
+    expect(server.getClientIds()).toEqual(['local-global-agent'])
+
+    const response = await server.httpRequest({
+      id: 'req-1',
+      method: 'GET',
+      path: '/api/auth/users',
+    }, { clientId: 'local-global-agent' })
+
+    expect(socket.emit).toHaveBeenCalledWith(
+      'http.request',
+      { id: 'req-1', method: 'GET', path: '/api/auth/users' },
+      expect.any(Function),
+    )
+    expect(response).toEqual({ id: 'req-1', status: 200, body: '{"ok":true}' })
+  })
+
+  it('accepts frontend JWT clients and injects their token and profile into forwarded requests', async () => {
+    authMocks.authenticateUserToken.mockResolvedValue({ id: 7, username: 'ada', role: 'user' })
+    authMocks.userCanAccessProfile.mockReturnValue(true)
+    const nsp = createMockNamespace()
+    const io = { of: vi.fn(() => nsp) }
+    const { GlobalAgentServer } = await import('../../packages/server/src/services/global-agent/server')
+
+    const server = new GlobalAgentServer(io as any)
+    server.init()
+
+    const agentSocket = createMockSocket('agent-socket', { token: server.getAuthToken(), instanceId: 'local-global-agent' })
+    await new Promise<void>((resolve, reject) => {
+      nsp.__middleware[0](agentSocket, (err?: Error) => err ? reject(err) : resolve())
+    })
+    nsp.__handlers.get('connection')?.(agentSocket)
+
+    const frontendSocket = createMockSocket('frontend-socket', { token: 'frontend-jwt', profile: 'research' })
+    await new Promise<void>((resolve, reject) => {
+      nsp.__middleware[0](frontendSocket, (err?: Error) => err ? reject(err) : resolve())
+    })
+    nsp.__handlers.get('connection')?.(frontendSocket)
+
+    const httpAck = vi.fn()
+    frontendSocket.__handlers.get('http.request')?.({
+      id: 'req-frontend',
+      method: 'GET',
+      path: '/api/auth/users',
+      clientId: 'local-global-agent',
+    }, httpAck)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(agentSocket.emit).toHaveBeenCalledWith(
+      'http.request',
+      {
+        id: 'req-frontend',
+        method: 'GET',
+        path: '/api/auth/users',
+        clientId: 'local-global-agent',
+        headers: {
+          authorization: 'Bearer frontend-jwt',
+          'x-hermes-profile': 'research',
+        },
+      },
+      expect.any(Function),
+    )
+    expect(httpAck).toHaveBeenCalledWith({ id: 'req-frontend', status: 200, body: '{"ok":true}' })
+
+    const openAck = vi.fn()
+    frontendSocket.__handlers.get('socket.open')?.({
+      id: 'chat-1',
+      namespace: '/chat-run',
+      clientId: 'local-global-agent',
+    }, openAck)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(agentSocket.emit).toHaveBeenCalledWith(
+      'socket.open',
+      {
+        id: 'chat-1',
+        namespace: '/chat-run',
+        clientId: 'local-global-agent',
+        auth: { token: 'frontend-jwt' },
+        query: { profile: 'research' },
+      },
+      expect.any(Function),
+    )
+  })
+
+  it('does not forward reserved Socket.IO lifecycle events to frontend clients', async () => {
+    authMocks.authenticateUserToken.mockResolvedValue({ id: 7, username: 'ada', role: 'user' })
+    authMocks.userCanAccessProfile.mockReturnValue(true)
+    const nsp = createMockNamespace()
+    const io = { of: vi.fn(() => nsp) }
+    const { GlobalAgentServer } = await import('../../packages/server/src/services/global-agent/server')
+
+    const server = new GlobalAgentServer(io as any)
+    server.init()
+
+    const agentSocket = createMockSocket('agent-socket', { token: server.getAuthToken(), instanceId: 'local-global-agent' })
+    await new Promise<void>((resolve, reject) => {
+      nsp.__middleware[0](agentSocket, (err?: Error) => err ? reject(err) : resolve())
+    })
+    nsp.__handlers.get('connection')?.(agentSocket)
+
+    const frontendSocket = createMockSocket('frontend-socket', { token: 'frontend-jwt', profile: 'research' })
+    await new Promise<void>((resolve, reject) => {
+      nsp.__middleware[0](frontendSocket, (err?: Error) => err ? reject(err) : resolve())
+    })
+    nsp.__handlers.get('connection')?.(frontendSocket)
+
+    const bridgeId = 'frontend:frontend-socket:chat-run'
+    const openAck = vi.fn()
+    frontendSocket.__handlers.get('socket.open')?.({
+      id: bridgeId,
+      namespace: '/chat-run',
+      clientId: 'local-global-agent',
+    }, openAck)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    frontendSocket.emit.mockClear()
+
+    agentSocket.__handlers.get('socket.event')?.({
+      id: bridgeId,
+      namespace: '/chat-run',
+      event: 'connect',
+      payload: { socketId: 'local-chat-run' },
+    })
+    expect(frontendSocket.emit).not.toHaveBeenCalledWith('connect', expect.anything())
+
+    agentSocket.__handlers.get('socket.event')?.({
+      id: bridgeId,
+      namespace: '/chat-run',
+      event: 'message.delta',
+      payload: { session_id: 's1', delta: 'hi' },
+    })
+    expect(frontendSocket.emit).toHaveBeenCalledWith('message.delta', { session_id: 's1', delta: 'hi' })
+  })
+})

--- a/tests/server/handle-coding-agent-run.test.ts
+++ b/tests/server/handle-coding-agent-run.test.ts
@@ -179,9 +179,8 @@ describe('handleCodingAgentRun', () => {
       expect.stringContaining('system prompt\n[Current Hermes profile: default]\n[Current Hermes Web UI model run token: run-token]'),
     )
     const prompt = sendCodingAgentRunInputMock.mock.calls.at(-1)?.[2]
-    expect(prompt).toContain('Hermes Web UI LAN device capabilities are MCP tools')
-    expect(prompt).toContain('Do not use list_mcp_resources or list_mcp_resource_templates')
-    expect(prompt).toContain('mcp__hermes-studio__hermes_lan_devices_scan')
-    expect(prompt).toContain('mcp__hermes-studio__hermes_lan_devices_list')
+    expect(prompt).not.toContain('Hermes Web UI LAN device capabilities are MCP tools')
+    expect(prompt).not.toContain('list_mcp_resources')
+    expect(prompt).not.toContain('mcp__hermes-studio__')
   })
 })

--- a/tests/server/handle-coding-agent-run.test.ts
+++ b/tests/server/handle-coding-agent-run.test.ts
@@ -59,4 +59,38 @@ describe('handleCodingAgentRun', () => {
     }), state)
     expect(sendCodingAgentRunInputMock).toHaveBeenCalledWith('session-1', 'use global codex')
   })
+
+  it('passes global session source through to the coding-agent runner', async () => {
+    managerMock.runIdForSession.mockReturnValue(undefined)
+    managerMock.isSessionLaunchCompatible.mockReturnValue(true)
+    startCodingAgentRunMock.mockResolvedValue({ agentSessionId: 'agent-session-1' })
+    sendCodingAgentRunInputMock.mockResolvedValue({ runId: 'agent-session-1' })
+
+    const { handleCodingAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-coding-agent-run')
+    const state = {
+      messages: [],
+      isWorking: false,
+      isAborting: false,
+      events: [],
+      queue: [],
+    }
+    const sessionMap = new Map([['session-1', state]])
+    const socket = {
+      join: vi.fn(),
+      emit: vi.fn(),
+    }
+
+    await handleCodingAgentRun({} as any, socket as any, {
+      session_id: 'session-1',
+      input: 'hello codex',
+      coding_agent_id: 'codex',
+      session_source: 'global_agent',
+    }, 'default', sessionMap as any)
+
+    expect(startCodingAgentRunMock).toHaveBeenCalledWith('codex', expect.objectContaining({
+      sessionId: 'session-1',
+      sessionSource: 'global_agent',
+    }), state)
+    expect(sendCodingAgentRunInputMock).toHaveBeenCalledWith('session-1', 'hello codex')
+  })
 })

--- a/tests/server/handle-coding-agent-run.test.ts
+++ b/tests/server/handle-coding-agent-run.test.ts
@@ -7,7 +7,7 @@ const managerMock = vi.hoisted(() => ({
 }))
 const startCodingAgentRunMock = vi.hoisted(() => vi.fn())
 const sendCodingAgentRunInputMock = vi.hoisted(() => vi.fn())
-const buildModelRunAuthPromptMock = vi.hoisted(() => vi.fn(async () => []))
+const writeModelRunProfileTokenMock = vi.hoisted(() => vi.fn(async () => undefined))
 const getSystemPromptMock = vi.hoisted(() => vi.fn(() => 'system prompt'))
 
 vi.mock('../../packages/server/src/services/agent-runner/coding-agent-run-manager', () => ({
@@ -20,7 +20,7 @@ vi.mock('../../packages/server/src/services/coding-agents', () => ({
 }))
 
 vi.mock('../../packages/server/src/services/hermes/run-chat/model-run-prompt', () => ({
-  buildModelRunAuthPrompt: buildModelRunAuthPromptMock,
+  writeModelRunProfileToken: writeModelRunProfileTokenMock,
 }))
 
 vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
@@ -30,7 +30,7 @@ vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
 describe('handleCodingAgentRun', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    buildModelRunAuthPromptMock.mockResolvedValue([])
+    writeModelRunProfileTokenMock.mockResolvedValue(undefined)
     getSystemPromptMock.mockReturnValue('system prompt')
   })
 
@@ -139,14 +139,16 @@ describe('handleCodingAgentRun', () => {
     expect(sendCodingAgentRunInputMock).toHaveBeenCalledWith('session-1', 'hello claude', 'system prompt')
   })
 
-  it('passes per-run MCP auth prompt separately from coding-agent input for authenticated users', async () => {
+  it('keeps profile token handling separate from the system prompt for authenticated users', async () => {
     managerMock.runIdForSession.mockReturnValue('agent-session-1')
     managerMock.isSessionLaunchCompatible.mockReturnValue(true)
     sendCodingAgentRunInputMock.mockResolvedValue({ runId: 'agent-session-1' })
-    buildModelRunAuthPromptMock.mockResolvedValue([
-      '[Current Hermes profile: default]',
-      '[Current Hermes Web UI model run token: run-token]',
-    ])
+    writeModelRunProfileTokenMock.mockResolvedValue(undefined)
+    getSystemPromptMock.mockReturnValue([
+      'system prompt',
+      'Hermes Studio MCP usage: call hermes_api_openapi_get before calling unfamiliar Web UI endpoints.',
+      'Use hermes_api_request with method, relative path, and JSON body/query fields.',
+    ].join('\n'))
 
     const { handleCodingAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-coding-agent-run')
     const state = {
@@ -169,16 +171,20 @@ describe('handleCodingAgentRun', () => {
       coding_agent_id: 'codex',
     }, 'default', sessionMap as any)
 
-    expect(buildModelRunAuthPromptMock).toHaveBeenCalledWith(
+    expect(writeModelRunProfileTokenMock).toHaveBeenCalledWith(
       { id: 1, username: 'admin', role: 'super_admin' },
       'default',
     )
     expect(sendCodingAgentRunInputMock).toHaveBeenCalledWith(
       'session-1',
       'hello codex',
-      expect.stringContaining('system prompt\n[Current Hermes profile: default]\n[Current Hermes Web UI model run token: run-token]'),
+      expect.stringContaining('system prompt\nHermes Studio MCP usage'),
     )
     const prompt = sendCodingAgentRunInputMock.mock.calls.at(-1)?.[2]
+    expect(prompt).toContain('hermes_api_request')
+    expect(prompt).not.toContain('run-token')
+    expect(prompt).not.toContain('[Current Hermes profile:')
+    expect(prompt).not.toContain('Current Hermes Web UI model run token')
     expect(prompt).not.toContain('Hermes Web UI LAN device capabilities are MCP tools')
     expect(prompt).not.toContain('list_mcp_resources')
     expect(prompt).not.toContain('mcp__hermes-studio__')

--- a/tests/server/handle-coding-agent-run.test.ts
+++ b/tests/server/handle-coding-agent-run.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const managerMock = vi.hoisted(() => ({
   runIdForSession: vi.fn(),
@@ -7,6 +7,8 @@ const managerMock = vi.hoisted(() => ({
 }))
 const startCodingAgentRunMock = vi.hoisted(() => vi.fn())
 const sendCodingAgentRunInputMock = vi.hoisted(() => vi.fn())
+const buildModelRunAuthPromptMock = vi.hoisted(() => vi.fn(async () => []))
+const getSystemPromptMock = vi.hoisted(() => vi.fn(() => 'system prompt'))
 
 vi.mock('../../packages/server/src/services/agent-runner/coding-agent-run-manager', () => ({
   codingAgentRunManager: managerMock,
@@ -17,7 +19,21 @@ vi.mock('../../packages/server/src/services/coding-agents', () => ({
   sendCodingAgentRunInput: sendCodingAgentRunInputMock,
 }))
 
+vi.mock('../../packages/server/src/services/hermes/run-chat/model-run-prompt', () => ({
+  buildModelRunAuthPrompt: buildModelRunAuthPromptMock,
+}))
+
+vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
+  getSystemPrompt: getSystemPromptMock,
+}))
+
 describe('handleCodingAgentRun', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    buildModelRunAuthPromptMock.mockResolvedValue([])
+    getSystemPromptMock.mockReturnValue('system prompt')
+  })
+
   it('restarts an existing coding-agent runner when the requested launch mode changes', async () => {
     managerMock.runIdForSession.mockReturnValue('agent-session-1')
     managerMock.isSessionLaunchCompatible.mockReturnValue(false)
@@ -57,7 +73,7 @@ describe('handleCodingAgentRun', () => {
       mode: 'global',
       profile: 'default',
     }), state)
-    expect(sendCodingAgentRunInputMock).toHaveBeenCalledWith('session-1', 'use global codex')
+    expect(sendCodingAgentRunInputMock).toHaveBeenCalledWith('session-1', 'use global codex', 'system prompt')
   })
 
   it('passes global session source through to the coding-agent runner', async () => {
@@ -91,6 +107,76 @@ describe('handleCodingAgentRun', () => {
       sessionId: 'session-1',
       sessionSource: 'global_agent',
     }), state)
-    expect(sendCodingAgentRunInputMock).toHaveBeenCalledWith('session-1', 'hello codex')
+    expect(sendCodingAgentRunInputMock).toHaveBeenCalledWith('session-1', 'hello codex', 'system prompt')
+  })
+
+  it('passes the Hermes system prompt on every scoped Claude Code run', async () => {
+    managerMock.runIdForSession.mockReturnValue(undefined)
+    managerMock.isSessionLaunchCompatible.mockReturnValue(true)
+    startCodingAgentRunMock.mockResolvedValue({ agentSessionId: 'agent-session-1' })
+    sendCodingAgentRunInputMock.mockResolvedValue({ runId: 'agent-session-1' })
+
+    const { handleCodingAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-coding-agent-run')
+    const state = {
+      messages: [],
+      isWorking: false,
+      isAborting: false,
+      events: [],
+      queue: [],
+    }
+    const sessionMap = new Map([['session-1', state]])
+    const socket = {
+      join: vi.fn(),
+      emit: vi.fn(),
+    }
+
+    await handleCodingAgentRun({} as any, socket as any, {
+      session_id: 'session-1',
+      input: 'hello claude',
+      coding_agent_id: 'claude-code',
+    }, 'default', sessionMap as any)
+
+    expect(sendCodingAgentRunInputMock).toHaveBeenCalledWith('session-1', 'hello claude', 'system prompt')
+  })
+
+  it('passes per-run MCP auth prompt separately from coding-agent input for authenticated users', async () => {
+    managerMock.runIdForSession.mockReturnValue('agent-session-1')
+    managerMock.isSessionLaunchCompatible.mockReturnValue(true)
+    sendCodingAgentRunInputMock.mockResolvedValue({ runId: 'agent-session-1' })
+    buildModelRunAuthPromptMock.mockResolvedValue([
+      '[Current Hermes profile: default]',
+      '[Current Hermes Web UI model run token: run-token]',
+    ])
+
+    const { handleCodingAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-coding-agent-run')
+    const state = {
+      messages: [],
+      isWorking: false,
+      isAborting: false,
+      events: [],
+      queue: [],
+    }
+    const sessionMap = new Map([['session-1', state]])
+    const socket = {
+      data: { user: { id: 1, username: 'admin', role: 'super_admin' } },
+      join: vi.fn(),
+      emit: vi.fn(),
+    }
+
+    await handleCodingAgentRun({} as any, socket as any, {
+      session_id: 'session-1',
+      input: 'hello codex',
+      coding_agent_id: 'codex',
+    }, 'default', sessionMap as any)
+
+    expect(buildModelRunAuthPromptMock).toHaveBeenCalledWith(
+      { id: 1, username: 'admin', role: 'super_admin' },
+      'default',
+    )
+    expect(sendCodingAgentRunInputMock).toHaveBeenCalledWith(
+      'session-1',
+      'hello codex',
+      'system prompt\n[Current Hermes profile: default]\n[Current Hermes Web UI model run token: run-token]',
+    )
   })
 })

--- a/tests/server/handle-coding-agent-run.test.ts
+++ b/tests/server/handle-coding-agent-run.test.ts
@@ -176,7 +176,12 @@ describe('handleCodingAgentRun', () => {
     expect(sendCodingAgentRunInputMock).toHaveBeenCalledWith(
       'session-1',
       'hello codex',
-      'system prompt\n[Current Hermes profile: default]\n[Current Hermes Web UI model run token: run-token]',
+      expect.stringContaining('system prompt\n[Current Hermes profile: default]\n[Current Hermes Web UI model run token: run-token]'),
     )
+    const prompt = sendCodingAgentRunInputMock.mock.calls.at(-1)?.[2]
+    expect(prompt).toContain('Hermes Web UI LAN device capabilities are MCP tools')
+    expect(prompt).toContain('Do not use list_mcp_resources or list_mcp_resource_templates')
+    expect(prompt).toContain('mcp__hermes-studio__hermes_lan_devices_scan')
+    expect(prompt).toContain('mcp__hermes-studio__hermes_lan_devices_list')
   })
 })

--- a/tests/server/hermes-web-ui-mcp.test.ts
+++ b/tests/server/hermes-web-ui-mcp.test.ts
@@ -1,0 +1,263 @@
+import { createServer } from 'http'
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import pkg from '../../package.json'
+
+function writeRpc(child: ChildProcessWithoutNullStreams, id: number, method: string, params?: unknown) {
+  child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`)
+}
+
+function waitForRpc(responses: Map<number, any>, id: number): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const started = Date.now()
+    const timer = setInterval(() => {
+      if (responses.has(id)) {
+        clearInterval(timer)
+        resolve(responses.get(id))
+        return
+      }
+      if (Date.now() - started > 5000) {
+        clearInterval(timer)
+        reject(new Error(`Timed out waiting for MCP response ${id}`))
+      }
+    }, 10)
+  })
+}
+
+describe('hermes-web-ui MCP server', () => {
+  let child: ChildProcessWithoutNullStreams | null = null
+  const homes: string[] = []
+
+  afterEach(() => {
+    child?.kill()
+    child = null
+    for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true })
+  })
+
+  it('exposes a public Web UI API requester tool', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-web-ui-mcp-'))
+    homes.push(home)
+    mkdirSync(join(home, 'profiles', 'research'), { recursive: true })
+    writeFileSync(join(home, 'profiles', 'research', '.model-run-token'), 'profile-token\n')
+    let chatRunHits = 0
+
+    const server = createServer((req, res) => {
+      if (req.url === '/api/openapi.json') {
+        res.setHeader('content-type', 'application/json')
+        res.end(JSON.stringify({
+          openapi: '3.0.3',
+          paths: {
+            '/api/test-public-requester': {
+              post: {
+                requestBody: {
+                  required: false,
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            '/api/chat-run/runs': {
+              post: {
+                requestBody: {
+                  required: true,
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        required: ['input'],
+                        properties: {
+                          input: { type: 'string' },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          authorization: req.headers.authorization || '',
+          profile: req.headers['x-hermes-profile'] || '',
+        }))
+        return
+      }
+      if (req.url?.startsWith('/api/test-public-requester')) {
+        let raw = ''
+        req.on('data', chunk => { raw += chunk })
+        req.on('end', () => {
+          res.setHeader('content-type', 'application/json')
+          res.end(JSON.stringify({
+            method: req.method,
+            url: req.url,
+            body: raw ? JSON.parse(raw) : null,
+            profile: req.headers['x-hermes-profile'],
+            authorization: req.headers.authorization,
+          }))
+        })
+        return
+      }
+      if (req.url === '/api/chat-run/runs') {
+        chatRunHits += 1
+        let raw = ''
+        req.on('data', chunk => { raw += chunk })
+        req.on('end', () => {
+          res.setHeader('content-type', 'application/json')
+          res.end(JSON.stringify({
+            ok: true,
+            body: raw ? JSON.parse(raw) : null,
+          }))
+        })
+        return
+      }
+      res.statusCode = 404
+      res.end('{}')
+    })
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    if (!address || typeof address === 'string') throw new Error('expected TCP server address')
+
+    const responses = new Map<number, any>()
+    child = spawn(process.execPath, ['bin/hermes-web-ui-mcp.mjs'], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HERMES_WEB_UI_URL: `http://127.0.0.1:${address.port}`,
+        HERMES_WEB_UI_HOME: home,
+        HERMES_WEB_UI_PROFILE: 'research',
+      },
+    })
+    child.stdout.on('data', (chunk) => {
+      for (const line of String(chunk).trim().split('\n')) {
+        if (!line) continue
+        const message = JSON.parse(line)
+        responses.set(message.id, message)
+      }
+    })
+
+    writeRpc(child, 1, 'initialize', {})
+    writeRpc(child, 2, 'tools/list')
+    writeRpc(child, 3, 'tools/call', {
+      name: 'hermes_api_request',
+      arguments: {
+        method: 'POST',
+        path: '/api/test-public-requester',
+        query: { q: 'hello' },
+        body: { ok: true },
+      },
+    })
+    writeRpc(child, 4, 'resources/read', {
+      uri: 'hermes://openapi.json',
+    })
+    writeRpc(child, 5, 'tools/call', {
+      name: 'hermes_api_request',
+      arguments: {
+        method: 'POST',
+        path: '/api/chat-run/runs',
+        body: {},
+      },
+    })
+    writeRpc(child, 7, 'tools/call', {
+      name: 'hermes_api_openapi_get',
+      arguments: {
+        path: '/api/chat-run/runs',
+        method: 'POST',
+      },
+    })
+
+    const initialized = await waitForRpc(responses, 1)
+    expect(initialized.result.serverInfo).toMatchObject({
+      name: 'hermes-web-ui-mcp',
+      version: pkg.version,
+    })
+
+    const list = await waitForRpc(responses, 2)
+    expect(list.result.tools.some((tool: any) => tool.name === 'hermes_api_request')).toBe(true)
+
+    const response = await waitForRpc(responses, 3)
+    const payload = JSON.parse(response.result.content[0].text)
+    expect(payload.status).toBe(200)
+    expect(payload.body).toMatchObject({
+      method: 'POST',
+      url: '/api/test-public-requester?q=hello',
+      body: { ok: true },
+      profile: 'research',
+      authorization: 'Bearer profile-token',
+    })
+    writeRpc(child, 8, 'tools/call', {
+      name: 'hermes_api_openapi_get',
+      arguments: {
+        path: '/api/test-public-requester',
+        method: 'POST',
+      },
+    })
+
+    const resource = await waitForRpc(responses, 4)
+    expect(resource.error).toBeUndefined()
+    expect(resource.result.contents[0]).toMatchObject({
+      uri: 'hermes://openapi.json',
+      mimeType: 'application/json',
+    })
+    expect(JSON.parse(resource.result.contents[0].text)).toMatchObject({
+      openapi: '3.0.3',
+      authorization: 'Bearer profile-token',
+      profile: 'research',
+    })
+
+    const invalid = await waitForRpc(responses, 5)
+    expect(invalid.result.isError).toBe(true)
+    expect(invalid.result.content[0].text).toContain('missing required field body.input')
+    expect(chatRunHits).toBe(0)
+
+    const compactManual = await waitForRpc(responses, 7)
+    const compactPayload = JSON.parse(compactManual.result.content[0].text)
+    expect(compactPayload).toMatchObject({
+      operationCount: 1,
+      operations: [{
+        method: 'POST',
+        path: '/api/chat-run/runs',
+        required: { body: ['input'] },
+      }],
+    })
+    expect(compactPayload.paths).toBeUndefined()
+
+    const optionalManual = await waitForRpc(responses, 8)
+    const optionalPayload = JSON.parse(optionalManual.result.content[0].text)
+    expect(optionalPayload.operations[0].required).toBeUndefined()
+
+    writeRpc(child, 6, 'tools/call', {
+      name: 'hermes_api_request',
+      arguments: {
+        method: 'POST',
+        path: '/api/chat-run/runs',
+        body: { input: 'hello' },
+      },
+    })
+    const valid = await waitForRpc(responses, 6)
+    const validPayload = JSON.parse(valid.result.content[0].text)
+    expect(validPayload.status).toBe(200)
+    expect(validPayload.body.body).toEqual({ input: 'hello' })
+    expect(chatRunHits).toBe(1)
+
+    await new Promise<void>(resolve => server.close(() => resolve()))
+  })
+
+  it('reports the package version from the CLI', async () => {
+    const child = spawn(process.execPath, ['bin/hermes-web-ui-mcp.mjs', '--version'], {
+      cwd: process.cwd(),
+      env: process.env,
+    })
+    let stdout = ''
+    child.stdout.on('data', chunk => { stdout += String(chunk) })
+    const code = await new Promise<number | null>(resolve => child.on('close', resolve))
+
+    expect(code).toBe(0)
+    expect(stdout.trim()).toBe(`hermes-web-ui-mcp v${pkg.version}`)
+  })
+})

--- a/tests/server/hermes-web-ui-mcp.test.ts
+++ b/tests/server/hermes-web-ui-mcp.test.ts
@@ -49,9 +49,14 @@ describe('hermes-web-ui MCP server', () => {
         res.setHeader('content-type', 'application/json')
         res.end(JSON.stringify({
           openapi: '3.0.3',
+          tags: [
+            { name: 'Chat Run', description: 'Chat run operations' },
+            { name: 'Testing', description: 'Test helper operations' },
+          ],
           paths: {
             '/api/test-public-requester': {
               post: {
+                tags: ['Testing'],
                 requestBody: {
                   required: false,
                   content: {
@@ -66,6 +71,7 @@ describe('hermes-web-ui MCP server', () => {
             },
             '/api/chat-run/runs': {
               post: {
+                tags: ['Chat Run'],
                 requestBody: {
                   required: true,
                   content: {
@@ -152,9 +158,7 @@ describe('hermes-web-ui MCP server', () => {
         body: { ok: true },
       },
     })
-    writeRpc(child, 4, 'resources/read', {
-      uri: 'hermes://openapi.json',
-    })
+    writeRpc(child, 4, 'resources/list')
     writeRpc(child, 5, 'tools/call', {
       name: 'hermes_api_request',
       arguments: {
@@ -170,12 +174,17 @@ describe('hermes-web-ui MCP server', () => {
         method: 'POST',
       },
     })
+    writeRpc(child, 9, 'tools/call', {
+      name: 'hermes_api_openapi_get',
+      arguments: {},
+    })
 
     const initialized = await waitForRpc(responses, 1)
     expect(initialized.result.serverInfo).toMatchObject({
       name: 'hermes-web-ui-mcp',
       version: pkg.version,
     })
+    expect(initialized.result.capabilities).toEqual({ tools: {} })
 
     const list = await waitForRpc(responses, 2)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_api_request')).toBe(true)
@@ -199,15 +208,9 @@ describe('hermes-web-ui MCP server', () => {
     })
 
     const resource = await waitForRpc(responses, 4)
-    expect(resource.error).toBeUndefined()
-    expect(resource.result.contents[0]).toMatchObject({
-      uri: 'hermes://openapi.json',
-      mimeType: 'application/json',
-    })
-    expect(JSON.parse(resource.result.contents[0].text)).toMatchObject({
-      openapi: '3.0.3',
-      authorization: 'Bearer profile-token',
-      profile: 'research',
+    expect(resource.error).toMatchObject({
+      code: -32601,
+      message: 'Method not found: resources/list',
     })
 
     const invalid = await waitForRpc(responses, 5)
@@ -218,18 +221,46 @@ describe('hermes-web-ui MCP server', () => {
     const compactManual = await waitForRpc(responses, 7)
     const compactPayload = JSON.parse(compactManual.result.content[0].text)
     expect(compactPayload).toMatchObject({
+      moduleCount: 2,
       operationCount: 1,
       operations: [{
         method: 'POST',
         path: '/api/chat-run/runs',
-        required: { body: ['input'] },
+        requestBody: {
+          fields: [
+            { name: 'input', required: true, type: 'string' },
+          ],
+        },
       }],
     })
     expect(compactPayload.paths).toBeUndefined()
 
+    const moduleManual = await waitForRpc(responses, 9)
+    const modulePayload = JSON.parse(moduleManual.result.content[0].text)
+    expect(modulePayload).toMatchObject({
+      moduleCount: 2,
+      operationCount: 2,
+      operationsOmitted: true,
+      modules: expect.arrayContaining([
+        {
+          tag: 'Chat Run',
+          operationCount: 1,
+          purpose: 'Start a chat or coding-agent run through the HTTP bridge and wait for the result.',
+          keywords: expect.arrayContaining(['chat', 'run']),
+          description: 'Chat run operations',
+        },
+        { tag: 'Testing', operationCount: 1, description: 'Test helper operations' },
+      ]),
+    })
+    expect(modulePayload.operations).toBeUndefined()
+
     const optionalManual = await waitForRpc(responses, 8)
     const optionalPayload = JSON.parse(optionalManual.result.content[0].text)
-    expect(optionalPayload.operations[0].required).toBeUndefined()
+    expect(optionalPayload.operations[0]).toMatchObject({
+      method: 'POST',
+      path: '/api/test-public-requester',
+      requestBody: { required: false, fields: [] },
+    })
 
     writeRpc(child, 6, 'tools/call', {
       name: 'hermes_api_request',

--- a/tests/server/lan-discovery.test.ts
+++ b/tests/server/lan-discovery.test.ts
@@ -186,11 +186,11 @@ describe('LAN discovery', () => {
 
     expect(mcpSource).toContain("name: 'hermes_lan_devices_list'")
     expect(mcpSource).toContain('online status')
-    expect(mcpSource).toContain('current model run token')
+    expect(mcpSource).toContain('temporary profile token')
     expect(mcpSource).toContain("'X-Hermes-Profile': profile")
     expect(mcpSource).toContain('token: args.token')
     expect(mcpSource).toContain('profile: args.profile')
-    expect(mcpSource).toContain('allowTokenFile: false')
+    expect(mcpSource).toContain("join(appHome(), 'profiles', segment, '.model-run-token')")
     expect(mcpSource).toContain("name: 'hermes_lan_terminal_list'")
     expect(mcpSource).toContain('/terminals`, withAuthArgs(args))')
   })

--- a/tests/server/lan-discovery.test.ts
+++ b/tests/server/lan-discovery.test.ts
@@ -143,7 +143,7 @@ describe('LAN discovery', () => {
     expect(result.devices).toEqual([])
   })
 
-  it('registers device request routes before auth and management routes behind auth', () => {
+  it('registers device request routes before auth and management routes behind super admin auth', () => {
     const source = readFileSync('packages/server/src/routes/index.ts', 'utf8')
     const deviceRoutesSource = readFileSync('packages/server/src/routes/devices.ts', 'utf8')
     const bootstrapSource = readFileSync('packages/server/src/index.ts', 'utf8')
@@ -157,6 +157,8 @@ describe('LAN discovery', () => {
     expect(deviceIndex).toBeGreaterThanOrEqual(0)
     expect(deviceRoutesSource).toContain("devicePublicRoutes.post('/api/devices/link-status'")
     expect(deviceRoutesSource).toContain("devicePublicRoutes.get('/api/devices/link-info'")
+    expect(deviceRoutesSource).toContain("import { requireSuperAdmin }")
+    expect(deviceRoutesSource).toContain('deviceRoutes.use(requireSuperAdmin)')
     expect(deviceRoutesSource).toContain("deviceRoutes.get('/api/devices/pairing-link'")
     expect(deviceRoutesSource).toContain("deviceRoutes.post('/api/devices/manual-request'")
     expect(deviceRoutesSource).toContain("deviceRoutes.delete('/api/devices/:id/request-history'")
@@ -184,7 +186,12 @@ describe('LAN discovery', () => {
 
     expect(mcpSource).toContain("name: 'hermes_lan_devices_list'")
     expect(mcpSource).toContain('online status')
+    expect(mcpSource).toContain('current model run token')
+    expect(mcpSource).toContain("'X-Hermes-Profile': profile")
+    expect(mcpSource).toContain('token: args.token')
+    expect(mcpSource).toContain('profile: args.profile')
+    expect(mcpSource).toContain('allowTokenFile: false')
     expect(mcpSource).toContain("name: 'hermes_lan_terminal_list'")
-    expect(mcpSource).toContain('/terminals`))')
+    expect(mcpSource).toContain('/terminals`, withAuthArgs(args))')
   })
 })

--- a/tests/server/llm-prompt.test.ts
+++ b/tests/server/llm-prompt.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { getSystemPrompt } from '../../packages/server/src/lib/llm-prompt'
+
+describe('LLM prompt', () => {
+  it('includes Hermes MCP usage guidance in every system prompt without runtime profile or resource URI values', () => {
+    const prompt = getSystemPrompt('custom instructions')
+
+    expect(prompt).toContain('custom instructions')
+    expect(prompt).toContain('hermes_api_openapi_get')
+    expect(prompt).toContain('hermes_api_request')
+    expect(prompt).toContain('OpenAPI requestBody')
+    expect(prompt).toContain('do not add Authorization headers')
+    expect(prompt).not.toContain('hermes://openapi.json')
+    expect(prompt).not.toContain('[Current Hermes profile:')
+  })
+})

--- a/tests/server/mcu-login-controller.test.ts
+++ b/tests/server/mcu-login-controller.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const startOutboundRelayClientMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../packages/server/src/services/global-agent/outbound-relay-client', () => ({
+  startOutboundRelayClient: startOutboundRelayClientMock,
+}))
+
+describe('MCU login controller', () => {
+  let db: any = null
+
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.stubEnv('AUTH_JWT_SECRET', 'test-secret')
+
+    const { DatabaseSync } = await import('node:sqlite')
+    db = new DatabaseSync(':memory:')
+    vi.doMock('../../packages/server/src/db/index', () => ({
+      getDb: () => db,
+      getStoragePath: () => ':memory:',
+    }))
+
+    const schemas = await import('../../packages/server/src/db/hermes/schemas')
+    schemas.initAllHermesTables()
+  })
+
+  async function loadModules() {
+    return {
+      ctrl: await import('../../packages/server/src/controllers/auth'),
+      users: await import('../../packages/server/src/db/hermes/users-store'),
+      auth: await import('../../packages/server/src/middleware/user-auth'),
+    }
+  }
+
+  function makeCtx(body: Record<string, unknown>) {
+    return {
+      request: { body },
+      headers: {},
+      query: {},
+      ip: '127.0.0.1',
+      status: 200,
+      body: null,
+      get: vi.fn(() => ''),
+      req: { socket: { remoteAddress: '127.0.0.1' } },
+    } as any
+  }
+
+  it('requires all MCU login fields', async () => {
+    const { ctrl } = await loadModules()
+    const ctx = makeCtx({
+      token: 'relay-token',
+      url: 'https://relay.example.com/global-agent',
+      id: 'mcu-1',
+      account: 'admin',
+    })
+
+    await ctrl.microcontrollerLogin(ctx)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toEqual({ error: 'token, url, id, account and password are required' })
+    expect(startOutboundRelayClientMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid existing account credentials', async () => {
+    const { ctrl, users } = await loadModules()
+    users.bootstrapDefaultSuperAdmin('admin', '123456')
+    const ctx = makeCtx({
+      token: 'relay-token',
+      url: 'https://relay.example.com/global-agent',
+      id: 'mcu-1',
+      account: 'admin',
+      password: 'wrong',
+    })
+
+    await ctrl.microcontrollerLogin(ctx)
+
+    expect(ctx.status).toBe(401)
+    expect(ctx.body).toEqual({ error: 'Invalid username or password' })
+    expect(startOutboundRelayClientMock).not.toHaveBeenCalled()
+  })
+
+  it('returns a user token and starts the outbound relay client', async () => {
+    startOutboundRelayClientMock.mockReturnValue({ start: vi.fn() })
+    const { ctrl, users, auth } = await loadModules()
+    users.createUser({
+      username: 'ops',
+      password: 'secret123',
+      role: 'admin',
+      profiles: ['default', 'research'],
+      defaultProfile: 'research',
+    })
+    const ctx = makeCtx({
+      token: 'relay-token',
+      url: 'https://user:pass@relay.example.com/global-agent',
+      id: 'mcu-1',
+      account: 'ops',
+      password: 'secret123',
+    })
+
+    await ctrl.microcontrollerLogin(ctx)
+
+    expect(ctx.status).toBe(200)
+    expect(ctx.body.relay).toEqual({
+      connected: true,
+      id: 'mcu-1',
+      url: 'https://relay.example.com/global-agent',
+    })
+    expect(ctx.body.profiles).toEqual(['research', 'default'])
+    expect(await auth.authenticateUserToken(ctx.body.token)).toEqual(expect.objectContaining({
+      username: 'ops',
+      role: 'admin',
+      profiles: ['research', 'default'],
+    }))
+    expect(startOutboundRelayClientMock).toHaveBeenCalledWith({
+      connectionId: 'mcu-1',
+      relayUrl: 'https://relay.example.com/global-agent',
+      relayToken: 'relay-token',
+      instanceId: 'mcu-1',
+    })
+  })
+})

--- a/tests/server/model-run-prompt.test.ts
+++ b/tests/server/model-run-prompt.test.ts
@@ -1,22 +1,43 @@
-import { describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const issueModelRunJwtMock = vi.hoisted(() => vi.fn(async () => 'model-run-token'))
+const homes: string[] = []
 
 vi.mock('../../packages/server/src/middleware/user-auth', () => ({
   issueModelRunJwt: issueModelRunJwtMock,
 }))
 
 describe('model run prompt', () => {
-  it('builds shared model-run auth context without agent-specific MCP tool names', async () => {
-    const { buildModelRunAuthPrompt } = await import('../../packages/server/src/services/hermes/run-chat/model-run-prompt')
-    const prompt = await buildModelRunAuthPrompt({ id: 1, username: 'admin', role: 'super_admin' }, 'default')
-    const text = prompt.join('\n')
+  afterEach(() => {
+    delete process.env.HERMES_WEB_UI_HOME
+    for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true })
+  })
+
+  it('stores the model-run token under the profile and keeps the token out of the prompt', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-model-run-prompt-'))
+    homes.push(home)
+    process.env.HERMES_WEB_UI_HOME = home
+
+    const { writeModelRunProfileToken, modelRunProfileTokenPath } = await import('../../packages/server/src/services/hermes/run-chat/model-run-prompt')
+    await writeModelRunProfileToken({ id: 1, username: 'admin', role: 'super_admin' }, 'default')
+    const tokenPath = modelRunProfileTokenPath('default')
 
     expect(issueModelRunJwtMock).toHaveBeenCalledWith({ id: 1, username: 'admin', role: 'super_admin' })
-    expect(text).toContain('[Current Hermes profile: default]')
-    expect(text).toContain('[Current Hermes Web UI model run token: model-run-token]')
-    expect(text).toContain('pass the current Hermes profile as the profile argument')
-    expect(text).not.toContain('list_mcp_resources')
-    expect(text).not.toContain('mcp__hermes-studio__')
+    expect(tokenPath).toBe(join(home, 'profiles', 'default', '.model-run-token'))
+    expect(readFileSync(tokenPath, 'utf-8').trim()).toBe('model-run-token')
+  })
+
+  it('returns profile instructions without writing a token for anonymous runs', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-model-run-prompt-'))
+    homes.push(home)
+    process.env.HERMES_WEB_UI_HOME = home
+
+    const { writeModelRunProfileToken, modelRunProfileTokenPath } = await import('../../packages/server/src/services/hermes/run-chat/model-run-prompt')
+    await writeModelRunProfileToken(undefined, 'research')
+
+    expect(existsSync(modelRunProfileTokenPath('research'))).toBe(false)
   })
 })

--- a/tests/server/model-run-prompt.test.ts
+++ b/tests/server/model-run-prompt.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const issueModelRunJwtMock = vi.hoisted(() => vi.fn(async () => 'model-run-token'))
+
+vi.mock('../../packages/server/src/middleware/user-auth', () => ({
+  issueModelRunJwt: issueModelRunJwtMock,
+}))
+
+describe('model run prompt', () => {
+  it('builds shared model-run auth context without agent-specific MCP tool names', async () => {
+    const { buildModelRunAuthPrompt } = await import('../../packages/server/src/services/hermes/run-chat/model-run-prompt')
+    const prompt = await buildModelRunAuthPrompt({ id: 1, username: 'admin', role: 'super_admin' }, 'default')
+    const text = prompt.join('\n')
+
+    expect(issueModelRunJwtMock).toHaveBeenCalledWith({ id: 1, username: 'admin', role: 'super_admin' })
+    expect(text).toContain('[Current Hermes profile: default]')
+    expect(text).toContain('[Current Hermes Web UI model run token: model-run-token]')
+    expect(text).toContain('pass the current Hermes profile as the profile argument')
+    expect(text).not.toContain('list_mcp_resources')
+    expect(text).not.toContain('mcp__hermes-studio__')
+  })
+})

--- a/tests/server/outbound-relay-client.test.ts
+++ b/tests/server/outbound-relay-client.test.ts
@@ -1,0 +1,374 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockIo, mockSocket, sockets, socketHandlers, resetMockSockets } = vi.hoisted(() => {
+  function createMockSocket(id: string) {
+    const handlers = new Map<string, (...args: any[]) => void>()
+    const socket: any = {
+      id,
+      __handlers: handlers,
+      on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+        handlers.set(event, handler)
+        return socket
+      }),
+      emit: vi.fn(),
+      disconnect: vi.fn(),
+    }
+    return socket
+  }
+
+  const sockets: any[] = []
+  const mockSocket: any = createMockSocket('socket-1')
+  const socketHandlers = mockSocket.__handlers as Map<string, (...args: any[]) => void>
+  const mockIo = vi.fn(() => {
+    const socket = sockets.length === 0 ? mockSocket : createMockSocket(`socket-${sockets.length + 1}`)
+    sockets.push(socket)
+    return socket
+  })
+  const resetMockSockets = () => {
+    sockets.length = 0
+    mockSocket.__handlers.clear()
+  }
+
+  return {
+    socketHandlers,
+    sockets,
+    mockSocket,
+    mockIo,
+    resetMockSockets,
+  }
+})
+
+vi.mock('socket.io-client', () => ({
+  io: mockIo,
+}))
+
+describe('outbound relay client', () => {
+  beforeEach(async () => {
+    const { stopOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+    stopOutboundRelayClient()
+    resetMockSockets()
+    vi.clearAllMocks()
+  })
+
+  it('stays disabled when no relay url is passed explicitly', async () => {
+    const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+
+    const client = startOutboundRelayClient({ relayUrl: '' })
+
+    expect(client).toBeNull()
+    expect(mockIo).not.toHaveBeenCalled()
+  })
+
+  it('connects to the configured remote relay as a socket client', async () => {
+    const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+
+    const client = startOutboundRelayClient({
+      relayUrl: 'https://user:pass@relay.example.com/hermes',
+      relayToken: 'relay-token',
+      instanceId: 'studio-1',
+      localBaseUrl: 'http://127.0.0.1:9999',
+      fetchImpl: vi.fn() as any,
+    })
+
+    expect(client).not.toBeNull()
+    expect(mockIo).toHaveBeenCalledWith('https://user:pass@relay.example.com/hermes', expect.objectContaining({
+      auth: {
+        token: 'relay-token',
+        instanceId: 'studio-1',
+        role: 'hermes-web-ui',
+      },
+      transports: ['websocket', 'polling'],
+      reconnection: true,
+    }))
+
+    socketHandlers.get('connect')?.()
+    expect(mockSocket.emit).toHaveBeenCalledWith('relay.ready', {
+      capabilities: ['http.request.v1', 'socket.chat-run.v1'],
+      instanceId: 'studio-1',
+    })
+  })
+
+  it('forwards an allowed HTTP request to the local Web UI server', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
+      status: 202,
+      headers: {
+        'content-type': 'application/json',
+        'x-result': 'accepted',
+        'transfer-encoding': 'chunked',
+      },
+    }))
+    const { OutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+    const client = new OutboundRelayClient({
+      relayUrl: 'https://relay.example.com',
+      relayToken: '',
+      instanceId: '',
+      localBaseUrl: 'http://127.0.0.1:8648/',
+      fetchImpl: fetchImpl as any,
+    })
+
+    const response = await client.handleHttpRequest({
+      id: 'req-1',
+      method: 'POST',
+      path: '/api/hermes/sessions?profile=default',
+      headers: {
+        authorization: 'Bearer user-jwt',
+        'content-type': 'application/json',
+        connection: 'keep-alive',
+        host: 'relay.example.com',
+        'x-hermes-profile': 'default',
+      },
+      body: { message: 'hello' },
+    })
+
+    expect(fetchImpl).toHaveBeenCalledWith('http://127.0.0.1:8648/api/hermes/sessions?profile=default', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ message: 'hello' }),
+    }))
+    const init = fetchImpl.mock.calls[0][1] as RequestInit
+    expect(Array.from((init.headers as Headers).entries())).toEqual([
+      ['authorization', 'Bearer user-jwt'],
+      ['content-type', 'application/json'],
+      ['x-hermes-profile', 'default'],
+    ])
+    expect(response).toEqual({
+      id: 'req-1',
+      status: 202,
+      headers: {
+        'content-type': 'application/json',
+        'x-result': 'accepted',
+      },
+      body: '{"ok":true}',
+      truncated: false,
+    })
+  })
+
+  it('forwards non-v1 local paths through the relay', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ users: [] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    const { OutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+    const client = new OutboundRelayClient({
+      relayUrl: 'https://relay.example.com',
+      relayToken: '',
+      instanceId: '',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: fetchImpl as any,
+    })
+
+    const response = await client.handleHttpRequest({
+      id: 'req-2',
+      method: 'GET',
+      path: '/api/auth/users',
+    })
+
+    expect(fetchImpl).toHaveBeenCalledWith('http://127.0.0.1:8648/api/auth/users', expect.objectContaining({
+      method: 'GET',
+    }))
+    expect(response).toEqual({
+      id: 'req-2',
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: '{"users":[]}',
+      truncated: false,
+    })
+  })
+
+  it('rejects /v1 paths without calling local fetch', async () => {
+    const fetchImpl = vi.fn()
+    const { OutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+    const client = new OutboundRelayClient({
+      relayUrl: 'https://relay.example.com',
+      relayToken: '',
+      instanceId: '',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: fetchImpl as any,
+    })
+
+    const response = await client.handleHttpRequest({
+      id: 'req-3',
+      method: 'GET',
+      path: '/v1/runs',
+    })
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(response).toEqual({
+      id: 'req-3',
+      status: 403,
+      error: {
+        code: 'path_not_allowed',
+        message: 'Relay request path is not allowed',
+      },
+    })
+  })
+
+  it('opens a local /chat-run socket and relays chat events both ways', async () => {
+    const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+    const client = startOutboundRelayClient({
+      relayUrl: 'https://relay.example.com',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: vi.fn() as any,
+    })
+    expect(client).not.toBeNull()
+
+    const openAck = vi.fn()
+    socketHandlers.get('socket.open')?.({
+      id: 'chat-1',
+      namespace: '/chat-run',
+      auth: { token: 'user-jwt' },
+      query: { profile: 'default' },
+    }, openAck)
+
+    const localSocket = sockets[1]
+    expect(mockIo).toHaveBeenCalledWith('http://127.0.0.1:8648/chat-run', expect.objectContaining({
+      auth: { token: 'user-jwt' },
+      query: { profile: 'default' },
+      transports: ['websocket', 'polling'],
+    }))
+    expect(openAck).toHaveBeenCalledWith({ id: 'chat-1', ok: true, namespace: '/chat-run', stream: true })
+
+    localSocket.__handlers.get('message.delta')?.({ session_id: 's1', delta: 'hello' })
+    expect(mockSocket.emit).toHaveBeenCalledWith('socket.event', {
+      id: 'chat-1',
+      namespace: '/chat-run',
+      event: 'message.delta',
+      payload: { session_id: 's1', delta: 'hello' },
+    })
+
+    const eventAck = vi.fn()
+    socketHandlers.get('socket.event')?.({
+      id: 'chat-1',
+      event: 'run',
+      payload: { session_id: 's1', input: 'hi' },
+    }, eventAck)
+    expect(localSocket.emit).toHaveBeenCalledWith('run', { session_id: 's1', input: 'hi' })
+    expect(eventAck).toHaveBeenCalledWith({ id: 'chat-1', ok: true, namespace: '/chat-run', event: 'run', stream: true })
+  })
+
+  it('supports non-streaming chat-run mode by suppressing deltas and returning final output', async () => {
+    const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+    startOutboundRelayClient({
+      relayUrl: 'https://relay.example.com',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: vi.fn() as any,
+    })
+
+    const openAck = vi.fn()
+    socketHandlers.get('socket.open')?.({
+      id: 'chat-1',
+      namespace: '/chat-run',
+      stream: false,
+    }, openAck)
+    expect(openAck).toHaveBeenCalledWith({ id: 'chat-1', ok: true, namespace: '/chat-run', stream: false })
+
+    const localSocket = sockets[1]
+    const eventAck = vi.fn()
+    socketHandlers.get('socket.event')?.({
+      id: 'chat-1',
+      event: 'run',
+      stream: false,
+      payload: { session_id: 's1', input: 'hi' },
+    }, eventAck)
+    expect(eventAck).toHaveBeenCalledWith({ id: 'chat-1', ok: true, namespace: '/chat-run', event: 'run', stream: false })
+
+    mockSocket.emit.mockClear()
+    localSocket.__handlers.get('message.delta')?.({ session_id: 's1', delta: 'Hello ' })
+    localSocket.__handlers.get('message.delta')?.({ session_id: 's1', delta: 'world' })
+    localSocket.__handlers.get('reasoning.delta')?.({ session_id: 's1', delta: 'thinking' })
+    expect(mockSocket.emit).not.toHaveBeenCalled()
+
+    localSocket.__handlers.get('run.completed')?.({ session_id: 's1', run_id: 'run-1' })
+    expect(mockSocket.emit).toHaveBeenCalledWith('socket.event', {
+      id: 'chat-1',
+      namespace: '/chat-run',
+      event: 'run.completed',
+      payload: {
+        session_id: 's1',
+        run_id: 'run-1',
+        output: 'Hello world',
+        reasoning: 'thinking',
+      },
+    })
+  })
+
+  it('rejects socket namespaces and events outside the chat-run allowlist', async () => {
+    const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+    startOutboundRelayClient({
+      relayUrl: 'https://relay.example.com',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: vi.fn() as any,
+    })
+
+    const openAck = vi.fn()
+    socketHandlers.get('socket.open')?.({ id: 'room-1', namespace: '/group-chat' }, openAck)
+    expect(openAck).toHaveBeenCalledWith({
+      id: 'room-1',
+      ok: false,
+      error: {
+        code: 'namespace_not_allowed',
+        message: 'Relay socket namespace is not allowed',
+      },
+    })
+
+    const eventAck = vi.fn()
+    socketHandlers.get('socket.event')?.({ id: 'chat-1', event: 'not.allowed', payload: {} }, eventAck)
+    expect(eventAck).toHaveBeenCalledWith({
+      id: 'chat-1',
+      ok: false,
+      error: {
+        code: 'event_not_allowed',
+        message: 'Relay socket event is not allowed',
+      },
+    })
+  })
+
+  it('manages multiple active relay clients by connection id', async () => {
+    const {
+      getOutboundRelayClient,
+      getOutboundRelayClients,
+      startOutboundRelayClient,
+      stopOutboundRelayClient,
+    } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+
+    const first = startOutboundRelayClient({
+      connectionId: 'primary',
+      relayUrl: 'https://relay.example.com',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: vi.fn() as any,
+    })
+    const second = startOutboundRelayClient({
+      connectionId: 'backup',
+      relayUrl: 'https://other-relay.example.com',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: vi.fn() as any,
+    })
+    const duplicate = startOutboundRelayClient({
+      connectionId: 'primary',
+      relayUrl: 'https://duplicate.example.com',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: vi.fn() as any,
+    })
+
+    expect(first).not.toBeNull()
+    expect(second).not.toBe(first)
+    expect(duplicate).toBe(first)
+    expect(getOutboundRelayClient()).toBe(first)
+    expect(getOutboundRelayClient('primary')).toBe(first)
+    expect(getOutboundRelayClient('backup')).toBe(second)
+    expect(getOutboundRelayClients().size).toBe(2)
+    expect(mockIo).toHaveBeenCalledTimes(2)
+
+    stopOutboundRelayClient('primary')
+
+    expect(mockSocket.disconnect).toHaveBeenCalledTimes(1)
+    expect(getOutboundRelayClient('primary')).toBeNull()
+    expect(getOutboundRelayClient('backup')).toBe(second)
+
+    stopOutboundRelayClient()
+
+    expect(sockets[1].disconnect).toHaveBeenCalledTimes(1)
+    expect(getOutboundRelayClients().size).toBe(0)
+  })
+})

--- a/tests/server/outbound-relay-client.test.ts
+++ b/tests/server/outbound-relay-client.test.ts
@@ -83,7 +83,7 @@ describe('outbound relay client', () => {
 
     socketHandlers.get('connect')?.()
     expect(mockSocket.emit).toHaveBeenCalledWith('relay.ready', {
-      capabilities: ['http.request.v1', 'socket.chat-run.v1'],
+      capabilities: ['http.request', 'socket.chat-run'],
       instanceId: 'studio-1',
     })
   })

--- a/tests/server/outbound-relay-client.test.ts
+++ b/tests/server/outbound-relay-client.test.ts
@@ -75,7 +75,7 @@ describe('outbound relay client', () => {
       auth: {
         token: 'relay-token',
         instanceId: 'studio-1',
-        role: 'hermes-web-ui',
+        role: 'hermes-studio',
       },
       transports: ['websocket', 'polling'],
       reconnection: true,

--- a/tests/server/run-chat-abort-goal.test.ts
+++ b/tests/server/run-chat-abort-goal.test.ts
@@ -96,7 +96,7 @@ describe('run chat abort goal handling', () => {
     }))
   })
 
-  it('keeps the session locked when a CLI interrupt does not sync before timeout', async () => {
+  it('releases local working state when a CLI interrupt does not sync before timeout', async () => {
     const { handleAbort } = await import('../../packages/server/src/services/hermes/run-chat/abort')
     const { emit, nsp, socket } = makeHarness()
     const state = {
@@ -106,7 +106,6 @@ describe('run chat abort goal handling', () => {
       events: [],
       queue: [
         { queue_id: 'goal-1', input: 'continue goal', profile: 'default', goalContinuation: true },
-        { queue_id: 'user-1', input: 'normal follow-up', profile: 'default', source: 'cli' },
       ],
       runId: 'run-1',
       profile: 'default',
@@ -116,25 +115,30 @@ describe('run chat abort goal handling', () => {
     const bridge = {
       interrupt: vi.fn().mockResolvedValue({ ok: true, synced: false }),
       goalPause: vi.fn().mockResolvedValue({ handled: true, status: 'paused', reason: 'user-interrupted' }),
+      destroy: vi.fn().mockResolvedValue({ destroyed: true }),
     }
     const runQueuedItem = vi.fn()
 
     await handleAbort(nsp as any, socket as any, 'session-1', sessionMap, bridge, runQueuedItem)
 
     expect(runQueuedItem).not.toHaveBeenCalled()
-    expect(calcAndUpdateUsageMock).not.toHaveBeenCalled()
-    expect(state.isWorking).toBe(true)
-    expect(state.isAborting).toBe(true)
-    expect(state.runId).toBe('run-1')
-    expect(state.queue).toEqual([
-      { queue_id: 'user-1', input: 'normal follow-up', profile: 'default', source: 'cli' },
-    ])
+    expect(bridge.destroy).toHaveBeenCalledWith('session-1', 'default')
+    expect(calcAndUpdateUsageMock).toHaveBeenCalled()
+    expect(state.isWorking).toBe(false)
+    expect(state.isAborting).toBe(false)
+    expect(state.runId).toBeUndefined()
+    expect(state.activeRunMarker).toBeUndefined()
+    expect(state.queue).toEqual([])
     expect(emit).toHaveBeenCalledWith('abort.timeout', expect.objectContaining({
       session_id: 'session-1',
       run_id: 'run-1',
       synced: false,
     }))
-    expect(emit).not.toHaveBeenCalledWith('abort.completed', expect.anything())
+    expect(emit).toHaveBeenCalledWith('abort.completed', expect.objectContaining({
+      session_id: 'session-1',
+      run_id: 'run-1',
+      synced: false,
+    }))
   })
 
   it('stops a coding-agent run even when chat-run state was not marked working', async () => {

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -196,6 +196,47 @@ describe('bridge run final context usage', () => {
     }))
   })
 
+  it('creates global-agent bridge sessions with source global_agent', async () => {
+    getSessionMock.mockReturnValue(undefined)
+    addMessageMock.mockReturnValue(42)
+    const emit = vi.fn()
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    const state = makeState()
+    const sessionMap = new Map([['session-1', state]])
+    const bridge = {
+      chat: vi.fn().mockResolvedValue({ run_id: 'run-1', status: 'started' }),
+      contextEstimate: vi.fn().mockResolvedValue({
+        token_count: 42,
+        message_count: 1,
+        tool_count: 0,
+        system_prompt_chars: 13,
+      }),
+      streamOutput: vi.fn(async function* () {
+        yield { run_id: 'run-1', done: true, status: 'completed', output: 'done' }
+      }),
+    } as any
+
+    const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    await handleBridgeRun(
+      nsp,
+      socket,
+      { input: 'hello', session_id: 'session-1', source: 'global_agent' },
+      'default',
+      sessionMap,
+      bridge,
+      false,
+      vi.fn(),
+      vi.fn(),
+    )
+
+    expect(createSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'session-1',
+      source: 'global_agent',
+    }))
+    expect(state.source).toBe('global_agent')
+  })
+
   it('evaluates active goals after a successful bridge run and queues continuation prompts', async () => {
     const emit = vi.fn()
     const nsp = makeNamespace(emit)

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -35,6 +35,7 @@ const syncBridgeReasoningToMessageMock = vi.fn()
 const recordBridgeToolStartedMock = vi.fn()
 const recordBridgeToolCompletedMock = vi.fn()
 const resolveBridgeRunModelConfigMock = vi.fn()
+const issueModelRunJwtMock = vi.fn(async () => 'model-run-token')
 
 vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
   getSystemPrompt: getSystemPromptMock,
@@ -87,12 +88,17 @@ vi.mock('../../packages/server/src/services/hermes/run-chat/model-config', () =>
   resolveBridgeRunModelConfig: resolveBridgeRunModelConfigMock,
 }))
 
+vi.mock('../../packages/server/src/middleware/user-auth', () => ({
+  issueModelRunJwt: issueModelRunJwtMock,
+}))
+
 function makeSocket() {
   return {
     connected: true,
     emit: vi.fn(),
     join: vi.fn(),
     to: vi.fn(() => ({ emit: vi.fn() })),
+    data: {},
   } as any
 }
 
@@ -117,6 +123,7 @@ describe('bridge run final context usage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getSystemPromptMock.mockReturnValue('system prompt')
+    issueModelRunJwtMock.mockResolvedValue('model-run-token')
     getSessionMock.mockReturnValue({ id: 'session-1', profile: 'default', model: '', provider: '' })
     resolveBridgeRunModelConfigMock.mockResolvedValue({ model: 'gpt-test', provider: 'openai' })
     buildCompressedHistoryMock.mockResolvedValue([{ role: 'user', content: 'previous' }])
@@ -194,6 +201,48 @@ describe('bridge run final context usage', () => {
       outputTokens: 7,
       contextTokens: 12345,
     }))
+  })
+
+  it('adds a super admin one hour model run token to bridge instructions for super admin runs', async () => {
+    const emit = vi.fn()
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    socket.data.user = { id: 1, username: 'admin', role: 'super_admin' }
+    const state = makeState()
+    const sessionMap = new Map([['session-1', state]])
+    const bridge = {
+      chat: vi.fn().mockResolvedValue({ run_id: 'run-1', status: 'started' }),
+      contextEstimate: vi.fn().mockResolvedValue({
+        token_count: 12345,
+        fixed_context_tokens: 12327,
+        message_count: 2,
+        tool_count: 4,
+        system_prompt_chars: 13,
+      }),
+      streamOutput: vi.fn(async function* () {
+        yield { run_id: 'run-1', done: true, status: 'completed', output: 'done' }
+      }),
+    } as any
+
+    const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    await handleBridgeRun(
+      nsp,
+      socket,
+      { input: 'hello', session_id: 'session-1' },
+      'default',
+      sessionMap,
+      bridge,
+      false,
+      vi.fn(),
+      vi.fn(),
+    )
+
+    const instructions = bridge.contextEstimate.mock.calls[0][2]
+    expect(issueModelRunJwtMock).toHaveBeenCalledWith({ id: 1, username: 'admin', role: 'super_admin' })
+    expect(instructions).toContain('[Current Hermes Web UI model run token: model-run-token]')
+    expect(instructions).toContain('pass the current Hermes profile as the profile argument')
+    expect(instructions).toContain('token argument')
+    expect(instructions).toContain('expires in 1 hour')
   })
 
   it('creates global-agent bridge sessions with source global_agent', async () => {

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const getSystemPromptMock = vi.fn()
 const getSessionMock = vi.fn()
@@ -36,6 +39,7 @@ const recordBridgeToolStartedMock = vi.fn()
 const recordBridgeToolCompletedMock = vi.fn()
 const resolveBridgeRunModelConfigMock = vi.fn()
 const issueModelRunJwtMock = vi.fn(async () => 'model-run-token')
+const homes: string[] = []
 
 vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
   getSystemPrompt: getSystemPromptMock,
@@ -121,6 +125,9 @@ function makeState() {
 
 describe('bridge run final context usage', () => {
   beforeEach(() => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-bridge-run-token-'))
+    homes.push(home)
+    process.env.HERMES_WEB_UI_HOME = home
     vi.clearAllMocks()
     getSystemPromptMock.mockReturnValue('system prompt')
     issueModelRunJwtMock.mockResolvedValue('model-run-token')
@@ -146,6 +153,11 @@ describe('bridge run final context usage', () => {
       const contextTokens = contextTokensWithCachedOverheadMock(state, messageTokens)
       return updateContextTokenUsageMock(sid, state, emit, contextTokens, usage)
     })
+  })
+
+  afterEach(() => {
+    delete process.env.HERMES_WEB_UI_HOME
+    for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true })
   })
 
   it('refreshes full context tokens when a bridge run completes', async () => {
@@ -184,7 +196,7 @@ describe('bridge run final context usage', () => {
     expect(bridge.contextEstimate).toHaveBeenCalledWith(
       'session-1',
       [],
-      expect.stringContaining('[Current Hermes profile: default]'),
+      expect.not.stringContaining('[Current Hermes profile:'),
       'default',
       { model: 'gpt-test', provider: 'openai' },
     )
@@ -203,7 +215,7 @@ describe('bridge run final context usage', () => {
     }))
   })
 
-  it('adds a super admin one hour model run token to bridge instructions for super admin runs', async () => {
+  it('stores a super admin model-run token for the profile without adding it to bridge instructions', async () => {
     const emit = vi.fn()
     const nsp = makeNamespace(emit)
     const socket = makeSocket()
@@ -239,12 +251,14 @@ describe('bridge run final context usage', () => {
 
     const instructions = bridge.contextEstimate.mock.calls[0][2]
     expect(issueModelRunJwtMock).toHaveBeenCalledWith({ id: 1, username: 'admin', role: 'super_admin' })
-    expect(instructions).toContain('[Current Hermes Web UI model run token: model-run-token]')
-    expect(instructions).toContain('pass the current Hermes profile as the profile argument')
-    expect(instructions).toContain('token argument')
+    expect(readFileSync(join(process.env.HERMES_WEB_UI_HOME || '', 'profiles', 'default', '.model-run-token'), 'utf-8').trim()).toBe('model-run-token')
+    expect(instructions).not.toContain('[Current Hermes profile:')
+    expect(instructions).not.toContain('pass the current Hermes profile as the profile argument')
+    expect(instructions).not.toContain('model-run-token')
+    expect(instructions).not.toContain('Current Hermes Web UI model run token')
+    expect(instructions).not.toContain('token argument')
     expect(instructions).not.toContain('list_mcp_resources')
     expect(instructions).not.toContain('mcp__hermes-studio__')
-    expect(instructions).toContain('expires in 1 hour')
   })
 
   it('creates global-agent bridge sessions with source global_agent', async () => {

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -215,6 +215,64 @@ describe('bridge run final context usage', () => {
     }))
   })
 
+  it('releases working state when the bridge stream ends without a terminal chunk', async () => {
+    const emit = vi.fn()
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    const state = makeState()
+    const sessionMap = new Map([['session-1', state]])
+    const bridge = {
+      chat: vi.fn().mockResolvedValue({ run_id: 'run-1', status: 'started' }),
+      contextEstimate: vi.fn().mockResolvedValue({
+        token_count: 12345,
+        fixed_context_tokens: 12327,
+        message_count: 2,
+        tool_count: 4,
+        system_prompt_chars: 13,
+      }),
+      streamOutput: vi.fn(async function* () {
+        yield {
+          run_id: 'run-1',
+          session_id: 'session-1',
+          done: false,
+          status: 'running',
+          delta: 'partial reply',
+          cursor: 1,
+          output: 'partial reply',
+          events: [],
+          event_cursor: 0,
+        }
+      }),
+    } as any
+
+    const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    await handleBridgeRun(
+      nsp,
+      socket,
+      { input: 'hello', session_id: 'session-1' },
+      'default',
+      sessionMap,
+      bridge,
+      false,
+      vi.fn(),
+      vi.fn(),
+    )
+
+    expect(state.isWorking).toBe(false)
+    expect(state.isAborting).toBe(false)
+    expect(state.runId).toBeUndefined()
+    expect(state.activeRunMarker).toBeUndefined()
+    expect(emit).toHaveBeenCalledWith('message.delta', expect.objectContaining({
+      delta: 'partial reply',
+    }))
+    expect(emit).toHaveBeenCalledWith('run.completed', expect.objectContaining({
+      output: 'partial reply',
+      inputTokens: 11,
+      outputTokens: 7,
+      contextTokens: 12345,
+    }))
+  })
+
   it('stores a super admin model-run token for the profile without adding it to bridge instructions', async () => {
     const emit = vi.fn()
     const nsp = makeNamespace(emit)

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -242,6 +242,8 @@ describe('bridge run final context usage', () => {
     expect(instructions).toContain('[Current Hermes Web UI model run token: model-run-token]')
     expect(instructions).toContain('pass the current Hermes profile as the profile argument')
     expect(instructions).toContain('token argument')
+    expect(instructions).not.toContain('list_mcp_resources')
+    expect(instructions).not.toContain('mcp__hermes-studio__')
     expect(instructions).toContain('expires in 1 hour')
   })
 

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -309,6 +309,24 @@ describe('session conversations controller', () => {
     expect(localListSessionsMock).toHaveBeenCalledWith('travel', undefined, 2000)
   })
 
+  it('lists only global-agent sessions when requested by source', async () => {
+    localListSessionsMock.mockReturnValue([
+      { id: 'global-1', profile: 'default', source: 'global_agent' },
+      { id: 'chat-1', profile: 'default', source: 'cli' },
+    ])
+
+    const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+    const ctx: any = {
+      query: { source: 'global_agent' },
+      state: {},
+      body: null,
+    }
+    await mod.list(ctx)
+
+    expect(localListSessionsMock).toHaveBeenCalledWith(undefined, 'global_agent', 2000)
+    expect(ctx.body.sessions).toEqual([expect.objectContaining({ id: 'global-1', source: 'global_agent' })])
+  })
+
   it('marks Hermes history sessions that already exist in the Web UI store', async () => {
     localListSessionsMock.mockReturnValue([{ id: 'cli-1', profile: 'travel' }])
     listSessionSummariesMock.mockResolvedValue([
@@ -381,6 +399,24 @@ describe('session conversations controller', () => {
     await mod.search(ctx)
 
     expect(localSearchSessionsMock).toHaveBeenCalledWith(undefined, 'docker', 10)
+  })
+
+  it('searches only global-agent sessions when requested by source', async () => {
+    localSearchSessionsMock.mockReturnValue([
+      { id: 'global-1', profile: 'default', source: 'global_agent' },
+      { id: 'chat-1', profile: 'default', source: 'cli' },
+    ])
+
+    const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+    const ctx: any = {
+      query: { q: 'docker', source: 'global_agent', limit: '10' },
+      state: {},
+      body: null,
+    }
+    await mod.search(ctx)
+
+    expect(localSearchSessionsMock).toHaveBeenCalledWith(undefined, 'docker', 10)
+    expect(ctx.body.results).toEqual([expect.objectContaining({ id: 'global-1', source: 'global_agent' })])
   })
 
   it('propagates local session store errors for conversation summaries', async () => {

--- a/tests/server/stt-transcribe-controller.test.ts
+++ b/tests/server/stt-transcribe-controller.test.ts
@@ -415,7 +415,6 @@ describe('route registration ordering', () => {
     const ttsPublicMiddleware = async () => {}
     const ttsProtectedMiddleware = async () => {}
     const sttProtectedMiddleware = async () => {}
-    const proxyMiddleware = async () => {}
 
     vi.doMock('../../packages/server/src/routes/hermes/tts', () => ({
       ttsRoutes: { routes: vi.fn(() => ttsPublicMiddleware) },
@@ -424,23 +423,18 @@ describe('route registration ordering', () => {
     vi.doMock('../../packages/server/src/routes/hermes/stt', () => ({
       sttProtectedRoutes: { routes: vi.fn(() => sttProtectedMiddleware) },
     }))
-    vi.doMock('../../packages/server/src/routes/hermes/proxy', () => ({
-      proxyRoutes: { routes: vi.fn(() => async () => {}) },
-      proxyMiddleware,
-    }))
 
     const { registerRoutes } = await import('../../packages/server/src/routes/index')
     const use = vi.fn()
     const app = { use }
     const requireAuth = vi.fn(async () => {})
 
-    const returnedProxyMiddleware = registerRoutes(app as any, [requireAuth] as any)
+    registerRoutes(app as any, [requireAuth] as any)
     const mountedMiddleware = use.mock.calls.map(([middleware]) => middleware)
 
     expect(mountedMiddleware.indexOf(ttsPublicMiddleware)).toBeGreaterThanOrEqual(0)
     expect(mountedMiddleware.indexOf(requireAuth)).toBeGreaterThan(mountedMiddleware.indexOf(ttsPublicMiddleware))
     expect(mountedMiddleware.indexOf(sttProtectedMiddleware)).toBeGreaterThan(mountedMiddleware.indexOf(requireAuth))
     expect(mountedMiddleware.indexOf(sttProtectedMiddleware)).toBeGreaterThan(mountedMiddleware.indexOf(ttsProtectedMiddleware))
-    expect(returnedProxyMiddleware).toBe(proxyMiddleware)
   })
 })

--- a/tests/server/studio-mcp-autoinject.test.ts
+++ b/tests/server/studio-mcp-autoinject.test.ts
@@ -59,10 +59,13 @@ describe('studio MCP autoinject', () => {
         HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
         HERMES_WEB_UI_HOME: '/Users/test/.hermes-web-ui',
         HERMES_WEBUI_STATE_DIR: '/Users/test/.hermes-web-ui',
+        HERMES_WEB_UI_PROFILE: 'default',
         HERMES_WEB_UI_MANAGED_MCP: '1',
       },
       enabled: true,
     })
+    const injectedWork = await updateConfigYamlForProfileMock.mock.calls[1][1]({})
+    expect(injectedWork.data.mcp_servers['hermes-studio'].env.HERMES_WEB_UI_PROFILE).toBe('work')
     expect(result.command).toBe(process.execPath)
   })
 
@@ -100,6 +103,7 @@ describe('studio MCP autoinject', () => {
             HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
             HERMES_WEB_UI_HOME: '/Users/test/.hermes-web-ui',
             HERMES_WEBUI_STATE_DIR: '/Users/test/.hermes-web-ui',
+            HERMES_WEB_UI_PROFILE: 'default',
             HERMES_WEB_UI_MANAGED_MCP: '1',
           },
           enabled: false,
@@ -128,6 +132,7 @@ describe('studio MCP autoinject', () => {
             HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
             HERMES_WEB_UI_HOME: '/tmp/hermes-web-ui-home',
             HERMES_WEBUI_STATE_DIR: '/tmp/hermes-web-ui-home',
+            HERMES_WEB_UI_PROFILE: 'default',
             HERMES_WEB_UI_MANAGED_MCP: '1',
           },
           enabled: true,
@@ -162,6 +167,7 @@ describe('studio MCP autoinject', () => {
             HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
             HERMES_WEB_UI_HOME: '/tmp/hermes-web-ui-home',
             HERMES_WEBUI_STATE_DIR: '/tmp/hermes-web-ui-home',
+            HERMES_WEB_UI_PROFILE: 'default',
             HERMES_WEB_UI_MANAGED_MCP: '1',
             HERMES_WEB_UI_TOKEN: 'old-token',
           },

--- a/tests/server/tts-synthesize-controller.test.ts
+++ b/tests/server/tts-synthesize-controller.test.ts
@@ -434,16 +434,10 @@ describe('route registration ordering', () => {
   it('mounts protected synthesize routes after requireAuth', async () => {
     const ttsPublicMiddleware = async () => {}
     const ttsProtectedMiddleware = async () => {}
-    const proxyMiddleware = async () => {}
 
     vi.doMock('../../packages/server/src/routes/hermes/tts', () => ({
       ttsRoutes: { routes: vi.fn(() => ttsPublicMiddleware) },
       ttsProtectedRoutes: { routes: vi.fn(() => ttsProtectedMiddleware) },
-    }))
-
-    vi.doMock('../../packages/server/src/routes/hermes/proxy', () => ({
-      proxyRoutes: { routes: vi.fn(() => async () => {}) },
-      proxyMiddleware,
     }))
 
     const { registerRoutes } = await import('../../packages/server/src/routes/index')
@@ -451,12 +445,11 @@ describe('route registration ordering', () => {
     const app = { use }
     const requireAuth = vi.fn(async () => {})
 
-    const returnedProxyMiddleware = registerRoutes(app as any, [requireAuth] as any)
+    registerRoutes(app as any, [requireAuth] as any)
     const mountedMiddleware = use.mock.calls.map(([middleware]) => middleware)
 
     expect(mountedMiddleware.indexOf(ttsPublicMiddleware)).toBeGreaterThanOrEqual(0)
     expect(mountedMiddleware.indexOf(requireAuth)).toBeGreaterThan(mountedMiddleware.indexOf(ttsPublicMiddleware))
     expect(mountedMiddleware.indexOf(ttsProtectedMiddleware)).toBeGreaterThan(mountedMiddleware.indexOf(requireAuth))
-    expect(returnedProxyMiddleware).toBe(proxyMiddleware)
   })
 })

--- a/tests/server/user-auth.test.ts
+++ b/tests/server/user-auth.test.ts
@@ -121,7 +121,34 @@ describe('user auth tables and middleware', () => {
     '/api/devices/peer-connections',
     '/api/devices/peer-connections/conn-1/terminals',
     '/api/devices/peer-connections/conn-1/exec',
-  ])('allows server token for local MCP device endpoint %s', async (path) => {
+  ])('rejects server token for local MCP device endpoint %s', async (path) => {
+    vi.stubEnv('AUTH_TOKEN', 'server-token')
+    const { auth } = await initUsers()
+    const ctx = {
+      path,
+      headers: { authorization: 'Bearer server-token' },
+      query: {},
+      ip: '127.0.0.1',
+      request: { ip: '127.0.0.1', body: {} },
+      req: { socket: { remoteAddress: '127.0.0.1' } },
+      state: {},
+      status: 200,
+      body: null,
+    } as any
+    const next = vi.fn(async () => {})
+
+    await auth.requireUserJwt(ctx, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(ctx.status).toBe(401)
+    expect(ctx.body).toEqual({ error: 'Unauthorized' })
+    expect(ctx.state.serverTokenAuth).toBeUndefined()
+  })
+
+  it.each([
+    '/api/hermes/media/apikey-image-generate',
+    '/api/hermes/media/grok-image-to-video',
+  ])('still allows server token for local media agent endpoint %s', async (path) => {
     vi.stubEnv('AUTH_TOKEN', 'server-token')
     const { auth } = await initUsers()
     const ctx = {
@@ -183,6 +210,28 @@ describe('user auth tables and middleware', () => {
     expect(ctx.body).toEqual({ error: 'Unauthorized' })
   })
 
+  it('requires super admin privileges after a valid user token reaches MCP device routes', async () => {
+    const { auth } = await initUsers()
+    const next = vi.fn(async () => {})
+    const adminCtx = {
+      state: { user: { id: 1, username: 'ops', role: 'admin' } },
+      status: 200,
+      body: null,
+    } as any
+    const superCtx = {
+      state: { user: { id: 2, username: 'root', role: 'super_admin' } },
+      status: 200,
+      body: null,
+    } as any
+
+    await auth.requireSuperAdmin(adminCtx, vi.fn(async () => {}))
+    await auth.requireSuperAdmin(superCtx, next)
+
+    expect(adminCtx.status).toBe(403)
+    expect(adminCtx.body).toEqual({ error: 'Super administrator privileges are required' })
+    expect(next).toHaveBeenCalledOnce()
+  })
+
   it('ignores stale profile headers for the aggregate available-models endpoint', async () => {
     const { auth } = await initUsers()
     const ctx = {
@@ -227,6 +276,28 @@ describe('user auth tables and middleware', () => {
     expect(payload?.role).toBe('super_admin')
 
     expect(auth.verifyUserJwt(token, 'wrong', 1000)).toBeNull()
+  })
+
+  it('signs model run JWTs with the same payload shape and a one hour expiry', async () => {
+    const { auth } = await initUsers()
+    const token = auth.signUserJwt(
+      { id: 1, username: 'admin', role: 'super_admin' },
+      'secret',
+      1000,
+      auth.MODEL_RUN_EXPIRES_SECONDS,
+    )
+
+    const payload = auth.verifyUserJwt(token, 'secret', 1000)
+    expect(payload).toMatchObject({
+      sub: '1',
+      username: 'admin',
+      role: 'super_admin',
+      type: 'access',
+      aud: 'hermes-web-ui',
+      iat: 1,
+      exp: 3601,
+    })
+    expect(auth.verifyUserJwt(token, 'secret', 1000 + 60 * 60 * 1000)).toBeNull()
   })
 
   it('authenticates JWTs passed as query tokens for download and websocket URLs', async () => {


### PR DESCRIPTION
## Summary
- add outbound global-agent relay client/server flow and expose global-agent sessions in chat UI
- add HTTP chat-run/OpenAPI/MCP docs improvements and remove stale v1/proxy docs
- add MCU login endpoint that authenticates existing users, returns token/profiles, and connects to the provided relay URL

## Tests
- npm run test -- tests/server/mcu-login-controller.test.ts tests/server/outbound-relay-client.test.ts
- npm run test -- tests/server/chat-run-api-controller.test.ts tests/server/api-docs-controller.test.ts
- npx tsc -p packages/server/tsconfig.json --noEmit --pretty false
- npx vue-tsc -b --pretty false
- npm run openapi:generate