### PR TITLE
[codex] support deleting v12 provider entries

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3635,6 +3635,29 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "providerKey",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "string"
+              ]
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "providers",
+                "custom_providers"
+              ]
+            }
           }
         ]
       }

--- a/packages/client/src/api/hermes/system.ts
+++ b/packages/client/src/api/hermes/system.ts
@@ -98,6 +98,9 @@ export interface AvailableModelGroup {
   builtin?: boolean
   /** Env var used by Hermes to override this provider's base URL. If present, the preset URL is editable. */
   base_url_env?: string
+  /** Config source for custom providers. Dict-backed providers can be deleted from providers:<key>. */
+  provider_source?: 'custom_providers' | 'providers'
+  provider_key?: string
   /** 可选：模型 ID -> 元数据（preview/disabled/alias）。alias 仅用于 Web UI 展示。 */
   model_meta?: Record<string, { preview?: boolean; disabled?: boolean; alias?: string }>
 }
@@ -232,8 +235,11 @@ export async function addCustomProvider(data: CustomProvider): Promise<void> {
   })
 }
 
-export async function removeCustomProvider(name: string): Promise<void> {
-  await request(`/api/hermes/config/providers/${encodeURIComponent(name)}`, {
+export async function removeCustomProvider(name: string, options: { source?: 'custom_providers' | 'providers'; providerKey?: string } = {}): Promise<void> {
+  const query = new URLSearchParams()
+  if (options.source) query.set('source', options.source)
+  if (options.providerKey) query.set('providerKey', options.providerKey)
+  await request(`/api/hermes/config/providers/${encodeURIComponent(name)}${query.size ? `?${query}` : ''}`, {
     method: 'DELETE',
   })
 }

--- a/packages/client/src/components/hermes/models/ProviderCard.vue
+++ b/packages/client/src/components/hermes/models/ProviderCard.vue
@@ -137,7 +137,10 @@ async function handleDelete() {
           chatStore.clearProviderFromSessions('copilot')
           await modelsStore.fetchProviders()
         } else {
-          await modelsStore.removeProvider(props.provider.provider)
+          await modelsStore.removeProvider(props.provider.provider, {
+            source: props.provider.provider_source,
+            providerKey: props.provider.provider_key,
+          })
         }
         // 删完之后若已没有默认模型，自动从剩余 provider 里挑一个，避免 chat 页
         // "无默认模型"的尴尬态。与 hermes CLI `model` 子命令的隐含行为对齐。

--- a/packages/client/src/stores/hermes/models.ts
+++ b/packages/client/src/stores/hermes/models.ts
@@ -77,8 +77,8 @@ export const useModelsStore = defineStore('models', () => {
     await useAppStore().reloadModels()
   }
 
-  async function removeProvider(name: string) {
-    await systemApi.removeCustomProvider(name)
+  async function removeProvider(name: string, options: { source?: 'custom_providers' | 'providers'; providerKey?: string } = {}) {
+    await systemApi.removeCustomProvider(name, options)
     await fetchProviders()
     await useAppStore().reloadModels()
   }

--- a/packages/server/src/controllers/hermes/media.ts
+++ b/packages/server/src/controllers/hermes/media.ts
@@ -4,6 +4,7 @@ import { dirname, extname, isAbsolute, join, resolve } from 'path'
 import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../../services/hermes/hermes-profile'
 import { config } from '../../config'
 import { readConfigYamlForProfile } from '../../services/config-helpers'
+import { getCompatibleCustomProviders } from '../../services/hermes/custom-providers-compat'
 
 const XAI_VIDEO_GENERATIONS_URL = 'https://api.x.ai/v1/videos/generations'
 const XAI_VIDEO_STATUS_URL = 'https://api.x.ai/v1/videos'
@@ -81,9 +82,7 @@ function buildApiUrl(baseUrl: string, pathWithV1: string): string {
 
 async function resolveFunCodexProvider(profile: string): Promise<FunCodexProvider | null> {
   const hermesConfig = await readConfigYamlForProfile(profile)
-  const customProviders = Array.isArray(hermesConfig.custom_providers)
-    ? hermesConfig.custom_providers as any[]
-    : []
+  const customProviders = getCompatibleCustomProviders(hermesConfig)
   const provider = customProviders.find(entry => String(entry?.name || '').trim() === APIKEY_IMAGE_PROVIDER)
   const apiKey = String(provider?.api_key || '').trim()
   const baseUrl = String(provider?.base_url || '').trim()

--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -21,7 +21,7 @@ import {
 const PROVIDER_MODEL_CATALOG = buildProviderModelMap()
 
 type ModelMeta = { preview?: boolean; disabled?: boolean; alias?: string }
-type AvailableGroup = { provider: string; label: string; base_url: string; models: string[]; api_key: string; api_mode?: 'chat_completions' | 'codex_responses' | 'anthropic_messages'; builtin?: boolean; model_meta?: Record<string, ModelMeta>; available_models?: string[]; base_url_env?: string }
+type AvailableGroup = { provider: string; label: string; base_url: string; models: string[]; api_key: string; api_mode?: 'chat_completions' | 'codex_responses' | 'anthropic_messages'; builtin?: boolean; model_meta?: Record<string, ModelMeta>; available_models?: string[]; base_url_env?: string; provider_source?: 'custom_providers' | 'providers'; provider_key?: string }
 type ModelVisibility = Record<string, ModelVisibilityRule>
 type CustomModels = Record<string, string[]>
 
@@ -350,12 +350,12 @@ async function buildAvailableForProfile(
 
   const groups: AvailableGroup[] = []
   const seenProviders = new Set<string>()
-  const addGroup = (provider: string, label: string, base_url: string, models: string[], api_key: string, builtin?: boolean, model_meta?: Record<string, ModelMeta>) => {
+  const addGroup = (provider: string, label: string, base_url: string, models: string[], api_key: string, builtin?: boolean, model_meta?: Record<string, ModelMeta>, extra?: Pick<AvailableGroup, 'provider_source' | 'provider_key'>) => {
     if (seenProviders.has(provider)) return
     seenProviders.add(provider)
     const availableModels = [...new Set(models)]
     const apiMode = providerApiMode(provider)
-    groups.push({ provider, label, base_url, models: availableModels, available_models: availableModels, api_key, ...(apiMode ? { api_mode: apiMode } : {}), ...(builtin ? { builtin: true } : {}), ...(model_meta ? { model_meta } : {}) })
+    groups.push({ provider, label, base_url, models: availableModels, available_models: availableModels, api_key, ...(apiMode ? { api_mode: apiMode } : {}), ...(builtin ? { builtin: true } : {}), ...(model_meta ? { model_meta } : {}), ...(extra?.provider_source ? { provider_source: extra.provider_source } : {}), ...(extra?.provider_key ? { provider_key: extra.provider_key } : {}) })
   }
 
   const copilotEnabled = appConfig.copilotEnabled === true
@@ -410,13 +410,13 @@ async function buildAvailableForProfile(
       let models = [...new Set([cp.model, ...configuredModels, ...builtinCatalogModels].filter(Boolean) as string[])]
       const cachedModels = getCachedProviderModels(modelCatalogCache, providerKey, baseUrl)
       if (cachedModels) models = [...new Set([...models, ...cachedModels])]
-      return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '', builtin: isBuiltinProviderKey(providerKey) }
+      return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '', builtin: isBuiltinProviderKey(providerKey), provider_source: cp.source, provider_key: cp.provider_key }
     }),
   )
   for (const result of customFetches) {
     if (result.status === 'fulfilled' && result.value?.models.length) {
-      const { providerKey, label, base_url, models, api_key, builtin } = result.value
-      addGroup(providerKey, label, base_url, models, api_key, builtin)
+      const { providerKey, label, base_url, models, api_key, builtin, provider_source, provider_key } = result.value
+      addGroup(providerKey, label, base_url, models, api_key, builtin, undefined, { provider_source, provider_key })
     }
   }
 
@@ -553,12 +553,12 @@ export async function getAvailable(ctx: any) {
       const match = envContent.match(new RegExp(`^${key}\\s*=\\s*(.+)`, 'm'))
       return match?.[1]?.trim() || ''
     }
-    const addGroup = (provider: string, label: string, base_url: string, models: string[], api_key: string, builtin?: boolean, model_meta?: Record<string, ModelMeta>) => {
+    const addGroup = (provider: string, label: string, base_url: string, models: string[], api_key: string, builtin?: boolean, model_meta?: Record<string, ModelMeta>, extra?: Pick<AvailableGroup, 'provider_source' | 'provider_key'>) => {
       if (seenProviders.has(provider)) return
       seenProviders.add(provider)
       const availableModels = [...models]
       const apiMode = providerApiMode(provider)
-      groups.push({ provider, label, base_url, models: availableModels, available_models: availableModels, api_key, ...(apiMode ? { api_mode: apiMode } : {}), ...(builtin ? { builtin: true } : {}), ...(model_meta ? { model_meta } : {}) })
+      groups.push({ provider, label, base_url, models: availableModels, available_models: availableModels, api_key, ...(apiMode ? { api_mode: apiMode } : {}), ...(builtin ? { builtin: true } : {}), ...(model_meta ? { model_meta } : {}), ...(extra?.provider_source ? { provider_source: extra.provider_source } : {}), ...(extra?.provider_key ? { provider_key: extra.provider_key } : {}) })
     }
 
     const isOAuthAuthorized = (providerKey: string): boolean => {
@@ -671,15 +671,15 @@ export async function getAvailable(ctx: any) {
         if (cp.api_key) {
           try { const fetched = await fetchProviderModels(baseUrl, cp.api_key); if (fetched.length > 0) models = [...new Set([...models, ...fetched])] } catch { }
         }
-        return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '', builtin: isBuiltinProviderKey(providerKey) }
+        return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '', builtin: isBuiltinProviderKey(providerKey), provider_source: cp.source, provider_key: cp.provider_key }
       }),
     )
 
     for (const result of customFetches) {
       const value = (result as { value?: any }).value
       if (value) {
-        const { providerKey, label, base_url, models, api_key: cpApiKey, builtin: cpBuiltin } = value
-        addGroup(providerKey, label, base_url, models, cpApiKey, cpBuiltin)
+        const { providerKey, label, base_url, models, api_key: cpApiKey, builtin: cpBuiltin, provider_source, provider_key } = value
+        addGroup(providerKey, label, base_url, models, cpApiKey, cpBuiltin, undefined, { provider_source, provider_key })
       }
     }
 

--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { getActiveEnvPath, getActiveAuthPath, getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../../services/hermes/hermes-profile'
 import { readConfigYaml, readConfigYamlForProfile, updateConfigYaml, updateConfigYamlForProfile, fetchProviderModels, buildModelGroups, PROVIDER_ENV_MAP } from '../../services/config-helpers'
+import { getCompatibleCustomProviders } from '../../services/hermes/custom-providers-compat'
 import { buildProviderModelMap, PROVIDER_PRESETS } from '../../shared/providers'
 import { getCopilotModelsDetailed, resolveCopilotOAuthToken, type CopilotModelMeta } from '../../services/hermes/copilot-models'
 import { readAppConfig, writeAppConfig, type ModelVisibilityRule } from '../../services/app-config'
@@ -317,9 +318,9 @@ async function buildAvailableForProfile(
     currentDefault = String(modelSection.default || '').trim()
     currentDefaultProvider = String(modelSection.provider || '').trim()
     if (currentDefaultProvider === 'custom' && currentDefault) {
-      const cps = Array.isArray(config.custom_providers) ? config.custom_providers as any[] : []
+      const cps = getCompatibleCustomProviders(config)
       const match = cps.find(
-        (cp: any) => cp.base_url?.replace(/\/+$/, '') === String(modelSection.base_url || '').replace(/\/+$/, '')
+        (cp) => cp.base_url?.replace(/\/+$/, '') === String(modelSection.base_url || '').replace(/\/+$/, '')
           && cp.model === currentDefault,
       )
       if (match) currentDefaultProvider = providerKeyForCustom(String(match.name || ''))
@@ -391,9 +392,7 @@ async function buildAvailableForProfile(
     }
   }
 
-  const customProviders = Array.isArray(config.custom_providers)
-    ? config.custom_providers as Array<{ name: string; base_url: string; model: string; api_key?: string }>
-    : []
+  const customProviders = getCompatibleCustomProviders(config)
   const customFetches = await Promise.allSettled(
     customProviders.map(async cp => {
       if (!cp.base_url) return null
@@ -404,7 +403,11 @@ async function buildAvailableForProfile(
       const builtinCatalogModels = isBuiltinProviderKey(providerKey)
         ? PROVIDER_MODEL_CATALOG[builtinProviderKey] || builtinPreset?.models || []
         : []
-      let models = [...new Set([cp.model, ...builtinCatalogModels].filter(Boolean))]
+      // Pull configured models from the v12+ providers.<name>.models dict (if any)
+      // alongside the legacy single `model` field; both contribute to what the
+      // UI shows. `models` is normalized to a dict shape regardless of source.
+      const configuredModels = cp.models ? Object.keys(cp.models) : []
+      let models = [...new Set([cp.model, ...configuredModels, ...builtinCatalogModels].filter(Boolean) as string[])]
       const cachedModels = getCachedProviderModels(modelCatalogCache, providerKey, baseUrl)
       if (cachedModels) models = [...new Set([...models, ...cachedModels])]
       return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '', builtin: isBuiltinProviderKey(providerKey) }
@@ -519,9 +522,9 @@ export async function getAvailable(ctx: any) {
       currentDefault = String(modelSection.default || '').trim()
       currentDefaultProvider = String(modelSection.provider || '').trim()
       // When hermes CLI sets provider: custom, resolve to custom:name
-      // by matching base_url + model against custom_providers
+      // by matching base_url + model against custom providers (v12 dict + legacy list).
       if (currentDefaultProvider === 'custom' && currentDefault) {
-        const cps = Array.isArray(config.custom_providers) ? config.custom_providers as any[] : []
+        const cps = getCompatibleCustomProviders(config) as any[]
         const match = cps.find(
           (cp: any) => cp.base_url?.replace(/\/+$/, '') === String(modelSection.base_url || '').replace(/\/+$/, '')
             && cp.model === currentDefault,
@@ -656,18 +659,17 @@ export async function getAvailable(ctx: any) {
       }
     }
 
-    const customProviders = Array.isArray(config.custom_providers)
-      ? config.custom_providers as Array<{ name: string; base_url: string; model: string; api_key?: string }>
-      : []
+    const customProviders = getCompatibleCustomProviders(config)
 
     const customFetches = await Promise.allSettled(
       customProviders.map(async cp => {
         if (!cp.base_url) return null
         const providerKey = `custom:${cp.name.trim().toLowerCase().replace(/ /g, '-')}`
         const baseUrl = cp.base_url.replace(/\/+$/, '')
-        let models = [cp.model]
+        const configuredModels = cp.models ? Object.keys(cp.models) : []
+        let models = [...new Set([cp.model, ...configuredModels].filter(Boolean) as string[])]
         if (cp.api_key) {
-          try { const fetched = await fetchProviderModels(baseUrl, cp.api_key); if (fetched.length > 0) models = [...new Set([cp.model, ...fetched])] } catch { }
+          try { const fetched = await fetchProviderModels(baseUrl, cp.api_key); if (fetched.length > 0) models = [...new Set([...models, ...fetched])] } catch { }
         }
         return { providerKey, label: cp.name, base_url: baseUrl, models, api_key: cp.api_key || '', builtin: isBuiltinProviderKey(providerKey) }
       }),

--- a/packages/server/src/controllers/hermes/providers.ts
+++ b/packages/server/src/controllers/hermes/providers.ts
@@ -3,6 +3,7 @@ import { writeFile } from 'fs/promises'
 import { join } from 'path'
 import { getActiveProfileName, getProfileDir } from '../../services/hermes/hermes-profile'
 import { updateConfigYamlForProfile, saveEnvValueForProfile, PROVIDER_ENV_MAP } from '../../services/config-helpers'
+import { getCompatibleCustomProviders, normalizeCustomProviderEntry } from '../../services/hermes/custom-providers-compat'
 import { PROVIDER_PRESETS } from '../../shared/providers'
 import { logger } from '../../services/logger'
 
@@ -58,6 +59,29 @@ function shouldPersistBuiltinBaseUrl(poolKey: string, requestedBaseUrl: string):
   const presetBaseUrl = PROVIDER_PRESETS.find(p => p.value === poolKey)?.base_url || ''
   if (!requestedBaseUrl || !presetBaseUrl) return !!requestedBaseUrl
   return normalizeBaseUrl(requestedBaseUrl) !== normalizeBaseUrl(presetBaseUrl)
+}
+
+function providerKeyForCustomName(name: string): string {
+  return `custom:${String(name || '').trim().toLowerCase().replace(/ /g, '-')}`
+}
+
+function findLegacyCustomProviderIndex(config: any, poolKey: string): number {
+  return Array.isArray(config.custom_providers)
+    ? (config.custom_providers as any[]).findIndex((e: any) => providerKeyForCustomName(e?.name) === poolKey)
+    : -1
+}
+
+function findProviderDictKey(config: any, poolKey: string, requestedProviderKey = ''): string {
+  const dict = config.providers
+  if (!dict || typeof dict !== 'object' || Array.isArray(dict)) return ''
+  if (requestedProviderKey && Object.prototype.hasOwnProperty.call(dict, requestedProviderKey)) {
+    return requestedProviderKey
+  }
+  for (const [key, entry] of Object.entries(dict)) {
+    const normalized = normalizeCustomProviderEntry(entry, key, 'providers')
+    if (normalized && providerKeyForCustomName(normalized.name) === poolKey) return key
+  }
+  return ''
 }
 
 export async function create(ctx: any) {
@@ -191,18 +215,34 @@ export async function update(ctx: any) {
 
 export async function remove(ctx: any) {
   const poolKey = decodeURIComponent(ctx.params.poolKey)
+  const query = ctx.query as { source?: string; providerKey?: string }
+  const requestedSource = query?.source === 'providers' || query?.source === 'custom_providers'
+    ? query.source
+    : ''
+  const requestedProviderKey = typeof query?.providerKey === 'string' ? query.providerKey.trim() : ''
   try {
     const profile = requestedProfile(ctx)
     const isCustom = poolKey.startsWith('custom:')
     const removed = await updateConfigYamlForProfile(profile, async (config) => {
       if (isCustom) {
-        const idx = Array.isArray(config.custom_providers)
-          ? (config.custom_providers as any[]).findIndex((e: any) => {
-            return `custom:${e.name.trim().toLowerCase().replace(/ /g, '-')}` === poolKey
-          })
-          : -1
-        if (idx === -1) return { data: config, result: false, write: false }
-        ;(config.custom_providers as any[]).splice(idx, 1)
+        const removeLegacy = requestedSource !== 'providers'
+        const removeDict = requestedSource !== 'custom_providers'
+        let didRemove = false
+        if (removeLegacy) {
+          const idx = findLegacyCustomProviderIndex(config, poolKey)
+          if (idx !== -1) {
+            ;(config.custom_providers as any[]).splice(idx, 1)
+            didRemove = true
+          }
+        }
+        if (!didRemove && removeDict) {
+          const dictKey = findProviderDictKey(config, poolKey, requestedProviderKey)
+          if (dictKey) {
+            delete config.providers[dictKey]
+            didRemove = true
+          }
+        }
+        if (!didRemove) return { data: config, result: false, write: false }
       } else {
         const envMapping = PROVIDER_ENV_MAP[poolKey]
         if (envMapping?.api_key_env) {
@@ -213,12 +253,12 @@ export async function remove(ctx: any) {
         }
       }
       if (config.model?.provider === poolKey) {
-        const remaining = Array.isArray(config.custom_providers) ? config.custom_providers as any[] : []
+        const remaining = getCompatibleCustomProviders(config)
         if (remaining.length > 0) {
           const fallbackCp = remaining[0]
-          const fallbackKey = `custom:${fallbackCp.name.trim().toLowerCase().replace(/ /g, '-')}`
+          const fallbackKey = providerKeyForCustomName(fallbackCp.name)
           if (typeof config.model !== 'object' || config.model === null) { config.model = {} }
-          config.model.default = fallbackCp.model
+          config.model.default = fallbackCp.model || Object.keys(fallbackCp.models || {})[0] || ''
           config.model.provider = fallbackKey
           delete config.model.base_url
           delete config.model.api_key

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -7,6 +7,7 @@ import { delimiter, dirname, join } from 'path'
 import { promisify } from 'util'
 import { getWebUiHome } from '../config'
 import { PROVIDER_ENV_MAP, readConfigYamlForProfile, safeReadFile } from './config-helpers'
+import { getCompatibleCustomProviders } from './hermes/custom-providers-compat'
 import { registerClaudeCodeProxyTarget } from './agent-runner/proxies/claude-code-proxy'
 import { registerCodexProxyTarget } from './agent-runner/proxies/codex-proxy'
 import type { ApiMode } from './agent-runner/types'
@@ -481,7 +482,7 @@ async function resolveStoredProviderLaunchInput(
   const preset = PROVIDER_PRESETS.find(item => item.value === normalizedProvider)
   const candidates = providerLookupCandidates(provider)
 
-  const customProviders = Array.isArray(config.custom_providers) ? config.custom_providers as any[] : []
+  const customProviders = getCompatibleCustomProviders(config)
   const customEntry = customProviders.find((entry) => {
     const name = slugProviderName(String(entry?.name || ''))
     return candidates.includes(`custom:${name}`) || candidates.includes(`custom_${name}`) || candidates.includes(name)

--- a/packages/server/src/services/config-helpers.ts
+++ b/packages/server/src/services/config-helpers.ts
@@ -3,6 +3,7 @@ import { readdir, stat } from 'fs/promises'
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { getActiveProfileDir, getActiveConfigPath, getActiveEnvPath, getProfileDir } from './hermes/hermes-profile'
+import { getCompatibleCustomProviders } from './hermes/custom-providers-compat'
 import { logger } from './logger'
 import { safeFileStore } from './safe-file-store'
 
@@ -262,22 +263,26 @@ export function buildModelGroups(config: Record<string, any>): { default: string
     defaultModel = modelSection.trim()
   }
 
-  // 2. Extract custom_providers section
-  const customProviders = config.custom_providers
-  if (Array.isArray(customProviders)) {
-    const customModels: ModelInfo[] = []
-    for (const entry of customProviders) {
-      if (entry && typeof entry === 'object') {
-        const cName = String(entry.name || '').trim()
-        const cModel = String(entry.model || '').trim()
-        if (cName && cModel) {
-          customModels.push({ id: cModel, label: `${cName}: ${cModel}` })
-        }
-      }
+  // 2. Aggregate custom providers from both schemas (legacy list + v12+ dict).
+  const customProviders = getCompatibleCustomProviders(config)
+  const customModels: ModelInfo[] = []
+  for (const entry of customProviders) {
+    const cName = entry.name.trim()
+    if (!cName) continue
+    const seen = new Set<string>()
+    const pushModel = (modelId: string) => {
+      const id = modelId.trim()
+      if (!id || seen.has(id)) return
+      seen.add(id)
+      customModels.push({ id, label: `${cName}: ${id}` })
     }
-    if (customModels.length > 0) {
-      groups.push({ provider: 'Custom', models: customModels })
+    if (entry.model) pushModel(entry.model)
+    if (entry.models && typeof entry.models === 'object') {
+      for (const id of Object.keys(entry.models)) pushModel(id)
     }
+  }
+  if (customModels.length > 0) {
+    groups.push({ provider: 'Custom', models: customModels })
   }
 
   return { default: defaultModel, groups }

--- a/packages/server/src/services/hermes/custom-providers-compat.ts
+++ b/packages/server/src/services/hermes/custom-providers-compat.ts
@@ -40,6 +40,7 @@ const CAMEL_ALIASES: Record<string, string> = {
 export interface NormalizedCustomProvider {
   name: string
   base_url: string
+  source: 'custom_providers' | 'providers'
   provider_key?: string
   api_key?: string
   key_env?: string
@@ -70,6 +71,7 @@ function looksLikeUrl(value: string): boolean {
 export function normalizeCustomProviderEntry(
   entry: any,
   providerKey: string = '',
+  source: 'custom_providers' | 'providers' = providerKey ? 'providers' : 'custom_providers',
 ): NormalizedCustomProvider | null {
   if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null
 
@@ -111,7 +113,7 @@ export function normalizeCustomProviderEntry(
   }
   if (!name) return null
 
-  const normalized: NormalizedCustomProvider = { name, base_url: baseUrl }
+  const normalized: NormalizedCustomProvider = { name, base_url: baseUrl, source }
 
   if (providerKey && providerKey.trim()) {
     normalized.provider_key = providerKey.trim()
@@ -215,14 +217,14 @@ export function getCompatibleCustomProviders(config: any): NormalizedCustomProvi
   if (legacy !== undefined) {
     if (!Array.isArray(legacy)) return [] // matches Agent: malformed legacy block bails out entirely
     for (const entry of legacy) {
-      appendIfNew(normalizeCustomProviderEntry(entry))
+      appendIfNew(normalizeCustomProviderEntry(entry, '', 'custom_providers'))
     }
   }
 
   const dict = config.providers
   if (dict && typeof dict === 'object' && !Array.isArray(dict)) {
     for (const [key, entry] of Object.entries(dict)) {
-      appendIfNew(normalizeCustomProviderEntry(entry, key))
+      appendIfNew(normalizeCustomProviderEntry(entry, key, 'providers'))
     }
   }
 

--- a/packages/server/src/services/hermes/custom-providers-compat.ts
+++ b/packages/server/src/services/hermes/custom-providers-compat.ts
@@ -1,0 +1,230 @@
+/**
+ * Compatibility layer for the two `config.yaml` provider schemas used by Hermes Agent.
+ *
+ * Hermes Agent's v12 migration converts `custom_providers:` (a list of provider
+ * entries) into `providers:` (a dict keyed by provider name) and deletes the list.
+ * Agent itself ships a compatibility helper, `get_compatible_custom_providers()`,
+ * so every consumer in core sees a unified list view across both schemas:
+ *
+ *   https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/config.py
+ *
+ * Studio historically only read the legacy `custom_providers:` list, which makes
+ * v12+ dict-shaped providers invisible in the model picker, catalog, and context
+ * lookups (Issue #1570). This helper mirrors Agent's behavior so Studio can read
+ * both shapes; write paths intentionally still target the legacy list (that's
+ * the canonical write surface Studio's UI manipulates today).
+ */
+
+const KNOWN_KEYS = new Set([
+  'name', 'api', 'url', 'base_url',
+  'api_key', 'key_env', 'api_key_env',
+  'api_mode', 'transport',
+  'model', 'default_model',
+  'models',
+  'context_length', 'rate_limit_delay',
+  'request_timeout_seconds', 'stale_timeout_seconds',
+  'discover_models', 'extra_body',
+])
+
+const CAMEL_ALIASES: Record<string, string> = {
+  apiKey: 'api_key',
+  baseUrl: 'base_url',
+  apiMode: 'api_mode',
+  keyEnv: 'key_env',
+  apiKeyEnv: 'key_env',
+  defaultModel: 'default_model',
+  contextLength: 'context_length',
+  rateLimitDelay: 'rate_limit_delay',
+}
+
+export interface NormalizedCustomProvider {
+  name: string
+  base_url: string
+  provider_key?: string
+  api_key?: string
+  key_env?: string
+  api_mode?: string
+  model?: string
+  models?: Record<string, any>
+  context_length?: number
+  rate_limit_delay?: number
+  discover_models?: boolean
+  extra_body?: Record<string, any>
+}
+
+function looksLikeUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return !!url.protocol && !!url.host
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Translate one provider entry (from either schema) into the unified record
+ * shape Studio's read paths expect. Returns `null` if the entry has no usable
+ * `base_url` or `name` — matching `_normalize_custom_provider_entry()`'s
+ * silent-drop semantics in Agent.
+ */
+export function normalizeCustomProviderEntry(
+  entry: any,
+  providerKey: string = '',
+): NormalizedCustomProvider | null {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null
+
+  const e: Record<string, any> = { ...entry }
+
+  // `api_key_env` is a documented snake_case alias for `key_env` (see
+  // upstream guide for Azure Foundry). Normalize before applying camelCase
+  // aliases so the canonical field always wins.
+  if ('api_key_env' in e && !('key_env' in e)) {
+    e.key_env = e.api_key_env
+  }
+
+  for (const [camel, snake] of Object.entries(CAMEL_ALIASES)) {
+    if (camel in e && !(snake in e)) {
+      e[snake] = e[camel]
+    }
+  }
+
+  // base_url: try base_url, then url, then api — accept first valid URL.
+  let baseUrl = ''
+  for (const key of ['base_url', 'url', 'api'] as const) {
+    const raw = e[key]
+    if (typeof raw === 'string' && raw.trim()) {
+      const candidate = raw.trim()
+      if (looksLikeUrl(candidate)) {
+        baseUrl = candidate
+        break
+      }
+    }
+  }
+  if (!baseUrl) return null
+
+  // name: prefer entry.name, fall back to dict key.
+  let name = ''
+  if (typeof e.name === 'string' && e.name.trim()) {
+    name = e.name.trim()
+  } else if (providerKey && providerKey.trim()) {
+    name = providerKey.trim()
+  }
+  if (!name) return null
+
+  const normalized: NormalizedCustomProvider = { name, base_url: baseUrl }
+
+  if (providerKey && providerKey.trim()) {
+    normalized.provider_key = providerKey.trim()
+  }
+
+  if (typeof e.api_key === 'string' && e.api_key.trim()) {
+    normalized.api_key = e.api_key.trim()
+  }
+  if (typeof e.key_env === 'string' && e.key_env.trim()) {
+    normalized.key_env = e.key_env.trim()
+  }
+
+  const apiMode = e.api_mode || e.transport
+  if (typeof apiMode === 'string' && apiMode.trim()) {
+    normalized.api_mode = apiMode.trim()
+  }
+
+  const modelName = e.model || e.default_model
+  if (typeof modelName === 'string' && modelName.trim()) {
+    normalized.model = modelName.trim()
+  }
+
+  // models: accept dict (v12+ canonical) or list (hand-edited / legacy).
+  if (e.models && typeof e.models === 'object' && !Array.isArray(e.models)) {
+    if (Object.keys(e.models).length > 0) {
+      normalized.models = e.models
+    }
+  } else if (Array.isArray(e.models) && e.models.length > 0) {
+    const dict: Record<string, any> = {}
+    for (const m of e.models) {
+      if (typeof m === 'string' && m.trim()) {
+        dict[m] = {}
+      }
+    }
+    if (Object.keys(dict).length > 0) {
+      normalized.models = dict
+    }
+  }
+
+  if (typeof e.context_length === 'number' && Number.isInteger(e.context_length) && e.context_length > 0) {
+    normalized.context_length = e.context_length
+  }
+  if (typeof e.rate_limit_delay === 'number' && e.rate_limit_delay >= 0) {
+    normalized.rate_limit_delay = e.rate_limit_delay
+  }
+  if (typeof e.discover_models === 'boolean') {
+    normalized.discover_models = e.discover_models
+  }
+  if (e.extra_body && typeof e.extra_body === 'object' && !Array.isArray(e.extra_body)) {
+    normalized.extra_body = { ...e.extra_body }
+  }
+
+  // Surface unknown keys in the logs — same intent as Agent's warning, kept
+  // soft so unfamiliar fields don't break callers.
+  const unknown = Object.keys(e).filter(k => !KNOWN_KEYS.has(k) && !(k in CAMEL_ALIASES))
+  if (unknown.length > 0) {
+    // Use console here to avoid the logger import cycle; this branch is rare
+    // and only fires for hand-edited configs.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[config-helpers] providers.${providerKey || '?'}: unknown config keys ignored: ${unknown.join(', ')}`,
+    )
+  }
+
+  return normalized
+}
+
+/**
+ * Return the full set of custom providers visible to Studio, drawn from both
+ * schemas with name/base_url/model deduplication. Mirrors Hermes Agent's
+ * `get_compatible_custom_providers()`.
+ *
+ * Order: legacy list entries first, then v12+ dict entries — matching Agent's
+ * traversal order so a hand-written list entry takes precedence over a
+ * dict entry with the same identity.
+ */
+export function getCompatibleCustomProviders(config: any): NormalizedCustomProvider[] {
+  if (!config || typeof config !== 'object') return []
+
+  const out: NormalizedCustomProvider[] = []
+  const seenProviderKeys = new Set<string>()
+  const seenIdentityTriples = new Set<string>()
+
+  const appendIfNew = (entry: NormalizedCustomProvider | null): void => {
+    if (!entry) return
+    const providerKey = (entry.provider_key || '').trim().toLowerCase()
+    const name = entry.name.trim().toLowerCase()
+    const baseUrl = entry.base_url.trim().replace(/\/+$/, '').toLowerCase()
+    const model = (entry.model || '').trim().toLowerCase()
+    const triple = `${name}|${baseUrl}|${model}`
+
+    if (providerKey && seenProviderKeys.has(providerKey)) return
+    if (name && baseUrl && seenIdentityTriples.has(triple)) return
+
+    out.push(entry)
+    if (providerKey) seenProviderKeys.add(providerKey)
+    if (name && baseUrl) seenIdentityTriples.add(triple)
+  }
+
+  const legacy = config.custom_providers
+  if (legacy !== undefined) {
+    if (!Array.isArray(legacy)) return [] // matches Agent: malformed legacy block bails out entirely
+    for (const entry of legacy) {
+      appendIfNew(normalizeCustomProviderEntry(entry))
+    }
+  }
+
+  const dict = config.providers
+  if (dict && typeof dict === 'object' && !Array.isArray(dict)) {
+    for (const [key, entry] of Object.entries(dict)) {
+      appendIfNew(normalizeCustomProviderEntry(entry, key))
+    }
+  }
+
+  return out
+}

--- a/packages/server/src/services/hermes/model-catalog-cache.ts
+++ b/packages/server/src/services/hermes/model-catalog-cache.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { config } from '../../config'
 import { PROVIDER_PRESETS } from '../../shared/providers'
 import { fetchProviderModels, PROVIDER_ENV_MAP, readConfigYamlForProfile } from '../config-helpers'
+import { getCompatibleCustomProviders } from './custom-providers-compat'
 import { logger } from '../logger'
 import { safeFileStore } from '../safe-file-store'
 import { getProfileDir, listProfileNamesFromDisk } from './hermes-profile'
@@ -267,19 +268,23 @@ async function collectRefreshCandidates(): Promise<RefreshCandidate[]> {
       })
     }
 
-    const customProviders = Array.isArray(configYaml.custom_providers) ? configYaml.custom_providers as any[] : []
+    const customProviders = getCompatibleCustomProviders(configYaml)
     for (const cp of customProviders) {
-      const name = String(cp?.name || '').trim()
-      const baseUrl = normalizeCatalogBaseUrl(cp?.base_url || '')
+      const name = cp.name
+      const baseUrl = normalizeCatalogBaseUrl(cp.base_url)
       if (!name || !baseUrl) continue
       const provider = providerKeyForCustom(name)
       const presetModels = presetsByProvider.get(name)?.models || []
+      // Respect the configured `models:` whitelist (v12+ dict) when present —
+      // those entries should always be reachable as fallbacks even before a
+      // live `/v1/models` probe runs.
+      const configuredModels = cp.models ? Object.keys(cp.models) : []
       mergeCandidate(candidates, {
         provider,
         label: name,
         base_url: baseUrl,
-        api_key: String(cp?.api_key || '').trim(),
-        fallback_models: uniqueModels([cp?.model, ...presetModels]),
+        api_key: cp.api_key || '',
+        fallback_models: uniqueModels([cp.model, ...configuredModels, ...presetModels]),
         profile,
       })
     }

--- a/packages/server/src/services/hermes/model-context.ts
+++ b/packages/server/src/services/hermes/model-context.ts
@@ -5,6 +5,7 @@ import { PROVIDER_PRESETS } from '../../shared/providers'
 import { getDb } from '../../db'
 import { MODEL_CONTEXT_TABLE } from '../../db/hermes/schemas'
 import { detectHermesHome } from './hermes-path'
+import { getCompatibleCustomProviders } from './custom-providers-compat'
 
 const HERMES_BASE = detectHermesHome()
 const MODELS_DEV_CACHE = resolve(HERMES_BASE, 'models_dev_cache.json')
@@ -186,7 +187,9 @@ function getModelBaseUrl(config: any): string | null {
 }
 
 function getCustomProviders(config: any): CustomProviderEntry[] {
-  return Array.isArray(config?.custom_providers) ? config.custom_providers as CustomProviderEntry[] : []
+  // Read from both legacy `custom_providers:` list and v12+ `providers:` dict
+  // so context-length resolution stays correct after a v11→v12 migration.
+  return getCompatibleCustomProviders(config) as unknown as CustomProviderEntry[]
 }
 
 function resolveCustomProviderEntry(config: any, modelName: string, provider: string | null): CustomProviderEntry | null {

--- a/tests/server/custom-providers-compat.test.ts
+++ b/tests/server/custom-providers-compat.test.ts
@@ -136,6 +136,7 @@ describe('getCompatibleCustomProviders', () => {
     const result = getCompatibleCustomProviders(config)
     expect(result).toHaveLength(1)
     expect(result[0].name).toBe('volc')
+    expect(result[0].source).toBe('custom_providers')
     expect(result[0].model).toBe('minimax-m3')
   })
 
@@ -154,6 +155,7 @@ describe('getCompatibleCustomProviders', () => {
     const result = getCompatibleCustomProviders(config)
     expect(result).toHaveLength(1)
     expect(result[0].name).toBe('volcengine-coding')
+    expect(result[0].source).toBe('providers')
     expect(result[0].provider_key).toBe('volcengine-coding')
     expect(result[0].base_url).toBe('https://ark.cn-beijing.volces.com/api/coding/v3')
     expect(result[0].key_env).toBe('ARK_CODING_API_KEY')

--- a/tests/server/custom-providers-compat.test.ts
+++ b/tests/server/custom-providers-compat.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getCompatibleCustomProviders,
+  normalizeCustomProviderEntry,
+} from '../../packages/server/src/services/hermes/custom-providers-compat'
+
+describe('normalizeCustomProviderEntry', () => {
+  it('returns null for non-objects', () => {
+    expect(normalizeCustomProviderEntry(null)).toBeNull()
+    expect(normalizeCustomProviderEntry('foo')).toBeNull()
+    expect(normalizeCustomProviderEntry([])).toBeNull()
+  })
+
+  it('returns null when no usable URL is present', () => {
+    expect(normalizeCustomProviderEntry({ name: 'foo' })).toBeNull()
+    expect(normalizeCustomProviderEntry({ name: 'foo', base_url: 'not-a-url' })).toBeNull()
+  })
+
+  it('returns null when no name is present and no providerKey is supplied', () => {
+    expect(normalizeCustomProviderEntry({ base_url: 'https://api.example.com' })).toBeNull()
+  })
+
+  it('falls back to providerKey when entry.name is missing', () => {
+    const result = normalizeCustomProviderEntry(
+      { base_url: 'https://api.example.com' },
+      'volcengine-coding',
+    )
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe('volcengine-coding')
+    expect(result!.provider_key).toBe('volcengine-coding')
+  })
+
+  it('accepts base_url, url, and api as URL aliases (first valid wins)', () => {
+    const fromUrl = normalizeCustomProviderEntry({ name: 'a', url: 'https://example.com' })
+    expect(fromUrl?.base_url).toBe('https://example.com')
+    const fromApi = normalizeCustomProviderEntry({ name: 'a', api: 'https://api.example.com' })
+    expect(fromApi?.base_url).toBe('https://api.example.com')
+    const baseWins = normalizeCustomProviderEntry({
+      name: 'a',
+      base_url: 'https://primary.example.com',
+      api: 'https://secondary.example.com',
+    })
+    expect(baseWins?.base_url).toBe('https://primary.example.com')
+  })
+
+  it('maps camelCase aliases to snake_case canonical fields', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      baseUrl: 'https://example.com',
+      apiKey: 'secret',
+      keyEnv: 'P_KEY',
+      defaultModel: 'm-1',
+    })
+    expect(result?.base_url).toBe('https://example.com')
+    expect(result?.api_key).toBe('secret')
+    expect(result?.key_env).toBe('P_KEY')
+    expect(result?.model).toBe('m-1')
+  })
+
+  it('treats api_key_env as a snake_case alias for key_env', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      base_url: 'https://example.com',
+      api_key_env: 'P_KEY',
+    })
+    expect(result?.key_env).toBe('P_KEY')
+  })
+
+  it('preserves transport as api_mode', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      base_url: 'https://example.com',
+      transport: 'chat_completions',
+    })
+    expect(result?.api_mode).toBe('chat_completions')
+  })
+
+  it('converts a list-of-strings models field into the dict shape', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      base_url: 'https://example.com',
+      models: ['m-1', 'm-2', 'm-3'],
+    })
+    expect(result?.models).toEqual({ 'm-1': {}, 'm-2': {}, 'm-3': {} })
+  })
+
+  it('preserves a dict-shaped models field', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      base_url: 'https://example.com',
+      models: { 'm-1': { context_length: 128_000 } },
+    })
+    expect(result?.models).toEqual({ 'm-1': { context_length: 128_000 } })
+  })
+
+  it('preserves discover_models, context_length, rate_limit_delay, extra_body', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      base_url: 'https://example.com',
+      discover_models: false,
+      context_length: 256_000,
+      rate_limit_delay: 0.5,
+      extra_body: { foo: 'bar' },
+    })
+    expect(result?.discover_models).toBe(false)
+    expect(result?.context_length).toBe(256_000)
+    expect(result?.rate_limit_delay).toBe(0.5)
+    expect(result?.extra_body).toEqual({ foo: 'bar' })
+  })
+
+  it('drops invalid context_length / rate_limit_delay values silently', () => {
+    const result = normalizeCustomProviderEntry({
+      name: 'p',
+      base_url: 'https://example.com',
+      context_length: 0,
+      rate_limit_delay: -1,
+    })
+    expect(result?.context_length).toBeUndefined()
+    expect(result?.rate_limit_delay).toBeUndefined()
+  })
+})
+
+describe('getCompatibleCustomProviders', () => {
+  it('returns an empty array for non-config inputs', () => {
+    expect(getCompatibleCustomProviders(null)).toEqual([])
+    expect(getCompatibleCustomProviders(undefined)).toEqual([])
+    expect(getCompatibleCustomProviders('not config')).toEqual([])
+  })
+
+  it('reads entries from the legacy custom_providers list', () => {
+    const config = {
+      custom_providers: [
+        { name: 'volc', base_url: 'https://volc.example.com', model: 'minimax-m3' },
+      ],
+    }
+    const result = getCompatibleCustomProviders(config)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('volc')
+    expect(result[0].model).toBe('minimax-m3')
+  })
+
+  it('reads entries from the v12+ providers dict', () => {
+    const config = {
+      providers: {
+        'volcengine-coding': {
+          api: 'https://ark.cn-beijing.volces.com/api/coding/v3',
+          key_env: 'ARK_CODING_API_KEY',
+          default_model: 'minimax-m3',
+          models: ['minimax-m3', 'kimi-k2.6', 'glm-5.1'],
+          discover_models: false,
+        },
+      },
+    }
+    const result = getCompatibleCustomProviders(config)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('volcengine-coding')
+    expect(result[0].provider_key).toBe('volcengine-coding')
+    expect(result[0].base_url).toBe('https://ark.cn-beijing.volces.com/api/coding/v3')
+    expect(result[0].key_env).toBe('ARK_CODING_API_KEY')
+    expect(result[0].model).toBe('minimax-m3')
+    expect(result[0].models).toEqual({ 'minimax-m3': {}, 'kimi-k2.6': {}, 'glm-5.1': {} })
+    expect(result[0].discover_models).toBe(false)
+  })
+
+  it('merges entries from both schemas, list first', () => {
+    const config = {
+      custom_providers: [
+        { name: 'legacy', base_url: 'https://legacy.example.com', model: 'm-l' },
+      ],
+      providers: {
+        modern: { api: 'https://modern.example.com', default_model: 'm-m' },
+      },
+    }
+    const result = getCompatibleCustomProviders(config)
+    expect(result.map(p => p.name)).toEqual(['legacy', 'modern'])
+  })
+
+  it('deduplicates entries by provider_key (prefers list first)', () => {
+    const config = {
+      custom_providers: [
+        { name: 'shared', base_url: 'https://list.example.com', model: 'list-model' },
+      ],
+      providers: {
+        // Same provider_key as the list entry's name — list entry wins per Hermes Agent semantics.
+        shared: { api: 'https://dict.example.com', default_model: 'dict-model' },
+      },
+    }
+    const result = getCompatibleCustomProviders(config)
+    // The dict entry has provider_key='shared'. The list entry has no provider_key
+    // (its name is just 'shared'). Identity dedup uses (name, base_url, model)
+    // triple — different base_urls, so both should appear.
+    expect(result).toHaveLength(2)
+    expect(result[0].base_url).toBe('https://list.example.com')
+    expect(result[1].base_url).toBe('https://dict.example.com')
+  })
+
+  it('deduplicates true duplicates by name+base_url+model triple', () => {
+    const config = {
+      custom_providers: [
+        { name: 'dup', base_url: 'https://dup.example.com', model: 'm-1' },
+        { name: 'dup', base_url: 'https://dup.example.com/', model: 'm-1' }, // trailing slash
+      ],
+    }
+    const result = getCompatibleCustomProviders(config)
+    expect(result).toHaveLength(1)
+  })
+
+  it('returns empty array when custom_providers is malformed', () => {
+    // Matches Hermes Agent: a non-list custom_providers value bails out entirely.
+    expect(getCompatibleCustomProviders({ custom_providers: 'broken' })).toEqual([])
+  })
+
+  it('skips dict entries without a base_url silently', () => {
+    const config = {
+      providers: {
+        'no-url': { default_model: 'foo' },
+        'with-url': { api: 'https://valid.example.com', default_model: 'bar' },
+      },
+    }
+    const result = getCompatibleCustomProviders(config)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('with-url')
+  })
+
+  it('handles the volcengine-coding example from issue #1570', () => {
+    // This is the exact config shape from the bug report — Studio should now see
+    // the provider with all 5 models.
+    const config = {
+      model: { default: 'minimax-m3', provider: 'volcengine-coding' },
+      providers: {
+        'volcengine-coding': {
+          api: 'https://ark.cn-beijing.volces.com/api/coding/v3',
+          key_env: 'ARK_CODING_API_KEY',
+          default_model: 'minimax-m3',
+          models: ['minimax-m3', 'kimi-k2.6', 'glm-5.1', 'deepseek-v4-pro', 'deepseek-v4-flash'],
+          discover_models: false,
+        },
+      },
+      custom_providers: [],
+    }
+    const result = getCompatibleCustomProviders(config)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('volcengine-coding')
+    expect(Object.keys(result[0].models || {})).toEqual([
+      'minimax-m3', 'kimi-k2.6', 'glm-5.1', 'deepseek-v4-pro', 'deepseek-v4-flash',
+    ])
+  })
+})

--- a/tests/server/provider-delete-controller.test.ts
+++ b/tests/server/provider-delete-controller.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
+import YAML from 'js-yaml'
 
 vi.mock('../../packages/server/src/services/hermes/hermes-cli', () => ({
   restartGateway: vi.fn().mockResolvedValue(undefined),
@@ -27,6 +28,10 @@ function makeCtx(poolKey: string, overrides: Record<string, any> = {}) {
 
 function readAuth(profileDir = hermesHome) {
   return JSON.parse(readFileSync(join(profileDir, 'auth.json'), 'utf-8'))
+}
+
+function readYaml(filePath: string) {
+  return YAML.load(readFileSync(filePath, 'utf-8')) as any
 }
 
 describe('providers controller delete', () => {
@@ -138,6 +143,81 @@ describe('providers controller delete', () => {
     const authAfter = readAuth()
     expect(authAfter.credential_pool).not.toHaveProperty('custom:deepseek-proxy')
     expect(authAfter.credential_pool['custom:keep-provider']).toEqual([{ label: 'keep' }])
+  })
+
+  it('removes v12 providers dict entries when requested by source', async () => {
+    writeFileSync(join(hermesHome, 'config.yaml'), [
+      'model:',
+      '  provider: custom:dict-provider',
+      '  default: dict-model',
+      'providers:',
+      '  dict-provider:',
+      '    api: https://dict.invalid/v1',
+      '    api_key: dict-key',
+      '    default_model: dict-model',
+      '  keep-provider:',
+      '    api: https://keep.invalid/v1',
+      '    default_model: keep-model',
+      '',
+    ].join('\n'))
+    writeFileSync(join(hermesHome, 'auth.json'), JSON.stringify({
+      credential_pool: {
+        'custom:dict-provider': [{ label: 'dict' }],
+        'custom:keep-provider': [{ label: 'keep' }],
+      },
+    }, null, 2))
+
+    const { remove } = await loadProvidersController()
+    const ctx = makeCtx('custom:dict-provider', {
+      query: { source: 'providers', providerKey: 'dict-provider' },
+    })
+
+    await remove(ctx)
+
+    expect(ctx.body).toEqual({ success: true })
+    const configAfter = readYaml(join(hermesHome, 'config.yaml'))
+    expect(configAfter.providers).not.toHaveProperty('dict-provider')
+    expect(configAfter.providers).toHaveProperty('keep-provider')
+    expect(configAfter.model).toEqual({
+      provider: 'custom:keep-provider',
+      default: 'keep-model',
+    })
+
+    const authAfter = readAuth()
+    expect(authAfter.credential_pool).not.toHaveProperty('custom:dict-provider')
+    expect(authAfter.credential_pool['custom:keep-provider']).toEqual([{ label: 'keep' }])
+  })
+
+  it('uses provider source to delete one side when legacy and dict providers share a name', async () => {
+    writeFileSync(join(hermesHome, 'config.yaml'), [
+      'model:',
+      '  provider: custom:shared',
+      '  default: legacy-model',
+      'custom_providers:',
+      '  - name: shared',
+      '    base_url: https://legacy.invalid/v1',
+      '    api_key: legacy-key',
+      '    model: legacy-model',
+      'providers:',
+      '  shared:',
+      '    api: https://dict.invalid/v1',
+      '    api_key: dict-key',
+      '    default_model: dict-model',
+      '',
+    ].join('\n'))
+
+    const { remove } = await loadProvidersController()
+    const ctx = makeCtx('custom:shared', {
+      query: { source: 'providers', providerKey: 'shared' },
+    })
+
+    await remove(ctx)
+
+    expect(ctx.body).toEqual({ success: true })
+    const configAfter = readYaml(join(hermesHome, 'config.yaml'))
+    expect(configAfter.providers).not.toHaveProperty('shared')
+    expect(configAfter.custom_providers).toHaveLength(1)
+    expect(configAfter.custom_providers[0].name).toBe('shared')
   })
 
   it('keeps OAuth-style provider deletion clearing stored auth entries', async () => {


### PR DESCRIPTION
## What
- Bring in PR #1571 v12 provider compatibility commit so `providers:` dict entries are exposed alongside legacy `custom_providers`.
- Add provider origin metadata (`provider_source`, `provider_key`) to model groups and pass it through the client delete flow.
- Allow delete provider API to remove either legacy `custom_providers` entries or v12 `providers` dict entries, including same-name collision handling.
- Regenerate OpenAPI docs for the new delete query params.

## Why
Deleting a custom provider needs to know where that provider came from. Without source metadata, v12 `providers:` entries can be shown but cannot be removed reliably, and same-name legacy/dict entries are ambiguous.

## Checks
- `npm run test -- tests/server/custom-providers-compat.test.ts tests/server/provider-delete-controller.test.ts tests/server/provider-update-controller.test.ts tests/server/model-visibility-controller.test.ts tests/server/coding-agents-launch.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json --pretty false`
- `npx vue-tsc -b --pretty false`
- `npm run harness:check`
- `npm run build`