### PR TITLE
[codex] fix Linux AppImage bottom gap

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -37,6 +37,10 @@ const nodeVersionLow = computed(() => {
 const isDesktopShell = computed(() =>
   (window as typeof window & { hermesDesktop?: { isDesktop?: boolean } }).hermesDesktop?.isDesktop === true,
 )
+const hasDesktopTitleBar = computed(() => {
+  const platform = (window as typeof window & { hermesDesktop?: { platform?: string } }).hermesDesktop?.platform
+  return isDesktopShell.value && (platform === 'darwin' || platform === 'win32')
+})
 
 function handleMobileMenuClick() {
   if (usesPageSidebar.value) {
@@ -70,7 +74,7 @@ useKeyboard()
       <AuthEventListener />
       <NDialogProvider>
         <NNotificationProvider>
-          <div class="app-shell" :class="{ desktop: isDesktopShell }">
+          <div class="app-shell" :class="{ desktop: isDesktopShell, 'desktop-titlebar-host': hasDesktopTitleBar }">
             <DesktopTitleBar v-if="isDesktopShell" />
             <div v-if="nodeVersionLow" class="node-warning-bar">
               {{ t('sidebar.nodeVersionWarning', { version: appStore.nodeVersion }) }}
@@ -120,7 +124,7 @@ useKeyboard()
   }
 }
 
-.app-shell.desktop .app-layout {
+.app-shell.desktop-titlebar-host .app-layout {
   --vh: calc(1vh - 0.36px);
 }
 


### PR DESCRIPTION
## Summary
- Scope the desktop 36px viewport compensation to platforms that render the custom desktop title bar.
- Leave Linux AppImage using the full content viewport so chat pages do not show an extra bottom gap.

Fixes #1575

## Root Cause
The app shell applied the desktop title-bar height compensation to every desktop platform. Linux desktop builds do not render the custom title bar, so their nested full-height pages were shortened by 36px and left a visible empty strip at the bottom.

## Validation
- npm run harness:check
- npx vue-tsc -b --pretty false
- npm run build