### PR TITLE
fix: loadSessionStateFromDb 增加 state.db 回退，修复旧版会话消息无法加载

### DIFF
--- a/docs/chat-chain-changes/2026-06-16-pr1586-state-db-fallback.md
+++ b/docs/chat-chain-changes/2026-06-16-pr1586-state-db-fallback.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-16
+pr: 1586
+feature: loadSessionStateFromDb 增加 state.db 回退
+impact: Socket.IO resume 路径在本地 DB 无消息时回退到 hermes-agent state.db 查询
+---
+
+`loadSessionStateFromDb()` 原本只通过 `getSessionDetailPaginated()` 查询 web-ui 本地 DB，当本地 DB 无会话消息时返回空。HTTP API 路径（`getConversationMessagesPaginated` controller）已有 `getSessionDetailPaginatedFromDbWithProfile()` 回退，但 resume 路径缺失。修复后当本地 DB 无消息时回退到 state.db 查询，使旧版会话（消息仅存于 state.db）恢复正常加载。

--- a/packages/server/src/services/hermes/run-chat/handle-api-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-api-run.ts
@@ -47,7 +47,7 @@ export async function loadSessionStateFromDb(sid: string, _sessionMap: Map<strin
         const session = getSession(sid)
         const profile = session?.profile || 'default'
         const dbDetail = await getSessionDetailPaginatedFromDbWithProfile(sid, profile)
-        if (dbDetail) actualDetail = dbDetail
+        if (dbDetail) actualDetail = dbDetail as any
       } catch (err) {
         logger.debug(err, '[chat-run-socket] state.db fallback failed for session %s', sid)
       }

--- a/packages/server/src/services/hermes/run-chat/handle-api-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-api-run.ts
@@ -11,6 +11,7 @@ import {
   updateSessionStats,
   getSessionDetailPaginated,
 } from '../../../db/hermes/session-store'
+import { getSessionDetailPaginatedFromDbWithProfile } from '../../../db/hermes/sessions-db'
 import { updateUsage } from '../../../db/hermes/usage-store'
 import { logger } from '../../logger'
 import { contentBlocksToString, extractTextForPreview, isContentBlockArray, convertContentBlocks } from './content-blocks'
@@ -36,7 +37,21 @@ export function resolveRunSource(source?: string, sessionId?: string): ChatRunSo
 
 export async function loadSessionStateFromDb(sid: string, _sessionMap: Map<string, SessionState>): Promise<SessionState> {
   try {
-    const actualDetail = getSessionDetailPaginated(sid)
+    let actualDetail = getSessionDetailPaginated(sid)
+
+    // Fallback to hermes-agent state.db when local DB has no messages.
+    // This handles sessions created by older versions where messages may
+    // only exist in hermes-agent's state.db, not in web-ui's local DB.
+    if (!actualDetail?.messages?.length) {
+      try {
+        const session = getSession(sid)
+        const profile = session?.profile || 'default'
+        const dbDetail = await getSessionDetailPaginatedFromDbWithProfile(sid, profile)
+        if (dbDetail) actualDetail = dbDetail
+      } catch (err) {
+        logger.debug(err, '[chat-run-socket] state.db fallback failed for session %s', sid)
+      }
+    }
 
     const messages = actualDetail?.messages ? handleMessage(actualDetail.messages, sid) : []
 


### PR DESCRIPTION
问题：升级到新版后，旧版会话列表可见但点进去无消息内容，只有 CLI 会话正常。

原因：Socket.IO resume 流程（switchSession 触发）中 loadSessionStateFromDb() 只查 web-ui 本地 DB，不查 hermes-agent 的 state.db。旧版会话的消息可能仅存在于 state.db 中，导致 resume 返回空。

HTTP API 路径（getConversationMessagesPaginated）已有 getSessionDetailPaginatedFromDbWithProfile 回退，但 resume 路径缺了这一步。

修复：loadSessionStateFromDb 中当本地 DB 无消息时，回退到 state.db 查询。

变更文件：packages/server/src/services/hermes/run-chat/handle-api-run.ts (+16 行)
