### PR TITLE
[codex] support configured apikey image providers

### DIFF
--- a/packages/server/src/controllers/hermes/media.ts
+++ b/packages/server/src/controllers/hermes/media.ts
@@ -23,7 +23,8 @@ type AuthJson = {
 
 type ApiKeyImageMode = 'text' | 'image' | 'edit'
 
-type FunCodexProvider = {
+type ApiKeyImageProvider = {
+  name: string
   apiKey: string
   baseUrl: string
   model: string
@@ -80,14 +81,33 @@ function buildApiUrl(baseUrl: string, pathWithV1: string): string {
   return `${base}${apiPath}`
 }
 
-async function resolveFunCodexProvider(profile: string): Promise<FunCodexProvider | null> {
+function normalizeCustomProviderName(value: unknown): string {
+  const name = String(value || '').trim()
+  if (!name) return ''
+  return name.startsWith('custom:') ? name.slice('custom:'.length).trim() : name
+}
+
+function requestedApiKeyImageProviderName(body: any): string {
+  return normalizeCustomProviderName(body?.provider || body?.provider_name || body?.custom_provider) || APIKEY_IMAGE_PROVIDER
+}
+
+function apiKeyFromCustomProvider(provider: any): string {
+  const direct = String(provider?.api_key || '').trim()
+  if (direct) return direct
+  const envName = String(provider?.api_key_env || provider?.key_env || '').trim()
+  return envName ? String(process.env[envName] || '').trim() : ''
+}
+
+async function resolveApiKeyImageProvider(profile: string, providerName = APIKEY_IMAGE_PROVIDER): Promise<ApiKeyImageProvider | null> {
+  const requestedName = normalizeCustomProviderName(providerName) || APIKEY_IMAGE_PROVIDER
   const hermesConfig = await readConfigYamlForProfile(profile)
   const customProviders = getCompatibleCustomProviders(hermesConfig)
-  const provider = customProviders.find(entry => String(entry?.name || '').trim() === APIKEY_IMAGE_PROVIDER)
-  const apiKey = String(provider?.api_key || '').trim()
+  const provider = customProviders.find(entry => normalizeCustomProviderName(entry?.name) === requestedName)
+  const apiKey = apiKeyFromCustomProvider(provider)
   const baseUrl = String(provider?.base_url || '').trim()
   if (!provider || !apiKey || !baseUrl) return null
   return {
+    name: requestedName,
     apiKey,
     baseUrl,
     model: String(provider?.model || '').trim(),
@@ -350,7 +370,7 @@ async function readSseImageResults(res: Response, limit: number): Promise<string
   return images.slice(0, limit)
 }
 
-async function requestApiKeyImage(provider: FunCodexProvider, mode: ApiKeyImageMode, body: any): Promise<string[]> {
+async function requestApiKeyImage(provider: ApiKeyImageProvider, mode: ApiKeyImageMode, body: any): Promise<string[]> {
   const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
   if (!prompt) {
     const err: any = new Error('prompt is required')
@@ -465,17 +485,19 @@ export async function apiKeyImageGenerate(ctx: Context) {
     return
   }
 
-  const provider = await resolveFunCodexProvider(profile)
+  const body = ctx.request.body as any
+  const providerName = requestedApiKeyImageProviderName(body)
+  const provider = await resolveApiKeyImageProvider(profile, providerName)
   if (!provider) {
     ctx.status = 401
+    const isDefaultProvider = providerName === APIKEY_IMAGE_PROVIDER
     ctx.body = {
-      error: `Missing fun-codex provider in profile "${profile}" config.yaml.`,
-      code: 'missing_fun_codex_provider',
+      error: `Missing ${providerName} provider in profile "${profile}" config.yaml.`,
+      code: isDefaultProvider ? 'missing_fun_codex_provider' : 'missing_apikey_image_provider',
     }
     return
   }
 
-  const body = ctx.request.body as any
   try {
     const mode = normalizeImageMode(body.mode)
     const images = await requestApiKeyImage(provider, mode, body)
@@ -485,7 +507,7 @@ export async function apiKeyImageGenerate(ctx: Context) {
       ok: true,
       mode,
       output_paths: outputPaths,
-      provider: APIKEY_IMAGE_PROVIDER,
+      provider: provider.name,
       base_url: provider.baseUrl,
       profile,
     }

--- a/packages/skills/apikey-image-gen/SKILL.md
+++ b/packages/skills/apikey-image-gen/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: apikey-image-gen
-description: "Generate or edit images through Hermes Web UI using the selected/requested profile's fun-codex provider from config.yaml."
+description: "Generate or edit images through Hermes Web UI using the selected/requested profile's configured API-key image provider from config.yaml."
 version: 1.0.0
 author: Ekko
 license: MIT
 platforms: [linux, macos, windows, termux]
 metadata:
   hermes:
-    tags: [api.apikey.fun, image-generation, image-editing, media]
+    tags: [api.apikey.fun, custom-provider, image-generation, image-editing, media]
 prerequisites:
   commands: [curl]
 ---
@@ -16,7 +16,7 @@ prerequisites:
 
 Use this skill when the user wants to generate an image, generate an image from a reference image, or edit an existing image.
 
-Always call Hermes Web UI's media endpoint. Do not call `api.apikey.fun` directly, and do not ask the user for an API key. The server reads the selected/requested profile's `config.yaml` and uses the `custom_providers` entry named `fun-codex`:
+Always call Hermes Web UI's media endpoint. Do not call an upstream image API directly, and do not ask the user for an API key. The server reads the selected/requested profile's `config.yaml` and uses a configured custom provider. By default it uses the provider named `fun-codex`, but callers may request another configured provider by sending `provider`, `provider_name`, or `custom_provider`.
 
 Do not use any built-in image generation tool as a fallback. If the Hermes Web UI endpoint returns `401`, `403`, connection failure, or any other error, stop and report the Hermes Web UI error to the user.
 
@@ -29,6 +29,16 @@ custom_providers:
     api_mode: codex_responses
 ```
 
+Example with another configured provider:
+
+```yaml
+custom_providers:
+  - name: agnes
+    base_url: https://agnes.example/v1
+    api_key_env: AGNES_API_KEY
+    model: agnes-image-2.1-flash
+```
+
 Endpoint:
 
 ```bash
@@ -39,7 +49,14 @@ Resolve the Hermes Web UI base URL in this order:
 
 1. `HERMES_WEB_UI_URL` environment variable, if set.
 2. `http://127.0.0.1:${PORT}`, if `PORT` is set.
-3. `http://127.0.0.1:8648` for local development.
+3. `http://127.0.0.1:8648` for the Web UI single-server default.
+
+Common local ports:
+
+- Development API backend: `http://127.0.0.1:8647`. Use this with `npm run dev`; do not target the Vite frontend port.
+- Web UI single-server default: `http://127.0.0.1:8648`.
+- Desktop app default: `http://127.0.0.1:8748`.
+- Custom port: set `HERMES_WEB_UI_URL` to the full base URL, or set `PORT` to use `http://127.0.0.1:${PORT}`.
 
 When Hermes Web UI is running from Docker Compose, the default external URL is `http://127.0.0.1:6060`.
 
@@ -84,6 +101,7 @@ Use when there is no input image.
 ```
 
 The server calls `POST /v1/images/generations` against the `fun-codex` base URL.
+If `provider`, `provider_name`, or `custom_provider` is present, the server calls the requested provider's base URL instead.
 
 ### Image To Image
 
@@ -100,6 +118,7 @@ Use when the user provides a reference image and wants a new image based on it.
 ```
 
 The server calls `POST /v1/responses` against the `fun-codex` base URL.
+If `provider`, `provider_name`, or `custom_provider` is present, the server calls the requested provider's base URL instead.
 
 ### Image Edit
 
@@ -116,18 +135,22 @@ Use when the user wants to modify an existing image while preserving parts of it
 ```
 
 The server calls `POST /v1/images/edits` against the `fun-codex` base URL.
+If `provider`, `provider_name`, or `custom_provider` is present, the server calls the requested provider's base URL instead.
 
 ## Request Fields
 
 - `mode`: `text`, `image`, or `edit`.
 - `prompt`: required.
+- `provider`: optional configured custom provider name. Defaults to `fun-codex`. `custom:<name>` is accepted and normalized to `<name>`.
+- `provider_name`: optional alias for `provider`.
+- `custom_provider`: optional alias for `provider`.
 - `image_path`: local png, jpeg, or webp path. Required for `image` and `edit` unless using `image_url` or `image_base64`.
 - `image_url`: optional alternative image input.
 - `image_base64`: optional alternative image input. If it is not a data URI, include `mime_type`.
 - `n`: number of images. Defaults to `1`.
 - `size`: defaults to `1024x1024`. Common values: `1024x1024`, `1536x1024`, `1024x1536`, `2048x2048`, `3840x2160`, `2160x3840`, `auto`.
 - `quality`: defaults to `auto`.
-- `model`: optional override. Text/edit default to `gpt-image-2`; image mode defaults to the `fun-codex` model in `config.yaml`.
+- `model`: optional override. If omitted, text/edit modes use `gpt-image-2`; image mode uses the selected provider's `model` when configured, then falls back to `gpt-5.4-mini`.
 - `image_model`: optional image tool model for image mode. Defaults to `gpt-image-2`.
 - `output_path`: optional absolute output file path. If omitted, the server saves to `${HERMES_WEB_UI_HOME:-~/.hermes-web-ui}/media/*.png`.
 - `timeout_ms`: defaults to `600000`.
@@ -161,6 +184,7 @@ curl -sS -X POST "$BASE_URL/api/hermes/media/apikey-image-generate" \
   -H 'Content-Type: application/json' \
   -d '{
     "mode": "text",
+    "provider": "fun-codex",
     "prompt": "A cinematic 4K photo of a silver robot hand holding a small glowing cube",
     "size": "3840x2160",
     "output_path": "/absolute/path/to/output.png"
@@ -180,3 +204,4 @@ Successful responses include:
 ```
 
 If the response code is `missing_fun_codex_provider`, tell the user to configure `fun-codex` in the selected/requested profile's `config.yaml`.
+If the response code is `missing_apikey_image_provider`, tell the user to configure the requested provider in the selected/requested profile's `config.yaml`, or omit `provider` to use the default `fun-codex` provider.

--- a/packages/skills/grok-image-to-video/SKILL.md
+++ b/packages/skills/grok-image-to-video/SKILL.md
@@ -32,7 +32,14 @@ Resolve the Hermes Web UI base URL in this order:
 
 1. `HERMES_WEB_UI_URL` environment variable, if set.
 2. `http://127.0.0.1:${PORT}`, if `PORT` is set.
-3. `http://127.0.0.1:8648` for local development.
+3. `http://127.0.0.1:8648` for the Web UI single-server default.
+
+Common local ports:
+
+- Development API backend: `http://127.0.0.1:8647`. Use this with `npm run dev`; do not target the Vite frontend port.
+- Web UI single-server default: `http://127.0.0.1:8648`.
+- Desktop app default: `http://127.0.0.1:8748`.
+- Custom port: set `HERMES_WEB_UI_URL` to the full base URL, or set `PORT` to use `http://127.0.0.1:${PORT}`.
 
 When Hermes Web UI is running from the provided Docker Compose setup, the default external URL is `http://127.0.0.1:6060`.
 

--- a/tests/server/media-controller.test.ts
+++ b/tests/server/media-controller.test.ts
@@ -5,6 +5,10 @@ const originalWebUiHome = process.env.HERMES_WEB_UI_HOME
 const originalWebuiStateDir = process.env.HERMES_WEBUI_STATE_DIR
 
 afterEach(() => {
+  vi.doUnmock('../../packages/server/src/services/hermes/hermes-profile')
+  vi.doUnmock('../../packages/server/src/services/config-helpers')
+  vi.clearAllMocks()
+  vi.unstubAllEnvs()
   vi.resetModules()
   if (originalWebUiHome === undefined) delete process.env.HERMES_WEB_UI_HOME
   else process.env.HERMES_WEB_UI_HOME = originalWebUiHome
@@ -21,5 +25,76 @@ describe('media controller', () => {
     expect(defaultMediaOutputPath('bad/request:id')).toBe(join('/tmp/hermes-web-ui-test-home', 'media', 'bad_request_id.mp4'))
     expect(defaultImageOutputPath('img_123')).toBe(join('/tmp/hermes-web-ui-test-home', 'media', 'img_123.png'))
     expect(defaultImageOutputPath('bad/request:id', 1)).toBe(join('/tmp/hermes-web-ui-test-home', 'media', 'bad_request_id-2.png'))
+  })
+
+  it('generates images through the requested configured custom provider', async () => {
+    vi.stubEnv('AGNES_API_KEY', 'agnes-secret')
+    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+      getActiveProfileName: () => 'default',
+      getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
+      listProfileNamesFromDisk: () => ['default'],
+    }))
+    vi.doMock('../../packages/server/src/services/config-helpers', () => ({
+      readConfigYamlForProfile: vi.fn(async () => ({
+        custom_providers: [{
+          name: 'agnes',
+          base_url: 'https://agnes.example/v1',
+          api_key_env: 'AGNES_API_KEY',
+          model: 'agnes-image-2.1-flash',
+        }],
+      })),
+    }))
+    const fetchMock = vi.fn(async () => new Response(
+      'data: {"data":[{"b64_json":"aW1hZ2UtYnl0ZXM="}]}\n\n',
+      { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+    ))
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchMock as any
+    try {
+      const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx: any = {
+        state: { serverTokenAuth: true },
+        query: {},
+        request: {
+          body: {
+            provider: 'agnes',
+            mode: 'text',
+            prompt: 'make an icon',
+            output_path: '/tmp/hermes-web-ui-agnes-image.png',
+          },
+        },
+        get: vi.fn(() => ''),
+        status: 200,
+        body: undefined,
+      }
+
+      await apiKeyImageGenerate(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body).toMatchObject({
+        ok: true,
+        mode: 'text',
+        provider: 'agnes',
+        base_url: 'https://agnes.example/v1',
+        profile: 'default',
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://agnes.example/v1/images/generations',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer agnes-secret',
+            'Content-Type': 'application/json',
+          }),
+        }),
+      )
+      const requestInit = fetchMock.mock.calls[0][1] as RequestInit
+      expect(JSON.parse(String(requestInit.body))).toMatchObject({
+        model: 'gpt-image-2',
+        prompt: 'make an icon',
+      })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Includes qdivan's `fix(media): support configured image providers` change from #1503, rebased onto current `main`.
- Keeps the current `getCompatibleCustomProviders()` provider-schema compatibility while allowing `/api/hermes/media/apikey-image-generate` to route by `provider`, `provider_name`, or `custom_provider`.
- Updates `packages/skills/apikey-image-gen/SKILL.md` so the skill description and request fields match the new provider-selection behavior.

Refs #1503

## Why
PR #1503 added custom image provider routing but left the bundled skill text describing only the hardcoded `fun-codex` path. The skill now documents the default provider, optional provider aliases, model fallback behavior, and `missing_apikey_image_provider` error handling.

## Validation
- `npm run test -- tests/server/media-controller.test.ts`
- `npm run harness:check`
- `npm run build`

## Notes
- The cherry-picked media controller change was adjusted during conflict resolution to use the current normalized provider shape from `getCompatibleCustomProviders()`; `default_model` is read by the compatibility layer and exposed as `provider.model`.
