### PR TITLE
[codex] include global agent sessions in search

### DIFF
--- a/docs/chat-chain-changes/2026-06-16-global-agent-search.md
+++ b/docs/chat-chain-changes/2026-06-16-global-agent-search.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-16
+commit: pending
+feature: Global agent session search
+impact: Default Web UI session search now includes global-agent sessions alongside normal chat and coding-agent sessions; explicit source=global_agent searches remain scoped to global-agent sessions only.
+---

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -100,7 +100,7 @@ function denySessionAccess(ctx: any, session: any | null | undefined): boolean {
 }
 
 function isVisibleWebUiSessionSource(source?: string | null): boolean {
-  return source === 'api_server' || source === 'cli' || source === 'coding_agent'
+  return source === 'api_server' || source === 'cli' || source === 'coding_agent' || source === 'global_agent'
 }
 
 function isRequestedSessionSource(source: string | undefined, sessionSource?: string | null): boolean {

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -388,7 +388,10 @@ describe('session conversations controller', () => {
   })
 
   it('searches all account-accessible single-chat sessions unless profile is explicit', async () => {
-    localSearchSessionsMock.mockReturnValue([])
+    localSearchSessionsMock.mockReturnValue([
+      { id: 'global-1', profile: 'default', source: 'global_agent' },
+      { id: 'chat-1', profile: 'default', source: 'cli' },
+    ])
 
     const mod = await import('../../packages/server/src/controllers/hermes/sessions')
     const ctx: any = {
@@ -399,6 +402,10 @@ describe('session conversations controller', () => {
     await mod.search(ctx)
 
     expect(localSearchSessionsMock).toHaveBeenCalledWith(undefined, 'docker', 10)
+    expect(ctx.body.results).toEqual([
+      expect.objectContaining({ id: 'global-1', source: 'global_agent' }),
+      expect.objectContaining({ id: 'chat-1', source: 'cli' }),
+    ])
   })
 
   it('searches only global-agent sessions when requested by source', async () => {


### PR DESCRIPTION
## What changed
- Include `global_agent` sessions in the default Web UI session search results.
- Keep explicit `source=global_agent` searches scoped to global-agent sessions only.
- Add a controller regression test and chat-chain change fragment.

## Why
The normal Chat session list already includes global-agent sessions, but the search modal did not return matching global-agent messages unless the UI was in Global Agent mode. This made global-agent sessions visible but not searchable from the default chat search.

## Validation
- `npm run test -- tests/server/sessions-controller.test.ts`
- `npm run harness:check`
