### PR TITLE
fix: restore mobile sidebar collapse controls

### DIFF
--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -756,6 +756,17 @@ function openVersionManagement() {
     padding: 8px 0;
   }
 
+  :deep(.profile-selector .selector-label),
+  :deep(.profile-selector .profile-name) {
+    display: none;
+  }
+
+  :deep(.profile-selector .profile-display) {
+    width: 40px;
+    justify-content: center;
+    padding: 4px;
+  }
+
   .sidebar-footer {
     align-items: center;
     gap: 6px;
@@ -806,6 +817,10 @@ function openVersionManagement() {
 
     &.open {
       transform: translateX(0);
+    }
+
+    .collapse-btn {
+      display: flex;
     }
 
     // Override global utility — sidebar is always 240px wide


### PR DESCRIPTION
## Summary
- keep the sidebar collapse button visible on mobile
- hide profile label/name in collapsed sidebar so only the avatar remains

## Tests
- npx vue-tsc -b --pretty false