### PR TITLE
fix: add reload skills chat command

### DIFF
--- a/docs/chat-chain-changes/2026-06-16-reload-skills-command.md
+++ b/docs/chat-chain-changes/2026-06-16-reload-skills-command.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-16
+commit: pending
+feature: Reload skills chat command
+impact: `/reload-skills` is now a Web UI chat control command that reloads Hermes skill slash-command metadata through the bridge while idle and refuses to enter the model queue while a turn is active.
+---
+
+Validation: focused server command tests and Python bridge syntax checks.

--- a/docs/chat-chain-changes/2026-06-16-reload-skills-command.md
+++ b/docs/chat-chain-changes/2026-06-16-reload-skills-command.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-16
-commit: pending
+pr: 1596
 feature: Reload skills chat command
 impact: `/reload-skills` is now a Web UI chat control command that reloads Hermes skill slash-command metadata through the bridge while idle and refuses to enter the model queue while a turn is active.
 ---

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -196,6 +196,7 @@ const bridgeCommands = computed<SlashCommandOption[]>(() => [
   { key: 'command:steer', name: 'steer', args: t('chat.slashCommandArgs.text'), description: t('chat.slashCommands.steer') },
   { key: 'command:destroy', name: 'destroy', args: '', description: t('chat.slashCommands.destroy') },
   { key: 'command:reload-mcp', name: 'reload-mcp', args: '', description: t('chat.slashCommands.reloadMcp') },
+  { key: 'command:reload-skills', name: 'reload-skills', args: '', description: t('chat.slashCommands.reloadSkills') },
 ])
 
 const slashActive = ref(false)
@@ -1088,17 +1089,20 @@ function isImage(type: string): boolean {
             {{ t('common.loading') }}
           </div>
           <template v-else>
-            <button
+            <div
               v-for="skill in filteredSkillPickerItems"
               :key="skill.key"
-              type="button"
+              role="button"
+              tabindex="0"
               class="skill-picker-item"
               @click="selectSkill(skill)"
+              @keydown.enter.prevent="selectSkill(skill)"
+              @keydown.space.prevent="selectSkill(skill)"
             >
-              <span class="skill-picker-command">/skill {{ skill.commandName }}</span>
-              <span class="skill-picker-name">{{ skill.name }}</span>
-              <span class="skill-picker-desc">{{ skill.description }}</span>
-            </button>
+              <div class="skill-picker-command">/skill {{ skill.commandName }}</div>
+              <div class="skill-picker-name">{{ skill.name }}</div>
+              <div class="skill-picker-desc">{{ skill.description }}</div>
+            </div>
           </template>
           <div v-if="!skillPickerLoading && filteredSkillPickerItems.length === 0" class="skill-picker-empty">
             {{ skillSearch ? t('skills.noMatch') : t('skills.noSkills') }}
@@ -1540,20 +1544,22 @@ function isImage(type: string): boolean {
 }
 
 .skill-picker-item {
-  display: grid;
-  grid-template-columns: minmax(160px, auto) minmax(120px, 0.6fr) minmax(0, 1fr);
-  align-items: center;
-  gap: 10px;
+  display: block;
+  flex: 0 0 76px;
   width: 100%;
-  min-height: 42px;
-  padding: 8px 10px;
+  height: 76px;
+  box-sizing: border-box;
+  padding: 7px 10px;
   border: 1px solid $border-color;
   border-radius: $radius-sm;
   background: $bg-secondary;
   color: $text-primary;
   text-align: left;
   cursor: pointer;
+  overflow: hidden;
+  outline: none;
 
+  &:focus-visible,
   &:hover {
     border-color: rgba(var(--accent-primary-rgb), 0.5);
     background: rgba(var(--accent-primary-rgb), 0.08);
@@ -1561,27 +1567,37 @@ function isImage(type: string): boolean {
 }
 
 .skill-picker-command {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-family: $font-code;
   font-size: 12px;
+  line-height: 16px;
   color: $accent-primary;
   white-space: nowrap;
 }
 
 .skill-picker-name,
 .skill-picker-desc {
-  min-width: 0;
+  display: block;
+  width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .skill-picker-name {
+  margin-top: 3px;
   font-size: 13px;
+  line-height: 18px;
   color: $text-primary;
 }
 
 .skill-picker-desc {
+  margin-top: 3px;
   font-size: 12px;
+  line-height: 16px;
   color: $text-secondary;
 }
 
@@ -1594,8 +1610,7 @@ function isImage(type: string): boolean {
 
 @media (max-width: 768px) {
   .skill-picker-item {
-    grid-template-columns: 1fr;
-    gap: 4px;
+    height: 76px;
   }
 }
 

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -445,6 +445,7 @@ export default {
       steer: 'Steuertext an den aktiven Bridge-Lauf senden',
       destroy: 'Bridge-Agent für diese Sitzung freigeben',
       reloadMcp: 'MCP-Server neu laden',
+      reloadSkills: 'Skill-Befehle neu laden',
     },
     attachFiles: 'Dateien anhangen',
     reasoningEffort: {

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -446,6 +446,7 @@ export default {
       steer: 'Send steering text to the active bridge run',
       destroy: 'Release the bridge agent for this session',
       reloadMcp: 'Reload MCP servers',
+      reloadSkills: 'Reload skill commands',
     },
     attachFiles: 'Attach files',
     reasoningEffort: {

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -445,6 +445,7 @@ export default {
       steer: 'Enviar texto de guía a la ejecución activa de Bridge',
       destroy: 'Liberar el agente Bridge de esta sesión',
       reloadMcp: 'Recargar servidores MCP',
+      reloadSkills: 'Recargar comandos de skills',
     },
     attachFiles: 'Adjuntar archivos',
     reasoningEffort: {

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -445,6 +445,7 @@ export default {
       steer: 'Envoyer un guidage à l’exécution Bridge active',
       destroy: 'Libérer l’agent Bridge de cette session',
       reloadMcp: 'Recharger les serveurs MCP',
+      reloadSkills: 'Recharger les commandes de skills',
     },
     attachFiles: 'Joindre des fichiers',
     reasoningEffort: {

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -445,6 +445,7 @@ export default {
       steer: '実行中の Bridge に誘導テキストを送信',
       destroy: 'このセッションの Bridge Agent を解放',
       reloadMcp: 'MCP サーバーを再読み込み',
+      reloadSkills: 'スキルコマンドを再読み込み',
     },
     attachFiles: 'ファイルを添付',
     reasoningEffort: {

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -445,6 +445,7 @@ export default {
       steer: '활성 Bridge 실행에 지시 텍스트 보내기',
       destroy: '이 세션의 Bridge Agent 해제',
       reloadMcp: 'MCP 서버 다시 로드',
+      reloadSkills: '스킬 명령 다시 로드',
     },
     attachFiles: '파일 첨부',
     reasoningEffort: {

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -445,6 +445,7 @@ export default {
       steer: 'Enviar texto de orientação para a execução ativa do Bridge',
       destroy: 'Liberar o Bridge Agent desta sessão',
       reloadMcp: 'Recarregar servidores MCP',
+      reloadSkills: 'Recarregar comandos de skills',
     },
     attachFiles: 'Anexar arquivos',
     reasoningEffort: {

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -363,6 +363,8 @@ export default {
       compress: 'Запустить сжатие контекста в простое',
       steer: 'Отправить направляющий текст текущему запуску Bridge',
       destroy: 'Освободить Bridge Agent текущего сеанса',
+      reloadMcp: 'Перезагрузить серверы MCP',
+      reloadSkills: 'Перезагрузить команды skills',
     },
     attachFiles: 'Прикрепить файлы',
     reasoningEffort: {

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -445,6 +445,7 @@ export default {
       steer: '向目前 Bridge 執行傳送引導文字',
       destroy: '釋放目前會話的 Bridge Agent',
       reloadMcp: '重載 MCP 伺服器',
+      reloadSkills: '重載技能命令',
     },
     attachFiles: '新增附件',
     reasoningEffort: {

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -446,6 +446,7 @@ export default {
       steer: '向当前 Bridge 运行发送引导文本',
       destroy: '释放当前会话的 Bridge Agent',
       reloadMcp: '重载 MCP 服务器',
+      reloadSkills: '重载技能命令',
     },
     attachFiles: '添加附件',
     reasoningEffort: {

--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -135,6 +135,15 @@ export interface AgentBridgeCommandResult extends AgentBridgeResponse {
   max_turns?: number
 }
 
+export interface AgentBridgeSkillReloadResult extends AgentBridgeResponse {
+  action: 'reload-skills'
+  added: Array<{ name: string; description?: string }>
+  removed: Array<{ name: string; description?: string }>
+  unchanged: string[]
+  total: number
+  commands?: number
+}
+
 export interface AgentBridgeSessionModelSwitch extends AgentBridgeResponse {
   session_id: string
   model: string
@@ -666,6 +675,10 @@ export class AgentBridgeClient {
 
   mcpReload(server?: string, profile?: string): Promise<McpActionResponse> {
     return this.request({ action: 'mcp_reload', ...(server ? { server } : {}), ...(profile ? { profile } : {}) }, { serialize: true })
+  }
+
+  reloadSkills(profile?: string): Promise<AgentBridgeSkillReloadResult> {
+    return this.request({ action: 'skills_reload', ...(profile ? { profile } : {}) }, { serialize: true })
   }
 }
 

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -1347,6 +1347,18 @@ class AgentPool:
                 return self._dispatch_goal_command(session_id, arg)
             if name == "subgoal":
                 return self._dispatch_subgoal_command(session_id, arg)
+            if name in {"reload-skills", "reload_skills"}:
+                from agent.skill_commands import reload_skills
+
+                result = reload_skills()
+                return {
+                    "session_id": session_id,
+                    "command": name,
+                    "handled": True,
+                    "type": "reload-skills",
+                    "action": "reload-skills",
+                    **_jsonable(result),
+                }
 
             try:
                 try:

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
@@ -18,6 +18,7 @@ from bridge_runtime import (
     _install_stop_signal_handlers,
     _jsonable,
     _positive_int,
+    _profile_env,
     _profile_home,
     _restore_profile_env,
     _start_parent_process_watchdog,
@@ -169,6 +170,9 @@ class BridgeServer:
                 req.get("profile"),
             )
 
+        if action == "skills_reload":
+            return self._reload_skills(req.get("profile"))
+
         if action == "switch_session_model":
             session_id = str(req.get("session_id") or "").strip()
             if not session_id:
@@ -284,6 +288,18 @@ class BridgeServer:
         if handler:
             return handler()
         return {"error": f"unknown MCP action: {action}", "ok": False}
+
+    def _reload_skills(self, profile: str | None = None) -> dict[str, Any]:
+        resolved_profile = profile or _worker_profile() or "default"
+        with _profile_env(resolved_profile):
+            from agent.skill_commands import reload_skills
+
+            result = reload_skills()
+        return {
+            "ok": True,
+            "action": "reload-skills",
+            **_jsonable(result),
+        }
 
     # ───── MCP sub-handlers ─────
 

--- a/packages/server/src/services/hermes/run-chat/session-command.ts
+++ b/packages/server/src/services/hermes/run-chat/session-command.ts
@@ -24,6 +24,7 @@ type CommandName =
   | 'steer'
   | 'destroy'
   | 'reload-mcp'
+  | 'reload-skills'
 
 interface ParsedSessionCommand {
   name: CommandName
@@ -60,6 +61,8 @@ const COMMAND_ALIASES: Record<string, CommandName> = {
   steer: 'steer',
   destroy: 'destroy',
   'reload-mcp': 'reload-mcp',
+  'reload-skills': 'reload-skills',
+  reload_skills: 'reload-skills',
 }
 
 export function parseSessionCommand(input: string | ContentBlock[]): ParsedSessionCommand | null {
@@ -603,6 +606,34 @@ export async function handleSessionCommand(
       return
     }
 
+    case 'reload-skills': {
+      if (state.isWorking) {
+        emitCommand({
+          ok: false,
+          action: 'reload-skills',
+          terminal: false,
+          message: 'Skills reload can only run while the session is idle. Wait for the current run to finish or abort it first.',
+        })
+        return
+      }
+      try {
+        const result = await reloadSkillsThroughBridge(ctx, sessionId)
+        emitCommand({
+          action: 'reload-skills',
+          message: formatReloadSkillsMessage(result),
+          result,
+        })
+      } catch (err) {
+        emitCommand({
+          ok: false,
+          action: 'reload-skills',
+          terminal: !state.isWorking,
+          message: `Skills reload failed: ${err instanceof Error ? err.message : String(err)}`,
+        })
+      }
+      return
+    }
+
     case 'destroy': {
       const wasWorking = state.isWorking
       let bridgeReachable = true
@@ -745,6 +776,55 @@ function parseGoalTurnProgress(message: string): { used: number; max: number } |
   const max = Number(match[2])
   if (!Number.isFinite(used) || !Number.isFinite(max) || max <= 0) return null
   return { used, max }
+}
+
+async function reloadSkillsThroughBridge(
+  ctx: SessionCommandContext,
+  sessionId: string,
+): Promise<Record<string, unknown>> {
+  try {
+    return await ctx.bridge.reloadSkills(ctx.profile)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    if (!message.includes('unknown action: skills_reload')) throw err
+  }
+
+  const result = await ctx.bridge.command(sessionId, 'reload-skills', ctx.profile)
+  if (result.handled && result.action === 'reload-skills') return result
+  throw new Error(
+    'The running Agent Bridge does not support /reload-skills yet. Restart the bridge and try again.',
+  )
+}
+
+function formatReloadSkillsMessage(result: Record<string, unknown>): string {
+  const added = Array.isArray(result.added) ? result.added : []
+  const removed = Array.isArray(result.removed) ? result.removed : []
+  const total = typeof result.total === 'number' && Number.isFinite(result.total)
+    ? result.total
+    : null
+  const lines = ['Skills reloaded successfully.']
+  if (!added.length && !removed.length) {
+    lines.push(total === null ? 'No skill changes detected.' : `No skill changes detected. Total skills: ${total}.`)
+    return lines.join('\n')
+  }
+  if (added.length) {
+    lines.push('Added skills:')
+    for (const item of added) lines.push(`- ${formatReloadSkillItem(item)}`)
+  }
+  if (removed.length) {
+    lines.push('Removed skills:')
+    for (const item of removed) lines.push(`- ${formatReloadSkillItem(item)}`)
+  }
+  if (total !== null) lines.push(`Total skills: ${total}.`)
+  return lines.join('\n')
+}
+
+function formatReloadSkillItem(item: unknown): string {
+  if (!item || typeof item !== 'object') return String(item || '')
+  const record = item as Record<string, unknown>
+  const name = typeof record.name === 'string' ? record.name : ''
+  const description = typeof record.description === 'string' ? record.description : ''
+  return description ? `${name}: ${description}` : name
 }
 
 function ensureCommandSession(sessionId: string, ctx: SessionCommandContext) {

--- a/tests/server/session-command-plan.test.ts
+++ b/tests/server/session-command-plan.test.ts
@@ -60,6 +60,15 @@ function makeContext(state: any, commandResult: Record<string, unknown> = {
   const bridge = {
     command: vi.fn(async () => commandResult),
     mcpReload: vi.fn(async () => ({ ok: true, message: 'MCP servers reloaded' })),
+    reloadSkills: vi.fn(async () => ({
+      ok: true,
+      action: 'reload-skills',
+      added: [{ name: 'demo-external-skill', description: 'Demo skill' }],
+      removed: [],
+      unchanged: [],
+      total: 1,
+      commands: 1,
+    })),
     status: vi.fn(async () => ({
       exists: true,
       running: false,
@@ -437,6 +446,58 @@ describe('plan session command', () => {
       action: 'reload-mcp',
       terminal: false,
       message: 'MCP reload can only run while the session is idle. Wait for the current run to finish or abort it first.',
+    }))
+  })
+
+  it('reloads skills while idle without queuing a model run', async () => {
+    const state = { messages: [], isWorking: false, events: [], queue: [] }
+    const { bridge, namespaceEmit, runQueuedItem, sessionMap, socket, nsp } = makeContext(state)
+    const { handleSessionCommand, parseSessionCommand } = await import('../../packages/server/src/services/hermes/run-chat/session-command')
+    const command = parseSessionCommand('/reload-skills')!
+
+    await handleSessionCommand('session-1', command, {
+      nsp: nsp as any,
+      socket: socket as any,
+      sessionMap,
+      bridge: bridge as any,
+      profile: 'default',
+      runQueuedItem,
+    })
+
+    expect(bridge.reloadSkills).toHaveBeenCalledWith('default')
+    expect(runQueuedItem).not.toHaveBeenCalled()
+    expect(state.queue).toEqual([])
+    expect(namespaceEmit).toHaveBeenCalledWith('session.command', expect.objectContaining({
+      command: 'reload-skills',
+      action: 'reload-skills',
+      message: 'Skills reloaded successfully.\nAdded skills:\n- demo-external-skill: Demo skill\nTotal skills: 1.',
+    }))
+  })
+
+  it('rejects skills reload while the session is running', async () => {
+    const state = { messages: [], isWorking: true, events: [], queue: [] }
+    const { bridge, namespaceEmit, runQueuedItem, sessionMap, socket, nsp } = makeContext(state)
+    const { handleSessionCommand, parseSessionCommand } = await import('../../packages/server/src/services/hermes/run-chat/session-command')
+    const command = parseSessionCommand('/reload-skills')!
+
+    await handleSessionCommand('session-1', command, {
+      nsp: nsp as any,
+      socket: socket as any,
+      sessionMap,
+      bridge: bridge as any,
+      profile: 'default',
+      runQueuedItem,
+    })
+
+    expect(bridge.reloadSkills).not.toHaveBeenCalled()
+    expect(runQueuedItem).not.toHaveBeenCalled()
+    expect(state.queue).toEqual([])
+    expect(namespaceEmit).toHaveBeenCalledWith('session.command', expect.objectContaining({
+      command: 'reload-skills',
+      ok: false,
+      action: 'reload-skills',
+      terminal: false,
+      message: 'Skills reload can only run while the session is idle. Wait for the current run to finish or abort it first.',
     }))
   })
 })


### PR DESCRIPTION
## Summary
- add `/reload-skills` as a Web UI chat control command backed by Hermes Agent skill reload
- expose `/reload-skills` in the chat slash command picker with localized labels
- fix the skill picker list item layout so long/default lists scroll without flex-shrinking rows

Fixes #1584

## Validation
- `npm run test -- tests/client/chat-input-draft.test.ts tests/server/session-command-plan.test.ts`
- `python3 -m py_compile packages/server/src/services/hermes/agent-bridge/python/bridge_server.py packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py`
- `npm run harness:check`
- `npm run build`