### PR TITLE
fix: save LongCat preset as custom provider

### DIFF
--- a/packages/server/src/services/config-helpers.ts
+++ b/packages/server/src/services/config-helpers.ts
@@ -46,7 +46,7 @@ export const PROVIDER_ENV_MAP: Record<string, { api_key_env: string; base_url_en
   'openai-codex': { api_key_env: '', base_url_env: '' },
   'openai-api': { api_key_env: 'OPENAI_API_KEY', base_url_env: 'OPENAI_BASE_URL' },
   copilot: { api_key_env: 'GITHUB_TOKEN', base_url_env: '' },
-  longcat: { api_key_env: 'LONGCAT_API_KEY', base_url_env: 'LONGCAT_BASE_URL' },
+  longcat: { api_key_env: '', base_url_env: '' },
   'tencent-tokenhub': { api_key_env: 'TENCENT_TOKENHUB_API_KEY', base_url_env: 'TOKENHUB_BASE_URL' },
 }
 

--- a/tests/server/provider-create-controller.test.ts
+++ b/tests/server/provider-create-controller.test.ts
@@ -99,4 +99,30 @@ describe('providers controller create', () => {
     expect(configAfter.custom_providers).toBeUndefined()
     expect(readFileSync(join(hermesHome, '.env'), 'utf-8')).toBe('')
   })
+
+  it('creates LongCat preset as a custom provider instead of env-backed builtin provider', async () => {
+    const { create } = await loadProvidersController()
+    const ctx = makeCtx({
+      name: 'LongCat',
+      base_url: 'https://api.longcat.chat/openai',
+      api_key: 'longcat-key',
+      model: 'LongCat-2.0-Preview',
+      providerKey: 'longcat',
+    })
+
+    await create(ctx)
+
+    expect(ctx.body).toEqual({ success: true })
+    const configAfter = readYaml(join(hermesHome, 'config.yaml'))
+    expect(configAfter.model).toEqual({ default: 'LongCat-2.0-Preview', provider: 'custom:longcat' })
+    expect(configAfter.custom_providers).toEqual([
+      expect.objectContaining({
+        name: 'longcat',
+        base_url: 'https://api.longcat.chat/openai',
+        api_key: 'longcat-key',
+        model: 'LongCat-2.0-Preview',
+      }),
+    ])
+    expect(readFileSync(join(hermesHome, '.env'), 'utf-8')).not.toContain('LONGCAT_API_KEY')
+  })
 })


### PR DESCRIPTION
## Summary
- keep the LongCat preset visible but stop treating it as an env-backed builtin provider
- save LongCat through the existing custom-provider path so Hermes Agent receives `custom:longcat` instead of unknown provider `longcat`
- add coverage for LongCat preset creation

Fixes #1595

## Validation
- `npm run test -- tests/server/provider-create-controller.test.ts`
- `npm run harness:check`