### PR TITLE
fix: 支持 CLI --no-open 启动

### DIFF
--- a/bin/hermes-web-ui.mjs
+++ b/bin/hermes-web-ui.mjs
@@ -183,6 +183,16 @@ function getPort() {
   return argPort ?? DEFAULT_PORT
 }
 
+function shouldOpenBrowser(argv = process.argv) {
+  return !argv.includes('--no-open')
+}
+
+function getRestartArgs(port, argv = process.argv) {
+  const args = ['restart', '--port', String(port)]
+  if (!shouldOpenBrowser(argv)) args.push('--no-open')
+  return args
+}
+
 function enableClientMode() {
   process.env.HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART = '1'
   process.env.CORS_ORIGINS = '*'
@@ -451,9 +461,11 @@ function startDaemon(port) {
         console.log(`  ✓ hermes-web-ui started`)
         console.log(`    ${url}`)
         console.log(`    Log: ${LOG_FILE}`)
-        const isWin = process.platform === 'win32'
-        const cmd = isWin ? `start ${url}` : process.platform === 'darwin' ? `open ${url}` : `xdg-open ${url}`
-        try { execSync(cmd, { stdio: 'ignore' }) } catch {}
+        if (shouldOpenBrowser()) {
+          const isWin = process.platform === 'win32'
+          const cmd = isWin ? `start ${url}` : process.platform === 'darwin' ? `open ${url}` : `xdg-open ${url}`
+          try { execSync(cmd, { stdio: 'ignore' }) } catch {}
+        }
       } else if (waited < maxWait) {
         setTimeout(poll, interval)
       } else {
@@ -655,6 +667,7 @@ Commands:
 Options:
   -v, --version      Show version number
   -h, --help         Show this help message
+  --no-open          Do not open a browser after startup
   --port <port>      Specify port (used with start/client/restart)
   --restart          Restart after clear-login-locks
 `)
@@ -758,7 +771,7 @@ function runUpdateInstall(npm) {
         process.exit(1)
       }
 
-      const restart = spawnCli(cli, ['restart', '--port', String(getUpdatePort())], {
+      const restart = spawnCli(cli, getRestartArgs(getUpdatePort()), {
         stdio: 'inherit',
         windowsHide: true,
         env: getCurrentNodeEnv(),
@@ -787,7 +800,9 @@ export {
   commandExists,
   getDaemonStopGraceMs,
   getListeningPids,
+  getRestartArgs,
   parseUnixNetstatListeningPids,
   resetDefaultLogin,
+  shouldOpenBrowser,
   stopDaemon,
 }

--- a/tests/server/cli-port-detection.test.ts
+++ b/tests/server/cli-port-detection.test.ts
@@ -157,6 +157,30 @@ describe('CLI port detection', () => {
     expect(getDaemonStopGraceMs()).toBe(9_000)
   })
 
+  it('skips browser launch when --no-open is provided', async () => {
+    const { shouldOpenBrowser } = await loadCli()
+
+    expect(shouldOpenBrowser(['node', 'bin/hermes-web-ui.mjs', 'start'])).toBe(true)
+    expect(shouldOpenBrowser(['node', 'bin/hermes-web-ui.mjs', 'start', '--no-open'])).toBe(false)
+    expect(shouldOpenBrowser(['node', 'bin/hermes-web-ui.mjs', 'restart', '--port', '9000', '--no-open'])).toBe(false)
+  })
+
+  it('preserves --no-open when update respawns restart', async () => {
+    const { getRestartArgs } = await loadCli()
+
+    expect(getRestartArgs(9000, ['node', 'bin/hermes-web-ui.mjs', 'update', '--port', '9000'])).toEqual([
+      'restart',
+      '--port',
+      '9000',
+    ])
+    expect(getRestartArgs(9000, ['node', 'bin/hermes-web-ui.mjs', 'update', '--port', '9000', '--no-open'])).toEqual([
+      'restart',
+      '--port',
+      '9000',
+      '--no-open',
+    ])
+  })
+
   it('resets an existing admin user to the default password', async () => {
     const home = mkdtempSync(join(tmpdir(), 'hermes-web-ui-cli-default-login-'))
     process.env.HERMES_WEB_UI_HOME = home


### PR DESCRIPTION
## 改动

Fixes #584.

新增 `--no-open` 启动参数，允许 `hermes-web-ui` 启动后不自动打开浏览器。

同时在自更新后的重启参数里保留 `--no-open`，避免用户本来选择静默启动，但更新重启后又打开浏览器。

## 验证

以下验证已通过：

- `npx vitest run tests/server/cli-port-detection.test.ts`
- `git diff --check origin/main...HEAD`
