### PR TITLE
fix: 安全显示工作区 junction 目录

### DIFF
--- a/docs/chat-chain-changes/2026-06-16-pr1605-workspace-junction-listing.md
+++ b/docs/chat-chain-changes/2026-06-16-pr1605-workspace-junction-listing.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-16
+pr: 1605
+feature: Workspace junction listing
+impact: Workspace folder discovery now includes in-bound symlink or junction directories while keeping file operations inside the configured workspace root.
+---

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -823,16 +823,11 @@ export async function listWorkspaceFolders(ctx: any) {
   const { resolve, join } = await import('path')
   const { readdir } = await import('fs/promises')
   const { existsSync } = await import('fs')
-  const { homedir } = await import('os')
-
-  const WORKSPACE_BASE = process.env.WORKSPACE_BASE?.trim() || homedir()
+  const { base: WORKSPACE_BASE, realBase: realWorkspaceBase } = await getWorkspaceBaseInfo()
   const subPath = (ctx.query.path as string) || ''
 
-  // Security: prevent path traversal
   const fullPath = resolve(join(WORKSPACE_BASE, subPath))
-  if (!isPathWithin(fullPath, WORKSPACE_BASE)) {
-    ctx.status = 403
-    ctx.body = { error: 'Access denied' }
+  if (!await ensureWorkspacePathAllowed(ctx, fullPath, WORKSPACE_BASE, realWorkspaceBase)) {
     return
   }
 
@@ -843,14 +838,37 @@ export async function listWorkspaceFolders(ctx: any) {
   }
 
   try {
+    const { realpath, stat } = await import('fs/promises')
     const entries = await readdir(fullPath, { withFileTypes: true })
-    const folders = entries
-      .filter(e => e.isDirectory() && !e.name.startsWith('.'))
-      .map(e => ({
-        name: e.name,
-        path: subPath ? `${subPath}/${e.name}` : e.name,
-        fullPath: join(fullPath, e.name),
-      }))
+    const folders = (await Promise.all(entries.map(async (entry) => {
+      if (entry.name.startsWith('.')) return null
+
+      const entryFullPath = join(fullPath, entry.name)
+      let isDirectory = entry.isDirectory()
+
+      if (!isDirectory && entry.isSymbolicLink()) {
+        try {
+          const info = await stat(entryFullPath)
+          isDirectory = info.isDirectory()
+        } catch {
+          return null
+        }
+      }
+
+      if (!isDirectory) return null
+
+      try {
+        if (!isPathWithin(await realpath(entryFullPath), realWorkspaceBase)) return null
+      } catch {
+        return null
+      }
+
+      return {
+        name: entry.name,
+        path: subPath ? `${subPath}/${entry.name}` : entry.name,
+        fullPath: entryFullPath,
+      }
+    }))).filter((entry): entry is { name: string; path: string; fullPath: string } => Boolean(entry))
       .sort((a, b) => a.name.localeCompare(b.name))
 
     ctx.body = { base: WORKSPACE_BASE, current: subPath, folders }
@@ -869,14 +887,58 @@ function invalidWorkspaceFolderName(name: string): boolean {
     name.includes('\0')
 }
 
-async function resolveWorkspaceFolderPath(ctx: any, inputPath: string) {
-  const { resolve, join } = await import('path')
+async function getWorkspaceBaseInfo() {
+  const { realpath } = await import('fs/promises')
   const { homedir } = await import('os')
-  const WORKSPACE_BASE = process.env.WORKSPACE_BASE?.trim() || homedir()
-  const fullPath = resolve(join(WORKSPACE_BASE, inputPath || ''))
-  if (!isPathWithin(fullPath, WORKSPACE_BASE)) {
+  const { resolve } = await import('path')
+
+  const base = resolve(process.env.WORKSPACE_BASE?.trim() || homedir())
+  let realBase = base
+  try {
+    realBase = await realpath(base)
+  } catch {
+    // Fall back to lexical base; missing base will be handled by the caller.
+  }
+  return { base, realBase }
+}
+
+async function ensureWorkspacePathAllowed(ctx: any, fullPath: string, basePath: string, realBasePath: string): Promise<boolean> {
+  const { realpath } = await import('fs/promises')
+  const { dirname } = await import('path')
+
+  if (!isPathWithin(fullPath, basePath)) {
     ctx.status = 403
     ctx.body = { error: 'Access denied' }
+    return false
+  }
+
+  let pathToCheck = fullPath
+  while (true) {
+    try {
+      if (!isPathWithin(await realpath(pathToCheck), realBasePath)) {
+        ctx.status = 403
+        ctx.body = { error: 'Access denied' }
+        return false
+      }
+      return true
+    } catch (err: any) {
+      if (err?.code !== 'ENOENT' && err?.code !== 'ENOTDIR') throw err
+      const parentPath = dirname(pathToCheck)
+      if (parentPath === pathToCheck) {
+        ctx.status = 403
+        ctx.body = { error: 'Access denied' }
+        return false
+      }
+      pathToCheck = parentPath
+    }
+  }
+}
+
+async function resolveWorkspaceFolderPath(ctx: any, inputPath: string) {
+  const { resolve, join } = await import('path')
+  const { base: WORKSPACE_BASE, realBase: realWorkspaceBase } = await getWorkspaceBaseInfo()
+  const fullPath = resolve(join(WORKSPACE_BASE, inputPath || ''))
+  if (!await ensureWorkspacePathAllowed(ctx, fullPath, WORKSPACE_BASE, realWorkspaceBase)) {
     return null
   }
   return { base: WORKSPACE_BASE, fullPath }

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { join } from 'path'
 
 const listConversationSummariesFromDbMock = vi.fn()
 const getConversationDetailFromDbMock = vi.fn()
@@ -32,6 +33,7 @@ const bridgeGetRuntimeStateMock = vi.fn()
 const codingAgentRunManagerMock = vi.hoisted(() => ({
   stop: vi.fn(),
 }))
+const originalWorkspaceBase = process.env.WORKSPACE_BASE
 
 vi.mock('../../packages/server/src/db/hermes/conversations-db', () => ({
   listConversationSummariesFromDb: listConversationSummariesFromDbMock,
@@ -174,6 +176,13 @@ describe('session conversations controller', () => {
     bridgeGetRuntimeStateMock.mockReset()
     bridgeGetRuntimeStateMock.mockReturnValue({ ready: false, running: false, endpoint: 'ipc:///tmp/hermes-agent-bridge.sock' })
     codingAgentRunManagerMock.stop.mockReset()
+  })
+
+  afterEach(() => {
+    vi.doUnmock('fs')
+    vi.doUnmock('fs/promises')
+    if (originalWorkspaceBase === undefined) delete process.env.WORKSPACE_BASE
+    else process.env.WORKSPACE_BASE = originalWorkspaceBase
   })
 
   it('lists conversations from the local session store', async () => {
@@ -929,6 +938,120 @@ describe('session conversations controller', () => {
     }))
     expect(localUpdateSessionMock.mock.calls.at(-1)?.[1].last_active).toBeGreaterThan(200)
     expect(ctx.body).toMatchObject({ ok: true, imported: true })
+  })
+
+  it('lists visible directory symlinks, skips broken links, and excludes external targets including junction-like dirents', async () => {
+    const workspaceBase = join(process.cwd(), 'workspace-base')
+    const currentPath = join(workspaceBase, 'parent')
+    const alphaPath = join(currentPath, 'alpha')
+    const safeLinkedPath = join(currentPath, 'linked-dir')
+    const externalLinkedPath = join(currentPath, 'linked-outside')
+    const externalJunctionPath = join(currentPath, 'junction-outside')
+    const directoryEntry = { name: 'alpha', isDirectory: () => true, isSymbolicLink: () => false }
+    const symlinkDirectoryEntry = { name: 'linked-dir', isDirectory: () => false, isSymbolicLink: () => true }
+    const externalSymlinkEntry = { name: 'linked-outside', isDirectory: () => false, isSymbolicLink: () => true }
+    const externalJunctionEntry = { name: 'junction-outside', isDirectory: () => true, isSymbolicLink: () => true }
+    const symlinkFileEntry = { name: 'linked-file', isDirectory: () => false, isSymbolicLink: () => true }
+    const brokenSymlinkEntry = { name: 'broken-link', isDirectory: () => false, isSymbolicLink: () => true }
+    const hiddenSymlinkEntry = { name: '.hidden-link', isDirectory: () => false, isSymbolicLink: () => true }
+    const fileEntry = { name: 'notes.txt', isDirectory: () => false, isSymbolicLink: () => false }
+    const existsSyncMock = vi.fn(() => true)
+    const readdirMock = vi.fn(async () => [
+      symlinkDirectoryEntry,
+      externalSymlinkEntry,
+      directoryEntry,
+      externalJunctionEntry,
+      symlinkFileEntry,
+      brokenSymlinkEntry,
+      hiddenSymlinkEntry,
+      fileEntry,
+    ])
+    const statMock = vi.fn(async (entryPath: string) => {
+      if (entryPath === safeLinkedPath) return { isDirectory: () => true }
+      if (entryPath === externalLinkedPath) return { isDirectory: () => true }
+      if (entryPath === join(currentPath, 'linked-file')) return { isDirectory: () => false }
+      if (entryPath === join(currentPath, 'broken-link')) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      throw new Error(`unexpected stat path: ${entryPath}`)
+    })
+    const realpathMock = vi.fn(async (entryPath: string) => {
+      if (entryPath === workspaceBase) return workspaceBase
+      if (entryPath === currentPath) return currentPath
+      if (entryPath === alphaPath) return alphaPath
+      if (entryPath === safeLinkedPath) return join(workspaceBase, 'resolved-linked-dir')
+      if (entryPath === externalLinkedPath) return join(process.cwd(), 'outside-workspace')
+      if (entryPath === externalJunctionPath) return join(process.cwd(), 'outside-workspace-junction')
+      throw new Error(`unexpected realpath path: ${entryPath}`)
+    })
+
+    vi.doMock('fs', async () => ({
+      ...(await vi.importActual<typeof import('fs')>('fs')),
+      existsSync: existsSyncMock,
+    }))
+    vi.doMock('fs/promises', async () => ({
+      ...(await vi.importActual<typeof import('fs/promises')>('fs/promises')),
+      readdir: readdirMock,
+      realpath: realpathMock,
+      stat: statMock,
+    }))
+    process.env.WORKSPACE_BASE = workspaceBase
+
+    const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+    const ctx: any = { query: { path: 'parent' }, body: null }
+
+    await mod.listWorkspaceFolders(ctx)
+
+    expect(realpathMock).toHaveBeenCalledWith(workspaceBase)
+    expect(realpathMock).toHaveBeenCalledWith(currentPath)
+    expect(existsSyncMock).toHaveBeenCalledWith(currentPath)
+    expect(readdirMock).toHaveBeenCalledWith(currentPath, { withFileTypes: true })
+    expect(realpathMock).toHaveBeenCalledWith(alphaPath)
+    expect(statMock).toHaveBeenCalledWith(safeLinkedPath)
+    expect(statMock).toHaveBeenCalledWith(externalLinkedPath)
+    expect(statMock).toHaveBeenCalledWith(join(currentPath, 'linked-file'))
+    expect(statMock).toHaveBeenCalledWith(join(currentPath, 'broken-link'))
+    expect(realpathMock).toHaveBeenCalledWith(safeLinkedPath)
+    expect(realpathMock).toHaveBeenCalledWith(externalLinkedPath)
+    expect(realpathMock).toHaveBeenCalledWith(externalJunctionPath)
+    expect(statMock).not.toHaveBeenCalledWith(externalJunctionPath)
+    expect(statMock).not.toHaveBeenCalledWith(join(currentPath, '.hidden-link'))
+    expect(ctx.status).toBeUndefined()
+    expect(ctx.body).toEqual({
+      base: workspaceBase,
+      current: 'parent',
+      folders: [
+        { name: 'alpha', path: 'parent/alpha', fullPath: join(currentPath, 'alpha') },
+        { name: 'linked-dir', path: 'parent/linked-dir', fullPath: safeLinkedPath },
+      ],
+    })
+  })
+
+  it('rejects workspace folder creation through a symlink that resolves outside the workspace base', async () => {
+    const workspaceBase = join(process.cwd(), 'workspace-base')
+    const escapeLinkPath = join(workspaceBase, 'escape-link')
+    const mkdirMock = vi.fn()
+    const realpathMock = vi.fn(async (entryPath: string) => {
+      if (entryPath === workspaceBase) return workspaceBase
+      if (entryPath === escapeLinkPath) return join(process.cwd(), 'outside-workspace')
+      throw new Error(`unexpected realpath path: ${entryPath}`)
+    })
+
+    vi.doMock('fs/promises', async () => ({
+      ...(await vi.importActual<typeof import('fs/promises')>('fs/promises')),
+      mkdir: mkdirMock,
+      realpath: realpathMock,
+    }))
+    process.env.WORKSPACE_BASE = workspaceBase
+
+    const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+    const ctx: any = { request: { body: { parentPath: 'escape-link', name: 'child' } }, body: null }
+
+    await mod.createWorkspaceFolder(ctx)
+
+    expect(realpathMock).toHaveBeenCalledWith(workspaceBase)
+    expect(realpathMock).toHaveBeenCalledWith(escapeLinkPath)
+    expect(mkdirMock).not.toHaveBeenCalled()
+    expect(ctx.status).toBe(403)
+    expect(ctx.body).toEqual({ error: 'Access denied' })
   })
 
   describe('exportSession', () => {


### PR DESCRIPTION
## 改动

Fixes #1456.

工作区目录列表现在会显示符号链接或 junction 形式的目录，但只允许真实路径仍在工作区根目录内的目标。

同一套真实路径校验也用于工作区目录的新建、重命名、删除路径解析，避免通过链接目录逃出工作区边界。

## 验证

以下验证已通过：

- `npx vitest run tests/server/sessions-controller.test.ts tests/server/sessions-routes.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `git diff --check origin/main...HEAD`

说明：本地没有 Windows runtime，测试覆盖了 symlink/junction-like 目录和外部目标拒绝路径。
