### PR TITLE
fix: 透传未知斜杠命令输入

### DIFF
--- a/docs/chat-chain-changes/2026-06-16-pr1607-slash-command-passthrough.md
+++ b/docs/chat-chain-changes/2026-06-16-pr1607-slash-command-passthrough.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-16
+pr: 1607
+feature: Unknown slash command passthrough
+impact: Unknown slash-prefixed chat input now reaches the agent as normal user text while known Web UI session commands keep their existing handling.
+---

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -18,6 +18,7 @@ import { transcribeSpeech } from '@/api/hermes/stt'
 import type { StoredSttProvider } from '@/api/hermes/stt-settings'
 import { useSttSettings } from '@/composables/useSttSettings'
 import { useBrowserSpeechRecognition } from '@/composables/useBrowserSpeechRecognition'
+import { BRIDGE_SESSION_COMMAND_DEFINITIONS } from '@/utils/hermes/bridge-session-commands'
 
 const chatStore = useChatStore()
 const appStore = useAppStore()
@@ -175,29 +176,16 @@ const voiceDialogueError = computed(() =>
   ?? null,
 )
 
-const bridgeCommands = computed<SlashCommandOption[]>(() => [
-  { key: 'command:usage', name: 'usage', args: '', description: t('chat.slashCommands.usage') },
-  { key: 'command:status', name: 'status', args: '', description: t('chat.slashCommands.status') },
-  { key: 'command:abort', name: 'abort', args: '', description: t('chat.slashCommands.abort') },
-  { key: 'command:queue', name: 'queue', args: t('chat.slashCommandArgs.message'), description: t('chat.slashCommands.queue') },
-  { key: 'command:skill', name: 'skill', args: '', description: t('skills.title'), opensSkillPicker: true },
-  { key: 'command:plan', name: 'plan', args: t('chat.slashCommandArgs.text'), description: t('chat.slashCommands.plan') },
-  { key: 'command:goal', name: 'goal', args: t('chat.slashCommandArgs.text'), description: t('chat.slashCommands.goal') },
-  { key: 'command:goal-status', name: 'goal', args: 'status', insertText: 'goal status', description: t('chat.slashCommands.goalStatus') },
-  { key: 'command:goal-pause', name: 'goal', args: 'pause', insertText: 'goal pause', description: t('chat.slashCommands.goalPause') },
-  { key: 'command:goal-resume', name: 'goal', args: 'resume', insertText: 'goal resume', description: t('chat.slashCommands.goalResume') },
-  { key: 'command:goal-done', name: 'goal', args: 'done', insertText: 'goal done', description: t('chat.slashCommands.goalDone') },
-  { key: 'command:goal-clear', name: 'goal', args: 'clear', insertText: 'goal clear', description: t('chat.slashCommands.goalClear') },
-  { key: 'command:subgoal', name: 'subgoal', args: t('chat.slashCommandArgs.text'), description: t('chat.slashCommands.subgoal') },
-  { key: 'command:clear', name: 'clear', args: '', description: t('chat.slashCommands.clear') },
-  { key: 'command:clear-history', name: 'clear', args: '--history', insertText: 'clear --history', description: t('chat.slashCommands.clearHistory') },
-  { key: 'command:title', name: 'title', args: t('chat.slashCommandArgs.title'), description: t('chat.slashCommands.title') },
-  { key: 'command:compress', name: 'compress', args: '', description: t('chat.slashCommands.compress') },
-  { key: 'command:steer', name: 'steer', args: t('chat.slashCommandArgs.text'), description: t('chat.slashCommands.steer') },
-  { key: 'command:destroy', name: 'destroy', args: '', description: t('chat.slashCommands.destroy') },
-  { key: 'command:reload-mcp', name: 'reload-mcp', args: '', description: t('chat.slashCommands.reloadMcp') },
-  { key: 'command:reload-skills', name: 'reload-skills', args: '', description: t('chat.slashCommands.reloadSkills') },
-])
+const bridgeCommands = computed<SlashCommandOption[]>(() =>
+  BRIDGE_SESSION_COMMAND_DEFINITIONS.map(command => ({
+    key: command.key,
+    name: command.name,
+    args: command.argsKey ? t(command.argsKey) : command.args || '',
+    description: t(command.descriptionKey),
+    insertText: command.insertText,
+    opensSkillPicker: command.opensSkillPicker,
+  }))
+)
 
 const slashActive = ref(false)
 const slashQuery = ref('')

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -228,12 +228,13 @@ const skillPickerItems = computed(() => {
   })
 })
 const filteredBridgeCommands = computed(() => {
-  const query = slashQuery.value.toLowerCase()
-  return bridgeCommands.value.filter(command =>
-    command.name.includes(query)
-    || command.insertText?.includes(query)
-    || command.description.toLowerCase().includes(query),
-  )
+  const query = slashQuery.value.trim().toLowerCase()
+  if (!query) return bridgeCommands.value
+  return bridgeCommands.value.filter((command) => {
+    const name = command.name.toLowerCase()
+    const insertText = command.insertText?.toLowerCase()
+    return name.startsWith(query) || insertText?.startsWith(query)
+  })
 })
 const filteredSkillPickerItems = computed(() => {
   const query = skillSearch.value.trim().toLowerCase()

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -10,31 +10,13 @@ import { useSettingsStore } from './settings'
 import { primeCompletionSound, playCompletionSound } from '@/utils/completion-sound'
 import { showCompletionNotification } from '@/utils/completion-notification'
 import { detectThinkingBoundary } from '@/utils/thinking-parser'
+import { isKnownBridgeSessionCommand } from '@/utils/hermes/bridge-session-commands'
 
 // Re-export ContentBlock for convenience
 export type ContentBlock = ContentBlockImport
 
 export const LIVE_CHAT_MESSAGE_PAGE_SIZE = 150
 export const LIVE_CHAT_MAX_LOADED_MESSAGES = 300
-
-const BRIDGE_SLASH_COMMANDS = new Set([
-  'usage',
-  'status',
-  'abort',
-  'queue',
-  'skill',
-  'plan',
-  'goal',
-  'subgoal',
-  'clear',
-  'title',
-  'compress',
-  'steer',
-  'destroy',
-  'reload-mcp',
-  'reload-skills',
-  'reload_skills',
-])
 
 export interface Attachment {
   id: string
@@ -138,14 +120,6 @@ interface CompressionState {
 
 function uid(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
-}
-
-function isKnownBridgeSlashCommand(input: string): boolean {
-  const trimmed = input.trim()
-  if (!trimmed.startsWith('/')) return false
-  const match = trimmed.match(/^\/([a-zA-Z][\w-]*)(?:\s|$)/)
-  if (!match) return false
-  return BRIDGE_SLASH_COMMANDS.has(match[1].toLowerCase())
 }
 
 function isToolOutputError(output: unknown): boolean {
@@ -1830,7 +1804,7 @@ export const useChatStore = defineStore('chat', () => {
       ? activeSession.value.messageCount == null || activeSession.value.messageCount === 0
       : false
     const isCodingAgentSession = isCodingAgentLikeSession(activeSession.value)
-    const isBridgeSlashCommand = !isCodingAgentSession && isKnownBridgeSlashCommand(trimmedContent)
+    const isBridgeSlashCommand = !isCodingAgentSession && isKnownBridgeSessionCommand(trimmedContent)
     const isBridgeCompressCommand = isBridgeSlashCommand && /^\/compress(?:\s|$)/i.test(trimmedContent)
     const isBridgePlanCommand = isBridgeSlashCommand && /^\/plan(?:\s|$)/i.test(trimmedContent)
     const isBridgeSkillCommand = isBridgeSlashCommand && /^\/skill(?:\s|$)/i.test(trimmedContent)

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -17,6 +17,25 @@ export type ContentBlock = ContentBlockImport
 export const LIVE_CHAT_MESSAGE_PAGE_SIZE = 150
 export const LIVE_CHAT_MAX_LOADED_MESSAGES = 300
 
+const BRIDGE_SLASH_COMMANDS = new Set([
+  'usage',
+  'status',
+  'abort',
+  'queue',
+  'skill',
+  'plan',
+  'goal',
+  'subgoal',
+  'clear',
+  'title',
+  'compress',
+  'steer',
+  'destroy',
+  'reload-mcp',
+  'reload-skills',
+  'reload_skills',
+])
+
 export interface Attachment {
   id: string
   name: string
@@ -119,6 +138,14 @@ interface CompressionState {
 
 function uid(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+}
+
+function isKnownBridgeSlashCommand(input: string): boolean {
+  const trimmed = input.trim()
+  if (!trimmed.startsWith('/')) return false
+  const match = trimmed.match(/^\/([a-zA-Z][\w-]*)(?:\s|$)/)
+  if (!match) return false
+  return BRIDGE_SLASH_COMMANDS.has(match[1].toLowerCase())
 }
 
 function isToolOutputError(output: unknown): boolean {
@@ -1790,6 +1817,8 @@ export const useChatStore = defineStore('chat', () => {
 
     primeCompletionBellIfEnabled()
 
+    const trimmedContent = content.trim()
+
     if (!activeSession.value) {
       const session = createSession()
       switchSession(session.id)
@@ -1801,18 +1830,18 @@ export const useChatStore = defineStore('chat', () => {
       ? activeSession.value.messageCount == null || activeSession.value.messageCount === 0
       : false
     const isCodingAgentSession = isCodingAgentLikeSession(activeSession.value)
-    const isBridgeSlashCommand = !isCodingAgentSession && content.trim().startsWith('/')
-    const isBridgeCompressCommand = isBridgeSlashCommand && /^\/compress(?:\s|$)/i.test(content.trim())
-    const isBridgePlanCommand = isBridgeSlashCommand && /^\/plan(?:\s|$)/i.test(content.trim())
-    const isBridgeSkillCommand = isBridgeSlashCommand && /^\/skill(?:\s|$)/i.test(content.trim())
-    const isBridgeGoalCommand = isBridgeSlashCommand && /^\/goal(?:\s|$)/i.test(content.trim())
+    const isBridgeSlashCommand = !isCodingAgentSession && isKnownBridgeSlashCommand(trimmedContent)
+    const isBridgeCompressCommand = isBridgeSlashCommand && /^\/compress(?:\s|$)/i.test(trimmedContent)
+    const isBridgePlanCommand = isBridgeSlashCommand && /^\/plan(?:\s|$)/i.test(trimmedContent)
+    const isBridgeSkillCommand = isBridgeSlashCommand && /^\/skill(?:\s|$)/i.test(trimmedContent)
+    const isBridgeGoalCommand = isBridgeSlashCommand && /^\/goal(?:\s|$)/i.test(trimmedContent)
     const wasLiveBeforeSend = isSessionLive(sid)
     const shouldQueue = wasLiveBeforeSend && (!isBridgeSlashCommand || isBridgePlanCommand || isBridgeSkillCommand)
 
     const userMsg: Message = {
       id: uid(),
       role: isBridgeSlashCommand ? 'command' : 'user',
-      content: content.trim(),
+      content: trimmedContent,
       timestamp: Date.now(),
       attachments: attachments && attachments.length > 0 ? attachments : undefined,
       queued: shouldQueue,
@@ -1861,7 +1890,7 @@ export const useChatStore = defineStore('chat', () => {
         input = await buildContentBlocks(content, attachments, uploaded)
       } else {
         // No attachments: use plain text format
-        input = content.trim()
+        input = trimmedContent
       }
 
       const appStore = useAppStore()

--- a/packages/client/src/utils/hermes/bridge-session-commands.ts
+++ b/packages/client/src/utils/hermes/bridge-session-commands.ts
@@ -1,0 +1,80 @@
+export type BridgeSessionCommandName =
+  | 'usage'
+  | 'status'
+  | 'abort'
+  | 'queue'
+  | 'skill'
+  | 'plan'
+  | 'goal'
+  | 'subgoal'
+  | 'clear'
+  | 'title'
+  | 'compress'
+  | 'steer'
+  | 'destroy'
+  | 'reload-mcp'
+  | 'reload-skills'
+
+export interface BridgeSessionCommandDefinition {
+  key: string
+  name: BridgeSessionCommandName
+  descriptionKey: string
+  argsKey?: string
+  args?: string
+  insertText?: string
+  opensSkillPicker?: boolean
+}
+
+export const BRIDGE_SESSION_COMMAND_DEFINITIONS: BridgeSessionCommandDefinition[] = [
+  { key: 'command:usage', name: 'usage', args: '', descriptionKey: 'chat.slashCommands.usage' },
+  { key: 'command:status', name: 'status', args: '', descriptionKey: 'chat.slashCommands.status' },
+  { key: 'command:abort', name: 'abort', args: '', descriptionKey: 'chat.slashCommands.abort' },
+  { key: 'command:queue', name: 'queue', argsKey: 'chat.slashCommandArgs.message', descriptionKey: 'chat.slashCommands.queue' },
+  { key: 'command:skill', name: 'skill', args: '', descriptionKey: 'skills.title', opensSkillPicker: true },
+  { key: 'command:plan', name: 'plan', argsKey: 'chat.slashCommandArgs.text', descriptionKey: 'chat.slashCommands.plan' },
+  { key: 'command:goal', name: 'goal', argsKey: 'chat.slashCommandArgs.text', descriptionKey: 'chat.slashCommands.goal' },
+  { key: 'command:goal-status', name: 'goal', args: 'status', insertText: 'goal status', descriptionKey: 'chat.slashCommands.goalStatus' },
+  { key: 'command:goal-pause', name: 'goal', args: 'pause', insertText: 'goal pause', descriptionKey: 'chat.slashCommands.goalPause' },
+  { key: 'command:goal-resume', name: 'goal', args: 'resume', insertText: 'goal resume', descriptionKey: 'chat.slashCommands.goalResume' },
+  { key: 'command:goal-done', name: 'goal', args: 'done', insertText: 'goal done', descriptionKey: 'chat.slashCommands.goalDone' },
+  { key: 'command:goal-clear', name: 'goal', args: 'clear', insertText: 'goal clear', descriptionKey: 'chat.slashCommands.goalClear' },
+  { key: 'command:subgoal', name: 'subgoal', argsKey: 'chat.slashCommandArgs.text', descriptionKey: 'chat.slashCommands.subgoal' },
+  { key: 'command:clear', name: 'clear', args: '', descriptionKey: 'chat.slashCommands.clear' },
+  { key: 'command:clear-history', name: 'clear', args: '--history', insertText: 'clear --history', descriptionKey: 'chat.slashCommands.clearHistory' },
+  { key: 'command:title', name: 'title', argsKey: 'chat.slashCommandArgs.title', descriptionKey: 'chat.slashCommands.title' },
+  { key: 'command:compress', name: 'compress', args: '', descriptionKey: 'chat.slashCommands.compress' },
+  { key: 'command:steer', name: 'steer', argsKey: 'chat.slashCommandArgs.text', descriptionKey: 'chat.slashCommands.steer' },
+  { key: 'command:destroy', name: 'destroy', args: '', descriptionKey: 'chat.slashCommands.destroy' },
+  { key: 'command:reload-mcp', name: 'reload-mcp', args: '', descriptionKey: 'chat.slashCommands.reloadMcp' },
+  { key: 'command:reload-skills', name: 'reload-skills', args: '', descriptionKey: 'chat.slashCommands.reloadSkills' },
+]
+
+export const BRIDGE_SESSION_COMMAND_NAMES = Array.from(
+  new Set(BRIDGE_SESSION_COMMAND_DEFINITIONS.map(command => command.name)),
+)
+
+const BRIDGE_SESSION_COMMAND_ALIASES = new Map<string, BridgeSessionCommandName>([
+  ['reload_skills', 'reload-skills'],
+])
+
+export function normalizeBridgeSessionCommandName(name: string): BridgeSessionCommandName | null {
+  const normalized = name.trim().toLowerCase()
+  if (!normalized) return null
+  const alias = BRIDGE_SESSION_COMMAND_ALIASES.get(normalized)
+  if (alias) return alias
+  return (BRIDGE_SESSION_COMMAND_NAMES as string[]).includes(normalized)
+    ? normalized as BridgeSessionCommandName
+    : null
+}
+
+export function readBridgeSessionCommandName(input: string): BridgeSessionCommandName | null {
+  const trimmed = input.trim()
+  if (!trimmed.startsWith('/')) return null
+  const match = trimmed.match(/^\/([a-zA-Z][\w-]*)(?:\s|$)/)
+  if (!match) return null
+  return normalizeBridgeSessionCommandName(match[1])
+}
+
+export function isKnownBridgeSessionCommand(input: string): boolean {
+  return readBridgeSessionCommandName(input) !== null
+}

--- a/packages/server/src/services/hermes/run-chat/session-command.ts
+++ b/packages/server/src/services/hermes/run-chat/session-command.ts
@@ -73,7 +73,7 @@ export function parseSessionCommand(input: string | ContentBlock[]): ParsedSessi
   if (!match) return null
   const rawName = match[1].toLowerCase()
   const name = COMMAND_ALIASES[rawName]
-  if (!name) return { name: 'status', rawName, args: match[2]?.trim() || '' }
+  if (!name) return null
   return { name, rawName, args: match[2]?.trim() || '' }
 }
 
@@ -89,8 +89,7 @@ export async function handleSessionCommand(
   const state = getOrCreateSession(ctx.sessionMap, sessionId)
   ctx.socket.join(`session:${sessionId}`)
   ensureCommandSession(sessionId, command, ctx)
-  const isKnownCommand = Boolean(COMMAND_ALIASES[command.rawName])
-  if (command.name !== 'plan' && command.name !== 'skill' && isKnownCommand) {
+  if (command.name !== 'plan' && command.name !== 'skill') {
     persistCommandMessage(sessionId, state, `/${command.rawName}${command.args ? ` ${command.args}` : ''}`)
   }
 
@@ -196,17 +195,6 @@ export async function handleSessionCommand(
       action: 'error',
       terminal: !state.isWorking,
       message: result?.message || `Unknown bridge command: /${command.rawName}`,
-    })
-    return
-  }
-
-  if (!isKnownCommand) {
-    if (state.isWorking) emitQueuedState(ctx, sessionId, state)
-    emitCommand({
-      ok: false,
-      action: 'error',
-      terminal: !state.isWorking,
-      message: `Unknown bridge command: /${command.rawName}`,
     })
     return
   }

--- a/tests/client/chat-input-draft.test.ts
+++ b/tests/client/chat-input-draft.test.ts
@@ -182,4 +182,18 @@ describe('ChatInput draft persistence', () => {
 
     expect((textarea.element as HTMLTextAreaElement).value).toBe('/skill github-pr-review ')
   })
+
+  it('hides bridge autocomplete for non-Hermes slash prefixes', async () => {
+    const wrapper = mountForSession('session-prefixes')
+    const textarea = wrapper.get('textarea')
+
+    await textarea.setValue('/')
+    await nextTick()
+    expect(wrapper.findAll('.slash-command-item').length).toBeGreaterThan(0)
+
+    await textarea.setValue('/ter')
+    await nextTick()
+
+    expect(wrapper.find('.slash-command-dropdown').exists()).toBe(false)
+  })
 })

--- a/tests/client/chat-store-reasoning-tool-boundary.test.ts
+++ b/tests/client/chat-store-reasoning-tool-boundary.test.ts
@@ -264,6 +264,32 @@ describe('chat store reasoning/tool boundaries', () => {
     ])
   })
 
+  it('sends unknown slash commands in idle bridge sessions as normal user input', async () => {
+    const store = useChatStore()
+    const session = makeSession()
+    session.source = 'cli'
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    await store.sendMessage('/terminal pwd')
+
+    expect(chatApi.startRunViaSocket).toHaveBeenCalledTimes(1)
+    expect(chatApi.startRunViaSocket.mock.calls[0][0]).toEqual(expect.objectContaining({
+      input: '/terminal pwd',
+      session_id: 'session-1',
+      source: 'cli',
+    }))
+    expect(store.messages).toEqual([
+      expect.objectContaining({
+        role: 'user',
+        content: '/terminal pwd',
+        queued: false,
+        systemType: undefined,
+      }),
+    ])
+  })
+
   it('starts global coding-agent runs without provider credentials', async () => {
     const store = useChatStore()
     const session = makeSession()

--- a/tests/client/chat-store-reasoning-tool-boundary.test.ts
+++ b/tests/client/chat-store-reasoning-tool-boundary.test.ts
@@ -232,6 +232,38 @@ describe('chat store reasoning/tool boundaries', () => {
     ])
   })
 
+  it('queues unknown slash commands in bridge sessions as normal user input', async () => {
+    const store = useChatStore()
+    const session = makeSession()
+    session.source = 'cli'
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    await store.sendMessage('first input')
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: RunEvent) => void
+    onEvent({ event: 'run.started', session_id: 'session-1' })
+
+    await store.sendMessage('/terminal pwd')
+
+    expect(chatApi.startRunViaSocket).toHaveBeenCalledTimes(2)
+    expect(store.queuedUserMessages.get('session-1')).toEqual([
+      expect.objectContaining({
+        role: 'user',
+        content: '/terminal pwd',
+        queued: true,
+        systemType: undefined,
+      }),
+    ])
+    expect(store.messages).toEqual([
+      expect.objectContaining({
+        role: 'user',
+        content: 'first input',
+        queued: false,
+      }),
+    ])
+  })
+
   it('starts global coding-agent runs without provider credentials', async () => {
     const store = useChatStore()
     const session = makeSession()

--- a/tests/server/run-chat-queued-item.test.ts
+++ b/tests/server/run-chat-queued-item.test.ts
@@ -6,6 +6,11 @@ const handleApiRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const handleCodingAgentRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const loadSessionStateFromDbMock = vi.hoisted(() => vi.fn())
 const ensureReadyMock = vi.hoisted(() => vi.fn())
+const sessionCommandMocks = vi.hoisted(() => ({
+  handleSessionCommand: vi.fn(),
+  isSessionCommand: vi.fn(() => false),
+  parseSessionCommand: vi.fn(() => null),
+}))
 const bridgeMock = vi.hoisted(() => ({
   status: vi.fn(),
   statusIfLoaded: vi.fn(),
@@ -26,11 +31,7 @@ vi.mock('../../packages/server/src/services/hermes/run-chat/handle-coding-agent-
   handleCodingAgentRun: handleCodingAgentRunMock,
 }))
 
-vi.mock('../../packages/server/src/services/hermes/run-chat/session-command', () => ({
-  handleSessionCommand: vi.fn(),
-  isSessionCommand: vi.fn(() => false),
-  parseSessionCommand: vi.fn(() => null),
-}))
+vi.mock('../../packages/server/src/services/hermes/run-chat/session-command', () => sessionCommandMocks)
 
 vi.mock('../../packages/server/src/services/hermes/agent-bridge', () => ({
   AgentBridgeClient: vi.fn(() => bridgeMock),
@@ -112,6 +113,35 @@ describe('ChatRunSocket queued bridge runs', () => {
       events: [],
       queue: [],
     })
+  })
+
+  it('dispatches unknown slash bridge input through the normal bridge run path', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    ;(server as any).onConnection(socket)
+
+    sessionCommandMocks.parseSessionCommand.mockReturnValueOnce(null)
+    sessionCommandMocks.isSessionCommand.mockReturnValueOnce(false)
+
+    await handlers.get('run')?.({
+      session_id: 'session-1',
+      input: '/terminal pwd',
+      source: 'cli',
+      queue_id: 'queue-terminal',
+      profile: 'default',
+    })
+
+    expect(sessionCommandMocks.parseSessionCommand).toHaveBeenCalledWith('/terminal pwd')
+    expect(sessionCommandMocks.handleSessionCommand).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(handleBridgeRunMock).toHaveBeenCalled())
+    const call = handleBridgeRunMock.mock.calls.at(-1)!
+    expect(call[2]).toEqual(expect.objectContaining({
+      input: '/terminal pwd',
+      source: 'cli',
+      queue_id: 'queue-terminal',
+    }))
+    expect(call[6]).toBe(false)
   })
 
   it('persists normal queued bridge messages when they are dequeued', async () => {

--- a/tests/server/session-command-plan.test.ts
+++ b/tests/server/session-command-plan.test.ts
@@ -236,6 +236,22 @@ describe('plan session command', () => {
     }))
   })
 
+  it('keeps the client known-command registry accepted by the server parser', async () => {
+    const { BRIDGE_SESSION_COMMAND_NAMES, isKnownBridgeSessionCommand } = await import('../../packages/client/src/utils/hermes/bridge-session-commands')
+    const { parseSessionCommand } = await import('../../packages/server/src/services/hermes/run-chat/session-command')
+
+    for (const commandName of BRIDGE_SESSION_COMMAND_NAMES) {
+      expect(isKnownBridgeSessionCommand(`/${commandName}`)).toBe(true)
+      expect(parseSessionCommand(`/${commandName}`)).toEqual(expect.objectContaining({ name: commandName }))
+    }
+
+    expect(isKnownBridgeSessionCommand('/reload_skills')).toBe(true)
+    expect(parseSessionCommand('/reload_skills')).toEqual(expect.objectContaining({
+      name: 'reload-skills',
+      rawName: 'reload_skills',
+    }))
+  })
+
   it('returns null for unknown slash commands so bridge runs can pass them through', async () => {
     const { isSessionCommand, parseSessionCommand } = await import('../../packages/server/src/services/hermes/run-chat/session-command')
 

--- a/tests/server/session-command-plan.test.ts
+++ b/tests/server/session-command-plan.test.ts
@@ -236,29 +236,11 @@ describe('plan session command', () => {
     }))
   })
 
-  it('keeps unknown slash commands on the existing unknown-command path', async () => {
-    const state = { messages: [], isWorking: false, events: [], queue: [] }
-    const { bridge, namespaceEmit, nsp, runQueuedItem, sessionMap, socket } = makeContext(state)
-    const { handleSessionCommand, parseSessionCommand } = await import('../../packages/server/src/services/hermes/run-chat/session-command')
-    const command = parseSessionCommand('/not-a-command test')!
+  it('returns null for unknown slash commands so bridge runs can pass them through', async () => {
+    const { isSessionCommand, parseSessionCommand } = await import('../../packages/server/src/services/hermes/run-chat/session-command')
 
-    await handleSessionCommand('session-1', command, {
-      nsp: nsp as any,
-      socket: socket as any,
-      sessionMap,
-      bridge: bridge as any,
-      profile: 'default',
-      runQueuedItem,
-    })
-
-    expect(bridge.command).not.toHaveBeenCalled()
-    expect(runQueuedItem).not.toHaveBeenCalled()
-    expect(namespaceEmit).toHaveBeenCalledWith('session.command', expect.objectContaining({
-      command: 'not-a-command',
-      action: 'error',
-      message: 'Unknown bridge command: /not-a-command',
-      terminal: true,
-    }))
+    expect(parseSessionCommand('/not-a-command test')).toBeNull()
+    expect(isSessionCommand('/not-a-command test')).toBe(false)
   })
 
   it('starts an idle goal command as a hidden kickoff run', async () => {


### PR DESCRIPTION
## 改动

Refs #1380.

未知的 `/...` 输入不再被当成 Web UI 内部未知命令直接拒绝，而是按普通用户消息继续发送给 agent。

已知的会话命令仍保留原来的处理路径；这个改动只处理透传行为，不改变工具发现或工具选择 UI。

## 验证

以下验证已通过：

- `npm test -- --run tests/client/chat-input-draft.test.ts tests/client/chat-store-reasoning-tool-boundary.test.ts tests/server/session-command-plan.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npx vue-tsc -b --pretty false`
