### PR TITLE
fix: 避免大静态资源动态 Brotli 压缩

### DIFF
--- a/packages/server/src/middleware/static-compression.ts
+++ b/packages/server/src/middleware/static-compression.ts
@@ -12,9 +12,13 @@ export type StaticCompressionEncoding = 'br' | 'gzip'
 
 export interface StaticCompressionOptions {
   minBytes?: number
+  maxBrotliBytes?: number
 }
 
 const DEFAULT_MIN_BYTES = 1024
+// Dynamic Brotli provides great ratios, but it can add seconds of TTFB on multi-megabyte
+// built assets. Cap it and fall back to gzip (or no compression) for larger responses.
+const DEFAULT_MAX_BROTLI_BYTES = 256 * 1024
 
 const COMPRESSIBLE_TYPES = new Set([
   'application/ecmascript',
@@ -64,12 +68,31 @@ function parseEncodingQuality(header: string, encoding: StaticCompressionEncodin
   return encodingQuality ?? wildcardQuality ?? 0
 }
 
-export function selectStaticCompressionEncoding(acceptEncoding: string): StaticCompressionEncoding | null {
+interface StaticCompressionSelectionOptions {
+  bodyLength?: number | null
+  maxBrotliBytes?: number
+}
+
+export function selectStaticCompressionEncoding(
+  acceptEncoding: string,
+  options: StaticCompressionSelectionOptions = {},
+): StaticCompressionEncoding | null {
   const brQuality = parseEncodingQuality(acceptEncoding, 'br')
   const gzipQuality = parseEncodingQuality(acceptEncoding, 'gzip')
+  const bodyLength = options.bodyLength ?? null
+  const maxBrotliBytes = options.maxBrotliBytes ?? DEFAULT_MAX_BROTLI_BYTES
 
   if (brQuality <= 0 && gzipQuality <= 0) return null
-  return brQuality >= gzipQuality ? 'br' : 'gzip'
+
+  if (brQuality >= gzipQuality) {
+    if (bodyLength !== null && bodyLength > maxBrotliBytes) {
+      return gzipQuality > 0 ? 'gzip' : null
+    }
+
+    return 'br'
+  }
+
+  return 'gzip'
 }
 
 function isReadableStream(value: unknown): value is Readable {
@@ -124,19 +147,24 @@ function createCompressionStream(encoding: StaticCompressionEncoding) {
 
 export function createStaticCompressionMiddleware(options: StaticCompressionOptions = {}): Middleware {
   const minBytes = options.minBytes ?? DEFAULT_MIN_BYTES
+  const maxBrotliBytes = options.maxBrotliBytes ?? DEFAULT_MAX_BROTLI_BYTES
 
   return async (ctx, next) => {
     await next()
 
     if (!shouldCompress(ctx, minBytes)) return
 
-    const encoding = selectStaticCompressionEncoding(ctx.get('Accept-Encoding'))
+    const body = ctx.body
+    const bodyLength = parseBodyLength(ctx, body)
+    ctx.vary('Accept-Encoding')
+    const encoding = selectStaticCompressionEncoding(ctx.get('Accept-Encoding'), {
+      bodyLength,
+      maxBrotliBytes,
+    })
     if (!encoding) return
 
-    ctx.vary('Accept-Encoding')
     ctx.set('Content-Encoding', encoding)
 
-    const body = ctx.body
     if (Buffer.isBuffer(body) || typeof body === 'string') {
       const original = Buffer.isBuffer(body) ? body : Buffer.from(body)
       const compressed = compressBuffer(original, encoding)

--- a/tests/server/static-compression.test.ts
+++ b/tests/server/static-compression.test.ts
@@ -7,6 +7,7 @@ import {
   createStaticCompressionMiddleware,
   isCompressibleContentType,
   selectStaticCompressionEncoding,
+  type StaticCompressionOptions,
 } from '../../packages/server/src/middleware/static-compression'
 
 interface RawResponse {
@@ -47,9 +48,14 @@ async function requestApp(app: Koa, headers: Record<string, string> = {}): Promi
   }
 }
 
-function createAssetApp(contentType: string, body: string | Buffer | Readable, contentLength?: number): Koa {
+function createAssetApp(
+  contentType: string,
+  body: string | Buffer | Readable,
+  contentLength?: number,
+  compressionOptions: StaticCompressionOptions = {},
+): Koa {
   const app = new Koa()
-  app.use(createStaticCompressionMiddleware({ minBytes: 0 }))
+  app.use(createStaticCompressionMiddleware({ minBytes: 0, ...compressionOptions }))
   app.use((ctx) => {
     ctx.type = contentType
     if (contentLength !== undefined) ctx.set('Content-Length', String(contentLength))
@@ -85,6 +91,32 @@ describe('static compression middleware', () => {
     expect(response.body.byteLength).toBeLessThan(Buffer.byteLength(source))
   })
 
+  it('falls back to gzip for large javascript assets instead of dynamic Brotli', async () => {
+    const source = 'export const route = "/chat";\n'.repeat(2048)
+    const response = await requestApp(
+      createAssetApp('application/javascript', source, undefined, { maxBrotliBytes: 1024 }),
+      { 'Accept-Encoding': 'gzip, br' },
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers['content-encoding']).toBe('gzip')
+    expect(response.headers.vary).toContain('Accept-Encoding')
+    expect(gunzipSync(response.body).toString('utf8')).toBe(source)
+  })
+
+  it('marks large identity fallbacks as varying on Accept-Encoding', async () => {
+    const source = 'export const route = "/chat";\n'.repeat(2048)
+    const response = await requestApp(
+      createAssetApp('application/javascript', source, undefined, { maxBrotliBytes: 1024 }),
+      { 'Accept-Encoding': 'br' },
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers['content-encoding']).toBeUndefined()
+    expect(response.headers.vary).toContain('Accept-Encoding')
+    expect(response.body.toString('utf8')).toBe(source)
+  })
+
   it('compresses static file streams without preserving the original content length', async () => {
     const source = 'export const route = "/chat";\n'.repeat(200)
     const response = await requestApp(
@@ -118,6 +150,8 @@ describe('static compression middleware', () => {
     expect(selectStaticCompressionEncoding('gzip;q=0, br;q=1')).toBe('br')
     expect(selectStaticCompressionEncoding('*;q=0.8')).toBe('br')
     expect(selectStaticCompressionEncoding('gzip;q=0, br;q=0')).toBeNull()
+    expect(selectStaticCompressionEncoding('gzip, br', { bodyLength: 4096, maxBrotliBytes: 1024 })).toBe('gzip')
+    expect(selectStaticCompressionEncoding('br', { bodyLength: 4096, maxBrotliBytes: 1024 })).toBeNull()
 
     expect(isCompressibleContentType('text/html; charset=utf-8')).toBe(true)
     expect(isCompressibleContentType('application/manifest+json')).toBe(true)


### PR DESCRIPTION
## 改动

Fixes #1522.

大体积静态资源不再走动态 Brotli 压缩，避免多 MB JS 资源在响应前被 Brotli 压缩拖慢首字节时间。

当客户端同时支持 gzip 和 Brotli 时，大资源会回退到 gzip；如果客户端只接受 Brotli，则返回未压缩内容，并保留 `Vary: Accept-Encoding`，避免缓存混淆不同编码版本。

## 验证

以下验证已通过：

- `npx vitest run tests/server/static-compression.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- large JS middleware smoke：`Accept-Encoding: br` 返回未压缩内容并带 `Vary: Accept-Encoding`
- large JS middleware smoke：`Accept-Encoding: gzip, br` 返回 gzip 并可正确解压
- `git diff --check origin/main...HEAD`
