### PR TITLE
fix: 支持 symlink skill 扫描

### DIFF
--- a/packages/server/src/controllers/hermes/skills.ts
+++ b/packages/server/src/controllers/hermes/skills.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, rm, stat, writeFile, cp } from 'fs/promises'
+import { mkdir, readdir, readFile, realpath, rm, stat, writeFile, cp } from 'fs/promises'
 import { homedir, tmpdir } from 'os'
 import { dirname, join, resolve } from 'path'
 import { createHash, randomBytes } from 'crypto'
@@ -178,18 +178,20 @@ function readUsageStats(usageContent: string | null): Map<string, UsageStats> {
   return map
 }
 
-async function findSkillDirByName(rootDir: string, skillName: string): Promise<string | null> {
-  let entries: import('fs').Dirent[]
+async function findSkillDirByName(rootDir: string, skillName: string, visited = new Set<string>()): Promise<string | null> {
+  const currentRealPath = await realpath(rootDir).catch(() => resolve(rootDir))
+  if (visited.has(currentRealPath)) return null
+  visited.add(currentRealPath)
+
+  let entries: VisibleDirectoryEntry[]
   try {
-    entries = await readdir(rootDir, { withFileTypes: true })
+    entries = await listVisibleDirectoryEntries(rootDir)
   } catch {
     return null
   }
 
   for (const entry of entries) {
-    if (!entry.isDirectory() || entry.name.startsWith('.')) continue
-
-    const entryPath = join(rootDir, entry.name)
+    const entryPath = entry.path
     const skillMd = await safeReadFile(join(entryPath, 'SKILL.md'))
     if (skillMd !== null) {
       if (entry.name === skillName) return entryPath
@@ -197,7 +199,7 @@ async function findSkillDirByName(rootDir: string, skillName: string): Promise<s
       continue
     }
 
-    const found = await findSkillDirByName(entryPath, skillName)
+    const found = await findSkillDirByName(entryPath, skillName, visited)
     if (found) return found
   }
 
@@ -229,6 +231,35 @@ async function resolveSkillDirFromConfig(
   return null
 }
 
+interface VisibleDirectoryEntry {
+  name: string
+  path: string
+}
+
+async function listVisibleDirectoryEntries(dir: string): Promise<VisibleDirectoryEntry[]> {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const directories: VisibleDirectoryEntry[] = []
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue
+
+    const entryPath = join(dir, entry.name)
+    try {
+      const info = await stat(entryPath)
+      if (!info.isDirectory()) continue
+      directories.push({
+        name: entry.name,
+        path: entryPath,
+      })
+    } catch {
+      continue
+    }
+  }
+
+  return directories
+}
+
 /**
  * Scan for skills at different directory depths.
  *
@@ -241,21 +272,18 @@ async function resolveSkillDirFromConfig(
  * Skills without a parent category (flat skills) are grouped under the "misc" category.
  */
 async function scanSkillsDir(skillsDir: string, bundledManifest: Map<string, string>, hubNames: Set<string>, disabledList: string[], usageStats: Map<string, UsageStats>) {
-  const allEntries = await readdir(skillsDir, { withFileTypes: true })
-  const dirNames = allEntries
-    .filter(e => e.isDirectory() && !e.name.startsWith('.'))
-    .map(e => e.name)
+  const rootRealPath = await realpath(skillsDir).catch(() => resolve(skillsDir))
+  const dirEntries = await listVisibleDirectoryEntries(skillsDir)
 
   // Classify directories: categories vs. flat skills
-  const categoryDirs: { name: string; description: string }[] = []
+  const categoryDirs: { name: string; description: string; path: string }[] = []
   const flatSkills: { name: string; skillMd: string; source: string }[] = []
 
-  for (const dirName of dirNames) {
-    const catDir = join(skillsDir, dirName)
+  for (const entry of dirEntries) {
+    const catDir = entry.path
     const hasDesc = await safeReadFile(join(catDir, 'DESCRIPTION.md'))
     const hasSkillMd = await safeReadFile(join(catDir, 'SKILL.md'))
-    const subEntries = await readdir(catDir, { withFileTypes: true })
-    const subDirs = subEntries.filter(se => se.isDirectory())
+    const subDirs = await listVisibleDirectoryEntries(catDir)
 
     // Priority: SKILL.md at top level → flat skill
     //           DESCRIPTION.md or subdirs (without SKILL.md) → category
@@ -263,14 +291,14 @@ async function scanSkillsDir(skillsDir: string, bundledManifest: Map<string, str
       // Flat skill: has SKILL.md at the top level (two-level pattern)
       // Could also have subdirectories (references/, scripts/, etc.)
       flatSkills.push({
-        name: dirName,
+        name: entry.name,
         skillMd: hasSkillMd,
-        source: getSkillSource(dirName, bundledManifest, hubNames),
+        source: getSkillSource(entry.name, bundledManifest, hubNames),
       })
     } else if (!!hasDesc || subDirs.length > 0) {
       // True category: has DESCRIPTION.md or subdirs, but no SKILL.md at top level
       const catDescription = hasDesc ? hasDesc.trim().split('\n')[0].replace(/^#+\s*/, '').slice(0, 100) : ''
-      categoryDirs.push({ name: dirName, description: catDescription })
+      categoryDirs.push({ name: entry.name, description: catDescription, path: catDir })
     }
   }
 
@@ -278,16 +306,18 @@ async function scanSkillsDir(skillsDir: string, bundledManifest: Map<string, str
   const categories: any[] = []
 
   for (const cat of categoryDirs) {
-    const catDir = join(skillsDir, cat.name)
-    const subEntries = await readdir(catDir, { withFileTypes: true })
+    const catDir = cat.path
     const skills: any[] = []
     // Recursively collect skills from subdirectories (supports nested sub-categories)
-    async function collectSkills(dir: string): Promise<any[]> {
-      const entries = await readdir(dir, { withFileTypes: true })
+    async function collectSkills(dir: string, visited = new Set<string>([rootRealPath])): Promise<any[]> {
+      const currentRealPath = await realpath(dir).catch(() => resolve(dir))
+      if (visited.has(currentRealPath)) return []
+      visited.add(currentRealPath)
+
+      const entries = await listVisibleDirectoryEntries(dir)
       const results: any[] = []
       for (const entry of entries) {
-        if (!entry.isDirectory() || entry.name.startsWith('.')) continue
-        const entryPath = join(dir, entry.name)
+        const entryPath = entry.path
         const skillMd = await safeReadFile(join(entryPath, 'SKILL.md'))
         if (skillMd) {
           const source = getSkillSource(entry.name, bundledManifest, hubNames)
@@ -313,7 +343,7 @@ async function scanSkillsDir(skillsDir: string, bundledManifest: Map<string, str
           })
         } else {
           // No SKILL.md — might be a sub-category container, recurse deeper
-          const subResults = await collectSkills(entryPath)
+          const subResults = await collectSkills(entryPath, visited)
           results.push(...subResults)
         }
       }

--- a/tests/server/skills-controller.test.ts
+++ b/tests/server/skills-controller.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { Readable } from 'stream'
@@ -158,6 +158,76 @@ describe('skills controller', () => {
       expect(tools.skills).toEqual([
         expect.objectContaining({ name: 'dupe-skill', source: 'local', description: 'local copy' }),
         expect.objectContaining({ name: 'external-skill', source: 'external', description: 'external copy' }),
+      ])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('lists flat symlinked skills in the misc category', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hermes-web-ui-symlink-flat-skill-'))
+    const profileDir = join(root, 'profile')
+    const profileSkillsDir = join(profileDir, 'skills')
+    const sharedSkillDir = join(root, 'shared-skills', 'linked-flat-skill')
+
+    await mkdir(profileSkillsDir, { recursive: true })
+    await mkdir(sharedSkillDir, { recursive: true })
+    await writeFile(join(sharedSkillDir, 'SKILL.md'), '# Linked Flat Skill\nflat symlink copy\n', 'utf-8')
+    await symlink(sharedSkillDir, join(profileSkillsDir, 'linked-flat-skill'))
+
+    mockGetProfileDir.mockReturnValue(profileDir)
+
+    try {
+      const { list } = await loadController()
+      const ctx: any = { state: { profile: { name: 'research' } }, body: null }
+
+      await list(ctx)
+
+      expect(ctx.body.categories).toContainEqual(expect.objectContaining({
+        name: 'misc',
+        skills: [
+          expect.objectContaining({
+            name: 'linked-flat-skill',
+            source: 'local',
+            description: 'flat symlink copy',
+          }),
+        ],
+      }))
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('traverses symlinked category entries without following hidden or cyclic links', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hermes-web-ui-symlink-category-skill-'))
+    const profileDir = join(root, 'profile')
+    const toolsDir = join(profileDir, 'skills', 'tools')
+    const linkedSkillDir = join(root, 'shared-skills', 'linked-skill')
+    const linkedCategoryDir = join(root, 'shared-skills', 'linked-category')
+
+    await mkdir(toolsDir, { recursive: true })
+    await mkdir(linkedSkillDir, { recursive: true })
+    await mkdir(linkedCategoryDir, { recursive: true })
+    await writeFile(join(toolsDir, 'DESCRIPTION.md'), '# Tools\n', 'utf-8')
+    await writeFile(join(linkedSkillDir, 'SKILL.md'), '# Linked Skill\nlinked skill copy\n', 'utf-8')
+    await writeFile(join(linkedCategoryDir, 'SKILL.md'), '# Linked Category Skill\nlinked category copy\n', 'utf-8')
+    await symlink(linkedSkillDir, join(toolsDir, 'linked-skill'))
+    await symlink(linkedCategoryDir, join(toolsDir, 'linked-group'))
+    await symlink(toolsDir, join(toolsDir, 'loop'))
+    await symlink(linkedSkillDir, join(toolsDir, '.hidden-skill'))
+
+    mockGetProfileDir.mockReturnValue(profileDir)
+
+    try {
+      const { list } = await loadController()
+      const ctx: any = { state: { profile: { name: 'research' } }, body: null }
+
+      await list(ctx)
+
+      const tools = ctx.body.categories.find((category: any) => category.name === 'tools')
+      expect(tools.skills).toEqual([
+        expect.objectContaining({ name: 'linked-group', description: 'linked category copy', source: 'local' }),
+        expect.objectContaining({ name: 'linked-skill', description: 'linked skill copy', source: 'local' }),
       ])
     } finally {
       await rm(root, { recursive: true, force: true })


### PR DESCRIPTION
## 改动

Fixes #1027.

基于 #1169 的 focused 修复方向继续补齐 symlink skill 扫描支持，感谢 @qiontoo 在 #1169 里提供的原始修复方向。

这个 PR 保持同样的 scope，但基于最新 `main` 重新实现，并补上额外防护：

- symlink entry 只有在 `stat()` 确认为目录后才纳入扫描
- 递归扫描使用 `realpath()` / visited-set，避免 cyclic symlink
- hidden symlink entry 仍然会被过滤
- 覆盖 flat skill、category skill、hidden/cycle regression

## 验证

以下验证已通过：

- `npm run harness:check`
- `npx vitest run tests/server/skills-controller.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `git diff --check origin/main...HEAD`
