### PR TITLE
feat: 添加聊天会话 turn navigator

### DIFF
--- a/docs/chat-chain-changes/2026-06-16-session-turn-navigator.md
+++ b/docs/chat-chain-changes/2026-06-16-session-turn-navigator.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-16
+pr: pending
+feature: Session turn navigator
+impact: Long Hermes Web UI chat sessions now show a compact turn navigator derived from user prompts, with smooth anchor scrolling to selected turns while preserving existing chat streaming and bottom-follow behavior.
+---

--- a/packages/client/src/components/hermes/chat/ConversationNavigator.vue
+++ b/packages/client/src/components/hermes/chat/ConversationNavigator.vue
@@ -1,0 +1,235 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+export interface ConversationNavItem {
+  id: string
+  messageId: string
+  index: number
+  label: string
+}
+
+const props = defineProps<{
+  items: ConversationNavItem[]
+  activeId?: string | null
+  label: string
+}>()
+
+const emit = defineEmits<{
+  navigate: [messageId: string]
+}>()
+
+const hoveredItem = ref<ConversationNavItem | null>(null);
+const tooltipTop = ref(0);
+
+function isActive(item: ConversationNavItem): boolean {
+  return props.activeId === item.id
+}
+
+function showTooltip(item: ConversationNavItem, event: MouseEvent | FocusEvent) {
+  const target = event.currentTarget;
+  if (!(target instanceof HTMLElement)) return;
+  const nav = target.closest<HTMLElement>(".conversation-navigator");
+  if (!nav) return;
+
+  const targetRect = target.getBoundingClientRect();
+  const navRect = nav.getBoundingClientRect();
+  hoveredItem.value = item;
+  tooltipTop.value = targetRect.top - navRect.top + targetRect.height / 2;
+}
+
+function hideTooltip(item: ConversationNavItem) {
+  if (hoveredItem.value?.id === item.id) hoveredItem.value = null;
+}
+</script>
+
+<template>
+  <nav
+    v-if="items.length > 0"
+    class="conversation-navigator"
+    :aria-label="label"
+    data-testid="conversation-navigator"
+  >
+    <div class="conversation-nav-rail" role="presentation">
+      <button
+        v-for="item in items"
+        :key="item.id"
+        type="button"
+        class="conversation-nav-dot"
+        :class="{ active: isActive(item) }"
+        :aria-label="item.label"
+        :aria-current="isActive(item) ? 'true' : undefined"
+        @mouseenter="showTooltip(item, $event)"
+        @mouseleave="hideTooltip(item)"
+        @focus="showTooltip(item, $event)"
+        @blur="hideTooltip(item)"
+        @click="emit('navigate', item.messageId)"
+      >
+        <span class="conversation-nav-dot-bar" aria-hidden="true"></span>
+      </button>
+    </div>
+    <span
+      v-if="hoveredItem"
+      class="conversation-nav-tooltip"
+      role="tooltip"
+      :style="{ top: `${tooltipTop}px` }"
+    >{{ hoveredItem.label }}</span>
+  </nav>
+</template>
+
+<style scoped lang="scss">
+@use "@/styles/variables" as *;
+
+.conversation-navigator {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 6;
+  width: 48px;
+  max-width: 48px;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.conversation-nav-rail {
+  width: 48px;
+  max-height: min(70vh, 520px);
+  padding: 5px 4px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: none;
+  pointer-events: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.conversation-nav-dot {
+  position: relative;
+  width: 40px;
+  height: 15px;
+  padding: 0 3px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  cursor: pointer;
+  pointer-events: auto;
+  opacity: 0.72;
+  transition:
+    opacity 90ms ease,
+    background-color 90ms ease,
+    transform 90ms ease;
+
+  &:hover,
+  &:focus-visible {
+    opacity: 1;
+    transform: translateX(-2px);
+    background: rgba(255, 255, 255, 0.11);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.28);
+    outline: none;
+
+    .conversation-nav-dot-bar {
+      width: 30px;
+      background: $text-secondary;
+    }
+  }
+
+  &.active {
+    opacity: 1;
+
+    .conversation-nav-dot-bar {
+      width: 34px;
+      background: $text-primary;
+      box-shadow: 0 0 0 1px rgba(var(--accent-primary-rgb), 0.12);
+    }
+  }
+}
+
+.conversation-nav-dot-bar {
+  width: 25px;
+  height: 3px;
+  border-radius: 999px;
+  background: $text-muted;
+  transition: width 90ms ease, background-color 90ms ease;
+
+  .dark & {
+    background: rgba(255, 255, 255, 0.42);
+  }
+}
+
+.conversation-nav-tooltip {
+  position: absolute;
+  right: calc(100% + 8px);
+  transform: translateY(-50%);
+  width: max-content;
+  max-width: min(360px, calc(100vw - 112px));
+  padding: 7px 10px;
+  border: 1px solid rgba(var(--accent-primary-rgb), 0.22);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.96);
+  color: $text-primary;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.16);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.35;
+  text-align: left;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  pointer-events: none;
+
+  .dark & {
+    background: rgba(28, 28, 28, 0.96);
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+}
+
+.dark .conversation-nav-dot:hover,
+.dark .conversation-nav-dot:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.22);
+}
+
+.dark .conversation-nav-dot.active .conversation-nav-dot-bar {
+  background: rgba(255, 255, 255, 0.95);
+}
+
+@media (max-width: 640px) {
+  .conversation-navigator {
+    right: 4px;
+    width: 36px;
+    max-width: 36px;
+  }
+
+  .conversation-nav-rail {
+    width: 36px;
+    padding: 4px 3px;
+    gap: 6px;
+  }
+
+  .conversation-nav-dot {
+    width: 30px;
+    height: 13px;
+  }
+
+  .conversation-nav-dot-bar {
+    width: 20px;
+  }
+
+  .conversation-nav-dot.active .conversation-nav-dot-bar {
+    width: 26px;
+  }
+
+  .conversation-nav-tooltip {
+    max-width: min(280px, calc(100vw - 80px));
+  }
+}
+</style>

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -20,6 +20,7 @@ import { useI18n } from "vue-i18n";
 import { NButton, NInput } from "naive-ui";
 import VirtualMessageList from "./VirtualMessageList.vue";
 import MessageItem from "./MessageItem.vue";
+import ConversationNavigator, { type ConversationNavItem } from "./ConversationNavigator.vue";
 import { LIVE_CHAT_MAX_LOADED_MESSAGES, useChatStore } from "@/stores/hermes/chat";
 import thinkingImage from "@/assets/thinking.gif";
 import { useToolTraceVisibility } from "@/composables/useToolTraceVisibility";
@@ -28,6 +29,8 @@ const chatStore = useChatStore();
 const { t } = useI18n();
 const { toolTraceVisible } = useToolTraceVisibility();
 const listRef = ref<InstanceType<typeof VirtualMessageList> | null>(null);
+const NAVIGATOR_MIN_TURNS = 4;
+const activeNavMessageId = ref<string | null>(null);
 const pendingInitialScrollSessionId = ref<string | null>(null);
 const showScrollBottomButton = ref(false);
 const thinkingElapsedMs = ref(0);
@@ -136,6 +139,34 @@ const displayMessages = computed(() => {
   });
 });
 
+function normalizeNavLabel(content: string): string {
+  const normalized = content.replace(/\s+/g, " ").trim();
+  if (!normalized) return t("chat.conversationNavigatorUntitledTurn");
+  return normalized.length > 56 ? `${normalized.slice(0, 56)}...` : normalized;
+}
+
+const conversationNavItems = computed<ConversationNavItem[]>(() =>
+  displayMessages.value
+    .filter((message) => message.role === "user")
+    .map((message, index) => ({
+      id: `turn-${message.id}`,
+      messageId: message.id,
+      index: index + 1,
+      label: t("chat.conversationNavigatorTurn", {
+        index: index + 1,
+        title: normalizeNavLabel(message.content || ""),
+      }),
+    })),
+);
+
+const showConversationNavigator = computed(
+  () => conversationNavItems.value.length >= NAVIGATOR_MIN_TURNS,
+);
+
+const activeNavItemId = computed(() =>
+  activeNavMessageId.value ? `turn-${activeNavMessageId.value}` : conversationNavItems.value[0]?.id || null,
+);
+
 const queuedMessages = computed(() => {
   const sid = chatStore.activeSessionId;
   if (!sid) return [];
@@ -146,9 +177,10 @@ const visibleClarify = computed(() => chatStore.activePendingClarify);
 const clarifyResponse = ref("");
 const hasFloatingPrompt = computed(() => !!visibleApproval.value || !!visibleClarify.value);
 const virtualListPadding = computed(() => {
-  if (queuedMessages.value.length > 0 && hasFloatingPrompt.value) return "20px 20px 380px";
-  if (queuedMessages.value.length > 0 || hasFloatingPrompt.value) return "20px 20px 260px";
-  return "20px";
+  const rightPadding = showConversationNavigator.value ? "clamp(44px, 7vw, 72px)" : "20px";
+  if (queuedMessages.value.length > 0 && hasFloatingPrompt.value) return `20px ${rightPadding} 380px 20px`;
+  if (queuedMessages.value.length > 0 || hasFloatingPrompt.value) return `20px ${rightPadding} 260px 20px`;
+  return `20px ${rightPadding} 20px 20px`;
 });
 
 const showHistoryArchiveLink = computed(() => {
@@ -197,6 +229,41 @@ function scrollToMessage(messageId: string) {
   listRef.value?.scrollToMessage(messageId);
 }
 
+function scrollToNavMessage(messageId: string) {
+  activeNavMessageId.value = messageId;
+  listRef.value?.scrollToAnchor(messageId, `message-${messageId}`, {
+    behavior: "smooth",
+    respectReducedMotion: false,
+  });
+}
+
+function getConversationScroller(): HTMLElement | null {
+  return listRef.value?.getScrollerElement?.() ?? null;
+}
+
+function computeActiveNavMessageId(): string | null {
+  const root = getConversationScroller();
+  if (!root || conversationNavItems.value.length === 0) return null;
+
+  const rootRect = root.getBoundingClientRect();
+  const activationY = rootRect.top + Math.min(root.clientHeight * 0.18, 96);
+  let active = conversationNavItems.value[0]?.messageId || null;
+
+  for (const item of conversationNavItems.value) {
+    const el = document.getElementById(`message-${item.messageId}`);
+    if (!(el instanceof HTMLElement) || !root.contains(el)) continue;
+    const rect = el.getBoundingClientRect();
+    if (rect.top <= activationY) active = item.messageId;
+    else break;
+  }
+
+  return active;
+}
+
+function updateActiveNavMessageId() {
+  activeNavMessageId.value = computeActiveNavMessageId();
+}
+
 function scrollToAnchor(messageId: string, anchorId: string) {
   listRef.value?.scrollToAnchor(messageId, anchorId);
 }
@@ -207,6 +274,7 @@ function updateScrollBottomButton() {
 
 function handleListScroll() {
   updateScrollBottomButton();
+  updateActiveNavMessageId();
 }
 
 function handleScrollBottomClick() {
@@ -259,10 +327,12 @@ watch(
   () => chatStore.activeSessionId,
   async (id, previousId) => {
     saveSessionScrollPosition(previousId);
+    activeNavMessageId.value = null;
     if (!id) return;
     pendingInitialScrollSessionId.value = id;
     await nextTick();
     applyInitialSessionScroll(id);
+    void nextTick(updateActiveNavMessageId);
   },
   { immediate: true },
 );
@@ -280,7 +350,18 @@ watch(
 watch(
   () => displayMessages.value.length,
   () => {
-    void nextTick(updateScrollBottomButton);
+    void nextTick(() => {
+      updateScrollBottomButton();
+      updateActiveNavMessageId();
+    });
+  },
+  { flush: "post" },
+);
+
+watch(
+  () => conversationNavItems.value.map((item) => item.messageId).join("|"),
+  () => {
+    void nextTick(updateActiveNavMessageId);
   },
   { flush: "post" },
 );
@@ -379,7 +460,10 @@ onBeforeUnmount(() => {
 });
 
 onMounted(() => {
-  void nextTick(updateScrollBottomButton);
+  void nextTick(() => {
+    updateScrollBottomButton();
+    updateActiveNavMessageId();
+  });
 });
 
 defineExpose({
@@ -390,7 +474,10 @@ defineExpose({
 </script>
 
 <template>
-  <div class="message-list-shell">
+  <div
+    class="message-list-shell"
+    :class="{ 'has-conversation-navigator': showConversationNavigator }"
+  >
     <VirtualMessageList
       :key="chatStore.activeSessionId || 'chat-empty'"
       ref="listRef"
@@ -600,8 +687,15 @@ defineExpose({
         </Transition>
       </template>
     </VirtualMessageList>
+    <ConversationNavigator
+      v-if="showConversationNavigator"
+      :items="conversationNavItems"
+      :active-id="activeNavItemId"
+      :label="t('chat.conversationNavigatorLabel')"
+      @navigate="scrollToNavMessage"
+    />
     <button
-      v-if="showScrollBottomButton"
+      v-if="showScrollBottomButton && !showConversationNavigator"
       type="button"
       class="scroll-bottom-button"
       :aria-label="t('chat.scrollToBottom')"

--- a/packages/client/src/components/hermes/chat/VirtualMessageList.vue
+++ b/packages/client/src/components/hermes/chat/VirtualMessageList.vue
@@ -13,6 +13,11 @@ type VirtualItem = {
 }
 
 type AnchorAlign = "start" | "center";
+type AnchorScrollBehavior = "auto" | "smooth";
+type AnchorScrollOptions = {
+  behavior?: AnchorScrollBehavior;
+  respectReducedMotion?: boolean;
+}
 type AnchorTarget = {
   token: number;
   index: number;
@@ -95,6 +100,26 @@ function syncViewport() {
 
 function markProgrammaticScroll(ms = 120) {
   programmaticScrollUntil = Date.now() + ms;
+}
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+}
+
+function resolveAnchorBehavior(
+  behavior: AnchorScrollBehavior = "auto",
+  options: Pick<AnchorScrollOptions, "respectReducedMotion"> = {},
+): AnchorScrollBehavior {
+  const respectReducedMotion = options.respectReducedMotion ?? true;
+  return behavior === "smooth" && (!respectReducedMotion || !prefersReducedMotion()) ? "smooth" : "auto";
+}
+
+function setScrollerScrollTop(el: HTMLElement, top: number, behavior: AnchorScrollBehavior) {
+  if (behavior === "smooth" && typeof el.scrollTo === "function") {
+    el.scrollTo({ top, behavior: "smooth" });
+    return;
+  }
+  el.scrollTop = top;
 }
 
 function isProgrammaticScroll(): boolean {
@@ -218,7 +243,7 @@ function findTargetElement(messageId: string, anchorId: string): HTMLElement | n
   return null;
 }
 
-function alignElement(targetEl: HTMLElement, align: AnchorAlign) {
+function alignElement(targetEl: HTMLElement, align: AnchorAlign, behavior: AnchorScrollBehavior = "auto") {
   const el = getScrollerElement();
   if (!el) return;
 
@@ -229,8 +254,9 @@ function alignElement(targetEl: HTMLElement, align: AnchorAlign) {
     : targetRect.top - scrollerRect.top - 24;
 
   if (Math.abs(delta) > 1) {
-    markProgrammaticScroll();
-    el.scrollTop = Math.max(0, el.scrollTop + delta);
+    const nextScrollTop = Math.max(0, el.scrollTop + delta);
+    markProgrammaticScroll(behavior === "smooth" ? 700 : 120);
+    setScrollerScrollTop(el, nextScrollTop, behavior);
   }
   syncViewport();
 }
@@ -240,10 +266,14 @@ function findRowElement(index: number): HTMLElement | null {
   return el?.querySelector<HTMLElement>(`.virtual-row[data-virtual-index="${index}"]`) ?? null;
 }
 
-function scrollToItem(index: number, options?: ScrollToOptions) {
-  markProgrammaticScroll();
+function scrollToItem(index: number, options?: ScrollToOptions & { behavior?: AnchorScrollBehavior }) {
+  const behavior = options?.behavior ?? "auto";
+  markProgrammaticScroll(behavior === "smooth" ? 700 : 120);
   if (props.virtualized) {
-    scrollerRef.value?.scrollToItem(index, options);
+    scrollerRef.value?.scrollToItem(index, {
+      ...options,
+      smooth: behavior === "smooth",
+    });
     syncViewport();
     return;
   }
@@ -263,12 +293,14 @@ function scrollToItem(index: number, options?: ScrollToOptions) {
     ? rowRect.top + rowRect.height / 2 - (scrollerRect.top + scrollerRect.height / 2)
     : rowRect.top - scrollerRect.top + offset;
 
-  el.scrollTop = Math.max(0, el.scrollTop + delta);
+  const nextScrollTop = Math.max(0, el.scrollTop + delta);
+  setScrollerScrollTop(el, nextScrollTop, behavior);
   syncViewport();
 }
 
-function scheduleAnchorAlignment(token: number, frames = 1) {
+function scheduleAnchorAlignment(token: number, frames = 1, behavior: AnchorScrollBehavior = "auto") {
   if (anchorFrame != null) cancelAnimationFrame(anchorFrame);
+  let initialBehavior = behavior;
 
   const step = (remaining: number) => {
     const target = activeAnchorTarget;
@@ -279,8 +311,10 @@ function scheduleAnchorAlignment(token: number, frames = 1) {
 
     const targetEl = findTargetElement(target.messageId, target.anchorId);
     if (targetEl) {
-      alignElement(targetEl, target.align);
-    } else {
+      const stepBehavior = initialBehavior;
+      initialBehavior = "auto";
+      alignElement(targetEl, target.align, stepBehavior);
+    } else if (initialBehavior !== "smooth") {
       scrollToItem(target.index, {
         align: target.align,
         offset: target.align === "start" ? -24 : 0,
@@ -327,10 +361,11 @@ function scrollToMessage(messageId: string) {
   });
 }
 
-function scrollToAnchor(messageId: string, anchorId: string) {
+function scrollToAnchor(messageId: string, anchorId: string, options: AnchorScrollOptions = {}) {
   const index = props.messages.findIndex(message => String(message.id) === messageId);
   if (index < 0) return;
 
+  const behavior = resolveAnchorBehavior(options.behavior, options);
   cancelAnchorAlignment();
   const token = anchorToken;
   activeAnchorTarget = {
@@ -342,8 +377,15 @@ function scrollToAnchor(messageId: string, anchorId: string) {
   };
 
   nextTick(() => {
-    scrollToItem(index, { align: "start", offset: -24 });
-    scheduleAnchorAlignment(token, 10);
+    const targetEl = findTargetElement(messageId, anchorId);
+    if (targetEl) {
+      alignElement(targetEl, "start", behavior);
+      if (behavior !== "smooth") scheduleAnchorAlignment(token, 10);
+      return;
+    }
+
+    scrollToItem(index, { align: "start", offset: -24, behavior });
+    scheduleAnchorAlignment(token, behavior === "smooth" ? 40 : 10, behavior);
   });
 }
 
@@ -443,6 +485,7 @@ defineExpose({
   scrollToBottom,
   scrollToMessage,
   scrollToAnchor,
+  getScrollerElement,
   captureScrollPosition,
   restoreScrollPosition,
   captureViewportPosition,

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -419,6 +419,9 @@ export default {
     outlineTitle: 'Konversationsübersicht',
     outlineEmpty: 'Kein Konversationsinhalt',
     outlineUserQuestion: 'Benutzerfrage',
+    conversationNavigatorLabel: 'Konversationsnavigation',
+    conversationNavigatorTurn: 'Runde {index}: {title}',
+    conversationNavigatorUntitledTurn: 'Unbenannte Nachricht',
     inputPlaceholder: 'Nachricht eingeben... (Enter zum Senden, Shift+Enter fur neue Zeile)',
     slashCommandArgs: {
       message: '<Nachricht>',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -420,6 +420,9 @@ export default {
     outlineTitle: 'Conversation Outline',
     outlineEmpty: 'No conversation content',
     outlineUserQuestion: 'User question',
+    conversationNavigatorLabel: 'Conversation navigation',
+    conversationNavigatorTurn: 'Turn {index}: {title}',
+    conversationNavigatorUntitledTurn: 'Untitled message',
     inputPlaceholder: 'Type a message... (Enter to send, Shift+Enter for new line)',
     slashCommandArgs: {
       message: '<message>',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -419,6 +419,9 @@ export default {
     outlineTitle: 'Esquema de la conversación',
     outlineEmpty: 'Sin contenido de conversación',
     outlineUserQuestion: 'Pregunta del usuario',
+    conversationNavigatorLabel: 'Navegación de conversación',
+    conversationNavigatorTurn: 'Turno {index}: {title}',
+    conversationNavigatorUntitledTurn: 'Mensaje sin título',
     inputPlaceholder: 'Escribe un mensaje... (Enter para enviar, Shift+Enter para nueva linea)',
     slashCommandArgs: {
       message: '<mensaje>',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -419,6 +419,9 @@ export default {
     outlineTitle: 'Plan de la conversation',
     outlineEmpty: 'Aucun contenu de conversation',
     outlineUserQuestion: 'Question utilisateur',
+    conversationNavigatorLabel: 'Navigation de conversation',
+    conversationNavigatorTurn: 'Tour {index} : {title}',
+    conversationNavigatorUntitledTurn: 'Message sans titre',
     inputPlaceholder: 'Tapez un message... (Entree pour envoyer, Shift+Entree pour un saut de ligne)',
     slashCommandArgs: {
       message: '<message>',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -419,6 +419,9 @@ export default {
     outlineTitle: '会話アウトライン',
     outlineEmpty: '会話内容はありません',
     outlineUserQuestion: 'ユーザーの質問',
+    conversationNavigatorLabel: '会話ナビゲーション',
+    conversationNavigatorTurn: 'ターン {index}: {title}',
+    conversationNavigatorUntitledTurn: '無題のメッセージ',
     inputPlaceholder: 'メッセージを入力... (Enter で送信、Shift+Enter で改行)',
     slashCommandArgs: {
       message: '<メッセージ>',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -419,6 +419,9 @@ export default {
     outlineTitle: '대화 개요',
     outlineEmpty: '대화 내용이 없습니다',
     outlineUserQuestion: '사용자 질문',
+    conversationNavigatorLabel: '대화 탐색',
+    conversationNavigatorTurn: '{index}번째 턴: {title}',
+    conversationNavigatorUntitledTurn: '제목 없는 메시지',
     inputPlaceholder: '메시지를 입력하세요... (Enter로 전송, Shift+Enter로 줄바꿈)',
     slashCommandArgs: {
       message: '<메시지>',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -419,6 +419,9 @@ export default {
     outlineTitle: 'Esboço da conversa',
     outlineEmpty: 'Nenhum conteúdo da conversa',
     outlineUserQuestion: 'Pergunta do usuário',
+    conversationNavigatorLabel: 'Navegação da conversa',
+    conversationNavigatorTurn: 'Turno {index}: {title}',
+    conversationNavigatorUntitledTurn: 'Mensagem sem título',
     inputPlaceholder: 'Digite uma mensagem... (Enter para enviar, Shift+Enter para nova linha)',
     slashCommandArgs: {
       message: '<mensagem>',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -346,6 +346,9 @@ export default {
     outlineTitle: 'План беседы',
     outlineEmpty: 'Нет содержимого беседы',
     outlineUserQuestion: 'Вопрос пользователя',
+    conversationNavigatorLabel: 'Навигация по беседе',
+    conversationNavigatorTurn: 'Ход {index}: {title}',
+    conversationNavigatorUntitledTurn: 'Сообщение без названия',
     inputPlaceholder: 'Введите сообщение... (Enter — отправить, Shift+Enter — новая строка)',
     slashCommandArgs: {
       message: '<сообщение>',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -419,6 +419,9 @@ export default {
     outlineTitle: '會話大綱',
     outlineEmpty: '暫無會話內容',
     outlineUserQuestion: '使用者問題',
+    conversationNavigatorLabel: '對話導覽',
+    conversationNavigatorTurn: '第 {index} 輪：{title}',
+    conversationNavigatorUntitledTurn: '未命名訊息',
     inputPlaceholder: '輸入訊息... (Enter 發送，Shift+Enter 換行)',
     slashCommandArgs: {
       message: '<訊息>',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -420,6 +420,9 @@ export default {
     outlineTitle: '会话大纲',
     outlineEmpty: '暂无会话内容',
     outlineUserQuestion: '用户问题',
+    conversationNavigatorLabel: '会话导航',
+    conversationNavigatorTurn: '第 {index} 轮：{title}',
+    conversationNavigatorUntitledTurn: '未命名消息',
     inputPlaceholder: '输入消息... (Enter 发送，Shift+Enter 换行)',
     slashCommandArgs: {
       message: '<消息>',

--- a/tests/client/conversation-navigator.test.ts
+++ b/tests/client/conversation-navigator.test.ts
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { defineComponent } from 'vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (key === 'chat.conversationNavigatorTurn') return `Turn ${params?.index}: ${params?.title}`
+      if (key === 'chat.conversationNavigatorLabel') return 'Conversation navigation'
+      if (key === 'chat.conversationNavigatorUntitledTurn') return 'Untitled message'
+      if (key === 'chat.emptyState') return 'Start a conversation'
+      return key
+    },
+  }),
+}))
+
+vi.mock('@/composables/useTheme', () => ({
+  useTheme: () => ({ isDark: false }),
+}))
+
+vi.mock('@/composables/useToolTraceVisibility', () => ({
+  useToolTraceVisibility: () => ({ toolTraceVisible: { value: true } }),
+}))
+
+import ConversationNavigator, {
+  type ConversationNavItem,
+} from '@/components/hermes/chat/ConversationNavigator.vue'
+import MessageList from '@/components/hermes/chat/MessageList.vue'
+import { useChatStore, type Message, type Session } from '@/stores/hermes/chat'
+
+const items: ConversationNavItem[] = [
+  { id: 'turn-u1', messageId: 'u1', index: 1, label: 'Turn 1: First prompt' },
+  { id: 'turn-u2', messageId: 'u2', index: 2, label: 'Turn 2: Second prompt' },
+  { id: 'turn-u3', messageId: 'u3', index: 3, label: 'Turn 3: Third prompt' },
+]
+
+const MessageItemStub = defineComponent({
+  name: 'MessageItem',
+  props: {
+    message: { type: Object, required: true },
+    highlight: { type: Boolean, default: false },
+  },
+  template: '<div class="stub-message" :id="`message-${message.id}`" :data-role="message.role">{{ message.content }}</div>',
+})
+
+function makeMessage(id: string, role: Message['role'], content: string): Message {
+  return { id, role, content, timestamp: Date.now() }
+}
+
+function makeSession(messages: Message[]): Session {
+  return {
+    id: 'session-1',
+    title: 'Long chat',
+    messages,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  }
+}
+
+describe('ConversationNavigator', () => {
+  it('renders one accessible button per navigation item', () => {
+    const wrapper = mount(ConversationNavigator, {
+      props: {
+        items,
+        activeId: 'turn-u2',
+        label: 'Conversation navigation',
+      },
+    })
+
+    expect(wrapper.get('[data-testid="conversation-navigator"]').attributes('aria-label')).toBe('Conversation navigation')
+    const buttons = wrapper.findAll('button.conversation-nav-dot')
+    expect(buttons).toHaveLength(3)
+    expect(buttons.map(button => button.attributes('aria-label'))).toEqual([
+      'Turn 1: First prompt',
+      'Turn 2: Second prompt',
+      'Turn 3: Third prompt',
+    ])
+    expect(buttons[1].classes()).toContain('active')
+    expect(buttons[1].attributes('aria-current')).toBe('true')
+    expect(buttons[1].attributes('title')).toBeUndefined()
+    expect(buttons[0].attributes('aria-current')).toBeUndefined()
+    expect(wrapper.find('.conversation-nav-tooltip').exists()).toBe(false)
+  })
+
+  it('shows an immediate custom tooltip for the hovered item', async () => {
+    const wrapper = mount(ConversationNavigator, {
+      attachTo: document.body,
+      props: {
+        items,
+        activeId: 'turn-u2',
+        label: 'Conversation navigation',
+      },
+    })
+
+    const button = wrapper.findAll('button.conversation-nav-dot')[1]
+    await button.trigger('mouseenter')
+
+    const tooltip = wrapper.get('.conversation-nav-tooltip')
+    expect(tooltip.text()).toBe('Turn 2: Second prompt')
+    expect(tooltip.attributes('role')).toBe('tooltip')
+    wrapper.unmount()
+  })
+
+  it('emits the target message id when a bar is clicked', async () => {
+    const wrapper = mount(ConversationNavigator, {
+      props: {
+        items,
+        activeId: 'turn-u1',
+        label: 'Conversation navigation',
+      },
+    })
+
+    await wrapper.findAll('button.conversation-nav-dot')[2].trigger('click')
+
+    expect(wrapper.emitted('navigate')).toEqual([['u3']])
+  })
+
+  it('renders nothing when no items are provided', () => {
+    const wrapper = mount(ConversationNavigator, {
+      props: {
+        items: [],
+        activeId: null,
+        label: 'Conversation navigation',
+      },
+    })
+
+    expect(wrapper.find('[data-testid="conversation-navigator"]').exists()).toBe(false)
+  })
+})
+
+describe('MessageList conversation navigator integration', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('shows navigator for long chats and derives anchors from user turns only', () => {
+    const chatStore = useChatStore()
+    chatStore.activeSessionId = 'session-1'
+    chatStore.activeSession = makeSession([
+      makeMessage('u1', 'user', 'First prompt'),
+      makeMessage('a1', 'assistant', 'First answer'),
+      makeMessage('tool-1', 'tool', ''),
+      makeMessage('u2', 'user', 'Second prompt'),
+      makeMessage('a2', 'assistant', 'Second answer'),
+      makeMessage('u3', 'user', 'Third prompt'),
+      makeMessage('u4', 'user', 'Fourth prompt'),
+    ])
+
+    const wrapper = mount(MessageList, {
+      global: {
+        stubs: {
+          MessageItem: MessageItemStub,
+          Transition: false,
+        },
+      },
+    })
+
+    const buttons = wrapper.findAll('button.conversation-nav-dot')
+    expect(buttons).toHaveLength(4)
+    expect(buttons.map(button => button.attributes('aria-label'))).toEqual([
+      'Turn 1: First prompt',
+      'Turn 2: Second prompt',
+      'Turn 3: Third prompt',
+      'Turn 4: Fourth prompt',
+    ])
+  })
+
+  it('hides navigator for short chats', () => {
+    const chatStore = useChatStore()
+    chatStore.activeSessionId = 'session-1'
+    chatStore.activeSession = makeSession([
+      makeMessage('u1', 'user', 'First prompt'),
+      makeMessage('u2', 'user', 'Second prompt'),
+      makeMessage('u3', 'user', 'Third prompt'),
+    ])
+
+    const wrapper = mount(MessageList, {
+      global: {
+        stubs: {
+          MessageItem: MessageItemStub,
+          Transition: false,
+        },
+      },
+    })
+
+    expect(wrapper.find('[data-testid="conversation-navigator"]').exists()).toBe(false)
+  })
+
+  it('keeps navigator click smooth even when the system prefers reduced motion', async () => {
+    const chatStore = useChatStore()
+    chatStore.activeSessionId = 'session-1'
+    chatStore.activeSession = makeSession([
+      makeMessage('u1', 'user', 'First prompt'),
+      makeMessage('u2', 'user', 'Second prompt'),
+      makeMessage('u3', 'user', 'Third prompt'),
+      makeMessage('u4', 'user', 'Fourth prompt'),
+    ])
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn((query: string) => ({
+        matches: query.includes('prefers-reduced-motion: reduce'),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+    const scrollTo = vi.fn(function (this: HTMLElement, options: ScrollToOptions) {
+      if (typeof options === 'object' && typeof options.top === 'number') this.scrollTop = options.top
+    })
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    })
+
+    const wrapper = mount(MessageList, {
+      attachTo: document.body,
+      global: {
+        stubs: {
+          MessageItem: MessageItemStub,
+          Transition: false,
+        },
+      },
+    })
+
+    wrapper.getComponent(ConversationNavigator).vm.$emit('navigate', 'u3')
+    await wrapper.vm.$nextTick()
+
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }))
+    const buttons = wrapper.findAll('button.conversation-nav-dot')
+    expect(buttons[2].classes()).toContain('active')
+    expect(buttons[2].attributes('aria-current')).toBe('true')
+    wrapper.unmount()
+  })
+})

--- a/tests/e2e/chat-session-navigator.spec.ts
+++ b/tests/e2e/chat-session-navigator.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from '@playwright/test'
+import { authenticate, mockChatSocket, mockHermesApi, TEST_ACCESS_KEY } from './fixtures'
+
+const nowSeconds = Math.floor(Date.now() / 1000)
+
+const longSessionMessages = [
+  { id: 'u1', role: 'user', content: 'First long-session prompt', timestamp: nowSeconds - 90 },
+  { id: 'a1', role: 'assistant', content: 'First answer\n\n'.repeat(30), timestamp: nowSeconds - 80 },
+  { id: 'u2', role: 'user', content: 'Second long-session prompt', timestamp: nowSeconds - 70 },
+  { id: 'a2', role: 'assistant', content: 'Second answer\n\n'.repeat(30), timestamp: nowSeconds - 60 },
+  { id: 'u3', role: 'user', content: 'Third long-session prompt', timestamp: nowSeconds - 50 },
+  { id: 'a3', role: 'assistant', content: 'Third answer\n\n'.repeat(30), timestamp: nowSeconds - 40 },
+  { id: 'u4', role: 'user', content: 'Fourth long-session prompt', timestamp: nowSeconds - 30 },
+  { id: 'a4', role: 'assistant', content: 'Fourth answer\n\n'.repeat(30), timestamp: nowSeconds - 20 },
+]
+
+async function openLongChat(
+  page: import('@playwright/test').Page,
+  messages = longSessionMessages,
+  sessionId = 'long-session',
+) {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  await page.addInitScript(({ sessionId, messages }) => {
+    ;(window as any).__PW_CHAT_SOCKET_RESUMES__ = {
+      [sessionId]: {
+        session_id: sessionId,
+        isWorking: false,
+        queueLength: 0,
+        messages,
+        events: [],
+      },
+    }
+  }, { sessionId, messages })
+  const api = await mockHermesApi(page, {
+    sessions: [
+      {
+        id: sessionId,
+        title: 'Long navigator session',
+        source: 'cli',
+        started_at: nowSeconds - 1000,
+        last_active: nowSeconds,
+        message_count: messages.length,
+        profile: 'research',
+      },
+    ],
+  })
+  await mockChatSocket(page)
+
+  await page.goto('/#/hermes/chat')
+  return api
+}
+
+test('shows compact conversation navigator for long chat sessions', async ({ page }) => {
+  const api = await openLongChat(page)
+
+  const navigator = page.getByTestId('conversation-navigator')
+  await expect(navigator).toBeVisible()
+  await expect(navigator.getByRole('button')).toHaveCount(4)
+
+  const turnTwo = navigator.getByRole('button', { name: /Turn 2:/ })
+  await turnTwo.hover()
+  await expect(navigator.locator('.conversation-nav-tooltip')).toBeVisible()
+  await expect(navigator.locator('.conversation-nav-tooltip')).toContainText('Second long-session prompt')
+
+  await page.evaluate(() => {
+    ;(window as any).__NAV_SCROLL_CALLS__ = []
+    const originalScrollTo = HTMLElement.prototype.scrollTo
+    HTMLElement.prototype.scrollTo = function scrollToWithCapture(...args: any[]) {
+      ;(window as any).__NAV_SCROLL_CALLS__.push(args[0])
+      return originalScrollTo.apply(this, args as any)
+    }
+  })
+
+  await navigator.getByRole('button', { name: /Turn 3:/ }).click()
+  await expect(page.locator('#message-u3')).toBeInViewport()
+  await expect.poll(async () => page.evaluate(() =>
+    ((window as any).__NAV_SCROLL_CALLS__ || []).some((call: any) => call?.behavior === 'smooth'),
+  )).toBe(true)
+
+  expect(api.unexpectedRequests).toEqual([])
+})
+
+test('keeps conversation navigator unobtrusive across desktop tablet and narrow widths', async ({ page }) => {
+  const api = await openLongChat(page)
+
+  for (const viewport of [
+    { width: 1440, height: 900 },
+    { width: 820, height: 1180 },
+    { width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize(viewport)
+    await page.goto('/#/hermes/chat')
+
+    const navigator = page.getByTestId('conversation-navigator')
+    const input = page.getByPlaceholder('Type a message... (Enter to send, Shift+Enter for new line)')
+    await expect(navigator).toBeVisible()
+    await expect(input).toBeVisible()
+
+    const navBox = await navigator.boundingBox()
+    const inputBox = await input.boundingBox()
+    expect(navBox).not.toBeNull()
+    expect(inputBox).not.toBeNull()
+    expect(navBox!.x + navBox!.width).toBeLessThanOrEqual(viewport.width)
+    expect(navBox!.x).toBeGreaterThanOrEqual(0)
+    expect(navBox!.y + navBox!.height).toBeLessThan(inputBox!.y)
+
+    const rightPadding = await page.locator('.virtual-message-list').evaluate((el) => parseFloat(getComputedStyle(el).paddingRight))
+    expect(rightPadding).toBeGreaterThanOrEqual(44)
+
+    await page.locator('.virtual-message-list').evaluate((el) => {
+      el.scrollTop = 0
+      el.dispatchEvent(new Event('scroll', { bubbles: true }))
+    })
+    await expect(page.getByLabel('Scroll to bottom')).toHaveCount(0)
+  }
+
+  expect(api.unexpectedRequests).toEqual([])
+})
+
+test('bounds the navigator rail for very long sessions', async ({ page }) => {
+  const manyTurnMessages = Array.from({ length: 36 }, (_, index) => ({
+    id: `u-many-${index + 1}`,
+    role: 'user',
+    content: `Long session prompt ${index + 1}`,
+    timestamp: nowSeconds - 500 + index,
+  }))
+
+  const api = await openLongChat(page, manyTurnMessages, 'many-turn-session')
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto('/#/hermes/chat')
+
+  const navigator = page.getByTestId('conversation-navigator')
+  await expect(navigator).toBeVisible()
+  await expect(navigator.getByRole('button')).toHaveCount(36)
+
+  const navBox = await navigator.boundingBox()
+  expect(navBox).not.toBeNull()
+  expect(navBox!.height).toBeLessThanOrEqual(844 * 0.72)
+  expect(navBox!.y).toBeGreaterThanOrEqual(0)
+  expect(navBox!.y + navBox!.height).toBeLessThanOrEqual(844)
+
+  expect(api.unexpectedRequests).toEqual([])
+})


### PR DESCRIPTION
## UAT 截图

<p align="center">
  <img src="https://github.com/hanzckernel/pr-visual-assets/releases/download/pr-infographics/hermes-studio-pr1610-session-turn-navigator-fb839c4c.png" alt="Hermes Web UI PR #1610 session turn navigator UAT screenshot" width="900">
</p>

## 摘要

- 为长 Hermes Web UI 聊天会话增加一个类似 ChatGPT 的紧凑 turn navigator，只从用户提问回合派生导航项。
- 保持实现前端侧、低侵入：复用现有 `message-<id>` anchor，使用右侧有界 overlay rail，短会话不显示。
- navigator 点击支持 smooth anchor scrolling，包括目标 virtualized row 尚未渲染时的远距离跳转。
- 保持核心聊天行为不变：streaming、bottom-follow、现有 outline navigation、短会话布局都不改。

## UX 说明

- 只有用户回合数量达到阈值时才显示 rail。
- hover/focus 会通过自定义 tooltip 立即显示对应 turn label / prompt，不依赖 native `title`。
- 超长会话时 rail 有最大高度和内部滚动；消息列表增加右侧 gutter，避免 rail 覆盖正文。
- navigator 可见时隐藏旧的右下 “scroll to bottom” 浮动按钮，避免右侧重复控件。
- navigator 点击强制使用 smooth scroll；这条显式用户交互不会被 macOS Reduce Motion 关闭。

## 实现说明

- 新增组件：`packages/client/src/components/hermes/chat/ConversationNavigator.vue`
- 集成位置：`packages/client/src/components/hermes/chat/MessageList.vue`
- smooth anchor 支持：`packages/client/src/components/hermes/chat/VirtualMessageList.vue`
- 已补全现有 locale 文件的文案 key。
- 已补 chat-chain fragment：`docs/chat-chain-changes/2026-06-16-session-turn-navigator.md`

## 已检查的重叠工作

只读 GitHub 搜索发现以下相关但不重复的历史工作：

- #1518 `[codex] redesign chat sidebars`：已合并，侧边栏/布局重构，不是会话内 turn navigator。
- #1527 `[codex] tune chat history loading controls`：已合并，聊天历史加载控制，不是当前会话内 prompt 导航。
- #973 / #979 native navigation links：会话/路由链接能力，不是会话内部 turn rail。
- #234 scroll behavior cleanup：较早的通用滚动改进，不包含这个 navigator。

未发现已经实现该 ChatGPT-style session turn navigator 的 open PR / issue。

## 验证

- `npm run test -- tests/client/conversation-navigator.test.ts` — 7 passed
- `PLAYWRIGHT_PORT=8673 npm run test:e2e -- tests/e2e/chat-session-navigator.spec.ts --workers=1` — 3 passed
- `npm run build` — passed
- `PLAYWRIGHT_PORT=8673 npm run test:e2e -- tests/e2e/chat-streaming.spec.ts --grep "sends a chat run" --workers=1` — 1 passed
- `npm run harness:check` — passed
- `git diff --check` — passed

## 本地 UAT

- `http://127.0.0.1:8661/` 返回 200。
- `http://127.0.0.1:8660/health` 返回 200。
- 浏览器手动 UAT 已确认：navigator 可见，hover tooltip 正常显示，点击 turn 后聊天内容会平滑移动到对应内容位置。

