### PR TITLE
修复新会话排序使用过期活动时间

### DIFF
--- a/docs/chat-chain-changes/2026-06-17-session-activity-order.md
+++ b/docs/chat-chain-changes/2026-06-17-session-activity-order.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-17
-pr: pending
+pr: 1614
 feature: Session list ordering
 impact: Chat session list ordering now uses the newest known activity timestamp so new sessions with stale last_active metadata still appear at the top.
 ---

--- a/docs/chat-chain-changes/2026-06-17-session-activity-order.md
+++ b/docs/chat-chain-changes/2026-06-17-session-activity-order.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-17
+pr: pending
+feature: Session list ordering
+impact: Chat session list ordering now uses the newest known activity timestamp so new sessions with stale last_active metadata still appear at the top.
+---

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -433,6 +433,14 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
   return result
 }
 
+function sessionActivitySeconds(s: SessionSummary): number {
+  return Math.max(
+    s.started_at || 0,
+    s.ended_at || 0,
+    s.last_active || 0,
+  )
+}
+
 function mapHermesSession(s: SessionSummary): Session {
   const isCodingAgentSession = s.source === 'coding_agent' || s.agent === 'claude' || s.agent === 'codex'
   const codingAgentId = s.agent === 'codex' ? 'codex' : s.agent === 'claude' ? 'claude-code' : undefined
@@ -441,6 +449,7 @@ function mapHermesSession(s: SessionSummary): Session {
         ? s.agent_mode
         : s.provider === 'global' ? 'global' : 'scoped')
     : undefined
+  const activitySeconds = sessionActivitySeconds(s)
   return {
     id: s.id,
     profile: s.profile || 'default',
@@ -453,7 +462,7 @@ function mapHermesSession(s: SessionSummary): Session {
     codingAgentMode,
     messages: [],
     createdAt: Math.round(s.started_at * 1000),
-    updatedAt: Math.round((s.last_active || s.ended_at || s.started_at) * 1000),
+    updatedAt: Math.round(activitySeconds * 1000),
     model: s.model,
     provider: s.provider || (s as any).billing_provider || '',
     messageCount: s.message_count,
@@ -625,7 +634,7 @@ export const useChatStore = defineStore('chat', () => {
     const byId = new Map<string, SessionSummary>()
     for (const session of [...localSessions, ...globalSessions]) byId.set(session.id, session)
     return [...byId.values()].sort((a, b) =>
-      (b.last_active || b.ended_at || b.started_at || 0) - (a.last_active || a.ended_at || a.started_at || 0),
+      sessionActivitySeconds(b) - sessionActivitySeconds(a),
     )
   }
 

--- a/tests/client/chat-store-session-order.test.ts
+++ b/tests/client/chat-store-session-order.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useChatStore } from '@/stores/hermes/chat'
+import { fetchSessions } from '@/api/hermes/sessions'
+
+vi.mock('@/api/hermes/sessions', () => ({
+  fetchSessions: vi.fn(),
+  fetchSessionMessagesPage: vi.fn(),
+  deleteSession: vi.fn(),
+  setSessionModel: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/chat', () => ({
+  startRunViaSocket: vi.fn(),
+  resumeSession: vi.fn((_sessionId: string, cb: (data: any) => void) => {
+    cb({ session_id: _sessionId, isWorking: false, messages: [] })
+  }),
+  registerSessionHandlers: vi.fn(),
+  unregisterSessionHandlers: vi.fn(),
+  getChatRunSocket: vi.fn(() => ({ emit: vi.fn() })),
+  respondToolApproval: vi.fn(),
+  respondClarify: vi.fn(),
+  onPeerUserMessage: vi.fn(() => vi.fn()),
+  onSessionCommand: vi.fn(() => vi.fn()),
+  onSessionTitleUpdated: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('@/api/client', () => ({
+  getActiveProfileName: () => 'default',
+}))
+
+vi.mock('@/api/hermes/download', () => ({
+  getDownloadUrl: (_path: string, name: string) => `/download/${name}`,
+}))
+
+vi.mock('@/utils/completion-sound', () => ({
+  primeCompletionSound: vi.fn(),
+  playCompletionSound: vi.fn(),
+}))
+
+vi.mock('@/utils/completion-notification', () => ({
+  showCompletionNotification: vi.fn(),
+}))
+
+vi.mock('@/utils/session-sync', () => ({
+  subscribeSessionSync: vi.fn(() => vi.fn()),
+  publishSessionSync: vi.fn(),
+}))
+
+function makeSession(id: string, times: Partial<{ started_at: number; ended_at: number | null; last_active: number }>) {
+  return {
+    id,
+    profile: 'default',
+    source: 'cli',
+    title: id,
+    preview: '',
+    started_at: times.started_at ?? 1,
+    ended_at: times.ended_at ?? null,
+    last_active: times.last_active,
+    message_count: 0,
+    tool_call_count: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    model: 'gpt-test',
+    provider: 'test',
+  }
+}
+
+describe('chat session ordering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('orders sessions by the newest known activity timestamp, including started_at', async () => {
+    vi.mocked(fetchSessions)
+      .mockResolvedValueOnce([
+        makeSession('older-active-session', { started_at: 100, last_active: 900 }),
+        makeSession('new-session-with-stale-last-active', { started_at: 1000, last_active: 200 }),
+      ] as any)
+      .mockResolvedValueOnce([])
+
+    const store = useChatStore()
+    await store.loadSessions()
+
+    expect(store.sessions.map(session => session.id)).toEqual([
+      'new-session-with-stale-last-active',
+      'older-active-session',
+    ])
+    expect(store.sessions[0].updatedAt).toBe(1000_000)
+  })
+})


### PR DESCRIPTION
## Summary
- 会话列表排序改为使用 `started_at`、`ended_at`、`last_active` 三者里的最新活动时间
- `updatedAt` 映射也统一使用同一个最新活动时间，避免新建会话因为 stale `last_active` 被排到旧会话后面
- 增加回归测试覆盖“新会话 started_at 更新但 last_active 较旧”的场景
- 增加 chat-chain change fragment 记录本次 session list 行为变化

Fixes #1112

## Tests
- ✅ `npx vitest run tests/client/chat-store-session-order.test.ts` passed
- ✅ `npm run harness:check` passed
- ✅ `npm run build` passed
