### PR TITLE
改善 Workspace 长文件名悬停显示

### DIFF
--- a/packages/client/src/components/hermes/files/FileList.vue
+++ b/packages/client/src/components/hermes/files/FileList.vue
@@ -106,7 +106,7 @@ async function handleDownload(entry: FileEntry) {
         >
           <div class="file-name">
             <span class="file-icon">{{ getFileIcon(entry) }}</span>
-            <span class="file-label">{{ entry.name }}</span>
+            <span class="file-label" :title="entry.name">{{ entry.name }}</span>
           </div>
           <div class="file-size">{{ entry.isDir ? '—' : formatSize(entry.size) }}</div>
           <div class="file-date">{{ formatDate(entry.modTime) }}</div>

--- a/packages/client/src/components/hermes/files/FileTree.vue
+++ b/packages/client/src/components/hermes/files/FileTree.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, h } from 'vue'
 import { NTree } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import { useFilesStore } from '@/stores/hermes/files'
@@ -44,6 +44,11 @@ function handleRootClick() {
   filesStore.navigateTo('')
 }
 
+function renderLabel({ option }: { option: TreeOption }) {
+  const label = String(option.label || '')
+  return h('span', { class: 'tree-node-label', title: label }, label)
+}
+
 onMounted(async () => {
   treeData.value = await loadChildren('')
 })
@@ -62,6 +67,7 @@ onMounted(async () => {
       :data="treeData"
       :selected-keys="selectedKeys"
       :on-load="handleLoad"
+      :render-label="renderLabel"
       expand-on-click
       block-line
       @update:selected-keys="handleSelect"
@@ -90,5 +96,14 @@ onMounted(async () => {
   &:hover {
     background-color: rgba(var(--accent-primary-rgb), 0.06);
   }
+}
+
+:deep(.tree-node-label) {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
 }
 </style>

--- a/tests/client/workspace-long-names.test.ts
+++ b/tests/client/workspace-long-names.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { defineComponent, h } from 'vue'
+import FileList from '@/components/hermes/files/FileList.vue'
+import FileTree from '@/components/hermes/files/FileTree.vue'
+import { useFilesStore } from '@/stores/hermes/files'
+import { listFiles } from '@/api/hermes/files'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('naive-ui', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('naive-ui')>()),
+  useMessage: () => ({ error: vi.fn() }),
+}))
+
+vi.mock('@/api/hermes/files', () => ({
+  listFiles: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/download', () => ({
+  downloadFile: vi.fn(),
+}))
+
+const NSpinStub = defineComponent({
+  props: ['show'],
+  setup(_props, { slots }) {
+    return () => h('div', slots.default?.())
+  },
+})
+
+const NButtonStub = defineComponent({
+  props: ['title'],
+  setup(props, { slots }) {
+    return () => h('button', { title: props.title }, slots.default?.())
+  },
+})
+
+const NEmptyStub = defineComponent({
+  props: ['description'],
+  setup(props) {
+    return () => h('div', String(props.description || ''))
+  },
+})
+
+const NTreeStub = defineComponent({
+  props: ['data', 'renderLabel'],
+  setup(props) {
+    return () => h('div', (props.data || []).map((option: any) =>
+      h('div', { class: 'tree-node' }, [props.renderLabel({ option })]),
+    ))
+  },
+})
+
+function mountFileList() {
+  return mount(FileList, {
+    global: {
+      stubs: {
+        NSpin: NSpinStub,
+        NButton: NButtonStub,
+        NEmpty: NEmptyStub,
+      },
+    },
+  })
+}
+
+describe('workspace long names', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+  })
+
+  it('exposes full file names as hover titles in the file list', () => {
+    const store = useFilesStore()
+    const longName = 'very-long-generated-report-name-that-would-be-truncated-in-the-workspace-list.md'
+    store.entries = [{
+      name: longName,
+      path: longName,
+      isDir: false,
+      size: 123,
+      modTime: '2026-06-16T00:00:00Z',
+    }]
+
+    const wrapper = mountFileList()
+
+    expect(wrapper.find('.file-label').text()).toBe(longName)
+    expect(wrapper.find('.file-label').attributes('title')).toBe(longName)
+  })
+
+  it('exposes full folder names as hover titles in the workspace tree', async () => {
+    const longName = 'very-long-folder-name-that-needs-a-hover-title'
+    vi.mocked(listFiles).mockResolvedValue({
+      path: '',
+      entries: [{
+        name: longName,
+        path: longName,
+        isDir: true,
+        size: 0,
+        modTime: '2026-06-16T00:00:00Z',
+      }],
+    } as any)
+
+    const wrapper = mount(FileTree, {
+      global: {
+        stubs: {
+          NTree: NTreeStub,
+        },
+      },
+    })
+    await vi.waitFor(() => {
+      expect(wrapper.find('.tree-node-label').exists()).toBe(true)
+    })
+
+    expect(wrapper.find('.tree-node-label').text()).toBe(longName)
+    expect(wrapper.find('.tree-node-label').attributes('title')).toBe(longName)
+  })
+})


### PR DESCRIPTION
## Summary
- Workspace 文件列表里的长文件名增加原生 hover `title`，方便查看完整名称
- 文件树里的文件夹标签也增加 hover `title`，并补上 ellipsis 样式，窄栏里不会撑坏布局
- 增加客户端测试覆盖文件列表和文件树两个长名称场景

Fixes #949

## Tests
- ✅ `npx vitest run tests/client/workspace-long-names.test.ts` passed
- ✅ `npm run build` passed
