### PR TITLE
[codex] allow file drops across chat panel

### DIFF
--- a/docs/chat-chain-changes/2026-06-17-chat-wide-file-drop.md
+++ b/docs/chat-chain-changes/2026-06-17-chat-wide-file-drop.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-17
+pr: pending
+feature: Chat file attachments
+impact: File drag-and-drop now works across one-on-one and group chat content areas while reusing the existing composer attachment flow.
+---

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -586,6 +586,11 @@ function addFile(file: File) {
   })
 }
 
+function addFiles(files: File[]) {
+  for (const file of files) addFile(file)
+  if (files.length > 0) textareaRef.value?.focus()
+}
+
 function handleAttachClick() {
   fileInputRef.value?.click()
 }
@@ -593,7 +598,7 @@ function handleAttachClick() {
 function handleFileChange(e: Event) {
   const input = e.target as HTMLInputElement
   if (!input.files) return
-  for (const file of input.files) addFile(file)
+  addFiles(Array.from(input.files))
   input.value = ''
 }
 
@@ -609,7 +614,7 @@ function handlePaste(e: ClipboardEvent) {
     if (!blob) continue
     const ext = item.type.split('/')[1] || 'png'
     const file = new File([blob], `pasted-${Date.now()}.${ext}`, { type: item.type })
-    addFile(file)
+    addFiles([file])
   }
 }
 
@@ -641,9 +646,10 @@ function handleDrop(e: DragEvent) {
   isDragging.value = false
   const files = Array.from(e.dataTransfer?.files || [])
   if (!files.length) return
-  for (const file of files) addFile(file)
-  textareaRef.value?.focus()
+  addFiles(files)
 }
+
+defineExpose({ addFiles })
 
 // --- Send ---
 

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -47,7 +47,10 @@ const isSuperAdmin = computed(() => isStoredSuperAdmin());
 
 const showOutline = ref(false);
 const messageListRef = ref<InstanceType<typeof MessageList> | null>(null);
+const chatInputRef = ref<(InstanceType<typeof ChatInput> & { addFiles?: (files: File[]) => void }) | null>(null);
 const chatContentWrapperRef = ref<HTMLElement | null>(null);
+const chatDropCounter = ref(0);
+const isChatDropActive = ref(false);
 const showToolPanel = ref(false);
 const activeToolPanel = ref<"files" | "terminal">("files");
 const toolPanelWidth = ref(560);
@@ -130,6 +133,44 @@ function startToolResize(event: PointerEvent) {
   window.addEventListener("pointerup", stopToolResize);
   document.body.style.userSelect = "none";
   document.body.style.cursor = "col-resize";
+}
+
+function hasDraggedFiles(event: DragEvent) {
+  return Array.from(event.dataTransfer?.types || []).includes("Files");
+}
+
+function resetChatDropState() {
+  chatDropCounter.value = 0;
+  isChatDropActive.value = false;
+}
+
+function handleChatDragOver(event: DragEvent) {
+  if (!hasDraggedFiles(event)) return;
+  event.preventDefault();
+  if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
+}
+
+function handleChatDragEnter(event: DragEvent) {
+  if (!hasDraggedFiles(event)) return;
+  event.preventDefault();
+  chatDropCounter.value += 1;
+  isChatDropActive.value = true;
+}
+
+function handleChatDragLeave(event: DragEvent) {
+  if (!hasDraggedFiles(event)) return;
+  chatDropCounter.value -= 1;
+  if (chatDropCounter.value <= 0) resetChatDropState();
+}
+
+function handleChatDrop(event: DragEvent) {
+  if (!hasDraggedFiles(event)) return;
+  event.preventDefault();
+  const files = Array.from(event.dataTransfer?.files || []);
+  const target = event.target instanceof Element ? event.target : null;
+  resetChatDropState();
+  if (!files.length || target?.closest(".chat-input-area")) return;
+  chatInputRef.value?.addFiles?.(files);
 }
 
 async function handleSessionClick(sessionId: string) {
@@ -1524,10 +1565,18 @@ async function handleSessionModelCustomSubmit() {
       </header>
 
       <template v-if="currentMode === 'chat'">
-        <div ref="chatContentWrapperRef" class="chat-content-wrapper">
+        <div
+          ref="chatContentWrapperRef"
+          class="chat-content-wrapper"
+          :class="{ 'chat-content-wrapper--drop-active': isChatDropActive }"
+          @dragover="handleChatDragOver"
+          @dragenter="handleChatDragEnter"
+          @dragleave="handleChatDragLeave"
+          @drop="handleChatDrop"
+        >
           <div class="chat-main-content">
             <MessageList ref="messageListRef" />
-            <ChatInput />
+            <ChatInput ref="chatInputRef" />
           </div>
           <OutlinePanel
             v-if="showOutline"
@@ -2145,6 +2194,17 @@ async function handleSessionModelCustomSubmit() {
   position: relative;
   min-width: 0;
   max-width: 100%;
+}
+
+.chat-content-wrapper--drop-active::after {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  z-index: 30;
+  pointer-events: none;
+  border: 2px dashed var(--accent-info);
+  border-radius: 8px;
+  background: rgba(var(--accent-info-rgb), 0.05);
 }
 
 .chat-main-content {

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -290,6 +290,11 @@ function addFile(file: File) {
     })
 }
 
+function addFiles(files: File[]) {
+    for (const file of files) addFile(file)
+    if (files.length > 0) textareaRef.value?.focus()
+}
+
 function handleAttachClick() {
     fileInputRef.value?.click()
 }
@@ -297,7 +302,7 @@ function handleAttachClick() {
 function handleFileChange(e: Event) {
     const input = e.target as HTMLInputElement
     if (!input.files) return
-    for (const file of input.files) addFile(file)
+    addFiles(Array.from(input.files))
     input.value = ''
 }
 
@@ -310,7 +315,7 @@ function handlePaste(e: ClipboardEvent) {
         const blob = item.getAsFile()
         if (!blob) continue
         const ext = item.type.split('/')[1] || 'png'
-        addFile(new File([blob], `pasted-${Date.now()}.${ext}`, { type: item.type }))
+        addFiles([new File([blob], `pasted-${Date.now()}.${ext}`, { type: item.type })])
     }
 }
 
@@ -338,9 +343,10 @@ function handleDrop(e: DragEvent) {
     e.preventDefault()
     dragCounter.value = 0
     isDragging.value = false
-    for (const file of Array.from(e.dataTransfer?.files || [])) addFile(file)
-    textareaRef.value?.focus()
+    addFiles(Array.from(e.dataTransfer?.files || []))
 }
+
+defineExpose({ addFiles })
 
 function removeAttachment(id: string) {
     const idx = attachments.value.findIndex(a => a.id === id)

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -37,6 +37,9 @@ const contextRoomId = ref<string | null>(null)
 const showRoomContextMenu = ref(false)
 const roomContextMenuX = ref(0)
 const roomContextMenuY = ref(0)
+const groupChatInputRef = ref<(InstanceType<typeof GroupChatInput> & { addFiles?: (files: File[]) => void }) | null>(null)
+const chatDropCounter = ref(0)
+const isChatDropActive = ref(false)
 
 const profileOptions = computed(() =>
     profilesStore.profiles.map(p => ({ label: p.name, value: p.name }))
@@ -82,6 +85,44 @@ function openPageSidebar() {
 
 function openSettingsPage() {
     router.push({ name: 'hermes.settings' })
+}
+
+function hasDraggedFiles(event: DragEvent) {
+    return Array.from(event.dataTransfer?.types || []).includes('Files')
+}
+
+function resetChatDropState() {
+    chatDropCounter.value = 0
+    isChatDropActive.value = false
+}
+
+function handleChatDragOver(event: DragEvent) {
+    if (!hasRoom.value || !hasDraggedFiles(event)) return
+    event.preventDefault()
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy'
+}
+
+function handleChatDragEnter(event: DragEvent) {
+    if (!hasRoom.value || !hasDraggedFiles(event)) return
+    event.preventDefault()
+    chatDropCounter.value += 1
+    isChatDropActive.value = true
+}
+
+function handleChatDragLeave(event: DragEvent) {
+    if (!hasRoom.value || !hasDraggedFiles(event)) return
+    chatDropCounter.value -= 1
+    if (chatDropCounter.value <= 0) resetChatDropState()
+}
+
+function handleChatDrop(event: DragEvent) {
+    if (!hasRoom.value || !hasDraggedFiles(event)) return
+    event.preventDefault()
+    const files = Array.from(event.dataTransfer?.files || [])
+    const target = event.target instanceof Element ? event.target : null
+    resetChatDropState()
+    if (!files.length || target?.closest('.chat-input-area')) return
+    groupChatInputRef.value?.addFiles?.(files)
 }
 
 function generateCode(): string {
@@ -412,7 +453,14 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
         />
 
         <!-- Main chat area -->
-        <div class="chat-main">
+        <div
+            class="chat-main"
+            :class="{ 'chat-main--drop-active': isChatDropActive }"
+            @dragover="handleChatDragOver"
+            @dragenter="handleChatDragEnter"
+            @dragleave="handleChatDragLeave"
+            @drop="handleChatDrop"
+        >
             <div class="chat-header">
                 <button class="icon-btn header-sidebar-toggle" @click="toggleSidebar">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -556,7 +604,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                         {{ store.typingText }}
                     </div>
                 </div>
-                <GroupChatInput @send="handleSendMessage" />
+                <GroupChatInput ref="groupChatInputRef" @send="handleSendMessage" />
             </template>
 
             <div v-else class="no-room">
@@ -1170,6 +1218,18 @@ export default defineComponent({ components: { CreateRoomForm } })
     flex-direction: column;
     min-width: 0;
     background-color: transparent;
+    position: relative;
+}
+
+.chat-main--drop-active::after {
+    content: "";
+    position: absolute;
+    inset: 12px;
+    z-index: 30;
+    pointer-events: none;
+    border: 2px dashed var(--accent-info);
+    border-radius: 8px;
+    background: rgba(var(--accent-info-rgb), 0.05);
 }
 
 .chat-header {


### PR DESCRIPTION
## Summary
- Allow files dragged over one-on-one chat and group chat content areas to attach to the active composer.
- Reuse the existing ChatInput and GroupChatInput attachment flows for picker, paste, input drop, and chat-wide drop.
- Add a chat-chain fragment for the changed chat interaction path.

## Validation
- `npm run test -- tests/client/chat-input-draft.test.ts`
- `npm run test -- tests/client/group-chat-input-mentions.test.ts tests/client/group-chat-store-streaming.test.ts`
- `npm run harness:check`
- `npm run build`