### PR TITLE
fix(group-chat): stable message ordering via firstSeenAt

### DIFF
--- a/docs/chat-chain-changes/2026-06-18-pr1624-group-chat-message-order.md
+++ b/docs/chat-chain-changes/2026-06-18-pr1624-group-chat-message-order.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-18
+pr: 1624
+feature: Group Chat message ordering
+impact: Group Chat assistant messages now keep their first-seen ordering during concurrent streaming replies even when final persisted messages arrive out of sequence.
+---

--- a/packages/client/src/api/hermes/group-chat.ts
+++ b/packages/client/src/api/hermes/group-chat.ts
@@ -54,6 +54,7 @@ export interface ChatMessage {
     toolPreview?: string
     toolResult?: unknown
     toolStatus?: 'running' | 'done' | 'error'
+    firstSeenAt?: number
     attachments?: Array<{ id: string; name: string; type: string; size: number; url: string }>
 }
 

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -110,6 +110,7 @@ function mergeFinalMessage(existing: ChatMessage | null, msg: ChatMessage): Chat
         reasoning: hasText(msg.reasoning) ? msg.reasoning : existing?.reasoning ?? msg.reasoning ?? null,
         reasoning_content: hasText(msg.reasoning_content) ? msg.reasoning_content : existing?.reasoning_content ?? msg.reasoning_content ?? null,
         isStreaming: false,
+        firstSeenAt: existing?.firstSeenAt ?? msg.firstSeenAt,
         attachments: existing?.attachments || msg.attachments,
     }
 }
@@ -284,7 +285,7 @@ const currentUserAvatar = ref('')
     }
 
     // ─── Computed ───────────────────────────────────────────
-    const sortedMessages = computed(() => mapGroupMessages([...messages.value].sort((a, b) => a.timestamp - b.timestamp)))
+    const sortedMessages = computed(() => mapGroupMessages([...messages.value].sort((a, b) => (a.firstSeenAt ?? a.timestamp) - (b.firstSeenAt ?? b.timestamp))))
 
     const memberNames = computed(() => {
         return members.value.map(m => m.name)
@@ -374,6 +375,7 @@ const currentUserAvatar = ref('')
                 !m.tool_calls?.length
             ))
             msg.isStreaming = true
+            msg.firstSeenAt = msg.firstSeenAt ?? msg.timestamp ?? Date.now()
             const idx = messages.value.findIndex(m => m.id === msg.id)
             if (idx >= 0) {
                 const existing = messages.value[idx]

--- a/tests/client/group-chat-store-streaming.test.ts
+++ b/tests/client/group-chat-store-streaming.test.ts
@@ -185,6 +185,27 @@ describe('group chat store streaming merge', () => {
     })
   })
 
+  it('preserves stable message order via sortedMessages when agents finish out of sequence', async () => {
+    const store = await createJoinedStore()
+
+    // Agent A starts first
+    emitSocket('message_stream_start', assistantMessage({ id: 'msg-a', timestamp: 100 }))
+    // Agent B starts second
+    emitSocket('message_stream_start', assistantMessage({ id: 'msg-b', timestamp: 200 }))
+
+    // Agent B finishes first (completes with a later timestamp)
+    emitSocket('message', assistantMessage({ id: 'msg-b', content: 'fast reply', timestamp: 300 }))
+    // Agent A finishes last (but started first)
+    emitSocket('message', assistantMessage({ id: 'msg-a', content: 'slow reply', timestamp: 400 }))
+
+    // sortedMessages should keep A (firstSeenAt=100) before B (firstSeenAt=200)
+    expect(store.sortedMessages).toHaveLength(2)
+    expect(store.sortedMessages[0].id).toBe('msg-a')
+    expect(store.sortedMessages[0].content).toBe('slow reply')
+    expect(store.sortedMessages[1].id).toBe('msg-b')
+    expect(store.sortedMessages[1].content).toBe('fast reply')
+  })
+
   it('ignores a late empty stream start for a completed message', async () => {
     const store = await createJoinedStore()
 

--- a/tests/client/group-chat-store-streaming.test.ts
+++ b/tests/client/group-chat-store-streaming.test.ts
@@ -189,14 +189,14 @@ describe('group chat store streaming merge', () => {
     const store = await createJoinedStore()
 
     // Agent A starts first
-    emitSocket('message_stream_start', assistantMessage({ id: 'msg-a', timestamp: 100 }))
+    emitSocket('message_stream_start', assistantMessage({ id: 'msg-a', senderId: 'agent-a', senderName: 'Agent A', timestamp: 100 }))
     // Agent B starts second
-    emitSocket('message_stream_start', assistantMessage({ id: 'msg-b', timestamp: 200 }))
+    emitSocket('message_stream_start', assistantMessage({ id: 'msg-b', senderId: 'agent-b', senderName: 'Agent B', timestamp: 200 }))
 
     // Agent B finishes first (completes with a later timestamp)
-    emitSocket('message', assistantMessage({ id: 'msg-b', content: 'fast reply', timestamp: 300 }))
+    emitSocket('message', assistantMessage({ id: 'msg-b', senderId: 'agent-b', senderName: 'Agent B', content: 'fast reply', timestamp: 300 }))
     // Agent A finishes last (but started first)
-    emitSocket('message', assistantMessage({ id: 'msg-a', content: 'slow reply', timestamp: 400 }))
+    emitSocket('message', assistantMessage({ id: 'msg-a', senderId: 'agent-a', senderName: 'Agent A', content: 'slow reply', timestamp: 400 }))
 
     // sortedMessages should keep A (firstSeenAt=100) before B (firstSeenAt=200)
     expect(store.sortedMessages).toHaveLength(2)


### PR DESCRIPTION
当群聊中有多个 agent 同时被触发回复时，消息按完成时间排序导致视觉上上下跳动。

**根因：** `sortedMessages` 使用可变字段 `timestamp` 排序，当 stream 结束时服务端持久化到数据库并广播 `message` 事件，`timestamp` 被覆盖为完成时间。

**修复：**
- `ChatMessage` 接口新增只读的 `firstSeenAt` 字段
- `message_stream_start` 时捕获首次时间戳，永不覆盖
- `sortedMessages` 按 `firstSeenAt || timestamp` 排序
- `mergeFinalMessage` 保留 `existing.firstSeenAt`
- 新增测试用例验证排序稳定性