### PR TITLE
fix: guard lan discovery responder on unmappable ports

### DIFF
--- a/packages/server/src/services/lan-discovery.ts
+++ b/packages/server/src/services/lan-discovery.ts
@@ -212,7 +212,13 @@ export function startLanDiscoveryResponder(options: StartResponderOptions = {}):
   if (responderSocket) return responderSocket
 
   const httpPort = options.httpPort || config.port
-  const discoveryPort = discoveryPortForHttpPort(httpPort)
+  let discoveryPort: number
+  try {
+    discoveryPort = discoveryPortForHttpPort(httpPort)
+  } catch (err) {
+    logger.warn(err, '[lan-discovery] disabled responder for unmappable HTTP port %d', httpPort)
+    return null
+  }
   const getSystemInfo = options.getSystemInfo || getPublicSystemInfo
   const socket = dgram.createSocket('udp4')
 

--- a/tests/server/lan-discovery.test.ts
+++ b/tests/server/lan-discovery.test.ts
@@ -46,6 +46,15 @@ describe('LAN discovery', () => {
     expect(discoveryPortForHttpPort(8748)).toBe(48748)
   })
 
+  it('does not start a discovery responder for HTTP ports without a UDP mapping', () => {
+    const socket = startLanDiscoveryResponder({
+      httpPort: 54321,
+      getSystemInfo: async () => fakeInfo,
+    })
+
+    expect(socket).toBeNull()
+  })
+
   it('classifies well-known LAN endpoints', () => {
     expect(getLanEndpointKind(8648)).toBe('web')
     expect(getLanEndpointKind(8748)).toBe('desktop')


### PR DESCRIPTION
## Summary\n- Guard LAN discovery responder startup when the configured HTTP port cannot map to a UDP discovery port.\n- Add a regression test covering the previously crashing `PORT=54321` case.\n\nCloses #1620\n\n## Validation\n- `npm run test -- tests/server/lan-discovery.test.ts -t "does not start a discovery responder for HTTP ports without a UDP mapping"`\n- `npm run test -- tests/server/lan-discovery.test.ts`\n- `npx tsc --noEmit -p packages/server/tsconfig.json`\n- `npm run harness:check`\n- `npm run build`