### PR TITLE
fix: include symlink folders in workspace picker

### DIFF
--- a/docs/chat-chain-changes/2026-06-18-workspace-symlink-folders.md
+++ b/docs/chat-chain-changes/2026-06-18-workspace-symlink-folders.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-18
-commit: 55a2294e
+commit: fc1df8d8
 feature: Workspace folder picker symlink support
 impact: Non-hidden symbolic-link directories are now returned by `/api/hermes/workspace/folders`, so Windows junctions and directory symlinks show up in the workspace selector instead of being filtered out.
 ---

--- a/docs/chat-chain-changes/2026-06-18-workspace-symlink-folders.md
+++ b/docs/chat-chain-changes/2026-06-18-workspace-symlink-folders.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-18
+commit: 55a2294e
+feature: Workspace folder picker symlink support
+impact: Non-hidden symbolic-link directories are now returned by `/api/hermes/workspace/folders`, so Windows junctions and directory symlinks show up in the workspace selector instead of being filtered out.
+---

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -870,7 +870,7 @@ export async function usageStats(ctx: any) {
  */
 export async function listWorkspaceFolders(ctx: any) {
   const { resolve, join } = await import('path')
-  const { readdir } = await import('fs/promises')
+  const { readdir, stat } = await import('fs/promises')
   const { existsSync } = await import('fs')
   const { homedir } = await import('os')
 
@@ -893,13 +893,27 @@ export async function listWorkspaceFolders(ctx: any) {
 
   try {
     const entries = await readdir(fullPath, { withFileTypes: true })
-    const folders = entries
-      .filter(e => (e.isDirectory() || e.isSymbolicLink()) && !e.name.startsWith('.'))
-      .map(e => ({
+    const folders = (await Promise.all(entries.map(async e => {
+      if (e.name.startsWith('.')) return null
+
+      const entryPath = join(fullPath, e.name)
+      if (!e.isDirectory()) {
+        if (!e.isSymbolicLink()) return null
+        try {
+          const target = await stat(entryPath)
+          if (!target.isDirectory()) return null
+        } catch {
+          return null
+        }
+      }
+
+      return {
         name: e.name,
-        path: subPath ? `${subPath}/${e.name}` : e.name,
-        fullPath: join(fullPath, e.name),
-      }))
+        path: subPath ? subPath + '/' + e.name : e.name,
+        fullPath: entryPath,
+      }
+    })))
+      .filter((folder): folder is { name: string; path: string; fullPath: string } => folder !== null)
       .sort((a, b) => a.name.localeCompare(b.name))
 
     ctx.body = { base: WORKSPACE_BASE, current: subPath, folders }

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -894,7 +894,7 @@ export async function listWorkspaceFolders(ctx: any) {
   try {
     const entries = await readdir(fullPath, { withFileTypes: true })
     const folders = entries
-      .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+      .filter(e => (e.isDirectory() || e.isSymbolicLink()) && !e.name.startsWith('.'))
       .map(e => ({
         name: e.name,
         path: subPath ? `${subPath}/${e.name}` : e.name,

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -36,6 +36,7 @@ const codingAgentRunManagerMock = vi.hoisted(() => ({
   stop: vi.fn(),
 }))
 const tempDirs: string[] = []
+const originalWorkspaceBase = process.env.WORKSPACE_BASE
 
 vi.mock('../../packages/server/src/db/hermes/conversations-db', () => ({
   listConversationSummariesFromDb: listConversationSummariesFromDbMock,
@@ -178,6 +179,19 @@ describe('session conversations controller', () => {
     bridgeGetRuntimeStateMock.mockReset()
     bridgeGetRuntimeStateMock.mockReturnValue({ ready: false, running: false, endpoint: 'ipc:///tmp/hermes-agent-bridge.sock' })
     codingAgentRunManagerMock.stop.mockReset()
+  })
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop()
+      if (dir) rmSync(dir, { recursive: true, force: true })
+    }
+
+    if (originalWorkspaceBase === undefined) {
+      delete process.env.WORKSPACE_BASE
+    } else {
+      process.env.WORKSPACE_BASE = originalWorkspaceBase
+    }
   })
 
   it('lists conversations from the local session store', async () => {
@@ -1058,11 +1072,29 @@ describe('session conversations controller', () => {
     tempDirs.push(homeDir)
     const baseDir = join(homeDir, 'workspace-base')
     const realDir = join(homeDir, 'real-project')
+    const realFile = join(homeDir, 'not-a-project.txt')
     mkdirSync(baseDir, { recursive: true })
     mkdirSync(realDir, { recursive: true })
-    symlinkSync(realDir, join(baseDir, 'linked-project'))
+    writeFileSync(realFile, 'not a folder')
+
+    const trySymlink = (target: string, linkPath: string, type: 'dir' | 'file' | 'junction') => {
+      try {
+        symlinkSync(target, linkPath, type)
+        return true
+      } catch (err: any) {
+        if (err?.code === 'EPERM' || err?.code === 'EACCES') return false
+        throw err
+      }
+    }
+
+    const dirLinkType = process.platform === 'win32' ? 'junction' : 'dir'
+    const linkedDirCreated = trySymlink(realDir, join(baseDir, 'linked-project'), dirLinkType)
+    trySymlink(realFile, join(baseDir, 'linked-file'), 'file')
+    trySymlink(join(homeDir, 'missing-project'), join(baseDir, 'broken-project'), 'dir')
     mkdirSync(join(baseDir, 'visible-project'), { recursive: true })
     mkdirSync(join(baseDir, '.hidden-project'), { recursive: true })
+
+    if (!linkedDirCreated) return
 
     process.env.WORKSPACE_BASE = baseDir
     const mod = await import('../../packages/server/src/controllers/hermes/sessions')

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const listConversationSummariesFromDbMock = vi.fn()
 const getConversationDetailFromDbMock = vi.fn()
@@ -32,6 +35,7 @@ const bridgeGetRuntimeStateMock = vi.fn()
 const codingAgentRunManagerMock = vi.hoisted(() => ({
   stop: vi.fn(),
 }))
+const tempDirs: string[] = []
 
 vi.mock('../../packages/server/src/db/hermes/conversations-db', () => ({
   listConversationSummariesFromDb: listConversationSummariesFromDbMock,
@@ -1049,7 +1053,32 @@ describe('session conversations controller', () => {
       expect(ctx.body).toEqual({ error: 'Session not found' })
     })
 
-    it('falls back to CLI when DB query fails', async () => {
+  it('lists workspace folders that are directories or symlinked directories', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'hermes-workspace-folders-'))
+    tempDirs.push(homeDir)
+    const baseDir = join(homeDir, 'workspace-base')
+    const realDir = join(homeDir, 'real-project')
+    mkdirSync(baseDir, { recursive: true })
+    mkdirSync(realDir, { recursive: true })
+    symlinkSync(realDir, join(baseDir, 'linked-project'))
+    mkdirSync(join(baseDir, 'visible-project'), { recursive: true })
+    mkdirSync(join(baseDir, '.hidden-project'), { recursive: true })
+
+    process.env.WORKSPACE_BASE = baseDir
+    const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+    const ctx: any = { query: {}, status: 200, body: null }
+
+    await mod.listWorkspaceFolders(ctx)
+
+    expect(ctx.body).toMatchObject({
+      base: baseDir,
+      current: '',
+    })
+    expect(ctx.body.folders.map((folder: any) => folder.name)).toEqual(['linked-project', 'visible-project'])
+    expect(ctx.body.folders[0].fullPath).toBe(join(baseDir, 'linked-project'))
+  })
+
+  it('falls back to CLI when DB query fails', async () => {
       const sessionData = { id: 'cli-123', title: 'CLI Session', messages: [] }
       localGetSessionDetailMock.mockReturnValue(sessionData)
 


### PR DESCRIPTION
## Summary\n- Include non-hidden symlinked directories in the workspace folder picker.\n- Add regression coverage using a symlinked workspace directory.\n- Add the required chat-chain change fragment.\n\nCloses #1456\n\n## Validation\n- `npm run test -- tests/server/sessions-controller.test.ts -t "lists workspace folders that are directories or symlinked directories"`\n- `npm run test -- tests/server/sessions-controller.test.ts`\n- `npx tsc --noEmit -p packages/server/tsconfig.json`\n- `npm run harness:check`\n- `npm run build`