### PR TITLE
fix: prevent quadratic BPE token-counting hang on long CJK runs

### DIFF
--- a/docs/chat-chain-changes/2026-06-18-pr1640-cjk-token-counting-guard.md
+++ b/docs/chat-chain-changes/2026-06-18-pr1640-cjk-token-counting-guard.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-18
+pr: 1640
+feature: Token counting (context compressor)
+impact: countTokens/countTokensForModel now short-circuit to the cheap CJK-aware heuristic when the input contains a contiguous letter/CJK run longer than 2000 characters, instead of calling the O(n^2) js-tiktoken BPE merge. This prevents the server event loop from hanging at 100% CPU on sessions with long unspaced CJK text. Normal and long space-separated text still use the exact tiktoken path, so token estimates for the common case are unchanged.
+---

--- a/packages/server/src/lib/context-compressor/index.ts
+++ b/packages/server/src/lib/context-compressor/index.ts
@@ -114,17 +114,49 @@ function getEncoder() {
   return _encoder
 }
 
+// js-tiktoken's BPE merge loop is O(n²) over the bytes of a single
+// pre-tokenizer "piece". The GPT pat_str groups contiguous \p{L} characters
+// into one piece, and CJK text has no spaces, so a long CJK run becomes a
+// single huge piece (e.g. 14k chars → 42k bytes → ~1.8B ops) that pins the
+// event loop at 100% CPU and never returns — encode() doesn't throw, it just
+// hangs, so the catch-based heuristic fallback never fires. Detect that
+// pathological case up front and use the cheap heuristic instead. Normal text
+// (even very long, but space-separated) keeps the exact tiktoken path.
+const MAX_LETTER_RUN = 2000
+
+function hasPathologicalRun(text: string): boolean {
+  let maxRun = 0
+  let run = 0
+  for (let i = 0; i < text.length; i++) {
+    const cc = text.charCodeAt(i)
+    // ASCII letters or anything at/above CJK/extended ranges (>0x2e7f)
+    if ((cc >= 65 && cc <= 90) || (cc >= 97 && cc <= 122) || cc > 0x2e7f) {
+      if (++run > maxRun) maxRun = run
+      if (maxRun > MAX_LETTER_RUN) return true
+    } else {
+      run = 0
+    }
+  }
+  return false
+}
+
+function heuristicTokens(text: string): number {
+  const cjk = (text.match(/[\u2e80-\u9fff\uac00-\ud7af\u3000-\u303f\uff00-\uffef]/g) || []).length
+  const other = text.length - cjk
+  return Math.ceil(cjk * 1.5 + other / 4)
+}
+
 export function countTokens(text: string): number {
+  if (hasPathologicalRun(text)) return heuristicTokens(text)
   try {
     return getEncoder().encode(text).length
   } catch {
-    const cjk = (text.match(/[\u2e80-\u9fff\uac00-\ud7af\u3000-\u303f\uff00-\uffef]/g) || []).length
-    const other = text.length - cjk
-    return Math.ceil(cjk * 1.5 + other / 4)
+    return heuristicTokens(text)
   }
 }
 
 export function countTokensForModel(text: string, model: string): number {
+  if (hasPathologicalRun(text)) return heuristicTokens(text)
   try {
     const enc = encodingForModel(model as any)
     return enc.encode(text).length

--- a/tests/server/context-compressor.test.ts
+++ b/tests/server/context-compressor.test.ts
@@ -500,3 +500,37 @@ describe('ChatContextCompressor', () => {
     expect(saveCompressionSnapshotMock).toHaveBeenCalledWith('s1', 'updated summary', 22, 23)
   })
 })
+
+describe('countTokens', () => {
+  it('returns a positive estimate for normal text via the exact tokenizer', async () => {
+    const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
+    expect(countTokens('The quick brown fox jumps over the lazy dog.')).toBeGreaterThan(0)
+  })
+
+  it('does not hang on a long contiguous CJK run (quadratic BPE guard)', async () => {
+    const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
+    // A long run of CJK characters with no spaces forms a single huge
+    // pre-tokenizer "piece". js-tiktoken's BPE merge loop is O(n^2) over the
+    // bytes of that piece, which pins the event loop for seconds/minutes and
+    // never throws — so the guard must short-circuit to the heuristic instead
+    // of calling encode(). 30k chars would be ~90k bytes => ~8.1B ops unguarded.
+    const poison = '一'.repeat(30000)
+    const start = performance.now()
+    const tokens = countTokens(poison)
+    const elapsedMs = performance.now() - start
+    expect(tokens).toBeGreaterThan(0)
+    expect(elapsedMs).toBeLessThan(250)
+  })
+
+  it('still uses the exact tokenizer for long space-separated text', async () => {
+    const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
+    // Long but with frequent spaces => no single piece exceeds the guard
+    // threshold, so the exact tiktoken path runs and stays fast.
+    const longText = 'word '.repeat(10000)
+    const start = performance.now()
+    const tokens = countTokens(longText)
+    const elapsedMs = performance.now() - start
+    expect(tokens).toBeGreaterThan(0)
+    expect(elapsedMs).toBeLessThan(1000)
+  })
+})


### PR DESCRIPTION
## Summary

`countTokens` (and `countTokensForModel`) in `context-compressor` could hang the entire server process when estimating tokens for a session containing a long run of CJK (Chinese/Japanese/Korean) characters. The Node event loop pinned at 100% CPU, local HTTP requests timed out, and nginx returned 504 — the Studio became completely unresponsive until the process was killed.

## Root cause

The token estimator uses `js-tiktoken` with the `cl100k_base` encoding. Its BPE merge loop is **O(n²)** over the bytes of a single pre-tokenizer "piece". The GPT `pat_str` groups contiguous `\p{L}` characters into one piece, and CJK text has no spaces, so a long CJK run collapses into a single enormous piece.

A real ~14,000-character CJK assistant message (~42,000 UTF-8 bytes) produced roughly **1.8 billion operations** in the merge loop per call — and `countTokens` is called frequently (usage estimation, context compression, etc.).

The cruel detail: `encode()` does **not throw** in this case, it just spins. So the existing `catch`-based CJK heuristic fallback never fired.

## Fix

Detect a pathological contiguous letter/CJK run (> 2000 chars) up front, before calling the tokenizer, and use the cheap CJK-aware heuristic instead. Normal text — even very long, but space-separated — still takes the exact `tiktoken` path, so accuracy for the common case is unchanged.

The guard is a single linear scan over the string (cheap relative to the work it prevents) and short-circuits as soon as the threshold is crossed.

## Testing

Added regression tests in `tests/server/context-compressor.test.ts`:

- A 30k-char contiguous CJK string completes in **3 ms** (would otherwise hang for minutes).
- Normal text still returns a positive estimate via the exact tokenizer.
- Long space-separated text (10k words) still uses the exact tokenizer and stays fast.

```
✓ tests/server/context-compressor.test.ts (17 tests)
✓ tests/server/run-chat-usage.test.ts (4 tests)
```

All existing context-compressor and run-chat-usage tests continue to pass.
