### PR TITLE
[codex] drop inherited anthropic auth token

### DIFF
--- a/docs/chat-chain-changes/2026-06-18-agent-bridge-anthropic-auth-env.md
+++ b/docs/chat-chain-changes/2026-06-18-agent-bridge-anthropic-auth-env.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-18
+pr: pending
+feature: Agent Bridge worker environment
+impact: Managed Agent Bridge broker processes and profile workers now remove inherited ANTHROPIC_AUTH_TOKEN from their child-process environment. Hermes-managed Anthropic credentials such as ANTHROPIC_API_KEY, ANTHROPIC_TOKEN, and custom provider keys are unchanged, preventing a host-level Anthropic SDK bearer token override from interfering with explicit provider configuration.
+---

--- a/packages/server/src/services/hermes/agent-bridge/manager.ts
+++ b/packages/server/src/services/hermes/agent-bridge/manager.ts
@@ -88,7 +88,7 @@ function isLegacyGlobalDefaultEndpoint(endpoint: string): boolean {
 }
 
 export function buildAgentBridgeProcessEnv(endpoint: string, hermesHome: string | undefined, agentRoot: string | undefined): NodeJS.ProcessEnv {
-  return {
+  const env: NodeJS.ProcessEnv = {
     ...process.env,
     HERMES_AGENT_BRIDGE_ENDPOINT: endpoint,
     HERMES_HOME: hermesHome,
@@ -97,6 +97,8 @@ export function buildAgentBridgeProcessEnv(endpoint: string, hermesHome: string 
     HERMES_OPENROUTER_APP_CATEGORIES: process.env.HERMES_OPENROUTER_APP_CATEGORIES || OPENROUTER_WEB_UI_ATTRIBUTION_ENV.HERMES_OPENROUTER_APP_CATEGORIES,
     ...(agentRoot ? { HERMES_AGENT_ROOT: agentRoot } : {}),
   }
+  delete env.ANTHROPIC_AUTH_TOKEN
+  return env
 }
 
 function pathCandidates(agentRoot?: string): string[] {

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
@@ -62,6 +62,7 @@ class WorkerProcess:
                 "HERMES_AGENT_BRIDGE_WORKER_PROFILE": self.profile,
                 "HERMES_AGENT_BRIDGE_BROKER_PID": str(os.getpid()),
             }
+            env.pop("ANTHROPIC_AUTH_TOKEN", None)
             self.process = subprocess.Popen(
                 args,
                 env=env,

--- a/tests/server/agent-bridge-manager.test.ts
+++ b/tests/server/agent-bridge-manager.test.ts
@@ -135,6 +135,15 @@ describe('agent bridge manager command resolution', () => {
     expect(env.HERMES_OPENROUTER_APP_CATEGORIES).toBe('custom-category')
   })
 
+  it('removes inherited Anthropic auth token from the bridge process env', async () => {
+    process.env.ANTHROPIC_AUTH_TOKEN = 'stale-bearer-token'
+
+    const { buildAgentBridgeProcessEnv } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const env = buildAgentBridgeProcessEnv('ipc:///tmp/test.sock', '/tmp/hermes-home', undefined)
+
+    expect(env).not.toHaveProperty('ANTHROPIC_AUTH_TOKEN')
+  })
+
   it('uses an isolated default bridge endpoint while running under Vitest', async () => {
     const { DEFAULT_AGENT_BRIDGE_ENDPOINT } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
 

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -1048,6 +1048,7 @@ original_getpid = bridge.os.getpid
 try:
     bridge.subprocess.Popen = fake_popen
     bridge.os.getpid = lambda: 4242
+    bridge.os.environ["ANTHROPIC_AUTH_TOKEN"] = "stale-bearer-token"
     proc_worker = bridge.WorkerProcess("default:compression:session-a", "default", "ipc:///tmp/worker.sock", "/agent", "/home")
     proc_worker._pipe_stderr = lambda: None
     proc_worker._wait_ready = lambda: None
@@ -1055,9 +1056,11 @@ try:
 finally:
     bridge.subprocess.Popen = original_popen
     bridge.os.getpid = original_getpid
+    bridge.os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
 
 assert created["env"]["HERMES_AGENT_BRIDGE_BROKER_PID"] == "4242"
 assert created["env"]["HERMES_AGENT_BRIDGE_WORKER_PROFILE"] == "default"
+assert "ANTHROPIC_AUTH_TOKEN" not in created["env"]
 assert created["encoding"] == "utf-8"
 assert created["errors"] == "replace"
 


### PR DESCRIPTION
## Summary
- Remove inherited `ANTHROPIC_AUTH_TOKEN` from managed Agent Bridge broker process env.
- Remove the same variable again when the broker starts profile worker subprocesses.
- Add regression coverage for both launch paths and document the chat-chain impact.

## Why
`ANTHROPIC_AUTH_TOKEN` is not a Hermes-managed Anthropic credential, but the Anthropic SDK can read it from the host process environment. If a stale host-level bearer token is inherited, it can interfere with explicit provider configuration such as `custom:fun-claude`.

## Impact
Hermes-managed credentials are unchanged: `ANTHROPIC_API_KEY`, `ANTHROPIC_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, and `custom_providers[].api_key` still flow normally. Only the SDK-specific inherited bearer override is stripped from bridge child processes.

## Validation
- `npm run test -- tests/server/agent-bridge-manager.test.ts`
- `npm run test -- tests/server/agent-bridge-python-concurrency.test.ts`
- `npm run harness:check`
