### PR TITLE
修复过期令牌导致的登录锁定恢复

### DIFF
--- a/packages/server/src/services/login-limiter.ts
+++ b/packages/server/src/services/login-limiter.ts
@@ -193,6 +193,12 @@ function checkAnyIpLock(ip: string): CheckResult | null {
     checkIpLock(ip, state.pairingIpMap)
 }
 
+function clearIpEntry(map: Record<string, IpEntry>, ip: string): boolean {
+  if (!map[ip]) return false
+  delete map[ip]
+  return true
+}
+
 function recordIpFailure(map: Record<string, IpEntry>, ip: string): IpEntry {
   const t = now()
   let entry = map[ip]
@@ -218,8 +224,9 @@ export function checkPassword(ip: string): CheckResult {
   const global = checkGlobalLimits()
   if (global) return global
 
-  // Check all lock maps so an IP blocked for abuse cannot pivot to another public endpoint.
-  const ipLock = checkAnyIpLock(ip)
+  // Password login is the recovery path for stale browser/API tokens. A token or
+  // pairing lock must not strand a user who can still prove the password.
+  const ipLock = checkIpLock(ip, state.passwordIpMap)
   if (ipLock) return ipLock
 
   state.globalMinuteCount++
@@ -315,11 +322,14 @@ export function recordPairingFailure(ip: string): void {
 }
 
 export function recordPasswordSuccess(ip: string): void {
-  if (state.passwordIpMap[ip]) {
-    delete state.passwordIpMap[ip]
+  const passwordCleared = clearIpEntry(state.passwordIpMap, ip)
+  const tokenCleared = clearIpEntry(state.tokenIpMap, ip)
+  const pairingCleared = clearIpEntry(state.pairingIpMap, ip)
+
+  if (passwordCleared || tokenCleared || pairingCleared) {
     state.globalTotalFailures = 0
     dirty = true
-    schedulePersist()
+    persistStateSync()
   }
 }
 

--- a/tests/server/login-limiter.test.ts
+++ b/tests/server/login-limiter.test.ts
@@ -64,6 +64,46 @@ describe('login limiter', () => {
     ])
   })
 
+  it('allows password login to recover an IP locked only by stale token failures', async () => {
+    const limiter = await loadLimiter()
+    const ip = '192.0.2.21'
+
+    for (let i = 0; i < 10; i++) {
+      expect(limiter.checkToken(ip)).toEqual({ allowed: true })
+      limiter.recordTokenFailure(ip)
+    }
+
+    expect(limiter.checkToken(ip)).toEqual({ allowed: false, status: 429 })
+    expect(limiter.getLockedIps()).toEqual([
+      expect.objectContaining({ ip, type: 'token', failures: 10 }),
+    ])
+
+    expect(limiter.checkPassword(ip)).toEqual({ allowed: true })
+    limiter.recordPasswordSuccess(ip)
+
+    const { writeFileSync } = await import('fs')
+    expect(writeFileSync).toHaveBeenCalled()
+    const persistedState = JSON.parse((writeFileSync as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1] as string)
+    expect(persistedState.tokenIpMap).toEqual({})
+
+    expect(limiter.getLockedIps()).toEqual([])
+    expect(limiter.checkToken(ip)).toEqual({ allowed: true })
+  })
+
+  it('keeps password locks authoritative for protected API and pairing attempts', async () => {
+    const limiter = await loadLimiter()
+    const ip = '192.0.2.22'
+
+    for (let i = 0; i < 10; i++) {
+      expect(limiter.checkPassword(ip)).toEqual({ allowed: true })
+      limiter.recordPasswordFailure(ip)
+    }
+
+    expect(limiter.checkPassword(ip)).toEqual({ allowed: false, status: 429 })
+    expect(limiter.checkToken(ip)).toEqual({ allowed: false, status: 429 })
+    expect(limiter.checkPairing(ip)).toEqual({ allowed: false, status: 429 })
+  })
+
   it('locks pairing attempts and clears stale failure records after the window', async () => {
     const limiter = await loadLimiter()
     const ip = '192.0.2.30'
@@ -93,5 +133,22 @@ describe('login limiter', () => {
     expect(limiter.getLockedIps()).toEqual([
       expect.objectContaining({ ip, type: 'pairing', failures: 10 }),
     ])
+  })
+
+  it('allows password login to recover an IP locked only by pairing failures', async () => {
+    const limiter = await loadLimiter()
+    const ip = '192.0.2.41'
+
+    for (let i = 0; i < 10; i++) {
+      expect(limiter.checkPairing(ip)).toEqual({ allowed: true })
+      limiter.recordPairingFailure(ip)
+    }
+
+    expect(limiter.checkPairing(ip)).toEqual({ allowed: false, status: 429 })
+    expect(limiter.checkPassword(ip)).toEqual({ allowed: true })
+    limiter.recordPasswordSuccess(ip)
+
+    expect(limiter.getLockedIps()).toEqual([])
+    expect(limiter.checkPairing(ip)).toEqual({ allowed: true })
   })
 })


### PR DESCRIPTION
## 改动说明
- 调整登录限流器：密码登录只受密码失败锁影响，不再被过期令牌或配对失败产生的 IP 锁挡住。
- 成功密码登录后，同步清理同一 IP 的密码、令牌、配对锁记录，并立即持久化，避免重启后旧锁继续生效。
- 保留安全边界：密码失败锁仍会阻止令牌认证和配对接口，防止真实密码爆破后切换入口继续尝试。
- 补充回归测试，覆盖过期令牌锁恢复、配对锁恢复、密码锁跨认证入口生效，以及令牌锁清理后的持久化状态。

## 验证结果
- `npm run test -- tests/server/auth.test.ts tests/server/login-limiter.test.ts`：通过，2 个测试文件、20 个测试全部通过。
- `npm run build`：通过，完成 OpenAPI 生成、Vue 类型检查、Vite 构建、服务端 TypeScript 检查和服务端打包；仅保留既有大 chunk 警告。
- `git diff --check`：通过，无空白问题。
- `npm run harness:check`：通过。

## Review
- 已完成独立 diff review；未发现阻塞问题。
