### PR TITLE
修复聊天时间戳、PWA 元数据、抽屉宽度和上传错误

### DIFF
--- a/docs/chat-chain-changes/2026-06-18-pr1660-roi-chat-mobile-polish.md
+++ b/docs/chat-chain-changes/2026-06-18-pr1660-roi-chat-mobile-polish.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-18
+pr: 1660
+feature: Chat timestamp, upload-error, and tool drawer polish
+impact: Chat messages now show dates when needed, upload failures surface server details, and the live ChatPanel tool drawer keeps a viewport-safe persisted width.
+---
+
+Also adds mobile/PWA install metadata for the Hermes Studio shell.

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -4,6 +4,11 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+  <link rel="apple-touch-icon" href="/logo.png" />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <meta name="theme-color" content="#f7f7f4" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-title" content="Hermes Studio" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Hermes Studio</title>
   <style>

--- a/packages/client/public/manifest.webmanifest
+++ b/packages/client/public/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Hermes Studio",
+  "short_name": "Hermes",
+  "description": "Self-hosted AI chat dashboard for Hermes Agent",
+  "start_url": "/#/hermes/chat",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#f7f7f4",
+  "theme_color": "#f7f7f4",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "1254x1254",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -53,7 +53,10 @@ const chatDropCounter = ref(0);
 const isChatDropActive = ref(false);
 const showToolPanel = ref(false);
 const activeToolPanel = ref<"files" | "terminal">("files");
-const toolPanelWidth = ref(560);
+const TOOL_PANEL_MIN_WIDTH = 360;
+const TOOL_PANEL_DEFAULT_WIDTH = 560;
+const TOOL_PANEL_STORAGE_KEY = "hermes.chat.toolPanelWidth";
+const toolPanelWidth = ref(loadToolPanelWidth());
 const toolResizeStart = ref<{ x: number; width: number } | null>(null);
 
 const currentMode = ref<"chat" | "live">("chat");
@@ -97,20 +100,38 @@ function handleOutlineNavigate(target: { messageId: string; anchorId: string }) 
   if (isMobile.value) showOutline.value = false;
 }
 
+function loadToolPanelWidth() {
+  if (typeof window === "undefined") return TOOL_PANEL_DEFAULT_WIDTH;
+  const saved = Number.parseInt(
+    window.localStorage.getItem(TOOL_PANEL_STORAGE_KEY) || "",
+    10,
+  );
+  return Number.isFinite(saved) ? Math.round(saved) : TOOL_PANEL_DEFAULT_WIDTH;
+}
+
 function toolPanelMaxWidth() {
+  if (typeof window === "undefined") return 1180;
+  if (isMobile.value) return window.innerWidth;
   const available = chatContentWrapperRef.value?.clientWidth || window.innerWidth;
-  return Math.max(320, available - 120);
+  return Math.max(320, Math.min(Math.floor(available * 0.88), available - 120));
+}
+
+function clampToolPanelWidth(width: number) {
+  const maxWidth = toolPanelMaxWidth();
+  const minWidth = Math.min(TOOL_PANEL_MIN_WIDTH, maxWidth);
+  return Math.min(maxWidth, Math.max(minWidth, Math.round(width)));
+}
+
+function handleToolPanelViewportResize() {
+  if (isMobile.value) return;
+  toolPanelWidth.value = clampToolPanelWidth(toolPanelWidth.value);
 }
 
 function handleToolResizeMove(event: PointerEvent) {
   const start = toolResizeStart.value;
   if (!start) return;
   const delta = start.x - event.clientX;
-  const maxWidth = toolPanelMaxWidth();
-  toolPanelWidth.value = Math.min(
-    Math.max(360, start.width + delta),
-    maxWidth,
-  );
+  toolPanelWidth.value = clampToolPanelWidth(start.width + delta);
 }
 
 function stopToolResize() {
@@ -118,6 +139,9 @@ function stopToolResize() {
   toolResizeStart.value = null;
   window.removeEventListener("pointermove", handleToolResizeMove);
   window.removeEventListener("pointerup", stopToolResize);
+  if (!isMobile.value) {
+    window.localStorage.setItem(TOOL_PANEL_STORAGE_KEY, String(toolPanelWidth.value));
+  }
   document.body.style.userSelect = "";
   document.body.style.cursor = "";
 }
@@ -198,6 +222,8 @@ onMounted(() => {
   handleMobileChange(mobileQuery);
   mobileQuery.addEventListener("change", handleMobileChange);
   window.addEventListener("hermes:open-page-sidebar", openPageSidebar);
+  window.addEventListener("resize", handleToolPanelViewportResize);
+  handleToolPanelViewportResize();
   if (profilesStore.profiles.length === 0) {
     void profilesStore.fetchProfiles();
   }
@@ -206,8 +232,15 @@ onMounted(() => {
 onUnmounted(() => {
   mobileQuery?.removeEventListener("change", handleMobileChange);
   window.removeEventListener("hermes:open-page-sidebar", openPageSidebar);
+  window.removeEventListener("resize", handleToolPanelViewportResize);
   stopToolResize();
 });
+watch(showToolPanel, async (visible) => {
+  if (!visible || isMobile.value) return;
+  await nextTick();
+  handleToolPanelViewportResize();
+});
+
 const showRenameModal = ref(false);
 const renameValue = ref("");
 const renameSessionId = ref<string | null>(null);

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -21,6 +21,7 @@ import {
 import { useGlobalSpeech } from "@/composables/useSpeech";
 import { useVoiceSettings } from "@/composables/useVoiceSettings";
 import { speedToEdgeRate, hzToEdgePitch } from "@/utils/ttsHelpers";
+import { formatChatTimestamp } from "@/utils/chat-timestamp";
 
 const TOOL_PAYLOAD_DISPLAY_LIMIT = 1000;
 const JSON_STRING_DISPLAY_LIMIT = 200;
@@ -293,10 +294,7 @@ function formatDuration(ms: number): string {
   return r === 0 ? `${m}m` : `${m}m ${r}s`;
 }
 
-const timeStr = computed(() => {
-  const d = new Date(props.message.timestamp);
-  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-});
+const timeStr = computed(() => formatChatTimestamp(props.message.timestamp));
 
 function isImage(type: string): boolean {
   return type.startsWith("image/");

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -17,6 +17,7 @@ import { useGlobalSpeech } from '@/composables/useSpeech'
 import { useVoiceSettings } from '@/composables/useVoiceSettings'
 import { speedToEdgeRate, hzToEdgePitch } from '@/utils/ttsHelpers'
 import { getDownloadUrl } from '@/api/hermes/download'
+import { formatChatTimestamp } from '@/utils/chat-timestamp'
 import type { ChatMessage, RoomAgent, MemberInfo } from '@/api/hermes/group-chat'
 
 const TOOL_PAYLOAD_DISPLAY_LIMIT = 1000
@@ -58,10 +59,7 @@ const agentInfo = computed(() => {
     return props.agents.find(a => a.agentId === props.message.senderId || a.name === props.message.senderName)
 })
 
-const timeStr = computed(() => {
-    const d = new Date(props.message.timestamp)
-    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-})
+const timeStr = computed(() => formatChatTimestamp(props.message.timestamp))
 
 const avatarProfileName = computed(() => agentInfo.value?.profile || props.message.senderName || props.message.senderId)
 const avatarProfile = computed(() => profilesStore.profiles.find(profile => profile.name === agentInfo.value?.profile))

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -13,6 +13,7 @@ import { primeCompletionSound, playCompletionSound } from '@/utils/completion-so
 import { showCompletionNotification } from '@/utils/completion-notification'
 import { detectThinkingBoundary } from '@/utils/thinking-parser'
 import { isKnownBridgeSessionCommand } from '@/utils/hermes/bridge-session-commands'
+import { responseErrorMessage } from '@/utils/http-error'
 
 // Re-export ContentBlock for convenience
 export type ContentBlock = ContentBlockImport
@@ -177,7 +178,7 @@ async function uploadFiles(attachments: Attachment[]): Promise<{ name: string; p
     body: formData,
     headers,
   })
-  if (!res.ok) throw new Error(`Upload failed: ${res.status}`)
+  if (!res.ok) throw new Error(await responseErrorMessage(res, 'Upload failed'))
   const data = await res.json() as { files: { name: string; path: string }[] }
   return data.files
 }

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { getActiveProfileName, getApiKey, getStoredUsername } from '@/api/client'
 import { fetchCurrentUser } from '@/api/auth'
 import { getDownloadUrl } from '@/api/hermes/download'
+import { responseErrorMessage } from '@/utils/http-error'
 import type { Attachment, ContentBlock } from './chat'
 import {
     connectGroupChat,
@@ -41,7 +42,7 @@ async function uploadGroupFiles(attachments: Attachment[]): Promise<{ name: stri
         body: formData,
         headers,
     })
-    if (!res.ok) throw new Error(`Upload failed: ${res.status}`)
+    if (!res.ok) throw new Error(await responseErrorMessage(res, 'Upload failed'))
     const data = await res.json() as { files: { name: string; path: string }[] }
     return data.files
 }

--- a/packages/client/src/utils/chat-timestamp.ts
+++ b/packages/client/src/utils/chat-timestamp.ts
@@ -1,0 +1,27 @@
+export function isSameLocalDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear()
+    && a.getMonth() === b.getMonth()
+    && a.getDate() === b.getDate()
+}
+
+export function formatChatTimestamp(
+  timestamp: number | string | Date,
+  options: { now?: Date; locale?: string | string[] } = {},
+): string {
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return ''
+
+  const now = options.now || new Date()
+  const locale = options.locale
+  const timeOptions: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit' }
+
+  if (isSameLocalDay(date, now)) {
+    return date.toLocaleTimeString(locale, timeOptions)
+  }
+
+  const dateOptions: Intl.DateTimeFormatOptions = date.getFullYear() === now.getFullYear()
+    ? { month: '2-digit', day: '2-digit', ...timeOptions }
+    : { year: 'numeric', month: '2-digit', day: '2-digit', ...timeOptions }
+
+  return date.toLocaleString(locale, dateOptions)
+}

--- a/packages/client/src/utils/http-error.ts
+++ b/packages/client/src/utils/http-error.ts
@@ -1,0 +1,48 @@
+function errorMessageText(error: unknown): string {
+  if (typeof error === 'string') return error.trim()
+  if (error == null) return ''
+  if (typeof error !== 'object') return String(error).trim()
+
+  if (Array.isArray(error)) {
+    return error.map(errorMessageText).filter(Boolean).join('\n')
+  }
+
+  const record = error as Record<string, unknown>
+  for (const key of ['message', 'error', 'detail', 'description', 'code']) {
+    const text = errorMessageText(record[key])
+    if (text) return text
+  }
+
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
+}
+
+export async function responseErrorMessage(
+  response: Response,
+  fallbackPrefix = 'Request failed',
+): Promise<string> {
+  let detail = ''
+
+  const contentType = response.headers.get('content-type') || ''
+  if (contentType.includes('application/json')) {
+    try {
+      detail = errorMessageText(await response.clone().json())
+    } catch {
+      detail = ''
+    }
+  }
+
+  if (!detail) {
+    try {
+      detail = (await response.clone().text()).trim()
+    } catch {
+      detail = ''
+    }
+  }
+
+  const base = `${fallbackPrefix}: ${response.status}`
+  return detail ? `${base} - ${detail}` : base
+}

--- a/tests/client/chat-timestamp.test.ts
+++ b/tests/client/chat-timestamp.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { formatChatTimestamp, isSameLocalDay } from '@/utils/chat-timestamp'
+
+describe('chat timestamp formatting', () => {
+  it('shows only hour and minute for messages from today', () => {
+    const now = new Date('2026-06-18T15:30:00')
+    const messageTime = new Date('2026-06-18T09:05:00')
+
+    expect(isSameLocalDay(messageTime, now)).toBe(true)
+    expect(formatChatTimestamp(messageTime, { now, locale: 'en-US' })).toBe('09:05 AM')
+  })
+
+  it('adds month and day for previous-day messages in the same year', () => {
+    const now = new Date('2026-06-18T15:30:00')
+    const messageTime = new Date('2026-06-17T22:15:00')
+
+    expect(formatChatTimestamp(messageTime, { now, locale: 'en-US' })).toBe('06/17, 10:15 PM')
+  })
+
+  it('adds year for messages from a different year', () => {
+    const now = new Date('2026-06-18T15:30:00')
+    const messageTime = new Date('2025-12-31T23:59:00')
+
+    expect(formatChatTimestamp(messageTime, { now, locale: 'en-US' })).toBe('12/31/2025, 11:59 PM')
+  })
+
+  it('returns an empty string for invalid timestamps', () => {
+    expect(formatChatTimestamp('not a date')).toBe('')
+  })
+})

--- a/tests/client/drawer-panel-resize.test.ts
+++ b/tests/client/drawer-panel-resize.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+
+describe('ChatPanel tool drawer resizing support', () => {
+  it('persists and clamps the live chat tool panel width while keeping mobile full width', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+
+    expect(source).toContain('class="chat-tool-panel"')
+    expect(source).toContain('const TOOL_PANEL_STORAGE_KEY = "hermes.chat.toolPanelWidth"')
+    expect(source).toContain('function clampToolPanelWidth')
+    expect(source).toContain('Math.floor(available * 0.88)')
+    expect(source).toContain('window.localStorage.setItem(TOOL_PANEL_STORAGE_KEY')
+    expect(source).toContain('window.addEventListener("resize", handleToolPanelViewportResize)')
+    expect(source).toContain('watch(showToolPanel')
+    expect(source).toContain('width: 100% !important;')
+  })
+})

--- a/tests/client/http-error.test.ts
+++ b/tests/client/http-error.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { responseErrorMessage } from '@/utils/http-error'
+
+describe('responseErrorMessage', () => {
+  it('uses JSON error fields when available', async () => {
+    const response = new Response(JSON.stringify({ error: 'Profile access denied' }), {
+      status: 403,
+      headers: { 'content-type': 'application/json' },
+    })
+
+    await expect(responseErrorMessage(response, 'Upload failed')).resolves.toBe('Upload failed: 403 - Profile access denied')
+  })
+
+  it('falls back to text response bodies', async () => {
+    const response = new Response('Forbidden by policy', { status: 403 })
+
+    await expect(responseErrorMessage(response, 'Upload failed')).resolves.toBe('Upload failed: 403 - Forbidden by policy')
+  })
+
+  it('keeps the original status-only fallback when no body exists', async () => {
+    const response = new Response('', { status: 500 })
+
+    await expect(responseErrorMessage(response, 'Upload failed')).resolves.toBe('Upload failed: 500')
+  })
+})

--- a/tests/client/pwa-metadata.test.ts
+++ b/tests/client/pwa-metadata.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+
+describe('PWA metadata', () => {
+  it('links manifest and touch icon from the client shell', () => {
+    const html = readFileSync('packages/client/index.html', 'utf8')
+
+    expect(html).toContain('rel="manifest" href="/manifest.webmanifest"')
+    expect(html).toContain('rel="apple-touch-icon" href="/logo.png"')
+    expect(html).toContain('name="apple-mobile-web-app-title" content="Hermes Studio"')
+  })
+
+  it('ships a standalone web manifest with the Hermes icon', () => {
+    const manifest = JSON.parse(readFileSync('packages/client/public/manifest.webmanifest', 'utf8'))
+
+    expect(manifest.name).toBe('Hermes Studio')
+    expect(manifest.display).toBe('standalone')
+    expect(manifest.start_url).toBe('/#/hermes/chat')
+    expect(manifest.icons).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        src: '/logo.png',
+        type: 'image/png',
+        purpose: 'any maskable',
+      }),
+    ]))
+  })
+})


### PR DESCRIPTION
## 改动说明

- 聊天消息时间戳改为日期感知：当天只显示时间，跨天显示日期+时间，跨年显示年份+日期+时间；覆盖普通聊天和群聊消息。
- 增加移动端/PWA 安装元数据：manifest、apple touch icon、theme color，并将 `start_url` 对齐当前 hash router 的 `/#/hermes/chat`。
- 修复实际在线路径 `ChatPanel.vue` 的工具抽屉宽度行为：宽度持久化、按视口 clamp、打开/窗口 resize 时重新收敛，移动端保持 100% 宽。
- 聊天和群聊上传失败时解析 JSON/text 错误体，显示服务端返回的具体原因，而不是只显示 `Upload failed: <status>`。
- 添加 chat-chain change fragment，满足 harness 对 chat session chain 变更的记录要求。

## 测试

- `npm run harness:check`
- `git diff --check`
- `npm run test -- tests/client/drawer-panel-resize.test.ts tests/client/pwa-metadata.test.ts tests/client/chat-timestamp.test.ts tests/client/http-error.test.ts tests/client/group-message-item-highlight.test.ts tests/client/chat-store-thinking.test.ts tests/client/group-chat-store-streaming.test.ts tests/client/chat-message-mobile-layout.test.ts`
- `npm run build`

## Review

- 第一轮 independent review 发现 #1117 初版误改到未被引用的 `DrawerPanel.vue`，没有覆盖真实路径。
- 已修正为在实际使用的 `ChatPanel.vue` 实现。
- 最终 independent re-review 结论：PASS，无 blocking issues。
