### PR TITLE
修复跨天聊天消息时间戳

### DIFF
--- a/docs/chat-chain-changes/2026-06-18-pr1662-chat-timestamps.md
+++ b/docs/chat-chain-changes/2026-06-18-pr1662-chat-timestamps.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-18
+pr: 1662
+feature: Date-aware chat message timestamps
+impact: Chat and group-chat message timestamps include the date for older messages so cross-day conversations remain readable.
+---

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -21,6 +21,7 @@ import {
 import { useGlobalSpeech } from "@/composables/useSpeech";
 import { useVoiceSettings } from "@/composables/useVoiceSettings";
 import { speedToEdgeRate, hzToEdgePitch } from "@/utils/ttsHelpers";
+import { formatChatTimestamp } from "@/utils/chat-timestamp";
 
 const TOOL_PAYLOAD_DISPLAY_LIMIT = 1000;
 const JSON_STRING_DISPLAY_LIMIT = 200;
@@ -293,10 +294,7 @@ function formatDuration(ms: number): string {
   return r === 0 ? `${m}m` : `${m}m ${r}s`;
 }
 
-const timeStr = computed(() => {
-  const d = new Date(props.message.timestamp);
-  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-});
+const timeStr = computed(() => formatChatTimestamp(props.message.timestamp));
 
 function isImage(type: string): boolean {
   return type.startsWith("image/");

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -17,6 +17,7 @@ import { useGlobalSpeech } from '@/composables/useSpeech'
 import { useVoiceSettings } from '@/composables/useVoiceSettings'
 import { speedToEdgeRate, hzToEdgePitch } from '@/utils/ttsHelpers'
 import { getDownloadUrl } from '@/api/hermes/download'
+import { formatChatTimestamp } from '@/utils/chat-timestamp'
 import type { ChatMessage, RoomAgent, MemberInfo } from '@/api/hermes/group-chat'
 
 const TOOL_PAYLOAD_DISPLAY_LIMIT = 1000
@@ -58,10 +59,7 @@ const agentInfo = computed(() => {
     return props.agents.find(a => a.agentId === props.message.senderId || a.name === props.message.senderName)
 })
 
-const timeStr = computed(() => {
-    const d = new Date(props.message.timestamp)
-    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-})
+const timeStr = computed(() => formatChatTimestamp(props.message.timestamp))
 
 const avatarProfileName = computed(() => agentInfo.value?.profile || props.message.senderName || props.message.senderId)
 const avatarProfile = computed(() => profilesStore.profiles.find(profile => profile.name === agentInfo.value?.profile))

--- a/packages/client/src/utils/chat-timestamp.ts
+++ b/packages/client/src/utils/chat-timestamp.ts
@@ -1,0 +1,27 @@
+export function isSameLocalDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear()
+    && a.getMonth() === b.getMonth()
+    && a.getDate() === b.getDate()
+}
+
+export function formatChatTimestamp(
+  timestamp: number | string | Date,
+  options: { now?: Date; locale?: string | string[] } = {},
+): string {
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return ''
+
+  const now = options.now || new Date()
+  const locale = options.locale
+  const timeOptions: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit' }
+
+  if (isSameLocalDay(date, now)) {
+    return date.toLocaleTimeString(locale, timeOptions)
+  }
+
+  const dateOptions: Intl.DateTimeFormatOptions = date.getFullYear() === now.getFullYear()
+    ? { month: '2-digit', day: '2-digit', ...timeOptions }
+    : { year: 'numeric', month: '2-digit', day: '2-digit', ...timeOptions }
+
+  return date.toLocaleString(locale, dateOptions)
+}

--- a/tests/client/chat-timestamp.test.ts
+++ b/tests/client/chat-timestamp.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { formatChatTimestamp, isSameLocalDay } from '@/utils/chat-timestamp'
+
+describe('chat timestamp formatting', () => {
+  it('shows only hour and minute for messages from today', () => {
+    const now = new Date('2026-06-18T15:30:00')
+    const messageTime = new Date('2026-06-18T09:05:00')
+
+    expect(isSameLocalDay(messageTime, now)).toBe(true)
+    expect(formatChatTimestamp(messageTime, { now, locale: 'en-US' })).toBe('09:05 AM')
+  })
+
+  it('adds month and day for previous-day messages in the same year', () => {
+    const now = new Date('2026-06-18T15:30:00')
+    const messageTime = new Date('2026-06-17T22:15:00')
+
+    expect(formatChatTimestamp(messageTime, { now, locale: 'en-US' })).toBe('06/17, 10:15 PM')
+  })
+
+  it('adds year for messages from a different year', () => {
+    const now = new Date('2026-06-18T15:30:00')
+    const messageTime = new Date('2025-12-31T23:59:00')
+
+    expect(formatChatTimestamp(messageTime, { now, locale: 'en-US' })).toBe('12/31/2025, 11:59 PM')
+  })
+
+  it('returns an empty string for invalid timestamps', () => {
+    expect(formatChatTimestamp('not a date')).toBe('')
+  })
+})


### PR DESCRIPTION
## 改动说明

- 新增共享 `formatChatTimestamp`，聊天消息当天只显示时间，跨天显示日期+时间，跨年显示年份+日期+时间。
- 将普通聊天 `MessageItem.vue` 和群聊 `GroupMessageItem.vue` 的时间显示接到同一 formatter。
- 添加 chat-chain change fragment，记录聊天链路可见行为变化。

Closes #1629

## 复现 / 适用性

- 原实现只用 `toLocaleTimeString`，跨天会话无法看出消息日期。
- 平台无关，不是 Windows-only。

## 测试

- `npm run harness:check`
- `git diff --check`
- `npm run test -- tests/client/chat-timestamp.test.ts tests/client/group-message-item-highlight.test.ts tests/client/chat-message-mobile-layout.test.ts`

## Review

- Independent review: PASS，无 blocking issues。
