### PR TITLE
添加移动端 PWA 安装元数据

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -4,6 +4,11 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+  <link rel="apple-touch-icon" href="/logo.png" />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <meta name="theme-color" content="#f7f7f4" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-title" content="Hermes Studio" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Hermes Studio</title>
   <style>

--- a/packages/client/public/manifest.webmanifest
+++ b/packages/client/public/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Hermes Studio",
+  "short_name": "Hermes",
+  "description": "Self-hosted AI chat dashboard for Hermes Agent",
+  "start_url": "/#/hermes/chat",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#f7f7f4",
+  "theme_color": "#f7f7f4",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "1254x1254",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/tests/client/pwa-metadata.test.ts
+++ b/tests/client/pwa-metadata.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+
+describe('PWA metadata', () => {
+  it('links manifest and touch icon from the client shell', () => {
+    const html = readFileSync('packages/client/index.html', 'utf8')
+
+    expect(html).toContain('rel="manifest" href="/manifest.webmanifest"')
+    expect(html).toContain('rel="apple-touch-icon" href="/logo.png"')
+    expect(html).toContain('name="apple-mobile-web-app-title" content="Hermes Studio"')
+  })
+
+  it('ships a standalone web manifest with the Hermes icon', () => {
+    const manifest = JSON.parse(readFileSync('packages/client/public/manifest.webmanifest', 'utf8'))
+
+    expect(manifest.name).toBe('Hermes Studio')
+    expect(manifest.display).toBe('standalone')
+    expect(manifest.start_url).toBe('/#/hermes/chat')
+    expect(manifest.icons).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        src: '/logo.png',
+        type: 'image/png',
+        purpose: 'any maskable',
+      }),
+    ]))
+  })
+})


### PR DESCRIPTION
## 改动说明

- 为 Hermes Studio client shell 增加 PWA/mobile install metadata。
- 添加 `manifest.webmanifest`，配置 standalone display、theme/background color、Hermes icon。
- 添加 `apple-touch-icon`、manifest link、theme-color 和 iOS web-app metadata。
- 将 manifest `start_url` 对齐当前 hash router：`/#/hermes/chat`。

Closes #1647

## 复现 / 适用性

- 原 `index.html` 只有 favicon，没有 manifest 或 apple touch icon。
- 这是移动 Web/PWA 安装体验问题，不是 Windows-only。

## 测试

已通过：

- `npm run harness:check` → Harness check passed
- `git diff --check` → passed
- `npm run test -- tests/client/pwa-metadata.test.ts` → 1 file / 2 tests passed

## Review

- 本地 diff 复核未发现 blocking issues。
- Independent reviewer provider 返回 quota 429，未能完成外部复核；此 PR 仅包含 HTML/manifest/test 的窄范围变更。
