### PR TITLE
修复聊天工具抽屉宽度持久化

### DIFF
--- a/docs/chat-chain-changes/2026-06-18-pr1664-chat-tool-drawer-resize.md
+++ b/docs/chat-chain-changes/2026-06-18-pr1664-chat-tool-drawer-resize.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-18
+pr: 1664
+feature: Resizable chat tool drawer
+impact: The live ChatPanel file/terminal drawer persists a viewport-safe width, reclamps on open and resize, and stays full-width on mobile.
+---

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -53,7 +53,10 @@ const chatDropCounter = ref(0);
 const isChatDropActive = ref(false);
 const showToolPanel = ref(false);
 const activeToolPanel = ref<"files" | "terminal">("files");
-const toolPanelWidth = ref(560);
+const TOOL_PANEL_MIN_WIDTH = 360;
+const TOOL_PANEL_DEFAULT_WIDTH = 560;
+const TOOL_PANEL_STORAGE_KEY = "hermes.chat.toolPanelWidth";
+const toolPanelWidth = ref(loadToolPanelWidth());
 const toolResizeStart = ref<{ x: number; width: number } | null>(null);
 
 const currentMode = ref<"chat" | "live">("chat");
@@ -97,20 +100,38 @@ function handleOutlineNavigate(target: { messageId: string; anchorId: string }) 
   if (isMobile.value) showOutline.value = false;
 }
 
+function loadToolPanelWidth() {
+  if (typeof window === "undefined") return TOOL_PANEL_DEFAULT_WIDTH;
+  const saved = Number.parseInt(
+    window.localStorage.getItem(TOOL_PANEL_STORAGE_KEY) || "",
+    10,
+  );
+  return Number.isFinite(saved) ? Math.round(saved) : TOOL_PANEL_DEFAULT_WIDTH;
+}
+
 function toolPanelMaxWidth() {
+  if (typeof window === "undefined") return 1180;
+  if (isMobile.value) return window.innerWidth;
   const available = chatContentWrapperRef.value?.clientWidth || window.innerWidth;
-  return Math.max(320, available - 120);
+  return Math.max(320, Math.min(Math.floor(available * 0.88), available - 120));
+}
+
+function clampToolPanelWidth(width: number) {
+  const maxWidth = toolPanelMaxWidth();
+  const minWidth = Math.min(TOOL_PANEL_MIN_WIDTH, maxWidth);
+  return Math.min(maxWidth, Math.max(minWidth, Math.round(width)));
+}
+
+function handleToolPanelViewportResize() {
+  if (isMobile.value) return;
+  toolPanelWidth.value = clampToolPanelWidth(toolPanelWidth.value);
 }
 
 function handleToolResizeMove(event: PointerEvent) {
   const start = toolResizeStart.value;
   if (!start) return;
   const delta = start.x - event.clientX;
-  const maxWidth = toolPanelMaxWidth();
-  toolPanelWidth.value = Math.min(
-    Math.max(360, start.width + delta),
-    maxWidth,
-  );
+  toolPanelWidth.value = clampToolPanelWidth(start.width + delta);
 }
 
 function stopToolResize() {
@@ -118,6 +139,9 @@ function stopToolResize() {
   toolResizeStart.value = null;
   window.removeEventListener("pointermove", handleToolResizeMove);
   window.removeEventListener("pointerup", stopToolResize);
+  if (!isMobile.value) {
+    window.localStorage.setItem(TOOL_PANEL_STORAGE_KEY, String(toolPanelWidth.value));
+  }
   document.body.style.userSelect = "";
   document.body.style.cursor = "";
 }
@@ -198,6 +222,8 @@ onMounted(() => {
   handleMobileChange(mobileQuery);
   mobileQuery.addEventListener("change", handleMobileChange);
   window.addEventListener("hermes:open-page-sidebar", openPageSidebar);
+  window.addEventListener("resize", handleToolPanelViewportResize);
+  handleToolPanelViewportResize();
   if (profilesStore.profiles.length === 0) {
     void profilesStore.fetchProfiles();
   }
@@ -206,8 +232,15 @@ onMounted(() => {
 onUnmounted(() => {
   mobileQuery?.removeEventListener("change", handleMobileChange);
   window.removeEventListener("hermes:open-page-sidebar", openPageSidebar);
+  window.removeEventListener("resize", handleToolPanelViewportResize);
   stopToolResize();
 });
+watch(showToolPanel, async (visible) => {
+  if (!visible || isMobile.value) return;
+  await nextTick();
+  handleToolPanelViewportResize();
+});
+
 const showRenameModal = ref(false);
 const renameValue = ref("");
 const renameSessionId = ref<string | null>(null);

--- a/tests/client/drawer-panel-resize.test.ts
+++ b/tests/client/drawer-panel-resize.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+
+describe('ChatPanel tool drawer resizing support', () => {
+  it('persists and clamps the live chat tool panel width while keeping mobile full width', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+
+    expect(source).toContain('class="chat-tool-panel"')
+    expect(source).toContain('const TOOL_PANEL_STORAGE_KEY = "hermes.chat.toolPanelWidth"')
+    expect(source).toContain('function clampToolPanelWidth')
+    expect(source).toContain('Math.floor(available * 0.88)')
+    expect(source).toContain('window.localStorage.setItem(TOOL_PANEL_STORAGE_KEY')
+    expect(source).toContain('window.addEventListener("resize", handleToolPanelViewportResize)')
+    expect(source).toContain('watch(showToolPanel')
+    expect(source).toContain('width: 100% !important;')
+  })
+})


### PR DESCRIPTION
## 改动说明

- 在实际使用的 `ChatPanel.vue` 工具面板路径中支持宽度持久化。
- 拖拽宽度按聊天内容区域/视口 clamp，打开面板和窗口 resize 时重新收敛。
- 移动端保持 100% 宽，避免桌面持久化宽度污染窄屏布局。
- 添加 chat-chain change fragment。

Closes #1117

## 复现 / 适用性

- 真实渲染路径是 `ChatPanel.vue` 的 `.chat-tool-panel`，原实现没有持久化宽度，也不会在打开/视口变化时重新 clamp。
- 平台无关，不是 Windows-only。

## 测试

- `npm run harness:check`
- `git diff --check`
- `npm run test -- tests/client/drawer-panel-resize.test.ts tests/client/chat-message-mobile-layout.test.ts`

## Review

- Independent review: PASS，无 blocking issues。
- 重点确认修复位于实际 `ChatPanel.vue` 路径，而不是未引用的 `DrawerPanel.vue`。
