### PR TITLE
显示聊天上传失败详情

### DIFF
--- a/docs/chat-chain-changes/2026-06-18-pr1665-upload-error-details.md
+++ b/docs/chat-chain-changes/2026-06-18-pr1665-upload-error-details.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-18
+pr: 1665
+feature: Upload error body details
+impact: Chat and group-chat uploads now surface server-provided JSON/text error details instead of only the HTTP status.
+---

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -13,6 +13,7 @@ import { primeCompletionSound, playCompletionSound } from '@/utils/completion-so
 import { showCompletionNotification } from '@/utils/completion-notification'
 import { detectThinkingBoundary } from '@/utils/thinking-parser'
 import { isKnownBridgeSessionCommand } from '@/utils/hermes/bridge-session-commands'
+import { responseErrorMessage } from '@/utils/http-error'
 
 // Re-export ContentBlock for convenience
 export type ContentBlock = ContentBlockImport
@@ -177,7 +178,7 @@ async function uploadFiles(attachments: Attachment[]): Promise<{ name: string; p
     body: formData,
     headers,
   })
-  if (!res.ok) throw new Error(`Upload failed: ${res.status}`)
+  if (!res.ok) throw new Error(await responseErrorMessage(res, 'Upload failed'))
   const data = await res.json() as { files: { name: string; path: string }[] }
   return data.files
 }

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { getActiveProfileName, getApiKey, getStoredUsername } from '@/api/client'
 import { fetchCurrentUser } from '@/api/auth'
 import { getDownloadUrl } from '@/api/hermes/download'
+import { responseErrorMessage } from '@/utils/http-error'
 import type { Attachment, ContentBlock } from './chat'
 import {
     connectGroupChat,
@@ -41,7 +42,7 @@ async function uploadGroupFiles(attachments: Attachment[]): Promise<{ name: stri
         body: formData,
         headers,
     })
-    if (!res.ok) throw new Error(`Upload failed: ${res.status}`)
+    if (!res.ok) throw new Error(await responseErrorMessage(res, 'Upload failed'))
     const data = await res.json() as { files: { name: string; path: string }[] }
     return data.files
 }

--- a/packages/client/src/utils/http-error.ts
+++ b/packages/client/src/utils/http-error.ts
@@ -1,0 +1,48 @@
+function errorMessageText(error: unknown): string {
+  if (typeof error === 'string') return error.trim()
+  if (error == null) return ''
+  if (typeof error !== 'object') return String(error).trim()
+
+  if (Array.isArray(error)) {
+    return error.map(errorMessageText).filter(Boolean).join('\n')
+  }
+
+  const record = error as Record<string, unknown>
+  for (const key of ['message', 'error', 'detail', 'description', 'code']) {
+    const text = errorMessageText(record[key])
+    if (text) return text
+  }
+
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
+}
+
+export async function responseErrorMessage(
+  response: Response,
+  fallbackPrefix = 'Request failed',
+): Promise<string> {
+  let detail = ''
+
+  const contentType = response.headers.get('content-type') || ''
+  if (contentType.includes('application/json')) {
+    try {
+      detail = errorMessageText(await response.clone().json())
+    } catch {
+      detail = ''
+    }
+  }
+
+  if (!detail) {
+    try {
+      detail = (await response.clone().text()).trim()
+    } catch {
+      detail = ''
+    }
+  }
+
+  const base = `${fallbackPrefix}: ${response.status}`
+  return detail ? `${base} - ${detail}` : base
+}

--- a/tests/client/http-error.test.ts
+++ b/tests/client/http-error.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { responseErrorMessage } from '@/utils/http-error'
+
+describe('responseErrorMessage', () => {
+  it('uses JSON error fields when available', async () => {
+    const response = new Response(JSON.stringify({ error: 'Profile access denied' }), {
+      status: 403,
+      headers: { 'content-type': 'application/json' },
+    })
+
+    await expect(responseErrorMessage(response, 'Upload failed')).resolves.toBe('Upload failed: 403 - Profile access denied')
+  })
+
+  it('falls back to text response bodies', async () => {
+    const response = new Response('Forbidden by policy', { status: 403 })
+
+    await expect(responseErrorMessage(response, 'Upload failed')).resolves.toBe('Upload failed: 403 - Forbidden by policy')
+  })
+
+  it('keeps the original status-only fallback when no body exists', async () => {
+    const response = new Response('', { status: 500 })
+
+    await expect(responseErrorMessage(response, 'Upload failed')).resolves.toBe('Upload failed: 500')
+  })
+})


### PR DESCRIPTION
## 改动说明

- 新增 `responseErrorMessage`，上传失败时优先解析 JSON 错误字段，回退到 text body，最后保留 status-only fallback。
- 普通聊天和群聊上传路径现在显示服务端返回的具体错误原因，而不是只显示 `Upload failed: <status>`。
- 不放松 `/upload` auth，只改善错误呈现。
- 添加 chat-chain change fragment。

Closes #1642

## 复现 / 适用性

- 原 chat/group-chat upload 在 `!res.ok` 时直接抛 `Upload failed: ${status}`，会丢弃服务端 error body。
- 这是 HTTP/auth/profile 错误呈现问题，不是 Windows-only。

## 测试

- `npm run harness:check`
- `git diff --check`
- `npm run test -- tests/client/http-error.test.ts tests/client/chat-store-thinking.test.ts tests/client/group-chat-store-streaming.test.ts`

## Review

- Independent review: PASS，无 blocking issues。
