### PR TITLE
修复克隆 Profile 后模型列表为空

### DIFF
--- a/docs/chat-chain-changes/2026-06-18-pr1666-cloned-profile-model-auth.md
+++ b/docs/chat-chain-changes/2026-06-18-pr1666-cloned-profile-model-auth.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-18
+pr: 1666
+feature: Cloned profile model provider auth
+impact: Cloned profiles keep access to the configured OAuth-only model provider so the chat model picker is not empty after cloning.
+---

--- a/packages/server/src/controllers/hermes/profiles.ts
+++ b/packages/server/src/controllers/hermes/profiles.ts
@@ -11,7 +11,7 @@ import {
   restartGatewayForProfile as restartGatewayRuntimeForProfile,
 } from '../../services/hermes/gateway-autostart'
 import { logger } from '../../services/logger'
-import { smartCloneCleanup } from '../../services/hermes/profile-credentials'
+import { smartCloneCleanup, copyModelProviderAuthForClone } from '../../services/hermes/profile-credentials'
 import { detectHermesRootHome } from '../../services/hermes/hermes-path'
 import { getActiveProfileName } from '../../services/hermes/hermes-profile'
 import { HermesSkillInjector } from '../../services/hermes/skill-injector'
@@ -412,8 +412,10 @@ export async function create(ctx: any) {
     let strippedCredentials: string[] = []
     let disabledPlatforms: string[] = []
     let strippedConfigCredentials: string[] = []
+    let copiedAuthProviders: string[] = []
     if (clone) {
       try {
+        copiedAuthProviders = copyModelProviderAuthForClone(name)
         const cleanup = smartCloneCleanup(name)
         strippedCredentials = cleanup.strippedCredentials
         disabledPlatforms = cleanup.disabledPlatforms
@@ -421,11 +423,13 @@ export async function create(ctx: any) {
         if (
           strippedCredentials.length > 0 ||
           disabledPlatforms.length > 0 ||
-          strippedConfigCredentials.length > 0
+          strippedConfigCredentials.length > 0 ||
+          copiedAuthProviders.length > 0
         ) {
           logger.info(
-            'Smart clone cleanup for "%s": stripped %d env credentials (%s), disabled %d platforms (%s), stripped %d config credentials (%s)',
+            'Smart clone cleanup for "%s": copied auth for %d model providers (%s), stripped %d env credentials (%s), disabled %d platforms (%s), stripped %d config credentials (%s)',
             name,
+            copiedAuthProviders.length, copiedAuthProviders.join(','),
             strippedCredentials.length, strippedCredentials.join(','),
             disabledPlatforms.length, disabledPlatforms.join(','),
             strippedConfigCredentials.length, strippedConfigCredentials.join(','),
@@ -445,6 +449,7 @@ export async function create(ctx: any) {
       strippedCredentials,
       disabledPlatforms,
       strippedConfigCredentials,
+      copiedAuthProviders,
     }
   } catch (err: any) {
     ctx.status = 500

--- a/packages/server/src/services/hermes/profile-credentials.ts
+++ b/packages/server/src/services/hermes/profile-credentials.ts
@@ -16,7 +16,6 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import yaml from 'js-yaml'
 import { detectHermesHome } from './hermes-path'
-import { PROVIDER_ENV_MAP } from '../config-helpers'
 
 function hermesBase(): string {
   return detectHermesHome()
@@ -217,6 +216,14 @@ function authProviderKeysForModelProvider(provider: string): string[] {
   return provider === 'claude-oauth' ? ['claude-oauth', 'anthropic'] : [provider]
 }
 
+const MODEL_AUTH_PROVIDERS = new Set([
+  'openai-codex',
+  'claude-oauth',
+  'xai-oauth',
+  'google-gemini-cli',
+  'nous',
+])
+
 /**
  * Copy the source profile's OAuth auth for the cloned profile's configured model
  * provider only.
@@ -234,8 +241,7 @@ export function copyModelProviderAuthForClone(profileName: string): string[] {
   if (!profileName || profileName === 'default') return []
   const targetDir = profileDir(profileName)
   const provider = configuredModelProvider(join(targetDir, 'config.yaml'))
-  const mapping = PROVIDER_ENV_MAP[provider]
-  if (!provider || !mapping || mapping.api_key_env) return []
+  if (!MODEL_AUTH_PROVIDERS.has(provider)) return []
 
   const sourceDir = profileDir(activeProfileName())
   const sourceAuth = readAuthJson(join(sourceDir, 'auth.json'))

--- a/packages/server/src/services/hermes/profile-credentials.ts
+++ b/packages/server/src/services/hermes/profile-credentials.ts
@@ -12,13 +12,30 @@
  * 操作前会备份原文件为 `.bak.<timestamp>`。
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
-import { homedir } from 'os'
 import yaml from 'js-yaml'
 import { detectHermesHome } from './hermes-path'
+import { PROVIDER_ENV_MAP } from '../config-helpers'
 
-const HERMES_BASE = detectHermesHome()
+function hermesBase(): string {
+  return detectHermesHome()
+}
+
+function profileDir(profileName: string): string {
+  const base = hermesBase()
+  return profileName === 'default'
+    ? base
+    : join(base, 'profiles', profileName)
+}
+
+function activeProfileName(): string {
+  try {
+    return readFileSync(join(hermesBase(), 'active_profile'), 'utf-8').trim() || 'default'
+  } catch {
+    return 'default'
+  }
+}
 
 /**
  * 已知"独占型"平台的环境变量前缀正则
@@ -171,18 +188,91 @@ export interface SmartCloneCleanup {
   strippedConfigCredentials: string[]
 }
 
+function configuredModelProvider(configPath: string): string {
+  if (!existsSync(configPath)) return ''
+  let cfg: any
+  try {
+    cfg = yaml.load(readFileSync(configPath, 'utf-8'), { json: true })
+  } catch {
+    return ''
+  }
+  const provider = cfg?.model && typeof cfg.model === 'object'
+    ? String(cfg.model.provider || '').trim()
+    : ''
+  if (!provider || provider === 'custom') return ''
+  return provider
+}
+
+function readAuthJson(path: string): any {
+  if (!existsSync(path)) return {}
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'))
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function authProviderKeysForModelProvider(provider: string): string[] {
+  return provider === 'claude-oauth' ? ['claude-oauth', 'anthropic'] : [provider]
+}
+
+/**
+ * Copy the source profile's OAuth auth for the cloned profile's configured model
+ * provider only.
+ *
+ * Hermes CLI `profile create --clone` copies config/.env/SOUL/skills, but not
+ * `auth.json`. OAuth-only model providers such as `openai-codex` then look
+ * configured in the cloned profile while `/available-models?profile=<clone>`
+ * returns no groups because the profile-local auth file is missing. Copying only
+ * the provider keys required by the cloned `model.provider` preserves model
+ * access without copying unrelated provider or platform credentials across
+ * profiles. Claude OAuth also copies its `anthropic` runtime alias because chat
+ * execution rewrites `claude-oauth` to `anthropic`.
+ */
+export function copyModelProviderAuthForClone(profileName: string): string[] {
+  if (!profileName || profileName === 'default') return []
+  const targetDir = profileDir(profileName)
+  const provider = configuredModelProvider(join(targetDir, 'config.yaml'))
+  const mapping = PROVIDER_ENV_MAP[provider]
+  if (!provider || !mapping || mapping.api_key_env) return []
+
+  const sourceDir = profileDir(activeProfileName())
+  const sourceAuth = readAuthJson(join(sourceDir, 'auth.json'))
+  const targetAuthPath = join(targetDir, 'auth.json')
+  const targetAuth = readAuthJson(targetAuthPath)
+  const copied = new Set<string>()
+
+  for (const authProvider of authProviderKeysForModelProvider(provider)) {
+    if (sourceAuth.providers?.[authProvider] && !targetAuth.providers?.[authProvider]) {
+      targetAuth.providers = { ...(targetAuth.providers || {}), [authProvider]: sourceAuth.providers[authProvider] }
+      copied.add(authProvider)
+    }
+    if (sourceAuth.credential_pool?.[authProvider] && !targetAuth.credential_pool?.[authProvider]) {
+      targetAuth.credential_pool = { ...(targetAuth.credential_pool || {}), [authProvider]: sourceAuth.credential_pool[authProvider] }
+      copied.add(authProvider)
+    }
+  }
+  if (copied.size === 0) return []
+
+  mkdirSync(targetDir, { recursive: true })
+  if (existsSync(targetAuthPath)) {
+    writeFileSync(`${targetAuthPath}.bak.${Date.now()}`, JSON.stringify(readAuthJson(targetAuthPath), null, 2) + '\n', 'utf-8')
+  }
+  writeFileSync(targetAuthPath, JSON.stringify(targetAuth, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 })
+  return [...copied]
+}
+
 /**
  * 一站式：清理新 profile 的独占凭据 + 禁用 config.yaml 中的独占平台
  *
  * @param profileName profile 名称（'default' → ~/.hermes/，其他 → ~/.hermes/profiles/<name>/）
  */
 export function smartCloneCleanup(profileName: string): SmartCloneCleanup {
-  const profileDir = profileName === 'default'
-    ? HERMES_BASE
-    : join(HERMES_BASE, 'profiles', profileName)
-  const configResult = disableExclusivePlatformsInConfig(join(profileDir, 'config.yaml'))
+  const targetDir = profileDir(profileName)
+  const configResult = disableExclusivePlatformsInConfig(join(targetDir, 'config.yaml'))
   return {
-    strippedCredentials: stripExclusivePlatformCredentials(join(profileDir, '.env')),
+    strippedCredentials: stripExclusivePlatformCredentials(join(targetDir, '.env')),
     disabledPlatforms: configResult.disabled,
     strippedConfigCredentials: configResult.strippedConfigCredentials,
   }

--- a/tests/server/profile-credentials.test.ts
+++ b/tests/server/profile-credentials.test.ts
@@ -304,6 +304,30 @@ describe('copyModelProviderAuthForClone', () => {
     expect(copyModelProviderAuthForClone('cloned')).toEqual([])
     expect(existsSync(join(cloneDir, 'auth.json'))).toBe(false)
   })
+
+  it('does not copy auth for keyless providers that are not stored OAuth providers', () => {
+    process.env.HERMES_HOME = tmpDir
+    writeFileSync(join(tmpDir, 'active_profile'), 'default\n')
+    writeFileSync(join(tmpDir, 'auth.json'), JSON.stringify({
+      providers: {
+        'fun-codex': { access_token: 'stale-fun-token' },
+      },
+      credential_pool: {
+        'fun-codex': [{ access_token: 'stale-fun-pool-token' }],
+      },
+    }, null, 2))
+    const cloneDir = join(tmpDir, 'profiles', 'cloned')
+    mkdirSync(cloneDir, { recursive: true })
+    writeFileSync(join(cloneDir, 'config.yaml'), [
+      'model:',
+      '  provider: fun-codex',
+      '  default: gpt-5.5',
+      '',
+    ].join('\n'))
+
+    expect(copyModelProviderAuthForClone('cloned')).toEqual([])
+    expect(existsSync(join(cloneDir, 'auth.json'))).toBe(false)
+  })
 })
 
 describe('EXCLUSIVE_PLATFORMS list', () => {

--- a/tests/server/profile-credentials.test.ts
+++ b/tests/server/profile-credentials.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, writeFileSync, readFileSync, readdirSync, existsSync, rmSync } from 'fs'
+import { mkdtempSync, writeFileSync, readFileSync, readdirSync, existsSync, rmSync, mkdirSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
   isExclusivePlatformKey,
   stripExclusivePlatformCredentials,
   disableExclusivePlatformsInConfig,
+  copyModelProviderAuthForClone,
   EXCLUSIVE_PLATFORMS,
   EXCLUSIVE_PLATFORM_ENV_PATTERNS,
 } from '../../packages/server/src/services/hermes/profile-credentials'
 
+const originalHermesHome = process.env.HERMES_HOME
 let tmpDir: string
 
 beforeEach(() => {
@@ -17,6 +19,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  if (originalHermesHome === undefined) delete process.env.HERMES_HOME
+  else process.env.HERMES_HOME = originalHermesHome
   rmSync(tmpDir, { recursive: true, force: true })
 })
 
@@ -205,6 +209,100 @@ describe('disableExclusivePlatformsInConfig', () => {
     writeFileSync(p, 'platforms: [unclosed')
     expect(disableExclusivePlatformsInConfig(p))
       .toEqual({ disabled: [], strippedConfigCredentials: [] })
+  })
+})
+
+describe('copyModelProviderAuthForClone', () => {
+  it('copies only the cloned model provider OAuth auth from the active source profile', () => {
+    process.env.HERMES_HOME = tmpDir
+    writeFileSync(join(tmpDir, 'active_profile'), 'default\n')
+    writeFileSync(join(tmpDir, 'auth.json'), JSON.stringify({
+      providers: {
+        'openai-codex': { access_token: 'codex-provider-token' },
+        anthropic: { access_token: 'anthropic-provider-token' },
+      },
+      credential_pool: {
+        'openai-codex': [{ access_token: 'codex-pool-token' }],
+        anthropic: [{ access_token: 'anthropic-pool-token' }],
+      },
+    }, null, 2))
+    const cloneDir = join(tmpDir, 'profiles', 'cloned')
+    mkdirSync(cloneDir, { recursive: true })
+    writeFileSync(join(cloneDir, 'config.yaml'), [
+      'model:',
+      '  provider: openai-codex',
+      '  default: gpt-5.5',
+      '',
+    ].join('\n'))
+
+    const copied = copyModelProviderAuthForClone('cloned')
+
+    expect(copied).toEqual(['openai-codex'])
+    const clonedAuth = JSON.parse(readFileSync(join(cloneDir, 'auth.json'), 'utf-8'))
+    expect(clonedAuth.providers['openai-codex']).toEqual({ access_token: 'codex-provider-token' })
+    expect(clonedAuth.credential_pool['openai-codex']).toEqual([{ access_token: 'codex-pool-token' }])
+    expect(clonedAuth.providers.anthropic).toBeUndefined()
+    expect(clonedAuth.credential_pool.anthropic).toBeUndefined()
+  })
+
+  it('copies the Claude OAuth runtime alias needed for chat execution', () => {
+    process.env.HERMES_HOME = tmpDir
+    writeFileSync(join(tmpDir, 'active_profile'), 'default\n')
+    writeFileSync(join(tmpDir, 'auth.json'), JSON.stringify({
+      providers: {
+        'claude-oauth': { access_token: 'claude-oauth-token' },
+        anthropic: { access_token: 'anthropic-runtime-token' },
+        'openai-codex': { access_token: 'codex-provider-token' },
+      },
+      credential_pool: {
+        'claude-oauth': [{ access_token: 'claude-oauth-pool-token' }],
+        anthropic: [{ access_token: 'anthropic-runtime-pool-token' }],
+        'openai-codex': [{ access_token: 'codex-pool-token' }],
+      },
+    }, null, 2))
+    const cloneDir = join(tmpDir, 'profiles', 'cloned')
+    mkdirSync(cloneDir, { recursive: true })
+    writeFileSync(join(cloneDir, 'config.yaml'), [
+      'model:',
+      '  provider: claude-oauth',
+      '  default: claude-sonnet-4',
+      '',
+    ].join('\n'))
+
+    const copied = copyModelProviderAuthForClone('cloned')
+
+    expect(copied.sort()).toEqual(['anthropic', 'claude-oauth'])
+    const clonedAuth = JSON.parse(readFileSync(join(cloneDir, 'auth.json'), 'utf-8'))
+    expect(clonedAuth.providers['claude-oauth']).toEqual({ access_token: 'claude-oauth-token' })
+    expect(clonedAuth.providers.anthropic).toEqual({ access_token: 'anthropic-runtime-token' })
+    expect(clonedAuth.credential_pool['claude-oauth']).toEqual([{ access_token: 'claude-oauth-pool-token' }])
+    expect(clonedAuth.credential_pool.anthropic).toEqual([{ access_token: 'anthropic-runtime-pool-token' }])
+    expect(clonedAuth.providers['openai-codex']).toBeUndefined()
+    expect(clonedAuth.credential_pool['openai-codex']).toBeUndefined()
+  })
+
+  it('does not copy auth for API-key providers that should use env/config credentials', () => {
+    process.env.HERMES_HOME = tmpDir
+    writeFileSync(join(tmpDir, 'active_profile'), 'default\n')
+    writeFileSync(join(tmpDir, 'auth.json'), JSON.stringify({
+      providers: {
+        anthropic: { access_token: 'anthropic-provider-token' },
+      },
+      credential_pool: {
+        anthropic: [{ access_token: 'anthropic-pool-token' }],
+      },
+    }, null, 2))
+    const cloneDir = join(tmpDir, 'profiles', 'cloned')
+    mkdirSync(cloneDir, { recursive: true })
+    writeFileSync(join(cloneDir, 'config.yaml'), [
+      'model:',
+      '  provider: anthropic',
+      '  default: claude-sonnet-4',
+      '',
+    ].join('\n'))
+
+    expect(copyModelProviderAuthForClone('cloned')).toEqual([])
+    expect(existsSync(join(cloneDir, 'auth.json'))).toBe(false)
   })
 })
 

--- a/tests/server/profiles-routes.test.ts
+++ b/tests/server/profiles-routes.test.ts
@@ -103,6 +103,50 @@ describe('Profile Routes', () => {
       expect(hermesCli.createProfile).toHaveBeenCalledWith('test', true)
     })
 
+    it('clone creation copies only the configured model provider auth for the new profile', async () => {
+      const hermesHome = await mkdtemp(join(tmpdir(), 'hermes-profile-clone-auth-'))
+      tempHomes.push(hermesHome)
+      process.env.HERMES_HOME = hermesHome
+      await writeFile(join(hermesHome, 'active_profile'), 'default\n', 'utf-8')
+      await writeFile(join(hermesHome, 'auth.json'), JSON.stringify({
+        providers: {
+          'openai-codex': { access_token: 'codex-provider-token' },
+          anthropic: { access_token: 'anthropic-provider-token' },
+        },
+        credential_pool: {
+          'openai-codex': [{ access_token: 'codex-pool-token' }],
+          anthropic: [{ access_token: 'anthropic-pool-token' }],
+        },
+      }, null, 2), 'utf-8')
+      vi.mocked(hermesCli.createProfile).mockImplementation(async (name: string) => {
+        const profileDir = join(hermesHome, 'profiles', name)
+        await mkdir(profileDir, { recursive: true })
+        await writeFile(join(profileDir, 'config.yaml'), [
+          'model:',
+          '  provider: openai-codex',
+          '  default: gpt-5.5',
+          '',
+        ].join('\n'), 'utf-8')
+        return 'Profile created'
+      })
+      const { create } = await import('../../packages/server/src/controllers/hermes/profiles')
+      const ctx: any = {
+        request: { body: { name: 'cloned', clone: true } },
+        status: 200,
+        body: undefined,
+      }
+
+      await create(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body.copiedAuthProviders).toEqual(['openai-codex'])
+      const clonedAuth = JSON.parse(readFileSync(join(hermesHome, 'profiles', 'cloned', 'auth.json'), 'utf-8'))
+      expect(clonedAuth.providers['openai-codex']).toEqual({ access_token: 'codex-provider-token' })
+      expect(clonedAuth.credential_pool['openai-codex']).toEqual([{ access_token: 'codex-pool-token' }])
+      expect(clonedAuth.providers.anthropic).toBeUndefined()
+      expect(clonedAuth.credential_pool.anthropic).toBeUndefined()
+    })
+
     it('deleteProfile calls CLI with name', async () => {
       vi.mocked(hermesCli.deleteProfile).mockResolvedValue(true)
 


### PR DESCRIPTION
## 改动说明

- Web UI clone profile 后，为新 profile 复制其 `model.provider` 所需的 OAuth auth 条目，避免 clone 后模型列表为空。
- 只复制 clone 配置中需要的 auth provider key，不复制无关 provider/platform credentials。
- `claude-oauth` 额外复制现有运行时 alias `anthropic`，因为 chat 执行路径会把 `claude-oauth` 映射为 `anthropic`。
- API-key provider（如 `anthropic`）不会从 `auth.json` 继承 token，仍走 env/config credential 路径。
- 添加 chat-chain change fragment。

Closes #1602

## 复现 / 适用性

- 已在 latest `origin/main` 复现：default profile 有 `openai-codex` OAuth auth 时模型列表正常；clone profile 复制了 `config.yaml` 但没有 `auth.json`，`/api/hermes/available-models?profile=<clone>` 返回 `groups: []`。
- 修复后用临时 `HERMES_HOME` + 本地 Web UI server 重新验证：default 和 clone 都返回 `openai-codex` group，clone 的 `copiedAuthProviders` 为 `['openai-codex']`，无关 `anthropic` auth 未复制。

## 测试

- RED: `npm run test -- tests/server/profile-credentials.test.ts` 先失败，确认缺少 clone model-provider auth copy。
- `npm run test -- tests/server/profile-credentials.test.ts tests/server/profiles-routes.test.ts tests/server/model-visibility-controller.test.ts` — passed, 3 files / 50 tests.
- `npm run harness:check` — passed.
- `git diff --check` — passed.
- `npm run build` — passed.

## Review

- Independent review: PASS after fixing the first review blocker around `claude-oauth` needing the `anthropic` runtime alias.
