### PR TITLE
修复删除 profile 后 managed gateway 被重新拉起

### DIFF
--- a/packages/server/src/controllers/hermes/profiles.ts
+++ b/packages/server/src/controllers/hermes/profiles.ts
@@ -8,6 +8,7 @@ import { SessionDeleter } from '../../services/hermes/session-deleter'
 import { AgentBridgeClient } from '../../services/hermes/agent-bridge'
 import {
   getGatewayRuntimeStatusForProfile,
+  prepareGatewayForProfileDelete,
   restartGatewayForProfile as restartGatewayRuntimeForProfile,
 } from '../../services/hermes/gateway-autostart'
 import { logger } from '../../services/logger'
@@ -133,6 +134,12 @@ function deleteForbiddenProfileFromDisk(name: string): boolean {
   } catch {}
   logger.warn('[deleteProfile] removed reserved profile "%s" from disk after Hermes CLI rejected deletion', name)
   return true
+}
+
+function profileDirectoryExists(name: string): boolean {
+  if (!name || name === 'default') return true
+  const base = detectHermesRootHome()
+  return existsSync(join(base, 'profiles', name))
 }
 
 function filterVisibleProfiles(profiles: HermesProfile[]): HermesProfile[] {
@@ -647,10 +654,16 @@ export async function remove(ctx: any) {
     } catch (err) {
       logger.warn(err, '[profiles] failed to destroy bridge sessions for deleted profile "%s"', name)
     }
+
+    await prepareGatewayForProfileDelete(name)
+
     const ok = await hermesCli.deleteProfile(name)
-    if (ok) {
+    if (ok && !profileDirectoryExists(name)) {
       removeProfileMetadata(name)
       ctx.body = { success: true }
+    } else if (ok) {
+      ctx.status = 500
+      ctx.body = { error: 'Failed to delete profile: profile directory still exists' }
     } else if (deleteForbiddenProfileFromDisk(name)) {
       removeProfileMetadata(name)
       ctx.body = { success: true, fallback: 'removed_reserved_profile_from_disk' }

--- a/packages/server/src/services/hermes/gateway-autostart.ts
+++ b/packages/server/src/services/hermes/gateway-autostart.ts
@@ -1,11 +1,11 @@
 import { execFile } from 'child_process'
-import { existsSync, readFileSync, readdirSync, unlinkSync } from 'fs'
+import { existsSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { promisify } from 'util'
 import { readAppConfig, type GatewayAutoStartConfig } from '../app-config'
 import { logger } from '../logger'
 import { getProfileDir, listProfileNamesFromDisk } from './hermes-profile'
-import { startGatewayRunManaged } from './gateway-runner'
+import { retireManagedGatewayForProfile, startGatewayRunManaged } from './gateway-runner'
 import { parseGatewayStatusesFromProfileList } from './profile-list-parser'
 import { execHermesWithBin } from './hermes-process'
 
@@ -360,6 +360,51 @@ async function stopGatewayForProfile(hermesBin: string, profile: string, profile
     logger.info('[gateway-autostart] gateway stopped profile=%s home=%s', profile, profileDir)
   } catch (err) {
     logger.warn(err, '[gateway-autostart] Hermes CLI gateway stop failed before restart profile=%s home=%s', profile, profileDir)
+  }
+}
+
+function writeGatewayDesiredStopped(profileDir: string): void {
+  if (!existsSync(profileDir)) return
+  const statePath = join(profileDir, 'gateway_state.json')
+  try {
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        gateway_state: 'stopped',
+        desired_state: 'stopped',
+        updated_at: new Date().toISOString(),
+      }, null, 2),
+      'utf-8',
+    )
+  } catch (err) {
+    logger.warn(err, '[gateway-autostart] failed to mark gateway desired stopped before profile delete profileDir=%s', profileDir)
+  }
+}
+
+export async function prepareGatewayForProfileDelete(profile: string): Promise<void> {
+  const hermesBin = resolveHermesBin()
+  const profileDir = getProfileDir(profile)
+
+  writeGatewayDesiredStopped(profileDir)
+
+  try {
+    await retireManagedGatewayForProfile(profileDir, { timeoutMs: 2000 })
+  } catch (err) {
+    logger.warn(err, '[gateway-autostart] failed to retire managed gateway before profile delete profile=%s home=%s', profile, profileDir)
+  }
+
+  try {
+    await execHermesWithBin(hermesBin, ['gateway', 'stop'], {
+      timeout: 10000,
+      windowsHide: true,
+      env: {
+        ...process.env,
+        HERMES_HOME: profileDir,
+      },
+    })
+    logger.info('[gateway-autostart] gateway stopped before profile delete profile=%s home=%s', profile, profileDir)
+  } catch (err) {
+    logger.warn(err, '[gateway-autostart] Hermes gateway stop failed before profile delete profile=%s home=%s', profile, profileDir)
   }
 }
 

--- a/packages/server/src/services/hermes/gateway-autostart.ts
+++ b/packages/server/src/services/hermes/gateway-autostart.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import { promisify } from 'util'
 import { readAppConfig, type GatewayAutoStartConfig } from '../app-config'
 import { logger } from '../logger'
-import { getProfileDir, listProfileNamesFromDisk } from './hermes-profile'
+import { getHermesBaseDir, getProfileDir, listProfileNamesFromDisk } from './hermes-profile'
 import { retireManagedGatewayForProfile, startGatewayRunManaged } from './gateway-runner'
 import { parseGatewayStatusesFromProfileList } from './profile-list-parser'
 import { execHermesWithBin } from './hermes-process'
@@ -381,9 +381,19 @@ function writeGatewayDesiredStopped(profileDir: string): void {
   }
 }
 
+function getProfileDirForDelete(profile: string): string {
+  if (!profile || profile === 'default') return getProfileDir(profile)
+  return join(getHermesBaseDir(), 'profiles', profile)
+}
+
 export async function prepareGatewayForProfileDelete(profile: string): Promise<void> {
   const hermesBin = resolveHermesBin()
-  const profileDir = getProfileDir(profile)
+  const profileDir = getProfileDirForDelete(profile)
+
+  if (!existsSync(profileDir)) {
+    logger.info('[gateway-autostart] skipping profile delete gateway prep for missing profile profile=%s home=%s', profile, profileDir)
+    return
+  }
 
   writeGatewayDesiredStopped(profileDir)
 

--- a/packages/server/src/services/hermes/gateway-runner.ts
+++ b/packages/server/src/services/hermes/gateway-runner.ts
@@ -175,6 +175,44 @@ export async function shutdownManagedGateways(
   return { signaled, forced, errors }
 }
 
+export async function retireManagedGatewayForProfile(
+  profileDir: string,
+  opts: {
+    timeoutMs?: number
+    platform?: NodeJS.Platform
+    killWindowsProcessTree?: KillWindowsProcessTree
+  } = {},
+): Promise<ManagedGatewayShutdownResult> {
+  const state = profileState.get(profileDir)
+  if (!state) return { signaled: 0, forced: 0, errors: 0 }
+
+  clearRespawnTimer(state, profileDir)
+
+  const entry = state.current
+  state.current = null
+  profileState.delete(profileDir)
+
+  if (!entry) return { signaled: 0, forced: 0, errors: 0 }
+
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS
+  const platform = opts.platform ?? process.platform
+  const killWindowsProcessTree = opts.killWindowsProcessTree ?? taskkillWindowsProcessTree
+
+  logger.info('[gateway-runner] retiring managed gateway profileDir=%s pid=%s', profileDir, entry.pid)
+  const result = await stopManagedGateway(entry, { timeoutMs, platform, killWindowsProcessTree })
+  const forced = result.forced ? 1 : 0
+  const errors = result.error ? 1 : 0
+
+  logger.info(
+    '[gateway-runner] managed gateway retire complete profileDir=%s signaled=1 forced=%s errors=%s',
+    profileDir,
+    forced,
+    errors,
+  )
+
+  return { signaled: 1, forced, errors }
+}
+
 export function startGatewayRunManaged(
   hermesBin: string,
   opts: { profileDir?: string } = {},

--- a/tests/server/gateway-autostart.test.ts
+++ b/tests/server/gateway-autostart.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import {
@@ -7,6 +7,7 @@ import {
   gatewayStatusLooksRunning,
   gatewayStateLooksRunningForProfile,
   parseGatewayStatusesFromProfileListOutput,
+  prepareGatewayForProfileDelete,
   recoverWindowsDesktopGatewayOrphans,
   selectProfilesForGatewayAutostart,
   shouldRecoverWindowsDesktopGatewayOrphans,
@@ -201,6 +202,52 @@ describe('gateway autostart status parsing', () => {
       expect(gatewayStateLooksRunningForProfile(dir)).toBe(true)
     } finally {
       rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('prepares a profile delete by marking the gateway desired stopped', async () => {
+    const previousHermesHome = process.env.HERMES_HOME
+    const previousHermesBin = process.env.HERMES_BIN
+    const home = mkdtempSync(join(tmpdir(), 'wui-delete-gateway-'))
+    const profileDir = join(home, 'profiles', 'work')
+    mkdirSync(profileDir, { recursive: true })
+
+    try {
+      process.env.HERMES_HOME = home
+      process.env.HERMES_BIN = '/definitely/missing/hermes'
+
+      await prepareGatewayForProfileDelete('work')
+
+      expect(JSON.parse(readFileSync(join(profileDir, 'gateway_state.json'), 'utf-8'))).toMatchObject({
+        gateway_state: 'stopped',
+        desired_state: 'stopped',
+      })
+    } finally {
+      if (previousHermesHome === undefined) delete process.env.HERMES_HOME
+      else process.env.HERMES_HOME = previousHermesHome
+      if (previousHermesBin === undefined) delete process.env.HERMES_BIN
+      else process.env.HERMES_BIN = previousHermesBin
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it('does not fail profile deletion prep when the gateway is already stopped', async () => {
+    const previousHermesHome = process.env.HERMES_HOME
+    const previousHermesBin = process.env.HERMES_BIN
+    const home = mkdtempSync(join(tmpdir(), 'wui-delete-gateway-'))
+    mkdirSync(join(home, 'profiles', 'work'), { recursive: true })
+
+    try {
+      process.env.HERMES_HOME = home
+      process.env.HERMES_BIN = '/definitely/missing/hermes'
+
+      await expect(prepareGatewayForProfileDelete('work')).resolves.toBeUndefined()
+    } finally {
+      if (previousHermesHome === undefined) delete process.env.HERMES_HOME
+      else process.env.HERMES_HOME = previousHermesHome
+      if (previousHermesBin === undefined) delete process.env.HERMES_BIN
+      else process.env.HERMES_BIN = previousHermesBin
+      rmSync(home, { recursive: true, force: true })
     }
   })
 })

--- a/tests/server/gateway-autostart.test.ts
+++ b/tests/server/gateway-autostart.test.ts
@@ -250,4 +250,24 @@ describe('gateway autostart status parsing', () => {
       rmSync(home, { recursive: true, force: true })
     }
   })
+
+  it('does not fall back to the default profile when delete prep sees a missing profile', async () => {
+    const previousHermesHome = process.env.HERMES_HOME
+    const previousHermesBin = process.env.HERMES_BIN
+    const home = mkdtempSync(join(tmpdir(), 'wui-delete-gateway-missing-'))
+
+    try {
+      process.env.HERMES_HOME = home
+      process.env.HERMES_BIN = '/definitely/missing/hermes'
+
+      await expect(prepareGatewayForProfileDelete('missing')).resolves.toBeUndefined()
+      expect(existsSync(join(home, 'gateway_state.json'))).toBe(false)
+    } finally {
+      if (previousHermesHome === undefined) delete process.env.HERMES_HOME
+      else process.env.HERMES_HOME = previousHermesHome
+      if (previousHermesBin === undefined) delete process.env.HERMES_BIN
+      else process.env.HERMES_BIN = previousHermesBin
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
 })

--- a/tests/server/gateway-respawn.test.ts
+++ b/tests/server/gateway-respawn.test.ts
@@ -195,6 +195,26 @@ describe('gateway-runner supervision', () => {
     expect(fakeChildren).toHaveLength(2)
   })
 
+  it('retires one managed profile gateway without scheduling a respawn', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    const { retireManagedGatewayForProfile, startGatewayRunManaged } = await import(
+      '../../packages/server/src/services/hermes/gateway-runner'
+    )
+
+    startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/delete-me' })
+    expect(fakeChildren).toHaveLength(1)
+
+    const retired = retireManagedGatewayForProfile('/tmp/delete-me', { timeoutMs: 5000 })
+    expect(fakeChildren[0].killSignals).toEqual(['SIGTERM'])
+
+    fakeChildren[0].emit('exit', 0, 'SIGTERM')
+    await expect(retired).resolves.toEqual({ signaled: 1, forced: 0, errors: 0 })
+    await vi.advanceTimersByTimeAsync(6000)
+
+    expect(fakeChildren).toHaveLength(1)
+  })
+
   it('stops managed gateways on shutdown without respawning them', async () => {
     vi.useFakeTimers()
     vi.resetModules()

--- a/tests/server/profile-delete-managed-gateway.test.ts
+++ b/tests/server/profile-delete-managed-gateway.test.ts
@@ -1,0 +1,75 @@
+import { EventEmitter } from 'events'
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const originalEnv = { ...process.env }
+
+class FakeChild extends EventEmitter {
+  pid: number
+  killSignals: string[] = []
+
+  constructor(pid: number) {
+    super()
+    this.pid = pid
+  }
+
+  unref() { /* no-op */ }
+
+  kill(signal?: string) {
+    this.killSignals.push(signal || 'SIGTERM')
+    return true
+  }
+}
+
+let fakeChildren: FakeChild[] = []
+
+vi.mock('../../packages/server/src/services/hermes/hermes-process', () => ({
+  execHermesWithBin: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+  spawnHermesWithBin: vi.fn(() => {
+    const child = new FakeChild(20000 + fakeChildren.length)
+    fakeChildren.push(child)
+    return child
+  }),
+}))
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  vi.resetModules()
+  process.env = { ...originalEnv }
+  fakeChildren = []
+})
+
+describe('profile delete managed gateway lifecycle', () => {
+  it('reproduces #1633 and proves delete prep suppresses managed respawn', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    const home = await mkdtemp(join(tmpdir(), 'wui-1633-'))
+    process.env.HERMES_HOME = home
+    process.env.HERMES_BIN = '/usr/bin/hermes'
+    const profileDir = join(home, 'profiles', 'work')
+    await mkdir(profileDir, { recursive: true })
+    await writeFile(join(profileDir, 'config.yaml'), 'model:\n  default: test\n', 'utf-8')
+
+    try {
+      const { startGatewayRunManaged } = await import('../../packages/server/src/services/hermes/gateway-runner')
+      const { prepareGatewayForProfileDelete } = await import('../../packages/server/src/services/hermes/gateway-autostart')
+
+      startGatewayRunManaged('/usr/bin/hermes', { profileDir })
+      expect(fakeChildren).toHaveLength(1)
+
+      const prep = prepareGatewayForProfileDelete('work')
+      expect(fakeChildren[0].killSignals).toEqual(['SIGTERM'])
+
+      fakeChildren[0].emit('exit', 0, 'SIGTERM')
+      await prep
+      await vi.advanceTimersByTimeAsync(6000)
+
+      expect(fakeChildren).toHaveLength(1)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/server/profiles-routes.test.ts
+++ b/tests/server/profiles-routes.test.ts
@@ -18,6 +18,12 @@ const sessionDeleterMocks = vi.hoisted(() => ({
   switchProfile: vi.fn(),
 }))
 
+const gatewayAutostartMocks = vi.hoisted(() => ({
+  getGatewayRuntimeStatusForProfile: vi.fn(),
+  prepareGatewayForProfileDelete: vi.fn(),
+  restartGatewayForProfile: vi.fn(),
+}))
+
 // Mock hermes-cli
 vi.mock('../../packages/server/src/services/hermes/hermes-cli', () => ({
   listProfiles: vi.fn(),
@@ -55,6 +61,12 @@ vi.mock('../../packages/server/src/services/hermes/session-deleter', () => ({
   },
 }))
 
+vi.mock('../../packages/server/src/services/hermes/gateway-autostart', () => ({
+  getGatewayRuntimeStatusForProfile: gatewayAutostartMocks.getGatewayRuntimeStatusForProfile,
+  prepareGatewayForProfileDelete: gatewayAutostartMocks.prepareGatewayForProfileDelete,
+  restartGatewayForProfile: gatewayAutostartMocks.restartGatewayForProfile,
+}))
+
 import * as hermesCli from '../../packages/server/src/services/hermes/hermes-cli'
 
 describe('Profile Routes', () => {
@@ -65,6 +77,7 @@ describe('Profile Routes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     agentBridgeMocks.destroyProfile.mockResolvedValue({ destroyed: 0 })
+    gatewayAutostartMocks.prepareGatewayForProfileDelete.mockResolvedValue(undefined)
     skillInjectorMocks.injectMissingSkills.mockResolvedValue({ targets: [] })
     skillInjectorMocks.resolveTargetDirForProfile.mockImplementation((name: string) => join('/tmp/hermes-skills', name))
   })
@@ -140,6 +153,47 @@ describe('Profile Routes', () => {
   })
 
   describe('profile deletion fallback', () => {
+    it('prepares the profile gateway for deletion before calling Hermes CLI delete', async () => {
+      const hermesHome = await mkdtemp(join(tmpdir(), 'hermes-profile-delete-'))
+      tempHomes.push(hermesHome)
+      process.env.HERMES_HOME = hermesHome
+      const profileDir = join(hermesHome, 'profiles', 'work')
+      await mkdir(profileDir, { recursive: true })
+      await writeFile(join(profileDir, 'config.yaml'), 'model:\n  default: test\n', 'utf-8')
+
+      gatewayAutostartMocks.prepareGatewayForProfileDelete.mockImplementation(async () => {
+        await rm(profileDir, { recursive: true, force: true })
+      })
+      vi.mocked(hermesCli.deleteProfile).mockResolvedValue(true)
+      const { remove } = await import('../../packages/server/src/controllers/hermes/profiles')
+      const ctx: any = { params: { name: 'work' }, status: 200, body: undefined }
+
+      await remove(ctx)
+
+      expect(gatewayAutostartMocks.prepareGatewayForProfileDelete).toHaveBeenCalledWith('work')
+      expect(hermesCli.deleteProfile).toHaveBeenCalledWith('work')
+      expect(ctx.status).toBe(200)
+      expect(ctx.body).toEqual({ success: true })
+    })
+
+    it('does not return success when Hermes CLI reports delete success but the profile directory remains', async () => {
+      const hermesHome = await mkdtemp(join(tmpdir(), 'hermes-profile-delete-'))
+      tempHomes.push(hermesHome)
+      process.env.HERMES_HOME = hermesHome
+      const profileDir = join(hermesHome, 'profiles', 'work')
+      await mkdir(profileDir, { recursive: true })
+      await writeFile(join(profileDir, 'config.yaml'), 'model:\n  default: test\n', 'utf-8')
+      vi.mocked(hermesCli.deleteProfile).mockResolvedValue(true)
+      const { remove } = await import('../../packages/server/src/controllers/hermes/profiles')
+      const ctx: any = { params: { name: 'work' }, status: 200, body: undefined }
+
+      await remove(ctx)
+
+      expect(ctx.status).toBe(500)
+      expect(ctx.body).toEqual({ error: 'Failed to delete profile: profile directory still exists' })
+      expect(existsSync(profileDir)).toBe(true)
+    })
+
     it('removes a reserved profile directory when Hermes CLI refuses to delete it', async () => {
       const hermesHome = await mkdtemp(join(tmpdir(), 'hermes-profile-delete-'))
       tempHomes.push(hermesHome)


### PR DESCRIPTION
## 改动说明
- 删除 profile 前先 retire 对应的 managed gateway runner：清掉该 profile 的 pending respawn timer，并在停止 child 前移除 runner state，避免“删除是正常生命周期”被误判成 gateway 崩溃后自动重启。
- 删除准备阶段会在 profile 目录仍存在时写入 `gateway_state: stopped` / `desired_state: stopped`，并 best-effort 执行 `hermes gateway stop`。
- delete API 只有在确认 profile 目录已经消失后才返回 `{ success: true }`；如果 CLI 声称成功但目录仍在，会返回 500。
- 删除准备不再使用会 fallback 到 default home 的 `getProfileDir()`；缺失或并发消失的非 default profile 会直接跳过，避免误停 default gateway。

Fixes #1633.

## 验证
- `npx vitest run tests/server/gateway-respawn.test.ts tests/server/gateway-autostart.test.ts tests/server/profiles-routes.test.ts tests/server/profile-delete-managed-gateway.test.ts` — 43 passed
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run build`
- `npm run harness:check`
- `git diff --check origin/main...HEAD`

## UAT / 回归证明
- 新增 `tests/server/profile-delete-managed-gateway.test.ts`，覆盖核心链路：启动 managed profile gateway → 执行 delete prep → 模拟旧 child exit → 推进超过 respawn delay → 确认没有新 child 被 spawn。
- 新增 missing profile 回归：delete prep 遇到不存在的 profile 时不会 fallback 到 default Hermes home，也不会创建/修改 default 的 `gateway_state.json`。

## Review
- 独立 integration review 先发现 1 个 blocker：missing profile 时 delete prep 可能通过 `getProfileDir()` fallback 到 default home。
- 已修复为非 default profile 使用精确的 `<Hermes base>/profiles/<name>` 目标路径，并在目录不存在时提前返回。
- focused re-review 通过，未发现新 blocker。
