### PR TITLE
[codex] add fork message action

### DIFF
--- a/docs/chat-chain-changes/2026-06-18-fork-message-action.md
+++ b/docs/chat-chain-changes/2026-06-18-fork-message-action.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-18
+pr: TBD
+feature: Fork message action
+impact: The last message action row can submit /fork without showing a false thinking state, and duplicate fork submissions are suppressed until the terminal command event settles.
+---
+
+Validation: focused fork/session tests, harness check, and production build.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -179,6 +179,9 @@ async function handleSessionClick(sessionId: string) {
     name: chatStore.runtimeMode === "global_agent" ? "hermes.globalAgentSession" : "hermes.session",
     params: { sessionId },
   });
+  if (chatStore.activeSessionId !== sessionId) {
+    await chatStore.switchSession(sessionId);
+  }
   if (mobileQuery?.matches) showSessions.value = false;
 }
 

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -31,7 +31,7 @@ const JSON_MAX_KEYS_PER_OBJECT = 50;
 const JSON_MAX_ITEMS_PER_ARRAY = 50;
 const JSON_TRUNCATED_KEY = "__truncated__";
 
-const props = defineProps<{ message: Message; highlight?: boolean; headingIdPrefix?: string }>();
+const props = defineProps<{ message: Message; highlight?: boolean; headingIdPrefix?: string; showForkAction?: boolean }>();
 const { t } = useI18n();
 const toast = useMessage();
 
@@ -196,6 +196,11 @@ const copyableContent = computed(() => {
   if (!content.trim()) return null
   return content
 })
+
+function forkFromCurrentTail() {
+  if (!props.showForkAction || chatStore.isStreaming) return
+  chatStore.sendMessage('/fork')
+}
 
 async function copyBubbleContent() {
   const text = copyableContent.value
@@ -1036,6 +1041,20 @@ onBeforeUnmount(() => {
                 <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
               </svg>
             </button>
+            <button
+              v-if="showForkAction"
+              class="fork-bubble-btn"
+              @click="forkFromCurrentTail"
+              :title="t('chat.slashCommands.fork')"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="6" cy="5" r="2.25" />
+                <circle cx="18" cy="5" r="2.25" />
+                <circle cx="12" cy="19" r="2.25" />
+                <path d="M6 7.25v2.25a4 4 0 0 0 4 4h4a4 4 0 0 0 4-4V7.25" />
+                <path d="M12 13.5v3.25" />
+              </svg>
+            </button>
             <span class="message-time">{{ timeStr }}</span>
           </div>
         </div>
@@ -1450,7 +1469,8 @@ onBeforeUnmount(() => {
 }
 
 .copy-bubble-btn,
-.speech-bubble-btn {
+.speech-bubble-btn,
+.fork-bubble-btn {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -198,7 +198,7 @@ const copyableContent = computed(() => {
 })
 
 function forkFromCurrentTail() {
-  if (!props.showForkAction || chatStore.isStreaming) return
+  if (!props.showForkAction || chatStore.isStreaming || chatStore.isForkPending) return
   chatStore.sendMessage('/fork')
 }
 

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -164,6 +164,21 @@ const displayMessagesWithForkDivider = computed<Message[]>(() => {
   ];
 });
 
+const canForkActiveSession = computed(() => {
+  const session = chatStore.activeSession;
+  const hasConversation = displayMessages.value.some((message) => message.role === "user" || message.role === "assistant");
+  return !!session && session.source !== "coding_agent" && !chatStore.isStreaming && !chatStore.isForkPending && hasConversation;
+});
+
+const lastForkActionMessageId = computed(() => {
+  const messages = displayMessagesWithForkDivider.value;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role === "user" || message.role === "assistant") return message.id;
+  }
+  return null;
+});
+
 const queuedMessages = computed(() => {
   const sid = chatStore.activeSessionId;
   if (!sid) return [];
@@ -506,6 +521,7 @@ defineExpose({
           v-else
           :message="msg"
           :highlight="chatStore.focusMessageId === msg.id"
+          :show-fork-action="canForkActiveSession && msg.id === lastForkActionMessageId"
         />
       </template>
       <template #after>

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1401,6 +1401,10 @@ export const useChatStore = defineStore('chat', () => {
     if ((evt as any).started === true && (evt as any).terminal === false) {
       serverWorking.value.add(sid)
     }
+    if ((evt as any).terminal === true) {
+      streamStates.value.delete(sid)
+      serverWorking.value.delete(sid)
+    }
 
     if (action === 'clear' && command === 'clear') {
       if (target) target.messages = []
@@ -1896,6 +1900,8 @@ export const useChatStore = defineStore('chat', () => {
     const isBridgePlanCommand = isBridgeSlashCommand && /^\/plan(?:\s|$)/i.test(trimmedContent)
     const isBridgeSkillCommand = isBridgeSlashCommand && /^\/skill(?:\s|$)/i.test(trimmedContent)
     const isBridgeGoalCommand = isBridgeSlashCommand && /^\/goal(?:\s|$)/i.test(trimmedContent)
+    const isBridgeForkCommand = isBridgeSlashCommand && /^\/fork(?:\s|$)/i.test(trimmedContent)
+    const shouldOptimisticallyShowRunStatus = !isCodingAgentSession && !isBridgeForkCommand
     const wasLiveBeforeSend = isSessionLive(sid)
     const shouldQueue = wasLiveBeforeSend && (!isBridgeSlashCommand || isBridgePlanCommand || isBridgeSkillCommand)
 
@@ -1914,7 +1920,7 @@ export const useChatStore = defineStore('chat', () => {
     } else {
       addMessage(sid, userMsg)
       updateSessionTitle(sid)
-      if (!isCodingAgentSession) serverWorking.value.add(sid)
+      if (shouldOptimisticallyShowRunStatus) serverWorking.value.add(sid)
     }
 
     let runSubmitted = false

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -619,6 +619,8 @@ export const useChatStore = defineStore('chat', () => {
   const streamStates = ref<Map<string, { abort: () => void }>>(new Map())
   /** sessionId → server-reported isWorking status */
   const serverWorking = ref<Set<string>>(new Set())
+  /** sessionIds with a terminal /fork command submitted but not settled yet */
+  const pendingForkCommands = ref<Set<string>>(new Set())
   /** Sessions that completed while the user was viewing another session. */
   const completedUnreadSessions = ref<Set<string>>(new Set())
   const sessionProfileFilter = ref<string | null>(null)
@@ -650,6 +652,10 @@ export const useChatStore = defineStore('chat', () => {
     const sid = activeSessionId.value
     if (sid == null) return false
     return streamStates.value.has(sid) || serverWorking.value.has(sid)
+  })
+  const isForkPending = computed(() => {
+    const sid = activeSessionId.value
+    return sid != null && pendingForkCommands.value.has(sid)
   })
   const isLoadingSessions = ref(false)
   const sessionsLoaded = ref(false)
@@ -687,6 +693,7 @@ export const useChatStore = defineStore('chat', () => {
     pendingClarifies.value = new Map()
     streamStates.value = new Map()
     serverWorking.value = new Set()
+    pendingForkCommands.value = new Set()
     sessionsLoaded.value = false
     clearActiveSession()
   }
@@ -1404,6 +1411,7 @@ export const useChatStore = defineStore('chat', () => {
     if ((evt as any).terminal === true) {
       streamStates.value.delete(sid)
       serverWorking.value.delete(sid)
+      pendingForkCommands.value.delete(sid)
     }
 
     if (action === 'clear' && command === 'clear') {
@@ -1903,6 +1911,10 @@ export const useChatStore = defineStore('chat', () => {
     const isBridgeForkCommand = isBridgeSlashCommand && /^\/fork(?:\s|$)/i.test(trimmedContent)
     const shouldOptimisticallyShowRunStatus = !isCodingAgentSession && !isBridgeForkCommand
     const wasLiveBeforeSend = isSessionLive(sid)
+    if (isBridgeForkCommand) {
+      if (pendingForkCommands.value.has(sid)) return
+      pendingForkCommands.value = new Set(pendingForkCommands.value).add(sid)
+    }
     const shouldQueue = wasLiveBeforeSend && (!isBridgeSlashCommand || isBridgePlanCommand || isBridgeSkillCommand)
 
     const userMsg: Message = {
@@ -2702,6 +2714,11 @@ export const useChatStore = defineStore('chat', () => {
         streamStates.value.set(sid, ctrl)
       }
     } catch (err: any) {
+      if (isBridgeForkCommand) {
+        const nextPendingForkCommands = new Set(pendingForkCommands.value)
+        nextPendingForkCommands.delete(sid)
+        pendingForkCommands.value = nextPendingForkCommands
+      }
       if (shouldQueue && !runSubmitted) {
         dropQueuedUserMessage(sid, userMsg.id)
       }
@@ -3509,6 +3526,7 @@ export const useChatStore = defineStore('chat', () => {
     focusMessageId,
     messages,
     isStreaming,
+    isForkPending,
     isRunActive,
     isSessionLive,
     isSessionCompletedUnread,

--- a/tests/client/chat-panel-session-click.test.ts
+++ b/tests/client/chat-panel-session-click.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+
+describe('ChatPanel session clicks', () => {
+  it('switches the store when the route is already on the clicked session', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+
+    expect(source).toContain('if (chatStore.activeSessionId !== sessionId)')
+    expect(source).toContain('await chatStore.switchSession(sessionId)')
+  })
+})

--- a/tests/client/chat-store-session-command.test.ts
+++ b/tests/client/chat-store-session-command.test.ts
@@ -188,6 +188,39 @@ describe('chat store session.command fanout', () => {
     expect(store.isStreaming).toBe(false)
   })
 
+  it('debounces terminal fork commands until the session.command settles', async () => {
+    const store = useChatStore()
+    const session = makeSession()
+    session.source = 'cli'
+    session.messageCount = 2
+    session.messages = [
+      { id: 'user-1', role: 'user', content: 'Previous question', timestamp: 1 },
+      { id: 'assistant-1', role: 'assistant', content: 'Previous answer', timestamp: 2 },
+    ]
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    await store.sendMessage('/fork')
+    await store.sendMessage('/fork')
+
+    expect(chatApi.startRunViaSocket).toHaveBeenCalledTimes(1)
+    expect(store.isStreaming).toBe(false)
+    expect(store.isForkPending).toBe(true)
+
+    chatApi.sessionCommandHandlers[0]({
+      event: 'session.command',
+      session_id: 'session-1',
+      command: 'fork',
+      action: 'branch',
+      ok: false,
+      message: 'Cannot branch: no conversation messages found to copy.',
+      terminal: true,
+    })
+
+    expect(store.isForkPending).toBe(false)
+  })
+
   it('clears stale working state when terminal session commands complete', () => {
     const store = useChatStore()
     const session = makeSession()

--- a/tests/client/chat-store-session-command.test.ts
+++ b/tests/client/chat-store-session-command.test.ts
@@ -40,6 +40,7 @@ vi.mock('@/api/hermes/chat', () => ({
 
 vi.mock('@/api/client', () => ({
   getActiveProfileName: () => 'default',
+  hasApiKey: () => false,
 }))
 
 vi.mock('@/api/hermes/sessions', () => ({
@@ -76,6 +77,7 @@ describe('chat store session.command fanout', () => {
     chatApi.sessionCommandHandlers = []
     chatApi.peerUserMessageHandlers = []
     chatApi.sessionTitleUpdatedHandlers = []
+    chatApi.startRunViaSocket.mockReturnValue({ abort: vi.fn() })
     setActivePinia(createPinia())
   })
 
@@ -158,6 +160,62 @@ describe('chat store session.command fanout', () => {
 
     expect(store.sessions[0].title).toBe('Generated Title')
     expect(store.activeSession?.title).toBe('Generated Title')
+  })
+
+  it('does not show a thinking/streaming state while submitting terminal fork commands', async () => {
+    const store = useChatStore()
+    const session = makeSession()
+    session.source = 'cli'
+    session.messageCount = 2
+    session.messages = [
+      { id: 'user-1', role: 'user', content: 'Previous question', timestamp: 1 },
+      { id: 'assistant-1', role: 'assistant', content: 'Previous answer', timestamp: 2 },
+    ]
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    await store.sendMessage('/fork')
+
+    expect(chatApi.startRunViaSocket).toHaveBeenCalledWith(
+      expect.objectContaining({ input: '/fork', session_id: 'session-1', source: 'cli' }),
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function),
+      undefined,
+      expect.any(Object),
+    )
+    expect(store.isStreaming).toBe(false)
+  })
+
+  it('clears stale working state when terminal session commands complete', () => {
+    const store = useChatStore()
+    const session = makeSession()
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    chatApi.sessionCommandHandlers[0]({
+      event: 'session.command',
+      session_id: 'session-1',
+      command: 'goal',
+      action: 'resume',
+      message: 'Goal resumed',
+      started: true,
+      terminal: false,
+    })
+    expect(store.isStreaming).toBe(true)
+
+    chatApi.sessionCommandHandlers[0]({
+      event: 'session.command',
+      session_id: 'session-1',
+      command: 'goal',
+      action: 'done',
+      message: 'Goal done.',
+      terminal: true,
+    })
+
+    expect(store.isStreaming).toBe(false)
   })
 
   it('adds and switches to a branched child session from session.command branch events', async () => {


### PR DESCRIPTION
## Summary
- Extract the #1657 message-level fork action onto current `main` without the already-merged #1656 history.
- Add a guarded fork button on the latest visible user/assistant message and debounce repeated `/fork` submissions while the terminal command is pending.
- Fix the post-fork sidebar case where the old session could not be selected until refresh by explicitly switching the store after session-list navigation.

## Validation
- `npm run test -- tests/client/chat-panel-session-click.test.ts tests/client/chat-store-session-command.test.ts tests/server/session-command-branch.test.ts tests/server/session-store-branch.test.ts`
- `git diff --check`
