### PR TITLE
[codex] clear active profile on auth expiry

### DIFF
--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -1,6 +1,7 @@
 import router from '@/router'
 
 const DEFAULT_BASE_URL = ''
+const ACTIVE_PROFILE_STORAGE_KEY = 'hermes_active_profile_name'
 
 function isDesktopShell(): boolean {
   return typeof window !== 'undefined' &&
@@ -27,6 +28,11 @@ export function setApiKey(key: string) {
 
 export function clearApiKey() {
   localStorage.removeItem('hermes_api_key')
+}
+
+function clearAuthSessionState() {
+  clearApiKey()
+  localStorage.removeItem(ACTIVE_PROFILE_STORAGE_KEY)
 }
 
 export function hasApiKey(): boolean {
@@ -68,7 +74,7 @@ export function getStoredUsername(): string | null {
 }
 
 export function getActiveProfileName(): string | null {
-  return localStorage.getItem('hermes_active_profile_name')
+  return localStorage.getItem(ACTIVE_PROFILE_STORAGE_KEY)
 }
 
 function bodyHasProfileSelector(body: BodyInit | null | undefined): boolean {
@@ -169,7 +175,7 @@ export async function request<T>(path: string, options: RequestInit = {}): Promi
     !path.startsWith('/v1/')
 
   if (res.status === 401 && isLocalBff) {
-    clearApiKey()
+    clearAuthSessionState()
     emitAuthNotice('expired')
     if (router.currentRoute.value.name !== 'login') {
       router.replace({ name: 'login' })
@@ -181,7 +187,7 @@ export async function request<T>(path: string, options: RequestInit = {}): Promi
     const text = await res.text().catch(() => '')
     if (res.status === 403 && isLocalBff) {
       if (text.includes('User is disabled or does not exist')) {
-        clearApiKey()
+        clearAuthSessionState()
         emitAuthNotice('expired')
         if (router.currentRoute.value.name !== 'login') {
           router.replace({ name: 'login' })

--- a/tests/client/api.test.ts
+++ b/tests/client/api.test.ts
@@ -108,27 +108,32 @@ describe('API Client', () => {
 
     it('clears token and redirects on 401 for local BFF endpoints', async () => {
       setApiKey('secret-key')
+      localStorage.setItem('hermes_active_profile_name', 'research')
       mockFetch.mockResolvedValue({ ok: false, status: 401 })
 
       await expect(request('/api/hermes/sessions')).rejects.toThrow('Unauthorized')
       expect(hasApiKey()).toBe(false)
+      expect(localStorage.getItem('hermes_active_profile_name')).toBeNull()
       expect(router.replace).toHaveBeenCalledWith({ name: 'login' })
     })
 
     it('emits a global auth notice on local 403 responses', async () => {
       const listener = vi.fn()
       window.addEventListener('hermes-auth-notice', listener)
+      localStorage.setItem('hermes_active_profile_name', 'research')
       mockFetch.mockResolvedValue({ ok: false, status: 403, text: () => Promise.resolve('Forbidden') })
 
       await expect(request('/api/hermes/profiles')).rejects.toThrow('API Error 403')
 
       expect(listener).toHaveBeenCalledOnce()
       expect(listener.mock.calls[0][0].detail).toEqual({ kind: 'forbidden' })
+      expect(localStorage.getItem('hermes_active_profile_name')).toBe('research')
       window.removeEventListener('hermes-auth-notice', listener)
     })
 
     it('clears token and redirects when the JWT user no longer exists', async () => {
       setApiKey('stale-jwt')
+      localStorage.setItem('hermes_active_profile_name', 'research')
       mockFetch.mockResolvedValue({
         ok: false,
         status: 403,
@@ -138,15 +143,18 @@ describe('API Client', () => {
       await expect(request('/api/hermes/profiles')).rejects.toThrow('API Error 403')
 
       expect(hasApiKey()).toBe(false)
+      expect(localStorage.getItem('hermes_active_profile_name')).toBeNull()
       expect(router.replace).toHaveBeenCalledWith({ name: 'login' })
     })
 
     it('does NOT clear token on 401 for proxied v1 endpoints', async () => {
       setApiKey('secret-key')
+      localStorage.setItem('hermes_active_profile_name', 'research')
       mockFetch.mockResolvedValue({ ok: false, status: 401, text: () => Promise.resolve('') })
 
       await expect(request('/api/hermes/v1/runs')).rejects.toThrow('API Error 401')
       expect(hasApiKey()).toBe(true)
+      expect(localStorage.getItem('hermes_active_profile_name')).toBe('research')
     })
 
     it('throws error on non-401 failure', async () => {


### PR DESCRIPTION
## Summary
- Clear the cached active profile when a local BFF auth session expires.
- Reuse the same auth-session cleanup for disabled/deleted-user responses.
- Keep ordinary 403 profile access denials and proxied v1 401s from clearing profile state.

## Why
A stale `hermes_active_profile_name` can survive a token-expiry redirect to login. After the user logs in again, uploads may still send the old `X-Hermes-Profile` header and get rejected with profile access errors.

## Validation
- `npm run test -- tests/client/api.test.ts`
- `git diff --check`
- `npm run harness:check`
- `npm run build`
