### PR TITLE
[codex] add hermes studio command namespaces

### DIFF
--- a/packages/desktop/src/main/cli-shim.ts
+++ b/packages/desktop/src/main/cli-shim.ts
@@ -32,8 +32,10 @@ interface CliShimInstallOptions {
   env?: NodeJS.ProcessEnv
   executablePath?: string
   homeDir?: string
+  nodePath?: string
   platform?: NodeJS.Platform
   runtimeVersion?: string
+  webUiScriptPath?: string
 }
 
 interface McpShimInstallOptions extends CliShimInstallOptions {
@@ -87,6 +89,8 @@ export function createShimContent(
   platform: NodeJS.Platform = process.platform,
   archName: string = process.arch,
   runtimeVersion = '0.15.2',
+  nodePath = process.execPath,
+  webUiScriptPath = resolve(process.cwd(), 'bin', 'hermes-web-ui.mjs'),
 ): string {
   if (platform === 'win32') {
     const runtimePlatform = windowsRuntimePlatformKey(archName)
@@ -94,6 +98,12 @@ export function createShimContent(
       '@echo off',
       `rem ${SHIM_MARKER}`,
       `set "APP=${executablePath}"`,
+      `set "NODE=${nodePath}"`,
+      `set "WEBUI_SCRIPT=${webUiScriptPath}"`,
+      'if "%~1"=="" goto openApp',
+      'if /I "%~1"=="help" goto help',
+      'if /I "%~1"=="-h" goto help',
+      'if /I "%~1"=="--help" goto help',
       'set "WEBUI_HOME=%HERMES_WEB_UI_HOME%"',
       'if "%WEBUI_HOME%"=="" set "WEBUI_HOME=%HERMES_WEBUI_STATE_DIR%"',
       'if "%WEBUI_HOME%"=="" set "WEBUI_HOME=%USERPROFILE%\\.hermes-web-ui"',
@@ -103,13 +113,45 @@ export function createShimContent(
       ')',
       `if "%RUNTIME%"=="" set "RUNTIME=%WEBUI_HOME%\\desktop-runtime\\hermes\\${runtimeVersion}\\${runtimePlatform}"`,
       'set "PYTHON=%RUNTIME%\\python\\python.exe"',
-      'if not exist "%PYTHON%" (',
-      '  echo Hermes Studio Python runtime not found at "%PYTHON%" 1>&2',
-      '  echo Open Hermes Studio once to finish runtime setup, then retry hermes-studio. 1>&2',
-      '  exit /b 127',
+      'if /I "%~1"=="cli" (',
+      '  if not exist "%PYTHON%" (',
+      '    echo Hermes Studio Python runtime not found at "%PYTHON%" 1>&2',
+      '    echo Open Hermes Studio once to finish runtime setup, then retry hermes-studio cli. 1>&2',
+      '    exit /b 127',
+      '  )',
+      '  shift',
+      '  "%PYTHON%" -m hermes_cli.main %*',
+      '  exit /b %ERRORLEVEL%',
       ')',
-      '"%PYTHON%" -m hermes_cli.main %*',
-      'exit /b %ERRORLEVEL%',
+      'if /I "%~1"=="web" (',
+      '  if not exist "%NODE%" (',
+      '    echo Hermes Studio Node runtime not found at "%NODE%" 1>&2',
+      '    echo Open Hermes Studio once to finish runtime setup, then retry hermes-studio web. 1>&2',
+      '    exit /b 127',
+      '  )',
+      '  if not exist "%WEBUI_SCRIPT%" (',
+      '    echo Hermes Web UI script not found at "%WEBUI_SCRIPT%" 1>&2',
+      '    exit /b 127',
+      '  )',
+      '  shift',
+      '  "%NODE%" "%WEBUI_SCRIPT%" %*',
+      '  exit /b %ERRORLEVEL%',
+      ')',
+      'echo Unknown Hermes Studio command: %~1 1>&2',
+      'echo Run hermes-studio --help for usage. 1>&2',
+      'exit /b 2',
+      ':openApp',
+      'start "" "%APP%"',
+      'exit /b 0',
+      ':help',
+      'echo Usage: hermes-studio [command] [options]',
+      'echo.',
+      'echo Commands:',
+      'echo   ^(no command^)       Open Hermes Studio desktop app',
+      'echo   cli [args...]       Run bundled Hermes Agent CLI',
+      'echo   web [args...]       Run bundled hermes-web-ui command',
+      'echo   help, -h, --help    Show this help message',
+      'exit /b 0',
       '',
     ].join('\r\n')
   }
@@ -118,12 +160,55 @@ export function createShimContent(
     '#!/bin/sh',
     `# ${SHIM_MARKER}`,
     `APP=${shellQuote(executablePath)}`,
+    `NODE=${shellQuote(nodePath)}`,
+    `WEBUI_SCRIPT=${shellQuote(webUiScriptPath)}`,
+    'show_help() {',
+    '  cat <<\'EOF\'',
+    'Usage: hermes-studio [command] [options]',
+    '',
+    'Commands:',
+    '  (no command)       Open Hermes Studio desktop app',
+    '  cli [args...]      Run bundled Hermes Agent CLI',
+    '  web [args...]      Run bundled hermes-web-ui command',
+    '  help, -h, --help   Show this help message',
+    'EOF',
+    '}',
     'if [ ! -x "$APP" ]; then',
     '  echo "Hermes Studio executable not found at $APP" >&2',
     '  exit 127',
     'fi',
     'unset ELECTRON_RUN_AS_NODE',
-    `exec "$APP" -- ${HERMES_CLI_ARG} "$@"`,
+    'case "${1:-}" in',
+    '  "")',
+    '    exec "$APP"',
+    '    ;;',
+    '  cli)',
+    '    shift',
+    `    exec "$APP" -- ${HERMES_CLI_ARG} "$@"`,
+    '    ;;',
+    '  web)',
+    '    shift',
+    '    if [ ! -x "$NODE" ]; then',
+    '      echo "Hermes Studio Node runtime not found at $NODE" >&2',
+    '      echo "Open Hermes Studio once to finish runtime setup, then retry hermes-studio web." >&2',
+    '      exit 127',
+    '    fi',
+    '    if [ ! -f "$WEBUI_SCRIPT" ]; then',
+    '      echo "Hermes Web UI script not found at $WEBUI_SCRIPT" >&2',
+    '      exit 127',
+    '    fi',
+    '    exec "$NODE" "$WEBUI_SCRIPT" "$@"',
+    '    ;;',
+    '  help|-h|--help)',
+    '    show_help',
+    '    exit 0',
+    '    ;;',
+    '  *)',
+    '    echo "Unknown Hermes Studio command: $1" >&2',
+    '    echo "Run hermes-studio --help for usage." >&2',
+    '    exit 2',
+    '    ;;',
+    'esac',
     '',
   ].join('\n')
 }
@@ -311,7 +396,14 @@ export async function installHermesStudioCliShim(options: CliShimInstallOptions 
   const shimPath = shimPathForPlatform(binDir, platform)
 
   mkdirSync(binDir, { recursive: true })
-  const status = writeShim(shimPath, createShimContent(executablePath, platform, process.arch, options.runtimeVersion), platform)
+  const status = writeShim(shimPath, createShimContent(
+    executablePath,
+    platform,
+    process.arch,
+    options.runtimeVersion,
+    options.nodePath,
+    options.webUiScriptPath,
+  ), platform)
   const pathUpdated = await ensureUserBinOnPath(homeDir, binDir, platform, env).catch((err) => {
     console.warn(`[cli-shim] failed to update PATH: ${err instanceof Error ? err.message : String(err)}`)
     return false

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -578,7 +578,11 @@ function runDesktopApp() {
     // default is fine there.
     if (process.platform !== 'darwin') Menu.setApplicationMenu(null)
     if (app.isPackaged) {
-      installHermesStudioCliShim({ runtimeVersion: desktopRuntimeVersion() }).then(result => {
+      installHermesStudioCliShim({
+        nodePath: bundledNode(),
+        runtimeVersion: desktopRuntimeVersion(),
+        webUiScriptPath: join(webuiDir(), 'bin', 'hermes-web-ui.mjs'),
+      }).then(result => {
         if (result.status === 'skipped') {
           console.warn(`[cli-shim] ${result.reason}: ${result.shimPath}`)
         }

--- a/tests/desktop/cli-shim.test.ts
+++ b/tests/desktop/cli-shim.test.ts
@@ -26,28 +26,53 @@ function tempHome(): string {
 }
 
 describe('Hermes Studio CLI shim', () => {
-  it('quotes Unix app paths and forwards args through --hermes-cli', () => {
-    const content = createShimContent("/Applications/Hermes Studio's.app/Contents/MacOS/Hermes Studio", 'darwin')
+  it('quotes Unix app paths and routes app, cli, web, and help commands', () => {
+    const content = createShimContent(
+      "/Applications/Hermes Studio's.app/Contents/MacOS/Hermes Studio",
+      'darwin',
+      'arm64',
+      '0.15.2',
+      '/runtime/node/bin/node',
+      '/resources/webui/bin/hermes-web-ui.mjs',
+    )
 
     expect(content).toContain("--hermes-cli")
     expect(content).toContain("APP='/Applications/Hermes Studio'\\''s.app/Contents/MacOS/Hermes Studio'")
+    expect(content).toContain("NODE='/runtime/node/bin/node'")
+    expect(content).toContain("WEBUI_SCRIPT='/resources/webui/bin/hermes-web-ui.mjs'")
     expect(content).toContain('unset ELECTRON_RUN_AS_NODE')
+    expect(content).toContain('case "${1:-}" in')
+    expect(content).toContain('exec "$APP"')
+    expect(content).toContain('shift')
     expect(content).toContain('exec "$APP" -- --hermes-cli "$@"')
+    expect(content).toContain('exec "$NODE" "$WEBUI_SCRIPT" "$@"')
+    expect(content).toContain('Usage: hermes-studio [command] [options]')
   })
 
-  it('runs the bundled Python Hermes CLI directly in Windows shims', () => {
+  it('routes Windows cli and web subcommands through bundled runtime paths', () => {
     const content = createShimContent(
       'C:\\Users\\Example\\AppData\\Local\\Programs\\Hermes Studio\\Hermes Studio.exe',
       'win32',
       'x64',
+      '0.15.2',
+      'C:\\runtime\\node\\node.exe',
+      'C:\\resources\\webui\\bin\\hermes-web-ui.mjs',
     )
 
     expect(content).toContain('desktop-runtime\\hermes\\0.15.2\\win-x64')
     expect(content).toContain('desktop-runtime\\active-version.json')
     expect(content).toContain("$j.platform -eq 'win-x64'")
     expect(content).toContain('[Console]::Out.Write($j.runtimeDirectory)')
+    expect(content).toContain('set "NODE=C:\\runtime\\node\\node.exe"')
+    expect(content).toContain('set "WEBUI_SCRIPT=C:\\resources\\webui\\bin\\hermes-web-ui.mjs"')
     expect(content).toContain('set "PYTHON=%RUNTIME%\\python\\python.exe"')
+    expect(content).toContain('if /I "%~1"=="cli" (')
+    expect(content).toContain('shift')
     expect(content).toContain('"%PYTHON%" -m hermes_cli.main %*')
+    expect(content).toContain('if /I "%~1"=="web" (')
+    expect(content).toContain('"%NODE%" "%WEBUI_SCRIPT%" %*')
+    expect(content).toContain('start "" "%APP%"')
+    expect(content).toContain('echo Usage: hermes-studio [command] [options]')
     expect(content).not.toContain('"%APP%" -- --hermes-cli')
   })
 
@@ -80,13 +105,16 @@ describe('Hermes Studio CLI shim', () => {
       homeDir,
       platform: 'darwin',
       executablePath: '/Applications/Hermes Studio.app/Contents/MacOS/Hermes Studio',
+      nodePath: '/runtime/node/bin/node',
+      webUiScriptPath: '/resources/webui/bin/hermes-web-ui.mjs',
       env: { PATH: '/usr/bin', SHELL: '/bin/zsh' },
     })
 
     expect(result.status).toBe('installed')
     expect(result.pathUpdated).toBe(true)
     expect(result.shimPath).toBe(shimPathForPlatform(join(homeDir, 'bin'), 'darwin'))
-    expect(readFileSync(result.shimPath, 'utf-8')).toContain('exec "$APP" -- --hermes-cli "$@"')
+    expect(readFileSync(result.shimPath, 'utf-8')).toContain("NODE='/runtime/node/bin/node'")
+    expect(readFileSync(result.shimPath, 'utf-8')).toContain("WEBUI_SCRIPT='/resources/webui/bin/hermes-web-ui.mjs'")
     expect(readFileSync(join(homeDir, '.zprofile'), 'utf-8')).toContain('export PATH="$HOME/bin:$PATH"')
   })
 })


### PR DESCRIPTION
## Summary
- Add explicit `hermes-studio cli ...` and `hermes-studio web ...` command namespaces to the desktop shim.
- Keep bare `hermes-studio` opening the desktop app and add wrapper help for `help`, `-h`, and `--help`.
- Pass the bundled Node runtime and packaged `hermes-web-ui` script into the shim so `web` commands run against the desktop runtime paths.

## Validation
- `npm run test -- tests/desktop/cli-shim.test.ts tests/desktop/hermes-cli-invocation.test.ts`
- `npm run harness:check`
- `npm run build`
- `git diff --check`
