### PR TITLE
[codex] document desktop command shims

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,20 @@ runtime and stores Hermes Agent data in the native Hermes location:
 The desktop wrapper stores its own Web UI state separately in
 `~/.hermes-web-ui` unless `HERMES_WEB_UI_HOME` is set.
 
+After the packaged desktop app starts, it installs managed command shims so the
+desktop app, bundled Hermes Agent CLI, and bundled Web UI CLI do not conflict:
+
+| Command | Description |
+| --- | --- |
+| `hermes-studio` | Open the Hermes Studio desktop app |
+| `hermes-studio cli ...` | Run the bundled Hermes Agent CLI |
+| `hermes-studio web ...` | Run the bundled `hermes-web-ui` command |
+| `hermes-studio -h` | Show wrapper help |
+| `hermes-studio-mcp` | Run the managed Web UI MCP bridge |
+
+Use `hermes-studio cli -h` for Hermes Agent CLI help and
+`hermes-studio web -h` for Web UI CLI help.
+
 Desktop auto-updates read the latest feed from
 `https://download.ekkolearnai.com/latest` first. If that endpoint is
 unavailable, the updater falls back to

--- a/README_zh.md
+++ b/README_zh.md
@@ -240,6 +240,20 @@ hermes-web-ui reset-default-login
 桌面壳自身的 Web UI 状态会单独保存到 `~/.hermes-web-ui`，除非设置了
 `HERMES_WEB_UI_HOME`。
 
+打包后的桌面应用启动后，会安装受管命令 shim，避免桌面应用、内置 Hermes Agent CLI
+和内置 Web UI CLI 的命令互相冲突：
+
+| 命令 | 说明 |
+|---|---|
+| `hermes-studio` | 打开 Hermes Studio 桌面应用 |
+| `hermes-studio cli ...` | 运行内置 Hermes Agent CLI |
+| `hermes-studio web ...` | 运行内置 `hermes-web-ui` 命令 |
+| `hermes-studio -h` | 显示 wrapper 帮助 |
+| `hermes-studio-mcp` | 运行受管 Web UI MCP bridge |
+
+使用 `hermes-studio cli -h` 查看 Hermes Agent CLI 帮助，使用
+`hermes-studio web -h` 查看 Web UI CLI 帮助。
+
 桌面自动更新会优先读取 `https://download.ekkolearnai.com/latest`。
 如果该端点不可用，更新器会回退到
 `https://github.com/EKKOLearnAI/hermes-studio/releases/latest/download`。

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -11,6 +11,21 @@ architecture from the project
 The desktop app bundles the Web UI runtime and launches it locally from the
 native shell app.
 
+## Command shims
+
+After the packaged desktop app starts, it installs managed command shims:
+
+| Command | Description |
+| --- | --- |
+| `hermes-studio` | Open the Hermes Studio desktop app |
+| `hermes-studio cli ...` | Run the bundled Hermes Agent CLI |
+| `hermes-studio web ...` | Run the bundled `hermes-web-ui` command |
+| `hermes-studio -h` | Show wrapper help |
+| `hermes-studio-mcp` | Run the managed Web UI MCP bridge |
+
+Use `hermes-studio cli -h` for Hermes Agent CLI help and
+`hermes-studio web -h` for Web UI CLI help.
+
 ## Data directories
 
 Hermes Agent data is stored in the same platform-specific location as native


### PR DESCRIPTION
## Summary

- Document the packaged desktop `hermes-studio` command shim behavior in the English README.
- Add the same command split documentation to the Chinese README.
- Add a desktop package README section for `hermes-studio`, `hermes-studio cli`, `hermes-studio web`, and `hermes-studio-mcp`.

## Why

The desktop wrapper now separates the bare desktop app command from bundled Hermes Agent CLI and bundled Web UI CLI entry points. The docs need to explain which command users should run for each path.

## Validation

- `git diff --cached --check`