### PR TITLE
fix(group-chat): separate UI history from model context

### DIFF
--- a/docs/chat-chain-changes/2026-06-18-pending-group-chat-context-cursors.md
+++ b/docs/chat-chain-changes/2026-06-18-pending-group-chat-context-cursors.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-18
+pr: pending
+feature: Group Chat context and mention-routing hardening
+impact: Group Chat now keeps UI pagination separate from agent context history, uses message-id cursors for same-timestamp replies and snapshot rebuilds, clears in-flight agent runs safely, and hardens agent-to-agent mention routing so only explicit leading addresses fan out by default.
+---
+
+This change bundle covers the full WUI group-chat context/routing hardening work rather than only the cursor fix: stable canonical ordering for assistant/tool multipart runs, full-retained-history context windows and token estimates, safe clear-context generation resets, snapshot-tail fallback behavior, and the new agent-authored leading-address routing default with a lightweight env rollback gate (`HERMES_GROUP_CHAT_AGENT_LEADING_ADDRESS_ROUTING=0`) if operators need to temporarily revert agent mention parsing behavior during rollout.

--- a/packages/server/src/routes/hermes/group-chat.ts
+++ b/packages/server/src/routes/hermes/group-chat.ts
@@ -184,7 +184,7 @@ groupChatRoutes.get('/api/hermes/group-chat/rooms/:roomId', async (ctx) => {
 
     const offset = ctx.query.offset ? Math.max(0, parseInt(ctx.query.offset as string, 10) || 0) : 0
     const limit = ctx.query.limit ? Math.max(1, parseInt(ctx.query.limit as string, 10) || 150) : 150
-    const messages = chatServer.getStorage().getMessages(ctx.params.roomId, limit, offset)
+    const messages = chatServer.getStorage().getRecentMessagesForUI(ctx.params.roomId, limit, offset)
     const total = chatServer.getStorage().getMessageCount(ctx.params.roomId)
     const agents = chatServer.getStorage().getRoomAgents(ctx.params.roomId)
     const members = chatServer.getStorage().getRoomMembers(ctx.params.roomId)

--- a/packages/server/src/services/hermes/context-engine/compressor.ts
+++ b/packages/server/src/services/hermes/context-engine/compressor.ts
@@ -11,6 +11,8 @@ import { DEFAULT_COMPRESSION_CONFIG } from './types'
 import { GatewaySummarizer } from './gateway-client'
 import { buildAgentInstructions, buildSummarizationSystemPrompt } from './prompt'
 import { logger } from '../../../services/logger'
+import { buildProjectedGroupChatHistory, projectGroupChatMessage } from '../group-chat/context-projection'
+import { sliceGroupMessagesForSnapshotTail } from '../group-chat/group-message-ordering'
 
 export class ContextEngine {
     private config: CompressionConfig
@@ -74,12 +76,18 @@ export class ContextEngine {
 
     private async _buildContextImpl(input: BuildContextInput): Promise<CompressedContext> {
         const config = { ...this.config, ...input.compression }
-        const allMessages = this.messageFetcher.getMessages(input.roomId)
-        // Filter out messages newer than the current one
-        const messages = allMessages.filter(m => m.timestamp <= input.currentMessage.timestamp)
+        const messages = this.messageFetcher.getMessagesForContext(input.roomId, {
+            throughMessageId: input.currentMessage.id,
+        })
         const total = messages.length
 
-        logger.debug(`[ContextEngine] buildContext START — room=${input.roomId}, agent=${input.agentName}, totalMessagesInDb=${allMessages.length}, afterFilter=${total}`)
+        logger.debug({
+            roomId: input.roomId,
+            agentName: input.agentName,
+            profile: input.profile || 'default',
+            retainedMessages: total,
+            throughMessageId: input.currentMessage.id,
+        }, '[ContextEngine] buildContext start')
 
         const instructions = buildAgentInstructions({
             agentName: input.agentName,
@@ -98,7 +106,15 @@ export class ContextEngine {
         }
 
         const snapshot = this.messageFetcher.getContextSnapshot(input.roomId)
-        logger.debug(`[ContextEngine] snapshot=${snapshot ? `EXISTS (lastMsgId=${snapshot.lastMessageId}, summaryLen=${snapshot.summary.length})` : 'NONE'}`)
+        logger.debug({
+            roomId: input.roomId,
+            agentName: input.agentName,
+            path: snapshot ? 'snapshot' : 'full',
+            snapshot: snapshot ? 'hit' : 'miss',
+            lastMessageId: snapshot?.lastMessageId,
+            summaryChars: snapshot?.summary.length || 0,
+            messageCount: total,
+        }, '[ContextEngine] snapshot lookup')
 
         const estimateFullContextTokens = async (
             history: Array<{ role: 'user' | 'assistant'; content: string }>,
@@ -135,12 +151,20 @@ export class ContextEngine {
         if (snapshot) {
             meta.hadSnapshot = true
 
-            // Find the position of lastMessageId in messages
-            const snapshotIdx = messages.findIndex(m => m.id === snapshot.lastMessageId)
-            // Collect messages after the snapshot position
-            const newMessages = snapshotIdx >= 0
-                ? messages.slice(snapshotIdx + 1)
-                : messages.filter(m => m.timestamp > snapshot.lastMessageTimestamp)
+            const snapshotTail = sliceGroupMessagesForSnapshotTail(messages, snapshot.lastMessageId)
+            const newMessages = snapshotTail.messages
+
+            if (!snapshotTail.snapshotCursorFound) {
+                logger.warn({
+                    roomId: input.roomId,
+                    agentName: input.agentName,
+                    path: 'snapshot',
+                    reason: 'snapshot_cursor_missing',
+                    lastMessageId: snapshot.lastMessageId,
+                    messageCount: newMessages.length,
+                    preservedTailCount: newMessages.length,
+                }, '[ContextEngine] snapshot cursor missing')
+            }
 
             const summaryTokens = this.countTokens(snapshot.summary)
             const newTokens = this.estimateTokensFromMessages(newMessages)
@@ -149,19 +173,38 @@ export class ContextEngine {
             meta.verbatimCount = newMessages.length
             meta.summaryTokenEstimate = summaryTokens
 
-            const snapshotHistory = this.buildHistory(snapshot.summary, newMessages, input.agentSocketId, input.agentName)
+            const snapshotHistory = this.buildHistory(snapshot.summary, newMessages, input.agentId, input.agentSocketId, input.agentName)
             const totalTokens = await estimateFullContextTokens(snapshotHistory, messageOnlyTokens)
             logThresholdCheck('snapshot', messageOnlyTokens, totalTokens)
+            logger.debug({
+                roomId: input.roomId,
+                agentName: input.agentName,
+                path: 'snapshot',
+                snapshotCursorFound: snapshotTail.snapshotCursorFound,
+                lastMessageId: snapshot.lastMessageId,
+                messageCount: newMessages.length,
+                summaryTokenEstimate: summaryTokens,
+                messageTailTokenEstimate: newTokens,
+                messageOnlyTokens,
+                fullContextTokens: totalTokens,
+                triggerTokens: config.triggerTokens,
+                preservedTailCount: newMessages.length,
+                decision: totalTokens <= config.triggerTokens ? 'reuse_summary' : 'incremental_compress',
+            }, '[ContextEngine] snapshot path evaluated')
 
-            logger.debug(`[ContextEngine] [Path A] snapshotIdx=${snapshotIdx}, newMessages=${newMessages.length}, summaryTokens=~${summaryTokens}, newTokens=~${newTokens}, totalTokens=~${totalTokens}, threshold=${config.triggerTokens}`)
-            logger.debug(`[ContextEngine] [Path A] EXISTING SUMMARY (${snapshot.summary.length} chars): ${snapshot.summary.slice(0, 300)}`)
-            if (newMessages.length > 0) {
-                logger.debug(`[ContextEngine] [Path A] NEW MESSAGES (${newMessages.length}): ${newMessages.map(m => `[${m.senderName}]: ${m.content.slice(0, 80)}`).join(' | ')}`)
-            }
-
-            // Under threshold — return summary + new messages directly
+            // Under threshold — return summary + new messages directly.
+            // If the cursor anchor was pruned, the retained transcript is our conservative
+            // verbatim tail after the still-valid summary.
             if (totalTokens <= config.triggerTokens) {
-                logger.debug(`[ContextEngine] [Path A] UNDER threshold — return summary + ${newMessages.length} verbatim msgs directly`)
+                logger.debug({
+                    roomId: input.roomId,
+                    agentName: input.agentName,
+                    path: 'snapshot',
+                    messageCount: newMessages.length,
+                    fullContextTokens: totalTokens,
+                    preservedTailCount: newMessages.length,
+                    decision: 'skip_compression',
+                }, '[ContextEngine] using snapshot summary with verbatim tail')
                 this.logHistory('Path A (no compress)', snapshotHistory)
                 return { conversationHistory: snapshotHistory, instructions, meta }
             }
@@ -172,8 +215,19 @@ export class ContextEngine {
                     `Context window is too small for group chat agent ${input.agentName}: fixed prompt/tool overhead plus ${newMessages.length} new messages uses ~${totalTokens} tokens, exceeding trigger ${config.triggerTokens}, and there is not enough history to compress.`,
                 )
             }
-            logger.debug(`[ContextEngine] [Path A] OVER threshold — starting INCREMENTAL compression of ${newMessages.length} msgs...`)
-            logger.debug(`[ContextEngine] [Path A] CONTEXT BEFORE COMPRESSION: summary(${snapshot.summary.length} chars) + ${newMessages.length} new msgs`)
+            logger.info({
+                roomId: input.roomId,
+                agentName: input.agentName,
+                path: 'snapshot',
+                messageCount: newMessages.length,
+                summaryTokenEstimate: summaryTokens,
+                messageTailTokenEstimate: newTokens,
+                messageOnlyTokens,
+                fullContextTokens: totalTokens,
+                triggerTokens: config.triggerTokens,
+                preservedTailCount: newMessages.length,
+                decision: 'incremental_compress',
+            }, '[ContextEngine] compression started')
             meta.compressed = true
             input.onProgress?.({
                 status: 'compressing',
@@ -198,34 +252,75 @@ export class ContextEngine {
                 this.messageFetcher.saveContextSnapshot(input.roomId, result.summary, lastMsg.id, lastMsg.timestamp)
 
                 meta.summaryTokenEstimate = this.countTokens(result.summary)
-                logger.debug(`[ContextEngine] [Path A] incremental compression DONE in ${elapsed}ms, newSummaryLen=${result.summary.length}, newLastMsgId=${lastMsg.id}`)
-                logger.debug(`[ContextEngine] [Path A] NEW SUMMARY (${result.summary.length} chars): ${result.summary.slice(0, 300)}`)
-                const history = this.buildHistory(result.summary, newMessages, input.agentSocketId, input.agentName)
+                const history = this.buildHistory(result.summary, newMessages, input.agentId, input.agentSocketId, input.agentName)
                 meta.contextTokenEstimate = await estimateFullContextTokens(history, this.estimateTokens(history))
+                logger.info({
+                    roomId: input.roomId,
+                    agentName: input.agentName,
+                    path: 'snapshot',
+                    messageCount: newMessages.length,
+                    summaryTokenEstimate: meta.summaryTokenEstimate,
+                    fullContextTokens: meta.contextTokenEstimate,
+                    preservedTailCount: newMessages.length,
+                    savedLastMessageId: lastMsg.id,
+                    elapsedMs: elapsed,
+                }, '[ContextEngine] compression completed')
                 this.logHistory('Path A (after incremental compress)', history)
                 if (result.sessionId) this.sessionCleaner?.(result.sessionId)
                 return { conversationHistory: history, instructions, meta }
             }
 
             // Compression failed — degrade
-            logger.warn(`[ContextEngine] [Path A] incremental compression FAILED (${elapsed}ms) — degrading to summary + trimmed verbatim`)
-            const history = this.buildHistory(snapshot.summary, newMessages, input.agentSocketId, input.agentName)
-            this.trimToBudget(history, summaryTokens, config.maxHistoryTokens)
+            const history = this.buildHistory(snapshot.summary, newMessages, input.agentId, input.agentSocketId, input.agentName)
+            this.trimToBudget(history, summaryTokens, config.maxHistoryTokens, 2, 1)
+            meta.verbatimCount = Math.max(0, history.length - 2)
+            logger.warn({
+                roomId: input.roomId,
+                agentName: input.agentName,
+                path: 'snapshot_degrade',
+                reason: 'incremental_compression_failed',
+                messageCount: newMessages.length,
+                summaryTokenEstimate: summaryTokens,
+                messageTailTokenEstimate: newTokens,
+                messageOnlyTokens,
+                fullContextTokens: totalTokens,
+                preservedTailCount: meta.verbatimCount,
+                maxHistoryTokens: config.maxHistoryTokens,
+                elapsedMs: elapsed,
+            }, '[ContextEngine] degraded to summary plus trimmed verbatim tail')
             return { conversationHistory: history, instructions, meta }
         }
 
         // ── Path B: No snapshot — full context ───────────────
         const messageOnlyTokens = this.estimateTokensFromMessages(messages)
         meta.verbatimCount = total
-        const fullHistory = messages.map(m => this.mapToHistory(m, input.agentSocketId, input.agentName))
+        const fullHistory = buildProjectedGroupChatHistory('', messages, { agentId: input.agentId, socketId: input.agentSocketId, name: input.agentName })
         const totalTokens = await estimateFullContextTokens(fullHistory, messageOnlyTokens)
         logThresholdCheck('full', messageOnlyTokens, totalTokens)
 
-        logger.debug(`[ContextEngine] [Path B] no snapshot, totalMessages=${total}, totalTokens=~${totalTokens}, threshold=${config.triggerTokens}`)
+        logger.debug({
+            roomId: input.roomId,
+            agentName: input.agentName,
+            path: 'full',
+            messageCount: total,
+            messageOnlyTokens,
+            fullContextTokens: totalTokens,
+            triggerTokens: config.triggerTokens,
+            preservedTailCount: total,
+            decision: totalTokens <= config.triggerTokens ? 'skip_compression' : 'full_compress',
+        }, '[ContextEngine] full path evaluated')
 
         // Under threshold — pass all messages verbatim
         if (totalTokens <= config.triggerTokens) {
-            logger.debug(`[ContextEngine] [Path B] UNDER threshold — return all ${total} msgs verbatim`)
+            logger.debug({
+                roomId: input.roomId,
+                agentName: input.agentName,
+                path: 'full',
+                messageCount: total,
+                fullContextTokens: totalTokens,
+                preservedTailCount: total,
+                decision: 'skip_compression',
+            }, '[ContextEngine] using full verbatim history')
             this.logHistory('Path B (no compress)', fullHistory)
             return { conversationHistory: fullHistory, instructions, meta }
         }
@@ -236,8 +331,17 @@ export class ContextEngine {
                 `Context window is too small for group chat agent ${input.agentName}: fixed prompt/tool overhead plus ${messages.length} messages uses ~${totalTokens} tokens, exceeding trigger ${config.triggerTokens}, and there is not enough history to compress.`,
             )
         }
-        logger.debug(`[ContextEngine] [Path B] OVER threshold — starting FULL compression of ${total} msgs...`)
-        logger.debug(`[ContextEngine] [Path B] CONTEXT BEFORE COMPRESSION: ${total} msgs, ~${totalTokens} tokens`)
+        logger.info({
+            roomId: input.roomId,
+            agentName: input.agentName,
+            path: 'full',
+            messageCount: total,
+            messageOnlyTokens,
+            fullContextTokens: totalTokens,
+            triggerTokens: config.triggerTokens,
+            preservedTailCount: messages.length > config.tailMessageCount ? config.tailMessageCount : 0,
+            decision: 'full_compress',
+        }, '[ContextEngine] compression started')
         meta.compressed = true
         input.onProgress?.({
             status: 'compressing',
@@ -266,20 +370,41 @@ export class ContextEngine {
             this.messageFetcher.saveContextSnapshot(input.roomId, result.summary, lastCompressedMsg.id, lastCompressedMsg.timestamp)
 
             meta.summaryTokenEstimate = this.countTokens(result.summary)
-            logger.debug(`[ContextEngine] [Path B] full compression DONE in ${elapsed}ms, summaryLen=${result.summary.length}, compressed=${toCompress.length} msgs, keptTail=${tail.length} msgs, savedLastMsgId=${lastCompressedMsg.id}`)
-            logger.debug(`[ContextEngine] [Path B] COMPRESSED SUMMARY (${result.summary.length} chars): ${result.summary.slice(0, 300)}`)
-            const history = this.buildHistory(result.summary, tail, input.agentSocketId, input.agentName)
+            const history = this.buildHistory(result.summary, tail, input.agentId, input.agentSocketId, input.agentName)
             meta.contextTokenEstimate = await estimateFullContextTokens(history, this.estimateTokens(history))
+            logger.info({
+                roomId: input.roomId,
+                agentName: input.agentName,
+                path: 'full',
+                messageCount: total,
+                compressedMessageCount: toCompress.length,
+                preservedTailCount: tail.length,
+                summaryTokenEstimate: meta.summaryTokenEstimate,
+                fullContextTokens: meta.contextTokenEstimate,
+                savedLastMessageId: lastCompressedMsg.id,
+                elapsedMs: elapsed,
+            }, '[ContextEngine] compression completed')
             this.logHistory('Path B (after full compress)', history)
             if (result.sessionId) this.sessionCleaner?.(result.sessionId)
             return { conversationHistory: history, instructions, meta }
         }
 
         // Compression failed — degrade
-        logger.warn(`[ContextEngine] [Path B] full compression FAILED (${elapsed}ms) — degrading to trimmed verbatim`)
-        const history = messages.map(m => this.mapToHistory(m, input.agentSocketId, input.agentName))
-        this.trimToBudget(history, 0, config.maxHistoryTokens)
+        const history = buildProjectedGroupChatHistory('', messages, { agentId: input.agentId, socketId: input.agentSocketId, name: input.agentName })
+        this.trimToBudget(history, 0, config.maxHistoryTokens, 0, 1)
         meta.verbatimCount = history.length
+        logger.warn({
+            roomId: input.roomId,
+            agentName: input.agentName,
+            path: 'full_degrade',
+            reason: 'full_compression_failed',
+            messageCount: total,
+            messageOnlyTokens,
+            fullContextTokens: totalTokens,
+            preservedTailCount: history.length,
+            maxHistoryTokens: config.maxHistoryTokens,
+            elapsedMs: elapsed,
+        }, '[ContextEngine] degraded to trimmed verbatim history')
         return { conversationHistory: history, instructions, meta }
     }
 
@@ -292,7 +417,7 @@ export class ContextEngine {
      * Used when user manually triggers compression.
      */
     async forceCompress(roomId: string, profile?: string): Promise<string> {
-        const allMessages = this.messageFetcher.getMessages(roomId)
+        const allMessages = this.messageFetcher.getMessagesForContext(roomId)
         if (allMessages.length === 0) return ''
 
         const config = { ...this.config }
@@ -324,20 +449,11 @@ export class ContextEngine {
     private buildHistory(
         summary: string,
         messages: StoredMessage[],
+        agentId: string,
         agentSocketId: string,
         agentName: string,
     ): Array<{ role: 'user' | 'assistant'; content: string }> {
-        const history: Array<{ role: 'user' | 'assistant'; content: string }> = []
-
-        if (summary) {
-            history.push(
-                { role: 'user', content: '[Previous conversation summary]\n' + summary },
-                { role: 'assistant', content: 'I have reviewed the conversation history and understand the context.' },
-            )
-        }
-
-        history.push(...messages.map(m => this.mapToHistory(m, agentSocketId, agentName)))
-        return history
+        return buildProjectedGroupChatHistory(summary, messages, { agentId, socketId: agentSocketId, name: agentName })
     }
 
     /**
@@ -374,62 +490,26 @@ export class ContextEngine {
 
     private mapToHistory(
         msg: StoredMessage,
+        agentId: string,
         agentSocketId: string,
         agentName: string,
     ): { role: 'user' | 'assistant'; content: string } {
-        const senderName = msg.senderName || 'unknown'
-        const isOwnAgent = msg.senderId === agentSocketId || senderName === agentName
-
-        if (msg.role === 'tool') {
-            const label = msg.tool_name ? `Tool result: ${msg.tool_name}` : 'Tool result'
-            return { role: 'user', content: `[${senderName}] [${label}]\n${msg.content || ''}` }
-        }
-
-        if (msg.role === 'assistant' && msg.tool_calls?.length) {
-            const toolsInfo = msg.tool_calls.map(tc => {
-                const name = tc.function?.name || 'unknown'
-                let args = tc.function?.arguments || '{}'
-                if (args.length > 4000) args = `${args.slice(0, 4000)}...`
-                return `[Calling tool: ${name} with arguments: ${args}]`
-            }).join('\n')
-            const content = msg.content?.trim()
-            return {
-                role: isOwnAgent ? 'assistant' : 'user',
-                content: content
-                    ? `${this.formatAttributedContent(senderName, content)}\n${this.formatAttributionPrefix(senderName, content)}${toolsInfo}`
-                    : `${this.formatAttributionPrefix(senderName, content)}${toolsInfo}`,
-            }
-        }
-
-        return {
-            role: isOwnAgent ? 'assistant' : 'user',
-            content: this.formatAttributedContent(senderName, msg.content || ''),
-        }
-    }
-
-    private formatAttributedContent(senderName: string, content: string): string {
-        return `${this.formatAttributionPrefix(senderName)}${this.stripMentions(content)}`
-    }
-
-    private formatAttributionPrefix(senderName: string, _content?: string): string {
-        return `[${senderName}]: `
-    }
-
-    private stripMentions(content: string): string {
-        return String(content || '')
-            .replace(/@([^\s@]+)/g, '')
-            .replace(/[ \t]{2,}/g, ' ')
-            .replace(/^\s+/, '')
+        return projectGroupChatMessage(msg, { agentId, socketId: agentSocketId, name: agentName })
     }
 
     private trimToBudget(
         history: Array<{ role: 'user' | 'assistant'; content: string }>,
         summaryTokens: number,
         maxTokens: number,
+        protectedPrefixCount: number,
+        minimumVerbatimCount: number,
     ): void {
+        const minimumHistoryLength = history.length <= protectedPrefixCount
+            ? history.length
+            : Math.min(history.length, protectedPrefixCount + Math.max(0, minimumVerbatimCount))
         let totalTokens = summaryTokens + this.estimateTokens(history)
-        while (totalTokens > maxTokens && history.length > 0) {
-            history.pop()
+        while (totalTokens > maxTokens && history.length > minimumHistoryLength) {
+            history.splice(protectedPrefixCount, 1)
             totalTokens = summaryTokens + this.estimateTokens(history)
         }
     }
@@ -451,13 +531,22 @@ export class ContextEngine {
         return Math.ceil(cjk * 1.5 + other / this.config.charsPerToken)
     }
 
-    /** Log assembled history for debugging */
+    /** Log assembled history for debugging without persisting message bodies */
     private logHistory(label: string, history: Array<{ role: string; content: string }>): void {
         const totalTokens = this.estimateTokens(history)
-        logger.debug(`[ContextEngine] ASSEMBLED HISTORY (${label}): ${history.length} entries, ~${totalTokens} tokens`)
-        for (const entry of history) {
-            const preview = entry.content.length > 150 ? entry.content.slice(0, 150) + '...' : entry.content
-            logger.debug(`  [${entry.role}] ${preview}`)
-        }
+        const roleCounts = history.reduce<Record<string, number>>((acc, entry) => {
+            acc[entry.role] = (acc[entry.role] || 0) + 1
+            return acc
+        }, {})
+        const charCounts = history.map((entry) => entry.content.length)
+        logger.debug({
+            label,
+            entryCount: history.length,
+            totalTokens,
+            roleCounts,
+            minChars: charCounts.length ? Math.min(...charCounts) : 0,
+            maxChars: charCounts.length ? Math.max(...charCounts) : 0,
+            tailEntryChars: charCounts.slice(-3),
+        }, '[ContextEngine] assembled history')
     }
 }

--- a/packages/server/src/services/hermes/context-engine/types.ts
+++ b/packages/server/src/services/hermes/context-engine/types.ts
@@ -1,3 +1,5 @@
+import type { GroupMessageCursorCutoff } from '../group-chat/group-message-ordering'
+
 // ─── Message Types ──────────────────────────────────────────
 
 /** Raw message from SQLite messages table */
@@ -76,7 +78,7 @@ export interface SummaryCacheEntry {
 // ─── Dependency Injection ──────────────────────────────────
 
 export interface MessageFetcher {
-    getMessages(roomId: string, limit?: number): StoredMessage[]
+    getMessagesForContext(roomId: string, cutoff?: GroupMessageCursorCutoff): StoredMessage[]
     getContextSnapshot(roomId: string): ContextSnapshot | null
     saveContextSnapshot(roomId: string, summary: string, lastMessageId: string, lastMessageTimestamp: number): void
     deleteContextSnapshot(roomId: string): void

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -8,6 +8,9 @@ import { AgentBridgeClient, type AgentBridgeContextEstimate, type AgentBridgeMes
 import { convertContentBlocksForAgent, isContentBlockArray } from '../run-chat/content-blocks'
 import { resolveBridgeRunModelConfig } from '../run-chat/model-config'
 import type { ContentBlock } from '../run-chat/types'
+import type { StoredMessage } from '../context-engine/types'
+import { buildProjectedGroupChatHistory, projectGroupChatMessage } from './context-projection'
+import { sliceGroupMessagesForSnapshotTail } from './group-message-ordering'
 import {
     isAllAgentsMentioned,
     resolveMentionTargets,
@@ -42,6 +45,18 @@ type MentionMessage = {
     timestamp: number
     input?: string | ContentBlock[]
     mentionDepth?: number
+}
+
+export function mentionMessageToStoredContextMessage(roomId: string, msg: MentionMessage): StoredMessage {
+    return {
+        id: msg.messageId || '',
+        roomId,
+        senderId: msg.senderId,
+        senderName: msg.senderName,
+        content: msg.content,
+        timestamp: msg.timestamp,
+        role: msg.senderKind === 'agent' ? 'assistant' : 'user',
+    }
 }
 
 type GroupEstimateMessage = { role: 'user' | 'assistant'; content: string }
@@ -458,7 +473,7 @@ class AgentClient {
                         members,
                         upstream: '',
                         apiKey: null,
-                        currentMessage: msg,
+                        currentMessage: mentionMessageToStoredContextMessage(roomId, msg),
                         compression,
                         profile: this.profile,
                         onProgress: (event: { status: 'compressing'; messageCount: number; tokenCount: number }) => {
@@ -610,7 +625,7 @@ class AgentClient {
         instructions?: string,
         modelContext: GroupModelContext = { model: '', provider: '' },
     ): Promise<void> {
-        if (!this.storage?.getMessages) return
+        if (!this.storage?.getMessagesForContext) return
         try {
             const history = this.buildRoomEstimateHistory(roomId)
             const cachedTokens = await this.estimateGroupContextTokens(
@@ -632,55 +647,17 @@ class AgentClient {
     }
 
     private buildRoomEstimateHistory(roomId: string): Array<{ role: 'user' | 'assistant'; content: string }> {
-        const messages = this.storage?.getMessages?.(roomId) || []
+        const messages: StoredMessage[] = this.storage?.getMessagesForContext?.(roomId) || []
+        const snapshot = this.storage?.getContextSnapshot?.(roomId)
+        if (snapshot?.summary) {
+            const tail = sliceGroupMessagesForSnapshotTail(messages, snapshot.lastMessageId).messages
+            return buildProjectedGroupChatHistory(snapshot.summary, tail, { agentId: this.agentId, socketId: this.socket?.id, name: this.name })
+        }
         return messages.map((message: any) => this.mapRoomMessageForEstimate(message))
     }
 
     private mapRoomMessageForEstimate(message: any): { role: 'user' | 'assistant'; content: string } {
-        const senderName = String(message?.senderName || 'unknown')
-        const role = String(message?.role || 'user')
-        const isOwnAgent = message?.senderId === this.socket?.id || senderName === this.name
-
-        if (role === 'tool') {
-            const label = message?.tool_name ? `Tool result: ${message.tool_name}` : 'Tool result'
-            return { role: 'user', content: `[${senderName}] [${label}]\n${message?.content || ''}` }
-        }
-
-        if (role === 'assistant' && Array.isArray(message?.tool_calls) && message.tool_calls.length > 0) {
-            const toolsInfo = message.tool_calls.map((toolCall: any) => {
-                const name = toolCall?.function?.name || 'unknown'
-                let args = String(toolCall?.function?.arguments || '{}')
-                if (args.length > 4000) args = `${args.slice(0, 4000)}...`
-                return `[Calling tool: ${name} with arguments: ${args}]`
-            }).join('\n')
-            const content = String(message?.content || '').trim()
-            return {
-                role: isOwnAgent ? 'assistant' : 'user',
-                content: content
-                    ? `${this.formatAttributedContent(senderName, content)}\n${this.formatAttributionPrefix(senderName)}${toolsInfo}`
-                    : `${this.formatAttributionPrefix(senderName)}${toolsInfo}`,
-            }
-        }
-
-        return {
-            role: isOwnAgent ? 'assistant' : 'user',
-            content: this.formatAttributedContent(senderName, String(message?.content || '')),
-        }
-    }
-
-    private formatAttributedContent(senderName: string, content: string): string {
-        return `${this.formatAttributionPrefix(senderName)}${this.stripMentions(content)}`
-    }
-
-    private formatAttributionPrefix(senderName: string): string {
-        return `[${senderName}]: `
-    }
-
-    private stripMentions(content: string): string {
-        return String(content || '')
-            .replace(/@([^\s@]+)/g, '')
-            .replace(/[ \t]{2,}/g, ' ')
-            .replace(/^\s+/, '')
+        return projectGroupChatMessage(message, { agentId: this.agentId, socketId: this.socket?.id, name: this.name })
     }
 
     private async sendAgentErrorMessage(

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -39,10 +39,12 @@ interface MessageData {
 }
 
 type MentionMessage = {
+    messageId?: string
     content: string
     senderName: string
     senderId: string
     timestamp: number
+    role?: string
     input?: string | ContentBlock[]
     mentionDepth?: number
 }
@@ -55,7 +57,7 @@ export function mentionMessageToStoredContextMessage(roomId: string, msg: Mentio
         senderName: msg.senderName,
         content: msg.content,
         timestamp: msg.timestamp,
-        role: msg.senderKind === 'agent' ? 'assistant' : 'user',
+        role: msg.role === 'assistant' ? 'assistant' : 'user',
     }
 }
 

--- a/packages/server/src/services/hermes/group-chat/context-projection.ts
+++ b/packages/server/src/services/hermes/group-chat/context-projection.ts
@@ -1,0 +1,89 @@
+import type { StoredMessage } from '../context-engine/types'
+
+export type GroupHistoryMessage = { role: 'user' | 'assistant'; content: string }
+
+export type ProjectableGroupChatMessage = Pick<
+    StoredMessage,
+    'senderId' | 'senderName' | 'content' | 'role' | 'tool_calls' | 'tool_name'
+>
+
+export type GroupChatProjectionAgent = {
+    agentId?: string
+    socketId?: string
+    name: string
+}
+
+export function projectGroupChatMessage(
+    message: ProjectableGroupChatMessage,
+    ownAgent: GroupChatProjectionAgent,
+): GroupHistoryMessage {
+    const senderName = String(message.senderName || 'unknown')
+    const senderId = typeof message.senderId === 'string' ? message.senderId.trim() : ''
+    const ownAgentId = typeof ownAgent.agentId === 'string' ? ownAgent.agentId.trim() : ''
+    const ownSocketId = typeof ownAgent.socketId === 'string' ? ownAgent.socketId.trim() : ''
+    const role = String(message.role || 'user')
+    const isOwnAgent = Boolean(
+        (senderId && ownAgentId && senderId === ownAgentId)
+        || (senderId && ownSocketId && senderId === ownSocketId)
+        || (!senderId && senderName === ownAgent.name),
+    )
+
+    if (role === 'tool') {
+        const label = message.tool_name ? `Tool result: ${message.tool_name}` : 'Tool result'
+        return { role: 'user', content: `[${senderName}] [${label}]\n${String(message.content || '')}` }
+    }
+
+    if (role === 'assistant' && Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+        const toolsInfo = message.tool_calls.map((toolCall) => {
+            const name = toolCall?.function?.name || 'unknown'
+            let args = String(toolCall?.function?.arguments || '{}')
+            if (args.length > 4000) args = `${args.slice(0, 4000)}...`
+            return `[Calling tool: ${name} with arguments: ${args}]`
+        }).join('\n')
+        const content = String(message.content || '').trim()
+        return {
+            role: isOwnAgent ? 'assistant' : 'user',
+            content: content
+                ? `${formatAttributedContent(senderName, content)}\n${formatAttributionPrefix(senderName)}${toolsInfo}`
+                : `${formatAttributionPrefix(senderName)}${toolsInfo}`,
+        }
+    }
+
+    return {
+        role: isOwnAgent ? 'assistant' : 'user',
+        content: formatAttributedContent(senderName, String(message.content || '')),
+    }
+}
+
+export function buildProjectedGroupChatHistory(
+    summary: string,
+    messages: ProjectableGroupChatMessage[],
+    ownAgent: GroupChatProjectionAgent,
+): GroupHistoryMessage[] {
+    const history: GroupHistoryMessage[] = []
+
+    if (summary) {
+        history.push(
+            { role: 'user', content: `[Previous conversation summary]\n${summary}` },
+            { role: 'assistant', content: 'I have reviewed the conversation history and understand the context.' },
+        )
+    }
+
+    history.push(...messages.map((message) => projectGroupChatMessage(message, ownAgent)))
+    return history
+}
+
+export function stripMentionsForContextProjection(content: string): string {
+    return String(content || '')
+        .replace(/@([^\s@]+)/g, '')
+        .replace(/[ \t]{2,}/g, ' ')
+        .replace(/^\s+/, '')
+}
+
+function formatAttributedContent(senderName: string, content: string): string {
+    return `${formatAttributionPrefix(senderName)}${stripMentionsForContextProjection(content)}`
+}
+
+function formatAttributionPrefix(senderName: string): string {
+    return `[${senderName}]: `
+}

--- a/packages/server/src/services/hermes/group-chat/group-message-ordering.ts
+++ b/packages/server/src/services/hermes/group-chat/group-message-ordering.ts
@@ -1,0 +1,147 @@
+export interface CanonicalGroupMessage {
+    id: string
+    timestamp: number
+}
+
+export interface GroupMessageCursorCutoff {
+    throughMessageId?: string
+    afterMessageId?: string
+}
+
+export interface GroupMessageCursorSlice<T extends CanonicalGroupMessage> {
+    messages: T[]
+    throughMessageFound: boolean
+    afterMessageFound: boolean
+}
+
+export interface GroupSnapshotTailSlice<T extends CanonicalGroupMessage> {
+    messages: T[]
+    snapshotCursorFound: boolean
+}
+
+export interface GroupMessagePaginationOptions {
+    limit?: number
+    offset?: number
+}
+
+export function groupRunOrder(id: string): { baseId: string; phase: number } {
+    const value = String(id || '')
+    const partMatch = value.match(/^(.*)_part_(\d+)(?:_(toolcall|toolresult)_.+)?$/)
+    if (partMatch) {
+        const part = Number(partMatch[2] || 0)
+        const kind = partMatch[3] || 'assistant'
+        const offset = kind === 'toolcall' ? 1 : kind === 'toolresult' ? 2 : 0
+        return { baseId: partMatch[1], phase: part * 3 + offset }
+    }
+    const toolIdx = value.indexOf('_toolcall_')
+    if (toolIdx >= 0) return { baseId: value.slice(0, toolIdx), phase: 0 }
+    const resultIdx = value.indexOf('_toolresult_')
+    if (resultIdx >= 0) return { baseId: value.slice(0, resultIdx), phase: 1 }
+    return { baseId: value, phase: 2 }
+}
+
+export function sortGroupMessagesCanonical<T extends CanonicalGroupMessage>(messages: readonly T[]): T[] {
+    const baseMinTimestamp = new Map<string, number>()
+    for (const msg of messages) {
+        const { baseId } = groupRunOrder(msg.id)
+        const existing = baseMinTimestamp.get(baseId)
+        if (existing == null || msg.timestamp < existing) baseMinTimestamp.set(baseId, msg.timestamp)
+    }
+    return [...messages].sort((a, b) => {
+        const ao = groupRunOrder(a.id)
+        const bo = groupRunOrder(b.id)
+        const at = baseMinTimestamp.get(ao.baseId) ?? a.timestamp
+        const bt = baseMinTimestamp.get(bo.baseId) ?? b.timestamp
+        if (at !== bt) return at - bt
+        if (ao.baseId !== bo.baseId) return ao.baseId.localeCompare(bo.baseId)
+        if (ao.phase !== bo.phase) return ao.phase - bo.phase
+        if (a.timestamp !== b.timestamp) return a.timestamp - b.timestamp
+        return a.id.localeCompare(b.id)
+    })
+}
+
+export function sliceGroupMessagesCanonical<T extends CanonicalGroupMessage>(
+    messages: readonly T[],
+    cutoff?: GroupMessageCursorCutoff,
+): GroupMessageCursorSlice<T> {
+    const ordered = sortGroupMessagesCanonical(messages)
+    let throughMessageFound = !cutoff?.throughMessageId
+    let afterMessageFound = !cutoff?.afterMessageId
+    let sliced = ordered
+
+    if (cutoff?.throughMessageId) {
+        const throughIdx = ordered.findIndex(message => message.id === cutoff.throughMessageId)
+        if (throughIdx >= 0) {
+            throughMessageFound = true
+            sliced = ordered.slice(0, throughIdx + 1)
+        }
+    }
+
+    if (cutoff?.afterMessageId) {
+        const afterIdx = sliced.findIndex(message => message.id === cutoff.afterMessageId)
+        if (afterIdx >= 0) {
+            afterMessageFound = true
+            sliced = sliced.slice(afterIdx + 1)
+        }
+    }
+
+    return {
+        messages: sliced,
+        throughMessageFound,
+        afterMessageFound,
+    }
+}
+
+/**
+ * Resolve the verbatim transcript tail that should follow a persisted summary snapshot.
+ *
+ * If the cursor anchor is still present, we keep only messages strictly after it. If the
+ * anchor is missing, it was likely pruned while the summary remained persisted. In that case
+ * the summary is still valid for the older conversation, but the exact incremental boundary is
+ * gone, so we conservatively treat the entire retained transcript as the verbatim post-summary
+ * tail. We intentionally do not guess with timestamp fallbacks.
+ */
+export function sliceGroupMessagesForSnapshotTail<T extends CanonicalGroupMessage>(
+    messages: readonly T[],
+    snapshotLastMessageId: string,
+): GroupSnapshotTailSlice<T> {
+    const slice = sliceGroupMessagesCanonical(messages, { afterMessageId: snapshotLastMessageId })
+    return {
+        messages: slice.messages,
+        snapshotCursorFound: slice.afterMessageFound,
+    }
+}
+
+/**
+ * Return a recent UI page in canonical order without splitting grouped assistant/tool events.
+ *
+ * Pagination remains offset-from-newest for compatibility with the previous SQL query, but the
+ * page boundaries are expanded to include every message sharing the boundary messages' grouped
+ * run base id. This can return slightly more than `limit` rows when the boundary crosses a
+ * multipart assistant/toolcall/toolresult group, which is preferable to rendering broken runs.
+ */
+export function paginateRecentGroupMessagesCanonical<T extends CanonicalGroupMessage>(
+    messages: readonly T[],
+    options: GroupMessagePaginationOptions = {},
+): T[] {
+    const limit = Math.max(0, Math.floor(Number(options.limit ?? 150)))
+    const offset = Math.max(0, Math.floor(Number(options.offset ?? 0)))
+    if (limit === 0) return []
+
+    const ordered = sortGroupMessagesCanonical(messages)
+    const rawEnd = Math.max(0, ordered.length - offset)
+    if (rawEnd === 0) return []
+
+    let start = Math.max(0, rawEnd - limit)
+    let end = rawEnd
+
+    if (start < end) {
+        const startBase = groupRunOrder(ordered[start].id).baseId
+        while (start > 0 && groupRunOrder(ordered[start - 1].id).baseId === startBase) start--
+
+        const endBase = groupRunOrder(ordered[end - 1].id).baseId
+        while (end < ordered.length && groupRunOrder(ordered[end].id).baseId === endBase) end++
+    }
+
+    return ordered.slice(start, end)
+}

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -12,6 +12,7 @@ import { authenticateUserToken, isAuthEnabled, type AuthenticatedUser } from '..
 import { findUserByUsername, getUserAvatar } from '../../../db/hermes/users-store'
 import { config } from '../../../config'
 import { createSocketIoCorsOrigin, shouldRejectUpgradeOrigin } from '../../../security'
+import { paginateRecentGroupMessagesCanonical, sliceGroupMessagesCanonical, sliceGroupMessagesForSnapshotTail, type GroupMessageCursorCutoff } from './group-message-ordering'
 
 // ─── Types ────────────────────────────────────────────────────
 
@@ -157,44 +158,15 @@ function maxAgentMentionDepth(): number {
     return Math.min(10, Math.floor(value))
 }
 
-function groupRunOrder(id: string): { baseId: string; phase: number } {
-    const value = String(id || '')
-    const partMatch = value.match(/^(.*)_part_(\d+)(?:_(toolcall|toolresult)_.+)?$/)
-    if (partMatch) {
-        const part = Number(partMatch[2] || 0)
-        const kind = partMatch[3] || 'assistant'
-        const offset = kind === 'toolcall' ? 1 : kind === 'toolresult' ? 2 : 0
-        return { baseId: partMatch[1], phase: part * 3 + offset }
-    }
-    const toolIdx = value.indexOf('_toolcall_')
-    if (toolIdx >= 0) return { baseId: value.slice(0, toolIdx), phase: 0 }
-    const resultIdx = value.indexOf('_toolresult_')
-    if (resultIdx >= 0) return { baseId: value.slice(0, resultIdx), phase: 1 }
-    return { baseId: value, phase: 2 }
-}
-
-function sortGroupMessages<T extends { id: string; timestamp: number }>(messages: T[]): T[] {
-    const baseMinTimestamp = new Map<string, number>()
-    for (const msg of messages) {
-        const { baseId } = groupRunOrder(msg.id)
-        const existing = baseMinTimestamp.get(baseId)
-        if (existing == null || msg.timestamp < existing) baseMinTimestamp.set(baseId, msg.timestamp)
-    }
-    return [...messages].sort((a, b) => {
-        const ao = groupRunOrder(a.id)
-        const bo = groupRunOrder(b.id)
-        const at = baseMinTimestamp.get(ao.baseId) ?? a.timestamp
-        const bt = baseMinTimestamp.get(bo.baseId) ?? b.timestamp
-        if (at !== bt) return at - bt
-        if (ao.baseId !== bo.baseId) return ao.baseId.localeCompare(bo.baseId)
-        if (ao.phase !== bo.phase) return ao.phase - bo.phase
-        if (a.timestamp !== b.timestamp) return a.timestamp - b.timestamp
-        return a.id.localeCompare(b.id)
-    })
-}
-
 class ChatStorage {
     private db() { return getDb() }
+
+    private mapStoredMessageRow(row: any): ChatMessage {
+        return {
+            ...row,
+            tool_calls: parseJsonArray(row.tool_calls),
+        }
+    }
 
     init(): void {
         if (_tablesEnsured) return
@@ -391,12 +363,15 @@ class ChatStorage {
 
     private estimateRoomTotalTokens(roomId: string, messages: ChatMessage[]): number {
         const snapshot = this.getContextSnapshot(roomId)
-        if (snapshot && messages.length) {
-            const snapshotIdx = messages.findIndex(m => m.id === snapshot.lastMessageId)
-            const newMessages = snapshotIdx >= 0
-                ? messages.slice(snapshotIdx + 1)
-                : messages.filter(m => m.timestamp > snapshot.lastMessageTimestamp)
-            const newUsage = this.estimateUsageTokensFromMessages(newMessages)
+        if (snapshot) {
+            const snapshotTail = messages.length
+                ? sliceGroupMessagesForSnapshotTail(messages, snapshot.lastMessageId)
+                : { messages: [], snapshotCursorFound: true }
+            const newUsage = this.estimateUsageTokensFromMessages(snapshotTail.messages)
+            // Missing cursor usually means pruneMessages() removed the anchor row while leaving
+            // the snapshot. The summary still covers the older conversation, and without the
+            // exact boundary we conservatively treat the retained transcript as the verbatim
+            // post-summary tail instead of guessing with timestamps.
             return countTokens(SUMMARY_PREFIX + snapshot.summary) + newUsage.inputTokens + newUsage.outputTokens
         }
         const usage = this.estimateUsageTokensFromMessages(messages)
@@ -405,14 +380,18 @@ class ChatStorage {
 
     // ─── Messages ─────────────────────────────────────────────
 
-    getMessages(roomId: string, limit = 150, offset = 0): ChatMessage[] {
+    getRecentMessagesForUI(roomId: string, limit = 150, offset = 0): ChatMessage[] {
         const rows = (this.db()?.prepare(
-            'SELECT id, roomId, senderId, senderName, content, timestamp, role, tool_call_id, tool_calls, tool_name, finish_reason, reasoning, reasoning_details, reasoning_content FROM gc_messages WHERE roomId = ? ORDER BY timestamp DESC LIMIT ? OFFSET ?'
-        ).all(roomId, limit, offset) || []) as any[]
-        return sortGroupMessages(rows.map(row => ({
-            ...row,
-            tool_calls: parseJsonArray(row.tool_calls),
-        })))
+            'SELECT id, roomId, senderId, senderName, content, timestamp, role, tool_call_id, tool_calls, tool_name, finish_reason, reasoning, reasoning_details, reasoning_content FROM gc_messages WHERE roomId = ?'
+        ).all(roomId) || []) as any[]
+        return paginateRecentGroupMessagesCanonical(rows.map(row => this.mapStoredMessageRow(row)), { limit, offset })
+    }
+
+    getMessagesForContext(roomId: string, cutoff?: GroupMessageCursorCutoff): ChatMessage[] {
+        const rows = (this.db()?.prepare(
+            'SELECT id, roomId, senderId, senderName, content, timestamp, role, tool_call_id, tool_calls, tool_name, finish_reason, reasoning, reasoning_details, reasoning_content FROM gc_messages WHERE roomId = ?'
+        ).all(roomId) || []) as any[]
+        return sliceGroupMessagesCanonical(rows.map(row => this.mapStoredMessageRow(row)), cutoff).messages
     }
 
     getMessageCount(roomId: string): number {
@@ -427,10 +406,7 @@ class ChatStorage {
             'SELECT id, roomId, senderId, senderName, content, timestamp, role, tool_call_id, tool_calls, tool_name, finish_reason, reasoning, reasoning_details, reasoning_content FROM gc_messages WHERE id = ?'
         ).get(messageId) as any
         if (!row) return null
-        return {
-            ...row,
-            tool_calls: parseJsonArray(row.tool_calls),
-        }
+        return this.mapStoredMessageRow(row)
     }
 
     addMessage(msg: ChatMessage): void {
@@ -478,7 +454,7 @@ class ChatStorage {
             const message = existing && options.preserveExistingTimestamp ? { ...msg, timestamp: existing.timestamp } : msg
             this.upsertMessage(message)
             this.pruneMessages(msg.roomId)
-            const messages = this.getMessages(msg.roomId)
+            const messages = this.getMessagesForContext(msg.roomId)
             const totalTokens = this.estimateRoomTotalTokens(msg.roomId, messages)
             this.updateRoomTotalTokens(msg.roomId, totalTokens)
             db.exec('COMMIT')
@@ -1018,7 +994,7 @@ export class GroupChatServer {
         }
 
         // Load history from SQLite
-        const messages = this.storage.getMessages(roomId)
+        const messages = this.storage.getRecentMessagesForUI(roomId)
         const agents = this.storage.getRoomAgents(roomId)
 
         ack?.({

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -1060,11 +1060,13 @@ export class GroupChatServer {
             // Agent replies are allowed to mention other agents, but mentionDepth
             // bounds chained agent-to-agent handoffs so one prompt cannot loop forever.
             this.agentClients.processMentions(roomId, {
+                messageId: savedMsg.id,
                 content: contentToText(savedMsg.content),
                 input: Array.isArray(data.content) ? data.content : undefined,
                 senderName: savedMsg.senderName,
                 senderId: savedMsg.senderId,
                 timestamp: savedMsg.timestamp,
+                role: savedMsg.role,
                 mentionDepth,
             }).catch((err) => {
                 logger.error(`[GroupChat] processMentions error: ${err.message}`)

--- a/tests/server/context-engine.test.ts
+++ b/tests/server/context-engine.test.ts
@@ -165,7 +165,7 @@ describe('ContextEngine.buildContext', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockFetcher = {
-            getMessages: vi.fn().mockReturnValue([]),
+            getMessagesForContext: vi.fn().mockReturnValue([]),
             getContextSnapshot: vi.fn().mockReturnValue(null),
             saveContextSnapshot: vi.fn(),
             deleteContextSnapshot: vi.fn(),
@@ -179,7 +179,7 @@ describe('ContextEngine.buildContext', () => {
 
     it('returns all messages as history when under threshold', async () => {
         const messages = makeMessages(10) // 10 messages, under trigger threshold
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
 
         const result = await engine.buildContext({
             roomId: 'room-1',
@@ -205,7 +205,7 @@ describe('ContextEngine.buildContext', () => {
 
     it('records full context token estimates without compressing when under threshold', async () => {
         const messages = makeMessages(3)
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
         const contextTokenEstimator = vi.fn().mockResolvedValue(19_379)
         const onProgress = vi.fn()
 
@@ -238,7 +238,7 @@ describe('ContextEngine.buildContext', () => {
 
     it('uses full context token estimates to trigger group compression', async () => {
         const messages = makeMessages(20)
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
         const onProgress = vi.fn()
 
         const result = await engine.buildContext({
@@ -271,7 +271,7 @@ describe('ContextEngine.buildContext', () => {
 
     it('throws when group prompt and tools exceed threshold with too little history to compress', async () => {
         const messages = makeMessages(4)
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
 
         await expect(engine.buildContext({
             roomId: 'room-1',
@@ -294,7 +294,7 @@ describe('ContextEngine.buildContext', () => {
 
     it('throws on snapshot path when overhead plus new messages exceed threshold without compressible history', async () => {
         const messages = makeMessages(12)
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
         mockFetcher.getContextSnapshot = vi.fn().mockReturnValue({
             roomId: 'room-1',
             summary: 'Existing summary',
@@ -324,7 +324,7 @@ describe('ContextEngine.buildContext', () => {
 
     it('splits into head/tail and compresses middle when over threshold', async () => {
         const messages = makeMessages(20)
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
 
         const result = await engine.buildContext({
             roomId: 'room-1',
@@ -348,7 +348,7 @@ describe('ContextEngine.buildContext', () => {
 
     it('uses cache hit when available and no new messages', async () => {
         const messages = makeMessages(20)
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
 
         // First call — creates snapshot (with forced compression)
         await engine.buildContext({
@@ -387,7 +387,7 @@ describe('ContextEngine.buildContext', () => {
 
     it('does incremental update when cache hit with new messages', async () => {
         const messages = makeMessages(20)
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
 
         // First call — full compression (with forced compression)
         await engine.buildContext({
@@ -422,7 +422,7 @@ describe('ContextEngine.buildContext', () => {
             senderName: 'NewUser', content: 'New middle message', timestamp: 12000,
         })
         const updatedMessages = [...messages.slice(0, 9), middleInsert, ...messages.slice(9)]
-        mockFetcher.getMessages = vi.fn().mockReturnValue(updatedMessages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(updatedMessages)
 
         const onProgress = vi.fn()
         // Second call — incremental update
@@ -449,7 +449,7 @@ describe('ContextEngine.buildContext', () => {
         mockSummarize.mockRejectedValue(new Error('LLM timeout'))
 
         const messages = makeMessages(20)
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
 
         const result = await engine.buildContext({
             roomId: 'room-1', agentId: 'agent-1', agentName: 'Claude',
@@ -479,7 +479,7 @@ describe('ContextEngine.buildContext', () => {
         })
 
         const messages = makeMessages(20)
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
 
         const result = await engine.buildContext({
             roomId: 'room-1', agentId: 'agent-1', agentName: 'Claude',
@@ -502,7 +502,7 @@ describe('ContextEngine.buildContext', () => {
             makeMessage({ senderId: 'user-1', senderName: 'Alice', content: 'Hello', timestamp: 1000 }),
             makeMessage({ senderId: 'agent-socket', senderName: 'Claude', content: 'Hi there', timestamp: 2000 }),
         ]
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
 
         const result = await engine.buildContext({
             roomId: 'room-1', agentId: 'agent-1', agentName: 'Claude',
@@ -524,7 +524,7 @@ describe('ContextEngine.buildContext', () => {
         const messages = [
             makeMessage({ senderId: 'user-2', senderName: 'Bob', content: 'Hey', timestamp: 1000 }),
         ]
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
 
         const result = await engine.buildContext({
             roomId: 'room-1', agentId: 'agent-1', agentName: 'Claude',
@@ -539,7 +539,7 @@ describe('ContextEngine.buildContext', () => {
 
     it('generates instructions with agent identity', async () => {
         const messages = makeMessages(1)
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
 
         const result = await engine.buildContext({
             roomId: 'room-1', agentId: 'agent-1', agentName: 'Claude',
@@ -570,7 +570,7 @@ describe('ContextEngine.buildContext', () => {
         })
 
         const messages = makeMessages(5)
-        mockFetcher.getMessages = vi.fn().mockReturnValue(messages)
+        mockFetcher.getMessagesForContext = vi.fn().mockReturnValue(messages)
 
         // Build context to create snapshot
         await engine.buildContext({

--- a/tests/server/group-chat-context-cache.test.ts
+++ b/tests/server/group-chat-context-cache.test.ts
@@ -1,10 +1,57 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { countTokens } from '../../packages/server/src/lib/context-compressor'
 import {
   estimateGroupHistoryMessageTokens,
   groupBridgeReasoningDeltaFromEvent,
   groupContextTokensWithFixedOverhead,
 } from '../../packages/server/src/services/hermes/group-chat/agent-clients'
+import { ContextEngine } from '../../packages/server/src/services/hermes/context-engine/compressor'
+import type {
+  GatewayCaller,
+  MessageFetcher,
+  StoredMessage,
+} from '../../packages/server/src/services/hermes/context-engine/types'
+import {
+  sliceGroupMessagesCanonical,
+  sliceGroupMessagesForSnapshotTail,
+  sortGroupMessagesCanonical,
+} from '../../packages/server/src/services/hermes/group-chat/group-message-ordering'
+
+function makeMessage(overrides: Partial<StoredMessage>): StoredMessage {
+  return {
+    id: 'm1',
+    roomId: 'room-1',
+    senderId: 'user-1',
+    senderName: 'Alice',
+    content: 'hello',
+    timestamp: 1,
+    role: 'user',
+    ...overrides,
+  }
+}
+
+function makeFetcher(messages: StoredMessage[], snapshot: ReturnType<MessageFetcher['getContextSnapshot']> = null): MessageFetcher {
+  return {
+    getMessagesForContext: vi.fn((_roomId: string, cutoff) => sliceGroupMessagesCanonical(messages, cutoff).messages),
+    getContextSnapshot: vi.fn(() => snapshot),
+    saveContextSnapshot: vi.fn(),
+    deleteContextSnapshot: vi.fn(),
+  }
+}
+
+function makeEngine(fetcher: MessageFetcher, summarize = vi.fn()): { engine: ContextEngine; summarize: ReturnType<typeof vi.fn> } {
+  const gatewayCaller: GatewayCaller = {
+    summarize: summarize.mockResolvedValue({ summary: 'Updated summary', sessionId: 'summary-session' }),
+  }
+  return {
+    engine: new ContextEngine({
+      config: { triggerTokens: 100_000, maxHistoryTokens: 32_000, tailMessageCount: 10, charsPerToken: 4, summarizationTimeoutMs: 30_000 },
+      messageFetcher: fetcher,
+      gatewayCaller,
+    }),
+    summarize,
+  }
+}
 
 describe('group chat fixed context cache helpers', () => {
   it('adds cached fixed context to group chat message tokens', () => {
@@ -37,5 +84,306 @@ describe('group chat fixed context cache helpers', () => {
       event: 'reasoning.delta',
       text: '',
     })).toBeNull()
+  })
+})
+
+describe('group chat context cursors', () => {
+  it('orders multipart assistant/toolcall/toolresult groups canonically before cursor slicing', () => {
+    const ordered = sortGroupMessagesCanonical([
+      makeMessage({ id: 'run-1_part_1_toolcall_weather', content: 'call-2', timestamp: 1_000, role: 'assistant' }),
+      makeMessage({ id: 'run-1_part_0_toolresult_weather', content: 'result-1', timestamp: 1_000, role: 'tool' }),
+      makeMessage({ id: 'run-1_part_1', content: 'assistant-2', timestamp: 1_000, role: 'assistant' }),
+      makeMessage({ id: 'run-1_part_0', content: 'assistant-1', timestamp: 1_000, role: 'assistant' }),
+      makeMessage({ id: 'run-1_part_1_toolresult_weather', content: 'result-2', timestamp: 1_000, role: 'tool' }),
+      makeMessage({ id: 'run-1_part_0_toolcall_weather', content: 'call-1', timestamp: 1_000, role: 'assistant' }),
+      makeMessage({ id: 'run-2', content: 'later run', timestamp: 2_000, role: 'assistant' }),
+    ])
+
+    expect(ordered.map(message => message.id)).toEqual([
+      'run-1_part_0',
+      'run-1_part_0_toolcall_weather',
+      'run-1_part_0_toolresult_weather',
+      'run-1_part_1',
+      'run-1_part_1_toolcall_weather',
+      'run-1_part_1_toolresult_weather',
+      'run-2',
+    ])
+
+    const snapshotTail = sliceGroupMessagesForSnapshotTail(ordered, 'run-1_part_0_toolresult_weather')
+    expect(snapshotTail.snapshotCursorFound).toBe(true)
+    expect(snapshotTail.messages.map(message => message.id)).toEqual([
+      'run-1_part_1',
+      'run-1_part_1_toolcall_weather',
+      'run-1_part_1_toolresult_weather',
+      'run-2',
+    ])
+  })
+
+  it('uses the current message id as the same-timestamp context boundary', async () => {
+    const messages = sortGroupMessagesCanonical([
+      makeMessage({ id: 'm1', content: 'first', timestamp: 1_000 }),
+      makeMessage({ id: 'm2', content: 'second', timestamp: 1_000 }),
+      makeMessage({ id: 'm3', content: 'third', timestamp: 1_000 }),
+    ])
+    const fetcher = makeFetcher(messages)
+    const { engine, summarize } = makeEngine(fetcher)
+
+    const result = await engine.buildContext({
+      roomId: 'room-1',
+      agentId: 'agent-1',
+      agentName: 'Worker',
+      agentDescription: '',
+      agentSocketId: 'agent-socket',
+      roomName: 'general',
+      memberNames: ['Alice'],
+      members: [{ userId: 'user-1', name: 'Alice', description: '' }],
+      upstream: '',
+      apiKey: null,
+      currentMessage: messages[1],
+    })
+
+    expect(fetcher.getMessagesForContext).toHaveBeenCalledWith('room-1', { throughMessageId: 'm2' })
+    expect(result.conversationHistory.map(message => message.content)).toEqual([
+      '[Alice]: first',
+      '[Alice]: second',
+    ])
+    expect(summarize).not.toHaveBeenCalled()
+  })
+
+  it('increments snapshots from lastMessageId even when timestamps are identical', async () => {
+    const messages = sortGroupMessagesCanonical([
+      makeMessage({ id: 'm1', content: 'first', timestamp: 1_000 }),
+      makeMessage({ id: 'm2', content: 'second', timestamp: 1_000 }),
+      makeMessage({ id: 'm3', content: 'third', timestamp: 1_000 }),
+    ])
+    const fetcher = makeFetcher(messages, {
+      roomId: 'room-1',
+      summary: 'Earlier summary',
+      lastMessageId: 'm1',
+      lastMessageTimestamp: 1_000,
+      updatedAt: Date.now(),
+    })
+    const { engine, summarize } = makeEngine(fetcher)
+
+    const result = await engine.buildContext({
+      roomId: 'room-1',
+      agentId: 'agent-1',
+      agentName: 'Worker',
+      agentDescription: '',
+      agentSocketId: 'agent-socket',
+      roomName: 'general',
+      memberNames: ['Alice'],
+      members: [{ userId: 'user-1', name: 'Alice', description: '' }],
+      upstream: '',
+      apiKey: null,
+      currentMessage: messages[2],
+    })
+
+    expect(result.conversationHistory.map(message => message.content)).toEqual([
+      '[Previous conversation summary]\nEarlier summary',
+      'I have reviewed the conversation history and understand the context.',
+      '[Alice]: second',
+      '[Alice]: third',
+    ])
+    expect(summarize).not.toHaveBeenCalled()
+  })
+
+  it('preserves snapshot summaries when the snapshot anchor was pruned from retained history', async () => {
+    const messages = sortGroupMessagesCanonical([
+      makeMessage({ id: 'm2', content: 'second', timestamp: 1_000 }),
+      makeMessage({ id: 'm3', content: 'third', timestamp: 1_000 }),
+    ])
+    const fetcher = makeFetcher(messages, {
+      roomId: 'room-1',
+      summary: 'Stale summary',
+      lastMessageId: 'm1',
+      lastMessageTimestamp: 1_000,
+      updatedAt: Date.now(),
+    })
+    const { engine, summarize } = makeEngine(fetcher)
+
+    const result = await engine.buildContext({
+      roomId: 'room-1',
+      agentId: 'agent-1',
+      agentName: 'Worker',
+      agentDescription: '',
+      agentSocketId: 'agent-socket',
+      roomName: 'general',
+      memberNames: ['Alice'],
+      members: [{ userId: 'user-1', name: 'Alice', description: '' }],
+      upstream: '',
+      apiKey: null,
+      currentMessage: messages[1],
+    })
+
+    expect(result.conversationHistory.map(message => message.content)).toEqual([
+      '[Previous conversation summary]\nStale summary',
+      'I have reviewed the conversation history and understand the context.',
+      '[Alice]: second',
+      '[Alice]: third',
+    ])
+    expect(result.meta.hadSnapshot).toBe(true)
+    expect(result.meta.verbatimCount).toBe(2)
+    expect(summarize).not.toHaveBeenCalled()
+  })
+})
+
+
+describe('group chat fallback trimming', () => {
+  it('drops oldest verbatim turns first when full compression falls back to trimming', async () => {
+    const messages = Array.from({ length: 6 }, (_value, index) => makeMessage({
+      id: `m${index + 1}`,
+      timestamp: index + 1,
+      content: `message-${index + 1} `.repeat(10),
+    }))
+    const fetcher = makeFetcher(messages)
+    const summarize = vi.fn().mockRejectedValue(new Error('summary unavailable'))
+    const gatewayCaller: GatewayCaller = { summarize }
+    const engine = new ContextEngine({
+      config: { triggerTokens: 1, maxHistoryTokens: 60, tailMessageCount: 2, charsPerToken: 4, summarizationTimeoutMs: 30_000 },
+      messageFetcher: fetcher,
+      gatewayCaller,
+    })
+
+    const result = await engine.buildContext({
+      roomId: 'room-1',
+      agentId: 'agent-1',
+      agentName: 'Worker',
+      agentDescription: '',
+      agentSocketId: 'agent-socket',
+      roomName: 'general',
+      memberNames: ['Alice'],
+      members: [{ userId: 'user-1', name: 'Alice', description: '' }],
+      upstream: '',
+      apiKey: null,
+      currentMessage: messages[messages.length - 1],
+      contextTokenEstimator: vi.fn().mockResolvedValue(999),
+    })
+
+    expect(result.conversationHistory.some(message => message.content.includes('message-1'))).toBe(false)
+    expect(result.conversationHistory.some(message => message.content.includes('message-2'))).toBe(false)
+    expect(result.conversationHistory).toHaveLength(2)
+    expect(result.conversationHistory[0]?.content).toContain('message-5')
+    expect(result.conversationHistory[1]?.content).toContain('message-6')
+  })
+
+  it('preserves the summary prefix while trimming oldest post-summary turns first', async () => {
+    const messages = Array.from({ length: 5 }, (_value, index) => makeMessage({
+      id: `m${index + 1}`,
+      timestamp: index + 1,
+      content: `message-${index + 1} `.repeat(10),
+    }))
+    const fetcher = makeFetcher(messages, {
+      roomId: 'room-1',
+      summary: 'Earlier summary',
+      lastMessageId: 'm1',
+      lastMessageTimestamp: 1,
+      updatedAt: Date.now(),
+    })
+    const summarize = vi.fn().mockRejectedValue(new Error('summary unavailable'))
+    const gatewayCaller: GatewayCaller = { summarize }
+    const engine = new ContextEngine({
+      config: { triggerTokens: 1, maxHistoryTokens: 90, tailMessageCount: 2, charsPerToken: 4, summarizationTimeoutMs: 30_000 },
+      messageFetcher: fetcher,
+      gatewayCaller,
+    })
+
+    const result = await engine.buildContext({
+      roomId: 'room-1',
+      agentId: 'agent-1',
+      agentName: 'Worker',
+      agentDescription: '',
+      agentSocketId: 'agent-socket',
+      roomName: 'general',
+      memberNames: ['Alice'],
+      members: [{ userId: 'user-1', name: 'Alice', description: '' }],
+      upstream: '',
+      apiKey: null,
+      currentMessage: messages[messages.length - 1],
+      contextTokenEstimator: vi.fn().mockResolvedValue(999),
+    })
+
+    expect(result.conversationHistory[0]).toEqual({ role: 'user', content: '[Previous conversation summary]\nEarlier summary' })
+    expect(result.conversationHistory[1]).toEqual({ role: 'assistant', content: 'I have reviewed the conversation history and understand the context.' })
+    expect(result.conversationHistory.some(message => message.content.includes('message-2'))).toBe(false)
+    expect(result.conversationHistory[2]?.content).toContain('message-4')
+    expect(result.conversationHistory[3]?.content).toContain('message-5')
+  })
+
+  it('keeps the newest verbatim turn even when full fallback budget is smaller than a single message', async () => {
+    const messages = Array.from({ length: 4 }, (_value, index) => makeMessage({
+      id: `m${index + 1}`,
+      timestamp: index + 1,
+      content: `message-${index + 1} `.repeat(10),
+    }))
+    const fetcher = makeFetcher(messages)
+    const summarize = vi.fn().mockRejectedValue(new Error('summary unavailable'))
+    const gatewayCaller: GatewayCaller = { summarize }
+    const engine = new ContextEngine({
+      config: { triggerTokens: 1, maxHistoryTokens: 1, tailMessageCount: 2, charsPerToken: 4, summarizationTimeoutMs: 30_000 },
+      messageFetcher: fetcher,
+      gatewayCaller,
+    })
+
+    const result = await engine.buildContext({
+      roomId: 'room-1',
+      agentId: 'agent-1',
+      agentName: 'Worker',
+      agentDescription: '',
+      agentSocketId: 'agent-socket',
+      roomName: 'general',
+      memberNames: ['Alice'],
+      members: [{ userId: 'user-1', name: 'Alice', description: '' }],
+      upstream: '',
+      apiKey: null,
+      currentMessage: messages[messages.length - 1],
+      contextTokenEstimator: vi.fn().mockResolvedValue(999),
+    })
+
+    expect(result.conversationHistory).toHaveLength(1)
+    expect(result.conversationHistory[0]?.content).toContain('message-4')
+  })
+
+  it('keeps the summary prefix and newest verbatim turn when snapshot fallback budget is tiny', async () => {
+    const messages = Array.from({ length: 5 }, (_value, index) => makeMessage({
+      id: `m${index + 1}`,
+      timestamp: index + 1,
+      content: `message-${index + 1} `.repeat(10),
+    }))
+    const fetcher = makeFetcher(messages, {
+      roomId: 'room-1',
+      summary: 'Earlier summary',
+      lastMessageId: 'm1',
+      lastMessageTimestamp: 1,
+      updatedAt: Date.now(),
+    })
+    const summarize = vi.fn().mockRejectedValue(new Error('summary unavailable'))
+    const gatewayCaller: GatewayCaller = { summarize }
+    const engine = new ContextEngine({
+      config: { triggerTokens: 1, maxHistoryTokens: 1, tailMessageCount: 2, charsPerToken: 4, summarizationTimeoutMs: 30_000 },
+      messageFetcher: fetcher,
+      gatewayCaller,
+    })
+
+    const result = await engine.buildContext({
+      roomId: 'room-1',
+      agentId: 'agent-1',
+      agentName: 'Worker',
+      agentDescription: '',
+      agentSocketId: 'agent-socket',
+      roomName: 'general',
+      memberNames: ['Alice'],
+      members: [{ userId: 'user-1', name: 'Alice', description: '' }],
+      upstream: '',
+      apiKey: null,
+      currentMessage: messages[messages.length - 1],
+      contextTokenEstimator: vi.fn().mockResolvedValue(999),
+    })
+
+    expect(result.conversationHistory).toEqual([
+      { role: 'user', content: '[Previous conversation summary]\nEarlier summary' },
+      { role: 'assistant', content: 'I have reviewed the conversation history and understand the context.' },
+      expect.objectContaining({ role: 'user', content: expect.stringContaining('message-5') }),
+    ])
   })
 })

--- a/tests/server/group-chat-context-projection.test.ts
+++ b/tests/server/group-chat-context-projection.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { mockIo, mockSocket } = vi.hoisted(() => {
+  const mockSocket: any = {
+    id: 'agent-socket-1',
+    connected: true,
+    io: { on: vi.fn() },
+    on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+      if (event === 'connect') queueMicrotask(() => handler())
+      return mockSocket
+    }),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  }
+  return {
+    mockSocket,
+    mockIo: vi.fn(() => mockSocket),
+  }
+})
+
+vi.mock('socket.io-client', () => ({
+  io: mockIo,
+}))
+
+vi.mock('../../packages/server/src/services/auth', () => ({
+  getToken: vi.fn(async () => 'test-token'),
+}))
+
+import { ContextEngine } from '../../packages/server/src/services/hermes/context-engine/compressor'
+import type {
+  GatewayCaller,
+  MessageFetcher,
+  StoredMessage,
+} from '../../packages/server/src/services/hermes/context-engine/types'
+import { AgentClients } from '../../packages/server/src/services/hermes/group-chat/agent-clients'
+import {
+  buildProjectedGroupChatHistory,
+  projectGroupChatMessage,
+} from '../../packages/server/src/services/hermes/group-chat/context-projection'
+
+function makeMessage(overrides: Partial<StoredMessage>): StoredMessage {
+  return {
+    id: 'm1',
+    roomId: 'room-1',
+    senderId: 'user-1',
+    senderName: 'Alice',
+    content: 'hello',
+    timestamp: 1,
+    role: 'user',
+    ...overrides,
+  }
+}
+
+describe('group chat context projection', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('projects own agent messages as assistant and other participants with attribution as user', () => {
+    expect(projectGroupChatMessage(makeMessage({ senderId: 'agent-1', senderName: 'Worker', role: 'assistant', content: '@Bob I handled it' }), {
+      agentId: 'agent-1',
+      socketId: 'agent-socket-1',
+      name: 'Worker',
+    })).toEqual({ role: 'assistant', content: '[Worker]: I handled it' })
+
+    expect(projectGroupChatMessage(makeMessage({ senderId: 'user-2', senderName: 'Alice', role: 'user', content: '@Worker please help' }), {
+      socketId: 'agent-socket-1',
+      name: 'Worker',
+    })).toEqual({ role: 'user', content: '[Alice]: please help' })
+  })
+
+  it('does not project same-name humans as the own agent when sender ids differ', () => {
+    expect(projectGroupChatMessage(makeMessage({
+      senderId: 'user-2',
+      senderName: 'Worker',
+      role: 'user',
+      content: '@Worker I am a different participant',
+    }), {
+      socketId: 'agent-socket-1',
+      name: 'Worker',
+    })).toEqual({ role: 'user', content: '[Worker]: I am a different participant' })
+  })
+
+  it('formats tool results and assistant tool calls consistently', () => {
+    expect(projectGroupChatMessage(makeMessage({
+      senderName: 'Worker',
+      senderId: 'agent-socket-1',
+      role: 'tool',
+      tool_name: 'search',
+      content: 'found docs',
+    }), {
+      socketId: 'agent-socket-1',
+      name: 'Worker',
+    })).toEqual({ role: 'user', content: '[Worker] [Tool result: search]\nfound docs' })
+
+    expect(projectGroupChatMessage(makeMessage({
+      senderName: 'Reviewer',
+      senderId: 'agent-reviewer',
+      role: 'assistant',
+      content: '@Worker let me check',
+      tool_calls: [{ function: { name: 'search', arguments: '{"q":"docs"}' } }],
+    }), {
+      socketId: 'agent-socket-1',
+      name: 'Worker',
+    })).toEqual({
+      role: 'user',
+      content: '[Reviewer]: let me check\n[Reviewer]: [Calling tool: search with arguments: {"q":"docs"}]',
+    })
+  })
+
+  it('preserves summary prefix while stripping mentions from projected content', () => {
+    const history = buildProjectedGroupChatHistory('Earlier summary', [
+      makeMessage({ senderName: 'Alice', content: '@Worker compare this with @Bob' }),
+    ], {
+      socketId: 'agent-socket-1',
+      name: 'Worker',
+    })
+
+    expect(history).toEqual([
+      { role: 'user', content: '[Previous conversation summary]\nEarlier summary' },
+      { role: 'assistant', content: 'I have reviewed the conversation history and understand the context.' },
+      { role: 'user', content: '[Alice]: compare this with ' },
+    ])
+  })
+
+  it('uses the same projection semantics for actual model context and final room token estimates', async () => {
+    const messages = [
+      makeMessage({ id: 'm1', senderName: 'Alice', senderId: 'user-1', role: 'user', content: '@Worker please compare options' }),
+      makeMessage({ id: 'm2', senderName: 'Worker', senderId: 'agent-1', role: 'assistant', content: '@Bob I will take this' }),
+      makeMessage({ id: 'm3', senderName: 'Reviewer', senderId: 'agent-reviewer', role: 'assistant', content: '@Worker checking', tool_calls: [{ function: { name: 'search', arguments: '{"q":"options"}' } }], timestamp: 3 }),
+      makeMessage({ id: 'm4', senderName: 'Worker', senderId: 'agent-1', role: 'tool', tool_name: 'search', content: 'docs found', timestamp: 4 }),
+    ]
+
+    const fetcher: MessageFetcher = {
+      getMessagesForContext: vi.fn(() => messages),
+      getContextSnapshot: vi.fn(() => null),
+      saveContextSnapshot: vi.fn(),
+      deleteContextSnapshot: vi.fn(),
+    }
+    const gatewayCaller: GatewayCaller = {
+      summarize: vi.fn(),
+    }
+    const engine = new ContextEngine({
+      config: { triggerTokens: 100_000, maxHistoryTokens: 32_000, tailMessageCount: 10, charsPerToken: 4, summarizationTimeoutMs: 30_000 },
+      messageFetcher: fetcher,
+      gatewayCaller,
+    })
+
+    const result = await engine.buildContext({
+      roomId: 'room-1',
+      agentId: 'agent-1',
+      agentName: 'Worker',
+      agentDescription: '',
+      agentSocketId: 'agent-socket-1',
+      roomName: 'general',
+      memberNames: ['Alice', 'Worker', 'Reviewer'],
+      members: [],
+      upstream: '',
+      apiKey: null,
+      currentMessage: messages[messages.length - 1],
+    })
+
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1',
+      profile: 'default',
+      name: 'Worker',
+      description: '',
+      invited: 0,
+    } as any)
+    client.setStorage({
+      getMessagesForContext: vi.fn(() => messages),
+    } as any)
+
+    expect((client as any).buildRoomEstimateHistory('room-1')).toEqual(result.conversationHistory)
+
+    client.disconnect()
+  })
+
+  it('includes persisted summary snapshots in final room token estimate history', async () => {
+    const messages = [
+      makeMessage({ id: 'm1', senderName: 'Alice', senderId: 'user-1', role: 'user', content: 'older request', timestamp: 1 }),
+      makeMessage({ id: 'm2', senderName: 'Worker', senderId: 'agent-1', role: 'assistant', content: 'old answer', timestamp: 2 }),
+      makeMessage({ id: 'm3', senderName: 'Alice', senderId: 'user-1', role: 'user', content: '@Worker latest request', timestamp: 3 }),
+    ]
+
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1',
+      profile: 'default',
+      name: 'Worker',
+      description: '',
+      invited: 0,
+    } as any)
+    client.setStorage({
+      getMessagesForContext: vi.fn(() => messages),
+      getContextSnapshot: vi.fn(() => ({
+        roomId: 'room-1',
+        summary: 'Earlier room summary',
+        lastMessageId: 'm1',
+        lastMessageTimestamp: 1,
+        updatedAt: Date.now(),
+      })),
+    } as any)
+
+    expect((client as any).buildRoomEstimateHistory('room-1')).toEqual([
+      { role: 'user', content: '[Previous conversation summary]\nEarlier room summary' },
+      { role: 'assistant', content: 'I have reviewed the conversation history and understand the context.' },
+      { role: 'assistant', content: '[Worker]: old answer' },
+      { role: 'user', content: '[Alice]: latest request' },
+    ])
+
+    client.disconnect()
+  })
+})

--- a/tests/server/group-chat-history-window.test.ts
+++ b/tests/server/group-chat-history-window.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DatabaseSync } from 'node:sqlite'
+import { createServer, type Server as HttpServer } from 'http'
+
+const dbMock = vi.hoisted(() => ({
+  current: null as DatabaseSync | null,
+}))
+
+const { mockIo, mockSocket } = vi.hoisted(() => {
+  const mockSocket: any = {
+    id: 'agent-socket-1',
+    connected: true,
+    io: { on: vi.fn() },
+    on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+      if (event === 'connect') queueMicrotask(() => handler())
+      return mockSocket
+    }),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  }
+  return {
+    mockSocket,
+    mockIo: vi.fn(() => mockSocket),
+  }
+})
+
+vi.mock('../../packages/server/src/db/index', () => ({
+  getDb: () => dbMock.current,
+}))
+
+vi.mock('socket.io-client', () => ({
+  io: mockIo,
+}))
+
+vi.mock('../../packages/server/src/services/auth', () => ({
+  getToken: vi.fn(async () => 'test-token'),
+}))
+
+import { countTokens, SUMMARY_PREFIX } from '../../packages/server/src/lib/context-compressor'
+import { initAllHermesTables } from '../../packages/server/src/db/hermes/schemas'
+import { GroupChatServer } from '../../packages/server/src/services/hermes/group-chat'
+import { AgentClients, mentionMessageToStoredContextMessage } from '../../packages/server/src/services/hermes/group-chat/agent-clients'
+import { sortGroupMessagesCanonical } from '../../packages/server/src/services/hermes/group-chat/group-message-ordering'
+
+function makeDb(): DatabaseSync {
+  return new DatabaseSync(':memory:')
+}
+
+function makeMessage(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'msg-1',
+    roomId: 'room-1',
+    senderId: 'user-1',
+    senderName: 'Alice',
+    content: 'hello',
+    timestamp: 1,
+    role: 'user',
+    ...overrides,
+  }
+}
+
+describe('group chat history windows', () => {
+  it('maps routed mention ids into context-engine current message cursors', () => {
+    const current = mentionMessageToStoredContextMessage('room-1', {
+      messageId: 'trigger-msg',
+      content: '@Worker use the context through this message only',
+      senderName: 'Alice',
+      senderId: 'user-1',
+      timestamp: 123,
+      senderKind: 'user',
+    })
+
+    expect(current.id).toBe('trigger-msg')
+    expect(current.roomId).toBe('room-1')
+    expect(current.role).toBe('user')
+  })
+
+  let httpServer: HttpServer
+  let groupServer: GroupChatServer
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dbMock.current = makeDb()
+    initAllHermesTables()
+    httpServer = createServer()
+    groupServer = new GroupChatServer(httpServer)
+  })
+
+  afterEach(() => {
+    groupServer?.getIO().close()
+    httpServer?.close()
+    dbMock.current?.close()
+    dbMock.current = null
+  })
+
+  it('returns a bounded recent UI page while context reads the full retained transcript in canonical order', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+
+    const seeded = Array.from({ length: 160 }, (_value, index) => makeMessage({
+      id: `msg-${index + 1}`,
+      content: `message ${index + 1}`,
+      timestamp: index + 1,
+    }))
+
+    for (const message of seeded) storage.saveMessageAndRefreshRoom(message as any)
+
+    const recentMessages = storage.getRecentMessagesForUI('room-1')
+    const contextMessages = storage.getMessagesForContext('room-1')
+
+    expect(recentMessages).toHaveLength(150)
+    expect(recentMessages[0]?.id).toBe('msg-11')
+    expect(recentMessages.at(-1)?.id).toBe('msg-160')
+    expect(contextMessages).toHaveLength(160)
+    expect(contextMessages.map(message => message.id)).toEqual(
+      sortGroupMessagesCanonical(seeded as Array<{ id: string; timestamp: number }>).map(message => message.id),
+    )
+  })
+
+  it('does not split same-timestamp multipart assistant/tool runs across UI page boundaries', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+
+    const seeded = [
+      makeMessage({ id: 'run-1_part_0', role: 'assistant', senderId: 'agent-1', senderName: 'Agent', content: 'assistant', timestamp: 100 }),
+      makeMessage({ id: 'run-1_part_0_toolcall_t', role: 'assistant', senderId: 'agent-1', senderName: 'Agent', content: '', timestamp: 100 }),
+      makeMessage({ id: 'run-1_part_0_toolresult_t', role: 'tool', senderId: 'agent-1', senderName: 'Agent', content: 'tool result', timestamp: 100 }),
+      makeMessage({ id: 'run-2', role: 'user', senderId: 'user-1', senderName: 'Human', content: 'next', timestamp: 100 }),
+    ]
+
+    for (const message of seeded) storage.saveMessageAndRefreshRoom(message as any)
+
+    expect(storage.getRecentMessagesForUI('room-1', 2, 0).map(message => message.id)).toEqual([
+      'run-1_part_0',
+      'run-1_part_0_toolcall_t',
+      'run-1_part_0_toolresult_t',
+      'run-2',
+    ])
+    expect(storage.getRecentMessagesForUI('room-1', 2, 2).map(message => message.id)).toEqual([
+      'run-1_part_0',
+      'run-1_part_0_toolcall_t',
+      'run-1_part_0_toolresult_t',
+    ])
+  })
+
+  it('computes room total tokens from the full retained context transcript, not the UI page window', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+
+    const seeded = Array.from({ length: 160 }, (_value, index) => makeMessage({
+      id: `msg-${index + 1}`,
+      content: `message-${index + 1}`,
+      timestamp: index + 1,
+    }))
+
+    let latest: { totalTokens: number } | null = null
+    for (const message of seeded) latest = storage.saveMessageAndRefreshRoom(message as any)
+
+    const expectedTotalTokens = seeded.reduce((sum, message) => sum + countTokens(String(message.content)), 0)
+
+    expect(storage.getRecentMessagesForUI('room-1')).toHaveLength(150)
+    expect(storage.getMessagesForContext('room-1')).toHaveLength(160)
+    expect(latest?.totalTokens).toBe(expectedTotalTokens)
+    expect(storage.getRoom('room-1')?.totalTokens).toBe(expectedTotalTokens)
+  })
+
+  it('preserves snapshot summary tokens when the snapshot anchor was pruned from retained history', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+
+    const seeded = Array.from({ length: 501 }, (_value, index) => makeMessage({
+      id: `msg-${index + 1}`,
+      content: `message-${index + 1}`,
+      timestamp: index + 1,
+    }))
+
+    storage.saveMessageAndRefreshRoom(seeded[0] as any)
+    storage.saveContextSnapshot('room-1', 'Earlier summary', 'msg-1', 1)
+
+    let latest: { totalTokens: number } | null = null
+    for (const message of seeded.slice(1)) latest = storage.saveMessageAndRefreshRoom(message as any)
+
+    const retained = storage.getMessagesForContext('room-1')
+    const expectedTotalTokens = countTokens(SUMMARY_PREFIX + 'Earlier summary')
+      + retained.reduce((sum, message) => sum + countTokens(String(message.content)), 0)
+
+    expect(retained).toHaveLength(500)
+    expect(retained.some(message => message.id === 'msg-1')).toBe(false)
+    expect(storage.getContextSnapshot('room-1')?.lastMessageId).toBe('msg-1')
+    expect(latest?.totalTokens).toBe(expectedTotalTokens)
+    expect(storage.getRoom('room-1')?.totalTokens).toBe(expectedTotalTokens)
+  })
+
+  it('uses the full context transcript for the final AgentClient room estimate', async () => {
+    const messages = Array.from({ length: 160 }, (_value, index) => ({
+      senderId: 'user-1',
+      senderName: 'Alice',
+      content: `message ${index + 1}`,
+      role: 'user',
+      timestamp: index + 1,
+    }))
+    const storage = {
+      getMessagesForContext: vi.fn(() => messages),
+      getRecentMessagesForUI: vi.fn(() => messages.slice(-150)),
+      updateRoomTotalTokens: vi.fn(),
+    }
+    const bridge = {
+      contextEstimate: vi.fn(async (_sessionId: string, history: Array<{ role: 'user' | 'assistant'; content: string }>) => ({
+        token_count: 4321,
+        fixed_context_tokens: 0,
+        message_count: history.length,
+      })),
+    }
+
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1',
+      profile: 'default',
+      name: 'Worker',
+      description: '',
+      invited: 0,
+    } as any)
+    client.setStorage(storage as any)
+
+    await (client as any).refreshRoomFullContextEstimate('room-1', 'session-1', bridge, undefined, { model: '', provider: '' })
+
+    expect(storage.getMessagesForContext).toHaveBeenCalledWith('room-1')
+    expect(storage.getRecentMessagesForUI).not.toHaveBeenCalled()
+    expect(bridge.contextEstimate).toHaveBeenCalledTimes(1)
+    expect(bridge.contextEstimate.mock.calls[0][1]).toHaveLength(160)
+    expect(storage.updateRoomTotalTokens).toHaveBeenCalledWith('room-1', 4321)
+    expect(mockSocket.emit).toHaveBeenCalledWith('context_status', expect.objectContaining({
+      roomId: 'room-1',
+      agentName: 'Worker',
+      status: 'replying',
+      totalTokens: 4321,
+    }))
+
+    client.disconnect()
+  })
+})

--- a/tests/server/group-chat-member-sync.test.ts
+++ b/tests/server/group-chat-member-sync.test.ts
@@ -248,7 +248,7 @@ describe('Group Chat member/agent identity sync', () => {
       })),
       saveRoom: vi.fn(),
       addRoomMember: vi.fn(),
-      getMessages: vi.fn(() => []),
+      getRecentMessagesForUI: vi.fn(() => []),
       getRoomAgents: vi.fn(() => []),
     }
     const socket = {


### PR DESCRIPTION
## 改动说明

这个 PR 是 group-chat context/routing hardening stack 的第 1 个切片：只处理历史读取、上下文窗口和 canonical ordering。

主要变化：
- 将 UI 分页读取和 agent/model context 读取拆开，避免 UI 当前页决定模型上下文。
- 增加 group-chat message canonical ordering helper，稳定 assistant/tool multipart message 的顺序。
- 用 message cursor 作为 context/snapshot 边界，避免 timestamp-only cutoff 在同毫秒消息下切错。
- 压缩 fallback 保留最新 tail，snapshot anchor 被 prune 时保守使用 retained transcript。
- UI pagination 为了不 split tool run，允许 page boundary 返回略多于 limit 的消息。

## 设计取舍

- `limit` 是 UI page 的目标值，不是硬上限；保持 tool run 完整比严格 message count 更重要。
- agent context 仍来自 shared room transcript，但通过 summary + tail 控制预算。
- 不改 core chat、model routing、approval 或普通 `/chat-run` 行为。

## 验证

- `npm run harness:check`
- `npm run test -- tests/server/group-chat-history-window.test.ts tests/server/group-chat-context-cache.test.ts tests/server/group-chat-context-projection.test.ts tests/server/group-chat-mention-routing.test.ts tests/server/group-chat-agent-instructions.test.ts tests/server/group-chat-clear-context-inflight.test.ts tests/server/context-engine.test.ts tests/server/group-chat-member-sync.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run build`

本地结果：78 tests passed；build passed。`group-chat-member-sync.test.ts` 中 mocked runtime failure 的 stderr 是预期测试输出。

## Review request

请重点确认：UI pagination 为了保持 assistant/tool-run 完整而把 limit 作为 soft target 是否可接受。
