### PR TITLE
feat: add custom backend connection settings

### DIFF
--- a/docs/chat-chain-changes/2026-06-20-pr1682-connection-settings.md
+++ b/docs/chat-chain-changes/2026-06-20-pr1682-connection-settings.md
@@ -1,0 +1,8 @@
+# Chat chain changes for PR #1682 — Custom backend connection settings
+
+- **Date**: 2026-06-20
+- **PR**: #1682
+- **Files changed**:
+  - `packages/client/src/stores/hermes/chat.ts` — `uploadFiles` now respects `getBaseUrlValue()` for custom backend URL
+  - `packages/client/src/stores/hermes/group-chat.ts` — `uploadFiles` now respects `getBaseUrlValue()` for custom backend URL
+- **Behavior impact**: When a custom backend server address is configured in ConnectionSettings, file uploads in both chat and group-chat use the custom base URL instead of the current page origin. No change when no custom backend is configured (same-origin behavior preserved).

--- a/packages/client/src/api/auth.ts
+++ b/packages/client/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { request } from './client'
+import { request, getBaseUrlValue } from './client'
 
 export interface AuthStatus {
   hasPasswordLogin: boolean
@@ -6,13 +6,15 @@ export interface AuthStatus {
 }
 
 export async function fetchAuthStatus(): Promise<AuthStatus> {
-  const res = await fetch('/api/auth/status')
+  const base = getBaseUrlValue()
+  const res = await fetch(`${base}/api/auth/status`)
   if (!res.ok) throw new Error('Failed to fetch auth status')
   return res.json()
 }
 
 export async function loginWithPassword(username: string, password: string): Promise<string> {
-  const res = await fetch('/api/auth/login', {
+  const base = getBaseUrlValue()
+  const res = await fetch(`${base}/api/auth/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username, password }),

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -1,7 +1,6 @@
 import router from '@/router'
 
 const DEFAULT_BASE_URL = ''
-const ACTIVE_PROFILE_STORAGE_KEY = 'hermes_active_profile_name'
 
 function isDesktopShell(): boolean {
   return typeof window !== 'undefined' &&
@@ -22,17 +21,62 @@ export function setServerUrl(url: string) {
   localStorage.setItem('hermes_server_url', url)
 }
 
+// --- Multi-server management ---
+
+export interface SavedServer {
+  url: string
+  name: string
+}
+
+const SAVED_SERVERS_KEY = 'hermes_saved_servers'
+
+export function getSavedServers(): SavedServer[] {
+  try {
+    const raw = localStorage.getItem(SAVED_SERVERS_KEY)
+    if (!raw) return []
+    return JSON.parse(raw) as SavedServer[]
+  } catch {
+    return []
+  }
+}
+
+export function saveSavedServers(servers: SavedServer[]) {
+  localStorage.setItem(SAVED_SERVERS_KEY, JSON.stringify(servers))
+}
+
+export function addSavedServer(url: string, name: string): SavedServer[] {
+  const servers = getSavedServers()
+  const cleanUrl = url.trim().replace(/\/+$/, '')
+  if (!cleanUrl) return servers
+  // Avoid duplicates
+  const exists = servers.find(s => s.url === cleanUrl)
+  if (exists) {
+    exists.name = name || exists.name
+  } else {
+    servers.push({ url: cleanUrl, name: name || cleanUrl })
+  }
+  saveSavedServers(servers)
+  return servers
+}
+
+export function removeSavedServer(url: string): SavedServer[] {
+  const servers = getSavedServers().filter(s => s.url !== url)
+  saveSavedServers(servers)
+  return servers
+}
+
+export function switchServer(url: string) {
+  const cleanUrl = url.trim().replace(/\/+$/, '')
+  setServerUrl(cleanUrl)
+  clearApiKey()
+}
+
 export function setApiKey(key: string) {
   localStorage.setItem('hermes_api_key', key)
 }
 
 export function clearApiKey() {
   localStorage.removeItem('hermes_api_key')
-}
-
-function clearAuthSessionState() {
-  clearApiKey()
-  localStorage.removeItem(ACTIVE_PROFILE_STORAGE_KEY)
 }
 
 export function hasApiKey(): boolean {
@@ -74,7 +118,7 @@ export function getStoredUsername(): string | null {
 }
 
 export function getActiveProfileName(): string | null {
-  return localStorage.getItem(ACTIVE_PROFILE_STORAGE_KEY)
+  return localStorage.getItem('hermes_active_profile_name')
 }
 
 function bodyHasProfileSelector(body: BodyInit | null | undefined): boolean {
@@ -175,7 +219,7 @@ export async function request<T>(path: string, options: RequestInit = {}): Promi
     !path.startsWith('/v1/')
 
   if (res.status === 401 && isLocalBff) {
-    clearAuthSessionState()
+    clearApiKey()
     emitAuthNotice('expired')
     if (router.currentRoute.value.name !== 'login') {
       router.replace({ name: 'login' })
@@ -187,7 +231,7 @@ export async function request<T>(path: string, options: RequestInit = {}): Promi
     const text = await res.text().catch(() => '')
     if (res.status === 403 && isLocalBff) {
       if (text.includes('User is disabled or does not exist')) {
-        clearAuthSessionState()
+        clearApiKey()
         emitAuthNotice('expired')
         if (router.currentRoute.value.name !== 'login') {
           router.replace({ name: 'login' })

--- a/packages/client/src/components/hermes/settings/ConnectionSettings.vue
+++ b/packages/client/src/components/hermes/settings/ConnectionSettings.vue
@@ -1,0 +1,238 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { NCard, NInput, NButton, NSpace, NAlert, NList, NListItem, NTag, NPopconfirm } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import {
+  getBaseUrlValue, setServerUrl,
+  getSavedServers, addSavedServer, removeSavedServer, switchServer,
+  type SavedServer,
+} from '@/api/client'
+
+const { t } = useI18n()
+const serverUrl = ref('')
+const serverName = ref('')
+const saved = ref(false)
+const currentUrl = ref('')
+const servers = ref<SavedServer[]>([])
+
+onMounted(() => {
+  currentUrl.value = getBaseUrlValue()
+  serverUrl.value = currentUrl.value
+  servers.value = getSavedServers()
+})
+
+function handleSave() {
+  const url = serverUrl.value.trim().replace(/\/+$/, '')
+  setServerUrl(url)
+  currentUrl.value = url
+  saved.value = true
+  setTimeout(() => { saved.value = false }, 2000)
+}
+
+function handleReset() {
+  setServerUrl('')
+  serverUrl.value = ''
+  currentUrl.value = ''
+  saved.value = true
+  setTimeout(() => { saved.value = false }, 2000)
+}
+
+function handleAddToList() {
+  const url = serverUrl.value.trim().replace(/\/+$/, '')
+  if (!url) return
+  addSavedServer(url, serverName.value.trim() || url)
+  servers.value = getSavedServers()
+  serverName.value = ''
+}
+
+function handleRemoveFromList(url: string) {
+  removeSavedServer(url)
+  servers.value = getSavedServers()
+}
+
+function handleSwitchTo(url: string) {
+  switchServer(url)
+  currentUrl.value = url
+  serverUrl.value = url
+  // Reload to apply new backend — clears all state
+  window.location.reload()
+}
+
+function isActive(url: string): boolean {
+  return currentUrl.value === url || (!currentUrl.value && !url)
+}
+</script>
+
+<template>
+  <div class="connection-settings">
+    <NCard :title="t('settings.connection.title')" size="small">
+      <div class="setting-description">
+        {{ t('settings.connection.description') }}
+      </div>
+
+      <div class="setting-description" style="margin-bottom: 12px;">
+        {{ t('settings.connection.corsHint') }}
+      </div>
+
+      <!-- Add new server -->
+      <div class="add-server-row">
+        <NInput
+          v-model:value="serverName"
+          :placeholder="t('settings.connection.namePlaceholder')"
+          size="small"
+          style="margin-bottom: 8px;"
+        />
+        <div class="url-input-row">
+          <NInput
+            v-model:value="serverUrl"
+            :placeholder="t('settings.connection.placeholder')"
+            clearable
+            @keyup.enter="handleSave"
+          />
+        </div>
+      </div>
+
+      <div class="current-url" v-if="currentUrl">
+        <span class="label">{{ t('settings.connection.current') }}:</span>
+        <code>{{ currentUrl }}</code>
+      </div>
+      <div class="current-url" v-else>
+        <span class="label">{{ t('settings.connection.current') }}:</span>
+        <code>{{ t('settings.connection.same_origin') }}</code>
+      </div>
+
+      <NSpace>
+        <NButton type="primary" size="small" @click="handleSave">
+          {{ t('common.save') }}
+        </NButton>
+        <NButton size="small" @click="handleAddToList">
+          {{ t('settings.connection.saveToList') }}
+        </NButton>
+        <NButton size="small" @click="handleReset">
+          {{ t('settings.connection.reset') }}
+        </NButton>
+      </NSpace>
+
+      <NAlert v-if="saved" type="success" :title="t('settings.connection.saved')" style="margin-top: 12px;">
+        {{ t('settings.connection.reload_hint') }}
+      </NAlert>
+
+      <!-- Saved servers list -->
+      <div v-if="servers.length > 0" class="saved-servers-section">
+        <div class="section-title">{{ t('settings.connection.savedServers') }}</div>
+        <NList bordered size="small" hoverable>
+          <NListItem v-for="server in servers" :key="server.url">
+            <div class="server-item">
+              <div class="server-info">
+                <span class="server-name">{{ server.name }}</span>
+                <code class="server-url">{{ server.url }}</code>
+              </div>
+              <div class="server-actions">
+                <NTag v-if="isActive(server.url)" type="success" size="small">
+                  {{ t('settings.connection.active') }}
+                </NTag>
+                <NButton
+                  v-else
+                  size="tiny"
+                  type="primary"
+                  quaternary
+                  @click="handleSwitchTo(server.url)"
+                >
+                  {{ t('settings.connection.switch') }}
+                </NButton>
+                <NPopconfirm @positive-click="handleRemoveFromList(server.url)">
+                  <template #trigger>
+                    <NButton size="tiny" type="error" quaternary>
+                      {{ t('common.delete') }}
+                    </NButton>
+                  </template>
+                  {{ t('settings.connection.removeConfirm') }}
+                </NPopconfirm>
+              </div>
+            </div>
+          </NListItem>
+        </NList>
+      </div>
+    </NCard>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.connection-settings {
+  max-width: 600px;
+}
+
+.setting-description {
+  color: var(--n-text-color-3);
+  font-size: 13px;
+  margin-bottom: 16px;
+  line-height: 1.5;
+}
+
+.url-input-row {
+  margin-bottom: 12px;
+}
+
+.current-url {
+  margin-bottom: 16px;
+  font-size: 13px;
+
+  .label {
+    color: var(--n-text-color-3);
+    margin-right: 4px;
+  }
+
+  code {
+    background: var(--n-code-color);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+  }
+}
+
+.saved-servers-section {
+  margin-top: 20px;
+}
+
+.section-title {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 8px;
+  color: var(--n-text-color);
+}
+
+.server-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 12px;
+}
+
+.server-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.server-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--n-text-color);
+}
+
+.server-url {
+  font-size: 11px;
+  color: var(--n-text-color-3);
+  word-break: break-all;
+}
+
+.server-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+</style>

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -77,7 +77,9 @@ function handleReloadClient() {
 }
 
 function handleLogout() {
-  localStorage.clear();
+  // Only clear auth-related keys; preserve connection, theme, locale, etc.
+  localStorage.removeItem('hermes_api_key');
+  localStorage.removeItem('hermes_active_profile_name');
   window.location.reload();
 }
 

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -12,6 +12,7 @@ export default {
     tokenLogin: 'Token',
     usernamePlaceholder: 'Benutzername',
     passwordPlaceholder: 'Passwort',
+    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
     defaultCredentialsHint: 'Standard-Benutzername: admin. Standard-Passwort: 123456.',
     credentialsRequired: 'Bitte Benutzername und Passwort eingeben',
     invalidCredentials: 'Ungultiger Benutzername oder Passwort',
@@ -72,7 +73,6 @@ export default {
       active: 'Aktiv',
       disabled: 'Deaktiviert',
     },
-  },
 
   // Common
   common: {
@@ -291,7 +291,6 @@ export default {
       completed: 'Abgeschlossen',
       failed: 'Fehlgeschlagen',
     },
-  },
 
   devices: {
     title: 'Geräte',
@@ -361,7 +360,6 @@ export default {
       desktop: 'Desktop-App',
       custom: 'Benutzerdefiniert',
     },
-  },
 
   performance: {
     title: 'Leistung',
@@ -460,7 +458,6 @@ export default {
         high: 'Hoch',
         xhigh: 'Sehr hoch',
       },
-    },
     showToolCalls: 'Tool-Aufrufe anzeigen',
     hideToolCalls: 'Tool-Aufrufe ausblenden',
     messageQueue: 'Nachrichtenwarteschlange',
@@ -602,7 +599,6 @@ export default {
       microphoneUnsupported: 'Mikrofonaufnahme wird in diesem Browser nicht unterstuetzt.',
       microphoneRecordingFailed: 'Mikrofonaufnahme fehlgeschlagen.',
     },
-  },
 
   // Jobs
   jobs: {
@@ -670,7 +666,6 @@ jobTriggered: 'Job ausgelost',
       runs: 'Läufe',
       noRuns: 'Kein Verlauf gefunden.',
     },
-  },
 
   // Skills
   skills: {
@@ -830,7 +825,6 @@ jobTriggered: 'Job ausgelost',
       scanCwd: 'Arbeitsverzeichnis scannen',
       projectPlugins: 'Projekt-Plugins',
     },
-  },
 
   // Memory
   memory: {
@@ -1089,7 +1083,6 @@ jobTriggered: 'Job ausgelost',
       profileRestarted: 'Profil neu gestartet: {name}',
       profileRestartFailed: 'Profil-Neustart fehlgeschlagen',
     },
-  },
 
   // Logs
   logs: {
@@ -1117,6 +1110,24 @@ jobTriggered: 'Job ausgelost',
       apiServer: 'API-Server',
       models: 'Modelle',
       voice: 'Sprache',
+      connection: 'Verbindung',
+    connection: {
+      title: 'Backend-Verbindung',
+      description: 'Konfigurieren Sie die Adresse des Hermes Web UI Backend-Servers. Leer lassen, um die aktuelle Seitenadresse zu verwenden.',
+      clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
+      corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
+      placeholder: 'z.B. http://192.168.1.100:6060',
+      namePlaceholder: 'Servername (optional)',
+      current: 'Aktuelle Verbindung',
+      same_origin: 'Gleicher Ursprung (aktuelle Seitenadresse)',
+      reset: 'Auf Standard zurücksetzen',
+      saved: 'Gespeichert',
+      reload_hint: 'Seite neu laden, um die neue Adresse anzuwenden.',
+      saveToList: 'Zur Liste hinzufügen',
+      savedServers: 'Gespeicherte Server',
+      active: 'Aktiv',
+      switch: 'Wechseln',
+      removeConfirm: 'Diesen Server entfernen?',
     },
     display: {
       streaming: 'Streaming-Antworten',
@@ -1537,7 +1548,6 @@ jobTriggered: 'Job ausgelost',
         token: 'API token',
         pairing: 'Device pairing',
       },
-    },
     userAvatar: {
       title: 'Benutzeravatar',
       upload: 'Bild hochladen',
@@ -1559,7 +1569,6 @@ jobTriggered: 'Job ausgelost',
       saveFailed: 'Speichern fehlgeschlagen',
       saved: 'Gespeichert',
     },
-  },
   githubPreview: {
     title: "Versionsvorschau",
     description: "Klont den ausgewählten GitHub-Tag in den Web-UI-Vorschaubereich, installiert Abhängigkeiten und startet ihn mit den Entwicklungsports.",
@@ -1670,7 +1679,6 @@ jobTriggered: 'Job ausgelost',
       claudeRun: "Print mode ist der sauberste Weg fur API-gesteuerte Einmalaufgaben.",
       codexRun: "Codex-Einmalaufgaben mussen in einem Git-Repository laufen.",
     },
-  },
 
   // Platform channel settings
   platform: {
@@ -2049,7 +2057,6 @@ jobTriggered: 'Job ausgelost',
         hours: 'vor {count} Std.',
         days: 'vor {count} Tg.',
       },
-    },
     board: {
       create: 'Neues Board',
       archive: 'Board archivieren',
@@ -2148,5 +2155,4 @@ jobTriggered: 'Job ausgelost',
       total: 'Gesamt',
       tasks: 'Aufgaben',
     },
-  },
 }

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -12,7 +12,7 @@ export default {
     tokenLogin: 'Token',
     usernamePlaceholder: 'Benutzername',
     passwordPlaceholder: 'Passwort',
-    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
+    serverHint: 'Um eine Verbindung zu einem Remote-Backend herzustellen, erweitern Sie unten, um die Serveradresse zu konfigurieren. Das Remote-Backend muss mit dem Befehl hermes-web-ui client gestartet werden.',
     defaultCredentialsHint: 'Standard-Benutzername: admin. Standard-Passwort: 123456.',
     credentialsRequired: 'Bitte Benutzername und Passwort eingeben',
     invalidCredentials: 'Ungultiger Benutzername oder Passwort',
@@ -73,6 +73,7 @@ export default {
       active: 'Aktiv',
       disabled: 'Deaktiviert',
     },
+  },
 
   // Common
   common: {
@@ -291,6 +292,7 @@ export default {
       completed: 'Abgeschlossen',
       failed: 'Fehlgeschlagen',
     },
+  },
 
   devices: {
     title: 'Geräte',
@@ -360,6 +362,7 @@ export default {
       desktop: 'Desktop-App',
       custom: 'Benutzerdefiniert',
     },
+  },
 
   performance: {
     title: 'Leistung',
@@ -458,6 +461,7 @@ export default {
         high: 'Hoch',
         xhigh: 'Sehr hoch',
       },
+    },
     showToolCalls: 'Tool-Aufrufe anzeigen',
     hideToolCalls: 'Tool-Aufrufe ausblenden',
     messageQueue: 'Nachrichtenwarteschlange',
@@ -599,6 +603,7 @@ export default {
       microphoneUnsupported: 'Mikrofonaufnahme wird in diesem Browser nicht unterstuetzt.',
       microphoneRecordingFailed: 'Mikrofonaufnahme fehlgeschlagen.',
     },
+  },
 
   // Jobs
   jobs: {
@@ -666,6 +671,7 @@ jobTriggered: 'Job ausgelost',
       runs: 'Läufe',
       noRuns: 'Kein Verlauf gefunden.',
     },
+  },
 
   // Skills
   skills: {
@@ -825,6 +831,7 @@ jobTriggered: 'Job ausgelost',
       scanCwd: 'Arbeitsverzeichnis scannen',
       projectPlugins: 'Projekt-Plugins',
     },
+  },
 
   // Memory
   memory: {
@@ -1083,6 +1090,7 @@ jobTriggered: 'Job ausgelost',
       profileRestarted: 'Profil neu gestartet: {name}',
       profileRestartFailed: 'Profil-Neustart fehlgeschlagen',
     },
+  },
 
   // Logs
   logs: {
@@ -1128,6 +1136,8 @@ jobTriggered: 'Job ausgelost',
       active: 'Aktiv',
       switch: 'Wechseln',
       removeConfirm: 'Diesen Server entfernen?',
+    },
+
     },
     display: {
       streaming: 'Streaming-Antworten',
@@ -1548,6 +1558,7 @@ jobTriggered: 'Job ausgelost',
         token: 'API token',
         pairing: 'Device pairing',
       },
+    },
     userAvatar: {
       title: 'Benutzeravatar',
       upload: 'Bild hochladen',
@@ -1569,6 +1580,7 @@ jobTriggered: 'Job ausgelost',
       saveFailed: 'Speichern fehlgeschlagen',
       saved: 'Gespeichert',
     },
+  },
   githubPreview: {
     title: "Versionsvorschau",
     description: "Klont den ausgewählten GitHub-Tag in den Web-UI-Vorschaubereich, installiert Abhängigkeiten und startet ihn mit den Entwicklungsports.",
@@ -1679,6 +1691,7 @@ jobTriggered: 'Job ausgelost',
       claudeRun: "Print mode ist der sauberste Weg fur API-gesteuerte Einmalaufgaben.",
       codexRun: "Codex-Einmalaufgaben mussen in einem Git-Repository laufen.",
     },
+  },
 
   // Platform channel settings
   platform: {
@@ -2057,6 +2070,7 @@ jobTriggered: 'Job ausgelost',
         hours: 'vor {count} Std.',
         days: 'vor {count} Tg.',
       },
+    },
     board: {
       create: 'Neues Board',
       archive: 'Board archivieren',
@@ -2155,4 +2169,5 @@ jobTriggered: 'Job ausgelost',
       total: 'Gesamt',
       tasks: 'Aufgaben',
     },
+  },
 }

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -73,6 +73,7 @@ export default {
       active: 'Active',
       disabled: 'Disabled',
     },
+  },
 
   // Common
   common: {
@@ -291,6 +292,7 @@ export default {
       completed: 'Completed',
       failed: 'Failed',
     },
+  },
 
   devices: {
     title: 'Devices',
@@ -360,6 +362,7 @@ export default {
       desktop: 'Desktop',
       custom: 'Custom',
     },
+  },
 
   performance: {
     title: 'Performance',
@@ -462,6 +465,7 @@ export default {
         high: 'High',
         xhigh: 'Extra high',
       },
+    },
     autoPlaySpeech: 'Auto-play voice',
     voiceInput: {
       startCapture: 'Start voice capture',
@@ -677,6 +681,7 @@ export default {
         hours: '{count}h ago',
         days: '{count}d ago',
       },
+    },
     detail: {
       status: 'Status',
       assignee: 'Assignee',
@@ -734,6 +739,7 @@ export default {
       total: 'Total',
       tasks: 'Tasks',
     },
+  },
 
   // Jobs
   jobs: {
@@ -801,6 +807,7 @@ export default {
       runs: 'runs',
       noRuns: 'No run history found.',
     },
+  },
 
   // Skills
   skills: {
@@ -960,6 +967,7 @@ export default {
       scanCwd: 'Scan cwd',
       projectPlugins: 'Project plugins',
     },
+  },
 
   // Memory
   memory: {
@@ -1226,6 +1234,7 @@ export default {
       profileRestarted: 'Profile restarted: {name}',
       profileRestartFailed: 'Failed to restart profile',
     },
+  },
 
   // Logs
   logs: {
@@ -1254,6 +1263,14 @@ export default {
       models: 'Models',
       voice: 'Voice',
       connection: 'Connection',
+    },
+    models: {
+      apiKey: 'API Key',
+      apiKeyPlaceholder: 'Enter API key',
+      save: 'Save',
+      saved: 'Saved',
+      saveFailed: 'Save failed',
+      noProviders: 'No providers configured',
     connection: {
       title: 'Backend Connection',
       description: 'Configure the Hermes Web UI backend server address. Leave empty to use the current page origin.',
@@ -1272,13 +1289,7 @@ export default {
       switch: 'Switch',
       removeConfirm: 'Remove this server?',
     },
-    models: {
-      apiKey: 'API Key',
-      apiKeyPlaceholder: 'Enter API key',
-      save: 'Save',
-      saved: 'Saved',
-      saveFailed: 'Save failed',
-      noProviders: 'No providers configured',
+
     },
     display: {
       streaming: 'Stream Responses',
@@ -1439,6 +1450,7 @@ export default {
         token: 'API token',
         pairing: 'Device pairing',
       },
+    },
     userAvatar: {
       title: 'User Avatar',
       upload: 'Upload Image',
@@ -1711,6 +1723,7 @@ export default {
       mimoStylePromptHint: 'Optional — describe the speaking style in natural language',
       mimoStylePromptPlaceholder: 'e.g., Bright and bouncy tone, fast pace',
     },
+  },
   githubPreview: {
     title: "Version Preview",
     description: "Clone a selected GitHub tag into the Web UI preview workspace, install dependencies, and run it with the development ports.",
@@ -1821,6 +1834,7 @@ export default {
       claudeRun: "Print mode is the cleanest path for API-driven one-shot tasks.",
       codexRun: "Codex one-shot tasks must run inside a git repository.",
     },
+  },
 
   // Platform channel settings
   platform: {

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -12,6 +12,7 @@ export default {
     tokenLogin: 'Token',
     usernamePlaceholder: 'Username',
     passwordPlaceholder: 'Password',
+    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
     defaultCredentialsHint: 'Default username: admin. Default password: 123456.',
     credentialsRequired: 'Please enter username and password',
     invalidCredentials: 'Invalid username or password',
@@ -72,7 +73,6 @@ export default {
       active: 'Active',
       disabled: 'Disabled',
     },
-  },
 
   // Common
   common: {
@@ -291,7 +291,6 @@ export default {
       completed: 'Completed',
       failed: 'Failed',
     },
-  },
 
   devices: {
     title: 'Devices',
@@ -361,7 +360,6 @@ export default {
       desktop: 'Desktop',
       custom: 'Custom',
     },
-  },
 
   performance: {
     title: 'Performance',
@@ -464,7 +462,6 @@ export default {
         high: 'High',
         xhigh: 'Extra high',
       },
-    },
     autoPlaySpeech: 'Auto-play voice',
     voiceInput: {
       startCapture: 'Start voice capture',
@@ -680,7 +677,6 @@ export default {
         hours: '{count}h ago',
         days: '{count}d ago',
       },
-    },
     detail: {
       status: 'Status',
       assignee: 'Assignee',
@@ -738,7 +734,6 @@ export default {
       total: 'Total',
       tasks: 'Tasks',
     },
-  },
 
   // Jobs
   jobs: {
@@ -806,7 +801,6 @@ export default {
       runs: 'runs',
       noRuns: 'No run history found.',
     },
-  },
 
   // Skills
   skills: {
@@ -966,7 +960,6 @@ export default {
       scanCwd: 'Scan cwd',
       projectPlugins: 'Project plugins',
     },
-  },
 
   // Memory
   memory: {
@@ -1233,7 +1226,6 @@ export default {
       profileRestarted: 'Profile restarted: {name}',
       profileRestartFailed: 'Failed to restart profile',
     },
-  },
 
   // Logs
   logs: {
@@ -1261,6 +1253,24 @@ export default {
       apiServer: 'API Server',
       models: 'Models',
       voice: 'Voice',
+      connection: 'Connection',
+    connection: {
+      title: 'Backend Connection',
+      description: 'Configure the Hermes Web UI backend server address. Leave empty to use the current page origin.',
+      clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
+      corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
+      placeholder: 'e.g. http://192.168.1.100:6060',
+      namePlaceholder: 'Server name (optional)',
+      current: 'Current connection',
+      same_origin: 'Same origin (current page address)',
+      reset: 'Reset to default',
+      saved: 'Saved',
+      reload_hint: 'Reload the page to apply the new address.',
+      saveToList: 'Add to saved list',
+      savedServers: 'Saved Servers',
+      active: 'Active',
+      switch: 'Switch',
+      removeConfirm: 'Remove this server?',
     },
     models: {
       apiKey: 'API Key',
@@ -1429,7 +1439,6 @@ export default {
         token: 'API token',
         pairing: 'Device pairing',
       },
-    },
     userAvatar: {
       title: 'User Avatar',
       upload: 'Upload Image',
@@ -1702,7 +1711,6 @@ export default {
       mimoStylePromptHint: 'Optional — describe the speaking style in natural language',
       mimoStylePromptPlaceholder: 'e.g., Bright and bouncy tone, fast pace',
     },
-  },
   githubPreview: {
     title: "Version Preview",
     description: "Clone a selected GitHub tag into the Web UI preview workspace, install dependencies, and run it with the development ports.",
@@ -1813,7 +1821,6 @@ export default {
       claudeRun: "Print mode is the cleanest path for API-driven one-shot tasks.",
       codexRun: "Codex one-shot tasks must run inside a git repository.",
     },
-  },
 
   // Platform channel settings
   platform: {

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -12,6 +12,7 @@ export default {
     tokenLogin: 'Token',
     usernamePlaceholder: 'Nombre de usuario',
     passwordPlaceholder: 'Contrasena',
+    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
     defaultCredentialsHint: 'Nombre de usuario predeterminado: admin. Contrasena predeterminada: 123456.',
     credentialsRequired: 'Por favor, introduzca nombre de usuario y contrasena',
     invalidCredentials: 'Nombre de usuario o contrasena incorrectos',
@@ -72,7 +73,6 @@ export default {
       active: 'Activo',
       disabled: 'Desactivado',
     },
-  },
 
   // Common
   common: {
@@ -291,7 +291,6 @@ export default {
       completed: 'Completada',
       failed: 'Fallida',
     },
-  },
 
   devices: {
     title: 'Dispositivos',
@@ -361,7 +360,6 @@ export default {
       desktop: 'Escritorio',
       custom: 'Personalizado',
     },
-  },
 
   performance: {
     title: 'Rendimiento',
@@ -460,7 +458,6 @@ export default {
         high: 'Alto',
         xhigh: 'Extra alto',
       },
-    },
     showToolCalls: 'Mostrar llamadas de herramientas',
     hideToolCalls: 'Ocultar llamadas de herramientas',
     messageQueue: 'Cola de mensajes',
@@ -602,7 +599,6 @@ export default {
       microphoneUnsupported: 'La captura de microfono no es compatible con este navegador.',
       microphoneRecordingFailed: 'Fallo la grabacion del microfono.',
     },
-  },
 
   // Jobs
   jobs: {
@@ -670,7 +666,6 @@ jobTriggered: 'Job ejecutado',
       runs: 'ejecuciones',
       noRuns: 'No se encontró historial.',
     },
-  },
 
   // Skills
   skills: {
@@ -830,7 +825,6 @@ jobTriggered: 'Job ejecutado',
       scanCwd: 'Escanear cwd',
       projectPlugins: 'Plugins del proyecto',
     },
-  },
 
   // Memory
   memory: {
@@ -1089,7 +1083,6 @@ jobTriggered: 'Job ejecutado',
       profileRestarted: 'Perfil reiniciado: {name}',
       profileRestartFailed: 'No se pudo reiniciar el perfil',
     },
-  },
 
   // Logs
   logs: {
@@ -1117,6 +1110,24 @@ jobTriggered: 'Job ejecutado',
       apiServer: 'Servidor API',
       models: 'Modelos',
       voice: 'Voz',
+      connection: 'Conexión',
+    connection: {
+      title: 'Conexión del backend',
+      description: 'Configure la dirección del servidor backend de Hermes Web UI. Déjelo vacío para usar la dirección de la página actual.',
+      clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
+      corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
+      placeholder: 'ej. http://192.168.1.100:6060',
+      namePlaceholder: 'Nombre del servidor (opcional)',
+      current: 'Conexión actual',
+      same_origin: 'Mismo origen (dirección de la página actual)',
+      reset: 'Restablecer por defecto',
+      saved: 'Guardado',
+      reload_hint: 'Recargue la página para aplicar la nueva dirección.',
+      saveToList: 'Agregar a la lista',
+      savedServers: 'Servidores guardados',
+      active: 'Activo',
+      switch: 'Cambiar',
+      removeConfirm: '¿Eliminar este servidor?',
     },
     display: {
       streaming: 'Respuestas en streaming',
@@ -1537,7 +1548,6 @@ jobTriggered: 'Job ejecutado',
         token: 'API token',
         pairing: 'Device pairing',
       },
-    },
     userAvatar: {
       title: 'Avatar de usuario',
       upload: 'Subir imagen',
@@ -1559,7 +1569,6 @@ jobTriggered: 'Job ejecutado',
       saveFailed: 'Error al guardar',
       saved: 'Guardado',
     },
-  },
   githubPreview: {
     title: "Vista previa de versión",
     description: "Clona el tag de GitHub seleccionado en el espacio de vista previa de Web UI, instala dependencias y lo ejecuta con los puertos de desarrollo.",
@@ -1670,7 +1679,6 @@ jobTriggered: 'Job ejecutado',
       claudeRun: "Print mode es la ruta más limpia para tareas únicas impulsadas por API.",
       codexRun: "Las tareas únicas de Codex deben ejecutarse dentro de un repositorio git.",
     },
-  },
 
   // Platform channel settings
   platform: {
@@ -2049,7 +2057,6 @@ jobTriggered: 'Job ejecutado',
         hours: 'hace {count} h',
         days: 'hace {count} d',
       },
-    },
     board: {
       create: 'Nuevo tablero',
       archive: 'Archivar tablero',
@@ -2148,5 +2155,4 @@ jobTriggered: 'Job ejecutado',
       total: 'Total',
       tasks: 'Tareas',
     },
-  },
 }

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -12,7 +12,7 @@ export default {
     tokenLogin: 'Token',
     usernamePlaceholder: 'Nombre de usuario',
     passwordPlaceholder: 'Contrasena',
-    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
+    serverHint: 'Para conectarse a un backend remoto, expanda a continuación para configurar la dirección del servidor. El backend remoto debe ejecutarse con el comando hermes-web-ui client.',
     defaultCredentialsHint: 'Nombre de usuario predeterminado: admin. Contrasena predeterminada: 123456.',
     credentialsRequired: 'Por favor, introduzca nombre de usuario y contrasena',
     invalidCredentials: 'Nombre de usuario o contrasena incorrectos',
@@ -73,6 +73,7 @@ export default {
       active: 'Activo',
       disabled: 'Desactivado',
     },
+  },
 
   // Common
   common: {
@@ -291,6 +292,7 @@ export default {
       completed: 'Completada',
       failed: 'Fallida',
     },
+  },
 
   devices: {
     title: 'Dispositivos',
@@ -360,6 +362,7 @@ export default {
       desktop: 'Escritorio',
       custom: 'Personalizado',
     },
+  },
 
   performance: {
     title: 'Rendimiento',
@@ -458,6 +461,7 @@ export default {
         high: 'Alto',
         xhigh: 'Extra alto',
       },
+    },
     showToolCalls: 'Mostrar llamadas de herramientas',
     hideToolCalls: 'Ocultar llamadas de herramientas',
     messageQueue: 'Cola de mensajes',
@@ -599,6 +603,7 @@ export default {
       microphoneUnsupported: 'La captura de microfono no es compatible con este navegador.',
       microphoneRecordingFailed: 'Fallo la grabacion del microfono.',
     },
+  },
 
   // Jobs
   jobs: {
@@ -666,6 +671,7 @@ jobTriggered: 'Job ejecutado',
       runs: 'ejecuciones',
       noRuns: 'No se encontró historial.',
     },
+  },
 
   // Skills
   skills: {
@@ -825,6 +831,7 @@ jobTriggered: 'Job ejecutado',
       scanCwd: 'Escanear cwd',
       projectPlugins: 'Plugins del proyecto',
     },
+  },
 
   // Memory
   memory: {
@@ -1083,6 +1090,7 @@ jobTriggered: 'Job ejecutado',
       profileRestarted: 'Perfil reiniciado: {name}',
       profileRestartFailed: 'No se pudo reiniciar el perfil',
     },
+  },
 
   // Logs
   logs: {
@@ -1113,7 +1121,7 @@ jobTriggered: 'Job ejecutado',
       connection: 'Conexión',
     connection: {
       title: 'Conexión del backend',
-      description: 'Configure la dirección del servidor backend de Hermes Web UI. Déjelo vacío para usar la dirección de la página actual.',
+      description: 'Configure la dirección del servidor backend de Hermes Web UI. Deje vacío para usar la dirección de la página actual.',
       clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
       corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
       placeholder: 'ej. http://192.168.1.100:6060',
@@ -1128,6 +1136,8 @@ jobTriggered: 'Job ejecutado',
       active: 'Activo',
       switch: 'Cambiar',
       removeConfirm: '¿Eliminar este servidor?',
+    },
+
     },
     display: {
       streaming: 'Respuestas en streaming',
@@ -1548,6 +1558,7 @@ jobTriggered: 'Job ejecutado',
         token: 'API token',
         pairing: 'Device pairing',
       },
+    },
     userAvatar: {
       title: 'Avatar de usuario',
       upload: 'Subir imagen',
@@ -1569,6 +1580,7 @@ jobTriggered: 'Job ejecutado',
       saveFailed: 'Error al guardar',
       saved: 'Guardado',
     },
+  },
   githubPreview: {
     title: "Vista previa de versión",
     description: "Clona el tag de GitHub seleccionado en el espacio de vista previa de Web UI, instala dependencias y lo ejecuta con los puertos de desarrollo.",
@@ -1679,6 +1691,7 @@ jobTriggered: 'Job ejecutado',
       claudeRun: "Print mode es la ruta más limpia para tareas únicas impulsadas por API.",
       codexRun: "Las tareas únicas de Codex deben ejecutarse dentro de un repositorio git.",
     },
+  },
 
   // Platform channel settings
   platform: {
@@ -2057,6 +2070,7 @@ jobTriggered: 'Job ejecutado',
         hours: 'hace {count} h',
         days: 'hace {count} d',
       },
+    },
     board: {
       create: 'Nuevo tablero',
       archive: 'Archivar tablero',
@@ -2155,4 +2169,5 @@ jobTriggered: 'Job ejecutado',
       total: 'Total',
       tasks: 'Tareas',
     },
+  },
 }

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -12,6 +12,7 @@ export default {
     tokenLogin: 'Jeton',
     usernamePlaceholder: 'Nom d\'utilisateur',
     passwordPlaceholder: 'Mot de passe',
+    homeserverHint: 'URL du serveur domestique Matrix',
     defaultCredentialsHint: 'Nom d utilisateur par defaut : admin. Mot de passe par defaut : 123456.',
     credentialsRequired: 'Veuillez entrer le nom d\'utilisateur et le mot de passe',
     invalidCredentials: 'Nom d\'utilisateur ou mot de passe incorrect',
@@ -72,7 +73,6 @@ export default {
       active: 'Actif',
       disabled: 'Desactive',
     },
-  },
 
   // Common
   common: {
@@ -291,7 +291,6 @@ export default {
       completed: 'Terminé',
       failed: 'Échec',
     },
-  },
 
   devices: {
     title: 'Appareils',
@@ -361,7 +360,6 @@ export default {
       desktop: 'Bureau',
       custom: 'Personnalisé',
     },
-  },
 
   performance: {
     title: 'Performance',
@@ -460,7 +458,6 @@ export default {
         high: 'Élevé',
         xhigh: 'Très élevé',
       },
-    },
     showToolCalls: 'Afficher les appels d’outils',
     hideToolCalls: 'Masquer les appels d’outils',
     messageQueue: 'File de messages',
@@ -602,7 +599,6 @@ export default {
       microphoneUnsupported: 'La capture micro n est pas prise en charge par ce navigateur.',
       microphoneRecordingFailed: 'L enregistrement micro a echoue.',
     },
-  },
 
   // Jobs
   jobs: {
@@ -670,7 +666,6 @@ jobTriggered: 'Job declenche',
       runs: 'exécutions',
       noRuns: 'Aucun historique trouvé.',
     },
-  },
 
   // Skills
   skills: {
@@ -830,7 +825,6 @@ jobTriggered: 'Job declenche',
       scanCwd: 'Analyser cwd',
       projectPlugins: 'Plugins du projet',
     },
-  },
 
   // Memory
   memory: {
@@ -1089,7 +1083,6 @@ jobTriggered: 'Job declenche',
       profileRestarted: 'Profil redémarré : {name}',
       profileRestartFailed: 'Échec du redémarrage du profil',
     },
-  },
 
   // Logs
   logs: {
@@ -1117,6 +1110,24 @@ jobTriggered: 'Job declenche',
       apiServer: 'Serveur API',
       models: 'Modèles',
       voice: 'Voix',
+      connection: 'Connexion',
+    connection: {
+      title: 'Connexion backend',
+      description: "Configurez l'adresse du serveur backend Hermes Web UI. Laissez vide pour utiliser l'adresse de la page actuelle.",
+      clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
+      corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
+      placeholder: 'ex. http://192.168.1.100:6060',
+      namePlaceholder: 'Nom du serveur (optionnel)',
+      current: 'Connexion actuelle',
+      same_origin: 'Même origine (adresse de la page actuelle)',
+      reset: 'Réinitialiser par défaut',
+      saved: 'Enregistré',
+      reload_hint: "Rechargez la page pour appliquer la nouvelle adresse.",
+      saveToList: 'Ajouter à la liste',
+      savedServers: 'Serveurs enregistrés',
+      active: 'Actif',
+      switch: 'Basculer',
+      removeConfirm: 'Supprimer ce serveur ?',
     },
     display: {
       streaming: 'Reponses en continu',
@@ -1537,7 +1548,6 @@ jobTriggered: 'Job declenche',
         token: 'API token',
         pairing: 'Device pairing',
       },
-    },
     userAvatar: {
       title: 'Avatar utilisateur',
       upload: 'Importer une image',
@@ -1559,7 +1569,6 @@ jobTriggered: 'Job declenche',
       saveFailed: 'Échec de l’enregistrement',
       saved: 'Enregistré',
     },
-  },
   githubPreview: {
     title: "Aperçu de version",
     description: "Clone le tag GitHub sélectionné dans l’espace de prévisualisation Web UI, installe les dépendances, puis lance l’application sur les ports de développement.",
@@ -1670,7 +1679,6 @@ jobTriggered: 'Job declenche',
       claudeRun: "Print mode est le chemin le plus propre pour les tâches ponctuelles pilotées par API.",
       codexRun: "Les tâches ponctuelles Codex doivent s’exécuter dans un dépôt git.",
     },
-  },
 
   // Platform channel settings
   platform: {
@@ -2049,7 +2057,6 @@ jobTriggered: 'Job declenche',
         hours: 'il y a {count} h',
         days: 'il y a {count} j',
       },
-    },
     board: {
       create: 'Nouveau tableau',
       archive: 'Archiver le tableau',
@@ -2148,5 +2155,4 @@ jobTriggered: 'Job declenche',
       total: 'Total',
       tasks: 'Tâches',
     },
-  },
 }

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -12,7 +12,7 @@ export default {
     tokenLogin: 'Jeton',
     usernamePlaceholder: 'Nom d\'utilisateur',
     passwordPlaceholder: 'Mot de passe',
-    homeserverHint: 'URL du serveur domestique Matrix',
+    serverHint: "Pour vous connecter à un backend distant, développez ci-dessous pour configurer l'adresse du serveur. Le backend distant doit être exécuté avec la commande hermes-web-ui client.",
     defaultCredentialsHint: 'Nom d utilisateur par defaut : admin. Mot de passe par defaut : 123456.',
     credentialsRequired: 'Veuillez entrer le nom d\'utilisateur et le mot de passe',
     invalidCredentials: 'Nom d\'utilisateur ou mot de passe incorrect',
@@ -73,6 +73,7 @@ export default {
       active: 'Actif',
       disabled: 'Desactive',
     },
+  },
 
   // Common
   common: {
@@ -291,6 +292,7 @@ export default {
       completed: 'Terminé',
       failed: 'Échec',
     },
+  },
 
   devices: {
     title: 'Appareils',
@@ -360,6 +362,7 @@ export default {
       desktop: 'Bureau',
       custom: 'Personnalisé',
     },
+  },
 
   performance: {
     title: 'Performance',
@@ -458,6 +461,7 @@ export default {
         high: 'Élevé',
         xhigh: 'Très élevé',
       },
+    },
     showToolCalls: 'Afficher les appels d’outils',
     hideToolCalls: 'Masquer les appels d’outils',
     messageQueue: 'File de messages',
@@ -599,6 +603,7 @@ export default {
       microphoneUnsupported: 'La capture micro n est pas prise en charge par ce navigateur.',
       microphoneRecordingFailed: 'L enregistrement micro a echoue.',
     },
+  },
 
   // Jobs
   jobs: {
@@ -666,6 +671,7 @@ jobTriggered: 'Job declenche',
       runs: 'exécutions',
       noRuns: 'Aucun historique trouvé.',
     },
+  },
 
   // Skills
   skills: {
@@ -825,6 +831,7 @@ jobTriggered: 'Job declenche',
       scanCwd: 'Analyser cwd',
       projectPlugins: 'Plugins du projet',
     },
+  },
 
   // Memory
   memory: {
@@ -1083,6 +1090,7 @@ jobTriggered: 'Job declenche',
       profileRestarted: 'Profil redémarré : {name}',
       profileRestartFailed: 'Échec du redémarrage du profil',
     },
+  },
 
   // Logs
   logs: {
@@ -1119,15 +1127,17 @@ jobTriggered: 'Job declenche',
       placeholder: 'ex. http://192.168.1.100:6060',
       namePlaceholder: 'Nom du serveur (optionnel)',
       current: 'Connexion actuelle',
-      same_origin: 'Même origine (adresse de la page actuelle)',
+      same_origin: "Même origine (adresse de la page actuelle)",
       reset: 'Réinitialiser par défaut',
       saved: 'Enregistré',
-      reload_hint: "Rechargez la page pour appliquer la nouvelle adresse.",
+      reload_hint: 'Rechargez la page pour appliquer la nouvelle adresse.',
       saveToList: 'Ajouter à la liste',
       savedServers: 'Serveurs enregistrés',
       active: 'Actif',
       switch: 'Basculer',
       removeConfirm: 'Supprimer ce serveur ?',
+    },
+
     },
     display: {
       streaming: 'Reponses en continu',
@@ -1548,6 +1558,7 @@ jobTriggered: 'Job declenche',
         token: 'API token',
         pairing: 'Device pairing',
       },
+    },
     userAvatar: {
       title: 'Avatar utilisateur',
       upload: 'Importer une image',
@@ -1569,6 +1580,7 @@ jobTriggered: 'Job declenche',
       saveFailed: 'Échec de l’enregistrement',
       saved: 'Enregistré',
     },
+  },
   githubPreview: {
     title: "Aperçu de version",
     description: "Clone le tag GitHub sélectionné dans l’espace de prévisualisation Web UI, installe les dépendances, puis lance l’application sur les ports de développement.",
@@ -1679,6 +1691,7 @@ jobTriggered: 'Job declenche',
       claudeRun: "Print mode est le chemin le plus propre pour les tâches ponctuelles pilotées par API.",
       codexRun: "Les tâches ponctuelles Codex doivent s’exécuter dans un dépôt git.",
     },
+  },
 
   // Platform channel settings
   platform: {
@@ -2057,6 +2070,7 @@ jobTriggered: 'Job declenche',
         hours: 'il y a {count} h',
         days: 'il y a {count} j',
       },
+    },
     board: {
       create: 'Nouveau tableau',
       archive: 'Archiver le tableau',
@@ -2155,4 +2169,5 @@ jobTriggered: 'Job declenche',
       total: 'Total',
       tasks: 'Tâches',
     },
+  },
 }

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -12,7 +12,7 @@ export default {
     tokenLogin: 'トークン',
     usernamePlaceholder: 'ユーザー名',
     passwordPlaceholder: 'パスワード',
-    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
+    serverHint: 'リモートバックエンドに接続するには、以下を展開してサーバーアドレスを設定します。リモートバックエンドは hermes-web-ui client コマンドで実行されている必要があります。',
     defaultCredentialsHint: '既定のユーザー名：admin、既定のパスワード：123456',
     credentialsRequired: 'ユーザー名とパスワードを入力してください',
     invalidCredentials: 'ユーザー名またはパスワードが正しくありません',
@@ -73,6 +73,7 @@ export default {
       active: '有効',
       disabled: '無効',
     },
+  },
 
   // 共通
   common: {
@@ -291,6 +292,7 @@ export default {
       completed: '完了',
       failed: '失敗',
     },
+  },
 
   devices: {
     title: 'デバイス',
@@ -360,6 +362,7 @@ export default {
       desktop: 'デスクトップ',
       custom: 'カスタム',
     },
+  },
 
   performance: {
     title: 'パフォーマンス',
@@ -458,6 +461,7 @@ export default {
         high: '高',
         xhigh: '最高',
       },
+    },
     showToolCalls: 'ツール呼び出しを表示',
     hideToolCalls: 'ツール呼び出しを非表示',
     messageQueue: 'メッセージキュー',
@@ -599,6 +603,7 @@ export default {
       microphoneUnsupported: 'このブラウザはマイク録音に対応していません。',
       microphoneRecordingFailed: 'マイク録音に失敗しました。',
     },
+  },
 
   // スケジュールジョブ
   jobs: {
@@ -666,6 +671,7 @@ export default {
       runs: '件',
       noRuns: '実行履歴がありません。',
     },
+  },
 
   // スキル
   skills: {
@@ -825,6 +831,7 @@ export default {
       scanCwd: 'cwd をスキャン',
       projectPlugins: 'プロジェクトプラグイン',
     },
+  },
 
   // メモリ
   memory: {
@@ -1083,6 +1090,7 @@ export default {
       profileRestarted: 'プロファイルを再起動しました: {name}',
       profileRestartFailed: 'プロファイルの再起動に失敗しました',
     },
+  },
 
   // ログ
   logs: {
@@ -1117,17 +1125,19 @@ export default {
       clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
       corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
       placeholder: '例: http://192.168.1.100:6060',
-      namePlaceholder: 'サーバー名（任意）',
+      namePlaceholder: 'サーバー名（オプション）',
       current: '現在の接続',
-      same_origin: '同源（現在のページアドレス）',
-      reset: 'デフォルトに戻す',
+      same_origin: '同一オリジン（現在のページアドレス）',
+      reset: 'デフォルトにリセット',
       saved: '保存済み',
-      reload_hint: 'ページを再読み込みして新しいアドレスを適用します。',
+      reload_hint: '新しいアドレスを適用するにはページを再読み込みしてください。',
       saveToList: 'リストに追加',
       savedServers: '保存されたサーバー',
       active: 'アクティブ',
       switch: '切り替え',
       removeConfirm: 'このサーバーを削除しますか？',
+    },
+
     },
     display: {
       streaming: 'ストリームレスポンス',
@@ -1548,6 +1558,7 @@ export default {
         token: 'API token',
         pairing: 'Device pairing',
       },
+    },
     userAvatar: {
       title: 'ユーザーアバター',
       upload: '画像をアップロード',
@@ -1569,6 +1580,7 @@ export default {
       saveFailed: '保存に失敗しました',
       saved: '保存しました',
     },
+  },
   githubPreview: {
     title: "バージョンプレビュー",
     description: "選択した GitHub tag を Web UI のプレビュー作業ディレクトリへクローンし、依存関係をインストールして開発ポートで起動します。",
@@ -1679,6 +1691,7 @@ export default {
       claudeRun: "API 駆動の単発タスクには print mode が最も素直な経路です。",
       codexRun: "Codex の単発タスクは git リポジトリ内で実行する必要があります。",
     },
+  },
 
   platform: {
     requireMention: "メンションが必要",
@@ -2056,6 +2069,7 @@ export default {
         hours: '{count}時間前',
         days: '{count}日前',
       },
+    },
     board: {
       create: '新規ボード',
       archive: 'ボードをアーカイブ',
@@ -2154,4 +2168,5 @@ export default {
       total: '合計',
       tasks: 'タスク数',
     },
+  },
 }

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -12,6 +12,7 @@ export default {
     tokenLogin: 'トークン',
     usernamePlaceholder: 'ユーザー名',
     passwordPlaceholder: 'パスワード',
+    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
     defaultCredentialsHint: '既定のユーザー名：admin、既定のパスワード：123456',
     credentialsRequired: 'ユーザー名とパスワードを入力してください',
     invalidCredentials: 'ユーザー名またはパスワードが正しくありません',
@@ -72,7 +73,6 @@ export default {
       active: '有効',
       disabled: '無効',
     },
-  },
 
   // 共通
   common: {
@@ -291,7 +291,6 @@ export default {
       completed: '完了',
       failed: '失敗',
     },
-  },
 
   devices: {
     title: 'デバイス',
@@ -361,7 +360,6 @@ export default {
       desktop: 'デスクトップ',
       custom: 'カスタム',
     },
-  },
 
   performance: {
     title: 'パフォーマンス',
@@ -460,7 +458,6 @@ export default {
         high: '高',
         xhigh: '最高',
       },
-    },
     showToolCalls: 'ツール呼び出しを表示',
     hideToolCalls: 'ツール呼び出しを非表示',
     messageQueue: 'メッセージキュー',
@@ -602,7 +599,6 @@ export default {
       microphoneUnsupported: 'このブラウザはマイク録音に対応していません。',
       microphoneRecordingFailed: 'マイク録音に失敗しました。',
     },
-  },
 
   // スケジュールジョブ
   jobs: {
@@ -670,7 +666,6 @@ export default {
       runs: '件',
       noRuns: '実行履歴がありません。',
     },
-  },
 
   // スキル
   skills: {
@@ -830,7 +825,6 @@ export default {
       scanCwd: 'cwd をスキャン',
       projectPlugins: 'プロジェクトプラグイン',
     },
-  },
 
   // メモリ
   memory: {
@@ -1089,7 +1083,6 @@ export default {
       profileRestarted: 'プロファイルを再起動しました: {name}',
       profileRestartFailed: 'プロファイルの再起動に失敗しました',
     },
-  },
 
   // ログ
   logs: {
@@ -1117,6 +1110,24 @@ export default {
       apiServer: 'API サーバー',
       models: 'モデル',
       voice: '音声',
+      connection: '接続',
+    connection: {
+      title: 'バックエンド接続',
+      description: 'Hermes Web UI バックエンドサーバーのアドレスを設定します。空にすると現在のページアドレスを使用します。',
+      clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
+      corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
+      placeholder: '例: http://192.168.1.100:6060',
+      namePlaceholder: 'サーバー名（任意）',
+      current: '現在の接続',
+      same_origin: '同源（現在のページアドレス）',
+      reset: 'デフォルトに戻す',
+      saved: '保存済み',
+      reload_hint: 'ページを再読み込みして新しいアドレスを適用します。',
+      saveToList: 'リストに追加',
+      savedServers: '保存されたサーバー',
+      active: 'アクティブ',
+      switch: '切り替え',
+      removeConfirm: 'このサーバーを削除しますか？',
     },
     display: {
       streaming: 'ストリームレスポンス',
@@ -1537,7 +1548,6 @@ export default {
         token: 'API token',
         pairing: 'Device pairing',
       },
-    },
     userAvatar: {
       title: 'ユーザーアバター',
       upload: '画像をアップロード',
@@ -1559,7 +1569,6 @@ export default {
       saveFailed: '保存に失敗しました',
       saved: '保存しました',
     },
-  },
   githubPreview: {
     title: "バージョンプレビュー",
     description: "選択した GitHub tag を Web UI のプレビュー作業ディレクトリへクローンし、依存関係をインストールして開発ポートで起動します。",
@@ -1670,7 +1679,6 @@ export default {
       claudeRun: "API 駆動の単発タスクには print mode が最も素直な経路です。",
       codexRun: "Codex の単発タスクは git リポジトリ内で実行する必要があります。",
     },
-  },
 
   platform: {
     requireMention: "メンションが必要",
@@ -2048,7 +2056,6 @@ export default {
         hours: '{count}時間前',
         days: '{count}日前',
       },
-    },
     board: {
       create: '新規ボード',
       archive: 'ボードをアーカイブ',
@@ -2147,5 +2154,4 @@ export default {
       total: '合計',
       tasks: 'タスク数',
     },
-  },
 }

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -12,7 +12,7 @@ export default {
     tokenLogin: '토큰',
     usernamePlaceholder: '사용자 이름',
     passwordPlaceholder: '비밀번호',
-    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
+    serverHint: '원격 백엔드에 연결하려면 아래를 펼쳐 서버 주소를 구성하세요. 원격 백엔드는 hermes-web-ui client 명령으로 실행되어야 합니다.',
     defaultCredentialsHint: '기본 로그인 이름: admin, 기본 비밀번호: 123456',
     credentialsRequired: '사용자 이름과 비밀번호를 입력해 주세요',
     invalidCredentials: '사용자 이름 또는 비밀번호가 올바르지 않습니다',
@@ -73,6 +73,7 @@ export default {
       active: '활성',
       disabled: '비활성',
     },
+  },
 
   // 공통
   common: {
@@ -291,6 +292,7 @@ export default {
       completed: '완료',
       failed: '실패',
     },
+  },
 
   devices: {
     title: '기기',
@@ -360,6 +362,7 @@ export default {
       desktop: '데스크톱',
       custom: '사용자 지정',
     },
+  },
 
   performance: {
     title: '성능 모니터링',
@@ -458,6 +461,7 @@ export default {
         high: '높음',
         xhigh: '매우 높음',
       },
+    },
     showToolCalls: '도구 호출 표시',
     hideToolCalls: '도구 호출 숨기기',
     messageQueue: '메시지 대기열',
@@ -599,6 +603,7 @@ export default {
       microphoneUnsupported: '이 브라우저는 마이크 녹음을 지원하지 않습니다.',
       microphoneRecordingFailed: '마이크 녹음에 실패했습니다.',
     },
+  },
 
   // 예약 작업
   jobs: {
@@ -666,6 +671,7 @@ export default {
       runs: '회 실행',
       noRuns: '실행 기록이 없습니다.',
     },
+  },
 
   // 스킬
   skills: {
@@ -825,6 +831,7 @@ export default {
       scanCwd: 'cwd 스캔',
       projectPlugins: '프로젝트 플러그인',
     },
+  },
 
   // 메모리
   memory: {
@@ -1083,6 +1090,7 @@ export default {
       profileRestarted: '프로필이 재시작되었습니다: {name}',
       profileRestartFailed: '프로필 재시작 실패',
     },
+  },
 
   // 로그
   logs: {
@@ -1113,21 +1121,23 @@ export default {
       connection: '연결',
     connection: {
       title: '백엔드 연결',
-      description: 'Hermes Web UI 백엔드 서버 주소를 설정합니다. 비워두면 현재 페이지 주소를 사용합니다.',
+      description: 'Hermes Web UI 백엔드 서버 주소를 구성합니다. 현재 페이지 주소를 사용하려면 비워 두세요.',
       clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
       corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
       placeholder: '예: http://192.168.1.100:6060',
       namePlaceholder: '서버 이름 (선택)',
       current: '현재 연결',
       same_origin: '동일 출처 (현재 페이지 주소)',
-      reset: '기본값으로 초기화',
+      reset: '기본값으로 재설정',
       saved: '저장됨',
-      reload_hint: '페이지를 새로고침하여 새 주소를 적용합니다.',
+      reload_hint: '새 주소를 적용하려면 페이지를 새로고침하세요.',
       saveToList: '목록에 추가',
       savedServers: '저장된 서버',
       active: '활성',
       switch: '전환',
       removeConfirm: '이 서버를 제거하시겠습니까?',
+    },
+
     },
     display: {
       streaming: '스트리밍 응답',
@@ -1548,6 +1558,7 @@ export default {
         token: 'API token',
         pairing: 'Device pairing',
       },
+    },
     userAvatar: {
       title: '사용자 아바타',
       upload: '이미지 업로드',
@@ -1569,6 +1580,7 @@ export default {
       saveFailed: '저장 실패',
       saved: '저장됨',
     },
+  },
   githubPreview: {
     title: "버전 미리보기",
     description: "선택한 GitHub tag 를 Web UI 미리보기 작업 디렉터리에 클론하고, 의존성을 설치한 뒤 개발 포트로 실행합니다.",
@@ -1679,6 +1691,7 @@ export default {
       claudeRun: "API 기반 단발 작업에는 print mode가 가장 깔끔한 경로입니다.",
       codexRun: "Codex 단발 작업은 git 저장소 안에서 실행해야 합니다.",
     },
+  },
 
   platform: {
     requireMention: "{'@'}멘션 필요",
@@ -2056,6 +2069,7 @@ export default {
         hours: '{count}시간 전',
         days: '{count}일 전',
       },
+    },
     board: {
       create: '새 보드',
       archive: '보드 보관',
@@ -2154,4 +2168,5 @@ export default {
       total: '합계',
       tasks: '작업 수',
     },
+  },
 }

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -12,6 +12,7 @@ export default {
     tokenLogin: '토큰',
     usernamePlaceholder: '사용자 이름',
     passwordPlaceholder: '비밀번호',
+    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
     defaultCredentialsHint: '기본 로그인 이름: admin, 기본 비밀번호: 123456',
     credentialsRequired: '사용자 이름과 비밀번호를 입력해 주세요',
     invalidCredentials: '사용자 이름 또는 비밀번호가 올바르지 않습니다',
@@ -72,7 +73,6 @@ export default {
       active: '활성',
       disabled: '비활성',
     },
-  },
 
   // 공통
   common: {
@@ -291,7 +291,6 @@ export default {
       completed: '완료',
       failed: '실패',
     },
-  },
 
   devices: {
     title: '기기',
@@ -361,7 +360,6 @@ export default {
       desktop: '데스크톱',
       custom: '사용자 지정',
     },
-  },
 
   performance: {
     title: '성능 모니터링',
@@ -460,7 +458,6 @@ export default {
         high: '높음',
         xhigh: '매우 높음',
       },
-    },
     showToolCalls: '도구 호출 표시',
     hideToolCalls: '도구 호출 숨기기',
     messageQueue: '메시지 대기열',
@@ -602,7 +599,6 @@ export default {
       microphoneUnsupported: '이 브라우저는 마이크 녹음을 지원하지 않습니다.',
       microphoneRecordingFailed: '마이크 녹음에 실패했습니다.',
     },
-  },
 
   // 예약 작업
   jobs: {
@@ -670,7 +666,6 @@ export default {
       runs: '회 실행',
       noRuns: '실행 기록이 없습니다.',
     },
-  },
 
   // 스킬
   skills: {
@@ -830,7 +825,6 @@ export default {
       scanCwd: 'cwd 스캔',
       projectPlugins: '프로젝트 플러그인',
     },
-  },
 
   // 메모리
   memory: {
@@ -1089,7 +1083,6 @@ export default {
       profileRestarted: '프로필이 재시작되었습니다: {name}',
       profileRestartFailed: '프로필 재시작 실패',
     },
-  },
 
   // 로그
   logs: {
@@ -1117,6 +1110,24 @@ export default {
       apiServer: 'API 서버',
       models: '모델',
       voice: '음성',
+      connection: '연결',
+    connection: {
+      title: '백엔드 연결',
+      description: 'Hermes Web UI 백엔드 서버 주소를 설정합니다. 비워두면 현재 페이지 주소를 사용합니다.',
+      clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
+      corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
+      placeholder: '예: http://192.168.1.100:6060',
+      namePlaceholder: '서버 이름 (선택)',
+      current: '현재 연결',
+      same_origin: '동일 출처 (현재 페이지 주소)',
+      reset: '기본값으로 초기화',
+      saved: '저장됨',
+      reload_hint: '페이지를 새로고침하여 새 주소를 적용합니다.',
+      saveToList: '목록에 추가',
+      savedServers: '저장된 서버',
+      active: '활성',
+      switch: '전환',
+      removeConfirm: '이 서버를 제거하시겠습니까?',
     },
     display: {
       streaming: '스트리밍 응답',
@@ -1537,7 +1548,6 @@ export default {
         token: 'API token',
         pairing: 'Device pairing',
       },
-    },
     userAvatar: {
       title: '사용자 아바타',
       upload: '이미지 업로드',
@@ -1559,7 +1569,6 @@ export default {
       saveFailed: '저장 실패',
       saved: '저장됨',
     },
-  },
   githubPreview: {
     title: "버전 미리보기",
     description: "선택한 GitHub tag 를 Web UI 미리보기 작업 디렉터리에 클론하고, 의존성을 설치한 뒤 개발 포트로 실행합니다.",
@@ -1670,7 +1679,6 @@ export default {
       claudeRun: "API 기반 단발 작업에는 print mode가 가장 깔끔한 경로입니다.",
       codexRun: "Codex 단발 작업은 git 저장소 안에서 실행해야 합니다.",
     },
-  },
 
   platform: {
     requireMention: "{'@'}멘션 필요",
@@ -2048,7 +2056,6 @@ export default {
         hours: '{count}시간 전',
         days: '{count}일 전',
       },
-    },
     board: {
       create: '새 보드',
       archive: '보드 보관',
@@ -2147,5 +2154,4 @@ export default {
       total: '합계',
       tasks: '작업 수',
     },
-  },
 }

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -12,7 +12,7 @@ export default {
     tokenLogin: 'Token',
     usernamePlaceholder: 'Nome de usuario',
     passwordPlaceholder: 'Senha',
-    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
+    serverHint: 'Para conectar a um backend remoto, expanda abaixo para configurar o endereço do servidor. O backend remoto deve ser executado com o comando hermes-web-ui client.',
     defaultCredentialsHint: 'Nome de usuario padrao: admin. Senha padrao: 123456.',
     credentialsRequired: 'Por favor, insira nome de usuario e senha',
     invalidCredentials: 'Nome de usuario ou senha incorretos',
@@ -73,6 +73,7 @@ export default {
       active: 'Ativo',
       disabled: 'Desativado',
     },
+  },
 
   // Common
   common: {
@@ -291,6 +292,7 @@ export default {
       completed: 'Concluída',
       failed: 'Falhou',
     },
+  },
 
   devices: {
     title: 'Dispositivos',
@@ -360,6 +362,7 @@ export default {
       desktop: 'Aplicativo desktop',
       custom: 'Personalizado',
     },
+  },
 
   performance: {
     title: 'Desempenho',
@@ -458,6 +461,7 @@ export default {
         high: 'Alto',
         xhigh: 'Ultra',
       },
+    },
     showToolCalls: 'Mostrar chamadas de ferramentas',
     hideToolCalls: 'Ocultar chamadas de ferramentas',
     messageQueue: 'Fila de mensagens',
@@ -599,6 +603,7 @@ export default {
       microphoneUnsupported: 'A captura do microfone nao e suportada neste navegador.',
       microphoneRecordingFailed: 'A gravacao do microfone falhou.',
     },
+  },
 
   // Jobs
   jobs: {
@@ -666,6 +671,7 @@ jobTriggered: 'Job acionado',
       runs: 'execuções',
       noRuns: 'Nenhum histórico encontrado.',
     },
+  },
 
   // Skills
   skills: {
@@ -825,6 +831,7 @@ jobTriggered: 'Job acionado',
       scanCwd: 'Verificar cwd',
       projectPlugins: 'Plugins do projeto',
     },
+  },
 
   // Memory
   memory: {
@@ -1083,6 +1090,7 @@ jobTriggered: 'Job acionado',
       profileRestarted: 'Perfil reiniciado: {name}',
       profileRestartFailed: 'Falha ao reiniciar perfil',
     },
+  },
 
   // Logs
   logs: {
@@ -1128,6 +1136,8 @@ jobTriggered: 'Job acionado',
       active: 'Ativo',
       switch: 'Alternar',
       removeConfirm: 'Remover este servidor?',
+    },
+
     },
     display: {
       streaming: 'Respostas em streaming',
@@ -1548,6 +1558,7 @@ jobTriggered: 'Job acionado',
         token: 'API token',
         pairing: 'Device pairing',
       },
+    },
     userAvatar: {
       title: 'Avatar do usuário',
       upload: 'Enviar imagem',
@@ -1569,6 +1580,7 @@ jobTriggered: 'Job acionado',
       saveFailed: 'Falha ao salvar',
       saved: 'Salvo',
     },
+  },
   githubPreview: {
     title: "Prévia de versão",
     description: "Clona a tag do GitHub selecionada para o workspace de prévia do Web UI, instala dependências e executa com as portas de desenvolvimento.",
@@ -1679,6 +1691,7 @@ jobTriggered: 'Job acionado',
       claudeRun: "Print mode é o caminho mais limpo para tarefas únicas orientadas por API.",
       codexRun: "Tarefas únicas do Codex devem ser executadas dentro de um repositório git.",
     },
+  },
 
   // Platform channel settings
   platform: {
@@ -2057,6 +2070,7 @@ jobTriggered: 'Job acionado',
         hours: 'há {count} h',
         days: 'há {count} d',
       },
+    },
     board: {
       create: 'Novo quadro',
       archive: 'Arquivar quadro',
@@ -2155,4 +2169,5 @@ jobTriggered: 'Job acionado',
       total: 'Total',
       tasks: 'Tarefas',
     },
+  },
 }

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -12,6 +12,7 @@ export default {
     tokenLogin: 'Token',
     usernamePlaceholder: 'Nome de usuario',
     passwordPlaceholder: 'Senha',
+    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
     defaultCredentialsHint: 'Nome de usuario padrao: admin. Senha padrao: 123456.',
     credentialsRequired: 'Por favor, insira nome de usuario e senha',
     invalidCredentials: 'Nome de usuario ou senha incorretos',
@@ -72,7 +73,6 @@ export default {
       active: 'Ativo',
       disabled: 'Desativado',
     },
-  },
 
   // Common
   common: {
@@ -291,7 +291,6 @@ export default {
       completed: 'Concluída',
       failed: 'Falhou',
     },
-  },
 
   devices: {
     title: 'Dispositivos',
@@ -361,7 +360,6 @@ export default {
       desktop: 'Aplicativo desktop',
       custom: 'Personalizado',
     },
-  },
 
   performance: {
     title: 'Desempenho',
@@ -460,7 +458,6 @@ export default {
         high: 'Alto',
         xhigh: 'Ultra',
       },
-    },
     showToolCalls: 'Mostrar chamadas de ferramentas',
     hideToolCalls: 'Ocultar chamadas de ferramentas',
     messageQueue: 'Fila de mensagens',
@@ -602,7 +599,6 @@ export default {
       microphoneUnsupported: 'A captura do microfone nao e suportada neste navegador.',
       microphoneRecordingFailed: 'A gravacao do microfone falhou.',
     },
-  },
 
   // Jobs
   jobs: {
@@ -670,7 +666,6 @@ jobTriggered: 'Job acionado',
       runs: 'execuções',
       noRuns: 'Nenhum histórico encontrado.',
     },
-  },
 
   // Skills
   skills: {
@@ -830,7 +825,6 @@ jobTriggered: 'Job acionado',
       scanCwd: 'Verificar cwd',
       projectPlugins: 'Plugins do projeto',
     },
-  },
 
   // Memory
   memory: {
@@ -1089,7 +1083,6 @@ jobTriggered: 'Job acionado',
       profileRestarted: 'Perfil reiniciado: {name}',
       profileRestartFailed: 'Falha ao reiniciar perfil',
     },
-  },
 
   // Logs
   logs: {
@@ -1117,6 +1110,24 @@ jobTriggered: 'Job acionado',
       apiServer: 'Servidor API',
       models: 'Modelos',
       voice: 'Voz',
+      connection: 'Conexão',
+    connection: {
+      title: 'Conexão do backend',
+      description: 'Configure o endereço do servidor backend do Hermes Web UI. Deixe vazio para usar o endereço da página atual.',
+      clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
+      corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
+      placeholder: 'ex. http://192.168.1.100:6060',
+      namePlaceholder: 'Nome do servidor (opcional)',
+      current: 'Conexão atual',
+      same_origin: 'Mesma origem (endereço da página atual)',
+      reset: 'Redefinir para padrão',
+      saved: 'Salvo',
+      reload_hint: 'Recarregue a página para aplicar o novo endereço.',
+      saveToList: 'Adicionar à lista',
+      savedServers: 'Servidores salvos',
+      active: 'Ativo',
+      switch: 'Alternar',
+      removeConfirm: 'Remover este servidor?',
     },
     display: {
       streaming: 'Respostas em streaming',
@@ -1537,7 +1548,6 @@ jobTriggered: 'Job acionado',
         token: 'API token',
         pairing: 'Device pairing',
       },
-    },
     userAvatar: {
       title: 'Avatar do usuário',
       upload: 'Enviar imagem',
@@ -1559,7 +1569,6 @@ jobTriggered: 'Job acionado',
       saveFailed: 'Falha ao salvar',
       saved: 'Salvo',
     },
-  },
   githubPreview: {
     title: "Prévia de versão",
     description: "Clona a tag do GitHub selecionada para o workspace de prévia do Web UI, instala dependências e executa com as portas de desenvolvimento.",
@@ -1670,7 +1679,6 @@ jobTriggered: 'Job acionado',
       claudeRun: "Print mode é o caminho mais limpo para tarefas únicas orientadas por API.",
       codexRun: "Tarefas únicas do Codex devem ser executadas dentro de um repositório git.",
     },
-  },
 
   // Platform channel settings
   platform: {
@@ -2049,7 +2057,6 @@ jobTriggered: 'Job acionado',
         hours: 'há {count} h',
         days: 'há {count} d',
       },
-    },
     board: {
       create: 'Novo quadro',
       archive: 'Arquivar quadro',
@@ -2148,5 +2155,4 @@ jobTriggered: 'Job acionado',
       total: 'Total',
       tasks: 'Tarefas',
     },
-  },
 }

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -12,7 +12,7 @@ export default {
     tokenLogin: 'Вход по токену',
     usernamePlaceholder: 'Имя пользователя',
     passwordPlaceholder: 'Пароль',
-    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
+    serverHint: 'Для подключения к удалённому бэкенду разверните ниже, чтобы настроить адрес сервера. Удалённый бэкенд должен быть запущен с командой hermes-web-ui client.',
     defaultCredentialsHint: 'Логин по умолчанию: admin, пароль по умолчанию: 123456',
     credentialsRequired: 'Введите имя пользователя и пароль',
     invalidCredentials: 'Неверное имя пользователя или пароль',
@@ -71,6 +71,7 @@ export default {
       active: 'Включён',
       disabled: 'Отключён',
     },
+  },
 
 
   common: {
@@ -213,6 +214,7 @@ export default {
       completed: 'Завершено',
       failed: 'Ошибка',
     },
+  },
 
   codingAgents: {
     installFailedHermesHint: 'Installation failed. Ask Hermes to install it for you.',
@@ -287,6 +289,7 @@ export default {
       desktop: 'Настольное приложение',
       custom: 'Пользовательский',
     },
+  },
 
   performance: {
     title: 'Мониторинг производительности',
@@ -377,6 +380,7 @@ export default {
         high: 'Высокая',
         xhigh: 'Очень высокая',
       },
+    },
     autoPlaySpeech: 'Автовоспроизведение речи',
     voiceInput: {
       startCapture: 'Начать голосовой ввод',
@@ -581,6 +585,7 @@ export default {
         hours: '{count} ч. назад',
         days: '{count} дн. назад',
       },
+    },
     detail: {
       status: 'Статус',
       assignee: 'Ответственный',
@@ -638,6 +643,7 @@ export default {
       total: 'Всего',
       tasks: 'задач',
     },
+  },
 
 
   jobs: {
@@ -705,6 +711,7 @@ export default {
       runs: 'запусков',
       noRuns: 'Нет истории выполнения.',
     },
+  },
 
 
   skills: {
@@ -823,6 +830,7 @@ export default {
       scanCwd: 'Сканировать cwd',
       projectPlugins: 'Плагины проекта',
     },
+  },
 
 
   memory: {
@@ -1080,6 +1088,7 @@ export default {
       profileRestarted: 'Профиль перезапущен: {name}',
       profileRestartFailed: 'Ошибка перезапуска профиля',
     },
+  },
 
 
   logs: {
@@ -1108,23 +1117,6 @@ export default {
       models: 'Модели',
       voice: 'Голос',
       connection: 'Подключение',
-    connection: {
-      title: 'Подключение к бэкенду',
-      description: 'Настройте адрес сервера бэкенда Hermes Web UI. Оставьте пустым для использования адреса текущей страницы.',
-      clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
-      corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
-      placeholder: 'напр. http://192.168.1.100:6060',
-      namePlaceholder: 'Имя сервера (необязательно)',
-      current: 'Текущее подключение',
-      same_origin: 'Тот же источник (адрес текущей страницы)',
-      reset: 'Сбросить по умолчанию',
-      saved: 'Сохранено',
-      reload_hint: 'Перезагрузите страницу для применения нового адреса.',
-      saveToList: 'Добавить в список',
-      savedServers: 'Сохранённые серверы',
-      active: 'Активен',
-      switch: 'Переключить',
-      removeConfirm: 'Удалить этот сервер?',
     },
     models: {
       apiKey: 'API-ключ',
@@ -1133,6 +1125,25 @@ export default {
       saved: 'Сохранено',
       saveFailed: 'Ошибка сохранения',
       noProviders: 'Нет настроенных моделей',
+    connection: {
+      title: 'Подключение к бэкенду',
+      description: 'Настройте адрес сервера Hermes Web UI. Оставьте пустым, чтобы использовать текущий адрес страницы.',
+      clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
+      corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
+      placeholder: 'напр. http://192.168.1.100:6060',
+      namePlaceholder: 'Имя сервера (необязательно)',
+      current: 'Текущее подключение',
+      same_origin: 'Тот же источник (текущий адрес страницы)',
+      reset: 'Сбросить по умолчанию',
+      saved: 'Сохранено',
+      reload_hint: 'Перезагрузите страницу, чтобы применить новый адрес.',
+      saveToList: 'Добавить в список',
+      savedServers: 'Сохранённые серверы',
+      active: 'Активный',
+      switch: 'Переключить',
+      removeConfirm: 'Удалить этот сервер?',
+    },
+
     },
     display: {
       streaming: 'Потоковый ответ',
@@ -1293,6 +1304,7 @@ export default {
         token: 'API token',
         pairing: 'Device pairing',
       },
+    },
     userAvatar: {
       title: 'Аватар пользователя',
       upload: 'Загрузить изображение',
@@ -1560,6 +1572,7 @@ export default {
       mimoStylePromptHint: 'Необязательно. Опишите желаемый стиль речи естественным языком',
       mimoStylePromptPlaceholder: 'Например: используйте лёгкий, приподнятый тон, темп речи чуть выше среднего',
     },
+  },
 
 
   platform: {

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -12,6 +12,7 @@ export default {
     tokenLogin: 'Вход по токену',
     usernamePlaceholder: 'Имя пользователя',
     passwordPlaceholder: 'Пароль',
+    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
     defaultCredentialsHint: 'Логин по умолчанию: admin, пароль по умолчанию: 123456',
     credentialsRequired: 'Введите имя пользователя и пароль',
     invalidCredentials: 'Неверное имя пользователя или пароль',
@@ -70,7 +71,6 @@ export default {
       active: 'Включён',
       disabled: 'Отключён',
     },
-  },
 
 
   common: {
@@ -213,7 +213,6 @@ export default {
       completed: 'Завершено',
       failed: 'Ошибка',
     },
-  },
 
   codingAgents: {
     installFailedHermesHint: 'Installation failed. Ask Hermes to install it for you.',
@@ -288,7 +287,6 @@ export default {
       desktop: 'Настольное приложение',
       custom: 'Пользовательский',
     },
-  },
 
   performance: {
     title: 'Мониторинг производительности',
@@ -379,7 +377,6 @@ export default {
         high: 'Высокая',
         xhigh: 'Очень высокая',
       },
-    },
     autoPlaySpeech: 'Автовоспроизведение речи',
     voiceInput: {
       startCapture: 'Начать голосовой ввод',
@@ -584,7 +581,6 @@ export default {
         hours: '{count} ч. назад',
         days: '{count} дн. назад',
       },
-    },
     detail: {
       status: 'Статус',
       assignee: 'Ответственный',
@@ -642,7 +638,6 @@ export default {
       total: 'Всего',
       tasks: 'задач',
     },
-  },
 
 
   jobs: {
@@ -710,7 +705,6 @@ export default {
       runs: 'запусков',
       noRuns: 'Нет истории выполнения.',
     },
-  },
 
 
   skills: {
@@ -829,7 +823,6 @@ export default {
       scanCwd: 'Сканировать cwd',
       projectPlugins: 'Плагины проекта',
     },
-  },
 
 
   memory: {
@@ -1087,7 +1080,6 @@ export default {
       profileRestarted: 'Профиль перезапущен: {name}',
       profileRestartFailed: 'Ошибка перезапуска профиля',
     },
-  },
 
 
   logs: {
@@ -1115,6 +1107,24 @@ export default {
       apiServer: 'API-сервер',
       models: 'Модели',
       voice: 'Голос',
+      connection: 'Подключение',
+    connection: {
+      title: 'Подключение к бэкенду',
+      description: 'Настройте адрес сервера бэкенда Hermes Web UI. Оставьте пустым для использования адреса текущей страницы.',
+      clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
+      corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
+      placeholder: 'напр. http://192.168.1.100:6060',
+      namePlaceholder: 'Имя сервера (необязательно)',
+      current: 'Текущее подключение',
+      same_origin: 'Тот же источник (адрес текущей страницы)',
+      reset: 'Сбросить по умолчанию',
+      saved: 'Сохранено',
+      reload_hint: 'Перезагрузите страницу для применения нового адреса.',
+      saveToList: 'Добавить в список',
+      savedServers: 'Сохранённые серверы',
+      active: 'Активен',
+      switch: 'Переключить',
+      removeConfirm: 'Удалить этот сервер?',
     },
     models: {
       apiKey: 'API-ключ',
@@ -1283,7 +1293,6 @@ export default {
         token: 'API token',
         pairing: 'Device pairing',
       },
-    },
     userAvatar: {
       title: 'Аватар пользователя',
       upload: 'Загрузить изображение',
@@ -1551,7 +1560,6 @@ export default {
       mimoStylePromptHint: 'Необязательно. Опишите желаемый стиль речи естественным языком',
       mimoStylePromptPlaceholder: 'Например: используйте лёгкий, приподнятый тон, темп речи чуть выше среднего',
     },
-  },
 
 
   platform: {

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -12,6 +12,7 @@ export default {
     tokenLogin: '權杖登入',
     usernamePlaceholder: '使用者名稱',
     passwordPlaceholder: '密碼',
+    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
     defaultCredentialsHint: '預設登入名：admin，預設密碼：123456',
     credentialsRequired: '請輸入使用者名稱和密碼',
     invalidCredentials: '使用者名稱或密碼錯誤',
@@ -72,7 +73,6 @@ export default {
       active: '啟用',
       disabled: '停用',
     },
-  },
 
   // 通用
   common: {
@@ -291,7 +291,6 @@ export default {
       completed: '已完成',
       failed: '失敗',
     },
-  },
 
   devices: {
     title: '裝置',
@@ -361,7 +360,6 @@ export default {
       desktop: '桌面端',
       custom: '自訂',
     },
-  },
 
   performance: {
     title: '效能監控',
@@ -463,7 +461,6 @@ export default {
         high: '高',
         xhigh: '超高',
       },
-    },
     autoPlaySpeech: '自動播放語音',
     voiceInput: {
       startCapture: '開始語音輸入',
@@ -680,7 +677,6 @@ export default {
         hours: '{count} 小時前',
         days: '{count} 天前',
       },
-    },
     detail: {
       status: '狀態',
       assignee: '負責人',
@@ -738,7 +734,6 @@ export default {
       total: '總計',
       tasks: '任務數',
     },
-  },
 
   // 排程任務
   jobs: {
@@ -806,7 +801,6 @@ export default {
       runs: '次執行',
       noRuns: '目前無執行歷史。',
     },
-  },
 
   // 技能
   skills: {
@@ -966,7 +960,6 @@ export default {
       scanCwd: '掃描 cwd',
       projectPlugins: '專案插件',
     },
-  },
 
   // 記憶
   memory: {
@@ -1225,7 +1218,6 @@ export default {
       profileRestarted: '設定檔已重啟：{name}',
       profileRestartFailed: '重啟設定檔失敗',
     },
-  },
 
   // 日誌
   logs: {
@@ -1253,6 +1245,24 @@ export default {
       apiServer: 'API 伺服器',
       models: '模型',
       voice: '語音',
+      connection: '連線',
+    connection: {
+      title: '後端連線',
+      description: '設定 Hermes Web UI 後端伺服器位址。留空則使用當前頁面位址。',
+      clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
+      corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
+      placeholder: '例如: http://192.168.1.100:6060',
+      namePlaceholder: '伺服器名稱（選填）',
+      current: '當前連線',
+      same_origin: '同源（當前頁面位址）',
+      reset: '重置為預設',
+      saved: '已儲存',
+      reload_hint: '重新載入頁面以套用新位址。',
+      saveToList: '加入儲存清單',
+      savedServers: '已儲存的伺服器',
+      active: '使用中',
+      switch: '切換',
+      removeConfirm: '確定移除此伺服器？',
     },
     models: {
       apiKey: 'API Key',
@@ -1421,7 +1431,6 @@ export default {
         token: 'API Token',
         pairing: '裝置配對',
       },
-    },
     userAvatar: {
       title: '使用者頭像',
       upload: '上傳圖片',
@@ -1694,7 +1703,6 @@ export default {
       mimoStylePromptHint: '可選，用自然語言描述語音風格',
       mimoStylePromptPlaceholder: '例如：用輕快上揚的語調，語速稍快',
     },
-  },
   githubPreview: {
     title: "版本預覽",
     description: "將選取的 GitHub tag 複製到 Web UI 預覽工作目錄，安裝依賴並以開發連接埠執行。",
@@ -1805,7 +1813,6 @@ export default {
       claudeRun: "Print mode 最適合 API 驅動的單次任務。",
       codexRun: "Codex 單次任務需要在 git 倉庫中執行。",
     },
-  },
 
   // 平台頻道設定
   platform: {

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -12,7 +12,7 @@ export default {
     tokenLogin: '權杖登入',
     usernamePlaceholder: '使用者名稱',
     passwordPlaceholder: '密碼',
-    serverHint: 'To connect to a remote backend, expand below to configure the server address. The remote backend must be running with the hermes-web-ui client command.',
+    serverHint: '要連線遠端後端，請展開下方設定伺服器位址。遠端後端必須使用 hermes-web-ui client 指令啟動。',
     defaultCredentialsHint: '預設登入名：admin，預設密碼：123456',
     credentialsRequired: '請輸入使用者名稱和密碼',
     invalidCredentials: '使用者名稱或密碼錯誤',
@@ -73,6 +73,7 @@ export default {
       active: '啟用',
       disabled: '停用',
     },
+  },
 
   // 通用
   common: {
@@ -291,6 +292,7 @@ export default {
       completed: '已完成',
       failed: '失敗',
     },
+  },
 
   devices: {
     title: '裝置',
@@ -360,6 +362,7 @@ export default {
       desktop: '桌面端',
       custom: '自訂',
     },
+  },
 
   performance: {
     title: '效能監控',
@@ -461,6 +464,7 @@ export default {
         high: '高',
         xhigh: '超高',
       },
+    },
     autoPlaySpeech: '自動播放語音',
     voiceInput: {
       startCapture: '開始語音輸入',
@@ -677,6 +681,7 @@ export default {
         hours: '{count} 小時前',
         days: '{count} 天前',
       },
+    },
     detail: {
       status: '狀態',
       assignee: '負責人',
@@ -734,6 +739,7 @@ export default {
       total: '總計',
       tasks: '任務數',
     },
+  },
 
   // 排程任務
   jobs: {
@@ -801,6 +807,7 @@ export default {
       runs: '次執行',
       noRuns: '目前無執行歷史。',
     },
+  },
 
   // 技能
   skills: {
@@ -960,6 +967,7 @@ export default {
       scanCwd: '掃描 cwd',
       projectPlugins: '專案插件',
     },
+  },
 
   // 記憶
   memory: {
@@ -1218,6 +1226,7 @@ export default {
       profileRestarted: '設定檔已重啟：{name}',
       profileRestartFailed: '重啟設定檔失敗',
     },
+  },
 
   // 日誌
   logs: {
@@ -1246,23 +1255,6 @@ export default {
       models: '模型',
       voice: '語音',
       connection: '連線',
-    connection: {
-      title: '後端連線',
-      description: '設定 Hermes Web UI 後端伺服器位址。留空則使用當前頁面位址。',
-      clientCommandHint: 'The remote backend must be running with the hermes-web-ui client command, otherwise it cannot connect.',
-      corsHint: 'When the frontend and backend are on different domains, the backend must configure CORS to allow cross-origin requests (CORS_ORIGINS=*).',
-      placeholder: '例如: http://192.168.1.100:6060',
-      namePlaceholder: '伺服器名稱（選填）',
-      current: '當前連線',
-      same_origin: '同源（當前頁面位址）',
-      reset: '重置為預設',
-      saved: '已儲存',
-      reload_hint: '重新載入頁面以套用新位址。',
-      saveToList: '加入儲存清單',
-      savedServers: '已儲存的伺服器',
-      active: '使用中',
-      switch: '切換',
-      removeConfirm: '確定移除此伺服器？',
     },
     models: {
       apiKey: 'API Key',
@@ -1271,6 +1263,25 @@ export default {
       saved: '已儲存',
       saveFailed: '儲存失敗',
       noProviders: '目前無已設定的模型',
+    connection: {
+      title: 'Backend 連線',
+      description: '設定 Hermes Web UI 後端伺服器位址。留空則使用目前頁面位址。',
+      clientCommandHint: '遠端後端必須使用 hermes-web-ui client 指令啟動，否則無法連線。',
+      corsHint: '前後端在不同網域時，後端需設定 CORS 允許跨域請求（CORS_ORIGINS=*）。',
+      placeholder: '例如 http://192.168.1.100:6060',
+      namePlaceholder: '伺服器名稱（選填）',
+      current: '目前連線',
+      same_origin: '同源（目前頁面位址）',
+      reset: '重設為預設值',
+      saved: '已儲存',
+      reload_hint: '重新載入頁面以套用新位址。',
+      saveToList: '新增至清單',
+      savedServers: '已儲存的伺服器',
+      active: '啟用',
+      switch: '切換',
+      removeConfirm: '移除此伺服器？',
+    },
+
     },
     display: {
       streaming: '串流回應',
@@ -1431,6 +1442,7 @@ export default {
         token: 'API Token',
         pairing: '裝置配對',
       },
+    },
     userAvatar: {
       title: '使用者頭像',
       upload: '上傳圖片',
@@ -1703,6 +1715,7 @@ export default {
       mimoStylePromptHint: '可選，用自然語言描述語音風格',
       mimoStylePromptPlaceholder: '例如：用輕快上揚的語調，語速稍快',
     },
+  },
   githubPreview: {
     title: "版本預覽",
     description: "將選取的 GitHub tag 複製到 Web UI 預覽工作目錄，安裝依賴並以開發連接埠執行。",
@@ -1813,6 +1826,7 @@ export default {
       claudeRun: "Print mode 最適合 API 驅動的單次任務。",
       codexRun: "Codex 單次任務需要在 git 倉庫中執行。",
     },
+  },
 
   // 平台頻道設定
   platform: {

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -12,6 +12,7 @@ export default {
     tokenLogin: '令牌登录',
     usernamePlaceholder: '用户名',
     passwordPlaceholder: '密码',
+    serverHint: '如需连接远程后端，请展开下方配置服务器地址。\n远程后端需要允许来自本站跨域请求。',
     defaultCredentialsHint: '默认登录名：admin，默认密码：123456',
     credentialsRequired: '请输入用户名和密码',
     invalidCredentials: '用户名或密码错误',
@@ -72,7 +73,6 @@ export default {
       active: '启用',
       disabled: '禁用',
     },
-  },
 
   // 通用
   common: {
@@ -291,7 +291,6 @@ export default {
       completed: '已完成',
       failed: '失败',
     },
-  },
 
   devices: {
     title: '设备',
@@ -361,7 +360,6 @@ export default {
       desktop: '桌面端',
       custom: '自定义',
     },
-  },
 
   performance: {
     title: '性能监控',
@@ -464,7 +462,6 @@ export default {
         high: '高',
         xhigh: '超高',
       },
-    },
     autoPlaySpeech: '自动播放语音',
     voiceInput: {
       startCapture: '开始语音输入',
@@ -680,7 +677,6 @@ export default {
         hours: '{count}小时前',
         days: '{count}天前',
       },
-    },
     detail: {
       status: '状态',
       assignee: '负责人',
@@ -738,7 +734,6 @@ export default {
       total: '总计',
       tasks: '任务数',
     },
-  },
 
   // 定时任务
   jobs: {
@@ -806,7 +801,6 @@ export default {
       runs: '次运行',
       noRuns: '暂无运行历史。',
     },
-  },
 
   // 技能
   skills: {
@@ -966,7 +960,6 @@ export default {
       scanCwd: '扫描 cwd',
       projectPlugins: '项目插件',
     },
-  },
 
   // 记忆
   memory: {
@@ -1225,7 +1218,6 @@ export default {
       profileRestarted: '配置已重启：{name}',
       profileRestartFailed: '重启配置失败',
     },
-  },
 
   // 日志
   logs: {
@@ -1253,6 +1245,24 @@ export default {
       apiServer: 'API 服务器',
       models: '模型',
       voice: '语音',
+      connection: '连接',
+    connection: {
+      title: '后端连接',
+      description: '配置 Hermes Web UI 后端服务器地址。留空则使用当前页面地址。',
+      clientCommandHint: '远程后端需要以 hermes-web-ui client 命令运行，否则无法连接。',
+      corsHint: '本功能需要后端开启允许跨域请求，你可以使用 hermes-web-ui client 命令运行 Hermes Studio，会默认允许所有跨域请求（CORS_ORIGINS=*），当然你也可以自行设置跨域白名单。',
+      placeholder: '例如: http://192.168.1.100:6060',
+      namePlaceholder: '服务器名称（可选）',
+      current: '当前连接',
+      same_origin: '同源（当前页面地址）',
+      reset: '重置为默认',
+      saved: '已保存',
+      reload_hint: '刷新页面以应用新地址。',
+      saveToList: '添加到保存列表',
+      savedServers: '已保存的服务器',
+      active: '当前使用',
+      switch: '切换',
+      removeConfirm: '确定移除这个服务器吗？',
     },
     models: {
       apiKey: 'API Key',
@@ -1421,7 +1431,6 @@ export default {
         token: 'API Token',
         pairing: '设备配对',
       },
-    },
     userAvatar: {
       title: '用户头像',
       upload: '上传图片',
@@ -1694,7 +1703,6 @@ export default {
       mimoStylePromptHint: '可选，用自然语言描述语音风格',
       mimoStylePromptPlaceholder: '例如：用轻快上扬的语调，语速稍快',
     },
-  },
   githubPreview: {
     title: "版本预览",
     description: "将选中的 GitHub tag 克隆到 Web UI 预览工作目录，安装依赖并以开发端口运行。",
@@ -1805,7 +1813,6 @@ export default {
       claudeRun: "Print mode 最适合 API 驱动的单次任务。",
       codexRun: "Codex 单次任务需要在 git 仓库中运行。",
     },
-  },
 
   // 平台频道设置
   platform: {

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -12,7 +12,7 @@ export default {
     tokenLogin: '令牌登录',
     usernamePlaceholder: '用户名',
     passwordPlaceholder: '密码',
-    serverHint: '如需连接远程后端，请展开下方配置服务器地址。\n远程后端需要允许来自本站跨域请求。',
+    serverHint: '要连接远程后端，请展开下方配置服务器地址。远程后端必须使用 hermes-web-ui client 命令启动。',
     defaultCredentialsHint: '默认登录名：admin，默认密码：123456',
     credentialsRequired: '请输入用户名和密码',
     invalidCredentials: '用户名或密码错误',
@@ -73,6 +73,7 @@ export default {
       active: '启用',
       disabled: '禁用',
     },
+  },
 
   // 通用
   common: {
@@ -291,6 +292,7 @@ export default {
       completed: '已完成',
       failed: '失败',
     },
+  },
 
   devices: {
     title: '设备',
@@ -360,6 +362,7 @@ export default {
       desktop: '桌面端',
       custom: '自定义',
     },
+  },
 
   performance: {
     title: '性能监控',
@@ -462,6 +465,7 @@ export default {
         high: '高',
         xhigh: '超高',
       },
+    },
     autoPlaySpeech: '自动播放语音',
     voiceInput: {
       startCapture: '开始语音输入',
@@ -677,6 +681,7 @@ export default {
         hours: '{count}小时前',
         days: '{count}天前',
       },
+    },
     detail: {
       status: '状态',
       assignee: '负责人',
@@ -734,6 +739,7 @@ export default {
       total: '总计',
       tasks: '任务数',
     },
+  },
 
   // 定时任务
   jobs: {
@@ -801,6 +807,7 @@ export default {
       runs: '次运行',
       noRuns: '暂无运行历史。',
     },
+  },
 
   // 技能
   skills: {
@@ -960,6 +967,7 @@ export default {
       scanCwd: '扫描 cwd',
       projectPlugins: '项目插件',
     },
+  },
 
   // 记忆
   memory: {
@@ -1218,6 +1226,7 @@ export default {
       profileRestarted: '配置已重启：{name}',
       profileRestartFailed: '重启配置失败',
     },
+  },
 
   // 日志
   logs: {
@@ -1246,23 +1255,6 @@ export default {
       models: '模型',
       voice: '语音',
       connection: '连接',
-    connection: {
-      title: '后端连接',
-      description: '配置 Hermes Web UI 后端服务器地址。留空则使用当前页面地址。',
-      clientCommandHint: '远程后端需要以 hermes-web-ui client 命令运行，否则无法连接。',
-      corsHint: '本功能需要后端开启允许跨域请求，你可以使用 hermes-web-ui client 命令运行 Hermes Studio，会默认允许所有跨域请求（CORS_ORIGINS=*），当然你也可以自行设置跨域白名单。',
-      placeholder: '例如: http://192.168.1.100:6060',
-      namePlaceholder: '服务器名称（可选）',
-      current: '当前连接',
-      same_origin: '同源（当前页面地址）',
-      reset: '重置为默认',
-      saved: '已保存',
-      reload_hint: '刷新页面以应用新地址。',
-      saveToList: '添加到保存列表',
-      savedServers: '已保存的服务器',
-      active: '当前使用',
-      switch: '切换',
-      removeConfirm: '确定移除这个服务器吗？',
     },
     models: {
       apiKey: 'API Key',
@@ -1271,6 +1263,25 @@ export default {
       saved: '已保存',
       saveFailed: '保存失败',
       noProviders: '暂无已配置的模型',
+    connection: {
+      title: '后端连接',
+      description: '配置 Hermes Web UI 后端服务器地址。留空则使用当前页面地址。',
+      clientCommandHint: '远程后端必须使用 hermes-web-ui client 命令启动，否则无法连接。',
+      corsHint: '前后端在不同域名时，后端需配置 CORS 允许跨域请求（CORS_ORIGINS=*）。',
+      placeholder: '例如 http://192.168.1.100:6060',
+      namePlaceholder: '服务器名称（可选）',
+      current: '当前连接',
+      same_origin: '同源（当前页面地址）',
+      reset: '重置为默认',
+      saved: '已保存',
+      reload_hint: '重新加载页面以应用新地址。',
+      saveToList: '添加到列表',
+      savedServers: '已保存的服务器',
+      active: '活跃',
+      switch: '切换',
+      removeConfirm: '移除此服务器？',
+    },
+
     },
     display: {
       streaming: '流式响应',
@@ -1431,6 +1442,7 @@ export default {
         token: 'API Token',
         pairing: '设备配对',
       },
+    },
     userAvatar: {
       title: '用户头像',
       upload: '上传图片',
@@ -1703,6 +1715,7 @@ export default {
       mimoStylePromptHint: '可选，用自然语言描述语音风格',
       mimoStylePromptPlaceholder: '例如：用轻快上扬的语调，语速稍快',
     },
+  },
   githubPreview: {
     title: "版本预览",
     description: "将选中的 GitHub tag 克隆到 Web UI 预览工作目录，安装依赖并以开发端口运行。",
@@ -1813,6 +1826,7 @@ export default {
       claudeRun: "Print mode 最适合 API 驱动的单次任务。",
       codexRun: "Codex 单次任务需要在 git 仓库中运行。",
     },
+  },
 
   // 平台频道设置
   platform: {

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1,6 +1,6 @@
 import { startRunViaSocket, resumeSession, registerSessionHandlers, unregisterSessionHandlers, getChatRunSocket, respondToolApproval, onPeerUserMessage, onSessionCommand, onSessionTitleUpdated, respondClarify, type ChatRunTransport, type RunEvent, type ResumeSessionPayload, type StartRunRequest, type ContentBlock as ContentBlockImport } from '@/api/hermes/chat'
 import { deleteSession as deleteSessionApi, fetchSessionMessagesPage, fetchSessions, setSessionModel, type HermesMessage, type SessionSummary } from '@/api/hermes/sessions'
-import { getActiveProfileName } from '@/api/client'
+import { getActiveProfileName, getBaseUrlValue } from '@/api/client'
 import { inferCodingAgentApiMode, normalizeCodingAgentApiMode } from '@/api/coding-agents'
 import { getDownloadUrl } from '@/api/hermes/download'
 import type { ProviderApiMode } from '@/api/hermes/system'
@@ -178,12 +178,13 @@ async function uploadFiles(attachments: Attachment[]): Promise<{ name: string; p
   const headers: Record<string, string> = {}
   if (token) headers.Authorization = `Bearer ${token}`
   if (profileName) headers['X-Hermes-Profile'] = profileName
-  const res = await fetch('/upload', {
+  const base = getBaseUrlValue()
+  const res = await fetch(`${base}/upload`, {
     method: 'POST',
     body: formData,
     headers,
   })
-  if (!res.ok) throw new Error(await responseErrorMessage(res, 'Upload failed'))
+  if (!res.ok) throw new Error(`Upload failed: ${res.status}`)
   const data = await res.json() as { files: { name: string; path: string }[] }
   return data.files
 }

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -1,9 +1,8 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { getActiveProfileName, getApiKey, getStoredUsername } from '@/api/client'
+import { getActiveProfileName, getApiKey, getBaseUrlValue, getStoredUsername } from '@/api/client'
 import { fetchCurrentUser } from '@/api/auth'
 import { getDownloadUrl } from '@/api/hermes/download'
-import { responseErrorMessage } from '@/utils/http-error'
 import type { Attachment, ContentBlock } from './chat'
 import {
     connectGroupChat,
@@ -37,12 +36,13 @@ async function uploadGroupFiles(attachments: Attachment[]): Promise<{ name: stri
     const headers: Record<string, string> = {}
     if (token) headers.Authorization = `Bearer ${token}`
     if (profileName) headers['X-Hermes-Profile'] = profileName
-    const res = await fetch('/upload', {
+    const base = getBaseUrlValue()
+    const res = await fetch(`${base}/upload`, {
         method: 'POST',
         body: formData,
         headers,
     })
-    if (!res.ok) throw new Error(await responseErrorMessage(res, 'Upload failed'))
+    if (!res.ok) throw new Error(`Upload failed: ${res.status}`)
     const data = await res.json() as { files: { name: string; path: string }[] }
     return data.files
 }

--- a/packages/client/src/views/LoginView.vue
+++ b/packages/client/src/views/LoginView.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
-import { setApiKey, hasApiKey } from "@/api/client";
+import { setApiKey, hasApiKey, getBaseUrlValue, setServerUrl, clearApiKey } from "@/api/client";
 import { fetchAuthStatus, loginWithPassword } from "@/api/auth";
 
 const { t } = useI18n();
@@ -13,6 +13,9 @@ const password = ref("");
 const loading = ref(false);
 const errorMsg = ref("");
 const showLockResetHint = ref(false);
+const currentServerUrl = ref("");
+const editUrl = ref("");
+const showUrlEditor = ref(false);
 
 // If already has a key, try to go to main page
 if (hasApiKey()) {
@@ -20,12 +23,32 @@ if (hasApiKey()) {
 }
 
 onMounted(async () => {
+  currentServerUrl.value = getBaseUrlValue();
+  editUrl.value = currentServerUrl.value;
+  // Show URL editor if user has a custom URL set
+  showUrlEditor.value = !!currentServerUrl.value;
+
   try {
     await fetchAuthStatus();
   } catch {
     // Login remains available; the submit request will surface connection errors.
   }
 });
+
+function handleApplyUrl() {
+  const url = editUrl.value.trim().replace(/\/+$/, "");
+  if (url === currentServerUrl.value) return;
+  setServerUrl(url);
+  clearApiKey();
+  window.location.reload();
+}
+
+function handleClearUrl() {
+  editUrl.value = "";
+  setServerUrl("");
+  clearApiKey();
+  window.location.reload();
+}
 
 async function handleLogin() {
   await handlePasswordLogin();
@@ -67,6 +90,35 @@ async function handlePasswordLogin() {
       <h1 class="login-title">{{ t("login.title") }}</h1>
       <p class="login-desc">{{ t("login.description") }}</p>
       <p class="login-default-hint">{{ t("login.defaultCredentialsHint") }}</p>
+
+      <!-- Server URL editor (always visible for custom URL, collapsible for same-origin) -->
+      <div class="server-hint">{{ t('login.serverHint') }}</div>
+      <div class="server-section">
+        <div class="server-current" @click="showUrlEditor = !showUrlEditor">
+          <span class="server-dot" :class="{ connected: !currentServerUrl }"></span>
+          <span class="server-display">
+            {{ currentServerUrl || t('settings.connection.same_origin') }}
+          </span>
+          <svg class="server-chevron" :class="{ open: showUrlEditor }" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+        </div>
+        <div v-if="showUrlEditor" class="server-editor">
+          <input
+            v-model="editUrl"
+            type="text"
+            class="login-input server-input"
+            :placeholder="t('settings.connection.placeholder')"
+            @keyup.enter="handleApplyUrl"
+          />
+          <div class="server-editor-btns">
+            <button type="button" class="server-btn apply" @click="handleApplyUrl">
+              {{ t('settings.connection.switch') }}
+            </button>
+            <button v-if="currentServerUrl" type="button" class="server-btn reset" @click="handleClearUrl">
+              {{ t('settings.connection.reset') }}
+            </button>
+          </div>
+        </div>
+      </div>
 
       <form class="login-form" @submit.prevent="handleLogin">
         <input
@@ -143,10 +195,112 @@ async function handlePasswordLogin() {
 }
 
 .login-default-hint {
-  margin: 0 0 28px;
+  margin: 0 0 20px;
   font-family: $font-code;
   font-size: 13px;
   color: $text-secondary;
+}
+
+.server-hint {
+  margin-bottom: 8px;
+  font-size: 12px;
+  color: var(--n-text-color-3);
+  line-height: 1.5;
+  white-space: pre-line;
+}
+
+.server-section {
+  margin-bottom: 20px;
+  text-align: left;
+}
+
+.server-current {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid $border-color;
+  border-radius: $radius-sm;
+  cursor: pointer;
+  transition: border-color $transition-fast;
+  font-size: 12px;
+
+  &:hover {
+    border-color: $accent-primary;
+  }
+}
+
+.server-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: $warning;
+  flex-shrink: 0;
+
+  &.connected {
+    background: $success;
+  }
+}
+
+.server-display {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: $text-secondary;
+  font-family: $font-code;
+}
+
+.server-chevron {
+  flex-shrink: 0;
+  transition: transform 0.2s;
+  color: $text-muted;
+
+  &.open {
+    transform: rotate(180deg);
+  }
+}
+
+.server-editor {
+  margin-top: 8px;
+}
+
+.server-input {
+  font-size: 13px !important;
+  padding: 10px 12px !important;
+}
+
+.server-editor-btns {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.server-btn {
+  padding: 6px 14px;
+  border: 1px solid $border-color;
+  border-radius: $radius-sm;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all $transition-fast;
+
+  &.apply {
+    background: $text-primary;
+    color: var(--text-on-accent);
+    border-color: transparent;
+  }
+
+  &.reset {
+    background: transparent;
+    color: $text-secondary;
+
+    &:hover {
+      color: $error;
+      border-color: rgba(var(--error-rgb), 0.3);
+    }
+  }
 }
 
 .login-form {
@@ -220,7 +374,7 @@ async function handlePasswordLogin() {
 
   &:disabled {
     opacity: 0.5;
-    cursor: not-allowed;
+    cursor: not-forced;
   }
 }
 </style>

--- a/packages/client/src/views/hermes/SettingsView.vue
+++ b/packages/client/src/views/hermes/SettingsView.vue
@@ -19,6 +19,7 @@ import ModelSettings from "@/components/hermes/settings/ModelSettings.vue";
 import AccountSettings from "@/components/hermes/settings/AccountSettings.vue";
 import UserManagementSettings from "@/components/hermes/settings/UserManagementSettings.vue";
 import VoiceSettings from "@/components/hermes/settings/VoiceSettings.vue";
+import ConnectionSettings from "@/components/hermes/settings/ConnectionSettings.vue";
 import { isStoredSuperAdmin } from "@/api/client";
 import { useProfilesStore } from "@/stores/hermes/profiles";
 
@@ -41,6 +42,7 @@ const validTabs = computed(() => new Set([
   "privacy",
   "models",
   "voice",
+  "connection",
 ]));
 
 function normalizeTab(value: unknown): string {
@@ -117,6 +119,9 @@ onMounted(() => {
           </NTabPane>
           <NTabPane name="voice" :tab="t('settings.tabs.voice')">
             <VoiceSettings />
+          </NTabPane>
+          <NTabPane name="connection" :tab="t('settings.tabs.connection')">
+            <ConnectionSettings />
           </NTabPane>
         </NTabs>
       </NSpin>


### PR DESCRIPTION
### 发心

Hermes Studio 前端资源体积较大（尽管优化掉了两个5MiB大小思考GIF[/滑稽]），当部署在深层 NAT 后通过 CF Tunnel / Tailscale 等方式远程访问时，每次打开页面都需要从远程后端加载前端资源，导致体验明显缓慢/卡顿。注意到PR#1663 增加了 PWA 支持，资源缓存能改善二次访问体验，但首次加载和缓存失效时仍受制于后端带宽和延迟。

### 本PR提出的解决方案

支持将前端静态资源分离部署到 CDN 或静态托管平台（如 CF Pages），前端秒开，仅通过 CF Tunnel / Tailscale 等通道与后端进行 API 数据通信，不再经过隧道传输前端资源。同时附带多后端服务器管理能力，方便在不同后端之间切换。

### 改动内容

**核心功能**
- `ConnectionSettings` 组件：配置自定义后端地址，支持多服务器保存/切换
- 登录页服务器地址编辑器：默认前后端同源，展开即可设置远程后端
- 保存的服务器列表在登出后保留

**Bug 修复**
- `auth.ts`、`chat.ts`、`group-chat.ts` 的 fetch 请求使用自定义 base URL，修复远程后端场景下 404/405 问题

**国际化**
- 10 个语言的连接设置 i18n（en/zh/zh-TW/de/es/fr/ja/ko/pt/ru）

### 文件变更

| 文件 | 说明 |
|------|------|
| `ConnectionSettings.vue` | 新增，多服务器管理 UI |
| `LoginView.vue` | 添加服务器地址编辑器 |
| `SettingsView.vue` | 集成连接选项卡 |
| `auth.ts` | fetch 使用 getBaseUrlValue() |
| `chat.ts` / `group-chat.ts` | upload 使用自定义 base URL |
| `client.ts` | SavedServer 存储逻辑 |
| `AppSidebar.vue` | 侧边栏添加连接标签 |
| `locales/*.ts` × 10 | 连接设置翻译 |