### PR TITLE
fix: guard missing conversation messages in session detail

### DIFF
--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -339,7 +339,7 @@ export async function getConversationMessages(ctx: any) {
     return
   }
   if (denySessionAccess(ctx, detail)) return
-  const messages = detail.messages
+  const messages = (detail.messages || [])
     .filter(m => {
       if (humanOnly && m.role !== 'user' && m.role !== 'assistant') return false
       if (!m.content) return false

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -521,6 +521,24 @@ describe('session conversations controller', () => {
     })
   })
 
+  it('treats missing conversation message arrays as empty', async () => {
+    localGetSessionDetailMock.mockReturnValue({
+      id: 'root',
+    })
+
+    const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+    const ctx: any = { params: { id: 'root' }, query: { humanOnly: 'false' }, body: null }
+    await mod.getConversationMessages(ctx)
+
+    expect(localGetSessionDetailMock).toHaveBeenCalledWith('root')
+    expect(ctx.body).toEqual({
+      session_id: 'root',
+      messages: [],
+      visible_count: 0,
+      thread_session_count: 1,
+    })
+  })
+
   it('returns 404 when local conversation detail is missing', async () => {
     localGetSessionDetailMock.mockReturnValue(null)
 


### PR DESCRIPTION
## What changed

- Guard `getConversationMessages` against missing `detail.messages` values.
- Add a regression test for the empty-message-array case.

## Why

Some conversation detail payloads can arrive without a `messages` array. The previous code assumed it always existed and would throw when calling array methods.

## Impact

This avoids an unnecessary 500 when loading session messages and makes the endpoint more resilient to incomplete data.

## Validation

- `npx vitest run tests/server/sessions-controller.test.ts`