### PR TITLE
[codex] increase goal evaluate timeout

### DIFF
--- a/docs/chat-chain-changes/2026-06-20-pr1686-goal-evaluate-timeout.md
+++ b/docs/chat-chain-changes/2026-06-20-pr1686-goal-evaluate-timeout.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-20
+pr: 1686
+feature: Goal auto-continuation evaluation timeout
+impact: Goal judge evaluation now waits up to 120 seconds instead of 5 seconds, preventing slow remote LLM services from timing out before continuation can be queued.
+---

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -37,7 +37,7 @@ import type { AuthenticatedUser } from '../../../middleware/user-auth'
 const BRIDGE_USAGE_FLUSH_DELAY_MS = 200
 const BRIDGE_TITLE_EVENT_POLL_INTERVAL_MS = 500
 const BRIDGE_TITLE_EVENT_POLL_TIMEOUT_MS = 45_000
-const BRIDGE_GOAL_EVALUATE_TIMEOUT_MS = 5_000
+const BRIDGE_GOAL_EVALUATE_TIMEOUT_MS = 120_000
 
 function stringValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''


### PR DESCRIPTION
## Summary

Increase the bridge goal evaluate timeout from 5 seconds to 120 seconds.

## Why

The 5 second hard timeout is too aggressive for remote or slow LLM services. When the goal judge call times out, continuation is not queued, which can leave a goal stuck after the first turn.

This aligns the runtime timeout with the default `auxiliary.goal_judge.timeout: 120` configuration.

## Validation

- `npx tsc --noEmit -p packages/server/tsconfig.json`