### PR TITLE
[codex] add mcp use ops tools

### DIFF
--- a/bin/hermes-studio-mcp.mjs
+++ b/bin/hermes-studio-mcp.mjs
@@ -576,6 +576,72 @@ function pickDefined(source, keys) {
   return picked
 }
 
+function boundedInteger(value, fallback, min, max) {
+  const parsed = Number.parseInt(String(value ?? ''), 10)
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.max(min, Math.min(max, parsed))
+}
+
+function cleanSessionContextPayload(payload, args = {}) {
+  const turns = boundedInteger(args.turns, 10, 1, 50)
+  const messages = Array.isArray(payload?.messages) ? payload.messages : []
+  const cleanMessages = messages
+    .filter(message => message?.role === 'user' || message?.role === 'assistant')
+    .filter(message => !Array.isArray(message?.tool_calls) || message.tool_calls.length === 0)
+    .filter(message => !message?.tool_call_id && !message?.tool_name)
+    .map(message => pickDefined(message, [
+      'id',
+      'session_id',
+      'role',
+      'content',
+      'timestamp',
+      'reasoning',
+      'reasoning_content',
+    ]))
+    .filter(message => typeof message.content === 'string' ? message.content.trim() : message.content != null)
+  const maxMessages = turns * 2
+  const returnedMessages = cleanMessages.slice(-maxMessages)
+  return {
+    ...payload,
+    messages: returnedMessages,
+    message_count: returnedMessages.length,
+    clean_message_count: cleanMessages.length,
+    requested_turns: turns,
+  }
+}
+
+function summarizeWorkerRuntime(payload) {
+  const workers = Array.isArray(payload?.bridge?.workers) ? payload.bridge.workers : []
+  const summarizedWorkers = workers.map(worker => {
+    const sessionCount = Number(worker?.sessionCount || 0)
+    const interactingSessionCount = Number(worker?.runningSessionCount || 0)
+    return {
+      profile: worker?.profile || '',
+      pid: worker?.pid || 0,
+      running: Boolean(worker?.running),
+      session_count: sessionCount,
+      interacting_session_count: interactingSessionCount,
+      completed_interaction_count: Math.max(0, sessionCount - interactingSessionCount),
+      last_used_at: worker?.lastUsedAt || null,
+      endpoint: worker?.endpoint || '',
+    }
+  })
+  const interactingWorkers = summarizedWorkers.filter(worker => worker.interacting_session_count > 0)
+  const completedWorkers = summarizedWorkers.filter(worker => worker.session_count > 0 && worker.interacting_session_count === 0)
+  return {
+    timestamp: payload?.timestamp || Date.now(),
+    bridge_reachable: Boolean(payload?.bridge?.reachable),
+    worker_count: summarizedWorkers.length,
+    running_worker_count: summarizedWorkers.filter(worker => worker.running).length,
+    session_count: summarizedWorkers.reduce((sum, worker) => sum + worker.session_count, 0),
+    interacting_session_count: summarizedWorkers.reduce((sum, worker) => sum + worker.interacting_session_count, 0),
+    completed_interaction_count: summarizedWorkers.reduce((sum, worker) => sum + worker.completed_interaction_count, 0),
+    interacting_workers: interactingWorkers,
+    completed_workers: completedWorkers,
+    workers: summarizedWorkers,
+  }
+}
+
 function availableModelGroups(payload) {
   const groups = Array.isArray(payload?.groups)
     ? payload.groups
@@ -810,6 +876,17 @@ const tools = [
       }),
   },
   {
+    name: 'hermes_studio_use_usage_stats',
+    toolset: 'use',
+    description: 'Query Hermes Studio usage totals, cost estimate, model breakdown, and daily trend for the selected profile.',
+    inputSchema: inputSchema({
+        days: {
+          type: 'number',
+          description: 'Number of days to include. Server clamps the range to 1-365. Defaults to 30.',
+        },
+      }),
+  },
+  {
     name: 'hermes_studio_use_session_get',
     toolset: 'use',
     description: 'Get one Hermes Studio session by id.',
@@ -832,6 +909,21 @@ const tools = [
         include_internal: {
           type: 'boolean',
           description: 'Set true to include internal/non-user-visible message roles.',
+        },
+      }, ['session_id']),
+  },
+  {
+    name: 'hermes_studio_use_session_context',
+    toolset: 'use',
+    description: 'Get the latest clean user/assistant context for one session, defaulting to the last 10 conversation turns and excluding tool calls/tool results.',
+    inputSchema: inputSchema({
+        session_id: {
+          type: 'string',
+          description: 'Session id.',
+        },
+        turns: {
+          type: 'number',
+          description: 'Number of recent conversation turns to return. Defaults to 10.',
         },
       }, ['session_id']),
   },
@@ -883,6 +975,68 @@ const tools = [
           description: 'Model id or visible model alias to look up.',
         },
       }, ['model']),
+  },
+  {
+    name: 'hermes_studio_use_provider_add',
+    toolset: 'use',
+    description: 'Add or update a Hermes Studio model provider for the selected profile, then make it the active default provider/model.',
+    inputSchema: inputSchema({
+        name: {
+          type: 'string',
+          description: 'Provider display/config name. For custom providers this becomes the custom provider name.',
+        },
+        base_url: {
+          type: 'string',
+          description: 'Provider API base URL. For built-in providers this can be omitted only when the preset supplies a default URL.',
+        },
+        api_key: {
+          type: 'string',
+          description: 'Provider API key. Some built-in providers do not require this.',
+        },
+        model: {
+          type: 'string',
+          description: 'Default model id to use with this provider.',
+        },
+        context_length: {
+          type: 'number',
+          description: 'Optional context length metadata for the model.',
+        },
+        providerKey: {
+          type: ['string', 'null'],
+          description: 'Optional built-in or custom provider key. Omit for a normal custom provider; use values like openai-codex or custom:my-provider when needed.',
+        },
+        api_mode: {
+          type: 'string',
+          enum: ['chat_completions', 'codex_responses', 'anthropic_messages', 'bedrock_converse', 'codex_app_server'],
+          description: 'Optional provider wire API mode.',
+        },
+      }, ['name', 'base_url', 'model']),
+  },
+  {
+    name: 'hermes_studio_use_provider_delete',
+    toolset: 'use',
+    description: 'Delete a Hermes Studio model provider or clear a built-in provider credential for the selected profile.',
+    inputSchema: inputSchema({
+        pool_key: {
+          type: 'string',
+          description: 'Provider pool key to delete, for example custom:my-provider, openai, openai-codex, or deepseek.',
+        },
+        source: {
+          type: 'string',
+          enum: ['custom_providers', 'providers'],
+          description: 'Optional custom provider storage source when removing one duplicate location.',
+        },
+        providerKey: {
+          type: 'string',
+          description: 'Optional providers-dict key to disambiguate dict-backed custom providers.',
+        },
+      }, ['pool_key']),
+  },
+  {
+    name: 'hermes_studio_use_worker_status',
+    toolset: 'use',
+    description: 'Summarize current Hermes worker state, including worker count, completed interactions, and sessions still interacting.',
+    inputSchema: inputSchema(),
   },
   {
     name: 'hermes_studio_lan_devices_list',
@@ -1094,12 +1248,21 @@ async function callTool(name, args = {}) {
       return jsonText(await request('/api/hermes/sessions/count', withAuthArgs(args, {
         query: pickDefined(args, ['source']),
       })))
+    case 'hermes_studio_use_usage_stats':
+      return jsonText(await request('/api/hermes/usage/stats', withAuthArgs(args, {
+        query: pickDefined(args, ['days']),
+      })))
     case 'hermes_studio_use_session_get':
       return jsonText(await request(`/api/hermes/sessions/${encodeURIComponent(args.session_id)}`, withAuthArgs(args)))
     case 'hermes_studio_use_session_messages':
       return jsonText(await request(`/api/hermes/sessions/conversations/${encodeURIComponent(args.session_id)}/messages`, withAuthArgs(args, {
         query: args.include_internal ? { humanOnly: '0' } : undefined,
       })))
+    case 'hermes_studio_use_session_context':
+      return jsonText(cleanSessionContextPayload(
+        await request(`/api/hermes/sessions/${encodeURIComponent(args.session_id)}/context`, withAuthArgs(args)),
+        args,
+      ))
     case 'hermes_studio_use_session_delete':
       return jsonText(await request(`/api/hermes/sessions/${encodeURIComponent(args.session_id)}`, withAuthArgs(args, {
         method: 'DELETE',
@@ -1117,6 +1280,28 @@ async function callTool(name, args = {}) {
       return jsonText(findProvidersForModel(
         await request('/api/hermes/available-models', withAuthArgs(args)),
         args.model,
+      ))
+    case 'hermes_studio_use_provider_add':
+      return jsonText(await request('/api/hermes/config/providers', withAuthArgs(args, {
+        method: 'POST',
+        body: pickDefined(args, [
+          'name',
+          'base_url',
+          'api_key',
+          'model',
+          'context_length',
+          'providerKey',
+          'api_mode',
+        ]),
+      })))
+    case 'hermes_studio_use_provider_delete':
+      return jsonText(await request(`/api/hermes/config/providers/${encodeURIComponent(args.pool_key)}`, withAuthArgs(args, {
+        method: 'DELETE',
+        query: pickDefined(args, ['source', 'providerKey']),
+      })))
+    case 'hermes_studio_use_worker_status':
+      return jsonText(summarizeWorkerRuntime(
+        await request('/api/hermes/performance/runtime', withAuthArgs(args)),
       ))
     case 'hermes_studio_lan_devices_list':
       return jsonText(await request('/api/devices', withAuthArgs(args)))

--- a/tests/server/hermes-web-ui-mcp.test.ts
+++ b/tests/server/hermes-web-ui-mcp.test.ts
@@ -331,8 +331,41 @@ describe('hermes-web-ui MCP server', () => {
         res.end(JSON.stringify({ count: 7 }))
         return
       }
+      if (req.url === '/api/hermes/usage/stats?days=7') {
+        res.end(JSON.stringify({
+          total_input_tokens: 100,
+          total_output_tokens: 40,
+          total_cache_read_tokens: 10,
+          total_cache_write_tokens: 2,
+          total_reasoning_tokens: 5,
+          total_sessions: 3,
+          total_cost: 0.0123,
+          total_api_calls: 4,
+          period_days: 7,
+          model_usage: [{ model: 'gpt-5.1', input_tokens: 100, output_tokens: 40, cache_read_tokens: 10, cache_write_tokens: 2, reasoning_tokens: 5, sessions: 3 }],
+          daily_usage: [],
+        }))
+        return
+      }
       if (req.url === '/api/hermes/sessions/session-1' && req.method === 'GET') {
         res.end(JSON.stringify({ id: 'session-1', title: 'Session 1' }))
+        return
+      }
+      if (req.url === '/api/hermes/sessions/session-1/context') {
+        res.end(JSON.stringify({
+          session_id: 'session-1',
+          title: 'Session 1',
+          messages: [
+            { id: 1, role: 'user', content: 'older', timestamp: 1 },
+            { id: 2, role: 'assistant', content: 'tool call shell', timestamp: 2, tool_calls: [{ id: 'call-1' }] },
+            { id: 3, role: 'tool', content: 'secret tool result', timestamp: 3, tool_call_id: 'call-1', tool_name: 'read_file' },
+            { id: 4, role: 'user', content: 'hello', timestamp: 4 },
+            { id: 5, role: 'assistant', content: 'hi', timestamp: 5 },
+            { id: 6, role: 'user', content: 'next', timestamp: 6 },
+            { id: 7, role: 'assistant', content: 'done', timestamp: 7 },
+          ],
+          message_count: 7,
+        }))
         return
       }
       if (req.url === '/api/hermes/sessions/session-1' && req.method === 'DELETE') {
@@ -363,6 +396,35 @@ describe('hermes-web-ui MCP server', () => {
             { id: 'openai', label: 'OpenAI', models: ['gpt-5.1'] },
             { id: 'openrouter', label: 'OpenRouter', models: ['gpt-5.1', 'claude-sonnet'], model_meta: { 'claude-sonnet': { alias: 'Claude Sonnet' } } },
           ],
+        }))
+        return
+      }
+      if (req.url === '/api/hermes/config/providers' && req.method === 'POST') {
+        let raw = ''
+        req.on('data', chunk => { raw += chunk })
+        req.on('end', () => {
+          res.end(JSON.stringify({
+            success: true,
+            body: raw ? JSON.parse(raw) : null,
+          }))
+        })
+        return
+      }
+      if (req.url === '/api/hermes/config/providers/custom%3Aedge-router?source=providers&providerKey=edge-router' && req.method === 'DELETE') {
+        res.end(JSON.stringify({ success: true, deleted: 'custom:edge-router' }))
+        return
+      }
+      if (req.url === '/api/hermes/performance/runtime') {
+        res.end(JSON.stringify({
+          timestamp: 123456,
+          bridge: {
+            reachable: true,
+            workers: [
+              { profile: 'default', pid: 101, running: true, sessionCount: 3, runningSessionCount: 1, lastUsedAt: 123400, endpoint: 'ipc://default' },
+              { profile: 'research', pid: 102, running: true, sessionCount: 2, runningSessionCount: 0, lastUsedAt: 123300, endpoint: 'ipc://research' },
+            ],
+          },
+          sessions: { active: 5, running: 1, byProfile: { default: 3, research: 2 } },
         }))
         return
       }
@@ -435,6 +497,37 @@ describe('hermes-web-ui MCP server', () => {
       name: 'hermes_studio_use_model_provider_get',
       arguments: { model: 'Claude Sonnet' },
     })
+    writeRpc(child, 15, 'tools/call', {
+      name: 'hermes_studio_use_provider_add',
+      arguments: {
+        name: 'Edge Router',
+        base_url: 'https://edge.example/v1',
+        api_key: 'secret-key',
+        model: 'edge-model',
+        context_length: 128000,
+        api_mode: 'chat_completions',
+      },
+    })
+    writeRpc(child, 16, 'tools/call', {
+      name: 'hermes_studio_use_provider_delete',
+      arguments: {
+        pool_key: 'custom:edge-router',
+        source: 'providers',
+        providerKey: 'edge-router',
+      },
+    })
+    writeRpc(child, 17, 'tools/call', {
+      name: 'hermes_studio_use_usage_stats',
+      arguments: { days: 7 },
+    })
+    writeRpc(child, 18, 'tools/call', {
+      name: 'hermes_studio_use_session_context',
+      arguments: { session_id: 'session-1', turns: 1 },
+    })
+    writeRpc(child, 19, 'tools/call', {
+      name: 'hermes_studio_use_worker_status',
+      arguments: {},
+    })
 
     const initialized = await waitForRpc(responses, 1)
     expect(initialized.result.serverInfo).toMatchObject({ toolset: 'use' })
@@ -442,9 +535,14 @@ describe('hermes-web-ui MCP server', () => {
     const list = await waitForRpc(responses, 2)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_chat_run')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_sessions_count')).toBe(true)
+    expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_usage_stats')).toBe(true)
+    expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_session_context')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_session_delete')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_session_rename')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_model_provider_get')).toBe(true)
+    expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_provider_add')).toBe(true)
+    expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_provider_delete')).toBe(true)
+    expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_worker_status')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_api_request')).toBe(false)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_lan_devices_list')).toBe(false)
 
@@ -481,6 +579,46 @@ describe('hermes-web-ui MCP server', () => {
       provider: 'openrouter',
       ambiguous: false,
     })
+    const addedProvider = JSON.parse((await waitForRpc(responses, 15)).result.content[0].text)
+    expect(addedProvider).toEqual({
+      success: true,
+      body: {
+        name: 'Edge Router',
+        base_url: 'https://edge.example/v1',
+        api_key: 'secret-key',
+        model: 'edge-model',
+        context_length: 128000,
+        api_mode: 'chat_completions',
+      },
+    })
+    const deletedProvider = JSON.parse((await waitForRpc(responses, 16)).result.content[0].text)
+    expect(deletedProvider).toEqual({ success: true, deleted: 'custom:edge-router' })
+    const usage = JSON.parse((await waitForRpc(responses, 17)).result.content[0].text)
+    expect(usage).toMatchObject({ total_input_tokens: 100, total_output_tokens: 40, period_days: 7 })
+    const context = JSON.parse((await waitForRpc(responses, 18)).result.content[0].text)
+    expect(context).toMatchObject({
+      session_id: 'session-1',
+      message_count: 2,
+      clean_message_count: 5,
+      requested_turns: 1,
+      messages: [
+        { id: 6, role: 'user', content: 'next', timestamp: 6 },
+        { id: 7, role: 'assistant', content: 'done', timestamp: 7 },
+      ],
+    })
+    expect(JSON.stringify(context)).not.toContain('tool_calls')
+    expect(JSON.stringify(context)).not.toContain('secret tool result')
+    const workerStatus = JSON.parse((await waitForRpc(responses, 19)).result.content[0].text)
+    expect(workerStatus).toMatchObject({
+      bridge_reachable: true,
+      worker_count: 2,
+      running_worker_count: 2,
+      session_count: 5,
+      interacting_session_count: 1,
+      completed_interaction_count: 4,
+    })
+    expect(workerStatus.interacting_workers.map((worker: any) => worker.profile)).toEqual(['default'])
+    expect(workerStatus.completed_workers.map((worker: any) => worker.profile)).toEqual(['research'])
 
     await new Promise<void>(resolve => server.close(() => resolve()))
   })


### PR DESCRIPTION
## Summary

- add curated MCP use tools for provider add/delete, usage stats, clean session context, and worker status

## Validation

- npm run test -- tests/server/hermes-web-ui-mcp.test.ts
- npm run harness:check
## Notes
The session context tool excludes tool calls and tool result messages, then returns the most recent clean user/assistant turns.






