### PR TITLE
[codex] fix MCU premature done status

### DIFF
--- a/packages/esp32-c3/src/main.cpp
+++ b/packages/esp32-c3/src/main.cpp
@@ -512,7 +512,7 @@ void drawOledFrame() {
     status += F(" ");
     status += oledHint;
   }
-  oledDrawCenteredText(57, fitOledText(status, 21), 1);
+  oledDrawScrollingText(57, status, 1);
 }
 
 void refreshOled(bool force = false) {

--- a/packages/esp32-c3/src/main.cpp
+++ b/packages/esp32-c3/src/main.cpp
@@ -2918,7 +2918,7 @@ void handleMcuAudioEnqueue(uint8_t clientId, const String &message) {
   int channels = jsonIntValue(message, F("channels"));
   segment.channels = channels == 1 ? 1 : 2;
   segment.durationMs = static_cast<uint32_t>(jsonIntValue(message, F("durationMs")));
-  segment.completionManagedByServer = true;
+  segment.completionManagedByServer = jsonBoolValue(message, F("completionManagedByServer"));
 
   bool queued = enqueueMcuAudio(segment);
   String json;

--- a/packages/esp32-c3/src/main.cpp
+++ b/packages/esp32-c3/src/main.cpp
@@ -158,6 +158,7 @@ struct McuAudioSegment {
   String mimeType;
   uint8_t channels = 2;
   uint32_t durationMs = 0;
+  bool completionManagedByServer = false;
 };
 
 McuAudioSegment mcuAudioQueue[kMaxMcuAudioQueue];
@@ -2761,6 +2762,7 @@ void startNextMcuAudio() {
   if (mcuCurrentAudio.url.length() > 0) {
     bool played = playPcmUrl(mcuCurrentAudio.url, mcuCurrentAudio.channels);
     String interruptedInteractionId = mcuCurrentAudio.interactionId;
+    bool completionManagedByServer = mcuCurrentAudio.completionManagedByServer;
     finishMcuAudio(!played);
     if (mcuVoiceAfterAudioInterrupt) {
       mcuVoiceAfterAudioInterrupt = false;
@@ -2779,7 +2781,7 @@ void startNextMcuAudio() {
     }
     if (played) {
       startNextMcuAudio();
-      if (!mcuAudioPlaying && mcuAudioCount == 0) {
+      if (!completionManagedByServer && !mcuAudioPlaying && mcuAudioCount == 0) {
         markMcuInteraction(interruptedInteractionId, F("completed"), F(""));
         broadcastMcuStatus();
       }
@@ -2916,6 +2918,7 @@ void handleMcuAudioEnqueue(uint8_t clientId, const String &message) {
   int channels = jsonIntValue(message, F("channels"));
   segment.channels = channels == 1 ? 1 : 2;
   segment.durationMs = static_cast<uint32_t>(jsonIntValue(message, F("durationMs")));
+  segment.completionManagedByServer = true;
 
   bool queued = enqueueMcuAudio(segment);
   String json;
@@ -4064,9 +4067,10 @@ void handleHealth() {
 void tickMcuInteraction() {
   if (mcuAudioPlaying && mcuAudioDurationMs > 0 &&
       millis() - mcuAudioStartedAtMs >= mcuAudioDurationMs) {
+    bool completionManagedByServer = mcuCurrentAudio.completionManagedByServer;
     finishMcuAudio(false);
     startNextMcuAudio();
-    if (!mcuAudioPlaying && mcuAudioCount == 0 &&
+    if (!completionManagedByServer && !mcuAudioPlaying && mcuAudioCount == 0 &&
         (mcuInteractionStatus == F("speaking") || mcuInteractionStatus == F("completed"))) {
       markMcuInteraction(mcuInteractionId, F("completed"), F(""));
       broadcastMcuStatus();

--- a/packages/esp32-c3/src/main.cpp
+++ b/packages/esp32-c3/src/main.cpp
@@ -2716,6 +2716,26 @@ void markMcuInteraction(const String &interactionId, const String &status, const
   oledDirty = true;
 }
 
+bool shouldPreserveMcuToolStatus(const String &interactionId) {
+  return mcuInteractionStatus == F("tool") && mcuToolName.length() > 0 &&
+         (interactionId.length() == 0 || mcuInteractionId.length() == 0 || interactionId == mcuInteractionId);
+}
+
+void touchMcuInteraction(const String &interactionId) {
+  if (interactionId.length() > 0) mcuInteractionId = interactionId;
+  mcuInteractionActive = true;
+  mcuInteractionUpdatedAtMs = millis();
+  oledDirty = true;
+}
+
+void markMcuAudioSpeaking(const String &interactionId) {
+  if (shouldPreserveMcuToolStatus(interactionId)) {
+    touchMcuInteraction(interactionId);
+    return;
+  }
+  markMcuInteraction(interactionId, F("speaking"), F(""));
+}
+
 void finishMcuAudio(bool interrupted) {
   if (!mcuAudioPlaying) return;
   String json;
@@ -2746,7 +2766,7 @@ void startNextMcuAudio() {
   mcuAudioPlaying = true;
   mcuAudioStartedAtMs = millis();
   mcuAudioDurationMs = mcuAudioDurationFor(mcuCurrentAudio);
-  markMcuInteraction(mcuCurrentAudio.interactionId, F("speaking"), F(""));
+  markMcuAudioSpeaking(mcuCurrentAudio.interactionId);
 
   String json;
   json.reserve(260);
@@ -2794,7 +2814,7 @@ bool enqueueMcuAudio(const McuAudioSegment &segment) {
   int tail = (mcuAudioHead + mcuAudioCount) % kMaxMcuAudioQueue;
   mcuAudioQueue[tail] = segment;
   ++mcuAudioCount;
-  markMcuInteraction(segment.interactionId, F("speaking"), F(""));
+  markMcuAudioSpeaking(segment.interactionId);
   startNextMcuAudio();
   return true;
 }
@@ -2804,12 +2824,16 @@ void handleMcuInteractionStatus(uint8_t clientId, const String &message) {
   String status = jsonStringValue(message, F("status"));
   String text = jsonStringValue(message, F("text"));
   if (status.length() == 0) status = F("thinking");
-  if (status != F("tool")) {
-    mcuToolName = "";
-    mcuToolPreview = "";
-    mcuToolStatus = "";
+  if (status == F("speaking") && shouldPreserveMcuToolStatus(interactionId)) {
+    touchMcuInteraction(interactionId);
+  } else {
+    if (status != F("tool")) {
+      mcuToolName = "";
+      mcuToolPreview = "";
+      mcuToolStatus = "";
+    }
+    markMcuInteraction(interactionId, status, text);
   }
-  markMcuInteraction(interactionId, status, text);
   sendWsJson(clientId, String(F("{\"type\":\"interaction.status.ack\",\"ok\":true,\"status\":\"")) +
                          escapeJson(status) + F("\"}"));
   broadcastMcuStatus();

--- a/packages/server/src/services/global-agent/outbound-relay-client.ts
+++ b/packages/server/src/services/global-agent/outbound-relay-client.ts
@@ -799,6 +799,7 @@ class PlainWebSocketRelayClient {
       channels: 1,
       sampleRate: MCU_TTS_SAMPLE_RATE,
       durationMs: Math.max(1200, Math.min(text.length * 180, 12_000)),
+      completionManagedByServer: true,
     })
     await waitForDone
   }

--- a/packages/server/src/services/global-agent/server.ts
+++ b/packages/server/src/services/global-agent/server.ts
@@ -1162,6 +1162,7 @@ export class GlobalAgentServer {
       channels: 1,
       sampleRate: MCU_TTS_SAMPLE_RATE,
       durationMs: Math.max(1200, Math.min(text.length * 180, 12_000)),
+      completionManagedByServer: true,
     }, { clientId: options.clientId })
     await waitForDone
   }

--- a/tests/server/global-agent-server.test.ts
+++ b/tests/server/global-agent-server.test.ts
@@ -635,6 +635,7 @@ describe('GlobalAgentServer', () => {
       interactionId: 'voice-1',
       segmentId: 'voice-1-tts-1',
       url: expect.stringMatching(/^\/api\/hermes\/mcu\/audio\/[a-f0-9-]+\.pcm$/),
+      completionManagedByServer: true,
     }))
     agentSocket.__handlers.get('audio.done')?.({
       interactionId: 'voice-1',
@@ -654,6 +655,7 @@ describe('GlobalAgentServer', () => {
       interactionId: 'voice-1',
       segmentId: 'voice-1-tts-2',
       url: expect.stringMatching(/^\/api\/hermes\/mcu\/audio\/[a-f0-9-]+\.pcm$/),
+      completionManagedByServer: true,
     }))
   })
 

--- a/tests/server/outbound-relay-client.test.ts
+++ b/tests/server/outbound-relay-client.test.ts
@@ -168,6 +168,7 @@ describe('outbound relay client', () => {
       channels: 2,
       sampleRate: 16000,
     })
+    expect(enqueuePayload).not.toHaveProperty('completionManagedByServer')
 
     ws.__handlers.get('message')?.(JSON.stringify({
       type: 'audio.done',
@@ -238,6 +239,7 @@ describe('outbound relay client', () => {
       channels: 1,
       sampleRate: 16000,
     })
+    expect(enqueuePayload).not.toHaveProperty('completionManagedByServer')
   })
 
   it('forwards an allowed HTTP request to the local Web UI server', async () => {


### PR DESCRIPTION
## Summary
- Keep MCU WebSocket audio segments from marking the whole interaction completed locally.
- Let server-managed MCU turns show DONE only after the server sends `interaction.status: completed`.

## Why
- MCU audio playback sends `audio.done` per segment. The firmware treated an empty audio queue after a segment as the full interaction being complete, so long runs with tool calls could show DONE while the server run was still active.

## Validation
- `git diff --check`
- `pio run` attempted, but the local PlatformIO toolchain is missing `riscv32-esp-elf-g++`, so firmware compilation could not complete in this environment.