### PR TITLE
Fix Windows PATH shim Unicode handling

### DIFF
--- a/packages/desktop/src/main/cli-shim.ts
+++ b/packages/desktop/src/main/cli-shim.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import { execFile } from 'node:child_process'
 import {
   appendFileSync,
@@ -18,6 +19,7 @@ const SHIM_MARKER = 'HERMES_STUDIO_CLI_SHIM'
 const MCP_SHIM_MARKER = 'HERMES_STUDIO_MCP_SHIM'
 const PATH_MARKER_START = '# >>> Hermes Studio CLI shim >>>'
 const PATH_MARKER_END = '# <<< Hermes Studio CLI shim <<<'
+const WINDOWS_USER_PATH_ENV_B64 = 'HERMES_STUDIO_WINDOWS_USER_PATH_B64'
 
 type ShimInstallStatus = 'installed' | 'updated' | 'unchanged' | 'skipped'
 
@@ -338,28 +340,48 @@ function shellPathSnippet(platform: NodeJS.Platform, profilePath: string): strin
   ].join('\n')
 }
 
+function powershellArgs(command: string): string[] {
+  return ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', command]
+}
+
+async function readWindowsUserPath(): Promise<string> {
+  const command = [
+    "$value = [Environment]::GetEnvironmentVariable('Path', 'User')",
+    "if ($null -ne $value -and $value.Length -gt 0) { [Console]::Out.Write([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($value))) }",
+  ].join('; ')
+  const { stdout } = await execFileAsync('powershell.exe', powershellArgs(command), {
+    encoding: 'utf-8',
+    timeout: 3000,
+    windowsHide: true,
+  })
+  const encoded = stdout.trim()
+  return encoded.length > 0 ? Buffer.from(encoded, 'base64').toString('utf-8') : ''
+}
+
+async function writeWindowsUserPath(pathValue: string): Promise<void> {
+  const command = [
+    `$bytes = [Convert]::FromBase64String($env:${WINDOWS_USER_PATH_ENV_B64})`,
+    '$value = [System.Text.Encoding]::UTF8.GetString($bytes)',
+    "[Environment]::SetEnvironmentVariable('Path', $value, 'User')",
+  ].join('; ')
+  await execFileAsync('powershell.exe', powershellArgs(command), {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      [WINDOWS_USER_PATH_ENV_B64]: Buffer.from(pathValue, 'utf-8').toString('base64'),
+    },
+    timeout: 3000,
+    windowsHide: true,
+  })
+}
+
 async function ensureWindowsUserPath(binDir: string): Promise<boolean> {
-  let currentPath = ''
-  try {
-    const { stdout } = await execFileAsync('reg.exe', ['query', 'HKCU\\Environment', '/v', 'Path'], {
-      encoding: 'utf-8',
-      timeout: 1500,
-      windowsHide: true,
-    })
-    const line = stdout.split(/\r?\n/).find(row => /^\s*Path\s+REG_/.test(row))
-    if (line) currentPath = line.replace(/^\s*Path\s+REG_\w+\s+/, '').trim()
-  } catch {
-    currentPath = process.env.Path || process.env.PATH || ''
-  }
+  const currentPath = await readWindowsUserPath()
 
   if (pathContainsDir(currentPath, binDir, 'win32')) return false
 
   const separator = currentPath ? ';' : ''
-  await execFileAsync('reg.exe', ['add', 'HKCU\\Environment', '/v', 'Path', '/t', 'REG_EXPAND_SZ', '/d', `${binDir}${separator}${currentPath}`, '/f'], {
-    encoding: 'utf-8',
-    timeout: 1500,
-    windowsHide: true,
-  })
+  await writeWindowsUserPath(`${binDir}${separator}${currentPath}`)
   return true
 }
 

--- a/tests/desktop/cli-shim.test.ts
+++ b/tests/desktop/cli-shim.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createMcpShimContent,
   createShimContent,
@@ -10,7 +10,17 @@ import {
   shimPathForPlatform,
 } from '../../packages/desktop/src/main/cli-shim'
 
+const execFileMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+}))
+
 let tempDirs: string[] = []
+
+beforeEach(() => {
+  execFileMock.mockReset()
+})
 
 afterEach(() => {
   for (const dir of tempDirs) {
@@ -118,5 +128,69 @@ describe('Hermes Studio CLI shim', () => {
     expect(readFileSync(result.shimPath, 'utf-8')).toContain("NODE='/runtime/node/bin/node'")
     expect(readFileSync(result.shimPath, 'utf-8')).toContain("WEBUI_SCRIPT='/resources/webui/bin/hermes-web-ui.mjs'")
     expect(readFileSync(join(homeDir, '.zprofile'), 'utf-8')).toContain('export PATH="$HOME/bin:$PATH"')
+  })
+
+  it('updates Windows user PATH through PowerShell without corrupting Unicode entries', async () => {
+    const existingPath = 'C:\\Users\\张三\\工具;C:\\Windows\\System32'
+    let writtenPath = ''
+    execFileMock.mockImplementation((command, args, options, callback) => {
+      const script = Array.isArray(args) ? args.join(' ') : ''
+      if (command !== 'powershell.exe') {
+        callback(new Error(`unexpected command: ${command}`))
+        return
+      }
+      if (script.includes('GetEnvironmentVariable')) {
+        callback(null, { stdout: Buffer.from(existingPath, 'utf-8').toString('base64'), stderr: '' })
+        return
+      }
+      if (script.includes('SetEnvironmentVariable')) {
+        writtenPath = Buffer.from(options.env.HERMES_STUDIO_WINDOWS_USER_PATH_B64, 'base64').toString('utf-8')
+        callback(null, { stdout: '', stderr: '' })
+        return
+      }
+      callback(new Error(`unexpected PowerShell script: ${script}`))
+    })
+
+    const homeDir = tempHome()
+    const result = await installHermesStudioCliShim({
+      homeDir,
+      platform: 'win32',
+      executablePath: 'C:\\Program Files\\Hermes Studio\\Hermes Studio.exe',
+      nodePath: 'C:\\Program Files\\Hermes Studio\\node.exe',
+      webUiScriptPath: 'C:\\Program Files\\Hermes Studio\\resources\\webui\\bin\\hermes-web-ui.mjs',
+      env: { Path: existingPath },
+    })
+
+    expect(result.status).toBe('installed')
+    expect(result.pathUpdated).toBe(true)
+    expect(execFileMock).toHaveBeenCalledTimes(2)
+    expect(execFileMock).not.toHaveBeenCalledWith('reg.exe', expect.anything(), expect.anything(), expect.anything())
+    expect(writtenPath).toBe(`${join(homeDir, 'bin')};${existingPath}`)
+  })
+
+  it('does not rewrite Windows user PATH when the shim directory is already present', async () => {
+    const homeDir = tempHome()
+    const existingPath = `${join(homeDir, 'bin')};C:\\Users\\张三\\工具`
+    execFileMock.mockImplementation((command, args, _options, callback) => {
+      const script = Array.isArray(args) ? args.join(' ') : ''
+      if (command === 'powershell.exe' && script.includes('GetEnvironmentVariable')) {
+        callback(null, { stdout: Buffer.from(existingPath, 'utf-8').toString('base64'), stderr: '' })
+        return
+      }
+      callback(new Error(`unexpected command: ${command}`))
+    })
+
+    const result = await installHermesStudioCliShim({
+      homeDir,
+      platform: 'win32',
+      executablePath: 'C:\\Program Files\\Hermes Studio\\Hermes Studio.exe',
+      nodePath: 'C:\\Program Files\\Hermes Studio\\node.exe',
+      webUiScriptPath: 'C:\\Program Files\\Hermes Studio\\resources\\webui\\bin\\hermes-web-ui.mjs',
+      env: { Path: existingPath },
+    })
+
+    expect(result.status).toBe('installed')
+    expect(result.pathUpdated).toBe(false)
+    expect(execFileMock).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary\n- replace Windows User PATH registration via reg.exe with PowerShell/.NET environment APIs\n- pass PATH values through UTF-8 base64 to avoid command-line escaping and codepage corruption\n- add Windows shim tests for Unicode PATH preservation and no-op behavior when the shim dir already exists\n\nFixes #1691\n\n## Validation\n- npm run test -- tests/desktop/cli-shim.test.ts\n- npm --prefix packages/desktop run build:main\n- git diff --check