### PR TITLE
fix: preserve cron file metadata

### DIFF
--- a/packages/server/src/controllers/hermes/jobs.ts
+++ b/packages/server/src/controllers/hermes/jobs.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'koa'
 import { existsSync, readFileSync } from 'fs'
+import { chmod, chown, stat } from 'fs/promises'
 import { join } from 'path'
 import { getHermesBin } from '../../services/hermes/hermes-path'
 import { getActiveProfileName, getProfileDir } from '../../services/hermes/hermes-profile'
@@ -20,6 +21,59 @@ function resolveProfileDir(profile: string): string {
 
 function getJobsPath(profile: string): string {
   return join(resolveProfileDir(profile), 'cron', 'jobs.json')
+}
+
+const CRON_MANAGED_FILES = [
+  { relativePath: 'cron/jobs.json', defaultMode: 0o644 },
+  { relativePath: '.env', defaultMode: 0o600 },
+] as const
+
+interface FileAccessMetadata {
+  path: string
+  mode: number
+  uid?: number
+  gid?: number
+}
+
+async function statAccessMetadata(path: string): Promise<FileAccessMetadata | null> {
+  try {
+    const stats = await stat(path)
+    return {
+      path,
+      mode: stats.mode & 0o777,
+      uid: stats.uid,
+      gid: stats.gid,
+    }
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return null
+    throw err
+  }
+}
+
+export async function captureCronManagedFileMetadata(profileDir: string): Promise<FileAccessMetadata[]> {
+  const profileMetadata = await statAccessMetadata(profileDir)
+  return Promise.all(CRON_MANAGED_FILES.map(async (file) => {
+    const target = join(profileDir, ...file.relativePath.split('/'))
+    const existing = await statAccessMetadata(target)
+    return {
+      path: target,
+      mode: existing?.mode ?? file.defaultMode,
+      uid: existing?.uid ?? profileMetadata?.uid,
+      gid: existing?.gid ?? profileMetadata?.gid,
+    }
+  }))
+}
+
+export async function restoreCronManagedFileMetadata(metadata: FileAccessMetadata[]): Promise<void> {
+  for (const entry of metadata) {
+    if (!existsSync(entry.path)) continue
+    await chmod(entry.path, entry.mode)
+    if (process.platform !== 'win32' && typeof entry.uid === 'number' && typeof entry.gid === 'number') {
+      await chown(entry.path, entry.uid, entry.gid).catch((err: any) => {
+        if (err?.code !== 'ENOENT' && err?.code !== 'EPERM' && err?.code !== 'EINVAL') throw err
+      })
+    }
+  }
 }
 
 function normalizeJob(job: JobRecord): JobRecord {
@@ -116,6 +170,7 @@ function getSkills(body: Record<string, any>): string[] | null {
 
 async function runHermesCron(profile: string, args: string[]): Promise<void> {
   const profileDir = resolveProfileDir(profile)
+  const metadata = await captureCronManagedFileMetadata(profileDir)
   try {
     await execHermesWithBin(getHermesBin(), args, {
       cwd: process.cwd(),
@@ -128,6 +183,8 @@ async function runHermesCron(profile: string, args: string[]): Promise<void> {
     const stderr = String(error?.stderr || '').trim()
     const stdout = String(error?.stdout || '').trim()
     throw new Error(stderr || stdout || error?.message || 'Hermes cron command failed')
+  } finally {
+    await restoreCronManagedFileMetadata(metadata)
   }
 }
 

--- a/tests/server/jobs-controller.test.ts
+++ b/tests/server/jobs-controller.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -24,7 +24,7 @@ vi.mock('child_process', () => ({
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
-import { create, pause, remove, resume, run as runJob, update } from '../../packages/server/src/controllers/hermes/jobs'
+import { captureCronManagedFileMetadata, create, pause, remove, restoreCronManagedFileMetadata, resume, run as runJob, update } from '../../packages/server/src/controllers/hermes/jobs'
 
 function createMockCtx(overrides: Record<string, any> = {}) {
   const ctx: any = {
@@ -79,6 +79,43 @@ describe('Hermes jobs controller', () => {
     if (tempDir) rmSync(tempDir, { recursive: true, force: true })
     tempDir = ''
     testState.profileDir = ''
+  })
+
+  it('restores existing cron-managed file modes after Hermes CLI rewrites them', async () => {
+    const cronDir = join(tempDir, 'cron')
+    mkdirSync(cronDir, { recursive: true })
+    const jobsPath = join(cronDir, 'jobs.json')
+    const envPath = join(tempDir, '.env')
+    writeFileSync(jobsPath, '{"jobs":[]}')
+    writeFileSync(envPath, 'TOKEN=secret\n')
+    chmodSync(jobsPath, 0o644)
+    chmodSync(envPath, 0o600)
+
+    const metadata = await captureCronManagedFileMetadata(tempDir)
+
+    chmodSync(jobsPath, 0o600)
+    chmodSync(envPath, 0o644)
+    await restoreCronManagedFileMetadata(metadata)
+
+    expect(statSync(jobsPath).mode & 0o777).toBe(0o644)
+    expect(statSync(envPath).mode & 0o777).toBe(0o600)
+  })
+
+  it('uses safe default modes for cron-managed files created by Hermes CLI', async () => {
+    const metadata = await captureCronManagedFileMetadata(tempDir)
+    const cronDir = join(tempDir, 'cron')
+    mkdirSync(cronDir, { recursive: true })
+    const jobsPath = join(cronDir, 'jobs.json')
+    const envPath = join(tempDir, '.env')
+    writeFileSync(jobsPath, '{"jobs":[]}')
+    writeFileSync(envPath, 'TOKEN=secret\n')
+    chmodSync(jobsPath, 0o600)
+    chmodSync(envPath, 0o644)
+
+    await restoreCronManagedFileMetadata(metadata)
+
+    expect(statSync(jobsPath).mode & 0o777).toBe(0o644)
+    expect(statSync(envPath).mode & 0o777).toBe(0o600)
   })
 
   it('returns 404 before editing when the local cron job does not exist', async () => {


### PR DESCRIPTION
Fixes #1699.

This preserves ownership/mode metadata for cron-managed Hermes files around Web UI cron operations:

- captures existing cron/jobs.json and .env metadata before invoking hermes cron
- falls back to profile directory owner with safe default modes for newly created files (jobs.json 0644, .env 0600)
- restores mode and, on POSIX when possible, owner/group after the cron command returns
- adds regression tests for existing file mode preservation and newly created file defaults

This keeps a root-running Web UI container from leaving shared Hermes files unreadable by the Hermes Agent user.