### PR TITLE
修复未支持的 Hermes 斜杠命令透传

### DIFF
--- a/docs/chat-chain-changes/2026-06-20-pending-known-slash-unsupported.md
+++ b/docs/chat-chain-changes/2026-06-20-pending-known-slash-unsupported.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-20
+pr: 1703
+feature: Known Hermes slash command guard
+impact: Hermes slash commands that Web UI chat does not support now return an unsupported command result instead of being submitted to the agent as normal user text; truly unknown slash input still passes through.
+---

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -12,7 +12,7 @@ import { useSettingsStore } from './settings'
 import { primeCompletionSound, playCompletionSound } from '@/utils/completion-sound'
 import { showCompletionNotification } from '@/utils/completion-notification'
 import { detectThinkingBoundary } from '@/utils/thinking-parser'
-import { isKnownBridgeSessionCommand } from '@/utils/hermes/bridge-session-commands'
+import { isKnownBridgeSessionCommand, readBridgeSessionCommandName } from '@/utils/hermes/bridge-session-commands'
 import { responseErrorMessage } from '@/utils/http-error'
 
 // Re-export ContentBlock for convenience
@@ -1915,12 +1915,13 @@ export const useChatStore = defineStore('chat', () => {
       ? activeSession.value.messageCount == null || activeSession.value.messageCount === 0
       : false
     const isCodingAgentSession = isCodingAgentLikeSession(activeSession.value)
+    const bridgeSlashCommandName = !isCodingAgentSession ? readBridgeSessionCommandName(trimmedContent) : null
     const isBridgeSlashCommand = !isCodingAgentSession && isKnownBridgeSessionCommand(trimmedContent)
-    const isBridgeCompressCommand = isBridgeSlashCommand && /^\/compress(?:\s|$)/i.test(trimmedContent)
-    const isBridgePlanCommand = isBridgeSlashCommand && /^\/plan(?:\s|$)/i.test(trimmedContent)
-    const isBridgeSkillCommand = isBridgeSlashCommand && /^\/skill(?:\s|$)/i.test(trimmedContent)
-    const isBridgeGoalCommand = isBridgeSlashCommand && /^\/goal(?:\s|$)/i.test(trimmedContent)
-    const isBridgeForkCommand = isBridgeSlashCommand && /^\/fork(?:\s|$)/i.test(trimmedContent)
+    const isBridgeCompressCommand = bridgeSlashCommandName === 'compress'
+    const isBridgePlanCommand = bridgeSlashCommandName === 'plan'
+    const isBridgeSkillCommand = bridgeSlashCommandName === 'skill'
+    const isBridgeGoalCommand = bridgeSlashCommandName === 'goal'
+    const isBridgeForkCommand = bridgeSlashCommandName === 'fork'
     const shouldOptimisticallyShowRunStatus = !isCodingAgentSession && !isBridgeForkCommand
     const wasLiveBeforeSend = isSessionLive(sid)
     if (isBridgeForkCommand) {

--- a/packages/client/src/utils/hermes/bridge-session-commands.ts
+++ b/packages/client/src/utils/hermes/bridge-session-commands.ts
@@ -16,6 +16,74 @@ export type BridgeSessionCommandName =
   | 'reload-mcp'
   | 'reload-skills'
 
+export type UnsupportedHermesSlashCommandName =
+  | 'start'
+  | 'new'
+  | 'topic'
+  | 'redraw'
+  | 'history'
+  | 'save'
+  | 'retry'
+  | 'undo'
+  | 'handoff'
+  | 'rollback'
+  | 'snapshot'
+  | 'stop'
+  | 'approve'
+  | 'deny'
+  | 'background'
+  | 'agents'
+  | 'whoami'
+  | 'profile'
+  | 'sethome'
+  | 'resume'
+  | 'sessions'
+  | 'config'
+  | 'model'
+  | 'codex-runtime'
+  | 'gquota'
+  | 'personality'
+  | 'statusbar'
+  | 'verbose'
+  | 'footer'
+  | 'yolo'
+  | 'reasoning'
+  | 'fast'
+  | 'skin'
+  | 'indicator'
+  | 'voice'
+  | 'busy'
+  | 'tools'
+  | 'toolsets'
+  | 'skills'
+  | 'memory'
+  | 'bundles'
+  | 'cron'
+  | 'suggestions'
+  | 'blueprint'
+  | 'curator'
+  | 'kanban'
+  | 'reload'
+  | 'browser'
+  | 'plugins'
+  | 'commands'
+  | 'help'
+  | 'restart'
+  | 'credits'
+  | 'billing'
+  | 'insights'
+  | 'platforms'
+  | 'platform'
+  | 'copy'
+  | 'paste'
+  | 'image'
+  | 'update'
+  | 'version'
+  | 'debug'
+  | 'quit'
+
+export type KnownBridgeSlashCommandName = BridgeSessionCommandName | UnsupportedHermesSlashCommandName
+
 export interface BridgeSessionCommandDefinition {
   key: string
   name: BridgeSessionCommandName
@@ -55,26 +123,122 @@ export const BRIDGE_SESSION_COMMAND_NAMES = Array.from(
   new Set(BRIDGE_SESSION_COMMAND_DEFINITIONS.map(command => command.name)),
 )
 
+export const UNSUPPORTED_HERMES_SLASH_COMMAND_NAMES: UnsupportedHermesSlashCommandName[] = [
+  'start',
+  'new',
+  'topic',
+  'redraw',
+  'history',
+  'save',
+  'retry',
+  'undo',
+  'handoff',
+  'rollback',
+  'snapshot',
+  'stop',
+  'approve',
+  'deny',
+  'background',
+  'agents',
+  'whoami',
+  'profile',
+  'sethome',
+  'resume',
+  'sessions',
+  'config',
+  'model',
+  'codex-runtime',
+  'gquota',
+  'personality',
+  'statusbar',
+  'verbose',
+  'footer',
+  'yolo',
+  'reasoning',
+  'fast',
+  'skin',
+  'indicator',
+  'voice',
+  'busy',
+  'tools',
+  'toolsets',
+  'skills',
+  'memory',
+  'bundles',
+  'cron',
+  'suggestions',
+  'blueprint',
+  'curator',
+  'kanban',
+  'reload',
+  'browser',
+  'plugins',
+  'commands',
+  'help',
+  'restart',
+  'credits',
+  'billing',
+  'insights',
+  'platforms',
+  'platform',
+  'copy',
+  'paste',
+  'image',
+  'update',
+  'version',
+  'debug',
+  'quit',
+]
+
 const BRIDGE_SESSION_COMMAND_ALIASES = new Map<string, BridgeSessionCommandName>([
+  ['branch', 'fork'],
+  ['reload_mcp', 'reload-mcp'],
   ['reload_skills', 'reload-skills'],
 ])
 
-export function normalizeBridgeSessionCommandName(name: string): BridgeSessionCommandName | null {
+const UNSUPPORTED_HERMES_SLASH_COMMAND_ALIASES = new Map<string, UnsupportedHermesSlashCommandName>([
+  ['reset', 'new'],
+  ['snap', 'snapshot'],
+  ['bg', 'background'],
+  ['btw', 'background'],
+  ['tasks', 'agents'],
+  ['set-home', 'sethome'],
+  ['codex_runtime', 'codex-runtime'],
+  ['sb', 'statusbar'],
+  ['suggest', 'suggestions'],
+  ['bp', 'blueprint'],
+  ['gateway', 'platforms'],
+  ['v', 'version'],
+  ['exit', 'quit'],
+])
+
+export function normalizeBridgeSessionCommandName(name: string): KnownBridgeSlashCommandName | null {
   const normalized = name.trim().toLowerCase()
   if (!normalized) return null
-  const alias = BRIDGE_SESSION_COMMAND_ALIASES.get(normalized)
-  if (alias) return alias
-  return (BRIDGE_SESSION_COMMAND_NAMES as string[]).includes(normalized)
-    ? normalized as BridgeSessionCommandName
+  const bridgeAlias = BRIDGE_SESSION_COMMAND_ALIASES.get(normalized)
+  if (bridgeAlias) return bridgeAlias
+  if ((BRIDGE_SESSION_COMMAND_NAMES as string[]).includes(normalized)) {
+    return normalized as BridgeSessionCommandName
+  }
+
+  const unsupportedAlias = UNSUPPORTED_HERMES_SLASH_COMMAND_ALIASES.get(normalized)
+  if (unsupportedAlias) return unsupportedAlias
+  return (UNSUPPORTED_HERMES_SLASH_COMMAND_NAMES as string[]).includes(normalized)
+    ? normalized as UnsupportedHermesSlashCommandName
     : null
 }
 
-export function readBridgeSessionCommandName(input: string): BridgeSessionCommandName | null {
+export function readBridgeSessionCommandName(input: string): KnownBridgeSlashCommandName | null {
   const trimmed = input.trim()
   if (!trimmed.startsWith('/')) return null
   const match = trimmed.match(/^\/([a-zA-Z][\w-]*)(?:\s|$)/)
   if (!match) return null
   return normalizeBridgeSessionCommandName(match[1])
+}
+
+export function isSupportedBridgeSessionCommand(input: string): boolean {
+  const name = readBridgeSessionCommandName(input)
+  return name !== null && (BRIDGE_SESSION_COMMAND_NAMES as string[]).includes(name)
 }
 
 export function isKnownBridgeSessionCommand(input: string): boolean {

--- a/packages/server/src/services/hermes/run-chat/session-command.ts
+++ b/packages/server/src/services/hermes/run-chat/session-command.ts
@@ -26,6 +26,7 @@ type CommandName =
   | 'destroy'
   | 'reload-mcp'
   | 'reload-skills'
+  | 'unsupported'
 
 interface ParsedSessionCommand {
   name: CommandName
@@ -77,12 +78,102 @@ const COMMAND_ALIASES: Record<string, CommandName> = {
   clear: 'clear',
   title: 'title',
   compress: 'compress',
+  branch: 'branch',
   fork: 'branch',
   steer: 'steer',
   destroy: 'destroy',
   'reload-mcp': 'reload-mcp',
+  reload_mcp: 'reload-mcp',
   'reload-skills': 'reload-skills',
   reload_skills: 'reload-skills',
+}
+
+const UNSUPPORTED_HERMES_COMMANDS = new Set([
+  'start',
+  'new',
+  'topic',
+  'redraw',
+  'history',
+  'save',
+  'retry',
+  'undo',
+  'handoff',
+  'rollback',
+  'snapshot',
+  'stop',
+  'approve',
+  'deny',
+  'background',
+  'agents',
+  'whoami',
+  'profile',
+  'sethome',
+  'resume',
+  'sessions',
+  'config',
+  'model',
+  'codex-runtime',
+  'gquota',
+  'personality',
+  'statusbar',
+  'verbose',
+  'footer',
+  'yolo',
+  'reasoning',
+  'fast',
+  'skin',
+  'indicator',
+  'voice',
+  'busy',
+  'tools',
+  'toolsets',
+  'skills',
+  'memory',
+  'bundles',
+  'cron',
+  'suggestions',
+  'blueprint',
+  'curator',
+  'kanban',
+  'reload',
+  'browser',
+  'plugins',
+  'commands',
+  'help',
+  'restart',
+  'credits',
+  'billing',
+  'insights',
+  'platforms',
+  'platform',
+  'copy',
+  'paste',
+  'image',
+  'update',
+  'version',
+  'debug',
+  'quit',
+])
+
+const UNSUPPORTED_HERMES_COMMAND_ALIASES: Record<string, string> = {
+  reset: 'new',
+  snap: 'snapshot',
+  bg: 'background',
+  btw: 'background',
+  tasks: 'agents',
+  'set-home': 'sethome',
+  codex_runtime: 'codex-runtime',
+  sb: 'statusbar',
+  suggest: 'suggestions',
+  bp: 'blueprint',
+  gateway: 'platforms',
+  v: 'version',
+  exit: 'quit',
+}
+
+function unsupportedHermesCommandName(rawName: string): string | null {
+  const canonical = UNSUPPORTED_HERMES_COMMAND_ALIASES[rawName] || rawName
+  return UNSUPPORTED_HERMES_COMMANDS.has(canonical) ? canonical : null
 }
 
 export function parseSessionCommand(input: string | ContentBlock[]): ParsedSessionCommand | null {
@@ -93,8 +184,11 @@ export function parseSessionCommand(input: string | ContentBlock[]): ParsedSessi
   if (!match) return null
   const rawName = match[1].toLowerCase()
   const name = COMMAND_ALIASES[rawName]
-  if (!name) return null
-  return { name, rawName, args: match[2]?.trim() || '' }
+  if (name) return { name, rawName, args: match[2]?.trim() || '' }
+  if (unsupportedHermesCommandName(rawName)) {
+    return { name: 'unsupported', rawName, args: match[2]?.trim() || '' }
+  }
+  return null
 }
 
 export function isSessionCommand(input: string | ContentBlock[]): boolean {
@@ -110,7 +204,7 @@ export async function handleSessionCommand(
   ctx.socket.join(`session:${sessionId}`)
   ensureCommandSession(sessionId, command, ctx)
   const isKnownCommand = Boolean(COMMAND_ALIASES[command.rawName])
-  if (command.name !== 'plan' && command.name !== 'skill' && command.name !== 'branch' && isKnownCommand) {
+  if (command.name !== 'plan' && command.name !== 'skill' && command.name !== 'branch' && (isKnownCommand || command.name === 'unsupported')) {
     persistCommandMessage(sessionId, state, `/${command.rawName}${command.args ? ` ${command.args}` : ''}`)
   }
 
@@ -124,6 +218,18 @@ export async function handleSessionCommand(
       ok: true,
       ...payload,
     })
+  }
+
+  if (command.name === 'unsupported') {
+    const canonical = unsupportedHermesCommandName(command.rawName) || command.rawName
+    emitCommand({
+      ok: false,
+      action: 'unsupported',
+      terminal: !state.isWorking,
+      unsupportedCommand: canonical,
+      message: `/${command.rawName} is a Hermes slash command, but it is not supported in Web UI chat yet. Use the matching Web UI control or Hermes CLI/TUI for now.`,
+    })
+    return
   }
 
   if (command.name === 'skill') {

--- a/tests/client/chat-store-reasoning-tool-boundary.test.ts
+++ b/tests/client/chat-store-reasoning-tool-boundary.test.ts
@@ -290,6 +290,63 @@ describe('chat store reasoning/tool boundaries', () => {
     ])
   })
 
+  it('marks unsupported Hermes slash commands as commands instead of normal user prompts', async () => {
+    const store = useChatStore()
+    const session = makeSession()
+    session.source = 'cli'
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    await store.sendMessage('/model openai/gpt-5')
+
+    expect(chatApi.startRunViaSocket).toHaveBeenCalledTimes(1)
+    expect(chatApi.startRunViaSocket.mock.calls[0][0]).toEqual(expect.objectContaining({
+      input: '/model openai/gpt-5',
+      session_id: 'session-1',
+      source: 'cli',
+    }))
+    expect(store.messages).toEqual([
+      expect.objectContaining({
+        role: 'command',
+        content: '/model openai/gpt-5',
+        queued: false,
+        systemType: 'command',
+      }),
+    ])
+  })
+
+  it('does not queue unsupported Hermes slash commands behind active bridge runs', async () => {
+    const store = useChatStore()
+    const session = makeSession()
+    session.source = 'cli'
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    await store.sendMessage('first input')
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: RunEvent) => void
+    onEvent({ event: 'run.started', session_id: 'session-1' })
+
+    await store.sendMessage('/yolo')
+
+    expect(chatApi.startRunViaSocket).toHaveBeenCalledTimes(2)
+    expect(store.queuedUserMessages.get('session-1')).toBeUndefined()
+    expect(store.messages).toEqual([
+      expect.objectContaining({
+        role: 'user',
+        content: 'first input',
+        queued: false,
+      }),
+      expect.objectContaining({
+        role: 'command',
+        content: '/yolo',
+        queued: false,
+        systemType: 'command',
+      }),
+    ])
+  })
+
   it('starts global coding-agent runs without provider credentials', async () => {
     const store = useChatStore()
     const session = makeSession()

--- a/tests/server/session-command-branch.test.ts
+++ b/tests/server/session-command-branch.test.ts
@@ -120,11 +120,11 @@ describe('branch session command', () => {
     })
   })
 
-  it('parses /fork as the only user-facing fork command', async () => {
+  it('parses /fork and /branch as user-facing branch commands', async () => {
     const { parseSessionCommand } = await import('../../packages/server/src/services/hermes/run-chat/session-command')
 
     expect(parseSessionCommand('/fork')).toMatchObject({ name: 'branch', rawName: 'fork', args: '' })
-    expect(parseSessionCommand('/branch alternate path')).toBeNull()
+    expect(parseSessionCommand('/branch alternate path')).toMatchObject({ name: 'branch', rawName: 'branch', args: 'alternate path' })
   })
 
   it('rejects /fork while the bridge session is running', async () => {

--- a/tests/server/session-command-plan.test.ts
+++ b/tests/server/session-command-plan.test.ts
@@ -237,7 +237,7 @@ describe('plan session command', () => {
   })
 
   it('keeps the client known-command registry accepted by the server parser', async () => {
-    const { BRIDGE_SESSION_COMMAND_NAMES, isKnownBridgeSessionCommand } = await import('../../packages/client/src/utils/hermes/bridge-session-commands')
+    const { BRIDGE_SESSION_COMMAND_NAMES, UNSUPPORTED_HERMES_SLASH_COMMAND_NAMES, isKnownBridgeSessionCommand } = await import('../../packages/client/src/utils/hermes/bridge-session-commands')
     const { parseSessionCommand } = await import('../../packages/server/src/services/hermes/run-chat/session-command')
 
     for (const commandName of BRIDGE_SESSION_COMMAND_NAMES) {
@@ -251,10 +251,74 @@ describe('plan session command', () => {
       }
     }
 
+    for (const commandName of UNSUPPORTED_HERMES_SLASH_COMMAND_NAMES) {
+      expect(isKnownBridgeSessionCommand(`/${commandName}`)).toBe(true)
+      expect(parseSessionCommand(`/${commandName}`)).toEqual(expect.objectContaining({
+        name: 'unsupported',
+        rawName: commandName,
+      }))
+    }
+
     expect(isKnownBridgeSessionCommand('/reload_skills')).toBe(true)
     expect(parseSessionCommand('/reload_skills')).toEqual(expect.objectContaining({
       name: 'reload-skills',
       rawName: 'reload_skills',
+    }))
+    expect(isKnownBridgeSessionCommand('/reload_mcp')).toBe(true)
+    expect(parseSessionCommand('/reload_mcp')).toEqual(expect.objectContaining({
+      name: 'reload-mcp',
+      rawName: 'reload_mcp',
+    }))
+    expect(isKnownBridgeSessionCommand('/branch alternative')).toBe(true)
+    expect(parseSessionCommand('/branch alternative')).toEqual(expect.objectContaining({
+      name: 'branch',
+      rawName: 'branch',
+      args: 'alternative',
+    }))
+  })
+
+  it('classifies unsupported Hermes slash commands separately from unknown passthrough', async () => {
+    const { isKnownBridgeSessionCommand } = await import('../../packages/client/src/utils/hermes/bridge-session-commands')
+    const { isSessionCommand, parseSessionCommand } = await import('../../packages/server/src/services/hermes/run-chat/session-command')
+
+    for (const command of ['/model openai/gpt-5', '/yolo', '/update', '/debug', '/billing', '/reset']) {
+      expect(isKnownBridgeSessionCommand(command)).toBe(true)
+      expect(parseSessionCommand(command)).toEqual(expect.objectContaining({ name: 'unsupported' }))
+      expect(isSessionCommand(command)).toBe(true)
+    }
+  })
+
+  it('emits unsupported for known Hermes slash commands without invoking bridge commands', async () => {
+    const state = { messages: [], isWorking: false, events: [], queue: [] }
+    const { bridge, namespaceEmit, nsp, runQueuedItem, sessionMap, socket } = makeContext(state)
+    const { handleSessionCommand, parseSessionCommand } = await import('../../packages/server/src/services/hermes/run-chat/session-command')
+    const command = parseSessionCommand('/model openai/gpt-5')!
+
+    await handleSessionCommand('session-1', command, {
+      nsp: nsp as any,
+      socket: socket as any,
+      sessionMap,
+      bridge: bridge as any,
+      profile: 'default',
+      runQueuedItem,
+    })
+
+    expect(bridge.command).not.toHaveBeenCalled()
+    expect(runQueuedItem).not.toHaveBeenCalled()
+    expect(addMessageMock).toHaveBeenCalledWith(expect.objectContaining({
+      role: 'command',
+      content: '/model openai/gpt-5',
+    }))
+    expect(addMessageMock).toHaveBeenCalledWith(expect.objectContaining({
+      role: 'command',
+      content: expect.stringContaining('/model is a Hermes slash command'),
+    }))
+    expect(namespaceEmit).toHaveBeenCalledWith('session.command', expect.objectContaining({
+      ok: false,
+      action: 'unsupported',
+      command: 'model',
+      unsupportedCommand: 'model',
+      message: expect.stringContaining('/model is a Hermes slash command'),
     }))
   })
 


### PR DESCRIPTION
## 改动

- 已把 Hermes 已知但当前聊天界面不支持的斜杠命令归类为 unsupported session command，避免 `/model`、`/yolo`、`/update`、`/debug`、`/billing` 等输入被当作普通用户消息送进模型。
- 保持 #1607 的行为：真正未知的斜杠输入仍然走普通聊天路径，例如 `/terminal pwd` 继续可以透传给 agent。
- 补上 `/branch` 和 `/reload_mcp` 别名处理，并让前后端命令分类保持一致。
- 已补回归测试，覆盖 unsupported 命令、未知命令透传、别名解析和分支命令契约。

关联 #1607。

## 验证

- `npm test -- --run tests/server/session-command-*.test.ts tests/client/chat-store-reasoning-tool-boundary.test.ts`：已通过，35 tests passed。
- `npm test -- --run tests/server/run-chat-queued-item.test.ts`：已通过，8 tests passed。
- `npm run harness:check`：已通过。
- `npx tsc --noEmit -p packages/server/tsconfig.json`：已通过。
- `npx vue-tsc -b --pretty false`：已通过。
- `npm run build`：已通过。
