### PR TITLE
[codex] fix MCU TTS PCM decoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.6.18",
       "license": "BSL-1.1",
       "dependencies": {
+        "@audio/decode-mp3": "^1.1.0",
+        "@audio/decode-wav": "^1.2.0",
         "@vscode/markdown-it-katex": "^1.1.2",
         "adm-zip": "^0.5.17",
         "eventsource": "^4.1.0",
@@ -157,6 +159,24 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@audio/decode-mp3": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@audio/decode-mp3/-/decode-mp3-1.1.0.tgz",
+      "integrity": "sha512-eOBqdICwjQ0P9z6ei0wXmXVTW/tIiQ4YGsG3QMFJsdrGORhNQh6paQz53utIcVndmri9xfQStqerxMGt+82ygQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mpg123-decoder": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@audio/decode-wav": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@audio/decode-wav/-/decode-wav-1.2.0.tgz",
+      "integrity": "sha512-Q6VicCGHeoqCiLnTDAaZI3kHCZGd24km/BVLZMBF2vOSbknwnqUEkWs4RRtKUfMX+KBtwAgihkzF0Aw4Y3DkBw==",
       "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
@@ -906,6 +926,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@eshaz/web-worker": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@eshaz/web-worker/-/web-worker-1.2.2.tgz",
+      "integrity": "sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@exodus/bytes": {
       "version": "1.15.1",
@@ -3724,6 +3750,16 @@
         "vue": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@wasm-audio-decoders/common": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@wasm-audio-decoders/common/-/common-9.0.7.tgz",
+      "integrity": "sha512-WRaUuWSKV7pkttBygml/a6dIEpatq2nnZGFIoPTc5yPLkxL6Wk4YaslPM98OPQvWacvNZ+Py9xROGDtrFBDzag==",
+      "license": "MIT",
+      "dependencies": {
+        "@eshaz/web-worker": "1.2.2",
+        "simple-yenc": "^1.0.4"
       }
     },
     "node_modules/@xterm/addon-fit": {
@@ -7803,6 +7839,19 @@
         "node": ">= 18"
       }
     },
+    "node_modules/mpg123-decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mpg123-decoder/-/mpg123-decoder-1.0.3.tgz",
+      "integrity": "sha512-+fjxnWigodWJm3+4pndi+KUg9TBojgn31DPk85zEsim7C6s0X5Ztc/hQYdytXkwuGXH+aB0/aEkG40Emukv6oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wasm-audio-decoders/common": "9.0.7"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9530,6 +9579,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/simple-yenc": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/simple-yenc/-/simple-yenc-1.0.4.tgz",
+      "integrity": "sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
       }
     },
     "node_modules/socket.io": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "dist/"
   ],
   "dependencies": {
+    "@audio/decode-mp3": "^1.1.0",
+    "@audio/decode-wav": "^1.2.0",
     "@vscode/markdown-it-katex": "^1.1.2",
     "adm-zip": "^0.5.17",
     "eventsource": "^4.1.0",

--- a/packages/server/src/services/global-agent/outbound-relay-client.ts
+++ b/packages/server/src/services/global-agent/outbound-relay-client.ts
@@ -77,6 +77,10 @@ const NON_STREAMING_SUPPRESSED_EVENTS = new Set([
   'reasoning.available',
 ])
 const MCU_TTS_SAMPLE_RATE = 16_000
+const MCU_TTS_OPTIONS = {
+  mcuPlayback: true,
+  sampleRate: MCU_TTS_SAMPLE_RATE,
+} as const
 const MCU_TTS_FAILED_PROMPT_TEXT = '当前文字转语音失败了，请配置下文字转语音再使用哦'
 const MCU_TTS_FAILED_PROMPT_PCM_URL =
   'https://ekko-hermes-studio.oss-cn-beijing.aliyuncs.com/tts-synthesize-failed-xiaohe.s16le.pcm'
@@ -829,7 +833,7 @@ class PlainWebSocketRelayClient {
       body: JSON.stringify({
         ...(provider ? { provider } : {}),
         text,
-        options: {},
+        options: MCU_TTS_OPTIONS,
       }),
     })
 
@@ -883,7 +887,7 @@ class PlainWebSocketRelayClient {
           body: JSON.stringify({
             provider: 'edge',
             text,
-            options: {},
+            options: MCU_TTS_OPTIONS,
           }),
         })
         if (!fallback.ok) {

--- a/packages/server/src/services/global-agent/server.ts
+++ b/packages/server/src/services/global-agent/server.ts
@@ -22,6 +22,10 @@ import type {
 const GLOBAL_AGENT_NAMESPACE = '/global-agent'
 const DEFAULT_GLOBAL_AGENT_TIMEOUT_MS = 30_000
 const MCU_TTS_SAMPLE_RATE = 16_000
+const MCU_TTS_OPTIONS = {
+  mcuPlayback: true,
+  sampleRate: MCU_TTS_SAMPLE_RATE,
+} as const
 const MCU_TTS_FAILED_PROMPT_TEXT = '当前文字转语音失败了，请配置下文字转语音再使用哦'
 const MCU_TTS_FAILED_PROMPT_PCM_URL =
   'https://ekko-hermes-studio.oss-cn-beijing.aliyuncs.com/tts-synthesize-failed-xiaohe.s16le.pcm'
@@ -1076,7 +1080,7 @@ export class GlobalAgentServer {
       body: JSON.stringify({
         ...(provider ? { provider } : {}),
         text,
-        options: {},
+        options: MCU_TTS_OPTIONS,
       }),
     })
 
@@ -1126,7 +1130,7 @@ export class GlobalAgentServer {
           body: JSON.stringify({
             provider: 'edge',
             text,
-            options: {},
+            options: MCU_TTS_OPTIONS,
           }),
         })
         if (!fallback.ok) {

--- a/packages/server/src/services/hermes/stt-providers/audio-convert.ts
+++ b/packages/server/src/services/hermes/stt-providers/audio-convert.ts
@@ -1,6 +1,19 @@
 import { spawn } from 'node:child_process'
+import { createRequire } from 'node:module'
 
 const TRANSCODE_TIMEOUT_MS = 30_000
+const DEFAULT_PCM_SAMPLE_RATE = 16000
+
+type DecodedAudio = {
+  channelData: Float32Array[]
+  sampleRate: number
+}
+
+type DecodeAudioModule = {
+  default: (src: ArrayBuffer | Uint8Array) => Promise<DecodedAudio>
+}
+
+const requireAudioDecoder = createRequire(__filename)
 
 /**
  * Check whether ffmpeg is available on the system PATH.
@@ -103,28 +116,17 @@ export async function transcodeToPcmS16le(
   mimeType: string,
   options: { sampleRate?: number } = {},
 ): Promise<{ audio: Buffer; mimeType: string; fileName: string }> {
-  if (!(await isFfmpegAvailable())) {
-    return { audio: input, mimeType, fileName: '' }
-  }
-
   const sampleRate = Number.isInteger(options.sampleRate) && Number(options.sampleRate) > 0
     ? Number(options.sampleRate)
-    : 16000
+    : DEFAULT_PCM_SAMPLE_RATE
 
-  const args = [
-    '-hide_banner',
-    '-loglevel', 'error',
-    '-i', 'pipe:0',
-    '-acodec', 'pcm_s16le',
-    '-ar', String(sampleRate),
-    '-ac', '1',
-    '-f', 's16le',
-    'pipe:1',
-  ]
+  const decoded = await decodeAudioForPcm(input, mimeType)
+  const mono = mixToMono(decoded.channelData)
+  const resampled = resampleLinear(mono, decoded.sampleRate, sampleRate)
+  const pcmBuffer = floatToS16le(resampled)
 
-  const pcmBuffer = await runFfmpeg(args, input, TRANSCODE_TIMEOUT_MS)
   if (pcmBuffer.length === 0) {
-    throw new Error('ffmpeg produced empty PCM output')
+    throw new Error('audio decode produced empty PCM output')
   }
 
   return {
@@ -132,4 +134,88 @@ export async function transcodeToPcmS16le(
     mimeType: 'audio/x-pcm',
     fileName: 'audio.pcm',
   }
+}
+
+async function decodeAudioForPcm(input: Buffer, mimeType: string): Promise<DecodedAudio> {
+  const normalized = normalizeMimeType(mimeType)
+  const kind = normalized.includes('mpeg') || normalized.includes('mp3') || looksLikeMp3(input)
+    ? 'mp3'
+    : normalized.includes('wav') || normalized.includes('wave') || looksLikeWav(input)
+      ? 'wav'
+      : ''
+
+  if (!kind) {
+    throw new Error(`unsupported audio format for MCU PCM decode: ${mimeType || 'unknown content type'}`)
+  }
+
+  try {
+    const mod = requireAudioDecoder(kind === 'mp3' ? '@audio/decode-mp3' : '@audio/decode-wav') as DecodeAudioModule
+    const decoded = await mod.default(input)
+    if (!decoded.channelData.length || !decoded.channelData[0]?.length || !Number.isFinite(decoded.sampleRate) || decoded.sampleRate <= 0) {
+      throw new Error('decoded audio is empty')
+    }
+    return decoded
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`MCU PCM decode failed for ${kind}: ${message}`)
+  }
+}
+
+function normalizeMimeType(mimeType: string): string {
+  return String(mimeType || '').split(';')[0].trim().toLowerCase()
+}
+
+function looksLikeWav(input: Buffer): boolean {
+  return input.length >= 12 && input.subarray(0, 4).toString('ascii') === 'RIFF' && input.subarray(8, 12).toString('ascii') === 'WAVE'
+}
+
+function looksLikeMp3(input: Buffer): boolean {
+  if (input.length >= 3 && input.subarray(0, 3).toString('ascii') === 'ID3') return true
+  return input.length >= 2 && input[0] === 0xff && (input[1] & 0xe0) === 0xe0
+}
+
+function mixToMono(channels: Float32Array[]): Float32Array {
+  const validChannels = channels.filter(channel => channel.length > 0)
+  if (!validChannels.length) return new Float32Array(0)
+  if (validChannels.length === 1) return validChannels[0]
+
+  const sampleCount = Math.max(...validChannels.map(channel => channel.length))
+  const mono = new Float32Array(sampleCount)
+  for (let i = 0; i < sampleCount; i += 1) {
+    let sum = 0
+    for (const channel of validChannels) {
+      sum += channel[i] ?? 0
+    }
+    mono[i] = sum / validChannels.length
+  }
+  return mono
+}
+
+function resampleLinear(input: Float32Array, sourceRate: number, targetRate: number): Float32Array {
+  if (!input.length) return input
+  if (sourceRate === targetRate) return input
+
+  const outputLength = Math.max(1, Math.round(input.length * targetRate / sourceRate))
+  const output = new Float32Array(outputLength)
+  const scale = sourceRate / targetRate
+
+  for (let i = 0; i < outputLength; i += 1) {
+    const sourceIndex = i * scale
+    const left = Math.floor(sourceIndex)
+    const right = Math.min(left + 1, input.length - 1)
+    const weight = sourceIndex - left
+    output[i] = input[left] * (1 - weight) + input[right] * weight
+  }
+
+  return output
+}
+
+function floatToS16le(samples: Float32Array): Buffer {
+  const output = Buffer.alloc(samples.length * 2)
+  for (let i = 0; i < samples.length; i += 1) {
+    const sample = Number.isFinite(samples[i]) ? Math.max(-1, Math.min(1, samples[i])) : 0
+    const int16 = sample < 0 ? Math.round(sample * 32768) : Math.round(sample * 32767)
+    output.writeInt16LE(int16, i * 2)
+  }
+  return output
 }

--- a/packages/server/src/services/hermes/tts-providers/doubao.ts
+++ b/packages/server/src/services/hermes/tts-providers/doubao.ts
@@ -45,7 +45,7 @@ function audioContentType(format: string): string {
 }
 
 function resolveAudioFormat(opts: DoubaoTtsProviderOptions): string {
-  const format = trimOptional(opts.format)?.toLowerCase().replace('-', '_') || DEFAULT_FORMAT
+  const format = trimOptional(opts.format)?.toLowerCase().replace('-', '_') || (opts.mcuPlayback ? 'pcm' : DEFAULT_FORMAT)
   if (!SUPPORTED_FORMATS.has(format)) {
     throw new Error(`Doubao TTS format must be one of ${Array.from(SUPPORTED_FORMATS).join(', ')}`)
   }
@@ -54,6 +54,7 @@ function resolveAudioFormat(opts: DoubaoTtsProviderOptions): string {
 
 function resolveSampleRate(opts: DoubaoTtsProviderOptions): number {
   const raw = opts.sampleRate ?? opts.sample_rate
+  if ((raw === undefined || raw === null) && opts.mcuPlayback) return 16000
   if (raw === undefined || raw === null) return DEFAULT_SAMPLE_RATE
   const sampleRate = Number(raw)
   if (!Number.isInteger(sampleRate) || sampleRate <= 0) {

--- a/packages/server/src/services/hermes/tts-providers/types.ts
+++ b/packages/server/src/services/hermes/tts-providers/types.ts
@@ -56,6 +56,7 @@ export interface DoubaoTtsProviderOptions {
   format?: string
   sampleRate?: number
   sample_rate?: number
+  mcuPlayback?: boolean
 }
 
 export type OpenaiTtsProvider = TtsProvider<OpenaiTtsProviderOptions>

--- a/tests/server/audio-convert.test.ts
+++ b/tests/server/audio-convert.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { transcodeToPcmS16le } from '../../packages/server/src/services/hermes/stt-providers/audio-convert'
+
+function wavS16le(samples: number[], sampleRate: number, channels = 1): Buffer {
+  const dataSize = samples.length * 2
+  const header = Buffer.alloc(44)
+  header.write('RIFF', 0)
+  header.writeUInt32LE(36 + dataSize, 4)
+  header.write('WAVE', 8)
+  header.write('fmt ', 12)
+  header.writeUInt32LE(16, 16)
+  header.writeUInt16LE(1, 20)
+  header.writeUInt16LE(channels, 22)
+  header.writeUInt32LE(sampleRate, 24)
+  header.writeUInt32LE(sampleRate * channels * 2, 28)
+  header.writeUInt16LE(channels * 2, 32)
+  header.writeUInt16LE(16, 34)
+  header.write('data', 36)
+  header.writeUInt32LE(dataSize, 40)
+
+  const data = Buffer.alloc(dataSize)
+  samples.forEach((sample, index) => {
+    data.writeInt16LE(sample, index * 2)
+  })
+  return Buffer.concat([header, data])
+}
+
+describe('audio-convert', () => {
+  it('decodes WAV to MCU PCM without ffmpeg', async () => {
+    const wav = wavS16le([0, 16384, -16384, 0], 8000)
+
+    const result = await transcodeToPcmS16le(wav, 'audio/wav', { sampleRate: 16000 })
+
+    expect(result.mimeType).toBe('audio/x-pcm')
+    expect(result.fileName).toBe('audio.pcm')
+    expect(result.audio.length).toBe(16)
+  })
+
+  it('rejects unsupported MCU PCM decode formats', async () => {
+    await expect(
+      transcodeToPcmS16le(Buffer.from('not audio'), 'audio/ogg', { sampleRate: 16000 }),
+    ).rejects.toThrow('unsupported audio format for MCU PCM decode')
+  })
+})

--- a/tests/server/doubao-tts-provider.test.ts
+++ b/tests/server/doubao-tts-provider.test.ts
@@ -88,6 +88,32 @@ describe('doubaoTtsProvider', () => {
     })
   })
 
+  it('defaults to PCM at 16kHz when requested for MCU playback', async () => {
+    const pcm = Buffer.from('pcm-audio')
+    mockFetch.mockResolvedValueOnce(textResponse(JSON.stringify({
+      data: pcm.toString('base64'),
+    })))
+
+    const result = await doubaoTtsProvider.synthesize(
+      { text: '已经找到设备。' },
+      {
+        apiKey: 'secret',
+        mcuPlayback: true,
+      },
+    )
+
+    expect(result).toEqual({
+      audio: pcm,
+      contentType: 'audio/x-pcm',
+      engine: 'doubao',
+      provider: 'doubao',
+    })
+    expect(getJsonBody().req_params.audio_params).toEqual({
+      format: 'pcm',
+      sample_rate: 16000,
+    })
+  })
+
   it('rejects unsupported formats before calling Doubao', async () => {
     await expect(doubaoTtsProvider.synthesize(
       { text: 'hello' },

--- a/tests/server/global-agent-server.test.ts
+++ b/tests/server/global-agent-server.test.ts
@@ -486,7 +486,7 @@ describe('GlobalAgentServer', () => {
     expect(audio.url).toMatch(/^\/api\/hermes\/mcu\/audio\/[a-f0-9-]+\.pcm$/)
   })
 
-  it('does not force provider PCM output for MCU speech synthesis', async () => {
+  it('marks TTS requests as MCU playback without forcing every provider to PCM', async () => {
     authMocks.authenticateUserToken.mockResolvedValue({ id: 7, username: 'ada', role: 'user' })
     authMocks.userCanAccessProfile.mockReturnValue(true)
     const fetchImpl = vi.fn(async () => new Response(Buffer.from('pcm-audio'), {
@@ -507,7 +507,10 @@ describe('GlobalAgentServer', () => {
 
     expect(JSON.parse(String(fetchImpl.mock.calls[0][1]?.body))).toMatchObject({
       text: 'hello',
-      options: {},
+      options: {
+        mcuPlayback: true,
+        sampleRate: 16000,
+      },
     })
   })
 
@@ -544,7 +547,10 @@ describe('GlobalAgentServer', () => {
     expect(JSON.parse(String(fetchImpl.mock.calls[1][1]?.body))).toMatchObject({
       provider: 'edge',
       text: 'hello',
-      options: {},
+      options: {
+        mcuPlayback: true,
+        sampleRate: 16000,
+      },
     })
   })
 
@@ -581,7 +587,10 @@ describe('GlobalAgentServer', () => {
     expect(JSON.parse(String(fetchImpl.mock.calls[1][1]?.body))).toMatchObject({
       provider: 'edge',
       text: 'hello',
-      options: {},
+      options: {
+        mcuPlayback: true,
+        sampleRate: 16000,
+      },
     })
   })
 


### PR DESCRIPTION
## Summary
- add MCU-only MP3/WAV decoding to produce 16 kHz s16le PCM without ffmpeg
- keep Web TTS playback formats unchanged while marking MCU TTS requests with mcuPlayback
- make Doubao default to PCM for MCU playback and keep Edge fallback behavior

## Validation
- `npm run test -- tests/server/audio-convert.test.ts tests/server/doubao-tts-provider.test.ts tests/server/global-agent-server.test.ts tests/server/outbound-relay-client.test.ts`
- `npm run build`
- `npm run harness:check`