### PR TITLE
[codex] Default unknown coding agent providers to chat completions

### DIFF
--- a/packages/client/src/api/coding-agents.ts
+++ b/packages/client/src/api/coding-agents.ts
@@ -38,7 +38,7 @@ export function inferCodingAgentApiMode(provider?: string | null, baseUrl?: stri
     return 'chat_completions'
   }
 
-  return 'codex_responses'
+  return 'chat_completions'
 }
 
 export function normalizeCodingAgentApiMode(

--- a/tests/client/coding-agent-api-modes.test.ts
+++ b/tests/client/coding-agent-api-modes.test.ts
@@ -24,6 +24,7 @@ describe('coding agent api modes', () => {
   it('infers a safe fallback protocol from provider identity and base URL', () => {
     expect(inferCodingAgentApiMode('anthropic', 'https://api.anthropic.com')).toBe('anthropic_messages')
     expect(inferCodingAgentApiMode('deepseek', 'https://api.deepseek.com')).toBe('chat_completions')
-    expect(inferCodingAgentApiMode('openrouter', 'https://openrouter.ai/api/v1')).toBe('codex_responses')
+    expect(inferCodingAgentApiMode('xiaomi', 'https://api.xiaomimimo.com/v1')).toBe('chat_completions')
+    expect(inferCodingAgentApiMode('openrouter', 'https://openrouter.ai/api/v1')).toBe('chat_completions')
   })
 })

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -469,6 +469,40 @@ describe('coding agent launch preparation', () => {
     expect(deepseekModel.model_messages.instructions_template).toContain('{{ base_instructions }}')
   })
 
+  it('defaults Codex providers without an api mode to Chat Completions', async () => {
+    makeHome()
+    const launch = await prepareCodingAgentLaunch('codex', {
+      profile: 'default',
+      provider: 'xiaomi',
+      model: 'mimo-v2.5-pro',
+      baseUrl: 'https://api.xiaomimimo.com/v1',
+      apiKey: 'sk-upstream',
+    })
+    const config = readFileSync(join(launch.rootDir, 'config.toml'), 'utf-8')
+    const routeKey = config.match(/\/api\/codex-proxy\/([^/]+)\/v1/)?.[1] || ''
+    const token = config.match(/experimental_bearer_token = "([^"]+)"/)?.[1] || ''
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      id: 'chatcmpl_test',
+      choices: [{
+        finish_reason: 'stop',
+        message: { role: 'assistant', content: 'ok' },
+      }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(routeKey, token, {
+      max_output_tokens: 16,
+      input: [{ role: 'user', content: [{ type: 'input_text', text: 'hello' }] }],
+    })
+
+    await codexProxyResponses(ctx)
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.xiaomimimo.com/v1/chat/completions', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer sk-upstream' }),
+    }))
+  })
+
   it('points Codex Responses providers at the local Responses proxy for stream capture', async () => {
     const home = makeHome()
 


### PR DESCRIPTION
## Summary
- default unknown coding-agent providers to Chat Completions instead of Responses
- cover Xiaomi/MiMo and OpenRouter fallback behavior in client tests
- add a Codex launch regression test that verifies MiMo forwards to `/chat/completions` when `apiMode` is omitted

## Why
MiMo/Xiaomi provider presets do not declare an explicit `api_mode`, so the previous frontend fallback selected `codex_responses` and launched Claude/Codex against `/responses`. Unknown providers should use the broadly compatible Chat Completions path unless a preset explicitly opts into Responses.

## Validation
- `npm run test -- tests/client/coding-agent-api-modes.test.ts tests/server/coding-agents-launch.test.ts`
- `npm run harness:check`
