### PR TITLE
fix: fallback when config backup is not writable

### DIFF
--- a/packages/server/src/services/safe-file-store.ts
+++ b/packages/server/src/services/safe-file-store.ts
@@ -24,6 +24,10 @@ function isYamlUpdateResult<T>(value: unknown): value is YamlUpdateResult<T> {
   return !!value && typeof value === 'object' && Object.hasOwn(value as Record<string, unknown>, 'data')
 }
 
+function shouldUseFallbackBackup(err: any): boolean {
+  return ['EACCES', 'EPERM', 'EEXIST'].includes(err?.code)
+}
+
 export class SafeFileStore {
   private queues = new Map<string, Promise<unknown>>()
 
@@ -127,7 +131,13 @@ export class SafeFileStore {
       try {
         await copyFile(target, options.backupPath || `${target}.bak`)
       } catch (err: any) {
-        if (err?.code !== 'ENOENT') throw err
+        if (err?.code === 'ENOENT') {
+          // Continue without a backup when the target does not exist yet.
+        } else if (!options.backupPath && shouldUseFallbackBackup(err)) {
+          await copyFile(target, `${target}.bak.${Date.now()}.${randomUUID()}`)
+        } else {
+          throw err
+        }
       }
     }
 

--- a/tests/server/safe-file-store-backup-fallback.test.ts
+++ b/tests/server/safe-file-store-backup-fallback.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockCopyFile,
+  mockMkdir,
+  mockReadFile,
+  mockRename,
+  mockRm,
+  mockWriteFile,
+} = vi.hoisted(() => ({
+  mockCopyFile: vi.fn(),
+  mockMkdir: vi.fn(),
+  mockReadFile: vi.fn(),
+  mockRename: vi.fn(),
+  mockRm: vi.fn(),
+  mockWriteFile: vi.fn(),
+}))
+
+vi.mock('fs/promises', () => ({
+  copyFile: mockCopyFile,
+  mkdir: mockMkdir,
+  readFile: mockReadFile,
+  rename: mockRename,
+  rm: mockRm,
+  writeFile: mockWriteFile,
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('SafeFileStore backup fallback', () => {
+  it('uses a timestamped backup when the default backup cannot be overwritten', async () => {
+    mockCopyFile
+      .mockRejectedValueOnce(Object.assign(new Error('permission denied'), { code: 'EACCES' }))
+      .mockResolvedValueOnce(undefined)
+    mockMkdir.mockResolvedValue(undefined)
+    mockWriteFile.mockResolvedValue(undefined)
+    mockRename.mockResolvedValue(undefined)
+
+    const { SafeFileStore } = await import('../../packages/server/src/services/safe-file-store')
+    const store = new SafeFileStore()
+
+    await store.writeText('/tmp/config.yaml', 'model:\n  default: new\n', { backup: true })
+
+    expect(mockCopyFile).toHaveBeenCalledTimes(2)
+    expect(mockCopyFile).toHaveBeenNthCalledWith(1, '/tmp/config.yaml', '/tmp/config.yaml.bak')
+    expect(mockCopyFile.mock.calls[1][0]).toBe('/tmp/config.yaml')
+    expect(mockCopyFile.mock.calls[1][1]).toMatch(/^\/tmp\/config\.yaml\.bak\.\d+\./)
+    expect(mockWriteFile).toHaveBeenCalledWith(expect.stringContaining('/tmp/config.yaml.tmp.'), 'model:\n  default: new\n', 'utf-8')
+    expect(mockRename).toHaveBeenCalledWith(expect.stringContaining('/tmp/config.yaml.tmp.'), '/tmp/config.yaml')
+  })
+
+  it('preserves explicit backup path failures', async () => {
+    mockCopyFile.mockRejectedValueOnce(Object.assign(new Error('permission denied'), { code: 'EACCES' }))
+    mockMkdir.mockResolvedValue(undefined)
+
+    const { SafeFileStore } = await import('../../packages/server/src/services/safe-file-store')
+    const store = new SafeFileStore()
+
+    await expect(store.writeText('/tmp/config.yaml', 'new', { backup: true, backupPath: '/tmp/custom.bak' })).rejects.toThrow('permission denied')
+    expect(mockCopyFile).toHaveBeenCalledTimes(1)
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Keep the existing default config backup path for normal writes.
- Fall back to a timestamped backup when the default backup path cannot be overwritten due to EACCES/EPERM/EEXIST.
- Add regression coverage for the provider/config save path so a stale read-only config.yaml.bak no longer blocks writes.

## Test Plan
- [x] git diff --check
- [ ] npm exec -- vitest run tests/server/safe-file-store.test.ts tests/server/safe-file-store-backup-fallback.test.ts (blocked locally: fresh clone has no node_modules, npm exec tried transient vitest and failed to resolve repo dev deps; local node is v22.22.0 while package.json requires >=23.0.0)

## Context
Hermes Studio currently backs up config.yaml to a fixed config.yaml.bak path before provider/model config writes. If that backup file already exists but is not writable, provider create/update/delete fails with EACCES before config.yaml can be saved.