### PR TITLE
fix coding agent custom provider key_env resolution

### DIFF
--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -503,6 +503,10 @@ async function resolveStoredProviderLaunchInput(
     canonicalProvider = `custom:${slugProviderName(String(customEntry.name || normalizedProvider))}`
     if (!baseUrl) baseUrl = String(customEntry.base_url || '').trim()
     if (!apiKey) apiKey = String(customEntry.api_key || '').trim()
+    if (!apiKey) {
+      const keyEnv = String(customEntry.key_env || '').trim()
+      if (keyEnv) apiKey = parseEnvValue(envContent, keyEnv)
+    }
     if (!apiMode) {
       apiMode = normalizeLaunchApiMode(
         customEntry.api_mode,

--- a/tests/server/coding-agent-resume-config.test.ts
+++ b/tests/server/coding-agent-resume-config.test.ts
@@ -244,4 +244,35 @@ describe('coding agent resumed session config', () => {
       .rejects.toThrow('Coding agent provider credentials are missing')
     expect(startRunMock).not.toHaveBeenCalled()
   })
+
+  it('resolves custom-provider credentials from key_env on continuation', async () => {
+    const home = makeHome()
+    getSessionMock.mockReturnValue({
+      id: 'session-1',
+      profile: 'default',
+      source: 'coding_agent',
+      agent: 'claude',
+      agent_session_id: 'agent-session-1',
+      provider: 'custom:sensenova',
+      model: 'deepseek-v4-flash',
+    })
+    readConfigYamlForProfileMock.mockResolvedValue({
+      custom_providers: [{
+        name: 'sensenova',
+        base_url: 'https://api.sensenova.cn/v1',
+        key_env: 'SENSENOVA_API_KEY',
+        model: 'deepseek-v4-flash',
+      }],
+    })
+    safeReadFileMock.mockResolvedValue('SENSENOVA_API_KEY=sk-from-env\n')
+
+    const { startCodingAgentRun } = await import('../../packages/server/src/services/coding-agents')
+    await expect(startCodingAgentRun('claude-code', { sessionId: 'session-1' })).resolves.toEqual(
+      expect.objectContaining({
+        provider: 'custom:sensenova',
+      }),
+    )
+    expect(startRunMock).toHaveBeenCalled()
+    expect(home).toBeTruthy()
+  })
 })


### PR DESCRIPTION
Fixes #1710

## What changed
- Resolve coding-agent custom provider credentials from `key_env` when resuming a session.
- Add a regression test for continuation with a custom provider that stores only its secret env var name in `config.yaml`.

## Why
Continuation sessions re-resolve provider credentials on the server, but custom providers only read embedded `api_key` values. That broke resumed sessions for providers that intentionally keep secrets in `.env` via `key_env`.

## Validation
- Reproduced the continuation path with a custom provider whose `config.yaml` only defines `key_env` and whose secret lives in `.env`.
- Verified the resumed session now starts successfully instead of failing with `Coding agent provider credentials are missing`.
- Confirmed the upstream diff only touches `packages/server/src/services/coding-agents.ts` and `tests/server/coding-agent-resume-config.test.ts`.

