### PR TITLE
fix(skills): limit skill detail file list height to prevent content overflow / 限制技能详情页文件列表高度

### DIFF
--- a/packages/client/src/components/hermes/skills/SkillDetail.vue
+++ b/packages/client/src/components/hermes/skills/SkillDetail.vue
@@ -311,6 +311,8 @@ watch(() => `${props.category}/${props.skill}`, loadSkill, { immediate: true })
   border-top: 1px solid $border-color;
   padding-top: 12px;
   margin-top: 12px;
+  max-height: 30vh;
+  overflow-y: auto;
 }
 
 .files-header {


### PR DESCRIPTION
## Problem / 问题

When a skill has many supporting files (e.g., references, templates, scripts), the file list section on the skill detail page expands without limit, pushing the SKILL.md content below the fold and making it very hard to read.

**问题描述**：
当技能包含较多附件文件（如参考文档、模板、脚本等）时，详情页的文件列表区域会无限撑大，导致 SKILL.md 正文内容被严重挤压到可视区域以下，阅读体验很差。

## Solution / 解决方案

Add `max-height: 30vh` and `overflow-y: auto` to the `.detail-files` container so it scrolls internally when it exceeds 30% of the viewport height. The SKILL.md content remains fully visible.

**解决方案**：
为 `.detail-files` 容器添加 `max-height: 30vh` 和 `overflow-y: auto`，当文件列表超过视口 30% 高度时，在其内部滚动，SKILL.md 正文保持完整可见。

## Changes / 变更

- `packages/client/src/components/hermes/skills/SkillDetail.vue`: Add scroll constraint (max-height + overflow-y:auto) to `.detail-files` CSS class

## Testing / 测试

本地 build 通过，在技能详情页验证了文件列表正确滚动。