### PR TITLE
[codex] add skills runtime filter

### DIFF
--- a/packages/client/src/api/hermes/skills.ts
+++ b/packages/client/src/api/hermes/skills.ts
@@ -1,6 +1,7 @@
 import { request, getBaseUrlValue, getApiKey, getActiveProfileName } from '../client'
 
 export type SkillSource = 'builtin' | 'hub' | 'local' | 'external'
+export type SkillTarget = 'hermes' | 'claude' | 'codex'
 
 export interface SkillInfo {
   name: string
@@ -102,8 +103,11 @@ export interface SkillUsageStats {
   top_skills: SkillUsageRow[]
 }
 
-export async function fetchSkills(profile?: string): Promise<SkillsData> {
-  const query = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+export async function fetchSkills(profile?: string, target: SkillTarget = 'hermes'): Promise<SkillsData> {
+  const params = new URLSearchParams()
+  if (profile) params.set('profile', profile)
+  if (target !== 'hermes') params.set('target', target)
+  const query = params.toString() ? `?${params.toString()}` : ''
   const res = await request<SkillListResponse>(`/api/hermes/skills${query}`)
   return { categories: res.categories, archived: res.archived ?? [], paths: res.paths }
 }
@@ -113,13 +117,18 @@ export async function fetchSkillUsageStats(days = 7): Promise<SkillUsageStats> {
   return request<SkillUsageStats>(`/api/hermes/skills/usage/stats?${params}`)
 }
 
-export async function fetchSkillContent(skillPath: string): Promise<string> {
-  const res = await request<{ content: string }>(`/api/hermes/skills/${skillPath}`)
+function targetQuery(target: SkillTarget = 'hermes'): string {
+  if (target === 'hermes') return ''
+  return `?target=${encodeURIComponent(target)}`
+}
+
+export async function fetchSkillContent(skillPath: string, target: SkillTarget = 'hermes'): Promise<string> {
+  const res = await request<{ content: string }>(`/api/hermes/skills/${skillPath}${targetQuery(target)}`)
   return res.content
 }
 
-export async function fetchSkillFiles(category: string, skill: string): Promise<SkillFileEntry[]> {
-  const res = await request<{ files: SkillFileEntry[] }>(`/api/hermes/skills/${category}/${skill}/files`)
+export async function fetchSkillFiles(category: string, skill: string, target: SkillTarget = 'hermes'): Promise<SkillFileEntry[]> {
+  const res = await request<{ files: SkillFileEntry[] }>(`/api/hermes/skills/${category}/${skill}/files${targetQuery(target)}`)
   return res.files
 }
 

--- a/packages/client/src/components/hermes/skills/SkillDetail.vue
+++ b/packages/client/src/components/hermes/skills/SkillDetail.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
 import MarkdownRenderer from '@/components/hermes/chat/MarkdownRenderer.vue'
-import { fetchSkillContent, fetchSkillFiles, pinSkillApi, type SkillFileEntry } from '@/api/hermes/skills'
+import { fetchSkillContent, fetchSkillFiles, pinSkillApi, type SkillFileEntry, type SkillTarget } from '@/api/hermes/skills'
 import { useI18n } from 'vue-i18n'
 import { useMessage } from 'naive-ui'
 
@@ -16,6 +16,8 @@ const props = defineProps<{
   useCount?: number
   viewCount?: number
   pinned?: boolean
+  target?: SkillTarget
+  readonly?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -38,8 +40,8 @@ async function loadSkill() {
   try {
     const skillPath = `${props.category}/${props.skill}/SKILL.md`
     const [skillContent, skillFiles] = await Promise.all([
-      fetchSkillContent(skillPath),
-      fetchSkillFiles(props.category, props.skill),
+      fetchSkillContent(skillPath, props.target || 'hermes'),
+      fetchSkillFiles(props.category, props.skill, props.target || 'hermes'),
     ])
     content.value = skillContent
     files.value = skillFiles.filter(f => !f.isDir && f.path !== 'SKILL.md')
@@ -66,7 +68,7 @@ async function viewFile(filePath: string) {
         relPath = afterSkillDir
       }
     }
-    fileContent.value = await fetchSkillContent(`${base}${relPath}`)
+    fileContent.value = await fetchSkillContent(`${base}${relPath}`, props.target || 'hermes')
   } catch (err: any) {
     fileContent.value = t('skills.fileLoadFailed') + `: ${err.message}`
   } finally {
@@ -95,7 +97,7 @@ async function handlePinToggle() {
   }
 }
 
-watch(() => `${props.category}/${props.skill}`, loadSkill, { immediate: true })
+watch(() => `${props.target || 'hermes'}/${props.category}/${props.skill}`, loadSkill, { immediate: true })
 </script>
 
 <template>
@@ -106,7 +108,7 @@ watch(() => `${props.category}/${props.skill}`, loadSkill, { immediate: true })
       <span class="detail-separator">/</span>
       <span class="detail-name">{{ skill }}</span>
       <div class="usage-stats">
-        <button class="pin-toggle" :class="{ active: pinned }" :disabled="pinLoading" :title="pinned ? t('skills.unpin') : t('skills.pin')" @click="handlePinToggle">
+        <button v-if="!readonly" class="pin-toggle" :class="{ active: pinned }" :disabled="pinLoading" :title="pinned ? t('skills.unpin') : t('skills.pin')" @click="handlePinToggle">
           <svg width="16" height="16" viewBox="0 0 24 24" :fill="pinned ? 'currentColor' : 'none'" stroke="currentColor" stroke-width="2"><path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z"/></svg>
         </button>
         <span v-if="viewCount != null" class="usage-stat" title="Views">

--- a/packages/client/src/components/hermes/skills/SkillList.vue
+++ b/packages/client/src/components/hermes/skills/SkillList.vue
@@ -17,6 +17,7 @@ const props = defineProps<{
     selectedSkill: string | null
     searchQuery: string
     sourceFilter: SourceFilter | null
+    readonly?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -240,7 +241,7 @@ function confirmDelete(category: string, skillName: string) {
                                     </span>
                                     <span v-if="skill.description" class="skill-desc">{{ skill.description }}</span>
                                 </div>
-                                <NSwitch size="small" :value="skill.enabled !== false"
+                                <NSwitch v-if="!readonly" size="small" :value="skill.enabled !== false"
                                     :loading="togglingSkills.has(skill.name)"
                                     @update:value="handleToggle(cat.name, skill.name, $event)" @click.stop />
                             </button>
@@ -276,7 +277,7 @@ function confirmDelete(category: string, skillName: string) {
                             </span>
                             <span v-if="skill.description" class="skill-desc">{{ skill.description }}</span>
                         </div>
-                        <button v-if="(skill.source ?? 'local') === 'local'" class="skill-action-btn"
+                        <button v-if="!readonly && (skill.source ?? 'local') === 'local'" class="skill-action-btn"
                             :title="t('skills.delete')" :disabled="deletingSkills.has(skill.name)"
                             @click.stop="confirmDelete(cat.name, skill.name)">
                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
@@ -288,7 +289,7 @@ function confirmDelete(category: string, skillName: string) {
                                 <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
                             </svg>
                         </button>
-                        <NSwitch size="small" :value="skill.enabled !== false"
+                        <NSwitch v-if="!readonly" size="small" :value="skill.enabled !== false"
                             :loading="togglingSkills.has(skill.name)"
                             @update:value="handleToggle(cat.name, skill.name, $event)" @click.stop />
                     </button>

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -682,6 +682,12 @@ jobTriggered: 'Job ausgelost',
   // Skills
   skills: {
     title: 'Fahigkeiten',
+    targetFilter: 'Runtime',
+    targets: {
+      hermes: 'Hermes',
+      claude: 'Claude',
+      codex: 'Codex',
+    },
     searchPlaceholder: 'Fahigkeiten suchen...',
     noMatch: 'Keine Fahigkeiten entsprechen Ihrer Suche',
     noSkills: 'Keine Fahigkeiten gefunden',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -818,6 +818,12 @@ export default {
   // Skills
   skills: {
     title: 'Skills',
+    targetFilter: 'Runtime',
+    targets: {
+      hermes: 'Hermes',
+      claude: 'Claude',
+      codex: 'Codex',
+    },
     searchPlaceholder: 'Search skills...',
     noMatch: 'No skills match your search',
     noSkills: 'No skills found',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -682,6 +682,12 @@ jobTriggered: 'Job ejecutado',
   // Skills
   skills: {
     title: 'Habilidades',
+    targetFilter: 'Runtime',
+    targets: {
+      hermes: 'Hermes',
+      claude: 'Claude',
+      codex: 'Codex',
+    },
     searchPlaceholder: 'Buscar habilidades...',
     noMatch: 'Ninguna habilidad coincide con tu busqueda',
     noSkills: 'No se encontraron habilidades',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -682,6 +682,12 @@ jobTriggered: 'Job declenche',
   // Skills
   skills: {
     title: 'Competences',
+    targetFilter: 'Runtime',
+    targets: {
+      hermes: 'Hermes',
+      claude: 'Claude',
+      codex: 'Codex',
+    },
     searchPlaceholder: 'Rechercher des competences...',
     noMatch: 'Aucune competence ne correspond a votre recherche',
     noSkills: 'Aucune competence trouvee',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -682,6 +682,12 @@ export default {
   // スキル
   skills: {
     title: 'スキル',
+    targetFilter: 'ランタイム',
+    targets: {
+      hermes: 'Hermes',
+      claude: 'Claude',
+      codex: 'Codex',
+    },
     searchPlaceholder: 'スキルを検索...',
     noMatch: '検索に一致するスキルがありません',
     noSkills: 'スキルがありません',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -682,6 +682,12 @@ export default {
   // 스킬
   skills: {
     title: '스킬',
+    targetFilter: '런타임',
+    targets: {
+      hermes: 'Hermes',
+      claude: 'Claude',
+      codex: 'Codex',
+    },
     searchPlaceholder: '스킬 검색...',
     noMatch: '검색과 일치하는 스킬이 없습니다',
     noSkills: '스킬을 찾을 수 없습니다',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -682,6 +682,12 @@ jobTriggered: 'Job acionado',
   // Skills
   skills: {
     title: 'Habilidades',
+    targetFilter: 'Runtime',
+    targets: {
+      hermes: 'Hermes',
+      claude: 'Claude',
+      codex: 'Codex',
+    },
     searchPlaceholder: 'Buscar habilidades...',
     noMatch: 'Nenhuma habilidade corresponde a sua busca',
     noSkills: 'Nenhuma habilidade encontrada',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -722,6 +722,12 @@ export default {
 
   skills: {
     title: 'Навыки',
+    targetFilter: 'Среда',
+    targets: {
+      hermes: 'Hermes',
+      claude: 'Claude',
+      codex: 'Codex',
+    },
     searchPlaceholder: 'Поиск навыков...',
     noMatch: 'Нет подходящих навыков',
     noSkills: 'Нет навыков',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -818,6 +818,12 @@ export default {
   // 技能
   skills: {
     title: '技能',
+    targetFilter: '執行環境',
+    targets: {
+      hermes: 'Hermes',
+      claude: 'Claude',
+      codex: 'Codex',
+    },
     searchPlaceholder: '搜尋技能...',
     noMatch: '沒有符合的技能',
     noSkills: '目前無技能',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -818,6 +818,12 @@ export default {
   // 技能
   skills: {
     title: '技能',
+    targetFilter: '运行时',
+    targets: {
+      hermes: 'Hermes',
+      claude: 'Claude',
+      codex: 'Codex',
+    },
     searchPlaceholder: '搜索技能...',
     noMatch: '没有匹配的技能',
     noSkills: '暂无技能',

--- a/packages/client/src/views/hermes/SkillsView.vue
+++ b/packages/client/src/views/hermes/SkillsView.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
-import { NBadge, NButton, NDrawer, NDrawerContent, NInput } from 'naive-ui'
+import { NBadge, NButton, NDrawer, NDrawerContent, NInput, NSelect } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import SkillList from '@/components/hermes/skills/SkillList.vue'
 import SkillDetail from '@/components/hermes/skills/SkillDetail.vue'
 import SkillImportModal from '@/components/hermes/skills/SkillImportModal.vue'
 import SkillExternalDirsModal from '@/components/hermes/skills/SkillExternalDirsModal.vue'
 import PendingWriteApprovals from '@/components/hermes/skills/PendingWriteApprovals.vue'
-import { fetchSkills, type SkillCategory, type SkillSource, type SkillInfo } from '@/api/hermes/skills'
+import { fetchSkills, type SkillCategory, type SkillSource, type SkillInfo, type SkillTarget } from '@/api/hermes/skills'
 import { fetchPendingWrites } from '@/api/hermes/write-gate'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 
@@ -23,6 +23,7 @@ const selectedSkill = ref('')
 const searchQuery = ref('')
 const showSidebar = ref(true)
 const sourceFilter = ref<SourceFilter | null>(null)
+const skillTarget = ref<SkillTarget>('hermes')
 const showImportModal = ref(false)
 const showExternalDirsModal = ref(false)
 const showWriteApprovalDrawer = ref(false)
@@ -38,6 +39,14 @@ const selectedSkillData = computed(() => {
   const cat = categories.value.find(c => c.name === selectedCategory.value)
   return cat?.skills.find(s => s.name === selectedSkill.value) ?? null
 })
+
+const skillTargetOptions = computed(() => [
+  { label: t('skills.targets.hermes'), value: 'hermes' },
+  { label: t('skills.targets.claude'), value: 'claude' },
+  { label: t('skills.targets.codex'), value: 'codex' },
+])
+
+const isHermesTarget = computed(() => skillTarget.value === 'hermes')
 
 function handleMobileChange(e: MediaQueryListEvent | MediaQueryList) {
   showSidebar.value = !e.matches
@@ -61,7 +70,7 @@ async function loadSkills() {
     if (!profilesStore.activeProfileName || profilesStore.profiles.length === 0) {
       await profilesStore.fetchProfiles()
     }
-    const data = await fetchSkills()
+    const data = await fetchSkills(undefined, skillTarget.value)
     categories.value = data.categories
     archived.value = data.archived
     ensureSelectedSkill()
@@ -70,6 +79,14 @@ async function loadSkills() {
   } finally {
     loading.value = false
   }
+}
+
+function handleTargetChange() {
+  selectedCategory.value = ''
+  selectedSkill.value = ''
+  sourceFilter.value = null
+  loadSkills()
+  if (skillTarget.value === 'hermes') loadPendingWriteCount()
 }
 
 async function loadPendingWriteCount() {
@@ -166,7 +183,7 @@ function handlePinToggled(name: string, pinned: boolean) {
       </div>
       <div class="header-actions">
         <NButton
-          v-if="writeApprovalSupported"
+          v-if="isHermesTarget && writeApprovalSupported"
           class="header-action-btn"
           size="small"
           :title="t('skills.writeApprovalTitle')"
@@ -186,6 +203,7 @@ function handlePinToggled(name: string, pinned: boolean) {
           </span>
         </NButton>
         <NButton
+          v-if="isHermesTarget"
           class="header-action-btn"
           size="small"
           :title="t('skills.import')"
@@ -202,6 +220,7 @@ function handlePinToggled(name: string, pinned: boolean) {
           <span class="header-action-label">{{ t('skills.import') }}</span>
         </NButton>
         <NButton
+          v-if="isHermesTarget"
           class="header-action-btn"
           size="small"
           :title="t('skills.externalDirs.manage')"
@@ -247,12 +266,22 @@ function handlePinToggled(name: string, pinned: boolean) {
       <div v-else class="skills-layout">
           <div class="mobile-backdrop" :class="{ active: showSidebar }" @click="showSidebar = false" />
           <div v-if="showSidebar" class="skills-sidebar">
+            <div class="skills-target-filter">
+              <span class="target-filter-label">{{ t('skills.targetFilter') }}</span>
+              <NSelect
+                v-model:value="skillTarget"
+                size="small"
+                :options="skillTargetOptions"
+                @update:value="handleTargetChange"
+              />
+            </div>
             <SkillList
               :categories="categories"
               :archived="archived"
               :selected-skill="selectedCategory && selectedSkill ? `${selectedCategory}/${selectedSkill}` : null"
               :search-query="searchQuery"
               :source-filter="sourceFilter"
+              :readonly="!isHermesTarget"
               @select="handleSelect"
               @deleted="handleSkillDeleted"
             />
@@ -267,6 +296,8 @@ function handlePinToggled(name: string, pinned: boolean) {
               :use-count="selectedSkillData?.useCount"
               :view-count="selectedSkillData?.viewCount"
               :pinned="selectedSkillData?.pinned"
+              :target="skillTarget"
+              :readonly="!isHermesTarget"
               @pin-toggled="handlePinToggled"
             />
             <div v-else class="empty-detail">
@@ -305,6 +336,22 @@ function handlePinToggled(name: string, pinned: boolean) {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.skills-target-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 8px 10px;
+  border-bottom: 1px solid $border-light;
+}
+
+.target-filter-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: $text-muted;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
 }
 
 .legend-item {

--- a/packages/server/src/controllers/hermes/skills.ts
+++ b/packages/server/src/controllers/hermes/skills.ts
@@ -24,6 +24,46 @@ function requestSkillsDir(ctx: any): string {
   return join(requestProfileDir(ctx), 'skills')
 }
 
+type SkillTarget = 'hermes' | 'claude' | 'codex'
+
+function requestSkillTarget(ctx: any): SkillTarget {
+  const target = String(ctx.query?.target || 'hermes').trim().toLowerCase()
+  return target === 'claude' || target === 'codex' ? target : 'hermes'
+}
+
+function globalSkillsDir(target: Exclude<SkillTarget, 'hermes'>): string {
+  return target === 'claude'
+    ? join(homedir(), '.claude', 'skills')
+    : join(homedir(), '.agents', 'skills')
+}
+
+function codexSystemSkillsDir(): string {
+  return join(homedir(), '.codex', 'skills', '.system')
+}
+
+function requestTargetSkillsDir(ctx: any): string {
+  const target = requestSkillTarget(ctx)
+  return target === 'hermes' ? requestSkillsDir(ctx) : globalSkillsDir(target)
+}
+
+async function resolveSkillDirForTarget(ctx: any, category: string, skillName: string): Promise<string | null> {
+  const target = requestSkillTarget(ctx)
+  const skillsDir = requestTargetSkillsDir(ctx)
+  if (target === 'hermes') {
+    const config = await readConfigYamlForProfile(requestedProfile(ctx))
+    return resolveSkillDirFromConfig(config, skillsDir, category, skillName)
+  }
+
+  const localSkillDir = await findSkillDirInRoot(skillsDir, category, skillName)
+  if (localSkillDir) return localSkillDir
+
+  if (target === 'codex') {
+    return findSkillDirInRoot(codexSystemSkillsDir(), category, skillName)
+  }
+
+  return null
+}
+
 function expandConfiguredPath(value: string): string {
   const expandedEnv = value.replace(/\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g, (_match, braced, bare) => {
     return process.env[braced || bare] || ''
@@ -385,6 +425,26 @@ async function scanSkillsDir(skillsDir: string, bundledManifest: Map<string, str
   return categories
 }
 
+async function scanSkillsDirIfExists(skillsDir: string, bundledManifest: Map<string, string>, hubNames: Set<string>, disabledList: string[], usageStats: Map<string, UsageStats>) {
+  try {
+    const info = await stat(skillsDir)
+    if (!info.isDirectory()) return []
+  } catch {
+    return []
+  }
+  return scanSkillsDir(skillsDir, bundledManifest, hubNames, disabledList, usageStats)
+}
+
+function withSkillSource(categories: any[], source: SkillSource): any[] {
+  return categories.map(category => ({
+    ...category,
+    skills: (category.skills || []).map((skill: any) => ({
+      ...skill,
+      source,
+    })),
+  }))
+}
+
 async function scanExternalSkillsDir(
   skillsDir: string,
   disabledList: string[],
@@ -445,8 +505,29 @@ function mergeExternalCategories(categories: any[], externalCategories: any[]): 
 }
 
 export async function list(ctx: any) {
-  const skillsDir = requestSkillsDir(ctx)
+  const target = requestSkillTarget(ctx)
+  const skillsDir = requestTargetSkillsDir(ctx)
   try {
+    if (target !== 'hermes') {
+      let categories = await scanSkillsDirIfExists(skillsDir, new Map(), new Set(), [], new Map())
+      const extraDirs: string[] = []
+      if (target === 'codex') {
+        const systemDir = codexSystemSkillsDir()
+        extraDirs.push(systemDir)
+        const systemCategories = withSkillSource(
+          await scanSkillsDirIfExists(systemDir, new Map(), new Set(), [], new Map()),
+          'builtin',
+        )
+        categories = mergeExternalCategories(categories, systemCategories)
+      }
+      ctx.body = {
+        categories,
+        archived: [],
+        paths: { local: skillsDir, external: extraDirs },
+      }
+      return
+    }
+
     const config = await readConfigYamlForProfile(requestedProfile(ctx))
     const disabledList: string[] = config.skills?.disabled || []
 
@@ -456,7 +537,7 @@ export async function list(ctx: any) {
     const usageStats = readUsageStats(await safeReadFile(join(skillsDir, '.usage.json')))
 
     // Scan all skills (supports both two-level and three-level directory structures)
-    let categories = await scanSkillsDir(skillsDir, bundledManifest, hubNames, disabledList, usageStats)
+    let categories = await scanSkillsDirIfExists(skillsDir, bundledManifest, hubNames, disabledList, usageStats)
     // Map resolved → raw so we can attach the user-written path (e.g. ~/...) to
     // each external skill — the SkillsView groups by this when the external
     // filter is active.
@@ -614,10 +695,8 @@ export async function toggle(ctx: any) {
 
 export async function listFiles(ctx: any) {
   const { category, skill } = ctx.params
-  const profileSkillsDir = requestSkillsDir(ctx)
   try {
-    const config = await readConfigYamlForProfile(requestedProfile(ctx))
-    const skillDir = await resolveSkillDirFromConfig(config, profileSkillsDir, category, skill)
+    const skillDir = await resolveSkillDirForTarget(ctx, category, skill)
     if (!skillDir) {
       ctx.status = 404
       ctx.body = { error: 'Skill not found' }
@@ -634,7 +713,7 @@ export async function listFiles(ctx: any) {
 
 export async function readFile_(ctx: any) {
   const filePath = (ctx.params as any).path
-  const profileSkillsDir = requestSkillsDir(ctx)
+  const profileSkillsDir = requestTargetSkillsDir(ctx)
   // Handle 'misc' category: real skill dir is skills/<skill>, not skills/misc/<skill>
   let realPath = filePath
   if (filePath.startsWith('misc/')) {
@@ -655,8 +734,7 @@ export async function readFile_(ctx: any) {
       const category = parts[0]
       const skillName = parts[1]
       const restPath = parts.slice(2).join('/')
-      const config = await readConfigYamlForProfile(requestedProfile(ctx))
-      const skillDir = await resolveSkillDirFromConfig(config, profileSkillsDir, category, skillName)
+      const skillDir = await resolveSkillDirForTarget(ctx, category, skillName)
       if (skillDir) {
         const resolvedPath = resolve(join(skillDir, restPath))
         if (isPathWithin(resolvedPath, skillDir)) {

--- a/tests/client/skills-view.test.ts
+++ b/tests/client/skills-view.test.ts
@@ -51,6 +51,11 @@ vi.mock('naive-ui', () => ({
     emits: ['update:value'],
     template: '<input class="n-input-stub" :value="value" @input="$emit(\'update:value\', $event.target.value)" />',
   }),
+  NSelect: defineComponent({
+    props: ['value', 'options', 'size'],
+    emits: ['update:value'],
+    template: '<select class="n-select-stub" :value="value" @change="$emit(\'update:value\', $event.target.value)"><option v-for="option in options" :key="option.value" :value="option.value">{{ option.label }}</option></select>',
+  }),
 }))
 
 import SkillsView from '@/views/hermes/SkillsView.vue'

--- a/tests/server/skills-controller.test.ts
+++ b/tests/server/skills-controller.test.ts
@@ -198,6 +198,85 @@ describe('skills controller', () => {
     }
   })
 
+  it('lists Codex user and system skills for the codex target', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hermes-web-ui-codex-skills-'))
+    const previousHome = process.env.HOME
+    const userSkillDir = join(root, '.agents', 'skills', 'user-skill')
+    const systemSkillDir = join(root, '.codex', 'skills', '.system', 'system-skill')
+
+    await mkdir(userSkillDir, { recursive: true })
+    await mkdir(systemSkillDir, { recursive: true })
+    await writeFile(join(userSkillDir, 'SKILL.md'), '# User Skill\nuser codex skill\n', 'utf-8')
+    await writeFile(join(systemSkillDir, 'SKILL.md'), '# System Skill\nsystem codex skill\n', 'utf-8')
+    process.env.HOME = root
+
+    try {
+      const { list } = await loadController()
+      const ctx: any = { query: { target: 'codex' }, state: { profile: { name: 'research' } }, body: null }
+
+      await list(ctx)
+
+      const misc = ctx.body.categories.find((category: any) => category.name === 'misc')
+      expect(misc.skills).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'user-skill', source: 'local', description: 'user codex skill' }),
+        expect.objectContaining({ name: 'system-skill', source: 'builtin', description: 'system codex skill' }),
+      ]))
+      expect(ctx.body.paths).toEqual({
+        local: join(root, '.agents', 'skills'),
+        external: [join(root, '.codex', 'skills', '.system')],
+      })
+      expect(mockReadConfigYamlForProfile).not.toHaveBeenCalled()
+    } finally {
+      if (previousHome == null) delete process.env.HOME
+      else process.env.HOME = previousHome
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('reads Codex system skill details for the codex target', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hermes-web-ui-codex-system-skill-'))
+    const previousHome = process.env.HOME
+    const systemSkillDir = join(root, '.codex', 'skills', '.system', 'imagegen')
+
+    await mkdir(join(systemSkillDir, 'references'), { recursive: true })
+    await writeFile(join(systemSkillDir, 'SKILL.md'), '# Imagegen\nsystem image skill\n', 'utf-8')
+    await writeFile(join(systemSkillDir, 'references', 'usage.md'), 'usage notes\n', 'utf-8')
+    process.env.HOME = root
+    mockListFilesRecursive.mockResolvedValue([
+      { path: 'SKILL.md', isDir: false },
+      { path: 'references/usage.md', isDir: false },
+    ])
+
+    try {
+      const { readFile_, listFiles } = await loadController()
+      const readCtx: any = {
+        query: { target: 'codex' },
+        params: { path: 'misc/imagegen/SKILL.md' },
+        state: { profile: { name: 'research' } },
+        body: null,
+      }
+
+      await readFile_(readCtx)
+
+      expect(readCtx.body).toEqual({ content: '# Imagegen\nsystem image skill\n' })
+
+      const filesCtx: any = {
+        query: { target: 'codex' },
+        params: { category: 'misc', skill: 'imagegen' },
+        state: { profile: { name: 'research' } },
+        body: null,
+      }
+
+      await listFiles(filesCtx)
+
+      expect(filesCtx.body).toEqual({ files: [{ path: 'references/usage.md', isDir: false }] })
+    } finally {
+      if (previousHome == null) delete process.env.HOME
+      else process.env.HOME = previousHome
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('traverses symlinked category entries without following hidden or cyclic links', async () => {
     const root = await mkdtemp(join(tmpdir(), 'hermes-web-ui-symlink-category-skill-'))
     const profileDir = join(root, 'profile')


### PR DESCRIPTION
## Summary
- Add a runtime selector above the Skills list with Hermes as the default target.
- Show Claude global skills from ~/.claude/skills and Codex user/system skills from ~/.agents/skills plus ~/.codex/skills/.system.
- Keep non-Hermes skill targets read-only in the UI while preserving Hermes management actions.
- Route skill detail and attached-file reads through the selected target.

## Validation
- `npm exec -- vitest run tests/server/skills-controller.test.ts tests/client/skills-view.test.ts`
- `npm run harness:check`
- `npm run build`