### PR TITLE
[codex] fix Windows auto updater recovery

### DIFF
--- a/packages/desktop/src/main/updater-helpers.ts
+++ b/packages/desktop/src/main/updater-helpers.ts
@@ -1,0 +1,40 @@
+import { join } from 'node:path'
+
+export function isWindowsUpdaterLockError(err: unknown): boolean {
+  const message = String((err as { message?: unknown } | null)?.message || err || '')
+  return /failed to uninstall old application files/i.test(message)
+    || /\bquitandinstall\b/i.test(message) && /\b(?:code|errno)?\s*:?\s*2\b/i.test(message)
+    || /\bsquirrel\b/i.test(message) && /\b(?:code|errno)?\s*:?\s*2\b/i.test(message)
+}
+
+function updateCacheNames(appName: string): string[] {
+  const names = new Set<string>()
+  const trimmed = appName.trim()
+  if (trimmed) {
+    names.add(`${trimmed}-updater`)
+    const kebab = trimmed
+      .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+      .replace(/[^a-zA-Z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .toLowerCase()
+    if (kebab) names.add(`${kebab}-updater`)
+  }
+  names.add('hermes-studio-updater')
+  names.add('Hermes Studio-updater')
+  return [...names]
+}
+
+export function pendingUpdateDirectories(options: {
+  appDataPath?: string | null
+  localAppData?: string | null
+  appName?: string | null
+}): string[] {
+  const bases = new Set<string>()
+  const appDataPath = options.appDataPath?.trim()
+  const localAppData = options.localAppData?.trim()
+  if (localAppData) bases.add(localAppData)
+  if (appDataPath) bases.add(appDataPath)
+  if (!bases.size) return []
+  return [...bases].flatMap(base => updateCacheNames(options.appName || 'Hermes Studio')
+    .map(name => join(base, name, 'pending')))
+}

--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -1,17 +1,24 @@
 import { app, dialog } from 'electron'
 import { autoUpdater, type ProgressInfo, type UpdateDownloadedEvent, type UpdateInfo } from 'electron-updater'
+import { execFile } from 'node:child_process'
+import { rm } from 'node:fs/promises'
+import { basename } from 'node:path'
+import { promisify } from 'node:util'
 import { t } from './desktop-i18n'
+import { isWindowsUpdaterLockError, pendingUpdateDirectories } from './updater-helpers'
 
 let initialized = false
 let checking = false
 let updateDownloaded = false
 let tryingFallbackFeed = false
+let recoveringPendingUpdate = false
 
 const CLOUDFLARE_LATEST_FEED_URL = 'https://download.ekkolearnai.com/latest'
 const GITHUB_LATEST_FEED_URL = 'https://github.com/EKKOLearnAI/hermes-studio/releases/latest/download'
+const execFileAsync = promisify(execFile)
 
 interface AutoUpdaterOptions {
-  beforeQuitAndInstall?: () => void
+  beforeQuitAndInstall?: () => void | Promise<void>
 }
 
 let options: AutoUpdaterOptions = {}
@@ -59,6 +66,92 @@ function showUpdateCheckFailed() {
   }).catch(() => undefined)
 }
 
+async function clearPendingUpdateDirectories(): Promise<void> {
+  if (process.platform !== 'win32') return
+  const dirs = pendingUpdateDirectories({
+    appDataPath: app.getPath('appData'),
+    localAppData: process.env.LOCALAPPDATA,
+    appName: app.getName(),
+  })
+  await Promise.all(dirs.map(async dir => {
+    try {
+      await rm(dir, { recursive: true, force: true })
+      console.warn(`[updater] cleared pending update directory: ${dir}`)
+    } catch (err) {
+      console.warn(`[updater] failed to clear pending update directory ${dir}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }))
+}
+
+async function recoverFailedPendingUpdate(err: unknown): Promise<void> {
+  if (recoveringPendingUpdate || process.platform !== 'win32' || !isWindowsUpdaterLockError(err)) return
+  recoveringPendingUpdate = true
+  try {
+    await clearPendingUpdateDirectories()
+    updateDownloaded = false
+  } finally {
+    recoveringPendingUpdate = false
+  }
+}
+
+export async function stopOtherWindowsAppInstances(execPath = process.execPath, currentPid = process.pid): Promise<void> {
+  if (process.platform !== 'win32') return
+  const normalizedExecPath = execPath.trim()
+  if (!normalizedExecPath) return
+  const script = `
+$ErrorActionPreference = 'SilentlyContinue'
+$target = [System.IO.Path]::GetFullPath($env:HERMES_STUDIO_UPDATE_EXE)
+$current = [int]$env:HERMES_STUDIO_UPDATE_PID
+function Get-HermesStudioProcess {
+  Get-CimInstance Win32_Process | Where-Object {
+    try {
+      $_.ProcessId -ne $current -and $_.ExecutablePath -and ([System.IO.Path]::GetFullPath($_.ExecutablePath) -ieq $target)
+    } catch {
+      $false
+    }
+  }
+}
+Get-HermesStudioProcess | ForEach-Object {
+  try {
+    $process = Get-Process -Id $_.ProcessId
+    if ($process) { $process.CloseMainWindow() | Out-Null }
+  } catch {}
+}
+Start-Sleep -Milliseconds 750
+Get-HermesStudioProcess | ForEach-Object {
+  try { Stop-Process -Id $_.ProcessId -Force } catch {}
+}
+`.trim()
+  try {
+    await execFileAsync('powershell.exe', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', script], {
+      env: {
+        ...process.env,
+        HERMES_STUDIO_UPDATE_EXE: normalizedExecPath,
+        HERMES_STUDIO_UPDATE_PID: String(currentPid),
+      },
+      timeout: 30_000,
+      windowsHide: true,
+    })
+    console.log(`[updater] stopped other ${basename(normalizedExecPath)} instances before update install`)
+  } catch (err) {
+    console.warn(`[updater] failed to stop other app instances before update install: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+async function prepareQuitAndInstall(): Promise<void> {
+  try {
+    await options.beforeQuitAndInstall?.()
+  } catch (err) {
+    console.warn(`[updater] beforeQuitAndInstall hook failed: ${err instanceof Error ? err.message : String(err)}`)
+  }
+  await stopOtherWindowsAppInstances()
+}
+
+async function quitAndInstallDownloadedUpdate(): Promise<void> {
+  await prepareQuitAndInstall()
+  autoUpdater.quitAndInstall()
+}
+
 export function initAutoUpdater(nextOptions: AutoUpdaterOptions = {}) {
   options = { ...options, ...nextOptions }
   if (initialized) return
@@ -85,6 +178,9 @@ export function initAutoUpdater(nextOptions: AutoUpdaterOptions = {}) {
   })
   autoUpdater.on('error', err => {
     console.error('[updater] error:', err)
+    recoverFailedPendingUpdate(err).catch(cleanupErr => {
+      console.warn(`[updater] pending update recovery failed: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`)
+    })
     if (checking && !tryingFallbackFeed) showUpdateCheckFailed()
   })
   autoUpdater.on('download-progress', (info: ProgressInfo) => {
@@ -102,8 +198,7 @@ export function initAutoUpdater(nextOptions: AutoUpdaterOptions = {}) {
       cancelId: 1,
     })
     if (response === 0) {
-      options.beforeQuitAndInstall?.()
-      autoUpdater.quitAndInstall()
+      await quitAndInstallDownloadedUpdate()
     }
   })
 
@@ -133,8 +228,7 @@ export async function checkForDesktopUpdates(manual: boolean): Promise<void> {
   }
 
   if (updateDownloaded) {
-    options.beforeQuitAndInstall?.()
-    autoUpdater.quitAndInstall()
+    await quitAndInstallDownloadedUpdate()
     return
   }
 

--- a/tests/desktop/updater.test.ts
+++ b/tests/desktop/updater.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { isWindowsUpdaterLockError, pendingUpdateDirectories } from '../../packages/desktop/src/main/updater-helpers'
+
+describe('desktop updater helpers', () => {
+  it('detects Squirrel locked-exe update failures', async () => {
+    expect(isWindowsUpdaterLockError(new Error('Failed to uninstall old application files. Please try running the installer again.: 2'))).toBe(true)
+    expect(isWindowsUpdaterLockError(new Error('Squirrel update failed with code 2'))).toBe(true)
+    expect(isWindowsUpdaterLockError(new Error('network timeout'))).toBe(false)
+  })
+
+  it('includes local and roaming pending update cache directories', async () => {
+    expect(pendingUpdateDirectories({
+      appDataPath: 'C:\\Users\\A\\AppData\\Roaming',
+      localAppData: 'C:\\Users\\A\\AppData\\Local',
+      appName: 'Hermes Studio',
+    })).toEqual(expect.arrayContaining([
+      'C:\\Users\\A\\AppData\\Local/Hermes Studio-updater/pending',
+      'C:\\Users\\A\\AppData\\Local/hermes-studio-updater/pending',
+      'C:\\Users\\A\\AppData\\Roaming/hermes-studio-updater/pending',
+    ]))
+  })
+})


### PR DESCRIPTION
## Summary
- Stop other same-path Hermes Studio processes before running `quitAndInstall()` on Windows so tray/background instances do not keep the executable locked.
- Detect Squirrel locked-exe update failures and clear stuck pending updater cache directories so launch does not retry the same broken pending update forever.
- Add focused helper coverage for Windows updater error detection and pending cache path resolution.

Fixes #1719

## Validation
- `npm run test -- tests/desktop/updater.test.ts`
- `npm --prefix packages/desktop run build`
