### PR TITLE
[codex] improve esp32 ota update feedback

### DIFF
--- a/packages/esp32-c3/src/main.cpp
+++ b/packages/esp32-c3/src/main.cpp
@@ -183,7 +183,16 @@ void mcuSocketLoop();
 bool waitForMcuSocketReady(uint32_t timeoutMs);
 void enqueueNoDevicePrompt(const String &interactionId);
 String activeDeviceEndpoint(const __FlashStringHelper *path);
-bool checkMcuFirmwareUpdate(bool force);
+bool downloadAndApplyMcuFirmware(const String &url, const String &md5, int expectedSize);
+
+enum class McuOtaResult : uint8_t {
+  Failed,
+  NoUpdate,
+  UpdateAvailable,
+  Updated,
+};
+
+McuOtaResult checkMcuFirmwareUpdate(bool force, bool applyUpdate = true, String *outFirmwareUrl = nullptr, String *outMd5 = nullptr, int *outSize = nullptr);
 
 struct LanDevice {
   String id;
@@ -1899,10 +1908,52 @@ void sendOtaPage(const String &notice = "") {
   server.send(200, F("text/html; charset=utf-8"), html);
 }
 
+void sendOtaUpdatingPage() {
+  String html = pageStart(F("OTA"));
+  html += F("<section class='panel'><p class='meta'>HStudio ESP32-C3</p><h1>OTA</h1><p class='lead'>固件正在更新</p>");
+  html += F("<p class='hint'>固件正在下载并写入，请勿关闭单片机或断开电源。设备会自动重启，页面检测到恢复后会弹窗提示完成。</p>");
+  html += F("<div class='info-grid'>");
+  appendInfoRow(html, F("当前状态"), F("正在更新，请勿关闭单片机"));
+  appendInfoRow(html, F("服务端"), activeDeviceUrl.length() > 0 ? activeDeviceUrl : String(F("未连接")));
+  html += F("</div><p id='ota-status' class='hint'>等待设备重启...</p>");
+  html += F("<script>");
+  html += F("let seenOffline=false,done=false,start=Date.now();");
+  html += F("const s=document.getElementById('ota-status');");
+  html += F("async function poll(){if(done)return;");
+  html += F("try{const r=await fetch('/health?ota='+Date.now(),{cache:'no-store'});");
+  html += F("if(r.ok&&seenOffline){done=true;s.textContent='固件更新完成，设备已恢复在线。';alert('固件更新完成，设备已重启。');location.href='/ota';return;}");
+  html += F("if(r.ok){s.textContent='正在写入固件，请勿关闭单片机...';}");
+  html += F("}catch(e){seenOffline=true;s.textContent='设备正在重启，请等待恢复...';}");
+  html += F("if(Date.now()-start>120000&&!done){done=true;s.textContent='更新超时，请重新打开设备页面确认状态。';alert('更新状态确认超时，请重新打开设备页面确认。');return;}");
+  html += F("setTimeout(poll,1500)}setTimeout(poll,3000);");
+  html += F("</script>");
+  html += F("</section>");
+  html += pageEnd();
+  server.send(200, F("text/html; charset=utf-8"), html);
+}
+
 void handleOtaCheck() {
-  bool ok = checkMcuFirmwareUpdate(true);
+  String firmwareUrl;
+  String md5;
+  int size = 0;
+  McuOtaResult result = checkMcuFirmwareUpdate(true, false, &firmwareUrl, &md5, &size);
+  bool ok = result != McuOtaResult::Failed;
   nextMcuOtaCheckAtMs = millis() + (ok ? kMcuOtaIntervalMs : kMcuOtaRetryMs);
-  sendOtaPage(ok ? String(F("检查完成，没有需要立即处理的错误。")) : String(F("检查失败，请确认已登录机器且服务端已重启。")));
+  if (result == McuOtaResult::NoUpdate) {
+    sendOtaPage(F("当前已经是最新固件，无需更新。"));
+    return;
+  }
+  if (result == McuOtaResult::UpdateAvailable) {
+    sendOtaUpdatingPage();
+    delay(800);
+    bool applied = downloadAndApplyMcuFirmware(firmwareUrl, md5, size);
+    if (!applied) {
+      nextMcuOtaCheckAtMs = millis() + kMcuOtaRetryMs;
+      setOledStatus(OledMode::Error, F("OTA"), F("FAIL"), 0);
+    }
+    return;
+  }
+  sendOtaPage(F("检查失败，请确认已登录机器且服务端已重启。"));
 }
 
 void scanAndSendStatusPage() {
@@ -3163,31 +3214,31 @@ bool downloadAndApplyMcuFirmware(const String &url, const String &md5, int expec
   return true;
 }
 
-bool checkMcuFirmwareUpdate(bool force) {
+McuOtaResult checkMcuFirmwareUpdate(bool force, bool applyUpdate, String *outFirmwareUrl, String *outMd5, int *outSize) {
   if (!wifiReady || WiFi.status() != WL_CONNECTED || activeDeviceUrl.length() == 0 || mcuAuthToken.length() == 0) {
-    return false;
+    return McuOtaResult::Failed;
   }
   if (!force && (audioBusy || mcuAudioPlaying || mcuInteractionStatus == F("listening") || mcuInteractionStatus == F("transcribing"))) {
-    return false;
+    return McuOtaResult::Failed;
   }
 
   String endpoint = activeDeviceEndpoint(F("/api/hermes/mcu/firmware/manifest"));
-  if (endpoint.length() == 0) return false;
+  if (endpoint.length() == 0) return McuOtaResult::Failed;
 
   HTTPClient http;
   http.setTimeout(12000);
-  if (!http.begin(endpoint)) return false;
+  if (!http.begin(endpoint)) return McuOtaResult::Failed;
   http.addHeader(F("Authorization"), String(F("Bearer ")) + mcuAuthToken);
   int code = http.GET();
   String body = http.getString();
   http.end();
   if (code == 404) {
     Serial.println(F("MCU OTA manifest not available"));
-    return true;
+    return McuOtaResult::NoUpdate;
   }
   if (code < 200 || code >= 300) {
     Serial.printf("MCU OTA manifest HTTP %d\n", code);
-    return false;
+    return McuOtaResult::Failed;
   }
 
   String md5 = jsonStringValue(body, F("md5"));
@@ -3195,21 +3246,25 @@ bool checkMcuFirmwareUpdate(bool force) {
   int size = jsonIntValue(body, F("size"));
   if (md5.length() != 32 || firmwarePath.length() == 0 || size <= 0) {
     Serial.println(F("MCU OTA manifest missing md5/url/size"));
-    return false;
+    return McuOtaResult::Failed;
   }
 
   String currentMd5 = ESP.getSketchMD5();
-  if (!force && currentMd5.equalsIgnoreCase(md5)) {
+  if (currentMd5.equalsIgnoreCase(md5)) {
     Serial.printf("MCU OTA already current md5=%s\n", currentMd5.c_str());
-    return true;
+    return McuOtaResult::NoUpdate;
   }
 
   String firmwareUrl = firmwarePath;
   if (firmwareUrl.startsWith(F("/"))) {
     firmwareUrl = activeDeviceEndpoint(firmwarePath.c_str());
   }
+  if (outFirmwareUrl) *outFirmwareUrl = firmwareUrl;
+  if (outMd5) *outMd5 = md5;
+  if (outSize) *outSize = size;
   Serial.printf("MCU OTA update available current=%s next=%s size=%d\n", currentMd5.c_str(), md5.c_str(), size);
-  return downloadAndApplyMcuFirmware(firmwareUrl, md5, size);
+  if (!applyUpdate) return McuOtaResult::UpdateAvailable;
+  return downloadAndApplyMcuFirmware(firmwareUrl, md5, size) ? McuOtaResult::Updated : McuOtaResult::Failed;
 }
 
 bool broadcastMcuVoiceWav(const String &interactionId, const uint8_t *wav, size_t wavLen) {
@@ -4238,8 +4293,8 @@ void loop() {
   refreshOled();
   handleBootButton();
   if (static_cast<int32_t>(millis() - nextMcuOtaCheckAtMs) >= 0) {
-    bool checked = checkMcuFirmwareUpdate(false);
-    nextMcuOtaCheckAtMs = millis() + (checked ? kMcuOtaIntervalMs : kMcuOtaRetryMs);
+    McuOtaResult otaResult = checkMcuFirmwareUpdate(false);
+    nextMcuOtaCheckAtMs = millis() + (otaResult == McuOtaResult::Failed ? kMcuOtaRetryMs : kMcuOtaIntervalMs);
   }
 
   if (wifiReady && WiFi.status() != WL_CONNECTED) {


### PR DESCRIPTION
## Summary

Improves the ESP32-C3 OTA page feedback so manual firmware update checks are explicit and visible to the user.

## Changes

- Distinguish OTA check outcomes with an explicit result enum instead of a boolean.
- Show a clear "already latest" message when the manifest MD5 matches the current firmware.
- Show an update-in-progress page before downloading/writing firmware.
- Add browser polling for `/health` to detect device reboot/recovery and alert when the firmware update completes.
- Add a timeout alert if the page cannot confirm the device recovered.

## Impact

Users no longer see a silent no-op when the firmware is already current, and they get a strong warning not to power off the MCU while an update is being applied.

## Validation

- `platformio run`
