### PR TITLE
[codex] fix mcu audio event targeting

### DIFF
--- a/packages/server/src/services/global-agent/server.ts
+++ b/packages/server/src/services/global-agent/server.ts
@@ -482,7 +482,6 @@ export class GlobalAgentServer {
     if (!socket) return false
     const event = typeof payload.type === 'string' && payload.type.trim() ? payload.type.trim() : 'mcu.event'
     socket.emit(event, payload)
-    socket.broadcast.emit('relay.socket.event', { clientId: this.clientIdForSocket(socket), payload })
     return true
   }
 
@@ -1053,7 +1052,6 @@ export class GlobalAgentServer {
       : { type: event, payload }
     this.handleMcuClientEvent(clientId, event, body)
     this.emitFrontendBridgeEvent(clientId, body)
-    this.clients.get(clientId)?.broadcast.emit('relay.socket.event', { clientId, payload: body })
   }
 
   private mcuSessionId(clientId: string | undefined, profile: string): string {

--- a/tests/server/global-agent-server.test.ts
+++ b/tests/server/global-agent-server.test.ts
@@ -378,7 +378,7 @@ describe('GlobalAgentServer', () => {
     expect(server.getClientIds()).toEqual(['device-1'])
   })
 
-  it('pushes MCU events to the selected agent socket and forwards MCU status events', async () => {
+  it('pushes MCU events only to the selected agent socket and forwards MCU status events to frontends', async () => {
     authMocks.authenticateUserToken.mockResolvedValue({ id: 7, username: 'ada', role: 'user' })
     authMocks.userCanAccessProfile.mockReturnValue(true)
     const nsp = createMockNamespace()
@@ -399,6 +399,17 @@ describe('GlobalAgentServer', () => {
     })
     nsp.__handlers.get('connection')?.(agentSocket)
 
+    const otherAgentSocket = createMockSocket('jwt-agent-socket-2', {
+      token: 'user-jwt',
+      role: 'hermes-studio',
+      instanceId: 'device-2',
+      profile: 'research',
+    })
+    await new Promise<void>((resolve, reject) => {
+      nsp.__middleware[0](otherAgentSocket, (err?: Error) => err ? reject(err) : resolve())
+    })
+    nsp.__handlers.get('connection')?.(otherAgentSocket)
+
     expect(server.emitMcuEvent({
       type: 'audio.enqueue',
       interactionId: 'voice-1',
@@ -411,19 +422,15 @@ describe('GlobalAgentServer', () => {
       segmentId: 'voice-1-tts-1',
       url: 'http://127.0.0.1/audio.pcm',
     })
+    expect(otherAgentSocket.emit).not.toHaveBeenCalledWith('audio.enqueue', expect.anything())
+    expect(agentSocket.broadcast.emit).not.toHaveBeenCalled()
 
     agentSocket.__handlers.get('audio.queued')?.({
       interactionId: 'voice-1',
       segmentId: 'voice-1-tts-1',
     })
-    expect(agentSocket.broadcast.emit).toHaveBeenCalledWith('relay.socket.event', {
-      clientId: 'device-1',
-      payload: {
-        type: 'audio.queued',
-        interactionId: 'voice-1',
-        segmentId: 'voice-1-tts-1',
-      },
-    })
+    expect(agentSocket.broadcast.emit).not.toHaveBeenCalled()
+    expect(otherAgentSocket.emit).not.toHaveBeenCalledWith('relay.socket.event', expect.anything())
   })
 
   it('keeps MCU voice stream in listening state until the upload is ended', async () => {


### PR DESCRIPTION
## Summary

Fixes MCU audio event targeting when multiple microcontrollers are connected to the same Web UI instance.

## Root Cause

The global-agent server sent targeted MCU events to the selected socket, but then also broadcast the same payload through `relay.socket.event` to other connected MCU sockets. With two MCUs connected, audio playback events could leak to the non-target device.

## Changes

- Stop broadcasting server-originated MCU events to other MCU sockets.
- Stop rebroadcasting MCU-originated status events to other MCU sockets.
- Keep the direct target socket emit path intact.
- Update the global-agent server test to verify `audio.enqueue` reaches only the selected device.

## Validation

- `npx vitest run tests/server/global-agent-server.test.ts`
- `npm run harness:check`
