### PR TITLE
[codex] Scope voice settings by profile

### DIFF
--- a/packages/client/src/api/hermes/tts.ts
+++ b/packages/client/src/api/hermes/tts.ts
@@ -1,3 +1,5 @@
+import { getActiveProfileName, getApiKey } from '../client'
+
 export interface TtsOptions {
   text: string
   lang?: string
@@ -26,15 +28,27 @@ async function readTtsError(res: Response): Promise<string> {
   }
 }
 
+function ttsHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+  const apiKey = getApiKey()
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`
+  }
+  const profile = getActiveProfileName()
+  if (profile) {
+    headers['X-Hermes-Profile'] = profile
+  }
+  return headers
+}
+
 export async function generateSpeech(opts: TtsOptions): Promise<{ audio: Blob; engine: string }> {
   const res = await fetch(
     `${localStorage.getItem('hermes_server_url') || ''}/api/hermes/tts`,
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${localStorage.getItem('hermes_api_key') || ''}`,
-      },
+      headers: ttsHeaders(),
       body: JSON.stringify(opts),
     },
   )
@@ -55,10 +69,7 @@ export async function synthesizeSpeech(
     `${localStorage.getItem('hermes_server_url') || ''}/api/hermes/tts/synthesize`,
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${localStorage.getItem('hermes_api_key') || ''}`,
-      },
+      headers: ttsHeaders(),
       body: JSON.stringify({
         provider: req.provider,
         text: req.text,

--- a/packages/client/src/components/hermes/settings/VoiceSettings.vue
+++ b/packages/client/src/components/hermes/settings/VoiceSettings.vue
@@ -6,6 +6,7 @@ import { useSpeech, type MimoTtsOptions, type OpenaiTtsOptions } from '@/composa
 import { useMicRecorder } from '@/composables/useMicRecorder'
 import { transcribeSpeech } from '@/api/hermes/stt'
 import { useVoiceApiConnections } from '@/composables/useVoiceApiConnections'
+import { speedToEdgeRate, hzToEdgePitch } from '@/utils/ttsHelpers'
 import VoiceApiCard, { type VoiceApiCardTestState } from './voice/VoiceApiCard.vue'
 import VoiceApiFormModal from './voice/VoiceApiFormModal.vue'
 import VoiceApiConfigurator from './voice/VoiceApiConfigurator.vue'
@@ -124,12 +125,18 @@ function openaiOptionsFor(connection: VoiceApiConnection): OpenaiTtsOptions {
   const provider = connection.provider === 'edge' || connection.provider === 'openai' || connection.provider === 'custom' || connection.provider === 'doubao'
     ? connection.provider
     : undefined
+  const edgeRate = Number(options.rate)
+  const edgePitch = Number(options.pitch)
   return {
     baseUrl: String(options.baseUrl || ''),
     model: typeof options.model === 'string' ? options.model : undefined,
     voice: typeof options.voice === 'string' ? options.voice : undefined,
-    rate: typeof options.rate === 'string' ? options.rate : undefined,
-    pitch: typeof options.pitch === 'string' ? options.pitch : undefined,
+    rate: connection.provider === 'edge' && Number.isFinite(edgeRate)
+      ? speedToEdgeRate(edgeRate)
+      : typeof options.rate === 'string' ? options.rate : undefined,
+    pitch: connection.provider === 'edge' && Number.isFinite(edgePitch)
+      ? hzToEdgePitch(edgePitch)
+      : typeof options.pitch === 'string' ? options.pitch : undefined,
     stylePrompt: typeof options.stylePrompt === 'string' ? options.stylePrompt : undefined,
     provider,
   }

--- a/packages/server/src/controllers/hermes/stt.ts
+++ b/packages/server/src/controllers/hermes/stt.ts
@@ -56,9 +56,9 @@ function authUserId(ctx: Context): number | null {
 }
 
 function requestedProfile(ctx: Context): string {
-  const queryProfile = typeof ctx.query.profile === 'string' ? ctx.query.profile : ''
+  const queryProfile = typeof ctx.query?.profile === 'string' ? ctx.query.profile : ''
   const headerProfile = ctx.get?.('x-hermes-profile') || ''
-  return (ctx.state.profile?.name || queryProfile || headerProfile || 'default').trim() || 'default'
+  return (ctx.state?.profile?.name || queryProfile || headerProfile || 'default').trim() || 'default'
 }
 
 function bearerToken(ctx: Context): string {
@@ -67,8 +67,8 @@ function bearerToken(ctx: Context): string {
   return match?.[1]?.trim() || ''
 }
 
-function resolveSttProfileStatus(userId: number, profile: string) {
-  const activeProvider = getActiveSttProvider(userId)
+function resolveSttProfileStatus(profile: string) {
+  const activeProvider = getActiveSttProvider(profile)
   if (!activeProvider || activeProvider === 'browser') {
     return {
       profile,
@@ -87,7 +87,7 @@ function resolveSttProfileStatus(userId: number, profile: string) {
     }
   }
 
-  const storedSetting = getSttProviderSetting(userId, activeProvider, { includeSecrets: true })
+  const storedSetting = getSttProviderSetting(profile, activeProvider, { includeSecrets: true })
   const hasSecret = Boolean(storedSetting?.secrets.apiKey)
   return {
     profile,
@@ -292,9 +292,10 @@ export async function listSettings(ctx: Context) {
   if (!userId) return
 
   try {
+    const profile = requestedProfile(ctx)
     ctx.body = {
-      settings: listSttProviderSettings(userId),
-      activeProvider: getActiveSttProvider(userId),
+      settings: listSttProviderSettings(profile),
+      activeProvider: getActiveSttProvider(profile),
     }
   } catch (error) {
     if (handleSettingsError(ctx, error)) return
@@ -306,14 +307,14 @@ export async function profileStatus(ctx: Context) {
   const userId = authUserId(ctx)
   if (!userId) return
 
-  ctx.body = resolveSttProfileStatus(userId, requestedProfile(ctx))
+  ctx.body = resolveSttProfileStatus(requestedProfile(ctx))
 }
 
 export async function missingProfileAudio(ctx: Context) {
   const userId = authUserId(ctx)
   if (!userId) return
 
-  const status = resolveSttProfileStatus(userId, requestedProfile(ctx))
+  const status = resolveSttProfileStatus(requestedProfile(ctx))
   if (status.configured) {
     ctx.status = 204
     return
@@ -339,14 +340,15 @@ export async function saveSettings(ctx: Context) {
   } | undefined
 
   try {
+    const profile = requestedProfile(ctx)
     const storedProvider = assertStoredSttProvider(provider)
-    const setting = saveSttProviderSetting(userId, storedProvider, {
+    const setting = saveSttProviderSetting(profile, storedProvider, {
       settings: body?.settings,
       secrets: body?.secrets,
     })
     const activeProvider = body?.activeProvider === undefined
-      ? saveActiveSttProvider(userId, storedProvider)
-      : saveActiveSttProvider(userId, assertActiveSttProvider(String(body.activeProvider)))
+      ? saveActiveSttProvider(profile, storedProvider)
+      : saveActiveSttProvider(profile, assertActiveSttProvider(String(body.activeProvider)))
 
     ctx.body = { setting, activeProvider }
   } catch (error) {
@@ -368,7 +370,9 @@ export async function deleteBaseUrlPreset(ctx: Context) {
   }
 
   try {
-    const setting = removeSttBaseUrlPreset(userId, assertStoredSttProvider(provider), rawUrl)
+    const profile = requestedProfile(ctx)
+    const storedProvider = assertStoredSttProvider(provider)
+    const setting = removeSttBaseUrlPreset(profile, storedProvider, rawUrl)
     ctx.body = { success: true, setting }
   } catch (error) {
     if (handleSettingsError(ctx, error)) return
@@ -384,7 +388,9 @@ export async function deleteSecret(ctx: Context) {
   const secretName = ctx.params.secretName || ''
 
   try {
-    const setting = clearStoredSttSecret(userId, assertStoredSttProvider(provider), secretName)
+    const profile = requestedProfile(ctx)
+    const storedProvider = assertStoredSttProvider(provider)
+    const setting = clearStoredSttSecret(profile, storedProvider, secretName)
     ctx.body = { success: true, setting }
   } catch (error) {
     if (handleSettingsError(ctx, error)) return
@@ -399,7 +405,8 @@ export async function saveActiveProvider(ctx: Context) {
   const body = ctx.request.body as { provider?: unknown } | undefined
 
   try {
-    const activeProvider = saveActiveSttProvider(userId, assertActiveSttProvider(String(body?.provider || '')))
+    const profile = requestedProfile(ctx)
+    const activeProvider = saveActiveSttProvider(profile, assertActiveSttProvider(String(body?.provider || '')))
     ctx.body = { activeProvider }
   } catch (error) {
     if (handleSettingsError(ctx, error)) return
@@ -437,7 +444,7 @@ export async function transcribe(ctx: Context) {
     return
   }
 
-  const storedSetting = getSttProviderSetting(userId, provider, { includeSecrets: true })
+  const storedSetting = getSttProviderSetting(requestedProfile(ctx), provider, { includeSecrets: true })
   if (!storedSetting) {
     ctx.status = 400
     ctx.body = { error: `STT settings are required for provider ${provider}` }
@@ -494,7 +501,7 @@ export async function mcuVoiceTurn(ctx: Context) {
   if (!userId) return
 
   const profile = requestedProfile(ctx)
-  const status = resolveSttProfileStatus(userId, profile)
+  const status = resolveSttProfileStatus(profile)
   if (!status.configured || !status.activeProvider || status.activeProvider === 'browser' || !isStoredSttProvider(status.activeProvider)) {
     ctx.body = {
       ok: false,
@@ -519,7 +526,7 @@ export async function mcuVoiceTurn(ctx: Context) {
     return
   }
 
-  const storedSetting = getSttProviderSetting(userId, status.activeProvider, { includeSecrets: true })
+  const storedSetting = getSttProviderSetting(profile, status.activeProvider, { includeSecrets: true })
   if (!storedSetting?.secrets.apiKey) {
     ctx.body = {
       ok: false,

--- a/packages/server/src/controllers/hermes/tts.ts
+++ b/packages/server/src/controllers/hermes/tts.ts
@@ -36,6 +36,12 @@ function authUserId(ctx: Context): number | null {
   return userId
 }
 
+function requestedProfile(ctx: Context): string {
+  const queryProfile = typeof ctx.query?.profile === 'string' ? ctx.query.profile : ''
+  const headerProfile = ctx.get?.('x-hermes-profile') || ''
+  return (ctx.state?.profile?.name || queryProfile || headerProfile || 'default').trim() || 'default'
+}
+
 function handleSettingsError(ctx: Context, error: unknown): boolean {
   if (error instanceof TtsSettingsValidationError) {
     ctx.status = 400
@@ -64,7 +70,7 @@ function mergeStoredTtsOptions(ctx: Context, providerName: string, options: Reco
     return nonEmptyRequestOptions
   }
 
-  const stored = getTtsProviderSetting(userId, providerName, { includeSecrets: true })
+  const stored = getTtsProviderSetting(requestedProfile(ctx), providerName, { includeSecrets: true })
   if (!stored) return nonEmptyRequestOptions
 
   const storedSecrets = stored.secrets.apiKey
@@ -81,11 +87,11 @@ function mergeStoredTtsOptions(ctx: Context, providerName: string, options: Reco
   }
 }
 
-function resolveActiveTtsProvider(userId: number | null, settings = userId ? listTtsProviderSettings(userId) : []) {
+function resolveActiveTtsProvider(profile: string, userId: number | null, settings?: ReturnType<typeof listTtsProviderSettings>) {
   if (!userId) return 'edge'
-  const active = getActiveTtsProvider(userId)
+  const active = getActiveTtsProvider(profile)
   if (active) return active
-  const configured = settings.filter(setting => setting.provider !== 'edge')
+  const configured = (settings ?? listTtsProviderSettings(profile)).filter(setting => setting.provider !== 'edge')
   return configured.length === 1 ? configured[0].provider : 'edge'
 }
 
@@ -94,10 +100,11 @@ export async function listSettings(ctx: Context) {
   if (!userId) return
 
   try {
-    const settings = listTtsProviderSettings(userId)
+    const profile = requestedProfile(ctx)
+    const settings = listTtsProviderSettings(profile)
     ctx.body = {
       settings,
-      activeProvider: resolveActiveTtsProvider(userId, settings),
+      activeProvider: resolveActiveTtsProvider(profile, userId, settings),
     }
   } catch (error) {
     if (handleSettingsError(ctx, error)) return
@@ -113,14 +120,15 @@ export async function saveSettings(ctx: Context) {
   const body = ctx.request.body as { settings?: unknown; secrets?: unknown; activeProvider?: unknown } | undefined
 
   try {
+    const profile = requestedProfile(ctx)
     const storedProvider = assertStoredTtsProvider(provider)
-    const setting = saveTtsProviderSetting(userId, storedProvider, {
+    const setting = saveTtsProviderSetting(profile, storedProvider, {
       settings: body?.settings,
       secrets: body?.secrets,
     })
     const activeProvider = body?.activeProvider === undefined
-      ? saveActiveTtsProvider(userId, storedProvider)
-      : saveActiveTtsProvider(userId, assertActiveTtsProvider(String(body.activeProvider)))
+      ? saveActiveTtsProvider(profile, storedProvider)
+      : saveActiveTtsProvider(profile, assertActiveTtsProvider(String(body.activeProvider)))
 
     ctx.body = { setting, activeProvider }
   } catch (error) {
@@ -136,7 +144,8 @@ export async function saveActiveProvider(ctx: Context) {
   const body = ctx.request.body as { provider?: unknown } | undefined
 
   try {
-    const activeProvider = saveActiveTtsProvider(userId, assertActiveTtsProvider(String(body?.provider || '')))
+    const profile = requestedProfile(ctx)
+    const activeProvider = saveActiveTtsProvider(profile, assertActiveTtsProvider(String(body?.provider || '')))
     ctx.body = { activeProvider }
   } catch (error) {
     if (handleSettingsError(ctx, error)) return
@@ -157,7 +166,9 @@ export async function deleteBaseUrlPreset(ctx: Context) {
   }
 
   try {
-    const setting = removeTtsBaseUrlPreset(userId, assertStoredTtsProvider(provider), rawUrl)
+    const profile = requestedProfile(ctx)
+    const storedProvider = assertStoredTtsProvider(provider)
+    const setting = removeTtsBaseUrlPreset(profile, storedProvider, rawUrl)
     ctx.body = { success: true, setting }
   } catch (error) {
     if (handleSettingsError(ctx, error)) return
@@ -173,7 +184,9 @@ export async function deleteSecret(ctx: Context) {
   const secretName = ctx.params.secretName || ''
 
   try {
-    const setting = clearStoredTtsSecret(userId, assertStoredTtsProvider(provider), secretName)
+    const profile = requestedProfile(ctx)
+    const storedProvider = assertStoredTtsProvider(provider)
+    const setting = clearStoredTtsSecret(profile, storedProvider, secretName)
     ctx.body = { success: true, setting }
   } catch (error) {
     if (handleSettingsError(ctx, error)) return
@@ -423,7 +436,7 @@ export async function synthesize(ctx: Context) {
 
   const requestOptions = asRecord(body.options)
   const userId = currentUserId(ctx)
-  const providerName = body.provider || resolveActiveTtsProvider(userId)
+  const providerName = body.provider || resolveActiveTtsProvider(requestedProfile(ctx), userId)
   const options = mergeStoredTtsOptions(ctx, providerName, requestOptions)
 
   const provider = getTtsProvider(providerName)

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -206,6 +206,32 @@ export const STT_USER_SETTINGS_SCHEMA: Record<string, string> = {
   updated_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
 }
 
+export const STT_PROFILE_PROVIDER_SETTINGS_TABLE = 'stt_profile_provider_settings'
+
+export const STT_PROFILE_PROVIDER_SETTINGS_SCHEMA: Record<string, string> = {
+  id: 'INTEGER PRIMARY KEY AUTOINCREMENT',
+  profile: "TEXT NOT NULL DEFAULT 'default'",
+  provider: 'TEXT NOT NULL',
+  settings_json: `TEXT NOT NULL DEFAULT '{}'`,
+  secrets_json: `TEXT NOT NULL DEFAULT '{}'`,
+  created_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+  updated_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+}
+
+export const STT_PROFILE_PROVIDER_SETTINGS_INDEXES = {
+  idx_stt_profile_provider_settings_profile: 'CREATE INDEX IF NOT EXISTS idx_stt_profile_provider_settings_profile ON stt_profile_provider_settings(profile)',
+  idx_stt_profile_provider_settings_profile_provider: 'CREATE UNIQUE INDEX IF NOT EXISTS idx_stt_profile_provider_settings_profile_provider ON stt_profile_provider_settings(profile, provider)',
+}
+
+export const STT_PROFILE_SETTINGS_TABLE = 'stt_profile_settings'
+
+export const STT_PROFILE_SETTINGS_SCHEMA: Record<string, string> = {
+  profile: "TEXT PRIMARY KEY DEFAULT 'default'",
+  active_provider: "TEXT NOT NULL DEFAULT 'browser'",
+  created_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+  updated_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+}
+
 export const TTS_PROVIDER_SETTINGS_TABLE = 'tts_provider_settings'
 
 export const TTS_PROVIDER_SETTINGS_SCHEMA: Record<string, string> = {
@@ -227,6 +253,32 @@ export const TTS_USER_SETTINGS_TABLE = 'tts_user_settings'
 
 export const TTS_USER_SETTINGS_SCHEMA: Record<string, string> = {
   user_id: 'INTEGER PRIMARY KEY',
+  active_provider: "TEXT NOT NULL DEFAULT 'edge'",
+  created_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+  updated_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+}
+
+export const TTS_PROFILE_PROVIDER_SETTINGS_TABLE = 'tts_profile_provider_settings'
+
+export const TTS_PROFILE_PROVIDER_SETTINGS_SCHEMA: Record<string, string> = {
+  id: 'INTEGER PRIMARY KEY AUTOINCREMENT',
+  profile: "TEXT NOT NULL DEFAULT 'default'",
+  provider: 'TEXT NOT NULL',
+  settings_json: `TEXT NOT NULL DEFAULT '{}'`,
+  secrets_json: `TEXT NOT NULL DEFAULT '{}'`,
+  created_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+  updated_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
+}
+
+export const TTS_PROFILE_PROVIDER_SETTINGS_INDEXES = {
+  idx_tts_profile_provider_settings_profile: 'CREATE INDEX IF NOT EXISTS idx_tts_profile_provider_settings_profile ON tts_profile_provider_settings(profile)',
+  idx_tts_profile_provider_settings_profile_provider: 'CREATE UNIQUE INDEX IF NOT EXISTS idx_tts_profile_provider_settings_profile_provider ON tts_profile_provider_settings(profile, provider)',
+}
+
+export const TTS_PROFILE_SETTINGS_TABLE = 'tts_profile_settings'
+
+export const TTS_PROFILE_SETTINGS_SCHEMA: Record<string, string> = {
+  profile: "TEXT PRIMARY KEY DEFAULT 'default'",
   active_provider: "TEXT NOT NULL DEFAULT 'edge'",
   created_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
   updated_at: `INTEGER NOT NULL DEFAULT (strftime('%s','now'))`,
@@ -443,6 +495,107 @@ function migrateLegacySttProviderSettingsUserIdDefault(
   }
 }
 
+function copyLegacyProviderSettingsToDefaultProfile(
+  db: NonNullable<ReturnType<typeof getDb>>,
+  sourceTableName: string,
+  targetTableName: string,
+): void {
+  if (!tableExists(db, sourceTableName) || !tableExists(db, targetTableName)) return
+
+  db.prepare(
+    `INSERT OR IGNORE INTO ${quoteIdentifier(targetTableName)} ` +
+    `(profile, provider, settings_json, secrets_json, created_at, updated_at) ` +
+    `SELECT 'default', old.provider, old.settings_json, old.secrets_json, old.created_at, old.updated_at ` +
+    `FROM ${quoteIdentifier(sourceTableName)} old ` +
+    `WHERE old.provider IS NOT NULL ` +
+    `AND NOT EXISTS (` +
+    `SELECT 1 FROM ${quoteIdentifier(sourceTableName)} newer ` +
+    `WHERE newer.provider = old.provider ` +
+    `AND (newer.updated_at > old.updated_at OR (newer.updated_at = old.updated_at AND newer.rowid > old.rowid))` +
+    `)`
+  ).run()
+}
+
+function copyLegacyActiveSettingsToDefaultProfile(
+  db: NonNullable<ReturnType<typeof getDb>>,
+  sourceTableName: string,
+  targetTableName: string,
+): void {
+  if (!tableExists(db, sourceTableName) || !tableExists(db, targetTableName)) return
+
+  db.prepare(
+    `INSERT OR IGNORE INTO ${quoteIdentifier(targetTableName)} ` +
+    `(profile, active_provider, created_at, updated_at) ` +
+    `SELECT 'default', active_provider, created_at, updated_at ` +
+    `FROM ${quoteIdentifier(sourceTableName)} ` +
+    `WHERE active_provider IS NOT NULL ` +
+    `ORDER BY updated_at DESC, rowid DESC ` +
+    `LIMIT 1`
+  ).run()
+}
+
+function tableHasColumn(
+  db: NonNullable<ReturnType<typeof getDb>>,
+  tableName: string,
+  columnName: string,
+): boolean {
+  if (!tableExists(db, tableName)) return false
+  const columns = db.prepare(`PRAGMA table_info(${quoteIdentifier(tableName)})`).all() as Array<{ name: string }>
+  return columns.some(column => column.name === columnName)
+}
+
+function pruneDuplicateProfileProviderSettings(
+  db: NonNullable<ReturnType<typeof getDb>>,
+  tableName: string,
+): void {
+  if (!tableHasColumn(db, tableName, 'profile') || !tableHasColumn(db, tableName, 'provider')) return
+
+  db.prepare(
+    `DELETE FROM ${quoteIdentifier(tableName)} ` +
+    `WHERE rowid NOT IN (` +
+    `SELECT kept.rowid FROM ${quoteIdentifier(tableName)} kept ` +
+    `WHERE NOT EXISTS (` +
+    `SELECT 1 FROM ${quoteIdentifier(tableName)} newer ` +
+    `WHERE newer.profile = kept.profile ` +
+    `AND newer.provider = kept.provider ` +
+    `AND (newer.updated_at > kept.updated_at OR (newer.updated_at = kept.updated_at AND newer.rowid > kept.rowid))` +
+    `)` +
+    `)`
+  ).run()
+}
+
+function pruneDuplicateProfileActiveSettings(
+  db: NonNullable<ReturnType<typeof getDb>>,
+  tableName: string,
+): void {
+  if (!tableHasColumn(db, tableName, 'profile')) return
+
+  db.prepare(
+    `DELETE FROM ${quoteIdentifier(tableName)} ` +
+    `WHERE rowid NOT IN (` +
+    `SELECT kept.rowid FROM ${quoteIdentifier(tableName)} kept ` +
+    `WHERE NOT EXISTS (` +
+    `SELECT 1 FROM ${quoteIdentifier(tableName)} newer ` +
+    `WHERE newer.profile = kept.profile ` +
+    `AND (newer.updated_at > kept.updated_at OR (newer.updated_at = kept.updated_at AND newer.rowid > kept.rowid))` +
+    `)` +
+    `)`
+  ).run()
+}
+
+function ensureProfileSettingsIndexes(
+  db: NonNullable<ReturnType<typeof getDb>>,
+  activeTableName: string,
+  activeIndexName: string,
+  providerTableName: string,
+  providerIndexes: Record<string, string>,
+): void {
+  pruneDuplicateProfileActiveSettings(db, activeTableName)
+  pruneDuplicateProfileProviderSettings(db, providerTableName)
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS ${quoteIdentifier(activeIndexName)} ON ${quoteIdentifier(activeTableName)}(profile)`)
+  createIndexes(db, providerIndexes)
+}
+
 /**
  * 主同步函数
  * - 表不存在：创建
@@ -519,10 +672,36 @@ export function initAllHermesTables(): void {
     })
     syncTable(STT_USER_SETTINGS_TABLE, STT_USER_SETTINGS_SCHEMA)
     migrateLegacySttProviderSettingsUserIdDefault(db)
+    syncTable(STT_PROFILE_PROVIDER_SETTINGS_TABLE, STT_PROFILE_PROVIDER_SETTINGS_SCHEMA, {
+      indexes: STT_PROFILE_PROVIDER_SETTINGS_INDEXES,
+    })
+    syncTable(STT_PROFILE_SETTINGS_TABLE, STT_PROFILE_SETTINGS_SCHEMA)
+    ensureProfileSettingsIndexes(
+      db,
+      STT_PROFILE_SETTINGS_TABLE,
+      'idx_stt_profile_settings_profile',
+      STT_PROFILE_PROVIDER_SETTINGS_TABLE,
+      STT_PROFILE_PROVIDER_SETTINGS_INDEXES,
+    )
+    copyLegacyProviderSettingsToDefaultProfile(db, STT_PROVIDER_SETTINGS_TABLE, STT_PROFILE_PROVIDER_SETTINGS_TABLE)
+    copyLegacyActiveSettingsToDefaultProfile(db, STT_USER_SETTINGS_TABLE, STT_PROFILE_SETTINGS_TABLE)
     syncTable(TTS_PROVIDER_SETTINGS_TABLE, TTS_PROVIDER_SETTINGS_SCHEMA, {
       indexes: TTS_PROVIDER_SETTINGS_INDEXES,
     })
     syncTable(TTS_USER_SETTINGS_TABLE, TTS_USER_SETTINGS_SCHEMA)
+    syncTable(TTS_PROFILE_PROVIDER_SETTINGS_TABLE, TTS_PROFILE_PROVIDER_SETTINGS_SCHEMA, {
+      indexes: TTS_PROFILE_PROVIDER_SETTINGS_INDEXES,
+    })
+    syncTable(TTS_PROFILE_SETTINGS_TABLE, TTS_PROFILE_SETTINGS_SCHEMA)
+    ensureProfileSettingsIndexes(
+      db,
+      TTS_PROFILE_SETTINGS_TABLE,
+      'idx_tts_profile_settings_profile',
+      TTS_PROFILE_PROVIDER_SETTINGS_TABLE,
+      TTS_PROFILE_PROVIDER_SETTINGS_INDEXES,
+    )
+    copyLegacyProviderSettingsToDefaultProfile(db, TTS_PROVIDER_SETTINGS_TABLE, TTS_PROFILE_PROVIDER_SETTINGS_TABLE)
+    copyLegacyActiveSettingsToDefaultProfile(db, TTS_USER_SETTINGS_TABLE, TTS_PROFILE_SETTINGS_TABLE)
 
     // Group chat - basic tables
     syncTable(GC_ROOMS_TABLE, GC_ROOMS_SCHEMA)

--- a/packages/server/src/db/hermes/stt-settings-store.ts
+++ b/packages/server/src/db/hermes/stt-settings-store.ts
@@ -1,5 +1,8 @@
 import { getDb } from '../index'
-import { STT_PROVIDER_SETTINGS_TABLE, STT_USER_SETTINGS_TABLE } from './schemas'
+import {
+  STT_PROFILE_PROVIDER_SETTINGS_TABLE,
+  STT_PROFILE_SETTINGS_TABLE,
+} from './schemas'
 import { normalizeSafeTtsBaseUrl } from '../../services/hermes/tts-providers/url-safety'
 
 export type StoredSttProvider = 'openai' | 'custom' | 'doubao'
@@ -15,7 +18,7 @@ export type SttStoredSettings = Partial<Record<Exclude<SttSettingKey, 'baseUrlPr
 export type SttStoredSecrets = Partial<Record<SttSecretKey, string>>
 
 export interface StoredSttProviderRow {
-  userId: number
+  profile: string
   provider: StoredSttProvider
   settings: SttStoredSettings
   secrets: SttStoredSecrets
@@ -37,7 +40,7 @@ const PROVIDER_LABELS: Record<StoredSttProvider, string> = {
   doubao: 'Doubao STT',
 }
 type StoredRow = {
-  user_id: number
+  profile: string
   provider: string
   settings_json: string
   secrets_json: string
@@ -70,11 +73,15 @@ function requireDb() {
   return db
 }
 
-function normalizeUserId(userId: number): number {
-  if (!Number.isInteger(userId) || userId <= 0) {
-    throw new SttSettingsValidationError('invalid user id')
+function normalizeProfile(profile: string): string {
+  if (typeof profile !== 'string') {
+    throw new SttSettingsValidationError('invalid profile')
   }
-  return userId
+  const value = profile.trim() || 'default'
+  if (value.length > 128) {
+    throw new SttSettingsValidationError('invalid profile')
+  }
+  return value
 }
 
 export function isStoredSttProvider(provider: string): provider is StoredSttProvider {
@@ -99,32 +106,32 @@ export function assertActiveSttProvider(provider: string): ActiveSttProvider {
   return provider
 }
 
-export function getActiveSttProvider(userId: number): ActiveSttProvider | null {
-  const id = normalizeUserId(userId)
+export function getActiveSttProvider(profile: string): ActiveSttProvider | null {
+  const profileName = normalizeProfile(profile)
   const db = getDb()
   if (!db) return null
 
   const row = db.prepare(
-    `SELECT active_provider FROM ${STT_USER_SETTINGS_TABLE} WHERE user_id = ?`
-  ).get(id) as { active_provider?: string } | null
+    `SELECT active_provider FROM ${STT_PROFILE_SETTINGS_TABLE} WHERE profile = ?`
+  ).get(profileName) as { active_provider?: string } | null
 
   const activeProvider = row?.active_provider
   return typeof activeProvider === 'string' && isActiveSttProvider(activeProvider) ? activeProvider : null
 }
 
-export function saveActiveSttProvider(userId: number, provider: ActiveSttProvider): ActiveSttProvider {
-  const id = normalizeUserId(userId)
+export function saveActiveSttProvider(profile: string, provider: ActiveSttProvider): ActiveSttProvider {
+  const profileName = normalizeProfile(profile)
   const activeProvider = assertActiveSttProvider(provider)
   const db = requireDb()
   const now = Date.now()
 
   db.prepare(
-    `INSERT INTO ${STT_USER_SETTINGS_TABLE} (user_id, active_provider, created_at, updated_at)
+    `INSERT INTO ${STT_PROFILE_SETTINGS_TABLE} (profile, active_provider, created_at, updated_at)
      VALUES (?, ?, ?, ?)
-     ON CONFLICT(user_id) DO UPDATE SET
+     ON CONFLICT(profile) DO UPDATE SET
        active_provider = excluded.active_provider,
        updated_at = excluded.updated_at`
-  ).run(id, activeProvider, now, now)
+  ).run(profileName, activeProvider, now, now)
 
   return activeProvider
 }
@@ -136,12 +143,12 @@ function assertKnownSecretName(secretName: string): SttSecretKey {
   return secretName as SttSecretKey
 }
 
-function readStoredRow(userId: number, provider: StoredSttProvider): StoredRow | null {
+function readStoredRow(profile: string, provider: StoredSttProvider): StoredRow | null {
   const db = getDb()
   if (!db) return null
   return db.prepare(
-    `SELECT user_id, provider, settings_json, secrets_json, created_at, updated_at FROM ${STT_PROVIDER_SETTINGS_TABLE} WHERE user_id = ? AND provider = ?`
-  ).get(userId, provider) as StoredRow | null
+    `SELECT profile, provider, settings_json, secrets_json, created_at, updated_at FROM ${STT_PROFILE_PROVIDER_SETTINGS_TABLE} WHERE profile = ? AND provider = ?`
+  ).get(profile, provider) as StoredRow | null
 }
 
 function normalizeBaseUrlPresets(provider: StoredSttProvider, input: unknown): string[] {
@@ -261,7 +268,7 @@ function rowToResult(row: StoredRow, includeSecrets: boolean): StoredSttProvider
   const secrets = sanitizeStoredSecrets(parseJsonObject(row.secrets_json))
 
   return {
-    userId: Number(row.user_id),
+    profile: row.profile || 'default',
     provider,
     settings,
     secrets: includeSecrets ? secrets : maskSecrets(secrets),
@@ -270,44 +277,44 @@ function rowToResult(row: StoredRow, includeSecrets: boolean): StoredSttProvider
   }
 }
 
-export function listSttProviderSettings(userId: number): StoredSttProviderRow[] {
-  const id = normalizeUserId(userId)
+export function listSttProviderSettings(profile: string): StoredSttProviderRow[] {
+  const profileName = normalizeProfile(profile)
   const db = getDb()
   if (!db) return []
 
   const rows = db.prepare(
-    `SELECT user_id, provider, settings_json, secrets_json, created_at, updated_at
-     FROM ${STT_PROVIDER_SETTINGS_TABLE}
-     WHERE user_id = ? AND provider IN (${PROVIDER_SQL_PLACEHOLDERS})
+    `SELECT profile, provider, settings_json, secrets_json, created_at, updated_at
+     FROM ${STT_PROFILE_PROVIDER_SETTINGS_TABLE}
+     WHERE profile = ? AND provider IN (${PROVIDER_SQL_PLACEHOLDERS})
      ORDER BY provider ASC`
-  ).all(id, ...PROVIDERS) as StoredRow[]
+  ).all(profileName, ...PROVIDERS) as StoredRow[]
 
   return rows.map(row => rowToResult(row, false))
 }
 
 export function getSttProviderSetting(
-  userId: number,
+  profile: string,
   provider: StoredSttProvider,
   options?: { includeSecrets?: boolean },
 ): StoredSttProviderRow | null {
-  const id = normalizeUserId(userId)
+  const profileName = normalizeProfile(profile)
   const storedProvider = assertStoredSttProvider(provider)
-  const row = readStoredRow(id, storedProvider)
+  const row = readStoredRow(profileName, storedProvider)
   return row ? rowToResult(row, options?.includeSecrets === true) : null
 }
 
 export function saveSttProviderSetting(
-  userId: number,
+  profile: string,
   provider: StoredSttProvider,
   input: {
     settings?: unknown
     secrets?: unknown
   },
 ): StoredSttProviderRow {
-  const id = normalizeUserId(userId)
+  const profileName = normalizeProfile(profile)
   const storedProvider = assertStoredSttProvider(provider)
   const db = requireDb()
-  const existing = readStoredRow(id, storedProvider)
+  const existing = readStoredRow(profileName, storedProvider)
   const existingSettings = existing ? sanitizeStoredSettings(storedProvider, parseJsonObject(existing.settings_json)) : {}
   const existingSecrets = existing ? sanitizeStoredSecrets(parseJsonObject(existing.secrets_json)) : {}
   const nextSettings = sanitizeStoredSettings(storedProvider, asObject(input.settings))
@@ -323,27 +330,27 @@ export function saveSttProviderSetting(
   const now = Date.now()
 
   db.prepare(
-    `INSERT INTO ${STT_PROVIDER_SETTINGS_TABLE} (user_id, provider, settings_json, secrets_json, created_at, updated_at)
+    `INSERT INTO ${STT_PROFILE_PROVIDER_SETTINGS_TABLE} (profile, provider, settings_json, secrets_json, created_at, updated_at)
      VALUES (?, ?, ?, ?, ?, ?)
-     ON CONFLICT(user_id, provider) DO UPDATE SET
+     ON CONFLICT(profile, provider) DO UPDATE SET
        settings_json = excluded.settings_json,
        secrets_json = excluded.secrets_json,
        updated_at = excluded.updated_at`
-  ).run(id, storedProvider, JSON.stringify(mergedSettings), JSON.stringify(mergedSecrets), existing?.created_at || now, now)
+  ).run(profileName, storedProvider, JSON.stringify(mergedSettings), JSON.stringify(mergedSecrets), existing?.created_at || now, now)
 
-  return getSttProviderSetting(id, storedProvider) as StoredSttProviderRow
+  return getSttProviderSetting(profileName, storedProvider) as StoredSttProviderRow
 }
 
 export function removeSttBaseUrlPreset(
-  userId: number,
+  profile: string,
   provider: StoredSttProvider,
   url: string,
 ): StoredSttProviderRow | null {
-  const id = normalizeUserId(userId)
+  const profileName = normalizeProfile(profile)
   const storedProvider = assertStoredSttProvider(provider)
   const normalizedUrl = normalizeSafeTtsBaseUrl(url, PROVIDER_LABELS[storedProvider])
   const db = requireDb()
-  const existing = readStoredRow(id, storedProvider)
+  const existing = readStoredRow(profileName, storedProvider)
   if (!existing) {
     return null
   }
@@ -365,22 +372,22 @@ export function removeSttBaseUrlPreset(
 
   const now = Date.now()
   db.prepare(
-    `UPDATE ${STT_PROVIDER_SETTINGS_TABLE} SET settings_json = ?, secrets_json = ?, updated_at = ? WHERE user_id = ? AND provider = ?`
-  ).run(JSON.stringify(settings), JSON.stringify(secrets), now, id, storedProvider)
+    `UPDATE ${STT_PROFILE_PROVIDER_SETTINGS_TABLE} SET settings_json = ?, secrets_json = ?, updated_at = ? WHERE profile = ? AND provider = ?`
+  ).run(JSON.stringify(settings), JSON.stringify(secrets), now, profileName, storedProvider)
 
-  return getSttProviderSetting(id, storedProvider)
+  return getSttProviderSetting(profileName, storedProvider)
 }
 
 export function clearStoredSttSecret(
-  userId: number,
+  profile: string,
   provider: StoredSttProvider,
   secretName: string,
 ): StoredSttProviderRow | null {
-  const id = normalizeUserId(userId)
+  const profileName = normalizeProfile(profile)
   const storedProvider = assertStoredSttProvider(provider)
   const secretKey = assertKnownSecretName(secretName)
   const db = requireDb()
-  const existing = readStoredRow(id, storedProvider)
+  const existing = readStoredRow(profileName, storedProvider)
   if (!existing) {
     return null
   }
@@ -391,8 +398,8 @@ export function clearStoredSttSecret(
   const now = Date.now()
 
   db.prepare(
-    `UPDATE ${STT_PROVIDER_SETTINGS_TABLE} SET settings_json = ?, secrets_json = ?, updated_at = ? WHERE user_id = ? AND provider = ?`
-  ).run(JSON.stringify(settings), JSON.stringify(secrets), now, id, storedProvider)
+    `UPDATE ${STT_PROFILE_PROVIDER_SETTINGS_TABLE} SET settings_json = ?, secrets_json = ?, updated_at = ? WHERE profile = ? AND provider = ?`
+  ).run(JSON.stringify(settings), JSON.stringify(secrets), now, profileName, storedProvider)
 
-  return getSttProviderSetting(id, storedProvider)
+  return getSttProviderSetting(profileName, storedProvider)
 }

--- a/packages/server/src/db/hermes/tts-settings-store.ts
+++ b/packages/server/src/db/hermes/tts-settings-store.ts
@@ -1,5 +1,8 @@
 import { getDb } from '../index'
-import { TTS_PROVIDER_SETTINGS_TABLE, TTS_USER_SETTINGS_TABLE } from './schemas'
+import {
+  TTS_PROFILE_PROVIDER_SETTINGS_TABLE,
+  TTS_PROFILE_SETTINGS_TABLE,
+} from './schemas'
 import { normalizeSafeTtsBaseUrl } from '../../services/hermes/tts-providers/url-safety'
 
 export type StoredTtsProvider = 'openai' | 'custom' | 'edge' | 'mimo' | 'doubao'
@@ -27,7 +30,7 @@ export type TtsStoredSettings = Partial<Record<Exclude<TtsSettingKey, 'baseUrlPr
 export type TtsStoredSecrets = Partial<Record<TtsSecretKey, string>>
 
 export interface StoredTtsProviderRow {
-  userId: number
+  profile: string
   provider: StoredTtsProvider
   settings: TtsStoredSettings
   secrets: TtsStoredSecrets
@@ -52,7 +55,7 @@ const PROVIDER_LABELS: Record<StoredTtsProvider, string> = {
 }
 
 type StoredRow = {
-  user_id: number
+  profile: string
   provider: string
   settings_json: string
   secrets_json: string
@@ -85,11 +88,15 @@ function requireDb() {
   return db
 }
 
-function normalizeUserId(userId: number): number {
-  if (!Number.isInteger(userId) || userId <= 0) {
-    throw new TtsSettingsValidationError('invalid user id')
+function normalizeProfile(profile: string): string {
+  if (typeof profile !== 'string') {
+    throw new TtsSettingsValidationError('invalid profile')
   }
-  return userId
+  const value = profile.trim() || 'default'
+  if (value.length > 128) {
+    throw new TtsSettingsValidationError('invalid profile')
+  }
+  return value
 }
 
 export function isStoredTtsProvider(provider: string): provider is StoredTtsProvider {
@@ -114,32 +121,32 @@ export function assertActiveTtsProvider(provider: string): ActiveTtsProvider {
   return provider
 }
 
-export function getActiveTtsProvider(userId: number): ActiveTtsProvider | null {
-  const id = normalizeUserId(userId)
+export function getActiveTtsProvider(profile: string): ActiveTtsProvider | null {
+  const profileName = normalizeProfile(profile)
   const db = getDb()
   if (!db) return null
 
   const row = db.prepare(
-    `SELECT active_provider FROM ${TTS_USER_SETTINGS_TABLE} WHERE user_id = ?`
-  ).get(id) as { active_provider?: string } | null
+    `SELECT active_provider FROM ${TTS_PROFILE_SETTINGS_TABLE} WHERE profile = ?`
+  ).get(profileName) as { active_provider?: string } | null
 
   const activeProvider = row?.active_provider
   return typeof activeProvider === 'string' && isActiveTtsProvider(activeProvider) ? activeProvider : null
 }
 
-export function saveActiveTtsProvider(userId: number, provider: ActiveTtsProvider): ActiveTtsProvider {
-  const id = normalizeUserId(userId)
+export function saveActiveTtsProvider(profile: string, provider: ActiveTtsProvider): ActiveTtsProvider {
+  const profileName = normalizeProfile(profile)
   const activeProvider = assertActiveTtsProvider(provider)
   const db = requireDb()
   const now = Date.now()
 
   db.prepare(
-    `INSERT INTO ${TTS_USER_SETTINGS_TABLE} (user_id, active_provider, created_at, updated_at)
+    `INSERT INTO ${TTS_PROFILE_SETTINGS_TABLE} (profile, active_provider, created_at, updated_at)
      VALUES (?, ?, ?, ?)
-     ON CONFLICT(user_id) DO UPDATE SET
+     ON CONFLICT(profile) DO UPDATE SET
        active_provider = excluded.active_provider,
        updated_at = excluded.updated_at`
-  ).run(id, activeProvider, now, now)
+  ).run(profileName, activeProvider, now, now)
 
   return activeProvider
 }
@@ -151,12 +158,12 @@ function assertKnownSecretName(secretName: string): TtsSecretKey {
   return secretName as TtsSecretKey
 }
 
-function readStoredRow(userId: number, provider: StoredTtsProvider): StoredRow | null {
+function readStoredRow(profile: string, provider: StoredTtsProvider): StoredRow | null {
   const db = getDb()
   if (!db) return null
   return db.prepare(
-    `SELECT user_id, provider, settings_json, secrets_json, created_at, updated_at FROM ${TTS_PROVIDER_SETTINGS_TABLE} WHERE user_id = ? AND provider = ?`
-  ).get(userId, provider) as StoredRow | null
+    `SELECT profile, provider, settings_json, secrets_json, created_at, updated_at FROM ${TTS_PROFILE_PROVIDER_SETTINGS_TABLE} WHERE profile = ? AND provider = ?`
+  ).get(profile, provider) as StoredRow | null
 }
 
 function normalizeBaseUrlPresets(provider: StoredTtsProvider, input: unknown): string[] {
@@ -203,6 +210,11 @@ function sanitizeStoredSettings(provider: StoredTtsProvider, input: Record<strin
     if (key === 'baseUrlPresets') {
       const presets = normalizeBaseUrlPresets(provider, rawValue)
       if (presets.length) out.baseUrlPresets = presets
+      continue
+    }
+
+    if (typeof rawValue === 'number' && Number.isFinite(rawValue) && (key === 'rate' || key === 'pitch')) {
+      out[key] = String(rawValue)
       continue
     }
 
@@ -258,7 +270,7 @@ function rowToResult(row: StoredRow, includeSecrets: boolean): StoredTtsProvider
   const secrets = sanitizeStoredSecrets(parseJsonObject(row.secrets_json))
 
   return {
-    userId: Number(row.user_id),
+    profile: row.profile || 'default',
     provider,
     settings,
     secrets: includeSecrets ? secrets : maskSecrets(secrets),
@@ -267,41 +279,41 @@ function rowToResult(row: StoredRow, includeSecrets: boolean): StoredTtsProvider
   }
 }
 
-export function listTtsProviderSettings(userId: number): StoredTtsProviderRow[] {
-  const id = normalizeUserId(userId)
+export function listTtsProviderSettings(profile: string): StoredTtsProviderRow[] {
+  const profileName = normalizeProfile(profile)
   const db = getDb()
   if (!db) return []
 
   const rows = db.prepare(
-    `SELECT user_id, provider, settings_json, secrets_json, created_at, updated_at
-     FROM ${TTS_PROVIDER_SETTINGS_TABLE}
-     WHERE user_id = ? AND provider IN (${PROVIDER_SQL_PLACEHOLDERS})
+    `SELECT profile, provider, settings_json, secrets_json, created_at, updated_at
+     FROM ${TTS_PROFILE_PROVIDER_SETTINGS_TABLE}
+     WHERE profile = ? AND provider IN (${PROVIDER_SQL_PLACEHOLDERS})
      ORDER BY provider ASC`
-  ).all(id, ...PROVIDERS) as StoredRow[]
+  ).all(profileName, ...PROVIDERS) as StoredRow[]
 
   return rows.map(row => rowToResult(row, false))
 }
 
 export function getTtsProviderSetting(
-  userId: number,
+  profile: string,
   provider: StoredTtsProvider,
   options?: { includeSecrets?: boolean },
 ): StoredTtsProviderRow | null {
-  const id = normalizeUserId(userId)
+  const profileName = normalizeProfile(profile)
   const storedProvider = assertStoredTtsProvider(provider)
-  const row = readStoredRow(id, storedProvider)
+  const row = readStoredRow(profileName, storedProvider)
   return row ? rowToResult(row, options?.includeSecrets === true) : null
 }
 
 export function saveTtsProviderSetting(
-  userId: number,
+  profile: string,
   provider: StoredTtsProvider,
   input: { settings?: unknown; secrets?: unknown },
 ): StoredTtsProviderRow {
-  const id = normalizeUserId(userId)
+  const profileName = normalizeProfile(profile)
   const storedProvider = assertStoredTtsProvider(provider)
   const db = requireDb()
-  const existing = readStoredRow(id, storedProvider)
+  const existing = readStoredRow(profileName, storedProvider)
   const existingSettings = existing ? sanitizeStoredSettings(storedProvider, parseJsonObject(existing.settings_json)) : {}
   const existingSecrets = existing ? sanitizeStoredSecrets(parseJsonObject(existing.secrets_json)) : {}
   const nextSettings = sanitizeStoredSettings(storedProvider, asObject(input.settings))
@@ -317,27 +329,27 @@ export function saveTtsProviderSetting(
   const now = Date.now()
 
   db.prepare(
-    `INSERT INTO ${TTS_PROVIDER_SETTINGS_TABLE} (user_id, provider, settings_json, secrets_json, created_at, updated_at)
+    `INSERT INTO ${TTS_PROFILE_PROVIDER_SETTINGS_TABLE} (profile, provider, settings_json, secrets_json, created_at, updated_at)
      VALUES (?, ?, ?, ?, ?, ?)
-     ON CONFLICT(user_id, provider) DO UPDATE SET
+     ON CONFLICT(profile, provider) DO UPDATE SET
        settings_json = excluded.settings_json,
        secrets_json = excluded.secrets_json,
        updated_at = excluded.updated_at`
-  ).run(id, storedProvider, JSON.stringify(mergedSettings), JSON.stringify(mergedSecrets), existing?.created_at || now, now)
+  ).run(profileName, storedProvider, JSON.stringify(mergedSettings), JSON.stringify(mergedSecrets), existing?.created_at || now, now)
 
-  return getTtsProviderSetting(id, storedProvider) as StoredTtsProviderRow
+  return getTtsProviderSetting(profileName, storedProvider) as StoredTtsProviderRow
 }
 
 export function removeTtsBaseUrlPreset(
-  userId: number,
+  profile: string,
   provider: StoredTtsProvider,
   url: string,
 ): StoredTtsProviderRow | null {
-  const id = normalizeUserId(userId)
+  const profileName = normalizeProfile(profile)
   const storedProvider = assertStoredTtsProvider(provider)
   const normalizedUrl = normalizeSafeTtsBaseUrl(url, PROVIDER_LABELS[storedProvider])
   const db = requireDb()
-  const existing = readStoredRow(id, storedProvider)
+  const existing = readStoredRow(profileName, storedProvider)
   if (!existing) return null
 
   const settings = sanitizeStoredSettings(storedProvider, parseJsonObject(existing.settings_json))
@@ -357,22 +369,22 @@ export function removeTtsBaseUrlPreset(
 
   const now = Date.now()
   db.prepare(
-    `UPDATE ${TTS_PROVIDER_SETTINGS_TABLE} SET settings_json = ?, secrets_json = ?, updated_at = ? WHERE user_id = ? AND provider = ?`
-  ).run(JSON.stringify(settings), JSON.stringify(secrets), now, id, storedProvider)
+    `UPDATE ${TTS_PROFILE_PROVIDER_SETTINGS_TABLE} SET settings_json = ?, secrets_json = ?, updated_at = ? WHERE profile = ? AND provider = ?`
+  ).run(JSON.stringify(settings), JSON.stringify(secrets), now, profileName, storedProvider)
 
-  return getTtsProviderSetting(id, storedProvider)
+  return getTtsProviderSetting(profileName, storedProvider)
 }
 
 export function clearStoredTtsSecret(
-  userId: number,
+  profile: string,
   provider: StoredTtsProvider,
   secretName: string,
 ): StoredTtsProviderRow | null {
-  const id = normalizeUserId(userId)
+  const profileName = normalizeProfile(profile)
   const storedProvider = assertStoredTtsProvider(provider)
   const secretKey = assertKnownSecretName(secretName)
   const db = requireDb()
-  const existing = readStoredRow(id, storedProvider)
+  const existing = readStoredRow(profileName, storedProvider)
   if (!existing) return null
 
   const settings = sanitizeStoredSettings(storedProvider, parseJsonObject(existing.settings_json))
@@ -381,8 +393,8 @@ export function clearStoredTtsSecret(
   const now = Date.now()
 
   db.prepare(
-    `UPDATE ${TTS_PROVIDER_SETTINGS_TABLE} SET settings_json = ?, secrets_json = ?, updated_at = ? WHERE user_id = ? AND provider = ?`
-  ).run(JSON.stringify(settings), JSON.stringify(secrets), now, id, storedProvider)
+    `UPDATE ${TTS_PROFILE_PROVIDER_SETTINGS_TABLE} SET settings_json = ?, secrets_json = ?, updated_at = ? WHERE profile = ? AND provider = ?`
+  ).run(JSON.stringify(settings), JSON.stringify(secrets), now, profileName, storedProvider)
 
-  return getTtsProviderSetting(id, storedProvider)
+  return getTtsProviderSetting(profileName, storedProvider)
 }

--- a/packages/server/src/services/global-agent/outbound-relay-client.ts
+++ b/packages/server/src/services/global-agent/outbound-relay-client.ts
@@ -512,7 +512,7 @@ class PlainWebSocketRelayClient {
         const segmentText = normalizeMcuSpeechText(text)
         if (!segmentText) return
         const segmentId = `${voice.interactionId}-tts-${++segmentIndex}`
-        ttsQueue = ttsQueue.then(() => this.enqueueMcuSpeechSegment(voice.interactionId, segmentId, segmentText))
+        ttsQueue = ttsQueue.then(() => this.enqueueMcuSpeechSegment(voice.profile, voice.interactionId, segmentId, segmentText))
           .catch((err) => {
             if (err instanceof Error && err.message === 'audio.interrupted') {
               this.interruptedInteractions.add(voice.interactionId)
@@ -787,10 +787,10 @@ class PlainWebSocketRelayClient {
     return `mcu-${instance}-${profileId}`
   }
 
-  private async enqueueMcuSpeechSegment(interactionId: string, segmentId: string, text: string): Promise<void> {
+  private async enqueueMcuSpeechSegment(profile: string, interactionId: string, segmentId: string, text: string): Promise<void> {
     if (this.interruptedInteractions.has(interactionId)) return
     this.sendJson({ type: 'interaction.status', interactionId, status: 'speaking' })
-    const audio = await this.synthesizeMcuSpeech(text)
+    const audio = await this.synthesizeMcuSpeech(text, profile)
     if (this.interruptedInteractions.has(interactionId)) return
     const waitForDone = this.waitForMcuAudioDone(segmentId, Math.max(90_000, Math.min(text.length * 1200, 300_000)))
     this.sendJson({
@@ -818,18 +818,20 @@ class PlainWebSocketRelayClient {
     })
   }
 
-  private async synthesizeMcuSpeech(text: string): Promise<{ url: string }> {
+  private async synthesizeMcuSpeech(text: string, profile: string): Promise<{ url: string }> {
     if (!this.options.userToken) {
       throw new Error('missing Web UI auth token')
     }
 
     const baseUrl = this.options.localBaseUrl.replace(/\/$/, '')
+    const headers = {
+      Authorization: `Bearer ${this.options.userToken}`,
+      'Content-Type': 'application/json',
+      'X-Hermes-Profile': profile || 'default',
+    }
     const requestTts = (provider?: 'edge') => this.options.fetchImpl(`${baseUrl}/api/hermes/tts/synthesize`, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${this.options.userToken}`,
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify({
         ...(provider ? { provider } : {}),
         text,
@@ -880,10 +882,7 @@ class PlainWebSocketRelayClient {
       try {
         const fallback = await this.options.fetchImpl(`${baseUrl}/api/hermes/tts/synthesize`, {
           method: 'POST',
-          headers: {
-            Authorization: `Bearer ${this.options.userToken}`,
-            'Content-Type': 'application/json',
-          },
+          headers,
           body: JSON.stringify({
             provider: 'edge',
             text,

--- a/packages/server/src/services/global-agent/server.ts
+++ b/packages/server/src/services/global-agent/server.ts
@@ -1068,13 +1068,15 @@ export class GlobalAgentServer {
     return `mcu-${instance}-${profileId}`
   }
 
-  private async synthesizeMcuSpeech(text: string, userToken: string): Promise<{ url: string }> {
+  private async synthesizeMcuSpeech(text: string, userToken: string, profile: string): Promise<{ url: string }> {
+    const headers = {
+      Authorization: `Bearer ${userToken}`,
+      'Content-Type': 'application/json',
+      'X-Hermes-Profile': profile || 'default',
+    }
     const requestTts = (provider?: 'edge') => this.fetchImpl(`${this.localBaseUrl}/api/hermes/tts/synthesize`, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${userToken}`,
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify({
         ...(provider ? { provider } : {}),
         text,
@@ -1121,10 +1123,7 @@ export class GlobalAgentServer {
       try {
         const fallback = await this.fetchImpl(`${this.localBaseUrl}/api/hermes/tts/synthesize`, {
           method: 'POST',
-          headers: {
-            Authorization: `Bearer ${userToken}`,
-            'Content-Type': 'application/json',
-          },
+          headers,
           body: JSON.stringify({
             provider: 'edge',
             text,
@@ -1151,7 +1150,7 @@ export class GlobalAgentServer {
   private async enqueueMcuSpeechSegment(options: McuVoiceChatTurnOptions, segmentId: string, text: string): Promise<void> {
     if (this.interruptedMcuInteractions.has(options.interactionId)) return
     this.emitMcuEvent({ type: 'interaction.status', interactionId: options.interactionId, status: 'speaking' }, { clientId: options.clientId })
-    const audio = await this.synthesizeMcuSpeech(text, options.userToken)
+    const audio = await this.synthesizeMcuSpeech(text, options.userToken, options.profile)
     if (this.interruptedMcuInteractions.has(options.interactionId)) return
     const waitForDone = this.waitForMcuAudioDone(segmentId, Math.max(90_000, Math.min(text.length * 1200, 300_000)))
     this.emitMcuEvent({

--- a/tests/client/use-speech-tts.test.ts
+++ b/tests/client/use-speech-tts.test.ts
@@ -66,6 +66,7 @@ describe('client TTS unified synthesize flow', () => {
   })
 
   it('synthesizeSpeech posts to the unified endpoint with auth, body, and signal', async () => {
+    localStorage.setItem('hermes_active_profile_name', 'research')
     mockFetch.mockResolvedValue(new Response('audio-bytes', {
       status: 200,
       headers: {
@@ -93,6 +94,7 @@ describe('client TTS unified synthesize flow', () => {
         headers: {
           'Content-Type': 'application/json',
           Authorization: 'Bearer secret-key',
+          'X-Hermes-Profile': 'research',
         },
         body: JSON.stringify({
           provider: 'openai',

--- a/tests/server/global-agent-server.test.ts
+++ b/tests/server/global-agent-server.test.ts
@@ -489,8 +489,11 @@ describe('GlobalAgentServer', () => {
     })
     server.init()
 
-    const audio = await (server as any).synthesizeMcuSpeech('hello', 'user-jwt')
+    const audio = await (server as any).synthesizeMcuSpeech('hello', 'user-jwt', 'research')
     expect(audio.url).toMatch(/^\/api\/hermes\/mcu\/audio\/[a-f0-9-]+\.pcm$/)
+    expect(fetchImpl.mock.calls[0][1]?.headers).toMatchObject({
+      'X-Hermes-Profile': 'research',
+    })
   })
 
   it('marks TTS requests as MCU playback without forcing every provider to PCM', async () => {
@@ -510,8 +513,11 @@ describe('GlobalAgentServer', () => {
     })
     server.init()
 
-    await (server as any).synthesizeMcuSpeech('hello', 'user-jwt')
+    await (server as any).synthesizeMcuSpeech('hello', 'user-jwt', 'research')
 
+    expect(fetchImpl.mock.calls[0][1]?.headers).toMatchObject({
+      'X-Hermes-Profile': 'research',
+    })
     expect(JSON.parse(String(fetchImpl.mock.calls[0][1]?.body))).toMatchObject({
       text: 'hello',
       options: {
@@ -547,10 +553,13 @@ describe('GlobalAgentServer', () => {
     })
     server.init()
 
-    const audio = await (server as any).synthesizeMcuSpeech('hello', 'user-jwt')
+    const audio = await (server as any).synthesizeMcuSpeech('hello', 'user-jwt', 'research')
 
     expect(audio.url).toMatch(/^\/api\/hermes\/mcu\/audio\/[a-f0-9-]+\.pcm$/)
     expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(fetchImpl.mock.calls[1][1]?.headers).toMatchObject({
+      'X-Hermes-Profile': 'research',
+    })
     expect(JSON.parse(String(fetchImpl.mock.calls[1][1]?.body))).toMatchObject({
       provider: 'edge',
       text: 'hello',
@@ -587,10 +596,13 @@ describe('GlobalAgentServer', () => {
     })
     server.init()
 
-    const audio = await (server as any).synthesizeMcuSpeech('hello', 'user-jwt')
+    const audio = await (server as any).synthesizeMcuSpeech('hello', 'user-jwt', 'research')
 
     expect(audio.url).toMatch(/^\/api\/hermes\/mcu\/audio\/[a-f0-9-]+\.pcm$/)
     expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(fetchImpl.mock.calls[1][1]?.headers).toMatchObject({
+      'X-Hermes-Profile': 'research',
+    })
     expect(JSON.parse(String(fetchImpl.mock.calls[1][1]?.body))).toMatchObject({
       provider: 'edge',
       text: 'hello',

--- a/tests/server/outbound-relay-client.test.ts
+++ b/tests/server/outbound-relay-client.test.ts
@@ -208,7 +208,7 @@ describe('outbound relay client', () => {
       type: 'voice.recorded',
       interactionId: 'voice-tts-fail',
       mimeType: 'audio/wav',
-      profile: 'default',
+      profile: 'research',
     }), false)
     ws.__handlers.get('message')?.(Buffer.from('wav-audio'), true)
 
@@ -222,6 +222,14 @@ describe('outbound relay client', () => {
 
     await vi.waitFor(() => {
       expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('tts-synthesize-failed-xiaohe.s16le.pcm'))
+    })
+    const ttsCalls = fetchImpl.mock.calls.filter(([url]: [string]) => url.includes('/api/hermes/tts/synthesize'))
+    expect(ttsCalls).toHaveLength(2)
+    expect(ttsCalls[0][1].headers).toMatchObject({
+      'X-Hermes-Profile': 'research',
+    })
+    expect(ttsCalls[1][1].headers).toMatchObject({
+      'X-Hermes-Profile': 'research',
     })
     const enqueuePayload = JSON.parse(
       ws.send.mock.calls

--- a/tests/server/stt-settings-controller.test.ts
+++ b/tests/server/stt-settings-controller.test.ts
@@ -68,6 +68,21 @@ describe('stt settings controller', () => {
     })
     expect(JSON.stringify(saveCtx.body)).not.toContain('server-secret')
 
+    const profileProviderRow = db.prepare(
+      'SELECT provider, settings_json, secrets_json FROM stt_profile_provider_settings WHERE profile = ? AND provider = ?'
+    ).get('default', 'openai') as { provider: string; settings_json: string; secrets_json: string }
+    expect(profileProviderRow.provider).toBe('openai')
+    expect(JSON.parse(profileProviderRow.settings_json)).toMatchObject({
+      model: 'gpt-4o-transcribe',
+      language: 'en',
+    })
+    expect(JSON.parse(profileProviderRow.secrets_json)).toEqual({ apiKey: 'server-secret' })
+
+    const profileActiveRow = db.prepare(
+      'SELECT active_provider FROM stt_profile_settings WHERE profile = ?'
+    ).get('default') as { active_provider: string }
+    expect(profileActiveRow.active_provider).toBe('openai')
+
     const listCtx = makeCtx(user)
     await ctrl.listSettings(listCtx)
 

--- a/tests/server/stt-settings-store.test.ts
+++ b/tests/server/stt-settings-store.test.ts
@@ -142,7 +142,7 @@ describe('stt settings store', () => {
   it('stores settings and masks secrets on read', async () => {
     const { store } = await initStore()
 
-    const saved = store.saveSttProviderSetting(7, 'openai', {
+    const saved = store.saveSttProviderSetting('default', 'openai', {
       settings: {
         baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
         model: 'gpt-4o-transcribe',
@@ -154,7 +154,7 @@ describe('stt settings store', () => {
     })
 
     expect(saved).toMatchObject({
-      userId: 7,
+      profile: 'default',
       provider: 'openai',
       settings: {
         baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
@@ -167,7 +167,7 @@ describe('stt settings store', () => {
     })
     expect(JSON.stringify(saved)).not.toContain('secret-value')
 
-    const fetched = store.getSttProviderSetting(7, 'openai')
+    const fetched = store.getSttProviderSetting('default', 'openai')
     expect(fetched).toEqual(saved)
     expect(JSON.stringify(fetched)).not.toContain('secret-value')
   })
@@ -175,7 +175,7 @@ describe('stt settings store', () => {
   it('returns raw secrets only for backend callers that opt in', async () => {
     const { store } = await initStore()
 
-    store.saveSttProviderSetting(7, 'openai', {
+    store.saveSttProviderSetting('default', 'openai', {
       settings: {
         baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
         model: 'gpt-4o-transcribe',
@@ -185,8 +185,8 @@ describe('stt settings store', () => {
       },
     })
 
-    expect(store.getSttProviderSetting(7, 'openai', { includeSecrets: true })).toMatchObject({
-      userId: 7,
+    expect(store.getSttProviderSetting('default', 'openai', { includeSecrets: true })).toMatchObject({
+      profile: 'default',
       provider: 'openai',
       settings: {
         baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
@@ -201,7 +201,7 @@ describe('stt settings store', () => {
   it('preserves existing raw secrets when the stored marker is submitted again', async () => {
     const { store } = await initStore()
 
-    store.saveSttProviderSetting(7, 'openai', {
+    store.saveSttProviderSetting('default', 'openai', {
       settings: {
         baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
         model: 'gpt-4o-transcribe',
@@ -211,7 +211,7 @@ describe('stt settings store', () => {
       },
     })
 
-    const updated = store.saveSttProviderSetting(7, 'openai', {
+    const updated = store.saveSttProviderSetting('default', 'openai', {
       settings: {
         language: 'en',
         prompt: 'Transcribe carefully',
@@ -222,7 +222,7 @@ describe('stt settings store', () => {
     })
 
     expect(updated).toMatchObject({
-      userId: 7,
+      profile: 'default',
       provider: 'openai',
       settings: {
         baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
@@ -235,7 +235,7 @@ describe('stt settings store', () => {
       },
     })
 
-    expect(store.getSttProviderSetting(7, 'openai', { includeSecrets: true })?.secrets).toEqual({
+    expect(store.getSttProviderSetting('default', 'openai', { includeSecrets: true })?.secrets).toEqual({
       apiKey: 'secret-value',
     })
   })
@@ -244,7 +244,7 @@ describe('stt settings store', () => {
     const { store } = await initStore()
     const trimmedPrompt = 'x'.repeat(1000)
 
-    const saved = store.saveSttProviderSetting(7, 'openai', {
+    const saved = store.saveSttProviderSetting('default', 'openai', {
       settings: {
         prompt: `  ${trimmedPrompt}extra  `,
       },
@@ -254,8 +254,8 @@ describe('stt settings store', () => {
     expect(saved.settings.prompt).toHaveLength(1000)
 
     const storedRow = db.prepare(
-      'SELECT settings_json FROM stt_provider_settings WHERE user_id = ? AND provider = ?'
-    ).get(7, 'openai') as { settings_json: string }
+      'SELECT settings_json FROM stt_profile_provider_settings WHERE profile = ? AND provider = ?'
+    ).get('default', 'openai') as { settings_json: string }
 
     expect(JSON.parse(storedRow.settings_json)).toMatchObject({
       prompt: trimmedPrompt,
@@ -265,7 +265,7 @@ describe('stt settings store', () => {
   it('clears one stored secret without deleting settings', async () => {
     const { store } = await initStore()
 
-    store.saveSttProviderSetting(7, 'openai', {
+    store.saveSttProviderSetting('default', 'openai', {
       settings: {
         baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
         model: 'gpt-4o-transcribe',
@@ -276,9 +276,9 @@ describe('stt settings store', () => {
       },
     })
 
-    const cleared = store.clearStoredSttSecret(7, 'openai', 'apiKey')
+    const cleared = store.clearStoredSttSecret('default', 'openai', 'apiKey')
     expect(cleared).toMatchObject({
-      userId: 7,
+      profile: 'default',
       provider: 'openai',
       settings: {
         baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
@@ -288,14 +288,14 @@ describe('stt settings store', () => {
       secrets: {},
     })
 
-    expect(store.getSttProviderSetting(7, 'openai')).toEqual(cleared)
-    expect(store.getSttProviderSetting(7, 'openai', { includeSecrets: true })?.secrets).toEqual({})
+    expect(store.getSttProviderSetting('default', 'openai')).toEqual(cleared)
+    expect(store.getSttProviderSetting('default', 'openai', { includeSecrets: true })?.secrets).toEqual({})
   })
 
-  it('lists only settings for the requested user', async () => {
+  it('lists only settings for the requested profile', async () => {
     const { store } = await initStore()
 
-    const expected = store.saveSttProviderSetting(7, 'openai', {
+    const expected = store.saveSttProviderSetting('default', 'openai', {
       settings: {
         baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
         model: 'gpt-4o-transcribe',
@@ -305,7 +305,7 @@ describe('stt settings store', () => {
       },
     })
 
-    store.saveSttProviderSetting(8, 'custom', {
+    store.saveSttProviderSetting('research', 'custom', {
       settings: {
         baseUrl: 'https://transcribe.example.com/v1',
         model: 'custom-whisper',
@@ -315,13 +315,13 @@ describe('stt settings store', () => {
       },
     })
 
-    expect(store.listSttProviderSettings(7)).toEqual([expected])
+    expect(store.listSttProviderSettings('default')).toEqual([expected])
   })
 
   it('ignores unsupported legacy provider rows when listing settings', async () => {
     const { store } = await initStore()
 
-    const expected = store.saveSttProviderSetting(7, 'openai', {
+    const expected = store.saveSttProviderSetting('default', 'openai', {
       settings: {
         baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
         model: 'gpt-4o-transcribe',
@@ -332,19 +332,19 @@ describe('stt settings store', () => {
     })
 
     db.prepare(
-      'INSERT INTO stt_provider_settings (user_id, provider, settings_json, secrets_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
-    ).run(7, 'deepgram', '{"language":"en"}', '{"apiKey":"legacy-secret"}', 1710000000, 1710000100)
+      'INSERT INTO stt_profile_provider_settings (profile, provider, settings_json, secrets_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run('default', 'deepgram', '{"language":"en"}', '{"apiKey":"legacy-secret"}', 1710000000, 1710000100)
 
-    expect(() => store.listSttProviderSettings(7)).not.toThrow()
-    expect(store.listSttProviderSettings(7)).toEqual([expected])
-    expect(() => store.getSttProviderSetting(7, 'deepgram' as any)).toThrow(/unknown STT provider/i)
+    expect(() => store.listSttProviderSettings('default')).not.toThrow()
+    expect(store.listSttProviderSettings('default')).toEqual([expected])
+    expect(() => store.getSttProviderSetting('default', 'deepgram' as any)).toThrow(/unknown STT provider/i)
   })
 
   it('rejects unsupported providers and secret names', async () => {
     const { store } = await initStore()
 
     expect(() => {
-      store.saveSttProviderSetting(7, 'deepgram', {
+      store.saveSttProviderSetting('default', 'deepgram', {
         settings: {
           model: 'nova-2',
         },
@@ -352,7 +352,7 @@ describe('stt settings store', () => {
     }).toThrow(/unknown STT provider/i)
 
     expect(() => {
-      store.saveSttProviderSetting(7, 'openai', {
+      store.saveSttProviderSetting('default', 'openai', {
         secrets: {
           token: 'secret-value',
         },
@@ -372,7 +372,7 @@ describe('stt settings store', () => {
   ])('allows local or private base urls using the shared url rules: %s', async (baseUrl) => {
     const { store } = await initStore()
 
-    const saved = store.saveSttProviderSetting(7, 'openai', {
+    const saved = store.saveSttProviderSetting('default', 'openai', {
       settings: {
         baseUrl,
       },
@@ -384,7 +384,7 @@ describe('stt settings store', () => {
   it('stores only supported audio transcode modes', async () => {
     const { store } = await initStore()
 
-    const saved = store.saveSttProviderSetting(7, 'custom', {
+    const saved = store.saveSttProviderSetting('default', 'custom', {
       settings: {
         baseUrl: 'http://127.0.0.1:8000/v1',
         model: 'whisper-1',
@@ -393,7 +393,7 @@ describe('stt settings store', () => {
     })
     expect(saved.settings.audioTranscode).toBe('ffmpeg')
 
-    const ignored = store.saveSttProviderSetting(7, 'custom', {
+    const ignored = store.saveSttProviderSetting('default', 'custom', {
       settings: {
         audioTranscode: 'auto',
       },

--- a/tests/server/stt-transcribe-controller.test.ts
+++ b/tests/server/stt-transcribe-controller.test.ts
@@ -173,7 +173,7 @@ describe('stt transcribe controller', () => {
   it('transcribes multipart audio using the stored secret and ignores client-supplied api keys', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ text: 'transcribed text' }))
     const { ctrl, store } = await initControllerAndStore()
-    store.saveSttProviderSetting(7, 'openai', {
+    store.saveSttProviderSetting('default', 'openai', {
       settings: {
         model: 'gpt-4o-transcribe',
         language: 'en',
@@ -220,7 +220,7 @@ describe('stt transcribe controller', () => {
 
   it('masks stored api keys when listing STT settings', async () => {
     const { ctrl, store } = await initControllerAndStore()
-    store.saveSttProviderSetting(7, 'openai', {
+    store.saveSttProviderSetting('default', 'openai', {
       settings: {
         model: 'gpt-4o-transcribe',
       },
@@ -277,11 +277,11 @@ describe('stt transcribe controller', () => {
 
   it('returns 204 from missing-STT prompt audio when profile STT is configured', async () => {
     const { ctrl, store } = await initControllerAndStore()
-    store.saveSttProviderSetting(7, 'doubao', {
+    store.saveSttProviderSetting('default', 'doubao', {
       settings: { model: 'volc.seedasr.auc' },
       secrets: { apiKey: 'server-secret' },
     })
-    store.saveActiveSttProvider(7, 'doubao')
+    store.saveActiveSttProvider('default', 'doubao')
     const ctx = makeJsonCtx({ id: 7, username: 'han', role: 'admin' }, '', undefined)
 
     await ctrl.missingProfileAudio(ctx)
@@ -292,7 +292,7 @@ describe('stt transcribe controller', () => {
 
   it('returns 400 when multipart audio is missing', async () => {
     const { ctrl, store } = await initControllerAndStore()
-    store.saveSttProviderSetting(7, 'openai', {
+    store.saveSttProviderSetting('default', 'openai', {
       settings: { model: 'gpt-4o-transcribe' },
       secrets: { apiKey: 'server-secret' },
     })
@@ -311,7 +311,7 @@ describe('stt transcribe controller', () => {
 
   it('returns 400 for malformed multipart filename* without throwing', async () => {
     const { ctrl, store } = await initControllerAndStore()
-    store.saveSttProviderSetting(7, 'openai', {
+    store.saveSttProviderSetting('default', 'openai', {
       settings: { model: 'gpt-4o-transcribe' },
       secrets: { apiKey: 'server-secret' },
     })
@@ -356,7 +356,7 @@ describe('stt transcribe controller', () => {
 
   it('returns 400 for saved custom provider settings missing baseUrl', async () => {
     const { ctrl, store } = await initControllerAndStore()
-    store.saveSttProviderSetting(7, 'custom', {
+    store.saveSttProviderSetting('default', 'custom', {
       settings: {
         model: 'whisper-1',
       },
@@ -384,7 +384,7 @@ describe('stt transcribe controller', () => {
   it('ignores client-supplied custom baseUrl, apiKey, and headers during transcription', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ text: 'custom transcript' }))
     const { ctrl, store } = await initControllerAndStore()
-    store.saveSttProviderSetting(7, 'custom', {
+    store.saveSttProviderSetting('default', 'custom', {
       settings: {
         baseUrl: 'https://example.com/v1',
         model: 'whisper-1',
@@ -434,7 +434,7 @@ describe('stt transcribe controller', () => {
         headers: new Headers({ 'X-Api-Status-Code': '20000000' }),
       })
     const { ctrl, store } = await initControllerAndStore()
-    store.saveSttProviderSetting(7, 'doubao', {
+    store.saveSttProviderSetting('default', 'doubao', {
       settings: {
         baseUrl: 'https://openspeech.bytedance.com/api/v3/auc/bigmodel',
         model: 'volc.seedasr.auc',
@@ -495,7 +495,7 @@ describe('stt transcribe controller', () => {
       })
 
     const { ctrl, store } = await initControllerAndStore()
-    store.saveSttProviderSetting(7, 'doubao', {
+    store.saveSttProviderSetting('default', 'doubao', {
       settings: {
         baseUrl: 'https://openspeech.bytedance.com/api/v3/auc/bigmodel',
         model: 'volc.seedasr.auc',
@@ -504,7 +504,7 @@ describe('stt transcribe controller', () => {
         apiKey: 'server-secret',
       },
     })
-    store.saveActiveSttProvider(7, 'doubao')
+    store.saveActiveSttProvider('default', 'doubao')
 
     const wav = Buffer.from('raw-mcu-wav')
     const ctx = makeRawAudioCtx(
@@ -544,14 +544,14 @@ describe('stt transcribe controller', () => {
     }))
 
     const { ctrl, store } = await initControllerAndStore()
-    store.saveSttProviderSetting(7, 'openai', {
+    store.saveSttProviderSetting('default', 'openai', {
       settings: {
         baseUrl: 'https://api.openai.com/v1/audio/transcriptions',
         model: 'gpt-4o-transcribe',
       },
       secrets: { apiKey: 'server-secret' },
     })
-    store.saveActiveSttProvider(7, 'openai')
+    store.saveActiveSttProvider('default', 'openai')
 
     const ctx = makeRawAudioCtx(
       { id: 7, username: 'han', role: 'admin' },
@@ -618,7 +618,7 @@ describe('stt transcribe controller', () => {
   it('returns 502 without leaking secrets when the provider fails', async () => {
     mockFetch.mockResolvedValueOnce(textResponse('upstream rejected bearer server-secret', { status: 401, statusText: 'Unauthorized' }))
     const { ctrl, store } = await initControllerAndStore()
-    store.saveSttProviderSetting(7, 'openai', {
+    store.saveSttProviderSetting('default', 'openai', {
       settings: { model: 'gpt-4o-transcribe' },
       secrets: { apiKey: 'server-secret' },
     })

--- a/tests/server/tts-synthesize-controller.test.ts
+++ b/tests/server/tts-synthesize-controller.test.ts
@@ -65,6 +65,7 @@ describe('tts synthesize controller', () => {
     vi.clearAllMocks()
     vi.doUnmock('../../packages/server/src/services/hermes/tts-providers')
     vi.doUnmock('../../packages/server/src/controllers/hermes/tts')
+    vi.doUnmock('../../packages/server/src/db/index')
   })
 
   it('returns 400 for an unknown provider', async () => {
@@ -83,6 +84,203 @@ describe('tts synthesize controller', () => {
     expect(ctx.body).toEqual({ error: 'unknown TTS provider' })
   })
 
+  it('saves TTS settings when the legacy provider table has no unique index', async () => {
+    const { DatabaseSync } = await import('node:sqlite')
+    const db = new DatabaseSync(':memory:')
+    vi.doMock('../../packages/server/src/db/index', () => ({
+      getDb: () => db,
+      getStoragePath: () => ':memory:',
+    }))
+
+    try {
+      const schemas = await import('../../packages/server/src/db/hermes/schemas')
+      schemas.initAllHermesTables()
+      db.exec('DROP INDEX IF EXISTS idx_tts_provider_settings_user_provider')
+      db.exec('DROP TABLE tts_provider_settings')
+      db.exec(`
+        CREATE TABLE tts_provider_settings (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          profile TEXT NOT NULL DEFAULT 'default',
+          provider TEXT NOT NULL,
+          settings_json TEXT NOT NULL DEFAULT '{}',
+          secrets_json TEXT NOT NULL DEFAULT '{}',
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        )
+      `)
+      db.exec('DROP TABLE tts_user_settings')
+      db.exec(`
+        CREATE TABLE tts_user_settings (
+          profile TEXT PRIMARY KEY DEFAULT 'default',
+          active_provider TEXT NOT NULL DEFAULT 'edge',
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        )
+      `)
+
+      const ctrl = await import('../../packages/server/src/controllers/hermes/tts')
+      const { ctx } = createMockCtx({
+        settings: {
+          model: 'tts-1',
+          voice: 'alloy',
+        },
+        secrets: {
+          apiKey: 'server-secret',
+        },
+      })
+      ctx.state = { user: { id: 7 } }
+      ctx.params = { provider: 'openai' }
+      ctx.query = {}
+      ctx.get = vi.fn(() => '')
+
+      await ctrl.saveSettings(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body.setting).toMatchObject({
+        provider: 'openai',
+        settings: {
+          model: 'tts-1',
+          voice: 'alloy',
+        },
+        secrets: {
+          apiKey: '[stored]',
+        },
+      })
+
+      const profileRow = db.prepare(
+        'SELECT settings_json, secrets_json FROM tts_profile_provider_settings WHERE profile = ? AND provider = ?'
+      ).get('default', 'openai') as { settings_json: string; secrets_json: string }
+      expect(JSON.parse(profileRow.settings_json)).toMatchObject({ model: 'tts-1', voice: 'alloy' })
+      expect(JSON.parse(profileRow.secrets_json)).toEqual({ apiKey: 'server-secret' })
+    } finally {
+      db.close()
+      vi.doUnmock('../../packages/server/src/db/index')
+    }
+  })
+
+  it('preserves numeric Edge TTS rate and pitch settings on save', async () => {
+    const { DatabaseSync } = await import('node:sqlite')
+    const db = new DatabaseSync(':memory:')
+    vi.doMock('../../packages/server/src/db/index', () => ({
+      getDb: () => db,
+      getStoragePath: () => ':memory:',
+    }))
+
+    try {
+      const schemas = await import('../../packages/server/src/db/hermes/schemas')
+      schemas.initAllHermesTables()
+
+      const ctrl = await import('../../packages/server/src/controllers/hermes/tts')
+      const { ctx } = createMockCtx({
+        settings: {
+          voice: 'zh-CN-YunxiNeural',
+          rate: 1.35,
+          pitch: -6,
+        },
+      })
+      ctx.state = { user: { id: 7 } }
+      ctx.params = { provider: 'edge' }
+      ctx.query = {}
+      ctx.get = vi.fn(() => '')
+
+      await ctrl.saveSettings(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body.setting).toMatchObject({
+        provider: 'edge',
+        settings: {
+          voice: 'zh-CN-YunxiNeural',
+          rate: '1.35',
+          pitch: '-6',
+        },
+      })
+
+      const listCtx = createMockCtx().ctx
+      listCtx.state = { user: { id: 7 } }
+      listCtx.query = {}
+      listCtx.get = vi.fn(() => '')
+
+      await ctrl.listSettings(listCtx)
+      expect(listCtx.body.settings).toEqual([
+        expect.objectContaining({
+          provider: 'edge',
+          settings: expect.objectContaining({
+            rate: '1.35',
+            pitch: '-6',
+          }),
+        }),
+      ])
+    } finally {
+      db.close()
+      vi.doUnmock('../../packages/server/src/db/index')
+    }
+  })
+
+  it('repairs preexisting profile TTS tables before saving settings', async () => {
+    const { DatabaseSync } = await import('node:sqlite')
+    const db = new DatabaseSync(':memory:')
+    vi.doMock('../../packages/server/src/db/index', () => ({
+      getDb: () => db,
+      getStoragePath: () => ':memory:',
+    }))
+
+    try {
+      db.exec(`
+        CREATE TABLE tts_profile_provider_settings (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          profile TEXT NOT NULL DEFAULT 'default',
+          provider TEXT NOT NULL,
+          settings_json TEXT NOT NULL DEFAULT '{}',
+          secrets_json TEXT NOT NULL DEFAULT '{}',
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        )
+      `)
+      db.exec(`
+        CREATE TABLE tts_profile_settings (
+          profile TEXT NOT NULL DEFAULT 'default',
+          active_provider TEXT NOT NULL DEFAULT 'edge',
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        )
+      `)
+      db.prepare(
+        'INSERT INTO tts_profile_provider_settings (profile, provider, settings_json, secrets_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+      ).run('default', 'edge', '{"voice":"old"}', '{}', 1, 1)
+      db.prepare(
+        'INSERT INTO tts_profile_provider_settings (profile, provider, settings_json, secrets_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+      ).run('default', 'edge', '{"voice":"newer"}', '{}', 2, 2)
+      db.prepare(
+        'INSERT INTO tts_profile_settings (profile, active_provider, created_at, updated_at) VALUES (?, ?, ?, ?)'
+      ).run('default', 'edge', 1, 1)
+      db.prepare(
+        'INSERT INTO tts_profile_settings (profile, active_provider, created_at, updated_at) VALUES (?, ?, ?, ?)'
+      ).run('default', 'openai', 2, 2)
+
+      const schemas = await import('../../packages/server/src/db/hermes/schemas')
+      schemas.initAllHermesTables()
+
+      const ctrl = await import('../../packages/server/src/controllers/hermes/tts')
+      const { ctx } = createMockCtx({
+        settings: { voice: 'zh-CN-XiaoxiaoNeural' },
+      })
+      ctx.state = { user: { id: 7 } }
+      ctx.params = { provider: 'edge' }
+      ctx.query = {}
+      ctx.get = vi.fn(() => '')
+
+      await ctrl.saveSettings(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body.setting.settings.voice).toBe('zh-CN-XiaoxiaoNeural')
+      expect(db.prepare('SELECT COUNT(*) AS count FROM tts_profile_provider_settings WHERE profile = ? AND provider = ?').get('default', 'edge').count).toBe(1)
+      expect(db.prepare('SELECT COUNT(*) AS count FROM tts_profile_settings WHERE profile = ?').get('default').count).toBe(1)
+    } finally {
+      db.close()
+      vi.doUnmock('../../packages/server/src/db/index')
+    }
+  })
+
   it('uses the active TTS provider when request provider is omitted', async () => {
     const audio = Buffer.from('active-audio')
     const provider = {
@@ -95,12 +293,14 @@ describe('tts synthesize controller', () => {
     }
     const getTtsProvider = vi.fn(() => provider)
     const getActiveTtsProvider = vi.fn(() => 'doubao')
+    const getTtsProviderSetting = vi.fn(() => null)
     vi.doMock('../../packages/server/src/services/hermes/tts-providers', () => ({
       getTtsProvider,
     }))
     vi.doMock('../../packages/server/src/db/hermes/tts-settings-store', async (importOriginal) => ({
       ...await importOriginal<typeof import('../../packages/server/src/db/hermes/tts-settings-store')>(),
       getActiveTtsProvider,
+      getTtsProviderSetting,
     }))
 
     const ctrl = await import('../../packages/server/src/controllers/hermes/tts')
@@ -109,7 +309,7 @@ describe('tts synthesize controller', () => {
 
     await ctrl.synthesize(ctx)
 
-    expect(getActiveTtsProvider).toHaveBeenCalledWith(7)
+    expect(getActiveTtsProvider).toHaveBeenCalledWith('default')
     expect(getTtsProvider).toHaveBeenCalledWith('doubao')
     expect(provider.synthesize).toHaveBeenCalledWith(
       { text: 'hello', signal: expect.any(AbortSignal) },
@@ -129,12 +329,16 @@ describe('tts synthesize controller', () => {
     }
     const getTtsProvider = vi.fn(() => provider)
     const getActiveTtsProvider = vi.fn(() => null)
+    const getTtsProviderSetting = vi.fn(() => null)
+    const listTtsProviderSettings = vi.fn(() => [])
     vi.doMock('../../packages/server/src/services/hermes/tts-providers', () => ({
       getTtsProvider,
     }))
     vi.doMock('../../packages/server/src/db/hermes/tts-settings-store', async (importOriginal) => ({
       ...await importOriginal<typeof import('../../packages/server/src/db/hermes/tts-settings-store')>(),
       getActiveTtsProvider,
+      getTtsProviderSetting,
+      listTtsProviderSettings,
     }))
 
     const ctrl = await import('../../packages/server/src/controllers/hermes/tts')
@@ -143,7 +347,8 @@ describe('tts synthesize controller', () => {
 
     await ctrl.synthesize(ctx)
 
-    expect(getActiveTtsProvider).toHaveBeenCalledWith(7)
+    expect(getActiveTtsProvider).toHaveBeenCalledWith('default')
+    expect(listTtsProviderSettings).toHaveBeenCalledWith('default')
     expect(getTtsProvider).toHaveBeenCalledWith('edge')
     expect(provider.synthesize).toHaveBeenCalledWith(
       { text: 'hello', signal: expect.any(AbortSignal) },
@@ -265,7 +470,7 @@ describe('tts synthesize controller', () => {
 
     await ctrl.synthesize(ctx)
 
-    expect(getTtsProviderSetting).toHaveBeenCalledWith(7, 'openai', { includeSecrets: true })
+    expect(getTtsProviderSetting).toHaveBeenCalledWith('default', 'openai', { includeSecrets: true })
     expect(provider.synthesize).toHaveBeenCalledWith(
       { text: 'Hello world', signal: expect.any(AbortSignal) },
       {


### PR DESCRIPTION
## Summary
- Move STT/TTS settings runtime storage to profile-scoped tables while keeping legacy user tables as migration sources only.
- Preserve default Edge TTS fallback and Edge rate/pitch settings, including test voice playback.
- Propagate the active profile into browser TTS fetches and MCU/global-agent TTS synthesis, including fallback requests.

## Root Cause
Voice settings were still tied to user-scoped legacy tables in several runtime paths. Some TTS requests also bypassed the shared client request helper, so they missed the active profile header. MCU TTS synthesis had the same profile propagation gap.

## Validation
- npm run test -- tests/server/global-agent-server.test.ts tests/server/outbound-relay-client.test.ts tests/server/tts-synthesize-controller.test.ts tests/server/stt-settings-controller.test.ts tests/client/use-speech-tts.test.ts
- npx tsc -p packages/server/tsconfig.json --noEmit
- npm run harness:check
- npm run build
- git diff --check