### PR TITLE
fix: persist model selection per chat session

### DIFF
--- a/docs/chat-chain-changes/2026-06-22-session-model-persistence.md
+++ b/docs/chat-chain-changes/2026-06-22-session-model-persistence.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-22
+pr: pending
+feature: Session-scoped model selection
+impact: Model picker changes on an existing chat now persist to that session instead of overwriting the global default, non-coding chat runs send the session model/provider on every turn so bridge state cannot drift after reloads or mid-session model changes, sidebar rows show each session's model, and model switching now shows a disabled/loading state while persistence is in flight.
+---

--- a/docs/chat-chain-changes/2026-06-23-run-model-config-explicit-selection.md
+++ b/docs/chat-chain-changes/2026-06-23-run-model-config-explicit-selection.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-23
+pr: pending
+feature: Session-scoped model selection
+impact: Bridge run model resolution now trusts an explicit requested or persisted session model/provider instead of treating the loaded model catalog as authoritative and falling back to the profile default when the selected model is absent from the current catalog response.
+---

--- a/packages/client/src/components/hermes/chat/SessionListItem.vue
+++ b/packages/client/src/components/hermes/chat/SessionListItem.vue
@@ -42,6 +42,11 @@ const profileHasModels = computed(() => {
 const profileModelsMissing = computed(() =>
   appStore.profileModelGroups.length > 0 && !profileHasModels.value,
 )
+const sessionModelLabel = computed(() => {
+  const model = props.session.model?.trim()
+  if (!model) return ''
+  return appStore.displayModelName(model, props.session.provider)
+})
 const isGlobalAgentSession = computed(() => props.session.source === 'global_agent')
 const sessionAgentLogo = computed(() => {
   if (props.session.source === 'coding_agent') {
@@ -157,6 +162,9 @@ onUnmounted(() => {
         <span v-if="props.showProfile" class="session-item-profile">
           <ProfileAvatar class="session-item-profile-avatar" :name="profileName" :avatar="profileAvatar" :size="16" />
           <span class="session-item-profile-name">{{ profileName }}</span>
+        </span>
+        <span v-if="sessionModelLabel" class="session-item-model" :title="sessionModelLabel">
+          {{ sessionModelLabel }}
         </span>
       </span>
     </div>
@@ -356,6 +364,28 @@ onUnmounted(() => {
   font-size: 11px;
   line-height: 16px;
   color: var(--text-muted);
+}
+
+.session-item-model {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 125px;
+  padding: 1px 6px;
+  border: 1px solid rgba(var(--accent-primary-rgb), 0.16);
+  border-radius: 999px;
+  background: rgba(var(--accent-primary-rgb), 0.07);
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 14px;
+  font-weight: 500;
+}
+
+.session-item.active .session-item-model {
+  border-color: rgba(var(--accent-primary-rgb), 0.24);
+  background: rgba(var(--accent-primary-rgb), 0.1);
+  color: var(--accent-primary);
 }
 
 .session-item-warning {

--- a/packages/client/src/components/layout/ModelSelector.vue
+++ b/packages/client/src/components/layout/ModelSelector.vue
@@ -2,6 +2,7 @@
 import { ref, computed } from 'vue'
 import { NModal, NInput, NSelect } from 'naive-ui'
 import { useAppStore } from '@/stores/hermes/app'
+import { useChatStore } from '@/stores/hermes/chat'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import { useI18n } from 'vue-i18n'
 
@@ -11,6 +12,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const appStore = useAppStore()
+const chatStore = useChatStore()
 const profilesStore = useProfilesStore()
 
 const showModal = ref(false)
@@ -18,6 +20,8 @@ const searchQuery = ref('')
 const collapsedGroups = ref<Record<string, boolean>>({})
 const customInput = ref('')
 const customProvider = ref('')
+const selectingModelKey = ref<string | null>(null)
+const selectionError = ref('')
 
 const activeProfileName = computed(() => profilesStore.activeProfileName || 'default')
 const activeModelGroups = computed(() => {
@@ -26,10 +30,14 @@ const activeModelGroups = computed(() => {
 })
 
 const providerOptions = computed(() => {
-  const current = appStore.selectedProvider
+  const current = effectiveProvider.value || appStore.selectedProvider
   customProvider.value = current
   return activeModelGroups.value.map(g => ({ label: g.label, value: g.provider }))
 })
+
+const effectiveModel = computed(() => chatStore.activeSession?.model || appStore.selectedModel)
+const effectiveProvider = computed(() => chatStore.activeSession?.provider || appStore.selectedProvider)
+const isSelectingModel = computed(() => selectingModelKey.value !== null)
 
 const modelGroupsWithCustom = computed(() =>
   activeModelGroups.value.map(g => ({
@@ -43,14 +51,14 @@ const modelGroupsWithCustom = computed(() =>
 
 const selectedModelInActiveProfile = computed(() =>
   modelGroupsWithCustom.value.some(group =>
-    group.provider === appStore.selectedProvider && group.models.includes(appStore.selectedModel),
+    group.provider === effectiveProvider.value && group.models.includes(effectiveModel.value),
   ),
 )
 
 const selectedDisplayName = computed(() =>
   selectedModelInActiveProfile.value
-    ? appStore.displayModelName(appStore.selectedModel, appStore.selectedProvider)
-    : '',
+    ? appStore.displayModelName(effectiveModel.value, effectiveProvider.value)
+    : effectiveModel.value,
 )
 
 function isCustomModel(model: string, provider: string) {
@@ -87,12 +95,43 @@ function isGroupCollapsed(provider: string) {
   return !!collapsedGroups.value[provider]
 }
 
-function handleSelect(model: string, provider: string) {
+async function persistSelectedModel(model: string, provider: string) {
+  if (chatStore.activeSession?.id) {
+    return chatStore.switchSessionModel(model, provider, chatStore.activeSession.id)
+  } else {
+    await appStore.switchModel(model, provider)
+    return true
+  }
+}
+
+function modelSelectionKey(model: string, provider: string) {
+  return `${provider}\u0000${model}`
+}
+
+function isModelSwitching(model: string, provider: string) {
+  return selectingModelKey.value === modelSelectionKey(model, provider)
+}
+
+async function handleSelect(model: string, provider: string) {
+  if (isSelectingModel.value) return
   const meta = activeModelGroups.value.find(g => g.provider === provider)?.model_meta?.[model]
   if (meta?.disabled) return
-  appStore.switchModel(model, provider)
-  setModalShow(false)
-  searchQuery.value = ''
+  selectingModelKey.value = modelSelectionKey(model, provider)
+  selectionError.value = ''
+  try {
+    const ok = await persistSelectedModel(model, provider)
+    if (!ok) {
+      selectionError.value = t('chat.modelSetFailed')
+      return
+    }
+    setModalShow(false)
+    searchQuery.value = ''
+  } catch (err) {
+    console.error('Failed to select model:', err)
+    selectionError.value = t('chat.modelSetFailed')
+  } finally {
+    selectingModelKey.value = null
+  }
 }
 
 function modelDisplayName(model: string, provider: string) {
@@ -103,16 +142,30 @@ function modelAlias(model: string, provider: string) {
   return appStore.getModelAlias(model, provider)
 }
 
-function handleCustomSubmit() {
+async function handleCustomSubmit() {
+  if (isSelectingModel.value) return
   const model = customInput.value.trim()
   if (!model || !customProvider.value) return
   // 拦截 disabled 模型，避免 custom input 绕过列表里的灰显限制
   const meta = activeModelGroups.value.find(g => g.provider === customProvider.value)?.model_meta?.[model]
   if (meta?.disabled) return
-  appStore.switchModel(model, customProvider.value)
-  setModalShow(false)
-  searchQuery.value = ''
-  customInput.value = ''
+  selectingModelKey.value = modelSelectionKey(model, customProvider.value)
+  selectionError.value = ''
+  try {
+    const ok = await persistSelectedModel(model, customProvider.value)
+    if (!ok) {
+      selectionError.value = t('chat.modelSetFailed')
+      return
+    }
+    setModalShow(false)
+    searchQuery.value = ''
+    customInput.value = ''
+  } catch (err) {
+    console.error('Failed to select custom model:', err)
+    selectionError.value = t('chat.modelSetFailed')
+  } finally {
+    selectingModelKey.value = null
+  }
 }
 
 function setModalShow(show: boolean) {
@@ -123,12 +176,14 @@ function setModalShow(show: boolean) {
 function openModal() {
   collapsedGroups.value = {}
   searchQuery.value = ''
+  selectionError.value = ''
   customInput.value = ''
-  customProvider.value = appStore.selectedProvider
+  customProvider.value = effectiveProvider.value || appStore.selectedProvider
   setModalShow(true)
 }
 
 function handleModalShowChange(show: boolean) {
+  if (!show && isSelectingModel.value) return
   setModalShow(show)
 }
 
@@ -172,8 +227,11 @@ async function handleRefresh() {
         </svg>
       </button>
     </div>
-    <button class="model-trigger" @click="openModal">
-      <span class="model-name" :title="appStore.selectedModel">{{ selectedDisplayName || '—' }}</span>
+    <button class="model-trigger" :class="{ switching: isSelectingModel }" :disabled="isSelectingModel" @click="openModal">
+      <span class="model-name" :title="effectiveModel">
+        {{ isSelectingModel ? t('common.loading') : (selectedDisplayName || '—') }}
+      </span>
+      <span v-if="isSelectingModel" class="model-trigger-spinner" aria-hidden="true" />
       <svg class="model-arrow" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="6 9 12 15 18 9" />
       </svg>
@@ -184,16 +242,21 @@ async function handleRefresh() {
       preset="card"
       :title="t('models.title')"
       :style="{ width: 'min(480px, calc(100vw - 32px))' }"
-      :mask-closable="true"
+      :mask-closable="!isSelectingModel"
       @update:show="handleModalShowChange"
     >
       <NInput
         v-model:value="searchQuery"
         :placeholder="t('models.searchPlaceholder')"
+        :disabled="isSelectingModel"
         clearable
         size="small"
         class="model-search"
       />
+      <div v-if="isSelectingModel || selectionError" class="model-selection-status" :class="{ error: selectionError }" role="status" aria-live="polite">
+        <span v-if="isSelectingModel" class="model-status-spinner" aria-hidden="true" />
+        <span>{{ selectionError || t('common.loading') }}</span>
+      </div>
       <div class="model-list">
         <div v-for="group in filteredGroups" :key="group.provider" class="model-group">
           <div class="model-group-header" @click="toggleGroup(group.provider)">
@@ -213,8 +276,10 @@ async function handleRefresh() {
               :key="model"
               class="model-item"
               :class="{
-                active: model === appStore.selectedModel && group.provider === appStore.selectedProvider,
+                active: model === effectiveModel && group.provider === effectiveProvider,
                 disabled: !!group.model_meta?.[model]?.disabled,
+                switching: isModelSwitching(model, group.provider),
+                busy: isSelectingModel,
               }"
               :title="group.model_meta?.[model]?.disabled ? t('models.disabledTooltip') : ''"
               @click="handleSelect(model, group.provider)"
@@ -232,12 +297,14 @@ async function handleRefresh() {
                 v-if="isCustomModel(model, group.provider)"
                 class="model-custom-remove"
                 type="button"
+                :disabled="isSelectingModel"
                 :title="t('models.removeCustomModel')"
                 @click.stop="removeCustomModel(model, group.provider)"
               >
                 ×
               </button>
-              <svg v-if="model === appStore.selectedModel && group.provider === appStore.selectedProvider" class="model-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <span v-if="isModelSwitching(model, group.provider)" class="model-switch-spinner" aria-hidden="true" />
+              <svg v-if="model === effectiveModel && group.provider === effectiveProvider" class="model-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="20 6 9 17 4 12" />
               </svg>
             </div>
@@ -251,12 +318,14 @@ async function handleRefresh() {
             <NSelect
               v-model:value="customProvider"
               :options="providerOptions"
+              :disabled="isSelectingModel"
               size="small"
               class="model-custom-provider"
             />
             <NInput
               v-model:value="customInput"
               :placeholder="t('models.customModelPlaceholder')"
+              :disabled="isSelectingModel"
               size="small"
               class="model-custom-input"
               @keydown.enter="handleCustomSubmit"
@@ -341,11 +410,61 @@ async function handleRefresh() {
   color: $text-primary;
   font-size: 13px;
   cursor: pointer;
-  transition: border-color $transition-fast;
+  transition: border-color $transition-fast, background-color $transition-fast;
 
-  &:hover {
+  &:hover:not(:disabled) {
     border-color: $accent-muted;
   }
+
+  &:disabled {
+    cursor: wait;
+  }
+
+  &.switching {
+    border-color: rgba(var(--accent-primary-rgb), 0.45);
+    background: rgba(var(--accent-primary-rgb), 0.06);
+  }
+}
+
+.model-trigger-spinner,
+.model-status-spinner,
+.model-switch-spinner {
+  flex: 0 0 auto;
+  width: 13px;
+  height: 13px;
+  border: 2px solid rgba(var(--accent-primary-rgb), 0.2);
+  border-top-color: $accent-primary;
+  border-radius: 50%;
+  animation: model-selection-spin 0.75s linear infinite;
+}
+
+.model-trigger-spinner {
+  width: 12px;
+  height: 12px;
+}
+
+.model-selection-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: -4px 0 10px;
+  padding: 8px 10px;
+  border: 1px solid rgba(var(--accent-primary-rgb), 0.18);
+  border-radius: $radius-sm;
+  background: rgba(var(--accent-primary-rgb), 0.06);
+  color: $text-secondary;
+  font-size: 12px;
+
+  &.error {
+    border-color: rgba(var(--error-rgb), 0.28);
+    background: rgba(var(--error-rgb), 0.08);
+    color: $error;
+  }
+}
+
+@keyframes model-selection-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }
 
 .model-name {
@@ -435,6 +554,18 @@ async function handleRefresh() {
   &.active {
     color: $accent-primary;
     font-weight: 500;
+  }
+
+  &.busy {
+    cursor: wait;
+    opacity: 0.62;
+  }
+
+  &.switching {
+    opacity: 1;
+    color: $accent-primary;
+    background: rgba(var(--accent-primary-rgb), 0.08);
+    box-shadow: inset 2px 0 0 $accent-primary;
   }
 
   &.disabled {

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -2037,10 +2037,10 @@ export const useChatStore = defineStore('chat', () => {
         profile: sessionProfile,
         model: sessionSource === 'coding_agent'
           ? (codingAgentMode === 'global' ? undefined : sessionModel || undefined)
-          : shouldSendInitialSessionConfig ? sessionModel || undefined : undefined,
+          : sessionModel || undefined,
         provider: sessionSource === 'coding_agent'
           ? (codingAgentMode === 'global' ? undefined : sessionProvider || undefined)
-          : shouldSendInitialSessionConfig ? sessionProvider || undefined : undefined,
+          : sessionProvider || undefined,
         model_groups: runModelGroups.map(group => ({
           provider: group.provider,
           models: group.models,

--- a/packages/server/src/services/hermes/run-chat/model-config.ts
+++ b/packages/server/src/services/hermes/run-chat/model-config.ts
@@ -22,12 +22,6 @@ async function resolveDefaultModelConfig(profile: string): Promise<{ model: stri
   }
 }
 
-function hasModelInGroups(groups: RunModelGroup[] | undefined, provider: string, model: string): boolean {
-  if (!groups?.length || !provider || !model) return false
-  const group = groups.find(item => item.provider === provider)
-  return Array.isArray(group?.models) && group.models.includes(model)
-}
-
 export async function resolveBridgeRunModelConfig(options: {
   profile: string
   sessionModel?: string | null
@@ -40,12 +34,9 @@ export async function resolveBridgeRunModelConfig(options: {
   const sessionProvider = String(options.sessionProvider || '').trim()
   const requestedModel = String(options.requestedModel || '').trim()
   const requestedProvider = String(options.requestedProvider || '').trim()
-  const candidateModel = sessionModel || requestedModel
-  const candidateProvider = sessionProvider || requestedProvider
-  const hasGroups = Array.isArray(options.modelGroups) && options.modelGroups.length > 0
-  const candidateAvailable = hasGroups && hasModelInGroups(options.modelGroups, candidateProvider, candidateModel)
-  const shouldUseDefault = !candidateModel || !candidateProvider || (hasGroups && !candidateAvailable)
-  return shouldUseDefault
+  const candidateModel = requestedModel || sessionModel
+  const candidateProvider = requestedProvider || sessionProvider
+  return !candidateModel || !candidateProvider
     ? resolveDefaultModelConfig(options.profile)
     : { model: candidateModel, provider: runtimeProvider(candidateProvider) }
 }

--- a/tests/client/chat-store-session-command.test.ts
+++ b/tests/client/chat-store-session-command.test.ts
@@ -251,6 +251,35 @@ describe('chat store session.command fanout', () => {
     expect(store.isStreaming).toBe(false)
   })
 
+  it('sends the session model on every non-coding-agent run', async () => {
+    const store = useChatStore()
+    const session = makeSession()
+    session.source = 'cli'
+    session.messageCount = 3
+    session.model = 'glm-5.2'
+    session.provider = 'zai'
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    await store.sendMessage('use the session model')
+
+    expect(chatApi.startRunViaSocket).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: 'use the session model',
+        session_id: 'session-1',
+        source: 'cli',
+        model: 'glm-5.2',
+        provider: 'zai',
+      }),
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function),
+      undefined,
+      expect.any(Object),
+    )
+  })
+
   it('adds and switches to a branched child session from session.command branch events', async () => {
     const store = useChatStore()
     const session = makeSession()

--- a/tests/client/model-selector-loading.test.ts
+++ b/tests/client/model-selector-loading.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, nextTick } from 'vue'
+import ModelSelector from '@/components/layout/ModelSelector.vue'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+const stores = vi.hoisted(() => {
+  const appStore = {
+    selectedModel: 'old-model',
+    selectedProvider: 'test-provider',
+    customModels: {} as Record<string, string[]>,
+    profileModelGroups: [
+      {
+        profile: 'default',
+        groups: [
+          {
+            provider: 'test-provider',
+            label: 'Test Provider',
+            models: ['old-model', 'new-model'],
+            model_meta: {},
+          },
+        ],
+      },
+    ],
+    displayModelName: (model: string) => model === 'new-model' ? 'New Model' : model,
+    getModelAlias: () => '',
+    removeCustomModel: vi.fn(),
+    switchModel: vi.fn(),
+    reloadModels: vi.fn(),
+  }
+  const chatStore = {
+    activeSession: {
+      id: 'session-1',
+      model: 'old-model',
+      provider: 'test-provider',
+    },
+    switchSessionModel: vi.fn(),
+  }
+  return { appStore, chatStore }
+})
+
+vi.mock('@/stores/hermes/app', () => ({
+  useAppStore: () => stores.appStore,
+}))
+
+vi.mock('@/stores/hermes/chat', () => ({
+  useChatStore: () => stores.chatStore,
+}))
+
+vi.mock('@/stores/hermes/profiles', () => ({
+  useProfilesStore: () => ({ activeProfileName: 'default' }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => ({
+      'common.loading': 'Loading...',
+      'models.title': 'Models',
+      'models.refresh': 'Refresh',
+      'models.searchPlaceholder': 'Search models...',
+      'models.customModelPlaceholder': 'Unlisted model ID',
+      'models.customModelHint': 'For provider-supported models not returned by the API; not a display rename. Press Enter to load.',
+      'models.aliasCanonical': 'Original ID',
+      'models.previewBadge': 'PREVIEW',
+      'models.disabledBadge': 'UNAVAILABLE',
+      'models.customBadge': 'CUSTOM',
+      'models.removeCustomModel': 'Remove this unlisted model',
+      'models.disabledTooltip': 'Unavailable',
+      'chat.modelSetFailed': 'Failed to set model',
+    } as Record<string, string>)[key] || key,
+  }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NModal: defineComponent({
+    name: 'NModal',
+    props: ['show', 'maskClosable'],
+    emits: ['update:show'],
+    template: '<div v-if="show" class="n-modal"><slot /></div>',
+  }),
+  NInput: defineComponent({
+    name: 'NInput',
+    inheritAttrs: false,
+    props: ['value', 'placeholder', 'disabled'],
+    emits: ['update:value', 'keydown'],
+    template: '<input class="n-input" :value="value" :placeholder="placeholder" :disabled="disabled" @input="$emit(\'update:value\', $event.target.value)" @keydown="$emit(\'keydown\', $event)" />',
+  }),
+  NSelect: defineComponent({
+    name: 'NSelect',
+    inheritAttrs: false,
+    props: ['value', 'options', 'disabled'],
+    emits: ['update:value'],
+    template: '<select class="n-select" :value="value" :disabled="disabled" @change="$emit(\'update:value\', $event.target.value)"><option v-for="option in options" :key="option.value" :value="option.value">{{ option.label }}</option></select>',
+  }),
+}))
+
+describe('ModelSelector loading state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stores.appStore.selectedModel = 'old-model'
+    stores.appStore.selectedProvider = 'test-provider'
+    stores.chatStore.activeSession = {
+      id: 'session-1',
+      model: 'old-model',
+      provider: 'test-provider',
+    }
+  })
+
+  it('shows immediate feedback while a session model switch is pending', async () => {
+    const pending = deferred<boolean>()
+    stores.chatStore.switchSessionModel.mockImplementation((model: string, provider: string) => {
+      return pending.promise.then(ok => {
+        if (ok) {
+          stores.chatStore.activeSession.model = model
+          stores.chatStore.activeSession.provider = provider
+        }
+        return ok
+      })
+    })
+
+    const wrapper = mount(ModelSelector)
+    await wrapper.get('.model-trigger').trigger('click')
+
+    const target = wrapper.findAll('.model-item').find(item => item.text().includes('New Model'))
+    expect(target).toBeTruthy()
+    await target!.trigger('click')
+    await nextTick()
+
+    expect(stores.chatStore.switchSessionModel).toHaveBeenCalledWith('new-model', 'test-provider', 'session-1')
+    expect(wrapper.get('.model-trigger').classes()).toContain('switching')
+    expect(wrapper.get('.model-trigger').attributes('disabled')).toBeDefined()
+    expect(wrapper.get('.model-selection-status').text()).toContain('Loading...')
+    expect(wrapper.get('.model-item.switching').text()).toContain('New Model')
+    expect(wrapper.find('.model-switch-spinner').exists()).toBe(true)
+
+    pending.resolve(true)
+    await pending.promise
+    await Promise.resolve()
+    await Promise.resolve()
+    await nextTick()
+
+    expect(wrapper.find('.n-modal').exists()).toBe(false)
+  })
+})

--- a/tests/client/session-list-item.test.ts
+++ b/tests/client/session-list-item.test.ts
@@ -7,6 +7,7 @@ import SessionListItem from '@/components/hermes/chat/SessionListItem.vue'
 vi.mock('@/stores/hermes/app', () => ({
   useAppStore: () => ({
     profileModelGroups: [],
+    displayModelName: (model: string) => (model === 'gpt-test' ? 'GPT Test Alias' : model),
   }),
 }))
 
@@ -69,6 +70,26 @@ describe('SessionListItem', () => {
     const link = wrapper.get('a.session-item')
     expect(link.attributes('href')).toBe('/session/s1')
     expect(wrapper.find('button.session-item').exists()).toBe(false)
+  })
+
+  it('renders the session model alias in the sidebar row', () => {
+    const wrapper = mount(SessionListItem, {
+      props: {
+        session,
+        active: false,
+        pinned: false,
+        canDelete: true,
+      },
+      global: {
+        stubs: {
+          ProfileAvatar: true,
+        },
+      },
+    })
+
+    const model = wrapper.get('.session-item-model')
+    expect(model.text()).toBe('GPT Test Alias')
+    expect(model.attributes('title')).toBe('GPT Test Alias')
   })
 
   it('renders selectable mode as a button and does not expose row href', () => {

--- a/tests/server/run-chat-model-config.test.ts
+++ b/tests/server/run-chat-model-config.test.ts
@@ -28,7 +28,7 @@ describe('run chat model config', () => {
     expect(readConfigYamlForProfileMock).not.toHaveBeenCalled()
   })
 
-  it('keeps an existing session model ahead of a requested model', async () => {
+  it('uses the requested model ahead of a stale session model', async () => {
     const { resolveBridgeRunModelConfig } = await import('../../packages/server/src/services/hermes/run-chat/model-config')
 
     const result = await resolveBridgeRunModelConfig({
@@ -43,7 +43,7 @@ describe('run chat model config', () => {
       ],
     })
 
-    expect(result).toEqual({ model: 'claude-sonnet-4.5', provider: 'anthropic' })
+    expect(result).toEqual({ model: 'gpt-5.2', provider: 'openai' })
     expect(readConfigYamlForProfileMock).not.toHaveBeenCalled()
   })
 
@@ -74,13 +74,25 @@ describe('run chat model config', () => {
     expect(readConfigYamlForProfileMock).not.toHaveBeenCalled()
   })
 
-  it('falls back to the profile default when the candidate model is unavailable', async () => {
+  it('keeps an explicit session model even when it is missing from the loaded model groups', async () => {
     const { resolveBridgeRunModelConfig } = await import('../../packages/server/src/services/hermes/run-chat/model-config')
 
     const result = await resolveBridgeRunModelConfig({
       profile: 'default',
-      requestedModel: 'missing-model',
-      requestedProvider: 'openai',
+      sessionModel: 'claude-opus-4-8',
+      sessionProvider: 'anthropic',
+      modelGroups: [{ provider: 'openai', models: ['gpt-5.2'] }],
+    })
+
+    expect(result).toEqual({ model: 'claude-opus-4-8', provider: 'anthropic' })
+    expect(readConfigYamlForProfileMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the profile default only when no explicit model/provider exists', async () => {
+    const { resolveBridgeRunModelConfig } = await import('../../packages/server/src/services/hermes/run-chat/model-config')
+
+    const result = await resolveBridgeRunModelConfig({
+      profile: 'default',
       modelGroups: [{ provider: 'openai', models: ['gpt-5.2'] }],
     })
 


### PR DESCRIPTION
## Summary
- route model picker changes through the active chat session when one exists instead of overwriting the global default model
- keep the global model selection only for the no-session/new-chat draft state
- send the session model/provider on every non-coding-agent run so bridge/runtime state cannot drift after reloads or mid-session model changes
- stop treating the loaded model catalog as authoritative for explicit session selections; missing/stale catalog entries no longer reset chats back to the profile default
- show each session's model in the left chat list, using configured model aliases where available
- add a model-switch loading state: disables repeated clicks, keeps the picker open, shows spinner/status feedback, and reports failures inline
- add chat-chain docs fragments and focused store/sidebar/model-selector/server resolver coverage

## Validation
- `npm run harness:check`
- `env NODE_OPTIONS='--max-old-space-size=2048' npm run test -- --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism tests/server/run-chat-model-config.test.ts tests/client/chat-store-session-command.test.ts tests/client/model-selector-loading.test.ts`
- `nice -n 10 env NODE_OPTIONS='--max-old-space-size=3072' npm run build`

Authored-by: Zephyr (AI Assistant) <raaisalpwardana+zephyr@gmail.com>
