### PR TITLE
[codex] fix new chat default model selection

### DIFF
--- a/docs/chat-chain-changes/2026-06-22-pr1736-new-chat-default-model.md
+++ b/docs/chat-chain-changes/2026-06-22-pr1736-new-chat-default-model.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-22
+pr: 1736
+feature: New chat default model selection
+impact: New Hermes chat sessions now prefer the active sidebar/global model selection for the active profile, while existing sessions keep their stored model.
+---

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -368,6 +368,21 @@ function getSelectableModelGroupsForProfile(profile: string) {
 
 function getDefaultModelForProfile(profile: string) {
   const groups = getSelectableModelGroupsForProfile(profile);
+  const activeProfileName = profilesStore.activeProfileName || "default";
+  const selectedProvider = appStore.selectedProvider || "";
+  const selectedModel = appStore.selectedModel || "";
+  const selectedGroup = selectedProvider
+    ? groups.find((group) => group.provider === selectedProvider)
+    : undefined;
+  if (
+    profile === activeProfileName &&
+    selectedGroup?.models.includes(selectedModel)
+  ) {
+    return {
+      provider: selectedProvider,
+      model: selectedModel,
+    };
+  }
   const profileModels = appStore.profileModelGroups.find(
     (entry) => entry.profile === profile,
   );

--- a/tests/client/chat-panel-session-click.test.ts
+++ b/tests/client/chat-panel-session-click.test.ts
@@ -21,4 +21,13 @@ describe('ChatPanel session clicks', () => {
     expect(source).not.toContain('header-model-button--readonly')
     expect(source).not.toContain('if (isActiveSessionCodingAgent.value) return')
   })
+
+  it('uses the active sidebar model as the new chat default for the active profile', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+
+    expect(source).toContain('const selectedProvider = appStore.selectedProvider || ""')
+    expect(source).toContain('const selectedModel = appStore.selectedModel || ""')
+    expect(source).toContain('profile === activeProfileName')
+    expect(source).toContain('selectedGroup?.models.includes(selectedModel)')
+  })
 })


### PR DESCRIPTION
## Summary
- make the new chat drawer prefer the active sidebar/global model selection for the active profile
- keep the existing profile-default fallback when the sidebar selection is not valid for the selected profile
- add a focused regression check for the new chat default selection path

## Root cause
The new chat drawer initialized its provider/model from the profile model defaults only. After changing the sidebar global model, the in-memory `appStore.selectedModel` was updated, but the drawer still used the older profile default until a page refresh reloaded persisted config.

## Validation
- `npm run test -- tests/client/chat-panel-session-click.test.ts`
