### PR TITLE
[codex] fix MCU double click and Xiao Fang He links

### DIFF
--- a/docs/chat-chain-changes/2026-06-23-sidebar-xiaofanghe-link.md
+++ b/docs/chat-chain-changes/2026-06-23-sidebar-xiaofanghe-link.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-23
+pr: 1740
+feature: Sidebar Xiao Fang He link
+impact: Chat and group chat sidebars now show an independent Xiao Fang He link beside the settings shortcut without changing session routing or runtime behavior.
+---

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -34,6 +34,7 @@ import OutlinePanel from "./OutlinePanel.vue";
 import FilesPanel from "./FilesPanel.vue";
 import TerminalPanel from "./TerminalPanel.vue";
 import PageSidebarNav from "@/components/layout/PageSidebarNav.vue";
+import SettingsCircuitBadge from "@/components/layout/SettingsCircuitBadge.vue";
 import { isStoredSuperAdmin } from "@/api/client";
 
 const chatStore = useChatStore();
@@ -1272,8 +1273,8 @@ async function handleSessionModelCustomSubmit() {
             <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
           </svg>
           <span>{{ t("sidebar.settings") }}</span>
-          <!-- <SettingsCircuitBadge /> -->
         </button>
+        <SettingsCircuitBadge />
       </div>
     </aside>
 
@@ -2263,10 +2264,14 @@ async function handleSessionModelCustomSubmit() {
 .page-sidebar-bottom {
   flex-shrink: 0;
   padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .page-sidebar-menu-btn {
-  width: 100%;
+  flex: 1 1 auto;
+  width: auto;
   min-width: 0;
   height: 36px;
   border: none;

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -10,6 +10,7 @@ import GroupMessageList from './GroupMessageList.vue'
 import GroupChatInput from './GroupChatInput.vue'
 import ProfileAvatar from '@/components/hermes/profiles/ProfileAvatar.vue'
 import PageSidebarNav from '@/components/layout/PageSidebarNav.vue'
+import SettingsCircuitBadge from '@/components/layout/SettingsCircuitBadge.vue'
 import { copyToClipboard } from '@/utils/clipboard'
 import type { Attachment } from '@/stores/hermes/chat'
 import type { RoomAgent } from '@/api/hermes/group-chat'
@@ -441,8 +442,8 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                         <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
                     </svg>
                     <span>{{ t('sidebar.settings') }}</span>
-                    <!-- <SettingsCircuitBadge /> -->
                 </button>
+                <SettingsCircuitBadge />
             </div>
         </div>
 
@@ -1180,10 +1181,14 @@ export default defineComponent({ components: { CreateRoomForm } })
 .page-sidebar-bottom {
     flex-shrink: 0;
     padding: 10px 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 
 .page-sidebar-menu-btn {
-    width: 100%;
+    flex: 1 1 auto;
+    width: auto;
     min-width: 0;
     height: 36px;
     border: none;

--- a/packages/client/src/components/layout/PageSidebarFooter.vue
+++ b/packages/client/src/components/layout/PageSidebarFooter.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
+import SettingsCircuitBadge from '@/components/layout/SettingsCircuitBadge.vue'
 
 const router = useRouter()
 const { t } = useI18n()
@@ -18,8 +19,8 @@ function openSettingsPage() {
         <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
       </svg>
       <span>{{ t('sidebar.settings') }}</span>
-      <!-- <SettingsCircuitBadge /> -->
     </button>
+    <SettingsCircuitBadge />
   </div>
 </template>
 
@@ -29,10 +30,14 @@ function openSettingsPage() {
 .page-sidebar-bottom {
   flex-shrink: 0;
   padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .page-sidebar-menu-btn {
-  width: 100%;
+  flex: 1 1 auto;
+  width: auto;
   min-width: 0;
   height: 36px;
   border: none;

--- a/packages/client/src/components/layout/SettingsCircuitBadge.vue
+++ b/packages/client/src/components/layout/SettingsCircuitBadge.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import { NTooltip } from 'naive-ui'
+</script>
+
 <template>
   <!-- Style 1: chip badge
   <svg class="settings-circuit-badge settings-circuit-badge--chip" viewBox="0 0 34 22" fill="none" aria-hidden="true">
@@ -26,25 +30,32 @@
     <circle class="settings-circuit-node" cx="27" cy="16" r="0.9" />
   </svg>
   -->
-  <svg class="settings-circuit-badge settings-circuit-badge--pcb" viewBox="0 0 36 22" fill="none" aria-hidden="true">
-    <rect class="settings-pcb-board" x="3" y="3" width="30" height="16" rx="3" />
-    <path class="settings-pcb-copper" d="M7 7h6v4h7v-3h9" />
-    <path class="settings-pcb-copper" d="M7 15h5v-3h5v4h12" />
-    <path class="settings-pcb-copper" d="M12 7v-2h8" />
-    <path class="settings-pcb-copper" d="M24 15v2h5" />
-    <path class="settings-pcb-current settings-pcb-current-main" d="M7 7h6v4h7v-3h9" pathLength="1" />
-    <path class="settings-pcb-current settings-pcb-current-main settings-pcb-current-late" d="M7 15h5v-3h5v4h12" pathLength="1" />
-    <path class="settings-pcb-current settings-pcb-current-branch" d="M12 7v-2h8" pathLength="1" />
-    <path class="settings-pcb-current settings-pcb-current-branch settings-pcb-current-late" d="M24 15v2h5" pathLength="1" />
-    <circle class="settings-pcb-pad settings-pcb-pad-live" cx="7" cy="7" r="1.2" />
-    <circle class="settings-pcb-pad" cx="13" cy="11" r="1" />
-    <circle class="settings-pcb-pad settings-pcb-pad-live" cx="20" cy="11" r="1.2" />
-    <circle class="settings-pcb-pad" cx="29" cy="8" r="1" />
-    <circle class="settings-pcb-pad settings-pcb-pad-live settings-pcb-pad-late" cx="17" cy="12" r="1.2" />
-    <circle class="settings-pcb-pad" cx="29" cy="15" r="1" />
-    <circle class="settings-pcb-via" cx="20" cy="5" r="0.8" />
-    <circle class="settings-pcb-via" cx="29" cy="17" r="0.8" />
-  </svg>
+  <NTooltip trigger="hover" placement="top">
+    <template #trigger>
+      <a class="settings-circuit-link" href="https://hermes-studio.ai/docs/hermes-esp32-intro/index.html" target="_blank" rel="noopener noreferrer" aria-label="小方盒" @click.stop>
+        <svg class="settings-circuit-badge settings-circuit-badge--pcb" viewBox="0 0 36 22" fill="none" aria-hidden="true">
+          <rect class="settings-pcb-board" x="3" y="3" width="30" height="16" rx="3" />
+          <path class="settings-pcb-copper" d="M7 7h6v4h7v-3h9" />
+          <path class="settings-pcb-copper" d="M7 15h5v-3h5v4h12" />
+          <path class="settings-pcb-copper" d="M12 7v-2h8" />
+          <path class="settings-pcb-copper" d="M24 15v2h5" />
+          <path class="settings-pcb-current settings-pcb-current-main" d="M7 7h6v4h7v-3h9" pathLength="1" />
+          <path class="settings-pcb-current settings-pcb-current-main settings-pcb-current-late" d="M7 15h5v-3h5v4h12" pathLength="1" />
+          <path class="settings-pcb-current settings-pcb-current-branch" d="M12 7v-2h8" pathLength="1" />
+          <path class="settings-pcb-current settings-pcb-current-branch settings-pcb-current-late" d="M24 15v2h5" pathLength="1" />
+          <circle class="settings-pcb-pad settings-pcb-pad-live" cx="7" cy="7" r="1.2" />
+          <circle class="settings-pcb-pad" cx="13" cy="11" r="1" />
+          <circle class="settings-pcb-pad settings-pcb-pad-live" cx="20" cy="11" r="1.2" />
+          <circle class="settings-pcb-pad" cx="29" cy="8" r="1" />
+          <circle class="settings-pcb-pad settings-pcb-pad-live settings-pcb-pad-late" cx="17" cy="12" r="1.2" />
+          <circle class="settings-pcb-pad" cx="29" cy="15" r="1" />
+          <circle class="settings-pcb-via" cx="20" cy="5" r="0.8" />
+          <circle class="settings-pcb-via" cx="29" cy="17" r="0.8" />
+        </svg>
+      </a>
+    </template>
+    小方盒
+  </NTooltip>
   <!-- Style 3: current scan line
   <svg class="settings-circuit-badge settings-circuit-badge--scan" viewBox="0 0 36 20" fill="none" aria-hidden="true">
     <path class="settings-scan-track" d="M3 10h6l3-5h7l3 10h5l3-5h3" />
@@ -66,10 +77,17 @@
   flex: 0 0 auto;
   width: 34px;
   height: 20px;
-  margin-left: auto;
   color: #d6a019;
   overflow: visible;
   filter: drop-shadow(0 0 4px rgba(214, 160, 25, 0.45));
+}
+
+.settings-circuit-link {
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+  color: inherit;
+  text-decoration: none;
 }
 
 .settings-circuit-badge--scan {
@@ -147,15 +165,15 @@
 .settings-pcb-current {
   stroke-width: 1.75;
   stroke-dasharray: 0.18 0.82;
-  /* animation: settings-circuit-flow 1.35s linear infinite; */
+  animation: settings-circuit-flow 1.35s linear infinite;
 }
 
 .settings-pcb-current-branch {
-  /* animation-duration: 1.8s; */
+  animation-duration: 1.8s;
 }
 
 .settings-pcb-current-late {
-  /* animation-delay: -0.65s; */
+  animation-delay: -0.65s;
 }
 
 .settings-pcb-pad,
@@ -171,11 +189,11 @@
 
 .settings-pcb-pad-live {
   fill: currentColor;
-  /* animation: settings-circuit-node 1.35s ease-in-out infinite; */
+  animation: settings-circuit-node 1.35s ease-in-out infinite;
 }
 
 .settings-pcb-pad-late {
-  /* animation-delay: -0.65s; */
+  animation-delay: -0.65s;
 }
 
 .settings-circuit-badge-shell {

--- a/packages/esp32-c3/src/main.cpp
+++ b/packages/esp32-c3/src/main.cpp
@@ -104,6 +104,7 @@ bool es8311Ready = false;
 bool bootWasPressed = false;
 bool bootLongPressHandled = false;
 bool bootClickPending = false;
+bool bootSecondClickStarted = false;
 bool bootInputArmed = false;
 uint32_t lastOledAtMs = 0;
 uint32_t restartAtMs = 0;
@@ -146,6 +147,7 @@ bool mcuInteractionActive = false;
 bool mcuAudioPlaying = false;
 bool mcuVoiceAfterAudioInterrupt = false;
 bool mcuAudioStopOnlyAfterInterrupt = false;
+bool mcuSessionClearAfterAudioInterrupt = false;
 bool voiceRecordHeardSpeech = false;
 uint32_t mcuInteractionUpdatedAtMs = 0;
 uint32_t mcuAudioStartedAtMs = 0;
@@ -177,6 +179,7 @@ void triggerBootVoiceTurn();
 bool broadcastMcuInterrupt(const String &interactionId, const String &reason);
 void clearMcuAudioQueue();
 void finishMcuAudio(bool interrupted);
+void clearMcuSessionByButton();
 void disconnectMcuSocketClient();
 void connectMcuSocketClient();
 void mcuSocketLoop();
@@ -1098,28 +1101,58 @@ bool shouldInterruptAudioForVoice() {
   bool pressed = digitalRead(kPinBoot) == LOW;
   uint32_t now = millis();
   if (!bootInputArmed) return false;
-  if (!pressed) {
-    if (audioInterruptPressStartedAtMs != 0 &&
-        now - audioInterruptPressStartedAtMs >= kBootDebounceMs &&
-        now - audioInterruptPressStartedAtMs < kBootLongPressMs) {
-      mcuAudioStopOnlyAfterInterrupt = true;
-      lastBootButtonAtMs = now;
-      audioInterruptPressStartedAtMs = 0;
-      return true;
+
+  if (pressed) {
+    if (audioInterruptPressStartedAtMs == 0) {
+      if (bootClickPending && now - bootClickPendingAtMs <= kBootDoubleClickMs) {
+        bootSecondClickStarted = true;
+      }
+      audioInterruptPressStartedAtMs = now;
+      return false;
     }
+    if (now - audioInterruptPressStartedAtMs < kBootLongPressMs) return false;
+
+    bootClickPending = false;
+    bootSecondClickStarted = false;
+    mcuVoiceAfterAudioInterrupt = true;
+    mcuAudioStopOnlyAfterInterrupt = false;
+    mcuSessionClearAfterAudioInterrupt = false;
+    lastBootButtonAtMs = now;
     audioInterruptPressStartedAtMs = 0;
-    return false;
+    return true;
   }
-  if (audioInterruptPressStartedAtMs == 0) {
-    audioInterruptPressStartedAtMs = now;
-    return false;
+
+  if (audioInterruptPressStartedAtMs != 0) {
+    uint32_t heldMs = now - audioInterruptPressStartedAtMs;
+    audioInterruptPressStartedAtMs = 0;
+    if (heldMs >= kBootDebounceMs && heldMs < kBootLongPressMs) {
+      if (bootClickPending && (bootSecondClickStarted || now - bootClickPendingAtMs <= kBootDoubleClickMs)) {
+        bootClickPending = false;
+        bootSecondClickStarted = false;
+        mcuAudioStopOnlyAfterInterrupt = false;
+        mcuSessionClearAfterAudioInterrupt = true;
+        lastBootButtonAtMs = now;
+        return true;
+      }
+      bootClickPending = true;
+      bootSecondClickStarted = false;
+      bootClickPendingAtMs = now;
+    }
   }
-  if (now - audioInterruptPressStartedAtMs < kBootLongPressMs) return false;
-  mcuVoiceAfterAudioInterrupt = true;
-  mcuAudioStopOnlyAfterInterrupt = false;
-  lastBootButtonAtMs = now;
-  audioInterruptPressStartedAtMs = 0;
-  return true;
+
+  if (bootClickPending && !bootSecondClickStarted && now - bootClickPendingAtMs > kBootDoubleClickMs) {
+    bootClickPending = false;
+    mcuAudioStopOnlyAfterInterrupt = true;
+    mcuSessionClearAfterAudioInterrupt = false;
+    lastBootButtonAtMs = now;
+    return true;
+  }
+
+  if (!bootClickPending) {
+    bootSecondClickStarted = false;
+  }
+
+  return false;
 }
 
 void initAudioHardware() {
@@ -2841,6 +2874,14 @@ void startNextMcuAudio() {
     String interruptedInteractionId = mcuCurrentAudio.interactionId;
     bool completionManagedByServer = mcuCurrentAudio.completionManagedByServer;
     finishMcuAudio(!played);
+    if (mcuSessionClearAfterAudioInterrupt) {
+      mcuSessionClearAfterAudioInterrupt = false;
+      mcuAudioStopOnlyAfterInterrupt = false;
+      mcuVoiceAfterAudioInterrupt = false;
+      clearMcuAudioQueue();
+      clearMcuSessionByButton();
+      return;
+    }
     if (mcuVoiceAfterAudioInterrupt) {
       mcuVoiceAfterAudioInterrupt = false;
       broadcastMcuInterrupt(interruptedInteractionId, F("listen"));
@@ -2932,6 +2973,7 @@ void stopMcuAudioQueueByButton() {
   clearMcuAudioQueue();
   mcuVoiceAfterAudioInterrupt = false;
   mcuAudioStopOnlyAfterInterrupt = false;
+  mcuSessionClearAfterAudioInterrupt = false;
   broadcastMcuInterrupt(interactionId, F("button"));
   markMcuInteraction(interactionId, F("aborted"), F(""));
   broadcastMcuStatus();
@@ -2968,6 +3010,7 @@ void clearMcuSessionByButton() {
   clearMcuAudioQueue();
   mcuVoiceAfterAudioInterrupt = false;
   mcuAudioStopOnlyAfterInterrupt = false;
+  mcuSessionClearAfterAudioInterrupt = false;
   broadcastMcuInterrupt(interactionId, F("session_clear"));
   if (!broadcastMcuSessionClear(interactionId)) {
     markMcuInteraction(interactionId, F("failed"), F("SOCKET OFF"));
@@ -3680,6 +3723,7 @@ void handleBootButton() {
     bootWasPressed = false;
     bootLongPressHandled = false;
     bootClickPending = false;
+    bootSecondClickStarted = false;
     audioInterruptPressStartedAtMs = 0;
     if (now < kBootInputArmDelayMs || bootPressed) {
       bootReleaseStartedAtMs = 0;
@@ -3697,6 +3741,16 @@ void handleBootButton() {
   }
 
   if (bootPressed && !bootWasPressed && now - lastBootButtonAtMs > kBootDebounceMs) {
+    if (bootClickPending && now - bootClickPendingAtMs > kBootDoubleClickMs) {
+      bootClickPending = false;
+      bootSecondClickStarted = false;
+      lastBootButtonAtMs = now;
+      stopMcuAudioQueueByButton();
+      return;
+    }
+    if (bootClickPending && now - bootClickPendingAtMs <= kBootDoubleClickMs) {
+      bootSecondClickStarted = true;
+    }
     bootWasPressed = true;
     bootLongPressHandled = false;
     bootPressedAtMs = now;
@@ -3707,6 +3761,7 @@ void handleBootButton() {
       now - bootPressedAtMs >= kBootLongPressMs) {
     bootLongPressHandled = true;
     bootClickPending = false;
+    bootSecondClickStarted = false;
     lastBootButtonAtMs = now;
     triggerBootVoiceTurn();
     return;
@@ -3716,19 +3771,22 @@ void handleBootButton() {
     bootWasPressed = false;
     uint32_t heldMs = now - bootPressedAtMs;
     if (!bootLongPressHandled && heldMs >= kBootDebounceMs) {
-      if (bootClickPending && now - bootClickPendingAtMs <= kBootDoubleClickMs) {
+      if (bootClickPending && (bootSecondClickStarted || now - bootClickPendingAtMs <= kBootDoubleClickMs)) {
         bootClickPending = false;
+        bootSecondClickStarted = false;
         lastBootButtonAtMs = now;
         clearMcuSessionByButton();
       } else {
         bootClickPending = true;
+        bootSecondClickStarted = false;
         bootClickPendingAtMs = now;
       }
     }
   }
 
-  if (bootClickPending && now - bootClickPendingAtMs > kBootDoubleClickMs) {
+  if (!bootWasPressed && bootClickPending && now - bootClickPendingAtMs > kBootDoubleClickMs) {
     bootClickPending = false;
+    bootSecondClickStarted = false;
     lastBootButtonAtMs = now;
     stopMcuAudioQueueByButton();
   }

--- a/packages/server/src/services/global-agent/outbound-relay-client.ts
+++ b/packages/server/src/services/global-agent/outbound-relay-client.ts
@@ -81,6 +81,7 @@ const MCU_TTS_OPTIONS = {
   mcuPlayback: true,
   sampleRate: MCU_TTS_SAMPLE_RATE,
 } as const
+const MCU_INTERRUPT_DEBOUNCE_MS = 280
 const MCU_TTS_FAILED_PROMPT_TEXT = '当前文字转语音失败了，请配置下文字转语音再使用哦'
 const MCU_TTS_FAILED_PROMPT_PCM_URL =
   'https://ekko-hermes-studio.oss-cn-beijing.aliyuncs.com/tts-synthesize-failed-xiaohe.s16le.pcm'
@@ -206,6 +207,7 @@ class PlainWebSocketRelayClient {
   private readonly sessionRuns = new Map<string, { interactionId: string; socket: Socket }>()
   private readonly interruptedInteractions = new Set<string>()
   private readonly recentlyInterruptedSessions = new Map<string, number>()
+  private readonly pendingInterrupts = new Map<string, { profile: string; interactionId: string; timer: NodeJS.Timeout }>()
 
   constructor(private readonly options: OutboundRelayClientOptions) {}
 
@@ -223,6 +225,7 @@ class PlainWebSocketRelayClient {
     }
     this.socket?.close()
     this.socket = null
+    this.cancelPendingInterrupts()
     this.rejectAudioWaiters(new Error('MCU websocket stopped'))
   }
 
@@ -381,7 +384,7 @@ class PlainWebSocketRelayClient {
     if (event.type === 'mcu.interrupt') {
       const interactionId = typeof event.interactionId === 'string' ? event.interactionId.trim() : ''
       const profile = typeof event.profile === 'string' && event.profile.trim() ? event.profile.trim() : 'default'
-      this.interruptMcuSession(profile, interactionId)
+      this.scheduleMcuInterrupt(profile, interactionId)
       this.sendJson({ type: 'mcu.interrupt.ack', interactionId, profile })
       return
     }
@@ -737,6 +740,47 @@ class PlainWebSocketRelayClient {
     this.sessionRuns.delete(active.sessionId)
   }
 
+  private scheduleMcuInterrupt(profile: string, interactionId: string): void {
+    const sessionId = this.mcuSessionId(profile)
+    this.cancelPendingInterrupt(sessionId)
+    const timer = setTimeout(() => {
+      this.pendingInterrupts.delete(sessionId)
+      this.interruptMcuSession(profile, interactionId)
+    }, MCU_INTERRUPT_DEBOUNCE_MS)
+    this.pendingInterrupts.set(sessionId, { profile, interactionId, timer })
+  }
+
+  private cancelPendingInterrupt(sessionId: string): void {
+    const pending = this.pendingInterrupts.get(sessionId)
+    if (!pending) return
+    clearTimeout(pending.timer)
+    this.pendingInterrupts.delete(sessionId)
+  }
+
+  private cancelPendingInterrupts(): void {
+    for (const pending of this.pendingInterrupts.values()) {
+      clearTimeout(pending.timer)
+    }
+    this.pendingInterrupts.clear()
+  }
+
+  private forgetMcuSessionRun(sessionId: string, interactionId?: string): void {
+    const sessionRun = this.sessionRuns.get(sessionId)
+    if (sessionRun) {
+      this.interruptedInteractions.add(sessionRun.interactionId)
+      this.activeRuns.delete(sessionRun.interactionId)
+      this.sessionRuns.delete(sessionId)
+    }
+    if (interactionId) {
+      this.interruptedInteractions.add(interactionId)
+      const active = this.activeRuns.get(interactionId)
+      if (active?.sessionId === sessionId) {
+        this.activeRuns.delete(interactionId)
+        this.sessionRuns.delete(sessionId)
+      }
+    }
+  }
+
   private interruptMcuSession(profile: string, interactionId?: string): void {
     const sessionId = this.mcuSessionId(profile)
     this.recentlyInterruptedSessions.set(sessionId, Date.now())
@@ -758,7 +802,8 @@ class PlainWebSocketRelayClient {
 
   private clearMcuSession(profile: string, interactionId?: string): void {
     const sessionId = this.mcuSessionId(profile)
-    this.interruptMcuSession(profile, interactionId)
+    this.cancelPendingInterrupt(sessionId)
+    this.forgetMcuSessionRun(sessionId, interactionId)
     const cleared = getChatRunServer()?.clearSessionHistory(sessionId)
     const deleted = cleared?.deleted ?? clearSessionMessages(sessionId)
     const memoryCleared = cleared?.hadMemoryState ?? false

--- a/packages/server/src/services/global-agent/server.ts
+++ b/packages/server/src/services/global-agent/server.ts
@@ -26,6 +26,7 @@ const MCU_TTS_OPTIONS = {
   mcuPlayback: true,
   sampleRate: MCU_TTS_SAMPLE_RATE,
 } as const
+const MCU_INTERRUPT_DEBOUNCE_MS = 280
 const MCU_TTS_FAILED_PROMPT_TEXT = '当前文字转语音失败了，请配置下文字转语音再使用哦'
 const MCU_TTS_FAILED_PROMPT_PCM_URL =
   'https://ekko-hermes-studio.oss-cn-beijing.aliyuncs.com/tts-synthesize-failed-xiaohe.s16le.pcm'
@@ -166,6 +167,13 @@ interface McuVoiceStreamState {
   bytes: number
   chunks: Buffer[]
   userToken: string
+}
+
+interface PendingMcuInterrupt {
+  clientId: string
+  profile: string
+  interactionId: string
+  timer: ReturnType<typeof setTimeout>
 }
 
 interface NormalizedBody {
@@ -395,6 +403,7 @@ export class GlobalAgentServer {
   private readonly mcuVoiceStreams = new Map<string, McuVoiceStreamState>()
   private readonly interruptedMcuInteractions = new Set<string>()
   private readonly recentlyInterruptedMcuSessions = new Map<string, number>()
+  private readonly pendingMcuInterrupts = new Map<string, PendingMcuInterrupt>()
   private readonly authToken = randomBytes(32).toString('hex')
   private readonly localBaseUrl: string
   private readonly fetchImpl: typeof fetch
@@ -688,6 +697,7 @@ export class GlobalAgentServer {
       if (this.clients.get(clientId)?.id === socket.id) {
         this.clients.delete(clientId)
       }
+      this.cancelPendingMcuInterruptsForClient(clientId)
       this.closeInboundSocketsForOwner(socket.id)
       logger.info('[global-agent] client disconnected id=%s socket=%s', clientId, socket.id)
     })
@@ -1188,6 +1198,48 @@ export class GlobalAgentServer {
     this.mcuSessionRuns.delete(active.sessionId)
   }
 
+  private scheduleMcuInterrupt(clientId: string, profile: string, interactionId: string): void {
+    const sessionId = this.mcuSessionId(clientId, profile)
+    this.cancelPendingMcuInterrupt(sessionId)
+    const timer = setTimeout(() => {
+      this.pendingMcuInterrupts.delete(sessionId)
+      this.interruptMcuSession(clientId, profile, interactionId)
+    }, MCU_INTERRUPT_DEBOUNCE_MS)
+    this.pendingMcuInterrupts.set(sessionId, { clientId, profile, interactionId, timer })
+  }
+
+  private cancelPendingMcuInterrupt(sessionId: string): void {
+    const pending = this.pendingMcuInterrupts.get(sessionId)
+    if (!pending) return
+    clearTimeout(pending.timer)
+    this.pendingMcuInterrupts.delete(sessionId)
+  }
+
+  private cancelPendingMcuInterruptsForClient(clientId: string): void {
+    for (const [sessionId, pending] of this.pendingMcuInterrupts.entries()) {
+      if (pending.clientId !== clientId) continue
+      clearTimeout(pending.timer)
+      this.pendingMcuInterrupts.delete(sessionId)
+    }
+  }
+
+  private forgetMcuSessionRun(sessionId: string, interactionId?: string): void {
+    const sessionRun = this.mcuSessionRuns.get(sessionId)
+    if (sessionRun) {
+      this.interruptedMcuInteractions.add(sessionRun.interactionId)
+      this.activeMcuRuns.delete(sessionRun.interactionId)
+      this.mcuSessionRuns.delete(sessionId)
+    }
+    if (interactionId) {
+      this.interruptedMcuInteractions.add(interactionId)
+      const active = this.activeMcuRuns.get(interactionId)
+      if (active?.sessionId === sessionId) {
+        this.activeMcuRuns.delete(interactionId)
+        this.mcuSessionRuns.delete(sessionId)
+      }
+    }
+  }
+
   private interruptMcuSession(clientId: string, profile: string, interactionId?: string): void {
     const sessionId = this.mcuSessionId(clientId, profile)
     this.recentlyInterruptedMcuSessions.set(sessionId, Date.now())
@@ -1206,7 +1258,8 @@ export class GlobalAgentServer {
 
   private clearMcuSession(clientId: string, profile: string, interactionId?: string): void {
     const sessionId = this.mcuSessionId(clientId, profile)
-    this.interruptMcuSession(clientId, profile, interactionId)
+    this.cancelPendingMcuInterrupt(sessionId)
+    this.forgetMcuSessionRun(sessionId, interactionId)
     const chatRunServer = getChatRunServer()
     if (!chatRunServer) {
       logger.error({ clientId, sessionId }, '[global-agent] cannot clear MCU chat session: chat-run server is unavailable')
@@ -1288,7 +1341,7 @@ export class GlobalAgentServer {
     if (event === 'mcu.interrupt') {
       const interactionId = typeof payload.interactionId === 'string' ? payload.interactionId.trim() : ''
       const profile = typeof payload.profile === 'string' && payload.profile.trim() ? payload.profile.trim() : 'default'
-      this.interruptMcuSession(clientId, profile, interactionId)
+      this.scheduleMcuInterrupt(clientId, profile, interactionId)
       this.emitMcuEvent({ type: 'mcu.interrupt.ack', interactionId, profile }, { clientId })
       return
     }

--- a/packages/website/public/docs/hermes-esp32-intro/index.html
+++ b/packages/website/public/docs/hermes-esp32-intro/index.html
@@ -204,6 +204,28 @@
       font-size: clamp(17px, 2vw, 22px);
     }
 
+    .price-row {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 12px;
+      margin-top: 18px;
+      font-weight: 900;
+    }
+
+    .price-original {
+      color: var(--soft);
+      font-size: 16px;
+      text-decoration: line-through;
+      text-decoration-thickness: 2px;
+    }
+
+    .price-presale {
+      color: var(--warn);
+      font-size: clamp(24px, 3vw, 34px);
+      line-height: 1.1;
+    }
+
     .hero-actions {
       display: flex;
       flex-wrap: wrap;
@@ -782,9 +804,14 @@
           <span class="label">ESP32-C3 + Hermes Studio</span>
           <h1>桌面 AI 对话小方盒</h1>
           <p>带小屏、麦克风、扬声器和实体按键，通过局域网连接电脑端 Hermes Studio。</p>
+          <div class="price-row" aria-label="价格">
+            <span class="price-original">原价 99</span>
+            <span class="price-presale">预订价 88</span>
+          </div>
           <div class="hero-actions">
             <a class="btn btn-primary" href="#tutorial">查看使用教程</a>
-            <a class="btn btn-secondary" href="#notice">购买前须知</a>
+            <a class="btn btn-secondary" href="https://m.tb.cn/h.RJXBNRb?tk=mOCHgSTIunn" target="_blank" rel="noopener noreferrer">闲鱼购买</a>
+            <a class="btn btn-secondary" href="https://www.xiaohongshu.com/discovery/item/6a392766000000000603388a?source=webshare&amp;xhsshare=pc_web&amp;xsec_token=CBIdoSWLtVJK2hb23fBG8KsuTMVKROk6O6NR-ornGx584=&amp;xsec_source=pc_share" target="_blank" rel="noopener noreferrer">小红书购买</a>
           </div>
         </div>
 

--- a/tests/server/global-agent-server.test.ts
+++ b/tests/server/global-agent-server.test.ts
@@ -841,6 +841,56 @@ describe('GlobalAgentServer', () => {
     })
   })
 
+  it('cancels a pending MCU interrupt when session clear arrives in the double-click window', async () => {
+    vi.useFakeTimers()
+    try {
+      authMocks.authenticateUserToken.mockResolvedValue({ id: 7, username: 'ada', role: 'user' })
+      authMocks.userCanAccessProfile.mockReturnValue(true)
+      const nsp = createMockNamespace()
+      const io = { of: vi.fn(() => nsp) }
+      const { GlobalAgentServer } = await import('../../packages/server/src/services/global-agent/server')
+
+      const server = new GlobalAgentServer(io as any)
+      server.init()
+
+      const agentSocket = createMockSocket('agent-socket', { token: server.getAuthToken(), instanceId: 'device-1' })
+      await new Promise<void>((resolve, reject) => {
+        nsp.__middleware[0](agentSocket, (err?: Error) => err ? reject(err) : resolve())
+      })
+      nsp.__handlers.get('connection')?.(agentSocket)
+
+      const runSocket = { emit: vi.fn() }
+      ;(server as any).mcuSessionRuns.set('mcu-device-1-research', {
+        interactionId: 'run-1',
+        socket: runSocket,
+      })
+
+      agentSocket.__handlers.get('mcu.interrupt')?.({
+        interactionId: 'run-1',
+        profile: 'research',
+      })
+      expect(runSocket.emit).not.toHaveBeenCalled()
+
+      agentSocket.__handlers.get('mcu.session.clear')?.({
+        interactionId: 'clear-1',
+        profile: 'research',
+      })
+
+      await vi.advanceTimersByTimeAsync(300)
+
+      expect(runSocket.emit).not.toHaveBeenCalled()
+      expect(chatRunMocks.clearSessionHistory).toHaveBeenCalledWith('mcu-device-1-research')
+      expect(agentSocket.emit).toHaveBeenCalledWith('mcu.session.cleared', expect.objectContaining({
+        type: 'mcu.session.cleared',
+        interactionId: 'clear-1',
+        profile: 'research',
+        sessionId: 'mcu-device-1-research',
+      }))
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('does not silently clear only the database when chat-run memory is unavailable', async () => {
     chatRunMocks.getChatRunServer.mockReturnValue(null)
     authMocks.authenticateUserToken.mockResolvedValue({ id: 7, username: 'ada', role: 'user' })


### PR DESCRIPTION
## What changed

- Fixed ESP32 BOOT button double-click handling so the second press does not let the first click fire a stop/interrupt action early.
- Added server-side MCU interrupt debouncing so an old-firmware `mcu.interrupt` followed by `mcu.session.clear` cancels the pending abort before clearing session history.
- Updated the ESP32 intro page with purchase links and presale pricing.
- Restored the animated Xiao Fang He sidebar badge, split it from the settings button, added a tooltip, and linked it to the ESP32 intro page.

## Why

The MCU double-click clear action could be interpreted as a single-click interrupt when the first click timeout elapsed while the second press was still held. The UI and docs updates expose the Xiao Fang He entry point and current purchase options.

## Validation

- `npm run build`
- `npm run harness:check`
- `npm run test -- tests/server/global-agent-server.test.ts tests/server/outbound-relay-client.test.ts`
- `pio run`
