### PR TITLE
Install Feishu (Lark) adapter dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,59 @@ ENV HERMES_HOME=/home/agent/.hermes
 ENV HERMES_WEB_UI_MANAGED_GATEWAY=1
 ENV PATH=/opt/hermes/.venv/bin:$PATH
 
+ARG BASE_IMAGE=nousresearch/hermes-agent:latest
+FROM ${BASE_IMAGE}
+
+ARG NODE_VERSION=24.15.0
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    ffmpeg \
+    make \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ARCH=$(dpkg --print-architecture) \
+    && if [ "$ARCH" = "amd64" ]; then NODE_ARCH="x64"; else NODE_ARCH="$ARCH"; fi \
+    && echo "Downloading Node.js v${NODE_VERSION} for ${NODE_ARCH}" \
+    && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.gz" \
+       -o /tmp/node.tar.gz \
+    && rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack \
+       /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+    && tar -xzf /tmp/node.tar.gz -C /usr/local --strip-components=1 \
+    && rm -f /tmp/node.tar.gz \
+    && node --version \
+    && npm --version
+
+WORKDIR /app
+
+COPY package*.json ./
+# Increase Node.js memory limit to prevent OOM during build
+ENV NODE_OPTIONS=--max-old-space-size=4096
+RUN npm ci --ignore-scripts && npm rebuild node-pty
+
+COPY . .
+
+RUN npm run build && npm prune --omit=dev
+
+ENV NODE_ENV=production
+ENV HOME=/home/agent
+ENV HERMES_HOME=/home/agent/.hermes
+ENV HERMES_WEB_UI_MANAGED_GATEWAY=1
+ENV PATH=/opt/hermes/.venv/bin:$PATH
+
+# Install Feishu (Lark) adapter dependencies so the Feishu platform works out-of-the-box
+RUN /opt/hermes/.venv/bin/python -m ensurepip && \
+    /opt/hermes/.venv/bin/python -m pip install 'hermes-agent[feishu]'
+
+EXPOSE 6060
+
+# 强制覆盖基础镜像的默认启动脚本，让镜像本身具备独立运行的能力
+ENTRYPOINT ["node", "dist/server/index.js"]
+CMD []
 EXPOSE 6060
 
 # 强制覆盖基础镜像的默认启动脚本，让镜像本身具备独立运行的能力


### PR DESCRIPTION
Install Feishu (Lark) adapter dependencies so the Feishu platform works out-of-the-box
构建docker镜像时就把 lark-oapi 等飞书依赖安装到 /opt/hermes/.venv/ 里，容器启动后飞书平台直接就能用，不用再手动安装依赖了。