### PR TITLE
[codex] fix desktop browser runtime resolution

### DIFF
--- a/packages/client/src/components/hermes/workflow/WorkflowAgentNode.vue
+++ b/packages/client/src/components/hermes/workflow/WorkflowAgentNode.vue
@@ -642,17 +642,17 @@ async function uploadImages(files: File[]) {
 }
 
 .workflow-handle {
-  width: 12px;
-  height: 12px;
+  width: 16px;
+  height: 16px;
   border: 2px solid $bg-card;
   background: var(--accent-info);
 }
 
 .input-handle {
-  left: -7px;
+  left: -9px;
 }
 
 .output-handle {
-  right: -7px;
+  right: -9px;
 }
 </style>

--- a/packages/desktop/scripts/install-hermes.mjs
+++ b/packages/desktop/scripts/install-hermes.mjs
@@ -56,8 +56,10 @@ const EXTRA_PYTHON_PACKAGES = splitPackageList(
 const BROWSER_PACKAGES = splitPackageList(
   process.env.HERMES_BROWSER_PACKAGES || 'agent-browser@^0.26.0 @askjo/camofox-browser@^1.5.2',
 )
-const WINDOWS_CHROME_FOR_TESTING_VERSION = (
-  process.env.HERMES_WINDOWS_CHROME_FOR_TESTING_VERSION || '149.0.7827.55'
+const CHROME_FOR_TESTING_VERSION = (
+  process.env.HERMES_CHROME_FOR_TESTING_VERSION
+  || process.env.HERMES_WINDOWS_CHROME_FOR_TESTING_VERSION
+  || '149.0.7827.55'
 ).trim()
 const SKIP_BROWSER_RUNTIME = process.env.HERMES_SKIP_BROWSER_RUNTIME === '1'
   || process.env.HERMES_SKIP_BROWSER_RUNTIME?.toLowerCase() === 'true'
@@ -114,10 +116,6 @@ function runInvocation(invocation, args, options = {}) {
 
 function optionalRunInvocation(invocation, args, options = {}) {
   return optionalRun(invocation.command, [...invocation.argsPrefix, ...args], options)
-}
-
-function powerShellLiteral(value) {
-  return `'${String(value).replace(/'/g, "''")}'`
 }
 
 function pythonBuildEnv() {
@@ -273,20 +271,28 @@ function findBundledBrowserExecutable() {
   return findBrowserInstallInHome(AGENT_BROWSER_HOME)?.executable ?? null
 }
 
-function shouldPinWindowsChromeForTesting() {
-  if (TARGET_OS !== 'win32') return false
-  if (!WINDOWS_CHROME_FOR_TESTING_VERSION) return false
-  return !['0', 'false', 'off', 'auto'].includes(WINDOWS_CHROME_FOR_TESTING_VERSION.toLowerCase())
+function shouldPinChromeForTesting() {
+  if (!CHROME_FOR_TESTING_VERSION) return false
+  return !['0', 'false', 'off', 'auto'].includes(CHROME_FOR_TESTING_VERSION.toLowerCase())
 }
 
-function windowsChromeForTestingUrl() {
+function chromeForTestingPlatform() {
+  if (TARGET_OS === 'win32' && TARGET_ARCH === 'x64') return 'win64'
+  if (TARGET_OS === 'darwin' && TARGET_ARCH === 'arm64') return 'mac-arm64'
+  if (TARGET_OS === 'darwin' && TARGET_ARCH === 'x64') return 'mac-x64'
+  if (TARGET_OS === 'linux' && TARGET_ARCH === 'x64') return 'linux64'
+  throw new Error(`Pinned Chrome for Testing is not configured for ${TARGET_OS}-${TARGET_ARCH}`)
+}
+
+function chromeForTestingUrl() {
+  if (process.env.HERMES_CHROME_FOR_TESTING_URL?.trim()) {
+    return process.env.HERMES_CHROME_FOR_TESTING_URL.trim()
+  }
   if (process.env.HERMES_WINDOWS_CHROME_FOR_TESTING_URL?.trim()) {
     return process.env.HERMES_WINDOWS_CHROME_FOR_TESTING_URL.trim()
   }
-  if (TARGET_ARCH !== 'x64') {
-    throw new Error(`Pinned Windows Chrome for Testing is only configured for x64, got ${TARGET_ARCH}`)
-  }
-  return `https://storage.googleapis.com/chrome-for-testing-public/${WINDOWS_CHROME_FOR_TESTING_VERSION}/win64/chrome-win64.zip`
+  const platform = chromeForTestingPlatform()
+  return `https://storage.googleapis.com/chrome-for-testing-public/${CHROME_FOR_TESTING_VERSION}/${platform}/chrome-${platform}.zip`
 }
 
 function removeChromeBundles() {
@@ -300,41 +306,58 @@ function removeChromeBundles() {
   }
 }
 
-function pinWindowsChromeForTestingBundle() {
-  if (!shouldPinWindowsChromeForTesting()) return
+function extractChromeForTestingArchive(url, zipPath, extractDir) {
+  run(pyBin, [
+    '-c',
+    [
+      'import sys',
+      'import urllib.request',
+      'import zipfile',
+      'url, zip_path, extract_dir = sys.argv[1:4]',
+      'urllib.request.urlretrieve(url, zip_path)',
+      'with zipfile.ZipFile(zip_path) as archive:',
+      '    archive.extractall(extract_dir)',
+    ].join('\n'),
+    url,
+    zipPath,
+    extractDir,
+  ])
+}
+
+function extractedChromeBundleDir(extractDir) {
+  const entries = readdirSync(extractDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory() && entry.name.startsWith('chrome-'))
+    .map(entry => join(extractDir, entry.name))
+  if (entries.length === 0) return null
+  return entries[0]
+}
+
+function pinChromeForTestingBundle() {
+  if (!shouldPinChromeForTesting()) return
 
   const targetBrowsersDir = join(AGENT_BROWSER_HOME, 'browsers')
-  const targetBundleDir = join(targetBrowsersDir, `chrome-${WINDOWS_CHROME_FOR_TESTING_VERSION}`)
+  const targetBundleDir = join(targetBrowsersDir, `chrome-${CHROME_FOR_TESTING_VERSION}`)
   const tmpRoot = mkdtempSync(join(tmpdir(), 'hermes-cft-'))
   const zipPath = join(tmpRoot, 'chrome.zip')
   const extractDir = join(tmpRoot, 'extract')
-  const url = windowsChromeForTestingUrl()
+  const url = chromeForTestingUrl()
 
   try {
-    console.log(`→ Pinning Windows Chrome for Testing ${WINDOWS_CHROME_FOR_TESTING_VERSION}`)
+    console.log(`→ Pinning Chrome for Testing ${CHROME_FOR_TESTING_VERSION} for ${TARGET_OS}-${TARGET_ARCH}`)
     mkdirSync(extractDir, { recursive: true })
-    run('powershell.exe', [
-      '-NoProfile',
-      '-ExecutionPolicy',
-      'Bypass',
-      '-Command',
-      [
-        '$ProgressPreference = "SilentlyContinue"',
-        `Invoke-WebRequest -Uri ${powerShellLiteral(url)} -OutFile ${powerShellLiteral(zipPath)}`,
-        `Expand-Archive -LiteralPath ${powerShellLiteral(zipPath)} -DestinationPath ${powerShellLiteral(extractDir)} -Force`,
-      ].join('; '),
-    ])
+    extractChromeForTestingArchive(url, zipPath, extractDir)
 
-    const executable = findBrowserExecutableUnder(extractDir, bundledBrowserExecutableNames())
+    const bundleDir = extractedChromeBundleDir(extractDir)
+    const executable = bundleDir ? findBrowserExecutableUnder(bundleDir, bundledBrowserExecutableNames()) : null
     if (!executable) {
-      console.error(`Pinned Chrome for Testing archive did not contain chrome.exe: ${url}`)
+      console.error(`Pinned Chrome for Testing archive did not contain a browser executable: ${url}`)
       process.exit(1)
     }
 
     removeChromeBundles()
     mkdirSync(targetBrowsersDir, { recursive: true })
-    cpSync(dirname(executable), targetBundleDir, { recursive: true, force: true, verbatimSymlinks: true })
-    console.log(`✓ pinned Windows Chrome for Testing at ${targetBundleDir}`)
+    cpSync(bundleDir, targetBundleDir, { recursive: true, force: true, verbatimSymlinks: true })
+    console.log(`✓ pinned Chrome for Testing at ${targetBundleDir}`)
   } finally {
     rmSync(tmpRoot, { recursive: true, force: true })
   }
@@ -432,7 +455,7 @@ function installBrowserRuntime() {
 
   console.log(`→ Installing Chromium for bundled agent-browser at ${AGENT_BROWSER_HOME}`)
   runInvocation(commandInvocation(ab), ['install'], { env: browserRuntimeEnv() })
-  pinWindowsChromeForTestingBundle()
+  pinChromeForTestingBundle()
 
   const browserExecutable = ensureBundledBrowserExecutable()
   if (!browserExecutable) {

--- a/packages/desktop/src/main/hermes-cli.ts
+++ b/packages/desktop/src/main/hermes-cli.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process'
 import { existsSync, mkdirSync } from 'node:fs'
 import { delimiter, dirname, join } from 'node:path'
 import {
-  bundledBrowserExecutable,
+  bundledAgentBrowserHome,
   bundledGit,
   bundledNode,
   bundledPython,
@@ -62,7 +62,7 @@ export async function runBundledHermesCli(args: string[]): Promise<number> {
     inheritedPath,
   ].filter(Boolean).join(delimiter)
   const gitBin = bundledGit()
-  const browserExecutable = process.env.AGENT_BROWSER_EXECUTABLE_PATH?.trim() || bundledBrowserExecutable()
+  const browserExecutableOverride = process.env.AGENT_BROWSER_EXECUTABLE_PATH?.trim()
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     HERMES_DESKTOP: 'true',
@@ -72,8 +72,8 @@ export async function runBundledHermesCli(args: string[]): Promise<number> {
     HERMES_AGENT_ROOT: pythonDir(),
     HERMES_AGENT_NODE: bundledNode(),
     HERMES_AGENT_NODE_ROOT: process.platform === 'win32' ? bundledNodeBin : dirname(bundledNodeBin),
-    AGENT_BROWSER_HOME: process.env.AGENT_BROWSER_HOME?.trim() || join(hermesHome(), 'agent-browser'),
-    ...(browserExecutable ? { AGENT_BROWSER_EXECUTABLE_PATH: browserExecutable } : {}),
+    AGENT_BROWSER_HOME: process.env.AGENT_BROWSER_HOME?.trim() || bundledAgentBrowserHome(),
+    ...(browserExecutableOverride ? { AGENT_BROWSER_EXECUTABLE_PATH: browserExecutableOverride } : {}),
     PLAYWRIGHT_BROWSERS_PATH: process.env.PLAYWRIGHT_BROWSERS_PATH || join(pythonDir(), 'ms-playwright'),
     ...(gitBin ? { HERMES_AGENT_GIT: gitBin } : {}),
     HERMES_HOME: hermesHome(),

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -7,7 +7,7 @@ import { randomBytes } from 'node:crypto'
 import { promisify } from 'node:util'
 import { app } from 'electron'
 import {
-  bundledBrowserExecutable,
+  bundledAgentBrowserHome,
   bundledGit,
   bundledNode,
   gitPathDirs,
@@ -343,7 +343,7 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     process.env.Path,
     COMMON_USER_BIN_DIRS.join(delimiter),
   )
-  const browserExecutable = process.env.AGENT_BROWSER_EXECUTABLE_PATH?.trim() || bundledBrowserExecutable()
+  const browserExecutableOverride = process.env.AGENT_BROWSER_EXECUTABLE_PATH?.trim()
   const gitBin = bundledGit()
 
   // Run via Electron's "run as Node" mode — Electron binary doubles as Node.
@@ -361,8 +361,8 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     HERMES_AGENT_ROOT: pythonDir(),
     HERMES_AGENT_NODE: bundledNode(),
     HERMES_AGENT_NODE_ROOT: isWin ? bundledNodeBin : dirname(bundledNodeBin),
-    AGENT_BROWSER_HOME: process.env.AGENT_BROWSER_HOME?.trim() || join(agentHome, 'agent-browser'),
-    ...(browserExecutable ? { AGENT_BROWSER_EXECUTABLE_PATH: browserExecutable } : {}),
+    AGENT_BROWSER_HOME: process.env.AGENT_BROWSER_HOME?.trim() || bundledAgentBrowserHome(),
+    ...(browserExecutableOverride ? { AGENT_BROWSER_EXECUTABLE_PATH: browserExecutableOverride } : {}),
     PLAYWRIGHT_BROWSERS_PATH: process.env.PLAYWRIGHT_BROWSERS_PATH || join(pythonDir(), 'ms-playwright'),
     ...(gitBin ? { HERMES_AGENT_GIT: gitBin } : {}),
     // Force TCP loopback for the agent bridge. The default `ipc:///tmp/...`

--- a/scripts/harness-check.mjs
+++ b/scripts/harness-check.mjs
@@ -390,9 +390,10 @@ if (!desktopRuntimeAssetName.includes('hermes-runtime-hermes-agent-')) {
 for (const phrase of [
   'websockets',
   'agent-browser@^0.26.0',
-  'HERMES_WINDOWS_CHROME_FOR_TESTING_VERSION',
+  'HERMES_CHROME_FOR_TESTING_VERSION',
   '149.0.7827.55',
-  'pinWindowsChromeForTestingBundle',
+  'pinChromeForTestingBundle',
+  'chromeForTestingPlatform',
   'AGENT_BROWSER_HOME',
   'AGENT_BROWSER_EXECUTABLE_PATH',
   'PLAYWRIGHT_BROWSERS_PATH',
@@ -418,6 +419,8 @@ for (const phrase of [
 }
 
 for (const phrase of [
+  'bundledAgentBrowserHome',
+  'AGENT_BROWSER_HOME',
   'bundledNodeBin',
   'HERMES_AGENT_NODE',
   'HERMES_AGENT_GIT',
@@ -427,6 +430,10 @@ for (const phrase of [
   if (!desktopWebuiServer.includes(phrase)) {
     fail(`desktop webui server must expose bundled browser runtime: ${phrase}`)
   }
+}
+
+if (desktopWebuiServer.includes('bundledBrowserExecutable()')) {
+  fail('desktop webui server must let agent-browser resolve the bundled browser from AGENT_BROWSER_HOME')
 }
 
 for (const phrase of [


### PR DESCRIPTION
## Summary
- Default desktop-launched server and bundled CLI to `AGENT_BROWSER_HOME` and only pass `AGENT_BROWSER_EXECUTABLE_PATH` when the user explicitly sets it.
- Pin bundled runtime Chrome for Testing to `149.0.7827.55` across supported browser-runtime platforms: macOS arm64, macOS x64, Windows x64, and Linux x64.
- Enlarge workflow node input/output handles for easier connections.
- Add harness checks for the new browser runtime behavior.

## Why
The desktop app was resolving and injecting a concrete Chrome executable path at startup. When runtime browser folders changed across installs, that stale path could override agent-browser discovery and launch the wrong or missing Chrome. Letting agent-browser resolve from `AGENT_BROWSER_HOME` keeps runtime upgrades from freezing a specific `chrome-*` directory in the server environment.

## Validation
- `npm run harness:check`
- `npm --prefix packages/desktop run build`
- `node --check packages/desktop/scripts/install-hermes.mjs`
- `npm run build`

## Notes
- Linux arm64 runtime still keeps `HERMES_SKIP_BROWSER_RUNTIME=true` in the runtime workflow, so no Chrome bundle is pinned there unless that skip is removed later.
