### PR TITLE
[codex] guard workflow node creation

### DIFF
--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -2024,6 +2024,7 @@ jobTriggered: 'Job ausgelost',
     actions: {
       newWorkflow: 'New Workflow',
       addNode: 'Add Node',
+      createWorkflowFirst: 'Please create a workflow first',
       reset: 'Reset',
       startExecution: 'Start Execution',
       executionPending: 'Workflow execution is not connected yet',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -621,6 +621,7 @@ export default {
     actions: {
       newWorkflow: 'New Workflow',
       addNode: 'Add Node',
+      createWorkflowFirst: 'Please create a workflow first',
       reset: 'Reset',
       startExecution: 'Start Execution',
       executionPending: 'Workflow execution is not connected yet',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -2024,6 +2024,7 @@ jobTriggered: 'Job ejecutado',
     actions: {
       newWorkflow: 'New Workflow',
       addNode: 'Add Node',
+      createWorkflowFirst: 'Please create a workflow first',
       reset: 'Reset',
       startExecution: 'Start Execution',
       executionPending: 'Workflow execution is not connected yet',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -2024,6 +2024,7 @@ jobTriggered: 'Job declenche',
     actions: {
       newWorkflow: 'New Workflow',
       addNode: 'Add Node',
+      createWorkflowFirst: 'Please create a workflow first',
       reset: 'Reset',
       startExecution: 'Start Execution',
       executionPending: 'Workflow execution is not connected yet',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -2023,6 +2023,7 @@ export default {
     actions: {
       newWorkflow: '新規ワークフロー',
       addNode: 'ノードを追加',
+      createWorkflowFirst: '先にワークフローを作成してください',
       reset: 'リセット',
       startExecution: '実行開始',
       executionPending: 'ワークフロー実行機能はまだ接続されていません',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -2023,6 +2023,7 @@ export default {
     actions: {
       newWorkflow: '새 워크플로',
       addNode: '노드 추가',
+      createWorkflowFirst: '먼저 워크플로를 생성하세요',
       reset: '재설정',
       startExecution: '실행 시작',
       executionPending: '워크플로 실행 기능은 아직 연결되지 않았습니다',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -2024,6 +2024,7 @@ jobTriggered: 'Job acionado',
     actions: {
       newWorkflow: 'New Workflow',
       addNode: 'Add Node',
+      createWorkflowFirst: 'Please create a workflow first',
       reset: 'Reset',
       startExecution: 'Start Execution',
       executionPending: 'Workflow execution is not connected yet',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -526,6 +526,7 @@ export default {
     actions: {
       newWorkflow: 'Новый workflow',
       addNode: 'Добавить узел',
+      createWorkflowFirst: 'Сначала создайте workflow',
       reset: 'Сбросить',
       startExecution: 'Запустить выполнение',
       executionPending: 'Выполнение workflow пока не подключено',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -621,6 +621,7 @@ export default {
     actions: {
       newWorkflow: '新增工作流',
       addNode: '新增節點',
+      createWorkflowFirst: '請先建立工作流',
       reset: '重置',
       startExecution: '開始執行',
       executionPending: '工作流執行功能待接入',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -621,6 +621,7 @@ export default {
     actions: {
       newWorkflow: '新建工作流',
       addNode: '添加节点',
+      createWorkflowFirst: '请先创建工作流',
       reset: '重置',
       startExecution: '开始执行',
       executionPending: '工作流执行功能待接入',

--- a/packages/client/src/views/hermes/WorkflowView.vue
+++ b/packages/client/src/views/hermes/WorkflowView.vue
@@ -1486,6 +1486,10 @@ function getNextVisibleNodePosition() {
 
 async function addAgentNode() {
   if (selectedWorkflowRunId.value) return
+  if (!activeWorkflowId.value) {
+    message.warning(t('workflow.actions.createWorkflowFirst'))
+    return
+  }
   const id = `agent-${nextNodeIndex.value}`
   nodes.value = [
     ...nodes.value,


### PR DESCRIPTION
## Summary
- Show a warning when the add-node action is clicked without an active workflow.
- Add localized copy for the new workflow-first warning.

## Why
The workflow canvas toolbar stayed clickable even when no workflow existed, which let users try to add nodes before there was a workflow document to save them into.

## Validation
- `npm run build`
