### PR TITLE
[codex] mark mini box sold out

### DIFF
--- a/packages/website/public/docs/hermes-esp32-intro/index.html
+++ b/packages/website/public/docs/hermes-esp32-intro/index.html
@@ -806,7 +806,7 @@
           <p>带小屏、麦克风、扬声器和实体按键，通过局域网连接电脑端 Hermes Studio。</p>
           <div class="price-row" aria-label="价格">
             <span class="price-original">原价 99</span>
-            <span class="price-presale">预订价 88</span>
+            <span class="price-presale">已售罄</span>
           </div>
           <div class="hero-actions">
             <a class="btn btn-primary" href="https://www.bilibili.com/video/BV1XfjJ6HEJF/?buvid=Y249B8269A108DAF48919C259A9DE04595BF&amp;from_spmid=main.space.0.0&amp;is_story_h5=false&amp;mid=NnXeSXRwQaaNqUgUnsx36Q%3D%3D&amp;p=1&amp;plat_id=114&amp;share_from=ugc&amp;share_medium=iphone&amp;share_plat=ios&amp;share_session_id=05D2CFF5-8FED-4709-9F97-26D684FA50E9&amp;share_source=WEIXIN&amp;share_tag=s_i&amp;timestamp=1782200632&amp;unique_k=82v3yJz&amp;up_id=257809052" target="_blank" rel="noopener noreferrer">查看使用教程</a>


### PR DESCRIPTION
## Summary

- Replace the Xiao Fang He presale price text with a sold-out status on the ESP32 intro page.

## Impact

The public product page no longer advertises the presale price and instead clearly shows that the item is sold out.

## Validation

- npm run harness:check