### PR TITLE
[codex] clarify BSL license scope

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,12 @@ Business Source License 1.1
 Parameters
 
 Licensor:             EKKOLearnAI
-Licensed Work:        Hermes Web UI
+Licensed Work:        Hermes Studio, formerly known as Hermes Web UI,
+                      including the hermes-web-ui npm package and CLI,
+                      Hermes Studio desktop applications, web applications,
+                      server components, runtime integrations, firmware,
+                      release artifacts, documentation, and all associated
+                      files in this repository.
 Additional Use Grant: You may use the Licensed Work for non-commercial purposes,
                       including personal use, education, and research.
                       Commercial use (including but not limited to selling,
@@ -33,8 +38,13 @@ limitations under the License.
 
 For the purposes of this License:
 
-- "Licensed Work" refers to all source code, documentation, and associated
-  files in this repository.
+- "Licensed Work" refers to Hermes Studio and all source code,
+  documentation, firmware, desktop applications, web applications, server
+  components, runtime integrations, release artifacts, packages, command-line
+  tools, and associated files in this repository. This includes materials
+  distributed or identified under the current Hermes Studio name, the former
+  Hermes Web UI name, the hermes-web-ui npm package name, and the
+  hermes-studio desktop application name.
 
 - "Non-commercial use" means use that is not primarily intended for or
   directed toward commercial advantage or monetary compensation.

--- a/README.md
+++ b/README.md
@@ -426,3 +426,7 @@ The BFF layer handles Socket.IO chat streaming, the Hermes agent bridge, profile
 ## License
 
 [BSL-1.1](./LICENSE)
+
+The license covers Hermes Studio, the former Hermes Web UI name, the
+`hermes-web-ui` npm package and CLI, desktop applications, firmware, release
+artifacts, documentation, and associated files in this repository.

--- a/README_zh.md
+++ b/README_zh.md
@@ -429,3 +429,6 @@ BFF 层负责：Socket.IO 聊天流式推送、Hermes agent bridge、按 Profile
 ## 许可证
 
 [BSL-1.1](./LICENSE)
+
+该许可证覆盖 Hermes Studio、原 Hermes Web UI 名称、`hermes-web-ui` npm 包和
+CLI、桌面应用、固件、发布产物、文档以及本仓库内的关联文件。


### PR DESCRIPTION
## Summary

- Update the BSL Licensed Work definition to cover Hermes Studio, the former Hermes Web UI name, the hermes-web-ui npm package and CLI, desktop apps, web/server components, runtime integrations, firmware, release artifacts, documentation, and associated repository files.
- Add matching English and Chinese README license notes so the coverage is visible from the project entry points.

## Impact

This keeps the current Hermes Studio branding, historical Hermes Web UI naming, npm package name, desktop distribution, and firmware materials aligned under the same BSL scope without renaming the published package or CLI.

## Validation

- npm run harness:check