### PR TITLE
[codex] align chat headers

### DIFF
--- a/docs/chat-chain-changes/2026-06-24-pr1777-chat-header-alignment.md
+++ b/docs/chat-chain-changes/2026-06-24-pr1777-chat-header-alignment.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-24
+pr: 1777
+feature: Chat header alignment
+impact: Single chat, group chat, and workflow headers use more consistent mobile sizing and alignment without changing chat runtime behavior.
+---

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -481,7 +481,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                             <div class="avatar-stack-inner">
                                 <!-- User avatar first -->
                                 <span class="avatar-stack-item" :style="{ zIndex: store.agents.length + 1 }">
-                                    <ProfileAvatar class="agent-avatar" :name="store.userName || store.userId" :avatar="userMemberAvatar" :size="28" />
+                                    <ProfileAvatar class="agent-avatar" :name="store.userName || store.userId" :avatar="userMemberAvatar" :size="24" />
                                 </span>
                                 <span
                                     v-for="(agent, index) in store.agents.slice(-4)"
@@ -489,7 +489,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                                     class="avatar-stack-item"
                                     :style="{ zIndex: store.agents.length - index }"
                                 >
-                                    <ProfileAvatar class="agent-avatar" :name="agentAvatarName(agent)" :avatar="profileAvatarFor(agent.profile)" :size="28" />
+                                    <ProfileAvatar class="agent-avatar" :name="agentAvatarName(agent)" :avatar="profileAvatarFor(agent.profile)" :size="24" />
                                 </span>
                                 <span v-if="store.agents.length > 4" class="avatar-stack-more">+{{ store.agents.length - 4 }}</span>
                             </div>
@@ -518,7 +518,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                     <!-- Only user avatar, no agents -->
                     <div v-else-if="store.userName" class="avatar-stack-inner">
                         <span class="avatar-stack-item">
-                            <ProfileAvatar class="agent-avatar" :name="store.userName || store.userId" :avatar="userMemberAvatar" :size="28" />
+                            <ProfileAvatar class="agent-avatar" :name="store.userName || store.userId" :avatar="userMemberAvatar" :size="24" />
                         </span>
                     </div>
                     <button class="icon-btn" :title="t('groupChat.addAgent')" @click="handleAddAgent">
@@ -1248,6 +1248,27 @@ export default defineComponent({ components: { CreateRoomForm } })
     gap: 12px;
     padding: 21px 20px;
     border-bottom: 1px solid $border-color;
+
+    .icon-btn {
+        width: 28px;
+        height: 28px;
+    }
+
+    .avatar-stack-item,
+    .avatar-stack-more {
+        width: 24px;
+        height: 24px;
+    }
+
+    .avatar-stack-item,
+    .avatar-stack-more,
+    .icon-btn {
+        box-sizing: content-box;
+    }
+
+    .avatar-stack-item {
+        margin-left: -10px;
+    }
 
     .room-title-text {
         font-size: 16px;

--- a/packages/client/src/views/hermes/WorkflowView.vue
+++ b/packages/client/src/views/hermes/WorkflowView.vue
@@ -1680,13 +1680,15 @@ function nodeColor(node: { data: WorkflowAgentNodeData }) {
               </svg>
             </template>
           </NButton>
-          <span class="header-workflow-title">{{ workflowName }}</span>
-          <button class="workspace-badge" type="button" :title="workflowWorkspace || t('workflow.workspace.select')" @click="openWorkspacePicker('active')">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-            </svg>
-            <span>{{ workflowWorkspace ? (workflowWorkspace.split('/').pop() || workflowWorkspace) : t('workflow.workspace.select') }}</span>
-          </button>
+          <div class="header-workflow-meta">
+            <span class="header-workflow-title">{{ workflowName }}</span>
+            <button class="workspace-badge" type="button" :title="workflowWorkspace || t('workflow.workspace.select')" @click="openWorkspacePicker('active')">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+              </svg>
+              <span>{{ workflowWorkspace ? (workflowWorkspace.split('/').pop() || workflowWorkspace) : t('workflow.workspace.select') }}</span>
+            </button>
+          </div>
         </div>
         <div class="header-actions">
           <NTooltip trigger="hover">
@@ -2212,19 +2214,36 @@ function nodeColor(node: { data: WorkflowAgentNodeData }) {
   flex: 0 0 auto;
 }
 
-.header-workflow-title {
+.header-workflow-meta {
   min-width: 0;
+  flex: 1 1 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  overflow: hidden;
+}
+
+.header-workflow-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-left: 10px;
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 600;
   line-height: 22px;
   color: $text-primary;
 }
 
 .workspace-badge {
+  flex: 0 1 auto;
   max-width: 160px;
+  min-width: 0;
   border: 0;
   border-radius: 4px;
   background: rgba(255, 255, 255, 0.05);
@@ -2528,17 +2547,44 @@ function nodeColor(node: { data: WorkflowAgentNodeData }) {
   }
 
   .page-header {
-    align-items: flex-start;
-    gap: 10px;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 8px;
+    padding: 16px 12px !important;
   }
 
   .header-actions {
-    width: 100%;
+    flex: 0 0 auto;
     justify-content: flex-end;
+    gap: 4px;
   }
 
   .header-left {
-    width: 100%;
+    flex: 1 1 auto;
+    min-width: 0;
+    gap: 8px;
+    align-items: center;
+    overflow: hidden;
+  }
+
+  .header-workflow-meta {
+    flex: 1 1 auto;
+    min-width: 0;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .header-workflow-title {
+    flex: 0 1 auto;
+    min-width: 0;
+    max-width: 52%;
+    line-height: 20px;
+  }
+
+  .workspace-badge {
+    flex: 0 1 auto;
+    max-width: 42%;
+    padding: 2px 6px;
   }
 
   .workflow-body {


### PR DESCRIPTION
## Summary
- Align the workflow header layout with the single-chat header on mobile while keeping the workflow title and workspace grouped on the left.
- Reduce group-chat header controls so the avatar stack and action buttons no longer make the header taller than single chat.

## Why
The single-chat, group-chat, and workflow headers had different effective heights and alignment. Group chat was being stretched by 32px header controls and the workflow header had custom mobile spacing that diverged from the single-chat baseline.

## Impact
- Mobile workflow header keeps title/workspace on the left and actions on the right.
- Group-chat header controls are constrained to match the single-chat header height more closely.

## Validation
- `npx vue-tsc -b`
- `git diff --cached --check`
