### PR TITLE
[codex] stop bridge broker on restart by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ These variables configure Hermes Web UI, its local Hermes runtime integration, a
 | `HERMES_AGENT_BRIDGE_TIMEOUT_MS` | `120000` | Timeout for Node requests to the bridge broker. |
 | `HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS` | `5000` | Short retry window for connecting to the bridge socket. |
 | `HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS` | `120000` | Timeout while waiting for the Python bridge to become ready. |
+| `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN` | enabled | Stop the bridge broker during Web UI shutdown and restart. Set `0`, `false`, `no`, or `off` to keep the bridge across restarts. |
 | `HERMES_AGENT_BRIDGE_AUTO_RESTART` | enabled | Auto-restart the bridge broker after unexpected exit. Set `0`, `false`, `no`, or `off` to disable. |
 | `HERMES_AGENT_BRIDGE_RESTART_DELAY_MS` | `1000` | Base delay for bridge auto-restart backoff. |
 | `HERMES_AGENT_BRIDGE_PLATFORM` | `cli` | Platform identity passed to Hermes Agent. |
@@ -357,12 +358,14 @@ These variables configure Hermes Web UI, its local Hermes runtime integration, a
 | `hermes-web-ui start`             | Start in background (daemon mode)  |
 | `hermes-web-ui start --port 9000` | Start on custom port               |
 | `hermes-web-ui stop`              | Stop background process            |
-| `hermes-web-ui restart`           | Restart background process         |
+| `hermes-web-ui restart`           | Restart background process; stops the bridge by default |
 | `hermes-web-ui status`            | Check if running                   |
 | `hermes-web-ui update`            | Update to latest version & restart |
 | `hermes-web-ui upgrade`           | Alias for `update`                 |
 | `hermes-web-ui -v`                | Show version number                |
 | `hermes-web-ui -h`                | Show help message                  |
+
+`restart`, `update`, and `upgrade` stop the Agent Bridge broker by default so restarted or updated servers do not reuse stale Python bridge processes. Set `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0` before restarting only when you explicitly want to keep the bridge broker and running bridge sessions alive.
 
 `update` / `upgrade` first attempt `npm cache clean --force`, then run `npm install -g hermes-web-ui@latest` and restart. Cache cleanup is best-effort; if it fails, the updater continues with the install.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -330,6 +330,7 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `HERMES_AGENT_BRIDGE_TIMEOUT_MS` | `120000` | Node 请求 bridge broker 的响应超时。 |
 | `HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS` | `5000` | 连接 bridge socket 失败时的短重试窗口。 |
 | `HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS` | `120000` | 等待 Python bridge ready 的超时。 |
+| `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN` | 开启 | Web UI 关闭和重启时是否停止 bridge broker；设为 `0`、`false`、`no` 或 `off` 才会在重启时保留 broker。 |
 | `HERMES_AGENT_BRIDGE_AUTO_RESTART` | 开启 | bridge broker 意外退出后是否自动重启；设为 `0`、`false`、`no` 或 `off` 可关闭。 |
 | `HERMES_AGENT_BRIDGE_RESTART_DELAY_MS` | `1000` | bridge 自动重启退避的基础延迟。 |
 | `HERMES_AGENT_BRIDGE_PLATFORM` | `cli` | 传给 Hermes Agent 的 platform 标识。 |
@@ -360,12 +361,14 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `hermes-web-ui start` | 后台启动（守护进程模式） |
 | `hermes-web-ui start --port 9000` | 自定义端口启动 |
 | `hermes-web-ui stop` | 停止后台进程 |
-| `hermes-web-ui restart` | 重启后台进程 |
+| `hermes-web-ui restart` | 重启后台进程；默认会关闭 bridge broker |
 | `hermes-web-ui status` | 查看运行状态 |
 | `hermes-web-ui update` | 更新到最新版本并重启 |
 | `hermes-web-ui upgrade` | `update` 的别名 |
 | `hermes-web-ui -v` | 显示版本号 |
 | `hermes-web-ui -h` | 显示帮助信息 |
+
+`restart`、`update` 和 `upgrade` 默认会停止 Agent Bridge broker，避免重启或更新后的服务复用旧 Python bridge 进程。只有明确希望保留 broker 和正在运行的 bridge session 时，才在重启前设置 `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0`。
 
 `update` / `upgrade` 会先尝试执行 `npm cache clean --force`，再执行 `npm install -g hermes-web-ui@latest` 并重启。缓存清理是 best-effort；如果清理失败，只提示 warning，升级安装会继续执行。
 

--- a/bin/hermes-web-ui.mjs
+++ b/bin/hermes-web-ui.mjs
@@ -36,10 +36,20 @@ function envPositiveInt(name) {
   return Number.isFinite(value) && value > 0 ? value : undefined
 }
 
+function shouldPreserveBridgeOnShutdown() {
+  const raw = String(process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN || '').trim().toLowerCase()
+  return ['0', 'false', 'no', 'off'].includes(raw)
+}
+
 function getDaemonStopGraceMs(options = {}) {
   const { restart = false } = options
-  if (restart) {
+  if (restart && shouldPreserveBridgeOnShutdown()) {
     return envPositiveInt('HERMES_WEB_UI_RESTART_GRACE_MS') ?? DEFAULT_RESTART_GRACE_MS
+  }
+  if (restart) {
+    return envPositiveInt('HERMES_WEB_UI_RESTART_GRACE_MS')
+      ?? envPositiveInt('HERMES_WEB_UI_STOP_GRACE_MS')
+      ?? DEFAULT_STOP_GRACE_MS
   }
   return envPositiveInt('HERMES_WEB_UI_STOP_GRACE_MS') ?? DEFAULT_STOP_GRACE_MS
 }
@@ -522,8 +532,9 @@ function stopDaemon(options = {}) {
   try {
     try {
       process.kill(pid, restart ? 'SIGUSR2' : 'SIGTERM')
-      // Restart keeps the bridge alive and should be quick. Stop waits longer
-      // so the server can ask the bridge broker to stop worker subprocesses.
+      // Restart uses a shorter grace window than stop. By default the server
+      // still shuts down the bridge; set HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0
+      // to keep the bridge across restarts.
       const graceMs = getDaemonStopGraceMs({ restart })
       const attempts = Math.max(1, Math.ceil(graceMs / STOP_POLL_INTERVAL_MS))
       for (let i = 0; i < attempts; i++) {

--- a/docs/chat-chain-changes/2026-06-04-pr1320-bridge-restart-resume.md
+++ b/docs/chat-chain-changes/2026-06-04-pr1320-bridge-restart-resume.md
@@ -3,7 +3,7 @@ date: 2026-06-04
 pr: 1320
 commit: 237fd954
 feature: Agent Bridge restart/resume；shutdown/stop timing
-impact: server 重启后 `ChatRunSocket.resume` 会查询 bridge status 并通过 `resumeBridgeRun()` 继续 poll 既有 `run_id` 的 delta/events。
+impact: Historical restart-resume behavior: server 重启后 `ChatRunSocket.resume` 会查询 bridge status 并通过 `resumeBridgeRun()` 继续 poll 既有 `run_id` 的 delta/events。2026-06-25 起默认 restart 会关闭 bridge，需设置 `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0` 才保留此行为。
 ---
 
-Web UI `restart`/页面内升级通过 `SIGUSR2` 保留 Agent Bridge。真实 `stop`/`SIGTERM` 仍会请求 bridge shutdown；非桌面 shutdown 兜底延长到 15s 以覆盖 worker 清理窗口，桌面 `HERMES_DESKTOP=true` 默认仍保持 3s。CLI `restart` 仍使用 5s grace，CLI `stop` 最长等 15s 且进程退出后立即返回。
+Historical behavior from PR 1320: Web UI `restart`/页面内升级通过 `SIGUSR2` 保留 Agent Bridge，而真实 `stop`/`SIGTERM` 会请求 bridge shutdown。2026-06-25 起默认策略已改为 restart/shutdown 都关闭 Agent Bridge broker；只有显式设置 `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0` 时才保留旧的 restart-resume 行为。CLI `restart` 仍使用较短 grace window，CLI `stop` 使用较长 grace window。

--- a/docs/chat-chain-changes/2026-06-25-bridge-stop-on-restart-default.md
+++ b/docs/chat-chain-changes/2026-06-25-bridge-stop-on-restart-default.md
@@ -1,0 +1,9 @@
+---
+date: 2026-06-25
+pr: pending
+commit: pending
+feature: Agent Bridge restart/shutdown policy
+impact: Web UI shutdown and restart now stop the Agent Bridge broker by default so package upgrades do not reattach to stale bridge processes. Operators can keep the previous restart-resume behavior by setting HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0.
+---
+
+`shouldStopAgentBridgeOnShutdown()` now treats `SIGUSR2` restart signals the same as normal shutdown signals unless `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN` is explicitly set to a false value. This avoids reusing an old Python bridge broker after CLI or in-app updates replace the Web UI package files.

--- a/docs/cli-chat-sessions.md
+++ b/docs/cli-chat-sessions.md
@@ -874,7 +874,9 @@ Bridge 启动失败不会阻止 Web UI server 启动，但普通 Chat run 会在
 关闭时：
 
 - `ChatRunSocket.close()` abort active response stream/清理内存态。
-- `AgentBridgeManager.stop()` 关闭 Python broker。
+- `AgentBridgeManager.stop()` 默认关闭 Python broker，包括 `restart` 使用的
+  `SIGUSR2`。如果需要保留 broker 和正在运行的 bridge session，可显式设置
+  `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0`。
 - 其他 WebSocket/Socket.IO 服务按 shutdown 流程停止。
 
 ## 22. 环境变量
@@ -887,6 +889,7 @@ Bridge 启动失败不会阻止 Web UI server 启动，但普通 Chat run 会在
 | `HERMES_AGENT_BRIDGE_TIMEOUT_MS` | Node 等待 bridge 请求响应的超时，默认 120000ms。 |
 | `HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS` | Node connect bridge 的短重试窗口，默认 5000ms。 |
 | `HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS` | bridge ready 超时，默认 120000ms。 |
+| `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN` | Web UI shutdown/restart 是否关闭 bridge broker，默认开启。设为 `0`/`false`/`no`/`off` 才会保留 broker。 |
 | `HERMES_AGENT_BRIDGE_AUTO_RESTART` | broker 意外退出是否自动重启，默认开启。 |
 | `HERMES_AGENT_BRIDGE_RESTART_DELAY_MS` | 自动重启基础延迟。 |
 | `HERMES_AGENT_BRIDGE_PYTHON` | 指定 Python 解释器。 |

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9776,6 +9776,37 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "STT"
+        ],
+        "summary": "Delete :provider",
+        "description": "DELETE /api/hermes/stt/settings/:provider",
+        "operationId": "deleteProvider",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/stt/settings/{provider}/base-url-preset": {
@@ -10062,6 +10093,37 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "TTS"
+        ],
+        "summary": "Delete :provider",
+        "description": "DELETE /api/hermes/tts/settings/:provider",
+        "operationId": "deleteProvider",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/hermes/tts/settings/{provider}/base-url-preset": {

--- a/packages/server/src/services/shutdown.ts
+++ b/packages/server/src/services/shutdown.ts
@@ -20,15 +20,15 @@ export function getShutdownForceExitMs(): number {
   return desktop ? DEFAULT_DESKTOP_SHUTDOWN_FORCE_EXIT_MS : DEFAULT_SHUTDOWN_FORCE_EXIT_MS
 }
 
-export function shouldStopAgentBridgeOnShutdown(signal: string): boolean {
+export function shouldStopAgentBridgeOnShutdown(_signal: string): boolean {
   const raw = String(process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN || '').trim().toLowerCase()
   if (['1', 'true', 'yes', 'on'].includes(raw)) return true
   if (['0', 'false', 'no', 'off'].includes(raw)) return false
 
-  // The CLI uses SIGUSR2 for an intentional Web UI restart so active bridge
-  // runs survive and can be reattached. SIGTERM/SIGINT represent real service
-  // shutdown and should stop the bridge broker/workers.
-  return signal !== 'SIGUSR2'
+  // Restart now defaults to a fresh bridge so package/runtime upgrades do not
+  // attach to stale brokers. Operators can opt back into restart resume with
+  // HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0.
+  return true
 }
 
 export function shouldStopManagedGatewaysOnShutdown(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -85,8 +85,7 @@ export function createShutdownHandler(server: any, groupChatServer?: any, chatRu
         logger.info('Leaving agent bridge running across Web UI shutdown')
       }
 
-      // Close ChatRunSocket first to release WebSocket state. CLI bridge runs
-      // keep running in the external bridge and are reattached after restart.
+      // Close ChatRunSocket first to release WebSocket state.
       if (chatRunServer) {
         chatRunServer.close()
         logger.info('ChatRunSocket closed')

--- a/packages/website/src/i18n/en.ts
+++ b/packages/website/src/i18n/en.ts
@@ -256,6 +256,7 @@ export default {
           ['HERMES_AGENT_BRIDGE_TIMEOUT_MS', 'Timeout for Node requests to the bridge broker'],
           ['HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS', 'Short retry window for connecting to the bridge socket'],
           ['HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS', 'Timeout while waiting for the Python bridge to become ready'],
+          ['HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN', 'Stop the bridge broker during Web UI shutdown and restart by default; set 0/false/no/off to preserve the broker across restarts'],
           ['HERMES_AGENT_BRIDGE_AUTO_RESTART', 'Auto-restart the bridge broker after unexpected exit; set 0/false/no/off to disable'],
           ['HERMES_AGENT_BRIDGE_RESTART_DELAY_MS', 'Base delay for bridge auto-restart backoff'],
           ['HERMES_AGENT_BRIDGE_PLATFORM', 'Platform identity passed to Hermes Agent'],
@@ -284,7 +285,7 @@ export default {
       },
       gateway: {
         title: 'Agent Bridge Runtime',
-        content: 'Chat runs are handled through the Hermes agent bridge, which runs alongside the Hermes Studio server and talks directly to the Hermes Agent runtime. HERMES_AGENT_BRIDGE_ENDPOINT controls the Node-to-broker address, while HERMES_AGENT_BRIDGE_WORKER_TRANSPORT controls the broker-to-profile-worker transport. Switching the frontend Hermes Profile changes later request context only; it does not restart the bridge or clear other running tasks.',
+        content: 'Chat runs are handled through the Hermes agent bridge, which runs alongside the Hermes Studio server and talks directly to the Hermes Agent runtime. HERMES_AGENT_BRIDGE_ENDPOINT controls the Node-to-broker address, while HERMES_AGENT_BRIDGE_WORKER_TRANSPORT controls the broker-to-profile-worker transport. Web UI shutdown and CLI/app restarts stop the bridge broker by default; set HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0 only when you intentionally want to preserve bridge sessions across restart. Switching the frontend Hermes Profile changes later request context only; it does not restart the bridge or clear other running tasks.',
       },
       profiles: {
         title: 'Profiles',

--- a/packages/website/src/i18n/zh.ts
+++ b/packages/website/src/i18n/zh.ts
@@ -256,6 +256,7 @@ export default {
           ['HERMES_AGENT_BRIDGE_TIMEOUT_MS', 'Node 请求 bridge broker 的响应超时'],
           ['HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS', '连接 bridge socket 失败时的短重试窗口'],
           ['HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS', '等待 Python bridge ready 的超时'],
+          ['HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN', 'Web UI 关闭和重启时默认停止 bridge broker；设为 0/false/no/off 才会在重启时保留 broker'],
           ['HERMES_AGENT_BRIDGE_AUTO_RESTART', 'bridge broker 意外退出后是否自动重启；设为 0/false/no/off 可关闭'],
           ['HERMES_AGENT_BRIDGE_RESTART_DELAY_MS', 'bridge 自动重启退避的基础延迟'],
           ['HERMES_AGENT_BRIDGE_PLATFORM', '传给 Hermes Agent 的 platform 标识'],
@@ -284,7 +285,7 @@ export default {
       },
       gateway: {
         title: 'Agent Bridge 运行时',
-        content: '聊天运行通过 Hermes agent bridge 处理。它随 Hermes Studio 服务一起运行，并直接连接 Hermes Agent runtime。HERMES_AGENT_BRIDGE_ENDPOINT 控制 Node 与 bridge broker 的连接地址；HERMES_AGENT_BRIDGE_WORKER_TRANSPORT 控制 broker 与各 Profile worker 的连接方式。前端切换 Hermes Profile 只影响后续请求上下文，不会重启 bridge 或清理其他正在运行的任务。',
+        content: '聊天运行通过 Hermes agent bridge 处理。它随 Hermes Studio 服务一起运行，并直接连接 Hermes Agent runtime。HERMES_AGENT_BRIDGE_ENDPOINT 控制 Node 与 bridge broker 的连接地址；HERMES_AGENT_BRIDGE_WORKER_TRANSPORT 控制 broker 与各 Profile worker 的连接方式。Web UI 关闭以及 CLI/应用内重启默认会停止 bridge broker；只有明确希望跨重启保留 bridge session 时，才设置 HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0。前端切换 Hermes Profile 只影响后续请求上下文，不会重启 bridge 或清理其他正在运行的任务。',
       },
       profiles: {
         title: '配置文件',

--- a/tests/server/cli-port-detection.test.ts
+++ b/tests/server/cli-port-detection.test.ts
@@ -141,11 +141,14 @@ describe('CLI port detection', () => {
     }
   })
 
-  it('keeps restart grace short while allowing stop to wait for bridge cleanup', async () => {
+  it('waits for bridge cleanup on restart unless broker preservation is requested', async () => {
     const { getDaemonStopGraceMs } = await loadCli()
 
-    expect(getDaemonStopGraceMs({ restart: true })).toBe(5_000)
+    expect(getDaemonStopGraceMs({ restart: true })).toBe(15_000)
     expect(getDaemonStopGraceMs()).toBe(15_000)
+
+    process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN = '0'
+    expect(getDaemonStopGraceMs({ restart: true })).toBe(5_000)
   })
 
   it('allows CLI stop and restart grace periods to be overridden separately', async () => {
@@ -155,6 +158,9 @@ describe('CLI port detection', () => {
 
     expect(getDaemonStopGraceMs({ restart: true })).toBe(2_500)
     expect(getDaemonStopGraceMs()).toBe(9_000)
+
+    delete process.env.HERMES_WEB_UI_RESTART_GRACE_MS
+    expect(getDaemonStopGraceMs({ restart: true })).toBe(9_000)
   })
 
   it('skips browser launch when --no-open is provided', async () => {

--- a/tests/server/shutdown.test.ts
+++ b/tests/server/shutdown.test.ts
@@ -25,10 +25,10 @@ describe('shutdown bridge policy', () => {
     else process.env.HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS = originalForceExitMs
   })
 
-  it('keeps the bridge for restart signals and stops it for service shutdown signals by default', () => {
+  it('stops the bridge for restart and service shutdown signals by default', () => {
     delete process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN
 
-    expect(shouldStopAgentBridgeOnShutdown('SIGUSR2')).toBe(false)
+    expect(shouldStopAgentBridgeOnShutdown('SIGUSR2')).toBe(true)
     expect(shouldStopAgentBridgeOnShutdown('SIGTERM')).toBe(true)
     expect(shouldStopAgentBridgeOnShutdown('SIGINT')).toBe(true)
   })
@@ -38,6 +38,7 @@ describe('shutdown bridge policy', () => {
     expect(shouldStopAgentBridgeOnShutdown('SIGUSR2')).toBe(true)
 
     process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN = '0'
+    expect(shouldStopAgentBridgeOnShutdown('SIGUSR2')).toBe(false)
     expect(shouldStopAgentBridgeOnShutdown('SIGTERM')).toBe(false)
   })
 


### PR DESCRIPTION
## Summary
- Stop the Agent Bridge broker by default for Web UI shutdown and restart, including CLI restart and in-app update restart paths.
- Add HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0 as the opt-in compatibility path to preserve broker sessions across restart.
- Sync README, Chinese README, website docs, chat-chain docs, and focused tests.

## Why
The previous restart behavior kept the Python bridge broker alive, which allowed updated or restarted Web UI processes to reattach to stale broker processes. This was especially visible during package/app updates.

## Validation
- `npm run harness:check`
- `npx vitest run tests/server/shutdown.test.ts tests/server/cli-port-detection.test.ts tests/server/update-controller.test.ts`
- `npm run build`
- `npm run build:website`

## Notes
- `docs/openapi.json` was regenerated locally by `npm run build` but is unrelated to this PR and was not included in the commit.