### PR TITLE
[codex] add workflow tools to MCP use

### DIFF
--- a/bin/hermes-studio-mcp.mjs
+++ b/bin/hermes-studio-mcp.mjs
@@ -1039,6 +1039,203 @@ const tools = [
     inputSchema: inputSchema(),
   },
   {
+    name: 'hermes_studio_use_workflows_list',
+    toolset: 'use',
+    description: 'List Hermes Studio workflows for the selected or requested profile.',
+    inputSchema: inputSchema({
+        profile: {
+          type: 'string',
+          description: 'Optional profile filter. When omitted, the active MCP profile is used through X-Hermes-Profile.',
+        },
+      }),
+  },
+  {
+    name: 'hermes_studio_use_workflow_get',
+    toolset: 'use',
+    description: 'Get one Hermes Studio workflow by id.',
+    inputSchema: inputSchema({
+        workflow_id: {
+          type: 'string',
+          description: 'Workflow id.',
+        },
+      }, ['workflow_id']),
+  },
+  {
+    name: 'hermes_studio_use_workflow_create',
+    toolset: 'use',
+    description: 'Create a Hermes Studio workflow with optional nodes, edges, viewport, workspace, and profile.',
+    inputSchema: inputSchema({
+        name: {
+          type: 'string',
+          description: 'Workflow name.',
+        },
+        profile: {
+          type: 'string',
+          description: 'Optional workflow profile. Defaults to the active MCP profile or server default.',
+        },
+        workspace: {
+          type: ['string', 'null'],
+          description: 'Optional workflow workspace path.',
+        },
+        nodes: {
+          type: 'array',
+          description: 'Optional workflow node array.',
+          items: { type: 'object', additionalProperties: true },
+        },
+        edges: {
+          type: 'array',
+          description: 'Optional workflow edge array.',
+          items: { type: 'object', additionalProperties: true },
+        },
+        viewport: {
+          type: ['object', 'null'],
+          description: 'Optional workflow viewport state.',
+          additionalProperties: true,
+        },
+      }, ['name']),
+  },
+  {
+    name: 'hermes_studio_use_workflow_update',
+    toolset: 'use',
+    description: 'Update a Hermes Studio workflow name, workspace, nodes, edges, or viewport.',
+    inputSchema: inputSchema({
+        workflow_id: {
+          type: 'string',
+          description: 'Workflow id.',
+        },
+        name: {
+          type: 'string',
+          description: 'Optional new workflow name.',
+        },
+        workspace: {
+          type: ['string', 'null'],
+          description: 'Optional workspace path update.',
+        },
+        nodes: {
+          type: 'array',
+          description: 'Optional replacement workflow node array.',
+          items: { type: 'object', additionalProperties: true },
+        },
+        edges: {
+          type: 'array',
+          description: 'Optional replacement workflow edge array.',
+          items: { type: 'object', additionalProperties: true },
+        },
+        viewport: {
+          type: ['object', 'null'],
+          description: 'Optional replacement workflow viewport state.',
+          additionalProperties: true,
+        },
+      }, ['workflow_id']),
+  },
+  {
+    name: 'hermes_studio_use_workflow_delete',
+    toolset: 'use',
+    description: 'Delete one Hermes Studio workflow by id, including its workflow run records.',
+    inputSchema: inputSchema({
+        workflow_id: {
+          type: 'string',
+          description: 'Workflow id to delete.',
+        },
+      }, ['workflow_id']),
+  },
+  {
+    name: 'hermes_studio_use_workflow_runs_list',
+    toolset: 'use',
+    description: 'List recent run records and node sessions for one workflow.',
+    inputSchema: inputSchema({
+        workflow_id: {
+          type: 'string',
+          description: 'Workflow id.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Optional maximum number of workflow runs.',
+        },
+      }, ['workflow_id']),
+  },
+  {
+    name: 'hermes_studio_use_workflow_run_start',
+    toolset: 'use',
+    description: 'Start a workflow run. Returns accepted status while the workflow continues asynchronously.',
+    inputSchema: inputSchema({
+        workflow_id: {
+          type: 'string',
+          description: 'Workflow id.',
+        },
+        start_node_ids: {
+          type: 'array',
+          description: 'Optional node ids to start from.',
+          items: { type: 'string' },
+        },
+        input: {
+          type: ['string', 'null'],
+          description: 'Optional workflow input text.',
+        },
+        timeout_ms: {
+          type: 'number',
+          description: 'Optional per-node run timeout in milliseconds.',
+        },
+      }, ['workflow_id']),
+  },
+  {
+    name: 'hermes_studio_use_workflow_run_stop',
+    toolset: 'use',
+    description: 'Cancel a queued or running workflow run.',
+    inputSchema: inputSchema({
+        workflow_id: {
+          type: 'string',
+          description: 'Workflow id.',
+        },
+        run_id: {
+          type: 'string',
+          description: 'Workflow run id.',
+        },
+      }, ['workflow_id', 'run_id']),
+  },
+  {
+    name: 'hermes_studio_use_workflow_run_rerun_from_node',
+    toolset: 'use',
+    description: 'Rerun an existing workflow run from a node. Use preserve_start_node=true to keep the selected node message and only rerun downstream nodes; false clears the selected node and downstream sessions.',
+    inputSchema: inputSchema({
+        workflow_id: {
+          type: 'string',
+          description: 'Workflow id.',
+        },
+        run_id: {
+          type: 'string',
+          description: 'Workflow run id.',
+        },
+        node_id: {
+          type: 'string',
+          description: 'Node id to rerun from.',
+        },
+        preserve_start_node: {
+          type: 'boolean',
+          description: 'When true, keep the selected node session and rerun downstream nodes only. Defaults to false on the server.',
+        },
+        timeout_ms: {
+          type: 'number',
+          description: 'Optional per-node run timeout in milliseconds.',
+        },
+      }, ['workflow_id', 'run_id', 'node_id']),
+  },
+  {
+    name: 'hermes_studio_use_workflow_run_delete',
+    toolset: 'use',
+    description: 'Delete one workflow run and its node session records.',
+    inputSchema: inputSchema({
+        workflow_id: {
+          type: 'string',
+          description: 'Workflow id.',
+        },
+        run_id: {
+          type: 'string',
+          description: 'Workflow run id.',
+        },
+      }, ['workflow_id', 'run_id']),
+  },
+  {
     name: 'hermes_studio_lan_devices_list',
     toolset: 'devices',
     description: 'List known LAN and remote devices from Hermes Web UI, including pairing and online status.',
@@ -1303,6 +1500,69 @@ async function callTool(name, args = {}) {
       return jsonText(summarizeWorkerRuntime(
         await request('/api/hermes/performance/runtime', withAuthArgs(args)),
       ))
+    case 'hermes_studio_use_workflows_list':
+      return jsonText(await request('/api/hermes/workflows', withAuthArgs(args, {
+        query: pickDefined(args, ['profile']),
+      })))
+    case 'hermes_studio_use_workflow_get':
+      return jsonText(await request(`/api/hermes/workflows/${encodeURIComponent(args.workflow_id)}`, withAuthArgs(args)))
+    case 'hermes_studio_use_workflow_create':
+      return jsonText(await request('/api/hermes/workflows', withAuthArgs(args, {
+        method: 'POST',
+        body: pickDefined(args, [
+          'name',
+          'profile',
+          'workspace',
+          'nodes',
+          'edges',
+          'viewport',
+        ]),
+      })))
+    case 'hermes_studio_use_workflow_update':
+      return jsonText(await request(`/api/hermes/workflows/${encodeURIComponent(args.workflow_id)}`, withAuthArgs(args, {
+        method: 'PATCH',
+        body: pickDefined(args, [
+          'name',
+          'workspace',
+          'nodes',
+          'edges',
+          'viewport',
+        ]),
+      })))
+    case 'hermes_studio_use_workflow_delete':
+      return jsonText(await request(`/api/hermes/workflows/${encodeURIComponent(args.workflow_id)}`, withAuthArgs(args, {
+        method: 'DELETE',
+      })))
+    case 'hermes_studio_use_workflow_runs_list':
+      return jsonText(await request(`/api/hermes/workflows/${encodeURIComponent(args.workflow_id)}/runs`, withAuthArgs(args, {
+        query: pickDefined(args, ['limit']),
+      })))
+    case 'hermes_studio_use_workflow_run_start':
+      return jsonText(await request(`/api/hermes/workflows/${encodeURIComponent(args.workflow_id)}/run`, withAuthArgs(args, {
+        method: 'POST',
+        body: pickDefined(args, [
+          'start_node_ids',
+          'input',
+          'timeout_ms',
+        ]),
+      })))
+    case 'hermes_studio_use_workflow_run_stop':
+      return jsonText(await request(`/api/hermes/workflows/${encodeURIComponent(args.workflow_id)}/runs/${encodeURIComponent(args.run_id)}/stop`, withAuthArgs(args, {
+        method: 'POST',
+      })))
+    case 'hermes_studio_use_workflow_run_rerun_from_node':
+      return jsonText(await request(`/api/hermes/workflows/${encodeURIComponent(args.workflow_id)}/runs/${encodeURIComponent(args.run_id)}/rerun-from-node`, withAuthArgs(args, {
+        method: 'POST',
+        body: pickDefined(args, [
+          'node_id',
+          'preserve_start_node',
+          'timeout_ms',
+        ]),
+      })))
+    case 'hermes_studio_use_workflow_run_delete':
+      return jsonText(await request(`/api/hermes/workflows/${encodeURIComponent(args.workflow_id)}/runs/${encodeURIComponent(args.run_id)}`, withAuthArgs(args, {
+        method: 'DELETE',
+      })))
     case 'hermes_studio_lan_devices_list':
       return jsonText(await request('/api/devices', withAuthArgs(args)))
     case 'hermes_studio_lan_devices_scan':

--- a/tests/server/hermes-web-ui-mcp.test.ts
+++ b/tests/server/hermes-web-ui-mcp.test.ts
@@ -428,6 +428,62 @@ describe('hermes-web-ui MCP server', () => {
         }))
         return
       }
+      if (req.url === '/api/hermes/workflows?profile=default') {
+        res.end(JSON.stringify({ workflows: [{ id: 'workflow-1', name: 'Demo workflow', profile: 'default' }] }))
+        return
+      }
+      if (req.url === '/api/hermes/workflows/workflow-1' && req.method === 'GET') {
+        res.end(JSON.stringify({ workflow: { id: 'workflow-1', name: 'Demo workflow', profile: 'default' } }))
+        return
+      }
+      if (req.url === '/api/hermes/workflows' && req.method === 'POST') {
+        let raw = ''
+        req.on('data', chunk => { raw += chunk })
+        req.on('end', () => {
+          res.end(JSON.stringify({ workflow: { id: 'workflow-created', body: raw ? JSON.parse(raw) : null } }))
+        })
+        return
+      }
+      if (req.url === '/api/hermes/workflows/workflow-1' && req.method === 'PATCH') {
+        let raw = ''
+        req.on('data', chunk => { raw += chunk })
+        req.on('end', () => {
+          res.end(JSON.stringify({ workflow: { id: 'workflow-1', body: raw ? JSON.parse(raw) : null } }))
+        })
+        return
+      }
+      if (req.url === '/api/hermes/workflows/workflow-1/runs?limit=5') {
+        res.end(JSON.stringify({ runs: [{ id: 'run-1', workflow_id: 'workflow-1', status: 'completed', node_sessions: [] }] }))
+        return
+      }
+      if (req.url === '/api/hermes/workflows/workflow-1/run' && req.method === 'POST') {
+        let raw = ''
+        req.on('data', chunk => { raw += chunk })
+        req.on('end', () => {
+          res.end(JSON.stringify({ ok: true, status: 'accepted', body: raw ? JSON.parse(raw) : null }))
+        })
+        return
+      }
+      if (req.url === '/api/hermes/workflows/workflow-1/runs/run-1/stop' && req.method === 'POST') {
+        res.end(JSON.stringify({ ok: true, run: { id: 'run-1', status: 'canceled' } }))
+        return
+      }
+      if (req.url === '/api/hermes/workflows/workflow-1/runs/run-1/rerun-from-node' && req.method === 'POST') {
+        let raw = ''
+        req.on('data', chunk => { raw += chunk })
+        req.on('end', () => {
+          res.end(JSON.stringify({ ok: true, status: 'accepted', body: raw ? JSON.parse(raw) : null }))
+        })
+        return
+      }
+      if (req.url === '/api/hermes/workflows/workflow-1/runs/run-1' && req.method === 'DELETE') {
+        res.end(JSON.stringify({ ok: true, deleted_run: 'run-1' }))
+        return
+      }
+      if (req.url === '/api/hermes/workflows/workflow-1' && req.method === 'DELETE') {
+        res.end(JSON.stringify({ ok: true, deleted_workflow: 'workflow-1' }))
+        return
+      }
       res.statusCode = 404
       res.end('{}')
     })
@@ -528,6 +584,53 @@ describe('hermes-web-ui MCP server', () => {
       name: 'hermes_studio_use_worker_status',
       arguments: {},
     })
+    writeRpc(child, 20, 'tools/call', {
+      name: 'hermes_studio_use_workflows_list',
+      arguments: { profile: 'default' },
+    })
+    writeRpc(child, 21, 'tools/call', {
+      name: 'hermes_studio_use_workflow_get',
+      arguments: { workflow_id: 'workflow-1' },
+    })
+    writeRpc(child, 22, 'tools/call', {
+      name: 'hermes_studio_use_workflow_create',
+      arguments: {
+        name: 'Created workflow',
+        profile: 'default',
+        workspace: '/tmp/workflow',
+        nodes: [{ id: 'node-1', type: 'agent' }],
+        edges: [],
+        viewport: { x: 1, y: 2, zoom: 0.8 },
+      },
+    })
+    writeRpc(child, 23, 'tools/call', {
+      name: 'hermes_studio_use_workflow_update',
+      arguments: { workflow_id: 'workflow-1', name: 'Updated workflow', nodes: [{ id: 'node-2' }] },
+    })
+    writeRpc(child, 24, 'tools/call', {
+      name: 'hermes_studio_use_workflow_runs_list',
+      arguments: { workflow_id: 'workflow-1', limit: 5 },
+    })
+    writeRpc(child, 25, 'tools/call', {
+      name: 'hermes_studio_use_workflow_run_start',
+      arguments: { workflow_id: 'workflow-1', start_node_ids: ['node-1'], input: 'go', timeout_ms: 1000 },
+    })
+    writeRpc(child, 26, 'tools/call', {
+      name: 'hermes_studio_use_workflow_run_stop',
+      arguments: { workflow_id: 'workflow-1', run_id: 'run-1' },
+    })
+    writeRpc(child, 27, 'tools/call', {
+      name: 'hermes_studio_use_workflow_run_rerun_from_node',
+      arguments: { workflow_id: 'workflow-1', run_id: 'run-1', node_id: 'node-2', preserve_start_node: true, timeout_ms: 2000 },
+    })
+    writeRpc(child, 28, 'tools/call', {
+      name: 'hermes_studio_use_workflow_run_delete',
+      arguments: { workflow_id: 'workflow-1', run_id: 'run-1' },
+    })
+    writeRpc(child, 29, 'tools/call', {
+      name: 'hermes_studio_use_workflow_delete',
+      arguments: { workflow_id: 'workflow-1' },
+    })
 
     const initialized = await waitForRpc(responses, 1)
     expect(initialized.result.serverInfo).toMatchObject({ toolset: 'use' })
@@ -543,6 +646,8 @@ describe('hermes-web-ui MCP server', () => {
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_provider_add')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_provider_delete')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_worker_status')).toBe(true)
+    expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_workflows_list')).toBe(true)
+    expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_workflow_run_rerun_from_node')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_api_request')).toBe(false)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_lan_devices_list')).toBe(false)
 
@@ -619,6 +724,34 @@ describe('hermes-web-ui MCP server', () => {
     })
     expect(workerStatus.interacting_workers.map((worker: any) => worker.profile)).toEqual(['default'])
     expect(workerStatus.completed_workers.map((worker: any) => worker.profile)).toEqual(['research'])
+    const workflows = JSON.parse((await waitForRpc(responses, 20)).result.content[0].text)
+    expect(workflows.workflows[0]).toMatchObject({ id: 'workflow-1', profile: 'default' })
+    const workflow = JSON.parse((await waitForRpc(responses, 21)).result.content[0].text)
+    expect(workflow.workflow).toMatchObject({ id: 'workflow-1', name: 'Demo workflow' })
+    const createdWorkflow = JSON.parse((await waitForRpc(responses, 22)).result.content[0].text)
+    expect(createdWorkflow.workflow.body).toMatchObject({
+      name: 'Created workflow',
+      profile: 'default',
+      workspace: '/tmp/workflow',
+      nodes: [{ id: 'node-1', type: 'agent' }],
+      edges: [],
+      viewport: { x: 1, y: 2, zoom: 0.8 },
+    })
+    const updatedWorkflow = JSON.parse((await waitForRpc(responses, 23)).result.content[0].text)
+    expect(updatedWorkflow.workflow.body).toEqual({ name: 'Updated workflow', nodes: [{ id: 'node-2' }] })
+    const workflowRuns = JSON.parse((await waitForRpc(responses, 24)).result.content[0].text)
+    expect(workflowRuns.runs[0]).toMatchObject({ id: 'run-1', workflow_id: 'workflow-1' })
+    const startedWorkflowRun = JSON.parse((await waitForRpc(responses, 25)).result.content[0].text)
+    expect(startedWorkflowRun).toMatchObject({ ok: true, status: 'accepted' })
+    expect(startedWorkflowRun.body).toEqual({ start_node_ids: ['node-1'], input: 'go', timeout_ms: 1000 })
+    const stoppedWorkflowRun = JSON.parse((await waitForRpc(responses, 26)).result.content[0].text)
+    expect(stoppedWorkflowRun.run).toMatchObject({ id: 'run-1', status: 'canceled' })
+    const rerunWorkflowRun = JSON.parse((await waitForRpc(responses, 27)).result.content[0].text)
+    expect(rerunWorkflowRun.body).toEqual({ node_id: 'node-2', preserve_start_node: true, timeout_ms: 2000 })
+    const deletedWorkflowRun = JSON.parse((await waitForRpc(responses, 28)).result.content[0].text)
+    expect(deletedWorkflowRun).toEqual({ ok: true, deleted_run: 'run-1' })
+    const deletedWorkflow = JSON.parse((await waitForRpc(responses, 29)).result.content[0].text)
+    expect(deletedWorkflow).toEqual({ ok: true, deleted_workflow: 'workflow-1' })
 
     await new Promise<void>(resolve => server.close(() => resolve()))
   })


### PR DESCRIPTION
## Summary
- Add curated workflow operations to the `hermes-studio-mcp use` toolset.
- Cover workflow list/get/create/update/delete, run list/start/stop/delete, and rerun-from-node.
- Extend MCP stdio tests to verify exposed workflow tools and request mappings.

## Impact
Agents using the `use` MCP server can operate workflows directly without falling back to the generic API requester. The rerun-from-node tool exposes `preserve_start_node` for the keep-current-node-message path.

## Validation
- `npx vitest run tests/server/hermes-web-ui-mcp.test.ts tests/server/workflow-controller.test.ts`
- `npm run harness:check`