### PR TITLE
[codex] Fix bridge session workspace cwd

### DIFF
--- a/docs/chat-chain-changes/2026-06-25-bridge-session-workspace-cwd.md
+++ b/docs/chat-chain-changes/2026-06-25-bridge-session-workspace-cwd.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-25
+pr: 1796
+feature: Bridge session workspace cwd
+impact: Hermes chat runs now pass the selected workspace into Agent Bridge session cwd handling instead of injecting it into model instructions.
+---
+
+Workspace paths are forwarded to chat runs and context estimates so Hermes Agent tools resolve relative paths from the session workspace.

--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -46,6 +46,7 @@ export interface AgentBridgeChatOptions {
   storage_message?: AgentBridgeMessage
   model?: string
   provider?: string
+  workspace?: string
   source?: string
   wait?: boolean
   timeout?: number
@@ -438,6 +439,7 @@ export class AgentBridgeClient {
       ...(profile ? { profile } : {}),
       ...(options.model ? { model: options.model } : {}),
       ...(options.provider ? { provider: options.provider } : {}),
+      ...(options.workspace ? { workspace: options.workspace } : {}),
       ...(options.source ? { source: options.source } : {}),
       ...(options.wait ? { wait: true } : {}),
       ...(options.timeout ? { timeout: options.timeout } : {}),
@@ -452,7 +454,7 @@ export class AgentBridgeClient {
     messages: unknown[],
     instructions?: string,
     profile?: string,
-    options: Pick<AgentBridgeChatOptions, 'model' | 'provider'> = {},
+    options: Pick<AgentBridgeChatOptions, 'model' | 'provider' | 'workspace'> = {},
   ): Promise<AgentBridgeContextEstimate> {
     return this.request<AgentBridgeContextEstimate>({
       action: 'context_estimate',
@@ -462,6 +464,7 @@ export class AgentBridgeClient {
       ...(profile ? { profile } : {}),
       ...(options.model ? { model: options.model } : {}),
       ...(options.provider ? { provider: options.provider } : {}),
+      ...(options.workspace ? { workspace: options.workspace } : {}),
     })
   }
 

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -42,6 +42,37 @@ from bridge_runtime import (
     _tool_names_from_definitions,
 )
 
+
+def _bind_session_workspace_cwd(session_id: str, workspace: str | None) -> bool:
+    workspace_cwd = str(workspace or "").strip()
+    if not workspace_cwd:
+        return False
+    bound = False
+    try:
+        from agent.runtime_cwd import set_session_cwd
+
+        set_session_cwd(workspace_cwd)
+        bound = True
+        try:
+            from tools.terminal_tool import register_task_env_overrides
+
+            register_task_env_overrides(session_id, {"cwd": workspace_cwd})
+        except Exception:
+            pass
+    except Exception:
+        return bound
+    return bound
+
+
+def _clear_session_workspace_cwd() -> None:
+    try:
+        from agent.runtime_cwd import clear_session_cwd
+
+        clear_session_cwd()
+    except Exception:
+        pass
+
+
 class SessionDbHolder:
     def __init__(self) -> None:
         self._lock = threading.Lock()
@@ -556,9 +587,15 @@ class AgentPool:
         profile: str | None = None,
         model: str | None = None,
         provider: str | None = None,
+        workspace: str | None = None,
     ) -> dict[str, Any]:
         session = self.get_or_create(session_id, profile=profile, model=model, provider=provider)
-        context_info = self._estimate_context_info(session.agent, messages or [], instructions)
+        session_cwd_bound = _bind_session_workspace_cwd(session.session_id, workspace)
+        try:
+            context_info = self._estimate_context_info(session.agent, messages or [], instructions)
+        finally:
+            if session_cwd_bound:
+                _clear_session_workspace_cwd()
         print(
             "[hermes_bridge] context estimate "
             f"session={session_id} profile={profile or 'default'} "
@@ -1016,6 +1053,7 @@ class AgentPool:
         force_compress: bool = False,
         model: str | None = None,
         provider: str | None = None,
+        workspace: str | None = None,
         source: str | None = None,
         reasoning_effort: str | None = None,
     ) -> RunRecord:
@@ -1030,20 +1068,25 @@ class AgentPool:
             session.running = True
             session.current_run_id = run_id
             session.last_used_at = time.time()
-            context_event = self._bridge_context_ready_event(session, instructions, profile)
-            if context_event:
-                record.events.append(_jsonable(context_event))
+            session_cwd_bound = _bind_session_workspace_cwd(session.session_id, workspace)
+            try:
+                context_event = self._bridge_context_ready_event(session, instructions, profile)
+                if context_event:
+                    record.events.append(_jsonable(context_event))
+            finally:
+                if session_cwd_bound:
+                    _clear_session_workspace_cwd()
 
         thread = threading.Thread(
             target=self._run_chat,
-            args=(session, record, message, storage_message, instructions, conversation_history, profile, force_compress, source, reasoning_effort),
+            args=(session, record, message, storage_message, instructions, conversation_history, profile, force_compress, workspace, source, reasoning_effort),
             daemon=True,
             name=f"hermes-bridge-run-{run_id[:8]}",
         )
         thread.start()
         return record
 
-    def _run_chat(self, session: AgentSession, record: RunRecord, message: Any, storage_message: Any | None = None, instructions: str | None = None, conversation_history: list[dict[str, Any]] | None = None, profile: str | None = None, force_compress: bool = False, source: str | None = None, reasoning_effort: str | None = None) -> None:
+    def _run_chat(self, session: AgentSession, record: RunRecord, message: Any, storage_message: Any | None = None, instructions: str | None = None, conversation_history: list[dict[str, Any]] | None = None, profile: str | None = None, force_compress: bool = False, workspace: str | None = None, source: str | None = None, reasoning_effort: str | None = None) -> None:
         with _profile_env(profile):
             _refresh_approval_allowlist()
             _install_execute_code_approval_memory_patch()
@@ -1067,10 +1110,12 @@ class AgentPool:
             approval_session_token = None
             registered_gateway_approval_session = None
             exec_ask_scope_entered = False
+            session_cwd_bound = False
             db_count_after_prepersist: int | None = None
             result_for_tail_sync: dict[str, Any] | None = None
             tail_synced = False
             try:
+                session_cwd_bound = _bind_session_workspace_cwd(session.session_id, workspace)
                 try:
                     self._enter_exec_ask_scope()
                     exec_ask_scope_entered = True
@@ -1239,6 +1284,8 @@ class AgentPool:
                         pass
                 if exec_ask_scope_entered:
                     self._exit_exec_ask_scope()
+                if session_cwd_bound:
+                    _clear_session_workspace_cwd()
 
     def interrupt(self, session_id: str, message: str | None = None) -> dict[str, Any]:
         with self._lock:

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
@@ -65,6 +65,7 @@ class BridgeServer:
             profile = req.get("profile")
             model = req.get("model")
             provider = req.get("provider")
+            workspace = req.get("workspace")
             source = req.get("source")
             # Local patch (reasoning-effort): per-session reasoning effort override (Web UI brain button).
             reasoning_effort = req.get("reasoning_effort")
@@ -78,6 +79,7 @@ class BridgeServer:
                 bool(req.get("force_compress")),
                 model,
                 provider,
+                workspace,
                 source,
                 reasoning_effort,
             )
@@ -103,6 +105,7 @@ class BridgeServer:
                 profile=req.get("profile"),
                 model=req.get("model"),
                 provider=req.get("provider"),
+                workspace=req.get("workspace"),
             )
 
         if action == "get_result":

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -219,9 +219,10 @@ function finiteToken(value: unknown): number | undefined {
     : undefined
 }
 
-function cacheBridgeContext(state: SessionState, data: Record<string, unknown> | AgentBridgeContextEstimate) {
+function cacheBridgeContext(state: SessionState, data: Record<string, unknown> | AgentBridgeContextEstimate, workspace?: string | null) {
   const fixedContextTokens = finiteToken(data.fixed_context_tokens)
   if (fixedContextTokens == null) return
+  const resolvedWorkspace = String(workspace || '').trim()
   state.bridgeContext = {
     fixedContextTokens,
     systemPromptTokens: finiteToken(data.system_prompt_tokens),
@@ -232,18 +233,21 @@ function cacheBridgeContext(state: SessionState, data: Record<string, unknown> |
     profile: typeof data.profile === 'string' ? data.profile : state.bridgeContext?.profile,
     model: typeof data.model === 'string' ? data.model : state.bridgeContext?.model,
     provider: typeof data.provider === 'string' ? data.provider : state.bridgeContext?.provider,
+    ...(resolvedWorkspace ? { workspace: resolvedWorkspace } : {}),
   }
 }
 
 function bridgeContextMatches(
   state: SessionState,
-  expected: { profile: string; model?: string | null; provider?: string | null },
+  expected: { profile: string; model?: string | null; provider?: string | null; workspace?: string | null },
 ): boolean {
   const context = state.bridgeContext
   if (!context) return false
   if (context.profile && context.profile !== expected.profile) return false
   if (expected.model && context.model && context.model !== expected.model) return false
   if (expected.provider && context.provider && context.provider !== expected.provider) return false
+  const expectedWorkspace = String(expected.workspace || '').trim()
+  if (expectedWorkspace && context.workspace !== expectedWorkspace) return false
   return true
 }
 
@@ -252,6 +256,7 @@ async function ensureBridgeFixedContext(args: {
   profile: string
   model?: string | null
   provider?: string | null
+  workspace?: string | null
   instructions: string
   state: SessionState
   bridge: AgentBridgeClient
@@ -268,9 +273,9 @@ async function ensureBridgeFixedContext(args: {
       [],
       args.instructions,
       args.profile,
-      { model: args.model ?? undefined, provider: args.provider ?? undefined },
+      { model: args.model ?? undefined, provider: args.provider ?? undefined, workspace: args.workspace ?? undefined },
     )
-    cacheBridgeContext(args.state, estimate)
+    cacheBridgeContext(args.state, estimate, args.workspace)
     const fixedContextTokens = getCachedBridgeContextOverhead(args.state)
     bridgeLogger.info({
       sessionId: args.sessionId,
@@ -342,7 +347,6 @@ export async function handleBridgeRun(
   const socketUser = socket.data.user as AuthenticatedUser | undefined
   await writeModelRunProfileToken(socketUser, profile)
   const runPrompt = [
-    workspace ? `[Current working directory: ${workspace}]` : '',
     'When calling Hermes Web UI endpoints from tools or skills, include the current Hermes profile as the X-Hermes-Profile header if the endpoint supports profile-scoped behavior.',
   ].filter(Boolean).join('\n')
   fullInstructions = `\n${runPrompt}\n${fullInstructions}`
@@ -456,6 +460,7 @@ export async function handleBridgeRun(
         profile,
         model: resolvedModel,
         provider: resolvedProvider,
+        workspace,
         instructions: fullInstructions,
         state,
         bridge,
@@ -507,6 +512,7 @@ export async function handleBridgeRun(
         ...(bridgeStorageInput !== undefined ? { storage_message: bridgeStorageInput } : {}),
         ...(resolvedModel ? { model: resolvedModel } : {}),
         ...(resolvedProvider ? { provider: resolvedProvider } : {}),
+        ...(workspace ? { workspace } : {}),
         // Local patch (reasoning-effort): per-session reasoning effort override.
         ...(data.reasoning_effort ? { reasoning_effort: data.reasoning_effort } : {}),
       },
@@ -546,6 +552,7 @@ export async function handleBridgeRun(
         dequeueNextQueuedRun,
         fullInstructions,
         { model: resolvedModel, provider: resolvedProvider },
+        workspace,
         currentInputTokens,
         shouldPersistUserMessage && displayRole === 'user',
         data.model_groups,
@@ -589,6 +596,7 @@ export async function handleBridgeRun(
         dequeueNextQueuedRun,
         fullInstructions,
         { model: resolvedModel, provider: resolvedProvider },
+        workspace,
         currentInputTokens,
         shouldPersistUserMessage && displayRole === 'user',
         data.model_groups,
@@ -614,6 +622,7 @@ export async function handleBridgeRun(
       profile,
       model: resolvedModel,
       provider: resolvedProvider,
+      workspace,
       instructions: fullInstructions,
       state,
       usage: errUsage,
@@ -655,6 +664,7 @@ export async function resumeBridgeRun(
     instructions: string
     model?: string | null
     provider?: string | null
+    workspace?: string | null
     source?: string | null
   },
   sessionMap: Map<string, SessionState>,
@@ -725,6 +735,7 @@ export async function resumeBridgeRun(
         dequeueNextQueuedRun,
         instructions,
         { model: args.model, provider: args.provider },
+        args.workspace,
       )
     }
     cursor = deltas.length
@@ -757,6 +768,7 @@ export async function resumeBridgeRun(
           dequeueNextQueuedRun,
           instructions,
           { model: args.model, provider: args.provider },
+          args.workspace,
         )
       }
       if (chunk.done) return
@@ -784,6 +796,7 @@ async function refreshFinalContextUsage(args: {
   profile: string
   model?: string | null
   provider?: string | null
+  workspace?: string | null
   instructions: string
   state: SessionState
   usage: { inputTokens: number; outputTokens: number }
@@ -805,6 +818,7 @@ async function refreshFinalContextUsage(args: {
       profile: args.profile,
       model: args.model,
       provider: args.provider,
+      workspace: args.workspace,
       instructions: args.instructions,
       state: args.state,
       bridge: args.bridge,
@@ -876,6 +890,7 @@ async function applyBridgeChunkAsync(
   dequeueNextQueuedRun: (socket: Socket, sessionId: string, fallbackProfile?: string) => void,
   instructions: string,
   modelContext: { model?: string | null; provider?: string | null },
+  workspace?: string | null,
   currentInputTokens = 0,
   currentInputIncludedInDb = true,
   modelGroups?: RunModelGroup[],
@@ -908,7 +923,7 @@ async function applyBridgeChunkAsync(
     if (evType === 'session.title.updated') {
       syncBridgeGeneratedTitle(sessionId, (ev as any).title, emit)
     } else if (evType === 'bridge.context.ready') {
-      cacheBridgeContext(state, ev)
+      cacheBridgeContext(state, ev, workspace)
       const usage = await calcAndUpdateUsage(sessionId, state, emit)
       const snapshotAware = await estimateSnapshotAwareMessageTokens({
         sessionId,
@@ -1242,6 +1257,7 @@ async function applyBridgeChunkAsync(
     profile,
     model: modelContext.model,
     provider: modelContext.provider,
+    workspace,
     instructions,
     state,
     usage,

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -25,7 +25,6 @@ import { contentBlocksToString } from './content-blocks'
 import type { ContentBlock, QueuedRun, SessionState } from './types'
 import { authenticateUserToken, isAuthEnabled, type AuthenticatedUser } from '../../../middleware/user-auth'
 import { userCanAccessProfile } from '../../../db/hermes/users-store'
-import { ensureHermesRunWorkspace } from './workspace'
 
 export type { ContentBlock } from './types'
 
@@ -446,14 +445,6 @@ export class ChatRunSocket {
       let fullInstructions = data.instructions
         ? `${getSystemPrompt(undefined, { source })}\n${data.instructions}`
         : getSystemPrompt(undefined, { source })
-      if (data.session_id) {
-        const sessionRow = getSession(data.session_id)
-        const workspace = await ensureHermesRunWorkspace(profile, sessionRow?.workspace || data.workspace)
-        if (workspace) {
-          const workspaceCtx = `[Current working directory: ${workspace}]`
-          fullInstructions = `\n${workspaceCtx}\n${fullInstructions}`
-        }
-      }
 
       await handleBridgeRun(
         this.nsp, socket, { ...data, instructions: fullInstructions }, profile,
@@ -546,6 +537,7 @@ export class ChatRunSocket {
           instructions,
           model: session?.model,
           provider: session?.provider,
+          workspace: session?.workspace,
           source,
         },
         this.sessionMap,
@@ -583,11 +575,7 @@ export class ChatRunSocket {
 
   private resumeInstructionsForSession(sessionId: string): string {
     const sessionRow = getSession(sessionId)
-    let fullInstructions = getSystemPrompt(undefined, { source: sessionRow?.source })
-    if (sessionRow?.workspace) {
-      fullInstructions = `\n[Current working directory: ${sessionRow.workspace}]\n${fullInstructions}`
-    }
-    return fullInstructions
+    return getSystemPrompt(undefined, { source: sessionRow?.source })
   }
 
   // --- Queue ---

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -107,6 +107,7 @@ export interface BridgeContextState {
   profile?: string
   model?: string
   provider?: string
+  workspace?: string
 }
 
 export type ChatRunSource = 'api_server' | 'cli' | 'coding_agent' | 'global_agent' | 'workflow'

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -46,7 +46,36 @@ def _get_approval_callback():
 
 terminal_tool.set_approval_callback = set_approval_callback
 terminal_tool._get_approval_callback = _get_approval_callback
+terminal_tool._task_env_overrides = {}
+
+def register_task_env_overrides(task_id, overrides):
+    terminal_tool._task_env_overrides[task_id] = dict(overrides or {})
+
+terminal_tool.register_task_env_overrides = register_task_env_overrides
 sys.modules["tools.terminal_tool"] = terminal_tool
+
+agent_pkg = types.ModuleType("agent")
+agent_pkg.__path__ = []
+sys.modules["agent"] = agent_pkg
+
+runtime_cwd = types.ModuleType("agent.runtime_cwd")
+runtime_cwd._cwd = contextvars.ContextVar("runtime_cwd", default="")
+runtime_cwd._cleared = []
+
+def set_session_cwd(cwd):
+    runtime_cwd._cwd.set(cwd or "")
+
+def clear_session_cwd():
+    runtime_cwd._cleared.append(runtime_cwd._cwd.get())
+    runtime_cwd._cwd.set("")
+
+def resolve_agent_cwd():
+    return runtime_cwd._cwd.get()
+
+runtime_cwd.set_session_cwd = set_session_cwd
+runtime_cwd.clear_session_cwd = clear_session_cwd
+runtime_cwd.resolve_agent_cwd = resolve_agent_cwd
+sys.modules["agent.runtime_cwd"] = runtime_cwd
 
 approval = types.ModuleType("tools.approval")
 approval._session_key = contextvars.ContextVar("approval_session_key", default="")
@@ -156,7 +185,7 @@ def make_pool():
     pool._db = FakeDbHolder(fake_db)
     return pool, fake_db
 
-def start_manual_run(pool, session_id, agent, message=None):
+def start_manual_run(pool, session_id, agent, message=None, workspace=None):
     session = bridge.AgentSession(session_id=session_id, agent=agent)
     run_id = f"run-{session_id}"
     record = bridge.RunRecord(run_id=run_id, session_id=session_id)
@@ -167,7 +196,7 @@ def start_manual_run(pool, session_id, agent, message=None):
         pool._runs[run_id] = record
     thread = threading.Thread(
         target=pool._run_chat,
-        args=(session, record, message or f"message:{session_id}", None, None, [], "default", False, "api_server"),
+        args=(session, record, message or f"message:{session_id}", None, None, [], "default", False, workspace, "api_server"),
         daemon=True,
     )
     thread.start()
@@ -1202,6 +1231,44 @@ assert events == [
     ("lock-free-during-shutdown", True),
     "shutdown-finished",
 ], events
+`)
+  })
+
+  it('binds workspace cwd per running session without process-wide cwd state', () => {
+    runPython(String.raw`
+${harness}
+
+class WorkspaceAgent:
+    def __init__(self):
+        self.seen = []
+
+    def run_conversation(self, message, session_id=None, stream_callback=None, **kwargs):
+        from agent.runtime_cwd import resolve_agent_cwd
+
+        cwd = resolve_agent_cwd()
+        self.seen.append((session_id, cwd))
+        if stream_callback:
+            stream_callback(cwd)
+        time.sleep(0.05)
+        return {"output": cwd}
+
+pool, _fake_db = make_pool()
+agent_a = WorkspaceAgent()
+agent_b = WorkspaceAgent()
+
+session_a, record_a, thread_a = start_manual_run(pool, "session-a", agent_a, "a", "/repo/a")
+session_b, record_b, thread_b = start_manual_run(pool, "session-b", agent_b, "b", "/repo/b")
+
+thread_a.join(timeout=2)
+thread_b.join(timeout=2)
+assert not thread_a.is_alive(), record_a.result
+assert not thread_b.is_alive(), record_b.result
+
+assert [cwd for _session_id, cwd in agent_a.seen] == ["/repo/a"], agent_a.seen
+assert [cwd for _session_id, cwd in agent_b.seen] == ["/repo/b"], agent_b.seen
+assert terminal_tool._task_env_overrides["session-a"] == {"cwd": "/repo/a"}, terminal_tool._task_env_overrides
+assert terminal_tool._task_env_overrides["session-b"] == {"cwd": "/repo/b"}, terminal_tool._task_env_overrides
+assert runtime_cwd.resolve_agent_cwd() == "", runtime_cwd.resolve_agent_cwd()
 `)
   })
 })

--- a/tests/server/agent-bridge-reasoning-effort.test.ts
+++ b/tests/server/agent-bridge-reasoning-effort.test.ts
@@ -57,4 +57,42 @@ describe('AgentBridgeClient.chat reasoning_effort forwarding', () => {
     expect(call).toBeDefined()
     expect(call).not.toHaveProperty('reasoning_effort')
   })
+
+  it('forwards workspace to chat and context estimate requests', async () => {
+    const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+    const client = new AgentBridgeClient({ endpoint: 'tcp://127.0.0.1:1', connectRetryMs: 0, timeoutMs: 1 })
+    const request = vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({
+        ok: true,
+        run_id: 'r-workspace',
+        session_id: 's-workspace',
+        status: 'running',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        session_id: 's-workspace',
+        token_count: 0,
+        message_count: 0,
+        tool_count: 0,
+        system_prompt_chars: 0,
+      })
+
+    await client.chat('s-workspace', 'hello', undefined, undefined, 'default', {
+      workspace: 'C:\\Users\\tester\\workspace',
+    })
+    await client.contextEstimate('s-workspace', [], undefined, 'default', {
+      workspace: 'C:\\Users\\tester\\workspace',
+    })
+
+    expect(request.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      action: 'chat',
+      session_id: 's-workspace',
+      workspace: 'C:\\Users\\tester\\workspace',
+    }))
+    expect(request.mock.calls[1]?.[0]).toEqual(expect.objectContaining({
+      action: 'context_estimate',
+      session_id: 's-workspace',
+      workspace: 'C:\\Users\\tester\\workspace',
+    }))
+  })
 })

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -202,10 +202,15 @@ describe('bridge run final context usage', () => {
       [],
       expect.not.stringContaining('[Current Hermes profile:'),
       'default',
-      { model: 'gpt-test', provider: 'openai' },
+      {
+        model: 'gpt-test',
+        provider: 'openai',
+        workspace: '/tmp/hermes-bridge-final-context/default/workspace',
+      },
     )
     expect(bridge.contextEstimate.mock.calls[0][2]).toContain('system prompt')
     expect(bridge.contextEstimate.mock.calls[0][2]).toContain('X-Hermes-Profile')
+    expect(bridge.contextEstimate.mock.calls[0][2]).not.toContain('Current working directory')
     expect(state.contextTokens).toBe(12345)
     expect(emit).toHaveBeenCalledWith('usage.updated', expect.objectContaining({
       inputTokens: 11,
@@ -315,6 +320,7 @@ describe('bridge run final context usage', () => {
     expect(issueModelRunJwtMock).toHaveBeenCalledWith({ id: 1, username: 'admin', role: 'super_admin' })
     expect(readFileSync(join(process.env.HERMES_WEB_UI_HOME || '', 'profiles', 'default', '.model-run-token'), 'utf-8').trim()).toBe('model-run-token')
     expect(instructions).not.toContain('[Current Hermes profile:')
+    expect(instructions).not.toContain('Current working directory')
     expect(instructions).not.toContain('pass the current Hermes profile as the profile argument')
     expect(instructions).not.toContain('model-run-token')
     expect(instructions).not.toContain('Current Hermes Web UI model run token')
@@ -363,6 +369,61 @@ describe('bridge run final context usage', () => {
       workspace: '/tmp/hermes-bridge-final-context/default/workspace',
     }))
     expect(state.source).toBe('global_agent')
+  })
+
+  it('passes the workflow workspace through to bridge runs', async () => {
+    const emit = vi.fn()
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    const state = makeState()
+    const sessionMap = new Map([['workflow-session', state]])
+    const bridge = {
+      chat: vi.fn().mockResolvedValue({ run_id: 'run-workflow', status: 'started' }),
+      contextEstimate: vi.fn().mockResolvedValue({
+        token_count: 42,
+        message_count: 1,
+        tool_count: 0,
+        system_prompt_chars: 13,
+      }),
+      streamOutput: vi.fn(async function* () {
+        yield { run_id: 'run-workflow', done: true, status: 'completed', output: 'done' }
+      }),
+    } as any
+
+    getSessionMock.mockReturnValue(undefined)
+
+    const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    await handleBridgeRun(
+      nsp,
+      socket,
+      {
+        input: 'run workflow node',
+        session_id: 'workflow-session',
+        source: 'workflow',
+        workspace: '/tmp/hermes-workflow-workspace',
+      },
+      'default',
+      sessionMap,
+      bridge,
+      false,
+      vi.fn(),
+      vi.fn(),
+    )
+
+    expect(createSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'workflow-session',
+      source: 'workflow',
+      workspace: '/tmp/hermes-workflow-workspace',
+    }))
+    expect(bridge.chat).toHaveBeenCalledWith(
+      'workflow-session',
+      'run workflow node',
+      expect.any(Array),
+      expect.any(String),
+      'default',
+      expect.objectContaining({ workspace: '/tmp/hermes-workflow-workspace' }),
+    )
+    expect(state.source).toBe('workflow')
   })
 
   it('evaluates active goals after a successful bridge run and queues continuation prompts', async () => {
@@ -747,7 +808,10 @@ describe('bridge run final context usage', () => {
       expect.any(Array),
       expect.any(String),
       'default',
-      expect.objectContaining({ storage_message: '/plan build the feature' }),
+      expect.objectContaining({
+        storage_message: '/plan build the feature',
+        workspace: '/tmp/hermes-bridge-final-context/default/workspace',
+      }),
     )
   })
 
@@ -806,7 +870,10 @@ describe('bridge run final context usage', () => {
       expect.any(Array),
       expect.any(String),
       'default',
-      expect.objectContaining({ storage_message: '[IMPORTANT: expanded skill prompt]' }),
+      expect.objectContaining({
+        storage_message: '[IMPORTANT: expanded skill prompt]',
+        workspace: '/tmp/hermes-bridge-final-context/default/workspace',
+      }),
     )
   })
 


### PR DESCRIPTION
## Summary
- pass selected chat/workflow workspaces through Agent Bridge chat and context estimate requests
- bind Hermes Agent runtime cwd per bridge session instead of relying on prompt text or process cwd
- cover default chat workspace, workflow workspace, Windows-style path forwarding, and concurrent Python bridge sessions

## Impact
Chat and workflow agent tools now resolve relative terminal and file operations from the selected workspace directory. This also removes the old Current working directory instruction injection from the model prompt.

Fixes #1794

## Validation
- python3 -m py_compile packages/server/src/services/hermes/agent-bridge/python/bridge_server.py packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
- npx vitest run tests/server/agent-bridge-reasoning-effort.test.ts tests/server/run-chat-bridge-final-context.test.ts tests/server/agent-bridge-python-concurrency.test.ts
- npm run harness:check
- npx tsc --noEmit -p packages/server/tsconfig.json