### PR TITLE
[codex] Fix MCP admin route access

### DIFF
--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -245,7 +245,7 @@ function openVersionManagement() {
             </svg>
             <span>{{ t("sidebar.versionPreview") }}</span>
           </RouteLinkItem>
-          <RouteLinkItem class="nav-item" :to="{ name: 'hermes.devices' }" :active="selectedKey === 'hermes.devices'">
+          <RouteLinkItem v-if="isSuperAdmin" class="nav-item" :to="{ name: 'hermes.devices' }" :active="selectedKey === 'hermes.devices'">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
               <rect x="3" y="4" width="18" height="12" rx="2" />
               <path d="M8 20h8" />

--- a/packages/client/src/router/index.ts
+++ b/packages/client/src/router/index.ts
@@ -122,6 +122,7 @@ const router = createRouter({
       path: '/hermes/devices',
       name: 'hermes.devices',
       component: () => import('@/views/hermes/DevicesView.vue'),
+      meta: { requiresSuperAdmin: true },
     },
     {
       path: '/hermes/group-chat',
@@ -153,7 +154,6 @@ const router = createRouter({
       path: '/hermes/mcp',
       name: 'hermes.mcp',
       component: () => import('@/views/hermes/McpManagerView.vue'),
-      meta: { requiresSuperAdmin: true },
     },
   ],
 })

--- a/tests/client/sidebar-search.test.ts
+++ b/tests/client/sidebar-search.test.ts
@@ -98,8 +98,13 @@ vi.mock('naive-ui', async () => {
 
 import AppSidebar from '@/components/layout/AppSidebar.vue'
 
+function fakeJwt(payload: Record<string, unknown>) {
+  return `header.${btoa(JSON.stringify(payload)).replace(/=/g, '')}.signature`
+}
+
 describe('AppSidebar navigation', () => {
   beforeEach(() => {
+    localStorage.clear()
     openSessionSearchMock.mockClear()
     mockAppStore.serverVersion = 'test'
     mockAppStore.latestVersion = ''
@@ -155,5 +160,23 @@ describe('AppSidebar navigation', () => {
 
     await agentGroup.find('.nav-group-label').trigger('click')
     expect(agentGroup.find('.nav-group-items').attributes('style')).toContain('display: none')
+  })
+
+  it('keeps MCP visible for admins while hiding device management', () => {
+    localStorage.setItem('hermes_api_key', fakeJwt({ sub: '2', role: 'admin' }))
+    const wrapper = mount(AppSidebar, {
+      global: {
+        stubs: {
+          ProfileSelector: true,
+          ModelSelector: true,
+          LanguageSwitch: true,
+          ThemeSwitch: true,
+          NButton: true,
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('sidebar.mcp')
+    expect(wrapper.text()).not.toContain('sidebar.devices')
   })
 })


### PR DESCRIPTION
## Summary
- allow non-super-admin admins to open the MCP management route
- keep device management restricted to super admins in both route metadata and sidebar navigation
- add sidebar coverage for admin visibility of MCP versus Devices

## Impact
Admins can access the MCP page again, while device management remains super-admin only.

## Validation
- npx vitest run tests/client/sidebar-search.test.ts
- npx vue-tsc -b
- npm run harness:check