### PR TITLE
[codex] fix linux deb install path

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -25,10 +25,10 @@
     "runtime:asset-name": "node scripts/runtime-asset-name.mjs",
     "prune:python": "node scripts/prune-python.mjs",
     "dev": "npm run build:main && electron .",
-    "dist": "npm run build && electron-builder",
-    "dist:mac": "npm run build && electron-builder --mac",
-    "dist:win": "npm run build && electron-builder --win",
-    "dist:linux": "npm run build && electron-builder --linux"
+    "dist": "npm run build && node scripts/electron-builder.mjs",
+    "dist:mac": "npm run build && node scripts/electron-builder.mjs --mac",
+    "dist:win": "npm run build && node scripts/electron-builder.mjs --win",
+    "dist:linux": "npm run build && node scripts/electron-builder.mjs --linux"
   },
   "devDependencies": {
     "@types/node": "^24.12.2",

--- a/packages/desktop/scripts/electron-builder.mjs
+++ b/packages/desktop/scripts/electron-builder.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+
+const args = process.argv.slice(2)
+
+function targetsLinux(value) {
+  return value === '--linux' || value === 'linux' || value.startsWith('--linux=')
+}
+
+function hasConfigOverride(sourceArgs, key) {
+  return sourceArgs.some(arg => arg === `--config.${key}` || arg.startsWith(`--config.${key}=`))
+}
+
+const debConfigArgs = [
+  '--config.productName=hermes-studio',
+  '--config.linux.executableName=hermes-studio',
+  '--config.linux.desktop.Name=Hermes Studio',
+]
+
+function linuxTargetInfo(sourceArgs) {
+  const index = sourceArgs.findIndex(targetsLinux)
+  if (index < 0) return null
+
+  const flag = sourceArgs[index]
+  if (flag.startsWith('--linux=')) {
+    return { index, targets: flag.slice('--linux='.length).split(',').filter(Boolean) }
+  }
+
+  const targets = []
+  for (let i = index + 1; i < sourceArgs.length; i += 1) {
+    const arg = sourceArgs[i]
+    if (arg.startsWith('-')) break
+    targets.push(arg)
+  }
+  return { index, targets }
+}
+
+function withLinuxTargets(sourceArgs, targets) {
+  const info = linuxTargetInfo(sourceArgs)
+  if (!info) return sourceArgs
+
+  const nextArgs = []
+  for (let i = 0; i < sourceArgs.length; i += 1) {
+    const arg = sourceArgs[i]
+    if (i !== info.index) {
+      nextArgs.push(arg)
+      continue
+    }
+
+    nextArgs.push(arg.startsWith('--linux=') ? '--linux' : arg, ...targets)
+    while (i + 1 < sourceArgs.length && !sourceArgs[i + 1].startsWith('-')) {
+      i += 1
+    }
+  }
+  return nextArgs
+}
+
+const binary = process.platform === 'win32' ? 'electron-builder.cmd' : 'electron-builder'
+
+function runBuilder(sourceArgs) {
+  const result = spawnSync(binary, sourceArgs, { stdio: 'inherit' })
+  if (result.error) {
+    console.error(result.error.message)
+    process.exit(1)
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}
+
+function withDebConfig(sourceArgs) {
+  const finalArgs = [...sourceArgs]
+  for (const arg of debConfigArgs) {
+    const key = arg.slice('--config.'.length, arg.indexOf('='))
+    if (!hasConfigOverride(finalArgs, key)) {
+      finalArgs.push(arg)
+    }
+  }
+  return finalArgs
+}
+
+const linuxInfo = linuxTargetInfo(args)
+
+if (!linuxInfo) {
+  runBuilder(args)
+  process.exit(0)
+}
+
+const explicitTargets = linuxInfo.targets
+const targets = explicitTargets.length > 0 ? explicitTargets : ['AppImage', 'deb']
+const hasDeb = targets.includes('deb')
+const nonDebTargets = targets.filter(target => target !== 'deb')
+
+if (!hasDeb) {
+  runBuilder(args)
+  process.exit(0)
+}
+
+runBuilder(withDebConfig(withLinuxTargets(args, ['deb'])))
+
+if (nonDebTargets.length > 0) {
+  runBuilder(withLinuxTargets(args, nonDebTargets))
+}


### PR DESCRIPTION
## Summary
- route desktop packaging through a small electron-builder wrapper
- keep macOS, Windows, and Linux AppImage builds unchanged
- apply a no-space `productName` only when building the Linux deb so it installs under `/opt/hermes-studio`

## Root cause
Electron Builder maps deb app files to `/opt/${productName}`. The existing Linux postinstall script created a no-space compatibility symlink, but the actual deb payload still installed under `/opt/Hermes Studio`, which can break Electron/Chromium launch paths on Linux.

## Validation
- `npm run harness:check`
- `npm --prefix packages/desktop run build`
- wrapper argument smoke test with a fake `electron-builder` binary to confirm only Linux deb receives the deb-specific config

Fixes #1806
