### PR TITLE
fix(history): include local-only coding_agent sessions in History list

### DIFF
--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -422,7 +422,12 @@ export async function listHermesSessions(ctx: any) {
   const historySessionsById = new Map<string, any>()
   for (const session of allSessions) historySessionsById.set(session.id, session)
   for (const session of localSessions) {
-    if (!isArchivedSession(session) || historySessionsById.has(session.id)) continue
+    if (historySessionsById.has(session.id)) continue
+    // Surface local-only sessions that are absent from the Hermes state.db
+    // (e.g. coding_agent runs started via the Web UI such as Claude Code /
+    // Codex). Without this, the History view cannot list or open them, and the
+    // chat panel's "view in history" link dead-ends to an empty list.
+    if (!isArchivedSession(session) && !isHermesHistorySessionSource(session.source)) continue
     historySessionsById.set(session.id, { ...session, webui_imported: true })
   }
   ctx.body = {


### PR DESCRIPTION
## Problem

When a conversation in **Claude Code / Codex mode** (source = `coding_agent`) grows long, the chat panel shows a "view in history" link once the loaded message count exceeds ~300. Clicking it navigates to `#/hermes/history/session/<id>`, but the **History view is empty** — the session is not listed there.

## Root cause

- `coding_agent` sessions are persisted **only** in the Web UI local store (`hermes-web-ui.db`), never in the Hermes CLI `state.db`.
- The History view's session list is sourced from `state.db` via `listSessionSummaries` inside `listHermesSessions`.
- `listHermesSessions` already iterates `localSessions` to merge local-only entries into the result, but it **gates the merge behind `isArchivedSession(session)`**:

```ts
for (const session of localSessions) {
  if (!isArchivedSession(session) || historySessionsById.has(session.id)) continue
  historySessionsById.set(session.id, { ...session, webui_imported: true })
}
```

Active `coding_agent` sessions have `is_archived = 0`, so `!isArchivedSession(session)` is `true` and the loop `continue`s past them — they are never merged, so they never appear in the History list. `HistoryView.de()` then fails to find the target session id and redirects back to an (empty) History list.

## Fix

Drop the archived precondition. Any local-only session whose source passes `isHermesHistorySessionSource` (and matches the optional `source` filter) is now merged:

```ts
for (const session of localSessions) {
  if (historySessionsById.has(session.id)) continue
  if (!isArchivedSession(session) && !isHermesHistorySessionSource(session.source)) continue
  historySessionsById.set(session.id, { ...session, webui_imported: true })
}
```

Archived sessions still merge as before (the `!isArchivedSession && !isHermesHistorySessionSource` guard lets archived ones through regardless of source). The final `filter` is unchanged, so the existing archived-handling behavior is preserved.

Session detail (`getHermesSession`) and paginated-message endpoints already read the local store first, so once a session is listed it opens correctly with the full message history.

## Verification

- `typescript` transpile of the modified file: OK.
- On the affected install (Web UI `0.6.20`): the local store holds 6 `coding_agent` sessions (message counts 32–1006, roles `user`/`assistant`/`tool` all present) while `state.db` contains none of them. With this change all 6 are merged into the History list and open with full messages.

## Scope

One-line logic change in `listHermesSessions`; no schema, API, or UI changes.
