### PR TITLE
[codex] fix windows electron builder wrapper

### DIFF
--- a/packages/desktop/scripts/electron-builder.mjs
+++ b/packages/desktop/scripts/electron-builder.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
 
 const args = process.argv.slice(2)
+const require = createRequire(import.meta.url)
+const electronBuilderCli = require.resolve('electron-builder/cli')
 
 function targetsLinux(value) {
   return value === '--linux' || value === 'linux' || value.startsWith('--linux=')
@@ -55,10 +58,8 @@ function withLinuxTargets(sourceArgs, targets) {
   return nextArgs
 }
 
-const binary = process.platform === 'win32' ? 'electron-builder.cmd' : 'electron-builder'
-
 function runBuilder(sourceArgs) {
-  const result = spawnSync(binary, sourceArgs, { stdio: 'inherit' })
+  const result = spawnSync(process.execPath, [electronBuilderCli, ...sourceArgs], { stdio: 'inherit' })
   if (result.error) {
     console.error(result.error.message)
     process.exit(1)


### PR DESCRIPTION
## Summary
- run electron-builder through its Node CLI entrypoint from the desktop wrapper
- avoid directly spawning electron-builder.cmd on Windows, which fails with EINVAL in GitHub Actions

## Root cause
The Linux deb wrapper introduced in #1807 routed all desktop builds through scripts/electron-builder.mjs. On Windows it attempted to spawn electron-builder.cmd directly with spawnSync, causing the Manual Desktop Build Windows job to fail before electron-builder/NSIS could run.

## Validation
- node scripts/electron-builder.mjs --help
- npm --prefix packages/desktop run build