### PR TITLE
fix(chat-run): 识别 cron source 并传播 / recognize cron source and propagate from MCP env

### DIFF
--- a/bin/hermes-studio-mcp.mjs
+++ b/bin/hermes-studio-mcp.mjs
@@ -791,12 +791,12 @@ const tools = [
         },
         source: {
           type: 'string',
-          enum: ['cli', 'coding_agent', 'global_agent'],
+          enum: ['cli', 'coding_agent', 'global_agent', 'cron'],
           description: 'Optional run backend source.',
         },
         session_source: {
           type: 'string',
-          enum: ['global_agent'],
+          enum: ['global_agent', 'workflow', 'cron'],
           description: 'Optional session source marker.',
         },
         instructions: {
@@ -1413,10 +1413,19 @@ async function callTool(name, args = {}) {
       })
       return jsonText(await requestEnvelope(path, options))
     }
-    case 'hermes_studio_use_chat_run':
-      return jsonText(await request('/api/chat-run/runs', withAuthArgs(args, {
+    case 'hermes_studio_use_chat_run': {
+      // If HERMES_SESSION_SOURCE is set in this process environment, use
+      // it as a last-resort fallback when the caller did not provide source.
+      // In practice the Python MCP client (tools/mcp_tool.py) already
+      // injects source="cron" into the args before the tool call reaches
+      // here, so this branch is primarily defense-in-depth.
+      const resolvedArgs = { ...args }
+      if (!resolvedArgs.source && process.env.HERMES_SESSION_SOURCE) {
+        resolvedArgs.source = process.env.HERMES_SESSION_SOURCE
+      }
+      return jsonText(await request('/api/chat-run/runs', withAuthArgs(resolvedArgs, {
         method: 'POST',
-        body: pickDefined(args, [
+        body: pickDefined(resolvedArgs, [
           'input',
           'session_id',
           'provider',
@@ -1437,6 +1446,7 @@ async function callTool(name, args = {}) {
           'include_events',
         ]),
       })))
+    }
     case 'hermes_studio_use_sessions_list':
       return jsonText(await request('/api/hermes/sessions', withAuthArgs(args, {
         query: pickDefined(args, ['limit', 'source']),

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -26,7 +26,7 @@ import {
   recordBridgeToolCompleted,
 } from './bridge-message'
 import { summarizeToolArguments } from './response-utils'
-import type { ContentBlock, QueuedRun, SessionState } from './types'
+import type { ChatRunSource, ContentBlock, QueuedRun, SessionState } from './types'
 import type { ChatMessage } from '../../../lib/context-compressor'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
 import { filterBridgeToolCallMarkupDelta, flushPendingToolCallMarkup } from './bridge-delta'
@@ -312,11 +312,13 @@ export async function handleBridgeRun(
   dequeueNextQueuedRun: (socket: Socket, sessionId: string, fallbackProfile?: string) => void,
 ) {
   const { input, session_id, instructions } = data
-  const runSource = data.session_source === 'global_agent' || data.source === 'global_agent'
+  const runSource: ChatRunSource = data.session_source === 'global_agent' || data.source === 'global_agent'
     ? 'global_agent'
     : data.session_source === 'workflow' || data.source === 'workflow'
       ? 'workflow'
-      : 'cli'
+    : data.session_source === 'cron' || data.source === 'cron'
+      ? 'cron'
+      : (data.source || 'cli') as ChatRunSource
   if (!session_id) {
     socket.emit('run.failed', { event: 'run.failed', error: 'session_id is required for cli source' })
     return

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -110,7 +110,7 @@ export interface BridgeContextState {
   workspace?: string
 }
 
-export type ChatRunSource = 'api_server' | 'cli' | 'coding_agent' | 'global_agent' | 'workflow'
+export type ChatRunSource = 'api_server' | 'cli' | 'coding_agent' | 'cron' | 'global_agent' | 'workflow'
 
 export interface BridgeCompressionResult {
   messages: ChatMessage[]


### PR DESCRIPTION
## 问题 / Problem

Cron 计划任务通过 MCP 工具 \`hermes_studio_use_chat_run\` 创建的子会话，被错误标记为 \`source="cli"\`，导致会话溢出到 CLI 列表中。

Child sessions spawned by cron agents via the \`hermes_studio_use_chat_run\` MCP tool were incorrectly created with \`source="cli"\`, causing them to leak into the CLI session list.

### 根因 / Root Cause

1. MCP server 是独立 Node.js 进程，不继承 cron scheduler 设置的 \`HERMES_SESSION_SOURCE=cron\` 环境变量。
2. \`handle-bridge-run.ts\` 只识别 \`global_agent\` 和 \`workflow\`，其他一律 fallback 到 \`"cli"\`。
3. MCP \`source\` enum 中不包含 \`"cron"\`。

### 修复 / Fix

1. **bin/hermes-studio-mcp.mjs** — \`source\`/\`session_source\` enum 增加 \`"cron"\`；未显式传递 source 时从 \`HERMES_SESSION_SOURCE\` 环境变量读取。
2. **handle-bridge-run.ts** — \`runSource\` 检测增加 \`"cron"\` 分支；fallback 时优先使用 \`data.source\` 而非硬编码 \`"cli"\`。
3. **(hermes-agent)** \`cron/scheduler.py\` 已设置 \`source="cron"\` 和环境变量（单独 PR）。

## Changed Files

- \`bin/hermes-studio-mcp.mjs\`
- \`packages/server/src/services/hermes/run-chat/handle-bridge-run.ts\`
