### PR TITLE
docs: add chat chain change fragment for cron source support

### DIFF
--- a/docs/chat-chain-changes/2026-06-28-cron-source.md
+++ b/docs/chat-chain-changes/2026-06-28-cron-source.md
@@ -1,0 +1,4 @@
+date: 2026-06-28
+pr: '#1826'
+feature: chat-run cron source support
+impact: Adds 'cron' to ChatRunSource type and MCP tool source enums; HERMES_SESSION_SOURCE env var propagates session source from cron job environments.


### PR DESCRIPTION
Adds 'cron' to ChatRunSource type and MCP tool source enums. HERMES_SESSION_SOURCE env var propagates session source from cron job environments.