### PR TITLE
[codex] set desktop runtime default to 0.17.0

### DIFF
--- a/packages/desktop/build/runtime-release.json
+++ b/packages/desktop/build/runtime-release.json
@@ -1,3 +1,4 @@
 {
-  "tag": "hermes-0.15.2-runtime"
+  "tag": "hermes-0.17.0-runtime",
+  "hermesAgentVersion": "0.17.0"
 }

--- a/packages/desktop/src/main/cli-shim.ts
+++ b/packages/desktop/src/main/cli-shim.ts
@@ -90,7 +90,7 @@ export function createShimContent(
   executablePath: string,
   platform: NodeJS.Platform = process.platform,
   archName: string = process.arch,
-  runtimeVersion = '0.15.2',
+  runtimeVersion = '0.17.0',
   nodePath = process.execPath,
   webUiScriptPath = resolve(process.cwd(), 'bin', 'hermes-web-ui.mjs'),
 ): string {

--- a/packages/desktop/src/main/paths.ts
+++ b/packages/desktop/src/main/paths.ts
@@ -10,7 +10,7 @@ import {
 import { compareHermesAgentVersions, hermesAgentVersionFromRuntimeTag } from './runtime-version'
 
 const isWin = platform() === 'win32'
-const DEFAULT_HERMES_AGENT_VERSION = '0.15.2'
+const DEFAULT_HERMES_AGENT_VERSION = '0.17.0'
 const MIN_COMPATIBLE_WEB_UI_VERSION = '0.6.14'
 const PACKAGED_RUNTIME_RELEASE_NAME = 'runtime-release.json'
 const ACTIVE_RUNTIME_VERSION_NAME = 'active-version.json'

--- a/tests/desktop/cli-shim.test.ts
+++ b/tests/desktop/cli-shim.test.ts
@@ -64,12 +64,12 @@ describe('Hermes Studio CLI shim', () => {
       'C:\\Users\\Example\\AppData\\Local\\Programs\\Hermes Studio\\Hermes Studio.exe',
       'win32',
       'x64',
-      '0.15.2',
+      undefined,
       'C:\\runtime\\node\\node.exe',
       'C:\\resources\\webui\\bin\\hermes-web-ui.mjs',
     )
 
-    expect(content).toContain('desktop-runtime\\hermes\\0.15.2\\win-x64')
+    expect(content).toContain('desktop-runtime\\hermes\\0.17.0\\win-x64')
     expect(content).toContain('desktop-runtime\\active-version.json')
     expect(content).toContain("$j.platform -eq 'win-x64'")
     expect(content).toContain('[Console]::Out.Write($j.runtimeDirectory)')

--- a/tests/desktop/runtime-manager.test.ts
+++ b/tests/desktop/runtime-manager.test.ts
@@ -45,7 +45,7 @@ function createRuntimeFiles(root: string) {
   writeFileSync(join(root, 'runtime-manifest.json'), JSON.stringify({
     schema: 1,
     platform: process.platform,
-    hermesAgentVersion: '0.15.2',
+    hermesAgentVersion: '0.17.0',
     asset: { name: 'hermes-runtime-test.tar.gz' },
   }))
 }
@@ -80,7 +80,7 @@ describe('desktop runtime manager', () => {
     vi.resetModules()
     process.env = { ...originalEnv }
     process.env.HERMES_WEB_UI_HOME = tempDir('hermes-runtime-home-')
-    process.env.HERMES_DESKTOP_RUNTIME_RELEASE_TAG = 'hermes-0.15.2-runtime'
+    process.env.HERMES_DESKTOP_RUNTIME_RELEASE_TAG = 'hermes-0.17.0-runtime'
     mockElectronApp.isPackaged = false
     mockElectronApp.getAppPath = () => process.cwd()
   })
@@ -103,7 +103,7 @@ describe('desktop runtime manager', () => {
       process.env.HERMES_WEB_UI_HOME!,
       'desktop-runtime',
       'hermes',
-      '0.15.2',
+      '0.17.0',
       'hermes-runtime-test.tar.gz.download',
     )
     mkdirSync(staleDownloadPath, { recursive: true })
@@ -115,7 +115,7 @@ describe('desktop runtime manager', () => {
       process.env.HERMES_WEB_UI_HOME!,
       'desktop-runtime',
       'hermes',
-      '0.15.2',
+      '0.17.0',
       runtimePlatformKey(),
     )
     expect(existsSync(staleDownloadPath)).toBe(true)

--- a/tests/desktop/runtime-paths.test.ts
+++ b/tests/desktop/runtime-paths.test.ts
@@ -130,7 +130,7 @@ describe('desktop runtime paths', () => {
 
     expect(desktopRuntimeDir()).toBe(runtimeDir)
     expect(webuiDir()).toBe(webUiDir)
-    expect(targetDesktopRuntimeDir()).toBe(join(homeDir, 'desktop-runtime', 'hermes', '0.15.2', runtimePlatformKey()))
+    expect(targetDesktopRuntimeDir()).toBe(join(homeDir, 'desktop-runtime', 'hermes', '0.17.0', runtimePlatformKey()))
   })
 
   it('removes downloaded Web UI caches below 0.6.14 so startup falls back to the bundled Web UI', async () => {
@@ -220,11 +220,12 @@ describe('desktop runtime paths', () => {
 
     const { runtimePlatformKey } = await import('../../packages/desktop/src/main/runtime-paths')
     const runtimeDir = join(homeDir, 'desktop-runtime', 'hermes', '0.15.2', runtimePlatformKey())
+    const targetRuntimeDir = join(homeDir, 'desktop-runtime', 'hermes', '0.17.0', runtimePlatformKey())
     createRuntimeWithoutManifest(runtimeDir)
 
     const { desktopRuntimeDir, targetDesktopRuntimeDir } = await import('../../packages/desktop/src/main/paths')
 
     expect(desktopRuntimeDir()).toBe(runtimeDir)
-    expect(targetDesktopRuntimeDir()).toBe(runtimeDir)
+    expect(targetDesktopRuntimeDir()).toBe(targetRuntimeDir)
   })
 })


### PR DESCRIPTION
## Summary
- Set the packaged desktop runtime release metadata to `hermes-0.17.0-runtime`.
- Align desktop runtime and CLI shim fallback versions with Hermes Agent `0.17.0`.
- Update focused desktop tests for the new default download/runtime target.

## Why
Fresh desktop installs without a cached runtime were still resolving the packaged runtime release tag to `0.15.2`, so the runtime download page selected the old runtime.

## Impact
New or missing desktop runtimes now download `0.17.0`. Existing valid cached runtimes are still allowed by the normal desktop startup path.

## Validation
- `npm run test -- tests/desktop/runtime-manager.test.ts tests/desktop/runtime-paths.test.ts tests/desktop/cli-shim.test.ts`
- `npm run harness:check`
