### PR TITLE
fix: MCP autoinject 在 Windows 桌面版使用绝对路径避免 PATH 查找失败

### DIFF
--- a/packages/server/src/services/hermes/studio-mcp-autoinject.ts
+++ b/packages/server/src/services/hermes/studio-mcp-autoinject.ts
@@ -89,13 +89,18 @@ function bundledMcpScriptPath(): string | null {
 }
 
 function managedCommandConfig(toolset: string): Record<string, unknown> {
-  if (isDesktopRuntime()) {
-    return { command: 'hermes-studio-mcp', args: [toolset] }
-  }
-
+  // Prefer the bundled script with an absolute path over a bare command name.
+  // On Windows (especially desktop builds), `hermes-studio-mcp` may not be in
+  // PATH even though the bundled .mjs script exists on disk.  Using
+  // process.execPath + the absolute script path avoids "file not found" errors
+  // when the MCP client tries to spawn the server process.
   const bundledScript = bundledMcpScriptPath()
   if (bundledScript) {
     return { command: process.execPath, args: [bundledScript, toolset] }
+  }
+
+  if (isDesktopRuntime()) {
+    return { command: 'hermes-studio-mcp', args: [toolset] }
   }
 
   logger.warn({ candidates: candidateBundledMcpScripts() }, '[mcp-autoinject] bundled MCP script not found; falling back to PATH command')

--- a/tests/server/studio-mcp-autoinject.test.ts
+++ b/tests/server/studio-mcp-autoinject.test.ts
@@ -205,17 +205,25 @@ describe('studio MCP autoinject', () => {
     expect(updated.data.mcp_servers['hermes-studio-use'].args).toEqual([join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'use'])
   })
 
-  it('uses the desktop command in desktop runtime', async () => {
+  it('prefers bundled script over bare desktop command in desktop runtime', async () => {
     process.env.HERMES_DESKTOP = 'true'
     const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
 
     await injectBundledMcpServer()
 
     const injected = await updateConfigYamlForProfileMock.mock.calls[0][1]({})
-    expect(injected.data.mcp_servers['hermes-studio-api'].command).toBe('hermes-studio-mcp')
-    expect(injected.data.mcp_servers['hermes-studio-api'].args).toEqual(['api'])
-    expect(injected.data.mcp_servers['hermes-studio-devices'].args).toEqual(['devices'])
-    expect(injected.data.mcp_servers['hermes-studio-use'].args).toEqual(['use'])
+    // Even in desktop runtime, the bundled script should take priority
+    // so the MCP client receives an absolute path that works regardless of PATH.
+    expect(injected.data.mcp_servers['hermes-studio-api'].command).toBe(process.execPath)
+    expect(injected.data.mcp_servers['hermes-studio-api'].args).toEqual([
+      join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'api',
+    ])
+    expect(injected.data.mcp_servers['hermes-studio-devices'].args).toEqual([
+      join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'devices',
+    ])
+    expect(injected.data.mcp_servers['hermes-studio-use'].args).toEqual([
+      join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'use',
+    ])
   })
 
   it('removes stale injected tokens from managed server config', async () => {


### PR DESCRIPTION
## 问题描述

在 Windows 桌面版中，Hermes Studio 设置页面的三个内置 MCP 服务器（`hermes-studio-api`、`hermes-studio-devices`、`hermes-studio-use`）全部显示"未连接"。

查看 Hermes 日志：

```
tools.mcp_tool: MCP server 'hermes-studio-api' failed initial connection after 3 attempts,
giving up: [WinError 2] 系统找不到指定的文件。
```

## 根因

`studio-mcp-autoinject.ts` 的 `managedCommandConfig()` 中，桌面模式（`isDesktopRuntime()=true`）直接返回裸命令名：

```typescript
if (isDesktopRuntime()) {
    return { command: 'hermes-studio-mcp', args: [toolset] }
}
```

这会写入 `config.yaml` 的 `command: hermes-studio-mcp`。

但 `hermes-studio-mcp` 对应 `bin/hermes-studio-mcp.mjs`，通过 `package.json` 的 `bin` 字段声明。在桌面版中，`hermes-web-ui` 包并非通过 `npm install -g` 全局安装，因此 npm 不会在 PATH 中创建 `.cmd`/`.bat` wrapper。Windows 上 Python `subprocess`（`shutil.which`）找不到该命令，MCP spawn 失败。

而非桌面模式的逻辑反而是正确的 —— 先通过 `bundledMcpScriptPath()` 查找 bundled script 的绝对路径，找到后使用 `process.execPath`（node）+ 脚本路径的方式：

```typescript
const bundledScript = bundledMcpScriptPath()
if (bundledScript) {
    return { command: process.execPath, args: [bundledScript, toolset] }
}
```

## 修复

将 bundled script 检查提到最前面，桌面和非桌面模式统一优先使用绝对路径。只有当 bundled script 确实不在磁盘上时，才回退到裸命令名。

### 修改前
```typescript
function managedCommandConfig(toolset: string): Record<string, unknown> {
  if (isDesktopRuntime()) {
    return { command: 'hermes-studio-mcp', args: [toolset] }
  }

  const bundledScript = bundledMcpScriptPath()
  if (bundledScript) {
    return { command: process.execPath, args: [bundledScript, toolset] }
  }
  // ...
}
```

### 修改后
```typescript
function managedCommandConfig(toolset: string): Record<string, unknown> {
  const bundledScript = bundledMcpScriptPath()
  if (bundledScript) {
    return { command: process.execPath, args: [bundledScript, toolset] }
  }

  if (isDesktopRuntime()) {
    return { command: 'hermes-studio-mcp', args: [toolset] }
  }
  // ...
}
```

## 验证

修复后，`config.yaml` 中注入的 MCP 配置将变为：
```yaml
command: /path/to/node.exe
args:
  - /path/to/bin/hermes-studio-mcp.mjs
  - api
```

使用绝对路径，不再依赖 PATH 中的命令名解析，Windows 桌面版可正常启动 MCP 服务器。