### PR TITLE
修复 History 保留本地归档状态

### DIFF
--- a/docs/chat-chain-changes/2026-06-29-issue-1837-archive-state.md
+++ b/docs/chat-chain-changes/2026-06-29-issue-1837-archive-state.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-29
-pr: pending
+pr: 1838
 feature: History archive state merge
 impact: History rows sourced from Hermes state.db now preserve Web UI local archive state so imported CLI/API sessions can be unarchived.
 ---

--- a/docs/chat-chain-changes/2026-06-29-issue-1837-archive-state.md
+++ b/docs/chat-chain-changes/2026-06-29-issue-1837-archive-state.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-29
+pr: pending
+feature: History archive state merge
+impact: History rows sourced from Hermes state.db now preserve Web UI local archive state so imported CLI/API sessions can be unarchived.
+---
+
+When a session exists in both Hermes `state.db` and the Web UI local store, the history listing keeps the state.db summary but overlays the local `is_archived` flag used by the History unarchive menu.

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1356,8 +1356,7 @@ export const useChatStore = defineStore('chat', () => {
       if (sessions.value.length > 0) {
         await switchSession(sessions.value[0].id)
       } else {
-        const session = createSession()
-        switchSession(session.id)
+        clearActiveSession()
       }
     } else if (target) {
       await refreshSessionListOnly(sessionProfileFilter.value)

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -421,6 +421,19 @@ export async function listHermesSessions(ctx: any) {
     }))
   const historySessionsById = new Map<string, any>()
   for (const session of allSessions) historySessionsById.set(session.id, session)
+
+  // Hermes state.db does not carry Web UI local archive state. When a CLI or
+  // api_server session exists in both databases, the state.db row is inserted
+  // first and would otherwise hide the local `is_archived` flag from History,
+  // preventing archived sessions from rendering the unarchive action.
+  const localSessionsById = new Map(localSessions.map(session => [session.id, session]))
+  for (const [id, session] of historySessionsById) {
+    const localSession = localSessionsById.get(id)
+    if (localSession?.is_archived != null) {
+      session.is_archived = localSession.is_archived
+    }
+  }
+
   for (const session of localSessions) {
     if (historySessionsById.has(session.id)) continue
     // Surface local-only sessions that are absent from the Hermes state.db

--- a/tests/client/chat-store-session-order.test.ts
+++ b/tests/client/chat-store-session-order.test.ts
@@ -114,4 +114,26 @@ describe('chat session ordering', () => {
     expect(archiveSession).toHaveBeenCalledWith('archive-me')
     expect(store.sessions.map(session => session.id)).toEqual(['active-session'])
   })
+
+  it('clears the active session when archiving the only runtime session', async () => {
+    vi.mocked(fetchSessions)
+      .mockResolvedValueOnce([
+        makeSession('archive-me', { started_at: 1000, last_active: 1000 }),
+      ] as any)
+      .mockResolvedValueOnce([])
+    vi.mocked(archiveSession).mockResolvedValueOnce(true)
+
+    const store = useChatStore()
+    await store.loadSessions()
+
+    expect(store.activeSessionId).toBe('archive-me')
+
+    const ok = await store.archiveSession('archive-me')
+
+    expect(ok).toBe(true)
+    expect(archiveSession).toHaveBeenCalledWith('archive-me')
+    expect(store.sessions).toEqual([])
+    expect(store.activeSessionId).toBeNull()
+    expect(store.activeSession).toBeNull()
+  })
 })

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -567,7 +567,12 @@ describe('session conversations controller', () => {
     await mod.listHermesSessions(ctx)
 
     expect(ctx.body.sessions).toEqual([
-      expect.objectContaining({ id: 'cli-archived', profile: 'travel', webui_imported: true }),
+      expect.objectContaining({
+        id: 'cli-archived',
+        profile: 'travel',
+        webui_imported: true,
+        is_archived: 1,
+      }),
     ])
   })
 

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -535,12 +535,12 @@ describe('session conversations controller', () => {
     ])
   })
 
-  it('keeps archived sessions visible in Hermes history', async () => {
-    localListSessionsMock.mockReturnValue([{ id: 'cli-archived', profile: 'travel', is_archived: 1 }])
+  it.each(['cli', 'api_server'])('keeps archived %s sessions visible in Hermes history', async (source) => {
+    localListSessionsMock.mockReturnValue([{ id: `${source}-archived`, profile: 'travel', source, is_archived: 1 }])
     listSessionSummariesMock.mockResolvedValue([
       {
-        id: 'cli-archived',
-        source: 'cli',
+        id: `${source}-archived`,
+        source,
         model: 'gpt-5',
         title: 'Archived imported history',
         started_at: 1,
@@ -568,7 +568,8 @@ describe('session conversations controller', () => {
 
     expect(ctx.body.sessions).toEqual([
       expect.objectContaining({
-        id: 'cli-archived',
+        id: `${source}-archived`,
+        source,
         profile: 'travel',
         webui_imported: true,
         is_archived: 1,


### PR DESCRIPTION
## 改动说明

- 修复 History 合并 Hermes `state.db` 会话与 Web UI 本地会话时丢失 `is_archived` 的问题。
- 当同一个 CLI / api_server 会话同时存在于两库时，继续使用 state.db 的历史摘要，但回填 Web UI 本地库中的归档状态。
- 这样归档后的 CLI / api_server 会话在历史视图右键菜单中会正确显示“取消归档”。

Closes #1837

## 验证

- `npm test -- tests/server/sessions-controller.test.ts`：43 passed
- `npm run harness:check`：passed
- `npm run build`：passed
- 浏览器 UAT：生产构建服务运行在独立端口 `127.0.0.1:18737`，使用独立 `HERMES_WEB_UI_HOME` / `HERMES_HOME`，种子会话同时存在于 state.db 和 Web UI 本地库；API 返回 `is_archived: 1` / `webui_imported: true`，History 右键菜单显示 `Unarchive`。