### PR TITLE
[codex] add Windows workspace drive picker

### DIFF
--- a/docs/chat-chain-changes/2026-06-30-issue-1836-windows-workspace-drives.md
+++ b/docs/chat-chain-changes/2026-06-30-issue-1836-windows-workspace-drives.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-30
+pr: 1841
+feature: Windows workspace drive picker
+impact: Chat and Workflow workspace selection can browse available Windows drive roots when no WORKSPACE_BASE is configured.
+---
+
+The shared FolderPicker now allows native Windows users to select workspaces from any detected drive letter while preserving the existing WORKSPACE_BASE/home-directory constraint on other platforms or configured deployments.

--- a/packages/client/src/components/hermes/chat/FolderPicker.vue
+++ b/packages/client/src/components/hermes/chat/FolderPicker.vue
@@ -9,6 +9,7 @@ interface FolderEntry {
   name: string
   path: string
   fullPath: string
+  readonly?: boolean
 }
 
 interface FolderListResponse {
@@ -72,6 +73,15 @@ async function loadFolders(subPath = ''): Promise<FolderListResponse | null> {
 }
 
 function relativeParentPath(path: string) {
+  const windowsPath = path.replace(/\//g, '\\')
+  const driveRoot = windowsPath.match(/^([a-zA-Z]:)\\?$/)
+  if (driveRoot) return `${driveRoot[1].toUpperCase()}\\`
+  const driveChild = windowsPath.match(/^([a-zA-Z]:)\\(.+)$/)
+  if (driveChild) {
+    const trimmed = windowsPath.replace(/\\+$/, '')
+    const idx = trimmed.lastIndexOf('\\')
+    return idx <= 2 ? `${driveChild[1].toUpperCase()}\\` : trimmed.slice(0, idx)
+  }
   const parts = path.split('/').filter(Boolean)
   parts.pop()
   return parts.join('/')
@@ -159,9 +169,11 @@ const contextOptions = computed(() => {
     { label: t('files.newFolder'), key: 'newFolder' },
   ]
   if (contextTarget.value) {
-    options.push({ label: t('files.rename'), key: 'rename' })
-    options.push({ type: 'divider', key: 'd2' })
-    options.push({ label: t('files.delete'), key: 'delete' })
+    if (!contextTarget.value.readonly) {
+      options.push({ label: t('files.rename'), key: 'rename' })
+      options.push({ type: 'divider', key: 'd2' })
+      options.push({ label: t('files.delete'), key: 'delete' })
+    }
   }
   return options
 })

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -27,6 +27,7 @@ import { readConfigYamlForProfile } from '../../services/config-helpers'
 import { codingAgentRunManager } from '../../services/agent-runner/coding-agent-run-manager'
 import { AgentBridgeClient, getAgentBridgeManager } from '../../services/hermes/agent-bridge'
 import { ensureHermesRunWorkspace } from '../../services/hermes/run-chat/workspace'
+import { win32 as pathWin32 } from 'path'
 
 function getPendingDeletedSessionIds(): Set<string> {
   return getGroupChatServer()?.getStorage().getPendingDeletedSessionIds() || new Set<string>()
@@ -972,19 +973,105 @@ export async function usageStats(ctx: any) {
   }
 }
 
+function workspaceBaseOverride(): string {
+  return process.env.WORKSPACE_BASE?.trim() || ''
+}
+
+function useWindowsDriveWorkspaceMode(): boolean {
+  return process.platform === 'win32' && !workspaceBaseOverride()
+}
+
+function windowsDriveRoot(pathValue: string): string | null {
+  const match = /^([a-zA-Z]:)[\\/]?$/.exec(pathValue.trim())
+  return match ? `${match[1].toUpperCase()}\\` : null
+}
+
+function normalizeWindowsWorkspacePath(inputPath: string): { base: string; fullPath: string } | null {
+  const raw = String(inputPath || '').trim()
+  if (!/^[a-zA-Z]:[\\/]/.test(raw)) return null
+  const fullPath = pathWin32.resolve(raw)
+  const root = windowsDriveRoot(pathWin32.parse(fullPath).root)
+  if (!root) return null
+  const rel = pathWin32.relative(root, fullPath)
+  if (rel.startsWith('..') || pathWin32.isAbsolute(rel)) return null
+  return { base: root, fullPath }
+}
+
+async function listWindowsWorkspaceDrives() {
+  const { existsSync } = await import('fs')
+  const drives = []
+  for (let code = 65; code <= 90; code += 1) {
+    const root = `${String.fromCharCode(code)}:\\`
+    if (!existsSync(root)) continue
+    drives.push({
+      name: root,
+      path: root,
+      fullPath: root,
+      readonly: true,
+    })
+  }
+  return drives
+}
+
 /**
- * List folders under workspace base path for folder picker.
- * GET /api/hermes/workspace/folders?path=<relative_path>
- * Base: current user's home directory (overridable via WORKSPACE_BASE env)
+ * List folders for the workspace folder picker.
+ * GET /api/hermes/workspace/folders?path=<path>
+ *
+ * By default this is rooted at the current user's home directory, or at
+ * WORKSPACE_BASE when configured. On native Windows without WORKSPACE_BASE, the
+ * picker can browse any available drive letter, while each request remains
+ * constrained to the selected drive root.
  */
 export async function listWorkspaceFolders(ctx: any) {
-  const { resolve, join } = await import('path')
+  const { resolve, join, win32 } = await import('path')
   const { readdir } = await import('fs/promises')
   const { existsSync } = await import('fs')
   const { homedir } = await import('os')
 
-  const WORKSPACE_BASE = process.env.WORKSPACE_BASE?.trim() || homedir()
   const subPath = (ctx.query.path as string) || ''
+  if (useWindowsDriveWorkspaceMode()) {
+    if (!subPath) {
+      const drives = await listWindowsWorkspaceDrives()
+      ctx.body = { base: '', current: '', roots: drives, folders: drives }
+      return
+    }
+
+    const resolved = normalizeWindowsWorkspacePath(subPath)
+    if (!resolved) {
+      ctx.status = 403
+      ctx.body = { error: 'Access denied' }
+      return
+    }
+
+    if (!existsSync(resolved.fullPath)) {
+      ctx.status = 404
+      ctx.body = { error: 'Path not found', folders: [] }
+      return
+    }
+
+    try {
+      const entries = await readdir(resolved.fullPath, { withFileTypes: true })
+      const folders = entries
+        .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+        .map(e => {
+          const fullPath = win32.join(resolved.fullPath, e.name)
+          return {
+            name: e.name,
+            path: fullPath,
+            fullPath,
+          }
+        })
+        .sort((a, b) => a.name.localeCompare(b.name))
+
+      ctx.body = { base: resolved.base, current: resolved.fullPath, folders }
+    } catch (err: any) {
+      ctx.status = 500
+      ctx.body = { error: err.message }
+    }
+    return
+  }
+
+  const WORKSPACE_BASE = workspaceBaseOverride() || homedir()
 
   // Security: prevent path traversal
   const fullPath = resolve(join(WORKSPACE_BASE, subPath))
@@ -1030,7 +1117,17 @@ function invalidWorkspaceFolderName(name: string): boolean {
 async function resolveWorkspaceFolderPath(ctx: any, inputPath: string) {
   const { resolve, join } = await import('path')
   const { homedir } = await import('os')
-  const WORKSPACE_BASE = process.env.WORKSPACE_BASE?.trim() || homedir()
+  if (useWindowsDriveWorkspaceMode()) {
+    const resolved = normalizeWindowsWorkspacePath(inputPath)
+    if (!resolved) {
+      ctx.status = 403
+      ctx.body = { error: 'Access denied' }
+      return null
+    }
+    return resolved
+  }
+
+  const WORKSPACE_BASE = workspaceBaseOverride() || homedir()
   const fullPath = resolve(join(WORKSPACE_BASE, inputPath || ''))
   if (!isPathWithin(fullPath, WORKSPACE_BASE)) {
     ctx.status = 403

--- a/tests/client/folder-picker-windows-drives.test.ts
+++ b/tests/client/folder-picker-windows-drives.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import FolderPicker from '@/components/hermes/chat/FolderPicker.vue'
+
+const requestMock = vi.hoisted(() => vi.fn())
+const messageMock = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+}))
+const dialogMock = vi.hoisted(() => ({
+  warning: vi.fn(),
+}))
+
+vi.mock('@/api/client', () => ({
+  request: requestMock,
+}))
+
+vi.mock('@/utils/clipboard', () => ({
+  copyToClipboard: vi.fn(),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NButton: defineComponent({
+    name: 'NButton',
+    emits: ['click'],
+    setup(_, { slots, emit }) {
+      return () => h('button', { onClick: () => emit('click') }, slots.default?.())
+    },
+  }),
+  NDropdown: defineComponent({
+    name: 'NDropdown',
+    props: { show: Boolean, options: { type: Array, default: () => [] } },
+    setup(props) {
+      return () => h('div', { class: 'dropdown-stub' }, props.show ? JSON.stringify(props.options) : '')
+    },
+  }),
+  NInput: defineComponent({
+    name: 'NInput',
+    inheritAttrs: false,
+    props: { value: { type: String, default: '' }, placeholder: String },
+    emits: ['update:value'],
+    setup(props, { emit }) {
+      return () => h('input', {
+        value: props.value,
+        placeholder: props.placeholder,
+        onInput: (event: Event) => emit('update:value', (event.target as HTMLInputElement).value),
+      })
+    },
+  }),
+  NModal: defineComponent({
+    name: 'NModal',
+    setup(_, { slots }) {
+      return () => h('div', slots.default?.())
+    },
+  }),
+  NSpace: defineComponent({
+    name: 'NSpace',
+    setup(_, { slots }) {
+      return () => h('div', slots.default?.())
+    },
+  }),
+  NSpin: defineComponent({
+    name: 'NSpin',
+    setup() {
+      return () => h('div', { class: 'spin-stub' })
+    },
+  }),
+  useDialog: () => dialogMock,
+  useMessage: () => messageMock,
+}))
+
+describe('FolderPicker Windows drives', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    requestMock.mockImplementation(async (url: string) => {
+      if (url === '/api/hermes/workspace/folders') {
+        return {
+          base: '',
+          current: '',
+          folders: [
+            { name: 'C:\\', path: 'C:\\', fullPath: 'C:\\', readonly: true },
+            { name: 'D:\\', path: 'D:\\', fullPath: 'D:\\', readonly: true },
+          ],
+        }
+      }
+      if (url === '/api/hermes/workspace/folders?path=D%3A%5C') {
+        return {
+          base: 'D:\\',
+          current: 'D:\\',
+          folders: [
+            { name: 'Projects', path: 'D:\\Projects', fullPath: 'D:\\Projects' },
+          ],
+        }
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+  })
+
+  it('renders and expands Windows drive roots', async () => {
+    const wrapper = mount(FolderPicker, { props: { modelValue: null } })
+
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('C:\\')
+    expect(wrapper.text()).toContain('D:\\')
+
+    const drive = wrapper.findAll('.folder-item').find(item => item.text().includes('D:\\'))
+    expect(drive).toBeTruthy()
+
+    await drive!.find('.folder-expand').trigger('click')
+    await flushPromises()
+
+    expect(requestMock).toHaveBeenCalledWith('/api/hermes/workspace/folders?path=D%3A%5C')
+    expect(wrapper.text()).toContain('Projects')
+  })
+})

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -213,6 +213,57 @@ describe('session conversations controller', () => {
     expect(ctx.body.sessions[0]).toMatchObject({ id: 'local-conversation', source: 'cli', title: 'Local' })
   })
 
+  it('lists Windows drive roots for the workspace folder picker', async () => {
+    const originalPlatform = process.platform
+    const originalWorkspaceBase = process.env.WORKSPACE_BASE
+    const readdirMock = vi.fn(async (path: string) => {
+      if (path === 'D:\\') {
+        return [
+          { name: 'Projects', isDirectory: () => true },
+          { name: 'notes.txt', isDirectory: () => false },
+        ]
+      }
+      return []
+    })
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    delete process.env.WORKSPACE_BASE
+    vi.doMock('fs', () => ({
+      existsSync: (path: string) => path === 'C:\\' || path === 'D:\\',
+    }))
+    vi.doMock('fs/promises', () => ({
+      readdir: readdirMock,
+    }))
+
+    try {
+      const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+      const rootCtx: any = { query: {}, body: null }
+
+      await mod.listWorkspaceFolders(rootCtx)
+
+      expect(rootCtx.body.folders).toEqual([
+        { name: 'C:\\', path: 'C:\\', fullPath: 'C:\\', readonly: true },
+        { name: 'D:\\', path: 'D:\\', fullPath: 'D:\\', readonly: true },
+      ])
+
+      const driveCtx: any = { query: { path: 'D:\\' }, body: null }
+      await mod.listWorkspaceFolders(driveCtx)
+
+      expect(readdirMock).toHaveBeenCalledWith('D:\\', { withFileTypes: true })
+      expect(driveCtx.body).toMatchObject({
+        base: 'D:\\',
+        current: 'D:\\',
+        folders: [{ name: 'Projects', path: 'D:\\Projects', fullPath: 'D:\\Projects' }],
+      })
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+      if (originalWorkspaceBase === undefined) delete process.env.WORKSPACE_BASE
+      else process.env.WORKSPACE_BASE = originalWorkspaceBase
+      vi.doUnmock('fs')
+      vi.doUnmock('fs/promises')
+    }
+  })
+
   it('returns clean session context without tool calls or tool results', async () => {
     localGetSessionDetailMock.mockReturnValue({
       id: 'session-context-1',


### PR DESCRIPTION
## Summary
- Add Windows drive-root browsing to the shared workspace folder picker when WORKSPACE_BASE is not configured.
- Keep non-Windows and WORKSPACE_BASE-scoped behavior unchanged.
- Mark drive roots read-only in the picker so users can select or expand them without rename/delete actions.
- Cover both server drive listing and the shared client FolderPicker used by Chat and Workflow.

Closes #1836

## Validation
- `npm run test -- tests/client/folder-picker-windows-drives.test.ts`
- `npm run test -- tests/server/sessions-controller.test.ts`
- `npm run build`