### PR TITLE
[codex] add desktop pet window

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -12,7 +12,7 @@ import { useAppStore } from '@/stores/hermes/app'
 import SessionSearchModal from '@/components/hermes/chat/SessionSearchModal.vue'
 import AuthEventListener from '@/components/auth/AuthEventListener.vue'
 import DefaultCredentialPrompt from '@/components/auth/DefaultCredentialPrompt.vue'
-import WebPet from '@/components/hermes/pets/WebPet.vue'
+import { desktopBridge } from '@/utils/desktop-bridge'
 
 const { isDark, isComic } = useTheme()
 const { t } = useI18n()
@@ -35,11 +35,10 @@ const nodeVersionLow = computed(() => {
   return !isNaN(major) && major < 23
 })
 
-const isDesktopShell = computed(() =>
-  (window as typeof window & { hermesDesktop?: { isDesktop?: boolean } }).hermesDesktop?.isDesktop === true,
-)
+const isDesktopShell = computed(() => desktopBridge()?.isDesktop === true)
+const isDesktopPetRoute = computed(() => route.name === 'desktop.pet')
 const hasDesktopTitleBar = computed(() => {
-  const platform = (window as typeof window & { hermesDesktop?: { platform?: string } }).hermesDesktop?.platform
+  const platform = desktopBridge()?.platform
   return isDesktopShell.value && (platform === 'darwin' || platform === 'win32')
 })
 
@@ -75,7 +74,8 @@ useKeyboard()
       <AuthEventListener />
       <NDialogProvider>
         <NNotificationProvider>
-          <div class="app-shell" :class="{ desktop: isDesktopShell, 'desktop-titlebar-host': hasDesktopTitleBar }">
+          <router-view v-if="isDesktopPetRoute" />
+          <div v-else class="app-shell" :class="{ desktop: isDesktopShell, 'desktop-titlebar-host': hasDesktopTitleBar }">
             <DesktopTitleBar v-if="isDesktopShell" />
             <div v-if="nodeVersionLow" class="node-warning-bar">
               {{ t('sidebar.nodeVersionWarning', { version: appStore.nodeVersion }) }}
@@ -91,9 +91,8 @@ useKeyboard()
               </main>
             </div>
           </div>
-          <SessionSearchModal />
-          <DefaultCredentialPrompt />
-          <WebPet />
+          <SessionSearchModal v-if="!isDesktopPetRoute" />
+          <DefaultCredentialPrompt v-if="!isDesktopPetRoute" />
         </NNotificationProvider>
       </NDialogProvider>
     </NMessageProvider>

--- a/packages/client/src/components/hermes/pets/WebPet.vue
+++ b/packages/client/src/components/hermes/pets/WebPet.vue
@@ -4,6 +4,7 @@ import { useRoute } from 'vue-router'
 import { usePetsStore } from '@/stores/hermes/pets'
 import { usePetStateStore } from '@/stores/hermes/pet-state'
 import { useProfilesStore } from '@/stores/hermes/profiles'
+import { desktopBridge, type DesktopWindowBounds } from '@/utils/desktop-bridge'
 import type { ActivePet, WebPetPosition } from '@/api/hermes/pets'
 import type { PetState } from '@/api/hermes/pet-state'
 
@@ -13,11 +14,17 @@ const SCALE_STEP = 0.06
 const SAVE_DELAY_MS = 350
 const STATE_SETTLE_MS = 180
 const MIN_STATE_VISIBLE_MS = 520
+const DESKTOP_WINDOW_PADDING = 80
+
+const props = defineProps<{
+  desktopWindow?: boolean
+}>()
 
 const route = useRoute()
 const petsStore = usePetsStore()
 const petStateStore = usePetStateStore()
 const profilesStore = useProfilesStore()
+const bridge = desktopBridge()
 
 const canvasRef = ref<HTMLCanvasElement | null>(null)
 const image = ref<HTMLImageElement | null>(null)
@@ -44,7 +51,8 @@ let lastStateChangedAt = 0
 let activeSpriteKey = ''
 let connectedPetProfile: string | null = null
 
-const isLoginPage = computed(() => route.name === 'login')
+const isDesktopWindow = computed(() => props.desktopWindow === true)
+const isLoginPage = computed(() => !isDesktopWindow.value && route.name === 'login')
 const pet = computed(() => petsStore.activePet)
 const visible = computed(() => !isLoginPage.value && !!pet.value?.enabled && !!image.value)
 const frameWidth = computed(() => pet.value?.frameW || 192)
@@ -71,18 +79,34 @@ const stateRow = computed(() => {
   return index >= 0 ? index : 0
 })
 
-const shellStyle = computed(() => ({
-  left: `${position.value.x}px`,
-  top: `${position.value.y}px`,
-  width: `${renderedWidth.value}px`,
-  height: `${renderedHeight.value}px`,
-}))
+const shellStyle = computed(() => {
+  if (isDesktopWindow.value) {
+    return {
+      left: `${DESKTOP_WINDOW_PADDING / 2}px`,
+      top: `${DESKTOP_WINDOW_PADDING / 2}px`,
+      width: `${renderedWidth.value}px`,
+      height: `${renderedHeight.value}px`,
+    }
+  }
+  return {
+    left: `${position.value.x}px`,
+    top: `${position.value.y}px`,
+    width: `${renderedWidth.value}px`,
+    height: `${renderedHeight.value}px`,
+  }
+})
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value))
 }
 
 function clampPosition(next: WebPetPosition): WebPetPosition {
+  if (isDesktopWindow.value) {
+    return {
+      x: Math.round(next.x),
+      y: Math.round(next.y),
+    }
+  }
   const maxX = Math.max(0, window.innerWidth - renderedWidth.value)
   const maxY = Math.max(0, window.innerHeight - renderedHeight.value)
   return {
@@ -92,6 +116,12 @@ function clampPosition(next: WebPetPosition): WebPetPosition {
 }
 
 function defaultPosition(): WebPetPosition {
+  if (isDesktopWindow.value) {
+    return {
+      x: Math.round(window.screenX || 0),
+      y: Math.round(window.screenY || 0),
+    }
+  }
   return clampPosition({
     x: window.innerWidth - renderedWidth.value - 28,
     y: window.innerHeight - renderedHeight.value - 28,
@@ -101,6 +131,70 @@ function defaultPosition(): WebPetPosition {
 function applyPetPreferences(active: ActivePet): void {
   scale.value = clamp(active.scale || 0.33, MIN_SCALE, MAX_SCALE)
   position.value = active.position ? clampPosition(active.position) : defaultPosition()
+  if (isDesktopWindow.value) void syncDesktopWindowBounds(false)
+}
+
+function desktopWindowBounds(): DesktopWindowBounds {
+  return {
+    x: position.value.x,
+    y: position.value.y,
+    width: renderedWidth.value + DESKTOP_WINDOW_PADDING,
+    height: renderedHeight.value + DESKTOP_WINDOW_PADDING,
+  }
+}
+
+function desktopPointerInset(): number {
+  return isDesktopWindow.value ? DESKTOP_WINDOW_PADDING / 2 : 0
+}
+
+async function syncDesktopWindowBounds(show = visible.value): Promise<void> {
+  if (!isDesktopWindow.value || !bridge?.setPetWindowBounds) return
+  const state = await bridge.setPetWindowBounds(desktopWindowBounds())
+  position.value = {
+    x: state.bounds.x,
+    y: state.bounds.y,
+  }
+  if (show && bridge.setPetWindowVisible) await bridge.setPetWindowVisible(true)
+}
+
+async function setDesktopWindowVisible(nextVisible: boolean): Promise<void> {
+  if (!isDesktopWindow.value || !bridge?.setPetWindowVisible) return
+  await bridge.setPetWindowVisible(nextVisible)
+}
+
+async function hydrateDesktopWindowPosition(): Promise<void> {
+  if (!isDesktopWindow.value || !bridge?.getPetWindowState || pet.value?.position) return
+  const state = await bridge.getPetWindowState()
+  position.value = {
+    x: state.bounds.x,
+    y: state.bounds.y,
+  }
+}
+
+async function ensureDesktopAuthReady(): Promise<void> {
+  if (!isDesktopWindow.value || localStorage.getItem('hermes_api_key')) return
+  const token = await bridge?.getToken?.().catch(() => '')
+  if (token) {
+    try {
+      localStorage.setItem('AUTH_TOKEN', token)
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ username: 'admin', password: '123456' }),
+      })
+      const body = await res.json().catch(() => null) as { token?: string; jwt?: string } | null
+      const jwt = body?.token || body?.jwt
+      if (jwt) localStorage.setItem('hermes_api_key', jwt)
+    } catch {
+      /* preload performs the same desktop auto-login; this is a fallback. */
+    }
+  }
+  for (let i = 0; i < 20 && !localStorage.getItem('hermes_api_key'); i += 1) {
+    await new Promise(resolve => window.setTimeout(resolve, 100))
+  }
 }
 
 function draw(): void {
@@ -234,8 +328,8 @@ function handlePointerDown(event: PointerEvent): void {
   overrideDisplayedState('run')
   movementRowOverride.value = ''
   dragOffset.value = {
-    x: event.clientX - position.value.x,
-    y: event.clientY - position.value.y,
+    x: (isDesktopWindow.value ? event.screenX : event.clientX) - position.value.x - desktopPointerInset(),
+    y: (isDesktopWindow.value ? event.screenY : event.clientY) - position.value.y - desktopPointerInset(),
   }
   ;(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId)
 }
@@ -244,14 +338,15 @@ function handlePointerMove(event: PointerEvent): void {
   if (!dragging.value || resizing.value) return
   const previousX = position.value.x
   position.value = clampPosition({
-    x: event.clientX - dragOffset.value.x,
-    y: event.clientY - dragOffset.value.y,
+    x: (isDesktopWindow.value ? event.screenX : event.clientX) - dragOffset.value.x - desktopPointerInset(),
+    y: (isDesktopWindow.value ? event.screenY : event.clientY) - dragOffset.value.y - desktopPointerInset(),
   })
   const deltaX = position.value.x - previousX
   if (Math.abs(deltaX) >= 1) {
     movementRowOverride.value = deltaX < 0 ? 'running-left' : 'running-right'
     draw()
   }
+  if (isDesktopWindow.value) void syncDesktopWindowBounds(false)
   scheduleSave()
 }
 
@@ -274,6 +369,7 @@ function setScale(next: number): void {
   scale.value = clamp(next, MIN_SCALE, MAX_SCALE)
   position.value = clampPosition(before)
   draw()
+  if (isDesktopWindow.value) void syncDesktopWindowBounds()
   scheduleSave()
 }
 
@@ -282,7 +378,7 @@ function handleResizePointerDown(event: PointerEvent): void {
   resizing.value = true
   dragging.value = false
   resizeStart.value = {
-    pointerX: event.clientX,
+    pointerX: isDesktopWindow.value ? event.screenX : event.clientX,
     width: renderedWidth.value,
   }
   ;(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId)
@@ -290,11 +386,13 @@ function handleResizePointerDown(event: PointerEvent): void {
 
 function handleResizePointerMove(event: PointerEvent): void {
   if (!resizing.value) return
-  const width = resizeStart.value.width + event.clientX - resizeStart.value.pointerX
+  const pointerX = isDesktopWindow.value ? event.screenX : event.clientX
+  const width = resizeStart.value.width + pointerX - resizeStart.value.pointerX
   const nextScale = width / frameWidth.value
   scale.value = clamp(nextScale, MIN_SCALE, MAX_SCALE)
   position.value = clampPosition(position.value)
   draw()
+  if (isDesktopWindow.value) void syncDesktopWindowBounds()
   scheduleSave()
 }
 
@@ -311,6 +409,10 @@ function handleWheel(event: WheelEvent): void {
 }
 
 function handleResize(): void {
+  if (isDesktopWindow.value) {
+    draw()
+    return
+  }
   position.value = pet.value?.position ? clampPosition(position.value) : defaultPosition()
   draw()
   scheduleSave()
@@ -332,6 +434,8 @@ async function connectPetStateForProfile(profile?: string | null): Promise<void>
 async function loadForProfile(profile?: string | null): Promise<void> {
   if (isLoginPage.value) return
   shutdownPetConnection()
+  await ensureDesktopAuthReady()
+  await hydrateDesktopWindowPosition()
   const active = await petsStore.loadActivePet()
   if (active?.enabled) await connectPetStateForProfile(profile)
 }
@@ -396,6 +500,12 @@ watch(
   { immediate: true },
 )
 
+watch(visible, shown => {
+  if (!isDesktopWindow.value) return
+  if (shown) void syncDesktopWindowBounds(true)
+  else void setDesktopWindowVisible(false)
+}, { immediate: true })
+
 onMounted(() => {
   lastStateChangedAt = Date.now()
   window.addEventListener('resize', handleResize)
@@ -409,6 +519,7 @@ onUnmounted(() => {
   clearStateSwitchTimer()
   clearStateOverrideTimer()
   petStateStore.disconnect()
+  void setDesktopWindowVisible(false)
   window.removeEventListener('resize', handleResize)
   window.removeEventListener('pagehide', shutdownPetConnection)
   window.removeEventListener('beforeunload', shutdownPetConnection)
@@ -419,7 +530,7 @@ onUnmounted(() => {
   <div
     v-show="visible"
     class="web-pet"
-    :class="{ dragging, resizing }"
+    :class="{ dragging, resizing, 'desktop-window': isDesktopWindow }"
     :style="shellStyle"
     @pointerdown="handlePointerDown"
     @pointermove="handlePointerMove"
@@ -459,12 +570,23 @@ onUnmounted(() => {
   &.resizing {
     cursor: nwse-resize;
   }
+
+  &.desktop-window {
+    background: transparent;
+    border: 0;
+    box-shadow: none;
+    filter: none;
+    outline: 0;
+  }
 }
 
 .web-pet-canvas {
   display: block;
   width: 100%;
   height: 100%;
+  background: transparent;
+  border: 0;
+  outline: 0;
 }
 
 .web-pet-resize {
@@ -512,5 +634,16 @@ onUnmounted(() => {
   box-shadow:
     0 4px 14px rgba(0, 0, 0, 0.3),
     inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.web-pet.desktop-window .web-pet-resize {
+  background: rgba(255, 255, 255, 0.76);
+  border: 0;
+  box-shadow: none;
+  outline: 0;
+}
+
+:global(.dark) .web-pet.desktop-window .web-pet-resize {
+  background: rgba(25, 28, 35, 0.78);
 }
 </style>

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -5,6 +5,7 @@ import { i18n } from './i18n'
 import App from './App.vue'
 import './styles/global.scss'
 import 'katex/dist/katex.min.css'
+import { desktopBridge } from '@/utils/desktop-bridge'
 
 // Apply theme classes before mount to prevent FOUC (Flash of Unstyled Content)
 const savedBrightness = localStorage.getItem('hermes_brightness') || 'system'
@@ -16,8 +17,9 @@ const isDark = savedBrightness === 'dark' || (savedBrightness === 'system' && pr
 
 // Resolve style
 const isComic = savedStyle === 'comic'
-const isDesktopShell =
-  (window as typeof window & { hermesDesktop?: { isDesktop?: boolean } }).hermesDesktop?.isDesktop === true
+const bridge = desktopBridge()
+const isDesktopShell = bridge?.isDesktop === true
+const isDesktopPetWindow = bridge?.windowKind === 'pet' || window.location.hash.startsWith('#/desktop-pet')
 
 // Apply classes to prevent FOUC
 if (isDark) {
@@ -28,6 +30,9 @@ if (isComic) {
 }
 if (isDesktopShell) {
   document.documentElement.classList.add('hermes-desktop-shell')
+}
+if (isDesktopPetWindow) {
+  document.documentElement.classList.add('hermes-desktop-pet-window')
 }
 
 // Read token from URL BEFORE router initializes (hash router strips params)

--- a/packages/client/src/router/index.ts
+++ b/packages/client/src/router/index.ts
@@ -5,6 +5,12 @@ const router = createRouter({
   history: createWebHashHistory(),
   routes: [
     {
+      path: '/desktop-pet',
+      name: 'desktop.pet',
+      component: () => import('@/views/hermes/DesktopPetView.vue'),
+      meta: { public: true },
+    },
+    {
       path: '/',
       name: 'login',
       component: () => import('@/views/LoginView.vue'),

--- a/packages/client/src/styles/global.scss
+++ b/packages/client/src/styles/global.scss
@@ -109,6 +109,13 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.hermes-desktop-pet-window,
+.hermes-desktop-pet-window body,
+.hermes-desktop-pet-window #app {
+  background: transparent !important;
+  background-color: transparent !important;
+}
+
 // Teleported overlays must remain clickable above Electron drag regions.
 .hermes-desktop-shell {
   .n-drawer,

--- a/packages/client/src/utils/desktop-bridge.ts
+++ b/packages/client/src/utils/desktop-bridge.ts
@@ -1,0 +1,41 @@
+export interface DesktopWindowBounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface DesktopPetWindowState {
+  bounds: DesktopWindowBounds
+  visible: boolean
+}
+
+export interface HermesDesktopBridge {
+  getToken: () => Promise<string>
+  retryBootstrap: (source?: 'cf' | 'github') => Promise<void>
+  notifyCompletion: (payload: { title: string; body?: string; icon?: string; tag?: string }) => Promise<boolean>
+  getWindowState: () => Promise<{ isMaximized: boolean }>
+  windowControl: (action: 'minimize' | 'toggle-maximize' | 'close') => Promise<{ isMaximized: boolean }>
+  getPetWindowState?: () => Promise<DesktopPetWindowState>
+  setPetWindowBounds?: (bounds: DesktopWindowBounds) => Promise<DesktopPetWindowState>
+  setPetWindowVisible?: (visible: boolean) => Promise<DesktopPetWindowState>
+  platform: string
+  isDesktop: boolean
+  windowKind?: 'main' | 'pet'
+}
+
+export type WindowWithHermesDesktop = Window & typeof globalThis & {
+  hermesDesktop?: HermesDesktopBridge
+}
+
+export function desktopBridge(): HermesDesktopBridge | undefined {
+  return (window as WindowWithHermesDesktop).hermesDesktop
+}
+
+export function isDesktopShell(): boolean {
+  return desktopBridge()?.isDesktop === true
+}
+
+export function isDesktopPetWindow(): boolean {
+  return desktopBridge()?.windowKind === 'pet'
+}

--- a/packages/client/src/views/hermes/DesktopPetView.vue
+++ b/packages/client/src/views/hermes/DesktopPetView.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import WebPet from '@/components/hermes/pets/WebPet.vue'
+</script>
+
+<template>
+  <main class="desktop-pet-view">
+    <WebPet desktop-window />
+  </main>
+</template>
+
+<style scoped lang="scss">
+:global(html.hermes-desktop-pet-window),
+:global(html.hermes-desktop-pet-window body),
+:global(html.hermes-desktop-pet-window #app) {
+  background: transparent !important;
+  background-color: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  outline: 0 !important;
+}
+
+.desktop-pet-view {
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+  background: transparent !important;
+  background-color: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  outline: 0 !important;
+}
+</style>

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, Tray, shell, ipcMain, nativeImage, Notification } from 'electron'
+import { app, BrowserWindow, Menu, Tray, shell, ipcMain, nativeImage, Notification, screen } from 'electron'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { startWebUiServer, stopWebUiServer, getToken } from './webui-server'
@@ -19,9 +19,16 @@ const PORT = Number(process.env.HERMES_DESKTOP_PORT) || 8748
 const START_HIDDEN = process.argv.includes('--hidden')
 const QUIT_EXISTING = process.argv.includes('--quit')
 const APP_USER_MODEL_ID = 'com.hermeswebui.studio'
+const PET_WINDOW_DEFAULT_WIDTH = 300
+const PET_WINDOW_DEFAULT_HEIGHT = 320
+const PET_WINDOW_MIN_SIZE = 72
+const PET_WINDOW_MAX_SIZE = 1200
 type WindowControlAction = 'minimize' | 'toggle-maximize' | 'close'
+type DesktopWindowBounds = { x: number; y: number; width: number; height: number }
 
 let mainWindow: BrowserWindow | null = null
+let petWindow: BrowserWindow | null = null
+let petWindowLoadPromise: Promise<void> | null = null
 let serverUrl: string | null = null
 let tray: Tray | null = null
 let isQuitting = false
@@ -82,6 +89,111 @@ function showMainWindow() {
 function quitApp() {
   isQuitting = true
   app.quit()
+}
+
+function defaultPetWindowBounds(): DesktopWindowBounds {
+  const { workArea } = screen.getPrimaryDisplay()
+  return {
+    x: Math.round(workArea.x + workArea.width - PET_WINDOW_DEFAULT_WIDTH - 28),
+    y: Math.round(workArea.y + workArea.height - PET_WINDOW_DEFAULT_HEIGHT - 28),
+    width: PET_WINDOW_DEFAULT_WIDTH,
+    height: PET_WINDOW_DEFAULT_HEIGHT,
+  }
+}
+
+function petWindowState() {
+  const target = petWindow && !petWindow.isDestroyed() ? petWindow : null
+  return {
+    bounds: target?.getBounds() || defaultPetWindowBounds(),
+    visible: !!target?.isVisible(),
+  }
+}
+
+function sanitizePetWindowBounds(input: unknown): DesktopWindowBounds | null {
+  if (!input || typeof input !== 'object') return null
+  const value = input as Partial<DesktopWindowBounds>
+  const x = Number(value.x)
+  const y = Number(value.y)
+  const width = Number(value.width)
+  const height = Number(value.height)
+  if (![x, y, width, height].every(Number.isFinite)) return null
+  return {
+    x: Math.round(x),
+    y: Math.round(y),
+    width: Math.round(Math.min(PET_WINDOW_MAX_SIZE, Math.max(PET_WINDOW_MIN_SIZE, width))),
+    height: Math.round(Math.min(PET_WINDOW_MAX_SIZE, Math.max(PET_WINDOW_MIN_SIZE, height))),
+  }
+}
+
+function petRouteUrl(): string | null {
+  if (!serverUrl) return null
+  return `${serverUrl.replace(/#.*$/, '').replace(/\/$/, '')}/#/desktop-pet`
+}
+
+function ensurePetWindow(): BrowserWindow {
+  if (petWindow && !petWindow.isDestroyed()) return petWindow
+
+  petWindow = new BrowserWindow({
+    ...defaultPetWindowBounds(),
+    title: 'Hermes Pet',
+    frame: false,
+    transparent: true,
+    backgroundColor: '#00000000',
+    hasShadow: false,
+    ...(process.platform === 'darwin' ? { roundedCorners: false } : {}),
+    ...(process.platform === 'win32' ? { thickFrame: false } : {}),
+    resizable: false,
+    maximizable: false,
+    minimizable: false,
+    fullscreenable: false,
+    skipTaskbar: true,
+    show: false,
+    acceptFirstMouse: true,
+    autoHideMenuBar: true,
+    alwaysOnTop: true,
+    webPreferences: {
+      preload: join(__dirname, '..', 'preload', 'index.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+      additionalArguments: ['--hermes-window-kind=pet'],
+    },
+  })
+  petWindow.setBackgroundColor('#00000000')
+  petWindow.setHasShadow(false)
+  petWindow.setAlwaysOnTop(true, process.platform === 'darwin' ? 'floating' : 'normal')
+  if (process.platform === 'darwin') {
+    petWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: false })
+  }
+  petWindow.on('closed', () => {
+    petWindow = null
+    petWindowLoadPromise = null
+  })
+  petWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('http://127.0.0.1') || url.startsWith('http://localhost')) {
+      return { action: 'allow' }
+    }
+    shell.openExternal(url).catch(() => undefined)
+    return { action: 'deny' }
+  })
+  return petWindow
+}
+
+async function loadPetWindowRoute(): Promise<void> {
+  const url = petRouteUrl()
+  if (!url) return
+  const target = ensurePetWindow()
+  if (target.webContents.getURL() === url) return
+  if (!petWindowLoadPromise) {
+    petWindowLoadPromise = target.loadURL(url)
+      .catch(err => {
+        console.warn('[desktop-pet] failed to load pet window:', err)
+      })
+      .finally(() => {
+        petWindowLoadPromise = null
+      })
+  }
+  await petWindowLoadPromise
 }
 
 function windowState() {
@@ -472,6 +584,7 @@ async function bootstrap(source?: RuntimeDownloadSource) {
     const url = await startWebUiServer(PORT)
     serverUrl = url
     if (mainWindow) await mainWindow.loadURL(url)
+    await loadPetWindowRoute()
   } catch (err) {
     console.error('Failed to start Web UI server:', err)
     if (mainWindow) {
@@ -492,6 +605,25 @@ ipcMain.handle('hermes-desktop:get-window-state', () => windowState())
 ipcMain.handle('hermes-desktop:window-control', (_event, action?: unknown) => {
   if (action !== 'minimize' && action !== 'toggle-maximize' && action !== 'close') return windowState()
   return handleWindowControl(action)
+})
+ipcMain.handle('hermes-desktop:get-pet-window-state', () => petWindowState())
+ipcMain.handle('hermes-desktop:set-pet-window-bounds', (_event, bounds?: unknown) => {
+  const nextBounds = sanitizePetWindowBounds(bounds)
+  if (!nextBounds) return petWindowState()
+  const target = ensurePetWindow()
+  target.setBounds(nextBounds, false)
+  return petWindowState()
+})
+ipcMain.handle('hermes-desktop:set-pet-window-visible', async (_event, visible?: unknown) => {
+  if (visible === false) {
+    if (!petWindow || petWindow.isDestroyed()) return petWindowState()
+    petWindow.hide()
+    return petWindowState()
+  }
+  await loadPetWindowRoute()
+  const target = ensurePetWindow()
+  target.showInactive()
+  return petWindowState()
 })
 function resolveNotificationIcon(icon: unknown): string {
   if (typeof icon !== 'string') return desktopIcon()

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -1,13 +1,24 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
+type DesktopWindowKind = 'main' | 'pet'
+
+function desktopWindowKind(): DesktopWindowKind {
+  const arg = process.argv.find(item => item.startsWith('--hermes-window-kind='))
+  return arg?.slice('--hermes-window-kind='.length) === 'pet' ? 'pet' : 'main'
+}
+
 contextBridge.exposeInMainWorld('hermesDesktop', {
   getToken: (): Promise<string> => ipcRenderer.invoke('hermes-desktop:get-token'),
   retryBootstrap: (source?: 'cf' | 'github'): Promise<void> => ipcRenderer.invoke('hermes-desktop:retry-bootstrap', source),
   notifyCompletion: (payload: { title: string; body?: string; icon?: string; tag?: string }): Promise<boolean> => ipcRenderer.invoke('hermes-desktop:notify-completion', payload),
   getWindowState: (): Promise<{ isMaximized: boolean }> => ipcRenderer.invoke('hermes-desktop:get-window-state'),
   windowControl: (action: 'minimize' | 'toggle-maximize' | 'close'): Promise<{ isMaximized: boolean }> => ipcRenderer.invoke('hermes-desktop:window-control', action),
+  getPetWindowState: () => ipcRenderer.invoke('hermes-desktop:get-pet-window-state'),
+  setPetWindowBounds: (bounds: { x: number; y: number; width: number; height: number }) => ipcRenderer.invoke('hermes-desktop:set-pet-window-bounds', bounds),
+  setPetWindowVisible: (visible: boolean) => ipcRenderer.invoke('hermes-desktop:set-pet-window-visible', visible),
   platform: process.platform,
   isDesktop: true,
+  windowKind: desktopWindowKind(),
 })
 
 const API_KEY_LS = 'hermes_api_key'


### PR DESCRIPTION
## What changed

- Adds a dedicated Electron transparent pet window that loads `/#/desktop-pet` separately from the main app window.
- Moves desktop pet drag and resize behavior to Electron window bounds while keeping pet scale and position persisted through existing profile preferences.
- Stops rendering the WebPet overlay in the normal web app and desktop main window.
- Adds a shared desktop bridge type helper for main-window and pet-window IPC.
- Hardens the desktop pet view so transparent backgrounds, resize controls, and window chrome do not create visible borders.

## Why

Desktop pets need to remain on the computer desktop independently of the Hermes Studio main window. The previous web overlay was tied to the app shell and could not stay visible after the main window was hidden.

## Validation

- `npm run build`
- `npx vue-tsc -b`
- `npm --prefix packages/desktop run build`
