### PR TITLE
fix: safely show workspace symlink folders

### DIFF
--- a/docs/chat-chain-changes/2026-06-30-workspace-junction-safety.md
+++ b/docs/chat-chain-changes/2026-06-30-workspace-junction-safety.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-30
+commit: 19f7c180
+feature: Workspace folder picker
+impact: workspace folder listing and folder mutation path validation hardened for symlink/junction entries; no chat session persistence/runtime chain semantics changed
+---
+
+# Workspace folder symlink/junction safety
+
+Changed file: `packages/server/src/controllers/hermes/sessions.ts`
+
+The workspace folder picker now realpath-vets browsed folders and directory symlink/junction-like entries. Safe directory symlinks whose target remains under the workspace base can appear in the picker; escaped targets and mutation paths through escaped symlink ancestors are rejected.
+
+This touches the shared sessions controller file, but it does not alter chat session creation, persistence, message ordering, or runtime transport behavior.

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -18,7 +18,7 @@ import { deleteUsage, getUsage, getUsageBatch } from '../../db/hermes/usage-stor
 import type { UsageStatsModelRow, UsageStatsDailyRow } from '../../db/hermes/usage-store'
 import { getModelContextLength } from '../../services/hermes/model-context'
 import { getActiveProfileName, listProfileNamesFromDisk } from '../../services/hermes/hermes-profile'
-import { isPathWithin } from '../../services/hermes/hermes-path'
+import { isNearestExistingRealPathWithin, isPathWithin, isRealPathWithin } from '../../services/hermes/hermes-path'
 import { getGroupChatServer } from '../../routes/hermes/group-chat'
 import { logger } from '../../services/logger'
 import type { ConversationSummary } from '../../services/hermes/conversations'
@@ -1013,6 +1013,21 @@ async function listWindowsWorkspaceDrives() {
   return drives
 }
 
+async function isSafeWorkspaceFolderEntry(entry: any, fullPath: string, basePath: string, statFn: any): Promise<boolean> {
+  if (entry.name.startsWith('.')) return false
+  if (!entry.isDirectory() && !(typeof entry.isSymbolicLink === 'function' && entry.isSymbolicLink())) {
+    return false
+  }
+
+  try {
+    const info = await statFn(fullPath)
+    if (!info.isDirectory()) return false
+    return await isRealPathWithin(fullPath, basePath)
+  } catch {
+    return false
+  }
+}
+
 /**
  * List folders for the workspace folder picker.
  * GET /api/hermes/workspace/folders?path=<path>
@@ -1024,7 +1039,7 @@ async function listWindowsWorkspaceDrives() {
  */
 export async function listWorkspaceFolders(ctx: any) {
   const { resolve, join, win32 } = await import('path')
-  const { readdir } = await import('fs/promises')
+  const { readdir, stat } = await import('fs/promises')
   const { existsSync } = await import('fs')
   const { homedir } = await import('os')
 
@@ -1049,18 +1064,24 @@ export async function listWorkspaceFolders(ctx: any) {
       return
     }
 
+    if (!await isRealPathWithin(resolved.fullPath, resolved.base)) {
+      ctx.status = 403
+      ctx.body = { error: 'Access denied' }
+      return
+    }
+
     try {
       const entries = await readdir(resolved.fullPath, { withFileTypes: true })
-      const folders = entries
-        .filter(e => e.isDirectory() && !e.name.startsWith('.'))
-        .map(e => {
-          const fullPath = win32.join(resolved.fullPath, e.name)
-          return {
-            name: e.name,
-            path: fullPath,
-            fullPath,
-          }
-        })
+      const folders = (await Promise.all(entries.map(async (entry) => {
+        const fullPath = win32.join(resolved.fullPath, entry.name)
+        if (!await isSafeWorkspaceFolderEntry(entry, fullPath, resolved.base, stat)) return null
+        return {
+          name: entry.name,
+          path: fullPath,
+          fullPath,
+        }
+      })))
+        .filter((entry): entry is { name: string; path: string; fullPath: string } => !!entry)
         .sort((a, b) => a.name.localeCompare(b.name))
 
       ctx.body = { base: resolved.base, current: resolved.fullPath, folders }
@@ -1087,15 +1108,24 @@ export async function listWorkspaceFolders(ctx: any) {
     return
   }
 
+  if (!await isRealPathWithin(fullPath, WORKSPACE_BASE)) {
+    ctx.status = 403
+    ctx.body = { error: 'Access denied' }
+    return
+  }
+
   try {
     const entries = await readdir(fullPath, { withFileTypes: true })
-    const folders = entries
-      .filter(e => e.isDirectory() && !e.name.startsWith('.'))
-      .map(e => ({
-        name: e.name,
-        path: subPath ? `${subPath}/${e.name}` : e.name,
-        fullPath: join(fullPath, e.name),
-      }))
+    const folders = (await Promise.all(entries.map(async (entry) => {
+      const entryFullPath = join(fullPath, entry.name)
+      if (!await isSafeWorkspaceFolderEntry(entry, entryFullPath, WORKSPACE_BASE, stat)) return null
+      return {
+        name: entry.name,
+        path: subPath ? `${subPath}/${entry.name}` : entry.name,
+        fullPath: entryFullPath,
+      }
+    })))
+      .filter((entry): entry is { name: string; path: string; fullPath: string } => !!entry)
       .sort((a, b) => a.name.localeCompare(b.name))
 
     ctx.body = { base: WORKSPACE_BASE, current: subPath, folders }
@@ -1156,6 +1186,11 @@ export async function createWorkspaceFolder(ctx: any) {
     ctx.body = { error: 'Access denied' }
     return
   }
+  if (!await isNearestExistingRealPathWithin(targetPath, resolvedParent.base)) {
+    ctx.status = 403
+    ctx.body = { error: 'Access denied' }
+    return
+  }
 
   try {
     await mkdir(targetPath)
@@ -1192,6 +1227,12 @@ export async function renameWorkspaceFolder(ctx: any) {
     ctx.body = { error: 'Access denied' }
     return
   }
+  if (!await isNearestExistingRealPathWithin(resolvedCurrent.fullPath, resolvedCurrent.base) ||
+    !await isNearestExistingRealPathWithin(targetPath, resolvedCurrent.base)) {
+    ctx.status = 403
+    ctx.body = { error: 'Access denied' }
+    return
+  }
 
   try {
     const info = await stat(resolvedCurrent.fullPath)
@@ -1223,6 +1264,11 @@ export async function deleteWorkspaceFolder(ctx: any) {
   if (resolvedCurrent.fullPath === resolvedCurrent.base) {
     ctx.status = 400
     ctx.body = { error: 'Cannot delete workspace root' }
+    return
+  }
+  if (!await isNearestExistingRealPathWithin(resolvedCurrent.fullPath, resolvedCurrent.base)) {
+    ctx.status = 403
+    ctx.body = { error: 'Access denied' }
     return
   }
 

--- a/packages/server/src/services/hermes/hermes-path.ts
+++ b/packages/server/src/services/hermes/hermes-path.ts
@@ -8,7 +8,8 @@
  */
 
 import { existsSync } from 'fs'
-import { basename, dirname, isAbsolute, relative, resolve, join } from 'path'
+import { realpath } from 'fs/promises'
+import { basename, dirname, isAbsolute, relative, resolve, join, win32 as pathWin32 } from 'path'
 import { homedir } from 'os'
 
 /**
@@ -77,15 +78,86 @@ function comparablePath(path: string): string {
   return process.platform === 'win32' ? path.toLowerCase() : path
 }
 
+function looksLikeWindowsPath(path: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(path)
+}
+
+function useWindowsPathOps(...paths: string[]): boolean {
+  return process.platform === 'win32' || paths.some(looksLikeWindowsPath)
+}
+
+function resolveComparablePath(path: string, useWindows: boolean): string {
+  return useWindows ? pathWin32.resolve(path) : resolve(path)
+}
+
+function relativeComparablePath(from: string, to: string, useWindows: boolean): string {
+  return useWindows ? pathWin32.relative(from, to) : relative(from, to)
+}
+
+function isComparableAbsolute(path: string, useWindows: boolean): boolean {
+  return useWindows ? pathWin32.isAbsolute(path) : isAbsolute(path)
+}
+
+function dirnameComparablePath(path: string, useWindows: boolean): string {
+  return useWindows ? pathWin32.dirname(path) : dirname(path)
+}
+
 export function isPathWithin(targetPath: string, basePath: string): boolean {
-  const base = resolve(basePath)
-  const target = resolve(targetPath)
-  const rel = relative(comparablePath(base), comparablePath(target))
-  return rel === '' || (!!rel && !rel.startsWith('..') && !isAbsolute(rel))
+  const useWindows = useWindowsPathOps(targetPath, basePath)
+  const base = resolveComparablePath(basePath, useWindows)
+  const target = resolveComparablePath(targetPath, useWindows)
+  const rel = relativeComparablePath(comparablePath(base), comparablePath(target), useWindows)
+  return rel === '' || (!!rel && !rel.startsWith('..') && !isComparableAbsolute(rel, useWindows))
 }
 
 export function relativePathFromBase(targetPath: string, basePath: string): string | null {
   if (!isPathWithin(targetPath, basePath)) return null
-  const rel = relative(resolve(basePath), resolve(targetPath))
+  const useWindows = useWindowsPathOps(targetPath, basePath)
+  const rel = relativeComparablePath(
+    resolveComparablePath(basePath, useWindows),
+    resolveComparablePath(targetPath, useWindows),
+    useWindows,
+  )
   return rel.replace(/\\/g, '/')
+}
+
+export async function realPathOrResolved(targetPath: string): Promise<string> {
+  try {
+    return await realpath(targetPath)
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT' && err?.code !== 'ENOTDIR') throw err
+    return resolveComparablePath(targetPath, useWindowsPathOps(targetPath))
+  }
+}
+
+export async function nearestExistingRealPath(targetPath: string): Promise<string | null> {
+  const useWindows = useWindowsPathOps(targetPath)
+  let current = resolveComparablePath(targetPath, useWindows)
+  while (true) {
+    try {
+      return await realpath(current)
+    } catch (err: any) {
+      if (err?.code !== 'ENOENT' && err?.code !== 'ENOTDIR') throw err
+    }
+
+    const parent = dirnameComparablePath(current, useWindows)
+    if (parent === current) return null
+    current = parent
+  }
+}
+
+export async function isRealPathWithin(targetPath: string, basePath: string): Promise<boolean> {
+  const [realTargetPath, realBasePath] = await Promise.all([
+    realPathOrResolved(targetPath),
+    realPathOrResolved(basePath),
+  ])
+  return isPathWithin(realTargetPath, realBasePath)
+}
+
+export async function isNearestExistingRealPathWithin(targetPath: string, basePath: string): Promise<boolean> {
+  const [realAncestorPath, realBasePath] = await Promise.all([
+    nearestExistingRealPath(targetPath),
+    realPathOrResolved(basePath),
+  ])
+  return !!realAncestorPath && isPathWithin(realAncestorPath, realBasePath)
 }

--- a/tests/server/file-provider-paths.test.ts
+++ b/tests/server/file-provider-paths.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { join, resolve } from 'path'
 import { tmpdir } from 'os'
+import { mkdir, mkdtemp, rm, symlink } from 'fs/promises'
 import { normalizePlatformPath, validatePath } from '../../packages/server/src/services/hermes/file-provider'
-import { isPathWithin, relativePathFromBase } from '../../packages/server/src/services/hermes/hermes-path'
+import { isNearestExistingRealPathWithin, isPathWithin, isRealPathWithin, relativePathFromBase } from '../../packages/server/src/services/hermes/hermes-path'
 
 describe('file provider platform path normalization', () => {
   it('converts MSYS drive paths to Windows absolute paths on Windows', () => {
@@ -48,5 +49,30 @@ describe('Hermes path containment helpers', () => {
       .toBe('logs/run.txt')
     expect(relativePathFromBase('/tmp/hermes-profile2/logs/run.txt', '/tmp/hermes-profile'))
       .toBeNull()
+  })
+
+  it('realpath-vets symlinked ancestors before allowing nested workspace operations', async () => {
+    const workspaceBase = await mkdtemp(join(tmpdir(), 'hermes-workspace-base-'))
+    const outsideRoot = await mkdtemp(join(tmpdir(), 'hermes-workspace-outside-'))
+
+    try {
+      const safeTarget = join(workspaceBase, 'projects')
+      const safeLink = join(workspaceBase, 'linked-projects')
+      const outsideTarget = join(outsideRoot, 'external-projects')
+      const outsideLink = join(workspaceBase, 'linked-external')
+
+      await mkdir(safeTarget, { recursive: true })
+      await mkdir(outsideTarget, { recursive: true })
+      await symlink(safeTarget, safeLink)
+      await symlink(outsideTarget, outsideLink)
+
+      await expect(isRealPathWithin(safeLink, workspaceBase)).resolves.toBe(true)
+      await expect(isRealPathWithin(outsideLink, workspaceBase)).resolves.toBe(false)
+      await expect(isNearestExistingRealPathWithin(join(safeLink, 'child'), workspaceBase)).resolves.toBe(true)
+      await expect(isNearestExistingRealPathWithin(join(outsideLink, 'child'), workspaceBase)).resolves.toBe(false)
+    } finally {
+      await rm(workspaceBase, { recursive: true, force: true })
+      await rm(outsideRoot, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, rm, symlink } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
 
 const listConversationSummariesFromDbMock = vi.fn()
 const getConversationDetailFromDbMock = vi.fn()
@@ -233,6 +236,8 @@ describe('session conversations controller', () => {
     }))
     vi.doMock('fs/promises', () => ({
       readdir: readdirMock,
+      stat: vi.fn(async () => ({ isDirectory: () => true })),
+      realpath: vi.fn(async (path: string) => path),
     }))
 
     try {
@@ -261,6 +266,105 @@ describe('session conversations controller', () => {
       else process.env.WORKSPACE_BASE = originalWorkspaceBase
       vi.doUnmock('fs')
       vi.doUnmock('fs/promises')
+    }
+  })
+
+  it('lists symlinked workspace folders that resolve within WORKSPACE_BASE and blocks escaped links', async () => {
+    const originalWorkspaceBase = process.env.WORKSPACE_BASE
+    const workspaceBase = await mkdtemp(join(tmpdir(), 'hermes-workspace-picker-'))
+    const outsideRoot = await mkdtemp(join(tmpdir(), 'hermes-workspace-picker-outside-'))
+
+    try {
+      const safeTarget = join(workspaceBase, 'workspace-target')
+      const safeChild = join(safeTarget, 'nested-child')
+      const safeLink = join(workspaceBase, 'linked-workspace')
+      const outsideTarget = join(outsideRoot, 'external-target')
+      const outsideLink = join(workspaceBase, 'linked-external')
+
+      await mkdir(safeChild, { recursive: true })
+      await mkdir(outsideTarget, { recursive: true })
+      await symlink(safeTarget, safeLink)
+      await symlink(outsideTarget, outsideLink)
+      process.env.WORKSPACE_BASE = workspaceBase
+
+      const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+      const rootCtx: any = { query: {}, body: null }
+      await mod.listWorkspaceFolders(rootCtx)
+
+      expect(rootCtx.status).toBeUndefined()
+      expect(rootCtx.body).toEqual({
+        base: workspaceBase,
+        current: '',
+        folders: [
+          { name: 'linked-workspace', path: 'linked-workspace', fullPath: safeLink },
+          { name: 'workspace-target', path: 'workspace-target', fullPath: safeTarget },
+        ],
+      })
+
+      const nestedCtx: any = { query: { path: 'linked-workspace' }, body: null }
+      await mod.listWorkspaceFolders(nestedCtx)
+
+      expect(nestedCtx.status).toBeUndefined()
+      expect(nestedCtx.body).toEqual({
+        base: workspaceBase,
+        current: 'linked-workspace',
+        folders: [
+          { name: 'nested-child', path: 'linked-workspace/nested-child', fullPath: join(safeLink, 'nested-child') },
+        ],
+      })
+
+      const escapedCtx: any = { query: { path: 'linked-external' }, body: null }
+      await mod.listWorkspaceFolders(escapedCtx)
+
+      expect(escapedCtx.status).toBe(403)
+      expect(escapedCtx.body).toEqual({ error: 'Access denied' })
+    } finally {
+      if (originalWorkspaceBase === undefined) delete process.env.WORKSPACE_BASE
+      else process.env.WORKSPACE_BASE = originalWorkspaceBase
+      await rm(workspaceBase, { recursive: true, force: true })
+      await rm(outsideRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('blocks workspace folder mutations through symlinked ancestors that escape WORKSPACE_BASE', async () => {
+    const originalWorkspaceBase = process.env.WORKSPACE_BASE
+    const workspaceBase = await mkdtemp(join(tmpdir(), 'hermes-workspace-mutation-'))
+    const outsideRoot = await mkdtemp(join(tmpdir(), 'hermes-workspace-mutation-outside-'))
+
+    try {
+      const outsideTarget = join(outsideRoot, 'external-target')
+      const escapeLink = join(workspaceBase, 'escape-link')
+
+      await mkdir(outsideTarget, { recursive: true })
+      await symlink(outsideTarget, escapeLink)
+      process.env.WORKSPACE_BASE = workspaceBase
+
+      const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+
+      const createCtx: any = { request: { body: { parentPath: 'escape-link', name: 'created' } }, body: null }
+      await mod.createWorkspaceFolder(createCtx)
+      expect(createCtx.status).toBe(403)
+      expect(createCtx.body).toEqual({ error: 'Access denied' })
+
+      const renameCtx: any = { request: { body: { path: 'escape-link', name: 'renamed-link' } }, body: null }
+      await mod.renameWorkspaceFolder(renameCtx)
+      expect(renameCtx.status).toBe(403)
+      expect(renameCtx.body).toEqual({ error: 'Access denied' })
+
+      const deleteCtx: any = { request: { body: { path: 'escape-link' } }, body: null }
+      await mod.deleteWorkspaceFolder(deleteCtx)
+      expect(deleteCtx.status).toBe(403)
+      expect(deleteCtx.body).toEqual({ error: 'Access denied' })
+
+      const { access } = await import('fs/promises')
+      await expect(access(escapeLink)).resolves.toBeUndefined()
+      await expect(access(join(outsideTarget, 'created'))).rejects.toMatchObject({ code: 'ENOENT' })
+      await expect(access(join(workspaceBase, 'renamed-link'))).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally {
+      if (originalWorkspaceBase === undefined) delete process.env.WORKSPACE_BASE
+      else process.env.WORKSPACE_BASE = originalWorkspaceBase
+      await rm(workspaceBase, { recursive: true, force: true })
+      await rm(outsideRoot, { recursive: true, force: true })
     }
   })
 


### PR DESCRIPTION
## 改动说明
- Workspace chooser 列目录时不再只依赖 `Dirent.isDirectory()`，而是对 symlink/junction-like 条目执行 `stat()` 和 realpath containment 校验。
- 只有真实目标仍在 workspace base 内的目录 symlink/junction 会显示。
- create / rename / delete folder 路径现在会检查最近存在祖先的 realpath，阻止通过逃逸 symlink/junction 绕过 workspace base。
- 抽出 realpath containment helper，并补充 Windows drive-style 路径测试覆盖。

Fixes #1456

## 验证
- `npx vitest run tests/server/sessions-controller.test.ts tests/server/file-provider-paths.test.ts tests/server/files-routes.test.ts`：通过，3 files / 62 tests。
- `npm run build`：通过。
- `git diff --check`：通过。
- 说明：本地环境为 macOS，真实 Windows junction 需要维护者/Windows 环境复测；核心 server/path 逻辑已用 focused tests 覆盖 safe symlink、escaped symlink、mutation bypass case。
