### PR TITLE
fix: clarify new chat drawer action

### DIFF
--- a/docs/chat-chain-changes/2026-06-30-new-chat-create-label.md
+++ b/docs/chat-chain-changes/2026-06-30-new-chat-create-label.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-30
+commit: 9d526dad
+feature: Chat / New Chat drawer
+impact: label-only drawer confirmation copy change; no chat-chain persistence or runtime behavior impact
+---
+
+# New Chat drawer confirmation label
+
+Changed file: `packages/client/src/components/hermes/chat/ChatPanel.vue`
+
+The left-sidebar trigger remains labeled as the entry action (`chat.newChat`). The drawer submit button now uses the existing create confirmation label (`common.create`) so the trigger and final confirmation action are not both rendered as “New Chat”.
+
+No chat-chain persistence, message ordering, fork/session identity, or runtime transport behavior changes.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -1555,7 +1555,7 @@ async function handleSessionModelCustomSubmit() {
               :disabled="!canConfirmNewChat"
               @click="confirmNewChat"
             >
-              {{ t("chat.newChat") }}
+              {{ t("common.create") }}
             </NButton>
           </div>
         </template>

--- a/tests/client/chat-panel-session-click.test.ts
+++ b/tests/client/chat-panel-session-click.test.ts
@@ -30,4 +30,11 @@ describe('ChatPanel session clicks', () => {
     expect(source).toContain('profile === activeProfileName')
     expect(source).toContain('selectedGroup?.models.includes(selectedModel)')
   })
+
+  it('uses a create action in the new chat drawer instead of duplicating the new chat trigger label', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+
+    expect(source).toContain('{{ t("common.create") }}')
+    expect(source).not.toContain('{{ t("chat.newChat") }}\n            </NButton>')
+  })
 })


### PR DESCRIPTION
## 改动说明
- New Chat 左侧入口仍保持 `chat.newChat`。
- New Chat drawer 的提交按钮改用现有 `common.create` 文案，避免入口和确认动作都显示为 “New Chat”。
- 添加 focused regression test，确保 drawer footer 使用 create action 而不是重复 trigger label。

Fixes #1766

## 验证
- `npx vitest run tests/client/chat-panel-session-click.test.ts`：通过。
- `npm run build`：通过。
- `git diff --check`：通过。
- `npm run harness:check`：通过；已添加 `docs/chat-chain-changes/2026-06-30-new-chat-create-label.md`。
