### PR TITLE
[codex] fix desktop Petdex previews

### DIFF
--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -8,6 +8,16 @@ function isDesktopShell(): boolean {
     (window as typeof window & { hermesDesktop?: { isDesktop?: boolean } }).hermesDesktop?.isDesktop === true
 }
 
+async function ensureDesktopAuthReady(): Promise<void> {
+  if (typeof window === 'undefined' || getApiKey()) return
+  const bridge = (window as typeof window & {
+    hermesDesktop?: { isDesktop?: boolean; ensureAuth?: () => Promise<boolean> }
+  }).hermesDesktop
+  if (bridge?.isDesktop === true && bridge.ensureAuth) {
+    await bridge.ensureAuth().catch(() => false)
+  }
+}
+
 function getBaseUrl(): string {
   if (import.meta.env.VITE_HERMES_PREVIEW === '1') return DEFAULT_BASE_URL
   if (isDesktopShell()) return DEFAULT_BASE_URL
@@ -147,6 +157,7 @@ function responseErrorMessage(text: string, statusText: string): string {
 }
 
 export async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  await ensureDesktopAuthReady()
   const base = getBaseUrl()
   const url = `${base}${path}`
   const isFormDataBody = typeof FormData !== 'undefined' && options.body instanceof FormData

--- a/packages/client/src/api/hermes/petdex.ts
+++ b/packages/client/src/api/hermes/petdex.ts
@@ -6,6 +6,7 @@ export interface PetdexPet {
   kind: string
   submittedBy: string
   spritesheetUrl: string
+  previewUrl?: string
   petJsonUrl: string
   zipUrl: string
 }

--- a/packages/client/src/router/index.ts
+++ b/packages/client/src/router/index.ts
@@ -169,7 +169,19 @@ const router = createRouter({
   ],
 })
 
-router.beforeEach((to, _from, next) => {
+async function ensureDesktopAuth(): Promise<void> {
+  if (hasApiKey()) return
+  const bridge = (window as typeof window & {
+    hermesDesktop?: { isDesktop?: boolean; ensureAuth?: () => Promise<boolean> }
+  }).hermesDesktop
+  if (bridge?.isDesktop === true && bridge.ensureAuth) {
+    await bridge.ensureAuth().catch(() => false)
+  }
+}
+
+router.beforeEach(async (to, _from, next) => {
+  await ensureDesktopAuth()
+
   // Public pages don't need auth
   if (to.meta.public) {
     // Already has key, skip login

--- a/packages/client/src/utils/desktop-bridge.ts
+++ b/packages/client/src/utils/desktop-bridge.ts
@@ -12,6 +12,7 @@ export interface DesktopPetWindowState {
 
 export interface HermesDesktopBridge {
   getToken: () => Promise<string>
+  ensureAuth?: () => Promise<boolean>
   retryBootstrap: (source?: 'cf' | 'github') => Promise<void>
   notifyCompletion: (payload: { title: string; body?: string; icon?: string; tag?: string }) => Promise<boolean>
   getWindowState: () => Promise<{ isMaximized: boolean }>

--- a/packages/client/src/views/hermes/PetdexView.vue
+++ b/packages/client/src/views/hermes/PetdexView.vue
@@ -140,7 +140,7 @@ onMounted(() => {
         <div v-if="visiblePets.length" class="pet-grid">
           <article v-for="pet in visiblePets" :key="pet.slug" class="pet-card">
             <div class="pet-preview">
-              <div class="pet-frame" :style="{ backgroundImage: `url(${pet.spritesheetUrl})` }" />
+              <div class="pet-frame" :style="{ backgroundImage: `url(${pet.previewUrl || pet.spritesheetUrl})` }" />
             </div>
             <div class="pet-body">
               <div class="pet-title-row">

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -11,6 +11,14 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getToken: (): Promise<string> => ipcRenderer.invoke('hermes-desktop:get-token'),
   retryBootstrap: (source?: 'cf' | 'github'): Promise<void> => ipcRenderer.invoke('hermes-desktop:retry-bootstrap', source),
   notifyCompletion: (payload: { title: string; body?: string; icon?: string; tag?: string }): Promise<boolean> => ipcRenderer.invoke('hermes-desktop:notify-completion', payload),
+  ensureAuth: async (): Promise<boolean> => {
+    const token = await ipcRenderer.invoke('hermes-desktop:get-token')
+    if (token) {
+      try { localStorage.setItem('AUTH_TOKEN', token) } catch { /* */ }
+      await autoLogin(token)
+    }
+    return !!localStorage.getItem(API_KEY_LS)
+  },
   getWindowState: (): Promise<{ isMaximized: boolean }> => ipcRenderer.invoke('hermes-desktop:get-window-state'),
   windowControl: (action: 'minimize' | 'toggle-maximize' | 'close'): Promise<{ isMaximized: boolean }> => ipcRenderer.invoke('hermes-desktop:window-control', action),
   getPetWindowState: () => ipcRenderer.invoke('hermes-desktop:get-pet-window-state'),

--- a/packages/server/src/controllers/hermes/petdex.ts
+++ b/packages/server/src/controllers/hermes/petdex.ts
@@ -1,7 +1,26 @@
 import type { Context } from 'koa'
-import { fetchPetdexManifest } from '../../services/hermes/petdex'
+import { fetchPetdexAsset, fetchPetdexManifest } from '../../services/hermes/petdex'
 
 export async function manifest(ctx: Context) {
   const force = ctx.query.force === '1' || ctx.query.force === 'true'
   ctx.body = await fetchPetdexManifest({ force })
+}
+
+export async function asset(ctx: Context) {
+  const url = typeof ctx.query.url === 'string' ? ctx.query.url.trim() : ''
+  if (!url) {
+    ctx.status = 400
+    ctx.body = { error: 'Petdex asset URL is required' }
+    return
+  }
+
+  try {
+    const asset = await fetchPetdexAsset(url)
+    ctx.type = asset.mime
+    ctx.set('Cache-Control', `public, max-age=${asset.maxAgeSeconds}`)
+    ctx.body = asset.buffer
+  } catch (err) {
+    ctx.status = 400
+    ctx.body = { error: err instanceof Error ? err.message : 'Petdex asset request failed' }
+  }
 }

--- a/packages/server/src/routes/hermes/petdex.ts
+++ b/packages/server/src/routes/hermes/petdex.ts
@@ -2,5 +2,7 @@ import Router from '@koa/router'
 import * as ctrl from '../../controllers/hermes/petdex'
 
 export const petdexRoutes = new Router()
+export const petdexPublicRoutes = new Router()
 
+petdexPublicRoutes.get('/api/hermes/petdex/asset', ctrl.asset)
 petdexRoutes.get('/api/hermes/petdex/manifest', ctrl.manifest)

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -45,7 +45,7 @@ import { performanceMonitorRoutes } from './hermes/performance-monitor'
 import { mcpRoutes } from './hermes/mcp'
 import { runtimeVersionRoutes } from './hermes/runtime-versions'
 import { writeGateRoutes } from './hermes/write-gate'
-import { petdexRoutes } from './hermes/petdex'
+import { petdexPublicRoutes, petdexRoutes } from './hermes/petdex'
 import { petRoutes } from './hermes/pets'
 
 /**
@@ -63,6 +63,7 @@ export function registerRoutes(app: any, authMiddleware: Array<(ctx: Context, ne
   app.use(codexProxyRoutes.routes())
   app.use(ttsRoutes.routes())
   app.use(apiDocsRoutes.routes())
+  app.use(petdexPublicRoutes.routes())
 
   // --- Auth middleware: all routes below require authentication ---
   authMiddleware.forEach((middleware) => app.use(middleware))

--- a/packages/server/src/services/hermes/petdex.ts
+++ b/packages/server/src/services/hermes/petdex.ts
@@ -4,6 +4,7 @@ export interface PetdexPet {
   kind: string
   submittedBy: string
   spritesheetUrl: string
+  previewUrl?: string
   petJsonUrl: string
   zipUrl: string
 }
@@ -17,6 +18,7 @@ export interface PetdexManifest {
 const PETDEX_MANIFEST_URL = 'https://assets.petdex.dev/manifests/petdex-v1.json'
 const CACHE_TTL_MS = 5 * 60 * 1000
 const FETCH_TIMEOUT_MS = 15_000
+const MAX_ASSET_BYTES = 10 * 1024 * 1024
 
 let cache: { expiresAt: number; manifest: PetdexManifest } | null = null
 
@@ -36,9 +38,29 @@ function normalizePet(value: unknown): PetdexPet | null {
     kind: asString(item.kind).trim() || 'pet',
     submittedBy: asString(item.submittedBy).trim(),
     spritesheetUrl,
+    previewUrl: `/api/hermes/petdex/asset?url=${encodeURIComponent(spritesheetUrl)}`,
     petJsonUrl: asString(item.petJsonUrl).trim(),
     zipUrl: asString(item.zipUrl).trim(),
   }
+}
+
+function assertPetdexAssetUrl(value: string): URL {
+  const url = new URL(value)
+  const host = url.hostname.toLowerCase()
+  if (url.protocol !== 'https:' || (host !== 'petdex.dev' && !host.endsWith('.petdex.dev'))) {
+    throw new Error('Unsupported petdex asset host')
+  }
+  return url
+}
+
+function imageMimeFromResponse(response: Response, pathname: string): string {
+  const contentType = response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase()
+  if (contentType?.startsWith('image/')) return contentType
+  const lower = pathname.toLowerCase()
+  if (lower.endsWith('.webp')) return 'image/webp'
+  if (lower.endsWith('.png')) return 'image/png'
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg'
+  return 'application/octet-stream'
 }
 
 function normalizeManifest(value: unknown): PetdexManifest {
@@ -78,6 +100,37 @@ export async function fetchPetdexManifest(options: { force?: boolean } = {}): Pr
     const manifest = normalizeManifest(await response.json())
     cache = { expiresAt: now + CACHE_TTL_MS, manifest }
     return manifest
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export async function fetchPetdexAsset(urlValue: string): Promise<{ buffer: Buffer; mime: string; maxAgeSeconds: number }> {
+  const url = assertPetdexAssetUrl(urlValue)
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'hermes-web-ui-petdex' },
+      signal: controller.signal,
+    })
+    if (!response.ok) throw new Error(`petdex asset request failed: ${response.status}`)
+
+    const length = Number(response.headers.get('content-length') || '0')
+    if (Number.isFinite(length) && length > MAX_ASSET_BYTES) {
+      throw new Error('petdex asset is too large')
+    }
+
+    const arrayBuffer = await response.arrayBuffer()
+    if (arrayBuffer.byteLength > MAX_ASSET_BYTES) {
+      throw new Error('petdex asset is too large')
+    }
+
+    return {
+      buffer: Buffer.from(arrayBuffer),
+      mime: imageMimeFromResponse(response, url.pathname),
+      maxAgeSeconds: 60 * 60,
+    }
   } finally {
     clearTimeout(timeout)
   }

--- a/tests/server/petdex-service.test.ts
+++ b/tests/server/petdex-service.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchPetdexAsset, fetchPetdexManifest } from '../../packages/server/src/services/hermes/petdex'
+
+describe('petdex service', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('adds local preview proxy URLs to manifest pets', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      generatedAt: '2026-06-30T00:00:00.000Z',
+      pets: [{
+        slug: 'desk-cat',
+        displayName: 'Desk Cat',
+        kind: 'cat',
+        submittedBy: 'petdex',
+        spritesheetUrl: 'https://assets.petdex.dev/pets/desk-cat/spritesheet.webp',
+      }],
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })))
+
+    const manifest = await fetchPetdexManifest({ force: true })
+
+    expect(manifest.pets[0].spritesheetUrl).toBe('https://assets.petdex.dev/pets/desk-cat/spritesheet.webp')
+    expect(manifest.pets[0].previewUrl).toBe(
+      '/api/hermes/petdex/asset?url=https%3A%2F%2Fassets.petdex.dev%2Fpets%2Fdesk-cat%2Fspritesheet.webp',
+    )
+  })
+
+  it('only proxies petdex https assets', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchPetdexAsset('https://example.com/pet.webp')).rejects.toThrow('Unsupported petdex asset host')
+    await expect(fetchPetdexAsset('http://assets.petdex.dev/pet.webp')).rejects.toThrow('Unsupported petdex asset host')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fetches allowed petdex image assets with a size limit', async () => {
+    const body = new Uint8Array([1, 2, 3, 4])
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(body, {
+      status: 200,
+      headers: {
+        'content-type': 'image/webp',
+        'content-length': String(body.byteLength),
+      },
+    })))
+
+    const asset = await fetchPetdexAsset('https://assets.petdex.dev/pets/desk-cat/spritesheet.webp')
+
+    expect(asset.mime).toBe('image/webp')
+    expect([...asset.buffer]).toEqual([1, 2, 3, 4])
+    expect(asset.maxAgeSeconds).toBe(3600)
+  })
+})


### PR DESCRIPTION
## What changed

- Adds a desktop `ensureAuth` bridge and waits for it before protected client API requests and route guards.
- Adds a restricted Petdex asset proxy for preview images, allowing only `https://petdex.dev` and `https://*.petdex.dev` assets with a size limit.
- Adds `previewUrl` to Petdex manifest entries and uses it for pet grid previews.
- Adds focused service coverage for preview URL generation and asset proxy host restrictions.

## Why

Desktop startup can render protected pages before the preload auto-login has written the Web UI JWT, causing Petdex API calls to fail. The Petdex grid also depended on Electron loading remote image URLs directly, which can leave desktop previews blank. Local preview URLs make the desktop list reliable without changing pet adoption storage.

## Validation

- `npm run test -- tests/server/petdex-service.test.ts`
- `npx vue-tsc -b`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm --prefix packages/desktop run build`
- `npm run build`
