### PR TITLE
Restore web pet mount in browser app

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -12,6 +12,7 @@ import { useAppStore } from '@/stores/hermes/app'
 import SessionSearchModal from '@/components/hermes/chat/SessionSearchModal.vue'
 import AuthEventListener from '@/components/auth/AuthEventListener.vue'
 import DefaultCredentialPrompt from '@/components/auth/DefaultCredentialPrompt.vue'
+import WebPet from '@/components/hermes/pets/WebPet.vue'
 import { desktopBridge } from '@/utils/desktop-bridge'
 
 const { isDark, isComic } = useTheme()
@@ -37,6 +38,7 @@ const nodeVersionLow = computed(() => {
 
 const isDesktopShell = computed(() => desktopBridge()?.isDesktop === true)
 const isDesktopPetRoute = computed(() => route.name === 'desktop.pet')
+const showWebPet = computed(() => !isLoginPage.value && !isDesktopShell.value && !isDesktopPetRoute.value)
 const hasDesktopTitleBar = computed(() => {
   const platform = desktopBridge()?.platform
   return isDesktopShell.value && (platform === 'darwin' || platform === 'win32')
@@ -91,6 +93,7 @@ useKeyboard()
               </main>
             </div>
           </div>
+          <WebPet v-if="showWebPet" />
           <SessionSearchModal v-if="!isDesktopPetRoute" />
           <DefaultCredentialPrompt v-if="!isDesktopPetRoute" />
         </NNotificationProvider>

--- a/tests/client/app-web-pet.test.ts
+++ b/tests/client/app-web-pet.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const routeMock = vi.hoisted(() => ({ name: 'hermes.chat' as string }))
+const appStoreMock = vi.hoisted(() => ({
+  nodeVersion: '23.0.0',
+  sidebarOpen: true,
+  toggleSidebar: vi.fn(),
+  closeSidebar: vi.fn(),
+  loadModels: vi.fn(),
+  startHealthPolling: vi.fn(),
+  stopHealthPolling: vi.fn(),
+}))
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRoute: () => routeMock,
+  }
+})
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) => params?.version ? `${key}:${params.version}` : key,
+  }),
+}))
+
+vi.mock('@/composables/useTheme', () => ({
+  useTheme: () => ({ isDark: false, isComic: false }),
+}))
+
+vi.mock('@/composables/useKeyboard', () => ({
+  useKeyboard: vi.fn(),
+}))
+
+vi.mock('@/stores/hermes/app', () => ({
+  useAppStore: () => appStoreMock,
+}))
+
+vi.mock('@/styles/theme', () => ({
+  getThemeOverrides: () => ({}),
+}))
+
+vi.mock('@/components/hermes/pets/WebPet.vue', () => ({
+  default: { name: 'WebPet', template: '<div class="web-pet-test" />' },
+}))
+
+vi.mock('@/components/auth/AuthEventListener.vue', () => ({
+  default: { name: 'AuthEventListener', template: '<div />' },
+}))
+
+vi.mock('@/components/auth/DefaultCredentialPrompt.vue', () => ({
+  default: { name: 'DefaultCredentialPrompt', template: '<div />' },
+}))
+
+vi.mock('@/components/hermes/chat/SessionSearchModal.vue', () => ({
+  default: { name: 'SessionSearchModal', template: '<div />' },
+}))
+
+vi.mock('@/components/layout/AppSidebar.vue', () => ({
+  default: { name: 'AppSidebar', template: '<aside />' },
+}))
+
+vi.mock('@/components/layout/DesktopTitleBar.vue', () => ({
+  default: { name: 'DesktopTitleBar', template: '<div />' },
+}))
+
+import App from '@/App.vue'
+
+type WindowWithDesktop = typeof window & {
+  hermesDesktop?: { isDesktop?: boolean; platform?: string }
+}
+
+function mountApp() {
+  return mount(App, {
+    global: {
+      stubs: {
+        NConfigProvider: { template: '<div><slot /></div>' },
+        NMessageProvider: { template: '<div><slot /></div>' },
+        NDialogProvider: { template: '<div><slot /></div>' },
+        NNotificationProvider: { template: '<div><slot /></div>' },
+        AuthEventListener: true,
+        AppSidebar: true,
+        DesktopTitleBar: true,
+        SessionSearchModal: true,
+        DefaultCredentialPrompt: true,
+        RouterView: { template: '<div class="router-view-test" />' },
+      },
+    },
+  })
+}
+
+describe('App web pet mounting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    routeMock.name = 'hermes.chat'
+    delete (window as WindowWithDesktop).hermesDesktop
+  })
+
+  it('mounts the web pet in the browser web app', () => {
+    const wrapper = mountApp()
+
+    expect(wrapper.findComponent({ name: 'WebPet' }).exists()).toBe(true)
+  })
+
+  it('does not mount the web pet in the Electron desktop shell', () => {
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { isDesktop: true, platform: 'darwin' },
+    })
+
+    const wrapper = mountApp()
+
+    expect(wrapper.findComponent({ name: 'WebPet' }).exists()).toBe(false)
+  })
+
+  it('does not duplicate the web pet on the dedicated desktop pet route', () => {
+    routeMock.name = 'desktop.pet'
+
+    const wrapper = mountApp()
+
+    expect(wrapper.findComponent({ name: 'WebPet' }).exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- restore WebPet mounting in the regular browser web app
- keep the web pet hidden in the Electron desktop shell and dedicated desktop pet route
- add a regression test for browser, desktop shell, and desktop pet route mounting behavior

## Tests
- npx vitest run tests/client/app-web-pet.test.ts
- npx vue-tsc -b