### PR TITLE
支持配置登录 JWT 有效期

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ These variables configure Hermes Web UI, its local Hermes runtime integration, a
 | `CORS_ORIGINS` | same host only | Comma- or space-separated cross-origin allowlist for HTTP, Socket.IO, and WebSocket requests. Set `*` only when you intentionally need legacy wildcard CORS. |
 | `AUTH_TOKEN` | auto-generated | Explicit bearer token. If unset, Web UI creates one under `HERMES_WEB_UI_HOME`. |
 | `AUTH_JWT_SECRET` | `AUTH_TOKEN` | JWT signing secret override for username/password sessions. |
+| `HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN` | `30d` | Username/password session JWT lifetime. Accepts seconds or `s`/`m`/`h`/`d` suffixes, for example `12h` or `7d`. |
 | `PROFILE` | `default` | Startup/default Hermes profile. Runtime requests use the profile selected by the frontend and authorized for the current account. |
 | `LOG_LEVEL` | `info` | Server log level. |
 | `BRIDGE_LOG_LEVEL` | `$LOG_LEVEL` or `info` | Bridge log level. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -313,6 +313,7 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `CORS_ORIGINS` | 仅同 host | HTTP、Socket.IO、WebSocket 跨源 allowlist，支持逗号或空格分隔。只有明确需要旧版 wildcard CORS 时才设置为 `*`。 |
 | `AUTH_TOKEN` | 自动生成 | 显式指定 bearer token。未设置时，Web UI 会在 `HERMES_WEB_UI_HOME` 下自动生成。 |
 | `AUTH_JWT_SECRET` | `AUTH_TOKEN` | 用户名/密码会话的 JWT 签名密钥覆盖。 |
+| `HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN` | `30d` | 用户名/密码会话 JWT 有效期。支持秒数或 `s`/`m`/`h`/`d` 后缀，例如 `12h` 或 `7d`。 |
 | `PROFILE` | `default` | 启动/默认 Hermes profile。运行时请求使用前端当前选择且当前账号有权限访问的 Profile。 |
 | `LOG_LEVEL` | `info` | Server 日志级别。 |
 | `BRIDGE_LOG_LEVEL` | `$LOG_LEVEL` 或 `info` | Bridge 日志级别。 |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - HERMES_HOME=/home/agent/.hermes
       - HERMES_BIN=/opt/hermes/.venv/bin/hermes
       - HERMES_WEB_UI_MANAGED_GATEWAY=1
+      - HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN=${HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN:-30d}
       - HERMES_WEB_UI_XAI_CALLBACK_BIND_HOST=0.0.0.0
       - PATH=/opt/hermes/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       - HERMES_ALLOW_ROOT_GATEWAY=1

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -18,6 +18,7 @@ import { homedir } from 'os'
  *
  * Auth:
  * - AUTH_TOKEN: Explicit bearer token. If unset, Web UI stores an auto-generated token under HERMES_WEB_UI_HOME.
+ * - HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN: Username/password session JWT lifetime. Supports seconds or s/m/h/d suffixes. Default: 30d.
  *
  * Runtime behavior:
  * - PROFILE: Initial Hermes profile name. Default: default.

--- a/packages/server/src/middleware/user-auth.ts
+++ b/packages/server/src/middleware/user-auth.ts
@@ -41,7 +41,34 @@ declare module 'koa' {
 
 const JWT_AUDIENCE = 'hermes-web-ui'
 const DEFAULT_EXPIRES_SECONDS = 60 * 60 * 24 * 30
+const MIN_EXPIRES_SECONDS = 1
+const MAX_EXPIRES_SECONDS = 60 * 60 * 24 * 365
 export const MODEL_RUN_EXPIRES_SECONDS = 60 * 60
+
+export function parseJwtExpirySeconds(value: string | undefined): number | null {
+  const raw = value?.trim()
+  if (!raw) return null
+
+  const match = raw.match(/^(\d+)(?:\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days))?$/i)
+  if (!match) return null
+
+  const amount = Number(match[1])
+  if (!Number.isSafeInteger(amount) || amount <= 0) return null
+
+  const unit = (match[2] || 's').toLowerCase()
+  const multiplier = unit.startsWith('d') ? 86400
+    : unit.startsWith('h') ? 3600
+      : unit.startsWith('m') ? 60
+        : 1
+  const seconds = amount * multiplier
+  if (!Number.isSafeInteger(seconds)) return null
+  if (seconds < MIN_EXPIRES_SECONDS || seconds > MAX_EXPIRES_SECONDS) return null
+  return seconds
+}
+
+export function getUserJwtExpiresSeconds(env: Record<string, string | undefined> = process.env): number {
+  return parseJwtExpirySeconds(env.HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN) ?? DEFAULT_EXPIRES_SECONDS
+}
 
 function base64UrlJson(value: unknown): string {
   return Buffer.from(JSON.stringify(value)).toString('base64url')
@@ -151,7 +178,7 @@ export function verifyUserJwt(token: string, secret: string, now = Date.now()): 
 
 export async function issueUserJwt(user: Pick<UserRecord, 'id' | 'username' | 'role'>): Promise<string> {
   const secret = await getJwtSecret()
-  return signUserJwt(user, secret)
+  return signUserJwt(user, secret, Date.now(), getUserJwtExpiresSeconds())
 }
 
 export async function issueModelRunJwt(user: Pick<UserRecord, 'id' | 'username' | 'role'>): Promise<string> {

--- a/tests/server/user-auth.test.ts
+++ b/tests/server/user-auth.test.ts
@@ -44,6 +44,50 @@ describe('user auth tables and middleware', () => {
     } as any
   }
 
+  function jwtPayload(token: string): any {
+    return JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf-8'))
+  }
+
+  it('uses the default user JWT lifetime when no override is configured', async () => {
+    const { auth } = await initUsers()
+    vi.setSystemTime(new Date('2026-06-30T00:00:00Z'))
+
+    const token = await auth.issueUserJwt({ id: 1, username: 'admin', role: 'super_admin' })
+    const payload = jwtPayload(token)
+
+    expect(payload.exp - payload.iat).toBe(60 * 60 * 24 * 30)
+  })
+
+  it('allows configuring the user JWT lifetime with HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN', async () => {
+    vi.stubEnv('HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN', '12h')
+    const { auth } = await initUsers()
+    vi.setSystemTime(new Date('2026-06-30T00:00:00Z'))
+
+    const token = await auth.issueUserJwt({ id: 1, username: 'admin', role: 'super_admin' })
+    const payload = jwtPayload(token)
+
+    expect(payload.exp - payload.iat).toBe(12 * 60 * 60)
+  })
+
+  it('falls back to the default user JWT lifetime for invalid overrides', async () => {
+    vi.stubEnv('HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN', 'forever')
+    const { auth } = await initUsers()
+
+    expect(auth.getUserJwtExpiresSeconds()).toBe(60 * 60 * 24 * 30)
+  })
+
+  it.each([
+    ['30s', 30],
+    ['90', 90],
+    ['15m', 15 * 60],
+    ['2 hours', 2 * 60 * 60],
+    ['7d', 7 * 24 * 60 * 60],
+  ])('parses user JWT lifetime override %s', async (value, seconds) => {
+    const { auth } = await initUsers()
+
+    expect(auth.parseJwtExpirySeconds(value)).toBe(seconds)
+  })
+
   it('creates the default super admin without profile bindings', async () => {
     const { schemas, users } = await initUsers()
 


### PR DESCRIPTION
## 改动
- 新增 `HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN`，用于配置用户名/密码登录后的 JWT 会话有效期。
- 使用严格的时长解析，只接受完整数字加 `s` / `m` / `h` / `d` 等单位，避免 `7200abc` 这类部分匹配被误接受。
- 补充 README / README_zh / 服务端配置说明，并让 Docker Compose 部署也转发该环境变量。

Closes #1094

## 验证
- `npm test -- tests/server/user-auth.test.ts`：已通过，46 个用例通过。
- `docker compose config >/tmp/wui-1094-compose-config.yml && grep -n 'HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN' /tmp/wui-1094-compose-config.yml`：已通过，Compose 配置中包含该环境变量。
- `npm run build`：已通过。
- `npm run harness:check`：已通过。
- `git diff --check`：已通过。
- 浏览器验收：生产构建服务设置 `HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN=60s` 后登录，解码 JWT 后确认 `exp - iat = 60` 秒。
