### PR TITLE
新增 profile 配置编辑入口

### DIFF
--- a/docs/chat-chain-changes/2026-06-30-profile-config-file-scope.md
+++ b/docs/chat-chain-changes/2026-06-30-profile-config-file-scope.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-30
+commit: pending
+feature: Chat file drawer profile scope reset
+impact: Chat file drawer explicitly uses the active profile instead of inheriting a scoped profile-config editor route.
+---
+
+The profile config edit affordance opens the Files view with an explicit `profile` and `file=config.yaml` query. The chat file drawer now clears that scoped files-store profile on mount so chat attachments and file operations do not accidentally target the last profile-config editor scope.

--- a/packages/client/src/api/hermes/download.ts
+++ b/packages/client/src/api/hermes/download.ts
@@ -8,11 +8,16 @@ function safeDecodeURIComponent(value: string): string {
   }
 }
 
+function normalizeProfile(profile?: string | null): string | null {
+  const value = typeof profile === 'string' ? profile.trim() : ''
+  return value || null
+}
+
 /**
  * Construct a download URL with auth token as query parameter.
  * Token is passed via query param because <a> tags cannot set headers.
  */
-export function getDownloadUrl(filePath: string, fileName?: string): string {
+export function getDownloadUrl(filePath: string, fileName?: string, profile?: string | null): string {
   const base = getBaseUrlValue()
 
   // Guard: if filePath is already a full download URL, extract the real path
@@ -35,7 +40,8 @@ export function getDownloadUrl(filePath: string, fileName?: string): string {
     const decodedName = safeDecodeURIComponent(fileName)
     params.set('name', decodedName)
   }
-  const profileName = getActiveProfileName()
+  const explicitProfile = normalizeProfile(profile)
+  const profileName = profile === undefined ? getActiveProfileName() : explicitProfile
   if (profileName) params.set('profile', profileName)
   const token = getApiKey()
   if (token) params.set('token', token)
@@ -46,8 +52,8 @@ export function getDownloadUrl(filePath: string, fileName?: string): string {
  * Download a file. Uses fetch to detect errors, then creates a blob URL
  * for the browser download. Throws with error message on failure.
  */
-export async function downloadFile(filePath: string, fileName?: string): Promise<void> {
-  const url = getDownloadUrl(filePath, fileName)
+export async function downloadFile(filePath: string, fileName?: string, profile?: string | null): Promise<void> {
+  const url = getDownloadUrl(filePath, fileName, profile)
   const res = await fetch(url)
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
@@ -68,8 +74,8 @@ export async function downloadFile(filePath: string, fileName?: string): Promise
  * Get preview file content.
  * Throws with error message on failure.
  */
-export async function fetchFileText(filePath: string, fileName?: string): Promise<string> {
-  const url = getDownloadUrl(filePath, fileName)
+export async function fetchFileText(filePath: string, fileName?: string, profile?: string | null): Promise<string> {
+  const url = getDownloadUrl(filePath, fileName, profile)
   const res = await fetch(url)
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))

--- a/packages/client/src/api/hermes/files.ts
+++ b/packages/client/src/api/hermes/files.ts
@@ -19,57 +19,72 @@ export interface FileStat {
   permissions?: string
 }
 
-export async function listFiles(path: string = ''): Promise<{ entries: FileEntry[]; path: string; absolutePath?: string }> {
+function normalizeProfile(profile?: string | null): string | null {
+  const value = typeof profile === 'string' ? profile.trim() : ''
+  return value || null
+}
+
+function appendProfile(params: URLSearchParams, profile?: string | null): void {
+  const value = normalizeProfile(profile)
+  if (value) params.set('profile', value)
+}
+
+export async function listFiles(path: string = '', profile?: string | null): Promise<{ entries: FileEntry[]; path: string; absolutePath?: string }> {
   const params = new URLSearchParams()
   if (path) params.set('path', path)
+  appendProfile(params, profile)
   const query = params.toString()
   return request<{ entries: FileEntry[]; path: string }>(`/api/hermes/files/list${query ? `?${query}` : ''}`)
 }
 
-export async function statFile(path: string): Promise<FileStat> {
-  return request<FileStat>(`/api/hermes/files/stat?path=${encodeURIComponent(path)}`)
+export async function statFile(path: string, profile?: string | null): Promise<FileStat> {
+  const params = new URLSearchParams({ path })
+  appendProfile(params, profile)
+  return request<FileStat>(`/api/hermes/files/stat?${params.toString()}`)
 }
 
-export async function readFile(path: string): Promise<{ content: string; path: string; size: number }> {
-  return request<{ content: string; path: string; size: number }>(`/api/hermes/files/read?path=${encodeURIComponent(path)}`)
+export async function readFile(path: string, profile?: string | null): Promise<{ content: string; path: string; size: number }> {
+  const params = new URLSearchParams({ path })
+  appendProfile(params, profile)
+  return request<{ content: string; path: string; size: number }>(`/api/hermes/files/read?${params.toString()}`)
 }
 
-export async function writeFile(path: string, content: string): Promise<void> {
+export async function writeFile(path: string, content: string, profile?: string | null): Promise<void> {
   await request<{ ok: boolean }>('/api/hermes/files/write', {
     method: 'PUT',
-    body: JSON.stringify({ path, content }),
+    body: JSON.stringify({ path, content, profile: normalizeProfile(profile) || undefined }),
   })
 }
 
-export async function deleteFile(path: string, recursive: boolean = false): Promise<void> {
+export async function deleteFile(path: string, recursive: boolean = false, profile?: string | null): Promise<void> {
   await request<{ ok: boolean }>('/api/hermes/files/delete', {
     method: 'DELETE',
-    body: JSON.stringify({ path, recursive }),
+    body: JSON.stringify({ path, recursive, profile: normalizeProfile(profile) || undefined }),
   })
 }
 
-export async function renameFile(oldPath: string, newPath: string): Promise<void> {
+export async function renameFile(oldPath: string, newPath: string, profile?: string | null): Promise<void> {
   await request<{ ok: boolean }>('/api/hermes/files/rename', {
     method: 'POST',
-    body: JSON.stringify({ oldPath, newPath }),
+    body: JSON.stringify({ oldPath, newPath, profile: normalizeProfile(profile) || undefined }),
   })
 }
 
-export async function mkDir(path: string): Promise<void> {
+export async function mkDir(path: string, profile?: string | null): Promise<void> {
   await request<{ ok: boolean }>('/api/hermes/files/mkdir', {
     method: 'POST',
-    body: JSON.stringify({ path }),
+    body: JSON.stringify({ path, profile: normalizeProfile(profile) || undefined }),
   })
 }
 
-export async function copyFile(srcPath: string, destPath: string): Promise<void> {
+export async function copyFile(srcPath: string, destPath: string, profile?: string | null): Promise<void> {
   await request<{ ok: boolean }>('/api/hermes/files/copy', {
     method: 'POST',
-    body: JSON.stringify({ srcPath, destPath }),
+    body: JSON.stringify({ srcPath, destPath, profile: normalizeProfile(profile) || undefined }),
   })
 }
 
-export async function uploadFiles(targetDir: string, files: File[]): Promise<{ name: string; path: string }[]> {
+export async function uploadFiles(targetDir: string, files: File[], profile?: string | null): Promise<{ name: string; path: string }[]> {
   const base = getBaseUrlValue()
   const formData = new FormData()
   for (const file of files) {
@@ -77,14 +92,16 @@ export async function uploadFiles(targetDir: string, files: File[]): Promise<{ n
   }
   const params = new URLSearchParams()
   if (targetDir) params.set('path', targetDir)
+  appendProfile(params, profile)
   const query = params.toString()
   const url = `${base}/api/hermes/files/upload${query ? `?${query}` : ''}`
 
   const headers: Record<string, string> = {}
   const token = getApiKey()
   if (token) headers['Authorization'] = `Bearer ${token}`
-  const profileName = getActiveProfileName()
-  if (profileName) headers['X-Hermes-Profile'] = profileName
+  const explicitProfile = normalizeProfile(profile)
+  const profileName = explicitProfile || getActiveProfileName()
+  if (profileName && !explicitProfile) headers['X-Hermes-Profile'] = profileName
 
   const res = await fetch(url, { method: 'POST', headers, body: formData })
   if (!res.ok) {
@@ -117,11 +134,12 @@ export async function uploadRuntimeFiles(files: File[]): Promise<{ name: string;
   return data.files
 }
 
-export function getFileDownloadUrl(relativePath: string, fileName?: string): string {
+export function getFileDownloadUrl(relativePath: string, fileName?: string, profile?: string | null): string {
   const base = getBaseUrlValue()
   const params = new URLSearchParams({ path: relativePath })
   if (fileName) params.set('name', fileName)
-  const profileName = getActiveProfileName()
+  const explicitProfile = normalizeProfile(profile)
+  const profileName = profile === undefined ? getActiveProfileName() : explicitProfile
   if (profileName) params.set('profile', profileName)
   const token = getApiKey()
   if (token) params.set('token', token)

--- a/packages/client/src/components/hermes/chat/FilesPanel.vue
+++ b/packages/client/src/components/hermes/chat/FilesPanel.vue
@@ -58,7 +58,7 @@ function handleRename(entry: FileEntry) {
 }
 
 onMounted(() => {
-  filesStore.fetchEntries('')
+  filesStore.fetchEntries('', { profile: null })
 })
 </script>
 

--- a/packages/client/src/components/hermes/files/FileContextMenu.vue
+++ b/packages/client/src/components/hermes/files/FileContextMenu.vue
@@ -74,7 +74,7 @@ async function handleSelect(key: string) {
       try { await filesStore.openPreview(entry) } catch { message.error(t('files.backendError')) }
       break
     case 'download':
-      try { await downloadFile(entry.path, entry.name) } catch (err: any) { message.error(err.message) }
+      try { await downloadFile(entry.path, entry.name, filesStore.currentProfile) } catch (err: any) { message.error(err.message) }
       break
     case 'copyPath': {
       const ok = await copyToClipboard(getClipboardPathForEntry(entry))

--- a/packages/client/src/components/hermes/files/FileEditor.vue
+++ b/packages/client/src/components/hermes/files/FileEditor.vue
@@ -19,6 +19,7 @@ const { t } = useI18n()
 const message = useMessage()
 const dialogApi = useDialog()
 const filesStore = useFilesStore()
+const props = defineProps<{ customClose?: () => void }>()
 
 const editorContainer = ref<HTMLElement | null>(null)
 let editor: monaco.editor.IStandaloneCodeEditor | null = null
@@ -70,6 +71,11 @@ async function handleSave() {
 }
 
 function handleClose() {
+  if (props.customClose) {
+    props.customClose()
+    return
+  }
+
   if (filesStore.hasUnsavedChanges) {
     dialogApi.warning({
       title: t('files.unsavedChanges'),

--- a/packages/client/src/components/hermes/files/FileList.vue
+++ b/packages/client/src/components/hermes/files/FileList.vue
@@ -70,7 +70,7 @@ function handleContextMenu(e: MouseEvent, entry: FileEntry) {
 
 async function handleDownload(entry: FileEntry) {
   try {
-    await downloadFile(entry.path, entry.name)
+    await downloadFile(entry.path, entry.name, filesStore.currentProfile)
   } catch (err: any) {
     message.error(err.message || t('files.backendError'))
   }

--- a/packages/client/src/components/hermes/files/FilePreview.vue
+++ b/packages/client/src/components/hermes/files/FilePreview.vue
@@ -13,7 +13,7 @@ const filesStore = useFilesStore()
 
 function getImageUrl(): string {
   if (!filesStore.previewFile) return ''
-  return getFileDownloadUrl(filesStore.previewFile.path)
+  return getFileDownloadUrl(filesStore.previewFile.path, undefined, filesStore.previewFile.profile)
 }
 
 const highlightedPreview = computed(() => {

--- a/packages/client/src/components/hermes/files/FileTree.vue
+++ b/packages/client/src/components/hermes/files/FileTree.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, h } from 'vue'
+import { computed, ref, watch, h } from 'vue'
 import { NTree } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import { useFilesStore } from '@/stores/hermes/files'
@@ -8,13 +8,18 @@ import type { TreeOption } from 'naive-ui'
 
 const { t } = useI18n()
 const filesStore = useFilesStore()
+const props = defineProps<{
+  profile?: string | null
+}>()
+
+const effectiveProfile = computed(() => props.profile === undefined ? filesStore.currentProfile : props.profile)
 
 const treeData = ref<TreeOption[]>([])
 const selectedKeys = ref<string[]>([])
 
 async function loadChildren(path: string): Promise<TreeOption[]> {
   try {
-    const result = await filesApi.listFiles(path)
+    const result = await filesApi.listFiles(path, effectiveProfile.value)
     return result.entries
       .filter(e => e.isDir)
       .sort((a, b) => a.name.localeCompare(b.name))
@@ -35,13 +40,13 @@ async function handleLoad(node: TreeOption): Promise<void> {
 function handleSelect(keys: string[]) {
   if (keys.length > 0) {
     selectedKeys.value = keys
-    filesStore.navigateTo(keys[0])
+    filesStore.navigateTo(keys[0], { profile: effectiveProfile.value })
   }
 }
 
 function handleRootClick() {
   selectedKeys.value = []
-  filesStore.navigateTo('')
+  filesStore.navigateTo('', { profile: effectiveProfile.value })
 }
 
 function renderLabel({ option }: { option: TreeOption }) {
@@ -49,9 +54,10 @@ function renderLabel({ option }: { option: TreeOption }) {
   return h('span', { class: 'tree-node-label', title: label }, label)
 }
 
-onMounted(async () => {
+watch(effectiveProfile, async () => {
+  selectedKeys.value = []
   treeData.value = await loadChildren('')
-})
+}, { immediate: true })
 </script>
 
 <template>

--- a/packages/client/src/components/hermes/profiles/ProfileCard.vue
+++ b/packages/client/src/components/hermes/profiles/ProfileCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { NButton, NTag, NSpin, useMessage, useDialog } from 'naive-ui'
 import type { HermesProfile, HermesProfileDetail } from '@/api/hermes/profiles'
 import { useProfilesStore } from '@/stores/hermes/profiles'
@@ -13,6 +14,7 @@ const { t } = useI18n()
 const profilesStore = useProfilesStore()
 const message = useMessage()
 const dialog = useDialog()
+const router = useRouter()
 
 const expanded = ref(false)
 const detailLoading = ref(false)
@@ -92,6 +94,16 @@ async function handleExport() {
     exporting.value = false
   }
 }
+
+function handleEditConfig() {
+  void router.push({
+    name: 'hermes.files',
+    query: {
+      profile: props.profile.name,
+      file: 'config.yaml',
+    },
+  })
+}
 </script>
 
 <template>
@@ -153,6 +165,9 @@ async function handleExport() {
     </div>
 
     <div class="card-actions">
+      <NButton size="tiny" quaternary @click="handleEditConfig">
+        {{ t('profiles.editConfig') }}
+      </NButton>
       <NButton
         v-if="!profile.active"
         size="tiny"

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -525,6 +525,7 @@ export default {
     sessionLinkCopied: 'Session link copied',
     copySessionId: 'Sitzungs-ID kopieren',
     export: 'Exportieren',
+    editConfig: 'Konfiguration bearbeiten',
     exportFull: 'Vollständiger Export (JSON)',
     exportCompressed: 'Komprimierter Export (TXT)',
     exportCompressing: 'Komprimiere Kontext, bitte warten...',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -1367,6 +1367,7 @@ export default {
     export: 'Export',
     rename: 'Rename',
     delete: 'Delete',
+    editConfig: 'Edit Config',
     switchTo: 'Switch Hermes Profile',
     switchConfirm: 'This will run `hermes profile use {name}` and change the active Hermes CLI profile. Continue?',
     switchSuccess: 'Hermes active profile switched to "{name}"',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -525,6 +525,7 @@ export default {
     sessionLinkCopied: 'Session link copied',
     copySessionId: 'Copiar ID de sesión',
     export: 'Exportar',
+    editConfig: 'Editar configuración',
     exportFull: 'Exportación completa (JSON)',
     exportCompressed: 'Exportación comprimida (TXT)',
     exportCompressing: 'Comprimiendo contexto, espere...',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -525,6 +525,7 @@ export default {
     sessionLinkCopied: 'Session link copied',
     copySessionId: "Copier l'ID de session",
     export: 'Exporter',
+    editConfig: 'Modifier la configuration',
     exportFull: 'Export complet (JSON)',
     exportCompressed: 'Export compressé (TXT)',
     exportCompressing: 'Compression du contexte, veuillez patienter...',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -525,6 +525,7 @@ export default {
     sessionLinkCopied: 'Session link copied',
     copySessionId: 'セッション ID をコピー',
     export: 'エクスポート',
+    editConfig: '設定を編集',
     exportFull: 'フルエクスポート (JSON)',
     exportCompressed: '圧縮エクスポート (TXT)',
     exportCompressing: 'コンテキストを圧縮中、お待ちください...',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -525,6 +525,7 @@ export default {
     sessionLinkCopied: 'Session link copied',
     copySessionId: '세션 ID 복사',
     export: '내보내기',
+    editConfig: '구성 편집',
     exportFull: '전체 내보내기 (JSON)',
     exportCompressed: '압축 내보내기 (TXT)',
     exportCompressing: '컨텍스트 압축 중, 잠시 기다려주세요...',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -525,6 +525,7 @@ export default {
     sessionLinkCopied: 'Session link copied',
     copySessionId: 'Copiar ID da sessão',
     export: 'Exportar',
+    editConfig: 'Editar configuração',
     exportFull: 'Exportação completa (JSON)',
     exportCompressed: 'Exportação comprimida (TXT)',
     exportCompressing: 'Comprimindo contexto, aguarde...',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -469,6 +469,7 @@ export default {
     copySessionLink: 'Копировать ссылку на сеанс',
     copySessionId: 'Копировать ID сеанса',
     export: 'Экспорт',
+    editConfig: 'Редактировать конфигурацию',
     exportFull: 'Полный экспорт (JSON)',
     exportCompressed: 'Сжатый экспорт (TXT)',
     exportCompressing: 'Сжатие контекста, подождите...',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -563,6 +563,7 @@ export default {
     sessionLinkCopied: 'Session link copied',
     copySessionId: '複製工作階段 ID',
     export: '匯出',
+    editConfig: '編輯設定檔',
     exportFull: '完整匯出 (JSON)',
     exportCompressed: '壓縮匯出 (TXT)',
     exportCompressing: '正在壓縮上下文，請稍候...',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -1359,6 +1359,7 @@ export default {
     export: '导出',
     rename: '重命名',
     delete: '删除',
+    editConfig: '编辑配置文件',
     switchTo: '切换 Hermes Profile',
     switchConfirm: '将执行 `hermes profile use {name}` 并切换 Hermes CLI 的 active profile，是否继续？',
     switchSuccess: 'Hermes active profile 已切换为 "{name}"',

--- a/packages/client/src/stores/hermes/files.ts
+++ b/packages/client/src/stores/hermes/files.ts
@@ -113,8 +113,14 @@ function isAffected(targetPath: string, changedPath: string, changedIsDir: boole
   return false
 }
 
+function normalizeProfile(profile?: string | null): string | null {
+  const value = typeof profile === 'string' ? profile.trim() : ''
+  return value || null
+}
+
 export const useFilesStore = defineStore('files', () => {
   const currentPath = ref('')
+  const currentProfile = ref<string | null>(null)
   const entries = ref<FileEntry[]>([])
   const loading = ref(false)
   const sortBy = ref<'name' | 'size' | 'modTime'>('name')
@@ -129,6 +135,7 @@ export const useFilesStore = defineStore('files', () => {
 
   const previewFile = ref<{
     path: string
+    profile?: string | null
     type: 'image' | 'markdown' | 'text'
     content?: string
     language?: string
@@ -154,17 +161,23 @@ export const useFilesStore = defineStore('files', () => {
     return copy
   })
 
-  async function fetchEntries(path?: string) {
+  function resolveProfile(profile?: string | null): string | null {
+    return profile === undefined ? currentProfile.value : normalizeProfile(profile)
+  }
+
+  async function fetchEntries(path?: string, options: { profile?: string | null } = {}) {
     if (path !== undefined && path !== currentPath.value) {
       // Switching directory invalidates the current preview; close it so the
       // file list becomes visible again. The editor has its own dirty-check
       // (see hasUnsavedChanges), so we leave editingFile alone here.
       previewFile.value = null
     }
+    const nextProfile = resolveProfile(options.profile)
+    currentProfile.value = nextProfile
     if (path !== undefined) currentPath.value = path
     loading.value = true
     try {
-      const result = await filesApi.listFiles(currentPath.value)
+      const result = await filesApi.listFiles(currentPath.value, nextProfile)
       entries.value = result.entries
     } catch (err) {
       console.error('Failed to fetch files:', err)
@@ -174,15 +187,17 @@ export const useFilesStore = defineStore('files', () => {
     }
   }
 
-  function navigateTo(path: string) { return fetchEntries(path) }
-  function navigateUp() {
+  function navigateTo(path: string, options: { profile?: string | null } = {}) { return fetchEntries(path, options) }
+  function navigateUp(options: { profile?: string | null } = {}) {
     const parts = currentPath.value.split('/').filter(Boolean)
     parts.pop()
-    return fetchEntries(parts.join('/'))
+    return fetchEntries(parts.join('/'), options)
   }
 
-  async function openEditor(filePath: string) {
-    const result = await filesApi.readFile(filePath)
+  async function openEditor(filePath: string, options: { profile?: string | null } = {}) {
+    const profile = resolveProfile(options.profile)
+    currentProfile.value = profile
+    const result = await filesApi.readFile(filePath, profile)
     editingFile.value = {
       path: filePath,
       content: result.content,
@@ -193,22 +208,25 @@ export const useFilesStore = defineStore('files', () => {
 
   async function saveEditor() {
     if (!editingFile.value) return
-    await filesApi.writeFile(editingFile.value.path, editingFile.value.content)
+    await filesApi.writeFile(editingFile.value.path, editingFile.value.content, currentProfile.value)
     editingFile.value.originalContent = editingFile.value.content
   }
 
   function closeEditor() { editingFile.value = null }
 
-  async function openPreview(entry: FileEntry) {
+  async function openPreview(entry: FileEntry, options: { profile?: string | null } = {}) {
+    const profile = resolveProfile(options.profile)
+    currentProfile.value = profile
     if (isImageFile(entry.name)) {
-      previewFile.value = { path: entry.path, type: 'image' }
+      previewFile.value = { path: entry.path, profile, type: 'image' }
     } else if (isMarkdownFile(entry.name)) {
-      const result = await filesApi.readFile(entry.path)
-      previewFile.value = { path: entry.path, type: 'markdown', content: result.content }
+      const result = await filesApi.readFile(entry.path, profile)
+      previewFile.value = { path: entry.path, profile, type: 'markdown', content: result.content }
     } else if (isTextFile(entry.name)) {
-      const result = await filesApi.readFile(entry.path)
+      const result = await filesApi.readFile(entry.path, profile)
       previewFile.value = {
         path: entry.path,
+        profile,
         type: 'text',
         content: result.content,
         language: getLanguageFromPath(entry.path),
@@ -220,48 +238,48 @@ export const useFilesStore = defineStore('files', () => {
 
   async function createDir(name: string, targetPath = currentPath.value) {
     const path = targetPath ? `${targetPath}/${name}` : name
-    await filesApi.mkDir(path)
-    await fetchEntries()
+    await filesApi.mkDir(path, currentProfile.value)
+    await fetchEntries(undefined)
   }
 
   async function createFile(name: string) {
     const path = currentPath.value ? `${currentPath.value}/${name}` : name
-    await filesApi.writeFile(path, '')
-    await fetchEntries()
+    await filesApi.writeFile(path, '', currentProfile.value)
+    await fetchEntries(undefined)
   }
 
   async function deleteEntry(entry: FileEntry) {
-    await filesApi.deleteFile(entry.path, entry.isDir)
+    await filesApi.deleteFile(entry.path, entry.isDir, currentProfile.value)
     if (previewFile.value && isAffected(previewFile.value.path, entry.path, entry.isDir)) {
       previewFile.value = null
     }
     if (editingFile.value && isAffected(editingFile.value.path, entry.path, entry.isDir)) {
       editingFile.value = null
     }
-    await fetchEntries()
+    await fetchEntries(undefined)
   }
 
   async function renameEntry(entry: FileEntry, newName: string) {
     const parentPath = entry.path.includes('/') ? entry.path.slice(0, entry.path.lastIndexOf('/')) : ''
     const newPath = parentPath ? `${parentPath}/${newName}` : newName
-    await filesApi.renameFile(entry.path, newPath)
+    await filesApi.renameFile(entry.path, newPath, currentProfile.value)
     if (previewFile.value && isAffected(previewFile.value.path, entry.path, entry.isDir)) {
       previewFile.value = null
     }
     if (editingFile.value && isAffected(editingFile.value.path, entry.path, entry.isDir)) {
       editingFile.value = null
     }
-    await fetchEntries()
+    await fetchEntries(undefined)
   }
 
   async function copyEntry(entry: FileEntry, destPath: string) {
-    await filesApi.copyFile(entry.path, destPath)
-    await fetchEntries()
+    await filesApi.copyFile(entry.path, destPath, currentProfile.value)
+    await fetchEntries(undefined)
   }
 
   async function uploadFiles(files: File[]) {
-    await filesApi.uploadFiles(currentPath.value, files)
-    await fetchEntries()
+    await filesApi.uploadFiles(currentPath.value, files, currentProfile.value)
+    await fetchEntries(undefined)
   }
 
   function setSort(by: 'name' | 'size' | 'modTime') {
@@ -279,7 +297,7 @@ export const useFilesStore = defineStore('files', () => {
   })
 
   return {
-    currentPath, entries, loading, sortBy, sortOrder,
+    currentPath, currentProfile, entries, loading, sortBy, sortOrder,
     editingFile, previewFile,
     pathSegments, sortedEntries, hasUnsavedChanges,
     fetchEntries, navigateTo, navigateUp,

--- a/packages/client/src/views/hermes/FilesView.vue
+++ b/packages/client/src/views/hermes/FilesView.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
+import { useDialog } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
 import { useFilesStore } from '@/stores/hermes/files'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import FileTree from '@/components/hermes/files/FileTree.vue'
@@ -17,6 +19,9 @@ import type { FileEntry } from '@/api/hermes/files'
 const filesStore = useFilesStore()
 const profilesStore = useProfilesStore()
 const route = useRoute()
+const router = useRouter()
+const dialog = useDialog()
+const { t } = useI18n()
 
 const contextMenuRef = ref<InstanceType<typeof FileContextMenu> | null>(null)
 const showUpload = ref(false)
@@ -25,6 +30,11 @@ const renameMode = ref<'newFile' | 'newFolder' | 'rename'>('newFile')
 const renameEntry = ref<FileEntry | null>(null)
 const renameTargetPath = ref<string | null>(null)
 const scopedProfile = computed(() => firstQueryString(route.query.profile))
+const routeFilePath = computed(() => firstQueryString(route.query.file))
+const isProfileConfigEditor = computed(() => !!scopedProfile.value && routeFilePath.value === 'config.yaml')
+const profileConfigTitle = computed(() =>
+  scopedProfile.value ? `${scopedProfile.value} / config.yaml` : 'config.yaml',
+)
 
 function handleContextMenu(e: MouseEvent, entry: FileEntry) {
   contextMenuRef.value?.show(e, entry)
@@ -78,16 +88,37 @@ async function loadFromRoute() {
   await ensureProfilesLoaded()
 
   const profile = scopedProfile.value
-  const filePath = firstQueryString(route.query.file)
+  const filePath = routeFilePath.value
   const directoryPath = filePath
     ? parentDir(filePath)
     : (firstQueryString(route.query.path) || '')
 
-  await filesStore.fetchEntries(directoryPath, { profile })
+  if (!isProfileConfigEditor.value) {
+    await filesStore.fetchEntries(directoryPath, { profile })
+  }
 
   if (filePath) {
     await filesStore.openEditor(filePath, { profile })
   }
+}
+
+function closeProfileConfigEditor() {
+  const close = () => {
+    filesStore.closeEditor()
+    void router.push({ name: 'hermes.profiles' })
+  }
+
+  if (filesStore.hasUnsavedChanges) {
+    dialog.warning({
+      title: t('files.unsavedChanges'),
+      positiveText: t('common.ok'),
+      negativeText: t('common.cancel'),
+      onPositiveClick: close,
+    })
+    return
+  }
+
+  close()
 }
 
 watch(
@@ -100,11 +131,22 @@ watch(
 </script>
 
 <template>
-  <div class="files-view">
-    <div class="files-tree-panel">
+  <div class="files-view" :class="{ 'profile-config-editor-view': isProfileConfigEditor }">
+    <template v-if="isProfileConfigEditor">
+      <div class="profile-config-editor-header">
+        <div class="profile-config-title">
+          <span class="profile-config-eyebrow">{{ t('profiles.editConfig') }}</span>
+          <span class="profile-config-file">{{ profileConfigTitle }}</span>
+        </div>
+      </div>
+      <div class="profile-config-editor-content">
+        <FileEditor v-if="filesStore.editingFile" :custom-close="closeProfileConfigEditor" />
+      </div>
+    </template>
+    <div v-else class="files-tree-panel">
       <FileTree :profile="scopedProfile" />
     </div>
-    <div class="files-main-panel">
+    <div v-if="!isProfileConfigEditor" class="files-main-panel">
       <FileToolbar
         @show-new-file="handleShowNewFile"
         @show-new-folder="handleShowNewFolder"
@@ -138,6 +180,47 @@ watch(
 .files-view {
   display: flex;
   height: 100%;
+  overflow: hidden;
+}
+
+.profile-config-editor-view {
+  flex-direction: column;
+}
+
+.profile-config-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 16px;
+  border-bottom: 1px solid $border-color;
+  background-color: $bg-card;
+}
+
+.profile-config-title {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 2px;
+}
+
+.profile-config-eyebrow {
+  font-size: 12px;
+  color: $text-secondary;
+}
+
+.profile-config-file {
+  font-size: 14px;
+  font-weight: 600;
+  color: $text-primary;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profile-config-editor-content {
+  flex: 1;
+  min-height: 0;
   overflow: hidden;
 }
 

--- a/packages/client/src/views/hermes/FilesView.vue
+++ b/packages/client/src/views/hermes/FilesView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { useFilesStore } from '@/stores/hermes/files'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import FileTree from '@/components/hermes/files/FileTree.vue'
@@ -15,6 +16,7 @@ import type { FileEntry } from '@/api/hermes/files'
 
 const filesStore = useFilesStore()
 const profilesStore = useProfilesStore()
+const route = useRoute()
 
 const contextMenuRef = ref<InstanceType<typeof FileContextMenu> | null>(null)
 const showUpload = ref(false)
@@ -22,6 +24,7 @@ const showRenameModal = ref(false)
 const renameMode = ref<'newFile' | 'newFolder' | 'rename'>('newFile')
 const renameEntry = ref<FileEntry | null>(null)
 const renameTargetPath = ref<string | null>(null)
+const scopedProfile = computed(() => firstQueryString(route.query.profile))
 
 function handleContextMenu(e: MouseEvent, entry: FileEntry) {
   contextMenuRef.value?.show(e, entry)
@@ -55,22 +58,51 @@ function handleRename(entry: FileEntry) {
   showRenameModal.value = true
 }
 
-async function loadRoot() {
+function firstQueryString(value: unknown): string | null {
+  const raw = Array.isArray(value) ? value[0] : value
+  return typeof raw === 'string' && raw.trim() ? raw.trim() : null
+}
+
+function parentDir(filePath: string): string {
+  const lastSlash = filePath.lastIndexOf('/')
+  return lastSlash > 0 ? filePath.slice(0, lastSlash) : ''
+}
+
+async function ensureProfilesLoaded() {
   if (!profilesStore.activeProfileName || profilesStore.profiles.length === 0) {
     await profilesStore.fetchProfiles()
   }
-  await filesStore.fetchEntries('')
 }
 
-onMounted(() => {
-  void loadRoot()
-})
+async function loadFromRoute() {
+  await ensureProfilesLoaded()
+
+  const profile = scopedProfile.value
+  const filePath = firstQueryString(route.query.file)
+  const directoryPath = filePath
+    ? parentDir(filePath)
+    : (firstQueryString(route.query.path) || '')
+
+  await filesStore.fetchEntries(directoryPath, { profile })
+
+  if (filePath) {
+    await filesStore.openEditor(filePath, { profile })
+  }
+}
+
+watch(
+  [() => route.query.profile, () => route.query.path, () => route.query.file],
+  () => {
+    void loadFromRoute()
+  },
+  { immediate: true },
+)
 </script>
 
 <template>
   <div class="files-view">
     <div class="files-tree-panel">
-      <FileTree />
+      <FileTree :profile="scopedProfile" />
     </div>
     <div class="files-main-panel">
       <FileToolbar

--- a/tests/client/api.test.ts
+++ b/tests/client/api.test.ts
@@ -205,6 +205,18 @@ describe('API Client', () => {
       expect(url.searchParams.get('token')).toBe('secret-key')
     })
 
+    it('uses an explicit profile selector for direct download URLs', () => {
+      setApiKey('secret-key')
+      localStorage.setItem('hermes_active_profile_name', 'research')
+
+      const url = new URL(getDownloadUrl('/tmp/reviewer.txt', 'reviewer.txt', 'reviewer'), 'http://localhost')
+
+      expect(url.searchParams.get('path')).toBe('/tmp/reviewer.txt')
+      expect(url.searchParams.get('name')).toBe('reviewer.txt')
+      expect(url.searchParams.get('profile')).toBe('reviewer')
+      expect(url.searchParams.get('token')).toBe('secret-key')
+    })
+
     it('handles raw percent signs in download paths and filenames', () => {
       const url = new URL(getDownloadUrl('/tmp/100% ready.txt', '100% ready.txt'), 'http://localhost')
 
@@ -233,6 +245,23 @@ describe('API Client', () => {
       expect(options.headers.Authorization).toBe('Bearer secret-key')
       expect(options.headers['X-Hermes-Profile']).toBe('research')
       expect(options.body).toBeInstanceOf(FormData)
+    })
+
+    it('uses an explicit profile selector instead of the active profile header', async () => {
+      setApiKey('secret-key')
+      localStorage.setItem('hermes_active_profile_name', 'research')
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ files: [] }),
+      })
+
+      await uploadFiles('notes', [new File(['hello'], 'hello.txt', { type: 'text/plain' })], 'reviewer')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/hermes/files/upload?path=notes&profile=reviewer')
+      expect(options.headers.Authorization).toBe('Bearer secret-key')
+      expect(options.headers['X-Hermes-Profile']).toBeUndefined()
     })
 
     it('adds auth and active profile headers when importing skills', async () => {

--- a/tests/client/file-tree-profile-scope.test.ts
+++ b/tests/client/file-tree-profile-scope.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import FileTree from '@/components/hermes/files/FileTree.vue'
+
+const mockFilesApi = vi.hoisted(() => ({
+  listFiles: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/files', () => mockFilesApi)
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NTree: { template: '<div class="n-tree-stub" />' },
+}))
+
+describe('FileTree profile scope', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    mockFilesApi.listFiles.mockResolvedValue({
+      entries: [{ name: 'settings', path: 'settings', isDir: true, size: 0, modTime: '2026-06-30T00:00:00.000Z' }],
+      path: '',
+    })
+  })
+
+  it('loads root directories from the selected profile', async () => {
+    mount(FileTree, { props: { profile: 'reviewer' } })
+    await flushPromises()
+
+    expect(mockFilesApi.listFiles).toHaveBeenCalledWith('', 'reviewer')
+  })
+})

--- a/tests/client/files-store.test.ts
+++ b/tests/client/files-store.test.ts
@@ -61,13 +61,47 @@ describe('files store', () => {
 
     await store.openPreview(entry)
 
-    expect(mockFilesApi.readFile).toHaveBeenCalledWith('Dockerfile')
+    expect(mockFilesApi.readFile).toHaveBeenCalledWith('Dockerfile', null)
     expect(store.previewFile).toEqual({
       path: 'Dockerfile',
+      profile: null,
       type: 'text',
       content: 'FROM node:20\nRUN npm test\n',
       language: 'dockerfile',
     })
+  })
+
+  it('resets profile scope for unscoped file panels', async () => {
+    mockFilesApi.listFiles.mockResolvedValue({ entries: [], path: '' })
+
+    const store = useFilesStore()
+
+    await store.fetchEntries('', { profile: 'reviewer' })
+    await store.fetchEntries('', { profile: null })
+
+    expect(store.currentProfile).toBeNull()
+    expect(mockFilesApi.listFiles).toHaveBeenLastCalledWith('', null)
+  })
+
+  it('keeps an explicit profile scope for config editor actions', async () => {
+    mockFilesApi.listFiles.mockResolvedValue({ entries: [], path: '' })
+    mockFilesApi.readFile.mockResolvedValue({
+      content: 'model:\n  default: gpt-5.4\n',
+      path: 'config.yaml',
+      size: 28,
+    })
+
+    const store = useFilesStore()
+
+    await store.fetchEntries('', { profile: 'reviewer' })
+    await store.openEditor('config.yaml')
+    store.editingFile!.content = 'model:\n  default: gpt-5.4-mini\n'
+    await store.saveEditor()
+
+    expect(store.currentProfile).toBe('reviewer')
+    expect(mockFilesApi.listFiles).toHaveBeenCalledWith('', 'reviewer')
+    expect(mockFilesApi.readFile).toHaveBeenCalledWith('config.yaml', 'reviewer')
+    expect(mockFilesApi.writeFile).toHaveBeenCalledWith('config.yaml', 'model:\n  default: gpt-5.4-mini\n', 'reviewer')
   })
 
   it('opens image previews without reading file contents', async () => {
@@ -85,6 +119,7 @@ describe('files store', () => {
     expect(mockFilesApi.readFile).not.toHaveBeenCalled()
     expect(store.previewFile).toEqual({
       path: 'diagram.png',
+      profile: null,
       type: 'image',
     })
   })

--- a/tests/client/files-view-profile-config-route.test.ts
+++ b/tests/client/files-view-profile-config-route.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { shallowMount, flushPromises } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 
 const routeState = vi.hoisted(() => ({
   query: {
@@ -9,12 +9,16 @@ const routeState = vi.hoisted(() => ({
   } as Record<string, unknown>,
 }))
 
+const routerPush = vi.hoisted(() => vi.fn())
+
 const mockFilesStore = vi.hoisted(() => ({
   currentPath: '',
   editingFile: null as null | Record<string, unknown>,
   previewFile: null as null | Record<string, unknown>,
+  hasUnsavedChanges: false,
   fetchEntries: vi.fn(async () => {}),
   openEditor: vi.fn(async () => {}),
+  closeEditor: vi.fn(),
 }))
 
 const mockProfilesStore = vi.hoisted(() => ({
@@ -28,8 +32,17 @@ vi.mock('vue-router', async (importOriginal) => {
   return {
     ...actual,
     useRoute: () => routeState,
+    useRouter: () => ({ push: routerPush }),
   }
 })
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('naive-ui', () => ({
+  useDialog: () => ({ warning: vi.fn() }),
+}))
 
 vi.mock('@/stores/hermes/files', () => ({
   useFilesStore: () => mockFilesStore,
@@ -44,7 +57,7 @@ vi.mock('@/components/hermes/files/FileBreadcrumb.vue', () => ({ default: { name
 vi.mock('@/components/hermes/files/FileToolbar.vue', () => ({ default: { name: 'FileToolbarStub', template: '<div class="FileToolbar-stub" />' } }))
 vi.mock('@/components/hermes/files/FileList.vue', () => ({ default: { name: 'FileListStub', template: '<div class="FileList-stub" />' } }))
 vi.mock('@/components/hermes/files/FileContextMenu.vue', () => ({ default: { name: 'FileContextMenuStub', template: '<div class="FileContextMenu-stub" />' } }))
-vi.mock('@/components/hermes/files/FileEditor.vue', () => ({ default: { name: 'FileEditorStub', template: '<div class="FileEditor-stub" />' } }))
+vi.mock('@/components/hermes/files/FileEditor.vue', () => ({ default: { name: 'FileEditorStub', props: ['customClose'], template: '<button class="FileEditor-stub" type="button" @click="customClose?.()" />' } }))
 vi.mock('@/components/hermes/files/FilePreview.vue', () => ({ default: { name: 'FilePreviewStub', template: '<div class="FilePreview-stub" />' } }))
 vi.mock('@/components/hermes/files/FileUploadModal.vue', () => ({ default: { name: 'FileUploadModalStub', template: '<div class="FileUploadModal-stub" />' } }))
 vi.mock('@/components/hermes/files/FileRenameModal.vue', () => ({ default: { name: 'FileRenameModalStub', template: '<div class="FileRenameModal-stub" />' } }))
@@ -60,14 +73,30 @@ describe('FilesView scoped config route handling', () => {
     mockFilesStore.currentPath = ''
     mockFilesStore.editingFile = null
     mockFilesStore.previewFile = null
+    mockFilesStore.hasUnsavedChanges = false
   })
 
-  it('loads the requested profile root and opens config.yaml in the editor', async () => {
-    shallowMount(FilesView)
+  it('opens config.yaml in a focused profile config editor', async () => {
+    const wrapper = mount(FilesView)
     await flushPromises()
 
     expect(mockProfilesStore.fetchProfiles).toHaveBeenCalledOnce()
-    expect(mockFilesStore.fetchEntries).toHaveBeenCalledWith('', { profile: 'reviewer' })
+    expect(mockFilesStore.fetchEntries).not.toHaveBeenCalled()
     expect(mockFilesStore.openEditor).toHaveBeenCalledWith('config.yaml', { profile: 'reviewer' })
+    expect(wrapper.find('.files-tree-panel').exists()).toBe(false)
+    expect(wrapper.find('.FileList-stub').exists()).toBe(false)
+    expect(wrapper.find('.profile-config-editor-header').exists()).toBe(true)
+    expect(wrapper.find('.profile-config-close').exists()).toBe(false)
+  })
+
+  it('wires the editor close action back to profiles', async () => {
+    mockFilesStore.editingFile = { path: 'config.yaml' }
+    const wrapper = mount(FilesView)
+    await flushPromises()
+
+    await wrapper.get('.FileEditor-stub').trigger('click')
+
+    expect(mockFilesStore.closeEditor).toHaveBeenCalledOnce()
+    expect(routerPush).toHaveBeenCalledWith({ name: 'hermes.profiles' })
   })
 })

--- a/tests/client/files-view-profile-config-route.test.ts
+++ b/tests/client/files-view-profile-config-route.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { shallowMount, flushPromises } from '@vue/test-utils'
+
+const routeState = vi.hoisted(() => ({
+  query: {
+    profile: 'reviewer',
+    file: 'config.yaml',
+  } as Record<string, unknown>,
+}))
+
+const mockFilesStore = vi.hoisted(() => ({
+  currentPath: '',
+  editingFile: null as null | Record<string, unknown>,
+  previewFile: null as null | Record<string, unknown>,
+  fetchEntries: vi.fn(async () => {}),
+  openEditor: vi.fn(async () => {}),
+}))
+
+const mockProfilesStore = vi.hoisted(() => ({
+  activeProfileName: null as string | null,
+  profiles: [] as Array<{ name: string }>,
+  fetchProfiles: vi.fn(async () => {}),
+}))
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRoute: () => routeState,
+  }
+})
+
+vi.mock('@/stores/hermes/files', () => ({
+  useFilesStore: () => mockFilesStore,
+}))
+
+vi.mock('@/stores/hermes/profiles', () => ({
+  useProfilesStore: () => mockProfilesStore,
+}))
+
+vi.mock('@/components/hermes/files/FileTree.vue', () => ({ default: { name: 'FileTreeStub', props: ['profile'], template: '<div class="FileTree-stub" />' } }))
+vi.mock('@/components/hermes/files/FileBreadcrumb.vue', () => ({ default: { name: 'FileBreadcrumbStub', template: '<div class="FileBreadcrumb-stub" />' } }))
+vi.mock('@/components/hermes/files/FileToolbar.vue', () => ({ default: { name: 'FileToolbarStub', template: '<div class="FileToolbar-stub" />' } }))
+vi.mock('@/components/hermes/files/FileList.vue', () => ({ default: { name: 'FileListStub', template: '<div class="FileList-stub" />' } }))
+vi.mock('@/components/hermes/files/FileContextMenu.vue', () => ({ default: { name: 'FileContextMenuStub', template: '<div class="FileContextMenu-stub" />' } }))
+vi.mock('@/components/hermes/files/FileEditor.vue', () => ({ default: { name: 'FileEditorStub', template: '<div class="FileEditor-stub" />' } }))
+vi.mock('@/components/hermes/files/FilePreview.vue', () => ({ default: { name: 'FilePreviewStub', template: '<div class="FilePreview-stub" />' } }))
+vi.mock('@/components/hermes/files/FileUploadModal.vue', () => ({ default: { name: 'FileUploadModalStub', template: '<div class="FileUploadModal-stub" />' } }))
+vi.mock('@/components/hermes/files/FileRenameModal.vue', () => ({ default: { name: 'FileRenameModalStub', template: '<div class="FileRenameModal-stub" />' } }))
+
+import FilesView from '@/views/hermes/FilesView.vue'
+
+describe('FilesView scoped config route handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    routeState.query = { profile: 'reviewer', file: 'config.yaml' }
+    mockProfilesStore.activeProfileName = null
+    mockProfilesStore.profiles = []
+    mockFilesStore.currentPath = ''
+    mockFilesStore.editingFile = null
+    mockFilesStore.previewFile = null
+  })
+
+  it('loads the requested profile root and opens config.yaml in the editor', async () => {
+    shallowMount(FilesView)
+    await flushPromises()
+
+    expect(mockProfilesStore.fetchProfiles).toHaveBeenCalledOnce()
+    expect(mockFilesStore.fetchEntries).toHaveBeenCalledWith('', { profile: 'reviewer' })
+    expect(mockFilesStore.openEditor).toHaveBeenCalledWith('config.yaml', { profile: 'reviewer' })
+  })
+})

--- a/tests/client/profile-card-config-edit.test.ts
+++ b/tests/client/profile-card-config-edit.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+
+const routerPush = vi.hoisted(() => vi.fn())
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRouter: () => ({ push: routerPush }),
+  }
+})
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NButton: defineComponent({
+    emits: ['click'],
+    template: '<button class="n-button-stub" type="button" @click="$emit(\'click\')"><slot /></button>',
+  }),
+  NTag: defineComponent({
+    template: '<span><slot /></span>',
+  }),
+  NSpin: defineComponent({
+    template: '<div><slot /></div>',
+  }),
+  useMessage: () => ({ success: vi.fn(), error: vi.fn() }),
+  useDialog: () => ({ warning: vi.fn() }),
+}))
+
+import ProfileCard from '@/components/hermes/profiles/ProfileCard.vue'
+
+describe('ProfileCard config edit affordance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('routes to the scoped config editor for that profile', async () => {
+    const wrapper = mount(ProfileCard, {
+      props: {
+        profile: {
+          name: 'reviewer',
+          active: false,
+          model: 'gpt-5.4',
+          alias: 'reviewer',
+          avatar: null,
+        },
+      },
+      global: {
+        plugins: [createTestingPinia({ createSpy: vi.fn })],
+        stubs: {
+          ProfileAvatar: { template: '<span class="profile-avatar-stub" />' },
+        },
+      },
+    })
+
+    await wrapper.get('.card-actions .n-button-stub').trigger('click')
+
+    expect(routerPush).toHaveBeenCalledWith({
+      name: 'hermes.files',
+      query: {
+        profile: 'reviewer',
+        file: 'config.yaml',
+      },
+    })
+  })
+})


### PR DESCRIPTION
## 改动
- 在 Profile 卡片上新增 Edit Config 入口，可直接打开该 profile 的 `config.yaml` 文件编辑器。
- 文件列表、左侧目录树、预览、下载和保存操作都会保持在当前选择的 profile 范围内，不再意外使用 active profile。
- 聊天文件面板会重置为非显式 profile 范围，避免从 profile 配置编辑页继承错误的文件范围。
- 为新增按钮文案补齐所有 locale。

## 范围说明
这个改动不只是给 Profile 卡片加一个入口。Edit Config 打开的是带 `profile=...` 的 Files editor，因此文件列表、左侧目录树、预览、下载和保存都需要使用同一个目标 profile。否则会出现从某个 profile 打开 `config.yaml`，但部分文件操作仍落到 active profile 的问题。

聊天文件面板则显式恢复为普通 active-profile 范围，避免从 profile 配置编辑页继承错误的文件范围。

Closes #1589

## 验证
- `npm test -- tests/client/api.test.ts tests/client/files-store.test.ts tests/client/files-view-profile-config-route.test.ts tests/client/file-tree-profile-scope.test.ts tests/client/profile-card-config-edit.test.ts`：已通过，34 个用例通过。
- `npm run build`：已通过。
- `npm run harness:check`：已通过。
- `git diff --check`：已通过。
- 浏览器验收：生产构建服务中 Profiles → Edit Config 打开 `/#/hermes/files?profile=default&file=config.yaml`，页面显示 `config.yaml` 编辑器内容。
