### PR TITLE
fix: resolveHermesPath rejects valid absolute paths and ..hidden filenames

### DIFF
--- a/packages/server/src/services/hermes/file-provider.ts
+++ b/packages/server/src/services/hermes/file-provider.ts
@@ -127,7 +127,7 @@ export function resolveHermesPath(relativePath: string, profile?: string): strin
     return homeDir
   }
   const normalized = normalize(relativePath).replace(/\\/g, '/')
-  if (normalized.startsWith('..') || normalized.includes('/../') || normalized.startsWith('/')) {
+  if ((normalized === '..' || normalized.startsWith('../')) || normalized.includes('/../')) {
     throw Object.assign(new Error('Invalid file path'), { code: 'invalid_path' })
   }
   const resolved = resolve(homeDir, normalized)

--- a/packages/server/src/services/hermes/hermes-path.ts
+++ b/packages/server/src/services/hermes/hermes-path.ts
@@ -107,7 +107,8 @@ export function isPathWithin(targetPath: string, basePath: string): boolean {
   const base = resolveComparablePath(basePath, useWindows)
   const target = resolveComparablePath(targetPath, useWindows)
   const rel = relativeComparablePath(comparablePath(base), comparablePath(target), useWindows)
-  return rel === '' || (!!rel && !rel.startsWith('..') && !isComparableAbsolute(rel, useWindows))
+  const sep = useWindows ? '\\' : '/'
+  return rel === '' || (!!rel && rel !== '..' && !rel.startsWith('..' + sep) && !isComparableAbsolute(rel, useWindows))
 }
 
 export function relativePathFromBase(targetPath: string, basePath: string): string | null {

--- a/tests/server/file-provider-paths.test.ts
+++ b/tests/server/file-provider-paths.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { join, resolve } from 'path'
 import { tmpdir } from 'os'
 import { mkdir, mkdtemp, rm, symlink } from 'fs/promises'
-import { normalizePlatformPath, validatePath } from '../../packages/server/src/services/hermes/file-provider'
+import { normalizePlatformPath, validatePath, resolveHermesPath } from '../../packages/server/src/services/hermes/file-provider'
 import { isNearestExistingRealPathWithin, isPathWithin, isRealPathWithin, relativePathFromBase } from '../../packages/server/src/services/hermes/hermes-path'
+
+vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+  getActiveProfileDir: () => '/tmp/hermes-test-home',
+  getActiveEnvPath: () => '/tmp/hermes-test-home/.env',
+  getProfileDir: (name: string) => `/tmp/hermes-test-home-${name}`,
+}))
 
 describe('file provider platform path normalization', () => {
   it('converts MSYS drive paths to Windows absolute paths on Windows', () => {
@@ -38,10 +44,52 @@ describe('file provider platform path normalization', () => {
   })
 })
 
+describe('resolveHermesPath path validation', () => {
+  it('resolves absolute path within homeDir correctly', () => {
+    const result = resolveHermesPath('/tmp/hermes-test-home/subdir/file.txt')
+    expect(result).toBe('/tmp/hermes-test-home/subdir/file.txt')
+  })
+
+  it('rejects absolute path outside homeDir', () => {
+    expect(() => resolveHermesPath('/etc/passwd')).toThrow('Path traversal detected')
+  })
+
+  it('rejects exact ".." (traversal)', () => {
+    expect(() => resolveHermesPath('..')).toThrow('Invalid file path')
+  })
+
+  it('rejects "../foo" (traversal)', () => {
+    expect(() => resolveHermesPath('../foo')).toThrow('Invalid file path')
+  })
+
+  it('allows "..hidden" filename (not traversal)', () => {
+    const result = resolveHermesPath('..hidden')
+    expect(result).toBe(resolve('/tmp/hermes-test-home', '..hidden'))
+  })
+
+  it('rejects mid-path traversal via /../', () => {
+    expect(() => resolveHermesPath('subdir/../../../etc/passwd')).toThrow('Invalid file path')
+  })
+
+  it('resolves relative path normally', () => {
+    const result = resolveHermesPath('docs/readme.md')
+    expect(result).toBe(resolve('/tmp/hermes-test-home', 'docs/readme.md'))
+  })
+})
+
 describe('Hermes path containment helpers', () => {
   it('does not treat sibling paths with the same prefix as inside the base', () => {
     expect(isPathWithin('/tmp/hermes-profile2/state.db', '/tmp/hermes-profile')).toBe(false)
     expect(isPathWithin('/tmp/hermes-profile/state.db', '/tmp/hermes-profile')).toBe(true)
+  })
+
+  it('allows filenames starting with double dots (not traversal)', () => {
+    expect(isPathWithin('/tmp/hermes-profile/..hidden', '/tmp/hermes-profile')).toBe(true)
+    expect(isPathWithin('/tmp/hermes-profile/...config', '/tmp/hermes-profile')).toBe(true)
+  })
+
+  it('rejects actual traversal via relative path', () => {
+    expect(isPathWithin('/tmp/other/file.txt', '/tmp/hermes-profile')).toBe(false)
   })
 
   it('returns normalized relative paths only for children', () => {


### PR DESCRIPTION
## Problem

`resolveHermesPath()` in `file-provider.ts` has an overly strict `normalized.startsWith('/')` check that rejects ALL absolute paths. The downstream `isPathWithin(resolved, homeDir)` containment check already prevents directory traversal correctly. This breaks the file browser when it requests legitimate local paths.

Additionally, `normalized.startsWith('..')` is overly broad — it rejects valid filenames like `..hidden` or `...` that are not traversal attempts.

## Fix

1. **`resolveHermesPath()`**: Remove redundant `startsWith('/')` check and replace imprecise `startsWith('..')` with exact traversal detection (`=== '..' || startsWith('../')`). The `isPathWithin` containment check remains as the true security gate.

2. **`isPathWithin()`**: Same fix — replace `!rel.startsWith('..')` with precise checks (`rel !== '..' && !rel.startsWith('../') && !rel.startsWith('..\\')`) to avoid false-positives on filenames starting with `..`.

## Security

- `isPathWithin(resolved, homeDir)` remains the primary security boundary
- `normalized.includes('/../')` stays as defense-in-depth for mid-path traversal
- `path.resolve(homeDir, '/etc/passwd')` → `/etc/passwd` → correctly rejected by `isPathWithin`

## Tests

Added 9 test cases covering:
- Absolute path within homeDir resolves correctly ✓
- Absolute path outside homeDir throws ✓
- Exact `..` and `../foo` traversal rejected ✓
- `..hidden` filename allowed (not traversal) ✓
- Mid-path `/../` traversal rejected ✓
- Direct `isPathWithin` tests for `..hidden`-style paths ✓

Closes #1848

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do - you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop - no hard feelings.