### PR TITLE
修复 Windows 跨盘符 junction 文件夹选择器

### DIFF
--- a/docs/chat-chain-changes/2026-06-30-windows-junction-picker-hotfix.md
+++ b/docs/chat-chain-changes/2026-06-30-windows-junction-picker-hotfix.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-06-30
-commit: pending
+pr: 1868
 feature: Windows workspace junction folder picker hotfix
 impact: Windows workspace folder picker can list and browse directory junction/symlink entries whose real target is outside WORKSPACE_BASE, matching the C:\\Drives\\D -> D:\\ workflow, while create/rename/delete operations keep realpath containment checks.
 ---

--- a/docs/chat-chain-changes/2026-06-30-windows-junction-picker-hotfix.md
+++ b/docs/chat-chain-changes/2026-06-30-windows-junction-picker-hotfix.md
@@ -1,0 +1,8 @@
+---
+date: 2026-06-30
+commit: pending
+feature: Windows workspace junction folder picker hotfix
+impact: Windows workspace folder picker can list and browse directory junction/symlink entries whose real target is outside WORKSPACE_BASE, matching the C:\\Drives\\D -> D:\\ workflow, while create/rename/delete operations keep realpath containment checks.
+---
+
+Hotfix after #1854: listing/browsing follows Windows directory junctions for the picker; mutation paths remain guarded.

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -1013,19 +1013,24 @@ async function listWindowsWorkspaceDrives() {
   return drives
 }
 
+async function isWorkspaceListPathAllowed(fullPath: string, basePath: string, statFn: any): Promise<boolean> {
+  try {
+    const info = await statFn(fullPath)
+    if (!info.isDirectory()) return false
+    if (process.platform === 'win32') return true
+    return await isRealPathWithin(fullPath, basePath)
+  } catch {
+    return false
+  }
+}
+
 async function isSafeWorkspaceFolderEntry(entry: any, fullPath: string, basePath: string, statFn: any): Promise<boolean> {
   if (entry.name.startsWith('.')) return false
   if (!entry.isDirectory() && !(typeof entry.isSymbolicLink === 'function' && entry.isSymbolicLink())) {
     return false
   }
 
-  try {
-    const info = await statFn(fullPath)
-    if (!info.isDirectory()) return false
-    return await isRealPathWithin(fullPath, basePath)
-  } catch {
-    return false
-  }
+  return isWorkspaceListPathAllowed(fullPath, basePath, statFn)
 }
 
 /**
@@ -1064,7 +1069,7 @@ export async function listWorkspaceFolders(ctx: any) {
       return
     }
 
-    if (!await isRealPathWithin(resolved.fullPath, resolved.base)) {
+    if (!await isWorkspaceListPathAllowed(resolved.fullPath, resolved.base, stat)) {
       ctx.status = 403
       ctx.body = { error: 'Access denied' }
       return
@@ -1108,7 +1113,7 @@ export async function listWorkspaceFolders(ctx: any) {
     return
   }
 
-  if (!await isRealPathWithin(fullPath, WORKSPACE_BASE)) {
+  if (!await isWorkspaceListPathAllowed(fullPath, WORKSPACE_BASE, stat)) {
     ctx.status = 403
     ctx.body = { error: 'Access denied' }
     return

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -269,6 +269,49 @@ describe('session conversations controller', () => {
     }
   })
 
+  it('lists Windows junction-like workspace folders even when their target realpath leaves WORKSPACE_BASE', async () => {
+    const originalPlatform = process.platform
+    const originalWorkspaceBase = process.env.WORKSPACE_BASE
+    const workspaceBase = await mkdtemp(join(tmpdir(), 'hermes-workspace-win-picker-'))
+    const outsideRoot = await mkdtemp(join(tmpdir(), 'hermes-workspace-win-picker-outside-'))
+
+    try {
+      const outsideTarget = join(outsideRoot, 'drive-target')
+      const outsideChild = join(outsideTarget, 'project')
+      const outsideLink = join(workspaceBase, 'DrivesD')
+
+      await mkdir(outsideChild, { recursive: true })
+      await symlink(outsideTarget, outsideLink)
+      Object.defineProperty(process, 'platform', { value: 'win32' })
+      process.env.WORKSPACE_BASE = workspaceBase
+
+      const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+      const rootCtx: any = { query: {}, body: null }
+      await mod.listWorkspaceFolders(rootCtx)
+
+      expect(rootCtx.status).toBeUndefined()
+      expect(rootCtx.body.folders).toContainEqual({
+        name: 'DrivesD',
+        path: 'DrivesD',
+        fullPath: outsideLink,
+      })
+
+      const nestedCtx: any = { query: { path: 'DrivesD' }, body: null }
+      await mod.listWorkspaceFolders(nestedCtx)
+
+      expect(nestedCtx.status).toBeUndefined()
+      expect(nestedCtx.body.folders).toEqual([
+        { name: 'project', path: 'DrivesD/project', fullPath: join(outsideLink, 'project') },
+      ])
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+      if (originalWorkspaceBase === undefined) delete process.env.WORKSPACE_BASE
+      else process.env.WORKSPACE_BASE = originalWorkspaceBase
+      await rm(workspaceBase, { recursive: true, force: true })
+      await rm(outsideRoot, { recursive: true, force: true })
+    }
+  })
+
   it('lists symlinked workspace folders that resolve within WORKSPACE_BASE and blocks escaped links', async () => {
     const originalWorkspaceBase = process.env.WORKSPACE_BASE
     const workspaceBase = await mkdtemp(join(tmpdir(), 'hermes-workspace-picker-'))


### PR DESCRIPTION
## 改动说明
- 修复 #1854 合并后仍可能过滤 Windows 跨盘符 junction 的问题，允许 workspace folder picker 在 Windows 上列出并浏览 directory symlink/junction 目标，即使 realpath 解析后离开 `WORKSPACE_BASE`。
- 保持 create / rename / delete 等 workspace folder mutation 路径继续使用 realpath containment，避免通过 escaped junction 写入或删除 base 外目录。
- 补充 Windows junction-like 回归测试，并新增 chat-chain fragment 说明该 controller 变更不改变 chat session 运行语义。

## 背景
#1854 已合并，但它仍把 listing/browsing 绑定到 `isRealPathWithin(...)`。对 issue 目标场景 `C:\\Drives\\D -> D:\\` 来说，junction 的 realpath 会解析到 `D:\\`，因此仍会被 `C:\\`/`WORKSPACE_BASE` containment 过滤。本 PR 是针对该语义缺口的 hotfix。

## 验证
- `npm test -- tests/server/sessions-controller.test.ts tests/server/file-provider-paths.test.ts`：通过，56 tests。
- `npm run build`：通过。
- `npm run harness:check`：通过。
- `git diff --check origin/main...HEAD`：通过。

## Windows UAT 状态
尝试在 Azure Windows VM 上做真实 junction UAT，但 VM 从 clean deallocated state 启动后持续停在 `VM running / Updating`，Web UI HTTP health 和 Azure run-command 都不可用。已再次 deallocate，最终状态为 `VM deallocated / Succeeded`。因此本 PR 先提交本地 hotfix 与回归测试；完整 Windows endpoint UAT 仍需 VM 恢复到 provisioning `Succeeded` 后补跑。

Fixes #1456
