### PR TITLE
[codex] restore blocking self update

### DIFF
--- a/packages/server/src/controllers/update.ts
+++ b/packages/server/src/controllers/update.ts
@@ -333,6 +333,28 @@ function getCurrentNodeEnv() {
   }
 }
 
+function getUpdateCommandCwd() {
+  const cwd = getWebUiHome()
+  mkdirSync(cwd, { recursive: true })
+  return cwd
+}
+
+function runNpmSync(args: string[], options: { timeout?: number; env?: NodeJS.ProcessEnv } = {}) {
+  const env = {
+    ...getCurrentNodeEnv(),
+    ...options.env,
+  }
+  const execution = npmExecution(args, env)
+  return execFileSync(execution.command, execution.args, {
+    cwd: getUpdateCommandCwd(),
+    encoding: 'utf-8',
+    timeout: options.timeout,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env,
+    windowsHide: true,
+  }).trim()
+}
+
 async function runNpmAsync(args: string[], options: { timeout?: number; cwd?: string; logLabel?: string; env?: NodeJS.ProcessEnv } = {}) {
   const env = {
     ...getCurrentNodeEnv(),
@@ -962,30 +984,30 @@ async function checkoutPreview(ref: string) {
   appendPreviewActionLog(`preview tag ready: ${ref}`)
 }
 
-async function getGlobalRootAsync() {
-  return runNpmAsync(['root', '-g'])
+function getGlobalRoot() {
+  return runNpmSync(['root', '-g'])
 }
 
-async function getGlobalCliScriptAsync() {
-  const cli = getGlobalPackageBin(await getGlobalRootAsync())
+function getGlobalCliScript() {
+  const cli = getGlobalPackageBin(getGlobalRoot())
   if (!existsSync(cli)) {
     throw new Error(`Updated hermes-web-ui CLI not found: ${cli}`)
   }
   return cli
 }
 
-async function runUpdateInstall() {
+function runUpdateInstall() {
   try {
-    await runNpmAsync(['cache', 'clean', '--force'], { timeout: 2 * 60 * 1000 })
+    runNpmSync(['cache', 'clean', '--force'], { timeout: 2 * 60 * 1000 })
   } catch (err) {
     console.warn('[update] failed to clean npm cache, continuing update:', err)
   }
 
-  return runNpmAsync(['install', '-g', 'hermes-web-ui@latest'], { timeout: 10 * 60 * 1000 })
+  return runNpmSync(['install', '-g', 'hermes-web-ui@latest'], { timeout: 10 * 60 * 1000 })
 }
 
-async function spawnRestart(port: string) {
-  const cli = await getGlobalCliScriptAsync()
+function spawnRestart(port: string) {
+  const cli = getGlobalCliScript()
 
   return spawn(process.execPath, [cli, 'restart', '--port', port], {
     detached: true,
@@ -1009,7 +1031,7 @@ export async function handleUpdate(ctx: any) {
   let keepUpdateLockForRestart = false
 
   try {
-    const output = await runUpdateInstall()
+    const output = runUpdateInstall()
 
     ctx.body = {
       success: true,
@@ -1018,29 +1040,27 @@ export async function handleUpdate(ctx: any) {
 
     keepUpdateLockForRestart = true
     setTimeout(() => {
-      void (async () => {
-        let restart
-        try {
-          restart = await spawnRestart(process.env.PORT || '8648')
-        } catch (err) {
-          updateInProgress = false
-          console.error('[update] failed to spawn restart:', err)
-          return
-        }
+      let restart
+      try {
+        restart = spawnRestart(process.env.PORT || '8648')
+      } catch (err) {
+        updateInProgress = false
+        console.error('[update] failed to spawn restart:', err)
+        return
+      }
 
-        restart.on('error', (err) => {
-          updateInProgress = false
-          console.error('[update] restart process failed:', err)
-        })
-        restart.on('exit', (code, signal) => {
-          updateInProgress = false
-          const failed = (typeof code === 'number' && code !== 0) || Boolean(signal)
-          if (failed) {
-            console.error(`[update] restart process exited before replacing server: code=${code} signal=${signal}`)
-          }
-        })
-        restart.unref()
-      })()
+      restart.on('error', (err) => {
+        updateInProgress = false
+        console.error('[update] restart process failed:', err)
+      })
+      restart.on('exit', (code, signal) => {
+        updateInProgress = false
+        const failed = (typeof code === 'number' && code !== 0) || Boolean(signal)
+        if (failed) {
+          console.error(`[update] restart process exited before replacing server: code=${code} signal=${signal}`)
+        }
+      })
+      restart.unref()
     }, 3000)
   } catch (err: any) {
     ctx.status = 500

--- a/tests/server/update-controller.test.ts
+++ b/tests/server/update-controller.test.ts
@@ -100,47 +100,48 @@ describe('update controller', () => {
     const npmCli = getNpmCliPath()
     const globalPrefix = getNodePrefix()
     const cliScript = getGlobalCliScript(globalPrefix)
-    const execFile = vi.fn((_command: string, args: string[], _options: any, callback: any) => {
+    const execFileSync = vi.fn((_command: string, args: string[]) => {
       if (args[1] === 'root') {
-        callback(null, process.platform === 'win32'
+        return process.platform === 'win32'
           ? join(globalPrefix, 'node_modules')
-          : join(globalPrefix, 'lib', 'node_modules'), '')
-        return
+          : join(globalPrefix, 'lib', 'node_modules')
       }
-      callback(null, 'updated', '')
+      return 'updated'
     })
-    const { handleUpdate, mocks } = await loadUpdateController({ execFile })
+    const { handleUpdate, mocks } = await loadUpdateController({ execFileSync })
     const ctx = createMockCtx()
 
     await handleUpdate(ctx)
 
-    expect(mocks.execFile).toHaveBeenCalledWith(
+    expect(mocks.execFileSync).toHaveBeenCalledWith(
       process.execPath,
       [npmCli, 'install', '-g', 'hermes-web-ui@latest'],
       expect.objectContaining({
         encoding: 'utf-8',
         timeout: 10 * 60 * 1000,
+        stdio: ['pipe', 'pipe', 'pipe'],
         windowsHide: true,
+        cwd: expect.any(String),
         env: expect.objectContaining({
           npm_node_execpath: process.execPath,
           PATH: expect.stringContaining(`${nodeBinDir}${delimiter}`),
         }),
       }),
-      expect.any(Function),
     )
     expect(ctx.body).toEqual({ success: true, message: 'updated' })
 
     await vi.runAllTimersAsync()
 
-    expect(mocks.execFile).toHaveBeenCalledWith(
+    expect(mocks.execFileSync).toHaveBeenCalledWith(
       process.execPath,
       [npmCli, 'root', '-g'],
       expect.objectContaining({
         encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
         windowsHide: true,
+        cwd: expect.any(String),
         env: expect.objectContaining({ npm_node_execpath: process.execPath }),
       }),
-      expect.any(Function),
     )
     expect(mocks.spawn).toHaveBeenCalledWith(
       process.execPath,
@@ -153,54 +154,6 @@ describe('update controller', () => {
       }),
     )
     expect(mocks.unref).toHaveBeenCalledOnce()
-  })
-
-  it('keeps update requests responsive while npm install is pending', async () => {
-    const npmCli = getNpmCliPath()
-    let installCallback: ((error: Error | null, stdout: string, stderr: string) => void) | undefined
-    const execFile = vi.fn((_command: string, args: string[], _options: any, callback: any) => {
-      if (args.includes('install') && args.includes('hermes-web-ui@latest')) {
-        installCallback = callback
-        return
-      }
-      callback(null, '', '')
-    })
-    const execFileSync = vi.fn((_command: string, args: string[]) => {
-      if (args.includes('install') && args.includes('hermes-web-ui@latest')) {
-        throw new Error('global update install must not use execFileSync')
-      }
-      return ''
-    })
-    const { handleUpdate, mocks } = await loadUpdateController({ execFile, execFileSync })
-    const first = createMockCtx()
-    const second = createMockCtx()
-
-    const firstUpdate = handleUpdate(first)
-    await Promise.resolve()
-    await handleUpdate(second)
-
-    expect(installCallback).toBeTypeOf('function')
-    expect(second.status).toBe(409)
-    expect(second.body).toEqual({
-      success: false,
-      message: 'hermes-web-ui update is already in progress',
-    })
-    expect(mocks.execFile).toHaveBeenCalledWith(
-      process.execPath,
-      [npmCli, 'install', '-g', 'hermes-web-ui@latest'],
-      expect.objectContaining({ timeout: 10 * 60 * 1000 }),
-      expect.any(Function),
-    )
-    expect(mocks.execFileSync).not.toHaveBeenCalledWith(
-      process.execPath,
-      [npmCli, 'install', '-g', 'hermes-web-ui@latest'],
-      expect.any(Object),
-    )
-
-    installCallback?.(null, 'updated', '')
-    await firstUpdate
-
-    expect(first.body).toEqual({ success: true, message: 'updated' })
   })
 
   it('falls back to the default port when PORT is not set', async () => {
@@ -242,27 +195,21 @@ describe('update controller', () => {
   })
 
   it('returns a 500 with stderr when installation fails', async () => {
-    const execFile = vi.fn((_command: string, args: string[], _options: any, callback: any) => {
+    const execFileSync = vi.fn((_command: string, args: string[]) => {
       if (args.includes('install') && args.includes('hermes-web-ui@latest')) {
         const error = new Error('install failed') as Error & { stderr?: string }
         error.stderr = 'engine mismatch'
-        callback(error, '', 'engine mismatch')
-        return
+        throw error
       }
-      callback(null, '', '')
+      return ''
     })
-    const { handleUpdate, mocks } = await loadUpdateController({ execFile })
+    const { handleUpdate, mocks } = await loadUpdateController({ execFileSync })
     const ctx = createMockCtx()
 
     await handleUpdate(ctx)
 
     expect(ctx.status).toBe(500)
     expect(ctx.body).toEqual({ success: false, message: 'engine mismatch' })
-    expect(mocks.execFileSync).not.toHaveBeenCalledWith(
-      process.execPath,
-      [expect.any(String), 'install', '-g', 'hermes-web-ui@latest'],
-      expect.any(Object),
-    )
     expect(mocks.spawn).not.toHaveBeenCalled()
     expect(exitSpy).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Summary
- Restore `/api/hermes/update` to blocking npm install/root execution before scheduling restart.
- Run self-update npm commands from the Web UI home directory so they do not inherit a global package cwd that npm may remove during install.
- Update self-update controller coverage to assert synchronous npm execution and stable cwd usage.

Fixes #1846

## Root Cause
The nonblocking self-update path returned after `npm install -g hermes-web-ui@latest`, then tried to run `npm root -g` from the old server process. During global install, npm can replace/remove the old package directory that the running process inherited as cwd, causing later npm commands to fail with `uv_cwd` and preventing restart into the newly installed version.

## Validation
- `npm run test -- tests/server/update-controller.test.ts`
