### PR TITLE
[codex] fix desktop mcp shutdown

### DIFF
--- a/docs/chat-chain-changes/2026-07-01-pr1871-desktop-mcp-shutdown.md
+++ b/docs/chat-chain-changes/2026-07-01-pr1871-desktop-mcp-shutdown.md
@@ -1,0 +1,9 @@
+---
+date: 2026-07-01
+pr: 1871
+commit: 3e82cf10
+feature: Desktop MCP shutdown
+impact: Desktop bridge shutdown now asks profile workers to close registered MCP servers before terminating worker processes.
+---
+
+Bundled Hermes Studio MCP configs generated for Web UI injection and coding-agent launches now prefer the packaged runtime node from `HERMES_AGENT_NODE` when it is available. This keeps desktop MCP subprocesses on the managed runtime while preserving the existing `process.execPath` fallback outside desktop runtime.

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -814,10 +814,15 @@ function bundledMcpScriptPath(): string | null {
   return candidateBundledMcpScripts().find(candidate => existsSync(candidate)) || null
 }
 
+function runtimeNodePath(): string | null {
+  const node = process.env.HERMES_AGENT_NODE?.trim()
+  return node || null
+}
+
 function hermesMcpCommandConfig(toolset: string): { command: string; args?: string[] } {
-  if (isDesktopRuntime()) return { command: 'hermes-studio-mcp', args: [toolset] }
   const script = bundledMcpScriptPath()
-  if (script) return { command: process.execPath, args: [script, toolset] }
+  if (script) return { command: runtimeNodePath() || process.execPath, args: [script, toolset] }
+  if (isDesktopRuntime()) return { command: 'hermes-studio-mcp', args: [toolset] }
   return { command: 'hermes-studio-mcp', args: [toolset] }
 }
 

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
@@ -223,6 +223,7 @@ class BridgeServer:
             return self.pool.list_sessions()
 
         if action == "shutdown":
+            self._shutdown_all_mcp_servers()
             self._stop.set()
             return {"status": "shutting_down"}
 
@@ -267,6 +268,15 @@ class BridgeServer:
             finally:
                 _restore_profile_env(original)
         threading.Thread(target=_bg, daemon=True).start()
+
+    def _shutdown_all_mcp_servers(self) -> int:
+        try:
+            from tools.mcp_tool import _run_on_mcp_loop, _servers, _lock
+        except ImportError:
+            return 0
+        with _lock:
+            names = list(_servers.keys())
+        return self._shutdown_mcp_servers(names, _servers, _lock, _run_on_mcp_loop)
 
     def _handle_mcp_action(self, action: str, req: dict[str, Any], profile: str | None = None) -> dict[str, Any]:
         """Handle MCP management actions in worker process."""

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
@@ -20,6 +20,7 @@ from bridge_runtime import _hidden_subprocess_kwargs, _json_line_bytes, _platfor
 class WorkerProcess:
     STARTUP_TIMEOUT_SECONDS = 120
     REQUEST_TIMEOUT_SECONDS = 120
+    SHUTDOWN_REQUEST_TIMEOUT_SECONDS = 15
 
     def __init__(self, key: str, profile: str, endpoint: str, agent_root: str | None, hermes_home: str | None) -> None:
         self.key = key or profile or "default"
@@ -145,6 +146,10 @@ class WorkerProcess:
         if proc is None:
             return
         if proc.poll() is None:
+            try:
+                self.request({"action": "shutdown"}, timeout=self.SHUTDOWN_REQUEST_TIMEOUT_SECONDS)
+            except Exception as exc:
+                print(f"[hermes-bridge-worker:{self.key}] graceful shutdown failed: {exc}", file=sys.stderr, flush=True)
             proc.terminate()
             try:
                 proc.wait(timeout=3)

--- a/packages/server/src/services/hermes/studio-mcp-autoinject.ts
+++ b/packages/server/src/services/hermes/studio-mcp-autoinject.ts
@@ -88,15 +88,19 @@ function bundledMcpScriptPath(): string | null {
   return candidateBundledMcpScripts().find(candidate => existsSync(candidate)) || null
 }
 
+function runtimeNodePath(): string | null {
+  const node = process.env.HERMES_AGENT_NODE?.trim()
+  return node || null
+}
+
 function managedCommandConfig(toolset: string): Record<string, unknown> {
   // Prefer the bundled script with an absolute path over a bare command name.
   // On Windows (especially desktop builds), `hermes-studio-mcp` may not be in
-  // PATH even though the bundled .mjs script exists on disk.  Using
-  // process.execPath + the absolute script path avoids "file not found" errors
-  // when the MCP client tries to spawn the server process.
+  // PATH even though the bundled .mjs script exists on disk.  Desktop provides
+  // HERMES_AGENT_NODE for the packaged runtime node; fall back to process.execPath.
   const bundledScript = bundledMcpScriptPath()
   if (bundledScript) {
-    return { command: process.execPath, args: [bundledScript, toolset] }
+    return { command: runtimeNodePath() || process.execPath, args: [bundledScript, toolset] }
   }
 
   if (isDesktopRuntime()) {

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -1234,6 +1234,64 @@ assert events == [
 `)
   })
 
+  it('shuts down MCP servers before worker shutdown exits', () => {
+    runPython(String.raw`
+${harness}
+
+events = []
+
+class FakeBridgeServer(bridge.BridgeServer):
+    def _shutdown_all_mcp_servers(self):
+        events.append("mcp-shutdown")
+        return 2
+
+server = FakeBridgeServer("tcp://127.0.0.1:1")
+response = server.handle({"action": "shutdown"})
+
+assert response == {"status": "shutting_down"}, response
+assert events == ["mcp-shutdown"], events
+assert server._stop.is_set(), "shutdown should stop worker after MCP shutdown"
+`)
+  })
+
+  it('requests worker shutdown before terminating the worker process', () => {
+    runPython(String.raw`
+${harness}
+
+events = []
+
+class FakeProcess:
+    def __init__(self):
+        self.terminated = False
+
+    def poll(self):
+        return None
+
+    def terminate(self):
+        events.append("terminate")
+        self.terminated = True
+
+    def wait(self, timeout=None):
+        events.append(("wait", timeout))
+
+worker = bridge.WorkerProcess("default", "default", "tcp://127.0.0.1:1", None, None)
+worker.process = FakeProcess()
+
+def fake_request(req, timeout=None):
+    events.append(("request", req, timeout))
+    return {"status": "shutting_down"}
+
+worker.request = fake_request
+worker.stop()
+
+assert events == [
+    ("request", {"action": "shutdown"}, worker.SHUTDOWN_REQUEST_TIMEOUT_SECONDS),
+    "terminate",
+    ("wait", 3),
+], events
+`)
+  })
+
   it('binds workspace cwd per running session without process-wide cwd state', () => {
     runPython(String.raw`
 ${harness}

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -28,6 +28,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.HERMES_WEB_UI_HOME
   delete process.env.HERMES_CODING_AGENT_GLOBAL_HOME
+  delete process.env.HERMES_AGENT_NODE
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
   for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true })
@@ -248,6 +249,32 @@ describe('coding agent launch preparation', () => {
     const prompt = readFileSync(join(result.rootDir, 'hermes-rules.md'), 'utf-8')
     expect(prompt).toContain('# 输出格式规范')
     expect(prompt).toContain('当你的回复中包含图片、视频或文件引用时')
+  })
+
+  it('uses the desktop runtime node for scoped Hermes Studio MCP configs when available', async () => {
+    const home = makeHome()
+    process.env.HERMES_AGENT_NODE = '/runtime/node'
+
+    const result = await prepareCodingAgentLaunch('claude-code', {
+      profile: 'default',
+      provider: 'openrouter',
+      model: 'cognitivecomputations/dolphin-mistral-24b-venice-edition:free',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      apiKey: 'sk-test',
+    })
+
+    const mcp = JSON.parse(readFileSync(join(result.rootDir, 'mcp.json'), 'utf-8'))
+    expect(mcp.mcpServers['hermes-studio-api']).toMatchObject({
+      command: '/runtime/node',
+      args: [join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'api'],
+      env: {
+        HERMES_WEB_UI_HOME: home,
+        HERMES_MCP_SERVER_NAME: 'hermes-studio-api',
+        HERMES_MCP_TOOLSET: 'api',
+      },
+    })
+    expect(mcp.mcpServers['hermes-studio-devices'].command).toBe('/runtime/node')
+    expect(mcp.mcpServers['hermes-studio-use'].command).toBe('/runtime/node')
   })
 
   it('cleans legacy Hermes MCP entries from scoped Claude and Codex configs', async () => {

--- a/tests/server/studio-mcp-autoinject.test.ts
+++ b/tests/server/studio-mcp-autoinject.test.ts
@@ -32,6 +32,7 @@ describe('studio MCP autoinject', () => {
     vi.resetModules()
     vi.clearAllMocks()
     delete process.env.HERMES_DESKTOP
+    delete process.env.HERMES_AGENT_NODE
     delete process.env.AUTH_TOKEN
     delete process.env.HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT
     delete process.env.HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT
@@ -205,16 +206,15 @@ describe('studio MCP autoinject', () => {
     expect(updated.data.mcp_servers['hermes-studio-use'].args).toEqual([join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'use'])
   })
 
-  it('prefers bundled script over bare desktop command in desktop runtime', async () => {
+  it('uses the desktop runtime node for bundled MCP servers when available', async () => {
     process.env.HERMES_DESKTOP = 'true'
+    process.env.HERMES_AGENT_NODE = '/runtime/node'
     const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
 
     await injectBundledMcpServer()
 
     const injected = await updateConfigYamlForProfileMock.mock.calls[0][1]({})
-    // Even in desktop runtime, the bundled script should take priority
-    // so the MCP client receives an absolute path that works regardless of PATH.
-    expect(injected.data.mcp_servers['hermes-studio-api'].command).toBe(process.execPath)
+    expect(injected.data.mcp_servers['hermes-studio-api'].command).toBe('/runtime/node')
     expect(injected.data.mcp_servers['hermes-studio-api'].args).toEqual([
       join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'api',
     ])


### PR DESCRIPTION
## Summary
- Use the desktop runtime node from `HERMES_AGENT_NODE` for bundled Hermes Studio MCP configs generated by Web UI autoinject and coding-agent launch prep.
- Shut down registered MCP servers inside bridge workers before the worker exits.
- Ask profile workers to perform graceful shutdown before the broker terminates them.

## Root Cause
Desktop WebUI version switching can leave MCP-related subprocesses around. The bridge shutdown path stopped workers directly, but did not explicitly route worker shutdown through the existing MCP `task.shutdown()` cleanup path first. Managed MCP configs could also run through the WebUI process executable instead of the packaged runtime node.

## Validation
- `npm run test -- tests/server/agent-bridge-python-concurrency.test.ts`
- `npm run test -- tests/server/studio-mcp-autoinject.test.ts tests/server/coding-agents-launch.test.ts`

Fixes #1866
