### PR TITLE
[codex] add agent git safety checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.githooks/* text eol=lf
+scripts/*.mjs text eol=lf

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+zero_sha=0000000000000000000000000000000000000000
+
+while read local_ref local_sha remote_ref remote_sha
+do
+  case "$remote_ref" in
+    refs/heads/main|refs/heads/master)
+      echo "Push rejected: direct pushes to ${remote_ref#refs/heads/} are not allowed." >&2
+      exit 1
+      ;;
+  esac
+
+  if [ "$local_sha" != "$zero_sha" ] &&
+     [ "$remote_sha" != "$zero_sha" ] &&
+     ! git merge-base --is-ancestor "$remote_sha" "$local_sha"
+  then
+    echo "Push rejected: force-pushing or rewriting remote branch history is not allowed." >&2
+    exit 1
+  fi
+done
+
+exit 0

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -73,10 +73,17 @@ npm run build
 
 - Branch from `main` for new work.
 - Use short, descriptive branch names such as `codex/fix-login-token` or `feat/group-chat-copy`.
+- Before editing, run `npm run agent:git:start`. Resolve any reported dirty or
+  unpushed starting state instead of building on top of it.
 - Commit only files that belong to the change.
 - Use concise commit messages that describe the change, for example `fix login token storage` or `add group chat clone naming`.
 - Keep commits focused. Do not bundle unrelated cleanup with feature work unless the cleanup is required.
 - Push the branch and open a PR against `main` unless the issue explicitly targets another base.
+- Agent work is not complete until `npm run agent:git:finish` confirms that the
+  working tree is clean and the branch is fully pushed to its upstream.
+- Never push directly to `main` or `master`, and never force-push. The repository
+  hook blocks these operations when `core.hooksPath` is configured as described
+  below.
 - Prefer draft PRs while validation is still running or when the change needs review before merge.
 - Mark a PR ready only after the relevant tests and build pass.
 - Keep PR titles concrete and scoped, for example `[codex] make Web UI state directory configurable`.
@@ -88,6 +95,12 @@ npm run build
   - validation commands run
   - known limitations or follow-up work, if any
 - Do not overwrite or revert unrelated user changes.
+
+Enable the repository-managed Git hooks once per checkout:
+
+```bash
+git config core.hooksPath .githooks
+```
 
 Use this PR body shape by default:
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "dev:server": "nodemon",
     "build": "npm run openapi:generate && vue-tsc -b && vite build && tsc --noEmit -p packages/server/tsconfig.json && node scripts/build-server.mjs",
     "harness:check": "node scripts/harness-check.mjs",
+    "agent:git:start": "node scripts/agent-git-check.mjs start",
+    "agent:git:finish": "node scripts/agent-git-check.mjs finish",
     "prepare": "[ -d dist ] || npm run build",
     "preview": "NODE_ENV=production vite preview",
     "test": "vitest run",

--- a/scripts/agent-git-check.mjs
+++ b/scripts/agent-git-check.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+
+function git(args) {
+  try {
+    return execFileSync('git', args, {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim()
+  } catch (error) {
+    const details = String(error.stderr || error.message || error).trim()
+    throw new Error(`git ${args.join(' ')} failed${details ? `: ${details}` : ''}`)
+  }
+}
+
+function fail(message) {
+  console.error(`Agent Git check failed: ${message}`)
+  process.exit(1)
+}
+
+const mode = process.argv[2]
+if (mode !== 'start' && mode !== 'finish') {
+  fail('expected "start" or "finish"')
+}
+
+try {
+  if (git(['rev-parse', '--is-inside-work-tree']) !== 'true') {
+    fail('the current directory is not a Git working tree')
+  }
+
+  const branch = git(['branch', '--show-current'])
+  if (!branch) fail('detached HEAD is not allowed for agent work')
+  if (branch === 'main' || branch === 'master') {
+    fail(`create a task branch before working; "${branch}" is protected`)
+  }
+
+  const status = git(['status', '--porcelain'])
+  if (status) {
+    fail(`the working tree is not clean:\n${status}`)
+  }
+
+  if (mode === 'start') {
+    git(['rev-parse', '--verify', 'origin/main'])
+    try {
+      execFileSync('git', ['merge-base', '--is-ancestor', 'origin/main', 'HEAD'], {
+        cwd: process.cwd(),
+        stdio: 'ignore',
+      })
+    } catch {
+      fail('the task branch does not contain the current local origin/main baseline')
+    }
+    console.log(`Agent Git start check passed on ${branch}.`)
+    process.exit(0)
+  }
+
+  let upstream
+  try {
+    upstream = git(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'])
+  } catch {
+    fail(`branch "${branch}" has no upstream; push it with git push -u origin ${branch}`)
+  }
+
+  const counts = git(['rev-list', '--left-right', '--count', `HEAD...${upstream}`])
+    .split(/\s+/)
+    .map(Number)
+  const [ahead, behind] = counts
+  if (ahead || behind) {
+    fail(`branch "${branch}" is not synchronized with ${upstream} (${ahead} ahead, ${behind} behind)`)
+  }
+
+  console.log(`Agent Git finish check passed: ${branch} is clean and fully pushed to ${upstream}.`)
+} catch (error) {
+  fail(error.message || String(error))
+}


### PR DESCRIPTION
## Summary
- require agent work to use a task branch and finish fully pushed
- block direct main/master pushes and history rewrites with a repository hook
- add start and finish checks for clean, synchronized Git state

## Validation
- npm run harness:check
- verified allowed task-branch pushes and rejected direct main pushes
- verified start and finish checks against a temporary Git remote