### PR TITLE
[codex] stream global agent tts segments

### DIFF
--- a/docs/chat-chain-changes/2026-07-01-global-agent-streaming-tts.md
+++ b/docs/chat-chain-changes/2026-07-01-global-agent-streaming-tts.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-01
+pr: pending
+feature: Global Agent MCU voice chat TTS playback
+impact: MCU voice turns now segment assistant message deltas through a shared streaming speech segmenter before TTS synthesis, and abort in-flight TTS requests when the device interrupts playback.
+---
+
+The segmenter skips fenced code, table rows, markdown link URLs, and bare URLs so device speech starts earlier without reading unstable or non-speech content. Playback interrupts now propagate to pending `/api/hermes/tts/synthesize` fetches through AbortSignal instead of only dropping audio after synthesis completes.

--- a/packages/server/src/services/global-agent/mcu-speech-segmenter.ts
+++ b/packages/server/src/services/global-agent/mcu-speech-segmenter.ts
@@ -1,0 +1,164 @@
+import { cleanTtsText } from '../hermes/tts-providers/text'
+
+const DEFAULT_MAX_SEGMENT_CHARS = 90
+const MIN_SEGMENT_CHARS = 24
+const SENTENCE_BOUNDARY_RE = /[。！？!?]/
+const SOFT_BOUNDARY_RE = /[，,；;、\n]/
+
+export interface McuSpeechSegmenter {
+  pushDelta(delta: string): string[]
+  flush(): string | null
+  reset(): void
+}
+
+export interface McuSpeechSegmenterOptions {
+  maxChars?: number
+}
+
+interface BoundaryScan {
+  sentenceBoundary: number
+  softBoundary: number
+}
+
+export function normalizeMcuSpeechText(text: string): string {
+  const withoutTables = text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/https?:\/\/[^\s<>)\]]+/gi, ' ')
+    .replace(/www\.[^\s<>)\]]+/gi, ' ')
+    .split(/\r?\n/)
+    .filter((line) => {
+      const trimmed = line.trim()
+      if (!trimmed) return true
+      const pipeCount = (trimmed.match(/\|/g) || []).length
+      if (pipeCount >= 2) return false
+      if (/^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/.test(trimmed)) return false
+      return true
+    })
+    .join('\n')
+
+  return cleanTtsText(withoutTables)
+    .replace(/^\s*[-*+]\s+/gm, '')
+    .replace(/[*_#>]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function advancePastTrailingClosers(text: string, index: number): number {
+  let end = index
+  while (end < text.length && /[\s"'”’）)\]】》]/.test(text[end])) {
+    end += 1
+  }
+  return end
+}
+
+function scanBoundaries(text: string): BoundaryScan {
+  let sentenceBoundary = -1
+  let softBoundary = -1
+  let inFence = false
+  let inInlineCode = false
+  let inLinkText = false
+  let inLinkUrl = false
+  let inUrl = false
+
+  for (let i = 0; i < text.length; i += 1) {
+    const rest = text.slice(i)
+
+    if (rest.startsWith('```')) {
+      inFence = !inFence
+      i += 2
+      continue
+    }
+
+    if (inFence) continue
+
+    const char = text[i]
+
+    if (char === '`') {
+      inInlineCode = !inInlineCode
+      continue
+    }
+    if (inInlineCode) continue
+
+    if (inLinkUrl) {
+      if (char === ')') inLinkUrl = false
+      continue
+    }
+
+    if (inUrl) {
+      if (/\s/.test(char)) inUrl = false
+      else continue
+    }
+
+    if (rest.startsWith('http://') || rest.startsWith('https://') || rest.startsWith('www.')) {
+      inUrl = true
+      if (rest.startsWith('https://')) i += 7
+      else if (rest.startsWith('http://')) i += 6
+      else i += 3
+      continue
+    }
+    if (inLinkText) {
+      if (char === ']' && text[i + 1] === '(') {
+        inLinkText = false
+        inLinkUrl = true
+        i += 1
+      }
+      continue
+    }
+    if (char === '[') {
+      inLinkText = true
+      continue
+    }
+
+    if (SENTENCE_BOUNDARY_RE.test(char)) {
+      sentenceBoundary = advancePastTrailingClosers(text, i + 1)
+    } else if (SOFT_BOUNDARY_RE.test(char)) {
+      softBoundary = advancePastTrailingClosers(text, i + 1)
+    }
+  }
+
+  return { sentenceBoundary, softBoundary }
+}
+
+export function createMcuSpeechSegmenter(options: McuSpeechSegmenterOptions = {}): McuSpeechSegmenter {
+  const maxChars = Math.max(MIN_SEGMENT_CHARS, options.maxChars || DEFAULT_MAX_SEGMENT_CHARS)
+  let buffer = ''
+
+  function takeReadySegments(force = false): string[] {
+    const segments: string[] = []
+
+    while (buffer.length > 0) {
+      const boundaries = scanBoundaries(buffer)
+      let end = boundaries.sentenceBoundary
+
+      if (end < 0 && buffer.length >= maxChars) {
+        end = boundaries.softBoundary
+      }
+      if (end < 0 && force) {
+        end = buffer.length
+      }
+      if (end < 0) break
+
+      const rawSegment = buffer.slice(0, end)
+      buffer = buffer.slice(end)
+      const segment = normalizeMcuSpeechText(rawSegment)
+      if (segment) segments.push(segment)
+    }
+
+    return segments
+  }
+
+  return {
+    pushDelta(delta: string) {
+      if (!delta) return []
+      buffer += delta
+      return takeReadySegments(false)
+    },
+    flush() {
+      const segments = takeReadySegments(true)
+      return segments.length > 0 ? segments.join(' ') : null
+    },
+    reset() {
+      buffer = ''
+    },
+  }
+}

--- a/packages/server/src/services/global-agent/outbound-relay-client.ts
+++ b/packages/server/src/services/global-agent/outbound-relay-client.ts
@@ -7,9 +7,9 @@ import { config } from '../../config'
 import { clearSessionMessages } from '../../db/hermes/session-store'
 import { getChatRunServer } from '../../routes/hermes/chat-run'
 import { logger } from '../logger'
-import { cleanTtsText } from '../hermes/tts-providers/text'
 import { transcodeToPcmS16le } from '../hermes/stt-providers/audio-convert'
 import { MCU_TTS_SAMPLE_RATE, mcuPromptText, mcuPromptUrl } from '../hermes/mcu-prompts'
+import { createMcuSpeechSegmenter, normalizeMcuSpeechText } from './mcu-speech-segmenter'
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 const MAX_REQUEST_TIMEOUT_MS = 120_000
@@ -82,14 +82,6 @@ const MCU_TTS_OPTIONS = {
   sampleRate: MCU_TTS_SAMPLE_RATE,
 } as const
 const MCU_INTERRUPT_DEBOUNCE_MS = 280
-
-function normalizeMcuSpeechText(text: string): string {
-  return cleanTtsText(text)
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    .replace(/[*_#>]+/g, '')
-    .replace(/\s+/g, ' ')
-    .trim()
-}
 
 function chooseMcuApprovalChoice(event: Record<string, unknown>): 'once' | 'session' | 'always' | null {
   const rawChoices = Array.isArray(event.choices) ? event.choices.map(choice => String(choice)) : []
@@ -203,6 +195,7 @@ class PlainWebSocketRelayClient {
   private readonly activeRuns = new Map<string, { socket: Socket; sessionId: string }>()
   private readonly sessionRuns = new Map<string, { interactionId: string; socket: Socket }>()
   private readonly interruptedInteractions = new Set<string>()
+  private readonly ttsAbortControllers = new Map<string, Set<AbortController>>()
   private readonly recentlyInterruptedSessions = new Map<string, number>()
   private readonly pendingInterrupts = new Map<string, { profile: string; interactionId: string; timer: NodeJS.Timeout }>()
 
@@ -503,10 +496,10 @@ class PlainWebSocketRelayClient {
         timeout: 30_000,
       })
       let output = ''
-      let spokenOutputLength = 0
       let segmentIndex = 0
       let ttsQueue = Promise.resolve()
       let settled = false
+      const speechSegmenter = createMcuSpeechSegmenter()
       const enqueueSpeech = (text: string) => {
         if (this.interruptedInteractions.has(voice.interactionId)) return
         const segmentText = normalizeMcuSpeechText(text)
@@ -547,9 +540,8 @@ class PlainWebSocketRelayClient {
           })
       }
       const flushCompletedAssistantMessage = () => {
-        const text = output.slice(spokenOutputLength)
-        spokenOutputLength = output.length
-        enqueueSpeech(text)
+        const text = speechSegmenter.flush()
+        if (text) enqueueSpeech(text)
       }
       const finish = () => {
         if (settled) return
@@ -624,11 +616,26 @@ class PlainWebSocketRelayClient {
       socket.on('message.delta', (event: Record<string, unknown> = {}) => {
         if (typeof event.delta === 'string') {
           output += event.delta
+          for (const segment of speechSegmenter.pushDelta(event.delta)) {
+            enqueueSpeech(segment)
+          }
         }
       })
       socket.on('run.completed', (event: Record<string, unknown> = {}) => {
-        if (typeof event.output === 'string' && event.output.trim()) output = event.output
-        if (spokenOutputLength > output.length) spokenOutputLength = 0
+        if (typeof event.output === 'string' && event.output.trim()) {
+          if (!output) {
+            output = event.output
+            for (const segment of speechSegmenter.pushDelta(event.output)) {
+              enqueueSpeech(segment)
+            }
+          } else if (event.output.startsWith(output) && event.output.length > output.length) {
+            const tail = event.output.slice(output.length)
+            output = event.output
+            for (const segment of speechSegmenter.pushDelta(tail)) {
+              enqueueSpeech(segment)
+            }
+          }
+        }
         flushCompletedAssistantMessage()
         ttsQueue.finally(() => {
           if (this.interruptedInteractions.has(voice.interactionId)) {
@@ -729,6 +736,7 @@ class PlainWebSocketRelayClient {
 
   private abortActiveRun(interactionId: string): void {
     this.interruptedInteractions.add(interactionId)
+    this.abortTts(interactionId)
     const active = this.activeRuns.get(interactionId)
     if (!active) return
     logger.info({ interactionId, sessionId: active.sessionId }, '[outbound-relay:ws] aborting chat-run after MCU audio interrupt')
@@ -765,11 +773,13 @@ class PlainWebSocketRelayClient {
     const sessionRun = this.sessionRuns.get(sessionId)
     if (sessionRun) {
       this.interruptedInteractions.add(sessionRun.interactionId)
+      this.abortTts(sessionRun.interactionId)
       this.activeRuns.delete(sessionRun.interactionId)
       this.sessionRuns.delete(sessionId)
     }
     if (interactionId) {
       this.interruptedInteractions.add(interactionId)
+      this.abortTts(interactionId)
       const active = this.activeRuns.get(interactionId)
       if (active?.sessionId === sessionId) {
         this.activeRuns.delete(interactionId)
@@ -781,10 +791,14 @@ class PlainWebSocketRelayClient {
   private interruptMcuSession(profile: string, interactionId?: string): void {
     const sessionId = this.mcuSessionId(profile)
     this.recentlyInterruptedSessions.set(sessionId, Date.now())
-    if (interactionId) this.interruptedInteractions.add(interactionId)
+    if (interactionId) {
+      this.interruptedInteractions.add(interactionId)
+      this.abortTts(interactionId)
+    }
     const sessionRun = this.sessionRuns.get(sessionId)
     if (sessionRun) {
       this.interruptedInteractions.add(sessionRun.interactionId)
+      this.abortTts(sessionRun.interactionId)
       logger.info({
         interactionId: sessionRun.interactionId,
         sessionId,
@@ -795,6 +809,34 @@ class PlainWebSocketRelayClient {
       return
     }
     if (interactionId) this.abortActiveRun(interactionId)
+  }
+
+  private registerTtsAbortController(interactionId: string): AbortController {
+    const controller = new AbortController()
+    if (this.interruptedInteractions.has(interactionId)) {
+      controller.abort()
+      return controller
+    }
+    const controllers = this.ttsAbortControllers.get(interactionId) || new Set<AbortController>()
+    controllers.add(controller)
+    this.ttsAbortControllers.set(interactionId, controllers)
+    return controller
+  }
+
+  private releaseTtsAbortController(interactionId: string, controller: AbortController): void {
+    const controllers = this.ttsAbortControllers.get(interactionId)
+    if (!controllers) return
+    controllers.delete(controller)
+    if (controllers.size === 0) this.ttsAbortControllers.delete(interactionId)
+  }
+
+  private abortTts(interactionId: string): void {
+    const controllers = this.ttsAbortControllers.get(interactionId)
+    if (!controllers) return
+    for (const controller of controllers) {
+      if (!controller.signal.aborted) controller.abort()
+    }
+    this.ttsAbortControllers.delete(interactionId)
   }
 
   private clearMcuSession(profile: string, interactionId?: string): void {
@@ -832,22 +874,30 @@ class PlainWebSocketRelayClient {
   private async enqueueMcuSpeechSegment(profile: string, interactionId: string, segmentId: string, text: string): Promise<void> {
     if (this.interruptedInteractions.has(interactionId)) return
     this.sendJson({ type: 'interaction.status', interactionId, status: 'speaking' })
-    const audio = await this.synthesizeMcuSpeech(text, profile)
-    if (this.interruptedInteractions.has(interactionId)) return
-    const waitForDone = this.waitForMcuAudioDone(segmentId, Math.max(90_000, Math.min(text.length * 1200, 300_000)))
-    this.sendJson({
-      type: 'audio.enqueue',
-      interactionId,
-      segmentId,
-      text: '',
-      url: audio.url,
-      mimeType: 'audio/x-pcm',
-      channels: 1,
-      sampleRate: MCU_TTS_SAMPLE_RATE,
-      durationMs: Math.max(1200, Math.min(text.length * 180, 12_000)),
-      completionManagedByServer: true,
-    })
-    await waitForDone
+    const controller = this.registerTtsAbortController(interactionId)
+    try {
+      const audio = await this.synthesizeMcuSpeech(text, profile, controller.signal)
+      if (this.interruptedInteractions.has(interactionId) || controller.signal.aborted) return
+      const waitForDone = this.waitForMcuAudioDone(segmentId, Math.max(90_000, Math.min(text.length * 1200, 300_000)))
+      this.sendJson({
+        type: 'audio.enqueue',
+        interactionId,
+        segmentId,
+        text: '',
+        url: audio.url,
+        mimeType: 'audio/x-pcm',
+        channels: 1,
+        sampleRate: MCU_TTS_SAMPLE_RATE,
+        durationMs: Math.max(1200, Math.min(text.length * 180, 12_000)),
+        completionManagedByServer: true,
+      })
+      await waitForDone
+    } catch (err) {
+      if (controller.signal.aborted) throw new Error('audio.interrupted')
+      throw err
+    } finally {
+      this.releaseTtsAbortController(interactionId, controller)
+    }
   }
 
   private waitForMcuAudioDone(segmentId: string, timeoutMs: number): Promise<void> {
@@ -860,7 +910,7 @@ class PlainWebSocketRelayClient {
     })
   }
 
-  private async synthesizeMcuSpeech(text: string, profile: string): Promise<{ url: string }> {
+  private async synthesizeMcuSpeech(text: string, profile: string, signal?: AbortSignal): Promise<{ url: string }> {
     if (!this.options.userToken) {
       throw new Error('missing Web UI auth token')
     }
@@ -874,6 +924,7 @@ class PlainWebSocketRelayClient {
     const requestTts = (provider?: 'edge') => this.options.fetchImpl(`${baseUrl}/api/hermes/tts/synthesize`, {
       method: 'POST',
       headers,
+      signal,
       body: JSON.stringify({
         ...(provider ? { provider } : {}),
         text,
@@ -925,6 +976,7 @@ class PlainWebSocketRelayClient {
         const fallback = await this.options.fetchImpl(`${baseUrl}/api/hermes/tts/synthesize`, {
           method: 'POST',
           headers,
+          signal,
           body: JSON.stringify({
             provider: 'edge',
             text,

--- a/packages/server/src/services/global-agent/server.ts
+++ b/packages/server/src/services/global-agent/server.ts
@@ -8,9 +8,9 @@ import { authenticateUserToken, type AuthenticatedUser } from '../../middleware/
 import { userCanAccessProfile } from '../../db/hermes/users-store'
 import { config } from '../../config'
 import { getChatRunServer } from '../../routes/hermes/chat-run'
-import { cleanTtsText } from '../hermes/tts-providers/text'
 import { transcodeToPcmS16le } from '../hermes/stt-providers/audio-convert'
 import { MCU_TTS_SAMPLE_RATE, mcuPromptText, mcuPromptUrl } from '../hermes/mcu-prompts'
+import { createMcuSpeechSegmenter, normalizeMcuSpeechText } from './mcu-speech-segmenter'
 import type {
   RelayHttpRequest,
   RelayHttpResponse,
@@ -278,14 +278,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
-function normalizeMcuSpeechText(text: string): string {
-  return cleanTtsText(text)
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    .replace(/[*_#>]+/g, '')
-    .replace(/\s+/g, ' ')
-    .trim()
-}
-
 function chooseMcuApprovalChoice(event: Record<string, unknown>): 'once' | 'session' | 'always' | null {
   const rawChoices = Array.isArray(event.choices) ? event.choices.map(choice => String(choice)) : []
   const choices = rawChoices.length > 0 ? rawChoices : ['once', 'session', 'deny']
@@ -399,6 +391,7 @@ export class GlobalAgentServer {
   private readonly mcuAudioWaiters = new Map<string, McuAudioWaiter>()
   private readonly mcuVoiceStreams = new Map<string, McuVoiceStreamState>()
   private readonly interruptedMcuInteractions = new Set<string>()
+  private readonly mcuTtsAbortControllers = new Map<string, Set<AbortController>>()
   private readonly recentlyInterruptedMcuSessions = new Map<string, number>()
   private readonly pendingMcuInterrupts = new Map<string, PendingMcuInterrupt>()
   private readonly authToken = randomBytes(32).toString('hex')
@@ -511,7 +504,7 @@ export class GlobalAgentServer {
     let ttsQueue = Promise.resolve()
     let settled = false
     let output = ''
-    let spokenOutputLength = 0
+    const speechSegmenter = createMcuSpeechSegmenter()
 
     const finish = () => {
       if (settled) return
@@ -566,9 +559,8 @@ export class GlobalAgentServer {
         })
     }
     const flushCompletedAssistantMessage = () => {
-      const text = output.slice(spokenOutputLength)
-      spokenOutputLength = output.length
-      enqueueSpeech(text)
+      const text = speechSegmenter.flush()
+      if (text) enqueueSpeech(text)
     }
     const timer = setTimeout(() => {
       fail('chat-run timed out')
@@ -626,10 +618,25 @@ export class GlobalAgentServer {
     socket.on('message.delta', (event: Record<string, unknown> = {}) => {
       if (typeof event.delta !== 'string') return
       output += event.delta
+      for (const segment of speechSegmenter.pushDelta(event.delta)) {
+        enqueueSpeech(segment)
+      }
     })
     socket.on('run.completed', (event: Record<string, unknown> = {}) => {
-      if (typeof event.output === 'string' && event.output.trim()) output = event.output
-      if (spokenOutputLength > output.length) spokenOutputLength = 0
+      if (typeof event.output === 'string' && event.output.trim()) {
+        if (!output) {
+          output = event.output
+          for (const segment of speechSegmenter.pushDelta(event.output)) {
+            enqueueSpeech(segment)
+          }
+        } else if (event.output.startsWith(output) && event.output.length > output.length) {
+          const tail = event.output.slice(output.length)
+          output = event.output
+          for (const segment of speechSegmenter.pushDelta(tail)) {
+            enqueueSpeech(segment)
+          }
+        }
+      }
       flushCompletedAssistantMessage()
       ttsQueue.finally(() => {
         if (this.interruptedMcuInteractions.has(options.interactionId)) {
@@ -1075,7 +1082,7 @@ export class GlobalAgentServer {
     return `mcu-${instance}-${profileId}`
   }
 
-  private async synthesizeMcuSpeech(text: string, userToken: string, profile: string): Promise<{ url: string }> {
+  private async synthesizeMcuSpeech(text: string, userToken: string, profile: string, signal?: AbortSignal): Promise<{ url: string }> {
     const headers = {
       Authorization: `Bearer ${userToken}`,
       'Content-Type': 'application/json',
@@ -1084,6 +1091,7 @@ export class GlobalAgentServer {
     const requestTts = (provider?: 'edge') => this.fetchImpl(`${this.localBaseUrl}/api/hermes/tts/synthesize`, {
       method: 'POST',
       headers,
+      signal,
       body: JSON.stringify({
         ...(provider ? { provider } : {}),
         text,
@@ -1131,6 +1139,7 @@ export class GlobalAgentServer {
         const fallback = await this.fetchImpl(`${this.localBaseUrl}/api/hermes/tts/synthesize`, {
           method: 'POST',
           headers,
+          signal,
           body: JSON.stringify({
             provider: 'edge',
             text,
@@ -1157,22 +1166,30 @@ export class GlobalAgentServer {
   private async enqueueMcuSpeechSegment(options: McuVoiceChatTurnOptions, segmentId: string, text: string): Promise<void> {
     if (this.interruptedMcuInteractions.has(options.interactionId)) return
     this.emitMcuEvent({ type: 'interaction.status', interactionId: options.interactionId, status: 'speaking' }, { clientId: options.clientId })
-    const audio = await this.synthesizeMcuSpeech(text, options.userToken, options.profile)
-    if (this.interruptedMcuInteractions.has(options.interactionId)) return
-    const waitForDone = this.waitForMcuAudioDone(segmentId, Math.max(90_000, Math.min(text.length * 1200, 300_000)))
-    this.emitMcuEvent({
-      type: 'audio.enqueue',
-      interactionId: options.interactionId,
-      segmentId,
-      text: '',
-      url: audio.url,
-      mimeType: 'audio/x-pcm',
-      channels: 1,
-      sampleRate: MCU_TTS_SAMPLE_RATE,
-      durationMs: Math.max(1200, Math.min(text.length * 180, 12_000)),
-      completionManagedByServer: true,
-    }, { clientId: options.clientId })
-    await waitForDone
+    const controller = this.registerMcuTtsAbortController(options.interactionId)
+    try {
+      const audio = await this.synthesizeMcuSpeech(text, options.userToken, options.profile, controller.signal)
+      if (this.interruptedMcuInteractions.has(options.interactionId) || controller.signal.aborted) return
+      const waitForDone = this.waitForMcuAudioDone(segmentId, Math.max(90_000, Math.min(text.length * 1200, 300_000)))
+      this.emitMcuEvent({
+        type: 'audio.enqueue',
+        interactionId: options.interactionId,
+        segmentId,
+        text: '',
+        url: audio.url,
+        mimeType: 'audio/x-pcm',
+        channels: 1,
+        sampleRate: MCU_TTS_SAMPLE_RATE,
+        durationMs: Math.max(1200, Math.min(text.length * 180, 12_000)),
+        completionManagedByServer: true,
+      }, { clientId: options.clientId })
+      await waitForDone
+    } catch (err) {
+      if (controller.signal.aborted) throw new Error('audio.interrupted')
+      throw err
+    } finally {
+      this.releaseMcuTtsAbortController(options.interactionId, controller)
+    }
   }
 
   private waitForMcuAudioDone(segmentId: string, timeoutMs: number): Promise<void> {
@@ -1187,6 +1204,7 @@ export class GlobalAgentServer {
 
   private abortActiveMcuRun(interactionId: string): void {
     this.interruptedMcuInteractions.add(interactionId)
+    this.abortMcuTts(interactionId)
     const active = this.activeMcuRuns.get(interactionId)
     if (!active) return
     logger.info({ interactionId, sessionId: active.sessionId }, '[global-agent] aborting MCU chat-run after audio interrupt')
@@ -1224,11 +1242,13 @@ export class GlobalAgentServer {
     const sessionRun = this.mcuSessionRuns.get(sessionId)
     if (sessionRun) {
       this.interruptedMcuInteractions.add(sessionRun.interactionId)
+      this.abortMcuTts(sessionRun.interactionId)
       this.activeMcuRuns.delete(sessionRun.interactionId)
       this.mcuSessionRuns.delete(sessionId)
     }
     if (interactionId) {
       this.interruptedMcuInteractions.add(interactionId)
+      this.abortMcuTts(interactionId)
       const active = this.activeMcuRuns.get(interactionId)
       if (active?.sessionId === sessionId) {
         this.activeMcuRuns.delete(interactionId)
@@ -1240,10 +1260,14 @@ export class GlobalAgentServer {
   private interruptMcuSession(clientId: string, profile: string, interactionId?: string): void {
     const sessionId = this.mcuSessionId(clientId, profile)
     this.recentlyInterruptedMcuSessions.set(sessionId, Date.now())
-    if (interactionId) this.interruptedMcuInteractions.add(interactionId)
+    if (interactionId) {
+      this.interruptedMcuInteractions.add(interactionId)
+      this.abortMcuTts(interactionId)
+    }
     const sessionRun = this.mcuSessionRuns.get(sessionId)
     if (sessionRun) {
       this.interruptedMcuInteractions.add(sessionRun.interactionId)
+      this.abortMcuTts(sessionRun.interactionId)
       logger.info({ interactionId: sessionRun.interactionId, sessionId }, '[global-agent] aborting MCU chat-run after interrupt')
       sessionRun.socket.emit('abort', { session_id: sessionId })
       this.activeMcuRuns.delete(sessionRun.interactionId)
@@ -1251,6 +1275,34 @@ export class GlobalAgentServer {
       return
     }
     if (interactionId) this.abortActiveMcuRun(interactionId)
+  }
+
+  private registerMcuTtsAbortController(interactionId: string): AbortController {
+    const controller = new AbortController()
+    if (this.interruptedMcuInteractions.has(interactionId)) {
+      controller.abort()
+      return controller
+    }
+    const controllers = this.mcuTtsAbortControllers.get(interactionId) || new Set<AbortController>()
+    controllers.add(controller)
+    this.mcuTtsAbortControllers.set(interactionId, controllers)
+    return controller
+  }
+
+  private releaseMcuTtsAbortController(interactionId: string, controller: AbortController): void {
+    const controllers = this.mcuTtsAbortControllers.get(interactionId)
+    if (!controllers) return
+    controllers.delete(controller)
+    if (controllers.size === 0) this.mcuTtsAbortControllers.delete(interactionId)
+  }
+
+  private abortMcuTts(interactionId: string): void {
+    const controllers = this.mcuTtsAbortControllers.get(interactionId)
+    if (!controllers) return
+    for (const controller of controllers) {
+      if (!controller.signal.aborted) controller.abort()
+    }
+    this.mcuTtsAbortControllers.delete(interactionId)
   }
 
   private clearMcuSession(clientId: string, profile: string, interactionId?: string): void {

--- a/tests/server/global-agent-server.test.ts
+++ b/tests/server/global-agent-server.test.ts
@@ -677,7 +677,7 @@ describe('GlobalAgentServer', () => {
 
     await waitForMockCalls(fetchImpl, 2)
     expect(JSON.parse(String(fetchImpl.mock.calls[1][1]?.body))).toMatchObject({
-      text: '结果如下： | 名称 | 值 | | --- | --- | | foo | 1 | 请确认。',
+      text: '结果如下： 请确认。',
     })
     expect(agentSocket.emit).toHaveBeenCalledWith('audio.enqueue', expect.objectContaining({
       interactionId: 'voice-1',
@@ -685,6 +685,63 @@ describe('GlobalAgentServer', () => {
       url: expect.stringMatching(/^\/api\/hermes\/mcu\/audio\/[a-f0-9-]+\.pcm$/),
       completionManagedByServer: true,
     }))
+  })
+
+  it('aborts in-flight MCU TTS synthesis when the device interrupts playback', async () => {
+    authMocks.authenticateUserToken.mockResolvedValue({ id: 7, username: 'ada', role: 'user' })
+    authMocks.userCanAccessProfile.mockReturnValue(true)
+    let ttsSignal: AbortSignal | undefined
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      ttsSignal = init?.signal || undefined
+      return await new Promise<Response>((_resolve, reject) => {
+        ttsSignal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), { once: true })
+      })
+    })
+    const nsp = createMockNamespace()
+    const io = { of: vi.fn(() => nsp) }
+    const { GlobalAgentServer } = await import('../../packages/server/src/services/global-agent/server')
+
+    const server = new GlobalAgentServer(io as any, {
+      fetchImpl: fetchImpl as any,
+      localBaseUrl: 'http://127.0.0.1:8647',
+    })
+    server.init()
+
+    const agentSocket = createMockSocket('jwt-agent-socket', {
+      token: 'user-jwt',
+      role: 'hermes-studio',
+      instanceId: 'device-1',
+      profile: 'research',
+    })
+    await new Promise<void>((resolve, reject) => {
+      nsp.__middleware[0](agentSocket, (err?: Error) => err ? reject(err) : resolve())
+    })
+    nsp.__handlers.get('connection')?.(agentSocket)
+
+    server.startMcuVoiceChatTurn({
+      userToken: 'user-jwt',
+      profile: 'research',
+      interactionId: 'voice-abort',
+      transcript: 'hi',
+      clientId: 'device-1',
+    })
+    const localSocket = clientSocketMocks.localSockets.at(-1)
+    localSocket.__handlers.get('connect')?.()
+    localSocket.__handlers.get('message.delta')?.({ delta: '这段正在合成。' })
+
+    await waitForMockCalls(fetchImpl, 1)
+    expect(ttsSignal?.aborted).toBe(false)
+
+    agentSocket.__handlers.get('audio.interrupted')?.({
+      interactionId: 'voice-abort',
+      segmentId: 'voice-abort-tts-1',
+    })
+
+    await vi.waitFor(() => {
+      expect(ttsSignal?.aborted).toBe(true)
+    })
+    expect(localSocket.emit).toHaveBeenCalledWith('abort', { session_id: 'mcu-device-1-research' })
+    expect(agentSocket.emit).not.toHaveBeenCalledWith('audio.enqueue', expect.anything())
   })
 
   it('auto-approves MCU chat-run approval requests using the same choice order as the client relay', async () => {

--- a/tests/server/mcu-speech-segmenter.test.ts
+++ b/tests/server/mcu-speech-segmenter.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createMcuSpeechSegmenter,
+  normalizeMcuSpeechText,
+} from '../../packages/server/src/services/global-agent/mcu-speech-segmenter'
+
+describe('MCU speech segmenter', () => {
+  it('waits for markdown links to close before emitting speech', () => {
+    const segmenter = createMcuSpeechSegmenter({ maxChars: 24 })
+
+    expect(segmenter.pushDelta('请打开 [控制台')).toEqual([])
+    expect(segmenter.pushDelta('](https://example.com)。')).toEqual([
+      '请打开 控制台。',
+    ])
+  })
+
+  it('skips fenced code and table rows when flushing readable text', () => {
+    const segmenter = createMcuSpeechSegmenter({ maxChars: 24 })
+
+    const segments = [
+      ...segmenter.pushDelta('结果如下：\n```ts\nconst value = 1;\n```\n'),
+      ...segmenter.pushDelta('| 名称 | 值 |\n| --- | --- |\n| foo | 1 |\n请确认。'),
+    ]
+    expect(segments.join(' ')).toContain('结果如下')
+    expect(segments.join(' ')).toContain('请确认')
+    expect(segments.join(' ')).not.toContain('const value')
+    expect(segments.join(' ')).not.toContain('foo')
+  })
+
+  it('normalizes markdown without preserving table syntax', () => {
+    const normalized = normalizeMcuSpeechText('结果如下：\n| 名称 | 值 |\n| --- | --- |\n| foo | 1 |\n[详情](https://example.com)。参考 https://example.com/a?b=1 和 www.example.com/path')
+    expect(normalized).toContain('结果如下')
+    expect(normalized).toContain('详情')
+    expect(normalized).not.toContain('https')
+    expect(normalized).not.toContain('www.')
+    expect(normalized).not.toContain('foo')
+  })
+})

--- a/tests/server/outbound-relay-client.test.ts
+++ b/tests/server/outbound-relay-client.test.ts
@@ -250,6 +250,65 @@ describe('outbound relay client', () => {
     expect(enqueuePayload).not.toHaveProperty('completionManagedByServer')
   })
 
+  it('aborts in-flight websocket MCU TTS synthesis when playback is interrupted', async () => {
+    let ttsSignal: AbortSignal | undefined
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.includes('/api/hermes/mcu/voice-turn')) {
+        return new Response(JSON.stringify({ ok: true, transcript: '你好' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      ttsSignal = init?.signal || undefined
+      return await new Promise<Response>((_resolve, reject) => {
+        ttsSignal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), { once: true })
+      })
+    })
+    const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+
+    startOutboundRelayClient({
+      relayUrl: 'ws://device.local:8787/',
+      relayProtocol: 'websocket',
+      userToken: 'user-jwt',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: fetchImpl as any,
+    })
+
+    const ws = mockWebSockets[0]
+    ws.__handlers.get('open')?.()
+    ws.__handlers.get('message')?.(JSON.stringify({
+      type: 'voice.recorded',
+      interactionId: 'voice-abort',
+      mimeType: 'audio/wav',
+      profile: 'research',
+    }), false)
+    ws.__handlers.get('message')?.(Buffer.from('wav-audio'), true)
+
+    await vi.waitFor(() => {
+      expect(mockIo).toHaveBeenCalledWith('http://127.0.0.1:8648/chat-run', expect.any(Object))
+    })
+    const localSocket = sockets.at(-1)
+    localSocket.__handlers.get('connect')?.()
+    localSocket.__handlers.get('message.delta')?.({ delta: '这段正在合成。' })
+
+    await vi.waitFor(() => {
+      expect(ttsSignal).toBeDefined()
+    })
+    expect(ttsSignal?.aborted).toBe(false)
+
+    ws.__handlers.get('message')?.(JSON.stringify({
+      type: 'audio.interrupted',
+      interactionId: 'voice-abort',
+      segmentId: 'voice-abort-tts-1',
+    }), false)
+
+    await vi.waitFor(() => {
+      expect(ttsSignal?.aborted).toBe(true)
+    })
+    expect(localSocket.emit).toHaveBeenCalledWith('abort', { session_id: 'mcu-device-research' })
+    expect(ws.send).not.toHaveBeenCalledWith(expect.stringContaining('"audio.enqueue"'))
+  })
+
   it('forwards an allowed HTTP request to the local Web UI server', async () => {
     const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
       status: 202,


### PR DESCRIPTION
## Summary
- Add a shared MCU speech segmenter for global-agent voice turns so assistant deltas can be synthesized in safe speech-sized chunks.
- Skip fenced code, markdown tables, markdown link URLs, and bare URLs before TTS synthesis.
- Abort in-flight `/api/hermes/tts/synthesize` requests when MCU playback is interrupted, instead of only dropping audio after synthesis completes.

## Impact
- MCU/global-agent voice responses can start earlier while avoiding unstable markdown/code/link content in spoken output.
- Device interrupts now stop pending TTS work for both server-side global-agent and outbound relay paths.

## Validation
- `npm run test -- tests/server/mcu-speech-segmenter.test.ts tests/server/global-agent-server.test.ts tests/server/outbound-relay-client.test.ts`
- `npm run harness:check`
- `npm run build`
