### PR TITLE
[codex] add pet close control

### DIFF
--- a/packages/client/src/api/hermes/pets.ts
+++ b/packages/client/src/api/hermes/pets.ts
@@ -42,6 +42,7 @@ export async function adoptPet(slug: string): Promise<ActivePet> {
 export async function updateActivePetPreferences(input: {
   scale?: number
   position?: WebPetPosition
+  enabled?: boolean
 }): Promise<ActivePet | null> {
   const res = await request<{ pet: ActivePet | null }>('/api/hermes/pets/active', {
     method: 'PATCH',

--- a/packages/client/src/components/hermes/pets/WebPet.vue
+++ b/packages/client/src/components/hermes/pets/WebPet.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { usePetsStore } from '@/stores/hermes/pets'
 import { usePetStateStore } from '@/stores/hermes/pet-state'
 import { useProfilesStore } from '@/stores/hermes/profiles'
@@ -21,6 +22,7 @@ const props = defineProps<{
 }>()
 
 const route = useRoute()
+const { t } = useI18n()
 const petsStore = usePetsStore()
 const petStateStore = usePetStateStore()
 const profilesStore = useProfilesStore()
@@ -50,6 +52,7 @@ let stateOverrideTimer: number | null = null
 let lastStateChangedAt = 0
 let activeSpriteKey = ''
 let connectedPetProfile: string | null = null
+let stopPetWindowRefresh: (() => void) | null = null
 
 const isDesktopWindow = computed(() => props.desktopWindow === true)
 const isLoginPage = computed(() => !isDesktopWindow.value && route.name === 'login')
@@ -408,6 +411,13 @@ function handleWheel(event: WheelEvent): void {
   setScale(scale.value + (event.deltaY < 0 ? SCALE_STEP : -SCALE_STEP))
 }
 
+async function handleClosePet(): Promise<void> {
+  dragging.value = false
+  resizing.value = false
+  await petsStore.hideActivePet()
+  await setDesktopWindowVisible(false)
+}
+
 function handleResize(): void {
   if (isDesktopWindow.value) {
     draw()
@@ -438,6 +448,11 @@ async function loadForProfile(profile?: string | null): Promise<void> {
   await hydrateDesktopWindowPosition()
   const active = await petsStore.loadActivePet()
   if (active?.enabled) await connectPetStateForProfile(profile)
+}
+
+function refreshDesktopPetWindow(): void {
+  if (!isDesktopWindow.value) return
+  void loadForProfile(profilesStore.activeProfileName || localStorage.getItem('hermes_active_profile_name') || 'default')
 }
 
 watch(
@@ -508,12 +523,15 @@ watch(visible, shown => {
 
 onMounted(() => {
   lastStateChangedAt = Date.now()
+  stopPetWindowRefresh = bridge?.onPetWindowRefresh?.(refreshDesktopPetWindow) || null
   window.addEventListener('resize', handleResize)
   window.addEventListener('pagehide', shutdownPetConnection)
   window.addEventListener('beforeunload', shutdownPetConnection)
 })
 
 onUnmounted(() => {
+  stopPetWindowRefresh?.()
+  stopPetWindowRefresh = null
   stopAnimation()
   if (saveTimer != null) window.clearTimeout(saveTimer)
   clearStateSwitchTimer()
@@ -540,6 +558,19 @@ onUnmounted(() => {
     @dblclick="handleDoubleClick"
   >
     <canvas ref="canvasRef" class="web-pet-canvas" :aria-label="pet?.displayName || 'Pet'" />
+    <button
+      type="button"
+      class="web-pet-close"
+      :aria-label="t('common.delete')"
+      :title="t('common.delete')"
+      @click.stop="handleClosePet"
+      @pointerdown.stop
+      @pointermove.stop
+      @pointerup.stop
+      @pointercancel.stop
+    >
+      ×
+    </button>
     <button
       type="button"
       class="web-pet-resize"
@@ -589,10 +620,9 @@ onUnmounted(() => {
   outline: 0;
 }
 
+.web-pet-close,
 .web-pet-resize {
   position: absolute;
-  right: -2px;
-  bottom: -2px;
   width: 22px;
   height: 22px;
   padding: 0;
@@ -613,6 +643,26 @@ onUnmounted(() => {
     opacity: 1;
     transform: translate(-1px, -1px);
   }
+}
+
+.web-pet-close {
+  top: -2px;
+  right: -2px;
+  color: rgba(32, 36, 45, 0.8);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+
+  &:hover {
+    transform: translate(-1px, 1px);
+  }
+}
+
+.web-pet-resize {
+  right: -2px;
+  bottom: -2px;
+  cursor: nwse-resize;
 
   img {
     width: 14px;
@@ -624,11 +674,14 @@ onUnmounted(() => {
   }
 }
 
+.web-pet:hover .web-pet-close,
 .web-pet:hover .web-pet-resize,
+.web-pet.dragging .web-pet-close,
 .web-pet.resizing .web-pet-resize {
   opacity: 0.92;
 }
 
+:global(.dark) .web-pet-close,
 :global(.dark) .web-pet-resize {
   background: rgba(25, 28, 35, 0.78);
   box-shadow:
@@ -636,6 +689,11 @@ onUnmounted(() => {
     inset 0 0 0 1px rgba(255, 255, 255, 0.12);
 }
 
+:global(.dark) .web-pet-close {
+  color: rgba(244, 247, 251, 0.82);
+}
+
+.web-pet.desktop-window .web-pet-close,
 .web-pet.desktop-window .web-pet-resize {
   background: rgba(255, 255, 255, 0.76);
   border: 0;
@@ -643,6 +701,7 @@ onUnmounted(() => {
   outline: 0;
 }
 
+:global(.dark) .web-pet.desktop-window .web-pet-close,
 :global(.dark) .web-pet.desktop-window .web-pet-resize {
   background: rgba(25, 28, 35, 0.78);
 }

--- a/packages/client/src/stores/hermes/pets.ts
+++ b/packages/client/src/stores/hermes/pets.ts
@@ -40,20 +40,26 @@ export const usePetsStore = defineStore('pets', () => {
     }
   }
 
-  async function savePreferences(input: { scale?: number; position?: WebPetPosition }): Promise<void> {
+  async function savePreferences(input: { scale?: number; position?: WebPetPosition; enabled?: boolean }): Promise<void> {
     if (!activePet.value) return
     activePet.value = {
       ...activePet.value,
       ...(typeof input.scale === 'number' ? { scale: input.scale } : {}),
       ...(input.position ? { position: input.position } : {}),
+      ...(typeof input.enabled === 'boolean' ? { enabled: input.enabled } : {}),
     }
     saving.value = true
     try {
       const saved = await petsApi.updateActivePetPreferences(input)
       if (saved) activePet.value = saved
+      else if (input.enabled === false) activePet.value = null
     } finally {
       saving.value = false
     }
+  }
+
+  async function hideActivePet(): Promise<void> {
+    await savePreferences({ enabled: false })
   }
 
   function clear(): void {
@@ -70,6 +76,7 @@ export const usePetsStore = defineStore('pets', () => {
     loadActivePet,
     adopt,
     savePreferences,
+    hideActivePet,
     clear,
   }
 })

--- a/packages/client/src/utils/desktop-bridge.ts
+++ b/packages/client/src/utils/desktop-bridge.ts
@@ -20,6 +20,7 @@ export interface HermesDesktopBridge {
   getPetWindowState?: () => Promise<DesktopPetWindowState>
   setPetWindowBounds?: (bounds: DesktopWindowBounds) => Promise<DesktopPetWindowState>
   setPetWindowVisible?: (visible: boolean) => Promise<DesktopPetWindowState>
+  onPetWindowRefresh?: (callback: () => void) => () => void
   platform: string
   isDesktop: boolean
   windowKind?: 'main' | 'pet'

--- a/packages/client/src/views/hermes/PetdexView.vue
+++ b/packages/client/src/views/hermes/PetdexView.vue
@@ -4,6 +4,7 @@ import { NAlert, NButton, NEmpty, NInput, NSelect, NSpin, NTag, useMessage } fro
 import { useI18n } from 'vue-i18n'
 import { fetchPetdexManifest, type PetdexManifest, type PetdexPet } from '@/api/hermes/petdex'
 import { usePetsStore } from '@/stores/hermes/pets'
+import { desktopBridge } from '@/utils/desktop-bridge'
 
 const { t } = useI18n()
 const message = useMessage()
@@ -16,6 +17,7 @@ const error = ref('')
 const searchQuery = ref('')
 const kindFilter = ref<string | null>(null)
 const visibleLimit = ref(96)
+const DESKTOP_ADOPT_SCALE = 0.58
 
 const pets = computed(() => manifest.value?.pets ?? [])
 const generatedAt = computed(() => {
@@ -80,6 +82,11 @@ async function adopt(pet: PetdexPet) {
   adoptingSlug.value = pet.slug
   try {
     await petsStore.adopt(pet.slug)
+    const bridge = desktopBridge()
+    if (bridge?.isDesktop) {
+      await petsStore.savePreferences({ scale: DESKTOP_ADOPT_SCALE })
+      await bridge.setPetWindowVisible?.(true).catch(() => undefined)
+    }
     message.success(t('petdex.adopted', { name: pet.displayName }))
   } catch (err: any) {
     message.error(err?.message || t('petdex.adoptFailed'))

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -23,6 +23,7 @@ const PET_WINDOW_DEFAULT_WIDTH = 300
 const PET_WINDOW_DEFAULT_HEIGHT = 320
 const PET_WINDOW_MIN_SIZE = 72
 const PET_WINDOW_MAX_SIZE = 1200
+const PET_WINDOW_REFRESH_CHANNEL = 'hermes-desktop:pet-window-refresh'
 type WindowControlAction = 'minimize' | 'toggle-maximize' | 'close'
 type DesktopWindowBounds = { x: number; y: number; width: number; height: number }
 
@@ -620,8 +621,10 @@ ipcMain.handle('hermes-desktop:set-pet-window-visible', async (_event, visible?:
     petWindow.hide()
     return petWindowState()
   }
+  const fromPetWindow = !!petWindow && !petWindow.isDestroyed() && _event.sender === petWindow.webContents
   await loadPetWindowRoute()
   const target = ensurePetWindow()
+  if (!fromPetWindow) target.webContents.send(PET_WINDOW_REFRESH_CHANNEL)
   target.showInactive()
   return petWindowState()
 })

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -24,6 +24,11 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getPetWindowState: () => ipcRenderer.invoke('hermes-desktop:get-pet-window-state'),
   setPetWindowBounds: (bounds: { x: number; y: number; width: number; height: number }) => ipcRenderer.invoke('hermes-desktop:set-pet-window-bounds', bounds),
   setPetWindowVisible: (visible: boolean) => ipcRenderer.invoke('hermes-desktop:set-pet-window-visible', visible),
+  onPetWindowRefresh: (callback: () => void): (() => void) => {
+    const listener = () => callback()
+    ipcRenderer.on('hermes-desktop:pet-window-refresh', listener)
+    return () => ipcRenderer.removeListener('hermes-desktop:pet-window-refresh', listener)
+  },
   platform: process.platform,
   isDesktop: true,
   windowKind: desktopWindowKind(),

--- a/packages/server/src/controllers/hermes/pets.ts
+++ b/packages/server/src/controllers/hermes/pets.ts
@@ -36,10 +36,12 @@ export async function updateActive(ctx: Context) {
   const body = ctx.request.body as {
     scale?: unknown
     position?: { x?: unknown; y?: unknown }
+    enabled?: unknown
   } | undefined
 
   const pet = await updateActivePetPreferences(requestedProfile(ctx), {
     scale: typeof body?.scale === 'number' ? body.scale : undefined,
+    enabled: typeof body?.enabled === 'boolean' ? body.enabled : undefined,
     position: body?.position && typeof body.position.x === 'number' && typeof body.position.y === 'number'
       ? { x: body.position.x, y: body.position.y }
       : undefined,

--- a/packages/server/src/services/hermes/pets.ts
+++ b/packages/server/src/services/hermes/pets.ts
@@ -239,14 +239,18 @@ export async function getActivePet(profile: string): Promise<ActivePetResponse |
 
 export async function updateActivePetPreferences(
   profile: string,
-  input: { scale?: number; position?: { x?: number; y?: number } },
+  input: { scale?: number; position?: { x?: number; y?: number }; enabled?: boolean },
 ): Promise<ActivePetResponse | null> {
   const active = await readJsonFile<ActivePetConfig>(activePetPath(profile))
-  if (!active?.enabled || !active.slug) return null
+  if (!active?.slug) return null
 
   const next: ActivePetConfig = {
     ...active,
     updatedAt: Date.now(),
+  }
+
+  if (typeof input.enabled === 'boolean') {
+    next.enabled = input.enabled
   }
 
   if (typeof input.scale === 'number' && Number.isFinite(input.scale)) {
@@ -261,6 +265,7 @@ export async function updateActivePetPreferences(
   }
 
   await writeJsonFile(activePetPath(profile), next)
+  if (!next.enabled) return null
   return getActivePet(profile)
 }
 

--- a/tests/client/pets-store.test.ts
+++ b/tests/client/pets-store.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import type { ActivePet } from '@/api/hermes/pets'
+
+const mockPetsApi = vi.hoisted(() => ({
+  fetchActivePet: vi.fn(),
+  adoptPet: vi.fn(),
+  updateActivePetPreferences: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/pets', () => mockPetsApi)
+
+import { usePetsStore } from '@/stores/hermes/pets'
+
+function activePet(overrides: Partial<ActivePet> = {}): ActivePet {
+  return {
+    enabled: true,
+    slug: 'desk-cat',
+    displayName: 'Desk Cat',
+    kind: 'cat',
+    submittedBy: 'petdex',
+    source: 'petdex',
+    mime: 'image/webp',
+    spritesheetDataUrl: 'data:image/webp;base64,AA==',
+    spritesheetRevision: 1,
+    frameW: 192,
+    frameH: 208,
+    framesPerState: 6,
+    loopMs: 1100,
+    scale: 0.33,
+    position: { x: 10, y: 20 },
+    stateRows: ['idle'],
+    installedAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }
+}
+
+describe('Pets Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('disables and clears the active pet when hiding it', async () => {
+    const store = usePetsStore()
+    store.activePet = activePet()
+    mockPetsApi.updateActivePetPreferences.mockResolvedValue(null)
+
+    await store.hideActivePet()
+
+    expect(mockPetsApi.updateActivePetPreferences).toHaveBeenCalledWith({ enabled: false })
+    expect(store.activePet).toBeNull()
+    expect(store.hasActivePet).toBe(false)
+    expect(store.saving).toBe(false)
+  })
+})

--- a/tests/server/pets-service.test.ts
+++ b/tests/server/pets-service.test.ts
@@ -1,0 +1,77 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getActivePet, updateActivePetPreferences } from '../../packages/server/src/services/hermes/pets'
+
+const originalWebUiHome = process.env.HERMES_WEB_UI_HOME
+
+let hermesHome = ''
+
+function profilePetsDir(profile: string): string {
+  const segment = Buffer.from(profile || 'default', 'utf-8').toString('base64url')
+  return join(hermesHome, 'profile-metadata', segment, 'pets')
+}
+
+async function writeInstalledPet(profile: string, slug: string): Promise<string> {
+  const petsDir = profilePetsDir(profile)
+  const petDir = join(petsDir, slug)
+  await mkdir(petDir, { recursive: true })
+  await writeFile(join(petDir, 'spritesheet.webp'), Buffer.from([1, 2, 3]))
+  await writeFile(join(petDir, 'pet.json'), `${JSON.stringify({
+    slug,
+    displayName: 'Desk Cat',
+    kind: 'cat',
+    submittedBy: 'petdex',
+    source: 'petdex',
+    spritesheetUrl: 'https://assets.petdex.dev/pets/desk-cat/spritesheet.webp',
+    petJsonUrl: '',
+    zipUrl: '',
+    spritesheetFile: 'spritesheet.webp',
+    mime: 'image/webp',
+    installedAt: 1,
+    updatedAt: 1,
+  }, null, 2)}\n`)
+  await writeFile(join(petsDir, 'active.json'), `${JSON.stringify({
+    enabled: true,
+    slug,
+    scale: 0.42,
+    position: { x: 15, y: 30 },
+    updatedAt: 2,
+  }, null, 2)}\n`)
+  return join(petsDir, 'active.json')
+}
+
+describe('pets service', () => {
+  beforeEach(async () => {
+    hermesHome = await mkdtemp(join(tmpdir(), 'hermes-pets-service-'))
+    process.env.HERMES_WEB_UI_HOME = hermesHome
+  })
+
+  afterEach(async () => {
+    await rm(hermesHome, { recursive: true, force: true })
+    if (originalWebUiHome === undefined) delete process.env.HERMES_WEB_UI_HOME
+    else process.env.HERMES_WEB_UI_HOME = originalWebUiHome
+  })
+
+  it('persists disabled active pet state and stops returning it as active', async () => {
+    const profile = 'default'
+    const activePath = await writeInstalledPet(profile, 'desk-cat')
+
+    await expect(getActivePet(profile)).resolves.toMatchObject({
+      enabled: true,
+      slug: 'desk-cat',
+      scale: 0.42,
+    })
+
+    await expect(updateActivePetPreferences(profile, { enabled: false })).resolves.toBeNull()
+    await expect(getActivePet(profile)).resolves.toBeNull()
+
+    const active = JSON.parse(await readFile(activePath, 'utf-8'))
+    expect(active).toMatchObject({
+      enabled: false,
+      slug: 'desk-cat',
+      scale: 0.42,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add a top-right close control to the web pet, matching the existing resize control styling.
- Persist pet hiding through the existing active pet `enabled` state so closed pets stay hidden after refresh/restart.
- Wake and refresh the desktop pet window after adopting a pet from the desktop shell.
- Increase the desktop adopt-time pet scale so newly adopted pets are visible without restarting.
- Add client and server coverage for hiding the active pet.

## Root Cause

Adopted pets could not be dismissed because the UI never exposed the existing `enabled` active-pet state. On desktop, adopting a pet happened in the main window while the pet is rendered in a separate window, so the pet window was not refreshed or shown until the app restarted. The default adopt scale was also too small for the standalone transparent desktop window.

## Validation

- `npm run test -- tests/client/pets-store.test.ts tests/server/pets-service.test.ts`
- `npm run build`
- `npm run harness:check`
