### PR TITLE
[codex] refresh chat input toolbar

### DIFF
--- a/docs/chat-chain-changes/2026-07-01-pr1883-chat-input-toolbar.md
+++ b/docs/chat-chain-changes/2026-07-01-pr1883-chat-input-toolbar.md
@@ -1,0 +1,9 @@
+---
+date: 2026-07-01
+pr: 1883
+commit: ac08e857
+feature: Chat input toolbar refresh
+impact: Chat and group chat composers keep the existing send, stop, attachment, reasoning, settings, model switching, and tool trace behavior while moving controls into the input surface and aligning first-paint fade/background treatment.
+---
+
+The chat input surface now owns the toolbar layout, settings dropdown, compact model switcher trigger, and context usage overlay. Message-list fade-in moved to the surrounding chat surface so the composer and transcript share the same initial background transition.

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1575,6 +1575,20 @@ function isImage(type: string): boolean {
     max-width: 118px;
   }
 
+  .input-settings-button {
+    width: 28px;
+    min-width: 28px;
+    padding: 0;
+
+    :deep(.n-button__content) {
+      display: none;
+    }
+
+    :deep(.n-button__icon) {
+      margin: 0;
+    }
+  }
+
   .context-info {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1559,6 +1559,7 @@ function isImage(type: string): boolean {
 
 @media (max-width: 768px) {
   .chat-input-area {
+    --voice-overlay-mobile-bottom-offset: 146px;
     padding: 8px 12px 12px;
   }
 

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -484,7 +484,8 @@ watch(
   },
 )
 
-const canSend = computed(() => inputText.value.trim() || attachments.value.length > 0)
+const canSend = computed(() => inputText.value.trim().length > 0 || attachments.value.length > 0)
+const sendButtonIsStop = computed(() => chatStore.isStreaming && !canSend.value)
 
 function scrollCommandIntoView() {
   nextTick(() => {
@@ -1178,14 +1179,14 @@ function isImage(type: string): boolean {
             type="primary"
             circle
             class="send-button"
-            :class="{ 'send-button--stop': chatStore.isStreaming }"
-            :disabled="chatStore.isStreaming ? chatStore.isAborting : !canSend"
-            :aria-label="chatStore.isStreaming ? t('chat.stop') : t('chat.send')"
-            @click="chatStore.isStreaming ? chatStore.stopStreaming() : handleSend()"
+            :class="{ 'send-button--stop': sendButtonIsStop }"
+            :disabled="sendButtonIsStop ? chatStore.isAborting : !canSend"
+            :aria-label="sendButtonIsStop ? 'Stop' : 'Send'"
+            @click="sendButtonIsStop ? chatStore.stopStreaming() : handleSend()"
           >
             <template #icon>
               <svg
-                v-if="chatStore.isStreaming"
+                v-if="sendButtonIsStop"
                 width="18"
                 height="18"
                 viewBox="0 0 24 24"
@@ -1195,7 +1196,7 @@ function isImage(type: string): boolean {
               </svg>
               <svg v-else width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5"/><path d="m5 12 7-7 7 7"/></svg>
             </template>
-            <span class="visually-hidden">{{ chatStore.isStreaming ? t('chat.stop') : t('chat.send') }}</span>
+            <span class="visually-hidden">{{ sendButtonIsStop ? t('chat.stop') : t('chat.send') }}</span>
           </NButton>
         </div>
       </div>

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1961,6 +1961,15 @@ function isImage(type: string): boolean {
   .skill-picker-item {
     height: 76px;
   }
+
+  .input-wrapper {
+    min-height: 118px;
+  }
+
+  .input-textarea::placeholder {
+    font-size: 13px;
+    line-height: 1.35;
+  }
 }
 
 .dropdown-fade-enter-active,

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1310,6 +1310,8 @@ function isImage(type: string): boolean {
 @use '@/styles/variables' as *;
 
 .chat-input-area {
+  position: relative;
+  z-index: 80;
   padding: 8px 20px 14px;
   border-top: 0;
   background-color: $bg-card;

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1116,7 +1116,7 @@ function isImage(type: string): boolean {
                       <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06A2 2 0 1 1 7.04 4.3l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.08a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9c.2.6.77 1 1.4 1H21a2 2 0 1 1 0 4h-.09c-.63 0-1.2.4-1.51 1Z"/>
                     </svg>
                   </template>
-                  <span>{{ t('sidebar.settings') }}</span>
+                  <span class="input-settings-label">{{ t('sidebar.settings') }}</span>
                   <svg class="toolbar-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
                 </NButton>
               </template>
@@ -1576,17 +1576,20 @@ function isImage(type: string): boolean {
   }
 
   .input-settings-button {
-    width: 28px;
-    min-width: 28px;
-    padding: 0;
+    min-width: 36px;
+    padding: 0 4px 0 6px;
 
     :deep(.n-button__content) {
-      display: none;
+      gap: 2px;
     }
 
     :deep(.n-button__icon) {
       margin: 0;
     }
+  }
+
+  .input-settings-label {
+    display: none;
   }
 
   .context-info {

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1572,7 +1572,13 @@ function isImage(type: string): boolean {
   }
 
   .input-model-button {
-    max-width: 118px;
+    min-width: 35px;
+    max-width: 35px;
+    padding: 0 4px 0 6px;
+  }
+
+  .input-model-label {
+    display: none;
   }
 
   .input-settings-button {

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -7,8 +7,8 @@ import { useSettingsStore } from '@/stores/hermes/settings'
 import { fetchContextLength } from '@/api/hermes/sessions'
 import { setModelContext } from '@/api/hermes/model-context'
 import { fetchSkills, type SkillCategory, type SkillInfo } from '@/api/hermes/skills'
-import { NButton, NTooltip, NSwitch, NModal, NInputNumber, NPopselect, useMessage } from 'naive-ui'
-import { computed, ref, nextTick, onMounted, onUnmounted, watch } from 'vue'
+import { NButton, NTooltip, NModal, NInputNumber, NPopselect, NDropdown, useMessage, type DropdownOption } from 'naive-ui'
+import { computed, ref, nextTick, onMounted, onUnmounted, watch, h } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useToolTraceVisibility } from '@/composables/useToolTraceVisibility'
 import VoiceDialogueControls from './VoiceDialogueControls.vue'
@@ -29,6 +29,16 @@ const settingsStore = useSettingsStore()
 const { t } = useI18n()
 const message = useMessage()
 const { toolTraceVisible, toggleToolTraceVisible } = useToolTraceVisibility()
+
+const props = withDefaults(defineProps<{
+  modelLabel?: string
+}>(), {
+  modelLabel: '',
+})
+
+const emit = defineEmits<{
+  modelClick: []
+}>()
 
 const reasoningEffortOptions = computed(() => [
   { label: t('chat.reasoningEffort.options.default'), value: '' },
@@ -53,6 +63,17 @@ function onReasoningEffortChange(value: string | null | undefined) {
   if (!sid) return
   chatStore.setSessionReasoningEffort(sid, value || '')
 }
+
+function handleModelButtonClick() {
+  emit('modelClick')
+}
+
+const compactModelLabel = computed(() => {
+  const label = props.modelLabel || t('models.selectModel')
+  const parts = label.split('/').filter(Boolean)
+  return parts[parts.length - 1] || label
+})
+
 const DRAFT_STORAGE_KEY = 'hermes_chat_input_drafts_v1'
 type DraftMap = Record<string, string>
 const inputText = ref('')
@@ -353,6 +374,24 @@ function startResize(e: MouseEvent) {
 
 // 自动播放语音开关
 const autoPlaySpeech = ref(false)
+const inputSettingsOptions = computed<DropdownOption[]>(() => [
+  {
+    label: t('chat.autoPlaySpeech'),
+    key: 'autoPlaySpeech',
+    icon: () => h('span', {
+      class: ['settings-check', { active: autoPlaySpeech.value }],
+      'aria-hidden': 'true',
+    }, autoPlaySpeech.value ? '✓' : ''),
+  },
+  {
+    label: t('chat.showToolCalls'),
+    key: 'toolTrace',
+    icon: () => h('span', {
+      class: ['settings-check', { active: toolTraceVisible.value }],
+      'aria-hidden': 'true',
+    }, toolTraceVisible.value ? '✓' : ''),
+  },
+])
 
 function readDraftMap(): DraftMap {
   try {
@@ -410,6 +449,17 @@ watch(autoPlaySpeech, (value) => {
   // 通知 chat store
   chatStore.setAutoPlaySpeech(value)
 })
+
+function handleInputSettingsSelect(key: string | number) {
+  if (key === 'autoPlaySpeech') {
+    autoPlaySpeech.value = !autoPlaySpeech.value
+    return
+  }
+
+  if (key === 'toolTrace') {
+    toggleToolTraceVisible()
+  }
+}
 
 watch(inputText, (value) => {
   saveDraftForActiveSession(value)
@@ -919,108 +969,6 @@ function isImage(type: string): boolean {
 
 <template>
   <div class="chat-input-area">
-    <!-- Top bar: attach + auto play speech + context info -->
-    <div class="input-top-bar">
-      <NTooltip trigger="hover">
-        <template #trigger>
-          <NButton quaternary size="tiny" @click="handleAttachClick" circle>
-            <template #icon>
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
-            </template>
-          </NButton>
-        </template>
-        {{ t('chat.attachFiles') }}
-      </NTooltip>
-
-      <NPopselect
-        v-if="!isCodingAgentSession"
-        :value="currentReasoningEffort"
-        :options="reasoningEffortOptions"
-        trigger="click"
-        @update:value="onReasoningEffortChange"
-      >
-        <NTooltip trigger="hover">
-          <template #trigger>
-            <NButton
-              quaternary
-              size="tiny"
-              circle
-              class="reasoning-effort-button"
-              :class="{ active: !!currentReasoningEffort }"
-              :aria-label="`${t('chat.reasoningEffort.tooltip')}: ${reasoningEffortLabel}`"
-            >
-              <template #icon>
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96.44 2.5 2.5 0 0 1-2.96-3.08 3 3 0 0 1-.34-5.58 2.5 2.5 0 0 1 1.32-4.24 2.5 2.5 0 0 1 1.98-3A2.5 2.5 0 0 1 9.5 2Z"/>
-                  <path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96.44 2.5 2.5 0 0 0 2.96-3.08 3 3 0 0 0 .34-5.58 2.5 2.5 0 0 0-1.32-4.24 2.5 2.5 0 0 0-1.98-3A2.5 2.5 0 0 0 14.5 2Z"/>
-                </svg>
-              </template>
-            </NButton>
-          </template>
-          {{ t('chat.reasoningEffort.tooltip') }}: {{ reasoningEffortLabel }}
-        </NTooltip>
-      </NPopselect>
-
-      <div class="auto-play-speech-switch">
-        <NTooltip trigger="hover">
-          <template #trigger>
-            <div class="switch-label">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <polygon points="5 3 19 12 5 21 5 3"/>
-              </svg>
-            </div>
-          </template>
-          {{ t('chat.autoPlaySpeech') }}
-        </NTooltip>
-        <NSwitch
-          size="small"
-          v-model:value="autoPlaySpeech"
-          :round="false"
-        />
-      </div>
-
-      <NTooltip trigger="hover">
-        <template #trigger>
-          <NButton
-            quaternary
-            size="tiny"
-            class="tool-trace-toggle"
-            :class="{ active: toolTraceVisible }"
-            :aria-label="toolTraceVisible ? t('chat.hideToolCalls') : t('chat.showToolCalls')"
-            @click="toggleToolTraceVisible"
-          >
-            <svg class="tool-trace-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M14.7 6.3a4.5 4.5 0 0 0-5.8 5.8L3.5 17.5a2.1 2.1 0 0 0 3 3l5.4-5.4a4.5 4.5 0 0 0 5.8-5.8l-3 3-3-3 3-3z"/>
-            </svg>
-          </NButton>
-        </template>
-        {{ toolTraceVisible ? t('chat.hideToolCalls') : t('chat.showToolCalls') }}
-      </NTooltip>
-
-      <span v-if="showContextUsage" class="context-info" :class="{ 'context-warning': usagePercent > 80 }">
-        {{ formatTokens(totalTokens) }} /
-        <NTooltip trigger="hover">
-          <template #trigger>
-            <span class="context-limit-editable" @click="handleEditContextLimit">
-              {{ formatTokens(contextLength) }}
-            </span>
-          </template>
-          <span>{{ t('chat.contextClickToEdit') }}</span>
-        </NTooltip>
-        · {{ t('chat.contextRemaining') }} {{ formatTokens(remainingTokens) }}
-      </span>
-      <div v-if="showContextUsage" class="context-bar">
-        <div
-          class="context-bar-fill"
-          :class="{
-            'context-bar-warn': usagePercent > 60 && usagePercent <= 80,
-            'context-bar-danger': usagePercent > 80,
-          }"
-          :style="{ width: `${usagePercent}%` }"
-        />
-      </div>
-    </div>
-
     <!-- Attachment previews -->
     <div v-if="attachments.length > 0" class="attachment-previews">
       <div
@@ -1066,6 +1014,30 @@ function isImage(type: string): boolean {
         @mousedown="startResize"
         @dblclick="resetTextareaHeight"
       ></div>
+      <div v-if="showContextUsage" class="context-usage-row">
+        <span class="context-info" :class="{ 'context-warning': usagePercent > 80 }">
+          {{ formatTokens(totalTokens) }} /
+          <NTooltip trigger="hover">
+            <template #trigger>
+              <span class="context-limit-editable" @click="handleEditContextLimit">
+                {{ formatTokens(contextLength) }}
+              </span>
+            </template>
+            <span>{{ t('chat.contextClickToEdit') }}</span>
+          </NTooltip>
+          · {{ t('chat.contextRemaining') }} {{ formatTokens(remainingTokens) }}
+        </span>
+        <div class="context-bar">
+          <div
+            class="context-bar-fill"
+            :class="{
+              'context-bar-warn': usagePercent > 60 && usagePercent <= 80,
+              'context-bar-danger': usagePercent > 80,
+            }"
+            :style="{ width: `${usagePercent}%` }"
+          />
+        </div>
+      </div>
       <textarea
         ref="textareaRef"
         v-model="inputText"
@@ -1079,6 +1051,154 @@ function isImage(type: string): boolean {
         @input="handleInput"
         @paste="handlePaste"
       ></textarea>
+      <div class="input-toolbar">
+        <!-- Bottom bar: attach + input settings + actions -->
+        <div class="input-top-bar">
+          <NTooltip trigger="hover">
+            <template #trigger>
+              <NButton quaternary size="tiny" @click="handleAttachClick" circle class="toolbar-icon-button">
+                <template #icon>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+                </template>
+              </NButton>
+            </template>
+            {{ t('chat.attachFiles') }}
+          </NTooltip>
+
+          <NPopselect
+            v-if="!isCodingAgentSession"
+            :value="currentReasoningEffort"
+            :options="reasoningEffortOptions"
+            trigger="click"
+            @update:value="onReasoningEffortChange"
+          >
+            <NTooltip trigger="hover">
+              <template #trigger>
+                <NButton
+                  quaternary
+                  size="tiny"
+                  class="reasoning-effort-button"
+                  :class="{ active: !!currentReasoningEffort }"
+                  :aria-label="`${t('chat.reasoningEffort.tooltip')}: ${reasoningEffortLabel}`"
+                >
+                  <template #icon>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96.44 2.5 2.5 0 0 1-2.96-3.08 3 3 0 0 1-.34-5.58 2.5 2.5 0 0 1 1.32-4.24 2.5 2.5 0 0 1 1.98-3A2.5 2.5 0 0 1 9.5 2Z"/>
+                      <path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96.44 2.5 2.5 0 0 0 2.96-3.08 3 3 0 0 0 .34-5.58 2.5 2.5 0 0 0-1.32-4.24 2.5 2.5 0 0 0-1.98-3A2.5 2.5 0 0 0 14.5 2Z"/>
+                    </svg>
+                  </template>
+                  <span class="reasoning-effort-label">{{ reasoningEffortLabel }}</span>
+                  <svg class="toolbar-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+                </NButton>
+              </template>
+              {{ t('chat.reasoningEffort.tooltip') }}: {{ reasoningEffortLabel }}
+            </NTooltip>
+          </NPopselect>
+
+          <NTooltip trigger="hover">
+            <template #trigger>
+              <NButton
+                quaternary
+                size="tiny"
+                class="input-model-button"
+                :title="props.modelLabel || t('models.selectModel')"
+                :aria-label="props.modelLabel || t('models.selectModel')"
+                @click="handleModelButtonClick"
+              >
+                <template #icon>
+                  <svg
+                    width="15"
+                    height="15"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.8"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <circle cx="12" cy="12" r="3" />
+                    <path d="M12 1v4" />
+                    <path d="M12 19v4" />
+                    <path d="M1 12h4" />
+                    <path d="M19 12h4" />
+                    <path d="M4.22 4.22l2.83 2.83" />
+                    <path d="M16.95 16.95l2.83 2.83" />
+                    <path d="M4.22 19.78l2.83-2.83" />
+                    <path d="M16.95 7.05l2.83-2.83" />
+                  </svg>
+                </template>
+                <span class="input-model-label">{{ compactModelLabel }}</span>
+                <svg class="toolbar-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+              </NButton>
+            </template>
+            {{ props.modelLabel || t('models.selectModel') }}
+          </NTooltip>
+
+          <NDropdown
+            trigger="click"
+            :options="inputSettingsOptions"
+            :show-arrow="true"
+            @select="handleInputSettingsSelect"
+          >
+            <NTooltip trigger="hover">
+              <template #trigger>
+                <NButton
+                  quaternary
+                  size="tiny"
+                  class="input-settings-button"
+                  :aria-label="t('sidebar.settings')"
+                >
+                  <template #icon>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="3"/>
+                      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06A2 2 0 1 1 7.04 4.3l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.08a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9c.2.6.77 1 1.4 1H21a2 2 0 1 1 0 4h-.09c-.63 0-1.2.4-1.51 1Z"/>
+                    </svg>
+                  </template>
+                  <span>{{ t('sidebar.settings') }}</span>
+                  <svg class="toolbar-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+                </NButton>
+              </template>
+              {{ t('sidebar.settings') }}
+            </NTooltip>
+          </NDropdown>
+
+        </div>
+        <div class="input-actions">
+          <VoiceDialogueControls
+            :status="voiceDialogue.status.value"
+            :transcript="voiceDialogueTranscript"
+            :error="voiceDialogueError"
+            :events="voiceDialogue.events.value"
+            :on-start="startVoiceCapture"
+            :on-stop="stopVoiceCapture"
+            :on-cancel="cancelVoiceCapture"
+          />
+          <NButton
+            size="medium"
+            type="primary"
+            circle
+            class="send-button"
+            :class="{ 'send-button--stop': chatStore.isStreaming }"
+            :disabled="chatStore.isStreaming ? chatStore.isAborting : !canSend"
+            :aria-label="chatStore.isStreaming ? t('chat.stop') : t('chat.send')"
+            @click="chatStore.isStreaming ? chatStore.stopStreaming() : handleSend()"
+          >
+            <template #icon>
+              <svg
+                v-if="chatStore.isStreaming"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <rect x="6" y="6" width="12" height="12" rx="2.5" fill="currentColor" />
+              </svg>
+              <svg v-else width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5"/><path d="m5 12 7-7 7 7"/></svg>
+            </template>
+            <span class="visually-hidden">{{ chatStore.isStreaming ? t('chat.stop') : t('chat.send') }}</span>
+          </NButton>
+        </div>
+      </div>
       <Transition name="dropdown-fade">
         <div
           v-if="slashActive && filteredBridgeCommands.length > 0"
@@ -1099,37 +1219,6 @@ function isImage(type: string): boolean {
           </div>
         </div>
       </Transition>
-      <div class="input-actions">
-        <VoiceDialogueControls
-          :status="voiceDialogue.status.value"
-          :transcript="voiceDialogueTranscript"
-          :error="voiceDialogueError"
-          :events="voiceDialogue.events.value"
-          :on-start="startVoiceCapture"
-          :on-stop="stopVoiceCapture"
-          :on-cancel="cancelVoiceCapture"
-        />
-        <NButton
-          v-if="chatStore.isStreaming"
-          size="small"
-          type="error"
-          :disabled="chatStore.isAborting"
-          @click="chatStore.stopStreaming()"
-        >
-          {{ t('chat.stop') }}
-        </NButton>
-        <NButton
-          size="small"
-          type="primary"
-          :disabled="!canSend"
-          @click="handleSend"
-        >
-          <template #icon>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
-          </template>
-          {{ t('chat.send') }}
-        </NButton>
-      </div>
     </div>
 
     <NModal
@@ -1220,25 +1309,27 @@ function isImage(type: string): boolean {
 @use '@/styles/variables' as *;
 
 .chat-input-area {
-  padding: 12px 20px 16px;
-  border-top: 1px solid $border-color;
+  padding: 8px 20px 14px;
+  border-top: 0;
+  background-color: $bg-card;
   flex-shrink: 0;
 }
 
 .input-top-bar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 0 0 6px;
+  gap: 7px;
+  min-width: 0;
+  flex: 1;
+  padding: 0;
 }
 
 .auto-play-speech-switch {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 0 0 0 8px;
-  border-left: 1px solid $border-light;
-  margin-left: 4px;
+  gap: 5px;
+  padding: 0 0 0 2px;
+  margin-left: 0;
 
   .switch-label {
     display: flex;
@@ -1268,7 +1359,7 @@ function isImage(type: string): boolean {
   width: 24px;
   min-width: 24px;
   height: 22px;
-  margin-left: -4px;
+  margin-left: 0;
   padding: 0;
   background: transparent !important;
   opacity: 1;
@@ -1297,10 +1388,91 @@ function isImage(type: string): boolean {
   }
 }
 
+.input-settings-button {
+  color: $text-secondary;
+  border-radius: 999px;
+  padding: 0 7px 0 6px;
+
+  :deep(.n-button__content) {
+    gap: 4px;
+  }
+
+  :deep(.n-button__state-border),
+  :deep(.n-button__border),
+  :deep(.n-button__ripple) {
+    display: none;
+  }
+}
+
+.input-model-button {
+  color: $text-secondary;
+  border-radius: 999px;
+  max-width: 190px;
+  padding: 0 4px 0 6px;
+
+  :deep(.n-button__content) {
+    gap: 4px;
+    min-width: 0;
+  }
+
+  :deep(.n-button__state-border),
+  :deep(.n-button__border),
+  :deep(.n-button__ripple) {
+    display: none;
+  }
+}
+
+.input-model-label {
+  display: inline-block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
 .reasoning-effort-button {
+  color: $text-secondary;
+  border-radius: 999px;
+  padding: 0 4px 0 6px;
+
   &.active {
     color: #4caf50;
   }
+
+  :deep(.n-button__content) {
+    gap: 4px;
+    min-width: 0;
+  }
+}
+
+.reasoning-effort-label {
+  display: inline-block;
+  max-width: 96px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
+.toolbar-chevron {
+  flex: 0 0 12px;
+  color: $text-muted;
+}
+
+.context-usage-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 7px;
+  position: absolute;
+  top: 9px;
+  right: 14px;
+  z-index: 1;
+  min-width: 0;
+  max-width: calc(100% - 28px);
+  padding: 0;
+  pointer-events: auto;
 }
 
 .context-info {
@@ -1351,9 +1523,55 @@ function isImage(type: string): boolean {
   }
 }
 
+.dark .context-info {
+  color: rgba(255, 255, 255, 0.68);
+
+  &.context-warning {
+    color: #f0bc58;
+  }
+}
+
+.dark .context-limit-editable {
+  color: rgba(255, 255, 255, 0.8);
+
+  &:hover {
+    border-bottom-color: rgba(255, 255, 255, 0.58);
+    background: rgba(255, 255, 255, 0.08);
+  }
+}
+
+.dark .context-bar {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.dark .context-bar-fill {
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0.72));
+
+  &.context-bar-warn {
+    background: linear-gradient(90deg, #d99d35, #f0bc58);
+  }
+
+  &.context-bar-danger {
+    background: linear-gradient(90deg, #d95445, #ff7a68);
+  }
+}
+
 @media (max-width: 768px) {
+  .chat-input-area {
+    padding: 8px 12px 12px;
+  }
+
   .input-top-bar {
     gap: 5px;
+  }
+
+  .reasoning-effort-label,
+  .auto-play-speech-switch {
+    display: none;
+  }
+
+  .input-model-button {
+    max-width: 118px;
   }
 
   .context-info {
@@ -1361,7 +1579,6 @@ function isImage(type: string): boolean {
     text-overflow: ellipsis;
     font-size: 10px;
     line-height: 14px;
-    margin-right: 10px;
   }
 
   .context-bar {
@@ -1371,6 +1588,7 @@ function isImage(type: string): boolean {
 }
 
 .attachment-previews {
+  width: 100%;
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
@@ -1449,21 +1667,32 @@ function isImage(type: string): boolean {
 
 .input-wrapper {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  background-color: $bg-input;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  width: 100%;
+  min-height: 150px;
+  background-color: $bg-card;
   border: 1px solid $border-color;
-  border-radius: $radius-md;
-  padding: 10px 12px;
+  border-radius: 18px;
+  padding: 22px 12px 9px;
   position: relative;
-  transition: border-color $transition-fast, background-color $transition-fast;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.08);
+  transition: border-color $transition-fast, box-shadow $transition-fast;
 
   &:focus-within {
+    border-color: rgba(var(--text-primary-rgb), 0.22);
+    box-shadow: 0 10px 32px rgba(0, 0, 0, 0.11);
+  }
+
+  &.drag-over {
     border-color: $accent-primary;
+    background-color: rgba(var(--accent-primary-rgb), 0.04);
   }
 
   .dark & {
-    background-color: #333333;
+    background-color: $bg-card;
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.32);
   }
 }
 
@@ -1483,7 +1712,9 @@ function isImage(type: string): boolean {
 }
 
 .input-textarea {
+  display: block;
   flex: 1;
+  width: 100%;
   background: none;
   border: none;
   outline: none;
@@ -1493,7 +1724,8 @@ function isImage(type: string): boolean {
   line-height: 1.5;
   resize: none;
   max-height: 400px;
-  min-height: 20px;
+  min-height: 24px;
+  padding: 0;
   overflow-y: auto;
 
   @media (max-width: 768px) {
@@ -1510,9 +1742,63 @@ function isImage(type: string): boolean {
 
 .input-actions {
   display: flex;
-  gap: 6px;
+  gap: 7px;
   flex-shrink: 0;
   align-items: center;
+}
+
+.input-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 32px;
+}
+
+.toolbar-icon-button {
+  color: $text-muted;
+}
+
+.send-button {
+  width: 30px !important;
+  min-width: 30px !important;
+  height: 30px !important;
+  padding: 0 !important;
+  border: 0 !important;
+  box-shadow: none !important;
+
+  :deep(.n-button__icon) {
+    margin: 0 !important;
+  }
+
+  :deep(.n-button__content) {
+    display: none;
+  }
+
+  :deep(.n-button__border),
+  :deep(.n-button__state-border),
+  :deep(.n-button__ripple),
+  :deep(.n-base-wave) {
+    display: none;
+  }
+
+  &:disabled {
+    color: var(--text-on-overlay);
+    background-color: #9f9f9f;
+    opacity: 1;
+  }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .slash-command-dropdown {
@@ -1687,10 +1973,4 @@ function isImage(type: string): boolean {
   transform: translateY(4px);
 }
 
-// Drag-over state
-.input-wrapper.drag-over {
-  border-color: var(--accent-info);
-  border-style: dashed;
-  background-color: rgba(var(--accent-info-rgb), 0.04);
-}
 </style>

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1096,6 +1096,34 @@ function isImage(type: string): boolean {
             </NTooltip>
           </NPopselect>
 
+          <NDropdown
+            trigger="click"
+            :options="inputSettingsOptions"
+            :show-arrow="true"
+            @select="handleInputSettingsSelect"
+          >
+            <NTooltip trigger="hover">
+              <template #trigger>
+                <NButton
+                  quaternary
+                  size="tiny"
+                  class="input-settings-button"
+                  :aria-label="t('sidebar.settings')"
+                >
+                  <template #icon>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="3"/>
+                      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06A2 2 0 1 1 7.04 4.3l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.08a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9c.2.6.77 1 1.4 1H21a2 2 0 1 1 0 4h-.09c-.63 0-1.2.4-1.51 1Z"/>
+                    </svg>
+                  </template>
+                  <span>{{ t('sidebar.settings') }}</span>
+                  <svg class="toolbar-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+                </NButton>
+              </template>
+              {{ t('sidebar.settings') }}
+            </NTooltip>
+          </NDropdown>
+
           <NTooltip trigger="hover">
             <template #trigger>
               <NButton
@@ -1134,34 +1162,6 @@ function isImage(type: string): boolean {
             </template>
             {{ props.modelLabel || t('models.selectModel') }}
           </NTooltip>
-
-          <NDropdown
-            trigger="click"
-            :options="inputSettingsOptions"
-            :show-arrow="true"
-            @select="handleInputSettingsSelect"
-          >
-            <NTooltip trigger="hover">
-              <template #trigger>
-                <NButton
-                  quaternary
-                  size="tiny"
-                  class="input-settings-button"
-                  :aria-label="t('sidebar.settings')"
-                >
-                  <template #icon>
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
-                      <circle cx="12" cy="12" r="3"/>
-                      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06A2 2 0 1 1 7.04 4.3l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.08a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9c.2.6.77 1 1.4 1H21a2 2 0 1 1 0 4h-.09c-.63 0-1.2.4-1.51 1Z"/>
-                    </svg>
-                  </template>
-                  <span>{{ t('sidebar.settings') }}</span>
-                  <svg class="toolbar-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
-                </NButton>
-              </template>
-              {{ t('sidebar.settings') }}
-            </NTooltip>
-          </NDropdown>
 
         </div>
         <div class="input-actions">

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -1690,37 +1690,6 @@ async function handleSessionModelCustomSubmit() {
               </template>
               {{ t("chat.copySessionId") }}
             </NTooltip>
-            <NButton
-              class="header-model-button"
-              size="small"
-              :circle="isMobile"
-              :title="activeSessionModelLabel"
-              @click="handleHeaderModelClick"
-            >
-              <template #icon>
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.8"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <circle cx="12" cy="12" r="3" />
-                  <path d="M12 1v4" />
-                  <path d="M12 19v4" />
-                  <path d="M1 12h4" />
-                  <path d="M19 12h4" />
-                  <path d="M4.22 4.22l2.83 2.83" />
-                  <path d="M16.95 16.95l2.83 2.83" />
-                  <path d="M4.22 19.78l2.83-2.83" />
-                  <path d="M16.95 7.05l2.83-2.83" />
-                </svg>
-              </template>
-              <template v-if="!isMobile">{{ activeSessionModelLabel }}</template>
-            </NButton>
           </template>
         </div>
       </header>
@@ -1737,7 +1706,11 @@ async function handleSessionModelCustomSubmit() {
         >
           <div class="chat-main-content">
             <MessageList ref="messageListRef" />
-            <ChatInput ref="chatInputRef" />
+            <ChatInput
+              ref="chatInputRef"
+              :model-label="activeSessionModelLabel"
+              @model-click="handleHeaderModelClick"
+            />
           </div>
           <OutlinePanel
             v-if="showOutline"
@@ -2378,6 +2351,18 @@ async function handleSessionModelCustomSubmit() {
   display: flex;
   flex-direction: column;
   min-width: 0;
+  background-color: $bg-card;
+  animation: chat-surface-fade-in 1.5s ease both;
+}
+
+@keyframes chat-surface-fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .chat-header {
@@ -2423,17 +2408,6 @@ async function handleSessionModelCustomSubmit() {
   align-items: center;
   gap: 4px;
   flex-shrink: 0;
-}
-
-.header-model-button {
-  max-width: 220px;
-}
-
-.header-model-button :deep(.n-button__content) {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .chat-mode-toggle {

--- a/packages/client/src/components/hermes/chat/VirtualMessageList.vue
+++ b/packages/client/src/components/hermes/chat/VirtualMessageList.vue
@@ -522,7 +522,6 @@ defineExpose({
   max-width: 100%;
   display: flex;
   position: relative;
-  animation: message-list-fade-in 1.5s ease both;
 }
 
 .virtual-message-list {
@@ -563,16 +562,6 @@ defineExpose({
   width: 100%;
   height: 100%;
   min-height: 0;
-}
-
-@keyframes message-list-fade-in {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
 }
 
 </style>

--- a/packages/client/src/components/hermes/chat/VoiceDialogueControls.vue
+++ b/packages/client/src/components/hermes/chat/VoiceDialogueControls.vue
@@ -127,7 +127,7 @@ function cancel() {
 }
 
 .voice-dialogue-controls--floating-overlay {
-  isolation: isolate;
+  z-index: 1300;
 }
 
 .voice-dialogue-controls__actions {

--- a/packages/client/src/components/hermes/chat/VoiceTranscriptOverlay.vue
+++ b/packages/client/src/components/hermes/chat/VoiceTranscriptOverlay.vue
@@ -126,7 +126,7 @@ const recentEventTypes = computed(() => props.events.slice(-5).map(event => even
     position: fixed;
     left: 1rem;
     right: 1rem;
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 5.5rem);
+    bottom: calc(env(safe-area-inset-bottom, 0px) + var(--voice-overlay-mobile-bottom-offset, 9rem));
     width: auto;
     max-width: none;
   }

--- a/packages/client/src/components/hermes/chat/VoiceTranscriptOverlay.vue
+++ b/packages/client/src/components/hermes/chat/VoiceTranscriptOverlay.vue
@@ -83,7 +83,7 @@ const recentEventTypes = computed(() => props.events.slice(-5).map(event => even
   position: absolute;
   right: 0;
   bottom: calc(100% + 0.5rem);
-  z-index: 10;
+  z-index: 1200;
   width: min(20rem, calc(100vw - 2rem));
   max-width: 20rem;
   pointer-events: none;

--- a/packages/client/src/components/hermes/chat/VoiceTranscriptOverlay.vue
+++ b/packages/client/src/components/hermes/chat/VoiceTranscriptOverlay.vue
@@ -73,9 +73,10 @@ const recentEventTypes = computed(() => props.events.slice(-5).map(event => even
   min-width: 12rem;
   padding: 0.5rem 0.75rem;
   color: var(--text-primary);
-  border: 1px solid var(--border-color);
+  border: 1px solid rgba(var(--text-primary-rgb), 0.12);
   border-radius: 0.75rem;
-  background: var(--bg-input);
+  background: var(--bg-card, var(--bg-input, #ffffff));
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.14);
 }
 
 .voice-transcript-overlay--floating {
@@ -87,6 +88,12 @@ const recentEventTypes = computed(() => props.events.slice(-5).map(event => even
   max-width: 20rem;
   pointer-events: none;
   box-sizing: border-box;
+}
+
+.dark .voice-transcript-overlay {
+  border-color: rgba(255, 255, 255, 0.14);
+  background: var(--bg-card, #333333);
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.42);
 }
 
 .voice-transcript-overlay__status,

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -966,6 +966,20 @@ function isImage(type: string): boolean {
         min-height: 118px;
     }
 
+    .input-settings-button {
+        width: 28px;
+        min-width: 28px;
+        padding: 0;
+
+        :deep(.n-button__content) {
+            display: none;
+        }
+
+        :deep(.n-button__icon) {
+            margin: 0;
+        }
+    }
+
     .input-textarea::placeholder {
         font-size: 13px;
         line-height: 1.35;

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, nextTick, onMounted, onUnmounted, watch, h } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { NButton, NSwitch, NTooltip } from 'naive-ui'
+import { NButton, NDropdown, NTooltip, type DropdownOption } from 'naive-ui'
 import { useGroupChatStore } from '@/stores/hermes/group-chat'
 import { useSettingsStore } from '@/stores/hermes/settings'
 import { useToolTraceVisibility } from '@/composables/useToolTraceVisibility'
@@ -24,6 +24,24 @@ const isDragging = ref(false)
 const dragCounter = ref(0)
 const isComposing = ref(false)
 const autoPlaySpeech = ref(false)
+const inputSettingsOptions = computed<DropdownOption[]>(() => [
+    {
+        label: t('chat.autoPlaySpeech'),
+        key: 'autoPlaySpeech',
+        icon: () => h('span', {
+            class: ['settings-check', { active: autoPlaySpeech.value }],
+            'aria-hidden': 'true',
+        }, autoPlaySpeech.value ? '✓' : ''),
+    },
+    {
+        label: t('chat.showToolCalls'),
+        key: 'toolTrace',
+        icon: () => h('span', {
+            class: ['settings-check', { active: toolTraceVisible.value }],
+            'aria-hidden': 'true',
+        }, toolTraceVisible.value ? '✓' : ''),
+    },
+])
 const isMobileViewport = ref(typeof window !== 'undefined' ? isMobileChatInputViewport(window.innerWidth) : false)
 const manualTextareaResize = ref(false)
 const configuredTextareaHeight = computed(() =>
@@ -47,6 +65,17 @@ watch(autoPlaySpeech, (value) => {
     localStorage.setItem('autoPlaySpeech', String(value))
     store.setAutoPlaySpeech(value)
 })
+
+function handleInputSettingsSelect(key: string | number) {
+    if (key === 'autoPlaySpeech') {
+        autoPlaySpeech.value = !autoPlaySpeech.value
+        return
+    }
+
+    if (key === 'toolTrace') {
+        toggleToolTraceVisible()
+    }
+}
 
 watch(configuredTextareaHeight, () => {
     applyConfiguredTextareaHeight()
@@ -416,39 +445,6 @@ function isImage(type: string): boolean {
 
 <template>
     <div class="chat-input-area">
-        <div class="input-top-bar">
-            <NTooltip trigger="hover">
-                <template #trigger>
-                    <NButton quaternary size="tiny" circle @click="handleAttachClick">
-                        <template #icon>
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
-                        </template>
-                    </NButton>
-                </template>
-                {{ t('chat.attachFiles') }}
-            </NTooltip>
-            <div class="auto-play-speech-switch">
-                <NTooltip trigger="hover">
-                    <template #trigger>
-                        <div class="switch-label">
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
-                        </div>
-                    </template>
-                    {{ t('chat.autoPlaySpeech') }}
-                </NTooltip>
-                <NSwitch v-model:value="autoPlaySpeech" size="small" :round="false" />
-            </div>
-            <NTooltip trigger="hover">
-                <template #trigger>
-                    <NButton quaternary size="tiny" class="tool-trace-toggle" :class="{ active: toolTraceVisible }" @click="toggleToolTraceVisible">
-                        <svg class="tool-trace-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M14.7 6.3a4.5 4.5 0 0 0-5.8 5.8L3.5 17.5a2.1 2.1 0 0 0 3 3l5.4-5.4a4.5 4.5 0 0 0 5.8-5.8l-3 3-3-3 3-3z"/>
-                        </svg>
-                    </NButton>
-                </template>
-                {{ toolTraceVisible ? t('chat.hideToolCalls') : t('chat.showToolCalls') }}
-            </NTooltip>
-        </div>
         <div v-if="attachments.length > 0" class="attachment-previews">
             <div v-for="att in attachments" :key="att.id" class="attachment-preview" :class="{ image: isImage(att.type) }">
                 <img v-if="isImage(att.type)" :src="att.url" :alt="att.name" class="attachment-thumb" />
@@ -484,18 +480,57 @@ function isImage(type: string): boolean {
                 @input="handleInput"
                 @paste="handlePaste"
             />
-            <div class="input-actions">
-                <NButton
-                    size="small"
-                    type="primary"
-                    :disabled="!canSend"
-                    @click="handleSend"
-                >
-                    <template #icon>
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
-                    </template>
-                    {{ t('chat.send') }}
-                </NButton>
+            <div class="input-toolbar">
+                <div class="input-top-bar">
+                    <NTooltip trigger="hover">
+                        <template #trigger>
+                            <NButton quaternary size="tiny" circle class="toolbar-icon-button" @click="handleAttachClick">
+                                <template #icon>
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+                                </template>
+                            </NButton>
+                        </template>
+                        {{ t('chat.attachFiles') }}
+                    </NTooltip>
+                    <NDropdown
+                        trigger="click"
+                        :options="inputSettingsOptions"
+                        :show-arrow="true"
+                        @select="handleInputSettingsSelect"
+                    >
+                        <NTooltip trigger="hover">
+                            <template #trigger>
+                                <NButton quaternary size="tiny" class="input-settings-button" :aria-label="t('sidebar.settings')">
+                                    <template #icon>
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+                                            <circle cx="12" cy="12" r="3"/>
+                                            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06A2 2 0 1 1 7.04 4.3l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.08a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9c.2.6.77 1 1.4 1H21a2 2 0 1 1 0 4h-.09c-.63 0-1.2.4-1.51 1Z"/>
+                                        </svg>
+                                    </template>
+                                    <span>{{ t('sidebar.settings') }}</span>
+                                    <svg class="toolbar-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+                                </NButton>
+                            </template>
+                            {{ t('sidebar.settings') }}
+                        </NTooltip>
+                    </NDropdown>
+                </div>
+                <div class="input-actions">
+                    <NButton
+                        size="medium"
+                        type="primary"
+                        circle
+                        class="send-button"
+                        :disabled="!canSend"
+                        :aria-label="t('chat.send')"
+                        @click="handleSend"
+                    >
+                        <template #icon>
+                            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5"/><path d="m5 12 7-7 7 7"/></svg>
+                        </template>
+                        <span class="visually-hidden">{{ t('chat.send') }}</span>
+                    </NButton>
+                </div>
             </div>
         </div>
         <Transition name="dropdown-fade">
@@ -530,25 +565,27 @@ function isImage(type: string): boolean {
 @use "@/styles/variables" as *;
 
 .chat-input-area {
-    padding: 12px 20px 16px;
-    border-top: 1px solid $border-color;
+    padding: 8px 20px 14px;
+    border-top: 0;
+    background-color: $bg-card;
     flex-shrink: 0;
 }
 
 .input-top-bar {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 0 0 6px;
+    gap: 7px;
+    min-width: 0;
+    flex: 1;
+    padding: 0;
 }
 
 .auto-play-speech-switch {
     display: flex;
     align-items: center;
-    gap: 6px;
-    padding-left: 8px;
-    border-left: 1px solid $border-light;
-    margin-left: 4px;
+    gap: 5px;
+    padding-left: 2px;
+    margin-left: 0;
 
     .switch-label {
         display: flex;
@@ -568,7 +605,7 @@ function isImage(type: string): boolean {
     width: 24px;
     min-width: 24px;
     height: 22px;
-    margin-left: -4px;
+    margin-left: 0;
     padding: 0;
     background: transparent !important;
 
@@ -585,7 +622,29 @@ function isImage(type: string): boolean {
     }
 }
 
+.input-settings-button {
+    color: $text-secondary;
+    border-radius: 999px;
+    padding: 0 7px 0 6px;
+
+    :deep(.n-button__content) {
+        gap: 4px;
+    }
+
+    :deep(.n-button__state-border),
+    :deep(.n-button__border),
+    :deep(.n-button__ripple) {
+        display: none;
+    }
+}
+
+.toolbar-chevron {
+    flex: 0 0 12px;
+    color: $text-muted;
+}
+
 .attachment-previews {
+    width: 100%;
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
@@ -687,26 +746,32 @@ function isImage(type: string): boolean {
 
 .input-wrapper {
     display: flex;
-    align-items: center;
-    gap: 10px;
-    background-color: $bg-input;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+    width: 100%;
+    min-height: 150px;
+    background-color: $bg-card;
     border: 1px solid $border-color;
-    border-radius: $radius-md;
-    padding: 10px 12px;
+    border-radius: 18px;
+    padding: 14px 12px 9px;
     position: relative;
-    transition: border-color $transition-fast, background-color $transition-fast;
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.08);
+    transition: border-color $transition-fast, box-shadow $transition-fast;
 
     &:focus-within {
-        border-color: $accent-primary;
+        border-color: rgba(var(--text-primary-rgb), 0.22);
+        box-shadow: 0 10px 32px rgba(0, 0, 0, 0.11);
     }
 
     &.drag-over {
         border-color: $accent-primary;
-        background-color: rgba($accent-primary, 0.08);
+        background-color: rgba(var(--accent-primary-rgb), 0.04);
     }
 
     .dark & {
-        background-color: #333333;
+        background-color: $bg-card;
+        box-shadow: 0 8px 28px rgba(0, 0, 0, 0.32);
     }
 }
 
@@ -726,7 +791,9 @@ function isImage(type: string): boolean {
 }
 
 .input-textarea {
+    display: block;
     flex: 1;
+    width: 100%;
     background: none;
     border: none;
     outline: none;
@@ -736,7 +803,8 @@ function isImage(type: string): boolean {
     line-height: 1.5;
     resize: none;
     max-height: 400px;
-    min-height: 20px;
+    min-height: 24px;
+    padding: 0;
     overflow-y: auto;
 
     @media (max-width: 768px) {
@@ -753,9 +821,77 @@ function isImage(type: string): boolean {
 
 .input-actions {
     display: flex;
-    gap: 6px;
+    gap: 7px;
     flex-shrink: 0;
     align-items: center;
+}
+
+.input-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    min-height: 32px;
+}
+
+.toolbar-icon-button {
+    color: $text-muted;
+}
+
+.send-button {
+    width: 30px !important;
+    min-width: 30px !important;
+    height: 30px !important;
+    padding: 0 !important;
+    border: 0 !important;
+    box-shadow: none !important;
+
+    :deep(.n-button__icon) {
+        margin: 0 !important;
+    }
+
+    :deep(.n-button__content) {
+        display: none;
+    }
+
+    :deep(.n-button__border),
+    :deep(.n-button__state-border),
+    :deep(.n-button__ripple),
+    :deep(.n-base-wave) {
+        display: none;
+    }
+
+    &:disabled {
+        color: var(--text-on-overlay);
+        background-color: #9f9f9f;
+        opacity: 1;
+    }
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 768px) {
+    .chat-input-area {
+        padding: 8px 12px 12px;
+    }
+
+    .input-top-bar {
+        gap: 5px;
+    }
+
+    .auto-play-speech-switch {
+        display: none;
+    }
 }
 
 /* ── Custom mention dropdown (replaces NDropdown) ── */

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -960,4 +960,15 @@ function isImage(type: string): boolean {
 .placement-top.dropdown-fade-leave-active {
     transform-origin: bottom;
 }
+
+@media (max-width: 768px) {
+    .input-wrapper {
+        min-height: 118px;
+    }
+
+    .input-textarea::placeholder {
+        font-size: 13px;
+        line-height: 1.35;
+    }
+}
 </style>

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -507,7 +507,7 @@ function isImage(type: string): boolean {
                                             <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06A2 2 0 1 1 7.04 4.3l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.08a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9c.2.6.77 1 1.4 1H21a2 2 0 1 1 0 4h-.09c-.63 0-1.2.4-1.51 1Z"/>
                                         </svg>
                                     </template>
-                                    <span>{{ t('sidebar.settings') }}</span>
+                                    <span class="input-settings-label">{{ t('sidebar.settings') }}</span>
                                     <svg class="toolbar-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
                                 </NButton>
                             </template>
@@ -967,17 +967,20 @@ function isImage(type: string): boolean {
     }
 
     .input-settings-button {
-        width: 28px;
-        min-width: 28px;
-        padding: 0;
+        min-width: 36px;
+        padding: 0 4px 0 6px;
 
         :deep(.n-button__content) {
-            display: none;
+            gap: 2px;
         }
 
         :deep(.n-button__icon) {
             margin: 0;
         }
+    }
+
+    .input-settings-label {
+        display: none;
     }
 
     .input-textarea::placeholder {

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -544,7 +544,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                 </div>
             </div>
 
-            <template v-if="hasRoom">
+            <div v-if="hasRoom" class="group-chat-surface">
                 <div class="group-message-shell">
                     <GroupMessageList />
                     <Transition name="approval-float">
@@ -611,7 +611,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                     </div>
                 </div>
                 <GroupChatInput ref="groupChatInputRef" @send="handleSendMessage" />
-            </template>
+            </div>
 
             <div v-else class="no-room">
                 <div class="no-room-icon">
@@ -1229,6 +1229,26 @@ export default defineComponent({ components: { CreateRoomForm } })
     min-width: 0;
     background-color: transparent;
     position: relative;
+}
+
+.group-chat-surface {
+    flex: 1;
+    min-height: 0;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    background-color: $bg-card;
+    animation: group-chat-surface-fade-in 1.5s ease both;
+}
+
+@keyframes group-chat-surface-fade-in {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
 }
 
 .chat-main--drop-active::after {

--- a/packages/client/src/styles/global.scss
+++ b/packages/client/src/styles/global.scss
@@ -109,6 +109,29 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+// Chat input route CSS is code-split; keep the footer color stable before the
+// component-scoped chunk arrives so entering chat does not flash the page bg.
+.chat-input-area,
+.chat-input-area .input-wrapper {
+  background-color: $bg-card;
+}
+
+.settings-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+  color: transparent;
+  font-size: 13px;
+  line-height: 16px;
+}
+
+.settings-check.active {
+  color: $accent-primary;
+}
+
 .hermes-desktop-pet-window,
 .hermes-desktop-pet-window body,
 .hermes-desktop-pet-window #app {

--- a/tests/client/chat-input-draft.test.ts
+++ b/tests/client/chat-input-draft.test.ts
@@ -17,6 +17,7 @@ vi.mock('naive-ui', () => ({
   NButton: { template: '<button type="button" v-bind="$attrs"><slot /><slot name="icon" /></button>' },
   NTooltip: { template: '<div><slot name="trigger" /><slot /></div>' },
   NSwitch: { template: '<button type="button"></button>' },
+  NDropdown: { template: '<div><slot /></div>' },
   NModal: { template: '<div><slot /><slot name="footer" /></div>' },
   NInputNumber: { template: '<input />' },
   NPopselect: {

--- a/tests/client/group-chat-input-mentions.test.ts
+++ b/tests/client/group-chat-input-mentions.test.ts
@@ -15,6 +15,7 @@ vi.mock('naive-ui', () => ({
   NButton: { template: '<button type="button" v-bind="$attrs"><slot /><slot name="icon" /></button>' },
   NTooltip: { template: '<div><slot name="trigger" /><slot /></div>' },
   NSwitch: { template: '<button type="button"></button>' },
+  NDropdown: { template: '<div><slot /></div>' },
 }))
 
 vi.mock('@/composables/useToolTraceVisibility', () => ({

--- a/tests/client/voice-dialogue-controls.test.ts
+++ b/tests/client/voice-dialogue-controls.test.ts
@@ -77,6 +77,7 @@ vi.mock('naive-ui', () => ({
   NButton: { template: '<button type="button" v-bind="$attrs"><slot /><slot name="icon" /></button>' },
   NTooltip: { template: '<div><slot name="trigger" /><slot /></div>' },
   NSwitch: { template: '<button type="button"></button>' },
+  NDropdown: { template: '<div><slot /></div>' },
   NModal: { template: '<div><slot /><slot name="footer" /></div>' },
   NInputNumber: { template: '<input />' },
   NPopselect: { template: '<div><slot /></div>' },


### PR DESCRIPTION
## Summary

- Refresh the chat input surface with an integrated toolbar, larger default height, full-width layout, and centered send/stop controls.
- Move model selection into the input toolbar, show compact model names, and group speech/tool toggles under a settings dropdown.
- Align chat surface fade/background behavior across regular and group chat, and brighten context usage in dark mode.

## Validation

- npm run test -- tests/client/chat-input-draft.test.ts tests/client/group-chat-input-mentions.test.ts tests/client/voice-dialogue-controls.test.ts
- npm run build
