### PR TITLE
[codex] Polish mobile chat chrome

### DIFF
--- a/docs/chat-chain-changes/2026-07-02-mobile-chat-header-title.md
+++ b/docs/chat-chain-changes/2026-07-02-mobile-chat-header-title.md
@@ -1,0 +1,6 @@
+---
+date: 2026-07-02
+pr: local
+feature: Mobile chat chrome
+impact: Single-chat and group-chat mobile headers hide chat titles, mobile input toolbar controls suppress hover tips, mobile diff drawers use narrower horizontal padding, and workspace diff drawers omit the generic code-copy button while keeping controls available.
+---

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1018,7 +1018,7 @@ function isImage(type: string): boolean {
       <div v-if="showContextUsage" class="context-usage-row">
         <span class="context-info" :class="{ 'context-warning': usagePercent > 80 }">
           {{ formatTokens(totalTokens) }} /
-          <NTooltip trigger="hover">
+          <NTooltip trigger="hover" :disabled="isMobileViewport">
             <template #trigger>
               <span class="context-limit-editable" @click="handleEditContextLimit">
                 {{ formatTokens(contextLength) }}
@@ -1055,7 +1055,7 @@ function isImage(type: string): boolean {
       <div class="input-toolbar">
         <!-- Bottom bar: attach + input settings + actions -->
         <div class="input-top-bar">
-          <NTooltip trigger="hover">
+          <NTooltip trigger="hover" :disabled="isMobileViewport">
             <template #trigger>
               <NButton quaternary size="tiny" @click="handleAttachClick" circle class="toolbar-icon-button">
                 <template #icon>
@@ -1073,7 +1073,7 @@ function isImage(type: string): boolean {
             trigger="click"
             @update:value="onReasoningEffortChange"
           >
-            <NTooltip trigger="hover">
+            <NTooltip trigger="hover" :disabled="isMobileViewport">
               <template #trigger>
                 <NButton
                   quaternary
@@ -1102,7 +1102,7 @@ function isImage(type: string): boolean {
             :show-arrow="true"
             @select="handleInputSettingsSelect"
           >
-            <NTooltip trigger="hover">
+            <NTooltip trigger="hover" :disabled="isMobileViewport">
               <template #trigger>
                 <NButton
                   quaternary
@@ -1124,13 +1124,13 @@ function isImage(type: string): boolean {
             </NTooltip>
           </NDropdown>
 
-          <NTooltip trigger="hover">
+          <NTooltip trigger="hover" :disabled="isMobileViewport">
             <template #trigger>
               <NButton
                 quaternary
                 size="tiny"
                 class="input-model-button"
-                :title="props.modelLabel || t('models.selectModel')"
+                :title="isMobileViewport ? undefined : props.modelLabel || t('models.selectModel')"
                 :aria-label="props.modelLabel || t('models.selectModel')"
                 @click="handleModelButtonClick"
               >

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2426,6 +2426,10 @@ async function handleSessionModelCustomSubmit() {
     display: none;
   }
 
+  .header-session-title {
+    display: none;
+  }
+
 }
 
 .workspace-badge {

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -510,10 +510,11 @@ function formatToolPayload(raw?: unknown, extractDiff = false): ToolPayload {
   };
 }
 
-function renderToolPayload(content: string, language?: string): string {
+function renderToolPayload(content: string, language?: string, options: { showCopyButton?: boolean } = {}): string {
   return renderHighlightedCodeBlock(content, language, t("common.copy"), {
     maxHighlightLength: TOOL_PAYLOAD_DISPLAY_LIMIT,
     formatDiffFoldLabel: (hiddenCount) => t("chat.unchangedLines", { count: hiddenCount }),
+    showCopyButton: options.showCopyButton,
   });
 }
 
@@ -581,7 +582,9 @@ const renderedToolResult = computed(() => {
 
 const renderedToolChangePatch = computed(() => {
   if (!selectedToolChangePatch.value) return "";
-  return renderToolPayload(selectedToolChangePatch.value, "diff");
+  return renderToolPayload(selectedToolChangePatch.value, "diff", {
+    showCopyButton: false,
+  });
 });
 
 function fileNameFromPath(path: string): string {
@@ -1221,6 +1224,8 @@ onBeforeUnmount(() => {
     @update:show="value => { if (!value) closeToolChangeDrawer(); else toolChangeDrawerVisible = value }"
   >
     <NDrawerContent
+      header-class="tool-change-drawer-header"
+      body-content-class="tool-change-drawer-body-content"
       :title="selectedToolChangeFileName || t('chat.workspaceChanges')"
       closable
     >
@@ -2031,6 +2036,7 @@ onBeforeUnmount(() => {
   flex: 0 0 auto;
   font-family: $font-code;
   font-size: 11px;
+  margin-top: 10px;
   overflow: hidden;
   padding: 0 0 10px;
   text-overflow: ellipsis;
@@ -2161,6 +2167,16 @@ onBeforeUnmount(() => {
   .tool-change-standalone {
     min-width: 0;
     width: calc(100vw - 24px);
+  }
+
+  :global(.tool-change-drawer-header) {
+    padding-left: 12px !important;
+    padding-right: 12px !important;
+  }
+
+  :global(.tool-change-drawer-body-content) {
+    padding-left: 8px !important;
+    padding-right: 8px !important;
   }
 }
 </style>

--- a/packages/client/src/components/hermes/chat/highlight.ts
+++ b/packages/client/src/components/hermes/chat/highlight.ts
@@ -41,16 +41,20 @@ function renderCodeBlockWrapper(
   copyLabel: string,
   extraClasses: string[] = [],
   rawCopyText?: string,
+  showCopyButton = true,
 ): string {
   const languageLabelHtml = labelLanguage
     ? `<span class="code-lang">${escapeHtml(labelLanguage)}</span>`
+    : ''
+  const copyButtonHtml = showCopyButton
+    ? `<button type="button" class="copy-btn" data-copy-code="true">${escapeHtml(copyLabel)}</button>`
     : ''
   const blockClasses = ['hljs-code-block', ...extraClasses].join(' ')
   const copyTextAttr = rawCopyText == null
     ? ''
     : ` data-copy-text="${escapeHtml(rawCopyText)}"`
 
-  return `<pre class="${blockClasses}"${copyTextAttr}><div class="code-header">${languageLabelHtml}<button type="button" class="copy-btn" data-copy-code="true">${escapeHtml(copyLabel)}</button></div><code class="hljs language-${sanitizeLanguageClass(codeClassLanguage)}">${highlighted}</code></pre>`
+  return `<pre class="${blockClasses}"${copyTextAttr}><div class="code-header">${languageLabelHtml}${copyButtonHtml}</div><code class="hljs language-${sanitizeLanguageClass(codeClassLanguage)}">${highlighted}</code></pre>`
 }
 
 function isUnifiedDiffLanguage(lang?: string): boolean {
@@ -176,6 +180,7 @@ function renderUnifiedDiffCode(
   labelLanguage: string,
   copyLabel: string,
   formatFoldLabel: (hiddenCount: number) => string,
+  showCopyButton = true,
 ): string {
   const numbers: DiffLineNumbers = {}
   const lines = content.split(/\r?\n/)
@@ -208,7 +213,7 @@ function renderUnifiedDiffCode(
     .map((row) => row.html)
     .join('')
 
-  return renderCodeBlockWrapper(highlighted, 'diff', labelLanguage, copyLabel, ['hljs-unified-diff'], content)
+  return renderCodeBlockWrapper(highlighted, 'diff', labelLanguage, copyLabel, ['hljs-unified-diff'], content, showCopyButton)
 }
 
 export function normalizeHighlightLanguage(lang?: string): string {
@@ -314,6 +319,7 @@ export function extractUnifiedDiffPayload(value: unknown, depth = 0): string | n
 type RenderHighlightedCodeBlockOptions = {
   maxHighlightLength?: number
   formatDiffFoldLabel?: (hiddenCount: number) => string
+  showCopyButton?: boolean
 }
 
 export function renderHighlightedCodeBlock(
@@ -328,7 +334,7 @@ export function renderHighlightedCodeBlock(
 
   if (isUnifiedDiffContent(content, requestedLanguage || normalizedLanguage)) {
     const formatDiffFoldLabel = options.formatDiffFoldLabel ?? ((hiddenCount: number) => String(hiddenCount))
-    return renderUnifiedDiffCode(content, requestedLanguage || 'diff', copyLabel, formatDiffFoldLabel)
+    return renderUnifiedDiffCode(content, requestedLanguage || 'diff', copyLabel, formatDiffFoldLabel, options.showCopyButton ?? true)
   }
 
   let highlighted = ''
@@ -355,7 +361,7 @@ export function renderHighlightedCodeBlock(
     }
   }
 
-  return renderCodeBlockWrapper(highlighted, codeClassLanguage, labelLanguage, copyLabel)
+  return renderCodeBlockWrapper(highlighted, codeClassLanguage, labelLanguage, copyLabel, [], undefined, options.showCopyButton ?? true)
 }
 
 export async function copyTextToClipboard(text: string): Promise<boolean> {

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -482,7 +482,7 @@ function isImage(type: string): boolean {
             />
             <div class="input-toolbar">
                 <div class="input-top-bar">
-                    <NTooltip trigger="hover">
+                    <NTooltip trigger="hover" :disabled="isMobileViewport">
                         <template #trigger>
                             <NButton quaternary size="tiny" circle class="toolbar-icon-button" @click="handleAttachClick">
                                 <template #icon>
@@ -498,7 +498,7 @@ function isImage(type: string): boolean {
                         :show-arrow="true"
                         @select="handleInputSettingsSelect"
                     >
-                        <NTooltip trigger="hover">
+                        <NTooltip trigger="hover" :disabled="isMobileViewport">
                             <template #trigger>
                                 <NButton quaternary size="tiny" class="input-settings-button" :aria-label="t('sidebar.settings')">
                                     <template #icon>

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -1584,5 +1584,9 @@ export default defineComponent({ components: { CreateRoomForm } })
         display: none;
     }
 
+    .room-title-text {
+        display: none;
+    }
+
 }
 </style>

--- a/tests/client/highlight-helper.test.ts
+++ b/tests/client/highlight-helper.test.ts
@@ -66,6 +66,15 @@ describe('highlight helper', () => {
     expect(html).not.toContain('onclick=')
   })
 
+  it('can render code blocks without a copy button', () => {
+    const html = renderHighlightedCodeBlock('x', 'json', 'Copy', {
+      showCopyButton: false,
+    })
+
+    expect(html).not.toContain('data-copy-code="true"')
+    expect(html).not.toContain('copy-btn')
+  })
+
 
   it('infers patch-style raw payloads as diff', () => {
     expect(inferStructuredLanguage([


### PR DESCRIPTION
## Summary
- Hide chat titles in single-chat and group-chat mobile headers.
- Disable mobile hover tips for chat input toolbar controls.
- Tighten workspace diff drawer mobile padding and remove its generic code-copy button.

## Validation
- npm run test -- tests/client/highlight-helper.test.ts
- npx vue-tsc -b
- npm run harness:check
