### PR TITLE
fix: export completed coding agent sessions

### DIFF
--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -105,6 +105,7 @@ interface ManagedCodingAgentRun {
   stoppedByUser?: boolean
   pendingChatCompletionEvent?: 'run.completed' | 'run.failed'
   pendingChatCompletionPayload?: Record<string, unknown>
+  memoryExportStarted?: boolean
 }
 
 interface CodingAgentRunSendOptions {
@@ -763,6 +764,7 @@ export class CodingAgentRunManager {
     run.printToolBlocks = new Map()
     run.currentChildStderr = ''
     run.runMarker = undefined
+    run.memoryExportStarted = false
 
     this.handleClaudePrintResponseEvent(run, {
       type: 'response.created',
@@ -1207,6 +1209,7 @@ export class CodingAgentRunManager {
     run.codexPendingUsage = undefined
     run.currentChildStderr = ''
     run.runMarker = undefined
+    run.memoryExportStarted = false
 
     this.handleClaudePrintResponseEvent(run, {
       type: 'response.created',
@@ -1670,7 +1673,72 @@ export class CodingAgentRunManager {
     run.state.activeRunMarker = undefined
     run.state.events = []
     this.markChatRunCompleted(run.launch.sessionId, event)
+    if (event === 'run.completed') this.startCodingAgentMemoryExport(run)
     run.runMarker = undefined
+  }
+
+  private startCodingAgentMemoryExport(run: ManagedCodingAgentRun) {
+    if (run.memoryExportStarted) return
+    const agentId = run.launch.agentId
+    const source = agentId === 'codex' ? 'codex' : agentId === 'claude-code' ? 'claude-code' : ''
+    if (!source) return
+    const nativeSessionId = String(run.launch.agentNativeSessionId || '').trim()
+    if (!nativeSessionId) {
+      logger.debug({ runId: run.id, sessionId: run.launch.sessionId, agentId }, '[coding-agent-run] memory export skipped: missing native session id')
+      return
+    }
+    run.memoryExportStarted = true
+
+    const args = ['threads', 'save', '--from', source, '--truncate', '--session-id', nativeSessionId]
+    const env: NodeJS.ProcessEnv = { ...process.env }
+    if (source === 'codex') {
+      const codexHome = run.launch.env?.CODEX_HOME || process.env.CODEX_HOME
+      if (codexHome) env.CODEX_HOME = codexHome
+    }
+
+    let child: ChildProcess
+    try {
+      child = spawnCodingAgentChild('nmem', args, {
+        cwd: existsSync(run.launch.workspaceDir) ? run.launch.workspaceDir : homedir(),
+        env,
+      })
+    } catch (err) {
+      logger.debug({ err, runId: run.id, sessionId: run.launch.sessionId, agentId, nativeSessionId }, '[coding-agent-run] memory export failed to start')
+      return
+    }
+
+    let stdout = ''
+    let stderr = ''
+    const timeout = setTimeout(() => {
+      try { child.kill() } catch {}
+    }, 60_000)
+    timeout.unref?.()
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout = `${stdout}${chunk.toString('utf8')}`.slice(-4000)
+    })
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr = `${stderr}${chunk.toString('utf8')}`.slice(-4000)
+    })
+    child.on('error', (err) => {
+      clearTimeout(timeout)
+      logger.debug({ err, runId: run.id, sessionId: run.launch.sessionId, agentId, nativeSessionId }, '[coding-agent-run] memory export process error')
+    })
+    child.on('exit', (code) => {
+      clearTimeout(timeout)
+      if (code === 0) {
+        logger.info({ runId: run.id, sessionId: run.launch.sessionId, agentId, nativeSessionId }, '[coding-agent-run] memory export completed')
+      } else {
+        logger.debug({
+          runId: run.id,
+          sessionId: run.launch.sessionId,
+          agentId,
+          nativeSessionId,
+          code,
+          stdout: stdout.slice(0, 1000),
+          stderr: stderr.slice(0, 1000),
+        }, '[coding-agent-run] memory export failed')
+      }
+    })
   }
 
   private codexNativeSessionIdFrom(value: any): string {


### PR DESCRIPTION
## Summary
- add a best-effort post-run export step for completed coding-agent native sessions
- support Codex and Claude Code by using their recorded native session ids
- run the export asynchronously after the chat response is flushed, so user-visible run completion is not blocked

## Behavior
- skips unsupported agents and runs without native session ids
- invokes the local session export CLI with `--truncate` to avoid oversized tool outputs
- bounds captured stdout/stderr and logs failures without failing the coding-agent run

## Why
Coding-agent runs are stored in their native session stores as well as Hermes Studio chat sessions. Triggering a post-run export hook makes completed runs available to local memory/archive tooling without requiring users to manually run an export command after every Codex or Claude Code turn.

## Testing
- Verified the PR branch contains only the intended `coding-agent-run-manager.ts` change.
- Verified the new guard/reset/export hook locations by inspecting the updated symbols:
  - `memoryExportStarted` is reset for Claude Code print turns and Codex exec turns.
  - `startCodingAgentMemoryExport()` is called only after `markChatRunCompleted()` for `run.completed`.
  - unsupported agents and missing native session ids are skipped.
- Verified the local session export CLI is available in the target runtime and supports the command shape used here:
  - `nmem threads save --from <codex|claude-code> --truncate --session-id <id>`.
- Attempted server typecheck with `npx tsc --noEmit -p packages/server/tsconfig.json`; this checkout cannot complete it because local dependencies are incomplete (`typescript`/`koa` are missing from `node_modules`).
- While attempting the build/typecheck path, OpenAPI generation completed successfully (`243 endpoints`, `38 tags`).
