### PR TITLE
[codex] fix chat input resize

### DIFF
--- a/docs/chat-chain-changes/2026-07-03-chat-input-resize.md
+++ b/docs/chat-chain-changes/2026-07-03-chat-input-resize.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-03
+commit: 0a3a7b4f
+feature: Chat input resize
+impact: Single-chat input manual height dragging again controls the visible textarea height after the refreshed toolbar layout; chat session creation, message ordering, and runtime transport behavior are unchanged.
+---
+
+# Chat input resize
+
+Changed file: `packages/client/src/components/hermes/chat/ChatInput.vue`
+
+The single-chat input textarea no longer flexes to fill the vertical input wrapper, so the existing resize handle's manual height value is reflected in the visible text area. The bottom toolbar stays pinned to the lower edge of the input wrapper.

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1740,7 +1740,7 @@ function isImage(type: string): boolean {
 
 .input-textarea {
   display: block;
-  flex: 1;
+  flex: 0 0 auto;
   width: 100%;
   background: none;
   border: none;
@@ -1779,6 +1779,7 @@ function isImage(type: string): boolean {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  margin-top: auto;
   min-height: 32px;
 }
 


### PR DESCRIPTION
## Summary
- Restore the single-chat input textarea so manual height dragging changes the visible input height again.
- Keep the refreshed bottom toolbar pinned to the bottom of the input wrapper after removing textarea flex growth.

## Root Cause
- The toolbar refresh changed the input wrapper to a vertical flex layout while the textarea still used `flex: 1`, so the drag handler updated `height` but flex sizing could keep the textarea filling available space instead of reflecting the manual height.

## Impact
- Users can resize the single-chat input vertically again without changing group chat behavior or chat send logic.

## Validation
- `npm run test -- tests/client/chat-input-draft.test.ts`
- `npm run test -- tests/client/chat-input-height.test.ts`
