### PR TITLE
[codex] show dot workspace folders

### DIFF
--- a/docs/chat-chain-changes/2026-07-03-dot-workspace-folders.md
+++ b/docs/chat-chain-changes/2026-07-03-dot-workspace-folders.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-03
+commit: local
+feature: Workspace folder picker
+impact: Workspace folder browsing now includes dot-prefixed directories such as .hermes, .config, and .codex while preserving WORKSPACE_BASE containment checks; chat session creation, message ordering, and runtime transport behavior are unchanged.
+---
+
+# Dot-prefixed workspace folders
+
+Changed file: `packages/server/src/controllers/hermes/sessions.ts`
+
+The workspace folder picker no longer hides directories whose names start with a dot. Hidden or tool-owned directories can now be selected as valid workspaces when they are inside the configured workspace base. Existing directory type checks, symlink handling, and path containment validation remain in place.

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -1142,7 +1142,6 @@ async function isWorkspaceListPathAllowed(fullPath: string, basePath: string, st
 }
 
 async function isSafeWorkspaceFolderEntry(entry: any, fullPath: string, basePath: string, statFn: any): Promise<boolean> {
-  if (entry.name.startsWith('.')) return false
   if (!entry.isDirectory() && !(typeof entry.isSymbolicLink === 'function' && entry.isSymbolicLink())) {
     return false
   }

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -370,6 +370,54 @@ describe('session conversations controller', () => {
     }
   })
 
+  it('lists dot-prefixed workspace folders under WORKSPACE_BASE', async () => {
+    const originalWorkspaceBase = process.env.WORKSPACE_BASE
+    const workspaceBase = await mkdtemp(join(tmpdir(), 'hermes-workspace-dot-picker-'))
+
+    try {
+      const hermesDir = join(workspaceBase, '.hermes')
+      const codexDir = join(workspaceBase, '.codex')
+      const hiddenChildDir = join(hermesDir, '.plugins')
+      const visibleChildDir = join(hermesDir, 'workspace')
+
+      await mkdir(hiddenChildDir, { recursive: true })
+      await mkdir(visibleChildDir, { recursive: true })
+      await mkdir(codexDir, { recursive: true })
+      process.env.WORKSPACE_BASE = workspaceBase
+
+      const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+      const rootCtx: any = { query: {}, body: null }
+      await mod.listWorkspaceFolders(rootCtx)
+
+      expect(rootCtx.status).toBeUndefined()
+      expect(rootCtx.body).toEqual({
+        base: workspaceBase,
+        current: '',
+        folders: [
+          { name: '.codex', path: '.codex', fullPath: codexDir },
+          { name: '.hermes', path: '.hermes', fullPath: hermesDir },
+        ],
+      })
+
+      const nestedCtx: any = { query: { path: '.hermes' }, body: null }
+      await mod.listWorkspaceFolders(nestedCtx)
+
+      expect(nestedCtx.status).toBeUndefined()
+      expect(nestedCtx.body).toEqual({
+        base: workspaceBase,
+        current: '.hermes',
+        folders: [
+          { name: '.plugins', path: '.hermes/.plugins', fullPath: hiddenChildDir },
+          { name: 'workspace', path: '.hermes/workspace', fullPath: visibleChildDir },
+        ],
+      })
+    } finally {
+      if (originalWorkspaceBase === undefined) delete process.env.WORKSPACE_BASE
+      else process.env.WORKSPACE_BASE = originalWorkspaceBase
+      await rm(workspaceBase, { recursive: true, force: true })
+    }
+  })
+
   it('blocks workspace folder mutations through symlinked ancestors that escape WORKSPACE_BASE', async () => {
     const originalWorkspaceBase = process.env.WORKSPACE_BASE
     const workspaceBase = await mkdtemp(join(tmpdir(), 'hermes-workspace-mutation-'))


### PR DESCRIPTION
## Summary
- Allow the workspace folder picker to list dot-prefixed directories such as `.hermes`, `.config`, and `.codex`.
- Add server coverage for dot-prefixed root and nested workspace folders.
- Add the required chat-chain change fragment for the sessions controller touch.

## Root Cause
- The workspace folder entry filter rejected every directory whose name started with `.`, which hid valid workspace roots used by Docker, local tool state, and other workflows.

## Impact
- Users can select dot-prefixed directories as workspaces while the existing directory type checks, symlink handling, and `WORKSPACE_BASE` containment checks remain in place.

## Validation
- `npm run test -- tests/server/sessions-controller.test.ts`
- `npm run harness:check`
