### PR TITLE
[codex] fix desktop login reset flow

### DIFF
--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -1,7 +1,7 @@
 export default {
   // Login
   login: {
-    title: 'Hermes Web UI',
+    title: 'Hermes Studio',
     description: 'Geben Sie Benutzername und Passwort ein, um fortzufahren.',
     placeholder: 'Zugangs-Token',
     submit: 'Anmelden',
@@ -18,6 +18,7 @@ export default {
     tooManyAttempts: 'Zu viele fehlgeschlagene Versuche, bitte versuchen Sie es spater erneut',
     lockResetHint: 'Wenn dies Ihr Server ist, heben Sie die Login-Sperre auf mit:',
     defaultLoginResetHint: 'Um das Standard-Admin-Passwort zuruckzusetzen, fuhren Sie aus:',
+    desktopLockResetHint: 'Too many failed login attempts. Open the system tray menu and choose Reset Login to reset the password.',
     sessionExpired: 'Die Anmeldung ist abgelaufen. Bitte melden Sie sich erneut an.',
     accessDenied: 'Sie haben keine Berechtigung fur diese Ressource.',
     passwordMismatch: 'Passworter stimmen nicht uberein',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -1,7 +1,7 @@
 export default {
   // Login
   login: {
-    title: 'Hermes Web UI',
+    title: 'Hermes Studio',
     description: 'Enter your username and password to continue.',
     placeholder: 'Access token',
     submit: 'Login',
@@ -18,6 +18,7 @@ export default {
     tooManyAttempts: 'Too many failed attempts, please try again later',
     lockResetHint: 'If this is your server, clear the login lock with:',
     defaultLoginResetHint: 'To reset the default admin password, run:',
+    desktopLockResetHint: 'Too many failed login attempts. Open the system tray menu and choose Reset Login to reset the password.',
     sessionExpired: 'Login expired. Please sign in again.',
     accessDenied: 'You do not have permission to access this resource.',
     passwordMismatch: 'Passwords do not match',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -1,7 +1,7 @@
 export default {
   // Login
   login: {
-    title: 'Hermes Web UI',
+    title: 'Hermes Studio',
     description: 'Introduce tu nombre de usuario y contrasena para continuar.',
     placeholder: 'Token de acceso',
     submit: 'Iniciar sesion',
@@ -18,6 +18,7 @@ export default {
     tooManyAttempts: 'Demasiados intentos fallidos, por favor intente mas tarde',
     lockResetHint: 'Si este es su servidor, borre el bloqueo de inicio de sesion con:',
     defaultLoginResetHint: 'Para restablecer la contrasena admin predeterminada, ejecute:',
+    desktopLockResetHint: 'Too many failed login attempts. Open the system tray menu and choose Reset Login to reset the password.',
     sessionExpired: 'La sesion expiro. Inicia sesion de nuevo.',
     accessDenied: 'No tienes permiso para acceder a este recurso.',
     passwordMismatch: 'Las contrasenas no coinciden',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -1,7 +1,7 @@
 export default {
   // Login
   login: {
-    title: 'Hermes Web UI',
+    title: 'Hermes Studio',
     description: 'Entrez votre nom d\'utilisateur et votre mot de passe pour continuer.',
     placeholder: 'Jeton d\'acces',
     submit: 'Connexion',
@@ -18,6 +18,7 @@ export default {
     tooManyAttempts: 'Trop de tentatives echouees, veuillez reessayer plus tard',
     lockResetHint: 'Si c est votre serveur, supprimez le verrouillage de connexion avec :',
     defaultLoginResetHint: 'Pour reinitialiser le mot de passe admin par defaut, executez :',
+    desktopLockResetHint: 'Too many failed login attempts. Open the system tray menu and choose Reset Login to reset the password.',
     sessionExpired: 'La session a expire. Veuillez vous reconnecter.',
     accessDenied: 'Vous n\'avez pas l\'autorisation d\'acceder a cette ressource.',
     passwordMismatch: 'Les mots de passe ne correspondent pas',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -1,7 +1,7 @@
 export default {
   // ログイン
   login: {
-    title: 'Hermes Web UI',
+    title: 'Hermes Studio',
     description: 'ユーザー名とパスワードを入力して続行してください。',
     placeholder: 'アクセストークン',
     submit: 'ログイン',
@@ -18,6 +18,7 @@ export default {
     tooManyAttempts: 'ログイン試行回数が多すぎます。しばらくしてからお試しください',
     lockResetHint: '自分のサーバーの場合は、次のコマンドでログインロックを解除できます:',
     defaultLoginResetHint: '既定の admin パスワードをリセットするには、次を実行してください:',
+    desktopLockResetHint: 'Too many failed login attempts. Open the system tray menu and choose Reset Login to reset the password.',
     sessionExpired: 'ログインの有効期限が切れました。再度ログインしてください。',
     accessDenied: 'このリソースにアクセスする権限がありません。',
     passwordMismatch: 'パスワードが一致しません',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -1,7 +1,7 @@
 export default {
   // 로그인
   login: {
-    title: 'Hermes Web UI',
+    title: 'Hermes Studio',
     description: '계속하려면 사용자 이름과 비밀번호를 입력하세요.',
     placeholder: '액세스 토큰',
     submit: '로그인',
@@ -18,6 +18,7 @@ export default {
     tooManyAttempts: '로그인 시도 횟수가 너무 많습니다. 잠시 후 다시 시도해 주세요',
     lockResetHint: '본인 서버라면 다음 명령으로 로그인 잠금을 해제할 수 있습니다:',
     defaultLoginResetHint: '기본 admin 비밀번호를 재설정하려면 다음을 실행하세요:',
+    desktopLockResetHint: 'Too many failed login attempts. Open the system tray menu and choose Reset Login to reset the password.',
     sessionExpired: '로그인이 만료되었습니다. 다시 로그인해 주세요.',
     accessDenied: '이 리소스에 접근할 권한이 없습니다.',
     passwordMismatch: '비밀번호가 일치하지 않습니다',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -1,7 +1,7 @@
 export default {
   // Login
   login: {
-    title: 'Hermes Web UI',
+    title: 'Hermes Studio',
     description: 'Insira seu nome de usuario e senha para continuar.',
     placeholder: 'Token de acesso',
     submit: 'Entrar',
@@ -18,6 +18,7 @@ export default {
     tooManyAttempts: 'Muitas tentativas falhadas, por favor tente novamente mais tarde',
     lockResetHint: 'Se este for seu servidor, limpe o bloqueio de login com:',
     defaultLoginResetHint: 'Para redefinir a senha admin padrao, execute:',
+    desktopLockResetHint: 'Too many failed login attempts. Open the system tray menu and choose Reset Login to reset the password.',
     sessionExpired: 'Login expirado. Entre novamente.',
     accessDenied: 'Voce nao tem permissao para acessar este recurso.',
     passwordMismatch: 'As senhas nao conferem',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -1,7 +1,7 @@
 export default {
 
   login: {
-    title: 'Hermes Web UI',
+    title: 'Hermes Studio',
     description: 'Введите имя пользователя и пароль для продолжения.',
     placeholder: 'Токен доступа',
     submit: 'Войти',
@@ -16,6 +16,7 @@ export default {
     credentialsRequired: 'Введите имя пользователя и пароль',
     invalidCredentials: 'Неверное имя пользователя или пароль',
     tooManyAttempts: 'Слишком много неудачных попыток входа, повторите попытку позже',
+    desktopLockResetHint: 'Too many failed login attempts. Open the system tray menu and choose Reset Login to reset the password.',
     sessionExpired: 'Сеанс истёк, войдите снова',
     accessDenied: 'У вас нет прав доступа к этому ресурсу',
     passwordMismatch: 'Пароли не совпадают',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -1,7 +1,7 @@
 export default {
   // 登入
   login: {
-    title: 'Hermes Web UI',
+    title: 'Hermes Studio',
     description: '輸入使用者名稱和密碼以繼續。',
     placeholder: '存取權杖',
     submit: '登入',
@@ -18,6 +18,7 @@ export default {
     tooManyAttempts: '登入失敗次數過多，請稍後再試',
     lockResetHint: '如果這是你的伺服器，可以執行以下命令清除登入鎖定：',
     defaultLoginResetHint: '如需重置預設 admin 密碼，可以執行：',
+    desktopLockResetHint: '登入失敗次數過多。請開啟系統托盤選單，選擇「重置登入」來重置密碼。',
     sessionExpired: '登入已過期，請重新登入',
     accessDenied: '你沒有權限存取此資源',
     passwordMismatch: '兩次密碼不一致',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -1,7 +1,7 @@
 export default {
   // 登录
   login: {
-    title: 'Hermes Web UI',
+    title: 'Hermes Studio',
     description: '输入用户名和密码以继续。',
     placeholder: '访问令牌',
     submit: '登录',
@@ -18,6 +18,7 @@ export default {
     tooManyAttempts: '登录失败次数过多，请稍后重试',
     lockResetHint: '如果这是你的服务器，可以执行以下命令清除登录锁定：',
     defaultLoginResetHint: '如需重置默认 admin 密码，可以执行：',
+    desktopLockResetHint: '登录失败次数过多。请打开系统托盘菜单，选择“重置登录”来重置密码。',
     sessionExpired: '登录已过期，请重新登录',
     accessDenied: '你没有权限访问该资源',
     passwordMismatch: '两次密码不一致',

--- a/packages/client/src/router/index.ts
+++ b/packages/client/src/router/index.ts
@@ -184,13 +184,19 @@ async function ensureDesktopAuth(): Promise<void> {
   }
 }
 
+function isDesktopShell(): boolean {
+  return (window as typeof window & {
+    hermesDesktop?: { isDesktop?: boolean }
+  }).hermesDesktop?.isDesktop === true
+}
+
 router.beforeEach(async (to, _from, next) => {
   await ensureDesktopAuth()
 
   // Public pages don't need auth
   if (to.meta.public) {
     // Already has key, skip login
-    if (to.name === 'login' && hasApiKey()) {
+    if (to.name === 'login' && hasApiKey() && !isDesktopShell()) {
       next({ path: '/hermes/chat' })
       return
     }

--- a/packages/client/src/views/LoginView.vue
+++ b/packages/client/src/views/LoginView.vue
@@ -2,8 +2,9 @@
 import { ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
-import { setApiKey, hasApiKey } from "@/api/client";
+import { setApiKey, clearApiKey, hasApiKey } from "@/api/client";
 import { fetchAuthStatus, loginWithPassword } from "@/api/auth";
+import { isDesktopShell } from "@/utils/desktop-bridge";
 
 const { t } = useI18n();
 const router = useRouter();
@@ -13,9 +14,13 @@ const password = ref("");
 const loading = ref(false);
 const errorMsg = ref("");
 const showLockResetHint = ref(false);
+const desktopShell = isDesktopShell();
 
-// If already has a key, try to go to main page
-if (hasApiKey()) {
+if (desktopShell) {
+  // Desktop login is a recovery path. Drop stale JWTs before any background
+  // request can reuse them and show an unrelated expiry notice.
+  clearApiKey();
+} else if (hasApiKey()) {
   router.replace("/hermes/chat");
 }
 
@@ -86,10 +91,15 @@ async function handlePasswordLogin() {
 
         <div v-if="errorMsg" class="login-error">{{ errorMsg }}</div>
         <div v-if="showLockResetHint" class="login-lock-hint">
-          <span>{{ t("login.lockResetHint") }}</span>
-          <code>hermes-web-ui clear-login-locks --restart</code>
-          <span>{{ t("login.defaultLoginResetHint") }}</span>
-          <code>hermes-web-ui reset-default-login</code>
+          <template v-if="desktopShell">
+            <span>{{ t("login.desktopLockResetHint") }}</span>
+          </template>
+          <template v-else>
+            <span>{{ t("login.lockResetHint") }}</span>
+            <code>hermes-web-ui clear-login-locks --restart</code>
+            <span>{{ t("login.defaultLoginResetHint") }}</span>
+            <code>hermes-web-ui reset-default-login</code>
+          </template>
         </div>
         <button type="submit" class="login-btn" :disabled="loading">
           {{ loading ? "..." : t("login.submit") }}

--- a/packages/desktop/src/main/desktop-i18n.ts
+++ b/packages/desktop/src/main/desktop-i18n.ts
@@ -6,6 +6,7 @@ type TranslationKey =
   | 'tray.show'
   | 'tray.hide'
   | 'tray.checkForUpdates'
+  | 'tray.resetLogin'
   | 'tray.openAtLogin'
   | 'tray.quit'
   | 'update.upToDateTitle'
@@ -43,6 +44,15 @@ type TranslationKey =
   | 'runtime.extracting'
   | 'runtime.ready'
   | 'common.ok'
+  | 'common.cancel'
+  | 'loginReset.confirmTitle'
+  | 'loginReset.confirmMessage'
+  | 'loginReset.confirmDetail'
+  | 'loginReset.resetting'
+  | 'loginReset.successTitle'
+  | 'loginReset.successMessage'
+  | 'loginReset.failedTitle'
+  | 'loginReset.failedMessage'
 
 const supportedLocales: DesktopLocale[] = ['en', 'zh', 'zh-TW', 'ja', 'ko', 'fr', 'es', 'de', 'pt']
 
@@ -51,6 +61,7 @@ const translations: Record<DesktopLocale, Record<TranslationKey, string>> = {
     'tray.show': 'Show Hermes Studio',
     'tray.hide': 'Hide Hermes Studio',
     'tray.checkForUpdates': 'Check for Updates',
+    'tray.resetLogin': 'Reset Login',
     'tray.openAtLogin': 'Open at Login',
     'tray.quit': 'Quit Hermes Studio',
     'update.upToDateTitle': 'Hermes Studio',
@@ -88,11 +99,21 @@ const translations: Record<DesktopLocale, Record<TranslationKey, string>> = {
     'runtime.extracting': 'Extracting Hermes runtime...',
     'runtime.ready': 'Hermes runtime ready.',
     'common.ok': 'OK',
+    'common.cancel': 'Cancel',
+    'loginReset.confirmTitle': 'Reset login',
+    'loginReset.confirmMessage': 'Reset the login to admin / 123456?',
+    'loginReset.confirmDetail': 'Hermes Studio will restart its local Web UI service, clear login locks, and return to the login page.',
+    'loginReset.resetting': 'Resetting login...',
+    'loginReset.successTitle': 'Login reset',
+    'loginReset.successMessage': 'Login has been reset to {username} / {password}.',
+    'loginReset.failedTitle': 'Login reset failed',
+    'loginReset.failedMessage': 'Could not reset the desktop login.',
   },
   zh: {
     'tray.show': '显示 Hermes Studio',
     'tray.hide': '隐藏 Hermes Studio',
     'tray.checkForUpdates': '检查更新',
+    'tray.resetLogin': '重置登录',
     'tray.openAtLogin': '开机启动',
     'tray.quit': '退出 Hermes Studio',
     'update.upToDateTitle': 'Hermes Studio',
@@ -130,11 +151,21 @@ const translations: Record<DesktopLocale, Record<TranslationKey, string>> = {
     'runtime.extracting': '正在解压 Hermes 运行时...',
     'runtime.ready': 'Hermes 运行时已就绪。',
     'common.ok': '确定',
+    'common.cancel': '取消',
+    'loginReset.confirmTitle': '重置登录',
+    'loginReset.confirmMessage': '确认将登录重置为 admin / 123456？',
+    'loginReset.confirmDetail': 'Hermes Studio 会重启本地 Web UI 服务、清除登录失败锁，然后回到登录页。',
+    'loginReset.resetting': '正在重置登录...',
+    'loginReset.successTitle': '登录已重置',
+    'loginReset.successMessage': '登录已重置为 {username} / {password}。',
+    'loginReset.failedTitle': '重置登录失败',
+    'loginReset.failedMessage': '无法重置桌面端登录。',
   },
   'zh-TW': {
     'tray.show': '顯示 Hermes Studio',
     'tray.hide': '隱藏 Hermes Studio',
     'tray.checkForUpdates': '檢查更新',
+    'tray.resetLogin': '重置登入',
     'tray.openAtLogin': '開機啟動',
     'tray.quit': '結束 Hermes Studio',
     'update.upToDateTitle': 'Hermes Studio',
@@ -172,11 +203,21 @@ const translations: Record<DesktopLocale, Record<TranslationKey, string>> = {
     'runtime.extracting': '正在解壓 Hermes 運行時...',
     'runtime.ready': 'Hermes 運行時已就緒。',
     'common.ok': '確定',
+    'common.cancel': '取消',
+    'loginReset.confirmTitle': '重置登入',
+    'loginReset.confirmMessage': '確認將登入重置為 admin / 123456？',
+    'loginReset.confirmDetail': 'Hermes Studio 會重新啟動本地 Web UI 服務、清除登入失敗鎖，然後回到登入頁。',
+    'loginReset.resetting': '正在重置登入...',
+    'loginReset.successTitle': '登入已重置',
+    'loginReset.successMessage': '登入已重置為 {username} / {password}。',
+    'loginReset.failedTitle': '重置登入失敗',
+    'loginReset.failedMessage': '無法重置桌面端登入。',
   },
   ja: {
     'tray.show': 'Hermes Studio を表示',
     'tray.hide': 'Hermes Studio を隠す',
     'tray.checkForUpdates': 'アップデートを確認',
+    'tray.resetLogin': 'Reset Login',
     'tray.openAtLogin': 'ログイン時に開く',
     'tray.quit': 'Hermes Studio を終了',
     'update.upToDateTitle': 'Hermes Studio',
@@ -214,11 +255,21 @@ const translations: Record<DesktopLocale, Record<TranslationKey, string>> = {
     'runtime.extracting': 'Hermes ランタイムを展開しています...',
     'runtime.ready': 'Hermes ランタイムの準備ができました。',
     'common.ok': 'OK',
+    'common.cancel': 'Cancel',
+    'loginReset.confirmTitle': 'Reset login',
+    'loginReset.confirmMessage': 'Reset the login to admin / 123456?',
+    'loginReset.confirmDetail': 'Hermes Studio will restart its local Web UI service, clear login locks, and return to the login page.',
+    'loginReset.resetting': 'Resetting login...',
+    'loginReset.successTitle': 'Login reset',
+    'loginReset.successMessage': 'Login has been reset to {username} / {password}.',
+    'loginReset.failedTitle': 'Login reset failed',
+    'loginReset.failedMessage': 'Could not reset the desktop login.',
   },
   ko: {
     'tray.show': 'Hermes Studio 표시',
     'tray.hide': 'Hermes Studio 숨기기',
     'tray.checkForUpdates': '업데이트 확인',
+    'tray.resetLogin': 'Reset Login',
     'tray.openAtLogin': '로그인 시 열기',
     'tray.quit': 'Hermes Studio 종료',
     'update.upToDateTitle': 'Hermes Studio',
@@ -256,11 +307,21 @@ const translations: Record<DesktopLocale, Record<TranslationKey, string>> = {
     'runtime.extracting': 'Hermes 런타임을 압축 해제하는 중...',
     'runtime.ready': 'Hermes 런타임이 준비되었습니다.',
     'common.ok': '확인',
+    'common.cancel': 'Cancel',
+    'loginReset.confirmTitle': 'Reset login',
+    'loginReset.confirmMessage': 'Reset the login to admin / 123456?',
+    'loginReset.confirmDetail': 'Hermes Studio will restart its local Web UI service, clear login locks, and return to the login page.',
+    'loginReset.resetting': 'Resetting login...',
+    'loginReset.successTitle': 'Login reset',
+    'loginReset.successMessage': 'Login has been reset to {username} / {password}.',
+    'loginReset.failedTitle': 'Login reset failed',
+    'loginReset.failedMessage': 'Could not reset the desktop login.',
   },
   fr: {
     'tray.show': 'Afficher Hermes Studio',
     'tray.hide': 'Masquer Hermes Studio',
     'tray.checkForUpdates': 'Rechercher les mises a jour',
+    'tray.resetLogin': 'Reset Login',
     'tray.openAtLogin': 'Ouvrir a la connexion',
     'tray.quit': 'Quitter Hermes Studio',
     'update.upToDateTitle': 'Hermes Studio',
@@ -298,11 +359,21 @@ const translations: Record<DesktopLocale, Record<TranslationKey, string>> = {
     'runtime.extracting': 'Extraction du runtime Hermes...',
     'runtime.ready': 'Runtime Hermes pret.',
     'common.ok': 'OK',
+    'common.cancel': 'Cancel',
+    'loginReset.confirmTitle': 'Reset login',
+    'loginReset.confirmMessage': 'Reset the login to admin / 123456?',
+    'loginReset.confirmDetail': 'Hermes Studio will restart its local Web UI service, clear login locks, and return to the login page.',
+    'loginReset.resetting': 'Resetting login...',
+    'loginReset.successTitle': 'Login reset',
+    'loginReset.successMessage': 'Login has been reset to {username} / {password}.',
+    'loginReset.failedTitle': 'Login reset failed',
+    'loginReset.failedMessage': 'Could not reset the desktop login.',
   },
   es: {
     'tray.show': 'Mostrar Hermes Studio',
     'tray.hide': 'Ocultar Hermes Studio',
     'tray.checkForUpdates': 'Buscar actualizaciones',
+    'tray.resetLogin': 'Reset Login',
     'tray.openAtLogin': 'Abrir al iniciar sesion',
     'tray.quit': 'Salir de Hermes Studio',
     'update.upToDateTitle': 'Hermes Studio',
@@ -340,11 +411,21 @@ const translations: Record<DesktopLocale, Record<TranslationKey, string>> = {
     'runtime.extracting': 'Extrayendo runtime de Hermes...',
     'runtime.ready': 'Runtime de Hermes listo.',
     'common.ok': 'Aceptar',
+    'common.cancel': 'Cancel',
+    'loginReset.confirmTitle': 'Reset login',
+    'loginReset.confirmMessage': 'Reset the login to admin / 123456?',
+    'loginReset.confirmDetail': 'Hermes Studio will restart its local Web UI service, clear login locks, and return to the login page.',
+    'loginReset.resetting': 'Resetting login...',
+    'loginReset.successTitle': 'Login reset',
+    'loginReset.successMessage': 'Login has been reset to {username} / {password}.',
+    'loginReset.failedTitle': 'Login reset failed',
+    'loginReset.failedMessage': 'Could not reset the desktop login.',
   },
   de: {
     'tray.show': 'Hermes Studio anzeigen',
     'tray.hide': 'Hermes Studio ausblenden',
     'tray.checkForUpdates': 'Nach Updates suchen',
+    'tray.resetLogin': 'Reset Login',
     'tray.openAtLogin': 'Beim Anmelden offnen',
     'tray.quit': 'Hermes Studio beenden',
     'update.upToDateTitle': 'Hermes Studio',
@@ -382,11 +463,21 @@ const translations: Record<DesktopLocale, Record<TranslationKey, string>> = {
     'runtime.extracting': 'Hermes Runtime wird entpackt...',
     'runtime.ready': 'Hermes Runtime ist bereit.',
     'common.ok': 'OK',
+    'common.cancel': 'Cancel',
+    'loginReset.confirmTitle': 'Reset login',
+    'loginReset.confirmMessage': 'Reset the login to admin / 123456?',
+    'loginReset.confirmDetail': 'Hermes Studio will restart its local Web UI service, clear login locks, and return to the login page.',
+    'loginReset.resetting': 'Resetting login...',
+    'loginReset.successTitle': 'Login reset',
+    'loginReset.successMessage': 'Login has been reset to {username} / {password}.',
+    'loginReset.failedTitle': 'Login reset failed',
+    'loginReset.failedMessage': 'Could not reset the desktop login.',
   },
   pt: {
     'tray.show': 'Mostrar Hermes Studio',
     'tray.hide': 'Ocultar Hermes Studio',
     'tray.checkForUpdates': 'Verificar atualizacoes',
+    'tray.resetLogin': 'Reset Login',
     'tray.openAtLogin': 'Abrir ao iniciar sessao',
     'tray.quit': 'Sair do Hermes Studio',
     'update.upToDateTitle': 'Hermes Studio',
@@ -424,6 +515,15 @@ const translations: Record<DesktopLocale, Record<TranslationKey, string>> = {
     'runtime.extracting': 'Extraindo runtime Hermes...',
     'runtime.ready': 'Runtime Hermes pronto.',
     'common.ok': 'OK',
+    'common.cancel': 'Cancel',
+    'loginReset.confirmTitle': 'Reset login',
+    'loginReset.confirmMessage': 'Reset the login to admin / 123456?',
+    'loginReset.confirmDetail': 'Hermes Studio will restart its local Web UI service, clear login locks, and return to the login page.',
+    'loginReset.resetting': 'Resetting login...',
+    'loginReset.successTitle': 'Login reset',
+    'loginReset.successMessage': 'Login has been reset to {username} / {password}.',
+    'loginReset.failedTitle': 'Login reset failed',
+    'loginReset.failedMessage': 'Could not reset the desktop login.',
   },
 }
 

--- a/packages/desktop/src/main/desktop-login-reset.ts
+++ b/packages/desktop/src/main/desktop-login-reset.ts
@@ -1,0 +1,55 @@
+import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { bundledNode, webUiHome, webuiDir } from './paths'
+
+const DEFAULT_USERNAME = 'admin'
+const DEFAULT_PASSWORD = '123456'
+const EXEC_MAX_BUFFER = 1024 * 1024
+
+function resolveNodeForWebUiCli(): string {
+  try {
+    const node = bundledNode()
+    if (existsSync(node)) return node
+  } catch {
+    /* fall back to the current executable */
+  }
+  return process.execPath
+}
+
+function webUiCliScriptPath(): string {
+  return join(webuiDir(), 'bin', 'hermes-web-ui.mjs')
+}
+
+async function runWebUiCliCommand(command: string): Promise<void> {
+  const node = resolveNodeForWebUiCli()
+  const script = webUiCliScriptPath()
+  const home = webUiHome()
+
+  await new Promise<void>((resolve, reject) => {
+    execFile(node, [script, command], {
+      cwd: webuiDir(),
+      env: {
+        ...process.env,
+        ELECTRON_RUN_AS_NODE: '1',
+        HERMES_WEB_UI_HOME: home,
+        HERMES_WEBUI_STATE_DIR: home,
+      },
+      maxBuffer: EXEC_MAX_BUFFER,
+      windowsHide: true,
+    }, (error, _stdout, stderr) => {
+      if (!error) {
+        resolve()
+        return
+      }
+      const detail = typeof stderr === 'string' && stderr.trim() ? stderr.trim() : error.message
+      reject(new Error(detail))
+    })
+  })
+}
+
+export async function resetDesktopDefaultLogin(): Promise<{ username: string; password: string }> {
+  await runWebUiCliCommand('reset-default-login')
+  await runWebUiCliCommand('clear-login-locks')
+  return { username: DEFAULT_USERNAME, password: DEFAULT_PASSWORD }
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,10 +1,11 @@
-import { app, BrowserWindow, Menu, Tray, shell, ipcMain, nativeImage, Notification, screen } from 'electron'
+import { app, BrowserWindow, Menu, Tray, shell, ipcMain, nativeImage, Notification, screen, dialog, type MessageBoxOptions } from 'electron'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { startWebUiServer, stopWebUiServer, getToken } from './webui-server'
 import { bundledNode, desktopIcon, desktopRuntimeVersion, desktopTrayTemplateIcon, desktopWindowsTrayIcon, hermesBinExists, hermesBin, webuiDir } from './paths'
 import { checkForDesktopUpdates, initAutoUpdater } from './updater'
 import { t } from './desktop-i18n'
+import { resetDesktopDefaultLogin } from './desktop-login-reset'
 import { installHermesStudioCliShim, installHermesStudioMcpShim } from './cli-shim'
 import { parseHermesCliArgs, runBundledHermesCli } from './hermes-cli'
 import {
@@ -34,6 +35,7 @@ let serverUrl: string | null = null
 let tray: Tray | null = null
 let isQuitting = false
 let isBootstrapping = false
+let isResettingLogin = false
 let windowFadeTimer: NodeJS.Timeout | null = null
 const activeNotifications = new Set<Notification>()
 
@@ -241,6 +243,78 @@ function setOpenAtLogin(openAtLogin: boolean) {
   })
 }
 
+async function clearWebLoginSession() {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  await mainWindow.webContents.executeJavaScript(`
+    try {
+      localStorage.removeItem('hermes_api_key');
+      sessionStorage.clear();
+      window.location.hash = '#/login';
+    } catch {
+      window.location.hash = '#/login';
+    }
+  `).catch(() => undefined)
+}
+
+function showDesktopMessageBox(options: MessageBoxOptions) {
+  if (mainWindow && !mainWindow.isDestroyed()) return dialog.showMessageBox(mainWindow, options)
+  return dialog.showMessageBox(options)
+}
+
+async function handleResetDefaultLogin() {
+  if (isResettingLogin || (isBootstrapping && !serverUrl)) return
+
+  const choice = await showDesktopMessageBox({
+    type: 'warning',
+    buttons: [t('tray.resetLogin'), t('common.cancel')],
+    defaultId: 0,
+    cancelId: 1,
+    title: t('loginReset.confirmTitle'),
+    message: t('loginReset.confirmMessage'),
+    detail: t('loginReset.confirmDetail'),
+  })
+  if (choice.response !== 0) return
+
+  isResettingLogin = true
+  updateTrayMenu()
+  showMainWindow()
+
+  try {
+    await clearWebLoginSession()
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      await mainWindow.loadURL(splashHtml(t('loginReset.resetting')))
+    }
+    await stopWebUiServer()
+    serverUrl = null
+    const credentials = await resetDesktopDefaultLogin()
+    const url = await startWebUiServer(PORT)
+    serverUrl = url
+    if (mainWindow && !mainWindow.isDestroyed()) await mainWindow.loadURL(url)
+    await loadPetWindowRoute()
+    await clearWebLoginSession()
+    await showDesktopMessageBox({
+      type: 'info',
+      buttons: [t('common.ok')],
+      defaultId: 0,
+      title: t('loginReset.successTitle'),
+      message: t('loginReset.successMessage', credentials),
+    })
+  } catch (err) {
+    console.error('[desktop-login-reset] failed:', err)
+    await showDesktopMessageBox({
+      type: 'error',
+      buttons: [t('common.ok')],
+      defaultId: 0,
+      title: t('loginReset.failedTitle'),
+      message: t('loginReset.failedMessage'),
+      detail: err instanceof Error ? err.message : String(err),
+    })
+  } finally {
+    isResettingLogin = false
+    updateTrayMenu()
+  }
+}
+
 function updateTrayMenu() {
   if (!tray) return
   const isVisible = !!mainWindow && mainWindow.isVisible()
@@ -261,6 +335,15 @@ function updateTrayMenu() {
       click: () => {
         checkForDesktopUpdates(true).catch(err => {
           console.error('[tray] update check failed:', err)
+        })
+      },
+    },
+    {
+      label: isResettingLogin ? t('loginReset.resetting') : t('tray.resetLogin'),
+      enabled: !isResettingLogin && (!isBootstrapping || !!serverUrl),
+      click: () => {
+        handleResetDefaultLogin().catch(err => {
+          console.error('[tray] reset login failed:', err)
         })
       },
     },
@@ -584,6 +667,7 @@ async function bootstrap(source?: RuntimeDownloadSource) {
     updateSplash({ stage: 'resolve', message: t('desktop.startingLocalServices') })
     const url = await startWebUiServer(PORT)
     serverUrl = url
+    updateTrayMenu()
     if (mainWindow) await mainWindow.loadURL(url)
     await loadPetWindowRoute()
   } catch (err) {

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -15,7 +15,6 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     const token = await ipcRenderer.invoke('hermes-desktop:get-token')
     if (token) {
       try { localStorage.setItem('AUTH_TOKEN', token) } catch { /* */ }
-      await autoLogin(token)
     }
     return !!localStorage.getItem(API_KEY_LS)
   },
@@ -35,33 +34,6 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
 })
 
 const API_KEY_LS = 'hermes_api_key'
-const DEFAULT_USERNAME = 'admin'
-const DEFAULT_PASSWORD = '123456'
-
-// Auto-login the bundled web UI so users don't see a login screen on launch.
-// We POST to /api/auth/login with the well-known default credentials, using
-// the server's AUTH_TOKEN as the bearer (the server requires *some* auth on
-// /api/auth/login from a packaged client). The returned JWT is dropped into
-// localStorage where the Vue client expects it.
-async function autoLogin(token: string): Promise<void> {
-  if (localStorage.getItem(API_KEY_LS)) return
-  try {
-    const res = await fetch('/api/auth/login', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({ username: DEFAULT_USERNAME, password: DEFAULT_PASSWORD }),
-    })
-    if (!res.ok) return
-    const body = await res.json().catch(() => null) as { token?: string; jwt?: string } | null
-    const jwt = body?.token || body?.jwt
-    if (jwt) localStorage.setItem(API_KEY_LS, jwt)
-  } catch {
-    /* ignore — first-load race or server still starting */
-  }
-}
 
 // Silently strip the "你必须修改默认密码" flag from /api/auth/me responses on
 // desktop. Users on a single-machine install don't benefit from a managed
@@ -153,7 +125,6 @@ window.addEventListener('DOMContentLoaded', async () => {
     const token = await ipcRenderer.invoke('hermes-desktop:get-token')
     if (token) {
       try { localStorage.setItem('AUTH_TOKEN', token) } catch { /* */ }
-      await autoLogin(token)
     }
   } catch {
     /* ignore */

--- a/tests/client/login-view.test.ts
+++ b/tests/client/login-view.test.ts
@@ -6,7 +6,9 @@ const mockReplace = vi.hoisted(() => vi.fn())
 const mockFetchAuthStatus = vi.hoisted(() => vi.fn())
 const mockLoginWithPassword = vi.hoisted(() => vi.fn())
 const mockSetApiKey = vi.hoisted(() => vi.fn())
+const mockClearApiKey = vi.hoisted(() => vi.fn())
 const mockHasApiKey = vi.hoisted(() => vi.fn())
+const mockIsDesktopShell = vi.hoisted(() => vi.fn())
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({
@@ -22,6 +24,7 @@ vi.mock('vue-i18n', () => ({
 
 vi.mock('@/api/client', () => ({
   setApiKey: mockSetApiKey,
+  clearApiKey: mockClearApiKey,
   hasApiKey: mockHasApiKey,
 }))
 
@@ -30,14 +33,38 @@ vi.mock('@/api/auth', () => ({
   loginWithPassword: mockLoginWithPassword,
 }))
 
+vi.mock('@/utils/desktop-bridge', () => ({
+  isDesktopShell: mockIsDesktopShell,
+}))
+
 import LoginView from '@/views/LoginView.vue'
 
 describe('LoginView password login', () => {
   beforeEach(() => {
     delete (window as any).__LOGIN_TOKEN__
     vi.clearAllMocks()
+    mockIsDesktopShell.mockReturnValue(false)
     mockHasApiKey.mockReturnValue(false)
     mockFetchAuthStatus.mockResolvedValue({ hasPasswordLogin: true, username: 'admin' })
+  })
+
+  it('keeps the web login redirect when a token already exists', () => {
+    mockHasApiKey.mockReturnValue(true)
+
+    mount(LoginView)
+
+    expect(mockClearApiKey).not.toHaveBeenCalled()
+    expect(mockReplace).toHaveBeenCalledWith('/hermes/chat')
+  })
+
+  it('clears stale tokens when the desktop login page is opened', () => {
+    mockIsDesktopShell.mockReturnValue(true)
+    mockHasApiKey.mockReturnValue(true)
+
+    mount(LoginView)
+
+    expect(mockClearApiKey).toHaveBeenCalledOnce()
+    expect(mockReplace).not.toHaveBeenCalledWith('/hermes/chat')
   })
 
   it('logs in with username and password', async () => {
@@ -93,5 +120,22 @@ describe('LoginView password login', () => {
       'hermes-web-ui clear-login-locks --restart',
       'hermes-web-ui reset-default-login',
     ])
+  })
+
+  it('shows the tray reset hint for locked desktop logins', async () => {
+    mockIsDesktopShell.mockReturnValue(true)
+    const err: any = new Error('Too many login attempts')
+    err.status = 429
+    mockLoginWithPassword.mockRejectedValue(err)
+    const wrapper = mount(LoginView)
+
+    const inputs = wrapper.findAll('input.login-input')
+    await inputs[0].setValue('admin')
+    await inputs[1].setValue('123456')
+    await wrapper.find('form.login-form').trigger('submit')
+
+    expect(wrapper.find('.login-error').text()).toBe('login.tooManyAttempts')
+    expect(wrapper.find('.login-lock-hint').text()).toContain('login.desktopLockResetHint')
+    expect(wrapper.findAll('.login-lock-hint code')).toHaveLength(0)
   })
 })

--- a/tests/client/router-login-redirect.test.ts
+++ b/tests/client/router-login-redirect.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockHasApiKey = vi.hoisted(() => vi.fn())
+const mockIsStoredSuperAdmin = vi.hoisted(() => vi.fn())
+
+vi.mock('@/api/client', () => ({
+  hasApiKey: mockHasApiKey,
+  isStoredSuperAdmin: mockIsStoredSuperAdmin,
+}))
+
+async function loadRouter() {
+  vi.resetModules()
+  return (await import('@/router')).default
+}
+
+describe('router login redirect', () => {
+  beforeEach(() => {
+    mockHasApiKey.mockReturnValue(false)
+    mockIsStoredSuperAdmin.mockReturnValue(true)
+    if (!document.queryCommandSupported) {
+      document.queryCommandSupported = vi.fn(() => false)
+    }
+    delete (window as any).hermesDesktop
+    window.location.hash = ''
+  })
+
+  afterEach(() => {
+    delete (window as any).hermesDesktop
+  })
+
+  it('keeps the web login redirect when a token exists', async () => {
+    mockHasApiKey.mockReturnValue(true)
+    const router = await loadRouter()
+
+    await router.push('/')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('hermes.chat')
+  }, 15_000)
+
+  it('does not redirect desktop login when a stale token exists', async () => {
+    mockHasApiKey.mockReturnValue(true)
+    ;(window as any).hermesDesktop = { isDesktop: true }
+    const router = await loadRouter()
+
+    await router.push('/')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('login')
+  })
+})

--- a/tests/desktop/desktop-login-reset.test.ts
+++ b/tests/desktop/desktop-login-reset.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('desktop login reset', () => {
+  it('exposes login reset from the tray and restarts only the local Web UI service', () => {
+    const source = readFileSync(resolve('packages/desktop/src/main/index.ts'), 'utf-8')
+
+    expect(source).toContain("t('tray.resetLogin')")
+    expect(source).toContain('async function handleResetDefaultLogin()')
+    expect(source).toContain('await stopWebUiServer()')
+    expect(source).toContain('await resetDesktopDefaultLogin()')
+    expect(source).toContain('await startWebUiServer(PORT)')
+  })
+
+  it('refreshes the tray menu once the Web UI server is ready', () => {
+    const source = readFileSync(resolve('packages/desktop/src/main/index.ts'), 'utf-8')
+
+    expect(source).toContain('serverUrl = url\n    updateTrayMenu()')
+    expect(source).toContain('enabled: !isResettingLogin && (!isBootstrapping || !!serverUrl)')
+  })
+
+  it('resets the default credentials and clears login locks through the Web UI CLI', () => {
+    const source = readFileSync(resolve('packages/desktop/src/main/desktop-login-reset.ts'), 'utf-8')
+
+    expect(source).toContain("runWebUiCliCommand('reset-default-login')")
+    expect(source).toContain("runWebUiCliCommand('clear-login-locks')")
+    expect(source).toContain("DEFAULT_USERNAME = 'admin'")
+    expect(source).toContain("DEFAULT_PASSWORD = '123456'")
+  })
+})

--- a/tests/desktop/preload-auth.test.ts
+++ b/tests/desktop/preload-auth.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+
+describe('desktop preload auth', () => {
+  it('does not auto-login with default credentials', () => {
+    const source = readFileSync(resolve('packages/desktop/src/preload/index.ts'), 'utf-8')
+
+    expect(source).not.toContain('/api/auth/login')
+    expect(source).not.toContain('DEFAULT_PASSWORD')
+    expect(source).not.toContain('DEFAULT_USERNAME')
+    expect(source).not.toContain('autoLogin')
+  })
+})

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -7,7 +7,7 @@ test('redirects protected routes to the login screen without a token', async ({ 
   await page.goto('/#/hermes/jobs')
 
   await expect(page).toHaveURL(/#\/$/)
-  await expect(page.getByRole('heading', { name: 'Hermes Web UI' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Hermes Studio' })).toBeVisible()
   await expect(page.getByPlaceholder('Username')).toBeVisible()
   await expect(page.getByPlaceholder('Password')).toBeVisible()
   expect(api.unexpectedRequests).toEqual([])


### PR DESCRIPTION
## Summary

- remove the desktop preload auto-login that posted the default `admin / 123456` credentials
- add a desktop tray action to reset the default login and clear login locks without quitting the Electron app
- keep regular Web UI login behavior unchanged while giving desktop locked-login users a tray reset hint

## Details

The desktop wrapper previously tried to auto-login with the bundled default credentials. That could interact badly with reset-default-login flows and login lock state. The desktop app now stores only the server auth token and lets the user sign in explicitly.

For recovery, the tray menu now exposes a Reset Login action. It stops only the local Web UI server child process, runs the existing Web UI CLI reset and lock-clear commands against the desktop state directory, restarts the local server, and returns the window to the login page.

The web login route still redirects to `/hermes/chat` when a web user already has a valid stored key. The desktop shell is the only case that allows the login page to load with a stale key so the page can clear it before background requests reuse it.

## Validation

- `npm run test -- tests/client/login-view.test.ts tests/client/router-login-redirect.test.ts tests/client/api.test.ts tests/client/i18n-coverage.test.ts`
- `npm run test -- tests/desktop/desktop-login-reset.test.ts tests/desktop/preload-auth.test.ts`
- `npm --prefix packages/desktop run build:main`
- `npm run harness:check`
- `npm run build`
