### PR TITLE
fix: make files panel follow session workspace

### DIFF
--- a/packages/client/src/api/hermes/download.ts
+++ b/packages/client/src/api/hermes/download.ts
@@ -13,11 +13,16 @@ function normalizeProfile(profile?: string | null): string | null {
   return value || null
 }
 
+function appendSessionId(params: URLSearchParams, sessionId?: string | null): void {
+  const value = typeof sessionId === 'string' ? sessionId.trim() : ''
+  if (value) params.set('session_id', value)
+}
+
 /**
  * Construct a download URL with auth token as query parameter.
  * Token is passed via query param because <a> tags cannot set headers.
  */
-export function getDownloadUrl(filePath: string, fileName?: string, profile?: string | null): string {
+export function getDownloadUrl(filePath: string, fileName?: string, profile?: string | null, sessionId?: string | null): string {
   const base = getBaseUrlValue()
 
   // Guard: if filePath is already a full download URL, extract the real path
@@ -43,6 +48,7 @@ export function getDownloadUrl(filePath: string, fileName?: string, profile?: st
   const explicitProfile = normalizeProfile(profile)
   const profileName = profile === undefined ? getActiveProfileName() : explicitProfile
   if (profileName) params.set('profile', profileName)
+  appendSessionId(params, sessionId)
   const token = getApiKey()
   if (token) params.set('token', token)
   return `${base}/api/hermes/download?${params.toString()}`
@@ -52,8 +58,8 @@ export function getDownloadUrl(filePath: string, fileName?: string, profile?: st
  * Download a file. Uses fetch to detect errors, then creates a blob URL
  * for the browser download. Throws with error message on failure.
  */
-export async function downloadFile(filePath: string, fileName?: string, profile?: string | null): Promise<void> {
-  const url = getDownloadUrl(filePath, fileName, profile)
+export async function downloadFile(filePath: string, fileName?: string, profile?: string | null, sessionId?: string | null): Promise<void> {
+  const url = getDownloadUrl(filePath, fileName, profile, sessionId)
   const res = await fetch(url)
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
@@ -74,8 +80,8 @@ export async function downloadFile(filePath: string, fileName?: string, profile?
  * Get preview file content.
  * Throws with error message on failure.
  */
-export async function fetchFileText(filePath: string, fileName?: string, profile?: string | null): Promise<string> {
-  const url = getDownloadUrl(filePath, fileName, profile)
+export async function fetchFileText(filePath: string, fileName?: string, profile?: string | null, sessionId?: string | null): Promise<string> {
+  const url = getDownloadUrl(filePath, fileName, profile, sessionId)
   const res = await fetch(url)
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))

--- a/packages/client/src/api/hermes/files.ts
+++ b/packages/client/src/api/hermes/files.ts
@@ -29,62 +29,70 @@ function appendProfile(params: URLSearchParams, profile?: string | null): void {
   if (value) params.set('profile', value)
 }
 
-export async function listFiles(path: string = '', profile?: string | null): Promise<{ entries: FileEntry[]; path: string; absolutePath?: string }> {
+function appendSessionId(params: URLSearchParams, sessionId?: string | null): void {
+  const value = typeof sessionId === 'string' ? sessionId.trim() : ''
+  if (value) params.set('session_id', value)
+}
+
+export async function listFiles(path: string = '', profile?: string | null, sessionId?: string | null): Promise<{ entries: FileEntry[]; path: string; absolutePath?: string }> {
   const params = new URLSearchParams()
   if (path) params.set('path', path)
   appendProfile(params, profile)
+  appendSessionId(params, sessionId)
   const query = params.toString()
   return request<{ entries: FileEntry[]; path: string }>(`/api/hermes/files/list${query ? `?${query}` : ''}`)
 }
 
-export async function statFile(path: string, profile?: string | null): Promise<FileStat> {
+export async function statFile(path: string, profile?: string | null, sessionId?: string | null): Promise<FileStat> {
   const params = new URLSearchParams({ path })
   appendProfile(params, profile)
+  appendSessionId(params, sessionId)
   return request<FileStat>(`/api/hermes/files/stat?${params.toString()}`)
 }
 
-export async function readFile(path: string, profile?: string | null): Promise<{ content: string; path: string; size: number }> {
+export async function readFile(path: string, profile?: string | null, sessionId?: string | null): Promise<{ content: string; path: string; size: number }> {
   const params = new URLSearchParams({ path })
   appendProfile(params, profile)
+  appendSessionId(params, sessionId)
   return request<{ content: string; path: string; size: number }>(`/api/hermes/files/read?${params.toString()}`)
 }
 
-export async function writeFile(path: string, content: string, profile?: string | null): Promise<void> {
+export async function writeFile(path: string, content: string, profile?: string | null, sessionId?: string | null): Promise<void> {
   await request<{ ok: boolean }>('/api/hermes/files/write', {
     method: 'PUT',
-    body: JSON.stringify({ path, content, profile: normalizeProfile(profile) || undefined }),
+    body: JSON.stringify({ path, content, profile: normalizeProfile(profile) || undefined, session_id: sessionId || undefined }),
   })
 }
 
-export async function deleteFile(path: string, recursive: boolean = false, profile?: string | null): Promise<void> {
+export async function deleteFile(path: string, recursive: boolean = false, profile?: string | null, sessionId?: string | null): Promise<void> {
   await request<{ ok: boolean }>('/api/hermes/files/delete', {
     method: 'DELETE',
-    body: JSON.stringify({ path, recursive, profile: normalizeProfile(profile) || undefined }),
+    body: JSON.stringify({ path, recursive, profile: normalizeProfile(profile) || undefined, session_id: sessionId || undefined }),
   })
 }
 
-export async function renameFile(oldPath: string, newPath: string, profile?: string | null): Promise<void> {
+export async function renameFile(oldPath: string, newPath: string, profile?: string | null, sessionId?: string | null): Promise<void> {
   await request<{ ok: boolean }>('/api/hermes/files/rename', {
     method: 'POST',
-    body: JSON.stringify({ oldPath, newPath, profile: normalizeProfile(profile) || undefined }),
+    body: JSON.stringify({ oldPath, newPath, profile: normalizeProfile(profile) || undefined, session_id: sessionId || undefined }),
   })
 }
 
-export async function mkDir(path: string, profile?: string | null): Promise<void> {
+export async function mkDir(path: string, profile?: string | null, sessionId?: string | null): Promise<void> {
   await request<{ ok: boolean }>('/api/hermes/files/mkdir', {
     method: 'POST',
-    body: JSON.stringify({ path, profile: normalizeProfile(profile) || undefined }),
+    body: JSON.stringify({ path, profile: normalizeProfile(profile) || undefined, session_id: sessionId || undefined }),
   })
 }
 
-export async function copyFile(srcPath: string, destPath: string, profile?: string | null): Promise<void> {
+export async function copyFile(srcPath: string, destPath: string, profile?: string | null, sessionId?: string | null): Promise<void> {
   await request<{ ok: boolean }>('/api/hermes/files/copy', {
     method: 'POST',
-    body: JSON.stringify({ srcPath, destPath, profile: normalizeProfile(profile) || undefined }),
+    body: JSON.stringify({ srcPath, destPath, profile: normalizeProfile(profile) || undefined, session_id: sessionId || undefined }),
   })
 }
 
-export async function uploadFiles(targetDir: string, files: File[], profile?: string | null): Promise<{ name: string; path: string }[]> {
+export async function uploadFiles(targetDir: string, files: File[], profile?: string | null, sessionId?: string | null): Promise<{ name: string; path: string }[]> {
   const base = getBaseUrlValue()
   const formData = new FormData()
   for (const file of files) {
@@ -93,6 +101,7 @@ export async function uploadFiles(targetDir: string, files: File[], profile?: st
   const params = new URLSearchParams()
   if (targetDir) params.set('path', targetDir)
   appendProfile(params, profile)
+  appendSessionId(params, sessionId)
   const query = params.toString()
   const url = `${base}/api/hermes/files/upload${query ? `?${query}` : ''}`
 
@@ -134,13 +143,14 @@ export async function uploadRuntimeFiles(files: File[]): Promise<{ name: string;
   return data.files
 }
 
-export function getFileDownloadUrl(relativePath: string, fileName?: string, profile?: string | null): string {
+export function getFileDownloadUrl(relativePath: string, fileName?: string, profile?: string | null, sessionId?: string | null): string {
   const base = getBaseUrlValue()
   const params = new URLSearchParams({ path: relativePath })
   if (fileName) params.set('name', fileName)
   const explicitProfile = normalizeProfile(profile)
   const profileName = profile === undefined ? getActiveProfileName() : explicitProfile
   if (profileName) params.set('profile', profileName)
+  appendSessionId(params, sessionId)
   const token = getApiKey()
   if (token) params.set('token', token)
   return `${base}/api/hermes/download?${params.toString()}`

--- a/packages/client/src/components/hermes/chat/FilesPanel.vue
+++ b/packages/client/src/components/hermes/chat/FilesPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useFilesStore } from '@/stores/hermes/files'
+import { useChatStore } from '@/stores/hermes/chat'
 import { useI18n } from 'vue-i18n'
 import { NButton } from 'naive-ui'
 import FileTree from '@/components/hermes/files/FileTree.vue'
@@ -15,6 +16,7 @@ import FileRenameModal from '@/components/hermes/files/FileRenameModal.vue'
 import type { FileEntry } from '@/api/hermes/files'
 
 const filesStore = useFilesStore()
+const chatStore = useChatStore()
 const { t } = useI18n()
 
 const contextMenuRef = ref<InstanceType<typeof FileContextMenu> | null>(null)
@@ -24,6 +26,7 @@ const renameMode = ref<'newFile' | 'newFolder' | 'rename'>('newFile')
 const renameEntry = ref<FileEntry | null>(null)
 const renameTargetPath = ref<string | null>(null)
 const showSidebar = ref(false)
+const activeSessionId = computed(() => chatStore.activeSessionId)
 
 function handleContextMenu(e: MouseEvent, entry: FileEntry) {
   contextMenuRef.value?.show(e, entry)
@@ -57,9 +60,13 @@ function handleRename(entry: FileEntry) {
   showRenameModal.value = true
 }
 
-onMounted(() => {
-  filesStore.fetchEntries('', { profile: null })
-})
+watch(
+  activeSessionId,
+  (sessionId) => {
+    void filesStore.fetchEntries('', { profile: null, sessionId })
+  },
+  { immediate: true },
+)
 </script>
 
 <template>
@@ -73,7 +80,7 @@ onMounted(() => {
       class="files-tree-panel"
       :class="{ 'mobile-visible': showSidebar }"
     >
-      <FileTree />
+      <FileTree :session-id="activeSessionId" />
     </div>
     <div class="files-main-panel">
       <div class="main-toolbar">

--- a/packages/client/src/components/hermes/files/FileTree.vue
+++ b/packages/client/src/components/hermes/files/FileTree.vue
@@ -10,16 +10,18 @@ const { t } = useI18n()
 const filesStore = useFilesStore()
 const props = defineProps<{
   profile?: string | null
+  sessionId?: string | null
 }>()
 
 const effectiveProfile = computed(() => props.profile === undefined ? filesStore.currentProfile : props.profile)
+const effectiveSessionId = computed(() => props.sessionId === undefined ? filesStore.currentSessionId : props.sessionId)
 
 const treeData = ref<TreeOption[]>([])
 const selectedKeys = ref<string[]>([])
 
 async function loadChildren(path: string): Promise<TreeOption[]> {
   try {
-    const result = await filesApi.listFiles(path, effectiveProfile.value)
+    const result = await filesApi.listFiles(path, effectiveProfile.value, effectiveSessionId.value)
     return result.entries
       .filter(e => e.isDir)
       .sort((a, b) => a.name.localeCompare(b.name))
@@ -40,13 +42,13 @@ async function handleLoad(node: TreeOption): Promise<void> {
 function handleSelect(keys: string[]) {
   if (keys.length > 0) {
     selectedKeys.value = keys
-    filesStore.navigateTo(keys[0], { profile: effectiveProfile.value })
+    filesStore.navigateTo(keys[0], { profile: effectiveProfile.value, sessionId: effectiveSessionId.value })
   }
 }
 
 function handleRootClick() {
   selectedKeys.value = []
-  filesStore.navigateTo('', { profile: effectiveProfile.value })
+  filesStore.navigateTo('', { profile: effectiveProfile.value, sessionId: effectiveSessionId.value })
 }
 
 function renderLabel({ option }: { option: TreeOption }) {
@@ -54,7 +56,7 @@ function renderLabel({ option }: { option: TreeOption }) {
   return h('span', { class: 'tree-node-label', title: label }, label)
 }
 
-watch(effectiveProfile, async () => {
+watch([effectiveProfile, effectiveSessionId], async () => {
   selectedKeys.value = []
   treeData.value = await loadChildren('')
 }, { immediate: true })

--- a/packages/client/src/stores/hermes/files.ts
+++ b/packages/client/src/stores/hermes/files.ts
@@ -122,6 +122,7 @@ function normalizeProfile(profile?: string | null): string | null {
 export const useFilesStore = defineStore('files', () => {
   const currentPath = ref('')
   const currentProfile = ref<string | null>(null)
+  const currentSessionId = ref<string | null>(null)
   const entries = ref<FileEntry[]>([])
   const loading = ref(false)
   const sortBy = ref<'name' | 'size' | 'modTime'>('name')
@@ -139,6 +140,7 @@ export const useFilesStore = defineStore('files', () => {
   const previewFile = ref<{
     path: string
     profile?: string | null
+    sessionId?: string | null
     type: 'image' | 'markdown' | 'text'
     content?: string
     language?: string
@@ -168,7 +170,12 @@ export const useFilesStore = defineStore('files', () => {
     return profile === undefined ? currentProfile.value : normalizeProfile(profile)
   }
 
-  async function fetchEntries(path?: string, options: { profile?: string | null } = {}) {
+  function resolveSessionId(sessionId?: string | null): string | null {
+    if (sessionId !== undefined) return typeof sessionId === 'string' && sessionId.trim() ? sessionId.trim() : null
+    return currentSessionId.value
+  }
+
+  async function fetchEntries(path?: string, options: { profile?: string | null; sessionId?: string | null } = {}) {
     if (path !== undefined && path !== currentPath.value) {
       // Switching directory invalidates the current preview; close it so the
       // file list becomes visible again. The editor has its own dirty-check
@@ -176,11 +183,13 @@ export const useFilesStore = defineStore('files', () => {
       previewFile.value = null
     }
     const nextProfile = resolveProfile(options.profile)
+    const nextSessionId = resolveSessionId(options.sessionId)
     currentProfile.value = nextProfile
+    currentSessionId.value = nextSessionId
     if (path !== undefined) currentPath.value = path
     loading.value = true
     try {
-      const result = await filesApi.listFiles(currentPath.value, nextProfile)
+      const result = await filesApi.listFiles(currentPath.value, nextProfile, nextSessionId)
       entries.value = result.entries
     } catch (err) {
       console.error('Failed to fetch files:', err)
@@ -190,22 +199,25 @@ export const useFilesStore = defineStore('files', () => {
     }
   }
 
-  function navigateTo(path: string, options: { profile?: string | null } = {}) { return fetchEntries(path, options) }
-  function navigateUp(options: { profile?: string | null } = {}) {
+  function navigateTo(path: string, options: { profile?: string | null; sessionId?: string | null } = {}) { return fetchEntries(path, options) }
+  function navigateUp(options: { profile?: string | null; sessionId?: string | null } = {}) {
     const parts = currentPath.value.split('/').filter(Boolean)
     parts.pop()
     return fetchEntries(parts.join('/'), options)
   }
 
-  async function openEditor(filePath: string, options: { profile?: string | null } = {}) {
+  async function openEditor(filePath: string, options: { profile?: string | null; sessionId?: string | null } = {}) {
     const profile = resolveProfile(options.profile)
+    const sessionId = resolveSessionId(options.sessionId)
     currentProfile.value = profile
-    const result = await filesApi.readFile(filePath, profile)
+    currentSessionId.value = sessionId
+    const result = await filesApi.readFile(filePath, profile, sessionId)
     editingFile.value = {
       path: filePath,
       content: result.content,
       originalContent: result.content,
       language: getLanguageFromPath(filePath),
+      ...(sessionId ? { workspaceSessionId: sessionId, workspaceRelativePath: filePath } : {}),
     }
   }
 
@@ -230,26 +242,29 @@ export const useFilesStore = defineStore('files', () => {
         editingFile.value.content,
       )
     } else {
-      await filesApi.writeFile(editingFile.value.path, editingFile.value.content, currentProfile.value)
+      await filesApi.writeFile(editingFile.value.path, editingFile.value.content, currentProfile.value, currentSessionId.value)
     }
     editingFile.value.originalContent = editingFile.value.content
   }
 
   function closeEditor() { editingFile.value = null }
 
-  async function openPreview(entry: FileEntry, options: { profile?: string | null } = {}) {
+  async function openPreview(entry: FileEntry, options: { profile?: string | null; sessionId?: string | null } = {}) {
     const profile = resolveProfile(options.profile)
+    const sessionId = resolveSessionId(options.sessionId)
     currentProfile.value = profile
+    currentSessionId.value = sessionId
     if (isImageFile(entry.name)) {
-      previewFile.value = { path: entry.path, profile, type: 'image' }
+      previewFile.value = { path: entry.path, profile, sessionId, type: 'image' }
     } else if (isMarkdownFile(entry.name)) {
-      const result = await filesApi.readFile(entry.path, profile)
-      previewFile.value = { path: entry.path, profile, type: 'markdown', content: result.content }
+      const result = await filesApi.readFile(entry.path, profile, sessionId)
+      previewFile.value = { path: entry.path, profile, sessionId, type: 'markdown', content: result.content }
     } else if (isTextFile(entry.name)) {
-      const result = await filesApi.readFile(entry.path, profile)
+      const result = await filesApi.readFile(entry.path, profile, sessionId)
       previewFile.value = {
         path: entry.path,
         profile,
+        sessionId,
         type: 'text',
         content: result.content,
         language: getLanguageFromPath(entry.path),
@@ -261,18 +276,18 @@ export const useFilesStore = defineStore('files', () => {
 
   async function createDir(name: string, targetPath = currentPath.value) {
     const path = targetPath ? `${targetPath}/${name}` : name
-    await filesApi.mkDir(path, currentProfile.value)
+    await filesApi.mkDir(path, currentProfile.value, currentSessionId.value)
     await fetchEntries(undefined)
   }
 
   async function createFile(name: string) {
     const path = currentPath.value ? `${currentPath.value}/${name}` : name
-    await filesApi.writeFile(path, '', currentProfile.value)
+    await filesApi.writeFile(path, '', currentProfile.value, currentSessionId.value)
     await fetchEntries(undefined)
   }
 
   async function deleteEntry(entry: FileEntry) {
-    await filesApi.deleteFile(entry.path, entry.isDir, currentProfile.value)
+    await filesApi.deleteFile(entry.path, entry.isDir, currentProfile.value, currentSessionId.value)
     if (previewFile.value && isAffected(previewFile.value.path, entry.path, entry.isDir)) {
       previewFile.value = null
     }
@@ -285,7 +300,7 @@ export const useFilesStore = defineStore('files', () => {
   async function renameEntry(entry: FileEntry, newName: string) {
     const parentPath = entry.path.includes('/') ? entry.path.slice(0, entry.path.lastIndexOf('/')) : ''
     const newPath = parentPath ? `${parentPath}/${newName}` : newName
-    await filesApi.renameFile(entry.path, newPath, currentProfile.value)
+    await filesApi.renameFile(entry.path, newPath, currentProfile.value, currentSessionId.value)
     if (previewFile.value && isAffected(previewFile.value.path, entry.path, entry.isDir)) {
       previewFile.value = null
     }
@@ -296,12 +311,12 @@ export const useFilesStore = defineStore('files', () => {
   }
 
   async function copyEntry(entry: FileEntry, destPath: string) {
-    await filesApi.copyFile(entry.path, destPath, currentProfile.value)
+    await filesApi.copyFile(entry.path, destPath, currentProfile.value, currentSessionId.value)
     await fetchEntries(undefined)
   }
 
   async function uploadFiles(files: File[]) {
-    await filesApi.uploadFiles(currentPath.value, files, currentProfile.value)
+    await filesApi.uploadFiles(currentPath.value, files, currentProfile.value, currentSessionId.value)
     await fetchEntries(undefined)
   }
 
@@ -320,7 +335,7 @@ export const useFilesStore = defineStore('files', () => {
   })
 
   return {
-    currentPath, currentProfile, entries, loading, sortBy, sortOrder,
+    currentPath, currentProfile, currentSessionId, entries, loading, sortBy, sortOrder,
     editingFile, previewFile,
     pathSegments, sortedEntries, hasUnsavedChanges,
     fetchEntries, navigateTo, navigateUp,

--- a/packages/client/src/views/hermes/FilesView.vue
+++ b/packages/client/src/views/hermes/FilesView.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useDialog } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import { useFilesStore } from '@/stores/hermes/files'
+import { useChatStore } from '@/stores/hermes/chat'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import FileTree from '@/components/hermes/files/FileTree.vue'
 import FileBreadcrumb from '@/components/hermes/files/FileBreadcrumb.vue'
@@ -17,6 +18,7 @@ import FileRenameModal from '@/components/hermes/files/FileRenameModal.vue'
 import type { FileEntry } from '@/api/hermes/files'
 
 const filesStore = useFilesStore()
+const chatStore = useChatStore()
 const profilesStore = useProfilesStore()
 const route = useRoute()
 const router = useRouter()
@@ -30,6 +32,7 @@ const renameMode = ref<'newFile' | 'newFolder' | 'rename'>('newFile')
 const renameEntry = ref<FileEntry | null>(null)
 const renameTargetPath = ref<string | null>(null)
 const scopedProfile = computed(() => firstQueryString(route.query.profile))
+const scopedSessionId = computed(() => firstQueryString(route.query.session_id) || chatStore.activeSessionId)
 const routeFilePath = computed(() => firstQueryString(route.query.file))
 const isProfileConfigEditor = computed(() => !!scopedProfile.value && routeFilePath.value === 'config.yaml')
 const profileConfigTitle = computed(() =>
@@ -93,12 +96,14 @@ async function loadFromRoute() {
     ? parentDir(filePath)
     : (firstQueryString(route.query.path) || '')
 
+  const sessionId = scopedSessionId.value
+
   if (!isProfileConfigEditor.value) {
-    await filesStore.fetchEntries(directoryPath, { profile })
+    await filesStore.fetchEntries(directoryPath, { profile, sessionId })
   }
 
   if (filePath) {
-    await filesStore.openEditor(filePath, { profile })
+    await filesStore.openEditor(filePath, { profile, sessionId })
   }
 }
 
@@ -122,7 +127,7 @@ function closeProfileConfigEditor() {
 }
 
 watch(
-  [() => route.query.profile, () => route.query.path, () => route.query.file],
+  [() => route.query.profile, () => route.query.session_id, () => route.query.path, () => route.query.file, () => chatStore.activeSessionId],
   () => {
     void loadFromRoute()
   },
@@ -144,7 +149,7 @@ watch(
       </div>
     </template>
     <div v-else class="files-tree-panel">
-      <FileTree :profile="scopedProfile" />
+      <FileTree :profile="scopedProfile" :session-id="scopedSessionId" />
     </div>
     <div v-if="!isProfileConfigEditor" class="files-main-panel">
       <FileToolbar

--- a/packages/server/src/routes/hermes/files.ts
+++ b/packages/server/src/routes/hermes/files.ts
@@ -7,21 +7,66 @@ import {
 } from '../../services/hermes/file-provider'
 import { requireSuperAdmin } from '../../middleware/user-auth'
 import { MultipartParseError, parseMultipartBoundary, parseMultipartFilename, splitMultipart } from '../../lib/multipart'
+import { getSession } from '../../db/hermes/session-store'
+import { isPathWithin, relativePathFromBase } from '../../services/hermes/hermes-path'
+import { resolve as pathResolve } from 'path'
 
 function requestedProfile(ctx: any): string | undefined {
   return ctx.state?.profile?.name
 }
 
+function requestedSessionId(ctx: any): string {
+  const querySessionId = typeof ctx.query?.session_id === 'string' ? ctx.query.session_id.trim() : ''
+  const bodySessionId = typeof ctx.request?.body?.session_id === 'string' ? ctx.request.body.session_id.trim() : ''
+  return querySessionId || bodySessionId
+}
+
+function getSessionWorkspace(ctx: any): string | null {
+  const sessionId = requestedSessionId(ctx)
+  if (!sessionId) return null
+  const session = getSession(sessionId)
+  if (!session) throw Object.assign(new Error('Session not found'), { code: 'not_found' })
+  if (session.profile && session.profile !== (requestedProfile(ctx) || 'default')) {
+    throw Object.assign(new Error('Session profile mismatch'), { code: 'permission_denied' })
+  }
+  const workspace = String(session.workspace || '').trim()
+  if (!workspace) throw Object.assign(new Error('Session workspace not found'), { code: 'not_found' })
+  return workspace
+}
+
+function normalizeRelativePath(relativePath: string): string {
+  if (!relativePath || relativePath === '.' || relativePath === '/') return ''
+  const normalized = relativePath.replace(/\\/g, '/')
+  if (normalized.startsWith('/') || normalized === '..' || normalized.startsWith('../') || normalized.includes('/../')) {
+    throw Object.assign(new Error('Invalid file path'), { code: 'invalid_path' })
+  }
+  return normalized
+}
+
 function resolveRequestPath(ctx: any, relativePath: string): string {
-  return resolveHermesPath(relativePath, requestedProfile(ctx))
+  const workspace = getSessionWorkspace(ctx)
+  if (!workspace) return resolveHermesPath(relativePath, requestedProfile(ctx))
+  const normalized = normalizeRelativePath(relativePath)
+  const resolved = normalized ? pathResolve(workspace, normalized) : workspace
+  if (!isPathWithin(resolved, workspace)) throw Object.assign(new Error('Path traversal detected'), { code: 'invalid_path' })
+  return resolved
 }
 
 async function createRequestFileProvider(ctx: any) {
   return createFileProvider(requestedProfile(ctx))
 }
 
-function withAbsolutePath<T extends { path: string }>(ctx: any, entry: T): T & { absolutePath: string } {
-  return { ...entry, absolutePath: resolveRequestPath(ctx, entry.path) }
+function joinRelativePath(parentPath: string, name: string): string {
+  const parent = normalizeRelativePath(parentPath)
+  return parent ? `${parent}/${name}` : name
+}
+
+function withAbsolutePath<T extends { path: string; name?: string }>(ctx: any, entry: T, parentPath = ''): T & { absolutePath: string } {
+  const workspace = getSessionWorkspace(ctx)
+  if (!workspace) return { ...entry, absolutePath: resolveRequestPath(ctx, entry.path) }
+  const relativePath = entry.name ? joinRelativePath(parentPath, entry.name) : normalizeRelativePath(entry.path)
+  const absolutePath = resolveRequestPath(ctx, relativePath)
+  return { ...entry, path: relativePathFromBase(absolutePath, workspace) ?? relativePath, absolutePath }
 }
 
 export const fileRoutes = new Router()
@@ -57,7 +102,7 @@ fileRoutes.get('/api/hermes/files/list', async (ctx) => {
       if (a.isDir !== b.isDir) return a.isDir ? -1 : 1
       return a.name.localeCompare(b.name)
     })
-    ctx.body = { entries: entries.map(entry => withAbsolutePath(ctx, entry)), path: relativePath, absolutePath: absPath }
+    ctx.body = { entries: entries.map(entry => withAbsolutePath(ctx, entry, relativePath)), path: relativePath, absolutePath: absPath }
   } catch (err: any) {
     handleError(ctx, err)
   }
@@ -75,7 +120,7 @@ fileRoutes.get('/api/hermes/files/stat', async (ctx) => {
     const absPath = resolveRequestPath(ctx, relativePath)
     const provider = await createRequestFileProvider(ctx)
     const info = await provider.stat(absPath)
-    ctx.body = withAbsolutePath(ctx, info)
+    ctx.body = withAbsolutePath(ctx, { ...info, path: relativePath })
   } catch (err: any) {
     handleError(ctx, err)
   }

--- a/tests/server/files-routes.test.ts
+++ b/tests/server/files-routes.test.ts
@@ -1,5 +1,9 @@
 import { Readable } from 'stream'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { DatabaseSync } from 'node:sqlite'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 
 const provider = {
   listDir: vi.fn(),
@@ -9,11 +13,24 @@ const provider = {
   deleteDir: vi.fn(),
   writeFile: vi.fn(),
 }
+const state = vi.hoisted(() => ({
+  db: null as DatabaseSync | null,
+}))
+
 const createFileProviderMock = vi.fn(async () => provider)
 const resolveHermesPathMock = vi.fn((relativePath: string) => {
   const normalized = relativePath.replace(/^\/+/, '')
   return normalized ? `/home/agent/.hermes/${normalized}` : '/home/agent/.hermes'
 })
+
+vi.mock('../../packages/server/src/db/index', () => ({
+  getDb: () => state.db,
+  isSqliteAvailable: () => Boolean(state.db),
+  jsonDelete: vi.fn(),
+  jsonGet: vi.fn(),
+  jsonGetAll: vi.fn(() => ({})),
+  jsonSet: vi.fn(),
+}))
 
 vi.mock('../../packages/server/src/services/hermes/file-provider', () => ({
   createFileProvider: createFileProviderMock,
@@ -47,8 +64,14 @@ function superAdminState(profile = 'research') {
 }
 
 describe('file routes path metadata', () => {
-  beforeEach(() => {
+  let root: string
+
+  beforeEach(async () => {
     vi.resetModules()
+    root = mkdtempSync(join(tmpdir(), 'hermes-files-routes-'))
+    state.db = new DatabaseSync(join(root, 'files.db'))
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    initAllHermesTables()
     createFileProviderMock.mockClear()
     resolveHermesPathMock.mockClear()
     provider.listDir.mockReset()
@@ -57,6 +80,12 @@ describe('file routes path metadata', () => {
     provider.deleteFile.mockReset()
     provider.deleteDir.mockReset()
     provider.writeFile.mockReset()
+  })
+
+  afterEach(() => {
+    state.db?.close()
+    state.db = null
+    if (root) rmSync(root, { recursive: true, force: true })
   })
 
   it('returns absolute paths for listed entries while preserving relative operation paths', async () => {
@@ -79,6 +108,48 @@ describe('file routes path metadata', () => {
           name: 'app.log',
           path: 'logs/app.log',
           absolutePath: '/home/agent/.hermes/logs/app.log',
+          isDir: false,
+          size: 12,
+          modTime: '2026-05-20T00:00:00.000Z',
+        },
+      ],
+    })
+  })
+
+
+
+  it('lists the active session workspace when session_id is provided', async () => {
+    const workspace = join(root, 'workspace')
+    mkdirSync(workspace)
+    const { createSession } = await import('../../packages/server/src/db/hermes/session-store')
+    createSession({
+      id: 'session-with-workspace',
+      profile: 'research',
+      source: 'api_server',
+      workspace,
+    })
+    provider.listDir.mockResolvedValue([
+      { name: 'project.md', path: 'project.md', isDir: false, size: 12, modTime: '2026-05-20T00:00:00.000Z' },
+    ])
+
+    const ctx: any = {
+      query: { session_id: 'session-with-workspace' },
+      state: { profile: { name: 'research' } },
+      body: null,
+    }
+
+    await runFileRoute('/api/hermes/files/list', ctx)
+
+    expect(provider.listDir).toHaveBeenCalledWith(workspace)
+    expect(resolveHermesPathMock).not.toHaveBeenCalled()
+    expect(ctx.body).toEqual({
+      path: '',
+      absolutePath: workspace,
+      entries: [
+        {
+          name: 'project.md',
+          path: 'project.md',
+          absolutePath: join(workspace, 'project.md'),
           isDir: false,
           size: 12,
           modTime: '2026-05-20T00:00:00.000Z',


### PR DESCRIPTION
## Summary
- Make the right-side Files workspace panel follow the active/session workspace when a `session_id` is available.
- Thread `session_id` through file list/tree/editor/preview/download APIs.
- Resolve `/api/hermes/files/*` against the session workspace on the server, with path traversal and profile mismatch checks.

## Tests
- `npm run build`
- `npm test -- tests/server/files-routes.test.ts tests/client/workspace-long-names.test.ts`
