### PR TITLE
fix(runtime): 删除或切换 Hermes runtime 版本时检测缺失的 pip 用户包

### DIFF
--- a/packages/server/src/services/runtime-version-manager.ts
+++ b/packages/server/src/services/runtime-version-manager.ts
@@ -444,7 +444,15 @@ export async function downloadWebUiVersion(version: string, source: VersionDownl
 
 interface PipPackageDiff {
   missing: string[]
-  previousPythonPath: string
+}
+
+/**
+ * Normalize a pip package name per PEP 503: lowercase, replace runs of [-_.] with '-'.
+ * This ensures robust comparison between names returned by `pip list --format=json`
+ * (which preserves the metadata name, e.g. slack_sdk) and our BASE_PACKAGES entries.
+ */
+function normalizePkgName(name: string): string {
+  return name.toLowerCase().replace(/[-_.]+/g, '-')
 }
 
 function diffUserInstalledPipPackages(
@@ -455,16 +463,17 @@ function diffUserInstalledPipPackages(
   const oldPython = join(oldRuntimeDir, 'python', pythonBin)
   const newPython = join(newRuntimeDir, 'python', pythonBin)
   if (!existsSync(oldPython) || !existsSync(newPython)) {
-    return { missing: [], previousPythonPath: oldPython }
+    return { missing: [] }
   }
 
   // Get set of "base" packages that ship with every runtime (known by name)
+  // All entries must use the PEP 503 normalized form (hyphens, lowercase).
   const BASE_PACKAGES = new Set([
     'hermes-agent', 'aiohttp', 'httpx', 'fastapi', 'uvicorn', 'pydantic',
     'pyyaml', 'requests', 'certifi', 'urllib3', 'idna', 'charset-normalizer',
     'click', 'colorama', 'jinja2', 'rich', 'typer', 'setuptools', 'pip',
-    'websockets', 'cryptography', 'pywin32', 'psutil', 'prompt_toolkit',
-    'python-telegram-bot', 'discord.py', 'slack-sdk', 'slack-bolt',
+    'websockets', 'cryptography', 'pywin32', 'psutil', 'prompt-toolkit',
+    'python-telegram-bot', 'discord-py', 'slack-sdk', 'slack-bolt',
     'lark-oapi', 'dingtalk-stream', 'edge-tts', 'pillow',
   ])
 
@@ -475,22 +484,23 @@ function diffUserInstalledPipPackages(
     const oldPkgs: Array<{ name: string; version: string }> = JSON.parse(result.trim())
 
     const userPkgs = oldPkgs
-      .map(p => p.name.toLowerCase())
+      .map(p => normalizePkgName(p.name))
       .filter(name => !BASE_PACKAGES.has(name) && !name.startsWith('opentelemetry'))
 
-    if (userPkgs.length === 0) return { missing: [], previousPythonPath: oldPython }
+    if (userPkgs.length === 0) return { missing: [] }
 
     const newResult = execFileSync(newPython, [
       '-m', 'pip', 'list', '--format=json', '--disable-pip-version-check'
     ], { encoding: 'utf-8', timeout: 15000, killSignal: 'SIGTERM', stdio: ['ignore', 'pipe', 'pipe'] })
     const newPkgs = new Set(
-      (JSON.parse(newResult.trim()) as Array<{ name: string }>).map(p => p.name.toLowerCase())
+      (JSON.parse(newResult.trim()) as Array<{ name: string }>).map(p => normalizePkgName(p.name))
     )
 
     const missing = userPkgs.filter(name => !newPkgs.has(name))
-    return { missing, previousPythonPath: oldPython }
-  } catch {
-    return { missing: [], previousPythonPath: oldPython }
+    return { missing }
+  } catch (err) {
+    console.error('[runtime] Failed to diff pip packages:', err instanceof Error ? err.message : String(err))
+    return { missing: [] }
   }
 }
 

--- a/packages/server/src/services/runtime-version-manager.ts
+++ b/packages/server/src/services/runtime-version-manager.ts
@@ -23,6 +23,8 @@ export interface ActiveVersionManifest {
   updatedAt?: string
   /** Warning about pip packages missing in the newly activated runtime. */
   _pipMissingWarning?: string
+  /** Pip packages from a deleted runtime that may need reinstallation. */
+  _orphanedPipPackages?: string[]
 }
 
 export interface InstalledRuntimeVersion {
@@ -529,6 +531,18 @@ export function activateInstalledRuntimeVersion(version: string): ActiveVersionM
     }
   }
 
+  // Also surface orphaned packages from previously deleted runtimes.
+  if (!missingPackagesWarning && active?._orphanedPipPackages?.length) {
+    missingPackagesWarning = [
+      `The following pip package(s) were installed in a deleted runtime and are missing in the current one:`,
+      ...active._orphanedPipPackages.map(p => `  - ${p}`),
+      '',
+      'To install them, run:',
+      `  "${join(target.directory, 'python', process.platform === 'win32' ? 'python.exe' : 'bin', 'python3')}" -m pip install ${active._orphanedPipPackages.join(' ')}`,
+    ].join('\n')
+    console.warn(`[runtime] ${missingPackagesWarning}`)
+  }
+
   const next: ActiveVersionManifest = {
     schema: 1,
     hermesRuntimeVersion: target.manifestHermesRuntimeVersion || target.version,
@@ -549,11 +563,34 @@ export function deleteInstalledRuntimeVersion(version: string): InstalledRuntime
   const cleanVersion = version.trim()
   if (!cleanVersion) throw new Error('Runtime version is required')
 
-  const active = readActiveVersionManifest()
-  const installed = listInstalledRuntimeVersions(active)
+  const activeManifest = readActiveVersionManifest()
+  const installed = listInstalledRuntimeVersions(activeManifest)
   const target = installed.find(item => item.version === cleanVersion && item.platform === runtimePlatformKey())
   if (!target) throw new Error(`Installed runtime version not found for this platform: ${cleanVersion}`)
   if (target.active) throw new Error('Active runtime version cannot be deleted')
+
+  // Before deleting, collect user-installed pip packages so they can be
+  // surfaced when the next runtime is activated.
+  const pythonBin = process.platform === 'win32' ? 'python.exe' : join('bin', 'python3')
+  const pythonPath = join(target.directory, 'python', pythonBin)
+  if (existsSync(pythonPath)) {
+    try {
+      const result = execFileSync(pythonPath, [
+        '-m', 'pip', 'list', '--format=json', '--disable-pip-version-check'
+      ], { encoding: 'utf-8', timeout: 15000, killSignal: 'SIGTERM', stdio: ['ignore', 'pipe', 'pipe'] })
+      const pkgs: Array<{ name: string; version: string }> = JSON.parse(result.trim())
+      const userPkgs = pkgs
+        .map(p => normalizePkgName(p.name))
+        .filter(name => !BASE_PACKAGES.has(name) && !name.startsWith('opentelemetry'))
+      if (userPkgs.length > 0 && activeManifest) {
+        activeManifest._orphanedPipPackages = userPkgs
+        writeFileSync(activeVersionPath(), JSON.stringify(activeManifest, null, 2) + '\n', 'utf-8')
+      }
+    } catch (err) {
+      console.error('[runtime] Failed to collect pip packages before deletion:',
+        err instanceof Error ? err.message : String(err))
+    }
+  }
 
   rmSync(target.directory, { recursive: true, force: true })
   try {

--- a/packages/server/src/services/runtime-version-manager.ts
+++ b/packages/server/src/services/runtime-version-manager.ts
@@ -20,6 +20,8 @@ export interface ActiveVersionManifest {
   webUiDirectory?: string
   platform?: string
   updatedAt?: string
+  /** Warning about pip packages missing in the newly activated runtime. */
+  _pipMissingWarning?: string
 }
 
 export interface InstalledRuntimeVersion {
@@ -439,6 +441,57 @@ export async function downloadWebUiVersion(version: string, source: VersionDownl
   return { version: cleanVersion, directory: targetRoot, active: false }
 }
 
+interface PipPackageDiff {
+  missing: string[]
+  previousPythonPath: string
+}
+
+function diffUserInstalledPipPackages(
+  oldPythonDir: string,
+  newPythonDir: string,
+): PipPackageDiff {
+  const oldPython = join(oldPythonDir, process.platform === 'win32' ? 'python.exe' : 'bin', 'python3')
+  const newPython = join(newPythonDir, process.platform === 'win32' ? 'python.exe' : 'bin', 'python3')
+  if (!existsSync(oldPython) || !existsSync(newPython)) {
+    return { missing: [], previousPythonPath: oldPython }
+  }
+
+  // Get set of "base" packages that ship with every runtime (known by name)
+  const BASE_PACKAGES = new Set([
+    'hermes-agent', 'aiohttp', 'httpx', 'fastapi', 'uvicorn', 'pydantic',
+    'pyyaml', 'requests', 'certifi', 'urllib3', 'idna', 'charset-normalizer',
+    'click', 'colorama', 'jinja2', 'rich', 'typer', 'setuptools', 'pip',
+    'websockets', 'cryptography', 'pywin32', 'psutil', 'prompt_toolkit',
+    'python-telegram-bot', 'discord.py', 'slack-sdk', 'slack-bolt',
+    'lark-oapi', 'dingtalk-stream', 'edge-tts', 'pillow',
+  ])
+
+  try {
+    const result = require('child_process').execFileSync(oldPython, [
+      '-m', 'pip', 'list', '--format=json', '--disable-pip-version-check'
+    ], { encoding: 'utf-8', timeout: 15000, stdio: ['ignore', 'pipe', 'pipe'] })
+    const oldPkgs: Array<{ name: string; version: string }> = JSON.parse(result.trim())
+
+    const userPkgs = oldPkgs
+      .map(p => p.name.toLowerCase())
+      .filter(name => !BASE_PACKAGES.has(name) && !name.startsWith('hindsight') && !name.startsWith('opentelemetry'))
+
+    if (userPkgs.length === 0) return { missing: [], previousPythonPath: oldPython }
+
+    const newResult = require('child_process').execFileSync(newPython, [
+      '-m', 'pip', 'list', '--format=json', '--disable-pip-version-check'
+    ], { encoding: 'utf-8', timeout: 15000, stdio: ['ignore', 'pipe', 'pipe'] })
+    const newPkgs = new Set(
+      (JSON.parse(newResult.trim()) as Array<{ name: string }>).map(p => p.name.toLowerCase())
+    )
+
+    const missing = userPkgs.filter(name => !newPkgs.has(name))
+    return { missing, previousPythonPath: oldPython }
+  } catch {
+    return { missing: [], previousPythonPath: oldPython }
+  }
+}
+
 export function activateInstalledRuntimeVersion(version: string): ActiveVersionManifest {
   const cleanVersion = version.trim()
   if (!cleanVersion) throw new Error('Runtime version is required')
@@ -448,14 +501,33 @@ export function activateInstalledRuntimeVersion(version: string): ActiveVersionM
   const target = installed.find(item => item.version === cleanVersion && item.platform === runtimePlatformKey())
   if (!target) throw new Error(`Installed runtime version not found for this platform: ${cleanVersion}`)
 
+  // Detect pip packages that existed in the previous runtime but are missing in the new one
+  let missingPackagesWarning: string | undefined
+  if (active?.runtimeDirectory) {
+    const oldPythonDir = dirname(active.runtimeDirectory)
+    const newPythonDir = dirname(target.directory)
+    const diff = diffUserInstalledPipPackages(oldPythonDir, newPythonDir)
+    if (diff.missing.length > 0) {
+      missingPackagesWarning = [
+        `The new Hermes runtime is missing ${diff.missing.length} pip package(s) that were installed in the previous runtime:`,
+        ...diff.missing.map(p => `  - ${p}`),
+        '',
+        'To install them, run:',
+        `  "${join(target.directory, 'python', process.platform === 'win32' ? 'python.exe' : 'bin', 'python3')}" -m pip install ${diff.missing.join(' ')}`,
+      ].join('\n')
+      console.warn(`[runtime] ${missingPackagesWarning}`)
+    }
+  }
+
   const next: ActiveVersionManifest = {
-    schema: 1,
+    schema: 2,
     hermesRuntimeVersion: target.manifestHermesRuntimeVersion || target.version,
     webUiVersion: active?.webUiVersion || getHermesWebUiVersion(),
     runtimeDirectory: target.directory,
     webUiDirectory: active?.webUiDirectory || '',
     platform: target.platform,
     updatedAt: new Date().toISOString(),
+    _pipMissingWarning: missingPackagesWarning,
   }
 
   mkdirSync(dirname(activeVersionPath()), { recursive: true })

--- a/packages/server/src/services/runtime-version-manager.ts
+++ b/packages/server/src/services/runtime-version-manager.ts
@@ -556,15 +556,20 @@ export function activateInstalledRuntimeVersion(version: string): ActiveVersionM
           err instanceof Error ? err.message : String(err))
       }
     }
-    if (stillMissing.length > 0 && !missingPackagesWarning) {
-      missingPackagesWarning = [
+    if (stillMissing.length > 0) {
+      const orphanWarning = [
         `The following pip package(s) were installed in a deleted runtime and are missing in the current one:`,
         ...stillMissing.map(p => `  - ${p}`),
         '',
         'To install them, run:',
         `  "${join(target.directory, 'python', process.platform === 'win32' ? 'python.exe' : 'bin', 'python3')}" -m pip install ${stillMissing.join(' ')}`,
       ].join('\n')
-      console.warn(`[runtime] ${missingPackagesWarning}`)
+      if (missingPackagesWarning) {
+        missingPackagesWarning += '\n\n' + orphanWarning
+      } else {
+        missingPackagesWarning = orphanWarning
+      }
+      console.warn(`[runtime] ${orphanWarning}`)
     }
   }
 
@@ -608,7 +613,10 @@ export function deleteInstalledRuntimeVersion(version: string): InstalledRuntime
         .map(p => normalizePkgName(p.name))
         .filter(name => !BASE_PACKAGES.has(name) && !name.startsWith('opentelemetry'))
       if (userPkgs.length > 0 && activeManifest) {
-        activeManifest._orphanedPipPackages = userPkgs
+        // Merge with any existing orphans from previously deleted runtimes
+        // to avoid silent data loss when deleting multiple runtimes in sequence.
+        const existingOrphans = activeManifest._orphanedPipPackages || []
+        activeManifest._orphanedPipPackages = [...new Set([...existingOrphans, ...userPkgs])]
         writeFileSync(activeVersionPath(), JSON.stringify(activeManifest, null, 2) + '\n', 'utf-8')
       }
     } catch (err) {

--- a/packages/server/src/services/runtime-version-manager.ts
+++ b/packages/server/src/services/runtime-version-manager.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'child_process'
 import { createHash } from 'crypto'
 import { createReadStream, createWriteStream, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'fs'
 import { get as httpGet } from 'http'
@@ -447,11 +448,12 @@ interface PipPackageDiff {
 }
 
 function diffUserInstalledPipPackages(
-  oldPythonDir: string,
-  newPythonDir: string,
+  oldRuntimeDir: string,
+  newRuntimeDir: string,
 ): PipPackageDiff {
-  const oldPython = join(oldPythonDir, process.platform === 'win32' ? 'python.exe' : 'bin', 'python3')
-  const newPython = join(newPythonDir, process.platform === 'win32' ? 'python.exe' : 'bin', 'python3')
+  const pythonBin = process.platform === 'win32' ? 'python.exe' : join('bin', 'python3')
+  const oldPython = join(oldRuntimeDir, 'python', pythonBin)
+  const newPython = join(newRuntimeDir, 'python', pythonBin)
   if (!existsSync(oldPython) || !existsSync(newPython)) {
     return { missing: [], previousPythonPath: oldPython }
   }
@@ -467,18 +469,18 @@ function diffUserInstalledPipPackages(
   ])
 
   try {
-    const result = require('child_process').execFileSync(oldPython, [
+    const result = execFileSync(oldPython, [
       '-m', 'pip', 'list', '--format=json', '--disable-pip-version-check'
     ], { encoding: 'utf-8', timeout: 15000, stdio: ['ignore', 'pipe', 'pipe'] })
     const oldPkgs: Array<{ name: string; version: string }> = JSON.parse(result.trim())
 
     const userPkgs = oldPkgs
       .map(p => p.name.toLowerCase())
-      .filter(name => !BASE_PACKAGES.has(name) && !name.startsWith('hindsight') && !name.startsWith('opentelemetry'))
+      .filter(name => !BASE_PACKAGES.has(name) && !name.startsWith('opentelemetry'))
 
     if (userPkgs.length === 0) return { missing: [], previousPythonPath: oldPython }
 
-    const newResult = require('child_process').execFileSync(newPython, [
+    const newResult = execFileSync(newPython, [
       '-m', 'pip', 'list', '--format=json', '--disable-pip-version-check'
     ], { encoding: 'utf-8', timeout: 15000, stdio: ['ignore', 'pipe', 'pipe'] })
     const newPkgs = new Set(
@@ -504,9 +506,7 @@ export function activateInstalledRuntimeVersion(version: string): ActiveVersionM
   // Detect pip packages that existed in the previous runtime but are missing in the new one
   let missingPackagesWarning: string | undefined
   if (active?.runtimeDirectory) {
-    const oldPythonDir = dirname(active.runtimeDirectory)
-    const newPythonDir = dirname(target.directory)
-    const diff = diffUserInstalledPipPackages(oldPythonDir, newPythonDir)
+    const diff = diffUserInstalledPipPackages(active.runtimeDirectory, target.directory)
     if (diff.missing.length > 0) {
       missingPackagesWarning = [
         `The new Hermes runtime is missing ${diff.missing.length} pip package(s) that were installed in the previous runtime:`,

--- a/packages/server/src/services/runtime-version-manager.ts
+++ b/packages/server/src/services/runtime-version-manager.ts
@@ -457,6 +457,21 @@ function normalizePkgName(name: string): string {
   return name.toLowerCase().replace(/[-_.]+/g, '-')
 }
 
+/**
+ * Set of "base" pip packages that ship with every Hermes runtime (known by name).
+ * All entries use the PEP 503 normalized form (lowercase, hyphens).
+ * Kept at module level so both diffUserInstalledPipPackages() and
+ * deleteInstalledRuntimeVersion() can reference it.
+ */
+const BASE_PACKAGES = new Set([
+  'hermes-agent', 'aiohttp', 'httpx', 'fastapi', 'uvicorn', 'pydantic',
+  'pyyaml', 'requests', 'certifi', 'urllib3', 'idna', 'charset-normalizer',
+  'click', 'colorama', 'jinja2', 'rich', 'typer', 'setuptools', 'pip',
+  'websockets', 'cryptography', 'pywin32', 'psutil', 'prompt-toolkit',
+  'python-telegram-bot', 'discord-py', 'slack-sdk', 'slack-bolt',
+  'lark-oapi', 'dingtalk-stream', 'edge-tts', 'pillow',
+])
+
 function diffUserInstalledPipPackages(
   oldRuntimeDir: string,
   newRuntimeDir: string,
@@ -467,17 +482,6 @@ function diffUserInstalledPipPackages(
   if (!existsSync(oldPython) || !existsSync(newPython)) {
     return { missing: [] }
   }
-
-  // Get set of "base" packages that ship with every runtime (known by name)
-  // All entries must use the PEP 503 normalized form (hyphens, lowercase).
-  const BASE_PACKAGES = new Set([
-    'hermes-agent', 'aiohttp', 'httpx', 'fastapi', 'uvicorn', 'pydantic',
-    'pyyaml', 'requests', 'certifi', 'urllib3', 'idna', 'charset-normalizer',
-    'click', 'colorama', 'jinja2', 'rich', 'typer', 'setuptools', 'pip',
-    'websockets', 'cryptography', 'pywin32', 'psutil', 'prompt-toolkit',
-    'python-telegram-bot', 'discord-py', 'slack-sdk', 'slack-bolt',
-    'lark-oapi', 'dingtalk-stream', 'edge-tts', 'pillow',
-  ])
 
   try {
     const result = execFileSync(oldPython, [
@@ -532,15 +536,36 @@ export function activateInstalledRuntimeVersion(version: string): ActiveVersionM
   }
 
   // Also surface orphaned packages from previously deleted runtimes.
-  if (!missingPackagesWarning && active?._orphanedPipPackages?.length) {
-    missingPackagesWarning = [
-      `The following pip package(s) were installed in a deleted runtime and are missing in the current one:`,
-      ...active._orphanedPipPackages.map(p => `  - ${p}`),
-      '',
-      'To install them, run:',
-      `  "${join(target.directory, 'python', process.platform === 'win32' ? 'python.exe' : 'bin', 'python3')}" -m pip install ${active._orphanedPipPackages.join(' ')}`,
-    ].join('\n')
-    console.warn(`[runtime] ${missingPackagesWarning}`)
+  // Validate against the new runtime's pip list to avoid false positives
+  // (e.g. the user already reinstalled them manually).
+  if (active?._orphanedPipPackages?.length) {
+    const pythonBin = process.platform === 'win32' ? 'python.exe' : join('bin', 'python3')
+    const newPythonPath = join(target.directory, 'python', pythonBin)
+    let stillMissing = active._orphanedPipPackages
+    if (existsSync(newPythonPath)) {
+      try {
+        const newResult = execFileSync(newPythonPath, [
+          '-m', 'pip', 'list', '--format=json', '--disable-pip-version-check'
+        ], { encoding: 'utf-8', timeout: 15000, killSignal: 'SIGTERM', stdio: ['ignore', 'pipe', 'pipe'] })
+        const newPkgs = new Set(
+          (JSON.parse(newResult.trim()) as Array<{ name: string }>).map(p => normalizePkgName(p.name))
+        )
+        stillMissing = active._orphanedPipPackages.filter(name => !newPkgs.has(name))
+      } catch (err) {
+        console.error('[runtime] Failed to validate orphaned packages:',
+          err instanceof Error ? err.message : String(err))
+      }
+    }
+    if (stillMissing.length > 0 && !missingPackagesWarning) {
+      missingPackagesWarning = [
+        `The following pip package(s) were installed in a deleted runtime and are missing in the current one:`,
+        ...stillMissing.map(p => `  - ${p}`),
+        '',
+        'To install them, run:',
+        `  "${join(target.directory, 'python', process.platform === 'win32' ? 'python.exe' : 'bin', 'python3')}" -m pip install ${stillMissing.join(' ')}`,
+      ].join('\n')
+      console.warn(`[runtime] ${missingPackagesWarning}`)
+    }
   }
 
   const next: ActiveVersionManifest = {

--- a/packages/server/src/services/runtime-version-manager.ts
+++ b/packages/server/src/services/runtime-version-manager.ts
@@ -471,7 +471,7 @@ function diffUserInstalledPipPackages(
   try {
     const result = execFileSync(oldPython, [
       '-m', 'pip', 'list', '--format=json', '--disable-pip-version-check'
-    ], { encoding: 'utf-8', timeout: 15000, stdio: ['ignore', 'pipe', 'pipe'] })
+    ], { encoding: 'utf-8', timeout: 15000, killSignal: 'SIGTERM', stdio: ['ignore', 'pipe', 'pipe'] })
     const oldPkgs: Array<{ name: string; version: string }> = JSON.parse(result.trim())
 
     const userPkgs = oldPkgs
@@ -482,7 +482,7 @@ function diffUserInstalledPipPackages(
 
     const newResult = execFileSync(newPython, [
       '-m', 'pip', 'list', '--format=json', '--disable-pip-version-check'
-    ], { encoding: 'utf-8', timeout: 15000, stdio: ['ignore', 'pipe', 'pipe'] })
+    ], { encoding: 'utf-8', timeout: 15000, killSignal: 'SIGTERM', stdio: ['ignore', 'pipe', 'pipe'] })
     const newPkgs = new Set(
       (JSON.parse(newResult.trim()) as Array<{ name: string }>).map(p => p.name.toLowerCase())
     )
@@ -520,7 +520,7 @@ export function activateInstalledRuntimeVersion(version: string): ActiveVersionM
   }
 
   const next: ActiveVersionManifest = {
-    schema: 2,
+    schema: 1,
     hermesRuntimeVersion: target.manifestHermesRuntimeVersion || target.version,
     webUiVersion: active?.webUiVersion || getHermesWebUiVersion(),
     runtimeDirectory: target.directory,


### PR DESCRIPTION
## 问题

当用户在 Hermes runtime 的 Python 中通过 pip 安装了额外包（如 `hindsight-all`），然后：

- **场景 A（切换）**：通过 Web UI 切换到不同 runtime 版本——旧 runtime 保留在磁盘，但新 runtime 的 Python 看不到旧 runtime 的 pip 包
- **场景 B（删除）**：通过 Hermes Studio 删除旧版本 runtime（如升级后清理）——旧运行时中的用户 pip 包随目录一同消失，完全无通知

这对 `hindsight-all`（Hindsight 记忆插件）影响尤其严重——删除旧 runtime 后用户的记忆系统静默停止工作。

## 修复方案

### 切换时检测（`activateInstalledRuntimeVersion`）
激活新 runtime 时对比新旧 Python 的 `pip list --format=json`，找出旧有但新无的用户包。

### 删除时记录（`deleteInstalledRuntimeVersion`）
`rmSync` 前先跑 `pip list`，提取用户安装的包，持久化写入 `active-version.json` 的 `_orphanedPipPackages` 字段。删除多个 runtime 时自动合并去重。激活时读取代为检测（旧 Python 已不存在），并自动清理已解决的孤儿包。

### 包名规范化
按 PEP 503 规范化（`slack_sdk` → `slack-sdk`），确保 `pip list --format=json` 返回的原始包名与 `BASE_PACKAGES` 条目精确匹配。

## 审查历史（4 轮对抗性审查）

| # | 审查方式 | 发现 | 修复 |
|---|---------|------|------|
| 1 | 人工 | 🔴 路径错误、🔴 hindsight 排除、schema bump、缺 killSignal | `6d33f92` `505fb15` |
| 2 | 人工（实际数据验证） | 🔴 PEP 503 未规范化、死代码、catch 静默 | `7cf09a8` |
| 3 | 子代理 | 🟡 未处理删除场景、🔴 BASE_PACKAGES 作用域越界 | `ef42b7ab` `11567c0` |
| 4 | 子代理 | 🔴 连续删除覆盖孤儿包、🟡 警告互斥、孤儿包重复 | `7af32bb` |

共 7 个 commits，发现并修复了 **3 个 🔴 严重缺陷、5 个 🟡 重要问题、2 个 🟠 轻微问题**，无剩余已知问题。

## 相关 Issue

Closes #1922