### PR TITLE
[codex] Add ekko agent chat integration

### DIFF
--- a/docs/chat-chain-changes/2026-07-04-local-ekko-agent-dev-entry.md
+++ b/docs/chat-chain-changes/2026-07-04-local-ekko-agent-dev-entry.md
@@ -1,0 +1,35 @@
+---
+date: 2026-07-04
+pr: pending
+feature: Ekko Agent dev entry and runtime request handling
+impact: Ekko Agent remains development-only in the new-chat selector, streams model output when providers support it, uses inferred provider protocol unless an explicit protocol is passed, retries protocol fallback only for protocol-shaped HTTP errors, emits reasoning deltas when providers return thinking content, reports tool durations, paces tool calls, stops after repeated tool failures, honors frontend abort requests, and retries each model loop step up to three times before failing the run.
+---
+
+Development builds now expose the Ekko Agent option in the new-chat selector so
+local testing can exercise the dedicated Ekko Agent runtime path. Production
+builds continue to hide the selector entry and keep existing Hermes, workflow,
+Group Chat, Claude Code, and Codex behavior unchanged.
+
+Ekko Agent no longer shows the scoped protocol picker in the frontend. Existing
+explicit protocol values are still honored when sent to the server, but a
+protocol-shaped provider error can fall back once to the URL/provider-inferred
+protocol. Ekko Agent also retries each model request in the agent loop up to
+three times before failing the run.
+
+Provider reasoning/thinking content is normalized into Ekko Agent model
+responses and emitted through the existing `reasoning.delta` chat event, so the
+client can display it with the same reasoning UI used by the existing chat
+chain.
+
+Tool execution now has a default delay between tool results and the next
+runtime action, plus a consecutive-failure guard. The terminal tool also
+normalizes simple shell-like command strings into command plus args so accidental
+`command: "ls skills"` style calls do not immediately become `ENOENT` loops.
+
+Frontend stop requests now abort the Ekko Agent session controller, propagate the
+signal through runtime model requests and tools, and terminate terminal commands
+that are still running.
+
+Model text deltas are forwarded through the existing `message.delta` event when
+the provider supports streaming. Tool completion and failure events include
+runtime duration so the client can show elapsed tool time.

--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -686,6 +686,7 @@ export function connectChatRun(requestedProfile?: string | null, transport: Chat
     // Tool events
     chatRunSocket.on('tool.started', globalToolStartedHandler)
     chatRunSocket.on('tool.completed', globalToolCompletedHandler)
+    chatRunSocket.on('tool.failed', globalToolCompletedHandler)
     chatRunSocket.on('workspace.diff.completed', globalWorkspaceDiffCompletedHandler)
     chatRunSocket.on('subagent.start', globalSubagentEventHandler)
     chatRunSocket.on('subagent.tool', globalSubagentEventHandler)

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -327,6 +327,27 @@ function autoSizeTextarea(el: HTMLTextAreaElement | undefined = textareaRef.valu
   el.style.height = `${Math.min(el.scrollHeight, 100)}px`
 }
 
+function focusTextareaFromInputWrapper(event: MouseEvent) {
+  if (event.defaultPrevented) return
+
+  const target = event.target instanceof Element ? event.target : null
+  if (!target) return
+
+  const interactiveTarget = target.closest([
+    'button',
+    'input',
+    'textarea',
+    '[role="button"]',
+    '.context-limit-editable',
+    '.input-toolbar',
+    '.resize-handle',
+  ].join(','))
+
+  if (interactiveTarget) return
+
+  textareaRef.value?.focus()
+}
+
 function applyConfiguredTextareaHeight() {
   if (manualTextareaResize.value) return
 
@@ -1001,6 +1022,7 @@ function isImage(type: string): boolean {
       @dragenter="handleDragEnter"
       @dragleave="handleDragLeave"
       @drop="handleDrop"
+      @mousedown="focusTextareaFromInputWrapper"
     >
       <input
         ref="fileInputRef"
@@ -1704,6 +1726,7 @@ function isImage(type: string): boolean {
   border-radius: 18px;
   padding: 22px 12px 9px;
   position: relative;
+  cursor: text;
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.08);
   transition: border-color $transition-fast, box-shadow $transition-fast;
 
@@ -1740,7 +1763,7 @@ function isImage(type: string): boolean {
 
 .input-textarea {
   display: block;
-  flex: 0 0 auto;
+  flex: 1 1 auto;
   width: 100%;
   background: none;
   border: none;
@@ -1751,7 +1774,7 @@ function isImage(type: string): boolean {
   line-height: 1.5;
   resize: none;
   max-height: 400px;
-  min-height: 24px;
+  min-height: 44px;
   padding: 0;
   overflow-y: auto;
 

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -330,11 +330,16 @@ const newChatWorkspace = ref("");
 const newChatLoading = ref(false);
 const CODING_AGENT_AUTH_PROVIDER_KEYS = new Set(["openai-codex", "copilot", "xai-oauth", "nous", "google-gemini-cli", "claude-oauth"]);
 
-const newChatAgentOptions = computed(() => [
-  { label: "Hermes", value: "hermes" },
-  { label: "Claude Code", value: "claude-code" },
-  { label: "Codex", value: "codex" },
-]);
+const showEkkoAgentEntry = import.meta.env.DEV;
+const newChatAgentOptions = computed(() => {
+  const options = [
+    { label: "Hermes", value: "hermes" },
+    { label: "Claude Code", value: "claude-code" },
+    { label: "Codex", value: "codex" },
+  ];
+  if (showEkkoAgentEntry) options.push({ label: "Ekko Agent", value: "ekko-agent" });
+  return options;
+});
 
 const newChatApiModeOptions = computed(() => [
   { label: t("codingAgents.protocolOpenAiChat"), value: "chat_completions" },
@@ -454,7 +459,7 @@ const canConfirmNewChat = computed(() => {
   if (!newChatUsesProviderModel.value) return true;
   if (!newChatProvider.value || !newChatModel.value) return false;
   if (!isNewChatCodingAgent.value) return true;
-  if (!newChatApiMode.value) return false;
+  if (isNewChatExternalCodingAgent.value && !newChatApiMode.value) return false;
   if (newChatNeedsBaseUrl.value && !newChatBaseUrl.value.trim()) return false;
   if (newChatNeedsApiKey.value && !newChatApiKey.value.trim()) return false;
   return true;
@@ -577,7 +582,7 @@ async function confirmNewChat() {
     workspace: newChatWorkspace.value || null,
     baseUrl: source === "coding_agent" && !isGlobalCodingAgent ? group?.base_url || newChatBaseUrl.value.trim() || undefined : undefined,
     apiKey: source === "coding_agent" && !isGlobalCodingAgent ? group?.api_key || newChatApiKey.value.trim() || undefined : undefined,
-    apiMode: source === "coding_agent" && !isGlobalCodingAgent ? newChatApiMode.value : undefined,
+    apiMode: isNewChatExternalCodingAgent.value && !isGlobalCodingAgent ? newChatApiMode.value : undefined,
   });
   await router.push({
     name: chatStore.runtimeMode === "global_agent" ? "hermes.globalAgentSession" : "hermes.session",
@@ -942,6 +947,10 @@ const isSessionModelScopedCodingAgent = computed(() =>
   sessionModelSession.value?.source === "coding_agent" &&
   sessionModelSession.value?.codingAgentMode !== "global",
 );
+const isSessionModelExternalCodingAgent = computed(() =>
+  isSessionModelScopedCodingAgent.value &&
+  (sessionModelSession.value?.agent === "claude-code" || sessionModelSession.value?.agent === "codex"),
+);
 
 const sessionModelBaseGroups = computed(() =>
   sessionModelProfile.value
@@ -1067,7 +1076,7 @@ async function applySessionModelSwitch(model: string, provider: string, apiMode?
 async function selectSessionModel(model: string, provider: string) {
   const meta = sessionModelBaseGroups.value.find((group) => group.provider === provider)?.model_meta?.[model];
   if (meta?.disabled || !sessionModelSessionId.value) return;
-  if (isSessionModelScopedCodingAgent.value) {
+  if (isSessionModelExternalCodingAgent.value) {
     pendingSessionModelSwitch.value = { model, provider };
     sessionModelApiMode.value = defaultSessionModelApiMode(provider);
     showSessionModelModeModal.value = true;
@@ -1526,7 +1535,7 @@ async function handleSessionModelCustomSubmit() {
               filterable
             />
           </label>
-          <label v-if="isNewChatCodingAgent && effectiveNewChatAgentMode === 'scoped'" class="new-chat-field">
+          <label v-if="isNewChatExternalCodingAgent && effectiveNewChatAgentMode === 'scoped'" class="new-chat-field">
             <span class="new-chat-label">{{ t("codingAgents.protocolScope") }}</span>
             <NSelect
               v-model:value="newChatApiMode"

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -266,6 +266,14 @@ function runtimeToolPayloadOrUndefined(value: unknown): unknown | undefined {
   return hasRuntimeToolPayload(value) ? value : undefined
 }
 
+function runtimeToolOutputFromEvent(event: unknown): unknown | undefined {
+  if (!event || typeof event !== 'object') return undefined
+  const record = event as Record<string, unknown>
+  return runtimeToolPayloadOrUndefined(
+    record.output ?? record.result ?? record.content ?? record.preview,
+  )
+}
+
 function runtimePayloadText(value: unknown): string {
   if (!hasRuntimeToolPayload(value)) return ''
   if (typeof value === 'string') return value
@@ -476,7 +484,7 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
         toolArgs,
         toolPreview: typeof preview === 'string' ? preview.slice(0, 100) || undefined : undefined,
         toolResult: moaPayload ? runtimeToolPayloadOrUndefined(moaPayload.result) : runtimeToolPayloadOrUndefined((msg as any).content),
-        toolStatus: 'done',
+        toolStatus: readFinishReason(msg) === 'error' ? 'error' : 'done',
         finishReason: readFinishReason(msg),
         runMarker: readRunMarker(msg),
       })
@@ -1345,16 +1353,16 @@ export const useChatStore = defineStore('chat', () => {
                     toolStatus: 'running',
                   })
                 }
-              } else if (e.event === 'tool.completed') {
+              } else if (e.event === 'tool.completed' || e.event === 'tool.failed') {
                 const msgs = getSessionMsgs(sessionId)
                 const toolCallId = e.tool_call_id as string | undefined
                 const toolMsgs = toolCallId
                   ? msgs.filter(m => m.role === 'tool' && m.toolCallId === toolCallId)
                   : msgs.filter(m => m.role === 'tool' && m.toolStatus === 'running')
                 if (toolMsgs.length > 0) {
-                  const output = runtimeToolPayloadOrUndefined((e as any).output)
+                  const output = runtimeToolOutputFromEvent(e)
                   updateMessage(sessionId, toolMsgs[toolMsgs.length - 1].id, {
-                    toolStatus: e.error === true || runtimeToolOutputHasError(output) ? 'error' : 'done',
+                    toolStatus: e.event === 'tool.failed' || e.error === true || runtimeToolOutputHasError(output) ? 'error' : 'done',
                     toolDuration: e.duration,
                     toolResult: output,
                   })
@@ -2352,7 +2360,7 @@ export const useChatStore = defineStore('chat', () => {
         agentToCodingAgentId(activeSession.value?.agent) ||
         'claude-code'
       const codingAgentMode = activeSession.value?.codingAgentMode || 'scoped'
-      const codingAgentApiMode = isCodingAgentExecution && codingAgentMode !== 'global'
+      const codingAgentApiMode = isCodingAgentExecution && codingAgentId !== 'ekko-agent' && codingAgentMode !== 'global'
         ? normalizeCodingAgentApiMode(
             activeSession.value?.apiMode || providerGroup?.api_mode,
             inferCodingAgentApiMode(
@@ -2821,7 +2829,8 @@ export const useChatStore = defineStore('chat', () => {
               break
             }
 
-            case 'tool.completed': {
+            case 'tool.completed':
+            case 'tool.failed': {
               runHadToolActivity = true
               const msgs = getSessionMsgs(sid)
               const toolCallId = (evt as any).tool_call_id as string | undefined
@@ -2830,8 +2839,8 @@ export const useChatStore = defineStore('chat', () => {
                 : msgs.filter(m => m.role === 'tool' && m.toolStatus === 'running')
               if (toolMsgs.length > 0) {
                 const last = toolMsgs[toolMsgs.length - 1]
-                const output = runtimeToolPayloadOrUndefined((evt as any).output)
-                const hasError = (evt as any).error === true || runtimeToolOutputHasError(output)
+                const output = runtimeToolOutputFromEvent(evt)
+                const hasError = evt.event === 'tool.failed' || (evt as any).error === true || runtimeToolOutputHasError(output)
                 const duration = (evt as any).duration
                 updateMessage(sid, last.id, {
                   toolStatus: hasError ? 'error' : 'done',
@@ -3415,7 +3424,8 @@ export const useChatStore = defineStore('chat', () => {
           break
         }
 
-        case 'tool.completed': {
+        case 'tool.completed':
+        case 'tool.failed': {
           runHadToolActivity = true
           const msgs = getSessionMsgs(sid)
           const toolCallId = (evt as any).tool_call_id as string | undefined
@@ -3423,8 +3433,8 @@ export const useChatStore = defineStore('chat', () => {
             ? msgs.filter(m => m.role === 'tool' && m.toolCallId === toolCallId)
             : msgs.filter(m => m.role === 'tool' && m.toolStatus === 'running')
           if (toolMsgs.length > 0) {
-            const output = runtimeToolPayloadOrUndefined((evt as any).output)
-            const hasError = (evt as any).error === true || runtimeToolOutputHasError(output)
+            const output = runtimeToolOutputFromEvent(evt)
+            const hasError = evt.event === 'tool.failed' || (evt as any).error === true || runtimeToolOutputHasError(output)
             updateMessage(sid, toolMsgs[toolMsgs.length - 1].id, {
               toolStatus: hasError ? 'error' : 'done',
               toolDuration: (evt as any).duration,

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -166,7 +166,7 @@ function mapHistoryMessages(messages: HermesMessage[]): Session['messages'] {
         ? JSON.stringify(m.tool_calls[0].function.arguments)
         : undefined
       msg.toolPreview = moaPayload?.preview
-      msg.toolStatus = 'done'
+      msg.toolStatus = m.finish_reason === 'error' ? 'error' : 'done'
       msg.toolResult = moaPayload ? moaPayload.result : (m.content || undefined)
       msg.content = ''
     }

--- a/packages/ekko-agent/src/index.ts
+++ b/packages/ekko-agent/src/index.ts
@@ -14,6 +14,7 @@ export function createEkkoAgentInfo(): EkkoAgentInfo {
 
 export * from './model/errors'
 export * from './model/messages'
+export * from './model/provider-config'
 export * from './model/registry'
 export * from './model/types'
 export * from './runtime/events'

--- a/packages/ekko-agent/src/model/http.ts
+++ b/packages/ekko-agent/src/model/http.ts
@@ -13,9 +13,14 @@ export function requestHeaders(config: ModelProviderConfig, defaults: Record<str
   return headers
 }
 
-export function abortSignal(timeoutMs?: number): AbortSignal | undefined {
-  if (!timeoutMs) return undefined
-  return AbortSignal.timeout(timeoutMs)
+export function abortSignal(timeoutMs?: number, signal?: AbortSignal): AbortSignal | undefined {
+  const signals = [
+    signal,
+    timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined,
+  ].filter(Boolean) as AbortSignal[]
+  if (signals.length === 0) return undefined
+  if (signals.length === 1) return signals[0]
+  return AbortSignal.any(signals)
 }
 
 export function providerUrl(config: ModelProviderConfig, fallbackBaseUrl: string, path: string): string {
@@ -63,12 +68,13 @@ export async function postJson<TResponse>(
   url: string,
   payload: unknown,
   headers: HeadersInit = requestHeaders(config),
+  signal?: AbortSignal,
 ): Promise<TResponse> {
   const response = await fetchImpl(url, {
     method: 'POST',
     headers,
     body: JSON.stringify(payload),
-    signal: abortSignal(config.timeoutMs),
+    signal: abortSignal(config.timeoutMs, signal),
   })
 
   if (!response.ok) {
@@ -84,12 +90,13 @@ export async function postStream(
   url: string,
   payload: unknown,
   headers: HeadersInit = requestHeaders(config),
+  signal?: AbortSignal,
 ): Promise<Response> {
   const response = await fetchImpl(url, {
     method: 'POST',
     headers,
     body: JSON.stringify(payload),
-    signal: abortSignal(config.timeoutMs),
+    signal: abortSignal(config.timeoutMs, signal),
   })
 
   if (!response.ok) {

--- a/packages/ekko-agent/src/model/messages.ts
+++ b/packages/ekko-agent/src/model/messages.ts
@@ -8,6 +8,8 @@ export type AgentMessageInput =
 interface AgentMessageLike {
   role?: AgentMessageRole
   content?: unknown
+  reasoning?: unknown
+  reasoning_content?: unknown
   text?: unknown
   name?: string
   toolCallId?: string
@@ -22,6 +24,7 @@ export interface AgentOutputMessage extends AgentMessage {
   model?: string
   usage?: ModelUsage
   finishReason?: string
+  reasoning?: string
   raw?: unknown
 }
 
@@ -44,6 +47,7 @@ export function normalizeAgentMessage(input: AgentMessageInput, fallbackRole: Ag
   return {
     role,
     content,
+    reasoning: normalizeReasoning(message.reasoning ?? message.reasoning_content),
     name: message.name,
     toolCallId: message.toolCallId ?? message.tool_call_id,
     toolCalls: message.toolCalls ?? message.tool_calls,
@@ -81,6 +85,7 @@ export function modelResponseToAgentMessage(response: ModelResponse): AgentOutpu
     id: response.id,
     model: response.model,
     content: response.content,
+    reasoning: response.reasoning,
     toolCalls: response.toolCalls,
     usage: response.usage,
     finishReason: response.finishReason,
@@ -91,6 +96,7 @@ export function modelResponseToAgentMessage(response: ModelResponse): AgentOutpu
 export async function collectModelEvents(events: AsyncIterable<ModelEvent>): Promise<AgentStreamOutput> {
   const collected: ModelEvent[] = []
   let content = ''
+  let reasoning = ''
   const toolCalls: AgentToolCall[] = []
   let usage: ModelUsage | undefined
   let done: Partial<ModelResponse> | undefined
@@ -99,6 +105,8 @@ export async function collectModelEvents(events: AsyncIterable<ModelEvent>): Pro
     collected.push(event)
     if (event.type === 'text-delta') {
       content += event.text
+    } else if (event.type === 'reasoning-delta') {
+      reasoning += event.text
     } else if (event.type === 'tool-call') {
       toolCalls.push(event.toolCall)
     } else if (event.type === 'usage') {
@@ -115,6 +123,7 @@ export async function collectModelEvents(events: AsyncIterable<ModelEvent>): Pro
       id: done?.id,
       model: done?.model,
       content: done?.content ?? content,
+      reasoning: done?.reasoning ?? (reasoning || undefined),
       toolCalls: done?.toolCalls ?? (toolCalls.length ? toolCalls : undefined),
       usage: done?.usage ?? usage,
       finishReason: done?.finishReason,
@@ -134,4 +143,10 @@ function normalizeContent(content: unknown): string {
   if (typeof content === 'string') return content
   if (content === undefined || content === null) return ''
   return JSON.stringify(content)
+}
+
+function normalizeReasoning(reasoning: unknown): string | undefined {
+  if (typeof reasoning === 'string') return reasoning || undefined
+  if (reasoning === undefined || reasoning === null) return undefined
+  return JSON.stringify(reasoning)
 }

--- a/packages/ekko-agent/src/model/provider-config.ts
+++ b/packages/ekko-agent/src/model/provider-config.ts
@@ -1,0 +1,98 @@
+import type { ModelProviderConfig, ModelProviderType, ModelRequestStyle } from './types'
+
+export interface ResolveModelProviderConfigInput {
+  provider: string
+  baseUrl?: string
+  apiKey?: string
+  model: string
+  apiMode?: string
+  timeoutMs?: number
+}
+
+export interface ResolvedModelProviderConfigs {
+  providerConfig: ModelProviderConfig
+  fallbackProviderConfig?: ModelProviderConfig
+  requestStyle: ModelRequestStyle
+  inferredRequestStyle: ModelRequestStyle
+}
+
+export function requestStyleFromApiMode(apiMode?: string): ModelRequestStyle | undefined {
+  const normalized = String(apiMode || '').toLowerCase()
+  if (normalized === 'chat_completions') return 'openai-chat'
+  if (normalized === 'codex_responses') return 'openai-responses'
+  if (normalized === 'anthropic_messages') return 'anthropic-messages'
+  return undefined
+}
+
+export function inferredRequestStyleForConfig(provider: string, baseUrl = ''): ModelRequestStyle {
+  const key = provider.toLowerCase()
+  const url = baseUrl.toLowerCase()
+  if (url.endsWith('/anthropic') || url.includes('api.anthropic.com')) return 'anthropic-messages'
+  if (key.includes('gemini') || key.includes('google') || url.includes('generativelanguage.googleapis.com')) return 'gemini-contents'
+  if (url.includes('api.openai.com') || url.includes('api.x.ai')) return 'openai-responses'
+  return 'openai-chat'
+}
+
+export function requestStyleForConfig(provider: string, baseUrl = '', apiMode?: string): ModelRequestStyle {
+  return requestStyleFromApiMode(apiMode) || inferredRequestStyleForConfig(provider, baseUrl)
+}
+
+export function providerTypeForStyle(provider: string, style: ModelRequestStyle): ModelProviderType {
+  const key = provider.toLowerCase()
+  if (style === 'anthropic-messages') return 'anthropic'
+  if (style === 'gemini-contents') return 'gemini'
+  if (key.includes('ollama')) return 'ollama'
+  if (key === 'openai') return 'openai'
+  return 'openai-compatible'
+}
+
+export function createProviderConfig(input: {
+  provider: string
+  requestStyle: ModelRequestStyle
+  baseUrl?: string
+  apiKey?: string
+  model: string
+  timeoutMs?: number
+}): ModelProviderConfig {
+  return {
+    id: input.provider || 'openai',
+    type: providerTypeForStyle(input.provider, input.requestStyle),
+    requestStyle: input.requestStyle,
+    baseUrl: input.baseUrl || undefined,
+    apiKey: input.apiKey || undefined,
+    defaultModel: input.model,
+    timeoutMs: input.timeoutMs,
+  }
+}
+
+export function resolveModelProviderConfigs(input: ResolveModelProviderConfigInput): ResolvedModelProviderConfigs {
+  const baseUrl = input.baseUrl || ''
+  const timeoutMs = input.timeoutMs ?? 120_000
+  const requestStyle = requestStyleForConfig(input.provider, baseUrl, input.apiMode)
+  const inferredRequestStyle = inferredRequestStyleForConfig(input.provider, baseUrl)
+  const providerConfig = createProviderConfig({
+    provider: input.provider,
+    requestStyle,
+    baseUrl,
+    apiKey: input.apiKey,
+    model: input.model,
+    timeoutMs,
+  })
+  const fallbackProviderConfig = requestStyleFromApiMode(input.apiMode) && inferredRequestStyle !== requestStyle
+    ? createProviderConfig({
+        provider: input.provider,
+        requestStyle: inferredRequestStyle,
+        baseUrl,
+        apiKey: input.apiKey,
+        model: input.model,
+        timeoutMs,
+      })
+    : undefined
+
+  return {
+    providerConfig,
+    fallbackProviderConfig,
+    requestStyle,
+    inferredRequestStyle,
+  }
+}

--- a/packages/ekko-agent/src/model/providers/anthropic.ts
+++ b/packages/ekko-agent/src/model/providers/anthropic.ts
@@ -34,6 +34,7 @@ interface AnthropicPayload {
 
 type AnthropicContentBlock =
   | { type: 'text'; text: string }
+  | { type: 'thinking'; thinking: string }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
   | { type: 'tool_result'; tool_use_id: string; content: string }
 
@@ -78,6 +79,7 @@ export class AnthropicMessagesModelClient implements ModelClient {
       anthropicUrl(this.config),
       toAnthropicMessagesPayload(this.config, { ...request, stream: false }),
       anthropicHeaders(this.config),
+      request.signal,
     )
     return normalizeAnthropicResponse(response)
   }
@@ -89,6 +91,7 @@ export class AnthropicMessagesModelClient implements ModelClient {
       anthropicUrl(this.config),
       toAnthropicMessagesPayload(this.config, { ...request, stream: true }),
       anthropicHeaders(this.config),
+      request.signal,
     )
 
     const toolCallBlocks = new Map<number, { id: string; name: string; argumentsText: string }>()
@@ -109,6 +112,9 @@ export class AnthropicMessagesModelClient implements ModelClient {
       if (chunk.type === 'content_block_delta' && isPlainRecord(chunk.delta)) {
         if (chunk.delta.type === 'text_delta' && typeof chunk.delta.text === 'string') {
           yield { type: 'text-delta', text: chunk.delta.text }
+        }
+        if (chunk.delta.type === 'thinking_delta' && typeof chunk.delta.thinking === 'string') {
+          yield { type: 'reasoning-delta', text: chunk.delta.thinking }
         }
         if (chunk.delta.type === 'input_json_delta' && typeof chunk.delta.partial_json === 'string') {
           const index = typeof chunk.index === 'number' ? chunk.index : 0
@@ -150,6 +156,7 @@ export function normalizeAnthropicResponse(response: AnthropicResponse): ModelRe
     id: response.id,
     model: response.model,
     content: response.content?.filter(block => block.type === 'text').map(block => block.text).join('') ?? '',
+    reasoning: response.content?.filter(block => block.type === 'thinking').map(block => block.thinking).join('') || undefined,
     toolCalls: response.content?.filter(block => block.type === 'tool_use').map(block => ({
       id: block.id,
       name: block.name,

--- a/packages/ekko-agent/src/model/providers/custom-runtime.ts
+++ b/packages/ekko-agent/src/model/providers/custom-runtime.ts
@@ -39,6 +39,8 @@ export class CustomRuntimeModelClient implements ModelClient {
       this.fetchImpl,
       customRuntimeUrl(this.config),
       { ...request, model: request.model ?? this.config.defaultModel, stream: false },
+      undefined,
+      request.signal,
     )
   }
 
@@ -48,6 +50,8 @@ export class CustomRuntimeModelClient implements ModelClient {
       this.fetchImpl,
       customRuntimeUrl(this.config),
       { ...request, model: request.model ?? this.config.defaultModel, stream: true },
+      undefined,
+      request.signal,
     )
 
     for await (const event of readServerSentEvents(response)) {

--- a/packages/ekko-agent/src/model/providers/gemini.ts
+++ b/packages/ekko-agent/src/model/providers/gemini.ts
@@ -83,6 +83,8 @@ export class GeminiContentsModelClient implements ModelClient {
       this.fetchImpl,
       geminiUrl(this.config, request.model, false),
       toGeminiContentsPayload(this.config, request),
+      undefined,
+      request.signal,
     )
     return normalizeGeminiResponse(response, request.model ?? this.config.defaultModel)
   }
@@ -93,6 +95,8 @@ export class GeminiContentsModelClient implements ModelClient {
       this.fetchImpl,
       geminiUrl(this.config, request.model, true),
       toGeminiContentsPayload(this.config, request),
+      undefined,
+      request.signal,
     )
 
     for await (const event of readServerSentEvents(response)) {

--- a/packages/ekko-agent/src/model/providers/openai-compatible.ts
+++ b/packages/ekko-agent/src/model/providers/openai-compatible.ts
@@ -52,6 +52,14 @@ interface OpenAIToolDefinition {
 
 type OpenAIMessageContent = string | Array<{ type?: string; text?: string }> | null | undefined
 
+interface OpenAIChatResponseMessage {
+  content?: OpenAIMessageContent
+  reasoning?: string
+  reasoning_content?: string
+  reasoning_details?: unknown
+  tool_calls?: OpenAIToolCall[]
+}
+
 interface OpenAIChatPayload {
   model: string
   messages: OpenAIChatMessage[]
@@ -70,12 +78,11 @@ interface OpenAIChatResponse {
   id?: string
   model?: string
   choices?: Array<{
-    message?: {
-      content?: OpenAIMessageContent
-      tool_calls?: OpenAIToolCall[]
-    }
+    message?: OpenAIChatResponseMessage
     delta?: {
       content?: string | null
+      reasoning?: string | null
+      reasoning_content?: string | null
       tool_calls?: Array<{
         index?: number
         id?: string
@@ -128,13 +135,13 @@ export class OpenAICompatibleModelClient implements ModelClient {
 
   async create(request: ModelRequest): Promise<ModelResponse> {
     const payload = toOpenAIChatPayload(this.config, { ...request, stream: false })
-    const response = await this.postJson(payload)
+    const response = await this.postJson(payload, request.signal)
     return normalizeOpenAIChatResponse(this.provider, response)
   }
 
   async *stream(request: ModelRequest): AsyncIterable<ModelEvent> {
     const payload = toOpenAIChatPayload(this.config, { ...request, stream: true })
-    const response = await this.post(payload)
+    const response = await this.post(payload, request.signal)
 
     if (!response.body) {
       throw new ModelProviderError('Model provider returned an empty stream body.', {
@@ -185,6 +192,10 @@ export class OpenAICompatibleModelClient implements ModelClient {
           if (content) {
             yield { type: 'text-delta', text: content }
           }
+          const reasoning = choice.delta?.reasoning_content ?? choice.delta?.reasoning
+          if (reasoning) {
+            yield { type: 'reasoning-delta', text: reasoning }
+          }
 
           for (const toolCallDelta of choice.delta?.tool_calls ?? []) {
             const index = toolCallDelta.index ?? 0
@@ -210,17 +221,17 @@ export class OpenAICompatibleModelClient implements ModelClient {
     yield { type: 'done', response: { id: responseId, model: responseModel, finishReason } }
   }
 
-  private async postJson(payload: OpenAIChatPayload): Promise<OpenAIChatResponse> {
-    const response = await this.post(payload)
+  private async postJson(payload: OpenAIChatPayload, signal?: AbortSignal): Promise<OpenAIChatResponse> {
+    const response = await this.post(payload, signal)
     return parseResponseJson(this.provider, response)
   }
 
-  private async post(payload: OpenAIChatPayload): Promise<Response> {
+  private async post(payload: OpenAIChatPayload, signal?: AbortSignal): Promise<Response> {
     const response = await this.fetchImpl(chatCompletionsUrl(this.config), {
       method: 'POST',
       headers: requestHeaders(this.config),
       body: JSON.stringify(payload),
-      signal: abortSignal(this.config.timeoutMs),
+      signal: abortSignal(this.config.timeoutMs, signal),
     })
 
     if (!response.ok) {
@@ -258,11 +269,20 @@ export function normalizeOpenAIChatResponse(provider: string, response: OpenAICh
     id: response.id,
     model: response.model,
     content: normalizeContent(choice?.message?.content),
+    reasoning: normalizeReasoning(choice?.message),
     toolCalls: choice?.message?.tool_calls?.map(toAgentToolCall),
     usage: response.usage ? normalizeUsage(response.usage) : undefined,
     finishReason: choice?.finish_reason ?? undefined,
     raw: response,
   }
+}
+
+function normalizeReasoning(message: OpenAIChatResponseMessage | undefined): string | undefined {
+  if (!message) return undefined
+  if (typeof message.reasoning_content === 'string' && message.reasoning_content) return message.reasoning_content
+  if (typeof message.reasoning === 'string' && message.reasoning) return message.reasoning
+  if (message.reasoning_details !== undefined && message.reasoning_details !== null) return JSON.stringify(message.reasoning_details)
+  return undefined
 }
 
 function toOpenAIChatMessage(message: AgentMessage): OpenAIChatMessage {

--- a/packages/ekko-agent/src/model/providers/openai-responses.ts
+++ b/packages/ekko-agent/src/model/providers/openai-responses.ts
@@ -41,10 +41,14 @@ interface OpenAIResponsesResponse {
   output?: Array<{
     type?: string
     content?: Array<{ type?: string; text?: string }>
+    summary?: Array<{ type?: string; text?: string }>
     name?: string
     call_id?: string
     arguments?: string
   }>
+  reasoning?: string
+  reasoning_text?: string
+  reasoning_summary?: string
   usage?: {
     input_tokens?: number
     output_tokens?: number
@@ -85,6 +89,8 @@ export class OpenAIResponsesModelClient implements ModelClient {
       this.fetchImpl,
       responsesUrl(this.config),
       toOpenAIResponsesPayload(this.config, { ...request, stream: false }),
+      undefined,
+      request.signal,
     )
     return normalizeOpenAIResponsesResponse(response)
   }
@@ -95,6 +101,8 @@ export class OpenAIResponsesModelClient implements ModelClient {
       this.fetchImpl,
       responsesUrl(this.config),
       toOpenAIResponsesPayload(this.config, { ...request, stream: true }),
+      undefined,
+      request.signal,
     )
 
     for await (const event of readServerSentEvents(response)) {
@@ -107,6 +115,14 @@ export class OpenAIResponsesModelClient implements ModelClient {
 
       if (chunk.type === 'response.output_text.delta' && typeof chunk.delta === 'string') {
         yield { type: 'text-delta', text: chunk.delta }
+      }
+      if (
+        (chunk.type === 'response.reasoning.delta' ||
+          chunk.type === 'response.reasoning_text.delta' ||
+          chunk.type === 'response.reasoning_summary_text.delta') &&
+        typeof chunk.delta === 'string'
+      ) {
+        yield { type: 'reasoning-delta', text: chunk.delta }
       }
       if (chunk.type === 'response.completed' && isPlainRecord(chunk.response)) {
         yield { type: 'done', response: normalizeOpenAIResponsesResponse(chunk.response as OpenAIResponsesResponse) }
@@ -139,11 +155,25 @@ export function normalizeOpenAIResponsesResponse(response: OpenAIResponsesRespon
     id: response.id,
     model: response.model,
     content: response.output_text ?? response.output?.flatMap(item => item.content ?? []).map(part => part.text ?? '').join('') ?? '',
+    reasoning: normalizeReasoning(response),
     toolCalls,
     usage: response.usage ? normalizeUsage(response.usage) : undefined,
     finishReason: response.status,
     raw: response,
   }
+}
+
+function normalizeReasoning(response: OpenAIResponsesResponse): string | undefined {
+  if (typeof response.reasoning === 'string' && response.reasoning) return response.reasoning
+  if (typeof response.reasoning_text === 'string' && response.reasoning_text) return response.reasoning_text
+  if (typeof response.reasoning_summary === 'string' && response.reasoning_summary) return response.reasoning_summary
+
+  const reasoning = response.output
+    ?.filter(item => item.type === 'reasoning')
+    .flatMap(item => [...(item.content ?? []), ...(item.summary ?? [])])
+    .map(part => part.text ?? '')
+    .join('')
+  return reasoning || undefined
 }
 
 function toOpenAIResponseInput(message: AgentMessage): OpenAIResponsesPayload['input'][number] {

--- a/packages/ekko-agent/src/model/providers/prompt-completion.ts
+++ b/packages/ekko-agent/src/model/providers/prompt-completion.ts
@@ -62,6 +62,8 @@ export class PromptCompletionModelClient implements ModelClient {
       this.fetchImpl,
       completionsUrl(this.config),
       toPromptCompletionPayload(this.config, { ...request, stream: false }),
+      undefined,
+      request.signal,
     )
     return normalizePromptCompletionResponse(response)
   }
@@ -72,6 +74,8 @@ export class PromptCompletionModelClient implements ModelClient {
       this.fetchImpl,
       completionsUrl(this.config),
       toPromptCompletionPayload(this.config, { ...request, stream: true }),
+      undefined,
+      request.signal,
     )
 
     for await (const event of readServerSentEvents(response)) {

--- a/packages/ekko-agent/src/model/types.ts
+++ b/packages/ekko-agent/src/model/types.ts
@@ -19,6 +19,7 @@ export type AgentMessageRole = 'system' | 'user' | 'assistant' | 'tool'
 export interface AgentMessage {
   role: AgentMessageRole
   content: string
+  reasoning?: string
   name?: string
   toolCallId?: string
   toolCalls?: AgentToolCall[]
@@ -46,6 +47,7 @@ export interface ModelUsage {
 export interface ModelRequest {
   model?: string
   messages: AgentMessage[]
+  signal?: AbortSignal
   temperature?: number
   maxTokens?: number
   tools?: AgentToolDefinition[]
@@ -58,6 +60,7 @@ export interface ModelResponse {
   id?: string
   model?: string
   content: string
+  reasoning?: string
   toolCalls?: AgentToolCall[]
   usage?: ModelUsage
   finishReason?: string
@@ -66,6 +69,7 @@ export interface ModelResponse {
 
 export type ModelEvent =
   | { type: 'text-delta'; text: string }
+  | { type: 'reasoning-delta'; text: string }
   | { type: 'tool-call'; toolCall: AgentToolCall }
   | { type: 'usage'; usage: ModelUsage }
   | { type: 'done'; response?: Partial<ModelResponse> }

--- a/packages/ekko-agent/src/runtime/events.ts
+++ b/packages/ekko-agent/src/runtime/events.ts
@@ -5,13 +5,16 @@ import type { AgentToolResult } from '../tools/types'
 export type AgentRuntimeEvent =
   | { type: 'run.started'; runId: string; maxSteps: number }
   | { type: 'model.started'; runId: string; step: number }
+  | { type: 'model.retry'; runId: string; step: number; retry: number; maxRetries: number; error: string }
   | { type: 'model.message'; runId: string; step: number; message: AgentOutputMessage }
   | { type: 'model.delta'; runId: string; step: number; text: string }
+  | { type: 'model.reasoning'; runId: string; step: number; text: string }
   | { type: 'model.tool_call'; runId: string; step: number; toolCall: AgentToolCall }
   | { type: 'model.usage'; runId: string; step: number; usage: ModelUsage }
   | { type: 'tool.started'; runId: string; step: number; toolCallId: string; toolName: string; arguments: Record<string, unknown> }
-  | { type: 'tool.completed'; runId: string; step: number; toolCallId: string; toolName: string; result: AgentToolResult }
-  | { type: 'tool.failed'; runId: string; step: number; toolCallId: string; toolName: string; result: AgentToolResult }
+  | { type: 'tool.completed'; runId: string; step: number; toolCallId: string; toolName: string; result: AgentToolResult; durationMs: number }
+  | { type: 'tool.failed'; runId: string; step: number; toolCallId: string; toolName: string; result: AgentToolResult; durationMs: number }
+  | { type: 'run.tool_failure_limit'; runId: string; failures: number }
   | { type: 'run.completed'; runId: string; output: AgentOutputMessage; steps: number }
   | { type: 'run.failed'; runId: string; error: string; steps: number }
   | { type: 'run.max_steps'; runId: string; maxSteps: number }

--- a/packages/ekko-agent/src/runtime/runtime.ts
+++ b/packages/ekko-agent/src/runtime/runtime.ts
@@ -2,11 +2,12 @@ import { randomUUID } from 'node:crypto'
 import {
   createSystemMessage,
   createToolResultMessage,
+  collectModelEvents,
   modelResponseToAgentMessage,
   normalizeAgentMessages,
 } from '../model/messages'
 import type { AgentOutputMessage } from '../model/messages'
-import type { AgentMessage, AgentToolCall, ModelRequest } from '../model/types'
+import type { AgentMessage, AgentToolCall, ModelRequest, ModelResponse } from '../model/types'
 import type { AgentSkill } from '../skills/types'
 import { AgentToolRegistry, createDefaultToolRegistry } from '../tools/registry'
 import type { AgentToolContext, AgentToolResult } from '../tools/types'
@@ -15,6 +16,14 @@ import { buildSystemPrompt } from './system-prompt'
 import type { AgentRuntimeOptions, AgentRuntimeRunInput, AgentRuntimeRunResult, AgentRuntimeStep } from './types'
 
 export const DEFAULT_AGENT_MAX_STEPS = 90
+export const DEFAULT_AGENT_MODEL_MAX_RETRIES = 3
+export const DEFAULT_AGENT_MAX_CONSECUTIVE_TOOL_FAILURES = 6
+export const DEFAULT_AGENT_TOOL_DELAY_MS = 1000
+
+interface ModelResponseResult {
+  response: ModelResponse
+  emittedReasoning: boolean
+}
 
 export class AgentRuntime {
   private readonly modelClient: AgentRuntimeOptions['modelClient']
@@ -25,6 +34,9 @@ export class AgentRuntime {
   private readonly maxSteps: number
   private readonly toolContext?: AgentToolContext
   private readonly modelDefaults?: AgentRuntimeOptions['modelDefaults']
+  private readonly maxModelRetries: number
+  private readonly maxConsecutiveToolFailures: number
+  private readonly toolDelayMs: number
 
   constructor(options: AgentRuntimeOptions) {
     this.modelClient = options.modelClient
@@ -35,6 +47,9 @@ export class AgentRuntime {
     this.maxSteps = options.maxSteps ?? DEFAULT_AGENT_MAX_STEPS
     this.toolContext = options.toolContext
     this.modelDefaults = options.modelDefaults
+    this.maxModelRetries = options.maxModelRetries ?? DEFAULT_AGENT_MODEL_MAX_RETRIES
+    this.maxConsecutiveToolFailures = options.maxConsecutiveToolFailures ?? DEFAULT_AGENT_MAX_CONSECUTIVE_TOOL_FAILURES
+    this.toolDelayMs = options.toolDelayMs ?? DEFAULT_AGENT_TOOL_DELAY_MS
     this.registerSkillTools(this.skills)
   }
 
@@ -60,6 +75,9 @@ export class AgentRuntime {
     const events: AgentRuntimeEvent[] = []
     const steps: AgentRuntimeStep[] = []
     const maxSteps = input.maxSteps ?? this.maxSteps
+    const maxModelRetries = input.maxModelRetries ?? this.maxModelRetries
+    const maxConsecutiveToolFailures = input.maxConsecutiveToolFailures ?? this.maxConsecutiveToolFailures
+    const toolDelayMs = input.toolDelayMs ?? this.toolDelayMs
     const emit = (event: AgentRuntimeEvent) => {
       events.push(event)
       input.onEvent?.(event)
@@ -74,15 +92,27 @@ export class AgentRuntime {
       role: 'assistant',
       content: '',
     }
+    let consecutiveToolFailures = 0
 
     try {
       for (let step = 1; step <= maxSteps; step += 1) {
+        throwIfAborted(input.signal)
         emit({ type: 'model.started', runId, step })
-        const response = await this.modelClient.create(this.modelRequest(input, messages))
+        const modelResult = await this.createModelResponseWithRetries(
+          this.modelRequest(input, messages),
+          runId,
+          step,
+          maxModelRetries,
+          emit,
+        )
+        const response = modelResult.response
         const assistantMessage = modelResponseToAgentMessage(response)
         output = assistantMessage
         messages.push(assistantMessage)
         steps.push({ type: 'model', step, message: assistantMessage })
+        if (assistantMessage.reasoning && !modelResult.emittedReasoning) {
+          emit({ type: 'model.reasoning', runId, step, text: assistantMessage.reasoning })
+        }
         emit({ type: 'model.message', runId, step, message: assistantMessage })
 
         const toolCalls = assistantMessage.toolCalls ?? []
@@ -92,9 +122,30 @@ export class AgentRuntime {
         }
 
         for (const toolCall of toolCalls) {
-          const result = await this.executeTool(runId, step, toolCall, input.toolContext ?? this.toolContext, emit)
+          throwIfAborted(input.signal)
+          const result = await this.executeTool(
+            runId,
+            step,
+            toolCall,
+            this.runToolContext(input),
+            emit,
+            input.signal,
+          )
+          throwIfAborted(input.signal)
           messages.push(createToolResultMessage(toolCall.id, result.content, toolCall.name))
           steps.push({ type: 'tool', step, toolCallId: toolCall.id, toolName: toolCall.name, result })
+          consecutiveToolFailures = result.ok ? 0 : consecutiveToolFailures + 1
+          if (maxConsecutiveToolFailures > 0 && consecutiveToolFailures >= maxConsecutiveToolFailures) {
+            emit({ type: 'run.tool_failure_limit', runId, failures: consecutiveToolFailures })
+            output = {
+              role: 'assistant',
+              content: `Stopped after ${consecutiveToolFailures} consecutive tool failures.`,
+              finishReason: 'tool_failure_limit',
+            }
+            emit({ type: 'run.completed', runId, output, steps: step })
+            return { runId, messages, output, steps, events }
+          }
+          await delay(toolDelayMs, input.signal)
         }
       }
 
@@ -113,6 +164,70 @@ export class AgentRuntime {
     }
   }
 
+  private async createModelResponseWithRetries(
+    request: ModelRequest,
+    runId: string,
+    step: number,
+    maxRetries: number,
+    emit: (event: AgentRuntimeEvent) => void,
+  ): Promise<ModelResponseResult> {
+    for (let attempt = 1; attempt <= maxRetries + 1; attempt += 1) {
+      try {
+        throwIfAborted(request.signal)
+        if (request.stream && this.modelClient.capabilities.streaming) {
+          return await this.streamModelResponse(request, runId, step, emit)
+        }
+        return {
+          response: await this.modelClient.create(request),
+          emittedReasoning: false,
+        }
+      } catch (error) {
+        throwIfAborted(request.signal)
+        if (attempt > maxRetries) throw error
+        emit({
+          type: 'model.retry',
+          runId,
+          step,
+          retry: attempt,
+          maxRetries,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+    throw new Error('Model request retry loop exited unexpectedly.')
+  }
+
+  private async streamModelResponse(
+    request: ModelRequest,
+    runId: string,
+    step: number,
+    emit: (event: AgentRuntimeEvent) => void,
+  ): Promise<ModelResponseResult> {
+    let emittedReasoning = false
+    const events = this.modelClient.stream({ ...request, stream: true })
+    const output = await collectModelEvents((async function *streamAndEmit() {
+      for await (const event of events) {
+        if (event.type === 'text-delta') {
+          emit({ type: 'model.delta', runId, step, text: event.text })
+        } else if (event.type === 'reasoning-delta') {
+          emittedReasoning = true
+          emit({ type: 'model.reasoning', runId, step, text: event.text })
+        } else if (event.type === 'tool-call') {
+          emit({ type: 'model.tool_call', runId, step, toolCall: event.toolCall })
+        } else if (event.type === 'usage') {
+          emit({ type: 'model.usage', runId, step, usage: event.usage })
+        } else if (event.type === 'error') {
+          throw new Error(event.error)
+        }
+        yield event
+      }
+    })())
+    return {
+      response: output.message,
+      emittedReasoning,
+    }
+  }
+
   private prepareMessages(input: AgentRuntimeRunInput, skills: AgentSkill[]): AgentMessage[] {
     const normalized = normalizeAgentMessages(input.messages)
     const userSystemMessages = normalized.filter(message => message.role === 'system').map(message => message.content)
@@ -122,7 +237,6 @@ export class AgentRuntime {
       runtimeInstructions: this.runtimeInstructions,
       userSystemMessages,
       skills,
-      tools: this.tools.definitions(),
       context: input.toolContext ?? this.toolContext,
     })
 
@@ -140,8 +254,18 @@ export class AgentRuntime {
       maxTokens: input.maxTokens ?? this.modelDefaults?.maxTokens,
       metadata: input.metadata ?? this.modelDefaults?.metadata,
       messages,
+      signal: input.signal,
       tools: this.tools.definitions(),
-      stream: false,
+      stream: this.modelClient.capabilities.streaming,
+    }
+  }
+
+  private runToolContext(input: AgentRuntimeRunInput): AgentToolContext | undefined {
+    const context = input.toolContext ?? this.toolContext
+    if (!input.signal) return context
+    return {
+      ...context,
+      signal: input.signal,
     }
   }
 
@@ -151,7 +275,9 @@ export class AgentRuntime {
     toolCall: AgentToolCall,
     context: AgentToolContext | undefined,
     emit: (event: AgentRuntimeEvent) => void,
+    signal?: AbortSignal,
   ): Promise<AgentToolResult> {
+    const startedAt = Date.now()
     emit({
       type: 'tool.started',
       runId,
@@ -162,7 +288,9 @@ export class AgentRuntime {
     })
 
     try {
+      throwIfAborted(signal)
       const result = await this.tools.execute(toolCall.name, toolCall.arguments, context)
+      throwIfAborted(signal)
       emit({
         type: result.ok ? 'tool.completed' : 'tool.failed',
         runId,
@@ -170,6 +298,7 @@ export class AgentRuntime {
         toolCallId: toolCall.id,
         toolName: toolCall.name,
         result,
+        durationMs: Date.now() - startedAt,
       })
       return result
     } catch (error) {
@@ -186,6 +315,7 @@ export class AgentRuntime {
         toolCallId: toolCall.id,
         toolName: toolCall.name,
         result,
+        durationMs: Date.now() - startedAt,
       })
       return result
     }
@@ -198,4 +328,30 @@ export class AgentRuntime {
       }
     }
   }
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!Number.isFinite(ms) || ms <= 0) return Promise.resolve()
+  throwIfAborted(signal)
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(abortError())
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw abortError()
+}
+
+function abortError(): Error {
+  const error = new Error('Run aborted.')
+  error.name = 'AbortError'
+  return error
 }

--- a/packages/ekko-agent/src/runtime/system-prompt.ts
+++ b/packages/ekko-agent/src/runtime/system-prompt.ts
@@ -1,4 +1,3 @@
-import type { AgentToolDefinition } from '../model/types'
 import type { AgentSkill } from '../skills/types'
 
 export interface SystemPromptInput {
@@ -6,7 +5,6 @@ export interface SystemPromptInput {
   runtimeInstructions?: string[]
   userSystemMessages?: string[]
   skills?: AgentSkill[]
-  tools?: AgentToolDefinition[]
   context?: {
     cwd?: string
     workspaceRoot?: string
@@ -37,13 +35,6 @@ export function buildSystemPrompt(input: SystemPromptInput = {}): string {
       skill.description ? `Description: ${skill.description}` : '',
       skill.instructions,
     ].filter(Boolean).join('\n')).join('\n\n')))
-  }
-
-  if (input.tools?.length) {
-    sections.push(section('Available Tools', input.tools.map(tool => {
-      const description = tool.description ? `: ${tool.description}` : ''
-      return `- ${tool.name}${description}`
-    }).join('\n')))
   }
 
   if (input.userSystemMessages?.length) {

--- a/packages/ekko-agent/src/runtime/types.ts
+++ b/packages/ekko-agent/src/runtime/types.ts
@@ -12,15 +12,22 @@ export interface AgentRuntimeOptions {
   systemPrompt?: string
   runtimeInstructions?: string[]
   maxSteps?: number
+  maxModelRetries?: number
+  maxConsecutiveToolFailures?: number
+  toolDelayMs?: number
   toolContext?: AgentToolContext
   modelDefaults?: Omit<ModelRequest, 'messages' | 'tools' | 'stream'>
 }
 
 export interface AgentRuntimeRunInput {
   messages: AgentMessageInput[]
+  signal?: AbortSignal
   systemPrompt?: string
   skills?: AgentSkill[]
   maxSteps?: number
+  maxModelRetries?: number
+  maxConsecutiveToolFailures?: number
+  toolDelayMs?: number
   toolContext?: AgentToolContext
   model?: string
   temperature?: number

--- a/packages/ekko-agent/src/tools/terminal.ts
+++ b/packages/ekko-agent/src/tools/terminal.ts
@@ -12,11 +12,11 @@ export interface TerminalExecInput extends Record<string, unknown> {
 export class TerminalExecTool implements AgentTool<TerminalExecInput> {
   readonly definition = {
     name: 'terminal_exec',
-    description: 'Run a terminal command with an argument array. Shell string execution is not used.',
+    description: 'Run a terminal command. Prefer command as the executable and args as the argument array; shell string execution is not used.',
     parameters: {
       type: 'object',
       properties: {
-        command: { type: 'string', description: 'Executable command to run.' },
+        command: { type: 'string', description: 'Executable command to run. Prefer a bare executable such as "node", "ls", or "/bin/sh".' },
         args: { type: 'array', items: { type: 'string' }, description: 'Command arguments.' },
         cwd: { type: 'string', description: 'Working directory relative to the workspace.' },
         timeoutMs: { type: 'number', description: 'Timeout in milliseconds.' },
@@ -27,12 +27,21 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
   }
 
   async execute(input: TerminalExecInput, context: AgentToolContext = {}): Promise<AgentToolResult> {
-    const args = Array.isArray(input.args) ? input.args.map(String) : []
+    const normalized = normalizeTerminalCommand(input.command, input.args)
+    const args = normalized.args
     const cwd = input.cwd ? resolveToolPath(input.cwd, context) : context.cwd || context.workspaceRoot || process.cwd()
     const timeoutMs = input.timeoutMs ?? context.timeoutMs ?? 30_000
+    if (context.signal?.aborted) {
+      return {
+        ok: false,
+        content: 'Command aborted.',
+        error: 'Command aborted.',
+        data: { command: normalized.command, args, cwd, originalCommand: input.command, aborted: true },
+      }
+    }
 
     return new Promise<AgentToolResult>((resolve) => {
-      const child = spawn(input.command, args, {
+      const child = spawn(normalized.command, args, {
         cwd,
         shell: false,
         windowsHide: true,
@@ -40,11 +49,17 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
       let stdout = ''
       let stderr = ''
       let timedOut = false
+      let aborted = false
 
       const timer = setTimeout(() => {
         timedOut = true
         child.kill('SIGTERM')
       }, timeoutMs)
+      const onAbort = () => {
+        aborted = true
+        child.kill('SIGTERM')
+      }
+      context.signal?.addEventListener('abort', onAbort, { once: true })
 
       child.stdout?.setEncoding('utf8')
       child.stderr?.setEncoding('utf8')
@@ -52,28 +67,32 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
       child.stderr?.on('data', chunk => { stderr += chunk })
       child.on('error', error => {
         clearTimeout(timer)
+        context.signal?.removeEventListener('abort', onAbort)
         resolve({
           ok: false,
           content: error.message,
           error: error.message,
-          data: { command: input.command, args, cwd },
+          data: { command: normalized.command, args, cwd, originalCommand: input.command },
         })
       })
       child.on('close', code => {
         clearTimeout(timer)
+        context.signal?.removeEventListener('abort', onAbort)
         const content = [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join('\n')
         resolve({
-          ok: code === 0 && !timedOut,
-          content,
-          error: timedOut ? `Command timed out after ${timeoutMs}ms` : code === 0 ? undefined : `Command exited with code ${code}`,
+          ok: code === 0 && !timedOut && !aborted,
+          content: content || (aborted ? 'Command aborted.' : content),
+          error: aborted ? 'Command aborted.' : timedOut ? `Command timed out after ${timeoutMs}ms` : code === 0 ? undefined : `Command exited with code ${code}`,
           data: {
-            command: input.command,
+            command: normalized.command,
             args,
             cwd,
+            originalCommand: input.command,
             exitCode: code,
             stdout,
             stderr,
             timedOut,
+            aborted,
           },
         })
       })
@@ -83,4 +102,61 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
 
 export function createTerminalTools(): AgentTool[] {
   return [new TerminalExecTool()]
+}
+
+function normalizeTerminalCommand(command: string, args?: string[]): { command: string; args: string[] } {
+  const normalizedArgs = Array.isArray(args) ? args.map(String) : []
+  if (normalizedArgs.length > 0 || !/\s/.test(command.trim())) {
+    return { command, args: normalizedArgs }
+  }
+
+  const parts = splitCommandLine(command)
+  if (parts.length <= 1) return { command, args: normalizedArgs }
+  return {
+    command: parts[0],
+    args: parts.slice(1),
+  }
+}
+
+function splitCommandLine(command: string): string[] {
+  const parts: string[] = []
+  let current = ''
+  let quote: '"' | "'" | null = null
+  let escaped = false
+
+  for (const char of command.trim()) {
+    if (escaped) {
+      current += char
+      escaped = false
+      continue
+    }
+    if (char === '\\') {
+      escaped = true
+      continue
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null
+      } else {
+        current += char
+      }
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      continue
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        parts.push(current)
+        current = ''
+      }
+      continue
+    }
+    current += char
+  }
+
+  if (escaped) current += '\\'
+  if (current) parts.push(current)
+  return parts
 }

--- a/packages/ekko-agent/src/tools/types.ts
+++ b/packages/ekko-agent/src/tools/types.ts
@@ -4,6 +4,7 @@ export interface AgentToolContext {
   cwd?: string
   workspaceRoot?: string
   timeoutMs?: number
+  signal?: AbortSignal
 }
 
 export interface AgentToolResult {

--- a/packages/server/src/services/hermes/run-chat/abort.ts
+++ b/packages/server/src/services/hermes/run-chat/abort.ts
@@ -110,6 +110,7 @@ export async function handleAbort(
       return
     }
   } else if (activeState.source === 'coding_agent') {
+    activeState.abortController?.abort()
     codingAgentRunManager.stop(sessionId, { reportClosed: false })
   } else if (activeState.abortController) {
     activeState.abortController.abort()

--- a/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
@@ -3,16 +3,15 @@ import { inspect } from 'util'
 import {
   AgentRuntime,
   createModelClient,
+  resolveModelProviderConfigs,
   type AgentMessage,
   type AgentToolCall,
   type ModelClient,
   type ModelEvent,
   type AgentRuntimeEvent,
   type ModelProviderConfig,
-  type ModelProviderType,
   type ModelRequest,
   type ModelResponse,
-  type ModelRequestStyle,
 } from '../../../../../ekko-agent/src'
 import { createSession, addMessage, getSession, updateSessionStats } from '../../../db/hermes/session-store'
 import { logger } from '../../logger'
@@ -54,24 +53,6 @@ function isEkkoAgentId(data: EkkoAgentRunSocketData): boolean {
   return data.coding_agent_id === 'ekko-agent' || data.agent_id === 'ekko-agent'
 }
 
-function requestStyleForConfig(provider: string, baseUrl: string, apiMode?: string): ModelRequestStyle {
-  const key = provider.toLowerCase()
-  const url = baseUrl.toLowerCase()
-  if (apiMode === 'codex_responses') return 'openai-responses'
-  if (apiMode === 'anthropic_messages') return 'anthropic-messages'
-  if (key.includes('gemini') || key.includes('google') || url.includes('generativelanguage.googleapis.com')) return 'gemini-contents'
-  return 'openai-chat'
-}
-
-function providerTypeForStyle(provider: string, style: ModelRequestStyle): ModelProviderType {
-  const key = provider.toLowerCase()
-  if (style === 'anthropic-messages') return 'anthropic'
-  if (style === 'gemini-contents') return 'gemini'
-  if (key.includes('ollama')) return 'ollama'
-  if (key === 'openai') return 'openai'
-  return 'openai-compatible'
-}
-
 function toAgentMessages(messages: SessionState['messages']): AgentMessage[] {
   return messages
     .filter(message => message.role === 'user' || message.role === 'assistant' || message.role === 'system' || message.role === 'command')
@@ -80,9 +61,10 @@ function toAgentMessages(messages: SessionState['messages']): AgentMessage[] {
       return {
         role,
         content: contentBlocksToString(message.content as any),
+        reasoning: message.reasoning || message.reasoning_content || undefined,
       }
     })
-    .filter(message => message.content.trim().length > 0)
+    .filter(message => message.content.trim().length > 0 || (message.reasoning?.trim().length ?? 0) > 0)
 }
 
 function appendStateEvent(state: SessionState, event: string, payload: any): void {
@@ -148,6 +130,11 @@ function requestForProvider(request: ModelRequest, config: ModelProviderConfig):
   }
 }
 
+function shouldFallbackProtocol(err: unknown): boolean {
+  const statusCode = (err as { statusCode?: number } | null)?.statusCode
+  return statusCode === 400 || statusCode === 404 || statusCode === 405 || statusCode === 415 || statusCode === 422
+}
+
 function toStoredToolCall(toolCall: AgentToolCall) {
   return {
     id: toolCall.id,
@@ -159,7 +146,17 @@ function toStoredToolCall(toolCall: AgentToolCall) {
   }
 }
 
-function createConsoleModelClient(client: ModelClient, context: { sessionId: string; providerConfig: ModelProviderConfig }): ModelClient {
+function createConsoleModelClient(
+  client: ModelClient,
+  context: {
+    sessionId: string
+    providerConfig: ModelProviderConfig
+    fallback?: {
+      client: ModelClient
+      providerConfig: ModelProviderConfig
+    }
+  },
+): ModelClient {
   return {
     ...client,
     provider: client.provider,
@@ -188,6 +185,33 @@ function createConsoleModelClient(client: ModelClient, context: { sessionId: str
           request_style: client.requestStyle,
           error: errorPayload(err),
         }))
+        if (context.fallback && context.fallback.providerConfig.requestStyle !== context.providerConfig.requestStyle && shouldFallbackProtocol(err)) {
+          const fallbackRequest = requestForProvider(request, context.fallback.providerConfig)
+          console.warn('[ekko-agent] model request protocol fallback', consolePayload({
+            session_id: context.sessionId,
+            from_request_style: context.providerConfig.requestStyle,
+            to_request_style: context.fallback.providerConfig.requestStyle,
+            provider_config: redactProviderConfig(context.fallback.providerConfig),
+            request: fallbackRequest,
+          }))
+          try {
+            const response = await context.fallback.client.create(fallbackRequest)
+            console.log('[ekko-agent] model request fallback success', consolePayload({
+              session_id: context.sessionId,
+              provider: context.fallback.client.provider,
+              request_style: context.fallback.client.requestStyle,
+              response,
+            }))
+            return response
+          } catch (fallbackErr) {
+            console.error('[ekko-agent] model request fallback failed', consolePayload({
+              session_id: context.sessionId,
+              provider: context.fallback.client.provider,
+              request_style: context.fallback.client.requestStyle,
+              error: errorPayload(fallbackErr),
+            }))
+          }
+        }
         throw err
       }
     },
@@ -214,6 +238,34 @@ function createConsoleModelClient(client: ModelClient, context: { sessionId: str
           request_style: client.requestStyle,
           error: errorPayload(err),
         }))
+        if (context.fallback && context.fallback.providerConfig.requestStyle !== context.providerConfig.requestStyle && shouldFallbackProtocol(err)) {
+          const fallbackRequest = requestForProvider(request, context.fallback.providerConfig)
+          console.warn('[ekko-agent] model stream protocol fallback', consolePayload({
+            session_id: context.sessionId,
+            from_request_style: context.providerConfig.requestStyle,
+            to_request_style: context.fallback.providerConfig.requestStyle,
+            provider_config: redactProviderConfig(context.fallback.providerConfig),
+            request: fallbackRequest,
+          }))
+          try {
+            for await (const event of context.fallback.client.stream(fallbackRequest)) {
+              yield event
+            }
+            console.log('[ekko-agent] model stream fallback success', consolePayload({
+              session_id: context.sessionId,
+              provider: context.fallback.client.provider,
+              request_style: context.fallback.client.requestStyle,
+            }))
+            return
+          } catch (fallbackErr) {
+            console.error('[ekko-agent] model stream fallback failed', consolePayload({
+              session_id: context.sessionId,
+              provider: context.fallback.client.provider,
+              request_style: context.fallback.client.requestStyle,
+              error: errorPayload(fallbackErr),
+            }))
+          }
+        }
         throw err
       }
     },
@@ -246,6 +298,8 @@ export async function handleEkkoAgentRun(
   state.profile = profile
   state.source = data.source === 'workflow' ? 'workflow' : 'coding_agent'
   state.events = []
+  const abortController = new AbortController()
+  state.abortController = abortController
 
   const storedSession = getSession(sessionId)
   const modelConfig = await resolveBridgeRunModelConfig({
@@ -322,19 +376,25 @@ export async function handleEkkoAgentRun(
   }
 
   const baseUrl = data.baseUrl || data.base_url || ''
-  const requestStyle = requestStyleForConfig(modelConfig.provider, baseUrl, data.apiMode || data.api_mode)
-  const providerConfig: ModelProviderConfig = {
-    id: modelConfig.provider || 'openai',
-    type: providerTypeForStyle(modelConfig.provider, requestStyle),
-    requestStyle,
-    baseUrl: baseUrl || undefined,
-    apiKey: data.apiKey || data.api_key || undefined,
-    defaultModel: modelConfig.model,
+  const apiMode = data.apiMode || data.api_mode
+  const apiKey = data.apiKey || data.api_key || undefined
+  const { providerConfig, fallbackProviderConfig } = resolveModelProviderConfigs({
+    provider: modelConfig.provider,
+    baseUrl,
+    apiKey,
+    model: modelConfig.model,
+    apiMode,
     timeoutMs: 120_000,
-  }
+  })
   const modelClient = createConsoleModelClient(createModelClient(providerConfig), {
     sessionId,
     providerConfig,
+    fallback: fallbackProviderConfig
+      ? {
+          client: createModelClient(fallbackProviderConfig),
+          providerConfig: fallbackProviderConfig,
+        }
+      : undefined,
   })
   const runtime = new AgentRuntime({
     modelClient,
@@ -349,9 +409,11 @@ export async function handleEkkoAgentRun(
   })
 
   let assistantText = ''
+  let assistantReasoning = ''
   let runId = ''
   let usageInput = 0
   let usageOutput = 0
+  let sawStreamUsage = false
   const handleRuntimeEvent = (event: AgentRuntimeEvent) => {
     if ('runId' in event) runId = event.runId
     if (event.type === 'run.started') {
@@ -365,16 +427,39 @@ export async function handleEkkoAgentRun(
     } else if (event.type === 'model.message') {
       const text = event.message.content || ''
       if (text && !event.message.toolCalls?.length) {
+        const shouldEmitFullMessage = assistantText.length === 0
         assistantText = text
-        emit('message.delta', {
-          event: 'message.delta',
-          run_id: event.runId,
-          delta: text,
-        })
+        if (shouldEmitFullMessage) {
+          emit('message.delta', {
+            event: 'message.delta',
+            run_id: event.runId,
+            delta: text,
+          })
+        }
       }
-      if (event.message.usage) {
+      if (event.message.usage && !sawStreamUsage) {
         usageInput += event.message.usage.inputTokens || 0
         usageOutput += event.message.usage.outputTokens || 0
+      }
+    } else if (event.type === 'model.delta') {
+      assistantText += event.text
+      emit('message.delta', {
+        event: 'message.delta',
+        run_id: event.runId,
+        delta: event.text,
+      })
+    } else if (event.type === 'model.usage') {
+      sawStreamUsage = true
+      usageInput += event.usage.inputTokens || 0
+      usageOutput += event.usage.outputTokens || 0
+    } else if (event.type === 'model.reasoning') {
+      if (event.text) {
+        assistantReasoning += event.text
+        emit('reasoning.delta', {
+          event: 'reasoning.delta',
+          run_id: event.runId,
+          delta: event.text,
+        })
       }
     } else if (event.type === 'tool.started') {
       emit('tool.started', {
@@ -382,6 +467,7 @@ export async function handleEkkoAgentRun(
         run_id: event.runId,
         tool: event.toolName,
         name: event.toolName,
+        arguments: event.arguments,
         preview: JSON.stringify(event.arguments || {}),
         tool_call_id: event.toolCallId,
       })
@@ -391,8 +477,10 @@ export async function handleEkkoAgentRun(
         run_id: event.runId,
         tool: event.toolName,
         name: event.toolName,
+        output: event.result.content,
         preview: event.result.content,
         tool_call_id: event.toolCallId,
+        duration: Math.round(event.durationMs / 10) / 100,
         error: event.result.error,
       })
     }
@@ -403,11 +491,13 @@ export async function handleEkkoAgentRun(
     const result = await runtime.run({
       model: modelConfig.model,
       messages: toAgentMessages(state.messages),
+      signal: abortController.signal,
       onEvent: handleRuntimeEvent,
       toolContext: {
         cwd: workspace,
         workspaceRoot: workspace,
         timeoutMs: 120_000,
+        signal: abortController.signal,
       },
       metadata: {
         session_id: sessionId,
@@ -431,6 +521,8 @@ export async function handleEkkoAgentRun(
           tool_calls: toolCalls,
           timestamp,
           finish_reason: 'tool_calls',
+          reasoning: step.message.reasoning || null,
+          reasoning_content: step.message.reasoning || null,
         })
         state.messages.push({
           id: assistantId || state.messages.length + 1,
@@ -440,6 +532,8 @@ export async function handleEkkoAgentRun(
           tool_calls: toolCalls,
           timestamp,
           finish_reason: 'tool_calls',
+          reasoning: step.message.reasoning || null,
+          reasoning_content: step.message.reasoning || null,
         })
       } else if (step.type === 'tool') {
         const timestamp = Math.floor(Date.now() / 1000)
@@ -450,6 +544,7 @@ export async function handleEkkoAgentRun(
           tool_call_id: step.toolCallId,
           tool_name: step.toolName,
           timestamp,
+          finish_reason: step.result.ok ? null : 'error',
         })
         state.messages.push({
           id: toolId || state.messages.length + 1,
@@ -459,16 +554,20 @@ export async function handleEkkoAgentRun(
           tool_call_id: step.toolCallId,
           tool_name: step.toolName,
           timestamp,
+          finish_reason: step.result.ok ? null : 'error',
         })
       }
     }
-    if (assistantText.trim()) {
+    assistantReasoning = result.output.reasoning || assistantReasoning
+    if (assistantText.trim() || assistantReasoning.trim()) {
       const assistantId = addMessage({
         session_id: sessionId,
         role: 'assistant',
         content: assistantText,
         timestamp: Math.floor(Date.now() / 1000),
         finish_reason: result.output.finishReason || null,
+        reasoning: assistantReasoning || null,
+        reasoning_content: assistantReasoning || null,
       })
       state.messages.push({
         id: assistantId || state.messages.length + 1,
@@ -477,6 +576,8 @@ export async function handleEkkoAgentRun(
         content: assistantText,
         timestamp: Math.floor(Date.now() / 1000),
         finish_reason: result.output.finishReason || null,
+        reasoning: assistantReasoning || null,
+        reasoning_content: assistantReasoning || null,
       })
     }
     if (!usageInput && !usageOutput) {
@@ -509,6 +610,10 @@ export async function handleEkkoAgentRun(
       queue_remaining: state.queue.length,
     })
   } catch (err) {
+    if (abortController.signal.aborted || isAbortError(err)) {
+      logger.info('[chat-run-socket] ekko-agent run aborted for session %s', sessionId)
+      return
+    }
     const error = err instanceof Error ? err.message : String(err)
     logger.warn(err, '[chat-run-socket] ekko-agent run failed for session %s', sessionId)
     emit('run.failed', {
@@ -518,16 +623,22 @@ export async function handleEkkoAgentRun(
       queue_remaining: state.queue.length,
     })
   } finally {
-    state.isWorking = false
-    state.isAborting = false
-    state.runId = undefined
-    state.abortController = undefined
-    state.activeRunMarker = undefined
-    state.responseRun = undefined
-    state.profile = undefined
-    state.events = []
-    if (state.queue.length > 0) {
-      dequeueNextQueuedRun(socket, sessionId, profile)
+    if (!abortController.signal.aborted || state.abortController === abortController) {
+      state.isWorking = false
+      state.isAborting = false
+      state.runId = undefined
+      state.abortController = undefined
+      state.activeRunMarker = undefined
+      state.responseRun = undefined
+      state.profile = undefined
+      state.events = []
+      if (state.queue.length > 0) {
+        dequeueNextQueuedRun(socket, sessionId, profile)
+      }
     }
   }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || error.message === 'Run aborted.')
 }

--- a/tests/ekko-agent/messages.test.ts
+++ b/tests/ekko-agent/messages.test.ts
@@ -90,6 +90,8 @@ describe('ekko-agent unified messages', () => {
   it('collects stream events into one assistant output message', async () => {
     async function *events(): AsyncIterable<ModelEvent> {
       yield { type: 'text-delta', text: 'Hel' }
+      yield { type: 'reasoning-delta', text: 'thinking ' }
+      yield { type: 'reasoning-delta', text: 'step' }
       yield { type: 'text-delta', text: 'lo' }
       yield {
         type: 'tool-call',
@@ -106,6 +108,8 @@ describe('ekko-agent unified messages', () => {
     await expect(collectModelEvents(events())).resolves.toEqual({
       events: [
         { type: 'text-delta', text: 'Hel' },
+        { type: 'reasoning-delta', text: 'thinking ' },
+        { type: 'reasoning-delta', text: 'step' },
         { type: 'text-delta', text: 'lo' },
         {
           type: 'tool-call',
@@ -123,6 +127,7 @@ describe('ekko-agent unified messages', () => {
         id: 'res_1',
         model: 'stream-model',
         content: 'Hello',
+        reasoning: 'thinking step',
         toolCalls: [{
           id: 'call_1',
           name: 'lookup',

--- a/tests/ekko-agent/model-request.test.ts
+++ b/tests/ekko-agent/model-request.test.ts
@@ -6,6 +6,7 @@ import {
   toAnthropicMessagesPayload,
   toGeminiContentsPayload,
   normalizeOpenAIChatResponse,
+  resolveModelProviderConfigs,
   toOpenAIResponsesPayload,
   toOpenAIChatPayload,
   toPromptCompletionPayload,
@@ -21,6 +22,43 @@ const providerConfig: ModelProviderConfig = {
 }
 
 describe('ekko-agent model requests', () => {
+  it('resolves provider configs from explicit api mode with inferred fallback', () => {
+    const resolved = resolveModelProviderConfigs({
+      provider: 'glm',
+      baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
+      apiKey: 'secret',
+      model: 'glm-5.2',
+      apiMode: 'codex_responses',
+    })
+
+    expect(resolved.providerConfig).toMatchObject({
+      id: 'glm',
+      type: 'openai-compatible',
+      requestStyle: 'openai-responses',
+      baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
+      apiKey: 'secret',
+      defaultModel: 'glm-5.2',
+    })
+    expect(resolved.fallbackProviderConfig).toMatchObject({
+      requestStyle: 'openai-chat',
+      defaultModel: 'glm-5.2',
+    })
+  })
+
+  it('infers anthropic provider configs from anthropic URLs', () => {
+    const resolved = resolveModelProviderConfigs({
+      provider: 'custom',
+      baseUrl: 'https://api.z.ai/api/anthropic',
+      model: 'glm-5.2',
+    })
+
+    expect(resolved.providerConfig).toMatchObject({
+      type: 'anthropic',
+      requestStyle: 'anthropic-messages',
+    })
+    expect(resolved.fallbackProviderConfig).toBeUndefined()
+  })
+
   it('converts internal requests to OpenAI-compatible chat payloads', () => {
     const payload = toOpenAIChatPayload(providerConfig, {
       messages: [

--- a/tests/ekko-agent/runtime.test.ts
+++ b/tests/ekko-agent/runtime.test.ts
@@ -3,11 +3,13 @@ import {
   AgentRuntime,
   AgentToolRegistry,
   DEFAULT_AGENT_MAX_STEPS,
+  DEFAULT_AGENT_MODEL_MAX_RETRIES,
   buildSystemPrompt,
 } from '../../packages/ekko-agent/src/index'
 import type {
   AgentTool,
   AgentToolProvider,
+  ModelEvent,
   ModelClient,
   ModelRequest,
   ModelResponse,
@@ -27,6 +29,24 @@ function modelClient(responder: (request: ModelRequest, call: number) => ModelRe
     },
     create: vi.fn(async (request: ModelRequest) => responder(request, ++call)),
     stream: vi.fn(),
+  }
+}
+
+function streamingModelClient(events: ModelEvent[]): ModelClient {
+  return {
+    provider: 'test',
+    requestStyle: 'custom-runtime',
+    capabilities: {
+      streaming: true,
+      tools: true,
+      vision: false,
+      jsonMode: false,
+      systemPrompt: true,
+    },
+    create: vi.fn(),
+    stream: vi.fn(async function *stream() {
+      for (const event of events) yield event
+    }),
   }
 }
 
@@ -53,6 +73,53 @@ describe('ekko-agent runtime', () => {
     expect(events).toEqual(['run.started', 'model.started', 'model.message', 'run.completed'])
   })
 
+  it('emits model reasoning before the assistant message', async () => {
+    const client = modelClient(() => ({
+      content: 'answer',
+      reasoning: 'thinking path',
+    }))
+    const runtime = new AgentRuntime({ modelClient: client, tools: new AgentToolRegistry() })
+    const events: string[] = []
+    const reasoning: string[] = []
+
+    const result = await runtime.run({
+      messages: ['hi'],
+      onEvent: event => {
+        events.push(event.type)
+        if (event.type === 'model.reasoning') reasoning.push(event.text)
+      },
+    })
+
+    expect(result.output.reasoning).toBe('thinking path')
+    expect(reasoning).toEqual(['thinking path'])
+    expect(events).toEqual(['run.started', 'model.started', 'model.reasoning', 'model.message', 'run.completed'])
+  })
+
+  it('streams model text deltas before the final assistant message', async () => {
+    const client = streamingModelClient([
+      { type: 'text-delta', text: 'Hel' },
+      { type: 'text-delta', text: 'lo' },
+      { type: 'done', response: { finishReason: 'stop' } },
+    ])
+    const runtime = new AgentRuntime({ modelClient: client, tools: new AgentToolRegistry() })
+    const events: string[] = []
+    const deltas: string[] = []
+
+    const result = await runtime.run({
+      messages: ['hi'],
+      onEvent: event => {
+        events.push(event.type)
+        if (event.type === 'model.delta') deltas.push(event.text)
+      },
+    })
+
+    expect(client.create).not.toHaveBeenCalled()
+    expect(client.stream).toHaveBeenCalledTimes(1)
+    expect(result.output.content).toBe('Hello')
+    expect(deltas).toEqual(['Hel', 'lo'])
+    expect(events).toEqual(['run.started', 'model.started', 'model.delta', 'model.delta', 'model.message', 'run.completed'])
+  })
+
   it('executes tool calls and continues the model loop', async () => {
     const echoTool: AgentTool = {
       definition: {
@@ -73,7 +140,7 @@ describe('ekko-agent runtime', () => {
           finishReason: 'tool_calls',
         }
       : { content: 'tool said from-tool', finishReason: 'stop' })
-    const runtime = new AgentRuntime({ modelClient: client, tools })
+    const runtime = new AgentRuntime({ modelClient: client, tools, toolDelayMs: 0 })
 
     const result = await runtime.run({ messages: ['use echo'] })
 
@@ -95,7 +162,7 @@ describe('ekko-agent runtime', () => {
           toolCalls: [{ id: 'call_missing', name: 'missing_tool', arguments: {} }],
         }
       : { content: 'handled missing tool' })
-    const runtime = new AgentRuntime({ modelClient: client, tools: new AgentToolRegistry(), maxSteps: 2 })
+    const runtime = new AgentRuntime({ modelClient: client, tools: new AgentToolRegistry(), maxSteps: 2, toolDelayMs: 0 })
 
     const result = await runtime.run({ messages: ['call missing'] })
 
@@ -106,6 +173,57 @@ describe('ekko-agent runtime', () => {
       content: 'Unknown tool: missing_tool',
     })
     expect(result.output.content).toBe('handled missing tool')
+  })
+
+  it('stops after consecutive tool failures', async () => {
+    const client = modelClient((_request, call) => ({
+      content: '',
+      toolCalls: [{ id: `call_missing_${call}`, name: 'missing_tool', arguments: {} }],
+    }))
+    const runtime = new AgentRuntime({
+      modelClient: client,
+      tools: new AgentToolRegistry(),
+      maxConsecutiveToolFailures: 2,
+      maxSteps: 10,
+      toolDelayMs: 0,
+    })
+    const events: string[] = []
+
+    const result = await runtime.run({
+      messages: ['call missing repeatedly'],
+      onEvent: event => events.push(event.type),
+    })
+
+    expect(result.output).toMatchObject({
+      content: 'Stopped after 2 consecutive tool failures.',
+      finishReason: 'tool_failure_limit',
+    })
+    expect(result.steps.filter(step => step.type === 'tool')).toHaveLength(2)
+    expect(client.create).toHaveBeenCalledTimes(2)
+    expect(events).toContain('run.tool_failure_limit')
+  })
+
+  it('passes abort signals into model requests', async () => {
+    const controller = new AbortController()
+    const client = modelClient((request) => {
+      expect(request.signal).toBe(controller.signal)
+      return { content: 'done' }
+    })
+    const runtime = new AgentRuntime({ modelClient: client, tools: new AgentToolRegistry() })
+
+    const result = await runtime.run({ messages: ['hi'], signal: controller.signal })
+
+    expect(result.output.content).toBe('done')
+  })
+
+  it('stops before a model request when aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const client = modelClient(() => ({ content: 'should not run' }))
+    const runtime = new AgentRuntime({ modelClient: client, tools: new AgentToolRegistry() })
+
+    await expect(runtime.run({ messages: ['hi'], signal: controller.signal })).rejects.toThrow('Run aborted.')
+    expect(client.create).not.toHaveBeenCalled()
   })
 
   it('defaults maxSteps to 90', async () => {
@@ -122,6 +240,44 @@ describe('ekko-agent runtime', () => {
 
     expect(DEFAULT_AGENT_MAX_STEPS).toBe(90)
     expect(seen).toEqual([90])
+  })
+
+  it('retries each model step before continuing the loop', async () => {
+    const client = modelClient((_request, call) => {
+      if (call < 3) throw new Error(`temporary failure ${call}`)
+      return { content: 'recovered' }
+    })
+    const runtime = new AgentRuntime({ modelClient: client, tools: new AgentToolRegistry() })
+    const retries: number[] = []
+
+    const result = await runtime.run({
+      messages: ['hi'],
+      onEvent: event => {
+        if (event.type === 'model.retry') retries.push(event.retry)
+      },
+    })
+
+    expect(result.output.content).toBe('recovered')
+    expect(client.create).toHaveBeenCalledTimes(3)
+    expect(retries).toEqual([1, 2])
+  })
+
+  it('stops the run after three failed model retries', async () => {
+    const client = modelClient(() => {
+      throw new Error('still failing')
+    })
+    const runtime = new AgentRuntime({ modelClient: client, tools: new AgentToolRegistry() })
+    const events: string[] = []
+
+    await expect(runtime.run({
+      messages: ['hi'],
+      onEvent: event => events.push(event.type),
+    })).rejects.toThrow('still failing')
+
+    expect(DEFAULT_AGENT_MODEL_MAX_RETRIES).toBe(3)
+    expect(client.create).toHaveBeenCalledTimes(4)
+    expect(events.filter(event => event === 'model.retry')).toHaveLength(3)
+    expect(events.at(-1)).toBe('run.failed')
   })
 
   it('builds a system prompt from runtime, skills, tools, and user system messages', async () => {
@@ -179,10 +335,13 @@ describe('ekko-agent runtime', () => {
     await new AgentRuntime({ modelClient: client, tools }).run({ messages: ['hi'] })
   })
 
-  it('buildSystemPrompt can be used directly', () => {
-    expect(buildSystemPrompt({
+  it('buildSystemPrompt omits structured tool descriptions', () => {
+    const prompt = buildSystemPrompt({
       basePrompt: 'Base',
-      tools: [{ name: 'read_file' }],
-    })).toContain('- read_file')
+    })
+
+    expect(prompt).toContain('Base')
+    expect(prompt).not.toContain('Available Tools')
+    expect(prompt).not.toContain('read_file')
   })
 })

--- a/tests/ekko-agent/tools.test.ts
+++ b/tests/ekko-agent/tools.test.ts
@@ -67,6 +67,40 @@ describe('ekko-agent tools', () => {
     })
   })
 
+  it('normalizes shell-like terminal command strings when args are omitted', async () => {
+    const terminal = new TerminalExecTool()
+
+    await expect(terminal.execute({
+      command: `${process.execPath} -e "process.stdout.write(process.argv[1])" hello-split`,
+    }, { workspaceRoot })).resolves.toMatchObject({
+      ok: true,
+      content: 'hello-split',
+      data: {
+        command: process.execPath,
+        args: ['-e', 'process.stdout.write(process.argv[1])', 'hello-split'],
+        exitCode: 0,
+      },
+    })
+  })
+
+  it('does not start terminal commands when the signal is already aborted', async () => {
+    const terminal = new TerminalExecTool()
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(terminal.execute({
+      command: process.execPath,
+      args: ['-e', 'process.stdout.write("should-not-run")'],
+    }, { workspaceRoot, signal: controller.signal })).resolves.toMatchObject({
+      ok: false,
+      content: 'Command aborted.',
+      error: 'Command aborted.',
+      data: {
+        aborted: true,
+      },
+    })
+  })
+
   it('reports non-zero terminal exits without throwing', async () => {
     const terminal = new TerminalExecTool()
 


### PR DESCRIPTION
## Summary

- Add dev-only Ekko Agent chat entry and keep protocol selection hidden for Ekko Agent.
- Move Ekko Agent provider protocol resolution/fallback into `packages/ekko-agent`, with explicit api mode honored before inferred fallback.
- Add streaming deltas, reasoning events, model retries, abort handling, tool failure/status handling, terminal timeout/signal support, and pacing safeguards for Ekko Agent runs.
- Fix Ekko Agent tool result rendering/status persistence and expand the chat input click target.
- Add chat-chain change documentation and focused Ekko Agent tests.

## Impact

Ekko Agent is exposed only in dev mode for chat creation. Existing Hermes, group chat, workflow, Claude Code, and Codex paths keep their existing protocol behavior. Failed Ekko Agent tools now surface as failed instead of remaining loading.

## Validation

- `npm --prefix packages/ekko-agent run check`
- `npm test -- tests/ekko-agent`
- `npm exec tsc -- --noEmit -p packages/server/tsconfig.json`
- `npm exec vue-tsc -- -b`
- `npm run harness:check`