### PR TITLE
修复 Codex Coding Agent 误用 app-server API 模式

### DIFF
--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -578,12 +578,12 @@ async function resolveStoredProviderLaunchInput(
 function normalizeLaunchApiMode(value: unknown, fallback: ApiMode): ApiMode {
   if (!value) return fallback
   const mode = String(value).trim() as ApiMode
-  if (!LAUNCH_API_MODES.has(mode)) {
-    const err = new Error('Invalid API protocol')
-    ;(err as any).status = 400
-    throw err
-  }
-  return mode
+  if (LAUNCH_API_MODES.has(mode)) return mode
+  if (mode === 'codex_app_server') return 'codex_responses'
+
+  const err = new Error('Invalid API protocol')
+  ;(err as any).status = 400
+  throw err
 }
 
 function storedCodingAgentMode(session: HermesSessionRow | null): 'scoped' | 'global' {

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -9,8 +9,10 @@ import { prepareCodingAgentLaunch } from '../../packages/server/src/services/cod
 const homes: string[] = []
 
 function mockProcessUid(uid: number) {
-  vi.spyOn(process, 'getuid').mockReturnValue(uid)
-  vi.spyOn(process, 'geteuid').mockReturnValue(uid)
+  vi.stubGlobal('process', Object.assign(process, {
+    getuid: vi.fn(() => uid),
+    geteuid: vi.fn(() => uid),
+  }))
 }
 
 function makeHome() {
@@ -467,6 +469,28 @@ describe('coding agent launch preparation', () => {
     expect(deepseekModel.context_window).toBeGreaterThan(0)
     expect(deepseekModel.max_context_window).toBe(deepseekModel.context_window)
     expect(deepseekModel.model_messages.instructions_template).toContain('{{ base_instructions }}')
+  })
+
+  it('normalizes Codex app-server provider mode to Responses for scoped Codex runs', async () => {
+    const home = makeHome()
+
+    const result = await prepareCodingAgentLaunch('codex', {
+      profile: 'default',
+      provider: 'ai-pixel.online',
+      model: 'gpt-5.5',
+      baseUrl: 'https://ai-pixel.online/v1',
+      apiKey: 'sk-upstream',
+      apiMode: 'codex_app_server' as any,
+    })
+
+    const config = readFileSync(join(result.rootDir, 'config.toml'), 'utf-8')
+    expect(config).toContain(`base_url = "http://127.0.0.1:`)
+    expect(config).toContain('/api/codex-proxy/')
+    expect(config).toContain('wire_api = "responses"')
+    expect(config).toContain('requires_openai_auth = false')
+    expect(config).toMatch(/experimental_bearer_token = "hwui_[^"]+"/)
+    expect(config).not.toContain('base_url = "https://ai-pixel.online/v1"')
+    expect(result.rootDir).toBe(join(home, 'coding-agent', 'model', 'default', 'ai-pixel.online', 'codex'))
   })
 
   it('defaults Codex providers without an api mode to Chat Completions', async () => {


### PR DESCRIPTION
## 背景
在 Hermes Studio 里使用 Codex Coding Agent 时，如果保存的 provider 配置里带有 `api_mode: codex_app_server`，scoped Coding Agent 启动链路会把这个 Hermes Agent 内部 runtime 协议当作普通上游协议处理。Windows 桌面环境下这会触发本地 `codex app-server` 启动失败，用户侧可能只看到 `Agent returned no output`。
## 修改
在 Coding Agent launch 服务端规范化 `apiMode` 时，将 `codex_app_server` 降级为 Codex scoped run 可用的 `codex_responses`。 保持其他不支持协议继续返回 `Invalid API protocol`。 增加服务端回归测试，确认 `codex_app_server` provider 会走 Hermes Studio 本地 Codex Responses proxy，并写入 `wire_api = "responses"`。
## 验证
✅ `vitest run tests/client/coding-agent-api-modes.test.ts`
 ✅ `vitest run tests/server/coding-agents-launch.test.ts -t "normalizes Codex app-server provider mode"`
⚠️ 运行完整 `tests/server/coding-agents-launch.test.ts` 时，本地 Windows 环境仍有既有断言失败（例如测试预期 `8648`，实际桌面端为 `8748`；以及 Windows shell command/路径转义差异），新增用例本身通过。
🤖 Generated with [Claude Code](https://claude.com/claude-code)