### PR TITLE
修复 Agent Bridge 在 Windows 上命中保留端口的问题

### DIFF
--- a/docs/chat-chain-changes/2026-07-04-pr1934-windows-worker-port.md
+++ b/docs/chat-chain-changes/2026-07-04-pr1934-windows-worker-port.md
@@ -1,0 +1,9 @@
+﻿---
+date: 2026-07-04
+pr: 1934
+commit: 90c4edd
+feature: Windows Agent Bridge 工作进程端口选择
+impact: 当桌面运行时提供 Windows 动态/私有端口段内的 worker port base 时，Agent Bridge 回退到默认安全端口段，避免命中系统保留端口导致 profile worker 启动失败；不改变 chat-run 协议、消息落库或工具审批行为。
+---
+
+`bridge_transport.py` 在 Windows TCP worker 端点计算中会识别 `HERMES_AGENT_BRIDGE_WORKER_PORT_BASE` 是否落入 49152-65535 动态/私有端口段；若落入该范围，则改用默认的 18780 基准端口，避免哈希偏移后选中被系统排除的端口并触发 `WinError 10013`。

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
@@ -176,6 +176,14 @@ def _worker_endpoint(key: str, namespace: str | None = None) -> str:
     use_tcp = transport == "tcp" or (transport not in {"ipc", "unix"} and os.name == "nt")
     if use_tcp:
         port_base = int(os.environ.get("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE", "18780"))
+        # Windows can reserve/exclude ports in the dynamic range (49152-65535).
+        # Desktop/runtime environments may provide a high worker port base; adding
+        # the per-worker hash can then choose an excluded port and make the
+        # profile worker exit before it can report ready. Prefer the known-safe
+        # default range for Windows worker ports when the configured base falls
+        # in that dynamic range.
+        if os.name == "nt" and port_base >= 49152:
+            port_base = 18780
         return f"tcp://127.0.0.1:{port_base + int(safe[:4], 16) % 1000}"
     root = Path(tempfile.gettempdir()) / "hermes-agent-bridge-workers"
     return f"ipc://{root / f'{safe}.sock'}"

--- a/tests/server/agent-bridge-worker-endpoint.test.ts
+++ b/tests/server/agent-bridge-worker-endpoint.test.ts
@@ -1,0 +1,66 @@
+﻿import { execFileSync } from 'child_process'
+import { describe, expect, it } from 'vitest'
+
+function runPython(script: string): any {
+  try {
+    const output = execFileSync(process.platform === 'win32' ? 'python' : 'python3', ['-c', script], {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    })
+    return JSON.parse(output)
+  } catch (error) {
+    const err = error as { stdout?: string; stderr?: string; message?: string }
+    throw new Error([
+      err.message || 'Python bridge transport script failed',
+      err.stdout ? `stdout:\n${err.stdout}` : '',
+      err.stderr ? `stderr:\n${err.stderr}` : '',
+    ].filter(Boolean).join('\n\n'))
+  }
+}
+
+describe('agent bridge worker endpoint', () => {
+  it('avoids high dynamic worker port bases on Windows', () => {
+    const result = runPython(String.raw`
+import importlib.util
+import json
+import os
+import sys
+import types
+
+bridge_runtime = types.ModuleType("bridge_runtime")
+bridge_runtime._hidden_subprocess_kwargs = lambda: {}
+bridge_runtime._json_line_bytes = lambda req: (json.dumps(req) + "\n").encode("utf-8")
+bridge_runtime._platform_text_encoding = lambda: "utf-8"
+sys.modules["bridge_runtime"] = bridge_runtime
+
+spec = importlib.util.spec_from_file_location(
+    "bridge_transport",
+    "packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py",
+)
+bridge_transport = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(bridge_transport)
+
+original_name = bridge_transport.os.name
+original_env = os.environ.get("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE")
+try:
+    bridge_transport.os.name = "nt"
+    os.environ["HERMES_AGENT_BRIDGE_WORKER_PORT_BASE"] = "50813"
+    endpoint = bridge_transport._worker_endpoint("default", "tcp://127.0.0.1:56618")
+finally:
+    bridge_transport.os.name = original_name
+    if original_env is None:
+        os.environ.pop("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE", None)
+    else:
+        os.environ["HERMES_AGENT_BRIDGE_WORKER_PORT_BASE"] = original_env
+
+port = int(endpoint.rsplit(":", 1)[1])
+print(json.dumps({"endpoint": endpoint, "port": port}))
+`)
+
+    expect(result.endpoint).toMatch(/^tcp:\/\/127\.0\.0\.1:\d+$/)
+    expect(result.port).toBeGreaterThanOrEqual(18780)
+    expect(result.port).toBeLessThan(19780)
+  })
+})


### PR DESCRIPTION
## 概要
- 避免 Agent Bridge 的 profile worker 使用 Windows 动态/私有端口段内的高位端口基准值。
- 当 `HERMES_AGENT_BRIDGE_WORKER_PORT_BASE` 落入 Windows 动态/私有端口段时，回退到已知安全的默认 worker 端口范围。
- 增加 Windows worker 端点计算的回归测试。
- 补充 `docs/chat-chain-changes/` 变更片段，满足仓库构建检查要求。

## 背景
Windows 上动态/私有端口段可能被系统保留或排除。桌面运行时如果传入较高的 worker port base（例如 `50813`），再叠加每个 worker 的哈希偏移后，可能选中被系统排除的端口（已观察到 `51523`），导致 profile worker 绑定失败：

```text
PermissionError: [WinError 10013] An attempt was made to access a socket in a way forbidden by its access permissions
```

worker 会在上报 ready 之前退出，MCP UI 调用侧最终表现为：

```text
API Error 503: profile worker default exited before ready
```

## 测试
- `npm run harness:check`
- `npx vitest run tests/server/agent-bridge-worker-endpoint.test.ts`（本地未安装依赖时会因缺少 `vitest/config` / `@vitejs/plugin-vue` 无法加载配置；CI 环境安装依赖后应可执行）