### PR TITLE
Group Chat 新功能线基线测试

### DIFF
--- a/tests/client/group-chat-store-baseline.test.ts
+++ b/tests/client/group-chat-store-baseline.test.ts
@@ -1,0 +1,281 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import type { ChatMessage, MemberInfo, RoomAgent, RoomInfo } from '@/api/hermes/group-chat'
+
+const groupChatApiMock = vi.hoisted(() => {
+  const handlers = new Map<string, Function[]>()
+  let joinAck: any = { members: [], agents: [], typingUsers: [], contextStatuses: [] }
+  const socket: any = {
+    connected: true,
+    id: 'socket-1',
+    on: vi.fn((event: string, cb: Function) => {
+      const existing = handlers.get(event) || []
+      existing.push(cb)
+      handlers.set(event, existing)
+      return socket
+    }),
+    emit: vi.fn((event: string, data?: any, ack?: Function) => {
+      if (event === 'join' && ack) ack(joinAck)
+      if (event === 'message' && ack) ack({ id: data?.id })
+      return socket
+    }),
+    disconnect: vi.fn(),
+  }
+  return {
+    handlers,
+    socket,
+    setJoinAck: (value: any) => { joinAck = value },
+    connectGroupChat: vi.fn(() => socket),
+    disconnectGroupChat: vi.fn(),
+    getSocket: vi.fn(() => socket),
+    getStoredUserId: vi.fn(() => 'user-1'),
+    getStoredUserName: vi.fn(() => 'tester'),
+    createRoom: vi.fn(),
+    listRooms: vi.fn(),
+    getRoomDetail: vi.fn(),
+    joinRoomByCode: vi.fn(),
+    addAgent: vi.fn(),
+    listAgents: vi.fn(),
+    removeAgent: vi.fn(),
+    cloneRoom: vi.fn(),
+    deleteRoom: vi.fn(),
+    clearRoomContext: vi.fn(),
+  }
+})
+const clientApiMock = vi.hoisted(() => ({
+  getApiKey: vi.fn(() => 'test-token'),
+  getActiveProfileName: vi.fn(() => 'research'),
+  getStoredUsername: vi.fn(() => null),
+}))
+const authApiMock = vi.hoisted(() => ({
+  fetchCurrentUser: vi.fn(),
+}))
+const fetchMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/api/hermes/group-chat', () => groupChatApiMock)
+vi.mock('@/api/client', () => clientApiMock)
+vi.mock('@/api/auth', () => authApiMock)
+vi.mock('@/api/hermes/download', () => ({ getDownloadUrl: vi.fn((path: string) => `/download?path=${path}`) }))
+vi.stubGlobal('fetch', fetchMock)
+
+function emitSocket(event: string, payload: unknown) {
+  for (const cb of groupChatApiMock.handlers.get(event) || []) cb(payload)
+}
+
+const room: RoomInfo = {
+  id: 'room-1',
+  name: 'Test Room',
+  inviteCode: 'ROOM1',
+  totalTokens: 7,
+} as RoomInfo
+
+const member: MemberInfo = {
+  id: 'member-1',
+  userId: 'user-1',
+  name: 'tester',
+  joinedAt: 1,
+  online: true,
+  socketId: 'socket-1',
+} as MemberInfo
+
+const agent: RoomAgent = {
+  id: 'row-agent',
+  roomId: 'room-1',
+  agentId: 'agent-1',
+  profile: 'default',
+  name: 'Agent',
+  description: '',
+  invited: 0,
+} as RoomAgent
+
+function userMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'msg-1',
+    roomId: 'room-1',
+    senderId: 'user-1',
+    senderName: 'tester',
+    content: 'hello',
+    timestamp: 1,
+    role: 'user',
+    ...overrides,
+  }
+}
+
+async function loadStore() {
+  const { useGroupChatStore } = await import('@/stores/hermes/group-chat')
+  return useGroupChatStore()
+}
+
+describe('group chat store baseline lifecycle', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    setActivePinia(createPinia())
+    localStorage.clear()
+    groupChatApiMock.handlers.clear()
+    groupChatApiMock.setJoinAck({ members: [], agents: [], typingUsers: [], contextStatuses: [] })
+    for (const key of Object.keys(groupChatApiMock)) {
+      const value = (groupChatApiMock as any)[key]
+      if (value?.mockReset && key !== 'socket') value.mockReset()
+    }
+    groupChatApiMock.connectGroupChat.mockReturnValue(groupChatApiMock.socket)
+    groupChatApiMock.disconnectGroupChat.mockReset()
+    groupChatApiMock.getSocket.mockReturnValue(groupChatApiMock.socket)
+    groupChatApiMock.getStoredUserId.mockReturnValue('user-1')
+    groupChatApiMock.getStoredUserName.mockReturnValue('Stored User')
+    groupChatApiMock.getRoomDetail.mockResolvedValue({ room, messages: [], agents: [], members: [], total: 0, hasMore: false })
+    groupChatApiMock.clearRoomContext.mockResolvedValue({ success: true, room: { ...room, totalTokens: 0 } })
+    clientApiMock.getApiKey.mockReturnValue('test-token')
+    clientApiMock.getActiveProfileName.mockReturnValue('research')
+    clientApiMock.getStoredUsername.mockReturnValue(null)
+    authApiMock.fetchCurrentUser.mockRejectedValue(new Error('not signed in'))
+    fetchMock.mockReset()
+    groupChatApiMock.socket.on.mockClear()
+    groupChatApiMock.socket.emit.mockReset()
+    groupChatApiMock.socket.emit.mockImplementation((event: string, data?: any, ack?: Function) => {
+      if (event === 'join' && ack) ack({ members: [], agents: [], typingUsers: [], contextStatuses: [] })
+      if (event === 'message' && ack) ack({ id: data?.id })
+      return groupChatApiMock.socket
+    })
+    groupChatApiMock.socket.disconnect.mockClear()
+  })
+
+  it('connects with stored user data and registers realtime handlers', async () => {
+    const store = await loadStore()
+
+    await store.connect()
+
+    expect(groupChatApiMock.connectGroupChat).toHaveBeenCalledWith({
+      userId: 'user-1',
+      userName: 'Stored User',
+      authUserId: undefined,
+    })
+    expect(groupChatApiMock.socket.on).toHaveBeenCalledWith('message', expect.any(Function))
+    expect(groupChatApiMock.socket.on).toHaveBeenCalledWith('approval.requested', expect.any(Function))
+    expect(groupChatApiMock.socket.on).toHaveBeenCalledWith('room_cleared', expect.any(Function))
+  })
+
+  it('joins a room from REST detail and realtime ack state', async () => {
+    const store = await loadStore()
+    const detailMessage = userMessage({ id: 'msg-1' })
+    groupChatApiMock.getRoomDetail.mockResolvedValue({
+      room,
+      messages: [detailMessage],
+      agents: [agent],
+      members: [member],
+      total: 5,
+      hasMore: true,
+    })
+    groupChatApiMock.socket.emit.mockImplementation((event: string, data?: any, ack?: Function) => {
+      if (event === 'join' && ack) ack({
+        roomName: 'Realtime Room',
+        members: [{ ...member, name: 'Realtime User' }],
+        agents: [agent],
+        typingUsers: [],
+        contextStatuses: [{ agentName: 'Agent', status: 'replying' }],
+      })
+      return groupChatApiMock.socket
+    })
+
+    await store.connect()
+    await store.joinRoom('room-1')
+
+    expect(groupChatApiMock.getRoomDetail).toHaveBeenCalledWith('room-1')
+    expect(groupChatApiMock.socket.emit).toHaveBeenCalledWith('join', expect.objectContaining({ roomId: 'room-1' }), expect.any(Function))
+    expect(store.currentRoomId).toBe('room-1')
+    expect(store.roomName).toBe('Realtime Room')
+    expect(store.messages.map((m: ChatMessage) => m.id)).toEqual(['msg-1'])
+    expect(store.members.map((m: MemberInfo) => m.name)).toEqual(['Realtime User'])
+    expect(store.agents.map((a: RoomAgent) => a.agentId)).toEqual(['agent-1'])
+    expect(store.totalMessages).toBe(5)
+    expect(store.hasMoreBefore).toBe(true)
+    expect(store.contextStatuses.get('Agent')).toEqual({ agentName: 'Agent', status: 'replying' })
+  })
+
+  it('sends text-only messages through the room socket', async () => {
+    const store = await loadStore()
+    await store.connect()
+    await store.joinRoom('room-1')
+
+    await store.sendMessage('hello room')
+
+    expect(groupChatApiMock.socket.emit).toHaveBeenCalledWith('message', expect.objectContaining({
+      roomId: 'room-1',
+      content: 'hello room',
+    }), expect.any(Function))
+    expect(store.error).toBeNull()
+  })
+
+  it('clears local room context from API response and room_cleared event', async () => {
+    const store = await loadStore()
+    groupChatApiMock.getRoomDetail.mockResolvedValue({
+      room,
+      messages: [userMessage()],
+      agents: [agent],
+      members: [member],
+      total: 1,
+      hasMore: false,
+    })
+    await store.connect()
+    await store.joinRoom('room-1')
+    store.rooms = [room]
+    emitSocket('typing', { roomId: 'room-1', userId: 'user-2', userName: 'Bob' })
+    store.contextStatuses.set('Agent', { agentName: 'Agent', status: 'replying' })
+    store.pendingApprovals.set('approval-1', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      approvalId: 'approval-1',
+      command: 'touch file',
+      description: 'needs approval',
+      choices: ['once', 'session', 'deny'],
+      allowPermanent: false,
+      isMemoryWrite: false,
+      requestedAt: 1,
+    })
+
+    await store.clearCurrentRoomContext()
+
+    expect(groupChatApiMock.clearRoomContext).toHaveBeenCalledWith('room-1')
+    expect(store.messages).toEqual([])
+    expect(store.typingNames).toEqual([])
+    expect(store.contextStatuses.size).toBe(0)
+    expect(store.rooms[0].totalTokens).toBe(0)
+
+    emitSocket('room_cleared', { roomId: 'room-1', totalTokens: 0 })
+    expect(store.pendingApprovals.size).toBe(0)
+  })
+
+  it('tracks pending approvals and removes them when resolved', async () => {
+    const store = await loadStore()
+    await store.connect()
+    await store.joinRoom('room-1')
+
+    emitSocket('approval.requested', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      approval_id: 'approval-1',
+      command: 'touch file',
+      description: 'needs approval',
+      choices: ['once', 'session', 'deny'],
+    })
+
+    expect(store.pendingApprovals.get('approval-1')).toMatchObject({
+      roomId: 'room-1',
+      agentName: 'Agent',
+      approvalId: 'approval-1',
+      choices: ['once', 'session', 'deny'],
+    })
+    emitSocket('approval.resolved', { approval_id: 'approval-1' })
+    expect(store.pendingApprovals.size).toBe(0)
+  })
+
+  it('updates the current room token display on room_updated', async () => {
+    const store = await loadStore()
+    store.rooms = [{ ...room, totalTokens: 7 }]
+    await store.connect()
+
+    emitSocket('room_updated', { roomId: 'room-1', totalTokens: 42 })
+
+    expect(store.rooms[0].totalTokens).toBe(42)
+  })
+})

--- a/tests/server/chat-run-baseline.test.ts
+++ b/tests/server/chat-run-baseline.test.ts
@@ -1,0 +1,130 @@
+import { EventEmitter } from 'events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ioMock = vi.hoisted(() => vi.fn())
+const scenarioMock = vi.hoisted(() => ({
+  emitRunEvents: vi.fn(),
+}))
+
+vi.mock('socket.io-client', () => ({
+  io: ioMock,
+}))
+
+function makeSocket() {
+  const emitter = new EventEmitter() as EventEmitter & {
+    emit: ReturnType<typeof vi.fn>
+    disconnect: ReturnType<typeof vi.fn>
+    emitNative: (event: string, payload?: unknown) => boolean
+  }
+  const nativeEmit = EventEmitter.prototype.emit.bind(emitter)
+  emitter.emitNative = nativeEmit
+  emitter.emit = vi.fn((event: string, payload?: unknown) => {
+    if (event === 'run') {
+      process.nextTick(() => scenarioMock.emitRunEvents(nativeEmit, payload))
+    }
+    return true
+  }) as any
+  emitter.disconnect = vi.fn()
+  return emitter
+}
+
+function makeCtx(body: Record<string, unknown>) {
+  return {
+    get: vi.fn((name: string) => name.toLowerCase() === 'authorization' ? 'Bearer token-1' : ''),
+    state: { profile: { name: 'default' } },
+    request: { body },
+    status: 200,
+    body: undefined as any,
+  }
+}
+
+describe('chat-run action/event baseline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns requires_action when approval is requested', async () => {
+    const socket = makeSocket()
+    ioMock.mockReturnValue(socket)
+    scenarioMock.emitRunEvents.mockImplementation((emitNative: Function) => {
+      emitNative('run.started', { run_id: 'run-1' })
+      emitNative('approval.requested', { run_id: 'run-1', approval_id: 'approval-1', command: 'touch file' })
+    })
+
+    const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
+    const ctx = makeCtx({ session_id: 'session-1', input: 'needs approval', include_events: true })
+    const pending = runOnce(ctx as any)
+    socket.emitNative('connect')
+    await pending
+
+    expect(ctx.status).toBe(409)
+    expect(ctx.body).toMatchObject({
+      ok: false,
+      status: 'requires_action',
+      event: 'approval.requested',
+      session_id: 'session-1',
+      run_id: 'run-1',
+      action: { event: 'approval.requested', approval_id: 'approval-1' },
+    })
+    expect(ctx.body.events.map((event: any) => event.event)).toEqual(['run.started', 'approval.requested'])
+  })
+
+  it('returns requires_action when clarification is requested', async () => {
+    const socket = makeSocket()
+    ioMock.mockReturnValue(socket)
+    scenarioMock.emitRunEvents.mockImplementation((emitNative: Function) => {
+      emitNative('run.started', { run_id: 'run-1' })
+      emitNative('clarify.requested', { run_id: 'run-1', question: 'Which room?' })
+    })
+
+    const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
+    const ctx = makeCtx({ session_id: 'session-1', input: 'needs clarify', include_events: true })
+    const pending = runOnce(ctx as any)
+    socket.emitNative('connect')
+    await pending
+
+    expect(ctx.status).toBe(409)
+    expect(ctx.body).toMatchObject({
+      ok: false,
+      status: 'requires_action',
+      event: 'clarify.requested',
+      action: { event: 'clarify.requested', question: 'Which room?' },
+    })
+  })
+
+  it('records bounded event history and accumulates output/reasoning when include_events is true', async () => {
+    const socket = makeSocket()
+    ioMock.mockReturnValue(socket)
+    scenarioMock.emitRunEvents.mockImplementation((emitNative: Function) => {
+      emitNative('run.started', { run_id: 'run-1' })
+      emitNative('reasoning.delta', { run_id: 'run-1', delta: 'thought' })
+      emitNative('tool.started', { run_id: 'run-1', name: 'lookup' })
+      emitNative('tool.completed', { run_id: 'run-1', name: 'lookup' })
+      emitNative('message.delta', { run_id: 'run-1', delta: 'hello' })
+      emitNative('run.completed', { run_id: 'run-1' })
+    })
+
+    const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
+    const ctx = makeCtx({ session_id: 'session-1', input: 'hello', include_events: true })
+    const pending = runOnce(ctx as any)
+    socket.emitNative('connect')
+    await pending
+
+    expect(ctx.status).toBe(200)
+    expect(ctx.body).toMatchObject({
+      ok: true,
+      status: 'completed',
+      output: 'hello',
+      reasoning: 'thought',
+      run_id: 'run-1',
+    })
+    expect(ctx.body.events.map((event: any) => event.event)).toEqual([
+      'run.started',
+      'reasoning.delta',
+      'tool.started',
+      'tool.completed',
+      'message.delta',
+      'run.completed',
+    ])
+  })
+})

--- a/tests/server/coding-agent-baseline.test.ts
+++ b/tests/server/coding-agent-baseline.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const managerMock = vi.hoisted(() => ({
+  runIdForSession: vi.fn(),
+  isSessionLaunchCompatible: vi.fn(),
+  isSessionProcessing: vi.fn(),
+  stop: vi.fn(),
+}))
+const startCodingAgentRunMock = vi.hoisted(() => vi.fn())
+const sendCodingAgentRunInputMock = vi.hoisted(() => vi.fn())
+const writeModelRunProfileTokenMock = vi.hoisted(() => vi.fn(async () => undefined))
+const getSystemPromptMock = vi.hoisted(() => vi.fn(() => 'system prompt'))
+const getSessionMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../packages/server/src/services/agent-runner/coding-agent-run-manager', () => ({
+  codingAgentRunManager: managerMock,
+}))
+vi.mock('../../packages/server/src/services/coding-agents', () => ({
+  startCodingAgentRun: startCodingAgentRunMock,
+  sendCodingAgentRunInput: sendCodingAgentRunInputMock,
+}))
+vi.mock('../../packages/server/src/services/hermes/run-chat/model-run-prompt', () => ({
+  writeModelRunProfileToken: writeModelRunProfileTokenMock,
+}))
+vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
+  getSystemPrompt: getSystemPromptMock,
+}))
+vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
+  getSession: getSessionMock,
+}))
+
+function state() {
+  return {
+    messages: [],
+    isWorking: false,
+    isAborting: false,
+    events: [],
+    queue: [],
+  } as any
+}
+
+function socket() {
+  return {
+    data: {},
+    join: vi.fn(),
+    emit: vi.fn(),
+  }
+}
+
+describe('coding-agent dispatch baseline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    managerMock.runIdForSession.mockReturnValue(undefined)
+    managerMock.isSessionLaunchCompatible.mockReturnValue(true)
+    managerMock.isSessionProcessing.mockReturnValue(false)
+    startCodingAgentRunMock.mockResolvedValue({ agentSessionId: 'agent-session-1' })
+    sendCodingAgentRunInputMock.mockResolvedValue({ runId: 'agent-session-1' })
+    writeModelRunProfileTokenMock.mockResolvedValue(undefined)
+    getSystemPromptMock.mockReturnValue('system prompt')
+    getSessionMock.mockReturnValue(null)
+  })
+
+  it('dispatches an explicit coding_agent_id and passes local proxy fields through', async () => {
+    const { handleCodingAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-coding-agent-run')
+    const runState = state()
+    const sessionMap = new Map([['session-1', runState]])
+    const runSocket = socket()
+
+    await handleCodingAgentRun({} as any, runSocket as any, {
+      session_id: 'session-1',
+      input: 'hello codex',
+      source: 'coding_agent',
+      coding_agent_id: 'codex',
+      baseUrl: 'http://127.0.0.1:1234',
+      apiKey: 'local-test-key',
+      apiMode: 'responses',
+    }, 'default', sessionMap as any)
+
+    expect(startCodingAgentRunMock).toHaveBeenCalledWith('codex', expect.objectContaining({
+      sessionId: 'session-1',
+      mode: 'scoped',
+      profile: 'default',
+      baseUrl: 'http://127.0.0.1:1234',
+      apiKey: 'local-test-key',
+      apiMode: 'responses',
+    }), runState)
+    expect(sendCodingAgentRunInputMock).toHaveBeenCalledWith('session-1', 'hello codex', 'system prompt')
+  })
+
+  it('uses agent_id as an alias when coding_agent_id is omitted', async () => {
+    const { handleCodingAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-coding-agent-run')
+    const runState = state()
+    const sessionMap = new Map([['session-1', runState]])
+
+    await handleCodingAgentRun({} as any, socket() as any, {
+      session_id: 'session-1',
+      input: 'hello alias',
+      source: 'coding_agent',
+      agent_id: 'codex',
+      base_url: 'http://127.0.0.1:2345',
+      api_key: 'alias-test-key',
+      api_mode: 'chat_completions',
+    }, 'default', sessionMap as any)
+
+    expect(startCodingAgentRunMock).toHaveBeenCalledWith('codex', expect.objectContaining({
+      baseUrl: 'http://127.0.0.1:2345',
+      apiKey: 'alias-test-key',
+      apiMode: 'chat_completions',
+    }), runState)
+  })
+
+  it('stringifies ContentBlock input before sending it to the coding agent', async () => {
+    const { handleCodingAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-coding-agent-run')
+    const blocks = [{ type: 'text', text: 'hello blocks' }]
+
+    await handleCodingAgentRun({} as any, socket() as any, {
+      session_id: 'session-1',
+      input: blocks as any,
+      coding_agent_id: 'claude-code',
+    }, 'default', new Map([['session-1', state()]]) as any)
+
+    expect(sendCodingAgentRunInputMock).toHaveBeenCalledWith('session-1', JSON.stringify(blocks), 'system prompt')
+  })
+
+  it('fails fast when session_id is missing', async () => {
+    const { handleCodingAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-coding-agent-run')
+    const runSocket = socket()
+
+    await handleCodingAgentRun({} as any, runSocket as any, {
+      input: 'missing session',
+      coding_agent_id: 'codex',
+    }, 'default', new Map() as any)
+
+    expect(runSocket.emit).toHaveBeenCalledWith('run.failed', {
+      event: 'run.failed',
+      error: 'session_id is required for coding agent runs',
+    })
+    expect(startCodingAgentRunMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/server/group-chat-agent-routing-baseline.test.ts
+++ b/tests/server/group-chat-agent-routing-baseline.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  connectGroupChatClient,
+  createTestGroupChatServer,
+  emitAck,
+} from './group-chat-test-helpers'
+import { GROUP_CHAT_AGENT_SOCKET_SECRET } from '../../packages/server/src/services/hermes/group-chat/agent-clients'
+import type { GroupChatServer } from '../../packages/server/src/services/hermes/group-chat'
+
+describe('group chat agent routing baseline', () => {
+  let harness: Awaited<ReturnType<typeof createTestGroupChatServer>>
+  let groupServer: GroupChatServer
+  let port: number
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    harness = await createTestGroupChatServer()
+    groupServer = harness.groupServer
+    port = harness.port
+    groupServer.getStorage().saveRoom('room-1', 'Room 1', 'ROOM1')
+    groupServer.getStorage().addRoomAgent('room-1', 'agent-worker', 'default', 'Worker', '', 0)
+  })
+
+  afterEach(() => {
+    harness?.cleanup()
+  })
+
+  async function joinHumanAndAgent() {
+    const human = await connectGroupChatClient(port, 'human-1', 'Human')
+    const agent = await connectGroupChatClient(port, 'agent-worker', 'Worker', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    harness.sockets.push(human, agent)
+    await emitAck(human, 'join', { roomId: 'room-1' })
+    await emitAck(agent, 'join', { roomId: 'room-1' })
+    return { human, agent }
+  }
+
+  it('routes human messages through mention processing', async () => {
+    const { human } = await joinHumanAndAgent()
+    const processMentions = vi.spyOn(groupServer.agentClients, 'processMentions').mockResolvedValue(undefined)
+
+    await emitAck(human, 'message', { roomId: 'room-1', id: 'human-msg-1', content: '@Worker hello' })
+
+    expect(processMentions).toHaveBeenCalledWith('room-1', expect.objectContaining({
+      messageId: 'human-msg-1',
+      role: 'user',
+      mentionDepth: 0,
+    }))
+  })
+
+  it('routes agent replies below the default mention-depth guard', async () => {
+    const { agent } = await joinHumanAndAgent()
+    const processMentions = vi.spyOn(groupServer.agentClients, 'processMentions').mockResolvedValue(undefined)
+
+    await emitAck(agent, 'message', {
+      roomId: 'room-1',
+      id: 'agent-msg-1',
+      content: '@Worker chain handoff',
+      role: 'assistant',
+      mentionDepth: 3,
+    })
+
+    expect(processMentions).toHaveBeenCalledWith('room-1', expect.objectContaining({
+      messageId: 'agent-msg-1',
+      role: 'assistant',
+      mentionDepth: 3,
+    }))
+  })
+
+  it('does not route agent replies at the default mention-depth guard', async () => {
+    const { agent } = await joinHumanAndAgent()
+    const processMentions = vi.spyOn(groupServer.agentClients, 'processMentions').mockResolvedValue(undefined)
+
+    await emitAck(agent, 'message', {
+      roomId: 'room-1',
+      id: 'agent-msg-2',
+      content: '@Worker stop looping',
+      role: 'assistant',
+      mentionDepth: 4,
+    })
+
+    expect(processMentions).not.toHaveBeenCalled()
+  })
+})

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  connectGroupChatClient,
+  createTestGroupChatServer,
+  emitAck,
+  once,
+} from './group-chat-test-helpers'
+import type { GroupChatServer } from '../../packages/server/src/services/hermes/group-chat'
+
+describe('group chat approval and context baseline', () => {
+  let harness: Awaited<ReturnType<typeof createTestGroupChatServer>>
+  let groupServer: GroupChatServer
+  let port: number
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    harness = await createTestGroupChatServer()
+    groupServer = harness.groupServer
+    port = harness.port
+    groupServer.getStorage().saveRoom('room-1', 'Room 1', 'ROOM1')
+  })
+
+  afterEach(() => {
+    harness?.cleanup()
+  })
+
+  async function joinPair() {
+    const agent = await connectGroupChatClient(port, 'agent-1', 'Agent')
+    const human = await connectGroupChatClient(port, 'human-1', 'Human')
+    harness.sockets.push(agent, human)
+    await emitAck(agent, 'join', { roomId: 'room-1' })
+    await emitAck(human, 'join', { roomId: 'room-1' })
+    return { agent, human }
+  }
+
+  it('relays context status and updates room token count', async () => {
+    const { agent, human } = await joinPair()
+    const statusEvent = once<any>(human, 'context_status')
+    const roomUpdated = once<any>(human, 'room_updated')
+
+    agent.emit('context_status', { roomId: 'room-1', agentName: 'Agent', status: 'replying', totalTokens: 123 })
+
+    expect(await statusEvent).toEqual({ roomId: 'room-1', agentName: 'Agent', status: 'replying' })
+    expect(await roomUpdated).toEqual({ roomId: 'room-1', totalTokens: 123 })
+    expect(groupServer.getStorage().getRoom('room-1')).toMatchObject({ totalTokens: 123 })
+  })
+
+  it('clears ready context status from join recovery', async () => {
+    const { agent } = await joinPair()
+    agent.emit('context_status', { roomId: 'room-1', agentName: 'Agent', status: 'replying' })
+    agent.emit('context_status', { roomId: 'room-1', agentName: 'Agent', status: 'ready' })
+
+    const lateJoiner = await connectGroupChatClient(port, 'human-2', 'Late')
+    harness.sockets.push(lateJoiner)
+    const joined = await emitAck<any>(lateJoiner, 'join', { roomId: 'room-1' })
+
+    expect(joined.contextStatuses).toEqual([])
+  })
+
+  it('relays approval requested with default choices', async () => {
+    const { agent, human } = await joinPair()
+    const requested = once<any>(human, 'approval.requested')
+
+    agent.emit('approval.requested', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      approval_id: 'approval-1',
+      command: 'touch file',
+      description: 'needs approval',
+    })
+
+    expect(await requested).toMatchObject({
+      event: 'approval.requested',
+      roomId: 'room-1',
+      agentName: 'Agent',
+      approval_id: 'approval-1',
+      choices: ['once', 'session', 'deny'],
+    })
+  })
+
+  it('relays approval resolved with normalized choice', async () => {
+    const { agent, human } = await joinPair()
+    const resolved = once<any>(human, 'approval.resolved')
+
+    agent.emit('approval.resolved', { roomId: 'room-1', agentName: 'Agent', approval_id: 'approval-1', choice: 'deny' })
+
+    expect(await resolved).toEqual({
+      event: 'approval.resolved',
+      roomId: 'room-1',
+      agentName: 'Agent',
+      approval_id: 'approval-1',
+      choice: 'deny',
+    })
+  })
+
+  it('rejects approval responses from sockets that have not joined the room', async () => {
+    const outsider = await connectGroupChatClient(port, 'outsider', 'Outsider')
+    harness.sockets.push(outsider)
+
+    await expect(emitAck(outsider, 'approval.respond', { roomId: 'room-1', approval_id: 'approval-1', choice: 'deny' })).resolves.toEqual({ error: 'Not in room' })
+  })
+
+  it('emits room_cleared and room_updated when runtime state is cleared', async () => {
+    const { human } = await joinPair()
+    const cleared = once<any>(human, 'room_cleared')
+    const updated = once<any>(human, 'room_updated')
+
+    groupServer.clearRoomRuntimeState('room-1')
+
+    expect(await cleared).toEqual({ roomId: 'room-1', totalTokens: 0 })
+    expect(await updated).toEqual({ roomId: 'room-1', totalTokens: 0 })
+  })
+})

--- a/tests/server/group-chat-baseline.test.ts
+++ b/tests/server/group-chat-baseline.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  connectGroupChatClient,
+  createTestGroupChatServer,
+  emitAck,
+  once,
+} from './group-chat-test-helpers'
+import type { GroupChatServer } from '../../packages/server/src/services/hermes/group-chat'
+
+describe('group chat baseline behavior', () => {
+  let harness: Awaited<ReturnType<typeof createTestGroupChatServer>>
+  let groupServer: GroupChatServer
+  let port: number
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    harness = await createTestGroupChatServer()
+    groupServer = harness.groupServer
+    port = harness.port
+  })
+
+  afterEach(() => {
+    harness?.cleanup()
+  })
+
+  it('joins an existing room and returns room-level history and membership', async () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1', 'ROOM1')
+    storage.saveMessageAndRefreshRoom({
+      id: 'msg-1',
+      roomId: 'room-1',
+      senderId: 'user-a',
+      senderName: 'Alice',
+      content: 'existing',
+      timestamp: 1,
+      role: 'user',
+    } as any)
+
+    const alice = await connectGroupChatClient(port, 'user-a', 'Alice')
+    harness.sockets.push(alice)
+    const joined = await emitAck<any>(alice, 'join', { roomId: 'room-1' })
+
+    expect(joined).toMatchObject({ roomId: 'room-1' })
+    expect(joined.messages.map((m: any) => m.id)).toEqual(['msg-1'])
+    expect(joined.members.map((m: any) => m.name)).toContain('Alice')
+  })
+
+  it('persists a sent message and broadcasts it to other room members', async () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1', 'ROOM1')
+    const alice = await connectGroupChatClient(port, 'user-a', 'Alice')
+    const bob = await connectGroupChatClient(port, 'user-b', 'Bob')
+    harness.sockets.push(alice, bob)
+    await emitAck(alice, 'join', { roomId: 'room-1' })
+    await emitAck(bob, 'join', { roomId: 'room-1' })
+
+    const seenByBob = once<any>(bob, 'message')
+    const ack = await emitAck<any>(alice, 'message', { roomId: 'room-1', id: 'client-msg-1', content: 'hello room' })
+    const broadcast = await seenByBob
+
+    expect(ack).toEqual({ id: 'client-msg-1' })
+    expect(broadcast).toMatchObject({ id: 'client-msg-1', roomId: 'room-1', senderName: 'Alice', content: 'hello room', role: 'user' })
+    expect(storage.getMessage('client-msg-1')).toMatchObject({ content: 'hello room', senderName: 'Alice' })
+  })
+})

--- a/tests/server/group-chat-mention-routing.test.ts
+++ b/tests/server/group-chat-mention-routing.test.ts
@@ -68,6 +68,18 @@ describe('group chat mention routing', () => {
     expect(resolveMentionTargets(agents, '@alligator and @Bob compare plans', 'socket-alice').map(a => a.name)).toEqual(['Bob'])
   })
 
+  it('handles prefix collisions and special-character agent names', () => {
+    const specialAgents: TestAgent[] = [
+      { name: 'Bob', id: 'socket-bob', agentId: 'agent-bob' },
+      { name: 'Bobcat', id: 'socket-bobcat', agentId: 'agent-bobcat' },
+      { name: 'C++', id: 'socket-cpp', agentId: 'agent-cpp' },
+    ]
+
+    expect(resolveMentionTargets(specialAgents, '@Bobcat inspect', 'human-1').map(a => a.name)).toEqual(['Bobcat'])
+    expect(resolveMentionTargets(specialAgents, '@Bob inspect', 'human-1').map(a => a.name)).toEqual(['Bob'])
+    expect(resolveMentionTargets(specialAgents, '@C++: inspect', 'human-1').map(a => a.name)).toEqual(['C++'])
+  })
+
   it('dedupes mixed @all and explicit mentions', () => {
     expect(resolveMentionTargets(agents, '@all @Bob compare plans', 'socket-alice').map(a => a.name)).toEqual(['Bob', 'Regex.Bot'])
   })

--- a/tests/server/group-chat-routes-baseline.test.ts
+++ b/tests/server/group-chat-routes-baseline.test.ts
@@ -1,0 +1,178 @@
+import Koa from 'koa'
+import bodyParser from '@koa/bodyparser'
+import { createServer, type Server as HttpServer } from 'http'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { groupChatRoutes, setGroupChatServer } from '../../packages/server/src/routes/hermes/group-chat'
+
+function listen(server: HttpServer): Promise<string> {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => {
+    const addr = server.address()
+    if (!addr || typeof addr === 'string') throw new Error('missing address')
+    resolve(`http://127.0.0.1:${addr.port}`)
+  }))
+}
+
+describe('group chat REST route baseline', () => {
+  let httpServer: HttpServer
+  let baseUrl: string
+  let storage: any
+  let agentClients: any
+  let clearRoomRuntimeState: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    storage = {
+      rooms: new Map<string, any>(),
+      agents: new Map<string, any[]>(),
+      messages: new Map<string, any[]>(),
+      members: new Map<string, any[]>(),
+      saveRoom: vi.fn((id, name, inviteCode, config) => storage.rooms.set(id, { id, name, inviteCode, totalTokens: 0, sessionSeed: '0', ...config })),
+      getRoom: vi.fn((id) => storage.rooms.get(id)),
+      getAllRooms: vi.fn(() => [...storage.rooms.values()]),
+      getRoomsForProfiles: vi.fn(() => [...storage.rooms.values()]),
+      getRecentMessagesForUI: vi.fn((roomId, limit = 150, offset = 0) => (storage.messages.get(roomId) || []).slice(offset, offset + limit)),
+      getMessageCount: vi.fn((roomId) => (storage.messages.get(roomId) || []).length),
+      getRoomAgents: vi.fn((roomId) => storage.agents.get(roomId) || []),
+      getRoomMembers: vi.fn((roomId) => storage.members.get(roomId) || []),
+      getRoomByInviteCode: vi.fn((code) => [...storage.rooms.values()].find((r: any) => r.inviteCode === code)),
+      addRoomAgent: vi.fn((roomId, agentId, profile, name, description, invited) => {
+        const row = { id: `row-${agentId}`, roomId, agentId, profile, name, description, invited }
+        storage.agents.set(roomId, [...(storage.agents.get(roomId) || []), row])
+        return row
+      }),
+      getRoomAgent: vi.fn((roomId, ref) => (storage.agents.get(roomId) || []).find((a: any) => a.id === ref || a.agentId === ref) || null),
+      removeRoomMembersForAgent: vi.fn(),
+      removeRoomAgent: vi.fn((roomId, ref) => storage.agents.set(roomId, (storage.agents.get(roomId) || []).filter((a: any) => a.id !== ref && a.agentId !== ref))),
+      clearRoomContext: vi.fn((roomId) => { const room = storage.rooms.get(roomId); if (room) Object.assign(room, { totalTokens: 0, sessionSeed: 'rotated' }) }),
+      deleteRoom: vi.fn((roomId) => storage.rooms.delete(roomId)),
+    }
+    agentClients = {
+      createAgent: vi.fn(async (cfg: any) => {
+        if (cfg.profile === 'bad-profile') throw new Error('agent runtime unavailable')
+        return { ...cfg, joinRoom: vi.fn(async () => ({})), disconnect: vi.fn() }
+      }),
+      addAgentToRoom: vi.fn(async () => ({})),
+      removeAgentFromRoom: vi.fn(),
+      disconnectRoom: vi.fn(),
+    }
+    clearRoomRuntimeState = vi.fn()
+    setGroupChatServer({ getStorage: () => storage, agentClients, clearRoomRuntimeState } as any)
+    const app = new Koa()
+    app.use(bodyParser())
+    app.use(groupChatRoutes.routes())
+    httpServer = createServer(app.callback())
+    baseUrl = await listen(httpServer)
+  })
+
+  afterEach(() => {
+    httpServer.close()
+    setGroupChatServer(null as any)
+  })
+
+  it('requires name and inviteCode when creating a room', async () => {
+    const res = await fetch(`${baseUrl}/api/hermes/group-chat/rooms`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Room' }),
+    })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: 'name and inviteCode are required' })
+  })
+
+  it('rejects reserved @all agent names when creating a room', async () => {
+    const res = await fetch(`${baseUrl}/api/hermes/group-chat/rooms`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Room', inviteCode: 'ROOM1', agents: [{ profile: 'default', name: 'all' }] }),
+    })
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: '`all` is reserved for @all mentions' })
+  })
+
+  it('creates a room, persists successful agents, and reports agent connection failures', async () => {
+    const res = await fetch(`${baseUrl}/api/hermes/group-chat/rooms`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Room',
+        inviteCode: 'ROOM1',
+        agents: [
+          { profile: 'default', name: 'Worker' },
+          { profile: 'bad-profile', name: 'Broken' },
+        ],
+      }),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.room).toMatchObject({ name: 'Room', inviteCode: 'ROOM1' })
+    expect(body.agents).toHaveLength(1)
+    expect(body.agentResults).toEqual([
+      expect.objectContaining({ profile: 'default', ok: true }),
+      expect.objectContaining({ profile: 'bad-profile', ok: false, code: 'PROFILE_AGENT_CONNECT_FAILED' }),
+    ])
+    expect(storage.saveRoom).toHaveBeenCalled()
+  })
+
+  it('returns room detail with paging metadata, agents, and members', async () => {
+    storage.rooms.set('room-1', { id: 'room-1', name: 'Room', inviteCode: 'ROOM1' })
+    storage.messages.set('room-1', [{ id: 'msg-1' }, { id: 'msg-2' }])
+    storage.agents.set('room-1', [{ id: 'row-agent', agentId: 'agent-1', profile: 'default', name: 'Agent' }])
+    storage.members.set('room-1', [{ userId: 'user-1', name: 'Alice' }])
+
+    const res = await fetch(`${baseUrl}/api/hermes/group-chat/rooms/room-1?limit=1&offset=1`)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toMatchObject({
+      room: { id: 'room-1', name: 'Room' },
+      messages: [{ id: 'msg-2' }],
+      agents: [{ agentId: 'agent-1' }],
+      members: [{ userId: 'user-1' }],
+      total: 2,
+      offset: 1,
+      limit: 1,
+      hasMore: false,
+    })
+  })
+
+  it('rejects duplicate room agent profiles', async () => {
+    storage.rooms.set('room-1', { id: 'room-1', name: 'Room', inviteCode: 'ROOM1' })
+    storage.agents.set('room-1', [{ id: 'row-agent', agentId: 'agent-1', profile: 'default', name: 'Agent' }])
+
+    const res = await fetch(`${baseUrl}/api/hermes/group-chat/rooms/room-1/agents`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profile: 'default', name: 'Agent' }),
+    })
+
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toEqual({ error: 'Agent already in room' })
+  })
+
+  it('removes an agent by row id and disconnects runtime by persisted agent id', async () => {
+    const agent = { id: 'row-agent', roomId: 'room-1', agentId: 'agent-1', profile: 'default', name: 'Agent' }
+    storage.agents.set('room-1', [agent])
+
+    const res = await fetch(`${baseUrl}/api/hermes/group-chat/rooms/room-1/agents/row-agent`, { method: 'DELETE' })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(storage.removeRoomMembersForAgent).toHaveBeenCalledWith('room-1', agent)
+    expect(storage.removeRoomAgent).toHaveBeenCalledWith('room-1', 'row-agent')
+    expect(agentClients.removeAgentFromRoom).toHaveBeenCalledWith('room-1', 'agent-1')
+    expect(body).toMatchObject({ success: true, agents: [], members: [] })
+  })
+
+  it('clears room context and runtime state while returning the updated room', async () => {
+    storage.rooms.set('room-1', { id: 'room-1', name: 'Room', inviteCode: 'ROOM1', totalTokens: 99, sessionSeed: 'old' })
+
+    const res = await fetch(`${baseUrl}/api/hermes/group-chat/rooms/room-1/clear-context`, { method: 'POST' })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(storage.clearRoomContext).toHaveBeenCalledWith('room-1')
+    expect(clearRoomRuntimeState).toHaveBeenCalledWith('room-1')
+    expect(body).toMatchObject({ success: true, room: { id: 'room-1', totalTokens: 0, sessionSeed: 'rotated' } })
+  })
+})

--- a/tests/server/group-chat-streaming.test.ts
+++ b/tests/server/group-chat-streaming.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  connectGroupChatClient,
+  createTestGroupChatServer,
+  emitAck,
+  once,
+} from './group-chat-test-helpers'
+import type { GroupChatServer } from '../../packages/server/src/services/hermes/group-chat'
+
+describe('group chat streaming baseline', () => {
+  let harness: Awaited<ReturnType<typeof createTestGroupChatServer>>
+  let groupServer: GroupChatServer
+  let port: number
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    harness = await createTestGroupChatServer()
+    groupServer = harness.groupServer
+    port = harness.port
+    groupServer.getStorage().saveRoom('room-1', 'Room 1', 'ROOM1')
+  })
+
+  afterEach(() => {
+    harness?.cleanup()
+  })
+
+  async function joinPair() {
+    const alice = await connectGroupChatClient(port, 'user-a', 'Alice')
+    const bob = await connectGroupChatClient(port, 'user-b', 'Bob')
+    harness.sockets.push(alice, bob)
+    await emitAck(alice, 'join', { roomId: 'room-1' })
+    await emitAck(bob, 'join', { roomId: 'room-1' })
+    return { alice, bob }
+  }
+
+  it('relays stream start, content delta, reasoning delta, and stream end to room members', async () => {
+    const { alice, bob } = await joinPair()
+
+    const streamStart = once<any>(bob, 'message_stream_start')
+    alice.emit('message_stream_start', { roomId: 'room-1', id: 'stream-1', senderName: 'Worker', timestamp: 10 })
+    expect(await streamStart).toMatchObject({
+      id: 'stream-1',
+      roomId: 'room-1',
+      senderName: 'Worker',
+      role: 'assistant',
+      finish_reason: 'streaming',
+    })
+
+    const contentDelta = once<any>(bob, 'message_stream_delta')
+    alice.emit('message_stream_delta', { roomId: 'room-1', id: 'stream-1', delta: 'hello' })
+    expect(await contentDelta).toEqual({ roomId: 'room-1', id: 'stream-1', delta: 'hello' })
+
+    const reasoningDelta = once<any>(bob, 'message_reasoning_delta')
+    alice.emit('message_reasoning_delta', { roomId: 'room-1', id: 'stream-1', delta: 'thinking' })
+    expect(await reasoningDelta).toEqual({ roomId: 'room-1', id: 'stream-1', delta: 'thinking' })
+
+    const streamEnd = once<any>(bob, 'message_stream_end')
+    alice.emit('message_stream_end', { roomId: 'room-1', id: 'stream-1' })
+    expect(await streamEnd).toEqual({ roomId: 'room-1', id: 'stream-1' })
+  })
+
+  it('ignores a representative invalid stream id', async () => {
+    const { alice, bob } = await joinPair()
+    const unexpected = once<any>(bob, 'message_stream_start', 100)
+
+    alice.emit('message_stream_start', { roomId: 'room-1', id: 'bad id with spaces' })
+
+    await expect(unexpected).rejects.toThrow('timeout waiting for message_stream_start')
+  })
+})

--- a/tests/server/group-chat-test-helpers.ts
+++ b/tests/server/group-chat-test-helpers.ts
@@ -1,0 +1,86 @@
+import { createServer, type Server as HttpServer } from 'http'
+import { DatabaseSync } from 'node:sqlite'
+import { io as clientIo, type Socket as ClientSocket } from 'socket.io-client'
+import { vi } from 'vitest'
+
+const groupChatDbMock = vi.hoisted(() => ({ current: null as DatabaseSync | null }))
+
+vi.mock('../../packages/server/src/db/index', () => ({ getDb: () => groupChatDbMock.current }))
+vi.mock('../../packages/server/src/middleware/user-auth', () => ({
+  isAuthEnabled: vi.fn(async () => false),
+  authenticateUserToken: vi.fn(),
+}))
+
+import { initAllHermesTables } from '../../packages/server/src/db/hermes/schemas'
+import { GroupChatServer } from '../../packages/server/src/services/hermes/group-chat'
+
+export function once<T = any>(socket: ClientSocket, event: string, timeoutMs = 2_000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`timeout waiting for ${event}`)), timeoutMs)
+    socket.once(event, (payload: T) => { clearTimeout(timer); resolve(payload) })
+  })
+}
+
+export function emitAck<T = any>(socket: ClientSocket, event: string, payload: unknown, timeoutMs = 2_000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`timeout waiting for ${event} ack`)), timeoutMs)
+    socket.emit(event, payload, (response: T) => { clearTimeout(timer); resolve(response) })
+  })
+}
+
+async function listen(server: HttpServer): Promise<number> {
+  return await new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') throw new Error('missing port')
+      resolve(address.port)
+    })
+  })
+}
+
+export async function connectGroupChatClient(
+  port: number,
+  userId: string,
+  name: string,
+  auth: Record<string, unknown> = {},
+): Promise<ClientSocket> {
+  const socket = clientIo(`http://127.0.0.1:${port}/group-chat`, {
+    transports: ['websocket'],
+    forceNew: true,
+    reconnection: false,
+    auth: { userId, name, ...auth },
+  })
+  return await once<ClientSocket>(socket as any, 'connect').then(() => socket)
+}
+
+export async function createTestGroupChatServer(): Promise<{
+  db: DatabaseSync
+  httpServer: HttpServer
+  groupServer: GroupChatServer
+  port: number
+  sockets: ClientSocket[]
+  cleanup: () => void
+}> {
+  const db = new DatabaseSync(':memory:')
+  groupChatDbMock.current = db
+  initAllHermesTables()
+  const httpServer = createServer()
+  const groupServer = new GroupChatServer(httpServer)
+  const port = await listen(httpServer)
+  const sockets: ClientSocket[] = []
+  return {
+    db,
+    httpServer,
+    groupServer,
+    port,
+    sockets,
+    cleanup: () => {
+      for (const socket of sockets) socket.disconnect()
+      groupServer.getIO().close()
+      httpServer.close()
+      db.close()
+      groupChatDbMock.current = null
+      sockets.length = 0
+    },
+  }
+}


### PR DESCRIPTION
## 背景

这是 identity-aware / visibility-aware / context-scoped Group Chat 新功能线的第一个基线 PR，但本 PR 本身不是功能实现 PR。

当前 Group Chat 已经有 room、members、agents、Socket.IO live events、`@mention` routing、`/chat-run` 和 coding-agent bridge。后续功能会改动 schema、routing、context projection、agent handoff 和 driver/adapters。为了避免把这些风险一次性混进一个大 PR，本 PR 先建立 observable-behavior baseline tests。

## 整体架构方向

目标不是把 Group Chat 做成某个游戏或外部平台 clone，而是把它演进成一个明确处理身份、可见性、上下文和 agent 协作的 control plane：

```text
Web UI / Discord / Telegram / API
        ↓
Platform / Socket Adapter
        ↓
Durable Event Log + Outbox
        ↓
Conversation Router
        ↓
Identity + Visibility Policy
        ↓
Scoped Context Builder
        ↓
Agent Orchestrator + Mailboxes
        ↓
Hermes / Claude Code / Codex Drivers
        ↓
Messages / Actions / Artifacts / Approvals
        ↓
Audience-aware Delivery
```

核心设计原则：

- actor identity 是权限、路由和上下文的根；human、agent、system、tool、external user 都应统一建模。
- channel / visibility 是信息边界；同一个 room 里不应假设所有消息都 room-wide broadcast。
- model context 是 projection，不是完整 transcript；agent 只能读到该 actor 有权看到的信息。
- information transfer 应结构化表达 announce/share/handoff/request/approval/artifact，而不是靠普通聊天文本隐式转交。
- durable event log / outbox 负责 replay、dedupe、delivery 状态；Socket.IO 只负责 live view。
- Hermes / Claude Code / Codex 应通过统一 driver 产出 run events，而不是直接写平台消息。
- Discord/Telegram/Web UI 都应是 adapter，不应绕过核心 routing/policy。

## 分阶段路线

| 阶段 | 目标 | 当前 PR 状态 |
|---|---|---|
| 1 | 固定现有 Group Chat / chat-run / coding-agent 行为 | 本 PR：tests only |
| 2 | 统一 human/agent/system/tool actor 建模 | 后续 PR |
| 3 | room 内支持 public/private/team/thread visibility | 后续 PR |
| 4 | agent context 按 actor visibility projection 构建 | 后续 PR |
| 5 | 结构化 share/handoff/approval/artifact/publish | 后续 PR |
| 6 | event seq、dedupe、replay、delivery 状态 | 后续 PR |
| 7 | mailbox、loop guard、routing policy、run state | 后续 PR |
| 8 | 统一 driver 接入 Hermes / Claude / Codex backend | 后续 PR |
| 9 | Discord/Telegram/API 作为 adapter 接入 | 后续 PR |
| 10 | 用有限通信场景验证身份/信息隔离 | 后续 PR |
| 11 | metrics、leakage tests、feature flags、release gates | 后续 PR |

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/67638bf8-a4c1-4b89-ac33-6f3e8b0f9247" />


最小安全闭环是阶段 1 → 5：先有 baseline，再落 identity、visibility、scoped context 和 structured transfer。driver、adapter、scenario harness 应在这些边界稳定后再接入。

## 本 PR 改动

本 PR 只提交核心代码/测试基线，不新增 source docs、roadmap 文件或解释性架构文件。

本次覆盖：

- Group Chat socket join/message persistence/streaming/approval/context status/clear runtime state
- Group Chat REST room/agent/clear-context baseline
- mention routing 边界补充，包括 prefix collision 和特殊字符 agent 名称
- `/chat-run` action-required 与 event capture baseline
- coding-agent dispatch baseline，包括 `coding_agent_id`、`agent_id` alias、local proxy fields passthrough、content block stringification
- client Group Chat store lifecycle：connect/join/send/clear/approval/room update
- 共享 Socket.IO + in-memory SQLite test helper，减少重复 setup 和异步 cleanup 风险

## 本 PR 边界

- 不实现新的 agent 功能。
- 不新增 source docs、roadmap、分阶段开关 helper 或 chat-chain explanation fragment。
- 不改变产品 runtime 行为。
- 不接入 actor identity、channel visibility、scoped context、durable outbox、orchestrator、Claude/Codex Group Chat driver 或外部平台 adapter。
- 这些后续能力应拆成后续 PR，而不是并入本 PR。

## 验证

本地已通过：

```bash
npm run test -- \
  tests/server/group-chat-baseline.test.ts \
  tests/server/group-chat-routes-baseline.test.ts \
  tests/server/group-chat-mention-routing.test.ts \
  tests/server/group-chat-agent-routing-baseline.test.ts \
  tests/server/group-chat-streaming.test.ts \
  tests/server/group-chat-approval.test.ts \
  tests/server/chat-run-baseline.test.ts \
  tests/server/chat-run-api-controller.test.ts \
  tests/server/coding-agent-baseline.test.ts \
  tests/server/handle-coding-agent-run.test.ts \
  tests/client/group-chat-store-baseline.test.ts \
  tests/client/group-chat-store-streaming.test.ts

npm run harness:check
npm run build
git diff --check HEAD^ HEAD
```

结果：12 个 test files / 66 tests 通过，harness check 通过，build 通过，diff whitespace check 通过。
