### PR TITLE
[codex] fix Windows worker dynamic port fallback

### DIFF
--- a/docs/chat-chain-changes/2026-07-04-pr1934-windows-worker-port.md
+++ b/docs/chat-chain-changes/2026-07-04-pr1934-windows-worker-port.md
@@ -1,0 +1,9 @@
+﻿---
+date: 2026-07-04
+pr: 1934
+commit: 90c4edd
+feature: Windows Agent Bridge 工作进程端口选择
+impact: 当桌面运行时提供 Windows 动态/私有端口段内的 worker port base 时，Agent Bridge 回退到默认安全端口段，避免命中系统保留端口导致 profile worker 启动失败；不改变 chat-run 协议、消息落库或工具审批行为。
+---
+
+`bridge_transport.py` 在 Windows TCP worker 端点计算中会识别 `HERMES_AGENT_BRIDGE_WORKER_PORT_BASE` 是否落入 49152-65535 动态/私有端口段；若落入该范围，则改用默认的 18780 基准端口，避免哈希偏移后选中被系统排除的端口并触发 `WinError 10013`。

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
@@ -176,6 +176,14 @@ def _worker_endpoint(key: str, namespace: str | None = None) -> str:
     use_tcp = transport == "tcp" or (transport not in {"ipc", "unix"} and os.name == "nt")
     if use_tcp:
         port_base = int(os.environ.get("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE", "18780"))
+        # Windows can reserve/exclude ports in the dynamic range (49152-65535).
+        # Desktop/runtime environments may provide a high worker port base; adding
+        # the per-worker hash can then choose an excluded port and make the
+        # profile worker exit before it can report ready. Prefer the known-safe
+        # default range for Windows worker ports when the configured base falls
+        # in that dynamic range.
+        if os.name == "nt" and port_base >= 49152:
+            port_base = 18780
         return f"tcp://127.0.0.1:{port_base + int(safe[:4], 16) % 1000}"
     root = Path(tempfile.gettempdir()) / "hermes-agent-bridge-workers"
     return f"ipc://{root / f'{safe}.sock'}"

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
@@ -176,15 +176,17 @@ def _worker_endpoint(key: str, namespace: str | None = None) -> str:
     use_tcp = transport == "tcp" or (transport not in {"ipc", "unix"} and os.name == "nt")
     if use_tcp:
         port_base = int(os.environ.get("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE", "18780"))
+        port_offset = int(safe[:4], 16) % 1000
+        port = port_base + port_offset
         # Windows can reserve/exclude ports in the dynamic range (49152-65535).
         # Desktop/runtime environments may provide a high worker port base; adding
         # the per-worker hash can then choose an excluded port and make the
         # profile worker exit before it can report ready. Prefer the known-safe
-        # default range for Windows worker ports when the configured base falls
-        # in that dynamic range.
-        if os.name == "nt" and port_base >= 49152:
-            port_base = 18780
-        return f"tcp://127.0.0.1:{port_base + int(safe[:4], 16) % 1000}"
+        # default range when the final worker port would fall in that dynamic
+        # range.
+        if os.name == "nt" and port >= 49152:
+            port = 18780 + port_offset
+        return f"tcp://127.0.0.1:{port}"
     root = Path(tempfile.gettempdir()) / "hermes-agent-bridge-workers"
     return f"ipc://{root / f'{safe}.sock'}"
 

--- a/tests/server/agent-bridge-worker-endpoint.test.ts
+++ b/tests/server/agent-bridge-worker-endpoint.test.ts
@@ -63,4 +63,48 @@ print(json.dumps({"endpoint": endpoint, "port": port}))
     expect(result.port).toBeGreaterThanOrEqual(18780)
     expect(result.port).toBeLessThan(19780)
   })
+
+  it('avoids worker ports that enter the Windows dynamic range after hash offset', () => {
+    const result = runPython(String.raw`
+import importlib.util
+import json
+import os
+import sys
+import types
+
+bridge_runtime = types.ModuleType("bridge_runtime")
+bridge_runtime._hidden_subprocess_kwargs = lambda: {}
+bridge_runtime._json_line_bytes = lambda req: (json.dumps(req) + "\n").encode("utf-8")
+bridge_runtime._platform_text_encoding = lambda: "utf-8"
+sys.modules["bridge_runtime"] = bridge_runtime
+
+spec = importlib.util.spec_from_file_location(
+    "bridge_transport",
+    "packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py",
+)
+bridge_transport = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(bridge_transport)
+
+original_name = bridge_transport.os.name
+original_env = os.environ.get("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE")
+try:
+    bridge_transport.os.name = "nt"
+    os.environ["HERMES_AGENT_BRIDGE_WORKER_PORT_BASE"] = "49000"
+    endpoint = bridge_transport._worker_endpoint("default", "tcp://127.0.0.1:56618")
+finally:
+    bridge_transport.os.name = original_name
+    if original_env is None:
+        os.environ.pop("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE", None)
+    else:
+        os.environ["HERMES_AGENT_BRIDGE_WORKER_PORT_BASE"] = original_env
+
+port = int(endpoint.rsplit(":", 1)[1])
+print(json.dumps({"endpoint": endpoint, "port": port}))
+`)
+
+    expect(result.endpoint).toMatch(/^tcp:\/\/127\.0\.0\.1:\d+$/)
+    expect(result.port).toBeGreaterThanOrEqual(18780)
+    expect(result.port).toBeLessThan(19780)
+  })
 })

--- a/tests/server/agent-bridge-worker-endpoint.test.ts
+++ b/tests/server/agent-bridge-worker-endpoint.test.ts
@@ -1,0 +1,66 @@
+﻿import { execFileSync } from 'child_process'
+import { describe, expect, it } from 'vitest'
+
+function runPython(script: string): any {
+  try {
+    const output = execFileSync(process.platform === 'win32' ? 'python' : 'python3', ['-c', script], {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    })
+    return JSON.parse(output)
+  } catch (error) {
+    const err = error as { stdout?: string; stderr?: string; message?: string }
+    throw new Error([
+      err.message || 'Python bridge transport script failed',
+      err.stdout ? `stdout:\n${err.stdout}` : '',
+      err.stderr ? `stderr:\n${err.stderr}` : '',
+    ].filter(Boolean).join('\n\n'))
+  }
+}
+
+describe('agent bridge worker endpoint', () => {
+  it('avoids high dynamic worker port bases on Windows', () => {
+    const result = runPython(String.raw`
+import importlib.util
+import json
+import os
+import sys
+import types
+
+bridge_runtime = types.ModuleType("bridge_runtime")
+bridge_runtime._hidden_subprocess_kwargs = lambda: {}
+bridge_runtime._json_line_bytes = lambda req: (json.dumps(req) + "\n").encode("utf-8")
+bridge_runtime._platform_text_encoding = lambda: "utf-8"
+sys.modules["bridge_runtime"] = bridge_runtime
+
+spec = importlib.util.spec_from_file_location(
+    "bridge_transport",
+    "packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py",
+)
+bridge_transport = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(bridge_transport)
+
+original_name = bridge_transport.os.name
+original_env = os.environ.get("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE")
+try:
+    bridge_transport.os.name = "nt"
+    os.environ["HERMES_AGENT_BRIDGE_WORKER_PORT_BASE"] = "50813"
+    endpoint = bridge_transport._worker_endpoint("default", "tcp://127.0.0.1:56618")
+finally:
+    bridge_transport.os.name = original_name
+    if original_env is None:
+        os.environ.pop("HERMES_AGENT_BRIDGE_WORKER_PORT_BASE", None)
+    else:
+        os.environ["HERMES_AGENT_BRIDGE_WORKER_PORT_BASE"] = original_env
+
+port = int(endpoint.rsplit(":", 1)[1])
+print(json.dumps({"endpoint": endpoint, "port": port}))
+`)
+
+    expect(result.endpoint).toMatch(/^tcp:\/\/127\.0\.0\.1:\d+$/)
+    expect(result.port).toBeGreaterThanOrEqual(18780)
+    expect(result.port).toBeLessThan(19780)
+  })
+})


### PR DESCRIPTION
## Summary
- Builds on #1934 to keep Windows Agent Bridge worker ports out of the dynamic/private range.
- Checks the final worker port after the per-worker hash offset, not just the configured base port.
- Adds a regression case for a base below `49152` that enters the dynamic range after the hash offset.

## Why
PR #1934 handled bases such as `50813`, but a base like `49000` can still produce a final worker port such as `49710` after the hash offset. That remains in the Windows dynamic/private range and can hit excluded ports.

## Validation
- `npx vitest run tests/server/agent-bridge-worker-endpoint.test.ts`
- `git diff --check`

Refs #1934
