### PR TITLE
fix(chat): 为代码代理会话显示推理和上下文设置

### DIFF
--- a/docs/chat-chain-changes/2026-07-05-pr1938-coding-agent-reasoning-context.md
+++ b/docs/chat-chain-changes/2026-07-05-pr1938-coding-agent-reasoning-context.md
@@ -11,3 +11,5 @@ impact: Codex / Claude Code 单聊会话复用 Hermes 输入栏的推理强度�
 后端 socket run payload 接收 `reasoning_effort`，coding-agent launch / run manager / proxy target 会携带该设置；当推理强度变化时，隐藏的 Codex / Claude Code 进程会重新启动以应用新配置。
 
 代理适配层会按上游模式透传推理字段：OpenAI Chat Completions 使用 `reasoning_effort`，OpenAI Responses 使用 `reasoning: { effort }`，Anthropic-compatible 请求使用 `reasoning_effort`。Codex model catalog 同步声明 `none` / `minimal` 推理等级。
+
+补充：全局 coding-agent 模式继续依赖用户本机 CLI 配置，不从 Web UI payload 注入 \\easoning_effort\\；scoped 模式才会透传该会话级设置。

--- a/docs/chat-chain-changes/2026-07-05-pr1938-coding-agent-reasoning-context.md
+++ b/docs/chat-chain-changes/2026-07-05-pr1938-coding-agent-reasoning-context.md
@@ -12,4 +12,7 @@ impact: Codex / Claude Code 单聊会话复用 Hermes 输入栏的推理强度�
 
 代理适配层会按上游模式透传推理字段：OpenAI Chat Completions 使用 `reasoning_effort`，OpenAI Responses 使用 `reasoning: { effort }`，Anthropic-compatible 请求使用 `reasoning_effort`。Codex model catalog 同步声明 `none` / `minimal` 推理等级。
 
-补充：全局 coding-agent 模式继续依赖用户本机 CLI 配置，不从 Web UI payload 注入 \\easoning_effort\\；scoped 模式才会透传该会话级设置。
+补充：全局 coding-agent 模式继续依赖用户本机 CLI 配置，不从 Web UI payload 注入 \\
+easoning_effort\\；scoped 模式才会透传该会话级设置。
+
+???coding-agent ???? flush ? DB ???????? token usage?????? `contextTokens` ? `usage.updated`??????????? Codex / Claude Code ???????

--- a/docs/chat-chain-changes/2026-07-05-pr1938-coding-agent-reasoning-context.md
+++ b/docs/chat-chain-changes/2026-07-05-pr1938-coding-agent-reasoning-context.md
@@ -1,0 +1,13 @@
+﻿---
+date: 2026-07-05
+pr: 1938
+commit: a087a1e
+feature: coding agent reasoning and context controls
+impact: Codex / Claude Code 单聊会话复用 Hermes 输入栏的推理强度与上下文长度设置，发送时会把 reasoning_effort 传入 coding-agent 启动与代理链路。
+---
+
+前端不再对 `source === "coding_agent"` 隐藏推理强度选择器，也会在新会话显示上下文长度行，方便直接编辑模型上下文窗口。
+
+后端 socket run payload 接收 `reasoning_effort`，coding-agent launch / run manager / proxy target 会携带该设置；当推理强度变化时，隐藏的 Codex / Claude Code 进程会重新启动以应用新配置。
+
+代理适配层会按上游模式透传推理字段：OpenAI Chat Completions 使用 `reasoning_effort`，OpenAI Responses 使用 `reasoning: { effort }`，Anthropic-compatible 请求使用 `reasoning_effort`。Codex model catalog 同步声明 `none` / `minimal` 推理等级。

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -588,10 +588,8 @@ let contextLengthRequest: Promise<void> | null = null
 const showContextEditModal = ref(false)
 const editingContextLimit = ref(256000)
 const isSavingContextLimit = ref(false)
-const isCodingAgentSession = computed(() => chatStore.activeSession?.source === 'coding_agent')
 
 async function handleEditContextLimit() {
-  if (isCodingAgentSession.value) return
   editingContextLimit.value = contextLength.value
   showContextEditModal.value = true
 }
@@ -639,7 +637,6 @@ function currentContextLengthKey() {
 }
 
 async function loadContextLength() {
-  if (isCodingAgentSession.value) return
   const key = currentContextLengthKey()
   if (key === contextLengthLoadedKey) return
   if (key === contextLengthRequestKey && contextLengthRequest) return contextLengthRequest
@@ -683,14 +680,13 @@ watch(
 )
 
 const totalTokens = computed(() => {
-  if (isCodingAgentSession.value) return 0
   const context = chatStore.activeSession?.contextTokens
   if (typeof context === 'number' && Number.isFinite(context) && context > 0) return context
   const input = chatStore.activeSession?.inputTokens ?? 0
   const output = chatStore.activeSession?.outputTokens ?? 0
   return input + output
 })
-const showContextUsage = computed(() => totalTokens.value > 0)
+const showContextUsage = computed(() => !!chatStore.activeSession)
 
 const remainingTokens = computed(() => Math.max(0, contextLength.value - totalTokens.value))
 
@@ -1089,7 +1085,6 @@ function isImage(type: string): boolean {
           </NTooltip>
 
           <NPopselect
-            v-if="!isCodingAgentSession"
             :value="currentReasoningEffort"
             :options="reasoningEffortOptions"
             trigger="click"

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -2399,7 +2399,11 @@ export const useChatStore = defineStore('chat', () => {
           : {}),
         // Per-session reasoning effort override. Hermes bridge and scoped coding
         // agents both consume this when the selected provider/API supports it.
-        reasoning_effort: activeSession.value?.reasoningEffort || undefined,
+        // Global coding-agent mode uses the user's native CLI config, so avoid
+        // injecting a per-session override there.
+        reasoning_effort: isCodingAgentExecution && codingAgentMode === 'global'
+          ? undefined
+          : activeSession.value?.reasoningEffort || undefined,
       }
       if (shouldSendInitialSessionConfig && activeSession.value) {
         activeSession.value.messageCount = Math.max(activeSession.value.messageCount || 0, 1)

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -2397,9 +2397,9 @@ export const useChatStore = defineStore('chat', () => {
               apiMode: codingAgentApiMode,
             }
           : {}),
-        // Per-session reasoning effort override. Coding Agent runners do not
-        // consume this setting yet, so keep their payloads explicit.
-        reasoning_effort: isCodingAgentExecution ? undefined : activeSession.value?.reasoningEffort || undefined,
+        // Per-session reasoning effort override. Hermes bridge and scoped coding
+        // agents both consume this when the selected provider/API supports it.
+        reasoning_effort: activeSession.value?.reasoningEffort || undefined,
       }
       if (shouldSendInitialSessionConfig && activeSession.value) {
         activeSession.value.messageCount = Math.max(activeSession.value.messageCount || 0, 1)

--- a/packages/server/src/services/agent-runner/adapters/anthropic.ts
+++ b/packages/server/src/services/agent-runner/adapters/anthropic.ts
@@ -4,7 +4,12 @@ export interface AnthropicAdapterTarget {
   baseUrl: string
 }
 
-export function stringifyContent(value: unknown): string {
+export function targetReasoningEffort(target: any): string {
+  const effort = String(target?.reasoningEffort || '').trim()
+  return ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'].includes(effort) ? effort : ''
+}
+
+function stringifyContent(value: unknown): string {
   if (typeof value === 'string') return value
   if (Array.isArray(value)) {
     return value.map((item) => {
@@ -99,6 +104,7 @@ export function anthropicToOpenAiChat(body: any, target: AnthropicAdapterTarget,
     messages.push(...anthropicContentToOpenAiMessages(message, preserveReasoningContent))
   }
 
+  const reasoningEffort = targetReasoningEffort(target)
   const tools = Array.isArray(body?.tools)
     ? body.tools.map((tool: any) => ({
       type: 'function',
@@ -115,6 +121,7 @@ export function anthropicToOpenAiChat(body: any, target: AnthropicAdapterTarget,
     messages,
     ...(typeof body?.max_tokens === 'number' ? { max_tokens: body.max_tokens } : {}),
     ...(typeof body?.temperature === 'number' ? { temperature: body.temperature } : {}),
+    ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
     ...(tools?.length ? { tools } : {}),
     stream,
   }
@@ -169,6 +176,7 @@ export function anthropicToOpenAiResponses(body: any, target: AnthropicAdapterTa
     input.push(...anthropicToOpenAiResponsesInput(message))
   }
 
+  const reasoningEffort = targetReasoningEffort(target)
   const tools = Array.isArray(body?.tools)
     ? body.tools.map((tool: any) => ({
       type: 'function',
@@ -184,6 +192,7 @@ export function anthropicToOpenAiResponses(body: any, target: AnthropicAdapterTa
     ...(body?.system ? { instructions: stringifyContent(body.system) } : {}),
     ...(typeof body?.max_tokens === 'number' ? { max_output_tokens: body.max_tokens } : {}),
     ...(typeof body?.temperature === 'number' ? { temperature: body.temperature } : {}),
+    ...(reasoningEffort ? { reasoning: { effort: reasoningEffort } } : {}),
     ...(tools?.length ? { tools } : {}),
     stream,
     store: false,

--- a/packages/server/src/services/agent-runner/adapters/responses.ts
+++ b/packages/server/src/services/agent-runner/adapters/responses.ts
@@ -235,7 +235,12 @@ export function normalizeResponseFunctionCall(name: unknown, argumentsValue: unk
   }
 }
 
-export function stringifyContent(value: unknown): string {
+export function targetReasoningEffort(target: any): string {
+  const effort = String(target?.reasoningEffort || '').trim()
+  return ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'].includes(effort) ? effort : ''
+}
+
+function stringifyContent(value: unknown): string {
   if (typeof value === 'string') return value
   if (Array.isArray(value)) {
     return value.map((item) => {
@@ -367,12 +372,14 @@ function responsesToolsToChatTools(tools: unknown): any[] | undefined {
 
 export function responsesToOpenAiChat(body: any, target: ResponsesAdapterTarget, stream = false): any {
   const tools = responsesToolsToChatTools(body?.tools)
+  const reasoningEffort = targetReasoningEffort(target)
   return {
     model: target.model,
     messages: responsesInputToChatMessages(body),
     ...(typeof body?.max_output_tokens === 'number' ? { max_tokens: body.max_output_tokens } : {}),
     ...(typeof body?.temperature === 'number' ? { temperature: body.temperature } : {}),
     ...(typeof body?.top_p === 'number' ? { top_p: body.top_p } : {}),
+    ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
     ...(tools?.length ? { tools } : {}),
     stream,
   }
@@ -450,6 +457,7 @@ function responsesToolsToAnthropicTools(tools: unknown): any[] | undefined {
 
 export function responsesToAnthropicMessages(body: any, target: ResponsesAdapterTarget, stream = false): any {
   const tools = responsesToolsToAnthropicTools(body?.tools)
+  const reasoningEffort = targetReasoningEffort(target)
   return {
     model: target.model,
     messages: responsesInputToAnthropicMessages(body),
@@ -457,6 +465,7 @@ export function responsesToAnthropicMessages(body: any, target: ResponsesAdapter
     ...(typeof body?.max_output_tokens === 'number' ? { max_tokens: body.max_output_tokens } : { max_tokens: 4096 }),
     ...(typeof body?.temperature === 'number' ? { temperature: body.temperature } : {}),
     ...(typeof body?.top_p === 'number' ? { top_p: body.top_p } : {}),
+    ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
     ...(tools?.length ? { tools } : {}),
     stream,
   }

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -5,6 +5,7 @@ import { spawn, type ChildProcess } from 'child_process'
 import { createSession, addMessage, getSession, updateSession, updateSessionStats } from '../../db/hermes/session-store'
 import { logger } from '../logger'
 import { applyResponseStreamEvent, flushResponseRunToDb } from '../hermes/run-chat/response-stream'
+import { calcAndUpdateUsage, updateMessageContextTokenUsage } from '../hermes/run-chat/usage'
 import { extractResponseText } from '../hermes/run-chat/response-utils'
 import type { SessionState } from '../hermes/run-chat/types'
 import type { CanonicalResponsesEvent } from './adapters/responses-stream'
@@ -616,6 +617,7 @@ export class CodingAgentRunManager {
       flushResponseRunToDb(run.state, run.launch.sessionId)
       run.state.responseRun = undefined
       updateSessionStats(run.launch.sessionId)
+      void this.refreshCodingAgentUsage(run)
       const final = (storageSafeResponseEvent.data as any).response || storageSafeResponseEvent.data
       const finalText = extractResponseText(final)
       const terminalError = storageSafeResponseEvent.type === 'response.failed'
@@ -636,6 +638,20 @@ export class CodingAgentRunManager {
         this.emitAndMarkPrintChatRunCompleted(run, chatCompletionEvent, chatCompletionPayload)
       }
     }
+  }
+
+  private async refreshCodingAgentUsage(run: ManagedCodingAgentRun) {
+    const emitUsage = (event: string, payload: any) => {
+      this.emitToChat(run.launch.sessionId, event, payload)
+    }
+    const usage = await calcAndUpdateUsage(run.launch.sessionId, run.state, emitUsage)
+    updateMessageContextTokenUsage(
+      run.launch.sessionId,
+      run.state,
+      emitUsage,
+      usage.inputTokens + usage.outputTokens,
+      usage,
+    )
   }
 
   private normalizeCodexChatTextEvent(run: ManagedCodingAgentRun, event: CanonicalResponsesEvent): CanonicalResponsesEvent | null {

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -71,6 +71,7 @@ export interface CodingAgentRunLaunch {
   env?: NodeJS.ProcessEnv
   state?: SessionState
   sessionSource?: 'global_agent' | 'workflow'
+  reasoningEffort?: string
 }
 
 interface ManagedCodingAgentRun {
@@ -414,6 +415,7 @@ export class CodingAgentRunManager {
     mode?: 'scoped' | 'global'
     provider?: string
     model?: string
+    reasoningEffort?: string
   }): boolean {
     const run = this.getBySession(sessionId)
     if (!run || run.exited) return false
@@ -426,6 +428,7 @@ export class CodingAgentRunManager {
       if (provider && run.launch.provider !== provider) return false
       if (model && run.launch.model !== model) return false
     }
+    if (String(run.launch.reasoningEffort || '').trim() !== String(launch.reasoningEffort || '').trim()) return false
     if (!hasManagedHermesMcpConfig(run)) return false
     return true
   }

--- a/packages/server/src/services/agent-runner/target-registry.ts
+++ b/packages/server/src/services/agent-runner/target-registry.ts
@@ -7,6 +7,7 @@ export interface AgentTargetInput {
   baseUrl: string
   apiKey: string
   apiMode?: AgentApiMode
+  reasoningEffort?: string
   agentId?: string
   agentSessionId?: string
   chatSessionId?: string

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -110,6 +110,7 @@ export interface CodingAgentLaunchInput extends CodingAgentConfigScope {
   baseUrl?: string
   apiKey?: string
   apiMode?: ApiMode
+  reasoningEffort?: string
   sessionId?: string
   agentSessionId?: string
   agentNativeSessionId?: string
@@ -130,6 +131,7 @@ export interface CodingAgentLaunchResult {
   env: Record<string, string>
   shellCommand: string
   files: Array<{ key: string; path: string; absolutePath: string }>
+  reasoningEffort?: string
 }
 
 export interface CodingAgentNativeLaunchResult extends CodingAgentLaunchResult {
@@ -637,6 +639,8 @@ function codexCatalogEntry(input: {
     description: input.displayName,
     default_reasoning_level: 'medium',
     supported_reasoning_levels: [
+      { effort: 'none', description: 'Disable provider-side reasoning when supported' },
+      { effort: 'minimal', description: 'Use the smallest provider-side reasoning budget when supported' },
       { effort: 'low', description: 'Fast responses with lighter reasoning' },
       { effort: 'medium', description: 'Balances speed and reasoning depth for everyday tasks' },
       { effort: 'high', description: 'Greater reasoning depth for complex problems' },
@@ -1565,6 +1569,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
   const baseUrl = String(input.baseUrl || '').trim()
   const preset = PROVIDER_PRESETS.find(item => item.value === provider)
   const apiMode = normalizeLaunchApiMode(input.apiMode, preset?.api_mode || 'chat_completions')
+  const reasoningEffort = String(input.reasoningEffort || '').trim()
   const rootDir = getScopedConfigRoot(tool.id, scope)
   const workspaceDir = resolveLaunchWorkspaceRoot(scope, input.workspace)
   await mkdir(rootDir, { recursive: true })
@@ -1590,6 +1595,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
           baseUrl,
           apiKey,
           apiMode,
+          reasoningEffort,
           agentId: tool.id,
           agentSessionId: input.agentSessionId,
           chatSessionId: input.sessionId,
@@ -1648,6 +1654,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
           baseUrl,
           apiKey,
           apiMode,
+          reasoningEffort,
           agentId: tool.id,
           agentSessionId: input.agentSessionId,
           chatSessionId: input.sessionId,
@@ -1662,6 +1669,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
       `model_provider = ${JSON.stringify(providerId)}`,
       `model = ${JSON.stringify(model)}`,
       'model_reasoning_summary = "auto"',
+      ...(reasoningEffort ? [`model_reasoning_effort = ${JSON.stringify(reasoningEffort)}`] : []),
       `developer_instructions = ${tomlMultilineString(getSystemPrompt().trim())}`,
       'disable_response_storage = true',
       '',
@@ -1686,7 +1694,10 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
     await writeScopedFile('auth', `${JSON.stringify({}, null, 2)}\n`)
 
     env = { CODEX_HOME: rootDir }
-    args = ['--model', model]
+    args = [
+      '--model', model,
+      ...(reasoningEffort ? ['-c', `model_reasoning_effort=${JSON.stringify(reasoningEffort)}`] : []),
+    ]
   }
 
   let shellCommand = buildLaunchShellCommand({
@@ -1722,6 +1733,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
     env,
     shellCommand,
     files,
+    reasoningEffort,
   }
 }
 
@@ -1797,6 +1809,7 @@ export async function startCodingAgentRun(
     workspaceDir: launch.workspaceDir,
     env: runtimeEnv,
     state,
+    reasoningEffort: launch.reasoningEffort,
     sessionSource: sessionSource === 'global_agent' || sessionSource === 'workflow' ? sessionSource : undefined,
   })
   updateSession(sessionId, {

--- a/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
@@ -31,6 +31,7 @@ export interface CodingAgentRunSocketData {
   api_key?: string
   apiMode?: any
   api_mode?: any
+  reasoning_effort?: string
   session_source?: 'global_agent' | 'workflow'
 }
 
@@ -68,6 +69,7 @@ export async function handleCodingAgentRun(
     mode,
     provider: launchProvider,
     model: launchModel,
+    reasoningEffort: data.reasoning_effort,
   })) {
     codingAgentRunManager.stop(sessionId, { reportClosed: false })
     runId = undefined
@@ -83,6 +85,7 @@ export async function handleCodingAgentRun(
       baseUrl: data.baseUrl || data.base_url,
       apiKey: data.apiKey || data.api_key,
       apiMode: data.apiMode || data.api_mode,
+      reasoningEffort: data.reasoning_effort,
       sessionSource: data.session_source,
     }, state)
     runId = started.agentSessionId

--- a/tests/client/chat-input-draft.test.ts
+++ b/tests/client/chat-input-draft.test.ts
@@ -136,7 +136,7 @@ describe('ChatInput draft persistence', () => {
     expect((wrapper.get('textarea').element as HTMLTextAreaElement).style.height).not.toBe('180px')
   })
 
-  it('hides context usage for coding-agent sessions', async () => {
+  it('shows context usage for coding-agent sessions', async () => {
     const wrapper = mountForSession('session-codex', {
       source: 'coding_agent',
       agent: 'codex',
@@ -147,11 +147,12 @@ describe('ChatInput draft persistence', () => {
     })
     await nextTick()
 
-    expect(wrapper.find('.context-info').exists()).toBe(false)
-    expect(wrapper.find('.context-bar').exists()).toBe(false)
+    expect(wrapper.find('.context-info').exists()).toBe(true)
+    expect(wrapper.find('.context-info').text()).toContain('2.0k')
+    expect(wrapper.find('.context-bar').exists()).toBe(true)
   })
 
-  it('hides reasoning effort selector for coding-agent sessions', async () => {
+  it('shows reasoning effort selector for coding-agent sessions', async () => {
     const wrapper = mountForSession('session-codex', {
       source: 'coding_agent',
       agent: 'codex',
@@ -159,8 +160,8 @@ describe('ChatInput draft persistence', () => {
     })
     await nextTick()
 
-    expect(wrapper.find('.n-popselect-stub').exists()).toBe(false)
-    expect(wrapper.find('[data-value="high"]').exists()).toBe(false)
+    expect(wrapper.find('.n-popselect-stub').exists()).toBe(true)
+    expect(wrapper.find('[data-value="high"]').exists()).toBe(true)
   })
 
   it('stores the selected reasoning effort for the active session', async () => {

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -432,7 +432,7 @@ describe('coding agent run state', () => {
     manager.shutdown()
   })
 
-  it('maps Codex exec JSONL assistant deltas into chat messages', () => {
+  it('maps Codex exec JSONL assistant deltas into chat messages', async () => {
     initAllHermesTables()
     const manager = new CodingAgentRunManager()
     const state: any = { messages: [], isWorking: false, events: [], queue: [] }
@@ -488,8 +488,13 @@ describe('coding agent run state', () => {
       finish_reason: 'stop',
     }))
     expect(state.isWorking).toBe(false)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
     expect(emitted.map(event => event.event)).toContain('message.delta')
-    expect(emitted.map(event => event.event)).not.toContain('usage.updated')
+    expect(emitted.map(event => event.event)).toContain('usage.updated')
+    expect(emitted.find(event => event.event === 'usage.updated' && event.payload.contextTokens != null)?.payload).toEqual(expect.objectContaining({
+      contextTokens: expect.any(Number),
+    }))
     expect(emitted.find(event => event.event === 'run.completed')?.payload).not.toHaveProperty('usage')
     manager.shutdown()
   })


### PR DESCRIPTION
## 变更说明

本 PR 让 Codex / Claude Code 等 coding agent 会话与普通 Hermes 会话保持一致：

- 输入框工具栏显示推理强度选择器
- 新会话也显示上下文长度信息，可直接编辑模型上下文长度
- 发送 coding agent 请求时携带 `reasoning_effort`
- scoped Codex / Claude Code 本地代理会将推理强度透传到对应上游请求或 Codex 配置
- 推理强度变化后，隐藏 coding agent 运行进程会重新启动以应用新配置

## 实现细节

- 前端移除 coding-agent 会话对推理强度和上下文长度 UI 的隐藏/跳过逻辑
- 后端 coding-agent run payload 增加 `reasoning_effort`
- agent proxy target 增加 `reasoningEffort`
- OpenAI Chat Completions / Responses / Anthropic 适配路径按 API mode 注入对应推理字段
- Codex model catalog 增加 `none` / `minimal` 推理等级

## 验证

已本地执行：

```bash
npx vue-tsc -b
npx tsc --noEmit -p packages/server/tsconfig.json
```