### PR TITLE
[codex] fix desktop login persistence

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -128,9 +128,18 @@ function sanitizePetWindowBounds(input: unknown): DesktopWindowBounds | null {
   }
 }
 
-function petRouteUrl(): string | null {
+function webUiHashUrl(hashPath: string): string | null {
   if (!serverUrl) return null
-  return `${serverUrl.replace(/#.*$/, '').replace(/\/$/, '')}/#/desktop-pet`
+  const normalizedHash = hashPath.startsWith('/') ? hashPath : `/${hashPath}`
+  return `${serverUrl.replace(/#.*$/, '').replace(/\/$/, '')}/#${normalizedHash}`
+}
+
+function mainRouteUrl(): string | null {
+  return webUiHashUrl('/hermes/chat')
+}
+
+function petRouteUrl(): string | null {
+  return webUiHashUrl('/desktop-pet')
 }
 
 function ensurePetWindow(): BrowserWindow {
@@ -446,7 +455,7 @@ function createWindow() {
   // macOS), go straight to it. Otherwise show a loading splash; bootstrap()
   // will swap in the real URL once the server is ready.
   if (serverUrl) {
-    mainWindow.loadURL(serverUrl)
+    mainWindow.loadURL(mainRouteUrl() || serverUrl)
   } else {
     mainWindow.loadURL(splashHtml(t('runtime.checking')))
   }
@@ -668,7 +677,7 @@ async function bootstrap(source?: RuntimeDownloadSource) {
     const url = await startWebUiServer(PORT)
     serverUrl = url
     updateTrayMenu()
-    if (mainWindow) await mainWindow.loadURL(url)
+    if (mainWindow) await mainWindow.loadURL(mainRouteUrl() || url)
     await loadPetWindowRoute()
   } catch (err) {
     console.error('Failed to start Web UI server:', err)
@@ -762,7 +771,7 @@ ipcMain.handle('hermes-desktop:notify-completion', (_event, payload?: { title?: 
 })
 ipcMain.handle('hermes-desktop:retry-bootstrap', async (_event, source?: RuntimeDownloadSource) => {
   if (serverUrl) {
-    await mainWindow?.loadURL(serverUrl)
+    await mainWindow?.loadURL(mainRouteUrl() || serverUrl)
     return
   }
   const selectedSource = source === 'cf' || source === 'github' ? source : undefined

--- a/tests/desktop/desktop-login-reset.test.ts
+++ b/tests/desktop/desktop-login-reset.test.ts
@@ -20,6 +20,14 @@ describe('desktop login reset', () => {
     expect(source).toContain('enabled: !isResettingLogin && (!isBootstrapping || !!serverUrl)')
   })
 
+  it('loads the authenticated desktop route instead of the login route on startup', () => {
+    const source = readFileSync(resolve('packages/desktop/src/main/index.ts'), 'utf-8')
+
+    expect(source).toContain("return webUiHashUrl('/hermes/chat')")
+    expect(source).toContain('mainWindow.loadURL(mainRouteUrl() || serverUrl)')
+    expect(source).toContain('if (mainWindow) await mainWindow.loadURL(mainRouteUrl() || url)')
+  })
+
   it('resets the default credentials and clears login locks through the Web UI CLI', () => {
     const source = readFileSync(resolve('packages/desktop/src/main/desktop-login-reset.ts'), 'utf-8')
 


### PR DESCRIPTION
## Summary
- Load the desktop main window directly into the authenticated chat route instead of the login route.
- Keep the existing login page recovery behavior for stale tokens and reset-login flows.
- Add a desktop regression test that guards against loading the root login route on startup.

## Why
Desktop startup loaded the Web UI root route (`#/`), which mounts the login page. On desktop the login page intentionally clears stored JWTs as a recovery path, so quitting and reopening the app could erase a valid login session and force the user to sign in again.

## Validation
- `npx vitest run tests/desktop/desktop-login-reset.test.ts tests/client/login-view.test.ts tests/client/router-login-redirect.test.ts`
- `git diff --check`
