### PR TITLE
[codex] align coding agent tool events

### DIFF
--- a/docs/chat-chain-changes/2026-07-05-coding-agent-tool-events.md
+++ b/docs/chat-chain-changes/2026-07-05-coding-agent-tool-events.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-05
+pr: pending
+feature: Coding-agent tool event status
+impact: Coding-agent tool failures now surface as tool.failed events with duration metadata while successful tools continue to emit tool.completed.
+---
+
+The Responses stream mapper now aligns coding-agent tool status events with the
+Hermes ekko-agent path by emitting `tool.failed` for failed tool outputs and
+preserving duration metadata on completed or failed tools. The chat UI continues
+to consume both terminal tool event names and now displays zero-second tool
+durations instead of hiding them.

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -655,7 +655,7 @@ defineExpose({
                 :title="tc.toolPreview"
               >{{ toolPreviewText(tc.toolPreview) }}</span>
               <span
-                v-if="tc.toolDuration && tc.toolStatus !== 'running'"
+                v-if="tc.toolDuration !== undefined && tc.toolStatus !== 'running'"
                 class="tool-call-duration"
                 :title="$t('chat.executionDuration')"
               >{{ formatToolDuration(tc.toolDuration) }}</span

--- a/packages/server/src/controllers/chat-run.ts
+++ b/packages/server/src/controllers/chat-run.ts
@@ -19,7 +19,7 @@ type ChatRunEvent = Record<string, unknown> & {
   text?: string
   output?: string | null
   reasoning?: string | null
-  error?: string
+  error?: unknown
 }
 
 const CHAT_RUN_EVENTS = [
@@ -30,6 +30,7 @@ const CHAT_RUN_EVENTS = [
   'reasoning.available',
   'tool.started',
   'tool.completed',
+  'tool.failed',
   'workspace.diff.completed',
   'run.completed',
   'run.failed',

--- a/packages/server/src/services/global-agent/outbound-relay-client.ts
+++ b/packages/server/src/services/global-agent/outbound-relay-client.ts
@@ -51,6 +51,7 @@ const CHAT_RUN_SERVER_EVENTS = [
   'reasoning.available',
   'tool.started',
   'tool.completed',
+  'tool.failed',
   'workspace.diff.completed',
   'run.completed',
   'run.failed',
@@ -608,12 +609,18 @@ class PlainWebSocketRelayClient {
         const preview = typeof event.preview === 'string' ? event.preview : undefined
         this.sendJson({ type: 'tool.started', interactionId: voice.interactionId, tool, preview })
       })
-      socket.on('tool.completed', (event: Record<string, unknown> = {}) => {
+      const handleToolFinished = (event: Record<string, unknown> = {}, failed = false) => {
         const tool = typeof event.tool === 'string' ? event.tool : typeof event.name === 'string' ? event.name : 'tool'
         const preview = typeof event.preview === 'string' ? event.preview : undefined
-        const error = typeof event.error === 'string' ? event.error : undefined
+        const error = typeof event.error === 'string'
+          ? event.error
+          : failed
+            ? 'tool.failed'
+            : undefined
         this.sendJson({ type: 'tool.completed', interactionId: voice.interactionId, tool, preview, error })
-      })
+      }
+      socket.on('tool.completed', (event: Record<string, unknown> = {}) => handleToolFinished(event))
+      socket.on('tool.failed', (event: Record<string, unknown> = {}) => handleToolFinished(event, true))
       socket.on('message.delta', (event: Record<string, unknown> = {}) => {
         if (typeof event.delta === 'string') {
           output += event.delta

--- a/packages/server/src/services/global-agent/server.ts
+++ b/packages/server/src/services/global-agent/server.ts
@@ -66,6 +66,7 @@ const CHAT_RUN_SERVER_EVENTS = [
   'reasoning.available',
   'tool.started',
   'tool.completed',
+  'tool.failed',
   'workspace.diff.completed',
   'run.completed',
   'run.failed',
@@ -106,6 +107,7 @@ const MCU_FORWARD_EVENTS = [
   'interaction.status',
   'tool.started',
   'tool.completed',
+  'tool.failed',
   'audio.started',
   'audio.done',
   'audio.interrupted',
@@ -610,12 +612,18 @@ export class GlobalAgentServer {
       const preview = typeof event.preview === 'string' ? event.preview : undefined
       this.emitMcuEvent({ type: 'tool.started', interactionId: options.interactionId, tool, preview }, { clientId: options.clientId })
     })
-    socket.on('tool.completed', (event: Record<string, unknown> = {}) => {
+    const handleToolFinished = (event: Record<string, unknown> = {}, failed = false) => {
       const tool = typeof event.tool === 'string' ? event.tool : typeof event.name === 'string' ? event.name : 'tool'
       const preview = typeof event.preview === 'string' ? event.preview : undefined
-      const error = typeof event.error === 'string' ? event.error : undefined
+      const error = typeof event.error === 'string'
+        ? event.error
+        : failed
+          ? 'tool.failed'
+          : undefined
       this.emitMcuEvent({ type: 'tool.completed', interactionId: options.interactionId, tool, preview, error }, { clientId: options.clientId })
-    })
+    }
+    socket.on('tool.completed', (event: Record<string, unknown> = {}) => handleToolFinished(event))
+    socket.on('tool.failed', (event: Record<string, unknown> = {}) => handleToolFinished(event, true))
     socket.on('message.delta', (event: Record<string, unknown> = {}) => {
       if (typeof event.delta !== 'string') return
       output += event.delta

--- a/packages/server/src/services/hermes/run-chat/response-stream.ts
+++ b/packages/server/src/services/hermes/run-chat/response-stream.ts
@@ -58,6 +58,49 @@ function appendReasoningToMessage(run: ResponseRunState, message: any, text: str
   run.reasoningMessageId = message.id
 }
 
+function stringifyToolOutput(output: unknown): string {
+  if (typeof output === 'string') return output
+  try {
+    return JSON.stringify(output ?? '')
+  } catch {
+    return String(output ?? '')
+  }
+}
+
+function errorFromValue(value: unknown): string | true | undefined {
+  if (value === true) return true
+  if (typeof value === 'string') return value || true
+  if (!value || typeof value !== 'object') return undefined
+  const record = value as Record<string, unknown>
+  if (typeof record.message === 'string' && record.message) return record.message
+  if (typeof record.error === 'string' && record.error) return record.error
+  try {
+    return JSON.stringify(record)
+  } catch {
+    return true
+  }
+}
+
+function toolOutputError(item: any): string | true | undefined {
+  const directError = errorFromValue(item?.error)
+  if (directError) return directError
+
+  const status = typeof item?.status === 'string' ? item.status.toLowerCase() : ''
+  if (status === 'failed' || status === 'error' || status === 'errored') return true
+
+  const output = item?.output
+  if (typeof output === 'string') return output.startsWith('Error') ? true : undefined
+  if (!output || typeof output !== 'object') return undefined
+
+  const record = output as Record<string, unknown>
+  const outputError = errorFromValue(record.error)
+  if (outputError) return outputError
+  if (record.is_error === true || record.ok === false) return true
+  const outputStatus = typeof record.status === 'string' ? record.status.toLowerCase() : ''
+  if (outputStatus === 'failed' || outputStatus === 'error' || outputStatus === 'errored') return true
+  return undefined
+}
+
 export function applyResponseStreamEvent(
   state: SessionState,
   sessionId: string,
@@ -242,12 +285,13 @@ export function applyResponseStreamEvent(
       const callId = item.call_id || item.id
       if (!callId) return null
       const key = `tool:${callId}`
-      const output = typeof item.output === 'string' ? item.output : JSON.stringify(item.output ?? '')
+      const output = stringifyToolOutput(item.output)
       const toolCallEntry = run.toolCalls.get(callId)
       const toolName = toolCallEntry?.function?.name || null
       const startedAt = toolCallEntry?.startedAt
       const duration = startedAt ? Math.round((Date.now() - startedAt) / 10) / 100 : undefined
-      const hasError = typeof item.output === 'string' && item.output.startsWith('Error')
+      const error = toolOutputError(item)
+      const eventName = error ? 'tool.failed' : 'tool.completed'
       if (!run.insertedKeys.has(key)) {
         run.insertedKeys.add(key)
         state.messages.push({
@@ -258,13 +302,14 @@ export function applyResponseStreamEvent(
           content: output,
           tool_call_id: callId,
           tool_name: toolName,
+          finish_reason: error ? 'error' : null,
           timestamp: now(),
         })
       }
       return {
-        event: 'tool.completed',
+        event: eventName,
         payload: {
-          event: 'tool.completed',
+          event: eventName,
           run_id: run.responseId,
           response_id: run.responseId,
           tool_call_id: callId,
@@ -272,7 +317,7 @@ export function applyResponseStreamEvent(
           name: toolName,
           output,
           duration,
-          error: hasError || undefined,
+          error: error || undefined,
         },
       }
     }

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -1388,6 +1388,73 @@ describe('response stream tool detail events', () => {
       }),
     }))
   })
+
+  it('emits completed tool events with duration', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+      const state: any = { messages: [], isWorking: false, events: [], queue: [] }
+      applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.created', {
+        response: { id: 'resp-1', status: 'in_progress' },
+      })
+      applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_item.added', {
+        item: { type: 'function_call', call_id: 'call-1', name: 'Bash', arguments: '{"command":"pwd"}' },
+      })
+
+      vi.setSystemTime(new Date('2026-01-01T00:00:01.230Z'))
+      const completed = applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_item.done', {
+        item: { type: 'function_call_output', call_id: 'call-1', output: 'ok' },
+      })
+
+      expect(completed).toEqual(expect.objectContaining({
+        event: 'tool.completed',
+        payload: expect.objectContaining({
+          event: 'tool.completed',
+          tool_call_id: 'call-1',
+          duration: 1.23,
+          output: 'ok',
+        }),
+      }))
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('emits failed tool events with duration and persisted error state', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+      const state: any = { messages: [], isWorking: false, events: [], queue: [] }
+      applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.created', {
+        response: { id: 'resp-1', status: 'in_progress' },
+      })
+      applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_item.added', {
+        item: { type: 'function_call', call_id: 'call-1', name: 'Bash', arguments: '{"command":"pwd"}' },
+      })
+
+      vi.setSystemTime(new Date('2026-01-01T00:00:02.500Z'))
+      const failed = applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_item.done', {
+        item: { type: 'function_call_output', call_id: 'call-1', output: { ok: false, error: 'permission denied' } },
+      })
+
+      expect(failed).toEqual(expect.objectContaining({
+        event: 'tool.failed',
+        payload: expect.objectContaining({
+          event: 'tool.failed',
+          tool_call_id: 'call-1',
+          duration: 2.5,
+          error: 'permission denied',
+          output: '{"ok":false,"error":"permission denied"}',
+        }),
+      }))
+      expect(state.messages.find((message: any) => message.role === 'tool')).toEqual(expect.objectContaining({
+        finish_reason: 'error',
+        tool_call_id: 'call-1',
+      }))
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 describe('Claude Code stream-json mapping', () => {

--- a/tests/server/global-agent-server.test.ts
+++ b/tests/server/global-agent-server.test.ts
@@ -798,6 +798,14 @@ describe('GlobalAgentServer', () => {
       tool: 'approval',
       error: undefined,
     })
+    localSocket.__handlers.get('tool.failed')?.({ tool: 'weather', error: 'permission denied' })
+    expect(agentSocket.emit).toHaveBeenCalledWith('tool.completed', {
+      type: 'tool.completed',
+      interactionId: 'voice-1',
+      tool: 'weather',
+      preview: undefined,
+      error: 'permission denied',
+    })
     localSocket.__handlers.get('run.failed')?.({ error: 'done' })
   })
 


### PR DESCRIPTION
## Summary
- emit `tool.failed` for failed coding-agent Responses tool outputs while keeping successful tools on `tool.completed`
- preserve tool duration metadata across completed and failed coding-agent tool events
- allow chat-run/global-agent relay paths to forward `tool.failed`, and keep MCU relay compatibility by translating it to completed-with-error
- show zero-second tool durations in the chat tool trace

## Validation
- `npm run harness:check`
- `npm run test`
- `npm run test:e2e`
- `npm run build`
- `git diff --check`