### PR TITLE
fix(desktop): handle EPIPE in webui-server stdout/stderr forwarding

### DIFF
--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -414,12 +414,22 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
 
   serverProc.stdout?.on('data', (chunk: Buffer) => {
     bridgeStartup.observe(chunk)
-    process.stdout.write(`[webui] ${chunk}`)
+    try {
+      process.stdout.write(`[webui] ${chunk}`)
+    } catch {
+      /* EPIPE: parent stdout closed, ignore */
+    }
   })
+  serverProc.stdout?.on('error', () => { /* EPIPE: ignore */ })
   serverProc.stderr?.on('data', (chunk: Buffer) => {
     bridgeStartup.observe(chunk)
-    process.stderr.write(`[webui] ${chunk}`)
+    try {
+      process.stderr.write(`[webui] ${chunk}`)
+    } catch {
+      /* EPIPE: parent stderr closed, ignore */
+    }
   })
+  serverProc.stderr?.on('error', () => { /* EPIPE: ignore */ })
   serverProc.on('exit', (code, signal) => {
     console.error(`[webui] server exited code=${code} signal=${signal}`)
     serverProc = null


### PR DESCRIPTION
## Summary

Fixes unhandled **write EPIPE** in the Electron main process (`packages/desktop/src/main/webui-server.ts`) when the parent process closes its stdout/stderr pipe.

## Root Cause

In `startWebUiServer()`, the spawned child process stdout/stderr is forwarded via `process.stdout.write()` / `process.stderr.write()` without any error handling. When the parent pipe closes, the write throws an unhandled EPIPE exception that crashes the main process.

## Changes

`packages/desktop/src/main/webui-server.ts:415-422`:
- Wrapped `process.stdout.write()` and `process.stderr.write()` in try/catch
- Added `.on('error')` silent handlers on both `serverProc.stdout` and `serverProc.stderr`

Before:
```typescript
serverProc.stdout?.on('data', (chunk: Buffer) => {
    bridgeStartup.observe(chunk)
    process.stdout.write(`[webui] ${chunk}`)
})
```

After (3 lines of protection):
```typescript
serverProc.stdout?.on('data', (chunk: Buffer) => {
    bridgeStartup.observe(chunk)
    try {
      process.stdout.write(`[webui] ${chunk}`)
    } catch {
      /* EPIPE: parent stdout closed, ignore */
    }
  })
  serverProc.stdout?.on('error', () => { /* EPIPE: ignore */ })
```

Same pattern applied to stderr.

## Related

Closes #1948
Also related to #1749 (similar EPIPE issue in the spawned server process)