### PR TITLE
[codex] Add global Ekko runtime context handling

### DIFF
--- a/docs/chat-chain-changes/2026-07-05-pr1950-ekko-agent-runtime-mcp.md
+++ b/docs/chat-chain-changes/2026-07-05-pr1950-ekko-agent-runtime-mcp.md
@@ -1,0 +1,15 @@
+---
+date: 2026-07-05
+pr: 1950
+feature: Ekko Agent runtime context and MCP tools
+impact: Ekko-agent chat runs now use the shared in-memory runtime, carry full request context estimates, and pass managed MCP tools into model requests.
+---
+
+Ekko-agent runs now go through a global server-side agent runtime while keeping
+session state isolated by session id. The run-chat path resolves the current
+profile's managed Hermes Studio MCP servers and passes them into Ekko tool
+context, and the Ekko runtime discovers those MCP tools before each model
+request.
+
+The chat stream now emits context token estimates for the full model request,
+including system prompt, message history, and tool definitions.

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
-  "watch": ["packages/server/src"],
+  "watch": ["packages/server/src", "packages/ekko-agent/src"],
   "ext": "ts,tsx",
   "execMap": {
     "ts": "node -r ts-node/register"

--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -34,6 +34,8 @@ export interface StartRunRequest {
   api_key?: string
   apiMode?: ProviderApiMode
   api_mode?: ProviderApiMode
+  mcpServers?: Record<string, unknown>
+  mcp_servers?: Record<string, unknown>
   /** Per-session reasoning effort override.
    * Empty/undefined = use config.yaml default. */
   reasoning_effort?: string
@@ -72,6 +74,8 @@ export interface RunEvent {
   output?: string | null
   /** Run-level workspace diff summary attached to terminal run events. */
   workspace_run_change?: unknown
+  /** Provider/runtime context returned by Ekko Agent for follow-up runs. */
+  context?: unknown
   usage?: {
     input_tokens: number
     output_tokens: number

--- a/packages/ekko-agent/src/model/messages.ts
+++ b/packages/ekko-agent/src/model/messages.ts
@@ -24,6 +24,7 @@ export interface AgentOutputMessage extends AgentMessage {
   model?: string
   usage?: ModelUsage
   finishReason?: string
+  context?: unknown
   reasoning?: string
   raw?: unknown
 }
@@ -89,6 +90,7 @@ export function modelResponseToAgentMessage(response: ModelResponse): AgentOutpu
     toolCalls: response.toolCalls,
     usage: response.usage,
     finishReason: response.finishReason,
+    context: response.context,
     raw: response.raw,
   }
 }
@@ -127,6 +129,7 @@ export async function collectModelEvents(events: AsyncIterable<ModelEvent>): Pro
       toolCalls: done?.toolCalls ?? (toolCalls.length ? toolCalls : undefined),
       usage: done?.usage ?? usage,
       finishReason: done?.finishReason,
+      context: done?.context,
       raw: done?.raw,
     },
   }

--- a/packages/ekko-agent/src/model/providers/openai-responses.ts
+++ b/packages/ekko-agent/src/model/providers/openai-responses.ts
@@ -32,6 +32,7 @@ interface OpenAIResponsesPayload {
   tool_choice?: 'auto' | 'none' | 'required'
   stream?: boolean
   metadata?: Record<string, unknown>
+  previous_response_id?: string
 }
 
 interface OpenAIResponsesResponse {
@@ -143,6 +144,7 @@ export function toOpenAIResponsesPayload(config: ModelProviderConfig, request: M
     tool_choice: request.toolChoice,
     stream: request.stream,
     metadata: request.metadata,
+    previous_response_id: openAIResponsesContext(request.context)?.responseId,
   }
 }
 
@@ -159,8 +161,15 @@ export function normalizeOpenAIResponsesResponse(response: OpenAIResponsesRespon
     toolCalls,
     usage: response.usage ? normalizeUsage(response.usage) : undefined,
     finishReason: response.status,
+    context: response.id ? { responseId: response.id } : undefined,
     raw: response,
   }
+}
+
+function openAIResponsesContext(context: unknown): { responseId?: string } | undefined {
+  if (!context || typeof context !== 'object') return undefined
+  const responseId = (context as { responseId?: unknown }).responseId
+  return typeof responseId === 'string' && responseId ? { responseId } : undefined
 }
 
 function normalizeReasoning(response: OpenAIResponsesResponse): string | undefined {

--- a/packages/ekko-agent/src/model/types.ts
+++ b/packages/ekko-agent/src/model/types.ts
@@ -54,6 +54,7 @@ export interface ModelRequest {
   toolChoice?: 'auto' | 'none' | 'required'
   stream?: boolean
   metadata?: Record<string, unknown>
+  context?: unknown
 }
 
 export interface ModelResponse {
@@ -64,6 +65,7 @@ export interface ModelResponse {
   toolCalls?: AgentToolCall[]
   usage?: ModelUsage
   finishReason?: string
+  context?: unknown
   raw?: unknown
 }
 

--- a/packages/ekko-agent/src/runtime/events.ts
+++ b/packages/ekko-agent/src/runtime/events.ts
@@ -1,20 +1,23 @@
 import type { AgentOutputMessage } from '../model/messages'
 import type { AgentToolCall, ModelUsage } from '../model/types'
 import type { AgentToolResult } from '../tools/types'
+import type { AgentRuntimeContextEstimate } from './types'
 
 export type AgentRuntimeEvent =
   | { type: 'run.started'; runId: string; maxSteps: number }
   | { type: 'model.started'; runId: string; step: number }
+  | { type: 'context.estimated'; runId: string; step: number; estimate: AgentRuntimeContextEstimate }
   | { type: 'model.retry'; runId: string; step: number; retry: number; maxRetries: number; error: string }
   | { type: 'model.message'; runId: string; step: number; message: AgentOutputMessage }
   | { type: 'model.delta'; runId: string; step: number; text: string }
   | { type: 'model.reasoning'; runId: string; step: number; text: string }
   | { type: 'model.tool_call'; runId: string; step: number; toolCall: AgentToolCall }
   | { type: 'model.usage'; runId: string; step: number; usage: ModelUsage }
+  | { type: 'model.context'; runId: string; step: number; context: unknown }
   | { type: 'tool.started'; runId: string; step: number; toolCallId: string; toolName: string; arguments: Record<string, unknown> }
   | { type: 'tool.completed'; runId: string; step: number; toolCallId: string; toolName: string; result: AgentToolResult; durationMs: number }
   | { type: 'tool.failed'; runId: string; step: number; toolCallId: string; toolName: string; result: AgentToolResult; durationMs: number }
   | { type: 'run.tool_failure_limit'; runId: string; failures: number }
-  | { type: 'run.completed'; runId: string; output: AgentOutputMessage; steps: number }
+  | { type: 'run.completed'; runId: string; output: AgentOutputMessage; steps: number; context?: unknown; contextEstimate?: AgentRuntimeContextEstimate }
   | { type: 'run.failed'; runId: string; error: string; steps: number }
   | { type: 'run.max_steps'; runId: string; maxSteps: number }

--- a/packages/ekko-agent/src/runtime/runtime.ts
+++ b/packages/ekko-agent/src/runtime/runtime.ts
@@ -68,12 +68,12 @@ export class AgentRuntime {
     }
   }
 
-  async refreshTools(): Promise<void> {
-    await this.tools.refreshTools()
+  async refreshTools(context?: AgentToolContext): Promise<void> {
+    await this.tools.refreshTools(context)
   }
 
   async run(input: AgentRuntimeRunInput): Promise<AgentRuntimeRunResult> {
-    await this.refreshTools()
+    await this.refreshTools(this.runToolContext(input))
 
     const runId = randomUUID()
     const events: AgentRuntimeEvent[] = []

--- a/packages/ekko-agent/src/runtime/runtime.ts
+++ b/packages/ekko-agent/src/runtime/runtime.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { getEncoding } from 'js-tiktoken'
 import {
   createSystemMessage,
   createToolResultMessage,
@@ -13,7 +14,7 @@ import { AgentToolRegistry, createDefaultToolRegistry } from '../tools/registry'
 import type { AgentToolContext, AgentToolResult } from '../tools/types'
 import type { AgentRuntimeEvent } from './events'
 import { buildSystemPrompt } from './system-prompt'
-import type { AgentRuntimeOptions, AgentRuntimeRunInput, AgentRuntimeRunResult, AgentRuntimeStep } from './types'
+import type { AgentRuntimeContextEstimate, AgentRuntimeOptions, AgentRuntimeRunInput, AgentRuntimeRunResult, AgentRuntimeStep } from './types'
 
 export const DEFAULT_AGENT_MAX_STEPS = 90
 export const DEFAULT_AGENT_MODEL_MAX_RETRIES = 3
@@ -26,7 +27,7 @@ interface ModelResponseResult {
 }
 
 export class AgentRuntime {
-  private readonly modelClient: AgentRuntimeOptions['modelClient']
+  private readonly modelClient?: AgentRuntimeOptions['modelClient']
   private readonly tools: AgentToolRegistry
   private readonly skills: AgentSkill[]
   private readonly systemPrompt?: string
@@ -37,6 +38,8 @@ export class AgentRuntime {
   private readonly maxModelRetries: number
   private readonly maxConsecutiveToolFailures: number
   private readonly toolDelayMs: number
+  private readonly defaultContextKey?: string
+  private readonly modelContexts = new Map<string, unknown>()
 
   constructor(options: AgentRuntimeOptions) {
     this.modelClient = options.modelClient
@@ -50,6 +53,7 @@ export class AgentRuntime {
     this.maxModelRetries = options.maxModelRetries ?? DEFAULT_AGENT_MODEL_MAX_RETRIES
     this.maxConsecutiveToolFailures = options.maxConsecutiveToolFailures ?? DEFAULT_AGENT_MAX_CONSECUTIVE_TOOL_FAILURES
     this.toolDelayMs = options.toolDelayMs ?? DEFAULT_AGENT_TOOL_DELAY_MS
+    this.defaultContextKey = options.contextKey
     this.registerSkillTools(this.skills)
   }
 
@@ -92,14 +96,21 @@ export class AgentRuntime {
       role: 'assistant',
       content: '',
     }
+    const contextKey = this.contextKeyFor(input)
+    let contextEstimate: AgentRuntimeContextEstimate | undefined
     let consecutiveToolFailures = 0
 
     try {
       for (let step = 1; step <= maxSteps; step += 1) {
         throwIfAborted(input.signal)
+        const modelClient = this.modelClientFor(input)
         emit({ type: 'model.started', runId, step })
+        const request = this.modelRequest(input, messages, modelClient, contextKey)
+        contextEstimate = estimateModelRequestContext(request)
+        emit({ type: 'context.estimated', runId, step, estimate: contextEstimate })
         const modelResult = await this.createModelResponseWithRetries(
-          this.modelRequest(input, messages),
+          request,
+          modelClient,
           runId,
           step,
           maxModelRetries,
@@ -113,12 +124,17 @@ export class AgentRuntime {
         if (assistantMessage.reasoning && !modelResult.emittedReasoning) {
           emit({ type: 'model.reasoning', runId, step, text: assistantMessage.reasoning })
         }
+        if (assistantMessage.context !== undefined) {
+          if (contextKey) this.modelContexts.set(contextKey, assistantMessage.context)
+          emit({ type: 'model.context', runId, step, context: assistantMessage.context })
+        }
         emit({ type: 'model.message', runId, step, message: assistantMessage })
 
         const toolCalls = assistantMessage.toolCalls ?? []
         if (toolCalls.length === 0) {
-          emit({ type: 'run.completed', runId, output, steps: step })
-          return { runId, messages, output, steps, events }
+          const context = contextKey ? this.modelContexts.get(contextKey) : assistantMessage.context
+          emit({ type: 'run.completed', runId, output, steps: step, context, contextEstimate })
+          return { runId, messages, output, steps, events, context, contextEstimate }
         }
 
         for (const toolCall of toolCalls) {
@@ -142,8 +158,9 @@ export class AgentRuntime {
               content: `Stopped after ${consecutiveToolFailures} consecutive tool failures.`,
               finishReason: 'tool_failure_limit',
             }
-            emit({ type: 'run.completed', runId, output, steps: step })
-            return { runId, messages, output, steps, events }
+            const context = contextKey ? this.modelContexts.get(contextKey) : undefined
+            emit({ type: 'run.completed', runId, output, steps: step, context, contextEstimate })
+            return { runId, messages, output, steps, events, context, contextEstimate }
           }
           await delay(toolDelayMs, input.signal)
         }
@@ -155,8 +172,9 @@ export class AgentRuntime {
         content: `Stopped after reaching maxSteps (${maxSteps}).`,
         finishReason: 'max_steps',
       }
-      emit({ type: 'run.completed', runId, output, steps: maxSteps })
-      return { runId, messages, output, steps, events }
+      const context = contextKey ? this.modelContexts.get(contextKey) : undefined
+      emit({ type: 'run.completed', runId, output, steps: maxSteps, context, contextEstimate })
+      return { runId, messages, output, steps, events, context, contextEstimate }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       emit({ type: 'run.failed', runId, error: message, steps: steps.length })
@@ -166,6 +184,7 @@ export class AgentRuntime {
 
   private async createModelResponseWithRetries(
     request: ModelRequest,
+    modelClient: NonNullable<AgentRuntimeOptions['modelClient']>,
     runId: string,
     step: number,
     maxRetries: number,
@@ -174,11 +193,11 @@ export class AgentRuntime {
     for (let attempt = 1; attempt <= maxRetries + 1; attempt += 1) {
       try {
         throwIfAborted(request.signal)
-        if (request.stream && this.modelClient.capabilities.streaming) {
-          return await this.streamModelResponse(request, runId, step, emit)
+        if (request.stream && modelClient.capabilities.streaming) {
+          return await this.streamModelResponse(request, modelClient, runId, step, emit)
         }
         return {
-          response: await this.modelClient.create(request),
+          response: await modelClient.create(request),
           emittedReasoning: false,
         }
       } catch (error) {
@@ -199,12 +218,13 @@ export class AgentRuntime {
 
   private async streamModelResponse(
     request: ModelRequest,
+    modelClient: NonNullable<AgentRuntimeOptions['modelClient']>,
     runId: string,
     step: number,
     emit: (event: AgentRuntimeEvent) => void,
   ): Promise<ModelResponseResult> {
     let emittedReasoning = false
-    const events = this.modelClient.stream({ ...request, stream: true })
+    const events = modelClient.stream({ ...request, stream: true })
     const output = await collectModelEvents((async function *streamAndEmit() {
       for await (const event of events) {
         if (event.type === 'text-delta') {
@@ -224,7 +244,7 @@ export class AgentRuntime {
     })())
     if (isEmptyModelResponse(output.message)) {
       return {
-        response: await this.modelClient.create({ ...request, stream: false }),
+        response: await modelClient.create({ ...request, stream: false }),
         emittedReasoning: false,
       }
     }
@@ -252,18 +272,40 @@ export class AgentRuntime {
     ]
   }
 
-  private modelRequest(input: AgentRuntimeRunInput, messages: AgentMessage[]): ModelRequest {
+  private modelRequest(
+    input: AgentRuntimeRunInput,
+    messages: AgentMessage[],
+    modelClient: NonNullable<AgentRuntimeOptions['modelClient']>,
+    contextKey: string | undefined,
+  ): ModelRequest {
+    const modelDefaults = input.modelDefaults ?? this.modelDefaults
     return {
-      ...this.modelDefaults,
-      model: input.model ?? this.modelDefaults?.model,
-      temperature: input.temperature ?? this.modelDefaults?.temperature,
-      maxTokens: input.maxTokens ?? this.modelDefaults?.maxTokens,
-      metadata: input.metadata ?? this.modelDefaults?.metadata,
+      ...modelDefaults,
+      model: input.model ?? modelDefaults?.model,
+      temperature: input.temperature ?? modelDefaults?.temperature,
+      maxTokens: input.maxTokens ?? modelDefaults?.maxTokens,
+      metadata: input.metadata ?? modelDefaults?.metadata,
       messages,
       signal: input.signal,
       tools: this.tools.definitions(),
-      stream: this.modelClient.capabilities.streaming,
+      stream: modelClient.capabilities.streaming,
+      context: input.context ?? (contextKey ? this.modelContexts.get(contextKey) : modelDefaults?.context),
     }
+  }
+
+  private contextKeyFor(input: AgentRuntimeRunInput): string | undefined {
+    return input.contextKey ||
+      (typeof input.metadata?.session_id === 'string' ? input.metadata.session_id : undefined) ||
+      input.toolContext?.sessionId ||
+      this.defaultContextKey
+  }
+
+  private modelClientFor(input: AgentRuntimeRunInput): NonNullable<AgentRuntimeOptions['modelClient']> {
+    const modelClient = input.modelClient ?? this.modelClient
+    if (!modelClient) {
+      throw new Error('AgentRuntime requires a modelClient in constructor options or run input.')
+    }
+    return modelClient
   }
 
   private runToolContext(input: AgentRuntimeRunInput): AgentToolContext | undefined {
@@ -368,4 +410,69 @@ function isEmptyModelResponse(response: ModelResponse): boolean {
     !response.reasoning?.trim() &&
     !(response.toolCalls?.length)
   )
+}
+
+function estimateModelRequestContext(request: ModelRequest): AgentRuntimeContextEstimate {
+  const systemMessages = request.messages.filter(message => message.role === 'system')
+  const nonSystemMessages = request.messages.filter(message => message.role !== 'system')
+  const systemPrompt = systemMessages.map(message => message.content || '').join('\n\n')
+  const systemPromptTokens = countTokensLocal(systemPrompt)
+  const messageTokens = nonSystemMessages.reduce((sum, message) => {
+    return sum + countTokensLocal(message.content || '') + countTokensLocal(JSON.stringify(message.toolCalls || ''))
+  }, 0)
+  const toolTokens = countTokensLocal(JSON.stringify(request.tools || []))
+  const modelContextTokens = request.context == null ? 0 : countTokensLocal(JSON.stringify(request.context))
+
+  return {
+    contextTokens: systemPromptTokens + messageTokens + toolTokens + modelContextTokens,
+    systemPromptTokens,
+    messageTokens,
+    toolTokens,
+    modelContextTokens,
+    messageCount: request.messages.length,
+    toolCount: request.tools?.length || 0,
+    systemPromptChars: systemPrompt.length,
+  }
+}
+
+function countTokensLocal(text: string): number {
+  if (!text) return 0
+  if (hasPathologicalRun(text)) return heuristicTokens(text)
+  try {
+    return getEncoder().encode(text).length
+  } catch {
+    return heuristicTokens(text)
+  }
+}
+
+let cachedEncoder: ReturnType<typeof getEncoding> | null = null
+
+function getEncoder(): ReturnType<typeof getEncoding> {
+  if (!cachedEncoder) cachedEncoder = getEncoding('cl100k_base')
+  return cachedEncoder
+}
+
+function heuristicTokens(text: string): number {
+  const cjk = (text.match(/[\u2e80-\u9fff\uac00-\ud7af\u3000-\u303f\uff00-\uffef]/g) || []).length
+  const other = text.length - cjk
+  return Math.ceil(cjk * 1.5 + other / 4)
+}
+
+function hasPathologicalRun(text: string): boolean {
+  const maxRun = 20_000
+  let run = 0
+  for (let i = 0; i < text.length; i += 1) {
+    const code = text.charCodeAt(i)
+    const isLetterOrDigit =
+      (code >= 48 && code <= 57) ||
+      (code >= 65 && code <= 90) ||
+      (code >= 97 && code <= 122)
+    if (isLetterOrDigit) {
+      run += 1
+      if (run > maxRun) return true
+    } else {
+      run = 0
+    }
+  }
+  return false
 }

--- a/packages/ekko-agent/src/runtime/types.ts
+++ b/packages/ekko-agent/src/runtime/types.ts
@@ -5,8 +5,19 @@ import type { AgentToolRegistry } from '../tools/registry'
 import type { AgentToolContext, AgentToolResult } from '../tools/types'
 import type { AgentRuntimeEvent } from './events'
 
+export interface AgentRuntimeContextEstimate {
+  contextTokens: number
+  systemPromptTokens: number
+  messageTokens: number
+  toolTokens: number
+  modelContextTokens: number
+  messageCount: number
+  toolCount: number
+  systemPromptChars: number
+}
+
 export interface AgentRuntimeOptions {
-  modelClient: ModelClient
+  modelClient?: ModelClient
   tools?: AgentToolRegistry
   skills?: AgentSkill[]
   systemPrompt?: string
@@ -17,6 +28,7 @@ export interface AgentRuntimeOptions {
   toolDelayMs?: number
   toolContext?: AgentToolContext
   modelDefaults?: Omit<ModelRequest, 'messages' | 'tools' | 'stream'>
+  contextKey?: string
 }
 
 export interface AgentRuntimeRunInput {
@@ -33,6 +45,10 @@ export interface AgentRuntimeRunInput {
   temperature?: number
   maxTokens?: number
   metadata?: Record<string, unknown>
+  modelClient?: ModelClient
+  modelDefaults?: Omit<ModelRequest, 'messages' | 'tools' | 'stream'>
+  contextKey?: string
+  context?: unknown
   onEvent?: (event: AgentRuntimeEvent) => void
 }
 
@@ -46,4 +62,6 @@ export interface AgentRuntimeRunResult {
   output: AgentOutputMessage
   steps: AgentRuntimeStep[]
   events: AgentRuntimeEvent[]
+  context?: unknown
+  contextEstimate?: AgentRuntimeContextEstimate
 }

--- a/packages/ekko-agent/src/tools/mcp.ts
+++ b/packages/ekko-agent/src/tools/mcp.ts
@@ -1,0 +1,221 @@
+import { spawn } from 'node:child_process'
+import type { AgentTool, AgentToolContext, AgentToolProvider, AgentToolResult } from './types'
+
+interface McpServerConfig {
+  command?: unknown
+  args?: unknown
+  env?: unknown
+  enabled?: unknown
+}
+
+interface JsonRpcResponse {
+  id?: number
+  result?: any
+  error?: { message?: string }
+}
+
+const DEFAULT_MCP_TIMEOUT_MS = 30_000
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizeServerConfig(value: unknown): McpServerConfig | null {
+  if (!isRecord(value)) return null
+  if (value.enabled === false) return null
+  if (typeof value.command !== 'string' || !value.command.trim()) return null
+  return value
+}
+
+function normalizeArgs(args: unknown): string[] {
+  return Array.isArray(args) ? args.map(arg => String(arg)) : []
+}
+
+function normalizeEnv(env: unknown): NodeJS.ProcessEnv {
+  if (!isRecord(env)) return process.env
+  const normalized: NodeJS.ProcessEnv = { ...process.env }
+  for (const [key, value] of Object.entries(env)) {
+    if (value != null) normalized[key] = String(value)
+  }
+  return normalized
+}
+
+function responseContentToText(result: any): string {
+  const content = Array.isArray(result?.content) ? result.content : []
+  const text = content
+    .map((item: any) => {
+      if (item?.type === 'text') return String(item.text ?? '')
+      return JSON.stringify(item)
+    })
+    .filter(Boolean)
+    .join('\n')
+  return text || JSON.stringify(result ?? {})
+}
+
+async function runMcpExchange(server: McpServerConfig, messages: Array<Record<string, unknown>>, timeoutMs: number): Promise<JsonRpcResponse[]> {
+  const command = String(server.command)
+  const child = spawn(command, normalizeArgs(server.args), {
+    env: normalizeEnv(server.env),
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
+  })
+
+  let stdout = ''
+  let stderr = ''
+  const responses: JsonRpcResponse[] = []
+  let settled = false
+
+  return await new Promise((resolve, reject) => {
+    const finish = (error?: Error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      child.kill()
+      if (error) reject(error)
+      else resolve(responses)
+    }
+
+    const timer = setTimeout(() => {
+      finish(new Error(`MCP server timed out after ${timeoutMs}ms: ${command}`))
+    }, timeoutMs)
+
+    child.on('error', finish)
+    child.stderr?.on('data', chunk => {
+      stderr += String(chunk)
+    })
+    child.stdout?.on('data', chunk => {
+      stdout += String(chunk)
+      let newline = stdout.indexOf('\n')
+      while (newline >= 0) {
+        const line = stdout.slice(0, newline).trim()
+        stdout = stdout.slice(newline + 1)
+        if (line) {
+          try {
+            responses.push(JSON.parse(line))
+          } catch {
+            // Ignore non-JSON log lines from MCP servers.
+          }
+        }
+        newline = stdout.indexOf('\n')
+      }
+      if (responses.length >= messages.length) finish()
+    })
+    child.on('exit', code => {
+      if (responses.length >= messages.length) finish()
+      else finish(new Error(`MCP server exited before responding: ${command}${code == null ? '' : ` code=${code}`}${stderr ? ` stderr=${stderr.trim()}` : ''}`))
+    })
+
+    for (const message of messages) {
+      child.stdin?.write(`${JSON.stringify(message)}\n`)
+    }
+  })
+}
+
+async function listMcpTools(server: McpServerConfig, timeoutMs: number): Promise<any[]> {
+  const responses = await runMcpExchange(server, [
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'ekko-agent', version: '0.1.0' },
+      },
+    },
+    { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+  ], timeoutMs)
+  const response = responses.find(item => item.id === 2)
+  if (response?.error) throw new Error(response.error.message || 'MCP tools/list failed')
+  return Array.isArray(response?.result?.tools) ? response.result.tools : []
+}
+
+async function callMcpTool(server: McpServerConfig, name: string, input: Record<string, unknown>, timeoutMs: number): Promise<AgentToolResult> {
+  const responses = await runMcpExchange(server, [
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'ekko-agent', version: '0.1.0' },
+      },
+    },
+    {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name, arguments: input },
+    },
+  ], timeoutMs)
+  const response = responses.find(item => item.id === 2)
+  if (response?.error) {
+    return { ok: false, content: response.error.message || 'MCP tools/call failed', error: response.error.message || 'MCP tools/call failed' }
+  }
+  const result = response?.result
+  const content = responseContentToText(result)
+  return {
+    ok: result?.isError !== true,
+    content,
+    data: result,
+    error: result?.isError === true ? content : undefined,
+  }
+}
+
+class McpTool implements AgentTool {
+  readonly definition: AgentTool['definition']
+
+  constructor(
+    private readonly serverName: string,
+    private readonly remoteName: string,
+    tool: any,
+  ) {
+    this.definition = {
+      name: String(tool.name || remoteName),
+      description: String(tool.description || `MCP tool ${remoteName} from ${serverName}`),
+      parameters: isRecord(tool.inputSchema) ? tool.inputSchema : { type: 'object', properties: {} },
+    }
+  }
+
+  async execute(input: Record<string, unknown>, context: AgentToolContext = {}): Promise<AgentToolResult> {
+    const server = normalizeServerConfig(context.mcpServers?.[this.serverName])
+    if (!server) {
+      return {
+        ok: false,
+        content: `MCP server is not configured: ${this.serverName}`,
+        error: `MCP server is not configured: ${this.serverName}`,
+      }
+    }
+    return await callMcpTool(server, this.remoteName, input, context.timeoutMs || DEFAULT_MCP_TIMEOUT_MS)
+  }
+}
+
+export function createMcpToolProvider(): AgentToolProvider {
+  return {
+    id: 'mcp',
+    async listTools(context?: AgentToolContext): Promise<AgentTool[]> {
+      if (!context?.mcpServers) return []
+      const timeoutMs = context.timeoutMs || DEFAULT_MCP_TIMEOUT_MS
+      const tools: AgentTool[] = []
+      const usedNames = new Set<string>()
+
+      for (const [serverName, rawConfig] of Object.entries(context.mcpServers)) {
+        const server = normalizeServerConfig(rawConfig)
+        if (!server) continue
+
+        try {
+          for (const tool of await listMcpTools(server, timeoutMs)) {
+            if (!tool?.name || usedNames.has(String(tool.name))) continue
+            usedNames.add(String(tool.name))
+            tools.push(new McpTool(serverName, String(tool.name), tool))
+          }
+        } catch {
+          // A broken MCP server should not prevent the rest of the agent run.
+        }
+      }
+
+      return tools
+    },
+  }
+}

--- a/packages/ekko-agent/src/tools/registry.ts
+++ b/packages/ekko-agent/src/tools/registry.ts
@@ -1,11 +1,13 @@
 import type { AgentTool, AgentToolContext, AgentToolProvider, AgentToolResult } from './types'
 import { createBrowserTools } from './browser'
 import { createFileTools } from './files'
+import { createMcpToolProvider } from './mcp'
 import { createTerminalTools } from './terminal'
 
 export class AgentToolRegistry {
   private readonly tools = new Map<string, AgentTool>()
   private readonly providers = new Map<string, AgentToolProvider>()
+  private readonly providerTools = new Map<string, Set<string>>()
 
   register(tool: AgentTool): void {
     this.tools.set(tool.definition.name, tool)
@@ -29,9 +31,17 @@ export class AgentToolRegistry {
     return this.providers.delete(providerId)
   }
 
-  async refreshTools(): Promise<void> {
+  async refreshTools(context?: AgentToolContext): Promise<void> {
     for (const provider of this.providers.values()) {
-      this.registerMany(await provider.listTools())
+      const previous = this.providerTools.get(provider.id)
+      if (previous) {
+        for (const name of previous) {
+          this.tools.delete(name)
+        }
+      }
+      const tools = await provider.listTools(context)
+      this.registerMany(tools)
+      this.providerTools.set(provider.id, new Set(tools.map(tool => tool.definition.name)))
     }
   }
 
@@ -61,5 +71,6 @@ export function createDefaultToolRegistry(): AgentToolRegistry {
   for (const tool of [...createFileTools(), ...createTerminalTools(), ...createBrowserTools()]) {
     registry.register(tool)
   }
+  registry.registerProvider(createMcpToolProvider())
   return registry
 }

--- a/packages/ekko-agent/src/tools/types.ts
+++ b/packages/ekko-agent/src/tools/types.ts
@@ -24,7 +24,7 @@ export interface AgentTool<TInput extends Record<string, unknown> = Record<strin
 
 export interface AgentToolProvider {
   id: string
-  listTools(): Promise<AgentTool[]>
+  listTools(context?: AgentToolContext): Promise<AgentTool[]>
 }
 
 export class AgentToolError extends Error {

--- a/packages/ekko-agent/src/tools/types.ts
+++ b/packages/ekko-agent/src/tools/types.ts
@@ -5,6 +5,7 @@ export interface AgentToolContext {
   workspaceRoot?: string
   sessionId?: string
   browserSessionId?: string
+  mcpServers?: Record<string, unknown>
   timeoutMs?: number
   signal?: AbortSignal
 }

--- a/packages/server/src/services/ekko-agent/manager.ts
+++ b/packages/server/src/services/ekko-agent/manager.ts
@@ -1,0 +1,32 @@
+import {
+  AgentRuntime,
+  type AgentRuntimeRunInput,
+  type AgentRuntimeRunResult,
+} from '../../../../ekko-agent/src'
+
+export class GlobalEkkoAgent {
+  readonly createdAt = Date.now()
+  lastUsedAt = this.createdAt
+  runCount = 0
+  private readonly runtime = new AgentRuntime({})
+
+  async run(input: AgentRuntimeRunInput): Promise<AgentRuntimeRunResult> {
+    this.lastUsedAt = Date.now()
+    this.runCount += 1
+    return this.runtime.run(input)
+  }
+
+  status() {
+    return {
+      createdAt: this.createdAt,
+      lastUsedAt: this.lastUsedAt,
+      runCount: this.runCount,
+    }
+  }
+}
+
+const globalEkkoAgent = new GlobalEkkoAgent()
+
+export function getGlobalEkkoAgent(): GlobalEkkoAgent {
+  return globalEkkoAgent
+}

--- a/packages/server/src/services/ekko-agent/mcp.ts
+++ b/packages/server/src/services/ekko-agent/mcp.ts
@@ -1,0 +1,113 @@
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { config } from '../../config'
+
+const MANAGED_ENV_KEY = 'HERMES_WEB_UI_MANAGED_MCP'
+const MANAGED_SERVERS = [
+  { name: 'hermes-studio-api', toolset: 'api' },
+  { name: 'hermes-studio-devices', toolset: 'devices' },
+  { name: 'hermes-studio-use', toolset: 'use' },
+] as const
+
+export type EkkoMcpServers = Record<string, unknown>
+
+function isEnabledEnv(value: string | undefined): boolean {
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase())
+}
+
+function isDesktopRuntime(): boolean {
+  return String(process.env.HERMES_DESKTOP || '').trim().toLowerCase() === 'true'
+}
+
+function allowTransientAutoinject(): boolean {
+  return isEnabledEnv(process.env.HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT)
+}
+
+function normalizedPathPrefix(pathname: string): string {
+  return pathname.replace(/\/+$/, '') + '/'
+}
+
+function isTransientAppHome(appHome: string): boolean {
+  const normalized = normalizedPathPrefix(appHome)
+  const transientRoots = [tmpdir(), '/tmp', '/private/tmp']
+    .filter(Boolean)
+    .map(root => normalizedPathPrefix(root))
+  return transientRoots.some(root => normalized.startsWith(root))
+}
+
+function shouldIncludeManagedMcpServers(): boolean {
+  if (isEnabledEnv(process.env.HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT)) return false
+  return !isTransientAppHome(config.appHome) || allowTransientAutoinject()
+}
+
+function candidateBundledMcpScripts(): string[] {
+  return [
+    process.env.HERMES_WEB_UI_MCP_BIN,
+    join(process.cwd(), 'bin/hermes-studio-mcp.mjs'),
+    join(__dirname, '../../bin/hermes-studio-mcp.mjs'),
+    join(__dirname, '../../../../../bin/hermes-studio-mcp.mjs'),
+    join(process.cwd(), 'bin/hermes-web-ui-mcp.mjs'),
+    join(__dirname, '../../bin/hermes-web-ui-mcp.mjs'),
+    join(__dirname, '../../../../../bin/hermes-web-ui-mcp.mjs'),
+  ].filter((value): value is string => !!value)
+}
+
+function bundledMcpScriptPath(): string | null {
+  return candidateBundledMcpScripts().find(candidate => existsSync(candidate)) || null
+}
+
+function runtimeNodePath(): string | null {
+  const node = process.env.HERMES_AGENT_NODE?.trim()
+  return node || null
+}
+
+function managedCommandConfig(toolset: string): Record<string, unknown> {
+  const bundledScript = bundledMcpScriptPath()
+  if (bundledScript) {
+    return { command: runtimeNodePath() || process.execPath, args: [bundledScript, toolset] }
+  }
+
+  if (isDesktopRuntime()) {
+    return { command: 'hermes-studio-mcp', args: [toolset] }
+  }
+
+  return { command: 'hermes-studio-mcp', args: [toolset] }
+}
+
+function managedMcpServerConfig(profile: string, serverName: string, toolset: string): Record<string, unknown> {
+  return {
+    ...managedCommandConfig(toolset),
+    env: {
+      HERMES_WEB_UI_URL: `http://127.0.0.1:${config.port}`,
+      HERMES_WEB_UI_HOME: config.appHome,
+      HERMES_WEBUI_STATE_DIR: config.appHome,
+      HERMES_WEB_UI_PROFILE: profile,
+      HERMES_MCP_SERVER_NAME: serverName,
+      HERMES_MCP_TOOLSET: toolset,
+      [MANAGED_ENV_KEY]: '1',
+    },
+    enabled: true,
+  }
+}
+
+export function buildManagedEkkoMcpServers(profile: string): EkkoMcpServers {
+  if (!shouldIncludeManagedMcpServers()) return {}
+
+  return Object.fromEntries(
+    MANAGED_SERVERS.map(server => [
+      server.name,
+      managedMcpServerConfig(profile, server.name, server.toolset),
+    ]),
+  )
+}
+
+export function resolveEkkoMcpServers(profile: string, provided?: EkkoMcpServers): EkkoMcpServers | undefined {
+  const managed = buildManagedEkkoMcpServers(profile)
+  const merged = {
+    ...managed,
+    ...(provided || {}),
+  }
+
+  return Object.keys(merged).length > 0 ? merged : undefined
+}

--- a/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
@@ -14,6 +14,7 @@ import {
   type ModelResponse,
 } from '../../../../../ekko-agent/src'
 import { getGlobalEkkoAgent } from '../../ekko-agent/manager'
+import { resolveEkkoMcpServers } from '../../ekko-agent/mcp'
 import { createSession, addMessage, getSession, updateSessionStats } from '../../../db/hermes/session-store'
 import { logger } from '../../logger'
 import { getProfileDir } from '../hermes-profile'
@@ -402,7 +403,7 @@ export async function handleEkkoAgentRun(
     apiMode,
     timeoutMs: 120_000,
   })
-  const mcpServers = data.mcpServers || data.mcp_servers
+  const mcpServers = resolveEkkoMcpServers(profile, data.mcpServers || data.mcp_servers)
   const modelClient = createConsoleModelClient(createModelClient(providerConfig), {
     sessionId,
     providerConfig,

--- a/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
@@ -2,7 +2,6 @@ import type { Server, Socket } from 'socket.io'
 import { createHash } from 'crypto'
 import { inspect } from 'util'
 import {
-  AgentRuntime,
   createModelClient,
   resolveModelProviderConfigs,
   type AgentMessage,
@@ -14,6 +13,7 @@ import {
   type ModelRequest,
   type ModelResponse,
 } from '../../../../../ekko-agent/src'
+import { getGlobalEkkoAgent } from '../../ekko-agent/manager'
 import { createSession, addMessage, getSession, updateSessionStats } from '../../../db/hermes/session-store'
 import { logger } from '../../logger'
 import { getProfileDir } from '../hermes-profile'
@@ -45,6 +45,8 @@ export interface EkkoAgentRunSocketData {
   api_key?: string
   apiMode?: string
   api_mode?: string
+  mcpServers?: Record<string, unknown>
+  mcp_servers?: Record<string, unknown>
   peerExcludeSocketId?: string
   queue_id?: string
   onEvent?: (event: string, payload: any) => void
@@ -400,6 +402,7 @@ export async function handleEkkoAgentRun(
     apiMode,
     timeoutMs: 120_000,
   })
+  const mcpServers = data.mcpServers || data.mcp_servers
   const modelClient = createConsoleModelClient(createModelClient(providerConfig), {
     sessionId,
     providerConfig,
@@ -410,19 +413,7 @@ export async function handleEkkoAgentRun(
         }
       : undefined,
   })
-  const runtime = new AgentRuntime({
-    modelClient,
-    toolContext: {
-      cwd: workspace,
-      workspaceRoot: workspace,
-      sessionId,
-      browserSessionId: sessionId,
-      timeoutMs: 120_000,
-    },
-    modelDefaults: {
-      model: modelConfig.model,
-    },
-  })
+  const agent = getGlobalEkkoAgent()
 
   let assistantText = ''
   let assistantReasoning = ''
@@ -430,6 +421,7 @@ export async function handleEkkoAgentRun(
   let usageInput = 0
   let usageOutput = 0
   let sawStreamUsage = false
+  let contextEstimate: any
   const handleRuntimeEvent = (event: AgentRuntimeEvent) => {
     if ('runId' in event) runId = event.runId
     if (event.type === 'run.started') {
@@ -439,6 +431,22 @@ export async function handleEkkoAgentRun(
         run_id: event.runId,
         model: modelConfig.model,
         provider: modelConfig.provider,
+      })
+    } else if (event.type === 'context.estimated') {
+      contextEstimate = event.estimate
+      state.contextTokens = event.estimate.contextTokens
+      emit('usage.updated', {
+        event: 'usage.updated',
+        run_id: event.runId,
+        input_tokens: state.inputTokens || 0,
+        output_tokens: state.outputTokens || 0,
+        total_tokens: (state.inputTokens || 0) + (state.outputTokens || 0),
+        contextTokens: event.estimate.contextTokens,
+        context_tokens: event.estimate.contextTokens,
+        systemPromptTokens: event.estimate.systemPromptTokens,
+        toolTokens: event.estimate.toolTokens,
+        messageTokens: event.estimate.messageTokens,
+        toolCount: event.estimate.toolCount,
       })
     } else if (event.type === 'model.message') {
       const text = event.message.content || ''
@@ -468,6 +476,12 @@ export async function handleEkkoAgentRun(
       sawStreamUsage = true
       usageInput += event.usage.inputTokens || 0
       usageOutput += event.usage.outputTokens || 0
+    } else if (event.type === 'model.context') {
+      emit('context.updated', {
+        event: 'context.updated',
+        run_id: event.runId,
+        context: event.context,
+      })
     } else if (event.type === 'model.reasoning') {
       if (event.text) {
         assistantReasoning += event.text
@@ -504,8 +518,12 @@ export async function handleEkkoAgentRun(
 
   try {
     logger.info('[chat-run-socket] starting ekko-agent run for session %s', sessionId)
-    const result = await runtime.run({
+    const result = await agent.run({
+      modelClient,
       model: modelConfig.model,
+      modelDefaults: {
+        model: modelConfig.model,
+      },
       messages: toAgentMessages(state.messages),
       signal: abortController.signal,
       onEvent: handleRuntimeEvent,
@@ -514,6 +532,7 @@ export async function handleEkkoAgentRun(
         workspaceRoot: workspace,
         sessionId,
         browserSessionId: sessionId,
+        mcpServers,
         timeoutMs: 120_000,
         signal: abortController.signal,
       },
@@ -631,11 +650,17 @@ export async function handleEkkoAgentRun(
       input_tokens: state.inputTokens || 0,
       output_tokens: state.outputTokens || 0,
       total_tokens: (state.inputTokens || 0) + (state.outputTokens || 0),
+      contextTokens: contextEstimate?.contextTokens ?? state.contextTokens,
+      context_tokens: contextEstimate?.contextTokens ?? state.contextTokens,
     })
     emit('run.completed', {
       event: 'run.completed',
       run_id: runId || result.runId,
       output: assistantText,
+      context: result.context,
+      contextTokens: contextEstimate?.contextTokens,
+      context_tokens: contextEstimate?.contextTokens,
+      contextEstimate,
       usage: {
         input_tokens: usageInput,
         output_tokens: usageOutput,

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -199,6 +199,8 @@ export class ChatRunSocket {
       api_key?: string
       apiMode?: string
       api_mode?: string
+      mcpServers?: Record<string, unknown>
+      mcp_servers?: Record<string, unknown>
       profile?: string
       allow_command_passthrough?: boolean
       // Local patch (reasoning-effort): per-session reasoning effort override.
@@ -269,6 +271,8 @@ export class ChatRunSocket {
             api_key: data.api_key,
             apiMode: data.apiMode,
             api_mode: data.api_mode,
+            mcpServers: data.mcpServers,
+            mcp_servers: data.mcp_servers,
             commandPassthrough: data.allow_command_passthrough,
             originSocketId: socket.id,
           })
@@ -404,6 +408,8 @@ export class ChatRunSocket {
       api_key?: string
       apiMode?: string
       api_mode?: string
+      mcpServers?: Record<string, unknown>
+      mcp_servers?: Record<string, unknown>
       one_shot_model?: boolean
       allow_command_passthrough?: boolean
       onEvent?: (event: string, payload: any) => void
@@ -651,6 +657,8 @@ export class ChatRunSocket {
       api_key: next.api_key,
       apiMode: next.apiMode,
       api_mode: next.api_mode,
+      mcpServers: next.mcpServers,
+      mcp_servers: next.mcp_servers,
       one_shot_model: next.oneShotModel,
       allow_command_passthrough: next.commandPassthrough,
     }, next.profile || fallbackProfile, skipUserMessage)
@@ -682,6 +690,8 @@ export class ChatRunSocket {
       api_key?: string
       apiMode?: string
       api_mode?: string
+      mcpServers?: Record<string, unknown>
+      mcp_servers?: Record<string, unknown>
       profile?: string
       reasoning_effort?: string
     },

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -50,6 +50,8 @@ export interface QueuedRun {
   api_key?: string
   apiMode?: string
   api_mode?: string
+  mcpServers?: Record<string, unknown>
+  mcp_servers?: Record<string, unknown>
   oneShotModel?: boolean
   commandPassthrough?: boolean
   originSocketId?: string

--- a/tests/ekko-agent/model-request.test.ts
+++ b/tests/ekko-agent/model-request.test.ts
@@ -212,6 +212,7 @@ describe('ekko-agent model requests', () => {
       ],
       tools: [{ name: 'search', parameters: { type: 'object' } }],
       maxTokens: 500,
+      context: { responseId: 'resp_previous' },
     })
 
     expect(payload).toMatchObject({
@@ -219,6 +220,7 @@ describe('ekko-agent model requests', () => {
       instructions: 'Be direct.',
       input: [{ role: 'user', content: 'Search docs.' }],
       max_output_tokens: 500,
+      previous_response_id: 'resp_previous',
       tools: [{ type: 'function', name: 'search' }],
     })
   })

--- a/tests/ekko-agent/runtime.test.ts
+++ b/tests/ekko-agent/runtime.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { join } from 'node:path'
 import {
   AgentRuntime,
   AgentToolRegistry,
@@ -183,6 +184,41 @@ describe('ekko-agent runtime', () => {
       { role: 'assistant', content: 'tool said from-tool' },
     ])
     expect(result.steps.map(step => step.type)).toEqual(['model', 'tool', 'model'])
+  })
+
+  it('discovers and executes MCP tools from the run tool context', async () => {
+    const client = modelClient((request, call) => {
+      if (call === 1) {
+        expect(request.tools?.some(tool => tool.name === 'fake_echo')).toBe(true)
+        return {
+          content: '',
+          toolCalls: [{ id: 'call_mcp', name: 'fake_echo', arguments: { text: 'hello' } }],
+          finishReason: 'tool_calls',
+        }
+      }
+      return { content: 'done', finishReason: 'stop' }
+    })
+    const runtime = new AgentRuntime({ modelClient: client, toolDelayMs: 0 })
+
+    const result = await runtime.run({
+      messages: ['use mcp'],
+      toolContext: {
+        mcpServers: {
+          fake: {
+            command: process.execPath,
+            args: [join(process.cwd(), 'tests/fixtures/fake-mcp-server.cjs')],
+          },
+        },
+      },
+    })
+
+    expect(result.messages).toMatchObject([
+      { role: 'system' },
+      { role: 'user', content: 'use mcp' },
+      { role: 'assistant', toolCalls: [{ id: 'call_mcp', name: 'fake_echo' }] },
+      { role: 'tool', toolCallId: 'call_mcp', name: 'fake_echo', content: 'mcp:hello' },
+      { role: 'assistant', content: 'done' },
+    ])
   })
 
   it('returns unknown tool failures as tool messages', async () => {

--- a/tests/ekko-agent/runtime.test.ts
+++ b/tests/ekko-agent/runtime.test.ts
@@ -88,7 +88,7 @@ describe('ekko-agent runtime', () => {
       model: 'test-model',
     })
     expect(result.messages.map(message => message.role)).toEqual(['system', 'user', 'assistant'])
-    expect(events).toEqual(['run.started', 'model.started', 'model.message', 'run.completed'])
+    expect(events).toEqual(['run.started', 'model.started', 'context.estimated', 'model.message', 'run.completed'])
   })
 
   it('emits model reasoning before the assistant message', async () => {
@@ -110,7 +110,7 @@ describe('ekko-agent runtime', () => {
 
     expect(result.output.reasoning).toBe('thinking path')
     expect(reasoning).toEqual(['thinking path'])
-    expect(events).toEqual(['run.started', 'model.started', 'model.reasoning', 'model.message', 'run.completed'])
+    expect(events).toEqual(['run.started', 'model.started', 'context.estimated', 'model.reasoning', 'model.message', 'run.completed'])
   })
 
   it('streams model text deltas before the final assistant message', async () => {
@@ -135,7 +135,7 @@ describe('ekko-agent runtime', () => {
     expect(client.stream).toHaveBeenCalledTimes(1)
     expect(result.output.content).toBe('Hello')
     expect(deltas).toEqual(['Hel', 'lo'])
-    expect(events).toEqual(['run.started', 'model.started', 'model.delta', 'model.delta', 'model.message', 'run.completed'])
+    expect(events).toEqual(['run.started', 'model.started', 'context.estimated', 'model.delta', 'model.delta', 'model.message', 'run.completed'])
   })
 
   it('falls back to non-streaming create when a provider stream returns no output', async () => {
@@ -363,6 +363,37 @@ describe('ekko-agent runtime', () => {
     })
 
     await new AgentRuntime({ modelClient: client, tools }).run({ messages: ['hi'] })
+  })
+
+  it('stores model context by session and sends it on follow-up runs', async () => {
+    const requests: ModelRequest[] = []
+    const client = modelClient((request, call) => {
+      requests.push(request)
+      return {
+        content: `ok-${call}`,
+        context: { responseId: `resp-${call}` },
+      }
+    })
+    const runtime = new AgentRuntime({ modelClient: client })
+
+    const first = await runtime.run({
+      messages: ['first'],
+      metadata: { session_id: 'session-a' },
+    })
+    const second = await runtime.run({
+      messages: ['second'],
+      metadata: { session_id: 'session-a' },
+    })
+    await runtime.run({
+      messages: ['other'],
+      metadata: { session_id: 'session-b' },
+    })
+
+    expect(first.context).toEqual({ responseId: 'resp-1' })
+    expect(second.context).toEqual({ responseId: 'resp-2' })
+    expect(requests[0].context).toBeUndefined()
+    expect(requests[1].context).toEqual({ responseId: 'resp-1' })
+    expect(requests[2].context).toBeUndefined()
   })
 
   it('buildSystemPrompt omits structured tool descriptions', () => {

--- a/tests/fixtures/fake-mcp-server.cjs
+++ b/tests/fixtures/fake-mcp-server.cjs
@@ -1,0 +1,56 @@
+const readline = require('node:readline')
+
+const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity })
+
+rl.on('line', line => {
+  if (!line.trim()) return
+  const message = JSON.parse(line)
+  if (message.method === 'initialize') {
+    process.stdout.write(`${JSON.stringify({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: {
+        protocolVersion: '2024-11-05',
+        capabilities: { tools: {} },
+        serverInfo: { name: 'fake-mcp', version: '0.0.0' },
+      },
+    })}\n`)
+    return
+  }
+  if (message.method === 'tools/list') {
+    process.stdout.write(`${JSON.stringify({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: {
+        tools: [
+          {
+            name: 'fake_echo',
+            description: 'Echo a value through fake MCP.',
+            inputSchema: {
+              type: 'object',
+              properties: { text: { type: 'string' } },
+              required: ['text'],
+              additionalProperties: false,
+            },
+          },
+        ],
+      },
+    })}\n`)
+    return
+  }
+  if (message.method === 'tools/call') {
+    process.stdout.write(`${JSON.stringify({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: {
+        content: [{ type: 'text', text: `mcp:${message.params?.arguments?.text || ''}` }],
+      },
+    })}\n`)
+    return
+  }
+  process.stdout.write(`${JSON.stringify({
+    jsonrpc: '2.0',
+    id: message.id,
+    error: { code: -32601, message: `Method not found: ${message.method}` },
+  })}\n`)
+})

--- a/tests/server/ekko-agent-manager.test.ts
+++ b/tests/server/ekko-agent-manager.test.ts
@@ -43,7 +43,7 @@ describe('GlobalEkkoAgent', () => {
       modelClient: client,
       modelDefaults: { model: 'test-model' },
       metadata: { session_id: 'session-1' },
-      toolContext: { mcpServers: { test: { command: 'node' } } },
+      toolContext: { mcpServers: { test: { command: 'node', enabled: false } } },
     })
 
     const request = vi.mocked(client.create).mock.calls[0]?.[0] as ModelRequest

--- a/tests/server/ekko-agent-manager.test.ts
+++ b/tests/server/ekko-agent-manager.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import { GlobalEkkoAgent } from '../../packages/server/src/services/ekko-agent/manager'
+import type { ModelClient, ModelRequest } from '../../packages/ekko-agent/src'
+
+function modelClient(content: string): ModelClient {
+  return {
+    provider: 'test',
+    requestStyle: 'custom-runtime',
+    capabilities: {
+      streaming: false,
+      tools: true,
+      vision: false,
+      jsonMode: false,
+      systemPrompt: true,
+    },
+    create: vi.fn(async () => ({ content })),
+    stream: vi.fn(),
+  }
+}
+
+describe('GlobalEkkoAgent', () => {
+  it('is created once and handles repeated runs through the same runtime', async () => {
+    const agent = new GlobalEkkoAgent()
+    const firstClient = modelClient('first')
+    const secondClient = modelClient('second')
+
+    const first = await agent.run({ messages: ['hi'], modelClient: firstClient })
+    const second = await agent.run({ messages: ['again'], modelClient: secondClient })
+
+    expect(first.output.content).toBe('first')
+    expect(second.output.content).toBe('second')
+    expect(agent.runCount).toBe(2)
+    expect(firstClient.create).toHaveBeenCalledTimes(1)
+    expect(secondClient.create).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes per-run model defaults, metadata, and tool context', async () => {
+    const agent = new GlobalEkkoAgent()
+    const client = modelClient('ok')
+
+    await agent.run({
+      messages: ['hi'],
+      modelClient: client,
+      modelDefaults: { model: 'test-model' },
+      metadata: { session_id: 'session-1' },
+      toolContext: { mcpServers: { test: { command: 'node' } } },
+    })
+
+    const request = vi.mocked(client.create).mock.calls[0]?.[0] as ModelRequest
+    expect(request.model).toBe('test-model')
+    expect(request.metadata).toEqual({ session_id: 'session-1' })
+  })
+})

--- a/tests/server/ekko-agent-mcp.test.ts
+++ b/tests/server/ekko-agent-mcp.test.ts
@@ -1,0 +1,98 @@
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const configMock = vi.hoisted(() => ({
+  port: 8648,
+  appHome: '/Users/test/.hermes-web-ui',
+}))
+
+vi.mock('../../packages/server/src/config', () => ({
+  config: configMock,
+}))
+
+describe('Ekko MCP server context', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    delete process.env.HERMES_DESKTOP
+    delete process.env.HERMES_AGENT_NODE
+    delete process.env.HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT
+    delete process.env.HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT
+    delete process.env.HERMES_WEB_UI_MCP_BIN
+    configMock.port = 8648
+    configMock.appHome = '/Users/test/.hermes-web-ui'
+  })
+
+  it('builds managed MCP servers for the current Web UI port and profile', async () => {
+    const { buildManagedEkkoMcpServers } = await import('../../packages/server/src/services/ekko-agent/mcp')
+
+    const servers = buildManagedEkkoMcpServers('work')
+
+    expect(servers['hermes-studio-api']).toEqual({
+      command: process.execPath,
+      args: [join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'api'],
+      env: {
+        HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
+        HERMES_WEB_UI_HOME: '/Users/test/.hermes-web-ui',
+        HERMES_WEBUI_STATE_DIR: '/Users/test/.hermes-web-ui',
+        HERMES_WEB_UI_PROFILE: 'work',
+        HERMES_MCP_SERVER_NAME: 'hermes-studio-api',
+        HERMES_MCP_TOOLSET: 'api',
+        HERMES_WEB_UI_MANAGED_MCP: '1',
+      },
+      enabled: true,
+    })
+    expect(servers['hermes-studio-devices']).toMatchObject({
+      args: [join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'devices'],
+      env: {
+        HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
+        HERMES_WEB_UI_PROFILE: 'work',
+        HERMES_MCP_TOOLSET: 'devices',
+      },
+    })
+    expect(servers['hermes-studio-use']).toMatchObject({
+      args: [join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'use'],
+      env: {
+        HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
+        HERMES_WEB_UI_PROFILE: 'work',
+        HERMES_MCP_TOOLSET: 'use',
+      },
+    })
+  })
+
+  it('merges caller-provided MCP servers and lets explicit entries override managed defaults', async () => {
+    const { resolveEkkoMcpServers } = await import('../../packages/server/src/services/ekko-agent/mcp')
+
+    const servers = resolveEkkoMcpServers('default', {
+      'hermes-studio-api': { command: 'custom-api' },
+      custom: { command: 'custom-mcp' },
+    })
+
+    expect(servers?.['hermes-studio-api']).toEqual({ command: 'custom-api' })
+    expect(servers?.custom).toEqual({ command: 'custom-mcp' })
+    expect(servers?.['hermes-studio-devices']).toBeDefined()
+    expect(servers?.['hermes-studio-use']).toBeDefined()
+  })
+
+  it('does not add managed MCP servers when startup autoinject is disabled or skipped', async () => {
+    process.env.HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT = '1'
+    let mod = await import('../../packages/server/src/services/ekko-agent/mcp')
+
+    expect(mod.resolveEkkoMcpServers('default')).toBeUndefined()
+    expect(mod.resolveEkkoMcpServers('default', { custom: { command: 'custom-mcp' } })).toEqual({
+      custom: { command: 'custom-mcp' },
+    })
+
+    vi.resetModules()
+    delete process.env.HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT
+    configMock.appHome = '/private/tmp/wui-preview-home'
+    mod = await import('../../packages/server/src/services/ekko-agent/mcp')
+
+    expect(mod.resolveEkkoMcpServers('default')).toBeUndefined()
+
+    vi.resetModules()
+    process.env.HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT = '1'
+    mod = await import('../../packages/server/src/services/ekko-agent/mcp')
+
+    expect(mod.resolveEkkoMcpServers('default')?.['hermes-studio-api']).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
- add a global Ekko Agent entrypoint with one server-process runtime shared by all runs
- allow per-run model clients/defaults while keeping runtime tools and provider context resident
- add Ekko context estimation for system prompt, history/messages, tools, and provider context using the repo token-counting approach
- pass MCP server parameters through run payloads and queues for future Ekko MCP integration

## Validation
- npx tsc --noEmit -p packages/ekko-agent/tsconfig.json
- npx tsc --noEmit -p packages/server/tsconfig.json
- npx vue-tsc --noEmit -p tsconfig.app.json
- npm run --silent test -- tests/ekko-agent/runtime.test.ts tests/ekko-agent/model-request.test.ts tests/server/ekko-agent-manager.test.ts

## Notes
- Ekko usage is still not written into session_usage; message-level token_count is also not populated yet. Those can be follow-up changes.