### PR TITLE
修复 Skills Usage 使用 Hermes 会话库统计

### DIFF
--- a/packages/server/src/db/hermes/sessions-db.ts
+++ b/packages/server/src/db/hermes/sessions-db.ts
@@ -1,4 +1,4 @@
-import { getActiveProfileDir, getProfileDir } from '../../services/hermes/hermes-profile'
+import { getActiveProfileDir, getHermesBaseDir } from '../../services/hermes/hermes-profile'
 import { join } from 'path'
 import { existsSync } from 'fs'
 import type { LocalUsageStats } from './usage-store'
@@ -80,6 +80,13 @@ interface HermesSessionInternalRow extends HermesSessionRow {
 
 function sessionDbPath(): string {
   return join(getActiveProfileDir(), 'state.db')
+}
+
+function sessionDbPathForProfile(profile?: string): string {
+  const name = String(profile || '').trim()
+  if (!name) return sessionDbPath()
+  if (name === 'default') return join(getHermesBaseDir(), 'state.db')
+  return join(getHermesBaseDir(), 'profiles', name, 'state.db')
 }
 
 function normalizeNumber(value: unknown, fallback = 0): number {
@@ -591,7 +598,7 @@ async function openSessionDb(profile?: string) {
     throw new Error(`node:sqlite requires Node >= 22.5, current: ${process.versions.node}`)
   }
   const { DatabaseSync } = await import('node:sqlite')
-  const dbPath = profile ? join(getProfileDir(profile), 'state.db') : sessionDbPath()
+  const dbPath = profile ? sessionDbPathForProfile(profile) : sessionDbPath()
   try {
     return new DatabaseSync(dbPath, { open: true, readOnly: true })
   } catch (err: any) {
@@ -658,7 +665,7 @@ export async function getSessionDetailFromDb(sessionId: string): Promise<HermesS
 
 export async function getSessionDetailFromDbWithProfile(sessionId: string, profile: string): Promise<HermesSessionDetailRow | null> {
   const { DatabaseSync } = await import('node:sqlite')
-  const dbPath = join(getProfileDir(profile), 'state.db')
+  const dbPath = sessionDbPathForProfile(profile)
   const db = new DatabaseSync(dbPath, { open: true, readOnly: true })
   try {
     const idx = loadAllSessions(db)
@@ -731,7 +738,7 @@ export async function getSessionDetailPaginatedFromDbWithProfile(
 
 export async function getExactSessionDetailFromDbWithProfile(sessionId: string, profile: string): Promise<HermesSessionDetailRow | null> {
   const { DatabaseSync } = await import('node:sqlite')
-  const dbPath = join(getProfileDir(profile), 'state.db')
+  const dbPath = sessionDbPathForProfile(profile)
   const db = new DatabaseSync(dbPath, { open: true, readOnly: true })
   try {
     const idx = loadAllSessions(db)
@@ -763,7 +770,7 @@ export async function findLatestExactSessionIdWithProfile(
   if (!trimmed) return null
 
   const { DatabaseSync } = await import('node:sqlite')
-  const dbPath = join(getProfileDir(profile), 'state.db')
+  const dbPath = sessionDbPathForProfile(profile)
   const db = new DatabaseSync(dbPath, { open: true, readOnly: true })
   const loweredQuery = trimmed.toLowerCase()
   const likePattern = buildLikePattern(loweredQuery)
@@ -1132,7 +1139,7 @@ export async function getSkillUsageStatsFromDb(
   const normalizedDays = Number.isFinite(days) ? days : 7
   const safeDays = Math.max(1, Math.floor(normalizedDays))
   const since = nowSeconds - safeDays * 24 * 60 * 60
-  const dbPath = profile ? join(getProfileDir(profile), 'state.db') : sessionDbPath()
+  const dbPath = profile ? sessionDbPathForProfile(profile) : sessionDbPath()
   if (!existsSync(dbPath)) return emptySkillUsageStats(safeDays)
 
   const db = await openSessionDb(profile)
@@ -1399,7 +1406,7 @@ export async function listSessionSummaries(source?: string, limit = 2000, profil
   }
 
   const { DatabaseSync } = await import('node:sqlite')
-  const dbPath = profile ? join(getProfileDir(profile), 'state.db') : sessionDbPath()
+  const dbPath = profile ? sessionDbPathForProfile(profile) : sessionDbPath()
   const db = new DatabaseSync(dbPath, { open: true, readOnly: true })
 
   try {
@@ -1446,7 +1453,7 @@ export async function searchSessionSummariesWithProfile(
   if (!trimmed) return []
 
   const { DatabaseSync } = await import('node:sqlite')
-  const dbPath = join(getProfileDir(profile), 'state.db')
+  const dbPath = sessionDbPathForProfile(profile)
   const db = new DatabaseSync(dbPath, { open: true, readOnly: true })
   const normalized = sanitizeFtsQuery(trimmed)
   const prefixQuery = toPrefixQuery(normalized)

--- a/packages/server/src/db/hermes/sessions-db.ts
+++ b/packages/server/src/db/hermes/sessions-db.ts
@@ -1,7 +1,7 @@
 import { getActiveProfileDir, getProfileDir } from '../../services/hermes/hermes-profile'
 import { join } from 'path'
+import { existsSync } from 'fs'
 import type { LocalUsageStats } from './usage-store'
-import { getDb } from '../index'
 
 const SQLITE_AVAILABLE = (() => {
   const [major, minor] = process.versions.node.split('.').map(Number)
@@ -910,6 +910,13 @@ function parseJsonObject(value: unknown): Record<string, unknown> | null {
 
 type SkillUsageAction = 'view' | 'manage'
 
+type SqliteDbLike = {
+  prepare(sql: string): {
+    get(...params: unknown[]): unknown
+    all(...params: unknown[]): unknown[]
+  }
+}
+
 interface RawSkillUsageEvent {
   skill: string
   action: SkillUsageAction
@@ -921,7 +928,18 @@ function extractSkillNameFromViewContent(content: string): string {
   if (match?.[1]) return match[1].trim()
 
   const parsed = parseJsonObject(content)
-  return typeof parsed?.name === 'string' ? parsed.name.trim() : ''
+  if (typeof parsed?.name === 'string') return parsed.name.trim()
+
+  const jsonNameMatch = content.match(/"name"\s*:\s*"((?:\\.|[^"\\])*)"/)
+  if (jsonNameMatch?.[1]) {
+    try {
+      return JSON.parse(`"${jsonNameMatch[1]}"`).trim()
+    } catch {
+      return jsonNameMatch[1].replace(/\\"/g, '"').trim()
+    }
+  }
+
+  return ''
 }
 
 function extractSkillNameFromManageContent(content: string): string {
@@ -953,13 +971,11 @@ function extractSkillToolCall(row: Record<string, unknown>): { action: SkillUsag
   for (const call of calls) {
     if (!call || typeof call !== 'object') continue
     const record = call as Record<string, unknown>
+    if (!toolCallRecordIds(record).includes(toolCallId)) continue
+
     const functionRecord = record.function && typeof record.function === 'object'
       ? record.function as Record<string, unknown>
       : {}
-    const ids = [record.id, record.call_id, record.tool_call_id, functionRecord.call_id]
-      .filter((value): value is string => typeof value === 'string')
-    if (!ids.includes(toolCallId)) continue
-
     const name = typeof functionRecord.name === 'string'
       ? functionRecord.name
       : typeof record.name === 'string'
@@ -980,21 +996,105 @@ function extractSkillToolCall(row: Record<string, unknown>): { action: SkillUsag
   return null
 }
 
+function toolCallRecordIds(record: Record<string, unknown>): string[] {
+  const functionRecord = record.function && typeof record.function === 'object'
+    ? record.function as Record<string, unknown>
+    : {}
+  return [record.id, record.call_id, record.tool_call_id, functionRecord.call_id]
+    .filter((value): value is string => typeof value === 'string')
+}
+
+function buildAssistantToolCallLookup(rows: Record<string, unknown>[]): Map<string, string> {
+  const lookup = new Map<string, string>()
+  for (const row of rows) {
+    const sessionId = typeof row.session_id === 'string' ? row.session_id : ''
+    const rawToolCalls = typeof row.tool_calls === 'string' ? row.tool_calls : ''
+    if (!sessionId || !rawToolCalls) continue
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(rawToolCalls)
+    } catch {
+      continue
+    }
+
+    const calls = Array.isArray(parsed) ? parsed : [parsed]
+    for (const call of calls) {
+      if (!call || typeof call !== 'object') continue
+      const record = call as Record<string, unknown>
+      const functionRecord = record.function && typeof record.function === 'object'
+        ? record.function as Record<string, unknown>
+        : {}
+      const name = typeof functionRecord.name === 'string'
+        ? functionRecord.name
+        : typeof record.name === 'string'
+          ? record.name
+          : ''
+      if (name !== 'skill_view' && name !== 'skill_manage') continue
+      const serialized = JSON.stringify([record])
+      for (const id of toolCallRecordIds(record)) {
+        lookup.set(`${sessionId}\u0000${id}`, serialized)
+      }
+    }
+  }
+  return lookup
+}
+
+function attachAssistantToolCalls(
+  candidateRows: Record<string, unknown>[],
+  assistantRows: Record<string, unknown>[],
+): Record<string, unknown>[] {
+  const lookup = buildAssistantToolCallLookup(assistantRows)
+  return candidateRows.map(row => {
+    const sessionId = typeof row.session_id === 'string' ? row.session_id : ''
+    const toolCallId = typeof row.tool_call_id === 'string' ? row.tool_call_id : ''
+    if (!sessionId || !toolCallId) return row
+    const assistantToolCalls = lookup.get(`${sessionId}\u0000${toolCallId}`)
+    return assistantToolCalls ? { ...row, assistant_tool_calls: assistantToolCalls } : row
+  })
+}
+
+function chunkValues<T>(values: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size))
+  }
+  return chunks
+}
+
+function sqliteIndexHint(db: SqliteDbLike, indexName: 'idx_sessions_started' | 'idx_messages_session'): string {
+  try {
+    const row = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?").get(indexName)
+    return row ? ` INDEXED BY ${indexName}` : ''
+  } catch {
+    return ''
+  }
+}
+
 function mapSkillUsageEvent(row: Record<string, unknown>): RawSkillUsageEvent | null {
   const content = typeof row.content === 'string' ? row.content : ''
   const toolName = typeof row.tool_name === 'string' ? row.tool_name : ''
-  const toolCall = extractSkillToolCall(row)
-  const action: SkillUsageAction | null = toolName === 'skill_view' || content.startsWith('[skill_view]')
+  let toolCall: { action: SkillUsageAction; skill: string } | null = null
+  let action: SkillUsageAction | null = toolName === 'skill_view' || content.startsWith('[skill_view]')
     ? 'view'
     : toolName === 'skill_manage' || content.startsWith('[skill_manage]')
       ? 'manage'
-      : toolCall?.action ?? null
+      : null
+
+  if (!action) {
+    toolCall = extractSkillToolCall(row)
+    action = toolCall?.action ?? null
+  }
 
   if (!action) return null
 
-  const skill = toolCall?.skill || (action === 'view'
+  let skill = action === 'view'
     ? extractSkillNameFromViewContent(content)
-    : extractSkillNameFromManageContent(content))
+    : extractSkillNameFromManageContent(content)
+  if (!skill) {
+    toolCall = toolCall || extractSkillToolCall(row)
+    skill = toolCall?.skill || ''
+  }
 
   if (!skill) return null
 
@@ -1010,6 +1110,20 @@ function formatUnixDate(timestamp: number | null): string {
   return new Date(timestamp * 1000).toISOString().slice(0, 10)
 }
 
+function emptySkillUsageStats(periodDays: number): HermesSkillUsageStats {
+  return {
+    period_days: periodDays,
+    summary: {
+      total_skill_loads: 0,
+      total_skill_edits: 0,
+      total_skill_actions: 0,
+      distinct_skills_used: 0,
+    },
+    by_day: [],
+    top_skills: [],
+  }
+}
+
 export async function getSkillUsageStatsFromDb(
   days = 7,
   nowSeconds = Math.floor(Date.now() / 1000),
@@ -1018,83 +1132,88 @@ export async function getSkillUsageStatsFromDb(
   const normalizedDays = Number.isFinite(days) ? days : 7
   const safeDays = Math.max(1, Math.floor(normalizedDays))
   const since = nowSeconds - safeDays * 24 * 60 * 60
-  const db = getDb()
-  if (!db) throw new Error('SQLite is not available')
+  const dbPath = profile ? join(getProfileDir(profile), 'state.db') : sessionDbPath()
+  if (!existsSync(dbPath)) return emptySkillUsageStats(safeDays)
 
-  const profileName = profile?.trim()
-  const profilePredicate = profileName ? 'AND s.profile = ?' : ''
-  const profileParams = profileName ? [profileName] : []
-  const skillContentExpression = `
-    CASE
-      WHEN m.tool_name IN ('skill_view', 'skill_manage')
-        OR m.content LIKE '[skill_view]%'
-        OR m.content LIKE '[skill_manage]%'
-      THEN m.content
-      ELSE ''
-    END
+  const db = await openSessionDb(profile)
+
+  const sessionsIndexHint = sqliteIndexHint(db, 'idx_sessions_started')
+  const messagesIndexHint = sqliteIndexHint(db, 'idx_messages_session')
+  const compactToolPredicate = `
+    COALESCE(m.tool_name, '') IN ('skill_view', 'skill_manage')
+    OR COALESCE(m.content, '') LIKE '[skill_view]%'
+    OR COALESCE(m.content, '') LIKE '[skill_manage]%'
   `
-  const toolPredicate = `
-    m.role = 'tool'
-    AND (
-      m.tool_name IN ('skill_view', 'skill_manage')
-      OR m.content LIKE '[skill_view]%'
-      OR m.content LIKE '[skill_manage]%'
-      OR m.tool_call_id IS NOT NULL
-    )
-  `
-  const recentRows = db.prepare(`
+  const eventTimeExpression = 'COALESCE(m.timestamp, s.started_at)'
+  const rowSelect = `
     SELECT
+      m.id AS message_id,
+      m.session_id,
       m.tool_name,
       m.tool_call_id,
-      ${skillContentExpression} AS content,
-      COALESCE(m.timestamp, s.started_at) AS timestamp,
-      (
-        SELECT a.tool_calls
-        FROM messages a
-        WHERE a.session_id = m.session_id
-          AND a.role = 'assistant'
-          AND m.tool_call_id IS NOT NULL
-          AND a.tool_calls LIKE '%' || m.tool_call_id || '%'
-        ORDER BY a.timestamp DESC
-        LIMIT 1
-      ) AS assistant_tool_calls
-    FROM sessions s
-    JOIN messages m ON m.session_id = s.id
-    WHERE ${toolPredicate}
-      ${profilePredicate}
-      AND s.started_at > ?
-  `).all(...profileParams, since) as Record<string, unknown>[]
-  const lateRows = db.prepare(`
-    SELECT
-      m.tool_name,
-      m.tool_call_id,
-      ${skillContentExpression} AS content,
-      COALESCE(m.timestamp, s.started_at) AS timestamp,
-      (
-        SELECT a.tool_calls
-        FROM messages a
-        WHERE a.session_id = m.session_id
-          AND a.role = 'assistant'
-          AND m.tool_call_id IS NOT NULL
-          AND a.tool_calls LIKE '%' || m.tool_call_id || '%'
-        ORDER BY a.timestamp DESC
-        LIMIT 1
-      ) AS assistant_tool_calls
-    FROM sessions s
-    JOIN messages m ON m.session_id = s.id
-    WHERE ${toolPredicate}
-      ${profilePredicate}
-      AND s.started_at <= ?
-      AND COALESCE(m.timestamp, s.started_at) > ?
-  `).all(...profileParams, since, since) as Record<string, unknown>[]
+      SUBSTR(m.content, 1, 300) AS content,
+      ${eventTimeExpression} AS timestamp
+    FROM sessions s${sessionsIndexHint}
+    JOIN messages m${messagesIndexHint} ON m.session_id = s.id
+  `
+  let rawRows: Record<string, unknown>[]
+  try {
+    const selectCandidateRows = (predicate: string): Record<string, unknown>[] => {
+      const recentRows = db.prepare(`
+        ${rowSelect}
+        WHERE m.role = 'tool'
+          AND (${predicate})
+          AND s.started_at > ?
+          AND ${eventTimeExpression} > ?
+      `).all(since, since) as Record<string, unknown>[]
+      const lateRows = db.prepare(`
+        ${rowSelect}
+        WHERE m.role = 'tool'
+          AND (${predicate})
+          AND s.started_at <= ?
+          AND ${eventTimeExpression} > ?
+      `).all(since, since) as Record<string, unknown>[]
+      return [...recentRows, ...lateRows]
+    }
+
+    const compactRows = selectCandidateRows(compactToolPredicate)
+    const toolCallRows = selectCandidateRows('m.tool_call_id IS NOT NULL')
+    const toolCallSessionIds = [...new Set(
+      toolCallRows
+        .map(row => typeof row.session_id === 'string' ? row.session_id : '')
+        .filter(Boolean),
+    )]
+    const assistantRows: Record<string, unknown>[] = []
+    for (const chunk of chunkValues(toolCallSessionIds, 500)) {
+      const placeholders = chunk.map(() => '?').join(', ')
+      assistantRows.push(...db.prepare(`
+        SELECT session_id, tool_calls
+        FROM messages${messagesIndexHint}
+        WHERE role = 'assistant'
+          AND tool_calls IS NOT NULL
+          AND (tool_calls LIKE '%skill_view%' OR tool_calls LIKE '%skill_manage%')
+          AND session_id IN (${placeholders})
+      `).all(...chunk) as Record<string, unknown>[])
+    }
+    rawRows = [...compactRows, ...attachAssistantToolCalls(toolCallRows, assistantRows)]
+  } finally {
+    db.close()
+  }
 
   const skillMap = new Map<string, { skill: string; view_count: number; manage_count: number; last_used_at: number | null }>()
   const dayMap = new Map<string, { date: string; view_count: number; manage_count: number }>()
   const daySkillMap = new Map<string, Map<string, { skill: string; view_count: number; manage_count: number }>>()
+  const countedMessageIds = new Set<string>()
 
-  for (const row of [...recentRows, ...lateRows]) {
+  for (const row of rawRows) {
     const event = mapSkillUsageEvent(row)
     if (!event) continue
+    const messageId = normalizeNullableNumber(row.message_id)
+    if (messageId != null) {
+      const messageKey = String(messageId)
+      if (countedMessageIds.has(messageKey)) continue
+      countedMessageIds.add(messageKey)
+    }
 
     const entry = skillMap.get(event.skill) || {
       skill: event.skill,

--- a/tests/server/skill-usage-stats-db.test.ts
+++ b/tests/server/skill-usage-stats-db.test.ts
@@ -1,20 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DatabaseSync } from 'node:sqlite'
+import { mkdtempSync, mkdirSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 
-const dbMock = vi.hoisted(() => ({
-  current: null as DatabaseSync | null,
-}))
+let hermesHome = ''
 
-vi.mock('../../packages/server/src/db/index', () => ({
-  getDb: () => dbMock.current,
-}))
-
-function createWebUiDb(): DatabaseSync {
-  const db = new DatabaseSync(':memory:')
+function createStateDb(profileDir = hermesHome, withIndexes = true): DatabaseSync {
+  mkdirSync(profileDir, { recursive: true })
+  const db = new DatabaseSync(join(profileDir, 'state.db'))
   db.exec(`
     CREATE TABLE sessions (
       id TEXT PRIMARY KEY,
-      profile TEXT NOT NULL DEFAULT 'default',
       source TEXT,
       started_at INTEGER
     );
@@ -28,14 +25,24 @@ function createWebUiDb(): DatabaseSync {
       tool_name TEXT,
       timestamp INTEGER
     );
-    CREATE INDEX idx_messages_session_id ON messages(session_id);
   `)
+  if (withIndexes) {
+    db.exec(`
+      CREATE INDEX idx_sessions_started ON sessions(started_at);
+      CREATE INDEX idx_messages_session ON messages(session_id);
+    `)
+  }
   return db
 }
 
-function insertSession(db: DatabaseSync, row: { id: string; profile?: string; source?: string; started_at: number }) {
-  db.prepare('INSERT INTO sessions (id, profile, source, started_at) VALUES (?, ?, ?, ?)')
-    .run(row.id, row.profile ?? 'default', row.source ?? 'api_server', row.started_at)
+function createProfileStateDb(profile: string): DatabaseSync {
+  const profileDir = join(hermesHome, 'profiles', profile)
+  return createStateDb(profileDir)
+}
+
+function insertSession(db: DatabaseSync, row: { id: string; source?: string; started_at: number }) {
+  db.prepare('INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)')
+    .run(row.id, row.source ?? 'api_server', row.started_at)
 }
 
 function insertToolResult(db: DatabaseSync, row: {
@@ -57,17 +64,19 @@ function insertAssistantToolCalls(db: DatabaseSync, sessionId: string, timestamp
 describe('Hermes skill usage analytics DB aggregation', () => {
   beforeEach(() => {
     vi.resetModules()
-    dbMock.current = createWebUiDb()
+    hermesHome = mkdtempSync(join(tmpdir(), 'wui-skill-usage-'))
+    process.env.HERMES_HOME = hermesHome
   })
 
   afterEach(() => {
-    dbMock.current?.close()
-    dbMock.current = null
+    delete process.env.HERMES_HOME
+    if (hermesHome) rmSync(hermesHome, { recursive: true, force: true })
+    hermesHome = ''
   })
 
-  it('counts completed skill loads and edits from Web UI sessions inside the requested profile and period', async () => {
+  it('counts completed skill loads and edits from canonical Hermes state.db by event timestamp', async () => {
     const now = 1_700_000_000
-    const db = dbMock.current!
+    const db = createStateDb()
 
     insertSession(db, { id: 'recent-chat', started_at: now - 60 })
     insertToolResult(db, {
@@ -89,11 +98,6 @@ describe('Hermes skill usage analytics DB aggregation', () => {
     })
     insertToolResult(db, {
       sessionId: 'recent-chat',
-      timestamp: now - 35,
-      content: '[skill_view] name=github-pr-workflow (22,106 chars)',
-    })
-    insertToolResult(db, {
-      sessionId: 'recent-chat',
       timestamp: now - 32,
       toolName: 'skill_view',
       content: JSON.stringify({
@@ -111,6 +115,11 @@ describe('Hermes skill usage analytics DB aggregation', () => {
       toolName: 'terminal',
       content: 'noop',
     })
+    insertToolResult(db, {
+      sessionId: 'recent-chat',
+      timestamp: now - 10 * 86400,
+      content: '[skill_view] name=old-message-inside-recent-session (1 chars)',
+    })
 
     insertSession(db, { id: 'web-api-session', started_at: now - 30 })
     insertAssistantToolCalls(db, 'web-api-session', now - 22, [
@@ -125,7 +134,7 @@ describe('Hermes skill usage analytics DB aggregation', () => {
       sessionId: 'web-api-session',
       timestamp: now - 20,
       toolCallId: 'call_api_skill_view',
-      content: JSON.stringify({ success: true, name: 'api-server-skill', description: 'API-server JSON tool result' }),
+      content: JSON.stringify({ success: true, description: 'API-server JSON tool result without skill name' }),
     })
 
     insertSession(db, { id: 'old-chat', started_at: now - 10 * 86400 })
@@ -142,12 +151,7 @@ describe('Hermes skill usage analytics DB aggregation', () => {
       content: '[skill_view] name=late-session-skill (1 chars)',
     })
 
-    insertSession(db, { id: 'other-profile-chat', profile: 'tester', started_at: now - 30 })
-    insertToolResult(db, {
-      sessionId: 'other-profile-chat',
-      timestamp: now - 20,
-      content: '[skill_view] name=other-profile-skill (1 chars)',
-    })
+    db.close()
 
     const mod = await import('../../packages/server/src/db/hermes/sessions-db')
     const result = await mod.getSkillUsageStatsFromDb(7, now, 'default')
@@ -155,21 +159,20 @@ describe('Hermes skill usage analytics DB aggregation', () => {
     expect(result).toEqual({
       period_days: 7,
       summary: {
-        total_skill_loads: 6,
+        total_skill_loads: 5,
         total_skill_edits: 1,
-        total_skill_actions: 7,
-        distinct_skills_used: 5,
+        total_skill_actions: 6,
+        distinct_skills_used: 4,
       },
       by_day: [
         {
           date: '2023-11-14',
-          view_count: 6,
+          view_count: 5,
           manage_count: 1,
-          total_count: 7,
+          total_count: 6,
           skills: [
             { skill: 'hermes-agent', view_count: 2, manage_count: 1, total_count: 3 },
             { skill: 'api-server-skill', view_count: 1, manage_count: 0, total_count: 1 },
-            { skill: 'github-pr-workflow', view_count: 1, manage_count: 0, total_count: 1 },
             { skill: 'github-project-analysis', view_count: 1, manage_count: 0, total_count: 1 },
             { skill: 'late-session-skill', view_count: 1, manage_count: 0, total_count: 1 },
           ],
@@ -181,7 +184,7 @@ describe('Hermes skill usage analytics DB aggregation', () => {
           view_count: 2,
           manage_count: 1,
           total_count: 3,
-          percentage: 3 / 7 * 100,
+          percentage: 3 / 6 * 100,
           last_used_at: now - 40,
         },
         {
@@ -189,7 +192,7 @@ describe('Hermes skill usage analytics DB aggregation', () => {
           view_count: 1,
           manage_count: 0,
           total_count: 1,
-          percentage: 1 / 7 * 100,
+          percentage: 1 / 6 * 100,
           last_used_at: now - 20,
         },
         {
@@ -197,26 +200,100 @@ describe('Hermes skill usage analytics DB aggregation', () => {
           view_count: 1,
           manage_count: 0,
           total_count: 1,
-          percentage: 1 / 7 * 100,
+          percentage: 1 / 6 * 100,
           last_used_at: now - 32,
-        },
-        {
-          skill: 'github-pr-workflow',
-          view_count: 1,
-          manage_count: 0,
-          total_count: 1,
-          percentage: 1 / 7 * 100,
-          last_used_at: now - 35,
         },
         {
           skill: 'late-session-skill',
           view_count: 1,
           manage_count: 0,
           total_count: 1,
-          percentage: 1 / 7 * 100,
+          percentage: 1 / 6 * 100,
           last_used_at: now - 40,
         },
       ],
     })
+  })
+
+  it('returns empty stats when the requested Hermes profile has no state.db yet', async () => {
+    const now = 1_700_000_000
+    const mod = await import('../../packages/server/src/db/hermes/sessions-db')
+    const result = await mod.getSkillUsageStatsFromDb(7, now, 'default')
+
+    expect(result).toEqual({
+      period_days: 7,
+      summary: {
+        total_skill_loads: 0,
+        total_skill_edits: 0,
+        total_skill_actions: 0,
+        distinct_skills_used: 0,
+      },
+      by_day: [],
+      top_skills: [],
+    })
+  })
+
+  it('falls back when a readable Hermes state.db lacks optional performance indexes', async () => {
+    const now = 1_700_000_000
+    const db = createStateDb(hermesHome, false)
+    insertSession(db, { id: 'indexless-chat', started_at: now - 60 })
+    insertToolResult(db, {
+      sessionId: 'indexless-chat',
+      timestamp: now - 50,
+      content: '[skill_view] name=indexless-skill (1 chars)',
+    })
+    db.close()
+
+    const mod = await import('../../packages/server/src/db/hermes/sessions-db')
+    const result = await mod.getSkillUsageStatsFromDb(7, now, 'default')
+
+    expect(result.summary).toMatchObject({
+      total_skill_loads: 1,
+      total_skill_edits: 0,
+      total_skill_actions: 1,
+      distinct_skills_used: 1,
+    })
+    expect(result.top_skills[0]?.skill).toBe('indexless-skill')
+  })
+
+  it('uses the requested Hermes profile state.db instead of a Web UI-local profile column', async () => {
+    const now = 1_700_000_000
+    const defaultDb = createStateDb()
+    insertSession(defaultDb, { id: 'default-chat', started_at: now - 60 })
+    insertToolResult(defaultDb, {
+      sessionId: 'default-chat',
+      timestamp: now - 50,
+      content: '[skill_view] name=default-skill (1 chars)',
+    })
+    defaultDb.close()
+
+    const testerDb = createProfileStateDb('tester')
+    insertSession(testerDb, { id: 'tester-chat', started_at: now - 60 })
+    insertToolResult(testerDb, {
+      sessionId: 'tester-chat',
+      timestamp: now - 50,
+      content: '[skill_view] name=tester-skill (1 chars)',
+    })
+    testerDb.close()
+
+    const mod = await import('../../packages/server/src/db/hermes/sessions-db')
+
+    const defaultResult = await mod.getSkillUsageStatsFromDb(7, now, 'default')
+    expect(defaultResult.summary).toMatchObject({
+      total_skill_loads: 1,
+      total_skill_edits: 0,
+      total_skill_actions: 1,
+      distinct_skills_used: 1,
+    })
+    expect(defaultResult.top_skills[0]?.skill).toBe('default-skill')
+
+    const testerResult = await mod.getSkillUsageStatsFromDb(7, now, 'tester')
+    expect(testerResult.summary).toMatchObject({
+      total_skill_loads: 1,
+      total_skill_edits: 0,
+      total_skill_actions: 1,
+      distinct_skills_used: 1,
+    })
+    expect(testerResult.top_skills[0]?.skill).toBe('tester-skill')
   })
 })

--- a/tests/server/skill-usage-stats-db.test.ts
+++ b/tests/server/skill-usage-stats-db.test.ts
@@ -233,6 +233,33 @@ describe('Hermes skill usage analytics DB aggregation', () => {
     })
   })
 
+  it('does not fall back to default usage when a named Hermes profile is missing', async () => {
+    const now = 1_700_000_000
+    const db = createStateDb()
+    insertSession(db, { id: 'default-chat', started_at: now - 60 })
+    insertToolResult(db, {
+      sessionId: 'default-chat',
+      timestamp: now - 50,
+      content: '[skill_view] name=default-skill (1 chars)',
+    })
+    db.close()
+
+    const mod = await import('../../packages/server/src/db/hermes/sessions-db')
+    const result = await mod.getSkillUsageStatsFromDb(7, now, 'deleted-profile')
+
+    expect(result).toEqual({
+      period_days: 7,
+      summary: {
+        total_skill_loads: 0,
+        total_skill_edits: 0,
+        total_skill_actions: 0,
+        distinct_skills_used: 0,
+      },
+      by_day: [],
+      top_skills: [],
+    })
+  })
+
   it('falls back when a readable Hermes state.db lacks optional performance indexes', async () => {
     const now = 1_700_000_000
     const db = createStateDb(hermesHome, false)


### PR DESCRIPTION
Closes #1461

## 改动说明
- Skills Usage 改为读取 Hermes canonical `state.db`，不再误读 Web UI 本地数据库。
- 使用 tool event/message timestamp 做窗口过滤，避免最近 session 壳里的旧消息污染 7d/30d 图表。
- 补齐 API Server `tool_call_id` 形态的 skill 名称回查，并处理新 profile 无 `state.db`、缺少可选索引的 fallback。
- 补了 missing/deleted profile 的保护，避免请求不存在的 profile 时回退读取 default `state.db`。

## 验证
- `npm test -- --run tests/server/skill-usage-stats-db.test.ts tests/client/skills-usage-view.test.ts`：9 tests passed
- `npm run build`：passed
- `git diff --check`：passed
- 补充验证（profile fallback guard）：`npm test -- tests/server/skill-usage-stats-db.test.ts`，5 tests passed；`npm run build` passed
- Codex independent review：no actionable correctness issues after profile fallback guard
- Production build UAT：
  - 7d：Actions 732 / Loads 637 / Edits 95 / Skills 29，范围 2026-06-28 → 2026-07-05
  - 30d：Actions 2122 / Loads 1882 / Edits 240 / Skills 58，范围 2026-06-05 → 2026-07-05

## 备注
- 这是统计正确性修复，不包含 sidebar active group 可见性改动。
