### PR TITLE
[codex] stabilize Ekko context usage updates

### DIFF
--- a/docs/chat-chain-changes/2026-07-06-ekko-agent-context-usage.md
+++ b/docs/chat-chain-changes/2026-07-06-ekko-agent-context-usage.md
@@ -1,0 +1,20 @@
+---
+date: 2026-07-06
+pr: pending
+commit: pending
+feature: Ekko Agent context usage and tool history
+impact: Ekko-agent runs no longer publish per-step request context estimates as formal usage updates, and follow-up turns now include paired tool results in model history.
+---
+
+Ekko-agent runtime `context.estimated` events remain available as estimate-only
+chat events for debugging and future UI detail surfaces, but they no longer
+overwrite the session's formal `contextTokens` through `usage.updated`.
+
+The final run completion path now applies the latest context estimate to session
+state and emits the single official `usage.updated` event, matching the steadier
+Hermes Agent Bridge context-meter behavior.
+
+Ekko-agent history projection now restores assistant tool-call messages together
+with matching `tool_call_id` result rows. Orphan tool rows are still skipped so
+providers do not receive invalid unpaired tool results, but follow-up turns can
+see browser/file/search results produced earlier in the conversation.

--- a/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
@@ -57,18 +57,106 @@ function isEkkoAgentId(data: EkkoAgentRunSocketData): boolean {
   return data.coding_agent_id === 'ekko-agent' || data.agent_id === 'ekko-agent'
 }
 
+function parseJsonRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function parseToolArguments(raw: unknown): { arguments: Record<string, unknown>; rawArguments?: string } {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) return { arguments: raw as Record<string, unknown> }
+  const rawArguments = typeof raw === 'string' ? raw : JSON.stringify(raw ?? {})
+  try {
+    const parsed = JSON.parse(rawArguments)
+    return {
+      arguments: parseJsonRecord(parsed) || {},
+      rawArguments,
+    }
+  } catch {
+    return { arguments: {}, rawArguments }
+  }
+}
+
+function normalizeStoredToolCall(raw: unknown): AgentToolCall | null {
+  const record = parseJsonRecord(raw)
+  if (!record) return null
+  const functionRecord = parseJsonRecord(record.function)
+  const id = String(record.id || record.call_id || record.tool_call_id || '').trim()
+  const name = String(record.name || functionRecord?.name || '').trim()
+  if (!id || !name) return null
+  const parsed = parseToolArguments(record.arguments ?? functionRecord?.arguments)
+  return {
+    id,
+    name,
+    arguments: parsed.arguments,
+    rawArguments: parsed.rawArguments,
+  }
+}
+
+function normalizeStoredToolCalls(value: unknown): AgentToolCall[] | undefined {
+  const rawCalls = Array.isArray(value)
+    ? value
+    : typeof value === 'string' && value.trim()
+      ? JSON.parse(value)
+      : []
+  if (!Array.isArray(rawCalls)) return undefined
+  const calls = rawCalls
+    .map(normalizeStoredToolCall)
+    .filter((call): call is AgentToolCall => !!call)
+  return calls.length ? calls : undefined
+}
+
 function toAgentMessages(messages: SessionState['messages']): AgentMessage[] {
-  return messages
-    .filter(message => message.role === 'user' || message.role === 'assistant' || message.role === 'system' || message.role === 'command')
-    .map((message): AgentMessage => {
-      const role: AgentMessage['role'] = message.role === 'assistant' || message.role === 'system' ? message.role : 'user'
-      return {
-        role,
+  const toolCallIds = new Set<string>()
+  const result: AgentMessage[] = []
+
+  for (const message of messages) {
+    if (message.role === 'user' || message.role === 'command' || message.role === 'system') {
+      const content = contentBlocksToString(message.content as any)
+      if (content.trim()) {
+        result.push({
+          role: message.role === 'system' ? 'system' : 'user',
+          content,
+        })
+      }
+      continue
+    }
+
+    if (message.role === 'assistant') {
+      let toolCalls: AgentToolCall[] | undefined
+      try {
+        toolCalls = normalizeStoredToolCalls(message.tool_calls)
+      } catch {
+        toolCalls = undefined
+      }
+      for (const call of toolCalls || []) toolCallIds.add(call.id)
+      const agentMessage: AgentMessage = {
+        role: 'assistant',
         content: contentBlocksToString(message.content as any),
         reasoning: message.reasoning || message.reasoning_content || undefined,
+        toolCalls,
       }
-    })
-    .filter(message => message.content.trim().length > 0 || (message.reasoning?.trim().length ?? 0) > 0)
+      if (agentMessage.content.trim() || (agentMessage.reasoning?.trim().length ?? 0) > 0 || toolCalls?.length) {
+        result.push(agentMessage)
+      }
+      continue
+    }
+
+    if (message.role === 'tool') {
+      const toolCallId = String(message.tool_call_id || '').trim()
+      if (!toolCallId || !toolCallIds.has(toolCallId)) continue
+      const content = contentBlocksToString(message.content as any)
+      if (!content.trim()) continue
+      result.push({
+        role: 'tool',
+        content,
+        toolCallId,
+        name: message.tool_name || undefined,
+      })
+      toolCallIds.delete(toolCallId)
+    }
+  }
+
+  return result
 }
 
 function appendStateEvent(state: SessionState, event: string, payload: any): void {
@@ -435,13 +523,9 @@ export async function handleEkkoAgentRun(
       })
     } else if (event.type === 'context.estimated') {
       contextEstimate = event.estimate
-      state.contextTokens = event.estimate.contextTokens
-      emit('usage.updated', {
-        event: 'usage.updated',
+      emit('context.estimated', {
+        event: 'context.estimated',
         run_id: event.runId,
-        input_tokens: state.inputTokens || 0,
-        output_tokens: state.outputTokens || 0,
-        total_tokens: (state.inputTokens || 0) + (state.outputTokens || 0),
         contextTokens: event.estimate.contextTokens,
         context_tokens: event.estimate.contextTokens,
         systemPromptTokens: event.estimate.systemPromptTokens,
@@ -644,6 +728,7 @@ export async function handleEkkoAgentRun(
     }
     state.inputTokens = (state.inputTokens || 0) + usageInput
     state.outputTokens = (state.outputTokens || 0) + usageOutput
+    if (contextEstimate?.contextTokens != null) state.contextTokens = contextEstimate.contextTokens
     updateSessionStats(sessionId)
     emit('usage.updated', {
       event: 'usage.updated',

--- a/tests/server/run-chat-ekko-context.test.ts
+++ b/tests/server/run-chat-ekko-context.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getSessionMock = vi.hoisted(() => vi.fn())
+const createSessionMock = vi.hoisted(() => vi.fn())
+const addMessageMock = vi.hoisted(() => vi.fn())
+const updateSessionStatsMock = vi.hoisted(() => vi.fn())
+const resolveBridgeRunModelConfigMock = vi.hoisted(() => vi.fn())
+const agentRunMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
+  getSession: getSessionMock,
+  createSession: createSessionMock,
+  addMessage: addMessageMock,
+  updateSessionStats: updateSessionStatsMock,
+}))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/model-config', () => ({
+  resolveBridgeRunModelConfig: resolveBridgeRunModelConfigMock,
+}))
+
+vi.mock('../../packages/server/src/services/ekko-agent/manager', () => ({
+  getGlobalEkkoAgent: vi.fn(() => ({
+    run: agentRunMock,
+  })),
+}))
+
+vi.mock('../../packages/server/src/services/ekko-agent/mcp', () => ({
+  resolveEkkoMcpServers: vi.fn(() => undefined),
+}))
+
+vi.mock('../../packages/ekko-agent/src', () => ({
+  createModelClient: vi.fn(() => ({
+    provider: 'test',
+    requestStyle: 'custom-runtime',
+    capabilities: {
+      streaming: false,
+      tools: true,
+      vision: false,
+      jsonMode: false,
+      systemPrompt: true,
+    },
+  })),
+  resolveModelProviderConfigs: vi.fn(() => ({
+    providerConfig: {
+      provider: 'test',
+      model: 'ekko-test-model',
+      apiMode: 'chat_completions',
+    },
+  })),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+  getProfileDir: vi.fn(() => '/tmp/hermes-default'),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/pet-state-socket', () => ({
+  observeRunChatPetEvent: vi.fn(),
+}))
+
+vi.mock('../../packages/server/src/services/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+function makeHarness() {
+  const roomTarget = { emit: vi.fn(), except: vi.fn(() => ({ emit: vi.fn() })) }
+  const nsp = {
+    adapter: { rooms: new Map([['session:session-1', new Set(['socket-1'])]]) },
+    to: vi.fn(() => roomTarget),
+  }
+  const socket = {
+    id: 'socket-1',
+    connected: true,
+    join: vi.fn(),
+    emit: vi.fn(),
+    to: vi.fn(() => roomTarget),
+  }
+  const state = {
+    messages: [],
+    isWorking: false,
+    events: [],
+    queue: [],
+    inputTokens: 10,
+    outputTokens: 5,
+  }
+  const sessionMap = new Map<string, any>([['session-1', state]])
+  const events: Array<{ event: string; payload: any }> = []
+  return { nsp, socket, sessionMap, state, events }
+}
+
+describe('ekko-agent context usage events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockReturnValue({
+      id: 'session-1',
+      profile: 'default',
+      source: 'coding_agent',
+      agent: 'ekko-agent',
+      model: 'ekko-test-model',
+      provider: 'test-provider',
+      workspace: '/tmp/workspace',
+    })
+    addMessageMock.mockReturnValue(1)
+    resolveBridgeRunModelConfigMock.mockResolvedValue({
+      model: 'ekko-test-model',
+      provider: 'test-provider',
+    })
+  })
+
+  it('does not publish step context estimates as formal usage updates', async () => {
+    agentRunMock.mockImplementationOnce(async (input: any) => {
+      input.onEvent({ type: 'run.started', runId: 'run-1', maxSteps: 3 })
+      input.onEvent({
+        type: 'context.estimated',
+        runId: 'run-1',
+        step: 1,
+        estimate: {
+          contextTokens: 10_000,
+          systemPromptTokens: 1_000,
+          messageTokens: 2_000,
+          toolTokens: 7_000,
+          modelContextTokens: 0,
+          messageCount: 2,
+          toolCount: 5,
+        },
+      })
+      input.onEvent({
+        type: 'context.estimated',
+        runId: 'run-1',
+        step: 2,
+        estimate: {
+          contextTokens: 30_000,
+          systemPromptTokens: 1_000,
+          messageTokens: 22_000,
+          toolTokens: 7_000,
+          modelContextTokens: 0,
+          messageCount: 4,
+          toolCount: 5,
+        },
+      })
+      return {
+        runId: 'run-1',
+        output: { role: 'assistant', content: 'done', usage: { inputTokens: 3, outputTokens: 2 } },
+        steps: [],
+        messages: [],
+        events: [],
+        contextEstimate: { contextTokens: 30_000 },
+      }
+    })
+    const { handleEkkoAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-ekko-agent-run')
+    const { nsp, socket, sessionMap, state, events } = makeHarness()
+
+    await handleEkkoAgentRun(nsp as any, socket as any, {
+      session_id: 'session-1',
+      input: 'continue',
+      coding_agent_id: 'ekko-agent',
+      onEvent: (event: string, payload: any) => events.push({ event, payload }),
+    }, 'default', sessionMap, vi.fn(() => false))
+
+    expect(events.filter(item => item.event === 'context.estimated').map(item => item.payload.contextTokens)).toEqual([
+      10_000,
+      30_000,
+    ])
+    const usageEvents = events.filter(item => item.event === 'usage.updated')
+    expect(usageEvents).toHaveLength(1)
+    expect(usageEvents[0].payload).toEqual(expect.objectContaining({
+      input_tokens: 13,
+      output_tokens: 7,
+      total_tokens: 20,
+      contextTokens: 30_000,
+    }))
+    expect(state.contextTokens).toBe(30_000)
+  })
+
+  it('includes paired tool results in Ekko history for follow-up turns', async () => {
+    agentRunMock.mockResolvedValueOnce({
+      runId: 'run-1',
+      output: { role: 'assistant', content: 'follow-up done', usage: { inputTokens: 3, outputTokens: 2 } },
+      steps: [],
+      messages: [],
+      events: [],
+      contextEstimate: { contextTokens: 12_000 },
+    })
+    const { handleEkkoAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-ekko-agent-run')
+    const { nsp, socket, sessionMap, state } = makeHarness()
+    state.messages = [
+      {
+        id: 1,
+        session_id: 'session-1',
+        role: 'user',
+        content: 'check weather',
+        timestamp: 1000,
+      },
+      {
+        id: 2,
+        session_id: 'session-1',
+        role: 'assistant',
+        content: '',
+        tool_calls: [{
+          id: 'call_weather',
+          type: 'function',
+          function: {
+            name: 'browser_navigate',
+            arguments: '{"url":"https://weather.example"}',
+          },
+        }],
+        timestamp: 1001,
+      },
+      {
+        id: 3,
+        session_id: 'session-1',
+        role: 'tool',
+        content: '{"forecast":"sunny"}',
+        tool_call_id: 'call_weather',
+        tool_name: 'browser_navigate',
+        timestamp: 1002,
+      },
+      {
+        id: 4,
+        session_id: 'session-1',
+        role: 'tool',
+        content: 'orphan result',
+        tool_call_id: 'call_orphan',
+        tool_name: 'browser_navigate',
+        timestamp: 1003,
+      },
+    ]
+
+    await handleEkkoAgentRun(nsp as any, socket as any, {
+      session_id: 'session-1',
+      input: 'thanks',
+      coding_agent_id: 'ekko-agent',
+    }, 'default', sessionMap, vi.fn(() => false))
+
+    const runInput = agentRunMock.mock.calls[0][0]
+    expect(runInput.messages).toMatchObject([
+      { role: 'user', content: 'check weather' },
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [{
+          id: 'call_weather',
+          name: 'browser_navigate',
+          arguments: { url: 'https://weather.example' },
+          rawArguments: '{"url":"https://weather.example"}',
+        }],
+      },
+      {
+        role: 'tool',
+        content: '{"forecast":"sunny"}',
+        toolCallId: 'call_weather',
+        name: 'browser_navigate',
+      },
+      { role: 'user', content: 'thanks' },
+    ])
+    expect(runInput.messages.some((message: any) => message.content === 'orphan result')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- stop publishing Ekko per-step context estimates as formal `usage.updated` events
- restore paired assistant tool calls and tool result rows into Ekko follow-up history
- add focused server coverage and a chat-chain change note

## Why
Ekko-agent emitted every runtime `context.estimated` event as `usage.updated`, so the chat context meter jumped during tool loops and then changed again on the next turn. Ekko history projection also dropped tool result rows, so follow-up turns could lose the tool output that explained the prior answer.

## Impact
The context meter now updates once at Ekko run completion, matching the steadier Hermes Agent Bridge behavior. Follow-up Ekko turns include valid paired tool results while still skipping orphan tool rows that would break provider message formats.

## Validation
- `npm run test -- tests/server/run-chat-ekko-context.test.ts tests/ekko-agent/runtime.test.ts tests/ekko-agent/messages.test.ts tests/ekko-agent/model-request.test.ts tests/server/ekko-agent-manager.test.ts`
- `npm run harness:check`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `git diff --check`