### PR TITLE
[codex] Stabilize Codex context usage

### DIFF
--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -6,13 +6,14 @@ import { createSession, addMessage, getSession, updateSession, updateSessionStat
 import type { ApiMode } from './types'
 import { logger } from '../logger'
 import { applyResponseStreamEvent, flushResponseRunToDb } from '../hermes/run-chat/response-stream'
-import { calcAndUpdateUsage, updateMessageContextTokenUsage } from '../hermes/run-chat/usage'
+import { calcAndUpdateUsage, estimateUsageTokensFromMessages, updateContextTokenUsage } from '../hermes/run-chat/usage'
 import { extractResponseText } from '../hermes/run-chat/response-utils'
 import type { SessionState } from '../hermes/run-chat/types'
 import type { CanonicalResponsesEvent } from './adapters/responses-stream'
 import { mapCodingAgentResponseEvent } from './coding-agent-event-mapper'
 import { normalizeWindowsCommandPath, windowsCmdShimExecution, windowsCommandNeedsShell } from '../windows-command'
 import { completeWorkspaceRunCheckpoint, startWorkspaceRunCheckpoint } from '../hermes/run-chat/workspace-diff-tracker'
+import { buildDbHistory, buildSnapshotAwareHistory } from '../hermes/run-chat/compression'
 
 const DEFAULT_IDLE_MS = 30 * 60 * 1000
 const TERMINAL_OUTPUT_FLUSH_MS = 120
@@ -106,6 +107,7 @@ interface ManagedCodingAgentRun {
   codexToolBlocks?: Map<string, { id: string; name: string; arguments: string; done: boolean }>
   codexChatText?: string
   codexPendingUsage?: any
+  terminalUsageRefresh?: Promise<void>
   stoppedByUser?: boolean
   pendingChatCompletionEvent?: 'run.completed' | 'run.failed'
   pendingChatCompletionPayload?: Record<string, unknown>
@@ -622,7 +624,7 @@ export class CodingAgentRunManager {
       flushResponseRunToDb(run.state, run.launch.sessionId)
       run.state.responseRun = undefined
       updateSessionStats(run.launch.sessionId)
-      void this.refreshCodingAgentUsage(run)
+      run.terminalUsageRefresh = this.refreshCodingAgentUsage(run)
       const final = (storageSafeResponseEvent.data as any).response || storageSafeResponseEvent.data
       const finalText = extractResponseText(final)
       const terminalError = storageSafeResponseEvent.type === 'response.failed'
@@ -640,7 +642,7 @@ export class CodingAgentRunManager {
         run.pendingChatCompletionEvent = chatCompletionEvent
         run.pendingChatCompletionPayload = chatCompletionPayload
       } else {
-        this.emitAndMarkPrintChatRunCompleted(run, chatCompletionEvent, chatCompletionPayload)
+        void this.emitAndMarkPrintChatRunCompletedAfterUsage(run, chatCompletionEvent, chatCompletionPayload)
       }
     }
   }
@@ -650,13 +652,28 @@ export class CodingAgentRunManager {
       this.emitToChat(run.launch.sessionId, event, payload)
     }
     const usage = await calcAndUpdateUsage(run.launch.sessionId, run.state, emitUsage)
-    updateMessageContextTokenUsage(
-      run.launch.sessionId,
-      run.state,
-      emitUsage,
-      usage.inputTokens + usage.outputTokens,
-      usage,
-    )
+    const contextTokens = await this.estimateCodingAgentContextTokens(run)
+    if (contextTokens != null) {
+      updateContextTokenUsage(run.launch.sessionId, run.state, emitUsage, contextTokens, usage)
+    }
+  }
+
+  private async estimateCodingAgentContextTokens(run: ManagedCodingAgentRun): Promise<number | undefined> {
+    try {
+      const dbHistory = await buildDbHistory(run.launch.sessionId, { excludeLastUser: false })
+      const snapshotHistory = await buildSnapshotAwareHistory(
+        run.launch.sessionId,
+        run.launch.profile || 'default',
+        dbHistory,
+        { model: run.launch.model, provider: run.launch.provider },
+      )
+      const usage = estimateUsageTokensFromMessages(snapshotHistory)
+      const contextTokens = usage.inputTokens + usage.outputTokens
+      if (contextTokens > 0) return contextTokens
+    } catch (err) {
+      logger.warn(err, '[coding-agent-run] failed to calculate context tokens for session %s', run.launch.sessionId)
+    }
+    return undefined
   }
 
   private normalizeCodexChatTextEvent(run: ManagedCodingAgentRun, event: CanonicalResponsesEvent): CanonicalResponsesEvent | null {
@@ -869,7 +886,7 @@ export class CodingAgentRunManager {
       logger.info({ runId: run.id, sessionId: run.launch.sessionId, code }, '[coding-agent-run] claude print exited')
       if (run.stoppedByUser) return
       if (run.pendingChatCompletionEvent) {
-        this.emitAndMarkPrintChatRunCompleted(run, run.pendingChatCompletionEvent, run.pendingChatCompletionPayload)
+        void this.emitAndMarkPrintChatRunCompletedAfterUsage(run, run.pendingChatCompletionEvent, run.pendingChatCompletionPayload)
         return
       }
       if (code === 0) {
@@ -1307,7 +1324,7 @@ export class CodingAgentRunManager {
       logger.info({ runId: run.id, sessionId: run.launch.sessionId, code }, '[coding-agent-run] codex exec exited')
       if (run.stoppedByUser) return
       if (run.pendingChatCompletionEvent) {
-        this.emitAndMarkPrintChatRunCompleted(run, run.pendingChatCompletionEvent, run.pendingChatCompletionPayload)
+        void this.emitAndMarkPrintChatRunCompletedAfterUsage(run, run.pendingChatCompletionEvent, run.pendingChatCompletionPayload)
         return
       }
       if (code === 0) {
@@ -1677,6 +1694,23 @@ export class CodingAgentRunManager {
 
   private completeCodexExecTurn(run: ManagedCodingAgentRun, usage?: any) {
     this.completeClaudePrintTurn(run, usage)
+  }
+
+  private async emitAndMarkPrintChatRunCompletedAfterUsage(
+    run: ManagedCodingAgentRun,
+    event: 'run.completed' | 'run.failed',
+    payload?: Record<string, unknown>,
+  ) {
+    const usageRefresh = run.terminalUsageRefresh
+    run.terminalUsageRefresh = undefined
+    if (usageRefresh) {
+      try {
+        await usageRefresh
+      } catch (err) {
+        logger.warn({ err, runId: run.id, sessionId: run.launch.sessionId }, '[coding-agent-run] terminal usage refresh failed before completion')
+      }
+    }
+    this.emitAndMarkPrintChatRunCompleted(run, event, payload)
   }
 
   private emitAndMarkPrintChatRunCompleted(run: ManagedCodingAgentRun, event: 'run.completed' | 'run.failed', payload?: Record<string, unknown>) {

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -285,7 +285,7 @@ describe('coding agent run state', () => {
     manager.shutdown()
   })
 
-  it('clears shared chat session run state when a print turn completes', () => {
+  it('clears shared chat session run state when a print turn completes', async () => {
     initAllHermesTables()
     const manager = new CodingAgentRunManager()
     const state: any = { messages: [], isWorking: false, events: [], queue: [] }
@@ -322,6 +322,7 @@ describe('coding agent run state', () => {
         },
       },
     })
+    await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(state).toEqual(expect.objectContaining({
       isWorking: false,
@@ -487,8 +488,8 @@ describe('coding agent run state', () => {
       content: 'I am GPT-5-Codex',
       finish_reason: 'stop',
     }))
-    expect(state.isWorking).toBe(false)
     await new Promise(resolve => setTimeout(resolve, 0))
+    expect(state.isWorking).toBe(false)
 
     expect(emitted.map(event => event.event)).toContain('message.delta')
     expect(emitted.map(event => event.event)).toContain('usage.updated')
@@ -496,6 +497,54 @@ describe('coding agent run state', () => {
       contextTokens: expect.any(Number),
     }))
     expect(emitted.find(event => event.event === 'run.completed')?.payload).not.toHaveProperty('usage')
+    const eventNames = emitted.map(event => event.event)
+    expect(eventNames.lastIndexOf('usage.updated')).toBeLessThan(eventNames.indexOf('run.completed'))
+    manager.shutdown()
+  })
+
+  it('does not reset Codex context tokens when a usage refresh has no context estimate', async () => {
+    initAllHermesTables()
+    const manager = new CodingAgentRunManager()
+    const state: any = {
+      messages: [],
+      isWorking: false,
+      events: [],
+      queue: [],
+      contextTokens: 15_000,
+    }
+    const emitted: Array<{ event: string; payload: any }> = []
+    ;(manager as any).emitToChat = (_sessionId: string, event: string, payload: any) => {
+      emitted.push({ event, payload })
+    }
+    const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    const agentSessionId = `agent-session-codex-empty-usage-${suffix}`
+    const chatSessionId = `chat-session-codex-empty-usage-${suffix}`
+    manager.start({
+      agentSessionId,
+      agentId: 'codex',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'gpt-5-codex',
+      sessionId: chatSessionId,
+      command: 'codex',
+      args: ['--model', 'gpt-5-codex'],
+      shellCommand: 'codex --model gpt-5-codex',
+      workspaceDir: process.cwd(),
+      state,
+    })
+    const run = (manager as any).runs.get(agentSessionId)
+
+    await (manager as any).refreshCodingAgentUsage(run)
+
+    expect(state.contextTokens).toBe(15_000)
+    expect(emitted).toContainEqual(expect.objectContaining({
+      event: 'usage.updated',
+      payload: expect.objectContaining({ inputTokens: 0, outputTokens: 0 }),
+    }))
+    expect(emitted).not.toContainEqual(expect.objectContaining({
+      event: 'usage.updated',
+      payload: expect.objectContaining({ contextTokens: 0 }),
+    }))
     manager.shutdown()
   })
 
@@ -931,7 +980,7 @@ describe('coding agent run state', () => {
     manager.shutdown()
   })
 
-  it('waits for Codex process exit before flushing final text after tools', () => {
+  it('waits for Codex process exit before flushing final text after tools', async () => {
     initAllHermesTables()
     const manager = new CodingAgentRunManager()
     const state: any = { messages: [], isWorking: false, events: [], queue: [] }
@@ -1066,6 +1115,7 @@ describe('coding agent run state', () => {
     }))
     run.currentChild = undefined
     ;(manager as any).completeCodexExecTurn(run, run.codexPendingUsage)
+    await new Promise(resolve => setTimeout(resolve, 0))
 
     const textMessages = state.messages.filter((message: any) => message.role === 'assistant' && !message.tool_calls?.length)
     expect(textMessages.map((message: any) => message.content)).toEqual([openingText, finalText])

--- a/tests/server/coding-agent-run-manager-windows.test.ts
+++ b/tests/server/coding-agent-run-manager-windows.test.ts
@@ -229,7 +229,7 @@ describe('coding agent Windows process launch', () => {
     ;(manager as any).sessionIndex.clear()
   })
 
-  it('emits a readable failed run when a hidden Claude Code process cannot start', () => {
+  it('emits a readable failed run when a hidden Claude Code process cannot start', async () => {
     const manager = new CodingAgentRunManager()
     const emitted: Array<{ event: string; payload: any }> = []
     ;(manager as any).ensureDbSession = () => {}
@@ -258,6 +258,7 @@ describe('coding agent Windows process launch', () => {
 
     manager.send('chat-session-error-1', 'test')
     testState.spawnCalls[0].child.emit('error', Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' }))
+    await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(emitted).toContainEqual(expect.objectContaining({
       event: 'run.failed',
@@ -272,7 +273,7 @@ describe('coding agent Windows process launch', () => {
     ;(manager as any).sessionIndex.clear()
   })
 
-  it('includes decoded stderr detail when a hidden Codex process exits non-zero', () => {
+  it('includes decoded stderr detail when a hidden Codex process exits non-zero', async () => {
     const manager = new CodingAgentRunManager()
     const emitted: Array<{ event: string; payload: any }> = []
     ;(manager as any).ensureDbSession = () => {}
@@ -302,6 +303,7 @@ describe('coding agent Windows process launch', () => {
     manager.send('chat-session-codex-error-1', 'test')
     testState.spawnCalls[0].child.stderr.emit('data', Buffer.from([0xb2, 0xbb, 0xca, 0xc7]))
     testState.spawnCalls[0].child.emit('exit', 1)
+    await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(emitted).toContainEqual(expect.objectContaining({
       event: 'run.failed',


### PR DESCRIPTION
## Summary
- make coding-agent terminal completion wait for usage/context refresh before emitting run.completed/run.failed
- keep Codex contextTokens from resetting when a refresh cannot produce a context estimate
- add regression coverage for Codex usage ordering and empty context estimates

## Root cause
Codex coding-agent runs launched usage refresh in the background and emitted completion immediately. If usage.updated arrived after run.completed, the client-side session handler could already be closed, so the final contextTokens update was missed. Hermes/Ekko already emit usage before completion.

## Validation
- npm run test -- tests/server/agent-runner-utils.test.ts
- npm run harness:check
- npm run build