### PR TITLE
[codex] Add journey Hermes version guidance

### DIFF
--- a/packages/server/src/services/hermes/journey.ts
+++ b/packages/server/src/services/hermes/journey.ts
@@ -2,6 +2,8 @@ import { getActiveProfileName, getProfileDir } from './hermes-profile'
 import { execHermes } from './hermes-process'
 
 const JOURNEY_TIMEOUT_MS = 10000
+const JOURNEY_MIN_HERMES_VERSION = '0.18.0'
+const JOURNEY_UNSUPPORTED_MESSAGE = `Please update Hermes to ${JOURNEY_MIN_HERMES_VERSION} or later to use Learning Journey.`
 
 export interface JourneyNode {
   id: string
@@ -92,19 +94,40 @@ function errorMessage(err: unknown): string {
   return String(err)
 }
 
+function isUnsupportedJourneyCommandError(message: string): boolean {
+  return /journey/i.test(message) && (
+    /invalid choice/i.test(message) ||
+    /unknown command/i.test(message) ||
+    /no such command/i.test(message) ||
+    /unrecognized command/i.test(message) ||
+    /unexpected argument/i.test(message) ||
+    /unrecognized arguments?/i.test(message)
+  )
+}
+
 export async function getJourneyGraph(profile?: string | null): Promise<JourneyGraphResponse> {
   const profileName = normalizeProfile(profile)
   const profileDir = getProfileDir(profileName)
 
+  let stdout: string
   try {
-    const { stdout } = await execHermes(['journey', '--json', '--no-color'], {
+    const result = await execHermes(['journey', '--json', '--no-color'], {
       timeout: JOURNEY_TIMEOUT_MS,
       env: {
         ...process.env,
         HERMES_HOME: profileDir,
       },
     })
+    stdout = result.stdout
+  } catch (err) {
+    const message = errorMessage(err)
+    if (isUnsupportedJourneyCommandError(message)) {
+      throw new Error(JOURNEY_UNSUPPORTED_MESSAGE)
+    }
+    throw new Error(`Failed to load Hermes journey graph: ${message}`)
+  }
 
+  try {
     return {
       profile: profileName,
       source: 'cli',

--- a/tests/server/hermes-journey-service.test.ts
+++ b/tests/server/hermes-journey-service.test.ts
@@ -47,4 +47,22 @@ describe('hermes journey service', () => {
     const { getJourneyGraph } = await import('../../packages/server/src/services/hermes/journey')
     await expect(getJourneyGraph('default')).rejects.toThrow('Hermes journey returned invalid JSON')
   })
+
+  it('asks users to update Hermes when the journey command is unsupported', async () => {
+    mockExecHermes.mockRejectedValueOnce(Object.assign(new Error('exit 2'), {
+      stderr: "usage: hermes [-h] {chat,config}\nhermes: error: argument command: invalid choice: 'journey'",
+    }))
+
+    const { getJourneyGraph } = await import('../../packages/server/src/services/hermes/journey')
+    await expect(getJourneyGraph('default')).rejects.toThrow('Please update Hermes to 0.18.0 or later to use Learning Journey.')
+  })
+
+  it('keeps non-version CLI errors actionable', async () => {
+    mockExecHermes.mockRejectedValueOnce(Object.assign(new Error('exit 1'), {
+      stderr: 'database is locked',
+    }))
+
+    const { getJourneyGraph } = await import('../../packages/server/src/services/hermes/journey')
+    await expect(getJourneyGraph('default')).rejects.toThrow('Failed to load Hermes journey graph: database is locked')
+  })
 })


### PR DESCRIPTION
## Summary
- show a clear English update prompt when the installed Hermes CLI does not support the journey command
- keep unrelated journey CLI failures reporting their original error
- add service coverage for unsupported command and generic CLI errors

## User impact
Users opening Learning Journey with an older Hermes Agent now see: Please update Hermes to 0.18.0 or later to use Learning Journey.

## Validation
- npm run test -- tests/server/hermes-journey-service.test.ts
- npm run harness:check
- npm run build