### PR TITLE
[codex] fix chat input frame height setting

### DIFF
--- a/docs/chat-chain-changes/2026-07-06-chat-input-height-settings.md
+++ b/docs/chat-chain-changes/2026-07-06-chat-input-height-settings.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-06
+commit: pending
+feature: Chat input height display setting
+impact: Chat and Group Chat input boxes now apply display setting changes after a local drag resize without changing run protocol, message persistence, resume, queue, or agent execution semantics.
+---
+
+Changing `display.chat_input_height` clears the current input component's local manual-resize override and reapplies the configured desktop height. The input frame derives its minimum height from the configured textarea height, so the visible border changes together with the text area. Mobile auto-height behavior remains unchanged.

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -310,6 +310,11 @@ async function loadSkills() {
 
 // 自定义高度拖拽
 const textareaHeight = ref<number | null>(null) // null = auto
+const inputWrapperStyle = computed(() => {
+  const height = textareaHeight.value ?? configuredTextareaHeight.value
+  if (height === null) return {}
+  return { minHeight: `${height + 71}px` }
+})
 
 function syncViewport() {
   if (typeof window === 'undefined') return
@@ -494,6 +499,11 @@ watch(() => chatStore.activeSession?.id, () => {
 })
 
 watch(configuredTextareaHeight, () => {
+  applyConfiguredTextareaHeight()
+})
+
+watch(() => settingsStore.display.chat_input_height, () => {
+  manualTextareaResize.value = false
   applyConfiguredTextareaHeight()
 })
 
@@ -1014,6 +1024,7 @@ function isImage(type: string): boolean {
     <div
       class="input-wrapper"
       :class="{ 'drag-over': isDragging }"
+      :style="inputWrapperStyle"
       @dragover="handleDragOver"
       @dragenter="handleDragEnter"
       @dragleave="handleDragLeave"

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -81,8 +81,18 @@ watch(configuredTextareaHeight, () => {
     applyConfiguredTextareaHeight()
 })
 
+watch(() => settingsStore.display.chat_input_height, () => {
+    manualTextareaResize.value = false
+    applyConfiguredTextareaHeight()
+})
+
 // 自定义高度拖拽
 const textareaHeight = ref<number | null>(null)
+const inputWrapperStyle = computed(() => {
+    const height = textareaHeight.value ?? configuredTextareaHeight.value
+    if (height === null) return {}
+    return { minHeight: `${height + 63}px` }
+})
 
 function syncViewport() {
   if (typeof window === 'undefined') return
@@ -460,6 +470,7 @@ function isImage(type: string): boolean {
         <div
             class="input-wrapper"
             :class="{ 'drag-over': isDragging }"
+            :style="inputWrapperStyle"
             @dragover="handleDragOver"
             @dragenter="handleDragEnter"
             @dragleave="handleDragLeave"

--- a/tests/client/chat-input-draft.test.ts
+++ b/tests/client/chat-input-draft.test.ts
@@ -125,6 +125,24 @@ describe('ChatInput draft persistence', () => {
     await nextTick()
 
     expect((wrapper.get('textarea').element as HTMLTextAreaElement).style.height).toBe('180px')
+    expect((wrapper.get('.input-wrapper').element as HTMLElement).style.minHeight).toBe('251px')
+  })
+
+  it('applies display setting changes after a manual resize', async () => {
+    const wrapper = mountForSession('session-a')
+    const settingsStore = useSettingsStore()
+    const resizeHandle = wrapper.get('.resize-handle')
+
+    await resizeHandle.trigger('mousedown', { clientY: 100 })
+    document.dispatchEvent(new MouseEvent('mousemove', { clientY: 50 }))
+    document.dispatchEvent(new MouseEvent('mouseup'))
+    await nextTick()
+
+    settingsStore.display.chat_input_height = 220
+    await nextTick()
+
+    expect((wrapper.get('textarea').element as HTMLTextAreaElement).style.height).toBe('220px')
+    expect((wrapper.get('.input-wrapper').element as HTMLElement).style.minHeight).toBe('291px')
   })
 
   it('keeps mobile chat input behavior even when a desktop height is configured', async () => {

--- a/tests/client/group-chat-input-mentions.test.ts
+++ b/tests/client/group-chat-input-mentions.test.ts
@@ -66,6 +66,29 @@ describe('GroupChatInput mentions', () => {
     await nextTick()
 
     expect((wrapper.get('textarea').element as HTMLTextAreaElement).style.height).toBe('168px')
+    expect((wrapper.get('.input-wrapper').element as HTMLElement).style.minHeight).toBe('231px')
+  })
+
+  it('applies display setting changes after a manual resize', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    const settingsStore = useSettingsStore()
+    settingsStore.display = {}
+
+    const wrapper = mount(GroupChatInput, {
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+    const resizeHandle = wrapper.get('.resize-handle')
+
+    await resizeHandle.trigger('mousedown', { clientY: 100 })
+    document.dispatchEvent(new MouseEvent('mousemove', { clientY: 50 }))
+    document.dispatchEvent(new MouseEvent('mouseup'))
+    await nextTick()
+
+    settingsStore.display.chat_input_height = 216
+    await nextTick()
+
+    expect((wrapper.get('textarea').element as HTMLTextAreaElement).style.height).toBe('216px')
+    expect((wrapper.get('.input-wrapper').element as HTMLElement).style.minHeight).toBe('279px')
   })
 
   it('preserves mobile auto height when a desktop preference is configured', async () => {


### PR DESCRIPTION
## Summary
- Make the chat and group chat input frame height follow the configured textarea height.
- Clear the local manual resize override when the display setting changes so settings updates apply immediately.
- Add client coverage for textarea and frame height changes after configured and manual resize states.

## Root Cause
- The display setting updated the textarea inline height, but the surrounding `.input-wrapper` kept its fixed CSS `min-height`, so the visible border could stay unchanged.

## Impact
- The display setting now updates the visible chat input frame on desktop.
- Mobile auto-height behavior remains unchanged.

## Validation
- `npm run test -- tests/client/chat-input-draft.test.ts`
- `npm run test -- tests/client/group-chat-input-mentions.test.ts`
- `npm run test -- tests/client/display-settings.test.ts`
- `npm run harness:check`