### PR TITLE
[codex] fix Claude Code model API mode prompt

### DIFF
--- a/docs/chat-chain-changes/2026-07-06-claude-code-model-api-mode.md
+++ b/docs/chat-chain-changes/2026-07-06-claude-code-model-api-mode.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-06
+commit: pending
+feature: Claude Code session model switching
+impact: Claude Code scoped sessions now use codingAgentId when deciding whether a model switch needs the API mode chooser. This changes only the client-side configuration prompt and does not alter run transport, message persistence, queueing, or resume semantics.
+---
+
+Scoped Claude Code sessions store `agent` as `claude` and `codingAgentId` as `claude-code`. The session model switch flow now normalizes those fields before deciding whether to show the API mode modal.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -947,9 +947,19 @@ const isSessionModelScopedCodingAgent = computed(() =>
   sessionModelSession.value?.source === "coding_agent" &&
   sessionModelSession.value?.codingAgentMode !== "global",
 );
+const sessionModelCodingAgentId = computed<ChatCodingAgentId | undefined>(() =>
+  sessionModelSession.value?.codingAgentId ||
+  (sessionModelSession.value?.agent === "claude"
+    ? "claude-code"
+    : sessionModelSession.value?.agent === "codex"
+      ? "codex"
+      : sessionModelSession.value?.agent === "ekko-agent"
+        ? "ekko-agent"
+        : undefined),
+);
 const isSessionModelExternalCodingAgent = computed(() =>
   isSessionModelScopedCodingAgent.value &&
-  (sessionModelSession.value?.agent === "claude-code" || sessionModelSession.value?.agent === "codex"),
+  (sessionModelCodingAgentId.value === "claude-code" || sessionModelCodingAgentId.value === "codex"),
 );
 
 const sessionModelBaseGroups = computed(() =>

--- a/tests/client/chat-panel-session-click.test.ts
+++ b/tests/client/chat-panel-session-click.test.ts
@@ -22,6 +22,16 @@ describe('ChatPanel session clicks', () => {
     expect(source).not.toContain('if (isActiveSessionCodingAgent.value) return')
   })
 
+  it('uses codingAgentId when deciding whether session model switches need an API mode', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+
+    expect(source).toContain('const sessionModelCodingAgentId = computed<ChatCodingAgentId | undefined>')
+    expect(source).toContain('sessionModelSession.value?.codingAgentId ||')
+    expect(source).toContain('sessionModelSession.value?.agent === "claude"')
+    expect(source).toContain('sessionModelCodingAgentId.value === "claude-code"')
+    expect(source).not.toContain('sessionModelSession.value?.agent === "claude-code"')
+  })
+
   it('uses the active sidebar model as the new chat default for the active profile', () => {
     const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
 


### PR DESCRIPTION
## Summary
- Normalize the session coding-agent identity before deciding whether model switches need an API mode chooser.
- Make scoped Claude Code sessions use `codingAgentId=claude-code` instead of checking the stored `agent` value directly.
- Add coverage to prevent regressing back to `agent === claude-code`.

## Root Cause
Claude Code sessions store `agent` as `claude`, while `codingAgentId` carries `claude-code`. The session model switch flow checked `agent === claude-code`, so Claude Code scoped sessions skipped the API mode modal.

## Impact
Claude Code scoped sessions now show the API mode chooser when switching models, matching Codex behavior. Run transport, persistence, queueing, and resume behavior are unchanged.

## Validation
- `npm run test -- tests/client/chat-panel-session-click.test.ts tests/client/coding-agent-api-modes.test.ts tests/client/chat-store-reasoning-tool-boundary.test.ts`
- `npm run harness:check`