### PR TITLE
fix(bridge): race condition in worker _wait_ready causes false 'exited before ready' timeout

### DIFF
--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -414,12 +414,22 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
 
   serverProc.stdout?.on('data', (chunk: Buffer) => {
     bridgeStartup.observe(chunk)
-    process.stdout.write(`[webui] ${chunk}`)
+    try {
+      process.stdout.write(`[webui] ${chunk}`)
+    } catch {
+      /* EPIPE: parent stdout closed, ignore */
+    }
   })
+  serverProc.stdout?.on('error', () => { /* EPIPE: ignore */ })
   serverProc.stderr?.on('data', (chunk: Buffer) => {
     bridgeStartup.observe(chunk)
-    process.stderr.write(`[webui] ${chunk}`)
+    try {
+      process.stderr.write(`[webui] ${chunk}`)
+    } catch {
+      /* EPIPE: parent stderr closed, ignore */
+    }
   })
+  serverProc.stderr?.on('error', () => { /* EPIPE: ignore */ })
   serverProc.on('exit', (code, signal) => {
     console.error(`[webui] server exited code=${code} signal=${signal}`)
     serverProc = null

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
@@ -117,14 +117,16 @@ class WorkerProcess:
         threading.Thread(target=read_stdout, daemon=True, name=f"hermes-bridge-worker-stdout-{self.key}").start()
         deadline = time.time() + self.STARTUP_TIMEOUT_SECONDS
         while time.time() < deadline:
-            if proc.poll() is not None:
-                raise RuntimeError(f"profile worker {self.key} exited before ready")
             try:
                 line = lines.get(timeout=0.1)
             except queue.Empty:
+                if proc.poll() is not None:
+                    raise RuntimeError(f"profile worker {self.key} exited before ready")
                 continue
             if line is None:
                 time.sleep(0.05)
+                if proc.poll() is not None:
+                    raise RuntimeError(f"profile worker {self.key} exited before ready")
                 continue
             text = line.strip()
             if text:


### PR DESCRIPTION
## Summary

Fixes a race condition in `WorkerProcess._wait_ready()` that causes the bridge broker to incorrectly raise "profile worker exited before ready" even when the worker successfully printed the ready event and initialized correctly.

## Root Cause

In `bridge_transport.py:_wait_ready()`, the loop checks `proc.poll()` **before** reading from the stdout line queue. If the worker process finishes its initialization and prints `{"event": "ready"}` to stdout, then exits immediately (e.g., watchdog triggers because the broker is busy), the sequence is:

1. Worker prints `{"event": "ready"}` → stdout
2. Worker process exits → `proc.poll()` returns non-None
3. **Broker sees exit first** → raises "exited before ready"  
4. Broker never reads the "ready" line from the queue

This means every new worker is immediately rejected as "exited before ready" even though it initialized correctly, causing all bridge operations to fail with a 120s timeout.

## Fix

Move the `proc.poll()` check **after** reading from the queue. Only raise "exited before ready" if the queue is empty (no more stdout lines to process AND the process has exited). This ensures the "ready" event is always processed before the exit check.

## Changes

`packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py`:
- Swap queue read before process exit check in the readiness wait loop
- Process exit is now only checked when the queue is empty (after all stdout lines have been consumed)

## Related

Fixes #1965
Building on the desktop EPIPE fix (#1949) — this addresses another source of 120s timeout errors in the Hermes Studio agent bridge.