### PR TITLE
fix cli npm command execution on Windows

### DIFF
--- a/bin/hermes-web-ui.mjs
+++ b/bin/hermes-web-ui.mjs
@@ -101,7 +101,7 @@ function getCurrentNodeEnv() {
 }
 
 function getGlobalPrefix() {
-  return execFileSync(getNpmBin(), ['prefix', '-g'], {
+  return execCliSync(getNpmBin(), ['prefix', '-g'], {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
     env: getCurrentNodeEnv(),
@@ -133,6 +133,15 @@ function quoteForWindowsCommand(value) {
   return `"${value.replace(/"/g, '""')}"`
 }
 
+function buildWindowsCommandLine(command, args) {
+  const commandArg = quoteForWindowsCommand(command)
+  const argsString = args.map(arg => (/\s/.test(String(arg)) ? quoteForWindowsCommand(String(arg)) : String(arg))).join(' ')
+  // cmd.exe's /C parsing strips one leading/trailing quote pair before running the
+  // command; without this extra wrap it mis-splits quoted paths that contain spaces
+  // (e.g. "C:\Program Files\nodejs\npm.cmd") at the first space.
+  return `"${commandArg} ${argsString}"`
+}
+
 function spawnCli(command, args, options) {
   if (process.platform === 'win32') {
     const lowerCommand = String(command).toLowerCase()
@@ -140,11 +149,27 @@ function spawnCli(command, args, options) {
       return spawn(command, args, options)
     }
 
-    const commandLine = `${quoteForWindowsCommand(command)} ${args.map(arg => String(arg)).join(' ')}`
-    return spawn(getWindowsShell(), ['/d', '/s', '/c', commandLine], options)
+    const commandLine = buildWindowsCommandLine(command, args)
+    return spawn(getWindowsShell(), ['/d', '/s', '/c', commandLine], { ...options, windowsVerbatimArguments: true })
   }
 
   return spawn(command, args, options)
+}
+
+// .cmd/.bat files cannot be spawned directly on Windows without a shell —
+// execFileSync throws EINVAL. Route through cmd.exe like spawnCli does.
+function execCliSync(command, args, options) {
+  if (process.platform === 'win32') {
+    const lowerCommand = String(command).toLowerCase()
+    if (!lowerCommand.endsWith('.cmd') && !lowerCommand.endsWith('.bat')) {
+      return execFileSync(command, args, options)
+    }
+
+    const commandLine = buildWindowsCommandLine(command, args)
+    return execFileSync(getWindowsShell(), ['/d', '/s', '/c', commandLine], { ...options, windowsVerbatimArguments: true })
+  }
+
+  return execFileSync(command, args, options)
 }
 
 function getPortFromArgs() {
@@ -752,7 +777,7 @@ function doUpdate() {
   const npm = getNpmBin()
   try {
     console.log('  🧹 Cleaning npm cache...')
-    execFileSync(npm, ['cache', 'clean', '--force'], {
+    execCliSync(npm, ['cache', 'clean', '--force'], {
       stdio: 'inherit',
       env: getCurrentNodeEnv(),
     })
@@ -811,7 +836,9 @@ if (process.argv[1] && realpathSync(resolve(process.argv[1])) === __filename) {
 export {
   clearLoginLocks,
   commandExists,
+  execCliSync,
   getDaemonStopGraceMs,
+  getGlobalPrefix,
   getListeningPids,
   getRestartArgs,
   parseUnixNetstatListeningPids,

--- a/tests/server/cli-port-detection.test.ts
+++ b/tests/server/cli-port-detection.test.ts
@@ -223,4 +223,31 @@ describe('CLI port detection', () => {
       rmSync(home, { recursive: true, force: true })
     }
   })
+
+  it('routes .cmd binaries through cmd.exe instead of spawning them directly (Windows EINVAL)', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    const execFileSync = vi.fn(() => '11.13.0')
+    const { execCliSync, mocks } = await loadCli({ execFileSync })
+
+    execCliSync('C:\\Program Files\\nodejs\\npm.cmd', ['prefix', '-g'], { encoding: 'utf-8' })
+
+    expect(mocks.execFileSync).toHaveBeenCalledTimes(1)
+    const [command, args, options] = mocks.execFileSync.mock.calls[0]
+    expect(command).not.toBe('C:\\Program Files\\nodejs\\npm.cmd')
+    expect(command.toLowerCase()).toContain('cmd.exe')
+    expect(args.at(-1)).toContain('"C:\\Program Files\\nodejs\\npm.cmd" prefix -g')
+    expect(options).toMatchObject({ windowsVerbatimArguments: true })
+  })
+
+  it('spawns non-.cmd binaries directly on Windows without a shell wrapper', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    const execFileSync = vi.fn(() => 'ok')
+    const { execCliSync, mocks } = await loadCli({ execFileSync })
+
+    execCliSync('node.exe', ['--version'], { encoding: 'utf-8' })
+
+    expect(mocks.execFileSync).toHaveBeenCalledWith('node.exe', ['--version'], { encoding: 'utf-8' })
+  })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,22 @@ import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
 
+function stripCliShebangForVitest() {
+  return {
+    name: 'strip-cli-shebang-for-vitest',
+    enforce: 'pre' as const,
+    transform(code: string, id: string) {
+      const normalizedId = id.split('?')[0].replace(/\\/g, '/')
+      if (!normalizedId.endsWith('/bin/hermes-web-ui.mjs')) return null
+
+      // Vite SSR may skip transforming .mjs files; AsyncFunction cannot evaluate a shebang.
+      return { code: code.replace(/^#!.*(?:\r?\n|$)/, ''), map: null }
+    },
+  }
+}
+
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [stripCliShebangForVitest(), vue()],
   resolve: {
     alias: {
       '@': resolve(__dirname, 'packages/client/src'),


### PR DESCRIPTION
## Validation
- `npm run test -- tests/server/cli-port-detection.test.ts`
- `npm run harness:check`
- `git diff --check`
- `node --check bin/hermes-web-ui.mjs`
- `npm run build`