### PR TITLE
[codex] Add bundled Web UI startup fallback

### DIFF
--- a/packages/desktop/src/main/paths.ts
+++ b/packages/desktop/src/main/paths.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron'
-import { existsSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { homedir, platform } from 'node:os'
 import {
@@ -15,12 +15,13 @@ const MIN_COMPATIBLE_WEB_UI_VERSION = '0.6.23'
 const PACKAGED_RUNTIME_RELEASE_NAME = 'runtime-release.json'
 const ACTIVE_RUNTIME_VERSION_NAME = 'active-version.json'
 let legacyWebUiVersionsCleaned = false
+let incompleteActiveWebUiWarningPath = ''
 
 export function isPackaged() {
   return !!app?.isPackaged
 }
 
-function defaultWebuiDir(): string {
+export function defaultWebuiDir(): string {
   if (isPackaged()) return resolve(process.resourcesPath, 'webui')
   return process.env.HERMES_WEB_UI_DIR?.trim() || resolve(app?.getAppPath?.() || resolve(process.cwd(), 'packages', 'desktop'), '..', '..')
 }
@@ -105,6 +106,24 @@ function readActiveRuntimeVersion(): ActiveRuntimeVersion | null {
   }
 }
 
+export function clearActiveWebUiDirectory(expectedDirectory?: string): void {
+  const file = activeRuntimeVersionFile()
+  const active = readActiveRuntimeVersion()
+  if (!active || typeof active !== 'object') return
+  const currentDirectory = typeof active.webUiDirectory === 'string' ? active.webUiDirectory.trim() : ''
+  if (!currentDirectory) return
+  if (expectedDirectory && resolve(currentDirectory) !== resolve(expectedDirectory)) return
+
+  const next = { ...(active as Record<string, unknown>) }
+  delete next.webUiDirectory
+  delete next.webUiVersion
+  try {
+    writeFileSync(file, JSON.stringify(next, null, 2) + '\n')
+  } catch (err) {
+    console.warn('[desktop] failed to clear active Web UI directory:', err instanceof Error ? err.message : String(err))
+  }
+}
+
 function cleanupLegacyWebUiVersions(): void {
   if (legacyWebUiVersionsCleaned) return
   legacyWebUiVersionsCleaned = true
@@ -130,6 +149,14 @@ function cleanupLegacyWebUiVersions(): void {
 // Bundled web-ui directory.
 // dev:  <repo root> (or HERMES_WEB_UI_DIR)
 // prod: <resources>/webui
+export function webuiServerEntryFor(root: string): string {
+  return join(root, 'dist', 'server', 'index.js')
+}
+
+function webuiDirectoryReady(root: string): boolean {
+  return existsSync(webuiServerEntryFor(root))
+}
+
 // active-version.json can pin the Web UI path used to start the local server.
 export function webuiDir(): string {
   const override = process.env.HERMES_WEB_UI_DIR?.trim()
@@ -138,18 +165,27 @@ export function webuiDir(): string {
   cleanupLegacyWebUiVersions()
 
   const active = readActiveRuntimeVersion()
+  const activeWebUiDirectory = typeof active?.webUiDirectory === 'string' ? active.webUiDirectory.trim() : ''
   if (active?.platform === runtimePlatformKey()
-    && typeof active.webUiDirectory === 'string'
-    && active.webUiDirectory.trim()
-    && existsSync(active.webUiDirectory)) {
-    return resolve(active.webUiDirectory)
+    && activeWebUiDirectory
+    && webuiDirectoryReady(activeWebUiDirectory)) {
+    return resolve(activeWebUiDirectory)
+  }
+
+  if (active?.platform === runtimePlatformKey()
+    && activeWebUiDirectory
+    && existsSync(activeWebUiDirectory)
+    && incompleteActiveWebUiWarningPath !== activeWebUiDirectory) {
+    incompleteActiveWebUiWarningPath = activeWebUiDirectory
+    console.warn(`[desktop] ignored incomplete active Web UI directory ${activeWebUiDirectory}; missing ${webuiServerEntryFor(activeWebUiDirectory)}`)
+    clearActiveWebUiDirectory(activeWebUiDirectory)
   }
 
   return defaultWebuiDir()
 }
 
 export function webuiServerEntry(): string {
-  return join(webuiDir(), 'dist', 'server', 'index.js')
+  return webuiServerEntryFor(webuiDir())
 }
 
 function runtimeReleaseMetadata(): RuntimeReleaseMetadata | null {

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -2,7 +2,7 @@ import { ChildProcess, execFile, spawn } from 'node:child_process'
 import { mkdirSync, readFileSync, writeFileSync, chmodSync, existsSync, readdirSync } from 'node:fs'
 import { createServer } from 'node:net'
 import { homedir } from 'node:os'
-import { dirname, delimiter, join } from 'node:path'
+import { dirname, delimiter, join, resolve } from 'node:path'
 import { randomBytes } from 'node:crypto'
 import { promisify } from 'node:util'
 import { app } from 'electron'
@@ -11,7 +11,9 @@ import {
   bundledGit,
   bundledNode,
   gitPathDirs,
-  webuiServerEntry,
+  clearActiveWebUiDirectory,
+  defaultWebuiDir,
+  webuiServerEntryFor,
   webuiDir,
   hermesBin,
   webUiHome,
@@ -305,9 +307,10 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
   ensureNativeModules()
   const token = ensureToken()
   currentServerPort = port
-  const entry = webuiServerEntry()
-  if (!existsSync(entry)) {
-    throw new Error(`Web UI server entry not found at ${entry}. Run: npm run build:webui`)
+  const primaryWebUiDir = webuiDir()
+  const primaryEntry = webuiServerEntryFor(primaryWebUiDir)
+  if (!existsSync(primaryEntry)) {
+    throw new Error(`Web UI server entry not found at ${primaryEntry}. Run: npm run build:webui`)
   }
 
   const home = webUiHome()
@@ -403,16 +406,33 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     PATH: runtimePath,
   }
 
+  const fallbackWebUiDir = defaultWebuiDir()
+  try {
+    return await launchWebUiServer(primaryWebUiDir, primaryEntry, env, port)
+  } catch (err) {
+    if (resolve(primaryWebUiDir) === resolve(fallbackWebUiDir)) throw err
+
+    const fallbackEntry = webuiServerEntryFor(fallbackWebUiDir)
+    if (!existsSync(fallbackEntry)) throw err
+
+    console.warn(`[webui] startup failed for active Web UI at ${primaryWebUiDir}; retrying bundled Web UI at ${fallbackWebUiDir}: ${err instanceof Error ? err.message : String(err)}`)
+    clearActiveWebUiDirectory(primaryWebUiDir)
+    return await launchWebUiServer(fallbackWebUiDir, fallbackEntry, env, port)
+  }
+}
+
+async function launchWebUiServer(webUiDirectory: string, entry: string, env: NodeJS.ProcessEnv, port: number): Promise<string> {
   serverProc = spawn(process.execPath, [entry], {
-    cwd: webuiDir(),
+    cwd: webUiDirectory,
     env,
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsHide: true,
   })
 
+  const launchedProc = serverProc
   const bridgeStartup = createAgentBridgeStartupTracker()
 
-  serverProc.stdout?.on('data', (chunk: Buffer) => {
+  launchedProc.stdout?.on('data', (chunk: Buffer) => {
     bridgeStartup.observe(chunk)
     try {
       process.stdout.write(`[webui] ${chunk}`)
@@ -420,8 +440,8 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
       /* EPIPE: parent stdout closed, ignore */
     }
   })
-  serverProc.stdout?.on('error', () => { /* EPIPE: ignore */ })
-  serverProc.stderr?.on('data', (chunk: Buffer) => {
+  launchedProc.stdout?.on('error', () => { /* EPIPE: ignore */ })
+  launchedProc.stderr?.on('data', (chunk: Buffer) => {
     bridgeStartup.observe(chunk)
     try {
       process.stderr.write(`[webui] ${chunk}`)
@@ -429,10 +449,10 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
       /* EPIPE: parent stderr closed, ignore */
     }
   })
-  serverProc.stderr?.on('error', () => { /* EPIPE: ignore */ })
-  serverProc.on('exit', (code, signal) => {
+  launchedProc.stderr?.on('error', () => { /* EPIPE: ignore */ })
+  launchedProc.on('exit', (code, signal) => {
     console.error(`[webui] server exited code=${code} signal=${signal}`)
-    serverProc = null
+    if (serverProc === launchedProc) serverProc = null
     if (!app.isReady() || code !== 0) {
       // Best-effort: if server dies abnormally during startup, surface to user
     }
@@ -440,7 +460,18 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
 
   const timeoutMs = readyTimeoutMs()
   const bridgeReady = bridgeStartup.wait(timeoutMs)
-  await waitForReady(port, timeoutMs)
+  const exitBeforeReady = new Promise<never>((_, reject) => {
+    launchedProc.once('exit', (code, signal) => {
+      reject(new Error(`Web UI server exited before becoming ready code=${code} signal=${signal}`))
+    })
+  })
+  try {
+    await Promise.race([waitForReady(port, timeoutMs), exitBeforeReady])
+  } catch (err) {
+    await terminateLaunchedProcess(launchedProc)
+    if (serverProc === launchedProc) serverProc = null
+    throw err
+  }
   const fullStartupTimeoutMs = fullStartupWaitMs()
   if (fullStartupTimeoutMs > 0) {
     await Promise.race([
@@ -456,6 +487,18 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     })
   }
   return getServerUrl(port)
+}
+
+async function terminateLaunchedProcess(proc: ChildProcess): Promise<void> {
+  if (proc.killed || proc.exitCode !== null || proc.signalCode !== null) return
+  await new Promise<void>(resolveDone => {
+    const timer = setTimeout(() => resolveDone(), 3000)
+    proc.once('exit', () => {
+      clearTimeout(timer)
+      resolveDone()
+    })
+    killProcessTree(proc)
+  })
 }
 
 async function waitForReady(port: number, timeoutMs: number): Promise<void> {

--- a/tests/desktop/runtime-paths.test.ts
+++ b/tests/desktop/runtime-paths.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -116,6 +116,8 @@ describe('desktop runtime paths', () => {
 
     const { runtimePlatformKey } = await import('../../packages/desktop/src/main/runtime-paths')
     createRuntime(runtimeDir, '0.15.1')
+    mkdirSync(join(webUiDir, 'dist', 'server'), { recursive: true })
+    writeFileSync(join(webUiDir, 'dist', 'server', 'index.js'), '')
     mkdirSync(join(homeDir, 'desktop-runtime'), { recursive: true })
     writeFileSync(join(homeDir, 'desktop-runtime', 'active-version.json'), JSON.stringify({
       schema: 1,
@@ -131,6 +133,34 @@ describe('desktop runtime paths', () => {
     expect(desktopRuntimeDir()).toBe(runtimeDir)
     expect(webuiDir()).toBe(webUiDir)
     expect(targetDesktopRuntimeDir()).toBe(join(homeDir, 'desktop-runtime', 'hermes', '0.18.0', runtimePlatformKey()))
+  })
+
+  it('falls back to the bundled Web UI when the active Web UI directory is incomplete', async () => {
+    const homeDir = tempDir()
+    const activeWebUiDir = join(homeDir, 'webui', '0.6.26')
+    const bundledWebUiDir = join(process.resourcesPath, 'webui')
+    process.env.HERMES_WEB_UI_HOME = homeDir
+    mockElectronApp.isPackaged = true
+
+    const { runtimePlatformKey } = await import('../../packages/desktop/src/main/runtime-paths')
+    mkdirSync(activeWebUiDir, { recursive: true })
+    mkdirSync(join(bundledWebUiDir, 'dist', 'server'), { recursive: true })
+    writeFileSync(join(bundledWebUiDir, 'dist', 'server', 'index.js'), '')
+    mkdirSync(join(homeDir, 'desktop-runtime'), { recursive: true })
+    writeFileSync(join(homeDir, 'desktop-runtime', 'active-version.json'), JSON.stringify({
+      schema: 1,
+      webUiVersion: '0.6.26',
+      webUiDirectory: activeWebUiDir,
+      platform: runtimePlatformKey(),
+    }))
+
+    const { webuiDir, webuiServerEntry } = await import('../../packages/desktop/src/main/paths')
+
+    expect(webuiDir()).toBe(bundledWebUiDir)
+    expect(webuiServerEntry()).toBe(join(bundledWebUiDir, 'dist', 'server', 'index.js'))
+    const active = JSON.parse(readFileSync(join(homeDir, 'desktop-runtime', 'active-version.json'), 'utf-8'))
+    expect(active.webUiDirectory).toBeUndefined()
+    expect(active.webUiVersion).toBeUndefined()
   })
 
   it('removes downloaded Web UI caches below 0.6.23 so startup falls back to the bundled Web UI', async () => {


### PR DESCRIPTION
## Summary

Fixes #1967 by making desktop startup resilient when `active-version.json` points at a missing or broken downloaded Web UI directory.

## Changes

- Treat an active Web UI directory as valid only when `dist/server/index.js` exists.
- Clear only the stale `webUiDirectory`/`webUiVersion` fields from `active-version.json` when the active Web UI is incomplete or fails startup, preserving the runtime pin.
- Retry startup once with the bundled `resources/webui` when the active Web UI process exits before ready or times out.
- Add a desktop path test covering incomplete active Web UI fallback and active manifest cleanup.

## Root Cause

Desktop startup previously accepted any existing `active-version.json.webUiDirectory` directory. A partially extracted or stale directory such as `~/.hermes-web-ui/webui/0.6.20` could exist without `dist/server/index.js`, preventing fallback to the bundled Web UI and surfacing `Web UI server entry not found`.

## Validation

- `npm exec vitest -- tests/desktop/runtime-paths.test.ts --run`
- `npm exec tsc -- --noEmit -p packages/desktop/tsconfig.json --ignoreDeprecations 6.0`
