### PR TITLE
[codex] Add remote MCU relay over Socket.IO

### DIFF
--- a/packages/esp32-c3/v1/src/main.cpp
+++ b/packages/esp32-c3/v1/src/main.cpp
@@ -139,7 +139,10 @@ String pendingProfileDeviceKey;
 String activeDeviceKey;
 String activeDeviceUrl;
 String mcuAuthToken;
+String mcuSocketRelayUrl;
 String mcuSocketTargetKey;
+String mcuRemoteDiscoveryToken;
+bool mcuSocketReconnectBlocked = false;
 String mcuInteractionId;
 String mcuInteractionStatus = "idle";
 String mcuInteractionText;
@@ -221,10 +224,13 @@ struct LanDevice {
   String webVersion;
   String agentVersion;
   String profile;
+  String relayUrl;
   uint16_t httpPort = 0;
   uint32_t responseMs = 0;
   uint32_t lastSeenMs = 0;
   bool loggedIn = false;
+  bool manualSource = false;
+  bool remoteLogin = false;
 };
 
 LanDevice lanDevices[kMaxLanDevices];
@@ -739,6 +745,7 @@ String mcuDeviceCode() {
 }
 
 String mcuSocketStateLabel() {
+  if (mcuSocketReconnectBlocked) return F("已被其他设备接管");
   if (mcuSocketNamespaceReady) return F("已连接");
   if (mcuSocketConnected) return F("握手中");
   if (wsReady) return F("重连中");
@@ -915,6 +922,42 @@ String jsonObjectValue(const String &json, const __FlashStringHelper *key) {
     if (inString) continue;
     if (c == '{') ++depth;
     if (c == '}') {
+      --depth;
+      if (depth == 0) return json.substring(openAt, i + 1);
+    }
+  }
+  return "";
+}
+
+String jsonArrayValue(const String &json, const __FlashStringHelper *key) {
+  String pattern = String(F("\"")) + key + F("\"");
+  int keyAt = json.indexOf(pattern);
+  if (keyAt < 0) return "";
+  int colonAt = json.indexOf(':', keyAt + pattern.length());
+  if (colonAt < 0) return "";
+  int openAt = json.indexOf('[', colonAt + 1);
+  if (openAt < 0) return "";
+
+  bool inString = false;
+  bool escaped = false;
+  int depth = 0;
+  for (int i = openAt; i < static_cast<int>(json.length()); ++i) {
+    char c = json[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (c == '\\') {
+      escaped = inString;
+      continue;
+    }
+    if (c == '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (c == '[') ++depth;
+    if (c == ']') {
       --depth;
       if (depth == 0) return json.substring(openAt, i + 1);
     }
@@ -1463,6 +1506,10 @@ String endpointLabel(const String &endpointKind, uint16_t httpPort) {
   return String(F("自定义端口 ")) + httpPort;
 }
 
+String lanDeviceSourceLabel(const LanDevice &device) {
+  return (device.manualSource || device.remoteLogin) ? String(F("远程获取局域网")) : String(F("局域网"));
+}
+
 String lanDeviceKey(const String &id, const String &endpointKind, uint16_t httpPort) {
   return id + F("|") + endpointKind + F("|") + String(httpPort);
 }
@@ -1564,12 +1611,14 @@ void clearProfileForDevice(const String &deviceKey, const String &addressKey) {
     prefs.remove("active_key");
     prefs.remove("active_addr");
     prefs.remove("active_url");
+    prefs.remove("relay_url");
     prefs.remove("auth_token");
   }
   prefs.end();
   if (activeDeviceKey == deviceKey) {
     activeDeviceKey = "";
     activeDeviceUrl = "";
+    mcuSocketRelayUrl = "";
     mcuAuthToken = "";
     disconnectMcuSocketClient();
   }
@@ -1581,10 +1630,13 @@ void applySavedProfile(LanDevice &device) {
   profile.trim();
   device.profile = profile;
   device.loggedIn = profile.length() > 0;
+  prefs.begin("mcu", true);
+  String activeKey = prefs.getString("active_key", "");
+  String activeAddr = prefs.getString("active_addr", "");
+  String relayUrl = prefs.getString("relay_url", "");
+  prefs.end();
+  device.remoteLogin = relayUrl.length() > 0 && (activeKey == lanDeviceKey(device) || activeAddr == lanAddressKey(device));
   if (activeDeviceKey.length() == 0) {
-    prefs.begin("mcu", true);
-    String activeAddr = prefs.getString("active_addr", "");
-    prefs.end();
     if (activeAddr.length() > 0 && activeAddr == lanAddressKey(device)) {
       activeDeviceKey = lanDeviceKey(device);
     }
@@ -1596,7 +1648,8 @@ String activeDeviceLabel() {
   for (int i = 0; i < lanDeviceCount; ++i) {
     if (lanDeviceKey(lanDevices[i]) == activeDeviceKey) {
       return endpointLabel(lanDevices[i].endpointKind, lanDevices[i].httpPort) + F(" · ") +
-             lanDevices[i].name + F(" · ") + lanDevices[i].profile;
+             lanDeviceSourceLabel(lanDevices[i]) + F(" · ") + lanDevices[i].name + F(" · ") +
+             lanDevices[i].profile;
     }
   }
   return activeDeviceKey;
@@ -1631,7 +1684,7 @@ int oldestLanDeviceSlot() {
 }
 
 void rememberLanDeviceInfo(const String &json, const String &host, const String &baseUrl, uint32_t responseMs,
-                           bool requireAnnouncement) {
+                           bool requireAnnouncement, bool manualSource = false) {
   if (requireAnnouncement) {
     if (jsonStringValue(json, F("type")) != F("hermes.announce")) return;
     if (jsonIntValue(json, F("version")) != 1) return;
@@ -1662,13 +1715,16 @@ void rememberLanDeviceInfo(const String &json, const String &host, const String 
   device.url = baseUrl.length() > 0 ? baseUrl : String(F("http://")) + device.ip + F(":") + httpPort;
   device.webVersion = jsonStringValue(json, F("hermes_web_ui_version"));
   device.agentVersion = jsonStringValue(json, F("hermes_agent_version"));
+  device.relayUrl = jsonStringValue(json, F("relay_url"));
+  device.relayUrl.trim();
   device.responseMs = responseMs;
   device.lastSeenMs = millis();
+  device.manualSource = manualSource;
   applySavedProfile(device);
 }
 
 void rememberLanDevice(const String &json, const IPAddress &remoteIp, uint32_t responseMs) {
-  rememberLanDeviceInfo(json, remoteIp.toString(), "", responseMs, true);
+  rememberLanDeviceInfo(json, remoteIp.toString(), "", responseMs, true, false);
 }
 
 String manualDevicePrefKey(int index) {
@@ -1742,7 +1798,7 @@ bool fetchManualDeviceInfo(const String &input, String *error) {
     if (error) *error = F("机器信息缺少设备身份");
     return false;
   }
-  rememberLanDeviceInfo(body, host, baseUrl, millis() - started, false);
+  rememberLanDeviceInfo(body, host, baseUrl, millis() - started, false, true);
   persistManualDeviceUrl(baseUrl);
   return true;
 }
@@ -1760,6 +1816,116 @@ void refreshManualDevices() {
     if (urls[i].length() == 0) continue;
     String ignored;
     fetchManualDeviceInfo(urls[i], &ignored);
+  }
+}
+
+void rememberRemoteMachineInfo(const String &json) {
+  if (!jsonBoolValue(json, F("connected"))) return;
+  String url = jsonStringValue(json, F("url"));
+  String host;
+  String baseUrl = normalizedManualDeviceUrl(url, &host);
+  if (baseUrl.length() == 0) return;
+  if (jsonStringValue(json, F("device_id")).length() == 0 ||
+      jsonStringValue(json, F("device_public_key")).length() == 0) {
+    return;
+  }
+  rememberLanDeviceInfo(json, host, baseUrl, 0, false, true);
+}
+
+void rememberRemoteMachineList(const String &json) {
+  String machines = jsonArrayValue(json, F("machines"));
+  if (machines.length() == 0) return;
+  bool inString = false;
+  bool escaped = false;
+  int depth = 0;
+  int objectStart = -1;
+  for (int i = 0; i < static_cast<int>(machines.length()); ++i) {
+    char c = machines[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (c == '\\') {
+      escaped = inString;
+      continue;
+    }
+    if (c == '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (c == '{') {
+      if (depth == 0) objectStart = i;
+      ++depth;
+    } else if (c == '}') {
+      --depth;
+      if (depth == 0 && objectStart >= 0) {
+        rememberRemoteMachineInfo(machines.substring(objectStart, i + 1));
+        objectStart = -1;
+      }
+    }
+  }
+}
+
+String normalizedRelayBaseUrl(const String &input) {
+  String raw = input;
+  raw.trim();
+  while (raw.endsWith("/")) raw.remove(raw.length() - 1);
+  if (raw.length() == 0) return "";
+  String scheme;
+  String host;
+  uint16_t port = 0;
+  String path;
+  if (!parseAudioUrl(raw, &scheme, &host, &port, &path)) return "";
+  return scheme + F("://") + host + F(":") + String(port);
+}
+
+bool relayUrlAlreadyQueued(const String urls[], int count, const String &url) {
+  for (int i = 0; i < count; ++i) {
+    if (urls[i] == url) return true;
+  }
+  return false;
+}
+
+void queueRelayUrl(String urls[], int *count, const String &url) {
+  if (!count || *count >= kMaxLanDevices + 1) return;
+  String normalized = normalizedRelayBaseUrl(url);
+  if (normalized.length() == 0 || relayUrlAlreadyQueued(urls, *count, normalized)) return;
+  urls[*count] = normalized;
+  *count += 1;
+}
+
+void fetchRemoteDevicesFromRelay(const String &relayBaseUrl) {
+  if (mcuRemoteDiscoveryToken.length() == 0) return;
+  if (normalizedRelayBaseUrl(mcuSocketRelayUrl) != relayBaseUrl) {
+    Serial.printf("Remote machine discovery skipped relay=%s without token\n", relayBaseUrl.c_str());
+    return;
+  }
+  String endpoint = relayBaseUrl + F("/global-agent/devices/") + mcuDeviceCode() + F("/machines");
+  HTTPClient http;
+  http.setTimeout(kMcuLoginTimeoutMs);
+  if (!http.begin(endpoint)) return;
+  http.addHeader(F("Authorization"), String(F("Bearer ")) + mcuRemoteDiscoveryToken);
+  int code = http.GET();
+  String body = http.getString();
+  http.end();
+  if (code < 200 || code >= 300) {
+    Serial.printf("Remote machine discovery failed code=%d body=%s\n", code, body.substring(0, 160).c_str());
+    return;
+  }
+  rememberRemoteMachineList(body);
+}
+
+void refreshRemoteDevices() {
+  if (!wifiReady || WiFi.status() != WL_CONNECTED) return;
+  String relayUrls[kMaxLanDevices + 1];
+  int relayUrlCount = 0;
+  queueRelayUrl(relayUrls, &relayUrlCount, mcuSocketRelayUrl);
+  for (int i = 0; i < lanDeviceCount; ++i) {
+    queueRelayUrl(relayUrls, &relayUrlCount, lanDevices[i].relayUrl);
+  }
+  for (int i = 0; i < relayUrlCount; ++i) {
+    fetchRemoteDevicesFromRelay(relayUrls[i]);
   }
 }
 
@@ -1809,6 +1975,7 @@ void scanLanDevices() {
   }
   lastLanDiscoveryAtMs = millis();
   refreshManualDevices();
+  refreshRemoteDevices();
 }
 
 bool ssidAlreadyScanned(const String &ssid) {
@@ -1861,6 +2028,7 @@ String pageStart(const String &title) {
 	                  "main{max-width:760px;margin:auto;padding:28px 18px 40px}.panel,.card{background:var(--surface);border:1px solid var(--line);border-radius:6px}.panel{padding:22px}.card{padding:16px;margin-top:12px}"
 	                  "h1{font-size:clamp(28px,5vw,44px);line-height:1.05;margin:0 0 10px}h2{font-size:18px;margin:0 0 10px}.lead,.hint{color:var(--muted);line-height:1.6}.lead{font-size:15px;margin:0 0 18px}.hint{font-size:12px;margin:0}.meta{font:12px/1.4 ui-monospace,'SFMono-Regular',Consolas,monospace;color:var(--muted);word-break:break-all}"
 	                  "form{display:grid;gap:12px}.field{display:grid;gap:7px}.label{font-size:12px;color:var(--muted)}input,select{width:100%;min-height:42px;border:1px solid var(--line);border-radius:6px;background:#fff;padding:10px 11px;font:14px/1.2 ui-monospace,'SFMono-Regular',Consolas,monospace;color:var(--ink)}select{appearance:none;-webkit-appearance:none;background-image:linear-gradient(45deg,transparent 50%,var(--muted) 50%),linear-gradient(135deg,var(--muted) 50%,transparent 50%);background-position:calc(100% - 18px) 18px,calc(100% - 13px) 18px;background-size:5px 5px,5px 5px;background-repeat:no-repeat;padding-right:34px}input:focus,select:focus{outline:2px solid #cfcfcf;outline-offset:1px}"
+	                  ".choice-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}.choice{position:relative;display:block}.choice input{position:absolute;opacity:0;pointer-events:none}.choice-card{height:100%;min-height:96px;border:1px solid var(--line);border-radius:6px;background:#fff;padding:14px 14px 14px 42px;display:grid;align-content:start;gap:6px;cursor:pointer;transition:border-color .15s,background .15s,box-shadow .15s}.choice-dot{position:absolute;left:14px;top:16px;width:16px;height:16px;border:1px solid #aaa;border-radius:50%;background:#fff}.choice-title{font:700 15px/1.2 'Avenir Next','PingFang SC','Noto Sans CJK SC',sans-serif}.choice-copy{font-size:12px;line-height:1.5;color:var(--muted)}.choice-meta{margin-top:2px;font:700 10px/1 ui-monospace,'SFMono-Regular',Consolas,monospace;color:#888;text-transform:uppercase}.choice input:checked+.choice-card{border-color:var(--accent);background:#f7f7f7;box-shadow:inset 0 0 0 1px var(--accent)}.choice input:checked+.choice-card .choice-dot{border-color:var(--accent);box-shadow:inset 0 0 0 4px #fff;background:var(--accent)}.choice input:focus+.choice-card{outline:2px solid #cfcfcf;outline-offset:1px}@media(max-width:560px){.choice-grid{grid-template-columns:1fr}.choice-card{min-height:84px}}"
 	                  ".tabs{display:flex;gap:8px;border-bottom:1px solid var(--line);margin:18px -22px 18px;padding:0 22px}.tab{border:1px solid var(--line);border-bottom:0;border-radius:6px 6px 0 0;background:#f4f4f4;min-height:38px;padding:10px 14px;font:600 13px/1 'Avenir Next','PingFang SC','Noto Sans CJK SC',sans-serif;color:inherit;text-decoration:none}.tab.active{background:var(--surface);position:relative;top:1px}.info-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}.info-row{border:1px solid var(--line);border-radius:6px;padding:12px;min-width:0}.info-row span{display:block;color:var(--muted);font-size:12px;margin-bottom:7px}.info-row strong{display:block;font:600 14px/1.35 ui-monospace,'SFMono-Regular',Consolas,monospace;word-break:break-all}@media(max-width:560px){.info-grid{grid-template-columns:1fr}}"
 	                  ".btn{border:1px solid var(--line);background:var(--surface);border-radius:6px;min-height:38px;padding:9px 13px;font:600 13px/1 'Avenir Next','PingFang SC','Noto Sans CJK SC',sans-serif;color:inherit;text-decoration:none;display:inline-flex;align-items:center;justify-content:center;cursor:pointer}.btn.primary{background:var(--accent);border-color:var(--accent);color:#fff}.btn.warn{background:var(--warn);border-color:var(--warn);color:#fff}.btn-row{display:flex;gap:10px;flex-wrap:wrap}.ok{color:var(--good)}.bad{color:var(--warn)}"
 	                  "</style></head><body><main>");
@@ -1955,6 +2123,9 @@ void sendStatusPage() {
   appendInfoRow(html, F("运行时间"), uptimeText());
   appendInfoRow(html, F("可用内存"), String(ESP.getFreeHeap()) + F(" bytes"));
   appendInfoRow(html, F("服务连接"), mcuSocketStateLabel());
+  if (mcuSocketRelayUrl.length() > 0) {
+    appendInfoRow(html, F("远程转发"), mcuSocketRelayUrl);
+  }
   appendInfoRow(html, F("音频硬件"), String(es8311Ready && i2sReady ? F("就绪") : F("未就绪")) + F(" · ") + lastAudioDetail);
   appendInfoRow(html, F("音量"), String(outputVolumePercent) + F("%"));
   appendInfoRow(html, F("电量"), F("未启用"));
@@ -2005,6 +2176,8 @@ void sendStatusPage() {
       bool online = millis() - device.lastSeenMs < kLanDiscoveryStaleMs;
       html += F("<div class='info-row'><span>");
       html += endpointLabel(device.endpointKind, device.httpPort);
+      html += F(" · ");
+      html += lanDeviceSourceLabel(device);
       html += online ? F(" · 在线") : F(" · 可能离线");
       html += device.loggedIn ? F(" · 已登录") : F(" · 未登录");
       if (lanDeviceKey(device) == activeDeviceKey) html += F(" · 当前交互");
@@ -2180,7 +2353,7 @@ bool lanDeviceIndex(int index, LanDevice **device) {
   return true;
 }
 
-String mcuLoginPayload(const String &account, const String &password) {
+String mcuLoginPayload(const String &account, const String &password, bool useRemoteRelay) {
   String payload;
   payload.reserve(560);
   payload += F("{\"token\":\"");
@@ -2194,11 +2367,13 @@ String mcuLoginPayload(const String &account, const String &password) {
   payload += escapeJson(account);
   payload += F("\",\"password\":\"");
   payload += escapeJson(password);
+  payload += F("\",\"relayMode\":\"");
+  payload += useRemoteRelay ? F("remote") : F("lan");
   payload += F("\"}");
   return payload;
 }
 
-bool runMcuLogin(LanDevice &device, const String &account, const String &password) {
+bool runMcuLogin(LanDevice &device, const String &account, const String &password, bool useRemoteRelay = false) {
   String endpoint = device.url;
   while (endpoint.endsWith("/")) endpoint.remove(endpoint.length() - 1);
   endpoint += F("/api/auth/mcu-login");
@@ -2215,7 +2390,7 @@ bool runMcuLogin(LanDevice &device, const String &account, const String &passwor
   http.addHeader(F("Content-Type"), F("application/json"));
   http.addHeader(F("X-Hermes-Device-Id"), deviceId());
   http.addHeader(F("X-Hermes-Device-Name"), F("HStudio ESP32-C3"));
-  int code = http.POST(mcuLoginPayload(account, password));
+  int code = http.POST(mcuLoginPayload(account, password, useRemoteRelay));
   String response = http.getString();
   http.end();
 
@@ -2227,9 +2402,21 @@ bool runMcuLogin(LanDevice &device, const String &account, const String &passwor
     pendingProfileDeviceKey = lanDeviceKey(device);
     activeDeviceUrl = device.url;
     mcuAuthToken = jsonStringValue(response, F("token"));
+    String relayPayload = jsonObjectValue(response, F("relay"));
+    String relayUrl = relayPayload.length() > 0 ? jsonStringValue(relayPayload, F("url")) : "";
+    relayUrl.trim();
+    mcuSocketRelayUrl = relayUrl;
+    device.remoteLogin = mcuSocketRelayUrl.length() > 0;
+    mcuSocketReconnectBlocked = false;
     prefs.begin("mcu", false);
     prefs.putString("active_url", activeDeviceUrl);
+    if (mcuSocketRelayUrl.length() > 0) {
+      prefs.putString("relay_url", mcuSocketRelayUrl);
+    } else {
+      prefs.remove("relay_url");
+    }
     if (mcuAuthToken.length() > 0) prefs.putString("auth_token", mcuAuthToken);
+    prefs.remove("relay_replaced");
     prefs.end();
     parseLoginProfiles(response);
     connectMcuSocketClient();
@@ -2254,12 +2441,13 @@ bool savedCredentialsForDevice(const LanDevice &device, String *account, String 
 }
 
 bool autoLoginDevice(LanDevice &device) {
+  if (mcuSocketReconnectBlocked && mcuSocketRelayUrl.length() > 0) return false;
   String account;
   String password;
   if (!savedCredentialsForDevice(device, &account, &password)) return false;
   Serial.printf("Auto MCU login target=%s url=%s profile=%s\n",
                 lanDeviceKey(device).c_str(), device.url.c_str(), selectedProfile.c_str());
-  bool ok = runMcuLogin(device, account, password);
+  bool ok = runMcuLogin(device, account, password, mcuSocketRelayUrl.length() > 0);
   if (ok && selectedProfile.length() > 0) {
     String key = lanDeviceKey(device);
     String addr = lanAddressKey(device);
@@ -2314,18 +2502,29 @@ void sendMcuLoginPage() {
   }
 
   String html = pageStart(F("登录设备"));
+  bool defaultRemoteLogin = device->manualSource || device->remoteLogin;
   html += F("<section class='panel'><p class='meta'>MCU LOGIN</p><h1>登录 ");
   html += escapeHtml(endpointLabel(device->endpointKind, device->httpPort));
   html += F("</h1><p class='lead'>");
   html += escapeHtml(device->name);
+  html += F(" · ");
+  html += escapeHtml(lanDeviceSourceLabel(*device));
   html += F(" · ");
   html += escapeHtml(device->url);
   html += F("</p><form method='post' action='/device/login'><input type='hidden' name='i' value='");
   html += index;
   html += F("'><div class='field'><span class='label'>账号</span><input name='account' autocomplete='username' required></div>");
   html += F("<div class='field'><span class='label'>密码</span><input name='password' type='password' autocomplete='current-password' required></div>");
+  html += F("<div class='field'><span class='label'>连接方式</span><div class='choice-grid'>");
+  html += F("<label class='choice'><input type='radio' name='login_mode' value='lan'");
+  if (!defaultRemoteLogin) html += F(" checked");
+  html += F("><span class='choice-card'><span class='choice-dot'></span><span class='choice-title'>局域网登录</span><span class='choice-copy'>直连当前 Web UI，同一 Wi-Fi 下响应最快。</span><span class='choice-meta'>LOCAL</span></span></label>");
+  html += F("<label class='choice'><input type='radio' name='login_mode' value='remote'");
+  if (defaultRemoteLogin) html += F(" checked");
+  html += F("><span class='choice-card'><span class='choice-dot'></span><span class='choice-title'>远程登录</span><span class='choice-copy'>通过远程服务器转发，适合跨网络使用。</span><span class='choice-meta'>REMOTE</span></span></label>");
+  html += F("</div></div>");
   html += F("<div class='btn-row'><button class='btn primary' type='submit'>登录</button><a class='btn' href='/device'>返回</a></div>");
-  html += F("<p class='hint'>登录成功后会让你选择 profile，设备会使用登录 token 连接当前机器。</p></form></section>");
+  html += F("<p class='hint'>局域网登录会连接当前机器；远程登录会请求当前机器返回远程转发服务地址。</p></form></section>");
   html += pageEnd();
   server.send(200, F("text/html; charset=utf-8"), html);
 }
@@ -2387,7 +2586,9 @@ void handleMcuLogin() {
   int index = server.arg(F("i")).toInt();
   String account = server.arg(F("account"));
   String password = server.arg(F("password"));
+  String loginMode = server.arg(F("login_mode"));
   account.trim();
+  loginMode.trim();
   LanDevice *device = nullptr;
   if (!lanDeviceIndex(index, &device)) {
     server.send(404, F("text/plain; charset=utf-8"), F("设备不存在，请先刷新探测"));
@@ -2397,7 +2598,7 @@ void handleMcuLogin() {
     server.send(400, F("text/plain; charset=utf-8"), F("缺少账号或密码"));
     return;
   }
-  runMcuLogin(*device, account, password);
+  runMcuLogin(*device, account, password, loginMode == F("remote"));
   sendProfilePage();
 }
 
@@ -2446,6 +2647,9 @@ void setActiveDevice() {
 
   activeDeviceKey = lanDeviceKey(*device);
   activeDeviceUrl = device->url;
+  mcuSocketRelayUrl = "";
+  mcuSocketReconnectBlocked = false;
+  device->remoteLogin = false;
   selectedProfile = device->profile;
   mcuAuthToken = "";
   disconnectMcuSocketClient();
@@ -2455,7 +2659,9 @@ void setActiveDevice() {
   prefs.putString("active_url", activeDeviceUrl);
   prefs.putString("last_key", activeDeviceKey);
   prefs.putString("last_profile", selectedProfile);
+  prefs.remove("relay_url");
   prefs.remove("auth_token");
+  prefs.remove("relay_replaced");
   prefs.end();
 
   if (!runMcuLogin(*device, account, password)) {
@@ -2478,6 +2684,7 @@ void logoutDevice() {
   clearProfileForDevice(key, lanAddressKey(*device));
   device->profile = "";
   device->loggedIn = false;
+  device->remoteLogin = false;
   if (pendingProfileDeviceKey == key) pendingProfileDeviceKey = "";
   if (activeDeviceKey == key) activeDeviceKey = "";
   String lastKey;
@@ -2565,6 +2772,7 @@ bool sendRawWsText(const String &payload) {
 
 bool sendMcuSocketEvent(const String &event, const String &json) {
   if (!wsReady || !mcuSocketNamespaceReady || event.length() == 0) return false;
+  if (mcuSocketReconnectBlocked && event != F("mcu.ready")) return false;
   String payload;
   payload.reserve(json.length() + event.length() + 28);
   payload += F("42/global-agent,[\"");
@@ -3987,10 +4195,15 @@ void handleBootButton() {
 }
 
 String mcuSocketAuthJson() {
+  String deviceCode = mcuDeviceCode();
   String json;
-  json.reserve(mcuAuthToken.length() + selectedProfile.length() + 180);
+  json.reserve(mcuAuthToken.length() + selectedProfile.length() + deviceCode.length() * 2 + 220);
   json += F("{\"token\":\"");
   json += escapeJson(mcuAuthToken);
+  json += F("\",\"deviceCode\":\"");
+  json += escapeJson(deviceCode);
+  json += F("\",\"device_code\":\"");
+  json += escapeJson(deviceCode);
   json += F("\",\"role\":\"hermes-studio\",\"instanceId\":\"");
   json += escapeJson(deviceId());
   json += F("\",\"profile\":\"");
@@ -4095,6 +4308,20 @@ void handleSocketIoText(const String &message) {
     String json;
     if (parseSocketIoEvent(message, &event, &json)) {
       Serial.printf("Socket.IO event %s %s\n", event.c_str(), json.c_str());
+      if (event == F("relay.replaced") || jsonStringValue(json, F("type")) == F("relay.replaced")) {
+        mcuSocketReconnectBlocked = true;
+        prefs.begin("mcu", false);
+        prefs.putBool("relay_replaced", true);
+        prefs.end();
+        lastAudioDetail = F("远程连接已被其他设备接管");
+        setOledStatus(OledMode::Error, F("SOCKET"), F("REPLACED"), 0);
+        return;
+      }
+      if (event == F("relay.auth.ok") || jsonStringValue(json, F("type")) == F("relay.auth.ok")) {
+        String machineList = jsonObjectValue(json, F("machineList"));
+        mcuRemoteDiscoveryToken = jsonStringValue(machineList, F("token"));
+        return;
+      }
       handleMcuWebSocketText(0, json);
     }
     return;
@@ -4185,9 +4412,20 @@ void disconnectMcuSocketClient() {
   mcuSocketTargetKey = "";
 }
 
+String activeMcuSocketUrl() {
+  String url = mcuSocketRelayUrl;
+  url.trim();
+  if (url.length() > 0) return url;
+  return activeDeviceUrl;
+}
+
 void connectMcuSocketClient() {
   if (!wifiReady || WiFi.status() != WL_CONNECTED || activeDeviceUrl.length() == 0 || mcuAuthToken.length() == 0) {
     disconnectMcuSocketClient();
+    return;
+  }
+  if (mcuSocketReconnectBlocked && mcuSocketRelayUrl.length() > 0) {
+    Serial.println(F("Socket.IO reconnect blocked after relay replacement"));
     return;
   }
 
@@ -4195,7 +4433,8 @@ void connectMcuSocketClient() {
   String host;
   uint16_t port = 0;
   String path;
-  if (!parseAudioUrl(activeDeviceUrl, &scheme, &host, &port, &path)) {
+  String socketUrl = activeMcuSocketUrl();
+  if (!parseAudioUrl(socketUrl, &scheme, &host, &port, &path)) {
     disconnectMcuSocketClient();
     return;
   }
@@ -4247,8 +4486,8 @@ void connectMcuSocketClient() {
   mcuSocketNamespaceReady = false;
   mcuSocketTargetKey = targetKey;
   lastMcuSocketConnectAtMs = millis();
-  Serial.printf("Socket.IO client connecting host=%s port=%u profile=%s\n",
-                host.c_str(), port, selectedProfile.c_str());
+  Serial.printf("Socket.IO client connecting host=%s port=%u profile=%s relay=%d\n",
+                host.c_str(), port, selectedProfile.c_str(), mcuSocketRelayUrl.length() > 0 ? 1 : 0);
   mcuSocketLoop();
 }
 
@@ -4534,7 +4773,9 @@ void setup() {
   pendingProfileDeviceKey = prefs.getString("last_key", "");
   activeDeviceKey = prefs.getString("active_key", "");
   activeDeviceUrl = prefs.getString("active_url", "");
+  mcuSocketRelayUrl = prefs.getString("relay_url", "");
   mcuAuthToken = prefs.getString("auth_token", "");
+  mcuSocketReconnectBlocked = prefs.getBool("relay_replaced", false);
   selectedProfile = prefs.getString("last_profile", "");
   prefs.end();
   setOledStatus(OledMode::Boot, F("BOOT"), F("WIFI ONLY"), 15);

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -61,6 +61,9 @@ export function getCorsOrigins(env: Record<string, string | undefined> = process
 }
 
 const appHome = getWebUiHome()
+const remoteRelay = {
+  url: 'http://192.168.10.103:8077',
+}
 
 export const config = {
   port: parseInt(process.env.PORT || '8648', 10),
@@ -70,4 +73,5 @@ export const config = {
   uploadDir: process.env.UPLOAD_DIR || join(appHome, 'upload'),
   dataDir: resolve(__dirname, '..', 'data'),
   corsOrigins: getCorsOrigins(),
+  remoteRelay,
 }

--- a/packages/server/src/controllers/auth.ts
+++ b/packages/server/src/controllers/auth.ts
@@ -25,6 +25,9 @@ import {
 import { issueUserJwt } from '../middleware/user-auth'
 import { listProfileNamesFromDisk } from '../services/hermes/hermes-profile'
 import { startOutboundRelayClient, stopOutboundRelayClient } from '../services/global-agent/outbound-relay-client'
+import { getLanEndpointKind } from '../services/lan-discovery'
+import { getPublicSystemInfo } from '../services/system-info'
+import { config } from '../config'
 
 /**
  * GET /api/auth/status
@@ -236,10 +239,27 @@ function requestBaseUrl(ctx: Context): string | undefined {
   return `${ctx.protocol || 'http'}://${host}`
 }
 
+async function verifyRemoteRelayDeviceCode(deviceCode: string): Promise<boolean> {
+  const url = `${config.remoteRelay.url.replace(/\/$/, '')}/global-agent/device/${encodeURIComponent(deviceCode)}`
+  const response = await fetch(url, { method: 'GET' })
+  return response.ok
+}
+
+async function localRelayMachineInfo(url: string) {
+  const info = await getPublicSystemInfo()
+  return {
+    ...info,
+    http_port: config.port,
+    endpoint_kind: getLanEndpointKind(config.port),
+    url,
+    relay_url: config.remoteRelay.url,
+  }
+}
+
 /**
  * POST /api/auth/mcu-login
  * Authenticate with the existing username/password login for an MCU/device.
- * When a legacy relay URL is provided, connect this Hermes Studio instance to it.
+ * When remote relay is requested or a legacy relay URL is provided, connect this Hermes Studio instance to it.
  * Body: { token, id, account, password, url? }.
  */
 export async function microcontrollerLogin(ctx: Context) {
@@ -249,12 +269,18 @@ export async function microcontrollerLogin(ctx: Context) {
     id,
     account,
     password,
+    relayMode,
+    remote,
+    device_code: deviceCode,
   } = ctx.request.body as {
     token?: string
     url?: string
     id?: string
     account?: string
     password?: string
+    relayMode?: string
+    remote?: boolean
+    device_code?: string
   }
 
   if (!relayToken || !id || !account || !password) {
@@ -263,27 +289,59 @@ export async function microcontrollerLogin(ctx: Context) {
     return
   }
 
-  const relayUrl = typeof url === 'string' && url.trim() ? normalizeRelayUrl(url) : null
+  const wantsRemoteRelay = relayMode === 'remote' || remote === true
+  const remoteRelayUrl = wantsRemoteRelay ? config.remoteRelay.url : ''
+  const relayUrl = typeof url === 'string' && url.trim()
+    ? normalizeRelayUrl(url)
+    : remoteRelayUrl || null
   if (url && !relayUrl) {
     ctx.status = 400
     ctx.body = { error: 'url must be a valid http, https, ws, or wss URL' }
     return
   }
 
+  const normalizedDeviceCode = typeof deviceCode === 'string' ? deviceCode.trim() : ''
+  if (wantsRemoteRelay && !normalizedDeviceCode) {
+    ctx.status = 400
+    ctx.body = { error: '缺少设备码' }
+    return
+  }
+
   const result = await passwordLogin(ctx, account, password)
   if (!result.ok) return
+
+  if (wantsRemoteRelay) {
+    try {
+      if (!await verifyRemoteRelayDeviceCode(normalizedDeviceCode)) {
+        ctx.status = 403
+        ctx.body = { error: '非官方设备码' }
+        return
+      }
+    } catch (err: any) {
+      ctx.status = 502
+      ctx.body = { error: err?.message || '远程设备码校验失败' }
+      return
+    }
+  }
 
   const connectionId = id.trim()
   stopOutboundRelayClient(connectionId)
   if (relayUrl) {
+    const relayStartUrl = wantsRemoteRelay && relayUrl === remoteRelayUrl
+      ? config.remoteRelay.url
+      : relayUrl
+    const localBaseUrl = requestBaseUrl(ctx)
+    const machineInfo = localBaseUrl ? await localRelayMachineInfo(localBaseUrl) : undefined
     const client = startOutboundRelayClient({
       connectionId,
-      relayUrl,
+      relayUrl: relayStartUrl,
       relayToken,
       userToken: result.token,
       instanceId: connectionId,
-      localBaseUrl: requestBaseUrl(ctx),
-      relayProtocol: relayUrl.startsWith('ws://') || relayUrl.startsWith('wss://') ? 'websocket' : 'socket.io',
+      ...(normalizedDeviceCode ? { deviceCode: normalizedDeviceCode } : {}),
+      ...(localBaseUrl ? { localBaseUrl } : {}),
+      ...(machineInfo ? { machineInfo } : {}),
+      relayProtocol: wantsRemoteRelay ? 'mcu-socket.io' : 'socket.io',
     })
     if (!client) {
       ctx.status = 400
@@ -298,6 +356,7 @@ export async function microcontrollerLogin(ctx: Context) {
     relay: {
       connected: Boolean(relayUrl),
       id: connectionId,
+      ...(wantsRemoteRelay && relayUrl === remoteRelayUrl ? { remote: true } : {}),
       ...(relayUrl ? { url: relayUrl } : {}),
     },
   }

--- a/packages/server/src/controllers/devices.ts
+++ b/packages/server/src/controllers/devices.ts
@@ -336,6 +336,7 @@ export async function deviceLinkInfoController(ctx: any) {
     ...info,
     http_port: config.port,
     endpoint_kind: getLanEndpointKind(config.port),
+    relay_url: config.remoteRelay.url,
   }
 }
 

--- a/packages/server/src/services/global-agent/outbound-relay-client.ts
+++ b/packages/server/src/services/global-agent/outbound-relay-client.ts
@@ -2,7 +2,6 @@ import { randomUUID } from 'crypto'
 import { mkdir, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { io, type Socket } from 'socket.io-client'
-import WebSocket from 'ws'
 import { config } from '../../config'
 import { clearSessionMessages } from '../../db/hermes/session-store'
 import { getChatRunServer } from '../../routes/hermes/chat-run'
@@ -15,6 +14,7 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 const MAX_REQUEST_TIMEOUT_MS = 120_000
 const MAX_REQUEST_BODY_BYTES = 5 * 1024 * 1024
 const MAX_RESPONSE_BODY_BYTES = 10 * 1024 * 1024
+const GLOBAL_AGENT_NAMESPACE = '/global-agent'
 
 const ALLOWED_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD'])
 const ALLOWED_REQUEST_HEADERS = new Set([
@@ -79,11 +79,30 @@ const NON_STREAMING_SUPPRESSED_EVENTS = new Set([
   'thinking.delta',
   'reasoning.available',
 ])
+const SOCKET_IO_RESERVED_EVENTS = new Set([
+  'connect',
+  'connect_error',
+  'disconnect',
+  'disconnecting',
+  'newListener',
+  'removeListener',
+])
 const MCU_TTS_OPTIONS = {
   mcuPlayback: true,
   sampleRate: MCU_TTS_SAMPLE_RATE,
 } as const
 const MCU_INTERRUPT_DEBOUNCE_MS = 280
+
+function resolveGlobalAgentSocketIoUrl(input: string): string {
+  const url = new URL(input)
+  const path = url.pathname.replace(/\/+$/, '')
+  if (!path) {
+    url.pathname = GLOBAL_AGENT_NAMESPACE
+  } else if (path !== GLOBAL_AGENT_NAMESPACE && !path.endsWith(GLOBAL_AGENT_NAMESPACE)) {
+    url.pathname = `${path}${GLOBAL_AGENT_NAMESPACE}`
+  }
+  return url.toString()
+}
 
 function chooseMcuApprovalChoice(event: Record<string, unknown>): 'once' | 'session' | 'always' | null {
   const rawChoices = Array.isArray(event.choices) ? event.choices.map(choice => String(choice)) : []
@@ -155,15 +174,18 @@ interface StartOutboundRelayClientOptions {
   relayToken?: string
   userToken?: string
   instanceId?: string
+  deviceCode?: string
   localBaseUrl?: string
+  machineInfo?: Record<string, unknown>
   fetchImpl?: typeof fetch
-  relayProtocol?: 'socket.io' | 'websocket'
+  relayProtocol?: 'socket.io' | 'mcu-socket.io'
 }
 
 type OutboundRelayClientOptions =
-  Required<Omit<StartOutboundRelayClientOptions, 'connectionId' | 'relayProtocol' | 'userToken'>> &
+  Required<Omit<StartOutboundRelayClientOptions, 'connectionId' | 'relayProtocol' | 'userToken' | 'machineInfo'>> &
   Pick<StartOutboundRelayClientOptions, 'userToken'>
-type RelayClient = Pick<OutboundRelayClient, 'start' | 'stop'> | PlainWebSocketRelayClient
+  & { machineInfo?: Record<string, unknown> }
+type RelayClient = Pick<OutboundRelayClient, 'start' | 'stop'> | McuSocketIoRelayClient
 
 interface LocalSocketBridge {
   id: string
@@ -181,11 +203,11 @@ interface McuVoiceMeta {
   profile: string
 }
 
-class PlainWebSocketRelayClient {
-  private socket: WebSocket | null = null
-  private reconnectTimer: NodeJS.Timeout | null = null
-  private reconnectDelayMs = 1000
+class McuSocketIoRelayClient {
+  private socket: Socket | null = null
+  private localAgentSocket: Socket | null = null
   private stopped = false
+  private reconnectBlockedReason = ''
   private pendingVoice: McuVoiceMeta | null = null
   private pendingVoiceStream: (McuVoiceMeta & {
     sampleRate: number
@@ -200,92 +222,157 @@ class PlainWebSocketRelayClient {
   private readonly ttsAbortControllers = new Map<string, Set<AbortController>>()
   private readonly recentlyInterruptedSessions = new Map<string, number>()
   private readonly pendingInterrupts = new Map<string, { profile: string; interactionId: string; timer: NodeJS.Timeout }>()
+  private audioUploadToken = ''
+  private audioUploadPath = '/global-agent/audio'
 
   constructor(private readonly options: OutboundRelayClientOptions) {}
 
   start(): void {
-    if (this.socket || this.reconnectTimer) return
+    if (this.socket) return
     this.stopped = false
+    this.reconnectBlockedReason = ''
     this.connect()
   }
 
   stop(): void {
     this.stopped = true
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer)
-      this.reconnectTimer = null
-    }
-    this.socket?.close()
+    this.socket?.disconnect()
     this.socket = null
+    this.localAgentSocket?.disconnect()
+    this.localAgentSocket = null
     this.cancelPendingInterrupts()
-    this.rejectAudioWaiters(new Error('MCU websocket stopped'))
+    this.rejectAudioWaiters(new Error('MCU Socket.IO relay stopped'))
   }
 
   private connect(): void {
     if (this.stopped) return
-    const socket = new WebSocket(this.options.relayUrl)
+    const authPayload: Record<string, unknown> = {
+      token: this.options.relayToken || undefined,
+      instanceId: this.options.instanceId || undefined,
+      role: 'hermes-studio',
+      clientRole: 'web',
+      relayRole: 'web',
+      machine: this.options.machineInfo || undefined,
+    }
+    if (this.options.deviceCode) {
+      authPayload.deviceCode = this.options.deviceCode
+      authPayload.device_code = this.options.deviceCode
+    }
+    const relaySocketUrl = resolveGlobalAgentSocketIoUrl(this.options.relayUrl)
+    const socket: Socket = io(relaySocketUrl, {
+      auth: authPayload,
+      transports: ['websocket', 'polling'],
+      reconnection: true,
+      reconnectionAttempts: Infinity,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 30_000,
+      timeout: 30_000,
+    })
     this.socket = socket
 
-    socket.on('open', () => {
-      this.reconnectDelayMs = 1000
-      logger.info({ relayUrl: this.redactedRelayUrl() }, '[outbound-relay:ws] connected')
-      this.sendJson({
-        type: 'mcu.auth',
-        token: this.options.relayToken || undefined,
-        instanceId: this.options.instanceId || undefined,
-        role: 'hermes-studio',
-      })
+    socket.on('connect', () => {
+      logger.info({ relayUrl: this.redactedRelayUrl() }, '[outbound-relay:mcu-sio] connected')
+      this.connectLocalAgentSocket()
     })
 
-    socket.on('message', (data, isBinary) => {
-      if (isBinary) {
-        const audio = this.binaryBuffer(data)
-        if (this.pendingVoiceStream) {
-          this.pendingVoiceStream.chunks.push(audio)
-          this.pendingVoiceStream.bytes += audio.length
-          return
-        }
-        logger.info({
-          relayUrl: this.redactedRelayUrl(),
-          bytes: audio.length,
-          interactionId: this.pendingVoice?.interactionId,
-        }, '[outbound-relay:ws] binary received')
-        void this.handleVoiceAudio(audio)
-        return
+    socket.on('connect_error', (err: Error) => {
+      logger.warn({ err, relayUrl: this.redactedRelayUrl() }, '[outbound-relay:mcu-sio] connection error')
+      if (err.message === 'device_code_not_allowed' || err.message.includes('非官方设备码')) {
+        this.stopped = true
+        this.reconnectBlockedReason = err.message
+        socket.io.opts.reconnection = false
       }
-      const text = Buffer.isBuffer(data) ? data.toString('utf-8') : String(data)
-      this.handleText(text)
     })
 
-    socket.on('error', (err) => {
-      logger.warn({ err, relayUrl: this.redactedRelayUrl() }, '[outbound-relay:ws] connection error')
-    })
-
-    socket.on('close', (code, reason) => {
-      if (this.socket === socket) this.socket = null
-      this.rejectAudioWaiters(new Error('MCU websocket disconnected'))
+    socket.on('disconnect', (reason: string) => {
+      this.localAgentSocket?.disconnect()
+      this.localAgentSocket = null
+      this.rejectAudioWaiters(new Error('MCU Socket.IO relay disconnected'))
       logger.info({
-        code,
-        reason: reason.toString(),
+        reason,
+        reconnectBlockedReason: this.reconnectBlockedReason || undefined,
         relayUrl: this.redactedRelayUrl(),
-      }, '[outbound-relay:ws] disconnected')
-      this.scheduleReconnect()
+      }, '[outbound-relay:mcu-sio] disconnected')
+    })
+
+    socket.onAny((eventName: string, payload: unknown) => {
+      if (SOCKET_IO_RESERVED_EVENTS.has(eventName)) return
+      this.handleRemoteEvent(eventName, payload)
     })
   }
 
-  private scheduleReconnect(): void {
-    if (this.stopped || this.reconnectTimer) return
-    const delay = this.reconnectDelayMs
-    this.reconnectDelayMs = Math.min(this.reconnectDelayMs * 2, 30_000)
-    this.reconnectTimer = setTimeout(() => {
-      this.reconnectTimer = null
-      this.connect()
-    }, delay)
+  private connectLocalAgentSocket(): void {
+    if (this.localAgentSocket || !this.options.userToken) return
+    const localBaseUrl = this.options.localBaseUrl.replace(/\/$/, '')
+    const socket: Socket = io(`${localBaseUrl}/global-agent`, {
+      auth: {
+        token: this.options.userToken,
+        role: 'hermes-studio',
+        instanceId: this.options.instanceId || this.options.deviceCode || undefined,
+      },
+      transports: ['websocket', 'polling'],
+      reconnection: true,
+      reconnectionAttempts: Infinity,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 30_000,
+      timeout: 30_000,
+    })
+    this.localAgentSocket = socket
+    socket.on('connect', () => {
+      logger.info({
+        relayUrl: this.redactedRelayUrl(),
+        localBaseUrl,
+        instanceId: this.options.instanceId || this.options.deviceCode || undefined,
+      }, '[outbound-relay:mcu-sio] local global-agent bridge connected')
+    })
+    socket.on('connect_error', (err: Error) => {
+      logger.warn({ err, localBaseUrl }, '[outbound-relay:mcu-sio] local global-agent bridge connection failed')
+    })
+    socket.on('disconnect', (reason: string) => {
+      logger.info({ reason, localBaseUrl }, '[outbound-relay:mcu-sio] local global-agent bridge disconnected')
+      if (this.localAgentSocket === socket) this.localAgentSocket = null
+    })
+    socket.onAny((eventName: string, payload: unknown) => {
+      if (SOCKET_IO_RESERVED_EVENTS.has(eventName)) return
+      void this.forwardLocalMcuEventToRelay(eventName, payload)
+    })
+  }
+
+  private emitLocalMcuEvent(eventName: string, payload: Record<string, unknown>): void {
+    this.connectLocalAgentSocket()
+    this.localAgentSocket?.emit(eventName, payload)
+  }
+
+  private async forwardLocalMcuEventToRelay(eventName: string, payload: unknown): Promise<void> {
+    if (this.stopped) return
+    const body = isRecord(payload)
+      ? { ...payload, type: typeof payload.type === 'string' && payload.type ? payload.type : eventName }
+      : { type: eventName, payload }
+    const out = await this.prepareMcuRelayPayload(body)
+    this.sendJson(out)
+  }
+
+  private async prepareMcuRelayPayload(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+    if (payload.type !== 'audio.enqueue') return payload
+    const url = typeof payload.url === 'string' ? payload.url.trim() : ''
+    if (!url) return payload
+    const remoteUrl = await this.uploadMcuAudioUrlToRelay(url).catch((err) => {
+      logger.warn({
+        err,
+        relayUrl: this.redactedRelayUrl(),
+        url,
+        interactionId: typeof payload.interactionId === 'string' ? payload.interactionId : undefined,
+        segmentId: typeof payload.segmentId === 'string' ? payload.segmentId : undefined,
+      }, '[outbound-relay:mcu-sio] failed to upload local MCU audio URL to relay')
+      return ''
+    })
+    return remoteUrl ? { ...payload, url: remoteUrl } : payload
   }
 
   private sendJson(payload: Record<string, unknown>): void {
-    if (this.socket?.readyState !== WebSocket.OPEN) return
-    this.socket.send(JSON.stringify(payload))
+    if (!this.socket?.connected || this.stopped) return
+    const type = typeof payload.type === 'string' && payload.type.trim() ? payload.type.trim() : 'mcu.event'
+    this.socket.emit(type, payload)
   }
 
   private rejectAudioWaiters(error: Error): void {
@@ -296,21 +383,42 @@ class PlainWebSocketRelayClient {
     }
   }
 
-  private handleText(text: string): void {
-    let event: Record<string, unknown>
-    try {
-      event = JSON.parse(text) as Record<string, unknown>
-    } catch {
-      logger.warn({ relayUrl: this.redactedRelayUrl(), text: text.slice(0, 300) }, '[outbound-relay:ws] invalid json')
-      return
-    }
+  private handleRemoteEvent(eventName: string, payload: unknown): void {
+    const event: Record<string, unknown> = isRecord(payload)
+      ? { ...payload, type: typeof payload.type === 'string' && payload.type ? payload.type : eventName }
+      : { type: eventName, payload }
     logger.info({
       relayUrl: this.redactedRelayUrl(),
       type: typeof event.type === 'string' ? event.type : undefined,
       status: typeof event.status === 'string' ? event.status : undefined,
       text: typeof event.text === 'string' ? event.text.slice(0, 300) : undefined,
       interactionId: typeof event.interactionId === 'string' ? event.interactionId : undefined,
-    }, '[outbound-relay:ws] event')
+    }, '[outbound-relay:mcu-sio] event')
+    if (event.type === 'mcu.auth.ok') {
+      const audioUpload = isRecord(event.audioUpload) ? event.audioUpload : null
+      const token = typeof audioUpload?.token === 'string' ? audioUpload.token.trim() : ''
+      if (token) {
+        this.audioUploadToken = token
+        this.audioUploadPath = typeof audioUpload?.url === 'string' && audioUpload.url.trim()
+          ? audioUpload.url.trim()
+          : '/global-agent/audio'
+      }
+      return
+    }
+    if (event.type === 'relay.replaced') {
+      this.reconnectBlockedReason = 'replaced'
+      this.stopped = true
+      logger.warn({
+        relayUrl: this.redactedRelayUrl(),
+        deviceCode: typeof event.deviceCode === 'string' ? event.deviceCode : undefined,
+        role: typeof event.role === 'string' ? event.role : undefined,
+      }, '[outbound-relay:mcu-sio] remote relay connection replaced; relay left connected but inactive')
+      this.localAgentSocket?.disconnect()
+      this.localAgentSocket = null
+      this.cancelPendingInterrupts()
+      this.rejectAudioWaiters(new Error('remote relay connection replaced'))
+      return
+    }
     if (event.type === 'voice.recorded') {
       this.pendingVoice = {
         interactionId: typeof event.interactionId === 'string' && event.interactionId.trim() ? event.interactionId.trim() : `mcu-voice-${Date.now()}`,
@@ -332,6 +440,32 @@ class PlainWebSocketRelayClient {
         bitsPerSample: Number(event.bitsPerSample) === 16 ? 16 : 16,
         chunks: [],
       }
+      this.emitLocalMcuEvent('voice.stream.start', event)
+      return
+    }
+    if (event.type === 'voice.stream.chunk') {
+      const data = typeof event.data === 'string' ? event.data : ''
+      if (!data) return
+      const audio = Buffer.from(data, 'base64')
+      if (this.pendingVoiceStream) {
+        this.pendingVoiceStream.chunks.push(audio)
+        const offset = this.pendingVoiceStream.bytes
+        this.pendingVoiceStream.bytes += audio.length
+        this.emitLocalMcuEvent('voice.stream.chunk', {
+          ...event,
+          interactionId: this.pendingVoiceStream.interactionId,
+          offset,
+          bytes: audio.length,
+          data,
+        })
+        return
+      }
+      logger.info({
+        relayUrl: this.redactedRelayUrl(),
+        bytes: audio.length,
+        interactionId: this.pendingVoice?.interactionId,
+      }, '[outbound-relay:mcu-sio] voice chunk received without stream metadata')
+      void this.handleVoiceAudio(audio)
       return
     }
     if (event.type === 'voice.stream.end') {
@@ -341,22 +475,16 @@ class PlainWebSocketRelayClient {
         this.sendJson({ type: 'interaction.status', status: 'failed', text: 'missing voice stream metadata' })
         return
       }
-      const pcm = Buffer.concat(stream.chunks, stream.bytes)
       logger.info({
         relayUrl: this.redactedRelayUrl(),
-        bytes: pcm.length,
+        bytes: stream.bytes,
         interactionId: stream.interactionId,
-      }, '[outbound-relay:ws] voice stream completed')
-      const wav = this.wrapPcmAsWav(pcm, stream.sampleRate, stream.channels, stream.bitsPerSample)
-      void this.handleVoiceAudio(wav, {
-        interactionId: stream.interactionId,
-        mimeType: 'audio/wav',
-        bytes: wav.length,
-        profile: stream.profile,
-      })
+      }, '[outbound-relay:mcu-sio] voice stream completed')
+      this.emitLocalMcuEvent('voice.stream.end', event)
       return
     }
     if (event.type === 'audio.done' || event.type === 'audio.interrupted' || event.type === 'audio.dropped') {
+      this.emitLocalMcuEvent(event.type, event)
       if (event.type === 'audio.interrupted' && typeof event.interactionId === 'string') {
         this.abortActiveRun(event.interactionId)
       }
@@ -374,23 +502,16 @@ class PlainWebSocketRelayClient {
       return
     }
     if (event.type === 'mcu.interrupt') {
-      const interactionId = typeof event.interactionId === 'string' ? event.interactionId.trim() : ''
-      const profile = typeof event.profile === 'string' && event.profile.trim() ? event.profile.trim() : 'default'
-      this.scheduleMcuInterrupt(profile, interactionId)
-      this.sendJson({ type: 'mcu.interrupt.ack', interactionId, profile })
+      this.emitLocalMcuEvent('mcu.interrupt', event)
       return
     }
     if (event.type === 'mcu.session.clear') {
-      const profile = typeof event.profile === 'string' && event.profile.trim() ? event.profile.trim() : 'default'
-      const interactionId = typeof event.interactionId === 'string' ? event.interactionId.trim() : ''
-      this.clearMcuSession(profile, interactionId)
+      this.emitLocalMcuEvent('mcu.session.clear', event)
+      return
     }
-  }
-
-  private binaryBuffer(data: WebSocket.RawData): Buffer {
-    if (Buffer.isBuffer(data)) return data
-    if (Array.isArray(data)) return Buffer.concat(data)
-    return Buffer.from(data)
+    if (typeof event.type === 'string' && event.type.trim()) {
+      this.emitLocalMcuEvent(event.type.trim(), event)
+    }
   }
 
   private wrapPcmAsWav(pcm: Buffer, sampleRate: number, channels: number, bitsPerSample: number): Buffer {
@@ -1005,7 +1126,88 @@ class PlainWebSocketRelayClient {
     await mkdir(dir, { recursive: true })
     const file = `${randomUUID()}.pcm`
     await writeFile(join(dir, file), audio)
-    return { url: `${baseUrl}/api/hermes/mcu/audio/${file}` }
+    const localUrl = `${baseUrl}/api/hermes/mcu/audio/${file}`
+    const remoteUrl = await this.uploadMcuAudioToRelay(audio, signal).catch((err) => {
+      logger.warn({
+        err,
+        relayUrl: this.redactedRelayUrl(),
+        bytes: audio.length,
+      }, '[outbound-relay:ws] failed to upload MCU audio to relay')
+      return ''
+    })
+    return { url: remoteUrl || localUrl }
+  }
+
+  private relayHttpBaseUrl(): string {
+    const url = new URL(this.options.relayUrl)
+    if (url.protocol === 'ws:') url.protocol = 'http:'
+    if (url.protocol === 'wss:') url.protocol = 'https:'
+    url.pathname = ''
+    url.search = ''
+    url.hash = ''
+    return url.toString().replace(/\/$/, '')
+  }
+
+  private resolveRelayAudioUploadUrl(): string {
+    const baseUrl = this.relayHttpBaseUrl()
+    if (/^https?:\/\//i.test(this.audioUploadPath)) return this.audioUploadPath
+    const path = this.audioUploadPath.startsWith('/') ? this.audioUploadPath : `/${this.audioUploadPath}`
+    return `${baseUrl}${path}`
+  }
+
+  private async uploadMcuAudioToRelay(audio: Buffer, signal?: AbortSignal): Promise<string> {
+    if (!this.audioUploadToken || !this.options.deviceCode) return ''
+    const uploadUrl = this.resolveRelayAudioUploadUrl()
+    const response = await this.options.fetchImpl(uploadUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.audioUploadToken}`,
+        'Content-Type': 'audio/x-pcm',
+        'X-Device-Code': this.options.deviceCode,
+        'X-Audio-Sample-Rate': String(MCU_TTS_SAMPLE_RATE),
+        'X-Audio-Channels': '1',
+      },
+      body: new Uint8Array(audio),
+      signal,
+    })
+    const text = await response.text()
+    let payload: Record<string, unknown> = {}
+    try {
+      payload = text ? JSON.parse(text) as Record<string, unknown> : {}
+    } catch {
+      payload = { error: text }
+    }
+    if (!response.ok || payload.ok === false) {
+      const error = typeof payload.error === 'string' ? payload.error : `relay audio upload failed: ${response.status}`
+      throw new Error(error)
+    }
+    const url = typeof payload.url === 'string' ? payload.url.trim() : ''
+    if (url) return url
+    const path = typeof payload.path === 'string' ? payload.path.trim() : ''
+    if (!path) throw new Error('relay audio upload did not return a URL')
+    return `${this.relayHttpBaseUrl()}${path.startsWith('/') ? path : `/${path}`}`
+  }
+
+  private resolveLocalAudioUrl(url: string): string {
+    if (/^https?:\/\//i.test(url)) return url
+    const path = url.startsWith('/') ? url : `/${url}`
+    return `${this.options.localBaseUrl.replace(/\/$/, '')}${path}`
+  }
+
+  private async uploadMcuAudioUrlToRelay(url: string): Promise<string> {
+    if (!this.audioUploadToken || !this.options.deviceCode) return ''
+    const localUrl = this.resolveLocalAudioUrl(url)
+    const response = await this.options.fetchImpl(localUrl, {
+      method: 'GET',
+      headers: this.options.userToken ? { Authorization: `Bearer ${this.options.userToken}` } : undefined,
+    })
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '')
+      throw new Error(`local MCU audio fetch failed: ${response.status}${detail ? ` ${detail.slice(0, 120)}` : ''}`)
+    }
+    const audio = Buffer.from(await response.arrayBuffer())
+    if (!audio.length) throw new Error('local MCU audio fetch returned empty audio')
+    return await this.uploadMcuAudioToRelay(audio, undefined)
   }
 
   private redactedRelayUrl(): string {
@@ -1205,25 +1407,35 @@ export class OutboundRelayClient {
   private readonly relayUrl: string
   private readonly relayToken: string
   private readonly instanceId: string
+  private readonly deviceCode: string
   private readonly localBaseUrl: string
+  private readonly machineInfo?: Record<string, unknown>
   private readonly fetchImpl: typeof fetch
 
   constructor(options: OutboundRelayClientOptions) {
     this.relayUrl = options.relayUrl
     this.relayToken = options.relayToken
     this.instanceId = options.instanceId
+    this.deviceCode = options.deviceCode
     this.localBaseUrl = options.localBaseUrl.replace(/\/$/, '')
+    this.machineInfo = options.machineInfo
     this.fetchImpl = options.fetchImpl
   }
 
   start(): void {
     if (this.socket) return
+    const auth: Record<string, unknown> = {
+      role: 'hermes-studio',
+    }
+    if (this.relayToken) auth.token = this.relayToken
+    if (this.deviceCode) {
+      auth.deviceCode = this.deviceCode
+      auth.device_code = this.deviceCode
+    }
+    if (this.instanceId) auth.instanceId = this.instanceId
+    if (this.machineInfo) auth.machine = this.machineInfo
     this.socket = io(this.relayUrl, {
-      auth: {
-        token: this.relayToken || undefined,
-        instanceId: this.instanceId || undefined,
-        role: 'hermes-studio',
-      },
+      auth,
       transports: ['websocket', 'polling'],
       reconnection: true,
       reconnectionAttempts: Infinity,
@@ -1241,9 +1453,16 @@ export class OutboundRelayClient {
     })
     this.socket.on('connect_error', (err: Error) => {
       logger.warn({ err, relayUrl: this.redactedRelayUrl() }, '[outbound-relay] connection failed')
+      if (err.message === 'device_code_not_allowed' || err.message.includes('非官方设备码')) {
+        this.stop()
+      }
     })
     this.socket.on('disconnect', (reason: string) => {
       logger.info({ reason, relayUrl: this.redactedRelayUrl() }, '[outbound-relay] disconnected')
+    })
+    this.socket.on('relay.replaced', (payload: unknown) => {
+      logger.warn({ payload, relayUrl: this.redactedRelayUrl() }, '[outbound-relay] remote relay connection replaced; reconnect disabled')
+      this.stop()
     })
     this.socket.on('http.request', (request: RelayHttpRequest, ack?: (response: RelayHttpResponse) => void) => {
       void this.handleHttpRequest(request)
@@ -1489,16 +1708,18 @@ export function startOutboundRelayClient(options: StartOutboundRelayClientOption
   const activeClient = activeClients.get(connectionId)
   if (activeClient) return activeClient
 
-  const clientOptions: OutboundRelayClientOptions = {
+    const clientOptions: OutboundRelayClientOptions = {
     relayUrl,
     relayToken: options.relayToken ?? '',
     userToken: options.userToken ?? '',
     instanceId: options.instanceId ?? '',
+    deviceCode: options.deviceCode ?? '',
     localBaseUrl: options.localBaseUrl ?? `http://127.0.0.1:${config.port}`,
+    machineInfo: options.machineInfo,
     fetchImpl: options.fetchImpl ?? fetch,
   }
-  const client = options.relayProtocol === 'websocket'
-    ? new PlainWebSocketRelayClient(clientOptions)
+  const client = options.relayProtocol === 'mcu-socket.io'
+    ? new McuSocketIoRelayClient(clientOptions)
     : new OutboundRelayClient(clientOptions)
   client.start()
   activeClients.set(connectionId, client)

--- a/tests/server/mcu-login-controller.test.ts
+++ b/tests/server/mcu-login-controller.test.ts
@@ -16,6 +16,8 @@ describe('MCU login controller', () => {
   beforeEach(async () => {
     vi.resetModules()
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
     vi.stubEnv('AUTH_JWT_SECRET', 'test-secret')
 
     const { DatabaseSync } = await import('node:sqlite')
@@ -157,5 +159,97 @@ describe('MCU login controller', () => {
       instanceId: 'mcu-1',
       relayProtocol: 'socket.io',
     })
+  })
+
+  it('keeps LAN login local when remote relay is not requested', async () => {
+    const { ctrl, users } = await loadModules()
+    users.createUser({
+      username: 'ops',
+      password: 'secret123',
+      role: 'admin',
+      profiles: ['default'],
+      defaultProfile: 'default',
+    })
+    const ctx = makeCtx({
+      token: 'relay-token',
+      id: 'mcu-1',
+      account: 'ops',
+      password: 'secret123',
+    })
+
+    await ctrl.microcontrollerLogin(ctx)
+
+    expect(ctx.status).toBe(200)
+    expect(ctx.body.relay).toEqual({
+      connected: false,
+      id: 'mcu-1',
+    })
+    expect(startOutboundRelayClientMock).not.toHaveBeenCalled()
+  })
+
+  it('uses the fixed remote relay when remote login is requested', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })))
+    startOutboundRelayClientMock.mockReturnValue({ start: vi.fn() })
+    const { ctrl, users } = await loadModules()
+    users.createUser({
+      username: 'ops',
+      password: 'secret123',
+      role: 'admin',
+      profiles: ['default'],
+      defaultProfile: 'default',
+    })
+    const ctx = makeCtx({
+      token: 'relay-token',
+      id: 'mcu-1',
+      account: 'ops',
+      password: 'secret123',
+      relayMode: 'remote',
+      device_code: 'hstudio_mcu_test',
+    })
+
+    await ctrl.microcontrollerLogin(ctx)
+
+    expect(ctx.status).toBe(200)
+    expect(ctx.body.relay).toEqual({
+      connected: true,
+      id: 'mcu-1',
+      remote: true,
+      url: 'http://192.168.10.103:8077',
+    })
+    expect(startOutboundRelayClientMock).toHaveBeenCalledWith({
+      connectionId: 'mcu-1',
+      relayUrl: 'http://192.168.10.103:8077',
+      relayToken: 'relay-token',
+      userToken: ctx.body.token,
+      instanceId: 'mcu-1',
+      deviceCode: 'hstudio_mcu_test',
+      relayProtocol: 'mcu-socket.io',
+    })
+  })
+
+  it('rejects remote login when the fixed relay does not allow the device code', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ ok: false }), { status: 404 })))
+    const { ctrl, users } = await loadModules()
+    users.createUser({
+      username: 'ops',
+      password: 'secret123',
+      role: 'admin',
+      profiles: ['default'],
+      defaultProfile: 'default',
+    })
+    const ctx = makeCtx({
+      token: 'relay-token',
+      id: 'mcu-1',
+      account: 'ops',
+      password: 'secret123',
+      relayMode: 'remote',
+      device_code: 'missing-device',
+    })
+
+    await ctrl.microcontrollerLogin(ctx)
+
+    expect(ctx.status).toBe(403)
+    expect(ctx.body).toEqual({ error: '非官方设备码' })
+    expect(startOutboundRelayClientMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/server/outbound-relay-client.test.ts
+++ b/tests/server/outbound-relay-client.test.ts
@@ -3,16 +3,30 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const { mockIo, mockSocket, sockets, socketHandlers, mockWebSockets, MockWebSocket, resetMockSockets } = vi.hoisted(() => {
   function createMockSocket(id: string) {
     const handlers = new Map<string, (...args: any[]) => void>()
+    const anyHandlers: Array<(event: string, ...args: any[]) => void> = []
     const socket: any = {
       id,
+      connected: false,
+      io: { opts: {} },
       __handlers: handlers,
+      __anyHandlers: anyHandlers,
       on: vi.fn((event: string, handler: (...args: any[]) => void) => {
-        handlers.set(event, handler)
+        handlers.set(event, (...args: any[]) => {
+          if (event === 'connect') socket.connected = true
+          if (event === 'disconnect') socket.connected = false
+          return handler(...args)
+        })
+        return socket
+      }),
+      onAny: vi.fn((handler: (event: string, ...args: any[]) => void) => {
+        anyHandlers.push(handler)
         return socket
       }),
       emit: vi.fn(),
       removeAllListeners: vi.fn(),
-      disconnect: vi.fn(),
+      disconnect: vi.fn(() => {
+        socket.connected = false
+      }),
     }
     return socket
   }
@@ -28,6 +42,7 @@ const { mockIo, mockSocket, sockets, socketHandlers, mockWebSockets, MockWebSock
   const resetMockSockets = () => {
     sockets.length = 0
     mockSocket.__handlers.clear()
+    mockSocket.__anyHandlers.length = 0
     mockWebSockets.length = 0
   }
 
@@ -76,6 +91,25 @@ describe('outbound relay client', () => {
     vi.clearAllMocks()
   })
 
+  function connectRemoteSocket() {
+    const socket = sockets[0]
+    socket.__handlers.get('connect')?.()
+    return socket
+  }
+
+  function emitRemote(socket: any, event: string, payload: unknown) {
+    for (const handler of socket.__anyHandlers) {
+      handler(event, payload)
+    }
+  }
+
+  function findEmittedPayload(socket: any, event: string, predicate: (payload: any) => boolean = () => true) {
+    return socket.emit.mock.calls
+      .filter(([eventName]: [string]) => eventName === event)
+      .map(([, payload]: [string, any]) => payload)
+      .find(predicate)
+  }
+
   it('stays disabled when no relay url is passed explicitly', async () => {
     const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
 
@@ -114,7 +148,7 @@ describe('outbound relay client', () => {
     })
   })
 
-  it('queues missing-STT prompt audio from websocket MCU voice turns', async () => {
+  it('queues missing-STT prompt audio from Socket.IO MCU voice turns', async () => {
     const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
       ok: false,
       audio: {
@@ -132,32 +166,35 @@ describe('outbound relay client', () => {
     const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
 
     startOutboundRelayClient({
-      relayUrl: 'ws://device.local:8787/',
-      relayProtocol: 'websocket',
+      relayUrl: 'http://device.local:8787/',
+      relayProtocol: 'mcu-socket.io',
       userToken: 'user-jwt',
       localBaseUrl: 'http://127.0.0.1:8648',
       fetchImpl: fetchImpl as any,
     })
 
-    const ws = mockWebSockets[0]
-    expect(ws).toBeInstanceOf(MockWebSocket)
-    ws.__handlers.get('open')?.()
-    ws.__handlers.get('message')?.(JSON.stringify({
+    expect(mockIo).toHaveBeenCalledWith('http://device.local:8787/global-agent', expect.objectContaining({
+      auth: expect.objectContaining({
+        clientRole: 'web',
+        relayRole: 'web',
+      }),
+    }))
+    const remoteSocket = connectRemoteSocket()
+    emitRemote(remoteSocket, 'voice.recorded', {
       type: 'voice.recorded',
       interactionId: 'voice-1',
       mimeType: 'audio/wav',
       profile: 'default',
-    }), false)
-    ws.__handlers.get('message')?.(Buffer.from('wav-audio'), true)
+    })
+    emitRemote(remoteSocket, 'voice.stream.chunk', {
+      type: 'voice.stream.chunk',
+      data: Buffer.from('wav-audio').toString('base64'),
+    })
 
     await vi.waitFor(() => {
-      expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"audio.enqueue"'))
+      expect(remoteSocket.emit).toHaveBeenCalledWith('audio.enqueue', expect.any(Object))
     })
-    const enqueuePayload = JSON.parse(
-      ws.send.mock.calls
-        .map(([payload]: [string]) => payload)
-        .find((payload: string) => payload.includes('"audio.enqueue"')),
-    )
+    const enqueuePayload = findEmittedPayload(remoteSocket, 'audio.enqueue')
     expect(enqueuePayload).toMatchObject({
       type: 'audio.enqueue',
       interactionId: 'voice-1',
@@ -170,16 +207,232 @@ describe('outbound relay client', () => {
     })
     expect(enqueuePayload).not.toHaveProperty('completionManagedByServer')
 
-    ws.__handlers.get('message')?.(JSON.stringify({
+    emitRemote(remoteSocket, 'audio.done', {
       type: 'audio.done',
       segmentId: 'voice-1-prompt',
-    }), false)
+    })
     await vi.waitFor(() => {
-      expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"status":"completed"'))
+      expect(remoteSocket.emit).toHaveBeenCalledWith('interaction.status', expect.objectContaining({
+        status: 'completed',
+      }))
     })
   })
 
-  it('queues the hosted TTS-failed prompt when websocket MCU speech synthesis fails', async () => {
+  it('does not reconnect the Socket.IO relay client after it is replaced remotely', async () => {
+    vi.useFakeTimers()
+    try {
+      const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+
+      startOutboundRelayClient({
+        relayUrl: 'http://relay.example.com',
+        relayProtocol: 'mcu-socket.io',
+        userToken: 'user-jwt',
+        deviceCode: 'device-code-1',
+        localBaseUrl: 'http://127.0.0.1:8648',
+        fetchImpl: vi.fn() as any,
+      })
+
+      const remoteSocket = connectRemoteSocket()
+      const localSocket = sockets[1]
+
+      emitRemote(remoteSocket, 'relay.replaced', {
+        type: 'relay.replaced',
+        deviceCode: 'device-code-1',
+        role: 'web',
+      })
+      remoteSocket.__handlers.get('disconnect')?.('io server disconnect')
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      expect(localSocket.disconnect).toHaveBeenCalled()
+      expect(sockets).toHaveLength(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not reconnect the Socket.IO relay client after device-code auth is rejected', async () => {
+    vi.useFakeTimers()
+    try {
+      const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+
+      startOutboundRelayClient({
+        relayUrl: 'http://relay.example.com',
+        relayProtocol: 'mcu-socket.io',
+        deviceCode: 'device-code-1',
+        localBaseUrl: 'http://127.0.0.1:8648',
+        fetchImpl: vi.fn() as any,
+      })
+
+      const remoteSocket = sockets[0]
+      remoteSocket.__handlers.get('connect_error')?.(new Error('非官方设备码'))
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      expect(sockets).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('bridges Socket.IO MCU voice streams to the local global-agent server without completing early', async () => {
+    const fetchImpl = vi.fn()
+    const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+
+    startOutboundRelayClient({
+      relayUrl: 'http://device.local:8787',
+      relayProtocol: 'mcu-socket.io',
+      userToken: 'user-jwt',
+      instanceId: 'mcu-1',
+      deviceCode: 'device-code-1',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: fetchImpl as any,
+    })
+
+    const remoteSocket = connectRemoteSocket()
+    const localGlobalAgentSocket = sockets.at(-1)
+    expect(mockIo).toHaveBeenCalledWith('http://127.0.0.1:8648/global-agent', expect.objectContaining({
+      auth: expect.objectContaining({
+        token: 'user-jwt',
+        role: 'hermes-studio',
+        instanceId: 'mcu-1',
+      }),
+    }))
+
+    emitRemote(remoteSocket, 'voice.stream.start', {
+      type: 'voice.stream.start',
+      interactionId: 'voice-stream-1',
+      sampleRate: 24000,
+      channels: 1,
+      bitsPerSample: 16,
+      profile: 'default',
+    })
+    emitRemote(remoteSocket, 'voice.stream.chunk', {
+      type: 'voice.stream.chunk',
+      data: Buffer.from([1, 2, 3, 4]).toString('base64'),
+    })
+    emitRemote(remoteSocket, 'voice.stream.end', {
+      type: 'voice.stream.end',
+      interactionId: 'voice-stream-1',
+      bytes: 4,
+    })
+
+    expect(localGlobalAgentSocket.emit).toHaveBeenCalledWith('voice.stream.start', expect.objectContaining({
+      type: 'voice.stream.start',
+      interactionId: 'voice-stream-1',
+      profile: 'default',
+    }))
+    expect(localGlobalAgentSocket.emit).toHaveBeenCalledWith('voice.stream.chunk', expect.objectContaining({
+      interactionId: 'voice-stream-1',
+      offset: 0,
+      bytes: 4,
+      data: Buffer.from([1, 2, 3, 4]).toString('base64'),
+    }))
+    expect(localGlobalAgentSocket.emit).toHaveBeenCalledWith('voice.stream.end', expect.objectContaining({
+      type: 'voice.stream.end',
+      interactionId: 'voice-stream-1',
+      bytes: 4,
+    }))
+    expect(fetchImpl).not.toHaveBeenCalledWith(expect.stringContaining('/api/hermes/mcu/voice-turn'), expect.any(Object))
+    expect(remoteSocket.emit).not.toHaveBeenCalledWith('interaction.status', expect.objectContaining({ status: 'completed' }))
+
+    localGlobalAgentSocket.__anyHandlers[0]('interaction.status', {
+      type: 'interaction.status',
+      interactionId: 'voice-stream-1',
+      status: 'thinking',
+      text: '你好',
+    })
+    await vi.waitFor(() => {
+      expect(remoteSocket.emit).toHaveBeenCalledWith('interaction.status', expect.objectContaining({
+        status: 'thinking',
+      }))
+    })
+  })
+
+  it('uploads Socket.IO MCU TTS audio to the remote relay before enqueueing playback', async () => {
+    const pcm = Buffer.from('pcm-audio')
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('/api/hermes/mcu/voice-turn')) {
+        return new Response(JSON.stringify({ ok: true, transcript: '你好' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url.includes('/api/hermes/tts/synthesize')) {
+        return new Response(pcm, {
+          status: 200,
+          headers: { 'content-type': 'audio/x-pcm' },
+        })
+      }
+      if (url === 'http://device.local:8787/global-agent/audio') {
+        return new Response(JSON.stringify({
+          ok: true,
+          url: 'http://device.local:8787/global-agent/audio/audio-1?token=download-token',
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      return new Response(JSON.stringify({ error: 'unexpected url' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      })
+    })
+    const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+
+    startOutboundRelayClient({
+      relayUrl: 'http://device.local:8787',
+      relayProtocol: 'mcu-socket.io',
+      userToken: 'user-jwt',
+      deviceCode: 'device-code-1',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: fetchImpl as any,
+    })
+
+    const remoteSocket = connectRemoteSocket()
+    emitRemote(remoteSocket, 'mcu.auth.ok', {
+      type: 'mcu.auth.ok',
+      audioUpload: {
+        url: '/global-agent/audio',
+        token: 'upload-token',
+      },
+    })
+    emitRemote(remoteSocket, 'voice.recorded', {
+      type: 'voice.recorded',
+      interactionId: 'voice-tts-ok',
+      mimeType: 'audio/wav',
+      profile: 'research',
+    })
+    emitRemote(remoteSocket, 'voice.stream.chunk', {
+      type: 'voice.stream.chunk',
+      data: Buffer.from('wav-audio').toString('base64'),
+    })
+
+    await vi.waitFor(() => {
+      expect(mockIo).toHaveBeenCalledWith('http://127.0.0.1:8648/chat-run', expect.any(Object))
+    })
+    const localSocket = sockets.at(-1)
+    localSocket.__handlers.get('connect')?.()
+    localSocket.__handlers.get('message.delta')?.({ delta: '你好' })
+    localSocket.__handlers.get('run.completed')?.({})
+
+    await vi.waitFor(() => {
+      expect(remoteSocket.emit).toHaveBeenCalledWith('audio.enqueue', expect.objectContaining({
+        url: 'http://device.local:8787/global-agent/audio/audio-1?token=download-token',
+      }))
+    })
+    const uploadCall = fetchImpl.mock.calls.find(([url]: [string]) => url === 'http://device.local:8787/global-agent/audio')
+    expect(uploadCall).toBeTruthy()
+    expect(uploadCall?.[1].headers).toMatchObject({
+      Authorization: 'Bearer upload-token',
+      'Content-Type': 'audio/x-pcm',
+      'X-Device-Code': 'device-code-1',
+      'X-Audio-Sample-Rate': '24000',
+      'X-Audio-Channels': '1',
+    })
+    expect(uploadCall?.[1].body).toBeInstanceOf(Uint8Array)
+    expect(Buffer.from(uploadCall?.[1].body as Uint8Array)).toEqual(pcm)
+  })
+
+  it('queues the hosted TTS-failed prompt when Socket.IO MCU speech synthesis fails', async () => {
     const fetchImpl = vi.fn(async (url: string) => {
       if (url.includes('/api/hermes/mcu/voice-turn')) {
         return new Response(JSON.stringify({ ok: true, transcript: '你好' }), {
@@ -195,22 +448,24 @@ describe('outbound relay client', () => {
     const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
 
     startOutboundRelayClient({
-      relayUrl: 'ws://device.local:8787/',
-      relayProtocol: 'websocket',
+      relayUrl: 'http://device.local:8787/',
+      relayProtocol: 'mcu-socket.io',
       userToken: 'user-jwt',
       localBaseUrl: 'http://127.0.0.1:8648',
       fetchImpl: fetchImpl as any,
     })
 
-    const ws = mockWebSockets[0]
-    ws.__handlers.get('open')?.()
-    ws.__handlers.get('message')?.(JSON.stringify({
+    const remoteSocket = connectRemoteSocket()
+    emitRemote(remoteSocket, 'voice.recorded', {
       type: 'voice.recorded',
       interactionId: 'voice-tts-fail',
       mimeType: 'audio/wav',
       profile: 'research',
-    }), false)
-    ws.__handlers.get('message')?.(Buffer.from('wav-audio'), true)
+    })
+    emitRemote(remoteSocket, 'voice.stream.chunk', {
+      type: 'voice.stream.chunk',
+      data: Buffer.from('wav-audio').toString('base64'),
+    })
 
     await vi.waitFor(() => {
       expect(mockIo).toHaveBeenCalledWith('http://127.0.0.1:8648/chat-run', expect.any(Object))
@@ -221,7 +476,9 @@ describe('outbound relay client', () => {
     localSocket.__handlers.get('run.completed')?.({})
 
     await vi.waitFor(() => {
-      expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('tts-failed-24k.s16le.pcm'))
+      expect(remoteSocket.emit).toHaveBeenCalledWith('audio.enqueue', expect.objectContaining({
+        url: '/api/hermes/mcu/audio/tts-failed-24k.s16le.pcm',
+      }))
     })
     const ttsCalls = fetchImpl.mock.calls.filter(([url]: [string]) => url.includes('/api/hermes/tts/synthesize'))
     expect(ttsCalls).toHaveLength(2)
@@ -231,11 +488,7 @@ describe('outbound relay client', () => {
     expect(ttsCalls[1][1].headers).toMatchObject({
       'X-Hermes-Profile': 'research',
     })
-    const enqueuePayload = JSON.parse(
-      ws.send.mock.calls
-        .map(([payload]: [string]) => payload)
-        .find((payload: string) => payload.includes('tts-failed-24k.s16le.pcm')),
-    )
+    const enqueuePayload = findEmittedPayload(remoteSocket, 'audio.enqueue', payload => payload.url === '/api/hermes/mcu/audio/tts-failed-24k.s16le.pcm')
     expect(enqueuePayload).toMatchObject({
       type: 'audio.enqueue',
       interactionId: 'voice-tts-fail',
@@ -250,7 +503,7 @@ describe('outbound relay client', () => {
     expect(enqueuePayload).not.toHaveProperty('completionManagedByServer')
   })
 
-  it('aborts in-flight websocket MCU TTS synthesis when playback is interrupted', async () => {
+  it('aborts in-flight Socket.IO MCU TTS synthesis when playback is interrupted', async () => {
     let ttsSignal: AbortSignal | undefined
     const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
       if (url.includes('/api/hermes/mcu/voice-turn')) {
@@ -267,22 +520,24 @@ describe('outbound relay client', () => {
     const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
 
     startOutboundRelayClient({
-      relayUrl: 'ws://device.local:8787/',
-      relayProtocol: 'websocket',
+      relayUrl: 'http://device.local:8787/',
+      relayProtocol: 'mcu-socket.io',
       userToken: 'user-jwt',
       localBaseUrl: 'http://127.0.0.1:8648',
       fetchImpl: fetchImpl as any,
     })
 
-    const ws = mockWebSockets[0]
-    ws.__handlers.get('open')?.()
-    ws.__handlers.get('message')?.(JSON.stringify({
+    const remoteSocket = connectRemoteSocket()
+    emitRemote(remoteSocket, 'voice.recorded', {
       type: 'voice.recorded',
       interactionId: 'voice-abort',
       mimeType: 'audio/wav',
       profile: 'research',
-    }), false)
-    ws.__handlers.get('message')?.(Buffer.from('wav-audio'), true)
+    })
+    emitRemote(remoteSocket, 'voice.stream.chunk', {
+      type: 'voice.stream.chunk',
+      data: Buffer.from('wav-audio').toString('base64'),
+    })
 
     await vi.waitFor(() => {
       expect(mockIo).toHaveBeenCalledWith('http://127.0.0.1:8648/chat-run', expect.any(Object))
@@ -296,17 +551,17 @@ describe('outbound relay client', () => {
     })
     expect(ttsSignal?.aborted).toBe(false)
 
-    ws.__handlers.get('message')?.(JSON.stringify({
+    emitRemote(remoteSocket, 'audio.interrupted', {
       type: 'audio.interrupted',
       interactionId: 'voice-abort',
       segmentId: 'voice-abort-tts-1',
-    }), false)
+    })
 
     await vi.waitFor(() => {
       expect(ttsSignal?.aborted).toBe(true)
     })
     expect(localSocket.emit).toHaveBeenCalledWith('abort', { session_id: 'mcu-device-research' })
-    expect(ws.send).not.toHaveBeenCalledWith(expect.stringContaining('"audio.enqueue"'))
+    expect(remoteSocket.emit).not.toHaveBeenCalledWith('audio.enqueue', expect.any(Object))
   })
 
   it('forwards an allowed HTTP request to the local Web UI server', async () => {


### PR DESCRIPTION
## Summary
- Add remote MCU login support with fixed relay configuration and device-code validation.
- Route Web UI remote relay traffic through Socket.IO `/global-agent` instead of the old raw WebSocket path.
- Update ESP32-C3 login/discovery flow for LAN vs remote login, clear login, persisted relay URL, and remote machine discovery.
- Include relay URL in LAN discovery responses and cover the flow with server tests.

## Validation
- `npm run harness:check`
- `npm run test -- tests/server/outbound-relay-client.test.ts tests/server/mcu-login-controller.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `pio run -d packages/esp32-c3/v1`

## Notes
- Remote relay URL is currently fixed to `http://192.168.10.103:8077` per local testing setup.
- Firmware was not reflashed for the last Socket.IO namespace fix because that change is server-side only.