### PR TITLE
[codex] 拆分 Group Chat 房间工作区绑定

### DIFF
--- a/docs/chat-chain-changes/2026-07-06-group-chat-room-workspace.md
+++ b/docs/chat-chain-changes/2026-07-06-group-chat-room-workspace.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-06
+commit: pending
+feature: Group chat room workspace binding
+impact: Group chat rooms can store a validated workspace path, redact it for invite/read-only access, keep management/approval controls limited to room managers, and pass the workspace into room agent bridge runs. This affects room create/clone/detail/list/update flows and agent bridge run options, but does not add workspace-diff message persistence or workspace run lifecycle handling.
+---
+
+This split PR adds the room-level workspace setting and management/access fencing needed before workspace-diff execution can be layered on top. Room agents receive the room workspace in bridge run options when configured; invite-code and read-only views do not expose the path or approval command payloads.

--- a/docs/chat-chain-changes/2026-07-08-pr1980-group-chat-workspace-modal.md
+++ b/docs/chat-chain-changes/2026-07-08-pr1980-group-chat-workspace-modal.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-08
+pr: 1980
+feature: Group chat workspace modal
+impact: Group chat workspace settings use the same fixed-width dialog sizing as single chat without changing room workspace storage or message execution behavior.
+---
+
+The group chat workspace picker modal now uses dialog sizing so desktop layouts do not expand the card to full width. The selected room workspace value and save/clear actions are unchanged.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -471,11 +471,20 @@
                   "account": {
                     "type": "string"
                   },
+                  "device_code": {
+                    "type": "string"
+                  },
                   "id": {
                     "type": "string"
                   },
                   "password": {
                     "type": "string"
+                  },
+                  "relayMode": {
+                    "type": "string"
+                  },
+                  "remote": {
+                    "type": "boolean"
                   },
                   "token": {
                     "type": "string"
@@ -4254,6 +4263,9 @@
                   },
                   "name": {
                     "type": "string"
+                  },
+                  "workspace": {
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -4777,6 +4789,66 @@
                 },
                 "required": [
                   "inviteCode"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hermes/group-chat/rooms/{roomId}/workspace": {
+      "put": {
+        "tags": [
+          "Group Chat"
+        ],
+        "summary": "Update workspace",
+        "description": "PUT /api/hermes/group-chat/rooms/:roomId/workspace",
+        "operationId": "updateWorkspace",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden - Workspace folder is not allowed"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "workspace": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "workspace"
                 ]
               }
             }

--- a/packages/client/src/api/hermes/group-chat.ts
+++ b/packages/client/src/api/hermes/group-chat.ts
@@ -7,10 +7,12 @@ export interface RoomInfo {
     id: string
     name: string
     inviteCode: string | null
+    canManage?: boolean
     triggerTokens?: number
     maxHistoryTokens?: number
     tailMessageCount?: number
     totalTokens?: number
+    workspace: string
 }
 
 export interface RoomAgent {
@@ -127,8 +129,10 @@ function generateUUID(): string {
     })
 }
 
-export function getSocket(): ReturnType<typeof io> | null {
-    return socket?.connected ? socket : null
+export function getSocket(options: { requireConnected?: boolean } = {}): ReturnType<typeof io> | null {
+    if (!socket) return null
+    if (options.requireConnected === false) return socket
+    return socket.connected ? socket : null
 }
 
 export function disconnectGroupChat(): void {
@@ -145,6 +149,7 @@ export async function createRoom(data: {
     inviteCode: string
     agents?: { profile: string; name?: string; description?: string; invited?: boolean }[]
     compression?: { triggerTokens?: number; maxHistoryTokens?: number; tailMessageCount?: number }
+    workspace?: string
 }): Promise<{ room: RoomInfo; agents: RoomAgent[]; agentResults?: AgentAddResult[] }> {
     return request('/api/hermes/group-chat/rooms', {
         method: 'POST',
@@ -228,6 +233,14 @@ export async function updateRoomConfig(roomId: string, config: { triggerTokens?:
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(config),
+    })
+}
+
+export async function updateRoomWorkspace(roomId: string, workspace: string): Promise<{ room: RoomInfo }> {
+    return request(`/api/hermes/group-chat/rooms/${roomId}/workspace`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ workspace }),
     })
 }
 

--- a/packages/client/src/components/hermes/group-chat/CreateRoomForm.vue
+++ b/packages/client/src/components/hermes/group-chat/CreateRoomForm.vue
@@ -3,6 +3,7 @@ import { ref, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { NInput, NButton, NSpace, NInputNumber, NCollapse, NCollapseItem } from 'naive-ui'
 import { getStoredUsername } from '@/api/client'
+import FolderPicker from '@/components/hermes/chat/FolderPicker.vue'
 
 type InputLikeInstance = {
     focus: () => void
@@ -10,12 +11,13 @@ type InputLikeInstance = {
 
 const { t } = useI18n()
 const emit = defineEmits<{
-    submit: [name: string, inviteCode: string, userName: string, description: string, compression: { triggerTokens: number; maxHistoryTokens: number; tailMessageCount: number }]
+    submit: [name: string, inviteCode: string, userName: string, description: string, compression: { triggerTokens: number; maxHistoryTokens: number; tailMessageCount: number }, workspace: string]
     cancel: []
 }>()
 
 const roomName = ref('')
 const inviteCode = ref('')
+const workspace = ref('')
 const userName = ref(localStorage.getItem('gc_user_name') || getStoredUsername() || '')
 const description = ref(localStorage.getItem('gc_user_description') || '')
 const roomInput = ref<InputLikeInstance | null>(null)
@@ -40,7 +42,7 @@ function handleCreate() {
     const code = inviteCode.value.trim() || generateCode()
     const user = userName.value.trim()
     if (!name || !user) return
-    emit('submit', name, code, user, description.value.trim(), { ...compression.value })
+    emit('submit', name, code, user, description.value.trim(), { ...compression.value }, workspace.value || '')
 }
 
 function focusRoomInput() {
@@ -89,6 +91,11 @@ function focusRoomInput() {
                     </svg>
                 </NButton>
             </div>
+        </div>
+
+        <div class="form-group">
+            <label class="form-label">{{ t('chat.workspace') }}</label>
+            <FolderPicker v-model="workspace" />
         </div>
 
         <NCollapse class="compression-collapse">

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -2,18 +2,19 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
-import { useMessage, NInput, NButton, NSpace, NSelect, NPopover, NPopconfirm, NInputNumber, NDropdown, type DropdownOption } from 'naive-ui'
+import { useMessage, NInput, NButton, NSpace, NSelect, NPopover, NPopconfirm, NInputNumber, NDropdown, NModal, type DropdownOption } from 'naive-ui'
 import { useGroupChatStore } from '@/stores/hermes/group-chat'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import { updateRoomConfig, forceCompress } from '@/api/hermes/group-chat'
 import GroupMessageList from './GroupMessageList.vue'
 import GroupChatInput from './GroupChatInput.vue'
+import FolderPicker from '@/components/hermes/chat/FolderPicker.vue'
 import ProfileAvatar from '@/components/hermes/profiles/ProfileAvatar.vue'
 import PageSidebarNav from '@/components/layout/PageSidebarNav.vue'
 import SettingsCircuitBadge from '@/components/layout/SettingsCircuitBadge.vue'
 import { copyToClipboard } from '@/utils/clipboard'
 import type { Attachment } from '@/stores/hermes/chat'
-import type { RoomAgent } from '@/api/hermes/group-chat'
+import type { RoomAgent, RoomInfo } from '@/api/hermes/group-chat'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -56,6 +57,17 @@ function agentAvatarName(agent: RoomAgent): string {
 }
 
 const hasRoom = computed(() => !!store.currentRoomId)
+const currentRoom = computed(() => store.rooms.find(room => room.id === store.currentRoomId) || null)
+const contextRoom = computed(() => store.rooms.find(room => room.id === contextRoomId.value) || null)
+function canManageRoom(room: Pick<RoomInfo, 'canManage'> | null | undefined): boolean {
+    return room?.canManage === true
+}
+const currentRoomCanManage = computed(() => canManageRoom(currentRoom.value))
+const visibleApproval = computed(() => currentRoomCanManage.value ? store.activePendingApproval : null)
+const currentWorkspaceLabel = computed(() => workspaceBasename(currentRoom.value?.workspace || ''))
+const showWorkspaceModal = ref(false)
+const workspaceRoomId = ref<string | null>(null)
+const workspaceValue = ref('')
 
 /** Resolve the current user's custom avatar — first from the member list, then from the cached current-user value. */
 const userMemberAvatar = computed(() => {
@@ -69,11 +81,16 @@ const userMemberAvatar = computed(() => {
     } catch { /* malformed JSON — fall through to multiavatar */ }
     return null
 })
-const visibleApproval = computed(() => store.activePendingApproval)
 
 function formatTokens(tokens: number): string {
     if (tokens >= 1000) return `${(tokens / 1000).toFixed(1)}k tokens`
     return `${tokens} tokens`
+}
+
+function workspaceBasename(path: string): string {
+    const trimmed = String(path || '').trim().replace(/[\\/]+$/, '')
+    if (!trimmed) return ''
+    return trimmed.split(/[\\/]/).pop() || trimmed
 }
 
 function toggleSidebar() {
@@ -157,10 +174,10 @@ function extractApiErrorMessage(err: any): string {
     return raw || t('common.saveFailed')
 }
 
-async function handleCreateRoom(name: string, inviteCode: string, userName: string, description: string, compression: { triggerTokens: number; maxHistoryTokens: number; tailMessageCount: number }) {
+async function handleCreateRoom(name: string, inviteCode: string, userName: string, description: string, compression: { triggerTokens: number; maxHistoryTokens: number; tailMessageCount: number }, workspace: string) {
     try {
         store.setUserInfo(userName, description)
-        const res = await store.createNewRoom(name, inviteCode, undefined, compression)
+        const res = await store.createNewRoom(name, inviteCode, undefined, compression, workspace)
         showCreateModal.value = false
         const failureMessage = formatAgentFailures(res.agentResults)
         if (failureMessage) message.warning(failureMessage)
@@ -172,6 +189,8 @@ async function handleCreateRoom(name: string, inviteCode: string, userName: stri
 }
 
 async function handleDeleteRoom(roomId: string) {
+    const room = store.rooms.find(r => r.id === roomId)
+    if (!canManageRoom(room)) return
     try {
         await store.deleteRoom(roomId)
         if (store.currentRoomId === roomId) {
@@ -194,10 +213,14 @@ async function copyRoomLink(roomId: string) {
     else message.error(t('common.copied') + ' ✗')
 }
 
-const roomContextMenuOptions = computed<DropdownOption[]>(() => [
-    { label: t('groupChat.copyRoomLink'), key: 'copy-link' },
-    { label: t('groupChat.cloneRoom'), key: 'clone-room' },
-])
+const roomContextMenuOptions = computed<DropdownOption[]>(() => {
+    const options: DropdownOption[] = [{ label: t('groupChat.copyRoomLink'), key: 'copy-link' }]
+    if (canManageRoom(contextRoom.value)) {
+        options.push({ label: t('chat.setWorkspace'), key: 'set-workspace' })
+        options.push({ label: t('groupChat.cloneRoom'), key: 'clone-room' })
+    }
+    return options
+})
 
 function handleRoomContextMenu(event: MouseEvent, roomId: string) {
     event.preventDefault()
@@ -217,13 +240,18 @@ function handleRoomContextSelect(key: string) {
     if (!roomId) return
     if (key === 'copy-link') {
         void copyRoomLink(roomId)
+    } else if (key === 'set-workspace') {
+        if (!canManageRoom(contextRoom.value)) return
+        handleOpenWorkspacePicker(roomId)
     } else if (key === 'clone-room') {
+        if (!canManageRoom(contextRoom.value)) return
         handleOpenCloneRoom(roomId)
     }
 }
 
 function handleOpenCloneRoom(roomId: string) {
     const room = store.rooms.find(r => r.id === roomId)
+    if (!canManageRoom(room)) return
     cloneSourceRoomId.value = roomId
     cloneRoomName.value = room?.name ? `${room.name} Copy` : ''
     cloneInviteCode.value = generateCode()
@@ -252,6 +280,7 @@ async function confirmCloneRoom() {
 
 async function handleClearRoomContext() {
     if (!store.currentRoomId) return
+    if (!currentRoomCanManage.value) return
     if (store.contextStatuses.size > 0) {
         message.warning(t('groupChat.compressingInProgress'))
         return
@@ -282,6 +311,7 @@ async function handleSendMessage(content: string, attachments?: Attachment[]) {
 }
 
 async function handleAddAgent() {
+    if (!currentRoomCanManage.value) return
     await profilesStore.fetchProfiles()
     showAddAgentModal.value = true
 }
@@ -323,7 +353,37 @@ async function confirmAddAgent() {
     }
 }
 
+function handleOpenWorkspacePicker(roomId = store.currentRoomId || '') {
+    if (!roomId) return
+    const room = store.rooms.find(r => r.id === roomId)
+    if (!canManageRoom(room)) return
+    workspaceRoomId.value = roomId
+    workspaceValue.value = room?.workspace || ''
+    showWorkspaceModal.value = true
+}
+
+async function handleSaveWorkspace() {
+    const roomId = workspaceRoomId.value || store.currentRoomId
+    if (!roomId) return
+    const room = store.rooms.find(r => r.id === roomId)
+    if (!canManageRoom(room)) return
+    try {
+        await store.setRoomWorkspace(roomId, String(workspaceValue.value || '').trim())
+        showWorkspaceModal.value = false
+        workspaceRoomId.value = null
+        message.success(t('chat.workspaceSet'))
+    } catch (err: any) {
+        message.error(err?.message || t('chat.workspaceSetFailed'))
+    }
+}
+
+async function handleClearWorkspace() {
+    workspaceValue.value = ''
+    await handleSaveWorkspace()
+}
+
 function handleOpenCompressionConfig() {
+    if (!currentRoomCanManage.value) return
     const room = store.rooms.find(r => r.id === store.currentRoomId)
     if (room) {
         compressionConfig.value = {
@@ -337,6 +397,7 @@ function handleOpenCompressionConfig() {
 
 async function handleSaveCompressionConfig() {
     if (!store.currentRoomId) return
+    if (!currentRoomCanManage.value) return
     try {
         const res = await updateRoomConfig(store.currentRoomId, { ...compressionConfig.value })
         const idx = store.rooms.findIndex(r => r.id === store.currentRoomId)
@@ -350,6 +411,7 @@ async function handleSaveCompressionConfig() {
 
 async function handleForceCompress() {
     if (!store.currentRoomId || isCompressing.value) return
+    if (!currentRoomCanManage.value) return
     if (store.contextStatuses.size > 0) {
         message.warning(t('groupChat.compressingInProgress'))
         return
@@ -367,6 +429,7 @@ async function handleForceCompress() {
 
 async function handleRemoveAgent(agentId: string) {
     if (!store.currentRoomId) return
+    if (!currentRoomCanManage.value) return
     try {
         await store.removeAgentFromRoom(store.currentRoomId, agentId)
     } catch {
@@ -375,6 +438,7 @@ async function handleRemoveAgent(agentId: string) {
 }
 
 async function handleInterruptAgent(agentName: string) {
+    if (!currentRoomCanManage.value) return
     try {
         await store.interruptAgent(agentName)
     } catch (err: any) {
@@ -383,6 +447,7 @@ async function handleInterruptAgent(agentName: string) {
 }
 
 async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
+    if (!currentRoomCanManage.value) return
     try {
         await store.respondApproval(choice)
     } catch (err: any) {
@@ -422,7 +487,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                         <span v-if="room.inviteCode" class="room-code">{{ room.inviteCode }}</span>
                         <span class="room-tokens">{{ formatTokens(room.totalTokens || 0) }}</span>
                     </div>
-                    <NPopconfirm @positive-click="handleDeleteRoom(room.id)">
+                    <NPopconfirm v-if="canManageRoom(room)" @positive-click="handleDeleteRoom(room.id)">
                         <template #trigger>
                             <button class="room-action-btn danger" @click.stop>
                                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
@@ -461,19 +526,32 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
         <!-- Main chat area -->
         <div
             class="chat-main"
-            :class="{ 'chat-main--drop-active': isChatDropActive }"
             @dragover="handleChatDragOver"
             @dragenter="handleChatDragEnter"
             @dragleave="handleChatDragLeave"
             @drop="handleChatDrop"
         >
             <div class="chat-header">
-                <button class="icon-btn header-sidebar-toggle" @click="toggleSidebar">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                        <rect x="3" y="3" width="18" height="18" rx="2" ry="2" /><line x1="9" y1="3" x2="9" y2="21" />
-                    </svg>
-                </button>
-                <span class="room-title-text">{{ store.roomName || (store.currentRoomId || t('groupChat.title')) }}</span>
+                <div class="header-left">
+                    <button class="icon-btn header-sidebar-toggle" @click="toggleSidebar">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" /><line x1="9" y1="3" x2="9" y2="21" />
+                        </svg>
+                    </button>
+                    <span class="room-title-text">{{ store.roomName || (store.currentRoomId || t('groupChat.title')) }}</span>
+                    <button
+                        v-if="currentRoom?.workspace"
+                        class="workspace-badge"
+                        type="button"
+                        :title="currentRoom.workspace"
+                        @click="() => handleOpenWorkspacePicker()"
+                    >
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+                        </svg>
+                        <span>{{ currentWorkspaceLabel }}</span>
+                    </button>
+                </div>
                 <div class="header-info">
                     <!-- Stacked avatars (user + agents) -->
                     <NPopover v-if="store.agents.length" trigger="click" placement="bottom-end" :width="220">
@@ -509,7 +587,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                                     <span class="agent-popover-name">{{ agent.name }}</span>
                                     <span class="agent-popover-profile">{{ agent.profile }}</span>
                                 </div>
-                                <button class="agent-popover-remove" @click="handleRemoveAgent(agent.id)">
+                                <button v-if="currentRoomCanManage" class="agent-popover-remove" @click="handleRemoveAgent(agent.id)">
                                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
                                 </button>
                             </div>
@@ -521,13 +599,13 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                             <ProfileAvatar class="agent-avatar" :name="store.userName || store.userId" :avatar="userMemberAvatar" :size="24" />
                         </span>
                     </div>
-                    <button class="icon-btn" :title="t('groupChat.addAgent')" @click="handleAddAgent">
+                    <button v-if="currentRoomCanManage" class="icon-btn" :title="t('groupChat.addAgent')" @click="handleAddAgent">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                     </button>
-                    <button class="icon-btn" :title="t('groupChat.compressionConfig')" @click="handleOpenCompressionConfig">
+                    <button v-if="currentRoomCanManage" class="icon-btn" :title="t('groupChat.compressionConfig')" @click="handleOpenCompressionConfig">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 4.6a1.65 1.65 0 0 0 1.51 1V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1.51 1z"/></svg>
                     </button>
-                    <NPopconfirm @positive-click="handleClearRoomContext">
+                    <NPopconfirm v-if="currentRoomCanManage" @positive-click="handleClearRoomContext">
                         <template #trigger>
                             <button class="icon-btn" :title="t('groupChat.clearContext')">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -544,73 +622,79 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                 </div>
             </div>
 
-            <div v-if="hasRoom" class="group-chat-surface">
-                <div class="group-message-shell">
-                    <GroupMessageList />
-                    <Transition name="approval-float">
-                        <div v-if="visibleApproval" class="approval-float-panel">
-                            <div class="approval-float-header">
-                                <span class="approval-float-icon" aria-hidden="true">
-                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10" />
-                                        <path d="m9 12 2 2 4-4" />
-                                    </svg>
+            <div
+                v-if="hasRoom"
+                class="group-chat-content-wrapper"
+                :class="{ 'chat-main--drop-active': isChatDropActive }"
+            >
+                <div class="group-chat-surface">
+                    <div class="group-message-shell">
+                        <GroupMessageList />
+                        <Transition name="approval-float">
+                            <div v-if="visibleApproval" class="approval-float-panel">
+                                <div class="approval-float-header">
+                                    <span class="approval-float-icon" aria-hidden="true">
+                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10" />
+                                            <path d="m9 12 2 2 4-4" />
+                                        </svg>
+                                    </span>
+                                    <span>{{ t('chat.approvalKicker') }}</span>
+                                </div>
+                                <div class="approval-float-title">
+                                    <span v-if="visibleApproval.agentName">@{{ visibleApproval.agentName }} · </span>{{ t('chat.approvalTitle') }}
+                                </div>
+                                <div class="approval-float-desc">{{ visibleApproval.description }}</div>
+                                <code class="approval-float-command">{{ visibleApproval.command }}</code>
+                                <div class="approval-float-actions">
+                                    <NButton v-if="visibleApproval.isMemoryWrite" size="small" type="primary" @click="handleApproval('once')">
+                                        {{ t('chat.approvalAgree') }}
+                                    </NButton>
+                                    <NButton v-if="!visibleApproval.isMemoryWrite && visibleApproval.choices.includes('once')" size="small" type="primary" @click="handleApproval('once')">
+                                        {{ t('chat.approvalAllowOnce') }}
+                                    </NButton>
+                                    <NButton v-if="!visibleApproval.isMemoryWrite && visibleApproval.choices.includes('session')" size="small" secondary @click="handleApproval('session')">
+                                        {{ t('chat.approvalAllowSession') }}
+                                    </NButton>
+                                    <NButton v-if="!visibleApproval.isMemoryWrite && visibleApproval.choices.includes('always')" size="small" secondary @click="handleApproval('always')">
+                                        {{ t('chat.approvalAlways') }}
+                                    </NButton>
+                                    <NButton v-if="visibleApproval.isMemoryWrite || visibleApproval.choices.includes('deny')" size="small" type="error" secondary @click="handleApproval('deny')">
+                                        {{ t('chat.approvalDeny') }}
+                                    </NButton>
+                                </div>
+                            </div>
+                        </Transition>
+                    </div>
+                    <div v-if="store.contextStatuses.size > 0 || (store.typingText && store.contextStatuses.size === 0)" class="status-bar">
+                        <div v-if="store.contextStatuses.size > 0" class="context-status-list">
+                            <div v-for="[name, status] in store.contextStatuses" :key="name" class="context-status">
+                                <span class="typing-dots">
+                                    <span /><span /><span />
                                 </span>
-                                <span>{{ t('chat.approvalKicker') }}</span>
-                            </div>
-                            <div class="approval-float-title">
-                                <span v-if="visibleApproval.agentName">@{{ visibleApproval.agentName }} · </span>{{ t('chat.approvalTitle') }}
-                            </div>
-                            <div class="approval-float-desc">{{ visibleApproval.description }}</div>
-                            <code class="approval-float-command">{{ visibleApproval.command }}</code>
-                            <div class="approval-float-actions">
-                                <NButton v-if="visibleApproval.isMemoryWrite" size="small" type="primary" @click="handleApproval('once')">
-                                    {{ t('chat.approvalAgree') }}
-                                </NButton>
-                                <NButton v-if="!visibleApproval.isMemoryWrite && visibleApproval.choices.includes('once')" size="small" type="primary" @click="handleApproval('once')">
-                                    {{ t('chat.approvalAllowOnce') }}
-                                </NButton>
-                                <NButton v-if="!visibleApproval.isMemoryWrite && visibleApproval.choices.includes('session')" size="small" secondary @click="handleApproval('session')">
-                                    {{ t('chat.approvalAllowSession') }}
-                                </NButton>
-                                <NButton v-if="!visibleApproval.isMemoryWrite && visibleApproval.choices.includes('always')" size="small" secondary @click="handleApproval('always')">
-                                    {{ t('chat.approvalAlways') }}
-                                </NButton>
-                                <NButton v-if="visibleApproval.isMemoryWrite || visibleApproval.choices.includes('deny')" size="small" type="error" secondary @click="handleApproval('deny')">
-                                    {{ t('chat.approvalDeny') }}
-                                </NButton>
+                                <span v-if="status.status === 'compressing'">
+                                    @{{ status.agentName }} {{ t('groupChat.agentCompressing') }}
+                                </span>
+                                <span v-else>
+                                    @{{ status.agentName }} {{ t('groupChat.agentReplying') }}
+                                </span>
+                                <button v-if="currentRoomCanManage" class="context-stop-btn" :title="t('common.cancel')" @click="handleInterruptAgent(status.agentName)">
+                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+                                        <line x1="18" y1="6" x2="6" y2="18" />
+                                        <line x1="6" y1="6" x2="18" y2="18" />
+                                    </svg>
+                                </button>
                             </div>
                         </div>
-                    </Transition>
-                </div>
-                <div v-if="store.contextStatuses.size > 0 || (store.typingText && store.contextStatuses.size === 0)" class="status-bar">
-                    <div v-if="store.contextStatuses.size > 0" class="context-status-list">
-                        <div v-for="[name, status] in store.contextStatuses" :key="name" class="context-status">
+                        <div v-else-if="store.typingText" class="typing-indicator">
                             <span class="typing-dots">
                                 <span /><span /><span />
                             </span>
-                            <span v-if="status.status === 'compressing'">
-                                @{{ status.agentName }} {{ t('groupChat.agentCompressing') }}
-                            </span>
-                            <span v-else>
-                                @{{ status.agentName }} {{ t('groupChat.agentReplying') }}
-                            </span>
-                            <button class="context-stop-btn" :title="t('common.cancel')" @click="handleInterruptAgent(status.agentName)">
-                                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
-                                    <line x1="18" y1="6" x2="6" y2="18" />
-                                    <line x1="6" y1="6" x2="18" y2="18" />
-                                </svg>
-                            </button>
+                            {{ store.typingText }}
                         </div>
                     </div>
-                    <div v-else-if="store.typingText" class="typing-indicator">
-                        <span class="typing-dots">
-                            <span /><span /><span />
-                        </span>
-                        {{ store.typingText }}
-                    </div>
+                    <GroupChatInput ref="groupChatInputRef" @send="handleSendMessage" />
                 </div>
-                <GroupChatInput ref="groupChatInputRef" @send="handleSendMessage" />
             </div>
 
             <div v-else class="no-room">
@@ -703,6 +787,16 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                     </div>
                 </div>
             </div>
+            <NModal v-model:show="showWorkspaceModal" preset="card" :title="t('chat.setWorkspaceTitle')" class="workspace-modal">
+                <FolderPicker v-model="workspaceValue" />
+                <template #footer>
+                    <NSpace justify="end">
+                        <NButton @click="showWorkspaceModal = false">{{ t('common.cancel') }}</NButton>
+                        <NButton @click="handleClearWorkspace">{{ t('workflow.workspace.clear') }}</NButton>
+                        <NButton type="primary" @click="handleSaveWorkspace">{{ t('common.save') }}</NButton>
+                    </NSpace>
+                </template>
+            </NModal>
             <div v-if="showCompressionModal" class="modal-backdrop" @click.self="showCompressionModal = false">
                 <div class="modal">
                     <h3>{{ t('groupChat.compressionConfig') }}</h3>
@@ -740,6 +834,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                 </div>
             </div>
         </Teleport>
+
     </div>
 </template>
 
@@ -1231,6 +1326,16 @@ export default defineComponent({ components: { CreateRoomForm } })
     position: relative;
 }
 
+.group-chat-content-wrapper {
+    flex: 1;
+    display: flex;
+    overflow: hidden;
+    position: relative;
+    min-width: 0;
+    min-height: 0;
+    max-width: 100%;
+}
+
 .group-chat-surface {
     flex: 1;
     min-height: 0;
@@ -1290,14 +1395,23 @@ export default defineComponent({ components: { CreateRoomForm } })
         margin-left: -10px;
     }
 
+    .header-left {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        overflow: hidden;
+        flex: 1;
+        min-width: 0;
+    }
+
     .room-title-text {
         font-size: 16px;
         font-weight: 600;
         color: $text-primary;
-        flex: 1;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        min-width: 0;
     }
 
     .header-info {
@@ -1305,6 +1419,39 @@ export default defineComponent({ components: { CreateRoomForm } })
         align-items: center;
         gap: 8px;
         flex-shrink: 0;
+    }
+
+    .workspace-badge {
+        border: 0;
+        font-size: 11px;
+        line-height: 16px;
+        color: $text-muted;
+        background: rgba(255, 255, 255, 0.05);
+        padding: 2px 8px;
+        border-radius: 4px;
+        max-width: 160px;
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        overflow: hidden;
+        cursor: pointer;
+        flex-shrink: 0;
+
+        svg {
+            flex: 0 0 auto;
+        }
+
+        span {
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        &:hover {
+            color: $text-secondary;
+            background: rgba(var(--accent-primary-rgb), 0.06);
+        }
     }
 
     .member-count {

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -787,9 +787,15 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                     </div>
                 </div>
             </div>
-            <NModal v-model:show="showWorkspaceModal" preset="card" :title="t('chat.setWorkspaceTitle')" class="workspace-modal">
+            <NModal
+                v-model:show="showWorkspaceModal"
+                preset="dialog"
+                :title="t('chat.setWorkspaceTitle')"
+                class="workspace-modal"
+                style="width: 520px; max-width: 92vw"
+            >
                 <FolderPicker v-model="workspaceValue" />
-                <template #footer>
+                <template #action>
                     <NSpace justify="end">
                         <NButton @click="showWorkspaceModal = false">{{ t('common.cancel') }}</NButton>
                         <NButton @click="handleClearWorkspace">{{ t('workflow.workspace.clear') }}</NButton>

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -25,7 +25,10 @@ import {
     cloneRoom as cloneRoomApi,
     deleteRoom as deleteRoomApi,
     clearRoomContext,
+    updateRoomWorkspace as updateRoomWorkspaceApi,
 } from '@/api/hermes/group-chat'
+
+type GroupChatSocket = ReturnType<typeof connectGroupChat>
 
 async function uploadGroupFiles(attachments: Attachment[]): Promise<{ name: string; path: string }[]> {
     const formData = new FormData()
@@ -217,6 +220,13 @@ const currentUserAvatar = ref('')
     const userId = ref(getStoredUserId())
     const userName = ref(getStoredGroupUserName() || getStoredUsername() || '')
 
+    function upsertRoom(room: RoomInfo | undefined | null) {
+        if (!room) return
+        const idx = rooms.value.findIndex(existing => existing.id === room.id)
+        if (idx >= 0) rooms.value[idx] = room
+        else rooms.value.push(room)
+    }
+
     function applyRealtimeJoinState(res: any, options: { syncMessages?: boolean } = {}) {
         members.value = res.members || []
         if (res.agents) agents.value = res.agents
@@ -260,14 +270,50 @@ const currentUserAvatar = ref('')
         }
     }
 
-    async function joinRealtimeRoom(roomId: string, options: { syncMessages?: boolean } = {}) {
-        const socket = getSocket()
-        if (!socket) return
+    async function waitForRealtimeSocket(socket: GroupChatSocket): Promise<void> {
+        if (socket.connected) return
+        await new Promise<void>((resolve, reject) => {
+            let settled = false
+            let timeout: ReturnType<typeof setTimeout> | null = null
+            const cleanup = () => {
+                if (timeout) clearTimeout(timeout)
+                socket.off?.('connect', onConnect)
+                socket.off?.('connect_error', onError)
+            }
+            const finish = (fn: () => void) => {
+                if (settled) return
+                settled = true
+                cleanup()
+                fn()
+            }
+            const onConnect = () => finish(resolve)
+            const onError = (err: Error) => finish(() => reject(err))
+            timeout = setTimeout(() => finish(() => reject(new Error('Group chat socket connection timed out'))), 30000)
+            socket.once('connect', onConnect)
+            socket.once('connect_error', onError)
+        })
+    }
+
+    async function ensureRealtimeSocket(): Promise<GroupChatSocket> {
+        let socket = getSocket()
+        if (socket) return socket
+        await connect()
+        socket = getSocket({ requireConnected: false })
+        if (!socket) throw new Error('Group chat socket not connected')
+        await waitForRealtimeSocket(socket)
+        const connectedSocket = getSocket()
+        if (!connectedSocket) throw new Error('Group chat socket not connected')
+        return connectedSocket
+    }
+
+    async function joinRealtimeRoom(roomId: string, options: { syncMessages?: boolean; inviteCode?: string } = {}) {
+        const socket = await ensureRealtimeSocket()
         const storedName = getStoredGroupUserName()
 
         await new Promise<void>((resolve) => {
             socket.emit('join', {
                 roomId,
+                inviteCode: options.inviteCode,
                 name: storedName || undefined,
                 description: localStorage.getItem('gc_user_description') || undefined,
             }, (res: any) => {
@@ -571,6 +617,7 @@ const currentUserAvatar = ref('')
 
         try {
             const res = await getRoomDetail(roomId)
+            upsertRoom(res.room)
             currentRoomId.value = res.room.id
             roomName.value = res.room.name
             messages.value = res.messages
@@ -660,15 +707,16 @@ const currentUserAvatar = ref('')
         }
     }
 
-    async function createNewRoom(name: string, inviteCode: string, agentList?: { profile: string; name?: string; description?: string; invited?: boolean }[], compression?: { triggerTokens: number; maxHistoryTokens: number; tailMessageCount: number }) {
+    async function createNewRoom(name: string, inviteCode: string, agentList?: { profile: string; name?: string; description?: string; invited?: boolean }[], compression?: { triggerTokens: number; maxHistoryTokens: number; tailMessageCount: number }, workspace?: string) {
         try {
             const res = await createRoom({
                 name,
                 inviteCode,
                 agents: agentList,
                 compression: compression || { triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10 },
+                workspace: workspace || undefined,
             })
-            rooms.value.push(res.room)
+            upsertRoom(res.room)
             return res
         } catch (err: any) {
             error.value = err.message
@@ -679,6 +727,11 @@ const currentUserAvatar = ref('')
     async function joinByCode(code: string) {
         try {
             const res = await joinRoomByCode(code)
+            upsertRoom(res.room)
+            await ensureRealtimeSocket()
+            currentRoomId.value = res.room.id
+            roomName.value = res.room.name
+            await joinRealtimeRoom(res.room.id, { syncMessages: true, inviteCode: code })
             await joinRoom(res.room.id)
             return res.room
         } catch (err: any) {
@@ -708,7 +761,7 @@ const currentUserAvatar = ref('')
     async function cloneRoom(roomId: string, data?: { name?: string; inviteCode?: string }) {
         try {
             const res = await cloneRoomApi(roomId, data)
-            rooms.value.push(res.room)
+            upsertRoom(res.room)
             return res
         } catch (err: any) {
             error.value = err.message
@@ -727,6 +780,20 @@ const currentUserAvatar = ref('')
             const idx = rooms.value.findIndex(r => r.id === currentRoomId.value)
             if (idx >= 0 && res.room) rooms.value[idx] = res.room
             return res
+        } catch (err: any) {
+            error.value = err.message
+            throw err
+        }
+    }
+
+    async function setRoomWorkspace(roomId: string, workspace: string) {
+        try {
+            const res = await updateRoomWorkspaceApi(roomId, workspace)
+            if (res.room) {
+                upsertRoom(res.room)
+                if (currentRoomId.value === roomId) roomName.value = res.room.name
+            }
+            return res.room
         } catch (err: any) {
             error.value = err.message
             throw err
@@ -857,6 +924,7 @@ const currentUserAvatar = ref('')
         deleteRoom,
         cloneRoom,
         clearCurrentRoomContext,
+        setRoomWorkspace,
         loadAgents,
         addAgentToRoom,
         removeAgentFromRoom,
@@ -882,6 +950,7 @@ function runtimePayloadText(value: unknown): string {
     }
     return String(value)
 }
+
 
 function mapGroupMessages(msgs: ChatMessage[]): ChatMessage[] {
     const toolNameMap = new Map<string, string>()
@@ -929,6 +998,7 @@ function mapGroupMessages(msgs: ChatMessage[]): ChatMessage[] {
             const toolName = msg.tool_name || toolNameMap.get(tcId) || undefined
             const toolArgs = toolArgsMap.has(tcId) ? toolArgsMap.get(tcId) : undefined
             let preview = ''
+            const toolResult = runtimeToolPayloadOrUndefined((msg as any).content)
             const contentText = runtimePayloadText((msg as any).content)
             if (contentText) {
                 try {
@@ -955,7 +1025,7 @@ function mapGroupMessages(msgs: ChatMessage[]): ChatMessage[] {
                 toolCallId: tcId || undefined,
                 toolArgs: toolArgs !== undefined ? toolArgs : (placeholderIdx !== -1 ? result[placeholderIdx].toolArgs : undefined),
                 toolPreview: typeof preview === 'string' ? preview.slice(0, 100) || undefined : undefined,
-                toolResult: runtimeToolPayloadOrUndefined((msg as any).content),
+                toolResult,
                 toolStatus: 'done',
             }
             if (placeholderIdx !== -1) result[placeholderIdx] = merged

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -430,6 +430,8 @@ export const GC_ROOMS_SCHEMA: Record<string, string> = {
   tailMessageCount: 'INTEGER NOT NULL DEFAULT 10',
   totalTokens: 'INTEGER NOT NULL DEFAULT 0',
   sessionSeed: "TEXT NOT NULL DEFAULT '0'",
+  workspace: "TEXT NOT NULL DEFAULT ''",
+  ownerAuthUserId: 'INTEGER',
 }
 
 export const GC_MESSAGES_TABLE = 'gc_messages'

--- a/packages/server/src/routes/hermes/group-chat.ts
+++ b/packages/server/src/routes/hermes/group-chat.ts
@@ -1,6 +1,7 @@
 import Router from '@koa/router'
 import type { GroupChatServer } from '../../services/hermes/group-chat'
 import { isReservedMentionName } from '../../services/hermes/group-chat/mention-routing'
+import { assertAllowedWorkspaceFolder } from '../../services/hermes/workspace-path'
 
 export const groupChatRoutes = new Router()
 
@@ -46,6 +47,72 @@ function agentConnectFailureBody(profile: string, err: any) {
     }
 }
 
+function userProfiles(user: any): string[] {
+    return Array.isArray(user?.profiles) ? user.profiles.map(String).filter(Boolean) : []
+}
+
+function isRoomOwner(room: any, user: any): boolean {
+    return typeof user?.id === 'number' && Number(room?.ownerAuthUserId || 0) === user.id
+}
+
+function hasProfileRoomAccess(storage: ReturnType<GroupChatServer['getStorage']>, roomId: string, user: any): boolean {
+    const profiles = userProfiles(user)
+    if (!profiles.length || typeof storage.getRoomsForProfiles !== 'function') return false
+    return storage.getRoomsForProfiles(profiles).some(room => room.id === roomId)
+}
+
+function canManageRoom(storage: ReturnType<GroupChatServer['getStorage']>, roomId: string, user: any): boolean {
+    if (!user || user.role === 'super_admin') return true
+    const room = typeof storage.getRoom === 'function' ? storage.getRoom(roomId) : null
+    if (room && isRoomOwner(room, user)) return true
+    return hasProfileRoomAccess(storage, roomId, user)
+}
+
+function canReadRoom(storage: ReturnType<GroupChatServer['getStorage']>, roomId: string, user: any): boolean {
+    if (canManageRoom(storage, roomId, user)) return true
+    return typeof user?.id === 'number' && typeof storage.getMemberByAuthUserId === 'function' && !!storage.getMemberByAuthUserId(roomId, user.id)
+}
+
+function serializeRoom(room: any, includeManageFields: boolean) {
+    if (!room) return room
+    const { ownerAuthUserId: _ownerAuthUserId, ...rest } = room
+    const serialized = { ...rest, canManage: includeManageFields }
+    if (Object.prototype.hasOwnProperty.call(room, 'inviteCode')) {
+        serialized.inviteCode = includeManageFields ? room.inviteCode ?? null : null
+    }
+    if (Object.prototype.hasOwnProperty.call(room, 'workspace')) {
+        serialized.workspace = includeManageFields ? String(room.workspace || '') : ''
+    }
+    return serialized
+}
+
+function persistRoomCreator(storage: ReturnType<GroupChatServer['getStorage']>, roomId: string, user: any): void {
+    if (typeof user?.id !== 'number' || user.id <= 0) return
+    storage.setRoomOwnerAuthUserId?.(roomId, user.id)
+    const username = String(user.username || `User-${user.id}`)
+    storage.addRoomMember(roomId, `auth:${user.id}`, username, '', '', user.id)
+}
+
+function visibleRoomsForUser(storage: ReturnType<GroupChatServer['getStorage']>, user: any) {
+    if (!user || user.role === 'super_admin') return storage.getAllRooms().map(room => serializeRoom(room, true))
+    const byId = new Map<string, any>()
+    const addRoom = (room: any, includeWorkspace: boolean) => {
+        if (!room) return
+        if (byId.has(room.id) && includeWorkspace) byId.set(room.id, serializeRoom(room, true))
+        else if (!byId.has(room.id)) byId.set(room.id, serializeRoom(room, includeWorkspace))
+    }
+    for (const room of storage.getRoomsForProfiles(userProfiles(user))) addRoom(room, true)
+    if (typeof user.id === 'number') {
+        if (typeof storage.getOwnedRoomsForAuthUser === 'function') {
+            for (const room of storage.getOwnedRoomsForAuthUser(user.id)) addRoom(room, true)
+        }
+        if (typeof storage.getRoomsForAuthUser === 'function') {
+            for (const room of storage.getRoomsForAuthUser(user.id)) addRoom(room, canManageRoom(storage, room.id, user))
+        }
+    }
+    return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id))
+}
+
 async function connectAndPersistRoomAgent(server: GroupChatServer, roomId: string, input: AgentInput, agentId = generateId()) {
     const profile = input.profile
     const name = input.name || profile
@@ -59,10 +126,15 @@ async function connectAndPersistRoomAgent(server: GroupChatServer, roomId: strin
         invited,
     })
 
+    const storage = server.getStorage()
+    let persisted: any
     try {
+        persisted = storage.addRoomAgent(roomId, agentId, profile, name, description, invited)
         await server.agentClients.addAgentToRoom(roomId, client)
-        return server.getStorage().addRoomAgent(roomId, agentId, profile, name, description, invited)
+        return persisted
     } catch (err) {
+        if (persisted) storage.removeRoomAgent(roomId, persisted.id || agentId)
+        else client.disconnect?.()
         server.agentClients.removeAgentFromRoom(roomId, client.agentId)
         throw err
     }
@@ -76,11 +148,12 @@ groupChatRoutes.post('/api/hermes/group-chat/rooms', async (ctx) => {
         return
     }
 
-    const { name, inviteCode, agents, compression } = ctx.request.body as {
+    const { name, inviteCode, agents, compression, workspace } = ctx.request.body as {
         name?: string
         inviteCode?: string
         agents?: { profile: string; name?: string; description?: string; invited?: boolean }[]
         compression?: { triggerTokens?: number; maxHistoryTokens?: number; tailMessageCount?: number }
+        workspace?: string
     }
     if (!name || !inviteCode) {
         ctx.status = 400
@@ -96,7 +169,32 @@ groupChatRoutes.post('/api/hermes/group-chat/rooms', async (ctx) => {
 
     const roomId = generateId()
     const storage = chatServer.getStorage()
-    storage.saveRoom(roomId, name, inviteCode, compression)
+    let normalizedWorkspace = ''
+    if (workspace !== undefined) {
+        if (typeof workspace !== 'string') {
+            ctx.status = 400
+            ctx.body = { error: 'workspace must be a string' }
+            return
+        }
+        const rawWorkspace = workspace.trim()
+        if (rawWorkspace) {
+            try {
+                normalizedWorkspace = (await assertAllowedWorkspaceFolder(rawWorkspace)).fullPath
+            } catch (err: any) {
+                ctx.status = Number(err?.status || 403)
+                ctx.body = { error: err?.message || 'Workspace folder is not allowed' }
+                return
+            }
+        }
+    }
+    const compressionConfig = compression ? {
+        triggerTokens: compression.triggerTokens,
+        maxHistoryTokens: compression.maxHistoryTokens,
+        tailMessageCount: compression.tailMessageCount,
+        workspace: normalizedWorkspace,
+    } : { workspace: normalizedWorkspace }
+    storage.saveRoom(roomId, name, inviteCode, compressionConfig)
+    persistRoomCreator(storage, roomId, ctx.state?.user)
 
     const addedAgents = []
     const agentResults = []
@@ -117,7 +215,7 @@ groupChatRoutes.post('/api/hermes/group-chat/rooms', async (ctx) => {
     }
 
     const room = storage.getRoom(roomId)
-    ctx.body = { room, agents: addedAgents, agentResults }
+    ctx.body = { room: serializeRoom(room, true), agents: addedAgents, agentResults }
 })
 
 // Clone room roles/config without copying the conversation context.
@@ -128,22 +226,29 @@ groupChatRoutes.post('/api/hermes/group-chat/rooms/:roomId/clone', async (ctx) =
         return
     }
 
-    const sourceRoom = chatServer.getStorage().getRoom(ctx.params.roomId)
+    const storage = chatServer.getStorage()
+    const sourceRoom = storage.getRoom(ctx.params.roomId)
     if (!sourceRoom) {
         ctx.status = 404
         ctx.body = { error: 'Room not found' }
         return
     }
+    if (!canManageRoom(storage, sourceRoom.id, ctx.state?.user)) {
+        ctx.status = 403
+        ctx.body = { error: 'Access denied' }
+        return
+    }
 
     const { name, inviteCode } = ctx.request.body as { name?: string; inviteCode?: string }
     const roomId = generateId()
-    const storage = chatServer.getStorage()
     const code = inviteCode?.trim() || generateInviteCode()
     storage.saveRoom(roomId, name?.trim() || `${sourceRoom.name} Copy`, code, {
         triggerTokens: sourceRoom.triggerTokens,
         maxHistoryTokens: sourceRoom.maxHistoryTokens,
         tailMessageCount: sourceRoom.tailMessageCount,
+        workspace: sourceRoom.workspace || '',
     })
+    persistRoomCreator(storage, roomId, ctx.state?.user)
 
     const addedAgents = []
     const agentResults = []
@@ -164,7 +269,7 @@ groupChatRoutes.post('/api/hermes/group-chat/rooms/:roomId/clone', async (ctx) =
     }
 
     const room = storage.getRoom(roomId)
-    ctx.body = { room, agents: addedAgents, agentResults }
+    ctx.body = { room: serializeRoom(room, true), agents: addedAgents, agentResults }
 })
 
 // Get room detail and messages
@@ -175,20 +280,27 @@ groupChatRoutes.get('/api/hermes/group-chat/rooms/:roomId', async (ctx) => {
         return
     }
 
-    const room = chatServer.getStorage().getRoom(ctx.params.roomId)
+    const storage = chatServer.getStorage()
+    const room = storage.getRoom(ctx.params.roomId)
     if (!room) {
         ctx.status = 404
         ctx.body = { error: 'Room not found' }
         return
     }
+    const canManage = canManageRoom(storage, room.id, ctx.state?.user)
+    if (!canManage && !canReadRoom(storage, room.id, ctx.state?.user)) {
+        ctx.status = 403
+        ctx.body = { error: 'Access denied' }
+        return
+    }
 
     const offset = ctx.query.offset ? Math.max(0, parseInt(ctx.query.offset as string, 10) || 0) : 0
     const limit = ctx.query.limit ? Math.max(1, parseInt(ctx.query.limit as string, 10) || 150) : 150
-    const messages = chatServer.getStorage().getRecentMessagesForUI(ctx.params.roomId, limit, offset)
-    const total = chatServer.getStorage().getMessageCount(ctx.params.roomId)
-    const agents = chatServer.getStorage().getRoomAgents(ctx.params.roomId)
-    const members = chatServer.getStorage().getRoomMembers(ctx.params.roomId)
-    ctx.body = { room, messages, agents, members, total, offset, limit, hasMore: offset + messages.length < total }
+    const messages = storage.getRecentMessagesForUI(ctx.params.roomId, limit, offset)
+    const total = storage.getMessageCount(ctx.params.roomId)
+    const agents = storage.getRoomAgents(ctx.params.roomId)
+    const members = storage.getRoomMembers(ctx.params.roomId)
+    ctx.body = { room: serializeRoom(room, canManage), messages, agents, members, total, offset, limit, hasMore: offset + messages.length < total }
 })
 
 // List rooms
@@ -199,13 +311,15 @@ groupChatRoutes.get('/api/hermes/group-chat/rooms', async (ctx) => {
         return
     }
 
-    const user = ctx.state.user
+    const user = ctx.state?.user
     const storage = chatServer.getStorage()
-    const rooms = !user || user.role === 'super_admin'
-        ? storage.getAllRooms()
-        : storage.getRoomsForProfiles(user.profiles || [])
+    const rooms = visibleRoomsForUser(storage, user)
     ctx.body = { rooms }
 })
+
+function roomWithoutWorkspace(room: any) {
+    return serializeRoom(room, false)
+}
 
 // Get room by invite code
 groupChatRoutes.get('/api/hermes/group-chat/rooms/join/:code', async (ctx) => {
@@ -222,7 +336,7 @@ groupChatRoutes.get('/api/hermes/group-chat/rooms/join/:code', async (ctx) => {
         return
     }
 
-    ctx.body = { room }
+    ctx.body = { room: roomWithoutWorkspace(room) }
 })
 
 // Update room invite code
@@ -233,6 +347,19 @@ groupChatRoutes.put('/api/hermes/group-chat/rooms/:roomId/invite-code', async (c
         return
     }
 
+    const storage = chatServer.getStorage()
+    const room = storage.getRoom(ctx.params.roomId)
+    if (!room) {
+        ctx.status = 404
+        ctx.body = { error: 'Room not found' }
+        return
+    }
+    if (!canManageRoom(storage, ctx.params.roomId, ctx.state?.user)) {
+        ctx.status = 403
+        ctx.body = { error: 'Access denied' }
+        return
+    }
+
     const { inviteCode } = ctx.request.body as { inviteCode?: string }
     if (!inviteCode) {
         ctx.status = 400
@@ -240,7 +367,7 @@ groupChatRoutes.put('/api/hermes/group-chat/rooms/:roomId/invite-code', async (c
         return
     }
 
-    chatServer.getStorage().updateRoomInviteCode(ctx.params.roomId, inviteCode)
+    storage.updateRoomInviteCode(ctx.params.roomId, inviteCode)
     ctx.body = { success: true }
 })
 
@@ -264,8 +391,20 @@ groupChatRoutes.post('/api/hermes/group-chat/rooms/:roomId/agents', async (ctx) 
         return
     }
 
+    const storage = chatServer.getStorage()
+    if (typeof storage.getRoom === 'function' && !storage.getRoom(ctx.params.roomId)) {
+        ctx.status = 404
+        ctx.body = { error: 'Room not found' }
+        return
+    }
+    if (!canManageRoom(storage, ctx.params.roomId, ctx.state?.user)) {
+        ctx.status = 403
+        ctx.body = { error: 'Access denied' }
+        return
+    }
+
     // Prevent duplicate agent in same room
-    const existing = chatServer.getStorage().getRoomAgents(ctx.params.roomId)
+    const existing = storage.getRoomAgents(ctx.params.roomId)
     if (existing.find(a => a.profile === profile)) {
         ctx.status = 409
         ctx.body = { error: 'Agent already in room' }
@@ -295,7 +434,19 @@ groupChatRoutes.get('/api/hermes/group-chat/rooms/:roomId/agents', async (ctx) =
         return
     }
 
-    const agents = chatServer.getStorage().getRoomAgents(ctx.params.roomId)
+    const storage = chatServer.getStorage()
+    if (typeof storage.getRoom === 'function' && !storage.getRoom(ctx.params.roomId)) {
+        ctx.status = 404
+        ctx.body = { error: 'Room not found' }
+        return
+    }
+    if (!canReadRoom(storage, ctx.params.roomId, ctx.state?.user)) {
+        ctx.status = 403
+        ctx.body = { error: 'Access denied' }
+        return
+    }
+
+    const agents = storage.getRoomAgents(ctx.params.roomId)
     ctx.body = { agents }
 })
 
@@ -310,6 +461,11 @@ groupChatRoutes.delete('/api/hermes/group-chat/rooms/:roomId/agents/:agentId', a
     const roomId = ctx.params.roomId
     const requestedAgentId = ctx.params.agentId
     const storage = chatServer.getStorage()
+    if (!canManageRoom(storage, roomId, ctx.state?.user)) {
+        ctx.status = 403
+        ctx.body = { error: 'Access denied' }
+        return
+    }
     const agent = storage.getRoomAgent(roomId, requestedAgentId)
     if (!agent) {
         ctx.status = 404
@@ -336,10 +492,21 @@ groupChatRoutes.delete('/api/hermes/group-chat/rooms/:roomId', async (ctx) => {
     }
 
     const roomId = ctx.params.roomId
+    const storage = chatServer.getStorage()
+    if (!storage.getRoom(roomId)) {
+        ctx.status = 404
+        ctx.body = { error: 'Room not found' }
+        return
+    }
+    if (!canManageRoom(storage, roomId, ctx.state?.user)) {
+        ctx.status = 403
+        ctx.body = { error: 'Access denied' }
+        return
+    }
     // Disconnect all agents in room
     chatServer.agentClients.disconnectRoom(roomId)
     // Delete all data
-    chatServer.getStorage().deleteRoom(roomId)
+    storage.deleteRoom(roomId)
     ctx.body = { success: true }
 })
 
@@ -352,15 +519,21 @@ groupChatRoutes.post('/api/hermes/group-chat/rooms/:roomId/clear-context', async
     }
 
     const roomId = ctx.params.roomId
-    if (!chatServer.getStorage().getRoom(roomId)) {
+    const storage = chatServer.getStorage()
+    const room = storage.getRoom(roomId)
+    if (!room) {
         ctx.status = 404
         ctx.body = { error: 'Room not found' }
         return
     }
-
-    chatServer.getStorage().clearRoomContext(roomId)
+    if (!canManageRoom(storage, roomId, ctx.state?.user)) {
+        ctx.status = 403
+        ctx.body = { error: 'Access denied' }
+        return
+    }
+    storage.clearRoomContext(roomId)
     chatServer.clearRoomRuntimeState(roomId)
-    ctx.body = { success: true, room: chatServer.getStorage().getRoom(roomId) }
+    ctx.body = { success: true, room: serializeRoom(storage.getRoom(roomId), true) }
 })
 
 // Update room compression config
@@ -378,9 +551,59 @@ groupChatRoutes.put('/api/hermes/group-chat/rooms/:roomId/config', async (ctx) =
         tailMessageCount?: number
     }
 
-    chatServer.getStorage().updateRoomConfig(roomId, { triggerTokens, maxHistoryTokens, tailMessageCount })
-    const room = chatServer.getStorage().getRoom(roomId)
-    ctx.body = { room }
+    const storage = chatServer.getStorage()
+    const room = storage.getRoom(roomId)
+    if (!room) {
+        ctx.status = 404
+        ctx.body = { error: 'Room not found' }
+        return
+    }
+    if (!canManageRoom(storage, roomId, ctx.state?.user)) {
+        ctx.status = 403
+        ctx.body = { error: 'Access denied' }
+        return
+    }
+    storage.updateRoomConfig(roomId, { triggerTokens, maxHistoryTokens, tailMessageCount })
+    ctx.body = { room: serializeRoom(storage.getRoom(roomId), true) }
+})
+
+// Update room workspace
+groupChatRoutes.put('/api/hermes/group-chat/rooms/:roomId/workspace', async (ctx) => {
+    if (!chatServer) {
+        ctx.status = 503
+        ctx.body = { error: 'Group chat not initialized' }
+        return
+    }
+
+    const storage = chatServer.getStorage()
+    const roomId = ctx.params.roomId
+    const room = storage.getRoom(roomId)
+    if (!room) {
+        ctx.status = 404
+        ctx.body = { error: 'Room not found' }
+        return
+    }
+    if (!canManageRoom(storage, roomId, ctx.state?.user)) {
+        ctx.status = 403
+        ctx.body = { error: 'Access denied' }
+        return
+    }
+
+    const { workspace } = ctx.request.body as { workspace: string }
+    if (typeof workspace !== 'string') {
+        ctx.status = 400
+        ctx.body = { error: 'workspace must be a string' }
+        return
+    }
+
+    try {
+        const rawWorkspace = workspace.trim()
+        const normalized = rawWorkspace ? (await assertAllowedWorkspaceFolder(rawWorkspace)).fullPath : ''
+        ctx.body = { room: serializeRoom(storage.updateRoomWorkspace(roomId, normalized), true) }
+    } catch (err: any) {
+        ctx.status = Number(err?.status || 403)
+        ctx.body = { error: err?.message || 'Workspace folder is not allowed' }
+    }
 })
 
 // Force compress a room's context
@@ -392,9 +615,15 @@ groupChatRoutes.post('/api/hermes/group-chat/rooms/:roomId/compress', async (ctx
     }
 
     const roomId = ctx.params.roomId
-    if (!chatServer.getStorage().getRoom(roomId)) {
+    const storage = chatServer.getStorage()
+    if (!storage.getRoom(roomId)) {
         ctx.status = 404
         ctx.body = { error: 'Room not found' }
+        return
+    }
+    if (!canManageRoom(storage, roomId, ctx.state?.user)) {
+        ctx.status = 403
+        ctx.body = { error: 'Access denied' }
         return
     }
 

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -532,6 +532,7 @@ class AgentClient {
                 : input
             const flushedAssistantParts = new Set<string>()
             let lastChunk: AgentBridgeOutput | null = null
+            const roomWorkspace = String(this.storage?.getRoom?.(roomId)?.workspace || '').trim()
             const started = await bridge.chat(
                 sessionId,
                 bridgeInput,
@@ -542,6 +543,7 @@ class AgentClient {
                     ...(modelContext.model ? { model: modelContext.model } : {}),
                     ...(modelContext.provider ? { provider: modelContext.provider } : {}),
                     source: 'api_server',
+                    ...(roomWorkspace ? { workspace: roomWorkspace } : {}),
                 },
             )
 

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -85,7 +85,10 @@ interface RoomInfo {
     tailMessageCount: number
     totalTokens: number
     sessionSeed: string
+    workspace: string
+    ownerAuthUserId: number | null
 }
+
 
 interface Member {
     id: string
@@ -102,6 +105,10 @@ interface Member {
 
 function authenticatedGroupUserId(authUserId: number): string {
     return `auth:${authUserId}`
+}
+
+function authenticatedUserProfiles(user: AuthenticatedUser | undefined): string[] {
+    return Array.isArray(user?.profiles) ? user.profiles.map(String).filter(Boolean) : []
 }
 
 let _tablesEnsured = false
@@ -277,15 +284,15 @@ class ChatStorage {
     // ─── Rooms ────────────────────────────────────────────────
 
     getRoom(roomId: string): RoomInfo | undefined {
-        return this.db()?.prepare('SELECT id, name, inviteCode, triggerTokens, maxHistoryTokens, tailMessageCount, totalTokens, sessionSeed FROM gc_rooms WHERE id = ?').get(roomId) as any
+        return this.db()?.prepare('SELECT id, name, inviteCode, triggerTokens, maxHistoryTokens, tailMessageCount, totalTokens, sessionSeed, workspace, ownerAuthUserId FROM gc_rooms WHERE id = ?').get(roomId) as any
     }
 
     getRoomByInviteCode(code: string): RoomInfo | undefined {
-        return this.db()?.prepare('SELECT id, name, inviteCode, triggerTokens, maxHistoryTokens, tailMessageCount, totalTokens, sessionSeed FROM gc_rooms WHERE inviteCode = ?').get(code) as any
+        return this.db()?.prepare('SELECT id, name, inviteCode, triggerTokens, maxHistoryTokens, tailMessageCount, totalTokens, sessionSeed, workspace, ownerAuthUserId FROM gc_rooms WHERE inviteCode = ?').get(code) as any
     }
 
     getAllRooms(): RoomInfo[] {
-        return (this.db()?.prepare('SELECT id, name, inviteCode, triggerTokens, maxHistoryTokens, tailMessageCount, totalTokens, sessionSeed FROM gc_rooms ORDER BY id').all() || []) as any[]
+        return (this.db()?.prepare('SELECT id, name, inviteCode, triggerTokens, maxHistoryTokens, tailMessageCount, totalTokens, sessionSeed, workspace, ownerAuthUserId FROM gc_rooms ORDER BY id').all() || []) as any[]
     }
 
     getRoomsForProfiles(profiles: string[]): RoomInfo[] {
@@ -293,7 +300,7 @@ class ChatStorage {
         if (!uniqueProfiles.length) return []
         const placeholders = uniqueProfiles.map(() => '?').join(', ')
         return (this.db()?.prepare(
-            `SELECT DISTINCT r.id, r.name, r.inviteCode, r.triggerTokens, r.maxHistoryTokens, r.tailMessageCount, r.totalTokens, r.sessionSeed
+            `SELECT DISTINCT r.id, r.name, r.inviteCode, r.triggerTokens, r.maxHistoryTokens, r.tailMessageCount, r.totalTokens, r.sessionSeed, r.workspace, r.ownerAuthUserId
              FROM gc_rooms r
              INNER JOIN gc_room_agents a ON a.roomId = r.id
              WHERE a.profile IN (${placeholders})
@@ -301,10 +308,38 @@ class ChatStorage {
         ).all(...uniqueProfiles) || []) as any[]
     }
 
-    saveRoom(id: string, name: string, inviteCode?: string, config?: { triggerTokens?: number; maxHistoryTokens?: number; tailMessageCount?: number }): void {
+    getRoomsForAuthUser(authUserId: number): RoomInfo[] {
+        if (!Number.isFinite(authUserId) || authUserId <= 0) return []
+        return (this.db()?.prepare(
+            `SELECT DISTINCT r.id, r.name, r.inviteCode, r.triggerTokens, r.maxHistoryTokens, r.tailMessageCount, r.totalTokens, r.sessionSeed, r.workspace, r.ownerAuthUserId
+             FROM gc_rooms r
+             INNER JOIN gc_room_members m ON m.roomId = r.id
+             WHERE m.authUserId = ?
+             ORDER BY r.id`
+        ).all(authUserId) || []) as any[]
+    }
+
+    getOwnedRoomsForAuthUser(authUserId: number): RoomInfo[] {
+        if (!Number.isFinite(authUserId) || authUserId <= 0) return []
+        return (this.db()?.prepare(
+            `SELECT id, name, inviteCode, triggerTokens, maxHistoryTokens, tailMessageCount, totalTokens, sessionSeed, workspace, ownerAuthUserId
+             FROM gc_rooms
+             WHERE ownerAuthUserId = ?
+             ORDER BY id`
+        ).all(authUserId) || []) as any[]
+    }
+
+    saveRoom(id: string, name: string, inviteCode?: string, config?: { triggerTokens?: number; maxHistoryTokens?: number; tailMessageCount?: number; workspace?: string; ownerAuthUserId?: number | null }): void {
+        const rawOwnerAuthUserId = Number(config?.ownerAuthUserId ?? 0)
+        const ownerAuthUserId = Number.isFinite(rawOwnerAuthUserId) && rawOwnerAuthUserId > 0 ? Math.floor(rawOwnerAuthUserId) : null
         this.db()?.prepare(
-            'INSERT OR IGNORE INTO gc_rooms (id, name, inviteCode, triggerTokens, maxHistoryTokens, tailMessageCount) VALUES (?, ?, ?, ?, ?, ?)'
-        ).run(id, name, inviteCode || null, config?.triggerTokens ?? 100000, config?.maxHistoryTokens ?? 32000, config?.tailMessageCount ?? 10)
+            'INSERT OR IGNORE INTO gc_rooms (id, name, inviteCode, triggerTokens, maxHistoryTokens, tailMessageCount, workspace, ownerAuthUserId) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+        ).run(id, name, inviteCode || null, config?.triggerTokens ?? 100000, config?.maxHistoryTokens ?? 32000, config?.tailMessageCount ?? 10, config?.workspace || '', ownerAuthUserId)
+    }
+
+    setRoomOwnerAuthUserId(roomId: string, authUserId: number): void {
+        if (!Number.isFinite(authUserId) || authUserId <= 0) return
+        this.db()?.prepare('UPDATE gc_rooms SET ownerAuthUserId = ? WHERE id = ?').run(authUserId, roomId)
     }
 
     updateRoomConfig(roomId: string, config: { triggerTokens?: number; maxHistoryTokens?: number; tailMessageCount?: number }): void {
@@ -326,8 +361,26 @@ class ChatStorage {
         this.db()?.prepare('UPDATE gc_rooms SET totalTokens = ? WHERE id = ?').run(tokens, roomId)
     }
 
+    getRoomWorkspace(roomId: string): string {
+        return String(this.getRoom(roomId)?.workspace || '')
+    }
+
+    updateRoomWorkspace(roomId: string, workspace: string): RoomInfo | null {
+        const room = this.getRoom(roomId)
+        if (!room) return null
+        const nextWorkspace = String(workspace || '')
+        if (String(room.workspace || '') === nextWorkspace) return room
+        const seed = this.newRoomSessionSeed()
+        this.db()?.prepare('UPDATE gc_rooms SET workspace = ?, sessionSeed = ? WHERE id = ?').run(nextWorkspace, seed, roomId)
+        return this.getRoom(roomId) || null
+    }
+
+    private newRoomSessionSeed(): string {
+        return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
+    }
+
     rotateRoomSessionSeed(roomId: string): string {
-        const seed = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
+        const seed = this.newRoomSessionSeed()
         this.db()?.prepare('UPDATE gc_rooms SET sessionSeed = ? WHERE id = ?').run(seed, roomId)
         return seed
     }
@@ -900,7 +953,7 @@ export class GroupChatServer {
 
         logger.debug(`[GroupChat] Connected: ${userName} (socket=${socket.id}, user=${userId})`)
 
-        socket.on('join', (data: { roomId?: string; name?: string }, ack?: (response?: unknown) => void) => this.handleJoin(socket, data, ack))
+        socket.on('join', (data: { roomId?: string; name?: string; description?: string; inviteCode?: string }, ack?: (response?: unknown) => void) => this.handleJoin(socket, data, ack))
         socket.on('message', (data: Partial<ChatMessage> & { roomId?: string; content: string | Array<Record<string, unknown>>; id?: string; mentionDepth?: number }, ack?: (response?: unknown) => void) => this.handleMessage(socket, data, ack))
         socket.on('message_stream_start', (data: { roomId?: string; id?: string; senderId?: string; senderName?: string; timestamp?: number }) => this.handleMessageStreamStart(socket, data))
         socket.on('message_stream_delta', (data: { roomId?: string; id?: string; delta?: string }) => this.handleMessageStreamDelta(socket, data))
@@ -918,12 +971,69 @@ export class GroupChatServer {
 
     // ─── Handlers ───────────────────────────────────────────────
 
-    private handleJoin(socket: Socket, data: { roomId?: string; name?: string; description?: string }, ack?: (res: any) => void): void {
+    private canSocketJoinRoom(socket: Socket, roomId: string, room: RoomInfo | undefined, existingMember: Member | null, inviteCode?: string): boolean {
+        if (!room) return typeof this.storage.getRoom !== 'function'
+        const requested = typeof inviteCode === 'string' ? inviteCode.trim() : ''
+        if (requested && room.inviteCode && requested === room.inviteCode) return true
+        const authUser = socket.data?.authUser as AuthenticatedUser | undefined
+        if (!authUser) return Boolean(existingMember || !room.inviteCode)
+        if (authUser.role === 'super_admin') return true
+        if (typeof authUser.id === 'number' && Number(room.ownerAuthUserId || 0) === authUser.id) return true
+        if (existingMember) return true
+        const profiles = authenticatedUserProfiles(authUser)
+        return profiles.length > 0 && typeof this.storage.getRoomsForProfiles === 'function' && this.storage.getRoomsForProfiles(profiles).some(candidate => candidate.id === roomId)
+    }
+
+    private canSocketManageRoom(socket: Socket, roomId: string): boolean {
+        if (this.socketRequestedSourceMap?.get(socket.id) === 'agent') return false
+        const room = typeof this.storage.getRoom === 'function' ? this.storage.getRoom(roomId) : undefined
+        if (!room) return false
+        const authUser = socket.data?.authUser as AuthenticatedUser | undefined
+        if (!authUser) return true
+        if (authUser.role === 'super_admin') return true
+        if (typeof authUser.id === 'number' && Number(room.ownerAuthUserId || 0) === authUser.id) return true
+        const profiles = authenticatedUserProfiles(authUser)
+        return profiles.length > 0 && typeof this.storage.getRoomsForProfiles === 'function' && this.storage.getRoomsForProfiles(profiles).some(candidate => candidate.id === roomId)
+    }
+
+    private getOnlineRoomMember(socket: Socket, roomId: string): { room: ChatRoom; member: Member } | null {
+        const room = this.rooms.get(roomId)
+        const member = room?.getOnlineMemberBySocketId(socket.id)
+        return room && member ? { room, member } : null
+    }
+
+    private isAgentEventSocket(socket: Socket, roomId: string, agentName?: string): boolean {
+        const joined = this.getOnlineRoomMember(socket, roomId)
+        if (!joined || joined.member.source !== 'agent') return false
+        return !agentName || joined.member.name === agentName
+    }
+
+    private emitToRoomManagers(roomId: string, event: string, payload: Record<string, unknown>): void {
+        const room = this.rooms.get(roomId)
+        if (!room) return
+        const emitted = new Set<string>()
+        for (const member of room.members.values()) {
+            if (!member.online || member.source === 'agent') continue
+            const socket = this.nsp.sockets.get(member.socketId)
+            if (!socket || emitted.has(socket.id)) continue
+            if (!this.canSocketManageRoom(socket, roomId)) continue
+            socket.emit(event, payload)
+            emitted.add(socket.id)
+        }
+    }
+
+
+    private handleJoin(socket: Socket, data: { roomId?: string; name?: string; description?: string; inviteCode?: string }, ack?: (res: any) => void): void {
         const socketId = socket.id
         const userId = this.socketUserMap.get(socketId) || socketId
         const requestedSource = this.socketRequestedSourceMap.get(socketId) || 'human'
         const roomId = data.roomId || 'general'
+        const storedRoom = typeof this.storage.getRoom === 'function' ? this.storage.getRoom(roomId) : undefined
         const roomAgent = this.storage.getRoomAgentByAgentId(roomId, userId)
+        if (requestedSource === 'agent' && !roomAgent) {
+            ack?.({ error: 'Access denied' })
+            return
+        }
         const source = requestedSource === 'agent' && roomAgent ? 'agent' : 'human'
         if (source === 'human' && roomAgent) {
             ack?.({ error: 'Reserved member identity' })
@@ -932,6 +1042,10 @@ export class GroupChatServer {
         const socketAuthUserId = this.socketAuthUserIdMap.get(socket.id)
         const existingMember = this.storage.getMemberByUserId(roomId, userId) ||
             (typeof socketAuthUserId === 'number' ? this.storage.getMemberByAuthUserId(roomId, socketAuthUserId) : null)
+        if (source !== 'agent' && !this.canSocketJoinRoom(socket, roomId, storedRoom, existingMember, data.inviteCode)) {
+            ack?.({ error: 'Access denied' })
+            return
+        }
         const userInfo = this.userInfoMap.get(userId) || {
             name: existingMember?.name || `User-${userId.slice(0, 6)}`,
             description: existingMember?.description || '',
@@ -946,9 +1060,13 @@ export class GroupChatServer {
 
         let room = this.rooms.get(roomId)
         if (!room) {
+            if (!storedRoom && typeof this.storage.getRoom === 'function') {
+                ack?.({ error: 'Room not found' })
+                return
+            }
             room = new ChatRoom(roomId)
             this.rooms.set(roomId, room)
-            this.storage.saveRoom(roomId, roomId)
+            if (!storedRoom) this.storage.saveRoom(roomId, roomId)
         }
 
         // Look up the user's avatar via their numeric users.id from the web UI session.
@@ -1024,6 +1142,7 @@ export class GroupChatServer {
         const member = room.getOnlineMemberBySocketId(socketId)
         const userId = member?.userId || socketId
         const userName = member?.name || `User-${socketId.slice(0, 6)}`
+        const role = normalizeMessageRole(data.role)
 
         const msg: ChatMessage = {
             id: this.normalizeClientMessageId(data.id) || this.generateId(),
@@ -1032,7 +1151,7 @@ export class GroupChatServer {
             senderName: userName,
             content: contentToStorageString(data.content),
             timestamp: this.normalizeMessageTimestamp(data.timestamp, data.role),
-            role: normalizeMessageRole(data.role),
+            role,
             tool_call_id: data.tool_call_id ?? null,
             tool_calls: Array.isArray(data.tool_calls) ? data.tool_calls : null,
             tool_name: data.tool_name ?? null,
@@ -1052,7 +1171,7 @@ export class GroupChatServer {
 
         const mentionDepth = normalizeMentionDepth(data.mentionDepth)
         const isAgentReply = savedMsg.role === 'assistant' && member?.source === 'agent'
-        const shouldRouteMentions = savedMsg.role === 'user' ||
+        const shouldRouteMentions = (savedMsg.role === 'user' && this.canSocketManageRoom(socket, roomId)) ||
             (isAgentReply && mentionDepth < maxAgentMentionDepth())
 
         if (shouldRouteMentions) {
@@ -1076,17 +1195,16 @@ export class GroupChatServer {
 
     private handleMessageStreamStart(socket: Socket, data: { roomId?: string; id?: string; senderId?: string; senderName?: string; timestamp?: number }): void {
         const roomId = data.roomId || 'general'
-        const room = this.rooms.get(roomId)
-        if (!room || !room.hasOnlineMember(socket.id)) return
+        const joined = this.getOnlineRoomMember(socket, roomId)
+        if (!joined || joined.member.source !== 'agent') return
         const id = this.normalizeClientMessageId(data.id)
         if (!id) return
 
-        const member = room.getOnlineMemberBySocketId(socket.id)
         this.nsp.to(roomId).emit('message_stream_start', {
             id,
             roomId,
-            senderId: data.senderId || member?.userId || socket.id,
-            senderName: data.senderName || member?.name || `User-${socket.id.slice(0, 6)}`,
+            senderId: joined.member.userId,
+            senderName: joined.member.name,
             content: '',
             timestamp: data.timestamp || Date.now(),
             role: 'assistant',
@@ -1096,8 +1214,8 @@ export class GroupChatServer {
 
     private handleMessageStreamDelta(socket: Socket, data: { roomId?: string; id?: string; delta?: string }): void {
         const roomId = data.roomId || 'general'
-        const room = this.rooms.get(roomId)
-        if (!room || !room.hasOnlineMember(socket.id)) return
+        const joined = this.getOnlineRoomMember(socket, roomId)
+        if (!joined || joined.member.source !== 'agent') return
         const id = this.normalizeClientMessageId(data.id)
         if (!id || !data.delta) return
         this.nsp.to(roomId).emit('message_stream_delta', {
@@ -1109,8 +1227,8 @@ export class GroupChatServer {
 
     private handleMessageReasoningDelta(socket: Socket, data: { roomId?: string; id?: string; delta?: string }): void {
         const roomId = data.roomId || 'general'
-        const room = this.rooms.get(roomId)
-        if (!room || !room.hasOnlineMember(socket.id)) return
+        const joined = this.getOnlineRoomMember(socket, roomId)
+        if (!joined || joined.member.source !== 'agent') return
         const id = this.normalizeClientMessageId(data.id)
         if (!id || !data.delta) return
         this.nsp.to(roomId).emit('message_reasoning_delta', {
@@ -1122,8 +1240,8 @@ export class GroupChatServer {
 
     private handleMessageStreamEnd(socket: Socket, data: { roomId?: string; id?: string }): void {
         const roomId = data.roomId || 'general'
-        const room = this.rooms.get(roomId)
-        if (!room || !room.hasOnlineMember(socket.id)) return
+        const joined = this.getOnlineRoomMember(socket, roomId)
+        if (!joined || joined.member.source !== 'agent') return
         const id = this.normalizeClientMessageId(data.id)
         if (!id) return
         this.nsp.to(roomId).emit('message_stream_end', { roomId, id })
@@ -1181,7 +1299,7 @@ export class GroupChatServer {
         const agentName = data.agentName || ''
         const status = data.status || ''
 
-        if (!agentName) return
+        if (!agentName || !this.isAgentEventSocket(socket, roomId, agentName)) return
 
         let roomStatuses = this.contextStatusState.get(roomId)
         if (!roomStatuses) {
@@ -1221,6 +1339,10 @@ export class GroupChatServer {
             ack?.({ error: 'Not in room' })
             return
         }
+        if (!this.canSocketManageRoom(socket, roomId)) {
+            ack?.({ error: 'Access denied' })
+            return
+        }
         try {
             await this.agentClients.interruptAgent(roomId, agentName)
             this.nsp.to(roomId).emit('context_status', { roomId, agentName, status: 'ready' })
@@ -1233,11 +1355,12 @@ export class GroupChatServer {
 
     private handleApprovalRequested(socket: Socket, data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean }): void {
         const roomId = data.roomId
-        if (!roomId || !data.approval_id) return
-        this.nsp.to(roomId).emit('approval.requested', {
+        const agentName = data.agentName || ''
+        if (!roomId || !data.approval_id || !this.isAgentEventSocket(socket, roomId, agentName)) return
+        this.emitToRoomManagers(roomId, 'approval.requested', {
             event: 'approval.requested',
             roomId,
-            agentName: data.agentName || '',
+            agentName,
             approval_id: data.approval_id,
             command: data.command || '',
             description: data.description || '',
@@ -1248,11 +1371,12 @@ export class GroupChatServer {
 
     private handleApprovalResolved(socket: Socket, data: { roomId?: string; agentName?: string; approval_id?: string; choice?: string }): void {
         const roomId = data.roomId
-        if (!roomId || !data.approval_id) return
-        this.nsp.to(roomId).emit('approval.resolved', {
+        const agentName = data.agentName || ''
+        if (!roomId || !data.approval_id || !this.isAgentEventSocket(socket, roomId, agentName)) return
+        this.emitToRoomManagers(roomId, 'approval.resolved', {
             event: 'approval.resolved',
             roomId,
-            agentName: data.agentName || '',
+            agentName,
             approval_id: data.approval_id,
             choice: data.choice || '',
         })
@@ -1267,6 +1391,10 @@ export class GroupChatServer {
         const room = this.rooms.get(roomId)
         if (!room?.hasOnlineMember(socket.id)) {
             ack?.({ error: 'Not in room' })
+            return
+        }
+        if (!this.canSocketManageRoom(socket, roomId)) {
+            ack?.({ error: 'Access denied' })
             return
         }
         try {

--- a/packages/server/src/services/hermes/workspace-path.ts
+++ b/packages/server/src/services/hermes/workspace-path.ts
@@ -1,0 +1,71 @@
+import { existsSync } from 'fs'
+import { stat } from 'fs/promises'
+import { homedir } from 'os'
+import { isAbsolute, join, resolve, win32 as pathWin32 } from 'path'
+import { isPathWithin, isRealPathWithin } from './hermes-path'
+
+export function workspaceBaseOverride(): string {
+  return process.env.WORKSPACE_BASE?.trim() || ''
+}
+
+export function useWindowsDriveWorkspaceMode(): boolean {
+  return process.platform === 'win32' && !workspaceBaseOverride()
+}
+
+function windowsDriveRoot(pathValue: string): string | null {
+  const match = /^([a-zA-Z]:)[\\/]?$/.exec(pathValue.trim())
+  return match ? `${match[1].toUpperCase()}\\` : null
+}
+
+export function normalizeWindowsWorkspacePath(inputPath: string): { base: string; fullPath: string } | null {
+  const raw = String(inputPath || '').trim()
+  if (!/^[a-zA-Z]:[\\/]/.test(raw)) return null
+  const fullPath = pathWin32.resolve(raw)
+  const root = windowsDriveRoot(pathWin32.parse(fullPath).root)
+  if (!root) return null
+  const rel = pathWin32.relative(root, fullPath)
+  if (rel.startsWith('..') || pathWin32.isAbsolute(rel)) return null
+  return { base: root, fullPath }
+}
+
+export async function isWorkspaceListPathAllowed(
+  fullPath: string,
+  basePath: string,
+  statFn: typeof stat,
+  options: { trustWindowsDriveRoot?: boolean; trustWindowsJunctions?: boolean; realPathWithinFn?: typeof isRealPathWithin } = {},
+): Promise<boolean> {
+  try {
+    const info = await statFn(fullPath)
+    if (!info.isDirectory()) return false
+    if (process.platform === 'win32' && options.trustWindowsDriveRoot) return true
+    return await (options.realPathWithinFn || isRealPathWithin)(fullPath, basePath)
+  } catch {
+    return false
+  }
+}
+
+export async function resolveAllowedWorkspaceFolder(inputPath: string): Promise<{ base: string; fullPath: string } | null> {
+  const raw = String(inputPath || '').trim()
+  if (!raw) return null
+
+  if (useWindowsDriveWorkspaceMode()) {
+    const resolved = normalizeWindowsWorkspacePath(raw)
+    if (!resolved) return null
+    return await isWorkspaceListPathAllowed(resolved.fullPath, resolved.base, stat, { trustWindowsDriveRoot: true }) ? resolved : null
+  }
+
+  const base = workspaceBaseOverride() || homedir()
+  const fullPath = isAbsolute(raw) ? resolve(raw) : resolve(join(base, raw))
+  if (!isPathWithin(fullPath, base)) return null
+  if (!existsSync(fullPath)) return null
+  return await isWorkspaceListPathAllowed(fullPath, base, stat) ? { base, fullPath } : null
+}
+
+export async function assertAllowedWorkspaceFolder(inputPath: string): Promise<{ base: string; fullPath: string }> {
+  const raw = String(inputPath || '').trim()
+  const resolved = await resolveAllowedWorkspaceFolder(raw)
+  if (resolved) return resolved
+  const err = new Error(raw ? 'Workspace folder is not allowed' : 'workspace is required') as Error & { status?: number }
+  err.status = raw ? 403 : 400
+  throw err
+}

--- a/scripts/generate-openapi.mjs
+++ b/scripts/generate-openapi.mjs
@@ -720,6 +720,11 @@ function generateResponses(path, method) {
     responses['400'] = { $ref: '#/components/responses/BadRequest' }
   }
 
+  if (path === '/api/hermes/group-chat/rooms/:roomId/workspace') {
+    responses['403'] = { description: 'Forbidden - Workspace folder is not allowed' }
+    responses['404'] = { $ref: '#/components/responses/NotFound' }
+  }
+
   return responses
 }
 

--- a/tests/client/group-chat-panel-workspace-source.test.ts
+++ b/tests/client/group-chat-panel-workspace-source.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('GroupChatPanel workspace save handling', () => {
+  it('coerces null picker values before trimming so clearing the input saves an empty workspace', () => {
+    const source = readFileSync('packages/client/src/components/hermes/group-chat/GroupChatPanel.vue', 'utf8')
+
+    expect(source).toContain("String(workspaceValue.value || '').trim()")
+    expect(source).not.toContain('workspaceValue.value.trim()')
+  })
+
+  it('gates workspace mutation controls to rooms the server marks manageable', () => {
+    const source = readFileSync('packages/client/src/components/hermes/group-chat/GroupChatPanel.vue', 'utf8')
+
+    expect(source).toContain('const currentRoomCanManage = computed(() => canManageRoom(currentRoom.value))')
+    expect(source).toContain('const visibleApproval = computed(() => currentRoomCanManage.value ? store.activePendingApproval : null)')
+    expect(source).toContain('if (!currentRoomCanManage.value) return')
+    expect(source).toContain('if (!canManageRoom(room)) return')
+    expect(source).toContain("options.push({ label: t('chat.setWorkspace'), key: 'set-workspace' })")
+    expect(source).toContain('v-if="currentRoomCanManage" class="context-stop-btn"')
+  })
+
+  it('renders the active room workspace badge beside the room title like single chat', () => {
+    const source = readFileSync('packages/client/src/components/hermes/group-chat/GroupChatPanel.vue', 'utf8')
+
+    expect(source).toContain('<div class="header-left">')
+    expect(source).toContain('class="workspace-badge"')
+    expect(source).toContain('v-if="currentRoom?.workspace"')
+    expect(source).toContain(':title="currentRoom.workspace"')
+    expect(source).not.toContain('class="workspace-chip"')
+    expect(source).not.toContain("currentWorkspaceLabel || t('chat.setWorkspace')")
+  })
+})

--- a/tests/client/group-chat-store-baseline.test.ts
+++ b/tests/client/group-chat-store-baseline.test.ts
@@ -15,6 +15,22 @@ const groupChatApiMock = vi.hoisted(() => {
       handlers.set(event, existing)
       return socket
     }),
+    once: vi.fn((event: string, cb: Function) => {
+      const wrapped = (...args: any[]) => {
+        socket.off(event, wrapped)
+        cb(...args)
+      }
+      return socket.on(event, wrapped)
+    }),
+    off: vi.fn((event: string, cb?: Function) => {
+      if (!cb) {
+        handlers.delete(event)
+        return socket
+      }
+      const existing = handlers.get(event) || []
+      handlers.set(event, existing.filter(handler => handler !== cb))
+      return socket
+    }),
     emit: vi.fn((event: string, data?: any, ack?: Function) => {
       if (event === 'join' && ack) ack(joinAck)
       if (event === 'message' && ack) ack({ id: data?.id })
@@ -130,7 +146,10 @@ describe('group chat store baseline lifecycle', () => {
     clientApiMock.getStoredUsername.mockReturnValue(null)
     authApiMock.fetchCurrentUser.mockRejectedValue(new Error('not signed in'))
     fetchMock.mockReset()
+    groupChatApiMock.socket.connected = true
     groupChatApiMock.socket.on.mockClear()
+    groupChatApiMock.socket.once.mockClear()
+    groupChatApiMock.socket.off.mockClear()
     groupChatApiMock.socket.emit.mockReset()
     groupChatApiMock.socket.emit.mockImplementation((event: string, data?: any, ack?: Function) => {
       if (event === 'join' && ack) ack({ members: [], agents: [], typingUsers: [], contextStatuses: [] })
@@ -190,6 +209,44 @@ describe('group chat store baseline lifecycle', () => {
     expect(store.totalMessages).toBe(5)
     expect(store.hasMoreBefore).toBe(true)
     expect(store.contextStatuses.get('Agent')).toEqual({ agentName: 'Agent', status: 'replying' })
+  })
+
+  it('joins invite rooms over realtime before fetching protected detail when the socket starts disconnected', async () => {
+    const store = await loadStore()
+    const order: string[] = []
+
+    groupChatApiMock.socket.connected = false
+    groupChatApiMock.getSocket.mockImplementation((options?: { requireConnected?: boolean }) => (
+      groupChatApiMock.socket.connected || options?.requireConnected === false ? groupChatApiMock.socket : null
+    ))
+    groupChatApiMock.socket.once.mockImplementation((event: string, cb: Function) => {
+      if (event === 'connect') {
+        setTimeout(() => {
+          groupChatApiMock.socket.connected = true
+          cb()
+        }, 0)
+      }
+      return groupChatApiMock.socket
+    })
+    groupChatApiMock.socket.emit.mockImplementation((event: string, data?: any, ack?: Function) => {
+      if (event === 'join' && ack) {
+        order.push(data?.inviteCode ? 'invite-join' : 'detail-join')
+        ack({ roomName: 'Realtime Room', members: [member], agents: [], typingUsers: [], contextStatuses: [] })
+      }
+      return groupChatApiMock.socket
+    })
+    groupChatApiMock.joinRoomByCode.mockResolvedValue({ room })
+    groupChatApiMock.getRoomDetail.mockImplementation(async () => {
+      order.push('detail')
+      return { room, messages: [], agents: [], members: [member], total: 0, hasMore: false }
+    })
+
+    await store.joinByCode('ROOM1')
+
+    expect(groupChatApiMock.connectGroupChat).toHaveBeenCalled()
+    expect(groupChatApiMock.getRoomDetail).toHaveBeenCalledWith('room-1')
+    expect(order).toEqual(['invite-join', 'detail', 'detail-join'])
+    expect(store.currentRoomId).toBe('room-1')
   })
 
   it('sends text-only messages through the room socket', async () => {

--- a/tests/client/group-chat-store-workspace.test.ts
+++ b/tests/client/group-chat-store-workspace.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+const groupChatApiMock = vi.hoisted(() => ({
+  connectGroupChat: vi.fn(),
+  disconnectGroupChat: vi.fn(),
+  getSocket: vi.fn(() => null),
+  getStoredUserId: vi.fn(() => 'user-1'),
+  getStoredUserName: vi.fn(() => 'tester'),
+  createRoom: vi.fn(),
+  listRooms: vi.fn(),
+  getRoomDetail: vi.fn(),
+  joinRoomByCode: vi.fn(),
+  addAgent: vi.fn(),
+  listAgents: vi.fn(),
+  removeAgent: vi.fn(),
+  cloneRoom: vi.fn(),
+  deleteRoom: vi.fn(),
+  clearRoomContext: vi.fn(),
+  updateRoomWorkspace: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/group-chat', () => groupChatApiMock)
+vi.mock('@/api/client', () => ({
+  getApiKey: vi.fn(() => 'token'),
+  getActiveProfileName: vi.fn(() => 'default'),
+  getStoredUsername: vi.fn(() => null),
+}))
+vi.mock('@/api/auth', () => ({ fetchCurrentUser: vi.fn(async () => { throw new Error('no user') }) }))
+vi.mock('@/api/hermes/download', () => ({ getDownloadUrl: vi.fn((path: string) => `/download?path=${path}`) }))
+
+describe('group chat store workspace', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('passes selected workspace when creating a room', async () => {
+    const { useGroupChatStore } = await import('@/stores/hermes/group-chat')
+    const store = useGroupChatStore()
+    groupChatApiMock.createRoom.mockResolvedValue({
+      room: { id: 'room-1', name: 'Room 1', inviteCode: null, workspace: '/tmp/repo' },
+      agents: [],
+    })
+
+    await store.createNewRoom('Room 1', 'invite-1', [], { triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10 }, '/tmp/repo')
+
+    expect(groupChatApiMock.createRoom).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Room 1',
+      inviteCode: 'invite-1',
+      workspace: '/tmp/repo',
+    }))
+    expect(store.rooms[0].workspace).toBe('/tmp/repo')
+  })
+
+  it('updates the rooms list after the workspace API succeeds', async () => {
+    const { useGroupChatStore } = await import('@/stores/hermes/group-chat')
+    const store = useGroupChatStore()
+    store.rooms = [{ id: 'room-1', name: 'Room 1', inviteCode: null, workspace: '' }]
+    groupChatApiMock.updateRoomWorkspace.mockResolvedValue({
+      room: { id: 'room-1', name: 'Room 1', inviteCode: null, workspace: '/tmp/repo' },
+    })
+
+    await store.setRoomWorkspace('room-1', '/tmp/repo')
+
+    expect(groupChatApiMock.updateRoomWorkspace).toHaveBeenCalledWith('room-1', '/tmp/repo')
+    expect(store.rooms[0].workspace).toBe('/tmp/repo')
+  })
+
+  it('clears workspace through the same API path', async () => {
+    const { useGroupChatStore } = await import('@/stores/hermes/group-chat')
+    const store = useGroupChatStore()
+    store.rooms = [{ id: 'room-1', name: 'Room 1', inviteCode: null, workspace: '/tmp/repo' }]
+    groupChatApiMock.updateRoomWorkspace.mockResolvedValue({
+      room: { id: 'room-1', name: 'Room 1', inviteCode: null, workspace: '' },
+    })
+
+    await store.setRoomWorkspace('room-1', '')
+
+    expect(store.rooms[0].workspace).toBe('')
+  })
+
+  it('does not mutate local workspace when the API rejects', async () => {
+    const { useGroupChatStore } = await import('@/stores/hermes/group-chat')
+    const store = useGroupChatStore()
+    store.rooms = [{ id: 'room-1', name: 'Room 1', inviteCode: null, workspace: '/tmp/repo' }]
+    groupChatApiMock.updateRoomWorkspace.mockRejectedValue(new Error('invalid workspace'))
+
+    await expect(store.setRoomWorkspace('room-1', '/outside')).rejects.toThrow('invalid workspace')
+
+    expect(store.rooms[0].workspace).toBe('/tmp/repo')
+  })
+})

--- a/tests/client/router-login-redirect.test.ts
+++ b/tests/client/router-login-redirect.test.ts
@@ -37,7 +37,7 @@ describe('router login redirect', () => {
     await router.isReady()
 
     expect(router.currentRoute.value.name).toBe('hermes.chat')
-  }, 15_000)
+  }, 60_000)
 
   it('does not redirect desktop login when a stale token exists', async () => {
     mockHasApiKey.mockReturnValue(true)

--- a/tests/server/group-chat-agent-routing-baseline.test.ts
+++ b/tests/server/group-chat-agent-routing-baseline.test.ts
@@ -5,6 +5,7 @@ import {
   emitAck,
 } from './group-chat-test-helpers'
 import { GROUP_CHAT_AGENT_SOCKET_SECRET } from '../../packages/server/src/services/hermes/group-chat/agent-clients'
+import { authenticateUserToken, isAuthEnabled } from '../../packages/server/src/middleware/user-auth'
 import type { GroupChatServer } from '../../packages/server/src/services/hermes/group-chat'
 
 describe('group chat agent routing baseline', () => {
@@ -14,6 +15,8 @@ describe('group chat agent routing baseline', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    vi.mocked(isAuthEnabled).mockResolvedValue(false)
+    vi.mocked(authenticateUserToken).mockResolvedValue(null as any)
     harness = await createTestGroupChatServer()
     groupServer = harness.groupServer
     port = harness.port
@@ -32,8 +35,8 @@ describe('group chat agent routing baseline', () => {
       agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
     })
     harness.sockets.push(human, agent)
-    await emitAck(human, 'join', { roomId: 'room-1' })
-    await emitAck(agent, 'join', { roomId: 'room-1' })
+    await emitAck(human, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    await emitAck(agent, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
     return { human, agent }
   }
 
@@ -48,6 +51,27 @@ describe('group chat agent routing baseline', () => {
       role: 'user',
       mentionDepth: 0,
     }))
+  })
+
+  it('does not route read-only invite member messages through agents', async () => {
+    vi.mocked(isAuthEnabled).mockResolvedValue(true)
+    vi.mocked(authenticateUserToken).mockImplementation(async (token: string) => {
+      if (token === 'read-only-token') return { id: 2, username: 'bob', role: 'admin', profiles: [] } as any
+      return null
+    })
+    const human = await connectGroupChatClient(port, 'ignored-user', 'Bob', { token: 'read-only-token' })
+    const agent = await connectGroupChatClient(port, 'agent-worker', 'Worker', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    harness.sockets.push(human, agent)
+    await emitAck(human, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    await emitAck(agent, 'join', { roomId: 'room-1' })
+    const processMentions = vi.spyOn(groupServer.agentClients, 'processMentions').mockResolvedValue(undefined)
+
+    await emitAck(human, 'message', { roomId: 'room-1', id: 'readonly-msg-1', content: '@Worker hello' })
+
+    expect(processMentions).not.toHaveBeenCalled()
   })
 
   it('routes agent replies below the default mention-depth guard', async () => {

--- a/tests/server/group-chat-agent-workspace.test.ts
+++ b/tests/server/group-chat-agent-workspace.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSocket = vi.hoisted(() => ({
+  id: 'agent-socket-1',
+  connected: true,
+  io: { on: vi.fn() },
+  on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+    if (event === 'connect') queueMicrotask(() => handler())
+    return mockSocket
+  }),
+  emit: vi.fn((event: string, data?: any, ack?: Function) => {
+    if (event === 'message' && ack) ack({ id: data?.id || 'msg-id' })
+    return mockSocket
+  }),
+  disconnect: vi.fn(),
+}))
+
+const bridgeMock = vi.hoisted(() => ({
+  chat: vi.fn(async (_sessionId: string, _input: unknown, _history: unknown, _instructions: unknown, _profile: unknown, _options: any) => {
+    return { ok: true, run_id: 'bridge-run-id', session_id: _sessionId, status: 'running' }
+  }),
+  streamOutput: vi.fn(async function* (runId: string) {
+    yield {
+      ok: true,
+      run_id: runId,
+      session_id: 'session-1',
+      status: 'complete',
+      delta: 'done',
+      cursor: 1,
+      output: 'done',
+      done: true,
+      events: [],
+      event_cursor: 0,
+    }
+  }),
+  contextEstimate: vi.fn(),
+  interrupt: vi.fn(),
+}))
+
+vi.mock('socket.io-client', () => ({ io: vi.fn(() => mockSocket) }))
+vi.mock('../../packages/server/src/services/auth', () => ({ getToken: vi.fn(async () => 'test-token') }))
+vi.mock('../../packages/server/src/services/config-helpers', () => ({
+  readConfigYamlForProfile: vi.fn(async () => ({ model: { default: 'model-a', provider: 'provider-a' } })),
+}))
+vi.mock('../../packages/server/src/db/hermes/usage-store', () => ({ updateUsage: vi.fn() }))
+vi.mock('../../packages/server/src/services/hermes/agent-bridge', () => ({
+  AgentBridgeClient: vi.fn(() => bridgeMock),
+}))
+
+describe('group chat agent workspace bridge runs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    bridgeMock.chat.mockResolvedValue({ ok: true, run_id: 'bridge-run-id', session_id: 'session-1', status: 'running' })
+  })
+
+  async function createClient(workspace = '') {
+    const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1',
+      profile: 'default',
+      name: 'Worker',
+      description: '',
+      invited: 0,
+    } as any)
+    const storage = {
+      getRoom: vi.fn(() => ({ sessionSeed: 'seed-1', workspace })),
+      getMessagesForContext: vi.fn(() => []),
+      getContextSnapshot: vi.fn(() => null),
+      saveSessionProfile: vi.fn(),
+      updateRoomTotalTokens: vi.fn(),
+    }
+    client.setStorage(storage as any)
+    return client as any
+  }
+
+  it('omits workspace when the room has no workspace', async () => {
+    const client = await createClient('')
+
+    await client.replyToMention('room-1', {
+      content: '@Worker hi',
+      senderName: 'Alice',
+      senderId: 'user-1',
+      timestamp: 1,
+    })
+
+    expect(bridgeMock.chat).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.any(Array),
+      expect.any(String),
+      'default',
+      expect.not.objectContaining({ workspace: expect.anything() }),
+    )
+  })
+
+  it('passes the normalized room workspace to the bridge run options', async () => {
+    const client = await createClient('/tmp/workspace')
+
+    await client.replyToMention('room-1', {
+      content: '@Worker hi',
+      senderName: 'Alice',
+      senderId: 'user-1',
+      timestamp: 1,
+    })
+
+    expect(bridgeMock.chat).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.any(Array),
+      expect.any(String),
+      'default',
+      expect.objectContaining({ workspace: '/tmp/workspace' }),
+    )
+  })
+})

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -5,6 +5,7 @@ import {
   emitAck,
   once,
 } from './group-chat-test-helpers'
+import { GROUP_CHAT_AGENT_SOCKET_SECRET } from '../../packages/server/src/services/hermes/group-chat/agent-clients'
 import type { GroupChatServer } from '../../packages/server/src/services/hermes/group-chat'
 
 describe('group chat approval and context baseline', () => {
@@ -18,6 +19,7 @@ describe('group chat approval and context baseline', () => {
     groupServer = harness.groupServer
     port = harness.port
     groupServer.getStorage().saveRoom('room-1', 'Room 1', 'ROOM1')
+    groupServer.getStorage().addRoomAgent('room-1', 'agent-1', 'default', 'Agent', '', 0)
   })
 
   afterEach(() => {
@@ -25,12 +27,19 @@ describe('group chat approval and context baseline', () => {
   })
 
   async function joinPair() {
-    const agent = await connectGroupChatClient(port, 'agent-1', 'Agent')
+    const agent = await connectGroupChatClient(port, 'agent-1', 'Agent', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
     const human = await connectGroupChatClient(port, 'human-1', 'Human')
     harness.sockets.push(agent, human)
     await emitAck(agent, 'join', { roomId: 'room-1' })
-    await emitAck(human, 'join', { roomId: 'room-1' })
+    await emitAck(human, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
     return { agent, human }
+  }
+
+  function wait(ms = 30) {
+    return new Promise(resolve => setTimeout(resolve, ms))
   }
 
   it('relays context status and updates room token count', async () => {
@@ -45,6 +54,19 @@ describe('group chat approval and context baseline', () => {
     expect(groupServer.getStorage().getRoom('room-1')).toMatchObject({ totalTokens: 123 })
   })
 
+  it('ignores context status emitted by human sockets', async () => {
+    const { human } = await joinPair()
+
+    human.emit('context_status', { roomId: 'room-1', agentName: 'Agent', status: 'replying', totalTokens: 999 })
+    await wait()
+
+    expect(groupServer.getStorage().getRoom('room-1')).toMatchObject({ totalTokens: 0 })
+    const lateJoiner = await connectGroupChatClient(port, 'human-2', 'Late')
+    harness.sockets.push(lateJoiner)
+    const joined = await emitAck<any>(lateJoiner, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    expect(joined.contextStatuses).toEqual([])
+  })
+
   it('clears ready context status from join recovery', async () => {
     const { agent } = await joinPair()
     agent.emit('context_status', { roomId: 'room-1', agentName: 'Agent', status: 'replying' })
@@ -52,7 +74,7 @@ describe('group chat approval and context baseline', () => {
 
     const lateJoiner = await connectGroupChatClient(port, 'human-2', 'Late')
     harness.sockets.push(lateJoiner)
-    const joined = await emitAck<any>(lateJoiner, 'join', { roomId: 'room-1' })
+    const joined = await emitAck<any>(lateJoiner, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
 
     expect(joined.contextStatuses).toEqual([])
   })
@@ -76,6 +98,45 @@ describe('group chat approval and context baseline', () => {
       approval_id: 'approval-1',
       choices: ['once', 'session', 'deny'],
     })
+  })
+
+  it('does not relay approval payloads to read-only invite members', async () => {
+    const { agent, human } = await joinPair()
+    const readonly = await connectGroupChatClient(port, 'human-readonly', 'ReadOnly')
+    harness.sockets.push(readonly)
+    groupServer.getIO().of('/group-chat').sockets.get(readonly.id!)!.data.authUser = { id: 7, role: 'user', profiles: [] }
+    await emitAck(readonly, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+
+    let leaked: unknown = null
+    readonly.on('approval.requested', payload => { leaked = payload })
+    const managerRequest = once<any>(human, 'approval.requested')
+
+    agent.emit('approval.requested', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      approval_id: 'approval-private',
+      command: 'cat /private/workspace/secret',
+      description: 'needs approval',
+    })
+
+    expect(await managerRequest).toMatchObject({ approval_id: 'approval-private' })
+    await wait()
+    expect(leaked).toBeNull()
+  })
+
+  it('ignores approval events emitted by human sockets', async () => {
+    const { human } = await joinPair()
+    let requested = false
+    let resolved = false
+    human.on('approval.requested', () => { requested = true })
+    human.on('approval.resolved', () => { resolved = true })
+
+    human.emit('approval.requested', { roomId: 'room-1', agentName: 'Agent', approval_id: 'approval-human' })
+    human.emit('approval.resolved', { roomId: 'room-1', agentName: 'Agent', approval_id: 'approval-human', choice: 'deny' })
+    await wait()
+
+    expect(requested).toBe(false)
+    expect(resolved).toBe(false)
   })
 
   it('relays approval resolved with normalized choice', async () => {

--- a/tests/server/group-chat-baseline.test.ts
+++ b/tests/server/group-chat-baseline.test.ts
@@ -38,7 +38,7 @@ describe('group chat baseline behavior', () => {
 
     const alice = await connectGroupChatClient(port, 'user-a', 'Alice')
     harness.sockets.push(alice)
-    const joined = await emitAck<any>(alice, 'join', { roomId: 'room-1' })
+    const joined = await emitAck<any>(alice, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
 
     expect(joined).toMatchObject({ roomId: 'room-1' })
     expect(joined.messages.map((m: any) => m.id)).toEqual(['msg-1'])
@@ -51,8 +51,8 @@ describe('group chat baseline behavior', () => {
     const alice = await connectGroupChatClient(port, 'user-a', 'Alice')
     const bob = await connectGroupChatClient(port, 'user-b', 'Bob')
     harness.sockets.push(alice, bob)
-    await emitAck(alice, 'join', { roomId: 'room-1' })
-    await emitAck(bob, 'join', { roomId: 'room-1' })
+    await emitAck(alice, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    await emitAck(bob, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
 
     const seenByBob = once<any>(bob, 'message')
     const ack = await emitAck<any>(alice, 'message', { roomId: 'room-1', id: 'client-msg-1', content: 'hello room' })

--- a/tests/server/group-chat-member-sync.test.ts
+++ b/tests/server/group-chat-member-sync.test.ts
@@ -69,17 +69,20 @@ describe('Group Chat member/agent identity sync', () => {
   })
 
   it('passes the same persisted agent id into the runtime client when adding an agent', async () => {
-    const addRoomAgent = vi.fn((roomId: string, agentId: string, profile: string, name: string, description: string, invited: number) => ({
-      id: 'row-1', roomId, agentId, profile, name, description, invited,
-    }))
+    const calls: string[] = []
+    const addRoomAgent = vi.fn((roomId: string, agentId: string, profile: string, name: string, description: string, invited: number) => {
+      calls.push('persist-agent')
+      return { id: 'row-1', roomId, agentId, profile, name, description, invited }
+    })
     const chatServer = {
       getStorage: () => ({
         getRoomAgents: vi.fn(() => []),
         addRoomAgent,
+        removeRoomAgent: vi.fn(),
       }),
       agentClients: {
         createAgent: vi.fn(async () => ({ agentId: 'runtime-agent' })),
-        addAgentToRoom: vi.fn(async () => undefined),
+        addAgentToRoom: vi.fn(async () => { calls.push('join-room') }),
       },
     }
     setGroupChatServer(chatServer as any)
@@ -95,6 +98,7 @@ describe('Group Chat member/agent identity sync', () => {
 
     const persisted = ctx.body.agent
     expect(persisted.agentId).toBeTruthy()
+    expect(calls).toEqual(['persist-agent', 'join-room'])
     expect(chatServer.agentClients.createAgent).toHaveBeenCalledWith(expect.objectContaining({
       agentId: persisted.agentId,
       profile: 'default',
@@ -137,13 +141,54 @@ describe('Group Chat member/agent identity sync', () => {
     expect(addRoomAgent).not.toHaveBeenCalled()
   })
 
-  it('does not persist an agent and disconnects runtime state when room join fails', async () => {
-    const addRoomAgent = vi.fn()
+  it('disconnects a newly created runtime agent when persistence fails before room join', async () => {
+    const runtimeClient = { agentId: 'agent-stable-1', disconnect: vi.fn() }
+    const addRoomAgent = vi.fn(() => {
+      throw new Error('database locked')
+    })
+    const chatServer = {
+      getStorage: () => ({
+        getRoomAgents: vi.fn(() => []),
+        addRoomAgent,
+        removeRoomAgent: vi.fn(),
+      }),
+      agentClients: {
+        createAgent: vi.fn(async () => runtimeClient),
+        addAgentToRoom: vi.fn(),
+        removeAgentFromRoom: vi.fn(),
+      },
+    }
+    setGroupChatServer(chatServer as any)
+
+    const handler = routeHandler('/api/hermes/group-chat/rooms/:roomId/agents', 'POST')
+    const ctx: any = {
+      params: { roomId: 'room-1' },
+      request: { body: { profile: 'default', name: 'Worker' } },
+      status: 200,
+      body: undefined,
+    }
+    await handler(ctx, async () => {})
+
+    expect(ctx.status).toBe(502)
+    expect(ctx.body).toMatchObject({
+      code: 'PROFILE_AGENT_CONNECT_FAILED',
+      profile: 'default',
+      reason: 'database locked',
+    })
+    expect(chatServer.agentClients.addAgentToRoom).not.toHaveBeenCalled()
+    expect(runtimeClient.disconnect).toHaveBeenCalled()
+    expect(chatServer.agentClients.removeAgentFromRoom).toHaveBeenCalledWith('room-1', 'agent-stable-1')
+  })
+
+  it('does not leave a persisted agent row and disconnects runtime state when room join fails', async () => {
+    const addRoomAgent = vi.fn((roomId: string, agentId: string, profile: string, name: string, description: string, invited: number) => ({ id: 'row-1', roomId, agentId, profile, name, description, invited }))
+    const removeRoomAgent = vi.fn()
     const runtimeClient = { agentId: 'agent-stable-1' }
     const chatServer = {
       getStorage: () => ({
         getRoomAgents: vi.fn(() => []),
         addRoomAgent,
+        removeRoomAgent,
       }),
       agentClients: {
         createAgent: vi.fn(async () => runtimeClient),
@@ -170,7 +215,8 @@ describe('Group Chat member/agent identity sync', () => {
       profile: 'default',
       reason: 'join failed',
     })
-    expect(addRoomAgent).not.toHaveBeenCalled()
+    expect(addRoomAgent).toHaveBeenCalledWith('room-1', expect.any(String), 'default', 'Worker', '', 0)
+    expect(removeRoomAgent).toHaveBeenCalledWith('room-1', 'row-1')
     expect(chatServer.agentClients.removeAgentFromRoom).toHaveBeenCalledWith('room-1', 'agent-stable-1')
   })
 
@@ -222,6 +268,161 @@ describe('Group Chat member/agent identity sync', () => {
       agents: [],
       members: [{ id: 'member-1', userId: 'human-1', name: 'Han', description: '', joinedAt: 1 }],
     })
+  })
+
+  it('rejects authenticated Socket.IO room joins without invite, membership, owner, or profile scope', () => {
+    const emit = vi.fn()
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map()
+    server.socketUserMap = new Map([['socket-1', 'auth:42']])
+    server.socketRequestedSourceMap = new Map([['socket-1', 'human']])
+    server.socketAuthUserIdMap = new Map([['socket-1', 42]])
+    server.userInfoMap = new Map([['auth:42', { name: 'alice', description: '' }]])
+    server.typingState = new Map()
+    server.contextStatusState = new Map()
+    server.storage = {
+      getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', inviteCode: 'secret', ownerAuthUserId: 7 })),
+      getRoomAgentByAgentId: vi.fn(() => null),
+      getMemberByUserId: vi.fn(() => null),
+      getMemberByAuthUserId: vi.fn(() => null),
+      getRoomsForProfiles: vi.fn(() => []),
+      saveRoom: vi.fn(),
+      addRoomMember: vi.fn(),
+      getRecentMessagesForUI: vi.fn(() => []),
+      getRoomAgents: vi.fn(() => []),
+    }
+    const socket = {
+      id: 'socket-1',
+      data: { authUser: { id: 42, username: 'alice', role: 'admin', profiles: ['other'] } },
+      join: vi.fn(),
+      to: vi.fn(() => ({ emit })),
+    }
+    const ack = vi.fn()
+
+    server.handleJoin(socket, { roomId: 'room-1' }, ack)
+
+    expect(ack).toHaveBeenCalledWith({ error: 'Access denied' })
+    expect(server.storage.addRoomMember).not.toHaveBeenCalled()
+    expect(socket.join).not.toHaveBeenCalled()
+  })
+
+  it('denies read-only room members realtime management actions', async () => {
+    const emit = vi.fn()
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map([['room-1', { hasOnlineMember: vi.fn(() => true) }]])
+    server.storage = {
+      getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', ownerAuthUserId: 7, inviteCode: 'secret' })),
+      getRoomsForProfiles: vi.fn(() => []),
+    }
+    server.agentClients = { interruptAgent: vi.fn() }
+    server.nsp = { to: vi.fn(() => ({ emit })) }
+    const socket = {
+      id: 'socket-1',
+      data: { authUser: { id: 42, username: 'member', role: 'admin', profiles: ['other'] } },
+    }
+    const interruptAck = vi.fn()
+    const approvalAck = vi.fn()
+
+    await server.handleInterruptAgent(socket, { roomId: 'room-1', agentName: 'Worker' }, interruptAck)
+    await server.handleApprovalRespond(socket, { roomId: 'room-1', approval_id: 'approval-1', choice: 'once' }, approvalAck)
+
+    expect(interruptAck).toHaveBeenCalledWith({ error: 'Access denied' })
+    expect(approvalAck).toHaveBeenCalledWith({ error: 'Access denied' })
+    expect(server.agentClients.interruptAgent).not.toHaveBeenCalled()
+  })
+
+  it('denies runtime agent sockets realtime management actions even after they join the room', async () => {
+    const emit = vi.fn()
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map([['room-1', { hasOnlineMember: vi.fn(() => true) }]])
+    server.socketRequestedSourceMap = new Map([['agent-socket', 'agent']])
+    server.storage = {
+      getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', ownerAuthUserId: 7, inviteCode: 'secret' })),
+      getRoomsForProfiles: vi.fn(() => []),
+    }
+    server.agentClients = { interruptAgent: vi.fn() }
+    server.nsp = { to: vi.fn(() => ({ emit })) }
+    const socket = { id: 'agent-socket', data: {} }
+    const interruptAck = vi.fn()
+    const approvalAck = vi.fn()
+
+    await server.handleInterruptAgent(socket, { roomId: 'room-1', agentName: 'Worker' }, interruptAck)
+    await server.handleApprovalRespond(socket, { roomId: 'room-1', approval_id: 'approval-1', choice: 'once' }, approvalAck)
+
+    expect(interruptAck).toHaveBeenCalledWith({ error: 'Access denied' })
+    expect(approvalAck).toHaveBeenCalledWith({ error: 'Access denied' })
+    expect(server.agentClients.interruptAgent).not.toHaveBeenCalled()
+  })
+
+  it('allows pre-persisted agent sockets to join without creating human membership', () => {
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map()
+    server.socketUserMap = new Map([['socket-agent', 'agent-stable-1']])
+    server.socketRequestedSourceMap = new Map([['socket-agent', 'agent']])
+    server.socketAuthUserIdMap = new Map()
+    server.userInfoMap = new Map([['agent-stable-1', { name: 'Worker', description: 'runtime agent' }]])
+    server.typingState = new Map()
+    server.contextStatusState = new Map()
+    server.storage = {
+      getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', inviteCode: 'secret', ownerAuthUserId: 7 })),
+      getRoomAgentByAgentId: vi.fn(() => ({ id: 'row-1', roomId: 'room-1', agentId: 'agent-stable-1', profile: 'default', name: 'Worker', description: '', invited: 0 })),
+      getMemberByUserId: vi.fn(() => null),
+      getMemberByAuthUserId: vi.fn(() => null),
+      saveRoom: vi.fn(),
+      addRoomMember: vi.fn(),
+      getRecentMessagesForUI: vi.fn(() => []),
+      getRoomAgents: vi.fn(() => []),
+    }
+    const socket = {
+      id: 'socket-agent',
+      data: {},
+      join: vi.fn(),
+      to: vi.fn(() => ({ emit: vi.fn() })),
+    }
+    const ack = vi.fn()
+
+    server.handleJoin(socket, { roomId: 'room-1' }, ack)
+
+    expect(server.storage.getRoomAgentByAgentId).toHaveBeenCalledWith('room-1', 'agent-stable-1')
+    expect(server.storage.addRoomMember).not.toHaveBeenCalled()
+    expect(socket.join).toHaveBeenCalledWith('room-1')
+    expect(ack.mock.calls[0][0]).toEqual(expect.objectContaining({ roomId: 'room-1', messages: [], agents: [] }))
+  })
+
+  it('allows Socket.IO room joins with the matching invite code and then persists membership', () => {
+    const emit = vi.fn()
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map()
+    server.socketUserMap = new Map([['socket-1', 'auth:42']])
+    server.socketRequestedSourceMap = new Map([['socket-1', 'human']])
+    server.socketAuthUserIdMap = new Map([['socket-1', 42]])
+    server.userInfoMap = new Map([['auth:42', { name: 'alice', description: '' }]])
+    server.typingState = new Map()
+    server.contextStatusState = new Map()
+    server.storage = {
+      getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', inviteCode: 'secret', ownerAuthUserId: 7 })),
+      getRoomAgentByAgentId: vi.fn(() => null),
+      getMemberByUserId: vi.fn(() => null),
+      getMemberByAuthUserId: vi.fn(() => null),
+      getRoomsForProfiles: vi.fn(() => []),
+      saveRoom: vi.fn(),
+      addRoomMember: vi.fn(),
+      getRecentMessagesForUI: vi.fn(() => []),
+      getRoomAgents: vi.fn(() => []),
+    }
+    const socket = {
+      id: 'socket-1',
+      data: { authUser: { id: 42, username: 'alice', role: 'admin', profiles: ['other'] } },
+      join: vi.fn(),
+      to: vi.fn(() => ({ emit })),
+    }
+    const ack = vi.fn()
+
+    server.handleJoin(socket, { roomId: 'room-1', inviteCode: 'secret' }, ack)
+
+    expect(server.storage.addRoomMember).toHaveBeenCalledWith('room-1', 'auth:42', 'alice', '', expect.any(String), 42)
+    expect(socket.join).toHaveBeenCalledWith('room-1')
+    expect(ack.mock.calls[0][0]).toEqual(expect.objectContaining({ roomId: 'room-1', messages: [], agents: [] }))
   })
 
   it('reuses an authenticated member name when the browser has no local group-chat name', () => {
@@ -295,7 +496,7 @@ describe('Group Chat member/agent identity sync', () => {
 
     expect(storage.getRoomsForProfiles).toHaveBeenCalledWith(['default', 'research'])
     expect(storage.getAllRooms).not.toHaveBeenCalled()
-    expect(ctx.body).toEqual({ rooms: visibleRooms })
+    expect(ctx.body).toEqual({ rooms: [expect.objectContaining({ id: 'room-default', inviteCode: null, canManage: true })] })
   })
 
   it('keeps room list unrestricted for super admins', async () => {
@@ -316,7 +517,7 @@ describe('Group Chat member/agent identity sync', () => {
 
     expect(storage.getAllRooms).toHaveBeenCalledOnce()
     expect(storage.getRoomsForProfiles).not.toHaveBeenCalled()
-    expect(ctx.body).toEqual({ rooms })
+    expect(ctx.body).toEqual({ rooms: [expect.objectContaining({ id: 'room-1', inviteCode: null, canManage: true })] })
   })
 
   it('routes @mentions from users and bounded agent replies', () => {
@@ -334,12 +535,17 @@ describe('Group Chat member/agent identity sync', () => {
       ['human-socket', 'human-1'],
       ['agent-socket', 'agent-1'],
     ])
+    server.socketRequestedSourceMap = new Map([
+      ['human-socket', 'human'],
+      ['agent-socket', 'agent'],
+    ])
     server.userInfoMap = new Map([
       ['human-1', { name: 'Human', description: '' }],
       ['agent-1', { name: '丫鬟', description: '' }],
     ])
     server.agentClients = { processMentions: vi.fn(async () => undefined) }
     server.storage = {
+      getRoom: vi.fn(() => ({ id: 'room-1' })),
       saveMessageAndRefreshRoom: vi.fn((msg: any) => ({ message: msg, totalTokens: 123 })),
     }
     server.nsp = { to: vi.fn(() => ({ emit })) }

--- a/tests/server/group-chat-streaming.test.ts
+++ b/tests/server/group-chat-streaming.test.ts
@@ -5,6 +5,7 @@ import {
   emitAck,
   once,
 } from './group-chat-test-helpers'
+import { GROUP_CHAT_AGENT_SOCKET_SECRET } from '../../packages/server/src/services/hermes/group-chat/agent-clients'
 import type { GroupChatServer } from '../../packages/server/src/services/hermes/group-chat'
 
 describe('group chat streaming baseline', () => {
@@ -18,6 +19,7 @@ describe('group chat streaming baseline', () => {
     groupServer = harness.groupServer
     port = harness.port
     groupServer.getStorage().saveRoom('room-1', 'Room 1', 'ROOM1')
+    groupServer.getStorage().addRoomAgent('room-1', 'agent-worker', 'default', 'Worker', '', 0)
   })
 
   afterEach(() => {
@@ -27,17 +29,22 @@ describe('group chat streaming baseline', () => {
   async function joinPair() {
     const alice = await connectGroupChatClient(port, 'user-a', 'Alice')
     const bob = await connectGroupChatClient(port, 'user-b', 'Bob')
-    harness.sockets.push(alice, bob)
-    await emitAck(alice, 'join', { roomId: 'room-1' })
-    await emitAck(bob, 'join', { roomId: 'room-1' })
-    return { alice, bob }
+    const worker = await connectGroupChatClient(port, 'agent-worker', 'Worker', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    harness.sockets.push(alice, bob, worker)
+    await emitAck(alice, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    await emitAck(bob, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    await emitAck(worker, 'join', { roomId: 'room-1' })
+    return { alice, bob, worker }
   }
 
   it('relays stream start, content delta, reasoning delta, and stream end to room members', async () => {
-    const { alice, bob } = await joinPair()
+    const { worker, bob } = await joinPair()
 
     const streamStart = once<any>(bob, 'message_stream_start')
-    alice.emit('message_stream_start', { roomId: 'room-1', id: 'stream-1', senderName: 'Worker', timestamp: 10 })
+    worker.emit('message_stream_start', { roomId: 'room-1', id: 'stream-1', senderName: 'Spoofed', timestamp: 10 })
     expect(await streamStart).toMatchObject({
       id: 'stream-1',
       roomId: 'room-1',
@@ -47,16 +54,34 @@ describe('group chat streaming baseline', () => {
     })
 
     const contentDelta = once<any>(bob, 'message_stream_delta')
-    alice.emit('message_stream_delta', { roomId: 'room-1', id: 'stream-1', delta: 'hello' })
+    worker.emit('message_stream_delta', { roomId: 'room-1', id: 'stream-1', delta: 'hello' })
     expect(await contentDelta).toEqual({ roomId: 'room-1', id: 'stream-1', delta: 'hello' })
 
     const reasoningDelta = once<any>(bob, 'message_reasoning_delta')
-    alice.emit('message_reasoning_delta', { roomId: 'room-1', id: 'stream-1', delta: 'thinking' })
+    worker.emit('message_reasoning_delta', { roomId: 'room-1', id: 'stream-1', delta: 'thinking' })
     expect(await reasoningDelta).toEqual({ roomId: 'room-1', id: 'stream-1', delta: 'thinking' })
 
     const streamEnd = once<any>(bob, 'message_stream_end')
-    alice.emit('message_stream_end', { roomId: 'room-1', id: 'stream-1' })
+    worker.emit('message_stream_end', { roomId: 'room-1', id: 'stream-1' })
     expect(await streamEnd).toEqual({ roomId: 'room-1', id: 'stream-1' })
+  })
+
+  it('ignores stream events emitted by human sockets', async () => {
+    const { alice, bob } = await joinPair()
+    const unexpectedStart = once<any>(bob, 'message_stream_start', 100)
+    const unexpectedDelta = once<any>(bob, 'message_stream_delta', 100)
+    const unexpectedReasoning = once<any>(bob, 'message_reasoning_delta', 100)
+    const unexpectedEnd = once<any>(bob, 'message_stream_end', 100)
+
+    alice.emit('message_stream_start', { roomId: 'room-1', id: 'stream-human', senderName: 'Worker' })
+    alice.emit('message_stream_delta', { roomId: 'room-1', id: 'stream-human', delta: 'hello' })
+    alice.emit('message_reasoning_delta', { roomId: 'room-1', id: 'stream-human', delta: 'thinking' })
+    alice.emit('message_stream_end', { roomId: 'room-1', id: 'stream-human' })
+
+    await expect(unexpectedStart).rejects.toThrow('timeout waiting for message_stream_start')
+    await expect(unexpectedDelta).rejects.toThrow('timeout waiting for message_stream_delta')
+    await expect(unexpectedReasoning).rejects.toThrow('timeout waiting for message_reasoning_delta')
+    await expect(unexpectedEnd).rejects.toThrow('timeout waiting for message_stream_end')
   })
 
   it('ignores a representative invalid stream id', async () => {

--- a/tests/server/group-chat-workspace.test.ts
+++ b/tests/server/group-chat-workspace.test.ts
@@ -1,0 +1,361 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DatabaseSync } from 'node:sqlite'
+import { createServer, type Server as HttpServer } from 'http'
+import { mkdir, mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const dbState = vi.hoisted(() => ({
+  db: null as DatabaseSync | null,
+}))
+
+vi.mock('../../packages/server/src/db/index', () => ({
+  getDb: () => dbState.db,
+  isSqliteAvailable: () => Boolean(dbState.db),
+}))
+
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => ({
+    id: 'agent-socket',
+    connected: true,
+    io: { on: vi.fn() },
+    on: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}))
+
+vi.mock('../../packages/server/src/services/auth', () => ({
+  getToken: vi.fn(async () => 'test-token'),
+}))
+
+async function routeHandler(path: string, method: string) {
+  const { groupChatRoutes } = await import('../../packages/server/src/routes/hermes/group-chat')
+  const layer = (groupChatRoutes as any).stack.find((item: any) => item.path === path && item.methods.includes(method))
+  if (!layer) throw new Error(`Route not found: ${method} ${path}`)
+  return layer.stack[0]
+}
+
+describe('group chat room workspace', () => {
+  let httpServer: HttpServer
+  let root: string
+  let originalWorkspaceBase: string | undefined
+
+  beforeEach(async () => {
+    vi.resetModules()
+    dbState.db = new DatabaseSync(':memory:')
+    root = await mkdtemp(join(tmpdir(), 'hermes-gc-workspace-'))
+    originalWorkspaceBase = process.env.WORKSPACE_BASE
+    process.env.WORKSPACE_BASE = root
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    initAllHermesTables()
+    httpServer = createServer()
+  })
+
+  afterEach(async () => {
+    httpServer?.close()
+    dbState.db?.close()
+    dbState.db = null
+    if (originalWorkspaceBase === undefined) delete process.env.WORKSPACE_BASE
+    else process.env.WORKSPACE_BASE = originalWorkspaceBase
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('defaults, persists, clears, and returns room workspace in list/detail rows', async () => {
+    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
+    const server = new GroupChatServer(httpServer)
+    const storage = server.getStorage()
+    const workspace = join(root, 'repo')
+    await mkdir(workspace)
+
+    storage.saveRoom('room-1', 'Room 1')
+    const initialSeed = storage.getRoom('room-1')?.sessionSeed
+    expect(storage.getRoom('room-1')?.workspace).toBe('')
+
+    const firstWorkspaceRoom = storage.updateRoomWorkspace('room-1', workspace)
+    expect(firstWorkspaceRoom?.workspace).toBe(workspace)
+    expect(firstWorkspaceRoom?.sessionSeed).not.toBe(initialSeed)
+    const workspaceSeed = firstWorkspaceRoom?.sessionSeed
+    expect(storage.getAllRooms()[0]?.workspace).toBe(workspace)
+    expect(storage.getRoom('room-1')?.workspace).toBe(workspace)
+
+    expect(storage.updateRoomWorkspace('room-1', workspace)?.sessionSeed).toBe(workspaceSeed)
+    const clearedRoom = storage.updateRoomWorkspace('room-1', '')
+    expect(clearedRoom?.workspace).toBe('')
+    expect(clearedRoom?.sessionSeed).not.toBe(workspaceSeed)
+    server.getIO().close()
+  })
+
+  it('sets a validated top-level workspace when creating a room', async () => {
+    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
+    const { setGroupChatServer } = await import('../../packages/server/src/routes/hermes/group-chat')
+    const server = new GroupChatServer(httpServer)
+    setGroupChatServer(server)
+    const workspace = join(root, 'repo with spaces')
+    await mkdir(workspace)
+
+    const handler = await routeHandler('/api/hermes/group-chat/rooms', 'POST')
+    const ctx: any = {
+      request: { body: { name: 'Room 1', inviteCode: 'invite-1', workspace, agents: [] } },
+      status: 200,
+      body: undefined,
+    }
+
+    await handler(ctx, async () => {})
+
+    expect(ctx.body.room.workspace).toBe(workspace)
+    expect(server.getStorage().getRoom(ctx.body.room.id)?.workspace).toBe(workspace)
+    server.getIO().close()
+  })
+
+  it('rejects invalid top-level workspace values when creating a room', async () => {
+    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
+    const { setGroupChatServer } = await import('../../packages/server/src/routes/hermes/group-chat')
+    const server = new GroupChatServer(httpServer)
+    setGroupChatServer(server)
+
+    const handler = await routeHandler('/api/hermes/group-chat/rooms', 'POST')
+    const ctx: any = {
+      request: { body: { name: 'Room 1', inviteCode: 'invite-1', workspace: '/definitely/outside', agents: [] } },
+      status: 200,
+      body: undefined,
+    }
+
+    await handler(ctx, async () => {})
+
+    expect(ctx.status).toBe(403)
+    expect(ctx.body).toEqual({ error: 'Workspace folder is not allowed' })
+    expect(server.getStorage().getAllRooms()).toEqual([])
+    server.getIO().close()
+  })
+
+  it('ignores unvalidated workspace values hidden in create-room compression config', async () => {
+    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
+    const { setGroupChatServer } = await import('../../packages/server/src/routes/hermes/group-chat')
+    const server = new GroupChatServer(httpServer)
+    setGroupChatServer(server)
+
+    const handler = await routeHandler('/api/hermes/group-chat/rooms', 'POST')
+    const ctx: any = {
+      request: {
+        body: {
+          name: 'Room 1',
+          inviteCode: 'invite-1',
+          compression: { triggerTokens: 123, workspace: '/definitely/outside' },
+          agents: [],
+        },
+      },
+      status: 200,
+      body: undefined,
+    }
+
+    await handler(ctx, async () => {})
+
+    expect(ctx.body.room.workspace).toBe('')
+    expect(ctx.body.room.triggerTokens).toBe(123)
+    server.getIO().close()
+  })
+
+  it('lets a regular admin reopen and list an agentless room they created', async () => {
+    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
+    const { setGroupChatServer } = await import('../../packages/server/src/routes/hermes/group-chat')
+    const server = new GroupChatServer(httpServer)
+    setGroupChatServer(server)
+    const user = { id: 7, username: 'alice', role: 'admin', profiles: ['default'] }
+
+    const create = await routeHandler('/api/hermes/group-chat/rooms', 'POST')
+    const createCtx: any = {
+      state: { user },
+      request: { body: { name: 'Agentless', inviteCode: 'agentless', agents: [] } },
+      status: 200,
+      body: undefined,
+    }
+    await create(createCtx, async () => {})
+    const roomId = createCtx.body.room.id
+
+    const detail = await routeHandler('/api/hermes/group-chat/rooms/:roomId', 'GET')
+    const detailCtx: any = { params: { roomId }, query: {}, state: { user }, status: 200, body: undefined }
+    await detail(detailCtx, async () => {})
+    expect(detailCtx.body.room.id).toBe(roomId)
+
+    const list = await routeHandler('/api/hermes/group-chat/rooms', 'GET')
+    const listCtx: any = { state: { user }, status: 200, body: undefined }
+    await list(listCtx, async () => {})
+    expect(listCtx.body.rooms.map((room: any) => room.id)).toContain(roomId)
+    server.getIO().close()
+  })
+
+  it('does not expose configured workspace paths through invite-code lookup', async () => {
+    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
+    const { setGroupChatServer } = await import('../../packages/server/src/routes/hermes/group-chat')
+    const server = new GroupChatServer(httpServer)
+    const workspace = join(root, 'repo')
+    await mkdir(workspace)
+    server.getStorage().saveRoom('room-1', 'Room 1', 'invite-1')
+    server.getStorage().updateRoomWorkspace('room-1', workspace)
+    setGroupChatServer(server)
+
+    const handler = await routeHandler('/api/hermes/group-chat/rooms/join/:code', 'GET')
+    const ctx: any = { params: { code: 'invite-1' }, status: 200, body: undefined }
+    await handler(ctx, async () => {})
+
+    expect(ctx.body.room.id).toBe('room-1')
+    expect(ctx.body.room.workspace).toBe('')
+    expect(ctx.body.room.inviteCode).toBe(null)
+    expect(ctx.body.room.canManage).toBe(false)
+    server.getIO().close()
+  })
+
+  it('keeps invite-code members read-only and redacts workspace paths without profile access', async () => {
+    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
+    const { setGroupChatServer } = await import('../../packages/server/src/routes/hermes/group-chat')
+    const server = new GroupChatServer(httpServer)
+    const storage = server.getStorage()
+    const workspace = join(root, 'repo')
+    await mkdir(workspace)
+    storage.saveRoom('room-1', 'Room 1', 'invite-1')
+    storage.updateRoomWorkspace('room-1', workspace)
+    storage.addRoomAgent('room-1', 'agent-1', 'research', 'Researcher', '', 0)
+    storage.addRoomMember('room-1', 'user-2', 'Bob', '', '', 2)
+    setGroupChatServer(server)
+    const user = { id: 2, username: 'bob', role: 'admin', profiles: ['default'] }
+
+    const list = await routeHandler('/api/hermes/group-chat/rooms', 'GET')
+    const listCtx: any = { state: { user }, status: 200, body: undefined }
+    await list(listCtx, async () => {})
+    expect(listCtx.body.rooms).toEqual([expect.objectContaining({ id: 'room-1', workspace: '', inviteCode: null, canManage: false })])
+
+    const detail = await routeHandler('/api/hermes/group-chat/rooms/:roomId', 'GET')
+    const detailCtx: any = { params: { roomId: 'room-1' }, query: {}, state: { user }, status: 200, body: undefined }
+    await detail(detailCtx, async () => {})
+    expect(detailCtx.status).toBe(200)
+    expect(detailCtx.body.room.workspace).toBe('')
+    expect(detailCtx.body.room.inviteCode).toBe(null)
+    expect(detailCtx.body.room.canManage).toBe(false)
+
+    const updateWorkspace = await routeHandler('/api/hermes/group-chat/rooms/:roomId/workspace', 'PUT')
+    const workspaceCtx: any = { params: { roomId: 'room-1' }, request: { body: { workspace } }, state: { user }, status: 200, body: undefined }
+    await updateWorkspace(workspaceCtx, async () => {})
+    expect(workspaceCtx.status).toBe(403)
+    expect(storage.getRoom('room-1')?.workspace).toBe(workspace)
+
+    const clone = await routeHandler('/api/hermes/group-chat/rooms/:roomId/clone', 'POST')
+    const cloneCtx: any = { params: { roomId: 'room-1' }, request: { body: { name: 'Copy' } }, state: { user }, status: 200, body: undefined }
+    await clone(cloneCtx, async () => {})
+    expect(cloneCtx.status).toBe(403)
+    expect(storage.getAllRooms()).toHaveLength(1)
+    server.getIO().close()
+  })
+
+  it('rejects workspace updates for rooms outside a regular admin profile scope', async () => {
+    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
+    const { setGroupChatServer } = await import('../../packages/server/src/routes/hermes/group-chat')
+    const server = new GroupChatServer(httpServer)
+    const storage = server.getStorage()
+    const workspace = join(root, 'repo')
+    await mkdir(workspace)
+    storage.saveRoom('room-private', 'Private Room')
+    storage.addRoomAgent('room-private', 'agent-1', 'research', 'Researcher', '', 0)
+    setGroupChatServer(server)
+
+    const handler = await routeHandler('/api/hermes/group-chat/rooms/:roomId/workspace', 'PUT')
+    const ctx: any = {
+      params: { roomId: 'room-private' },
+      state: { user: { id: 2, username: 'ops', role: 'admin', profiles: ['default'] } },
+      request: { body: { workspace } },
+      status: 200,
+      body: undefined,
+    }
+
+    await handler(ctx, async () => {})
+
+    expect(ctx.status).toBe(403)
+    expect(ctx.body).toEqual({ error: 'Access denied' })
+    expect(storage.getRoom('room-private')?.workspace).toBe('')
+    server.getIO().close()
+  })
+
+  it('rejects room detail and clone reads outside a regular admin profile scope', async () => {
+    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
+    const { setGroupChatServer } = await import('../../packages/server/src/routes/hermes/group-chat')
+    const server = new GroupChatServer(httpServer)
+    const storage = server.getStorage()
+    const workspace = join(root, 'repo')
+    await mkdir(workspace)
+    storage.saveRoom('room-private', 'Private Room')
+    storage.updateRoomWorkspace('room-private', workspace)
+    storage.addRoomAgent('room-private', 'agent-1', 'research', 'Researcher', '', 0)
+    setGroupChatServer(server)
+    const user = { id: 2, username: 'ops', role: 'admin', profiles: ['default'] }
+
+    const detail = await routeHandler('/api/hermes/group-chat/rooms/:roomId', 'GET')
+    const detailCtx: any = { params: { roomId: 'room-private' }, query: {}, state: { user }, status: 200, body: undefined }
+    await detail(detailCtx, async () => {})
+    expect(detailCtx.status).toBe(403)
+    expect(detailCtx.body).toEqual({ error: 'Access denied' })
+
+    const clone = await routeHandler('/api/hermes/group-chat/rooms/:roomId/clone', 'POST')
+    const cloneCtx: any = { params: { roomId: 'room-private' }, request: { body: { name: 'Copy' } }, state: { user }, status: 200, body: undefined }
+    await clone(cloneCtx, async () => {})
+    expect(cloneCtx.status).toBe(403)
+    expect(cloneCtx.body).toEqual({ error: 'Access denied' })
+    expect(storage.getAllRooms()).toHaveLength(1)
+    server.getIO().close()
+  })
+
+  it('adds workspace to existing gc_rooms tables with a default value', async () => {
+    dbState.db?.exec('DROP TABLE gc_rooms')
+    dbState.db?.exec(`CREATE TABLE gc_rooms (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      inviteCode TEXT UNIQUE,
+      triggerTokens INTEGER NOT NULL DEFAULT 100000,
+      maxHistoryTokens INTEGER NOT NULL DEFAULT 32000,
+      tailMessageCount INTEGER NOT NULL DEFAULT 10,
+      totalTokens INTEGER NOT NULL DEFAULT 0,
+      sessionSeed TEXT NOT NULL DEFAULT '0'
+    )`)
+    dbState.db?.prepare('INSERT INTO gc_rooms (id, name) VALUES (?, ?)').run('old-room', 'Old Room')
+
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    initAllHermesTables()
+
+    const row = dbState.db?.prepare('SELECT workspace FROM gc_rooms WHERE id = ?').get('old-room') as { workspace: string }
+    expect(row.workspace).toBe('')
+  })
+
+  it('validates workspace updates through the group room REST route', async () => {
+    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
+    const { setGroupChatServer } = await import('../../packages/server/src/routes/hermes/group-chat')
+    const server = new GroupChatServer(httpServer)
+    const workspace = join(root, 'repo')
+    await mkdir(workspace)
+    server.getStorage().saveRoom('room-1', 'Room 1')
+    setGroupChatServer(server)
+
+    const handler = await routeHandler('/api/hermes/group-chat/rooms/:roomId/workspace', 'PUT')
+    const okCtx: any = { params: { roomId: 'room-1' }, request: { body: { workspace } }, status: 200, body: undefined }
+    await handler(okCtx, async () => {})
+    expect(okCtx.body.room.workspace).toBe(workspace)
+
+    const badCtx: any = { params: { roomId: 'room-1' }, request: { body: { workspace: '/definitely/outside' } }, status: 200, body: undefined }
+    await handler(badCtx, async () => {})
+    expect(badCtx.status).toBe(403)
+    expect(server.getStorage().getRoom('room-1')?.workspace).toBe(workspace)
+
+    const missingCtx: any = { params: { roomId: 'room-1' }, request: { body: {} }, status: 200, body: undefined }
+    await handler(missingCtx, async () => {})
+    expect(missingCtx.status).toBe(400)
+    expect(server.getStorage().getRoom('room-1')?.workspace).toBe(workspace)
+
+    const nullCtx: any = { params: { roomId: 'room-1' }, request: { body: { workspace: null } }, status: 200, body: undefined }
+    await handler(nullCtx, async () => {})
+    expect(nullCtx.status).toBe(400)
+    expect(server.getStorage().getRoom('room-1')?.workspace).toBe(workspace)
+
+    const clearCtx: any = { params: { roomId: 'room-1' }, request: { body: { workspace: '' } }, status: 200, body: undefined }
+    await handler(clearCtx, async () => {})
+    expect(clearCtx.body.room.workspace).toBe('')
+    server.getIO().close()
+  })
+})

--- a/tests/server/workspace-path.test.ts
+++ b/tests/server/workspace-path.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+describe('workspace path validation', () => {
+  let root: string
+  let originalWorkspaceBase: string | undefined
+
+  beforeEach(async () => {
+    vi.resetModules()
+    root = await mkdtemp(join(tmpdir(), 'hermes-workspace-path-'))
+    originalWorkspaceBase = process.env.WORKSPACE_BASE
+    process.env.WORKSPACE_BASE = root
+  })
+
+  afterEach(async () => {
+    if (originalWorkspaceBase === undefined) delete process.env.WORKSPACE_BASE
+    else process.env.WORKSPACE_BASE = originalWorkspaceBase
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('resolves valid folders under the configured base', async () => {
+    const folder = join(root, 'project')
+    await mkdir(folder)
+    const { resolveAllowedWorkspaceFolder } = await import('../../packages/server/src/services/hermes/workspace-path')
+
+    await expect(resolveAllowedWorkspaceFolder('project')).resolves.toEqual({ base: root, fullPath: folder })
+    await expect(resolveAllowedWorkspaceFolder(folder)).resolves.toEqual({ base: root, fullPath: folder })
+  })
+
+  it('rejects traversal outside the base', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'hermes-workspace-path-outside-'))
+    const { resolveAllowedWorkspaceFolder, assertAllowedWorkspaceFolder } = await import('../../packages/server/src/services/hermes/workspace-path')
+
+    await expect(resolveAllowedWorkspaceFolder(outside)).resolves.toBeNull()
+    await expect(assertAllowedWorkspaceFolder(outside)).rejects.toMatchObject({ status: 403 })
+    await rm(outside, { recursive: true, force: true })
+  })
+
+  it('rejects files and empty strings as workspace folders', async () => {
+    await writeFile(join(root, 'file.txt'), 'not a folder')
+    const { resolveAllowedWorkspaceFolder, assertAllowedWorkspaceFolder } = await import('../../packages/server/src/services/hermes/workspace-path')
+
+    await expect(resolveAllowedWorkspaceFolder('file.txt')).resolves.toBeNull()
+    await expect(resolveAllowedWorkspaceFolder('')).resolves.toBeNull()
+    await expect(assertAllowedWorkspaceFolder('')).rejects.toMatchObject({ status: 400 })
+  })
+
+  it('normalizes native Windows drive paths when drive mode is active', async () => {
+    const originalPlatform = process.platform
+    const originalWorkspaceBase = process.env.WORKSPACE_BASE
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    delete process.env.WORKSPACE_BASE
+    try {
+      const { normalizeWindowsWorkspacePath } = await import('../../packages/server/src/services/hermes/workspace-path')
+      expect(normalizeWindowsWorkspacePath('c:/Users/Alice/Project')).toEqual({
+        base: 'C:\\',
+        fullPath: 'c:\\Users\\Alice\\Project',
+      })
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+      if (originalWorkspaceBase === undefined) delete process.env.WORKSPACE_BASE
+      else process.env.WORKSPACE_BASE = originalWorkspaceBase
+    }
+  })
+
+  it('requires realpath containment on Windows when WORKSPACE_BASE is configured', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    try {
+      const { isWorkspaceListPathAllowed } = await import('../../packages/server/src/services/hermes/workspace-path')
+      const directoryStat = async () => ({ isDirectory: () => true }) as any
+      const escapedViaJunction = vi.fn(async () => false)
+      const withinBase = vi.fn(async () => true)
+
+      await expect(isWorkspaceListPathAllowed('C:\\base\\link', 'C:\\base', directoryStat, { realPathWithinFn: escapedViaJunction })).resolves.toBe(false)
+      expect(escapedViaJunction).toHaveBeenCalledWith('C:\\base\\link', 'C:\\base')
+      await expect(isWorkspaceListPathAllowed('C:\\base\\link', 'C:\\base', directoryStat, { trustWindowsJunctions: true, realPathWithinFn: escapedViaJunction })).resolves.toBe(false)
+
+      await expect(isWorkspaceListPathAllowed('C:\\base\\project', 'C:\\base', directoryStat, { realPathWithinFn: withinBase })).resolves.toBe(true)
+      expect(withinBase).toHaveBeenCalledWith('C:\\base\\project', 'C:\\base')
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    }
+  })
+
+  it('keeps Windows drive-root mode listable without a configured base', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    try {
+      const { isWorkspaceListPathAllowed } = await import('../../packages/server/src/services/hermes/workspace-path')
+      const directoryStat = async () => ({ isDirectory: () => true }) as any
+      const realPathWithinFn = vi.fn(async () => false)
+
+      await expect(isWorkspaceListPathAllowed('C:\\Users\\Alice', 'C:\\', directoryStat, { trustWindowsDriveRoot: true, realPathWithinFn })).resolves.toBe(true)
+      expect(realPathWithinFn).not.toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    }
+  })
+})


### PR DESCRIPTION
## 改动说明

这是替代 #1953 的 stacked split 第 1 段，只保留 Group Chat 房间工作区绑定、访问边界和相关 UX。

- 创建房间时支持选择 workspace，并通过 server-side validator 校验 top-level `workspace`。
- 房间信息持久化 validated workspace，并把该 workspace 传给 group-agent Bridge run。
- 对只读 invite/member 访问隐藏 workspace、inviteCode 和管理动作。
- 引入 `canManage` 合约，让管理 UI default-deny，避免依赖 super-admin/unknown-room 推断。
- approval requested/resolved 事件仅广播给 room managers，避免只读成员收到 command/description payload。
- 修复 invite-code join 顺序：先完成 realtime room join，再读取受保护的 room detail。
- 收敛原单体 PR 的 UX：保留 workspace header/sidebar/create-room 相关改动，排除 Files/Terminal side panel、resize listener 和 super-admin-only tool panel 噪音。

## Stack

- Parent: 当前 PR，base = `main`。
- Child: `codex/group-chat-workspace-diff-exec`，base = `codex/group-chat-room-workspace-binding`。
- Supersedes: #1953 的原单体 PR 将由本 PR 和 child PR 替代。

## Diff hygiene

- baoyu infographic、分析稿、HTML/PNG 渲染文件没有进入源码 diff。
- 源码 diff 中仅保留 repo harness/API 合约需要的 `docs/chat-chain-changes` fragment 和 `docs/openapi.json` 生成结果。

## 验证结果

- `npm test -- tests/server/group-chat-workspace.test.ts tests/server/group-chat-agent-workspace.test.ts tests/server/group-chat-approval.test.ts tests/server/group-chat-streaming.test.ts tests/server/group-chat-agent-routing-baseline.test.ts tests/server/group-chat-member-sync.test.ts tests/server/workspace-path.test.ts tests/client/group-chat-store-baseline.test.ts tests/client/group-chat-store-workspace.test.ts tests/client/group-chat-panel-workspace-source.test.ts tests/client/router-login-redirect.test.ts`：通过，11 files / 67 tests passed。
- `npm run test`：通过，289 files passed；2140 passed / 2 skipped。
- `npm run build`：通过。
- `npm run harness:check`：通过，Harness check passed。
- `git diff --check`：通过。
- Independent Codex blocker review：NO BLOCKERS。
