### PR TITLE
fix: inherit external MCP in scoped coding agents

### DIFF
--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -868,16 +868,25 @@ function isManagedHermesMcpServer(value: unknown): boolean {
   return typeof server.command === 'string' && LEGACY_HERMES_MCP_COMMANDS.has(server.command)
 }
 
+function normalizeClaudeMcpServer(server: unknown): unknown {
+  if (!server || typeof server !== 'object' || Array.isArray(server)) return server
+  const normalized = { ...(server as Record<string, unknown>) }
+  if (normalized.type === 'streamableHttp') normalized.type = 'http'
+  return normalized
+}
+
 function parseClaudeMcpServers(existingContent: string | null | undefined = ''): Record<string, unknown> {
   if (!existingContent?.trim()) return {}
   try {
     const parsed = JSON.parse(existingContent)
     if (!parsed?.mcpServers || typeof parsed.mcpServers !== 'object' || Array.isArray(parsed.mcpServers)) return {}
-    return Object.fromEntries(Object.entries(parsed.mcpServers).filter(([name, server]) => {
-      if (HERMES_MCP_SERVER_NAMES.has(name)) return false
-      if (LEGACY_HERMES_MCP_SERVER_NAMES.has(name)) return false
-      return !isManagedHermesMcpServer(server)
-    }))
+    return Object.fromEntries(Object.entries(parsed.mcpServers)
+      .filter(([name, server]) => {
+        if (HERMES_MCP_SERVER_NAMES.has(name)) return false
+        if (LEGACY_HERMES_MCP_SERVER_NAMES.has(name)) return false
+        return !isManagedHermesMcpServer(server)
+      })
+      .map(([name, server]) => [name, normalizeClaudeMcpServer(server)]))
   } catch {
     return {}
   }
@@ -893,6 +902,8 @@ function inheritClaudeSettings(existingContent: string | null | undefined = ''):
     if (Array.isArray(enabledServers)) inherited.enabledMcpjsonServers = enabledServers.map(String).filter(Boolean)
     const plugins = (parsed as any).plugins
     if (plugins && typeof plugins === 'object' && !Array.isArray(plugins)) inherited.plugins = plugins
+    const enabledPlugins = (parsed as any).enabledPlugins
+    if (enabledPlugins && typeof enabledPlugins === 'object' && !Array.isArray(enabledPlugins)) inherited.enabledPlugins = enabledPlugins
     return inherited
   } catch {
     return {}
@@ -911,7 +922,7 @@ function claudeMcpConfigJson(profile: string, ...existingContents: Array<string 
 }
 
 function parseCodexExternalMcpBlocks(...contents: Array<string | null | undefined>): string[] {
-  const blocksByServer = new Map<string, string[]>()
+  const blockByServer = new Map<string, string>()
 
   for (const content of contents) {
     if (!content?.trim()) continue
@@ -922,17 +933,20 @@ function parseCodexExternalMcpBlocks(...contents: Array<string | null | undefine
       const block = currentLines.join('\n').trim()
       const isManaged = block.includes(`${HERMES_MCP_MANAGED_ENV_KEY}`)
       if (!HERMES_MCP_SERVER_NAMES.has(currentServer) && !LEGACY_HERMES_MCP_SERVER_NAMES.has(currentServer) && !isManaged) {
-        const existing = blocksByServer.get(currentServer) || []
-        existing.push(block)
-        blocksByServer.set(currentServer, existing)
+        blockByServer.set(currentServer, block)
       }
     }
 
     for (const line of content.split(/\r?\n/)) {
       const mcpMatch = line.match(/^\s*\[mcp_servers\.([^\].]+)(?:\.[^\]]+)?\]\s*$/)
       if (mcpMatch) {
+        const nextServer = mcpMatch[1]
+        if (currentServer && nextServer === currentServer) {
+          currentLines.push(line)
+          continue
+        }
         flush()
-        currentServer = mcpMatch[1]
+        currentServer = nextServer
         currentLines = [line]
         continue
       }
@@ -947,7 +961,7 @@ function parseCodexExternalMcpBlocks(...contents: Array<string | null | undefine
     flush()
   }
 
-  return Array.from(blocksByServer.values()).flat().filter(Boolean)
+  return Array.from(blockByServer.values()).filter(Boolean)
 }
 
 function codexMcpConfigToml(profile: string, ...externalContents: Array<string | null | undefined>): string {

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -938,10 +938,11 @@ function parseCodexExternalMcpBlocks(...contents: Array<string | null | undefine
     }
 
     for (const line of content.split(/\r?\n/)) {
-      const mcpMatch = line.match(/^\s*\[mcp_servers\.([^\].]+)(?:\.[^\]]+)?\]\s*$/)
+      const mcpMatch = line.match(/^\s*\[mcp_servers\.([^\].]+)(\.[^\]]+)?\]\s*$/)
       if (mcpMatch) {
         const nextServer = mcpMatch[1]
-        if (currentServer && nextServer === currentServer) {
+        const isSubtable = Boolean(mcpMatch[2])
+        if (currentServer && nextServer === currentServer && isSubtable) {
           currentLines.push(line)
           continue
         }

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -166,7 +166,7 @@ const TOOL_DEFINITIONS: CodingAgentDefinition[] = [
 const CONFIG_FILE_DEFINITIONS: Record<CodingAgentId, Array<Omit<CodingAgentConfigFileDefinition, 'absolutePath'> & { scopedPath: string }>> = {
   'claude-code': [
     { key: 'settings', path: '~/.claude/settings.json', scopedPath: 'settings.json', language: 'json' },
-    { key: 'mcp', path: '~/.claude.json', scopedPath: 'mcp.json', language: 'json' },
+    { key: 'mcp', path: '~/.claude/mcp.json', scopedPath: 'mcp.json', language: 'json' },
     { key: 'prompt', path: '~/.claude/hermes-rules.md', scopedPath: 'hermes-rules.md', language: 'markdown' },
   ],
   codex: [
@@ -883,16 +883,75 @@ function parseClaudeMcpServers(existingContent: string | null | undefined = ''):
   }
 }
 
-function claudeMcpConfigJson(profile: string, existingContent: string | null | undefined = ''): string {
-  const mcpServers = parseClaudeMcpServers(existingContent)
+function inheritClaudeSettings(existingContent: string | null | undefined = ''): Record<string, unknown> {
+  if (!existingContent?.trim()) return {}
+  try {
+    const parsed = JSON.parse(existingContent)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    const inherited: Record<string, unknown> = {}
+    const enabledServers = (parsed as any).enabledMcpjsonServers
+    if (Array.isArray(enabledServers)) inherited.enabledMcpjsonServers = enabledServers.map(String).filter(Boolean)
+    const plugins = (parsed as any).plugins
+    if (plugins && typeof plugins === 'object' && !Array.isArray(plugins)) inherited.plugins = plugins
+    return inherited
+  } catch {
+    return {}
+  }
+}
+
+function claudeMcpConfigJson(profile: string, ...existingContents: Array<string | null | undefined>): string {
+  const mcpServers: Record<string, unknown> = {}
+  for (const content of existingContents) {
+    Object.assign(mcpServers, parseClaudeMcpServers(content))
+  }
   for (const server of HERMES_MCP_SERVERS) {
     mcpServers[server.name] = hermesMcpServerConfig(profile, server.name, server.toolset)
   }
   return `${JSON.stringify({ mcpServers }, null, 2)}\n`
 }
 
-function codexMcpConfigToml(profile: string): string {
-  const blocks: string[] = []
+function parseCodexExternalMcpBlocks(...contents: Array<string | null | undefined>): string[] {
+  const blocksByServer = new Map<string, string[]>()
+
+  for (const content of contents) {
+    if (!content?.trim()) continue
+    let currentServer = ''
+    let currentLines: string[] = []
+    const flush = () => {
+      if (!currentServer || currentLines.length === 0) return
+      const block = currentLines.join('\n').trim()
+      const isManaged = block.includes(`${HERMES_MCP_MANAGED_ENV_KEY}`)
+      if (!HERMES_MCP_SERVER_NAMES.has(currentServer) && !LEGACY_HERMES_MCP_SERVER_NAMES.has(currentServer) && !isManaged) {
+        const existing = blocksByServer.get(currentServer) || []
+        existing.push(block)
+        blocksByServer.set(currentServer, existing)
+      }
+    }
+
+    for (const line of content.split(/\r?\n/)) {
+      const mcpMatch = line.match(/^\s*\[mcp_servers\.([^\].]+)(?:\.[^\]]+)?\]\s*$/)
+      if (mcpMatch) {
+        flush()
+        currentServer = mcpMatch[1]
+        currentLines = [line]
+        continue
+      }
+      if (/^\s*\[/.test(line)) {
+        flush()
+        currentServer = ''
+        currentLines = []
+        continue
+      }
+      if (currentServer) currentLines.push(line)
+    }
+    flush()
+  }
+
+  return Array.from(blocksByServer.values()).flat().filter(Boolean)
+}
+
+function codexMcpConfigToml(profile: string, ...externalContents: Array<string | null | undefined>): string {
+  const blocks: string[] = [...parseCodexExternalMcpBlocks(...externalContents)]
   for (const item of HERMES_MCP_SERVERS) {
     const server = hermesMcpServerConfig(profile, item.name, item.toolset)
     const lines = [
@@ -1619,7 +1678,10 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
     const claudeBaseUrl = proxyTarget?.baseUrl || baseUrl
     const claudeApiKey = proxyTarget?.token || apiKey
     const modelName = displayNameForModel(model)
+    const globalSettingsPath = getLiveConfigFileDefinition(tool.id, 'settings')?.absolutePath
+    const inheritedSettings = inheritClaudeSettings(globalSettingsPath ? await safeReadFile(globalSettingsPath) : '')
     const settings = {
+      ...inheritedSettings,
       model,
       env: {
         ...(claudeApiKey ? { ANTHROPIC_API_KEY: claudeApiKey } : {}),
@@ -1637,9 +1699,11 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
     }
     env = settings.env
     await writeScopedFile('settings', `${JSON.stringify(settings, null, 2)}\n`)
+    const globalMcpPath = getLiveConfigFileDefinition(tool.id, 'mcp')?.absolutePath
     const existingMcpPath = getScopedConfigFileDefinition(tool.id, 'mcp', scope)?.absolutePath
+    const globalMcpConfig = globalMcpPath ? await safeReadFile(globalMcpPath) : ''
     const existingMcpConfig = existingMcpPath ? await safeReadFile(existingMcpPath) : ''
-    await writeScopedFile('mcp', claudeMcpConfigJson(scope.profile, existingMcpConfig))
+    await writeScopedFile('mcp', claudeMcpConfigJson(scope.profile, globalMcpConfig, existingMcpConfig))
     await writeScopedFile('prompt', hermesPromptDocument())
 
     const settingsPath = join(rootDir, 'settings.json')
@@ -1695,7 +1759,11 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
       'requires_openai_auth = false',
       ...(codexApiKey ? [`experimental_bearer_token = ${JSON.stringify(codexApiKey)}`] : []),
       '',
-      codexMcpConfigToml(scope.profile),
+      codexMcpConfigToml(
+        scope.profile,
+        await safeReadFile(getLiveConfigFileDefinition(tool.id, 'config')?.absolutePath || ''),
+        await safeReadFile(getScopedConfigFileDefinition(tool.id, 'config', scope)?.absolutePath || ''),
+      ),
     ].join('\n')
     const catalog = buildCodexModelCatalog({
       profile: scope.profile,

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -385,11 +385,19 @@ describe('coding agent launch preparation', () => {
     writeFileSync(codexScopedConfigPath, [
       '[mcp_servers.nowledge-mem]',
       'type = "streamableHttp"',
-      'url = "https://nowledge-mem.scoped.example/remote-api/mcp/"',
+      'url = "https://nowledge-mem.scoped-latest.example/remote-api/mcp/"',
       '',
       '[mcp_servers.nowledge-mem.http_headers]',
       'APP = "codex-scoped"',
       'Authorization = "Bearer scoped"',
+      '',
+      '[mcp_servers.nowledge-mem]',
+      'type = "streamableHttp"',
+      'url = "https://nowledge-mem.scoped-latest.example/remote-api/mcp/"',
+      '',
+      '[mcp_servers.nowledge-mem.http_headers]',
+      'APP = "codex-scoped-latest"',
+      'Authorization = "Bearer scoped-latest"',
       '',
     ].join('\n'))
 
@@ -420,9 +428,10 @@ describe('coding agent launch preparation', () => {
     const codexConfig = readFileSync(join(codex.rootDir, 'config.toml'), 'utf-8')
     expect(codexConfig.match(/^\[mcp_servers\.nowledge-mem\]$/gm)).toHaveLength(1)
     expect(codexConfig.match(/^\[mcp_servers\.nowledge-mem\.http_headers\]$/gm)).toHaveLength(1)
-    expect(codexConfig).toContain('url = "https://nowledge-mem.scoped.example/remote-api/mcp/"')
-    expect(codexConfig).toContain('APP = "codex-scoped"')
+    expect(codexConfig).toContain('url = "https://nowledge-mem.scoped-latest.example/remote-api/mcp/"')
+    expect(codexConfig).toContain('APP = "codex-scoped-latest"')
     expect(codexConfig).not.toContain('APP = "codex"')
+    expect(codexConfig).not.toContain('APP = "codex-scoped"')
     expect(codexConfig).not.toContain('command = "stale-managed"')
     expect(codexConfig).not.toContain('[model_providers.unrelated]')
     expect(codexConfig).toContain('[mcp_servers.hermes-studio-api]')

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -346,8 +346,10 @@ describe('coding agent launch preparation', () => {
     const claudeGlobalMcpPath = join(home, 'global-home', '.claude', 'mcp.json')
     const claudeGlobalSettingsPath = join(home, 'global-home', '.claude', 'settings.json')
     const codexGlobalConfigPath = join(home, 'global-home', '.codex', 'config.toml')
+    const codexScopedConfigPath = join(home, 'coding-agent', 'model', 'default', 'openrouter', 'codex', 'config.toml')
     mkdirSync(dirname(claudeGlobalMcpPath), { recursive: true })
     mkdirSync(dirname(codexGlobalConfigPath), { recursive: true })
+    mkdirSync(dirname(codexScopedConfigPath), { recursive: true })
     writeFileSync(claudeGlobalMcpPath, `${JSON.stringify({
       mcpServers: {
         'nowledge-mem': {
@@ -380,6 +382,16 @@ describe('coding agent launch preparation', () => {
       'name = "should-not-be-copied"',
       '',
     ].join('\n'))
+    writeFileSync(codexScopedConfigPath, [
+      '[mcp_servers.nowledge-mem]',
+      'type = "streamableHttp"',
+      'url = "https://nowledge-mem.scoped.example/remote-api/mcp/"',
+      '',
+      '[mcp_servers.nowledge-mem.http_headers]',
+      'APP = "codex-scoped"',
+      'Authorization = "Bearer scoped"',
+      '',
+    ].join('\n'))
 
     const claude = await prepareCodingAgentLaunch('claude-code', {
       profile: 'default',
@@ -393,7 +405,7 @@ describe('coding agent launch preparation', () => {
     expect(claudeSettings.enabledMcpjsonServers).toEqual(['nowledge-mem'])
     expect(claudeSettings.plugins).toMatchObject({ 'nowledge-mem@nowledge-community': true })
     expect(claudeMcp.mcpServers['nowledge-mem']).toMatchObject({
-      type: 'streamableHttp',
+      type: 'http',
       url: 'https://nowledge-mem.example/remote-api/mcp/',
     })
     expect(claudeMcp.mcpServers['hermes-studio-api'].command).toBe(process.execPath)
@@ -406,9 +418,11 @@ describe('coding agent launch preparation', () => {
       apiKey: 'test-api-key',
     })
     const codexConfig = readFileSync(join(codex.rootDir, 'config.toml'), 'utf-8')
-    expect(codexConfig).toContain('[mcp_servers.nowledge-mem]')
-    expect(codexConfig).toContain('[mcp_servers.nowledge-mem.http_headers]')
-    expect(codexConfig).toContain('APP = "codex"')
+    expect(codexConfig.match(/^\[mcp_servers\.nowledge-mem\]$/gm)).toHaveLength(1)
+    expect(codexConfig.match(/^\[mcp_servers\.nowledge-mem\.http_headers\]$/gm)).toHaveLength(1)
+    expect(codexConfig).toContain('url = "https://nowledge-mem.scoped.example/remote-api/mcp/"')
+    expect(codexConfig).toContain('APP = "codex-scoped"')
+    expect(codexConfig).not.toContain('APP = "codex"')
     expect(codexConfig).not.toContain('command = "stale-managed"')
     expect(codexConfig).not.toContain('[model_providers.unrelated]')
     expect(codexConfig).toContain('[mcp_servers.hermes-studio-api]')

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -341,6 +341,81 @@ describe('coding agent launch preparation', () => {
     expect(codexConfig).toContain('[mcp_servers.hermes-studio-use]')
   })
 
+  it('inherits external MCP configs for scoped Claude and Codex launches', async () => {
+    const home = makeHome()
+    const claudeGlobalMcpPath = join(home, 'global-home', '.claude', 'mcp.json')
+    const claudeGlobalSettingsPath = join(home, 'global-home', '.claude', 'settings.json')
+    const codexGlobalConfigPath = join(home, 'global-home', '.codex', 'config.toml')
+    mkdirSync(dirname(claudeGlobalMcpPath), { recursive: true })
+    mkdirSync(dirname(codexGlobalConfigPath), { recursive: true })
+    writeFileSync(claudeGlobalMcpPath, `${JSON.stringify({
+      mcpServers: {
+        'nowledge-mem': {
+          type: 'streamableHttp',
+          url: 'https://nowledge-mem.example/remote-api/mcp/',
+          headers: { APP: 'claude code', Authorization: 'Bearer test' },
+        },
+        'hermes-studio-api': { command: 'stale-managed' },
+      },
+    }, null, 2)}
+`)
+    writeFileSync(claudeGlobalSettingsPath, `${JSON.stringify({
+      enabledMcpjsonServers: ['nowledge-mem'],
+      plugins: { 'nowledge-mem@nowledge-community': true },
+    }, null, 2)}
+`)
+    writeFileSync(codexGlobalConfigPath, [
+      '[mcp_servers.nowledge-mem]',
+      'type = "streamableHttp"',
+      'url = "https://nowledge-mem.example/remote-api/mcp/"',
+      '',
+      '[mcp_servers.nowledge-mem.http_headers]',
+      'APP = "codex"',
+      'Authorization = "Bearer test"',
+      '',
+      '[mcp_servers.hermes-studio-api]',
+      'command = "stale-managed"',
+      '',
+      '[model_providers.unrelated]',
+      'name = "should-not-be-copied"',
+      '',
+    ].join('\n'))
+
+    const claude = await prepareCodingAgentLaunch('claude-code', {
+      profile: 'default',
+      provider: 'openrouter',
+      model: 'anthropic/claude-sonnet-4.6',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      apiKey: 'test-api-key',
+    })
+    const claudeSettings = JSON.parse(readFileSync(join(claude.rootDir, 'settings.json'), 'utf-8'))
+    const claudeMcp = JSON.parse(readFileSync(join(claude.rootDir, 'mcp.json'), 'utf-8'))
+    expect(claudeSettings.enabledMcpjsonServers).toEqual(['nowledge-mem'])
+    expect(claudeSettings.plugins).toMatchObject({ 'nowledge-mem@nowledge-community': true })
+    expect(claudeMcp.mcpServers['nowledge-mem']).toMatchObject({
+      type: 'streamableHttp',
+      url: 'https://nowledge-mem.example/remote-api/mcp/',
+    })
+    expect(claudeMcp.mcpServers['hermes-studio-api'].command).toBe(process.execPath)
+
+    const codex = await prepareCodingAgentLaunch('codex', {
+      profile: 'default',
+      provider: 'openrouter',
+      model: 'openai/gpt-oss-20b:free',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      apiKey: 'test-api-key',
+    })
+    const codexConfig = readFileSync(join(codex.rootDir, 'config.toml'), 'utf-8')
+    expect(codexConfig).toContain('[mcp_servers.nowledge-mem]')
+    expect(codexConfig).toContain('[mcp_servers.nowledge-mem.http_headers]')
+    expect(codexConfig).toContain('APP = "codex"')
+    expect(codexConfig).not.toContain('command = "stale-managed"')
+    expect(codexConfig).not.toContain('[model_providers.unrelated]')
+    expect(codexConfig).toContain('[mcp_servers.hermes-studio-api]')
+    expect(codexConfig).toContain('[mcp_servers.hermes-studio-devices]')
+    expect(codexConfig).toContain('[mcp_servers.hermes-studio-use]')
+  })
+
   it('isolates Claude Code settings for hidden chat runs only', async () => {
     const home = makeHome()
 


### PR DESCRIPTION
## Summary
- Inherit external Claude Code MCP config from `~/.claude/mcp.json` into scoped coding-agent launches.
- Preserve Claude Code local MCP enablement settings such as `enabledMcpjsonServers` and `plugins` when scoped mode uses `--setting-sources local`.
- Inherit external Codex `[mcp_servers.*]` blocks from global/scoped `config.toml` while filtering stale Hermes-managed MCP blocks.
- Add a regression test for external MCP inheritance in scoped Claude Code and Codex launches.

## Why
Scoped workflow/coding-agent sessions currently regenerate isolated Claude/Codex config. This can drop external MCP servers configured globally, so agents launched from workflows only see Hermes Studio managed MCP servers and cannot use user-installed MCP integrations.

## Related
There is a related upstream PR, #1955, for inheriting profile MCP servers such as Headroom. This PR covers the global Claude/Codex config path needed by external MCP integrations such as Nowledge Mem.

## Validation
- `npm test -- --run tests/server/coding-agents-launch.test.ts -t "inherits external MCP configs"`
- `npm test -- --run tests/server/coding-agents-launch.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run build`
- `git diff --check`
