### PR TITLE
[codex] skip empty workspace diff changes

### DIFF
--- a/docs/chat-chain-changes/2026-07-08-issue1984-empty-workspace-diffs.md
+++ b/docs/chat-chain-changes/2026-07-08-issue1984-empty-workspace-diffs.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-08
+pr: pending
+feature: Empty workspace diff filtering
+impact: Workspace run diff cards skip zero-byte content-only changes so empty artifacts do not appear as changed files with +0/-0 counts.
+---
+
+The workspace diff tracker now ignores changes where both before and after states are empty and no patch or line delta exists. Non-empty file additions, modifications, and deletions continue to be recorded.

--- a/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
+++ b/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
@@ -558,6 +558,15 @@ function compareSnapshots(before: SnapshotFile | undefined, after: SnapshotFile,
   }
 }
 
+function isEmptyContentOnlyChange(comparison: SnapshotComparison): boolean {
+  return comparison.changed &&
+    comparison.additions === 0 &&
+    comparison.deletions === 0 &&
+    !comparison.patch &&
+    (comparison.sizeBefore == null || comparison.sizeBefore === 0) &&
+    (comparison.sizeAfter == null || comparison.sizeAfter === 0)
+}
+
 export function startWorkspaceRunCheckpoint(args: {
   sessionId: string
   runId?: string | null
@@ -649,6 +658,7 @@ export function completeWorkspaceRunCheckpoint(args: {
       Math.max(0, MAX_TOTAL_PATCH_BYTES - totalPatchBytes),
     )
     if (!comparison.changed) continue
+    if (isEmptyContentOnlyChange(comparison)) continue
     totalPatchBytes += comparison.patchBytes
     totalAdditions += comparison.additions
     totalDeletions += comparison.deletions

--- a/tests/server/workspace-diff-tracker.test.ts
+++ b/tests/server/workspace-diff-tracker.test.ts
@@ -161,6 +161,47 @@ describe('workspace diff tracker', () => {
     expect(detail?.patch).toContain('+new')
   })
 
+  it('skips empty zero-byte file changes in non-git workspaces', async () => {
+    const {
+      completeWorkspaceRunCheckpoint,
+      startWorkspaceRunCheckpoint,
+    } = await import('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker')
+
+    const workspace = join(root, 'plain-empty-file')
+    mkdirSync(workspace)
+
+    startWorkspaceRunCheckpoint({
+      sessionId: 'session-empty',
+      runId: 'run-empty',
+      workspace,
+    })
+
+    writeFileSync(join(workspace, 'empty.txt'), '')
+    const emptyOnlyChange = completeWorkspaceRunCheckpoint({
+      sessionId: 'session-empty',
+      runId: 'run-empty',
+      workspace,
+    })
+
+    expect(emptyOnlyChange).toBeNull()
+
+    startWorkspaceRunCheckpoint({
+      sessionId: 'session-empty',
+      runId: 'run-non-empty',
+      workspace,
+    })
+
+    writeFileSync(join(workspace, 'non-empty.txt'), 'content\n')
+    const nonEmptyChange = completeWorkspaceRunCheckpoint({
+      sessionId: 'session-empty',
+      runId: 'run-non-empty',
+      workspace,
+    })
+
+    expect(nonEmptyChange).not.toBeNull()
+    expect(nonEmptyChange?.files.map(file => file.path)).toEqual(['non-empty.txt'])
+  })
+
   it('skips common language dependency and build directories in non-git workspaces', async () => {
     const {
       completeWorkspaceRunCheckpoint,


### PR DESCRIPTION
## Summary

- Skips workspace diff entries where both before and after states are empty, with no patch and no line delta.
- Adds regression coverage for zero-byte file changes in non-git workspaces while keeping non-empty additions tracked.
- Documents the chat-chain behavior change for issue #1984.

## Why

Linux workspaces can end up with empty artifacts such as a `nul` file from Windows-style command redirection. These were shown as `+0/-0` workspace diff cards even though there is no meaningful file content diff to display.

## Validation

- `npm run harness:check`
- `npm test -- --run tests/server/workspace-diff-tracker.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `git diff --check`