### PR TITLE
fix: route workflow coding agent aborts correctly

### DIFF
--- a/packages/server/src/services/hermes/run-chat/abort.ts
+++ b/packages/server/src/services/hermes/run-chat/abort.ts
@@ -67,14 +67,21 @@ export async function handleAbort(
   })
   logger.info({ sessionId, runId }, '[chat-run-socket][abort] started')
 
+  // Workflow sessions can be backed either by Hermes bridge runs or by scoped
+  // coding-agent runners. Prefer the coding-agent runtime when it owns the
+  // session; otherwise source='workflow' is misclassified as a bridge run and
+  // bridge.interrupt returns "unknown session" while the coding agent keeps
+  // running.
+  const shouldAbortThroughBridge = isBridgeRunSource(activeState.source) && !isCodingAgentRun
+
   // Flush in-memory assistant text to DB before aborting the stream.
-  if (isBridgeRunSource(activeState.source)) {
+  if (shouldAbortThroughBridge) {
     flushBridgePendingToDb(activeState, sessionId)
   } else {
     flushResponseRunToDb(activeState, sessionId)
   }
 
-  if (isBridgeRunSource(activeState.source)) {
+  if (shouldAbortThroughBridge) {
     let interruptResult: any = null
     try {
       interruptResult = await bridge.interrupt(sessionId, 'Aborted by user', activeState.profile)
@@ -109,7 +116,7 @@ export async function handleAbort(
       await markAbortCompleted(nsp, socket, sessionId, runId || 'bridge_abort_timeout', sessionMap, runQueuedItem, false)
       return
     }
-  } else if (activeState.source === 'coding_agent') {
+  } else if (isCodingAgentRun) {
     activeState.abortController?.abort()
     codingAgentRunManager.stop(sessionId, { reportClosed: false })
   } else if (activeState.abortController) {

--- a/tests/server/run-chat-abort-goal.test.ts
+++ b/tests/server/run-chat-abort-goal.test.ts
@@ -141,6 +141,47 @@ describe('run chat abort goal handling', () => {
     }))
   })
 
+
+  it('stops a workflow-scoped coding-agent run instead of misrouting abort through the bridge', async () => {
+    const { handleAbort } = await import('../../packages/server/src/services/hermes/run-chat/abort')
+    const { emit, nsp, socket } = makeHarness()
+    codingAgentRunManagerMock.hasSession.mockReturnValue(true)
+    codingAgentRunManagerMock.stop.mockReturnValue(true)
+    const state = {
+      messages: [],
+      isWorking: true,
+      isAborting: false,
+      events: [],
+      queue: [],
+      runId: 'coding-run-1',
+      profile: 'default',
+      source: 'workflow',
+    } as any
+    const sessionMap = new Map([['session-1', state]])
+    const bridge = {
+      interrupt: vi.fn().mockRejectedValue(new Error('unknown session: session-1')),
+      goalPause: vi.fn(),
+    }
+    const runQueuedItem = vi.fn()
+
+    await handleAbort(nsp as any, socket as any, 'session-1', sessionMap, bridge, runQueuedItem)
+
+    expect(bridge.interrupt).not.toHaveBeenCalled()
+    expect(bridge.goalPause).not.toHaveBeenCalled()
+    expect(flushResponseRunToDbMock).toHaveBeenCalledWith(expect.objectContaining({
+      source: 'workflow',
+    }), 'session-1')
+    expect(flushBridgePendingToDbMock).not.toHaveBeenCalled()
+    expect(codingAgentRunManagerMock.stop).toHaveBeenCalledWith('session-1', { reportClosed: false })
+    expect(state.isWorking).toBe(false)
+    expect(state.isAborting).toBe(false)
+    expect(emit).toHaveBeenCalledWith('abort.completed', expect.objectContaining({
+      session_id: 'session-1',
+      run_id: 'coding-run-1',
+      synced: true,
+    }))
+  })
+
   it('stops a coding-agent run even when chat-run state was not marked working', async () => {
     const { handleAbort } = await import('../../packages/server/src/services/hermes/run-chat/abort')
     const { emit, nsp, socket } = makeHarness()


### PR DESCRIPTION
## Summary
- Fix workflow-scoped coding agent abort routing so sessions owned by `codingAgentRunManager` do not get misrouted through the Hermes bridge.
- Prevent `source: "workflow"` coding-agent sessions from producing bridge `unknown session` aborts while the underlying Claude/Codex runner keeps running.
- Add a regression test for workflow-scoped coding agent aborts.

## Root cause
Workflow scoped coding agents store their session state with `source: "workflow"`, while `codingAgentRunManager.hasSession(sessionId)` is true. `handleAbort` previously treated every `source: "workflow"` state as a bridge run via `isBridgeRunSource`, so abort called `bridge.interrupt(sessionId, ...)`. The bridge does not own those coding-agent sessions and returns `unknown session`; the error was logged but then `markAbortCompleted(..., synced=true)` ran without stopping the coding-agent process.

## Fix
Use `codingAgentRunManager.hasSession(sessionId)` / `isCodingAgentRun` to prefer the coding-agent stop path over the bridge path when a workflow session is actually backed by a scoped coding-agent runner.

## Test plan
- `npm test -- tests/server/run-chat-abort-goal.test.ts`
- `npm run build`
