### PR TITLE
[codex] Remove broken Star History embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,12 +421,6 @@ The BFF layer handles Socket.IO chat streaming, the Hermes agent bridge, profile
 
 **Backend:** Koa 2 (BFF server) + node-pty (web terminal)
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=EKKOLearnAI/hermes-studio&type=Date)](https://star-history.com/#EKKOLearnAI/hermes-studio&Date)
-
-<!-- If the chart above doesn't load, visit https://star-history.com/#EKKOLearnAI/hermes-studio -->
-
 ## License
 
 [BSL-1.1](./LICENSE)

--- a/README_zh.md
+++ b/README_zh.md
@@ -424,12 +424,6 @@ BFF 层负责：Socket.IO 聊天流式推送、Hermes agent bridge、按 Profile
 
 **后端：** Koa 2（BFF 服务器）+ node-pty（Web 终端）
 
-## Star 历史
-
-[![Star 历史图表](https://api.star-history.com/svg?repos=EKKOLearnAI/hermes-studio&type=Date)](https://star-history.com/#EKKOLearnAI/hermes-studio&Date)
-
-<!-- 如上方图表未加载，可访问 https://star-history.com/#EKKOLearnAI/hermes-studio -->
-
 ## 许可证
 
 [BSL-1.1](./LICENSE)


### PR DESCRIPTION
## Summary
- Remove the Star History embed from the English and Chinese READMEs.
- Avoid a broken third-party chart rendering in GitHub README pages when Star History API tokens are invalid, expired, or rate-limited.

## Context
The current embed at `api.star-history.com/svg?repos=EKKOLearnAI/hermes-studio&type=Date` returns `503` with `All GitHub API tokens are rate-limited, try again later`, and the Star History page can redirect users into token settings.

## Validation
- `rg -n "star-history|Star History|Star 历史" README.md README_zh.md` returns no matches
- `git diff --check`
- `npm run harness:check`