### PR TITLE
[codex] fix workflow approval rerun states

### DIFF
--- a/docs/chat-chain-changes/2026-07-09-workflow-node-approval.md
+++ b/docs/chat-chain-changes/2026-07-09-workflow-node-approval.md
@@ -11,6 +11,8 @@ without a node-level approval gate.
 
 Workflow manager still passes `approvalChoice: 'once'` to chat runs so existing
 tool-call approval behavior is unchanged. Node approval happens after a node chat
-run succeeds: the manager marks that node `pending_approval`, waits for the
-workflow node approval API response, then either releases downstream nodes or
-cancels the workflow run.
+run succeeds: the manager marks that node `pending_approval` and waits for the
+workflow node approval API response. Approval releases downstream nodes.
+Rejection marks only that node `approval_rejected`; other pending node approvals
+remain pending, and not-yet-executed downstream nodes are canceled only after the
+active approval batch has resolved.

--- a/packages/client/src/api/hermes/workflow-socket.ts
+++ b/packages/client/src/api/hermes/workflow-socket.ts
@@ -2,7 +2,7 @@ import { io, type Socket } from 'socket.io-client'
 import { getActiveProfileName, getApiKey, getBaseUrlValue } from '../client'
 import type { WorkflowRecord } from './workflows'
 
-export type WorkflowRuntimeState = 'idle' | 'queued' | 'running' | 'pending_approval' | 'completed' | 'failed' | 'canceled'
+export type WorkflowRuntimeState = 'idle' | 'queued' | 'running' | 'pending_approval' | 'completed' | 'failed' | 'approval_rejected' | 'canceled'
 
 export interface WorkflowRuntimeStatus {
   workflowId: string

--- a/packages/client/src/api/hermes/workflows.ts
+++ b/packages/client/src/api/hermes/workflows.ts
@@ -42,7 +42,7 @@ export interface WorkflowBatchDeleteResult {
 }
 
 export type WorkflowRunStatus = 'queued' | 'running' | 'completed' | 'failed' | 'canceled'
-export type WorkflowRunNodeStatus = 'queued' | 'running' | 'completed' | 'failed' | 'blocked' | 'canceled'
+export type WorkflowRunNodeStatus = 'queued' | 'running' | 'completed' | 'failed' | 'blocked' | 'approval_rejected' | 'canceled'
 
 export interface WorkflowRunRecord {
   id: string

--- a/packages/client/src/components/hermes/workflow/WorkflowAgentNode.vue
+++ b/packages/client/src/components/hermes/workflow/WorkflowAgentNode.vue
@@ -411,6 +411,10 @@ async function uploadImages(files: File[]) {
   box-shadow: 0 0 8px rgba(217, 119, 6, 0.55);
 }
 
+.status-approval_rejected .node-status-dot {
+  background: #b45309;
+}
+
 .status-completed .node-status-dot {
   background: #16a34a;
 }

--- a/packages/client/src/components/hermes/workflow/types.ts
+++ b/packages/client/src/components/hermes/workflow/types.ts
@@ -7,7 +7,7 @@ export interface WorkflowSelectOption extends SelectOption {
   value: string
 }
 
-export type WorkflowNodeStatus = 'idle' | 'queued' | 'running' | 'pending_approval' | 'completed' | 'failed' | 'canceled'
+export type WorkflowNodeStatus = 'idle' | 'queued' | 'running' | 'pending_approval' | 'completed' | 'failed' | 'approval_rejected' | 'canceled'
 
 export interface WorkflowAgentNodeData {
   title: string

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -2030,6 +2030,7 @@ jobTriggered: 'Job ausgelost',
     },
     status: {
       pending_approval: 'Wartet auf Freigabe',
+      approval_rejected: 'Freigabe abgelehnt',
     },
   },
 

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -768,6 +768,7 @@ export default {
       pending_approval: 'Pending approval',
       completed: 'Completed',
       failed: 'Failed',
+      approval_rejected: 'Approval rejected',
       canceled: 'Canceled',
     },
     runs: {

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -2030,6 +2030,7 @@ jobTriggered: 'Job ejecutado',
     },
     status: {
       pending_approval: 'Pendiente de aprobacion',
+      approval_rejected: 'Aprobacion rechazada',
     },
   },
 

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -2030,6 +2030,7 @@ jobTriggered: 'Job declenche',
     },
     status: {
       pending_approval: 'En attente d\'approbation',
+      approval_rejected: 'Approbation refusee',
     },
   },
 

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -2029,6 +2029,7 @@ export default {
     },
     status: {
       pending_approval: '承認待ち',
+      approval_rejected: '承認拒否',
     },
   },
 

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -2029,6 +2029,7 @@ export default {
     },
     status: {
       pending_approval: '승인 대기',
+      approval_rejected: '승인 거부',
     },
   },
 

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -2030,6 +2030,7 @@ jobTriggered: 'Job acionado',
     },
     status: {
       pending_approval: 'Aguardando aprovacao',
+      approval_rejected: 'Aprovacao rejeitada',
     },
   },
 

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -673,6 +673,7 @@ export default {
       pending_approval: 'Ожидает одобрения',
       completed: 'Завершено',
       failed: 'Ошибка',
+      approval_rejected: 'Одобрение отклонено',
       canceled: 'Отменено',
     },
     runs: {

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -768,6 +768,7 @@ export default {
       pending_approval: '待審批',
       completed: '已完成',
       failed: '失敗',
+      approval_rejected: '審批拒絕',
       canceled: '已取消',
     },
     runs: {

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -768,6 +768,7 @@ export default {
       pending_approval: '待审批',
       completed: '已完成',
       failed: '失败',
+      approval_rejected: '审批拒绝',
       canceled: '已取消',
     },
     runs: {

--- a/packages/client/src/views/hermes/WorkflowView.vue
+++ b/packages/client/src/views/hermes/WorkflowView.vue
@@ -167,6 +167,7 @@ let removeWorkflowStatusListener: (() => void) | null = null
 let mobileQuery: MediaQueryList | null = null
 let applyingWorkflow = false
 let workflowRunsLoadSeq = 0
+let workflowRunsLoadingSeq = 0
 
 const agentOptions = computed<WorkflowSelectOption[]>(() => [
   { label: 'Hermes', value: 'hermes' },
@@ -233,19 +234,25 @@ const contextMenuOptions = computed<DropdownOption[]>(() => {
     const run = selectedWorkflowRun.value
     const isBusy = Boolean(rerunningWorkflowNodeId.value) || isWorkflowLive(activeWorkflowId.value)
     const hasNodeSession = Boolean(run?.node_sessions?.some(session => session.node_id === target.id && session.session_id))
+    const hasRunnableNodeSession = Boolean(run?.node_sessions?.some(session => (
+      session.node_id === target.id &&
+      session.session_id &&
+      session.status !== 'queued'
+    )))
+    const canPreserveStartNode = Boolean(run && workflowNodeStatusFromRun(run, target.id) === 'completed')
     const hasDownstream = edges.value.some(edge => edge.source === target.id)
     const options: DropdownOption[] = []
     if (hasNodeSession) {
       options.push({
         key: 'rerun-downstream-keep-node',
         label: t('workflow.actions.rerunDownstreamKeepNode'),
-        disabled: isBusy || !hasDownstream,
+        disabled: isBusy || !hasDownstream || !canPreserveStartNode,
       })
     }
     options.push({
       key: 'rerun-from-node-clear',
       label: t('workflow.actions.rerunDownstreamClearNode'),
-      disabled: isBusy,
+      disabled: isBusy || !hasRunnableNodeSession,
     })
     return options
   }
@@ -731,6 +738,7 @@ function workflowNodeStatusFromRuntime(status?: WorkflowRuntimeStatus, nodeId?: 
     case 'pending_approval':
     case 'completed':
     case 'failed':
+    case 'approval_rejected':
     case 'canceled':
       return currentStatus
     default:
@@ -797,6 +805,7 @@ function workflowNodeStatusFromRun(run: WorkflowRunRecord, nodeId: string): Work
     case 'running':
     case 'completed':
     case 'failed':
+    case 'approval_rejected':
     case 'canceled':
       return nodeSession.status
     case 'blocked':
@@ -870,7 +879,10 @@ async function loadWorkflowRuns(
     return
   }
   const requestSeq = ++workflowRunsLoadSeq
-  if (!options.silent) workflowRunsLoading.value = true
+  if (!options.silent) {
+    workflowRunsLoadingSeq = requestSeq
+    workflowRunsLoading.value = true
+  }
   try {
     const runs = await listWorkflowRuns(workflowId, 100)
     if (requestSeq !== workflowRunsLoadSeq) return
@@ -890,7 +902,9 @@ async function loadWorkflowRuns(
   } catch (err) {
     console.error('Failed to load workflow runs:', err)
   } finally {
-    if (requestSeq === workflowRunsLoadSeq && !options.silent) workflowRunsLoading.value = false
+    if (!options.silent && workflowRunsLoadingSeq === requestSeq) {
+      workflowRunsLoading.value = false
+    }
   }
 }
 
@@ -1427,13 +1441,15 @@ async function rerunWorkflowFromNode(nodeId: string, preserveStartNode: boolean)
     await rerunWorkflowRunFromNode(workflowId, run.id, nodeId, {
       preserve_start_node: preserveStartNode,
     })
-    void loadWorkflowRuns(workflowId, run.id)
+    void loadWorkflowRuns(workflowId, run.id, {
+      silent: true,
+      applySelectedSnapshot: false,
+    })
     const now = Date.now()
     const nextStatuses: Record<string, WorkflowRuntimeState> = Object.fromEntries(
-      nodes.value.map(node => [node.id, workflowNodeStatusFromRun(run, node.id)]),
+      nodes.value.map(node => [node.id, node.data.status || 'idle']),
     )
-    const queuedNodeIds = downstreamWorkflowNodeIds(nodeId)
-    if (!preserveStartNode) queuedNodeIds.add(nodeId)
+    const queuedNodeIds = rerunWorkflowNodeIds(nodeId, preserveStartNode, run)
     for (const queuedNodeId of queuedNodeIds) nextStatuses[queuedNodeId] = 'queued'
     handleWorkflowRuntimeStatus({
       workflowId,
@@ -1467,6 +1483,23 @@ function downstreamWorkflowNodeIds(nodeId: string): Set<string> {
     for (const edge of edges.value.filter(edge => edge.source === next)) stack.push(edge.target)
   }
   return visited
+}
+
+function rerunWorkflowNodeIds(nodeId: string, preserveStartNode: boolean, run: WorkflowRunRecord): Set<string> {
+  const activeIds = preserveStartNode
+    ? downstreamWorkflowNodeIds(nodeId)
+    : new Set([nodeId, ...downstreamWorkflowNodeIds(nodeId)])
+  let expanded = true
+  while (expanded) {
+    expanded = false
+    for (const edge of edges.value) {
+      if (!activeIds.has(edge.target) || activeIds.has(edge.source)) continue
+      if (workflowNodeStatusFromRun(run, edge.source) === 'completed') continue
+      activeIds.add(edge.source)
+      expanded = true
+    }
+  }
+  return activeIds
 }
 
 function initialRunNodeStatuses(sourceNodes: WorkflowNode[], sourceEdges: WorkflowEdge[]): Record<string, WorkflowRuntimeState> {
@@ -1647,6 +1680,7 @@ function nodeColor(node: { data: WorkflowAgentNodeData }) {
   if (node.data.status === 'pending_approval') return '#d97706'
   if (node.data.status === 'completed') return '#16a34a'
   if (node.data.status === 'failed') return '#dc2626'
+  if (node.data.status === 'approval_rejected') return '#b45309'
   if (node.data.status === 'canceled') return '#f97316'
   return '#9ca3af'
 }

--- a/packages/server/src/controllers/hermes/workflows.ts
+++ b/packages/server/src/controllers/hermes/workflows.ts
@@ -250,9 +250,6 @@ export async function approveNode(ctx: Context) {
     ctx.body = { error: 'workflow node approval is not pending' }
     return
   }
-  if (!approvedValue) {
-    await manager.stopRun(id, runId, 'Workflow node approval rejected')
-  }
   ctx.body = { ok: true }
 }
 
@@ -296,11 +293,13 @@ export async function rerunFromNode(ctx: Context) {
   void manager.rerunFromNode(id, runId, nodeId, runInput).catch((err: any) => {
     const message = err?.message || 'failed to rerun workflow'
     logger.error(err, '[workflow] async rerun failed for workflow %s run %s node %s', id, runId, nodeId)
+    const currentStatus = manager.getRuntimeStatus(id)
     manager.setRuntimeStatus(id, {
       status: 'failed',
       runId,
       completedAt: Date.now(),
       error: message,
+      nodeStatuses: { ...currentStatus.nodeStatuses },
     })
   })
 

--- a/packages/server/src/db/hermes/workflow-run-store.ts
+++ b/packages/server/src/db/hermes/workflow-run-store.ts
@@ -3,7 +3,7 @@ import { getDb, jsonDelete, jsonGet, jsonGetAll, jsonSet } from '../index'
 import { WORKFLOW_RUN_NODE_SESSIONS_TABLE, WORKFLOW_RUNS_TABLE } from './schemas'
 
 export type WorkflowRunStatus = 'queued' | 'running' | 'completed' | 'failed' | 'canceled'
-export type WorkflowRunNodeStatus = 'queued' | 'running' | 'completed' | 'failed' | 'blocked' | 'canceled'
+export type WorkflowRunNodeStatus = 'queued' | 'running' | 'completed' | 'failed' | 'blocked' | 'approval_rejected' | 'canceled'
 
 export interface WorkflowRunRecord {
   id: string

--- a/packages/server/src/services/workflow-manager.ts
+++ b/packages/server/src/services/workflow-manager.ts
@@ -37,7 +37,7 @@ import { logger } from './logger'
 
 export type { WorkflowCreateInput, WorkflowRecord, WorkflowUpdateInput }
 
-export type WorkflowRuntimeState = 'idle' | 'queued' | 'running' | 'pending_approval' | 'completed' | 'failed' | 'canceled'
+export type WorkflowRuntimeState = 'idle' | 'queued' | 'running' | 'pending_approval' | 'completed' | 'failed' | 'approval_rejected' | 'canceled'
 export type WorkflowRunType = 'workflow'
 export type WorkflowNodeAgent = 'hermes' | 'claude-code' | 'codex'
 
@@ -324,7 +324,6 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
     if (!run || run.workflow_id !== workflowId) return false
     const pending = this.pendingNodeApprovals.get(this.nodeApprovalKey(runId, nodeId))
     if (!pending || pending.workflowId !== workflowId || pending.nodeId !== nodeId) return false
-    if (!approved) this.canceledRunIds.add(runId)
     this.pendingNodeApprovals.delete(this.nodeApprovalKey(runId, nodeId))
     pending.resolve(approved)
     return true
@@ -643,15 +642,15 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
           })
           if (!approved) {
             const error = 'Workflow node approval rejected'
-            updateWorkflowRunNodeSession(nodeSession.id, { status: 'canceled', finished_at: Date.now(), error })
-            nodeStatuses[node.id] = 'canceled'
+            updateWorkflowRunNodeSession(nodeSession.id, { status: 'approval_rejected', finished_at: Date.now(), error })
+            nodeStatuses[node.id] = 'approval_rejected'
             this.setRuntimeStatus(workflow.id, {
-              status: 'canceled',
+              status: 'running',
               runId: run.id,
               error,
               nodeStatuses: { ...nodeStatuses },
             })
-            return { node, ok: false, canceled: true, error }
+            return { node, ok: false, approvalRejected: true, error }
           }
           outputs.set(node.id, output)
           completed.add(node.id)
@@ -673,6 +672,11 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
           if ('canceled' in failed && failed.canceled) {
             const canceledRun = failRun(failed.error || 'Workflow run canceled')
             return { run: canceledRun, nodeSessions: listWorkflowRunNodeSessions(run.id) }
+          }
+          if ('approvalRejected' in failed && failed.approvalRejected) {
+            const message = `Node ${failed.node.data.title || failed.node.id} approval rejected`
+            const failedRun = failRun(message)
+            return { run: failedRun, nodeSessions: listWorkflowRunNodeSessions(run.id) }
           }
           nodeStatuses[failed.node.id] = 'failed'
           const message = `Node ${failed.node.data.title || failed.node.id} failed: ${failed.error}`
@@ -783,6 +787,19 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
     const activeIds = preserveStartNode
       ? reachableFrom(downstreamStartIds, outgoing)
       : reachableFrom([targetNodeId], outgoing)
+    let expandedActiveIds = true
+    while (expandedActiveIds) {
+      expandedActiveIds = false
+      for (const activeNodeId of [...activeIds]) {
+        for (const edge of incoming.get(activeNodeId) || []) {
+          if (activeIds.has(edge.source)) continue
+          const upstreamSession = existingSessionByNode.get(edge.source)
+          if (upstreamSession?.status === 'completed') continue
+          activeIds.add(edge.source)
+          expandedActiveIds = true
+        }
+      }
+    }
     if (activeIds.size === 0) {
       const err = new Error('workflow node has no downstream nodes to rerun')
       ;(err as any).status = 400
@@ -962,15 +979,15 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
           })
           if (!approved) {
             const error = 'Workflow node approval rejected'
-            updateWorkflowRunNodeSession(nodeSession.id, { status: 'canceled', finished_at: Date.now(), error })
-            nodeStatuses[node.id] = 'canceled'
+            updateWorkflowRunNodeSession(nodeSession.id, { status: 'approval_rejected', finished_at: Date.now(), error })
+            nodeStatuses[node.id] = 'approval_rejected'
             this.setRuntimeStatus(workflow.id, {
-              status: 'canceled',
+              status: 'running',
               runId: run.id,
               error,
               nodeStatuses: { ...nodeStatuses },
             })
-            return { node, ok: false, canceled: true, error }
+            return { node, ok: false, approvalRejected: true, error }
           }
           outputs.set(node.id, output)
           completed.add(node.id)
@@ -992,6 +1009,11 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
           if ('canceled' in failed && failed.canceled) {
             const canceledRun = failRun(failed.error || 'Workflow run canceled')
             return { run: canceledRun, nodeSessions: listWorkflowRunNodeSessions(run.id) }
+          }
+          if ('approvalRejected' in failed && failed.approvalRejected) {
+            const message = `Node ${failed.node.data.title || failed.node.id} approval rejected`
+            const failedRun = failRun(message)
+            return { run: failedRun, nodeSessions: listWorkflowRunNodeSessions(run.id) }
           }
           nodeStatuses[failed.node.id] = 'failed'
           const message = `Node ${failed.node.data.title || failed.node.id} failed: ${failed.error}`

--- a/tests/server/workflow-controller.test.ts
+++ b/tests/server/workflow-controller.test.ts
@@ -168,10 +168,9 @@ describe('workflow controller', () => {
     expect(c.body).toEqual({ ok: true })
   })
 
-  it('stops a workflow run when a pending workflow node is rejected', async () => {
+  it('records a workflow node rejection without stopping the run immediately', async () => {
     managerMock.get.mockReturnValue({ id: 'workflow-1', profile: 'default' })
     managerMock.approveNode.mockReturnValue(true)
-    managerMock.stopRun.mockResolvedValue({ id: 'run-1', workflow_id: 'workflow-1', status: 'canceled' })
 
     const mod = await import('../../packages/server/src/controllers/hermes/workflows')
     const c = ctx({
@@ -182,7 +181,7 @@ describe('workflow controller', () => {
     await mod.approveNode(c)
 
     expect(managerMock.approveNode).toHaveBeenCalledWith('workflow-1', 'run-1', 'node-1', false)
-    expect(managerMock.stopRun).toHaveBeenCalledWith('workflow-1', 'run-1', 'Workflow node approval rejected')
+    expect(managerMock.stopRun).not.toHaveBeenCalled()
     expect(c.body).toEqual({ ok: true })
   })
 

--- a/tests/server/workflow-manager.test.ts
+++ b/tests/server/workflow-manager.test.ts
@@ -150,4 +150,134 @@ describe('workflow manager', () => {
       await manager.delete(workflow.id)
     }
   })
+
+  it('keeps parallel pending approvals open after one node is rejected', async () => {
+    const { WorkflowManager } = await import('../../packages/server/src/services/workflow-manager')
+    const manager = new WorkflowManager()
+    chatRunMock.runAndWait.mockReset()
+    chatRunMock.abortSession.mockReset()
+    chatRunMock.runAndWait.mockResolvedValue({ ok: true, output: 'done' })
+
+    const workflow = manager.create({
+      name: `Parallel approvals ${Date.now()}`,
+      profile: 'default',
+      nodes: [
+        {
+          id: 'first',
+          type: 'agent',
+          data: { title: 'First', agent: 'hermes', input: 'first task', approvalRequired: true },
+        },
+        {
+          id: 'second',
+          type: 'agent',
+          data: { title: 'Second', agent: 'hermes', input: 'second task', approvalRequired: true },
+        },
+        {
+          id: 'join',
+          type: 'agent',
+          data: { title: 'Join', agent: 'hermes', input: 'join task' },
+        },
+      ],
+      edges: [
+        { id: 'first-join', source: 'first', target: 'join' },
+        { id: 'second-join', source: 'second', target: 'join' },
+      ],
+    })
+
+    try {
+      const runPromise = manager.runNow(workflow.id)
+      await vi.waitFor(() => {
+        const statuses = manager.getRuntimeStatus(workflow.id).nodeStatuses
+        expect(statuses.first).toBe('pending_approval')
+        expect(statuses.second).toBe('pending_approval')
+      })
+      expect(chatRunMock.runAndWait).toHaveBeenCalledTimes(2)
+
+      const runId = manager.getRuntimeStatus(workflow.id).runId
+      expect(runId).toBeTruthy()
+      expect(manager.approveNode(workflow.id, runId!, 'first', false)).toBe(true)
+      await vi.waitFor(() => {
+        const statuses = manager.getRuntimeStatus(workflow.id).nodeStatuses
+        expect(statuses.first).toBe('approval_rejected')
+        expect(statuses.second).toBe('pending_approval')
+      })
+
+      expect(manager.approveNode(workflow.id, runId!, 'second', true)).toBe(true)
+      await expect(runPromise).resolves.toMatchObject({
+        run: { status: 'failed' },
+      })
+      const finalStatuses = manager.getRuntimeStatus(workflow.id).nodeStatuses
+      expect(finalStatuses.first).toBe('approval_rejected')
+      expect(finalStatuses.second).toBe('completed')
+      expect(finalStatuses.join).toBe('canceled')
+      expect(chatRunMock.runAndWait).toHaveBeenCalledTimes(2)
+    } finally {
+      await manager.delete(workflow.id)
+    }
+  })
+
+  it('reruns incomplete external upstream dependencies for downstream joins', async () => {
+    const { WorkflowManager } = await import('../../packages/server/src/services/workflow-manager')
+    const {
+      createWorkflowRun,
+      createWorkflowRunNodeSession,
+      listWorkflowRunNodeSessions,
+    } = await import('../../packages/server/src/db/hermes/workflow-run-store')
+    const manager = new WorkflowManager()
+    chatRunMock.runAndWait.mockReset()
+    chatRunMock.abortSession.mockReset()
+    chatRunMock.runAndWait.mockResolvedValue({ ok: true, output: 'done' })
+
+    const snapshotNodes = [
+      { id: 'entry-a', type: 'agent', data: { title: 'Entry A', agent: 'hermes', input: 'a' } },
+      { id: 'entry-b', type: 'agent', data: { title: 'Entry B', agent: 'hermes', input: 'b' } },
+      { id: 'join', type: 'agent', data: { title: 'Join', agent: 'hermes', input: 'join' } },
+    ]
+    const snapshotEdges = [
+      { id: 'entry-a-join', source: 'entry-a', target: 'join' },
+      { id: 'entry-b-join', source: 'entry-b', target: 'join' },
+    ]
+    const workflow = manager.create({
+      name: `Rerun dependencies ${Date.now()}`,
+      profile: 'default',
+      nodes: snapshotNodes,
+      edges: snapshotEdges,
+    })
+    const run = createWorkflowRun({
+      workflow_id: workflow.id,
+      profile: 'default',
+      status: 'canceled',
+      snapshot_nodes: snapshotNodes,
+      snapshot_edges: snapshotEdges,
+      started_at: Date.now(),
+    })
+    for (const [sequence, nodeId] of ['entry-a', 'entry-b', 'join'].entries()) {
+      createWorkflowRunNodeSession({
+        run_id: run.id,
+        workflow_id: workflow.id,
+        node_id: nodeId,
+        session_id: `canceled-${nodeId}`,
+        profile: 'default',
+        agent: 'hermes',
+        status: 'canceled',
+        sequence,
+        started_at: Date.now(),
+        finished_at: Date.now(),
+      })
+    }
+
+    try {
+      await expect(manager.rerunFromNode(workflow.id, run.id, 'entry-a')).resolves.toMatchObject({
+        run: { status: 'completed' },
+      })
+      expect(chatRunMock.runAndWait).toHaveBeenCalledTimes(3)
+      expect(listWorkflowRunNodeSessions(run.id).map(session => [session.node_id, session.status])).toEqual([
+        ['entry-a', 'completed'],
+        ['entry-b', 'completed'],
+        ['join', 'completed'],
+      ])
+    } finally {
+      await manager.delete(workflow.id)
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- Treat rejected workflow node approvals as node-level `approval_rejected` state instead of canceling the whole run immediately.
- Keep other pending node approvals active until each one is approved or rejected, then cancel only not-yet-executed downstream nodes.
- Fix rerun-from-node behavior for canceled/multi-entry flows by rerunning incomplete upstream dependencies required by downstream joins.
- Prevent workflow run list loading from getting stuck when live status refreshes overlap explicit reloads, and tighten rerun context menu availability.

## Impact
- Node approval rejection no longer marks unrelated pending approvals as canceled.
- Rerun actions are disabled for nodes that have never run, and preserve-downstream rerun is only available from completed nodes.

## Validation
- `npm run test -- tests/server/workflow-manager.test.ts tests/server/workflow-controller.test.ts`
- `npm run test -- tests/client/i18n-coverage.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npx vue-tsc -b`
- `npm run harness:check`
