### PR TITLE
fix: keep new files in workspace diffs

### DIFF
--- a/docs/chat-chain-changes/2026-07-09-pr2003-sqlite-sidecar-workspace-diffs.md
+++ b/docs/chat-chain-changes/2026-07-09-pr2003-sqlite-sidecar-workspace-diffs.md
@@ -2,7 +2,7 @@
 date: 2026-07-09
 pr: 2003
 feature: Workspace diff SQLite sidecar filtering
-impact: Workspace run diff cards skip SQLite WAL/SHM sidecar files so runtime database churn does not appear as +0/-0 changed files.
+impact: Workspace run diff cards skip SQLite WAL/SHM sidecar files and continue scanning past unchanged files so newly created ordinary files are not hidden by the changed-file cap.
 ---
 
-The workspace diff tracker now treats `.db-wal`, `.db-shm`, `.sqlite-wal`, and `.sqlite-shm` as skipped file extensions, matching the existing `.db` and `.sqlite` filtering. User-created text/code files in the same workspace continue to be recorded normally.
+The workspace diff tracker now treats `.db-wal`, `.db-shm`, `.sqlite-wal`, and `.sqlite-shm` as skipped file extensions, matching the existing `.db` and `.sqlite` filtering. It also applies the changed-file cap after detecting actual changes instead of slicing the candidate path list first, so newly created ordinary text/code files in large non-git workspaces continue to be recorded normally.

--- a/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
+++ b/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
@@ -650,10 +650,10 @@ export function completeWorkspaceRunCheckpointDraft(args: {
   let totalPatchBytes = 0
   let totalAdditions = 0
   let totalDeletions = 0
-  let truncated = checkpoint.truncated || status.truncated || relPaths.size > MAX_CHANGED_FILES
+  let truncated = checkpoint.truncated || status.truncated
   let remainingSnapshotBytes = checkpoint.kind === 'filesystem' ? MAX_TOTAL_SNAPSHOT_BYTES : Number.POSITIVE_INFINITY
 
-  for (const relPath of [...relPaths].slice(0, MAX_CHANGED_FILES)) {
+  for (const relPath of relPaths) {
     const after = snapshotPath(checkpoint.root, relPath, remainingSnapshotBytes)
     if (after.content) {
       remainingSnapshotBytes -= after.content.length
@@ -673,6 +673,10 @@ export function completeWorkspaceRunCheckpointDraft(args: {
     )
     if (!comparison.changed) continue
     if (isEmptyContentOnlyChange(comparison)) continue
+    if (files.length >= MAX_CHANGED_FILES) {
+      truncated = true
+      break
+    }
     totalPatchBytes += comparison.patchBytes
     totalAdditions += comparison.additions
     totalDeletions += comparison.deletions

--- a/tests/server/workspace-diff-tracker.test.ts
+++ b/tests/server/workspace-diff-tracker.test.ts
@@ -261,6 +261,47 @@ describe('workspace diff tracker', () => {
     expect(change?.files.map(file => file.path)).toEqual(['notes.md'])
   })
 
+  it('records newly created ordinary files even when many unchanged files already exist in non-git workspaces', async () => {
+    const {
+      completeWorkspaceRunCheckpoint,
+      startWorkspaceRunCheckpoint,
+    } = await import('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker')
+
+    const workspace = join(root, 'plain-many-existing-files')
+    mkdirSync(workspace)
+    for (let index = 0; index < 120; index += 1) {
+      writeFileSync(join(workspace, `existing-${index.toString().padStart(3, '0')}.txt`), 'unchanged\n')
+    }
+
+    startWorkspaceRunCheckpoint({
+      sessionId: 'session-many-existing-files',
+      runId: 'run-many-existing-files',
+      workspace,
+    })
+
+    writeFileSync(join(workspace, 'README-visible.md'), '# visible new file\n')
+    writeFileSync(join(workspace, 'notes-visible.txt'), 'plain text visible\n')
+    writeFileSync(join(workspace, 'config-visible.json'), '{"visible": true}\n')
+    writeFileSync(join(workspace, 'state.db-wal'), Buffer.alloc(32 * 1024, 0))
+    writeFileSync(join(workspace, 'state.db-shm'), Buffer.alloc(32 * 1024, 0))
+    writeFileSync(join(workspace, 'cache.sqlite-wal'), Buffer.alloc(32 * 1024, 0))
+    writeFileSync(join(workspace, 'cache.sqlite-shm'), Buffer.alloc(32 * 1024, 0))
+
+    const change = completeWorkspaceRunCheckpoint({
+      sessionId: 'session-many-existing-files',
+      runId: 'run-many-existing-files',
+      workspace,
+    })
+
+    expect(change).not.toBeNull()
+    expect(change?.files).toHaveLength(3)
+    expect(change?.files.map(file => file.path)).toEqual(expect.arrayContaining([
+      'README-visible.md',
+      'config-visible.json',
+      'notes-visible.txt',
+    ]))
+  })
+
   it('skips common language dependency and build directories in non-git workspaces', async () => {
     const {
       completeWorkspaceRunCheckpoint,


### PR DESCRIPTION
## Summary
- continue scanning workspace diff candidates until actual changed files reach the cap
- prevents newly created ordinary files from being hidden behind many unchanged existing files
- keeps SQLite WAL/SHM sidecar files filtered

## Verification
- `NODE_ENV=development npm test -- tests/server/workspace-diff-tracker.test.ts`
- `npm run harness:check`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `git diff --check`
- `npm run build`