### PR TITLE
fix: suppress zero-line workspace diffs

### DIFF
--- a/docs/chat-chain-changes/2026-07-14-pr2011-zero-line-workspace-diffs.md
+++ b/docs/chat-chain-changes/2026-07-14-pr2011-zero-line-workspace-diffs.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-14
+pr: 2011
+feature: Workspace diff zero-line filtering and historical cleanup
+impact: Binary zero-line changes are omitted by a generic rule while text sidecar files with real line changes remain visible; stale zero-line history is repaired idempotently.
+---
+
+Workspace diff tracking no longer hides SQLite sidecar filenames unconditionally. Binary changes do not invent line counts, so generic `additions = 0 AND deletions = 0` filtering suppresses meaningless rows while text sidecars with real line changes remain visible. Schema initialization atomically removes historical zero-line child rows, deletes empty parent cards, and recomputes surviving parent aggregates.

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -789,6 +789,59 @@ export function syncTable(
   addMissingSafeColumns(db, tableName, schema)
 }
 
+function cleanupHistoricalZeroLineWorkspaceDiffs(
+  db: NonNullable<ReturnType<typeof getDb>>,
+): void {
+  const zeroLinePredicate = 'additions = 0 AND deletions = 0'
+  const affectedRows = db.prepare(
+    `SELECT DISTINCT change_id FROM ${WORKSPACE_RUN_CHANGE_FILES_TABLE} WHERE ${zeroLinePredicate}`,
+  ).all() as Array<{ change_id: string }>
+  if (affectedRows.length === 0) return
+
+  db.exec('BEGIN IMMEDIATE')
+  try {
+    db.prepare(`DELETE FROM ${WORKSPACE_RUN_CHANGE_FILES_TABLE} WHERE ${zeroLinePredicate}`).run()
+    const aggregate = db.prepare(
+      `SELECT COUNT(*) AS files_changed, COALESCE(SUM(additions), 0) AS additions,
+        COALESCE(SUM(deletions), 0) AS deletions, COALESCE(MAX(truncated), 0) AS truncated,
+        COALESCE(SUM(patch_bytes), 0) AS total_patch_bytes
+       FROM ${WORKSPACE_RUN_CHANGE_FILES_TABLE} WHERE change_id = ?`,
+    )
+    const updateParent = db.prepare(
+      `UPDATE ${WORKSPACE_RUN_CHANGES_TABLE}
+       SET files_changed = ?, additions = ?, deletions = ?, truncated = ?, total_patch_bytes = ?
+       WHERE change_id = ?`,
+    )
+    const deleteParent = db.prepare(`DELETE FROM ${WORKSPACE_RUN_CHANGES_TABLE} WHERE change_id = ?`)
+
+    for (const { change_id: changeId } of affectedRows) {
+      const totals = aggregate.get(changeId) as {
+        files_changed: number
+        additions: number
+        deletions: number
+        truncated: number
+        total_patch_bytes: number
+      }
+      if (totals.files_changed === 0) {
+        deleteParent.run(changeId)
+      } else {
+        updateParent.run(
+          totals.files_changed,
+          totals.additions,
+          totals.deletions,
+          totals.truncated,
+          totals.total_patch_bytes,
+          changeId,
+        )
+      }
+    }
+    db.exec('COMMIT')
+  } catch (error) {
+    db.exec('ROLLBACK')
+    throw error
+  }
+}
+
 // ============================================================================
 // Unified Initializer
 // ============================================================================
@@ -817,6 +870,7 @@ export function initAllHermesTables(): void {
     syncTable(WORKSPACE_RUN_CHANGE_FILES_TABLE, WORKSPACE_RUN_CHANGE_FILES_SCHEMA, {
       indexes: WORKSPACE_RUN_CHANGE_FILES_INDEXES,
     })
+    cleanupHistoricalZeroLineWorkspaceDiffs(db)
 
     // Workflow store
     syncTable(WORKFLOWS_TABLE, WORKFLOWS_SCHEMA, {

--- a/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
+++ b/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
@@ -140,11 +140,7 @@ const DEFAULT_SKIPPED_FILE_EXTENSIONS = new Set([
   '.7z',
   '.rar',
   '.sqlite',
-  '.sqlite-shm',
-  '.sqlite-wal',
   '.db',
-  '.db-shm',
-  '.db-wal',
   '.pdf',
   '.docx',
   '.xlsx',
@@ -544,8 +540,8 @@ function compareSnapshots(before: SnapshotFile | undefined, after: SnapshotFile,
     deletions = counts.deletions
   } else {
     truncated = !binary
-    if (changeType === 'added') additions = after.content ? after.content.toString('utf8').split('\n').length : 0
-    if (changeType === 'deleted') deletions = safeBefore.content ? safeBefore.content.toString('utf8').split('\n').length : 0
+    if (!binary && changeType === 'added') additions = after.content ? after.content.toString('utf8').split('\n').length : 0
+    if (!binary && changeType === 'deleted') deletions = safeBefore.content ? safeBefore.content.toString('utf8').split('\n').length : 0
   }
 
   return {

--- a/tests/server/workspace-diff-tracker.test.ts
+++ b/tests/server/workspace-diff-tracker.test.ts
@@ -290,6 +290,82 @@ describe('workspace diff tracker', () => {
     expect(change?.files.map(file => file.path)).toEqual(['notes.md'])
   })
 
+  it('retains line-level changes in SQLite sidecar-named files', async () => {
+    const {
+      completeWorkspaceRunCheckpoint,
+      startWorkspaceRunCheckpoint,
+    } = await import('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker')
+
+    writeFileSync(join(repo, 'state.db-wal'), 'before\n')
+    git(repo, ['add', 'state.db-wal'])
+    git(repo, ['commit', '-m', 'add text sidecar fixture'])
+
+    startWorkspaceRunCheckpoint({
+      sessionId: 'session-sidecar-lines',
+      runId: 'run-sidecar-lines',
+      workspace: repo,
+    })
+
+    writeFileSync(join(repo, 'state.db-wal'), 'after\n')
+    const change = completeWorkspaceRunCheckpoint({
+      sessionId: 'session-sidecar-lines',
+      runId: 'run-sidecar-lines',
+      workspace: repo,
+    })
+
+    expect(change).not.toBeNull()
+    expect(change?.files).toEqual([
+      expect.objectContaining({
+        path: 'state.db-wal',
+        additions: 1,
+        deletions: 1,
+        binary: false,
+      }),
+    ])
+  })
+
+  it('cleans historical zero-line rows and repairs parent aggregates idempotently', async () => {
+    const db = state.db!
+    const now = 1_700_000_000
+    const insertParent = db.prepare(`
+      INSERT INTO workspace_run_changes
+        (change_id, session_id, files_changed, additions, deletions, truncated, total_patch_bytes, created_at)
+      VALUES (?, 'session-history', ?, ?, ?, ?, ?, ?)
+    `)
+    const insertFile = db.prepare(`
+      INSERT INTO workspace_run_change_files
+        (change_id, session_id, path, additions, deletions, patch_bytes, truncated, created_at)
+      VALUES (?, 'session-history', ?, ?, ?, ?, ?, ?)
+    `)
+
+    insertParent.run('mixed', 2, 99, 88, 1, 777, now)
+    insertFile.run('mixed', 'zero.bin', 0, 0, 100, 1, now)
+    insertFile.run('mixed', 'kept.txt', 3, 2, 42, 0, now)
+    insertParent.run('zero-only', 1, 0, 0, 1, 64, now)
+    insertFile.run('zero-only', 'only.bin', 0, 0, 64, 1, now)
+
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    initAllHermesTables()
+    initAllHermesTables()
+
+    expect(db.prepare('SELECT path FROM workspace_run_change_files ORDER BY path').all()).toEqual([
+      { path: 'kept.txt' },
+    ])
+    expect(db.prepare(`
+      SELECT change_id, files_changed, additions, deletions, truncated, total_patch_bytes
+      FROM workspace_run_changes ORDER BY change_id
+    `).all()).toEqual([
+      {
+        change_id: 'mixed',
+        files_changed: 1,
+        additions: 3,
+        deletions: 2,
+        truncated: 0,
+        total_patch_bytes: 42,
+      },
+    ])
+  })
+
   it('records newly created ordinary files even when many unchanged files already exist in non-git workspaces', async () => {
     const {
       completeWorkspaceRunCheckpoint,


### PR DESCRIPTION
## Summary

- Use a single per-file rule for workspace diff suppression: omit rows only when both `additions` and `deletions` are zero.
- Remove the filename-specific SQLite WAL/SHM exclusions previously introduced by #2003, so files such as `*.db-wal` remain visible whenever they contain line-level changes.
- Clean historical zero-line child rows idempotently during schema initialization.
- Delete parent cards left with no files; otherwise recalculate `files_changed`, `additions`, `deletions`, `truncated`, and `total_patch_bytes` from the remaining children.
- Keep zero-line files from consuming the changed-file cap while preserving siblings with line-level changes.

## Behavioral contract

For each file independently:

- `additions = 0` and `deletions = 0` → do not save or display it.
- Any non-zero line delta → preserve it, regardless of filename or extension.

This intentionally replaces extension-specific filtering. A byte-level binary change with no line delta is hidden; a `*.db-wal` file with line-level changes is retained.

## Verification

- `NODE_ENV=development npm test -- tests/server/workspace-history-cleanup.test.ts tests/server/workspace-diff-tracker.test.ts tests/server/hermes-schemas.test.ts` — 11/11 passed
- `npm run harness:check` — passed
- `npx tsc --noEmit -p packages/server/tsconfig.json` — passed
- `git diff --check` — passed
- `npm run build` — passed
