### PR TITLE
[codex] sort preview version tags

### DIFF
--- a/packages/server/src/controllers/update.ts
+++ b/packages/server/src/controllers/update.ts
@@ -18,11 +18,17 @@ const PREVIEW_AGENT_BRIDGE_TRANSPORT_ENV = 'HERMES_WEB_UI_PREVIEW_AGENT_BRIDGE_T
 const PREVIEW_FRONTEND_URL = `http://localhost:${PREVIEW_FRONTEND_PORT}`
 const PREVIEW_TAG_REF_PATTERN = /^[A-Za-z0-9._/-]+$/
 const PREVIEW_MAIN_REF = 'main'
+const PREVIEW_VERSION_TAG_LIMIT = 8
 const PREVIEW_TAGS_CACHE_MS = 5 * 60 * 1000
 
 type PreviewTagRef = { name: string; sha: string }
 type PreviewTagsCache = { expiresAt: number; tags: PreviewTagRef[] }
 type PreviewActionResult = { success: boolean; message?: string; code?: string }
+
+type ParsedPreviewVersion = {
+  core: string
+  prerelease: string
+}
 
 class PreviewRuntimeState {
   process: ChildProcess | null = null
@@ -147,7 +153,39 @@ function parsePreviewTagRefs(output: string): PreviewTagRef[] {
       return { sha: sha || '', name: (ref || '').replace(/^refs\/tags\//, '') }
     })
     .filter(tag => tag.name)
-    .reverse()
+}
+
+function parsePreviewVersion(name: string): ParsedPreviewVersion | null {
+  const match = name.trim().match(/^v(\d+\.\d+\.\d+)(?:-((?:alpha|beta|rc)(?:[.-]\d+)?))?$/)
+  if (!match) return null
+  return { core: match[1], prerelease: match[2] || '' }
+}
+
+function comparePreviewVersions(left: PreviewTagRef, right: PreviewTagRef): number {
+  const leftVersion = parsePreviewVersion(left.name)
+  const rightVersion = parsePreviewVersion(right.name)
+
+  if (!leftVersion || !rightVersion) {
+    if (leftVersion) return -1
+    if (rightVersion) return 1
+    return right.name.localeCompare(left.name, undefined, { numeric: true })
+  }
+
+  const coreOrder = rightVersion.core.localeCompare(leftVersion.core, undefined, { numeric: true })
+  if (coreOrder !== 0) return coreOrder
+  if (!leftVersion.prerelease && rightVersion.prerelease) return -1
+  if (leftVersion.prerelease && !rightVersion.prerelease) return 1
+  return rightVersion.prerelease.localeCompare(leftVersion.prerelease, undefined, { numeric: true })
+}
+
+function withPreviewMain(tags: PreviewTagRef[]): PreviewTagRef[] {
+  return [
+    { name: PREVIEW_MAIN_REF, sha: '' },
+    ...tags
+      .filter(tag => parsePreviewVersion(tag.name))
+      .sort(comparePreviewVersions)
+      .slice(0, PREVIEW_VERSION_TAG_LIMIT),
+  ]
 }
 
 function execFileText(
@@ -1088,7 +1126,7 @@ export async function previewTags(ctx: any) {
 
   try {
     appendPreviewActionLog('load tags with git ls-remote')
-    const tags = [{ name: PREVIEW_MAIN_REF, sha: '' }, ...await listPreviewTagsWithGitAsync()]
+    const tags = withPreviewMain(await listPreviewTagsWithGitAsync())
     previewState.setTags(tags)
     ctx.body = { tags }
     return
@@ -1107,12 +1145,9 @@ export async function previewTags(ctx: any) {
     }
 
     const tags = await res.json() as Array<{ name?: string; commit?: { sha?: string } }>
-    const parsedTags = [
-      { name: PREVIEW_MAIN_REF, sha: '' },
-      ...tags
+    const parsedTags = withPreviewMain(tags
       .filter((tag): tag is { name: string; commit?: { sha?: string } } => typeof tag.name === 'string' && Boolean(tag.name.trim()))
-      .map(tag => ({ name: tag.name, sha: tag.commit?.sha || '' })),
-    ]
+      .map(tag => ({ name: tag.name, sha: tag.commit?.sha || '' })))
     previewState.setTags(parsedTags)
     ctx.body = { tags: parsedTags }
   } catch (apiErr: any) {

--- a/tests/server/update-controller.test.ts
+++ b/tests/server/update-controller.test.ts
@@ -218,8 +218,18 @@ describe('update controller', () => {
     process.env.HERMES_WEB_UI_PREVIEW_REPO = 'https://github.com/EKKOLearnAI/hermes-studio'
     const execFile = vi.fn((_command: string, _args: string[], _options: any, callback: any) => {
       callback(null, [
+        'ghi789\trefs/tags/v0.6.9',
+        'jkl012\trefs/tags/v0.6.10-beta',
         'abc123\trefs/tags/v0.6.6',
-        'def456\trefs/tags/v0.6.7',
+        'def456\trefs/tags/v0.6.10',
+        'mno345\trefs/tags/v0.6.28',
+        'pqr678\trefs/tags/v0.6.6-linux-desktop-fixes-test-20260530200253',
+        'stu901\trefs/tags/0.6.29',
+        'vwx234\trefs/tags/v0.6.27',
+        'yz0567\trefs/tags/v0.6.26',
+        'bcd890\trefs/tags/v0.6.25',
+        'efg123\trefs/tags/v0.6.24',
+        'hij456\trefs/tags/v0.6.23',
       ].join('\n'), '')
     })
     const execFileSync = vi.fn(() => 'git version 2.0.0')
@@ -232,8 +242,14 @@ describe('update controller', () => {
     expect(ctx.body).toEqual({
       tags: [
         { name: 'main', sha: '' },
-        { name: 'v0.6.7', sha: 'def456' },
-        { name: 'v0.6.6', sha: 'abc123' },
+        { name: 'v0.6.28', sha: 'mno345' },
+        { name: 'v0.6.27', sha: 'vwx234' },
+        { name: 'v0.6.26', sha: 'yz0567' },
+        { name: 'v0.6.25', sha: 'bcd890' },
+        { name: 'v0.6.24', sha: 'efg123' },
+        { name: 'v0.6.23', sha: 'hij456' },
+        { name: 'v0.6.10', sha: 'def456' },
+        { name: 'v0.6.10-beta', sha: 'jkl012' },
       ],
     })
     expect(mocks.execFile).toHaveBeenCalledWith(
@@ -253,8 +269,18 @@ describe('update controller', () => {
     const fetchMock = vi.fn(async () => ({
       ok: true,
       json: async () => [
-        { name: 'v0.6.7', commit: { sha: 'def456' } },
+        { name: 'v0.6.9', commit: { sha: 'ghi789' } },
         { name: 'v0.6.6', commit: { sha: 'abc123' } },
+        { name: 'v0.6.10-beta', commit: { sha: 'jkl012' } },
+        { name: 'v0.6.28', commit: { sha: 'mno345' } },
+        { name: 'v0.6.10', commit: { sha: 'def456' } },
+        { name: 'v0.6.6-linux-desktop-fixes-test-20260530200253', commit: { sha: 'pqr678' } },
+        { name: '0.6.29', commit: { sha: 'stu901' } },
+        { name: 'v0.6.27', commit: { sha: 'vwx234' } },
+        { name: 'v0.6.26', commit: { sha: 'yz0567' } },
+        { name: 'v0.6.25', commit: { sha: 'bcd890' } },
+        { name: 'v0.6.24', commit: { sha: 'efg123' } },
+        { name: 'v0.6.23', commit: { sha: 'hij456' } },
       ],
     }))
     vi.stubGlobal('fetch', fetchMock)
@@ -267,8 +293,14 @@ describe('update controller', () => {
     expect(ctx.body).toEqual({
       tags: [
         { name: 'main', sha: '' },
-        { name: 'v0.6.7', sha: 'def456' },
-        { name: 'v0.6.6', sha: 'abc123' },
+        { name: 'v0.6.28', sha: 'mno345' },
+        { name: 'v0.6.27', sha: 'vwx234' },
+        { name: 'v0.6.26', sha: 'yz0567' },
+        { name: 'v0.6.25', sha: 'bcd890' },
+        { name: 'v0.6.24', sha: 'efg123' },
+        { name: 'v0.6.23', sha: 'hij456' },
+        { name: 'v0.6.10', sha: 'def456' },
+        { name: 'v0.6.10-beta', sha: 'jkl012' },
       ],
     })
     expect(fetchMock).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- sort version preview tags by semantic version in descending order while keeping `main` first
- only include lowercase `vX.Y.Z` tags and conventional `alpha`, `beta`, or `rc` prereleases
- limit the version preview selector to the latest eight eligible tags
- exclude temporary tags such as `v0.6.6-linux-desktop-fixes-test-20260530200253`

## Why
The preview selector used the raw order returned by `git ls-remote` or the GitHub tags API. That order is not semantic, so multi-digit patch versions appeared out of sequence and temporary build tags leaked into the UI.

## Impact
The selector now shows `main` followed by at most eight recent, valid version tags in newest-to-oldest order. Filtering and limiting happen before the response is cached, so both tag-loading paths behave identically.

## Validation
- `npm run test -- tests/server/update-controller.test.ts`
- `npm run harness:check`
- `npm run build`
- `git diff --check`
