### PR TITLE
fix(workflow): enforce exact node capability policies

### DIFF
--- a/docs/chat-chain-changes/2026-07-10-workflow-node-toolset-policy.md
+++ b/docs/chat-chain-changes/2026-07-10-workflow-node-toolset-policy.md
@@ -7,10 +7,14 @@ impact: Hermes-backed workflow nodes can restrict runtime toolsets per node whil
 
 # Workflow node toolset policy
 
-Workflow snapshots propagate `executionPolicy.allowedToolsets` through chat-run
-and both Agent Bridge request paths before an `AIAgent` is created. An explicit
-empty allowlist remains a zero-tool policy, and sessions are not reused across
-different policies.
+Workflow snapshots propagate `executionPolicy.allowedToolsets` and the optional
+exact `executionPolicy.allowedTools` whitelist through chat-run and both Agent
+Bridge request paths before an `AIAgent` is created. The bridge first resolves
+the allowed toolsets, then intersects the assembled Agent tool surface with the
+exact whitelist and freezes MCP refresh for that session so later connections
+cannot widen it. Policies can also set `skipMemory` and `skipContextFiles` to
+prevent persistent-memory activity and cwd/SOUL context injection. An explicit empty allowlist remains a zero-tool policy, and
+sessions are not reused across different policies.
 
 The initial enforcement applies only to Hermes-backed nodes. Workflow nodes
 using scoped Codex or Claude runtimes fail closed when configured with this

--- a/docs/chat-chain-changes/2026-07-10-workflow-node-toolset-policy.md
+++ b/docs/chat-chain-changes/2026-07-10-workflow-node-toolset-policy.md
@@ -1,0 +1,17 @@
+---
+date: 2026-07-10
+pr: 2023
+feature: Workflow node toolset policy
+impact: Hermes-backed workflow nodes can restrict runtime toolsets per node while workflows without a policy retain the existing profile-level tool configuration.
+---
+
+# Workflow node toolset policy
+
+Workflow snapshots propagate `executionPolicy.allowedToolsets` through chat-run
+and both Agent Bridge request paths before an `AIAgent` is created. An explicit
+empty allowlist remains a zero-tool policy, and sessions are not reused across
+different policies.
+
+The initial enforcement applies only to Hermes-backed nodes. Workflow nodes
+using scoped Codex or Claude runtimes fail closed when configured with this
+policy rather than silently running without enforcement.

--- a/docs/chat-chain-changes/2026-07-10-workflow-node-toolset-policy.md
+++ b/docs/chat-chain-changes/2026-07-10-workflow-node-toolset-policy.md
@@ -19,3 +19,7 @@ sessions are not reused across different policies.
 The initial enforcement applies only to Hermes-backed nodes. Workflow nodes
 using scoped Codex or Claude runtimes fail closed when configured with this
 policy rather than silently running without enforcement.
+
+Final context accounting now carries the same policy through both successful
+and failed run finalization. A restricted session therefore cannot be recreated
+with profile-default tools merely because post-run context usage is refreshed.

--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -43,6 +43,9 @@ export interface AgentBridgeRequestOptions {
 
 export interface AgentBridgeExecutionPolicy {
   allowedToolsets: string[]
+  allowedTools?: string[]
+  skipMemory?: boolean
+  skipContextFiles?: boolean
 }
 
 export interface AgentBridgeChatOptions {

--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -41,6 +41,10 @@ export interface AgentBridgeRequestOptions {
   serialize?: boolean
 }
 
+export interface AgentBridgeExecutionPolicy {
+  allowedToolsets: string[]
+}
+
 export interface AgentBridgeChatOptions {
   force_compress?: boolean
   storage_message?: AgentBridgeMessage
@@ -53,6 +57,7 @@ export interface AgentBridgeChatOptions {
   /** Local patch (reasoning-effort): per-session reasoning effort override.
    * Empty/undefined = use config.yaml default. */
   reasoning_effort?: string
+  executionPolicy?: AgentBridgeExecutionPolicy
 }
 
 export type AgentBridgeMessage =
@@ -440,6 +445,7 @@ export class AgentBridgeClient {
       ...(options.model ? { model: options.model } : {}),
       ...(options.provider ? { provider: options.provider } : {}),
       ...(options.workspace ? { workspace: options.workspace } : {}),
+      ...(options.executionPolicy ? { execution_policy: options.executionPolicy } : {}),
       ...(options.source ? { source: options.source } : {}),
       ...(options.wait ? { wait: true } : {}),
       ...(options.timeout ? { timeout: options.timeout } : {}),
@@ -454,7 +460,7 @@ export class AgentBridgeClient {
     messages: unknown[],
     instructions?: string,
     profile?: string,
-    options: Pick<AgentBridgeChatOptions, 'model' | 'provider' | 'workspace'> = {},
+    options: Pick<AgentBridgeChatOptions, 'model' | 'provider' | 'workspace' | 'executionPolicy'> = {},
   ): Promise<AgentBridgeContextEstimate> {
     return this.request<AgentBridgeContextEstimate>({
       action: 'context_estimate',
@@ -465,6 +471,7 @@ export class AgentBridgeClient {
       ...(options.model ? { model: options.model } : {}),
       ...(options.provider ? { provider: options.provider } : {}),
       ...(options.workspace ? { workspace: options.workspace } : {}),
+      ...(options.executionPolicy ? { execution_policy: options.executionPolicy } : {}),
     })
   }
 

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -153,9 +153,12 @@ class AgentPool:
         profile: str | None = None,
         model: str | None = None,
         provider: str | None = None,
+        execution_policy: dict[str, Any] | None = None,
     ) -> AgentSession:
         requested_model = str(model or "").strip()
         requested_provider = str(provider or "").strip()
+        raw_allowed_toolsets = execution_policy.get("allowedToolsets") if isinstance(execution_policy, dict) else None
+        requested_toolsets = [str(value).strip() for value in raw_allowed_toolsets if str(value).strip()] if isinstance(raw_allowed_toolsets, list) else None
         with self._lock:
             existing = self._sessions.get(session_id)
             if existing is not None:
@@ -165,13 +168,18 @@ class AgentPool:
                     (requested_model and existing.config.get("model") != requested_model)
                     or (requested_provider and existing.config.get("provider") != requested_provider)
                 )
-                config_changed = profile_changed or runtime_changed
+                policy_changed = existing.config.get("allowed_toolsets") != requested_toolsets
+                config_changed = profile_changed or runtime_changed or policy_changed
                 if config_changed:
                     if profile_changed and not existing.running:
                         self._destroy_session(session_id)
                     elif profile_changed:
                         existing.last_used_at = time.time()
                         return existing
+                    elif policy_changed and not existing.running:
+                        self._destroy_session(session_id)
+                    elif policy_changed:
+                        raise RuntimeError(f"session {session_id} execution policy cannot change while running")
                     elif not existing.running:
                         try:
                             self._switch_loaded_session_model(
@@ -232,7 +240,7 @@ class AgentPool:
                     verbose_logging=False,
                     reasoning_config=_load_reasoning_config(),
                     service_tier=_load_service_tier(),
-                    enabled_toolsets=_load_enabled_toolsets(),
+                    enabled_toolsets=requested_toolsets if requested_toolsets is not None else _load_enabled_toolsets(),
                     platform=_bridge_platform(),
                     session_id=session_id,
                     session_db=self._db.get_for_profile(profile),
@@ -262,6 +270,7 @@ class AgentPool:
                         "base_url": runtime.get("base_url"),
                         "api_mode": runtime.get("api_mode"),
                         "platform": _bridge_platform(),
+                        "allowed_toolsets": requested_toolsets,
                         "resumed": False,
                         "resumed_message_count": 0,
                         "mcp_tool_count": len(discovered_mcp_tools),
@@ -615,6 +624,7 @@ class AgentPool:
             "profile": profile or session.config.get("profile") or "default",
             "model": session.config.get("model"),
             "provider": session.config.get("provider"),
+            "allowed_toolsets": session.config.get("allowed_toolsets"),
             **info,
         }
         session.config["context_info"] = event
@@ -629,8 +639,9 @@ class AgentPool:
         model: str | None = None,
         provider: str | None = None,
         workspace: str | None = None,
+        execution_policy: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        session = self.get_or_create(session_id, profile=profile, model=model, provider=provider)
+        session = self.get_or_create(session_id, profile=profile, model=model, provider=provider, execution_policy=execution_policy)
         session_cwd_bound = _bind_session_workspace_cwd(session.session_id, workspace)
         try:
             context_info = self._estimate_context_info(session.agent, messages or [], instructions)
@@ -652,6 +663,7 @@ class AgentPool:
             "profile": profile or session.config.get("profile") or "default",
             "model": session.config.get("model"),
             "provider": session.config.get("provider"),
+            "allowed_toolsets": session.config.get("allowed_toolsets"),
             **context_info,
         }
 
@@ -1117,8 +1129,9 @@ class AgentPool:
         workspace: str | None = None,
         source: str | None = None,
         reasoning_effort: str | None = None,
+        execution_policy: dict[str, Any] | None = None,
     ) -> RunRecord:
-        session = self.get_or_create(session_id, profile=profile, model=model, provider=provider)
+        session = self.get_or_create(session_id, profile=profile, model=model, provider=provider, execution_policy=execution_policy)
         with session.lock:
             if session.running:
                 raise RuntimeError(f"session {session_id} is already running")

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -159,6 +159,10 @@ class AgentPool:
         requested_provider = str(provider or "").strip()
         raw_allowed_toolsets = execution_policy.get("allowedToolsets") if isinstance(execution_policy, dict) else None
         requested_toolsets = [str(value).strip() for value in raw_allowed_toolsets if str(value).strip()] if isinstance(raw_allowed_toolsets, list) else None
+        raw_allowed_tools = execution_policy.get("allowedTools") if isinstance(execution_policy, dict) else None
+        requested_tools = [str(value).strip() for value in raw_allowed_tools if str(value).strip()] if isinstance(raw_allowed_tools, list) else None
+        skip_memory = execution_policy.get("skipMemory") is True if isinstance(execution_policy, dict) else False
+        skip_context_files = execution_policy.get("skipContextFiles") is True if isinstance(execution_policy, dict) else False
         with self._lock:
             existing = self._sessions.get(session_id)
             if existing is not None:
@@ -168,7 +172,12 @@ class AgentPool:
                     (requested_model and existing.config.get("model") != requested_model)
                     or (requested_provider and existing.config.get("provider") != requested_provider)
                 )
-                policy_changed = existing.config.get("allowed_toolsets") != requested_toolsets
+                policy_changed = (
+                    existing.config.get("allowed_toolsets") != requested_toolsets
+                    or existing.config.get("allowed_tools") != requested_tools
+                    or existing.config.get("skip_memory") != skip_memory
+                    or existing.config.get("skip_context_files") != skip_context_files
+                )
                 config_changed = profile_changed or runtime_changed or policy_changed
                 if config_changed:
                     if profile_changed and not existing.running:
@@ -245,6 +254,8 @@ class AgentPool:
                     session_id=session_id,
                     session_db=self._db.get_for_profile(profile),
                     ephemeral_system_prompt=prompt,
+                    skip_memory=skip_memory,
+                    skip_context_files=skip_context_files,
                     status_callback=self._status_callback(session_id),
                     thinking_callback=self._make_thinking_callback(session_id),
                     reasoning_callback=self._text_event_callback(session_id, "reasoning.delta"),
@@ -256,6 +267,20 @@ class AgentPool:
                 )
                 agent.compression_enabled = False
                 self._install_compression_hook(agent, session_id)
+                if requested_tools is not None:
+                    allowed_names = set(requested_tools)
+                    agent.tools = [
+                        tool for tool in (getattr(agent, "tools", None) or [])
+                        if str(tool.get("function", {}).get("name") or "") in allowed_names
+                    ]
+                    agent.valid_tool_names = {
+                        name for name in getattr(agent, "valid_tool_names", set())
+                        if name in allowed_names
+                    }
+                    context_engine_names = getattr(agent, "_context_engine_tool_names", None)
+                    if isinstance(context_engine_names, set):
+                        context_engine_names.intersection_update(allowed_names)
+                    agent._skip_mcp_refresh = True
                 mcp_tool_names = self._mcp_tool_names(self._agent_tool_names(getattr(agent, "tools", None) or []))
 
                 session = AgentSession(
@@ -271,6 +296,9 @@ class AgentPool:
                         "api_mode": runtime.get("api_mode"),
                         "platform": _bridge_platform(),
                         "allowed_toolsets": requested_toolsets,
+                        "allowed_tools": requested_tools,
+                        "skip_memory": skip_memory,
+                        "skip_context_files": skip_context_files,
                         "resumed": False,
                         "resumed_message_count": 0,
                         "mcp_tool_count": len(discovered_mcp_tools),

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
@@ -82,6 +82,7 @@ class BridgeServer:
                 workspace,
                 source,
                 reasoning_effort,
+                req.get("execution_policy"),
             )
             if req.get("wait"):
                 timeout = float(req.get("timeout", 0) or 0)
@@ -106,6 +107,7 @@ class BridgeServer:
                 model=req.get("model"),
                 provider=req.get("provider"),
                 workspace=req.get("workspace"),
+                execution_policy=req.get("execution_policy"),
             )
 
         if action == "get_result":

--- a/packages/server/src/services/hermes/agent-bridge/python/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/hermes_bridge.py
@@ -212,9 +212,10 @@ class AgentPool(_pool.AgentPool):
         profile: str | None = None,
         model: str | None = None,
         provider: str | None = None,
+        execution_policy: dict[str, Any] | None = None,
     ) -> AgentSession:
         _sync_pool_patches()
-        return super().get_or_create(session_id, profile, model, provider)
+        return super().get_or_create(session_id, profile, model, provider, execution_policy)
 
     def start_chat(self, *args: Any, **kwargs: Any) -> RunRecord:
         _sync_pool_patches()

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -602,6 +602,7 @@ export async function handleBridgeRun(
         currentInputTokens,
         shouldPersistUserMessage && displayRole === 'user',
         data.model_groups,
+        data.execution_policy,
       )
       if (chunk.done) {
         sawTerminalChunk = true
@@ -646,6 +647,7 @@ export async function handleBridgeRun(
         currentInputTokens,
         shouldPersistUserMessage && displayRole === 'user',
         data.model_groups,
+        data.execution_policy,
       )
     }
   } catch (err: any) {
@@ -669,6 +671,7 @@ export async function handleBridgeRun(
       model: resolvedModel,
       provider: resolvedProvider,
       workspace,
+      executionPolicy: data.execution_policy,
       instructions: fullInstructions,
       state,
       usage: errUsage,
@@ -867,6 +870,7 @@ async function refreshFinalContextUsage(args: {
   model?: string | null
   provider?: string | null
   workspace?: string | null
+  executionPolicy?: WorkflowExecutionPolicy
   instructions: string
   state: SessionState
   usage: { inputTokens: number; outputTokens: number }
@@ -889,6 +893,7 @@ async function refreshFinalContextUsage(args: {
       model: args.model,
       provider: args.provider,
       workspace: args.workspace,
+      executionPolicy: args.executionPolicy,
       instructions: args.instructions,
       state: args.state,
       bridge: args.bridge,
@@ -964,6 +969,7 @@ async function applyBridgeChunkAsync(
   currentInputTokens = 0,
   currentInputIncludedInDb = true,
   modelGroups?: RunModelGroup[],
+  executionPolicy?: WorkflowExecutionPolicy,
 ): Promise<void> {
   if (state.activeRunMarker !== runMarker) {
     bridgeLogger.info({
@@ -1388,6 +1394,7 @@ async function applyBridgeChunkAsync(
     model: modelContext.model,
     provider: modelContext.provider,
     workspace,
+    executionPolicy,
     instructions,
     state,
     usage,

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -27,7 +27,7 @@ import {
   recordBridgeMoaDisplayTool,
 } from './bridge-message'
 import { summarizeToolArguments } from './response-utils'
-import type { ContentBlock, QueuedRun, SessionState } from './types'
+import type { ContentBlock, QueuedRun, SessionState, WorkflowExecutionPolicy } from './types'
 import type { ChatMessage } from '../../../lib/context-compressor'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
 import { filterBridgeToolCallMarkupDelta, flushPendingToolCallMarkup } from './bridge-delta'
@@ -270,6 +270,7 @@ async function ensureBridgeFixedContext(args: {
   model?: string | null
   provider?: string | null
   workspace?: string | null
+  executionPolicy?: WorkflowExecutionPolicy
   instructions: string
   state: SessionState
   bridge: AgentBridgeClient
@@ -286,7 +287,12 @@ async function ensureBridgeFixedContext(args: {
       [],
       args.instructions,
       args.profile,
-      { model: args.model ?? undefined, provider: args.provider ?? undefined, workspace: args.workspace ?? undefined },
+      {
+        model: args.model ?? undefined,
+        provider: args.provider ?? undefined,
+        workspace: args.workspace ?? undefined,
+        executionPolicy: args.executionPolicy,
+      },
     )
     cacheBridgeContext(args.state, estimate, args.workspace)
     const fixedContextTokens = getCachedBridgeContextOverhead(args.state)
@@ -316,7 +322,7 @@ async function ensureBridgeFixedContext(args: {
 export async function handleBridgeRun(
   nsp: ReturnType<Server['of']>,
   socket: Socket,
-  data: { input: string | ContentBlock[]; display_input?: string | ContentBlock[] | null; display_role?: 'user' | 'command'; storage_message?: string; session_id?: string; model?: string; provider?: string; model_groups?: RunModelGroup[]; instructions?: string; workspace?: string | null; source?: string; session_source?: 'global_agent' | 'workflow'; queue_id?: string; peerExcludeSocketId?: string; reasoning_effort?: string; one_shot_model?: boolean; onEvent?: (event: string, payload: any) => void },
+  data: { input: string | ContentBlock[]; display_input?: string | ContentBlock[] | null; display_role?: 'user' | 'command'; storage_message?: string; session_id?: string; model?: string; provider?: string; model_groups?: RunModelGroup[]; instructions?: string; workspace?: string | null; source?: string; session_source?: 'global_agent' | 'workflow'; workflow_id?: string; workflow_run_id?: string; workflow_node_id?: string; execution_policy?: WorkflowExecutionPolicy; queue_id?: string; peerExcludeSocketId?: string; reasoning_effort?: string; one_shot_model?: boolean; onEvent?: (event: string, payload: any) => void },
   profile: string,
   sessionMap: Map<string, SessionState>,
   bridge: AgentBridgeClient,
@@ -490,6 +496,7 @@ export async function handleBridgeRun(
         model: resolvedModel,
         provider: resolvedProvider,
         workspace,
+        executionPolicy: data.execution_policy,
         instructions: fullInstructions,
         state,
         bridge,
@@ -542,6 +549,7 @@ export async function handleBridgeRun(
         ...(resolvedModel ? { model: resolvedModel } : {}),
         ...(resolvedProvider ? { provider: resolvedProvider } : {}),
         ...(workspace ? { workspace } : {}),
+        ...(data.execution_policy ? { executionPolicy: data.execution_policy } : {}),
         // Local patch (reasoning-effort): per-session reasoning effort override.
         ...(data.reasoning_effort ? { reasoning_effort: data.reasoning_effort } : {}),
       },

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -23,7 +23,7 @@ import { getOrCreateSession } from './compression'
 import { loadSessionStateFromDb, resolveRunSource } from './load-state'
 import { handleSessionCommand, isSessionCommand, parseSessionCommand } from './session-command'
 import { contentBlocksToString } from './content-blocks'
-import type { ChatCodingAgentId, ContentBlock, QueuedRun, SessionState } from './types'
+import type { ChatCodingAgentId, ContentBlock, QueuedRun, SessionState, WorkflowExecutionPolicy } from './types'
 import { authenticateUserToken, isAuthEnabled, type AuthenticatedUser } from '../../../middleware/user-auth'
 import { userCanAccessProfile } from '../../../db/hermes/users-store'
 import { observeRunChatPetEvent } from '../pet-state-socket'
@@ -397,6 +397,10 @@ export class ChatRunSocket {
       workspace?: string | null
       source?: string
       session_source?: 'global_agent' | 'workflow'
+      workflow_id?: string
+      workflow_run_id?: string
+      workflow_node_id?: string
+      execution_policy?: WorkflowExecutionPolicy
       queue_id?: string
       peerExcludeSocketId?: string
       coding_agent_id?: ChatCodingAgentId
@@ -647,6 +651,10 @@ export class ChatRunSocket {
       workspace: next.workspace,
       source: next.source,
       session_source: next.sessionSource,
+      workflow_id: next.workflowId,
+      workflow_run_id: next.workflowRunId,
+      workflow_node_id: next.workflowNodeId,
+      execution_policy: next.executionPolicy,
       queue_id: next.queue_id,
       peerExcludeSocketId: next.originSocketId,
       coding_agent_id: next.codingAgentId,
@@ -695,6 +703,10 @@ export class ChatRunSocket {
       mcp_servers?: Record<string, unknown>
       profile?: string
       reasoning_effort?: string
+      workflow_id?: string
+      workflow_run_id?: string
+      workflow_node_id?: string
+      execution_policy?: WorkflowExecutionPolicy
     },
     options: { profile?: string; user?: AuthenticatedUser; timeoutMs?: number; approvalChoice?: ChatRunAutoApprovalChoice } = {},
   ): Promise<ChatRunAndWaitResult> {

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -56,6 +56,14 @@ export interface QueuedRun {
   commandPassthrough?: boolean
   originSocketId?: string
   goalContinuation?: boolean
+  workflowId?: string
+  workflowRunId?: string
+  workflowNodeId?: string
+  executionPolicy?: WorkflowExecutionPolicy
+}
+
+export interface WorkflowExecutionPolicy {
+  allowedToolsets: string[]
 }
 
 export interface SessionState {

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -64,6 +64,9 @@ export interface QueuedRun {
 
 export interface WorkflowExecutionPolicy {
   allowedToolsets: string[]
+  allowedTools?: string[]
+  skipMemory?: boolean
+  skipContextFiles?: boolean
 }
 
 export interface SessionState {

--- a/packages/server/src/services/workflow-manager.ts
+++ b/packages/server/src/services/workflow-manager.ts
@@ -92,6 +92,7 @@ interface WorkflowNodeSnapshot {
     skills: string[]
     images: string[]
     approvalRequired: boolean
+    executionPolicy?: { allowedToolsets: string[] }
   }
 }
 
@@ -155,6 +156,12 @@ function stringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter(item => typeof item === 'string' && item.trim()).map(item => item.trim()) : []
 }
 
+function normalizeExecutionPolicy(value: unknown): { allowedToolsets: string[] } | undefined {
+  const record = value && typeof value === 'object' ? value as Record<string, unknown> : null
+  if (!record || !Array.isArray(record.allowedToolsets)) return undefined
+  return { allowedToolsets: stringArray(record.allowedToolsets) }
+}
+
 function normalizeNode(raw: unknown): WorkflowNodeSnapshot | null {
   const record = raw && typeof raw === 'object' ? raw as Record<string, any> : {}
   const id = typeof record.id === 'string' && record.id.trim() ? record.id.trim() : ''
@@ -173,12 +180,19 @@ function normalizeNode(raw: unknown): WorkflowNodeSnapshot | null {
       skills: stringArray(data.skills),
       images: stringArray(data.images),
       approvalRequired: data.approvalRequired === true,
+      executionPolicy: normalizeExecutionPolicy(data.executionPolicy),
     },
   }
 }
 
 export function workflowNodeRequiresApproval(node: { data?: { approvalRequired?: unknown } }): boolean {
   return node.data?.approvalRequired === true
+}
+
+function assertWorkflowNodeExecutionPolicyIsSupported(node: WorkflowNodeSnapshot): void {
+  if (node.data.executionPolicy && node.data.agent !== 'hermes') {
+    throw new Error(`Workflow node ${node.data.title || node.id} configures executionPolicy, but runtime enforcement currently supports Hermes nodes only`)
+  }
 }
 
 function isUnfinishedWorkflowNodeStatus(status: WorkflowRuntimeState | undefined): boolean {
@@ -570,6 +584,7 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
           const nodeSessionId = randomUUID()
           nodeSessionIds.set(node.id, nodeSessionId)
           runningOrDone.add(node.id)
+          assertWorkflowNodeExecutionPolicyIsSupported(node)
           const target = resolveWorkflowNodeRunTarget(node.data.agent)
           const nodeSession = createWorkflowRunNodeSession({
             run_id: run.id,
@@ -605,6 +620,10 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
             coding_agent_id: target.codingAgentId,
             agent_id: target.codingAgentId,
             apiMode: node.data.apiMode || undefined,
+            workflow_id: workflow.id,
+            workflow_run_id: run.id,
+            workflow_node_id: node.id,
+            execution_policy: node.data.executionPolicy,
           }, {
             profile,
             user: input.user,
@@ -908,6 +927,7 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
         const results = await Promise.all(ready.map(async node => {
           const nodeSessionId = randomUUID()
           runningOrDone.add(node.id)
+          assertWorkflowNodeExecutionPolicyIsSupported(node)
           const target = resolveWorkflowNodeRunTarget(node.data.agent)
           const nodeSession = createWorkflowRunNodeSession({
             run_id: run.id,
@@ -942,6 +962,10 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
             coding_agent_id: target.codingAgentId,
             agent_id: target.codingAgentId,
             apiMode: node.data.apiMode || undefined,
+            workflow_id: workflow.id,
+            workflow_run_id: run.id,
+            workflow_node_id: node.id,
+            execution_policy: node.data.executionPolicy,
           }, {
             profile,
             user: input.user,

--- a/packages/server/src/services/workflow-manager.ts
+++ b/packages/server/src/services/workflow-manager.ts
@@ -92,7 +92,7 @@ interface WorkflowNodeSnapshot {
     skills: string[]
     images: string[]
     approvalRequired: boolean
-    executionPolicy?: { allowedToolsets: string[] }
+    executionPolicy?: { allowedToolsets: string[]; allowedTools?: string[]; skipMemory?: boolean; skipContextFiles?: boolean }
   }
 }
 
@@ -156,10 +156,15 @@ function stringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter(item => typeof item === 'string' && item.trim()).map(item => item.trim()) : []
 }
 
-function normalizeExecutionPolicy(value: unknown): { allowedToolsets: string[] } | undefined {
+function normalizeExecutionPolicy(value: unknown): { allowedToolsets: string[]; allowedTools?: string[]; skipMemory?: boolean; skipContextFiles?: boolean } | undefined {
   const record = value && typeof value === 'object' ? value as Record<string, unknown> : null
   if (!record || !Array.isArray(record.allowedToolsets)) return undefined
-  return { allowedToolsets: stringArray(record.allowedToolsets) }
+  return {
+    allowedToolsets: stringArray(record.allowedToolsets),
+    ...(Array.isArray(record.allowedTools) ? { allowedTools: stringArray(record.allowedTools) } : {}),
+    ...(typeof record.skipMemory === 'boolean' ? { skipMemory: record.skipMemory } : {}),
+    ...(typeof record.skipContextFiles === 'boolean' ? { skipContextFiles: record.skipContextFiles } : {}),
+  }
 }
 
 function normalizeNode(raw: unknown): WorkflowNodeSnapshot | null {

--- a/tests/server/agent-bridge-profile-env.test.ts
+++ b/tests/server/agent-bridge-profile-env.test.ts
@@ -519,6 +519,163 @@ print(json.dumps({
     })
   })
 
+  it('applies an exact allowed-tools whitelist after agent tool assembly', async () => {
+    await writeFile(join(tempDir, 'config.yaml'), 'model:\n  default: fake-model\n', 'utf-8')
+
+    const result = await runBridgeProbe(`
+import importlib.util
+import json
+import os
+import sys
+import types
+
+spec = importlib.util.spec_from_file_location("hermes_bridge", os.environ["BRIDGE_PATH"])
+bridge = importlib.util.module_from_spec(spec)
+sys.modules["hermes_bridge"] = bridge
+spec.loader.exec_module(bridge)
+
+root = os.environ["TEST_HERMES_HOME"]
+os.environ["HERMES_HOME"] = root
+os.environ["HERMES_AGENT_BRIDGE_BASE_HOME"] = root
+
+run_agent = types.ModuleType("run_agent")
+class FakeAgent:
+    def __init__(self, **kwargs):
+        self.tools = [
+            {"type": "function", "function": {"name": "browser_navigate"}},
+            {"type": "function", "function": {"name": "browser_snapshot"}},
+            {"type": "function", "function": {"name": "browser_type"}},
+        ]
+        self.valid_tool_names = {"browser_navigate", "browser_snapshot", "browser_type"}
+        self._context_engine_tool_names = {"browser_type"}
+        self._skip_mcp_refresh = False
+        self.skip_memory = kwargs.get("skip_memory")
+        self.skip_context_files = kwargs.get("skip_context_files")
+run_agent.AIAgent = FakeAgent
+sys.modules["run_agent"] = run_agent
+
+class FakeDbHolder:
+    error = None
+    def get_for_profile(self, profile):
+        return None
+
+bridge._ensure_agent_imports = lambda: None
+bridge._load_cfg = lambda: {"model": {"default": "fake-model"}, "agent": {}}
+bridge._resolve_runtime = lambda model, provider=None: {"provider": "fake"}
+bridge._load_enabled_toolsets = lambda: ["browser"]
+bridge._discover_bridge_mcp_tools = lambda: []
+bridge._load_reasoning_config = lambda: None
+bridge._load_service_tier = lambda: None
+
+pool = bridge.AgentPool()
+pool._db = FakeDbHolder()
+session = pool.get_or_create(
+    "session-exact-tools",
+    profile="default",
+    execution_policy={
+        "allowedToolsets": ["browser"],
+        "allowedTools": ["browser_navigate", "browser_snapshot"],
+        "skipMemory": True,
+        "skipContextFiles": True,
+    },
+)
+
+print(json.dumps({
+    "tools": [tool["function"]["name"] for tool in session.agent.tools],
+    "valid_tool_names": sorted(session.agent.valid_tool_names),
+    "context_engine_tool_names": sorted(session.agent._context_engine_tool_names),
+    "allowed_tools": session.config.get("allowed_tools"),
+    "skip_mcp_refresh": session.agent._skip_mcp_refresh,
+    "skip_memory": session.agent.skip_memory,
+    "skip_context_files": session.agent.skip_context_files,
+}))
+`)
+
+    expect(result).toEqual({
+      tools: ['browser_navigate', 'browser_snapshot'],
+      valid_tool_names: ['browser_navigate', 'browser_snapshot'],
+      context_engine_tool_names: [],
+      allowed_tools: ['browser_navigate', 'browser_snapshot'],
+      skip_mcp_refresh: true,
+      skip_memory: true,
+      skip_context_files: true,
+    })
+  })
+
+  it('recreates an idle session when its execution policy changes', async () => {
+    await writeFile(join(tempDir, 'config.yaml'), 'model:\n  default: fake-model\n', 'utf-8')
+
+    const result = await runBridgeProbe(`
+import importlib.util
+import json
+import os
+import sys
+import types
+
+spec = importlib.util.spec_from_file_location("hermes_bridge", os.environ["BRIDGE_PATH"])
+bridge = importlib.util.module_from_spec(spec)
+sys.modules["hermes_bridge"] = bridge
+spec.loader.exec_module(bridge)
+
+root = os.environ["TEST_HERMES_HOME"]
+os.environ["HERMES_HOME"] = root
+os.environ["HERMES_AGENT_BRIDGE_BASE_HOME"] = root
+
+created = []
+run_agent = types.ModuleType("run_agent")
+class FakeAgent:
+    def __init__(self, **kwargs):
+        created.append(1)
+        self.tools = [
+            {"type": "function", "function": {"name": "browser_navigate"}},
+            {"type": "function", "function": {"name": "browser_snapshot"}},
+        ]
+        self.valid_tool_names = {"browser_navigate", "browser_snapshot"}
+        self._context_engine_tool_names = set()
+        self._skip_mcp_refresh = False
+run_agent.AIAgent = FakeAgent
+sys.modules["run_agent"] = run_agent
+
+class FakeDbHolder:
+    error = None
+    def get_for_profile(self, profile):
+        return None
+
+bridge._ensure_agent_imports = lambda: None
+bridge._load_cfg = lambda: {"model": {"default": "fake-model"}, "agent": {}}
+bridge._resolve_runtime = lambda model, provider=None: {"provider": "fake"}
+bridge._load_enabled_toolsets = lambda: ["browser"]
+bridge._discover_bridge_mcp_tools = lambda: []
+bridge._load_reasoning_config = lambda: None
+bridge._load_service_tier = lambda: None
+
+pool = bridge.AgentPool()
+pool._db = FakeDbHolder()
+first = pool.get_or_create(
+    "session-policy-change",
+    profile="default",
+    execution_policy={"allowedToolsets": ["browser"], "allowedTools": ["browser_navigate"], "skipMemory": True},
+)
+second = pool.get_or_create(
+    "session-policy-change",
+    profile="default",
+    execution_policy={"allowedToolsets": ["browser"], "allowedTools": ["browser_navigate"], "skipMemory": False},
+)
+
+print(json.dumps({
+    "created": len(created),
+    "same_session": first is second,
+    "tools": [tool["function"]["name"] for tool in second.agent.tools],
+}))
+`)
+
+    expect(result).toEqual({
+      created: 2,
+      same_session: false,
+      tools: ['browser_navigate'],
+    })
+  })
+
   it('forwards agent turn-boundary callbacks without duplicating streamed text', async () => {
     await writeFile(join(tempDir, 'config.yaml'), 'model:\n  default: fake-model\n', 'utf-8')
 

--- a/tests/server/agent-bridge-reasoning-effort.test.ts
+++ b/tests/server/agent-bridge-reasoning-effort.test.ts
@@ -58,6 +58,39 @@ describe('AgentBridgeClient.chat reasoning_effort forwarding', () => {
     expect(call).not.toHaveProperty('reasoning_effort')
   })
 
+  it('forwards the same execution policy to context estimate and chat', async () => {
+    const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+    const client = new AgentBridgeClient({ endpoint: 'tcp://127.0.0.1:1', connectRetryMs: 0, timeoutMs: 1 })
+    const request = vi.spyOn(client, 'request')
+      .mockResolvedValueOnce({
+        ok: true,
+        session_id: 's-policy',
+        token_count: 0,
+        message_count: 0,
+        tool_count: 0,
+        system_prompt_chars: 0,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        run_id: 'r-policy',
+        session_id: 's-policy',
+        status: 'running',
+      })
+    const executionPolicy = { allowedToolsets: ['safe'] }
+
+    await client.contextEstimate('s-policy', [], undefined, 'default', { executionPolicy })
+    await client.chat('s-policy', 'plan only', undefined, undefined, 'default', { executionPolicy })
+
+    expect(request.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      action: 'context_estimate',
+      execution_policy: executionPolicy,
+    }))
+    expect(request.mock.calls[1]?.[0]).toEqual(expect.objectContaining({
+      action: 'chat',
+      execution_policy: executionPolicy,
+    }))
+  })
+
   it('forwards workspace to chat and context estimate requests', async () => {
     const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
     const client = new AgentBridgeClient({ endpoint: 'tcp://127.0.0.1:1', connectRetryMs: 0, timeoutMs: 1 })

--- a/tests/server/agent-bridge-reasoning-effort.test.ts
+++ b/tests/server/agent-bridge-reasoning-effort.test.ts
@@ -76,7 +76,7 @@ describe('AgentBridgeClient.chat reasoning_effort forwarding', () => {
         session_id: 's-policy',
         status: 'running',
       })
-    const executionPolicy = { allowedToolsets: ['safe'] }
+    const executionPolicy = { allowedToolsets: ['browser'], allowedTools: ['browser_navigate', 'browser_snapshot'], skipMemory: true, skipContextFiles: true }
 
     await client.contextEstimate('s-policy', [], undefined, 'default', { executionPolicy })
     await client.chat('s-policy', 'plan only', undefined, undefined, 'default', { executionPolicy })

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -251,7 +251,13 @@ describe('bridge run final context usage', () => {
     }))
   })
 
-  it('refreshes full context tokens when a bridge run completes', async () => {
+  it('refreshes full context tokens when a bridge run completes without widening its execution policy', async () => {
+    const executionPolicy = {
+      allowedToolsets: [],
+      allowedTools: [],
+      skipMemory: true,
+      skipContextFiles: true,
+    }
     const emit = vi.fn()
     const nsp = makeNamespace(emit)
     const socket = makeSocket()
@@ -275,7 +281,7 @@ describe('bridge run final context usage', () => {
     await handleBridgeRun(
       nsp,
       socket,
-      { input: 'hello', session_id: 'session-1' },
+      { input: 'hello', session_id: 'session-1', execution_policy: executionPolicy },
       'default',
       sessionMap,
       bridge,
@@ -293,6 +299,7 @@ describe('bridge run final context usage', () => {
         model: 'gpt-test',
         provider: 'openai',
         workspace: '/tmp/hermes-bridge-final-context/default/workspace',
+        executionPolicy,
       },
     )
     expect(bridge.contextEstimate.mock.calls[0][2]).toContain('system prompt')
@@ -1200,7 +1207,13 @@ describe('bridge run final context usage', () => {
     )
   })
 
-  it('refreshes full context tokens when a bridge run fails', async () => {
+  it('refreshes full context tokens when a bridge run fails without widening its execution policy', async () => {
+    const executionPolicy = {
+      allowedToolsets: [],
+      allowedTools: [],
+      skipMemory: true,
+      skipContextFiles: true,
+    }
     const emit = vi.fn()
     const nsp = makeNamespace(emit)
     const socket = makeSocket()
@@ -1222,7 +1235,7 @@ describe('bridge run final context usage', () => {
     await handleBridgeRun(
       nsp,
       socket,
-      { input: 'hello', session_id: 'session-1' },
+      { input: 'hello', session_id: 'session-1', execution_policy: executionPolicy },
       'default',
       sessionMap,
       bridge,
@@ -1231,6 +1244,13 @@ describe('bridge run final context usage', () => {
       vi.fn(),
     )
 
+    expect(bridge.contextEstimate).toHaveBeenCalledWith(
+      'session-1',
+      [],
+      expect.any(String),
+      'default',
+      expect.objectContaining({ executionPolicy }),
+    )
     expect(state.contextTokens).toBe(54321)
     expect(emit).toHaveBeenCalledWith('usage.updated', expect.objectContaining({
       inputTokens: 11,

--- a/tests/server/workflow-manager.test.ts
+++ b/tests/server/workflow-manager.test.ts
@@ -151,7 +151,12 @@ describe('workflow manager', () => {
           title: 'Plan',
           agent: 'hermes',
           input: 'Read and plan only',
-          executionPolicy: { allowedToolsets: ['safe'] },
+          executionPolicy: {
+            allowedToolsets: ['browser'],
+            allowedTools: ['browser_navigate', 'browser_snapshot'],
+            skipMemory: true,
+            skipContextFiles: true,
+          },
         },
       }],
       edges: [],
@@ -166,7 +171,12 @@ describe('workflow manager', () => {
         session_source: 'workflow',
         workflow_id: workflow.id,
         workflow_node_id: 'plan',
-        execution_policy: { allowedToolsets: ['safe'] },
+        execution_policy: {
+          allowedToolsets: ['browser'],
+          allowedTools: ['browser_navigate', 'browser_snapshot'],
+          skipMemory: true,
+          skipContextFiles: true,
+        },
       }), expect.any(Object))
     } finally {
       await manager.delete(workflow.id)

--- a/tests/server/workflow-manager.test.ts
+++ b/tests/server/workflow-manager.test.ts
@@ -1,8 +1,29 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DatabaseSync } from 'node:sqlite'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
 
 const chatRunMock = vi.hoisted(() => ({
   runAndWait: vi.fn(),
   abortSession: vi.fn(),
+}))
+
+const databaseState = vi.hoisted(() => ({
+  db: null as DatabaseSync | null,
+  appHome: '',
+}))
+
+vi.mock('../../packages/server/src/db/index', () => ({
+  getDb: () => databaseState.db,
+  jsonDelete: vi.fn(),
+  jsonGet: vi.fn(),
+  jsonGetAll: vi.fn(() => ({})),
+  jsonSet: vi.fn(),
+}))
+
+vi.mock('../../packages/server/src/config', () => ({
+  config: { appHome: databaseState.appHome },
 }))
 
 vi.mock('../../packages/server/src/routes/hermes/chat-run', () => ({
@@ -22,6 +43,23 @@ vi.mock('../../packages/server/src/db/hermes/session-store', async (importOrigin
 })
 
 describe('workflow manager', () => {
+  let root = ''
+
+  beforeEach(async () => {
+    vi.resetModules()
+    root = mkdtempSync(join(tmpdir(), 'hermes-workflow-manager-'))
+    databaseState.appHome = join(root, 'home')
+    databaseState.db = new DatabaseSync(join(root, 'workflow-manager.db'))
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    initAllHermesTables()
+  })
+
+  afterEach(() => {
+    databaseState.db?.close()
+    databaseState.db = null
+    if (root) rmSync(root, { recursive: true, force: true })
+  })
+
   it('returns a server-wide singleton instance', async () => {
     const { WorkflowManager, getWorkflowManager } = await import('../../packages/server/src/services/workflow-manager')
 
@@ -94,6 +132,106 @@ describe('workflow manager', () => {
     expect(workflowNodeRequiresApproval({ data: { approvalRequired: true } })).toBe(true)
     expect(workflowNodeRequiresApproval({ data: { approvalRequired: false } })).toBe(false)
     expect(workflowNodeRequiresApproval({ data: {} })).toBe(false)
+  })
+
+  it('propagates a node execution policy into a fresh workflow run', async () => {
+    const { WorkflowManager } = await import('../../packages/server/src/services/workflow-manager')
+    const manager = new WorkflowManager()
+    chatRunMock.runAndWait.mockReset()
+    chatRunMock.abortSession.mockReset()
+    chatRunMock.runAndWait.mockResolvedValue({ ok: true, output: 'plan complete' })
+
+    const workflow = manager.create({
+      name: `Restricted node ${Date.now()}`,
+      profile: 'default',
+      nodes: [{
+        id: 'plan',
+        type: 'agent',
+        data: {
+          title: 'Plan',
+          agent: 'hermes',
+          input: 'Read and plan only',
+          executionPolicy: { allowedToolsets: ['safe'] },
+        },
+      }],
+      edges: [],
+    })
+
+    try {
+      await expect(manager.runNow(workflow.id)).resolves.toMatchObject({
+        run: { status: 'completed' },
+      })
+      expect(chatRunMock.runAndWait).toHaveBeenCalledWith(expect.objectContaining({
+        source: 'workflow',
+        session_source: 'workflow',
+        workflow_id: workflow.id,
+        workflow_node_id: 'plan',
+        execution_policy: { allowedToolsets: ['safe'] },
+      }), expect.any(Object))
+    } finally {
+      await manager.delete(workflow.id)
+    }
+  })
+
+  it('preserves an explicit zero-tool policy instead of falling back to profile tools', async () => {
+    const { WorkflowManager } = await import('../../packages/server/src/services/workflow-manager')
+    const manager = new WorkflowManager()
+    chatRunMock.runAndWait.mockReset()
+    chatRunMock.runAndWait.mockResolvedValue({ ok: true, output: 'review complete' })
+    const workflow = manager.create({
+      name: `Zero-tool node ${Date.now()}`,
+      profile: 'default',
+      nodes: [{
+        id: 'review',
+        type: 'agent',
+        data: {
+          title: 'Review',
+          agent: 'hermes',
+          input: 'Review without tools',
+          executionPolicy: { allowedToolsets: [] },
+        },
+      }],
+      edges: [],
+    })
+
+    try {
+      await manager.runNow(workflow.id)
+      expect(chatRunMock.runAndWait).toHaveBeenCalledWith(expect.objectContaining({
+        execution_policy: { allowedToolsets: [] },
+      }), expect.any(Object))
+    } finally {
+      await manager.delete(workflow.id)
+    }
+  })
+
+  it('rejects a scoped coding-agent node policy that this runtime cannot enforce', async () => {
+    const { WorkflowManager } = await import('../../packages/server/src/services/workflow-manager')
+    const manager = new WorkflowManager()
+    chatRunMock.runAndWait.mockReset()
+    const workflow = manager.create({
+      name: `Unsupported scoped policy ${Date.now()}`,
+      profile: 'default',
+      nodes: [{
+        id: 'code',
+        type: 'agent',
+        data: {
+          title: 'Code',
+          agent: 'codex',
+          input: 'Implement',
+          executionPolicy: { allowedToolsets: ['safe'] },
+        },
+      }],
+      edges: [],
+    })
+
+    try {
+      await expect(manager.runNow(workflow.id)).resolves.toMatchObject({
+        run: { status: 'failed', error: expect.stringContaining('Hermes nodes only') },
+      })
+      expect(chatRunMock.runAndWait).not.toHaveBeenCalled()
+    } finally {
+      await manager.delete(workflow.id)
+    }
   })
 
   it('pauses downstream nodes until an approval-required node is approved', async () => {


### PR DESCRIPTION
## Summary

- propagates Workflow node `executionPolicy` from the immutable run snapshot through WorkflowManager, chat-run, bridge client/server, and the Hermes agent runtime;
- keeps `allowedToolsets` as the coarse capability source, then applies `allowedTools` as an exact intersection after tool assembly; an explicit empty list remains zero-tool and unknown names cannot add capabilities;
- freezes exact-whitelist sessions against later MCP refresh so a newly available MCP cannot widen a node between turns;
- propagates `skipMemory` and `skipContextFiles` into `AIAgent` to prevent implicit memory synchronization and workspace-context injection for deterministic nodes;
- includes all policy fields in bridge-session identity: any change recreates an idle session, while a running session rejects policy changes;
- rejects policy-bearing scoped Codex/Claude nodes because that runtime cannot enforce these Hermes-specific controls.

## Security invariants

- Prompt wording is not treated as an authorization boundary.
- `allowedTools` can only reduce the tool surface resolved from `allowedToolsets`.
- `allowedTools: []` means no tools.
- Exact-whitelist sessions cannot regain tools through per-turn MCP discovery.
- Memory and context-file isolation are explicit, auditable node policy fields.

## Validation

- 27/27 targeted tests passed across WorkflowManager, bridge policy forwarding, exact tool pruning, memory/context isolation, and session recreation.
- `npm run harness:check`
- `tsc --noEmit -p packages/server/tsconfig.json`
- `python3 -m py_compile packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py`
- `git diff --check`
- full `npm run build` passed before push

Standalone Codex and Claude CLI review attempts were unavailable because those local CLI sessions were not authenticated; no review result is claimed from them. GitHub Build and Playwright checks are required on the pushed head.

Closes #2022