### PR TITLE
fix(client): handle malformed session export filenames

### DIFF
--- a/docs/chat-chain-changes/2026-07-10-pr2026-session-export-filenames.md
+++ b/docs/chat-chain-changes/2026-07-10-pr2026-session-export-filenames.md
@@ -1,0 +1,11 @@
+---
+date: 2026-07-10
+pr: 2026
+feature: Session export filenames
+impact: Session exports now continue downloading when the response filename contains a raw percent sign instead of failing with a malformed URI error.
+---
+
+The client still decodes valid percent-encoded `Content-Disposition` filenames,
+but falls back to the raw filename when decoding encounters a malformed percent
+escape. This keeps export responses such as `filename="100% ready.json"` from
+throwing before the browser download begins.

--- a/packages/client/src/api/hermes/sessions.ts
+++ b/packages/client/src/api/hermes/sessions.ts
@@ -424,7 +424,14 @@ export async function exportSession(id: string, mode: 'full' | 'compressed' = 'f
   const contentDisposition = res.headers.get('Content-Disposition') || ''
   let filename = `session_${id}.${ext}`
   const match = contentDisposition.match(/filename\*?=(?:UTF-8'')?([^;\n]+)/i)
-  if (match) filename = decodeURIComponent(match[1].replace(/"/g, ''))
+  if (match) {
+    const dispositionFilename = match[1].replace(/"/g, '')
+    try {
+      filename = decodeURIComponent(dispositionFilename)
+    } catch {
+      filename = dispositionFilename
+    }
+  }
   const a = document.createElement('a')
   a.href = URL.createObjectURL(blob)
   a.download = filename

--- a/tests/client/api.test.ts
+++ b/tests/client/api.test.ts
@@ -16,7 +16,7 @@ import { getApiKey, setApiKey, clearApiKey, hasApiKey, getStoredUserRole, isStor
 import { getDownloadUrl } from '../../packages/client/src/api/hermes/download'
 import { uploadFiles } from '../../packages/client/src/api/hermes/files'
 import { importSkill } from '../../packages/client/src/api/hermes/skills'
-import { archiveSession, batchDeleteSessions, importHermesSession, unarchiveSession } from '../../packages/client/src/api/hermes/sessions'
+import { archiveSession, batchDeleteSessions, exportSession, importHermesSession, unarchiveSession } from '../../packages/client/src/api/hermes/sessions'
 import router from '@/router'
 
 function fakeJwt(payload: Record<string, unknown>) {
@@ -223,6 +223,42 @@ describe('API Client', () => {
       expect(url.pathname).toBe('/api/hermes/download')
       expect(url.searchParams.get('path')).toBe('/tmp/100% ready.txt')
       expect(url.searchParams.get('name')).toBe('100% ready.txt')
+    })
+
+    it('exports sessions when the response filename contains a raw percent sign', async () => {
+      const blob = new Blob(['session'])
+      mockFetch.mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(blob),
+        headers: new Headers({
+          'Content-Disposition': 'attachment; filename="100% ready.json"',
+        }),
+      })
+      const createObjectUrl = vi.fn(() => 'blob:session-export')
+      const revokeObjectUrl = vi.fn()
+      const OriginalUrl = URL
+      class ExportUrl extends OriginalUrl {}
+      Object.defineProperties(ExportUrl, {
+        createObjectURL: { value: createObjectUrl },
+        revokeObjectURL: { value: revokeObjectUrl },
+      })
+      vi.stubGlobal('URL', ExportUrl)
+      const originalCreateElement = document.createElement.bind(document)
+      const downloadAnchor = originalCreateElement('a') as HTMLAnchorElement
+      vi.spyOn(downloadAnchor, 'click').mockImplementation(() => undefined)
+      const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+        return tagName.toLowerCase() === 'a' ? downloadAnchor : originalCreateElement(tagName)
+      })
+
+      try {
+        await expect(exportSession('session-1')).resolves.toBeUndefined()
+        expect(downloadAnchor.download).toBe('100% ready.json')
+        expect(revokeObjectUrl).toHaveBeenCalledWith('blob:session-export')
+      } finally {
+        createElementSpy.mockRestore()
+        vi.unstubAllGlobals()
+        vi.stubGlobal('fetch', mockFetch)
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

Session export currently decodes the filename from `Content-Disposition` with `decodeURIComponent()` unconditionally. A valid response such as:

```http
Content-Disposition: attachment; filename="100% ready.json"
```

throws `URIError: URI malformed`, so the server returns the export successfully but the browser never starts the download.

This change preserves normal decoding for percent-encoded filenames and falls back to the raw disposition filename when it contains malformed percent escapes.

## Validation

- Added a failing-before-fix regression test for `filename="100% ready.json"`.
- `NODE_ENV=test npx -y -p node@24 -p npm@11 npm test -- --run tests/client/api.test.ts` — 27 tests passed.
- `NODE_ENV=development npx -y -p node@24 -p npm@11 npm run build` — passed with the existing Vite large-chunk warning only.
- `npm run harness:check` — passed.
- `git diff --check` — passed.
- Built `hermes-studio:pr-audit` and verified the container `/health` endpoint reports the server and agent bridge ready.

## Duplicate Check

- No open PR matched `session export` in the upstream repository.
- No issue matched the session-export raw-percent filename failure.
- This is the same defensive decoding pattern already used by `getDownloadUrl()` for raw percent signs, applied to session export filenames.

## Browser / Playwright

Not run. The failure is covered at the API-client boundary by stubbing the export response, blob URL, and download anchor; the production build and Docker health smoke test also pass.
