### PR TITLE
fix: reconnect chat socket after profile switch

### DIFF
--- a/docs/chat-chain-changes/2026-07-11-issue1884-profile-socket-reuse.md
+++ b/docs/chat-chain-changes/2026-07-11-issue1884-profile-socket-reuse.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-11
+pr: pending
+feature: Chat-run profile socket reuse
+impact: Omitted-profile chat-run socket requests now reconnect when the active Hermes profile has changed instead of reusing a socket for the previous profile.
+---
+
+Explicit same-profile chat-run socket requests still reuse the connected socket.

--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -2,6 +2,7 @@ import { io, type Socket } from 'socket.io-client'
 import { getBaseUrlValue, getApiKey } from '../client'
 import type { ChatCodingAgentId } from '../coding-agents'
 import type { ProviderApiMode } from './system'
+import { useProfilesStore } from '@/stores/hermes/profiles'
 
 export type ContentBlock =
   | { type: 'text'; text: string }
@@ -657,10 +658,22 @@ export function getChatRunSocket(transport?: ChatRunTransport): Socket | null {
 
 export function connectChatRun(requestedProfile?: string | null, transport: ChatRunTransport = 'chat-run'): Socket {
   const normalizedRequestedProfile = requestedProfile?.trim() || null
+  // Get active profile from store (authoritative source)
+  let profile = normalizedRequestedProfile || 'default'
+  try {
+    if (!normalizedRequestedProfile) {
+      const profilesStore = useProfilesStore()
+      profile = profilesStore.activeProfileName || 'default'
+    }
+  } catch {
+    // Fallback to localStorage during early initialization
+    profile = normalizedRequestedProfile || localStorage.getItem('hermes_active_profile_name') || 'default'
+  }
+
   if (
     chatRunSocket?.connected &&
     chatRunSocketTransport === transport &&
-    (!normalizedRequestedProfile || chatRunSocketProfile === normalizedRequestedProfile)
+    chatRunSocketProfile === profile
   ) {
     return chatRunSocket
   }
@@ -676,18 +689,6 @@ export function connectChatRun(requestedProfile?: string | null, transport: Chat
   const baseUrl = getBaseUrlValue()
   const token = getApiKey()
 
-  // Get active profile from store (authoritative source)
-  let profile = normalizedRequestedProfile || 'default'
-  try {
-    if (!normalizedRequestedProfile) {
-      const { useProfilesStore } = require('@/stores/hermes/profiles')
-      const profilesStore = useProfilesStore()
-      profile = profilesStore.activeProfileName || 'default'
-    }
-  } catch {
-    // Fallback to localStorage during early initialization
-    profile = normalizedRequestedProfile || localStorage.getItem('hermes_active_profile_name') || 'default'
-  }
   chatRunSocketProfile = profile
   chatRunSocketTransport = transport
 

--- a/tests/client/chat-run-reconnect.test.ts
+++ b/tests/client/chat-run-reconnect.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const socketState = vi.hoisted(() => ({
   sockets: [] as any[],
+  calls: [] as Array<{ url: string; options: any }>,
+  activeProfileName: 'default',
 }))
 
 vi.mock('socket.io-client', () => {
@@ -66,13 +68,22 @@ vi.mock('socket.io-client', () => {
   }
 
   return {
-    io: vi.fn(() => {
+    io: vi.fn((url: string, options: any) => {
       const socket = createSocket()
       socketState.sockets.push(socket)
+      socketState.calls.push({ url, options })
       return socket
     }),
   }
 })
+
+vi.mock('@/stores/hermes/profiles', () => ({
+  useProfilesStore: () => ({
+    get activeProfileName() {
+      return socketState.activeProfileName
+    },
+  }),
+}))
 
 vi.mock('../../packages/client/src/api/client', () => ({
   getApiKey: () => 'test-token',
@@ -83,6 +94,14 @@ describe('chat-run socket reconnect handling', () => {
   beforeEach(() => {
     vi.resetModules()
     socketState.sockets = []
+    socketState.calls = []
+    socketState.activeProfileName = 'default'
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn((key: string) => (key === 'hermes_active_profile_name' ? socketState.activeProfileName : null)),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    })
   })
 
   it('keeps transient mobile disconnects alive and resumes after reconnect', async () => {
@@ -179,6 +198,33 @@ describe('chat-run socket reconnect handling', () => {
     expect(socket.__listenerCount('connect')).toBe(1)
     expect(socket.__listenerCount('disconnect')).toBe(1)
     expect(socket.emit).toHaveBeenCalledWith('run', body)
+  })
+
+  it('reconnects to the current active profile when no profile is requested', async () => {
+    const { connectChatRun } = await import('../../packages/client/src/api/hermes/chat')
+
+    const defaultSocket = connectChatRun(null)
+    expect(socketState.calls[0].options.query).toEqual({ profile: 'default' })
+
+    socketState.activeProfileName = 'research'
+    const researchSocket = connectChatRun(null)
+
+    expect(researchSocket).not.toBe(defaultSocket)
+    expect(defaultSocket.removeAllListeners).toHaveBeenCalled()
+    expect(defaultSocket.disconnect).toHaveBeenCalled()
+    expect(socketState.calls).toHaveLength(2)
+    expect(socketState.calls[1].options.query).toEqual({ profile: 'research' })
+  })
+
+  it('reuses an existing socket for an explicit matching profile', async () => {
+    const { connectChatRun } = await import('../../packages/client/src/api/hermes/chat')
+
+    const socket = connectChatRun('default')
+    const reusedSocket = connectChatRun('default')
+
+    expect(reusedSocket).toBe(socket)
+    expect(socketState.calls).toHaveLength(1)
+    expect(socket.disconnect).not.toHaveBeenCalled()
   })
 
   it('fans session.command events to run-local and global handlers', async () => {


### PR DESCRIPTION
## Summary

- resolve the effective active Hermes profile before deciding whether to reuse the connected chat-run socket
- reconnect when an omitted-profile call follows an active-profile change
- retain socket reuse for explicit calls targeting the same profile
- add focused regression coverage for both behaviors

Fixes #1884.

## Validation

- Baseline regression: with the production file restored from `origin/main`, `npm run test -- tests/client/chat-run-reconnect.test.ts` failed at the intended stale-socket assertion (1 failed, 6 passed)
- Fixed regression: `npm run test -- tests/client/chat-run-reconnect.test.ts` passed (7/7)
- `npm run harness:check` passed
- `npm run build` passed
- `git diff --check` passed

## Duplicate Check

Checked current `origin/main` and open upstream PRs immediately before publication. Main does not contain the profile-matching reuse guard, and no active duplicate PR was found for #1884, `connectChatRun`, or profile-socket reuse.

## Browser/Playwright Status

Not run. This change affects socket-selection logic without a visual UI change; deterministic client unit coverage exercises the stale-profile reconnection and same-profile reuse paths.
