### PR TITLE
[codex] collapse workspace diffs and restore chat input background

### DIFF
--- a/docs/chat-chain-changes/2026-07-11-zero-line-diff-collapse.md
+++ b/docs/chat-chain-changes/2026-07-11-zero-line-diff-collapse.md
@@ -1,0 +1,6 @@
+---
+date: 2026-07-11
+commit: local
+feature: Suppress zero-line workspace changes and collapse diff details by default
+impact: Workspace diff tracking drops files with no added or deleted lines before persistence, while direct-chat and group-chat diff cards keep their summaries visible and hide file details until expanded.
+---

--- a/docs/chat-chain-changes/2026-07-11-zero-line-diff-collapse.md
+++ b/docs/chat-chain-changes/2026-07-11-zero-line-diff-collapse.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-07-11
-commit: local
+commit: PR #2032
 feature: Suppress zero-line workspace changes and collapse diff details by default
 impact: Workspace diff tracking drops files with no added or deleted lines before persistence, while direct-chat and group-chat diff cards keep their summaries visible and hide file details until expanded.
 ---

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1344,6 +1344,10 @@ function isImage(type: string): boolean {
   border-top: 0;
   background-color: $bg-card;
   flex-shrink: 0;
+
+  .dark & {
+    background-color: #333333;
+  }
 }
 
 .input-top-bar {
@@ -1747,7 +1751,7 @@ function isImage(type: string): boolean {
   }
 
   .dark & {
-    background-color: $bg-card;
+    background-color: #333333;
     box-shadow: 0 8px 28px rgba(0, 0, 0, 0.32);
   }
 }

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -948,7 +948,24 @@ onBeforeUnmount(() => {
         @click="handleToolDetailClick"
       >
         <div class="tool-change-card">
-          <div class="tool-change-card-header">
+          <button
+            class="tool-change-card-header"
+            type="button"
+            :aria-expanded="toolExpanded"
+            @click.stop="toolExpanded = !toolExpanded"
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              class="tool-change-chevron"
+              :class="{ rotated: toolExpanded }"
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
             <span class="tool-change-card-title">
               {{ t("chat.changedFiles", { files: toolChange?.files_changed || 0 }) }}
             </span>
@@ -956,28 +973,30 @@ onBeforeUnmount(() => {
               <span class="additions">+{{ toolChange?.additions || 0 }}</span>
               <span class="deletions">-{{ toolChange?.deletions || 0 }}</span>
             </span>
-          </div>
-          <button
-            v-for="file in toolChange?.files || []"
-            :key="file.id"
-            class="tool-change-file-row"
-            :class="{ selected: selectedToolChangeFileId === file.id }"
-            type="button"
-            @click.stop="openToolChangeFile(file)"
-          >
-            <span class="tool-change-file-main">
-              <span class="tool-change-file-badge" :class="fileBadgeClass(file.path)">
-                {{ fileExtension(file.path) }}
-              </span>
-              <span class="tool-change-file-name" :title="file.path">
-                {{ fileNameFromPath(file.path) }}
-              </span>
-            </span>
-            <span class="tool-change-file-stats">
-              <span class="additions">+{{ file.additions }}</span>
-              <span class="deletions">-{{ file.deletions }}</span>
-            </span>
           </button>
+          <div v-if="toolExpanded" class="tool-change-files">
+            <button
+              v-for="file in toolChange?.files || []"
+              :key="file.id"
+              class="tool-change-file-row"
+              :class="{ selected: selectedToolChangeFileId === file.id }"
+              type="button"
+              @click.stop="openToolChangeFile(file)"
+            >
+              <span class="tool-change-file-main">
+                <span class="tool-change-file-badge" :class="fileBadgeClass(file.path)">
+                  {{ fileExtension(file.path) }}
+                </span>
+                <span class="tool-change-file-name" :title="file.path">
+                  {{ fileNameFromPath(file.path) }}
+                </span>
+              </span>
+              <span class="tool-change-file-stats">
+                <span class="additions">+{{ file.additions }}</span>
+                <span class="deletions">-{{ file.deletions }}</span>
+              </span>
+            </button>
+          </div>
         </div>
       </div>
       <div v-else-if="toolExpanded && hasToolDetails" class="tool-details" @click="handleToolDetailClick">
@@ -1870,10 +1889,32 @@ onBeforeUnmount(() => {
 
 .tool-change-card-header {
   align-items: baseline;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
   display: flex;
   gap: 8px;
   justify-content: flex-start;
   min-width: 0;
+  padding: 0;
+  text-align: left;
+  width: 100%;
+}
+
+.tool-change-chevron {
+  align-self: center;
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+
+  &.rotated {
+    transform: rotate(90deg);
+  }
+}
+
+.tool-change-files {
+  display: grid;
+  gap: 10px;
 }
 
 .tool-change-card-title {

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -508,10 +508,29 @@ onBeforeUnmount(() => {
                 <span v-if="isAgent && agentInfo?.description" class="agent-desc">{{ agentInfo.description }}</span>
             </div>
             <div v-if="workspaceDiffPayload" class="workspace-diff-card">
-                <div class="workspace-diff-head">
-                    <span class="workspace-diff-title">{{ t('chat.workspaceChanges') }}</span>
+                <button
+                    class="workspace-diff-head"
+                    type="button"
+                    :aria-expanded="toolExpanded"
+                    @click="toolExpanded = !toolExpanded"
+                >
+                    <span class="workspace-diff-title-wrap">
+                        <svg
+                            width="12"
+                            height="12"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            class="workspace-diff-chevron"
+                            :class="{ rotated: toolExpanded }"
+                        >
+                            <polyline points="9 18 15 12 9 6" />
+                        </svg>
+                        <span class="workspace-diff-title">{{ t('chat.workspaceChanges') }}</span>
+                    </span>
                     <span class="workspace-diff-status">{{ workspaceDiffPayload.status }}</span>
-                </div>
+                </button>
                 <div class="workspace-diff-meta" :title="workspaceDiffLabel">
                     <span>{{ workspaceDiffLabel }}</span>
                     <span>{{ t('chat.changedFiles', { files: workspaceDiffPayload.files_changed ?? workspaceDiffFiles.length }) }}</span>
@@ -519,7 +538,7 @@ onBeforeUnmount(() => {
                     <span class="diff-del">-{{ workspaceDiffPayload.deletions || 0 }}</span>
                     <span v-if="workspaceDiffPayload.truncated">{{ t('chat.truncated') }}</span>
                 </div>
-                <div class="workspace-diff-files" @click="handleToolDetailClick">
+                <div v-if="toolExpanded" class="workspace-diff-files" @click="handleToolDetailClick">
                     <div v-for="file in workspaceDiffFiles" :key="file.id || file.path" class="workspace-diff-file">
                         <div class="workspace-diff-file-head">
                             <span class="workspace-diff-path">{{ file.path }}</span>
@@ -817,9 +836,31 @@ onBeforeUnmount(() => {
 }
 
 .workspace-diff-head {
+    background: transparent;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
     justify-content: space-between;
     padding: 8px 10px;
     border-bottom: 1px solid $border-color;
+    text-align: left;
+    width: 100%;
+}
+
+.workspace-diff-title-wrap {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.workspace-diff-chevron {
+    flex-shrink: 0;
+    transition: transform 0.15s ease;
+
+    &.rotated {
+        transform: rotate(90deg);
+    }
 }
 
 .workspace-diff-title {

--- a/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
+++ b/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
@@ -562,13 +562,8 @@ function compareSnapshots(before: SnapshotFile | undefined, after: SnapshotFile,
   }
 }
 
-function isEmptyContentOnlyChange(comparison: SnapshotComparison): boolean {
-  return comparison.changed &&
-    comparison.additions === 0 &&
-    comparison.deletions === 0 &&
-    !comparison.patch &&
-    (comparison.sizeBefore == null || comparison.sizeBefore === 0) &&
-    (comparison.sizeAfter == null || comparison.sizeAfter === 0)
+function isZeroLineDiff(comparison: SnapshotComparison): boolean {
+  return comparison.changed && comparison.additions === 0 && comparison.deletions === 0
 }
 
 export function startWorkspaceRunCheckpoint(args: {
@@ -672,7 +667,7 @@ export function completeWorkspaceRunCheckpointDraft(args: {
       Math.max(0, MAX_TOTAL_PATCH_BYTES - totalPatchBytes),
     )
     if (!comparison.changed) continue
-    if (isEmptyContentOnlyChange(comparison)) continue
+    if (isZeroLineDiff(comparison)) continue
     if (files.length >= MAX_CHANGED_FILES) {
       truncated = true
       break

--- a/tests/client/group-chat-workspace-diff.test.ts
+++ b/tests/client/group-chat-workspace-diff.test.ts
@@ -132,7 +132,7 @@ describe('group chat workspace diff client rendering', () => {
     })
   })
 
-  it('renders a workspace diff card instead of raw JSON details', () => {
+  it('renders a workspace diff card collapsed by default and expands it on demand', async () => {
     const wrapper = mount(GroupMessageItem, {
       props: {
         message: {
@@ -150,6 +150,12 @@ describe('group chat workspace diff client rendering', () => {
 
     expect(wrapper.find('.workspace-diff-card').exists()).toBe(true)
     expect(wrapper.text()).toContain('chat.workspaceChanges')
+    expect(wrapper.find('.workspace-diff-files').exists()).toBe(false)
+    expect(wrapper.find('.workspace-diff-head').attributes('aria-expanded')).toBe('false')
+
+    await wrapper.find('.workspace-diff-head').trigger('click')
+
+    expect(wrapper.find('.workspace-diff-head').attributes('aria-expanded')).toBe('true')
     expect(wrapper.text()).toContain('src/a.ts')
     expect(wrapper.find('.tool-line').exists()).toBe(false)
     expect(wrapper.text()).not.toContain('"kind"')

--- a/tests/client/message-item-highlight.test.ts
+++ b/tests/client/message-item-highlight.test.ts
@@ -393,6 +393,62 @@ describe('MessageItem tool details', () => {
     expect(toolDetails.text()).not.toContain('chat.truncated')
   })
 
+  it('keeps workspace change files collapsed until the summary is expanded', async () => {
+    const wrapper = mount(MessageItem, {
+      props: {
+        message: {
+          id: 'workspace-change',
+          role: 'tool',
+          content: '',
+          timestamp: Date.now(),
+          toolName: 'workspace_diff',
+          toolStatus: 'done',
+          toolChange: {
+            change_id: 'change-1',
+            session_id: 'session-1',
+            run_id: 'run-1',
+            source: 'run',
+            workspace: '/tmp/repo',
+            workspace_kind: 'git',
+            started_at: 1,
+            finished_at: 2,
+            files_changed: 1,
+            additions: 2,
+            deletions: 1,
+            truncated: false,
+            total_patch_bytes: 32,
+            created_at: 2,
+            files: [{
+              id: 1,
+              change_id: 'change-1',
+              session_id: 'session-1',
+              path: 'src/example.ts',
+              old_path: null,
+              change_type: 'modified',
+              additions: 2,
+              deletions: 1,
+              size_before: 10,
+              size_after: 12,
+              patch_bytes: 32,
+              truncated: false,
+              binary: false,
+              created_at: 2,
+            }],
+          },
+        } satisfies Message,
+      },
+      global: { stubs: { MarkdownRenderer: true } },
+    })
+
+    expect(wrapper.find('.tool-change-file-row').exists()).toBe(false)
+    expect(wrapper.find('.tool-change-card-header').attributes('aria-expanded')).toBe('false')
+
+    await wrapper.find('.tool-change-card-header').trigger('click')
+
+    expect(wrapper.find('.tool-change-card-header').attributes('aria-expanded')).toBe('true')
+    expect(wrapper.find('.tool-change-file-row').text()).toContain('example.ts')
+  })
+
   it('shows only an embedded difference field when a JSON tool result contains a unified diff', async () => {
     const writeText = vi.mocked(navigator.clipboard.writeText)
     const largeDiff = `diff --git a/foo.ts b/foo.ts\n--- a/foo.ts\n+++ b/foo.ts\n@@ -1,1 +1,1 @@\n-${'a'.repeat(1600)}\n+${'b'.repeat(1600)}\n`

--- a/tests/server/workspace-diff-tracker.test.ts
+++ b/tests/server/workspace-diff-tracker.test.ts
@@ -202,6 +202,35 @@ describe('workspace diff tracker', () => {
     expect(nonEmptyChange?.files.map(file => file.path)).toEqual(['non-empty.txt'])
   })
 
+  it('does not save zero-line diffs that are not covered by filename filters', async () => {
+    const {
+      completeWorkspaceRunCheckpoint,
+      startWorkspaceRunCheckpoint,
+    } = await import('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker')
+
+    const workspace = join(root, 'plain-zero-line-diff')
+    mkdirSync(workspace)
+    writeFileSync(join(workspace, '.global-cache'), Buffer.from([0, 1, 2, 3]))
+
+    startWorkspaceRunCheckpoint({
+      sessionId: 'session-zero-line',
+      runId: 'run-zero-line',
+      workspace,
+    })
+
+    writeFileSync(join(workspace, '.global-cache'), Buffer.from([0, 4, 5, 6]))
+    writeFileSync(join(workspace, 'notes.md'), 'visible change\n')
+    const change = completeWorkspaceRunCheckpoint({
+      sessionId: 'session-zero-line',
+      runId: 'run-zero-line',
+      workspace,
+    })
+
+    expect(change).not.toBeNull()
+    expect(change?.files.map(file => file.path)).toEqual(['notes.md'])
+    expect(state.db?.prepare('SELECT COUNT(*) AS count FROM workspace_run_change_files WHERE additions = 0 AND deletions = 0').get()).toEqual({ count: 0 })
+  })
+
   it('skips SQLite WAL and SHM sidecar files in non-git workspaces', async () => {
     const {
       completeWorkspaceRunCheckpoint,


### PR DESCRIPTION
## Summary
- suppress zero-line workspace file changes before persistence
- collapse direct-chat and group-chat workspace diff details by default while keeping summaries visible
- add expand controls and accessibility state to workspace diff cards
- restore the standard dark chat composer background to #333333
- add focused client and server regression coverage plus the required chat-chain change record

## Why
Workspace tracking could persist binary or metadata-only changes with zero added and deleted lines, creating noisy diff entries. Workspace change cards also expanded all file details immediately, taking unnecessary space. Separately, the shared dark card token change unintentionally darkened the chat composer.

## Impact
Workspace change summaries remain compact until expanded, zero-line noise is omitted, and the normal dark chat composer consistently uses #333333. Light theme behavior is unchanged.

## Validation
- npm run test -- tests/client/group-chat-workspace-diff.test.ts tests/client/message-item-highlight.test.ts tests/server/workspace-diff-tracker.test.ts
- npm run test -- tests/client/style-system.test.ts tests/client/chat-input-draft.test.ts
- npm run harness:check
- npm run build