### PR TITLE
fix: bound Bridge tool results in model context

### DIFF
--- a/docs/chat-chain-changes/2026-07-11-bridge-tool-result-context-limit.md
+++ b/docs/chat-chain-changes/2026-07-11-bridge-tool-result-context-limit.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-11
+pr: pending
+feature: Bridge tool-result context projection
+impact: Hermes Bridge tool results remain complete in session storage while model history and context-token estimates use the same 5,500-character head/tail projection. Coding Agent persistence behavior is unchanged.
+---
+
+Large persisted tool results no longer dominate resumed Bridge history or its local context estimate.

--- a/packages/server/src/lib/context-compressor/index.ts
+++ b/packages/server/src/lib/context-compressor/index.ts
@@ -19,6 +19,7 @@ import { mkdir, writeFile } from 'fs/promises'
 import { resolve } from 'path'
 import { logger } from '../../services/logger'
 import { AgentBridgeClient, type AgentBridgeRunResult } from '../../services/hermes/agent-bridge'
+import { truncateToolResultForContext } from '../tool-result-context'
 import {
   getCompressionSnapshot,
   saveCompressionSnapshot,
@@ -360,9 +361,7 @@ export function serializeForSummary(messages: ChatMessage[]): string {
     const role = msg.role === 'tool' ? `[tool:${msg.name || 'unknown'}]` : msg.role
     let content = contentToString(msg.content || '')
 
-    if (msg.role === 'tool' && content.length > 5500) {
-      content = content.slice(0, 4000) + '\n... [truncated]\n...' + content.slice(-1500)
-    }
+    if (msg.role === 'tool') content = truncateToolResultForContext(content)
 
     if (msg.role === 'assistant' && msg.tool_calls?.length) {
       const toolsInfo = msg.tool_calls.map(tc => {

--- a/packages/server/src/lib/tool-result-context.ts
+++ b/packages/server/src/lib/tool-result-context.ts
@@ -1,0 +1,19 @@
+export const TOOL_RESULT_CONTEXT_LIMIT = 5_500
+export const TOOL_RESULT_CONTEXT_HEAD_CHARS = 4_000
+export const TOOL_RESULT_CONTEXT_MARKER = '\n... [truncated]\n...'
+export const TOOL_RESULT_CONTEXT_TAIL_CHARS =
+  TOOL_RESULT_CONTEXT_LIMIT - TOOL_RESULT_CONTEXT_HEAD_CHARS - TOOL_RESULT_CONTEXT_MARKER.length
+
+/**
+ * Bound tool results when they are projected into model context.
+ *
+ * Persistence intentionally keeps the complete result. This projection mirrors
+ * the long-standing context-compressor rule: preserve the useful beginning and
+ * ending while preventing one tool response from dominating the context.
+ */
+export function truncateToolResultForContext(content: string): string {
+  if (content.length <= TOOL_RESULT_CONTEXT_LIMIT) return content
+  return content.slice(0, TOOL_RESULT_CONTEXT_HEAD_CHARS) +
+    TOOL_RESULT_CONTEXT_MARKER +
+    content.slice(-TOOL_RESULT_CONTEXT_TAIL_CHARS)
+}

--- a/packages/server/src/services/hermes/run-chat/compression.ts
+++ b/packages/server/src/services/hermes/run-chat/compression.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../db/hermes/session-store'
 import { getCompressionSnapshot } from '../../../db/hermes/compression-snapshot'
 import { ChatContextCompressor, SUMMARY_PREFIX } from '../../../lib/context-compressor'
+import { truncateToolResultForContext } from '../../../lib/tool-result-context'
 import { getModelContextLength } from '../model-context'
 import { readConfigYamlForProfile } from '../../config-helpers'
 import { logger } from '../../logger'
@@ -194,7 +195,10 @@ export async function buildDbHistory(
     : validMessages
 
   return sourceMessages.map((m, idx, arr) => {
-    const msg: any = { role: m.role, content: m.content || '' }
+    const content = m.role === 'tool'
+      ? truncateToolResultForContext(m.content || '')
+      : m.content || ''
+    const msg: any = { role: m.role, content }
     if (m.reasoning_content != null) msg.reasoning_content = m.reasoning_content
     if (m.tool_calls?.length) {
       const cleanedToolCalls = m.tool_calls
@@ -262,7 +266,9 @@ export async function buildCompressedHistory(
       return history
     }
     const cState = getOrCreateSession(sessionMap, sessionId)
-    const assembledTokens = await calcAndUpdateUsage(sessionId, cState, emit)
+    const assembledTokens = await calcAndUpdateUsage(sessionId, cState, emit, {
+      truncateToolResultsForContext: true,
+    })
     const currentRunInputTokens = typeof currentInputTokens === 'number' && Number.isFinite(currentInputTokens) && currentInputTokens > 0
       ? Math.floor(currentInputTokens)
       : 0
@@ -286,7 +292,9 @@ export async function buildCompressedHistory(
         contextTokens,
       })
     }
-    const messageOnlyTotalTokens = assembledTokens.inputTokens + assembledTokens.outputTokens
+    const messageOnlyTotalTokens =
+      (assembledTokens.contextInputTokens ?? assembledTokens.inputTokens) +
+      (assembledTokens.contextOutputTokens ?? assembledTokens.outputTokens)
     let totalTokens = messageOnlyTotalTokens
 
     if (history.length === 0) {
@@ -429,8 +437,12 @@ export async function compressHistory(
       provider: summarizerModelContext.provider,
       workerKey: `${summarizerProfile}:compression:${sessionId}`,
     })
-    const afterTokens = await calcAndUpdateUsage(sessionId, cState, emit)
-    const compressedAfterTokens = afterTokens.inputTokens + afterTokens.outputTokens
+    const afterTokens = await calcAndUpdateUsage(sessionId, cState, emit, {
+      truncateToolResultsForContext: true,
+    })
+    const compressedAfterTokens =
+      (afterTokens.contextInputTokens ?? afterTokens.inputTokens) +
+      (afterTokens.contextOutputTokens ?? afterTokens.outputTokens)
     const resultUsage = estimateUsageTokensFromMessages(result.messages)
     const resultMessageTokens = resultUsage.inputTokens + resultUsage.outputTokens
     const compressedRunMessageTokens = Math.max(

--- a/packages/server/src/services/hermes/run-chat/usage.ts
+++ b/packages/server/src/services/hermes/run-chat/usage.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../db/hermes/session-store'
 import { getCompressionSnapshot } from '../../../db/hermes/compression-snapshot'
 import { countTokens, SUMMARY_PREFIX } from '../../../lib/context-compressor'
+import { truncateToolResultForContext } from '../../../lib/tool-result-context'
 import { logger } from '../../logger'
 import type { SessionState } from './types'
 
@@ -44,35 +45,52 @@ export async function calcAndUpdateUsage(
   sid: string,
   state: SessionState,
   emit: (event: string, payload: any) => void,
-): Promise<{ inputTokens: number; outputTokens: number }> {
+  options: { truncateToolResultsForContext?: boolean } = {},
+): Promise<{
+  inputTokens: number
+  outputTokens: number
+  contextInputTokens?: number
+  contextOutputTokens?: number
+}> {
   try {
     const detail = getSessionDetail(sid)
-    const msgs = detail?.messages
+    const storedMessages = detail?.messages
       ?.filter(m => m.role === 'user' || m.role === 'assistant' || m.role === 'tool') || []
-
     const snapshot = getCompressionSnapshot(sid)
-    let inputTokens: number
-    let outputTokens: number
-    if (snapshot && msgs.length && snapshot.lastMessageIndex >= 0 && snapshot.lastMessageIndex < msgs.length) {
-      const newMessages = msgs.slice(snapshot.lastMessageIndex + 1)
-      const newUsage = estimateUsageTokensFromMessages(newMessages)
-      inputTokens = countTokens(SUMMARY_PREFIX + snapshot.summary) +
-        newUsage.inputTokens
-      outputTokens = newUsage.outputTokens
-    } else {
-      const usage = estimateUsageTokensFromMessages(msgs)
-      inputTokens = usage.inputTokens
-      outputTokens = usage.outputTokens
+    const estimateSnapshotUsage = (messages: typeof storedMessages) => {
+      if (snapshot && messages.length && snapshot.lastMessageIndex >= 0 && snapshot.lastMessageIndex < messages.length) {
+        const newMessages = messages.slice(snapshot.lastMessageIndex + 1)
+        const newUsage = estimateUsageTokensFromMessages(newMessages)
+        return {
+          inputTokens: countTokens(SUMMARY_PREFIX + snapshot.summary) + newUsage.inputTokens,
+          outputTokens: newUsage.outputTokens,
+        }
+      }
+      return estimateUsageTokensFromMessages(messages)
     }
-    state.inputTokens = inputTokens
-    state.outputTokens = outputTokens
+    const usage = estimateSnapshotUsage(storedMessages)
+    const contextUsage = options.truncateToolResultsForContext
+      ? estimateSnapshotUsage(storedMessages.map(message => message.role === 'tool'
+        ? { ...message, content: truncateToolResultForContext(message.content || '') }
+        : message))
+      : undefined
+    state.inputTokens = usage.inputTokens
+    state.outputTokens = usage.outputTokens
     emit('usage.updated', {
       event: 'usage.updated',
       session_id: sid,
-      inputTokens,
-      outputTokens,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
     })
-    return { inputTokens, outputTokens }
+    return {
+      ...usage,
+      ...(contextUsage
+        ? {
+            contextInputTokens: contextUsage.inputTokens,
+            contextOutputTokens: contextUsage.outputTokens,
+          }
+        : {}),
+    }
   } catch (err: any) {
     logger.warn(err, '[chat-run-socket] failed to calculate usage for session %s', sid)
     return { inputTokens: 0, outputTokens: 0 }

--- a/tests/server/run-chat-compression.test.ts
+++ b/tests/server/run-chat-compression.test.ts
@@ -176,6 +176,84 @@ describe('run chat compression trigger', () => {
     ])
   })
 
+  it('projects complete persisted tool results into a 5500-character bridge history', async () => {
+    const completeToolResult = `HEAD-${'x'.repeat(7_000)}-TAIL`
+    const detail = {
+      messages: [
+        {
+          id: 1,
+          session_id: 'session-1',
+          role: 'tool',
+          content: completeToolResult,
+          tool_call_id: 'tool-call-1',
+          tool_name: 'session_get',
+          timestamp: 1,
+        },
+      ],
+    }
+    getSessionDetailMock.mockReturnValue(detail)
+
+    const { buildDbHistory } = await import('../../packages/server/src/services/hermes/run-chat/compression')
+    const history = await buildDbHistory('session-1')
+    const projected = String(history[0]?.content || '')
+
+    expect(projected).toHaveLength(5_500)
+    expect(projected).toContain('... [truncated]')
+    expect(projected).toMatch(/^HEAD-/)
+    expect(projected).toMatch(/-TAIL$/)
+    expect(detail.messages[0].content).toBe(completeToolResult)
+  })
+
+  it('uses the 5500-character bridge history for context tokens instead of complete DB usage', async () => {
+    const completeToolResult = `HEAD-${'x'.repeat(70_000)}-TAIL`
+    getSessionDetailMock.mockReturnValue({
+      messages: [
+        {
+          id: 1,
+          session_id: 'session-1',
+          role: 'tool',
+          content: completeToolResult,
+          tool_call_id: 'tool-call-1',
+          tool_name: 'session_get',
+          timestamp: 1,
+        },
+      ],
+    })
+    calcAndUpdateUsageMock.mockResolvedValue({
+      inputTokens: 0,
+      outputTokens: 500_000,
+      contextInputTokens: 0,
+      contextOutputTokens: 5_500,
+    })
+    estimateUsageTokensFromMessagesMock.mockImplementation((messages: any[]) => ({
+      inputTokens: 0,
+      outputTokens: messages.reduce((sum, message) => sum + String(message.content || '').length, 0),
+    }))
+    const contextTokenEstimator = vi.fn(async (_messages: any[], messageTokens: number) => messageTokens)
+
+    const { buildCompressedHistory } = await import('../../packages/server/src/services/hermes/run-chat/compression')
+    const history = await buildCompressedHistory(
+      'session-1',
+      'default',
+      'http://upstream',
+      undefined,
+      vi.fn(),
+      new Map(),
+      {},
+      contextTokenEstimator,
+    )
+
+    expect(String(history[0]?.content || '')).toHaveLength(5_500)
+    expect(calcAndUpdateUsageMock).toHaveBeenCalledWith(
+      'session-1',
+      expect.any(Object),
+      expect.any(Function),
+      { truncateToolResultsForContext: true },
+    )
+    expect(contextTokenEstimator).toHaveBeenCalledWith(expect.any(Array), 5_500)
+    expect(compressorCompressMock).not.toHaveBeenCalled()
+  })
+
   it('does not compress long low-token history just because it has more than 150 messages', async () => {
     const messages = Array.from({ length: 152 }, (_, index) => ({
       id: index + 1,

--- a/tests/server/run-chat-tool-result-context.test.ts
+++ b/tests/server/run-chat-tool-result-context.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const addMessageMock = vi.fn()
+const getSessionDetailMock = vi.fn()
+
+vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
+  addMessage: addMessageMock,
+  getSessionDetail: getSessionDetailMock,
+}))
+
+vi.mock('../../packages/server/src/db/hermes/compression-snapshot', () => ({
+  getCompressionSnapshot: vi.fn(() => null),
+}))
+
+vi.mock('../../packages/server/src/services/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+describe('Bridge tool result context projection', () => {
+  beforeEach(() => {
+    addMessageMock.mockReset()
+    getSessionDetailMock.mockReset()
+  })
+
+  it('keeps the complete result in memory and persistence while context is bounded', async () => {
+    const completeToolResult = `HEAD-${'x'.repeat(70_000)}-TAIL`
+    const state: any = {
+      messages: [],
+      bridgePendingTools: [{
+        id: 'tool-call-1',
+        name: 'session_get',
+        arguments: '{}',
+        startedAt: Date.now(),
+      }],
+    }
+    const { recordBridgeToolCompleted } = await import(
+      '../../packages/server/src/services/hermes/run-chat/bridge-message'
+    )
+    const { truncateToolResultForContext } = await import(
+      '../../packages/server/src/lib/tool-result-context'
+    )
+
+    const completed = recordBridgeToolCompleted(
+      state,
+      'session-1',
+      'run-1',
+      'session_get',
+      { tool_call_id: 'tool-call-1', result: completeToolResult },
+    )
+
+    expect(completed.output).toBe(completeToolResult)
+    expect(state.messages[0].content).toBe(completeToolResult)
+    expect(addMessageMock).toHaveBeenCalledWith(expect.objectContaining({
+      role: 'tool',
+      content: completeToolResult,
+    }))
+    expect(truncateToolResultForContext(completeToolResult)).toHaveLength(5_500)
+  })
+
+  it('bounds Bridge context tokens without changing the default Coding Agent estimate', async () => {
+    const completeToolResult = `HEAD-${'x'.repeat(70_000)}-TAIL`
+    getSessionDetailMock.mockReturnValue({
+      messages: [{ role: 'tool', content: completeToolResult }],
+    })
+    const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
+    const { truncateToolResultForContext } = await import(
+      '../../packages/server/src/lib/tool-result-context'
+    )
+    const { calcAndUpdateUsage } = await import(
+      '../../packages/server/src/services/hermes/run-chat/usage'
+    )
+    const makeState = () => ({ messages: [], isWorking: false, events: [], queue: [] }) as any
+
+    const bridgeUsage = await calcAndUpdateUsage(
+      'session-1',
+      makeState(),
+      vi.fn(),
+      { truncateToolResultsForContext: true },
+    )
+    const defaultUsage = await calcAndUpdateUsage('session-1', makeState(), vi.fn())
+
+    expect(bridgeUsage.outputTokens).toBe(countTokens(completeToolResult))
+    expect(bridgeUsage.contextOutputTokens).toBe(countTokens(truncateToolResultForContext(completeToolResult)))
+    expect(defaultUsage.outputTokens).toBe(countTokens(completeToolResult))
+    expect(defaultUsage.contextOutputTokens).toBeUndefined()
+    expect(bridgeUsage.outputTokens).toBeGreaterThan(bridgeUsage.contextOutputTokens || 0)
+  })
+})


### PR DESCRIPTION
## Summary

- keep complete Hermes Bridge tool results in session memory and SQLite persistence
- project tool results to a strict 5,500-character head/tail representation when building model history
- use the same projection for Bridge context-token estimates while leaving cumulative input/output usage unchanged
- reuse the projection in context summarization and preserve the existing Coding Agent storage guard

## Why

Bridge `tool.completed` events prefer the complete `result` over `result_preview`, and the raw result was reused directly from the database when rebuilding model history. Large logs, API responses, or nested session reads could therefore dominate context and recursively amplify subsequent tool results.

The database remains lossless for history and inspection, while the content sent back to the model and the context estimate now share one bounded representation.

Fixes #2028.

## User impact

Large Bridge tool results remain visible and retrievable in full from persisted session history, but each contributes at most 5,500 characters to future model context. Coding Agent persistence behavior and the Usage analytics page are unchanged.

## Validation

- focused Bridge/Coding Agent regression suite: 82/82 passed
- `npm run test`: 2,238 passed, 2 skipped
- `npm run test:e2e -- --workers=1`: 30/30 passed
- `npm run harness:check`
- `npm run build`
- `git diff --check`

## Local coverage note

`npm run test:coverage` completed the test assertions but report generation is blocked by an existing stale Desktop release sourcemap reference to a missing `dist/server/index.js.map`.