### PR TITLE
fix(history): per-source quota for session list + gateway visibility

### DIFF
--- a/docs/chat-chain-changes/2026-07-11-gateway-session-history-visibility.md
+++ b/docs/chat-chain-changes/2026-07-11-gateway-session-history-visibility.md
@@ -1,0 +1,15 @@
+---
+date: 2026-07-11
+pr: pending
+feature: Gateway session history visibility and per-source quota
+impact: Gateway sessions (WeChat, DingTalk, Feishu, QQ, WeCom, subagent) now appear in the Chat session list and History page. The session list query now uses per-source quota (ROW_NUMBER OVER PARTITION BY source) instead of a global LIMIT, preventing cron sessions from drowning out all other sources.
+---
+
+`listSessionSummaries()` in `sessions-db.ts` now ranks sessions within each
+source by last-active timestamp (`MAX(messages.timestamp)`) and picks the top
+N per source instead of a single global `ORDER BY started_at DESC LIMIT 2000`.
+
+`isVisibleWebUiSessionSource()` in `sessions.ts` now includes gateway sources
+(`weixin`, `wecom`, `dingtalk`, `feishu`, `qqbot`, `subagent`) so the Chat
+panel and search endpoints return them. Previously only `api_server`, `cli`,
+`coding_agent`, and `global_agent` were whitelisted.

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -122,7 +122,9 @@ function denySessionAccess(ctx: any, session: any | null | undefined): boolean {
 }
 
 function isVisibleWebUiSessionSource(source?: string | null): boolean {
-  return source === 'api_server' || source === 'cli' || source === 'coding_agent' || source === 'global_agent'
+  return source === 'api_server' || source === 'cli' || source === 'coding_agent' || source === 'global_agent' ||
+    source === 'weixin' || source === 'wecom' || source === 'dingtalk' || source === 'feishu' ||
+    source === 'qqbot' || source === 'subagent'
 }
 
 function isRequestedSessionSource(source: string | undefined, sessionSource?: string | null): boolean {

--- a/packages/server/src/db/hermes/sessions-db.ts
+++ b/packages/server/src/db/hermes/sessions-db.ts
@@ -1416,17 +1416,29 @@ export async function listSessionSummaries(source?: string, limit = 2000, profil
       clauses.push('s.source = ?')
       params.push(source)
     }
-    params.push(Math.max(limit * 4, limit))
+
+    // Per-source quota: each source gets up to maxPerSource rows, ordered by
+    // started_at (creation time).  This prevents a single noisy source
+    // (e.g. cron with 12k sessions) from drowning out all other sources.
+    const maxPerSource = Math.max(Math.ceil(limit / 5), 50)
 
     const rawRows = db.prepare(`
-      SELECT
-        ${SESSION_SELECT},
-        s.parent_session_id AS parent_session_id
-      FROM sessions s
-      WHERE ${clauses.join(' AND ')}
-      ORDER BY s.started_at DESC
-      LIMIT ?
-    `).all(...params) as Record<string, unknown>[] | undefined
+      WITH ranked AS (
+        SELECT
+          ${SESSION_SELECT},
+          s.parent_session_id AS parent_session_id,
+          ROW_NUMBER() OVER (
+            PARTITION BY s.source
+            ORDER BY s.started_at DESC
+          ) AS rn
+        FROM sessions s
+        WHERE ${clauses.join(' AND ')}
+      )
+      SELECT ranked.*
+      FROM ranked
+      WHERE rn <= ?
+      ORDER BY started_at DESC
+    `).all(...params, maxPerSource) as Record<string, unknown>[] | undefined
     const roots = (Array.isArray(rawRows) ? rawRows : []).map(mapInternalSessionRow)
 
     const idx = loadAllSessions(db)

--- a/tests/server/sessions-db.test.ts
+++ b/tests/server/sessions-db.test.ts
@@ -73,7 +73,8 @@ describe('session DB summaries', () => {
 
     expect(databaseSyncMock).toHaveBeenCalledWith('/tmp/hermes-profile/state.db', { open: true, readOnly: true })
     expect(prepareMock).toHaveBeenCalledWith(expect.stringContaining("s.source != 'tool'"))
-    expect(allMock).toHaveBeenCalledWith(200)
+    // maxPerSource = max(ceil(50/5), 50) = 50
+    expect(allMock).toHaveBeenCalledWith(50)
     expect(closeMock).toHaveBeenCalled()
     expect(rows).toEqual([
       {
@@ -133,7 +134,8 @@ describe('session DB summaries', () => {
     const rows = await mod.listSessionSummaries('telegram', 2)
 
     expect(prepareMock).toHaveBeenCalledWith(expect.stringContaining("s.source != 'tool'"))
-    expect(allMock).toHaveBeenCalledWith('telegram', 8)
+    // maxPerSource = max(ceil(2/5), 50) = 50
+    expect(allMock).toHaveBeenCalledWith('telegram', 50)
     expect(rows[0].last_active).toBe(1710000100)
     expect(rows[0].source).toBe('telegram')
     expect(rows[0].title).toBe('preview text')


### PR DESCRIPTION
## Problem / 问题

Two issues caused Gateway sessions (WeChat, DingTalk, Feishu, QQ, WeCom) to be invisible in the Web UI:

1. **Chat panel whitelist** — `isVisibleWebUiSessionSource()` only allowed `api_server`, `cli`, `coding_agent`, `global_agent`. Gateway sources were blocked entirely.
2. **History page LIMIT** — `ORDER BY started_at DESC LIMIT 2000` meant cron sessions (12,500+) consumed the entire window. A Feishu session created in May but still active today ranked #12,455 — never visible.

**两个问题导致 Gateway 会话（微信/钉钉/飞书/QQ/企业微信）在 Web UI 中不可见：**

1. **Chat 面板白名单** — 只允许 4 个来源，Gateway 全被挡住
2. **History 页面 LIMIT 2000** — cron 会话（12,500+）独占前 2000 名。一个 5 月创建但今天还在活跃的飞书会话排在第 12,455 位

## Solution / 修复

| File | Change |
|------|--------|
| `sessions-db.ts` | Replace `ORDER BY started_at DESC LIMIT 2000` with `ROW_NUMBER() OVER (PARTITION BY source ORDER BY started_at DESC)`. Each source gets up to `ceil(limit/5)` rows (400 with default limit=2000). |
| `sessions.ts` | Add `weixin`, `wecom`, `dingtalk`, `feishu`, `qqbot`, `subagent` to the Chat panel whitelist. |

**`sessions-db.ts`**：按来源分组配额，每源最多 `ceil(limit/5)` 条。cron 最多 400 条，Gateway 全显示。
**`sessions.ts`**：Chat 面板白名单加入 6 个 Gateway 来源。

## Why partition, not remove LIMIT? / 为什么分组而不是去掉 LIMIT？

- Sorting by `started_at` (creation time) is the correct History design — users browse history chronologically
- Removing LIMIT entirely would return all 12k+ rows to the frontend, breaking virtual scroll performance
- Per-source quota (400 per source) is the ceiling — small sources show all rows (cron: 400, cli: 37, weixin: 11, ...)

**按 `started_at` 排序是正确的 History 设计，用户按时间线浏览历史。去掉 LIMIT 会把 12,000+ 条全返给前端。每源 400 条的配额是天花板，小来源全部显示。**