### PR TITLE
[codex] fix MiMo voice clone audio upload

### DIFF
--- a/packages/client/src/components/hermes/settings/VoiceSettings.vue
+++ b/packages/client/src/components/hermes/settings/VoiceSettings.vue
@@ -6,6 +6,7 @@ import { useSpeech, type MimoTtsOptions, type OpenaiTtsOptions } from '@/composa
 import { useMicRecorder } from '@/composables/useMicRecorder'
 import { transcribeSpeech } from '@/api/hermes/stt'
 import { useVoiceApiConnections } from '@/composables/useVoiceApiConnections'
+import { useVoiceSettings } from '@/composables/useVoiceSettings'
 import { speedToEdgeRate, hzToEdgePitch } from '@/utils/ttsHelpers'
 import VoiceApiCard, { type VoiceApiCardTestState } from './voice/VoiceApiCard.vue'
 import VoiceApiFormModal from './voice/VoiceApiFormModal.vue'
@@ -23,6 +24,7 @@ const { t } = useI18n()
 const message = useMessage()
 const speech = useSpeech()
 const voiceApi = useVoiceApiConnections()
+const voiceSettings = useVoiceSettings()
 
 const testText = ref(t('settings.voice.testTextDefault'))
 const showAddModal = ref(false)
@@ -151,8 +153,12 @@ function mimoOptionsFor(connection: VoiceApiConnection): MimoTtsOptions {
     authMode: options.authMode === 'api-key' || options.authMode === 'bearer' || options.authMode === 'both' ? options.authMode : undefined,
     voiceMode: options.voiceMode === 'preset' || options.voiceMode === 'voiceDesign' || options.voiceMode === 'voiceClone' ? options.voiceMode : undefined,
     voiceDesignDesc: typeof options.voiceDesignDesc === 'string' ? options.voiceDesignDesc : undefined,
-    voiceCloneDataUri: typeof options.voiceCloneDataUri === 'string' ? options.voiceCloneDataUri : undefined,
-    voiceCloneFormat: options.voiceCloneFormat === 'mp3' || options.voiceCloneFormat === 'wav' ? options.voiceCloneFormat : undefined,
+    voiceCloneDataUri: typeof options.voiceCloneDataUri === 'string'
+      ? options.voiceCloneDataUri
+      : voiceSettings.mimoVoiceCloneDataUri.value || undefined,
+    voiceCloneFormat: options.voiceCloneFormat === 'mp3' || options.voiceCloneFormat === 'wav'
+      ? options.voiceCloneFormat
+      : voiceSettings.mimoVoiceCloneFormat.value,
     stylePrompt: typeof options.stylePrompt === 'string' ? options.stylePrompt : undefined,
   }
 }

--- a/packages/client/src/components/hermes/settings/voice/VoiceApiConfigurator.vue
+++ b/packages/client/src/components/hermes/settings/voice/VoiceApiConfigurator.vue
@@ -6,6 +6,7 @@ import type { VoiceApiConnection, VoiceApiSavePayload } from '@/types/voice-api'
 import { VOICE_API_PRESETS } from '@/constants/voiceApiPresets'
 import { DOUBAO_TTS_2_RESOURCE_ID, DOUBAO_TTS_VOICE_OPTIONS, doubaoTtsResourceForVoice } from '@/constants/doubaoTtsVoices'
 import { speedToEdgeRate, hzToEdgePitch } from '@/utils/ttsHelpers'
+import { useVoiceSettings } from '@/composables/useVoiceSettings'
 
 const props = defineProps<{
   connection: VoiceApiConnection | null
@@ -18,10 +19,17 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const voiceSettings = useVoiceSettings()
 
 const loading = ref(false)
 const formData = ref<Record<string, string | number | undefined>>({})
 const apiKeyInput = ref('')
+const mimoCloneAudioInput = ref<HTMLInputElement | null>(null)
+const mimoCloneDataUri = ref('')
+const mimoCloneFileName = ref('')
+const mimoCloneFormat = ref<'mp3' | 'wav'>('wav')
+const MIMO_CLONE_AUDIO_MAX_BYTES = 10 * 1024 * 1024
+const MIMO_CLONE_AUDIO_ACCEPT = 'audio/mpeg,audio/mp3,audio/wav,.mp3,.wav'
 
 const preset = computed(() =>
   props.connection ? VOICE_API_PRESETS.find(p => p.kind === props.connection!.kind && p.provider === props.connection!.provider && (p.baseUrl === props.connection!.baseUrl || !p.baseUrl)) : null
@@ -60,8 +68,63 @@ watch(() => props.connection, (conn) => {
       formData.value.pitch = numberField('pitch', 0)
     }
     apiKeyInput.value = ''
+    if (conn.provider === 'mimo') {
+      mimoCloneDataUri.value = voiceSettings.mimoVoiceCloneDataUri.value
+      mimoCloneFileName.value = voiceSettings.mimoVoiceCloneFileName.value
+      mimoCloneFormat.value = voiceSettings.mimoVoiceCloneFormat.value
+    }
   }
 }, { immediate: true })
+
+function inferCloneAudioFormat(file: File): 'mp3' | 'wav' {
+  const name = file.name.toLowerCase()
+  return file.type.includes('mpeg') || file.type.includes('mp3') || name.endsWith('.mp3') ? 'mp3' : 'wav'
+}
+
+function readFileAsDataUri(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result || ''))
+    reader.onerror = () => reject(reader.error || new Error('Failed to read audio file'))
+    reader.readAsDataURL(file)
+  })
+}
+
+async function handleMimoCloneAudioChange(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+
+  const lowerName = file.name.toLowerCase()
+  const validType = file.type === 'audio/wav'
+    || file.type === 'audio/x-wav'
+    || file.type === 'audio/mpeg'
+    || file.type === 'audio/mp3'
+    || lowerName.endsWith('.wav')
+    || lowerName.endsWith('.mp3')
+  if (!validType || file.size > MIMO_CLONE_AUDIO_MAX_BYTES) {
+    input.value = ''
+    return
+  }
+
+  try {
+    const format = inferCloneAudioFormat(file)
+    const dataUri = await readFileAsDataUri(file)
+    const mimeType = format === 'mp3' ? 'audio/mpeg' : 'audio/wav'
+    mimoCloneDataUri.value = dataUri.replace(/^data:[^;,]*;base64,/, `data:${mimeType};base64,`)
+    mimoCloneFileName.value = file.name
+    mimoCloneFormat.value = format
+  } finally {
+    input.value = ''
+  }
+}
+
+function clearMimoCloneAudio() {
+  mimoCloneDataUri.value = ''
+  mimoCloneFileName.value = ''
+  mimoCloneFormat.value = 'wav'
+  if (mimoCloneAudioInput.value) mimoCloneAudioInput.value.value = ''
+}
 
 async function handleSave() {
   if (!props.connection) return
@@ -69,8 +132,22 @@ async function handleSave() {
   loading.value = true
   try {
     const apiKey = apiKeyInput.value.trim()
+    const settings: Record<string, unknown> = { ...formData.value }
+    if (props.connection.provider === 'mimo') {
+      const model = stringField('model')
+      settings.voiceMode = model === 'mimo-v2.5-tts-voiceclone'
+        ? 'voiceClone'
+        : model === 'mimo-v2.5-tts-voicedesign' ? 'voiceDesign' : 'preset'
+      if (model === 'mimo-v2.5-tts-voiceclone') {
+        // These fields are consumed client-side by useVoiceApiConnections and
+        // deliberately omitted from the server's small settings payload.
+        settings.voiceCloneDataUri = mimoCloneDataUri.value
+        settings.voiceCloneFileName = mimoCloneFileName.value
+        settings.voiceCloneFormat = mimoCloneFormat.value
+      }
+    }
     emit('save', props.connection, {
-      settings: { ...formData.value },
+      settings,
       ...(apiKey ? { secrets: { apiKey } } : {}),
     })
   } finally {
@@ -243,6 +320,29 @@ function handleDoubaoVoiceUpdate(value: string) {
           </NFormItem>
           <NFormItem :label="t('settings.voice.mimoVoiceDesignPrompt')" v-if="stringField('model') === 'mimo-v2.5-tts-voicedesign'">
             <NInput :value="stringField('voiceDesignDesc')" type="textarea" :rows="3" @update:value="value => setField('voiceDesignDesc', value)" />
+          </NFormItem>
+          <NFormItem :label="t('settings.voice.mimoCloneAudio')" v-if="stringField('model') === 'mimo-v2.5-tts-voiceclone'">
+            <NSpace vertical style="width: 100%">
+              <input
+                ref="mimoCloneAudioInput"
+                type="file"
+                :accept="MIMO_CLONE_AUDIO_ACCEPT"
+                style="display: none"
+                @change="handleMimoCloneAudioChange"
+              />
+              <NSpace align="center">
+                <NButton size="small" @click="mimoCloneAudioInput?.click()">
+                  {{ t('settings.voice.mimoCloneAudioUpload') }}
+                </NButton>
+                <span v-if="mimoCloneFileName" style="font-size: 12px; opacity: 0.7">
+                  {{ mimoCloneFileName }} · {{ mimoCloneFormat }}
+                </span>
+                <NButton v-if="mimoCloneDataUri" size="small" tertiary @click="clearMimoCloneAudio">
+                  {{ t('settings.voice.mimoCloneAudioClear') }}
+                </NButton>
+              </NSpace>
+              <span style="font-size: 12px; opacity: 0.6">{{ t('settings.voice.mimoCloneAudioHint') }}</span>
+            </NSpace>
           </NFormItem>
         </template>
 

--- a/packages/client/src/composables/useVoiceApiConnections.ts
+++ b/packages/client/src/composables/useVoiceApiConnections.ts
@@ -96,6 +96,8 @@ export function useVoiceApiConnections() {
       vs.setMimoVoice(connection.voice || stringSetting(settings, 'voice') || vs.mimoVoice.value)
       vs.setMimoStylePrompt(stringSetting(settings, 'stylePrompt'))
       vs.setMimoVoiceDesignDesc(stringSetting(settings, 'voiceDesignDesc'))
+      const cloneFormat = stringSetting(settings, 'voiceCloneFormat')
+      if (cloneFormat === 'mp3' || cloneFormat === 'wav') vs.setMimoVoiceCloneFormat(cloneFormat)
       return
     }
 
@@ -255,13 +257,24 @@ export function useVoiceApiConnections() {
   async function saveConnection(kind: VoiceApiKind, provider: VoiceApiProvider, payload: VoiceApiSavePayload) {
     if (kind === 'tts') {
       if (!isStoredTtsProvider(provider)) throw new Error(`Unsupported TTS provider: ${String(provider)}`)
+      const settings = { ...(payload.settings || {}) }
+      const hasCloneDataUri = Object.prototype.hasOwnProperty.call(settings, 'voiceCloneDataUri')
+      const hasCloneFileName = Object.prototype.hasOwnProperty.call(settings, 'voiceCloneFileName')
+      const cloneDataUri = settings.voiceCloneDataUri
+      const cloneFileName = settings.voiceCloneFileName
+      delete settings.voiceCloneDataUri
+      delete settings.voiceCloneFileName
       const res = await saveTtsSettings(provider, {
-        settings: payload.settings as TtsStoredSettings | undefined,
+        settings: settings as TtsStoredSettings,
         secrets: payload.secrets as TtsStoredSecretsInput | undefined,
         activeProvider: provider,
       })
       await refresh()
       await setActiveConnection('tts', `tts-${provider}`)
+      if (provider === 'mimo') {
+        if (hasCloneDataUri && typeof cloneDataUri === 'string') vs.setMimoVoiceCloneDataUri(cloneDataUri)
+        if (hasCloneFileName && typeof cloneFileName === 'string') vs.setMimoVoiceCloneFileName(cloneFileName)
+      }
       return res
     }
 

--- a/packages/server/src/services/hermes/tts-providers/mimo.ts
+++ b/packages/server/src/services/hermes/tts-providers/mimo.ts
@@ -74,16 +74,7 @@ function buildMessages(text: string, opts: MimoTtsProviderOptions) {
     return [
       {
         role: 'user',
-        content: [
-          { type: 'text', text: opts.stylePrompt || '' },
-          {
-            type: 'input_audio',
-            input_audio: {
-              data: opts.voiceCloneDataUri,
-              format: opts.voiceCloneFormat || 'wav',
-            },
-          },
-        ],
+        content: opts.stylePrompt || '',
       },
       {
         role: 'assistant',
@@ -116,6 +107,8 @@ function buildAudio(opts: MimoTtsProviderOptions): Record<string, string> {
 
   if (mode === 'preset' && opts.voice) {
     audio.voice = opts.voice
+  } else if (mode === 'voiceClone' && opts.voiceCloneDataUri) {
+    audio.voice = opts.voiceCloneDataUri
   }
 
   return audio

--- a/tests/client/use-voice-api-connections-mimo.test.ts
+++ b/tests/client/use-voice-api-connections-mimo.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ttsApiMock = vi.hoisted(() => ({
+  deleteTtsProvider: vi.fn(),
+  fetchTtsSettings: vi.fn(),
+  saveActiveTtsProvider: vi.fn(),
+  saveTtsSettings: vi.fn(),
+}))
+
+const sttApiMock = vi.hoisted(() => ({
+  deleteSttProvider: vi.fn(),
+  fetchSttSettings: vi.fn(),
+  saveActiveSttProvider: vi.fn(),
+  saveSttSettings: vi.fn(),
+}))
+
+const voiceSettingsMock = vi.hoisted(() => {
+  const state = {
+    provider: { value: 'mimo' },
+    edgeVoice: { value: 'zh-CN-XiaoxiaoNeural' },
+    edgeRate: { value: 1 },
+    edgePitchHz: { value: 0 },
+    mimoBaseUrl: { value: 'https://api.xiaomimimo.com/v1' },
+    mimoModel: { value: 'mimo-v2.5-tts' },
+    mimoVoice: { value: '冰糖' },
+    mimoVoiceCloneDataUri: { value: '' },
+    mimoVoiceCloneFileName: { value: '' },
+    mimoVoiceCloneFormat: { value: 'wav' },
+  }
+  return {
+    ...state,
+    setProvider: vi.fn((value: string) => { state.provider.value = value }),
+    setMimoBaseUrl: vi.fn(),
+    setMimoModel: vi.fn(),
+    setMimoVoice: vi.fn(),
+    setMimoStylePrompt: vi.fn(),
+    setMimoVoiceDesignDesc: vi.fn(),
+    setMimoVoiceCloneDataUri: vi.fn((value: string) => { state.mimoVoiceCloneDataUri.value = value }),
+    setMimoVoiceCloneFileName: vi.fn((value: string) => { state.mimoVoiceCloneFileName.value = value }),
+    setMimoVoiceCloneFormat: vi.fn((value: string) => { state.mimoVoiceCloneFormat.value = value }),
+  }
+})
+
+vi.mock('@/api/hermes/tts-settings', () => ttsApiMock)
+vi.mock('@/api/hermes/stt-settings', () => sttApiMock)
+vi.mock('@/composables/useVoiceSettings', () => ({ useVoiceSettings: () => voiceSettingsMock }))
+vi.mock('@/composables/useSttSettings', () => ({
+  useSttSettings: () => ({
+    provider: { value: 'browser' },
+    loadServerSttSettings: vi.fn(),
+    setProvider: vi.fn(),
+  }),
+}))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+
+import { useVoiceApiConnections } from '@/composables/useVoiceApiConnections'
+
+describe('useVoiceApiConnections MiMo voice clone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    voiceSettingsMock.mimoVoiceCloneDataUri.value = ''
+    voiceSettingsMock.mimoVoiceCloneFileName.value = ''
+    voiceSettingsMock.mimoVoiceCloneFormat.value = 'wav'
+    ttsApiMock.saveTtsSettings.mockResolvedValue({})
+    ttsApiMock.saveActiveTtsProvider.mockResolvedValue('mimo')
+    ttsApiMock.fetchTtsSettings.mockResolvedValue({
+      activeProvider: 'mimo',
+      providers: [{
+        provider: 'mimo',
+        settings: {
+          model: 'mimo-v2.5-tts-voiceclone',
+          voiceMode: 'voiceClone',
+          voiceCloneFormat: 'mp3',
+        },
+        secrets: { apiKey: '[stored]' },
+        updatedAt: 1,
+      }],
+    })
+    sttApiMock.fetchSttSettings.mockResolvedValue({ activeProvider: 'browser', providers: [] })
+  })
+
+  it('keeps clone audio client-side while saving the remaining settings', async () => {
+    const connections = useVoiceApiConnections()
+    const dataUri = 'data:audio/mp3;base64,ZmFrZQ=='
+
+    await connections.saveConnection('tts', 'mimo', {
+      settings: {
+        model: 'mimo-v2.5-tts-voiceclone',
+        voiceMode: 'voiceClone',
+        voiceCloneFormat: 'mp3',
+        voiceCloneDataUri: dataUri,
+        voiceCloneFileName: 'sample.mp3',
+      },
+    })
+
+    expect(ttsApiMock.saveTtsSettings).toHaveBeenCalledWith('mimo', {
+      settings: {
+        model: 'mimo-v2.5-tts-voiceclone',
+        voiceMode: 'voiceClone',
+        voiceCloneFormat: 'mp3',
+      },
+      secrets: undefined,
+      activeProvider: 'mimo',
+    })
+    expect(voiceSettingsMock.setMimoVoiceCloneDataUri).toHaveBeenCalledWith(dataUri)
+    expect(voiceSettingsMock.setMimoVoiceCloneFileName).toHaveBeenCalledWith('sample.mp3')
+    expect(voiceSettingsMock.setMimoVoiceCloneFormat).toHaveBeenCalledWith('mp3')
+  })
+})

--- a/tests/server/mimo-tts-provider.test.ts
+++ b/tests/server/mimo-tts-provider.test.ts
@@ -237,7 +237,7 @@ describe('mimoTtsProvider', () => {
     expect(body.messages[1]).toEqual({ role: 'assistant', content: 'Narrate this' })
   })
 
-  it('voiceClone model infers voiceClone mode and includes input_audio payload without audio.voice', async () => {
+  it('voiceClone model infers voiceClone mode and sends the reference audio as audio.voice', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({
       choices: [{ message: { audio: { data: Buffer.from('ok').toString('base64') } } }],
     }))
@@ -255,20 +255,14 @@ describe('mimoTtsProvider', () => {
     )
 
     const body = getJsonBody()
-    expect(body.audio).toEqual({ format: 'wav' })
+    expect(body.audio).toEqual({
+      format: 'wav',
+      voice: 'data:audio/wav;base64,ZmFrZQ==',
+    })
     expect(body.messages).toEqual([
       {
         role: 'user',
-        content: [
-          { type: 'text', text: 'Match the cadence of the reference audio.' },
-          {
-            type: 'input_audio',
-            input_audio: {
-              data: 'data:audio/wav;base64,ZmFrZQ==',
-              format: 'mp3',
-            },
-          },
-        ],
+        content: 'Match the cadence of the reference audio.',
       },
       {
         role: 'assistant',
@@ -346,20 +340,14 @@ describe('mimoTtsProvider', () => {
     )
 
     const body = getJsonBody()
-    expect(body.audio).toEqual({ format: 'wav' })
+    expect(body.audio).toEqual({
+      format: 'wav',
+      voice: 'data:audio/wav;base64,ZmFrZQ==',
+    })
     expect(body.messages).toEqual([
       {
         role: 'user',
-        content: [
-          { type: 'text', text: 'Match the cadence of the reference audio.' },
-          {
-            type: 'input_audio',
-            input_audio: {
-              data: 'data:audio/wav;base64,ZmFrZQ==',
-              format: 'wav',
-            },
-          },
-        ],
+        content: 'Match the cadence of the reference audio.',
       },
       {
         role: 'assistant',


### PR DESCRIPTION
## Summary
- restore the WAV/MP3 reference-audio picker for MiMo voice-clone connections
- keep the large Base64 payload in client voice state while persisting only small TTS settings
- send the reference Data URI through MiMo's required `audio.voice` field
- add client and server regression coverage

## Root cause
The voice-provider card migration omitted the former MiMo clone-audio input. The provider implementation also used an `input_audio` message payload, while the current MiMo V2.5 API requires the reference Data URI in `audio.voice`.

## Impact
Users can select a reference WAV or MP3 file up to 10 MB, save the voice-clone configuration, and synthesize or test cloned speech successfully.

Closes #2041

## Validation
- `npm run test -- tests/server/mimo-tts-provider.test.ts tests/client/use-speech-tts.test.ts tests/client/use-voice-api-connections-mimo.test.ts tests/client/use-voice-settings-mimo.test.ts`
- `npm run test:e2e` (30 passed)
- `npm run build`
- `npm run harness:check`

## Known limitation
MiMo's voice-clone API is stateless, so the reference audio is included with every synthesis request.
