### PR TITLE
fix: preserve custom provider state in Studio bridge

### DIFF
--- a/docs/chat-chain-changes/2026-07-12-studio-custom-provider-alias.md
+++ b/docs/chat-chain-changes/2026-07-12-studio-custom-provider-alias.md
@@ -1,0 +1,23 @@
+---
+date: 2026-07-12
+pr: TBD
+commit: 155526af
+feature: Studio custom-provider model selection
+impact: Prevents a custom provider alias from triggering a redundant client rebuild that drops configured default headers and causes WAF 403 responses.
+---
+
+# Studio custom-provider alias client rebuild
+
+Hermes Studio sends the visible provider selector (for example `custom:liuzheng`) on chat runs, while Hermes Agent normalizes the active runtime provider to `custom`.
+
+The bridge previously stored only the normalized provider in the session. On the next request, `custom:liuzheng != custom` was treated as a runtime change, so the bridge called `AIAgent.switch_model()` even when the model, endpoint, and transport were unchanged.
+
+Affected Hermes runtimes reconstruct `_client_kwargs` during `switch_model()` without reapplying `model.default_headers`. The subsequent request therefore reverted to the OpenAI SDK User-Agent and could be rejected by WAF-sensitive custom endpoints.
+
+The bridge now:
+
+- preserves the requested provider selector in session metadata;
+- compares the resolved runtime model/provider/base URL/API mode before rebuilding;
+- skips `switch_model()` when the effective runtime is unchanged.
+
+A regression test covers the `custom:liuzheng` → normalized `custom` alias case.

--- a/docs/chat-chain-changes/2026-07-12-studio-custom-provider-alias.md
+++ b/docs/chat-chain-changes/2026-07-12-studio-custom-provider-alias.md
@@ -1,7 +1,7 @@
 ---
 date: 2026-07-12
 pr: TBD
-commit: 155526af
+commit: 7d0740d0
 feature: Studio custom-provider model selection
 impact: Prevents a custom provider alias from triggering a redundant client rebuild that drops configured default headers and causes WAF 403 responses.
 ---

--- a/docs/chat-chain-changes/2026-07-12-studio-custom-provider-alias.md
+++ b/docs/chat-chain-changes/2026-07-12-studio-custom-provider-alias.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-07-12
-pr: TBD
+pr: 2054
 commit: 7d0740d0
 feature: Studio custom-provider model selection
 impact: Prevents a custom provider alias from triggering a redundant client rebuild that drops configured default headers and causes WAF 403 responses.

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -297,7 +297,11 @@ class AgentPool:
                         "requested_session_id": session_id,
                         "profile": profile or "default",
                         "model": resolved_model,
-                        "provider": runtime.get("provider"),
+                        # Keep the user-facing provider selector (for example
+                        # custom:liuzheng) separate from the normalized runtime
+                        # provider (custom). Otherwise the next request sees a
+                        # false provider change and rebuilds the client.
+                        "provider": requested_provider or runtime.get("provider"),
                         "base_url": runtime.get("base_url"),
                         "api_mode": runtime.get("api_mode"),
                         "platform": _bridge_platform(),
@@ -363,6 +367,45 @@ class AgentPool:
             runtime = _resolve_runtime(requested_model, requested_provider or None)
 
         resolved_provider = str(runtime.get("provider") or requested_provider or "")
+        effective_provider = requested_provider or resolved_provider
+        current_agent_provider = str(getattr(session.agent, "provider", "") or "")
+        current_agent_model = str(getattr(session.agent, "model", "") or "")
+        current_base_url = str(getattr(session.agent, "base_url", "") or "").rstrip("/")
+        resolved_base_url = str(runtime.get("base_url") or "").rstrip("/")
+        current_api_mode = str(getattr(session.agent, "api_mode", "") or "")
+        resolved_api_mode = str(runtime.get("api_mode") or "")
+        current_api_key = getattr(session.agent, "api_key", None)
+        resolved_api_key = runtime.get("api_key")
+
+        # Provider selectors such as custom:liuzheng normalize to the runtime
+        # provider "custom". Re-selecting that same runtime must not rebuild the
+        # client: switch_model reconstructs _client_kwargs, and affected Hermes
+        # runtimes lose model.default_headers during that reconstruction.
+        runtime_unchanged = (
+            requested_model == current_agent_model
+            and resolved_provider == current_agent_provider
+            and resolved_base_url == current_base_url
+            and resolved_api_mode == current_api_mode
+            and resolved_api_key == current_api_key
+        )
+        if runtime_unchanged:
+            session.config.update({
+                "profile": target_profile,
+                "model": requested_model,
+                "provider": effective_provider,
+                "base_url": runtime.get("base_url"),
+                "api_mode": runtime.get("api_mode"),
+            })
+            session.config.pop("pending_model_switch", None)
+            session.last_used_at = time.time()
+            return {
+                "switched": True,
+                "deferred": False,
+                "session_id": session.session_id,
+                "model": requested_model,
+                "provider": effective_provider,
+            }
+
         switch_model = getattr(session.agent, "switch_model", None)
         if not callable(switch_model):
             raise RuntimeError("loaded agent does not support switch_model")
@@ -379,7 +422,7 @@ class AgentPool:
         session.config.update({
             "profile": target_profile,
             "model": requested_model,
-            "provider": resolved_provider,
+            "provider": effective_provider,
             "base_url": runtime.get("base_url"),
             "api_mode": runtime.get("api_mode"),
         })
@@ -400,7 +443,7 @@ class AgentPool:
         return {
             "session_id": session.session_id,
             "model": requested_model,
-            "provider": resolved_provider,
+            "provider": effective_provider,
             "loaded": True,
             "switched": True,
         }

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -269,6 +269,101 @@ assert "pending_model_switch_note" in session.config
 `)
   })
 
+  it('does not rebuild an idle agent when only the requested custom-provider alias differs', () => {
+    runPython(String.raw`
+${harness}
+
+def fake_resolve_runtime(model, provider=None):
+    assert provider == "custom:liuzheng"
+    return {
+        "provider": "custom",
+        "base_url": "https://custom.example/v1",
+        "api_key": "same-key",
+        "api_mode": "chat_completions",
+    }
+
+bridge._resolve_runtime = fake_resolve_runtime
+pool, _fake_db = make_pool()
+
+class SwitchableAgent:
+    def __init__(self):
+        self.model = "same-model"
+        self.provider = "custom"
+        self.base_url = "https://custom.example/v1"
+        self.api_key = "same-key"
+        self.api_mode = "chat_completions"
+        self.switch_calls = []
+
+    def switch_model(self, **kwargs):
+        self.switch_calls.append(kwargs)
+
+agent = SwitchableAgent()
+session = bridge.AgentSession(
+    session_id="session-custom-alias",
+    agent=agent,
+    config={"profile": "default", "model": "same-model", "provider": "custom"},
+)
+pool._sessions["session-custom-alias"] = session
+
+result = pool.switch_session_model(
+    "session-custom-alias", "same-model", "custom:liuzheng", "default",
+)
+
+assert result["switched"] is True
+assert agent.switch_calls == []
+assert session.config["model"] == "same-model"
+assert session.config["provider"] == "custom:liuzheng"
+assert session.config["base_url"] == "https://custom.example/v1"
+`)
+  })
+
+  it('rebuilds an idle agent when credentials change under the same runtime', () => {
+    runPython(String.raw`
+${harness}
+
+def fake_resolve_runtime(model, provider=None):
+    return {
+        "provider": "custom",
+        "base_url": "https://custom.example/v1",
+        "api_key": "rotated-key",
+        "api_mode": "chat_completions",
+    }
+
+bridge._resolve_runtime = fake_resolve_runtime
+pool, _fake_db = make_pool()
+
+class SwitchableAgent:
+    def __init__(self):
+        self.model = "same-model"
+        self.provider = "custom"
+        self.base_url = "https://custom.example/v1"
+        self.api_key = "old-key"
+        self.api_mode = "chat_completions"
+        self.switch_calls = []
+
+    def switch_model(self, **kwargs):
+        self.switch_calls.append(kwargs)
+        self.api_key = kwargs["api_key"]
+
+agent = SwitchableAgent()
+session = bridge.AgentSession(
+    session_id="session-rotated-key",
+    agent=agent,
+    config={"profile": "default", "model": "same-model", "provider": "custom:liuzheng"},
+)
+pool._sessions["session-rotated-key"] = session
+
+result = pool.switch_session_model(
+    "session-rotated-key", "same-model", "custom:liuzheng", "default",
+)
+
+assert result["switched"] is True
+assert result["provider"] == "custom:liuzheng"
+assert len(agent.switch_calls) == 1
+assert agent.switch_calls[0]["api_key"] == "rotated-key"
+`)
+  })
+
   it('defers a loaded session model switch while a run is active and applies it after completion', () => {
     runPython(String.raw`
 ${harness}


### PR DESCRIPTION
## Summary

Fix Hermes Studio's handling of custom-provider aliases during loaded-session model selection.

A request can use a visible provider selector such as `custom:liuzheng`, while runtime resolution normalizes it to `custom`. The bridge previously stored only the normalized provider. The next request then compared `custom:liuzheng` against `custom`, treated the unchanged runtime as a model/provider change, and called `AIAgent.switch_model()` unnecessarily.

With Hermes Runtime 0.18.2, that redundant client rebuild drops configured `model.default_headers`. WAF-sensitive OpenAI-compatible endpoints then receive the SDK User-Agent instead of the configured User-Agent and return HTTP 403.

## Environment reproduced

- Hermes Studio: `0.6.29`
- Hermes Web UI: `0.6.29`
- Hermes Runtime: `0.18.2`
- Platform: `macOS arm64`
- Runtime path: `~/.hermes-web-ui/desktop-runtime/hermes/0.18.2/mac-arm64`
- Provider selector: `custom:liuzheng`
- Resolved runtime provider: `custom`
- Model: `gpt-5.6-sol`

## Root cause evidence

Instrumentation at the final OpenAI-client construction boundary showed:

```text
agent_init                      default_headers={User-Agent: curl/8.7.1}
switch_model                    default_headers={}
chat_completion_stream_request default_headers={}
```

The initial Agent client was configured correctly. The Studio bridge's redundant `switch_model()` call rebuilt it without the configured default headers.

## Changes

- Preserve the requested custom-provider selector in session metadata.
- Compare the actual resolved runtime before calling `switch_model()`:
  - model
  - normalized runtime provider
  - base URL
  - API mode
  - active API credential
- Skip the client rebuild only when all client-affecting runtime fields are unchanged.
- Continue rebuilding when the API key changes so credential rotation and revocation still take effect.
- Return the visible provider selector consistently from both paths.
- Add regression coverage for:
  - `custom:liuzheng` resolving to `custom` without a redundant rebuild;
  - API-key rotation forcing a rebuild under an otherwise unchanged runtime.

## Verification

```text
NODE_ENV=development npx vitest run \
  tests/server/agent-bridge-python-concurrency.test.ts \
  tests/server/agent-bridge-profile-env.test.ts

Test Files: 2 passed
Tests: 36 passed
```

```text
python3 -m py_compile packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
npm run harness:check
NODE_ENV=development npm run build
```

All completed successfully.

Installed-Studio verification used the same `custom:liuzheng / gpt-5.6-sol` configuration and completed two consecutive turns in one session:

```text
CURRENT_STUDIO_OK
SECOND_TURN_OK
```

## Scope

This PR is intentionally limited to the confirmed Studio bridge alias/session-state bug. Hermes Runtime should separately ensure every explicit `switch_model()` rebuild reapplies user default headers and custom-provider headers.
