### PR TITLE
fix: preserve extensions for Markdown downloads

### DIFF
--- a/docs/chat-chain-changes/2026-07-13-markdown-download-filenames.md
+++ b/docs/chat-chain-changes/2026-07-13-markdown-download-filenames.md
@@ -1,0 +1,10 @@
+---
+date: 2026-07-13
+pr: pending
+feature: Markdown local-file download filenames
+impact: Local Markdown file links keep the target file extension when the visible label has no suffix.
+---
+
+Markdown-rendered local file cards now infer the download filename from the
+target path when the link label is a human-readable name without a conventional
+extension. Explicit labels that already include an extension remain preserved.

--- a/packages/client/src/api/hermes/download.ts
+++ b/packages/client/src/api/hermes/download.ts
@@ -13,6 +13,38 @@ function normalizeProfile(profile?: string | null): string | null {
   return value || null
 }
 
+function hasConventionalExtension(value: string): boolean {
+  return /\.[A-Za-z0-9]{1,12}$/.test(value.trim())
+}
+
+function extractDownloadPath(filePath: string): string {
+  if (filePath.startsWith('/api/hermes/download?')) {
+    try {
+      const parsed = new URL(filePath, 'http://localhost')
+      return parsed.searchParams.get('path') || filePath
+    } catch {
+      return filePath
+    }
+  }
+
+  return filePath.split('?')[0].split('#')[0]
+}
+
+function getPathBasename(filePath: string): string {
+  const decodedPath = safeDecodeURIComponent(extractDownloadPath(filePath))
+  return decodedPath.split(/[\\/]/).pop()?.trim() || ''
+}
+
+export function inferDownloadFileName(filePath: string, fileName?: string): string {
+  const decodedName = fileName ? safeDecodeURIComponent(fileName).trim() : ''
+  if (decodedName && hasConventionalExtension(decodedName)) return decodedName
+
+  const basename = getPathBasename(filePath)
+  if (basename && hasConventionalExtension(basename)) return basename
+
+  return decodedName || basename || 'download'
+}
+
 /**
  * Construct a download URL with auth token as query parameter.
  * Token is passed via query param because <a> tags cannot set headers.
@@ -37,7 +69,7 @@ export function getDownloadUrl(filePath: string, fileName?: string, profile?: st
   const decodedPath = safeDecodeURIComponent(filePath)
   const params = new URLSearchParams({ path: decodedPath })
   if (fileName) {
-    const decodedName = safeDecodeURIComponent(fileName)
+    const decodedName = inferDownloadFileName(decodedPath, fileName)
     params.set('name', decodedName)
   }
   const explicitProfile = normalizeProfile(profile)
@@ -63,7 +95,7 @@ export async function downloadFile(filePath: string, fileName?: string, profile?
   const blobUrl = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = blobUrl
-  a.download = fileName || filePath.split('/').pop() || 'download'
+  a.download = inferDownloadFileName(filePath, fileName)
   document.body.appendChild(a)
   a.click()
   document.body.removeChild(a)

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -17,7 +17,7 @@ import {
   renderMermaidPlaceholder,
   SUPPORT_PREVIEW_FILE_TYPES,
 } from './mermaidRenderer'
-import { downloadFile, getDownloadUrl, fetchFileText } from '@/api/hermes/download'
+import { downloadFile, getDownloadUrl, fetchFileText, inferDownloadFileName } from '@/api/hermes/download'
 
 const LATEX_FENCE_LANGS = new Set(['latex', 'tex', 'math', 'katex'])
 const PREVIEW_AREA_WIDTH = 'min(800px, 100vw)'
@@ -181,6 +181,7 @@ const renderedHtml = computed(() => {
 
     const path = normalizeLocalFilePath(rawPath)
     const fileName = filename.trim()
+    const downloadName = inferDownloadFileName(path, fileName)
 
     // Video files: render as video player
     if (hasExtension(path, VIDEO_EXTENSIONS)) {
@@ -213,7 +214,7 @@ const renderedHtml = computed(() => {
     }
 
     // Other files: render as file card
-    return `<div class="markdown-file-card" data-path="${path}" data-filename="${fileName}" title="${t('download.downloadFile')}">
+    return `<div class="markdown-file-card" data-path="${path}" data-filename="${downloadName}" title="${t('download.downloadFile')}">
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
         <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
         <polyline points="14 2 14 8 20 8" />
@@ -454,7 +455,7 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
     // Parse the real file path from the existing query param
     const url = new URL(href, window.location.origin)
     const realPath = url.searchParams.get('path') || href
-    downloadFile(realPath, fileName || undefined).catch((err: Error) => {
+    downloadFile(realPath, inferDownloadFileName(realPath, fileName || undefined)).catch((err: Error) => {
       message.error(err.message || t('download.downloadFailed'))
     })
     return
@@ -466,8 +467,9 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
     event.stopPropagation()
     const linkText = link.textContent || ''
     const fileName = linkText.startsWith('File: ') ? linkText.slice(6).trim() : linkText.trim()
+    const path = normalizeLocalFilePath(href)
     message.info(t('download.downloading'))
-    downloadFile(normalizeLocalFilePath(href), fileName || undefined).catch((err: Error) => {
+    downloadFile(path, inferDownloadFileName(path, fileName || undefined)).catch((err: Error) => {
       message.error(err.message || t('download.downloadFailed'))
     })
   }

--- a/tests/client/api.test.ts
+++ b/tests/client/api.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/router', () => ({
 }))
 
 import { getApiKey, setApiKey, clearApiKey, hasApiKey, getStoredUserRole, isStoredSuperAdmin, request } from '../../packages/client/src/api/client'
-import { getDownloadUrl } from '../../packages/client/src/api/hermes/download'
+import { downloadFile, getDownloadUrl } from '../../packages/client/src/api/hermes/download'
 import { uploadFiles } from '../../packages/client/src/api/hermes/files'
 import { importSkill } from '../../packages/client/src/api/hermes/skills'
 import { archiveSession, batchDeleteSessions, exportSession, importHermesSession, unarchiveSession } from '../../packages/client/src/api/hermes/sessions'
@@ -223,6 +223,54 @@ describe('API Client', () => {
       expect(url.pathname).toBe('/api/hermes/download')
       expect(url.searchParams.get('path')).toBe('/tmp/100% ready.txt')
       expect(url.searchParams.get('name')).toBe('100% ready.txt')
+    })
+
+    it('uses the target basename when a supplied download label has no extension', () => {
+      const url = new URL(getDownloadUrl('/tmp/report.md', '下载报告'), 'http://localhost')
+
+      expect(url.pathname).toBe('/api/hermes/download')
+      expect(url.searchParams.get('path')).toBe('/tmp/report.md')
+      expect(url.searchParams.get('name')).toBe('report.md')
+    })
+
+    it('preserves explicit custom download names that already include an extension', () => {
+      const url = new URL(getDownloadUrl('/tmp/report.md', 'custom-name.md'), 'http://localhost')
+
+      expect(url.searchParams.get('path')).toBe('/tmp/report.md')
+      expect(url.searchParams.get('name')).toBe('custom-name.md')
+    })
+
+    it('sets the browser download name from the path when the label has no extension', async () => {
+      const blob = new Blob(['report'])
+      mockFetch.mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(blob),
+      })
+      const createObjectUrl = vi.fn(() => 'blob:download')
+      const revokeObjectUrl = vi.fn()
+      const OriginalUrl = URL
+      class DownloadUrl extends OriginalUrl {}
+      Object.defineProperties(DownloadUrl, {
+        createObjectURL: { value: createObjectUrl },
+        revokeObjectURL: { value: revokeObjectUrl },
+      })
+      vi.stubGlobal('URL', DownloadUrl)
+      const originalCreateElement = document.createElement.bind(document)
+      const downloadAnchor = originalCreateElement('a') as HTMLAnchorElement
+      vi.spyOn(downloadAnchor, 'click').mockImplementation(() => undefined)
+      const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+        return tagName.toLowerCase() === 'a' ? downloadAnchor : originalCreateElement(tagName)
+      })
+
+      try {
+        await expect(downloadFile('/tmp/report.md', '下载报告')).resolves.toBeUndefined()
+        expect(downloadAnchor.download).toBe('report.md')
+        expect(revokeObjectUrl).toHaveBeenCalledWith('blob:download')
+      } finally {
+        createElementSpy.mockRestore()
+        vi.unstubAllGlobals()
+        vi.stubGlobal('fetch', mockFetch)
+      }
     })
 
     it('exports sessions when the response filename contains a raw percent sign', async () => {

--- a/tests/client/markdown-rendering.test.ts
+++ b/tests/client/markdown-rendering.test.ts
@@ -58,11 +58,15 @@ vi.mock('naive-ui', () => ({
   }),
 }))
 
-vi.mock('@/api/hermes/download', () => ({
-  downloadFile: downloadApiMock.downloadFile,
-  fetchFileText: downloadApiMock.fetchFileText,
-  getDownloadUrl: downloadApiMock.getDownloadUrl,
-}))
+vi.mock('@/api/hermes/download', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/hermes/download')>()
+  return {
+    ...actual,
+    downloadFile: downloadApiMock.downloadFile,
+    fetchFileText: downloadApiMock.fetchFileText,
+    getDownloadUrl: downloadApiMock.getDownloadUrl,
+  }
+})
 
 import MarkdownRenderer from '@/components/hermes/chat/MarkdownRenderer.vue'
 
@@ -317,6 +321,20 @@ describe('MarkdownRenderer', () => {
     expect(downloadApiMock.downloadFile).toHaveBeenCalledWith('/tmp/notes.txt', 'notes.txt')
     expect(downloadApiMock.fetchFileText).not.toHaveBeenCalled()
     expect(wrapper.find('.n-drawer-stub').exists()).toBe(false)
+  })
+
+  it('preserves the target extension when a local file link label has no suffix', async () => {
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: '[下载报告](/tmp/report.md)',
+      },
+    })
+
+    await wrapper.find('.att-download-btn').trigger('click')
+    await Promise.resolve()
+
+    expect(downloadApiMock.downloadFile).toHaveBeenCalledTimes(1)
+    expect(downloadApiMock.downloadFile).toHaveBeenCalledWith('/tmp/report.md', 'report.md')
   })
 
   it('opens text previews in a responsive drawer with a close control', async () => {


### PR DESCRIPTION
## Summary

- preserve the target file extension when a Markdown local-file link uses a human-readable label without a suffix
- share filename inference between Markdown file cards, direct local links, the download URL, and the browser `download` attribute
- preserve explicit custom filenames that already include an extension

Fixes #1864.

## Validation

- `npm run test -- tests/client/api.test.ts tests/client/markdown-rendering.test.ts` — 65 tests passed
- `npm run harness:check` — passed
- `npm run build` — passed
- `git diff --check` — passed
- independent audit reproduced the regression on the unmodified base, then verified the focused tests and harness on the patch

## Duplicate Check

Refreshed against `origin/main` at `f0399f4c11292d59ecf6c800112da2fd634c5153` immediately before publication. Issue #1864 remains open with no comments. Searches by issue number, `MarkdownRenderer`, `downloadFile`, `a.download`, and the download-extension behavior found no open or recently closed equivalent PR.

## Browser / Playwright Status

Playwright was not run because the repository has no deterministic fixture for chat local-file downloads or `download.suggestedFilename()` on `/api/hermes/download`. Equivalent browser-facing filename behavior is covered by jsdom/Vitest: the Markdown file-card click path, generated `name` query parameter, and `HTMLAnchorElement.download` value are all asserted.
