### PR TITLE
fix: keep production Ekko memory database disabled

### DIFF
--- a/packages/ekko-agent/README.md
+++ b/packages/ekko-agent/README.md
@@ -99,8 +99,9 @@ In development, Ekko Agent stores its SQLite database at
 `packages/ekko-agent/sql-data/ekko-agent.db`. It uses the same single-file
 SQLite/DELETE journal layout as `packages/server/data/hermes-web-ui.db`, so the
 database can be opened directly in Navicat. Tests remain isolated in temporary
-directories, while production stores data under
-`HERMES_WEB_UI_HOME/ekko/ekko.db`.
+directories. While the production Ekko Agent entry remains hidden, the server
+starts Ekko Agent with memory disabled and does not create the `ekko` directory
+or `HERMES_WEB_UI_HOME/ekko/ekko.db`.
 
 ```ts
 import { AgentRuntime, createDefaultToolRegistry } from './src/index'

--- a/packages/server/src/services/ekko-agent/manager.ts
+++ b/packages/server/src/services/ekko-agent/manager.ts
@@ -74,7 +74,17 @@ export class GlobalEkkoAgent {
   }
 }
 
-const globalEkkoAgent = new GlobalEkkoAgent({ webUiHome: config.appHome })
+export function createGlobalEkkoAgent(
+  options: GlobalEkkoAgentOptions = {},
+  env: Record<string, string | undefined> = process.env,
+): GlobalEkkoAgent {
+  return new GlobalEkkoAgent({
+    ...options,
+    memory: env.NODE_ENV === 'production' ? false : options.memory,
+  })
+}
+
+const globalEkkoAgent = createGlobalEkkoAgent({ webUiHome: config.appHome })
 
 export function getGlobalEkkoAgent(): GlobalEkkoAgent {
   return globalEkkoAgent

--- a/tests/server/ekko-agent-manager.test.ts
+++ b/tests/server/ekko-agent-manager.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
-import { GlobalEkkoAgent } from '../../packages/server/src/services/ekko-agent/manager'
+import { createGlobalEkkoAgent, GlobalEkkoAgent } from '../../packages/server/src/services/ekko-agent/manager'
 import type { ModelClient, ModelRequest } from '../../packages/ekko-agent/src'
 
 function modelClient(content: string): ModelClient {
@@ -70,6 +70,29 @@ describe('GlobalEkkoAgent', () => {
         memoryDatabasePath: join(webUiHome, 'ekko', 'ekko.db'),
       })
       expect(existsSync(join(webUiHome, 'ekko', 'ekko.db'))).toBe(true)
+    } finally {
+      agent.close()
+      await rm(webUiHome, { recursive: true, force: true })
+    }
+  })
+
+  it('does not create a memory database when the production entry is hidden', async () => {
+    const webUiHome = await mkdtemp(join(tmpdir(), 'global-ekko-agent-production-'))
+    const agent = createGlobalEkkoAgent({ webUiHome }, { NODE_ENV: 'production' })
+    try {
+      const result = await agent.run({
+        messages: ['hello'],
+        modelClient: modelClient('ok'),
+        metadata: { session_id: 'session-1' },
+      })
+
+      expect(result.output.content).toBe('ok')
+      expect(agent.status()).toMatchObject({
+        memoryEnabled: false,
+        memoryDatabasePath: undefined,
+      })
+      expect(existsSync(join(webUiHome, 'ekko'))).toBe(false)
+      expect(existsSync(join(webUiHome, 'ekko', 'ekko.db'))).toBe(false)
     } finally {
       agent.close()
       await rm(webUiHome, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- construct the production global Ekko Agent with memory disabled while its UI entry remains hidden
- prevent production runs from creating the `ekko` directory or `ekko.db`
- document the production boundary and add regression coverage

## Impact
- production does not access SQLite or run Ekko memory migrations
- development and test memory behavior remains unchanged

## Validation
- `npm run test -- tests/server/ekko-agent-manager.test.ts tests/ekko-agent/database.test.ts`
- `npm run harness:check`
- `npm run build`