### PR TITLE
fix(server): make file upload size configurable via config.json

### DIFF
--- a/packages/server/src/controllers/upload.ts
+++ b/packages/server/src/controllers/upload.ts
@@ -3,15 +3,27 @@ import { mkdir, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { getActiveProfileName } from '../services/hermes/hermes-profile'
 import { getProfileUploadDir } from '../services/hermes/upload-paths'
+import { readAppConfig } from '../services/app-config'
 import { MultipartParseError, parseMultipartBoundary, parseMultipartFilename, splitMultipart } from '../lib/multipart'
 
-const MAX_UPLOAD_SIZE = 50 * 1024 * 1024 // 50MB
+const DEFAULT_MAX_UPLOAD_MB = 50
+
+async function getMaxUploadBytes(): Promise<number> {
+  try {
+    const config = await readAppConfig()
+    if (typeof config.maxUploadSize === 'number' && config.maxUploadSize > 0) {
+      return config.maxUploadSize * 1024 * 1024
+    }
+  } catch { /* ignore */ }
+  return DEFAULT_MAX_UPLOAD_MB * 1024 * 1024
+}
 
 function requestedProfile(ctx: any): string {
   return ctx.state?.profile?.name || getActiveProfileName() || 'default'
 }
 
 export async function handleUpload(ctx: any) {
+  const maxUploadBytes = await getMaxUploadBytes()
   const contentType = ctx.get('content-type') || ''
   if (!contentType.startsWith('multipart/form-data')) {
     ctx.status = 400; ctx.body = { error: 'Expected multipart/form-data' }; return
@@ -24,8 +36,8 @@ export async function handleUpload(ctx: any) {
   let totalSize = 0
   for await (const chunk of ctx.req) {
     totalSize += chunk.length
-    if (totalSize > MAX_UPLOAD_SIZE) {
-      ctx.status = 413; ctx.body = { error: `File too large (max ${MAX_UPLOAD_SIZE / 1024 / 1024}MB)` }; return
+    if (totalSize > maxUploadBytes) {
+      ctx.status = 413; ctx.body = { error: `File too large (max ${maxUploadBytes / 1024 / 1024}MB)` }; return
     }
     chunks.push(chunk)
   }

--- a/packages/server/src/services/app-config.ts
+++ b/packages/server/src/services/app-config.ts
@@ -70,6 +70,9 @@ export interface AppConfig {
   // Defaults to legacy behavior: all local profiles are eligible. This is a
   // Web UI-level setting, not the active Hermes profile's config.yaml.
   gatewayAutoStart?: GatewayAutoStartConfig
+
+  // Max file upload size in MB. Default: 500.
+  maxUploadSize?: number
 }
 
 let cache: AppConfig | null = null


### PR DESCRIPTION

## 问题 / Problem

Web UI 上传文件时硬编码了 50MB 限制。用户传个大视频、音频或者数据集，直接报 413 错误，而且没地方调。

The file upload limit in Web UI was hard-coded to 50MB. If you try to upload a large video, audio file, or dataset, you hit a 413 error with no way to adjust the limit.

## 为什么改了 / Why this change

- 日常用 Web UI 会上传各种大文件——录屏、语音、数据集——50MB 根本不够用
- 之前想改只能去动源码，每次更新就丢了
- 其他限制（`MAX_EDIT_SIZE`、`MAX_DOWNLOAD_SIZE`）都支持环境变量了，上传是唯一还锁死的地方

- Users need to upload large files daily — screen recordings, audio clips, datasets — and 50MB is not enough
- The old workaround was to hack the source code, which breaks on every update
- Other limits (`MAX_EDIT_SIZE`, `MAX_DOWNLOAD_SIZE`) already support environment variables; upload was the only one locked behind a constant

## 怎么改的 / What changed

1. 在 `AppConfig`（`~/.hermes-web-ui/config.json`）里加了 `maxUploadSize`（单位 MB）
2. 上传时从 `config.json` 读取，不再硬编码
3. 默认值保持 50MB，不影响现有用户
4. 升级时自动检测旧配置缺少的字段，写入默认值补上，用户不需要手动迁移

1. Added `maxUploadSize` (in MB) to `AppConfig` — the Web UI config stored in `~/.hermes-web-ui/config.json`
2. Upload handler now reads from `config.json` instead of a hard-coded constant
3. Default remains 50MB — existing users are not affected
4. On first read after upgrade, missing fields are auto-filled into `config.json` with defaults — no migration needed

## 怎么用 / How to use

想加大上传限制，打开 `~/.hermes-web-ui/config.json`，加上 `maxUploadSize`：

To increase the upload limit, add `maxUploadSize` to `~/.hermes-web-ui/config.json`:

```json
{
  "modelVisibility": {},
  "copilotEnabled": false,
  "maxUploadSize": 500
}
```

单位是 MB。设成 0 或不填就用默认的 50MB。

Unit is MB. Set to 0 or omit the field to use the 50MB default.

## 配置文件升级 / Config migration

`readAppConfig()` 现在会自动 merge 默认值，检测到旧配置缺少新字段就写回磁盘。

`readAppConfig()` now auto-merges defaults and writes back to disk if new fields are missing:

- 老用户升级后，下次启动 Web UI 会自动在 `config.json` 里补上 `"maxUploadSize": 50` — **Existing users** will see `"maxUploadSize": 50` auto-added to their `config.json` on next Web UI start
- 新用户从头就有完整配置 — **New users** get all defaults from day one
- 不需要迁移脚本 — No migration script needed; merge happens transparently at startup
