### PR TITLE
fix realtime voice recovery and approval overlay

### DIFF
--- a/docs/chat-chain-changes/2026-07-14-pc-no-speech-restart.md
+++ b/docs/chat-chain-changes/2026-07-14-pc-no-speech-restart.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-14
+pr: pending
+feature: PC realtime voice no-speech recovery
+impact: PC browser speech recognition now restarts listening after a no-speech result instead of treating silence as a fatal voice-chain error.
+---
+
+Realtime voice uses continuous browser recognition on PC. When the browser
+reports `no-speech`, only the failed browser recognition instance is cleared
+and restarted after the normal short delay; the microphone recorder and
+visualizer stream remain open. Network, permission, and other recognition
+failures keep their existing error and backend-fallback behavior.

--- a/docs/chat-chain-changes/2026-07-14-realtime-voice-approval-layer.md
+++ b/docs/chat-chain-changes/2026-07-14-realtime-voice-approval-layer.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-14
+pr: pending
+feature: Realtime voice approval overlay
+impact: Pending command approvals remain visible and interactive above the realtime voice stage without changing their normal chat layout.
+---
+
+The single-chat approval panel keeps its existing message-area placement during
+normal chat. While realtime voice is open, only the approval panel is
+teleported to the document body and rendered as a fixed highest-priority layer.
+Closing realtime voice returns the panel to its original stack with queued and
+clarification prompts.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -1965,7 +1965,10 @@ async function handleSessionModelCustomSubmit() {
           @drop="handleChatDrop"
         >
           <div class="chat-main-content">
-            <MessageList ref="messageListRef" />
+            <MessageList
+              ref="messageListRef"
+              :approval-portal-to-body="showRealtimeVoice"
+            />
             <ChatInput
               ref="chatInputRef"
               :model-label="activeSessionModelLabel"

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -24,6 +24,12 @@ import { LIVE_CHAT_MAX_LOADED_MESSAGES, useChatStore, type Message } from "@/sto
 import thinkingImage from "@/assets/thinking.gif";
 import { useToolTraceVisibility } from "@/composables/useToolTraceVisibility";
 
+const props = withDefaults(defineProps<{
+  approvalPortalToBody?: boolean
+}>(), {
+  approvalPortalToBody: false,
+})
+
 const chatStore = useChatStore();
 const { t } = useI18n();
 const { toolTraceVisible } = useToolTraceVisibility();
@@ -732,8 +738,13 @@ defineExpose({
       v-if="visibleApproval || visibleClarify || queuedMessages.length > 0"
       class="message-float-stack"
     >
+    <Teleport to="body" :disabled="!props.approvalPortalToBody">
       <Transition name="queue-float">
-        <div v-if="visibleApproval" class="approval-float-panel">
+        <div
+          v-if="visibleApproval"
+          class="approval-float-panel"
+          :class="{ 'approval-float-panel--global': props.approvalPortalToBody }"
+        >
           <div class="float-panel-header">
             <span class="approval-float-icon" aria-hidden="true">
               <svg
@@ -800,6 +811,7 @@ defineExpose({
           </div>
         </div>
       </Transition>
+    </Teleport>
       <Transition name="queue-float">
         <div v-if="!visibleApproval && visibleClarify" class="approval-float-panel">
           <div class="float-panel-header">
@@ -957,6 +969,14 @@ defineExpose({
 
 .approval-float-panel {
   border-color: rgba(var(--accent-primary-rgb), 0.24);
+}
+
+.approval-float-panel--global {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 2147483000;
+  width: min(720px, calc(100vw - 32px));
 }
 
 .queue-float-panel {
@@ -1173,6 +1193,13 @@ defineExpose({
   .queue-float-panel {
     padding: 7px;
     border-radius: 14px;
+  }
+
+  .approval-float-panel--global {
+    left: 8px;
+    right: 8px;
+    bottom: max(8px, env(safe-area-inset-bottom));
+    width: auto;
   }
 
   .queue-float-header {

--- a/packages/client/src/components/hermes/chat/RealtimeVoiceStage.vue
+++ b/packages/client/src/components/hermes/chat/RealtimeVoiceStage.vue
@@ -202,6 +202,10 @@ function isMobileDevice() {
   return hasTouch && hasCoarsePointer && screenShortEdge <= 1024
 }
 
+function browserCaptureContinuous() {
+  return !isMobileDevice()
+}
+
 function clearTimers() {
   if (silenceTimer) clearTimeout(silenceTimer)
   if (restartTimer) clearTimeout(restartTimer)
@@ -473,7 +477,7 @@ async function startCapture() {
 
     await browserRecognition.start({
       language: browserCaptureLanguage(),
-      continuous: false,
+      continuous: browserCaptureContinuous(),
     })
     mode.value = 'listening'
     void startVisualizer(micRecorder.stream.value)
@@ -488,6 +492,7 @@ async function submitTranscript(value: string) {
   const transcript = normalizeText(value)
   submittedTranscript.value = transcript
   if (!transcript) {
+    stopVisualizer()
     mode.value = 'idle'
     return
   }
@@ -524,12 +529,19 @@ async function transcribeBackendCapture(audio: Blob, setting: SttProviderSetting
 }
 
 async function handleRecognitionFailure() {
-  if ((mode.value !== 'listening' && mode.value !== 'processing') || handlingRecognitionFailure || !browserRecognition.error.value) return
+  if (!sessionActive.value || activeCaptureMode !== 'browser' || handlingRecognitionFailure || !browserRecognition.error.value) return
   handlingRecognitionFailure = true
   clearTimers()
-  mode.value = 'processing'
 
   try {
+    if (browserRecognition.errorCode.value === 'no-speech') {
+      browserRecognition.clearError()
+      if (mode.value === 'processing' && !waitingForResponse.value) mode.value = 'listening'
+      scheduleBrowserRecognitionRestart()
+      return
+    }
+
+    mode.value = 'processing'
     if (browserRecognition.errorCode.value === 'network' && activeBackendSetting) {
       const audio = await micRecorder.stop()
       stopVisualizer()
@@ -637,6 +649,33 @@ function scheduleRestart(delay = 420) {
       void startCapture()
     }
   }, delay)
+}
+
+function scheduleBrowserRecognitionRestart(delay = 420) {
+  if (!sessionActive.value || activeCaptureMode !== 'browser') return
+  if (restartTimer) clearTimeout(restartTimer)
+  restartTimer = setTimeout(() => {
+    restartTimer = null
+    if (!sessionActive.value || activeCaptureMode !== 'browser') return
+    browserRecognition.clearError()
+    void browserRecognition.start({
+      language: browserCaptureLanguage(),
+      continuous: browserCaptureContinuous(),
+    }).catch((cause) => {
+      activeCaptureMode = null
+      micRecorder.cancel()
+      stopVisualizer()
+      setError(cause)
+    })
+  }, delay)
+}
+
+function scheduleSilenceCommit() {
+  if (silenceTimer) clearTimeout(silenceTimer)
+  silenceTimer = setTimeout(() => {
+    silenceTimer = null
+    if (mode.value === 'listening') void stopCapture()
+  }, SILENCE_COMMIT_MS)
 }
 
 function waitForSpeechPlayback(generation: number) {
@@ -830,8 +869,10 @@ function finishResponseIfReady() {
   void waitForSpeechQueueIdle().finally(() => {
     if (generation !== playbackGeneration || !sessionActive.value) return
     waitingForResponse.value = false
-    if (mode.value !== 'error') mode.value = 'idle'
-    scheduleRestart()
+    if (mode.value !== 'error') {
+      mode.value = activeCaptureMode === 'browser' ? 'listening' : 'idle'
+    }
+    if (activeCaptureMode === null) scheduleRestart()
   })
 }
 
@@ -854,11 +895,7 @@ function closeStage() {
 
 watch(currentTranscript, (value) => {
   if (mode.value !== 'listening' || !value) return
-  if (silenceTimer) clearTimeout(silenceTimer)
-  silenceTimer = setTimeout(() => {
-    silenceTimer = null
-    if (mode.value === 'listening') void stopCapture()
-  }, SILENCE_COMMIT_MS)
+  scheduleSilenceCommit()
 })
 watch(() => browserRecognition.error.value, () => {
   void handleRecognitionFailure()

--- a/tests/client/message-list-scroll-position.test.ts
+++ b/tests/client/message-list-scroll-position.test.ts
@@ -247,4 +247,46 @@ describe('MessageList session scroll position', () => {
 
     expect(mockScrollToBottom).toHaveBeenCalledWith({ frames: 1, keepAliveMs: 0 })
   })
+
+  it('only portals approvals to the global layer while realtime voice is open', async () => {
+    const chatStore = useChatStore()
+    const session = makeSession('approval-layer-session')
+    chatStore.activeSessionId = session.id
+    chatStore.activeSession = session
+    chatStore.pendingApprovals.set(session.id, {
+      sessionId: session.id,
+      approvalId: 'approval-layer-request',
+      command: 'npm run test',
+      description: 'Run tests',
+      choices: ['once', 'deny'],
+      allowPermanent: false,
+      isMemoryWrite: false,
+      requestedAt: Date.now(),
+    })
+
+    const wrapper = mount(MessageList, {
+      props: { approvalPortalToBody: false },
+      global: {
+        stubs: { Transition: false },
+      },
+    })
+    await nextTick()
+
+    expect(wrapper.find('.message-float-stack .approval-float-panel').exists()).toBe(true)
+    expect(document.body.querySelector('.approval-float-panel--global')).toBeNull()
+
+    await wrapper.setProps({ approvalPortalToBody: true })
+    await nextTick()
+
+    const globalPanel = document.body.querySelector('.approval-float-panel--global')
+    expect(globalPanel).not.toBeNull()
+    expect(globalPanel?.parentElement).toBe(document.body)
+
+    await wrapper.setProps({ approvalPortalToBody: false })
+    await nextTick()
+
+    expect(document.body.querySelector('.approval-float-panel--global')).toBeNull()
+    expect(wrapper.find('.message-float-stack .approval-float-panel').exists()).toBe(true)
+    wrapper.unmount()
+  })
 })

--- a/tests/client/realtime-voice-playback-queue.test.ts
+++ b/tests/client/realtime-voice-playback-queue.test.ts
@@ -322,7 +322,7 @@ describe('RealtimeVoiceStage prepared playback queue', () => {
     expect(testState.recorder.start).toHaveBeenCalledTimes(1)
     expect(testState.browserRecognition.start).toHaveBeenCalledWith({
       language: 'zh-CN',
-      continuous: false,
+      continuous: true,
     })
 
     testState.browserRecognition.errorCode.value = 'network'
@@ -385,6 +385,33 @@ describe('RealtimeVoiceStage prepared playback queue', () => {
     wrapper.unmount()
   })
 
+  it('keeps restart-based browser capture on mobile when no backend STT is configured', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('navigator', {
+      userAgent: 'Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/138 Mobile Safari/537.36',
+      maxTouchPoints: 5,
+    })
+    vi.stubGlobal('screen', { width: 430, height: 932 })
+    vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: true })))
+    const wrapper = mount(RealtimeVoiceStage)
+
+    await vi.advanceTimersByTimeAsync(180)
+    await settle()
+
+    expect(testState.browserRecognition.start).toHaveBeenCalledWith({
+      language: 'zh-CN',
+      continuous: false,
+    })
+
+    testState.recognitionStopResult = '移动端问题'
+    await wrapper.get('[data-testid="realtime-voice-toggle"]').trigger('click')
+    await settle()
+
+    expect(testState.store.sendMessage).toHaveBeenCalledWith('移动端问题')
+    expect(testState.browserRecognition.start).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+
   it('shows a direct network error when the active STT setting has no backend fallback', async () => {
     const wrapper = mount(RealtimeVoiceStage)
 
@@ -393,7 +420,7 @@ describe('RealtimeVoiceStage prepared playback queue', () => {
     expect(testState.recorder.start).not.toHaveBeenCalled()
     expect(testState.browserRecognition.start).toHaveBeenCalledWith({
       language: 'zh-CN',
-      continuous: false,
+      continuous: true,
     })
     testState.browserRecognition.errorCode.value = 'network'
     testState.browserRecognition.error.value = new Error('network')
@@ -404,4 +431,79 @@ describe('RealtimeVoiceStage prepared playback queue', () => {
     expect(wrapper.get('[data-testid="realtime-voice-caption"]').text()).toBe('realtimeVoice.networkUnavailableNoFallback')
     wrapper.unmount()
   })
+
+  it('restarts PC browser capture when no speech is detected', async () => {
+    vi.useFakeTimers()
+    const wrapper = mount(RealtimeVoiceStage)
+
+    await vi.advanceTimersByTimeAsync(180)
+    await settle()
+
+    expect(testState.browserRecognition.start).toHaveBeenCalledTimes(1)
+    expect(wrapper.classes()).toContain('voice-stage--listening')
+
+    testState.browserRecognition.errorCode.value = 'no-speech'
+    testState.browserRecognition.error.value = new Error('Browser speech recognition failed: no-speech.')
+    await settle()
+
+    expect(testState.browserRecognition.clearError).toHaveBeenCalled()
+    expect(testState.transcribeSpeech).not.toHaveBeenCalled()
+    expect(testState.recorder.cancel).not.toHaveBeenCalled()
+    expect(wrapper.classes()).toContain('voice-stage--listening')
+    expect(wrapper.classes()).not.toContain('voice-stage--error')
+
+    await vi.advanceTimersByTimeAsync(420)
+    await settle()
+
+    expect(testState.browserRecognition.start).toHaveBeenCalledTimes(2)
+    expect(wrapper.classes()).toContain('voice-stage--listening')
+    wrapper.unmount()
+  })
+
+  it('keeps microphone capture stopped while the assistant response is playing', async () => {
+    vi.useFakeTimers()
+    testState.store.isStreaming = true
+    const wrapper = mount(RealtimeVoiceStage)
+
+    await vi.advanceTimersByTimeAsync(180)
+    await settle()
+
+    testState.recognitionStopResult = '第一个问题'
+    await wrapper.get('[data-testid="realtime-voice-toggle"]').trigger('click')
+    await settle()
+
+    expect(testState.store.sendMessage).toHaveBeenCalledWith('第一个问题')
+    expect(testState.browserRecognition.stop).toHaveBeenCalledTimes(1)
+    expect(testState.browserRecognition.start).toHaveBeenCalledTimes(1)
+
+    testState.store.messages.push({
+      id: 'assistant-no-capture',
+      role: 'assistant',
+      content: '这是正在播放的回答。',
+      timestamp: Date.now(),
+      isStreaming: true,
+    })
+    await settle()
+    resolveRequest(0)
+    await settle()
+
+    expect(wrapper.classes()).toContain('voice-stage--speaking')
+    testState.browserRecognition.partialTranscript.value = '这是正在播放的回答'
+    await settle()
+
+    expect(testState.store.stopStreaming).not.toHaveBeenCalled()
+    expect(testState.browserRecognition.start).toHaveBeenCalledTimes(1)
+
+    testState.audioInstances[0].onended?.()
+    testState.store.isStreaming = false
+    await settle()
+    await vi.advanceTimersByTimeAsync(420)
+    await settle()
+
+    expect(testState.browserRecognition.start).toHaveBeenCalledTimes(2)
+    expect(wrapper.classes()).toContain('voice-stage--listening')
+    testState.store.isStreaming = true
+    wrapper.unmount()
+  })
+
 })


### PR DESCRIPTION
## Summary
- keep PC browser speech recognition continuous and recover `no-speech` without tearing down the microphone chain
- stop microphone capture while the assistant is thinking or speaking, then resume after playback to avoid capturing TTS output
- portal pending command approvals above realtime voice only while the voice stage is open, preserving the normal chat layout

## Root cause
PC realtime voice used restart-based browser recognition and treated `no-speech` as fatal. Keeping capture active during assistant playback also allowed speaker output to be transcribed. Approval prompts remained inside the message-list stacking context and were hidden behind the teleported voice stage.

## Impact
PC voice listening recovers from silence without showing a broken-chain error, assistant speech is not recorded as user input, mobile capture behavior remains unchanged, and approvals stay visible and interactive over realtime voice.

## Validation
- `npm run test -- tests/client/message-list-scroll-position.test.ts tests/client/realtime-voice-playback-queue.test.ts tests/client/use-browser-speech-recognition.test.ts tests/client/voice-dialogue-controls.test.ts`
- `npm run harness:check`
- `npm run build`
