### PR TITLE
perf: reduce first-screen bundle loading

### DIFF
--- a/docs/chat-chain-changes/2026-07-14-first-screen-bundle-splitting.md
+++ b/docs/chat-chain-changes/2026-07-14-first-screen-bundle-splitting.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-14
+pr: pending
+feature: First-screen bundle splitting
+impact: The app loads only startup code and the active locale before mounting, while heavy Markdown, Mermaid, editor, sidebar, pet, and inactive locale code stays lazy.
+---
+
+The production build now preserves route and dynamic-import boundaries instead
+of forcing every dependency into shared vendor chunks. Markdown rendering loads
+only when it is used while retaining the full syntax-highlighting catalog,
+locale messages load on demand, and hashed build assets receive immutable cache
+headers. The existing logo is unchanged.

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -1,24 +1,27 @@
 <script setup lang="ts">
-import { onUnmounted, computed, watch } from 'vue'
+import { computed, defineAsyncComponent, onUnmounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { darkTheme, NConfigProvider, NMessageProvider, NDialogProvider, NNotificationProvider } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import { getThemeOverrides } from '@/styles/theme'
 import { useTheme } from '@/composables/useTheme'
-import AppSidebar from '@/components/layout/AppSidebar.vue'
-import DesktopTitleBar from '@/components/layout/DesktopTitleBar.vue'
 import { useKeyboard } from '@/composables/useKeyboard'
+import { useSessionSearch } from '@/composables/useSessionSearch'
 import { useAppStore } from '@/stores/hermes/app'
-import SessionSearchModal from '@/components/hermes/chat/SessionSearchModal.vue'
 import AuthEventListener from '@/components/auth/AuthEventListener.vue'
-import DefaultCredentialPrompt from '@/components/auth/DefaultCredentialPrompt.vue'
-import WebPet from '@/components/hermes/pets/WebPet.vue'
 import { desktopBridge } from '@/utils/desktop-bridge'
+
+const AppSidebar = defineAsyncComponent(async () => (await import('@/components/layout/AppSidebar.vue')).default)
+const DesktopTitleBar = defineAsyncComponent(async () => (await import('@/components/layout/DesktopTitleBar.vue')).default)
+const SessionSearchModal = defineAsyncComponent(async () => (await import('@/components/hermes/chat/SessionSearchModal.vue')).default)
+const DefaultCredentialPrompt = defineAsyncComponent(async () => (await import('@/components/auth/DefaultCredentialPrompt.vue')).default)
+const WebPet = defineAsyncComponent(async () => (await import('@/components/hermes/pets/WebPet.vue')).default)
 
 const { isDark, isComic } = useTheme()
 const { t } = useI18n()
 const appStore = useAppStore()
 const route = useRoute()
+const { sessionSearchOpen } = useSessionSearch()
 
 const themeOverrides = computed(() => getThemeOverrides(isDark.value, isComic.value))
 const naiveTheme = computed(() => isDark.value ? darkTheme : null)
@@ -94,7 +97,7 @@ useKeyboard()
             </div>
           </div>
           <WebPet v-if="showWebPet" />
-          <SessionSearchModal v-if="!isDesktopPetRoute" />
+          <SessionSearchModal v-if="!isDesktopPetRoute && sessionSearchOpen" />
           <DefaultCredentialPrompt v-if="!isDesktopPetRoute" />
         </NNotificationProvider>
       </NDialogProvider>

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import 'katex/dist/katex.min.css'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { NDrawer, NDrawerContent, NSpin, useMessage } from 'naive-ui'

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -5,7 +5,6 @@ import { useI18n } from "vue-i18n";
 import { NButton, NDrawer, NDrawerContent, NSpin, useMessage } from "naive-ui";
 import { downloadFile, getDownloadUrl } from "@/api/hermes/download";
 import { copyToClipboard } from "@/utils/clipboard";
-import MarkdownRenderer from "./MarkdownRenderer.vue";
 import { parseThinking, countThinkingChars } from "@/utils/thinking-parser";
 import { useChatStore } from "@/stores/hermes/chat";
 import { useFilesStore } from "@/stores/hermes/files";
@@ -26,6 +25,7 @@ import { formatChatTimestamp } from "@/utils/chat-timestamp";
 import type { WorkspaceRunChangeFileSummary } from "@/api/hermes/sessions";
 
 const FileEditor = defineAsyncComponent(() => import("@/components/hermes/files/FileEditor.vue"));
+const MarkdownRenderer = defineAsyncComponent(async () => (await import("./MarkdownRenderer.vue")).default);
 
 const TOOL_PAYLOAD_DISPLAY_LIMIT = 1000;
 const JSON_STRING_DISPLAY_LIMIT = 200;

--- a/packages/client/src/components/hermes/chat/SessionSearchModal.vue
+++ b/packages/client/src/components/hermes/chat/SessionSearchModal.vue
@@ -211,6 +211,7 @@ watch(
     await nextTick()
     inputRef.value?.focus?.()
   },
+  { immediate: true },
 )
 
 watch(query, (value) => {

--- a/packages/client/src/components/hermes/files/FilePreview.vue
+++ b/packages/client/src/components/hermes/files/FilePreview.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed, h } from 'vue'
+import { computed, defineAsyncComponent, h } from 'vue'
 import { NButton, NIcon, useMessage } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import { useFilesStore } from '@/stores/hermes/files'
 import { getFileDownloadUrl } from '@/api/hermes/files'
-import MarkdownRenderer from '@/components/hermes/chat/MarkdownRenderer.vue'
 import { handleCodeBlockCopyClick, renderHighlightedCodeBlock } from '@/components/hermes/chat/highlight'
+
+const MarkdownRenderer = defineAsyncComponent(async () => (await import('@/components/hermes/chat/MarkdownRenderer.vue')).default)
 
 const { t } = useI18n()
 const message = useMessage()

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, defineAsyncComponent, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useMessage } from 'naive-ui'
-import MarkdownRenderer from '../chat/MarkdownRenderer.vue'
 import ProfileAvatar from '@/components/hermes/profiles/ProfileAvatar.vue'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import {
@@ -19,6 +18,8 @@ import { speedToEdgeRate, hzToEdgePitch } from '@/utils/ttsHelpers'
 import { getDownloadUrl } from '@/api/hermes/download'
 import { formatChatTimestamp } from '@/utils/chat-timestamp'
 import type { ChatMessage, RoomAgent, MemberInfo } from '@/api/hermes/group-chat'
+
+const MarkdownRenderer = defineAsyncComponent(async () => (await import('../chat/MarkdownRenderer.vue')).default)
 
 const TOOL_PAYLOAD_DISPLAY_LIMIT = 1000
 const JSON_STRING_DISPLAY_LIMIT = 200

--- a/packages/client/src/components/hermes/jobs/JobRunHistory.vue
+++ b/packages/client/src/components/hermes/jobs/JobRunHistory.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { ref, watch, computed } from 'vue'
+import { ref, watch, computed, defineAsyncComponent } from 'vue'
 import { NSpin, NEmpty, NCollapse, NCollapseItem } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import { listCronRuns, readCronRun } from '@/api/hermes/cron-history'
 import type { RunEntry, RunDetail } from '@/api/hermes/cron-history'
-import MarkdownRenderer from '@/components/hermes/chat/MarkdownRenderer.vue'
+
+const MarkdownRenderer = defineAsyncComponent(async () => (await import('@/components/hermes/chat/MarkdownRenderer.vue')).default)
 
 const props = defineProps<{
   selectedJobId: string | null

--- a/packages/client/src/components/hermes/skills/PendingWriteApprovals.vue
+++ b/packages/client/src/components/hermes/skills/PendingWriteApprovals.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, defineAsyncComponent, onMounted, ref } from 'vue'
 import { NButton, NTag, useMessage } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
-import MarkdownRenderer from '@/components/hermes/chat/MarkdownRenderer.vue'
 import {
   approvePendingWrite,
   fetchPendingWriteReview,
@@ -11,6 +10,8 @@ import {
   type PendingWriteReview,
   type PendingWriteRecord,
 } from '@/api/hermes/write-gate'
+
+const MarkdownRenderer = defineAsyncComponent(async () => (await import('@/components/hermes/chat/MarkdownRenderer.vue')).default)
 
 const emit = defineEmits<{
   (e: 'count-change', count: number): void

--- a/packages/client/src/components/hermes/skills/SkillDetail.vue
+++ b/packages/client/src/components/hermes/skills/SkillDetail.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
-import MarkdownRenderer from '@/components/hermes/chat/MarkdownRenderer.vue'
+import { computed, defineAsyncComponent, ref, watch } from 'vue'
 import { fetchSkillContent, fetchSkillFiles, pinSkillApi, saveSkillContent, type SkillFileEntry, type SkillTarget } from '@/api/hermes/skills'
 import { useI18n } from 'vue-i18n'
 import { useMessage } from 'naive-ui'
+
+const MarkdownRenderer = defineAsyncComponent(async () => (await import('@/components/hermes/chat/MarkdownRenderer.vue')).default)
 
 const { t } = useI18n()
 const message = useMessage()

--- a/packages/client/src/components/layout/LanguageSwitch.vue
+++ b/packages/client/src/components/layout/LanguageSwitch.vue
@@ -18,9 +18,8 @@ const options = [
   { label: 'Русский', value: 'ru' },
 ]
 
-function handleChange(val: string) {
-  switchLocale(val)
-  localStorage.setItem('hermes_locale', val)
+async function handleChange(val: string) {
+  await switchLocale(val)
 }
 </script>
 

--- a/packages/client/src/composables/useKeyboard.ts
+++ b/packages/client/src/composables/useKeyboard.ts
@@ -1,11 +1,9 @@
 import { onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { useChatStore } from '@/stores/hermes/chat'
 import { useSessionSearch } from './useSessionSearch'
 
 export function useKeyboard() {
   const router = useRouter()
-  const chatStore = useChatStore()
   const { sessionSearchOpen, openSessionSearch, closeSessionSearch } = useSessionSearch()
 
   function handleKeydown(e: KeyboardEvent) {
@@ -13,7 +11,9 @@ export function useKeyboard() {
 
     if (mod && e.key === 'n') {
       e.preventDefault()
-      chatStore.newChat()
+      void import('@/stores/hermes/chat').then(({ useChatStore }) => {
+        useChatStore().newChat()
+      })
       return
     }
 

--- a/packages/client/src/i18n/index.ts
+++ b/packages/client/src/i18n/index.ts
@@ -1,5 +1,5 @@
 import { createI18n } from 'vue-i18n'
-import { messages, supportedLocales } from './messages'
+import { loadLocaleMessages, mergeMessagesWithFallback, supportedLocales } from './messages'
 import type { SupportedLocale } from './messages'
 
 const saved = localStorage.getItem('hermes_locale')
@@ -40,14 +40,54 @@ function setHtmlLang(locale: SupportedLocale) {
 const locale = resolveLocale(saved)
 setHtmlLang(locale)
 
-export const i18n = createI18n({
-  legacy: false,
-  locale,
-  fallbackLocale: 'en',
-  messages,
-})
+async function createAppI18n() {
+  const englishMessagesPromise = loadLocaleMessages('en')
+  const localeMessagesPromise = locale === 'en'
+    ? englishMessagesPromise
+    : loadLocaleMessages(locale)
+  const [englishMessages, localeMessages] = await Promise.all([
+    englishMessagesPromise,
+    localeMessagesPromise,
+  ])
+  const initialMessages = locale === 'en'
+    ? { en: englishMessages }
+    : {
+        en: englishMessages,
+        [locale]: mergeMessagesWithFallback(englishMessages, localeMessages),
+      }
 
-export function switchLocale(newLocale: string): void {
-  ;(i18n.global.locale as any).value = newLocale
-  setHtmlLang(newLocale as SupportedLocale)
+  return createI18n({
+    legacy: false,
+    locale,
+    fallbackLocale: 'en',
+    messages: initialMessages,
+  })
+}
+
+export const i18nReady = createAppI18n()
+
+let localeSwitchSequence = 0
+
+export async function switchLocale(newLocale: string): Promise<void> {
+  if (!(supportedLocales as readonly string[]).includes(newLocale)) return
+
+  const i18n = await i18nReady
+  const globalI18n = i18n.global as any
+  const nextLocale = newLocale as SupportedLocale
+  const sequence = ++localeSwitchSequence
+  if (!(globalI18n.availableLocales as readonly string[]).includes(nextLocale)) {
+    const nextMessages = await loadLocaleMessages(nextLocale)
+    if (sequence !== localeSwitchSequence) return
+    globalI18n.setLocaleMessage(
+      nextLocale,
+      nextLocale === 'en'
+        ? nextMessages
+        : mergeMessagesWithFallback(globalI18n.getLocaleMessage('en'), nextMessages),
+    )
+  }
+
+  if (sequence !== localeSwitchSequence) return
+  globalI18n.locale.value = nextLocale
+  setHtmlLang(nextLocale)
+  localStorage.setItem('hermes_locale', nextLocale)
 }

--- a/packages/client/src/i18n/messages.ts
+++ b/packages/client/src/i18n/messages.ts
@@ -1,14 +1,3 @@
-import en from './locales/en'
-import zh from './locales/zh'
-import zhTW from './locales/zh-TW'
-import ja from './locales/ja'
-import ko from './locales/ko'
-import fr from './locales/fr'
-import es from './locales/es'
-import de from './locales/de'
-import pt from './locales/pt'
-import ru from './locales/ru'
-
 export type LocaleMessages = Record<string, any>
 
 export const supportedLocales = ['en', 'zh', 'zh-TW', 'ja', 'ko', 'fr', 'es', 'de', 'pt', 'ru'] as const
@@ -34,11 +23,31 @@ export function mergeMessagesWithFallback(
   return merged
 }
 
-const rawMessages: Record<string, LocaleMessages> = { en, zh, 'zh-TW': zhTW, ja, ko, fr, es, de, pt, ru }
-
-export const messages: Record<string, LocaleMessages> = {}
-for (const [locale, msg] of Object.entries(rawMessages)) {
-  messages[locale] = locale === 'en' ? msg : mergeMessagesWithFallback({ ...en }, { ...msg })
+const localeLoaders: Record<SupportedLocale, () => Promise<{ default: LocaleMessages }>> = {
+  en: () => import('./locales/en'),
+  zh: () => import('./locales/zh'),
+  'zh-TW': () => import('./locales/zh-TW'),
+  ja: () => import('./locales/ja'),
+  ko: () => import('./locales/ko'),
+  fr: () => import('./locales/fr'),
+  es: () => import('./locales/es'),
+  de: () => import('./locales/de'),
+  pt: () => import('./locales/pt'),
+  ru: () => import('./locales/ru'),
 }
 
-export { en }
+const localeMessagePromises = new Map<SupportedLocale, Promise<LocaleMessages>>()
+
+export function loadLocaleMessages(locale: SupportedLocale): Promise<LocaleMessages> {
+  const existing = localeMessagePromises.get(locale)
+  if (existing) return existing
+
+  const pending = localeLoaders[locale]()
+    .then(module => module.default)
+    .catch((error) => {
+      localeMessagePromises.delete(locale)
+      throw error
+    })
+  localeMessagePromises.set(locale, pending)
+  return pending
+}

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -1,10 +1,9 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import router from './router'
-import { i18n } from './i18n'
+import { i18nReady } from './i18n'
 import App from './App.vue'
 import './styles/global.scss'
-import 'katex/dist/katex.min.css'
 import { desktopBridge } from '@/utils/desktop-bridge'
 
 // Apply theme classes before mount to prevent FOUC (Flash of Unstyled Content)
@@ -43,10 +42,14 @@ if (urlToken) {
   ;(window as any).__LOGIN_TOKEN__ = urlToken
 }
 
-const app = createApp(App)
-app.use(createPinia())
-app.use(i18n)
-app.use(router)
-router.isReady().finally(() => {
+async function mountApp(): Promise<void> {
+  const i18n = await i18nReady
+  const app = createApp(App)
+  app.use(createPinia())
+  app.use(i18n)
+  app.use(router)
+  await router.isReady().catch(() => undefined)
   app.mount('#app')
-})
+}
+
+void mountApp()

--- a/packages/client/src/views/hermes/MemoryView.vue
+++ b/packages/client/src/views/hermes/MemoryView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, computed, defineAsyncComponent } from 'vue'
 import { NButton, useMessage } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
-import MarkdownRenderer from '@/components/hermes/chat/MarkdownRenderer.vue'
 import { fetchMemory, saveMemory, type MemoryData } from '@/api/hermes/skills'
 import { useProfilesStore } from '@/stores/hermes/profiles'
+
+const MarkdownRenderer = defineAsyncComponent(async () => (await import('@/components/hermes/chat/MarkdownRenderer.vue')).default)
 
 const { t } = useI18n()
 const message = useMessage()

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,7 +5,7 @@ import bodyParser from '@koa/bodyparser'
 import serve from 'koa-static'
 import send from 'koa-send'
 import os from 'os'
-import { resolve } from 'path'
+import { relative, resolve } from 'path'
 import { mkdir } from 'fs/promises'
 import { readFileSync } from 'fs'
 import { config, shouldCreateWebUiDataDir } from './config'
@@ -31,6 +31,7 @@ import { WorkflowSocketServer } from './services/workflow-socket'
 import { PetStateSocketServer } from './services/hermes/pet-state-socket'
 import { logger } from './services/logger'
 import { createStaticCompressionMiddleware } from './middleware/static-compression'
+import { getStaticCacheControl, SPA_ENTRY_CACHE_CONTROL } from './middleware/static-cache'
 import { requireUserJwt, resolveUserProfile } from './middleware/user-auth'
 import { createCorsOriginResolver, securityHeaders } from './security'
 import type { ShutdownHandler } from './services/shutdown'
@@ -310,12 +311,18 @@ export async function bootstrap() {
   // SPA fallback
   const distDir = resolve(__dirname, '..', 'client')
   app.use(createStaticCompressionMiddleware())
-  app.use(serve(distDir))
+  app.use(serve(distDir, {
+    setHeaders(res, filePath) {
+      const cacheControl = getStaticCacheControl(relative(distDir, filePath))
+      if (cacheControl) res.setHeader('Cache-Control', cacheControl)
+    },
+  }))
   app.use(async (ctx) => {
     if (!ctx.path.startsWith('/api') &&
       ctx.path !== '/health' &&
       ctx.path !== '/upload' &&
       ctx.path !== '/webhook') {
+      ctx.set('Cache-Control', SPA_ENTRY_CACHE_CONTROL)
       await send(ctx, 'index.html', { root: distDir })
     }
   })

--- a/packages/server/src/middleware/static-cache.ts
+++ b/packages/server/src/middleware/static-cache.ts
@@ -1,0 +1,9 @@
+export const IMMUTABLE_ASSET_CACHE_CONTROL = 'public, max-age=31536000, immutable'
+export const SPA_ENTRY_CACHE_CONTROL = 'no-cache'
+
+export function getStaticCacheControl(relativePath: string): string | null {
+  const normalizedPath = relativePath.replaceAll('\\', '/').replace(/^\.\//, '')
+  if (normalizedPath === 'index.html') return SPA_ENTRY_CACHE_CONTROL
+  if (normalizedPath.startsWith('assets/')) return IMMUTABLE_ASSET_CACHE_CONTROL
+  return null
+}

--- a/tests/client/app-web-pet.test.ts
+++ b/tests/client/app-web-pet.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const routeMock = vi.hoisted(() => ({ name: 'hermes.chat' as string }))
@@ -99,8 +99,9 @@ describe('App web pet mounting', () => {
     delete (window as WindowWithDesktop).hermesDesktop
   })
 
-  it('mounts the web pet in the browser web app', () => {
+  it('mounts the web pet in the browser web app', async () => {
     const wrapper = mountApp()
+    await flushPromises()
 
     expect(wrapper.findComponent({ name: 'WebPet' }).exists()).toBe(true)
   })

--- a/tests/client/i18n-coverage.test.ts
+++ b/tests/client/i18n-coverage.test.ts
@@ -3,7 +3,7 @@ import { readdirSync, readFileSync } from 'fs'
 import { join, relative } from 'path'
 
 import { changelog } from '@/data/changelog'
-import { messages, supportedLocales } from '@/i18n/messages'
+import { mergeMessagesWithFallback, supportedLocales } from '@/i18n/messages'
 import en from '@/i18n/locales/en'
 import zh from '@/i18n/locales/zh'
 import zhTW from '@/i18n/locales/zh-TW'
@@ -31,6 +31,13 @@ const rawMessages: Record<string, Record<string, unknown>> = {
   de,
   pt,
   ru,
+}
+
+const messages: Record<string, Record<string, unknown>> = {}
+for (const [locale, localeMessages] of Object.entries(rawMessages)) {
+  messages[locale] = locale === 'en'
+    ? localeMessages
+    : mergeMessagesWithFallback(en, localeMessages)
 }
 
 function walkFiles(dir: string, files: string[] = []): string[] {

--- a/tests/client/i18n-lazy-loading.test.ts
+++ b/tests/client/i18n-lazy-loading.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('i18n lazy loading', () => {
+  afterEach(() => {
+    localStorage.removeItem('hermes_locale')
+    vi.resetModules()
+  })
+
+  it('loads only the initial locale and adds another locale on demand', async () => {
+    localStorage.setItem('hermes_locale', 'en')
+    vi.resetModules()
+
+    const { i18nReady, switchLocale } = await import('@/i18n')
+    const i18n = await i18nReady
+
+    expect(i18n.global.availableLocales).toEqual(['en'])
+
+    await switchLocale('zh')
+
+    expect(i18n.global.availableLocales).toEqual(['en', 'zh'])
+    expect(i18n.global.locale.value).toBe('zh')
+    expect(document.documentElement.lang).toBe('zh')
+    expect(localStorage.getItem('hermes_locale')).toBe('zh')
+    expect(i18n.global.t('common.cancel')).not.toBe('common.cancel')
+  })
+})

--- a/tests/server/static-cache.test.ts
+++ b/tests/server/static-cache.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getStaticCacheControl,
+  IMMUTABLE_ASSET_CACHE_CONTROL,
+  SPA_ENTRY_CACHE_CONTROL,
+} from '../../packages/server/src/middleware/static-cache'
+
+describe('static cache headers', () => {
+  it('caches fingerprinted build assets as immutable', () => {
+    expect(getStaticCacheControl('assets/js/index-abc123.js')).toBe(IMMUTABLE_ASSET_CACHE_CONTROL)
+    expect(getStaticCacheControl('assets\\css\\index-abc123.css')).toBe(IMMUTABLE_ASSET_CACHE_CONTROL)
+  })
+
+  it('revalidates the SPA entry and leaves public assets unchanged', () => {
+    expect(getStaticCacheControl('index.html')).toBe(SPA_ENTRY_CACHE_CONTROL)
+    expect(getStaticCacheControl('logo.png')).toBeNull()
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,28 +55,6 @@ export default defineConfig({
     cssCodeSplit: true,
     rollupOptions: {
       output: {
-        // Manual chunk splitting to speed up rendering
-        manualChunks(id) {
-          // Separate large heavy packages to avoid blocking other chunks
-          if (id.includes('node_modules/monaco-editor')) {
-            return 'monaco-editor'
-          }
-          if (id.includes('node_modules/mermaid')) {
-            return 'mermaid'
-          }
-          if (id.includes('node_modules/@xterm')) {
-            return 'xterm'
-          }
-          if (id.includes('node_modules')) {
-            if (id.includes('vue') || id.includes('pinia') || id.includes('vue-router')) {
-              return 'vue-vendor'
-            }
-            if (id.includes('naive-ui')) {
-              return 'ui-vendor'
-            }
-            return 'vendor'
-          }
-        },
         // Optimize chunk file names for better caching
         chunkFileNames: 'assets/js/[name]-[hash].js',
         entryFileNames: 'assets/js/[name]-[hash].js',


### PR DESCRIPTION
## Summary

- preserve Vite route and dynamic-import boundaries instead of forcing dependencies into shared vendor chunks
- lazy-load inactive locales, global shell components, Markdown rendering, KaTeX styles, and other optional UI
- retain the full syntax-highlighting catalog while keeping heavy rendering code out of the entry preload graph
- add immutable caching for hashed assets and no-cache behavior for the SPA entry document
- keep the existing logo and favicon unchanged

## Why

The previous manual chunk configuration pulled Mermaid and large shared vendor chunks into the initial module preload graph. This made the browser download and parse code that was not required to render the first screen and also produced a circular vendor/Mermaid dependency.

For a Chinese locale startup, the compressed startup JavaScript measured approximately 388 KB after this change, down from approximately 2.21 MB in the previous preload graph (about an 82% reduction).

## User impact

The application can render its shell after loading only the startup code and active locale. Markdown, Mermaid, Monaco, inactive locales, and optional overlays load when needed. Existing Markdown, diagram, syntax-highlighting, locale switching, search, and desktop behavior remain available.

## Validation

- `npm run build`
- `npm run harness:check`
- `npm run test` — 312 files passed, 2371 tests passed, 2 skipped
- `npm run test:e2e` — 33 tests passed
- production build entry contains no heavy `modulepreload` links
- local development client, health endpoint, and optimized `highlight.js` dependency return HTTP 200

Closes #2061
