### PR TITLE
fix: replay chat fade on session switch

### DIFF
--- a/docs/chat-chain-changes/2026-07-14-chat-session-surface-fade.md
+++ b/docs/chat-chain-changes/2026-07-14-chat-session-surface-fade.md
@@ -1,0 +1,10 @@
+---
+date: 2026-07-14
+pr: pending
+feature: Chat session surface fade
+impact: Switching sessions replays the fade across both the conversation and input without remounting either component.
+---
+
+The persistent chat surface now replays its existing fade animation when the
+active session changes. The input component stays mounted so drafts, focus, and
+other local input state are preserved during the transition.

--- a/docs/chat-chain-changes/2026-07-14-chat-session-surface-fade.md
+++ b/docs/chat-chain-changes/2026-07-14-chat-session-surface-fade.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-07-14
-pr: pending
+pr: 2069
 feature: Chat session surface fade
 impact: Switching sessions replays the fade across both the conversation and input without remounting either component.
 ---

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -55,6 +55,8 @@ const showRealtimeVoice = ref(false);
 const messageListRef = ref<InstanceType<typeof MessageList> | null>(null);
 const chatInputRef = ref<(InstanceType<typeof ChatInput> & { addFiles?: (files: File[]) => void }) | null>(null);
 const chatContentWrapperRef = ref<HTMLElement | null>(null);
+const chatMainContentRef = ref<HTMLElement | null>(null);
+let sessionFadeAnimation: Animation | null = null;
 const chatDropCounter = ref(0);
 const isChatDropActive = ref(false);
 const showToolPanel = ref(false);
@@ -249,11 +251,37 @@ onMounted(() => {
   }
 });
 
+watch(
+  () => chatStore.activeSessionId,
+  async (sessionId, previousSessionId) => {
+    if (!sessionId || !previousSessionId || sessionId === previousSessionId) return;
+
+    await nextTick();
+    const surface = chatMainContentRef.value;
+    if (!surface || typeof surface.animate !== "function") return;
+
+    sessionFadeAnimation?.cancel();
+    sessionFadeAnimation = surface.animate(
+      [
+        { opacity: 0 },
+        { opacity: 1 },
+      ],
+      {
+        duration: 1500,
+        easing: "ease",
+      },
+    );
+  },
+  { flush: "post" },
+);
+
 onUnmounted(() => {
   mobileQuery?.removeEventListener("change", handleMobileChange);
   window.removeEventListener("hermes:open-page-sidebar", openPageSidebar);
   window.removeEventListener("resize", handleToolPanelViewportResize);
   stopToolResize();
+  sessionFadeAnimation?.cancel();
+  sessionFadeAnimation = null;
 });
 watch(showToolPanel, async (visible) => {
   if (!visible || isMobile.value) return;
@@ -1964,7 +1992,7 @@ async function handleSessionModelCustomSubmit() {
           @dragleave="handleChatDragLeave"
           @drop="handleChatDrop"
         >
-          <div class="chat-main-content">
+          <div ref="chatMainContentRef" class="chat-main-content">
             <MessageList
               ref="messageListRef"
               :approval-portal-to-body="showRealtimeVoice"

--- a/tests/client/chat-panel-session-click.test.ts
+++ b/tests/client/chat-panel-session-click.test.ts
@@ -9,6 +9,16 @@ describe('ChatPanel session clicks', () => {
     expect(source).toContain('await chatStore.switchSession(sessionId)')
   })
 
+  it('replays the whole chat surface fade without remounting the input', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+
+    expect(source).toContain('ref="chatMainContentRef" class="chat-main-content"')
+    expect(source).toContain('() => chatStore.activeSessionId')
+    expect(source).toContain('sessionFadeAnimation = surface.animate(')
+    expect(source).toContain('sessionFadeAnimation?.cancel()')
+    expect(source).not.toContain(':key="chatStore.activeSessionId" class="chat-main-content"')
+  })
+
   it('allows session model switching for coding agent sessions', () => {
     const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
 


### PR DESCRIPTION
## Summary

- replay the existing 1.5-second fade across the whole chat surface whenever the active session changes
- keep both the message list and chat input mounted during the transition
- cancel an in-flight fade before starting another and clean it up when the panel unmounts
- add regression coverage and a chat-chain change fragment

## Root cause

The fade was moved from the session-keyed message list to the persistent chat surface when virtual scrolling was removed. That placement correctly includes both the conversation and input, but the persistent container only ran its CSS animation on the initial mount, so session switches no longer replayed the effect.

## User impact

Switching between conversations now fades the message list and input together. The input is not remounted, so drafts, focus, attachments, and other local input state are preserved.

## Validation

- `npm run test -- tests/client/chat-panel-session-click.test.ts tests/client/chat-input-draft.test.ts tests/client/message-list-scroll-position.test.ts` — 23 tests passed
- `npm run build`
- `git diff --check`
