### PR TITLE
[codex] inject Ekko provider and model context

### DIFF
--- a/docs/chat-chain-changes/2026-07-14-ekko-agent-model-context.md
+++ b/docs/chat-chain-changes/2026-07-14-ekko-agent-model-context.md
@@ -1,0 +1,10 @@
+---
+date: 2026-07-14
+pr: 2071
+feature: Ekko Agent provider and model context
+impact: Ekko Agent system prompts now identify the provider and model used by the current run.
+---
+
+The Ekko Agent runtime resolves the active provider from the per-run model client
+and the active model from run-level model settings, then includes both values in
+the system prompt's `Runtime Context` section alongside workspace paths.

--- a/packages/ekko-agent/src/runtime/runtime.ts
+++ b/packages/ekko-agent/src/runtime/runtime.ts
@@ -284,13 +284,20 @@ export class AgentRuntime {
     const normalized = normalizeAgentMessages(input.messages)
     const userSystemMessages = normalized.filter(message => message.role === 'system').map(message => message.content)
     const nonSystemMessages = normalized.filter(message => message.role !== 'system')
+    const modelClient = this.modelClientFor(input)
+    const toolContext = input.toolContext ?? this.toolContext
     const systemPrompt = buildSystemPrompt({
       basePrompt: input.systemPrompt ?? this.systemPrompt,
       runtimeInstructions: this.runtimeInstructions,
       userSystemMessages,
       skills,
       memoryContext,
-      context: input.toolContext ?? this.toolContext,
+      context: {
+        provider: modelClient.provider,
+        model: input.model ?? input.modelDefaults?.model ?? this.modelDefaults?.model,
+        cwd: toolContext?.cwd,
+        workspaceRoot: toolContext?.workspaceRoot,
+      },
     })
 
     return [

--- a/packages/ekko-agent/src/runtime/system-prompt.ts
+++ b/packages/ekko-agent/src/runtime/system-prompt.ts
@@ -7,6 +7,8 @@ export interface SystemPromptInput {
   skills?: AgentSkill[]
   memoryContext?: string
   context?: {
+    provider?: string
+    model?: string
     cwd?: string
     workspaceRoot?: string
   }
@@ -22,8 +24,10 @@ export function buildSystemPrompt(input: SystemPromptInput = {}): string {
     sections.push(section('Runtime Instructions', input.runtimeInstructions.filter(Boolean).join('\n')))
   }
 
-  if (input.context?.workspaceRoot || input.context?.cwd) {
+  if (input.context?.provider || input.context?.model || input.context?.workspaceRoot || input.context?.cwd) {
     const lines = [
+      input.context.provider ? `provider: ${input.context.provider}` : '',
+      input.context.model ? `model: ${input.context.model}` : '',
       input.context.workspaceRoot ? `workspaceRoot: ${input.context.workspaceRoot}` : '',
       input.context.cwd ? `cwd: ${input.context.cwd}` : '',
     ].filter(Boolean)

--- a/tests/ekko-agent/runtime.test.ts
+++ b/tests/ekko-agent/runtime.test.ts
@@ -470,12 +470,14 @@ describe('ekko-agent runtime', () => {
         { role: 'system', content: 'User system.' },
         { role: 'user', content: 'Go' },
       ],
+      model: 'test-model',
     })
 
     expect(requests[0].messages[0].content).toContain('Base prompt.')
     expect(requests[0].messages[0].content).toContain('Use tools carefully.')
     expect(requests[0].messages[0].content).toContain('Review for correctness.')
     expect(requests[0].messages[0].content).toContain('User system.')
+    expect(requests[0].messages[0].content).toContain('## Runtime Context\nprovider: test\nmodel: test-model')
     expect(requests[0].messages.filter(message => message.role === 'system')).toHaveLength(1)
   })
 
@@ -541,5 +543,23 @@ describe('ekko-agent runtime', () => {
     expect(prompt).toContain('Base')
     expect(prompt).not.toContain('Available Tools')
     expect(prompt).not.toContain('read_file')
+  })
+
+  it('buildSystemPrompt includes provider and model in runtime context', () => {
+    const prompt = buildSystemPrompt({
+      basePrompt: 'Base',
+      context: {
+        provider: 'openrouter',
+        model: 'anthropic/claude-sonnet-4',
+        workspaceRoot: '/tmp/workspace',
+      },
+    })
+
+    expect(prompt).toContain([
+      '## Runtime Context',
+      'provider: openrouter',
+      'model: anthropic/claude-sonnet-4',
+      'workspaceRoot: /tmp/workspace',
+    ].join('\n'))
   })
 })


### PR DESCRIPTION
## Summary

- add provider and model fields to Ekko Agent's runtime system context
- resolve those fields from the active per-run model client and effective model setting
- cover direct prompt construction and end-to-end runtime prompt assembly
- document the chat-chain behavior change

## Why

Ekko Agent used the selected provider and model for API requests, but its system prompt only exposed workspace paths. This lets the model identify the provider and model backing the current run.

## Impact

Ekko Agent system prompts now include `provider` and `model` in the `Runtime Context` section. No existing request routing or provider configuration behavior changes.

## Validation

- `npm run test -- tests/ekko-agent/runtime.test.ts`
- `npm --prefix packages/ekko-agent run check`
- `npm run harness:check`
- `npm run build`
