### PR TITLE
fix(desktop): preserve parent PATH in terminal snapshots

### DIFF
--- a/packages/desktop/scripts/apply-hermes-patches.mjs
+++ b/packages/desktop/scripts/apply-hermes-patches.mjs
@@ -439,7 +439,7 @@ if (!localEnvironmentSource || !baseEnvironmentSource) {
 ` +
       `        # patch:local-parent-path-preserve — carry parent PATH through bash -l
 ` +
-      `        if login:
+      `        if login and not _IS_WINDOWS:
 ` +
       `            _path_key = _path_env_key(run_env)
 ` +

--- a/packages/desktop/scripts/apply-hermes-patches.mjs
+++ b/packages/desktop/scripts/apply-hermes-patches.mjs
@@ -43,6 +43,8 @@ const dingtalkPatchCandidates = [
 const dtPath = dingtalkPatchCandidates.find(path => existsSync(path))
 const browserToolPath = join(sitePkgs, 'tools', 'browser_tool.py')
 const sitecustomizePath = join(sitePkgs, 'sitecustomize.py')
+const localEnvironmentPath = join(sitePkgs, 'tools', 'environments', 'local.py')
+const baseEnvironmentPath = join(sitePkgs, 'tools', 'environments', 'base.py')
 if (!dtPath) {
   console.error(
     `DingTalk adapter not found. Checked:\n${dingtalkPatchCandidates.map(path => `  - ${path}`).join('\n')}`,
@@ -109,6 +111,23 @@ function validateSitecustomizePatches(text) {
     && !text.includes('_hermes_apply_hidden_process_options')
   ) {
     failPatchValidation('sitecustomize hidden subprocess patch marker exists but hook implementation is missing')
+  }
+}
+
+function validateParentPathPatches(localText, baseText) {
+  const localMarker = localText.includes('# patch:local-parent-path-preserve')
+  const baseMarker = baseText.includes('# patch:base-merge-parent-path')
+  if (localMarker !== baseMarker) {
+    failPatchValidation('parent PATH snapshot patches are incomplete: local and base patches must be applied together')
+  }
+  if (localMarker && !localText.includes('run_env["HERMES_INIT_PARENT_PATH"]')) {
+    failPatchValidation('local parent PATH patch marker exists but PATH capture is missing')
+  }
+  if (baseMarker && (
+    !baseText.includes('for __hermes_path_entry')
+    || !baseText.includes('unset HERMES_INIT_PARENT_PATH')
+  )) {
+    failPatchValidation('base parent PATH patch marker exists but merge or cleanup logic is missing')
   }
 }
 
@@ -401,9 +420,81 @@ function appendSitecustomizePatch(id, marker, body) {
 appendSitecustomizePatch('brotlicffi-error-compat', brotlicffiCompatMarker, brotlicffiCompat)
 appendSitecustomizePatch('desktop-hidden-subprocess-defaults', desktopHiddenSubprocessMarker, desktopHiddenSubprocessDefaults)
 
+let localEnvironmentSource = existsSync(localEnvironmentPath) ? readFileSync(localEnvironmentPath, 'utf-8') : ''
+let baseEnvironmentSource = existsSync(baseEnvironmentPath) ? readFileSync(baseEnvironmentPath, 'utf-8') : ''
+if (!localEnvironmentSource || !baseEnvironmentSource) {
+  failPatchValidation('parent PATH snapshot patch requires both local.py and base.py')
+}
+{
+  const localEnvironmentBefore = localEnvironmentSource
+  localEnvironmentSource = patchText(
+    localEnvironmentSource,
+    'local-parent-path-preserve',
+    '# patch:local-parent-path-preserve',
+    `        run_env = _make_run_env(self.env)
+
+        # Recover when the cwd has been deleted`,
+    `        run_env = _make_run_env(self.env)
+
+` +
+      `        # patch:local-parent-path-preserve — carry parent PATH through bash -l
+` +
+      `        if login:
+` +
+      `            _path_key = _path_env_key(run_env)
+` +
+      `            if _path_key is not None and _path_key in run_env:
+` +
+      `                run_env["HERMES_INIT_PARENT_PATH"] = run_env[_path_key]
+
+` +
+      `        # Recover when the cwd has been deleted`,
+  )
+  const baseEnvironmentBefore = baseEnvironmentSource
+  baseEnvironmentSource = patchText(
+    baseEnvironmentSource,
+    'base-merge-parent-path',
+    '# patch:base-merge-parent-path',
+    [
+      '        bootstrap = (',
+      '            f"export -p > {_snap_tmp}\\n"',
+    ].join('\n'),
+    [
+      '        bootstrap = (',
+      '            # patch:base-merge-parent-path — retain profile PATH and append missing parent entries',
+      "            f'if [ -n \"${{HERMES_INIT_PARENT_PATH:-}}\" ]; then\\n'",
+      "            f'  __hermes_saved_ifs=\"$IFS\"\\n'",
+      "            f'  __hermes_saved_flags=\"$-\"\\n'",
+      "            f'  IFS=:\\n'",
+      "            f'  set -f\\n'",
+      "            f'  for __hermes_path_entry in $HERMES_INIT_PARENT_PATH; do\\n'",
+      "            f'    [ -n \"$__hermes_path_entry\" ] || continue\\n'",
+      "            f'    case \":$PATH:\" in\\n'",
+      "            f'      *\":$__hermes_path_entry:\"*) ;;\\n'",
+      "            f'      *) PATH=\"${{PATH:+$PATH:}}$__hermes_path_entry\" ;;\\n'",
+      "            f'    esac\\n'",
+      "            f'  done\\n'",
+      "            f'  IFS=\"$__hermes_saved_ifs\"\\n'",
+      "            f'  case \"$__hermes_saved_flags\" in *f*) ;; *) set +f ;; esac\\n'",
+      "            f'  export PATH\\n'",
+      "            f'fi\\n'",
+      "            f'unset HERMES_INIT_PARENT_PATH __hermes_path_entry __hermes_saved_ifs __hermes_saved_flags\\n'",
+      '            f"export -p > {_snap_tmp}\\n"',
+    ].join('\n'),
+  )
+  validateParentPathPatches(localEnvironmentSource, baseEnvironmentSource)
+
+  if (localEnvironmentSource !== localEnvironmentBefore) {
+    writeFileSync(localEnvironmentPath, localEnvironmentSource)
+  }
+  if (baseEnvironmentSource !== baseEnvironmentBefore) {
+    writeFileSync(baseEnvironmentPath, baseEnvironmentSource)
+  }
+}
+
 if (existsSync(sitecustomizePath)) {
   validateSitecustomizePatches(readFileSync(sitecustomizePath, 'utf-8'))
 }
-compilePatchedPython([dtPath, browserToolPath, sitecustomizePath])
+compilePatchedPython([dtPath, browserToolPath, sitecustomizePath, localEnvironmentPath, baseEnvironmentPath])
 
 console.log(`Done. Applied ${applied}, skipped ${skipped}.`)

--- a/tests/desktop/apply-hermes-patches.test.ts
+++ b/tests/desktop/apply-hermes-patches.test.ts
@@ -1,0 +1,107 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const tempDirs: string[] = []
+
+function createFakeSitePackages(): string {
+  const root = mkdtempSync(join(tmpdir(), 'hermes-parent-path-patch-'))
+  tempDirs.push(root)
+  const envDir = join(root, 'tools', 'environments')
+  mkdirSync(envDir, { recursive: true })
+  writeFileSync(join(envDir, 'local.py'), [
+    '    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):',
+    '        args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]',
+    '        run_env = _make_run_env(self.env)',
+    '',
+    '        # Recover when the cwd has been deleted',
+    '        safe_cwd = _resolve_safe_cwd(self.cwd)',
+    '',
+  ].join('\n'))
+  writeFileSync(join(envDir, 'base.py'), [
+    '    def init_session(self):',
+    '        _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$BASHPID"',
+    '        bootstrap = (',
+    '            f"export -p > {_snap_tmp}\\n"',
+    '            f"alias -p >> {_snap_tmp}\\n"',
+    '        )',
+    '',
+  ].join('\n'))
+
+  const adapterDir = join(root, 'plugins', 'platforms', 'dingtalk')
+  mkdirSync(adapterDir, { recursive: true })
+  writeFileSync(join(adapterDir, 'adapter.py'), [
+    '# patch:dt-card-tpl-env',
+    '# patch:dt-card-before-webhook',
+    '# patch:dt-card-before-webhook-gate',
+    '# patch:dt-dm-robot-code',
+    '# patch:dt-card-autolayout',
+  ].join('\n'))
+  writeFileSync(join(root, 'sitecustomize.py'), '')
+  return root
+}
+
+function runPatch(sitePackages: string): string {
+  return execFileSync('node', [join(process.cwd(), 'packages/desktop/scripts/apply-hermes-patches.mjs')], {
+    env: {
+      ...process.env,
+      HERMES_AGENT_SITE_PACKAGES: sitePackages,
+      TARGET_OS: 'linux',
+      TARGET_ARCH: 'x64',
+    },
+    encoding: 'utf8',
+    timeout: 15_000,
+  })
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('desktop Hermes parent PATH patch', () => {
+  it('applies a paired idempotent patch that merges parent-only PATH entries before snapshot export', () => {
+    const sitePackages = createFakeSitePackages()
+
+    runPatch(sitePackages)
+
+    const local = readFileSync(join(sitePackages, 'tools', 'environments', 'local.py'), 'utf8')
+    const base = readFileSync(join(sitePackages, 'tools', 'environments', 'base.py'), 'utf8')
+    expect(local).toContain('# patch:local-parent-path-preserve')
+    expect(local).toContain('if login:')
+    expect(local).toContain('run_env["HERMES_INIT_PARENT_PATH"]')
+    expect(base).toContain('# patch:base-merge-parent-path')
+    expect(base).toContain('if [ -n "${{HERMES_INIT_PARENT_PATH:-}}" ]')
+    expect(base).toContain('for __hermes_path_entry')
+    expect(base).toContain('PATH="${{PATH:+$PATH:}}$__hermes_path_entry"')
+    expect(base.indexOf('# patch:base-merge-parent-path')).toBeLessThan(base.indexOf('export -p >'))
+    expect(base).toContain('unset HERMES_INIT_PARENT_PATH')
+
+    const firstLocal = local
+    const firstBase = base
+    const secondOutput = runPatch(sitePackages)
+    expect(secondOutput).toContain('local-parent-path-preserve  (already applied)')
+    expect(secondOutput).toContain('base-merge-parent-path  (already applied)')
+    expect(readFileSync(join(sitePackages, 'tools', 'environments', 'local.py'), 'utf8')).toBe(firstLocal)
+    expect(readFileSync(join(sitePackages, 'tools', 'environments', 'base.py'), 'utf8')).toBe(firstBase)
+  })
+
+  it('does not leave a half-applied patch when either upstream anchor changes', () => {
+    const sitePackages = createFakeSitePackages()
+    const localPath = join(sitePackages, 'tools', 'environments', 'local.py')
+    const basePath = join(sitePackages, 'tools', 'environments', 'base.py')
+    const originalLocal = readFileSync(localPath, 'utf8')
+    writeFileSync(basePath, readFileSync(basePath, 'utf8').replace('export -p >', 'export --changed >'))
+
+    expect(() => runPatch(sitePackages)).toThrow()
+    expect(readFileSync(localPath, 'utf8')).toBe(originalLocal)
+  })
+
+  it('fails closed when the Hermes environment modules are missing', () => {
+    const sitePackages = createFakeSitePackages()
+    rmSync(join(sitePackages, 'tools', 'environments'), { recursive: true, force: true })
+
+    expect(() => runPatch(sitePackages)).toThrow()
+  })
+})

--- a/tests/desktop/apply-hermes-patches.test.ts
+++ b/tests/desktop/apply-hermes-patches.test.ts
@@ -69,7 +69,7 @@ describe('desktop Hermes parent PATH patch', () => {
     const local = readFileSync(join(sitePackages, 'tools', 'environments', 'local.py'), 'utf8')
     const base = readFileSync(join(sitePackages, 'tools', 'environments', 'base.py'), 'utf8')
     expect(local).toContain('# patch:local-parent-path-preserve')
-    expect(local).toContain('if login:')
+    expect(local).toContain('if login and not _IS_WINDOWS:')
     expect(local).toContain('run_env["HERMES_INIT_PARENT_PATH"]')
     expect(base).toContain('# patch:base-merge-parent-path')
     expect(base).toContain('if [ -n "${{HERMES_INIT_PARENT_PATH:-}}" ]')


### PR DESCRIPTION
## Summary

- preserve parent-runtime PATH entries that `bash -l` would otherwise discard before the desktop Hermes terminal snapshot is written;
- keep login/profile PATH ordering, appending only parent entries that are missing;
- limit the merge to POSIX, avoiding colon-based parsing of Windows `Path` values;
- remove the temporary `HERMES_INIT_PARENT_PATH` variable before `export -p` persists the snapshot;
- apply the paired `local.py` / `base.py` patch atomically and fail closed if either module or source anchor is missing.

## Root cause

Hermes Studio desktop currently bundles `hermes-agent==0.18.0`. `LocalEnvironment` passes a completed PATH into `bash -l`, but `/etc/profile` can replace it before `BaseEnvironment.init_session()` executes `export -p`. Entries injected only by the parent runtime therefore disappear even though shell-init-file entries remain available.

## Verification

- strict RED → GREEN coverage for paired application, idempotency, missing-module fail-closed behavior, and no half-applied patch when an upstream anchor changes: `3/3` PASS;
- applied the Studio patch script to a clean copy of the packaged `hermes-agent 0.18.0` source;
- patched `local.py` and `base.py` pass `py_compile`;
- real `LocalEnvironment` snapshot probe confirms:
  - snapshot initialization completes;
  - profile PATH entries retain precedence;
  - the parent-only PATH entry appears exactly once;
  - profile and parent marker binaries are both discoverable;
  - `HERMES_INIT_PARENT_PATH` is absent from the persisted snapshot;
- `npm run harness:check`: PASS;
- `npm run build`: PASS;
- `npm run test:coverage` compared with pristine latest `main` in the same environment: `39 failed / 2342 passed / 2 skipped`, `new_failures=[]` (the same 39 environment-dependent baseline failures remain).

Supersedes the stale implementation in #1669.

Closes #2074
