### PR TITLE
fix: attach workspace diffs to assistant turns

### DIFF
--- a/docs/chat-chain-changes/2026-07-15-issue-2079-workspace-diff-turn-attribution.md
+++ b/docs/chat-chain-changes/2026-07-15-issue-2079-workspace-diff-turn-attribution.md
@@ -1,0 +1,7 @@
+---
+date: 2026-07-15
+issue: "#2079"
+pr: pending
+feature: Attach Workspace Diff summaries to the Assistant response that produced them
+impact: Coding Agent checkpoints now persist the final Assistant message ID and render as collapsed per-turn summaries inside that response; legacy or not-yet-loaded records keep the existing standalone fallback without deleting audit history.
+---

--- a/docs/chat-chain-changes/2026-07-15-issue-2079-workspace-diff-turn-attribution.md
+++ b/docs/chat-chain-changes/2026-07-15-issue-2079-workspace-diff-turn-attribution.md
@@ -3,5 +3,5 @@ date: 2026-07-15
 issue: "#2079"
 pr: "#2082"
 feature: Attach Workspace Diff summaries to the Assistant response that produced them
-impact: Coding Agent checkpoints now persist the final Assistant message ID and render as collapsed per-turn summaries inside that response; legacy or not-yet-loaded records keep the existing standalone fallback without deleting audit history.
+impact: Coding Agent checkpoints and native Hermes Agent runs now persist the final Assistant message ID and render as collapsed per-turn summaries inside that response, including workspace changes made through ordinary terminal and write_file tools; legacy or not-yet-loaded records keep the existing standalone fallback without deleting audit history.
 ---

--- a/docs/chat-chain-changes/2026-07-15-issue-2079-workspace-diff-turn-attribution.md
+++ b/docs/chat-chain-changes/2026-07-15-issue-2079-workspace-diff-turn-attribution.md
@@ -1,7 +1,7 @@
 ---
 date: 2026-07-15
 issue: "#2079"
-pr: pending
+pr: "#2082"
 feature: Attach Workspace Diff summaries to the Assistant response that produced them
 impact: Coding Agent checkpoints now persist the final Assistant message ID and render as collapsed per-turn summaries inside that response; legacy or not-yet-loaded records keep the existing standalone fallback without deleting audit history.
 ---

--- a/packages/client/src/api/hermes/sessions.ts
+++ b/packages/client/src/api/hermes/sessions.ts
@@ -114,6 +114,9 @@ export interface WorkspaceRunChangeFileDetail extends WorkspaceRunChangeFileSumm
 
 export interface WorkspaceRunChangeSummary {
   change_id: string
+  room_id?: string
+  message_id?: string
+  assistant_message_id?: string
   session_id: string
   run_id: string
   source: 'run'

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -22,7 +22,7 @@ import { useGlobalSpeech } from "@/composables/useSpeech";
 import { useVoiceSettings } from "@/composables/useVoiceSettings";
 import { speedToEdgeRate, hzToEdgePitch } from "@/utils/ttsHelpers";
 import { formatChatTimestamp } from "@/utils/chat-timestamp";
-import type { WorkspaceRunChangeFileSummary } from "@/api/hermes/sessions";
+import type { WorkspaceRunChangeFileSummary, WorkspaceRunChangeSummary } from "@/api/hermes/sessions";
 
 const FileEditor = defineAsyncComponent(() => import("@/components/hermes/files/FileEditor.vue"));
 const MarkdownRenderer = defineAsyncComponent(async () => (await import("./MarkdownRenderer.vue")).default);
@@ -183,6 +183,8 @@ function getContentFileUrl(file: DisplayContentFile): string {
 }
 
 const toolExpanded = ref(false);
+const expandedWorkspaceChangeIds = ref(new Set<string>());
+const activeToolChange = ref<WorkspaceRunChangeSummary | null>(null);
 const previewUrl = ref<string | null>(null);
 const selectedToolChangeFileId = ref<number | null>(null);
 const selectedToolChangePatch = ref("");
@@ -553,7 +555,19 @@ const hasAttachments = computed(
 const toolArgsPayload = computed(() => formatToolPayload(props.message.toolArgs));
 const toolResultPayload = computed(() => formatToolPayload(props.message.toolResult, true));
 const toolChange = computed(() => props.message.toolChange || null);
+const workspaceChanges = computed(() => props.message.workspaceChanges || []);
 const hasToolChange = computed(() => (toolChange.value?.files?.length || 0) > 0);
+
+function isWorkspaceChangeExpanded(changeId: string): boolean {
+  return expandedWorkspaceChangeIds.value.has(changeId);
+}
+
+function toggleWorkspaceChange(changeId: string): void {
+  const next = new Set(expandedWorkspaceChangeIds.value);
+  if (next.has(changeId)) next.delete(changeId);
+  else next.add(changeId);
+  expandedWorkspaceChangeIds.value = next;
+}
 
 const hasToolDetails = computed(
   () => !!(toolArgsPayload.value.full || toolResultPayload.value.full || hasToolChange.value),
@@ -621,14 +635,18 @@ const selectedToolChangeFileName = computed(() =>
 
 const selectedToolChangeAbsolutePath = computed(() => {
   const file = toolChangeDrawerFile.value;
-  const workspace = toolChange.value?.workspace || "";
+  const workspace = activeToolChange.value?.workspace || toolChange.value?.workspace || "";
   if (!file || !workspace) return file?.path || "";
   const separator = workspace.includes("\\") && !workspace.includes("/") ? "\\" : "/";
   const cleanWorkspace = workspace.replace(/[\\/]+$/, "");
   return `${cleanWorkspace}${separator}${file.path}`;
 });
 
-async function openToolChangeFile(file: WorkspaceRunChangeFileSummary): Promise<void> {
+async function openToolChangeFile(
+  file: WorkspaceRunChangeFileSummary,
+  change: WorkspaceRunChangeSummary | null = toolChange.value,
+): Promise<void> {
+  activeToolChange.value = change;
   selectedToolChangeFileId.value = file.id;
   toolChangeDrawerFile.value = file;
   toolChangeDrawerMode.value = "diff";
@@ -649,7 +667,7 @@ async function openToolChangeFile(file: WorkspaceRunChangeFileSummary): Promise<
 
 async function editSelectedToolChangeFile(): Promise<void> {
   const file = toolChangeDrawerFile.value;
-  const sessionId = toolChange.value?.session_id || props.message.toolChange?.session_id || "";
+  const sessionId = activeToolChange.value?.session_id || toolChange.value?.session_id || props.message.toolChange?.session_id || "";
   if (!file || !sessionId) return;
   isLoadingToolChangePatch.value = true;
   try {
@@ -672,6 +690,7 @@ function closeToolChangeDrawer() {
   if (filesStore.editingFile?.path === selectedToolChangeAbsolutePath.value && !filesStore.hasUnsavedChanges) {
     filesStore.closeEditor();
   }
+  activeToolChange.value = null;
 }
 
 function closeToolChangeEditor() {
@@ -1162,6 +1181,57 @@ onBeforeUnmount(() => {
               :heading-id-prefix="effectiveHeadingIdPrefix"
             />
 
+            <div
+              v-for="change in workspaceChanges"
+              :key="change.change_id"
+              class="tool-change-card assistant-workspace-change"
+              @click="handleToolDetailClick"
+            >
+              <button
+                class="tool-change-card-header"
+                type="button"
+                :aria-expanded="isWorkspaceChangeExpanded(change.change_id)"
+                @click.stop="toggleWorkspaceChange(change.change_id)"
+              >
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  class="tool-change-chevron"
+                  :class="{ rotated: isWorkspaceChangeExpanded(change.change_id) }"
+                >
+                  <polyline points="9 18 15 12 9 6" />
+                </svg>
+                <span class="tool-change-card-title">{{ t("chat.changesThisTurn") }}</span>
+                <span class="tool-change-card-file-count">{{ t("chat.changedFiles", { files: change.files_changed || 0 }) }}</span>
+                <span class="tool-change-card-stats">
+                  <span class="additions">+{{ change.additions || 0 }}</span>
+                  <span class="deletions">-{{ change.deletions || 0 }}</span>
+                </span>
+              </button>
+              <div v-if="isWorkspaceChangeExpanded(change.change_id)" class="tool-change-files">
+                <button
+                  v-for="file in change.files || []"
+                  :key="file.id"
+                  class="tool-change-file-row"
+                  :class="{ selected: selectedToolChangeFileId === file.id }"
+                  type="button"
+                  @click.stop="openToolChangeFile(file, change)"
+                >
+                  <span class="tool-change-file-main">
+                    <span class="tool-change-file-badge" :class="fileBadgeClass(file.path)">{{ fileExtension(file.path) }}</span>
+                    <span class="tool-change-file-name" :title="file.path">{{ fileNameFromPath(file.path) }}</span>
+                  </span>
+                  <span class="tool-change-file-stats">
+                    <span class="additions">+{{ file.additions }}</span>
+                    <span class="deletions">-{{ file.deletions }}</span>
+                  </span>
+                </button>
+              </div>
+            </div>
             <!-- Render system message content -->
             <MarkdownRenderer
               v-if="message.role === 'system' && message.content && !isCommandMessage"
@@ -1920,6 +1990,16 @@ onBeforeUnmount(() => {
 .tool-change-card-title {
   font-size: 13px;
   font-weight: 700;
+}
+
+.tool-change-card-file-count {
+  color: $text-muted;
+  font-size: 12px;
+}
+
+.assistant-workspace-change {
+  margin-top: 10px;
+  padding: 8px 10px;
 }
 
 .tool-change-card-stats,

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -639,6 +639,7 @@ export default {
     result: 'Ergebnis',
     workspaceChanges: 'Workspace-Änderungen',
     changedFiles: '{files} Dateien geändert',
+    changesThisTurn: 'Änderungen in diesem Durchgang',
     diffUnavailable: 'Diff nicht verfügbar',
     binaryFileDiffUnavailable: 'Diff für Binärdateien nicht verfügbar',
     truncated: '... (abgeschnitten)',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -729,6 +729,7 @@ export default {
     result: 'Result',
     workspaceChanges: 'Workspace changes',
     changedFiles: '{files} files changed',
+    changesThisTurn: 'Changes this turn',
     diffUnavailable: 'Diff unavailable',
     binaryFileDiffUnavailable: 'Binary file diff unavailable',
     truncated: '... (truncated)',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -639,6 +639,7 @@ export default {
     result: 'Resultado',
     workspaceChanges: 'Cambios del workspace',
     changedFiles: '{files} archivos modificados',
+    changesThisTurn: 'Cambios de este turno',
     diffUnavailable: 'Diff no disponible',
     binaryFileDiffUnavailable: 'Diff no disponible para archivos binarios',
     truncated: '... (truncado)',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -639,6 +639,7 @@ export default {
     result: 'Resultat',
     workspaceChanges: 'Modifications du workspace',
     changedFiles: '{files} fichiers modifies',
+    changesThisTurn: 'Modifications de ce tour',
     diffUnavailable: 'Diff indisponible',
     binaryFileDiffUnavailable: 'Diff indisponible pour les fichiers binaires',
     truncated: '... (tronque)',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -639,6 +639,7 @@ export default {
     result: '結果',
     workspaceChanges: 'ワークスペース変更',
     changedFiles: '{files} ファイルを変更',
+    changesThisTurn: 'このターンの変更',
     diffUnavailable: 'diff を表示できません',
     binaryFileDiffUnavailable: 'バイナリファイルの diff は表示できません',
     truncated: '... (省略)',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -639,6 +639,7 @@ export default {
     result: '결과',
     workspaceChanges: '작업공간 변경',
     changedFiles: '{files}개 파일 변경됨',
+    changesThisTurn: '이번 턴의 변경 사항',
     diffUnavailable: 'diff를 표시할 수 없습니다',
     binaryFileDiffUnavailable: '바이너리 파일 diff를 표시할 수 없습니다',
     truncated: '... (잘림)',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -639,6 +639,7 @@ export default {
     result: 'Resultado',
     workspaceChanges: 'Alterações do workspace',
     changedFiles: '{files} arquivos alterados',
+    changesThisTurn: 'Alterações desta rodada',
     diffUnavailable: 'Diff indisponível',
     binaryFileDiffUnavailable: 'Diff indisponível para arquivos binários',
     truncated: '... (truncado)',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -608,6 +608,7 @@ export default {
     result: 'Результат',
     workspaceChanges: 'Изменения workspace',
     changedFiles: 'Изменено файлов: {files}',
+    changesThisTurn: 'Изменения в этом ходе',
     diffUnavailable: 'Diff недоступен',
     binaryFileDiffUnavailable: 'Diff для бинарного файла недоступен',
     truncated: '... (обрезано)',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -718,6 +718,7 @@ export default {
     result: '結果',
     workspaceChanges: '工作區變更',
     changedFiles: '{files} 個檔案已更改',
+    changesThisTurn: '本輪修改',
     diffUnavailable: '無法顯示 diff',
     binaryFileDiffUnavailable: '二進位檔案無法顯示 diff',
     truncated: '... (已截斷)',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -729,6 +729,7 @@ export default {
     result: '结果',
     workspaceChanges: '工作区变更',
     changedFiles: '{files} 个文件已更改',
+    changesThisTurn: '本轮修改',
     diffUnavailable: '无法显示 diff',
     binaryFileDiffUnavailable: '二进制文件无法显示 diff',
     truncated: '... (已截断)',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -70,6 +70,7 @@ export interface Message {
   toolStatus?: 'running' | 'done' | 'error'
   toolDuration?: number  // 工具执行时长（秒）
   toolChange?: WorkspaceRunChangeSummary
+  workspaceChanges?: WorkspaceRunChangeSummary[]
   isStreaming?: boolean
   attachments?: Attachment[]
   // 思考/推理文本。两条来源：
@@ -158,6 +159,48 @@ interface CompressionState {
 
 function uid(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+}
+
+export function alignWorkspaceChangeAssistantMessage(
+  messages: Message[],
+  change: WorkspaceRunChangeSummary | null | undefined,
+  assistantMessageId?: string | null,
+): string | null {
+  const currentAssistantMessageId = String(assistantMessageId || '').trim()
+  const persistedAssistantMessageId = String(change?.assistant_message_id || '').trim()
+  if (!persistedAssistantMessageId) return currentAssistantMessageId || null
+  if (!currentAssistantMessageId || persistedAssistantMessageId === currentAssistantMessageId) {
+    return messages.some(item => item.id === persistedAssistantMessageId)
+      ? persistedAssistantMessageId
+      : currentAssistantMessageId || null
+  }
+  const message = messages.find(item => item.id === currentAssistantMessageId)
+  const idAlreadyLoaded = messages.some(item => item.id === persistedAssistantMessageId)
+  if (message && !idAlreadyLoaded) {
+    message.id = persistedAssistantMessageId
+    return persistedAssistantMessageId
+  }
+  return idAlreadyLoaded ? persistedAssistantMessageId : currentAssistantMessageId
+}
+
+export function attachWorkspaceChangesToExactTurns(
+  messages: Message[],
+  changes: WorkspaceRunChangeSummary[],
+): WorkspaceRunChangeSummary[] {
+  for (const message of messages) message.workspaceChanges = []
+  const assistantById = new Map(
+    messages
+      .filter(message => message.role === 'assistant')
+      .map(message => [message.id, message]),
+  )
+  const fallback: WorkspaceRunChangeSummary[] = []
+  for (const change of changes) {
+    const assistantMessageId = String(change.assistant_message_id || '').trim()
+    const target = assistantMessageId ? assistantById.get(assistantMessageId) : undefined
+    if (target) target.workspaceChanges!.push(change)
+    else fallback.push(change)
+  }
+  return fallback
 }
 
 function isToolOutputError(output: unknown): boolean {
@@ -860,21 +903,24 @@ export const useChatStore = defineStore('chat', () => {
     const target = sessions.value.find(session => session.id === sessionId)
     if (!target) return
     const changes = workspaceRunChangesBySession.value.get(sessionId)
-    const runChanges: WorkspaceRunChangeSummary[] = []
+    const existingById = new Map(
+      target.messages
+        .filter(message => message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX))
+        .map(message => [message.id, message]),
+    )
+    target.messages = target.messages.filter(message => !message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX))
     for (const message of target.messages) {
       if (message.role === 'tool' && message.toolCallId) {
         message.toolChange = changes?.get(message.toolCallId)
       }
-      if (message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX)) {
-        const changeId = message.id.slice(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX.length)
-        message.toolChange = changes?.get(changeId)
-      }
     }
-    if (!changes) return
-    for (const change of changes.values()) {
-      if (change?.source === 'run') runChanges.push(change)
+    if (!changes) {
+      for (const message of target.messages) message.workspaceChanges = []
+      return
     }
-    insertWorkspaceRunChangeMessages(target, runChanges)
+    const runChanges = [...changes.values()].filter(change => change?.source === 'run')
+    const legacyChanges = attachWorkspaceChangesToExactTurns(target.messages, runChanges)
+    insertWorkspaceRunChangeMessages(target, legacyChanges, existingById)
   }
 
   function workspaceRunChangeMessageId(changeId: string): string {
@@ -886,7 +932,11 @@ export const useChatStore = defineStore('chat', () => {
     return Number.isFinite(seconds) && seconds > 0 ? Math.round(seconds * 1000) : Date.now()
   }
 
-  function insertWorkspaceRunChangeMessages(target: Session, changes: WorkspaceRunChangeSummary[]) {
+  function insertWorkspaceRunChangeMessages(
+    target: Session,
+    changes: WorkspaceRunChangeSummary[],
+    existingById = new Map<string, Message>(),
+  ) {
     const sortedChanges = changes
       .filter(change => change?.change_id && (change.files?.length > 0))
       .sort((a, b) => {
@@ -894,12 +944,6 @@ export const useChatStore = defineStore('chat', () => {
         return timeDelta !== 0 ? timeDelta : b.change_id.localeCompare(a.change_id)
       })
     if (!sortedChanges.length) return
-    const existingById = new Map(
-      target.messages
-        .filter(message => message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX))
-        .map(message => [message.id, message]),
-    )
-    target.messages = target.messages.filter(message => !message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX))
     for (const change of sortedChanges) {
       const messageId = workspaceRunChangeMessageId(change.change_id)
       const existing = existingById.get(messageId) || null
@@ -952,12 +996,29 @@ export const useChatStore = defineStore('chat', () => {
     attachToolChangesToMessages(sessionId)
   }
 
-  function handleWorkspaceRunChangeEvent(sessionId: string, evt: any) {
-    upsertWorkspaceRunChange(sessionId, evt?.change as WorkspaceRunChangeSummary | undefined)
+  function handleWorkspaceRunChangeEvent(
+    sessionId: string,
+    evt: any,
+    assistantMessageId?: string | null,
+  ): string | null {
+    const change = evt?.change as WorkspaceRunChangeSummary | undefined
+    const target = sessions.value.find(session => session.id === sessionId)
+    const alignedAssistantMessageId = target
+      ? alignWorkspaceChangeAssistantMessage(target.messages, change, assistantMessageId)
+      : assistantMessageId || null
+    upsertWorkspaceRunChange(sessionId, change)
+    return alignedAssistantMessageId
   }
 
-  function handleTerminalWorkspaceRunChange(sessionId: string, evt: any) {
-    upsertWorkspaceRunChange(sessionId, evt?.workspace_run_change as WorkspaceRunChangeSummary | undefined)
+  function handleTerminalWorkspaceRunChange(
+    sessionId: string,
+    evt: any,
+    assistantMessageId?: string | null,
+  ) {
+    const change = evt?.workspace_run_change as WorkspaceRunChangeSummary | undefined
+    const target = sessions.value.find(session => session.id === sessionId)
+    if (target) alignWorkspaceChangeAssistantMessage(target.messages, change, assistantMessageId)
+    upsertWorkspaceRunChange(sessionId, change)
   }
 
   function restoreWorkspaceRunChangeMessages(sessionId: string) {
@@ -2899,7 +2960,7 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'workspace.diff.completed': {
-              handleWorkspaceRunChangeEvent(sid, evt)
+              activeAssistantMessageId = handleWorkspaceRunChangeEvent(sid, evt, activeAssistantMessageId)
               break
             }
 
@@ -2933,8 +2994,6 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'run.completed': {
-              handleTerminalWorkspaceRunChange(sid, evt)
-              clearAgentEventMessages(sid)
               const msgs = getSessionMsgs(sid)
               const lastMsg = activeAssistantMessageId
                 ? msgs.find(m => m.id === activeAssistantMessageId)
@@ -2942,6 +3001,7 @@ export const useChatStore = defineStore('chat', () => {
               const completedAssistantMessageId = lastMsg?.role === 'assistant' && lastMsg.isStreaming
                 ? lastMsg.id
                 : null
+              clearAgentEventMessages(sid)
               if (lastMsg?.isStreaming) {
                 updateMessage(sid, lastMsg.id, { isStreaming: false })
               }
@@ -3047,6 +3107,11 @@ export const useChatStore = defineStore('chat', () => {
                 playCompletionBellIfEnabled()
                 showCompletionNotificationIfEnabled(sid, completedAssistantMessageId)
               }
+              const terminalAssistantMessageId = completedAssistantMessageId || [...getSessionMsgs(sid)]
+                .reverse()
+                .find(message => message.role === 'assistant' && String(message.content || '').trim())
+                ?.id
+              handleTerminalWorkspaceRunChange(sid, evt, terminalAssistantMessageId)
               attachToolChangesToMessages(sid)
 
               // 自动播放语音
@@ -3076,7 +3141,11 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'run.failed': {
-              handleTerminalWorkspaceRunChange(sid, evt)
+              const failedMessages = getSessionMsgs(sid)
+              const failedAssistant = activeAssistantMessageId
+                ? failedMessages.find(message => message.id === activeAssistantMessageId)
+                : [...failedMessages].reverse().find(message => message.role === 'assistant' && message.isStreaming)
+              handleTerminalWorkspaceRunChange(sid, evt, failedAssistant?.id)
               clearAgentEventMessages(sid)
               if ((evt as any).inputTokens != null) {
                 const target = sessions.value.find(s => s.id === sid)

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -106,6 +106,7 @@ export const WORKSPACE_RUN_CHANGES_SCHEMA: Record<string, string> = {
   change_id: 'TEXT PRIMARY KEY',
   room_id: "TEXT NOT NULL DEFAULT ''",
   message_id: "TEXT NOT NULL DEFAULT ''",
+  assistant_message_id: "TEXT NOT NULL DEFAULT ''",
   session_id: 'TEXT NOT NULL',
   run_id: 'TEXT NOT NULL DEFAULT \'\'',
   source: 'TEXT NOT NULL DEFAULT \'run\'',

--- a/packages/server/src/db/hermes/workspace-run-changes-store.ts
+++ b/packages/server/src/db/hermes/workspace-run-changes-store.ts
@@ -29,6 +29,7 @@ export interface WorkspaceRunChangeSummary {
   change_id: string
   room_id: string
   message_id: string
+  assistant_message_id: string
   session_id: string
   run_id: string
   source: 'run'
@@ -49,6 +50,7 @@ export interface SaveWorkspaceRunChangeInput {
   change_id: string
   room_id?: string
   message_id?: string
+  assistant_message_id?: string
   session_id: string
   run_id?: string
   source?: 'run'
@@ -107,6 +109,7 @@ function mapSummary(row: Record<string, unknown>, files: WorkspaceRunChangeFileS
     change_id: String(row.change_id || ''),
     room_id: String(row.room_id || ''),
     message_id: String(row.message_id || ''),
+    assistant_message_id: String(row.assistant_message_id || ''),
     session_id: String(row.session_id || ''),
     run_id: String(row.run_id || ''),
     source: 'run',
@@ -147,13 +150,14 @@ export function insertWorkspaceRunChange(db: HermesDb, change: SaveWorkspaceRunC
   db.prepare(`DELETE FROM ${WORKSPACE_RUN_CHANGES_TABLE} WHERE change_id = ?`).run(change.change_id)
   db.prepare(
     `INSERT INTO ${WORKSPACE_RUN_CHANGES_TABLE} (
-      change_id, room_id, message_id, session_id, run_id, source, workspace, workspace_kind, started_at, finished_at,
+      change_id, room_id, message_id, assistant_message_id, session_id, run_id, source, workspace, workspace_kind, started_at, finished_at,
       files_changed, additions, deletions, truncated, total_patch_bytes, created_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     change.change_id,
     change.room_id || '',
     change.message_id || '',
+    change.assistant_message_id || '',
     change.session_id,
     change.run_id || '',
     change.source || 'run',

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -113,6 +113,7 @@ interface ManagedCodingAgentRun {
   pendingChatCompletionEvent?: 'run.completed' | 'run.failed'
   pendingChatCompletionPayload?: Record<string, unknown>
   memoryExportStarted?: boolean
+  assistantMessageId?: string
 }
 
 interface CodingAgentRunSendOptions {
@@ -550,6 +551,7 @@ export class CodingAgentRunManager {
     if (!text) throw new Error('Input is required')
     const systemPrompt = String(options.systemPrompt || '').trim()
     this.ensureDbSession(run)
+    run.assistantMessageId = undefined
     this.addUserMessage(run, text)
     this.touch(run)
     this.emitTerminalStatus(run, 'Input sent to coding agent.')
@@ -657,7 +659,7 @@ export class CodingAgentRunManager {
       this.emitToChat(run.launch.sessionId, mapped.event, mapped.payload)
     }
     if (isTerminalEvent) {
-      flushResponseRunToDb(run.state, run.launch.sessionId)
+      run.assistantMessageId = flushResponseRunToDb(run.state, run.launch.sessionId)
       run.state.responseRun = undefined
       updateSessionStats(run.launch.sessionId)
       run.terminalUsageRefresh = this.refreshCodingAgentUsage(run)
@@ -1918,6 +1920,7 @@ export class CodingAgentRunManager {
         sessionId: run.launch.sessionId,
         runId: run.id,
         workspace: run.launch.workspaceDir,
+        assistantMessageId: run.assistantMessageId,
       })
       if (!change) return null
       this.emitToChat(run.launch.sessionId, 'workspace.diff.completed', {

--- a/packages/server/src/services/hermes/run-chat/bridge-message.ts
+++ b/packages/server/src/services/hermes/run-chat/bridge-message.ts
@@ -7,15 +7,15 @@ import { addMessage } from '../../../db/hermes/session-store'
 import { logger } from '../../logger'
 import type { SessionMessage, SessionState } from './types'
 
-export function flushBridgePendingToDb(state: SessionState, sessionId: string, runMarker?: string) {
+export function flushBridgePendingToDb(state: SessionState, sessionId: string, runMarker?: string): string | undefined {
   const content = state.bridgePendingAssistantContent || ''
   const reasoning = state.bridgePendingReasoningContent || ''
-  if (!content.trim()) return
+  if (!content.trim()) return state.bridgeAssistantMessageId
   if (runMarker) {
     const last = findOpenBridgeAssistantMessage(state, runMarker)
     if (last) syncBridgeReasoningToMessage(last, reasoning)
   }
-  addMessage({
+  const persistedId = addMessage({
     session_id: sessionId,
     role: 'assistant',
     content,
@@ -25,10 +25,12 @@ export function flushBridgePendingToDb(state: SessionState, sessionId: string, r
   })
   state.bridgePendingAssistantContent = ''
   state.bridgePendingReasoningContent = ''
+  if (persistedId != null) state.bridgeAssistantMessageId = String(persistedId)
   if (runMarker) {
     const last = findOpenBridgeAssistantMessage(state, runMarker)
     if (last && last.finish_reason == null) last.finish_reason = 'stop'
   }
+  return state.bridgeAssistantMessageId
 }
 
 export function findOpenBridgeAssistantMessage(state: SessionState, runMarker: string): SessionMessage | undefined {

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -393,6 +393,7 @@ export async function handleBridgeRun(
   state.abortController = undefined
   state.bridgeOutput = ''
   state.bridgePendingAssistantContent = ''
+  state.bridgeAssistantMessageId = undefined
   state.bridgePendingReasoningContent = ''
   state.bridgePendingToolCallMarkup = ''
   state.bridgeToolCounter = 0
@@ -1446,6 +1447,7 @@ async function applyBridgeChunkAsync(
       sessionId,
       runId: chunk.run_id,
       workspace,
+      assistantMessageId: state.bridgeAssistantMessageId,
     })
     workspaceRunChange = change
     if (change) {

--- a/packages/server/src/services/hermes/run-chat/response-stream.ts
+++ b/packages/server/src/services/hermes/run-chat/response-stream.ts
@@ -383,14 +383,15 @@ export function getResponseRunState(state: SessionState, runMarker?: string): Re
 }
 
 /** Flush all non-user messages for this run to DB in order. */
-export function flushResponseRunToDb(state: SessionState, sessionId: string) {
+export function flushResponseRunToDb(state: SessionState, sessionId: string): string | undefined {
   const run = state.responseRun
-  if (!run?.runMarker) return
+  if (!run?.runMarker) return undefined
   let flushed = 0
+  let finalAssistantMessageId: string | undefined
   for (const msg of state.messages) {
     if (msg.runMarker !== run.runMarker) continue
     if (msg.role === 'user') continue
-    addMessage({
+    const persistedId = addMessage({
       session_id: sessionId,
       role: msg.role,
       content: msg.content || '',
@@ -402,7 +403,11 @@ export function flushResponseRunToDb(state: SessionState, sessionId: string) {
       reasoning_content: msg.reasoning_content ?? null,
       timestamp: msg.timestamp,
     })
+    if (persistedId != null && msg.role === 'assistant' && String(msg.content || '').trim()) {
+      finalAssistantMessageId = String(persistedId)
+    }
     flushed++
   }
   logger.info('[chat-run-socket] flushResponseRunToDb: flushed %d messages for session %s', flushed, sessionId)
+  return finalAssistantMessageId
 }

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -80,6 +80,7 @@ export interface SessionState {
   responseRun?: ResponseRunState
   source?: ChatRunSource
   bridgePendingAssistantContent?: string
+  bridgeAssistantMessageId?: string
   bridgePendingReasoningContent?: string
   bridgePendingToolCallMarkup?: string
   bridgeOutput?: string

--- a/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
+++ b/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
@@ -633,6 +633,7 @@ export function completeWorkspaceRunCheckpointDraft(args: {
   sessionId: string
   runId?: string | null
   workspace?: string | null
+  assistantMessageId?: string | null
 }): SaveWorkspaceRunChangeInput | null {
   const runId = args.runId || ''
   if (!runId) return null
@@ -699,6 +700,7 @@ export function completeWorkspaceRunCheckpointDraft(args: {
     change_id: checkpoint.changeId,
     session_id: checkpoint.sessionId,
     run_id: runId || checkpoint.runId,
+    assistant_message_id: args.assistantMessageId || '',
     source: 'run',
     workspace: args.workspace || checkpoint.workspace,
     workspace_kind: checkpoint.kind,
@@ -717,6 +719,7 @@ export function completeWorkspaceRunCheckpoint(args: {
   sessionId: string
   runId?: string | null
   workspace?: string | null
+  assistantMessageId?: string | null
 }): WorkspaceRunChangeSummary | null {
   const draft = completeWorkspaceRunCheckpointDraft(args)
   return draft ? saveWorkspaceRunChange(draft) : null

--- a/tests/client/chat-store-workspace-diff-turn.test.ts
+++ b/tests/client/chat-store-workspace-diff-turn.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { alignWorkspaceChangeAssistantMessage, attachWorkspaceChangesToExactTurns, useChatStore } from '@/stores/hermes/chat'
+
+const sessionApi = vi.hoisted(() => ({
+  fetchSessions: vi.fn(),
+  fetchWorkspaceRunChangesForSession: vi.fn(),
+}))
+
+const chatApi = vi.hoisted(() => ({
+  resumePayload: null as any,
+  resumeSession: vi.fn((sessionId: string, callback: (data: any) => void) => {
+    callback({ ...chatApi.resumePayload, session_id: sessionId })
+    return {} as any
+  }),
+  startRunViaSocket: vi.fn(() => ({ abort: vi.fn() })),
+}))
+
+vi.mock('@/api/hermes/sessions', () => ({
+  archiveSession: vi.fn(),
+  deleteSession: vi.fn(),
+  fetchSessionMessagesPage: vi.fn(),
+  fetchSessions: sessionApi.fetchSessions,
+  fetchWorkspaceRunChangesForSession: sessionApi.fetchWorkspaceRunChangesForSession,
+  fetchWorkspaceRunChangeFile: vi.fn(async () => null),
+  setSessionModel: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/chat', () => ({
+  startRunViaSocket: chatApi.startRunViaSocket,
+  resumeSession: chatApi.resumeSession,
+  registerSessionHandlers: vi.fn(),
+  unregisterSessionHandlers: vi.fn(),
+  getChatRunSocket: vi.fn(() => ({ emit: vi.fn() })),
+  respondToolApproval: vi.fn(),
+  respondClarify: vi.fn(),
+  onPeerUserMessage: vi.fn(() => vi.fn()),
+  onSessionCommand: vi.fn(() => vi.fn()),
+  onSessionTitleUpdated: vi.fn(() => vi.fn()),
+  onSessionWorkspaceUpdated: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('@/api/client', () => ({ getActiveProfileName: () => 'default' }))
+vi.mock('@/api/hermes/download', () => ({ getDownloadUrl: (_path: string, name: string) => `/download/${name}` }))
+vi.mock('@/utils/completion-sound', () => ({ primeCompletionSound: vi.fn(), playCompletionSound: vi.fn() }))
+vi.mock('@/utils/completion-notification', () => ({ showCompletionNotification: vi.fn() }))
+vi.mock('@/utils/session-sync', () => ({ subscribeSessionSync: vi.fn(() => vi.fn()), publishSessionSync: vi.fn() }))
+
+function summary() {
+  return {
+    id: 'session-1', profile: 'default', source: 'coding_agent', agent: 'codex', title: 'Turn changes',
+    preview: '', started_at: 1, ended_at: 2, last_active: 2, message_count: 4, tool_call_count: 0,
+    input_tokens: 0, output_tokens: 0, model: 'gpt-test', provider: 'test',
+  }
+}
+
+function change(id: string, assistantMessageId?: string) {
+  return {
+    change_id: id,
+    assistant_message_id: assistantMessageId || '',
+    session_id: 'session-1', run_id: 'run-1', source: 'run', workspace: '/tmp/repo', workspace_kind: 'git',
+    started_at: 1, finished_at: 2, files_changed: 1, additions: 2, deletions: 1,
+    truncated: false, total_patch_bytes: 20, created_at: 2,
+    files: [{
+      id: id === 'change-1' ? 1 : 2, change_id: id, session_id: 'session-1', path: `${id}.ts`, old_path: null,
+      change_type: 'modified', additions: 2, deletions: 1, size_before: 1, size_after: 2,
+      patch_bytes: 20, truncated: false, binary: false, created_at: 2,
+    }],
+  }
+}
+
+describe('chat workspace diff turn association', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    setActivePinia(createPinia())
+    sessionApi.fetchSessions.mockResolvedValueOnce([summary()]).mockResolvedValueOnce([])
+    chatApi.resumePayload = {
+      isWorking: false,
+      messages: [
+        { id: 1, session_id: 'session-1', role: 'user', content: 'first', timestamp: 1 },
+        { id: 2, session_id: 'session-1', role: 'assistant', content: 'first done', timestamp: 2 },
+        { id: 3, session_id: 'session-1', role: 'user', content: 'second', timestamp: 3 },
+        { id: 4, session_id: 'session-1', role: 'assistant', content: 'second done', timestamp: 4 },
+      ],
+      events: [], queueLength: 0, messageLoadedCount: 4, messageTotal: 4, hasMoreBefore: false,
+    }
+  })
+
+  it('attaches each persisted change to its exact assistant turn without synthetic cards', async () => {
+    sessionApi.fetchWorkspaceRunChangesForSession.mockResolvedValue([
+      change('change-1', '2'),
+      change('change-2', '4'),
+      change('change-3', '4'),
+    ])
+
+    const store = useChatStore()
+    await store.loadSessions()
+
+    expect(store.activeSession?.messages.map(message => message.role)).toEqual(['user', 'assistant', 'user', 'assistant'])
+    expect(store.activeSession?.messages.find(message => message.id === '2')?.workspaceChanges?.map(item => item.change_id)).toEqual([
+      'change-1',
+    ])
+    expect(store.activeSession?.messages.find(message => message.id === '4')?.workspaceChanges?.map(item => item.change_id)).toEqual([
+      'change-2',
+      'change-3',
+    ])
+  })
+
+  it('preserves tool-call workspace change restoration alongside turn associations', async () => {
+    chatApi.resumePayload.messages.splice(3, 0, {
+      id: 5,
+      session_id: 'session-1',
+      role: 'tool',
+      content: 'workspace result',
+      tool_call_id: 'tool-change',
+      timestamp: 3.5,
+    })
+    sessionApi.fetchWorkspaceRunChangesForSession.mockResolvedValue([change('tool-change')])
+
+    const store = useChatStore()
+    await store.loadSessions()
+
+    expect(store.activeSession?.messages.find(message => message.toolCallId === 'tool-change')?.toolChange?.change_id)
+      .toBe('tool-change')
+  })
+
+  it('keeps a standalone timestamp fallback for legacy changes without an assistant id', async () => {
+    sessionApi.fetchWorkspaceRunChangesForSession.mockResolvedValue([change('legacy-change')])
+
+    const store = useChatStore()
+    await store.loadSessions()
+
+    const legacy = store.activeSession?.messages.find(message => message.id === 'workspace-run-change:legacy-change')
+    expect(legacy).toMatchObject({ role: 'tool', toolChange: { change_id: 'legacy-change' } })
+  })
+
+  it('aligns a live assistant temporary id with the persisted attribution id', () => {
+    const messages = [{
+      id: 'temporary-assistant',
+      role: 'assistant' as const,
+      content: 'third done',
+      timestamp: 5,
+      isStreaming: false,
+    }]
+    const attributedChange = change('change-live', '42')
+
+    expect(alignWorkspaceChangeAssistantMessage(messages, attributedChange, 'temporary-assistant')).toBe('42')
+    expect(messages[0].id).toBe('42')
+    expect(attachWorkspaceChangesToExactTurns(messages, [attributedChange])).toEqual([])
+    expect(messages[0].workspaceChanges?.map(item => item.change_id)).toEqual(['change-live'])
+  })
+
+  it('moves an unresolved explicit association from fallback to the assistant after pagination loads it', () => {
+    const unresolved = change('change-page-1', '2')
+    const messages = [
+      { id: '4', role: 'assistant' as const, content: 'newer', timestamp: 4 },
+    ]
+
+    expect(attachWorkspaceChangesToExactTurns(messages, [unresolved])).toEqual([unresolved])
+
+    messages.unshift({ id: '2', role: 'assistant', content: 'older', timestamp: 2 })
+    expect(attachWorkspaceChangesToExactTurns(messages, [unresolved])).toEqual([])
+    expect(messages[0].workspaceChanges?.map(item => item.change_id)).toEqual(['change-page-1'])
+  })
+
+  it('does not overwrite existing tool-message change metadata while recomputing turn associations', () => {
+    const existing = change('tool-change')
+    const messages = [{
+      id: 'tool-1', role: 'tool' as const, content: '', timestamp: 1, toolChange: existing,
+    }]
+
+    attachWorkspaceChangesToExactTurns(messages, [change('turn-change', '42')])
+
+    expect(messages[0].toolChange).toBe(existing)
+    expect(messages[0].workspaceChanges).toEqual([])
+  })
+})

--- a/tests/client/message-item-highlight.test.ts
+++ b/tests/client/message-item-highlight.test.ts
@@ -449,6 +449,58 @@ describe('MessageItem tool details', () => {
     expect(wrapper.find('.tool-change-file-row').text()).toContain('example.ts')
   })
 
+  it('renders a turn-scoped workspace change inside its assistant response', async () => {
+    const wrapper = mount(MessageItem, {
+      props: {
+        message: {
+          id: 'assistant-42',
+          role: 'assistant',
+          content: 'Implemented the requested change.',
+          timestamp: Date.now(),
+          workspaceChanges: [{
+            change_id: 'change-turn-1',
+            assistant_message_id: '42',
+            session_id: 'session-1',
+            run_id: 'run-1',
+            source: 'run',
+            workspace: '/tmp/repo',
+            workspace_kind: 'git',
+            started_at: 1,
+            finished_at: 2,
+            files_changed: 1,
+            additions: 2,
+            deletions: 1,
+            truncated: false,
+            total_patch_bytes: 32,
+            created_at: 2,
+            files: [{
+              id: 1,
+              change_id: 'change-turn-1',
+              session_id: 'session-1',
+              path: 'src/example.ts',
+              old_path: null,
+              change_type: 'modified',
+              additions: 2,
+              deletions: 1,
+              size_before: 10,
+              size_after: 12,
+              patch_bytes: 32,
+              truncated: false,
+              binary: false,
+              created_at: 2,
+            }],
+          }],
+        } as Message,
+      },
+      global: { stubs: { MarkdownRenderer: true } },
+    })
+
+    expect(wrapper.find('.msg-content.assistant .assistant-workspace-change').exists()).toBe(true)
+    expect(wrapper.find('.tool-change-card-title').text()).toBe('chat.changesThisTurn')
+    expect(wrapper.find('.tool-change-file-row').exists()).toBe(false)
+    expect(wrapper.find('.assistant-workspace-change .tool-change-card-header').attributes('aria-expanded')).toBe('false')
+  })
+
   it('shows only an embedded difference field when a JSON tool result contains a unified diff', async () => {
     const writeText = vi.mocked(navigator.clipboard.writeText)
     const largeDiff = `diff --git a/foo.ts b/foo.ts\n--- a/foo.ts\n+++ b/foo.ts\n@@ -1,1 +1,1 @@\n-${'a'.repeat(1600)}\n+${'b'.repeat(1600)}\n`

--- a/tests/server/bridge-message-workspace-attribution.test.ts
+++ b/tests/server/bridge-message-workspace-attribution.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const addMessageMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
+  addMessage: addMessageMock,
+}))
+
+vi.mock('../../packages/server/src/services/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+describe('bridge assistant workspace attribution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('retains the latest persisted assistant row id for the active Hermes Agent run', async () => {
+    addMessageMock.mockReturnValue(73)
+    const state: any = {
+      messages: [],
+      isWorking: true,
+      events: [],
+      queue: [],
+      bridgePendingAssistantContent: 'Finished the workspace update.',
+      bridgePendingReasoningContent: '',
+    }
+    const { flushBridgePendingToDb } = await import('../../packages/server/src/services/hermes/run-chat/bridge-message')
+
+    const persistedId = flushBridgePendingToDb(state, 'session-hermes')
+
+    expect(persistedId).toBe('73')
+    expect(state.bridgeAssistantMessageId).toBe('73')
+  })
+})

--- a/tests/server/response-stream-reasoning-storage.test.ts
+++ b/tests/server/response-stream-reasoning-storage.test.ts
@@ -103,6 +103,26 @@ describe('response stream reasoning storage', () => {
     }))
   })
 
+  it('returns the persisted final assistant message id for turn-scoped records', () => {
+    const state: SessionState = { messages: [], isWorking: false, events: [], queue: [] }
+    addMessageMock.mockReturnValueOnce(40).mockReturnValueOnce(41).mockReturnValueOnce(42)
+
+    applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.created', {
+      response: { id: 'resp-1', status: 'in_progress' },
+    })
+    applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_text.delta', {
+      delta: 'Before tool.',
+    })
+    applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_item.done', {
+      item: { type: 'function_call', call_id: 'tool-1', name: 'Bash', arguments: '{}' },
+    })
+    applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_text.delta', {
+      delta: 'Final answer.',
+    })
+
+    expect(flushResponseRunToDb(state, 'session-1')).toBe('42')
+  })
+
   it('deduplicates final reasoning snapshots after streamed reasoning deltas', () => {
     const state: SessionState = { messages: [], isWorking: false, events: [], queue: [] }
 

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -40,6 +40,8 @@ const recordBridgeToolCompletedMock = vi.fn()
 const recordBridgeMoaDisplayToolMock = vi.fn()
 const resolveBridgeRunModelConfigMock = vi.fn()
 const issueModelRunJwtMock = vi.fn(async () => 'model-run-token')
+const startWorkspaceRunCheckpointMock = vi.fn()
+const completeWorkspaceRunCheckpointMock = vi.fn()
 const homes: string[] = []
 
 vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
@@ -92,6 +94,11 @@ vi.mock('../../packages/server/src/services/hermes/run-chat/bridge-message', () 
 
 vi.mock('../../packages/server/src/services/hermes/run-chat/model-config', () => ({
   resolveBridgeRunModelConfig: resolveBridgeRunModelConfigMock,
+}))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker', () => ({
+  startWorkspaceRunCheckpoint: startWorkspaceRunCheckpointMock,
+  completeWorkspaceRunCheckpoint: completeWorkspaceRunCheckpointMock,
 }))
 
 vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
@@ -147,6 +154,7 @@ describe('bridge run final context usage', () => {
     buildSnapshotAwareHistoryMock.mockImplementation(async (_sessionId: string, _profile: string, history: any[]) => history)
     calcAndUpdateUsageMock.mockResolvedValue({ inputTokens: 11, outputTokens: 7 })
     estimateUsageTokensFromMessagesMock.mockReturnValue({ inputTokens: 11, outputTokens: 7 })
+    completeWorkspaceRunCheckpointMock.mockReturnValue(null)
     ensureOpenBridgeAssistantMessageMock.mockImplementation((state: any, sessionId: string, runMarker: string) => {
       const existing = [...state.messages].reverse().find((message: any) => (
         message.runMarker === runMarker &&
@@ -1045,6 +1053,105 @@ describe('bridge run final context usage', () => {
       output: 'Text [Call',
     }))
   })
+
+  it.each(['terminal', 'write_file'])(
+    'attributes native Hermes Agent %s workspace changes to the final persisted assistant row',
+    async (toolName) => {
+      const emit = vi.fn()
+      const nsp = makeNamespace(emit)
+      const socket = makeSocket()
+      const state = makeState()
+      const sessionMap = new Map([['session-1', state]])
+      const change = {
+        change_id: `run:run-1:${toolName}`,
+        assistant_message_id: '73',
+        session_id: 'session-1',
+        run_id: 'run-1',
+        source: 'run',
+        files: [],
+      }
+      recordBridgeToolStartedMock.mockReturnValue({
+        id: `call-${toolName}`,
+        name: toolName,
+        arguments: '{}',
+      })
+      recordBridgeToolCompletedMock.mockReturnValue({
+        id: `call-${toolName}`,
+        output: 'ok',
+      })
+      flushBridgePendingToDbMock.mockImplementation((targetState: any) => {
+        if (String(targetState.bridgePendingAssistantContent || '').trim()) {
+          targetState.bridgePendingAssistantContent = ''
+          targetState.bridgeAssistantMessageId = '73'
+        }
+        return targetState.bridgeAssistantMessageId
+      })
+      completeWorkspaceRunCheckpointMock.mockReturnValue(change)
+      const bridge = {
+        chat: vi.fn().mockResolvedValue({ run_id: 'run-1', status: 'started' }),
+        contextEstimate: vi.fn().mockResolvedValue({
+          token_count: 12345,
+          message_count: 2,
+          tool_count: 4,
+          system_prompt_chars: 13,
+        }),
+        streamOutput: vi.fn(async function* () {
+          yield {
+            run_id: 'run-1',
+            done: false,
+            status: 'running',
+            events: [
+              { event: 'tool.started', tool_name: toolName, tool_call_id: `call-${toolName}`, args: {} },
+              { event: 'tool.completed', tool_name: toolName, tool_call_id: `call-${toolName}`, result: 'ok' },
+            ],
+          }
+          yield { run_id: 'run-1', done: true, status: 'completed', delta: 'Done.', output: 'Done.', events: [] }
+        }),
+      } as any
+
+      const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+      await handleBridgeRun(
+        nsp,
+        socket,
+        { input: 'update the workspace', session_id: 'session-1' },
+        'default',
+        sessionMap,
+        bridge,
+        false,
+        vi.fn(),
+        vi.fn(),
+      )
+
+      expect(recordBridgeToolStartedMock).toHaveBeenCalledWith(
+        state,
+        'session-1',
+        expect.any(String),
+        toolName,
+        {},
+        `call-${toolName}`,
+      )
+      expect(recordBridgeToolCompletedMock).toHaveBeenCalledWith(
+        state,
+        'session-1',
+        expect.any(String),
+        toolName,
+        expect.objectContaining({ event: 'tool.completed' }),
+      )
+      expect(startWorkspaceRunCheckpointMock).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: 'session-1',
+        runId: 'run-1',
+      }))
+      expect(completeWorkspaceRunCheckpointMock).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: 'session-1',
+        runId: 'run-1',
+        assistantMessageId: '73',
+      }))
+      expect(emit).toHaveBeenCalledWith('workspace.diff.completed', expect.objectContaining({ change }))
+      expect(emit).toHaveBeenCalledWith('run.completed', expect.objectContaining({
+        workspace_run_change: change,
+      }))
+    },
+  )
 
   it('persists the visible plan command instead of the expanded skill prompt', async () => {
     const emit = vi.fn()

--- a/tests/server/schema-sync.test.ts
+++ b/tests/server/schema-sync.test.ts
@@ -364,6 +364,43 @@ describe('Database Schema Synchronization', () => {
         .toEqual({ count: 1 })
     })
 
+
+    it('adds assistant turn attribution to legacy workspace changes without losing audit rows', async () => {
+      const {
+        syncTable,
+        WORKSPACE_RUN_CHANGES_TABLE,
+        WORKSPACE_RUN_CHANGES_SCHEMA,
+        WORKSPACE_RUN_CHANGES_INDEXES,
+      } = await import('../../packages/server/src/db/hermes/schemas')
+      const db = getTestDb()
+      const legacySchema = Object.fromEntries(
+        Object.entries(WORKSPACE_RUN_CHANGES_SCHEMA).filter(([name]) => name !== 'assistant_message_id'),
+      )
+      const columnSql = Object.entries(legacySchema)
+        .map(([name, definition]) => `"${name}" ${definition}`)
+        .join(', ')
+      db.exec(`CREATE TABLE "${WORKSPACE_RUN_CHANGES_TABLE}" (${columnSql})`)
+      db.prepare(`
+        INSERT INTO "${WORKSPACE_RUN_CHANGES_TABLE}"
+          (change_id, session_id, workspace, created_at)
+        VALUES (?, ?, ?, ?)
+      `).run('legacy-change', 'session-1', '/tmp/repo', 42)
+
+      syncTable(WORKSPACE_RUN_CHANGES_TABLE, WORKSPACE_RUN_CHANGES_SCHEMA, {
+        indexes: WORKSPACE_RUN_CHANGES_INDEXES,
+      })
+
+      expect(getTableColumns(db, WORKSPACE_RUN_CHANGES_TABLE).has('assistant_message_id')).toBe(true)
+      expect(db.prepare(`
+        SELECT change_id, session_id, assistant_message_id
+        FROM "${WORKSPACE_RUN_CHANGES_TABLE}"
+      `).get()).toEqual({
+        change_id: 'legacy-change',
+        session_id: 'session-1',
+        assistant_message_id: '',
+      })
+    })
+
     it('adds missing safe columns to existing table without rebuilding', async () => {
       const { syncTable, USAGE_TABLE, USAGE_SCHEMA } = await import('../../packages/server/src/db/hermes/schemas')
 

--- a/tests/server/workspace-diff-tracker.test.ts
+++ b/tests/server/workspace-diff-tracker.test.ts
@@ -86,10 +86,12 @@ describe('workspace diff tracker', () => {
       sessionId: 'session-1',
       runId: 'run-1',
       workspace: repo,
+      assistantMessageId: '42',
     })
 
     expect(change).not.toBeNull()
     expect(change?.change_id).toMatch(/^run:run-1:/)
+    expect(change?.assistant_message_id).toBe('42')
     expect(change?.files.map(file => file.path)).toEqual(['changed.txt'])
     expect(change?.files[0]).toMatchObject({
       change_type: 'modified',
@@ -126,6 +128,76 @@ describe('workspace diff tracker', () => {
       change!.change_id,
       secondChange!.change_id,
     ]))
+  })
+
+  it('persists the exact final assistant row id through the coding-agent completion path', async () => {
+    const { startWorkspaceRunCheckpoint } = await import('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker')
+    const { CodingAgentRunManager } = await import('../../packages/server/src/services/agent-runner/coding-agent-run-manager')
+    const manager = new CodingAgentRunManager()
+    const emitted: Array<{ event: string; payload: any }> = []
+    ;(manager as any).emitToChat = (_sessionId: string, event: string, payload: any) => {
+      emitted.push({ event, payload })
+    }
+    ;(manager as any).markChatRunCompleted = () => {}
+    ;(manager as any).refreshCodingAgentUsage = async () => {}
+
+    manager.start({
+      agentSessionId: 'runner-turn-1',
+      agentId: 'claude-code',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'test-model',
+      sessionId: 'session-runner-turn',
+      command: 'claude',
+      args: [],
+      shellCommand: 'claude',
+      workspaceDir: repo,
+      state: { messages: [], isWorking: false, events: [], queue: [] },
+    })
+    startWorkspaceRunCheckpoint({
+      sessionId: 'session-runner-turn',
+      runId: 'runner-turn-1',
+      workspace: repo,
+    })
+    writeFileSync(join(repo, 'changed.txt'), 'runner update\n')
+
+    manager.handleResponseEvent('runner-turn-1', {
+      type: 'response.created',
+      data: { response: { id: 'response-runner-turn', status: 'in_progress' } },
+    })
+    manager.handleResponseEvent('runner-turn-1', {
+      type: 'response.output_text.delta',
+      data: { delta: 'Implemented the change.' },
+    })
+    manager.handleResponseEvent('runner-turn-1', {
+      type: 'response.completed',
+      data: {
+        response: {
+          id: 'response-runner-turn',
+          status: 'completed',
+          output: [{ type: 'message', content: [{ type: 'output_text', text: 'Implemented the change.' }] }],
+          model: 'test-model',
+          usage: { input_tokens: 10, output_tokens: 4 },
+        },
+      },
+    })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const assistant = state.db?.prepare(`
+      SELECT id FROM messages
+      WHERE session_id = ? AND role = 'assistant'
+      ORDER BY id DESC LIMIT 1
+    `).get('session-runner-turn') as { id: number } | undefined
+    const persistedChange = state.db?.prepare(`
+      SELECT assistant_message_id FROM workspace_run_changes
+      WHERE session_id = ?
+      ORDER BY created_at DESC LIMIT 1
+    `).get('session-runner-turn') as { assistant_message_id: string } | undefined
+
+    expect(assistant).toBeTruthy()
+    expect(persistedChange?.assistant_message_id).toBe(String(assistant?.id))
+    expect(emitted.some(item => item.event === 'workspace.diff.completed')).toBe(true)
+    manager.shutdown()
   })
 
   it('records added, modified, and deleted files in non-git workspaces', async () => {


### PR DESCRIPTION
## Summary

- persist the final visible Assistant message ID on each Coding Agent workspace-diff checkpoint
- render each attributed checkpoint as a compact, collapsed **Changes this turn** summary inside that Assistant response
- keep every original checkpoint, file summary, and patch available for audit
- preserve standalone cards for legacy records and explicit associations whose Assistant message has not loaded yet
- keep ordinary tool-call and Group Chat workspace-diff behavior unchanged

Closes #2079.

## Why

Workspace diffs are intentionally incremental per Coding Agent turn. Previously, restored run checkpoints were inserted as standalone synthetic tool cards, so several turns editing the same files looked like duplicate cards even though they represented different deltas.

This change fixes the presentation and attribution instead of deleting or grouping audit history.

## Implementation

- add an additive `assistant_message_id TEXT NOT NULL DEFAULT ''` column to `workspace_run_changes`
- return the last persisted visible Assistant row ID from response flushing and pass it through checkpoint completion
- attach exact-ID checkpoints to `Message.workspaceChanges[]`
- align temporary live Assistant IDs with persisted DB IDs when the diff event arrives before terminal completion
- recompute associations after history pagination, allowing unresolved records to move under the correct Assistant once loaded
- render multiple checkpoints independently under one Assistant without overloading existing `toolChange` metadata
- add localized `chat.changesThisTurn` text to all ten locale files

## Compatibility and scope

- existing rows migrate additively and default to an empty attribution ID
- legacy and unresolved records remain visible as standalone cards with full patch access
- Group Chat's durable workspace-diff audit-message semantics are unchanged
- no checkpoints are deleted, merged by run ID, grouped by file set, or filtered to latest-only
- session baseline-to-current net diff is intentionally out of scope for this PR

## Verification

Latest base: `upstream/main` at `0dabbda394b428077ca6a19c987efb3b6f218909`.

Passed after updating to the latest base:

- `npx vitest run tests/server/workspace-diff-tracker.test.ts tests/server/response-stream-reasoning-storage.test.ts tests/server/schema-sync.test.ts tests/server/group-chat-workspace-diff.test.ts tests/client/chat-store-workspace-diff-turn.test.ts tests/client/message-item-highlight.test.ts` — **6 files, 59 tests passed**
- `npx vue-tsc -b --pretty false`
- `npx tsc --noEmit -p packages/server/tsconfig.json --pretty false`
- `npm run harness:check`
- `npm run build`
- `git diff --check upstream/main`

Manual production-build UI acceptance in an isolated state directory:

- two Assistant turns editing the same two files displayed separate nested summaries with distinct totals
- summaries were collapsed by default and expanded independently
- each same-named file opened its own original checkpoint patch (`old → turn-1`, then `turn-1 → turn-2`)
- after reopening the session, exact Assistant placement and collapsed state remained stable
- a seeded legacy row with no `assistant_message_id` remained visible as a standalone card and its file patch still opened

Full-suite note:

- an earlier `npm test` attempt on this host reported **320/324 files passed**, **2548 tests passed**, **9 failed**, **2 skipped**
- all 9 failures were confined to Agent bridge/profile/plugin discovery tests whose isolation assumptions detect the real Hermes Agent installation and bundled plugins on this host
- this branch does not modify those source modules or tests; the feature-focused suites, type checks, harness, build, and UI acceptance above pass

## Behavior

The new summary stays collapsed beneath the Assistant response until opened:

`Changes this turn · 2 files changed · +N -N`

Opening it reveals the original per-file rows and patch drawer for that exact checkpoint.
