### PR TITLE
fix cross-platform voice capture and captions

### DIFF
--- a/docs/chat-chain-changes/2026-07-15-pcm-chat-input-and-voice-captions.md
+++ b/docs/chat-chain-changes/2026-07-15-pcm-chat-input-and-voice-captions.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-07-15
-pr: pending
+pr: 2086
 feature: PCM chat input and voice caption lifecycle
 impact: Mobile and Electron chat input recordings now upload PCM/WAV, and realtime voice no longer restores the user's transcript after assistant TTS begins.
 ---

--- a/docs/chat-chain-changes/2026-07-15-pcm-chat-input-and-voice-captions.md
+++ b/docs/chat-chain-changes/2026-07-15-pcm-chat-input-and-voice-captions.md
@@ -1,0 +1,10 @@
+---
+date: 2026-07-15
+pr: pending
+feature: PCM chat input and voice caption lifecycle
+impact: Mobile and Electron chat input recordings now upload PCM/WAV, and realtime voice no longer restores the user's transcript after assistant TTS begins.
+---
+
+Backend STT capture from the chat input now uses the same single-shot 16 kHz PCM/WAV recorder as the STT settings test on mobile devices and in the Electron desktop shell. Regular browser sessions keep their existing browser recognition and MediaRecorder behavior.
+
+Realtime voice keeps the submitted transcript visible while waiting for the first assistant audio segment. Once TTS starts, gaps between assistant speech segments show the thinking hint instead of falling back to the user's previous transcript.

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -13,6 +13,7 @@ import { useI18n } from 'vue-i18n'
 import { useToolTraceVisibility } from '@/composables/useToolTraceVisibility'
 import VoiceDialogueControls from './VoiceDialogueControls.vue'
 import { useMicRecorder } from '@/composables/useMicRecorder'
+import { usePcmStreamRecorder } from '@/composables/usePcmStreamRecorder'
 import { useGlobalSpeech } from '@/composables/useSpeech'
 import { useVoiceDialogue } from '@/composables/useVoiceDialogue'
 import { transcribeSpeech } from '@/api/hermes/stt'
@@ -21,6 +22,8 @@ import { useSttSettings } from '@/composables/useSttSettings'
 import { useBrowserSpeechRecognition } from '@/composables/useBrowserSpeechRecognition'
 import { BRIDGE_SESSION_COMMAND_DEFINITIONS } from '@/utils/hermes/bridge-session-commands'
 import { clampChatInputHeight, isMobileChatInputViewport } from '@/utils/chat-input-height'
+import { isDesktopShell } from '@/utils/desktop-bridge'
+import { isMobileDevice } from '@/utils/device'
 
 const chatStore = useChatStore()
 const appStore = useAppStore()
@@ -96,6 +99,13 @@ const micRecorder = useMicRecorder({
     recordingFailed: t('chat.voiceInput.microphoneRecordingFailed'),
   },
 })
+const pcmRecorder = usePcmStreamRecorder({
+  voiceActivityThreshold: 0.02,
+  messages: {
+    unsupported: t('chat.voiceInput.microphoneUnsupported'),
+    recordingFailed: t('chat.voiceInput.microphoneRecordingFailed'),
+  },
+})
 const sttSettings = useSttSettings()
 const browserRecognition = useBrowserSpeechRecognition({
   messages: {
@@ -104,7 +114,7 @@ const browserRecognition = useBrowserSpeechRecognition({
     failedWithReason: (reason) => t('chat.voiceInput.browserSpeechFailedWithReason', { error: reason }),
   },
 })
-const activeVoiceCaptureMode = ref<'browser' | 'backend' | null>(null)
+const activeVoiceCaptureMode = ref<'browser' | 'backend' | 'pcm' | null>(null)
 const configuredTextareaHeight = computed(() =>
   isMobileViewport.value ? null : clampChatInputHeight(settingsStore.display.chat_input_height),
 )
@@ -206,6 +216,7 @@ const shouldShowBrowserRecognitionError = computed(() =>
 const voiceDialogueError = computed(() =>
   voiceDialogue.error.value?.message
   ?? (shouldShowBrowserRecognitionError.value ? browserRecognition.error.value?.message : null)
+  ?? pcmRecorder.error.value?.message
   ?? micRecorder.state.value.error?.message
   ?? null,
 )
@@ -804,8 +815,11 @@ async function startVoiceCapture() {
   browserRecognition.clearError()
   const { captureId } = await voiceDialogue.beginCapture()
   const useBrowserProvider = sttSettings.provider.value === 'browser'
+  const usePcmCapture = !useBrowserProvider && (isDesktopShell() || isMobileDevice())
 
-  activeVoiceCaptureMode.value = useBrowserProvider ? 'browser' : 'backend'
+  activeVoiceCaptureMode.value = useBrowserProvider
+    ? 'browser'
+    : usePcmCapture ? 'pcm' : 'backend'
 
   try {
     if (useBrowserProvider) {
@@ -813,7 +827,11 @@ async function startVoiceCapture() {
       return
     }
 
-    await micRecorder.start()
+    if (usePcmCapture) {
+      await pcmRecorder.start()
+    } else {
+      await micRecorder.start()
+    }
   } catch {
     activeVoiceCaptureMode.value = null
     voiceDialogue.cancelCapture(captureId)
@@ -845,17 +863,24 @@ async function stopVoiceCapture() {
     return
   }
 
-  if (micRecorder.state.value.status === 'requesting') {
-    micRecorder.cancel()
+  const usePcmCapture = activeVoiceCaptureMode.value === 'pcm'
+  const captureStatus = usePcmCapture
+    ? pcmRecorder.status.value
+    : micRecorder.state.value.status
+  if (captureStatus === 'requesting') {
+    if (usePcmCapture) pcmRecorder.cancel()
+    else micRecorder.cancel()
     activeVoiceCaptureMode.value = null
     voiceDialogue.cancelCapture(captureId)
     return
   }
 
-  let audio: Blob
+  let audio: Blob | null
 
   try {
-    audio = await micRecorder.stop()
+    audio = usePcmCapture
+      ? await pcmRecorder.stop()
+      : await micRecorder.stop()
   } catch {
     activeVoiceCaptureMode.value = null
     voiceDialogue.cancelCapture(captureId)
@@ -864,7 +889,7 @@ async function stopVoiceCapture() {
 
   activeVoiceCaptureMode.value = null
 
-  if (audio.size <= 0) {
+  if (!audio || audio.size <= 0) {
     voiceDialogue.cancelCapture(captureId)
     return
   }
@@ -879,6 +904,8 @@ async function stopVoiceCapture() {
 function cancelVoiceCapture() {
   if (activeVoiceCaptureMode.value === 'browser') {
     browserRecognition.cancel()
+  } else if (activeVoiceCaptureMode.value === 'pcm') {
+    pcmRecorder.cancel()
   } else {
     micRecorder.cancel()
   }

--- a/packages/client/src/components/hermes/chat/RealtimeVoiceStage.vue
+++ b/packages/client/src/components/hermes/chat/RealtimeVoiceStage.vue
@@ -13,6 +13,7 @@ import { useSttSettings } from '@/composables/useSttSettings'
 import { useVoiceSettings } from '@/composables/useVoiceSettings'
 import { useChatStore, type Message } from '@/stores/hermes/chat'
 import { isDesktopShell } from '@/utils/desktop-bridge'
+import { isMobileDevice } from '@/utils/device'
 import { hzToEdgePitch, speedToEdgeRate } from '@/utils/ttsHelpers'
 
 type VoiceStageMode = 'idle' | 'paused' | 'listening' | 'processing' | 'thinking' | 'speaking' | 'error'
@@ -78,6 +79,7 @@ const submittedTranscript = ref('')
 const backendStreamTranscript = ref('')
 const errorMessage = ref('')
 const waitingForResponse = ref(false)
+const responseAudioStarted = ref(false)
 const responseStartedAt = ref(0)
 const audioLevel = ref(0)
 const segmentAudioPlaying = ref(false)
@@ -152,7 +154,11 @@ const displayCaption = computed(() => {
     return activeSpeechSegment.value.subtitleText
   }
   if (
-    (mode.value === 'listening' || mode.value === 'processing' || mode.value === 'thinking')
+    (
+      mode.value === 'listening'
+      || mode.value === 'processing'
+      || (mode.value === 'thinking' && !responseAudioStarted.value)
+    )
     && currentTranscript.value
   ) {
     return currentTranscript.value
@@ -202,25 +208,6 @@ function toolDetail(message: Message) {
 
 function browserCaptureLanguage() {
   return sttSettings.openaiLanguage.value.trim() || sttSettings.customLanguage.value.trim() || ''
-}
-
-function isMobileDevice() {
-  if (typeof navigator === 'undefined') return false
-  const userAgent = navigator.userAgent || ''
-  if (/Android|iPhone|iPad|iPod|Mobile/i.test(userAgent)) return true
-
-  const hasTouch = navigator.maxTouchPoints > 1
-  const pointerQuery = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
-    ? window.matchMedia('(pointer: coarse), (any-pointer: coarse)')
-    : null
-  const hasCoarsePointer = Boolean(pointerQuery?.matches)
-  const screenShortEdge = typeof window !== 'undefined' && window.screen
-    ? Math.min(window.screen.width, window.screen.height)
-    : Number.POSITIVE_INFINITY
-
-  // "Request desktop site" can replace the mobile UA entirely. Physical
-  // touch/pointer/screen traits still distinguish the phone from a PC.
-  return hasTouch && hasCoarsePointer && screenShortEdge <= 1024
 }
 
 function browserCaptureContinuous() {
@@ -387,6 +374,7 @@ function resetResponseSpeechState() {
   responseStartMessageIndex = chatStore.messages.length
   lastResponseAssistantId = null
   responseFinalizing = false
+  responseAudioStarted.value = false
   ttsSegmentIndex = 0
   processedAssistantText.clear()
   processedToolMessageIds.clear()
@@ -851,6 +839,7 @@ async function playPreparedSpeech(segment: VoiceSpeechSegment, audioBlob: Blob) 
         }
         segmentAudioPlaying.value = true
         activeSpeechSegment.value = segment
+        responseAudioStarted.value = true
         mode.value = 'speaking'
       })
       .catch(finish)
@@ -872,6 +861,7 @@ async function playSpeechSegment(segment: VoiceSpeechSegment) {
         voiceName: voiceSettings.webspeechVoice.value || undefined,
       })
       activeSpeechSegment.value = segment
+      responseAudioStarted.value = true
       mode.value = 'speaking'
       await waitForSpeechPlayback(generation)
     } else {

--- a/packages/client/src/utils/device.ts
+++ b/packages/client/src/utils/device.ts
@@ -1,0 +1,18 @@
+export function isMobileDevice() {
+  if (typeof navigator === 'undefined') return false
+  const userAgent = navigator.userAgent || ''
+  if (/Android|iPhone|iPad|iPod|Mobile/i.test(userAgent)) return true
+
+  const hasTouch = navigator.maxTouchPoints > 1
+  const pointerQuery = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(pointer: coarse), (any-pointer: coarse)')
+    : null
+  const hasCoarsePointer = Boolean(pointerQuery?.matches)
+  const screenShortEdge = typeof window !== 'undefined' && window.screen
+    ? Math.min(window.screen.width, window.screen.height)
+    : Number.POSITIVE_INFINITY
+
+  // "Request desktop site" can replace the mobile UA entirely. Physical
+  // touch/pointer/screen traits still distinguish the phone from a PC.
+  return hasTouch && hasCoarsePointer && screenShortEdge <= 1024
+}

--- a/tests/client/realtime-voice-playback-queue.test.ts
+++ b/tests/client/realtime-voice-playback-queue.test.ts
@@ -310,6 +310,42 @@ describe('RealtimeVoiceStage prepared playback queue', () => {
     wrapper.unmount()
   })
 
+  it('does not restore the user transcript between assistant TTS segments', async () => {
+    testState.recognitionStopResult = '这是用户刚才说的话'
+    const wrapper = mount(RealtimeVoiceStage)
+
+    await wrapper.get('[data-testid="realtime-voice-toggle"]').trigger('click')
+    await settle()
+    await wrapper.get('[data-testid="realtime-voice-toggle"]').trigger('click')
+    await settle()
+
+    expect(wrapper.get('[data-testid="realtime-voice-caption"]').text()).toBe('这是用户刚才说的话')
+
+    testState.store.messages.push({
+      id: 'assistant-caption-gap',
+      role: 'assistant',
+      content: '第一句。第二句。',
+      timestamp: Date.now(),
+      isStreaming: true,
+    })
+    await settle()
+    resolveRequest(0)
+    await settle()
+
+    expect(wrapper.get('[data-testid="realtime-voice-caption"]').text()).toBe('第一句。')
+
+    testState.audioInstances[0].onended?.()
+    await settle()
+
+    expect(wrapper.classes()).toContain('voice-stage--thinking')
+    expect(wrapper.get('[data-testid="realtime-voice-caption"]').text()).toBe('realtimeVoice.hint.thinking')
+    expect(wrapper.get('[data-testid="realtime-voice-caption"]').text()).not.toContain('这是用户刚才说的话')
+
+    await wrapper.get('[data-testid="realtime-voice-toggle"]').trigger('click')
+    await settle()
+    wrapper.unmount()
+  })
+
   it('never plays assistant messages that existed before the current voice turn', async () => {
     testState.store.isStreaming = false
     testState.store.messages.push(

--- a/tests/client/voice-dialogue-controls.test.ts
+++ b/tests/client/voice-dialogue-controls.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
 import { defineComponent } from 'vue'
@@ -12,6 +12,9 @@ const {
   micStartMock,
   micStopMock,
   micCancelMock,
+  pcmStartMock,
+  pcmStopMock,
+  pcmCancelMock,
   transcribeSpeechMock,
   browserStartMock,
   browserStopMock,
@@ -19,6 +22,8 @@ const {
   browserClearErrorMock,
   speechStopMock,
   micRecorderState,
+  pcmRecorderStatus,
+  pcmRecorderError,
   browserRecognitionStatus,
   browserRecognitionTranscript,
   browserRecognitionPartialTranscript,
@@ -29,6 +34,9 @@ const {
   micStartMock: vi.fn(),
   micStopMock: vi.fn(),
   micCancelMock: vi.fn(),
+  pcmStartMock: vi.fn(),
+  pcmStopMock: vi.fn(),
+  pcmCancelMock: vi.fn(),
   transcribeSpeechMock: vi.fn(),
   browserStartMock: vi.fn(),
   browserStopMock: vi.fn(),
@@ -43,6 +51,8 @@ const {
       mimeType: 'audio/webm' as string | null,
     },
   },
+  pcmRecorderStatus: { value: 'idle' as 'idle' | 'requesting' | 'recording' | 'error' },
+  pcmRecorderError: { value: null as Error | null },
   browserRecognitionStatus: { value: 'idle' as 'idle' | 'listening' | 'stopping' | 'error' },
   browserRecognitionTranscript: { value: '' },
   browserRecognitionPartialTranscript: { value: '' },
@@ -103,6 +113,17 @@ vi.mock('@/composables/useMicRecorder', () => ({
     start: micStartMock,
     stop: micStopMock,
     cancel: micCancelMock,
+  }),
+}))
+
+vi.mock('@/composables/usePcmStreamRecorder', () => ({
+  usePcmStreamRecorder: () => ({
+    status: pcmRecorderStatus,
+    error: pcmRecorderError,
+    isRecording: { value: false },
+    start: pcmStartMock,
+    stop: pcmStopMock,
+    cancel: pcmCancelMock,
   }),
 }))
 
@@ -210,6 +231,18 @@ describe('VoiceDialogueControls', () => {
       return new Blob(['audio'], { type: 'audio/webm' })
     })
     micCancelMock.mockImplementation(() => undefined)
+    pcmRecorderStatus.value = 'idle'
+    pcmRecorderError.value = null
+    pcmStartMock.mockImplementation(async () => {
+      pcmRecorderStatus.value = 'recording'
+    })
+    pcmStopMock.mockImplementation(async () => {
+      pcmRecorderStatus.value = 'idle'
+      return new Blob([new Uint8Array(256)], { type: 'audio/wav' })
+    })
+    pcmCancelMock.mockImplementation(() => {
+      pcmRecorderStatus.value = 'idle'
+    })
     browserStartMock.mockImplementation(async () => {
       browserRecognitionStatus.value = 'listening'
       browserRecognitionError.value = null
@@ -240,9 +273,21 @@ describe('VoiceDialogueControls', () => {
     browserRecognitionError.value = null
     browserRecognitionIsSupported.value = true
     useVoiceDialogueOverride.value = null
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: undefined,
+    })
 
     const { useSttSettings } = await import('../../packages/client/src/composables/useSttSettings')
     useSttSettings().reset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: undefined,
+    })
   })
 
   it('starts recording from the mic button while idle', async () => {
@@ -582,6 +627,58 @@ describe('VoiceDialogueControls', () => {
     })
     expect(chatStore.sendMessage).not.toHaveBeenCalled()
     expect((wrapper.get('textarea').element as HTMLTextAreaElement).value).toBe('hello hermes')
+  })
+
+  it('records desktop-shell input as PCM WAV instead of MediaRecorder Opus', async () => {
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { isDesktop: true, platform: 'win32' },
+    })
+    const wav = new Blob([new Uint8Array(256)], { type: 'audio/wav' })
+    pcmStopMock.mockResolvedValueOnce(wav)
+
+    const { wrapper } = mountChatInput()
+    await flushPromises()
+
+    await wrapper.get('[data-testid="voice-record-toggle"]').trigger('click')
+    await flushPromises()
+    expect(pcmStartMock).toHaveBeenCalledOnce()
+    expect(micStartMock).not.toHaveBeenCalled()
+
+    await wrapper.get('[data-testid="voice-record-toggle"]').trigger('click')
+    await flushPromises()
+
+    expect(pcmStopMock).toHaveBeenCalledOnce()
+    expect(micStopMock).not.toHaveBeenCalled()
+    expect(transcribeSpeechMock).toHaveBeenCalledWith(expect.objectContaining({
+      audio: wav,
+      provider: 'openai',
+    }))
+  })
+
+  it('records mobile input as PCM WAV instead of MediaRecorder Opus', async () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      userAgent: 'Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/138 Mobile Safari/537.36',
+      maxTouchPoints: 5,
+    })
+    const wav = new Blob([new Uint8Array(256)], { type: 'audio/wav' })
+    pcmStopMock.mockResolvedValueOnce(wav)
+
+    const { wrapper } = mountChatInput()
+    await flushPromises()
+
+    await wrapper.get('[data-testid="voice-record-toggle"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-testid="voice-record-toggle"]').trigger('click')
+    await flushPromises()
+
+    expect(pcmStartMock).toHaveBeenCalledOnce()
+    expect(micStartMock).not.toHaveBeenCalled()
+    expect(transcribeSpeechMock).toHaveBeenCalledWith(expect.objectContaining({
+      audio: wav,
+      provider: 'openai',
+    }))
   })
 
   it('uses Doubao as a server-backed STT provider without client-side credentials', async () => {


### PR DESCRIPTION
## Summary

- record chat-input backend STT audio as 16 kHz mono PCM/WAV in Electron and on mobile devices
- keep regular browser capture behavior unchanged
- stop restoring the user's transcript between assistant TTS segments after playback begins
- share mobile-device detection between chat input and realtime voice

## Root cause

The realtime voice screen and STT settings test already generated PCM/WAV, but the chat input still used `MediaRecorder`, which commonly produces WebM/Opus on Windows Electron. Some STT providers reject that platform-specific output. Realtime voice also kept the submitted transcript as a caption fallback after the first assistant audio segment, so it briefly reappeared between TTS segments.

## Impact

Desktop and mobile chat-input recordings no longer depend on Opus decoding or server-side transcoding when using backend STT. Assistant speech captions remain stable across segmented TTS playback.

## Validation

- `npm run test -- tests/client/voice-dialogue-controls.test.ts tests/client/realtime-voice-playback-queue.test.ts tests/client/use-pcm-stream-recorder.test.ts` (50 passed)
- `npm run harness:check`
- `npm run build`
