### PR TITLE
fix(desktop): allow macOS microphone input

### DIFF
--- a/packages/desktop/build/entitlements.mac.inherit.plist
+++ b/packages/desktop/build/entitlements.mac.inherit.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+</dict>
+</plist>

--- a/packages/desktop/build/entitlements.mac.plist
+++ b/packages/desktop/build/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+</dict>
+</plist>

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -61,6 +61,8 @@ mac:
   hardenedRuntime: true
   gatekeeperAssess: false
   notarize: true
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.inherit.plist
   extendInfo:
     NSMicrophoneUsageDescription: "Hermes Studio uses the microphone for voice conversations and speech transcription."
   artifactName: "Hermes.Studio-${version}-${arch}.${ext}"

--- a/scripts/harness-check.mjs
+++ b/scripts/harness-check.mjs
@@ -250,6 +250,8 @@ const desktopRuntimeWorkflow = await readText('.github/workflows/desktop-runtime
 const webuiReleaseWorkflow = await readText('.github/workflows/webui-release.yml')
 const dockerPublishWorkflow = await readText('.github/workflows/docker-publish.yml')
 const electronBuilderConfig = await readText('packages/desktop/electron-builder.yml')
+const desktopMacEntitlements = await readText('packages/desktop/build/entitlements.mac.plist')
+const desktopMacInheritedEntitlements = await readText('packages/desktop/build/entitlements.mac.inherit.plist')
 const desktopPackageJson = await readText('packages/desktop/package.json')
 const desktopInstallHermes = await readText('packages/desktop/scripts/install-hermes.mjs')
 const desktopHermesPatches = await readText('packages/desktop/scripts/apply-hermes-patches.mjs')
@@ -290,6 +292,21 @@ if (!webuiReleaseWorkflow.includes('make_latest: false')) {
 
 if (!electronBuilderConfig.includes('icon: build/icons')) {
   fail('electron-builder.yml must configure the Linux icon set')
+}
+
+for (const entitlementFile of ['build/entitlements.mac.plist', 'build/entitlements.mac.inherit.plist']) {
+  if (!electronBuilderConfig.includes(entitlementFile)) {
+    fail(`electron-builder.yml must configure ${entitlementFile}`)
+  }
+}
+
+for (const [file, text] of [
+  ['entitlements.mac.plist', desktopMacEntitlements],
+  ['entitlements.mac.inherit.plist', desktopMacInheritedEntitlements],
+]) {
+  if (!text.includes('<key>com.apple.security.device.audio-input</key>')) {
+    fail(`${file} must allow microphone audio input`)
+  }
 }
 
 for (const target of ['target_os: darwin', 'target_os: win32', 'target_os: linux']) {


### PR DESCRIPTION
## Summary

- add the macOS audio-input entitlement to the main application
- inherit the audio-input entitlement in Electron helper processes
- explicitly configure both entitlement files in electron-builder
- add harness checks to prevent the packaging configuration from regressing

## Root cause

Hermes Studio enables Hardened Runtime and declares `NSMicrophoneUsageDescription`, but the signed application and renderer helper did not contain `com.apple.security.device.audio-input`. macOS therefore denied microphone access without presenting the expected permission prompt.

## User impact

Packaged macOS builds can request and use microphone access for STT and voice conversations.

## Validation

- `plutil -lint packages/desktop/build/entitlements.mac.plist packages/desktop/build/entitlements.mac.inherit.plist`
- `npm run harness:check`
- [macOS arm64 signed and notarized build](https://github.com/EKKOLearnAI/hermes-studio/actions/runs/29401653046)
- verified the final main app and Renderer Helper signatures contain `com.apple.security.device.audio-input = true`
- `codesign --verify --deep --strict`
- Gatekeeper assessment passed as Notarized Developer ID
- notarization ticket validation passed
