### PR TITLE
fix group chat input background

### DIFF
--- a/docs/chat-chain-changes/2026-07-16-group-chat-input-background.md
+++ b/docs/chat-chain-changes/2026-07-16-group-chat-input-background.md
@@ -1,0 +1,6 @@
+---
+date: 2026-07-16
+pr: 2092
+feature: Align group-chat input background with direct chat
+impact: Group-chat composers now use the same dark-theme background as direct-chat composers.
+---

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -580,6 +580,10 @@ function isImage(type: string): boolean {
     border-top: 0;
     background-color: $bg-card;
     flex-shrink: 0;
+
+    .dark & {
+        background-color: #333333;
+    }
 }
 
 .input-top-bar {
@@ -781,7 +785,7 @@ function isImage(type: string): boolean {
     }
 
     .dark & {
-        background-color: $bg-card;
+        background-color: #333333;
         box-shadow: 0 8px 28px rgba(0, 0, 0, 0.32);
     }
 }

--- a/tests/client/style-system.test.ts
+++ b/tests/client/style-system.test.ts
@@ -24,4 +24,12 @@ describe('client style system', () => {
     expect(theme).toContain("borderRadius: '8px'")
     expect(theme).toContain("borderRadiusSmall: '6px'")
   })
+
+  it('keeps direct-chat and group-chat composer backgrounds aligned in dark mode', () => {
+    const chatInput = readClientFile('components/hermes/chat/ChatInput.vue')
+    const groupChatInput = readClientFile('components/hermes/group-chat/GroupChatInput.vue')
+
+    expect(chatInput.match(/background-color: #333333;/g)).toHaveLength(2)
+    expect(groupChatInput.match(/background-color: #333333;/g)).toHaveLength(2)
+  })
 })


### PR DESCRIPTION
## Summary
- align the group-chat composer surface and input frame with the direct-chat dark-theme background
- add a regression test covering dark-mode composer background parity
- record the group-chat behavior change in the chat-chain change log

## Root cause
The direct-chat composer had a dark-mode override of `#333333`, while the group-chat composer continued to use `$bg-card` (`#2a2a2a`). This made the two input areas visibly inconsistent.

## Impact
Group-chat and direct-chat inputs now use the same background color in dark mode. Light-theme behavior is unchanged.

## Validation
- `npm run test -- tests/client/style-system.test.ts`
- `npm run harness:check`
- `npm run build`
