### PR TITLE
feat: add message references to single and group chat

### DIFF
--- a/docs/chat-chain-changes/2026-07-16-single-chat-message-reference.md
+++ b/docs/chat-chain-changes/2026-07-16-single-chat-message-reference.md
@@ -1,0 +1,16 @@
+---
+date: 2026-07-16
+pr: pending
+feature: Single-chat and group-chat message references
+impact: Users can reference a completed message in their next turn without changing either message database schema or legacy history loading.
+---
+
+Single-chat and group-chat message actions can select a message as the reference
+for the next turn. Each input shows a removable, conversation-scoped one-line
+preview outside the input box. Sending wraps the referenced content in an
+explicit `quoted_message` block for the agent while message rendering converts
+it back to a clean Markdown quote. Group mention routing ignores `@` tokens
+inside the quoted block, so only mentions in the new reply can trigger agents.
+Existing persistence and model context paths continue treating the result as
+ordinary content, so previously stored messages are unchanged and need no
+migration.

--- a/docs/chat-chain-changes/2026-07-16-single-chat-message-reference.md
+++ b/docs/chat-chain-changes/2026-07-16-single-chat-message-reference.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-07-16
-pr: pending
+pr: 2098
 feature: Single-chat and group-chat message references
 impact: Users can reference a completed message in their next turn without changing either message database schema or legacy history loading.
 ---

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -116,6 +116,10 @@ const attachments = ref<Attachment[]>([])
 const isDragging = ref(false)
 const dragCounter = ref(0)
 const isComposing = ref(false)
+const activeMessageReference = computed(() => chatStore.activeMessageReference)
+const messageReferencePreview = computed(() =>
+  activeMessageReference.value?.content.replace(/\s+/g, ' ').trim() || '',
+)
 const isMobileViewport = ref(typeof window !== 'undefined' ? isMobileChatInputViewport(window.innerWidth) : false)
 const manualTextareaResize = ref(false)
 const speech = useGlobalSpeech()
@@ -215,6 +219,20 @@ function insertVoiceTranscriptIntoInput(text: string) {
     autoSizeTextarea(textarea)
   })
 }
+
+function clearMessageReference() {
+  const sessionId = chatStore.activeSessionId
+  if (sessionId) chatStore.clearMessageReference(sessionId)
+  textareaRef.value?.focus()
+}
+
+watch(
+  () => activeMessageReference.value?.id,
+  (id) => {
+    if (!id) return
+    nextTick(() => textareaRef.value?.focus())
+  },
+)
 
 const voiceDialogue = useVoiceDialogue({
   transcribe: async (audio) => {
@@ -1060,6 +1078,22 @@ function isImage(type: string): boolean {
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
         </button>
       </div>
+    </div>
+
+    <div v-if="activeMessageReference" class="message-reference-preview">
+      <span class="message-reference-text">{{ messageReferencePreview }}</span>
+      <button
+        type="button"
+        class="message-reference-remove"
+        :aria-label="t('chat.cancelReference')"
+        :title="t('chat.cancelReference')"
+        @click.stop="clearMessageReference"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
     </div>
 
     <div
@@ -2002,6 +2036,49 @@ function isImage(type: string): boolean {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+}
+
+.message-reference-preview {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  margin: 0 8px 8px;
+  padding: 4px 8px;
+  border-radius: 8px;
+  background: rgba(var(--accent-primary-rgb), 0.07);
+  cursor: default;
+}
+
+.message-reference-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  color: $text-secondary;
+  font-size: 12px;
+  line-height: 24px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.message-reference-remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 26px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: $text-muted;
+  cursor: pointer;
+
+  &:hover {
+    color: $text-primary;
+    background: rgba(var(--text-primary-rgb), 0.08);
   }
 }
 

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import type { Message, ContentBlock } from "@/stores/hermes/chat";
+import {
+  formatReferencedContentForDisplay,
+  parseMessageReference,
+  type Message,
+  type ContentBlock,
+} from "@/stores/hermes/chat";
 import { computed, defineAsyncComponent, onBeforeUnmount, onMounted, ref, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 import { NButton, NDrawer, NDrawerContent, NSpin, useMessage } from "naive-ui";
@@ -145,6 +150,14 @@ const displayText = computed(() => {
     .filter(Boolean)
     .join('\n');
 });
+const parsedMessageReference = computed(() =>
+  props.message.role === 'user' ? parseMessageReference(displayText.value) : null,
+)
+const referencedContentMarkdown = computed(() =>
+  parsedMessageReference.value
+    ? formatReferencedContentForDisplay(parsedMessageReference.value.content)
+    : '',
+)
 
 // Extract files from ContentBlock[]
 const contentFiles = computed<DisplayContentFile[] | null>(() => {
@@ -203,6 +216,11 @@ const assistantProfileAvatar = computed(() => profilesStore.profiles.find(profil
 // Copy entire bubble content
 const copyableContent = computed(() => {
   if (props.message.role === 'tool') return null
+  if (parsedMessageReference.value) {
+    return [referencedContentMarkdown.value, parsedMessageReference.value.reply]
+      .filter(Boolean)
+      .join('\n\n')
+  }
   const content = props.message.content || ''
   if (!content.trim()) return null
   return content
@@ -224,9 +242,30 @@ async function copyBubbleContent() {
   toast.error(t('chat.copyFailed'))
 }
 
+function referenceBubbleContent() {
+  const content = quotableContent.value
+  const sessionId = chatStore.activeSessionId
+  if (!content || !sessionId) return
+  chatStore.setMessageReference(sessionId, {
+    id: props.message.id,
+    role: props.message.role as 'user' | 'assistant',
+    content,
+    sender: props.message.role,
+  })
+}
+
 const parsedThinking = computed(() =>
   parseThinking(props.message.content || "", { streaming: !!props.message.isStreaming }),
 );
+
+const quotableContent = computed(() => {
+  if (props.message.role !== 'user' && props.message.role !== 'assistant') return null
+  if (props.message.isStreaming || isAgentError.value) return null
+  const content = props.message.role === 'assistant'
+    ? parsedThinking.value.body.trim()
+    : (parsedMessageReference.value?.reply || parsedMessageReference.value?.content || displayText.value).trim()
+  return content || null
+})
 
 // 优先使用来自 reasoning 字段/事件的思考文本；否则回退到从 content 解析的 <think> 标签。
 // 若两者共存，则拼接展示（罕见，但保持信息不丢）。
@@ -1149,10 +1188,12 @@ onBeforeUnmount(() => {
                     </template>
                   </div>
                 </div>
-                <MarkdownRenderer v-if="displayText" :content="displayText" />
               </template>
-              <!-- Plain text format -->
-              <MarkdownRenderer v-else-if="message.content" :content="message.content" />
+              <template v-if="parsedMessageReference">
+                <MarkdownRenderer :content="referencedContentMarkdown" />
+                <MarkdownRenderer v-if="parsedMessageReference.reply" :content="parsedMessageReference.reply" />
+              </template>
+              <MarkdownRenderer v-else-if="displayText" :content="displayText" />
             </template>
 
             <!-- Render assistant message content -->
@@ -1214,6 +1255,17 @@ onBeforeUnmount(() => {
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
                 <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+              </svg>
+            </button>
+            <button
+              v-if="quotableContent"
+              class="reference-bubble-btn"
+              @click="referenceBubbleContent"
+              :title="t('chat.referenceMessage')"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M9 17l-5-5 5-5" />
+                <path d="M20 18v-2a4 4 0 0 0-4-4H4" />
               </svg>
             </button>
             <button
@@ -1688,6 +1740,7 @@ onBeforeUnmount(() => {
 }
 
 .copy-bubble-btn,
+.reference-bubble-btn,
 .speech-bubble-btn,
 .fork-bubble-btn {
   display: flex;

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -20,7 +20,7 @@ import { useI18n } from "vue-i18n";
 import { NButton, NInput } from "naive-ui";
 import VirtualMessageList from "./VirtualMessageList.vue";
 import MessageItem from "./MessageItem.vue";
-import { LIVE_CHAT_MAX_LOADED_MESSAGES, useChatStore, type Message } from "@/stores/hermes/chat";
+import { LIVE_CHAT_MAX_LOADED_MESSAGES, parseMessageReference, useChatStore, type Message } from "@/stores/hermes/chat";
 import thinkingImage from "@/assets/thinking.gif";
 import { useToolTraceVisibility } from "@/composables/useToolTraceVisibility";
 
@@ -260,7 +260,9 @@ function removeQueuedMessage(messageId: string) {
 }
 
 function queuedPreview(content: string): string {
-  const normalized = content.replace(/\s+/g, " ").trim();
+  const reference = parseMessageReference(content);
+  const visibleContent = reference?.reply || reference?.content || content;
+  const normalized = visibleContent.replace(/\s+/g, " ").trim();
   return normalized.length > 48 ? `${normalized.slice(0, 48)}...` : normalized;
 }
 

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -23,6 +23,10 @@ const attachments = ref<Attachment[]>([])
 const isDragging = ref(false)
 const dragCounter = ref(0)
 const isComposing = ref(false)
+const activeMessageReference = computed(() => store.activeMessageReference)
+const messageReferencePreview = computed(() =>
+    activeMessageReference.value?.content.replace(/\s+/g, ' ').trim() || '',
+)
 const autoPlaySpeech = ref(false)
 const inputSettingsOptions = computed<DropdownOption[]>(() => [
     {
@@ -85,6 +89,19 @@ watch(() => settingsStore.display.chat_input_height, () => {
     manualTextareaResize.value = false
     applyConfiguredTextareaHeight()
 })
+
+watch(
+    () => activeMessageReference.value?.id,
+    (id) => {
+        if (id) nextTick(() => textareaRef.value?.focus())
+    },
+)
+
+function clearMessageReference() {
+    const roomId = store.currentRoomId
+    if (roomId) store.clearMessageReference(roomId)
+    textareaRef.value?.focus()
+}
 
 // 自定义高度拖拽
 const textareaHeight = ref<number | null>(null)
@@ -467,6 +484,21 @@ function isImage(type: string): boolean {
                 </button>
             </div>
         </div>
+        <div v-if="activeMessageReference" class="message-reference-preview">
+            <span class="message-reference-text">{{ messageReferencePreview }}</span>
+            <button
+                type="button"
+                class="message-reference-remove"
+                :aria-label="t('chat.cancelReference')"
+                :title="t('chat.cancelReference')"
+                @click.stop="clearMessageReference"
+            >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+            </button>
+        </div>
         <div
             class="input-wrapper"
             :class="{ 'drag-over': isDragging }"
@@ -757,6 +789,49 @@ function isImage(type: string): boolean {
 @keyframes typing-bounce {
     0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
     30% { transform: translateY(-3px); opacity: 1; }
+}
+
+.message-reference-preview {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    margin: 0 8px 8px;
+    padding: 4px 8px;
+    border-radius: 8px;
+    background: rgba(var(--accent-primary-rgb), 0.07);
+    cursor: default;
+}
+
+.message-reference-text {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    color: $text-secondary;
+    font-size: 12px;
+    line-height: 24px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.message-reference-remove {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 24px;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: 0;
+    border-radius: 7px;
+    background: transparent;
+    color: $text-muted;
+    cursor: pointer;
+
+    &:hover {
+        color: $text-primary;
+        background: rgba(var(--text-primary-rgb), 0.08);
+    }
 }
 
 .input-wrapper {

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -18,6 +18,8 @@ import { speedToEdgeRate, hzToEdgePitch } from '@/utils/ttsHelpers'
 import { getDownloadUrl } from '@/api/hermes/download'
 import { formatChatTimestamp } from '@/utils/chat-timestamp'
 import type { ChatMessage, RoomAgent, MemberInfo } from '@/api/hermes/group-chat'
+import { useGroupChatStore } from '@/stores/hermes/group-chat'
+import { formatReferencedContentForDisplay, parseMessageReference } from '@/stores/hermes/chat'
 
 const MarkdownRenderer = defineAsyncComponent(async () => (await import('../chat/MarkdownRenderer.vue')).default)
 
@@ -38,6 +40,7 @@ const props = defineProps<{
 
 const { t } = useI18n()
 const toast = useMessage()
+const groupChatStore = useGroupChatStore()
 const profilesStore = useProfilesStore()
 const speech = useGlobalSpeech()
 const voiceSettings = useVoiceSettings()
@@ -167,10 +170,32 @@ const displayBody = computed(() => {
         .map((block: any) => block.text)
         .join('\n')
 })
+const parsedMessageReference = computed(() =>
+    props.message.role !== 'assistant' && props.message.role !== 'tool'
+        ? parseMessageReference(displayBody.value)
+        : null,
+)
+const referencedContentMarkdown = computed(() =>
+    parsedMessageReference.value
+        ? formatReferencedContentForDisplay(parsedMessageReference.value.content)
+        : '',
+)
 const copyableContent = computed(() => {
     if (isToolMessage.value) return null
+    if (parsedMessageReference.value) {
+        return [referencedContentMarkdown.value, parsedMessageReference.value.reply]
+            .filter(Boolean)
+            .join('\n\n')
+    }
     const content = displayBody.value || ''
     return content.trim() ? content : null
+})
+const quotableContent = computed(() => {
+    if (isToolMessage.value || props.message.isStreaming || isAgentError.value) return null
+    const content = props.message.role === 'assistant'
+        ? assistantBody.value
+        : parsedMessageReference.value?.reply || parsedMessageReference.value?.content || displayBody.value
+    return content.trim() || null
 })
 
 const toolExpanded = ref(false)
@@ -465,6 +490,19 @@ async function copyBubbleContent() {
     else toast.error(t('chat.copyFailed'))
 }
 
+function referenceBubbleContent() {
+    const content = quotableContent.value
+    const roomId = groupChatStore.currentRoomId
+    if (!content || !roomId) return
+    const role = props.message.role === 'assistant' || isAgent.value ? 'assistant' : 'user'
+    groupChatStore.setMessageReference(roomId, {
+        id: props.message.id,
+        role,
+        content,
+        sender: props.message.senderName || props.message.senderId,
+    })
+}
+
 function isImage(type: string): boolean {
     return type.startsWith('image/')
 }
@@ -649,7 +687,11 @@ onBeforeUnmount(() => {
                         <MarkdownRenderer :content="thinkingFullText" />
                     </div>
                 </div>
-                <MarkdownRenderer v-if="displayBody" :content="displayBody" :mention-names="mentionNames" />
+                <template v-if="parsedMessageReference">
+                    <MarkdownRenderer :content="referencedContentMarkdown" :mention-names="mentionNames" />
+                    <MarkdownRenderer v-if="parsedMessageReference.reply" :content="parsedMessageReference.reply" :mention-names="mentionNames" />
+                </template>
+                <MarkdownRenderer v-else-if="displayBody" :content="displayBody" :mention-names="mentionNames" />
                 <span v-if="message.isStreaming && !displayBody" class="streaming-dots">
                     <span></span><span></span><span></span>
                 </span>
@@ -674,6 +716,17 @@ onBeforeUnmount(() => {
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
                         <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                    </svg>
+                </button>
+                <button
+                    v-if="quotableContent"
+                    class="reference-bubble-btn"
+                    :title="t('chat.referenceMessage')"
+                    @click="referenceBubbleContent"
+                >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M9 17l-5-5 5-5" />
+                        <path d="M20 18v-2a4 4 0 0 0-4-4H4" />
                     </svg>
                 </button>
                 <span class="message-time">{{ timeStr }}</span>
@@ -727,7 +780,7 @@ onBeforeUnmount(() => {
     }
 
     &.self .msg-content {
-        background-color: rgba(var(--accent-primary-rgb), 0.1);
+        background-color: rgba(var(--accent-primary-rgb), 0.06);
     }
 }
 
@@ -1016,6 +1069,7 @@ onBeforeUnmount(() => {
 }
 
 .copy-bubble-btn,
+.reference-bubble-btn,
 .speech-bubble-btn {
     display: flex;
     align-items: center;

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -652,6 +652,8 @@ export default {
     copyBubble: 'Nachricht kopieren',
     copiedBubble: 'Nachricht kopiert',
     copyFailed: 'Kopieren fehlgeschlagen',
+    referenceMessage: 'Nachricht zitieren',
+    cancelReference: 'Zitat entfernen',
     playSpeech: 'Sprache abspielen',
     pauseSpeech: 'Pausieren',
     resumeSpeech: 'Fortsetzen',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -744,6 +744,8 @@ export default {
     copyBubble: 'Copy message',
     copiedBubble: 'Message copied',
     copyFailed: 'Copy failed',
+    referenceMessage: 'Reference message',
+    cancelReference: 'Cancel reference',
     playSpeech: 'Play voice',
     pauseSpeech: 'Pause',
     resumeSpeech: 'Resume',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -652,6 +652,8 @@ export default {
     copyBubble: 'Copiar mensaje',
     copiedBubble: 'Mensaje copiado',
     copyFailed: 'Error al copiar',
+    referenceMessage: 'Citar mensaje',
+    cancelReference: 'Cancelar cita',
     playSpeech: 'Reproducir voz',
     pauseSpeech: 'Pausa',
     resumeSpeech: 'Reanudar',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -652,6 +652,8 @@ export default {
     copyBubble: 'Copier le message',
     copiedBubble: 'Message copié',
     copyFailed: 'Échec de la copie',
+    referenceMessage: 'Citer le message',
+    cancelReference: 'Annuler la citation',
     playSpeech: 'Lire à voix haute',
     pauseSpeech: 'Pause',
     resumeSpeech: 'Reprendre',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -652,6 +652,8 @@ export default {
     copyBubble: 'メッセージをコピー',
     copiedBubble: 'コピーしました',
     copyFailed: 'コピーに失敗しました',
+    referenceMessage: 'メッセージを引用',
+    cancelReference: '引用を解除',
     playSpeech: '音声を読み上げ',
     pauseSpeech: '一時停止',
     resumeSpeech: '再開',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -652,6 +652,8 @@ export default {
     copyBubble: '메시지 복사',
     copiedBubble: '복사됨',
     copyFailed: '복사 실패',
+    referenceMessage: '메시지 인용',
+    cancelReference: '인용 취소',
     playSpeech: '음성 재생',
     pauseSpeech: '일시정지',
     resumeSpeech: '재개',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -652,6 +652,8 @@ export default {
     copyBubble: 'Copiar mensagem',
     copiedBubble: 'Mensagem copiada',
     copyFailed: 'Falha ao copiar',
+    referenceMessage: 'Citar mensagem',
+    cancelReference: 'Cancelar citação',
     playSpeech: 'Reproduzir voz',
     pauseSpeech: 'Pausar',
     resumeSpeech: 'Retomar',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -622,6 +622,8 @@ export default {
     copyBubble: 'Копировать сообщение',
     copiedBubble: 'Скопировано',
     copyFailed: 'Ошибка копирования',
+    referenceMessage: 'Цитировать сообщение',
+    cancelReference: 'Отменить цитирование',
     playSpeech: 'Воспроизвести речь',
     pauseSpeech: 'Пауза',
     resumeSpeech: 'Продолжить',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -733,6 +733,8 @@ export default {
     copyBubble: '複製訊息',
     copiedBubble: '已複製',
     copyFailed: '複製失敗',
+    referenceMessage: '引用訊息',
+    cancelReference: '取消引用',
     playSpeech: '播放語音',
     pauseSpeech: '暫停',
     resumeSpeech: '繼續',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -744,6 +744,8 @@ export default {
     copyBubble: '复制消息',
     copiedBubble: '已复制',
     copyFailed: '复制失败',
+    referenceMessage: '引用消息',
+    cancelReference: '取消引用',
     playSpeech: '播放语音',
     pauseSpeech: '暂停',
     resumeSpeech: '继续',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -85,6 +85,51 @@ export interface Message {
   runMarker?: string | null
 }
 
+export interface MessageReference {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  sender?: string
+}
+
+export interface ParsedMessageReference {
+  content: string
+  reply: string
+}
+
+export function parseMessageReference(content: string): ParsedMessageReference | null {
+  if (!content.startsWith('<quoted_message')) return null
+  const openEnd = content.indexOf('>\n')
+  if (openEnd === -1) return null
+  const closeMarker = '\n</quoted_message>'
+  const closeStart = content.indexOf(closeMarker, openEnd + 2)
+  if (closeStart === -1) return null
+
+  return {
+    content: content.slice(openEnd + 2, closeStart).trim(),
+    reply: content.slice(closeStart + closeMarker.length).trim(),
+  }
+}
+
+export function formatReferencedContentForDisplay(content: string): string {
+  return content
+    .trim()
+    .split(/\r?\n/)
+    .map(line => line ? `> ${line}` : '>')
+    .join('\n')
+}
+
+export function formatMessageWithReference(reference: MessageReference, content: string): string {
+  const sender = reference.sender?.trim()
+  const openTag = sender
+    ? `<quoted_message sender=${JSON.stringify(sender)}>`
+    : '<quoted_message>'
+  const quotedContent = reference.content.trim()
+  const reply = content.trim()
+  const referenceBlock = `${openTag}\n${quotedContent}\n</quoted_message>`
+  return reply ? `${referenceBlock}\n\n${reply}` : referenceBlock
+}
+
 export interface PendingApproval {
   sessionId: string
   approvalId: string
@@ -710,6 +755,12 @@ export const useChatStore = defineStore('chat', () => {
   const queuedUserMessages = ref<Map<string, Message[]>>(new Map())
   /** sessionId → queue ids that server reported as dequeued before the peer message arrived */
   const dequeuedQueueIds = ref<Map<string, Set<string>>>(new Map())
+  /** sessionId → message selected as the reference for the next user turn */
+  const messageReferences = ref<Map<string, MessageReference>>(new Map())
+  const activeMessageReference = computed(() => {
+    const sid = activeSessionId.value
+    return sid ? messageReferences.value.get(sid) || null : null
+  })
   const pendingApprovals = ref<Map<string, PendingApproval>>(new Map())
   const activePendingApproval = computed(() => {
     const sid = activeSessionId.value
@@ -826,6 +877,19 @@ export const useChatStore = defineStore('chat', () => {
     const next = new Set(completedUnreadSessions.value)
     next.delete(sessionId)
     completedUnreadSessions.value = next
+  }
+
+  function setMessageReference(sessionId: string, reference: MessageReference) {
+    const next = new Map(messageReferences.value)
+    next.set(sessionId, reference)
+    messageReferences.value = next
+  }
+
+  function clearMessageReference(sessionId: string) {
+    if (!messageReferences.value.has(sessionId)) return
+    const next = new Map(messageReferences.value)
+    next.delete(sessionId)
+    messageReferences.value = next
   }
 
   function markSessionCompletedUnread(sessionId: string, hasQueue = false) {
@@ -1515,6 +1579,7 @@ export const useChatStore = defineStore('chat', () => {
     const ok = await deleteSessionApi(sessionId, target?.profile)
     if (!ok) return false
     sessions.value = sessions.value.filter(s => s.id !== sessionId)
+    clearMessageReference(sessionId)
     if (activeSessionId.value === sessionId) {
       if (sessions.value.length > 0) {
         await switchSession(sessions.value[0].id)
@@ -1531,6 +1596,7 @@ export const useChatStore = defineStore('chat', () => {
     const ok = await archiveSessionApi(sessionId)
     if (!ok) return false
     sessions.value = sessions.value.filter(s => s.id !== sessionId)
+    clearMessageReference(sessionId)
     if (completedUnreadSessions.value.has(sessionId)) {
       const next = new Set(completedUnreadSessions.value)
       next.delete(sessionId)
@@ -1793,6 +1859,7 @@ export const useChatStore = defineStore('chat', () => {
       if (target) target.messages = []
       queuedUserMessages.value.delete(sid)
       queueLengths.value.delete(sid)
+      clearMessageReference(sid)
       if ((evt as any).clearHistory) {
         const message = String((evt as any).message || '')
         if (message) {
@@ -1826,6 +1893,7 @@ export const useChatStore = defineStore('chat', () => {
       serverWorking.value.delete(sid)
       queueLengths.value.delete(sid)
       queuedUserMessages.value.delete(sid)
+      clearMessageReference(sid)
       setAbortState(null)
       const msgs = getSessionMsgs(sid)
       msgs.forEach(m => {
@@ -2303,6 +2371,10 @@ export const useChatStore = defineStore('chat', () => {
     const isBridgeMoaCommand = isBridgeSlashCommand && /^\/moa(?:\s|$)/i.test(trimmedContent)
     const isBridgeGoalCommand = isBridgeSlashCommand && /^\/goal(?:\s|$)/i.test(trimmedContent)
     const isBridgeForkCommand = isBridgeSlashCommand && /^\/fork(?:\s|$)/i.test(trimmedContent)
+    const messageReference = isBridgeSlashCommand ? null : messageReferences.value.get(sid) || null
+    const submittedContent = messageReference
+      ? formatMessageWithReference(messageReference, trimmedContent)
+      : trimmedContent
     const shouldOptimisticallyShowRunStatus = !isCodingAgentSession && !isBridgeForkCommand
     const wasLiveBeforeSend = isSessionLive(sid)
     if (isBridgeForkCommand) {
@@ -2322,7 +2394,7 @@ export const useChatStore = defineStore('chat', () => {
     const userMsg: Message = {
       id: uid(),
       role: isBridgeSlashCommand ? 'command' : 'user',
-      content: trimmedContent,
+      content: submittedContent,
       timestamp: Date.now(),
       attachments: attachments && attachments.length > 0 ? attachments : undefined,
       queued: shouldQueue,
@@ -2336,6 +2408,7 @@ export const useChatStore = defineStore('chat', () => {
       updateSessionTitle(sid)
       if (shouldOptimisticallyShowRunStatus) serverWorking.value.add(sid)
     }
+    clearMessageReference(sid)
 
     let runSubmitted = false
     try {
@@ -2368,10 +2441,10 @@ export const useChatStore = defineStore('chat', () => {
         }
 
         // Build content blocks with uploaded file paths
-        input = await buildContentBlocks(content, attachments, uploaded)
+        input = await buildContentBlocks(submittedContent, attachments, uploaded)
       } else {
         // No attachments: use plain text format
-        input = trimmedContent
+        input = submittedContent
       }
 
       const appStore = useAppStore()
@@ -4015,10 +4088,13 @@ export const useChatStore = defineStore('chat', () => {
     isAborting,
     queueLengths,
     queuedUserMessages,
+    activeMessageReference,
     pendingApprovals,
     activePendingApproval,
     activePendingClarify,
     removeQueuedMessage,
+    setMessageReference,
+    clearMessageReference,
     isLoadingSessions,
     sessionsLoaded,
     isLoadingMessages,

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -4,7 +4,7 @@ import { getActiveProfileName, getApiKey, getStoredUsername } from '@/api/client
 import { fetchCurrentUser } from '@/api/auth'
 import { getDownloadUrl } from '@/api/hermes/download'
 import { responseErrorMessage } from '@/utils/http-error'
-import type { Attachment, ContentBlock } from './chat'
+import { formatMessageWithReference, type Attachment, type ContentBlock, type MessageReference } from './chat'
 import {
     connectGroupChat,
     disconnectGroupChat,
@@ -137,6 +137,11 @@ export const useGroupChatStore = defineStore('groupChat', () => {
     const currentRoomId = ref<string | null>(null)
     const rooms = ref<RoomInfo[]>([])
     const messages = ref<ChatMessage[]>([])
+    const messageReferences = ref<Map<string, MessageReference>>(new Map())
+    const activeMessageReference = computed(() => {
+        const roomId = currentRoomId.value
+        return roomId ? messageReferences.value.get(roomId) || null : null
+    })
     const members = ref<MemberInfo[]>([])
     const agents = ref<RoomAgent[]>([])
     const roomName = ref('')
@@ -170,6 +175,19 @@ const currentUserAvatar = ref('')
 
     function setAutoPlaySpeech(enabled: boolean) {
         autoPlaySpeechEnabled.value = enabled
+    }
+
+    function setMessageReference(roomId: string, reference: MessageReference) {
+        const next = new Map(messageReferences.value)
+        next.set(roomId, reference)
+        messageReferences.value = next
+    }
+
+    function clearMessageReference(roomId: string) {
+        if (!messageReferences.value.has(roomId)) return
+        const next = new Map(messageReferences.value)
+        next.delete(roomId)
+        messageReferences.value = next
     }
 
     function playMessageSpeech(messageId: string, content: string) {
@@ -663,18 +681,24 @@ const currentUserAvatar = ref('')
     async function sendMessage(content: string, attachments?: Attachment[]) {
         const socket = getSocket()
         if (!socket || !currentRoomId.value) return
+        const roomId = currentRoomId.value
         emitStopTyping()
         const messageId = uid()
-        let finalContent: string | ContentBlock[] = content.trim()
+        const messageReference = messageReferences.value.get(roomId) || null
+        const submittedContent = messageReference
+            ? formatMessageWithReference(messageReference, content)
+            : content.trim()
+        clearMessageReference(roomId)
+        let finalContent: string | ContentBlock[] = submittedContent
         if (attachments?.length) {
             const uploaded = await uploadGroupFiles(attachments)
-            finalContent = buildGroupContentBlocks(content, attachments, uploaded)
+            finalContent = buildGroupContentBlocks(submittedContent, attachments, uploaded)
             const urlMap = new Map(uploaded.map(f => {
                 return [f.name, getDownloadUrl(normalizeLocalFilePath(f.path), f.name)]
             }))
             messages.value.push({
                 id: messageId,
-                roomId: currentRoomId.value,
+                roomId,
                 senderId: userId.value,
                 senderName: userName.value || 'You',
                 content: JSON.stringify(finalContent),
@@ -687,7 +711,7 @@ const currentUserAvatar = ref('')
         }
 
         return new Promise<void>((resolve, reject) => {
-            socket!.emit('message', { roomId: currentRoomId.value, id: messageId, content: finalContent }, (res: { id?: string; error?: string }) => {
+            socket!.emit('message', { roomId, id: messageId, content: finalContent }, (res: { id?: string; error?: string }) => {
                 if (res.error) {
                     messages.value = messages.value.filter(m => m.id !== messageId)
                     reject(new Error(res.error))
@@ -744,6 +768,7 @@ const currentUserAvatar = ref('')
         try {
             await deleteRoomApi(roomId)
             rooms.value = rooms.value.filter(r => r.id !== roomId)
+            clearMessageReference(roomId)
             if (currentRoomId.value === roomId) {
                 currentRoomId.value = null
                 messages.value = []
@@ -771,9 +796,11 @@ const currentUserAvatar = ref('')
 
     async function clearCurrentRoomContext() {
         if (!currentRoomId.value) return
+        const roomId = currentRoomId.value
         try {
-            const res = await clearRoomContext(currentRoomId.value)
+            const res = await clearRoomContext(roomId)
             messages.value = []
+            clearMessageReference(roomId)
             resetMessagePaging()
             typingUsers.value.clear()
             contextStatuses.value.clear()
@@ -893,6 +920,7 @@ const currentUserAvatar = ref('')
         pendingApprovals,
         activePendingApproval,
         autoPlaySpeechEnabled,
+        activeMessageReference,
         totalMessages,
         loadedMessageCount,
         hasMoreBefore,
@@ -911,6 +939,8 @@ const currentUserAvatar = ref('')
         disconnect,
         setUserInfo,
         setAutoPlaySpeech,
+        setMessageReference,
+        clearMessageReference,
         joinRoom,
         loadOlderMessages,
         sendMessage,

--- a/packages/server/src/services/hermes/group-chat/mention-routing.ts
+++ b/packages/server/src/services/hermes/group-chat/mention-routing.ts
@@ -13,6 +13,11 @@ type MentionRange = {
 
 const BEFORE_BOUNDARY = new Set(['(', '[', '{', '<'])
 const AFTER_BOUNDARY = new Set(['.', ',', '!', '?', ';', ':', '，', '。', '！', '？', '；', '：', ')', ']', '}', '>'])
+const QUOTED_MESSAGE_BLOCK_RE = /<quoted_message(?:\s[^>]*)?>[\s\S]*?<\/quoted_message>/gi
+
+function maskQuotedMessageBlocks(content: string): string {
+    return content.replace(QUOTED_MESSAGE_BLOCK_RE, block => block.replace(/[^\n]/g, ' '))
+}
 
 export function escapeMentionName(name: string): string {
     return name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -33,7 +38,8 @@ function isAfterBoundary(char: string | undefined): boolean {
 function findMentionRanges(content: string, mentionName: string): MentionRange[] {
     if (!content || !mentionName) return []
 
-    const contentLower = content.toLowerCase()
+    const routableContent = maskQuotedMessageBlocks(content)
+    const contentLower = routableContent.toLowerCase()
     const mentionLower = mentionName.toLowerCase()
     const ranges: MentionRange[] = []
     let fromIndex = 0
@@ -44,7 +50,7 @@ function findMentionRanges(content: string, mentionName: string): MentionRange[]
 
         const start = atIndex
         const end = atIndex + mentionName.length + 1
-        if (isBeforeBoundary(content[start - 1]) && isAfterBoundary(content[end])) {
+        if (isBeforeBoundary(routableContent[start - 1]) && isAfterBoundary(routableContent[end])) {
             ranges.push({ start, end })
         }
         fromIndex = atIndex + 1

--- a/tests/client/chat-input-draft.test.ts
+++ b/tests/client/chat-input-draft.test.ts
@@ -118,6 +118,27 @@ describe('ChatInput draft persistence', () => {
     expect((remountedA.get('textarea').element as HTMLTextAreaElement).value).toBe('draft for session a')
   })
 
+  it('shows and cancels the active session message reference', async () => {
+    const wrapper = mountForSession('session-reference')
+    const chatStore = useChatStore()
+
+    chatStore.setMessageReference('session-reference', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'A referenced assistant response',
+    })
+    await nextTick()
+
+    expect(wrapper.get('.message-reference-preview').text()).toContain('A referenced assistant response')
+    expect(wrapper.get('.message-reference-preview').element.parentElement?.classList.contains('input-wrapper')).toBe(false)
+    expect(chatStore.activeMessageReference?.id).toBe('assistant-1')
+
+    await wrapper.get('.message-reference-remove').trigger('click')
+
+    expect(wrapper.find('.message-reference-preview').exists()).toBe(false)
+    expect(chatStore.activeMessageReference).toBeNull()
+  })
+
   it('applies the configured desktop input height from display settings', async () => {
     const wrapper = mountForSession('session-a', {}, { chat_input_height: 180 })
     await flushPromises()

--- a/tests/client/chat-message-reference.test.ts
+++ b/tests/client/chat-message-reference.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { formatMessageWithReference, formatReferencedContentForDisplay, parseMessageReference } from '@/stores/hermes/chat'
+
+describe('single-chat message references', () => {
+  it('formats a referenced message as a readable Markdown quote', () => {
+    expect(formatMessageWithReference({
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'First line\n\nSecond line',
+    }, 'Continue from this answer')).toBe([
+      '<quoted_message>',
+      'First line',
+      '',
+      'Second line',
+      '</quoted_message>',
+      '',
+      'Continue from this answer',
+    ].join('\n'))
+  })
+
+  it('supports an attachment-only reply while preserving the reference', () => {
+    expect(formatMessageWithReference({
+      id: 'user-1',
+      role: 'user',
+      content: 'Review this file',
+    }, '')).toBe([
+      '<quoted_message>',
+      'Review this file',
+      '</quoted_message>',
+    ].join('\n'))
+  })
+
+  it('parses agent markup for clean display without exposing the tags', () => {
+    const parsed = parseMessageReference([
+      '<quoted_message sender="Worker">',
+      '@Reviewer previous answer',
+      '</quoted_message>',
+      '',
+      'Continue from there',
+    ].join('\n'))
+
+    expect(parsed).toEqual({
+      content: '@Reviewer previous answer',
+      reply: 'Continue from there',
+    })
+    expect(formatReferencedContentForDisplay(parsed!.content)).toBe('> @Reviewer previous answer')
+  })
+})

--- a/tests/client/group-chat-input-mentions.test.ts
+++ b/tests/client/group-chat-input-mentions.test.ts
@@ -54,6 +54,31 @@ describe('GroupChatInput mentions', () => {
     expect(wrapper.find('.mention-dropdown').text()).toContain('@Worker')
   })
 
+  it('shows the active room reference outside the input and can cancel it', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    const settingsStore = useSettingsStore()
+    settingsStore.display = {}
+    const store = useGroupChatStore()
+    store.currentRoomId = 'room-1'
+    store.setMessageReference('room-1', {
+      id: 'message-1',
+      role: 'assistant',
+      content: 'A referenced group response',
+      sender: 'Worker',
+    })
+
+    const wrapper = mount(GroupChatInput, {
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+    await nextTick()
+
+    expect(wrapper.get('.message-reference-preview').text()).toContain('A referenced group response')
+    expect(wrapper.get('.message-reference-preview').element.parentElement?.classList.contains('input-wrapper')).toBe(false)
+
+    await wrapper.get('.message-reference-remove').trigger('click')
+    expect(store.activeMessageReference).toBeNull()
+  })
+
   it('applies the configured desktop input height', async () => {
     const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
     const settingsStore = useSettingsStore()

--- a/tests/client/group-chat-store-baseline.test.ts
+++ b/tests/client/group-chat-store-baseline.test.ts
@@ -263,6 +263,32 @@ describe('group chat store baseline lifecycle', () => {
     expect(store.error).toBeNull()
   })
 
+  it('sends a group reference with explicit agent markup and clears the draft reference', async () => {
+    const store = await loadStore()
+    await store.connect()
+    await store.joinRoom('room-1')
+    store.setMessageReference('room-1', {
+      id: 'quoted-1',
+      role: 'assistant',
+      content: '@Agent previous answer',
+      sender: 'Agent',
+    })
+
+    await store.sendMessage('@Agent continue')
+
+    expect(groupChatApiMock.socket.emit).toHaveBeenCalledWith('message', expect.objectContaining({
+      roomId: 'room-1',
+      content: [
+        '<quoted_message sender="Agent">',
+        '@Agent previous answer',
+        '</quoted_message>',
+        '',
+        '@Agent continue',
+      ].join('\n'),
+    }), expect.any(Function))
+    expect(store.activeMessageReference).toBeNull()
+  })
+
   it('clears local room context from API response and room_cleared event', async () => {
     const store = await loadStore()
     groupChatApiMock.getRoomDetail.mockResolvedValue({

--- a/tests/client/group-message-item-highlight.test.ts
+++ b/tests/client/group-message-item-highlight.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/api/hermes/download', () => ({
 
 import GroupMessageItem from '@/components/hermes/group-chat/GroupMessageItem.vue'
 import type { ChatMessage } from '@/api/hermes/group-chat'
+import { useGroupChatStore } from '@/stores/hermes/group-chat'
 
 function mountToolMessage(message: Partial<ChatMessage>) {
   return mount(GroupMessageItem, {
@@ -72,6 +73,36 @@ describe('GroupMessageItem tool details', () => {
         pause: vi.fn(),
         resume: vi.fn(),
       },
+    })
+  })
+
+  it('selects a group message as the active room reference', async () => {
+    const store = useGroupChatStore()
+    store.currentRoomId = 'room-1'
+    const wrapper = mount(GroupMessageItem, {
+      props: {
+        message: {
+          id: 'group-assistant',
+          roomId: 'room-1',
+          senderId: 'agent-1',
+          senderName: 'Worker',
+          role: 'assistant',
+          content: 'Use this group answer',
+          timestamp: Date.now(),
+        },
+        agents: [{ id: 'agent-row', roomId: 'room-1', agentId: 'agent-1', profile: 'worker', name: 'Worker', description: '', invited: 1 }],
+        members: [],
+        currentUserId: 'user-1',
+      },
+      global: { stubs: { MarkdownRenderer: true, ProfileAvatar: true } },
+    })
+
+    await wrapper.get('.reference-bubble-btn').trigger('click')
+
+    expect(store.activeMessageReference).toMatchObject({
+      id: 'group-assistant',
+      content: 'Use this group answer',
+      sender: 'Worker',
     })
   })
 

--- a/tests/client/message-item-highlight.test.ts
+++ b/tests/client/message-item-highlight.test.ts
@@ -33,7 +33,7 @@ vi.mock('naive-ui', () => ({
 }))
 
 import MessageItem from '@/components/hermes/chat/MessageItem.vue'
-import type { Message } from '@/stores/hermes/chat'
+import { useChatStore, type Message } from '@/stores/hermes/chat'
 
 describe('MessageItem tool details', () => {
   beforeEach(() => {
@@ -60,6 +60,50 @@ describe('MessageItem tool details', () => {
         resume: vi.fn(),
       },
     })
+  })
+
+  it('selects a completed user or assistant message as the next-turn reference', async () => {
+    const chatStore = useChatStore()
+    chatStore.activeSessionId = 'session-1'
+    const wrapper = mount(MessageItem, {
+      props: {
+        message: {
+          id: 'assistant-reference',
+          role: 'assistant',
+          content: 'Use this answer as context',
+          timestamp: Date.now(),
+        } satisfies Message,
+      },
+      global: { stubs: { MarkdownRenderer: true } },
+    })
+
+    await wrapper.get('.reference-bubble-btn').trigger('click')
+
+    expect(chatStore.activeMessageReference).toMatchObject({
+      id: 'assistant-reference',
+      role: 'assistant',
+      content: 'Use this answer as context',
+    })
+  })
+
+  it('keeps legacy assistant thinking text out of the message reference', async () => {
+    const chatStore = useChatStore()
+    chatStore.activeSessionId = 'session-1'
+    const wrapper = mount(MessageItem, {
+      props: {
+        message: {
+          id: 'assistant-with-thinking',
+          role: 'assistant',
+          content: '<think>private reasoning</think>Visible answer',
+          timestamp: Date.now(),
+        } satisfies Message,
+      },
+      global: { stubs: { MarkdownRenderer: true } },
+    })
+
+    await wrapper.get('.reference-bubble-btn').trigger('click')
+
+    expect(chatStore.activeMessageReference?.content).toBe('Visible answer')
   })
 
   it('renders highlighted code blocks for tool arguments and tool results', async () => {

--- a/tests/server/group-chat-mention-routing.test.ts
+++ b/tests/server/group-chat-mention-routing.test.ts
@@ -80,6 +80,20 @@ describe('group chat mention routing', () => {
     expect(resolveMentionTargets(specialAgents, '@C++: inspect', 'human-1').map(a => a.name)).toEqual(['C++'])
   })
 
+  it('ignores mentions inside a quoted message while preserving them as context', () => {
+    const content = [
+      '<quoted_message sender="Alice">',
+      '@Bob please review this',
+      '</quoted_message>',
+      '',
+      '@Regex.Bot what do you think?',
+    ].join('\n')
+
+    expect(resolveMentionTargets(agents, content, 'socket-alice').map(agent => agent.name)).toEqual(['Regex.Bot'])
+    expect(stripMentionRoutingTokens(content, 'Regex.Bot')).toContain('@Bob please review this')
+    expect(stripMentionRoutingTokens(content, 'Regex.Bot')).not.toContain('@Regex.Bot')
+  })
+
   it('dedupes mixed @all and explicit mentions', () => {
     expect(resolveMentionTargets(agents, '@all @Bob compare plans', 'socket-alice').map(a => a.name)).toEqual(['Bob', 'Regex.Bot'])
   })


### PR DESCRIPTION
## Summary

- add message reference actions to completed single-chat and group-chat messages
- show a removable one-line reference preview outside the composer
- send referenced content in an explicit `<quoted_message>` block while rendering a clean quote in the transcript
- keep references scoped to the active session or room and clear them after sending or context removal
- ignore `@` mentions inside quoted group-chat content so only mentions in the new reply route agents
- align the current user's group-chat bubble background with agent replies

## Why

Hermes Studio did not have a native way to reply with message context. Plain text prefixes were ambiguous to agents, and group-chat mentions copied from quoted content could incorrectly trigger routing.

This implementation keeps the existing persistence schema unchanged and carries reference context through the normal message content path.

## User impact

Users can quote a completed user or assistant/agent message in both chat modes. The quote preview stays compact, and quoted mentions remain context without waking an agent unless the user mentions that agent again in the new reply.

## Validation

- `npm run harness:check`
- `npm run test:coverage` — 325 files passed, 2580 tests passed, 2 skipped
- `npm run test:e2e` — 38 passed
- `npm run build`

Closes #2091
