### PR TITLE
[codex] unify desktop card layout

### DIFF
--- a/docs/chat-chain-changes/2026-07-16-desktop-card-layout.md
+++ b/docs/chat-chain-changes/2026-07-16-desktop-card-layout.md
@@ -1,0 +1,11 @@
+---
+date: 2026-07-16
+pr: 2100
+feature: Desktop card layout, chat surface colors, and conversation navigation state
+impact: Desktop chat, group chat, history, and workflow surfaces use a consistent inset card layout without changing message data, session state, routing, or Agent runtime behavior.
+---
+
+This change is visual only. Mobile main content keeps its previous edge-to-edge
+layout, while desktop sidebars and main surfaces gain shared spacing, radii,
+shadows, and theme-aware colors. Chat input, message persistence, context
+construction, Socket.IO events, and Agent execution behavior are unchanged.

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -92,7 +92,7 @@ useKeyboard()
               </button>
               <div v-if="!isLoginPage && showAppSidebar && appStore.sidebarOpen" class="mobile-backdrop" @click="appStore.closeSidebar" />
               <AppSidebar v-if="!isLoginPage && showAppSidebar" />
-              <main class="app-main">
+              <main class="app-main" :class="{ 'app-main--card': showAppSidebar }">
                 <router-view />
               </main>
             </div>
@@ -127,6 +127,7 @@ useKeyboard()
   width: 100%;
   max-width: 100%;
   overflow: hidden;
+  background-color: $bg-card;
 
   &.no-sidebar {
     display: block;
@@ -145,6 +146,34 @@ useKeyboard()
 
   .no-sidebar & {
     height: 100%;
+  }
+
+  &--card {
+    margin: 10px 10px 10px 0;
+    background-color: $bg-main-surface;
+    border: 1px solid $border-color;
+    border-radius: 14px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+  }
+}
+
+@media (min-width: 769px) {
+  .app-main--card {
+    overflow: hidden;
+
+    :deep(> *) {
+      height: 100% !important;
+      max-height: 100%;
+    }
+  }
+}
+
+@media (max-width: $breakpoint-mobile) {
+  .app-main--card {
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
   }
 }
 

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1440,12 +1440,8 @@ function isImage(type: string): boolean {
   z-index: 80;
   padding: 8px 20px 14px;
   border-top: 0;
-  background-color: $bg-card;
+  background-color: $bg-main-surface;
   flex-shrink: 0;
-
-  .dark & {
-    background-color: #333333;
-  }
 }
 
 .input-top-bar {

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -1995,7 +1995,10 @@ async function handleSessionModelCustomSubmit() {
       </NDrawerContent>
     </NDrawer>
 
-    <div class="chat-main">
+    <div
+      class="chat-main"
+      :class="{ 'chat-main--sidebar-collapsed': currentMode !== 'chat' || !showSessions }"
+    >
       <header class="chat-header">
         <div class="header-left">
           <NButton
@@ -2225,6 +2228,7 @@ async function handleSessionModelCustomSubmit() {
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
+  background-color: $bg-card;
 }
 
 .session-model-search {
@@ -2434,7 +2438,13 @@ async function handleSessionModelCustomSubmit() {
 
 .session-list {
   width: $sidebar-width;
-  border-right: 1px solid $border-color;
+  min-height: 0;
+  align-self: stretch;
+  margin: 10px;
+  background: $bg-sidebar-surface;
+  border: 1px solid $border-color;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
@@ -2445,23 +2455,26 @@ async function handleSessionModelCustomSubmit() {
 
   &.collapsed {
     width: 0;
-    border-right: none;
+    margin-left: 0;
+    margin-right: 0;
+    border: none;
+    box-shadow: none;
     opacity: 0;
     pointer-events: none;
   }
 
   @media (max-width: $breakpoint-mobile) {
     position: absolute;
-    left: 0;
-    top: 0;
-    height: 100%;
+    left: 10px;
+    top: 10px;
+    bottom: 10px;
+    height: auto;
+    margin: 0;
     z-index: 120;
-    background: $bg-card;
-    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
     width: $sidebar-width;
 
     &.collapsed {
-      transform: translateX(-100%);
+      transform: translateX(calc(-100% - 10px));
       opacity: 0;
     }
   }
@@ -2795,6 +2808,22 @@ async function handleSessionModelCustomSubmit() {
   flex-direction: column;
   overflow: hidden;
   min-width: 0;
+  margin: 10px 10px 10px 0;
+  background: $bg-main-surface;
+  border: 1px solid $border-color;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+
+  &--sidebar-collapsed {
+    margin-left: 10px;
+  }
+
+  @media (max-width: $breakpoint-mobile) {
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+  }
 }
 
 .chat-content-wrapper {
@@ -2823,7 +2852,7 @@ async function handleSessionModelCustomSubmit() {
   display: flex;
   flex-direction: column;
   min-width: 0;
-  background-color: $bg-card;
+  background-color: $bg-main-surface;
   animation: chat-surface-fade-in 1.5s ease both;
 }
 

--- a/packages/client/src/components/hermes/chat/HistoryMessageList.vue
+++ b/packages/client/src/components/hermes/chat/HistoryMessageList.vue
@@ -245,6 +245,17 @@ defineExpose({
   min-width: 0;
   position: relative;
   display: flex;
+  animation: history-message-surface-fade-in 1.5s ease both;
+}
+
+@keyframes history-message-surface-fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .empty-state {

--- a/packages/client/src/components/hermes/chat/VirtualMessageList.vue
+++ b/packages/client/src/components/hermes/chat/VirtualMessageList.vue
@@ -534,11 +534,7 @@ defineExpose({
   scrollbar-width: thin;
   padding: var(--virtual-list-padding);
   box-sizing: border-box;
-  background-color: $bg-card;
-
-  .dark & {
-    background-color: #333333;
-  }
+  background-color: $bg-main-surface;
 }
 
 .virtual-row {

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -610,12 +610,8 @@ function isImage(type: string): boolean {
 .chat-input-area {
     padding: 8px 20px 14px;
     border-top: 0;
-    background-color: $bg-card;
+    background-color: $bg-main-surface;
     flex-shrink: 0;
-
-    .dark & {
-        background-color: #333333;
-    }
 }
 
 .input-top-bar {

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -526,6 +526,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
         <!-- Main chat area -->
         <div
             class="chat-main"
+            :class="{ 'chat-main--sidebar-collapsed': !showSidebar }"
             @dragover="handleChatDragOver"
             @dragenter="handleChatDragEnter"
             @dragleave="handleChatDragLeave"
@@ -861,6 +862,7 @@ export default defineComponent({ components: { CreateRoomForm } })
     position: relative;
     min-width: 0;
     max-width: 100%;
+    background-color: $bg-card;
 }
 
 .sidebar-backdrop {
@@ -1103,10 +1105,17 @@ export default defineComponent({ components: { CreateRoomForm } })
 
 .room-sidebar {
     width: $sidebar-width;
+    min-height: 0;
+    align-self: stretch;
+    margin: 10px;
+    background: $bg-sidebar-surface;
+    border: 1px solid $border-color;
+    border-radius: 14px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
     flex-shrink: 0;
-    border-right: 1px solid $border-color;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
 }
 
 .sidebar-header {
@@ -1328,8 +1337,17 @@ export default defineComponent({ components: { CreateRoomForm } })
     display: flex;
     flex-direction: column;
     min-width: 0;
-    background-color: transparent;
+    margin: 10px 10px 10px 0;
+    overflow: hidden;
+    background-color: $bg-main-surface;
+    border: 1px solid $border-color;
+    border-radius: 14px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
     position: relative;
+
+    &--sidebar-collapsed {
+        margin-left: 10px;
+    }
 }
 
 .group-chat-content-wrapper {
@@ -1348,7 +1366,7 @@ export default defineComponent({ components: { CreateRoomForm } })
     min-width: 0;
     display: flex;
     flex-direction: column;
-    background-color: $bg-card;
+    background-color: $bg-main-surface;
     animation: group-chat-surface-fade-in 1.5s ease both;
 }
 
@@ -1719,14 +1737,21 @@ export default defineComponent({ components: { CreateRoomForm } })
 // ─── Mobile ──────────────────────────────────────────────
 
 @media (max-width: $breakpoint-mobile) {
+    .chat-main {
+        margin: 0;
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+    }
+
     .room-sidebar {
         position: absolute;
-        left: 0;
-        top: 0;
-        bottom: 0;
+        left: 10px;
+        top: 10px;
+        bottom: 10px;
+        height: auto;
+        margin: 0;
         z-index: 100;
-        background-color: $bg-card;
-        box-shadow: 4px 0 16px rgba(0, 0, 0, 0.1);
     }
 
     .chat-header {

--- a/packages/client/src/components/hermes/settings/ProxySettings.vue
+++ b/packages/client/src/components/hermes/settings/ProxySettings.vue
@@ -71,7 +71,8 @@ async function save() {
 @use '@/styles/variables' as *;
 
 .settings-section {
-  max-width: 820px;
+  width: 100%;
+  max-width: none;
 }
 
 .section-title {
@@ -86,7 +87,13 @@ async function save() {
 }
 
 .input-lg {
-  width: 360px;
+  width: 100%;
+}
+
+.proxy-settings :deep(.setting-info),
+.proxy-settings :deep(.setting-control) {
+  min-width: 0;
+  flex: 1;
 }
 
 .settings-actions {

--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -453,12 +453,18 @@ function handleUpdateClick() {
 .sidebar {
   position: relative;
   width: $sidebar-width;
-  height: calc(100 * var(--vh));
-  background-color: $bg-sidebar;
-  border-right: 1px solid $border-color;
+  height: auto;
+  min-height: 0;
+  align-self: stretch;
+  margin: 10px;
+  background-color: $bg-sidebar-surface;
+  border: 1px solid $border-color;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   padding: 8px 12px 20px;
+  overflow: hidden;
   flex-shrink: 0;
   transition: width $transition-normal;
 }
@@ -898,10 +904,13 @@ function handleUpdateClick() {
 @media (max-width: $breakpoint-mobile) {
   .sidebar {
     position: fixed;
-    left: 0;
-    top: 0;
+    left: 10px;
+    top: 10px;
+    bottom: 10px;
+    margin: 0;
+    height: auto;
     z-index: 1000;
-    transform: translateX(-100%);
+    transform: translateX(calc(-100% - 10px));
     transition: transform $transition-normal;
     padding-top: env(safe-area-inset-top, 0px);
 

--- a/packages/client/src/components/layout/DesktopTitleBar.vue
+++ b/packages/client/src/components/layout/DesktopTitleBar.vue
@@ -86,7 +86,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   border-bottom: 1px solid $border-color;
-  background: $bg-sidebar;
+  background: $bg-main-surface;
   color: $text-primary;
   user-select: none;
   -webkit-app-region: drag;

--- a/packages/client/src/components/layout/PageSidebarNav.vue
+++ b/packages/client/src/components/layout/PageSidebarNav.vue
@@ -304,4 +304,12 @@ function openApiRelay() {
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
   }
 }
+
+:global(.dark .conversation-switch--three .conversation-switch-tab.active) {
+  background: $bg-card-hover;
+  color: $accent-primary;
+  box-shadow:
+    inset 0 0 0 1px $border-color,
+    0 2px 5px rgba(0, 0, 0, 0.22);
+}
 </style>

--- a/packages/client/src/styles/variables.scss
+++ b/packages/client/src/styles/variables.scss
@@ -12,6 +12,8 @@
   --bg-card: #ffffff;
   --bg-card-hover: #fafafa;
   --bg-input: #ffffff;
+  --bg-sidebar-surface: var(--bg-card);
+  --bg-main-surface: var(--bg-card);
 
   // Borders
   --border-color: #e0e0e0;
@@ -64,6 +66,8 @@
   --bg-card: #2a2a2a;
   --bg-card-hover: #333333;
   --bg-input: #2a2a2a;
+  --bg-sidebar-surface: var(--bg-primary);
+  --bg-main-surface: var(--bg-primary);
 
   // Borders
   --border-color: #3a3a3a;
@@ -85,8 +89,8 @@
   --warning: #ffb74d;
 
   // Message bubbles
-  --msg-user-bg: #252525;
-  --msg-assistant-bg: #252525;
+  --msg-user-bg: #292929;
+  --msg-assistant-bg: #292929;
   --msg-system-border: #555555;
 
   // Code
@@ -138,6 +142,8 @@ $bg-sidebar: var(--bg-sidebar);
 $bg-card: var(--bg-card);
 $bg-card-hover: var(--bg-card-hover);
 $bg-input: var(--bg-input);
+$bg-sidebar-surface: var(--bg-sidebar-surface);
+$bg-main-surface: var(--bg-main-surface);
 
 // Borders
 $border-color: var(--border-color);

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -887,7 +887,10 @@ function handleBatchDeleteConfirm() {
       @clickoutside="handleClickOutside"
     />
 
-    <div class="chat-main">
+    <div
+      class="chat-main"
+      :class="{ 'chat-main--sidebar-collapsed': !showSessions }"
+    >
       <header class="chat-header">
         <div class="header-left">
           <NButton class="history-sidebar-toggle" quaternary size="small" @click="showSessions = !showSessions" circle>
@@ -926,6 +929,7 @@ function handleBatchDeleteConfirm() {
       <div class="history-content-wrapper">
         <div class="history-main-content">
           <HistoryMessageList
+            :key="historySession?.id || 'history-empty'"
             ref="historyMessageListRef"
             :session="historySession"
             :load-older="loadOlderHistoryMessages"
@@ -948,6 +952,8 @@ function handleBatchDeleteConfirm() {
   display: flex;
   height: 100%;
   position: relative;
+  overflow: hidden;
+  background: $bg-card;
 }
 
 .history-content-wrapper {
@@ -967,7 +973,13 @@ function handleBatchDeleteConfirm() {
 
 .session-list {
   width: $sidebar-width;
-  border-right: 1px solid $border-color;
+  min-height: 0;
+  align-self: stretch;
+  margin: 10px;
+  background: $bg-sidebar-surface;
+  border: 1px solid $border-color;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
@@ -976,23 +988,26 @@ function handleBatchDeleteConfirm() {
 
   &.collapsed {
     width: 0;
-    border-right: none;
+    margin-left: 0;
+    margin-right: 0;
+    border: none;
+    box-shadow: none;
     opacity: 0;
     pointer-events: none;
   }
 
   @media (max-width: $breakpoint-mobile) {
     position: absolute;
-    left: 0;
-    top: 0;
-    height: 100%;
+    left: 10px;
+    top: 10px;
+    bottom: 10px;
+    height: auto;
+    margin: 0;
     z-index: 120;
-    background: $bg-card;
-    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
     width: $sidebar-width;
 
     &.collapsed {
-      transform: translateX(-100%);
+      transform: translateX(calc(-100% - 10px));
       opacity: 0;
     }
   }
@@ -1126,6 +1141,15 @@ function handleBatchDeleteConfirm() {
   flex-direction: column;
   overflow: hidden;
   min-width: 0;
+  margin: 10px 10px 10px 0;
+  background: $bg-main-surface;
+  border: 1px solid $border-color;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+
+  &--sidebar-collapsed {
+    margin-left: 10px;
+  }
 }
 
 .chat-header {
@@ -1182,6 +1206,13 @@ function handleBatchDeleteConfirm() {
 }
 
 @media (max-width: $breakpoint-mobile) {
+  .chat-main {
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
   .chat-header {
     padding: 16px 12px 16px 52px;
   }

--- a/packages/client/src/views/hermes/KanbanView.vue
+++ b/packages/client/src/views/hermes/KanbanView.vue
@@ -308,7 +308,10 @@ async function handleDispatch() {
     </div>
 
     <!-- Board -->
-    <NSpin :show="kanbanStore.loading && kanbanStore.tasks.length === 0">
+    <NSpin
+      class="kanban-board-spin"
+      :show="kanbanStore.loading && kanbanStore.tasks.length === 0"
+    >
       <div class="kanban-board">
         <NCollapse v-model:expanded-names="expandedStatusNames">
           <NCollapseItem
@@ -465,6 +468,23 @@ async function handleDispatch() {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+}
+
+.kanban-board-spin {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+
+  :deep(.n-spin-container),
+  :deep(.n-spin-content) {
+    height: 100%;
+    min-height: 0;
+  }
+
+  :deep(.n-spin-content) {
+    display: flex;
+    flex-direction: column;
+  }
 }
 
 .column-header {

--- a/packages/client/src/views/hermes/WorkflowView.vue
+++ b/packages/client/src/views/hermes/WorkflowView.vue
@@ -2316,7 +2316,10 @@ function nodeColor(node: { data: WorkflowAgentNodeData }) {
       <PageSidebarFooter v-if="showWorkflowSidebar" />
     </aside>
 
-    <main class="workflow-main">
+    <main
+      class="workflow-main"
+      :class="{ 'workflow-main--sidebar-collapsed': !showWorkflowSidebar }"
+    >
       <header class="page-header">
         <div class="header-left">
           <NButton
@@ -2901,6 +2904,7 @@ function nodeColor(node: { data: WorkflowAgentNodeData }) {
   min-width: 0;
   position: relative;
   overflow: hidden;
+  background-color: $bg-card;
 }
 
 .workflow-main {
@@ -2909,11 +2913,27 @@ function nodeColor(node: { data: WorkflowAgentNodeData }) {
   flex: 1;
   display: flex;
   flex-direction: column;
+  margin: 10px 10px 10px 0;
+  overflow: hidden;
+  background: $bg-main-surface;
+  border: 1px solid $border-color;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+
+  &--sidebar-collapsed {
+    margin-left: 10px;
+  }
 }
 
 .workflow-sidebar {
   width: $sidebar-width;
-  border-right: 1px solid $border-color;
+  min-height: 0;
+  align-self: stretch;
+  margin: 10px;
+  background: $bg-sidebar-surface;
+  border: 1px solid $border-color;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
@@ -2924,7 +2944,10 @@ function nodeColor(node: { data: WorkflowAgentNodeData }) {
 
   &.collapsed {
     width: 0;
-    border-right: none;
+    margin-left: 0;
+    margin-right: 0;
+    border: none;
+    box-shadow: none;
     opacity: 0;
     pointer-events: none;
   }
@@ -3683,18 +3706,25 @@ function nodeColor(node: { data: WorkflowAgentNodeData }) {
 }
 
 @media (max-width: $breakpoint-mobile) {
+  .workflow-main {
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
   .workflow-sidebar {
     position: absolute;
-    left: 0;
-    top: 0;
-    height: 100%;
+    left: 10px;
+    top: 10px;
+    bottom: 10px;
+    height: auto;
+    margin: 0;
     z-index: 120;
-    background: $bg-card;
-    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
     width: $sidebar-width;
 
     &.collapsed {
-      transform: translateX(-100%);
+      transform: translateX(calc(-100% - 10px));
       opacity: 0;
     }
   }

--- a/tests/client/style-system.test.ts
+++ b/tests/client/style-system.test.ts
@@ -25,11 +25,33 @@ describe('client style system', () => {
     expect(theme).toContain("borderRadiusSmall: '6px'")
   })
 
-  it('keeps direct-chat and group-chat composer backgrounds aligned in dark mode', () => {
+  it('keeps chat surfaces aligned while preserving composer elevation in dark mode', () => {
     const chatInput = readClientFile('components/hermes/chat/ChatInput.vue')
     const groupChatInput = readClientFile('components/hermes/group-chat/GroupChatInput.vue')
+    const virtualMessageList = readClientFile('components/hermes/chat/VirtualMessageList.vue')
 
-    expect(chatInput.match(/background-color: #333333;/g)).toHaveLength(2)
-    expect(groupChatInput.match(/background-color: #333333;/g)).toHaveLength(2)
+    expect(chatInput).toContain('background-color: $bg-main-surface;')
+    expect(groupChatInput).toContain('background-color: $bg-main-surface;')
+    expect(virtualMessageList).toContain('background-color: $bg-main-surface;')
+    expect(chatInput.match(/background-color: #333333;/g)).toHaveLength(1)
+    expect(groupChatInput.match(/background-color: #333333;/g)).toHaveLength(1)
+  })
+
+  it('replays the history detail fade when the selected session changes', () => {
+    const historyView = readClientFile('views/hermes/HistoryView.vue')
+    const historyMessageList = readClientFile('components/hermes/chat/HistoryMessageList.vue')
+
+    expect(historyView).toContain(`:key="historySession?.id || 'history-empty'"`)
+    expect(historyMessageList).toContain('animation: history-message-surface-fade-in 1.5s ease both;')
+  })
+
+  it('keeps the three-way conversation switch active state visible in dark mode', () => {
+    const pageSidebarNav = readClientFile('components/layout/PageSidebarNav.vue')
+
+    expect(pageSidebarNav).toContain(
+      ':global(.dark .conversation-switch--three .conversation-switch-tab.active)',
+    )
+    expect(pageSidebarNav).toContain('background: $bg-card-hover;')
+    expect(pageSidebarNav).toContain('inset 0 0 0 1px $border-color')
   })
 })


### PR DESCRIPTION
## Summary

- Apply a consistent inset card layout to desktop navigation, chat, group chat, history, workflow, and regular app content while retaining edge-to-edge mobile main content.
- Align light/dark surface tokens across sidebars, main content, desktop title bar, chat canvas, composer background, and slightly lift dark message bubbles.
- Make Proxy settings responsive, restore Kanban internal scrolling with a stable header, add history detail fade-in on session changes, and improve the dark three-way conversation switch active state.

## Why

The existing desktop surfaces mixed flat edge-to-edge panels and several unrelated dark background values. Adding outer spacing also exposed height-chain issues in Kanban and fixed-width behavior in Proxy settings.

## Impact

Desktop pages now render as consistent card surfaces with theme-aware colors. Mobile main content remains unchanged. This is visual/layout-only for chat; message data, persistence, routing, Socket.IO, and Agent runtime behavior are unchanged.

## Validation

- `npm run harness:check`
- `npm run test:coverage` (325 files, 2580 passed, 2 skipped)
- `npm run test:e2e` (37/38 first run; the timed-out multitab case passed on targeted rerun)
- `npx playwright test tests/e2e/chat-session-multitab.spec.ts tests/e2e/history-session-deeplink.spec.ts` (6 passed)
- `npm run build`
- `npx vitest run tests/client/style-system.test.ts` (5 passed)