### PR TITLE
fix: select concrete cron delivery targets

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4824,6 +4824,32 @@
         }
       }
     },
+    "/api/hermes/jobs/delivery-targets": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Get delivery-targets",
+        "description": "GET /api/hermes/jobs/delivery-targets",
+        "operationId": "deliveryTargets",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/api/hermes/jobs/{id}": {
       "get": {
         "tags": [

--- a/packages/client/src/api/hermes/jobs.ts
+++ b/packages/client/src/api/hermes/jobs.ts
@@ -97,6 +97,20 @@ export interface JobFormValues {
   provider: string
 }
 
+export interface JobDeliveryTarget {
+  platform: string
+  id: string
+  name: string
+  type: string | null
+  thread_id: string | null
+  value: string
+}
+
+export interface JobDeliveryTargetsResponse {
+  updated_at: string | null
+  targets: JobDeliveryTarget[]
+}
+
 function unwrap(res: { job: Job }): Job {
   return res.job
 }
@@ -162,6 +176,10 @@ export function buildJobUpdateRequest(original: Job, form: JobFormValues): Updat
 export async function listJobs(): Promise<Job[]> {
   const res = await request<{ jobs: Job[] }>('/api/hermes/jobs?include_disabled=true')
   return res.jobs
+}
+
+export async function listJobDeliveryTargets(): Promise<JobDeliveryTargetsResponse> {
+  return request<JobDeliveryTargetsResponse>('/api/hermes/jobs/delivery-targets')
 }
 
 export async function getJob(jobId: string): Promise<Job> {

--- a/packages/client/src/components/hermes/jobs/JobFormModal.vue
+++ b/packages/client/src/components/hermes/jobs/JobFormModal.vue
@@ -2,15 +2,15 @@
 import { ref, onMounted, computed } from 'vue'
 import { NModal, NForm, NFormItem, NInput, NButton, NSelect, NInputNumber, useMessage } from 'naive-ui'
 import { useJobsStore } from '@/stores/hermes/jobs'
-import { useSettingsStore } from '@/stores/hermes/settings'
 import { useAppStore } from '@/stores/hermes/app'
 import {
   buildJobUpdateRequest,
   getJob,
   jobRepeatToEditValue,
+  listJobDeliveryTargets,
   scheduleToEditableInput,
 } from '@/api/hermes/jobs'
-import type { CreateJobRequest, Job } from '@/api/hermes/jobs'
+import type { CreateJobRequest, Job, JobDeliveryTarget } from '@/api/hermes/jobs'
 import { fetchSkills } from '@/api/hermes/skills'
 import type { SkillInfo } from '@/api/hermes/skills'
 import { useI18n } from 'vue-i18n'
@@ -27,7 +27,6 @@ const emit = defineEmits<{
 }>()
 
 const jobsStore = useJobsStore()
-const settingsStore = useSettingsStore()
 const appStore = useAppStore()
 const message = useMessage()
 
@@ -35,12 +34,14 @@ const showModal = ref(true)
 const loading = ref(false)
 const skillsLoading = ref(false)
 const skillOptions = ref<Array<{ label: string; value: string }>>([])
+const deliveryTargetsLoading = ref(false)
+const deliveryTargets = ref<JobDeliveryTarget[]>([])
 
 const formData = ref({
   name: '',
   schedule: '',
   prompt: '',
-  deliver: 'origin',
+  deliver: 'local',
   skills: [] as string[],
   repeat_times: null as number | null,
   provider: '',
@@ -60,38 +61,6 @@ const schedulePresets = computed(() => [
   { label: t('jobs.presetEveryMonday'), value: '0 9 * * 1' },
   { label: t('jobs.presetEveryMonth'), value: '0 9 1 * *' },
 ])
-
-function hasText(value: unknown): boolean {
-  return typeof value === 'string' && value.trim().length > 0
-}
-
-function isDeliverTargetConfigured(key: string): boolean {
-  const config = settingsStore.platforms[key] || {}
-  switch (key) {
-    case 'telegram':
-    case 'discord':
-    case 'slack':
-      return hasText(config.token)
-    case 'whatsapp':
-      return config.enabled === true || config.enabled === 'true'
-    case 'matrix':
-      return hasText(config.token) && hasText(config.extra?.homeserver)
-    case 'weixin':
-      return hasText(config.token) && hasText(config.extra?.account_id)
-    case 'wecom':
-      return hasText(config.extra?.bot_id) && hasText(config.extra?.secret)
-    case 'feishu':
-      return hasText(config.extra?.app_id) && hasText(config.extra?.app_secret)
-    case 'dingtalk':
-      return (hasText(config.extra?.client_id) && hasText(config.extra?.client_secret))
-        || (hasText(config.extra?.app_key) && hasText(config.extra?.client_secret))
-    case 'qqbot':
-      return hasText(config.extra?.app_id) && hasText(config.extra?.client_secret)
-    default:
-      return false
-  }
-}
-
 
 const providerOptions = computed(() => {
   const options = [
@@ -134,31 +103,45 @@ function handleProviderChange(provider: string) {
 }
 
 const targetOptions = computed(() => {
-  const options: Array<{ label: string; value: string; disabled?: boolean }> = [
-    { label: t('jobs.origin'), value: 'origin' },
+  const options: Array<{ label: string; value: string }> = [
     { label: t('jobs.local'), value: 'local' },
   ]
-  const channels = [
-    { key: 'telegram', label: 'Telegram' },
-    { key: 'discord', label: 'Discord' },
-    { key: 'slack', label: 'Slack' },
-    { key: 'whatsapp', label: 'WhatsApp' },
-    { key: 'matrix', label: 'Matrix' },
-    { key: 'weixin', label: 'WeChat' },
-    { key: 'wecom', label: 'WeCom' },
-    { key: 'feishu', label: 'Feishu' },
-    { key: 'dingtalk', label: 'DingTalk' },
-    { key: 'qqbot', label: 'QQBot' },
-  ]
-  for (const ch of channels) {
+  // Jobs created by the Web UI have no messaging origin. Keep the legacy
+  // value editable when loading an existing job, but do not offer it for new jobs.
+  if (formData.value.deliver === 'origin') {
+    options.unshift({ label: t('jobs.origin'), value: 'origin' })
+  }
+  for (const target of deliveryTargets.value) {
+    const typeSuffix = target.type ? ` (${target.type})` : ''
     options.push({
-      label: ch.label,
-      value: ch.key,
-      disabled: !isDeliverTargetConfigured(ch.key),
+      label: `${formatPlatformName(target.platform)} · ${target.name}${typeSuffix}`,
+      value: target.value,
     })
+  }
+
+  const current = formData.value.deliver.trim()
+  if (current && !options.some(option => option.value === current)) {
+    options.push({ label: current, value: current })
   }
   return options
 })
+
+function formatPlatformName(platform: string): string {
+  const names: Record<string, string> = {
+    weixin: 'WeChat',
+    wecom: 'WeCom',
+    qqbot: 'QQBot',
+    whatsapp: 'WhatsApp',
+    whatsapp_cloud: 'WhatsApp Cloud',
+    dingtalk: 'DingTalk',
+    feishu: 'Feishu',
+  }
+  return names[platform] || platform
+    .split('_')
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
 
 const originalJob = ref<Job | null>(null)
 
@@ -185,12 +168,24 @@ async function loadSkillOptions() {
   }
 }
 
-onMounted(async () => {
-  if (Object.keys(settingsStore.platforms || {}).length === 0) {
-    await settingsStore.fetchSettings()
+async function loadDeliveryTargets() {
+  deliveryTargetsLoading.value = true
+  try {
+    const data = await listJobDeliveryTargets()
+    deliveryTargets.value = Array.isArray(data.targets) ? data.targets : []
+  } catch {
+    deliveryTargets.value = []
+  } finally {
+    deliveryTargetsLoading.value = false
   }
-  await appStore.loadModels()
-  await loadSkillOptions()
+}
+
+onMounted(async () => {
+  await Promise.all([
+    appStore.loadModels(),
+    loadSkillOptions(),
+    loadDeliveryTargets(),
+  ])
 
   if (props.jobId) {
     try {
@@ -347,6 +342,8 @@ function handleClose() {
         <NSelect
           v-model:value="formData.deliver"
           :options="targetOptions"
+          :loading="deliveryTargetsLoading"
+          filterable
         />
       </NFormItem>
 

--- a/packages/server/src/controllers/hermes/jobs.ts
+++ b/packages/server/src/controllers/hermes/jobs.ts
@@ -10,6 +10,15 @@ const TIMEOUT_MS = 60_000
 
 type JobRecord = Record<string, any>
 
+interface DeliveryTargetRecord {
+  platform: string
+  id: string
+  name: string
+  type: string | null
+  thread_id: string | null
+  value: string
+}
+
 function resolveProfile(ctx: Context): string {
   const requestedProfile = ctx.state?.profile?.name
   return requestedProfile || getActiveProfileName()
@@ -21,6 +30,58 @@ function resolveProfileDir(profile: string): string {
 
 function getJobsPath(profile: string): string {
   return join(resolveProfileDir(profile), 'cron', 'jobs.json')
+}
+
+function getChannelDirectoryPath(profile: string): string {
+  return join(resolveProfileDir(profile), 'channel_directory.json')
+}
+
+function readDeliveryTargets(profile: string): { updated_at: string | null; targets: DeliveryTargetRecord[] } {
+  const directoryPath = getChannelDirectoryPath(profile)
+  if (!existsSync(directoryPath)) return { updated_at: null, targets: [] }
+
+  try {
+    const parsed = JSON.parse(readFileSync(directoryPath, 'utf-8'))
+    const platforms = parsed?.platforms
+    if (!platforms || typeof platforms !== 'object' || Array.isArray(platforms)) {
+      return { updated_at: null, targets: [] }
+    }
+
+    const targets: DeliveryTargetRecord[] = []
+    const seen = new Set<string>()
+    for (const [rawPlatform, rawChannels] of Object.entries(platforms)) {
+      const platform = String(rawPlatform || '').trim().toLowerCase()
+      if (!platform || !Array.isArray(rawChannels)) continue
+
+      for (const rawChannel of rawChannels) {
+        if (!rawChannel || typeof rawChannel !== 'object') continue
+        const channel = rawChannel as Record<string, unknown>
+        const id = String(channel.id ?? channel.chat_id ?? '').trim()
+        if (!id) continue
+
+        const value = `${platform}:${id}`
+        if (seen.has(value)) continue
+        seen.add(value)
+
+        const name = String(channel.name ?? id).trim() || id
+        const type = channel.type == null ? null : String(channel.type).trim() || null
+        const threadId = channel.thread_id == null ? null : String(channel.thread_id).trim() || null
+        targets.push({ platform, id, name, type, thread_id: threadId, value })
+      }
+    }
+
+    targets.sort((a, b) => {
+      const platformOrder = a.platform.localeCompare(b.platform)
+      return platformOrder || a.name.localeCompare(b.name) || a.id.localeCompare(b.id)
+    })
+
+    const updatedAt = typeof parsed.updated_at === 'string' && parsed.updated_at.trim()
+      ? parsed.updated_at
+      : null
+    return { updated_at: updatedAt, targets }
+  } catch {
+    return { updated_at: null, targets: [] }
+  }
 }
 
 function normalizeJob(job: JobRecord): JobRecord {
@@ -238,6 +299,10 @@ export async function list(ctx: Context) {
   const jobs = readJobs(profile, includeDisabled)
   const config = await readConfigYamlForProfile(profile)
   ctx.body = { jobs: resolveJobDefaults(jobs, config) }
+}
+
+export function deliveryTargets(ctx: Context) {
+  ctx.body = readDeliveryTargets(resolveProfile(ctx))
 }
 
 export async function get(ctx: Context) {

--- a/packages/server/src/routes/hermes/jobs.ts
+++ b/packages/server/src/routes/hermes/jobs.ts
@@ -4,6 +4,7 @@ import * as ctrl from '../../controllers/hermes/jobs'
 export const jobRoutes = new Router()
 
 jobRoutes.get('/api/hermes/jobs', ctrl.list)
+jobRoutes.get('/api/hermes/jobs/delivery-targets', ctrl.deliveryTargets)
 jobRoutes.get('/api/hermes/jobs/:id', ctrl.get)
 jobRoutes.post('/api/hermes/jobs', ctrl.create)
 jobRoutes.patch('/api/hermes/jobs/:id', ctrl.update)

--- a/tests/client/job-form-modal.test.ts
+++ b/tests/client/job-form-modal.test.ts
@@ -9,24 +9,6 @@ const mockMessage = vi.hoisted(() => ({
   error: vi.fn(),
 }))
 
-const mockSettingsStore = vi.hoisted(() => ({
-  platforms: {} as Record<string, any>,
-  fetchSettings: vi.fn(async () => {
-    mockSettingsStore.platforms = {
-      telegram: { token: 'telegram-token' },
-      discord: { token: 'discord-token' },
-      slack: { token: 'slack-token' },
-      whatsapp: { enabled: true },
-      matrix: { token: 'matrix-token' },
-      weixin: { token: 'weixin-token' },
-      wecom: { extra: { bot_id: 'wecom-bot' } },
-      feishu: { extra: { app_id: 'feishu-app' } },
-      dingtalk: { extra: { client_id: 'dingtalk-client' } },
-      qqbot: { extra: { app_id: 'qq-app', client_secret: 'qq-secret' } },
-    }
-  }),
-}))
-
 const mockJobsStore = vi.hoisted(() => ({
   createJob: vi.fn(),
   updateJob: vi.fn(),
@@ -56,9 +38,7 @@ const mockFetchSkills = vi.hoisted(() => vi.fn(async () => ({
   archived: [],
 })))
 
-vi.mock('@/stores/hermes/settings', () => ({
-  useSettingsStore: () => mockSettingsStore,
-}))
+const mockListJobDeliveryTargets = vi.hoisted(() => vi.fn())
 
 vi.mock('@/stores/hermes/jobs', () => ({
   useJobsStore: () => mockJobsStore,
@@ -73,6 +53,7 @@ vi.mock('@/api/hermes/jobs', async () => {
   return {
     ...actual,
     getJob: vi.fn(),
+    listJobDeliveryTargets: mockListJobDeliveryTargets,
   }
 })
 
@@ -124,55 +105,59 @@ import JobFormModal from '@/components/hermes/jobs/JobFormModal.vue'
 describe('JobFormModal deliver targets', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockSettingsStore.platforms = {}
+    mockListJobDeliveryTargets.mockResolvedValue({ updated_at: null, targets: [] })
   })
 
-  it('loads platform settings when the store has not been hydrated', async () => {
+  it('loads delivery targets and models when opened', async () => {
     mount(JobFormModal, {
       props: { jobId: null },
     })
 
     await flushPromises()
 
-    expect(mockSettingsStore.fetchSettings).toHaveBeenCalledOnce()
+    expect(mockListJobDeliveryTargets).toHaveBeenCalledOnce()
     expect(mockAppStore.loadModels).toHaveBeenCalledOnce()
   })
 
-  it('shows every supported platform channel in deliver target options', async () => {
-    mockSettingsStore.platforms = {
-      telegram: { token: 'telegram-token' },
-      whatsapp: { enabled: false },
-      qqbot: { extra: { app_id: 'qq-app', client_secret: 'qq-secret' } },
-    }
+  it('shows discovered profile channels as explicit delivery targets', async () => {
+    mockListJobDeliveryTargets.mockResolvedValue({
+      updated_at: '2026-07-17T09:15:00+08:00',
+      targets: [
+        {
+          platform: 'weixin',
+          id: 'wx-user@im.wechat',
+          name: '微信私聊',
+          type: 'dm',
+          thread_id: null,
+          value: 'weixin:wx-user@im.wechat',
+        },
+        {
+          platform: 'feishu',
+          id: 'oc_example',
+          name: '研发群',
+          type: 'group',
+          thread_id: null,
+          value: 'feishu:oc_example',
+        },
+      ],
+    })
     const wrapper = mount(JobFormModal, {
       props: { jobId: null },
     })
 
     await flushPromises()
 
-    expect(mockSettingsStore.fetchSettings).not.toHaveBeenCalled()
     const labels = wrapper.findAll('.n-select-stub')[4].text()
-    expect(labels).toContain('Telegram')
-    expect(labels).toContain('Discord')
-    expect(labels).toContain('Slack')
-    expect(labels).toContain('WhatsApp')
-    expect(labels).toContain('Matrix')
-    expect(labels).toContain('WeChat')
-    expect(labels).toContain('WeCom')
-    expect(labels).toContain('Feishu')
-    expect(labels).toContain('DingTalk')
-    expect(labels).toContain('QQBot')
+    expect(labels).toContain('WeChat · 微信私聊 (dm)')
+    expect(labels).toContain('Feishu · 研发群 (group)')
 
     const options = wrapper.findAll('.n-select-stub')[4].findAll('option')
     const optionByValue = Object.fromEntries(options.map(option => [option.attributes('value'), option]))
-    expect(optionByValue.telegram.attributes('disabled')).toBeUndefined()
-    expect(optionByValue.qqbot.attributes('disabled')).toBeUndefined()
-    expect(optionByValue.discord.attributes('disabled')).toBe('')
-    expect(optionByValue.whatsapp.attributes('disabled')).toBe('')
+    expect(optionByValue['weixin:wx-user@im.wechat']).toBeTruthy()
+    expect(optionByValue['feishu:oc_example']).toBeTruthy()
   })
 
   it('submits selected skills when creating a job', async () => {
-    mockSettingsStore.platforms = { telegram: { token: 'telegram-token' } }
     mockJobsStore.createJob.mockResolvedValue({ id: 'job-1' })
     const wrapper = mount(JobFormModal, {
       props: { jobId: null },
@@ -191,7 +176,7 @@ describe('JobFormModal deliver targets', () => {
       name: 'Daily research',
       schedule: '0 9 * * *',
       prompt: 'summarize updates',
-      deliver: 'origin',
+      deliver: 'local',
       skills: ['planner', 'reviewer'],
       repeat: undefined,
       provider: undefined,
@@ -200,7 +185,6 @@ describe('JobFormModal deliver targets', () => {
   })
 
   it('submits selected provider and model when creating a job', async () => {
-    mockSettingsStore.platforms = { telegram: { token: 'telegram-token' } }
     mockJobsStore.createJob.mockResolvedValue({ id: 'job-1' })
     const wrapper = mount(JobFormModal, {
       props: { jobId: null },
@@ -220,6 +204,37 @@ describe('JobFormModal deliver targets', () => {
     expect(mockJobsStore.createJob).toHaveBeenCalledWith(expect.objectContaining({
       provider: 'openai',
       model: 'gpt-4.1-mini',
+    }))
+  })
+
+  it('submits the selected explicit delivery target when creating a job', async () => {
+    mockListJobDeliveryTargets.mockResolvedValue({
+      updated_at: null,
+      targets: [{
+        platform: 'weixin',
+        id: 'wx-user@im.wechat',
+        name: '微信私聊',
+        type: 'dm',
+        thread_id: null,
+        value: 'weixin:wx-user@im.wechat',
+      }],
+    })
+    mockJobsStore.createJob.mockResolvedValue({ id: 'job-1' })
+    const wrapper = mount(JobFormModal, {
+      props: { jobId: null },
+    })
+
+    await flushPromises()
+    const inputs = wrapper.findAll('.n-input-stub')
+    await inputs[0].setValue('WeChat hello')
+    await inputs[1].setValue('*/5 * * * *')
+    await inputs[2].setValue('say hello')
+    await wrapper.findAll('.n-select-stub')[4].setValue('weixin:wx-user@im.wechat')
+    await wrapper.findAll('.n-button-stub')[1].trigger('click')
+    await flushPromises()
+
+    expect(mockJobsStore.createJob).toHaveBeenCalledWith(expect.objectContaining({
+      deliver: 'weixin:wx-user@im.wechat',
     }))
   })
 })

--- a/tests/server/jobs-controller.test.ts
+++ b/tests/server/jobs-controller.test.ts
@@ -6,11 +6,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const testState = vi.hoisted(() => ({
   profileDir: '',
   execFile: vi.fn(),
+  resolvedProfiles: [] as string[],
 }))
 
 vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
   getActiveProfileName: () => 'default',
-  getProfileDir: () => testState.profileDir || '/fake/home/.hermes',
+  getProfileDir: (profile: string) => {
+    testState.resolvedProfiles.push(profile)
+    return testState.profileDir || '/fake/home/.hermes'
+  },
 }))
 
 vi.mock('../../packages/server/src/services/hermes/hermes-path', () => ({
@@ -24,7 +28,7 @@ vi.mock('child_process', () => ({
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
-import { create, pause, remove, resume, run as runJob, update } from '../../packages/server/src/controllers/hermes/jobs'
+import { create, deliveryTargets, pause, remove, resume, run as runJob, update } from '../../packages/server/src/controllers/hermes/jobs'
 
 function createMockCtx(overrides: Record<string, any> = {}) {
   const ctx: any = {
@@ -68,6 +72,7 @@ describe('Hermes jobs controller', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    testState.resolvedProfiles = []
     tempDir = mkdtempSync(join(tmpdir(), 'hermes-web-ui-jobs-test-'))
     testState.profileDir = tempDir
     testState.execFile.mockImplementation((_bin, _args, _opts, cb) => {
@@ -238,6 +243,56 @@ describe('Hermes jobs controller', () => {
     const persisted = JSON.parse(readFileSync(join(tempDir, 'cron', 'jobs.json'), 'utf-8'))
     expect(persisted.jobs[0].provider).toBe('anthropic')
     expect(persisted.jobs[0].model).toBe('claude-sonnet-4')
+  })
+
+  it('returns explicit delivery targets from the selected profile channel directory', () => {
+    writeFileSync(join(tempDir, 'channel_directory.json'), JSON.stringify({
+      updated_at: '2026-07-17T09:15:00+08:00',
+      platforms: {
+        weixin: [
+          { id: 'wx-user@im.wechat', name: '微信私聊', type: 'dm', thread_id: null },
+          { id: 'wx-user@im.wechat', name: '重复项', type: 'dm', thread_id: null },
+        ],
+        feishu: [
+          { id: 'oc_example', name: '研发群', type: 'group' },
+          { id: '', name: 'invalid' },
+        ],
+      },
+    }))
+    const ctx = createMockCtx({ state: { profile: { name: 'research' } } })
+
+    deliveryTargets(ctx)
+
+    expect(testState.resolvedProfiles).toContain('research')
+    expect(ctx.body).toEqual({
+      updated_at: '2026-07-17T09:15:00+08:00',
+      targets: [
+        {
+          platform: 'feishu',
+          id: 'oc_example',
+          name: '研发群',
+          type: 'group',
+          thread_id: null,
+          value: 'feishu:oc_example',
+        },
+        {
+          platform: 'weixin',
+          id: 'wx-user@im.wechat',
+          name: '微信私聊',
+          type: 'dm',
+          thread_id: null,
+          value: 'weixin:wx-user@im.wechat',
+        },
+      ],
+    })
+  })
+
+  it('returns an empty delivery target list when the profile directory is unavailable', () => {
+    const ctx = createMockCtx()
+
+    deliveryTargets(ctx)
+
+    expect(ctx.body).toEqual({ updated_at: null, targets: [] })
   })
 
 })


### PR DESCRIPTION
## Summary

- add a profile-aware jobs API that reads concrete messaging targets from the Hermes channel directory
- replace the static platform-only cron delivery dropdown with searchable DM/channel targets
- persist explicit `platform:chat_id` values for newly created and edited jobs
- default Web UI-created jobs to local delivery while preserving legacy origin values when editing
- update unit coverage and the generated OpenAPI document

## Root cause

The Web UI treated a configured messaging platform as a complete delivery target and stored only values such as `dingtalk` or `weixin`. Jobs created from a live messaging conversation worked because Hermes captured an origin conversation, but jobs created from the Web UI had no origin and could not resolve a concrete recipient unless a separate home channel was configured.

This caused the cron run itself to complete while the expected text was never delivered to the selected messaging conversation.

## Impact

Users can now select the actual DM, group, or channel discovered for the active Hermes profile. Cron jobs store the concrete recipient and can use Hermes' normal automatic text-delivery path.

## Validation

- `npm test -- --run tests/server/jobs-controller.test.ts tests/client/job-form-modal.test.ts`
- `npm run harness:check`
- `npm run build`

Closes #2104
