### PR TITLE
fix: align Coding Agents dark background

### DIFF
--- a/packages/client/src/views/hermes/CodingAgentsView.vue
+++ b/packages/client/src/views/hermes/CodingAgentsView.vue
@@ -679,7 +679,7 @@ onMounted(() => {
   flex: 1;
   overflow-y: auto;
   padding: 20px;
-  background: $bg-secondary;
+  background: $bg-main-surface;
 }
 
 .content-description {

--- a/tests/client/style-system.test.ts
+++ b/tests/client/style-system.test.ts
@@ -54,4 +54,12 @@ describe('client style system', () => {
     expect(pageSidebarNav).toContain('background: $bg-card-hover;')
     expect(pageSidebarNav).toContain('inset 0 0 0 1px $border-color')
   })
+
+  it('keeps the coding agents page aligned with the app main surface', () => {
+    const codingAgentsView = readClientFile('views/hermes/CodingAgentsView.vue')
+
+    expect(codingAgentsView).toMatch(
+      /\.coding-agents-content\s*\{[^}]*background: \$bg-main-surface;/s,
+    )
+  })
 })


### PR DESCRIPTION
## Summary

- align the Coding Agents content background with the shared app main surface
- add a style regression test for the page surface token

## Root cause

The Coding Agents page explicitly used `$bg-secondary` for its full content area. In dark mode that resolves to `#252525`, while the surrounding `app-main--card` and comparable pages use `$bg-main-surface`, which resolves to `#1a1a1a`.

## Impact

The Coding Agents page now has the same dark-mode background as other sidebar pages, without changing its cards or secondary surface styling.

## Validation

- `npm run test -- tests/client/style-system.test.ts` (6 passed)
- `git diff --check`
