### PR TITLE
fix(bridge): honor queued ready event before exit

### DIFF
--- a/docs/chat-chain-changes/2026-07-17-worker-ready-race.md
+++ b/docs/chat-chain-changes/2026-07-17-worker-ready-race.md
@@ -1,0 +1,10 @@
+---
+date: 2026-07-17
+pr: pending
+feature: Agent Bridge worker readiness
+impact: Worker startup consumes a queued ready event before reporting that the worker exited before readiness.
+---
+
+This preserves the existing failure for workers that exit without reporting ready,
+while avoiding a false startup failure when stdout already contains the ready
+handshake.

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py
@@ -117,14 +117,16 @@ class WorkerProcess:
         threading.Thread(target=read_stdout, daemon=True, name=f"hermes-bridge-worker-stdout-{self.key}").start()
         deadline = time.time() + self.STARTUP_TIMEOUT_SECONDS
         while time.time() < deadline:
-            if proc.poll() is not None:
-                raise RuntimeError(f"profile worker {self.key} exited before ready")
             try:
                 line = lines.get(timeout=0.1)
             except queue.Empty:
+                if proc.poll() is not None:
+                    raise RuntimeError(f"profile worker {self.key} exited before ready")
                 continue
             if line is None:
                 time.sleep(0.05)
+                if proc.poll() is not None:
+                    raise RuntimeError(f"profile worker {self.key} exited before ready")
                 continue
             text = line.strip()
             if text:

--- a/tests/server/agent-bridge-worker-endpoint.test.ts
+++ b/tests/server/agent-bridge-worker-endpoint.test.ts
@@ -20,6 +20,107 @@ function runPython(script: string): any {
 }
 
 describe('agent bridge worker endpoint', () => {
+  it('accepts an already queued ready event before treating worker exit as startup failure', () => {
+    const result = runPython(String.raw`
+import importlib.util
+import json
+import sys
+import types
+
+bridge_runtime = types.ModuleType("bridge_runtime")
+bridge_runtime._hidden_subprocess_kwargs = lambda: {}
+bridge_runtime._json_line_bytes = lambda req: (json.dumps(req) + "\n").encode("utf-8")
+bridge_runtime._platform_text_encoding = lambda: "utf-8"
+sys.modules["bridge_runtime"] = bridge_runtime
+
+spec = importlib.util.spec_from_file_location(
+    "bridge_transport",
+    "packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py",
+)
+bridge_transport = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(bridge_transport)
+
+class InlineThread:
+    def __init__(self, target, **_kwargs):
+        self.target = target
+
+    def start(self):
+        self.target()
+
+class ExitedProcess:
+    stdout = ['{"event":"ready"}\n']
+
+    def poll(self):
+        return 0
+
+original_thread = bridge_transport.threading.Thread
+try:
+    bridge_transport.threading.Thread = InlineThread
+    worker = bridge_transport.WorkerProcess("default", "default", "ipc:///tmp/worker.sock", None, None)
+    worker.process = ExitedProcess()
+    worker._wait_ready()
+finally:
+    bridge_transport.threading.Thread = original_thread
+
+print(json.dumps({"ready": True}))
+`)
+
+    expect(result.ready).toBe(true)
+  })
+
+  it('still rejects an exited worker that has no queued ready event', () => {
+    const result = runPython(String.raw`
+import importlib.util
+import json
+import sys
+import types
+
+bridge_runtime = types.ModuleType("bridge_runtime")
+bridge_runtime._hidden_subprocess_kwargs = lambda: {}
+bridge_runtime._json_line_bytes = lambda req: (json.dumps(req) + "\n").encode("utf-8")
+bridge_runtime._platform_text_encoding = lambda: "utf-8"
+sys.modules["bridge_runtime"] = bridge_runtime
+
+spec = importlib.util.spec_from_file_location(
+    "bridge_transport",
+    "packages/server/src/services/hermes/agent-bridge/python/bridge_transport.py",
+)
+bridge_transport = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(bridge_transport)
+
+class InlineThread:
+    def __init__(self, target, **_kwargs):
+        self.target = target
+
+    def start(self):
+        self.target()
+
+class ExitedProcess:
+    stdout = []
+
+    def poll(self):
+        return 0
+
+original_thread = bridge_transport.threading.Thread
+try:
+    bridge_transport.threading.Thread = InlineThread
+    worker = bridge_transport.WorkerProcess("default", "default", "ipc:///tmp/worker.sock", None, None)
+    worker.process = ExitedProcess()
+    try:
+        worker._wait_ready()
+    except RuntimeError as exc:
+        print(json.dumps({"error": str(exc)}))
+    else:
+        raise AssertionError("expected exited worker without ready event to fail")
+finally:
+    bridge_transport.threading.Thread = original_thread
+`)
+
+    expect(result.error).toContain('exited before ready')
+  })
+
   it('avoids high dynamic worker port bases on Windows', () => {
     const result = runPython(String.raw`
 import importlib.util


### PR DESCRIPTION
## Summary

- consume a queued Agent Bridge worker `ready` event before treating process exit as a pre-ready failure
- preserve the existing failure when an exited worker has no queued readiness event
- add deterministic regression coverage for both orderings

Closes #1965.

## Validation

- RED on unmodified `origin/main`: `npm run test -- tests/server/agent-bridge-worker-endpoint.test.ts` failed with `RuntimeError: profile worker default exited before ready` for the queued-ready case
- GREEN: `npm run test -- tests/server/agent-bridge-worker-endpoint.test.ts` (4 tests passed)
- `npm run test -- tests/server/agent-bridge-python-concurrency.test.ts` (26 tests passed)
- `npm run harness:check`
- `git diff --check`

## Duplicate Check

Checked live on 2026-07-18 (Asia/Shanghai) against upstream main `ff8d78f613d3d0984508588f6571b853851c5ca3`. Issue #1965 remains open. PRs #1964 and #1973 are closed and unmerged; no open PR matched issue `1965`, `_wait_ready`, `exited before ready`, or `bridge_transport.py`.

## Browser / Playwright

Not run: this is isolated Python Agent Bridge startup readiness logic with no browser-visible interaction path. Focused bridge tests and the repository harness passed.
