### PR TITLE
fix(mcp): 避免持久化临时 worktree launcher

### DIFF
--- a/packages/server/src/services/hermes/studio-mcp-autoinject.ts
+++ b/packages/server/src/services/hermes/studio-mcp-autoinject.ts
@@ -1,9 +1,10 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { config } from '../../config'
 import { updateConfigYamlForProfile } from '../config-helpers'
 import { logger } from '../logger'
+import { isPathWithin } from './hermes-path'
 import { listProfileNamesFromDisk } from './hermes-profile'
 
 const LEGACY_SERVER_NAME = 'hermes-studio'
@@ -52,20 +53,63 @@ function allowTransientAutoinject(): boolean {
   return isEnabledEnv(process.env.HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT)
 }
 
-function normalizedPathPrefix(pathname: string): string {
-  return pathname.replace(/\/+$/, '') + '/'
+function canonicalPath(pathname: string): string {
+  try {
+    return realpathSync(pathname)
+  } catch {
+    return resolve(pathname)
+  }
 }
 
-function isTransientAppHome(appHome: string): boolean {
-  const normalized = normalizedPathPrefix(appHome)
-  const transientRoots = [tmpdir(), '/tmp', '/private/tmp']
+function isTransientPath(pathname: string): boolean {
+  const candidate = canonicalPath(pathname)
+  return [tmpdir(), '/tmp', '/private/tmp']
     .filter(Boolean)
-    .map(root => normalizedPathPrefix(root))
-  return transientRoots.some(root => normalized.startsWith(root))
+    .some(root => isPathWithin(candidate, canonicalPath(root)))
 }
 
-function shouldSkipTransientAutoinject(): boolean {
-  return isTransientAppHome(config.appHome) && !allowTransientAutoinject()
+function isLinkedGitWorktreeMarker(marker: string): boolean {
+  try {
+    const firstLine = readFileSync(marker, 'utf8').split(/\r?\n/, 1)[0]?.trim() || ''
+    const match = /^gitdir:\s*(.+)$/i.exec(firstLine)
+    if (!match) return false
+    const gitDir = canonicalPath(resolve(dirname(marker), match[1].trim()))
+    const commonDirText = readFileSync(join(gitDir, 'commondir'), 'utf8').trim()
+    if (!commonDirText) return false
+    const commonDir = canonicalPath(resolve(gitDir, commonDirText))
+    // Linked worktrees declare their common dir and live at
+    // <common-dir>/worktrees/<id>; a lookalike gitdir pathname is not enough.
+    return canonicalPath(dirname(gitDir)) === canonicalPath(join(commonDir, 'worktrees'))
+  } catch {
+    return false
+  }
+}
+
+function isLinkedGitWorktreePath(pathname: string): boolean {
+  let current = dirname(canonicalPath(pathname))
+  while (true) {
+    const marker = join(current, '.git')
+    if (existsSync(marker)) {
+      try {
+        const markerType = statSync(marker)
+        if (markerType.isFile()) return isLinkedGitWorktreeMarker(marker)
+        if (markerType.isDirectory()) return false
+      } catch {
+        return false
+      }
+    }
+    const parent = dirname(current)
+    if (parent === current) return false
+    current = parent
+  }
+}
+
+function shouldSkipTransientAutoinject(bundledScript: string | null): boolean {
+  if (allowTransientAutoinject()) return false
+  return isTransientPath(config.appHome) || (
+    bundledScript !== null &&
+    (isTransientPath(bundledScript) || isLinkedGitWorktreePath(bundledScript))
+  )
 }
 
 function isDesktopRuntime(): boolean {
@@ -93,12 +137,14 @@ function runtimeNodePath(): string | null {
   return node || null
 }
 
-function managedCommandConfig(toolset: string): Record<string, unknown> {
+function managedCommandConfig(
+  toolset: string,
+  bundledScript: string | null,
+): Record<string, unknown> {
   // Prefer the bundled script with an absolute path over a bare command name.
   // On Windows (especially desktop builds), `hermes-studio-mcp` may not be in
   // PATH even though the bundled .mjs script exists on disk.  Desktop provides
   // HERMES_AGENT_NODE for the packaged runtime node; fall back to process.execPath.
-  const bundledScript = bundledMcpScriptPath()
   if (bundledScript) {
     return { command: runtimeNodePath() || process.execPath, args: [bundledScript, toolset] }
   }
@@ -111,7 +157,12 @@ function managedCommandConfig(toolset: string): Record<string, unknown> {
   return { command: 'hermes-studio-mcp', args: [toolset] }
 }
 
-function managedConfig(profile: string, serverName: string, toolset: string): Record<string, unknown> {
+function managedConfig(
+  profile: string,
+  serverName: string,
+  toolset: string,
+  bundledScript: string | null,
+): Record<string, unknown> {
   const env: Record<string, string> = {
     HERMES_WEB_UI_URL: `http://127.0.0.1:${config.port}`,
     HERMES_WEB_UI_HOME: config.appHome,
@@ -123,7 +174,7 @@ function managedConfig(profile: string, serverName: string, toolset: string): Re
   }
 
   return {
-    ...managedCommandConfig(toolset),
+    ...managedCommandConfig(toolset, bundledScript),
     env,
     enabled: true,
   }
@@ -163,7 +214,10 @@ function sameConfig(existing: Record<string, any>, desired: Record<string, unkno
     existing.env[MANAGED_ENV_KEY] === desiredEnv[MANAGED_ENV_KEY]
 }
 
-async function injectIntoProfile(profile: string): Promise<BundledMcpInjectionTargetResult> {
+async function injectIntoProfile(
+  profile: string,
+  bundledScript: string | null,
+): Promise<BundledMcpInjectionTargetResult> {
   return await updateConfigYamlForProfile(profile, current => {
     const cfg = isRecord(current) ? current : {}
     if (!isRecord(cfg.mcp_servers)) cfg.mcp_servers = {}
@@ -193,7 +247,7 @@ async function injectIntoProfile(profile: string): Promise<BundledMcpInjectionTa
     }
 
     for (const server of MANAGED_SERVERS) {
-      const desired = managedConfig(profile, server.name, server.toolset)
+      const desired = managedConfig(profile, server.name, server.toolset, bundledScript)
       const existing = cfg.mcp_servers[server.name]
       if (!existing) {
         cfg.mcp_servers[server.name] = desired
@@ -246,7 +300,13 @@ async function injectIntoProfile(profile: string): Promise<BundledMcpInjectionTa
 }
 
 export async function injectBundledMcpServer(): Promise<BundledMcpInjectionResult> {
-  const commandInfo = managedConfig('default', MANAGED_SERVERS[0].name, MANAGED_SERVERS[0].toolset)
+  const bundledScript = bundledMcpScriptPath()
+  const commandInfo = managedConfig(
+    'default',
+    MANAGED_SERVERS[0].name,
+    MANAGED_SERVERS[0].toolset,
+    bundledScript,
+  )
   const result: BundledMcpInjectionResult = {
     serverNames: MANAGED_SERVERS.map(server => server.name),
     command: String(commandInfo.command),
@@ -258,13 +318,16 @@ export async function injectBundledMcpServer(): Promise<BundledMcpInjectionResul
     return result
   }
 
-  if (shouldSkipTransientAutoinject()) {
-    logger.info({ appHome: config.appHome }, '[mcp-autoinject] skipped for transient Web UI home')
+  if (shouldSkipTransientAutoinject(bundledScript)) {
+    logger.info(
+      { appHome: config.appHome, bundledScript },
+      '[mcp-autoinject] skipped for transient Web UI home or MCP launcher',
+    )
     return result
   }
 
   for (const profile of listProfileNamesFromDisk()) {
-    result.targets.push(await injectIntoProfile(profile))
+    result.targets.push(await injectIntoProfile(profile, bundledScript))
   }
 
   const changed = result.targets.filter(target => target.status === 'injected' || target.status === 'updated')

--- a/tests/server/studio-mcp-autoinject.test.ts
+++ b/tests/server/studio-mcp-autoinject.test.ts
@@ -1,8 +1,60 @@
-import { join } from 'node:path'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, dirname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const updateConfigYamlForProfileMock = vi.fn()
 const listProfileNamesFromDiskMock = vi.fn()
+const fixtureRoots: string[] = []
+let stableLauncher = ''
+
+type GitMarker =
+  | 'directory'
+  | 'worktree'
+  | 'submodule'
+  | 'separate-worktrees'
+  | 'nested-submodule-worktrees'
+
+function createLauncherFixture(parent: string, gitMarker?: GitMarker): string {
+  const root = mkdtempSync(join(parent, '.studio-mcp-autoinject-test-'))
+  fixtureRoots.push(root)
+  if (gitMarker === 'directory') mkdirSync(join(root, '.git'))
+  if (gitMarker === 'worktree') {
+    const gitDir = join(root, '.git-common/worktrees/fixture')
+    mkdirSync(gitDir, { recursive: true })
+    writeFileSync(join(gitDir, 'commondir'), '../..\n')
+    writeFileSync(join(root, '.git'), `gitdir: ${gitDir}\n`)
+  }
+  if (gitMarker === 'submodule') {
+    const gitDir = join(root, '.git-common/modules/fixture')
+    mkdirSync(gitDir, { recursive: true })
+    writeFileSync(join(root, '.git'), `gitdir: ${gitDir}\n`)
+  }
+  if (gitMarker === 'separate-worktrees') {
+    const gitDir = join(root, '.git-common/worktrees/fixture')
+    mkdirSync(gitDir, { recursive: true })
+    writeFileSync(join(root, '.git'), `gitdir: ${gitDir}\n`)
+  }
+  if (gitMarker === 'nested-submodule-worktrees') {
+    const gitDir = join(root, '.git-common/modules/vendor/worktrees/fixture')
+    mkdirSync(gitDir, { recursive: true })
+    writeFileSync(join(root, '.git'), `gitdir: ${gitDir}\n`)
+  }
+  mkdirSync(join(root, 'bin'))
+  const launcher = join(root, 'bin/hermes-studio-mcp.mjs')
+  writeFileSync(launcher, '#!/usr/bin/env node\n')
+  return launcher
+}
+
+function createStableLauncherAlias(targetLauncher: string): string {
+  const root = mkdtempSync(join(process.cwd(), '.studio-mcp-autoinject-alias-'))
+  fixtureRoots.push(root)
+  mkdirSync(join(root, '.git'))
+  const aliasBin = join(root, 'bin')
+  symlinkSync(dirname(targetLauncher), aliasBin, process.platform === 'win32' ? 'junction' : 'dir')
+  return join(aliasBin, basename(targetLauncher))
+}
+
 const configMock = vi.hoisted(() => ({
   port: 8648,
   appHome: '/Users/test/.hermes-web-ui',
@@ -36,6 +88,9 @@ describe('studio MCP autoinject', () => {
     delete process.env.AUTH_TOKEN
     delete process.env.HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT
     delete process.env.HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT
+    delete process.env.HERMES_WEB_UI_MCP_BIN
+    stableLauncher = createLauncherFixture(process.cwd(), 'directory')
+    process.env.HERMES_WEB_UI_MCP_BIN = stableLauncher
     configMock.port = 8648
     configMock.appHome = '/Users/test/.hermes-web-ui'
     listProfileNamesFromDiskMock.mockReturnValue(['default', 'work'])
@@ -43,6 +98,11 @@ describe('studio MCP autoinject', () => {
       const updated = await updater({})
       return updated.result
     })
+  })
+
+  afterEach(() => {
+    delete process.env.HERMES_WEB_UI_MCP_BIN
+    for (const root of fixtureRoots.splice(0).reverse()) rmSync(root, { recursive: true, force: true })
   })
 
   it('injects bundled MCP server into every profile without relying on a global PATH shim', async () => {
@@ -55,7 +115,7 @@ describe('studio MCP autoinject', () => {
     const injectedDefault = await updateConfigYamlForProfileMock.mock.calls[0][1]({})
     expect(injectedDefault.data.mcp_servers['hermes-studio-api']).toEqual({
       command: process.execPath,
-      args: [join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'api'],
+      args: [stableLauncher, 'api'],
       env: {
         HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
         HERMES_WEB_UI_HOME: '/Users/test/.hermes-web-ui',
@@ -69,7 +129,7 @@ describe('studio MCP autoinject', () => {
     })
     expect(injectedDefault.data.mcp_servers['hermes-studio-devices']).toMatchObject({
       command: process.execPath,
-      args: [join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'devices'],
+      args: [stableLauncher, 'devices'],
       env: {
         HERMES_MCP_SERVER_NAME: 'hermes-studio-devices',
         HERMES_MCP_TOOLSET: 'devices',
@@ -78,7 +138,7 @@ describe('studio MCP autoinject', () => {
     })
     expect(injectedDefault.data.mcp_servers['hermes-studio-use']).toMatchObject({
       command: process.execPath,
-      args: [join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'use'],
+      args: [stableLauncher, 'use'],
       env: {
         HERMES_MCP_SERVER_NAME: 'hermes-studio-use',
         HERMES_MCP_TOOLSET: 'use',
@@ -101,6 +161,68 @@ describe('studio MCP autoinject', () => {
     expect(updateConfigYamlForProfileMock).not.toHaveBeenCalled()
   })
 
+  it('skips autoinject for a transient bundled launcher even with a stable app home', async () => {
+    process.env.HERMES_WEB_UI_MCP_BIN = createLauncherFixture(tmpdir())
+    const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
+
+    const result = await injectBundledMcpServer()
+
+    expect(result.targets).toEqual([])
+    expect(updateConfigYamlForProfileMock).not.toHaveBeenCalled()
+  })
+
+  it('skips autoinject for a bundled launcher inside a linked Git worktree', async () => {
+    process.env.HERMES_WEB_UI_MCP_BIN = createLauncherFixture(process.cwd(), 'worktree')
+    const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
+
+    const result = await injectBundledMcpServer()
+
+    expect(result.targets).toEqual([])
+    expect(updateConfigYamlForProfileMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps autoinject enabled for a submodule-style Git checkout', async () => {
+    process.env.HERMES_WEB_UI_MCP_BIN = createLauncherFixture(process.cwd(), 'submodule')
+    const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
+
+    const result = await injectBundledMcpServer()
+
+    expect(result.targets.map(target => target.profile)).toEqual(['default', 'work'])
+    expect(updateConfigYamlForProfileMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not treat worktrees-shaped separate git dirs as linked worktrees', async () => {
+    const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
+
+    for (const marker of ['separate-worktrees', 'nested-submodule-worktrees'] as const) {
+      vi.clearAllMocks()
+      process.env.HERMES_WEB_UI_MCP_BIN = createLauncherFixture(process.cwd(), marker)
+
+      const result = await injectBundledMcpServer()
+
+      expect(result.targets.map(target => target.profile)).toEqual(['default', 'work'])
+      expect(updateConfigYamlForProfileMock).toHaveBeenCalledTimes(2)
+    }
+  })
+
+  it('skips stable-looking aliases that resolve to transient launchers', async () => {
+    const targets = [
+      createLauncherFixture(tmpdir()),
+      createLauncherFixture(process.cwd(), 'worktree'),
+    ]
+    const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
+
+    for (const target of targets) {
+      vi.clearAllMocks()
+      process.env.HERMES_WEB_UI_MCP_BIN = createStableLauncherAlias(target)
+
+      const result = await injectBundledMcpServer()
+
+      expect(result.targets).toEqual([])
+      expect(updateConfigYamlForProfileMock).not.toHaveBeenCalled()
+    }
+  })
+
   it('allows transient preview autoinject when explicitly requested', async () => {
     configMock.appHome = '/private/tmp/wui-preview-home'
     process.env.HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT = '1'
@@ -120,7 +242,7 @@ describe('studio MCP autoinject', () => {
       mcp_servers: {
         'hermes-studio-api': {
           command: process.execPath,
-          args: [join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'api'],
+          args: [stableLauncher, 'api'],
           env: {
             HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
             HERMES_WEB_UI_HOME: '/Users/test/.hermes-web-ui',
@@ -201,9 +323,9 @@ describe('studio MCP autoinject', () => {
     expect(updated.data.mcp_servers['hermes-studio']).toBeUndefined()
     expect(updated.data.mcp_servers['hermes-web-ui-mcp']).toBeUndefined()
     expect(updated.data.mcp_servers['hermes-studio-api'].command).toBe(process.execPath)
-    expect(updated.data.mcp_servers['hermes-studio-api'].args).toEqual([join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'api'])
-    expect(updated.data.mcp_servers['hermes-studio-devices'].args).toEqual([join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'devices'])
-    expect(updated.data.mcp_servers['hermes-studio-use'].args).toEqual([join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'use'])
+    expect(updated.data.mcp_servers['hermes-studio-api'].args).toEqual([stableLauncher, 'api'])
+    expect(updated.data.mcp_servers['hermes-studio-devices'].args).toEqual([stableLauncher, 'devices'])
+    expect(updated.data.mcp_servers['hermes-studio-use'].args).toEqual([stableLauncher, 'use'])
   })
 
   it('uses the desktop runtime node for bundled MCP servers when available', async () => {
@@ -216,13 +338,13 @@ describe('studio MCP autoinject', () => {
     const injected = await updateConfigYamlForProfileMock.mock.calls[0][1]({})
     expect(injected.data.mcp_servers['hermes-studio-api'].command).toBe('/runtime/node')
     expect(injected.data.mcp_servers['hermes-studio-api'].args).toEqual([
-      join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'api',
+      stableLauncher, 'api',
     ])
     expect(injected.data.mcp_servers['hermes-studio-devices'].args).toEqual([
-      join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'devices',
+      stableLauncher, 'devices',
     ])
     expect(injected.data.mcp_servers['hermes-studio-use'].args).toEqual([
-      join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'use',
+      stableLauncher, 'use',
     ])
   })
 


### PR DESCRIPTION
## 改动说明

- 将实际选中的 bundled MCP launcher 纳入 transient autoinject guard
- 默认跳过临时目录、符号链接指向的临时目标和 linked Git worktree 中的 launcher
- 通过 `commondir` 关系识别真实 linked worktree，避免误判主 checkout、普通 submodule 及 worktrees-shaped separate git dir
- 保留正常安装和显式 opt-in 行为

Closes #2120

## 范围

这是一个仅触及 autoinject guard 和对应单元测试的 minimal fix：

- 不改变 MCP 配置 schema
- 不重构 managed-entry migration
- 不改变用户显式 disable/allow 行为
- 同一次注入只解析一次 launcher，确保检查和持久化的是同一路径

## 验证结果

- `npm run test -- tests/server/studio-mcp-autoinject.test.ts`：14/14 通过
- `npx tsc --noEmit -p packages/server/tsconfig.json`：通过
- `npm run test:coverage`：全量通过
- `npm run harness:check`：`Harness check passed`
- `npm run build`：通过
- `npx playwright test --workers=2`：54/54 通过
- isolated product-path UAT：linked-worktree launcher 未改写 profile；稳定安装 launcher 正常注入
