### PR TITLE
fix(chat): persist session profile filter

### DIFF
--- a/docs/chat-chain-changes/2026-07-18-session-profile-filter-persistence.md
+++ b/docs/chat-chain-changes/2026-07-18-session-profile-filter-persistence.md
@@ -1,0 +1,9 @@
+---
+date: 2026-07-18
+pr: 2123
+feature: Session Profile filter persistence
+impact: The chat session list restores its selected Profile filter after a page reload and falls back to all Profiles when the cached Profile is unavailable.
+---
+
+The filter preference is stored separately from the active Hermes Profile and
+does not change session ownership, runtime selection, or message behavior.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -387,7 +387,7 @@ const profileFilterOptions = computed(() => [
 ]);
 
 async function handleProfileFilterChange(value: string) {
-  chatStore.sessionProfileFilter = value === "__all__" ? null : value;
+  chatStore.setSessionProfileFilter(value === "__all__" ? null : value);
   await chatStore.loadSessions(chatStore.sessionProfileFilter);
 }
 

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -631,6 +631,7 @@ const STORAGE_KEY_PREFIX = 'hermes_active_session_'
 type ChatRuntimeMode = 'default' | 'global_agent'
 let activeRuntimeMode: ChatRuntimeMode = 'default'
 const LEGACY_STORAGE_KEY = 'hermes_active_session'
+const SESSION_PROFILE_FILTER_STORAGE_KEY = 'hermes_session_profile_filter_v1'
 
 // 获取当前 profile 名称，用于隔离缓存。
 // 从 profiles store 的 activeProfileName（同步 localStorage）读取，
@@ -748,7 +749,12 @@ export const useChatStore = defineStore('chat', () => {
   const pendingForkCommands = ref<Set<string>>(new Set())
   /** Sessions that completed while the user was viewing another session. */
   const completedUnreadSessions = ref<Set<string>>(new Set())
-  const sessionProfileFilter = ref<string | null>(null)
+  const storedSessionProfileFilter = getItemBestEffort(SESSION_PROFILE_FILTER_STORAGE_KEY)?.trim()
+  const sessionProfileFilter = ref<string | null>(
+    storedSessionProfileFilter && storedSessionProfileFilter !== '__all__'
+      ? storedSessionProfileFilter
+      : null,
+  )
   /** sessionId → queued message count */
   const queueLengths = ref<Map<string, number>>(new Map())
   /** sessionId → queued user messages not yet visible in the transcript */
@@ -772,6 +778,22 @@ export const useChatStore = defineStore('chat', () => {
     const sid = activeSessionId.value
     return sid ? pendingClarifies.value.get(sid) || null : null
   })
+
+  function setSessionProfileFilter(profile: string | null) {
+    const normalized = profile?.trim()
+    sessionProfileFilter.value = normalized && normalized !== '__all__' ? normalized : null
+    if (sessionProfileFilter.value) {
+      setItemBestEffort(SESSION_PROFILE_FILTER_STORAGE_KEY, sessionProfileFilter.value)
+    } else {
+      removeItem(SESSION_PROFILE_FILTER_STORAGE_KEY)
+    }
+  }
+
+  function validateSessionProfileFilter(profileNames: string[]) {
+    const current = sessionProfileFilter.value
+    if (!current || profileNames.length === 0 || profileNames.includes(current)) return
+    setSessionProfileFilter(null)
+  }
 
   // 自动播放语音开关
   const autoPlaySpeechEnabled = ref(false)
@@ -4083,6 +4105,8 @@ export const useChatStore = defineStore('chat', () => {
     isSessionCompletedUnread,
     clearSessionCompletedUnread,
     sessionProfileFilter,
+    setSessionProfileFilter,
+    validateSessionProfileFilter,
     compressionState,
     abortState,
     isAborting,

--- a/packages/client/src/views/hermes/ChatView.vue
+++ b/packages/client/src/views/hermes/ChatView.vue
@@ -54,6 +54,7 @@ onMounted(async () => {
     profilesStore.fetchProfiles(),
     settingsStore.fetchSettings(),
   ])
+  chatStore.validateSessionProfileFilter(profilesStore.profiles.map(profile => profile.name))
   await loadRouteSession()
 })
 

--- a/packages/client/src/views/hermes/GlobalAgentView.vue
+++ b/packages/client/src/views/hermes/GlobalAgentView.vue
@@ -38,6 +38,7 @@ onMounted(async () => {
     profilesStore.fetchProfiles(),
     settingsStore.fetchSettings(),
   ])
+  chatStore.validateSessionProfileFilter(profilesStore.profiles.map(profile => profile.name))
   await loadRouteSession()
 })
 

--- a/tests/client/chat-store-profile-filter.test.ts
+++ b/tests/client/chat-store-profile-filter.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useChatStore } from '@/stores/hermes/chat'
+
+const STORAGE_KEY = 'hermes_session_profile_filter_v1'
+
+vi.mock('@/api/hermes/sessions', () => ({
+  archiveSession: vi.fn(),
+  fetchSessions: vi.fn(),
+  fetchSessionMessagesPage: vi.fn(),
+  fetchWorkspaceRunChangesForSession: vi.fn(async () => []),
+  fetchWorkspaceRunChangeFile: vi.fn(async () => null),
+  deleteSession: vi.fn(),
+  setSessionModel: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/chat', () => ({
+  startRunViaSocket: vi.fn(),
+  resumeSession: vi.fn(),
+  registerSessionHandlers: vi.fn(),
+  unregisterSessionHandlers: vi.fn(),
+  getChatRunSocket: vi.fn(() => ({ emit: vi.fn() })),
+  respondToolApproval: vi.fn(),
+  respondClarify: vi.fn(),
+  onPeerUserMessage: vi.fn(() => vi.fn()),
+  onSessionCommand: vi.fn(() => vi.fn()),
+  onSessionTitleUpdated: vi.fn(() => vi.fn()),
+  onSessionWorkspaceUpdated: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('@/api/client', () => ({
+  getActiveProfileName: () => 'default',
+}))
+
+vi.mock('@/api/hermes/download', () => ({
+  getDownloadUrl: (_path: string, name: string) => `/download/${name}`,
+}))
+
+vi.mock('@/utils/completion-sound', () => ({
+  primeCompletionSound: vi.fn(),
+  playCompletionSound: vi.fn(),
+}))
+
+vi.mock('@/utils/completion-notification', () => ({
+  showCompletionNotification: vi.fn(),
+}))
+
+vi.mock('@/utils/session-sync', () => ({
+  subscribeSessionSync: vi.fn(() => vi.fn()),
+  publishSessionSync: vi.fn(),
+}))
+
+describe('chat session profile filter persistence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('restores the selected profile from localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'research')
+
+    const store = useChatStore()
+
+    expect(store.sessionProfileFilter).toBe('research')
+  })
+
+  it('persists a profile selection and clears it when all profiles is selected', () => {
+    const store = useChatStore()
+
+    store.setSessionProfileFilter('research')
+    expect(store.sessionProfileFilter).toBe('research')
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('research')
+
+    store.setSessionProfileFilter(null)
+    expect(store.sessionProfileFilter).toBeNull()
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('clears a cached profile that is no longer available', () => {
+    localStorage.setItem(STORAGE_KEY, 'deleted-profile')
+    const store = useChatStore()
+
+    store.validateSessionProfileFilter(['default', 'research'])
+
+    expect(store.sessionProfileFilter).toBeNull()
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- persist the chat session Profile filter in localStorage
- restore the selected filter after a page reload
- clear the saved value when "All Profiles" is selected
- fall back to all profiles when the cached Profile no longer exists

## Why

The session Profile filter lived only in Pinia memory, so refreshing the page always reset it to "All Profiles".

## Impact

Users keep their selected session Profile filter across page reloads without changing the active Hermes Profile or session data.

## Validation

- `npm run test -- tests/client/chat-store-profile-filter.test.ts tests/client/chat-view-tab-title.test.ts` (5 passed)
- `npm run build`
- `npm run test:e2e` (54 passed)

Closes #2112
