### PR TITLE
[codex] gracefully stop desktop services before updates

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -34,6 +34,7 @@ let petWindowLoadPromise: Promise<void> | null = null
 let serverUrl: string | null = null
 let tray: Tray | null = null
 let isQuitting = false
+let appShutdownPromise: Promise<void> | null = null
 let isBootstrapping = false
 let isResettingLogin = false
 let windowFadeTimer: NodeJS.Timeout | null = null
@@ -92,6 +93,18 @@ function showMainWindow() {
 function quitApp() {
   isQuitting = true
   app.quit()
+}
+
+async function prepareAppShutdown(): Promise<void> {
+  isQuitting = true
+  if (!appShutdownPromise) {
+    appShutdownPromise = (async () => {
+      cancelWindowFade()
+      await showShutdownSplash()
+      await stopWebUiServer().catch(() => undefined)
+    })()
+  }
+  await appShutdownPromise
 }
 
 function defaultPetWindowBounds(): DesktopWindowBounds {
@@ -871,11 +884,7 @@ function runDesktopApp() {
     createTray()
     createWindow()
     bootstrap()
-    initAutoUpdater({
-      beforeQuitAndInstall: () => {
-        isQuitting = true
-      },
-    })
+    initAutoUpdater({ beforeQuitAndInstall: prepareAppShutdown })
     app.on('activate', () => {
       if (BrowserWindow.getAllWindows().length === 0) {
         createWindow()
@@ -897,9 +906,7 @@ function runDesktopApp() {
       return
     }
     e.preventDefault()
-    cancelWindowFade()
-    await showShutdownSplash()
-    await stopWebUiServer().catch(() => undefined)
+    await prepareAppShutdown()
     app.exit(0)
   })
 }

--- a/tests/desktop/updater.test.ts
+++ b/tests/desktop/updater.test.ts
@@ -34,4 +34,21 @@ describe('desktop updater helpers', () => {
     expect(updaterSource).toContain('if (response === 0) {\n    await autoUpdater.downloadUpdate()')
     expect(updaterSource).not.toContain('setInterval(')
   })
+
+  it('gracefully stops the current app before starting a downloaded update', () => {
+    const updaterSource = readFileSync(resolve('packages/desktop/src/main/updater.ts'), 'utf-8')
+    const mainSource = readFileSync(resolve('packages/desktop/src/main/index.ts'), 'utf-8')
+
+    expect(mainSource).toContain('async function prepareAppShutdown(): Promise<void>')
+    expect(mainSource).toContain('await stopWebUiServer().catch(() => undefined)')
+    expect(mainSource).toContain('initAutoUpdater({ beforeQuitAndInstall: prepareAppShutdown })')
+    expect(mainSource).toContain('await prepareAppShutdown()\n    app.exit(0)')
+
+    const prepareCurrentInstance = updaterSource.indexOf('await options.beforeQuitAndInstall?.()')
+    const stopOtherInstances = updaterSource.indexOf('await stopOtherWindowsAppInstances()', prepareCurrentInstance)
+    const startInstaller = updaterSource.indexOf('autoUpdater.quitAndInstall()', stopOtherInstances)
+    expect(prepareCurrentInstance).toBeGreaterThan(-1)
+    expect(stopOtherInstances).toBeGreaterThan(prepareCurrentInstance)
+    expect(startInstaller).toBeGreaterThan(stopOtherInstances)
+  })
 })


### PR DESCRIPTION
## Summary
- reuse one idempotent desktop shutdown routine for tray exit and update restart
- wait for Web UI, Agent Bridge, gateway, socket, and database cleanup before launching the updater
- keep Windows residual-instance cleanup after the current app has shut down gracefully
- cover the shutdown and installer ordering with a focused desktop updater test

## Why
The immediate-update path previously marked the app as quitting but could terminate the Electron-hosted Web UI child before its graceful shutdown endpoint ran. That created a race with Agent Bridge and database cleanup, especially on Windows.

## Impact
Windows, macOS, and Linux now complete the same graceful current-instance shutdown before starting their platform updater. Windows retains its additional stale-instance cleanup as a fallback.

## Validation
- `npm run test -- tests/desktop/updater.test.ts`
- `npm --prefix packages/desktop run build`
- `npm run harness:check`
- `npm run build`
