### PR TITLE
Support background delegate task delivery

### DIFF
--- a/docs/chat-chain-changes/2026-07-18-background-delegate-task-delivery.md
+++ b/docs/chat-chain-changes/2026-07-18-background-delegate-task-delivery.md
@@ -25,3 +25,19 @@ status remains in the panel header instead of appearing as transcript content.
 Background parent dispatch events and `delegation.updated` lifecycle records do
 not create placeholder cards, so each visible entry is keyed by a real
 `subagent_id` and always opens the corresponding live stream.
+Agent callers may pass `background_delegation_enabled=false` when the Bridge
+creates a cached Hermes `AgentSession`. The value is retained in that session's
+configuration; later turns bind `async_delivery` from the creation policy
+instead of treating it as a mutable per-run setting. This keeps synchronous
+`delegate_task` available while background requests fall back to the current
+turn. Ordinary Web UI single-chat agents are currently created disabled.
+Group-chat agents and Hermes workflow-node agents pass the same disabled policy
+at their own creation call sites and remain disabled independently of any
+future single-chat opt-in. Coding Agent and Ekko Agent paths do not receive the
+field. The bridge filters session-context arguments against the installed
+Hermes Runtime signature, so the bundled 0.18.0 context API keeps receiving its
+supported legacy fields while 0.18.2 and newer receive the session-level
+async-delivery capability. Agent Bridge retains Hermes Runtime's `tui`
+session-source contract because background delegation uses that path to bind
+completion ownership to the durable agent session across compression-driven
+session-id rotation.

--- a/docs/chat-chain-changes/2026-07-18-background-delegate-task-delivery.md
+++ b/docs/chat-chain-changes/2026-07-18-background-delegate-task-delivery.md
@@ -1,0 +1,24 @@
+---
+date: 2026-07-18
+pr: pending
+feature: Background delegate task delivery
+impact: Background subagent telemetry remains visible after the parent turn ends, and durable completion notifications start a new parent turn without adding child tool traffic to the parent context.
+---
+
+Agent Bridge workers expose one background event and completion poll each. The
+Node chat runtime uses one scheduler across workers, while the client keeps one
+session-scoped Socket handler alive until all background delegations have been
+delivered. Worker recovery accepts recent session ownership routes so pending
+completion records restored from Hermes `state.db` can be claimed safely.
+Graceful shutdown now closes the chat scheduler before the bridge, releases
+queued delivery claims, interrupts active parent and delegated runs, and kills
+tracked tool subprocess trees before worker exit.
+The existing session Stop action also interrupts only that session's active
+background delegations alongside its parent Hermes run.
+Background task cards and the active tool strip open the same resizable side
+panel used by file and PDF previews. Its body reuses the chat message list and
+message renderer for live subagent text, reasoning, and tool calls; lifecycle
+status remains in the panel header instead of appearing as transcript content.
+Background parent dispatch events and `delegation.updated` lifecycle records do
+not create placeholder cards, so each visible entry is keyed by a real
+`subagent_id` and always opens the corresponding live stream.

--- a/docs/chat-chain-changes/2026-07-18-background-delegate-task-delivery.md
+++ b/docs/chat-chain-changes/2026-07-18-background-delegate-task-delivery.md
@@ -14,7 +14,10 @@ Graceful shutdown now closes the chat scheduler before the bridge, releases
 queued delivery claims, interrupts active parent and delegated runs, and kills
 tracked tool subprocess trees before worker exit.
 The existing session Stop action also interrupts only that session's active
-background delegations alongside its parent Hermes run.
+background delegations alongside its parent Hermes run. Interrupted child task
+snapshots and cards now receive an explicit terminal event, with the client also
+settling any still-running card when abort completion arrives, so a silent child
+shutdown cannot leave a permanent loading indicator.
 Background task cards and the active tool strip open the same resizable side
 panel used by file and PDF previews. Its body reuses the chat message list and
 message renderer for live subagent text, reasoning, and tool calls; lifecycle

--- a/docs/chat-chain-changes/2026-07-18-background-delegate-task-delivery.md
+++ b/docs/chat-chain-changes/2026-07-18-background-delegate-task-delivery.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-07-18
-pr: pending
+pr: 2126
 feature: Background delegate task delivery
 impact: Background subagent telemetry remains visible after the parent turn ends, and durable completion notifications start a new parent turn without adding child tool traffic to the parent context.
 ---

--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -89,6 +89,26 @@ export interface RunEvent {
   workspace?: string | null
   /** Queue length from run.queued event */
   queue_length?: number
+  /** Number of background delegations still running or awaiting delivery. */
+  background_pending?: number
+  /** True when this run was started by a delivered background completion. */
+  autonomous?: boolean
+  delegation_id?: string
+  subagent_id?: string
+  task_index?: number
+  task_count?: number
+  goal?: string
+  model?: string
+  status?: string
+  summary?: string
+  arguments?: unknown
+  tool_count?: number
+  duration_seconds?: number
+  background_seq?: number
+  api_calls?: number
+  input_tokens?: number
+  output_tokens?: number
+  cost_usd?: number
   /** Queue item that was just removed because it is starting now. */
   dequeued_queue_id?: string
   /** Queued user messages from run.queued/resume payloads. */
@@ -125,6 +145,8 @@ export interface ResumeSessionPayload {
   workspace?: string | null
   queueLength?: number
   queueMessages?: RunEvent['queued_messages']
+  backgroundTasks?: Array<Record<string, unknown>>
+  backgroundPending?: number
 }
 
 // ============================
@@ -307,7 +329,7 @@ function globalRunCompletedHandler(event: RunEvent): void {
   }
 
   // Auto-cleanup session handlers on completion (skip if more runs queued)
-  if ((event as any).queue_remaining > 0) return
+  if ((event as any).queue_remaining > 0 || (event.background_pending || 0) > 0) return
   sessionEventHandlers.delete(sid)
 }
 
@@ -324,7 +346,7 @@ function globalRunFailedHandler(event: RunEvent): void {
   }
 
   // Auto-cleanup session handlers on failure (skip if more runs queued)
-  if ((event as any).queue_remaining > 0) return
+  if ((event as any).queue_remaining > 0 || (event.background_pending || 0) > 0) return
   sessionEventHandlers.delete(sid)
 }
 
@@ -722,7 +744,10 @@ export function connectChatRun(requestedProfile?: string | null, transport: Chat
     chatRunSocket.on('subagent.start', globalSubagentEventHandler)
     chatRunSocket.on('subagent.tool', globalSubagentEventHandler)
     chatRunSocket.on('subagent.progress', globalSubagentEventHandler)
+    chatRunSocket.on('subagent.text', globalSubagentEventHandler)
+    chatRunSocket.on('subagent.thinking', globalSubagentEventHandler)
     chatRunSocket.on('subagent.complete', globalSubagentEventHandler)
+    chatRunSocket.on('delegation.updated', globalSubagentEventHandler)
 
     // Run lifecycle events
     chatRunSocket.on('run.started', globalRunStartedHandler)
@@ -937,6 +962,10 @@ export function startRunViaSocket(
       if (closed) return
       onEvent(evt)
       if ((evt as any).queue_remaining > 0) return
+      if ((evt.background_pending || 0) > 0) {
+        onDone()
+        return
+      }
       closed = true
       removeTerminalSocketListeners()
       onDone()
@@ -945,6 +974,10 @@ export function startRunViaSocket(
       if (closed) return
       onEvent(evt)
       if ((evt as any).queue_remaining > 0) return
+      if ((evt.background_pending || 0) > 0) {
+        onDone()
+        return
+      }
       closed = true
       removeTerminalSocketListeners()
       onDone()

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -36,11 +36,13 @@ import MessageList from "./MessageList.vue";
 import SessionListItem from "./SessionListItem.vue";
 import OutlinePanel from "./OutlinePanel.vue";
 import TerminalPanel from "./TerminalPanel.vue";
+import SubagentStreamPanel from "./SubagentStreamPanel.vue";
 import PageSidebarNav from "@/components/layout/PageSidebarNav.vue";
 import SettingsCircuitBadge from "@/components/layout/SettingsCircuitBadge.vue";
 import { isStoredSuperAdmin } from "@/api/client";
 import { useDefaultWorkspace } from "@/composables/useDefaultWorkspace";
 import { canScopedCodingAgentUseProvider, usesServerManagedProviderAuth } from "@/utils/codingAgentProviders";
+import { OPEN_SUBAGENT_STREAM_EVENT, type OpenSubagentStreamDetail } from "@/utils/hermes/subagent-stream";
 
 const FilesPanel = defineAsyncComponent(async () => (await import('./FilesPanel.vue')).default);
 const FilePreview = defineAsyncComponent(async () => (await import('@/components/hermes/files/FilePreview.vue')).default);
@@ -68,6 +70,11 @@ const chatDropCounter = ref(0);
 const isChatDropActive = ref(false);
 const showToolPanel = ref(false);
 const activeToolPanel = ref<"files" | "terminal">("files");
+const selectedSubagent = ref<OpenSubagentStreamDetail | null>(null);
+const selectedSubagentStream = computed(() => {
+  const selected = selectedSubagent.value;
+  return selected ? chatStore.getSubagentStream(selected.sessionId, selected.subagentId) : null;
+});
 const activeWorkspaceSessionId = computed(() => chatStore.activeSession?.workspace && !chatStore.activeSession.isLocalOnly ? chatStore.activeSession.id : null);
 const activePreviewSessionId = computed(() => chatStore.activeSession?.id && !chatStore.activeSession.isLocalOnly ? chatStore.activeSession.id : null);
 const activeWorkspacePath = computed(() => chatStore.activeSession?.workspace && !chatStore.activeSession.isLocalOnly ? chatStore.activeSession.workspace : null);
@@ -194,6 +201,7 @@ function closeToolPanelOverlay(): boolean {
   if (toolPanelStore.workspaceDiff && filesStore.editingFile) filesStore.closeEditor();
   filesStore.closePreview();
   toolPanelStore.closeWorkspaceDiff();
+  selectedSubagent.value = null;
   showToolPanel.value = false;
   return true;
 }
@@ -296,9 +304,25 @@ function handleWorkspaceFilePreviewRequest(event: Event) {
   const fileName = customEvent.detail?.fileName || previewPath.split("/").pop() || previewPath;
   filesStore.closePreview();
   toolPanelStore.closeWorkspaceDiff();
+  selectedSubagent.value = null;
   void filesStore.openSessionWorkspacePreview(sessionId, previewPath, fileName).catch((error) => {
     message.error(error instanceof Error ? error.message : t("files.previewFailed"));
   });
+}
+
+function handleOpenSubagentStreamRequest(event: Event) {
+  const customEvent = event as CustomEvent<OpenSubagentStreamDetail>;
+  const detail = customEvent.detail;
+  if (!detail?.sessionId || !detail.subagentId || detail.sessionId !== chatStore.activeSessionId) return;
+  if (toolPanelStore.workspaceDiff && filesStore.hasUnsavedChanges) {
+    message.warning(t("files.unsavedChanges"));
+    return;
+  }
+  if (toolPanelStore.workspaceDiff && filesStore.editingFile) filesStore.closeEditor();
+  filesStore.closePreview();
+  toolPanelStore.closeWorkspaceDiff();
+  selectedSubagent.value = detail;
+  showToolPanel.value = true;
 }
 
 onMounted(() => {
@@ -307,6 +331,7 @@ onMounted(() => {
   mobileQuery.addEventListener("change", handleMobileChange);
   window.addEventListener("hermes:open-page-sidebar", openPageSidebar);
   window.addEventListener("hermes:preview-workspace-file", handleWorkspaceFilePreviewRequest);
+  window.addEventListener(OPEN_SUBAGENT_STREAM_EVENT, handleOpenSubagentStreamRequest);
   window.addEventListener("resize", handleToolPanelViewportResize);
   handleToolPanelViewportResize();
   if (profilesStore.profiles.length === 0) {
@@ -319,7 +344,7 @@ watch(
   async (sessionId, previousSessionId) => {
     if (!sessionId || !previousSessionId || sessionId === previousSessionId) return;
 
-    if (filesStore.previewFile || toolPanelStore.workspaceDiff) {
+    if (filesStore.previewFile || toolPanelStore.workspaceDiff || selectedSubagent.value) {
       closeToolPanelOverlay();
     }
 
@@ -346,6 +371,7 @@ onUnmounted(() => {
   mobileQuery?.removeEventListener("change", handleMobileChange);
   window.removeEventListener("hermes:open-page-sidebar", openPageSidebar);
   window.removeEventListener("hermes:preview-workspace-file", handleWorkspaceFilePreviewRequest);
+  window.removeEventListener(OPEN_SUBAGENT_STREAM_EVENT, handleOpenSubagentStreamRequest);
   window.removeEventListener("resize", handleToolPanelViewportResize);
   stopToolResize();
   sessionFadeAnimation?.cancel();
@@ -362,14 +388,20 @@ watch(showToolPanel, async (visible) => {
 watch(
   () => toolPanelStore.workspaceDiff,
   (workspaceDiff) => {
-    if (workspaceDiff) showToolPanel.value = true;
+    if (workspaceDiff) {
+      selectedSubagent.value = null;
+      showToolPanel.value = true;
+    }
   },
 );
 
 watch(
   () => filesStore.previewFile,
   (previewFile) => {
-    if (previewFile) showToolPanel.value = true;
+    if (previewFile) {
+      selectedSubagent.value = null;
+      showToolPanel.value = true;
+    }
   },
 );
 
@@ -2258,6 +2290,11 @@ async function handleSessionModelCustomSubmit() {
               <FilePreview
                 v-else-if="filesStore.previewFile"
                 :custom-close="closeToolPanelOverlay"
+              />
+              <SubagentStreamPanel
+                v-else-if="selectedSubagent"
+                :stream="selectedSubagentStream"
+                @close="closeToolPanelOverlay"
               />
               <template v-else>
                 <div class="chat-tool-tabs" role="tablist">

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -29,6 +29,7 @@ import { useGlobalSpeech } from "@/composables/useSpeech";
 import { useVoiceSettings } from "@/composables/useVoiceSettings";
 import { speedToEdgeRate, hzToEdgePitch } from "@/utils/ttsHelpers";
 import { formatChatTimestamp } from "@/utils/chat-timestamp";
+import { openSubagentStream, subagentIdFromToolCall } from "@/utils/hermes/subagent-stream";
 
 const MarkdownRenderer = defineAsyncComponent(async () => (await import("./MarkdownRenderer.vue")).default);
 
@@ -593,6 +594,8 @@ const hasToolChange = computed(() => (toolChange.value?.files?.length || 0) > 0)
 const hasToolDetails = computed(
   () => !!(toolArgsPayload.value.full || toolResultPayload.value.full || hasToolChange.value),
 );
+const isSubagentTool = computed(() => subagentIdFromToolCall(props.message.toolCallId) !== null);
+const hasInlineToolDetails = computed(() => hasToolDetails.value && !isSubagentTool.value);
 
 const fullToolArgs = computed(() => toolArgsPayload.value.full);
 const formattedToolArgs = computed(() => toolArgsPayload.value.display);
@@ -614,6 +617,14 @@ const renderedToolResult = computed(() => {
     toolResultPayload.value.language,
   );
 });
+
+function handleToolLineClick() {
+  if (isSubagentTool.value) {
+    openSubagentStream(chatStore.activeSessionId, props.message.toolCallId);
+    return;
+  }
+  if (hasInlineToolDetails.value) toolExpanded.value = !toolExpanded.value;
+}
 
 async function openToolChangeFile(file: { id: string | number; path: string; additions: number; deletions: number }): Promise<void> {
   const storedFile = toolChange.value?.files.find(candidate => String(candidate.id) === String(file.id));
@@ -838,11 +849,16 @@ onBeforeUnmount(() => {
       <div
         v-if="!hasToolChange"
         class="tool-line"
-        :class="{ expandable: hasToolDetails }"
-        @click="hasToolDetails && (toolExpanded = !toolExpanded)"
+        :class="{ expandable: hasInlineToolDetails || isSubagentTool, 'subagent-entry': isSubagentTool }"
+        :role="isSubagentTool ? 'button' : undefined"
+        :tabindex="isSubagentTool ? 0 : undefined"
+        :title="isSubagentTool ? t('subagent.open') : undefined"
+        @click="handleToolLineClick"
+        @keydown.enter.prevent="handleToolLineClick"
+        @keydown.space.prevent="handleToolLineClick"
       >
         <svg
-          v-if="hasToolDetails"
+          v-if="hasInlineToolDetails || isSubagentTool"
           width="10"
           height="10"
           viewBox="0 0 24 24"
@@ -850,7 +866,7 @@ onBeforeUnmount(() => {
           stroke="currentColor"
           stroke-width="2"
           class="tool-chevron"
-          :class="{ rotated: toolExpanded }"
+          :class="{ rotated: toolExpanded && !isSubagentTool }"
         >
           <polyline points="9 18 15 12 9 6" />
         </svg>
@@ -870,7 +886,7 @@ onBeforeUnmount(() => {
         </svg>
         <span class="tool-name">{{ message.toolName }}</span>
         <span
-          v-if="message.toolPreview && !toolExpanded"
+          v-if="message.toolPreview && (!toolExpanded || isSubagentTool)"
           class="tool-preview"
           >{{ message.toolPreview }}</span
         >
@@ -898,7 +914,7 @@ onBeforeUnmount(() => {
           @select="openToolChangeFile"
         />
       </div>
-      <div v-else-if="toolExpanded && hasToolDetails" class="tool-details" @click="handleToolDetailClick">
+      <div v-else-if="!isSubagentTool && toolExpanded && hasToolDetails" class="tool-details" @click="handleToolDetailClick">
         <div v-if="formattedToolArgs" class="tool-detail-section" data-copy-source="tool-args">
           <div class="tool-detail-label">{{ t("chat.arguments") }}</div>
           <div class="tool-detail-code-block" v-html="renderedToolArgs"></div>
@@ -1637,7 +1653,9 @@ onBeforeUnmount(() => {
   &.expandable {
     cursor: pointer;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
+      outline: none;
       background: rgba(0, 0, 0, 0.03);
     }
   }

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -23,6 +23,7 @@ import MessageItem from "./MessageItem.vue";
 import { LIVE_CHAT_MAX_LOADED_MESSAGES, parseMessageReference, useChatStore, type Message } from "@/stores/hermes/chat";
 import thinkingImage from "@/assets/thinking.gif";
 import { useToolTraceVisibility } from "@/composables/useToolTraceVisibility";
+import { openSubagentStream, subagentIdFromToolCall } from "@/utils/hermes/subagent-stream";
 
 const props = withDefaults(defineProps<{
   approvalPortalToBody?: boolean
@@ -58,6 +59,15 @@ function formatToolDuration(seconds: number): string {
 function toolPreviewText(preview?: string): string {
   const text = String(preview || '')
   return text.length > 160 ? `${text.slice(0, 157)}...` : text
+}
+
+function isSubagentToolCall(message: Message): boolean {
+  return subagentIdFromToolCall(message.toolCallId) !== null
+}
+
+function handleToolCallClick(message: Message) {
+  if (!isSubagentToolCall(message)) return
+  openSubagentStream(chatStore.activeSessionId, message.toolCallId)
 }
 
 function formatElapsed(ms: number): string {
@@ -642,6 +652,13 @@ defineExpose({
               v-for="tc in visibleToolCalls"
               :key="tc.id"
               class="tool-call-item"
+              :class="{ 'subagent-entry': isSubagentToolCall(tc) }"
+              :role="isSubagentToolCall(tc) ? 'button' : undefined"
+              :tabindex="isSubagentToolCall(tc) ? 0 : undefined"
+              :title="isSubagentToolCall(tc) ? t('subagent.open') : undefined"
+              @click="handleToolCallClick(tc)"
+              @keydown.enter.prevent="handleToolCallClick(tc)"
+              @keydown.space.prevent="handleToolCallClick(tc)"
             >
               <svg
                 width="12"
@@ -1575,6 +1592,16 @@ defineExpose({
   padding: 3px 8px;
   background: rgba(0, 0, 0, 0.03);
   border-radius: $radius-sm;
+
+  &.subagent-entry {
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+      outline: none;
+      background: rgba(var(--accent-primary-rgb), 0.09);
+    }
+  }
 
   .dark & {
     background: rgba(255, 255, 255, 0.06);

--- a/packages/client/src/components/hermes/chat/SubagentStreamPanel.vue
+++ b/packages/client/src/components/hermes/chat/SubagentStreamPanel.vue
@@ -1,0 +1,363 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { Message, SubagentStream, SubagentStreamEntry, SubagentStreamStatus } from '@/stores/hermes/chat'
+import MessageItem from './MessageItem.vue'
+import VirtualMessageList from './VirtualMessageList.vue'
+
+const props = defineProps<{
+  stream: SubagentStream | null
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const { t } = useI18n()
+const streamListRef = ref<InstanceType<typeof VirtualMessageList> | null>(null)
+
+const streamRevision = computed(() => {
+  const stream = props.stream
+  if (!stream) return 'empty'
+  return `${stream.status}:${stream.entries.map(entry => `${entry.id}:${entry.timestamp}:${entry.text?.length || 0}`).join('|')}`
+})
+
+const taskPosition = computed(() => {
+  const stream = props.stream
+  if (!stream) return ''
+  return `${stream.taskIndex + 1}/${Math.max(1, stream.taskCount)}`
+})
+
+const streamMessages = computed(() =>
+  (props.stream?.entries || [])
+    .filter(entry => entry.kind !== 'status')
+    .map((entry, index) => entryMessage(entry, index)),
+)
+
+const metrics = computed(() => {
+  const stream = props.stream
+  if (!stream) return []
+  const values: Array<{ key: string; value: string }> = []
+  if (stream.model) values.push({ key: 'model', value: stream.model })
+  if (stream.toolCount != null) values.push({ key: 'tools', value: t('subagent.tools', { count: stream.toolCount }) })
+  if (stream.inputTokens != null || stream.outputTokens != null) {
+    values.push({
+      key: 'tokens',
+      value: t('subagent.tokens', {
+        input: formatCount(stream.inputTokens || 0),
+        output: formatCount(stream.outputTokens || 0),
+      }),
+    })
+  }
+  if (stream.durationSeconds != null) values.push({ key: 'duration', value: formatDuration(stream.durationSeconds) })
+  return values
+})
+
+function formatCount(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`
+  return String(value)
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 1) return `${Math.round(seconds * 1000)}ms`
+  if (seconds < 60) return `${Math.round(seconds * 10) / 10}s`
+  const minutes = Math.floor(seconds / 60)
+  const remaining = Math.round(seconds % 60)
+  return `${minutes}m ${remaining}s`
+}
+
+function statusKey(status: SubagentStreamStatus | 'started'): string {
+  if (status === 'error') return 'failed'
+  return status
+}
+
+function statusText(entry?: SubagentStreamEntry): string {
+  if (entry?.text && entry.status === 'running') return entry.text
+  const status = entry?.status || props.stream?.status || 'running'
+  return t(`subagent.${statusKey(status)}`)
+}
+
+function entryMessage(entry: SubagentStreamEntry, index: number): Message {
+  const common = {
+    id: `subagent-stream:${props.stream?.subagentId || 'unknown'}:${entry.id}:${index}`,
+    timestamp: entry.timestamp,
+  }
+  if (entry.kind === 'tool') {
+    return {
+      ...common,
+      role: 'tool',
+      content: '',
+      toolName: entry.toolName || t('subagent.tool'),
+      toolCallId: `subagent-stream-tool:${entry.id}`,
+      toolPreview: entry.text,
+      toolArgs: entry.toolArgs,
+      toolStatus: 'done',
+    }
+  }
+  if (entry.kind === 'thinking') {
+    return {
+      ...common,
+      role: 'assistant',
+      content: '',
+      reasoning: entry.text || '',
+      isStreaming: props.stream?.status === 'running'
+        && props.stream.entries[props.stream.entries.length - 1]?.id === entry.id,
+    }
+  }
+  return {
+    ...common,
+    role: 'assistant',
+    content: entry.text || '',
+  }
+}
+
+watch(streamRevision, () => {
+  if (streamListRef.value?.shouldAutoFollowBottom(96) !== false) {
+    streamListRef.value?.scrollToBottom({ frames: 2, keepAliveMs: 250 })
+  }
+})
+
+onMounted(() => {
+  streamListRef.value?.scrollToBottom({ frames: 2, keepAliveMs: 250 })
+})
+</script>
+
+<template>
+  <section class="subagent-stream-panel">
+    <header class="subagent-stream-header">
+      <div class="subagent-stream-heading">
+        <div class="subagent-stream-kicker">
+          <span class="subagent-live-dot" :class="{ active: stream?.status === 'running' }" aria-hidden="true"></span>
+          <span>{{ t('subagent.title') }}</span>
+          <span v-if="taskPosition" class="subagent-task-position">{{ taskPosition }}</span>
+        </div>
+        <div class="subagent-stream-title">{{ stream?.goal || t('subagent.noGoal') }}</div>
+        <div v-if="metrics.length" class="subagent-stream-metrics">
+          <span v-for="metric in metrics" :key="metric.key">{{ metric.value }}</span>
+        </div>
+      </div>
+      <div class="subagent-header-actions">
+        <span v-if="stream" class="subagent-status" :class="`status-${statusKey(stream.status)}`">
+          {{ statusText() }}
+        </span>
+        <button
+          type="button"
+          class="subagent-close"
+          :aria-label="t('subagent.close')"
+          :title="t('subagent.close')"
+          @click="emit('close')"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </header>
+
+    <div class="subagent-stream-body">
+      <VirtualMessageList
+        ref="streamListRef"
+        :messages="streamMessages"
+        :virtualized="false"
+        padding="20px"
+        :row-gap="16"
+      >
+        <template #item="{ message }">
+          <MessageItem :message="message" />
+        </template>
+        <template #empty>
+          <div class="subagent-empty">
+            <span v-if="stream?.status === 'running'" class="subagent-empty-spinner" aria-hidden="true"></span>
+            <span>{{ stream?.status === 'running' ? t('subagent.waiting') : statusText() }}</span>
+          </div>
+        </template>
+      </VirtualMessageList>
+    </div>
+  </section>
+</template>
+
+<style scoped lang="scss">
+@use "@/styles/variables" as *;
+
+.subagent-stream-panel {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: $bg-main-surface;
+}
+
+.subagent-stream-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 8px 16px;
+  border-bottom: 1px solid $border-color;
+}
+
+.subagent-stream-heading {
+  min-width: 0;
+}
+
+.subagent-stream-kicker {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: $text-secondary;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.subagent-live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: $text-muted;
+
+  &.active {
+    background: var(--accent-primary);
+    box-shadow: 0 0 0 4px rgba(var(--accent-primary-rgb), 0.12);
+    animation: subagent-pulse 1.6s ease-in-out infinite;
+  }
+}
+
+.subagent-task-position {
+  color: $text-muted;
+  font-family: $font-code;
+  font-weight: 400;
+}
+
+.subagent-stream-title {
+  margin-top: 6px;
+  color: $text-primary;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.subagent-stream-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+
+  span {
+    padding: 2px 7px;
+    border-radius: 999px;
+    background: rgba(var(--accent-primary-rgb), 0.07);
+    color: $text-muted;
+    font-family: $font-code;
+    font-size: 10px;
+  }
+}
+
+.subagent-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.subagent-status {
+  padding: 3px 8px;
+  border-radius: 999px;
+  color: $text-secondary;
+  background: rgba(var(--accent-primary-rgb), 0.08);
+  font-size: 11px;
+
+  &.status-running {
+    color: var(--accent-primary);
+  }
+
+  &.status-failed,
+  &.status-cancelled,
+  &.status-interrupted {
+    color: $error;
+    background: rgba(var(--error-rgb), 0.08);
+  }
+}
+
+.subagent-close {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  border-radius: $radius-sm;
+  color: $text-muted;
+  background: transparent;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    outline: none;
+    color: $text-primary;
+    background: rgba(var(--accent-primary-rgb), 0.08);
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.8;
+    stroke-linecap: round;
+  }
+}
+
+.subagent-stream-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  background: $bg-main-surface;
+}
+
+.subagent-empty {
+  height: 100%;
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: $text-muted;
+  font-size: 13px;
+}
+
+.subagent-empty-spinner {
+  width: 14px;
+  height: 14px;
+  border: 1.5px solid $text-muted;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: subagent-spin 0.7s linear infinite;
+}
+
+@keyframes subagent-spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes subagent-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+
+@media (max-width: $breakpoint-mobile) {
+  .subagent-stream-header {
+    padding: 8px 12px;
+  }
+
+  .subagent-status {
+    display: none;
+  }
+
+  .subagent-stream-body :deep(.virtual-message-list) {
+    --virtual-list-padding: 16px 12px 24px !important;
+  }
+}
+</style>

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -481,6 +481,12 @@ export default {
     files: 'Arbeitsbereich',
   },
 
+  subagent: {
+    title: 'Hintergrundaufgabe', noGoal: 'Unbenannte Hintergrundaufgabe', open: 'Live-Ausgabe der Hintergrundaufgabe öffnen', close: 'Ausgabe der Hintergrundaufgabe schließen',
+    waiting: 'Warte auf Live-Ausgabe…', tool: 'Werkzeug', tools: '{count} Werkzeuge', tokens: '{input} ein · {output} aus',
+    started: 'Gestartet', running: 'Wird ausgeführt', completed: 'Abgeschlossen', failed: 'Fehlgeschlagen', cancelled: 'Abgebrochen', interrupted: 'Unterbrochen',
+  },
+
   realtimeVoice: {
     title: 'Echtzeit-Sprache', mode: 'Sprachmodus', open: 'Echtzeit-Sprache öffnen', back: 'Zurück zum Chat', connected: 'Sprachverbindung bereit',
     turnMode: 'Echtzeit-Vorschau · rundenbasiert', browserStt: 'Browser', browserTts: 'Browser', untitledSession: 'Unbenannte Unterhaltung',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -481,6 +481,12 @@ export default {
     files: 'Workspace',
   },
 
+  subagent: {
+    title: 'Background task', noGoal: 'Untitled background task', open: 'Open live background task output', close: 'Close background task output',
+    waiting: 'Waiting for live output...', tool: 'Tool', tools: '{count} tools', tokens: '{input} in · {output} out',
+    started: 'Started', running: 'Running', completed: 'Completed', failed: 'Failed', cancelled: 'Cancelled', interrupted: 'Interrupted',
+  },
+
   realtimeVoice: {
     title: 'Realtime Voice',
     mode: 'Voice mode',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -481,6 +481,12 @@ export default {
     files: 'Espacio de trabajo',
   },
 
+  subagent: {
+    title: 'Tarea en segundo plano', noGoal: 'Tarea en segundo plano sin título', open: 'Abrir salida en directo de la tarea', close: 'Cerrar salida de la tarea',
+    waiting: 'Esperando salida en directo…', tool: 'Herramienta', tools: '{count} herramientas', tokens: '{input} entrada · {output} salida',
+    started: 'Iniciada', running: 'En ejecución', completed: 'Completada', failed: 'Fallida', cancelled: 'Cancelada', interrupted: 'Interrumpida',
+  },
+
   realtimeVoice: {
     title: 'Voz en tiempo real', mode: 'Modo de voz', open: 'Abrir voz en tiempo real', back: 'Volver al chat', connected: 'Enlace de voz listo',
     turnMode: 'Vista previa en tiempo real · por turnos', browserStt: 'Navegador', browserTts: 'Navegador', untitledSession: 'Conversación sin título',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -481,6 +481,12 @@ export default {
     files: 'Espace de travail',
   },
 
+  subagent: {
+    title: 'Tâche en arrière-plan', noGoal: 'Tâche en arrière-plan sans titre', open: 'Ouvrir la sortie en direct de la tâche', close: 'Fermer la sortie de la tâche',
+    waiting: 'En attente de la sortie en direct…', tool: 'Outil', tools: '{count} outils', tokens: '{input} entrée · {output} sortie',
+    started: 'Démarrée', running: 'En cours', completed: 'Terminée', failed: 'Échec', cancelled: 'Annulée', interrupted: 'Interrompue',
+  },
+
   realtimeVoice: {
     title: 'Voix en temps réel', mode: 'Mode vocal', open: 'Ouvrir la voix en temps réel', back: 'Retour au chat', connected: 'Liaison vocale prête',
     turnMode: 'Aperçu temps réel · mode tour par tour', browserStt: 'Navigateur', browserTts: 'Navigateur', untitledSession: 'Conversation sans titre',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -481,6 +481,12 @@ export default {
     files: 'ワークスペース',
   },
 
+  subagent: {
+    title: 'バックグラウンドタスク', noGoal: '無題のバックグラウンドタスク', open: 'バックグラウンドタスクのライブ出力を開く', close: 'バックグラウンドタスクの出力を閉じる',
+    waiting: 'ライブ出力を待機中…', tool: 'ツール', tools: 'ツール呼び出し {count} 回', tokens: '入力 {input} · 出力 {output}',
+    started: '開始済み', running: '実行中', completed: '完了', failed: '失敗', cancelled: 'キャンセル済み', interrupted: '中断済み',
+  },
+
   realtimeVoice: {
     title: 'リアルタイム音声', mode: '音声モード', open: 'リアルタイム音声を開く', back: 'チャットに戻る', connected: '音声リンク準備完了',
     turnMode: 'リアルタイムプレビュー · ターン方式', browserStt: 'ブラウザ', browserTts: 'ブラウザ', untitledSession: '無題の会話',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -481,6 +481,12 @@ export default {
     files: '작업 공간',
   },
 
+  subagent: {
+    title: '백그라운드 작업', noGoal: '제목 없는 백그라운드 작업', open: '백그라운드 작업 실시간 출력 열기', close: '백그라운드 작업 출력 닫기',
+    waiting: '실시간 출력을 기다리는 중…', tool: '도구', tools: '도구 호출 {count}회', tokens: '입력 {input} · 출력 {output}',
+    started: '시작됨', running: '실행 중', completed: '완료됨', failed: '실패함', cancelled: '취소됨', interrupted: '중단됨',
+  },
+
   realtimeVoice: {
     title: '실시간 음성', mode: '음성 모드', open: '실시간 음성 열기', back: '채팅으로 돌아가기', connected: '음성 연결 준비됨',
     turnMode: '실시간 미리보기 · 턴 방식', browserStt: '브라우저', browserTts: '브라우저', untitledSession: '제목 없는 대화',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -481,6 +481,12 @@ export default {
     files: 'Espaço de trabalho',
   },
 
+  subagent: {
+    title: 'Tarefa em segundo plano', noGoal: 'Tarefa em segundo plano sem título', open: 'Abrir saída ao vivo da tarefa', close: 'Fechar saída da tarefa',
+    waiting: 'Aguardando saída ao vivo…', tool: 'Ferramenta', tools: '{count} ferramentas', tokens: '{input} entrada · {output} saída',
+    started: 'Iniciada', running: 'Em execução', completed: 'Concluída', failed: 'Falhou', cancelled: 'Cancelada', interrupted: 'Interrompida',
+  },
+
   realtimeVoice: {
     title: 'Voz em tempo real', mode: 'Modo de voz', open: 'Abrir voz em tempo real', back: 'Voltar ao chat', connected: 'Conexão de voz pronta',
     turnMode: 'Prévia em tempo real · por turnos', browserStt: 'Navegador', browserTts: 'Navegador', untitledSession: 'Conversa sem título',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -408,6 +408,12 @@ export default {
     files: 'Рабочая область',
   },
 
+  subagent: {
+    title: 'Фоновая задача', noGoal: 'Фоновая задача без названия', open: 'Открыть поток фоновой задачи', close: 'Закрыть поток фоновой задачи',
+    waiting: 'Ожидание потока данных…', tool: 'Инструмент', tools: 'Инструментов: {count}', tokens: 'Ввод {input} · вывод {output}',
+    started: 'Запущена', running: 'Выполняется', completed: 'Завершена', failed: 'Ошибка', cancelled: 'Отменена', interrupted: 'Прервана',
+  },
+
   realtimeVoice: {
     title: 'Голос в реальном времени', mode: 'Голосовой режим', open: 'Открыть голосовой режим', back: 'Вернуться в чат', connected: 'Голосовая связь готова',
     turnMode: 'Предпросмотр · по очереди', browserStt: 'Браузер', browserTts: 'Браузер', untitledSession: 'Разговор без названия',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -481,6 +481,12 @@ export default {
     files: '工作區',
   },
 
+  subagent: {
+    title: '背景子任務', noGoal: '未命名背景子任務', open: '開啟背景子任務即時輸出', close: '關閉背景子任務輸出',
+    waiting: '正在等待即時輸出…', tool: '工具', tools: '{count} 次工具呼叫', tokens: '輸入 {input} · 輸出 {output}',
+    started: '已啟動', running: '執行中', completed: '已完成', failed: '執行失敗', cancelled: '已取消', interrupted: '已停止',
+  },
+
   realtimeVoice: {
     title: '即時語音',
     mode: '語音模式',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -481,6 +481,12 @@ export default {
     files: '工作区',
   },
 
+  subagent: {
+    title: '后台子任务', noGoal: '未命名后台子任务', open: '打开后台子任务实时输出', close: '关闭后台子任务输出',
+    waiting: '正在等待实时输出…', tool: '工具', tools: '{count} 次工具调用', tokens: '输入 {input} · 输出 {output}',
+    started: '已启动', running: '执行中', completed: '已完成', failed: '执行失败', cancelled: '已取消', interrupted: '已停止',
+  },
+
   realtimeVoice: {
     title: '实时语音',
     mode: '语音模式',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -85,6 +85,212 @@ export interface Message {
   runMarker?: string | null
 }
 
+export type SubagentStreamStatus =
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'error'
+  | 'cancelled'
+  | 'interrupted'
+
+export interface SubagentStreamEntry {
+  id: string
+  kind: 'text' | 'thinking' | 'tool' | 'status'
+  timestamp: number
+  text?: string
+  toolName?: string
+  toolArgs?: unknown
+  status?: SubagentStreamStatus | 'started'
+}
+
+export interface SubagentStream {
+  sessionId: string
+  subagentId: string
+  taskIndex: number
+  taskCount: number
+  goal?: string
+  model?: string
+  status: SubagentStreamStatus
+  startedAt: number
+  updatedAt: number
+  completedAt?: number
+  durationSeconds?: number
+  toolCount?: number
+  apiCalls?: number
+  inputTokens?: number
+  outputTokens?: number
+  costUsd?: number
+  summary?: string
+  lastBackgroundSeq?: number
+  entries: SubagentStreamEntry[]
+}
+
+const SUBAGENT_STREAM_ENTRY_LIMIT = 200
+const SUBAGENT_STREAM_TEXT_LIMIT = 80_000
+let subagentStreamEntrySequence = 0
+
+function subagentEventTimestamp(value: unknown): number {
+  const timestamp = Number(value)
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return Date.now()
+  return timestamp < 1_000_000_000_000 ? Math.round(timestamp * 1000) : Math.round(timestamp)
+}
+
+function subagentStatus(value: unknown, fallback: SubagentStreamStatus = 'running'): SubagentStreamStatus {
+  const status = String(value || '').trim().toLowerCase()
+  if (status === 'completed' || status === 'failed' || status === 'error' || status === 'cancelled' || status === 'interrupted') {
+    return status
+  }
+  return fallback
+}
+
+function subagentEntryId(eventName: string, evt: RunEvent): string {
+  const backgroundSequence = Number((evt as any).background_seq)
+  if (Number.isFinite(backgroundSequence)) return `${eventName}:${backgroundSequence}`
+  if ((evt as any).background_snapshot) return `snapshot:${eventName}`
+  subagentStreamEntrySequence += 1
+  return `${eventName}:${subagentStreamEntrySequence}`
+}
+
+function trimSubagentEntries(entries: SubagentStreamEntry[]): SubagentStreamEntry[] {
+  return entries.length > SUBAGENT_STREAM_ENTRY_LIMIT
+    ? entries.slice(entries.length - SUBAGENT_STREAM_ENTRY_LIMIT)
+    : entries
+}
+
+function appendSubagentText(
+  entries: SubagentStreamEntry[],
+  entry: SubagentStreamEntry,
+): SubagentStreamEntry[] {
+  const previous = entries[entries.length - 1]
+  if (previous?.kind === entry.kind && entry.text) {
+    const previousText = previous.text || ''
+    const nextText = entry.text.startsWith(previousText)
+      ? entry.text
+      : `${previousText}${entry.text}`
+    entries[entries.length - 1] = {
+      ...previous,
+      text: nextText.slice(-SUBAGENT_STREAM_TEXT_LIMIT),
+      timestamp: entry.timestamp,
+    }
+    return entries
+  }
+  entries.push({
+    ...entry,
+    text: entry.text?.slice(-SUBAGENT_STREAM_TEXT_LIMIT),
+  })
+  return trimSubagentEntries(entries)
+}
+
+export function reduceSubagentStream(
+  current: SubagentStream | undefined,
+  sessionId: string,
+  evt: RunEvent,
+): SubagentStream {
+  const eventName = String(evt.event || '')
+  const subagentId = String((evt as any).subagent_id || evt.delegation_id || `${(evt as any).task_index ?? 0}`)
+  const timestamp = subagentEventTimestamp(evt.timestamp || (evt as any).updated_at)
+  const backgroundSequence = Number((evt as any).background_seq)
+  if (
+    current
+    && Number.isFinite(backgroundSequence)
+    && current.lastBackgroundSeq != null
+    && backgroundSequence <= current.lastBackgroundSeq
+  ) {
+    return current
+  }
+
+  const incomingTaskIndex = Number((evt as any).task_index)
+  const incomingTaskCount = Number((evt as any).task_count)
+  const goal = String((evt as any).goal || '').trim()
+  const model = String((evt as any).model || '').trim()
+  const summary = String((evt as any).summary || '').trim()
+  const rawText = String(evt.text || evt.preview || '')
+  const text = rawText.trim()
+  const toolName = String((evt as any).tool || (evt as any).name || '').trim()
+  const durationSeconds = Number((evt as any).duration_seconds ?? (evt as any).duration)
+  const toolCount = Number((evt as any).tool_count)
+  const apiCalls = Number((evt as any).api_calls)
+  const inputTokens = Number((evt as any).input_tokens)
+  const outputTokens = Number((evt as any).output_tokens)
+  const costUsd = Number((evt as any).cost_usd)
+  const isTerminal = eventName === 'subagent.complete'
+    || (eventName === 'delegation.updated' && ['completed', 'failed', 'error', 'cancelled', 'interrupted'].includes(String((evt as any).status || '').toLowerCase()))
+  const nextStatus = isTerminal
+    ? subagentStatus((evt as any).status, 'completed')
+    : 'running'
+  const entries = current ? [...current.entries] : []
+  const entryId = subagentEntryId(eventName, evt)
+
+  if (eventName === 'subagent.start') {
+    if (!entries.some(entry => entry.kind === 'status' && entry.status === 'started')) {
+      entries.push({ id: entryId, kind: 'status', status: 'started', timestamp, text: goal || undefined })
+    }
+  } else if (eventName === 'subagent.text' && rawText) {
+    appendSubagentText(entries, { id: entryId, kind: 'text', timestamp, text: rawText })
+  } else if (eventName === 'subagent.thinking' && rawText) {
+    appendSubagentText(entries, { id: entryId, kind: 'thinking', timestamp, text: rawText })
+  } else if (eventName === 'subagent.tool') {
+    entries.push({
+      id: entryId,
+      kind: 'tool',
+      timestamp,
+      text: text || undefined,
+      toolName: toolName || undefined,
+      toolArgs: (evt as any).arguments,
+    })
+  } else if (eventName === 'subagent.progress' && text) {
+    const previous = entries[entries.length - 1]
+    const progressEntry: SubagentStreamEntry = {
+      id: entryId,
+      kind: 'status',
+      status: 'running',
+      timestamp,
+      text,
+    }
+    if (previous?.kind === 'status' && previous.status === 'running') entries[entries.length - 1] = progressEntry
+    else entries.push(progressEntry)
+  }
+
+  if (isTerminal) {
+    const finalText = summary || text
+    const previousText = [...entries].reverse().find(entry => entry.kind === 'text')?.text?.trim()
+    if (finalText && previousText !== finalText) {
+      entries.push({ id: `${entryId}:summary`, kind: 'text', timestamp, text: finalText })
+    }
+    const previous = entries[entries.length - 1]
+    const terminalEntry: SubagentStreamEntry = {
+      id: entryId,
+      kind: 'status',
+      status: nextStatus,
+      timestamp,
+    }
+    if (previous?.kind === 'status' && previous.status !== 'started') entries[entries.length - 1] = terminalEntry
+    else entries.push(terminalEntry)
+  }
+
+  return {
+    sessionId,
+    subagentId,
+    taskIndex: Number.isFinite(incomingTaskIndex) ? incomingTaskIndex : current?.taskIndex || 0,
+    taskCount: Number.isFinite(incomingTaskCount) && incomingTaskCount > 0 ? incomingTaskCount : current?.taskCount || 1,
+    goal: goal || current?.goal,
+    model: model || current?.model,
+    status: nextStatus,
+    startedAt: current?.startedAt || subagentEventTimestamp((evt as any).started_at || timestamp),
+    updatedAt: timestamp,
+    completedAt: isTerminal ? subagentEventTimestamp((evt as any).completed_at || timestamp) : current?.completedAt,
+    durationSeconds: Number.isFinite(durationSeconds) ? durationSeconds : current?.durationSeconds,
+    toolCount: Number.isFinite(toolCount) ? toolCount : current?.toolCount,
+    apiCalls: Number.isFinite(apiCalls) ? apiCalls : current?.apiCalls,
+    inputTokens: Number.isFinite(inputTokens) ? inputTokens : current?.inputTokens,
+    outputTokens: Number.isFinite(outputTokens) ? outputTokens : current?.outputTokens,
+    costUsd: Number.isFinite(costUsd) ? costUsd : current?.costUsd,
+    summary: summary || current?.summary,
+    lastBackgroundSeq: Number.isFinite(backgroundSequence) ? backgroundSequence : current?.lastBackgroundSeq,
+    entries: trimSubagentEntries(entries),
+  }
+}
+
 export interface MessageReference {
   id: string
   role: 'user' | 'assistant'
@@ -332,6 +538,25 @@ function runtimePayloadText(value: unknown): string {
   return String(value)
 }
 
+function runtimeObjectPayload(value: unknown): Record<string, unknown> | null {
+  if (!value) return null
+  if (typeof value === 'object' && !Array.isArray(value)) return value as Record<string, unknown>
+  if (typeof value !== 'string') return null
+  try {
+    const parsed = JSON.parse(value)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null
+  } catch {
+    return null
+  }
+}
+
+function isBackgroundDelegateToolPayload(toolName: unknown, payload: unknown): boolean {
+  if (String(toolName || '') !== 'delegate_task') return false
+  return runtimeObjectPayload(payload)?.mode === 'background'
+}
+
 function parsePersistedMoaToolPayload(toolName: string | undefined, value: unknown): { preview?: string; result?: unknown } | null {
   if (toolName !== 'moa_reference' && toolName !== 'moa_aggregating') return null
   const payload = typeof value === 'string'
@@ -500,6 +725,7 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
       const toolName = msg.tool_name || toolNameMap.get(tcId) || undefined
       const toolArgs = toolArgsMap.has(tcId) ? toolArgsMap.get(tcId) : undefined
       const moaPayload = parsePersistedMoaToolPayload(toolName, (msg as any).content)
+      const backgroundDelegate = isBackgroundDelegateToolPayload(toolName, (msg as any).content)
       // Extract a short preview from the content
       let preview = moaPayload?.preview || ''
       const contentText = runtimePayloadText((msg as any).content)
@@ -520,6 +746,7 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
       if (placeholderIdx !== -1) {
         result.splice(placeholderIdx, 1)
       }
+      if (backgroundDelegate) continue
       result.push({
         id: String(msg.id),
         role: 'tool',
@@ -749,6 +976,8 @@ export const useChatStore = defineStore('chat', () => {
   const pendingForkCommands = ref<Set<string>>(new Set())
   /** Sessions that completed while the user was viewing another session. */
   const completedUnreadSessions = ref<Set<string>>(new Set())
+  /** UI-only live streams for Hermes background subagents. Never sent into parent context. */
+  const subagentStreams = ref<Map<string, SubagentStream>>(new Map())
   const storedSessionProfileFilter = getItemBestEffort(SESSION_PROFILE_FILTER_STORAGE_KEY)?.trim()
   const sessionProfileFilter = ref<string | null>(
     storedSessionProfileFilter && storedSessionProfileFilter !== '__all__'
@@ -1320,6 +1549,7 @@ export const useChatStore = defineStore('chat', () => {
     if (!activeSession.value) return
 
     isLoadingMessages.value = true
+    let backgroundPendingOnResume = 0
 
     try {
       // Load messages via Socket.IO resume (server loads from DB if not in memory)
@@ -1341,6 +1571,7 @@ export const useChatStore = defineStore('chat', () => {
           } else {
             serverWorking.value.delete(sessionId)
           }
+          backgroundPendingOnResume = Number(data.backgroundPending || 0)
           if (data.queueLength && data.queueLength > 0) {
             queueLengths.value.set(sessionId, data.queueLength)
           } else {
@@ -1432,6 +1663,7 @@ export const useChatStore = defineStore('chat', () => {
               } else if (e.event === 'workspace.diff.completed') {
                 handleWorkspaceRunChangeEvent(sessionId, e)
               } else if (e.event === 'tool.started') {
+                if (isBackgroundDelegateToolPayload(e.tool || e.name, (e as any).arguments)) continue
                 const msgs = getSessionMsgs(sessionId)
                 const toolCallId = e.tool_call_id as string | undefined
                 const existingTool = toolCallId
@@ -1463,8 +1695,13 @@ export const useChatStore = defineStore('chat', () => {
                 const toolMsgs = toolCallId
                   ? msgs.filter(m => m.role === 'tool' && m.toolCallId === toolCallId)
                   : msgs.filter(m => m.role === 'tool' && m.toolStatus === 'running')
+                const output = runtimeToolOutputFromEvent(e)
+                const toolName = e.tool || e.name || toolMsgs[toolMsgs.length - 1]?.toolName
+                if (isBackgroundDelegateToolPayload(toolName, output)) {
+                  target.messages = target.messages.filter(message => !toolMsgs.includes(message))
+                  continue
+                }
                 if (toolMsgs.length > 0) {
-                  const output = runtimeToolOutputFromEvent(e)
                   updateMessage(sessionId, toolMsgs[toolMsgs.length - 1].id, {
                     toolStatus: e.event === 'tool.failed' || e.error === true || runtimeToolOutputHasError(output) ? 'error' : 'done',
                     toolDuration: e.duration,
@@ -1473,9 +1710,29 @@ export const useChatStore = defineStore('chat', () => {
                 }
               } else if (e.event === 'moa.reference' || e.event === 'moa.aggregating') {
                 handleMoaEvent(sessionId, e as RunEvent)
-              } else if (String(e.event || '').startsWith('subagent.')) {
+              } else if (String(e.event || '').startsWith('subagent.') || e.event === 'delegation.updated') {
                 handleSubagentEvent(sessionId, e as RunEvent)
               }
+            }
+          }
+          if (Array.isArray(data.backgroundTasks)) {
+            for (const task of data.backgroundTasks) {
+              const lastEvent = String(task.last_event || '')
+              const status = String(task.status || '')
+              const event = lastEvent.startsWith('subagent.')
+                ? lastEvent
+                : status === 'running' ? 'subagent.progress' : 'subagent.complete'
+              handleSubagentEvent(sessionId, {
+                ...task,
+                event,
+                session_id: sessionId,
+                background_snapshot: true,
+                subagent_id: task.subagent_id,
+                tool: task.last_tool,
+                name: task.last_tool,
+                text: task.preview,
+                duration_seconds: task.duration_seconds,
+              } as RunEvent)
             }
           }
           resolve()
@@ -1492,7 +1749,7 @@ export const useChatStore = defineStore('chat', () => {
 
     // Resume in-flight run event listeners if needed
     if (activeSessionId.value === sessionId) {
-      resumeServerWorkingRun(sessionId)
+      resumeServerWorkingRun(sessionId, backgroundPendingOnResume > 0, !serverWorking.value.has(sessionId))
     }
   }
 
@@ -1669,7 +1926,7 @@ export const useChatStore = defineStore('chat', () => {
   function settleRunningTools(sessionId: string, status: 'done' | 'error') {
     const msgs = getSessionMsgs(sessionId)
     msgs.forEach((m, i) => {
-      if (m.role === 'tool' && m.toolStatus === 'running') {
+      if (m.role === 'tool' && m.toolStatus === 'running' && !m.toolCallId?.startsWith('subagent:')) {
         msgs[i] = { ...m, toolStatus: status }
       }
     })
@@ -1693,31 +1950,63 @@ export const useChatStore = defineStore('chat', () => {
 
   function handleSubagentEvent(sessionId: string, evt: RunEvent) {
     const eventName = String(evt.event || '')
-    if (!eventName.startsWith('subagent.')) return
+    if (!eventName.startsWith('subagent.') && eventName !== 'delegation.updated') return
+
+    if (eventName === 'delegation.updated') {
+      const delegationId = String(evt.delegation_id || '').trim()
+      const status = subagentStatus((evt as any).status)
+      if (status === 'running') return
+      const sessionStreams = [...subagentStreams.value.values()].filter(stream =>
+        stream.sessionId === sessionId && stream.status === 'running',
+      )
+      const exactMatch = sessionStreams.find(stream => stream.subagentId === delegationId)
+      const targets = exactMatch
+        ? [exactMatch]
+        : ['failed', 'error', 'cancelled', 'interrupted'].includes(status)
+          ? sessionStreams
+          : []
+      for (const stream of targets) {
+        handleSubagentEvent(sessionId, {
+          ...evt,
+          event: 'subagent.complete',
+          subagent_id: stream.subagentId,
+          task_index: stream.taskIndex,
+          task_count: stream.taskCount,
+          goal: stream.goal,
+          model: stream.model,
+          status,
+        })
+      }
+      return
+    }
 
     const subagentId = String((evt as any).subagent_id || `${(evt as any).task_index ?? 0}`)
-    const toolCallId = `subagent:${evt.run_id || 'run'}:${subagentId}`
+    const streamKey = `${sessionId}:${subagentId}`
+    subagentStreams.value.set(
+      streamKey,
+      reduceSubagentStream(subagentStreams.value.get(streamKey), sessionId, evt),
+    )
+    const toolCallId = `subagent:${subagentId}`
     const taskIndex = Number((evt as any).task_index ?? 0)
     const taskCount = Number((evt as any).task_count ?? 1)
     const label = `${taskIndex + 1}/${Math.max(1, taskCount || 1)}`
     const toolName = String((evt as any).tool || (evt as any).name || '')
     const toolCount = Number((evt as any).tool_count || 0)
     const goal = String((evt as any).goal || '').trim()
-    const text = String(evt.text || evt.preview || '').trim()
+    const rawText = String(evt.text || evt.preview || '')
+    const text = rawText.trim()
     const summary = String((evt as any).summary || '').trim()
     const duration = Number((evt as any).duration_seconds ?? (evt as any).duration)
 
-    let preview = text || summary || goal
+    let preview = `${label}${goal ? ` · ${goal}` : ''}`
     if (eventName === 'subagent.start') {
-      preview = `subagent ${label} started${goal ? `: ${goal}` : ''}`
+      preview = `${label}${goal ? ` · ${goal}` : ''}`
     } else if (eventName === 'subagent.tool') {
-      const prefix = `subagent ${label}${toolCount ? ` turn ${toolCount}` : ''}`
-      preview = `${prefix}${toolName ? `: ${toolName}` : ''}${text ? ` - ${text}` : ''}`
-    } else if (eventName === 'subagent.progress') {
-      preview = `subagent ${label}: ${text || 'working'}`
+      preview = `${label}${toolCount ? ` · #${toolCount}` : ''}${toolName ? ` · ${toolName}` : ''}${text ? ` · ${text}` : ''}`
+    } else if (eventName === 'subagent.progress' || eventName === 'subagent.text' || eventName === 'subagent.thinking') {
+      preview = `${label}${text ? ` · ${text}` : goal ? ` · ${goal}` : ''}`
     } else if (eventName === 'subagent.complete') {
-      const status = String((evt as any).status || 'completed')
-      preview = `subagent ${label} ${status}${summary ? `: ${summary}` : ''}`
+      preview = `${label}${summary ? ` · ${summary}` : text ? ` · ${text}` : ''}`
     }
 
     const msgs = getSessionMsgs(sessionId)
@@ -1729,6 +2018,9 @@ export const useChatStore = defineStore('chat', () => {
       toolName: 'delegate_task',
       toolCallId,
       toolPreview: preview.slice(0, 220),
+      toolArgs: eventName === 'subagent.tool'
+        ? runtimeToolPayloadOrUndefined((evt as any).arguments)
+        : existing?.toolArgs,
       toolStatus,
       toolDuration: Number.isFinite(duration) ? duration : undefined,
       toolResult: eventName === 'subagent.complete'
@@ -1738,8 +2030,9 @@ export const useChatStore = defineStore('chat', () => {
             api_calls: (evt as any).api_calls,
             input_tokens: (evt as any).input_tokens,
             output_tokens: (evt as any).output_tokens,
+            output_tail: (evt as any).output_tail,
           }, null, 2)
-        : undefined,
+        : existing?.toolResult,
     }
 
     if (existing) {
@@ -1754,6 +2047,10 @@ export const useChatStore = defineStore('chat', () => {
       timestamp: Date.now(),
       ...update,
     })
+  }
+
+  function getSubagentStream(sessionId: string, subagentId: string): SubagentStream | null {
+    return subagentStreams.value.get(`${sessionId}:${subagentId}`) || null
   }
 
   function handleMoaEvent(sessionId: string, evt: RunEvent) {
@@ -2937,6 +3234,7 @@ export const useChatStore = defineStore('chat', () => {
 
             case 'tool.started': {
               runHadToolActivity = true
+              if (isBackgroundDelegateToolPayload(evt.tool || evt.name, (evt as any).arguments)) break
               const msgs = getSessionMsgs(sid)
               const toolCallId = (evt as any).tool_call_id as string | undefined
               const last = activeAssistantMessageId
@@ -2981,9 +3279,15 @@ export const useChatStore = defineStore('chat', () => {
               const toolMsgs = toolCallId
                 ? msgs.filter(m => m.role === 'tool' && m.toolCallId === toolCallId)
                 : msgs.filter(m => m.role === 'tool' && m.toolStatus === 'running')
+              const output = runtimeToolOutputFromEvent(evt)
+              const toolName = evt.tool || evt.name || toolMsgs[toolMsgs.length - 1]?.toolName
+              if (isBackgroundDelegateToolPayload(toolName, output)) {
+                const session = sessions.value.find(item => item.id === sid)
+                if (session) session.messages = session.messages.filter(message => !toolMsgs.includes(message))
+                break
+              }
               if (toolMsgs.length > 0) {
                 const last = toolMsgs[toolMsgs.length - 1]
-                const output = runtimeToolOutputFromEvent(evt)
                 const hasError = evt.event === 'tool.failed' || (evt as any).error === true || runtimeToolOutputHasError(output)
                 const duration = (evt as any).duration
                 updateMessage(sid, last.id, {
@@ -3004,7 +3308,10 @@ export const useChatStore = defineStore('chat', () => {
             case 'subagent.start':
             case 'subagent.tool':
             case 'subagent.progress':
-            case 'subagent.complete': {
+            case 'subagent.text':
+            case 'subagent.thinking':
+            case 'subagent.complete':
+            case 'delegation.updated': {
               runHadToolActivity = true
               handleSubagentEvent(sid, evt)
               break
@@ -3273,7 +3580,7 @@ export const useChatStore = defineStore('chat', () => {
    * Emits 'resume' to join the session room on the server,
    * then sets up event listeners to receive ongoing events.
    */
-  function resumeServerWorkingRun(sid: string, force = false) {
+  function resumeServerWorkingRun(sid: string, force = false, passive = false) {
     // Don't register duplicate listeners if already streaming
     if (streamStates.value.has(sid)) return
     // Only set up listeners if the server reported an active run during resume.
@@ -3294,6 +3601,20 @@ export const useChatStore = defineStore('chat', () => {
       serverWorking.value.delete(sid)
       // Unregister from global session handlers
       unregisterSessionHandlers(sid)
+    }
+
+    const markIdleKeepingBackgroundListener = () => {
+      streamStates.value.delete(sid)
+      serverWorking.value.delete(sid)
+    }
+
+    const ensureAbortHandle = () => {
+      if (streamStates.value.has(sid)) return
+      streamStates.value.set(sid, {
+        abort: () => {
+          getChatRunSocket(runtimeTransport())?.emit('abort', { session_id: sid })
+        },
+      })
     }
 
     const closeStreamingAssistant = () => {
@@ -3362,6 +3683,7 @@ export const useChatStore = defineStore('chat', () => {
         case 'run.started':
           clearSessionCompletedUnread(sid)
           serverWorking.value.add(sid)
+          ensureAbortHandle()
           clearAgentEventMessages(sid)
           setAbortState(null)
           setCompressionState(sid, null)
@@ -3537,6 +3859,7 @@ export const useChatStore = defineStore('chat', () => {
 
         case 'tool.started': {
           runHadToolActivity = true
+          if (isBackgroundDelegateToolPayload(evt.tool || evt.name, (evt as any).arguments)) break
           const msgs = getSessionMsgs(sid)
           const toolCallId = (evt as any).tool_call_id as string | undefined
           const last = activeAssistantMessageId
@@ -3581,8 +3904,14 @@ export const useChatStore = defineStore('chat', () => {
           const toolMsgs = toolCallId
             ? msgs.filter(m => m.role === 'tool' && m.toolCallId === toolCallId)
             : msgs.filter(m => m.role === 'tool' && m.toolStatus === 'running')
+          const output = runtimeToolOutputFromEvent(evt)
+          const toolName = evt.tool || evt.name || toolMsgs[toolMsgs.length - 1]?.toolName
+          if (isBackgroundDelegateToolPayload(toolName, output)) {
+            const session = sessions.value.find(item => item.id === sid)
+            if (session) session.messages = session.messages.filter(message => !toolMsgs.includes(message))
+            break
+          }
           if (toolMsgs.length > 0) {
-            const output = runtimeToolOutputFromEvent(evt)
             const hasError = evt.event === 'tool.failed' || (evt as any).error === true || runtimeToolOutputHasError(output)
             updateMessage(sid, toolMsgs[toolMsgs.length - 1].id, {
               toolStatus: hasError ? 'error' : 'done',
@@ -3602,7 +3931,10 @@ export const useChatStore = defineStore('chat', () => {
         case 'subagent.start':
         case 'subagent.tool':
         case 'subagent.progress':
-        case 'subagent.complete': {
+        case 'subagent.text':
+        case 'subagent.thinking':
+        case 'subagent.complete':
+        case 'delegation.updated': {
           runHadToolActivity = true
           handleSubagentEvent(sid, evt)
           break
@@ -3632,6 +3964,7 @@ export const useChatStore = defineStore('chat', () => {
           handleTerminalWorkspaceRunChange(sid, evt)
           clearAgentEventMessages(sid)
           const hasQueue = (evt as any).queue_remaining > 0
+          const hasBackground = (evt.background_pending || 0) > 0
           if (hasQueue) {
             queueLengths.value.set(sid, (evt as any).queue_remaining)
           } else {
@@ -3743,15 +4076,21 @@ export const useChatStore = defineStore('chat', () => {
             }
           }
 
-          if (!hasQueue) {
+          if (!hasQueue && !hasBackground) {
             markSessionCompletedUnread(sid)
             cleanup()
             activeAssistantMessageId = null
             reasoningAssistantMessageId = null
             activeRunMarker = null
-          } else {
+          } else if (hasQueue) {
             markSessionCompletedUnread(sid, true)
             // More runs pending — reset for next run but don't cleanup
+            activeAssistantMessageId = null
+            reasoningAssistantMessageId = null
+            activeRunMarker = null
+          } else {
+            markSessionCompletedUnread(sid)
+            markIdleKeepingBackgroundListener()
             activeAssistantMessageId = null
             reasoningAssistantMessageId = null
             activeRunMarker = null
@@ -3772,6 +4111,7 @@ export const useChatStore = defineStore('chat', () => {
             }
           }
           const hasQueue = (evt as any).queue_remaining > 0
+          const hasBackground = (evt.background_pending || 0) > 0
           if (hasQueue) {
             queueLengths.value.set(sid, (evt as any).queue_remaining)
           } else {
@@ -3779,8 +4119,10 @@ export const useChatStore = defineStore('chat', () => {
           }
           addAgentErrorMessage(sid, evt.error)
           settleRunningTools(sid, 'error')
-          if (!hasQueue) {
+          if (!hasQueue && !hasBackground) {
             cleanup()
+          } else if (hasBackground && !hasQueue) {
+            markIdleKeepingBackgroundListener()
           }
           activeAssistantMessageId = null
           reasoningAssistantMessageId = null
@@ -3831,12 +4173,10 @@ export const useChatStore = defineStore('chat', () => {
     // Server already joined room and replayed events.
     // Just set up handlers for ongoing streaming events.
 
-    // Mark as streaming so UI shows the indicator and can still abort after refresh.
-    streamStates.value.set(sid, {
-      abort: () => {
-        getChatRunSocket(runtimeTransport())?.emit('abort', { session_id: sid })
-      },
-    })
+    // A passive listener keeps background subagent telemetry alive without
+    // making the parent session look busy. The abort handle is installed when
+    // the completion notification starts its autonomous parent turn.
+    if (!passive) ensureAbortHandle()
   }
 
   function handlePeerUserMessage(evt: RunEvent) {
@@ -4116,6 +4456,8 @@ export const useChatStore = defineStore('chat', () => {
     pendingApprovals,
     activePendingApproval,
     activePendingClarify,
+    subagentStreams,
+    getSubagentStream,
     removeQueuedMessage,
     setMessageReference,
     clearMessageReference,

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -215,6 +215,7 @@ export function reduceSubagentStream(
   const costUsd = Number((evt as any).cost_usd)
   const isTerminal = eventName === 'subagent.complete'
     || (eventName === 'delegation.updated' && ['completed', 'failed', 'error', 'cancelled', 'interrupted'].includes(String((evt as any).status || '').toLowerCase()))
+  if (current && current.status !== 'running' && !isTerminal) return current
   const nextStatus = isTerminal
     ? subagentStatus((evt as any).status, 'completed')
     : 'running'
@@ -1645,6 +1646,7 @@ export const useChatStore = defineStore('chat', () => {
                 setAbortState({ aborting: true, synced: false, timedOut: true, message: (e as any).message })
               } else if (e.event === 'abort.completed') {
                 setAbortState({ aborting: false, synced: e.synced ?? false })
+                settleInterruptedSubagents(sessionId)
               } else if (e.event === 'approval.requested') {
                 setPendingApproval({ ...e, session_id: sessionId } as RunEvent)
               } else if (e.event === 'approval.resolved') {
@@ -1982,10 +1984,10 @@ export const useChatStore = defineStore('chat', () => {
 
     const subagentId = String((evt as any).subagent_id || `${(evt as any).task_index ?? 0}`)
     const streamKey = `${sessionId}:${subagentId}`
-    subagentStreams.value.set(
-      streamKey,
-      reduceSubagentStream(subagentStreams.value.get(streamKey), sessionId, evt),
-    )
+    const currentStream = subagentStreams.value.get(streamKey)
+    const nextStream = reduceSubagentStream(currentStream, sessionId, evt)
+    if (nextStream === currentStream) return
+    subagentStreams.value.set(streamKey, nextStream)
     const toolCallId = `subagent:${subagentId}`
     const taskIndex = Number((evt as any).task_index ?? 0)
     const taskCount = Number((evt as any).task_count ?? 1)
@@ -2011,9 +2013,9 @@ export const useChatStore = defineStore('chat', () => {
 
     const msgs = getSessionMsgs(sessionId)
     const existing = msgs.find(m => m.role === 'tool' && m.toolCallId === toolCallId)
-    const toolStatus = eventName === 'subagent.complete'
-      ? ((evt as any).status && String((evt as any).status) !== 'completed' ? 'error' : 'done')
-      : 'running'
+    const toolStatus = nextStream.status === 'running'
+      ? 'running'
+      : nextStream.status === 'completed' ? 'done' : 'error'
     const update: Partial<Message> = {
       toolName: 'delegate_task',
       toolCallId,
@@ -2047,6 +2049,25 @@ export const useChatStore = defineStore('chat', () => {
       timestamp: Date.now(),
       ...update,
     })
+  }
+
+  function settleInterruptedSubagents(sessionId: string) {
+    const runningStreams = [...subagentStreams.value.values()].filter(stream =>
+      stream.sessionId === sessionId && stream.status === 'running',
+    )
+    for (const stream of runningStreams) {
+      handleSubagentEvent(sessionId, {
+        event: 'subagent.complete',
+        session_id: sessionId,
+        subagent_id: stream.subagentId,
+        task_index: stream.taskIndex,
+        task_count: stream.taskCount,
+        goal: stream.goal,
+        model: stream.model,
+        status: 'interrupted',
+        timestamp: Date.now(),
+      })
+    }
   }
 
   function getSubagentStream(sessionId: string, subagentId: string): SubagentStream | null {
@@ -2981,6 +3002,7 @@ export const useChatStore = defineStore('chat', () => {
                 break
               case 'abort.completed':
                 setAbortState({ aborting: false, synced: (e as any).synced ?? false })
+                settleInterruptedSubagents(sid)
                 break
               case 'approval.requested':
                 setPendingApproval({ ...e, session_id: sid })
@@ -3112,6 +3134,7 @@ export const useChatStore = defineStore('chat', () => {
 
             case 'abort.completed': {
               setAbortState({ aborting: false, synced: (evt as any).synced ?? false })
+              settleInterruptedSubagents(sid)
               clearPendingInteractions(sid)
               if ((evt as any).queue_length > 0) {
                 queueLengths.value.set(sid, (evt as any).queue_length)
@@ -3745,6 +3768,7 @@ export const useChatStore = defineStore('chat', () => {
 
         case 'abort.completed': {
           setAbortState({ aborting: false, synced: (evt as any).synced ?? false })
+          settleInterruptedSubagents(sid)
           clearPendingInteractions(sid)
           if ((evt as any).queue_length > 0) {
             queueLengths.value.set(sid, (evt as any).queue_length)

--- a/packages/client/src/utils/hermes/subagent-stream.ts
+++ b/packages/client/src/utils/hermes/subagent-stream.ts
@@ -1,0 +1,22 @@
+export const OPEN_SUBAGENT_STREAM_EVENT = 'hermes:open-subagent-stream'
+
+export interface OpenSubagentStreamDetail {
+  sessionId: string
+  subagentId: string
+}
+
+export function subagentIdFromToolCall(toolCallId?: string): string | null {
+  const prefix = 'subagent:'
+  if (!toolCallId?.startsWith(prefix)) return null
+  const subagentId = toolCallId.slice(prefix.length).trim()
+  return subagentId || null
+}
+
+export function openSubagentStream(sessionId: string | null | undefined, toolCallId?: string): boolean {
+  const subagentId = subagentIdFromToolCall(toolCallId)
+  if (!sessionId || !subagentId || typeof window === 'undefined') return false
+  window.dispatchEvent(new CustomEvent<OpenSubagentStreamDetail>(OPEN_SUBAGENT_STREAM_EVENT, {
+    detail: { sessionId, subagentId },
+  }))
+  return true
+}

--- a/packages/server/src/routes/hermes/group-chat.ts
+++ b/packages/server/src/routes/hermes/group-chat.ts
@@ -106,6 +106,7 @@ async function connectAndPersistRoomAgent(server: GroupChatServer, roomId: strin
         name,
         description,
         invited,
+        backgroundDelegationEnabled: false,
     })
 
     const storage = server.getStorage()

--- a/packages/server/src/services/hermes/agent-bridge/README.md
+++ b/packages/server/src/services/hermes/agent-bridge/README.md
@@ -88,7 +88,19 @@ is required.
 import { AgentBridgeClient } from './services/hermes/agent-bridge'
 
 const bridge = new AgentBridgeClient()
-const run = await bridge.chat(sessionId, message)
+// Select this policy when the cached Hermes AgentSession is first created.
+// contextEstimate may be the creation boundary before the first chat call.
+await bridge.contextEstimate(
+  sessionId,
+  [],
+  instructions,
+  profile,
+  { background_delegation_enabled: false },
+)
+const run = await bridge.chat(sessionId, message, undefined, instructions, profile, {
+  // Creation fallback if chat is the first Bridge operation for this session.
+  background_delegation_enabled: false,
+})
 
 for await (const chunk of bridge.streamOutput(run.run_id)) {
   if (chunk.delta) {
@@ -100,6 +112,22 @@ for await (const chunk of bridge.streamOutput(run.run_id)) {
 The external chat call only sends `session_id` and `message`. Provider, model,
 keys, tools, reasoning, and session DB are resolved by hermes-agent from the
 normal Hermes config and environment.
+
+`background_delegation_enabled` is an Agent-session creation setting. It is
+optional and defaults to `true` for Bridge consumers that do not select a
+policy. The created `AgentSession` retains the value, and later runs bind the
+Hermes context from that cached setting instead of changing it per turn.
+Passing `false` binds `async_delivery=false`, so `delegate_task` remains
+available but requests for background execution fall back to the synchronous
+path. Hermes currently exposes this as its session-level async-delivery
+capability, so other detached-completion tools in that AgentSession also see it
+disabled.
+
+Hermes Web UI currently creates ordinary single-chat agents with this value set
+to `false`. Group-chat agents and Hermes workflow-node agents also set it to
+`false` at their own call sites and are intentionally kept disabled even if
+single chat is enabled in the future. Coding Agent and Ekko Agent calls do not
+receive this Hermes Bridge field.
 
 The bridge instantiates `AIAgent` with `platform="cli"` by default so behavior
 matches CLI chat. Override it only if a caller intentionally needs a distinct

--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -176,6 +176,48 @@ export interface AgentBridgeGoalPause extends AgentBridgeResponse {
   message?: string
 }
 
+export interface AgentBridgeBackgroundTask {
+  subagent_id: string
+  status?: string
+  goal?: string
+  model?: string
+  last_event?: string
+  last_tool?: string
+  preview?: string
+  updated_at?: number
+  [key: string]: unknown
+}
+
+export interface AgentBridgeBackgroundSession {
+  session_id: string
+  profile: string
+  events: Array<Record<string, unknown>>
+  tasks: AgentBridgeBackgroundTask[]
+  running_count: number
+}
+
+export interface AgentBridgeBackgroundNotification {
+  delegation_id: string
+  session_id: string
+  profile: string
+  claim_id: string
+  status?: string
+  message: string
+  event: Record<string, unknown>
+}
+
+export interface AgentBridgeBackgroundPoll extends AgentBridgeResponse {
+  broker_id?: string
+  pending_count?: number
+  sessions: AgentBridgeBackgroundSession[]
+  notifications: AgentBridgeBackgroundNotification[]
+}
+
+export interface AgentBridgeBackgroundRoute {
+  profile: string
+  session_ids: string[]
+}
+
 export class AgentBridgeError extends Error {
   response?: unknown
 }
@@ -362,7 +404,7 @@ export class AgentBridgeClient {
       const timeoutMs = options.timeoutMs || this.timeoutMs
       const startedAt = Date.now()
       const action = String(payload.action || '')
-      const shouldLogRequest = action !== 'get_output'
+      const shouldLogRequest = action !== 'get_output' && action !== 'background_poll'
       const runtimeContext = shouldLogRequest ? this.runtimeContext(payload) : undefined
       if (shouldLogRequest) {
         bridgeLogger.info({
@@ -396,7 +438,7 @@ export class AgentBridgeClient {
         }
         return response as T
       } catch (err: any) {
-        if (!(err instanceof AgentBridgeError)) {
+        if (!(err instanceof AgentBridgeError) && action !== 'background_poll') {
           bridgeLogger.error({
             durationMs: Date.now() - startedAt,
             err: { message: err?.message, name: err?.name },
@@ -631,6 +673,46 @@ export class AgentBridgeClient {
       session_id: sessionId,
       ...(profile ? { profile } : {}),
     }, options)
+  }
+
+  backgroundPoll(
+    routes?: AgentBridgeBackgroundRoute[],
+    options: AgentBridgeRequestOptions = {},
+  ): Promise<AgentBridgeBackgroundPoll> {
+    return this.request<AgentBridgeBackgroundPoll>({
+      action: 'background_poll',
+      ...(routes?.length ? { routes } : {}),
+    }, options)
+  }
+
+  completeBackgroundNotification(
+    sessionId: string,
+    profile: string,
+    delegationId: string,
+    claimId: string,
+  ): Promise<AgentBridgeResponse> {
+    return this.request({
+      action: 'background_notification_complete',
+      session_id: sessionId,
+      profile,
+      delegation_id: delegationId,
+      claim_id: claimId,
+    })
+  }
+
+  releaseBackgroundNotification(
+    sessionId: string,
+    profile: string,
+    delegationId: string,
+    claimId: string,
+  ): Promise<AgentBridgeResponse> {
+    return this.request({
+      action: 'background_notification_release',
+      session_id: sessionId,
+      profile,
+      delegation_id: delegationId,
+      claim_id: claimId,
+    })
   }
 
   destroy(sessionId: string, profile?: string, workerKey?: string): Promise<AgentBridgeResponse> {

--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -43,6 +43,9 @@ export interface AgentBridgeRequestOptions {
 
 export interface AgentBridgeChatOptions {
   force_compress?: boolean
+  /** Agent-session creation policy. False keeps delegate_task available but
+   * makes background=true fall back to synchronous execution. */
+  background_delegation_enabled?: boolean
   storage_message?: AgentBridgeMessage
   model?: string
   provider?: string
@@ -486,6 +489,9 @@ export class AgentBridgeClient {
       ...(options.wait ? { wait: true } : {}),
       ...(options.timeout ? { timeout: options.timeout } : {}),
       ...(options.force_compress ? { force_compress: true } : {}),
+      ...(options.background_delegation_enabled !== undefined
+        ? { background_delegation_enabled: options.background_delegation_enabled }
+        : {}),
       // Local patch (reasoning-effort): per-session reasoning effort override.
       ...(options.reasoning_effort ? { reasoning_effort: options.reasoning_effort } : {}),
     })
@@ -496,7 +502,7 @@ export class AgentBridgeClient {
     messages: unknown[],
     instructions?: string,
     profile?: string,
-    options: Pick<AgentBridgeChatOptions, 'model' | 'provider' | 'workspace'> = {},
+    options: Pick<AgentBridgeChatOptions, 'model' | 'provider' | 'workspace' | 'background_delegation_enabled'> = {},
   ): Promise<AgentBridgeContextEstimate> {
     return this.request<AgentBridgeContextEstimate>({
       action: 'context_estimate',
@@ -507,6 +513,9 @@ export class AgentBridgeClient {
       ...(options.model ? { model: options.model } : {}),
       ...(options.provider ? { provider: options.provider } : {}),
       ...(options.workspace ? { workspace: options.workspace } : {}),
+      ...(options.background_delegation_enabled !== undefined
+        ? { background_delegation_enabled: options.background_delegation_enabled }
+        : {}),
     })
   }
 

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_broker.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_broker.py
@@ -256,6 +256,59 @@ class BridgeBroker:
         if action == "status_if_loaded":
             return self._status_if_loaded(req)
 
+        if action == "background_poll":
+            requested_routes: dict[str, set[str]] = {}
+            for route in req.get("routes") or []:
+                if not isinstance(route, dict):
+                    continue
+                profile = self._normalize_profile(route.get("profile"))
+                requested_routes.setdefault(profile, set()).update(
+                    str(session_id).strip()
+                    for session_id in (route.get("session_ids") or [])
+                    if str(session_id).strip()
+                )
+            for profile in requested_routes:
+                self._worker_for_profile(profile)
+            with self._lock:
+                workers = list(self._workers.values())
+            sessions: list[dict[str, Any]] = []
+            notifications: list[dict[str, Any]] = []
+            pending_count = 0
+            for worker in workers:
+                profile = getattr(worker, "profile", "default") or "default"
+                if not worker.running:
+                    if profile not in requested_routes:
+                        continue
+                try:
+                    response = worker.request({
+                        "action": "background_poll",
+                        "session_ids": sorted(requested_routes.get(profile, set())),
+                    })
+                except Exception:
+                    continue
+                pending_count += int(response.get("pending_count") or 0)
+                for session in response.get("sessions") or []:
+                    if isinstance(session, dict):
+                        sessions.append({**session, "profile": profile})
+                for notification in response.get("notifications") or []:
+                    if isinstance(notification, dict):
+                        notifications.append({**notification, "profile": profile})
+            return {
+                "broker_id": str(os.getpid()),
+                "pending_count": pending_count,
+                "sessions": sessions,
+                "notifications": notifications,
+            }
+
+        if action in {"background_notification_complete", "background_notification_release"}:
+            session_id = str(req.get("session_id") or "")
+            profile, worker_key = self._route_for_session(
+                session_id,
+                req.get("profile"),
+                req.get("worker_key") if "worker_key" in req else None,
+            )
+            return self._forward(profile, req, worker_key)
+
         if action in {"interrupt", "steer", "command", "switch_session_model", "goal_evaluate", "goal_pause", "status", "get_history", "get_session_title", "destroy"}:
             session_id = str(req.get("session_id") or "")
             profile, worker_key = self._route_for_session(session_id, req.get("profile"), req.get("worker_key") if "worker_key" in req else None)

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import inspect
 import json
 import os
 import queue
@@ -71,6 +72,40 @@ def _clear_session_workspace_cwd() -> None:
         clear_session_cwd()
     except Exception:
         pass
+
+
+def _set_bridge_session_vars(
+    session_id: str,
+    profile: str | None,
+    workspace: str | None,
+    background_delegation_enabled: bool,
+) -> Any:
+    """Bind the richest session context supported by the installed runtime."""
+    from gateway.session_context import set_session_vars
+
+    values = {
+        "platform": "agent_bridge",
+        # Hermes delegate_task has a TUI-specific durable session routing path.
+        # Agent Bridge uses that contract so compression-driven session-id
+        # rotation cannot orphan a detached completion.
+        "source": "tui",
+        "session_key": session_id,
+        "session_id": session_id,
+        "ui_session_id": session_id,
+        "profile": str(profile or "default"),
+        "cwd": str(workspace or ""),
+        "async_delivery": background_delegation_enabled,
+    }
+    try:
+        parameters = inspect.signature(set_session_vars).parameters.values()
+        accepts_extra = any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters)
+        accepted_names = {parameter.name for parameter in parameters}
+        supported = values if accepts_extra else {
+            name: value for name, value in values.items() if name in accepted_names
+        }
+    except (TypeError, ValueError):
+        supported = values
+    return set_session_vars(**supported)
 
 
 class SessionDbHolder:
@@ -200,6 +235,7 @@ class AgentPool:
         profile: str | None = None,
         model: str | None = None,
         provider: str | None = None,
+        background_delegation_enabled: bool | None = None,
     ) -> AgentSession:
         requested_model = str(model or "").strip()
         requested_provider = str(provider or "").strip()
@@ -318,6 +354,9 @@ class AgentPool:
                         "mcp_tool_count": len(discovered_mcp_tools),
                         "active_mcp_tool_count": len(mcp_tool_names),
                         "db_error": self._db.error,
+                        # This is an Agent-session policy, not a per-turn flag.
+                        # Callers select it when the cached AIAgent is created.
+                        "background_delegation_enabled": background_delegation_enabled is not False,
                     },
                 )
                 self._sessions[session_id] = session
@@ -719,8 +758,15 @@ class AgentPool:
         model: str | None = None,
         provider: str | None = None,
         workspace: str | None = None,
+        background_delegation_enabled: bool | None = None,
     ) -> dict[str, Any]:
-        session = self.get_or_create(session_id, profile=profile, model=model, provider=provider)
+        session = self.get_or_create(
+            session_id,
+            profile=profile,
+            model=model,
+            provider=provider,
+            background_delegation_enabled=background_delegation_enabled,
+        )
         session_cwd_bound = _bind_session_workspace_cwd(session.session_id, workspace)
         try:
             context_info = self._estimate_context_info(session.agent, messages or [], instructions)
@@ -1391,8 +1437,15 @@ class AgentPool:
         workspace: str | None = None,
         source: str | None = None,
         reasoning_effort: str | None = None,
+        background_delegation_enabled: bool | None = None,
     ) -> RunRecord:
-        session = self.get_or_create(session_id, profile=profile, model=model, provider=provider)
+        session = self.get_or_create(
+            session_id,
+            profile=profile,
+            model=model,
+            provider=provider,
+            background_delegation_enabled=background_delegation_enabled,
+        )
         # Install after agent construction so any runtime plugin initialization
         # has completed. Rechecking on every run also recovers from a forced
         # plugin reload that clears the manager's callback registry.
@@ -1457,17 +1510,11 @@ class AgentPool:
             try:
                 session_cwd_bound = _bind_session_workspace_cwd(session.session_id, workspace)
                 try:
-                    from gateway.session_context import set_session_vars
-
-                    session_context_tokens = set_session_vars(
-                        platform="agent_bridge",
-                        source="tui",
-                        session_key=session.session_id,
-                        session_id=session.session_id,
-                        ui_session_id=session.session_id,
-                        profile=str(profile or "default"),
-                        cwd=str(workspace or ""),
-                        async_delivery=True,
+                    session_context_tokens = _set_bridge_session_vars(
+                        session.session_id,
+                        profile,
+                        workspace,
+                        session.config.get("background_delegation_enabled", True) is not False,
                     )
                 except Exception:
                     session_context_tokens = None

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -129,9 +129,15 @@ class AgentSession:
     lock: threading.RLock = field(default_factory=threading.RLock)
     created_at: float = field(default_factory=time.time)
     last_used_at: float = field(default_factory=time.time)
+    background_events: list[dict[str, Any]] = field(default_factory=list)
+    background_event_seq: int = 0
+    background_tasks: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
 class AgentPool:
+    MAX_BACKGROUND_EVENTS_PER_SESSION = 500
+    MAX_BACKGROUND_TASKS_PER_SESSION = 50
+
     def __init__(self) -> None:
         self._sessions: dict[str, AgentSession] = {}
         self._runs: dict[str, RunRecord] = {}
@@ -141,6 +147,8 @@ class AgentPool:
         self._gateway_approval_requests: dict[str, str] = {}
         self._gateway_approval_pattern_keys: dict[str, list[str]] = {}
         self._compression_requests: dict[str, queue.Queue[dict[str, Any]]] = {}
+        self._background_notification_claims: dict[tuple[str, str], dict[str, Any]] = {}
+        self._suppressed_background_delegations: set[str] = set()
         self._clarify_requests: dict[str, queue.Queue[str]] = {}
         self._run_context = threading.local()
         self._approval_handlers: dict[str, Callable[..., str]] = {}
@@ -767,9 +775,193 @@ class AgentPool:
     def _append_event(self, session_id: str, event: dict[str, Any]) -> None:
         with self._lock:
             session = self._sessions.get(session_id)
+            if session and str(event.get("event") or "").startswith("subagent."):
+                event = self._record_background_event(session, event)
             run_id = session.current_run_id if session else None
             if run_id and run_id in self._runs:
                 self._runs[run_id].events.append(_jsonable(event))
+            elif session and str(event.get("event") or "").startswith("subagent."):
+                session.background_events.append(_jsonable(event))
+                if len(session.background_events) > self.MAX_BACKGROUND_EVENTS_PER_SESSION:
+                    del session.background_events[:-self.MAX_BACKGROUND_EVENTS_PER_SESSION]
+
+    def _record_background_event(
+        self,
+        session: AgentSession,
+        event: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Attach stable UI routing metadata without touching agent messages."""
+        session.background_event_seq += 1
+        payload = dict(event)
+        payload["background_seq"] = session.background_event_seq
+        payload["session_id"] = session.session_id
+        payload.setdefault("timestamp", time.time())
+
+        subagent_id = str(payload.get("subagent_id") or "").strip()
+        if subagent_id:
+            previous = session.background_tasks.get(subagent_id, {})
+            event_name = str(payload.get("event") or "")
+            status = str(payload.get("status") or "").strip()
+            if event_name == "subagent.start":
+                status = "running"
+            elif event_name != "subagent.complete":
+                status = status or str(previous.get("status") or "running")
+            else:
+                status = status or "completed"
+            task = {
+                **previous,
+                "subagent_id": subagent_id,
+                "parent_id": payload.get("parent_id"),
+                "depth": payload.get("depth"),
+                "task_index": payload.get("task_index"),
+                "task_count": payload.get("task_count"),
+                "goal": payload.get("goal"),
+                "model": payload.get("model"),
+                "tool_count": payload.get("tool_count", previous.get("tool_count", 0)),
+                "last_event": event_name,
+                "last_tool": payload.get("tool_name") or previous.get("last_tool"),
+                "preview": payload.get("text") or payload.get("summary") or previous.get("preview"),
+                "status": status,
+                "updated_at": payload["timestamp"],
+            }
+            if event_name == "subagent.start":
+                task["started_at"] = payload["timestamp"]
+            if event_name == "subagent.complete":
+                task["completed_at"] = payload["timestamp"]
+                task["summary"] = payload.get("summary")
+                task["duration_seconds"] = payload.get("duration_seconds")
+                task["api_calls"] = payload.get("api_calls")
+                task["input_tokens"] = payload.get("input_tokens")
+                task["output_tokens"] = payload.get("output_tokens")
+                task["cost_usd"] = payload.get("cost_usd")
+                task["files_read"] = payload.get("files_read")
+                task["files_written"] = payload.get("files_written")
+            session.background_tasks[subagent_id] = _jsonable(task)
+            if len(session.background_tasks) > self.MAX_BACKGROUND_TASKS_PER_SESSION:
+                ordered = sorted(
+                    session.background_tasks.items(),
+                    key=lambda item: float(item[1].get("updated_at") or 0),
+                )
+                removable = [item for item in ordered if item[1].get("status") != "running"]
+                for stale_id, _ in removable[: max(0, len(ordered) - self.MAX_BACKGROUND_TASKS_PER_SESSION)]:
+                    session.background_tasks.pop(stale_id, None)
+        return payload
+
+    def poll_background(self, recover_session_ids: list[Any] | None = None) -> dict[str, Any]:
+        """Drain worker-level UI telemetry and claim owned async completions."""
+        with self._lock:
+            loaded_session_ids = set(self._sessions)
+            loaded_session_ids.update(
+                str(session_id).strip()
+                for session_id in (recover_session_ids or [])
+                if str(session_id).strip()
+            )
+            session_payloads = []
+            for session in self._sessions.values():
+                events = list(session.background_events)
+                session.background_events.clear()
+                tasks = list(session.background_tasks.values())
+                if events or any(task.get("status") == "running" for task in tasks):
+                    session_payloads.append({
+                        "session_id": session.session_id,
+                        "events": _jsonable(events),
+                        "tasks": _jsonable(tasks),
+                        "running_count": sum(1 for task in tasks if task.get("status") == "running"),
+                    })
+
+        notifications: list[dict[str, Any]] = []
+        pending_notification_count = 0
+        if loaded_session_ids:
+            try:
+                from tools.async_delegation import claim_event_delivery, complete_completion_delivery
+                from tools.process_registry import format_process_notification, process_registry
+
+                def owns_event(evt: dict[str, Any]) -> bool:
+                    session_key = str(evt.get("session_key") or "")
+                    parent_session_id = str(evt.get("parent_session_id") or "")
+                    return session_key in loaded_session_ids or parent_session_id in loaded_session_ids
+
+                deferred: list[dict[str, Any]] = []
+                queue_size = process_registry.completion_queue.qsize()
+                for _ in range(queue_size):
+                    try:
+                        event = process_registry.completion_queue.get_nowait()
+                    except Exception:
+                        break
+                    if event.get("type") != "async_delegation" or not owns_event(event):
+                        deferred.append(event)
+                        continue
+                    claim_id = claim_event_delivery(event, "agent-bridge")
+                    if claim_id is None:
+                        pending_notification_count += 1
+                        deferred.append(event)
+                        continue
+                    delegation_id = str(event.get("delegation_id") or "")
+                    with self._lock:
+                        suppressed = delegation_id in self._suppressed_background_delegations
+                    if suppressed or str(event.get("status") or "").lower() in {"interrupted", "cancelled", "canceled"}:
+                        complete_completion_delivery(
+                            delegation_id,
+                            claim_id,
+                        )
+                        with self._lock:
+                            self._suppressed_background_delegations.discard(delegation_id)
+                        continue
+                    message = format_process_notification(event)
+                    if not message:
+                        complete_completion_delivery(
+                            str(event.get("delegation_id") or ""),
+                            claim_id,
+                        )
+                        continue
+                    session_id = str(event.get("parent_session_id") or event.get("session_key") or "")
+                    notifications.append({
+                        "delegation_id": str(event.get("delegation_id") or ""),
+                        "session_id": session_id,
+                        "claim_id": claim_id,
+                        "status": event.get("status"),
+                        "message": message,
+                        "event": _jsonable(event),
+                    })
+                    with self._lock:
+                        self._background_notification_claims[(
+                            str(event.get("delegation_id") or ""),
+                            claim_id,
+                        )] = event
+                for event in deferred:
+                    process_registry.completion_queue.put(event)
+            except Exception as exc:
+                print(
+                    f"[hermes_bridge] background completion poll failed: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
+        return {
+            "sessions": session_payloads,
+            "notifications": notifications,
+            "pending_count": pending_notification_count,
+        }
+
+    def complete_background_notification(self, delegation_id: str, claim_id: str) -> dict[str, Any]:
+        from tools.async_delegation import complete_completion_delivery
+
+        completed = complete_completion_delivery(delegation_id, claim_id)
+        with self._lock:
+            self._background_notification_claims.pop((delegation_id, claim_id), None)
+        return {"delegation_id": delegation_id, "completed": bool(completed)}
+
+    def release_background_notification(self, delegation_id: str, claim_id: str) -> dict[str, Any]:
+        from tools.async_delegation import release_completion_delivery
+
+        released = release_completion_delivery(delegation_id, claim_id)
+        with self._lock:
+            event = self._background_notification_claims.pop((delegation_id, claim_id), None)
+        if released and event is not None:
+            from tools.process_registry import process_registry
+
+            process_registry.completion_queue.put(event)
+        return {"delegation_id": delegation_id, "released": bool(released)}
 
     def _status_callback(self, session_id: str):
         def callback(kind, text=None):
@@ -1255,6 +1447,7 @@ class AgentPool:
                         record.events.append({"event": "stream.delta", "delta": text})
 
             approval_session_token = None
+            session_context_tokens = None
             registered_gateway_approval_session = None
             exec_ask_scope_entered = False
             session_cwd_bound = False
@@ -1263,6 +1456,21 @@ class AgentPool:
             tail_synced = False
             try:
                 session_cwd_bound = _bind_session_workspace_cwd(session.session_id, workspace)
+                try:
+                    from gateway.session_context import set_session_vars
+
+                    session_context_tokens = set_session_vars(
+                        platform="agent_bridge",
+                        source="tui",
+                        session_key=session.session_id,
+                        session_id=session.session_id,
+                        ui_session_id=session.session_id,
+                        profile=str(profile or "default"),
+                        cwd=str(workspace or ""),
+                        async_delivery=True,
+                    )
+                except Exception:
+                    session_context_tokens = None
                 try:
                     self._enter_exec_ask_scope()
                     exec_ask_scope_entered = True
@@ -1429,16 +1637,65 @@ class AgentPool:
                         reset_current_session_key(approval_session_token)
                     except Exception:
                         pass
+                if session_context_tokens is not None:
+                    try:
+                        from gateway.session_context import clear_session_vars
+
+                        clear_session_vars(session_context_tokens)
+                    except Exception:
+                        pass
                 if exec_ask_scope_entered:
                     self._exit_exec_ask_scope()
                 if session_cwd_bound:
                     _clear_session_workspace_cwd()
+
+    @staticmethod
+    def _background_delegation_ids_for_session(session_id: str) -> list[str]:
+        try:
+            from tools.async_delegation import list_async_delegations
+
+            ids = []
+            for record in list_async_delegations():
+                if str(record.get("status") or "") not in {"running", "finalizing"}:
+                    continue
+                if not any(
+                    str(record.get(key) or "") == session_id
+                    for key in ("session_key", "origin_ui_session_id", "parent_session_id")
+                ):
+                    continue
+                delegation_id = str(record.get("delegation_id") or "").strip()
+                if delegation_id:
+                    ids.append(delegation_id)
+            return ids
+        except Exception:
+            return []
+
+    @staticmethod
+    def _interrupt_background_for_session(session_id: str, reason: str) -> int:
+        try:
+            from tools.async_delegation import interrupt_for_session
+
+            return int(interrupt_for_session(
+                session_key=session_id,
+                origin_ui_session_id=session_id,
+                parent_session_id=session_id,
+                reason=reason,
+            ) or 0)
+        except Exception:
+            return 0
 
     def interrupt(self, session_id: str, message: str | None = None) -> dict[str, Any]:
         with self._lock:
             session = self._sessions.get(session_id)
         if session is None:
             raise KeyError(f"unknown session: {session_id}")
+        background_delegation_ids = self._background_delegation_ids_for_session(session_id)
+        with self._lock:
+            self._suppressed_background_delegations.update(background_delegation_ids)
+        background_interrupted = self._interrupt_background_for_session(
+            session_id,
+            "user_interrupt",
+        )
         if not hasattr(session.agent, "interrupt"):
             raise RuntimeError("agent does not support interrupt")
         session.agent.interrupt(message)
@@ -1450,7 +1707,13 @@ class AgentPool:
                     synced = True
                     break
             time.sleep(0.05)
-        return {"status": "interrupted", "session_id": session_id, "synced": synced}
+        return {
+            "status": "interrupted",
+            "session_id": session_id,
+            "synced": synced,
+            "background_interrupted": background_interrupted,
+            "background_delegation_ids": background_delegation_ids,
+        }
 
     def steer(self, session_id: str, text: str) -> dict[str, Any]:
         with self._lock:
@@ -1896,16 +2159,33 @@ class AgentPool:
         }
 
     def destroy(self, session_id: str) -> dict[str, Any]:
+        background_delegation_ids = self._background_delegation_ids_for_session(session_id)
+        with self._lock:
+            self._suppressed_background_delegations.update(background_delegation_ids)
+        background_interrupted = self._interrupt_background_for_session(
+            session_id,
+            "session_destroyed",
+        )
         with self._lock:
             session = self._sessions.pop(session_id, None)
         if session is None:
-            return {"session_id": session_id, "destroyed": False}
+            return {
+                "session_id": session_id,
+                "destroyed": False,
+                "background_interrupted": background_interrupted,
+                "background_delegation_ids": background_delegation_ids,
+            }
         if session.running and hasattr(session.agent, "interrupt"):
             try:
                 session.agent.interrupt("Session destroyed")
             except Exception:
                 pass
-        return {"session_id": session_id, "destroyed": True}
+        return {
+            "session_id": session_id,
+            "destroyed": True,
+            "background_interrupted": background_interrupted,
+            "background_delegation_ids": background_delegation_ids,
+        }
 
     def destroy_all(self) -> dict[str, Any]:
         with self._lock:
@@ -1915,6 +2195,72 @@ class AgentPool:
             result = self.destroy(sid)
             destroyed.append(result)
         return {"destroyed": len(destroyed)}
+
+    def shutdown(self) -> dict[str, Any]:
+        """Bounded worker cleanup for parent runs, delegations, and tool processes."""
+        with self._lock:
+            sessions = list(self._sessions.values())
+            claimed_notifications = list(self._background_notification_claims)
+
+        interrupted_sessions = 0
+        for session in sessions:
+            if not session.running or not hasattr(session.agent, "interrupt"):
+                continue
+            try:
+                session.agent.interrupt("Agent bridge shutting down")
+                interrupted_sessions += 1
+            except Exception:
+                pass
+
+        interrupted_delegations = 0
+        active_count = None
+        try:
+            from tools.async_delegation import active_count as async_active_count
+            from tools.async_delegation import interrupt_all
+
+            active_count = async_active_count
+            interrupted_delegations = int(interrupt_all("agent_bridge_shutdown") or 0)
+        except Exception:
+            pass
+
+        killed_processes = 0
+        try:
+            from tools.process_registry import process_registry
+
+            killed_processes = int(process_registry.kill_all() or 0)
+        except Exception:
+            pass
+
+        if active_count is not None and interrupted_delegations:
+            deadline = time.time() + 2.0
+            while time.time() < deadline:
+                try:
+                    if int(active_count() or 0) == 0:
+                        break
+                except Exception:
+                    break
+                time.sleep(0.05)
+
+        released_claims = 0
+        if claimed_notifications:
+            try:
+                from tools.async_delegation import release_completion_delivery
+
+                for delegation_id, claim_id in claimed_notifications:
+                    if release_completion_delivery(delegation_id, claim_id):
+                        released_claims += 1
+            except Exception:
+                pass
+            with self._lock:
+                for key in claimed_notifications:
+                    self._background_notification_claims.pop(key, None)
+
+        return {
+            "interrupted_sessions": interrupted_sessions,
+            "interrupted_delegations": interrupted_delegations,
+            "killed_processes": killed_processes,
+            "released_claims": released_claims,
+        }
 
     def status(self, session_id: str) -> dict[str, Any]:
         with self._lock:

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -1684,6 +1684,33 @@ class AgentPool:
         except Exception:
             return 0
 
+    def _settle_interrupted_background_tasks(self, session_id: str) -> int:
+        """Persist terminal UI events when upstream interruption ends silently."""
+        with self._lock:
+            session = self._sessions.get(session_id)
+            if session is None:
+                return 0
+            timestamp = time.time()
+            interrupted = 0
+            for subagent_id, task in list(session.background_tasks.items()):
+                if str(task.get("status") or "").lower() != "running":
+                    continue
+                event = {
+                    **task,
+                    "event": "subagent.complete",
+                    "subagent_id": subagent_id,
+                    "tool_name": task.get("last_tool"),
+                    "status": "interrupted",
+                    "timestamp": timestamp,
+                    "completed_at": timestamp,
+                }
+                recorded = self._record_background_event(session, event)
+                session.background_events.append(_jsonable(recorded))
+                interrupted += 1
+            if len(session.background_events) > self.MAX_BACKGROUND_EVENTS_PER_SESSION:
+                del session.background_events[:-self.MAX_BACKGROUND_EVENTS_PER_SESSION]
+            return interrupted
+
     def interrupt(self, session_id: str, message: str | None = None) -> dict[str, Any]:
         with self._lock:
             session = self._sessions.get(session_id)
@@ -1696,6 +1723,7 @@ class AgentPool:
             session_id,
             "user_interrupt",
         )
+        self._settle_interrupted_background_tasks(session_id)
         if not hasattr(session.agent, "interrupt"):
             raise RuntimeError("agent does not support interrupt")
         session.agent.interrupt(message)

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
@@ -213,6 +213,24 @@ class BridgeServer:
         if action == "status":
             return self.pool.status(str(req.get("session_id") or ""))
 
+        if action == "background_poll":
+            session_ids = req.get("session_ids")
+            return self.pool.poll_background(session_ids if isinstance(session_ids, list) else None)
+
+        if action == "background_notification_complete":
+            delegation_id = str(req.get("delegation_id") or "").strip()
+            claim_id = str(req.get("claim_id") or "").strip()
+            if not delegation_id or not claim_id:
+                raise ValueError("delegation_id and claim_id are required")
+            return self.pool.complete_background_notification(delegation_id, claim_id)
+
+        if action == "background_notification_release":
+            delegation_id = str(req.get("delegation_id") or "").strip()
+            claim_id = str(req.get("claim_id") or "").strip()
+            if not delegation_id or not claim_id:
+                raise ValueError("delegation_id and claim_id are required")
+            return self.pool.release_background_notification(delegation_id, claim_id)
+
         if action == "destroy":
             return self.pool.destroy(str(req.get("session_id") or ""))
 
@@ -223,9 +241,10 @@ class BridgeServer:
             return self.pool.list_sessions()
 
         if action == "shutdown":
-            self._shutdown_all_mcp_servers()
+            cleanup = self.pool.shutdown()
+            cleanup["mcp_servers"] = self._shutdown_all_mcp_servers()
             self._stop.set()
-            return {"status": "shutting_down"}
+            return {"status": "shutting_down", "cleanup": cleanup}
 
         # ───── MCP Management (forwarded from broker) ─────
         if action.startswith("mcp_"):

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
@@ -67,6 +67,12 @@ class BridgeServer:
             provider = req.get("provider")
             workspace = req.get("workspace")
             source = req.get("source")
+            raw_background_delegation_enabled = req.get("background_delegation_enabled")
+            background_delegation_enabled = (
+                raw_background_delegation_enabled
+                if isinstance(raw_background_delegation_enabled, bool)
+                else None
+            )
             # Local patch (reasoning-effort): per-session reasoning effort override (Web UI brain button).
             reasoning_effort = req.get("reasoning_effort")
             record = self.pool.start_chat(
@@ -82,6 +88,7 @@ class BridgeServer:
                 workspace,
                 source,
                 reasoning_effort,
+                background_delegation_enabled,
             )
             if req.get("wait"):
                 timeout = float(req.get("timeout", 0) or 0)
@@ -98,6 +105,12 @@ class BridgeServer:
             messages = req.get("messages") or req.get("conversation_history") or []
             if not isinstance(messages, list):
                 raise ValueError("messages must be a list")
+            raw_background_delegation_enabled = req.get("background_delegation_enabled")
+            background_delegation_enabled = (
+                raw_background_delegation_enabled
+                if isinstance(raw_background_delegation_enabled, bool)
+                else None
+            )
             return self.pool.estimate_context(
                 session_id,
                 messages=messages,
@@ -106,6 +119,7 @@ class BridgeServer:
                 model=req.get("model"),
                 provider=req.get("provider"),
                 workspace=req.get("workspace"),
+                background_delegation_enabled=background_delegation_enabled,
             )
 
         if action == "get_result":

--- a/packages/server/src/services/hermes/agent-bridge/python/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/hermes_bridge.py
@@ -212,9 +212,16 @@ class AgentPool(_pool.AgentPool):
         profile: str | None = None,
         model: str | None = None,
         provider: str | None = None,
+        background_delegation_enabled: bool | None = None,
     ) -> AgentSession:
         _sync_pool_patches()
-        return super().get_or_create(session_id, profile, model, provider)
+        return super().get_or_create(
+            session_id,
+            profile,
+            model,
+            provider,
+            background_delegation_enabled,
+        )
 
     def start_chat(self, *args: Any, **kwargs: Any) -> RunRecord:
         _sync_pool_patches()

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -31,6 +31,8 @@ interface AgentConfig {
     name: string
     description: string
     invited: number
+    /** Group-chat Hermes agents must never detach delegate_task work. */
+    backgroundDelegationEnabled: false
 }
 
 interface MessageData {
@@ -160,6 +162,7 @@ class AgentClient {
     readonly profile: string
     readonly name: string
     readonly description: string
+    private readonly backgroundDelegationEnabled: false
     private socket: Socket | null = null
     private joinedRooms = new Set<string>()
     private handlers: AgentEventHandler
@@ -178,6 +181,7 @@ class AgentClient {
         this.profile = config.profile
         this.name = config.name
         this.description = config.description
+        this.backgroundDelegationEnabled = config.backgroundDelegationEnabled ?? false
         this.handlers = handlers
     }
 
@@ -443,6 +447,7 @@ class AgentClient {
             {
                 ...(modelContext.model ? { model: modelContext.model } : {}),
                 ...(modelContext.provider ? { provider: modelContext.provider } : {}),
+                background_delegation_enabled: this.backgroundDelegationEnabled,
             },
         )
         this.cacheBridgeContext(sessionId, estimate, instructions, modelContext)
@@ -753,6 +758,8 @@ class AgentClient {
                     ...(modelContext.provider ? { provider: modelContext.provider } : {}),
                     source: 'api_server',
                     ...(roomWorkspace ? { workspace: roomWorkspace } : {}),
+                    // Used only if this operation creates the cached AgentSession.
+                    background_delegation_enabled: this.backgroundDelegationEnabled,
                 },
             )
             bridgeStarted = true

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -1097,6 +1097,7 @@ export class GroupChatServer {
                         name: agent.name,
                         description: agent.description,
                         invited: agent.invited,
+                        backgroundDelegationEnabled: false,
                     })
                     await this.agentClients.addAgentToRoom(room.id, client)
                     total++

--- a/packages/server/src/services/hermes/run-chat/abort.ts
+++ b/packages/server/src/services/hermes/run-chat/abort.ts
@@ -85,6 +85,25 @@ export async function handleAbort(
     let interruptResult: any = null
     try {
       interruptResult = await bridge.interrupt(sessionId, 'Aborted by user', activeState.profile)
+      const interruptedDelegationIds = Array.isArray(interruptResult?.background_delegation_ids)
+        ? interruptResult.background_delegation_ids.map((value: unknown) => String(value || '').trim()).filter(Boolean)
+        : []
+      for (const delegationId of interruptedDelegationIds) {
+        activeState.backgroundDelegations = activeState.backgroundDelegations || {}
+        const previous = activeState.backgroundDelegations[delegationId]
+        activeState.backgroundDelegations[delegationId] = {
+          delegationId,
+          status: 'interrupted',
+          profile: previous?.profile || activeState.profile || 'default',
+          updatedAt: Date.now(),
+        }
+        emitToSession(nsp, socket, sessionId, 'delegation.updated', {
+          event: 'delegation.updated',
+          delegation_id: delegationId,
+          status: 'interrupted',
+          delivery_status: 'cancelled',
+        })
+      }
     } catch (err) {
       logger.warn(err, '[chat-run-socket][abort] failed to interrupt CLI bridge for session %s', sessionId)
     }

--- a/packages/server/src/services/hermes/run-chat/abort.ts
+++ b/packages/server/src/services/hermes/run-chat/abort.ts
@@ -18,6 +18,30 @@ function isBridgeRunSource(source?: string): boolean {
   return source === 'cli' || source === 'global_agent' || source === 'workflow'
 }
 
+function settleInterruptedBackgroundTasks(state: SessionState): Array<Record<string, unknown>> {
+  const timestamp = Date.now() / 1000
+  const completed: Array<Record<string, unknown>> = []
+  state.backgroundTasks = state.backgroundTasks || {}
+  for (const [subagentId, task] of Object.entries(state.backgroundTasks)) {
+    if (String(task.status || '').toLowerCase() !== 'running') continue
+    const snapshot = {
+      ...task,
+      subagent_id: subagentId,
+      status: 'interrupted',
+      last_event: 'subagent.complete',
+      updated_at: timestamp,
+      completed_at: timestamp,
+    }
+    state.backgroundTasks[subagentId] = snapshot
+    completed.push({
+      ...snapshot,
+      event: 'subagent.complete',
+      timestamp,
+    })
+  }
+  return completed
+}
+
 export async function handleAbort(
   nsp: ReturnType<Server['of']>,
   socket: Socket,
@@ -103,6 +127,9 @@ export async function handleAbort(
           status: 'interrupted',
           delivery_status: 'cancelled',
         })
+      }
+      for (const task of settleInterruptedBackgroundTasks(activeState)) {
+        emitToSession(nsp, socket, sessionId, 'subagent.complete', task)
       }
     } catch (err) {
       logger.warn(err, '[chat-run-socket][abort] failed to interrupt CLI bridge for session %s', sessionId)

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -47,6 +47,24 @@ function stringValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
+function parseBackgroundDelegation(toolName: string, output: string): { delegationId: string; status: string } | null {
+  if (toolName !== 'delegate_task') return null
+  try {
+    const payload = JSON.parse(output) as Record<string, unknown>
+    const delegationId = stringValue(payload.delegation_id)
+    if (!delegationId || payload.mode !== 'background') return null
+    return { delegationId, status: stringValue(payload.status) || 'dispatched' }
+  } catch {
+    return null
+  }
+}
+
+function backgroundPendingCount(state: SessionState): number {
+  return Object.values(state.backgroundDelegations || {})
+    .filter(delegation => delegation.status === 'running' || delegation.status === 'delivering')
+    .length
+}
+
 function normalizeTitleText(value: unknown): string {
   return String(value || '').replace(/\s+/g, ' ').trim()
 }
@@ -316,7 +334,7 @@ async function ensureBridgeFixedContext(args: {
 export async function handleBridgeRun(
   nsp: ReturnType<Server['of']>,
   socket: Socket,
-  data: { input: string | ContentBlock[]; display_input?: string | ContentBlock[] | null; display_role?: 'user' | 'command'; storage_message?: string; session_id?: string; model?: string; provider?: string; model_groups?: RunModelGroup[]; instructions?: string; workspace?: string | null; source?: string; session_source?: 'global_agent' | 'workflow'; queue_id?: string; peerExcludeSocketId?: string; reasoning_effort?: string; one_shot_model?: boolean; onEvent?: (event: string, payload: any) => void },
+  data: { input: string | ContentBlock[]; display_input?: string | ContentBlock[] | null; display_role?: 'user' | 'command'; storage_message?: string; session_id?: string; model?: string; provider?: string; model_groups?: RunModelGroup[]; instructions?: string; workspace?: string | null; source?: string; session_source?: 'global_agent' | 'workflow'; queue_id?: string; peerExcludeSocketId?: string; reasoning_effort?: string; one_shot_model?: boolean; background_delegation_id?: string; background_claim_id?: string; autonomous?: boolean; onEvent?: (event: string, payload: any) => void },
   profile: string,
   sessionMap: Map<string, SessionState>,
   bridge: AgentBridgeClient,
@@ -512,6 +530,7 @@ export async function handleBridgeRun(
     currentInputTokens,
   )
   const bridgeHistory = history
+  let backgroundNotificationAccepted = false
 
   try {
     const bridgeInput = isContentBlockArray(input)
@@ -547,6 +566,15 @@ export async function handleBridgeRun(
       },
     )
     state.runId = started.run_id
+    if (data.background_delegation_id && data.background_claim_id) {
+      await bridge.completeBackgroundNotification(
+        session_id,
+        profile,
+        data.background_delegation_id,
+        data.background_claim_id,
+      )
+      backgroundNotificationAccepted = true
+    }
     try {
       startWorkspaceRunCheckpoint({
         sessionId: session_id,
@@ -565,11 +593,15 @@ export async function handleBridgeRun(
       event: 'run.started',
       run_id: started.run_id,
       queue_length: state.queue.length || 0,
+      autonomous: data.autonomous === true,
+      delegation_id: data.background_delegation_id,
     })
     emit('run.started', {
       event: 'run.started',
       run_id: started.run_id,
       queue_length: state.queue.length || 0,
+      autonomous: data.autonomous === true,
+      delegation_id: data.background_delegation_id,
     })
 
     let lastChunk: AgentBridgeOutput | null = null
@@ -594,6 +626,7 @@ export async function handleBridgeRun(
         currentInputTokens,
         shouldPersistUserMessage && displayRole === 'user',
         data.model_groups,
+        { autonomous: data.autonomous === true, delegationId: data.background_delegation_id },
       )
       if (chunk.done) {
         sawTerminalChunk = true
@@ -638,9 +671,20 @@ export async function handleBridgeRun(
         currentInputTokens,
         shouldPersistUserMessage && displayRole === 'user',
         data.model_groups,
+        { autonomous: data.autonomous === true, delegationId: data.background_delegation_id },
       )
     }
   } catch (err: any) {
+    if (data.background_delegation_id && data.background_claim_id && !backgroundNotificationAccepted) {
+      void bridge.releaseBackgroundNotification(
+        session_id,
+        profile,
+        data.background_delegation_id,
+        data.background_claim_id,
+      ).catch(releaseErr => {
+        bridgeLogger.warn(releaseErr, '[chat-run-socket] failed to release background notification claim %s', data.background_delegation_id)
+      })
+    }
     if (state.activeRunMarker !== runMarker) return
     if (!state.isWorking) return
     const queueLen = state.queue?.length ?? 0
@@ -674,6 +718,9 @@ export async function handleBridgeRun(
       outputTokens: errUsage.outputTokens,
       contextTokens: errContextTokens,
       queue_remaining: queueLen,
+      background_pending: backgroundPendingCount(state),
+      autonomous: data.autonomous === true,
+      delegation_id: data.background_delegation_id,
     })
     if (queueLen > 0) {
       dequeueNextQueuedRun(socket, session_id)
@@ -1006,6 +1053,7 @@ async function applyBridgeChunkAsync(
   currentInputTokens = 0,
   currentInputIncludedInDb = true,
   modelGroups?: RunModelGroup[],
+  runMetadata?: { autonomous?: boolean; delegationId?: string },
 ): Promise<void> {
   if (state.activeRunMarker !== runMarker) {
     bridgeLogger.info({
@@ -1079,6 +1127,19 @@ async function applyBridgeChunkAsync(
     } else if (evType === 'tool.completed') {
       const toolName = (ev.tool_name as string) || ''
       const completed = recordBridgeToolCompleted(state, sessionId, runMarker, toolName, ev)
+      const backgroundDelegation = parseBackgroundDelegation(toolName, completed.output)
+      if (backgroundDelegation) {
+        state.backgroundDelegations = state.backgroundDelegations || {}
+        const existing = state.backgroundDelegations[backgroundDelegation.delegationId]
+        if (!existing || existing.status === 'running') {
+          state.backgroundDelegations[backgroundDelegation.delegationId] = {
+            delegationId: backgroundDelegation.delegationId,
+            status: 'running',
+            profile,
+            updatedAt: Date.now(),
+          }
+        }
+      }
       const payload = {
         event: 'tool.completed',
         run_id: chunk.run_id,
@@ -1091,6 +1152,17 @@ async function applyBridgeChunkAsync(
       }
       pushState(sessionMap, sessionId, 'tool.completed', payload)
       emit('tool.completed', payload)
+      if (backgroundDelegation) {
+        const delegationPayload = {
+          event: 'delegation.updated',
+          run_id: chunk.run_id,
+          delegation_id: backgroundDelegation.delegationId,
+          status: 'running',
+          background_pending: backgroundPendingCount(state),
+        }
+        pushState(sessionMap, sessionId, 'delegation.updated', delegationPayload)
+        emit('delegation.updated', delegationPayload)
+      }
     } else if (evType?.startsWith('subagent.')) {
       const payload = {
         event: evType,
@@ -1106,6 +1178,7 @@ async function applyBridgeChunkAsync(
         tool_count: ev.tool_count,
         tool: ev.tool_name,
         name: ev.tool_name,
+        arguments: ev.args,
         preview: ev.text || ev.summary || ev.tool_preview || '',
         text: ev.text || '',
         status: ev.status,
@@ -1120,6 +1193,7 @@ async function applyBridgeChunkAsync(
         files_read: ev.files_read,
         files_written: ev.files_written,
         output_tail: ev.output_tail,
+        background_seq: ev.background_seq,
       }
       pushState(sessionMap, sessionId, evType, payload)
       emit(evType, payload)
@@ -1440,6 +1514,13 @@ async function applyBridgeChunkAsync(
   })
   const hadQueuedRunBeforeGoalEvaluation = state.queue.length > 0
   const eventName = terminalError ? 'run.failed' : 'run.completed'
+  if (runMetadata?.delegationId && state.backgroundDelegations?.[runMetadata.delegationId]) {
+    state.backgroundDelegations[runMetadata.delegationId] = {
+      ...state.backgroundDelegations[runMetadata.delegationId],
+      status: terminalError ? 'failed' : 'completed',
+      updatedAt: Date.now(),
+    }
+  }
   let workspaceRunChange: ReturnType<typeof completeWorkspaceRunCheckpoint> = null
   try {
     const change = completeWorkspaceRunCheckpoint({
@@ -1478,6 +1559,9 @@ async function applyBridgeChunkAsync(
     outputTokens: usage.outputTokens,
     contextTokens,
     queue_remaining: state.queue.length,
+    background_pending: backgroundPendingCount(state),
+    autonomous: runMetadata?.autonomous === true,
+    delegation_id: runMetadata?.delegationId,
     workspace_run_change: workspaceRunChange,
   }
   emit(eventName, payload)

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -292,6 +292,7 @@ async function ensureBridgeFixedContext(args: {
   state: SessionState
   bridge: AgentBridgeClient
   refresh?: boolean
+  backgroundDelegationEnabled?: boolean
 }): Promise<number | undefined> {
   const cached = bridgeContextMatches(args.state, args)
     ? getCachedBridgeContextOverhead(args.state)
@@ -304,7 +305,14 @@ async function ensureBridgeFixedContext(args: {
       [],
       args.instructions,
       args.profile,
-      { model: args.model ?? undefined, provider: args.provider ?? undefined, workspace: args.workspace ?? undefined },
+      {
+        model: args.model ?? undefined,
+        provider: args.provider ?? undefined,
+        workspace: args.workspace ?? undefined,
+        ...(args.backgroundDelegationEnabled !== undefined
+          ? { background_delegation_enabled: args.backgroundDelegationEnabled }
+          : {}),
+      },
     )
     cacheBridgeContext(args.state, estimate, args.workspace)
     const fixedContextTokens = getCachedBridgeContextOverhead(args.state)
@@ -334,7 +342,7 @@ async function ensureBridgeFixedContext(args: {
 export async function handleBridgeRun(
   nsp: ReturnType<Server['of']>,
   socket: Socket,
-  data: { input: string | ContentBlock[]; display_input?: string | ContentBlock[] | null; display_role?: 'user' | 'command'; storage_message?: string; session_id?: string; model?: string; provider?: string; model_groups?: RunModelGroup[]; instructions?: string; workspace?: string | null; source?: string; session_source?: 'global_agent' | 'workflow'; queue_id?: string; peerExcludeSocketId?: string; reasoning_effort?: string; one_shot_model?: boolean; background_delegation_id?: string; background_claim_id?: string; autonomous?: boolean; onEvent?: (event: string, payload: any) => void },
+  data: { input: string | ContentBlock[]; display_input?: string | ContentBlock[] | null; display_role?: 'user' | 'command'; storage_message?: string; session_id?: string; model?: string; provider?: string; model_groups?: RunModelGroup[]; instructions?: string; workspace?: string | null; source?: string; session_source?: 'global_agent' | 'workflow'; queue_id?: string; peerExcludeSocketId?: string; reasoning_effort?: string; background_delegation_enabled?: boolean; one_shot_model?: boolean; background_delegation_id?: string; background_claim_id?: string; autonomous?: boolean; onEvent?: (event: string, payload: any) => void },
   profile: string,
   sessionMap: Map<string, SessionState>,
   bridge: AgentBridgeClient,
@@ -348,6 +356,10 @@ export async function handleBridgeRun(
     : data.session_source === 'workflow' || data.source === 'workflow'
       ? 'workflow'
       : 'cli'
+  // Web UI Hermes agents currently opt out at creation time. Workflow callers
+  // also pass false explicitly; a future single-chat setting can opt in with true
+  // without changing the permanently-disabled workflow and group-chat callers.
+  const backgroundDelegationEnabled = data.background_delegation_enabled === true
   if (!session_id) {
     socket.emit('run.failed', { event: 'run.failed', error: 'session_id is required for cli source' })
     return
@@ -512,6 +524,7 @@ export async function handleBridgeRun(
         state,
         bridge,
         refresh: true,
+        backgroundDelegationEnabled,
       })
       const contextTokens = fixedContextTokens == null
         ? localMessageTokens
@@ -561,6 +574,9 @@ export async function handleBridgeRun(
         ...(resolvedModel ? { model: resolvedModel } : {}),
         ...(resolvedProvider ? { provider: resolvedProvider } : {}),
         ...(workspace ? { workspace } : {}),
+        // Creation fallback when this chat is the first operation for the
+        // cached AgentSession (for example if context estimation was skipped).
+        background_delegation_enabled: backgroundDelegationEnabled,
         // Local patch (reasoning-effort): per-session reasoning effort override.
         ...(data.reasoning_effort ? { reasoning_effort: data.reasoning_effort } : {}),
       },

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -10,9 +10,13 @@
 import type { Server, Socket } from 'socket.io'
 import { logger } from '../../logger'
 import { getSystemPrompt } from '../../../lib/llm-prompt'
-import { clearSessionMessages, getSession, getSessionDetail  } from '../../../db/hermes/session-store'
+import { clearSessionMessages, getSession, getSessionDetail, listSessions } from '../../../db/hermes/session-store'
 import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../hermes-profile'
-import { AgentBridgeClient } from '../agent-bridge'
+import {
+  AgentBridgeClient,
+  type AgentBridgeBackgroundNotification,
+  type AgentBridgeBackgroundSession,
+} from '../agent-bridge'
 import { getAgentBridgeManager } from '../agent-bridge/manager'
 import { redactAgentBridgeError } from '../agent-bridge/redact'
 import { handleBridgeRun, resumeBridgeRun } from './handle-bridge-run'
@@ -106,18 +110,30 @@ type ChatRunAutoApprovalChoice = 'once' | 'session' | 'always'
 export class ChatRunSocket {
   private nsp: ReturnType<Server['of']>
   private bridge = new AgentBridgeClient()
+  private backgroundBridge = new AgentBridgeClient({ timeoutMs: 1000, connectRetryMs: 0 })
   /** sessionId → session state (messages, working status, events, run tracking) */
   private sessionMap = new Map<string, SessionState>()
   private bridgeResumePolls = new Set<string>()
   private readonly runWaiters = new Map<string, Set<(event: string, payload: any) => void>>()
+  private backgroundPollTimer?: NodeJS.Timeout
+  private backgroundPollInFlight = false
+  private backgroundRecoveryNeeded = true
+  private backgroundBrokerId?: string
+  private backgroundPollRetryAt = 0
+  private backgroundActivityGraceUntil = 0
+  private closing = false
 
   constructor(io: Server) {
     this.nsp = io.of('/chat-run')
   }
 
   init() {
+    this.closing = false
     this.nsp.use(this.authMiddleware.bind(this))
     this.nsp.on('connection', this.onConnection.bind(this))
+    this.backgroundPollTimer = setInterval(() => void this.pollBackgroundWork(), 500)
+    this.backgroundPollTimer.unref?.()
+    void this.pollBackgroundWork()
     logger.info('[chat-run-socket] Socket.IO ready at /chat-run')
   }
 
@@ -414,6 +430,9 @@ export class ChatRunSocket {
       one_shot_model?: boolean
       allow_command_passthrough?: boolean
       reasoning_effort?: string
+      background_delegation_id?: string
+      background_claim_id?: string
+      autonomous?: boolean
       onEvent?: (event: string, payload: any) => void
     },
     profile: string,
@@ -456,6 +475,14 @@ export class ChatRunSocket {
         }
         if (queueRemaining > 0) payload.queue_remaining = queueRemaining
         socket.emit('run.failed', payload)
+        if (data.session_id && data.background_delegation_id && data.background_claim_id) {
+          void this.bridge.releaseBackgroundNotification(
+            data.session_id,
+            profile,
+            data.background_delegation_id,
+            data.background_claim_id,
+          ).catch(err => logger.warn(err, '[chat-run-socket] failed to release undelivered background notification'))
+        }
         if (data.session_id && shouldDequeueNext) {
           this.dequeueNextQueuedRun(socket, data.session_id, profile)
         }
@@ -498,6 +525,214 @@ export class ChatRunSocket {
     )
   }
 
+  private backgroundPendingCount(state: SessionState): number {
+    const delegations = Object.values(state.backgroundDelegations || {})
+      .filter(item => item.status === 'running' || item.status === 'delivering')
+      .length
+    if (delegations > 0) return delegations
+    return Object.values(state.backgroundTasks || {})
+      .filter(task => task.status === 'running')
+      .length
+  }
+
+  private async sessionStateForBackground(sessionId: string): Promise<SessionState | null> {
+    const existing = this.sessionMap.get(sessionId)
+    if (existing) return existing
+    if (!getSession(sessionId)) return null
+    const loaded = await loadSessionStateFromDb(sessionId, this.sessionMap)
+    this.sessionMap.set(sessionId, loaded)
+    return loaded
+  }
+
+  private applyBackgroundSessionPoll(poll: AgentBridgeBackgroundSession, state: SessionState) {
+    if ((poll.events?.length || 0) > 0 || poll.running_count > 0) {
+      this.backgroundActivityGraceUntil = Date.now() + 30_000
+    }
+    state.backgroundTasks = state.backgroundTasks || {}
+    for (const task of poll.tasks || []) {
+      const subagentId = String(task.subagent_id || '').trim()
+      if (subagentId) state.backgroundTasks[subagentId] = { ...task }
+    }
+    for (const rawEvent of poll.events || []) {
+      const event = String(rawEvent.event || '')
+      if (!event.startsWith('subagent.')) continue
+      this.emitExternalEvent(poll.session_id, event, {
+        ...rawEvent,
+        event,
+        profile: poll.profile,
+        background: true,
+      })
+    }
+  }
+
+  private socketForBackgroundRun(sessionId: string): Socket {
+    const room = this.nsp.adapter.rooms.get(`session:${sessionId}`)
+    if (room) {
+      for (const socketId of room) {
+        const socket = this.nsp.sockets.get(socketId)
+        if (socket) return socket
+      }
+    }
+    return {
+      id: `background-run-${sessionId}`,
+      connected: false,
+      data: {},
+      join: () => {},
+      emit: (event: string, payload: any) => this.nsp.to(`session:${sessionId}`).emit(event, payload),
+      to: (roomName: string) => ({
+        emit: (event: string, payload: any) => this.nsp.to(roomName).emit(event, payload),
+      }),
+    } as unknown as Socket
+  }
+
+  private async scheduleBackgroundNotification(notification: AgentBridgeBackgroundNotification) {
+    const sessionId = String(notification.session_id || '').trim()
+    const delegationId = String(notification.delegation_id || '').trim()
+    const claimId = String(notification.claim_id || '').trim()
+    if (!sessionId || !delegationId || !claimId || !notification.message) return
+
+    const releaseClaim = () => this.backgroundBridge.releaseBackgroundNotification(
+      sessionId,
+      notification.profile,
+      delegationId,
+      claimId,
+    )
+    if (this.closing) {
+      await releaseClaim()
+      return
+    }
+
+    const session = getSession(sessionId)
+    if (!session) {
+      logger.warn('[chat-run-socket] acknowledging orphaned background delegation %s for missing session %s', delegationId, sessionId)
+      await this.backgroundBridge.completeBackgroundNotification(
+        sessionId,
+        notification.profile,
+        delegationId,
+        claimId,
+      )
+      return
+    }
+
+    const state = await this.sessionStateForBackground(sessionId)
+    if (!state) {
+      await releaseClaim()
+      return
+    }
+    if (this.closing) {
+      await releaseClaim()
+      return
+    }
+    state.backgroundDelegations = state.backgroundDelegations || {}
+    state.backgroundDelegations[delegationId] = {
+      delegationId,
+      status: 'delivering',
+      profile: notification.profile,
+      updatedAt: Date.now(),
+    }
+    this.emitExternalEvent(sessionId, 'delegation.updated', {
+      event: 'delegation.updated',
+      profile: notification.profile,
+      delegation_id: delegationId,
+      status: notification.status || 'completed',
+      delivery_status: 'delivering',
+      background_pending: this.backgroundPendingCount(state),
+    })
+
+    const next: QueuedRun = {
+      queue_id: `delegation_${delegationId}`,
+      input: notification.message,
+      displayInput: null,
+      storageMessage: notification.message,
+      model: session.model || undefined,
+      provider: session.provider || undefined,
+      profile: notification.profile || session.profile || 'default',
+      workspace: session.workspace,
+      source: resolveRunSource(session.source || undefined, sessionId),
+      backgroundDelegationId: delegationId,
+      backgroundClaimId: claimId,
+      autonomous: true,
+    }
+
+    if (state.isWorking) {
+      state.queue.push(next)
+      logger.info('[chat-run-socket] queued background delegation %s for busy session %s', delegationId, sessionId)
+      return
+    }
+
+    state.isWorking = true
+    state.profile = next.profile
+    state.source = next.source
+    this.runQueuedItem(this.socketForBackgroundRun(sessionId), sessionId, next, next.profile)
+  }
+
+  private needsBackgroundPoll(): boolean {
+    if (this.closing) return false
+    if (this.backgroundRecoveryNeeded) return true
+    if (Date.now() < this.backgroundActivityGraceUntil) return true
+    for (const state of this.sessionMap.values()) {
+      if (this.backgroundPendingCount(state) > 0) return true
+      if (Object.values(state.backgroundTasks || {}).some(task => task.status === 'running')) return true
+    }
+    return false
+  }
+
+  private backgroundRecoveryRoutes() {
+    const cutoff = Math.floor(Date.now() / 1000) - 8 * 24 * 60 * 60
+    const sessionsByProfile = new Map<string, string[]>()
+    for (const session of listSessions(undefined, undefined, 10_000)) {
+      if (session.last_active < cutoff) continue
+      if (!isHermesWorkerBackedSession(session)) continue
+      const profile = session.profile || 'default'
+      const ids = sessionsByProfile.get(profile) || []
+      ids.push(session.id)
+      sessionsByProfile.set(profile, ids)
+    }
+    return [...sessionsByProfile.entries()].map(([profile, session_ids]) => ({ profile, session_ids }))
+  }
+
+  private async pollBackgroundWork() {
+    if (this.closing || this.backgroundPollInFlight || Date.now() < this.backgroundPollRetryAt || !this.needsBackgroundPoll()) return
+    this.backgroundPollInFlight = true
+    try {
+      const recovering = this.backgroundRecoveryNeeded
+      const routes = recovering ? this.backgroundRecoveryRoutes() : undefined
+      const result = await this.backgroundBridge.backgroundPoll(routes, { timeoutMs: recovering ? 120_000 : 1000 })
+      if (this.closing) {
+        await Promise.allSettled((result.notifications || []).map(notification => (
+          this.backgroundBridge.releaseBackgroundNotification(
+            notification.session_id,
+            notification.profile,
+            notification.delegation_id,
+            notification.claim_id,
+          )
+        )))
+        return
+      }
+      const brokerChanged = Boolean(this.backgroundBrokerId && result.broker_id && result.broker_id !== this.backgroundBrokerId)
+      if (result.broker_id) this.backgroundBrokerId = result.broker_id
+      this.backgroundRecoveryNeeded = brokerChanged && !recovering
+      this.backgroundPollRetryAt = 0
+      if ((result.pending_count || 0) > 0) {
+        this.backgroundActivityGraceUntil = Date.now() + 310_000
+      }
+      for (const poll of result.sessions || []) {
+        const sessionId = String(poll.session_id || '').trim()
+        if (!sessionId) continue
+        const state = await this.sessionStateForBackground(sessionId)
+        if (state) this.applyBackgroundSessionPoll(poll, state)
+      }
+      for (const notification of result.notifications || []) {
+        await this.scheduleBackgroundNotification(notification)
+      }
+    } catch (err) {
+      this.backgroundPollRetryAt = Date.now() + 5000
+      logger.debug(err, '[chat-run-socket] background bridge poll unavailable')
+    } finally {
+      this.backgroundPollInFlight = false
+    }
+  }
+
   // --- Resume ---
 
   private async resumeSession(socket: Socket, sid: string) {
@@ -532,6 +767,8 @@ export class ChatRunSocket {
       contextTokens: state.contextTokens,
       queueLength: state.queue?.length || 0,
       queueMessages: this.serializeQueuedMessages(state.queue || []),
+      backgroundTasks: Object.values(state.backgroundTasks || {}),
+      backgroundPending: this.backgroundPendingCount(state),
     })
 
     logger.info('[chat-run-socket] socket %s resumed session %s (working: %s, messages: %d)',
@@ -665,6 +902,9 @@ export class ChatRunSocket {
       one_shot_model: next.oneShotModel,
       allow_command_passthrough: next.commandPassthrough,
       reasoning_effort: next.reasoningEffort,
+      background_delegation_id: next.backgroundDelegationId,
+      background_claim_id: next.backgroundClaimId,
+      autonomous: next.autonomous,
     }, next.profile || fallbackProfile, skipUserMessage)
   }
 
@@ -1011,7 +1251,14 @@ export class ChatRunSocket {
   }
 
   /** Close all active upstream response streams */
-  close() {
+  async close() {
+    if (this.closing) return
+    this.closing = true
+    if (this.backgroundPollTimer) {
+      clearInterval(this.backgroundPollTimer)
+      this.backgroundPollTimer = undefined
+    }
+    const releaseClaims: Array<Promise<unknown>> = []
     for (const [sessionId, state] of this.sessionMap.entries()) {
       if (state.abortController) {
         try {
@@ -1020,8 +1267,24 @@ export class ChatRunSocket {
           logger.warn(e, '[chat-run-socket] failed to abort controller for session %s', sessionId)
         }
       }
+      for (const queued of state.queue) {
+        if (!queued.backgroundDelegationId || !queued.backgroundClaimId) continue
+        releaseClaims.push(this.backgroundBridge.releaseBackgroundNotification(
+          sessionId,
+          queued.profile,
+          queued.backgroundDelegationId,
+          queued.backgroundClaimId,
+        ))
+      }
     }
     this.sessionMap.clear()
+    const releaseResults = await Promise.allSettled(releaseClaims)
+    for (const result of releaseResults) {
+      if (result.status === 'rejected') {
+        logger.warn(result.reason, '[chat-run-socket] failed to release queued background notification on close')
+      }
+    }
+    await Promise.allSettled([this.bridge.close(), this.backgroundBridge.close()])
     logger.info('[chat-run-socket] closed all connections and cleared state')
   }
 

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -430,6 +430,7 @@ export class ChatRunSocket {
       one_shot_model?: boolean
       allow_command_passthrough?: boolean
       reasoning_effort?: string
+      background_delegation_enabled?: boolean
       background_delegation_id?: string
       background_claim_id?: string
       autonomous?: boolean
@@ -938,6 +939,8 @@ export class ChatRunSocket {
       mcp_servers?: Record<string, unknown>
       profile?: string
       reasoning_effort?: string
+      /** Hermes Agent creation policy used by internal orchestration callers. */
+      background_delegation_enabled?: boolean
       one_shot_model?: boolean
     },
     options: { profile?: string; user?: AuthenticatedUser; timeoutMs?: number; approvalChoice?: ChatRunAutoApprovalChoice } = {},

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -57,6 +57,16 @@ export interface QueuedRun {
   originSocketId?: string
   goalContinuation?: boolean
   reasoningEffort?: string
+  backgroundDelegationId?: string
+  backgroundClaimId?: string
+  autonomous?: boolean
+}
+
+export interface BackgroundDelegationState {
+  delegationId: string
+  status: 'running' | 'delivering' | 'completed' | 'failed' | 'interrupted'
+  profile?: string
+  updatedAt: number
 }
 
 export interface SessionState {
@@ -91,6 +101,8 @@ export interface SessionState {
     startedAt: number
   }>
   bridgeCompressionResults?: Record<string, BridgeCompressionResult>
+  backgroundTasks?: Record<string, Record<string, unknown>>
+  backgroundDelegations?: Record<string, BackgroundDelegationState>
 }
 
 export interface ResponseRunState {

--- a/packages/server/src/services/shutdown.ts
+++ b/packages/server/src/services/shutdown.ts
@@ -74,6 +74,14 @@ export function createShutdownHandler(server: any, groupChatServer?: any, chatRu
         logger.info('[shutdown] leaving managed gateways running')
       }
 
+      // Stop accepting/routing chat work before stopping the bridge. This lets
+      // ChatRunSocket release any claimed background completion back to Hermes
+      // while the broker is still reachable.
+      if (chatRunServer) {
+        await chatRunServer.close()
+        logger.info('ChatRunSocket closed')
+      }
+
       if (agentBridgeManager && shouldStopAgentBridgeOnShutdown(signal)) {
         try {
           await agentBridgeManager.stop()
@@ -83,12 +91,6 @@ export function createShutdownHandler(server: any, groupChatServer?: any, chatRu
         }
       } else if (agentBridgeManager) {
         logger.info('Leaving agent bridge running across Web UI shutdown')
-      }
-
-      // Close ChatRunSocket first to release WebSocket state.
-      if (chatRunServer) {
-        chatRunServer.close()
-        logger.info('ChatRunSocket closed')
       }
 
       stopOutboundRelayClient()

--- a/packages/server/src/services/workflow-manager.ts
+++ b/packages/server/src/services/workflow-manager.ts
@@ -1355,7 +1355,9 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
           profile, workspace: workspace, model: node.data.model || undefined,
           provider: node.data.provider || undefined, mode: node.data.agent === 'hermes' ? undefined : 'scoped',
           coding_agent_id: target.codingAgentId, agent_id: target.codingAgentId,
-          ...(node.data.agent === 'hermes' ? {} : { apiMode: node.data.apiMode || undefined }),
+          ...(node.data.agent === 'hermes'
+            ? { background_delegation_enabled: false }
+            : { apiMode: node.data.apiMode || undefined }),
           one_shot_model: true,
           ...(node.data.reasoningEffort !== 'default' ? { reasoning_effort: node.data.reasoningEffort } : {}),
         }, { profile, user: args.user, timeoutMs: remainingTimeoutMs, approvalChoice: 'once' })
@@ -1857,7 +1859,9 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
             mode: node.data.agent === 'hermes' ? undefined : 'scoped',
             coding_agent_id: target.codingAgentId,
             agent_id: target.codingAgentId,
-            ...(node.data.agent === 'hermes' ? {} : { apiMode: node.data.apiMode || undefined }),
+            ...(node.data.agent === 'hermes'
+              ? { background_delegation_enabled: false }
+              : { apiMode: node.data.apiMode || undefined }),
             one_shot_model: true,
             ...(node.data.reasoningEffort !== 'default' ? { reasoning_effort: node.data.reasoningEffort } : {}),
           }, {

--- a/tests/client/chat-run-reconnect.test.ts
+++ b/tests/client/chat-run-reconnect.test.ts
@@ -212,4 +212,53 @@ describe('chat-run socket reconnect handling', () => {
     socket.__trigger('session.command', { ...event, message: 'next status' })
     expect(onGlobalCommand).toHaveBeenCalledTimes(1)
   })
+
+  it('keeps the session listener alive while background delegations remain', async () => {
+    const { startRunViaSocket } = await import('../../packages/client/src/api/hermes/chat')
+    const onEvent = vi.fn()
+    const onDone = vi.fn()
+
+    startRunViaSocket(
+      { session_id: 'session-background', input: 'delegate this', profile: 'default', source: 'cli' },
+      onEvent,
+      onDone,
+      vi.fn(),
+    )
+
+    const socket = socketState.sockets[0]
+    socket.__trigger('run.completed', {
+      event: 'run.completed',
+      session_id: 'session-background',
+      background_pending: 1,
+    })
+    expect(onDone).toHaveBeenCalledTimes(1)
+
+    const childText = {
+      event: 'subagent.text',
+      session_id: 'session-background',
+      subagent_id: 'child-1',
+      text: 'still working',
+    }
+    socket.__trigger('subagent.text', childText)
+    expect(onEvent).toHaveBeenCalledWith(childText)
+
+    socket.__trigger('run.started', {
+      event: 'run.started',
+      session_id: 'session-background',
+      autonomous: true,
+      delegation_id: 'deleg-1',
+    })
+    socket.__trigger('run.completed', {
+      event: 'run.completed',
+      session_id: 'session-background',
+      autonomous: true,
+      delegation_id: 'deleg-1',
+      background_pending: 0,
+    })
+    expect(onDone).toHaveBeenCalledTimes(2)
+
+    const callsAfterCompletion = onEvent.mock.calls.length
+    socket.__trigger('subagent.text', { ...childText, text: 'late event' })
+    expect(onEvent).toHaveBeenCalledTimes(callsAfterCompletion)
+  })
 })

--- a/tests/client/chat-store-compression-state.test.ts
+++ b/tests/client/chat-store-compression-state.test.ts
@@ -180,6 +180,37 @@ describe('chat store compression state', () => {
     expect(store.messages.find(message => message.toolCallId === 'subagent:child-1')?.toolStatus).toBe('error')
   })
 
+  it('settles every running subagent card when session stop completes without child terminal events', async () => {
+    const store = useChatStore()
+    store.sessions = [makeSession('session-1')]
+    await store.switchSession('session-1')
+    const sessionHandlers = chatApi.registerSessionHandlers.mock.calls.find(call => call[0] === 'session-1')?.[1]
+
+    for (const [index, subagentId] of ['child-1', 'child-2'].entries()) {
+      sessionHandlers.onSubagentEvent({
+        event: 'subagent.start',
+        session_id: 'session-1',
+        subagent_id: subagentId,
+        task_index: index,
+        task_count: 2,
+        goal: `Task ${index + 1}`,
+      })
+    }
+
+    sessionHandlers.onAbortCompleted({
+      event: 'abort.completed',
+      session_id: 'session-1',
+      synced: true,
+    })
+
+    expect(store.getSubagentStream('session-1', 'child-1')?.status).toBe('interrupted')
+    expect(store.getSubagentStream('session-1', 'child-2')?.status).toBe('interrupted')
+    expect(store.messages.filter(message => message.toolCallId?.startsWith('subagent:'))).toEqual([
+      expect.objectContaining({ toolCallId: 'subagent:child-1', toolStatus: 'error' }),
+      expect.objectContaining({ toolCallId: 'subagent:child-2', toolStatus: 'error' }),
+    ])
+  })
+
   it('replaces a persisted background delegate dispatch with its real recovered child stream', async () => {
     chatApi.resumeSession.mockImplementationOnce((sessionId: string, onResumed: (data: any) => void) => {
       onResumed({

--- a/tests/client/chat-store-compression-state.test.ts
+++ b/tests/client/chat-store-compression-state.test.ts
@@ -121,6 +121,115 @@ describe('chat store compression state', () => {
     }))
   })
 
+  it('does not create a duplicate placeholder card for delegation lifecycle updates', async () => {
+    const store = useChatStore()
+    store.sessions = [makeSession('session-1')]
+    await store.switchSession('session-1')
+    const sessionHandlers = chatApi.registerSessionHandlers.mock.calls.find(call => call[0] === 'session-1')?.[1]
+
+    sessionHandlers.onToolStarted({
+      event: 'tool.started',
+      session_id: 'session-1',
+      tool_call_id: 'delegate-call-1',
+      tool: 'delegate_task',
+      arguments: { mode: 'background', goal: 'Inspect the task' },
+    })
+    sessionHandlers.onToolCompleted({
+      event: 'tool.completed',
+      session_id: 'session-1',
+      tool_call_id: 'delegate-call-1',
+      tool: 'delegate_task',
+      output: JSON.stringify({ mode: 'background', delegation_id: 'delegation-1' }),
+    })
+    sessionHandlers.onSubagentEvent({
+      event: 'delegation.updated',
+      session_id: 'session-1',
+      delegation_id: 'delegation-1',
+      status: 'running',
+    })
+    expect(store.messages.filter(message => message.toolCallId?.startsWith('subagent:'))).toHaveLength(0)
+    expect(store.subagentStreams.size).toBe(0)
+
+    sessionHandlers.onSubagentEvent({
+      event: 'subagent.start',
+      session_id: 'session-1',
+      subagent_id: 'child-1',
+      task_index: 0,
+      task_count: 1,
+      goal: 'Inspect the task',
+    })
+    sessionHandlers.onSubagentEvent({
+      event: 'subagent.text',
+      session_id: 'session-1',
+      subagent_id: 'child-1',
+      text: 'Working on it',
+    })
+
+    const taskCards = store.messages.filter(message => message.toolCallId?.startsWith('subagent:'))
+    expect(taskCards).toHaveLength(1)
+    expect(store.getSubagentStream('session-1', 'child-1')?.entries.some(entry => entry.kind === 'text')).toBe(true)
+
+    sessionHandlers.onSubagentEvent({
+      event: 'delegation.updated',
+      session_id: 'session-1',
+      delegation_id: 'delegation-1',
+      status: 'interrupted',
+    })
+    expect(store.messages.filter(message => message.toolCallId?.startsWith('subagent:'))).toHaveLength(1)
+    expect(store.getSubagentStream('session-1', 'child-1')?.status).toBe('interrupted')
+    expect(store.messages.find(message => message.toolCallId === 'subagent:child-1')?.toolStatus).toBe('error')
+  })
+
+  it('replaces a persisted background delegate dispatch with its real recovered child stream', async () => {
+    chatApi.resumeSession.mockImplementationOnce((sessionId: string, onResumed: (data: any) => void) => {
+      onResumed({
+        session_id: sessionId,
+        isWorking: false,
+        messages: [{
+          id: 'assistant-tool-call',
+          role: 'assistant',
+          content: '',
+          timestamp: Date.now() / 1000,
+          tool_calls: [{
+            id: 'delegate-call-1',
+            function: {
+              name: 'delegate_task',
+              arguments: JSON.stringify({ mode: 'background', goal: 'Inspect the task' }),
+            },
+          }],
+        }, {
+          id: 'delegate-result',
+          role: 'tool',
+          content: JSON.stringify({ mode: 'background', delegation_id: 'delegation-1' }),
+          tool_call_id: 'delegate-call-1',
+          tool_name: 'delegate_task',
+          timestamp: Date.now() / 1000,
+        }],
+        events: [],
+        backgroundPending: 1,
+        backgroundTasks: [{
+          subagent_id: 'child-1',
+          status: 'running',
+          last_event: 'subagent.text',
+          task_index: 0,
+          task_count: 1,
+          goal: 'Inspect the task',
+          preview: 'Recovered live output',
+        }],
+      })
+      return {} as any
+    })
+
+    const store = useChatStore()
+    store.sessions = [makeSession('session-1')]
+    await store.switchSession('session-1')
+
+    const delegateCards = store.messages.filter(message => message.toolName === 'delegate_task')
+    expect(delegateCards).toHaveLength(1)
+    expect(delegateCards[0]?.toolCallId).toBe('subagent:child-1')
+    expect(store.getSubagentStream('session-1', 'child-1')?.entries.some(entry => entry.text === 'Recovered live output')).toBe(true)
+  })
+
   it('surfaces non-terminal reattach warnings replayed in a non-working resume payload', async () => {
     chatApi.resumeSession.mockImplementationOnce((sessionId: string, onResumed: (data: any) => void) => {
       onResumed({

--- a/tests/client/subagent-stream-panel.test.ts
+++ b/tests/client/subagent-stream-panel.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import type { SubagentStream } from '@/stores/hermes/chat'
+import SubagentStreamPanel from '@/components/hermes/chat/SubagentStreamPanel.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const MessageItemStub = defineComponent({
+  props: ['message'],
+  template: '<div class="rendered-message" :data-role="message.role">{{ message.content || message.toolName }}</div>',
+})
+
+const VirtualMessageListStub = defineComponent({
+  props: ['messages'],
+  setup(_props, { expose }) {
+    expose({
+      shouldAutoFollowBottom: () => true,
+      scrollToBottom: vi.fn(),
+    })
+  },
+  template: `
+    <div class="virtual-message-list">
+      <template v-if="messages.length">
+        <div v-for="message in messages" :key="message.id">
+          <slot name="item" :message="message" />
+        </div>
+      </template>
+      <slot v-else name="empty" />
+    </div>
+  `,
+})
+
+function streamFixture(): SubagentStream {
+  return {
+    sessionId: 'session-1',
+    subagentId: 'child-1',
+    taskIndex: 0,
+    taskCount: 1,
+    goal: 'Review shutdown behavior',
+    status: 'completed',
+    startedAt: 1,
+    updatedAt: 4,
+    entries: [
+      { id: 'start', kind: 'status', status: 'started', timestamp: 1 },
+      { id: 'text', kind: 'text', text: 'The worker exits safely.', timestamp: 2 },
+      { id: 'tool', kind: 'tool', toolName: 'read_file', timestamp: 3 },
+      { id: 'complete', kind: 'status', status: 'completed', timestamp: 4 },
+    ],
+  }
+}
+
+describe('SubagentStreamPanel', () => {
+  it('uses the chat message renderer but keeps lifecycle status out of the transcript', () => {
+    const wrapper = mount(SubagentStreamPanel, {
+      props: { stream: streamFixture() },
+      global: {
+        stubs: {
+          MessageItem: MessageItemStub,
+          VirtualMessageList: VirtualMessageListStub,
+        },
+      },
+    })
+
+    const messages = wrapper.findAll('.rendered-message')
+    expect(messages).toHaveLength(2)
+    expect(messages.map(message => message.attributes('data-role'))).toEqual(['assistant', 'tool'])
+    expect(wrapper.find('.virtual-message-list').text()).not.toContain('subagent.completed')
+    expect(wrapper.find('.subagent-status').text()).toBe('subagent.completed')
+  })
+})

--- a/tests/client/subagent-stream.test.ts
+++ b/tests/client/subagent-stream.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { reduceSubagentStream } from '@/stores/hermes/chat'
+import {
+  OPEN_SUBAGENT_STREAM_EVENT,
+  openSubagentStream,
+  subagentIdFromToolCall,
+  type OpenSubagentStreamDetail,
+} from '@/utils/hermes/subagent-stream'
+
+describe('background subagent streams', () => {
+  it('coalesces live text while preserving thinking and tool calls as structured entries', () => {
+    let stream = reduceSubagentStream(undefined, 'session-1', {
+      event: 'subagent.start',
+      subagent_id: 'child-1',
+      task_index: 0,
+      task_count: 2,
+      goal: 'Inspect the updater',
+      model: 'test-model',
+      background_seq: 1,
+      timestamp: 1_000,
+    })
+    stream = reduceSubagentStream(stream, 'session-1', {
+      event: 'subagent.text',
+      subagent_id: 'child-1',
+      text: 'Found ',
+      background_seq: 2,
+    })
+    stream = reduceSubagentStream(stream, 'session-1', {
+      event: 'subagent.text',
+      subagent_id: 'child-1',
+      text: 'the worker.',
+      background_seq: 3,
+    })
+    stream = reduceSubagentStream(stream, 'session-1', {
+      event: 'subagent.thinking',
+      subagent_id: 'child-1',
+      text: 'Checking shutdown ordering',
+      background_seq: 4,
+    })
+    stream = reduceSubagentStream(stream, 'session-1', {
+      event: 'subagent.tool',
+      subagent_id: 'child-1',
+      tool: 'read_file',
+      arguments: { path: 'shutdown.ts' },
+      preview: 'shutdown.ts',
+      tool_count: 1,
+      background_seq: 5,
+    })
+
+    expect(stream).toMatchObject({
+      sessionId: 'session-1',
+      subagentId: 'child-1',
+      taskIndex: 0,
+      taskCount: 2,
+      goal: 'Inspect the updater',
+      model: 'test-model',
+      status: 'running',
+      toolCount: 1,
+    })
+    expect(stream.entries.filter(entry => entry.kind === 'text')).toHaveLength(1)
+    expect(stream.entries.find(entry => entry.kind === 'text')?.text).toBe('Found the worker.')
+    expect(stream.entries.find(entry => entry.kind === 'thinking')?.text).toBe('Checking shutdown ordering')
+    expect(stream.entries.find(entry => entry.kind === 'tool')).toMatchObject({
+      toolName: 'read_file',
+      toolArgs: { path: 'shutdown.ts' },
+    })
+  })
+
+  it('marks terminal updates without replaying an older background event', () => {
+    const running = reduceSubagentStream(undefined, 'session-1', {
+      event: 'subagent.text',
+      subagent_id: 'child-1',
+      text: 'working',
+      background_seq: 10,
+    })
+    const completed = reduceSubagentStream(running, 'session-1', {
+      event: 'subagent.complete',
+      subagent_id: 'child-1',
+      status: 'completed',
+      summary: 'Done safely',
+      duration_seconds: 12.5,
+      input_tokens: 100,
+      output_tokens: 25,
+      background_seq: 11,
+    })
+    const stale = reduceSubagentStream(completed, 'session-1', {
+      event: 'subagent.text',
+      subagent_id: 'child-1',
+      text: 'stale',
+      background_seq: 9,
+    })
+
+    expect(completed).toMatchObject({
+      status: 'completed',
+      summary: 'Done safely',
+      durationSeconds: 12.5,
+      inputTokens: 100,
+      outputTokens: 25,
+    })
+    expect(completed.entries.at(-1)).toMatchObject({ kind: 'status', status: 'completed' })
+    expect(stale).toBe(completed)
+  })
+
+  it('opens only subagent tool calls in the live output panel', () => {
+    expect(subagentIdFromToolCall('subagent:child-1')).toBe('child-1')
+    expect(subagentIdFromToolCall('tool:child-1')).toBeNull()
+
+    const listener = vi.fn<(event: Event) => void>()
+    window.addEventListener(OPEN_SUBAGENT_STREAM_EVENT, listener)
+    expect(openSubagentStream('session-1', 'subagent:child-1')).toBe(true)
+    expect(openSubagentStream('session-1', 'tool:child-1')).toBe(false)
+    window.removeEventListener(OPEN_SUBAGENT_STREAM_EVENT, listener)
+
+    const event = listener.mock.calls[0]?.[0] as CustomEvent<OpenSubagentStreamDetail>
+    expect(event.detail).toEqual({ sessionId: 'session-1', subagentId: 'child-1' })
+  })
+})

--- a/tests/client/subagent-stream.test.ts
+++ b/tests/client/subagent-stream.test.ts
@@ -100,6 +100,14 @@ describe('background subagent streams', () => {
     })
     expect(completed.entries.at(-1)).toMatchObject({ kind: 'status', status: 'completed' })
     expect(stale).toBe(completed)
+
+    const lateOutput = reduceSubagentStream(completed, 'session-1', {
+      event: 'subagent.text',
+      subagent_id: 'child-1',
+      text: 'late output',
+      background_seq: 7,
+    })
+    expect(lateOutput).toBe(completed)
   })
 
   it('opens only subagent tool calls in the live output panel', () => {

--- a/tests/e2e/chat-streaming.spec.ts
+++ b/tests/e2e/chat-streaming.spec.ts
@@ -74,6 +74,128 @@ test('sends a chat run and renders streamed Socket.IO response events', async ({
   expect(api.unexpectedRequests).toEqual([])
 })
 
+test('shows one real subagent card and opens its live chat stream in the resizable preview panel', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  const api = await mockHermesApi(page)
+  await mockChatSocket(page)
+
+  await page.goto('/#/hermes/chat')
+  await sendChatMessage(page, 'Delegate the research task')
+  const { run } = await waitForRun(page)
+
+  await page.evaluate((sid) => {
+    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    socket.__trigger('run.started', { event: 'run.started', session_id: sid, run_id: 'run-delegate' })
+    socket.__trigger('tool.started', {
+      event: 'tool.started',
+      session_id: sid,
+      run_id: 'run-delegate',
+      tool_call_id: 'delegate-call-1',
+      tool: 'delegate_task',
+      arguments: { mode: 'background', goal: 'Research the latest technology news' },
+    })
+    socket.__trigger('tool.completed', {
+      event: 'tool.completed',
+      session_id: sid,
+      run_id: 'run-delegate',
+      tool_call_id: 'delegate-call-1',
+      tool: 'delegate_task',
+      output: JSON.stringify({
+        mode: 'background',
+        status: 'dispatched',
+        delegation_id: 'delegation-1',
+      }),
+    })
+    socket.__trigger('delegation.updated', {
+      event: 'delegation.updated',
+      session_id: sid,
+      delegation_id: 'delegation-1',
+      status: 'running',
+      background_pending: 1,
+    })
+    socket.__trigger('run.completed', {
+      event: 'run.completed',
+      session_id: sid,
+      run_id: 'run-delegate',
+      output: 'Delegation started.',
+      background_pending: 1,
+    })
+  }, run.session_id)
+
+  await expect(page.locator('.subagent-entry')).toHaveCount(0)
+
+  await page.evaluate((sid) => {
+    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    socket.__trigger('subagent.start', {
+      event: 'subagent.start',
+      session_id: sid,
+      subagent_id: 'child-1',
+      task_index: 0,
+      task_count: 1,
+      goal: 'Research the latest technology news',
+      model: 'test-model',
+      background_seq: 1,
+    })
+    socket.__trigger('subagent.text', {
+      event: 'subagent.text',
+      session_id: sid,
+      subagent_id: 'child-1',
+      text: 'Child live answer.',
+      background_seq: 2,
+    })
+    socket.__trigger('subagent.tool', {
+      event: 'subagent.tool',
+      session_id: sid,
+      subagent_id: 'child-1',
+      tool: 'search_web',
+      arguments: { query: 'technology news' },
+      preview: 'technology news',
+      tool_count: 1,
+      background_seq: 3,
+    })
+  }, run.session_id)
+
+  const subagentCards = page.locator('.message.tool .subagent-entry')
+  await expect(subagentCards).toHaveCount(1)
+  await expect(subagentCards).toContainText('delegate_task')
+  await subagentCards.click()
+
+  const panel = page.locator('.subagent-stream-panel')
+  await expect(panel).toBeVisible()
+  await expect(panel).toContainText('Research the latest technology news')
+  await expect(panel).toContainText('Child live answer.')
+  await expect(panel).toContainText('search_web')
+  await expect(panel.getByText('Waiting for live output...')).toHaveCount(0)
+  await expect(panel.locator('.message-bubble.system')).toHaveCount(0)
+
+  const backgrounds = await page.evaluate(() => ({
+    chat: getComputedStyle(document.querySelector('.chat-main-content')!).backgroundColor,
+    panel: getComputedStyle(document.querySelector('.subagent-stream-panel')!).backgroundColor,
+    transcript: getComputedStyle(document.querySelector('.subagent-stream-panel .virtual-message-list')!).backgroundColor,
+  }))
+  expect(backgrounds.panel).toBe(backgrounds.chat)
+  expect(backgrounds.transcript).toBe(backgrounds.chat)
+
+  await page.evaluate((sid) => {
+    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    socket.__trigger('subagent.complete', {
+      event: 'subagent.complete',
+      session_id: sid,
+      subagent_id: 'child-1',
+      task_index: 0,
+      task_count: 1,
+      status: 'completed',
+      summary: 'Research finished.',
+      background_seq: 4,
+    })
+  }, run.session_id)
+
+  await expect(panel.locator('.subagent-status')).toHaveText('Completed')
+  await expect(panel).toContainText('Research finished.')
+  await expect(panel.locator('.message-bubble.system')).toHaveCount(0)
+  expect(api.unexpectedRequests).toEqual([])
+})
+
 test('uses the newly selected profile for the next chat-run socket after profile switch reload', async ({ page }) => {
   await authenticate(page, TEST_ACCESS_KEY, 'default')
   const api = await mockHermesApi(page, { initialProfileName: 'default' })

--- a/tests/e2e/chat-streaming.spec.ts
+++ b/tests/e2e/chat-streaming.spec.ts
@@ -196,6 +196,57 @@ test('shows one real subagent card and opens its live chat stream in the resizab
   expect(api.unexpectedRequests).toEqual([])
 })
 
+test('settles a running subagent card when Stop completes without a child terminal event', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  const api = await mockHermesApi(page)
+  await mockChatSocket(page)
+
+  await page.goto('/#/hermes/chat')
+  await sendChatMessage(page, 'Start background work')
+  const { run } = await waitForRun(page)
+
+  await page.evaluate((sid) => {
+    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    socket.__trigger('run.started', { event: 'run.started', session_id: sid, run_id: 'run-stop-child' })
+    socket.__trigger('subagent.start', {
+      event: 'subagent.start',
+      session_id: sid,
+      subagent_id: 'child-stop',
+      task_index: 0,
+      task_count: 1,
+      goal: 'Long-running background work',
+      background_seq: 1,
+    })
+  }, run.session_id)
+
+  const subagentCard = page.locator('.subagent-entry').filter({ hasText: 'Long-running background work' })
+  await expect(subagentCard).toHaveCount(1)
+  await subagentCard.click()
+  const panel = page.locator('.subagent-stream-panel')
+  await expect(panel.locator('.subagent-status')).toHaveText('Running')
+  await expect(subagentCard.locator('.tool-call-spinner')).toHaveCount(1)
+
+  await page.getByRole('button', { name: 'Stop' }).click()
+  await page.waitForFunction((sid) => {
+    const emitted = (window as any).__PW_CHAT_SOCKET__?.emitted || []
+    return emitted.some((item: any) => item.event === 'abort' && item.payload?.session_id === sid)
+  }, run.session_id)
+  await page.evaluate((sid) => {
+    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    socket.__trigger('abort.completed', {
+      event: 'abort.completed',
+      session_id: sid,
+      run_id: 'run-stop-child',
+      synced: true,
+    })
+  }, run.session_id)
+
+  await expect(panel.locator('.subagent-status')).toHaveText('Interrupted')
+  await expect(panel.locator('.subagent-live-dot')).not.toHaveClass(/active/)
+  await expect(subagentCard.locator('.tool-call-spinner, .tool-spinner')).toHaveCount(0)
+  expect(api.unexpectedRequests).toEqual([])
+})
+
 test('uses the newly selected profile for the next chat-run socket after profile switch reload', async ({ page }) => {
   await authenticate(page, TEST_ACCESS_KEY, 'default')
   const api = await mockHermesApi(page, { initialProfileName: 'default' })

--- a/tests/server/agent-bridge-client-background.test.ts
+++ b/tests/server/agent-bridge-client-background.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+
+describe('AgentBridgeClient background delegation requests', () => {
+  it('forwards recovery routes and delivery acknowledgements', async () => {
+    const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+    const client = new AgentBridgeClient({ endpoint: 'tcp://127.0.0.1:1', connectRetryMs: 0, timeoutMs: 1 })
+    const request = vi.spyOn(client, 'request').mockResolvedValue({ ok: true })
+
+    await client.backgroundPoll([
+      { profile: 'default', session_ids: ['session-1'] },
+    ], { timeoutMs: 500 })
+    await client.completeBackgroundNotification('session-1', 'default', 'deleg-1', 'claim-1')
+    await client.releaseBackgroundNotification('session-1', 'default', 'deleg-2', 'claim-2')
+
+    expect(request).toHaveBeenNthCalledWith(1, {
+      action: 'background_poll',
+      routes: [{ profile: 'default', session_ids: ['session-1'] }],
+    }, { timeoutMs: 500 })
+    expect(request).toHaveBeenNthCalledWith(2, {
+      action: 'background_notification_complete',
+      session_id: 'session-1',
+      profile: 'default',
+      delegation_id: 'deleg-1',
+      claim_id: 'claim-1',
+    })
+    expect(request).toHaveBeenNthCalledWith(3, {
+      action: 'background_notification_release',
+      session_id: 'session-1',
+      profile: 'default',
+      delegation_id: 'deleg-2',
+      claim_id: 'claim-2',
+    })
+  })
+})

--- a/tests/server/agent-bridge-client-background.test.ts
+++ b/tests/server/agent-bridge-client-background.test.ts
@@ -1,6 +1,35 @@
 import { describe, expect, it, vi } from 'vitest'
 
 describe('AgentBridgeClient background delegation requests', () => {
+  it('forwards an explicit Agent-session creation setting', async () => {
+    const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+    const client = new AgentBridgeClient({ endpoint: 'tcp://127.0.0.1:1', connectRetryMs: 0, timeoutMs: 1 })
+    const request = vi.spyOn(client, 'request').mockResolvedValue({
+      ok: true,
+      run_id: 'run-1',
+      session_id: 'session-1',
+      status: 'running',
+    })
+
+    await client.chat('session-1', 'hello', undefined, undefined, 'default', {
+      background_delegation_enabled: false,
+    })
+    await client.chat('session-2', 'hello')
+    await client.contextEstimate('session-3', [], undefined, 'default', {
+      background_delegation_enabled: false,
+    })
+
+    expect(request.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      action: 'chat',
+      background_delegation_enabled: false,
+    }))
+    expect(request.mock.calls[1]?.[0]).not.toHaveProperty('background_delegation_enabled')
+    expect(request.mock.calls[2]?.[0]).toEqual(expect.objectContaining({
+      action: 'context_estimate',
+      background_delegation_enabled: false,
+    }))
+  })
+
   it('forwards recovery routes and delivery acknowledgements', async () => {
     const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
     const client = new AgentBridgeClient({ endpoint: 'tcp://127.0.0.1:1', connectRetryMs: 0, timeoutMs: 1 })

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -406,6 +406,13 @@ class InterruptibleAgent:
 pool, _fake_db = make_pool()
 session = bridge.AgentSession(session_id="session-1", agent=InterruptibleAgent())
 pool._sessions[session.session_id] = session
+pool._append_event(session.session_id, {
+    "event": "subagent.start",
+    "subagent_id": "child-current",
+    "task_index": 0,
+    "task_count": 1,
+    "goal": "background work",
+})
 
 result = pool.interrupt("session-1", "Aborted by user")
 
@@ -423,6 +430,12 @@ assert calls == [{
     "reason": "user_interrupt",
 }, {"parent_message": "Aborted by user"}]
 assert pool._suppressed_background_delegations == {"deleg-current"}
+polled = pool.poll_background()
+assert polled["sessions"][0]["tasks"][0]["status"] == "interrupted"
+assert [event["event"] for event in polled["sessions"][0]["events"]] == [
+    "subagent.start", "subagent.complete"
+]
+assert polled["sessions"][0]["events"][-1]["status"] == "interrupted"
 `)
   })
 

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -212,6 +212,220 @@ def wait_for(condition, timeout=20):
 `
 
 describe('agent bridge Python session concurrency', () => {
+  it('buffers subagent events after the parent run has ended', () => {
+    runPython(String.raw`
+${harness}
+
+pool, _fake_db = make_pool()
+session = bridge.AgentSession(session_id="background-session", agent=object())
+record = bridge.RunRecord(run_id="parent-run", session_id=session.session_id)
+session.current_run_id = record.run_id
+with pool._lock:
+    pool._sessions[session.session_id] = session
+    pool._runs[record.run_id] = record
+
+pool._append_event(session.session_id, {
+    "event": "subagent.start",
+    "subagent_id": "child-1",
+    "goal": "inspect the repository",
+})
+assert len(record.events) == 1
+assert session.background_events == []
+assert session.background_tasks["child-1"]["status"] == "running"
+
+session.current_run_id = None
+pool._append_event(session.session_id, {
+    "event": "subagent.text",
+    "subagent_id": "child-1",
+    "text": "found the relevant file",
+})
+pool._append_event(session.session_id, {
+    "event": "subagent.complete",
+    "subagent_id": "child-1",
+    "status": "completed",
+    "summary": "done",
+})
+
+polled = pool.poll_background()
+assert [event["event"] for event in polled["sessions"][0]["events"]] == [
+    "subagent.text", "subagent.complete"
+]
+assert polled["sessions"][0]["tasks"][0]["status"] == "completed"
+assert pool.poll_background()["sessions"] == []
+`)
+  })
+
+  it('requeues a released durable background completion claim', () => {
+    runPython(String.raw`
+${harness}
+
+import queue
+
+process_registry_module = types.ModuleType("tools.process_registry")
+process_registry_module.process_registry = types.SimpleNamespace(completion_queue=queue.Queue())
+process_registry_module.format_process_notification = lambda event: "background result ready"
+sys.modules["tools.process_registry"] = process_registry_module
+
+async_module = types.ModuleType("tools.async_delegation")
+async_module.claim_event_delivery = lambda event, consumer: "claim-1"
+async_module.release_completion_delivery = lambda delegation_id, claim_id: True
+async_module.complete_completion_delivery = lambda delegation_id, claim_id: True
+sys.modules["tools.async_delegation"] = async_module
+
+pool, _fake_db = make_pool()
+event = {
+    "type": "async_delegation",
+    "delegation_id": "deleg-1",
+    "session_key": "session-1",
+    "parent_session_id": "session-1",
+    "status": "completed",
+}
+process_registry_module.process_registry.completion_queue.put(event)
+
+polled = pool.poll_background(["session-1"])
+assert polled["notifications"][0]["claim_id"] == "claim-1"
+assert process_registry_module.process_registry.completion_queue.empty()
+
+released = pool.release_background_notification("deleg-1", "claim-1")
+assert released["released"] is True
+assert process_registry_module.process_registry.completion_queue.get_nowait() == event
+`)
+  })
+
+  it('acknowledges a user-cancelled delegation completion without starting a new parent turn', () => {
+    runPython(String.raw`
+${harness}
+
+import queue
+
+completed = []
+process_registry_module = types.ModuleType("tools.process_registry")
+process_registry_module.process_registry = types.SimpleNamespace(completion_queue=queue.Queue())
+process_registry_module.format_process_notification = lambda event: "should not be delivered"
+sys.modules["tools.process_registry"] = process_registry_module
+
+async_module = types.ModuleType("tools.async_delegation")
+async_module.claim_event_delivery = lambda event, consumer: "claim-interrupted"
+async_module.complete_completion_delivery = lambda delegation_id, claim_id: completed.append(
+    (delegation_id, claim_id)
+) or True
+sys.modules["tools.async_delegation"] = async_module
+
+pool, _fake_db = make_pool()
+pool._suppressed_background_delegations.add("deleg-interrupted")
+process_registry_module.process_registry.completion_queue.put({
+    "type": "async_delegation",
+    "delegation_id": "deleg-interrupted",
+    "session_key": "session-1",
+    "parent_session_id": "session-1",
+    "status": "completed",
+})
+
+polled = pool.poll_background(["session-1"])
+
+assert polled["notifications"] == []
+assert process_registry_module.process_registry.completion_queue.empty()
+assert completed == [("deleg-interrupted", "claim-interrupted")]
+assert pool._suppressed_background_delegations == set()
+`)
+  })
+
+  it('interrupts background work and releases claims during worker shutdown', () => {
+    runPython(String.raw`
+${harness}
+
+calls = []
+
+async_module = types.ModuleType("tools.async_delegation")
+async_module.interrupt_all = lambda reason: calls.append(("interrupt_all", reason)) or 1
+async_module.active_count = lambda: 0
+async_module.release_completion_delivery = lambda delegation_id, claim_id: calls.append(
+    ("release", delegation_id, claim_id)
+) or True
+sys.modules["tools.async_delegation"] = async_module
+
+process_registry_module = types.ModuleType("tools.process_registry")
+process_registry_module.process_registry = types.SimpleNamespace(
+    kill_all=lambda: calls.append(("kill_all",)) or 2,
+)
+sys.modules["tools.process_registry"] = process_registry_module
+
+class InterruptibleAgent:
+    def interrupt(self, message):
+        calls.append(("session_interrupt", message))
+
+pool, _fake_db = make_pool()
+session = bridge.AgentSession(session_id="session-1", agent=InterruptibleAgent())
+session.running = True
+pool._sessions[session.session_id] = session
+pool._background_notification_claims[("deleg-1", "claim-1")] = {"type": "async_delegation"}
+
+result = pool.shutdown()
+
+assert result == {
+    "interrupted_sessions": 1,
+    "interrupted_delegations": 1,
+    "killed_processes": 2,
+    "released_claims": 1,
+}
+assert calls == [
+    ("session_interrupt", "Agent bridge shutting down"),
+    ("interrupt_all", "agent_bridge_shutdown"),
+    ("kill_all",),
+    ("release", "deleg-1", "claim-1"),
+]
+assert pool._background_notification_claims == {}
+`)
+  })
+
+  it('interrupts only the current session background delegations on user stop', () => {
+    runPython(String.raw`
+${harness}
+
+calls = []
+async_module = types.ModuleType("tools.async_delegation")
+async_module.interrupt_for_session = lambda **kwargs: calls.append(kwargs) or 2
+async_module.list_async_delegations = lambda: [
+    {
+        "delegation_id": "deleg-current",
+        "status": "running",
+        "session_key": "session-1",
+    },
+    {
+        "delegation_id": "deleg-other",
+        "status": "running",
+        "session_key": "session-2",
+    },
+]
+sys.modules["tools.async_delegation"] = async_module
+
+class InterruptibleAgent:
+    def interrupt(self, message):
+        calls.append({"parent_message": message})
+
+pool, _fake_db = make_pool()
+session = bridge.AgentSession(session_id="session-1", agent=InterruptibleAgent())
+pool._sessions[session.session_id] = session
+
+result = pool.interrupt("session-1", "Aborted by user")
+
+assert result == {
+    "status": "interrupted",
+    "session_id": "session-1",
+    "synced": True,
+    "background_interrupted": 2,
+    "background_delegation_ids": ["deleg-current"],
+}
+assert calls == [{
+    "session_key": "session-1",
+    "origin_ui_session_id": "session-1",
+    "parent_session_id": "session-1",
+    "reason": "user_interrupt",
+}, {"parent_message": "Aborted by user"}]
+assert pool._suppressed_background_delegations == {"deleg-current"}
+`)
+  })
+
   it('hot-switches a loaded idle session model without recreating the session', () => {
     runPython(String.raw`
 ${harness}
@@ -1333,7 +1547,7 @@ assert events == [
 `)
   })
 
-  it('shuts down MCP servers before worker shutdown exits', () => {
+  it('cleans worker background state and MCP servers before shutdown exits', () => {
     runPython(String.raw`
 ${harness}
 
@@ -1347,7 +1561,16 @@ class FakeBridgeServer(bridge.BridgeServer):
 server = FakeBridgeServer("tcp://127.0.0.1:1")
 response = server.handle({"action": "shutdown"})
 
-assert response == {"status": "shutting_down"}, response
+assert response == {
+    "status": "shutting_down",
+    "cleanup": {
+        "interrupted_sessions": 0,
+        "interrupted_delegations": 0,
+        "killed_processes": 0,
+        "released_claims": 0,
+        "mcp_servers": 2,
+    },
+}, response
 assert events == ["mcp-shutdown"], events
 assert server._stop.is_set(), "shutdown should stop worker after MCP shutdown"
 `)

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -212,6 +212,129 @@ def wait_for(condition, timeout=20):
 `
 
 describe('agent bridge Python session concurrency', () => {
+  it('binds Agent-session background delivery capability across runtime context versions', () => {
+    runPython(String.raw`
+${harness}
+
+gateway_pkg = types.ModuleType("gateway")
+gateway_pkg.__path__ = []
+sys.modules["gateway"] = gateway_pkg
+
+session_context = types.ModuleType("gateway.session_context")
+captured = []
+
+def modern_set_session_vars(
+    platform="",
+    source="",
+    session_key="",
+    session_id="",
+    profile="",
+    cwd="",
+    async_delivery=True,
+):
+    captured.append({
+        "platform": platform,
+        "source": source,
+        "session_key": session_key,
+        "session_id": session_id,
+        "profile": profile,
+        "cwd": cwd,
+        "async_delivery": async_delivery,
+    })
+    return ["modern-token"]
+
+session_context.set_session_vars = modern_set_session_vars
+sys.modules["gateway.session_context"] = session_context
+
+tokens = bridge._set_bridge_session_vars(
+    "session-modern",
+    "profile-modern",
+    "/tmp/workspace-modern",
+    False,
+)
+assert tokens == ["modern-token"]
+assert captured[-1] == {
+    "platform": "agent_bridge",
+    "source": "tui",
+    "session_key": "session-modern",
+    "session_id": "session-modern",
+    "profile": "profile-modern",
+    "cwd": "/tmp/workspace-modern",
+    "async_delivery": False,
+}
+
+def legacy_set_session_vars(
+    platform="",
+    chat_id="",
+    chat_name="",
+    thread_id="",
+    user_id="",
+    user_name="",
+    session_key="",
+    message_id="",
+):
+    captured.append({"platform": platform, "session_key": session_key})
+    return ["legacy-token"]
+
+session_context.set_session_vars = legacy_set_session_vars
+tokens = bridge._set_bridge_session_vars(
+    "session-legacy",
+    "profile-legacy",
+    "C:/workspace-legacy",
+    True,
+)
+assert tokens == ["legacy-token"]
+assert captured[-1] == {
+    "platform": "agent_bridge",
+    "session_key": "session-legacy",
+}
+`)
+  })
+
+  it('forwards Agent creation policy from chat and context-estimate requests', () => {
+    runPython(String.raw`
+${harness}
+
+captured = []
+
+class FakePool:
+    def start_chat(self, *args):
+        captured.append(args)
+        return bridge.RunRecord(run_id=f"run-{len(captured)}", session_id=args[0])
+
+    def estimate_context(self, *args, **kwargs):
+        captured.append(kwargs)
+        return {"session_id": args[0]}
+
+server = object.__new__(bridge.BridgeServer)
+server.pool = FakePool()
+
+disabled = server.handle({
+    "action": "chat",
+    "session_id": "session-disabled",
+    "message": "hello",
+    "background_delegation_enabled": False,
+})
+enabled = server.handle({
+    "action": "chat",
+    "session_id": "session-default",
+    "message": "hello",
+})
+estimated = server.handle({
+    "action": "context_estimate",
+    "session_id": "session-estimate-disabled",
+    "background_delegation_enabled": False,
+})
+
+assert disabled["status"] == "running"
+assert enabled["status"] == "running"
+assert captured[0][-1] is False
+assert captured[1][-1] is None
+assert estimated["session_id"] == "session-estimate-disabled"
+assert captured[2]["background_delegation_enabled"] is False
+`)
+  })
+
   it('buffers subagent events after the parent run has ended', () => {
     runPython(String.raw`
 ${harness}

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -12,6 +12,8 @@ const getSessionMock = vi.hoisted(() => vi.fn((sessionId?: string) => sessionId
 const bridgeMock = vi.hoisted(() => ({
   status: vi.fn(),
   statusIfLoaded: vi.fn(),
+  releaseBackgroundNotification: vi.fn(async () => ({ ok: true, released: true })),
+  close: vi.fn(async () => {}),
 }))
 
 vi.mock('../../packages/server/src/services/hermes/run-chat/handle-bridge-run', () => ({
@@ -107,6 +109,10 @@ describe('ensureBridgeReadyForChatRun', () => {
     getRuntimeStateMock.mockReset()
     bridgeMock.status.mockReset()
     bridgeMock.statusIfLoaded.mockReset()
+    bridgeMock.releaseBackgroundNotification.mockReset()
+    bridgeMock.close.mockReset()
+    bridgeMock.releaseBackgroundNotification.mockResolvedValue({ ok: true, released: true })
+    bridgeMock.close.mockResolvedValue(undefined)
     handleBridgeRunMock.mockReset()
     resumeBridgeRunMock.mockReset()
     handleCodingAgentRunMock.mockReset()
@@ -178,6 +184,10 @@ describe('ChatRunSocket bridge readiness gating', () => {
     getRuntimeStateMock.mockReset()
     bridgeMock.status.mockReset()
     bridgeMock.statusIfLoaded.mockReset()
+    bridgeMock.releaseBackgroundNotification.mockReset()
+    bridgeMock.close.mockReset()
+    bridgeMock.releaseBackgroundNotification.mockResolvedValue({ ok: true, released: true })
+    bridgeMock.close.mockResolvedValue(undefined)
     handleBridgeRunMock.mockReset()
     resumeBridgeRunMock.mockReset()
     handleCodingAgentRunMock.mockReset()
@@ -617,5 +627,46 @@ describe('ChatRunSocket bridge readiness gating', () => {
       isWorking: false,
       events: [],
     }))
+  })
+
+  it('releases queued background completion claims before closing bridge clients', async () => {
+    const order: string[] = []
+    bridgeMock.releaseBackgroundNotification.mockImplementationOnce(async () => {
+      order.push('release')
+      return { ok: true, released: true }
+    })
+    bridgeMock.close.mockImplementation(async () => {
+      order.push('close')
+    })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    ;(server as any).sessionMap.set('session-1', {
+      messages: [],
+      isWorking: true,
+      isAborting: false,
+      events: [],
+      queue: [{
+        queue_id: 'delegation-d1',
+        input: 'completion',
+        profile: 'default',
+        source: 'cli',
+        backgroundDelegationId: 'd1',
+        backgroundClaimId: 'claim-1',
+      }],
+    })
+
+    await server.close()
+
+    expect(bridgeMock.releaseBackgroundNotification).toHaveBeenCalledWith(
+      'session-1',
+      'default',
+      'd1',
+      'claim-1',
+    )
+    expect(order[0]).toBe('release')
+    expect(order.slice(1)).toEqual(['close', 'close'])
+    expect((server as any).sessionMap.size).toBe(0)
+    expect((server as any).closing).toBe(true)
   })
 })

--- a/tests/server/group-chat-agent-workspace.test.ts
+++ b/tests/server/group-chat-agent-workspace.test.ts
@@ -146,6 +146,7 @@ describe('group chat agent workspace bridge runs', () => {
       name: 'Worker',
       description: '',
       invited: 0,
+      backgroundDelegationEnabled: false,
     } as any) as any
     const storage = { getRoom: vi.fn(() => ({ sessionSeed: 'seed-1', workspace: '' })) }
     client.setStorage(storage as any)
@@ -224,6 +225,7 @@ describe('group chat agent workspace bridge runs', () => {
       name: 'Worker',
       description: '',
       invited: 0,
+      backgroundDelegationEnabled: false,
     } as any)
     const storage = {
       getRoom: vi.fn(() => ({ sessionSeed: 'seed-1', workspace })),
@@ -256,8 +258,12 @@ describe('group chat agent workspace bridge runs', () => {
       expect.any(Array),
       expect.any(String),
       'default',
-      expect.not.objectContaining({ workspace: expect.anything(), run_id: expect.anything() }),
+      expect.objectContaining({
+        background_delegation_enabled: false,
+      }),
     )
+    expect(bridgeMock.chat.mock.calls[0]?.[5]).not.toHaveProperty('workspace')
+    expect(bridgeMock.chat.mock.calls[0]?.[5]).not.toHaveProperty('run_id')
   })
 
   it('cancels a pending reply when interrupt arrives before bridge.chat starts', async () => {

--- a/tests/server/run-chat-abort-goal.test.ts
+++ b/tests/server/run-chat-abort-goal.test.ts
@@ -79,7 +79,11 @@ describe('run chat abort goal handling', () => {
     } as any
     const sessionMap = new Map([['session-1', state]])
     const bridge = {
-      interrupt: vi.fn().mockResolvedValue({ ok: true }),
+      interrupt: vi.fn().mockResolvedValue({
+        ok: true,
+        background_interrupted: 1,
+        background_delegation_ids: ['deleg-1'],
+      }),
       goalPause: vi.fn().mockResolvedValue({ handled: true, status: 'paused', reason: 'user-interrupted' }),
     }
     const runQueuedItem = vi.fn()
@@ -92,6 +96,18 @@ describe('run chat abort goal handling', () => {
       queue_id: 'user-1',
     }), 'default')
     expect(state.queue).toEqual([])
+    expect(state.backgroundDelegations).toEqual({
+      'deleg-1': expect.objectContaining({
+        delegationId: 'deleg-1',
+        status: 'interrupted',
+      }),
+    })
+    expect(emit).toHaveBeenCalledWith('delegation.updated', expect.objectContaining({
+      session_id: 'session-1',
+      delegation_id: 'deleg-1',
+      status: 'interrupted',
+      delivery_status: 'cancelled',
+    }))
     expect(emit).toHaveBeenCalledWith('abort.completed', expect.objectContaining({
       session_id: 'session-1',
       synced: true,

--- a/tests/server/run-chat-abort-goal.test.ts
+++ b/tests/server/run-chat-abort-goal.test.ts
@@ -76,6 +76,22 @@ describe('run chat abort goal handling', () => {
       runId: 'run-1',
       profile: 'default',
       source: 'cli',
+      backgroundTasks: {
+        'child-1': {
+          subagent_id: 'child-1',
+          status: 'running',
+          task_index: 0,
+          task_count: 2,
+          goal: 'First task',
+        },
+        'child-2': {
+          subagent_id: 'child-2',
+          status: 'completed',
+          task_index: 1,
+          task_count: 2,
+          goal: 'Second task',
+        },
+      },
     } as any
     const sessionMap = new Map([['session-1', state]])
     const bridge = {
@@ -107,6 +123,16 @@ describe('run chat abort goal handling', () => {
       delegation_id: 'deleg-1',
       status: 'interrupted',
       delivery_status: 'cancelled',
+    }))
+    expect(state.backgroundTasks['child-1']).toEqual(expect.objectContaining({
+      status: 'interrupted',
+      last_event: 'subagent.complete',
+    }))
+    expect(state.backgroundTasks['child-2'].status).toBe('completed')
+    expect(emit).toHaveBeenCalledWith('subagent.complete', expect.objectContaining({
+      session_id: 'session-1',
+      subagent_id: 'child-1',
+      status: 'interrupted',
     }))
     expect(emit).toHaveBeenCalledWith('abort.completed', expect.objectContaining({
       session_id: 'session-1',

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -295,6 +295,14 @@ describe('bridge run final context usage', () => {
         workspace: '/tmp/hermes-bridge-final-context/default/workspace',
       },
     )
+    expect(bridge.chat).toHaveBeenCalledWith(
+      'session-1',
+      'hello',
+      expect.any(Array),
+      expect.any(String),
+      'default',
+      expect.objectContaining({ background_delegation_enabled: false }),
+    )
     expect(bridge.contextEstimate.mock.calls[0][2]).toContain('system prompt')
     expect(bridge.contextEstimate.mock.calls[0][2]).toContain('X-Hermes-Profile')
     expect(bridge.contextEstimate.mock.calls[0][2]).not.toContain('Current working directory')
@@ -695,6 +703,7 @@ describe('bridge run final context usage', () => {
         session_id: 'workflow-session',
         source: 'workflow',
         workspace: '/tmp/hermes-workflow-workspace',
+        background_delegation_enabled: false,
       },
       'default',
       sessionMap,
@@ -715,7 +724,10 @@ describe('bridge run final context usage', () => {
       expect.any(Array),
       expect.any(String),
       'default',
-      expect.objectContaining({ workspace: '/tmp/hermes-workflow-workspace' }),
+      expect.objectContaining({
+        workspace: '/tmp/hermes-workflow-workspace',
+        background_delegation_enabled: false,
+      }),
     )
     expect(state.source).toBe('workflow')
   })

--- a/tests/server/shutdown-background-order.test.ts
+++ b/tests/server/shutdown-background-order.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const closeDbMock = vi.hoisted(() => vi.fn())
+const stopPreviewRuntimeMock = vi.hoisted(() => vi.fn(async () => {}))
+const shutdownManagedGatewaysMock = vi.hoisted(() => vi.fn(async () => ({ stopped: 0 })))
+const stopOutboundRelayClientMock = vi.hoisted(() => vi.fn())
+const codingAgentShutdownMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../packages/server/src/db', () => ({ closeDb: closeDbMock }))
+vi.mock('../../packages/server/src/controllers/update', () => ({ stopPreviewRuntime: stopPreviewRuntimeMock }))
+vi.mock('../../packages/server/src/services/hermes/gateway-runner', () => ({
+  shutdownManagedGateways: shutdownManagedGatewaysMock,
+}))
+vi.mock('../../packages/server/src/services/global-agent/outbound-relay-client', () => ({
+  stopOutboundRelayClient: stopOutboundRelayClientMock,
+}))
+vi.mock('../../packages/server/src/services/agent-runner/coding-agent-run-manager', () => ({
+  codingAgentRunManager: { shutdown: codingAgentShutdownMock },
+}))
+vi.mock('../../packages/server/src/services/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+describe('graceful shutdown background delivery ordering', () => {
+  const originalStopBridge = process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN = '1'
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    if (originalStopBridge === undefined) delete process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN
+    else process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN = originalStopBridge
+  })
+
+  it('awaits ChatRunSocket claim release before stopping the Hermes bridge', async () => {
+    const order: string[] = []
+    const chatRunServer = {
+      close: vi.fn(async () => {
+        order.push('chat-run-close')
+      }),
+    }
+    const agentBridgeManager = {
+      stop: vi.fn(async () => {
+        order.push('bridge-stop')
+      }),
+    }
+    const groupChatServer = {
+      agentClients: { disconnectAll: vi.fn(() => order.push('agent-clients-close')) },
+      getIO: vi.fn(() => ({ close: vi.fn(() => order.push('socket-io-close')) })),
+    }
+    const httpServer = {
+      close: vi.fn((callback: () => void) => {
+        order.push('http-close')
+        callback()
+      }),
+    }
+    vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+    const { createShutdownHandler } = await import('../../packages/server/src/services/shutdown')
+
+    await createShutdownHandler(httpServer, groupChatServer, chatRunServer, agentBridgeManager)('desktop-request')
+
+    expect(order).toEqual([
+      'chat-run-close',
+      'bridge-stop',
+      'agent-clients-close',
+      'socket-io-close',
+      'http-close',
+    ])
+    expect(closeDbMock).toHaveBeenCalledOnce()
+    expect(process.exit).toHaveBeenCalledWith(0)
+  })
+})

--- a/tests/server/workflow-manager.test.ts
+++ b/tests/server/workflow-manager.test.ts
@@ -210,6 +210,7 @@ describe('workflow manager', () => {
       expect(result.run.snapshot_nodes[0]?.data).not.toHaveProperty('executionPolicy')
       expect(chatRunMock.runAndWait).toHaveBeenCalledWith(expect.objectContaining({
         provider: 'custom:test', model: 'model-a', one_shot_model: true, reasoning_effort: 'high',
+        background_delegation_enabled: false,
       }), expect.any(Object))
       expect(chatRunMock.runAndWait.mock.calls[0]?.[0]).not.toHaveProperty('apiMode')
       expect(chatRunMock.runAndWait.mock.calls[0]?.[0]).not.toHaveProperty('execution_policy')
@@ -236,6 +237,7 @@ describe('workflow manager', () => {
       expect(chatRunMock.runAndWait).toHaveBeenCalledWith(expect.objectContaining({
         coding_agent_id: 'codex', apiMode: 'chat_completions',
       }), expect.any(Object))
+      expect(chatRunMock.runAndWait.mock.calls[0]?.[0]).not.toHaveProperty('background_delegation_enabled')
     } finally { await manager.delete(workflow.id) }
   })
 


### PR DESCRIPTION
## Summary
- keep background Hermes delegate-task telemetry available after the parent turn ends and recover pending durable completion delivery after restart
- scope Stop and shutdown cleanup to the correct Hermes sessions, release delivery claims safely, and keep child tool traffic out of parent context
- show each real subagent once in a resizable chat-style live output panel, without lifecycle placeholder cards or system-status bubbles
- persist and emit interrupted child terminal states so Stop settles every running subagent card instead of leaving a permanent loading indicator
- treat `background_delegation_enabled` as a cached Hermes AgentSession creation policy: ordinary single chat is currently disabled, while group chat and Hermes workflow nodes are permanently disabled at their own call sites
- keep synchronous `delegate_task` available and leave Coding Agent and Ekko Agent execution paths unchanged
- filter Hermes session-context arguments by the installed Runtime signature so bundled 0.18.0 and pip 0.18.2 remain compatible

The loading bug occurred because `abort.completed` finalized the parent run and ordinary tool rows, but subagent cards use separate stream state and were intentionally excluded from ordinary tool cleanup. The worker and Node runtime now emit exact interrupted child terminal events, while the client also settles any still-running child as an abort-completion fallback and ignores late non-terminal output after a terminal state.

Background delegation policy is selected when the Bridge creates its cached `AgentSession`, not as mutable UI state on every chat turn. Hermes currently exposes the behavior through session-level `async_delivery`; setting it to false makes `delegate_task(background=true)` fall back to synchronous execution.

Closes #2048

## Validation
- `npm run harness:check`
- focused Vitest: 190 passed
- `npm run test:coverage`
- `npm run test:e2e` (56 passed)
- `npm run build`
- Python bridge `py_compile`

## Release
- No release or installer publishing is included.
