### PR TITLE
fix(chat): attach workspace diffs to assistant turns

### DIFF
--- a/docs/chat-chain-changes/2026-07-18-session-workspace-diff-turn-attribution.md
+++ b/docs/chat-chain-changes/2026-07-18-session-workspace-diff-turn-attribution.md
@@ -1,0 +1,11 @@
+---
+date: 2026-07-18
+issue: "#2079"
+pr: 2127
+feature: Session workspace diff turn attribution
+impact: Workspace changes persist their exact Assistant-message association so live and reloaded sessions render each diff under the response that produced it.
+---
+
+Session-scoped legacy workspace paths are normalized without changing generic file APIs. Run checkpoints suppress zero-line noise, repair historical parent aggregates idempotently, and retain a standalone fallback only for legacy change records that have no persisted Assistant association.
+
+The server records the database Assistant message ID with each workspace change. The live chat aligns its temporary Assistant ID to that persisted ID, and history reloads attach the same change records to the exact Assistant turn.

--- a/docs/chat-chain-changes/2026-07-18-session-workspace-diff-turn-attribution.md
+++ b/docs/chat-chain-changes/2026-07-18-session-workspace-diff-turn-attribution.md
@@ -8,4 +8,4 @@ impact: Workspace changes persist their exact Assistant-message association so l
 
 Session-scoped legacy workspace paths are normalized without changing generic file APIs. Run checkpoints suppress zero-line noise, repair historical parent aggregates idempotently, and retain a standalone fallback only for legacy change records that have no persisted Assistant association.
 
-The server records the database Assistant message ID with each workspace change. The live chat aligns its temporary Assistant ID to that persisted ID, and history reloads attach the same change records to the exact Assistant turn.
+The server records the database Assistant message ID with each workspace change and rebinds the matching in-memory message to that ID before it can be returned by session resume. The live chat aligns its temporary Assistant ID to the same persisted ID, and history reloads attach the change records to the exact Assistant turn. Group chat retains its durable workspace-diff audit message while using the persisted parent Assistant message ID to render that diff inside the exact Agent reply for live and reloaded rooms.

--- a/packages/client/src/api/hermes/group-chat.ts
+++ b/packages/client/src/api/hermes/group-chat.ts
@@ -57,8 +57,39 @@ export interface ChatMessage {
     toolPreview?: string
     toolResult?: unknown
     toolStatus?: 'running' | 'done' | 'error'
+    workspaceChanges?: GroupWorkspaceDiffPayload[]
     firstSeenAt?: number
     attachments?: Array<{ id: string; name: string; type: string; size: number; url: string }>
+}
+
+export interface GroupWorkspaceDiffFile {
+    id: string | number
+    path: string
+    change_type?: 'added' | 'modified' | 'deleted' | 'renamed'
+    additions: number
+    deletions: number
+    patch?: string | null
+    binary?: boolean
+    truncated?: boolean
+}
+
+export interface GroupWorkspaceDiffPayload {
+    kind: 'workspace_diff'
+    version: number
+    room_id: string
+    session_id: string
+    run_id: string
+    status: 'completed' | 'failed' | 'aborted'
+    change_id: string
+    workspace_basename: string
+    workspace?: string
+    workspace_root?: string
+    files_changed: number
+    additions: number
+    deletions: number
+    truncated: boolean
+    files: GroupWorkspaceDiffFile[]
+    parent_message_id?: string
 }
 
 export interface MemberInfo {

--- a/packages/client/src/api/hermes/sessions.ts
+++ b/packages/client/src/api/hermes/sessions.ts
@@ -133,6 +133,9 @@ export interface WorkspaceRunChangeFileDetail extends WorkspaceRunChangeFileSumm
 
 export interface WorkspaceRunChangeSummary {
   change_id: string
+  room_id?: string
+  message_id?: string
+  assistant_message_id?: string
   session_id: string
   run_id: string
   source: 'run'

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -30,6 +30,7 @@ import { useVoiceSettings } from "@/composables/useVoiceSettings";
 import { speedToEdgeRate, hzToEdgePitch } from "@/utils/ttsHelpers";
 import { formatChatTimestamp } from "@/utils/chat-timestamp";
 import { openSubagentStream, subagentIdFromToolCall } from "@/utils/hermes/subagent-stream";
+import type { WorkspaceRunChangeSummary } from "@/api/hermes/sessions";
 
 const MarkdownRenderer = defineAsyncComponent(async () => (await import("./MarkdownRenderer.vue")).default);
 
@@ -197,6 +198,7 @@ function getContentFileUrl(file: DisplayContentFile): string {
 }
 
 const toolExpanded = ref(false);
+const expandedWorkspaceChangeIds = ref(new Set<string>());
 const previewUrl = ref<string | null>(null);
 const selectedToolChangeFileId = ref<number | null>(null);
 
@@ -589,7 +591,19 @@ const hasAttachments = computed(
 const toolArgsPayload = computed(() => formatToolPayload(props.message.toolArgs));
 const toolResultPayload = computed(() => formatToolPayload(props.message.toolResult, true));
 const toolChange = computed(() => props.message.toolChange || null);
+const workspaceChanges = computed(() => props.message.workspaceChanges || []);
 const hasToolChange = computed(() => (toolChange.value?.files?.length || 0) > 0);
+
+function isWorkspaceChangeExpanded(changeId: string): boolean {
+  return expandedWorkspaceChangeIds.value.has(changeId);
+}
+
+function toggleWorkspaceChange(changeId: string): void {
+  const next = new Set(expandedWorkspaceChangeIds.value);
+  if (next.has(changeId)) next.delete(changeId);
+  else next.add(changeId);
+  expandedWorkspaceChangeIds.value = next;
+}
 
 const hasToolDetails = computed(
   () => !!(toolArgsPayload.value.full || toolResultPayload.value.full || hasToolChange.value),
@@ -632,6 +646,17 @@ async function openToolChangeFile(file: { id: string | number; path: string; add
   selectedToolChangeFileId.value = storedFile.id;
   filesStore.closePreview();
   await toolPanelStore.openWorkspaceDiff(storedFile, toolChange.value?.workspace || "");
+}
+
+async function openAssistantWorkspaceChangeFile(
+  file: { id: string | number; path: string; additions: number; deletions: number },
+  change: WorkspaceRunChangeSummary,
+): Promise<void> {
+  const storedFile = change.files.find(candidate => String(candidate.id) === String(file.id));
+  if (!storedFile) return;
+  selectedToolChangeFileId.value = storedFile.id;
+  filesStore.closePreview();
+  await toolPanelStore.openWorkspaceDiff(storedFile, change.workspace || "");
 }
 
 // 语音播放相关
@@ -1077,6 +1102,21 @@ onBeforeUnmount(() => {
               v-if="message.role === 'assistant' && message.content && !parsedThinking.body"
               :content="message.content"
               :heading-id-prefix="effectiveHeadingIdPrefix"
+            />
+
+            <ToolChangeCard
+              v-for="change in workspaceChanges"
+              :key="change.change_id"
+              class="assistant-workspace-change"
+              :files="change.files || []"
+              :files-changed="change.files_changed || 0"
+              :additions="change.additions || 0"
+              :deletions="change.deletions || 0"
+              :expanded="isWorkspaceChangeExpanded(change.change_id)"
+              :selected-file-id="selectedToolChangeFileId"
+              :title="t('chat.changesThisTurn')"
+              @toggle="toggleWorkspaceChange(change.change_id)"
+              @select="file => openAssistantWorkspaceChangeFile(file, change)"
             />
 
             <!-- Render system message content -->
@@ -1765,6 +1805,10 @@ onBeforeUnmount(() => {
 .tool-change-loading {
   color: $text-muted;
   font-size: 11px;
+}
+
+.assistant-workspace-change {
+  margin-top: 10px;
 }
 
 @keyframes spin {

--- a/packages/client/src/components/hermes/chat/ToolChangeCard.vue
+++ b/packages/client/src/components/hermes/chat/ToolChangeCard.vue
@@ -15,12 +15,14 @@ const props = withDefaults(defineProps<{
   deletions?: number
   expanded?: boolean
   selectedFileId?: string | number | null
+  title?: string
 }>(), {
   filesChanged: 0,
   additions: 0,
   deletions: 0,
   expanded: false,
   selectedFileId: null,
+  title: '',
 })
 
 const emit = defineEmits<{
@@ -79,6 +81,9 @@ function fileBadgeClass(path: string): string {
         <polyline points="9 18 15 12 9 6" />
       </svg>
       <span class="tool-change-card-title">
+        {{ props.title || t('chat.changedFiles', { files: props.filesChanged || props.files.length }) }}
+      </span>
+      <span v-if="props.title" class="tool-change-card-file-count">
         {{ t('chat.changedFiles', { files: props.filesChanged || props.files.length }) }}
       </span>
       <span class="tool-change-card-stats">
@@ -165,6 +170,11 @@ function fileBadgeClass(path: string): string {
 .tool-change-card-title {
   font-size: 13px;
   font-weight: 700;
+}
+
+.tool-change-card-file-count {
+  color: $text-muted;
+  font-size: 12px;
 }
 
 .tool-change-card-stats,

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -17,7 +17,7 @@ import { useVoiceSettings } from '@/composables/useVoiceSettings'
 import { speedToEdgeRate, hzToEdgePitch } from '@/utils/ttsHelpers'
 import { getDownloadUrl } from '@/api/hermes/download'
 import { formatChatTimestamp } from '@/utils/chat-timestamp'
-import type { ChatMessage, RoomAgent, MemberInfo } from '@/api/hermes/group-chat'
+import type { ChatMessage, GroupWorkspaceDiffFile, GroupWorkspaceDiffPayload, RoomAgent, MemberInfo } from '@/api/hermes/group-chat'
 import { useGroupChatStore } from '@/stores/hermes/group-chat'
 import { formatReferencedContentForDisplay, parseMessageReference } from '@/stores/hermes/chat'
 import { isPreviewableFile } from '@/utils/hermes/file-preview'
@@ -34,15 +34,6 @@ const JSON_MAX_NODES = 1000
 const JSON_MAX_KEYS_PER_OBJECT = 50
 const JSON_MAX_ITEMS_PER_ARRAY = 50
 const JSON_TRUNCATED_KEY = '__truncated__'
-
-interface GroupWorkspaceDiffFile {
-    id: string | number
-    path: string
-    additions: number
-    deletions: number
-    binary?: boolean
-    patch?: string | null
-}
 
 const props = defineProps<{
     message: ChatMessage
@@ -215,6 +206,7 @@ const quotableContent = computed(() => {
 })
 
 const toolExpanded = ref(false)
+const expandedWorkspaceChangeIds = ref(new Set<string>())
 const isToolMessage = computed(() => props.message.role === 'tool')
 const workspaceDiffPayload = computed(() => {
     if ((props.message.toolName || props.message.tool_name) !== 'workspace_diff') return null
@@ -232,6 +224,7 @@ const workspaceDiffPayload = computed(() => {
     return null
 })
 const workspaceDiffFiles = computed(() => Array.isArray(workspaceDiffPayload.value?.files) ? workspaceDiffPayload.value.files : [])
+const assistantWorkspaceChanges = computed(() => props.message.workspaceChanges || [])
 const selectedWorkspaceDiffFileId = computed(() => toolPanelStore.workspaceDiff?.file.id ?? null)
 const toolArgsPayload = computed(() => formatToolPayload(props.message.toolArgs))
 const toolResultPayload = computed(() => formatToolPayload(props.message.toolResult, true))
@@ -243,8 +236,18 @@ const formattedToolResult = computed(() => toolResultPayload.value.display)
 const renderedToolArgs = computed(() => formattedToolArgs.value ? renderToolPayload(formattedToolArgs.value, toolArgsPayload.value.language) : '')
 const renderedToolResult = computed(() => formattedToolResult.value ? renderToolPayload(formattedToolResult.value, toolResultPayload.value.language) : '')
 
-function openWorkspaceDiffFile(file: GroupWorkspaceDiffFile): void {
-    const payload = workspaceDiffPayload.value
+function isWorkspaceChangeExpanded(changeId: string): boolean {
+    return expandedWorkspaceChangeIds.value.has(changeId)
+}
+
+function toggleWorkspaceChange(changeId: string): void {
+    const next = new Set(expandedWorkspaceChangeIds.value)
+    if (next.has(changeId)) next.delete(changeId)
+    else next.add(changeId)
+    expandedWorkspaceChangeIds.value = next
+}
+
+function openWorkspaceDiffFileForPayload(file: GroupWorkspaceDiffFile, payload: GroupWorkspaceDiffPayload | null): void {
     if (!payload || !file) return
     filesStore.closePreview()
     toolPanelStore.openInlineWorkspaceDiff({
@@ -254,6 +257,10 @@ function openWorkspaceDiffFile(file: GroupWorkspaceDiffFile): void {
         deletions: Number(file.deletions || 0),
         binary: file.binary === true,
     }, typeof file.patch === 'string' ? file.patch : null, payload.workspace || payload.workspace_root || '')
+}
+
+function openWorkspaceDiffFile(file: GroupWorkspaceDiffFile): void {
+    openWorkspaceDiffFileForPayload(file, workspaceDiffPayload.value)
 }
 const canPlaySpeech = computed(() => {
     if (props.message.role !== 'assistant') return false
@@ -709,6 +716,20 @@ onBeforeUnmount(() => {
                     <MarkdownRenderer v-if="parsedMessageReference.reply" :content="parsedMessageReference.reply" :mention-names="mentionNames" />
                 </template>
                 <MarkdownRenderer v-else-if="displayBody" :content="displayBody" :mention-names="mentionNames" />
+                <ToolChangeCard
+                    v-for="change in assistantWorkspaceChanges"
+                    :key="change.change_id"
+                    class="assistant-workspace-change"
+                    :files="change.files || []"
+                    :files-changed="change.files_changed || 0"
+                    :additions="change.additions || 0"
+                    :deletions="change.deletions || 0"
+                    :expanded="isWorkspaceChangeExpanded(change.change_id)"
+                    :selected-file-id="selectedWorkspaceDiffFileId"
+                    :title="t('chat.changesThisTurn')"
+                    @toggle="toggleWorkspaceChange(change.change_id)"
+                    @select="file => openWorkspaceDiffFileForPayload(file, change)"
+                />
                 <span v-if="message.isStreaming && !displayBody" class="streaming-dots">
                     <span></span><span></span><span></span>
                 </span>
@@ -894,6 +915,10 @@ onBeforeUnmount(() => {
     max-width: 100%;
     min-width: 0;
     width: fit-content;
+}
+
+.assistant-workspace-change {
+    margin-top: 10px;
 }
 
 .tool-detail-section {

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -646,6 +646,7 @@ export default {
     result: 'Ergebnis',
     workspaceChanges: 'Workspace-Änderungen',
     changedFiles: '{files} Dateien geändert',
+    changesThisTurn: 'Änderungen in diesem Durchgang',
     diffUnavailable: 'Diff nicht verfügbar',
     binaryFileDiffUnavailable: 'Diff für Binärdateien nicht verfügbar',
     truncated: '... (abgeschnitten)',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -737,6 +737,7 @@ export default {
     result: 'Result',
     workspaceChanges: 'Workspace changes',
     changedFiles: '{files} files changed',
+    changesThisTurn: 'Changes this turn',
     diffUnavailable: 'Diff unavailable',
     binaryFileDiffUnavailable: 'Binary file diff unavailable',
     truncated: '... (truncated)',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -646,6 +646,7 @@ export default {
     result: 'Resultado',
     workspaceChanges: 'Cambios del workspace',
     changedFiles: '{files} archivos modificados',
+    changesThisTurn: 'Cambios de este turno',
     diffUnavailable: 'Diff no disponible',
     binaryFileDiffUnavailable: 'Diff no disponible para archivos binarios',
     truncated: '... (truncado)',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -646,6 +646,7 @@ export default {
     result: 'Resultat',
     workspaceChanges: 'Modifications du workspace',
     changedFiles: '{files} fichiers modifies',
+    changesThisTurn: 'Modifications de ce tour',
     diffUnavailable: 'Diff indisponible',
     binaryFileDiffUnavailable: 'Diff indisponible pour les fichiers binaires',
     truncated: '... (tronque)',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -646,6 +646,7 @@ export default {
     result: '結果',
     workspaceChanges: 'ワークスペース変更',
     changedFiles: '{files} ファイルを変更',
+    changesThisTurn: 'このターンの変更',
     diffUnavailable: 'diff を表示できません',
     binaryFileDiffUnavailable: 'バイナリファイルの diff は表示できません',
     truncated: '... (省略)',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -646,6 +646,7 @@ export default {
     result: '결과',
     workspaceChanges: '작업공간 변경',
     changedFiles: '{files}개 파일 변경됨',
+    changesThisTurn: '이번 턴의 변경 사항',
     diffUnavailable: 'diff를 표시할 수 없습니다',
     binaryFileDiffUnavailable: '바이너리 파일 diff를 표시할 수 없습니다',
     truncated: '... (잘림)',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -646,6 +646,7 @@ export default {
     result: 'Resultado',
     workspaceChanges: 'Alterações do workspace',
     changedFiles: '{files} arquivos alterados',
+    changesThisTurn: 'Alterações desta rodada',
     diffUnavailable: 'Diff indisponível',
     binaryFileDiffUnavailable: 'Diff indisponível para arquivos binários',
     truncated: '... (truncado)',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -615,6 +615,7 @@ export default {
     result: 'Результат',
     workspaceChanges: 'Изменения workspace',
     changedFiles: 'Изменено файлов: {files}',
+    changesThisTurn: 'Изменения в этом ходе',
     diffUnavailable: 'Diff недоступен',
     binaryFileDiffUnavailable: 'Diff для бинарного файла недоступен',
     truncated: '... (обрезано)',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -726,6 +726,7 @@ export default {
     result: '結果',
     workspaceChanges: '工作區變更',
     changedFiles: '{files} 個檔案已更改',
+    changesThisTurn: '本輪修改',
     diffUnavailable: '無法顯示 diff',
     binaryFileDiffUnavailable: '二進位檔案無法顯示 diff',
     truncated: '... (已截斷)',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -737,6 +737,7 @@ export default {
     result: '结果',
     workspaceChanges: '工作区变更',
     changedFiles: '{files} 个文件已更改',
+    changesThisTurn: '本轮修改',
     diffUnavailable: '无法显示 diff',
     binaryFileDiffUnavailable: '二进制文件无法显示 diff',
     truncated: '... (已截断)',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -70,6 +70,7 @@ export interface Message {
   toolStatus?: 'running' | 'done' | 'error'
   toolDuration?: number  // 工具执行时长（秒）
   toolChange?: WorkspaceRunChangeSummary
+  workspaceChanges?: WorkspaceRunChangeSummary[]
   isStreaming?: boolean
   attachments?: Attachment[]
   // 思考/推理文本。两条来源：
@@ -410,6 +411,48 @@ interface CompressionState {
 
 function uid(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+}
+
+export function alignWorkspaceChangeAssistantMessage(
+  messages: Message[],
+  change: WorkspaceRunChangeSummary | null | undefined,
+  assistantMessageId?: string | null,
+): string | null {
+  const currentAssistantMessageId = String(assistantMessageId || '').trim()
+  const persistedAssistantMessageId = String(change?.assistant_message_id || '').trim()
+  if (!persistedAssistantMessageId) return currentAssistantMessageId || null
+  if (!currentAssistantMessageId || persistedAssistantMessageId === currentAssistantMessageId) {
+    return messages.some(item => item.id === persistedAssistantMessageId)
+      ? persistedAssistantMessageId
+      : currentAssistantMessageId || null
+  }
+  const message = messages.find(item => item.id === currentAssistantMessageId)
+  const idAlreadyLoaded = messages.some(item => item.id === persistedAssistantMessageId)
+  if (message && !idAlreadyLoaded) {
+    message.id = persistedAssistantMessageId
+    return persistedAssistantMessageId
+  }
+  return idAlreadyLoaded ? persistedAssistantMessageId : currentAssistantMessageId
+}
+
+export function attachWorkspaceChangesToExactTurns(
+  messages: Message[],
+  changes: WorkspaceRunChangeSummary[],
+): WorkspaceRunChangeSummary[] {
+  for (const message of messages) message.workspaceChanges = []
+  const assistantById = new Map(
+    messages
+      .filter(message => message.role === 'assistant')
+      .map(message => [message.id, message]),
+  )
+  const fallback: WorkspaceRunChangeSummary[] = []
+  for (const change of changes) {
+    const assistantMessageId = String(change.assistant_message_id || '').trim()
+    const target = assistantMessageId ? assistantById.get(assistantMessageId) : undefined
+    if (target) target.workspaceChanges!.push(change)
+    else fallback.push(change)
+  }
+  return fallback
 }
 
 function isToolOutputError(output: unknown): boolean {
@@ -1176,21 +1219,24 @@ export const useChatStore = defineStore('chat', () => {
     const target = sessions.value.find(session => session.id === sessionId)
     if (!target) return
     const changes = workspaceRunChangesBySession.value.get(sessionId)
-    const runChanges: WorkspaceRunChangeSummary[] = []
+    const existingById = new Map(
+      target.messages
+        .filter(message => message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX))
+        .map(message => [message.id, message]),
+    )
+    target.messages = target.messages.filter(message => !message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX))
     for (const message of target.messages) {
       if (message.role === 'tool' && message.toolCallId) {
         message.toolChange = changes?.get(message.toolCallId)
       }
-      if (message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX)) {
-        const changeId = message.id.slice(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX.length)
-        message.toolChange = changes?.get(changeId)
-      }
     }
-    if (!changes) return
-    for (const change of changes.values()) {
-      if (change?.source === 'run') runChanges.push(change)
+    if (!changes) {
+      for (const message of target.messages) message.workspaceChanges = []
+      return
     }
-    insertWorkspaceRunChangeMessages(target, runChanges)
+    const runChanges = [...changes.values()].filter(change => change?.source === 'run')
+    const legacyChanges = attachWorkspaceChangesToExactTurns(target.messages, runChanges)
+    insertWorkspaceRunChangeMessages(target, legacyChanges, existingById)
   }
 
   function workspaceRunChangeMessageId(changeId: string): string {
@@ -1202,7 +1248,11 @@ export const useChatStore = defineStore('chat', () => {
     return Number.isFinite(seconds) && seconds > 0 ? Math.round(seconds * 1000) : Date.now()
   }
 
-  function insertWorkspaceRunChangeMessages(target: Session, changes: WorkspaceRunChangeSummary[]) {
+  function insertWorkspaceRunChangeMessages(
+    target: Session,
+    changes: WorkspaceRunChangeSummary[],
+    existingById = new Map<string, Message>(),
+  ) {
     const sortedChanges = changes
       .filter(change => change?.change_id && (change.files?.length > 0))
       .sort((a, b) => {
@@ -1210,12 +1260,6 @@ export const useChatStore = defineStore('chat', () => {
         return timeDelta !== 0 ? timeDelta : b.change_id.localeCompare(a.change_id)
       })
     if (!sortedChanges.length) return
-    const existingById = new Map(
-      target.messages
-        .filter(message => message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX))
-        .map(message => [message.id, message]),
-    )
-    target.messages = target.messages.filter(message => !message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX))
     for (const change of sortedChanges) {
       const messageId = workspaceRunChangeMessageId(change.change_id)
       const existing = existingById.get(messageId) || null
@@ -1268,12 +1312,29 @@ export const useChatStore = defineStore('chat', () => {
     attachToolChangesToMessages(sessionId)
   }
 
-  function handleWorkspaceRunChangeEvent(sessionId: string, evt: any) {
-    upsertWorkspaceRunChange(sessionId, evt?.change as WorkspaceRunChangeSummary | undefined)
+  function handleWorkspaceRunChangeEvent(
+    sessionId: string,
+    evt: any,
+    assistantMessageId?: string | null,
+  ): string | null {
+    const change = evt?.change as WorkspaceRunChangeSummary | undefined
+    const target = sessions.value.find(session => session.id === sessionId)
+    const alignedAssistantMessageId = target
+      ? alignWorkspaceChangeAssistantMessage(target.messages, change, assistantMessageId)
+      : assistantMessageId || null
+    upsertWorkspaceRunChange(sessionId, change)
+    return alignedAssistantMessageId
   }
 
-  function handleTerminalWorkspaceRunChange(sessionId: string, evt: any) {
-    upsertWorkspaceRunChange(sessionId, evt?.workspace_run_change as WorkspaceRunChangeSummary | undefined)
+  function handleTerminalWorkspaceRunChange(
+    sessionId: string,
+    evt: any,
+    assistantMessageId?: string | null,
+  ) {
+    const change = evt?.workspace_run_change as WorkspaceRunChangeSummary | undefined
+    const target = sessions.value.find(session => session.id === sessionId)
+    if (target) alignWorkspaceChangeAssistantMessage(target.messages, change, assistantMessageId)
+    upsertWorkspaceRunChange(sessionId, change)
   }
 
   function restoreWorkspaceRunChangeMessages(sessionId: string) {
@@ -3324,7 +3385,7 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'workspace.diff.completed': {
-              handleWorkspaceRunChangeEvent(sid, evt)
+              activeAssistantMessageId = handleWorkspaceRunChangeEvent(sid, evt, activeAssistantMessageId)
               break
             }
 
@@ -3361,8 +3422,6 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'run.completed': {
-              handleTerminalWorkspaceRunChange(sid, evt)
-              clearAgentEventMessages(sid)
               const msgs = getSessionMsgs(sid)
               const lastMsg = activeAssistantMessageId
                 ? msgs.find(m => m.id === activeAssistantMessageId)
@@ -3370,6 +3429,7 @@ export const useChatStore = defineStore('chat', () => {
               const completedAssistantMessageId = lastMsg?.role === 'assistant' && lastMsg.isStreaming
                 ? lastMsg.id
                 : null
+              clearAgentEventMessages(sid)
               if (lastMsg?.isStreaming) {
                 updateMessage(sid, lastMsg.id, { isStreaming: false })
               }
@@ -3475,6 +3535,11 @@ export const useChatStore = defineStore('chat', () => {
                 playCompletionBellIfEnabled()
                 showCompletionNotificationIfEnabled(sid, completedAssistantMessageId)
               }
+              const terminalAssistantMessageId = completedAssistantMessageId || [...getSessionMsgs(sid)]
+                .reverse()
+                .find(message => message.role === 'assistant' && String(message.content || '').trim())
+                ?.id
+              handleTerminalWorkspaceRunChange(sid, evt, terminalAssistantMessageId)
               attachToolChangesToMessages(sid)
 
               // 自动播放语音
@@ -3504,7 +3569,11 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'run.failed': {
-              handleTerminalWorkspaceRunChange(sid, evt)
+              const failedMessages = getSessionMsgs(sid)
+              const failedAssistant = activeAssistantMessageId
+                ? failedMessages.find(message => message.id === activeAssistantMessageId)
+                : [...failedMessages].reverse().find(message => message.role === 'assistant' && message.isStreaming)
+              handleTerminalWorkspaceRunChange(sid, evt, failedAssistant?.id)
               clearAgentEventMessages(sid)
               if ((evt as any).inputTokens != null) {
                 const target = sessions.value.find(s => s.id === sid)

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -14,6 +14,7 @@ import {
     type RoomInfo,
     type RoomAgent,
     type ChatMessage,
+    type GroupWorkspaceDiffPayload,
     type MemberInfo,
     createRoom,
     listRooms,
@@ -992,6 +993,31 @@ function parseWorkspaceDiffPayload(value: unknown): unknown {
     }
 }
 
+function groupWorkspaceDiffPayload(value: unknown): GroupWorkspaceDiffPayload | null {
+    const parsed = parseWorkspaceDiffPayload(value)
+    return parsed && typeof parsed === 'object' && (parsed as any).kind === 'workspace_diff'
+        ? parsed as GroupWorkspaceDiffPayload
+        : null
+}
+
+function attachWorkspaceDiffsToParentMessages(messages: ChatMessage[]): ChatMessage[] {
+    const mapped: ChatMessage[] = messages.map(message => ({ ...message, workspaceChanges: [] }))
+    const assistantById = new Map(
+        mapped
+            .filter(message => message.role === 'assistant')
+            .map(message => [message.id, message]),
+    )
+    return mapped.filter(message => {
+        if ((message.toolName || message.tool_name) !== 'workspace_diff') return true
+        const payload = groupWorkspaceDiffPayload(message.toolResult ?? message.content)
+        const parentMessageId = String(payload?.parent_message_id || '').trim()
+        const parent = parentMessageId ? assistantById.get(parentMessageId) : undefined
+        if (!payload || !parent) return true
+        parent.workspaceChanges!.push(payload)
+        return false
+    })
+}
+
 function mapGroupMessages(msgs: ChatMessage[]): ChatMessage[] {
     const toolNameMap = new Map<string, string>()
     const toolArgsMap = new Map<string, unknown>()
@@ -1077,5 +1103,5 @@ function mapGroupMessages(msgs: ChatMessage[]): ChatMessage[] {
 
         result.push(msg)
     }
-    return result
+    return attachWorkspaceDiffsToParentMessages(result)
 }

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -18,8 +18,8 @@ import { getLocalUsageStats, getRecordedUsageSessionIds, getUsage, getUsageBatch
 import type { UsageStatsAgentRow, UsageStatsModelRow, UsageStatsDailyRow } from '../../db/hermes/usage-store'
 import { deleteWorkspaceRunChangesForSession, getWorkspaceRunChangeFile as getWorkspaceRunChangeFileFromDb, listWorkspaceRunChangesForSession } from '../../db/hermes/workspace-run-changes-store'
 import { getModelContextLength } from '../../services/hermes/model-context'
-import { getActiveProfileName, listProfileNamesFromDisk } from '../../services/hermes/hermes-profile'
-import { isNearestExistingRealPathWithin, isPathWithin } from '../../services/hermes/hermes-path'
+import { getActiveProfileDir, getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../../services/hermes/hermes-profile'
+import { isNearestExistingRealPathWithin, isPathWithin, relativePathFromBase } from '../../services/hermes/hermes-path'
 import {
   isWorkspaceListPathAllowed,
   normalizeWindowsWorkspacePath,
@@ -622,6 +622,24 @@ function workspaceRelativePath(workspace: string, fullPath: string): string {
   return relative(workspace, fullPath).replace(/\\/g, '/')
 }
 
+function sessionWorkspacePrefix(workspace: string, profile?: string | null): string {
+  const profileDir = profile ? getProfileDir(profile) : getActiveProfileDir()
+  return relativePathFromBase(workspace, profileDir) || ''
+}
+
+function normalizeSessionWorkspaceRelativePath(
+  workspace: string,
+  profile: string | null | undefined,
+  value: unknown,
+  options: { allowEmpty?: boolean } = {},
+): string {
+  const normalized = normalizeWorkspaceRelativePath(value, options)
+  const prefix = sessionWorkspacePrefix(workspace, profile)
+  if (!prefix) return normalized
+  if (normalized === prefix) return ''
+  return normalized.startsWith(`${prefix}/`) ? normalized.slice(prefix.length + 1) : normalized
+}
+
 async function resolveSessionWorkspacePath(
   ctx: any,
   relativePathValue: unknown,
@@ -632,7 +650,7 @@ async function resolveSessionWorkspacePath(
   if (denySessionAccess(ctx, session)) throw Object.assign(new Error('Forbidden'), { code: 'forbidden', status: 403, handled: true })
   const workspace = String(session.workspace || '').trim()
   if (!workspace) throw Object.assign(new Error('Session workspace not found'), { code: 'workspace_not_found', status: 404 })
-  const relativePath = normalizeWorkspaceRelativePath(relativePathValue, options)
+  const relativePath = normalizeSessionWorkspaceRelativePath(workspace, session.profile, relativePathValue, options)
   const fullPath = pathResolve(workspace, relativePath)
   if (!isPathWithin(fullPath, workspace) || !await isNearestExistingRealPathWithin(fullPath, workspace)) {
     throw Object.assign(new Error('Invalid file path'), { code: 'invalid_path', status: 400 })

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -106,6 +106,7 @@ export const WORKSPACE_RUN_CHANGES_SCHEMA: Record<string, string> = {
   change_id: 'TEXT PRIMARY KEY',
   room_id: "TEXT NOT NULL DEFAULT ''",
   message_id: "TEXT NOT NULL DEFAULT ''",
+  assistant_message_id: "TEXT NOT NULL DEFAULT ''",
   session_id: 'TEXT NOT NULL',
   run_id: 'TEXT NOT NULL DEFAULT \'\'',
   source: 'TEXT NOT NULL DEFAULT \'run\'',
@@ -943,6 +944,59 @@ export function syncTable(
   addMissingSafeColumns(db, tableName, schema)
 }
 
+function cleanupHistoricalZeroLineWorkspaceDiffs(
+  db: NonNullable<ReturnType<typeof getDb>>,
+): void {
+  const zeroLinePredicate = 'additions = 0 AND deletions = 0'
+  const affectedRows = db.prepare(
+    `SELECT DISTINCT change_id FROM ${WORKSPACE_RUN_CHANGE_FILES_TABLE} WHERE ${zeroLinePredicate}`,
+  ).all() as Array<{ change_id: string }>
+  if (affectedRows.length === 0) return
+
+  db.exec('BEGIN IMMEDIATE')
+  try {
+    db.prepare(`DELETE FROM ${WORKSPACE_RUN_CHANGE_FILES_TABLE} WHERE ${zeroLinePredicate}`).run()
+    const aggregate = db.prepare(
+      `SELECT COUNT(*) AS files_changed, COALESCE(SUM(additions), 0) AS additions,
+        COALESCE(SUM(deletions), 0) AS deletions, COALESCE(MAX(truncated), 0) AS truncated,
+        COALESCE(SUM(patch_bytes), 0) AS total_patch_bytes
+       FROM ${WORKSPACE_RUN_CHANGE_FILES_TABLE} WHERE change_id = ?`,
+    )
+    const updateParent = db.prepare(
+      `UPDATE ${WORKSPACE_RUN_CHANGES_TABLE}
+       SET files_changed = ?, additions = ?, deletions = ?, truncated = ?, total_patch_bytes = ?
+       WHERE change_id = ?`,
+    )
+    const deleteParent = db.prepare(`DELETE FROM ${WORKSPACE_RUN_CHANGES_TABLE} WHERE change_id = ?`)
+
+    for (const { change_id: changeId } of affectedRows) {
+      const totals = aggregate.get(changeId) as {
+        files_changed: number
+        additions: number
+        deletions: number
+        truncated: number
+        total_patch_bytes: number
+      }
+      if (totals.files_changed === 0) {
+        deleteParent.run(changeId)
+      } else {
+        updateParent.run(
+          totals.files_changed,
+          totals.additions,
+          totals.deletions,
+          totals.truncated,
+          totals.total_patch_bytes,
+          changeId,
+        )
+      }
+    }
+    db.exec('COMMIT')
+  } catch (error) {
+    db.exec('ROLLBACK')
+    throw error
+  }
+}
+
 // ============================================================================
 // Unified Initializer
 // ============================================================================
@@ -971,6 +1025,7 @@ export function initAllHermesTables(): void {
     syncTable(WORKSPACE_RUN_CHANGE_FILES_TABLE, WORKSPACE_RUN_CHANGE_FILES_SCHEMA, {
       indexes: WORKSPACE_RUN_CHANGE_FILES_INDEXES,
     })
+    cleanupHistoricalZeroLineWorkspaceDiffs(db)
 
     // Workflow store
     syncTable(WORKFLOWS_TABLE, WORKFLOWS_SCHEMA, {

--- a/packages/server/src/db/hermes/workspace-run-changes-store.ts
+++ b/packages/server/src/db/hermes/workspace-run-changes-store.ts
@@ -29,6 +29,7 @@ export interface WorkspaceRunChangeSummary {
   change_id: string
   room_id: string
   message_id: string
+  assistant_message_id: string
   session_id: string
   run_id: string
   source: 'run'
@@ -49,6 +50,7 @@ export interface SaveWorkspaceRunChangeInput {
   change_id: string
   room_id?: string
   message_id?: string
+  assistant_message_id?: string
   session_id: string
   run_id?: string
   source?: 'run'
@@ -107,6 +109,7 @@ function mapSummary(row: Record<string, unknown>, files: WorkspaceRunChangeFileS
     change_id: String(row.change_id || ''),
     room_id: String(row.room_id || ''),
     message_id: String(row.message_id || ''),
+    assistant_message_id: String(row.assistant_message_id || ''),
     session_id: String(row.session_id || ''),
     run_id: String(row.run_id || ''),
     source: 'run',
@@ -147,13 +150,14 @@ export function insertWorkspaceRunChange(db: HermesDb, change: SaveWorkspaceRunC
   db.prepare(`DELETE FROM ${WORKSPACE_RUN_CHANGES_TABLE} WHERE change_id = ?`).run(change.change_id)
   db.prepare(
     `INSERT INTO ${WORKSPACE_RUN_CHANGES_TABLE} (
-      change_id, room_id, message_id, session_id, run_id, source, workspace, workspace_kind, started_at, finished_at,
+      change_id, room_id, message_id, assistant_message_id, session_id, run_id, source, workspace, workspace_kind, started_at, finished_at,
       files_changed, additions, deletions, truncated, total_patch_bytes, created_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     change.change_id,
     change.room_id || '',
     change.message_id || '',
+    change.assistant_message_id || '',
     change.session_id,
     change.run_id || '',
     change.source || 'run',

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -113,6 +113,7 @@ interface ManagedCodingAgentRun {
   pendingChatCompletionEvent?: 'run.completed' | 'run.failed'
   pendingChatCompletionPayload?: Record<string, unknown>
   memoryExportStarted?: boolean
+  assistantMessageId?: string
 }
 
 interface CodingAgentRunSendOptions {
@@ -550,6 +551,7 @@ export class CodingAgentRunManager {
     if (!text) throw new Error('Input is required')
     const systemPrompt = String(options.systemPrompt || '').trim()
     this.ensureDbSession(run)
+    run.assistantMessageId = undefined
     this.addUserMessage(run, text)
     this.touch(run)
     this.emitTerminalStatus(run, 'Input sent to coding agent.')
@@ -657,7 +659,7 @@ export class CodingAgentRunManager {
       this.emitToChat(run.launch.sessionId, mapped.event, mapped.payload)
     }
     if (isTerminalEvent) {
-      flushResponseRunToDb(run.state, run.launch.sessionId)
+      run.assistantMessageId = flushResponseRunToDb(run.state, run.launch.sessionId)
       run.state.responseRun = undefined
       updateSessionStats(run.launch.sessionId)
       run.terminalUsageRefresh = this.refreshCodingAgentUsage(run)
@@ -1918,6 +1920,7 @@ export class CodingAgentRunManager {
         sessionId: run.launch.sessionId,
         runId: run.id,
         workspace: run.launch.workspaceDir,
+        assistantMessageId: run.assistantMessageId,
       })
       if (!change) return null
       this.emitToChat(run.launch.sessionId, 'workspace.diff.completed', {

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -534,6 +534,7 @@ class ChatStorage {
                 ...args.draft,
                 room_id: args.roomId,
                 message_id: messageId,
+                assistant_message_id: args.parentMessageId || '',
                 workspace: workspaceLabel,
             }
             const change = insertWorkspaceRunChange(db, redactedDraft)

--- a/packages/server/src/services/hermes/run-chat/bridge-message.ts
+++ b/packages/server/src/services/hermes/run-chat/bridge-message.ts
@@ -7,15 +7,15 @@ import { addMessage } from '../../../db/hermes/session-store'
 import { logger } from '../../logger'
 import type { SessionMessage, SessionState } from './types'
 
-export function flushBridgePendingToDb(state: SessionState, sessionId: string, runMarker?: string) {
+export function flushBridgePendingToDb(state: SessionState, sessionId: string, runMarker?: string): string | undefined {
   const content = state.bridgePendingAssistantContent || ''
   const reasoning = state.bridgePendingReasoningContent || ''
-  if (!content.trim()) return
+  if (!content.trim()) return state.bridgeAssistantMessageId
   if (runMarker) {
     const last = findOpenBridgeAssistantMessage(state, runMarker)
     if (last) syncBridgeReasoningToMessage(last, reasoning)
   }
-  addMessage({
+  const persistedId = addMessage({
     session_id: sessionId,
     role: 'assistant',
     content,
@@ -25,10 +25,12 @@ export function flushBridgePendingToDb(state: SessionState, sessionId: string, r
   })
   state.bridgePendingAssistantContent = ''
   state.bridgePendingReasoningContent = ''
+  if (persistedId != null) state.bridgeAssistantMessageId = String(persistedId)
   if (runMarker) {
     const last = findOpenBridgeAssistantMessage(state, runMarker)
     if (last && last.finish_reason == null) last.finish_reason = 'stop'
   }
+  return state.bridgeAssistantMessageId
 }
 
 export function findOpenBridgeAssistantMessage(state: SessionState, runMarker: string): SessionMessage | undefined {

--- a/packages/server/src/services/hermes/run-chat/bridge-message.ts
+++ b/packages/server/src/services/hermes/run-chat/bridge-message.ts
@@ -11,10 +11,8 @@ export function flushBridgePendingToDb(state: SessionState, sessionId: string, r
   const content = state.bridgePendingAssistantContent || ''
   const reasoning = state.bridgePendingReasoningContent || ''
   if (!content.trim()) return state.bridgeAssistantMessageId
-  if (runMarker) {
-    const last = findOpenBridgeAssistantMessage(state, runMarker)
-    if (last) syncBridgeReasoningToMessage(last, reasoning)
-  }
+  const assistantMessage = runMarker ? findOpenBridgeAssistantMessage(state, runMarker) : undefined
+  if (assistantMessage) syncBridgeReasoningToMessage(assistantMessage, reasoning)
   const persistedId = addMessage({
     session_id: sessionId,
     role: 'assistant',
@@ -25,11 +23,11 @@ export function flushBridgePendingToDb(state: SessionState, sessionId: string, r
   })
   state.bridgePendingAssistantContent = ''
   state.bridgePendingReasoningContent = ''
-  if (persistedId != null) state.bridgeAssistantMessageId = String(persistedId)
-  if (runMarker) {
-    const last = findOpenBridgeAssistantMessage(state, runMarker)
-    if (last && last.finish_reason == null) last.finish_reason = 'stop'
+  if (persistedId != null) {
+    state.bridgeAssistantMessageId = String(persistedId)
+    if (assistantMessage) assistantMessage.id = persistedId
   }
+  if (assistantMessage && assistantMessage.finish_reason == null) assistantMessage.finish_reason = 'stop'
   return state.bridgeAssistantMessageId
 }
 

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -712,7 +712,7 @@ export async function handleBridgeRun(
     state.activeRunMarker = undefined
     state.events = []
     state.bridgePendingToolCallMarkup = undefined
-    flushBridgePendingToDb(state, session_id)
+    flushBridgePendingToDb(state, session_id, runMarker)
     updateSessionStats(session_id)
     const message = err instanceof Error ? err.message : String(err)
     const errUsage = await calcAndUpdateUsage(session_id, state, emit)
@@ -1511,7 +1511,7 @@ async function applyBridgeChunkAsync(
   }
 
   flushPendingToolMarkupToAssistant(state, runMarker, chunk.run_id, emit)
-  flushBridgePendingToDb(state, sessionId)
+  flushBridgePendingToDb(state, sessionId, runMarker)
   finalResponse = bridgeFinalResponse(chunk, state, useMoaFinalResponse)
   state.bridgePendingToolCallMarkup = undefined
   updateSessionStats(sessionId)

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -423,6 +423,7 @@ export async function handleBridgeRun(
   state.abortController = undefined
   state.bridgeOutput = ''
   state.bridgePendingAssistantContent = ''
+  state.bridgeAssistantMessageId = undefined
   state.bridgePendingReasoningContent = ''
   state.bridgePendingToolCallMarkup = ''
   state.bridgeToolCounter = 0
@@ -1543,6 +1544,7 @@ async function applyBridgeChunkAsync(
       sessionId,
       runId: chunk.run_id,
       workspace,
+      assistantMessageId: state.bridgeAssistantMessageId,
     })
     workspaceRunChange = change
     if (change) {

--- a/packages/server/src/services/hermes/run-chat/response-stream.ts
+++ b/packages/server/src/services/hermes/run-chat/response-stream.ts
@@ -403,8 +403,13 @@ export function flushResponseRunToDb(state: SessionState, sessionId: string): st
       reasoning_content: msg.reasoning_content ?? null,
       timestamp: msg.timestamp,
     })
-    if (persistedId != null && msg.role === 'assistant' && String(msg.content || '').trim()) {
-      finalAssistantMessageId = String(persistedId)
+    if (persistedId != null) {
+      const previousId = msg.id
+      msg.id = persistedId
+      if (run.reasoningMessageId === previousId) run.reasoningMessageId = persistedId
+      if (msg.role === 'assistant' && String(msg.content || '').trim()) {
+        finalAssistantMessageId = String(persistedId)
+      }
     }
     flushed++
   }

--- a/packages/server/src/services/hermes/run-chat/response-stream.ts
+++ b/packages/server/src/services/hermes/run-chat/response-stream.ts
@@ -383,14 +383,15 @@ export function getResponseRunState(state: SessionState, runMarker?: string): Re
 }
 
 /** Flush all non-user messages for this run to DB in order. */
-export function flushResponseRunToDb(state: SessionState, sessionId: string) {
+export function flushResponseRunToDb(state: SessionState, sessionId: string): string | undefined {
   const run = state.responseRun
-  if (!run?.runMarker) return
+  if (!run?.runMarker) return undefined
   let flushed = 0
+  let finalAssistantMessageId: string | undefined
   for (const msg of state.messages) {
     if (msg.runMarker !== run.runMarker) continue
     if (msg.role === 'user') continue
-    addMessage({
+    const persistedId = addMessage({
       session_id: sessionId,
       role: msg.role,
       content: msg.content || '',
@@ -402,7 +403,11 @@ export function flushResponseRunToDb(state: SessionState, sessionId: string) {
       reasoning_content: msg.reasoning_content ?? null,
       timestamp: msg.timestamp,
     })
+    if (persistedId != null && msg.role === 'assistant' && String(msg.content || '').trim()) {
+      finalAssistantMessageId = String(persistedId)
+    }
     flushed++
   }
   logger.info('[chat-run-socket] flushResponseRunToDb: flushed %d messages for session %s', flushed, sessionId)
+  return finalAssistantMessageId
 }

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -90,6 +90,7 @@ export interface SessionState {
   responseRun?: ResponseRunState
   source?: ChatRunSource
   bridgePendingAssistantContent?: string
+  bridgeAssistantMessageId?: string
   bridgePendingReasoningContent?: string
   bridgePendingToolCallMarkup?: string
   bridgeOutput?: string

--- a/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
+++ b/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
@@ -140,11 +140,7 @@ const DEFAULT_SKIPPED_FILE_EXTENSIONS = new Set([
   '.7z',
   '.rar',
   '.sqlite',
-  '.sqlite-shm',
-  '.sqlite-wal',
   '.db',
-  '.db-shm',
-  '.db-wal',
   '.pdf',
   '.docx',
   '.xlsx',
@@ -548,8 +544,8 @@ function compareSnapshots(before: SnapshotFile | undefined, after: SnapshotFile,
     deletions = counts.deletions
   } else {
     truncated = !binary
-    if (changeType === 'added') additions = after.content ? after.content.toString('utf8').split('\n').length : 0
-    if (changeType === 'deleted') deletions = safeBefore.content ? safeBefore.content.toString('utf8').split('\n').length : 0
+    if (!binary && changeType === 'added') additions = after.content ? after.content.toString('utf8').split('\n').length : 0
+    if (!binary && changeType === 'deleted') deletions = safeBefore.content ? safeBefore.content.toString('utf8').split('\n').length : 0
   }
 
   return {
@@ -633,6 +629,7 @@ export function completeWorkspaceRunCheckpointDraft(args: {
   sessionId: string
   runId?: string | null
   workspace?: string | null
+  assistantMessageId?: string | null
 }): SaveWorkspaceRunChangeInput | null {
   const runId = args.runId || ''
   if (!runId) return null
@@ -699,6 +696,7 @@ export function completeWorkspaceRunCheckpointDraft(args: {
     change_id: checkpoint.changeId,
     session_id: checkpoint.sessionId,
     run_id: runId || checkpoint.runId,
+    assistant_message_id: args.assistantMessageId || '',
     source: 'run',
     workspace: args.workspace || checkpoint.workspace,
     workspace_kind: checkpoint.kind,
@@ -717,6 +715,7 @@ export function completeWorkspaceRunCheckpoint(args: {
   sessionId: string
   runId?: string | null
   workspace?: string | null
+  assistantMessageId?: string | null
 }): WorkspaceRunChangeSummary | null {
   const draft = completeWorkspaceRunCheckpointDraft(args)
   return draft ? saveWorkspaceRunChange(draft) : null

--- a/tests/client/chat-store-workspace-diff-turn.test.ts
+++ b/tests/client/chat-store-workspace-diff-turn.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { alignWorkspaceChangeAssistantMessage, attachWorkspaceChangesToExactTurns, useChatStore } from '@/stores/hermes/chat'
+
+const sessionApi = vi.hoisted(() => ({
+  fetchSessions: vi.fn(),
+  fetchWorkspaceRunChangesForSession: vi.fn(),
+}))
+
+const chatApi = vi.hoisted(() => ({
+  resumePayload: null as any,
+  resumeSession: vi.fn((sessionId: string, callback: (data: any) => void) => {
+    callback({ ...chatApi.resumePayload, session_id: sessionId })
+    return {} as any
+  }),
+  startRunViaSocket: vi.fn(() => ({ abort: vi.fn() })),
+}))
+
+vi.mock('@/api/hermes/sessions', () => ({
+  archiveSession: vi.fn(),
+  deleteSession: vi.fn(),
+  fetchSessionMessagesPage: vi.fn(),
+  fetchSessions: sessionApi.fetchSessions,
+  fetchWorkspaceRunChangesForSession: sessionApi.fetchWorkspaceRunChangesForSession,
+  fetchWorkspaceRunChangeFile: vi.fn(async () => null),
+  setSessionModel: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/chat', () => ({
+  startRunViaSocket: chatApi.startRunViaSocket,
+  resumeSession: chatApi.resumeSession,
+  registerSessionHandlers: vi.fn(),
+  unregisterSessionHandlers: vi.fn(),
+  getChatRunSocket: vi.fn(() => ({ emit: vi.fn() })),
+  respondToolApproval: vi.fn(),
+  respondClarify: vi.fn(),
+  onPeerUserMessage: vi.fn(() => vi.fn()),
+  onSessionCommand: vi.fn(() => vi.fn()),
+  onSessionTitleUpdated: vi.fn(() => vi.fn()),
+  onSessionWorkspaceUpdated: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('@/api/client', () => ({ getActiveProfileName: () => 'default' }))
+vi.mock('@/api/hermes/download', () => ({ getDownloadUrl: (_path: string, name: string) => `/download/${name}` }))
+vi.mock('@/utils/completion-sound', () => ({ primeCompletionSound: vi.fn(), playCompletionSound: vi.fn() }))
+vi.mock('@/utils/completion-notification', () => ({ showCompletionNotification: vi.fn() }))
+vi.mock('@/utils/session-sync', () => ({ subscribeSessionSync: vi.fn(() => vi.fn()), publishSessionSync: vi.fn() }))
+
+function summary() {
+  return {
+    id: 'session-1', profile: 'default', source: 'coding_agent', agent: 'codex', title: 'Turn changes',
+    preview: '', started_at: 1, ended_at: 2, last_active: 2, message_count: 4, tool_call_count: 0,
+    input_tokens: 0, output_tokens: 0, model: 'gpt-test', provider: 'test',
+  }
+}
+
+function change(id: string, assistantMessageId?: string) {
+  return {
+    change_id: id,
+    assistant_message_id: assistantMessageId || '',
+    session_id: 'session-1', run_id: 'run-1', source: 'run', workspace: '/tmp/repo', workspace_kind: 'git',
+    started_at: 1, finished_at: 2, files_changed: 1, additions: 2, deletions: 1,
+    truncated: false, total_patch_bytes: 20, created_at: 2,
+    files: [{
+      id: id === 'change-1' ? 1 : 2, change_id: id, session_id: 'session-1', path: `${id}.ts`, old_path: null,
+      change_type: 'modified', additions: 2, deletions: 1, size_before: 1, size_after: 2,
+      patch_bytes: 20, truncated: false, binary: false, created_at: 2,
+    }],
+  }
+}
+
+describe('chat workspace diff turn association', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    setActivePinia(createPinia())
+    sessionApi.fetchSessions.mockResolvedValueOnce([summary()]).mockResolvedValueOnce([])
+    chatApi.resumePayload = {
+      isWorking: false,
+      messages: [
+        { id: 1, session_id: 'session-1', role: 'user', content: 'first', timestamp: 1 },
+        { id: 2, session_id: 'session-1', role: 'assistant', content: 'first done', timestamp: 2 },
+        { id: 3, session_id: 'session-1', role: 'user', content: 'second', timestamp: 3 },
+        { id: 4, session_id: 'session-1', role: 'assistant', content: 'second done', timestamp: 4 },
+      ],
+      events: [], queueLength: 0, messageLoadedCount: 4, messageTotal: 4, hasMoreBefore: false,
+    }
+  })
+
+  it('attaches each persisted change to its exact assistant turn without synthetic cards', async () => {
+    sessionApi.fetchWorkspaceRunChangesForSession.mockResolvedValue([
+      change('change-1', '2'),
+      change('change-2', '4'),
+      change('change-3', '4'),
+    ])
+
+    const store = useChatStore()
+    await store.loadSessions()
+
+    expect(store.activeSession?.messages.map(message => message.role)).toEqual(['user', 'assistant', 'user', 'assistant'])
+    expect(store.activeSession?.messages.find(message => message.id === '2')?.workspaceChanges?.map(item => item.change_id)).toEqual([
+      'change-1',
+    ])
+    expect(store.activeSession?.messages.find(message => message.id === '4')?.workspaceChanges?.map(item => item.change_id)).toEqual([
+      'change-2',
+      'change-3',
+    ])
+  })
+
+  it('preserves tool-call workspace change restoration alongside turn associations', async () => {
+    chatApi.resumePayload.messages.splice(3, 0, {
+      id: 5,
+      session_id: 'session-1',
+      role: 'tool',
+      content: 'workspace result',
+      tool_call_id: 'tool-change',
+      timestamp: 3.5,
+    })
+    sessionApi.fetchWorkspaceRunChangesForSession.mockResolvedValue([change('tool-change')])
+
+    const store = useChatStore()
+    await store.loadSessions()
+
+    expect(store.activeSession?.messages.find(message => message.toolCallId === 'tool-change')?.toolChange?.change_id)
+      .toBe('tool-change')
+  })
+
+  it('keeps a standalone timestamp fallback for legacy changes without an assistant id', async () => {
+    sessionApi.fetchWorkspaceRunChangesForSession.mockResolvedValue([change('legacy-change')])
+
+    const store = useChatStore()
+    await store.loadSessions()
+
+    const legacy = store.activeSession?.messages.find(message => message.id === 'workspace-run-change:legacy-change')
+    expect(legacy).toMatchObject({ role: 'tool', toolChange: { change_id: 'legacy-change' } })
+  })
+
+  it('aligns a live assistant temporary id with the persisted attribution id', () => {
+    const messages = [{
+      id: 'temporary-assistant',
+      role: 'assistant' as const,
+      content: 'third done',
+      timestamp: 5,
+      isStreaming: false,
+    }]
+    const attributedChange = change('change-live', '42')
+
+    expect(alignWorkspaceChangeAssistantMessage(messages, attributedChange, 'temporary-assistant')).toBe('42')
+    expect(messages[0].id).toBe('42')
+    expect(attachWorkspaceChangesToExactTurns(messages, [attributedChange])).toEqual([])
+    expect(messages[0].workspaceChanges?.map(item => item.change_id)).toEqual(['change-live'])
+  })
+
+  it('moves an unresolved explicit association from fallback to the assistant after pagination loads it', () => {
+    const unresolved = change('change-page-1', '2')
+    const messages = [
+      { id: '4', role: 'assistant' as const, content: 'newer', timestamp: 4 },
+    ]
+
+    expect(attachWorkspaceChangesToExactTurns(messages, [unresolved])).toEqual([unresolved])
+
+    messages.unshift({ id: '2', role: 'assistant', content: 'older', timestamp: 2 })
+    expect(attachWorkspaceChangesToExactTurns(messages, [unresolved])).toEqual([])
+    expect(messages[0].workspaceChanges?.map(item => item.change_id)).toEqual(['change-page-1'])
+  })
+
+  it('does not overwrite existing tool-message change metadata while recomputing turn associations', () => {
+    const existing = change('tool-change')
+    const messages = [{
+      id: 'tool-1', role: 'tool' as const, content: '', timestamp: 1, toolChange: existing,
+    }]
+
+    attachWorkspaceChangesToExactTurns(messages, [change('turn-change', '42')])
+
+    expect(messages[0].toolChange).toBe(existing)
+    expect(messages[0].workspaceChanges).toEqual([])
+  })
+})

--- a/tests/client/group-chat-workspace-diff.test.ts
+++ b/tests/client/group-chat-workspace-diff.test.ts
@@ -4,7 +4,7 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import GroupMessageItem from '@/components/hermes/group-chat/GroupMessageItem.vue'
 import GroupMessageList from '@/components/hermes/group-chat/GroupMessageList.vue'
-import type { ChatMessage } from '@/api/hermes/group-chat'
+import type { ChatMessage, GroupWorkspaceDiffPayload } from '@/api/hermes/group-chat'
 
 const toolTraceVisibleState = vi.hoisted(() => ({ value: true }))
 
@@ -67,7 +67,7 @@ vi.mock('naive-ui', () => ({
   useMessage: () => ({ error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() }),
 }))
 
-const payload = {
+const payload: GroupWorkspaceDiffPayload = {
   kind: 'workspace_diff',
   version: 1,
   room_id: 'room-1',
@@ -85,6 +85,18 @@ const payload = {
     { id: 1, path: 'src/a.ts', change_type: 'modified', additions: 2, deletions: 1, patch: 'diff --git a/src/a.ts b/src/a.ts\n-old\n+new\n', binary: false, truncated: false },
     { id: 2, path: 'asset.bin', change_type: 'added', additions: 0, deletions: 0, patch: null, binary: true, truncated: false },
   ],
+}
+
+function assistantMessage(): ChatMessage {
+  return {
+    id: 'assistant-1',
+    roomId: 'room-1',
+    senderId: 'agent-1',
+    senderName: 'Worker',
+    content: 'Finished the workspace update.',
+    timestamp: 1,
+    role: 'assistant',
+  }
 }
 
 function workspaceDiffMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
@@ -130,6 +142,63 @@ describe('group chat workspace diff client rendering', () => {
       toolName: 'workspace_diff',
       toolResult: expect.objectContaining({ kind: 'workspace_diff', files_changed: 2 }),
     })
+  })
+
+  it('attaches persisted and realtime workspace diffs to their exact assistant message', async () => {
+    groupChatApiMock.getRoomDetail.mockResolvedValue({
+      room: { id: 'room-1', name: 'Room 1', inviteCode: null, workspace: '/tmp/repo' },
+      messages: [
+        assistantMessage(),
+        workspaceDiffMessage({
+          content: JSON.stringify({ ...payload, parent_message_id: 'assistant-1' }),
+          timestamp: 2,
+        }),
+      ],
+      agents: [],
+      members: [],
+    })
+    const { useGroupChatStore } = await import('@/stores/hermes/group-chat')
+    const store = useGroupChatStore()
+
+    await store.joinRoom('room-1')
+
+    expect(store.sortedMessages).toHaveLength(1)
+    expect(store.sortedMessages[0]).toMatchObject({
+      id: 'assistant-1',
+      role: 'assistant',
+      workspaceChanges: [expect.objectContaining({ change_id: 'change-1' })],
+    })
+
+    store.messages = [assistantMessage()]
+    store.messages.push(workspaceDiffMessage({
+      content: JSON.stringify({ ...payload, parent_message_id: 'assistant-1' }),
+      timestamp: 2,
+    }))
+
+    expect(store.sortedMessages).toHaveLength(1)
+    expect(store.sortedMessages[0].workspaceChanges?.[0]?.change_id).toBe('change-1')
+  })
+
+  it('renders an associated workspace diff inside the assistant message', async () => {
+    const wrapper = mount(GroupMessageItem, {
+      props: {
+        message: {
+          ...assistantMessage(),
+          workspaceChanges: [{ ...payload, parent_message_id: 'assistant-1' }],
+        },
+        agents: [{ id: 'a1', roomId: 'room-1', agentId: 'agent-1', profile: 'default', name: 'Worker', description: '', invited: 0 }],
+        members: [],
+        currentUserId: 'user-1',
+      },
+      global: { stubs: { MarkdownRenderer: true, ProfileAvatar: true } },
+    })
+
+    expect(wrapper.find('.tool-message').exists()).toBe(false)
+    expect(wrapper.find('.assistant-workspace-change').exists()).toBe(true)
+    expect(wrapper.text()).toContain('chat.changesThisTurn')
+
+    await wrapper.find('.tool-change-card-header').trigger('click')
+    expect(wrapper.find('.tool-change-file-row').text()).toContain('a.ts')
   })
 
   it('renders a workspace diff card collapsed by default and expands it on demand', async () => {

--- a/tests/client/message-item-highlight.test.ts
+++ b/tests/client/message-item-highlight.test.ts
@@ -493,6 +493,58 @@ describe('MessageItem tool details', () => {
     expect(wrapper.find('.tool-change-file-row').text()).toContain('example.ts')
   })
 
+  it('renders a turn-scoped workspace change inside its assistant response', async () => {
+    const wrapper = mount(MessageItem, {
+      props: {
+        message: {
+          id: 'assistant-42',
+          role: 'assistant',
+          content: 'Implemented the requested change.',
+          timestamp: Date.now(),
+          workspaceChanges: [{
+            change_id: 'change-turn-1',
+            assistant_message_id: '42',
+            session_id: 'session-1',
+            run_id: 'run-1',
+            source: 'run',
+            workspace: '/tmp/repo',
+            workspace_kind: 'git',
+            started_at: 1,
+            finished_at: 2,
+            files_changed: 1,
+            additions: 2,
+            deletions: 1,
+            truncated: false,
+            total_patch_bytes: 32,
+            created_at: 2,
+            files: [{
+              id: 1,
+              change_id: 'change-turn-1',
+              session_id: 'session-1',
+              path: 'src/example.ts',
+              old_path: null,
+              change_type: 'modified',
+              additions: 2,
+              deletions: 1,
+              size_before: 10,
+              size_after: 12,
+              patch_bytes: 32,
+              truncated: false,
+              binary: false,
+              created_at: 2,
+            }],
+          }],
+        } as Message,
+      },
+      global: { stubs: { MarkdownRenderer: true } },
+    })
+
+    expect(wrapper.find('.msg-content.assistant .assistant-workspace-change').exists()).toBe(true)
+    expect(wrapper.find('.tool-change-card-title').text()).toBe('chat.changesThisTurn')
+    expect(wrapper.find('.tool-change-file-row').exists()).toBe(false)
+    expect(wrapper.find('.assistant-workspace-change .tool-change-card-header').attributes('aria-expanded')).toBe('false')
+  })
+
   it('shows only an embedded difference field when a JSON tool result contains a unified diff', async () => {
     const writeText = vi.mocked(navigator.clipboard.writeText)
     const largeDiff = `diff --git a/foo.ts b/foo.ts\n--- a/foo.ts\n+++ b/foo.ts\n@@ -1,1 +1,1 @@\n-${'a'.repeat(1600)}\n+${'b'.repeat(1600)}\n`

--- a/tests/server/bridge-message-workspace-attribution.test.ts
+++ b/tests/server/bridge-message-workspace-attribution.test.ts
@@ -15,10 +15,17 @@ describe('bridge assistant workspace attribution', () => {
     vi.clearAllMocks()
   })
 
-  it('retains the latest persisted assistant row id for the active Hermes Agent run', async () => {
+  it('rebinds the in-memory assistant message to its persisted row id for session resume', async () => {
     addMessageMock.mockReturnValue(73)
     const state: any = {
-      messages: [],
+      messages: [{
+        id: 1,
+        session_id: 'session-hermes',
+        runMarker: 'run-hermes',
+        role: 'assistant',
+        content: 'Finished the workspace update.',
+        timestamp: 1,
+      }],
       isWorking: true,
       events: [],
       queue: [],
@@ -27,9 +34,10 @@ describe('bridge assistant workspace attribution', () => {
     }
     const { flushBridgePendingToDb } = await import('../../packages/server/src/services/hermes/run-chat/bridge-message')
 
-    const persistedId = flushBridgePendingToDb(state, 'session-hermes')
+    const persistedId = flushBridgePendingToDb(state, 'session-hermes', 'run-hermes')
 
     expect(persistedId).toBe('73')
     expect(state.bridgeAssistantMessageId).toBe('73')
+    expect(state.messages[0]).toMatchObject({ id: 73, finish_reason: 'stop' })
   })
 })

--- a/tests/server/bridge-message-workspace-attribution.test.ts
+++ b/tests/server/bridge-message-workspace-attribution.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const addMessageMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
+  addMessage: addMessageMock,
+}))
+
+vi.mock('../../packages/server/src/services/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+describe('bridge assistant workspace attribution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('retains the latest persisted assistant row id for the active Hermes Agent run', async () => {
+    addMessageMock.mockReturnValue(73)
+    const state: any = {
+      messages: [],
+      isWorking: true,
+      events: [],
+      queue: [],
+      bridgePendingAssistantContent: 'Finished the workspace update.',
+      bridgePendingReasoningContent: '',
+    }
+    const { flushBridgePendingToDb } = await import('../../packages/server/src/services/hermes/run-chat/bridge-message')
+
+    const persistedId = flushBridgePendingToDb(state, 'session-hermes')
+
+    expect(persistedId).toBe('73')
+    expect(state.bridgeAssistantMessageId).toBe('73')
+  })
+})

--- a/tests/server/group-chat-workspace-diff.test.ts
+++ b/tests/server/group-chat-workspace-diff.test.ts
@@ -91,6 +91,7 @@ describe('group chat workspace diff persistence', () => {
     storage.saveRoom('room-1', 'Room 1')
     const runId = '0123456789abcdef0123456789abcdef'
     const draft = await makeDraft(runId)
+    const parentMessageId = 'assistant-message-1'
 
     const saved = storage.saveWorkspaceDiffMessageForRun({
       roomId: 'room-1',
@@ -101,6 +102,7 @@ describe('group chat workspace diff persistence', () => {
       status: 'completed',
       workspace,
       draft: draft!,
+      parentMessageId,
     })
 
     expect(saved?.message).toMatchObject({
@@ -119,6 +121,7 @@ describe('group chat workspace diff persistence', () => {
       run_id: runId,
       status: 'completed',
       files_changed: 1,
+      parent_message_id: parentMessageId,
     })
     expect(payload.files[0].patch).toContain('-old')
     expect(payload.files[0].patch).toContain('+new')
@@ -127,11 +130,12 @@ describe('group chat workspace diff persistence', () => {
 
     const rows = dbState.db?.prepare('SELECT COUNT(*) AS count FROM gc_messages WHERE tool_name = ?').get('workspace_diff') as { count: number }
     expect(rows.count).toBe(1)
-    const changeRow = dbState.db?.prepare('SELECT workspace, room_id, message_id FROM workspace_run_changes WHERE change_id = ?').get(payload.change_id) as { workspace: string; room_id: string; message_id: string }
+    const changeRow = dbState.db?.prepare('SELECT workspace, room_id, message_id, assistant_message_id FROM workspace_run_changes WHERE change_id = ?').get(payload.change_id) as { workspace: string; room_id: string; message_id: string; assistant_message_id: string }
     expect(changeRow.workspace).toBe('workspace')
     expect(changeRow.workspace).not.toBe(workspace)
     expect(changeRow.room_id).toBe('room-1')
     expect(changeRow.message_id).toBe(saved!.message.id)
+    expect(changeRow.assistant_message_id).toBe(parentMessageId)
     const changeRows = dbState.db?.prepare('SELECT COUNT(*) AS count FROM workspace_run_changes WHERE change_id = ?').get(payload.change_id) as { count: number }
     expect(changeRows.count).toBe(1)
     server.getIO().close()

--- a/tests/server/response-stream-reasoning-storage.test.ts
+++ b/tests/server/response-stream-reasoning-storage.test.ts
@@ -103,7 +103,7 @@ describe('response stream reasoning storage', () => {
     }))
   })
 
-  it('returns the persisted final assistant message id for turn-scoped records', () => {
+  it('rebinds run messages to persisted ids and returns the final assistant id', () => {
     const state: SessionState = { messages: [], isWorking: false, events: [], queue: [] }
     addMessageMock.mockReturnValueOnce(40).mockReturnValueOnce(41).mockReturnValueOnce(42)
 
@@ -121,6 +121,7 @@ describe('response stream reasoning storage', () => {
     })
 
     expect(flushResponseRunToDb(state, 'session-1')).toBe('42')
+    expect(state.messages.map(message => message.id)).toEqual([40, 41, 42])
   })
 
   it('deduplicates final reasoning snapshots after streamed reasoning deltas', () => {

--- a/tests/server/response-stream-reasoning-storage.test.ts
+++ b/tests/server/response-stream-reasoning-storage.test.ts
@@ -103,6 +103,26 @@ describe('response stream reasoning storage', () => {
     }))
   })
 
+  it('returns the persisted final assistant message id for turn-scoped records', () => {
+    const state: SessionState = { messages: [], isWorking: false, events: [], queue: [] }
+    addMessageMock.mockReturnValueOnce(40).mockReturnValueOnce(41).mockReturnValueOnce(42)
+
+    applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.created', {
+      response: { id: 'resp-1', status: 'in_progress' },
+    })
+    applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_text.delta', {
+      delta: 'Before tool.',
+    })
+    applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_item.done', {
+      item: { type: 'function_call', call_id: 'tool-1', name: 'Bash', arguments: '{}' },
+    })
+    applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_text.delta', {
+      delta: 'Final answer.',
+    })
+
+    expect(flushResponseRunToDb(state, 'session-1')).toBe('42')
+  })
+
   it('deduplicates final reasoning snapshots after streamed reasoning deltas', () => {
     const state: SessionState = { messages: [], isWorking: false, events: [], queue: [] }
 

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -40,6 +40,8 @@ const recordBridgeToolCompletedMock = vi.fn()
 const recordBridgeMoaDisplayToolMock = vi.fn()
 const resolveBridgeRunModelConfigMock = vi.fn()
 const issueModelRunJwtMock = vi.fn(async () => 'model-run-token')
+const startWorkspaceRunCheckpointMock = vi.fn()
+const completeWorkspaceRunCheckpointMock = vi.fn()
 const homes: string[] = []
 
 vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
@@ -92,6 +94,11 @@ vi.mock('../../packages/server/src/services/hermes/run-chat/bridge-message', () 
 
 vi.mock('../../packages/server/src/services/hermes/run-chat/model-config', () => ({
   resolveBridgeRunModelConfig: resolveBridgeRunModelConfigMock,
+}))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker', () => ({
+  startWorkspaceRunCheckpoint: startWorkspaceRunCheckpointMock,
+  completeWorkspaceRunCheckpoint: completeWorkspaceRunCheckpointMock,
 }))
 
 vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
@@ -147,6 +154,7 @@ describe('bridge run final context usage', () => {
     buildSnapshotAwareHistoryMock.mockImplementation(async (_sessionId: string, _profile: string, history: any[]) => history)
     calcAndUpdateUsageMock.mockResolvedValue({ inputTokens: 11, outputTokens: 7 })
     estimateUsageTokensFromMessagesMock.mockReturnValue({ inputTokens: 11, outputTokens: 7 })
+    completeWorkspaceRunCheckpointMock.mockReturnValue(null)
     ensureOpenBridgeAssistantMessageMock.mockImplementation((state: any, sessionId: string, runMarker: string) => {
       const existing = [...state.messages].reverse().find((message: any) => (
         message.runMarker === runMarker &&
@@ -1057,6 +1065,105 @@ describe('bridge run final context usage', () => {
       output: 'Text [Call',
     }))
   })
+
+  it.each(['terminal', 'write_file'])(
+    'attributes native Hermes Agent %s workspace changes to the final persisted assistant row',
+    async (toolName) => {
+      const emit = vi.fn()
+      const nsp = makeNamespace(emit)
+      const socket = makeSocket()
+      const state = makeState()
+      const sessionMap = new Map([['session-1', state]])
+      const change = {
+        change_id: `run:run-1:${toolName}`,
+        assistant_message_id: '73',
+        session_id: 'session-1',
+        run_id: 'run-1',
+        source: 'run',
+        files: [],
+      }
+      recordBridgeToolStartedMock.mockReturnValue({
+        id: `call-${toolName}`,
+        name: toolName,
+        arguments: '{}',
+      })
+      recordBridgeToolCompletedMock.mockReturnValue({
+        id: `call-${toolName}`,
+        output: 'ok',
+      })
+      flushBridgePendingToDbMock.mockImplementation((targetState: any) => {
+        if (String(targetState.bridgePendingAssistantContent || '').trim()) {
+          targetState.bridgePendingAssistantContent = ''
+          targetState.bridgeAssistantMessageId = '73'
+        }
+        return targetState.bridgeAssistantMessageId
+      })
+      completeWorkspaceRunCheckpointMock.mockReturnValue(change)
+      const bridge = {
+        chat: vi.fn().mockResolvedValue({ run_id: 'run-1', status: 'started' }),
+        contextEstimate: vi.fn().mockResolvedValue({
+          token_count: 12345,
+          message_count: 2,
+          tool_count: 4,
+          system_prompt_chars: 13,
+        }),
+        streamOutput: vi.fn(async function* () {
+          yield {
+            run_id: 'run-1',
+            done: false,
+            status: 'running',
+            events: [
+              { event: 'tool.started', tool_name: toolName, tool_call_id: `call-${toolName}`, args: {} },
+              { event: 'tool.completed', tool_name: toolName, tool_call_id: `call-${toolName}`, result: 'ok' },
+            ],
+          }
+          yield { run_id: 'run-1', done: true, status: 'completed', delta: 'Done.', output: 'Done.', events: [] }
+        }),
+      } as any
+
+      const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+      await handleBridgeRun(
+        nsp,
+        socket,
+        { input: 'update the workspace', session_id: 'session-1' },
+        'default',
+        sessionMap,
+        bridge,
+        false,
+        vi.fn(),
+        vi.fn(),
+      )
+
+      expect(recordBridgeToolStartedMock).toHaveBeenCalledWith(
+        state,
+        'session-1',
+        expect.any(String),
+        toolName,
+        {},
+        `call-${toolName}`,
+      )
+      expect(recordBridgeToolCompletedMock).toHaveBeenCalledWith(
+        state,
+        'session-1',
+        expect.any(String),
+        toolName,
+        expect.objectContaining({ event: 'tool.completed' }),
+      )
+      expect(startWorkspaceRunCheckpointMock).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: 'session-1',
+        runId: 'run-1',
+      }))
+      expect(completeWorkspaceRunCheckpointMock).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: 'session-1',
+        runId: 'run-1',
+        assistantMessageId: '73',
+      }))
+      expect(emit).toHaveBeenCalledWith('workspace.diff.completed', expect.objectContaining({ change }))
+      expect(emit).toHaveBeenCalledWith('run.completed', expect.objectContaining({
+        workspace_run_change: change,
+      }))
+    },
+  )
 
   it('persists the visible plan command instead of the expanded skill prompt', async () => {
     const emit = vi.fn()

--- a/tests/server/schema-sync.test.ts
+++ b/tests/server/schema-sync.test.ts
@@ -364,6 +364,43 @@ describe('Database Schema Synchronization', () => {
         .toEqual({ count: 1 })
     })
 
+
+    it('adds assistant turn attribution to legacy workspace changes without losing audit rows', async () => {
+      const {
+        syncTable,
+        WORKSPACE_RUN_CHANGES_TABLE,
+        WORKSPACE_RUN_CHANGES_SCHEMA,
+        WORKSPACE_RUN_CHANGES_INDEXES,
+      } = await import('../../packages/server/src/db/hermes/schemas')
+      const db = getTestDb()
+      const legacySchema = Object.fromEntries(
+        Object.entries(WORKSPACE_RUN_CHANGES_SCHEMA).filter(([name]) => name !== 'assistant_message_id'),
+      )
+      const columnSql = Object.entries(legacySchema)
+        .map(([name, definition]) => `"${name}" ${definition}`)
+        .join(', ')
+      db.exec(`CREATE TABLE "${WORKSPACE_RUN_CHANGES_TABLE}" (${columnSql})`)
+      db.prepare(`
+        INSERT INTO "${WORKSPACE_RUN_CHANGES_TABLE}"
+          (change_id, session_id, workspace, created_at)
+        VALUES (?, ?, ?, ?)
+      `).run('legacy-change', 'session-1', '/tmp/repo', 42)
+
+      syncTable(WORKSPACE_RUN_CHANGES_TABLE, WORKSPACE_RUN_CHANGES_SCHEMA, {
+        indexes: WORKSPACE_RUN_CHANGES_INDEXES,
+      })
+
+      expect(getTableColumns(db, WORKSPACE_RUN_CHANGES_TABLE).has('assistant_message_id')).toBe(true)
+      expect(db.prepare(`
+        SELECT change_id, session_id, assistant_message_id
+        FROM "${WORKSPACE_RUN_CHANGES_TABLE}"
+      `).get()).toEqual({
+        change_id: 'legacy-change',
+        session_id: 'session-1',
+        assistant_message_id: '',
+      })
+    })
+
     it('adds missing safe columns to existing table without rebuilding', async () => {
       const { syncTable, USAGE_TABLE, USAGE_SCHEMA } = await import('../../packages/server/src/db/hermes/schemas')
 

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -342,6 +342,109 @@ describe('session conversations controller', () => {
     }
   })
 
+  it('accepts legacy workspace-prefixed paths for session workspace files', async () => {
+    const workspace = '/tmp/hermes-test/research/workspace'
+    await rm('/tmp/hermes-test', { recursive: true, force: true })
+    await mkdir(join(workspace, 'project'), { recursive: true })
+    await writeFile(join(workspace, 'project', 'notes.md'), 'hello')
+    getSessionMock.mockReturnValue({
+      id: 'session-with-workspace',
+      profile: 'research',
+      workspace,
+    })
+
+    try {
+      const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+      const listCtx: any = {
+        params: { id: 'session-with-workspace' },
+        query: { path: 'workspace/project' },
+        state: { profile: { name: 'research' } },
+        body: null,
+      }
+
+      await mod.listWorkspaceFiles(listCtx)
+
+      expect(listCtx.status).toBeUndefined()
+      expect(listCtx.body.path).toBe('project')
+      expect(listCtx.body.absolutePath).toBe(join(workspace, 'project'))
+      expect(listCtx.body.entries).toEqual([
+        expect.objectContaining({ name: 'notes.md', path: 'project/notes.md', isDir: false }),
+      ])
+
+      const readCtx: any = {
+        params: { id: 'session-with-workspace' },
+        query: { path: 'workspace/project/notes.md' },
+        state: { profile: { name: 'research' } },
+        body: null,
+      }
+
+      await mod.readWorkspaceFile(readCtx)
+
+      expect(readCtx.status).toBeUndefined()
+      expect(readCtx.body).toMatchObject({ content: 'hello', path: 'project/notes.md' })
+    } finally {
+      await rm('/tmp/hermes-test', { recursive: true, force: true })
+    }
+  })
+
+  it('keeps already session-relative workspace paths unchanged', async () => {
+    const workspace = '/tmp/hermes-test/research/workspace'
+    await rm('/tmp/hermes-test', { recursive: true, force: true })
+    await mkdir(join(workspace, 'project'), { recursive: true })
+    await writeFile(join(workspace, 'project', 'notes.md'), 'hello')
+    getSessionMock.mockReturnValue({
+      id: 'session-relative-workspace',
+      profile: 'research',
+      workspace,
+    })
+
+    try {
+      const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+      const ctx: any = {
+        params: { id: 'session-relative-workspace' },
+        query: { path: 'project/notes.md' },
+        state: { profile: { name: 'research' } },
+        body: null,
+      }
+
+      await mod.readWorkspaceFile(ctx)
+
+      expect(ctx.status).toBeUndefined()
+      expect(ctx.body).toMatchObject({ content: 'hello', path: 'project/notes.md' })
+    } finally {
+      await rm('/tmp/hermes-test', { recursive: true, force: true })
+    }
+  })
+
+  it('uses the session profile when no explicit request profile is present', async () => {
+    const workspace = '/tmp/hermes-test/research/workspace'
+    await rm('/tmp/hermes-test', { recursive: true, force: true })
+    await mkdir(join(workspace, 'project'), { recursive: true })
+    await writeFile(join(workspace, 'project', 'notes.md'), 'hello')
+    getSessionMock.mockReturnValue({
+      id: 'session-profile-workspace',
+      profile: 'research',
+      workspace,
+    })
+
+    try {
+      const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+      const ctx: any = {
+        params: { id: 'session-profile-workspace' },
+        query: { path: 'workspace/project/notes.md' },
+        state: {},
+        body: null,
+      }
+
+      await mod.readWorkspaceFile(ctx)
+
+      expect(ctx.status).toBeUndefined()
+      expect(ctx.body).toMatchObject({ content: 'hello', path: 'project/notes.md' })
+    } finally {
+      await rm('/tmp/hermes-test', { recursive: true, force: true })
+    }
+  })
+
   it('lists Windows drive roots for the workspace folder picker', async () => {
     const originalPlatform = process.platform
     const originalWorkspaceBase = process.env.WORKSPACE_BASE

--- a/tests/server/workspace-diff-tracker.test.ts
+++ b/tests/server/workspace-diff-tracker.test.ts
@@ -86,10 +86,12 @@ describe('workspace diff tracker', () => {
       sessionId: 'session-1',
       runId: 'run-1',
       workspace: repo,
+      assistantMessageId: '42',
     })
 
     expect(change).not.toBeNull()
     expect(change?.change_id).toMatch(/^run:run-1:/)
+    expect(change?.assistant_message_id).toBe('42')
     expect(change?.files.map(file => file.path)).toEqual(['changed.txt'])
     expect(change?.files[0]).toMatchObject({
       change_type: 'modified',
@@ -126,6 +128,76 @@ describe('workspace diff tracker', () => {
       change!.change_id,
       secondChange!.change_id,
     ]))
+  })
+
+  it('persists the exact final assistant row id through the coding-agent completion path', async () => {
+    const { startWorkspaceRunCheckpoint } = await import('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker')
+    const { CodingAgentRunManager } = await import('../../packages/server/src/services/agent-runner/coding-agent-run-manager')
+    const manager = new CodingAgentRunManager()
+    const emitted: Array<{ event: string; payload: any }> = []
+    ;(manager as any).emitToChat = (_sessionId: string, event: string, payload: any) => {
+      emitted.push({ event, payload })
+    }
+    ;(manager as any).markChatRunCompleted = () => {}
+    ;(manager as any).refreshCodingAgentUsage = async () => {}
+
+    manager.start({
+      agentSessionId: 'runner-turn-1',
+      agentId: 'claude-code',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'test-model',
+      sessionId: 'session-runner-turn',
+      command: 'claude',
+      args: [],
+      shellCommand: 'claude',
+      workspaceDir: repo,
+      state: { messages: [], isWorking: false, events: [], queue: [] },
+    })
+    startWorkspaceRunCheckpoint({
+      sessionId: 'session-runner-turn',
+      runId: 'runner-turn-1',
+      workspace: repo,
+    })
+    writeFileSync(join(repo, 'changed.txt'), 'runner update\n')
+
+    manager.handleResponseEvent('runner-turn-1', {
+      type: 'response.created',
+      data: { response: { id: 'response-runner-turn', status: 'in_progress' } },
+    })
+    manager.handleResponseEvent('runner-turn-1', {
+      type: 'response.output_text.delta',
+      data: { delta: 'Implemented the change.' },
+    })
+    manager.handleResponseEvent('runner-turn-1', {
+      type: 'response.completed',
+      data: {
+        response: {
+          id: 'response-runner-turn',
+          status: 'completed',
+          output: [{ type: 'message', content: [{ type: 'output_text', text: 'Implemented the change.' }] }],
+          model: 'test-model',
+          usage: { input_tokens: 10, output_tokens: 4 },
+        },
+      },
+    })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const assistant = state.db?.prepare(`
+      SELECT id FROM messages
+      WHERE session_id = ? AND role = 'assistant'
+      ORDER BY id DESC LIMIT 1
+    `).get('session-runner-turn') as { id: number } | undefined
+    const persistedChange = state.db?.prepare(`
+      SELECT assistant_message_id FROM workspace_run_changes
+      WHERE session_id = ?
+      ORDER BY created_at DESC LIMIT 1
+    `).get('session-runner-turn') as { assistant_message_id: string } | undefined
+
+    expect(assistant).toBeTruthy()
+    expect(persistedChange?.assistant_message_id).toBe(String(assistant?.id))
+    expect(emitted.some(item => item.event === 'workspace.diff.completed')).toBe(true)
+    manager.shutdown()
   })
 
   it('records added, modified, and deleted files in non-git workspaces', async () => {
@@ -298,6 +370,82 @@ describe('workspace diff tracker', () => {
 
     expect(change).not.toBeNull()
     expect(change?.files.map(file => file.path)).toEqual(['notes.md'])
+  })
+
+  it('retains line-level changes in SQLite sidecar-named files', async () => {
+    const {
+      completeWorkspaceRunCheckpoint,
+      startWorkspaceRunCheckpoint,
+    } = await import('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker')
+
+    writeFileSync(join(repo, 'state.db-wal'), 'before\n')
+    git(repo, ['add', 'state.db-wal'])
+    git(repo, ['commit', '-m', 'add text sidecar fixture'])
+
+    startWorkspaceRunCheckpoint({
+      sessionId: 'session-sidecar-lines',
+      runId: 'run-sidecar-lines',
+      workspace: repo,
+    })
+
+    writeFileSync(join(repo, 'state.db-wal'), 'after\n')
+    const change = completeWorkspaceRunCheckpoint({
+      sessionId: 'session-sidecar-lines',
+      runId: 'run-sidecar-lines',
+      workspace: repo,
+    })
+
+    expect(change).not.toBeNull()
+    expect(change?.files).toEqual([
+      expect.objectContaining({
+        path: 'state.db-wal',
+        additions: 1,
+        deletions: 1,
+        binary: false,
+      }),
+    ])
+  })
+
+  it('cleans historical zero-line rows and repairs parent aggregates idempotently', async () => {
+    const db = state.db!
+    const now = 1_700_000_000
+    const insertParent = db.prepare(`
+      INSERT INTO workspace_run_changes
+        (change_id, session_id, files_changed, additions, deletions, truncated, total_patch_bytes, created_at)
+      VALUES (?, 'session-history', ?, ?, ?, ?, ?, ?)
+    `)
+    const insertFile = db.prepare(`
+      INSERT INTO workspace_run_change_files
+        (change_id, session_id, path, additions, deletions, patch_bytes, truncated, created_at)
+      VALUES (?, 'session-history', ?, ?, ?, ?, ?, ?)
+    `)
+
+    insertParent.run('mixed', 2, 99, 88, 1, 777, now)
+    insertFile.run('mixed', 'zero.bin', 0, 0, 100, 1, now)
+    insertFile.run('mixed', 'kept.txt', 3, 2, 42, 0, now)
+    insertParent.run('zero-only', 1, 0, 0, 1, 64, now)
+    insertFile.run('zero-only', 'only.bin', 0, 0, 64, 1, now)
+
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    initAllHermesTables()
+    initAllHermesTables()
+
+    expect(db.prepare('SELECT path FROM workspace_run_change_files ORDER BY path').all()).toEqual([
+      { path: 'kept.txt' },
+    ])
+    expect(db.prepare(`
+      SELECT change_id, files_changed, additions, deletions, truncated, total_patch_bytes
+      FROM workspace_run_changes ORDER BY change_id
+    `).all()).toEqual([
+      {
+        change_id: 'mixed',
+        files_changed: 1,
+        additions: 3,
+        deletions: 2,
+        truncated: 0,
+        total_patch_bytes: 42,
+      },
+    ])
   })
 
   it('records newly created ordinary files even when many unchanged files already exist in non-git workspaces', async () => {


### PR DESCRIPTION
## Summary

This PR contains only the session workspace/file-diff behavior split from the original mixed PR at the maintainer's request:

- persist the database Assistant message ID for each run checkpoint
- attach each workspace diff to the exact Assistant response in live and reloaded sessions
- retain a standalone card only for legacy rows without an Assistant association
- suppress zero-line/noise rows and repair historical parent aggregates idempotently
- normalize legacy workspace paths only in session-scoped APIs; generic file routes are unchanged

## Scope boundary

Workflow route, loop, canvas, and execution-history UI changes are isolated in #2128 and are not part of this PR.

The implementation preserves the current `ToolChangeCard`/tool-panel architecture, session Profile-filter persistence, and the background subagent delivery behavior on the latest upstream `main`.

## Verification

Validated on current upstream `main`:

- focused and upstream-overlap Vitest: 13 files / 154 tests passed
- `i18n-coverage`: passed, including `chat.changesThisTurn` in all 10 locales
- full coverage A/B on this host: 0 current-only failures versus the exact upstream base
- `npm run harness:check`: passed
- `npm run build`: passed
- `git diff --check`: passed

Closes #2079.
Supersedes the still-needed behavior from #1924, #2011, and #2082.
