### PR TITLE
fix(group-chat): @mention not triggering after CJK/non-whitespace characters

### DIFF
--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -217,7 +217,8 @@ function updateMentionState() {
     }
 
     // Make sure the @ is not part of a word (preceded by space or start of line)
-    if (atPos > 0 && text[atPos - 1] !== ' ' && text[atPos - 1] !== '\n') {
+    // Using /\w/ which matches [a-zA-Z0-9_]; CJK/punctuation/emoji are not \w so they work as delimiters
+    if (atPos > 0 && /\w/.test(text[atPos - 1])) {
         mentionActive.value = false
         return
     }


### PR DESCRIPTION
## Problem

In Hermes Studio group chat, the @mention autocomplete only triggers when `@` is at the beginning of a message or immediately preceded by a space or newline. This breaks mention for any non-ASCII text — Chinese characters, Japanese, Korean, emoji, punctuation, etc.

**Reproduction:**
- `帮我查一下@后端` → ❌ dropdown does not appear
- `帮我查一下 @后端` → ✅ works (with a space)
- `help@backend` → ❌ does not work
- `help @backend` → ✅ works

This is an i18n/globalization bug that primarily affects CJK users.

## Root Cause

In `packages/client/src/components/hermes/group-chat/GroupChatInput.vue`, the `updateMentionState()` function at line 220 checks whether the character before `@` is a valid delimiter using hard-coded comparisons:

```typescript
// Before (broken):
if (atPos > 0 && text[atPos - 1] !== ' ' && text[atPos - 1] !== '\n') {
    mentionActive.value = false;
    return;
}
```

This only recognizes ASCII space (`0x20`) and newline (`0x0A`). Chinese characters (CJK Unified Ideographs), full-width punctuation, and any other non-whitespace characters are not recognized as valid delimiters, so the mention system silently rejects them.

## Fix

Replaced the hard-coded space/newline check with a `\w` regex test:

```typescript
// After (fixed):
if (atPos > 0 && /\w/.test(text[atPos - 1])) {
    mentionActive.value = false;
    return;
}
```

`\w` matches `[a-zA-Z0-9_]`. CJK characters, full-width characters, emoji, and punctuation are NOT matched by `\w`, so they correctly work as valid delimiters. Only actual word characters suppress the mention — which is the correct behavior (e.g., `email@domain` or `variable@func` should not trigger mentions).

## Verification

| Scenario | Before | After |
|----------|--------|-------|
| `帮我查一下@后端` | ❌ | ✅ |
| ` @后端` | ✅ | ✅ |
| `help@backend` | ❌ | ❌ (correctly suppressed) |
| `hello.@后端` | ❌ | ✅ |

Fixes #2132