### PR TITLE
fix(agent-bridge): persist legacy execute_code approvals

### DIFF
--- a/docs/chat-chain-changes/2026-07-19-execute-code-approval-memory.md
+++ b/docs/chat-chain-changes/2026-07-19-execute-code-approval-memory.md
@@ -1,0 +1,9 @@
+---
+date: 2026-07-19
+pr: pending
+feature: Execute-code approval memory
+impact: Legacy Agent Bridge gateway approvals for execute_code can persist Session and Always choices when descriptive guard pattern keys are emitted.
+---
+
+The bridge now carries an execute_code marker from structured gateway approval
+tool fields instead of relying only on the literal pattern key.

--- a/docs/chat-chain-changes/2026-07-19-execute-code-approval-memory.md
+++ b/docs/chat-chain-changes/2026-07-19-execute-code-approval-memory.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-07-19
-pr: pending
+pr: 2135
 feature: Execute-code approval memory
 impact: Legacy Agent Bridge gateway approvals for execute_code can persist Session and Always choices when descriptive guard pattern keys are emitted.
 ---

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -17,6 +17,7 @@ from typing import Any, Callable
 from bridge_runtime import (
     APPROVAL_TIMEOUT_MS,
     APPROVAL_TIMEOUT_SECONDS,
+    _approval_is_execute_code,
     _approval_pattern_keys,
     _base_hermes_home,
     _bridge_platform,
@@ -181,6 +182,7 @@ class AgentPool:
         self._approval_requests: dict[str, queue.Queue[str]] = {}
         self._gateway_approval_requests: dict[str, str] = {}
         self._gateway_approval_pattern_keys: dict[str, list[str]] = {}
+        self._gateway_approval_execute_code: dict[str, bool] = {}
         self._compression_requests: dict[str, queue.Queue[dict[str, Any]]] = {}
         self._background_notification_claims: dict[tuple[str, str], dict[str, Any]] = {}
         self._suppressed_background_delegations: set[str] = set()
@@ -1270,9 +1272,11 @@ class AgentPool:
             approval_id = uuid.uuid4().hex
             choices = ["once", "session", "always", "deny"]
             pattern_keys = _approval_pattern_keys(approval_data)
+            is_execute_code = _approval_is_execute_code(approval_data)
             with self._lock:
                 self._gateway_approval_requests[approval_id] = session_id
                 self._gateway_approval_pattern_keys[approval_id] = pattern_keys
+                self._gateway_approval_execute_code[approval_id] = is_execute_code
             self._append_event(session_id, {
                 "event": "approval.requested",
                 "approval_id": approval_id,
@@ -1810,6 +1814,7 @@ class AgentPool:
             with self._lock:
                 gateway_session_id = self._gateway_approval_requests.pop(approval_id, None)
                 pattern_keys = self._gateway_approval_pattern_keys.pop(approval_id, [])
+                is_execute_code = self._gateway_approval_execute_code.pop(approval_id, False)
             if gateway_session_id is None:
                 return {"approval_id": approval_id, "resolved": False, "choice": cleaned}
             try:
@@ -1819,7 +1824,7 @@ class AgentPool:
             except Exception:
                 resolved = False
             if resolved:
-                _persist_execute_code_approval_choice(gateway_session_id, pattern_keys, cleaned)
+                _persist_execute_code_approval_choice(gateway_session_id, pattern_keys, cleaned, is_execute_code)
             self._append_event(gateway_session_id, {
                 "event": "approval.resolved",
                 "approval_id": approval_id,

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_runtime.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_runtime.py
@@ -720,7 +720,14 @@ def _install_execute_code_approval_memory_patch() -> None:
         import tools.approval as approval
 
         original = getattr(approval, "check_execute_code_guard", None)
-        if not callable(original) or getattr(original, "_hermes_web_ui_memory_patch", False):
+        if getattr(original, "_hermes_web_ui_memory_patch", False):
+            return
+        if not callable(original):
+            if not getattr(approval, "_hermes_web_ui_memory_patch_missing_logged", False):
+                _bridge_log("execute_code_approval_memory_patch.skipped", {
+                    "reason": "check_execute_code_guard_missing",
+                })
+                setattr(approval, "_hermes_web_ui_memory_patch_missing_logged", True)
             return
 
         def patched_check_execute_code_guard(code: str, env_type: str, *args: Any, **kwargs: Any) -> dict[str, Any]:
@@ -735,8 +742,9 @@ def _install_execute_code_approval_memory_patch() -> None:
         setattr(patched_check_execute_code_guard, "_hermes_web_ui_memory_patch", True)
         setattr(patched_check_execute_code_guard, "_hermes_web_ui_original", original)
         approval.check_execute_code_guard = patched_check_execute_code_guard
-    except Exception:
-        pass
+        _bridge_log("execute_code_approval_memory_patch.installed", {})
+    except Exception as exc:
+        _bridge_log("execute_code_approval_memory_patch.failed", {"error": str(exc)})
 
 
 def _approval_pattern_keys(approval_data: dict[str, Any]) -> list[str]:
@@ -750,8 +758,51 @@ def _approval_pattern_keys(approval_data: dict[str, Any]) -> list[str]:
     return result
 
 
-def _persist_execute_code_approval_choice(session_id: str, pattern_keys: list[str], choice: str) -> None:
-    if "execute_code" not in pattern_keys or choice not in {"session", "always"}:
+def _tool_name_from_approval_data(approval_data: Any) -> str:
+    if not isinstance(approval_data, dict):
+        return ""
+    for key in ("tool_name", "function_name"):
+        value = approval_data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    tool = approval_data.get("tool")
+    if isinstance(tool, str) and tool.strip():
+        return tool.strip()
+    if isinstance(tool, dict):
+        value = tool.get("name")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        function = tool.get("function")
+        if isinstance(function, dict):
+            value = function.get("name")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    tool_call = approval_data.get("tool_call")
+    if isinstance(tool_call, dict):
+        value = tool_call.get("name")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        function = tool_call.get("function")
+        if isinstance(function, dict):
+            value = function.get("name")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
+def _approval_is_execute_code(approval_data: dict[str, Any]) -> bool:
+    return _tool_name_from_approval_data(approval_data) == "execute_code"
+
+
+def _persist_execute_code_approval_choice(
+    session_id: str,
+    pattern_keys: list[str],
+    choice: str,
+    is_execute_code: bool = False,
+) -> None:
+    if choice not in {"session", "always"}:
+        return
+    if not is_execute_code and "execute_code" not in pattern_keys:
         return
     try:
         from tools.approval import approve_permanent, approve_session, load_permanent_allowlist, save_permanent_allowlist
@@ -764,8 +815,8 @@ def _persist_execute_code_approval_choice(session_id: str, pattern_keys: list[st
             patterns = set(permanent) if isinstance(permanent, set) else set(load_permanent_allowlist())
             patterns.add("execute_code")
             save_permanent_allowlist(patterns)
-    except Exception:
-        pass
+    except Exception as exc:
+        _bridge_log("execute_code_approval_memory_persist.failed", {"error": str(exc)})
 
 
 def _resolve_model(cfg: dict[str, Any]) -> str:

--- a/packages/server/src/services/hermes/agent-bridge/python/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/hermes_bridge.py
@@ -42,6 +42,7 @@ _RUNTIME_PATCH_NAMES = (
     "_apply_openrouter_attribution_override",
     "_apply_profile_dotenv",
     "_apply_profile_env",
+    "_approval_is_execute_code",
     "_base_hermes_home",
     "_bridge_log",
     "_bridge_platform",
@@ -74,6 +75,7 @@ _RUNTIME_PATCH_NAMES = (
 _POOL_PATCH_NAMES = (
     "APPROVAL_TIMEOUT_MS",
     "APPROVAL_TIMEOUT_SECONDS",
+    "_approval_is_execute_code",
     "_approval_pattern_keys",
     "_base_hermes_home",
     "_bridge_platform",

--- a/tests/server/agent-bridge-learn-command.test.ts
+++ b/tests/server/agent-bridge-learn-command.test.ts
@@ -21,6 +21,7 @@ function runPython(script: string): any {
 
 const harness = String.raw`
 import contextlib
+import ast
 import importlib.util
 import json
 import sys
@@ -31,6 +32,7 @@ from pathlib import Path
 bridge_runtime = types.ModuleType("bridge_runtime")
 bridge_runtime.APPROVAL_TIMEOUT_MS = 1000
 bridge_runtime.APPROVAL_TIMEOUT_SECONDS = 1
+bridge_runtime._approval_is_execute_code = lambda *_args, **_kwargs: False
 bridge_runtime._approval_pattern_keys = lambda *_args, **_kwargs: []
 bridge_runtime._base_hermes_home = lambda: Path(tempfile.gettempdir())
 bridge_runtime._bridge_platform = lambda: "agent-bridge"
@@ -60,11 +62,21 @@ def _profile_env(_profile):
     yield
 
 bridge_runtime._profile_env = _profile_env
+
+bridge_pool_path = Path("packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py")
+imported_runtime_names = {
+    alias.name
+    for node in ast.parse(bridge_pool_path.read_text(encoding="utf-8")).body
+    if isinstance(node, ast.ImportFrom) and node.module == "bridge_runtime"
+    for alias in node.names
+}
+missing_runtime_stubs = sorted(name for name in imported_runtime_names if not hasattr(bridge_runtime, name))
+assert not missing_runtime_stubs, f"fake bridge_runtime is missing stubs: {missing_runtime_stubs}"
 sys.modules["bridge_runtime"] = bridge_runtime
 
 spec = importlib.util.spec_from_file_location(
     "bridge_pool",
-    "packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py",
+    bridge_pool_path,
 )
 bridge_pool = importlib.util.module_from_spec(spec)
 assert spec.loader is not None

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -876,6 +876,31 @@ assert approval._check_execute_code_calls == [("print(4)", "local", True)]
 `)
   })
 
+  it('remembers legacy execute_code gateway approvals with descriptive pattern keys', () => {
+    runPython(String.raw`
+${harness}
+
+delattr(approval, "check_execute_code_guard")
+pool, _fake_db = make_pool()
+
+notify = pool._gateway_approval_notify("legacy-session")
+notify({
+    "command": "python3 - <<'PY'\nprint(1)\nPY",
+    "description": "Run Python code",
+    "tool_name": "execute_code",
+    "pattern_key": "python execution",
+    "pattern_keys": ["python execution", "shell heredoc"],
+})
+approval_id = next(iter(pool._gateway_approval_requests.keys()))
+
+result = pool.respond_approval(approval_id, "session")
+
+assert result["resolved"] is True
+assert approval.is_approved("legacy-session", "execute_code") is True
+assert approval._saved_permanent == set()
+`)
+  })
+
   it('routes terminal/gateway approvals and stream callbacks per concurrent session', () => {
     runPython(String.raw`
 ${harness}

--- a/tests/server/agent-bridge-usage-hook.test.ts
+++ b/tests/server/agent-bridge-usage-hook.test.ts
@@ -20,6 +20,7 @@ function runPython(script: string): any {
 
 const harness = String.raw`
 import contextlib
+import ast
 import importlib.util
 import json
 import sys
@@ -30,6 +31,7 @@ from pathlib import Path
 bridge_runtime = types.ModuleType("bridge_runtime")
 bridge_runtime.APPROVAL_TIMEOUT_MS = 1000
 bridge_runtime.APPROVAL_TIMEOUT_SECONDS = 1
+bridge_runtime._approval_is_execute_code = lambda *_args, **_kwargs: False
 bridge_runtime._approval_pattern_keys = lambda *_args, **_kwargs: []
 bridge_runtime._base_hermes_home = lambda: Path(tempfile.gettempdir())
 bridge_runtime._bridge_platform = lambda: "agent-bridge"
@@ -59,6 +61,16 @@ def _profile_env(_profile):
     yield
 
 bridge_runtime._profile_env = _profile_env
+
+bridge_pool_path = Path("packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py")
+imported_runtime_names = {
+    alias.name
+    for node in ast.parse(bridge_pool_path.read_text(encoding="utf-8")).body
+    if isinstance(node, ast.ImportFrom) and node.module == "bridge_runtime"
+    for alias in node.names
+}
+missing_runtime_stubs = sorted(name for name in imported_runtime_names if not hasattr(bridge_runtime, name))
+assert not missing_runtime_stubs, f"fake bridge_runtime is missing stubs: {missing_runtime_stubs}"
 sys.modules["bridge_runtime"] = bridge_runtime
 
 plugins = types.ModuleType("hermes_cli.plugins")
@@ -74,7 +86,7 @@ sys.modules["hermes_cli.plugins"] = plugins
 
 spec = importlib.util.spec_from_file_location(
     "bridge_pool",
-    "packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py",
+    bridge_pool_path,
 )
 bridge_pool = importlib.util.module_from_spec(spec)
 assert spec.loader is not None


### PR DESCRIPTION
## Summary

- persist Session/Always approval choices for legacy Hermes Agent runtimes when structured gateway approval data identifies `execute_code`
- keep execute-code detection conservative by using exact structured tool names or the existing literal pattern key
- log whether the optional execute-code guard hook is installed, unavailable, or fails to install
- add focused regression coverage for a legacy runtime without `check_execute_code_guard`

Fixes #1993.

## Validation

- `npm run test -- tests/server/agent-bridge-python-concurrency.test.ts` (34 passed)
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile packages/server/src/services/hermes/agent-bridge/python/bridge_runtime.py packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py packages/server/src/services/hermes/agent-bridge/python/hermes_bridge.py`
- `npm run harness:check`
- `git diff --check`
- independent read-only audit: candidate PASS, patch PASS

## Duplicate Check

Immediately before publication, `origin/main` remained at `62d875bfb68e35363830ce4b705129a234ac06f9`, issue #1993 remained open, and live GitHub searches found no active PR covering `check_execute_code_guard` absence or legacy `execute_code` approval-memory persistence. Closed PR #1910 addresses guard-signature forwarding, not this compatibility path.

## Browser / Playwright

Not run; not applicable. This change is limited to backend Python Agent Bridge approval-memory behavior and is covered by the focused server/Python harness regression.
