### PR TITLE
Fix Linux desktop packaging

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -53,11 +53,10 @@ extraResources:
       - "**/*"
       # Drop other-platform node-pty prebuilds (saves ~45MB)
       - "!node-pty/prebuilds/!(${platform}-${arch})/**"
-      # Linux has no bundled prebuild and loads the native module plus helper
-      # compiled by `npm rebuild node-pty` from build/Release.
+      # Linux has no bundled prebuild and loads the native module compiled by
+      # `npm rebuild node-pty` from build/Release.
       - "!node-pty/build/**"
       - "node-pty/build/Release/pty.node"
-      - "node-pty/build/Release/spawn-helper"
       - "!**/*.md"
 
 asarUnpack:

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -53,7 +53,11 @@ extraResources:
       - "**/*"
       # Drop other-platform node-pty prebuilds (saves ~45MB)
       - "!node-pty/prebuilds/!(${platform}-${arch})/**"
+      # Linux has no bundled prebuild and loads the native module plus helper
+      # compiled by `npm rebuild node-pty` from build/Release.
       - "!node-pty/build/**"
+      - "node-pty/build/Release/pty.node"
+      - "node-pty/build/Release/spawn-helper"
       - "!**/*.md"
 
 asarUnpack:

--- a/packages/desktop/scripts/electron-builder.mjs
+++ b/packages/desktop/scripts/electron-builder.mjs
@@ -17,7 +17,7 @@ function hasConfigOverride(sourceArgs, key) {
 const debConfigArgs = [
   '--config.productName=hermes-studio',
   '--config.linux.executableName=hermes-studio',
-  '--config.linux.desktop.Name=Hermes Studio',
+  '--config.linux.desktop.entry.Name=Hermes Studio',
 ]
 
 function linuxTargetInfo(sourceArgs) {

--- a/packages/desktop/scripts/verify-packaged-webui.mjs
+++ b/packages/desktop/scripts/verify-packaged-webui.mjs
@@ -32,12 +32,8 @@ export default async function verifyPackagedWebUi(context) {
 
   const hasNodePtyPrebuild = existsSync(nodePtyPrebuild)
   if (context.electronPlatformName === 'linux' && !hasNodePtyPrebuild) {
-    const nodePtyRelease = join(nodePtyRoot, 'build', 'Release')
-    const compiledRuntime = [
-      join(nodePtyRelease, 'pty.node'),
-      join(nodePtyRelease, 'spawn-helper'),
-    ]
-    missing.push(...compiledRuntime.filter(path => !existsSync(path)))
+    const compiledModule = join(nodePtyRoot, 'build', 'Release', 'pty.node')
+    if (!existsSync(compiledModule)) missing.push(compiledModule)
   } else if (!hasNodePtyPrebuild) {
     missing.push(nodePtyPrebuild)
   }

--- a/packages/desktop/scripts/verify-packaged-webui.mjs
+++ b/packages/desktop/scripts/verify-packaged-webui.mjs
@@ -20,15 +20,28 @@ export default async function verifyPackagedWebUi(context) {
   const webUiRoot = join(packagedResourcesDirectory(context), 'webui')
   const nodePtyRoot = join(webUiRoot, 'node_modules', 'node-pty')
   const nodePtyTarget = `${context.electronPlatformName}-${targetArchName(context.arch)}`
+  const nodePtyPrebuild = join(nodePtyRoot, 'prebuilds', nodePtyTarget)
   const required = [
     join(webUiRoot, 'package.json'),
     join(webUiRoot, 'bin', 'hermes-web-ui.mjs'),
     join(webUiRoot, 'dist', 'server', 'index.js'),
     join(nodePtyRoot, 'package.json'),
-    join(nodePtyRoot, 'prebuilds', nodePtyTarget),
     join(webUiRoot, 'node_modules', 'socket.io', 'package.json'),
   ]
   const missing = required.filter(path => !existsSync(path))
+
+  const hasNodePtyPrebuild = existsSync(nodePtyPrebuild)
+  if (context.electronPlatformName === 'linux' && !hasNodePtyPrebuild) {
+    const nodePtyRelease = join(nodePtyRoot, 'build', 'Release')
+    const compiledRuntime = [
+      join(nodePtyRelease, 'pty.node'),
+      join(nodePtyRelease, 'spawn-helper'),
+    ]
+    missing.push(...compiledRuntime.filter(path => !existsSync(path)))
+  } else if (!hasNodePtyPrebuild) {
+    missing.push(nodePtyPrebuild)
+  }
+
   if (missing.length > 0) {
     throw new Error(`Packaged Web UI is incomplete; missing: ${missing.join(', ')}`)
   }

--- a/tests/desktop/packaged-webui.test.ts
+++ b/tests/desktop/packaged-webui.test.ts
@@ -29,6 +29,16 @@ function createPackagedWebUi(appOutDir: string): void {
   }
 }
 
+function createCompiledLinuxNodePty(appOutDir: string): void {
+  const nodePtyRoot = join(appOutDir, 'resources', 'webui', 'node_modules', 'node-pty')
+  rmSync(join(nodePtyRoot, 'prebuilds'), { recursive: true, force: true })
+  for (const file of ['build/Release/pty.node', 'build/Release/spawn-helper']) {
+    const target = join(nodePtyRoot, file)
+    mkdirSync(dirname(target), { recursive: true })
+    writeFileSync(target, '')
+  }
+}
+
 afterEach(() => {
   for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true })
 })
@@ -45,6 +55,17 @@ describe('packaged desktop Web UI', () => {
     expect(config).toContain('afterPack: "./scripts/verify-packaged-webui.mjs"')
     expect(config).toContain('from: "../../node_modules"')
     expect(config).toContain('to: "webui/node_modules"')
+    const buildExclusion = config.indexOf('!node-pty/build/**')
+    expect(buildExclusion).toBeGreaterThan(-1)
+    expect(config.indexOf('node-pty/build/Release/pty.node')).toBeGreaterThan(buildExclusion)
+    expect(config.indexOf('node-pty/build/Release/spawn-helper')).toBeGreaterThan(buildExclusion)
+  })
+
+  it('uses the electron-builder 26 desktop entry schema for deb packages', () => {
+    const script = readFileSync(resolve('packages/desktop/scripts/electron-builder.mjs'), 'utf8')
+
+    expect(script).toContain('--config.linux.desktop.entry.Name=Hermes Studio')
+    expect(script).not.toContain('--config.linux.desktop.Name=Hermes Studio')
   })
 
   it('accepts a package containing the server and target native dependencies', async () => {
@@ -70,5 +91,32 @@ describe('packaged desktop Web UI', () => {
       arch: 1,
       packager: { appInfo: { productFilename: 'Hermes Studio' } },
     } as never)).rejects.toThrow('Packaged Web UI is incomplete')
+  })
+
+  it('accepts source-built node-pty runtime files on Linux', async () => {
+    const appOutDir = packagedRoot()
+    createPackagedWebUi(appOutDir)
+    createCompiledLinuxNodePty(appOutDir)
+
+    await expect(verifyPackagedWebUi({
+      appOutDir,
+      electronPlatformName: 'linux',
+      arch: 3,
+      packager: { appInfo: { productFilename: 'Hermes Studio' } },
+    } as never)).resolves.toBeUndefined()
+  })
+
+  it('rejects an incomplete source-built node-pty runtime on Linux', async () => {
+    const appOutDir = packagedRoot()
+    createPackagedWebUi(appOutDir)
+    createCompiledLinuxNodePty(appOutDir)
+    rmSync(join(appOutDir, 'resources', 'webui', 'node_modules', 'node-pty', 'build', 'Release', 'spawn-helper'))
+
+    await expect(verifyPackagedWebUi({
+      appOutDir,
+      electronPlatformName: 'linux',
+      arch: 3,
+      packager: { appInfo: { productFilename: 'Hermes Studio' } },
+    } as never)).rejects.toThrow('spawn-helper')
   })
 })

--- a/tests/desktop/packaged-webui.test.ts
+++ b/tests/desktop/packaged-webui.test.ts
@@ -32,11 +32,9 @@ function createPackagedWebUi(appOutDir: string): void {
 function createCompiledLinuxNodePty(appOutDir: string): void {
   const nodePtyRoot = join(appOutDir, 'resources', 'webui', 'node_modules', 'node-pty')
   rmSync(join(nodePtyRoot, 'prebuilds'), { recursive: true, force: true })
-  for (const file of ['build/Release/pty.node', 'build/Release/spawn-helper']) {
-    const target = join(nodePtyRoot, file)
-    mkdirSync(dirname(target), { recursive: true })
-    writeFileSync(target, '')
-  }
+  const target = join(nodePtyRoot, 'build', 'Release', 'pty.node')
+  mkdirSync(dirname(target), { recursive: true })
+  writeFileSync(target, '')
 }
 
 afterEach(() => {
@@ -58,7 +56,6 @@ describe('packaged desktop Web UI', () => {
     const buildExclusion = config.indexOf('!node-pty/build/**')
     expect(buildExclusion).toBeGreaterThan(-1)
     expect(config.indexOf('node-pty/build/Release/pty.node')).toBeGreaterThan(buildExclusion)
-    expect(config.indexOf('node-pty/build/Release/spawn-helper')).toBeGreaterThan(buildExclusion)
   })
 
   it('uses the electron-builder 26 desktop entry schema for deb packages', () => {
@@ -106,17 +103,17 @@ describe('packaged desktop Web UI', () => {
     } as never)).resolves.toBeUndefined()
   })
 
-  it('rejects an incomplete source-built node-pty runtime on Linux', async () => {
+  it('rejects a missing source-built node-pty module on Linux', async () => {
     const appOutDir = packagedRoot()
     createPackagedWebUi(appOutDir)
     createCompiledLinuxNodePty(appOutDir)
-    rmSync(join(appOutDir, 'resources', 'webui', 'node_modules', 'node-pty', 'build', 'Release', 'spawn-helper'))
+    rmSync(join(appOutDir, 'resources', 'webui', 'node_modules', 'node-pty', 'build', 'Release', 'pty.node'))
 
     await expect(verifyPackagedWebUi({
       appOutDir,
       electronPlatformName: 'linux',
       arch: 3,
       packager: { appInfo: { productFilename: 'Hermes Studio' } },
-    } as never)).rejects.toThrow('spawn-helper')
+    } as never)).rejects.toThrow('pty.node')
   })
 })


### PR DESCRIPTION
## What changed

- update the deb desktop entry override for the electron-builder 26 schema
- retain the Linux node-pty native module in the bundled Web UI
- accept and verify source-built node-pty files for Linux packages
- add regression coverage for both Linux packaging failures

## Root cause

Linux x64 passed linux.desktop.Name to electron-builder 26 instead of linux.desktop.entry.Name. Linux compiles node-pty locally because no Linux prebuild is bundled, but the desktop resource filter removed build/Release before the afterPack verifier ran.

## Validation

- npm test: 348 files passed, 2746 tests passed, 2 skipped
- npm run build
- npm run harness:check
- npm --prefix packages/desktop run build
- targeted packaged Web UI tests
- electron-builder 26 schema validation
- Linux node-pty resource filter validation
- Linux x64 deb and AppImage build: https://github.com/EKKOLearnAI/hermes-studio/actions/runs/29672681604
- Linux arm64 AppImage build: https://github.com/EKKOLearnAI/hermes-studio/actions/runs/29672682411
- PR Build and Playwright checks passed