### PR TITLE
fix(workflow): preserve bridge run source across handoff

### DIFF
--- a/docs/chat-chain-changes/2026-07-19-workflow-bridge-handoff.md
+++ b/docs/chat-chain-changes/2026-07-19-workflow-bridge-handoff.md
@@ -1,0 +1,23 @@
+---
+date: 2026-07-19
+pr: pending
+feature: Workflow bridge handoff
+impact: Hermes Workflow nodes no longer run ordinary-chat standing-goal evaluation after completion, preventing that post-turn work from blocking the next node's Agent Bridge readiness check.
+---
+
+Workflow progression is owned by the DAG scheduler, and each Workflow node uses a
+separate Session. Successful Workflow bridge runs now skip ordinary Chat's
+standing-goal continuation judge while CLI and Global Agent sessions preserve the
+existing continuation behavior.
+
+Bridge reattachment also preserves `source: workflow` in both the socket state and
+the resumed run helper, so a resumed Workflow node follows the same terminal
+semantics as a fresh node.
+
+Regression coverage forces source changes in both directions: Workflow completion
+followed by queued CLI/Global Agent work still skips the judge, while CLI/Global
+Agent completion followed by queued Workflow work still evaluates ordinary Chat
+goals and keeps the completed run's source on any generated continuation. It also
+covers empty-queue Workflow completion, synthetic completion when a bridge stream
+ends without a terminal chunk, resumed runs, and caller-side source recovery from
+a hydrated state that omits source.

--- a/docs/chat-chain-changes/2026-07-19-workflow-bridge-handoff.md
+++ b/docs/chat-chain-changes/2026-07-19-workflow-bridge-handoff.md
@@ -1,8 +1,8 @@
 ---
 date: 2026-07-19
-pr: pending
+pr: 2137
 feature: Workflow bridge handoff
-impact: Hermes Workflow nodes no longer run ordinary-chat standing-goal evaluation after completion, preventing that post-turn work from blocking the next node's Agent Bridge readiness check.
+impact: Hermes Workflow nodes no longer run ordinary-chat standing-goal evaluation after completion, while all Hermes bridge runs retain the existing broker readiness gate.
 ---
 
 Workflow progression is owned by the DAG scheduler, and each Workflow node uses a
@@ -20,4 +20,6 @@ Agent completion followed by queued Workflow work still evaluates ordinary Chat
 goals and keeps the completed run's source on any generated continuation. It also
 covers empty-queue Workflow completion, synthetic completion when a bridge stream
 ends without a terminal chunk, resumed runs, and caller-side source recovery from
-a hydrated state that omits source.
+a hydrated state that omits source. Workflow starts continue to use the same broker
+readiness check as other Hermes bridge runs; this change does not bypass or extend
+the existing outage behavior.

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -27,7 +27,7 @@ import {
   recordBridgeMoaDisplayTool,
 } from './bridge-message'
 import { summarizeToolArguments } from './response-utils'
-import type { ContentBlock, QueuedRun, SessionState } from './types'
+import type { ChatRunSource, ContentBlock, QueuedRun, SessionState } from './types'
 import type { ChatMessage } from '../../../lib/context-compressor'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
 import { filterBridgeToolCallMarkupDelta, flushPendingToolCallMarkup } from './bridge-delta'
@@ -42,6 +42,14 @@ const BRIDGE_USAGE_FLUSH_DELAY_MS = 200
 const BRIDGE_TITLE_EVENT_POLL_INTERVAL_MS = 500
 const BRIDGE_TITLE_EVENT_POLL_TIMEOUT_MS = 45_000
 const BRIDGE_GOAL_EVALUATE_TIMEOUT_MS = 120_000
+
+type BridgeRunSource = Extract<ChatRunSource, 'cli' | 'global_agent' | 'workflow'>
+
+function normalizeBridgeRunSource(source?: string | null, sessionSource?: string | null): BridgeRunSource {
+  if (sessionSource === 'global_agent' || source === 'global_agent') return 'global_agent'
+  if (sessionSource === 'workflow' || source === 'workflow') return 'workflow'
+  return 'cli'
+}
 
 function stringValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
@@ -351,11 +359,7 @@ export async function handleBridgeRun(
   dequeueNextQueuedRun: (socket: Socket, sessionId: string, fallbackProfile?: string) => void,
 ) {
   const { input, session_id, instructions } = data
-  const runSource = data.session_source === 'global_agent' || data.source === 'global_agent'
-    ? 'global_agent'
-    : data.session_source === 'workflow' || data.source === 'workflow'
-      ? 'workflow'
-      : 'cli'
+  const runSource = normalizeBridgeRunSource(data.source, data.session_source)
   // Web UI Hermes agents currently opt out at creation time. Workflow callers
   // also pass false explicitly; a future single-chat setting can opt in with true
   // without changing the permanently-disabled workflow and group-chat callers.
@@ -639,6 +643,7 @@ export async function handleBridgeRun(
         dequeueNextQueuedRun,
         fullInstructions,
         { model: resolvedModel, provider: resolvedProvider },
+        runSource,
         workspace,
         currentInputTokens,
         shouldPersistUserMessage && displayRole === 'user',
@@ -684,6 +689,7 @@ export async function handleBridgeRun(
         dequeueNextQueuedRun,
         fullInstructions,
         { model: resolvedModel, provider: resolvedProvider },
+        runSource,
         workspace,
         currentInputTokens,
         shouldPersistUserMessage && displayRole === 'user',
@@ -777,6 +783,7 @@ export async function resumeBridgeRun(
   dequeueNextQueuedRun: (socket: Socket, sessionId: string, fallbackProfile?: string) => void,
 ) {
   const { sessionId, runId, profile, instructions } = args
+  const runSource = normalizeBridgeRunSource(args.source)
   let state = sessionMap.get(sessionId)
   if (!state) {
     state = { messages: [], isWorking: false, events: [], queue: [] }
@@ -787,7 +794,7 @@ export async function resumeBridgeRun(
   state.isWorking = true
   state.isAborting = state.isAborting === true
   state.profile = profile
-  state.source = args.source === 'global_agent' ? 'global_agent' : 'cli'
+  state.source = runSource
   state.runId = runId
   state.activeRunMarker = runMarker
   state.bridgeOutput = state.bridgeOutput || latestAssistantText(state)
@@ -852,6 +859,7 @@ export async function resumeBridgeRun(
         dequeueNextQueuedRun,
         instructions,
         { model: args.model, provider: args.provider },
+        runSource,
         args.workspace,
       )
     }
@@ -885,6 +893,7 @@ export async function resumeBridgeRun(
           dequeueNextQueuedRun,
           instructions,
           { model: args.model, provider: args.provider },
+          runSource,
           args.workspace,
         )
       }
@@ -1066,6 +1075,7 @@ async function applyBridgeChunkAsync(
   dequeueNextQueuedRun: (socket: Socket, sessionId: string, fallbackProfile?: string) => void,
   instructions: string,
   modelContext: { model?: string | null; provider?: string | null },
+  runSource: BridgeRunSource,
   workspace?: string | null,
   currentInputTokens = 0,
   currentInputIncludedInDb = true,
@@ -1584,7 +1594,11 @@ async function applyBridgeChunkAsync(
   }
   emit(eventName, payload)
 
-  if (!terminalError) {
+  // Workflow node progression is owned by the DAG scheduler. Use the immutable
+  // source of the run being finalized: state.source may already describe the
+  // next queued run by this point. The standing-goal judge uses the same profile
+  // worker as chat runs and can otherwise delay the scheduler's next node.
+  if (!terminalError && runSource !== 'workflow') {
     await maybeEnqueueGoalContinuation({
       nsp,
       socket,
@@ -1596,6 +1610,7 @@ async function applyBridgeChunkAsync(
       modelGroups,
       instructions,
       finalResponse,
+      runSource,
     })
   }
 
@@ -1667,6 +1682,7 @@ async function maybeEnqueueGoalContinuation(args: {
   modelGroups?: RunModelGroup[]
   instructions: string
   finalResponse: string
+  runSource: BridgeRunSource
 }) {
   const finalResponse = args.finalResponse || ''
   if (!finalResponse.trim()) return
@@ -1717,7 +1733,7 @@ async function maybeEnqueueGoalContinuation(args: {
     model_groups: args.modelGroups,
     instructions: undefined,
     profile: args.profile,
-    source: args.state.source === 'global_agent' ? 'global_agent' : 'cli',
+    source: args.runSource === 'global_agent' ? 'global_agent' : 'cli',
     goalContinuation: true,
   }
   args.state.queue.push(next)

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -796,7 +796,11 @@ export class ChatRunSocket {
       state.runId = runId
       state.activeRunMarker = undefined
       state.profile = profile
-      state.source = source === 'global_agent' ? 'global_agent' : 'cli'
+      state.source = source === 'global_agent'
+        ? 'global_agent'
+        : source === 'workflow'
+          ? 'workflow'
+          : 'cli'
       state.events = []
       const instructions = this.resumeInstructionsForSession(sid)
       void resumeBridgeRun(

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -443,7 +443,13 @@ export class ChatRunSocket {
     if (data.session_id && isBridgeRunSource(source) && isSessionCommand(data.input) && data.allow_command_passthrough !== true) return
 
     if (!isCodingAgentExecution(source, data)) {
-      const bridgeReady = await ensureBridgeReadyForChatRun()
+      // Workflow nodes are already sequenced by the Workflow manager. A previous
+      // Hermes node can leave the shared broker briefly busy after its terminal
+      // event; a 1s readiness probe would misclassify that handoff as downtime.
+      // Let the real bridge request wait/fail on its normal transport contract.
+      const bridgeReady = source === 'workflow'
+        ? { ok: true as const }
+        : await ensureBridgeReadyForChatRun()
       if (!bridgeReady.ok) {
         let shouldDequeueNext = false
         let queueRemaining = 0

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -443,13 +443,7 @@ export class ChatRunSocket {
     if (data.session_id && isBridgeRunSource(source) && isSessionCommand(data.input) && data.allow_command_passthrough !== true) return
 
     if (!isCodingAgentExecution(source, data)) {
-      // Workflow nodes are already sequenced by the Workflow manager. A previous
-      // Hermes node can leave the shared broker briefly busy after its terminal
-      // event; a 1s readiness probe would misclassify that handoff as downtime.
-      // Let the real bridge request wait/fail on its normal transport contract.
-      const bridgeReady = source === 'workflow'
-        ? { ok: true as const }
-        : await ensureBridgeReadyForChatRun()
+      const bridgeReady = await ensureBridgeReadyForChatRun()
       if (!bridgeReady.ok) {
         let shouldDequeueNext = false
         let queueRemaining = 0

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -208,6 +208,35 @@ describe('ChatRunSocket bridge readiness gating', () => {
     })
   })
 
+  it('lets workflow Hermes runs use the real bridge request instead of a transient readiness probe', async () => {
+    ensureReadyMock.mockResolvedValueOnce({
+      reachable: false,
+      status: 'unreachable',
+      endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+      error: 'Agent bridge request timed out after 1000ms',
+    })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('run')?.({
+      input: 'next workflow node',
+      session_id: 'workflow-session-1',
+      source: 'workflow',
+      session_source: 'workflow',
+    })
+
+    expect(ensureReadyMock).not.toHaveBeenCalled()
+    expect(handleBridgeRunMock).toHaveBeenCalledTimes(1)
+    expect(handleBridgeRunMock.mock.calls[0][2]).toEqual(expect.objectContaining({
+      input: 'next workflow node',
+      source: 'workflow',
+      session_source: 'workflow',
+    }))
+    expect(socket.emit).not.toHaveBeenCalledWith('run.failed', expect.anything())
+  })
+
   it('emits run.failed before starting a cli run when the bridge is unreachable', async () => {
     ensureReadyMock.mockResolvedValueOnce({
       reachable: false,

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -208,35 +208,6 @@ describe('ChatRunSocket bridge readiness gating', () => {
     })
   })
 
-  it('lets workflow Hermes runs use the real bridge request instead of a transient readiness probe', async () => {
-    ensureReadyMock.mockResolvedValueOnce({
-      reachable: false,
-      status: 'unreachable',
-      endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
-      error: 'Agent bridge request timed out after 1000ms',
-    })
-    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
-    const { handlers, io, socket } = makeServerHarness()
-    const server = new ChatRunSocket(io as any)
-
-    ;(server as any).onConnection(socket)
-    await handlers.get('run')?.({
-      input: 'next workflow node',
-      session_id: 'workflow-session-1',
-      source: 'workflow',
-      session_source: 'workflow',
-    })
-
-    expect(ensureReadyMock).not.toHaveBeenCalled()
-    expect(handleBridgeRunMock).toHaveBeenCalledTimes(1)
-    expect(handleBridgeRunMock.mock.calls[0][2]).toEqual(expect.objectContaining({
-      input: 'next workflow node',
-      source: 'workflow',
-      session_source: 'workflow',
-    }))
-    expect(socket.emit).not.toHaveBeenCalledWith('run.failed', expect.anything())
-  })
-
   it('emits run.failed before starting a cli run when the bridge is unreachable', async () => {
     ensureReadyMock.mockResolvedValueOnce({
       reachable: false,
@@ -300,6 +271,34 @@ describe('ChatRunSocket bridge readiness gating', () => {
       session_source: 'global_agent',
     }))
     expect(socket.emit).not.toHaveBeenCalledWith('run.failed', expect.anything())
+  })
+
+  it('keeps workflow Hermes runs behind the broker readiness gate', async () => {
+    ensureReadyMock.mockResolvedValueOnce({
+      reachable: false,
+      status: 'unreachable',
+      endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+      error: 'bridge offline',
+    })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('run')?.({
+      input: 'next workflow node',
+      session_id: 'workflow-session-1',
+      source: 'workflow',
+      session_source: 'workflow',
+    })
+
+    expect(ensureReadyMock).toHaveBeenCalledTimes(1)
+    expect(handleBridgeRunMock).not.toHaveBeenCalled()
+    expect(socket.emit).toHaveBeenCalledWith('run.failed', {
+      event: 'run.failed',
+      session_id: 'workflow-session-1',
+      error: 'Agent Bridge is not reachable: bridge offline',
+    })
   })
 
   it('routes global coding-agent runs through the coding-agent path while preserving session source', async () => {

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -539,6 +539,58 @@ describe('ChatRunSocket bridge readiness gating', () => {
     }))
   })
 
+  it('reattaches workflow bridge runs with the workflow source preserved', async () => {
+    getSessionMock.mockImplementation((sessionId?: string) => sessionId
+      ? { id: sessionId, profile: 'default', source: 'workflow', agent: 'hermes', model: 'gpt-test', provider: 'openai' }
+      : undefined)
+    bridgeMock.statusIfLoaded.mockResolvedValueOnce({
+      ok: true,
+      exists: true,
+      running: true,
+      loaded: true,
+      current_run_id: 'run-workflow',
+    })
+    loadSessionStateFromDbMock.mockResolvedValueOnce({
+      messages: [],
+      isWorking: false,
+      isAborting: false,
+      runId: undefined,
+      activeRunMarker: undefined,
+      profile: 'default',
+      events: [],
+      queue: [],
+    })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { emitted, handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    let sourceAtResume = ''
+    resumeBridgeRunMock.mockImplementationOnce((...args: any[]) => {
+      const sessionMap = args[3] as Map<string, any>
+      sourceAtResume = sessionMap.get('session-1').source
+      return Promise.resolve()
+    })
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('resume')?.({ session_id: 'session-1' })
+
+    expect(sourceAtResume).toBe('workflow')
+    expect(ensureReadyMock).not.toHaveBeenCalled()
+    expect(bridgeMock.statusIfLoaded).toHaveBeenCalledWith('session-1', 'default', { timeoutMs: 1000 })
+    expect(resumeBridgeRunMock).toHaveBeenCalledWith(
+      expect.anything(),
+      socket,
+      expect.objectContaining({
+        sessionId: 'session-1',
+        runId: 'run-workflow',
+        source: 'workflow',
+      }),
+      expect.any(Map),
+      bridgeMock,
+      expect.any(Function),
+    )
+    expect(emitted.some(({ event }) => event === 'run.reattach_failed')).toBe(false)
+  })
+
   it('reattaches global-agent bridge runs with the global source preserved', async () => {
     getSessionMock.mockImplementation((sessionId?: string) => sessionId
       ? { id: sessionId, profile: 'default', source: 'global_agent', model: 'gpt-test', provider: 'openai' }

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -592,6 +592,66 @@ describe('bridge run final context usage', () => {
     }))
   })
 
+  it('releases workflow state without judging goals when the bridge stream ends without a terminal chunk', async () => {
+    const emit = vi.fn()
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    const state = makeState()
+    const sessionMap = new Map([['session-1', state]])
+    const goalEvaluate = vi.fn(async () => {
+      throw new Error('workflow synthetic completion must not judge standing goals')
+    })
+    const bridge = {
+      chat: vi.fn().mockResolvedValue({ run_id: 'run-1', status: 'started' }),
+      contextEstimate: vi.fn().mockResolvedValue({
+        token_count: 12345,
+        fixed_context_tokens: 12327,
+        message_count: 2,
+        tool_count: 4,
+        system_prompt_chars: 13,
+      }),
+      streamOutput: vi.fn(async function* () {
+        yield {
+          run_id: 'run-1',
+          session_id: 'session-1',
+          done: false,
+          status: 'running',
+          delta: 'partial workflow reply',
+          cursor: 1,
+          output: 'partial workflow reply',
+          events: [],
+          event_cursor: 0,
+        }
+      }),
+      goalEvaluate,
+    } as any
+
+    const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    await handleBridgeRun(
+      nsp,
+      socket,
+      { input: 'hello', session_id: 'session-1', source: 'workflow' },
+      'default',
+      sessionMap,
+      bridge,
+      false,
+      vi.fn(),
+      vi.fn(),
+    )
+
+    expect(state.isWorking).toBe(false)
+    expect(state.isAborting).toBe(false)
+    expect(state.runId).toBeUndefined()
+    expect(state.activeRunMarker).toBeUndefined()
+    expect(goalEvaluate).not.toHaveBeenCalled()
+    expect(emit).toHaveBeenCalledWith('run.completed', expect.objectContaining({
+      output: 'partial workflow reply',
+      inputTokens: 11,
+      outputTokens: 7,
+      contextTokens: 12345,
+    }))
+  })
+
   it('stores a super admin model-run token for the profile without adding it to bridge instructions', async () => {
     const emit = vi.fn()
     const nsp = makeNamespace(emit)
@@ -739,6 +799,182 @@ describe('bridge run final context usage', () => {
     )
     expect(state.source).toBe('workflow')
   })
+
+  it('does not evaluate standing goals after a workflow run with no queued continuation', async () => {
+    const emit = vi.fn()
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    const state = makeState()
+    const sessionMap = new Map([['workflow-session', state]])
+    const bridge = {
+      chat: vi.fn().mockResolvedValue({ run_id: 'run-workflow', status: 'started' }),
+      contextEstimate: vi.fn().mockResolvedValue({
+        token_count: 42,
+        message_count: 1,
+        tool_count: 0,
+        system_prompt_chars: 13,
+      }),
+      goalEvaluate: vi.fn().mockRejectedValue(new Error('workflow must not evaluate standing goals')),
+      streamOutput: vi.fn(async function* () {
+        yield {
+          run_id: 'run-workflow',
+          done: true,
+          status: 'completed',
+          output: 'workflow node complete',
+          result: { final_response: 'workflow node complete' },
+        }
+      }),
+    } as any
+
+    const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    await handleBridgeRun(
+      nsp,
+      socket,
+      { input: 'run workflow node', session_id: 'workflow-session', source: 'workflow' },
+      'default',
+      sessionMap,
+      bridge,
+      false,
+      vi.fn(),
+      vi.fn(),
+    )
+
+    expect(bridge.goalEvaluate).not.toHaveBeenCalled()
+    expect(state.queue).toEqual([])
+    expect(emit).toHaveBeenCalledWith('run.completed', expect.objectContaining({
+      output: 'workflow node complete',
+    }))
+  })
+
+  it.each(['cli', 'global_agent'] as const)(
+    'does not evaluate standing goals after a workflow run when a %s continuation is queued',
+    async (nextSource) => {
+      const emit = vi.fn()
+      const nsp = makeNamespace(emit)
+      const socket = makeSocket()
+      const state = makeState()
+      // Mark the queued item as an internal continuation so hasRealQueuedRun()
+      // cannot hide a regression in the completed-run source decision.
+      state.queue.push({
+        queue_id: `next-${nextSource}`,
+        input: 'queued continuation',
+        profile: 'default',
+        source: nextSource,
+        goalContinuation: true,
+      })
+      const sessionMap = new Map([['workflow-session', state]])
+      const dequeueNextQueuedRun = vi.fn()
+      const bridge = {
+        chat: vi.fn().mockResolvedValue({ run_id: 'run-workflow', status: 'started' }),
+        contextEstimate: vi.fn().mockResolvedValue({
+          token_count: 42,
+          message_count: 1,
+          tool_count: 0,
+          system_prompt_chars: 13,
+        }),
+        goalEvaluate: vi.fn().mockRejectedValue(new Error('workflow must not evaluate standing goals')),
+        streamOutput: vi.fn(async function* () {
+          yield {
+            run_id: 'run-workflow',
+            done: true,
+            status: 'completed',
+            output: 'workflow node complete',
+            result: { final_response: 'workflow node complete' },
+          }
+        }),
+      } as any
+
+      const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+      await handleBridgeRun(
+        nsp,
+        socket,
+        { input: 'run workflow node', session_id: 'workflow-session', source: 'workflow' },
+        'default',
+        sessionMap,
+        bridge,
+        false,
+        vi.fn(),
+        dequeueNextQueuedRun,
+      )
+
+      expect(bridge.goalEvaluate).not.toHaveBeenCalled()
+      expect(state.source).toBe(nextSource)
+      expect(dequeueNextQueuedRun).toHaveBeenCalledWith(socket, 'workflow-session')
+      expect(emit).toHaveBeenCalledWith('run.completed', expect.objectContaining({
+        output: 'workflow node complete',
+      }))
+      expect(emit).not.toHaveBeenCalledWith('run.failed', expect.anything())
+    },
+  )
+
+  it.each(['cli', 'global_agent'] as const)(
+    'evaluates standing goals for a completed %s run even when a workflow continuation is queued',
+    async (runSource) => {
+      const emit = vi.fn()
+      const nsp = makeNamespace(emit)
+      const socket = makeSocket()
+      const state = makeState()
+      // Keep the queued Workflow item internal so the real-queue guard cannot
+      // bypass the completed ordinary run's standing-goal evaluation.
+      state.queue.push({
+        queue_id: 'next-workflow',
+        input: 'queued workflow continuation',
+        profile: 'default',
+        source: 'workflow',
+        goalContinuation: true,
+      })
+      const sessionMap = new Map([['ordinary-session', state]])
+      const dequeueNextQueuedRun = vi.fn()
+      const bridge = {
+        chat: vi.fn().mockResolvedValue({ run_id: `run-${runSource}`, status: 'started' }),
+        contextEstimate: vi.fn().mockResolvedValue({
+          token_count: 42,
+          message_count: 1,
+          tool_count: 0,
+          system_prompt_chars: 13,
+        }),
+        goalEvaluate: vi.fn().mockResolvedValue({
+          handled: true,
+          should_continue: true,
+          continuation_prompt: 'continue ordinary standing goal',
+        }),
+        streamOutput: vi.fn(async function* () {
+          yield {
+            run_id: `run-${runSource}`,
+            done: true,
+            status: 'completed',
+            output: 'ordinary chat complete',
+            result: { final_response: 'ordinary chat complete' },
+          }
+        }),
+      } as any
+
+      const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+      await handleBridgeRun(
+        nsp,
+        socket,
+        { input: 'continue chat', session_id: 'ordinary-session', source: runSource },
+        'default',
+        sessionMap,
+        bridge,
+        false,
+        vi.fn(),
+        dequeueNextQueuedRun,
+      )
+
+      expect(bridge.goalEvaluate).toHaveBeenCalledWith('ordinary-session', 'ordinary chat complete', 'default')
+      expect(state.queue).toEqual([
+        expect.objectContaining({ source: 'workflow' }),
+        expect.objectContaining({
+          input: 'continue ordinary standing goal',
+          source: runSource,
+          goalContinuation: true,
+        }),
+      ])
+      expect(state.source).toBe('workflow')
+      expect(dequeueNextQueuedRun).toHaveBeenCalledWith(socket, 'ordinary-session')
+    },
+  )
 
   it('evaluates active goals after a successful bridge run and queues continuation prompts', async () => {
     const emit = vi.fn()

--- a/tests/server/run-chat-bridge-resume.test.ts
+++ b/tests/server/run-chat-bridge-resume.test.ts
@@ -89,11 +89,12 @@ describe('resumeBridgeRun', () => {
     estimateUsageTokensFromMessagesMock.mockReturnValue({ inputTokens: 3, outputTokens: 2 })
   })
 
-  it('continues polling an existing bridge run after web server state is recreated', async () => {
+  it('continues polling a resumed workflow run without judging goals when a cli continuation is queued', async () => {
     const { resumeBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
     const { nsp, emitted } = createNamespace()
     const socket = { id: 'socket-1', connected: true, emit: vi.fn() }
     const sessionMap = new Map<string, any>()
+    const dequeueNextQueuedRun = vi.fn()
     sessionMap.set('session-resume', {
       messages: [
         { id: 1, session_id: 'session-resume', role: 'user', content: 'hello', timestamp: 1 },
@@ -101,7 +102,13 @@ describe('resumeBridgeRun', () => {
       ],
       isWorking: true,
       events: [],
-      queue: [],
+      queue: [{
+        queue_id: 'next-cli',
+        input: 'queued cli continuation',
+        profile: 'default',
+        source: 'cli',
+        goalContinuation: true,
+      }],
     })
 
     const bridge = {
@@ -170,10 +177,11 @@ describe('resumeBridgeRun', () => {
         instructions: 'system prompt',
         model: 'gpt-test',
         provider: 'openai',
+        source: 'workflow',
       },
       sessionMap,
       bridge as any,
-      vi.fn(),
+      dequeueNextQueuedRun,
     )
 
     expect(bridge.getResult).toHaveBeenCalledWith('run-resume')
@@ -193,6 +201,9 @@ describe('resumeBridgeRun', () => {
       isEstimated: false,
     }))
     expect(updateUsageMock).toHaveBeenCalledTimes(1)
+    expect(bridge.goalEvaluate).not.toHaveBeenCalled()
+    expect(sessionMap.get('session-resume').source).toBe('cli')
+    expect(dequeueNextQueuedRun).toHaveBeenCalledWith(socket, 'session-resume')
     expect(emitted).toEqual(expect.arrayContaining([
       expect.objectContaining({
         event: 'message.delta',
@@ -203,8 +214,110 @@ describe('resumeBridgeRun', () => {
         payload: expect.objectContaining({ output: 'Hello world', session_id: 'session-resume' }),
       }),
     ]))
-    expect(sessionMap.get('session-resume').isWorking).toBe(false)
+    expect(sessionMap.get('session-resume').isWorking).toBe(true)
   })
+
+  it.each(['cli', 'global_agent'] as const)(
+    'preserves standing-goal evaluation and continuation source for a resumed %s run when a workflow continuation is queued',
+    async (runSource) => {
+      const { resumeBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+      const { nsp } = createNamespace()
+      const socket = { id: 'socket-1', connected: true, emit: vi.fn() }
+      const sessionMap = new Map<string, any>()
+      const dequeueNextQueuedRun = vi.fn()
+      sessionMap.set('session-resume', {
+        messages: [
+          { id: 1, session_id: 'session-resume', role: 'user', content: 'hello', timestamp: 1 },
+          { id: 2, session_id: 'session-resume', role: 'assistant', content: 'Hello', timestamp: 2 },
+        ],
+        isWorking: true,
+        events: [],
+        queue: [{
+          queue_id: 'next-workflow',
+          input: 'queued workflow continuation',
+          profile: 'default',
+          source: 'workflow',
+          goalContinuation: true,
+        }],
+      })
+
+      const bridge = {
+        getResult: vi.fn(async () => ({
+          ok: true,
+          run_id: `run-${runSource}`,
+          session_id: 'session-resume',
+          status: 'running',
+          output: 'Hello',
+          deltas: ['Hello'],
+          events: [],
+        })),
+        getOutput: vi.fn(async () => ({
+          ok: true,
+          run_id: `run-${runSource}`,
+          session_id: 'session-resume',
+          status: 'complete',
+          delta: ' world',
+          cursor: 2,
+          output: 'Hello world',
+          done: true,
+          result: { final_response: 'Hello world' },
+          error: null,
+          events: [],
+          event_cursor: 0,
+        })),
+        contextEstimate: vi.fn(async () => ({
+          ok: true,
+          session_id: 'session-resume',
+          fixed_context_tokens: 0,
+          system_prompt_tokens: 0,
+          tool_tokens: 0,
+          message_count: 0,
+          tool_count: 0,
+          system_prompt_chars: 0,
+        })),
+        goalEvaluate: vi.fn(async () => ({
+          ok: true,
+          session_id: 'session-resume',
+          handled: true,
+          should_continue: true,
+          continuation_prompt: `continue ${runSource}`,
+        })),
+      }
+
+      await resumeBridgeRun(
+        nsp as any,
+        socket as any,
+        {
+          sessionId: 'session-resume',
+          runId: `run-${runSource}`,
+          profile: 'default',
+          instructions: 'system prompt',
+          model: 'gpt-test',
+          provider: 'openai',
+          source: runSource,
+        },
+        sessionMap,
+        bridge as any,
+        dequeueNextQueuedRun,
+      )
+
+      expect(bridge.goalEvaluate).toHaveBeenCalledWith('session-resume', 'Hello world', 'default')
+      expect(sessionMap.get('session-resume').source).toBe('workflow')
+      expect(sessionMap.get('session-resume').queue).toEqual([
+        expect.objectContaining({
+          input: 'queued workflow continuation',
+          source: 'workflow',
+          goalContinuation: true,
+        }),
+        expect.objectContaining({
+          input: `continue ${runSource}`,
+          source: runSource,
+          goalContinuation: true,
+        }),
+      ])
+      expect(dequeueNextQueuedRun).toHaveBeenCalledWith(socket, 'session-resume')
+    },
+  )
 
   it('completes a timed-out abort when the resumed bridge run reaches a terminal state', async () => {
     const { resumeBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')


### PR DESCRIPTION
## Summary

Preserve the immutable source of each Hermes bridge run across Workflow handoff, resume, and reattachment so terminal handling applies the completed run's semantics rather than mutable state from a queued successor.

## Root cause

Workflow nodes and ordinary Chat sessions have different post-turn semantics, but terminal bridge handling previously consulted mutable Session state. By the time a run completed, that state could already describe the next queued run. A completed Workflow run could therefore enter ordinary Chat standing-goal evaluation, or a completed CLI/Global Agent run could inherit Workflow semantics.

## Changes

- Freeze an immutable source for each fresh or resumed bridge run.
- Skip ordinary Chat standing-goal evaluation only when the completed run itself is `workflow`.
- Preserve existing CLI and Global Agent standing-goal behavior.
- Derive generated ordinary Chat continuation source from the completed run, not a queued successor.
- Preserve Workflow source through reattachment and DB hydration.
- Keep every Hermes bridge run, including Workflow, behind the existing broker readiness gate.
- Update the change fragment to `pr: 2137`.

## Maintainer feedback follow-up

The observed timeout requests used the current broker endpoint with `action: "ping"`; they were not `worker_ping` requests. The logs establish a transient broker-level timeout, but do not establish that synchronous Profile-worker `goal_evaluate` blocked broker ping. The unconditional Workflow readiness bypass has therefore been removed, and a regression now asserts that Workflow Hermes runs retain the same readiness gate and outage behavior as other Hermes bridge runs.

## Verification (head `66806e3d`)

- Fresh/resume/reattach and readiness tests: 49/49 passed
- Agent Bridge Python concurrency tests: 33/33 passed, including broker ping while another broker request is blocked
- Server TypeScript check: passed
- Harness check: passed
- Production build: passed
- `git diff --check`: passed

## Scope

This does not change Workflow topology, prompts, approvals, readiness timeout, readiness error handling, or provider/model routing.

Related tracking issue: wtj-0527/hermes-studio#16.