### PR TITLE
feat: add cursor-based session compression

### DIFF
--- a/docs/chat-chain-changes/2026-07-20-bridge-terminal-error-detection.md
+++ b/docs/chat-chain-changes/2026-07-20-bridge-terminal-error-detection.md
@@ -1,0 +1,13 @@
+---
+date: 2026-07-20
+commit: pending
+feature: Bridge terminal error false-positive prevention
+impact: Successful long-form assistant responses can discuss rate limiting and other failure concepts without being emitted as transient run.failed messages.
+---
+
+# Bridge terminal error detection avoids long-form false positives
+
+- Trust an explicit successful bridge result instead of reclassifying its final response from incidental error terminology.
+- Keep compact final-response detection for providers that return API failures without setting bridge failure flags.
+- Narrow Chinese rate-limit matching so normal documentation such as `初始化登录限流` remains a successful assistant response.
+- Cover successful documentation, genuine Chinese rate-limit failures, and long-form responses with terminal-error regression tests.

--- a/docs/chat-chain-changes/2026-07-20-ekko-compression-fallback.md
+++ b/docs/chat-chain-changes/2026-07-20-ekko-compression-fallback.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-20
+pr: pending
+feature: Clean Ekko context compression
+impact: Context summaries use a fresh tool-free, skill-free, memory-free Ekko Agent first and immediately fall back to the existing Hermes compression run when that call fails.
+---
+
+The Ekko summarizer is limited to one non-streaming model step with model
+retries disabled. It resolves the selected compression model from the source
+profile without reusing the global Ekko runtime, MCP registry, skills, memory,
+or session context. The Hermes fallback preserves the existing temporary
+compression session and dedicated worker-key behavior.

--- a/docs/chat-chain-changes/2026-07-20-hide-empty-session-categories.md
+++ b/docs/chat-chain-changes/2026-07-20-hide-empty-session-categories.md
@@ -1,0 +1,10 @@
+---
+date: 2026-07-20
+commit: pending
+feature: Hide empty session category groups
+impact: The chat session sidebar no longer leaves zero-count category headers behind after all visible sessions in a category are deleted or pinned.
+---
+
+The category definitions remain available for new-session assignment and later
+reuse. Only the sidebar grouping is filtered, so deleting the last session does
+not implicitly delete user-managed category data.

--- a/docs/chat-chain-changes/2026-07-20-session-compression-cursor.md
+++ b/docs/chat-chain-changes/2026-07-20-session-compression-cursor.md
@@ -1,0 +1,20 @@
+---
+date: 2026-07-20
+pr: pending
+feature: Stable session compression cursor
+impact: Hermes chat resumes use bounded display reads, while compressed runs load only the protected head and messages after a stable database cursor.
+---
+
+Compression snapshots now retain message cursor, protected-head cursor, and
+history revision fields alongside the legacy array index. First compression
+still reads the complete unsummarized history; later compression and usage
+paths batch the post-cursor range and do not reload message bodies represented
+by the summary. Forced compression and compressed exports use the same bounded
+path. Legacy snapshots remain index-based until a successful real compression
+cycle upgrades them.
+
+Clearing or deleting history invalidates the snapshot transactionally, stale
+in-flight summaries fail the revision compare-and-swap, and branches remap
+cursor IDs to the child rows. Socket resume uses its latest display page plus
+persisted usage, and Coding Agent usage uses native records rather than Web UI
+history reconstruction.

--- a/docs/planning/session-compression-cursor.md
+++ b/docs/planning/session-compression-cursor.md
@@ -1,7 +1,11 @@
 # Session Compression Cursor Plan
 
 Date: 2026-07-19
+Updated: 2026-07-20
 Issue: https://github.com/EKKOLearnAI/hermes-studio/issues/2138
+
+Status: Implemented on 2026-07-20. The legacy index fields remain available
+for compatibility and are upgraded only by a successful compression cycle.
 
 ## Context
 
@@ -29,7 +33,9 @@ prefix without losing or duplicating a model-visible message.
 ## Goals
 
 - Replace array-position compression boundaries with a stable database cursor.
-- Build an existing snapshot's effective model context from a bounded head,
+- Preserve existing index-based snapshots and upgrade them in place only when
+  that session next enters a real compression cycle.
+- Build a cursor snapshot's effective model context from a bounded head,
   its summary, and only messages after the cursor.
 - Keep the first compression accurate even though it must inspect the complete
   unsummarized history.
@@ -40,10 +46,10 @@ prefix without losing or duplicating a model-visible message.
 - Invalidate or remap snapshots correctly when history is cleared, deleted,
   edited, imported, or copied into a branch.
 - Keep the user-visible chat and History pagination behavior unchanged.
+- Keep Coding Agent execution independent from Web UI context compression.
 
 ## Non-Goals
 
-- Do not implement this plan as part of the planning change.
 - Do not replace `node:sqlite` solely for this optimization.
 - Do not move all persistence to a Worker Thread in the first implementation.
 - Do not archive or delete old messages after they are summarized.
@@ -51,6 +57,29 @@ prefix without losing or duplicating a model-visible message.
   thresholds unless required by a separate change.
 - Do not make the first summary without reading the content that must be
   summarized.
+- Do not invalidate all legacy compression snapshots during deployment or force
+  old sessions to regenerate summaries solely because the cursor schema was
+  added.
+- Do not send Web UI message history to Codex or Claude Code. Coding Agents own
+  their native session history and resume behavior.
+
+## Scope Boundary
+
+The compression cursor applies to Hermes Bridge chat sessions whose model
+context is assembled by the Web UI server. It does not apply to Coding Agent
+execution.
+
+Coding Agent runs send only the current input and system prompt to the selected
+agent. Claude Code resumes with its native session ID through `--resume`; Codex
+resumes through `codex exec resume`. Their native runtimes own context retention
+and any internal compaction.
+
+The current Coding Agent path still performs complete Web UI history reads on a
+cold UI resume and after a run to estimate local usage and `contextTokens`.
+Those reads are display/accounting work, not model input, and should be removed
+or replaced with persisted/native usage values. Reconstructing Web UI history
+does not accurately describe a Coding Agent's internal context after native
+compaction.
 
 ## Current Behavior
 
@@ -105,29 +134,77 @@ is conceptually:
 Only the current index-based representation requires the already summarized
 middle section to be loaded again.
 
+### Compression Execution
+
+Summary generation is not an in-process string transformation. Each actual
+full or incremental summary first creates a fresh Ekko Agent runtime. That
+runtime has tools, MCP, skills, and memory disabled, allows one model step, and
+does not retry a failed model request. It receives only the summary prompt and
+the fixed instruction to generate the checkpoint.
+
+If that Ekko call fails or returns no usable summary, compression immediately
+falls back to the previous Hermes `chat` run through Agent Bridge. The fallback
+uses a temporary `compress_*` session ID, receives the same summary prompt as
+conversation history, uses the dedicated
+`<profile>:compression:<source-session-id>` worker key, waits for the result,
+and destroys the temporary compression session afterward.
+
+The first compression therefore sends the complete selected historical range
+to a summarizer model. Incremental compression sends the previous summary and
+only the newly selected range. Preserving legacy summaries avoids an expensive
+and unnecessary full-history summarization after upgrade.
+
+For Hermes Bridge chat, complete history is not cached across runs. Every run
+currently calls `buildDbHistory()` again, and usage/context-token updates can
+perform additional complete reads during the same run. Cursor adoption must
+therefore update all of these consumers; optimizing only the initial context
+assembly would leave repeated full-history reads in place.
+
 ## Proposed Design
 
 ### Stable Message Cursor
 
-Add a stable boundary to the snapshot:
+Add a stable boundary to the snapshot and keep the current history revision on
+the session:
 
 ```sql
+ALTER TABLE sessions
+  ADD COLUMN history_revision INTEGER NOT NULL DEFAULT 0;
+
 ALTER TABLE chat_compression_snapshots
   ADD COLUMN compressed_through_message_id INTEGER;
 
 ALTER TABLE chat_compression_snapshots
   ADD COLUMN history_revision INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE chat_compression_snapshots
+  ADD COLUMN protected_head_through_message_id INTEGER;
 ```
 
 `compressed_through_message_id` is the ID of the last context message whose
-content is represented by `summary`. Message ordering must continue to use the
-same database order as context construction, currently message `id`, rather
-than timestamp.
+content is represented by `summary`. `protected_head_through_message_id` freezes
+the protected head selected when the snapshot was written so a later
+`protect_first_n` configuration change cannot duplicate or omit messages.
+Message ordering must continue to use the same database order as context
+construction, currently message `id`, rather than timestamp.
 
-Keep `last_message_index` temporarily for legacy snapshots and diagnostics. New
-snapshot writes should use the cursor as the source of truth. Keep
+Keep `last_message_index` for legacy snapshots, compatibility, diagnostics, and
+rollback. Do not clear or rewrite existing snapshots during schema migration.
+New snapshot writes should use the cursor as the source of truth while
+continuing to populate the legacy field where it is inexpensive to do so. Keep
 `message_count_at_time` as optional validation and observability data, but do
 not use a count as the boundary identity.
+
+Snapshot reads use this precedence:
+
+1. When `compressed_through_message_id` is present, use the cursor path.
+2. When the cursor is absent but `last_message_index` is present, use the
+   existing index-based path unchanged.
+3. When neither boundary exists, treat the session as having no snapshot.
+
+Opening, switching, reconnecting, or merely starting a run must not discard a
+legacy snapshot. A legacy snapshot remains valid under the same rules as before
+until a compression cycle upgrades it.
 
 ### Cursor-Carrying Context Entries
 
@@ -151,8 +228,8 @@ messages are rejected, or tool-call metadata is normalized.
 
 ### Snapshot-Aware Context Query
 
-For a valid cursor snapshot, query only the protected head and the range after
-the boundary:
+For a valid cursor snapshot, query only the protected head recorded by the
+snapshot and the range after the boundary:
 
 ```sql
 SELECT *
@@ -181,11 +258,22 @@ The model context becomes:
 ]
 ```
 
-The head query may need to read slightly more than `protect_first_n` raw rows
-until it obtains the requested number of valid context entries. This remains a
-small bounded query.
+For a new snapshot, the head query ends at
+`protected_head_through_message_id`; the current `protect_first_n` value is used
+only when creating a new protected-head boundary. The query may need to read
+slightly more raw rows until it obtains the requested number of valid context
+entries. This remains a small bounded query.
+
+Context construction must also preserve the current `excludeLastUser` behavior.
+When the latest persisted user message is supplied separately as the current
+run input, it must not also be included in the post-cursor history.
 
 ### Incremental Compression
+
+The compression semantics do not change. The current implementation also uses
+the previous summary plus messages after `last_message_index`; the cursor only
+replaces how that boundary is represented and queried so the summarized middle
+does not need to be loaded.
 
 When the snapshot-aware context exceeds the compression threshold:
 
@@ -232,14 +320,16 @@ not merely the row at a desired numeric tail size.
 Append-only writes do not invalidate a cursor. Destructive or rewriting
 operations must invalidate it transactionally.
 
-A snapshot is usable only when:
+A cursor snapshot is usable only when:
 
-- its `history_revision` matches the session revision;
+- its captured `history_revision` matches `sessions.history_revision`;
 - its cursor row still exists and belongs to the same session;
 - the cursor row still participates in the normalized context order;
 - the summary and cursor were committed together.
 
-Increment `history_revision`, or delete the snapshot, when an operation:
+Append-only message inserts do not increment `sessions.history_revision`.
+Increment the session revision and delete or invalidate its snapshot in the same
+transaction when an operation:
 
 - clears session messages;
 - deletes or edits a message at or before the cursor;
@@ -249,6 +339,13 @@ Increment `history_revision`, or delete the snapshot, when an operation:
 Deleting a session must also delete its snapshot. Clearing history must not
 leave an old summary available to future messages. This needs explicit coverage
 because the current clear path does not invalidate the compression snapshot.
+
+Compression calls the summarizer outside a database transaction. Snapshot save
+must therefore be compare-and-swap: it receives the revision observed when the
+compression input was read and writes only if the session still has that
+revision. A clear, edit, import, or delete that happens while summarization is in
+flight must prevent the old compression result from recreating a stale
+snapshot.
 
 ### Branched Sessions
 
@@ -267,25 +364,51 @@ The existing index can remain useful as a migration fallback because a 1:1
 branch copy preserves ordinal position, but the child snapshot must ultimately
 store its own message cursor.
 
-### Legacy Snapshot Migration
+### Legacy Snapshot Compatibility And Upgrade
 
-Existing snapshots have only `last_message_index`. Migrate them lazily when a
-run first needs compression context:
+Existing snapshots have only `last_message_index`. They must not be invalidated
+as a deployment migration and must not be forced through a new full-history
+summary. Until upgraded, they continue through the current index-based read and
+compression path.
 
-1. Load the legacy normalized history using the current behavior.
-2. Resolve `last_message_index` to the corresponding database message ID.
-3. Validate that the resolved boundary does not split a tool interaction.
-4. Persist the cursor and current history revision.
-5. Continue through the new cursor path on later runs.
+Upgrade a legacy snapshot only when that session next actually enters a
+compression cycle:
 
-This permits one final full read per legacy snapshot while keeping all future
-incremental loads bounded. If the legacy index cannot be resolved safely,
-invalidate the snapshot and perform a normal first compression rather than
-guessing a boundary.
+1. Load the legacy normalized history using the existing path. This is work the
+   old compression cycle already requires; do not add a separate full read on
+   resume, session open, or a run that does not compress.
+2. Carry each surviving context entry's database message ID through
+   normalization.
+3. Resolve the existing `last_message_index` to the corresponding database
+   message ID and resolve the protected-head boundary used for the new
+   snapshot.
+4. Validate that the resolved boundary belongs to the session and does not
+   split a tool interaction.
+5. Reuse the existing summary as the previous summary and summarize only the
+   incremental range selected by the normal compression algorithm. Do not
+   summarize the already compacted history again.
+6. Atomically save the resulting summary, cursor, protected-head boundary, and
+   captured session revision. Keep `last_message_index` populated for
+   compatibility and diagnostics.
+7. Use the new cursor path on later runs.
+
+If compression is not triggered, the legacy snapshot remains unchanged and the
+session continues to behave exactly as it does today. If summarization or the
+compare-and-swap save fails, retain the legacy snapshot rather than partially
+migrating it.
+
+If the legacy index cannot be resolved or would split a tool interaction, do
+not guess a cursor and do not discard the existing summary automatically. Log
+the reason and keep the snapshot on the legacy path. A separately designed
+repair or explicit invalidation path can handle irrecoverable snapshots without
+making normal upgrades destructive.
 
 Using SQL `OFFSET last_message_index` alone is not sufficient for the permanent
 design. It avoids materializing old content but still depends on a shifting
 ordinal and may not match the normalized context array when rows are filtered.
+The upgrade uses the already constructed cursor-carrying normalized history so
+the persisted cursor identifies the same model-visible boundary as the legacy
+index.
 
 ### Resume And Display Separation
 
@@ -312,12 +435,23 @@ getSessionMetadata(sessionId)
 getContextHead(sessionId, validLimit)
 getContextAfterCursor(sessionId, cursorId, batchOptions?)
 getContextHistoryForFirstCompression(sessionId)
-resolveLegacyCompressionCursor(sessionId, lastMessageIndex)
+resolveLegacyCompressionCursor(entries, lastMessageIndex)
 ```
 
 Routes and Socket.IO handlers should not select message bodies when they need
 only session metadata. Compression services should consume cursor-carrying
 context entries rather than generic session-detail objects.
+
+Inventory and migrate every Hermes snapshot consumer, including run-context
+assembly, usage calculation, Bridge compression events, forced compression,
+session commands, and export compression. Updating only the primary
+`buildCompressedHistory()` call would leave hidden complete-history reads in
+the runtime path.
+
+Coding Agent usage and resume paths are separate consumers. They should use the
+latest display page plus persisted or native-agent usage values and must not use
+compression snapshot helpers to reconstruct a model context that the Web UI
+does not send.
 
 ## Observability
 
@@ -358,8 +492,15 @@ second.
 
 ### Legacy Migration
 
-- A valid legacy index resolves once and persists a cursor.
-- An invalid, stale, or turn-splitting legacy index is rejected safely.
+- Deployment leaves legacy snapshots, summaries, and index fields unchanged.
+- Opening, switching, reconnecting, and non-compressing runs do not migrate or
+  invalidate a legacy snapshot.
+- The next actual compression cycle reuses the old summary, resolves the legacy
+  index, and persists a cursor without re-summarizing the compacted prefix.
+- A failed compression or revision compare-and-swap leaves the legacy snapshot
+  usable and does not partially migrate it.
+- An invalid or turn-splitting legacy index remains on the legacy path and is
+  reported without guessing a cursor.
 - Later loads use the cursor path without another full-history query.
 
 ### Resume And Performance
@@ -367,48 +508,64 @@ second.
 - Socket resume emits only the configured latest page.
 - Resume metadata does not call a full session-detail query.
 - Resume does not build or tokenize complete DB history.
+- A normal Hermes Bridge run with a cursor snapshot does not perform a complete
+  history read through usage or context-token helpers.
+- Coding Agent execution sends only current input through its native session;
+  cold resume and post-run usage calculation do not reconstruct complete Web UI
+  history.
 - A synthetic session with at least 15,000 mixed user, assistant, and tool rows
   remains responsive while opening and switching sessions.
-- A large session with an existing snapshot reads a bounded head plus only the
+- A large session with a cursor snapshot reads a bounded head plus only the
   uncompressed range when starting a run.
 
 ## Implementation Slices
 
 1. Add query instrumentation and focused metadata/context query helpers.
-2. Remove full-history work from pure resume and reconnect paths.
-3. Add cursor and history-revision fields while retaining legacy snapshot
-   reads.
-4. Carry database IDs through context normalization and update compressor
-   results to return a cursor.
-5. Switch incremental context construction to head plus post-cursor queries.
-6. Add transactional invalidation for clear, delete, edit, and import paths.
-7. Map snapshot cursors during branch creation.
-8. Add lazy legacy migration, performance regression coverage, and operational
-   timings.
-9. Profile the completed path before deciding whether tokenization or SQLite
-   work also needs a Worker Thread.
+2. Remove full-history work from pure resume and reconnect paths, including the
+   generic Coding Agent resume path.
+3. Add session revision, snapshot cursor, protected-head, and snapshot revision
+   fields without modifying existing snapshot rows or removing legacy fields.
+4. Add transactional invalidation for clear, delete, edit, and import paths,
+   plus compare-and-swap snapshot writes.
+5. Carry database IDs through context normalization and update compressor
+   results to return cursor boundaries.
+6. Map new-format snapshot cursors during branch creation while preserving the
+   current ordinal copy behavior for legacy snapshots.
+7. Add dual-read behavior: cursor-first with an unchanged legacy-index fallback.
+8. Switch new-format incremental context construction and all Hermes usage
+   consumers to protected head plus post-cursor queries.
+9. Remove complete-history Coding Agent context estimation and use
+   persisted/native-agent usage values.
+10. Upgrade a legacy snapshot only during its next actual compression cycle and
+    add compatibility, performance, and operational-timing coverage.
+11. Profile the completed path before deciding whether tokenization or SQLite
+    work also needs a Worker Thread.
 
 ## Acceptance Criteria
 
 - Opening, switching, or reconnecting to a session does not read or tokenize
   its complete message history.
 - The first compression remains complete and accurate.
-- After a snapshot exists, context construction does not load message bodies
-  already represented by the summary.
+- After a cursor snapshot exists, context construction does not load message
+  bodies already represented by the summary.
 - Incremental compression never loses, duplicates, or reorders a model-visible
   message.
 - Tool interactions remain structurally valid across every compression
   boundary.
 - Clear, delete, edit, import, and branch operations cannot reuse an invalid
   summary.
-- Legacy snapshots migrate safely or are invalidated without guessing.
+- Legacy snapshots remain usable until a successful compression cycle upgrades
+  them; their summaries are not discarded or regenerated solely because of the
+  schema upgrade.
+- A snapshot with both legacy and cursor fields always uses the cursor as the
+  read boundary while retaining the legacy field for compatibility.
+- Coding Agent runs never receive reconstructed Web UI history and do not use
+  Web UI compression snapshots.
 - Existing 150-message paging and live-chat rendering limits remain unchanged.
 - Focused tests cover a history of at least 15,000 mixed-role rows.
 
 ## Open Questions
 
-- Should `history_revision` live on `sessions` or only in the compression
-  snapshot lifecycle?
 - Should large post-cursor ranges stream from SQLite in batches or move to a
   Worker Thread after cursor adoption?
 - Should per-message token counts be completed and aggregated so resume can

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -48,6 +48,7 @@ import SessionListItem from "./SessionListItem.vue";
 import OutlinePanel from "./OutlinePanel.vue";
 import TerminalPanel from "./TerminalPanel.vue";
 import SubagentStreamPanel from "./SubagentStreamPanel.vue";
+import { buildVisibleSessionCategoryGroups } from "./session-category-groups";
 import PageSidebarNav from "@/components/layout/PageSidebarNav.vue";
 import SettingsCircuitBadge from "@/components/layout/SettingsCircuitBadge.vue";
 import { isStoredSuperAdmin } from "@/api/client";
@@ -491,25 +492,11 @@ const unpinnedSessions = computed(() =>
   ),
 );
 
-const categorizedSessions = computed(() => {
-  const knownCategoryIds = new Set(sessionCategories.value.map((category) => category.id));
-  const groups = sessionCategories.value.map((category) => ({
-    key: `category-${category.id}`,
-    label: category.name,
-    sessions: unpinnedSessions.value.filter((session) => session.categoryId === category.id),
-  }));
-  const uncategorized = unpinnedSessions.value.filter(
-    (session) => session.categoryId == null || !knownCategoryIds.has(session.categoryId),
-  );
-  if (uncategorized.length > 0) {
-    groups.push({
-      key: "category-none",
-      label: t("chat.uncategorized"),
-      sessions: uncategorized,
-    });
-  }
-  return groups;
-});
+const categorizedSessions = computed(() => buildVisibleSessionCategoryGroups(
+  sessionCategories.value,
+  unpinnedSessions.value,
+  t("chat.uncategorized"),
+));
 
 watch(
   () => [

--- a/packages/client/src/components/hermes/chat/session-category-groups.ts
+++ b/packages/client/src/components/hermes/chat/session-category-groups.ts
@@ -1,0 +1,40 @@
+export interface SessionCategoryLike {
+  id: number;
+  name: string;
+}
+
+export interface SessionCategoryAssignment {
+  categoryId?: number | null;
+}
+
+export interface VisibleSessionCategoryGroup<T> {
+  key: string;
+  label: string;
+  sessions: T[];
+}
+
+export function buildVisibleSessionCategoryGroups<T extends SessionCategoryAssignment>(
+  categories: readonly SessionCategoryLike[],
+  sessions: readonly T[],
+  uncategorizedLabel: string,
+): VisibleSessionCategoryGroup<T>[] {
+  const knownCategoryIds = new Set(categories.map((category) => category.id));
+  const groups = categories
+    .map((category) => ({
+      key: `category-${category.id}`,
+      label: category.name,
+      sessions: sessions.filter((session) => session.categoryId === category.id),
+    }))
+    .filter((group) => group.sessions.length > 0);
+  const uncategorized = sessions.filter(
+    (session) => session.categoryId == null || !knownCategoryIds.has(session.categoryId),
+  );
+  if (uncategorized.length > 0) {
+    groups.push({
+      key: "category-none",
+      label: uncategorizedLabel,
+      sessions: uncategorized,
+    });
+  }
+  return groups;
+}

--- a/packages/ekko-agent/README.md
+++ b/packages/ekko-agent/README.md
@@ -127,6 +127,10 @@ const result = await runtime.run({
 })
 ```
 
+Set `toolsEnabled: false` to omit all tool sources (built-ins, MCP, memory,
+and skill tools). Set `skillsEnabled: false` to omit constructor and per-run
+skills. The switches are independent and default to `true`.
+
 ## Commands
 
 ```bash

--- a/packages/ekko-agent/src/runtime/runtime.ts
+++ b/packages/ekko-agent/src/runtime/runtime.ts
@@ -33,7 +33,9 @@ interface ModelResponseResult {
 
 export class AgentRuntime {
   private readonly modelClient?: AgentRuntimeOptions['modelClient']
+  private readonly toolsEnabled: boolean
   private readonly tools: AgentToolRegistry
+  private readonly skillsEnabled: boolean
   private readonly skills: AgentSkill[]
   private readonly systemPrompt?: string
   private readonly runtimeInstructions: string[]
@@ -49,8 +51,12 @@ export class AgentRuntime {
 
   constructor(options: AgentRuntimeOptions) {
     this.modelClient = options.modelClient
-    this.tools = options.tools ?? createDefaultToolRegistry()
-    this.skills = options.skills ?? []
+    this.toolsEnabled = options.toolsEnabled !== false
+    this.tools = this.toolsEnabled
+      ? options.tools ?? createDefaultToolRegistry()
+      : new AgentToolRegistry()
+    this.skillsEnabled = options.skillsEnabled !== false
+    this.skills = this.skillsEnabled ? options.skills ?? [] : []
     this.systemPrompt = options.systemPrompt
     this.runtimeInstructions = options.runtimeInstructions ?? []
     this.maxSteps = options.maxSteps ?? DEFAULT_AGENT_MAX_STEPS
@@ -62,10 +68,11 @@ export class AgentRuntime {
     this.defaultContextKey = options.contextKey
     this.memory = options.memory
     this.registerSkillTools(this.skills)
-    if (this.memory) this.tools.registerMany(createMemoryTools(this.memory))
+    if (this.toolsEnabled && this.memory) this.tools.registerMany(createMemoryTools(this.memory))
   }
 
   registerSkill(skill: AgentSkill): void {
+    if (!this.skillsEnabled) return
     this.skills.push(skill)
     this.registerSkillTools([skill])
   }
@@ -77,6 +84,7 @@ export class AgentRuntime {
   }
 
   async refreshTools(context?: AgentToolContext): Promise<void> {
+    if (!this.toolsEnabled) return
     await this.tools.refreshTools(context)
   }
 
@@ -97,8 +105,9 @@ export class AgentRuntime {
 
     emit({ type: 'run.started', runId, maxSteps })
 
-    const runSkills = [...this.skills, ...(input.skills ?? [])]
-    this.registerSkillTools(input.skills ?? [])
+    const inputSkills = this.skillsEnabled ? input.skills ?? [] : []
+    const runSkills = [...this.skills, ...inputSkills]
+    this.registerSkillTools(inputSkills)
     const memoryIdentity = this.memoryIdentityFor(input)
     const memoryContext = await this.prepareMemory(input, memoryIdentity)
     if (memoryContext) {
@@ -367,7 +376,7 @@ export class AgentRuntime {
       metadata: input.metadata ?? modelDefaults?.metadata,
       messages,
       signal: input.signal,
-      tools: this.tools.definitions(),
+      tools: this.toolsEnabled ? this.tools.definitions() : undefined,
       stream: modelClient.capabilities.streaming,
       context: input.context ?? (contextKey ? this.modelContexts.get(contextKey) : modelDefaults?.context),
     }
@@ -451,6 +460,7 @@ export class AgentRuntime {
   }
 
   private registerSkillTools(skills: AgentSkill[]): void {
+    if (!this.toolsEnabled || !this.skillsEnabled) return
     for (const skill of skills) {
       if (skill.tools?.length) {
         this.tools.registerMany(skill.tools)

--- a/packages/ekko-agent/src/runtime/types.ts
+++ b/packages/ekko-agent/src/runtime/types.ts
@@ -20,7 +20,11 @@ export interface AgentRuntimeContextEstimate {
 
 export interface AgentRuntimeOptions {
   modelClient?: ModelClient
+  /** Disable every tool source, including built-ins, MCP, memory, and skill tools. */
+  toolsEnabled?: boolean
   tools?: AgentToolRegistry
+  /** Disable every skill source, including constructor and per-run skills. */
+  skillsEnabled?: boolean
   skills?: AgentSkill[]
   systemPrompt?: string
   runtimeInstructions?: string[]

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -13,7 +13,7 @@ import {
   updateSession as localUpdateSession,
   updateSessionStats as localUpdateSessionStats,
 } from '../../db/hermes/session-store'
-import { ExportCompressor } from '../../lib/context-compressor/export-compressor'
+import { buildDbExportHistory, ExportCompressor } from '../../lib/context-compressor/export-compressor'
 import { getLocalUsageStats, getRecordedUsageSessionIds, getUsage, getUsageBatch } from '../../db/hermes/usage-store'
 import {
   SESSION_CATEGORY_NAME_MAX_LENGTH,
@@ -1874,7 +1874,10 @@ export async function deleteWorkspaceFolder(ctx: any) {
 const exportCompressor = new ExportCompressor()
 
 export async function exportSession(ctx: any) {
-  const session = localGetSessionDetail(ctx.params.id)
+  const mode = (ctx.query.mode as string) || 'full'
+  const session = mode === 'compressed'
+    ? localGetSession(ctx.params.id)
+    : localGetSessionDetail(ctx.params.id)
 
   if (!session) {
     ctx.status = 404
@@ -1883,7 +1886,6 @@ export async function exportSession(ctx: any) {
   }
   if (denySessionAccess(ctx, session)) return
 
-  const mode = (ctx.query.mode as string) || 'full'
   const ext = (ctx.query.ext as string) || (mode === 'compressed' ? 'txt' : 'json')
   const title = session.title || 'session'
   const safeName = title.replace(/[^a-zA-Z0-9一-鿿_-]/g, '_').slice(0, 50)
@@ -1904,7 +1906,7 @@ export async function exportSession(ctx: any) {
     if (ext === 'txt') {
       ctx.set('Content-Disposition', `attachment; filename="${encodeURIComponent(filename)}"`)
       ctx.set('Content-Type', 'text/plain; charset=utf-8')
-      ctx.body = serializeAsText(session.title, session.messages || [])
+      ctx.body = serializeAsText(session.title, (session as any).messages || [])
     } else {
       ctx.set('Content-Disposition', `attachment; filename="${encodeURIComponent(filename)}"`)
       ctx.set('Content-Type', 'application/json')
@@ -1917,14 +1919,7 @@ async function compressSession(session: any) {
   const profile = session.profile || getActiveProfileName()
   const upstream = ''
   const apiKey = undefined
-  const messages = (session.messages || []).map((m: any) => ({
-    role: m.role,
-    content: m.content || '',
-    tool_calls: m.tool_calls,
-    tool_call_id: m.tool_call_id,
-    name: m.tool_name,
-    reasoning_content: m.reasoning,
-  }))
+  const messages = buildDbExportHistory(session.id)
 
   return exportCompressor.compress(messages, upstream, apiKey, session.id, {
     profile,

--- a/packages/server/src/db/hermes/compression-snapshot.ts
+++ b/packages/server/src/db/hermes/compression-snapshot.ts
@@ -1,19 +1,40 @@
-/**
- * SQLite-backed compression snapshot store for 1:1 chat sessions.
- *
- * Stores the latest compression summary and the index of the last
- * compressed message, so incremental compression can pick up where
- * the previous one left off.
- */
+/** SQLite-backed compression snapshots for 1:1 chat sessions. */
 
 import { isSqliteAvailable, getDb } from '../index'
-import { COMPRESSION_SNAPSHOT_TABLE as TABLE } from './schemas'
+import {
+  COMPRESSION_SNAPSHOT_TABLE as TABLE,
+  MESSAGES_TABLE,
+  SESSIONS_TABLE,
+} from './schemas'
 
-export function getCompressionSnapshot(sessionId: string): { summary: string; lastMessageIndex: number; messageCountAtTime: number } | null {
+export interface CompressionSnapshot {
+  summary: string
+  lastMessageIndex: number
+  messageCountAtTime: number
+  compressedThroughMessageId: number | null
+  protectedHeadThroughMessageId: number | null
+  historyRevision: number
+}
+
+export interface CompressionSnapshotCursorWrite {
+  compressedThroughMessageId: number
+  protectedHeadThroughMessageId?: number | null
+  expectedHistoryRevision: number
+}
+
+export function getCompressionSnapshot(sessionId: string): CompressionSnapshot | null {
   if (!isSqliteAvailable()) return null
   return getDb()!.prepare(
-    `SELECT summary, last_message_index AS lastMessageIndex, message_count_at_time AS messageCountAtTime FROM ${TABLE} WHERE session_id = ?`,
-  ).get(sessionId) as any ?? null
+    `SELECT
+       summary,
+       last_message_index AS lastMessageIndex,
+       message_count_at_time AS messageCountAtTime,
+       compressed_through_message_id AS compressedThroughMessageId,
+       protected_head_through_message_id AS protectedHeadThroughMessageId,
+       history_revision AS historyRevision
+     FROM ${TABLE}
+     WHERE session_id = ?`,
+  ).get(sessionId) as CompressionSnapshot | undefined ?? null
 }
 
 export function saveCompressionSnapshot(
@@ -21,43 +42,161 @@ export function saveCompressionSnapshot(
   summary: string,
   lastMessageIndex: number,
   messageCountAtTime: number,
-): void {
-  if (!isSqliteAvailable()) return
-  getDb()!.prepare(
-    `INSERT INTO ${TABLE} (session_id, summary, last_message_index, message_count_at_time, updated_at)
-     VALUES (?, ?, ?, ?, ?)
+  cursor?: CompressionSnapshotCursorWrite,
+): boolean {
+  if (!isSqliteAvailable()) return true
+  const db = getDb()!
+  const session = db.prepare(
+    `SELECT history_revision AS historyRevision FROM ${SESSIONS_TABLE} WHERE id = ?`,
+  ).get(sessionId) as { historyRevision: number } | undefined
+  if (!session) return false
+  const historyRevision = Number(session.historyRevision || 0)
+  if (cursor && historyRevision !== cursor.expectedHistoryRevision) return false
+
+  if (cursor) {
+    const compressedBoundary = db.prepare(
+      `SELECT id FROM ${MESSAGES_TABLE}
+       WHERE session_id = ? AND id = ? AND role IN ('user', 'assistant', 'tool')`,
+    ).get(sessionId, cursor.compressedThroughMessageId)
+    if (!compressedBoundary) return false
+    if (
+      cursor.protectedHeadThroughMessageId != null &&
+      cursor.protectedHeadThroughMessageId > cursor.compressedThroughMessageId
+    ) return false
+    if (cursor.protectedHeadThroughMessageId != null) {
+      const protectedBoundary = db.prepare(
+        `SELECT id FROM ${MESSAGES_TABLE}
+         WHERE session_id = ? AND id = ? AND role IN ('user', 'assistant', 'tool')`,
+      ).get(sessionId, cursor.protectedHeadThroughMessageId)
+      if (!protectedBoundary) return false
+    }
+  }
+
+  let resolvedLastIndex = lastMessageIndex
+  let resolvedMessageCount = messageCountAtTime
+  if (cursor) {
+    const through = db.prepare(
+      `SELECT COUNT(*) AS count FROM ${MESSAGES_TABLE}
+       WHERE session_id = ?
+         AND role IN ('user', 'assistant', 'tool')
+         AND id <= ?`,
+    ).get(sessionId, cursor.compressedThroughMessageId) as { count: number }
+    const total = db.prepare(
+      `SELECT COUNT(*) AS count FROM ${MESSAGES_TABLE}
+       WHERE session_id = ? AND role IN ('user', 'assistant', 'tool')`,
+    ).get(sessionId) as { count: number }
+    resolvedLastIndex = Math.max(-1, Number(through?.count || 0) - 1)
+    resolvedMessageCount = Number(total?.count || 0)
+  }
+
+  const result = db.prepare(
+    `INSERT INTO ${TABLE} (
+       session_id, summary, last_message_index, message_count_at_time,
+       compressed_through_message_id, protected_head_through_message_id,
+       history_revision, updated_at
+     )
+     SELECT ?, ?, ?, ?, ?, ?, s.history_revision, ?
+     FROM ${SESSIONS_TABLE} s
+     WHERE s.id = ? AND s.history_revision = ?
      ON CONFLICT(session_id) DO UPDATE SET
        summary = excluded.summary,
        last_message_index = excluded.last_message_index,
        message_count_at_time = excluded.message_count_at_time,
+       compressed_through_message_id = excluded.compressed_through_message_id,
+       protected_head_through_message_id = excluded.protected_head_through_message_id,
+       history_revision = excluded.history_revision,
        updated_at = excluded.updated_at`,
-  ).run(sessionId, summary, lastMessageIndex, messageCountAtTime, Date.now())
+  ).run(
+    sessionId,
+    summary,
+    resolvedLastIndex,
+    resolvedMessageCount,
+    cursor?.compressedThroughMessageId ?? null,
+    cursor?.protectedHeadThroughMessageId ?? null,
+    Date.now(),
+    sessionId,
+    cursor?.expectedHistoryRevision ?? historyRevision,
+  )
+  return result.changes > 0
 }
 
 export function copyCompressionSnapshot(sourceSessionId: string, targetSessionId: string): boolean {
   if (!isSqliteAvailable()) return false
   const db = getDb()!
-  const snapshot = db.prepare(
-    `SELECT summary, last_message_index AS lastMessageIndex, message_count_at_time AS messageCountAtTime FROM ${TABLE} WHERE session_id = ?`,
-  ).get(sourceSessionId) as { summary: string; lastMessageIndex: number; messageCountAtTime: number } | undefined
+  const snapshot = getCompressionSnapshot(sourceSessionId)
   if (!snapshot) return false
+  const sourceSession = db.prepare(
+    `SELECT history_revision AS historyRevision FROM ${SESSIONS_TABLE} WHERE id = ?`,
+  ).get(sourceSessionId) as { historyRevision: number } | undefined
+  if (
+    !sourceSession ||
+    (snapshot.compressedThroughMessageId != null &&
+      Number(sourceSession.historyRevision || 0) !== snapshot.historyRevision)
+  ) return false
+  const targetSession = db.prepare(
+    `SELECT history_revision AS historyRevision FROM ${SESSIONS_TABLE} WHERE id = ?`,
+  ).get(targetSessionId) as { historyRevision: number } | undefined
+  if (!targetSession) return false
+
+  const mappedCursor = mapCopiedMessageId(
+    sourceSessionId,
+    targetSessionId,
+    snapshot.compressedThroughMessageId,
+  )
+  const mappedProtectedHead = mapCopiedMessageId(
+    sourceSessionId,
+    targetSessionId,
+    snapshot.protectedHeadThroughMessageId,
+  )
+  const canCopyCursor = snapshot.compressedThroughMessageId == null || mappedCursor != null
+  if (!canCopyCursor) return false
+  if (snapshot.protectedHeadThroughMessageId != null && mappedProtectedHead == null) return false
 
   db.prepare(
-    `INSERT INTO ${TABLE} (session_id, summary, last_message_index, message_count_at_time, updated_at)
-     VALUES (?, ?, ?, ?, ?)
+    `INSERT INTO ${TABLE} (
+       session_id, summary, last_message_index, message_count_at_time,
+       compressed_through_message_id, protected_head_through_message_id,
+       history_revision, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(session_id) DO UPDATE SET
        summary = excluded.summary,
        last_message_index = excluded.last_message_index,
        message_count_at_time = excluded.message_count_at_time,
+       compressed_through_message_id = excluded.compressed_through_message_id,
+       protected_head_through_message_id = excluded.protected_head_through_message_id,
+       history_revision = excluded.history_revision,
        updated_at = excluded.updated_at`,
   ).run(
     targetSessionId,
     snapshot.summary,
     snapshot.lastMessageIndex,
     snapshot.messageCountAtTime,
+    mappedCursor,
+    mappedProtectedHead,
+    Number(targetSession.historyRevision || 0),
     Date.now(),
   )
   return true
+}
+
+function mapCopiedMessageId(
+  sourceSessionId: string,
+  targetSessionId: string,
+  sourceMessageId: number | null,
+): number | null {
+  if (sourceMessageId == null) return null
+  const db = getDb()!
+  const position = db.prepare(
+    `SELECT COUNT(*) AS count FROM ${MESSAGES_TABLE}
+     WHERE session_id = ? AND id <= ?`,
+  ).get(sourceSessionId, sourceMessageId) as { count: number } | undefined
+  const offset = Number(position?.count || 0) - 1
+  if (offset < 0) return null
+  const target = db.prepare(
+    `SELECT id FROM ${MESSAGES_TABLE}
+     WHERE session_id = ? ORDER BY id LIMIT 1 OFFSET ?`,
+  ).get(targetSessionId, offset) as { id: number } | undefined
+  return target ? Number(target.id) : null
 }
 
 export function deleteCompressionSnapshot(sessionId: string): void {

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -86,6 +86,7 @@ export const SESSIONS_SCHEMA: Record<string, string> = {
   is_archived: 'INTEGER NOT NULL DEFAULT 0',
   workspace: 'TEXT',
   category_id: 'INTEGER',
+  history_revision: 'INTEGER NOT NULL DEFAULT 0',
 }
 
 export const SESSIONS_INDEXES = {
@@ -288,6 +289,9 @@ export const COMPRESSION_SNAPSHOT_SCHEMA: Record<string, string> = {
   summary: 'TEXT NOT NULL DEFAULT \'\'',
   last_message_index: 'INTEGER NOT NULL DEFAULT 0',
   message_count_at_time: 'INTEGER NOT NULL DEFAULT 0',
+  compressed_through_message_id: 'INTEGER',
+  protected_head_through_message_id: 'INTEGER',
+  history_revision: 'INTEGER NOT NULL DEFAULT 0',
   updated_at: 'INTEGER NOT NULL',
 }
 

--- a/packages/server/src/db/hermes/session-store.ts
+++ b/packages/server/src/db/hermes/session-store.ts
@@ -3,7 +3,7 @@
  * Uses the same ensureTable/getDb pattern as usage-store.ts.
  */
 import { isSqliteAvailable, getDb } from '../index'
-import { SESSIONS_TABLE, MESSAGES_TABLE } from './schemas'
+import { COMPRESSION_SNAPSHOT_TABLE, SESSIONS_TABLE, MESSAGES_TABLE } from './schemas'
 import { normalizeMessageContentForStorageRole } from './message-content'
 import { copyCompressionSnapshot } from './compression-snapshot'
 
@@ -42,6 +42,7 @@ export interface HermesSessionRow {
   is_archived: number
   workspace: string | null
   category_id: number | null
+  history_revision: number
   parent_title?: string | null
   parent_last_message?: string | null
   parent_last_message_role?: string | null
@@ -138,6 +139,7 @@ function mapSessionRow(row: Record<string, unknown>): HermesSessionRow {
     is_archived: Number(row.is_archived || 0),
     workspace: row.workspace != null ? String(row.workspace) : null,
     category_id: row.category_id != null ? Number(row.category_id) : null,
+    history_revision: Number(row.history_revision || 0),
     parent_title: row.parent_title != null ? String(row.parent_title) : null,
     parent_last_message: row.parent_last_message != null ? String(row.parent_last_message) : null,
     parent_last_message_role: row.parent_last_message_role != null ? String(row.parent_last_message_role) : null,
@@ -200,6 +202,7 @@ export function createSession(data: {
       billing_provider: null, estimated_cost_usd: 0, actual_cost_usd: null,
       cost_status: '', preview: '', last_active: now, is_archived: 0, workspace: data.workspace || null,
       category_id: data.category_id ?? null,
+      history_revision: 0,
     }
   }
   const db = getDb()!
@@ -325,9 +328,8 @@ export function createBranchedSession(data: {
       ).run(forkPointMessageId, data.id)
     }
 
-    // Preserve the parent's compressed runtime context for the fork. The child
-    // copies parent messages 1:1, so the snapshot index remains valid and the
-    // first child turn can use summary+tail instead of re-sending raw history.
+    // Preserve the parent's compressed runtime context when its boundary is in
+    // the copied prefix. Cursor IDs are remapped to the child's new row IDs.
     copyCompressionSnapshot(data.parent_session_id, data.id)
     db.exec('COMMIT')
   } catch (e) {
@@ -344,6 +346,38 @@ export function getSession(id: string): HermesSessionRow | null {
   const row = db.prepare(
     `SELECT * FROM ${SESSIONS_TABLE} WHERE id = ?`,
   ).get(id) as Record<string, unknown> | undefined
+  return row ? mapSessionRow(row) : null
+}
+
+/** Session and branch metadata without loading this session's message bodies. */
+export function getSessionMetadata(id: string): HermesSessionRow | null {
+  if (!isSqliteAvailable()) return null
+  const row = getDb()!.prepare(`
+    SELECT s.*, p.title AS parent_title,
+      (
+        SELECT REPLACE(REPLACE(m.content, CHAR(10), ' '), CHAR(13), ' ')
+        FROM ${MESSAGES_TABLE} m
+        WHERE m.session_id = s.parent_session_id
+          AND m.role IN ('user', 'assistant')
+          AND m.content IS NOT NULL
+          AND TRIM(m.content) <> ''
+        ORDER BY m.timestamp DESC, m.id DESC
+        LIMIT 1
+      ) AS parent_last_message,
+      (
+        SELECT m.role
+        FROM ${MESSAGES_TABLE} m
+        WHERE m.session_id = s.parent_session_id
+          AND m.role IN ('user', 'assistant')
+          AND m.content IS NOT NULL
+          AND TRIM(m.content) <> ''
+        ORDER BY m.timestamp DESC, m.id DESC
+        LIMIT 1
+      ) AS parent_last_message_role
+    FROM ${SESSIONS_TABLE} s
+    LEFT JOIN ${SESSIONS_TABLE} p ON p.id = s.parent_session_id
+    WHERE s.id = ?
+  `).get(id) as Record<string, unknown> | undefined
   return row ? mapSessionRow(row) : null
 }
 
@@ -379,17 +413,39 @@ export function updateSession(id: string, data: Partial<Omit<HermesSessionRow, '
 export function deleteSession(id: string): boolean {
   if (!isSqliteAvailable()) return false
   const db = getDb()!
-  db.prepare(`DELETE FROM ${MESSAGES_TABLE} WHERE session_id = ?`).run(id)
-  const result = db.prepare(`DELETE FROM ${SESSIONS_TABLE} WHERE id = ?`).run(id)
-  return result.changes > 0
+  db.exec('BEGIN')
+  try {
+    db.prepare(`DELETE FROM ${COMPRESSION_SNAPSHOT_TABLE} WHERE session_id = ?`).run(id)
+    db.prepare(`DELETE FROM ${MESSAGES_TABLE} WHERE session_id = ?`).run(id)
+    const result = db.prepare(`DELETE FROM ${SESSIONS_TABLE} WHERE id = ?`).run(id)
+    db.exec('COMMIT')
+    return result.changes > 0
+  } catch (error) {
+    db.exec('ROLLBACK')
+    throw error
+  }
 }
 
 export function clearSessionMessages(id: string): number {
   if (!isSqliteAvailable()) return 0
   const db = getDb()!
-  const result = db.prepare(`DELETE FROM ${MESSAGES_TABLE} WHERE session_id = ?`).run(id)
-  updateSessionStats(id)
-  return Number(result.changes)
+  db.exec('BEGIN')
+  try {
+    const result = db.prepare(`DELETE FROM ${MESSAGES_TABLE} WHERE session_id = ?`).run(id)
+    db.prepare(`DELETE FROM ${COMPRESSION_SNAPSHOT_TABLE} WHERE session_id = ?`).run(id)
+    db.prepare(
+      `UPDATE ${SESSIONS_TABLE}
+       SET history_revision = history_revision + 1,
+           message_count = 0,
+           last_active = started_at
+       WHERE id = ?`,
+    ).run(id)
+    db.exec('COMMIT')
+    return Number(result.changes)
+  } catch (error) {
+    db.exec('ROLLBACK')
+    throw error
+  }
 }
 
 export function renameSession(id: string, title: string): boolean {
@@ -798,6 +854,76 @@ export function getMessageCount(sessionId: string): number {
     `SELECT COUNT(*) as cnt FROM ${MESSAGES_TABLE} WHERE session_id = ?`,
   ).get(sessionId) as { cnt: number } | undefined
   return row?.cnt ?? 0
+}
+
+export function getSessionContextMessages(
+  sessionId: string,
+  options: {
+    afterId?: number
+    throughId?: number
+    limit?: number
+  } = {},
+): HermesMessageRow[] {
+  if (!isSqliteAvailable()) return []
+  const db = getDb()!
+  const clauses = ['session_id = ?', `role IN ('user', 'assistant', 'tool')`]
+  const params: Array<string | number> = [sessionId]
+  if (Number.isSafeInteger(options.afterId)) {
+    clauses.push('id > ?')
+    params.push(options.afterId!)
+  }
+  if (Number.isSafeInteger(options.throughId)) {
+    clauses.push('id <= ?')
+    params.push(options.throughId!)
+  }
+  const limit = Number.isSafeInteger(options.limit) && options.limit! >= 0
+    ? Math.floor(options.limit!)
+    : undefined
+  const rows = db.prepare(
+    `SELECT * FROM ${MESSAGES_TABLE}
+     WHERE ${clauses.join(' AND ')}
+     ORDER BY id${limit != null ? ' LIMIT ?' : ''}`,
+  ).all(...params, ...(limit != null ? [limit] : [])) as Record<string, unknown>[]
+  return rows.map(mapMessageRow)
+}
+
+export function getSessionContextMessage(sessionId: string, messageId: number): HermesMessageRow | null {
+  if (!isSqliteAvailable() || !Number.isSafeInteger(messageId)) return null
+  const row = getDb()!.prepare(
+    `SELECT * FROM ${MESSAGES_TABLE}
+     WHERE session_id = ? AND id = ? AND role IN ('user', 'assistant', 'tool')`,
+  ).get(sessionId, messageId) as Record<string, unknown> | undefined
+  return row ? mapMessageRow(row) : null
+}
+
+export function getSessionContextMessageCount(sessionId: string, throughId?: number): number {
+  if (!isSqliteAvailable()) return 0
+  const hasBoundary = Number.isSafeInteger(throughId)
+  const row = getDb()!.prepare(
+    `SELECT COUNT(*) AS count FROM ${MESSAGES_TABLE}
+     WHERE session_id = ? AND role IN ('user', 'assistant', 'tool')${hasBoundary ? ' AND id <= ?' : ''}`,
+  ).get(sessionId, ...(hasBoundary ? [throughId!] : [])) as { count: number } | undefined
+  return Number(row?.count || 0)
+}
+
+export function getFirstSessionMessageByRole(sessionId: string, role: string): HermesMessageRow | null {
+  if (!isSqliteAvailable()) return null
+  const row = getDb()!.prepare(
+    `SELECT * FROM ${MESSAGES_TABLE}
+     WHERE session_id = ? AND role = ?
+       AND content IS NOT NULL AND TRIM(content) <> ''
+     ORDER BY id
+     LIMIT 1`,
+  ).get(sessionId, role) as Record<string, unknown> | undefined
+  return row ? mapMessageRow(row) : null
+}
+
+export function getSessionMessageCountByRole(sessionId: string, role: string): number {
+  if (!isSqliteAvailable()) return 0
+  const row = getDb()!.prepare(
+    `SELECT COUNT(*) AS count FROM ${MESSAGES_TABLE} WHERE session_id = ? AND role = ?`,
+  ).get(sessionId, role) as { count: number } | undefined
+  return Number(row?.count || 0)
 }
 
 export function updateSessionStats(id: string): void {

--- a/packages/server/src/lib/context-compressor/export-compressor.ts
+++ b/packages/server/src/lib/context-compressor/export-compressor.ts
@@ -22,7 +22,32 @@ import {
   buildConversationHistory,
   callSummarizer,
 } from './index'
-import { getCompressionSnapshot } from '../../db/hermes/compression-snapshot'
+import { deleteCompressionSnapshot, getCompressionSnapshot } from '../../db/hermes/compression-snapshot'
+import {
+  buildDbHistory,
+  readCursorSnapshotParts,
+} from '../../services/hermes/run-chat/context-history'
+
+export function buildDbExportHistory(sessionId: string): ChatMessage[] {
+  const snapshot = getCompressionSnapshot(sessionId)
+  if (snapshot?.compressedThroughMessageId != null) {
+    const cursorRead = readCursorSnapshotParts(sessionId, snapshot)
+    if (cursorRead.status === 'usable') {
+      // ExportCompressor supplies the previous summary separately, so only
+      // protected head and post-cursor messages belong in the incremental input.
+      return [...cursorRead.parts.head, ...cursorRead.parts.newMessages]
+    }
+    if (cursorRead.status === 'invalid') {
+      logger.warn(
+        '[export-compressor] session=%s: invalid cursor snapshot (%s); exporting from full history',
+        sessionId,
+        cursorRead.reason,
+      )
+      deleteCompressionSnapshot(sessionId)
+    }
+  }
+  return buildDbHistory(sessionId)
+}
 
 export class ExportCompressor {
   private config: CompressionConfig
@@ -54,8 +79,9 @@ export class ExportCompressor {
 
     if (snapshot) {
       logger.info(
-        '[export-compressor] session=%s: incremental compress with existing snapshot at index %d',
-        sessionId, snapshot.lastMessageIndex,
+        '[export-compressor] session=%s: incremental compress with existing snapshot boundary %s',
+        sessionId,
+        snapshot.compressedThroughMessageId ?? snapshot.lastMessageIndex,
       )
       return this.incrementalCompress(
         messages, snapshot, upstream, apiKey, meta, summarizer,
@@ -71,14 +97,16 @@ export class ExportCompressor {
 
   private async incrementalCompress(
     messages: ChatMessage[],
-    snapshot: { summary: string; lastMessageIndex: number },
+    snapshot: { summary: string; lastMessageIndex: number; compressedThroughMessageId?: number | null },
     upstream: string,
     apiKey: string | undefined,
     meta: CompressedResult['meta'],
     summarizer?: string | SummarizerOptions,
   ): Promise<CompressedResult> {
     const { summary: previousSummary, lastMessageIndex } = snapshot
-    const newMessages = messages.slice(lastMessageIndex + 1)
+    const newMessages = snapshot.compressedThroughMessageId != null
+      ? messages
+      : messages.slice(lastMessageIndex + 1)
 
     let summary: string | null = null
     try {

--- a/packages/server/src/lib/context-compressor/index.ts
+++ b/packages/server/src/lib/context-compressor/index.ts
@@ -2,7 +2,8 @@
  * Chat Context Compressor
  *
  * Compresses 1:1 chat conversation history before sending to upstream.
- * Uses the Hermes structured summary prompt for LLM-based compression.
+ * Uses the Hermes structured summary prompt with a clean Ekko runtime and
+ * falls back to the Hermes Agent Bridge when Ekko summarization fails.
  *
  * Algorithm:
  * 1. If total tokens < trigger threshold → return as-is
@@ -19,7 +20,14 @@ import { mkdir, writeFile } from 'fs/promises'
 import { resolve } from 'path'
 import { logger } from '../../services/logger'
 import { AgentBridgeClient, type AgentBridgeRunResult } from '../../services/hermes/agent-bridge'
+import { resolveEkkoProviderRuntimeConfig } from '../../services/ekko-agent/provider-runtime'
 import { truncateToolResultForContext } from '../tool-result-context'
+import {
+  AgentRuntime,
+  createModelClient,
+  resolveModelProviderConfigs,
+  type ModelClient,
+} from '../../../../ekko-agent/src'
 import {
   getCompressionSnapshot,
   saveCompressionSnapshot,
@@ -38,6 +46,8 @@ export interface ContentBlock {
 export interface ChatMessage {
   role: string
   content: string | ContentBlock[]
+  /** Internal database identity used for compression boundaries; never serialized to a model. */
+  cursorId?: number
   tool_calls?: Array<{ id: string; type: string; function: { name: string; arguments: string } }>
   tool_call_id?: string
   name?: string
@@ -75,6 +85,8 @@ export interface CompressedResult {
     summaryTokenEstimate: number
     verbatimCount: number
     compressedStartIndex: number
+    compressedThroughCursor?: number
+    protectedHeadThroughCursor?: number | null
   }
 }
 
@@ -82,10 +94,18 @@ export interface SummarizerOptions {
   profile?: string
   model?: string | null
   provider?: string | null
+  apiMode?: string | null
+  historyRevision?: number
   workerKey?: string
 }
 
+type SummarizerConversationMessage = {
+  role: 'user' | 'assistant'
+  content: string
+}
+
 const SUMMARIZER_TRIGGER_MESSAGE = 'Generate the context checkpoint summary now.'
+const EKKO_SUMMARIZER_SYSTEM_PROMPT = 'You are a context checkpoint summarizer. Follow the supplied instructions exactly and return only the updated summary.'
 const SUMMARIZER_DEBUG_DIR = 'logs/context-compressor'
 const SUMMARIZER_DEBUG_FILE = 'summarizer-debug.json'
 
@@ -490,14 +510,12 @@ export async function callSummarizer(
   previousSummary?: string,
   summarizer?: string | SummarizerOptions,
 ): Promise<string> {
-  void upstream
-  void apiKey
   const options: SummarizerOptions = typeof summarizer === 'string'
     ? { profile: summarizer }
     : summarizer || {}
   const profile = options.profile || 'default'
   void history
-  const convHistory: Array<{ role: string; content: string }> = []
+  const convHistory: SummarizerConversationMessage[] = []
 
   if (previousSummary) {
     convHistory.unshift(
@@ -509,6 +527,100 @@ export async function callSummarizer(
     convHistory.unshift({ role: 'user', content: prompt })
   }
 
+  try {
+    return await callEkkoSummarizer(upstream, apiKey, convHistory, timeoutMs, {
+      ...options,
+      profile,
+    })
+  } catch (err) {
+    logger.warn(err, '[context-compressor] clean Ekko summarizer failed; falling back to Hermes for profile %s', profile)
+    return callHermesSummarizer(convHistory, timeoutMs, {
+      ...options,
+      profile,
+    })
+  }
+}
+
+async function callEkkoSummarizer(
+  upstream: string,
+  apiKey: string | undefined,
+  convHistory: SummarizerConversationMessage[],
+  timeoutMs: number,
+  options: SummarizerOptions & { profile: string },
+): Promise<string> {
+  const model = String(options.model || '').trim()
+  const provider = String(options.provider || '').trim()
+  if (!model || !provider) throw new Error('Ekko summarization requires a model and provider')
+
+  const runtimeConfig = await resolveEkkoProviderRuntimeConfig({
+    profile: options.profile,
+    provider,
+    baseUrl: upstream,
+    apiKey,
+    apiMode: String(options.apiMode || '').trim() || undefined,
+  })
+  const { providerConfig } = resolveModelProviderConfigs({
+    provider: runtimeConfig.provider,
+    baseUrl: runtimeConfig.baseUrl,
+    apiKey: runtimeConfig.apiKey,
+    model,
+    apiMode: runtimeConfig.apiMode,
+    timeoutMs,
+  })
+  const providerClient = createModelClient(providerConfig)
+  const modelClient: ModelClient = {
+    provider: providerClient.provider,
+    requestStyle: providerClient.requestStyle,
+    capabilities: { ...providerClient.capabilities, streaming: false },
+    create: request => providerClient.create(request),
+    stream: request => providerClient.stream(request),
+  }
+  const runtime = new AgentRuntime({
+    modelClient,
+    toolsEnabled: false,
+    skillsEnabled: false,
+    systemPrompt: EKKO_SUMMARIZER_SYSTEM_PROMPT,
+    maxSteps: 1,
+    maxModelRetries: 0,
+    toolDelayMs: 0,
+    modelDefaults: {
+      model,
+      toolChoice: 'none',
+    },
+  })
+
+  await writeSummarizerDebugDump({
+    writtenAt: new Date().toISOString(),
+    engine: 'ekko-agent',
+    profile: options.profile,
+    model,
+    provider,
+    message: SUMMARIZER_TRIGGER_MESSAGE,
+    convHistory,
+  })
+
+  const result = await runtime.run({
+    messages: [
+      ...convHistory,
+      { role: 'user', content: SUMMARIZER_TRIGGER_MESSAGE },
+    ],
+    memoryEnabled: false,
+  })
+  const output = String(result.output.content || '').trim()
+  if (result.output.toolCalls?.length || result.output.finishReason === 'max_steps') {
+    throw new Error('Clean Ekko summarizer did not complete in one model step')
+  }
+  if (!output) throw new Error('Empty Ekko summarization response')
+  return output
+}
+
+async function callHermesSummarizer(
+  convHistory: SummarizerConversationMessage[],
+  timeoutMs: number,
+  options: SummarizerOptions & { profile: string },
+): Promise<string> {
+  const profile = options.profile
+
   const bridge = new AgentBridgeClient({ timeoutMs: timeoutMs + 15_000 })
   const sessionId = `compress_${Date.now().toString(36)}_${randomUUID().replace(/-/g, '').slice(0, 12)}`
   const workerKey = options.workerKey || `${profile}:compression:${sessionId}`
@@ -518,6 +630,7 @@ export async function callSummarizer(
     writtenAt: new Date().toISOString(),
     sessionId,
     workerKey,
+    engine: 'hermes-agent',
     profile,
     model: options.model || null,
     provider: options.provider || null,
@@ -600,6 +713,17 @@ export class ChatContextCompressor {
     // Check if we have a previous compression snapshot
     const snapshot = sessionId ? getCompressionSnapshot(sessionId) : null
 
+    if (snapshot?.compressedThroughMessageId != null) {
+      logger.info(
+        '[context-compressor] session=%s: incremental compress with cursor %d',
+        sessionId,
+        snapshot.compressedThroughMessageId,
+      )
+      return this.incrementalCompress(
+        messages, snapshot, upstream, apiKey, sessionId!, makeMeta(), summarizer,
+      )
+    }
+
     if (snapshot && snapshot.lastMessageIndex >= 0 && snapshot.lastMessageIndex < messages.length) {
       // Has snapshot → incremental compress (merge old summary with new messages)
       logger.info(
@@ -637,7 +761,13 @@ export class ChatContextCompressor {
 
   private async incrementalCompress(
     messages: ChatMessage[],
-    snapshot: { summary: string; lastMessageIndex: number },
+    snapshot: {
+      summary: string
+      lastMessageIndex: number
+      compressedThroughMessageId?: number | null
+      protectedHeadThroughMessageId?: number | null
+      historyRevision?: number
+    },
     upstream: string,
     apiKey: string | undefined,
     sessionId: string,
@@ -646,9 +776,17 @@ export class ChatContextCompressor {
   ): Promise<CompressedResult> {
     const { summary: previousSummary, lastMessageIndex } = snapshot
     const total = messages.length
-    const headCount = Math.min(this.config.headMessageCount, Math.max(0, lastMessageIndex + 1))
-    const head = messages.slice(0, headCount)
-    const newMessages = messages.slice(lastMessageIndex + 1)
+    const cursorSnapshot = snapshot.compressedThroughMessageId != null
+    const head = cursorSnapshot
+      ? messages.filter(message => (
+          message.cursorId != null &&
+          snapshot.protectedHeadThroughMessageId != null &&
+          message.cursorId <= snapshot.protectedHeadThroughMessageId
+        ))
+      : messages.slice(0, Math.min(this.config.headMessageCount, Math.max(0, lastMessageIndex + 1)))
+    const newMessages = cursorSnapshot
+      ? messages.filter(message => message.cursorId != null && message.cursorId > snapshot.compressedThroughMessageId!)
+      : messages.slice(lastMessageIndex + 1)
     const tailCount = this.config.tailMessageCount
     const previousSummaryMessage: ChatMessage = { role: 'user', content: SUMMARY_PREFIX + '\n\n' + previousSummary }
     const assembledWithPrevious = [
@@ -661,9 +799,10 @@ export class ChatContextCompressor {
 
     // If the new segment itself is too small to split but already over budget,
     // fold all new messages into the existing summary instead of preserving them verbatim.
-    const tailStart = assembledOverBudget && !canKeepTailWindow
+    const requestedTailStart = assembledOverBudget && !canKeepTailWindow
       ? newMessages.length
       : Math.max(0, newMessages.length - tailCount)
+    const tailStart = safeTailStart(newMessages, requestedTailStart)
     const toCompress = newMessages.slice(0, tailStart)
     const tail = newMessages.slice(tailStart)
 
@@ -677,6 +816,10 @@ export class ChatContextCompressor {
           summaryTokenEstimate: countTokens(SUMMARY_PREFIX + previousSummary),
           verbatimCount: head.length + newMessages.length,
           compressedStartIndex: lastMessageIndex,
+          ...(cursorSnapshot ? {
+            compressedThroughCursor: snapshot.compressedThroughMessageId!,
+            protectedHeadThroughCursor: snapshot.protectedHeadThroughMessageId ?? null,
+          } : {}),
         },
       }
     }
@@ -712,6 +855,10 @@ export class ChatContextCompressor {
           summaryTokenEstimate: countTokens(SUMMARY_PREFIX + previousSummary),
           verbatimCount: budgetedFallback.length === fallback.length ? head.length + newMessages.length : 0,
           compressedStartIndex: lastMessageIndex,
+          ...(cursorSnapshot ? {
+            compressedThroughCursor: snapshot.compressedThroughMessageId!,
+            protectedHeadThroughCursor: snapshot.protectedHeadThroughMessageId ?? null,
+          } : {}),
         },
       }
     }
@@ -724,8 +871,29 @@ export class ChatContextCompressor {
     result = enforceCompressedBudget(result, this.config.triggerTokens, head.length)
 
     const newLastIndex = lastMessageIndex + tailStart
+    const compressedThroughCursor = toCompress.at(-1)?.cursorId
+    const protectedHeadThroughCursor = cursorSnapshot
+      ? snapshot.protectedHeadThroughMessageId ?? null
+      : head.at(-1)?.cursorId ?? null
     if (sessionId) {
-      saveCompressionSnapshot(sessionId, summary, newLastIndex, total)
+      const legacyBoundarySafe = cursorSnapshot || isSafeCompressionBoundary(messages, lastMessageIndex + 1)
+      const canWriteCursor = compressedThroughCursor != null && legacyBoundarySafe
+      const saved = canWriteCursor
+        ? saveCompressionSnapshot(
+            sessionId,
+            summary,
+            newLastIndex,
+            total,
+            {
+              compressedThroughMessageId: compressedThroughCursor,
+              protectedHeadThroughMessageId: protectedHeadThroughCursor,
+              expectedHistoryRevision: cursorSnapshot
+                ? Number(snapshot.historyRevision || 0)
+                : Number((typeof summarizer === 'object' && summarizer?.historyRevision) || 0),
+            },
+          )
+        : saveCompressionSnapshot(sessionId, summary, newLastIndex, total)
+      if (saved === false) throw new Error('Compression snapshot changed while summarizing')
     }
 
     return {
@@ -737,6 +905,10 @@ export class ChatContextCompressor {
         summaryTokenEstimate: countTokens(SUMMARY_PREFIX + summary),
         verbatimCount: result.length === head.length + 1 + tail.length ? head.length + tail.length : 0,
         compressedStartIndex: newLastIndex,
+        ...(compressedThroughCursor != null ? {
+          compressedThroughCursor,
+          protectedHeadThroughCursor,
+        } : {}),
       },
     }
   }
@@ -753,10 +925,14 @@ export class ChatContextCompressor {
     const requestedHeadCount = Math.min(this.config.headMessageCount, total)
     const requestedTailCount = this.config.tailMessageCount
     const canKeepProtectedWindows = total > requestedHeadCount + requestedTailCount
-    const headCount = canKeepProtectedWindows ? requestedHeadCount : 0
+    let headCount = canKeepProtectedWindows ? safeHeadEnd(messages, requestedHeadCount) : 0
     const tailCount = canKeepProtectedWindows ? requestedTailCount : 0
 
-    const tailStart = total - tailCount
+    let tailStart = safeTailStart(messages, total - tailCount)
+    if (headCount >= tailStart) {
+      headCount = 0
+      tailStart = total
+    }
     const head = messages.slice(0, headCount)
     const toCompress = messages.slice(headCount, tailStart)
     const tail = messages.slice(tailStart)
@@ -786,8 +962,23 @@ export class ChatContextCompressor {
 
     result.push(...head)
     result.push({ role: 'user', content: SUMMARY_PREFIX + '\n\n' + summary })
+    const compressedThroughCursor = toCompress.at(-1)?.cursorId
+    const protectedHeadThroughCursor = head.at(-1)?.cursorId ?? null
     if (sessionId) {
-      saveCompressionSnapshot(sessionId, summary, tailStart - 1, total)
+      const saved = compressedThroughCursor != null
+        ? saveCompressionSnapshot(
+            sessionId,
+            summary,
+            tailStart - 1,
+            total,
+            {
+              compressedThroughMessageId: compressedThroughCursor,
+              protectedHeadThroughMessageId: protectedHeadThroughCursor,
+              expectedHistoryRevision: Number((typeof summarizer === 'object' && summarizer?.historyRevision) || 0),
+            },
+          )
+        : saveCompressionSnapshot(sessionId, summary, tailStart - 1, total)
+      if (saved === false) throw new Error('Compression snapshot changed while summarizing')
     }
 
     result.push(...tail)
@@ -802,6 +993,10 @@ export class ChatContextCompressor {
         summaryTokenEstimate: summary ? countTokens(SUMMARY_PREFIX + summary) : 0,
         verbatimCount: budgetedResult.length === result.length ? head.length + tail.length : 0,
         compressedStartIndex: tailStart - 1,
+        ...(compressedThroughCursor != null ? {
+          compressedThroughCursor,
+          protectedHeadThroughCursor,
+        } : {}),
       },
     }
   }
@@ -810,6 +1005,23 @@ export class ChatContextCompressor {
   static invalidateSnapshot(sessionId: string): void {
     deleteCompressionSnapshot(sessionId)
   }
+}
+
+function safeHeadEnd(messages: ChatMessage[], requestedExclusive: number): number {
+  let end = Math.max(0, Math.min(messages.length, requestedExclusive))
+  while (end < messages.length && messages[end]?.role === 'tool') end += 1
+  return end
+}
+
+function safeTailStart(messages: ChatMessage[], requestedStart: number): number {
+  let start = Math.max(0, Math.min(messages.length, requestedStart))
+  while (start > 0 && start < messages.length && messages[start]?.role === 'tool') start -= 1
+  return start
+}
+
+function isSafeCompressionBoundary(messages: ChatMessage[], boundaryExclusive: number): boolean {
+  if (boundaryExclusive <= 0 || boundaryExclusive >= messages.length) return true
+  return messages[boundaryExclusive]?.role !== 'tool'
 }
 
 async function* readSseFrames(stream: ReadableStream<Uint8Array>): AsyncGenerator<{ event?: string; data: string }> {

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -7,14 +7,13 @@ import type { ApiMode } from './types'
 import { logger } from '../logger'
 import { normalizeTokenUsage, recordSessionUsage } from '../usage-recorder'
 import { applyResponseStreamEvent, flushResponseRunToDb } from '../hermes/run-chat/response-stream'
-import { calcAndUpdateUsage, estimateUsageTokensFromMessages, updateContextTokenUsage } from '../hermes/run-chat/usage'
+import { calcAndUpdateUsage, updateContextTokenUsage } from '../hermes/run-chat/usage'
 import { extractResponseText } from '../hermes/run-chat/response-utils'
 import type { SessionState } from '../hermes/run-chat/types'
 import type { CanonicalResponsesEvent } from './adapters/responses-stream'
 import { mapCodingAgentResponseEvent } from './coding-agent-event-mapper'
 import { normalizeWindowsCommandPath, windowsCmdShimExecution, windowsCommandNeedsShell } from '../windows-command'
 import { completeWorkspaceRunCheckpoint, startWorkspaceRunCheckpoint } from '../hermes/run-chat/workspace-diff-tracker'
-import { buildDbHistory, buildSnapshotAwareHistory } from '../hermes/run-chat/compression'
 
 const DEFAULT_IDLE_MS = 30 * 60 * 1000
 const TERMINAL_OUTPUT_FLUSH_MS = 120
@@ -662,7 +661,6 @@ export class CodingAgentRunManager {
       run.assistantMessageId = flushResponseRunToDb(run.state, run.launch.sessionId)
       run.state.responseRun = undefined
       updateSessionStats(run.launch.sessionId)
-      run.terminalUsageRefresh = this.refreshCodingAgentUsage(run)
       const final = (storageSafeResponseEvent.data as any).response || storageSafeResponseEvent.data
       if (run.launch.mode !== 'scoped' && final?.usage) {
         const usage = normalizeTokenUsage(final.usage)
@@ -681,6 +679,7 @@ export class CodingAgentRunManager {
           })
         }
       }
+      run.terminalUsageRefresh = this.refreshCodingAgentUsage(run)
       const finalText = extractResponseText(final)
       const terminalError = storageSafeResponseEvent.type === 'response.failed'
         ? responseErrorMessage(final?.error || (responseEvent.data as any).error) || 'Coding agent run failed'
@@ -706,29 +705,15 @@ export class CodingAgentRunManager {
     const emitUsage = (event: string, payload: any) => {
       this.emitToChat(run.launch.sessionId, event, payload)
     }
-    const usage = await calcAndUpdateUsage(run.launch.sessionId, run.state, emitUsage)
-    const contextTokens = await this.estimateCodingAgentContextTokens(run)
-    if (contextTokens != null) {
+    const usage = await calcAndUpdateUsage(run.launch.sessionId, run.state, emitUsage, {
+      nativeSource: 'coding_agent',
+    })
+    const contextTokens = usage.contextInputTokens != null || usage.contextOutputTokens != null
+      ? (usage.contextInputTokens || 0) + (usage.contextOutputTokens || 0)
+      : undefined
+    if (contextTokens != null && contextTokens > 0) {
       updateContextTokenUsage(run.launch.sessionId, run.state, emitUsage, contextTokens, usage)
     }
-  }
-
-  private async estimateCodingAgentContextTokens(run: ManagedCodingAgentRun): Promise<number | undefined> {
-    try {
-      const dbHistory = await buildDbHistory(run.launch.sessionId, { excludeLastUser: false })
-      const snapshotHistory = await buildSnapshotAwareHistory(
-        run.launch.sessionId,
-        run.launch.profile || 'default',
-        dbHistory,
-        { model: run.launch.model, provider: run.launch.provider },
-      )
-      const usage = estimateUsageTokensFromMessages(snapshotHistory)
-      const contextTokens = usage.inputTokens + usage.outputTokens
-      if (contextTokens > 0) return contextTokens
-    } catch (err) {
-      logger.warn(err, '[coding-agent-run] failed to calculate context tokens for session %s', run.launch.sessionId)
-    }
-    return undefined
   }
 
   private normalizeCodexChatTextEvent(run: ManagedCodingAgentRun, event: CanonicalResponsesEvent): CanonicalResponsesEvent | null {

--- a/packages/server/src/services/ekko-agent/provider-runtime.ts
+++ b/packages/server/src/services/ekko-agent/provider-runtime.ts
@@ -1,0 +1,104 @@
+import { join } from 'path'
+import { PROVIDER_PRESETS } from '../../shared/providers'
+import { PROVIDER_ENV_MAP, readConfigYamlForProfile, safeReadFile } from '../config-helpers'
+import { getCompatibleCustomProviders } from '../hermes/custom-providers-compat'
+import { getProfileDir } from '../hermes/hermes-profile'
+import { resolveEkkoAuthorizedProviderCredentials } from './auth-providers'
+
+export interface EkkoProviderRuntimeConfig {
+  provider: string
+  baseUrl?: string
+  apiKey?: string
+  apiMode?: string
+}
+
+export async function resolveEkkoProviderRuntimeConfig(input: {
+  profile: string
+  provider: string
+  baseUrl?: string
+  apiKey?: string
+  apiMode?: string
+}): Promise<EkkoProviderRuntimeConfig> {
+  const provider = String(input.provider || '').trim()
+  if (!provider) throw new Error('Ekko model provider is required')
+
+  const profile = String(input.profile || '').trim() || 'default'
+  const providerKey = providerKeyWithoutCustomPrefix(provider.toLowerCase())
+  const authorized = await resolveEkkoAuthorizedProviderCredentials(profile, provider)
+  let baseUrl = String(input.baseUrl || authorized.baseUrl || '').trim()
+  let apiKey = String(input.apiKey || authorized.apiKey || '').trim()
+  let apiMode = String(input.apiMode || '').trim()
+
+  let config: Record<string, any> = {}
+  try {
+    config = await readConfigYamlForProfile(profile)
+  } catch {}
+  const envContent = await safeReadFile(join(getProfileDir(profile), '.env')) || ''
+
+  const customEntry = getCompatibleCustomProviders(config).find((entry) => {
+    const entryKeys = [entry.name, entry.provider_key]
+      .filter(Boolean)
+      .flatMap(value => providerLookupCandidates(String(value)))
+    return providerLookupCandidates(provider).some(candidate => entryKeys.includes(candidate))
+  })
+  if (customEntry) {
+    if (!baseUrl) baseUrl = String(customEntry.base_url || '').trim()
+    if (!apiKey) apiKey = String(customEntry.api_key || '').trim()
+    if (!apiKey && customEntry.key_env) apiKey = parseEnvValue(envContent, customEntry.key_env)
+    if (!apiMode) apiMode = String(customEntry.api_mode || '').trim()
+  }
+
+  const preset = PROVIDER_PRESETS.find(entry => entry.value === providerKey)
+  const envMapping = PROVIDER_ENV_MAP[providerKey]
+  if (!baseUrl) {
+    baseUrl = envMapping?.base_url_env
+      ? parseEnvValue(envContent, envMapping.base_url_env) || preset?.base_url || ''
+      : preset?.base_url || ''
+  }
+  if (!apiKey && envMapping?.api_key_env) {
+    apiKey = parseEnvValue(envContent, envMapping.api_key_env)
+  }
+  if (!apiMode) apiMode = String(preset?.api_mode || '').trim()
+
+  return {
+    provider,
+    ...(baseUrl ? { baseUrl } : {}),
+    ...(apiKey ? { apiKey } : {}),
+    ...(apiMode ? { apiMode } : {}),
+  }
+}
+
+function providerKeyWithoutCustomPrefix(provider: string): string {
+  if (provider.startsWith('custom:')) return provider.slice('custom:'.length)
+  if (provider.startsWith('custom_')) return provider.slice('custom_'.length)
+  return provider
+}
+
+function providerLookupCandidates(provider: string): string[] {
+  const normalized = String(provider || '').trim().toLowerCase().replace(/ /g, '-')
+  const withoutCustom = providerKeyWithoutCustomPrefix(normalized)
+  return [...new Set([
+    normalized,
+    withoutCustom,
+    withoutCustom ? `custom:${withoutCustom}` : '',
+    withoutCustom ? `custom_${withoutCustom}` : '',
+  ].filter(Boolean))]
+}
+
+function parseEnvValue(envContent: string, key: string): string {
+  for (const line of envContent.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const separator = trimmed.indexOf('=')
+    if (separator < 0 || trimmed.slice(0, separator).trim() !== key) continue
+    const raw = trimmed.slice(separator + 1).trim()
+    if (
+      (raw.startsWith('"') && raw.endsWith('"')) ||
+      (raw.startsWith("'") && raw.endsWith("'"))
+    ) {
+      return raw.slice(1, -1)
+    }
+    return raw
+  }
+  return ''
+}

--- a/packages/server/src/services/hermes/run-chat/compression.ts
+++ b/packages/server/src/services/hermes/run-chat/compression.ts
@@ -3,19 +3,20 @@
  * apply snapshot-aware compression and LLM summarization.
  */
 
-import {
-  getSessionDetail,
-  getSession,
-} from '../../../db/hermes/session-store'
-import { getCompressionSnapshot } from '../../../db/hermes/compression-snapshot'
+import { getSession } from '../../../db/hermes/session-store'
+import { deleteCompressionSnapshot, getCompressionSnapshot } from '../../../db/hermes/compression-snapshot'
 import { ChatContextCompressor, SUMMARY_PREFIX } from '../../../lib/context-compressor'
-import { truncateToolResultForContext } from '../../../lib/tool-result-context'
 import { getModelContextLength } from '../model-context'
 import { readConfigYamlForProfile } from '../../config-helpers'
 import { logger } from '../../logger'
 import { bridgeLogger } from '../../logger'
 import { calcAndUpdateUsage, estimateUsageTokensFromMessages, updateMessageContextTokenUsage } from './usage'
-import { isAssistantMessageSendable } from './message-format'
+import {
+  assembleCursorSnapshotHistory,
+  buildDbHistory as queryDbHistory,
+  readCursorSnapshotParts,
+  type CursorSnapshotParts,
+} from './context-history'
 import type { ChatMessage, CompressionConfig as CompressorConfig } from '../../../lib/context-compressor'
 import type { SessionState, BridgeCompressionResult } from './types'
 
@@ -83,6 +84,19 @@ export async function buildSnapshotAwareHistory(
 ): Promise<ChatMessage[]> {
   const snapshot = getCompressionSnapshot(sessionId)
   if (!snapshot) return history
+  const cursorRead = readCursorSnapshotParts(sessionId, snapshot)
+  if (cursorRead.status === 'usable') {
+    return assembleCursorSnapshotHistory(snapshot, cursorRead.parts, SUMMARY_PREFIX)
+  }
+  if (cursorRead.status === 'invalid') {
+    logger.warn(
+      '[context-compress] session=%s: invalid cursor snapshot (%s); rebuilding from full history',
+      sessionId,
+      cursorRead.reason,
+    )
+    deleteCompressionSnapshot(sessionId)
+    return history
+  }
   const contextLength = getModelContextLength({
     profile,
     model: modelContext.model,
@@ -90,6 +104,31 @@ export async function buildSnapshotAwareHistory(
   })
   const compressionConfig = await getRunChatCompressionConfig(profile, contextLength)
   return buildSnapshotHistory(snapshot, history, compressionConfig.compressor) || history
+}
+
+export async function buildDbSnapshotAwareHistory(
+  sessionId: string,
+  profile: string,
+  options: { excludeLastUser?: boolean; truncateToolResults?: boolean } = {},
+  modelContext: { model?: string | null; provider?: string | null } = {},
+): Promise<ChatMessage[]> {
+  const snapshot = getCompressionSnapshot(sessionId)
+  if (snapshot) {
+    const cursorRead = readCursorSnapshotParts(sessionId, snapshot, options)
+    if (cursorRead.status === 'usable') {
+      return assembleCursorSnapshotHistory(snapshot, cursorRead.parts, SUMMARY_PREFIX)
+    }
+    if (cursorRead.status === 'invalid') {
+      logger.warn(
+        '[context-compress] session=%s: invalid cursor snapshot (%s); invalidating it',
+        sessionId,
+        cursorRead.reason,
+      )
+      deleteCompressionSnapshot(sessionId)
+    }
+  }
+  const history = await buildDbHistory(sessionId, options)
+  return buildSnapshotAwareHistory(sessionId, profile, history, modelContext)
 }
 
 function clampRatio(value: unknown, fallback: number, min: number, max: number): number {
@@ -176,55 +215,9 @@ async function getRunChatCompressionConfig(profile: string, contextLength: numbe
  */
 export async function buildDbHistory(
   sessionId: string,
-  options: { excludeLastUser?: boolean } = {},
+  options: { excludeLastUser?: boolean; truncateToolResults?: boolean } = {},
 ): Promise<ChatMessage[]> {
-  const detail = getSessionDetail(sessionId)
-  if (!detail?.messages?.length) return []
-
-  const validMessages = detail.messages.filter(m =>
-    (m.role === 'user' || m.role === 'assistant' || m.role === 'tool') && m.content !== undefined,
-  )
-
-  const sourceMessages = options.excludeLastUser
-    ? (() => {
-      const lastUserMsgIndex = [...validMessages].reverse().findIndex(m => m.role === 'user')
-      return lastUserMsgIndex >= 0
-        ? validMessages.slice(0, validMessages.length - lastUserMsgIndex - 1)
-        : validMessages
-    })()
-    : validMessages
-
-  return sourceMessages.map((m, idx, arr) => {
-    const content = m.role === 'tool'
-      ? truncateToolResultForContext(m.content || '')
-      : m.content || ''
-    const msg: any = { role: m.role, content }
-    if (m.reasoning_content != null) msg.reasoning_content = m.reasoning_content
-    if (m.tool_calls?.length) {
-      const cleanedToolCalls = m.tool_calls
-        .filter((tc: any) => tc.id && tc.id.length > 0)
-        .map((tc: any) => ({ id: tc.id, type: tc.type, function: tc.function }))
-      if (cleanedToolCalls.length > 0) msg.tool_calls = cleanedToolCalls
-    }
-    if (m.role === 'tool') {
-      let callId = m.tool_call_id
-      if (!callId || callId.length === 0) {
-        const prevMsg = arr[idx - 1]
-        if (prevMsg?.role === 'assistant' && prevMsg.tool_calls?.length) {
-          const tc = prevMsg.tool_calls.find((t: any) => t.function?.name === m.tool_name)
-          if (tc?.id) callId = tc.id
-        }
-      }
-      if (!callId || callId.length === 0) return null
-      msg.tool_call_id = callId
-    }
-    if (m.tool_name) msg.name = m.tool_name
-    if (m.role === 'assistant' && !isAssistantMessageSendable(msg)) {
-      logger.warn('[chat-run-socket] skipped empty assistant message while building history for session %s', sessionId)
-      return null
-    }
-    return msg
-  }).filter((m): m is ChatMessage => m !== null)
+  return queryDbHistory(sessionId, options)
 }
 
 export function estimateSnapshotAwareHistoryUsage(
@@ -252,7 +245,27 @@ export async function buildCompressedHistory(
   currentInputTokens = 0,
 ): Promise<ChatMessage[]> {
   try {
-    let history = await buildDbHistory(sessionId, { excludeLastUser: true })
+    let snapshot = getCompressionSnapshot(sessionId)
+    let cursorParts: CursorSnapshotParts | null = null
+    let history: ChatMessage[]
+    if (snapshot?.compressedThroughMessageId != null) {
+      const cursorRead = readCursorSnapshotParts(sessionId, snapshot, { excludeLastUser: true })
+      if (cursorRead.status === 'usable') {
+        cursorParts = cursorRead.parts
+        history = assembleCursorSnapshotHistory(snapshot, cursorParts, SUMMARY_PREFIX)
+      } else {
+        logger.warn(
+          '[context-compress] session=%s: invalid cursor snapshot (%s); invalidating it before run',
+          sessionId,
+          cursorRead.status === 'invalid' ? cursorRead.reason : 'unexpected_legacy',
+        )
+        deleteCompressionSnapshot(sessionId)
+        snapshot = null
+        history = await buildDbHistory(sessionId, { excludeLastUser: true })
+      }
+    } else {
+      history = await buildDbHistory(sessionId, { excludeLastUser: true })
+    }
 
     const contextLength = getModelContextLength({
       profile,
@@ -309,9 +322,8 @@ export async function buildCompressedHistory(
     }
 
     const canCompressHistory = history.length > 4
-    const snapshot = getCompressionSnapshot(sessionId)
-    const staleSnapshot = snapshot && !isSnapshotUsable(snapshot, history)
-    if (staleSnapshot) {
+    const staleSnapshot = snapshot && snapshot.compressedThroughMessageId == null && !isSnapshotUsable(snapshot, history)
+    if (staleSnapshot && snapshot) {
       logger.warn('[context-compress] session=%s: stale snapshot index %d for %d history messages; using summary plus safe tail',
         sessionId, snapshot.lastMessageIndex, history.length)
       const staleHistory = buildSnapshotHistory(snapshot, history, compressionConfig.compressor) || history
@@ -332,7 +344,40 @@ export async function buildCompressedHistory(
       }, '[context-compress] threshold check')
     }
 
-    if (snapshot && !staleSnapshot) {
+    if (snapshot && cursorParts) {
+      const historyUsage = estimateUsageTokensFromMessages(history)
+      const historyMessageTokens = historyUsage.inputTokens + historyUsage.outputTokens
+      const runMessageTokens = Math.max(historyMessageTokens + currentRunInputTokens, messageOnlyTotalTokens)
+      totalTokens = await estimateLocalContextTokens(history, runMessageTokens)
+      emitContextUsage(totalTokens)
+      logger.info({
+        sessionId,
+        profile,
+        messages: history.length,
+        newMessages: cursorParts.newMessages.length,
+        messageOnlyTokens: runMessageTokens,
+        fullContextTokens: totalTokens,
+        triggerTokens,
+        decision: totalTokens > triggerTokens ? 'compress' : 'skip',
+        snapshot: 'cursor',
+      }, '[context-compress] threshold check')
+      if (totalTokens > triggerTokens) {
+        history = await compressHistory(
+          history,
+          cursorParts.newMessages,
+          sessionId,
+          upstream,
+          apiKey,
+          cState,
+          totalTokens,
+          emit,
+          sessionMap,
+          modelContext,
+          compressionConfig.compressor,
+          currentRunInputTokens,
+        )
+      }
+    } else if (snapshot && !staleSnapshot) {
       const newMessages = history.slice(snapshot.lastMessageIndex + 1)
       const snapshotHistory = buildSnapshotHistory(snapshot, history, compressionConfig.compressor) || history
       const snapshotUsage = estimateUsageTokensFromMessages(snapshotHistory)
@@ -435,6 +480,7 @@ export async function compressHistory(
       profile: summarizerProfile,
       model: summarizerModelContext.model,
       provider: summarizerModelContext.provider,
+      historyRevision: session?.history_revision ?? 0,
       workerKey: `${summarizerProfile}:compression:${sessionId}`,
     })
     const afterTokens = await calcAndUpdateUsage(sessionId, cState, emit, {
@@ -510,7 +556,16 @@ export async function forceCompressBridgeHistory(
   _messages: ChatMessage[],
   beforeTokenOverride?: number | null,
 ): Promise<BridgeCompressionResult> {
-  const history = await buildDbHistory(sessionId, { excludeLastUser: true })
+  const initialSnapshot = getCompressionSnapshot(sessionId)
+  const session = getSession(sessionId)
+  const history = initialSnapshot?.compressedThroughMessageId != null
+    ? await buildDbSnapshotAwareHistory(
+        sessionId,
+        profile,
+        { excludeLastUser: true },
+        { model: session?.model, provider: session?.provider },
+      )
+    : await buildDbHistory(sessionId, { excludeLastUser: true })
 
   if (history.length === 0) {
     return {
@@ -529,10 +584,14 @@ export async function forceCompressBridgeHistory(
 
   const upstream = ''
   const apiKey = undefined
-  const session = getSession(sessionId)
   const contextLength = getModelContextLength({ profile, model: session?.model, provider: session?.provider })
   const compressionConfig = await getRunChatCompressionConfig(session?.profile || profile, contextLength)
-  const beforeUsage = estimateSnapshotAwareHistoryUsage(sessionId, history)
+  const beforeUsage = initialSnapshot?.compressedThroughMessageId != null
+    ? (() => {
+        const usage = estimateUsageTokensFromMessages(history)
+        return { messageCount: history.length, tokenCount: usage.inputTokens + usage.outputTokens }
+      })()
+    : estimateSnapshotAwareHistoryUsage(sessionId, history)
   const totalTokens = typeof beforeTokenOverride === 'number' && Number.isFinite(beforeTokenOverride) && beforeTokenOverride > 0
     ? Math.floor(beforeTokenOverride)
     : beforeUsage.tokenCount
@@ -556,6 +615,7 @@ export async function forceCompressBridgeHistory(
     profile: summarizerProfile,
     model: summarizerModelContext.model,
     provider: summarizerModelContext.provider,
+    historyRevision: session?.history_revision ?? 0,
     workerKey: `${summarizerProfile}:compression:${sessionId}`,
   })
   const compressedMessages = result.messages.map(m => {

--- a/packages/server/src/services/hermes/run-chat/context-history.ts
+++ b/packages/server/src/services/hermes/run-chat/context-history.ts
@@ -1,0 +1,217 @@
+import type { CompressionSnapshot } from '../../../db/hermes/compression-snapshot'
+import {
+  getSession,
+  getSessionContextMessage,
+  getSessionContextMessages,
+  type HermesMessageRow,
+} from '../../../db/hermes/session-store'
+import type { ChatMessage } from '../../../lib/context-compressor'
+import { truncateToolResultForContext } from '../../../lib/tool-result-context'
+import { logger } from '../../logger'
+import { isAssistantMessageSendable } from './message-format'
+
+export interface CursorSnapshotParts {
+  head: ChatMessage[]
+  newMessages: ChatMessage[]
+  historyRevision: number
+}
+
+export type CursorSnapshotReadResult =
+  | { status: 'usable'; parts: CursorSnapshotParts }
+  | { status: 'invalid'; reason: string }
+  | { status: 'legacy' }
+
+export function buildDbHistoryFromContextRows(
+  sessionId: string,
+  rows: HermesMessageRow[],
+  options: {
+    excludeLastUser?: boolean
+    truncateToolResults?: boolean
+  } = {},
+): ChatMessage[] {
+  const sourceRows = options.excludeLastUser ? excludeLatestUserAndFollowing(rows) : rows
+  return sourceRows.map((row, index, allRows) => {
+    const content = row.role === 'tool' && options.truncateToolResults !== false
+      ? truncateToolResultForContext(row.content || '')
+      : row.content || ''
+    const cursorId = Number(row.id)
+    const message: ChatMessage = {
+      role: row.role,
+      content,
+    }
+    // The cursor is runtime-only metadata. Keeping it non-enumerable lets the
+    // compressor advance snapshots without leaking database IDs to providers.
+    if (Number.isSafeInteger(cursorId)) {
+      Object.defineProperty(message, 'cursorId', {
+        value: cursorId,
+        enumerable: false,
+      })
+    }
+    if (row.reasoning_content != null) message.reasoning_content = row.reasoning_content
+    if (row.tool_calls?.length) {
+      const cleanedToolCalls = row.tool_calls
+        .filter((toolCall: any) => toolCall.id && toolCall.id.length > 0)
+        .map((toolCall: any) => ({
+          id: toolCall.id,
+          type: toolCall.type,
+          function: toolCall.function,
+        }))
+      if (cleanedToolCalls.length > 0) message.tool_calls = cleanedToolCalls
+    }
+    if (row.role === 'tool') {
+      let callId = row.tool_call_id
+      if (!callId) {
+        const previous = allRows[index - 1]
+        if (previous?.role === 'assistant' && previous.tool_calls?.length) {
+          const match = previous.tool_calls.find((toolCall: any) => toolCall.function?.name === row.tool_name)
+          if (match?.id) callId = match.id
+        }
+      }
+      if (!callId) return null
+      message.tool_call_id = callId
+    }
+    if (row.tool_name) message.name = row.tool_name
+    if (row.role === 'assistant' && !isAssistantMessageSendable(message)) {
+      logger.warn('[chat-run-socket] skipped empty assistant message while building history for session %s', sessionId)
+      return null
+    }
+    return message
+  }).filter((message): message is ChatMessage => message !== null)
+}
+
+export function buildDbHistory(
+  sessionId: string,
+  options: {
+    excludeLastUser?: boolean
+    truncateToolResults?: boolean
+  } = {},
+): ChatMessage[] {
+  const startedAt = Date.now()
+  const rows = getSessionContextMessages(sessionId)
+  const messages = buildDbHistoryFromContextRows(
+    sessionId,
+    rows,
+    options,
+  )
+  logContextRead('full', sessionId, startedAt, rows.length, messages.length)
+  return messages
+}
+
+export function readCursorSnapshotParts(
+  sessionId: string,
+  snapshot: CompressionSnapshot | null,
+  options: {
+    excludeLastUser?: boolean
+    truncateToolResults?: boolean
+  } = {},
+): CursorSnapshotReadResult {
+  if (!snapshot || snapshot.compressedThroughMessageId == null) return { status: 'legacy' }
+  const session = getSession(sessionId)
+  if (!session) return { status: 'invalid', reason: 'session_missing' }
+  if (session.history_revision !== snapshot.historyRevision) {
+    return { status: 'invalid', reason: 'history_revision_mismatch' }
+  }
+  const cursor = getSessionContextMessage(sessionId, snapshot.compressedThroughMessageId)
+  if (!cursor) return { status: 'invalid', reason: 'cursor_missing' }
+  if (
+    snapshot.protectedHeadThroughMessageId != null &&
+    snapshot.protectedHeadThroughMessageId > snapshot.compressedThroughMessageId
+  ) {
+    return { status: 'invalid', reason: 'protected_head_after_cursor' }
+  }
+  if (
+    snapshot.protectedHeadThroughMessageId != null &&
+    !getSessionContextMessage(sessionId, snapshot.protectedHeadThroughMessageId)
+  ) {
+    return { status: 'invalid', reason: 'protected_head_missing' }
+  }
+
+  const startedAt = Date.now()
+  const headRows = snapshot.protectedHeadThroughMessageId == null
+    ? []
+    : getSessionContextMessages(sessionId, {
+        throughId: snapshot.protectedHeadThroughMessageId,
+      })
+  const { rows: newRows, batches } = readPostCursorRows(
+    sessionId,
+    snapshot.compressedThroughMessageId,
+  )
+  const head = buildDbHistoryFromContextRows(sessionId, headRows, {
+    truncateToolResults: options.truncateToolResults,
+  })
+  const newMessages = buildDbHistoryFromContextRows(sessionId, newRows, options)
+  const elapsedMs = Date.now() - startedAt
+  const logPayload = {
+    sessionId,
+    cursorId: snapshot.compressedThroughMessageId,
+    historyRevision: session.history_revision,
+    headRows: headRows.length,
+    postCursorRows: newRows.length,
+    validMessages: head.length + newMessages.length,
+    batches,
+    elapsedMs,
+  }
+  logger.info(logPayload, '[context-history] cursor context read')
+  if (elapsedMs > 1_000) logger.warn(logPayload, '[context-history] slow cursor context read')
+  return {
+    status: 'usable',
+    parts: {
+      head,
+      newMessages,
+      historyRevision: session.history_revision,
+    },
+  }
+}
+
+export function assembleCursorSnapshotHistory(
+  snapshot: CompressionSnapshot,
+  parts: CursorSnapshotParts,
+  summaryPrefix: string,
+): ChatMessage[] {
+  return [
+    ...parts.head,
+    { role: 'user', content: `${summaryPrefix}\n\n${snapshot.summary}` },
+    ...parts.newMessages,
+  ]
+}
+
+function excludeLatestUserAndFollowing(rows: HermesMessageRow[]): HermesMessageRow[] {
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    if (rows[index].role === 'user') return rows.slice(0, index)
+  }
+  return rows
+}
+
+function readPostCursorRows(
+  sessionId: string,
+  cursorId: number,
+  batchSize = 500,
+): { rows: HermesMessageRow[]; batches: number } {
+  const rows: HermesMessageRow[] = []
+  let afterId = cursorId
+  let batches = 0
+  while (true) {
+    const batch = getSessionContextMessages(sessionId, { afterId, limit: batchSize })
+    if (batch.length === 0) break
+    rows.push(...batch)
+    batches += 1
+    const nextAfterId = Number(batch.at(-1)?.id)
+    if (!Number.isSafeInteger(nextAfterId) || nextAfterId <= afterId) break
+    afterId = nextAfterId
+    if (batch.length < batchSize) break
+  }
+  return { rows, batches }
+}
+
+function logContextRead(
+  mode: 'full',
+  sessionId: string,
+  startedAt: number,
+  rawRows: number,
+  validMessages: number,
+): void {
+  const elapsedMs = Date.now() - startedAt
+  const payload = { sessionId, mode, rawRows, validMessages, elapsedMs }
+  logger.info(payload, '[context-history] context read')
+  if (elapsedMs > 1_000) logger.warn(payload, '[context-history] slow context read')
+}

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -5,12 +5,12 @@
 
 import type { Server, Socket } from 'socket.io'
 import { getSystemPrompt } from '../../../lib/llm-prompt'
-import { getSession, getSessionDetail, createSession, addMessage, updateSession, updateSessionStats } from '../../../db/hermes/session-store'
+import { getFirstSessionMessageByRole, getSession, getSessionMessageCountByRole, createSession, addMessage, updateSession, updateSessionStats } from '../../../db/hermes/session-store'
 import { logger, bridgeLogger } from '../../logger'
 import { normalizeTokenUsage, recordSessionUsage } from '../../usage-recorder'
 import { AgentBridgeClient, type AgentBridgeContextEstimate, type AgentBridgeMessage, type AgentBridgeOutput } from '../agent-bridge'
 import { contentBlocksToString, convertContentBlocksForAgent, extractTextForPreview, isContentBlockArray } from './content-blocks'
-import { buildCompressedHistory, buildDbHistory, buildSnapshotAwareHistory, forceCompressBridgeHistory, pushState, replaceState } from './compression'
+import { buildCompressedHistory, buildDbSnapshotAwareHistory, forceCompressBridgeHistory, pushState, replaceState } from './compression'
 import {
   calcAndUpdateUsage,
   contextTokensWithCachedOverhead,
@@ -85,19 +85,19 @@ function fallbackTitleFromText(text: string, limit: number, ellipsis: boolean): 
 }
 
 function isReplaceableLocalTitle(sessionId: string): boolean {
-  const detail = getSessionDetail(sessionId)
-  if (!detail) return false
-  const current = normalizeTitleText(detail.title)
+  const session = getSession(sessionId)
+  if (!session) return false
+  const current = normalizeTitleText(session.title)
   if (!current) return true
   const variants = new Set<string>([''])
-  const preview = normalizeTitleText(detail.preview)
+  const preview = normalizeTitleText(session.preview)
   if (preview) {
     variants.add(preview)
     variants.add(fallbackTitleFromText(preview, 40, true))
     variants.add(fallbackTitleFromText(preview, 63, false))
     variants.add(fallbackTitleFromText(preview, 100, false))
   }
-  const firstUser = detail.messages.find(message => message.role === 'user' && normalizeTitleText(message.content))
+  const firstUser = getFirstSessionMessageByRole(sessionId, 'user')
   const firstUserText = normalizeTitleText(firstUser?.content)
   if (firstUserText) {
     variants.add(firstUserText)
@@ -137,9 +137,7 @@ function syncBridgeGeneratedTitle(sessionId: string, title: unknown, emit: (even
 function shouldPollBridgeGeneratedTitle(sessionId: string): boolean {
   const session = getSession(sessionId)
   if (!session || !isBridgeSessionSource(session.source)) return false
-  const detail = getSessionDetail(sessionId)
-  if (!detail) return false
-  const userMessageCount = detail.messages.filter(message => message.role === 'user').length
+  const userMessageCount = getSessionMessageCountByRole(sessionId, 'user')
   return userMessageCount <= 2 && isReplaceableLocalTitle(sessionId)
 }
 
@@ -945,11 +943,10 @@ async function refreshFinalContextUsage(args: {
   bridge: AgentBridgeClient
 }): Promise<number | undefined> {
   try {
-    const dbHistory = await buildDbHistory(args.sessionId, { excludeLastUser: false })
-    const finalHistory = await buildSnapshotAwareHistory(
+    const finalHistory = await buildDbSnapshotAwareHistory(
       args.sessionId,
       args.profile,
-      dbHistory,
+      { excludeLastUser: false },
       { model: args.model, provider: args.provider },
     )
     const finalMessageUsage = estimateUsageTokensFromMessages(finalHistory)
@@ -1000,11 +997,10 @@ async function estimateSnapshotAwareMessageTokens(args: {
   currentInputTokens?: number
   currentInputIncludedInDb?: boolean
 }): Promise<{ messageTokens: number; messages: number }> {
-  const dbHistory = await buildDbHistory(args.sessionId, { excludeLastUser: false })
-  const snapshotHistory = await buildSnapshotAwareHistory(
+  const snapshotHistory = await buildDbSnapshotAwareHistory(
     args.sessionId,
     args.profile,
-    dbHistory,
+    { excludeLastUser: false },
     { model: args.model, provider: args.provider },
   )
   const usage = estimateUsageTokensFromMessages(snapshotHistory)
@@ -1327,7 +1323,12 @@ async function applyBridgeChunkAsync(
       replaceState(sessionMap, sessionId, 'clarify.resolved', payload)
       emit('clarify.resolved', payload)
     } else if (evType === 'bridge.compression.requested') {
-      const bridgeHistory = await buildDbHistory(sessionId, { excludeLastUser: true })
+      const bridgeHistory = await buildDbSnapshotAwareHistory(
+        sessionId,
+        profile,
+        { excludeLastUser: true },
+        { model: modelContext.model, provider: modelContext.provider },
+      )
       const bridgeUsage = estimateUsageTokensFromMessages(bridgeHistory)
       const messageOnlyTokens = bridgeUsage.inputTokens + bridgeUsage.outputTokens
       const runInputTokens = typeof currentInputTokens === 'number' && Number.isFinite(currentInputTokens) && currentInputTokens > 0

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -153,7 +153,17 @@ function looksLikeAgentFailure(value: string): boolean {
     || /\b(?:rate limit|too many requests|quota)\b.{0,100}\b429\b/i.test(text)
     || /\b(?:500|502|503|504)\b.{0,100}\b(?:server error|bad gateway|service unavailable|gateway timeout|upstream|provider|request failed|api)\b/i.test(text)
     || /\b(?:server error|bad gateway|service unavailable|gateway timeout|upstream|provider|request failed|api)\b.{0,100}\b(?:500|502|503|504)\b/i.test(text)
-    || /(?:无可用渠道|渠道不可用|认证失败|鉴权失败|额度不足|余额不足|请求失败|接口调用失败|限流)/i.test(text)
+    || /(?:无可用渠道|渠道不可用|认证失败|鉴权失败|额度不足|余额不足|请求失败|接口调用失败)/i.test(text)
+    || /(?:请求|接口|模型|渠道|API).{0,20}(?:被限流|触发限流|因限流失败)/i.test(text)
+    || /(?:限流|频率限制).{0,20}(?:失败|错误|重试|稍后)/i.test(text)
+}
+
+function looksLikeStandaloneAgentFailure(value: string): boolean {
+  const text = value.replace(/\s+/g, ' ').trim()
+  // A provider failure returned as final_response is normally a compact error.
+  // Do not scan an arbitrary long-form successful answer for incidental terms
+  // such as "登录限流" or documentation about HTTP error handling.
+  return text.length > 0 && text.length <= 2_000 && looksLikeAgentFailure(text)
 }
 
 export function bridgeTerminalError(chunk: Pick<AgentBridgeOutput, 'status' | 'error' | 'result'>): string | null {
@@ -176,8 +186,9 @@ export function bridgeTerminalError(chunk: Pick<AgentBridgeOutput, 'status' | 'e
   }
 
   if (resultError && looksLikeAgentFailure(resultError)) return resultError
+  if (result?.completed === true) return null
   if (!finalResponse && resultMessage && looksLikeAgentFailure(resultMessage)) return resultMessage
-  if (finalResponse && looksLikeAgentFailure(finalResponse)) return finalResponse
+  if (finalResponse && looksLikeStandaloneAgentFailure(finalResponse)) return finalResponse
 
   return null
 }

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -10,7 +10,7 @@
 import type { Server, Socket } from 'socket.io'
 import { logger } from '../../logger'
 import { getSystemPrompt } from '../../../lib/llm-prompt'
-import { clearSessionMessages, getSession, getSessionDetail, listSessions } from '../../../db/hermes/session-store'
+import { clearSessionMessages, getSession, getSessionMetadata, listSessions } from '../../../db/hermes/session-store'
 import { getSessionCategory } from '../../../db/hermes/session-category-store'
 import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../hermes-profile'
 import {
@@ -758,7 +758,7 @@ export class ChatRunSocket {
     const resumeEvents = state.isWorking
       ? state.events
       : (state.events || []).filter(evt => evt?.event === 'run.reattach_failed')
-    const sessionDetail = getSessionDetail(sid)
+    const sessionDetail = getSessionMetadata(sid)
     socket.emit('resumed', {
       session_id: sid,
       messages: state.messages,

--- a/packages/server/src/services/hermes/run-chat/load-state.ts
+++ b/packages/server/src/services/hermes/run-chat/load-state.ts
@@ -1,11 +1,9 @@
-import { getCompressionSnapshot } from '../../../db/hermes/compression-snapshot'
 import {
   getSession,
   getSessionDetailPaginated,
 } from '../../../db/hermes/session-store'
-import { countTokens, SUMMARY_PREFIX } from '../../../lib/context-compressor'
+import { getRecordedUsageTotals, getUsage } from '../../../db/hermes/usage-store'
 import { logger } from '../../logger'
-import { buildDbHistory, buildSnapshotAwareHistory } from './compression'
 import { handleMessage } from './message-format'
 import { estimateUsageTokensFromMessages } from './usage'
 import type { ChatRunSource, SessionState } from './types'
@@ -21,38 +19,37 @@ export function resolveRunSource(source?: string, sessionId?: string): ChatRunSo
 
 export async function loadSessionStateFromDb(sid: string, _sessionMap: Map<string, SessionState>): Promise<SessionState> {
   try {
+    const displayStartedAt = Date.now()
     const actualDetail = getSessionDetailPaginated(sid)
 
     const messages = actualDetail?.messages ? handleMessage(actualDetail.messages, sid) : []
+    const displayElapsedMs = Date.now() - displayStartedAt
+    const displayPayload = {
+      sessionId: sid,
+      rows: actualDetail?.messages.length || 0,
+      total: actualDetail?.total || 0,
+      elapsedMs: displayElapsedMs,
+    }
+    logger.info(displayPayload, '[chat-run-socket] display page loaded')
+    if (displayElapsedMs > 1_000) logger.warn(displayPayload, '[chat-run-socket] slow display page load')
 
     let inputTokens: number
     let outputTokens: number
     let contextTokens: number | undefined
-    const snapshot = getCompressionSnapshot(sid)
-    if (snapshot && snapshot.lastMessageIndex >= 0 && snapshot.lastMessageIndex < messages.length) {
-      const newMessages = messages.slice(snapshot.lastMessageIndex + 1)
-      const newUsage = estimateUsageTokensFromMessages(newMessages)
-      inputTokens = countTokens(SUMMARY_PREFIX + snapshot.summary) +
-        newUsage.inputTokens
-      outputTokens = newUsage.outputTokens
-    } else {
-      const usage = estimateUsageTokensFromMessages(messages)
-      inputTokens = usage.inputTokens
-      outputTokens = usage.outputTokens
-    }
-    try {
-      const session = getSession(sid)
-      const dbHistory = await buildDbHistory(sid, { excludeLastUser: false })
-      const snapshotHistory = await buildSnapshotAwareHistory(
-        sid,
-        session?.profile || 'default',
-        dbHistory,
-        { model: session?.model, provider: session?.provider },
-      )
-      const contextUsage = estimateUsageTokensFromMessages(snapshotHistory)
-      contextTokens = contextUsage.inputTokens + contextUsage.outputTokens
-    } catch (err) {
-      logger.warn(err, '[chat-run-socket] failed to calculate snapshot-aware context tokens for session %s', sid)
+    const session = actualDetail?.session || getSession(sid)
+    const usageSource = session?.source === 'coding_agent' || ['codex', 'claude', 'claude-code', 'claude_code'].includes(session?.agent || '')
+      ? 'coding_agent'
+      : session?.agent === 'ekko_agent' || session?.agent === 'ekko-agent'
+        ? 'ekko_agent'
+        : 'hermes'
+    const totals = getRecordedUsageTotals(sid, usageSource)
+    const pageUsage = estimateUsageTokensFromMessages(messages)
+    const latestUsage = getUsage(sid)
+    const hasPersistedUsage = !!latestUsage || totals.inputTokens > 0 || totals.outputTokens > 0
+    inputTokens = hasPersistedUsage ? totals.inputTokens : pageUsage.inputTokens
+    outputTokens = hasPersistedUsage ? totals.outputTokens : pageUsage.outputTokens
+    if (latestUsage) {
+      contextTokens = Number(latestUsage.input_tokens || 0) + Number(latestUsage.output_tokens || 0)
     }
 
     logger.info('[chat-run-socket] loaded session %s from DB (%d messages)', sid, messages.length)

--- a/packages/server/src/services/hermes/run-chat/session-command.ts
+++ b/packages/server/src/services/hermes/run-chat/session-command.ts
@@ -4,9 +4,9 @@ import { logger } from '../../logger'
 import type { AgentBridgeClient } from '../agent-bridge'
 import { readConfigYamlForProfile } from '../../config-helpers'
 import { flushBridgePendingToDb } from './bridge-message'
-import { buildDbHistory, estimateSnapshotAwareHistoryUsage, forceCompressBridgeHistory, getOrCreateSession, replaceState } from './compression'
+import { buildDbSnapshotAwareHistory, forceCompressBridgeHistory, getOrCreateSession, replaceState } from './compression'
 import { handleAbort } from './abort'
-import { calcAndUpdateUsage, contextTokensWithCachedOverhead, updateMessageContextTokenUsage } from './usage'
+import { calcAndUpdateUsage, contextTokensWithCachedOverhead, estimateUsageTokensFromMessages, updateMessageContextTokenUsage } from './usage'
 import { contentBlocksToString } from './content-blocks'
 import type { ChatRunSource, ContentBlock, QueuedRun, SessionState } from './types'
 
@@ -646,12 +646,19 @@ export async function handleSessionCommand(
       clearTransientRunState(state)
       const emit = (event: string, payload: any) => emitToSession(ctx.nsp, ctx.socket, sessionId, event, payload)
       try {
-        const history = await buildDbHistory(sessionId, { excludeLastUser: true })
-        const usageEstimate = estimateSnapshotAwareHistoryUsage(sessionId, history)
-        const beforeContextTokens = contextTokensWithCachedOverhead(state, usageEstimate.tokenCount)
+        const session = getSession(sessionId)
+        const history = await buildDbSnapshotAwareHistory(
+          sessionId,
+          ctx.profile,
+          { excludeLastUser: true },
+          { model: session?.model, provider: session?.provider },
+        )
+        const historyUsage = estimateUsageTokensFromMessages(history)
+        const beforeMessageTokens = historyUsage.inputTokens + historyUsage.outputTokens
+        const beforeContextTokens = contextTokensWithCachedOverhead(state, beforeMessageTokens)
         emit('compression.started', {
           event: 'compression.started',
-          message_count: usageEstimate.messageCount,
+          message_count: history.length,
           token_count: beforeContextTokens,
           source: 'command',
         })

--- a/packages/server/src/services/hermes/run-chat/usage.ts
+++ b/packages/server/src/services/hermes/run-chat/usage.ts
@@ -6,10 +6,12 @@
 import {
   getSessionDetail,
 } from '../../../db/hermes/session-store'
-import { getCompressionSnapshot } from '../../../db/hermes/compression-snapshot'
+import { deleteCompressionSnapshot, getCompressionSnapshot } from '../../../db/hermes/compression-snapshot'
+import { getRecordedUsageTotals, getUsage } from '../../../db/hermes/usage-store'
 import { countTokens, SUMMARY_PREFIX } from '../../../lib/context-compressor'
 import { truncateToolResultForContext } from '../../../lib/tool-result-context'
 import { logger } from '../../logger'
+import { assembleCursorSnapshotHistory, readCursorSnapshotParts } from './context-history'
 import type { SessionState } from './types'
 
 type UsageTokenMessage = {
@@ -45,7 +47,10 @@ export async function calcAndUpdateUsage(
   sid: string,
   state: SessionState,
   emit: (event: string, payload: any) => void,
-  options: { truncateToolResultsForContext?: boolean } = {},
+  options: {
+    truncateToolResultsForContext?: boolean
+    nativeSource?: 'coding_agent'
+  } = {},
 ): Promise<{
   inputTokens: number
   outputTokens: number
@@ -53,10 +58,81 @@ export async function calcAndUpdateUsage(
   contextOutputTokens?: number
 }> {
   try {
+    if (options.nativeSource) {
+      const totals = getRecordedUsageTotals(sid, options.nativeSource)
+      const latest = getUsage(sid)
+      const usage = {
+        inputTokens: totals.inputTokens,
+        outputTokens: totals.outputTokens,
+      }
+      state.inputTokens = usage.inputTokens
+      state.outputTokens = usage.outputTokens
+      emit('usage.updated', {
+        event: 'usage.updated',
+        session_id: sid,
+        ...usage,
+      })
+      return {
+        ...usage,
+        ...(latest
+          ? {
+              contextInputTokens: Number(latest.input_tokens || 0),
+              contextOutputTokens: Number(latest.output_tokens || 0),
+            }
+          : {}),
+      }
+    }
+
+    const snapshot = getCompressionSnapshot(sid)
+    if (snapshot?.compressedThroughMessageId != null) {
+      const cursorRead = readCursorSnapshotParts(sid, snapshot, {
+        truncateToolResults: false,
+      })
+      if (cursorRead.status === 'usable') {
+        const messages = assembleCursorSnapshotHistory(snapshot, cursorRead.parts, SUMMARY_PREFIX)
+        const usage = estimateUsageTokensFromMessages(messages)
+        let contextUsage: { inputTokens: number; outputTokens: number } | undefined
+        if (options.truncateToolResultsForContext) {
+          const contextRead = readCursorSnapshotParts(sid, snapshot, {
+            truncateToolResults: true,
+          })
+          if (contextRead.status === 'usable') {
+            contextUsage = estimateUsageTokensFromMessages(
+              assembleCursorSnapshotHistory(snapshot, contextRead.parts, SUMMARY_PREFIX),
+            )
+          }
+        }
+        state.inputTokens = usage.inputTokens
+        state.outputTokens = usage.outputTokens
+        emit('usage.updated', {
+          event: 'usage.updated',
+          session_id: sid,
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+        })
+        return {
+          ...usage,
+          ...(contextUsage
+            ? {
+                contextInputTokens: contextUsage.inputTokens,
+                contextOutputTokens: contextUsage.outputTokens,
+              }
+            : {}),
+        }
+      }
+      if (cursorRead.status === 'invalid') {
+        logger.warn(
+          '[chat-run-socket] invalid cursor snapshot while calculating usage for session %s (%s)',
+          sid,
+          cursorRead.reason,
+        )
+        deleteCompressionSnapshot(sid)
+      }
+    }
+
     const detail = getSessionDetail(sid)
     const storedMessages = detail?.messages
       ?.filter(m => m.role === 'user' || m.role === 'assistant' || m.role === 'tool') || []
-    const snapshot = getCompressionSnapshot(sid)
     const estimateSnapshotUsage = (messages: typeof storedMessages) => {
       if (snapshot && messages.length && snapshot.lastMessageIndex >= 0 && snapshot.lastMessageIndex < messages.length) {
         const newMessages = messages.slice(snapshot.lastMessageIndex + 1)

--- a/tests/client/session-category-groups.test.ts
+++ b/tests/client/session-category-groups.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildVisibleSessionCategoryGroups } from '../../packages/client/src/components/hermes/chat/session-category-groups'
+
+describe('session category groups', () => {
+  it('hides categories that have no visible sessions', () => {
+    const groups = buildVisibleSessionCategoryGroups(
+      [
+        { id: 1, name: 'Work' },
+        { id: 2, name: 'Empty' },
+      ],
+      [
+        { id: 'session-1', categoryId: 1 },
+        { id: 'session-2', categoryId: null },
+      ],
+      'Uncategorized',
+    )
+
+    expect(groups.map((group) => [group.key, group.sessions.length])).toEqual([
+      ['category-1', 1],
+      ['category-none', 1],
+    ])
+  })
+
+  it('returns no groups when the session list is empty', () => {
+    expect(buildVisibleSessionCategoryGroups(
+      [{ id: 1, name: 'Work' }],
+      [],
+      'Uncategorized',
+    )).toEqual([])
+  })
+
+  it('shows sessions with deleted or unknown categories as uncategorized', () => {
+    const groups = buildVisibleSessionCategoryGroups(
+      [{ id: 1, name: 'Work' }],
+      [{ id: 'session-1', categoryId: 999 }],
+      'Uncategorized',
+    )
+
+    expect(groups).toEqual([{
+      key: 'category-none',
+      label: 'Uncategorized',
+      sessions: [{ id: 'session-1', categoryId: 999 }],
+    }])
+  })
+})

--- a/tests/e2e/session-categories.spec.ts
+++ b/tests/e2e/session-categories.spec.ts
@@ -64,7 +64,7 @@ test('groups sessions by category and persists collapsed groups', async ({ page 
   const workHeader = page.locator('.session-group-header').filter({ hasText: 'Work' })
   await expect(workHeader).toBeVisible()
   await expect(workHeader.locator('.session-group-count')).toHaveText('2')
-  await expect(page.locator('.session-group-header').filter({ hasText: 'Empty' })).toBeVisible()
+  await expect(page.locator('.session-group-header').filter({ hasText: 'Empty' })).toHaveCount(0)
   await expect(page.getByRole('link', { name: /Project Alpha/ })).toBeVisible()
   await expect(page.getByRole('link', { name: /Project Beta/ })).toBeVisible()
 

--- a/tests/ekko-agent/runtime.test.ts
+++ b/tests/ekko-agent/runtime.test.ts
@@ -481,6 +481,80 @@ describe('ekko-agent runtime', () => {
     expect(requests[0].messages.filter(message => message.role === 'system')).toHaveLength(1)
   })
 
+  it('disables all tools without disabling skill instructions', async () => {
+    const listTools = vi.fn(async () => [])
+    const tools = new AgentToolRegistry()
+    tools.registerProvider({ id: 'dynamic', listTools })
+    const client = modelClient((request) => {
+      expect(request.tools).toBeUndefined()
+      expect(request.messages[0].content).toContain('Keep this skill instruction.')
+      return { content: 'ok' }
+    })
+
+    await new AgentRuntime({
+      modelClient: client,
+      tools,
+      toolsEnabled: false,
+      skills: [{
+        id: 'kept-skill',
+        name: 'Kept Skill',
+        instructions: 'Keep this skill instruction.',
+      }],
+    }).run({ messages: ['hi'] })
+
+    expect(listTools).not.toHaveBeenCalled()
+  })
+
+  it('disables constructor and per-run skills without disabling regular tools', async () => {
+    const regularTool: AgentTool = {
+      definition: { name: 'regular_tool', parameters: { type: 'object' } },
+      async execute() {
+        return { ok: true, content: 'regular' }
+      },
+    }
+    const skillTool: AgentTool = {
+      definition: { name: 'skill_tool', parameters: { type: 'object' } },
+      async execute() {
+        return { ok: true, content: 'skill' }
+      },
+    }
+    const tools = new AgentToolRegistry()
+    tools.register(regularTool)
+    const client = modelClient((request) => {
+      expect(request.tools?.map(tool => tool.name)).toEqual(['regular_tool'])
+      expect(request.messages[0].content).not.toContain('Disabled constructor skill.')
+      expect(request.messages[0].content).not.toContain('Disabled run skill.')
+      return { content: 'ok' }
+    })
+    const runtime = new AgentRuntime({
+      modelClient: client,
+      tools,
+      skillsEnabled: false,
+      skills: [{
+        id: 'constructor-skill',
+        name: 'Constructor Skill',
+        instructions: 'Disabled constructor skill.',
+        tools: [skillTool],
+      }],
+    })
+
+    runtime.registerSkill({
+      id: 'registered-skill',
+      name: 'Registered Skill',
+      instructions: 'Disabled registered skill.',
+      tools: [skillTool],
+    })
+    await runtime.run({
+      messages: ['hi'],
+      skills: [{
+        id: 'run-skill',
+        name: 'Run Skill',
+        instructions: 'Disabled run skill.',
+        tools: [skillTool],
+      }],
+    })
+  })
+
   it('refreshes dynamic tool providers before running', async () => {
     const providerTool: AgentTool = {
       definition: { name: 'provided_tool', parameters: { type: 'object' } },

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -57,6 +57,7 @@ vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
 
 vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
   getSession: getSessionMock,
+  getSessionMetadata: getSessionMock,
   getSessionDetail: vi.fn(() => null),
 }))
 

--- a/tests/server/compression-cursor-store.test.ts
+++ b/tests/server/compression-cursor-store.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('compression cursor persistence', () => {
+  let db: any = null
+
+  beforeEach(async () => {
+    vi.resetModules()
+    const { DatabaseSync } = await import('node:sqlite')
+    db = new DatabaseSync(':memory:')
+    vi.doMock('../../packages/server/src/db/index', () => ({
+      getDb: () => db,
+      isSqliteAvailable: () => true,
+      getStoragePath: () => ':memory:',
+    }))
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    initAllHermesTables()
+  })
+
+  afterEach(() => {
+    db?.close()
+    db = null
+    vi.doUnmock('../../packages/server/src/db/index')
+    vi.resetModules()
+  })
+
+  it('stores a stable cursor while retaining legacy diagnostics', async () => {
+    const { addMessage, createSession } = await import('../../packages/server/src/db/hermes/session-store')
+    const { getCompressionSnapshot, saveCompressionSnapshot } = await import('../../packages/server/src/db/hermes/compression-snapshot')
+    createSession({ id: 'session-1', source: 'cli' })
+    const headId = addMessage({ session_id: 'session-1', role: 'user', content: 'head' })!
+    addMessage({ session_id: 'session-1', role: 'assistant', content: 'middle' })
+    const boundaryId = addMessage({ session_id: 'session-1', role: 'user', content: 'fold me' })!
+    addMessage({ session_id: 'session-1', role: 'assistant', content: 'tail' })
+
+    expect(saveCompressionSnapshot('session-1', 'summary', 0, 0, {
+      compressedThroughMessageId: boundaryId,
+      protectedHeadThroughMessageId: headId,
+      expectedHistoryRevision: 0,
+    })).toBe(true)
+    expect(getCompressionSnapshot('session-1')).toEqual({
+      summary: 'summary',
+      lastMessageIndex: 2,
+      messageCountAtTime: 4,
+      compressedThroughMessageId: boundaryId,
+      protectedHeadThroughMessageId: headId,
+      historyRevision: 0,
+    })
+  })
+
+  it('invalidates a snapshot transactionally and rejects an in-flight stale write after clear', async () => {
+    const { addMessage, clearSessionMessages, createSession, getSession } = await import('../../packages/server/src/db/hermes/session-store')
+    const { getCompressionSnapshot, saveCompressionSnapshot } = await import('../../packages/server/src/db/hermes/compression-snapshot')
+    createSession({ id: 'session-clear', source: 'cli' })
+    const boundaryId = addMessage({ session_id: 'session-clear', role: 'user', content: 'old' })!
+    expect(saveCompressionSnapshot('session-clear', 'old summary', 0, 1, {
+      compressedThroughMessageId: boundaryId,
+      expectedHistoryRevision: 0,
+    })).toBe(true)
+
+    expect(clearSessionMessages('session-clear')).toBe(1)
+    expect(getCompressionSnapshot('session-clear')).toBeNull()
+    expect(getSession('session-clear')?.history_revision).toBe(1)
+    const replacementId = addMessage({ session_id: 'session-clear', role: 'user', content: 'new' })!
+    expect(saveCompressionSnapshot('session-clear', 'stale result', 0, 1, {
+      compressedThroughMessageId: replacementId,
+      expectedHistoryRevision: 0,
+    })).toBe(false)
+    expect(getCompressionSnapshot('session-clear')).toBeNull()
+  })
+
+  it('removes snapshots with sessions and remaps cursor IDs for complete branches', async () => {
+    const {
+      addMessage,
+      createBranchedSession,
+      createSession,
+      deleteSession,
+      getSessionContextMessages,
+    } = await import('../../packages/server/src/db/hermes/session-store')
+    const {
+      copyCompressionSnapshot,
+      getCompressionSnapshot,
+      saveCompressionSnapshot,
+    } = await import('../../packages/server/src/db/hermes/compression-snapshot')
+
+    createSession({ id: 'parent', source: 'cli' })
+    const parentHead = addMessage({ session_id: 'parent', role: 'user', content: 'head', timestamp: 1 })!
+    const parentCursor = addMessage({ session_id: 'parent', role: 'assistant', content: 'middle', timestamp: 2 })!
+    addMessage({ session_id: 'parent', role: 'user', content: 'tail', timestamp: 3 })
+    expect(saveCompressionSnapshot('parent', 'parent summary', 1, 3, {
+      compressedThroughMessageId: parentCursor,
+      protectedHeadThroughMessageId: parentHead,
+      expectedHistoryRevision: 0,
+    })).toBe(true)
+
+    createBranchedSession({
+      id: 'child',
+      parent_session_id: 'parent',
+      source: 'cli',
+      ended_at: 4,
+      last_active: 4,
+      messages: [
+        { role: 'user', content: 'head', timestamp: 1 },
+        { role: 'assistant', content: 'middle', timestamp: 2 },
+        { role: 'user', content: 'tail', timestamp: 3 },
+      ],
+    })
+    const childRows = getSessionContextMessages('child')
+    expect(getCompressionSnapshot('child')).toEqual(expect.objectContaining({
+      summary: 'parent summary',
+      compressedThroughMessageId: Number(childRows[1].id),
+      protectedHeadThroughMessageId: Number(childRows[0].id),
+      historyRevision: 0,
+    }))
+
+    createSession({ id: 'partial-child', source: 'cli' })
+    addMessage({ session_id: 'partial-child', role: 'user', content: 'head' })
+    expect(copyCompressionSnapshot('parent', 'partial-child')).toBe(false)
+    expect(getCompressionSnapshot('partial-child')).toBeNull()
+
+    expect(deleteSession('child')).toBe(true)
+    expect(getCompressionSnapshot('child')).toBeNull()
+  })
+
+  it('keeps legacy rows unchanged when the cursor columns are introduced', async () => {
+    db.exec('DROP TABLE chat_compression_snapshots')
+    db.exec(`CREATE TABLE chat_compression_snapshots (
+      session_id TEXT PRIMARY KEY,
+      summary TEXT NOT NULL DEFAULT '',
+      last_message_index INTEGER NOT NULL DEFAULT 0,
+      message_count_at_time INTEGER NOT NULL DEFAULT 0,
+      updated_at INTEGER NOT NULL
+    )`)
+    db.prepare(`INSERT INTO chat_compression_snapshots
+      (session_id, summary, last_message_index, message_count_at_time, updated_at)
+      VALUES (?, ?, ?, ?, ?)`
+    ).run('legacy', 'legacy summary', 42, 50, 1)
+
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    initAllHermesTables()
+    const row = db.prepare('SELECT * FROM chat_compression_snapshots WHERE session_id = ?').get('legacy') as any
+    expect(row).toEqual(expect.objectContaining({
+      summary: 'legacy summary',
+      last_message_index: 42,
+      message_count_at_time: 50,
+      compressed_through_message_id: null,
+      protected_head_through_message_id: null,
+      history_revision: 0,
+    }))
+  })
+
+  it('reads only protected head and post-cursor context for a 15,000-row session', async () => {
+    const { addMessages, createSession, getSessionContextMessages } = await import('../../packages/server/src/db/hermes/session-store')
+    const { getCompressionSnapshot, saveCompressionSnapshot } = await import('../../packages/server/src/db/hermes/compression-snapshot')
+    const { readCursorSnapshotParts } = await import('../../packages/server/src/services/hermes/run-chat/context-history')
+    const { buildDbExportHistory } = await import('../../packages/server/src/lib/context-compressor/export-compressor')
+    createSession({ id: 'large', source: 'cli' })
+    addMessages(Array.from({ length: 15_000 }, (_, index) => ({
+      session_id: 'large',
+      role: index % 5 === 4 ? 'moa' : index % 2 === 0 ? 'user' : 'assistant',
+      content: `message-${index}`,
+      timestamp: index + 1,
+    })))
+    const contextRows = getSessionContextMessages('large')
+    const headId = Number(contextRows[1].id)
+    const boundaryId = Number(contextRows.at(-6)!.id)
+    expect(saveCompressionSnapshot('large', 'large summary', 0, 0, {
+      compressedThroughMessageId: boundaryId,
+      protectedHeadThroughMessageId: headId,
+      expectedHistoryRevision: 0,
+    })).toBe(true)
+
+    const result = readCursorSnapshotParts('large', getCompressionSnapshot('large'))
+    expect(result.status).toBe('usable')
+    if (result.status === 'usable') {
+      expect(result.parts.head).toHaveLength(2)
+      expect(result.parts.newMessages).toHaveLength(5)
+      expect(result.parts.newMessages[0].content).toBe(contextRows.at(-5)!.content)
+    }
+    const exportHistory = buildDbExportHistory('large')
+    expect(exportHistory).toHaveLength(7)
+    expect(exportHistory[0].content).toBe(contextRows[0].content)
+    expect(exportHistory.at(-1)?.content).toBe(contextRows.at(-1)?.content)
+  })
+})

--- a/tests/server/context-compressor.test.ts
+++ b/tests/server/context-compressor.test.ts
@@ -5,6 +5,11 @@ const saveCompressionSnapshotMock = vi.fn()
 const deleteCompressionSnapshotMock = vi.fn()
 const bridgeRequestMock = vi.fn()
 const bridgeDestroyMock = vi.fn()
+const ekkoRuntimeOptionsMock = vi.fn()
+const ekkoRuntimeRunMock = vi.fn()
+const createModelClientMock = vi.fn()
+const resolveModelProviderConfigsMock = vi.fn()
+const resolveEkkoProviderRuntimeConfigMock = vi.fn()
 
 vi.mock('../../packages/server/src/services/logger', () => ({
   logger: {
@@ -28,6 +33,22 @@ vi.mock('../../packages/server/src/services/hermes/agent-bridge', () => ({
   },
 }))
 
+vi.mock('../../packages/server/src/services/ekko-agent/provider-runtime', () => ({
+  resolveEkkoProviderRuntimeConfig: resolveEkkoProviderRuntimeConfigMock,
+}))
+
+vi.mock('../../packages/ekko-agent/src', () => ({
+  AgentRuntime: class {
+    constructor(options: unknown) {
+      ekkoRuntimeOptionsMock(options)
+    }
+
+    run = ekkoRuntimeRunMock
+  },
+  createModelClient: createModelClientMock,
+  resolveModelProviderConfigs: resolveModelProviderConfigsMock,
+}))
+
 describe('ChatContextCompressor', () => {
   let originalFetch: typeof global.fetch
 
@@ -38,12 +59,113 @@ describe('ChatContextCompressor', () => {
     deleteCompressionSnapshotMock.mockReset()
     bridgeRequestMock.mockReset()
     bridgeDestroyMock.mockReset()
+    ekkoRuntimeOptionsMock.mockReset()
+    ekkoRuntimeRunMock.mockReset()
+    createModelClientMock.mockReset()
+    resolveModelProviderConfigsMock.mockReset()
+    resolveEkkoProviderRuntimeConfigMock.mockReset()
     bridgeRequestMock.mockRejectedValue(new Error('summarizer failed'))
     bridgeDestroyMock.mockResolvedValue(undefined)
+    ekkoRuntimeRunMock.mockRejectedValue(new Error('ekko summarizer failed'))
+    resolveEkkoProviderRuntimeConfigMock.mockResolvedValue({
+      provider: 'openrouter',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      apiKey: 'profile-key',
+      apiMode: 'chat_completions',
+    })
+    resolveModelProviderConfigsMock.mockReturnValue({
+      providerConfig: { id: 'openrouter', defaultModel: 'summary-model' },
+    })
+    createModelClientMock.mockReturnValue({
+      provider: 'openrouter',
+      requestStyle: 'openai-chat',
+      capabilities: {
+        streaming: true,
+        tools: true,
+        vision: false,
+        jsonMode: false,
+        systemPrompt: true,
+      },
+      create: vi.fn(),
+      stream: vi.fn(),
+    })
   })
 
   afterEach(() => {
     global.fetch = originalFetch
+  })
+
+  it('uses a fresh one-step tool-free and skill-free Ekko agent for summarization', async () => {
+    const { callSummarizer } = await import('../../packages/server/src/lib/context-compressor')
+    ekkoRuntimeRunMock.mockResolvedValue({
+      output: { role: 'assistant', content: 'ekko summary', finishReason: 'stop' },
+    })
+
+    const result = await callSummarizer(
+      '',
+      undefined,
+      'Summarize these turns.',
+      [],
+      12_000,
+      undefined,
+      { profile: 'work', model: 'summary-model', provider: 'openrouter' },
+    )
+
+    expect(result).toBe('ekko summary')
+    expect(ekkoRuntimeOptionsMock).toHaveBeenCalledWith(expect.objectContaining({
+      toolsEnabled: false,
+      skillsEnabled: false,
+      maxSteps: 1,
+      maxModelRetries: 0,
+      toolDelayMs: 0,
+      modelDefaults: expect.objectContaining({
+        model: 'summary-model',
+        toolChoice: 'none',
+      }),
+    }))
+    expect(ekkoRuntimeRunMock).toHaveBeenCalledWith(expect.objectContaining({
+      memoryEnabled: false,
+      messages: [
+        { role: 'user', content: 'Summarize these turns.' },
+        { role: 'user', content: 'Generate the context checkpoint summary now.' },
+      ],
+    }))
+    expect(bridgeRequestMock).not.toHaveBeenCalled()
+    expect(bridgeDestroyMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the existing Hermes summarizer after the first Ekko failure', async () => {
+    const { callSummarizer } = await import('../../packages/server/src/lib/context-compressor')
+    ekkoRuntimeRunMock.mockRejectedValueOnce(new Error('provider unavailable'))
+    bridgeRequestMock.mockResolvedValue({
+      status: 'completed',
+      result: { final_response: 'hermes fallback summary' },
+    })
+
+    const result = await callSummarizer(
+      '',
+      undefined,
+      'Summarize these turns.',
+      [],
+      12_000,
+      undefined,
+      {
+        profile: 'default',
+        model: 'summary-model',
+        provider: 'openrouter',
+        workerKey: 'default:compression:session-1',
+      },
+    )
+
+    expect(result).toBe('hermes fallback summary')
+    expect(ekkoRuntimeRunMock).toHaveBeenCalledTimes(1)
+    expect(bridgeRequestMock).toHaveBeenCalledTimes(1)
+    expect(bridgeRequestMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'chat',
+      worker_key: 'default:compression:session-1',
+      model: 'summary-model',
+      provider: 'openrouter',
+    }), expect.any(Object))
   })
 
   it('keeps full history when full summarization fails', async () => {
@@ -498,6 +620,178 @@ describe('ChatContextCompressor', () => {
     expect(result.meta.verbatimCount).toBe(3)
     expect(result.meta.compressedStartIndex).toBe(22)
     expect(saveCompressionSnapshotMock).toHaveBeenCalledWith('s1', 'updated summary', 22, 23)
+  })
+
+  it('stores message cursors on the first successful compression', async () => {
+    const { ChatContextCompressor } = await import('../../packages/server/src/lib/context-compressor')
+    const compressor = new ChatContextCompressor({
+      config: { headMessageCount: 2, tailMessageCount: 2, summaryBudget: 1000 },
+    })
+    const messages = Array.from({ length: 8 }, (_, index) => ({
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      content: `message ${index}`,
+      cursorId: 101 + index,
+    }))
+    getCompressionSnapshotMock.mockReturnValue(null)
+    bridgeRequestMock.mockResolvedValue({
+      status: 'completed',
+      result: { final_response: 'cursor summary' },
+    })
+
+    const result = await compressor.compress(messages, '', undefined, 's1', {
+      profile: 'default',
+      historyRevision: 3,
+    })
+
+    expect(result.meta).toEqual(expect.objectContaining({
+      compressedThroughCursor: 106,
+      protectedHeadThroughCursor: 102,
+    }))
+    expect(saveCompressionSnapshotMock).toHaveBeenCalledWith(
+      's1',
+      'cursor summary',
+      5,
+      8,
+      {
+        compressedThroughMessageId: 106,
+        protectedHeadThroughMessageId: 102,
+        expectedHistoryRevision: 3,
+      },
+    )
+  })
+
+  it('does not advance a cursor when only the protected tail follows it', async () => {
+    const { ChatContextCompressor, SUMMARY_PREFIX } = await import('../../packages/server/src/lib/context-compressor')
+    const compressor = new ChatContextCompressor({ config: { tailMessageCount: 10 } })
+    getCompressionSnapshotMock.mockReturnValue({
+      summary: 'previous summary',
+      lastMessageIndex: 4,
+      messageCountAtTime: 5,
+      compressedThroughMessageId: 105,
+      protectedHeadThroughMessageId: 101,
+      historyRevision: 2,
+    })
+    const messages = [
+      { role: 'user', content: 'head', cursorId: 101 },
+      { role: 'user', content: `${SUMMARY_PREFIX}\n\nprevious summary` },
+      { role: 'assistant', content: 'new answer', cursorId: 106 },
+      { role: 'user', content: 'new question', cursorId: 107 },
+    ]
+
+    const result = await compressor.compress(messages, '', undefined, 's1')
+
+    expect(result.meta).toEqual(expect.objectContaining({
+      compressedThroughCursor: 105,
+      protectedHeadThroughCursor: 101,
+      llmCompressed: false,
+    }))
+    expect(saveCompressionSnapshotMock).not.toHaveBeenCalled()
+    expect(bridgeRequestMock).not.toHaveBeenCalled()
+  })
+
+  it('moves a cursor tail boundary backward instead of orphaning tool results', async () => {
+    const { ChatContextCompressor } = await import('../../packages/server/src/lib/context-compressor')
+    const compressor = new ChatContextCompressor({ config: { tailMessageCount: 3 } })
+    getCompressionSnapshotMock.mockReturnValue({
+      summary: 'previous summary',
+      lastMessageIndex: 3,
+      messageCountAtTime: 4,
+      compressedThroughMessageId: 104,
+      protectedHeadThroughMessageId: null,
+      historyRevision: 0,
+    })
+    const messages = [
+      {
+        role: 'assistant',
+        content: 'calling tool',
+        cursorId: 105,
+        tool_calls: [{ id: 'call-1', type: 'function', function: { name: 'read', arguments: '{}' } }],
+      },
+      { role: 'tool', content: 'tool result', cursorId: 106, tool_call_id: 'call-1' },
+      { role: 'user', content: 'follow up', cursorId: 107 },
+      { role: 'assistant', content: 'answer', cursorId: 108 },
+    ]
+
+    const result = await compressor.compress(messages, '', undefined, 's1')
+
+    expect(result.messages.map(message => message.content)).toEqual([
+      expect.stringContaining('previous summary'),
+      'calling tool',
+      'tool result',
+      'follow up',
+      'answer',
+    ])
+    expect(saveCompressionSnapshotMock).not.toHaveBeenCalled()
+    expect(bridgeRequestMock).not.toHaveBeenCalled()
+  })
+
+  it('upgrades a legacy snapshot to a cursor only during a successful compression cycle', async () => {
+    const { ChatContextCompressor } = await import('../../packages/server/src/lib/context-compressor')
+    const compressor = new ChatContextCompressor({
+      config: { triggerTokens: 100, headMessageCount: 1, tailMessageCount: 1, summaryBudget: 100 },
+    })
+    const messages = Array.from({ length: 7 }, (_, index) => ({
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      content: `large ${index} ${'token '.repeat(80)}`,
+      cursorId: 201 + index,
+    }))
+    getCompressionSnapshotMock.mockReturnValue({
+      summary: 'legacy summary',
+      lastMessageIndex: 1,
+      messageCountAtTime: 2,
+      compressedThroughMessageId: null,
+      protectedHeadThroughMessageId: null,
+      historyRevision: 0,
+    })
+    bridgeRequestMock.mockResolvedValue({
+      status: 'completed',
+      result: { final_response: 'upgraded summary' },
+    })
+
+    await compressor.compress(messages, '', undefined, 's1', {
+      profile: 'default',
+      historyRevision: 4,
+    })
+
+    expect(saveCompressionSnapshotMock).toHaveBeenCalledWith(
+      's1',
+      'upgraded summary',
+      5,
+      7,
+      {
+        compressedThroughMessageId: 206,
+        protectedHeadThroughMessageId: 201,
+        expectedHistoryRevision: 4,
+      },
+    )
+  })
+
+  it('reuses a cursor summary for export without applying the legacy index to bounded input', async () => {
+    const { ExportCompressor } = await import('../../packages/server/src/lib/context-compressor/export-compressor')
+    const compressor = new ExportCompressor()
+    getCompressionSnapshotMock.mockReturnValue({
+      summary: 'existing cursor summary',
+      lastMessageIndex: 999,
+      messageCountAtTime: 1_000,
+      compressedThroughMessageId: 500,
+      protectedHeadThroughMessageId: 1,
+      historyRevision: 0,
+    })
+    bridgeRequestMock.mockResolvedValue({
+      status: 'completed',
+      result: { final_response: 'export summary' },
+    })
+
+    const result = await compressor.compress([
+      { role: 'user', content: 'protected head' },
+      { role: 'assistant', content: 'post cursor answer' },
+    ], '', undefined, 's1')
+
+    expect(result.messages).toEqual([{ role: 'user', content: 'export summary' }])
+    const serializedRequest = JSON.stringify(bridgeRequestMock.mock.calls[0]?.[0])
+    expect(serializedRequest).toContain('protected head')
+    expect(serializedRequest).toContain('post cursor answer')
+    expect(serializedRequest).toContain('existing cursor summary')
   })
 })
 

--- a/tests/server/ekko-agent-provider-runtime.test.ts
+++ b/tests/server/ekko-agent-provider-runtime.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  readConfigYamlForProfile: vi.fn(),
+  safeReadFile: vi.fn(),
+  resolveAuthorized: vi.fn(),
+}))
+
+vi.mock('../../packages/server/src/services/config-helpers', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../packages/server/src/services/config-helpers')>(),
+  readConfigYamlForProfile: mocks.readConfigYamlForProfile,
+  safeReadFile: mocks.safeReadFile,
+}))
+
+vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+  getProfileDir: (profile: string) => `/profiles/${profile}`,
+}))
+
+vi.mock('../../packages/server/src/services/ekko-agent/auth-providers', () => ({
+  resolveEkkoAuthorizedProviderCredentials: mocks.resolveAuthorized,
+}))
+
+describe('resolveEkkoProviderRuntimeConfig', () => {
+  beforeEach(() => {
+    mocks.readConfigYamlForProfile.mockReset()
+    mocks.safeReadFile.mockReset()
+    mocks.resolveAuthorized.mockReset()
+    mocks.readConfigYamlForProfile.mockResolvedValue({})
+    mocks.safeReadFile.mockResolvedValue('')
+    mocks.resolveAuthorized.mockResolvedValue({})
+  })
+
+  it('resolves a built-in provider from the profile env and preset', async () => {
+    mocks.safeReadFile.mockResolvedValue([
+      'OPENAI_API_KEY="profile-openai-key"',
+      'OPENAI_BASE_URL=https://gateway.example/v1',
+    ].join('\n'))
+    const { resolveEkkoProviderRuntimeConfig } = await import(
+      '../../packages/server/src/services/ekko-agent/provider-runtime'
+    )
+
+    await expect(resolveEkkoProviderRuntimeConfig({
+      profile: 'work',
+      provider: 'openai-api',
+    })).resolves.toEqual({
+      provider: 'openai-api',
+      baseUrl: 'https://gateway.example/v1',
+      apiKey: 'profile-openai-key',
+      apiMode: 'codex_responses',
+    })
+    expect(mocks.safeReadFile).toHaveBeenCalledWith('/profiles/work/.env')
+  })
+
+  it('resolves custom provider credentials and protocol from profile config', async () => {
+    mocks.readConfigYamlForProfile.mockResolvedValue({
+      custom_providers: [{
+        name: 'Summary Proxy',
+        base_url: 'https://summary.example/v1',
+        key_env: 'SUMMARY_PROXY_KEY',
+        api_mode: 'anthropic_messages',
+      }],
+    })
+    mocks.safeReadFile.mockResolvedValue("SUMMARY_PROXY_KEY='custom-key'")
+    const { resolveEkkoProviderRuntimeConfig } = await import(
+      '../../packages/server/src/services/ekko-agent/provider-runtime'
+    )
+
+    await expect(resolveEkkoProviderRuntimeConfig({
+      profile: 'default',
+      provider: 'custom:summary-proxy',
+    })).resolves.toEqual({
+      provider: 'custom:summary-proxy',
+      baseUrl: 'https://summary.example/v1',
+      apiKey: 'custom-key',
+      apiMode: 'anthropic_messages',
+    })
+  })
+
+  it('prefers explicit connection values over stored OAuth credentials', async () => {
+    mocks.resolveAuthorized.mockResolvedValue({
+      baseUrl: 'https://stored.example/v1',
+      apiKey: 'stored-key',
+    })
+    const { resolveEkkoProviderRuntimeConfig } = await import(
+      '../../packages/server/src/services/ekko-agent/provider-runtime'
+    )
+
+    await expect(resolveEkkoProviderRuntimeConfig({
+      profile: 'default',
+      provider: 'openai-codex',
+      baseUrl: 'https://explicit.example/v1',
+      apiKey: 'explicit-key',
+      apiMode: 'codex_responses',
+    })).resolves.toEqual({
+      provider: 'openai-codex',
+      baseUrl: 'https://explicit.example/v1',
+      apiKey: 'explicit-key',
+      apiMode: 'codex_responses',
+    })
+  })
+})

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -13,6 +13,14 @@ const updateUsageMock = vi.fn()
 const buildCompressedHistoryMock = vi.fn()
 const buildDbHistoryMock = vi.fn()
 const buildSnapshotAwareHistoryMock = vi.fn(async (_sessionId: string, _profile: string, history: any[]) => history)
+const buildDbSnapshotAwareHistoryMock = vi.fn(async (sessionId: string, profile: string, options: any, modelContext: any) => (
+  buildSnapshotAwareHistoryMock(
+    sessionId,
+    profile,
+    await buildDbHistoryMock(sessionId, options),
+    modelContext,
+  )
+))
 const pushStateMock = vi.fn()
 const replaceStateMock = vi.fn()
 const forceCompressBridgeHistoryMock = vi.fn()
@@ -69,6 +77,7 @@ vi.mock('../../packages/server/src/services/hermes/run-chat/compression', () => 
   buildCompressedHistory: buildCompressedHistoryMock,
   buildDbHistory: buildDbHistoryMock,
   buildSnapshotAwareHistory: buildSnapshotAwareHistoryMock,
+  buildDbSnapshotAwareHistory: buildDbSnapshotAwareHistoryMock,
   pushState: pushStateMock,
   replaceState: replaceStateMock,
   forceCompressBridgeHistory: forceCompressBridgeHistoryMock,

--- a/tests/server/run-chat-bridge-terminal-error.test.ts
+++ b/tests/server/run-chat-bridge-terminal-error.test.ts
@@ -83,6 +83,39 @@ describe('bridge terminal error detection', () => {
     } as any)).toBeNull()
   })
 
+  it('does not flag successful project documentation that mentions login rate limiting', () => {
+    expect(bridgeTerminalError({
+      status: 'complete',
+      result: {
+        completed: true,
+        final_response: [
+          '# Hermes Studio 项目整体理解',
+          '服务启动流程：',
+          '- 创建数据目录',
+          '- 初始化登录限流',
+          '- 启动 Python Agent Bridge',
+        ].join('\n'),
+      },
+    } as any)).toBeNull()
+  })
+
+  it('still detects a compact Chinese rate-limit failure response', () => {
+    const error = 'API 请求被限流，请稍后重试'
+    expect(bridgeTerminalError({
+      status: 'complete',
+      result: { final_response: error },
+    } as any)).toBe(error)
+  })
+
+  it('does not scan long-form final responses for incidental failure terms', () => {
+    expect(bridgeTerminalError({
+      status: 'complete',
+      result: {
+        final_response: `${'项目架构说明。'.repeat(400)}初始化登录限流。`,
+      },
+    } as any)).toBeNull()
+  })
+
   it('does not treat a successful result message as an error', () => {
     expect(bridgeTerminalError({
       status: 'complete',

--- a/tests/server/run-chat-clarify-respond.test.ts
+++ b/tests/server/run-chat-clarify-respond.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../packages/server/src/services/logger', () => ({
 
 vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
   getSession: vi.fn(() => null),
+  getSessionMetadata: vi.fn(() => null),
   getSessionDetail: vi.fn(() => null),
 }))
 

--- a/tests/server/run-chat-compression.test.ts
+++ b/tests/server/run-chat-compression.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const getSessionDetailMock = vi.fn()
 const getSessionMock = vi.fn()
+const getSessionContextMessagesMock = vi.fn()
+const getSessionContextMessageMock = vi.fn()
 const getCompressionSnapshotMock = vi.fn()
 const getModelContextLengthMock = vi.fn()
 const calcAndUpdateUsageMock = vi.fn()
@@ -24,6 +26,8 @@ const compressorConstructorMock = vi.fn()
 vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
   getSessionDetail: getSessionDetailMock,
   getSession: getSessionMock,
+  getSessionContextMessages: getSessionContextMessagesMock,
+  getSessionContextMessage: getSessionContextMessageMock,
 }))
 
 vi.mock('../../packages/server/src/db/hermes/compression-snapshot', () => ({
@@ -77,6 +81,8 @@ describe('run chat compression trigger', () => {
   beforeEach(() => {
     getSessionDetailMock.mockReset()
     getSessionMock.mockReset()
+    getSessionContextMessagesMock.mockReset()
+    getSessionContextMessageMock.mockReset()
     getCompressionSnapshotMock.mockReset()
     getModelContextLengthMock.mockReset()
     calcAndUpdateUsageMock.mockReset()
@@ -86,7 +92,18 @@ describe('run chat compression trigger', () => {
     compressorConstructorMock.mockReset()
     readConfigYamlForProfileMock.mockReset()
 
-    getSessionMock.mockReturnValue({ id: 'session-1', profile: 'default' })
+    getSessionMock.mockReturnValue({ id: 'session-1', profile: 'default', history_revision: 0 })
+    getSessionContextMessagesMock.mockImplementation((_sessionId: string, options: { afterId?: number; throughId?: number } = {}) => {
+      const rows = getSessionDetailMock()?.messages || []
+      return rows.filter((row: any) => (
+        ['user', 'assistant', 'tool'].includes(row.role) &&
+        (options.afterId == null || Number(row.id) > options.afterId) &&
+        (options.throughId == null || Number(row.id) <= options.throughId)
+      ))
+    })
+    getSessionContextMessageMock.mockImplementation((sessionId: string, messageId: number) => (
+      getSessionContextMessagesMock(sessionId).find((row: any) => Number(row.id) === messageId) || null
+    ))
     getModelContextLengthMock.mockReturnValue(256_000)
     calcAndUpdateUsageMock.mockResolvedValue({ inputTokens: 1_000, outputTokens: 0 })
     estimateUsageTokensFromMessagesMock.mockReturnValue({ inputTokens: 0, outputTokens: 0 })
@@ -137,6 +154,58 @@ describe('run chat compression trigger', () => {
     expect(history).toEqual([
       { role: 'assistant', content: 'called a tool', reasoning_content: '' },
     ])
+  })
+
+  it('builds a cursor snapshot run from protected head and post-cursor rows without a full-history read', async () => {
+    const rows = [
+      { id: 1, session_id: 'session-1', role: 'user', content: 'protected head', timestamp: 1 },
+      { id: 6, session_id: 'session-1', role: 'assistant', content: 'new answer', timestamp: 6 },
+      { id: 7, session_id: 'session-1', role: 'user', content: 'follow up', timestamp: 7 },
+      { id: 8, session_id: 'session-1', role: 'user', content: 'current input', timestamp: 8 },
+    ]
+    getSessionDetailMock.mockImplementation(() => {
+      throw new Error('full history must not be read')
+    })
+    getSessionContextMessagesMock.mockImplementation((_sessionId: string, options: { afterId?: number; throughId?: number } = {}) => (
+      rows.filter(row => (
+        (options.afterId == null || row.id > options.afterId) &&
+        (options.throughId == null || row.id <= options.throughId)
+      ))
+    ))
+    getSessionContextMessageMock.mockImplementation((_sessionId: string, messageId: number) => (
+      messageId === 5
+        ? { id: 5, session_id: 'session-1', role: 'assistant', content: 'cursor row', timestamp: 5 }
+        : rows.find(row => row.id === messageId) || null
+    ))
+    getCompressionSnapshotMock.mockReturnValue({
+      summary: 'previous summary',
+      lastMessageIndex: 4,
+      messageCountAtTime: 5,
+      compressedThroughMessageId: 5,
+      protectedHeadThroughMessageId: 1,
+      historyRevision: 0,
+    })
+    calcAndUpdateUsageMock.mockResolvedValue({ inputTokens: 100, outputTokens: 100 })
+    estimateUsageTokensFromMessagesMock.mockReturnValue({ inputTokens: 100, outputTokens: 100 })
+
+    const { buildCompressedHistory } = await import('../../packages/server/src/services/hermes/run-chat/compression')
+    const history = await buildCompressedHistory(
+      'session-1',
+      'default',
+      'http://upstream',
+      undefined,
+      vi.fn(),
+      new Map(),
+    )
+
+    expect(history).toEqual([
+      { role: 'user', content: 'protected head' },
+      { role: 'user', content: '[Previous context summary]\n\nprevious summary' },
+      { role: 'assistant', content: 'new answer' },
+      { role: 'user', content: 'follow up' },
+    ])
+    expect(getSessionDetailMock).not.toHaveBeenCalled()
+    expect(compressorCompressMock).not.toHaveBeenCalled()
   })
 
   it('excludes persisted MoA display rows from bridge history', async () => {

--- a/tests/server/run-chat-load-state.test.ts
+++ b/tests/server/run-chat-load-state.test.ts
@@ -6,6 +6,8 @@ const getCompressionSnapshotMock = vi.fn()
 const estimateUsageTokensFromMessagesMock = vi.fn()
 const buildDbHistoryMock = vi.fn()
 const buildSnapshotAwareHistoryMock = vi.fn()
+const getRecordedUsageTotalsMock = vi.fn()
+const getUsageMock = vi.fn()
 
 vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
   getSession: getSessionMock,
@@ -17,6 +19,8 @@ vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
 
 vi.mock('../../packages/server/src/db/hermes/usage-store', () => ({
   updateUsage: vi.fn(),
+  getRecordedUsageTotals: getRecordedUsageTotalsMock,
+  getUsage: getUsageMock,
 }))
 
 vi.mock('../../packages/server/src/db/hermes/compression-snapshot', () => ({
@@ -80,6 +84,7 @@ describe('loadSessionStateFromDb', () => {
       profile: 'default',
       model: 'gpt-test',
       provider: 'openai',
+      source: 'cli',
     })
     getSessionDetailPaginatedMock.mockReturnValue({
       messages: [
@@ -108,21 +113,26 @@ describe('loadSessionStateFromDb', () => {
       }
       return { inputTokens: 28_000, outputTokens: 0 }
     })
+    getRecordedUsageTotalsMock.mockReturnValue({
+      inputTokens: 28_000,
+      outputTokens: 2_000,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      reasoningTokens: 0,
+      apiCalls: 1,
+    })
+    getUsageMock.mockReturnValue({ input_tokens: 8_000, output_tokens: 1_000 })
   })
 
-  it('hydrates contextTokens from the same snapshot-aware history used for bridge runs', async () => {
+  it('hydrates persisted usage without reconstructing complete history on resume', async () => {
     const { loadSessionStateFromDb } = await import('../../packages/server/src/services/hermes/run-chat/load-state')
 
     const state = await loadSessionStateFromDb('session-1', new Map())
 
-    expect(buildSnapshotAwareHistoryMock).toHaveBeenCalledWith(
-      'session-1',
-      'default',
-      expect.any(Array),
-      { model: 'gpt-test', provider: 'openai' },
-    )
+    expect(buildDbHistoryMock).not.toHaveBeenCalled()
+    expect(buildSnapshotAwareHistoryMock).not.toHaveBeenCalled()
     expect(state.inputTokens).toBe(28_000)
-    expect(state.outputTokens).toBe(0)
+    expect(state.outputTokens).toBe(2_000)
     expect(state.contextTokens).toBe(9_000)
   })
 })

--- a/tests/server/run-chat-queued-item.test.ts
+++ b/tests/server/run-chat-queued-item.test.ts
@@ -57,6 +57,7 @@ vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
 vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
   clearSessionMessages: sessionStoreMocks.clearSessionMessages,
   getSession: vi.fn(() => ({ id: 'session-1', profile: 'default', source: 'cli' })),
+  getSessionMetadata: vi.fn(() => ({ id: 'session-1', profile: 'default', source: 'cli' })),
   getSessionDetail: vi.fn(() => null),
 }))
 

--- a/tests/server/run-chat-usage-cursor.test.ts
+++ b/tests/server/run-chat-usage-cursor.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getSessionDetailMock = vi.fn()
+const getSessionMock = vi.fn()
+const getSessionContextMessagesMock = vi.fn()
+const getSessionContextMessageMock = vi.fn()
+const getCompressionSnapshotMock = vi.fn()
+const deleteCompressionSnapshotMock = vi.fn()
+const getRecordedUsageTotalsMock = vi.fn()
+const getUsageMock = vi.fn()
+
+vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
+  getSessionDetail: getSessionDetailMock,
+  getSession: getSessionMock,
+  getSessionContextMessages: getSessionContextMessagesMock,
+  getSessionContextMessage: getSessionContextMessageMock,
+}))
+
+vi.mock('../../packages/server/src/db/hermes/compression-snapshot', () => ({
+  getCompressionSnapshot: getCompressionSnapshotMock,
+  deleteCompressionSnapshot: deleteCompressionSnapshotMock,
+}))
+
+vi.mock('../../packages/server/src/db/hermes/usage-store', () => ({
+  getRecordedUsageTotals: getRecordedUsageTotalsMock,
+  getUsage: getUsageMock,
+}))
+
+vi.mock('../../packages/server/src/services/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+describe('cursor-aware chat usage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockReturnValue({ id: 'session-1', history_revision: 0 })
+    getSessionDetailMock.mockImplementation(() => {
+      throw new Error('full history must not be read')
+    })
+    getCompressionSnapshotMock.mockReturnValue({
+      summary: 'summary',
+      lastMessageIndex: 9,
+      messageCountAtTime: 10,
+      compressedThroughMessageId: 10,
+      protectedHeadThroughMessageId: 1,
+      historyRevision: 0,
+    })
+    const rows = [
+      { id: 1, session_id: 'session-1', role: 'user', content: 'head', timestamp: 1 },
+      { id: 11, session_id: 'session-1', role: 'assistant', content: 'tail', timestamp: 11 },
+    ]
+    getSessionContextMessagesMock.mockImplementation((_sid: string, options: { afterId?: number; throughId?: number } = {}) => (
+      rows.filter(row => (
+        (options.afterId == null || row.id > options.afterId) &&
+        (options.throughId == null || row.id <= options.throughId)
+      ))
+    ))
+    getSessionContextMessageMock.mockImplementation((_sid: string, id: number) => (
+      id === 10
+        ? { id: 10, session_id: 'session-1', role: 'assistant', content: 'boundary', timestamp: 10 }
+        : rows.find(row => row.id === id) || null
+    ))
+  })
+
+  it('counts summary plus bounded cursor context without loading full history', async () => {
+    const { calcAndUpdateUsage } = await import('../../packages/server/src/services/hermes/run-chat/usage')
+    const state: any = { messages: [], events: [], queue: [], isWorking: false }
+    const emit = vi.fn()
+
+    const usage = await calcAndUpdateUsage('session-1', state, emit, {
+      truncateToolResultsForContext: true,
+    })
+
+    expect(usage.inputTokens + usage.outputTokens).toBeGreaterThan(0)
+    expect(getSessionDetailMock).not.toHaveBeenCalled()
+    expect(deleteCompressionSnapshotMock).not.toHaveBeenCalled()
+    expect(emit).toHaveBeenCalledWith('usage.updated', expect.objectContaining({
+      session_id: 'session-1',
+    }))
+  })
+
+  it('uses native Coding Agent usage without consulting messages or compression snapshots', async () => {
+    getRecordedUsageTotalsMock.mockReturnValue({ inputTokens: 100, outputTokens: 40 })
+    getUsageMock.mockReturnValue({ input_tokens: 70, output_tokens: 10 })
+    const { calcAndUpdateUsage } = await import('../../packages/server/src/services/hermes/run-chat/usage')
+    const state: any = { messages: [], events: [], queue: [], isWorking: false }
+
+    const usage = await calcAndUpdateUsage('session-1', state, vi.fn(), {
+      nativeSource: 'coding_agent',
+    })
+
+    expect(usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 40,
+      contextInputTokens: 70,
+      contextOutputTokens: 10,
+    })
+    expect(getCompressionSnapshotMock).not.toHaveBeenCalled()
+    expect(getSessionDetailMock).not.toHaveBeenCalled()
+    expect(getSessionContextMessagesMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -38,6 +38,7 @@ const getRecordedUsageSessionIdsMock = vi.fn()
 const getActiveProfileNameMock = vi.fn()
 const loggerWarnMock = vi.fn()
 const getCompressionSnapshotMock = vi.fn()
+const buildDbExportHistoryMock = vi.fn()
 const listUserProfilesMock = vi.fn()
 const readConfigYamlForProfileMock = vi.fn()
 const bridgeSwitchSessionModelMock = vi.fn()
@@ -157,6 +158,7 @@ vi.mock('../../packages/server/src/db/hermes/compression-snapshot', () => ({
 }))
 
 vi.mock('../../packages/server/src/lib/context-compressor/export-compressor', () => ({
+  buildDbExportHistory: buildDbExportHistoryMock,
   ExportCompressor: class {
     async compress(messages: any[]) {
       return {
@@ -225,6 +227,7 @@ describe('session conversations controller', () => {
     getActiveProfileNameMock.mockReturnValue('default')
     loggerWarnMock.mockReset()
     getCompressionSnapshotMock.mockReset()
+    buildDbExportHistoryMock.mockReset()
     listUserProfilesMock.mockReset()
     listUserProfilesMock.mockReturnValue([])
     readConfigYamlForProfileMock.mockReset()
@@ -2003,6 +2006,37 @@ describe('session conversations controller', () => {
       expect(ctx.body).toContain('hello')
       expect(ctx.body).toContain('[assistant]')
       expect(ctx.body).toContain('hi')
+    })
+
+    it('uses snapshot-aware DB history for compressed export without loading full session detail', async () => {
+      getSessionMock.mockReturnValue({
+        id: 'compressed-123',
+        title: 'Compressed Export',
+        profile: 'default',
+        model: 'gpt-test',
+        provider: 'openai',
+      })
+      buildDbExportHistoryMock.mockReturnValue([
+        { role: 'user', content: 'protected head' },
+        { role: 'assistant', content: 'post cursor' },
+      ])
+
+      const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+      const ctx: any = {
+        params: { id: 'compressed-123' },
+        query: { mode: 'compressed', ext: 'json' },
+        set: vi.fn(),
+        body: null,
+      }
+
+      await mod.exportSession(ctx)
+
+      expect(localGetSessionDetailMock).not.toHaveBeenCalled()
+      expect(buildDbExportHistoryMock).toHaveBeenCalledWith('compressed-123')
+      expect(JSON.parse(ctx.body).messages).toEqual([
+        { role: 'user', content: 'protected head' },
+        { role: 'assistant', content: 'post cursor' },
+      ])
     })
 
     it('returns 404 when session not found', async () => {


### PR DESCRIPTION
## Summary

- add stable message cursors and history revisions to compression snapshots while retaining legacy index fields
- build compressed run, usage, resume, and export context from the protected head plus post-cursor messages
- run compression through a fresh tool-free, skill-free, memory-free Ekko Agent and immediately fall back to Hermes when it fails
- preserve snapshot correctness across clear, delete, concurrent compression, and session branching
- avoid false `run.failed` events when successful long-form answers mention terms such as “登录限流”
- hide zero-count category groups in the session sidebar without deleting user-defined categories

## Why

The previous compression path could rebuild full message history on later runs and tied snapshots to unstable array indexes. Large sessions therefore retained avoidable memory and query cost. Compression also reused the Hermes runtime directly, and two follow-up test cases exposed transient UI issues: broad error-text detection could misclassify successful answers, and empty session categories remained visible after their last session was removed.

## Impact

Compressed Hermes sessions now read bounded history after the first successful compression, legacy snapshots migrate on a successful compression cycle, Coding Agent resume/usage avoids Web UI history reconstruction, and compressed exports reuse the cursor path. Existing session messages and legacy snapshot fields remain compatible. Session lists no longer show empty groups, and successful long responses are not rendered as transient agent errors.

## Validation

- `npm run harness:check`
- `npm run test:coverage`
- `npm run test:e2e` (67 passed)
- `npm run build`
- targeted compression, bridge terminal-error, export, usage, resume, category grouping, and session controller tests
- `git diff --check`
