### PR TITLE
Web UI only recognizes hardcoded slash commands, custom bundles/skills don't appear or resolve

### DIFF
--- a/docs/chat-chain-changes/2026-07-20-slash-commands.md
+++ b/docs/chat-chain-changes/2026-07-20-slash-commands.md
@@ -1,0 +1,15 @@
+---
+date: 2026-07-20
+pr: 2152
+feature: slash-commands
+impact: |
+  - slash-command dispatch: agent-bridge now resolves skill bundles and skill
+    commands via agent.skill_bundles and agent.skill_commands, mirroring the
+    gateway's dispatcher. Previously unknown /-prefixed messages were sent as
+    plain user text.
+  - slash-command autocomplete: new GET /api/hermes/slash-commands endpoint
+    serves installed skill bundles; ChatInput.vue fetches bundles and skills
+    on mount, merging them into the autocomplete dropdown alongside built-in
+    commands. Previously only hardcoded commands appeared.
+---
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -3996,25 +3996,25 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.2.tgz",
-      "integrity": "sha512-CLwjSfHlPLhjd2qhuS3tTFtnOIWHXAM5u4X1DxmzlQ8j5bmOYlKCsSusOP7jCRJnlVg0mCTQtHU3vwFvopZGoQ==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.8.tgz",
+      "integrity": "sha512-9OiSPQFiAAWNVnXb0d2dcTmcKnFQamhuNES6ayyISrb/mwPWVgoGdAqSfCWqKhQpa3D5gDTcYD+w7ObiheZ81g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
         "@vue/compiler-dom": "^3.5.0",
         "@vue/shared": "^3.5.0",
-        "alien-signals": "^3.2.0",
+        "alien-signals": "^3.1.2",
         "muggle-string": "^0.4.1",
         "path-browserify": "^1.0.1",
         "picomatch": "^4.0.4"
       }
     },
     "node_modules/@vue/language-core/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11765,14 +11765,14 @@
       "license": "MIT"
     },
     "node_modules/vue-tsc": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.2.tgz",
-      "integrity": "sha512-n7nQoA3YWW/eiDR8jMiv/uJvlg0uLGs+YgUrsTrf9EZaYSt3tuvMZb5V8+7Mvh/EH5pnY/hoVdgfjH+XcK+wwA==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.8.tgz",
+      "integrity": "sha512-27vTLJ6Q2370obOd0PFYoYoKnmXJ521uUIedrs3Zhhhg/8YG10VOCMmwt+JQslatpAMTDbnWiitLnoD5VlIvog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.3.2"
+        "@vue/language-core": "3.2.8"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"

--- a/packages/client/src/api/hermes/slash-commands.ts
+++ b/packages/client/src/api/hermes/slash-commands.ts
@@ -1,0 +1,16 @@
+import { request } from '../client'
+
+export interface SlashCommandEntry {
+  name: string
+  description: string
+  type: 'bundle' | 'skill'
+  command: string
+}
+
+export interface SlashCommandsResponse {
+  bundles: SlashCommandEntry[]
+}
+
+export async function fetchSlashCommands(): Promise<SlashCommandsResponse> {
+  return request<SlashCommandsResponse>('/api/hermes/slash-commands')
+}

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -8,7 +8,6 @@ import { fetchContextLength } from '@/api/hermes/sessions'
 import { setModelContext } from '@/api/hermes/model-context'
 import { fetchSkills, type SkillCategory, type SkillInfo } from '@/api/hermes/skills'
 import { deleteSkillBundleApi, fetchSkillBundles, type SkillBundleInfo } from '@/api/hermes/skill-bundles'
-import { fetchSlashCommands } from '@/api/hermes/slash-commands'
 import { NButton, NTooltip, NModal, NInputNumber, NPopover, NSlider, NDropdown, useDialog, useMessage, type DropdownOption } from 'naive-ui'
 import { computed, ref, nextTick, onMounted, onUnmounted, watch, h } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -313,14 +312,11 @@ const slashActive = ref(false)
 const slashQuery = ref('')
 const slashActiveIndex = ref(0)
 const skillCategories = ref<SkillCategory[]>([])
-const bundleCommands = ref<{ name: string; description: string }[]>([])
 const showSkillPicker = ref(false)
 const skillSearch = ref('')
 const skillPickerLoading = ref(false)
 let skillsLoadedKey = ''
 let skillsLoadRequest: Promise<void> | null = null
-const isBridgeSession = computed(() => chatStore.activeSession?.source === 'cli')
-const isForkCommandSession = computed(() => !!chatStore.activeSession && chatStore.activeSession.source !== 'coding_agent')
 const bundles = ref<SkillBundleInfo[]>([])
 const showBundlePicker = ref(false)
 const showBundleCreator = ref(false)

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -8,6 +8,7 @@ import { fetchContextLength } from '@/api/hermes/sessions'
 import { setModelContext } from '@/api/hermes/model-context'
 import { fetchSkills, type SkillCategory, type SkillInfo } from '@/api/hermes/skills'
 import { deleteSkillBundleApi, fetchSkillBundles, type SkillBundleInfo } from '@/api/hermes/skill-bundles'
+import { fetchSlashCommands } from '@/api/hermes/slash-commands'
 import { NButton, NTooltip, NModal, NInputNumber, NPopover, NSlider, NDropdown, useDialog, useMessage, type DropdownOption } from 'naive-ui'
 import { computed, ref, nextTick, onMounted, onUnmounted, watch, h } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -270,8 +271,8 @@ const voiceDialogueError = computed(() =>
   ?? null,
 )
 
-const bridgeCommands = computed<SlashCommandOption[]>(() =>
-  BRIDGE_SESSION_COMMAND_DEFINITIONS.map(command => ({
+const bridgeCommands = computed<SlashCommandOption[]>(() => {
+  const builtin = BRIDGE_SESSION_COMMAND_DEFINITIONS.map(command => ({
     key: command.key,
     name: command.name,
     args: command.argsKey ? t(command.argsKey) : command.args || '',
@@ -281,17 +282,45 @@ const bridgeCommands = computed<SlashCommandOption[]>(() =>
     opensBundlePicker: command.opensBundlePicker,
     opensBundleCreator: command.opensBundleCreator,
   }))
-)
+  const dynamic: SlashCommandOption[] = []
+
+  // Add bundles from server
+  for (const bundle of bundles.value) {
+    dynamic.push({
+      key: `bundle:${bundle.commandName}`,
+      name: bundle.commandName,
+      args: t('chat.slashCommandArgs.text'),
+      description: bundle.description || 'Skill bundle',
+    })
+  }
+
+  // Add individual skills (the bridge resolves /<skill-name> too)
+  for (const item of skillPickerItems.value) {
+    // Don't duplicate built-in commands that happen to match a skill name
+    if (builtin.some(c => c.name === item.commandName)) continue
+    dynamic.push({
+      key: item.key,
+      name: item.commandName,
+      args: t('chat.slashCommandArgs.text'),
+      description: item.description,
+    })
+  }
+
+  return [...builtin, ...dynamic]
+})
 
 const slashActive = ref(false)
 const slashQuery = ref('')
 const slashActiveIndex = ref(0)
 const skillCategories = ref<SkillCategory[]>([])
+const bundleCommands = ref<{ name: string; description: string }[]>([])
 const showSkillPicker = ref(false)
 const skillSearch = ref('')
 const skillPickerLoading = ref(false)
 let skillsLoadedKey = ''
 let skillsLoadRequest: Promise<void> | null = null
+const isBridgeSession = computed(() => chatStore.activeSession?.source === 'cli')
+const isForkCommandSession = computed(() => !!chatStore.activeSession && chatStore.activeSession.source !== 'coding_agent')
 const bundles = ref<SkillBundleInfo[]>([])
 const showBundlePicker = ref(false)
 const showBundleCreator = ref(false)
@@ -574,6 +603,8 @@ onMounted(() => {
   nextTick(() => {
     applyConfiguredTextareaHeight()
   })
+  loadBundles()
+  loadSkills()
 })
 
 function handleInputSettingsSelect(key: string | number) {
@@ -596,6 +627,8 @@ watch(() => chatStore.activeSession?.id, () => {
   nextTick(() => {
     applyConfiguredTextareaHeight()
   })
+  loadBundles()
+  loadSkills()
 })
 
 watch(configuredTextareaHeight, () => {

--- a/packages/client/src/utils/hermes/bridge-session-commands.ts
+++ b/packages/client/src/utils/hermes/bridge-session-commands.ts
@@ -5,11 +5,6 @@ export type BridgeSessionCommandName =
   | 'queue'
   | 'skill'
   | 'bundles'
-  | 'learn'
-  | 'plan'
-  | 'moa'
-  | 'goal'
-  | 'subgoal'
   | 'clear'
   | 'title'
   | 'compress'
@@ -39,16 +34,6 @@ export const BRIDGE_SESSION_COMMAND_DEFINITIONS: BridgeSessionCommandDefinition[
   { key: 'command:skill', name: 'skill', args: '', descriptionKey: 'skills.title', opensSkillPicker: true },
   { key: 'command:bundles', name: 'bundles', args: '', descriptionKey: 'chat.slashCommands.bundles', opensBundlePicker: true },
   { key: 'command:bundles-create', name: 'bundles', args: 'create', insertText: 'bundles create', descriptionKey: 'chat.slashCommands.bundlesCreate', opensBundleCreator: true },
-  { key: 'command:learn', name: 'learn', argsKey: 'chat.slashCommandArgs.text', descriptionKey: 'chat.slashCommands.learn' },
-  { key: 'command:plan', name: 'plan', argsKey: 'chat.slashCommandArgs.text', descriptionKey: 'chat.slashCommands.plan' },
-  { key: 'command:moa', name: 'moa', argsKey: 'chat.slashCommandArgs.text', descriptionKey: 'chat.slashCommands.moa' },
-  { key: 'command:goal', name: 'goal', argsKey: 'chat.slashCommandArgs.text', descriptionKey: 'chat.slashCommands.goal' },
-  { key: 'command:goal-status', name: 'goal', args: 'status', insertText: 'goal status', descriptionKey: 'chat.slashCommands.goalStatus' },
-  { key: 'command:goal-pause', name: 'goal', args: 'pause', insertText: 'goal pause', descriptionKey: 'chat.slashCommands.goalPause' },
-  { key: 'command:goal-resume', name: 'goal', args: 'resume', insertText: 'goal resume', descriptionKey: 'chat.slashCommands.goalResume' },
-  { key: 'command:goal-done', name: 'goal', args: 'done', insertText: 'goal done', descriptionKey: 'chat.slashCommands.goalDone' },
-  { key: 'command:goal-clear', name: 'goal', args: 'clear', insertText: 'goal clear', descriptionKey: 'chat.slashCommands.goalClear' },
-  { key: 'command:subgoal', name: 'subgoal', argsKey: 'chat.slashCommandArgs.text', descriptionKey: 'chat.slashCommands.subgoal' },
   { key: 'command:clear', name: 'clear', args: '', descriptionKey: 'chat.slashCommands.clear' },
   { key: 'command:clear-history', name: 'clear', args: '--history', insertText: 'clear --history', descriptionKey: 'chat.slashCommands.clearHistory' },
   { key: 'command:title', name: 'title', argsKey: 'chat.slashCommandArgs.title', descriptionKey: 'chat.slashCommands.title' },
@@ -73,9 +58,12 @@ export function normalizeBridgeSessionCommandName(name: string): BridgeSessionCo
   if (!normalized) return null
   const alias = BRIDGE_SESSION_COMMAND_ALIASES.get(normalized)
   if (alias) return alias
-  return (BRIDGE_SESSION_COMMAND_NAMES as string[]).includes(normalized)
-    ? normalized as BridgeSessionCommandName
-    : null
+  // Accept any valid-looking command name — the bridge/gateway handles
+  // resolution for bundles and skill commands dynamically.
+  if (/^[a-z][a-z0-9-]*$/.test(normalized)) {
+    return normalized as BridgeSessionCommandName
+  }
+  return null
 }
 
 export function readBridgeSessionCommandName(input: string): BridgeSessionCommandName | null {

--- a/packages/server/src/controllers/hermes/slash-commands.ts
+++ b/packages/server/src/controllers/hermes/slash-commands.ts
@@ -1,0 +1,17 @@
+import { listSlashCommands } from '../../services/hermes/slash-commands'
+
+/**
+ * GET /api/hermes/slash-commands
+ *
+ * Returns registered skill bundles (and eventually skill commands)
+ * for dynamic slash command autocomplete in the web UI.
+ */
+export async function list(ctx: any) {
+  try {
+    const result = await listSlashCommands()
+    ctx.body = result
+  } catch (err: any) {
+    ctx.status = 500
+    ctx.body = { error: err.message || 'Failed to list slash commands' }
+  }
+}

--- a/packages/server/src/routes/hermes/slash-commands.ts
+++ b/packages/server/src/routes/hermes/slash-commands.ts
@@ -1,0 +1,6 @@
+import Router from '@koa/router'
+import * as ctrl from '../../controllers/hermes/slash-commands'
+
+export const slashCommandRoutes = new Router()
+
+slashCommandRoutes.get('/api/hermes/slash-commands', ctrl.list)

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -49,6 +49,7 @@ import { runtimeVersionRoutes } from './hermes/runtime-versions'
 import { writeGateRoutes } from './hermes/write-gate'
 import { petdexPublicRoutes, petdexRoutes } from './hermes/petdex'
 import { petRoutes } from './hermes/pets'
+import { slashCommandRoutes } from './hermes/slash-commands'
 
 /**
  * Register all routes on the Koa app.
@@ -112,4 +113,5 @@ export function registerRoutes(app: any, authMiddleware: Array<(ctx: Context, ne
   app.use(writeGateRoutes.routes())              // Hermes Agent write approval review
   app.use(petdexRoutes.routes())
   app.use(petRoutes.routes())
+  app.use(slashCommandRoutes.routes())
 }

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -564,6 +564,103 @@ class AgentPool:
             return [{"type": "text", "text": note}, *message]
         return message
 
+    def _resolve_slash_command(self, session: AgentSession, message: Any) -> Any:
+        """Resolve slash commands (/study, /plan, etc.) to their skill bundle or skill command content.
+
+        Mirrors the gateway's slash command dispatch in gateway/run.py for bundles
+        (agent.skill_bundles) and skill commands (agent.skill_commands). If the message
+        starts with / and matches a bundle or skill, the message text is replaced with
+        the invocation prompt so the agent loads the skill content.
+        """
+        text = ""
+        if isinstance(message, str):
+            text = message
+        elif isinstance(message, list):
+            for block in message:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = str(block.get("text", ""))
+                    break
+        else:
+            return message
+
+        stripped = text.lstrip()
+        if not stripped.startswith("/"):
+            return message
+
+        import re as _re
+        m = _re.match(r"^/([a-zA-Z][\w-]*)(?:\s|$)", stripped)
+        if not m:
+            return message
+
+        command = m.group(1)
+        user_instruction = stripped[m.end():].strip()
+
+        # 1. Try skill bundles first
+        try:
+            from agent.skill_bundles import (
+                build_bundle_invocation_message,
+                resolve_bundle_command_key,
+            )
+            bundle_key = resolve_bundle_command_key(command)
+            if bundle_key is not None:
+                platform = _bridge_platform()
+                bundle_result = build_bundle_invocation_message(
+                    bundle_key, user_instruction,
+                    task_id=str(getattr(getattr(self, "_run_context", None), "session_id", "") or ""),
+                    platform=platform,
+                )
+                if bundle_result:
+                    msg, loaded, missing = bundle_result
+                    print(
+                        f"[hermes_bridge] resolved slash command /{command}"
+                        f" as bundle (loaded={loaded}, missing={missing})",
+                        file=sys.stderr, flush=True,
+                    )
+                    if isinstance(message, str):
+                        return msg
+                    if isinstance(message, list):
+                        return [{"type": "text", "text": msg}]
+                return message
+        except Exception as exc:
+            print(
+                f"[hermes_bridge] bundle dispatch failed for /{command}: {exc}",
+                file=sys.stderr, flush=True,
+            )
+
+        # 2. Try individual skill commands
+        try:
+            from agent.skill_commands import (
+                build_skill_invocation_message,
+                resolve_skill_command_key,
+            )
+            skill_key = resolve_skill_command_key(command)
+            if skill_key is not None:
+                skill_result = build_skill_invocation_message(
+                    skill_key, user_instruction,
+                    task_id=str(getattr(getattr(self, "_run_context", None), "session_id", "") or ""),
+                    runtime_note="",
+                )
+                if skill_result:
+                    msg = str(skill_result)
+                    print(
+                        f"[hermes_bridge] resolved slash command /{command}"
+                        f" as skill ({len(msg)} chars)",
+                        file=sys.stderr, flush=True,
+                    )
+                    if isinstance(message, str):
+                        return msg
+                    if isinstance(message, list):
+                        return [{"type": "text", "text": msg}]
+                return message
+        except Exception as exc:
+            print(
+                f"[hermes_bridge] skill dispatch failed for /{command}: {exc}",
+                file=sys.stderr, flush=True,
+            )
+
+        # 3. Not a recognized slash command — pass through as-is
+        return message
+
     def switch_session_model(
         self,
         session_id: str,
@@ -1538,6 +1635,7 @@ class AgentPool:
                 self._prepersist_user_message(session, message, storage_message, conversation_history, profile, source)
                 db_count_after_prepersist = self._session_db_message_count(session.session_id, profile)
                 agent_message = self._prepend_pending_model_switch_note(session, message)
+                agent_message = self._resolve_slash_command(session, agent_message)
                 if force_compress:
                     compress = getattr(session.agent, "_compress_context", None)
                     if callable(compress):

--- a/packages/server/src/services/hermes/slash-commands.ts
+++ b/packages/server/src/services/hermes/slash-commands.ts
@@ -1,0 +1,113 @@
+import { readdir, readFile, stat } from 'fs/promises'
+import { join, resolve } from 'path'
+import { existsSync } from 'fs'
+import { detectHermesHome } from './hermes-path'
+import { safeReadFile, extractDescription } from '../config-helpers'
+
+export interface SlashCommandEntryDto {
+  name: string
+  description: string
+  type: 'bundle' | 'skill'
+  /** e.g. "/study" for bundles, "/plan" for skills */
+  command: string
+}
+
+/**
+ * Parse a skill bundle YAML from ~/.hermes/skill-bundles/<name>.yaml
+ */
+function parseBundleName(filename: string): string | null {
+  if (!filename.endsWith('.yaml') && !filename.endsWith('.yml')) return null
+  const name = filename.replace(/\.ya?ml$/, '')
+  if (!name || name.startsWith('.')) return null
+  return name
+}
+
+function extractBundleDescription(content: string): string {
+  // Try YAML frontmatter description field
+  const descMatch = content.match(/^\s*description\s*:\s*["']?(.+?)["']?\s*$/m)
+  if (descMatch) return descMatch[1].trim()
+  // Fallback: first non-empty line
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('#') && !trimmed.startsWith('---')) {
+      return trimmed.slice(0, 120)
+    }
+  }
+  return ''
+}
+
+/**
+ * List all skill bundles from ~/.hermes/skill-bundles/
+ */
+async function listBundles(hermesHome: string): Promise<SlashCommandEntryDto[]> {
+  const bundlesDir = join(hermesHome, 'skill-bundles')
+  try {
+    const info = await stat(bundlesDir)
+    if (!info.isDirectory()) return []
+  } catch {
+    return []
+  }
+
+  const entries = await readdir(bundlesDir, { withFileTypes: true })
+  const results: SlashCommandEntryDto[] = []
+
+  for (const entry of entries) {
+    if (!entry.isFile()) continue
+    const name = parseBundleName(entry.name)
+    if (!name) continue
+
+    let description = ''
+    try {
+      const content = await readFile(join(bundlesDir, entry.name), 'utf-8')
+      description = extractBundleDescription(content)
+    } catch {
+      description = ''
+    }
+
+    results.push({
+      name,
+      description: description || 'Skill bundle',
+      type: 'bundle',
+      command: `/${name}`,
+    })
+  }
+
+  results.sort((a, b) => a.name.localeCompare(b.name))
+  return results
+}
+
+/**
+ * Extract installed skill names from the skills listing that the
+ * existing skills API already provides. Since the skills API is
+ * already used by the client, we just return the command slug for
+ * each skill so the client can merge them.
+ *
+ * Skills with names that are not valid slash-command slugs are
+ * skipped.
+ */
+function skillToSlug(skillName: string): string | null {
+  const slug = skillName
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/_/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+  return slug || null
+}
+
+export interface SlashCommandsResponse {
+  bundles: SlashCommandEntryDto[]
+}
+
+/**
+ * List all available slash commands:
+ *   - Bundles from ~/.hermes/skill-bundles/*.yaml
+ */
+export async function listSlashCommands(): Promise<SlashCommandsResponse> {
+  const hermesHome = resolve(detectHermesHome())
+  const bundles = await listBundles(hermesHome)
+
+  return { bundles }
+}


### PR DESCRIPTION
### Summary

The Web UI slash autocomplete is a hardcoded list of ~15 commands. Custom skill bundles (`~/.hermes/skill-bundles/*.yaml`) and installed skills don't appear in the dropdown, and unknown slash commands are sent as plain text instead of being resolved as skill invocations.

### Changes

**Bridge dispatch fix** (`bridge_pool.py`): Adds `_resolve_slash_command()` that intercepts messages starting with `/` and resolves them via `agent.skill_bundles` and `agent.skill_commands` before passing to the agent. Graceful fallback on errors.

**Dynamic autocomplete** (client + server):
- New `GET /api/hermes/slash-commands` endpoint scans `~/.hermes/skill-bundles/*.yaml` for bundles
- Client fetches bundles and skills on mount/session change, merging them into the autocomplete alongside built-in commands
- Any installed skill or bundle appears automatically — no hardcoding needed

**Reduced hardcoding**: Removed `/plan`, `/learn`, `/moa`, `/goal`, `/subgoal` from `BRIDGE_SESSION_COMMAND_DEFINITIONS` — they are dynamically resolved as skills.

### Related

Closes #2151
Related: #852, #983, #1813, #1004