### PR TITLE
fix(workflow): allow scoped Coding Agent protocol overrides

### DIFF
--- a/packages/client/src/components/hermes/workflow/WorkflowAgentNode.vue
+++ b/packages/client/src/components/hermes/workflow/WorkflowAgentNode.vue
@@ -10,6 +10,7 @@ import type { WorkflowAgentNodeData, WorkflowAgentNodeEditableData } from './typ
 import type { CodingAgentApiMode } from '@/api/coding-agents'
 import type { ProviderApiMode } from '@/api/hermes/system'
 import { getFileDownloadUrl } from '@/api/hermes/files'
+import { isAuthModelProvider } from '@/utils/codingAgentProviders'
 
 import '@vue-flow/node-resizer/dist/style.css'
 
@@ -29,6 +30,11 @@ const statusTip = computed(() => (
     : ''
 ))
 const isCodingAgent = computed(() => props.data.agent !== 'hermes')
+const selectableModelGroups = computed(() => (
+  isCodingAgent.value
+    ? props.data.modelGroups.filter(group => !isAuthModelProvider(group.provider))
+    : props.data.modelGroups
+))
 const apiModeOptions = computed(() => [
   { label: t('codingAgents.protocolOpenAiChat'), value: 'chat_completions' },
   { label: t('codingAgents.protocolOpenAiResponses'), value: 'codex_responses' },
@@ -175,7 +181,7 @@ async function uploadImages(files: File[]) {
       <WorkflowModelSelector
         :provider="data.provider"
         :model="data.model"
-        :groups="data.modelGroups"
+        :groups="selectableModelGroups"
         :disabled="data.readonly"
         @select="handleModelSelect"
       />

--- a/packages/client/src/views/hermes/WorkflowView.vue
+++ b/packages/client/src/views/hermes/WorkflowView.vue
@@ -36,6 +36,7 @@ import {
   workflowLoopBodyNodeIds,
 } from '@/utils/workflow-edge-authoring'
 import WorkflowAgentNode from '@/components/hermes/workflow/WorkflowAgentNode.vue'
+import { isAuthModelProvider } from '@/utils/codingAgentProviders'
 import WorkflowFieldHelp from '@/components/hermes/workflow/WorkflowFieldHelp.vue'
 import WorkflowConditionEdge from '@/components/hermes/workflow/WorkflowConditionEdge.vue'
 import FolderPicker from '@/components/hermes/chat/FolderPicker.vue'
@@ -920,14 +921,18 @@ function defaultApiMode(provider: string) {
 }
 
 function normalizeNodeModel(data: WorkflowAgentNodeData): Pick<WorkflowAgentNodeData, 'provider' | 'model' | 'apiMode'> {
-  const currentGroup = modelGroups.value.find(group => group.provider === data.provider)
+  const availableGroups = data.agent === 'hermes'
+    ? modelGroups.value
+    : modelGroups.value.filter(group => !isAuthModelProvider(group.provider))
+  const currentGroup = availableGroups.find(group => group.provider === data.provider)
   if (currentGroup?.models.includes(data.model)) {
     return { provider: data.provider, model: data.model, apiMode: data.apiMode || defaultApiMode(data.provider) }
   }
+  const fallbackGroup = availableGroups.find(group => group.models.length > 0)
   return {
-    provider: defaultModelSelection.value.provider,
-    model: defaultModelSelection.value.model,
-    apiMode: defaultApiMode(defaultModelSelection.value.provider),
+    provider: fallbackGroup?.provider || '',
+    model: fallbackGroup?.models[0] || '',
+    apiMode: defaultApiMode(fallbackGroup?.provider || ''),
   }
 }
 
@@ -2230,19 +2235,22 @@ function initialRunNodeStatuses(sourceNodes: WorkflowNode[], sourceEdges: Workfl
 
 function updateNodeData(id: string, patch: Partial<WorkflowAgentNodeEditableData>) {
   if (selectedWorkflowRunId.value) return
-  nodes.value = nodes.value.map<WorkflowNode>(node => (
-    node.id === id
-      ? {
-          ...node,
-          style: patch.images ? expandNodeHeightForImages(node.style, patch.images.length) : node.style,
-          data: withRuntimeNodeData({
-            ...node.data,
-            ...patch,
-            skills: typeof patch.agent === 'string' && patch.agent !== node.data.agent ? [] : patch.skills ?? node.data.skills,
-          }),
-        }
-      : node
-  ))
+  nodes.value = nodes.value.map<WorkflowNode>((node) => {
+    if (node.id !== id) return node
+    const data = {
+      ...node.data,
+      ...patch,
+      skills: typeof patch.agent === 'string' && patch.agent !== node.data.agent ? [] : patch.skills ?? node.data.skills,
+    }
+    return {
+      ...node,
+      style: patch.images ? expandNodeHeightForImages(node.style, patch.images.length) : node.style,
+      data: withRuntimeNodeData({
+        ...data,
+        ...(typeof patch.agent === 'string' && patch.agent !== node.data.agent ? normalizeNodeModel(data) : {}),
+      }),
+    }
+  })
   if (typeof patch.agent === 'string') void ensureSkillOptionsForAgent(patch.agent)
 }
 

--- a/packages/server/src/services/coding-agent-provider-policy.ts
+++ b/packages/server/src/services/coding-agent-provider-policy.ts
@@ -1,0 +1,19 @@
+const SCOPED_CODING_AGENT_AUTH_PROVIDERS = new Set([
+  'openai-codex',
+  'copilot',
+  'xai-oauth',
+  'qwen-oauth',
+  'nous',
+  'claude-oauth',
+])
+
+export function isScopedCodingAgentAuthProvider(provider: unknown): boolean {
+  return SCOPED_CODING_AGENT_AUTH_PROVIDERS.has(String(provider || '').trim().toLowerCase())
+}
+
+export function assertScopedCodingAgentProviderAllowed(mode: 'scoped' | 'global', provider: unknown): void {
+  if (mode === 'global' || !isScopedCodingAgentAuthProvider(provider)) return
+  const err = new Error('Coding agent scoped mode does not support OAuth/subscription providers. Use global mode or select an API-key provider.')
+  ;(err as any).status = 400
+  throw err
+}

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -19,6 +19,7 @@ import { codingAgentRunManager } from './agent-runner/coding-agent-run-manager'
 import { getSession, updateSession, type HermesSessionRow } from '../db/hermes/session-store'
 import type { SessionState } from './hermes/run-chat/types'
 import { normalizeWindowsCommandPath, windowsCmdShimExecution, windowsCommandNeedsShell, type WindowsCommandExecution } from './windows-command'
+import { assertScopedCodingAgentProviderAllowed } from './coding-agent-provider-policy'
 
 const execFileAsync = promisify(execFile)
 const LAUNCH_API_MODES = new Set<ApiMode>(['chat_completions', 'codex_responses', 'anthropic_messages'])
@@ -28,7 +29,6 @@ const CODEX_CATALOG_BASE_INSTRUCTIONS = 'You are Codex, a coding agent. Be preci
 const NODE_ENVIRONMENT_MISSING_CODE = 'node_environment_missing'
 const POSIX_LAUNCHER_FILE = 'launch.sh'
 const WINDOWS_LAUNCHER_FILE = 'launch.ps1'
-const CODING_AGENT_SCOPED_AUTH_PROVIDERS = new Set(['openai-codex', 'copilot', 'xai-oauth', 'qwen-oauth', 'nous', 'claude-oauth'])
 const CLAUDE_CODE_SKIP_PERMISSIONS_ARGS = ['--dangerously-skip-permissions']
 const CLAUDE_CODE_ROOT_PERMISSION_ARGS = ['--permission-mode', 'auto']
 const HERMES_MCP_SERVERS = [
@@ -479,19 +479,6 @@ function belongsToDifferentBuiltinProvider(provider: string, baseUrl: string): b
     item.value !== providerKey &&
     providerPresetHost(item.base_url) === inputHost
   ))
-}
-
-function isScopedCodingAgentAuthProvider(provider: string, apiKey = ''): boolean {
-  const providerKey = String(provider || '').trim().toLowerCase()
-  return CODING_AGENT_SCOPED_AUTH_PROVIDERS.has(providerKey)
-}
-
-function assertScopedCodingAgentProviderAllowed(mode: CodingAgentLaunchResult['mode'], provider: string, apiKey = ''): void {
-  if (mode === 'global') return
-  if (!isScopedCodingAgentAuthProvider(provider, apiKey)) return
-  const err = new Error('Coding agent scoped mode does not support OAuth/subscription providers. Use global mode or select an API-key provider.')
-  ;(err as any).status = 400
-  throw err
 }
 
 async function resolveStoredProviderLaunchInput(
@@ -1649,7 +1636,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
   const scope = normalizeConfigScope({ profile: input.profile, provider })
   const model = String(input.model || '').trim()
   const apiKey = String(input.apiKey || '').trim()
-  assertScopedCodingAgentProviderAllowed(mode, provider, apiKey)
+  assertScopedCodingAgentProviderAllowed(mode, provider)
   if (!model) {
     const err = new Error('Model is required')
     ;(err as any).status = 400
@@ -1858,11 +1845,7 @@ export async function startCodingAgentRun(
   const resolvedInput = await resolveStoredProviderLaunchInput(input, existingSession)
   const requestedMode = resolvedInput.mode === 'global' ? 'global' : 'scoped'
   const requestedProvider = String(resolvedInput.provider || '').trim().toLowerCase()
-  if (requestedMode !== 'global' && CODING_AGENT_SCOPED_AUTH_PROVIDERS.has(requestedProvider)) {
-    const err = new Error('Coding agent scoped mode does not support OAuth/subscription providers. Use global mode or select an API-key provider.')
-    ;(err as any).status = 400
-    throw err
-  }
+  assertScopedCodingAgentProviderAllowed(requestedMode, requestedProvider)
   if (requestedMode !== 'global' && (!String(resolvedInput.baseUrl || '').trim() || !String(resolvedInput.apiKey || '').trim())) {
     const err = new Error('Coding agent provider credentials are missing. Re-select the provider/model or update the provider API key before continuing this session.')
     ;(err as any).status = 400

--- a/packages/server/src/services/workflow-import-capabilities.ts
+++ b/packages/server/src/services/workflow-import-capabilities.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'crypto'
+import { isScopedCodingAgentAuthProvider } from './coding-agent-provider-policy'
 
 interface CapabilityGroup { provider: string; models: string[]; api_mode?: string }
 
@@ -29,10 +30,12 @@ export function assertWorkflowImportCapabilities(nodes: unknown[], groups: Capab
     if (!provider && !model && !apiMode) continue
     const exact = `${provider}\u0000${model}\u0000${apiMode}`
     const scopedCodingAgent = agent === 'codex' || agent === 'claude-code'
+    const scopedCodingAgentProviderBlocked = scopedCodingAgent && isScopedCodingAgentAuthProvider(provider)
     const codingAgentTargetAvailable = scopedCodingAgent
+      && !scopedCodingAgentProviderBlocked
       && SCOPED_CODING_AGENT_API_MODES.has(apiMode)
       && configuredProviderModels.has(`${provider}\u0000${model}`)
-    if (!configured.has(exact) && !codingAgentTargetAvailable) {
+    if (scopedCodingAgentProviderBlocked || (!configured.has(exact) && !codingAgentTargetAvailable)) {
       throw Object.assign(new Error(`workflow node ${String(node.id || '?')} target capability is unavailable in profile`), { status: 409 })
     }
   }

--- a/packages/server/src/services/workflow-import-capabilities.ts
+++ b/packages/server/src/services/workflow-import-capabilities.ts
@@ -2,8 +2,14 @@ import { createHash } from 'crypto'
 
 interface CapabilityGroup { provider: string; models: string[]; api_mode?: string }
 
+const SCOPED_CODING_AGENT_API_MODES = new Set(['chat_completions', 'codex_responses', 'anthropic_messages'])
+
 function normalizedCapabilityTuples(groups: CapabilityGroup[]): string[] {
   return groups.flatMap(group => (group.models || []).map(model => `${group.provider}\u0000${model}\u0000${group.api_mode || ''}`)).sort()
+}
+
+function normalizedProviderModels(groups: CapabilityGroup[]): Set<string> {
+  return new Set(groups.flatMap(group => (group.models || []).map(model => `${group.provider}\u0000${model}`)))
 }
 
 export function workflowImportEnvironmentRevision(groups: CapabilityGroup[]): string {
@@ -12,15 +18,21 @@ export function workflowImportEnvironmentRevision(groups: CapabilityGroup[]): st
 
 export function assertWorkflowImportCapabilities(nodes: unknown[], groups: CapabilityGroup[]): void {
   const configured = new Set(normalizedCapabilityTuples(groups))
+  const configuredProviderModels = normalizedProviderModels(groups)
   for (const raw of nodes) {
     const node = raw && typeof raw === 'object' ? raw as Record<string, any> : {}
     const data = node.data && typeof node.data === 'object' ? node.data as Record<string, any> : {}
+    const agent = typeof data.agent === 'string' ? data.agent.trim() : ''
     const provider = typeof data.provider === 'string' ? data.provider.trim() : ''
     const model = typeof data.model === 'string' ? data.model.trim() : ''
     const apiMode = typeof data.apiMode === 'string' ? data.apiMode.trim() : ''
     if (!provider && !model && !apiMode) continue
     const exact = `${provider}\u0000${model}\u0000${apiMode}`
-    if (!configured.has(exact)) {
+    const scopedCodingAgent = agent === 'codex' || agent === 'claude-code'
+    const codingAgentTargetAvailable = scopedCodingAgent
+      && SCOPED_CODING_AGENT_API_MODES.has(apiMode)
+      && configuredProviderModels.has(`${provider}\u0000${model}`)
+    if (!configured.has(exact) && !codingAgentTargetAvailable) {
       throw Object.assign(new Error(`workflow node ${String(node.id || '?')} target capability is unavailable in profile`), { status: 409 })
     }
   }

--- a/tests/client/coding-agent-providers.test.ts
+++ b/tests/client/coding-agent-providers.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../../packages/client/src/utils/codingAgentProviders'
 
 describe('coding agent provider visibility', () => {
-  it.each(['nous', 'openai-codex', 'xai-oauth', 'qwen-oauth'])(
+  it.each(['nous', 'openai-codex', 'copilot', 'xai-oauth', 'qwen-oauth', 'claude-oauth'])(
     'exposes %s to scoped Ekko Agent sessions',
     (provider) => {
       expect(isAuthModelProvider(provider)).toBe(true)

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -40,6 +40,12 @@ interface MockHermesApiOptions {
   channelCredentials?: boolean
   channelConfig?: Record<string, unknown>
   providerEditor?: Record<string, unknown>
+  modelGroups?: Array<{
+    provider: string
+    label: string
+    models: string[]
+    [key: string]: unknown
+  }>
 }
 
 export const TEST_MODEL_GROUP = {
@@ -406,16 +412,18 @@ export async function mockHermesApi(page: Page, options: MockHermesApiOptions = 
     }
 
     if (pathname === '/api/hermes/available-models') {
+      const groups = options.modelGroups ?? [TEST_MODEL_GROUP]
+      const defaultGroup = groups.find(group => Array.isArray(group.models) && group.models.length > 0)
       await route.fulfill(jsonResponse({
-        default: 'test-model',
-        default_provider: 'test-provider',
-        groups: [TEST_MODEL_GROUP],
-        allProviders: [TEST_MODEL_GROUP],
+        default: defaultGroup?.models?.[0] || '',
+        default_provider: defaultGroup?.provider || '',
+        groups,
+        allProviders: groups,
         profiles: ['default', 'research'].map(profile => ({
           profile,
-          default: 'test-model',
-          default_provider: 'test-provider',
-          groups: [TEST_MODEL_GROUP],
+          default: defaultGroup?.models?.[0] || '',
+          default_provider: defaultGroup?.provider || '',
+          groups,
         })),
         model_aliases: {},
         model_visibility: {},

--- a/tests/e2e/workflow-ui.spec.ts
+++ b/tests/e2e/workflow-ui.spec.ts
@@ -1,6 +1,49 @@
 import { readFile } from 'fs/promises'
 import { expect, test } from '@playwright/test'
-import { authenticate, mockChatSocket, mockHermesApi, TEST_ACCESS_KEY } from './fixtures'
+import { authenticate, mockChatSocket, mockHermesApi, TEST_ACCESS_KEY, TEST_MODEL_GROUP } from './fixtures'
+
+test('workflow Coding Agent nodes hide auth providers and reset auth selections', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  const authGroup = {
+    provider: 'openai-codex',
+    label: 'OpenAI Codex Subscription',
+    base_url: '',
+    models: ['gpt-5-codex'],
+    available_models: ['gpt-5-codex'],
+    api_key: '',
+    api_mode: 'codex_app_server',
+    builtin: true,
+  }
+  const api = await mockHermesApi(page, {
+    modelGroups: [authGroup, TEST_MODEL_GROUP],
+    workflows: [{
+      id: 'wf-auth-provider', name: 'Provider policy', profile: 'research', workspace: null,
+      nodes: [{
+        id: 'agent', type: 'agent', position: { x: 80, y: 80 },
+        data: {
+          title: 'Agent', agent: 'hermes', provider: 'openai-codex', model: 'gpt-5-codex',
+          apiMode: 'codex_responses', input: 'Run', skills: [], images: [], approvalRequired: false,
+        },
+      }],
+      edges: [], viewport: { x: 80, y: 80, zoom: .75 }, created_at: 1, updated_at: 1,
+    }],
+    workflowRuns: [],
+  })
+
+  await page.goto('/#/hermes/workflow')
+  const node = page.locator('.vue-flow__node[data-id="agent"]')
+  await expect(node.locator('.model-trigger')).toContainText('gpt-5-codex')
+
+  await node.locator('.n-select').first().click()
+  await page.getByText('Codex', { exact: true }).last().click()
+  await expect(node.locator('.model-trigger')).toContainText('test-model')
+
+  await node.locator('.model-trigger').click()
+  const modelDialog = page.getByRole('dialog')
+  await expect(modelDialog.getByText('Test Provider', { exact: true })).toBeVisible()
+  await expect(modelDialog.getByText('OpenAI Codex Subscription', { exact: true })).toHaveCount(0)
+  expect(api.unexpectedRequests).toEqual([])
+})
 
 test('workflow canvas exposes orchestration editing and portability controls', async ({ page }) => {
   await authenticate(page, TEST_ACCESS_KEY, 'research')

--- a/tests/server/workflow-import-capabilities.test.ts
+++ b/tests/server/workflow-import-capabilities.test.ts
@@ -33,6 +33,15 @@ describe('workflow import capabilities', () => {
     ], groups)).toThrow('unavailable')
   })
 
+  it.each(['openai-codex', 'copilot', 'xai-oauth', 'qwen-oauth', 'nous', 'claude-oauth'])(
+    'rejects scoped Coding Agent targets backed by auth provider %s',
+    (provider) => {
+      expect(() => assertWorkflowImportCapabilities([
+        node({ agent: 'codex', provider, model: 'model-a', apiMode: 'codex_responses' }),
+      ], [{ provider, models: ['model-a'], api_mode: 'codex_responses' }])).toThrow('unavailable')
+    },
+  )
+
   it('allows runtime-default nodes and revisions change with any target capability', () => {
     expect(() => assertWorkflowImportCapabilities([node({})], [])).not.toThrow()
     const one = workflowImportEnvironmentRevision([{ provider: 'p', models: ['a'], api_mode: 'chat_completions' }])

--- a/tests/server/workflow-import-capabilities.test.ts
+++ b/tests/server/workflow-import-capabilities.test.ts
@@ -13,6 +13,26 @@ describe('workflow import capabilities', () => {
     expect(() => assertWorkflowImportCapabilities([node({ provider: 'custom:test', model: 'model-a', apiMode: 'chat_completions' })], [{ provider: 'custom:test', models: ['model-a'] }])).toThrow('unavailable')
   })
 
+  it('accepts scoped Coding Agent protocol overrides for a configured provider and model', () => {
+    const groups = [{ provider: 'custom:test', models: ['model-a'], api_mode: 'chat_completions' }]
+
+    expect(() => assertWorkflowImportCapabilities([
+      node({ agent: 'codex', provider: 'custom:test', model: 'model-a', apiMode: 'codex_responses' }),
+      node({ agent: 'claude-code', provider: 'custom:test', model: 'model-a', apiMode: 'anthropic_messages' }),
+    ], groups)).not.toThrow()
+  })
+
+  it('keeps scoped Coding Agent targets fail closed for missing models and unsupported protocols', () => {
+    const groups = [{ provider: 'custom:test', models: ['model-a'], api_mode: 'chat_completions' }]
+
+    expect(() => assertWorkflowImportCapabilities([
+      node({ agent: 'codex', provider: 'custom:test', model: 'model-b', apiMode: 'codex_responses' }),
+    ], groups)).toThrow('unavailable')
+    expect(() => assertWorkflowImportCapabilities([
+      node({ agent: 'claude-code', provider: 'custom:test', model: 'model-a', apiMode: 'bedrock_converse' }),
+    ], groups)).toThrow('unavailable')
+  })
+
   it('allows runtime-default nodes and revisions change with any target capability', () => {
     expect(() => assertWorkflowImportCapabilities([node({})], [])).not.toThrow()
     const one = workflowImportEnvironmentRevision([{ provider: 'p', models: ['a'], api_mode: 'chat_completions' }])


### PR DESCRIPTION
## Summary

- keep exact profile-owned `provider + model + apiMode` matching for Hermes Workflow nodes;
- allow scoped Codex and Claude Code nodes to select a launcher-supported wire protocol when their API-key provider/model pair exists in the active profile;
- hide OAuth/subscription providers from Workflow Coding Agent model selection and reset incompatible selections when switching runtimes;
- keep missing provider/model pairs, unsupported protocols, and scoped OAuth/subscription targets fail-closed.

## Why

Workflow execution preflight treated a provider group's single default `api_mode` as the complete protocol capability of every Agent runtime. Scoped Coding Agents already accept an explicit supported protocol and adapt requests through their launcher proxies, so valid API-key Coding Agent targets could be rejected before a Run was created.

The relaxed capability check must still match scoped launcher policy: OAuth/subscription providers are available to Hermes or global Coding Agents, but are not valid scoped Coding Agent targets.

## Impact

- Hermes protocol selection remains profile-owned and exact.
- Scoped Coding Agent protocol selection remains node-owned within the launcher's supported protocol set.
- Workflow authors cannot select OAuth/subscription providers for Codex or Claude Code nodes.
- Stored or hand-crafted incompatible targets are rejected by server preflight before a Run is created.

Closes #2153

## Validation

- `npm run test -- tests/server/workflow-import-capabilities.test.ts tests/server/workflow-controller.test.ts tests/server/workflow-manager.test.ts tests/server/coding-agent-resume-config.test.ts tests/client/coding-agent-providers.test.ts` — 165/165 passed.
- `npm run test:e2e -- tests/e2e/workflow-ui.spec.ts` — 15/15 passed.
- `npm run harness:check` passed.
- `npm run build` passed.
- `git diff --check` passed.
