### PR TITLE
fix: recover Claude encrypted-thinking continuations

### DIFF
--- a/docs/chat-chain-changes/2026-07-21-claude-encrypted-thinking-sse-retry.md
+++ b/docs/chat-chain-changes/2026-07-21-claude-encrypted-thinking-sse-retry.md
@@ -1,0 +1,11 @@
+---
+date: 2026-07-21
+pr: 2158
+feature: Claude encrypted-thinking SSE retry
+impact: Custom Anthropic-compatible Coding Agent providers now recover when an invalid encrypted-thinking continuation is reported inside a successful HTTP SSE response.
+---
+
+The Claude Code proxy inspects only the SSE prelude before any business event is
+delivered. A matching encrypted-content error cancels that stream and retries once
+with historical opaque thinking removed from the outgoing request; normal response
+events, tool history, and the request's top-level thinking configuration are preserved.

--- a/packages/server/src/services/agent-runner/proxies/claude-code-proxy.ts
+++ b/packages/server/src/services/agent-runner/proxies/claude-code-proxy.ts
@@ -29,6 +29,7 @@ import {
 import { agentRunGateway, ProviderApiError } from '../gateway'
 import { teeAsyncIterable } from '../stream-tee'
 import { codingAgentRunManager } from '../coding-agent-run-manager'
+import { logger } from '../../logger'
 
 export type { ApiMode } from '../types'
 
@@ -95,20 +96,41 @@ function anthropicRequestBody(body: any, target: ClaudeCodeProxyTarget): any {
 
 const OPAQUE_THINKING_BLOCK_TYPES = new Set(['thinking', 'redacted_thinking'])
 
-function withoutOpaqueThinkingHistory(body: any): any | null {
+type OpaqueThinkingSanitization = {
+  body: any
+  removedBlocks: number
+  removedMessages: number
+}
+
+function withoutOpaqueThinkingHistory(body: any): OpaqueThinkingSanitization | null {
   if (!Array.isArray(body?.messages)) return null
-  let removed = false
-  const messages = body.messages.map((message: any) => {
-    if (!Array.isArray(message?.content)) return message
+  let removedBlocks = 0
+  let removedMessages = 0
+  const messages: any[] = []
+
+  for (const message of body.messages) {
+    if (!Array.isArray(message?.content)) {
+      messages.push(message)
+      continue
+    }
     const content = message.content.filter((block: any) => {
       const strip = OPAQUE_THINKING_BLOCK_TYPES.has(String(block?.type || ''))
-      removed ||= strip
+      if (strip) removedBlocks += 1
       return !strip
     })
-    return content.length === message.content.length ? message : { ...message, content }
-  })
-  if (!removed || messages.some((message: any) => Array.isArray(message?.content) && message.content.length === 0)) return null
-  return { ...body, messages }
+    if (content.length === 0 && message.content.length > 0) {
+      removedMessages += 1
+      continue
+    }
+    messages.push(content.length === message.content.length ? message : { ...message, content })
+  }
+
+  if (removedBlocks === 0 || messages.length === 0) return null
+  return {
+    body: { ...body, messages },
+    removedBlocks,
+    removedMessages,
+  }
 }
 
 const ENCRYPTED_CONTENT_MESSAGE = /^Encrypted content could not be decrypted or parsed\.?$/i
@@ -131,9 +153,34 @@ async function withCustomEncryptedContentRetry<T>(
     return await request(body)
   } catch (error) {
     if (!isCustomEncryptedContentFailure(target, error)) throw error
-    const retryBody = withoutOpaqueThinkingHistory(body)
-    if (!retryBody) throw error
-    return request(retryBody)
+    const sanitization = withoutOpaqueThinkingHistory(body)
+    if (!sanitization) {
+      loggerLikeWarn({
+        provider: target.provider,
+        status: 400,
+        retryStarted: false,
+      }, '[claude-code-proxy] encrypted-thinking compatibility retry skipped')
+      throw error
+    }
+    loggerLikeWarn({
+      provider: target.provider,
+      status: 400,
+      removedBlocks: sanitization.removedBlocks,
+      removedMessages: sanitization.removedMessages,
+      retryStarted: true,
+    }, '[claude-code-proxy] retrying without historical opaque thinking')
+    try {
+      return await request(sanitization.body)
+    } catch (retryError) {
+      const providerError = retryError instanceof ProviderApiError ? retryError.providerError as any : null
+      loggerLikeWarn({
+        provider: target.provider,
+        status: retryError instanceof ProviderApiError ? retryError.status : null,
+        code: String(providerError?.error?.code || ''),
+        retryFailed: true,
+      }, '[claude-code-proxy] encrypted-thinking compatibility retry failed')
+      throw retryError
+    }
   }
 }
 
@@ -203,10 +250,7 @@ function observeResponsesEvents(target: ClaudeCodeProxyTarget, events: AsyncIter
 }
 
 function loggerLikeWarn(err: unknown, message: string) {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require('../../logger').logger.warn(err, message)
-  } catch {}
+  logger.warn(err, message)
 }
 
 async function openAiChatToAnthropicSseStream(target: ClaudeCodeProxyTarget, body: any): Promise<Readable> {

--- a/packages/server/src/services/agent-runner/proxies/claude-code-proxy.ts
+++ b/packages/server/src/services/agent-runner/proxies/claude-code-proxy.ts
@@ -26,7 +26,7 @@ import {
   openAiResponsesSseToResponsesEvents,
   type CanonicalResponsesEvent,
 } from '../adapters/responses-stream'
-import { agentRunGateway } from '../gateway'
+import { agentRunGateway, ProviderApiError } from '../gateway'
 import { teeAsyncIterable } from '../stream-tee'
 import { codingAgentRunManager } from '../coding-agent-run-manager'
 
@@ -93,21 +93,65 @@ function anthropicRequestBody(body: any, target: ClaudeCodeProxyTarget): any {
   }
 }
 
+const OPAQUE_THINKING_BLOCK_TYPES = new Set(['thinking', 'redacted_thinking'])
+
+function withoutOpaqueThinkingHistory(body: any): any | null {
+  if (!Array.isArray(body?.messages)) return null
+  let removed = false
+  const messages = body.messages.map((message: any) => {
+    if (!Array.isArray(message?.content)) return message
+    const content = message.content.filter((block: any) => {
+      const strip = OPAQUE_THINKING_BLOCK_TYPES.has(String(block?.type || ''))
+      removed ||= strip
+      return !strip
+    })
+    return content.length === message.content.length ? message : { ...message, content }
+  })
+  if (!removed || messages.some((message: any) => Array.isArray(message?.content) && message.content.length === 0)) return null
+  return { ...body, messages }
+}
+
+const ENCRYPTED_CONTENT_MESSAGE = /^Encrypted content could not be decrypted or parsed\.?$/i
+const ENCRYPTED_CONTENT_VERIFICATION_MESSAGE = /^The encrypted content [^\r\n]+ could not be verified\. Reason: Encrypted content could not be decrypted or parsed\.?$/i
+
+function isCustomEncryptedContentFailure(target: ClaudeCodeProxyTarget, error: unknown): boolean {
+  if (!target.provider.startsWith('custom:') || !(error instanceof ProviderApiError) || error.status !== 400) return false
+  const providerError = error.providerError as any
+  if (providerError?.error?.code === 'invalid_encrypted_content') return true
+  const message = String(providerError?.error?.message || '')
+  return ENCRYPTED_CONTENT_MESSAGE.test(message) || ENCRYPTED_CONTENT_VERIFICATION_MESSAGE.test(message)
+}
+
+async function withCustomEncryptedContentRetry<T>(
+  target: ClaudeCodeProxyTarget,
+  body: any,
+  request: (nextBody: any) => Promise<T>,
+): Promise<T> {
+  try {
+    return await request(body)
+  } catch (error) {
+    if (!isCustomEncryptedContentFailure(target, error)) throw error
+    const retryBody = withoutOpaqueThinkingHistory(body)
+    if (!retryBody) throw error
+    return request(retryBody)
+  }
+}
+
 async function callAnthropicMessages(target: ClaudeCodeProxyTarget, body: any): Promise<any> {
   if (target.apiMode !== 'anthropic_messages') {
     const err = new Error(`Claude proxy Anthropic adapter only supports anthropic_messages targets, got ${target.apiMode}`)
     ;(err as any).status = 501
     throw err
   }
-  return agentRunGateway.completeJson({
+  return withCustomEncryptedContentRetry(target, body, nextBody => agentRunGateway.completeJson({
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
     headers: {
       'x-api-key': target.apiKey,
       'anthropic-version': '2023-06-01',
     },
-    body: anthropicRequestBody(body, target),
-  })
+    body: anthropicRequestBody(nextBody, target),
+  }))
 }
 
 async function callOpenAiChat(target: ClaudeCodeProxyTarget, body: any): Promise<any> {
@@ -189,15 +233,15 @@ async function anthropicMessagesSseStream(target: ClaudeCodeProxyTarget, body: a
     throw err
   }
 
-  const stream = await agentRunGateway.streamBytes({
+  const stream = await withCustomEncryptedContentRetry(target, body, nextBody => agentRunGateway.streamBytes({
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
     headers: {
       'x-api-key': target.apiKey,
       'anthropic-version': '2023-06-01',
     },
-    body: anthropicRequestBody(body, target),
-  })
+    body: anthropicRequestBody(nextBody, target),
+  }))
   const [clientStream, observerStream] = teeAsyncIterable(stream)
   observeResponsesEvents(target, anthropicMessagesSseToResponsesEvents(observerStream, target))
   return Readable.from(clientStream)

--- a/packages/server/src/services/agent-runner/proxies/claude-code-proxy.ts
+++ b/packages/server/src/services/agent-runner/proxies/claude-code-proxy.ts
@@ -6,7 +6,7 @@ import {
   chatCompletionsUrl as resolveChatCompletionsUrl,
   responsesUrl as resolveResponsesUrl,
 } from '../endpoint-resolver'
-import { sseEvent } from '../sse'
+import { parseSseFrame, readSseFrameTexts, sseEvent } from '../sse'
 import { AgentTargetRegistry, type AgentTargetInput, type RegisteredAgentTarget } from '../target-registry'
 import type { ApiMode } from '../types'
 import {
@@ -136,52 +136,157 @@ function withoutOpaqueThinkingHistory(body: any): OpaqueThinkingSanitization | n
 const ENCRYPTED_CONTENT_MESSAGE = /^Encrypted content could not be decrypted or parsed\.?$/i
 const ENCRYPTED_CONTENT_VERIFICATION_MESSAGE = /^The encrypted content [^\r\n]+ could not be verified\. Reason: Encrypted content could not be decrypted or parsed\.?$/i
 
-function isCustomEncryptedContentFailure(target: ClaudeCodeProxyTarget, error: unknown): boolean {
+function isCustomEncryptedContentFailure(target: ClaudeCodeProxyTarget, error: unknown): error is ProviderApiError {
   if (!target.provider.startsWith('custom:') || !(error instanceof ProviderApiError) || error.status !== 400) return false
-  const providerError = error.providerError as any
-  if (providerError?.error?.code === 'invalid_encrypted_content') return true
-  const message = String(providerError?.error?.message || '')
+  return isEncryptedContentProviderError(error.providerError)
+}
+
+function isEncryptedContentProviderError(providerError: unknown): boolean {
+  const typedProviderError = providerError as any
+  if (typedProviderError?.error?.code === 'invalid_encrypted_content') return true
+  const message = String(typedProviderError?.error?.message || '')
   return ENCRYPTED_CONTENT_MESSAGE.test(message) || ENCRYPTED_CONTENT_VERIFICATION_MESSAGE.test(message)
+}
+
+function opaqueThinkingRetryBody(
+  target: ClaudeCodeProxyTarget,
+  body: any,
+  status: number,
+): any | null {
+  const sanitization = withoutOpaqueThinkingHistory(body)
+  if (!sanitization) {
+    loggerLikeWarn({
+      provider: target.provider,
+      status,
+      retryStarted: false,
+    }, '[claude-code-proxy] encrypted-thinking compatibility retry skipped')
+    return null
+  }
+  loggerLikeWarn({
+    provider: target.provider,
+    status,
+    removedBlocks: sanitization.removedBlocks,
+    removedMessages: sanitization.removedMessages,
+    retryStarted: true,
+  }, '[claude-code-proxy] retrying without historical opaque thinking')
+  return sanitization.body
+}
+
+function logEncryptedContentRetryFailure(target: ClaudeCodeProxyTarget, retryError: unknown) {
+  const providerError = retryError instanceof ProviderApiError ? retryError.providerError as any : null
+  loggerLikeWarn({
+    provider: target.provider,
+    status: retryError instanceof ProviderApiError ? retryError.status : null,
+    code: String(providerError?.error?.code || ''),
+    retryFailed: true,
+  }, '[claude-code-proxy] encrypted-thinking compatibility retry failed')
 }
 
 async function withCustomEncryptedContentRetry<T>(
   target: ClaudeCodeProxyTarget,
   body: any,
   request: (nextBody: any) => Promise<T>,
-): Promise<T> {
+): Promise<{ value: T; retried: boolean }> {
   try {
-    return await request(body)
+    return { value: await request(body), retried: false }
   } catch (error) {
     if (!isCustomEncryptedContentFailure(target, error)) throw error
-    const sanitization = withoutOpaqueThinkingHistory(body)
-    if (!sanitization) {
-      loggerLikeWarn({
-        provider: target.provider,
-        status: 400,
-        retryStarted: false,
-      }, '[claude-code-proxy] encrypted-thinking compatibility retry skipped')
-      throw error
-    }
-    loggerLikeWarn({
-      provider: target.provider,
-      status: 400,
-      removedBlocks: sanitization.removedBlocks,
-      removedMessages: sanitization.removedMessages,
-      retryStarted: true,
-    }, '[claude-code-proxy] retrying without historical opaque thinking')
+    const retryBody = opaqueThinkingRetryBody(target, body, error.status)
+    if (!retryBody) throw error
     try {
-      return await request(sanitization.body)
+      return { value: await request(retryBody), retried: true }
     } catch (retryError) {
-      const providerError = retryError instanceof ProviderApiError ? retryError.providerError as any : null
-      loggerLikeWarn({
-        provider: target.provider,
-        status: retryError instanceof ProviderApiError ? retryError.status : null,
-        code: String(providerError?.error?.code || ''),
-        retryFailed: true,
-      }, '[claude-code-proxy] encrypted-thinking compatibility retry failed')
+      logEncryptedContentRetryFailure(target, retryError)
       throw retryError
     }
   }
+}
+
+type SseProbeResult = {
+  stream: AsyncIterable<Uint8Array> | null
+  encryptedContentError: boolean
+}
+
+const SSE_ERROR_PROBE_LIMIT = 64 * 1024
+
+function replayAsyncIterator(
+  chunks: Uint8Array[],
+  iterator: AsyncIterator<Uint8Array>,
+): AsyncIterable<Uint8Array> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      try {
+        for (const chunk of chunks) yield chunk
+        while (true) {
+          const next = await iterator.next()
+          if (next.done) return
+          yield next.value
+        }
+      } finally {
+        await iterator.return?.()
+      }
+    },
+  }
+}
+
+function isEncryptedContentSseFrame(rawFrame: string): boolean {
+  const frame = parseSseFrame(rawFrame)
+  if (!frame) return false
+  let data: any
+  try {
+    data = JSON.parse(frame.data)
+  } catch {
+    return false
+  }
+  if (frame.event !== 'error' && data?.type !== 'error') return false
+  return isEncryptedContentProviderError(data)
+}
+
+function isIgnorableSsePreludeFrame(rawFrame: string): boolean {
+  const frame = parseSseFrame(rawFrame)
+  return !frame || frame.event === 'ping'
+}
+
+async function probeSseEncryptedContentError(
+  stream: AsyncIterable<Uint8Array>,
+): Promise<SseProbeResult> {
+  const iterator = stream[Symbol.asyncIterator]()
+  const decoder = new TextDecoder()
+  const chunks: Uint8Array[] = []
+  let decoded = ''
+  let byteLength = 0
+
+  while (byteLength <= SSE_ERROR_PROBE_LIMIT) {
+    const next = await iterator.next()
+    if (next.done) {
+      decoded += decoder.decode()
+      if (decoded && isEncryptedContentSseFrame(decoded)) {
+        await iterator.return?.()
+        return { stream: null, encryptedContentError: true }
+      }
+      return { stream: replayAsyncIterator(chunks, iterator), encryptedContentError: false }
+    }
+
+    chunks.push(next.value)
+    byteLength += next.value.byteLength
+    decoded += decoder.decode(next.value, { stream: true })
+    const parsed = readSseFrameTexts(decoded)
+    decoded = parsed.rest
+
+    let hasBusinessFrame = false
+    for (const rawFrame of parsed.frames) {
+      if (isEncryptedContentSseFrame(rawFrame)) {
+        await iterator.return?.()
+        return { stream: null, encryptedContentError: true }
+      }
+      if (!isIgnorableSsePreludeFrame(rawFrame)) hasBusinessFrame = true
+    }
+    if (hasBusinessFrame) {
+      return { stream: replayAsyncIterator(chunks, iterator), encryptedContentError: false }
+    }
+  }
+
+  return { stream: replayAsyncIterator(chunks, iterator), encryptedContentError: false }
 }
 
 async function callAnthropicMessages(target: ClaudeCodeProxyTarget, body: any): Promise<any> {
@@ -190,7 +295,7 @@ async function callAnthropicMessages(target: ClaudeCodeProxyTarget, body: any): 
     ;(err as any).status = 501
     throw err
   }
-  return withCustomEncryptedContentRetry(target, body, nextBody => agentRunGateway.completeJson({
+  const result = await withCustomEncryptedContentRetry(target, body, nextBody => agentRunGateway.completeJson({
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
     headers: {
@@ -199,6 +304,7 @@ async function callAnthropicMessages(target: ClaudeCodeProxyTarget, body: any): 
     },
     body: anthropicRequestBody(nextBody, target),
   }))
+  return result.value
 }
 
 async function callOpenAiChat(target: ClaudeCodeProxyTarget, body: any): Promise<any> {
@@ -277,7 +383,7 @@ async function anthropicMessagesSseStream(target: ClaudeCodeProxyTarget, body: a
     throw err
   }
 
-  const stream = await withCustomEncryptedContentRetry(target, body, nextBody => agentRunGateway.streamBytes({
+  const request = (nextBody: any) => agentRunGateway.streamBytes({
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
     headers: {
@@ -285,7 +391,36 @@ async function anthropicMessagesSseStream(target: ClaudeCodeProxyTarget, body: a
       'anthropic-version': '2023-06-01',
     },
     body: anthropicRequestBody(nextBody, target),
-  }))
+  })
+  const initial = await withCustomEncryptedContentRetry(target, body, request)
+  const stream = initial.value
+  // Only retry before a business event reaches Claude Code; replaying a partially
+  // delivered response would duplicate Anthropic stream events.
+  const canRetrySseError = target.provider.startsWith('custom:')
+    && !initial.retried
+    && withoutOpaqueThinkingHistory(body) !== null
+  if (canRetrySseError) {
+    const probe = await probeSseEncryptedContentError(stream)
+    if (probe.encryptedContentError) {
+      const retryBody = opaqueThinkingRetryBody(target, body, 200)
+      if (retryBody) {
+        try {
+          const retryStream = await request(retryBody)
+          const [clientStream, observerStream] = teeAsyncIterable(retryStream)
+          observeResponsesEvents(target, anthropicMessagesSseToResponsesEvents(observerStream, target))
+          return Readable.from(clientStream)
+        } catch (retryError) {
+          logEncryptedContentRetryFailure(target, retryError)
+          throw retryError
+        }
+      }
+    }
+    if (probe.stream) {
+      const [clientStream, observerStream] = teeAsyncIterable(probe.stream)
+      observeResponsesEvents(target, anthropicMessagesSseToResponsesEvents(observerStream, target))
+      return Readable.from(clientStream)
+    }
+  }
   const [clientStream, observerStream] = teeAsyncIterable(stream)
   observeResponsesEvents(target, anthropicMessagesSseToResponsesEvents(observerStream, target))
   return Readable.from(clientStream)

--- a/packages/server/src/services/agent-runner/target-registry.ts
+++ b/packages/server/src/services/agent-runner/target-registry.ts
@@ -41,7 +41,7 @@ export class AgentTargetRegistry<T extends AgentTargetInput> {
       baseUrl: input.baseUrl.trim().replace(/\/+$/, ''),
       apiMode: input.apiMode || 'chat_completions',
     } as NormalizedAgentTargetInput<T>
-    const key = this.keyParts(normalized).join('\0')
+    const key = JSON.stringify(this.keyParts(normalized))
     const existing = this.targets.get(key)
     const routeKey = existing?.routeKey || Buffer.from(key, 'utf-8').toString('base64url')
     const token = existing?.token || `hwui_${randomBytes(24).toString('base64url')}`

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -385,6 +385,21 @@ function normalizeScopeSegment(value: string | undefined, fallback: string, labe
   return segment
 }
 
+function normalizeProviderIdentity(value: string | undefined): string {
+  const provider = String(value || '').trim() || 'default'
+  if (/[\x00-\x1f\x7f-\x9f]/.test(provider)) {
+    const err = new Error('Invalid provider')
+    ;(err as any).status = 400
+    throw err
+  }
+  if (provider.length > 128) {
+    const err = new Error('provider is too long')
+    ;(err as any).status = 400
+    throw err
+  }
+  return provider
+}
+
 function normalizeConfigScope(scope: CodingAgentConfigScope = {}): Required<CodingAgentConfigScope> {
   return {
     profile: normalizeScopeSegment(scope.profile, 'default', 'profile'),
@@ -1632,7 +1647,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
     }
   }
 
-  const provider = normalizeScopeSegment(input.provider, 'default', 'provider')
+  const provider = normalizeProviderIdentity(input.provider)
   const scope = normalizeConfigScope({ profile: input.profile, provider })
   const model = String(input.model || '').trim()
   const apiKey = String(input.apiKey || '').trim()
@@ -1810,7 +1825,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
     agentId: tool.id,
     mode,
     profile: scope.profile,
-    provider: scope.provider,
+    provider,
     model,
     apiMode,
     rootDir,

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -156,6 +156,41 @@ describe('agent runner target registry', () => {
     expect(chat.routeKey).not.toBe(secondUrl.routeKey)
     expect(chat.token).not.toBe(secondUrl.token)
   })
+
+  it('keeps target tuples distinct when a key part contains the legacy delimiter', () => {
+    type SessionTargetInput = AgentTargetInput & {
+      agentSessionId: string
+      chatSessionId: string
+    }
+    const registry = new AgentTargetRegistry<SessionTargetInput>(
+      input => [input.provider, input.model, input.apiMode, input.baseUrl, input.agentSessionId, input.chatSessionId],
+    )
+    const common = {
+      provider: 'custom:compat-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiMode: 'anthropic_messages' as const,
+    }
+
+    const first = registry.register({
+      ...common,
+      apiKey: 'sk-first',
+      agentSessionId: 'agent',
+      chatSessionId: 'chat\0tail',
+    })
+    const second = registry.register({
+      ...common,
+      apiKey: 'sk-second',
+      agentSessionId: 'agent\0chat',
+      chatSessionId: 'tail',
+    })
+
+    expect(first.key).not.toBe(second.key)
+    expect(first.routeKey).not.toBe(second.routeKey)
+    expect(first.token).not.toBe(second.token)
+    expect(registry.find(first.routeKey)?.apiKey).toBe('sk-first')
+    expect(registry.find(second.routeKey)?.apiKey).toBe('sk-second')
+  })
 })
 
 describe('agent runner stream tee', () => {

--- a/tests/server/claude-code-proxy-thinking-compat.test.ts
+++ b/tests/server/claude-code-proxy-thinking-compat.test.ts
@@ -41,6 +41,37 @@ function encryptedContentError(options: { code?: string | null; message?: string
   })
 }
 
+function eventStreamResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder()
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk))
+      controller.close()
+    },
+  }), { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+}
+
+function successfulEventStreamResponse(text = 'continued'): Response {
+  return eventStreamResponse([
+    'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_stream_retry","type":"message","role":"assistant","model":"review-model","content":[],"usage":{"input_tokens":10,"output_tokens":0}}}\n\n',
+    'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+    `event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":${JSON.stringify(text)}}}\n\n`,
+    'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+    'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n',
+    'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+  ])
+}
+
+function encryptedContentEventStreamResponse(): Response {
+  return eventStreamResponse([
+    ': keep-alive\n\n',
+    'event: ping\ndata: {"type":"ping"}\n\n',
+    'event: er',
+    'ror\ndata: {"type":"error","error":{"type":"invalid_request_error","code":"invalid_',
+    'encrypted_content","message":"Encrypted content could not be decrypted or parsed."}}\n\n',
+  ])
+}
+
 function continuationBody(stream = false): any {
   return {
     model: 'client-alias',
@@ -159,6 +190,81 @@ describe('Claude Code custom Anthropic continuation compatibility', () => {
     const retryBody = requestBody(fetchMock, 1)
     expect(retryBody.messages[1].content.map((block: any) => block.type)).toEqual(['text', 'tool_use'])
     expect(chunks.join('')).toContain('continued')
+  })
+
+  it('retries when a successful HTTP response carries an encrypted-content SSE error', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'custom:sse-error-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'upstream-key',
+      apiMode: 'anthropic_messages',
+    })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(encryptedContentEventStreamResponse())
+      .mockResolvedValueOnce(successfulEventStreamResponse('continued after SSE retry'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const body = continuationBody(true)
+    const snapshot = structuredClone(body)
+    const ctx = makeProxyContext(target.routeKey, target.token, body)
+    await claudeProxyMessages(ctx)
+    const chunks: string[] = []
+    for await (const chunk of ctx.body) chunks.push(Buffer.from(chunk).toString('utf8'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(body).toEqual(snapshot)
+    expect(requestBody(fetchMock, 0).messages[1].content.map((block: any) => block.type)).toEqual([
+      'thinking', 'redacted_thinking', 'text', 'tool_use',
+    ])
+    expect(requestBody(fetchMock, 1).messages[1].content.map((block: any) => block.type)).toEqual(['text', 'tool_use'])
+    expect(chunks.join('')).toContain('continued after SSE retry')
+    expect(chunks.join('')).not.toContain('invalid_encrypted_content')
+  })
+
+  it('does not retry again when the SSE compatibility retry also returns the same error', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'custom:sse-retry-once-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'upstream-key',
+      apiMode: 'anthropic_messages',
+    })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(encryptedContentEventStreamResponse())
+      .mockResolvedValueOnce(encryptedContentEventStreamResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, continuationBody(true))
+    await claudeProxyMessages(ctx)
+    const chunks: string[] = []
+    for await (const chunk of ctx.body) chunks.push(Buffer.from(chunk).toString('utf8'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(chunks.join('')).toContain('invalid_encrypted_content')
+  })
+
+  it('does not make a third request when an HTTP compatibility retry returns an SSE error', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'custom:http-then-sse-error-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'upstream-key',
+      apiMode: 'anthropic_messages',
+    })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(encryptedContentError())
+      .mockResolvedValueOnce(encryptedContentEventStreamResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, continuationBody(true))
+    await claudeProxyMessages(ctx)
+    const chunks: string[] = []
+    for await (const chunk of ctx.body) chunks.push(Buffer.from(chunk).toString('utf8'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(requestBody(fetchMock, 1).messages[1].content.map((block: any) => block.type)).toEqual(['text', 'tool_use'])
+    expect(chunks.join('')).toContain('invalid_encrypted_content')
   })
 
   it('retries an exact encrypted-content message when the provider omits the error code', async () => {

--- a/tests/server/claude-code-proxy-thinking-compat.test.ts
+++ b/tests/server/claude-code-proxy-thinking-compat.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync, statSync } from 'fs'
+import { tmpdir } from 'os'
+import { resolve } from 'path'
+
 import {
   claudeProxyMessages,
   registerClaudeCodeProxyTarget,
@@ -250,16 +254,68 @@ describe('Claude Code custom Anthropic continuation compatibility', () => {
     expect(ctx.status).toBe(400)
   })
 
-  it('does not retry when removing opaque blocks would leave an empty message', async () => {
+  it('retries after dropping a historical message that contains only opaque thinking', async () => {
     const target = registerClaudeCodeProxyTarget({
       provider: 'custom:empty-message-provider',
       model: 'review-model',
       baseUrl: 'https://provider.example',
-      apiKey: 'upstream-key',
+      apiKey: 'provider-key',
       apiMode: 'anthropic_messages',
     })
     const body = continuationBody()
     body.messages[1].content = [{ type: 'thinking', thinking: '', signature: 'opaque-signature' }]
+    const snapshot = structuredClone(body)
+    const logFile = resolve(tmpdir(), 'hermes-web-ui-test-logs', String(process.pid), 'server.log')
+    const logOffset = statSync(logFile).size
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(encryptedContentError())
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 'msg_empty_history_retry_ok',
+        type: 'message',
+        role: 'assistant',
+        model: 'review-model',
+        content: [{ type: 'text', text: 'continued' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 1 },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, body)
+    await claudeProxyMessages(ctx)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(body).toEqual(snapshot)
+    expect(requestBody(fetchMock, 0).messages).toEqual(snapshot.messages)
+    expect(requestBody(fetchMock, 1).messages).toEqual([
+      snapshot.messages[0],
+      snapshot.messages[2],
+    ])
+    expect(ctx.body.content).toEqual([{ type: 'text', text: 'continued' }])
+    const logDelta = readFileSync(logFile).subarray(logOffset).toString('utf8')
+    expect(logDelta).toContain('retrying without historical opaque thinking')
+    expect(logDelta).toContain('"provider":"custom:empty-message-provider"')
+    expect(logDelta).toContain('"status":400')
+    expect(logDelta).toContain('"removedBlocks":1')
+    expect(logDelta).toContain('"removedMessages":1')
+    expect(logDelta).toContain('"retryStarted":true')
+    expect(logDelta).not.toContain('opaque-signature')
+    expect(logDelta).not.toContain('provider-key')
+    expect(logDelta).not.toContain('Encrypted content')
+  })
+
+  it('does not retry when removing opaque-only messages would leave no history', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'custom:all-opaque-history-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'provider-key',
+      apiMode: 'anthropic_messages',
+    })
+    const body = continuationBody()
+    body.messages = [{
+      role: 'assistant',
+      content: [{ type: 'thinking', thinking: '', signature: 'opaque-signature' }],
+    }]
     const fetchMock = vi.fn(async () => encryptedContentError())
     vi.stubGlobal('fetch', fetchMock)
 

--- a/tests/server/claude-code-proxy-thinking-compat.test.ts
+++ b/tests/server/claude-code-proxy-thinking-compat.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  claudeProxyMessages,
+  registerClaudeCodeProxyTarget,
+} from '../../packages/server/src/services/agent-runner/proxies/claude-code-proxy'
+
+function makeProxyContext(routeKey: string, token: string, body: any): any {
+  return {
+    params: { key: routeKey },
+    request: { body },
+    responseHeaders: {} as Record<string, string>,
+    get(name: string) {
+      if (name.toLowerCase() === 'authorization') return `Bearer ${token}`
+      return ''
+    },
+    set(name: string, value: string) {
+      this.responseHeaders[name] = value
+    },
+  }
+}
+
+function encryptedContentError(options: { code?: string | null; message?: string; status?: number } = {}) {
+  const {
+    code = 'invalid_encrypted_content',
+    message = 'Encrypted content could not be decrypted or parsed.',
+    status = 400,
+  } = options
+  return new Response(JSON.stringify({
+    error: {
+      message,
+      ...(code ? { code } : {}),
+      type: 'invalid_request_error',
+    },
+  }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function continuationBody(stream = false): any {
+  return {
+    model: 'client-alias',
+    stream,
+    max_tokens: 64,
+    thinking: { type: 'adaptive' },
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'inspect the repository' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: '', signature: 'opaque-signature' },
+          { type: 'redacted_thinking', data: 'opaque-redacted-payload' },
+          { type: 'text', text: 'I will read the file.' },
+          { type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: 'README.md' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'contents' }],
+      },
+    ],
+  }
+}
+
+function requestBody(fetchMock: any, index: number): any {
+  const init = fetchMock.mock.calls[index]?.[1] as RequestInit | undefined
+  return JSON.parse(String(init?.body))
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('Claude Code custom Anthropic continuation compatibility', () => {
+  it('retries a custom provider invalid encrypted-content response without opaque thinking history', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'custom:compat-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'upstream-key',
+      apiMode: 'anthropic_messages',
+    })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(encryptedContentError())
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 'msg_retry_ok',
+        type: 'message',
+        role: 'assistant',
+        model: 'review-model',
+        content: [{ type: 'text', text: 'continued' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 1 },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const originalBody = continuationBody()
+    originalBody.messages.push({ role: 'user', content: 'preserve string content' })
+    const originalSnapshot = structuredClone(originalBody)
+    const ctx = makeProxyContext(target.routeKey, target.token, originalBody)
+    await claudeProxyMessages(ctx)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(originalBody).toEqual(originalSnapshot)
+    const firstBody = requestBody(fetchMock, 0)
+    const retryBody = requestBody(fetchMock, 1)
+    expect(firstBody).toEqual({ ...originalSnapshot, model: 'review-model' })
+    expect(firstBody.messages[1].content.map((block: any) => block.type)).toEqual([
+      'thinking', 'redacted_thinking', 'text', 'tool_use',
+    ])
+    expect(retryBody).toMatchObject({
+      model: 'review-model',
+      thinking: { type: 'adaptive' },
+    })
+    expect(retryBody.messages[1].content).toEqual([
+      { type: 'text', text: 'I will read the file.' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: 'README.md' } },
+    ])
+    expect(retryBody.messages[2].content).toEqual([
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'contents' },
+    ])
+    expect(ctx.body.content).toEqual([{ type: 'text', text: 'continued' }])
+  })
+
+  it('applies the same one-time compatibility retry to streaming continuations', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'custom:stream-compat-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'upstream-key',
+      apiMode: 'anthropic_messages',
+    })
+    const encoder = new TextEncoder()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(encryptedContentError())
+      .mockResolvedValueOnce(new Response(new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_stream_retry","type":"message","role":"assistant","model":"review-model","content":[],"usage":{"input_tokens":10,"output_tokens":0}}}\n\n'))
+          controller.enqueue(encoder.encode('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n'))
+          controller.enqueue(encoder.encode('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"continued"}}\n\n'))
+          controller.enqueue(encoder.encode('event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n'))
+          controller.enqueue(encoder.encode('event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n'))
+          controller.enqueue(encoder.encode('event: message_stop\ndata: {"type":"message_stop"}\n\n'))
+          controller.close()
+        },
+      }), { status: 200, headers: { 'Content-Type': 'text/event-stream' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, continuationBody(true))
+    await claudeProxyMessages(ctx)
+    const chunks: string[] = []
+    for await (const chunk of ctx.body) chunks.push(Buffer.from(chunk).toString('utf8'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const retryBody = requestBody(fetchMock, 1)
+    expect(retryBody.messages[1].content.map((block: any) => block.type)).toEqual(['text', 'tool_use'])
+    expect(chunks.join('')).toContain('continued')
+  })
+
+  it('retries an exact encrypted-content message when the provider omits the error code', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'custom:message-only-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'upstream-key',
+      apiMode: 'anthropic_messages',
+    })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(encryptedContentError({
+        code: null,
+        message: 'The encrypted content opaque-value could not be verified. Reason: Encrypted content could not be decrypted or parsed.',
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 'msg_message_retry_ok',
+        type: 'message',
+        role: 'assistant',
+        model: 'review-model',
+        content: [{ type: 'text', text: 'continued' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 1 },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, continuationBody())
+    await claudeProxyMessages(ctx)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(ctx.body.content).toEqual([{ type: 'text', text: 'continued' }])
+  })
+
+  it('does not retry a near-match encrypted-content message', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'custom:near-match-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'upstream-key',
+      apiMode: 'anthropic_messages',
+    })
+    const fetchMock = vi.fn(async () => encryptedContentError({
+      code: null,
+      message: 'prefix: Encrypted content could not be decrypted or parsed. Please change the request.',
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, continuationBody())
+    await claudeProxyMessages(ctx)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(ctx.status).toBe(400)
+  })
+
+  it('retries at most once and preserves the second provider error', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'custom:retry-once-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'upstream-key',
+      apiMode: 'anthropic_messages',
+    })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(encryptedContentError())
+      .mockResolvedValueOnce(encryptedContentError({ message: 'The encrypted content could not be verified.' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, continuationBody())
+    await claudeProxyMessages(ctx)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(ctx.status).toBe(400)
+    expect(ctx.body.error.provider_error.error.message).toBe('The encrypted content could not be verified.')
+  })
+
+  it('does not retry when no opaque thinking block can be removed safely', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'custom:no-opaque-history-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'upstream-key',
+      apiMode: 'anthropic_messages',
+    })
+    const body = continuationBody()
+    body.messages[1].content = body.messages[1].content.filter((block: any) => !['thinking', 'redacted_thinking'].includes(block.type))
+    const fetchMock = vi.fn(async () => encryptedContentError())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, body)
+    await claudeProxyMessages(ctx)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(ctx.status).toBe(400)
+  })
+
+  it('does not retry when removing opaque blocks would leave an empty message', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'custom:empty-message-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'upstream-key',
+      apiMode: 'anthropic_messages',
+    })
+    const body = continuationBody()
+    body.messages[1].content = [{ type: 'thinking', thinking: '', signature: 'opaque-signature' }]
+    const fetchMock = vi.fn(async () => encryptedContentError())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, body)
+    await claudeProxyMessages(ctx)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(ctx.status).toBe(400)
+  })
+
+  it('does not retry matching messages with a non-400 status or a transport exception', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'custom:status-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'upstream-key',
+      apiMode: 'anthropic_messages',
+    })
+    const statusFetch = vi.fn(async () => encryptedContentError({ status: 422 }))
+    vi.stubGlobal('fetch', statusFetch)
+    const statusCtx = makeProxyContext(target.routeKey, target.token, continuationBody())
+    await claudeProxyMessages(statusCtx)
+    expect(statusFetch).toHaveBeenCalledTimes(1)
+    expect(statusCtx.status).toBe(422)
+
+    const transportFetch = vi.fn(async () => { throw new Error('socket closed') })
+    vi.stubGlobal('fetch', transportFetch)
+    const transportCtx = makeProxyContext(target.routeKey, target.token, continuationBody())
+    await claudeProxyMessages(transportCtx)
+    expect(transportFetch).toHaveBeenCalledTimes(1)
+    expect(transportCtx.status).toBe(502)
+  })
+
+  it('does not alter or retry official Anthropic provider failures', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      baseUrl: 'https://api.anthropic.com',
+      apiKey: 'upstream-key',
+      apiMode: 'anthropic_messages',
+    })
+    const fetchMock = vi.fn(async () => encryptedContentError())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const body = continuationBody()
+    const ctx = makeProxyContext(target.routeKey, target.token, body)
+    await claudeProxyMessages(ctx)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(requestBody(fetchMock, 0).messages[1].content).toEqual(body.messages[1].content)
+    expect(ctx.status).toBe(400)
+    expect(ctx.body.error.provider_error.error.code).toBe('invalid_encrypted_content')
+  })
+
+  it('does not retry unrelated custom-provider bad requests', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'custom:strict-provider',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'upstream-key',
+      apiMode: 'anthropic_messages',
+    })
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      error: { message: 'max_tokens is invalid', code: 'invalid_request_error' },
+    }), { status: 400, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, continuationBody())
+    await claudeProxyMessages(ctx)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(ctx.status).toBe(400)
+    expect(ctx.body.error.provider_error.error.code).toBe('invalid_request_error')
+  })
+})

--- a/tests/server/coding-agent-resume-config.test.ts
+++ b/tests/server/coding-agent-resume-config.test.ts
@@ -195,7 +195,7 @@ describe('coding agent resumed session config', () => {
 
     const config = readFileSync(join(home, 'coding-agent', 'model', 'default', 'deepseek', 'codex', 'config.toml'), 'utf-8')
     const routeKey = config.match(/\/api\/codex-proxy\/([^/]+)\/v1/)?.[1] || ''
-    const routeParts = Buffer.from(routeKey, 'base64url').toString('utf8').split('\0')
+    const routeParts = JSON.parse(Buffer.from(routeKey, 'base64url').toString('utf8'))
     expect(routeParts).toEqual(expect.arrayContaining([
       'deepseek',
       'deepseek-v4-pro',

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -517,6 +517,81 @@ describe('coding agent launch preparation', () => {
     expect(settings.env.ANTHROPIC_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/api\/claude-code-proxy\/.+$/)
   })
 
+  it('keeps canonical custom provider identity behind filesystem-safe Claude config paths', async () => {
+    const home = makeHome()
+    const provider = 'custom:compat-provider'
+    const result = await prepareCodingAgentLaunch('claude-code', {
+      profile: 'default',
+      provider,
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'provider-key',
+      apiMode: 'anthropic_messages',
+    })
+
+    expect(result.provider).toBe(provider)
+    expect(result.rootDir).toBe(join(home, 'coding-agent', 'model', 'default', 'custom_compat-provider', 'claude-code'))
+    const settings = JSON.parse(readFileSync(join(result.rootDir, 'settings.json'), 'utf-8'))
+    const proxyUrl = new URL(settings.env.ANTHROPIC_BASE_URL)
+    const routeKey = proxyUrl.pathname.split('/').filter(Boolean).at(-1) || ''
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        type: 'api_error',
+        request_id: '',
+        error: {
+          type: 'api_error',
+          message: 'The encrypted content opaque-value could not be verified. Reason: Encrypted content could not be decrypted or parsed.',
+        },
+      }), { status: 400, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 'msg_retry_ok',
+        type: 'message',
+        role: 'assistant',
+        model: 'review-model',
+        content: [{ type: 'text', text: 'continued' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 1 },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const body = {
+      model: 'client-alias',
+      max_tokens: 64,
+      thinking: { type: 'adaptive' },
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'inspect the repository' }] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: '', signature: 'opaque-signature' },
+            { type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: 'README.md' } },
+          ],
+        },
+        { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'contents' }] },
+      ],
+    }
+    const ctx = makeProxyContext(routeKey, settings.env.ANTHROPIC_API_KEY, body)
+    await claudeProxyMessages(ctx)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(ctx.body.content).toEqual([{ type: 'text', text: 'continued' }])
+    const retryBody = JSON.parse(String((fetchMock.mock.calls[1]?.[1] as RequestInit | undefined)?.body))
+    expect(retryBody.messages[1].content.map((block: any) => block.type)).toEqual(['tool_use'])
+  })
+
+  it('rejects control characters in canonical provider identities before proxy registration', async () => {
+    makeHome()
+
+    await expect(prepareCodingAgentLaunch('claude-code', {
+      profile: 'default',
+      provider: 'custom:x\0y',
+      model: 'review-model',
+      baseUrl: 'https://provider.example',
+      apiKey: 'provider-key',
+      apiMode: 'anthropic_messages',
+    })).rejects.toThrow('Invalid provider')
+  })
+
   it('keeps Codex model selection on the CLI while isolating CODEX_HOME', async () => {
     const home = makeHome()
 


### PR DESCRIPTION
## Summary

- keep the first scoped Claude Code `anthropic_messages` request unchanged
- when a `custom:*` provider returns HTTP 400 with the exact `invalid_encrypted_content` error, retry once after removing only historical `thinking` and `redacted_thinking` blocks
- preserve text, `tool_use`, `tool_result`, message order, the current request's top-level thinking configuration, and the original request object
- leave official Anthropic targets, unrelated errors, non-400 responses, and requests that cannot be sanitized safely unchanged

## Why this is narrow

The compatibility path is error-triggered rather than proactive. Providers that accept opaque thinking replay continue to receive the original request. The fallback is entered only for the observed encrypted-content rejection, is limited to one retry, and fails closed if removing the opaque blocks would leave an empty structured message.

## Tests

- new compatibility suite: 10/10
  - streaming and non-streaming recovery
  - exact code and exact message matching
  - near-match rejection
  - one retry maximum and second-error propagation
  - no removable history / empty-message fail-closed behavior
  - non-400 and transport failure boundaries
  - official Anthropic and unrelated custom-provider non-regression
  - first-request equality and source-object immutability
- Coding Agent / proxy / Workflow suites: 305/305
- server and client TypeScript checks: pass
- `npm run harness:check`: pass
- `npm run build`: pass
- full Vitest comparison against detached `upstream/main`: 10 new passing tests, zero new failures

Closes #2157
