### PR TITLE
Add Hermes interim messages and single-chat background tasks

### DIFF
--- a/docs/chat-chain-changes/2026-07-20-hermes-interim-assistant-messages.md
+++ b/docs/chat-chain-changes/2026-07-20-hermes-interim-assistant-messages.md
@@ -1,0 +1,10 @@
+---
+date: 2026-07-20
+pr: pending
+feature: Hermes interim assistant messages
+impact: Hermes 0.19 mid-turn commentary is preserved as authoritative, independently persisted assistant messages without duplicating streamed text.
+---
+
+The Agent Bridge forwards `message.interim` with its `already_streamed` marker.
+The server reconciles the authoritative text with any streamed prefix before
+sealing the message, and clients start a new assistant bubble for later output.

--- a/docs/chat-chain-changes/2026-07-20-hermes-interim-assistant-messages.md
+++ b/docs/chat-chain-changes/2026-07-20-hermes-interim-assistant-messages.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-07-20
-pr: pending
+pr: 2160
 feature: Hermes interim assistant messages
 impact: Hermes 0.19 mid-turn commentary is preserved as authoritative, independently persisted assistant messages without duplicating streamed text.
 ---

--- a/docs/chat-chain-changes/2026-07-21-single-chat-background-delegation.md
+++ b/docs/chat-chain-changes/2026-07-21-single-chat-background-delegation.md
@@ -1,0 +1,15 @@
+---
+date: 2026-07-21
+pr: 2160
+feature: Single-chat background delegation and authoritative terminal output
+impact: Ordinary Hermes chats can deliver background tasks after the parent turn, while terminal responses retain authoritative interim assistant text.
+---
+
+Ordinary single-chat Hermes Agent sessions now enable background delegation at
+creation. Group-chat agents and Hermes workflow-node agents continue to pass an
+explicit disabled policy, so their behavior is unchanged.
+
+Completed runs now prefer the server's reconciled output over the Bridge's raw
+delta snapshot. This preserves interim callback corrections and callback-only
+assistant commentary in the terminal response consumed by HTTP and relay
+callers.

--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -54,6 +54,8 @@ export interface RunEvent {
   delta?: string
   /** Payload text for `reasoning.delta` / `thinking.delta` / `reasoning.available` events. */
   text?: string
+  /** Whether a `message.interim` payload was already delivered by message.delta. */
+  already_streamed?: boolean
   /** MoA reference metadata forwarded as display-only reasoning. */
   label?: string
   index?: number
@@ -172,6 +174,7 @@ const TRANSIENT_DISCONNECT_REASONS = new Set<string>([
  */
 const sessionEventHandlers = new Map<string, {
   onMessageDelta: (event: RunEvent) => void
+  onMessageInterim: (event: RunEvent) => void
   onReasoningDelta: (event: RunEvent) => void
   onThinkingDelta: (event: RunEvent) => void
   onReasoningAvailable: (event: RunEvent) => void
@@ -217,6 +220,13 @@ function globalMessageDeltaHandler(event: RunEvent): void {
   if (handlers?.onMessageDelta) {
     handlers.onMessageDelta(event)
   }
+}
+
+function globalMessageInterimHandler(event: RunEvent): void {
+  const sid = event.session_id
+  if (!sid) return
+
+  sessionEventHandlers.get(sid)?.onMessageInterim(event)
 }
 
 /**
@@ -573,6 +583,7 @@ export function registerSessionHandlers(
   sessionId: string,
   handlers: {
     onMessageDelta: (event: RunEvent) => void
+    onMessageInterim: (event: RunEvent) => void
     onReasoningDelta: (event: RunEvent) => void
     onThinkingDelta: (event: RunEvent) => void
     onReasoningAvailable: (event: RunEvent) => void
@@ -731,6 +742,7 @@ export function connectChatRun(requestedProfile?: string | null, transport: Chat
   if (!globalListenersRegistered) {
     // Message events
     chatRunSocket.on('message.delta', globalMessageDeltaHandler)
+    chatRunSocket.on('message.interim', globalMessageInterimHandler)
     chatRunSocket.on('reasoning.delta', globalReasoningDeltaHandler)
     chatRunSocket.on('thinking.delta', globalThinkingDeltaHandler)
     chatRunSocket.on('reasoning.available', globalReasoningAvailableHandler)
@@ -923,6 +935,10 @@ export function startRunViaSocket(
   // Define event handlers for this session
   const handlers = {
     onMessageDelta: (evt: RunEvent) => {
+      if (closed) return
+      onEvent(evt)
+    },
+    onMessageInterim: (evt: RunEvent) => {
       if (closed) return
       onEvent(evt)
     },

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -3322,6 +3322,33 @@ export const useChatStore = defineStore('chat', () => {
               break
             }
 
+            case 'message.interim': {
+              const text = String(evt.text || '')
+              if (!text.trim()) break
+              runProducedAssistantText = true
+              runProducedAssistantContent = true
+              const msgs = getSessionMsgs(sid)
+              const active = activeAssistantMessageId
+                ? msgs.find(m => m.id === activeAssistantMessageId)
+                : null
+              if (active?.role === 'assistant') {
+                active.content = text
+                active.isStreaming = false
+                if (active.reasoning) noteReasoningEnd(active.id)
+              } else {
+                addMessage(sid, {
+                  id: uid(),
+                  role: 'assistant',
+                  content: text,
+                  timestamp: Date.now(),
+                  isStreaming: false,
+                })
+              }
+              activeAssistantMessageId = null
+
+              break
+            }
+
             case 'session.title.updated': {
               applyGeneratedSessionTitle(evt)
               break
@@ -3956,6 +3983,33 @@ export const useChatStore = defineStore('chat', () => {
           break
         }
 
+        case 'message.interim': {
+          const text = String(evt.text || '')
+          if (!text.trim()) break
+          runProducedAssistantText = true
+          runProducedAssistantContent = true
+          const msgs = getSessionMsgs(sid)
+          const active = activeAssistantMessageId
+            ? msgs.find(m => m.id === activeAssistantMessageId)
+            : null
+          if (active?.role === 'assistant') {
+            active.content = text
+            active.isStreaming = false
+            if (active.reasoning) noteReasoningEnd(active.id)
+          } else {
+            addMessage(sid, {
+              id: uid(),
+              role: 'assistant',
+              content: text,
+              timestamp: Date.now(),
+              isStreaming: false,
+            })
+          }
+          activeAssistantMessageId = null
+
+          break
+        }
+
         case 'session.title.updated': {
           applyGeneratedSessionTitle(evt)
           break
@@ -4249,6 +4303,7 @@ export const useChatStore = defineStore('chat', () => {
     // Register handlers in global session map
     registerSessionHandlers(sid, {
       onMessageDelta: (evt) => handleEvent(evt),
+      onMessageInterim: (evt) => handleEvent(evt),
       onReasoningDelta: (evt) => handleEvent(evt),
       onThinkingDelta: (evt) => handleEvent(evt),
       onReasoningAvailable: (evt) => handleEvent(evt),

--- a/packages/server/src/controllers/chat-run.ts
+++ b/packages/server/src/controllers/chat-run.ts
@@ -25,6 +25,7 @@ type ChatRunEvent = Record<string, unknown> & {
 const CHAT_RUN_EVENTS = [
   'run.started',
   'message.delta',
+  'message.interim',
   'reasoning.delta',
   'thinking.delta',
   'reasoning.available',

--- a/packages/server/src/services/global-agent/outbound-relay-client.ts
+++ b/packages/server/src/services/global-agent/outbound-relay-client.ts
@@ -47,6 +47,7 @@ const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
 const CHAT_RUN_SERVER_EVENTS = [
   'run.started',
   'message.delta',
+  'message.interim',
   'reasoning.delta',
   'thinking.delta',
   'reasoning.available',
@@ -76,6 +77,7 @@ const CHAT_RUN_SERVER_EVENTS = [
 ]
 const NON_STREAMING_SUPPRESSED_EVENTS = new Set([
   'message.delta',
+  'message.interim',
   'reasoning.delta',
   'thinking.delta',
   'reasoning.available',

--- a/packages/server/src/services/global-agent/server.ts
+++ b/packages/server/src/services/global-agent/server.ts
@@ -62,6 +62,7 @@ const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
 const CHAT_RUN_SERVER_EVENTS = [
   'run.started',
   'message.delta',
+  'message.interim',
   'reasoning.delta',
   'thinking.delta',
   'reasoning.available',
@@ -91,6 +92,7 @@ const CHAT_RUN_SERVER_EVENTS = [
 ]
 const NON_STREAMING_SUPPRESSED_EVENTS = new Set([
   'message.delta',
+  'message.interim',
   'reasoning.delta',
   'thinking.delta',
   'reasoning.available',

--- a/packages/server/src/services/hermes/agent-bridge/README.md
+++ b/packages/server/src/services/hermes/agent-bridge/README.md
@@ -123,11 +123,11 @@ path. Hermes currently exposes this as its session-level async-delivery
 capability, so other detached-completion tools in that AgentSession also see it
 disabled.
 
-Hermes Web UI currently creates ordinary single-chat agents with this value set
-to `false`. Group-chat agents and Hermes workflow-node agents also set it to
-`false` at their own call sites and are intentionally kept disabled even if
-single chat is enabled in the future. Coding Agent and Ekko Agent calls do not
-receive this Hermes Bridge field.
+Hermes Web UI creates ordinary single-chat agents with this value set to
+`true`, enabling background task delivery by default. Group-chat agents and
+Hermes workflow-node agents set it to `false` at their own call sites and remain
+intentionally disabled. Coding Agent and Ekko Agent calls do not receive this
+Hermes Bridge field.
 
 The bridge instantiates `AIAgent` with `platform="cli"` by default so behavior
 matches CLI chat. Override it only if a caller intentionally needs a distinct

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -324,6 +324,7 @@ class AgentPool:
                     thinking_callback=self._make_thinking_callback(session_id),
                     reasoning_callback=self._text_event_callback(session_id, "reasoning.delta"),
                     stream_delta_callback=self._stream_delta_callback(session_id),
+                    interim_assistant_callback=self._interim_assistant_callback(session_id),
                     tool_progress_callback=self._tool_progress_callback(session_id),
                     tool_start_callback=self._tool_start_callback(session_id),
                     tool_complete_callback=self._tool_complete_callback(session_id),
@@ -1166,6 +1167,19 @@ class AgentPool:
             # Text deltas are already captured by the per-run stream_callback
             # passed to run_conversation.  Only consume boundary signals here
             # so registering this callback does not duplicate assistant text.
+
+        return callback
+
+    def _interim_assistant_callback(self, session_id: str):
+        def callback(text, *, already_streamed=False):
+            value = str(text or "")
+            if not value.strip():
+                return
+            self._append_event(session_id, {
+                "event": "message.interim",
+                "text": value,
+                "already_streamed": bool(already_streamed),
+            })
 
         return callback
 

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -261,6 +261,44 @@ function processBridgeTextDelta(
   })
 }
 
+function processBridgeInterimMessage(
+  state: SessionState,
+  sessionId: string,
+  runMarker: string,
+  runId: string,
+  text: string,
+  alreadyStreamed: boolean,
+  emit: (event: string, payload: any) => void,
+): void {
+  if (!text.trim()) return
+
+  // Hermes treats the interim payload as authoritative. A provider may have
+  // streamed only a prefix, or may have delivered commentary solely through
+  // this callback, so replace the current segment instead of appending text.
+  const message = ensureOpenBridgeAssistantMessage(state, sessionId, runMarker)
+  const previous = message.content || state.bridgePendingAssistantContent || ''
+  const output = state.bridgeOutput || ''
+  if (previous && output.endsWith(previous)) {
+    state.bridgeOutput = output.slice(0, -previous.length) + text
+  } else if (!previous) {
+    state.bridgeOutput = output + text
+  } else if (!output.endsWith(text)) {
+    state.bridgeOutput = output + text
+  }
+  state.bridgePendingAssistantContent = text
+  message.content = text
+  syncBridgeReasoningToMessage(message, state.bridgePendingReasoningContent)
+  flushBridgePendingToDb(state, sessionId, runMarker)
+
+  emit('message.interim', {
+    event: 'message.interim',
+    run_id: runId,
+    text,
+    already_streamed: alreadyStreamed,
+    output: state.bridgeOutput,
+  })
+}
+
 function finiteToken(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0
     ? Math.floor(value)
@@ -1114,7 +1152,20 @@ async function applyBridgeChunkAsync(
       processBridgeTextDelta(state, sessionId, runMarker, chunk.run_id, String((ev as any).delta || ''), emit)
       continue
     }
-    if (evType === 'model.usage') {
+    if (evType === 'message.interim') {
+      // Release any partial markup prefix before replacing the segment with
+      // Hermes' authoritative interim text, then seal it as its own message.
+      flushPendingToolMarkupToAssistant(state, runMarker, chunk.run_id, emit)
+      processBridgeInterimMessage(
+        state,
+        sessionId,
+        runMarker,
+        chunk.run_id,
+        String((ev as any).text || ''),
+        Boolean((ev as any).already_streamed),
+        emit,
+      )
+    } else if (evType === 'model.usage') {
       recordBridgeModelUsage(sessionId, chunk.run_id, ev, profile, modelContext)
     } else if (evType === 'session.title.updated') {
       syncBridgeGeneratedTitle(sessionId, (ev as any).title, emit)

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -407,10 +407,10 @@ export async function handleBridgeRun(
 ) {
   const { input, session_id, instructions } = data
   const runSource = normalizeBridgeRunSource(data.source, data.session_source)
-  // Web UI Hermes agents currently opt out at creation time. Workflow callers
-  // also pass false explicitly; a future single-chat setting can opt in with true
-  // without changing the permanently-disabled workflow and group-chat callers.
-  const backgroundDelegationEnabled = data.background_delegation_enabled === true
+  // Ordinary single-chat Hermes agents enable background delegation by default.
+  // Workflow and group-chat callers pass false explicitly at their own creation
+  // boundaries and remain disabled independently of this default.
+  const backgroundDelegationEnabled = data.background_delegation_enabled !== false
   if (!session_id) {
     socket.emit('run.failed', { event: 'run.failed', error: 'session_id is required for cli source' })
     return
@@ -1726,7 +1726,10 @@ function bridgeFinalResponse(chunk: AgentBridgeOutput, state: SessionState, useR
   const finalResponse = result && typeof result.final_response === 'string'
     ? result.final_response
     : ''
-  const streamedResponse = chunk.output || state.bridgeOutput || ''
+  // The reconciled state includes authoritative interim callbacks and filtered
+  // deltas. The bridge output is only the raw delta snapshot, so use it as a
+  // fallback when no reconciled output was produced locally.
+  const streamedResponse = state.bridgeOutput || chunk.output || ''
   return useResultFinalResponse ? finalResponse || streamedResponse : streamedResponse
 }
 

--- a/tests/client/chat-run-reconnect.test.ts
+++ b/tests/client/chat-run-reconnect.test.ts
@@ -119,6 +119,18 @@ describe('chat-run socket reconnect handling', () => {
 
     socket.__trigger('message.delta', { event: 'message.delta', session_id: 'session-1', delta: 'after reconnect' })
     expect(onEvent).toHaveBeenCalledWith({ event: 'message.delta', session_id: 'session-1', delta: 'after reconnect' })
+    socket.__trigger('message.interim', {
+      event: 'message.interim',
+      session_id: 'session-1',
+      text: 'after reconnect',
+      already_streamed: true,
+    })
+    expect(onEvent).toHaveBeenCalledWith({
+      event: 'message.interim',
+      session_id: 'session-1',
+      text: 'after reconnect',
+      already_streamed: true,
+    })
     expect(onDone).not.toHaveBeenCalled()
   })
 

--- a/tests/client/chat-store-reasoning-tool-boundary.test.ts
+++ b/tests/client/chat-store-reasoning-tool-boundary.test.ts
@@ -137,6 +137,39 @@ describe('chat store reasoning/tool boundaries', () => {
     }))
   })
 
+  it('uses interim assistant text as authoritative and seals each segment', async () => {
+    const store = useChatStore()
+    const session = makeSession()
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    await store.sendMessage('verify the result')
+
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: RunEvent) => void
+    onEvent({ event: 'run.started', session_id: 'session-1' })
+    onEvent({ event: 'message.delta', session_id: 'session-1', delta: 'partial' })
+    onEvent({
+      event: 'message.interim',
+      session_id: 'session-1',
+      text: 'partial answer',
+      already_streamed: true,
+    })
+    onEvent({
+      event: 'message.interim',
+      session_id: 'session-1',
+      text: 'callback-only commentary',
+      already_streamed: false,
+    })
+    onEvent({ event: 'message.delta', session_id: 'session-1', delta: 'final answer' })
+
+    expect(store.messages.filter(message => message.role === 'assistant')).toEqual([
+      expect.objectContaining({ content: 'partial answer', isStreaming: false }),
+      expect.objectContaining({ content: 'callback-only commentary', isStreaming: false }),
+      expect.objectContaining({ content: 'final answer', isStreaming: true }),
+    ])
+  })
+
   it('renders MoA reference and aggregating events as tools before the final assistant message', async () => {
     const store = useChatStore()
     const session = makeSession()

--- a/tests/server/agent-bridge-profile-env.test.ts
+++ b/tests/server/agent-bridge-profile-env.test.ts
@@ -544,6 +544,7 @@ class FakeAgent:
     def __init__(self, **kwargs):
         self.tools = []
         self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
 
     def run_conversation(self, message, **kwargs):
         stream_callback = kwargs.get("stream_callback")
@@ -552,6 +553,9 @@ class FakeAgent:
         if self.stream_delta_callback:
             self.stream_delta_callback("ignored-duplicate-text")
             self.stream_delta_callback(None)
+        if self.interim_assistant_callback:
+            self.interim_assistant_callback("hello", already_streamed=True)
+            self.interim_assistant_callback("callback-only", already_streamed=False)
         return {
             "final_response": "hello",
             "messages": [
@@ -595,6 +599,8 @@ print(json.dumps({
     expect(result.events).toEqual(expect.arrayContaining([
       expect.objectContaining({ event: 'stream.delta', delta: 'hello' }),
       expect.objectContaining({ event: 'turn.boundary' }),
+      expect.objectContaining({ event: 'message.interim', text: 'hello', already_streamed: true }),
+      expect.objectContaining({ event: 'message.interim', text: 'callback-only', already_streamed: false }),
     ]))
     expect(result.events).not.toEqual(expect.arrayContaining([
       expect.objectContaining({ event: 'stream.delta', delta: 'ignored-duplicate-text' }),

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -416,6 +416,86 @@ describe('bridge run final context usage', () => {
     )
   })
 
+  it('seals authoritative interim assistant messages without duplicating streamed text', async () => {
+    const emit = vi.fn()
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    const state = makeState()
+    flushBridgePendingToDbMock.mockImplementation((targetState: any, _sessionId: string, runMarker: string) => {
+      const message = [...targetState.messages].reverse().find((candidate: any) => (
+        candidate.runMarker === runMarker
+        && candidate.role === 'assistant'
+        && candidate.finish_reason == null
+      ))
+      if (message && String(targetState.bridgePendingAssistantContent || '').trim()) {
+        message.finish_reason = 'stop'
+      }
+      targetState.bridgePendingAssistantContent = ''
+      targetState.bridgePendingReasoningContent = ''
+    })
+    const sessionMap = new Map([['session-1', state]])
+    const bridge = {
+      chat: vi.fn().mockResolvedValue({ run_id: 'run-1', status: 'started' }),
+      contextEstimate: vi.fn().mockResolvedValue({
+        token_count: 12345,
+        fixed_context_tokens: 12327,
+        message_count: 2,
+        tool_count: 4,
+        system_prompt_chars: 13,
+      }),
+      streamOutput: vi.fn(async function* () {
+        yield {
+          run_id: 'run-1',
+          done: false,
+          status: 'running',
+          events: [
+            { event: 'stream.delta', delta: 'partial' },
+            { event: 'message.interim', text: 'partial answer', already_streamed: true },
+            { event: 'message.interim', text: 'callback-only commentary', already_streamed: false },
+          ],
+        }
+        yield {
+          run_id: 'run-1',
+          done: true,
+          status: 'completed',
+          events: [{ event: 'stream.delta', delta: 'final answer' }],
+        }
+      }),
+    } as any
+
+    const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    await handleBridgeRun(
+      nsp,
+      socket,
+      { input: 'hello', session_id: 'session-1' },
+      'default',
+      sessionMap,
+      bridge,
+      false,
+      vi.fn(),
+      vi.fn(),
+    )
+
+    expect(state.messages.filter((message: any) => message.role === 'assistant').map((message: any) => message.content)).toEqual([
+      'partial answer',
+      'callback-only commentary',
+      'final answer',
+    ])
+    expect(state.bridgeOutput).toBe('partial answercallback-only commentaryfinal answer')
+    expect(emit.mock.calls.filter(([event]) => event === 'message.delta')).toEqual([
+      ['message.delta', expect.objectContaining({ delta: 'partial' })],
+      ['message.delta', expect.objectContaining({ delta: 'final answer' })],
+    ])
+    expect(emit).toHaveBeenCalledWith('message.interim', expect.objectContaining({
+      text: 'partial answer',
+      already_streamed: true,
+    }))
+    expect(emit).toHaveBeenCalledWith('message.interim', expect.objectContaining({
+      text: 'callback-only commentary',
+      already_streamed: false,
+    }))
+  })
+
   it('uses result.final_response for moa and records only its exact model-call event', async () => {
     resolveBridgeRunModelConfigMock.mockResolvedValueOnce({ model: 'default', provider: 'moa' })
     const emit = vi.fn()

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -318,7 +318,7 @@ describe('bridge run final context usage', () => {
       expect.any(Array),
       expect.any(String),
       'default',
-      expect.objectContaining({ background_delegation_enabled: false }),
+      expect.objectContaining({ background_delegation_enabled: true }),
     )
     expect(bridge.contextEstimate.mock.calls[0][2]).toContain('system prompt')
     expect(bridge.contextEstimate.mock.calls[0][2]).toContain('X-Hermes-Profile')
@@ -458,6 +458,7 @@ describe('bridge run final context usage', () => {
           run_id: 'run-1',
           done: true,
           status: 'completed',
+          output: 'partialfinal answer',
           events: [{ event: 'stream.delta', delta: 'final answer' }],
         }
       }),
@@ -493,6 +494,9 @@ describe('bridge run final context usage', () => {
     expect(emit).toHaveBeenCalledWith('message.interim', expect.objectContaining({
       text: 'callback-only commentary',
       already_streamed: false,
+    }))
+    expect(emit).toHaveBeenCalledWith('run.completed', expect.objectContaining({
+      output: 'partial answercallback-only commentaryfinal answer',
     }))
   })
 


### PR DESCRIPTION
## Summary

- wire Hermes 0.19 `interim_assistant_callback` through the Python Agent Bridge
- treat `message.interim.text` as authoritative, reconcile partial streaming, and persist each interim segment independently
- prefer the server's reconciled assistant output over the Bridge's raw delta snapshot at run completion
- forward interim lifecycle events through chat-run, Global Agent, relay, HTTP API, and the client socket layer
- seal interim assistant bubbles in the client so later output starts a new message
- enable background delegation for ordinary Hermes single-chat AgentSessions while keeping group chat and workflow agents disabled
- add bridge, server lifecycle, client store, reconnect, relay, and background-policy regression coverage

## Why

Hermes 0.19 can emit real mid-turn assistant commentary and verification candidates outside the ordinary token stream. Without this callback, callback-only commentary is lost; when only a prefix was streamed, naïvely appending the interim payload duplicates text. The terminal Bridge snapshot also contains only raw streamed deltas, so preferring it over reconciled state discards authoritative interim corrections.

Ordinary single-chat sessions previously forced `background_delegation_enabled=false`, preventing `delegate_task(mode="background")` from using Hermes' asynchronous delivery path even though the Web UI already supports durable background completion delivery.

## Impact

Mid-turn narration and verification candidates remain visible and stored as distinct assistant messages, including for HTTP and relay consumers of the terminal response. Ordinary Hermes single-chat agents can launch asynchronous background sub-tasks and receive their completion later. Group-chat agents and Hermes workflow-node agents remain explicitly synchronous.

## Validation

- focused Vitest suite covering bridge final context, workflow, group chat, HTTP, Global Agent, relay, and background policy: 209 passed
- `npm run test:e2e -- tests/e2e/chat-streaming.spec.ts`: 13 passed
- `npm run harness:check`
- `npm run build`
