### PR TITLE
fix MiniMax MCP tool name limit

### DIFF
--- a/bin/hermes-studio-mcp.mjs
+++ b/bin/hermes-studio-mcp.mjs
@@ -1272,7 +1272,7 @@ const tools = [
       }, ['workflow_id', 'run_id']),
   },
   {
-    name: 'hermes_studio_use_workflow_run_rerun_from_node',
+    name: 'hermes_studio_use_workflow_rerun_node',
     toolset: 'use',
     description: 'Rerun an existing workflow run from a node. Use preserve_start_node=true to keep the selected node message and only rerun downstream nodes; false clears the selected node and downstream sessions.',
     inputSchema: inputSchema({
@@ -1440,6 +1440,7 @@ const tools = [
 const TOOL_ALIASES = new Map([
   ['hermes_api_openapi_get', 'hermes_studio_api_openapi_get'],
   ['hermes_api_request', 'hermes_studio_api_request'],
+  ['hermes_studio_use_workflow_run_rerun_from_node', 'hermes_studio_use_workflow_rerun_node'],
   ['hermes_lan_devices_list', 'hermes_studio_lan_devices_list'],
   ['hermes_lan_devices_scan', 'hermes_studio_lan_devices_scan'],
   ['hermes_lan_peer_connect', 'hermes_studio_lan_peer_connect'],
@@ -1631,7 +1632,7 @@ async function callTool(name, args = {}) {
       return jsonText(await request(`/api/hermes/workflows/${encodeURIComponent(args.workflow_id)}/runs/${encodeURIComponent(args.run_id)}/stop`, withAuthArgs(args, {
         method: 'POST',
       })))
-    case 'hermes_studio_use_workflow_run_rerun_from_node':
+    case 'hermes_studio_use_workflow_rerun_node':
       return jsonText(await request(`/api/hermes/workflows/${encodeURIComponent(args.workflow_id)}/runs/${encodeURIComponent(args.run_id)}/rerun-from-node`, withAuthArgs(args, {
         method: 'POST',
         body: pickDefined(args, [

--- a/tests/server/hermes-web-ui-mcp.test.ts
+++ b/tests/server/hermes-web-ui-mcp.test.ts
@@ -27,6 +27,14 @@ function waitForRpc(responses: Map<number, any>, id: number): Promise<any> {
   })
 }
 
+function expectProviderSafeToolNames(serverName: string, tools: Array<{ name: string }>) {
+  const safeServerName = serverName.replace(/[^A-Za-z0-9_]/g, '_')
+  const overlongNames = tools
+    .map(tool => `mcp__${safeServerName}__${tool.name}`)
+    .filter(name => name.length > 64)
+  expect(overlongNames).toEqual([])
+}
+
 describe('hermes-web-ui MCP server', () => {
   let child: ChildProcessWithoutNullStreams | null = null
   const homes: string[] = []
@@ -195,6 +203,7 @@ describe('hermes-web-ui MCP server', () => {
     expect(initialized.result.capabilities).toEqual({ tools: {} })
 
     const list = await waitForRpc(responses, 2)
+    expectProviderSafeToolNames('hermes-studio-api', list.result.tools)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_api_request')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_lan_devices_list')).toBe(false)
 
@@ -644,6 +653,7 @@ describe('hermes-web-ui MCP server', () => {
     expect(initialized.result.serverInfo).toMatchObject({ toolset: 'use' })
 
     const list = await waitForRpc(responses, 2)
+    expectProviderSafeToolNames('hermes-studio-use', list.result.tools)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_chat_run')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_sessions_count')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_usage_stats')).toBe(true)
@@ -655,7 +665,8 @@ describe('hermes-web-ui MCP server', () => {
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_provider_delete')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_worker_status')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_workflows_list')).toBe(true)
-    expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_workflow_run_rerun_from_node')).toBe(true)
+    expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_workflow_rerun_node')).toBe(true)
+    expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_use_workflow_run_rerun_from_node')).toBe(false)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_api_request')).toBe(false)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_lan_devices_list')).toBe(false)
     expect(list.result.tools.find((tool: any) => tool.name === 'hermes_studio_use_chat_run')?.description).toContain('internal delegation')
@@ -834,6 +845,7 @@ describe('hermes-web-ui MCP server', () => {
     expect(initialized.result.serverInfo).toMatchObject({ toolset: 'devices' })
 
     const list = await waitForRpc(responses, 2)
+    expectProviderSafeToolNames('hermes-studio-devices', list.result.tools)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_lan_devices_list')).toBe(true)
     expect(list.result.tools.some((tool: any) => tool.name === 'hermes_studio_api_request')).toBe(false)
 


### PR DESCRIPTION
## Summary
- shorten the workflow rerun MCP tool name so its provider-qualified function name stays within 64 characters
- preserve the previous tool name as a callable compatibility alias without exposing it to providers
- enforce the 64-character provider limit across all bundled Hermes Studio MCP toolsets

## Root cause
Hermes prefixes MCP tools with the sanitized server name. The `hermes-studio-use` server combined with `hermes_studio_use_workflow_run_rerun_from_node` produced a 70-character function name, which MiniMax M2.7 rejects before streaming begins.

## User impact
MiniMax M2.7 users can chat normally with the bundled Hermes Studio MCP servers enabled. Existing direct callers of the old MCP tool name continue to work through the local alias, while providers only receive the shorter name.

Fixes #2166

## Validation
- `npx vitest run tests/server/hermes-web-ui-mcp.test.ts`
- `npm run harness:check`
- `npm run build`
- `node --check bin/hermes-studio-mcp.mjs`
