### PR TITLE
Support file attachments from paste and workspace

### DIFF
--- a/docs/chat-chain-changes/2026-07-22-issue-2165-file-input.md
+++ b/docs/chat-chain-changes/2026-07-22-issue-2165-file-input.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-07-22
-pr: pending
+pr: 2175
 feature: Clipboard and workspace file attachments
 impact: Single and group chats can attach non-image clipboard files and add workspace files to the active composer from the file context menu.
 ---

--- a/docs/chat-chain-changes/2026-07-22-issue-2165-file-input.md
+++ b/docs/chat-chain-changes/2026-07-22-issue-2165-file-input.md
@@ -1,0 +1,10 @@
+---
+date: 2026-07-22
+pr: pending
+feature: Clipboard and workspace file attachments
+impact: Single and group chats can attach non-image clipboard files and add workspace files to the active composer from the file context menu.
+---
+
+Clipboard files continue through the existing attachment upload and content-block
+pipeline. Workspace files are read through the existing authenticated session or
+room content endpoint and added to the composer without sending automatically.

--- a/packages/client/src/api/hermes/group-chat.ts
+++ b/packages/client/src/api/hermes/group-chat.ts
@@ -306,6 +306,14 @@ export async function fetchGroupWorkspaceFileBlob(roomId: string, path: string, 
     )
 }
 
+export async function fetchGroupWorkspaceAttachmentBlob(roomId: string, path: string, signal?: AbortSignal): Promise<Blob> {
+    const params = new URLSearchParams({ path, download: '1' })
+    return fetchAuthenticatedBlob(
+        `/api/hermes/group-chat/rooms/${encodeURIComponent(roomId)}/workspace-file/content?${params}`,
+        { signal },
+    )
+}
+
 export async function fetchGroupWorkspaceFileText(roomId: string, path: string): Promise<{ content: string; size: number }> {
     const params = new URLSearchParams({ path, text: '1' })
     const blob = await fetchAuthenticatedBlob(

--- a/packages/client/src/api/hermes/sessions.ts
+++ b/packages/client/src/api/hermes/sessions.ts
@@ -248,6 +248,18 @@ export async function fetchSessionWorkspaceFileBlob(
   )
 }
 
+export async function fetchSessionWorkspaceAttachmentBlob(
+  sessionId: string,
+  path: string,
+  signal?: AbortSignal,
+): Promise<Blob> {
+  const params = new URLSearchParams({ path, download: '1' })
+  return fetchAuthenticatedBlob(
+    `/api/hermes/sessions/${encodeURIComponent(sessionId)}/workspace-file/content?${params}`,
+    { signal },
+  )
+}
+
 export async function fetchSessionWorkspaceFileText(
   sessionId: string,
   path: string,

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -12,6 +12,7 @@ import { NButton, NTooltip, NModal, NInputNumber, NPopover, NSlider, NDropdown, 
 import { computed, ref, nextTick, onMounted, onUnmounted, watch, h } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useToolTraceVisibility } from '@/composables/useToolTraceVisibility'
+import { extractClipboardFiles } from '@/utils/clipboard-files'
 import VoiceDialogueControls from './VoiceDialogueControls.vue'
 import BundleCreateModal from './BundleCreateModal.vue'
 import { useMicRecorder } from '@/composables/useMicRecorder'
@@ -920,20 +921,13 @@ function handleFileChange(e: Event) {
   input.value = ''
 }
 
-// --- Paste image ---
+// --- Paste files ---
 
 function handlePaste(e: ClipboardEvent) {
-  const items = Array.from(e.clipboardData?.items || [])
-  const imageItems = items.filter(i => i.type.startsWith('image/'))
-  if (!imageItems.length) return
+  const files = extractClipboardFiles(e.clipboardData)
+  if (!files.length) return
   e.preventDefault()
-  for (const item of imageItems) {
-    const blob = item.getAsFile()
-    if (!blob) continue
-    const ext = item.type.split('/')[1] || 'png'
-    const file = new File([blob], `pasted-${Date.now()}.${ext}`, { type: item.type })
-    addFiles([file])
-  }
+  addFiles(files)
 }
 
 // --- Drag and drop ---

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -264,6 +264,10 @@ function handleChatDrop(event: DragEvent) {
   chatInputRef.value?.addFiles?.(files);
 }
 
+function handleWorkspaceFileAttach(file: File) {
+  chatInputRef.value?.addFiles?.([file]);
+}
+
 async function handleSessionClick(sessionId: string) {
   chatStore.clearSessionCompletedUnread(sessionId);
   await router.push({
@@ -2659,6 +2663,7 @@ async function handleSessionModelCustomSubmit() {
                     v-show="activeToolPanel === 'files'"
                     :workspace-session-id="activeWorkspaceSessionId"
                     :workspace="activeWorkspacePath"
+                    @attach="handleWorkspaceFileAttach"
                   />
                   <TerminalPanel
                     v-show="activeToolPanel === 'terminal'"

--- a/packages/client/src/components/hermes/chat/FilesPanel.vue
+++ b/packages/client/src/components/hermes/chat/FilesPanel.vue
@@ -2,7 +2,7 @@
 import { defineAsyncComponent, ref, onMounted, watch } from 'vue'
 import { useFilesStore } from '@/stores/hermes/files'
 import { useI18n } from 'vue-i18n'
-import { NButton } from 'naive-ui'
+import { NButton, useMessage } from 'naive-ui'
 import FileTree from '@/components/hermes/files/FileTree.vue'
 import FileBreadcrumb from '@/components/hermes/files/FileBreadcrumb.vue'
 import FileToolbar from '@/components/hermes/files/FileToolbar.vue'
@@ -11,16 +11,23 @@ import FileContextMenu from '@/components/hermes/files/FileContextMenu.vue'
 import FileUploadModal from '@/components/hermes/files/FileUploadModal.vue'
 import FileRenameModal from '@/components/hermes/files/FileRenameModal.vue'
 import type { FileEntry } from '@/api/hermes/files'
+import { fetchSessionWorkspaceAttachmentBlob } from '@/api/hermes/sessions'
+import { fetchGroupWorkspaceAttachmentBlob } from '@/api/hermes/group-chat'
 
 const FileEditor = defineAsyncComponent(async () => (await import('@/components/hermes/files/FileEditor.vue')).default)
 
 const filesStore = useFilesStore()
 const { t } = useI18n()
+const message = useMessage()
 
 const props = defineProps<{
   workspaceSessionId?: string | null
   workspaceRoomId?: string | null
   workspace?: string | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'attach', file: File): void
 }>()
 
 const contextMenuRef = ref<InstanceType<typeof FileContextMenu> | null>(null)
@@ -62,6 +69,24 @@ function handleRename(entry: FileEntry) {
   renameEntry.value = entry
   renameTargetPath.value = null
   showRenameModal.value = true
+}
+
+async function handleAttach(entry: FileEntry) {
+  if (entry.isDir) return
+  try {
+    const blob = props.workspaceSessionId
+      ? await fetchSessionWorkspaceAttachmentBlob(props.workspaceSessionId, entry.path)
+      : props.workspaceRoomId
+        ? await fetchGroupWorkspaceAttachmentBlob(props.workspaceRoomId, entry.path)
+        : null
+    if (!blob) return
+    emit('attach', new File([blob], entry.name, {
+      type: blob.type || 'application/octet-stream',
+      lastModified: Date.parse(entry.modTime) || Date.now(),
+    }))
+  } catch {
+    message.error(t('files.attachFailed'))
+  }
 }
 
 watch(
@@ -136,6 +161,8 @@ onMounted(() => {
     </div>
     <FileContextMenu
       ref="contextMenuRef"
+      :allow-attach="Boolean(workspaceSessionId || workspaceRoomId)"
+      @attach="handleAttach"
       @rename="handleRename"
       @new-folder="handleContextNewFolder"
     />

--- a/packages/client/src/components/hermes/files/FileContextMenu.vue
+++ b/packages/client/src/components/hermes/files/FileContextMenu.vue
@@ -13,12 +13,17 @@ const message = useMessage()
 const dialog = useDialog()
 const filesStore = useFilesStore()
 
+const props = defineProps<{
+  allowAttach?: boolean
+}>()
+
 const showMenu = ref(false)
 const menuX = ref(0)
 const menuY = ref(0)
 const targetEntry = ref<FileEntry | null>(null)
 
 const emit = defineEmits<{
+  (e: 'attach', entry: FileEntry): void
   (e: 'rename', entry: FileEntry): void
   (e: 'newFolder', entry: FileEntry): void
 }>()
@@ -41,6 +46,9 @@ function getOptions() {
   if (entry.isDir) {
     options.push({ label: t('files.open'), key: 'open' })
   } else {
+    if (props.allowAttach) {
+      options.push({ label: t('files.attachToChat'), key: 'attach' })
+    }
     if (isTextFile(entry.name)) {
       options.push({ label: t('files.edit'), key: 'edit' })
     }
@@ -66,6 +74,9 @@ async function handleSelect(key: string) {
   if (!entry) return
 
   switch (key) {
+    case 'attach':
+      if (!entry.isDir && props.allowAttach) emit('attach', entry)
+      break
     case 'open':
       filesStore.navigateTo(entry.path)
       break

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -5,6 +5,7 @@ import { NButton, NDropdown, NTooltip, type DropdownOption } from 'naive-ui'
 import { useGroupChatStore } from '@/stores/hermes/group-chat'
 import { useSettingsStore } from '@/stores/hermes/settings'
 import { useToolTraceVisibility } from '@/composables/useToolTraceVisibility'
+import { extractClipboardFiles } from '@/utils/clipboard-files'
 import { buildMentionOptions, type MentionOption } from './mention-options'
 import type { Attachment } from '@/stores/hermes/chat'
 import { clampChatInputHeight, isMobileChatInputViewport } from '@/utils/chat-input-height'
@@ -411,16 +412,10 @@ function handleFileChange(e: Event) {
 }
 
 function handlePaste(e: ClipboardEvent) {
-    const items = Array.from(e.clipboardData?.items || [])
-    const imageItems = items.filter(i => i.type.startsWith('image/'))
-    if (!imageItems.length) return
+    const files = extractClipboardFiles(e.clipboardData)
+    if (!files.length) return
     e.preventDefault()
-    for (const item of imageItems) {
-        const blob = item.getAsFile()
-        if (!blob) continue
-        const ext = item.type.split('/')[1] || 'png'
-        addFiles([new File([blob], `pasted-${Date.now()}.${ext}`, { type: item.type })])
-    }
+    addFiles(files)
 }
 
 function handleDragOver(e: DragEvent) {

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -264,6 +264,10 @@ function handleChatDrop(event: DragEvent) {
     groupChatInputRef.value?.addFiles?.(files)
 }
 
+function handleWorkspaceFileAttach(file: File) {
+    groupChatInputRef.value?.addFiles?.([file])
+}
+
 function generateCode(): string {
     const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
     let code = ''
@@ -903,6 +907,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                                 <FilesPanel
                                     :workspace-room-id="store.currentRoomId"
                                     :workspace="currentRoom.workspace"
+                                    @attach="handleWorkspaceFileAttach"
                                 />
                             </div>
                         </template>

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -2255,6 +2255,7 @@ jobTriggered: 'Job ausgelost',
   },
 
   files: {
+    attachToChat: 'Zum Chat hinzufügen', attachFailed: 'Datei konnte nicht zum Chat hinzugefügt werden',
     previewMode: 'Vorschau', sourceMode: 'Quelltext', tableMode: 'Tabelle', worksheet: 'Arbeitsblatt',
     htmlPreviewTitle: 'Isolierte HTML-Vorschau', previewLoading: 'Vorschau wird geladen...', previewFailed: 'Vorschau nicht verfügbar',
     previewMimeMismatch: 'Der Dateityp stimmt nicht mit dem Vorschauformat überein.', downloadInstead: 'Stattdessen herunterladen',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -2656,6 +2656,8 @@ export default {
     preview: 'Preview',
     download: 'Download',
     copyPath: 'Copy Path',
+    attachToChat: 'Add to Chat',
+    attachFailed: 'Failed to add file to chat',
     rename: 'Rename',
     delete: 'Delete',
     name: 'Name',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -2255,6 +2255,7 @@ jobTriggered: 'Job ejecutado',
   },
 
   files: {
+    attachToChat: 'Añadir al chat', attachFailed: 'No se pudo añadir el archivo al chat',
     previewMode: 'Vista previa', sourceMode: 'Código fuente', tableMode: 'Tabla', worksheet: 'Hoja',
     htmlPreviewTitle: 'Vista previa HTML aislada', previewLoading: 'Cargando vista previa...', previewFailed: 'Vista previa no disponible',
     previewMimeMismatch: 'El tipo de archivo no coincide con el formato de vista previa.', downloadInstead: 'Descargar en su lugar',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -2255,6 +2255,7 @@ jobTriggered: 'Job declenche',
   },
 
   files: {
+    attachToChat: 'Ajouter au chat', attachFailed: 'Impossible d’ajouter le fichier au chat',
     previewMode: 'Aperçu', sourceMode: 'Source', tableMode: 'Tableau', worksheet: 'Feuille',
     htmlPreviewTitle: 'Aperçu HTML isolé', previewLoading: 'Chargement de l’aperçu...', previewFailed: 'Aperçu indisponible',
     previewMimeMismatch: 'Le type du fichier ne correspond pas au format d’aperçu.', downloadInstead: 'Télécharger à la place',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -2254,6 +2254,7 @@ export default {
   },
 
   files: {
+    attachToChat: 'チャットに追加', attachFailed: 'ファイルをチャットに追加できませんでした',
     previewMode: 'プレビュー', sourceMode: 'ソース', tableMode: '表', worksheet: 'ワークシート',
     htmlPreviewTitle: '分離された HTML プレビュー', previewLoading: 'プレビューを読み込み中...', previewFailed: 'プレビューできません',
     previewMimeMismatch: 'ファイル形式がプレビュー形式と一致しません。', downloadInstead: '代わりにダウンロード',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -2254,6 +2254,7 @@ export default {
   },
 
   files: {
+    attachToChat: '채팅에 추가', attachFailed: '파일을 채팅에 추가하지 못했습니다',
     previewMode: '미리보기', sourceMode: '소스', tableMode: '표', worksheet: '워크시트',
     htmlPreviewTitle: '격리된 HTML 미리보기', previewLoading: '미리보기 불러오는 중...', previewFailed: '미리보기를 사용할 수 없음',
     previewMimeMismatch: '파일 형식이 미리보기 형식과 일치하지 않습니다.', downloadInstead: '대신 다운로드',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -2255,6 +2255,7 @@ jobTriggered: 'Job acionado',
   },
 
   files: {
+    attachToChat: 'Adicionar ao chat', attachFailed: 'Falha ao adicionar arquivo ao chat',
     previewMode: 'Prévia', sourceMode: 'Código-fonte', tableMode: 'Tabela', worksheet: 'Planilha',
     htmlPreviewTitle: 'Prévia HTML isolada', previewLoading: 'Carregando prévia...', previewFailed: 'Prévia indisponível',
     previewMimeMismatch: 'O tipo do arquivo não corresponde ao formato da prévia.', downloadInstead: 'Baixar em vez disso',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -2312,6 +2312,8 @@ export default {
     preview: 'Предпросмотр',
     download: 'Скачать',
     copyPath: 'Копировать путь',
+    attachToChat: 'Добавить в чат',
+    attachFailed: 'Не удалось добавить файл в чат',
     rename: 'Переименовать',
     delete: 'Удалить',
     name: 'Имя',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -2617,6 +2617,8 @@ export default {
     preview: '預覽',
     download: '下載',
     copyPath: '複製路徑',
+    attachToChat: '加入輸入框',
+    attachFailed: '加入檔案失敗',
     rename: '重新命名',
     delete: '刪除',
     name: '名稱',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -2658,6 +2658,8 @@ export default {
     preview: '预览',
     download: '下载',
     copyPath: '复制路径',
+    attachToChat: '添加到输入框',
+    attachFailed: '添加文件失败',
     rename: '重命名',
     delete: '删除',
     name: '名称',

--- a/packages/client/src/utils/clipboard-files.ts
+++ b/packages/client/src/utils/clipboard-files.ts
@@ -1,0 +1,20 @@
+export function extractClipboardFiles(clipboardData: DataTransfer | null): File[] {
+  if (!clipboardData) return []
+
+  const itemFiles = Array.from(clipboardData.items || [])
+    .filter(item => item.kind === 'file')
+    .map(item => item.getAsFile())
+    .filter((file): file is File => file !== null)
+  const files = itemFiles.length > 0 ? itemFiles : Array.from(clipboardData.files || [])
+  const pastedAt = Date.now()
+
+  return files.map((file, index) => {
+    if (!file.type.startsWith('image/')) return file
+    const extension = file.type.split('/')[1]?.replace(/[^a-z0-9.+-]/gi, '') || 'png'
+    const suffix = index > 0 ? `-${index + 1}` : ''
+    return new File([file], `pasted-${pastedAt}${suffix}.${extension}`, {
+      type: file.type,
+      lastModified: file.lastModified,
+    })
+  })
+}

--- a/tests/client/chat-input-draft.test.ts
+++ b/tests/client/chat-input-draft.test.ts
@@ -103,6 +103,32 @@ describe('ChatInput draft persistence', () => {
     deleteSkillBundleApiMock.mockReset()
     deleteSkillBundleApiMock.mockResolvedValue(undefined)
     dialogWarningMock.mockReset()
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:chat-attachment'),
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    })
+  })
+
+  it('adds a pasted non-image file to the attachment list', async () => {
+    const wrapper = mountForSession('session-file-paste')
+    const file = new File(['hello'], 'notes.txt', { type: 'text/plain' })
+    const paste = new Event('paste', { bubbles: true, cancelable: true })
+    Object.defineProperty(paste, 'clipboardData', {
+      value: {
+        items: [{ kind: 'file', type: file.type, getAsFile: () => file }],
+        files: [file],
+      },
+    })
+
+    wrapper.get('textarea').element.dispatchEvent(paste)
+    await nextTick()
+
+    expect(paste.defaultPrevented).toBe(true)
+    expect(wrapper.get('.attachment-file').text()).toContain('notes.txt')
   })
 
   it('restores unsent text for the active session after the chat view is remounted', async () => {

--- a/tests/client/clipboard-files.test.ts
+++ b/tests/client/clipboard-files.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { extractClipboardFiles } from '@/utils/clipboard-files'
+
+function clipboardData(items: Array<{ kind: string; type: string; getAsFile: () => File | null }>, files: File[] = []) {
+  return { items, files } as unknown as DataTransfer
+}
+
+describe('clipboard file extraction', () => {
+  it('keeps pasted non-image files and ignores text clipboard items', () => {
+    const documentFile = new File(['hello'], 'notes.txt', { type: 'text/plain' })
+    const files = extractClipboardFiles(clipboardData([
+      { kind: 'string', type: 'text/plain', getAsFile: () => null },
+      { kind: 'file', type: 'text/plain', getAsFile: () => documentFile },
+    ]))
+
+    expect(files).toEqual([documentFile])
+  })
+
+  it('gives pasted images unique generated names', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1234)
+    const image = new File(['image'], 'image.png', { type: 'image/png' })
+
+    const files = extractClipboardFiles(clipboardData([
+      { kind: 'file', type: 'image/png', getAsFile: () => image },
+    ]))
+
+    expect(files[0]).toMatchObject({ name: 'pasted-1234.png', type: 'image/png' })
+  })
+
+  it('falls back to clipboardData.files when item files are unavailable', () => {
+    const archive = new File(['zip'], 'archive.zip', { type: 'application/zip' })
+    expect(extractClipboardFiles(clipboardData([], [archive]))).toEqual([archive])
+  })
+})

--- a/tests/client/file-context-menu.test.ts
+++ b/tests/client/file-context-menu.test.ts
@@ -133,4 +133,23 @@ describe('FileContextMenu', () => {
     expect(keys).not.toContain('edit')
     expect(keys).toContain('download')
   })
+
+  it('offers workspace files as chat attachments only when enabled', async () => {
+    const entry: FileEntry = {
+      name: 'report.pdf',
+      path: 'reports/report.pdf',
+      isDir: false,
+      size: 128,
+      modTime: '2026-06-02T00:00:00.000Z',
+    }
+    const regularWrapper = mount(FileContextMenu)
+    await showMenu(regularWrapper, entry)
+    expect(regularWrapper.find('[data-key="attach"]').exists()).toBe(false)
+
+    const workspaceWrapper = mount(FileContextMenu, { props: { allowAttach: true } })
+    await showMenu(workspaceWrapper, entry)
+    await workspaceWrapper.get('[data-key="attach"]').trigger('click')
+
+    expect(workspaceWrapper.emitted('attach')).toEqual([[entry]])
+  })
 })

--- a/tests/client/files-panel-attach.test.ts
+++ b/tests/client/files-panel-attach.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+import { defineComponent } from 'vue'
+import type { FileEntry } from '@/api/hermes/files'
+
+const fetchSessionAttachment = vi.hoisted(() => vi.fn())
+const fetchGroupAttachment = vi.hoisted(() => vi.fn())
+const message = vi.hoisted(() => ({ error: vi.fn() }))
+
+vi.mock('@/api/hermes/sessions', () => ({
+  fetchSessionWorkspaceAttachmentBlob: fetchSessionAttachment,
+}))
+vi.mock('@/api/hermes/group-chat', () => ({
+  fetchGroupWorkspaceAttachmentBlob: fetchGroupAttachment,
+}))
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+vi.mock('naive-ui', () => ({
+  NButton: defineComponent({ template: '<button><slot /><slot name="icon" /></button>' }),
+  useMessage: () => message,
+}))
+vi.mock('@/components/hermes/files/FileTree.vue', () => ({ default: defineComponent({ template: '<div />' }) }))
+vi.mock('@/components/hermes/files/FileBreadcrumb.vue', () => ({ default: defineComponent({ template: '<div />' }) }))
+vi.mock('@/components/hermes/files/FileToolbar.vue', () => ({ default: defineComponent({ template: '<div />' }) }))
+vi.mock('@/components/hermes/files/FileList.vue', () => ({ default: defineComponent({ template: '<div />' }) }))
+vi.mock('@/components/hermes/files/FileUploadModal.vue', () => ({ default: defineComponent({ template: '<div />' }) }))
+vi.mock('@/components/hermes/files/FileRenameModal.vue', () => ({ default: defineComponent({ template: '<div />' }) }))
+vi.mock('@/components/hermes/files/FileEditor.vue', () => ({ default: defineComponent({ template: '<div />' }) }))
+vi.mock('@/components/hermes/files/FileContextMenu.vue', () => ({
+  default: defineComponent({
+    name: 'FileContextMenuStub',
+    emits: ['attach', 'rename', 'new-folder'],
+    template: '<div />',
+  }),
+}))
+
+import FilesPanel from '@/components/hermes/chat/FilesPanel.vue'
+
+const entry: FileEntry = {
+  name: 'report.pdf',
+  path: 'reports/report.pdf',
+  isDir: false,
+  size: 5,
+  modTime: '2026-06-02T00:00:00.000Z',
+}
+
+describe('FilesPanel workspace attachments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loads a session workspace file and emits it as a browser File', async () => {
+    fetchSessionAttachment.mockResolvedValue(new Blob(['hello'], { type: 'application/pdf' }))
+    const wrapper = mount(FilesPanel, {
+      props: { workspaceSessionId: 'session-1', workspace: '/tmp/workspace' },
+      global: { plugins: [createTestingPinia({ createSpy: vi.fn })] },
+    })
+
+    wrapper.getComponent({ name: 'FileContextMenuStub' }).vm.$emit('attach', entry)
+    await flushPromises()
+
+    expect(fetchSessionAttachment).toHaveBeenCalledWith('session-1', 'reports/report.pdf')
+    const file = wrapper.emitted<File[]>('attach')?.[0]?.[0]
+    expect(file).toBeInstanceOf(File)
+    expect(file).toMatchObject({ name: 'report.pdf', type: 'application/pdf', size: 5 })
+  })
+
+  it('loads a group workspace file from the room endpoint', async () => {
+    fetchGroupAttachment.mockResolvedValue(new Blob(['hello'], { type: 'text/plain' }))
+    const wrapper = mount(FilesPanel, {
+      props: { workspaceRoomId: 'room-1', workspace: '/tmp/room' },
+      global: { plugins: [createTestingPinia({ createSpy: vi.fn })] },
+    })
+
+    wrapper.getComponent({ name: 'FileContextMenuStub' }).vm.$emit('attach', entry)
+    await flushPromises()
+
+    expect(fetchGroupAttachment).toHaveBeenCalledWith('room-1', 'reports/report.pdf')
+    expect(wrapper.emitted('attach')).toHaveLength(1)
+  })
+})

--- a/tests/client/group-chat-input-mentions.test.ts
+++ b/tests/client/group-chat-input-mentions.test.ts
@@ -26,6 +26,37 @@ describe('GroupChatInput mentions', () => {
   beforeEach(() => {
     localStorage.clear()
     window.innerWidth = 1024
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:group-attachment'),
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    })
+  })
+
+  it('adds a pasted non-image file to the attachment list', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    const settingsStore = useSettingsStore()
+    settingsStore.display = {}
+    const file = new File(['hello'], 'group-notes.txt', { type: 'text/plain' })
+    const wrapper = mount(GroupChatInput, {
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+    const paste = new Event('paste', { bubbles: true, cancelable: true })
+    Object.defineProperty(paste, 'clipboardData', {
+      value: {
+        items: [{ kind: 'file', type: file.type, getAsFile: () => file }],
+        files: [file],
+      },
+    })
+
+    wrapper.get('textarea').element.dispatchEvent(paste)
+    await nextTick()
+
+    expect(paste.defaultPrevented).toBe(true)
+    expect(wrapper.get('.attachment-file').text()).toContain('group-notes.txt')
   })
 
   it('updates mention suggestions after the textarea has a custom height', async () => {


### PR DESCRIPTION
## Summary

- allow arbitrary files from the clipboard to be added to normal and group chat composers
- add a workspace file context-menu action that downloads and attaches the selected file without sending it
- add locale coverage and focused tests for both attachment paths

## Impact

Users can prepare file attachments directly by pasting files or choosing **Add to chat** from the workspace file menu.

## Validation

- `npm run harness:check`
- `npm run build`
- focused client tests: 41 passed
- `npm run test`: 2,876 passed; one unrelated Codex model-catalog assertion still expects `gpt-5.4-mini`

Closes #2165