### PR TITLE
Compact workspace file metadata columns

### DIFF
--- a/packages/client/src/components/hermes/files/FileList.vue
+++ b/packages/client/src/components/hermes/files/FileList.vue
@@ -28,7 +28,20 @@ function formatSize(bytes: number): string {
 function formatDate(iso: string): string {
   if (!iso) return '—'
   const d = new Date(iso)
-  return d.toLocaleString()
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleString(undefined, {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+}
+
+function formatDateTitle(iso: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleString()
 }
 
 function getFileIcon(entry: FileEntry): string {
@@ -109,7 +122,7 @@ async function handleDownload(entry: FileEntry) {
             <span class="file-label" :title="entry.name">{{ entry.name }}</span>
           </div>
           <div class="file-size">{{ entry.isDir ? '—' : formatSize(entry.size) }}</div>
-          <div class="file-date">{{ formatDate(entry.modTime) }}</div>
+          <div class="file-date" :title="formatDateTitle(entry.modTime)">{{ formatDate(entry.modTime) }}</div>
           <div class="file-actions">
             <NButton v-if="isPreviewableFile(entry.name) && !entry.isDir" size="tiny" quaternary @click.stop="handlePreview(entry)" :title="t('files.preview')">👁️</NButton>
             <NButton v-if="isTextFile(entry.name) && !entry.isDir" size="tiny" quaternary @click.stop="filesStore.openEditor(entry.path)" :title="t('files.edit')">✏️</NButton>
@@ -130,9 +143,9 @@ async function handleDownload(entry: FileEntry) {
 
 .file-list-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 80px 160px 60px;
+  grid-template-columns: minmax(0, 1fr) 72px 104px 60px;
   align-items: center;
-  column-gap: 16px;
+  column-gap: 8px;
 }
 
 .file-list-header {

--- a/tests/client/file-list-layout.test.ts
+++ b/tests/client/file-list-layout.test.ts
@@ -38,5 +38,10 @@ describe('FileList layout', () => {
     expect(wrapper.find('.file-list-header').classes()).toContain('file-list-grid')
     expect(wrapper.find('.file-list-row').classes()).toContain('file-list-grid')
     expect(wrapper.find('.file-name .file-label').exists()).toBe(true)
+
+    const date = wrapper.find('.file-list-row .file-date')
+    expect(date.text()).not.toContain('2026')
+    expect(date.text()).not.toMatch(/:\d{2}:\d{2}/)
+    expect(date.attributes('title')).toBe(new Date('2026-06-06T08:00:00.000Z').toLocaleString())
   })
 })


### PR DESCRIPTION
## Summary

- compact the workspace file size and modified-time columns
- show modified times without the year or seconds
- preserve the full localized timestamp in the hover title
- cover the compact timestamp behavior in the file-list layout test

## Why

The modified-time column reserved 160px with 16px column gaps. In the narrower workspace panel this consumed too much horizontal space and truncated file names unnecessarily.

## Impact

File names receive about 80px more room while users can still inspect the full modification time by hovering over it.

## Validation

- `npm run test -- tests/client/file-list-layout.test.ts tests/client/workspace-long-names.test.ts`
- `npm run harness:check`
- `npm run build`