### PR TITLE
fix: isolate MCU background task result delivery

### DIFF
--- a/docs/chat-chain-changes/2026-07-22-mcu-background-result-speech.md
+++ b/docs/chat-chain-changes/2026-07-22-mcu-background-result-speech.md
@@ -1,0 +1,24 @@
+---
+date: 2026-07-22
+pr: pending
+feature: MCU background result speech
+impact: MCU voice turns return to idle after the parent response and later speak only the final autonomous Agent response produced for completed background work.
+---
+
+The Global Agent server and the direct outbound MCU relay compatibility path
+keep a hidden session listener while a voice-triggered Hermes run has pending
+background delegations. Subagent telemetry and delegation lifecycle events
+remain server-internal and are not forwarded to the MCU. When the background
+completion starts its autonomous parent turn, the listener buffers that turn
+and reuses the existing MCU audio queue only after `run.completed` provides the
+final Agent output. Existing MCU firmware and the transparent remote relay
+server require no protocol changes. An MCU interrupt received after the parent
+turn is already idle no longer records a deferred session abort, so immediately
+starting another recording leaves pending background delegations running; an
+interrupt during an active foreground turn still aborts that turn normally.
+Each MCU foreground run now carries an internal `queue_id`. When a new voice
+turn is queued while an autonomous background delivery is returning on the
+same chat session, MCU listeners use that identifier to keep the two event
+streams separate. The existing background listener owns the autonomous result;
+the new listener ignores it until its own queued run starts. This identifier is
+not part of the MCU wire protocol, so older firmware remains compatible.

--- a/packages/server/src/services/global-agent/outbound-relay-client.ts
+++ b/packages/server/src/services/global-agent/outbound-relay-client.ts
@@ -206,6 +206,17 @@ interface McuVoiceMeta {
   profile: string
 }
 
+interface RelayMcuBackgroundListener {
+  socket: Socket
+  close: () => void
+}
+
+interface PendingRelayMcuBackgroundSpeech {
+  profile: string
+  delegationId?: string
+  text: string
+}
+
 interface EnqueuedMcuSpeechSegment {
   playbackDone: Promise<void>
 }
@@ -230,6 +241,9 @@ class McuSocketIoRelayClient {
   private readonly audioWaiters = new Map<string, { resolve: () => void; reject: (err: Error) => void; timer: NodeJS.Timeout }>()
   private readonly activeRuns = new Map<string, { socket: Socket; sessionId: string }>()
   private readonly sessionRuns = new Map<string, { interactionId: string; socket: Socket }>()
+  private readonly backgroundListeners = new Map<string, RelayMcuBackgroundListener>()
+  private readonly pendingBackgroundSpeech = new Map<string, PendingRelayMcuBackgroundSpeech[]>()
+  private readonly backgroundSpeechRuns = new Set<string>()
   private readonly interruptedInteractions = new Set<string>()
   private readonly ttsAbortControllers = new Map<string, Set<AbortController>>()
   private readonly recentlyInterruptedSessions = new Map<string, number>()
@@ -249,6 +263,9 @@ class McuSocketIoRelayClient {
 
   stop(): void {
     this.stopped = true
+    for (const listener of [...this.backgroundListeners.values()]) listener.close()
+    this.backgroundListeners.clear()
+    this.pendingBackgroundSpeech.clear()
     this.socket?.disconnect()
     this.socket = null
     this.localAgentSocket?.disconnect()
@@ -317,6 +334,7 @@ class McuSocketIoRelayClient {
     socket.on('connect', () => {
       logger.info({ relayUrl: this.redactedRelayUrl() }, '[outbound-relay:mcu-sio] connected')
       this.connectLocalAgentSocket()
+      for (const sessionId of this.pendingBackgroundSpeech.keys()) void this.flushBackgroundSpeech(sessionId)
     })
 
     socket.on('connect_error', (err: Error) => {
@@ -814,6 +832,7 @@ class McuSocketIoRelayClient {
         })
         return
       }
+      if (payload.accepted === true) return
       const transcript = typeof payload.transcript === 'string' ? payload.transcript : ''
       if (!transcript.trim()) {
         this.sendJson({
@@ -842,6 +861,7 @@ class McuSocketIoRelayClient {
   ): Promise<void> {
     await new Promise<void>((resolve) => {
       const sessionId = this.mcuSessionId(voice.profile)
+      const primaryQueueId = `mcu_${randomUUID()}`
       this.interruptedInteractions.delete(voice.interactionId)
       const socket: Socket = io(`${this.options.localBaseUrl.replace(/\/$/, '')}/chat-run`, {
         auth: this.options.userToken ? { token: this.options.userToken } : {},
@@ -856,7 +876,19 @@ class McuSocketIoRelayClient {
       const playbackQueue: Promise<void>[] = []
       let previousPlaybackDone = Promise.resolve()
       let settled = false
+      let primaryFinished = false
+      let primaryResolved = false
+      let primaryTerminalReceived = false
+      let currentRunPrimary = false
+      let currentRunAutonomous = false
+      let currentDelegationId: string | undefined
+      let backgroundOutput = ''
+      let backgroundPending = 0
       const speechSegmenter = createMcuSpeechSegmenter()
+      const ownsBackgroundEvents = () => {
+        const listener = this.backgroundListeners.get(sessionId)
+        return primaryTerminalReceived || listener?.socket === socket
+      }
       const enqueueSpeech = (text: string) => {
         if (this.interruptedInteractions.has(voice.interactionId)) return
         const segmentText = normalizeMcuSpeechText(text)
@@ -917,16 +949,46 @@ class McuSocketIoRelayClient {
         const text = speechSegmenter.flush()
         if (text) enqueueSpeech(text)
       }
+      const resolvePrimary = () => {
+        if (primaryResolved) return
+        primaryResolved = true
+        resolve()
+      }
+      const releasePrimaryRun = () => {
+        if (primaryFinished) return
+        primaryFinished = true
+        this.activeRuns.delete(voice.interactionId)
+        const sessionRun = this.sessionRuns.get(sessionId)
+        if (sessionRun?.socket === socket) this.sessionRuns.delete(sessionId)
+        this.interruptedInteractions.delete(voice.interactionId)
+        clearTimeout(timer)
+        resolvePrimary()
+        void this.flushBackgroundSpeech(sessionId)
+      }
       const finish = () => {
         if (settled) return
         settled = true
-        this.activeRuns.delete(voice.interactionId)
-        this.sessionRuns.delete(sessionId)
-        this.interruptedInteractions.delete(voice.interactionId)
-        clearTimeout(timer)
+        releasePrimaryRun()
+        const listener = this.backgroundListeners.get(sessionId)
+        if (listener?.socket === socket) this.backgroundListeners.delete(sessionId)
         socket.removeAllListeners()
         socket.disconnect()
-        resolve()
+      }
+      const keepBackgroundListener = () => {
+        if (settled) return
+        releasePrimaryRun()
+        const existing = this.backgroundListeners.get(sessionId)
+        if (existing && existing.socket !== socket) existing.close()
+        this.backgroundListeners.set(sessionId, { socket, close: finish })
+        logger.info({
+          interactionId: voice.interactionId,
+          sessionId,
+          backgroundPending,
+        }, '[outbound-relay:ws] keeping MCU session listener for background delivery')
+      }
+      const finishPrimaryRun = () => {
+        if (backgroundPending > 0) keepBackgroundListener()
+        else finish()
       }
       const fail = (message: string) => {
         this.sendJson({
@@ -944,6 +1006,15 @@ class McuSocketIoRelayClient {
       socket.on('connect_error', (err: Error) => {
         fail(err.message || 'chat-run connection failed')
       })
+      socket.on('disconnect', (reason: string) => {
+        if (settled) return
+        if (primaryFinished) {
+          logger.warn({ sessionId, reason }, '[outbound-relay:ws] MCU background session listener disconnected')
+          finish()
+          return
+        }
+        fail(`chat-run disconnected: ${reason}`)
+      })
       socket.on('connect', () => {
         logger.info({
           interactionId: voice.interactionId,
@@ -956,6 +1027,7 @@ class McuSocketIoRelayClient {
         const runPayload = {
           input: transcript,
           session_id: sessionId,
+          queue_id: primaryQueueId,
           profile: voice.profile,
           source: 'global_agent',
           session_source: 'global_agent',
@@ -969,19 +1041,36 @@ class McuSocketIoRelayClient {
         }
         socket.emit('run', runPayload)
       })
-      socket.on('run.started', () => {
+      socket.on('run.started', (event: Record<string, unknown> = {}) => {
+        const queueId = typeof event.queue_id === 'string' ? event.queue_id : undefined
+        const autonomous = event.autonomous === true
+        currentRunPrimary = !autonomous && queueId === primaryQueueId
+        currentRunAutonomous = autonomous && ownsBackgroundEvents()
+        currentDelegationId = currentRunAutonomous && typeof event.delegation_id === 'string' && event.delegation_id.trim()
+          ? event.delegation_id.trim()
+          : undefined
+        backgroundOutput = ''
+        if (!currentRunPrimary) return
         this.sendJson({ type: 'interaction.status', interactionId: voice.interactionId, status: 'thinking' })
       })
-      socket.on('run.queued', () => {
+      socket.on('run.queued', (event: Record<string, unknown> = {}) => {
+        const queuedMessages = Array.isArray(event.queued_messages) ? event.queued_messages : []
+        const ownsQueueEvent = event.dequeued_queue_id === primaryQueueId || queuedMessages.some((message) => (
+          typeof message === 'object' && message !== null && (message as Record<string, unknown>).id === primaryQueueId
+        ))
+        if (!ownsQueueEvent) return
+        currentRunPrimary = false
         this.sendJson({ type: 'interaction.status', interactionId: voice.interactionId, status: 'thinking' })
       })
       socket.on('tool.started', (event: Record<string, unknown> = {}) => {
+        if (!currentRunPrimary) return
         flushCompletedAssistantMessage()
         const tool = typeof event.tool === 'string' ? event.tool : typeof event.name === 'string' ? event.name : 'tool'
         const preview = typeof event.preview === 'string' ? event.preview : undefined
         this.sendJson({ type: 'tool.started', interactionId: voice.interactionId, tool, preview })
       })
       const handleToolFinished = (event: Record<string, unknown> = {}, failed = false) => {
+        if (!currentRunPrimary) return
         const tool = typeof event.tool === 'string' ? event.tool : typeof event.name === 'string' ? event.name : 'tool'
         const preview = typeof event.preview === 'string' ? event.preview : undefined
         const error = typeof event.error === 'string'
@@ -995,6 +1084,11 @@ class McuSocketIoRelayClient {
       socket.on('tool.failed', (event: Record<string, unknown> = {}) => handleToolFinished(event, true))
       socket.on('message.delta', (event: Record<string, unknown> = {}) => {
         if (typeof event.delta === 'string') {
+          if (currentRunAutonomous) {
+            backgroundOutput += event.delta
+            return
+          }
+          if (!currentRunPrimary) return
           output += event.delta
           for (const segment of speechSegmenter.pushDelta(event.delta)) {
             enqueueSpeech(segment)
@@ -1002,6 +1096,36 @@ class McuSocketIoRelayClient {
         }
       })
       socket.on('run.completed', (event: Record<string, unknown> = {}) => {
+        backgroundPending = Math.max(0, Number(event.background_pending) || 0)
+        const autonomous = event.autonomous === true || currentRunAutonomous
+        if (autonomous) {
+          const text = typeof event.output === 'string' && event.output.trim()
+            ? event.output
+            : backgroundOutput
+          if (ownsBackgroundEvents() && text.trim()) {
+            this.queueBackgroundSpeech(sessionId, {
+              profile: voice.profile,
+              delegationId: typeof event.delegation_id === 'string' && event.delegation_id.trim()
+                ? event.delegation_id.trim()
+                : currentDelegationId,
+              text,
+            })
+          }
+          currentRunAutonomous = false
+          currentRunPrimary = false
+          currentDelegationId = undefined
+          backgroundOutput = ''
+          if (primaryFinished && backgroundPending === 0) finish()
+          return
+        }
+        const queueId = typeof event.queue_id === 'string' ? event.queue_id : undefined
+        const isPrimary = currentRunPrimary || queueId === primaryQueueId
+        if (!isPrimary || primaryTerminalReceived) {
+          if (primaryFinished && backgroundPending === 0) finish()
+          return
+        }
+        primaryTerminalReceived = true
+        currentRunPrimary = false
         if (typeof event.output === 'string' && event.output.trim()) {
           if (!output) {
             output = event.output
@@ -1029,7 +1153,7 @@ class McuSocketIoRelayClient {
               interactionId: voice.interactionId,
               status: 'completed',
             })
-            finish()
+            finishPrimaryRun()
           })
           .catch((err) => {
             if (this.interruptedInteractions.has(voice.interactionId) || (err instanceof Error && err.message === 'audio.interrupted')) {
@@ -1040,9 +1164,34 @@ class McuSocketIoRelayClient {
           })
       })
       socket.on('run.failed', (event: Record<string, unknown> = {}) => {
-        fail(typeof event.error === 'string' ? event.error : 'chat-run failed')
+        backgroundPending = Math.max(0, Number(event.background_pending) || 0)
+        const autonomous = event.autonomous === true || currentRunAutonomous
+        const queueId = typeof event.queue_id === 'string' ? event.queue_id : undefined
+        const isPrimary = currentRunPrimary || queueId === primaryQueueId
+        currentRunAutonomous = false
+        currentRunPrimary = false
+        currentDelegationId = undefined
+        backgroundOutput = ''
+        if (autonomous || !isPrimary || primaryTerminalReceived) {
+          if (primaryFinished && backgroundPending === 0) finish()
+          return
+        }
+        primaryTerminalReceived = true
+        this.sendJson({
+          type: 'interaction.status',
+          interactionId: voice.interactionId,
+          status: 'failed',
+          text: typeof event.error === 'string' ? event.error : 'chat-run failed',
+        })
+        finishPrimaryRun()
+      })
+      socket.on('delegation.updated', (event: Record<string, unknown> = {}) => {
+        if (event.background_pending == null) return
+        backgroundPending = Math.max(0, Number(event.background_pending) || 0)
+        if (primaryFinished && backgroundPending === 0) finish()
       })
       socket.on('approval.requested', (event: Record<string, unknown> = {}) => {
+        if (!currentRunPrimary && !currentRunAutonomous) return
         const approvalId = typeof event.approval_id === 'string' ? event.approval_id : ''
         const choice = chooseMcuApprovalChoice(event)
         if (!approvalId || !choice) {
@@ -1055,12 +1204,14 @@ class McuSocketIoRelayClient {
           approvalId,
           choice,
         }, '[outbound-relay:ws] auto-approving MCU chat-run approval')
-        this.sendJson({
-          type: 'tool.started',
-          interactionId: voice.interactionId,
-          tool: 'approval',
-          preview: choice,
-        })
+        if (!currentRunAutonomous) {
+          this.sendJson({
+            type: 'tool.started',
+            interactionId: voice.interactionId,
+            tool: 'approval',
+            preview: choice,
+          })
+        }
         socket.emit('approval.respond', {
           session_id: sessionId,
           approval_id: approvalId,
@@ -1068,6 +1219,7 @@ class McuSocketIoRelayClient {
         })
       })
       socket.on('approval.resolved', (event: Record<string, unknown> = {}) => {
+        if (!currentRunPrimary) return
         const resolved = event.resolved !== false
         this.sendJson({
           type: 'tool.completed',
@@ -1077,9 +1229,87 @@ class McuSocketIoRelayClient {
         })
       })
       socket.on('clarify.requested', () => {
+        if (!currentRunPrimary) return
         fail('clarification required')
       })
     })
+  }
+
+  private queueBackgroundSpeech(sessionId: string, item: PendingRelayMcuBackgroundSpeech): void {
+    const text = item.text.trim()
+    if (!text) return
+    const queue = this.pendingBackgroundSpeech.get(sessionId) || []
+    if (item.delegationId && queue.some(queued => queued.delegationId === item.delegationId)) return
+    queue.push({ ...item, text })
+    this.pendingBackgroundSpeech.set(sessionId, queue)
+    void this.flushBackgroundSpeech(sessionId)
+  }
+
+  private async flushBackgroundSpeech(sessionId: string): Promise<void> {
+    if (
+      this.stopped
+      || !this.socket?.connected
+      || this.backgroundSpeechRuns.has(sessionId)
+      || this.sessionRuns.has(sessionId)
+    ) return
+    const queue = this.pendingBackgroundSpeech.get(sessionId)
+    if (!queue?.length) return
+
+    this.backgroundSpeechRuns.add(sessionId)
+    try {
+      while (queue.length > 0 && !this.sessionRuns.has(sessionId) && this.socket?.connected) {
+        const item = queue.shift()
+        if (!item) break
+        await this.playBackgroundSpeech(item)
+      }
+    } catch (err) {
+      if (!(err instanceof Error && err.message === 'audio.interrupted')) {
+        logger.warn({ err, sessionId }, '[outbound-relay:ws] failed to deliver MCU background speech')
+      }
+    } finally {
+      this.backgroundSpeechRuns.delete(sessionId)
+      if (queue.length === 0) this.pendingBackgroundSpeech.delete(sessionId)
+    }
+  }
+
+  private async playBackgroundSpeech(item: PendingRelayMcuBackgroundSpeech): Promise<void> {
+    const suffix = (item.delegationId || randomUUID())
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 96) || randomUUID()
+    const interactionId = `mcu-background-${suffix}`
+    const segmenter = createMcuSpeechSegmenter()
+    const segments = segmenter.pushDelta(item.text)
+    const tail = segmenter.flush()
+    if (tail) segments.push(tail)
+
+    let segmentIndex = 0
+    try {
+      for (const rawText of segments) {
+        const text = normalizeMcuSpeechText(rawText)
+        if (!text) continue
+        const segmentId = `${interactionId}-tts-${++segmentIndex}`
+        const controller = this.registerTtsAbortController(interactionId)
+        const audioResult: Promise<McuSpeechSynthesisResult> = this.synthesizeMcuSpeech(
+          text,
+          item.profile,
+          controller.signal,
+        )
+          .then(audio => ({ ok: true as const, audio }))
+          .catch(err => ({ ok: false as const, err, aborted: controller.signal.aborted }))
+          .finally(() => this.releaseTtsAbortController(interactionId, controller))
+        const audio = await this.enqueueMcuSpeechSegment(interactionId, segmentId, text, audioResult)
+        await audio.playbackDone
+        if (this.interruptedInteractions.has(interactionId)) throw new Error('audio.interrupted')
+      }
+
+      if (segmentIndex > 0) {
+        this.sendJson({ type: 'interaction.status', interactionId, status: 'completed' })
+      }
+    } finally {
+      this.interruptedInteractions.delete(interactionId)
+    }
   }
 
   private async enqueuePromptAudioFromVoiceTurn(interactionId: string, payload: Record<string, unknown>): Promise<boolean> {
@@ -1159,6 +1389,8 @@ class McuSocketIoRelayClient {
   }
 
   private forgetMcuSessionRun(sessionId: string, interactionId?: string): void {
+    this.pendingBackgroundSpeech.delete(sessionId)
+    this.backgroundListeners.get(sessionId)?.close()
     const sessionRun = this.sessionRuns.get(sessionId)
     if (sessionRun) {
       this.interruptedInteractions.add(sessionRun.interactionId)
@@ -1179,13 +1411,15 @@ class McuSocketIoRelayClient {
 
   private interruptMcuSession(profile: string, interactionId?: string): void {
     const sessionId = this.mcuSessionId(profile)
-    this.recentlyInterruptedSessions.set(sessionId, Date.now())
-    if (interactionId) {
+    const sessionRun = this.sessionRuns.get(sessionId)
+    const active = interactionId ? this.activeRuns.get(interactionId) : undefined
+    const hasActiveTts = interactionId ? this.ttsAbortControllers.has(interactionId) : false
+    if (interactionId && (sessionRun || active || hasActiveTts)) {
       this.interruptedInteractions.add(interactionId)
       this.abortTts(interactionId)
     }
-    const sessionRun = this.sessionRuns.get(sessionId)
     if (sessionRun) {
+      this.recentlyInterruptedSessions.set(sessionId, Date.now())
       this.interruptedInteractions.add(sessionRun.interactionId)
       this.abortTts(sessionRun.interactionId)
       logger.info({
@@ -1197,7 +1431,10 @@ class McuSocketIoRelayClient {
       this.sessionRuns.delete(sessionId)
       return
     }
-    if (interactionId) this.abortActiveRun(interactionId)
+    if (interactionId && active?.sessionId === sessionId) {
+      this.recentlyInterruptedSessions.set(sessionId, Date.now())
+      this.abortActiveRun(interactionId)
+    }
   }
 
   private registerTtsAbortController(interactionId: string): AbortController {

--- a/packages/server/src/services/global-agent/server.ts
+++ b/packages/server/src/services/global-agent/server.ts
@@ -189,6 +189,17 @@ interface PendingMcuInterrupt {
   timer: ReturnType<typeof setTimeout>
 }
 
+interface McuBackgroundListener {
+  socket: ClientSocket
+  close: () => void
+}
+
+interface PendingMcuBackgroundSpeech {
+  options: McuVoiceChatTurnOptions
+  delegationId?: string
+  text: string
+}
+
 interface NormalizedBody {
   body?: BodyInit
   contentType?: string
@@ -415,6 +426,9 @@ export class GlobalAgentServer {
   private readonly localSocketBridges = new Map<string, LocalSocketBridge>()
   private readonly activeMcuRuns = new Map<string, { socket: ClientSocket; sessionId: string }>()
   private readonly mcuSessionRuns = new Map<string, { interactionId: string; socket: ClientSocket }>()
+  private readonly mcuBackgroundListeners = new Map<string, McuBackgroundListener>()
+  private readonly pendingMcuBackgroundSpeech = new Map<string, PendingMcuBackgroundSpeech[]>()
+  private readonly mcuBackgroundSpeechRuns = new Set<string>()
   private readonly mcuAudioWaiters = new Map<string, McuAudioWaiter>()
   private readonly mcuVoiceStreams = new Map<string, McuVoiceStreamState>()
   private readonly interruptedMcuInteractions = new Set<string>()
@@ -528,6 +542,7 @@ export class GlobalAgentServer {
 
   startMcuVoiceChatTurn(options: McuVoiceChatTurnOptions): void {
     const sessionId = this.mcuSessionId(options.clientId, options.profile)
+    const primaryQueueId = `mcu_${randomUUID()}`
     this.emitMcuEvent({
       type: 'interaction.status',
       interactionId: options.interactionId,
@@ -547,18 +562,54 @@ export class GlobalAgentServer {
     const playbackQueue: Promise<void>[] = []
     let previousPlaybackDone = Promise.resolve()
     let settled = false
+    let primaryFinished = false
+    let primaryTerminalReceived = false
+    let currentRunPrimary = false
+    let currentRunAutonomous = false
+    let currentDelegationId: string | undefined
+    let backgroundOutput = ''
+    let backgroundPending = 0
     let output = ''
     const speechSegmenter = createMcuSpeechSegmenter()
+    const ownsBackgroundEvents = () => {
+      const listener = this.mcuBackgroundListeners.get(sessionId)
+      return primaryTerminalReceived || listener?.socket === socket
+    }
 
+    const releasePrimaryRun = () => {
+      if (primaryFinished) return
+      primaryFinished = true
+      this.activeMcuRuns.delete(options.interactionId)
+      const sessionRun = this.mcuSessionRuns.get(sessionId)
+      if (sessionRun?.socket === socket) this.mcuSessionRuns.delete(sessionId)
+      this.interruptedMcuInteractions.delete(options.interactionId)
+      clearTimeout(timer)
+      void this.flushMcuBackgroundSpeech(sessionId)
+    }
     const finish = () => {
       if (settled) return
       settled = true
-      this.activeMcuRuns.delete(options.interactionId)
-      this.mcuSessionRuns.delete(sessionId)
-      this.interruptedMcuInteractions.delete(options.interactionId)
-      clearTimeout(timer)
+      releasePrimaryRun()
+      const listener = this.mcuBackgroundListeners.get(sessionId)
+      if (listener?.socket === socket) this.mcuBackgroundListeners.delete(sessionId)
       socket.removeAllListeners()
       socket.disconnect()
+    }
+    const keepBackgroundListener = () => {
+      if (settled) return
+      releasePrimaryRun()
+      const existing = this.mcuBackgroundListeners.get(sessionId)
+      if (existing && existing.socket !== socket) existing.close()
+      this.mcuBackgroundListeners.set(sessionId, { socket, close: finish })
+      logger.info({
+        interactionId: options.interactionId,
+        sessionId,
+        backgroundPending,
+      }, '[global-agent] keeping MCU session listener for background delivery')
+    }
+    const finishPrimaryRun = () => {
+      if (backgroundPending > 0) keepBackgroundListener()
+      else finish()
     }
     const fail = (message: string) => {
       this.emitMcuEvent({
@@ -632,7 +683,13 @@ export class GlobalAgentServer {
       fail(err.message || 'chat-run connection failed')
     })
     socket.on('disconnect', (reason: string) => {
-      if (!settled) fail(`chat-run disconnected: ${reason}`)
+      if (settled) return
+      if (primaryFinished) {
+        logger.warn({ sessionId, reason }, '[global-agent] MCU background session listener disconnected')
+        finish()
+        return
+      }
+      fail(`chat-run disconnected: ${reason}`)
     })
     socket.on('connect', () => {
       logger.info({
@@ -646,6 +703,7 @@ export class GlobalAgentServer {
       const runPayload = {
         input: options.transcript,
         session_id: sessionId,
+        queue_id: primaryQueueId,
         profile: options.profile,
         source: 'global_agent',
         session_source: 'global_agent',
@@ -659,19 +717,36 @@ export class GlobalAgentServer {
       }
       socket.emit('run', runPayload)
     })
-    socket.on('run.started', () => {
+    socket.on('run.started', (event: Record<string, unknown> = {}) => {
+      const queueId = typeof event.queue_id === 'string' ? event.queue_id : undefined
+      const autonomous = event.autonomous === true
+      currentRunPrimary = !autonomous && queueId === primaryQueueId
+      currentRunAutonomous = autonomous && ownsBackgroundEvents()
+      currentDelegationId = currentRunAutonomous && typeof event.delegation_id === 'string' && event.delegation_id.trim()
+        ? event.delegation_id.trim()
+        : undefined
+      backgroundOutput = ''
+      if (!currentRunPrimary) return
       this.emitMcuEvent({ type: 'interaction.status', interactionId: options.interactionId, status: 'thinking' }, { clientId: options.clientId })
     })
-    socket.on('run.queued', () => {
+    socket.on('run.queued', (event: Record<string, unknown> = {}) => {
+      const queuedMessages = Array.isArray(event.queued_messages) ? event.queued_messages : []
+      const ownsQueueEvent = event.dequeued_queue_id === primaryQueueId || queuedMessages.some((message) => (
+        typeof message === 'object' && message !== null && (message as Record<string, unknown>).id === primaryQueueId
+      ))
+      if (!ownsQueueEvent) return
+      currentRunPrimary = false
       this.emitMcuEvent({ type: 'interaction.status', interactionId: options.interactionId, status: 'thinking' }, { clientId: options.clientId })
     })
     socket.on('tool.started', (event: Record<string, unknown> = {}) => {
+      if (!currentRunPrimary) return
       flushCompletedAssistantMessage()
       const tool = typeof event.tool === 'string' ? event.tool : typeof event.name === 'string' ? event.name : 'tool'
       const preview = typeof event.preview === 'string' ? event.preview : undefined
       this.emitMcuEvent({ type: 'tool.started', interactionId: options.interactionId, tool, preview }, { clientId: options.clientId })
     })
     const handleToolFinished = (event: Record<string, unknown> = {}, failed = false) => {
+      if (!currentRunPrimary) return
       const tool = typeof event.tool === 'string' ? event.tool : typeof event.name === 'string' ? event.name : 'tool'
       const preview = typeof event.preview === 'string' ? event.preview : undefined
       const error = typeof event.error === 'string'
@@ -685,12 +760,47 @@ export class GlobalAgentServer {
     socket.on('tool.failed', (event: Record<string, unknown> = {}) => handleToolFinished(event, true))
     socket.on('message.delta', (event: Record<string, unknown> = {}) => {
       if (typeof event.delta !== 'string') return
+      if (currentRunAutonomous) {
+        backgroundOutput += event.delta
+        return
+      }
+      if (!currentRunPrimary) return
       output += event.delta
       for (const segment of speechSegmenter.pushDelta(event.delta)) {
         enqueueSpeech(segment)
       }
     })
     socket.on('run.completed', (event: Record<string, unknown> = {}) => {
+      backgroundPending = Math.max(0, Number(event.background_pending) || 0)
+      const autonomous = event.autonomous === true || currentRunAutonomous
+      if (autonomous) {
+        const text = typeof event.output === 'string' && event.output.trim()
+          ? event.output
+          : backgroundOutput
+        if (ownsBackgroundEvents() && text.trim()) {
+          this.queueMcuBackgroundSpeech(sessionId, {
+            options,
+            delegationId: typeof event.delegation_id === 'string' && event.delegation_id.trim()
+              ? event.delegation_id.trim()
+              : currentDelegationId,
+            text,
+          })
+        }
+        currentRunAutonomous = false
+        currentRunPrimary = false
+        currentDelegationId = undefined
+        backgroundOutput = ''
+        if (primaryFinished && backgroundPending === 0) finish()
+        return
+      }
+      const queueId = typeof event.queue_id === 'string' ? event.queue_id : undefined
+      const isPrimary = currentRunPrimary || queueId === primaryQueueId
+      if (!isPrimary || primaryTerminalReceived) {
+        if (primaryFinished && backgroundPending === 0) finish()
+        return
+      }
+      primaryTerminalReceived = true
+      currentRunPrimary = false
       if (typeof event.output === 'string' && event.output.trim()) {
         if (!output) {
           output = event.output
@@ -714,7 +824,7 @@ export class GlobalAgentServer {
             return
           }
           this.emitMcuEvent({ type: 'interaction.status', interactionId: options.interactionId, status: 'completed' }, { clientId: options.clientId })
-          finish()
+          finishPrimaryRun()
         })
         .catch((err) => {
           if (this.interruptedMcuInteractions.has(options.interactionId) || (err instanceof Error && err.message === 'audio.interrupted')) {
@@ -725,16 +835,43 @@ export class GlobalAgentServer {
         })
     })
     socket.on('run.failed', (event: Record<string, unknown> = {}) => {
-      fail(typeof event.error === 'string' ? event.error : 'chat-run failed')
+      backgroundPending = Math.max(0, Number(event.background_pending) || 0)
+      const autonomous = event.autonomous === true || currentRunAutonomous
+      const queueId = typeof event.queue_id === 'string' ? event.queue_id : undefined
+      const isPrimary = currentRunPrimary || queueId === primaryQueueId
+      currentRunAutonomous = false
+      currentRunPrimary = false
+      currentDelegationId = undefined
+      backgroundOutput = ''
+      if (autonomous || !isPrimary || primaryTerminalReceived) {
+        if (primaryFinished && backgroundPending === 0) finish()
+        return
+      }
+      primaryTerminalReceived = true
+      this.emitMcuEvent({
+        type: 'interaction.status',
+        interactionId: options.interactionId,
+        status: 'failed',
+        text: typeof event.error === 'string' ? event.error : 'chat-run failed',
+      }, { clientId: options.clientId })
+      finishPrimaryRun()
+    })
+    socket.on('delegation.updated', (event: Record<string, unknown> = {}) => {
+      if (event.background_pending == null) return
+      backgroundPending = Math.max(0, Number(event.background_pending) || 0)
+      if (primaryFinished && backgroundPending === 0) finish()
     })
     socket.on('approval.requested', (event: Record<string, unknown> = {}) => {
+      if (!currentRunPrimary && !currentRunAutonomous) return
       const approvalId = typeof event.approval_id === 'string' ? event.approval_id : ''
       const choice = chooseMcuApprovalChoice(event)
       if (!approvalId || !choice) {
         fail('approval required')
         return
       }
-      this.emitMcuEvent({ type: 'tool.started', interactionId: options.interactionId, tool: 'approval', preview: choice }, { clientId: options.clientId })
+      if (!currentRunAutonomous) {
+        this.emitMcuEvent({ type: 'tool.started', interactionId: options.interactionId, tool: 'approval', preview: choice }, { clientId: options.clientId })
+      }
       socket.emit('approval.respond', {
         session_id: sessionId,
         approval_id: approvalId,
@@ -742,6 +879,7 @@ export class GlobalAgentServer {
       })
     })
     socket.on('approval.resolved', (event: Record<string, unknown> = {}) => {
+      if (!currentRunPrimary) return
       const resolved = event.resolved !== false
       this.emitMcuEvent({
         type: 'tool.completed',
@@ -751,8 +889,84 @@ export class GlobalAgentServer {
       }, { clientId: options.clientId })
     })
     socket.on('clarify.requested', () => {
+      if (!currentRunPrimary) return
       fail('clarification required')
     })
+  }
+
+  private queueMcuBackgroundSpeech(sessionId: string, item: PendingMcuBackgroundSpeech): void {
+    const text = item.text.trim()
+    if (!text) return
+    const queue = this.pendingMcuBackgroundSpeech.get(sessionId) || []
+    if (item.delegationId && queue.some(queued => queued.delegationId === item.delegationId)) return
+    queue.push({ ...item, text })
+    this.pendingMcuBackgroundSpeech.set(sessionId, queue)
+    void this.flushMcuBackgroundSpeech(sessionId)
+  }
+
+  private async flushMcuBackgroundSpeech(sessionId: string): Promise<void> {
+    if (this.mcuBackgroundSpeechRuns.has(sessionId) || this.mcuSessionRuns.has(sessionId)) return
+    const queue = this.pendingMcuBackgroundSpeech.get(sessionId)
+    if (!queue?.length) return
+    if (!this.resolveClient(queue[0].options.clientId)) return
+
+    this.mcuBackgroundSpeechRuns.add(sessionId)
+    try {
+      while (queue.length > 0 && !this.mcuSessionRuns.has(sessionId)) {
+        const item = queue.shift()
+        if (!item) break
+        await this.playMcuBackgroundSpeech(item)
+      }
+    } catch (err) {
+      if (!(err instanceof Error && err.message === 'audio.interrupted')) {
+        logger.warn({ err, sessionId }, '[global-agent] failed to deliver MCU background speech')
+      }
+    } finally {
+      this.mcuBackgroundSpeechRuns.delete(sessionId)
+      if (queue.length === 0) this.pendingMcuBackgroundSpeech.delete(sessionId)
+    }
+  }
+
+  private async playMcuBackgroundSpeech(item: PendingMcuBackgroundSpeech): Promise<void> {
+    const suffix = (item.delegationId || randomUUID())
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 96) || randomUUID()
+    const interactionId = `mcu-background-${suffix}`
+    const options = { ...item.options, interactionId }
+    const segmenter = createMcuSpeechSegmenter()
+    const segments = segmenter.pushDelta(item.text)
+    const tail = segmenter.flush()
+    if (tail) segments.push(tail)
+
+    let segmentIndex = 0
+    try {
+      for (const rawText of segments) {
+        const text = normalizeMcuSpeechText(rawText)
+        if (!text) continue
+        const segmentId = `${interactionId}-tts-${++segmentIndex}`
+        const controller = this.registerMcuTtsAbortController(interactionId)
+        const audioResult: Promise<McuSpeechSynthesisResult> = this.synthesizeMcuSpeech(
+          text,
+          options.userToken,
+          options.profile,
+          controller.signal,
+        )
+          .then(audio => ({ ok: true as const, audio }))
+          .catch(err => ({ ok: false as const, err, aborted: controller.signal.aborted }))
+          .finally(() => this.releaseMcuTtsAbortController(interactionId, controller))
+        const audio = await this.enqueueMcuSpeechSegment(options, segmentId, text, audioResult)
+        await audio.playbackDone
+        if (this.interruptedMcuInteractions.has(interactionId)) throw new Error('audio.interrupted')
+      }
+
+      if (segmentIndex > 0) {
+        this.emitMcuEvent({ type: 'interaction.status', interactionId, status: 'completed' }, { clientId: options.clientId })
+      }
+    } finally {
+      this.interruptedMcuInteractions.delete(interactionId)
+    }
   }
 
   private onConnection(socket: Socket): void {
@@ -772,6 +986,9 @@ export class GlobalAgentServer {
       logger.info('[global-agent] replaced existing client id=%s old_socket=%s new_socket=%s', clientId, existing.id, socket.id)
     }
     this.clients.set(clientId, socket)
+    for (const [sessionId, queue] of this.pendingMcuBackgroundSpeech.entries()) {
+      if (queue.some(item => item.options.clientId === clientId)) void this.flushMcuBackgroundSpeech(sessionId)
+    }
     logger.info('[global-agent] client connected id=%s socket=%s', clientId, socket.id)
 
     socket.on('disconnect', () => {
@@ -1314,7 +1531,7 @@ export class GlobalAgentServer {
     }
     const waitForDone = this.waitForMcuAudioDone(segmentId, Math.max(90_000, Math.min(text.length * 1200, 300_000)))
     waitForDone.catch(() => undefined)
-    this.emitMcuEvent({
+    const emitted = this.emitMcuEvent({
       type: 'audio.enqueue',
       interactionId: options.interactionId,
       segmentId,
@@ -1326,6 +1543,15 @@ export class GlobalAgentServer {
       durationMs: Math.max(1200, Math.min(text.length * 180, 12_000)),
       completionManagedByServer: true,
     }, { clientId: options.clientId })
+    if (!emitted) {
+      const waiter = this.mcuAudioWaiters.get(segmentId)
+      if (waiter) {
+        clearTimeout(waiter.timer)
+        this.mcuAudioWaiters.delete(segmentId)
+        waiter.reject(new Error('MCU client disconnected before audio delivery'))
+      }
+      throw new Error('MCU client disconnected before audio delivery')
+    }
     return { playbackDone: waitForDone }
   }
 
@@ -1376,6 +1602,8 @@ export class GlobalAgentServer {
   }
 
   private forgetMcuSessionRun(sessionId: string, interactionId?: string): void {
+    this.pendingMcuBackgroundSpeech.delete(sessionId)
+    this.mcuBackgroundListeners.get(sessionId)?.close()
     const sessionRun = this.mcuSessionRuns.get(sessionId)
     if (sessionRun) {
       this.interruptedMcuInteractions.add(sessionRun.interactionId)
@@ -1396,13 +1624,15 @@ export class GlobalAgentServer {
 
   private interruptMcuSession(clientId: string, profile: string, interactionId?: string): void {
     const sessionId = this.mcuSessionId(clientId, profile)
-    this.recentlyInterruptedMcuSessions.set(sessionId, Date.now())
-    if (interactionId) {
+    const sessionRun = this.mcuSessionRuns.get(sessionId)
+    const active = interactionId ? this.activeMcuRuns.get(interactionId) : undefined
+    const hasActiveTts = interactionId ? this.mcuTtsAbortControllers.has(interactionId) : false
+    if (interactionId && (sessionRun || active || hasActiveTts)) {
       this.interruptedMcuInteractions.add(interactionId)
       this.abortMcuTts(interactionId)
     }
-    const sessionRun = this.mcuSessionRuns.get(sessionId)
     if (sessionRun) {
+      this.recentlyInterruptedMcuSessions.set(sessionId, Date.now())
       this.interruptedMcuInteractions.add(sessionRun.interactionId)
       this.abortMcuTts(sessionRun.interactionId)
       logger.info({ interactionId: sessionRun.interactionId, sessionId }, '[global-agent] aborting MCU chat-run after interrupt')
@@ -1411,7 +1641,10 @@ export class GlobalAgentServer {
       this.mcuSessionRuns.delete(sessionId)
       return
     }
-    if (interactionId) this.abortActiveMcuRun(interactionId)
+    if (interactionId && active?.sessionId === sessionId) {
+      this.recentlyInterruptedMcuSessions.set(sessionId, Date.now())
+      this.abortActiveMcuRun(interactionId)
+    }
   }
 
   private registerMcuTtsAbortController(interactionId: string): AbortController {

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -412,7 +412,7 @@ export async function handleBridgeRun(
   // boundaries and remain disabled independently of this default.
   const backgroundDelegationEnabled = data.background_delegation_enabled !== false
   if (!session_id) {
-    socket.emit('run.failed', { event: 'run.failed', error: 'session_id is required for cli source' })
+    socket.emit('run.failed', { event: 'run.failed', queue_id: data.queue_id, error: 'session_id is required for cli source' })
     return
   }
 
@@ -660,6 +660,7 @@ export async function handleBridgeRun(
     pushState(sessionMap, session_id, 'run.started', {
       event: 'run.started',
       run_id: started.run_id,
+      queue_id: data.queue_id,
       queue_length: state.queue.length || 0,
       autonomous: data.autonomous === true,
       delegation_id: data.background_delegation_id,
@@ -667,6 +668,7 @@ export async function handleBridgeRun(
     emit('run.started', {
       event: 'run.started',
       run_id: started.run_id,
+      queue_id: data.queue_id,
       queue_length: state.queue.length || 0,
       autonomous: data.autonomous === true,
       delegation_id: data.background_delegation_id,
@@ -695,7 +697,7 @@ export async function handleBridgeRun(
         currentInputTokens,
         shouldPersistUserMessage && displayRole === 'user',
         data.model_groups,
-        { autonomous: data.autonomous === true, delegationId: data.background_delegation_id },
+        { autonomous: data.autonomous === true, delegationId: data.background_delegation_id, queueId: data.queue_id },
       )
       if (chunk.done) {
         sawTerminalChunk = true
@@ -741,7 +743,7 @@ export async function handleBridgeRun(
         currentInputTokens,
         shouldPersistUserMessage && displayRole === 'user',
         data.model_groups,
-        { autonomous: data.autonomous === true, delegationId: data.background_delegation_id },
+        { autonomous: data.autonomous === true, delegationId: data.background_delegation_id, queueId: data.queue_id },
       )
     }
   } catch (err: any) {
@@ -791,6 +793,7 @@ export async function handleBridgeRun(
       background_pending: backgroundPendingCount(state),
       autonomous: data.autonomous === true,
       delegation_id: data.background_delegation_id,
+      queue_id: data.queue_id,
     })
     if (queueLen > 0) {
       dequeueNextQueuedRun(socket, session_id)
@@ -1125,7 +1128,7 @@ async function applyBridgeChunkAsync(
   currentInputTokens = 0,
   currentInputIncludedInDb = true,
   modelGroups?: RunModelGroup[],
-  runMetadata?: { autonomous?: boolean; delegationId?: string },
+  runMetadata?: { autonomous?: boolean; delegationId?: string; queueId?: string },
 ): Promise<void> {
   if (state.activeRunMarker !== runMarker) {
     bridgeLogger.info({
@@ -1653,6 +1656,7 @@ async function applyBridgeChunkAsync(
     background_pending: backgroundPendingCount(state),
     autonomous: runMetadata?.autonomous === true,
     delegation_id: runMetadata?.delegationId,
+    queue_id: runMetadata?.queueId,
     workspace_run_change: workspaceRunChange,
   }
   emit(eventName, payload)

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -237,6 +237,7 @@ export class ChatRunSocket {
         socket.emit('run.failed', {
           event: 'run.failed',
           session_id: data.session_id,
+          queue_id: data.queue_id,
           error: err instanceof Error ? err.message : String(err),
         })
         return
@@ -331,6 +332,7 @@ export class ChatRunSocket {
         socket.emit('run.failed', {
           event: 'run.failed',
           session_id: data.session_id,
+          queue_id: data.queue_id,
           error: err instanceof Error ? err.message : String(err),
         })
       }
@@ -479,11 +481,13 @@ export class ChatRunSocket {
         const payload: {
           event: 'run.failed'
           session_id?: string
+          queue_id?: string
           error: string
           queue_remaining?: number
         } = {
           event: 'run.failed',
           session_id: data.session_id,
+          queue_id: data.queue_id,
           error: `Agent Bridge is not reachable: ${bridgeReady.error}`,
         }
         if (queueRemaining > 0) payload.queue_remaining = queueRemaining

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -379,6 +379,7 @@ describe('ChatRunSocket bridge readiness gating', () => {
     expect(socket.emit).toHaveBeenCalledWith('run.failed', {
       event: 'run.failed',
       session_id: 'session-1',
+      queue_id: 'queue-failed',
       error: 'Agent Bridge is not reachable: bridge offline',
       queue_remaining: 1,
     })

--- a/tests/server/global-agent-server.test.ts
+++ b/tests/server/global-agent-server.test.ts
@@ -165,6 +165,16 @@ async function waitForMockCallWith(
   throw new Error('Timed out waiting for matching mock call')
 }
 
+function startPrimaryMockRun(socket: any, runId = 'run-primary'): string {
+  const runCall = socket.emit.mock.calls
+    .filter(([event]: [string]) => event === 'run')
+    .at(-1)
+  const queueId = runCall?.[1]?.queue_id
+  expect(queueId).toMatch(/^mcu_/)
+  socket.__handlers.get('run.started')?.({ run_id: runId, queue_id: queueId })
+  return queueId
+}
+
 describe('GlobalAgentServer', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -965,6 +975,7 @@ describe('GlobalAgentServer', () => {
     })
     const localSocket = clientSocketMocks.localSockets.at(-1)
     localSocket.__handlers.get('connect')?.()
+    startPrimaryMockRun(localSocket)
     localSocket.__handlers.get('message.delta')?.({ delta: '好嘞，这就去查。\n' })
     await waitForMockCalls(fetchImpl, 1)
     expect(JSON.parse(String(fetchImpl.mock.calls[0][1]?.body))).toMatchObject({
@@ -1022,6 +1033,304 @@ describe('GlobalAgentServer', () => {
     )
   })
 
+  it('keeps MCU background work non-blocking and speaks only the final autonomous agent response', async () => {
+    authMocks.authenticateUserToken.mockResolvedValue({ id: 7, username: 'ada', role: 'user' })
+    authMocks.userCanAccessProfile.mockReturnValue(true)
+    const fetchImpl = vi.fn(async () => new Response(Buffer.from('pcm-audio'), {
+      status: 200,
+      headers: { 'Content-Type': 'audio/x-pcm' },
+    }))
+    const nsp = createMockNamespace()
+    const io = { of: vi.fn(() => nsp) }
+    const { GlobalAgentServer } = await import('../../packages/server/src/services/global-agent/server')
+
+    const server = new GlobalAgentServer(io as any, {
+      fetchImpl: fetchImpl as any,
+      localBaseUrl: 'http://127.0.0.1:8647',
+    })
+    server.init()
+
+    const agentSocket = createMockSocket('jwt-agent-socket', {
+      token: 'user-jwt',
+      role: 'hermes-studio',
+      instanceId: 'device-1',
+      profile: 'research',
+    })
+    await new Promise<void>((resolve, reject) => {
+      nsp.__middleware[0](agentSocket, (err?: Error) => err ? reject(err) : resolve())
+    })
+    nsp.__handlers.get('connection')?.(agentSocket)
+
+    server.startMcuVoiceChatTurn({
+      userToken: 'user-jwt',
+      profile: 'research',
+      interactionId: 'voice-background',
+      transcript: '后台查询天气',
+      clientId: 'device-1',
+    })
+    const localSocket = clientSocketMocks.localSockets.at(-1)
+    localSocket.__handlers.get('connect')?.()
+    startPrimaryMockRun(localSocket, 'run-parent')
+    localSocket.__handlers.get('delegation.updated')?.({
+      delegation_id: 'delegation-1',
+      status: 'running',
+      background_pending: 1,
+    })
+    localSocket.__handlers.get('run.completed')?.({
+      run_id: 'run-parent',
+      output: '',
+      background_pending: 1,
+    })
+
+    await waitForMockCallWith(agentSocket.emit, ([event, payload]) =>
+      event === 'interaction.status'
+      && (payload as { interactionId?: string; status?: string })?.interactionId === 'voice-background'
+      && (payload as { status?: string })?.status === 'completed',
+    )
+    expect(localSocket.disconnect).not.toHaveBeenCalled()
+    expect(fetchImpl).not.toHaveBeenCalled()
+
+    agentSocket.emit.mockClear()
+    localSocket.__handlers.get('run.started')?.({
+      run_id: 'run-background-delivery',
+      autonomous: true,
+      delegation_id: 'delegation-1',
+    })
+    localSocket.__handlers.get('message.delta')?.({
+      run_id: 'run-background-delivery',
+      delta: '厦门明天晴，最高温度 30 度。',
+    })
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(agentSocket.emit).not.toHaveBeenCalledWith('interaction.status', expect.objectContaining({ status: 'thinking' }))
+    expect(agentSocket.emit).not.toHaveBeenCalledWith('audio.enqueue', expect.anything())
+
+    localSocket.__handlers.get('run.completed')?.({
+      run_id: 'run-background-delivery',
+      autonomous: true,
+      delegation_id: 'delegation-1',
+      output: '厦门明天晴，最高温度 30 度。',
+      background_pending: 0,
+    })
+
+    await waitForMockCalls(fetchImpl, 1)
+    expect(JSON.parse(String(fetchImpl.mock.calls[0][1]?.body))).toMatchObject({
+      text: '厦门明天晴，最高温度 30 度。',
+    })
+    await waitForMockCallWith(agentSocket.emit, ([event, payload]) =>
+      event === 'audio.enqueue'
+      && (payload as { interactionId?: string })?.interactionId === 'mcu-background-delegation-1',
+    )
+    expect(agentSocket.emit).toHaveBeenCalledWith('audio.enqueue', expect.objectContaining({
+      interactionId: 'mcu-background-delegation-1',
+      segmentId: 'mcu-background-delegation-1-tts-1',
+      completionManagedByServer: true,
+    }))
+    expect(localSocket.disconnect).toHaveBeenCalled()
+
+    agentSocket.__handlers.get('audio.done')?.({
+      interactionId: 'mcu-background-delegation-1',
+      segmentId: 'mcu-background-delegation-1-tts-1',
+    })
+    await waitForMockCallWith(agentSocket.emit, ([event, payload]) =>
+      event === 'interaction.status'
+      && (payload as { interactionId?: string; status?: string })?.interactionId === 'mcu-background-delegation-1'
+      && (payload as { status?: string })?.status === 'completed',
+    )
+  })
+
+  it('does not abort idle background work when a new MCU recording starts', async () => {
+    authMocks.authenticateUserToken.mockResolvedValue({ id: 7, username: 'ada', role: 'user' })
+    authMocks.userCanAccessProfile.mockReturnValue(true)
+    const nsp = createMockNamespace()
+    const io = { of: vi.fn(() => nsp) }
+    const { GlobalAgentServer } = await import('../../packages/server/src/services/global-agent/server')
+
+    const server = new GlobalAgentServer(io as any, { localBaseUrl: 'http://127.0.0.1:8647' })
+    server.init()
+
+    const agentSocket = createMockSocket('jwt-agent-socket', {
+      token: 'user-jwt',
+      role: 'hermes-studio',
+      instanceId: 'device-1',
+      profile: 'research',
+    })
+    await new Promise<void>((resolve, reject) => {
+      nsp.__middleware[0](agentSocket, (err?: Error) => err ? reject(err) : resolve())
+    })
+    nsp.__handlers.get('connection')?.(agentSocket)
+
+    server.startMcuVoiceChatTurn({
+      userToken: 'user-jwt',
+      profile: 'research',
+      interactionId: 'voice-parent',
+      transcript: '启动后台任务',
+      clientId: 'device-1',
+    })
+    const parentSocket = clientSocketMocks.localSockets.at(-1)
+    parentSocket.__handlers.get('connect')?.()
+    startPrimaryMockRun(parentSocket, 'run-parent')
+    parentSocket.__handlers.get('run.completed')?.({
+      run_id: 'run-parent',
+      output: '',
+      background_pending: 1,
+    })
+    await waitForMockCallWith(agentSocket.emit, ([event, payload]) =>
+      event === 'interaction.status'
+      && (payload as { interactionId?: string; status?: string })?.interactionId === 'voice-parent'
+      && (payload as { status?: string })?.status === 'completed',
+    )
+
+    agentSocket.__handlers.get('mcu.interrupt')?.({
+      interactionId: 'voice-parent',
+      profile: 'research',
+    })
+    await new Promise(resolve => setTimeout(resolve, 320))
+    expect(parentSocket.emit).not.toHaveBeenCalledWith('abort', { session_id: 'mcu-device-1-research' })
+
+    server.startMcuVoiceChatTurn({
+      userToken: 'user-jwt',
+      profile: 'research',
+      interactionId: 'voice-follow-up',
+      transcript: '继续聊另一个问题',
+      clientId: 'device-1',
+    })
+    const followUpSocket = clientSocketMocks.localSockets.at(-1)
+    followUpSocket.__handlers.get('connect')?.()
+
+    expect(parentSocket.disconnect).not.toHaveBeenCalled()
+    expect(followUpSocket.emit).not.toHaveBeenCalledWith('abort', { session_id: 'mcu-device-1-research' })
+    expect(followUpSocket.emit).toHaveBeenCalledWith('run', expect.objectContaining({
+      input: '继续聊另一个问题',
+      session_id: 'mcu-device-1-research',
+    }))
+  })
+
+  it('isolates a queued MCU voice turn from a background result returning on the same session', async () => {
+    authMocks.authenticateUserToken.mockResolvedValue({ id: 7, username: 'ada', role: 'user' })
+    authMocks.userCanAccessProfile.mockReturnValue(true)
+    const fetchImpl = vi.fn(async () => new Response(Buffer.from('pcm-audio'), {
+      status: 200,
+      headers: { 'Content-Type': 'audio/x-pcm' },
+    }))
+    const nsp = createMockNamespace()
+    const io = { of: vi.fn(() => nsp) }
+    const { GlobalAgentServer } = await import('../../packages/server/src/services/global-agent/server')
+
+    const server = new GlobalAgentServer(io as any, {
+      fetchImpl: fetchImpl as any,
+      localBaseUrl: 'http://127.0.0.1:8647',
+    })
+    server.init()
+
+    const agentSocket = createMockSocket('jwt-agent-socket', {
+      token: 'user-jwt',
+      role: 'hermes-studio',
+      instanceId: 'device-1',
+      profile: 'research',
+    })
+    await new Promise<void>((resolve, reject) => {
+      nsp.__middleware[0](agentSocket, (err?: Error) => err ? reject(err) : resolve())
+    })
+    nsp.__handlers.get('connection')?.(agentSocket)
+
+    server.startMcuVoiceChatTurn({
+      userToken: 'user-jwt',
+      profile: 'research',
+      interactionId: 'voice-parent',
+      transcript: '启动后台任务',
+      clientId: 'device-1',
+    })
+    const parentSocket = clientSocketMocks.localSockets.at(-1)
+    parentSocket.__handlers.get('connect')?.()
+    const parentQueueId = startPrimaryMockRun(parentSocket, 'run-parent')
+    parentSocket.__handlers.get('run.completed')?.({
+      run_id: 'run-parent',
+      queue_id: parentQueueId,
+      output: '',
+      background_pending: 1,
+    })
+    await waitForMockCallWith(agentSocket.emit, ([event, payload]) => (
+      event === 'interaction.status'
+      && (payload as { interactionId?: string; status?: string })?.interactionId === 'voice-parent'
+      && (payload as { status?: string })?.status === 'completed'
+    ))
+
+    server.startMcuVoiceChatTurn({
+      userToken: 'user-jwt',
+      profile: 'research',
+      interactionId: 'voice-follow-up',
+      transcript: '继续问一个问题',
+      clientId: 'device-1',
+    })
+    const followUpSocket = clientSocketMocks.localSockets.at(-1)
+    followUpSocket.__handlers.get('connect')?.()
+    const followUpRun = followUpSocket.emit.mock.calls
+      .filter(([event]: [string]) => event === 'run')
+      .at(-1)?.[1]
+    const followUpQueueId = followUpRun?.queue_id
+    expect(followUpQueueId).toMatch(/^mcu_/)
+    followUpSocket.__handlers.get('run.queued')?.({
+      queued_messages: [{ id: followUpQueueId }],
+    })
+    expect(parentSocket.disconnect).not.toHaveBeenCalled()
+
+    const autonomousStarted = {
+      run_id: 'run-background-delivery',
+      queue_id: 'delegation_delegation-1',
+      autonomous: true,
+      delegation_id: 'delegation-1',
+    }
+    parentSocket.__handlers.get('run.started')?.(autonomousStarted)
+    followUpSocket.__handlers.get('run.started')?.(autonomousStarted)
+    parentSocket.__handlers.get('message.delta')?.({ delta: '后台结果。' })
+    followUpSocket.__handlers.get('message.delta')?.({ delta: '后台结果。' })
+    const autonomousCompleted = {
+      ...autonomousStarted,
+      output: '后台结果。',
+      background_pending: 0,
+    }
+    parentSocket.__handlers.get('run.completed')?.(autonomousCompleted)
+    followUpSocket.__handlers.get('run.completed')?.(autonomousCompleted)
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(parentSocket.disconnect).toHaveBeenCalled()
+    expect(followUpSocket.disconnect).not.toHaveBeenCalled()
+
+    followUpSocket.__handlers.get('run.started')?.({
+      run_id: 'run-follow-up',
+      queue_id: followUpQueueId,
+    })
+    followUpSocket.__handlers.get('run.completed')?.({
+      run_id: 'run-follow-up',
+      queue_id: followUpQueueId,
+      output: '',
+      background_pending: 0,
+    })
+
+    await waitForMockCalls(fetchImpl, 1)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(String(fetchImpl.mock.calls[0][1]?.body))).toMatchObject({ text: '后台结果。' })
+    await waitForMockCallWith(agentSocket.emit, ([event, payload]) => (
+      event === 'interaction.status'
+      && (payload as { interactionId?: string; status?: string })?.interactionId === 'voice-follow-up'
+      && (payload as { status?: string })?.status === 'completed'
+    ))
+    await waitForMockCallWith(agentSocket.emit, ([event, payload]) => (
+      event === 'audio.enqueue'
+      && (payload as { interactionId?: string })?.interactionId === 'mcu-background-delegation-1'
+    ))
+    expect(agentSocket.emit).not.toHaveBeenCalledWith('interaction.status', expect.objectContaining({
+      interactionId: 'voice-follow-up',
+      status: 'failed',
+    }))
+
+    agentSocket.__handlers.get('audio.done')?.({
+      interactionId: 'mcu-background-delegation-1',
+      segmentId: 'mcu-background-delegation-1-tts-1',
+    })
+  })
+
   it('starts later MCU TTS synthesis early but triggers MCU playback one segment at a time', async () => {
     authMocks.authenticateUserToken.mockResolvedValue({ id: 7, username: 'ada', role: 'user' })
     authMocks.userCanAccessProfile.mockReturnValue(true)
@@ -1067,6 +1376,7 @@ describe('GlobalAgentServer', () => {
     })
     const localSocket = clientSocketMocks.localSockets.at(-1)
     localSocket.__handlers.get('connect')?.()
+    startPrimaryMockRun(localSocket)
     localSocket.__handlers.get('message.delta')?.({ delta: '第一句。\n' })
     await waitForMockCalls(fetchImpl, 1)
     localSocket.__handlers.get('message.delta')?.({ delta: '第二句。\n' })
@@ -1153,6 +1463,7 @@ describe('GlobalAgentServer', () => {
     })
     const localSocket = clientSocketMocks.localSockets.at(-1)
     localSocket.__handlers.get('connect')?.()
+    startPrimaryMockRun(localSocket)
     localSocket.__handlers.get('message.delta')?.({ delta: '这段正在合成。\n' })
 
     await waitForMockCalls(fetchImpl, 1)
@@ -1200,6 +1511,7 @@ describe('GlobalAgentServer', () => {
     })
     const localSocket = clientSocketMocks.localSockets.at(-1)
     localSocket.__handlers.get('connect')?.()
+    startPrimaryMockRun(localSocket)
     localSocket.__handlers.get('approval.requested')?.({
       approval_id: 'approval-1',
       choices: ['once', 'session', 'deny'],
@@ -1335,6 +1647,46 @@ describe('GlobalAgentServer', () => {
       deleted: 2,
       memoryCleared: true,
     })
+  })
+
+  it('still aborts an active foreground run when MCU starts listening again', async () => {
+    vi.useFakeTimers()
+    try {
+      authMocks.authenticateUserToken.mockResolvedValue({ id: 7, username: 'ada', role: 'user' })
+      authMocks.userCanAccessProfile.mockReturnValue(true)
+      const nsp = createMockNamespace()
+      const io = { of: vi.fn(() => nsp) }
+      const { GlobalAgentServer } = await import('../../packages/server/src/services/global-agent/server')
+
+      const server = new GlobalAgentServer(io as any)
+      server.init()
+      const agentSocket = createMockSocket('agent-socket', {
+        token: 'user-jwt',
+        role: 'hermes-studio',
+        instanceId: 'device-1',
+        profile: 'research',
+      })
+      await new Promise<void>((resolve, reject) => {
+        nsp.__middleware[0](agentSocket, (err?: Error) => err ? reject(err) : resolve())
+      })
+      nsp.__handlers.get('connection')?.(agentSocket)
+
+      const runSocket = { emit: vi.fn() }
+      ;(server as any).mcuSessionRuns.set('mcu-device-1-research', {
+        interactionId: 'run-1',
+        socket: runSocket,
+      })
+
+      agentSocket.__handlers.get('mcu.interrupt')?.({
+        interactionId: 'run-1',
+        profile: 'research',
+      })
+      await vi.advanceTimersByTimeAsync(300)
+
+      expect(runSocket.emit).toHaveBeenCalledWith('abort', { session_id: 'mcu-device-1-research' })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('cancels a pending MCU interrupt when session clear arrives in the double-click window', async () => {

--- a/tests/server/outbound-relay-client.test.ts
+++ b/tests/server/outbound-relay-client.test.ts
@@ -119,6 +119,16 @@ describe('outbound relay client', () => {
     return sockets.find(socket => socket.__url === url)
   }
 
+  function startPrimaryMockRun(socket: any, runId = 'run-primary'): string {
+    const runCall = socket.emit.mock.calls
+      .filter(([event]: [string]) => event === 'run')
+      .at(-1)
+    const queueId = runCall?.[1]?.queue_id
+    expect(queueId).toMatch(/^mcu_/)
+    socket.__handlers.get('run.started')?.({ run_id: runId, queue_id: queueId })
+    return queueId
+  }
+
   it('stays disabled when no relay url is passed explicitly', async () => {
     const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
 
@@ -519,6 +529,7 @@ describe('outbound relay client', () => {
     })
     const localSocket = socketForUrl('http://127.0.0.1:8648/chat-run')
     localSocket.__handlers.get('connect')?.()
+    startPrimaryMockRun(localSocket)
     localSocket.__handlers.get('message.delta')?.({ delta: '你好' })
     localSocket.__handlers.get('run.completed')?.({})
 
@@ -538,6 +549,121 @@ describe('outbound relay client', () => {
     })
     expect(uploadCall?.[1].body).toBeInstanceOf(Uint8Array)
     expect(Buffer.from(uploadCall?.[1].body as Uint8Array).subarray(0, 4).toString('ascii')).toBe('HADP')
+  })
+
+  it('keeps direct relay background work non-blocking and sends only the final autonomous agent response', async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('/api/hermes/mcu/voice-turn')) {
+        return new Response(JSON.stringify({ ok: true, transcript: '后台查询天气' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url.includes('/api/hermes/tts/synthesize')) {
+        return new Response(Buffer.from('pcm-audio'), {
+          status: 200,
+          headers: { 'content-type': 'audio/x-pcm' },
+        })
+      }
+      return new Response('not found', { status: 404 })
+    })
+    const { startOutboundRelayClient } = await import('../../packages/server/src/services/global-agent/outbound-relay-client')
+
+    startOutboundRelayClient({
+      relayUrl: 'http://device.local:8787',
+      relayProtocol: 'mcu-socket.io',
+      userToken: 'user-jwt',
+      deviceCode: 'device-code-1',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: fetchImpl as any,
+    })
+
+    const remoteSocket = connectRemoteSocket()
+    emitRemote(remoteSocket, 'voice.recorded', {
+      type: 'voice.recorded',
+      interactionId: 'voice-background',
+      mimeType: 'audio/wav',
+      profile: 'research',
+    })
+    emitRemote(remoteSocket, 'voice.stream.chunk', {
+      type: 'voice.stream.chunk',
+      data: Buffer.from('wav-audio').toString('base64'),
+    })
+
+    await vi.waitFor(() => {
+      expect(socketForUrl('http://127.0.0.1:8648/chat-run')).toBeTruthy()
+    })
+    const localSocket = socketForUrl('http://127.0.0.1:8648/chat-run')
+    localSocket.__handlers.get('connect')?.()
+    startPrimaryMockRun(localSocket, 'run-parent')
+    localSocket.__handlers.get('delegation.updated')?.({
+      delegation_id: 'delegation-1',
+      status: 'running',
+      background_pending: 1,
+    })
+    localSocket.__handlers.get('run.completed')?.({
+      run_id: 'run-parent',
+      output: '',
+      background_pending: 1,
+    })
+
+    await vi.waitFor(() => {
+      expect(remoteSocket.emit).toHaveBeenCalledWith('interaction.status', expect.objectContaining({
+        interactionId: 'voice-background',
+        status: 'completed',
+      }))
+    })
+    expect(localSocket.disconnect).not.toHaveBeenCalled()
+    expect(fetchImpl.mock.calls.filter(([url]: [string]) => url.includes('/api/hermes/tts/synthesize'))).toHaveLength(0)
+
+    remoteSocket.emit.mockClear()
+    localSocket.__handlers.get('run.started')?.({
+      run_id: 'run-background-delivery',
+      autonomous: true,
+      delegation_id: 'delegation-1',
+    })
+    localSocket.__handlers.get('message.delta')?.({
+      run_id: 'run-background-delivery',
+      delta: '厦门明天晴，最高温度 30 度。',
+    })
+    expect(remoteSocket.emit).not.toHaveBeenCalledWith('interaction.status', expect.objectContaining({ status: 'thinking' }))
+    expect(remoteSocket.emit).not.toHaveBeenCalledWith('audio.enqueue', expect.anything())
+
+    localSocket.__handlers.get('run.completed')?.({
+      run_id: 'run-background-delivery',
+      autonomous: true,
+      delegation_id: 'delegation-1',
+      output: '厦门明天晴，最高温度 30 度。',
+      background_pending: 0,
+    })
+
+    await vi.waitFor(() => {
+      const ttsCalls = fetchImpl.mock.calls.filter(([url]: [string]) => url.includes('/api/hermes/tts/synthesize'))
+      expect(ttsCalls).toHaveLength(1)
+      expect(JSON.parse(String(ttsCalls[0][1]?.body))).toMatchObject({
+        text: '厦门明天晴，最高温度 30 度。',
+      })
+    })
+    await vi.waitFor(() => {
+      expect(remoteSocket.emit).toHaveBeenCalledWith('audio.enqueue', expect.objectContaining({
+        interactionId: 'mcu-background-delegation-1',
+        segmentId: 'mcu-background-delegation-1-tts-1',
+        completionManagedByServer: true,
+      }))
+    })
+    expect(localSocket.disconnect).toHaveBeenCalled()
+
+    emitRemote(remoteSocket, 'audio.done', {
+      type: 'audio.done',
+      interactionId: 'mcu-background-delegation-1',
+      segmentId: 'mcu-background-delegation-1-tts-1',
+    })
+    await vi.waitFor(() => {
+      expect(remoteSocket.emit).toHaveBeenCalledWith('interaction.status', expect.objectContaining({
+        interactionId: 'mcu-background-delegation-1',
+        status: 'completed',
+      }))
+    })
   })
 
   it('queues the hosted TTS-failed prompt when Socket.IO MCU speech synthesis fails', async () => {
@@ -580,6 +706,7 @@ describe('outbound relay client', () => {
     })
     const localSocket = socketForUrl('http://127.0.0.1:8648/chat-run')
     localSocket.__handlers.get('connect')?.()
+    startPrimaryMockRun(localSocket)
     localSocket.__handlers.get('message.delta')?.({ delta: '你好' })
     localSocket.__handlers.get('run.completed')?.({})
 
@@ -652,6 +779,7 @@ describe('outbound relay client', () => {
     })
     const localSocket = socketForUrl('http://127.0.0.1:8648/chat-run')
     localSocket.__handlers.get('connect')?.()
+    startPrimaryMockRun(localSocket)
     localSocket.__handlers.get('message.delta')?.({ delta: '这段正在合成。\n' })
 
     await vi.waitFor(() => {

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -239,7 +239,7 @@ describe('bridge run final context usage', () => {
     await handleBridgeRun(
       nsp,
       socket,
-      { input: 'hello again', session_id: 'session-1' },
+      { input: 'hello again', session_id: 'session-1', queue_id: 'mcu-test-run' },
       'default',
       sessionMap,
       bridge,
@@ -263,8 +263,12 @@ describe('bridge run final context usage', () => {
     expect(reopenCallIndex).toBeGreaterThanOrEqual(0)
     expect(endedCallIndex).toBeGreaterThanOrEqual(0)
     expect(reopenCallIndex).toBeLessThan(endedCallIndex)
+    expect(emit).toHaveBeenCalledWith('run.started', expect.objectContaining({
+      queue_id: 'mcu-test-run',
+    }))
     expect(emit).toHaveBeenCalledWith('run.completed', expect.objectContaining({
       output: 'done',
+      queue_id: 'mcu-test-run',
     }))
   })
 


### PR DESCRIPTION
## What changed

- keep the MCU chat-run listener alive while background delegations are pending
- speak only the final autonomous Agent response after background work completes
- isolate foreground MCU voice runs with an internal `queue_id`
- preserve active foreground interruption while allowing idle background work to continue
- apply the same compatibility behavior to the direct outbound relay path
- document the chat-chain behavior and add concurrency regression coverage

## Why

MCU voice turns created a new `/chat-run` listener for each recording. When a background autonomous result returned while a new voice turn was queued on the same session, the new listener could receive the old run mid-stream and treat its events as the current foreground response. That race could leave the MCU interaction stuck in `thinking` or mix background output into the new reply.

The Web UI did not reproduce this because it retains a session-scoped listener. The MCU adapters now use an internal `queue_id` to identify their own foreground run while the previous listener remains responsible for the background result.

## Impact

- MCU parent turns return to idle without waiting for background subtasks.
- A later background result is synthesized only after the final autonomous Agent response is available.
- Starting a new recording while background work is idle does not abort that work.
- Starting or interrupting during an active foreground run still aborts normally.
- The MCU wire protocol is unchanged, so existing firmware remains compatible.
- The transparent remote relay server requires no changes.

## Validation

- `npm run harness:check`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- 91 focused server tests passed
- `npm run build`
- full Vitest run: 2,880 passed, 2 skipped; one unrelated existing Codex model-catalog assertion expects `gpt-5.4-mini`, while the current catalog returns newer models
