### PR TITLE
fix: enforce fail-closed coding agent routing

### DIFF
--- a/bin/hermes-studio-mcp.mjs
+++ b/bin/hermes-studio-mcp.mjs
@@ -576,6 +576,61 @@ function pickDefined(source, keys) {
   return picked
 }
 
+const CHAT_RUN_PAYLOAD_KEYS = [
+  'input',
+  'session_id',
+  'provider',
+  'model',
+  'model_groups',
+  'source',
+  'session_source',
+  'instructions',
+  'workspace',
+  'reasoning_effort',
+  'coding_agent_id',
+  'agent_id',
+  'mode',
+  'baseUrl',
+  'apiKey',
+  'apiMode',
+  'timeout_ms',
+  'include_events',
+]
+
+function startChatRun(args, overrides = {}) {
+  return request('/api/chat-run/runs', withAuthArgs(args, {
+    method: 'POST',
+    body: {
+      ...pickDefined(args, CHAT_RUN_PAYLOAD_KEYS),
+      ...overrides,
+    },
+  }))
+}
+
+function validateCodingAgentRunArgs(args) {
+  if (
+    (typeof args.input !== 'string' || !args.input.trim())
+    && (!Array.isArray(args.input) || args.input.length === 0)
+  ) {
+    return 'input must be a non-empty string or non-empty array'
+  }
+  if (args.mode !== undefined && !['scoped', 'global'].includes(args.mode)) {
+    return 'mode must be one of: scoped, global'
+  }
+  for (const key of ['provider', 'model', 'coding_agent_id']) {
+    if (typeof args[key] !== 'string' || !args[key].trim()) {
+      return `${key} must be a non-empty exact ${key === 'provider' ? 'provider key' : key === 'model' ? 'model id' : 'coding agent id'}`
+    }
+  }
+  if (!['claude-code', 'codex'].includes(args.coding_agent_id)) {
+    return 'coding_agent_id must be one of: claude-code, codex'
+  }
+  if (args.provider.trim().toLowerCase() === 'custom') {
+    return 'provider must not be the generic "custom" key; pass the exact configured provider key'
+  }
+  return ''
+}
+
 function boundedInteger(value, fallback, min, max) {
   const parsed = Number.parseInt(String(value ?? ''), 10)
   if (!Number.isFinite(parsed)) return fallback
@@ -828,7 +883,7 @@ const tools = [
   {
     name: 'hermes_studio_use_chat_run',
     toolset: 'use',
-    description: 'Start one user-requested Hermes Studio chat or coding-agent run through the HTTP bridge and wait for completion. Do not use this as an internal delegation or subtask mechanism.',
+    description: 'Start one user-requested regular Hermes Studio chat through the HTTP bridge and wait for completion. Coding tasks must use hermes_studio_use_coding_agent_run so the coding agent, provider, and model cannot silently fall back to CLI defaults. Do not use this as an internal delegation or subtask mechanism.',
     inputSchema: inputSchema({
         input: {
           oneOf: [
@@ -913,6 +968,76 @@ const tools = [
           description: 'Include recorded run events in the response.',
         },
       }, ['input']),
+  },
+  {
+    name: 'hermes_studio_use_coding_agent_run',
+    toolset: 'use',
+    description: 'Start one user-requested coding-agent run. Coding tasks must use this dedicated tool. The coding agent executor, provider, and model are inherited exactly as provided; source is fixed to coding_agent and mode defaults to scoped. Missing or ambiguous routing fields fail before any HTTP request. Do not use this as an internal delegation or subtask mechanism.',
+    inputSchema: inputSchema({
+        input: {
+          oneOf: [
+            { type: 'string' },
+            { type: 'array', items: { type: 'object', additionalProperties: true } },
+          ],
+          description: 'Coding task text or content blocks.',
+        },
+        coding_agent_id: {
+          type: 'string',
+          enum: ['claude-code', 'codex'],
+          description: 'Exact coding agent executor selected by the caller.',
+        },
+        provider: {
+          type: 'string',
+          description: 'Exact configured provider key. The generic custom key is rejected.',
+        },
+        model: {
+          type: 'string',
+          description: 'Exact model id for this coding-agent run.',
+        },
+        mode: {
+          type: 'string',
+          enum: ['scoped', 'global'],
+          default: 'scoped',
+          description: 'Optional coding-agent launch mode. Defaults to scoped.',
+        },
+        session_id: {
+          type: 'string',
+          description: 'Optional existing session id. Omit to create a new session.',
+        },
+        instructions: {
+          type: 'string',
+          description: 'Optional extra run instructions.',
+        },
+        workspace: {
+          type: ['string', 'null'],
+          description: 'Optional working directory for the run.',
+        },
+        reasoning_effort: {
+          type: 'string',
+          description: 'Optional per-run reasoning effort override.',
+        },
+        baseUrl: {
+          type: 'string',
+          description: 'Optional provider base URL for coding-agent runs.',
+        },
+        apiKey: {
+          type: 'string',
+          description: 'Optional provider API key for coding-agent runs.',
+        },
+        apiMode: {
+          type: 'string',
+          enum: ['chat_completions', 'codex_responses', 'anthropic_messages'],
+          description: 'Optional provider wire API mode for coding-agent runs.',
+        },
+        timeout_ms: {
+          type: 'number',
+          description: 'Maximum time to wait for a terminal run event.',
+        },
+        include_events: {
+          type: 'boolean',
+          description: 'Include recorded run events in the response.',
+        },
+      }, ['input', 'coding_agent_id', 'provider', 'model']),
   },
   {
     name: 'hermes_studio_use_sessions_list',
@@ -1497,29 +1622,16 @@ async function callTool(name, args = {}) {
       return jsonText(await requestEnvelope(path, options))
     }
     case 'hermes_studio_use_chat_run':
-      return jsonText(await request('/api/chat-run/runs', withAuthArgs(args, {
-        method: 'POST',
-        body: pickDefined(args, [
-          'input',
-          'session_id',
-          'provider',
-          'model',
-          'model_groups',
-          'source',
-          'session_source',
-          'instructions',
-          'workspace',
-          'reasoning_effort',
-          'coding_agent_id',
-          'agent_id',
-          'mode',
-          'baseUrl',
-          'apiKey',
-          'apiMode',
-          'timeout_ms',
-          'include_events',
-        ]),
-      })))
+      return jsonText(await startChatRun(args))
+    case 'hermes_studio_use_coding_agent_run': {
+      const validationError = validateCodingAgentRunArgs(args)
+      if (validationError) return errorText(validationError)
+      return jsonText(await startChatRun(args, {
+        source: 'coding_agent',
+        coding_agent_id: args.coding_agent_id,
+        mode: args.mode || 'scoped',
+      }))
+    }
     case 'hermes_studio_use_sessions_list':
       return jsonText(await request('/api/hermes/sessions', withAuthArgs(args, {
         query: pickDefined(args, ['limit', 'source']),

--- a/docs/chat-chain-changes/2026-07-22-coding-agent-mcp-run-contract.md
+++ b/docs/chat-chain-changes/2026-07-22-coding-agent-mcp-run-contract.md
@@ -1,0 +1,10 @@
+---
+date: 2026-07-22
+pr: pending
+feature: Fail-closed coding-agent MCP run contract
+impact: Coding-agent runs now use a dedicated MCP tool with explicit executor, provider, and model routing, while ordinary chat runs remain compatible.
+---
+
+`hermes_studio_use_coding_agent_run` fixes `source` to `coding_agent` and
+defaults `mode` to `scoped`. It rejects missing or ambiguous routing fields
+before calling the existing `/api/chat-run/runs` bridge.

--- a/packages/server/src/lib/llm-prompt.ts
+++ b/packages/server/src/lib/llm-prompt.ts
@@ -83,6 +83,7 @@ export const HERMES_MCP_USAGE_GUIDELINES = [
   'Use the module purpose and keywords from hermes_studio_api_openapi_get to choose the right module, then call it again with a tag, path, or method filter before calling unfamiliar Web UI endpoints.',
   'Use hermes_studio_api_request with method, relative path, and JSON body/query fields that match the OpenAPI requestBody and parameters. Do not call full URLs.',
   'Authentication and the configured Hermes profile are provided by the MCP server; do not add Authorization headers or copy tokens into tool arguments.',
+  'Coding tasks must use hermes_studio_use_coding_agent_run, with coding_agent_id, provider and model exactly matching the requested executor and route. Do not use hermes_studio_use_chat_run for coding-agent execution.',
   'Do not use hermes_studio_use_chat_run, Hermes Studio session tools, /api/chat-run/*, or /api/hermes/sessions/* as an internal delegation mechanism. In delegate_task, subtask, or workflow-node contexts, do not create, rename, delete, or continue Hermes Studio sessions unless the user explicitly asked to operate Hermes Studio sessions; return the delegated result in the current task instead.',
 ];
 

--- a/tests/server/hermes-web-ui-mcp.test.ts
+++ b/tests/server/hermes-web-ui-mcp.test.ts
@@ -317,6 +317,249 @@ describe('hermes-web-ui MCP server', () => {
     expect(stdout.trim()).toBe(`hermes-studio-mcp v${pkg.version}`)
   })
 
+  it('exposes a fail-closed coding-agent run tool without changing generic chat runs', async () => {
+    const receivedBodies: Record<string, unknown>[] = []
+    const server = createServer((req, res) => {
+      if (req.url !== '/api/chat-run/runs') {
+        res.statusCode = 404
+        res.end('{}')
+        return
+      }
+      let raw = ''
+      req.on('data', chunk => { raw += chunk })
+      req.on('end', () => {
+        const body = raw ? JSON.parse(raw) : null
+        receivedBodies.push(body)
+        res.setHeader('content-type', 'application/json')
+        res.end(JSON.stringify({ ok: true, body }))
+      })
+    })
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    if (!address || typeof address === 'string') throw new Error('expected TCP server address')
+
+    const responses = new Map<number, any>()
+    child = spawn(process.execPath, ['bin/hermes-studio-mcp.mjs', 'use'], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HERMES_WEB_UI_URL: `http://127.0.0.1:${address.port}`,
+      },
+    })
+    child.stdout.on('data', (chunk) => {
+      for (const line of String(chunk).trim().split('\n')) {
+        if (!line) continue
+        const message = JSON.parse(line)
+        responses.set(message.id, message)
+      }
+    })
+
+    writeRpc(child, 1, 'tools/list')
+    writeRpc(child, 2, 'tools/call', {
+      name: 'hermes_studio_use_coding_agent_run',
+      arguments: {
+        input: 'fix the bug',
+        coding_agent_id: 'codex',
+        provider: 'openai',
+        model: 'gpt-5.1-codex',
+      },
+    })
+    writeRpc(child, 3, 'tools/call', {
+      name: 'hermes_studio_use_coding_agent_run',
+      arguments: {
+        input: 'empty provider',
+        coding_agent_id: 'codex',
+        provider: '',
+        model: 'gpt-5.1-codex',
+      },
+    })
+    writeRpc(child, 4, 'tools/call', {
+      name: 'hermes_studio_use_coding_agent_run',
+      arguments: {
+        input: 'missing provider',
+        coding_agent_id: 'codex',
+        model: 'gpt-5.1-codex',
+      },
+    })
+    writeRpc(child, 5, 'tools/call', {
+      name: 'hermes_studio_use_coding_agent_run',
+      arguments: {
+        input: 'empty model',
+        coding_agent_id: 'codex',
+        provider: 'openai',
+        model: ' ',
+      },
+    })
+    writeRpc(child, 6, 'tools/call', {
+      name: 'hermes_studio_use_coding_agent_run',
+      arguments: {
+        input: 'missing model',
+        coding_agent_id: 'codex',
+        provider: 'openai',
+      },
+    })
+    writeRpc(child, 7, 'tools/call', {
+      name: 'hermes_studio_use_coding_agent_run',
+      arguments: {
+        input: 'empty agent',
+        coding_agent_id: '',
+        provider: 'openai',
+        model: 'gpt-5.1-codex',
+      },
+    })
+    writeRpc(child, 8, 'tools/call', {
+      name: 'hermes_studio_use_coding_agent_run',
+      arguments: {
+        input: 'missing agent',
+        provider: 'openai',
+        model: 'gpt-5.1-codex',
+      },
+    })
+    writeRpc(child, 9, 'tools/call', {
+      name: 'hermes_studio_use_coding_agent_run',
+      arguments: {
+        input: 'generic custom is not exact',
+        coding_agent_id: 'codex',
+        provider: 'custom',
+        model: 'private-codex',
+      },
+    })
+    writeRpc(child, 10, 'tools/call', {
+      name: 'hermes_studio_use_chat_run',
+      arguments: { input: 'normal CLI chat' },
+    })
+    writeRpc(child, 11, 'tools/call', {
+      name: 'hermes_studio_use_coding_agent_run',
+      arguments: {
+        input: [{ type: 'text', text: 'fix with context' }],
+        coding_agent_id: 'codex',
+        provider: 'openai',
+        model: 'gpt-5.1-codex',
+        mode: 'global',
+      },
+    })
+    writeRpc(child, 12, 'tools/call', {
+      name: 'hermes_studio_use_coding_agent_run',
+      arguments: {
+        input: '',
+        coding_agent_id: 'codex',
+        provider: 'openai',
+        model: 'gpt-5.1-codex',
+      },
+    })
+    writeRpc(child, 13, 'tools/call', {
+      name: 'hermes_studio_use_coding_agent_run',
+      arguments: {
+        input: [],
+        coding_agent_id: 'codex',
+        provider: 'openai',
+        model: 'gpt-5.1-codex',
+      },
+    })
+    writeRpc(child, 14, 'tools/call', {
+      name: 'hermes_studio_use_coding_agent_run',
+      arguments: {
+        input: 'invalid mode',
+        coding_agent_id: 'codex',
+        provider: 'openai',
+        model: 'gpt-5.1-codex',
+        mode: 'evil',
+      },
+    })
+
+    const list = await waitForRpc(responses, 1)
+    const codingAgentTool = list.result.tools.find((tool: any) => tool.name === 'hermes_studio_use_coding_agent_run')
+    expect(codingAgentTool.inputSchema.required).toEqual([
+      'input',
+      'coding_agent_id',
+      'provider',
+      'model',
+    ])
+    expect(codingAgentTool.inputSchema.properties.mode).toEqual({
+      type: 'string',
+      enum: ['scoped', 'global'],
+      default: 'scoped',
+      description: 'Optional coding-agent launch mode. Defaults to scoped.',
+    })
+    expect(codingAgentTool.description).toContain('Coding tasks must use this dedicated tool')
+    expect(codingAgentTool.description).toContain('exactly as provided')
+
+    const codingAgentRun = JSON.parse((await waitForRpc(responses, 2)).result.content[0].text)
+    expect(codingAgentRun.body).toEqual({
+      input: 'fix the bug',
+      provider: 'openai',
+      model: 'gpt-5.1-codex',
+      source: 'coding_agent',
+      coding_agent_id: 'codex',
+      mode: 'scoped',
+    })
+
+    for (const id of [3, 4]) {
+      const invalidProvider = await waitForRpc(responses, id)
+      expect(invalidProvider.result.isError).toBe(true)
+      expect(invalidProvider.result.content[0].text).toContain('provider must be a non-empty exact provider key')
+    }
+    for (const id of [5, 6]) {
+      const invalidModel = await waitForRpc(responses, id)
+      expect(invalidModel.result.isError).toBe(true)
+      expect(invalidModel.result.content[0].text).toContain('model must be a non-empty exact model id')
+    }
+    for (const id of [7, 8]) {
+      const invalidAgent = await waitForRpc(responses, id)
+      expect(invalidAgent.result.isError).toBe(true)
+      expect(invalidAgent.result.content[0].text).toContain('coding_agent_id must be a non-empty exact coding agent id')
+    }
+
+    const genericCustom = await waitForRpc(responses, 9)
+    expect(genericCustom.result.isError).toBe(true)
+    expect(genericCustom.result.content[0].text).toContain('provider must not be the generic "custom" key')
+
+    const genericChatRun = JSON.parse((await waitForRpc(responses, 10)).result.content[0].text)
+    expect(genericChatRun.body).toEqual({ input: 'normal CLI chat' })
+
+    const contentBlockRun = JSON.parse((await waitForRpc(responses, 11)).result.content[0].text)
+    expect(contentBlockRun.body).toEqual({
+      input: [{ type: 'text', text: 'fix with context' }],
+      provider: 'openai',
+      model: 'gpt-5.1-codex',
+      source: 'coding_agent',
+      coding_agent_id: 'codex',
+      mode: 'global',
+    })
+
+    for (const id of [12, 13]) {
+      const invalidInput = await waitForRpc(responses, id)
+      expect(invalidInput.result.isError).toBe(true)
+      expect(invalidInput.result.content[0].text).toContain('input must be a non-empty string or non-empty array')
+    }
+
+    const invalidMode = await waitForRpc(responses, 14)
+    expect(invalidMode.result.isError).toBe(true)
+    expect(invalidMode.result.content[0].text).toContain('mode must be one of: scoped, global')
+
+    expect(receivedBodies).toEqual([
+      {
+        input: 'fix the bug',
+        provider: 'openai',
+        model: 'gpt-5.1-codex',
+        source: 'coding_agent',
+        coding_agent_id: 'codex',
+        mode: 'scoped',
+      },
+      { input: 'normal CLI chat' },
+      {
+        input: [{ type: 'text', text: 'fix with context' }],
+        provider: 'openai',
+        model: 'gpt-5.1-codex',
+        source: 'coding_agent',
+        coding_agent_id: 'codex',
+        mode: 'global',
+      },
+    ])
+
+    await new Promise<void>(resolve => server.close(() => resolve()))
+  })
+
   it('exposes curated Hermes Studio use tools in the use toolset', async () => {
     const server = createServer((req, res) => {
       res.setHeader('content-type', 'application/json')

--- a/tests/server/llm-prompt.test.ts
+++ b/tests/server/llm-prompt.test.ts
@@ -10,6 +10,8 @@ describe('LLM prompt', () => {
     expect(prompt).toContain('hermes_studio_api_request')
     expect(prompt).toContain('OpenAPI requestBody')
     expect(prompt).toContain('do not add Authorization headers')
+    expect(prompt).toContain('Coding tasks must use hermes_studio_use_coding_agent_run')
+    expect(prompt).toContain('provider and model exactly')
     expect(prompt).toContain('Do not use hermes_studio_use_chat_run')
     expect(prompt).toContain('internal delegation mechanism')
     expect(prompt).toContain('return the delegated result in the current task instead')


### PR DESCRIPTION
## Summary

- add a dedicated `hermes_studio_use_coding_agent_run` MCP tool for coding-agent launches
- require exact `coding_agent_id`, `provider`, and `model` routing fields and force `source=coding_agent`
- reject empty input, generic `custom`, unsupported agents, and invalid modes before making an HTTP request
- keep the existing generic chat-run tool backward compatible
- direct coding tasks to the dedicated tool in the generated LLM prompt

## Problem

The generic chat-run MCP tool only required `input`. Some models therefore omitted the optional coding-agent routing fields, and the request silently fell back to a regular CLI/Hermes run while still looking successful to the caller.

This change makes coding-agent launches fail closed instead of silently changing execution paths.

## Contract

The dedicated tool requires `input`, `coding_agent_id` (`codex` or `claude-code`), exact `provider`, and exact `model`. It fixes `source` to `coding_agent`, defaults `mode` to `scoped`, and validates the contract both in the MCP schema and at runtime.

## Verification

After rebasing onto the current `main`:

- `npm run harness:check` — passed
- focused Vitest suite — 7/7 passed
- `npm run build` — passed
- `git diff --check origin/main...HEAD` — passed
- local end-to-end Grok → Codex launch verified as a real coding-agent run rather than a CLI fallback

## Compatibility

The existing `hermes_studio_use_chat_run` behavior remains available for regular Studio chat runs. The new tool only adds a stricter path for explicit coding-agent execution.