### PR TITLE
Fix chat diff attribution and Desktop browser previews

### DIFF
--- a/docs/chat-chain-changes/2026-07-23-hide-unattributed-workspace-diffs.md
+++ b/docs/chat-chain-changes/2026-07-23-hide-unattributed-workspace-diffs.md
@@ -1,0 +1,18 @@
+---
+date: 2026-07-23
+pr: pending
+feature: Hide unattributed single-chat workspace diffs
+impact: Workspace changes without an assistant message ID no longer render as legacy cards near the end of chat history.
+---
+
+Single-chat workspace diff rendering now requires a non-empty
+`assistant_message_id`. Unattributed historical changes are ignored instead of
+being restored onto tool messages or inserted as timestamp-based synthetic cards.
+
+Changes that do contain an assistant message ID keep the existing pagination
+behavior: if the referenced message is not loaded yet, the temporary standalone
+card can remain until that exact assistant turn is loaded and the diff is attached
+to it.
+
+This is a client projection change only. Workspace diff collection, persistence,
+server APIs, and attributed historical records are unchanged.

--- a/docs/chat-chain-changes/2026-07-23-open-desktop-links-in-browser.md
+++ b/docs/chat-chain-changes/2026-07-23-open-desktop-links-in-browser.md
@@ -1,0 +1,14 @@
+---
+date: 2026-07-23
+pr: pending
+feature: Open chat links in the Desktop browser
+impact: Desktop single-chat and group-chat links and HTML workspace files open in the embedded browser while Web behavior remains unchanged.
+---
+
+Desktop single-chat and group-chat message links now open in the embedded
+browser. Opening an HTML workspace file sends its already-authenticated content
+to an isolated browser preview tab instead of rendering the Web UI iframe.
+
+The Web UI keeps its existing external-tab behavior and restrictive HTML iframe
+preview. Local HTML preview tabs are not persisted, so raw preview content is
+not written into the browser profile tab history.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -56,6 +56,7 @@ import { useDefaultWorkspace } from "@/composables/useDefaultWorkspace";
 import { canScopedCodingAgentUseProvider, usesServerManagedProviderAuth } from "@/utils/codingAgentProviders";
 import { OPEN_SUBAGENT_STREAM_EVENT, type OpenSubagentStreamDetail } from "@/utils/hermes/subagent-stream";
 import { hasDesktopBrowserBridge } from "@/utils/desktop-bridge";
+import { OPEN_DESKTOP_BROWSER_PANEL_EVENT } from "@/utils/desktop-browser";
 
 const FilesPanel = defineAsyncComponent(async () => (await import('./FilesPanel.vue')).default);
 const FilePreview = defineAsyncComponent(async () => (await import('@/components/hermes/files/FilePreview.vue')).default);
@@ -351,12 +352,27 @@ function handleOpenSubagentStreamRequest(event: Event) {
   showToolPanel.value = true;
 }
 
+function handleOpenDesktopBrowserPanelRequest() {
+  if (!desktopBrowserAvailable) return;
+  if (toolPanelStore.workspaceDiff && filesStore.hasUnsavedChanges) {
+    message.warning(t("files.unsavedChanges"));
+    return;
+  }
+  if (toolPanelStore.workspaceDiff && filesStore.editingFile) filesStore.closeEditor();
+  filesStore.closePreview();
+  toolPanelStore.closeWorkspaceDiff();
+  selectedSubagent.value = null;
+  activeToolPanel.value = "browser";
+  showToolPanel.value = true;
+}
+
 onMounted(() => {
   mobileQuery = window.matchMedia("(max-width: 768px)");
   handleMobileChange(mobileQuery);
   mobileQuery.addEventListener("change", handleMobileChange);
   window.addEventListener("hermes:open-page-sidebar", openPageSidebar);
   window.addEventListener("hermes:preview-workspace-file", handleWorkspaceFilePreviewRequest);
+  window.addEventListener(OPEN_DESKTOP_BROWSER_PANEL_EVENT, handleOpenDesktopBrowserPanelRequest);
   window.addEventListener(OPEN_SUBAGENT_STREAM_EVENT, handleOpenSubagentStreamRequest);
   window.addEventListener("resize", handleToolPanelViewportResize);
   handleToolPanelViewportResize();
@@ -398,6 +414,7 @@ onUnmounted(() => {
   mobileQuery?.removeEventListener("change", handleMobileChange);
   window.removeEventListener("hermes:open-page-sidebar", openPageSidebar);
   window.removeEventListener("hermes:preview-workspace-file", handleWorkspaceFilePreviewRequest);
+  window.removeEventListener(OPEN_DESKTOP_BROWSER_PANEL_EVENT, handleOpenDesktopBrowserPanelRequest);
   window.removeEventListener(OPEN_SUBAGENT_STREAM_EVENT, handleOpenSubagentStreamRequest);
   window.removeEventListener("resize", handleToolPanelViewportResize);
   stopToolResize();

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -19,6 +19,7 @@ import {
 } from './mermaidRenderer'
 import { downloadFile, getDownloadUrl, inferDownloadFileName } from '@/api/hermes/download'
 import { isPreviewableFile } from '@/utils/hermes/file-preview'
+import { openUrlInDesktopBrowser } from '@/utils/desktop-browser'
 
 const LATEX_FENCE_LANGS = new Set(['latex', 'tex', 'math', 'katex'])
 function getFenceLanguage(info: string): string {
@@ -444,10 +445,16 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
   const href = link.getAttribute('href')
   if (!href) return
 
-  // Let http(s) links behave normally — use window.open to prevent
-  // the hash-based router from intercepting the click
+  // Desktop chat links stay inside the embedded browser. Web deployments keep
+  // using a separate browser tab so the hash-based router cannot intercept.
   if (href.startsWith('http://') || href.startsWith('https://')) {
     event.preventDefault()
+    try {
+      if (await openUrlInDesktopBrowser(href)) return
+    } catch (error) {
+      message.error(`${t('browser.loadFailed')}: ${error instanceof Error ? error.message : String(error)}`)
+      return
+    }
     window.open(href, '_blank', 'noopener,noreferrer')
     return
   }

--- a/packages/client/src/components/hermes/files/FilePreview.vue
+++ b/packages/client/src/components/hermes/files/FilePreview.vue
@@ -9,6 +9,7 @@ import { downloadSessionWorkspaceFile, fetchSessionWorkspaceFileBlob } from '@/a
 import { downloadGroupWorkspaceFile, fetchGroupWorkspaceFileBlob } from '@/api/hermes/group-chat'
 import { handleCodeBlockCopyClick, renderHighlightedCodeBlock } from '@/components/hermes/chat/highlight'
 import { previewMimeMatches } from '@/utils/hermes/file-preview'
+import { openHtmlInDesktopBrowser } from '@/utils/desktop-browser'
 
 const MarkdownRenderer = defineAsyncComponent(async () => (await import('@/components/hermes/chat/MarkdownRenderer.vue')).default)
 const HtmlFilePreview = defineAsyncComponent(async () => (await import('./HtmlFilePreview.vue')).default)
@@ -68,6 +69,7 @@ async function loadPreview(): Promise<void> {
       const text = await blob.text()
       if (generation !== requestGeneration) return
       previewText.value = text
+      if (file.type === 'html' && await openHtmlInDesktopBrowser(text, file.name)) return
     } else {
       const buffer = await blob.arrayBuffer()
       if (generation !== requestGeneration) return

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -17,10 +17,13 @@ import type { Attachment } from '@/stores/hermes/chat'
 import type { RoomAgent, RoomInfo } from '@/api/hermes/group-chat'
 import { useFilesStore } from '@/stores/hermes/files'
 import { useToolPanelStore } from '@/stores/hermes/tool-panel'
+import { hasDesktopBrowserBridge } from '@/utils/desktop-bridge'
+import { OPEN_DESKTOP_BROWSER_PANEL_EVENT } from '@/utils/desktop-browser'
 
 const FilesPanel = defineAsyncComponent(async () => (await import('@/components/hermes/chat/FilesPanel.vue')).default)
 const FilePreview = defineAsyncComponent(async () => (await import('@/components/hermes/files/FilePreview.vue')).default)
 const WorkspaceDiffPreview = defineAsyncComponent(async () => (await import('@/components/hermes/files/WorkspaceDiffPreview.vue')).default)
+const DesktopBrowserPanel = defineAsyncComponent(async () => (await import('@/components/hermes/chat/DesktopBrowserPanel.vue')).default)
 
 const { t } = useI18n()
 const router = useRouter()
@@ -54,6 +57,8 @@ const chatDropCounter = ref(0)
 const isChatDropActive = ref(false)
 const groupChatContentWrapperRef = ref<HTMLElement | null>(null)
 const showWorkspacePanel = ref(false)
+const activeWorkspacePanel = ref<'files' | 'browser'>('files')
+const desktopBrowserAvailable = hasDesktopBrowserBridge()
 const workspacePanelMobile = ref(window.innerWidth <= 768)
 const WORKSPACE_PANEL_MIN_WIDTH = 360
 const WORKSPACE_PANEL_DEFAULT_WIDTH = 560
@@ -185,8 +190,35 @@ function closeWorkspacePanel(): void {
 
 function toggleWorkspacePanel(): void {
     if (!currentRoom.value?.workspace) return
-    if (showWorkspacePanel.value) closeWorkspacePanel()
-    else showWorkspacePanel.value = true
+    if (showWorkspacePanel.value && activeWorkspacePanel.value === 'files') {
+        closeWorkspacePanel()
+        return
+    }
+    activeWorkspacePanel.value = 'files'
+    showWorkspacePanel.value = true
+}
+
+function selectWorkspacePanel(panel: 'files' | 'browser'): void {
+    if (panel === 'browser') {
+        if (!desktopBrowserAvailable) return
+        if (toolPanelStore.workspaceDiff?.editable && filesStore.hasUnsavedChanges) {
+            message.warning(t('files.unsavedChanges'))
+            return
+        }
+        if (toolPanelStore.workspaceDiff?.editable && filesStore.editingFile) filesStore.closeEditor()
+        filesStore.closePreview()
+        toolPanelStore.closeWorkspaceDiff()
+    }
+    activeWorkspacePanel.value = panel
+    showWorkspacePanel.value = true
+}
+
+function handleOpenDesktopBrowserPanelRequest(): void {
+    selectWorkspacePanel('browser')
+}
+
+function handleBrowserAttachment(payload: { file: File }): void {
+    groupChatInputRef.value?.addFiles?.([payload.file])
 }
 
 function groupWorkspacePreviewPath(filePath: string): string | null {
@@ -444,6 +476,7 @@ async function handleAddAgent() {
 onMounted(() => {
     window.addEventListener('hermes:open-page-sidebar', openPageSidebar)
     window.addEventListener('hermes:preview-workspace-file', handleWorkspaceFilePreviewRequest)
+    window.addEventListener(OPEN_DESKTOP_BROWSER_PANEL_EVENT, handleOpenDesktopBrowserPanelRequest)
     window.addEventListener('resize', handleWorkspacePanelResize)
     handleWorkspacePanelResize()
     if (profilesStore.profiles.length === 0) {
@@ -454,6 +487,7 @@ onMounted(() => {
 onUnmounted(() => {
     window.removeEventListener('hermes:open-page-sidebar', openPageSidebar)
     window.removeEventListener('hermes:preview-workspace-file', handleWorkspaceFilePreviewRequest)
+    window.removeEventListener(OPEN_DESKTOP_BROWSER_PANEL_EVENT, handleOpenDesktopBrowserPanelRequest)
     window.removeEventListener('resize', handleWorkspacePanelResize)
     stopWorkspaceResize()
     if (showWorkspacePanel.value) closeWorkspacePanel()
@@ -465,11 +499,17 @@ watch(() => store.currentRoomId, (roomId, previousRoomId) => {
 })
 
 watch(() => filesStore.previewFile, previewFile => {
-    if (previewFile?.workspaceRoomId === store.currentRoomId) showWorkspacePanel.value = true
+    if (previewFile?.workspaceRoomId === store.currentRoomId) {
+        activeWorkspacePanel.value = 'files'
+        showWorkspacePanel.value = true
+    }
 })
 
 watch(() => toolPanelStore.workspaceDiff, workspaceDiff => {
-    if (workspaceDiff) showWorkspacePanel.value = true
+    if (workspaceDiff) {
+        activeWorkspacePanel.value = 'files'
+        showWorkspacePanel.value = true
+    }
 })
 
 watch(showWorkspacePanel, async visible => {
@@ -879,14 +919,49 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                     <GroupChatInput ref="groupChatInputRef" @send="handleSendMessage" />
                 </div>
                 <aside
-                    v-if="showWorkspacePanel && (toolPanelStore.workspaceDiff || currentRoom?.workspace || filesStore.previewFile?.workspaceRoomId === store.currentRoomId)"
+                    v-if="showWorkspacePanel && (activeWorkspacePanel === 'browser' ? desktopBrowserAvailable : (toolPanelStore.workspaceDiff || currentRoom?.workspace || filesStore.previewFile?.workspaceRoomId === store.currentRoomId))"
                     class="group-workspace-panel"
                     :style="workspacePanelStyle"
                 >
                     <div class="group-workspace-resize-handle" @pointerdown="startWorkspaceResize" />
                     <div class="group-workspace-panel-inner">
+                        <div
+                            v-if="desktopBrowserAvailable && !toolPanelStore.workspaceDiff && !filesStore.previewFile"
+                            class="group-workspace-panel-tabs"
+                            role="tablist"
+                        >
+                            <button
+                                type="button"
+                                role="tab"
+                                :class="{ active: activeWorkspacePanel === 'files' }"
+                                :aria-selected="activeWorkspacePanel === 'files'"
+                                @click="selectWorkspacePanel('files')"
+                            >
+                                {{ t('drawer.files') }}
+                            </button>
+                            <button
+                                type="button"
+                                role="tab"
+                                :class="{ active: activeWorkspacePanel === 'browser' }"
+                                :aria-selected="activeWorkspacePanel === 'browser'"
+                                @click="selectWorkspacePanel('browser')"
+                            >
+                                {{ t('browser.title') }}
+                            </button>
+                            <button class="group-workspace-panel-close" type="button" :title="t('files.closePreview')" @click="closeWorkspacePanel">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <line x1="18" y1="6" x2="6" y2="18" />
+                                    <line x1="6" y1="6" x2="18" y2="18" />
+                                </svg>
+                            </button>
+                        </div>
+                        <DesktopBrowserPanel
+                            class="group-browser-panel"
+                            v-if="desktopBrowserAvailable && activeWorkspacePanel === 'browser'"
+                            @attach="handleBrowserAttachment"
+                        />
                         <WorkspaceDiffPreview
-                            v-if="toolPanelStore.workspaceDiff"
+                            v-else-if="toolPanelStore.workspaceDiff"
                             :custom-close="closeWorkspacePanel"
                         />
                         <FilePreview
@@ -894,7 +969,7 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                             :custom-close="closeWorkspacePanel"
                         />
                         <template v-else-if="currentRoom?.workspace">
-                            <div class="group-workspace-panel-header">
+                            <div v-if="!desktopBrowserAvailable" class="group-workspace-panel-header">
                                 <span>{{ t('drawer.files') }}</span>
                                 <button type="button" :title="t('files.closePreview')" @click="closeWorkspacePanel">
                                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -1691,6 +1766,46 @@ export default defineComponent({ components: { CreateRoomForm } })
     min-width: 0;
     min-height: 0;
     overflow: hidden;
+}
+
+.group-workspace-panel-tabs {
+    height: 47px;
+    padding: 8px 12px;
+    border-bottom: 1px solid $border-color;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    box-sizing: border-box;
+
+    button {
+        height: 30px;
+        padding: 0 10px;
+        border: 0;
+        border-radius: $radius-sm;
+        color: $text-secondary;
+        background: transparent;
+        cursor: pointer;
+
+        &:hover,
+        &.active {
+            color: var(--accent-primary);
+            background: rgba(var(--accent-primary-rgb), 0.1);
+        }
+    }
+
+    .group-workspace-panel-close {
+        width: 30px;
+        padding: 0;
+        margin-left: auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    }
+}
+
+.group-browser-panel {
+    flex: 1;
+    min-height: 0;
 }
 
 .group-workspace-panel-header {

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -451,6 +451,7 @@ export function attachWorkspaceChangesToExactTurns(
   const fallback: WorkspaceRunChangeSummary[] = []
   for (const change of changes) {
     const assistantMessageId = String(change.assistant_message_id || '').trim()
+    if (!assistantMessageId) continue
     const target = assistantMessageId ? assistantById.get(assistantMessageId) : undefined
     if (target) target.workspaceChanges!.push(change)
     else fallback.push(change)
@@ -1240,7 +1241,8 @@ export const useChatStore = defineStore('chat', () => {
     target.messages = target.messages.filter(message => !message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX))
     for (const message of target.messages) {
       if (message.role === 'tool' && message.toolCallId) {
-        message.toolChange = changes?.get(message.toolCallId)
+        const change = changes?.get(message.toolCallId)
+        message.toolChange = String(change?.assistant_message_id || '').trim() ? change : undefined
       }
     }
     if (!changes) {
@@ -1248,8 +1250,8 @@ export const useChatStore = defineStore('chat', () => {
       return
     }
     const runChanges = [...changes.values()].filter(change => change?.source === 'run')
-    const legacyChanges = attachWorkspaceChangesToExactTurns(target.messages, runChanges)
-    insertWorkspaceRunChangeMessages(target, legacyChanges, existingById)
+    const unresolvedAttributedChanges = attachWorkspaceChangesToExactTurns(target.messages, runChanges)
+    insertWorkspaceRunChangeMessages(target, unresolvedAttributedChanges, existingById)
   }
 
   function workspaceRunChangeMessageId(changeId: string): string {

--- a/packages/client/src/utils/desktop-bridge.ts
+++ b/packages/client/src/utils/desktop-bridge.ts
@@ -84,6 +84,7 @@ export interface DesktopBrowserBridge {
   getState: () => Promise<DesktopBrowserState>
   setViewport: (bounds: DesktopWindowBounds, visible: boolean) => Promise<DesktopBrowserState>
   createTab: (url?: string, activate?: boolean) => Promise<DesktopBrowserTab>
+  createHtmlPreviewTab?: (html: string, title: string, activate?: boolean) => Promise<DesktopBrowserTab>
   closeTab: (tabId: string) => Promise<DesktopBrowserState>
   activateTab: (tabId: string) => Promise<DesktopBrowserState>
   navigate: (tabId: string, url: string) => Promise<DesktopBrowserTab>

--- a/packages/client/src/utils/desktop-browser.ts
+++ b/packages/client/src/utils/desktop-browser.ts
@@ -1,0 +1,25 @@
+import { desktopBridge, hasDesktopBrowserBridge } from './desktop-bridge'
+
+export const OPEN_DESKTOP_BROWSER_PANEL_EVENT = 'hermes:open-desktop-browser-panel'
+
+function revealDesktopBrowserPanel(): void {
+  window.dispatchEvent(new CustomEvent(OPEN_DESKTOP_BROWSER_PANEL_EVENT))
+}
+
+export async function openUrlInDesktopBrowser(url: string): Promise<boolean> {
+  if (!hasDesktopBrowserBridge()) return false
+  const browser = desktopBridge()?.browser
+  if (!browser) return false
+  await browser.createTab(url, true)
+  revealDesktopBrowserPanel()
+  return true
+}
+
+export async function openHtmlInDesktopBrowser(html: string, title: string): Promise<boolean> {
+  if (!hasDesktopBrowserBridge()) return false
+  const browser = desktopBridge()?.browser
+  if (!browser?.createHtmlPreviewTab) return false
+  await browser.createHtmlPreviewTab(html, title, true)
+  revealDesktopBrowserPanel()
+  return true
+}

--- a/packages/desktop/src/main/browser/browser-manager.ts
+++ b/packages/desktop/src/main/browser/browser-manager.ts
@@ -39,6 +39,8 @@ interface TabRecord {
   tab: DesktopBrowserTab
   view: WebContentsView
   console: BrowserConsoleEntry[]
+  htmlPreviewTitle?: string
+  ephemeral?: boolean
 }
 
 interface BrowserManagerOptions {
@@ -54,6 +56,7 @@ const ANNOTATION_CANCEL_EVENT = '__hermes_browser_cancel_annotation__'
 const ANNOTATION_STATE_KEY = '__hermes_browser_annotation_state__'
 const SESSION_COOKIE_PERSIST_DELAY_MS = 750
 const SESSION_SHUTDOWN_TIMEOUT_MS = 2_000
+const HTML_PREVIEW_MAX_BYTES = 10 * 1024 * 1024
 
 const RISK_DIALOG_COPY = {
   de: ['Agent-Aktion bestätigen', 'Diese Browser-Aktion kann eine wichtige Änderung ausführen:', 'Abbrechen', 'Einmal erlauben'],
@@ -202,16 +205,34 @@ export class BrowserManager {
     return this.openTab(url, activate, true)
   }
 
-  private async openTab(url: string, activate: boolean, waitForLoad: boolean): Promise<DesktopBrowserTab> {
+  async createHtmlPreviewTab(html: string, title: string, activate = true): Promise<DesktopBrowserTab> {
+    const size = Buffer.byteLength(html, 'utf8')
+    if (size > HTML_PREVIEW_MAX_BYTES) throw new Error('HTML preview is too large')
+    const previewTitle = String(title || '').replace(/[\u0000-\u001f\u007f]/g, '').trim().slice(0, 256) || 'HTML Preview'
+    const dataUrl = `data:text/html;charset=utf-8,${encodeURIComponent(html)}`
+    return this.openTab('about:blank', activate, true, { dataUrl, title: previewTitle })
+  }
+
+  private async openTab(
+    url: string,
+    activate: boolean,
+    waitForLoad: boolean,
+    htmlPreview?: { dataUrl: string; title: string },
+  ): Promise<DesktopBrowserTab> {
     if (this.records.size >= MAX_TABS) throw new Error(`Browser supports at most ${MAX_TABS} tabs per profile`)
     const normalizedUrl = normalizeBrowserUrl(url, { allowBlank: true })
     const profile = this.requireProfile(this.activeProfileId)
     const record = await this.buildTab(profile, normalizedUrl)
+    if (htmlPreview) {
+      record.htmlPreviewTitle = htmlPreview.title
+      record.ephemeral = true
+      record.tab.title = htmlPreview.title
+    }
     this.records.set(record.tab.id, record)
     this.window.contentView.addChildView(record.view)
     if (activate || !this.activeTabId) this.activeTabId = record.tab.id
     this.syncViews()
-    const loading = record.view.webContents.loadURL(normalizedUrl).catch(() => {
+    const loading = record.view.webContents.loadURL(htmlPreview?.dataUrl || normalizedUrl).catch(() => {
       record.tab.loading = false
       this.refreshTab(record)
       this.emitState()
@@ -727,6 +748,7 @@ export class BrowserManager {
       ]).popup({ window: this.window })
     })
     contents.on('will-navigate', details => {
+      if (record.htmlPreviewTitle && details.url.startsWith('data:text/html')) return
       if (!isAllowedBrowserRequest(details.url)) details.preventDefault()
     })
     contents.on('did-start-loading', () => { tab.loading = true; this.automation.invalidate(id); this.emitState() })
@@ -735,7 +757,11 @@ export class BrowserManager {
     const persistNavigation = () => { void this.persistTabs().catch(error => console.warn('[desktop-browser] failed to persist tabs:', error)) }
     contents.on('did-navigate', () => { this.refreshTab(record); this.automation.invalidate(id); persistNavigation(); this.emitState() })
     contents.on('did-navigate-in-page', () => { this.refreshTab(record); this.automation.invalidate(id); persistNavigation(); this.emitState() })
-    contents.on('page-title-updated', (_event, title) => { tab.title = title || tab.url; this.emitState() })
+    contents.on('page-title-updated', (_event, title) => {
+      const isHtmlPreview = !!record.htmlPreviewTitle && contents.getURL().startsWith('data:text/html')
+      tab.title = title || (isHtmlPreview ? record.htmlPreviewTitle || 'HTML Preview' : tab.url)
+      this.emitState()
+    })
     contents.on('page-favicon-updated', (_event, favicons) => { tab.faviconUrl = favicons[0]; this.emitState() })
     contents.on('render-process-gone', () => { tab.crashed = true; tab.loading = false; this.emitState() })
     contents.debugger.on('detach', () => {
@@ -933,13 +959,19 @@ export class BrowserManager {
 
   private async persistTabs(): Promise<void> {
     if (!this.activeProfileId) return
-    await this.profileStore.setTabs(this.activeProfileId, [...this.records.values()].map(record => record.tab.url))
+    await this.profileStore.setTabs(
+      this.activeProfileId,
+      [...this.records.values()].filter(record => !record.ephemeral).map(record => record.tab.url),
+    )
   }
 
   private refreshTab(record: TabRecord): void {
     const contents = record.view.webContents
-    record.tab.url = contents.getURL() || 'about:blank'
-    record.tab.title = contents.getTitle() || record.tab.url
+    const currentUrl = contents.getURL() || 'about:blank'
+    const isHtmlPreview = !!record.htmlPreviewTitle && currentUrl.startsWith('data:text/html')
+    if (record.htmlPreviewTitle) record.ephemeral = isHtmlPreview
+    record.tab.url = isHtmlPreview ? 'about:blank' : currentUrl
+    record.tab.title = contents.getTitle() || (isHtmlPreview ? record.htmlPreviewTitle || 'HTML Preview' : record.tab.url)
     record.tab.canGoBack = contents.navigationHistory.canGoBack()
     record.tab.canGoForward = contents.navigationHistory.canGoForward()
     record.tab.crashed = false

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -852,6 +852,13 @@ ipcMain.handle('hermes-desktop:browser-set-viewport', (event, bounds?: unknown, 
   return browserForEvent(event).setViewport(sanitized, visible === true)
 })
 ipcMain.handle('hermes-desktop:browser-create-tab', (event, url?: unknown, activate?: unknown) => browserForEvent(event).createTab(typeof url === 'string' ? url : 'about:blank', activate !== false))
+ipcMain.handle('hermes-desktop:browser-create-html-preview-tab', (event, html?: unknown, title?: unknown, activate?: unknown) => (
+  browserForEvent(event).createHtmlPreviewTab(
+    typeof html === 'string' ? html : '',
+    typeof title === 'string' ? title : '',
+    activate !== false,
+  )
+))
 ipcMain.handle('hermes-desktop:browser-close-tab', (event, tabId?: unknown) => browserForEvent(event).closeTab(String(tabId || '')))
 ipcMain.handle('hermes-desktop:browser-activate-tab', (event, tabId?: unknown) => browserForEvent(event).activateTab(String(tabId || '')))
 ipcMain.handle('hermes-desktop:browser-navigate', (event, tabId?: unknown, url?: unknown) => {

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -39,6 +39,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     getState: (): Promise<DesktopBrowserState> => ipcRenderer.invoke('hermes-desktop:browser-get-state'),
     setViewport: (bounds: BrowserBounds, visible: boolean): Promise<DesktopBrowserState> => ipcRenderer.invoke('hermes-desktop:browser-set-viewport', bounds, visible),
     createTab: (url?: string, activate?: boolean): Promise<DesktopBrowserTab> => ipcRenderer.invoke('hermes-desktop:browser-create-tab', url, activate),
+    createHtmlPreviewTab: (html: string, title: string, activate?: boolean): Promise<DesktopBrowserTab> => ipcRenderer.invoke('hermes-desktop:browser-create-html-preview-tab', html, title, activate),
     closeTab: (tabId: string): Promise<DesktopBrowserState> => ipcRenderer.invoke('hermes-desktop:browser-close-tab', tabId),
     activateTab: (tabId: string): Promise<DesktopBrowserState> => ipcRenderer.invoke('hermes-desktop:browser-activate-tab', tabId),
     navigate: (tabId: string, url: string): Promise<DesktopBrowserTab> => ipcRenderer.invoke('hermes-desktop:browser-navigate', tabId, url),

--- a/tests/client/chat-store-workspace-diff-turn.test.ts
+++ b/tests/client/chat-store-workspace-diff-turn.test.ts
@@ -108,7 +108,7 @@ describe('chat workspace diff turn association', () => {
     ])
   })
 
-  it('preserves tool-call workspace change restoration alongside turn associations', async () => {
+  it('does not restore a tool-call workspace card when the change has no assistant message id', async () => {
     chatApi.resumePayload.messages.splice(3, 0, {
       id: 5,
       session_id: 'session-1',
@@ -122,18 +122,21 @@ describe('chat workspace diff turn association', () => {
     const store = useChatStore()
     await store.loadSessions()
 
-    expect(store.activeSession?.messages.find(message => message.toolCallId === 'tool-change')?.toolChange?.change_id)
-      .toBe('tool-change')
+    expect(store.activeSession?.messages.find(message => message.toolCallId === 'tool-change')?.toolChange)
+      .toBeUndefined()
   })
 
-  it('keeps a standalone timestamp fallback for legacy changes without an assistant id', async () => {
-    sessionApi.fetchWorkspaceRunChangesForSession.mockResolvedValue([change('legacy-change')])
+  it('does not render a standalone fallback for legacy changes without an assistant message id', async () => {
+    sessionApi.fetchWorkspaceRunChangesForSession.mockResolvedValue([
+      change('legacy-change-1'),
+      change('legacy-change-2'),
+    ])
 
     const store = useChatStore()
     await store.loadSessions()
 
-    const legacy = store.activeSession?.messages.find(message => message.id === 'workspace-run-change:legacy-change')
-    expect(legacy).toMatchObject({ role: 'tool', toolChange: { change_id: 'legacy-change' } })
+    const legacy = store.activeSession?.messages.filter(message => message.id.startsWith('workspace-run-change:'))
+    expect(legacy).toEqual([])
   })
 
   it('aligns a live assistant temporary id with the persisted attribution id', () => {
@@ -163,6 +166,15 @@ describe('chat workspace diff turn association', () => {
     messages.unshift({ id: '2', role: 'assistant', content: 'older', timestamp: 2 })
     expect(attachWorkspaceChangesToExactTurns(messages, [unresolved])).toEqual([])
     expect(messages[0].workspaceChanges?.map(item => item.change_id)).toEqual(['change-page-1'])
+  })
+
+  it('drops unattributed changes instead of returning them as standalone fallbacks', () => {
+    const messages = [
+      { id: '4', role: 'assistant' as const, content: 'newer', timestamp: 4 },
+    ]
+
+    expect(attachWorkspaceChangesToExactTurns(messages, [change('legacy-change')])).toEqual([])
+    expect(messages[0].workspaceChanges).toEqual([])
   })
 
   it('does not overwrite existing tool-message change metadata while recomputing turn associations', () => {

--- a/tests/client/desktop-browser-open.test.ts
+++ b/tests/client/desktop-browser-open.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function browserBridge() {
+  const createTab = vi.fn().mockResolvedValue({ id: 'web-tab' })
+  const createHtmlPreviewTab = vi.fn().mockResolvedValue({ id: 'html-tab' })
+  const methods = [
+    'getState', 'setViewport', 'closeTab', 'activateTab', 'navigate',
+    'navigationAction', 'createProfile', 'chooseProfileRootDirectory', 'renameProfile', 'profileSwitchImpact',
+    'switchProfile', 'updateProfile', 'deleteProfile', 'clearProfileData', 'cancelDownload',
+    'takeOver', 'annotate', 'cancelAnnotation', 'updateAnnotationNote',
+    'captureAnnotations', 'clearAnnotations', 'onAnnotationRequest', 'onStateChange',
+  ]
+  return {
+    ...Object.fromEntries(methods.map(method => [method, vi.fn()])),
+    createTab,
+    createHtmlPreviewTab,
+  }
+}
+
+afterEach(() => {
+  delete (window as typeof window & { hermesDesktop?: unknown }).hermesDesktop
+  vi.resetModules()
+})
+
+describe('desktop browser open helpers', () => {
+  it('opens web URLs and HTML content through the trusted desktop bridge', async () => {
+    const browser = browserBridge()
+    ;(window as typeof window & { hermesDesktop?: unknown }).hermesDesktop = {
+      isDesktop: true,
+      browser,
+    }
+    const listener = vi.fn()
+    const { OPEN_DESKTOP_BROWSER_PANEL_EVENT, openHtmlInDesktopBrowser, openUrlInDesktopBrowser } = await import(
+      '../../packages/client/src/utils/desktop-browser'
+    )
+    window.addEventListener(OPEN_DESKTOP_BROWSER_PANEL_EVENT, listener)
+
+    await expect(openUrlInDesktopBrowser('https://example.com')).resolves.toBe(true)
+    await expect(openHtmlInDesktopBrowser('<h1>Hello</h1>', 'report.html')).resolves.toBe(true)
+
+    expect(browser.createTab).toHaveBeenCalledWith('https://example.com', true)
+    expect(browser.createHtmlPreviewTab).toHaveBeenCalledWith('<h1>Hello</h1>', 'report.html', true)
+    expect(listener).toHaveBeenCalledTimes(2)
+    window.removeEventListener(OPEN_DESKTOP_BROWSER_PANEL_EVENT, listener)
+  })
+
+  it('leaves Web UI behavior untouched without the desktop bridge', async () => {
+    const { openHtmlInDesktopBrowser, openUrlInDesktopBrowser } = await import(
+      '../../packages/client/src/utils/desktop-browser'
+    )
+
+    await expect(openUrlInDesktopBrowser('https://example.com')).resolves.toBe(false)
+    await expect(openHtmlInDesktopBrowser('<h1>Hello</h1>', 'report.html')).resolves.toBe(false)
+  })
+
+  it('keeps URL browsing available with an older desktop bridge and falls back for HTML previews', async () => {
+    const browser = browserBridge()
+    delete (browser as Partial<typeof browser>).createHtmlPreviewTab
+    ;(window as typeof window & { hermesDesktop?: unknown }).hermesDesktop = {
+      isDesktop: true,
+      browser,
+    }
+    const { openHtmlInDesktopBrowser, openUrlInDesktopBrowser } = await import(
+      '../../packages/client/src/utils/desktop-browser'
+    )
+
+    await expect(openUrlInDesktopBrowser('https://example.com')).resolves.toBe(true)
+    await expect(openHtmlInDesktopBrowser('<h1>Hello</h1>', 'report.html')).resolves.toBe(false)
+    expect(browser.createTab).toHaveBeenCalledWith('https://example.com', true)
+  })
+})

--- a/tests/client/desktop-browser-route.test.ts
+++ b/tests/client/desktop-browser-route.test.ts
@@ -45,6 +45,7 @@ describe('desktop browser chat panel gate', () => {
 
   it('separates the pure browser panel from the settings-only page', () => {
     const chatPanel = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+    const groupChatPanel = readFileSync('packages/client/src/components/hermes/group-chat/GroupChatPanel.vue', 'utf8')
     const browserPanel = readFileSync('packages/client/src/components/hermes/chat/DesktopBrowserPanel.vue', 'utf8')
     const settingsPage = readFileSync('packages/client/src/views/hermes/DesktopBrowserView.vue', 'utf8')
     const sidebar = readFileSync('packages/client/src/components/layout/AppSidebar.vue', 'utf8')
@@ -52,6 +53,11 @@ describe('desktop browser chat panel gate', () => {
     expect(chatPanel).toContain('v-if="desktopBrowserAvailable"')
     expect(chatPanel).toContain("activeToolPanel === 'browser'")
     expect(chatPanel).toContain('@attach="handleBrowserAttachment"')
+    expect(chatPanel).toContain('OPEN_DESKTOP_BROWSER_PANEL_EVENT')
+    expect(groupChatPanel).toContain("activeWorkspacePanel = ref<'files' | 'browser'>('files')")
+    expect(groupChatPanel).toContain('OPEN_DESKTOP_BROWSER_PANEL_EVENT')
+    expect(groupChatPanel).toContain('const DesktopBrowserPanel = defineAsyncComponent')
+    expect(groupChatPanel).toContain("activeWorkspacePanel === 'browser'")
     expect(browserPanel).toContain('onAnnotationRequest')
     expect(browserPanel).toContain('EXTERNAL_OVERLAY_SELECTOR')
     expect(browserPanel).toContain("'.n-modal-body-wrapper'")

--- a/tests/client/file-preview-desktop-html.test.ts
+++ b/tests/client/file-preview-desktop-html.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+const previewMocks = vi.hoisted(() => ({
+  fetchFilePreviewBlob: vi.fn(),
+  openHtmlInDesktopBrowser: vi.fn(),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NAlert: { template: '<div><slot name="header" /><slot /></div>' },
+  NButton: { template: '<button><slot name="icon" /><slot /></button>' },
+  NIcon: { template: '<i><slot /></i>' },
+  NSpin: { template: '<div class="spin" />' },
+  useMessage: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+
+vi.mock('@/api/hermes/files', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/api/hermes/files')>()
+  return { ...actual, fetchFilePreviewBlob: previewMocks.fetchFilePreviewBlob }
+})
+
+vi.mock('@/utils/desktop-browser', () => ({
+  openHtmlInDesktopBrowser: previewMocks.openHtmlInDesktopBrowser,
+}))
+
+import { useFilesStore } from '@/stores/hermes/files'
+import FilePreview from '@/components/hermes/files/FilePreview.vue'
+
+describe('desktop HTML file preview', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    previewMocks.fetchFilePreviewBlob.mockReset()
+    previewMocks.openHtmlInDesktopBrowser.mockReset()
+    previewMocks.fetchFilePreviewBlob.mockResolvedValue({
+      type: 'text/html; charset=utf-8',
+      text: vi.fn().mockResolvedValue('<!doctype html><html><body>Hello desktop</body></html>'),
+    })
+  })
+
+  it('hands authenticated HTML content to the desktop browser instead of rendering an iframe', async () => {
+    const filesStore = useFilesStore()
+    const revealBrowser = () => filesStore.closePreview()
+    window.addEventListener('hermes:open-desktop-browser-panel', revealBrowser)
+    previewMocks.openHtmlInDesktopBrowser.mockImplementation(async () => {
+      window.dispatchEvent(new CustomEvent('hermes:open-desktop-browser-panel'))
+      return true
+    })
+    filesStore.previewFile = {
+      path: 'reports/result.html',
+      name: 'result.html',
+      size: 54,
+      profile: 'default',
+      type: 'html',
+    }
+
+    const wrapper = mount(FilePreview, {
+      global: {
+        stubs: {
+          HtmlFilePreview: { template: '<iframe />' },
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(previewMocks.fetchFilePreviewBlob).toHaveBeenCalledWith(
+      'reports/result.html',
+      'default',
+      expect.any(AbortSignal),
+    )
+    expect(previewMocks.openHtmlInDesktopBrowser).toHaveBeenCalledWith(
+      '<!doctype html><html><body>Hello desktop</body></html>',
+      'result.html',
+    )
+    expect(wrapper.find('iframe').exists()).toBe(false)
+    window.removeEventListener('hermes:open-desktop-browser-panel', revealBrowser)
+  })
+
+  it('keeps the iframe preview in the Web UI', async () => {
+    previewMocks.openHtmlInDesktopBrowser.mockResolvedValue(false)
+    const filesStore = useFilesStore()
+    filesStore.previewFile = {
+      path: 'reports/result.html',
+      name: 'result.html',
+      size: 54,
+      profile: 'default',
+      type: 'html',
+    }
+
+    const wrapper = mount(FilePreview, {
+      global: {
+        stubs: {
+          HtmlFilePreview: {
+            props: ['content'],
+            template: '<iframe :data-content="content" />',
+          },
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.get('iframe').attributes('data-content')).toContain('Hello desktop')
+  })
+})

--- a/tests/client/markdown-rendering.test.ts
+++ b/tests/client/markdown-rendering.test.ts
@@ -16,8 +16,16 @@ const downloadApiMock = vi.hoisted(() => ({
   getDownloadUrl: vi.fn((path: string) => `http://test.local/api/hermes/download?path=${encodeURIComponent(path)}`),
 }))
 
+const desktopBrowserMock = vi.hoisted(() => ({
+  openUrlInDesktopBrowser: vi.fn(() => Promise.resolve(false)),
+}))
+
 vi.mock('mermaid', () => ({
   default: mermaidMock,
+}))
+
+vi.mock('@/utils/desktop-browser', () => ({
+  openUrlInDesktopBrowser: desktopBrowserMock.openUrlInDesktopBrowser,
 }))
 
 async function flushMermaidRender(): Promise<void> {
@@ -81,6 +89,8 @@ describe('MarkdownRenderer', () => {
     downloadApiMock.downloadFile.mockClear()
     downloadApiMock.fetchFileText.mockClear()
     downloadApiMock.getDownloadUrl.mockClear()
+    desktopBrowserMock.openUrlInDesktopBrowser.mockReset()
+    desktopBrowserMock.openUrlInDesktopBrowser.mockResolvedValue(false)
     mermaidMock.render.mockImplementation(async (id: string, source: string) => ({
       svg: `<svg id="${id}" data-testid="mermaid-svg"><text>${source}</text></svg>`,
     }))
@@ -98,6 +108,37 @@ describe('MarkdownRenderer', () => {
         writeText: vi.fn().mockResolvedValue(undefined),
       },
     })
+  })
+
+  it('opens message links in the embedded browser when the desktop bridge is available', async () => {
+    desktopBrowserMock.openUrlInDesktopBrowser.mockResolvedValue(true)
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: '[Hermes](https://example.com/docs)',
+      },
+    })
+
+    await wrapper.get('a').trigger('click')
+
+    expect(desktopBrowserMock.openUrlInDesktopBrowser).toHaveBeenCalledWith('https://example.com/docs')
+    expect(open).not.toHaveBeenCalled()
+    open.mockRestore()
+  })
+
+  it('keeps opening message links in a new tab in the Web UI', async () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: '[Hermes](https://example.com/docs)',
+      },
+    })
+
+    await wrapper.get('a').trigger('click')
+
+    expect(desktopBrowserMock.openUrlInDesktopBrowser).toHaveBeenCalledWith('https://example.com/docs')
+    expect(open).toHaveBeenCalledWith('https://example.com/docs', '_blank', 'noopener,noreferrer')
+    open.mockRestore()
   })
 
   it('highlights vue fenced blocks instead of rendering them as plain text', () => {

--- a/tests/desktop/browser-security.test.ts
+++ b/tests/desktop/browser-security.test.ts
@@ -71,6 +71,11 @@ describe('desktop browser security primitives', () => {
     expect(source).toContain('if (!this.downloadItems.has(download.id)) return')
     expect(source).not.toContain('item.pause()')
     expect(source).not.toContain('dialog.showSaveDialog(this.window')
+    expect(source).toContain('async createHtmlPreviewTab(html: string, title: string')
+    expect(source).toContain('if (size > HTML_PREVIEW_MAX_BYTES)')
+    expect(source).toContain('record.ephemeral = true')
+    expect(source).toContain("filter(record => !record.ephemeral)")
+    expect(source).toContain("record.tab.url = isHtmlPreview ? 'about:blank' : currentUrl")
   })
 
   it('persists owner-only isolated profile roots and rejects overlapping or non-empty directories', async () => {


### PR DESCRIPTION
## What changed

- Ignore historical workspace changes that do not contain an `assistant_message_id`, while preserving exact-turn attachment and pagination fallback for attributed changes.
- Open HTTP/HTTPS links from both single-chat and group-chat messages in the embedded Desktop browser.
- Open authenticated HTML workspace content in an isolated Desktop browser preview tab instead of the Web UI iframe.
- Add the browser panel and Files/Browser switching to Group Chat.
- Keep the new HTML preview bridge optional so newer Web UI builds still retain normal browser support on an older Electron shell.
- Keep Web behavior unchanged: external links still use a new browser tab and HTML files still use the restrictive iframe preview.

## Why

Legacy workspace-diff fallback treated records without a message ID as attachable chat artifacts, which could collect old changes at the bottom of a conversation. Separately, shared message rendering always used `window.open`, HTML preview always used an iframe, and Group Chat did not expose the Desktop browser panel.

## Impact

Old unattributed diff records no longer appear in chat. Desktop users can open chat links and HTML workspace files in the embedded browser from both conversation modes. Ordinary browser tabs remain persistent; local HTML preview tabs are intentionally ephemeral so raw file content is not stored in the browser tab configuration.

## Validation

- `npm run test` — 377 files passed, 2943 tests passed, 2 skipped
- `npm run build`
- `npm --prefix packages/desktop run build`
- `npx vue-tsc -b --pretty false`
- `npm run harness:check`
- `git diff --check`
