### PR TITLE
Ensure Desktop exit cleans Agent Bridge processes

### DIFF
--- a/docs/chat-chain-changes/2026-07-23-clean-desktop-bridge-shutdown.md
+++ b/docs/chat-chain-changes/2026-07-23-clean-desktop-bridge-shutdown.md
@@ -17,3 +17,7 @@ process exit as a last-resort safeguard, unless
 `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0` explicitly preserves the Bridge.
 Windows process-tree termination commands also have a fixed timeout so the
 fallback itself cannot block application exit indefinitely.
+
+Windows installer upgrades send the same `--quit` request used by the tray
+action and wait up to 30 seconds for the visible shutdown flow to finish.
+Only processes that remain after that grace period are force-stopped.

--- a/docs/chat-chain-changes/2026-07-23-clean-desktop-bridge-shutdown.md
+++ b/docs/chat-chain-changes/2026-07-23-clean-desktop-bridge-shutdown.md
@@ -1,0 +1,16 @@
+---
+date: 2026-07-23
+pr: pending
+feature: Clean Desktop Agent Bridge shutdown
+impact: Exiting Hermes Studio now force-stops the managed Agent Bridge process tree if graceful shutdown does not finish in time.
+---
+
+Desktop shutdown still asks the Agent Bridge and its profile workers to stop
+gracefully first. If that path stalls, Windows terminates the complete process
+tree and Linux/macOS terminate the detached bridge process group so worker and
+MCP subprocesses do not remain after the app exits.
+
+The Desktop browser broker also has a bounded shutdown path, ensuring an active
+browser operation cannot prevent Web UI and Agent Bridge cleanup from running.
+The Web UI shutdown deadline repeats the bridge force-stop before its final
+process exit as a last-resort safeguard.

--- a/docs/chat-chain-changes/2026-07-23-clean-desktop-bridge-shutdown.md
+++ b/docs/chat-chain-changes/2026-07-23-clean-desktop-bridge-shutdown.md
@@ -13,4 +13,7 @@ MCP subprocesses do not remain after the app exits.
 The Desktop browser broker also has a bounded shutdown path, ensuring an active
 browser operation cannot prevent Web UI and Agent Bridge cleanup from running.
 The Web UI shutdown deadline repeats the bridge force-stop before its final
-process exit as a last-resort safeguard.
+process exit as a last-resort safeguard, unless
+`HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0` explicitly preserves the Bridge.
+Windows process-tree termination commands also have a fixed timeout so the
+fallback itself cannot block application exit indefinitely.

--- a/packages/desktop/build/installer.nsh
+++ b/packages/desktop/build/installer.nsh
@@ -3,7 +3,6 @@
     DetailPrint "Stopping Hermes Studio..."
     nsExec::ExecToLog '"$INSTDIR\Hermes Studio.exe" --quit'
     Pop $0
-    Sleep 1500
 
     InitPluginsDir
     FileOpen $0 "$PLUGINSDIR\stop-hermes-studio.ps1" w
@@ -77,13 +76,18 @@
     FileWrite $0 "    if ($$process) { $$process.CloseMainWindow() | Out-Null }$\r$\n"
     FileWrite $0 "  } catch {}$\r$\n"
     FileWrite $0 "}$\r$\n"
-    FileWrite $0 "Start-Sleep -Milliseconds 750$\r$\n"
-    FileWrite $0 "$$deadline = (Get-Date).AddSeconds(30)$\r$\n"
-    FileWrite $0 "while ((Get-Date) -lt $$deadline) {$\r$\n"
+    FileWrite $0 "$$gracefulDeadline = (Get-Date).AddSeconds(30)$\r$\n"
+    FileWrite $0 "while ((Get-Date) -lt $$gracefulDeadline) {$\r$\n"
+    FileWrite $0 "  $$processes = @(Get-HermesStudioRelatedProcess)$\r$\n"
+    FileWrite $0 "  if ($$processes.Count -eq 0) { exit 0 }$\r$\n"
+    FileWrite $0 "  Start-Sleep -Milliseconds 500$\r$\n"
+    FileWrite $0 "}$\r$\n"
+    FileWrite $0 "$$forceDeadline = (Get-Date).AddSeconds(5)$\r$\n"
+    FileWrite $0 "while ((Get-Date) -lt $$forceDeadline) {$\r$\n"
     FileWrite $0 "  $$processes = @(Get-HermesStudioRelatedProcess)$\r$\n"
     FileWrite $0 "  if ($$processes.Count -eq 0) { exit 0 }$\r$\n"
     FileWrite $0 "  $$processes | ForEach-Object { try { Stop-Process -Id $$_.ProcessId -Force } catch {} }$\r$\n"
-    FileWrite $0 "  Start-Sleep -Milliseconds 500$\r$\n"
+    FileWrite $0 "  Start-Sleep -Milliseconds 250$\r$\n"
     FileWrite $0 "}$\r$\n"
     FileWrite $0 "if (@(Get-HermesStudioRelatedProcess).Count -eq 0) { exit 0 }$\r$\n"
     FileWrite $0 "exit 1$\r$\n"

--- a/packages/desktop/src/main/browser/browser-broker.ts
+++ b/packages/desktop/src/main/browser/browser-broker.ts
@@ -27,6 +27,7 @@ interface BrokerClient {
 
 const BODY_LIMIT = 1024 * 1024
 const LEASE_TTL_MS = 60_000
+const STOP_TIMEOUT_MS = 2_000
 
 function asObject(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
@@ -91,7 +92,8 @@ export class BrowserBroker {
     }
   }
 
-  async stop(): Promise<void> {
+  async stop(timeoutMs = STOP_TIMEOUT_MS): Promise<void> {
+    this.revokeAll()
     for (const timer of this.leaseTimers.values()) clearTimeout(timer)
     this.leaseTimers.clear()
     this.leases.clear()
@@ -102,7 +104,25 @@ export class BrowserBroker {
     this.server = null
     this.descriptor = null
     this.token = ''
-    await new Promise<void>(resolve => server ? server.close(() => resolve()) : resolve())
+    await new Promise<void>((resolve) => {
+      if (!server) {
+        resolve()
+        return
+      }
+      let settled = false
+      const finish = () => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        resolve()
+      }
+      const timeout = setTimeout(() => {
+        server.closeAllConnections?.()
+        finish()
+      }, Math.max(0, timeoutMs))
+      server.close(finish)
+      server.closeIdleConnections?.()
+    })
     await rm(join(this.brokerRoot, 'broker.json'), { force: true }).catch(() => undefined)
   }
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -136,7 +136,7 @@ async function prepareAppShutdown(): Promise<void> {
       cancelWindowFade()
       await showShutdownSplash()
       await browserBroker?.stop().catch(() => undefined)
-      await browserManager?.destroy()
+      await browserManager?.destroy().catch(() => undefined)
       browserBroker = null
       browserManager = null
       await stopWebUiServer().catch(() => undefined)
@@ -1103,8 +1103,11 @@ function runDesktopApp() {
       return
     }
     e.preventDefault()
-    await prepareAppShutdown()
-    app.exit(0)
+    try {
+      await prepareAppShutdown()
+    } finally {
+      app.exit(0)
+    }
   })
 }
 

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -1,4 +1,4 @@
-import { ChildProcess, execFile, spawn } from 'node:child_process'
+import { ChildProcess, execFile, execFileSync, spawn } from 'node:child_process'
 import { mkdirSync, readFileSync, writeFileSync, chmodSync, existsSync, readdirSync } from 'node:fs'
 import { createServer } from 'node:net'
 import { homedir } from 'node:os'
@@ -36,18 +36,53 @@ let serverProc: ChildProcess | null = null
 let cachedToken: string | null = null
 let currentServerPort = DEFAULT_PORT
 
+function posixDescendantPids(rootPid: number): number[] {
+  try {
+    const output = execFileSync('ps', ['-ax', '-o', 'pid=,ppid='], {
+      encoding: 'utf-8',
+      timeout: 5_000,
+    })
+    const children = new Map<number, number[]>()
+    for (const line of output.split(/\r?\n/)) {
+      const match = line.trim().match(/^(\d+)\s+(\d+)$/)
+      if (!match) continue
+      const pid = Number(match[1])
+      const parentPid = Number(match[2])
+      children.set(parentPid, [...(children.get(parentPid) || []), pid])
+    }
+    const descendants: number[] = []
+    const visit = (parentPid: number) => {
+      for (const pid of children.get(parentPid) || []) {
+        visit(pid)
+        descendants.push(pid)
+      }
+    }
+    visit(rootPid)
+    return descendants
+  } catch {
+    return []
+  }
+}
+
 function killProcessTree(proc: ChildProcess): void {
-  if (!proc.pid || proc.killed) return
+  if (!proc.pid) return
   if (process.platform === 'win32') {
     try {
-      const killer = spawn('taskkill.exe', ['/PID', String(proc.pid), '/T', '/F'], {
-        stdio: 'ignore',
+      execFileSync('taskkill.exe', ['/PID', String(proc.pid), '/T', '/F'], {
+        encoding: 'utf-8',
         windowsHide: true,
       })
-      killer.once('error', () => undefined)
       return
     } catch {
       /* fall through */
+    }
+  } else {
+    for (const pid of posixDescendantPids(proc.pid)) {
+      try {
+        process.kill(pid, 'SIGKILL')
+      } catch {
+        /* already exited */
+      }
     }
   }
   try {
@@ -529,7 +564,7 @@ async function requestGracefulShutdown(port: number, token: string): Promise<voi
 }
 
 export async function stopWebUiServer(): Promise<void> {
-  if (!serverProc || serverProc.killed) return
+  if (!serverProc) return
 
   const proc = serverProc
   const exited = new Promise<void>(resolve => {

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -28,6 +28,7 @@ const DEFAULT_READY_TIMEOUT_MS = 120_000
 const DEFAULT_FULL_STARTUP_WAIT_MS = 0
 const DEFAULT_STOP_TIMEOUT_MS = 20_000
 const DEFAULT_GRACEFUL_STOP_TIMEOUT_MS = 18_000
+const FORCE_KILL_COMMAND_TIMEOUT_MS = 5_000
 const AGENT_BRIDGE_STARTED_MARKER = '[bootstrap] agent bridge started'
 const AGENT_BRIDGE_FAILED_MARKER = '[bootstrap] agent bridge failed to start'
 const execFileAsync = promisify(execFile)
@@ -70,6 +71,7 @@ function killProcessTree(proc: ChildProcess): void {
     try {
       execFileSync('taskkill.exe', ['/PID', String(proc.pid), '/T', '/F'], {
         encoding: 'utf-8',
+        timeout: FORCE_KILL_COMMAND_TIMEOUT_MS,
         windowsHide: true,
       })
       return

--- a/packages/server/src/services/hermes/agent-bridge/manager.ts
+++ b/packages/server/src/services/hermes/agent-bridge/manager.ts
@@ -11,6 +11,8 @@ const DEFAULT_AGENT_BRIDGE_RESTART_DELAY_MS = 1000
 const MAX_AGENT_BRIDGE_RESTART_DELAY_MS = 30000
 const DEFAULT_AGENT_BRIDGE_RECOVERY_EXIT_TIMEOUT_MS = 5000
 const DEFAULT_AGENT_BRIDGE_RECOVERY_SIGKILL_WAIT_MS = 250
+const DEFAULT_AGENT_BRIDGE_SHUTDOWN_TIMEOUT_MS = 10_000
+const DEFAULT_AGENT_BRIDGE_FORCE_KILL_WAIT_MS = 2_000
 const OPENROUTER_WEB_UI_ATTRIBUTION_ENV = {
   HERMES_OPENROUTER_APP_REFERER: 'https://hermes-studio.ai',
   HERMES_OPENROUTER_APP_TITLE: 'Hermes Studio',
@@ -478,6 +480,83 @@ async function killStaleIpcBridgeProcesses(endpoint: string): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, 500))
 }
 
+function bridgePidsForEndpoint(endpoint: string): number[] {
+  if (process.platform === 'win32') {
+    const port = tcpEndpointPort(endpoint)
+    return port ? windowsListeningPidsOnPort(port) : []
+  }
+  try {
+    const output = execFileSync('ps', ['-ax', '-o', 'pid=,command='], {
+      encoding: 'utf-8',
+      timeout: 5_000,
+    })
+    return output.split(/\r?\n/).flatMap(line => {
+      const match = line.trim().match(/^(\d+)\s+(.+)$/)
+      if (!match || !match[2].includes('hermes_bridge.py') || !match[2].includes(endpoint)) return []
+      const pid = Number(match[1])
+      return Number.isSafeInteger(pid) && pid > 0 && pid !== process.pid ? [pid] : []
+    })
+  } catch {
+    return []
+  }
+}
+
+function posixDescendantPids(rootPid: number): number[] {
+  try {
+    const output = execFileSync('ps', ['-ax', '-o', 'pid=,ppid='], {
+      encoding: 'utf-8',
+      timeout: 5_000,
+    })
+    const children = new Map<number, number[]>()
+    for (const line of output.split(/\r?\n/)) {
+      const match = line.trim().match(/^(\d+)\s+(\d+)$/)
+      if (!match) continue
+      const pid = Number(match[1])
+      const parentPid = Number(match[2])
+      const siblings = children.get(parentPid) || []
+      siblings.push(pid)
+      children.set(parentPid, siblings)
+    }
+    const descendants: number[] = []
+    const visit = (parentPid: number) => {
+      for (const pid of children.get(parentPid) || []) {
+        visit(pid)
+        descendants.push(pid)
+      }
+    }
+    visit(rootPid)
+    return descendants
+  } catch {
+    return []
+  }
+}
+
+function forceKillBridgeEndpointProcesses(endpoint: string): void {
+  for (const pid of bridgePidsForEndpoint(endpoint)) {
+    try {
+      if (process.platform === 'win32') {
+        execFileSync('taskkill.exe', ['/PID', String(pid), '/T', '/F'], {
+          encoding: 'utf-8',
+          windowsHide: true,
+        })
+      } else {
+        for (const descendantPid of posixDescendantPids(pid)) {
+          try {
+            process.kill(descendantPid, 'SIGKILL')
+          } catch {}
+        }
+        try {
+          process.kill(-pid, 'SIGKILL')
+        } catch {
+          process.kill(pid, 'SIGKILL')
+        }
+      }
+    } catch (err) {
+      logger.warn(err, '[agent-bridge] failed to force-kill bridge endpoint process pid=%s', pid)
+    }
+  }
+}
+
 export class AgentBridgeManager {
   endpoint: string
   private readonly options: AgentBridgeManagerOptions
@@ -873,6 +952,57 @@ export class AgentBridgeManager {
     })
   }
 
+  private forceKillManagedChildTree(child: ChildProcess): void {
+    const pid = child.pid
+    if (!pid) return
+    if (process.platform === 'win32') {
+      try {
+        execFileSync('taskkill.exe', ['/PID', String(pid), '/T', '/F'], {
+          encoding: 'utf-8',
+          windowsHide: true,
+        })
+        return
+      } catch (err) {
+        logger.warn(err, '[agent-bridge] failed to force-kill managed bridge tree pid=%s', pid)
+      }
+    } else {
+      for (const descendantPid of posixDescendantPids(pid)) {
+        try {
+          process.kill(descendantPid, 'SIGKILL')
+        } catch {}
+      }
+      try {
+        // Managed bridges are detached process-group leaders on POSIX. Killing
+        // the group also covers profile workers and their MCP subprocesses.
+        process.kill(-pid, 'SIGKILL')
+        return
+      } catch (err) {
+        logger.warn(err, '[agent-bridge] failed to force-kill managed bridge process group pgid=%s', pid)
+      }
+    }
+    try {
+      child.kill('SIGKILL')
+    } catch (err) {
+      logger.warn(err, '[agent-bridge] failed to force-kill managed bridge pid=%s', pid)
+    }
+  }
+
+  forceStop(): void {
+    this.stopGeneration += 1
+    this.stopping = true
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer)
+      this.restartTimer = null
+    }
+    const child = this.child
+    const attached = this.attached
+    this.ready = false
+    this.attached = false
+    this.child = null
+    if (child) this.forceKillManagedChildTree(child)
+    else if (attached) forceKillBridgeEndpointProcesses(this.endpoint)
+  }
+
   private async startProcess(): Promise<void> {
     if (await this.attachExistingBridge()) {
       return
@@ -1055,6 +1185,7 @@ export class AgentBridgeManager {
     const child = this.child
     if (!child) {
       if (this.attached || this.ready) {
+        let shutdownRequested = false
         try {
           const client = new AgentBridgeClient({
             endpoint: this.endpoint,
@@ -1062,9 +1193,11 @@ export class AgentBridgeManager {
             connectRetryMs: 0,
           })
           await client.shutdown()
+          shutdownRequested = true
         } catch (err) {
           logger.warn(err, '[agent-bridge] failed to request attached bridge shutdown')
         }
+        if (!shutdownRequested) forceKillBridgeEndpointProcesses(this.endpoint)
       }
       this.ready = false
       this.attached = false
@@ -1073,27 +1206,48 @@ export class AgentBridgeManager {
     }
     this.ready = false
     this.attached = false
-    this.child = null
 
-    await new Promise<void>((resolveStop) => {
-      // Allow enough time for the broker to gracefully stop its worker
-      // subprocesses (WorkerProcess.stop uses a 3s timeout per worker).
-      const timeout = setTimeout(() => {
-        // `child.killed` only means a signal was sent. Escalate on shutdown
-        // timeout even if SIGTERM was already sent by recovery.
-        try {
-          child.kill('SIGKILL')
-        } catch {}
-        resolveStop()
-      }, 10_000)
-      child.once('exit', () => {
-        clearTimeout(timeout)
-        resolveStop()
+    const startedAt = Date.now()
+    let observedExit = child.exitCode != null || child.signalCode != null
+    const exited = observedExit
+      ? Promise.resolve()
+      : new Promise<void>(resolveExit => {
+          child.once('exit', () => {
+            observedExit = true
+            resolveExit()
+          })
+        })
+    const shutdownTimeoutMs = envPositiveInt('HERMES_AGENT_BRIDGE_SHUTDOWN_TIMEOUT_MS')
+      ?? DEFAULT_AGENT_BRIDGE_SHUTDOWN_TIMEOUT_MS
+
+    if (process.platform === 'win32') {
+      // Node's SIGTERM emulation on Windows terminates only the broker. Ask the
+      // broker to stop its workers first, then use taskkill /T as the fallback.
+      const client = new AgentBridgeClient({
+        endpoint: this.endpoint,
+        timeoutMs: Math.min(5_000, shutdownTimeoutMs),
+        connectRetryMs: 0,
       })
-      if (!child.killed) {
-        child.kill('SIGTERM')
-      }
-    })
+      await client.shutdown().catch(err => {
+        logger.warn(err, '[agent-bridge] managed bridge graceful shutdown request failed')
+      })
+    } else if (!child.killed) {
+      child.kill('SIGTERM')
+    }
+
+    const remainingMs = Math.max(0, shutdownTimeoutMs - (Date.now() - startedAt))
+    const exitedGracefully = observedExit
+      || (remainingMs > 0 && await this.waitForPromiseSettlementWithin(exited, remainingMs))
+    if (!exitedGracefully) {
+      logger.warn(
+        '[agent-bridge] managed bridge tree pid=%s did not exit within %dms; force-killing descendants',
+        child.pid,
+        shutdownTimeoutMs,
+      )
+      this.forceKillManagedChildTree(child)
+      await this.waitForPromiseSettlementWithin(exited, DEFAULT_AGENT_BRIDGE_FORCE_KILL_WAIT_MS)
+    }
+    if (this.child === child) this.child = null
     this.stopping = false
   }
 }

--- a/packages/server/src/services/hermes/agent-bridge/manager.ts
+++ b/packages/server/src/services/hermes/agent-bridge/manager.ts
@@ -13,6 +13,7 @@ const DEFAULT_AGENT_BRIDGE_RECOVERY_EXIT_TIMEOUT_MS = 5000
 const DEFAULT_AGENT_BRIDGE_RECOVERY_SIGKILL_WAIT_MS = 250
 const DEFAULT_AGENT_BRIDGE_SHUTDOWN_TIMEOUT_MS = 10_000
 const DEFAULT_AGENT_BRIDGE_FORCE_KILL_WAIT_MS = 2_000
+const FORCE_KILL_COMMAND_TIMEOUT_MS = 5_000
 const OPENROUTER_WEB_UI_ATTRIBUTION_ENV = {
   HERMES_OPENROUTER_APP_REFERER: 'https://hermes-studio.ai',
   HERMES_OPENROUTER_APP_TITLE: 'Hermes Studio',
@@ -537,6 +538,7 @@ function forceKillBridgeEndpointProcesses(endpoint: string): void {
       if (process.platform === 'win32') {
         execFileSync('taskkill.exe', ['/PID', String(pid), '/T', '/F'], {
           encoding: 'utf-8',
+          timeout: FORCE_KILL_COMMAND_TIMEOUT_MS,
           windowsHide: true,
         })
       } else {
@@ -959,6 +961,7 @@ export class AgentBridgeManager {
       try {
         execFileSync('taskkill.exe', ['/PID', String(pid), '/T', '/F'], {
           encoding: 'utf-8',
+          timeout: FORCE_KILL_COMMAND_TIMEOUT_MS,
           windowsHide: true,
         })
         return

--- a/packages/server/src/services/shutdown.ts
+++ b/packages/server/src/services/shutdown.ts
@@ -48,13 +48,17 @@ export function createShutdownHandler(server: any, groupChatServer?: any, chatRu
     if (isShuttingDown) return
     isShuttingDown = true
 
+    const stopAgentBridge = Boolean(agentBridgeManager && shouldStopAgentBridgeOnShutdown(signal))
+
     // Force exit only if graceful cleanup hangs. The bridge can take up to 10s
     // to stop worker subprocesses, so this cap must be longer than that.
     const forceExitTimer = setTimeout(() => {
-      try {
-        agentBridgeManager?.forceStop?.()
-      } catch (err) {
-        logger.warn(err, 'Failed to force-stop agent bridge during shutdown timeout')
+      if (stopAgentBridge) {
+        try {
+          agentBridgeManager?.forceStop?.()
+        } catch (err) {
+          logger.warn(err, 'Failed to force-stop agent bridge during shutdown timeout')
+        }
       }
       process.exit(0)
     }, getShutdownForceExitMs())
@@ -89,7 +93,7 @@ export function createShutdownHandler(server: any, groupChatServer?: any, chatRu
         logger.info('ChatRunSocket closed')
       }
 
-      if (agentBridgeManager && shouldStopAgentBridgeOnShutdown(signal)) {
+      if (stopAgentBridge) {
         try {
           await agentBridgeManager.stop()
           logger.info('Agent bridge stopped')

--- a/packages/server/src/services/shutdown.ts
+++ b/packages/server/src/services/shutdown.ts
@@ -50,7 +50,14 @@ export function createShutdownHandler(server: any, groupChatServer?: any, chatRu
 
     // Force exit only if graceful cleanup hangs. The bridge can take up to 10s
     // to stop worker subprocesses, so this cap must be longer than that.
-    setTimeout(() => process.exit(0), getShutdownForceExitMs())
+    const forceExitTimer = setTimeout(() => {
+      try {
+        agentBridgeManager?.forceStop?.()
+      } catch (err) {
+        logger.warn(err, 'Failed to force-stop agent bridge during shutdown timeout')
+      }
+      process.exit(0)
+    }, getShutdownForceExitMs())
 
     logger.info('Shutting down (%s)...', signal)
     console.log(`[shutdown] Received signal: ${signal}`)
@@ -122,6 +129,7 @@ export function createShutdownHandler(server: any, groupChatServer?: any, chatRu
     }
 
     closeDb()
+    clearTimeout(forceExitTimer)
     process.exit(0)
   }
 }

--- a/tests/desktop/browser-broker.test.ts
+++ b/tests/desktop/browser-broker.test.ts
@@ -203,4 +203,50 @@ describe('Desktop Browser Broker', () => {
       await broker.stop()
     }
   })
+
+  it('bounds shutdown and cancels an active browser operation', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hermes-browser-broker-stop-'))
+    roots.push(root)
+    const tabs = [{ id: 'tab-1', agentControl: 'idle' }]
+    let markStarted!: () => void
+    let releaseSnapshot!: () => void
+    let cancelled = 0
+    const started = new Promise<void>(resolve => { markStarted = resolve })
+    const gate = new Promise<void>(resolve => { releaseSnapshot = resolve })
+    const manager = {
+      state: () => ({ tabs }),
+      snapshot: async () => {
+        markStarted()
+        await gate
+        return { tabId: 'tab-1', snapshotId: 'snapshot-1' }
+      },
+      setAgentControl: () => {},
+      revokeAgentControl: () => {},
+      cancelAgentOperation: () => { cancelled += 1 },
+    } as unknown as BrowserManager
+    const broker = new BrowserBroker(manager, root)
+    const descriptor = await broker.start()
+
+    const registration = await fetch(`${descriptor.endpoint}/session`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${descriptor.token}`, 'Content-Type': 'application/json' },
+      body: '{}',
+    })
+    const client = await registration.json() as { client_id: string; session_token: string }
+    const running = fetch(descriptor.endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${client.session_token}`,
+        'Content-Type': 'application/json',
+        'X-Hermes-Browser-Client': client.client_id,
+      },
+      body: JSON.stringify({ method: 'snapshot', params: { tab_id: 'tab-1' } }),
+    }).catch(() => null)
+
+    await started
+    await broker.stop(25)
+    expect(cancelled).toBe(1)
+    releaseSnapshot()
+    await running
+  })
 })

--- a/tests/desktop/installer-shutdown.test.ts
+++ b/tests/desktop/installer-shutdown.test.ts
@@ -23,6 +23,19 @@ describe('Windows installer shutdown hook', () => {
     expect(script.indexOf('$$protectedProcessIds.Contains')).toBeLessThan(script.indexOf('$$cmd.IndexOf($$installDir'))
   })
 
+  it('waits for graceful app shutdown before force-stopping remaining processes', () => {
+    const script = readFileSync(resolve('packages/desktop/build/installer.nsh'), 'utf8')
+    const gracefulDeadline = script.indexOf('$$gracefulDeadline = (Get-Date).AddSeconds(30)')
+    const forceDeadline = script.indexOf('$$forceDeadline = (Get-Date).AddSeconds(5)', gracefulDeadline)
+    const forceStop = script.indexOf('Stop-Process -Id $$_.ProcessId -Force', gracefulDeadline)
+
+    expect(script).toContain(`nsExec::ExecToLog '"$INSTDIR\\Hermes Studio.exe" --quit'`)
+    expect(gracefulDeadline).toBeGreaterThan(-1)
+    expect(forceDeadline).toBeGreaterThan(gracefulDeadline)
+    expect(forceStop).toBeGreaterThan(forceDeadline)
+    expect(script.slice(gracefulDeadline, forceDeadline)).not.toContain('Stop-Process')
+  })
+
   it('replaces the broken installed uninstaller before upgrading', () => {
     const script = readFileSync(resolve('packages/desktop/build/installer.nsh'), 'utf8')
 

--- a/tests/desktop/updater.test.ts
+++ b/tests/desktop/updater.test.ts
@@ -42,7 +42,7 @@ describe('desktop updater helpers', () => {
     expect(mainSource).toContain('async function prepareAppShutdown(): Promise<void>')
     expect(mainSource).toContain('await stopWebUiServer().catch(() => undefined)')
     expect(mainSource).toContain('initAutoUpdater({ beforeQuitAndInstall: prepareAppShutdown })')
-    expect(mainSource).toContain('await prepareAppShutdown()\n    app.exit(0)')
+    expect(mainSource).toContain('try {\n      await prepareAppShutdown()\n    } finally {\n      app.exit(0)')
 
     const prepareCurrentInstance = updaterSource.indexOf('await options.beforeQuitAndInstall?.()')
     const stopOtherInstances = updaterSource.indexOf('await stopOtherWindowsAppInstances()', prepareCurrentInstance)

--- a/tests/server/agent-bridge-manager.test.ts
+++ b/tests/server/agent-bridge-manager.test.ts
@@ -439,6 +439,54 @@ describe('agent bridge manager command resolution', () => {
     }
   })
 
+  it('force-stops the complete managed bridge process tree', async () => {
+    const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+    const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6557' })
+    const child = createMockManagedChild(45678)
+    ;(manager as any).child = child
+    ;(manager as any).ready = true
+    const forceKillTree = vi.spyOn(manager as any, 'forceKillManagedChildTree').mockImplementation(() => {})
+
+    manager.forceStop()
+
+    expect(forceKillTree).toHaveBeenCalledWith(child)
+    expect(manager.getRuntimeState()).toMatchObject({
+      ready: false,
+      running: false,
+      attached: false,
+      stopping: true,
+      pid: undefined,
+    })
+  })
+
+  it('force-kills the managed bridge tree when graceful shutdown times out', async () => {
+    vi.useFakeTimers()
+    process.env.HERMES_AGENT_BRIDGE_SHUTDOWN_TIMEOUT_MS = '25'
+    try {
+      const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
+      const manager = new AgentBridgeManager({ endpoint: 'tcp://127.0.0.1:6556' })
+      const child = createMockManagedChild(45679)
+      ;(manager as any).child = child
+      ;(manager as any).ready = true
+      const forceKillTree = vi.spyOn(manager as any, 'forceKillManagedChildTree').mockImplementation(() => {})
+
+      const stopping = manager.stop()
+      await vi.advanceTimersByTimeAsync(25)
+
+      expect(forceKillTree).toHaveBeenCalledWith(child)
+      child.emit('exit', null, 'SIGKILL')
+      await stopping
+      expect(manager.getRuntimeState()).toMatchObject({
+        ready: false,
+        running: false,
+        stopping: false,
+        pid: undefined,
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('clears stopping after stop completes for an attached bridge', async () => {
     const endpoint = `tcp://127.0.0.1:${36000 + (process.pid % 10000)}`
     const actions: string[] = []

--- a/tests/server/shutdown-background-order.test.ts
+++ b/tests/server/shutdown-background-order.test.ts
@@ -75,4 +75,22 @@ describe('graceful shutdown background delivery ordering', () => {
     expect(closeDbMock).toHaveBeenCalledOnce()
     expect(process.exit).toHaveBeenCalledWith(0)
   })
+
+  it('force-kills the bridge before the shutdown deadline exits the server', async () => {
+    stopPreviewRuntimeMock.mockImplementationOnce(() => new Promise<void>(() => {}))
+    const agentBridgeManager = {
+      stop: vi.fn(async () => {}),
+      forceStop: vi.fn(),
+    }
+    const httpServer = { close: vi.fn() }
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+    const { createShutdownHandler, getShutdownForceExitMs } = await import('../../packages/server/src/services/shutdown')
+
+    void createShutdownHandler(httpServer, undefined, undefined, agentBridgeManager)('desktop-request')
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(getShutdownForceExitMs())
+
+    expect(agentBridgeManager.forceStop).toHaveBeenCalledOnce()
+    expect(exitSpy).toHaveBeenCalledWith(0)
+  })
 })

--- a/tests/server/shutdown-background-order.test.ts
+++ b/tests/server/shutdown-background-order.test.ts
@@ -93,4 +93,24 @@ describe('graceful shutdown background delivery ordering', () => {
     expect(agentBridgeManager.forceStop).toHaveBeenCalledOnce()
     expect(exitSpy).toHaveBeenCalledWith(0)
   })
+
+  it('preserves the configured bridge across the forced shutdown deadline', async () => {
+    process.env.HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN = '0'
+    stopPreviewRuntimeMock.mockImplementationOnce(() => new Promise<void>(() => {}))
+    const agentBridgeManager = {
+      stop: vi.fn(async () => {}),
+      forceStop: vi.fn(),
+    }
+    const httpServer = { close: vi.fn() }
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+    const { createShutdownHandler, getShutdownForceExitMs } = await import('../../packages/server/src/services/shutdown')
+
+    void createShutdownHandler(httpServer, undefined, undefined, agentBridgeManager)('desktop-request')
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(getShutdownForceExitMs())
+
+    expect(agentBridgeManager.stop).not.toHaveBeenCalled()
+    expect(agentBridgeManager.forceStop).not.toHaveBeenCalled()
+    expect(exitSpy).toHaveBeenCalledWith(0)
+  })
 })


### PR DESCRIPTION
## What changed

- Bound Desktop Browser Broker shutdown and cancel active browser operations before continuing exit.
- Stop the Agent Bridge gracefully first, then force-kill its full process tree on Windows or process group and descendants on Linux/macOS.
- Make the Web UI shutdown deadline force-stop the Bridge before exiting while preserving `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0`.
- Bound Windows process-tree termination commands so the fallback cannot block application exit indefinitely.
- Make Desktop Web UI fallback termination cover descendant processes and guarantee the Electron exit path with `finally`.
- Make Windows installer upgrades show the normal shutdown screen and wait up to 30 seconds before force-stopping remaining managed processes.
- Add shutdown regression coverage and update the chat-chain change fragment.

## Why

The previous exit path could block indefinitely while closing an active Browser Broker request. If graceful Web UI or Agent Bridge shutdown timed out, only the immediate broker or Web UI PID was killed, allowing detached Bridge workers or MCP subprocesses to remain alive after Hermes Studio exited.

The Windows installer also began force-stopping processes before the normal shutdown path had enough time to flush browser state and clean the Bridge process tree.

## Impact

Tray Quit, in-app updates, and Windows overwrite installs now use the visible bounded shutdown flow. Installer upgrades continue as soon as managed processes exit, wait at most 30 seconds for graceful cleanup, and only then use a 5-second force-stop fallback.

An explicit `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN=0` setting continues to preserve the Bridge even when the Web UI shutdown deadline is reached.

## Validation

- `npm run test -- tests/desktop/installer-shutdown.test.ts tests/desktop/updater.test.ts tests/server/shutdown.test.ts tests/server/shutdown-background-order.test.ts tests/server/agent-bridge-manager.test.ts tests/desktop/browser-broker.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm --prefix packages/desktop run build`
- `npm run harness:check`
- `git diff --check`
