### PR TITLE
[codex] polish Windows browser toolbar layout

### DIFF
--- a/docs/chat-chain-changes/2026-07-23-windows-browser-toolbar-layout.md
+++ b/docs/chat-chain-changes/2026-07-23-windows-browser-toolbar-layout.md
@@ -1,0 +1,15 @@
+---
+date: 2026-07-23
+pr: 2198
+feature: Windows browser toolbar layout
+impact: Embedded browser navigation icons render consistently on Windows, and the custom title bar now fills space released by collapsed route-owned sidebars.
+---
+
+The embedded browser uses SVG paths for back, forward, reload, and stop
+controls instead of platform-font Unicode glyphs.
+
+Single chat, Global Agent, history, workflow, and group chat surfaces publish
+their local sidebar state to the app shell. The Windows custom title bar uses
+that state to remove its left offset when the page sidebar is fully collapsed.
+Message delivery, session persistence, and group chat runtime behavior are
+unchanged.

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -45,8 +45,8 @@ const desktopPlatform = computed(() => desktopBridge()?.platform || '')
 const isDesktopWindows = computed(() => isDesktopShell.value && desktopPlatform.value === 'win32')
 const desktopTitleBarLeft = computed(() => {
   if (isLoginPage.value) return 10
-  if (showAppSidebar.value && appStore.sidebarCollapsed) return 84
-  return 260
+  if (showAppSidebar.value) return appStore.sidebarCollapsed ? 84 : 260
+  return appStore.pageSidebarExpanded ? 260 : 10
 })
 const isDesktopPetRoute = computed(() => route.name === 'desktop.pet')
 const showWebPet = computed(() => !isLoginPage.value && !isDesktopShell.value && !isDesktopPetRoute.value)

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -121,6 +121,9 @@ const showSessions = ref(
   typeof window === "undefined" ||
     !window.matchMedia("(max-width: 768px)").matches,
 );
+const pageSidebarExpanded = computed(
+  () => currentMode.value === "chat" && showSessions.value,
+);
 let mobileQuery: MediaQueryList | null = null;
 const isMobile = ref(false);
 const toolPanelStyle = computed(() => ({
@@ -301,6 +304,12 @@ function handleMobileChange(e: MediaQueryListEvent | MediaQueryList) {
 function openPageSidebar() {
   showSessions.value = true;
 }
+
+watch(
+  pageSidebarExpanded,
+  (expanded) => appStore.setPageSidebarExpanded(expanded),
+  { immediate: true },
+);
 
 function workspacePreviewPath(filePath: string): string | null {
   const workspace = activeWorkspacePath.value?.replace(/\\/g, "/").replace(/\/+$/, "");

--- a/packages/client/src/components/hermes/chat/DesktopBrowserPanel.vue
+++ b/packages/client/src/components/hermes/chat/DesktopBrowserPanel.vue
@@ -438,9 +438,43 @@ onUnmounted(() => {
       </div>
 
       <div class="toolbar">
-        <button :disabled="hasAnnotationSession || !activeTab?.canGoBack" :title="t('browser.back')" @click="navigationAction('back')">←</button>
-        <button :disabled="hasAnnotationSession || !activeTab?.canGoForward" :title="t('browser.forward')" @click="navigationAction('forward')">→</button>
-        <button :disabled="hasAnnotationSession" :title="activeTab?.loading ? t('browser.stop') : t('browser.reload')" @click="navigationAction(activeTab?.loading ? 'stop' : 'reload')">{{ activeTab?.loading ? '×' : '↻' }}</button>
+        <button
+          type="button"
+          :disabled="hasAnnotationSession || !activeTab?.canGoBack"
+          :title="t('browser.back')"
+          :aria-label="t('browser.back')"
+          @click="navigationAction('back')"
+        >
+          <svg class="toolbar-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          :disabled="hasAnnotationSession || !activeTab?.canGoForward"
+          :title="t('browser.forward')"
+          :aria-label="t('browser.forward')"
+          @click="navigationAction('forward')"
+        >
+          <svg class="toolbar-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="m9 18 6-6-6-6" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          :disabled="hasAnnotationSession"
+          :title="activeTab?.loading ? t('browser.stop') : t('browser.reload')"
+          :aria-label="activeTab?.loading ? t('browser.stop') : t('browser.reload')"
+          @click="navigationAction(activeTab?.loading ? 'stop' : 'reload')"
+        >
+          <svg v-if="activeTab?.loading" class="toolbar-icon toolbar-stop-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <rect x="7" y="7" width="10" height="10" rx="1" />
+          </svg>
+          <svg v-else class="toolbar-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M20 12a8 8 0 1 1-2.34-5.66L20 8" />
+            <path d="M20 4v4h-4" />
+          </svg>
+        </button>
         <NInput v-model:value="address" size="small" :placeholder="t('browser.addressPlaceholder')" :disabled="busy || hasAnnotationSession" @keydown.enter="navigate" />
         <NSelect
           class="profile-switcher"
@@ -531,8 +565,10 @@ onUnmounted(() => {
 .tab { width: 190px; min-width: 100px; height: 34px; border: 0; border-radius: 8px 8px 0 0; background: transparent; color: inherit; display: flex; align-items: center; gap: 7px; padding: 0 9px; cursor: pointer; }
 .tab.active { color: var(--text-primary, #1a1a1a); background: var(--bg-card, #fff); box-shadow: inset 0 0 0 1px var(--border-color, #e0e0e0); }
 .tab img { width: 16px; height: 16px; }.tab span { flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; text-align: left; }.tab i { color: #3b82f6; font-size: 9px; }.tab b { font: 18px/1 sans-serif; font-weight: 400; }
-.new-tab, .toolbar > button, .download-trigger { border: 0; background: transparent; color: inherit; cursor: pointer; border-radius: 6px; }.new-tab { width: 34px; height: 34px; font-size: 20px; }.toolbar > button, .download-trigger { width: 30px; height: 30px; font-size: 18px; }.toolbar > button:hover, .download-trigger:hover, .new-tab:hover { background: rgba(127,127,127,.15); }.toolbar > button:disabled { opacity: .35; }
+.new-tab, .toolbar > button, .download-trigger { border: 0; background: transparent; color: inherit; cursor: pointer; border-radius: 6px; }.new-tab { width: 34px; height: 34px; font-size: 20px; }.toolbar > button, .download-trigger { width: 30px; height: 30px; font-size: 18px; }.toolbar > button { display: inline-grid; place-items: center; padding: 0; }.toolbar > button:hover, .download-trigger:hover, .new-tab:hover { background: rgba(127,127,127,.15); }.toolbar > button:disabled { opacity: .35; }
 .toolbar { height: 46px; flex: 0 0 46px; padding: 7px 10px; border-bottom: 1px solid var(--border-color); display: flex; align-items: center; gap: 8px; }
+.toolbar-icon { width: 18px; height: 18px; fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+.toolbar-stop-icon { fill: currentColor; stroke: none; }
 .profile-switcher { width: 136px; flex: 0 0 136px; }
 .download-trigger { position: relative; flex: 0 0 30px; padding: 0; }
 .download-trigger > b { position: absolute; top: -3px; right: -4px; min-width: 15px; height: 15px; padding: 0 3px; border-radius: 8px; background: #ef4444; color: #fff; font: 10px/15px sans-serif; text-align: center; }

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { useMessage, NInput, NButton, NSpace, NSelect, NPopover, NPopconfirm, NInputNumber, NDropdown, NModal, type DropdownOption } from 'naive-ui'
 import { useGroupChatStore } from '@/stores/hermes/group-chat'
+import { useAppStore } from '@/stores/hermes/app'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import { updateRoomConfig, forceCompress } from '@/api/hermes/group-chat'
 import GroupMessageList from './GroupMessageList.vue'
@@ -28,12 +29,18 @@ const DesktopBrowserPanel = defineAsyncComponent(async () => (await import('@/co
 const { t } = useI18n()
 const router = useRouter()
 const message = useMessage()
+const appStore = useAppStore()
 const store = useGroupChatStore()
 const profilesStore = useProfilesStore()
 const filesStore = useFilesStore()
 const toolPanelStore = useToolPanelStore()
 
 const showSidebar = ref(window.innerWidth > 768)
+watch(
+    showSidebar,
+    expanded => appStore.setPageSidebarExpanded(expanded),
+    { immediate: true },
+)
 const showCreateModal = ref(false)
 const showCloneModal = ref(false)
 const showAddAgentModal = ref(false)

--- a/packages/client/src/stores/hermes/app.ts
+++ b/packages/client/src/stores/hermes/app.ts
@@ -27,6 +27,8 @@ export const useAppStore = defineStore('app', () => {
   const sidebarOpen = ref(false)
   // Desktop-only collapsed state (icon-rail mode). Persisted to localStorage.
   const sidebarCollapsed = ref(localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === '1')
+  // Expanded state of route-owned sidebars, used by the Windows title bar.
+  const pageSidebarExpanded = ref(true)
 
   const connected = ref(false)
   const serverVersion = ref(WEB_UI_VERSION)
@@ -335,12 +337,18 @@ export const useAppStore = defineStore('app', () => {
     }
   }
 
+  function setPageSidebarExpanded(expanded: boolean) {
+    pageSidebarExpanded.value = expanded
+  }
+
   return {
     sidebarOpen,
     sidebarCollapsed,
+    pageSidebarExpanded,
     toggleSidebar,
     closeSidebar,
     toggleSidebarCollapsed,
+    setPageSidebarExpanded,
     connected,
     serverVersion,
     latestVersion,

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -103,6 +103,11 @@ async function loadHermesSessions() {
 const showSessions = ref(
   typeof window === 'undefined' || !window.matchMedia('(max-width: 768px)').matches,
 )
+watch(
+  showSessions,
+  expanded => appStore.setPageSidebarExpanded(expanded),
+  { immediate: true },
+)
 let mobileQuery: MediaQueryList | null = null
 const isMobile = ref(false)
 

--- a/packages/client/src/views/hermes/WorkflowView.vue
+++ b/packages/client/src/views/hermes/WorkflowView.vue
@@ -294,6 +294,11 @@ const activeWorkflowId = ref('')
 const showWorkflowSidebar = ref(
   typeof window === 'undefined' || !window.matchMedia('(max-width: 768px)').matches,
 )
+watch(
+  showWorkflowSidebar,
+  expanded => appStore.setPageSidebarExpanded(expanded),
+  { immediate: true },
+)
 const isMobile = ref(false)
 const workflowsLoading = ref(false)
 const workflowProfileFilter = ref<string | null>(null)

--- a/tests/client/app-store.test.ts
+++ b/tests/client/app-store.test.ts
@@ -45,6 +45,15 @@ describe('App Store', () => {
     expect(window.localStorage.getItem('hermes_sidebar_collapsed')).toBe('0')
   })
 
+  it('tracks route-owned sidebar state for desktop chrome layout', () => {
+    const store = useAppStore()
+
+    expect(store.pageSidebarExpanded).toBe(true)
+
+    store.setPageSidebarExpanded(false)
+    expect(store.pageSidebarExpanded).toBe(false)
+  })
+
   it('loads model visibility and falls back when the configured default is hidden', async () => {
     mockSystemApi.fetchAvailableModels.mockResolvedValue({
       default: 'deepseek-chat',

--- a/tests/client/app-web-pet.test.ts
+++ b/tests/client/app-web-pet.test.ts
@@ -6,6 +6,8 @@ const routeMock = vi.hoisted(() => ({ name: 'hermes.chat' as string }))
 const appStoreMock = vi.hoisted(() => ({
   nodeVersion: '23.0.0',
   sidebarOpen: true,
+  sidebarCollapsed: false,
+  pageSidebarExpanded: true,
   toggleSidebar: vi.fn(),
   closeSidebar: vi.fn(),
   loadModels: vi.fn(),
@@ -68,7 +70,11 @@ vi.mock('@/components/layout/AppSidebar.vue', () => ({
 }))
 
 vi.mock('@/components/layout/DesktopTitleBar.vue', () => ({
-  default: { name: 'DesktopTitleBar', template: '<div />' },
+  default: {
+    name: 'DesktopTitleBar',
+    props: ['standalone', 'leftOffset'],
+    template: '<div />',
+  },
 }))
 
 import App from '@/App.vue'
@@ -92,7 +98,6 @@ function mountApp() {
         NNotificationProvider: { template: '<div><slot /></div>' },
         AuthEventListener: true,
         AppSidebar: true,
-        DesktopTitleBar: true,
         SessionSearchModal: true,
         DefaultCredentialPrompt: true,
         RouterView: { template: '<div class="router-view-test" />' },
@@ -105,6 +110,8 @@ describe('App web pet mounting', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     routeMock.name = 'hermes.chat'
+    appStoreMock.sidebarCollapsed = false
+    appStoreMock.pageSidebarExpanded = true
     delete (window as WindowWithDesktop).hermesDesktop
   })
 
@@ -139,6 +146,19 @@ describe('App web pet mounting', () => {
 
     expect(wrapper.find('.app-shell').classes()).toContain('desktop-platform-win32')
     expect(wrapper.findComponent({ name: 'DesktopTitleBar' }).exists()).toBe(true)
+  })
+
+  it('expands the Windows control bar when a page-owned sidebar is collapsed', async () => {
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { isDesktop: true, platform: 'win32' },
+    })
+    appStoreMock.pageSidebarExpanded = false
+
+    const wrapper = mountApp()
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'DesktopTitleBar' }).props('leftOffset')).toBe(10)
   })
 
   it('marks Windows desktop shell as maximized when the native window state changes', async () => {


### PR DESCRIPTION
## Summary
- replace the embedded browser's Unicode back, forward, reload, and stop glyphs with deterministic SVG icons
- make the Windows custom title bar follow both the global sidebar and route-owned sidebars
- cover chat, global agent, history, workflow, and group chat sidebar state
- add focused store and app-shell coverage for the collapsed title-bar offset
- document the affected chat-chain surfaces for the repository harness

## Why
The browser navigation controls depended on platform fonts, so they rendered inconsistently on Windows. The custom Windows title bar also only observed the global sidebar state; page-owned sidebars could collapse while the title bar kept its original 260px left offset.

## Impact
Browser navigation icons now render consistently across platforms. Collapsing a page sidebar expands the Windows title bar into the released space instead of leaving a blank segment. Message delivery, session persistence, and group chat runtime behavior are unchanged.

## Validation
- `npm run harness:check`
- `npx vitest run tests/client/app-store.test.ts tests/client/app-web-pet.test.ts tests/client/desktop-titlebar.test.ts tests/client/desktop-browser-route.test.ts`
- `npx vue-tsc -b --pretty false`
- `npm run build`
- `git diff --check`
