### PR TITLE
add desktop text context menu

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -24,6 +24,7 @@ import { t } from './desktop-i18n'
 import { resetDesktopDefaultLogin } from './desktop-login-reset'
 import { installHermesStudioCliShim, installHermesStudioMcpShim } from './cli-shim'
 import { parseHermesCliArgs, runBundledHermesCli } from './hermes-cli'
+import { installSelectionContextMenu } from './selection-context-menu'
 import {
   ensureDesktopRuntime,
   isDesktopRuntimeReady,
@@ -500,6 +501,8 @@ async function createWindow(): Promise<void> {
   mainWindow.on('maximize', notifyWindowStateChanged)
   mainWindow.on('unmaximize', notifyWindowStateChanged)
   mainWindow.on('restore', notifyWindowStateChanged)
+
+  installSelectionContextMenu(mainWindow)
 
   // External links → system browser
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {

--- a/packages/desktop/src/main/selection-context-menu.ts
+++ b/packages/desktop/src/main/selection-context-menu.ts
@@ -1,0 +1,23 @@
+import { Menu, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
+
+export function installSelectionContextMenu(targetWindow: BrowserWindow): void {
+  targetWindow.webContents.on('context-menu', (_event, params) => {
+    let template: MenuItemConstructorOptions[]
+
+    if (params.isEditable) {
+      template = [
+        { role: 'cut', enabled: params.editFlags.canCut },
+        { role: 'copy', enabled: params.editFlags.canCopy },
+        { role: 'paste', enabled: params.editFlags.canPaste },
+        { type: 'separator' },
+        { role: 'selectAll', enabled: params.editFlags.canSelectAll },
+      ]
+    } else if (params.selectionText && params.editFlags.canCopy) {
+      template = [{ role: 'copy' }]
+    } else {
+      return
+    }
+
+    Menu.buildFromTemplate(template).popup({ window: targetWindow })
+  })
+}

--- a/tests/desktop/selection-context-menu.test.ts
+++ b/tests/desktop/selection-context-menu.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronMocks = vi.hoisted(() => ({
+  buildFromTemplate: vi.fn(),
+  popup: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  Menu: {
+    buildFromTemplate: electronMocks.buildFromTemplate,
+  },
+}))
+
+import { installSelectionContextMenu } from '../../packages/desktop/src/main/selection-context-menu'
+
+type ContextMenuHandler = (
+  event: unknown,
+  params: {
+    selectionText: string
+    isEditable: boolean
+    editFlags: {
+      canCut: boolean
+      canCopy: boolean
+      canPaste: boolean
+      canSelectAll: boolean
+    }
+  },
+) => void
+
+function contextMenuParams({
+  selectionText = '',
+  isEditable = false,
+  canCut = false,
+  canCopy = false,
+  canPaste = false,
+  canSelectAll = false,
+} = {}) {
+  return {
+    selectionText,
+    isEditable,
+    editFlags: { canCut, canCopy, canPaste, canSelectAll },
+  }
+}
+
+function setupContextMenu() {
+  let handler: ContextMenuHandler | undefined
+  const webContents = {
+    on: vi.fn((event: string, listener: ContextMenuHandler) => {
+      if (event === 'context-menu') handler = listener
+    }),
+  }
+  const targetWindow = { webContents }
+
+  installSelectionContextMenu(targetWindow as never)
+
+  return {
+    handler: () => {
+      expect(handler).toBeTypeOf('function')
+      return handler!
+    },
+    targetWindow,
+    webContents,
+  }
+}
+
+describe('desktop selection context menu', () => {
+  beforeEach(() => {
+    electronMocks.buildFromTemplate.mockReset()
+    electronMocks.popup.mockReset()
+    electronMocks.buildFromTemplate.mockReturnValue({ popup: electronMocks.popup })
+  })
+
+  it('registers the selection menu on the main desktop window', () => {
+    const source = readFileSync(resolve('packages/desktop/src/main/index.ts'), 'utf8')
+
+    expect(source).toContain("import { installSelectionContextMenu } from './selection-context-menu'")
+    expect(source).toContain('installSelectionContextMenu(mainWindow)')
+  })
+
+  it('shows the native copy action for a copyable text selection', () => {
+    const { handler, targetWindow, webContents } = setupContextMenu()
+
+    expect(webContents.on).toHaveBeenCalledWith('context-menu', expect.any(Function))
+    handler()({}, contextMenuParams({ selectionText: 'selected reply text', canCopy: true }))
+
+    expect(electronMocks.buildFromTemplate).toHaveBeenCalledWith([{ role: 'copy' }])
+    expect(electronMocks.popup).toHaveBeenCalledWith({ window: targetWindow })
+  })
+
+  it('shows standard editing actions, including paste, in editable fields', () => {
+    const { handler, targetWindow } = setupContextMenu()
+
+    handler()({}, contextMenuParams({
+      selectionText: 'draft text',
+      isEditable: true,
+      canCut: true,
+      canCopy: true,
+      canPaste: true,
+      canSelectAll: true,
+    }))
+
+    expect(electronMocks.buildFromTemplate).toHaveBeenCalledWith([
+      { role: 'cut', enabled: true },
+      { role: 'copy', enabled: true },
+      { role: 'paste', enabled: true },
+      { type: 'separator' },
+      { role: 'selectAll', enabled: true },
+    ])
+    expect(electronMocks.popup).toHaveBeenCalledWith({ window: targetWindow })
+  })
+
+  it('does not replace existing context menus when there is no copyable selection', () => {
+    const { handler } = setupContextMenu()
+
+    handler()({}, contextMenuParams({ canCopy: true }))
+    handler()({}, contextMenuParams({ selectionText: 'selected reply text' }))
+
+    expect(electronMocks.buildFromTemplate).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add a native Electron context menu for copying selected message text
- provide cut, copy, paste, and select-all actions in editable fields
- preserve existing custom context menus when there is no applicable text action
- add focused desktop coverage for menu registration and behavior

Fixes #2202

## Why
Electron does not provide the browser's default context menu automatically. As a result, selected reply text could only be copied with the keyboard shortcut, and editable fields had no right-click paste action.

## User impact
Desktop users can now right-click selected conversation text to copy it. Text inputs expose the standard editing actions and automatically disable unavailable actions.

## Validation
- `npm run test -- tests/desktop`
- `npm --prefix packages/desktop run build:main`
- `npm run harness:check`
- `npm run build`
