### PR TITLE
Fix session scroll restoration races

### DIFF
--- a/docs/chat-chain-changes/2026-07-24-session-scroll-restoration.md
+++ b/docs/chat-chain-changes/2026-07-24-session-scroll-restoration.md
@@ -1,0 +1,18 @@
+---
+date: 2026-07-24
+pr: pending
+feature: Session scroll restoration and switch ordering
+impact: Returning to a conversation keeps a bottom-following transcript pinned after delayed content rendering, and rapid session switches no longer apply stale list or resume responses.
+---
+
+The live transcript now observes rendered content height as well as the scroll
+viewport. When a saved session position was at the bottom, delayed image,
+highlighting, table, or other layout changes keep the view pinned until the
+user deliberately scrolls away.
+
+Session-list loads and session resume requests use request ordering guards.
+Message-loading state is scoped to the latest request for each session, so an
+older request cannot clear or overwrite the state of the conversation that the
+user most recently selected.
+
+Server-side chat history and message persistence are unchanged.

--- a/packages/client/src/components/hermes/chat/VirtualMessageList.vue
+++ b/packages/client/src/components/hermes/chat/VirtualMessageList.vue
@@ -61,6 +61,7 @@ defineSlots<{
 }>();
 
 const hostRef = ref<HTMLElement | null>(null);
+const contentRef = ref<HTMLElement | null>(null);
 const scrollerRef = ref<DynamicScrollerExposed<VirtualItem> | null>(null);
 const scrollTop = ref(0);
 const viewportHeight = ref(0);
@@ -139,7 +140,9 @@ function handleWheel(event: WheelEvent) {
 
 function handleResize() {
   syncViewport();
-  if (Date.now() < keepBottomUntil || isNearBottom(64)) scheduleScrollToBottom(2);
+  if (!userDetachedFromBottom || Date.now() < keepBottomUntil || isNearBottom(64)) {
+    scheduleScrollToBottom(2);
+  }
   if (activeAnchorTarget) scheduleAnchorAlignment(activeAnchorTarget.token, 4);
 }
 
@@ -421,6 +424,9 @@ onMounted(() => {
     if (el && typeof ResizeObserver !== "undefined") {
       resizeObserver = new ResizeObserver(handleResize);
       resizeObserver.observe(el);
+      const content = contentRef.value
+        ?? el.querySelector<HTMLElement>(".vue-recycle-scroller__item-wrapper");
+      if (content) resizeObserver.observe(content);
     }
   });
 });
@@ -495,16 +501,18 @@ defineExpose({
       @scroll.passive="handleScroll"
       @wheel.passive="handleWheel"
     >
-      <slot v-if="messages.length > 0" name="before" />
-      <div
-        v-for="(item, index) in messages"
-        :key="messageKey(item)"
-        class="virtual-row"
-        :data-virtual-index="index"
-      >
-        <slot name="item" :message="item" />
+      <div ref="contentRef" class="virtual-message-list-content">
+        <slot v-if="messages.length > 0" name="before" />
+        <div
+          v-for="(item, index) in messages"
+          :key="messageKey(item)"
+          class="virtual-row"
+          :data-virtual-index="index"
+        >
+          <slot name="item" :message="item" />
+        </div>
+        <slot v-if="messages.length > 0" name="after" />
       </div>
-      <slot v-if="messages.length > 0" name="after" />
     </div>
     <div v-if="messages.length === 0 && $slots.empty" class="virtual-message-list-empty">
       <slot name="empty" />
@@ -542,6 +550,11 @@ defineExpose({
   min-width: 0;
   max-width: 100%;
   padding-bottom: var(--virtual-row-gap);
+}
+
+.virtual-message-list-content {
+  min-width: 0;
+  max-width: 100%;
 }
 
 .virtual-message-list-empty {

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1107,8 +1107,27 @@ export const useChatStore = defineStore('chat', () => {
   })
   const isLoadingSessions = ref(false)
   const sessionsLoaded = ref(false)
-  const isLoadingMessages = ref(false)
+  const messageLoadRequests = ref<Map<string, number>>(new Map())
+  const isLoadingMessages = computed(() => {
+    const sid = activeSessionId.value
+    return sid ? messageLoadRequests.value.has(sid) : false
+  })
   const isRunActive = computed(() => isStreaming.value)
+  let loadSessionsRequestSequence = 0
+  let switchSessionRequestSequence = 0
+
+  function beginMessageLoad(sessionId: string, requestSequence: number) {
+    const next = new Map(messageLoadRequests.value)
+    next.set(sessionId, requestSequence)
+    messageLoadRequests.value = next
+  }
+
+  function endMessageLoad(sessionId: string, requestSequence: number) {
+    if (messageLoadRequests.value.get(sessionId) !== requestSequence) return
+    const next = new Map(messageLoadRequests.value)
+    next.delete(sessionId)
+    messageLoadRequests.value = next
+  }
 
   async function fetchRuntimeSessions(profile?: string | null): Promise<SessionSummary[]> {
     const scopedProfile = profile || undefined
@@ -1408,9 +1427,11 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   async function loadSessions(profile?: string | null, preferredSessionId?: string | null) {
+    const requestSequence = ++loadSessionsRequestSequence
     isLoadingSessions.value = true
     try {
       const list = await fetchRuntimeSessions(profile)
+      if (requestSequence !== loadSessionsRequestSequence) return
       const fresh = list.map(mapHermesSession)
       // Preserve already-loaded messages for sessions that are still present,
       // so we don't blow away the active session's messages on refresh.
@@ -1447,10 +1468,14 @@ export const useChatStore = defineStore('chat', () => {
         clearActiveSession()
       }
     } catch (err) {
-      console.error('Failed to load sessions:', err)
+      if (requestSequence === loadSessionsRequestSequence) {
+        console.error('Failed to load sessions:', err)
+      }
     } finally {
-      isLoadingSessions.value = false
-      sessionsLoaded.value = true
+      if (requestSequence === loadSessionsRequestSequence) {
+        isLoadingSessions.value = false
+        sessionsLoaded.value = true
+      }
     }
   }
 
@@ -1635,6 +1660,7 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   async function switchSession(sessionId: string, focusId?: string | null) {
+    const requestSequence = ++switchSessionRequestSequence
     clearThinkingObservationFor(sessionId)
     activeSessionId.value = sessionId
     focusMessageId.value = focusId ?? null
@@ -1646,7 +1672,7 @@ export const useChatStore = defineStore('chat', () => {
 
     if (!activeSession.value) return
 
-    isLoadingMessages.value = true
+    beginMessageLoad(sessionId, requestSequence)
     let backgroundPendingOnResume = 0
 
     try {
@@ -1655,7 +1681,11 @@ export const useChatStore = defineStore('chat', () => {
         const timeout = setTimeout(() => reject(new Error('resume timeout')), 15_000)
         resumeSession(sessionId, (data) => {
           clearTimeout(timeout)
-          if (data.session_id !== sessionId || activeSessionId.value !== sessionId) {
+          if (
+            data.session_id !== sessionId
+            || activeSessionId.value !== sessionId
+            || requestSequence !== switchSessionRequestSequence
+          ) {
             resolve()
             return
           }
@@ -1837,17 +1867,17 @@ export const useChatStore = defineStore('chat', () => {
           resolve()
         }, activeSession.value?.profile, runtimeTransport())
       })
-      if (activeSessionId.value === sessionId) {
+      if (activeSessionId.value === sessionId && requestSequence === switchSessionRequestSequence) {
         await loadWorkspaceRunChangesForSession(sessionId)
       }
     } catch (err) {
       console.error('Failed to load session messages via resume:', err)
     } finally {
-      isLoadingMessages.value = false
+      endMessageLoad(sessionId, requestSequence)
     }
 
     // Resume in-flight run event listeners if needed
-    if (activeSessionId.value === sessionId) {
+    if (activeSessionId.value === sessionId && requestSequence === switchSessionRequestSequence) {
       resumeServerWorkingRun(sessionId, backgroundPendingOnResume > 0, !serverWorking.value.has(sessionId))
     }
   }

--- a/tests/client/chat-store-compression-state.test.ts
+++ b/tests/client/chat-store-compression-state.test.ts
@@ -122,6 +122,87 @@ describe('chat store compression state', () => {
     }))
   })
 
+  it('keeps message loading scoped to the active session during rapid switches', async () => {
+    const callbacks = new Map<string, (data: any) => void>()
+    chatApi.resumeSession.mockImplementation((sessionId: string, onResumed: (data: any) => void) => {
+      callbacks.set(sessionId, onResumed)
+      return {} as any
+    })
+    const store = useChatStore()
+    store.sessions = [makeSession('session-1'), makeSession('session-2')]
+
+    const firstSwitch = store.switchSession('session-1')
+    const secondSwitch = store.switchSession('session-2')
+    expect(store.activeSessionId).toBe('session-2')
+    expect(store.isLoadingMessages).toBe(true)
+
+    callbacks.get('session-1')?.({
+      session_id: 'session-1',
+      messages: [],
+      isWorking: false,
+      events: [],
+    })
+    await firstSwitch
+    expect(store.isLoadingMessages).toBe(true)
+
+    callbacks.get('session-2')?.({
+      session_id: 'session-2',
+      messages: [],
+      isWorking: false,
+      events: [],
+    })
+    await secondSwitch
+    expect(store.isLoadingMessages).toBe(false)
+  })
+
+  it('ignores an obsolete response after switching away and back to the same session', async () => {
+    const callbacks: Array<{ sessionId: string; callback: (data: any) => void }> = []
+    chatApi.resumeSession.mockImplementation((sessionId: string, callback: (data: any) => void) => {
+      callbacks.push({ sessionId, callback })
+      return {} as any
+    })
+    const store = useChatStore()
+    store.sessions = [makeSession('session-1'), makeSession('session-2')]
+
+    const firstSessionOne = store.switchSession('session-1')
+    const sessionTwo = store.switchSession('session-2')
+    const secondSessionOne = store.switchSession('session-1')
+
+    callbacks[2].callback({
+      session_id: 'session-1',
+      messages: [{ id: 'fresh', role: 'user', content: 'fresh response', timestamp: 2 }],
+      isWorking: false,
+      events: [],
+    })
+    await secondSessionOne
+
+    expect(store.isLoadingMessages).toBe(false)
+    expect(store.activeSessionId).toBe('session-1')
+    expect(store.activeSession?.messages).toEqual([
+      expect.objectContaining({ id: 'fresh', content: 'fresh response' }),
+    ])
+
+    callbacks[0].callback({
+      session_id: 'session-1',
+      messages: [{ id: 'stale', role: 'user', content: 'stale response', timestamp: 1 }],
+      isWorking: false,
+      events: [],
+    })
+    await firstSessionOne
+    callbacks[1].callback({
+      session_id: 'session-2',
+      messages: [],
+      isWorking: false,
+      events: [],
+    })
+    await sessionTwo
+
+    expect(store.isLoadingMessages).toBe(false)
+    expect(store.activeSession?.messages).toEqual([
+      expect.objectContaining({ id: 'fresh', content: 'fresh response' }),
+    ])
+  })
+
   it('keeps abort lifecycle and stop handling scoped to each session', async () => {
     chatApi.resumeSession.mockImplementation((sessionId: string, onResumed: (data: any) => void) => {
       onResumed({

--- a/tests/client/chat-store-session-order.test.ts
+++ b/tests/client/chat-store-session-order.test.ts
@@ -139,4 +139,25 @@ describe('chat session ordering', () => {
     expect(store.activeSessionId).toBeNull()
     expect(store.activeSession).toBeNull()
   })
+
+  it('ignores a stale session-list response after a newer route load completes', async () => {
+    const pending: Array<(sessions: any[]) => void> = []
+    vi.mocked(fetchSessions).mockImplementation(() => new Promise(resolve => pending.push(resolve)))
+
+    const store = useChatStore()
+    const first = store.loadSessions(null, 'session-a')
+    const second = store.loadSessions(null, 'session-b')
+
+    pending[2]([makeSession('session-b', { started_at: 2000, last_active: 2000 })])
+    pending[3]([])
+    await second
+
+    pending[0]([makeSession('session-a', { started_at: 1000, last_active: 1000 })])
+    pending[1]([])
+    await first
+
+    expect(store.sessions.map(session => session.id)).toEqual(['session-b'])
+    expect(store.activeSessionId).toBe('session-b')
+    expect(store.activeSession?.id).toBe('session-b')
+  })
 })

--- a/tests/client/virtual-message-list-scroll.test.ts
+++ b/tests/client/virtual-message-list-scroll.test.ts
@@ -50,16 +50,26 @@ function setScrollerMetrics(el: HTMLElement, metrics: { scrollHeight: number; cl
 
 describe('VirtualMessageList scroll behavior', () => {
   let rafCallbacks: FrameRequestCallback[]
+  let resizeCallbacks: ResizeObserverCallback[]
 
   beforeEach(() => {
     vi.clearAllMocks()
     rafCallbacks = []
+    resizeCallbacks = []
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       rafCallbacks.push(callback)
       return rafCallbacks.length
     })
     vi.stubGlobal('cancelAnimationFrame', (id: number) => {
       rafCallbacks[id - 1] = () => undefined
+    })
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallbacks.push(callback)
+      }
+      observe() {}
+      disconnect() {}
+      unobserve() {}
     })
   })
 
@@ -213,5 +223,34 @@ describe('VirtualMessageList scroll behavior', () => {
 
     expect(dynamicScrollToBottomMock).not.toHaveBeenCalled()
     expect(scroller.element.scrollTop).toBe(800)
+  })
+
+  it('keeps a bottom-following transcript pinned when rendered content grows later', async () => {
+    const wrapper = mount(VirtualMessageList, {
+      props: {
+        messages: [{ id: 'message-1' }],
+        virtualized: false,
+      },
+      slots: {
+        item: '<div>message</div>',
+      },
+    })
+    await nextTick()
+
+    const scroller = wrapper.find<HTMLElement>('.virtual-message-list')
+    setScrollerMetrics(scroller.element, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 600,
+    })
+    await scroller.trigger('scroll')
+
+    Object.defineProperty(scroller.element, 'scrollHeight', { configurable: true, value: 1400 })
+    resizeCallbacks.forEach(callback => callback([], {} as ResizeObserver))
+    while (rafCallbacks.length > 0) {
+      rafCallbacks.shift()?.(performance.now())
+    }
+
+    expect(scroller.element.scrollTop).toBe(1000)
   })
 })


### PR DESCRIPTION
## Summary

- keep bottom-following transcripts pinned when delayed content changes the rendered height
- ignore stale session-list and resume responses during rapid session switching
- scope message-loading state to the active session's latest request
- add regression coverage and the required chat-chain change record

## Root cause

The list observed only the fixed-height scroll viewport, so delayed descendant layout changes could move a restored bottom position upward. Session loading also relied on shared state and session IDs alone, allowing older requests—including an A → B → A sequence—to overwrite newer results.

## Validation

- `npm run test -- tests/client/virtual-message-list-scroll.test.ts tests/client/message-list-scroll-position.test.ts tests/client/chat-store-session-order.test.ts tests/client/chat-store-compression-state.test.ts` (39 tests passed)
- `npm run build`
- `npm run harness:check`
- `git diff --check`

Fixes #2200
