### PR TITLE
[codex] add standalone desktop chat window

### DIFF
--- a/docs/chat-chain-changes/2026-07-24-desktop-standalone-chat-window.md
+++ b/docs/chat-chain-changes/2026-07-24-desktop-standalone-chat-window.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-24
+pr: pending
+feature: Standalone desktop chat window
+impact: Desktop sessions can open in a native-chrome, sidebar-free chat window while Web sessions keep opening in a normal browser tab.
+---
+
+The standalone route reuses the existing single-chat view, store, message list, and input. It only suppresses the session sidebar and chat header when hosted by the dedicated Electron window; session loading, Socket.IO resume, streaming, approvals, persistence, and queue behavior are unchanged.

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -28,11 +28,12 @@ const themeOverrides = computed(() => getThemeOverrides(isDark.value, isComic.va
 const naiveTheme = computed(() => isDark.value ? darkTheme : null)
 
 const isLoginPage = computed(() => route.name === 'login')
+const isStandaloneChatPage = computed(() => route.meta?.standaloneChat === true)
 const usesPageSidebar = computed(() =>
   ['hermes.chat', 'hermes.session', 'hermes.history', 'hermes.historySession', 'hermes.globalAgent', 'hermes.globalAgentSession', 'hermes.groupChat', 'hermes.groupChatRoom', 'hermes.workflow'].includes(route.name as string),
 )
-const showAppSidebar = computed(() => !isLoginPage.value && !usesPageSidebar.value)
-const showMobileMenuButton = computed(() => !isLoginPage.value && (showAppSidebar.value || usesPageSidebar.value))
+const showAppSidebar = computed(() => !isLoginPage.value && !isStandaloneChatPage.value && !usesPageSidebar.value)
+const showMobileMenuButton = computed(() => !isLoginPage.value && !isStandaloneChatPage.value && (showAppSidebar.value || usesPageSidebar.value))
 
 const nodeVersionLow = computed(() => {
   const v = appStore.nodeVersion
@@ -43,13 +44,15 @@ const nodeVersionLow = computed(() => {
 const isDesktopShell = computed(() => desktopBridge()?.isDesktop === true)
 const desktopPlatform = computed(() => desktopBridge()?.platform || '')
 const isDesktopWindows = computed(() => isDesktopShell.value && desktopPlatform.value === 'win32')
+const isDesktopChatWindow = computed(() => desktopBridge()?.windowKind === 'chat')
+const showDesktopTitleBar = computed(() => isDesktopWindows.value && !isDesktopChatWindow.value)
 const desktopTitleBarLeft = computed(() => {
   if (isLoginPage.value) return 10
   if (showAppSidebar.value) return appStore.sidebarCollapsed ? 84 : 260
   return appStore.pageSidebarExpanded ? 260 : 10
 })
 const isDesktopPetRoute = computed(() => route.name === 'desktop.pet')
-const showWebPet = computed(() => !isLoginPage.value && !isDesktopShell.value && !isDesktopPetRoute.value)
+const showWebPet = computed(() => !isLoginPage.value && !isStandaloneChatPage.value && !isDesktopShell.value && !isDesktopPetRoute.value)
 const desktopPlatformClass = computed(() => desktopPlatform.value ? `desktop-platform-${desktopPlatform.value}` : '')
 const isDesktopWindowMaximized = ref(false)
 let stopWindowStateListener: (() => void) | undefined
@@ -75,7 +78,7 @@ watch(isLoginPage, (loginPage) => {
 
 onMounted(() => {
   const bridge = desktopBridge()
-  if (!bridge?.isDesktop || desktopPlatform.value !== 'win32') return
+  if (!bridge?.isDesktop || (desktopPlatform.value !== 'win32' && bridge.windowKind !== 'chat')) return
   bridge.getWindowState?.()
     .then(state => {
       isDesktopWindowMaximized.value = !!state.isMaximized
@@ -101,13 +104,13 @@ useKeyboard()
       <NDialogProvider>
         <NNotificationProvider>
           <router-view v-if="isDesktopPetRoute" />
-          <div v-else class="app-shell" :class="[desktopPlatformClass, { desktop: isDesktopShell, 'desktop-window-maximized': isDesktopWindowMaximized }]">
+          <div v-else class="app-shell" :class="[desktopPlatformClass, { desktop: isDesktopShell, 'desktop-chat-window': isDesktopChatWindow, 'desktop-window-maximized': isDesktopWindowMaximized }]">
             <DesktopTitleBar
-              v-if="isDesktopWindows"
-              :standalone="isLoginPage"
+              v-if="showDesktopTitleBar"
+              :standalone="isLoginPage || isDesktopChatWindow"
               :left-offset="desktopTitleBarLeft"
             />
-            <div v-if="nodeVersionLow" class="node-warning-bar">
+            <div v-if="nodeVersionLow && !isStandaloneChatPage" class="node-warning-bar">
               {{ t('sidebar.nodeVersionWarning', { version: appStore.nodeVersion }) }}
             </div>
             <div class="app-layout" :class="{ 'no-sidebar': isLoginPage || !showAppSidebar }">
@@ -122,9 +125,9 @@ useKeyboard()
             </div>
           </div>
           <WebPet v-if="showWebPet" />
-          <SessionSearchModal v-if="!isDesktopPetRoute && sessionSearchOpen" />
-          <DefaultCredentialPrompt v-if="!isDesktopPetRoute" />
-          <ProviderConfigurationPrompt v-if="!isDesktopPetRoute" />
+          <SessionSearchModal v-if="!isDesktopPetRoute && !isStandaloneChatPage && sessionSearchOpen" />
+          <DefaultCredentialPrompt v-if="!isDesktopPetRoute && !isStandaloneChatPage" />
+          <ProviderConfigurationPrompt v-if="!isDesktopPetRoute && !isStandaloneChatPage" />
         </NNotificationProvider>
       </NDialogProvider>
     </NMessageProvider>
@@ -269,6 +272,28 @@ useKeyboard()
   :deep(.workflow-view > .workflow-sidebar > .page-sidebar-top),
   :deep(.group-chat-panel > .room-sidebar > .sidebar-header) {
     padding-top: 32px;
+  }
+}
+
+.app-shell.desktop-chat-window {
+  :deep(.chat-panel--standalone > .chat-main) {
+    margin: 10px;
+  }
+}
+
+.app-shell.desktop-chat-window.desktop-platform-darwin,
+.app-shell.desktop-chat-window.desktop-platform-win32 {
+  &::before {
+    top: 0;
+    height: 46px;
+  }
+
+  .app-layout {
+    padding-top: 46px;
+  }
+
+  :deep(.chat-panel--standalone > .chat-main) {
+    margin-top: 0;
   }
 }
 

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -55,8 +55,14 @@ import { isStoredSuperAdmin } from "@/api/client";
 import { useDefaultWorkspace } from "@/composables/useDefaultWorkspace";
 import { canScopedCodingAgentUseProvider, usesServerManagedProviderAuth } from "@/utils/codingAgentProviders";
 import { OPEN_SUBAGENT_STREAM_EVENT, type OpenSubagentStreamDetail } from "@/utils/hermes/subagent-stream";
-import { hasDesktopBrowserBridge } from "@/utils/desktop-bridge";
+import { desktopBridge, hasDesktopBrowserBridge } from "@/utils/desktop-bridge";
 import { OPEN_DESKTOP_BROWSER_PANEL_EVENT } from "@/utils/desktop-browser";
+
+const props = withDefaults(defineProps<{
+  standalone?: boolean;
+}>(), {
+  standalone: false,
+});
 
 const FilesPanel = defineAsyncComponent(async () => (await import('./FilesPanel.vue')).default);
 const FilePreview = defineAsyncComponent(async () => (await import('@/components/hermes/files/FilePreview.vue')).default);
@@ -89,6 +95,8 @@ const isChatDropActive = ref(false);
 const showToolPanel = ref(false);
 const activeToolPanel = ref<"files" | "terminal" | "browser">("files");
 const desktopBrowserAvailable = hasDesktopBrowserBridge();
+const desktopChatWindowAvailable = desktopBridge()?.isDesktop === true
+  && typeof desktopBridge()?.openChatWindow === "function";
 const selectedSubagent = ref<OpenSubagentStreamDetail | null>(null);
 const selectedSubagentStream = computed(() => {
   const selected = selectedSubagent.value;
@@ -118,11 +126,13 @@ const isBatchDeleting = ref(false);
 // where the session list covers the chat content ("auto-fixes after a
 // moment" — that was the race).
 const showSessions = ref(
-  typeof window === "undefined" ||
-    !window.matchMedia("(max-width: 768px)").matches,
+  !props.standalone && (
+    typeof window === "undefined" ||
+    !window.matchMedia("(max-width: 768px)").matches
+  )
 );
 const pageSidebarExpanded = computed(
-  () => currentMode.value === "chat" && showSessions.value,
+  () => !props.standalone && currentMode.value === "chat" && showSessions.value,
 );
 let mobileQuery: MediaQueryList | null = null;
 const isMobile = ref(false);
@@ -148,6 +158,11 @@ function sessionHref(sessionId: string) {
 
 function openSessionInNewTab(sessionId: string) {
   if (typeof window === "undefined") return;
+  const bridge = desktopBridge();
+  if (bridge?.isDesktop && bridge.openChatWindow) {
+    void bridge.openChatWindow(sessionId, sessionProfile(sessionId) || undefined);
+    return;
+  }
   window.open(sessionHref(sessionId), "_blank", "noopener,noreferrer");
 }
 
@@ -388,7 +403,7 @@ onMounted(() => {
   if (profilesStore.profiles.length === 0) {
     void profilesStore.fetchProfiles();
   }
-  void loadSessionCategories();
+  if (!props.standalone) void loadSessionCategories();
 });
 
 watch(
@@ -1374,7 +1389,12 @@ const contextMenuOptions = computed(() => {
       },
     ],
   })
-  options.push({ label: t("chat.openSessionInNewTab"), key: "open-link" })
+  options.push({
+    label: t(desktopChatWindowAvailable
+      ? "chat.openSessionInNewWindow"
+      : "chat.openSessionInNewTab"),
+    key: "open-link",
+  })
   options.push({ label: t("chat.copySessionLink"), key: "copy-link" })
   options.push({ label: t("chat.copySessionId"), key: "copy-id" })
   return options
@@ -1786,15 +1806,15 @@ async function handleSessionModelCustomSubmit() {
 </script>
 
 <template>
-  <div class="chat-panel">
+  <div class="chat-panel" :class="{ 'chat-panel--standalone': standalone }">
     <div
-      v-if="currentMode === 'chat'"
+      v-if="currentMode === 'chat' && !standalone"
       class="session-backdrop"
       :class="{ active: showSessions }"
       @click="showSessions = false"
     />
     <aside
-      v-if="currentMode === 'chat'"
+      v-if="currentMode === 'chat' && !standalone"
       class="session-list"
       :class="{ collapsed: !showSessions }"
     >
@@ -1952,7 +1972,9 @@ async function handleSessionModelCustomSubmit() {
             :selected="isSessionSelected(s)"
             :show-profile="true"
             :to="sessionHref(s.id)"
+            :intercept-modified-navigation="desktopChatWindowAvailable"
             @select="handleSessionClick(s.id)"
+            @open-new="openSessionInNewTab(s.id)"
             @contextmenu="handleContextMenu($event, s.id)"
             @delete="handleDeleteSession(s.id)"
             @toggle-select="toggleSessionSelection(s)"
@@ -1997,7 +2019,9 @@ async function handleSessionModelCustomSubmit() {
               :selected="isSessionSelected(s)"
               :show-profile="true"
               :to="sessionHref(s.id)"
+              :intercept-modified-navigation="desktopChatWindowAvailable"
               @select="handleSessionClick(s.id)"
+              @open-new="openSessionInNewTab(s.id)"
               @contextmenu="handleContextMenu($event, s.id)"
               @delete="handleDeleteSession(s.id)"
               @toggle-select="toggleSessionSelection(s)"
@@ -2490,7 +2514,7 @@ async function handleSessionModelCustomSubmit() {
       class="chat-main"
       :class="{ 'chat-main--sidebar-collapsed': currentMode !== 'chat' || !showSessions }"
     >
-      <header class="chat-header">
+      <header v-if="!standalone" class="chat-header">
         <div class="header-left">
           <NButton
             v-if="currentMode === 'chat'"

--- a/packages/client/src/components/hermes/chat/SessionListItem.vue
+++ b/packages/client/src/components/hermes/chat/SessionListItem.vue
@@ -19,6 +19,7 @@ const props = withDefaults(defineProps<{
   selected?: boolean
   showProfile?: boolean
   to?: string
+  interceptModifiedNavigation?: boolean
 }>(), {
   showProfile: true,
 })
@@ -28,6 +29,7 @@ const emit = defineEmits<{
   contextmenu: [event: MouseEvent]
   delete: []
   'toggle-select': []
+  'open-new': []
 }>()
 
 const { t } = useI18n()
@@ -97,7 +99,13 @@ function onClick(event?: MouseEvent) {
     event?.preventDefault()
     return
   }
-  if (isModifiedNavigation(event)) return
+  if (isModifiedNavigation(event)) {
+    if (props.interceptModifiedNavigation) {
+      event?.preventDefault()
+      emit('open-new')
+    }
+    return
+  }
   if (props.to && !props.selectable) event?.preventDefault()
   emit('select')
 }

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -689,6 +689,7 @@ export default {
     monitorRoleAssistant: 'Assistent',
     copySessionLink: 'Sitzungslink kopieren',
     openSessionInNewTab: 'In neuem Tab öffnen',
+    openSessionInNewWindow: 'In neuem Fenster öffnen',
     sessionLinkCopied: 'Session link copied',
     copySessionId: 'Sitzungs-ID kopieren',
     export: 'Exportieren',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -756,6 +756,7 @@ export default {
     monitorRoleAssistant: 'Assistant',
     copySessionLink: 'Copy Session Link',
     openSessionInNewTab: 'Open in new tab',
+    openSessionInNewWindow: 'Open in new window',
     sessionLinkCopied: 'Session link copied',
     copySessionId: 'Copy Session ID',
     export: 'Export',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -689,6 +689,7 @@ export default {
     monitorRoleAssistant: 'Asistente',
     copySessionLink: 'Copiar enlace de sesión',
     openSessionInNewTab: 'Abrir en una nueva pestaña',
+    openSessionInNewWindow: 'Abrir en una nueva ventana',
     sessionLinkCopied: 'Session link copied',
     copySessionId: 'Copiar ID de sesión',
     export: 'Exportar',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -689,6 +689,7 @@ export default {
     monitorRoleAssistant: 'Assistant',
     copySessionLink: 'Copier le lien de session',
     openSessionInNewTab: 'Ouvrir dans un nouvel onglet',
+    openSessionInNewWindow: 'Ouvrir dans une nouvelle fenêtre',
     sessionLinkCopied: 'Session link copied',
     copySessionId: "Copier l'ID de session",
     export: 'Exporter',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -689,6 +689,7 @@ export default {
     monitorRoleAssistant: 'アシスタント',
     copySessionLink: 'セッションリンクをコピー',
     openSessionInNewTab: '新しいタブで開く',
+    openSessionInNewWindow: '新しいウィンドウで開く',
     sessionLinkCopied: 'Session link copied',
     copySessionId: 'セッション ID をコピー',
     export: 'エクスポート',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -689,6 +689,7 @@ export default {
     monitorRoleAssistant: '어시스턴트',
     copySessionLink: '세션 링크 복사',
     openSessionInNewTab: '새 탭에서 열기',
+    openSessionInNewWindow: '새 창에서 열기',
     sessionLinkCopied: 'Session link copied',
     copySessionId: '세션 ID 복사',
     export: '내보내기',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -689,6 +689,7 @@ export default {
     monitorRoleAssistant: 'Assistente',
     copySessionLink: 'Copiar link da sessão',
     openSessionInNewTab: 'Abrir em nova aba',
+    openSessionInNewWindow: 'Abrir em nova janela',
     sessionLinkCopied: 'Session link copied',
     copySessionId: 'Copiar ID da sessão',
     export: 'Exportar',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -634,6 +634,7 @@ export default {
     monitorRoleUser: 'Пользователь',
     monitorRoleAssistant: 'Ассистент',
     copySessionLink: 'Копировать ссылку на сеанс',
+    openSessionInNewWindow: 'Открыть в новом окне',
     copySessionId: 'Копировать ID сеанса',
     export: 'Экспорт',
     editConfig: 'Редактировать конфигурацию',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -753,6 +753,7 @@ export default {
     monitorRoleAssistant: '助手',
     copySessionLink: '複製工作階段連結',
     openSessionInNewTab: '在新分頁開啟',
+    openSessionInNewWindow: '在新視窗開啟',
     sessionLinkCopied: 'Session link copied',
     copySessionId: '複製工作階段 ID',
     export: '匯出',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -756,6 +756,7 @@ export default {
     monitorRoleAssistant: '助手',
     copySessionLink: '复制会话链接',
     openSessionInNewTab: '在新标签页打开',
+    openSessionInNewWindow: '在新窗口打开',
     sessionLinkCopied: 'Session link copied',
     copySessionId: '复制会话 ID',
     export: '导出',

--- a/packages/client/src/router/index.ts
+++ b/packages/client/src/router/index.ts
@@ -28,6 +28,12 @@ const router = createRouter({
       component: () => import('@/views/hermes/ChatView.vue'),
     },
     {
+      path: '/desktop-chat/:sessionId',
+      name: 'desktop.chat',
+      component: () => import('@/views/hermes/ChatView.vue'),
+      meta: { standaloneChat: true },
+    },
+    {
       path: '/hermes/history',
       name: 'hermes.history',
       component: () => import('@/views/hermes/HistoryView.vue'),

--- a/packages/client/src/utils/desktop-bridge.ts
+++ b/packages/client/src/utils/desktop-bridge.ts
@@ -125,6 +125,7 @@ export interface HermesDesktopBridge {
   retryBootstrap: (source?: 'cf' | 'github') => Promise<void>
   selectRuntimeDirectory?: (defaultPath?: string) => Promise<string | null>
   notifyCompletion: (payload: { title: string; body?: string; icon?: string; tag?: string }) => Promise<boolean>
+  openChatWindow?: (sessionId: string, profile?: string) => Promise<void>
   getWindowState: () => Promise<{ isMaximized: boolean }>
   windowControl: (action: 'minimize' | 'toggle-maximize' | 'close') => Promise<{ isMaximized: boolean }>
   onWindowStateChange?: (callback: (state: { isMaximized: boolean }) => void) => () => void
@@ -135,7 +136,7 @@ export interface HermesDesktopBridge {
   browser?: DesktopBrowserBridge
   platform: string
   isDesktop: boolean
-  windowKind?: 'main' | 'pet'
+  windowKind?: 'main' | 'pet' | 'chat'
 }
 
 export type WindowWithHermesDesktop = Window & typeof globalThis & {
@@ -168,4 +169,8 @@ export function isDesktopShell(): boolean {
 
 export function isDesktopPetWindow(): boolean {
   return desktopBridge()?.windowKind === 'pet'
+}
+
+export function isDesktopChatWindow(): boolean {
+  return desktopBridge()?.windowKind === 'chat'
 }

--- a/packages/client/src/views/hermes/ChatView.vue
+++ b/packages/client/src/views/hermes/ChatView.vue
@@ -24,9 +24,10 @@ const routeProfile = computed(() => {
   return typeof value === 'string' && value.trim() ? value : null
 })
 
+const isStandaloneChat = computed(() => route.meta?.standaloneChat === true)
 const productTitle = 'Hermes Studio'
 const tabTitle = computed(() => {
-  if (route.name !== 'hermes.session') return productTitle
+  if (route.name !== 'hermes.session' && route.name !== 'desktop.chat') return productTitle
   return chatStore.activeSession?.title?.trim() || productTitle
 })
 
@@ -77,8 +78,8 @@ watch([routeSessionId, routeProfile], async ([sessionId]) => {
 </script>
 
 <template>
-  <div class="chat-view">
-    <ChatPanel />
+  <div class="chat-view" :class="{ 'chat-view--standalone': isStandaloneChat }">
+    <ChatPanel :standalone="isStandaloneChat" />
   </div>
 </template>
 
@@ -87,5 +88,9 @@ watch([routeSessionId, routeProfile], async ([sessionId]) => {
   height: calc(100 * var(--vh));
   display: flex;
   flex-direction: column;
+
+  &--standalone {
+    height: 100%;
+  }
 }
 </style>

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -56,6 +56,7 @@ type DesktopWindowBounds = { x: number; y: number; width: number; height: number
 let mainWindow: BrowserWindow | null = null
 let petWindow: BrowserWindow | null = null
 let petWindowLoadPromise: Promise<void> | null = null
+const chatWindows = new Map<string, BrowserWindow>()
 let serverUrl: string | null = null
 let tray: Tray | null = null
 let isQuitting = false
@@ -194,6 +195,11 @@ function petRouteUrl(): string | null {
   return webUiHashUrl('/desktop-pet')
 }
 
+function chatRouteUrl(sessionId: string, profile?: string): string | null {
+  const query = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+  return webUiHashUrl(`/desktop-chat/${encodeURIComponent(sessionId)}${query}`)
+}
+
 function ensurePetWindow(): BrowserWindow {
   if (petWindow && !petWindow.isDestroyed()) return petWindow
 
@@ -260,28 +266,28 @@ async function loadPetWindowRoute(): Promise<void> {
   await petWindowLoadPromise
 }
 
-function windowState() {
+function windowState(target: BrowserWindow | null = mainWindow) {
   return {
-    isMaximized: !!mainWindow?.isMaximized(),
+    isMaximized: !!target && !target.isDestroyed() && target.isMaximized(),
   }
 }
 
-function notifyWindowStateChanged() {
-  if (!mainWindow || mainWindow.isDestroyed()) return
-  mainWindow.webContents.send(WINDOW_STATE_CHANGE_CHANNEL, windowState())
+function notifyWindowStateChanged(target: BrowserWindow | null) {
+  if (!target || target.isDestroyed()) return
+  target.webContents.send(WINDOW_STATE_CHANGE_CHANNEL, windowState(target))
 }
 
-function handleWindowControl(action: WindowControlAction) {
-  if (!mainWindow || mainWindow.isDestroyed()) return windowState()
+function handleWindowControl(target: BrowserWindow | null, action: WindowControlAction) {
+  if (!target || target.isDestroyed()) return windowState(target)
   if (action === 'minimize') {
-    mainWindow.minimize()
+    target.minimize()
   } else if (action === 'toggle-maximize') {
-    if (mainWindow.isMaximized()) mainWindow.unmaximize()
-    else mainWindow.maximize()
+    if (target.isMaximized()) target.unmaximize()
+    else target.maximize()
   } else if (action === 'close') {
-    mainWindow.close()
+    target.close()
   }
-  return windowState()
+  return windowState(target)
 }
 
 function hasQuitRequest(data: unknown): boolean {
@@ -498,9 +504,9 @@ async function createWindow(): Promise<void> {
 
   mainWindow.on('show', updateTrayMenu)
   mainWindow.on('hide', updateTrayMenu)
-  mainWindow.on('maximize', notifyWindowStateChanged)
-  mainWindow.on('unmaximize', notifyWindowStateChanged)
-  mainWindow.on('restore', notifyWindowStateChanged)
+  mainWindow.on('maximize', () => notifyWindowStateChanged(mainWindow))
+  mainWindow.on('unmaximize', () => notifyWindowStateChanged(mainWindow))
+  mainWindow.on('restore', () => notifyWindowStateChanged(mainWindow))
 
   installSelectionContextMenu(mainWindow)
 
@@ -522,6 +528,84 @@ async function createWindow(): Promise<void> {
     await mainWindow.loadURL(splashHtml(t('runtime.checking')))
   }
   updateTrayMenu()
+}
+
+function normalizeChatWindowValue(value: unknown, maxLength: number): string | null {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim()
+  if (!normalized || normalized.length > maxLength || /[\u0000-\u001f\u007f]/.test(normalized)) return null
+  return normalized
+}
+
+async function openChatWindow(sessionIdInput: unknown, profileInput?: unknown): Promise<void> {
+  const sessionId = normalizeChatWindowValue(sessionIdInput, 512)
+  if (!sessionId) throw new Error('Invalid chat session ID')
+  const profile = profileInput == null ? undefined : normalizeChatWindowValue(profileInput, 200) || undefined
+  const windowKey = `${profile || ''}\u0000${sessionId}`
+
+  const existing = chatWindows.get(windowKey)
+  if (existing && !existing.isDestroyed()) {
+    if (existing.isMinimized()) existing.restore()
+    existing.show()
+    existing.focus()
+    return
+  }
+
+  const url = chatRouteUrl(sessionId, profile)
+  if (!url) throw new Error('Desktop Web UI is not ready')
+
+  const chatWindow = new BrowserWindow({
+    width: 620,
+    height: 760,
+    minWidth: 620,
+    minHeight: 480,
+    title: 'Hermes Studio',
+    backgroundColor: '#1a1a1a',
+    autoHideMenuBar: true,
+    show: false,
+    ...(process.platform === 'darwin'
+      ? {
+          titleBarStyle: 'hiddenInset' as const,
+          trafficLightPosition: { x: 20, y: 16 },
+        }
+      : process.platform === 'win32'
+        ? {
+            titleBarStyle: 'hidden' as const,
+            titleBarOverlay: { height: 46 },
+          }
+        : {}),
+    ...(process.platform === 'linux' ? { icon: desktopIcon() } : {}),
+    webPreferences: {
+      preload: join(__dirname, '..', 'preload', 'index.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+      additionalArguments: ['--hermes-window-kind=chat'],
+    },
+  })
+  chatWindows.set(windowKey, chatWindow)
+
+  chatWindow.once('ready-to-show', () => {
+    if (chatWindow.isDestroyed()) return
+    chatWindow.show()
+    chatWindow.focus()
+  })
+  chatWindow.on('maximize', () => notifyWindowStateChanged(chatWindow))
+  chatWindow.on('unmaximize', () => notifyWindowStateChanged(chatWindow))
+  chatWindow.on('restore', () => notifyWindowStateChanged(chatWindow))
+  chatWindow.on('closed', () => {
+    if (chatWindows.get(windowKey) === chatWindow) chatWindows.delete(windowKey)
+  })
+
+  installSelectionContextMenu(chatWindow)
+  chatWindow.webContents.setWindowOpenHandler(({ url: targetUrl }) => {
+    if (/^(https?:|mailto:)/i.test(targetUrl)) {
+      shell.openExternal(targetUrl).catch(() => undefined)
+    }
+    return { action: 'deny' }
+  })
+
+  await chatWindow.loadURL(url)
 }
 
 async function initializeDesktopBrowser(): Promise<void> {
@@ -558,15 +642,19 @@ function installMicrophonePermissionHandler() {
     const isMainRenderer = !!mainWindow
       && !mainWindow.isDestroyed()
       && webContents === mainWindow.webContents
+    const isChatRenderer = [...chatWindows.values()].some(window => (
+      !window.isDestroyed() && webContents === window.webContents
+    ))
+    const isTrustedRenderer = isMainRenderer || isChatRenderer
     if (permission !== 'media') {
-      callback(isMainRenderer)
+      callback(isTrustedRenderer)
       return
     }
 
     const mediaTypes = ('mediaTypes' in details ? details.mediaTypes : undefined) ?? []
     const requestsAudio = mediaTypes.length ? mediaTypes.includes('audio') : true
 
-    if (!isMainRenderer || !requestsAudio) {
+    if (!isTrustedRenderer || !requestsAudio) {
       callback(false)
       return
     }
@@ -836,6 +924,12 @@ async function bootstrap(source?: RuntimeDownloadSource) {
 }
 
 ipcMain.handle('hermes-desktop:get-token', () => getToken())
+ipcMain.handle('hermes-desktop:open-chat-window', (event, sessionId?: unknown, profile?: unknown) => {
+  if (!mainWindow || mainWindow.isDestroyed() || event.sender !== mainWindow.webContents) {
+    throw new Error('Chat windows can only be opened from the main window')
+  }
+  return openChatWindow(sessionId, profile)
+})
 
 function browserForEvent(event: IpcMainInvokeEvent): BrowserManager {
   if (!mainWindow || mainWindow.isDestroyed() || event.sender !== mainWindow.webContents) throw new Error('Desktop browser IPC is only available to the main window')
@@ -950,10 +1044,13 @@ ipcMain.handle('hermes-desktop:select-runtime-directory', async (_event, default
     : await dialog.showOpenDialog(options)
   return result.canceled ? null : result.filePaths[0] || null
 })
-ipcMain.handle('hermes-desktop:get-window-state', () => windowState())
-ipcMain.handle('hermes-desktop:window-control', (_event, action?: unknown) => {
-  if (action !== 'minimize' && action !== 'toggle-maximize' && action !== 'close') return windowState()
-  return handleWindowControl(action)
+ipcMain.handle('hermes-desktop:get-window-state', event => {
+  return windowState(BrowserWindow.fromWebContents(event.sender))
+})
+ipcMain.handle('hermes-desktop:window-control', (event, action?: unknown) => {
+  const target = BrowserWindow.fromWebContents(event.sender)
+  if (action !== 'minimize' && action !== 'toggle-maximize' && action !== 'close') return windowState(target)
+  return handleWindowControl(target, action)
 })
 ipcMain.handle('hermes-desktop:get-pet-window-state', () => petWindowState())
 ipcMain.handle('hermes-desktop:set-pet-window-bounds', (_event, bounds?: unknown) => {

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -1,11 +1,12 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type { BrowserBounds, BrowserProfileCreateInput, BrowserProfileSwitchImpact, BrowserProfileUpdateInput, BrowserSelection, DesktopBrowserProfile, DesktopBrowserState, DesktopBrowserTab } from '../main/browser/browser-types'
 
-type DesktopWindowKind = 'main' | 'pet'
+type DesktopWindowKind = 'main' | 'pet' | 'chat'
 
 function desktopWindowKind(): DesktopWindowKind {
   const arg = process.argv.find(item => item.startsWith('--hermes-window-kind='))
-  return arg?.slice('--hermes-window-kind='.length) === 'pet' ? 'pet' : 'main'
+  const kind = arg?.slice('--hermes-window-kind='.length)
+  return kind === 'pet' || kind === 'chat' ? kind : 'main'
 }
 
 contextBridge.exposeInMainWorld('hermesDesktop', {
@@ -13,6 +14,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   retryBootstrap: (source?: 'cf' | 'github'): Promise<void> => ipcRenderer.invoke('hermes-desktop:retry-bootstrap', source),
   selectRuntimeDirectory: (defaultPath?: string): Promise<string | null> => ipcRenderer.invoke('hermes-desktop:select-runtime-directory', defaultPath),
   notifyCompletion: (payload: { title: string; body?: string; icon?: string; tag?: string }): Promise<boolean> => ipcRenderer.invoke('hermes-desktop:notify-completion', payload),
+  openChatWindow: (sessionId: string, profile?: string): Promise<void> => ipcRenderer.invoke('hermes-desktop:open-chat-window', sessionId, profile),
   ensureAuth: async (): Promise<boolean> => {
     const token = await ipcRenderer.invoke('hermes-desktop:get-token')
     if (token) {

--- a/tests/client/app-web-pet.test.ts
+++ b/tests/client/app-web-pet.test.ts
@@ -2,7 +2,10 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const routeMock = vi.hoisted(() => ({ name: 'hermes.chat' as string }))
+const routeMock = vi.hoisted(() => ({
+  name: 'hermes.chat' as string,
+  meta: {} as Record<string, unknown>,
+}))
 const appStoreMock = vi.hoisted(() => ({
   nodeVersion: '23.0.0',
   sidebarOpen: true,
@@ -83,6 +86,7 @@ type WindowWithDesktop = typeof window & {
   hermesDesktop?: {
     isDesktop?: boolean
     platform?: string
+    windowKind?: 'main' | 'pet' | 'chat'
     getWindowState?: () => Promise<{ isMaximized: boolean }>
     onWindowStateChange?: (callback: (state: { isMaximized: boolean }) => void) => () => void
   }
@@ -110,6 +114,7 @@ describe('App web pet mounting', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     routeMock.name = 'hermes.chat'
+    routeMock.meta = {}
     appStoreMock.sidebarCollapsed = false
     appStoreMock.pageSidebarExpanded = true
     delete (window as WindowWithDesktop).hermesDesktop
@@ -191,6 +196,23 @@ describe('App web pet mounting', () => {
 
     const wrapper = mountApp()
 
+    expect(wrapper.findComponent({ name: 'WebPet' }).exists()).toBe(false)
+  })
+
+  it('leaves chat window controls to native chrome without mounting the application sidebar', async () => {
+    routeMock.name = 'desktop.chat'
+    routeMock.meta = { standaloneChat: true }
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { isDesktop: true, platform: 'darwin', windowKind: 'chat' },
+    })
+
+    const wrapper = mountApp()
+    await flushPromises()
+
+    expect(wrapper.find('.app-shell').classes()).toContain('desktop-chat-window')
+    expect(wrapper.findComponent({ name: 'DesktopTitleBar' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'AppSidebar' }).exists()).toBe(false)
     expect(wrapper.findComponent({ name: 'WebPet' }).exists()).toBe(false)
   })
 })

--- a/tests/client/chat-panel-session-click.test.ts
+++ b/tests/client/chat-panel-session-click.test.ts
@@ -9,6 +9,15 @@ describe('ChatPanel session clicks', () => {
     expect(source).toContain('await chatStore.switchSession(sessionId)')
   })
 
+  it('opens desktop sessions in a native chat window while preserving the web tab fallback', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+
+    expect(source).toContain('bridge.openChatWindow(sessionId, sessionProfile(sessionId) || undefined)')
+    expect(source).toContain('window.open(sessionHref(sessionId), "_blank", "noopener,noreferrer")')
+    expect(source).toContain('v-if="currentMode === \'chat\' && !standalone"')
+    expect(source).toContain('<header v-if="!standalone" class="chat-header">')
+  })
+
   it('replays the whole chat surface fade without remounting the input', () => {
     const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
 

--- a/tests/client/chat-view-tab-title.test.ts
+++ b/tests/client/chat-view-tab-title.test.ts
@@ -10,13 +10,18 @@ import { useProfilesStore } from '@/stores/hermes/profiles'
 import { useSettingsStore } from '@/stores/hermes/settings'
 
 vi.mock('@/components/hermes/chat/ChatPanel.vue', () => ({
-  default: { template: '<div data-testid="chat-panel" />' },
+  default: {
+    name: 'ChatPanel',
+    props: { standalone: Boolean },
+    template: '<div data-testid="chat-panel" />',
+  },
 }))
 
 const mockRoute = {
-  name: 'hermes.session',
-  params: {},
-  query: {},
+  name: 'hermes.session' as string,
+  params: {} as Record<string, string>,
+  query: {} as Record<string, string>,
+  meta: {} as Record<string, unknown>,
 }
 
 vi.mock('vue-router', () => ({
@@ -81,6 +86,10 @@ describe('ChatView tab title', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     document.title = 'Hermes Studio'
+    mockRoute.name = 'hermes.session'
+    mockRoute.params = {}
+    mockRoute.query = {}
+    mockRoute.meta = {}
     setActivePinia(createPinia())
 
     const appStore = useAppStore()
@@ -117,6 +126,22 @@ describe('ChatView tab title', () => {
     const wrapper = mount(ChatView)
 
     expect(document.title).toBe('Hermes Studio')
+    wrapper.unmount()
+  })
+
+  it('renders the desktop chat route in standalone mode without forking chat logic', () => {
+    mockRoute.name = 'desktop.chat'
+    mockRoute.params = { sessionId: 'session-1' }
+    mockRoute.meta = { standaloneChat: true }
+
+    const chatStore = useChatStore()
+    chatStore.activeSession = makeSession('Desktop Chat')
+
+    const wrapper = mount(ChatView)
+
+    expect(wrapper.getComponent({ name: 'ChatPanel' }).props('standalone')).toBe(true)
+    expect(wrapper.get('.chat-view').classes()).toContain('chat-view--standalone')
+    expect(document.title).toBe('Desktop Chat')
     wrapper.unmount()
   })
 })

--- a/tests/client/session-list-item.test.ts
+++ b/tests/client/session-list-item.test.ts
@@ -133,6 +133,30 @@ describe('SessionListItem', () => {
     link.element.addEventListener('click', event => event.preventDefault())
     await link.trigger('click', { ctrlKey: true })
     expect(wrapper.emitted('select')).toBeUndefined()
+    expect(wrapper.emitted('open-new')).toBeUndefined()
+  })
+
+  it('routes modified clicks through the desktop window handler when requested', async () => {
+    const wrapper = mount(SessionListItem, {
+      props: {
+        session,
+        active: false,
+        pinned: false,
+        canDelete: true,
+        to: '/session/s1',
+        interceptModifiedNavigation: true,
+      },
+      global: {
+        stubs: {
+          ProfileAvatar: true,
+        },
+      },
+    })
+
+    await wrapper.get('a.session-item').trigger('click', { ctrlKey: true })
+
+    expect(wrapper.emitted('open-new')).toHaveLength(1)
+    expect(wrapper.emitted('select')).toBeUndefined()
   })
 
   it('renders the Hermes logo for Hermes sessions', () => {

--- a/tests/desktop/chat-window.test.ts
+++ b/tests/desktop/chat-window.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+
+describe('desktop chat window', () => {
+  it('creates one native-chrome BrowserWindow per session on the standalone chat route', () => {
+    const mainSource = readFileSync(resolve('packages/desktop/src/main/index.ts'), 'utf8')
+    const preloadSource = readFileSync(resolve('packages/desktop/src/preload/index.ts'), 'utf8')
+    const routerSource = readFileSync(resolve('packages/client/src/router/index.ts'), 'utf8')
+    const openChatWindowSource = mainSource.slice(
+      mainSource.indexOf('async function openChatWindow'),
+      mainSource.indexOf('async function initializeDesktopBrowser'),
+    )
+
+    expect(mainSource).toContain('const chatWindows = new Map<string, BrowserWindow>()')
+    expect(mainSource).toContain("return webUiHashUrl(`/desktop-chat/${encodeURIComponent(sessionId)}${query}`)")
+    expect(openChatWindowSource).not.toContain('frame: false')
+    expect(openChatWindowSource).toContain('width: 620')
+    expect(openChatWindowSource).toContain('height: 760')
+    expect(openChatWindowSource).toContain("titleBarStyle: 'hiddenInset'")
+    expect(openChatWindowSource).toContain('titleBarOverlay: { height: 46 }')
+    expect(openChatWindowSource).toContain("additionalArguments: ['--hermes-window-kind=chat']")
+    expect(mainSource).toContain("ipcMain.handle('hermes-desktop:open-chat-window'")
+    expect(preloadSource).toContain("ipcRenderer.invoke('hermes-desktop:open-chat-window'")
+    expect(routerSource).toContain("path: '/desktop-chat/:sessionId'")
+    expect(routerSource).toContain('meta: { standaloneChat: true }')
+  })
+
+  it('targets window controls at the renderer that invoked them', () => {
+    const source = readFileSync(resolve('packages/desktop/src/main/index.ts'), 'utf8')
+
+    expect(source).toContain('const target = BrowserWindow.fromWebContents(event.sender)')
+    expect(source).toContain('return handleWindowControl(target, action)')
+  })
+})

--- a/tests/e2e/desktop-window-chrome.spec.ts
+++ b/tests/e2e/desktop-window-chrome.spec.ts
@@ -2,10 +2,15 @@ import { expect, test, type Page } from '@playwright/test'
 import { authenticate, mockChatSocket, mockHermesApi, TEST_ACCESS_KEY } from './fixtures'
 
 type DesktopPlatform = 'darwin' | 'linux' | 'win32'
+type DesktopWindowKind = 'main' | 'chat'
 
-async function installDesktopBridge(page: Page, platform: DesktopPlatform, withBrowser = false) {
-  await page.addInitScript(({ desktopPlatform, includeBrowser }) => {
-    const state = { actions: [] as string[], isMaximized: false }
+async function installDesktopBridge(page: Page, platform: DesktopPlatform, withBrowser = false, windowKind: DesktopWindowKind = 'main') {
+  await page.addInitScript(({ desktopPlatform, includeBrowser, desktopWindowKind }) => {
+    const state = {
+      actions: [] as string[],
+      isMaximized: false,
+      chatWindows: [] as Array<{ sessionId: string; profile?: string }>,
+    }
     ;(window as typeof window & { __PW_DESKTOP_WINDOW__?: typeof state }).__PW_DESKTOP_WINDOW__ = state
     const browserState = {
       available: true,
@@ -98,16 +103,20 @@ async function installDesktopBridge(page: Page, platform: DesktopPlatform, withB
       value: {
         isDesktop: true,
         platform: desktopPlatform,
+        windowKind: desktopWindowKind,
         getWindowState: async () => ({ isMaximized: state.isMaximized }),
         windowControl: async (action: string) => {
           state.actions.push(action)
           if (action === 'toggle-maximize') state.isMaximized = !state.isMaximized
           return { isMaximized: state.isMaximized }
         },
+        openChatWindow: async (sessionId: string, profile?: string) => {
+          state.chatWindows.push({ sessionId, profile })
+        },
         ...(browser ? { browser } : {}),
       },
     })
-  }, { desktopPlatform: platform, includeBrowser: withBrowser })
+  }, { desktopPlatform: platform, includeBrowser: withBrowser, desktopWindowKind: windowKind })
 }
 
 async function openDesktopJobs(page: Page, platform: DesktopPlatform) {
@@ -192,6 +201,87 @@ test('keeps chat gutters while placing New below macOS traffic lights', async ({
   await expect(newRoom).toBeVisible()
   expect((await groupSidebar.boundingBox())?.y).toBe(10)
   expect((await newRoom.boundingBox())?.y).toBeGreaterThanOrEqual(43)
+})
+
+test('renders a native-chrome desktop chat route with only messages and input', async ({ page }) => {
+  const session = {
+    id: 'desktop-chat-1',
+    title: 'Focused Desktop Chat',
+    source: 'cli',
+    model: 'test-model',
+    provider: 'test-provider',
+    profile: 'research',
+    started_at: 1_800_000_000,
+    ended_at: null,
+    last_active: 1_800_000_100,
+    message_count: 0,
+  }
+  await installDesktopBridge(page, 'darwin', false, 'chat')
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  await page.addInitScript(() => {
+    ;(window as typeof window & { __PW_CHAT_SOCKET_RESUMES__?: Record<string, unknown> }).__PW_CHAT_SOCKET_RESUMES__ = {
+      'desktop-chat-1': {
+        session_id: 'desktop-chat-1',
+        messages: [],
+        isWorking: false,
+        messageLoadedCount: 0,
+        messageTotal: 0,
+      },
+    }
+  })
+  await mockChatSocket(page)
+  await mockHermesApi(page, { sessions: [session] })
+  await page.goto('/#/desktop-chat/desktop-chat-1?profile=research')
+
+  await expect(page.locator('.desktop-titlebar')).toHaveCount(0)
+  await expect.poll(() => topGutterDragRegion(page)).toEqual({ appRegion: 'drag', height: '46px' })
+  await expect(page.locator('.message-list-shell')).toBeVisible()
+  await expect(page.locator('.chat-input-area')).toBeVisible()
+  await expect(page.locator('.session-list')).toHaveCount(0)
+  await expect(page.locator('.chat-header')).toHaveCount(0)
+  await expect(page.locator('aside.sidebar')).toHaveCount(0)
+})
+
+test('routes the desktop session popup action to the native chat window bridge', async ({ page }) => {
+  const session = {
+    id: 'desktop-popup-1',
+    title: 'Popup Session',
+    source: 'cli',
+    model: 'test-model',
+    provider: 'test-provider',
+    profile: 'research',
+    started_at: 1_800_000_000,
+    ended_at: null,
+    last_active: 1_800_000_100,
+    message_count: 0,
+  }
+  await installDesktopBridge(page, 'darwin')
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  await page.addInitScript(() => {
+    ;(window as typeof window & { __PW_CHAT_SOCKET_RESUMES__?: Record<string, unknown> }).__PW_CHAT_SOCKET_RESUMES__ = {
+      'desktop-popup-1': {
+        session_id: 'desktop-popup-1',
+        messages: [],
+        isWorking: false,
+        messageLoadedCount: 0,
+        messageTotal: 0,
+      },
+    }
+  })
+  await mockChatSocket(page)
+  await mockHermesApi(page, { sessions: [session] })
+  await page.goto('/#/hermes/chat')
+
+  await page.locator('.session-item').first().click({ button: 'right' })
+  await page.getByText('Open in new window', { exact: true }).click()
+
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & {
+      __PW_DESKTOP_WINDOW__?: { chatWindows: Array<{ sessionId: string; profile?: string }> }
+    }
+  ).__PW_DESKTOP_WINDOW__?.chatWindows)).toEqual([
+    { sessionId: 'desktop-popup-1', profile: 'research' },
+  ])
 })
 
 test('keeps the larger top gutter on macOS workflow pages', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add an Electron-only standalone chat window for individual sessions
- reuse the existing chat view in a sidebar-free and header-free route while keeping Web new-tab behavior unchanged
- use native macOS traffic lights, Windows Window Controls Overlay, and the native Linux title bar
- default the standalone window to 620 × 760 and focus the existing window when the same profile/session is opened again
- add focused client, desktop, i18n, and Playwright coverage

## Why
Desktop users need a compact focused chat window without duplicating or forking the existing chat runtime. Reusing the current chat view keeps session loading, streaming, approvals, attachments, and persistence on the same code path.

## User impact
On Desktop, “Open in new window” and modified session clicks open a dedicated native-chrome chat window containing only the message list and input. Browser users continue to open the existing full chat route in a new tab.

## Validation
- `npm run harness:check`
- `npm run test -- tests/client/chat-view-tab-title.test.ts tests/client/chat-panel-session-click.test.ts tests/client/session-list-item.test.ts tests/client/app-web-pet.test.ts tests/client/desktop-titlebar.test.ts tests/client/i18n-coverage.test.ts tests/desktop/chat-window.test.ts`
- `npm --prefix packages/desktop run build:main`
- `npx playwright test tests/e2e/desktop-window-chrome.spec.ts --grep "native-chrome desktop chat route|native chat window bridge"`
- `npm run build`
