### PR TITLE
Remove sensitive browser input restrictions

### DIFF
--- a/packages/desktop/src/main/browser/browser-automation.ts
+++ b/packages/desktop/src/main/browser/browser-automation.ts
@@ -112,7 +112,6 @@ export class BrowserAutomation {
       if (typeof action.snapshot_id !== 'string' || typeof action.ref !== 'string') throw new Error('snapshot_id and ref are required')
       if (action.action === 'type' && typeof action.text !== 'string') throw new Error('text is required for browser typing')
       const backendNodeId = this.resolveRef(tabId, action.snapshot_id, action.ref).backendDOMNodeId
-      await this.assertSafeElement(contents, backendNodeId, action.action)
       const objectId = await this.resolveObject(contents, backendNodeId)
       try {
         if (action.action === 'click') {
@@ -248,24 +247,4 @@ export class BrowserAutomation {
     return response.object.objectId
   }
 
-  private async assertSafeElement(contents: WebContents, backendNodeId: number, action: 'click' | 'type'): Promise<void> {
-    const response = await contents.debugger.sendCommand('DOM.describeNode', { backendNodeId, depth: 0 }) as {
-      node?: { nodeName?: string; attributes?: string[] }
-    }
-    const attributes = response.node?.attributes || []
-    const values = new Map<string, string>()
-    for (let index = 0; index < attributes.length; index += 2) values.set(String(attributes[index]).toLowerCase(), String(attributes[index + 1] || ''))
-    const inputType = values.get('type')?.toLowerCase()
-    const autocomplete = values.get('autocomplete')?.toLowerCase() || ''
-    if (inputType === 'file') throw new Error('Agent file uploads are blocked; use the page manually to choose a file')
-    const fieldIdentity = [values.get('name'), values.get('id'), values.get('aria-label'), autocomplete]
-      .filter(Boolean)
-      .join(' ')
-      .toLowerCase()
-    const sensitiveAutocomplete = autocomplete.startsWith('cc-') || autocomplete === 'current-password' || autocomplete === 'new-password'
-    const paymentField = /(?:card.?number|credit.?card|payment|\bcvv\b|\bcvc\b|security.?code)/i.test(fieldIdentity)
-    if (action === 'type' && (inputType === 'password' || sensitiveAutocomplete || paymentField)) {
-      throw new Error('Agent entry into password and payment fields is blocked; take over the tab to enter sensitive data')
-    }
-  }
 }

--- a/tests/desktop/browser-automation.test.ts
+++ b/tests/desktop/browser-automation.test.ts
@@ -48,20 +48,18 @@ describe('desktop browser automation safety', () => {
     })).rejects.toThrow(/stale/)
   })
 
-  it('blocks Agent typing into password and payment fields', async () => {
-    const passwordAutomation = new BrowserAutomation()
-    const passwordContents = fakeContents({ attributes: ['type', 'password'] })
-    const passwordSnapshot = await passwordAutomation.snapshot('password-tab', passwordContents)
-    await expect(passwordAutomation.interact('password-tab', passwordContents, {
-      action: 'type', snapshot_id: passwordSnapshot.snapshotId, ref: '@e1', text: 'secret',
-    })).rejects.toThrow(/password and payment/)
+  it.each([
+    ['password', ['type', 'password']],
+    ['payment', ['type', 'text', 'name', 'card_number']],
+    ['file', ['type', 'file']],
+  ])('does not block Agent typing into %s fields', async (_field, attributes) => {
+    const automation = new BrowserAutomation()
+    const contents = fakeContents({ attributes })
+    const snapshot = await automation.snapshot('tab-1', contents)
 
-    const paymentAutomation = new BrowserAutomation()
-    const paymentContents = fakeContents({ attributes: ['type', 'text', 'name', 'card_number'] })
-    const paymentSnapshot = await paymentAutomation.snapshot('payment-tab', paymentContents)
-    await expect(paymentAutomation.interact('payment-tab', paymentContents, {
-      action: 'type', snapshot_id: paymentSnapshot.snapshotId, ref: '@e1', text: '4111111111111111',
-    })).rejects.toThrow(/password and payment/)
+    await expect(automation.interact('tab-1', contents, {
+      action: 'type', snapshot_id: snapshot.snapshotId, ref: '@e1', text: 'test value',
+    })).resolves.toBeUndefined()
   })
 
   it('clicks a current safe element through its resolved DOM object', async () => {


### PR DESCRIPTION
## What changed

- Remove the desktop browser automation guard that rejected typing into password and payment fields.
- Remove the related file-input rejection from the same element guard.
- Update browser automation tests to verify these field types are no longer blocked.

## Why

The MCP browser should allow automation clients to enter values into these fields instead of requiring manual tab takeover. The previous behavior came from a local `assertSafeElement` check in the Electron browser automation layer.

## Impact

MCP browser `type` actions now follow the normal interaction path for password, payment, and file inputs. Existing URL restrictions, protected accessibility-value redaction, user takeover handling, and high-risk click confirmation remain unchanged.

## Validation

- `npx vitest run tests/desktop/browser-*.test.ts tests/server/hermes-studio-browser-mcp.test.ts` (21 tests passed)
- `npm run build`
- `npm run harness:check`
- `git diff --check`
