### PR TITLE
fix(group-chat): preserve per-room human member profiles

### DIFF
--- a/docs/chat-chain-changes/2026-07-25-group-chat-room-member-names.md
+++ b/docs/chat-chain-changes/2026-07-25-group-chat-room-member-names.md
@@ -1,0 +1,15 @@
+---
+date: 2026-07-25
+pr: 2212
+feature: Per-room human member profiles
+impact: Human display names and descriptions remain room-specific across reconnects, browser ports, and room switches.
+---
+
+Room creation now persists the creator's form-entered member profile before
+the realtime join. Later joins treat the room member row as authoritative,
+using the authenticated user ID to recover the same identity when a browser
+client ID changes.
+
+An explicit member-profile socket action lets a user repair or rename only
+their current room profile. Ordinary joins no longer double as an implicit
+rename operation, and agent identities remain unchanged.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4605,6 +4605,12 @@
                   "inviteCode": {
                     "type": "string"
                   },
+                  "memberDescription": {
+                    "type": "string"
+                  },
+                  "memberName": {
+                    "type": "string"
+                  },
                   "name": {
                     "type": "string"
                   },

--- a/packages/client/src/api/hermes/group-chat.ts
+++ b/packages/client/src/api/hermes/group-chat.ts
@@ -179,6 +179,8 @@ export function disconnectGroupChat(): void {
 export async function createRoom(data: {
     name: string
     inviteCode: string
+    memberName?: string
+    memberDescription?: string
     agents?: { profile: string; name?: string; description?: string; invited?: boolean }[]
     compression?: { triggerTokens?: number; maxHistoryTokens?: number; tailMessageCount?: number }
     workspace?: string

--- a/packages/client/src/components/hermes/group-chat/CreateRoomForm.vue
+++ b/packages/client/src/components/hermes/group-chat/CreateRoomForm.vue
@@ -57,6 +57,7 @@ function focusRoomInput() {
             <NInput
                 v-model:value="userName"
                 :placeholder="t('groupChat.yourNamePlaceholder')"
+                :maxlength="120"
                 @keyup.enter="focusRoomInput"
             />
         </div>
@@ -66,6 +67,7 @@ function focusRoomInput() {
                 v-model:value="description"
                 type="textarea"
                 :rows="2"
+                :maxlength="2000"
                 :placeholder="t('groupChat.yourDescriptionPlaceholder')"
             />
         </div>

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -45,6 +45,10 @@ const showCreateModal = ref(false)
 const showCloneModal = ref(false)
 const showAddAgentModal = ref(false)
 const showCompressionModal = ref(false)
+const showUserProfileModal = ref(false)
+const userProfileName = ref('')
+const userProfileDescription = ref('')
+const isSavingUserProfile = ref(false)
 const compressionConfig = ref({ triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10 })
 const isCompressing = ref(false)
 const inviteCodeDraft = ref('')
@@ -341,7 +345,14 @@ function extractApiErrorMessage(err: any): string {
 async function handleCreateRoom(name: string, inviteCode: string, userName: string, description: string, compression: { triggerTokens: number; maxHistoryTokens: number; tailMessageCount: number }, workspace: string) {
     try {
         store.setUserInfo(userName, description)
-        const res = await store.createNewRoom(name, inviteCode, undefined, compression, workspace)
+        const res = await store.createNewRoom(
+            name,
+            inviteCode,
+            undefined,
+            compression,
+            workspace,
+            { name: userName, description },
+        )
         showCreateModal.value = false
         const failureMessage = formatAgentFailures(res.agentResults)
         if (failureMessage) message.warning(failureMessage)
@@ -580,6 +591,28 @@ async function handleClearWorkspace() {
     await handleSaveWorkspace()
 }
 
+function handleOpenUserProfile() {
+    const member = store.members.find(item => item.userId === store.userId)
+    userProfileName.value = member?.name || store.userName || ''
+    userProfileDescription.value = member?.description || ''
+    showUserProfileModal.value = true
+}
+
+async function handleSaveUserProfile() {
+    const name = userProfileName.value.trim()
+    if (!name || isSavingUserProfile.value) return
+    isSavingUserProfile.value = true
+    try {
+        await store.updateCurrentMemberProfile(name, userProfileDescription.value)
+        showUserProfileModal.value = false
+        message.success(t('common.saved'))
+    } catch {
+        message.error(t('common.saveFailed'))
+    } finally {
+        isSavingUserProfile.value = false
+    }
+}
+
 function handleOpenRoomSettings() {
     if (!currentRoomCanManage.value) return
     const room = store.rooms.find(r => r.id === store.currentRoomId)
@@ -814,6 +847,12 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                             <ProfileAvatar class="agent-avatar" :name="store.userName || store.userId" :avatar="userMemberAvatar" :size="24" />
                         </span>
                     </div>
+                    <button v-if="hasRoom" class="icon-btn" :title="t('groupChat.yourName')" @click="handleOpenUserProfile">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M12 20h9" />
+                            <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L8 18l-4 1 1-4Z" />
+                        </svg>
+                    </button>
                     <button v-if="currentRoomCanManage" class="icon-btn" :title="t('groupChat.addAgent')" @click="handleAddAgent">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                     </button>
@@ -1100,6 +1139,45 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                         <NButton @click="showWorkspaceModal = false">{{ t('common.cancel') }}</NButton>
                         <NButton @click="handleClearWorkspace">{{ t('workflow.workspace.clear') }}</NButton>
                         <NButton type="primary" @click="handleSaveWorkspace">{{ t('common.save') }}</NButton>
+                    </NSpace>
+                </template>
+            </NModal>
+            <NModal
+                v-model:show="showUserProfileModal"
+                preset="dialog"
+                :title="t('groupChat.yourName')"
+                style="width: 460px; max-width: 92vw"
+            >
+                <div class="form-group">
+                    <label class="form-label">{{ t('groupChat.yourName') }}</label>
+                    <NInput
+                        v-model:value="userProfileName"
+                        :placeholder="t('groupChat.yourNamePlaceholder')"
+                        :maxlength="120"
+                        @keyup.enter="handleSaveUserProfile"
+                    />
+                </div>
+                <div class="form-group">
+                    <label class="form-label">{{ t('groupChat.yourDescription') }}</label>
+                    <NInput
+                        v-model:value="userProfileDescription"
+                        type="textarea"
+                        :rows="3"
+                        :maxlength="2000"
+                        :placeholder="t('groupChat.yourDescriptionPlaceholder')"
+                    />
+                </div>
+                <template #action>
+                    <NSpace justify="end">
+                        <NButton @click="showUserProfileModal = false">{{ t('common.cancel') }}</NButton>
+                        <NButton
+                            type="primary"
+                            :disabled="!userProfileName.trim()"
+                            :loading="isSavingUserProfile"
+                            @click="handleSaveUserProfile"
+                        >
+                            {{ t('common.save') }}
+                        </NButton>
                     </NSpace>
                 </template>
             </NModal>

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -326,14 +326,12 @@ const currentUserAvatar = ref('')
         return connectedSocket
     }
 
-    async function joinRealtimeRoom(roomId: string, options: { syncMessages?: boolean; inviteCode?: string; profileName?: string; profileDescription?: string } = {}) {
+    async function joinRealtimeRoom(roomId: string, options: { syncMessages?: boolean; inviteCode?: string } = {}) {
         const socket = await ensureRealtimeSocket()
-        // Use explicitly passed profile name (from create-room form) first;
-        // fall back to localStorage so first-time joins still pick up the
-        // last-entered name. On rejoin the server prefers the per-room DB
-        // record, so a stale stored name is harmless.
-        const storedName = options.profileName || getStoredGroupUserName()
-        const storedDescription = options.profileDescription || localStorage.getItem('gc_user_description')
+        // Browser storage is only a first-join default. Once the member row
+        // exists, the server keeps the room-specific profile authoritative.
+        const storedName = getStoredGroupUserName()
+        const storedDescription = localStorage.getItem('gc_user_description')
 
         await new Promise<void>((resolve) => {
             socket.emit('join', {
@@ -526,6 +524,14 @@ const currentUserAvatar = ref('')
             }
         })
 
+        socket.on('member_updated', (data: { roomId: string; members: MemberInfo[] }) => {
+            if (data.roomId === currentRoomId.value) {
+                members.value = data.members
+                const currentMember = members.value.find(member => member.userId === userId.value)
+                if (currentMember?.name) userName.value = currentMember.name
+            }
+        })
+
         socket.on('typing', (data: { roomId: string; userId: string; userName: string }) => {
             if (data.roomId === currentRoomId.value && !typingUsers.value.has(data.userId)) {
                 const timer = setTimeout(() => typingUsers.value.delete(data.userId), 5000)
@@ -635,6 +641,32 @@ const currentUserAvatar = ref('')
         localStorage.setItem('gc_user_description', description)
     }
 
+    async function updateCurrentMemberProfile(name: string, description = '') {
+        const roomId = currentRoomId.value
+        const socket = getSocket()
+        const normalizedName = name.trim()
+        const normalizedDescription = description.trim()
+        if (!roomId || !socket) throw new Error('Join a room before updating your profile')
+        if (!normalizedName) throw new Error('Name is required')
+
+        await new Promise<void>((resolve, reject) => {
+            socket.emit('update_member_profile', {
+                roomId,
+                name: normalizedName,
+                description: normalizedDescription,
+            }, (res: { error?: string; members?: MemberInfo[] }) => {
+                if (res?.error) {
+                    reject(new Error(res.error))
+                    return
+                }
+                if (res?.members) members.value = res.members
+                userName.value = normalizedName
+                setUserInfo(normalizedName, normalizedDescription)
+                resolve()
+            })
+        })
+    }
+
     // ─── Room Actions ──────────────────────────────────────
     async function joinRoom(roomId: string) {
         isJoining.value = true
@@ -738,11 +770,20 @@ const currentUserAvatar = ref('')
         }
     }
 
-    async function createNewRoom(name: string, inviteCode: string, agentList?: { profile: string; name?: string; description?: string; invited?: boolean }[], compression?: { triggerTokens: number; maxHistoryTokens: number; tailMessageCount: number }, workspace?: string) {
+    async function createNewRoom(
+        name: string,
+        inviteCode: string,
+        agentList?: { profile: string; name?: string; description?: string; invited?: boolean }[],
+        compression?: { triggerTokens: number; maxHistoryTokens: number; tailMessageCount: number },
+        workspace?: string,
+        memberProfile?: { name: string; description?: string },
+    ) {
         try {
             const res = await createRoom({
                 name,
                 inviteCode,
+                memberName: memberProfile?.name,
+                memberDescription: memberProfile?.description,
                 agents: agentList,
                 compression: compression || { triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10 },
                 workspace: workspace || undefined,
@@ -962,6 +1003,7 @@ const currentUserAvatar = ref('')
         connect,
         disconnect,
         setUserInfo,
+        updateCurrentMemberProfile,
         setAutoPlaySpeech,
         setMessageReference,
         clearMessageReference,

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -326,16 +326,21 @@ const currentUserAvatar = ref('')
         return connectedSocket
     }
 
-    async function joinRealtimeRoom(roomId: string, options: { syncMessages?: boolean; inviteCode?: string } = {}) {
+    async function joinRealtimeRoom(roomId: string, options: { syncMessages?: boolean; inviteCode?: string; profileName?: string; profileDescription?: string } = {}) {
         const socket = await ensureRealtimeSocket()
-        const storedName = getStoredGroupUserName()
+        // Use explicitly passed profile name (from create-room form) first;
+        // fall back to localStorage so first-time joins still pick up the
+        // last-entered name. On rejoin the server prefers the per-room DB
+        // record, so a stale stored name is harmless.
+        const storedName = options.profileName || getStoredGroupUserName()
+        const storedDescription = options.profileDescription || localStorage.getItem('gc_user_description')
 
         await new Promise<void>((resolve) => {
             socket.emit('join', {
                 roomId,
                 inviteCode: options.inviteCode,
                 name: storedName || undefined,
-                description: localStorage.getItem('gc_user_description') || undefined,
+                description: storedDescription || undefined,
             }, (res: any) => {
                 if (currentRoomId.value !== roomId) {
                     resolve()

--- a/packages/server/src/routes/hermes/group-chat.ts
+++ b/packages/server/src/routes/hermes/group-chat.ts
@@ -68,11 +68,17 @@ function serializeRoom(room: any, includeManageFields: boolean) {
     return serialized
 }
 
-function persistRoomCreator(storage: ReturnType<GroupChatServer['getStorage']>, roomId: string, user: any): void {
+function persistRoomCreator(
+    storage: ReturnType<GroupChatServer['getStorage']>,
+    roomId: string,
+    user: any,
+    memberName?: string,
+    memberDescription?: string,
+): void {
     if (typeof user?.id !== 'number' || user.id <= 0) return
     storage.setRoomOwnerAuthUserId?.(roomId, user.id)
-    const username = String(user.username || `User-${user.id}`)
-    storage.addRoomMember(roomId, `auth:${user.id}`, username, '', '', user.id)
+    const username = memberName?.trim() || String(user.username || `User-${user.id}`)
+    storage.addRoomMember(roomId, `auth:${user.id}`, username, memberDescription?.trim() || '', '', user.id)
 }
 
 function visibleRoomsForUser(storage: ReturnType<GroupChatServer['getStorage']>, user: any) {
@@ -131,16 +137,31 @@ groupChatRoutes.post('/api/hermes/group-chat/rooms', async (ctx) => {
         return
     }
 
-    const { name, inviteCode, agents, compression, workspace } = ctx.request.body as {
+    const { name, inviteCode, agents, compression, workspace, memberName, memberDescription } = ctx.request.body as {
         name?: string
         inviteCode?: string
         agents?: { profile: string; name?: string; description?: string; invited?: boolean }[]
         compression?: { triggerTokens?: number; maxHistoryTokens?: number; tailMessageCount?: number }
         workspace?: string
+        memberName?: string
+        memberDescription?: string
     }
     if (!name || !inviteCode) {
         ctx.status = 400
         ctx.body = { error: 'name and inviteCode are required' }
+        return
+    }
+    if (
+        (memberName !== undefined && typeof memberName !== 'string') ||
+        (memberDescription !== undefined && typeof memberDescription !== 'string')
+    ) {
+        ctx.status = 400
+        ctx.body = { error: 'memberName and memberDescription must be strings' }
+        return
+    }
+    if ((memberName?.trim().length || 0) > 120 || (memberDescription?.trim().length || 0) > 2000) {
+        ctx.status = 400
+        ctx.body = { error: 'Member profile is too long' }
         return
     }
     const reservedAgent = (agents || []).find(a => isReservedMentionName(a.name || a.profile))
@@ -177,7 +198,7 @@ groupChatRoutes.post('/api/hermes/group-chat/rooms', async (ctx) => {
         workspace: normalizedWorkspace,
     } : { workspace: normalizedWorkspace }
     storage.saveRoom(roomId, name, inviteCode, compressionConfig)
-    persistRoomCreator(storage, roomId, ctx.state?.user)
+    persistRoomCreator(storage, roomId, ctx.state?.user, memberName, memberDescription)
 
     const addedAgents = []
     const agentResults = []

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -1275,13 +1275,17 @@ export class GroupChatServer {
             return
         }
         const userInfo = this.userInfoMap.get(userId) || {
-            name: existingMember?.name || `User-${userId.slice(0, 6)}`,
-            description: existingMember?.description || '',
+            name: `User-${userId.slice(0, 6)}`,
+            description: '',
         }
         const requestedName = typeof data.name === 'string' ? data.name.trim() : ''
         const requestedDescription = typeof data.description === 'string' ? data.description.trim() : ''
-        const userName = requestedName || existingMember?.name || userInfo.name
-        const description = requestedDescription || existingMember?.description || userInfo.description
+        // On rejoin, prefer the per-room DB record over the join-request name
+        // so switching rooms doesn't overwrite a member's per-room identity.
+        // The DB is authoritative for existing members; requestedName only
+        // applies on first join (when there's no DB record yet).
+        const userName = existingMember?.name || requestedName || userInfo.name
+        const description = existingMember?.description || requestedDescription || userInfo.description
 
         // Update stored user info
         this.userInfoMap.set(userId, { name: userName, description })

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -1155,6 +1155,7 @@ export class GroupChatServer {
         logger.debug(`[GroupChat] Connected: ${userName} (socket=${socket.id}, user=${userId})`)
 
         socket.on('join', (data: { roomId?: string; name?: string }, ack?: (response?: unknown) => void) => this.handleJoin(socket, data, ack))
+        socket.on('update_member_profile', (data: { roomId?: string; name?: string; description?: string } | undefined, ack?: (response?: unknown) => void) => this.handleUpdateMemberProfile(socket, data, ack))
         socket.on('message', (data: Partial<ChatMessage> & { roomId?: string; content: string | Array<Record<string, unknown>>; id?: string; mentionDepth?: number }, ack?: (response?: unknown) => void) => this.handleMessage(socket, data, ack))
         socket.on('message_stream_start', (data: { roomId?: string; id?: string; senderId?: string; senderName?: string; timestamp?: number }) => this.handleMessageStreamStart(socket, data))
         socket.on('message_stream_delta', (data: { roomId?: string; id?: string; delta?: string }) => this.handleMessageStreamDelta(socket, data))
@@ -1359,6 +1360,51 @@ export class GroupChatServer {
         })
 
         logger.debug(`[GroupChat] ${userName} (user=${userId}) joined room: ${roomId}`)
+    }
+
+    private handleUpdateMemberProfile(
+        socket: Socket,
+        data: { roomId?: string; name?: string; description?: string } | undefined,
+        ack?: (res: any) => void,
+    ): void {
+        const roomId = typeof data?.roomId === 'string' ? data.roomId.trim() : ''
+        const name = typeof data?.name === 'string' ? data.name.trim() : ''
+        const description = typeof data?.description === 'string' ? data.description.trim() : ''
+        if (!roomId || !name) {
+            ack?.({ error: 'roomId and name are required' })
+            return
+        }
+        if (name.length > 120 || description.length > 2000) {
+            ack?.({ error: 'Member profile is too long' })
+            return
+        }
+
+        const joined = this.getOnlineRoomMember(socket, roomId)
+        if (!joined || joined.member.source !== 'human') {
+            ack?.({ error: 'Access denied' })
+            return
+        }
+
+        try {
+            const userId = joined.member.userId
+            const authUserId = this.socketAuthUserIdMap.get(socket.id)
+            const avatar = joined.member.avatar || ''
+            this.storage.addRoomMember(roomId, userId, name, description, avatar, authUserId)
+            joined.room.addOrUpdateMember(socket.id, userId, name, description, 'human', avatar)
+            this.userInfoMap.set(userId, { name, description })
+
+            const members = joined.room.getMembersList()
+            this.nsp.to(roomId).emit('member_updated', {
+                roomId,
+                memberId: userId,
+                memberName: name,
+                members,
+            })
+            ack?.({ member: joined.room.getOnlineMemberBySocketId(socket.id), members })
+        } catch (err) {
+            logger.error(`[GroupChat] Failed to update member profile: ${(err as Error).message}`)
+            ack?.({ error: 'Failed to update member profile' })
+        }
     }
 
     private handleMessage(socket: Socket, data: Partial<ChatMessage> & { roomId?: string; content: string | Array<Record<string, unknown>>; id?: string; mentionDepth?: number }, ack?: (res: any) => void): void {

--- a/tests/client/group-chat-store-baseline.test.ts
+++ b/tests/client/group-chat-store-baseline.test.ts
@@ -212,6 +212,71 @@ describe('group chat store baseline lifecycle', () => {
     expect(store.contextStatuses.get('Agent')).toEqual({ agentName: 'Agent', status: 'replying' })
   })
 
+  it('persists the create-form member profile with a new room', async () => {
+    const store = await loadStore()
+    groupChatApiMock.createRoom.mockResolvedValue({
+      room,
+      agents: [],
+    })
+
+    await store.createNewRoom(
+      'Family Room',
+      'ROOM1',
+      undefined,
+      undefined,
+      undefined,
+      { name: '妈妈', description: 'family profile' },
+    )
+
+    expect(groupChatApiMock.createRoom).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Family Room',
+      inviteCode: 'ROOM1',
+      memberName: '妈妈',
+      memberDescription: 'family profile',
+    }))
+  })
+
+  it('updates only the current room member profile through the joined socket', async () => {
+    const store = await loadStore()
+    groupChatApiMock.socket.emit.mockImplementation((event: string, data?: any, ack?: Function) => {
+      if (event === 'join' && ack) {
+        ack({
+          roomName: 'Family Room',
+          members: [{ ...member, name: 'alice-login', description: '' }],
+          agents: [],
+          typingUsers: [],
+          contextStatuses: [],
+        })
+      }
+      if (event === 'update_member_profile' && ack) {
+        ack({
+          members: [{ ...member, name: data.name, description: data.description }],
+        })
+      }
+      return groupChatApiMock.socket
+    })
+
+    await store.connect()
+    await store.joinRoom('room-1')
+    await store.updateCurrentMemberProfile(' 妈妈 ', ' family profile ')
+
+    expect(groupChatApiMock.socket.emit).toHaveBeenCalledWith(
+      'update_member_profile',
+      {
+        roomId: 'room-1',
+        name: '妈妈',
+        description: 'family profile',
+      },
+      expect.any(Function),
+    )
+    expect(store.userName).toBe('妈妈')
+    expect(store.members[0]).toEqual(expect.objectContaining({
+      name: '妈妈',
+      description: 'family profile',
+    }))
+    expect(localStorage.getItem('gc_user_name')).toBe('妈妈')
+  })
+
   it('joins invite rooms over realtime before fetching protected detail when the socket starts disconnected', async () => {
     const store = await loadStore()
     const order: string[] = []

--- a/tests/server/group-chat-member-sync.test.ts
+++ b/tests/server/group-chat-member-sync.test.ts
@@ -731,6 +731,113 @@ describe('Group Chat member/agent identity sync', () => {
     ])
   })
 
+  it('persists the room creator profile from the create form before realtime join', async () => {
+    const addRoomMember = vi.fn()
+    const storage = {
+      setRoomOwnerAuthUserId: vi.fn(),
+      addRoomMember,
+      saveRoom: vi.fn(),
+      getRoom: vi.fn((roomId: string) => ({
+        id: roomId,
+        name: 'Family Room',
+        inviteCode: 'secret',
+        ownerAuthUserId: 42,
+      })),
+    }
+    setGroupChatServer({
+      getStorage: () => storage,
+      agentClients: {},
+    } as any)
+
+    const handler = routeHandler('/api/hermes/group-chat/rooms', 'POST')
+    const ctx: any = {
+      state: { user: { id: 42, username: 'alice-login', role: 'admin' } },
+      request: {
+        body: {
+          name: 'Family Room',
+          inviteCode: 'secret',
+          memberName: '妈妈',
+          memberDescription: 'family profile',
+        },
+      },
+      status: 200,
+      body: undefined,
+    }
+    await handler(ctx, async () => {})
+
+    expect(addRoomMember).toHaveBeenCalledWith(
+      expect.any(String),
+      'auth:42',
+      '妈妈',
+      'family profile',
+      '',
+      42,
+    )
+    expect(ctx.body.room).toEqual(expect.objectContaining({ name: 'Family Room' }))
+  })
+
+  it('updates an explicitly requested human profile only in the joined room', () => {
+    const emit = vi.fn()
+    const liveMember: any = {
+      id: 'socket-1',
+      userId: 'auth:42',
+      name: 'alice-login',
+      description: '',
+      source: 'human',
+      avatar: 'avatar-data',
+      online: true,
+      socketId: 'socket-1',
+    }
+    const room = {
+      getOnlineMemberBySocketId: vi.fn(() => liveMember),
+      addOrUpdateMember: vi.fn((
+        _socketId: string,
+        _userId: string,
+        name: string,
+        description: string,
+      ) => {
+        liveMember.name = name
+        liveMember.description = description
+        return liveMember
+      }),
+      getMembersList: vi.fn(() => [liveMember]),
+    }
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map([['room-family', room]])
+    server.socketAuthUserIdMap = new Map([['socket-1', 42]])
+    server.userInfoMap = new Map([['auth:42', { name: 'alice-login', description: '' }]])
+    server.storage = { addRoomMember: vi.fn() }
+    server.nsp = { to: vi.fn(() => ({ emit })) }
+    const socket = { id: 'socket-1' }
+    const ack = vi.fn()
+
+    server.handleUpdateMemberProfile(socket, {
+      roomId: 'room-family',
+      name: '妈妈',
+      description: 'family profile',
+    }, ack)
+
+    expect(server.storage.addRoomMember).toHaveBeenCalledWith(
+      'room-family',
+      'auth:42',
+      '妈妈',
+      'family profile',
+      'avatar-data',
+      42,
+    )
+    expect(server.userInfoMap.get('auth:42')).toEqual({
+      name: '妈妈',
+      description: 'family profile',
+    })
+    expect(emit).toHaveBeenCalledWith('member_updated', expect.objectContaining({
+      roomId: 'room-family',
+      memberName: '妈妈',
+    }))
+    expect(ack).toHaveBeenCalledWith(expect.objectContaining({
+      member: expect.objectContaining({ name: '妈妈' }),
+    }))
+  })
+
   it('filters room list to rooms containing one of the regular admin profiles', async () => {
     const allRooms = [
       { id: 'room-default', name: 'Default', inviteCode: null },

--- a/tests/server/group-chat-member-sync.test.ts
+++ b/tests/server/group-chat-member-sync.test.ts
@@ -830,4 +830,159 @@ describe('Group Chat member/agent identity sync', () => {
     server.handleMessage({ id: 'agent-socket' }, { roomId: 'room-1', content: '@all too deep', role: 'assistant', mentionDepth: 4, agentSessionId }, vi.fn())
     expect(server.agentClients.processMentions).not.toHaveBeenCalled()
   })
+
+  it('preserves per-room member name on rejoin when global userInfoMap has a different name', () => {
+    // Reproduces hermes-agent #54774 / hermes-studio per-room member name bug:
+    // switching rooms should not overwrite a member's per-room display name.
+    const emit = vi.fn()
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map()
+    server.socketUserMap = new Map([['socket-1', 'auth:42']])
+    server.socketRequestedSourceMap = new Map([['socket-1', 'human']])
+    server.socketAuthUserIdMap = new Map([['socket-1', 42]])
+    // User joined room B last, so global userInfoMap has "郑工" (work name).
+    // But room A's DB record has "爸爸" (family name).
+    server.userInfoMap = new Map([['auth:42', { name: '郑工', description: '' }]])
+    server.typingState = new Map()
+    server.contextStatusState = new Map()
+    server.storage = {
+      getRoom: vi.fn(() => ({ id: 'room-1', name: 'Family Room', inviteCode: 'secret' })),
+      getRoomAgentByAgentId: vi.fn(() => null),
+      // Room A's existing DB record has "爸爸" (per-room name)
+      getMemberByUserId: vi.fn(() => ({
+        id: 'member-1',
+        userId: 'auth:42',
+        name: '爸爸',
+        description: 'family persona',
+        joinedAt: 1000,
+        avatar: '',
+        authUserId: 42,
+      })),
+      getMemberByAuthUserId: vi.fn(() => null),
+      getRoomsForProfiles: vi.fn(() => []),
+      saveRoom: vi.fn(),
+      addRoomMember: vi.fn(),
+      getRecentMessagesForUI: vi.fn(() => []),
+      getRoomAgents: vi.fn(() => []),
+    }
+    const socket = {
+      id: 'socket-1',
+      join: vi.fn(),
+      to: vi.fn(() => ({ emit })),
+    }
+    const ack = vi.fn()
+
+    server.handleJoin(socket, { roomId: 'room-1' }, ack)
+
+    // Per-room DB name ("爸爸") must be preserved, NOT overwritten by
+    // the global userInfoMap entry ("郑工").
+    expect(server.storage.addRoomMember).toHaveBeenCalledWith(
+      'room-1',
+      'auth:42',
+      '爸爸',
+      'family persona',
+      expect.any(String),
+      42,
+    )
+  })
+
+  it('uses requestedName on first join when no existing member record exists', () => {
+    const emit = vi.fn()
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map()
+    server.socketUserMap = new Map([['socket-1', 'auth:42']])
+    server.socketRequestedSourceMap = new Map([['socket-1', 'human']])
+    server.socketAuthUserIdMap = new Map([['socket-1', 42]])
+    server.userInfoMap = new Map([['auth:42', { name: 'default-name', description: '' }]])
+    server.typingState = new Map()
+    server.contextStatusState = new Map()
+    server.storage = {
+      getRoom: vi.fn(() => ({ id: 'room-2', name: 'Work Room', inviteCode: 'work123' })),
+      getRoomAgentByAgentId: vi.fn(() => null),
+      getMemberByUserId: vi.fn(() => null), // no existing member → first join
+      getMemberByAuthUserId: vi.fn(() => null),
+      getRoomsForProfiles: vi.fn(() => []),
+      saveRoom: vi.fn(),
+      addRoomMember: vi.fn(),
+      getRecentMessagesForUI: vi.fn(() => []),
+      getRoomAgents: vi.fn(() => []),
+    }
+    const socket = {
+      id: 'socket-1',
+      join: vi.fn(),
+      to: vi.fn(() => ({ emit })),
+    }
+    const ack = vi.fn()
+
+    // Client passes name from the create-room form, plus invite code to pass
+    // canSocketJoinRoom gate.
+    server.handleJoin(socket, {
+      roomId: 'room-2',
+      inviteCode: 'work123',
+      name: '郑工',
+      description: 'work persona',
+    }, ack)
+
+    // On first join, requestedName is used
+    expect(server.storage.addRoomMember).toHaveBeenCalledWith(
+      'room-2',
+      'auth:42',
+      '郑工',
+      'work persona',
+      expect.any(String),
+      42,
+    )
+  })
+
+  it('preserves per-room member description on rejoin when global userInfoMap has stale description', () => {
+    const emit = vi.fn()
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map()
+    server.socketUserMap = new Map([['socket-1', 'auth:42']])
+    server.socketRequestedSourceMap = new Map([['socket-1', 'human']])
+    server.socketAuthUserIdMap = new Map([['socket-1', 42]])
+    server.userInfoMap = new Map([['auth:42', {
+      name: 'global-stale-name',
+      description: 'global-stale-desc',
+    }]])
+    server.typingState = new Map()
+    server.contextStatusState = new Map()
+    server.storage = {
+      getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room' })),
+      getRoomAgentByAgentId: vi.fn(() => null),
+      getMemberByUserId: vi.fn(() => ({
+        id: 'member-1',
+        userId: 'auth:42',
+        name: '爸爸',
+        description: 'per-room-family-desc',
+        joinedAt: 1000,
+        avatar: '',
+        authUserId: 42,
+      })),
+      getMemberByAuthUserId: vi.fn(() => null),
+      getRoomsForProfiles: vi.fn(() => []),
+      saveRoom: vi.fn(),
+      addRoomMember: vi.fn(),
+      getRecentMessagesForUI: vi.fn(() => []),
+      getRoomAgents: vi.fn(() => []),
+    }
+    const socket = {
+      id: 'socket-1',
+      join: vi.fn(),
+      to: vi.fn(() => ({ emit })),
+    }
+    const ack = vi.fn()
+
+    server.handleJoin(socket, { roomId: 'room-1' }, ack)
+
+    expect(server.storage.addRoomMember).toHaveBeenCalledWith(
+      'room-1',
+      'auth:42',
+      '爸爸',
+      'per-room-family-desc',
+      expect.any(String),
+      42,
+    )
+  })
+
 })


### PR DESCRIPTION
## Summary

Fixes human group-chat names and descriptions leaking between rooms. A room member profile is now persisted independently per room, recovered with the authenticated Web UI user ID when browser client/socket IDs change, and changed only through an explicit room-profile edit.

**Reported in:** [NousResearch/hermes-agent#54774](https://github.com/NousResearch/hermes-agent/issues/54774)

## Root cause

1. Realtime joins preferred the browser globally stored name over the existing `gc_room_members` row.
2. Room creation seeded the creator row from the account username before the create-form profile could be applied.
3. Once an incorrect name was persisted, there was no explicit way to repair only the current room profile.

## What this PR does

- Treats the existing per-room member row as authoritative on ordinary joins.
- Uses stable `authUserId` / `auth:<id>` identity for authenticated users, so changing ports or reconnecting does not depend on an ephemeral client/socket ID.
- Persists the creator form-entered name and description during room creation.
- Adds an explicit current-room human profile update flow and broadcasts the updated member list.
- Leaves agent identities and agent persistence behavior unchanged.
- Validates profile field types and lengths and updates the OpenAPI schema.

## Validation

- `npm run harness:check`
- `npm run test` — 380 files passed, 2983 tests passed, 2 skipped
- Focused group-chat suite — 4 files / 46 tests passed
- `npm run build`

A chat-chain change note is included at `docs/chat-chain-changes/2026-07-25-group-chat-room-member-names.md`.