### PR TITLE
fix custom tts voice selection

### DIFF
--- a/docs/chat-chain-changes/2026-07-25-custom-tts-voice.md
+++ b/docs/chat-chain-changes/2026-07-25-custom-tts-voice.md
@@ -1,0 +1,13 @@
+---
+date: 2026-07-25
+pr: pending
+feature: Custom OpenAI-compatible TTS voice selection
+impact: Custom TTS playback can persist and send a configured voice instead of always relying on the provider default.
+---
+
+Custom OpenAI-compatible TTS connections now expose the same voice field used by
+other speech providers. Selecting the custom provider copies the stored voice
+into the legacy playback state, and group-chat playback includes that voice in
+the server synthesize request.
+
+Chat text, session persistence, and message ordering are unchanged.

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -457,6 +457,7 @@ function playSpeech(content: string, autoplay = false) {
             provider: 'custom' as const,
             baseUrl: voiceSettings.customUrl.value,
             apiKey: voiceSettings.customApiKey.value || undefined,
+            voice: voiceSettings.customVoice.value,
         }
         if (autoplay) void speech.openaiPlay(props.message.id, content, options).catch(handleAutoplayTtsError)
         else speech.openaiToggle(props.message.id, content, options)

--- a/packages/client/src/composables/useVoiceApiConnections.ts
+++ b/packages/client/src/composables/useVoiceApiConnections.ts
@@ -87,6 +87,7 @@ export function useVoiceApiConnections() {
 
     if (connection.provider === 'custom') {
       vs.setCustomUrl(connection.baseUrl || stringSetting(settings, 'baseUrl'))
+      vs.setCustomVoice(connection.voice || stringSetting(settings, 'voice') || vs.customVoice.value)
       return
     }
 

--- a/packages/client/src/composables/useVoiceSettings.ts
+++ b/packages/client/src/composables/useVoiceSettings.ts
@@ -19,6 +19,7 @@ export interface VoiceSettingsData {
   // Custom endpoint (OpenAI-compatible)
   customUrl: string
   customApiKey: string
+  customVoice: string
 
   // Edge TTS
   edgeUrl: string
@@ -83,6 +84,7 @@ const DEFAULT: VoiceSettingsData = {
 
   customUrl: '',
   customApiKey: '',
+  customVoice: 'alloy',
 
   edgeUrl: '',
   edgeVoice: 'zh-CN-XiaoxiaoNeural',
@@ -147,6 +149,7 @@ const openaiVoice = ref<string>(load().openaiVoice)
 // Custom
 const customUrl = ref<string>(load().customUrl)
 const customApiKey = ref<string>(load().customApiKey)
+const customVoice = ref<string>(load().customVoice)
 
 // Edge TTS
 const edgeUrl = ref<string>(load().edgeUrl)
@@ -176,7 +179,7 @@ const doubaoStylePrompt = ref<string>(load().doubaoStylePrompt)
 // Auto-persist on change
 watch(
   [provider, webspeechVoice, openaiApiKey, openaiBaseUrl, openaiModel, openaiVoice,
-   customUrl, customApiKey, edgeUrl, edgeVoice, edgeRate, edgePitchHz,
+   customUrl, customApiKey, customVoice, edgeUrl, edgeVoice, edgeRate, edgePitchHz,
    mimoApiKey, mimoAuthMode, mimoBaseUrl, mimoModel, mimoVoice, mimoVoiceDesignDesc,
    mimoVoiceCloneDataUri, mimoVoiceCloneFileName, mimoVoiceCloneFormat, mimoStylePrompt,
    doubaoApiKey, doubaoBaseUrl, doubaoModel, doubaoVoice, doubaoStylePrompt],
@@ -191,6 +194,7 @@ watch(
         openaiVoice: openaiVoice.value,
         customUrl: customUrl.value,
         customApiKey: customApiKey.value,
+        customVoice: customVoice.value,
         edgeUrl: edgeUrl.value,
         edgeVoice: edgeVoice.value,
         edgeRate: edgeRate.value,
@@ -227,6 +231,7 @@ export function useVoiceSettings() {
     openaiVoice,
     customUrl,
     customApiKey,
+    customVoice,
     edgeUrl,
     edgeVoice,
     edgeRate,
@@ -255,6 +260,7 @@ export function useVoiceSettings() {
     setOpenaiVoice(v: string) { openaiVoice.value = v },
     setCustomUrl(v: string) { customUrl.value = v },
     setCustomApiKey(v: string) { customApiKey.value = v },
+    setCustomVoice(v: string) { customVoice.value = v },
     setEdgeUrl(v: string) { edgeUrl.value = v },
     setEdgeVoice(v: string) { edgeVoice.value = v },
     setEdgeRate(v: number) { edgeRate.value = v },
@@ -284,6 +290,7 @@ export function useVoiceSettings() {
       openaiVoice.value = DEFAULT.openaiVoice
       customUrl.value = DEFAULT.customUrl
       customApiKey.value = DEFAULT.customApiKey
+      customVoice.value = DEFAULT.customVoice
       edgeUrl.value = DEFAULT.edgeUrl
       edgeVoice.value = DEFAULT.edgeVoice
       edgeRate.value = DEFAULT.edgeRate

--- a/packages/client/src/constants/voiceApiPresets.ts
+++ b/packages/client/src/constants/voiceApiPresets.ts
@@ -74,6 +74,7 @@ export const VOICE_API_PRESETS: VoiceApiPreset[] = [
     isSecretRequired: true,
     capabilities: {
       models: true,
+      voices: true,
     },
   },
 

--- a/tests/client/use-voice-api-connections-mimo.test.ts
+++ b/tests/client/use-voice-api-connections-mimo.test.ts
@@ -18,6 +18,8 @@ const sttApiMock = vi.hoisted(() => ({
 const voiceSettingsMock = vi.hoisted(() => {
   const state = {
     provider: { value: 'mimo' },
+    customUrl: { value: '' },
+    customVoice: { value: 'alloy' },
     edgeVoice: { value: 'zh-CN-XiaoxiaoNeural' },
     edgeRate: { value: 1 },
     edgePitchHz: { value: 0 },
@@ -31,6 +33,8 @@ const voiceSettingsMock = vi.hoisted(() => {
   return {
     ...state,
     setProvider: vi.fn((value: string) => { state.provider.value = value }),
+    setCustomUrl: vi.fn((value: string) => { state.customUrl.value = value }),
+    setCustomVoice: vi.fn((value: string) => { state.customVoice.value = value }),
     setMimoBaseUrl: vi.fn(),
     setMimoModel: vi.fn(),
     setMimoVoice: vi.fn(),
@@ -106,5 +110,29 @@ describe('useVoiceApiConnections MiMo voice clone', () => {
     expect(voiceSettingsMock.setMimoVoiceCloneDataUri).toHaveBeenCalledWith(dataUri)
     expect(voiceSettingsMock.setMimoVoiceCloneFileName).toHaveBeenCalledWith('sample.mp3')
     expect(voiceSettingsMock.setMimoVoiceCloneFormat).toHaveBeenCalledWith('mp3')
+  })
+
+  it('applies a saved custom TTS voice to legacy playback state', async () => {
+    ttsApiMock.saveActiveTtsProvider.mockResolvedValue('custom')
+    ttsApiMock.fetchTtsSettings.mockResolvedValue({
+      activeProvider: 'custom',
+      providers: [{
+        provider: 'custom',
+        settings: {
+          baseUrl: 'https://api.groq.com/openai/v1',
+          model: 'playai-tts',
+          voice: 'Fritz-PlayAI',
+        },
+        secrets: { apiKey: '[stored]' },
+        updatedAt: 1,
+      }],
+    })
+
+    const connections = useVoiceApiConnections()
+    await connections.refresh()
+    await connections.setActiveConnection('tts', 'tts-custom')
+
+    expect(voiceSettingsMock.setCustomUrl).toHaveBeenCalledWith('https://api.groq.com/openai/v1')
+    expect(voiceSettingsMock.setCustomVoice).toHaveBeenCalledWith('Fritz-PlayAI')
   })
 })


### PR DESCRIPTION
## Summary
- Expose the voice field for Custom TTS connections so OpenAI-compatible providers can use non-`alloy` voices.
- Persist the custom voice in voice settings, apply it when the custom provider is selected, and pass it through group-chat playback.
- Add regression coverage for applying a saved custom TTS voice.

Fixes #2213

## Validation
- `npm run test -- tests/client/use-voice-api-connections-mimo.test.ts tests/server/openai-tts-provider.test.ts`
- `npm run harness:check`
- `NODE_OPTIONS=--max-old-space-size=4096 npx vue-tsc -b --pretty false`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run build`
