### PR TITLE
Remove the 200-turn cap from Agent settings

### DIFF
--- a/packages/client/src/components/hermes/settings/AgentSettings.vue
+++ b/packages/client/src/components/hermes/settings/AgentSettings.vue
@@ -50,7 +50,7 @@ function debouncedSave(key: string, value: any) {
     <SettingRow :label="t('settings.agent.gatewayTimeout')" :hint="t('settings.agent.gatewayTimeoutHint')">
       <NInputNumber
         :value="settingsStore.agent.gateway_timeout"
-        :min="60" :max="7200" :step="60"
+        :min="0" :max="7200" :step="60"
         size="small" class="input-sm"
         @update:value="v => v != null && debouncedSave('gateway_timeout', v)"
       />

--- a/packages/client/src/components/hermes/settings/AgentSettings.vue
+++ b/packages/client/src/components/hermes/settings/AgentSettings.vue
@@ -42,7 +42,7 @@ function debouncedSave(key: string, value: any) {
     <SettingRow :label="t('settings.agent.maxTurns')" :hint="t('settings.agent.maxTurnsHint')">
       <NInputNumber
         :value="settingsStore.agent.max_turns"
-        :min="1" :max="200" :step="5"
+        :min="1" :step="5"
         size="small" class="input-sm"
         @update:value="v => v != null && debouncedSave('max_turns', v)"
       />

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -1911,7 +1911,7 @@ export default {
       maxTurns: 'Max Turns',
       maxTurnsHint: 'Maximum interaction rounds per conversation',
       gatewayTimeout: 'Gateway Timeout',
-      gatewayTimeoutHint: 'Request timeout in seconds',
+      gatewayTimeoutHint: 'Request inactivity timeout in seconds; 0 means unlimited',
       restartDrainTimeout: 'Restart Drain Timeout',
       restartDrainTimeoutHint: 'Drain timeout before restart in seconds',
       toolEnforcement: 'Tool Enforcement',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -1903,7 +1903,7 @@ export default {
       maxTurns: '最大轮次',
       maxTurnsHint: '单次对话最大交互轮数',
       gatewayTimeout: '网关超时',
-      gatewayTimeoutHint: '单次请求超时时间（秒）',
+      gatewayTimeoutHint: '单次请求无活动超时时间（秒），0 表示无限制',
       restartDrainTimeout: '重启排空超时',
       restartDrainTimeoutHint: '重启前排空请求的超时时间（秒）',
       toolEnforcement: '工具执行策略',

--- a/tests/client/agent-settings-max-turns.test.ts
+++ b/tests/client/agent-settings-max-turns.test.ts
@@ -1,18 +1,28 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
-describe('AgentSettings maximum turns', () => {
-  it('does not impose a Studio-specific upper limit', () => {
-    const source = readFileSync(
-      'packages/client/src/components/hermes/settings/AgentSettings.vue',
-      'utf8',
-    )
+describe('AgentSettings numeric limits', () => {
+  const source = readFileSync(
+    'packages/client/src/components/hermes/settings/AgentSettings.vue',
+    'utf8',
+  )
+
+  it('does not impose a Studio-specific maximum-turns upper limit', () => {
     const maxTurnsInput = source.match(
-      /<NInputNumber\s+[\s\S]*?:value="settingsStore\.agent\.max_turns"[\s\S]*?\/>/,
+      /<NInputNumber(?:(?!\/>)[\s\S])*?:value="settingsStore\.agent\.max_turns"(?:(?!\/>)[\s\S])*?\/>/,
     )?.[0]
 
     expect(maxTurnsInput).toBeDefined()
     expect(maxTurnsInput).not.toMatch(/:max=/)
     expect(maxTurnsInput).toContain(':min="1"')
+  })
+
+  it('allows zero to disable the gateway inactivity timeout', () => {
+    const gatewayTimeoutInput = source.match(
+      /<NInputNumber(?:(?!\/>)[\s\S])*?:value="settingsStore\.agent\.gateway_timeout"(?:(?!\/>)[\s\S])*?\/>/,
+    )?.[0]
+
+    expect(gatewayTimeoutInput).toBeDefined()
+    expect(gatewayTimeoutInput).toContain(':min="0"')
   })
 })

--- a/tests/client/agent-settings-max-turns.test.ts
+++ b/tests/client/agent-settings-max-turns.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('AgentSettings maximum turns', () => {
+  it('does not impose a Studio-specific upper limit', () => {
+    const source = readFileSync(
+      'packages/client/src/components/hermes/settings/AgentSettings.vue',
+      'utf8',
+    )
+    const maxTurnsInput = source.match(
+      /<NInputNumber\s+[\s\S]*?:value="settingsStore\.agent\.max_turns"[\s\S]*?\/>/,
+    )?.[0]
+
+    expect(maxTurnsInput).toBeDefined()
+    expect(maxTurnsInput).not.toMatch(/:max=/)
+    expect(maxTurnsInput).toContain(':min="1"')
+  })
+})


### PR DESCRIPTION
## Summary

- remove the Studio-only `200` upper bound from **Maximum turns**
- retain the minimum value of `1` and the existing step size
- add a regression test that prevents reintroducing a UI upper cap

Closes #2224

## Verification

- `node node_modules/.bin/vitest run tests/client/agent-settings-max-turns.test.ts`
- `node node_modules/.bin/vue-tsc -b`
- `node node_modules/typescript/bin/tsc --noEmit -p packages/server/tsconfig.json`
- `npm run build`
- `npm run harness:check`
