### PR TITLE
Add external context compression for Ekko

### DIFF
--- a/docs/chat-chain-changes/2026-07-26-ekko-external-context-compression.md
+++ b/docs/chat-chain-changes/2026-07-26-ekko-external-context-compression.md
@@ -1,0 +1,24 @@
+---
+date: 2026-07-26
+pr: pending
+feature: Externally managed Ekko context compression
+impact: Web UI-hosted Ekko conversations now use the shared snapshot-aware compression chain before each run instead of sending the loaded display history directly to Ekko.
+---
+
+The Ekko chat handler now rebuilds model history from the database, applies the
+same automatic compression thresholds and persistent compression snapshots as
+Hermes chat, and appends the current input after the compressed history.
+Provider-visible fixed context is estimated from Ekko's system prompt, tools,
+and provider context before the threshold decision. Compression progress uses
+the existing `compression.started` and `compression.completed` socket events.
+Ekko conversations explicitly disable the shared Hermes Agent summarization
+fallback; Hermes conversations retain it.
+
+The clean Ekko summarizer preserves the selected provider's streaming
+capability. This avoids holding a large summary request open without response
+data until the entire completion is ready, which can trip shorter upstream
+gateway timeouts even though the local summarization timeout is five minutes.
+
+Context ownership remains with the host: this Web UI path manages compression
+externally, while a future standalone Ekko host can manage its own internal
+compression without depending on Web UI snapshot storage.

--- a/docs/planning/session-compression-cursor.md
+++ b/docs/planning/session-compression-cursor.md
@@ -142,12 +142,14 @@ runtime has tools, MCP, skills, and memory disabled, allows one model step, and
 does not retry a failed model request. It receives only the summary prompt and
 the fixed instruction to generate the checkpoint.
 
-If that Ekko call fails or returns no usable summary, compression immediately
-falls back to the previous Hermes `chat` run through Agent Bridge. The fallback
-uses a temporary `compress_*` session ID, receives the same summary prompt as
+For Hermes Agent conversations, an Ekko failure or unusable summary falls back
+to the previous Hermes `chat` run through Agent Bridge. The fallback uses a
+temporary `compress_*` session ID, receives the same summary prompt as
 conversation history, uses the dedicated
 `<profile>:compression:<source-session-id>` worker key, waits for the result,
-and destroys the temporary compression session afterward.
+and destroys the temporary compression session afterward. Ekko Agent
+conversations disable that fallback: an Ekko summarization failure stays in the
+shared compressor's normal failure path and never starts Hermes Agent.
 
 The first compression therefore sends the complete selected historical range
 to a summarizer model. Incremental compression sends the previous summary and

--- a/packages/ekko-agent/README.md
+++ b/packages/ekko-agent/README.md
@@ -97,6 +97,12 @@ const result = await tools.execute('terminal_exec', {
 events together. The default `maxSteps` is `90`, matching Hermes' regular agent
 turn budget.
 
+When Ekko runs inside a host that owns conversation persistence, the host also
+owns context compression. `estimateContext()` exposes the provider-visible
+system, tool, message, and provider-context estimate needed for that external
+threshold decision without starting a model call. A standalone Ekko host can
+instead implement and own its internal compression lifecycle.
+
 In development, Ekko Agent stores its SQLite database at
 `packages/ekko-agent/sql-data/ekko-agent.db`. It uses the same single-file
 SQLite/DELETE journal layout as `packages/server/data/hermes-web-ui.db`, so the

--- a/packages/ekko-agent/src/runtime/runtime.ts
+++ b/packages/ekko-agent/src/runtime/runtime.ts
@@ -88,6 +88,21 @@ export class AgentRuntime {
     await this.tools.refreshTools(context)
   }
 
+  /**
+   * Estimate the provider-visible context without starting a model run.
+   *
+   * Hosts that own conversation compaction can use this to account for Ekko's
+   * system prompt, tools, and provider context while keeping compaction itself
+   * outside the runtime.
+   */
+  async estimateContext(input: AgentRuntimeRunInput): Promise<AgentRuntimeContextEstimate> {
+    await this.refreshTools(this.runToolContext(input))
+    const modelClient = this.modelClientFor(input)
+    const messages = this.prepareMessages(input)
+    const request = this.modelRequest(input, messages, modelClient, this.contextKeyFor(input))
+    return estimateModelRequestContext(request)
+  }
+
   async run(input: AgentRuntimeRunInput): Promise<AgentRuntimeRunResult> {
     await this.refreshTools(this.runToolContext(input))
 

--- a/packages/server/src/lib/context-compressor/index.ts
+++ b/packages/server/src/lib/context-compressor/index.ts
@@ -2,8 +2,8 @@
  * Chat Context Compressor
  *
  * Compresses 1:1 chat conversation history before sending to upstream.
- * Uses the Hermes structured summary prompt with a clean Ekko runtime and
- * falls back to the Hermes Agent Bridge when Ekko summarization fails.
+ * Uses the Hermes structured summary prompt with a clean Ekko runtime and can
+ * optionally fall back to the Hermes Agent Bridge when the host allows it.
  *
  * Algorithm:
  * 1. If total tokens < trigger threshold → return as-is
@@ -26,7 +26,6 @@ import {
   AgentRuntime,
   createModelClient,
   resolveModelProviderConfigs,
-  type ModelClient,
 } from '../../../../ekko-agent/src'
 import {
   getCompressionSnapshot,
@@ -97,6 +96,7 @@ export interface SummarizerOptions {
   apiMode?: string | null
   historyRevision?: number
   workerKey?: string
+  allowHermesFallback?: boolean
 }
 
 type SummarizerConversationMessage = {
@@ -533,6 +533,17 @@ export async function callSummarizer(
       profile,
     })
   } catch (err) {
+    if (options.allowHermesFallback === false) {
+      logger.warn(
+        {
+          err,
+          cause: err instanceof Error ? err.cause : undefined,
+        },
+        '[context-compressor] clean Ekko summarizer failed; Hermes fallback disabled for profile %s',
+        profile,
+      )
+      throw err
+    }
     logger.warn(err, '[context-compressor] clean Ekko summarizer failed; falling back to Hermes for profile %s', profile)
     return callHermesSummarizer(convHistory, timeoutMs, {
       ...options,
@@ -568,15 +579,11 @@ async function callEkkoSummarizer(
     timeoutMs,
   })
   const providerClient = createModelClient(providerConfig)
-  const modelClient: ModelClient = {
-    provider: providerClient.provider,
-    requestStyle: providerClient.requestStyle,
-    capabilities: { ...providerClient.capabilities, streaming: false },
-    create: request => providerClient.create(request),
-    stream: request => providerClient.stream(request),
-  }
   const runtime = new AgentRuntime({
-    modelClient,
+    // Preserve the provider's streaming capability. Long summary requests can
+    // otherwise sit idle until the complete response is ready and be severed
+    // by an upstream gateway before our own timeout is reached.
+    modelClient: providerClient,
     toolsEnabled: false,
     skillsEnabled: false,
     systemPrompt: EKKO_SUMMARIZER_SYSTEM_PROMPT,

--- a/packages/server/src/services/ekko-agent/manager.ts
+++ b/packages/server/src/services/ekko-agent/manager.ts
@@ -5,6 +5,7 @@ import {
   SqliteMemoryStore,
   type AgentRuntimeRunInput,
   type AgentRuntimeRunResult,
+  type AgentRuntimeContextEstimate,
 } from '../../../../ekko-agent/src'
 import { resolve } from 'node:path'
 import { config } from '../../config'
@@ -33,6 +34,10 @@ export class GlobalEkkoAgent {
     this.lastUsedAt = Date.now()
     this.runCount += 1
     return this.runtimeInstance().run(input)
+  }
+
+  async estimateContext(input: AgentRuntimeRunInput): Promise<AgentRuntimeContextEstimate> {
+    return this.runtimeInstance().estimateContext(input)
   }
 
   close(): void {

--- a/packages/server/src/services/hermes/run-chat/compression.ts
+++ b/packages/server/src/services/hermes/run-chat/compression.ts
@@ -29,6 +29,7 @@ interface RunChatCompressionConfig {
 interface CompressionModelContext {
   model?: string | null
   provider?: string | null
+  allowHermesFallback?: boolean
 }
 
 export class ContextWindowTooSmallError extends Error {
@@ -243,13 +244,14 @@ export async function buildCompressedHistory(
   modelContext: CompressionModelContext = {},
   contextTokenEstimator?: (messages: ChatMessage[], messageTokens: number) => Promise<number | null | undefined>,
   currentInputTokens = 0,
+  excludeLastUser = true,
 ): Promise<ChatMessage[]> {
   try {
     let snapshot = getCompressionSnapshot(sessionId)
     let cursorParts: CursorSnapshotParts | null = null
     let history: ChatMessage[]
     if (snapshot?.compressedThroughMessageId != null) {
-      const cursorRead = readCursorSnapshotParts(sessionId, snapshot, { excludeLastUser: true })
+      const cursorRead = readCursorSnapshotParts(sessionId, snapshot, { excludeLastUser })
       if (cursorRead.status === 'usable') {
         cursorParts = cursorRead.parts
         history = assembleCursorSnapshotHistory(snapshot, cursorParts, SUMMARY_PREFIX)
@@ -261,10 +263,10 @@ export async function buildCompressedHistory(
         )
         deleteCompressionSnapshot(sessionId)
         snapshot = null
-        history = await buildDbHistory(sessionId, { excludeLastUser: true })
+        history = await buildDbHistory(sessionId, { excludeLastUser })
       }
     } else {
-      history = await buildDbHistory(sessionId, { excludeLastUser: true })
+      history = await buildDbHistory(sessionId, { excludeLastUser })
     }
 
     const contextLength = getModelContextLength({
@@ -482,6 +484,7 @@ export async function compressHistory(
       provider: summarizerModelContext.provider,
       historyRevision: session?.history_revision ?? 0,
       workerKey: `${summarizerProfile}:compression:${sessionId}`,
+      allowHermesFallback: modelContext.allowHermesFallback !== false,
     })
     const afterTokens = await calcAndUpdateUsage(sessionId, cState, emit, {
       truncateToolResultsForContext: true,
@@ -617,6 +620,7 @@ export async function forceCompressBridgeHistory(
     provider: summarizerModelContext.provider,
     historyRevision: session?.history_revision ?? 0,
     workerKey: `${summarizerProfile}:compression:${sessionId}`,
+    allowHermesFallback: true,
   })
   const compressedMessages = result.messages.map(m => {
     const msg: any = { role: m.role, content: m.content }

--- a/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
@@ -18,12 +18,13 @@ import { getGlobalEkkoAgent } from '../../ekko-agent/manager'
 import { resolveEkkoMcpServers } from '../../ekko-agent/mcp'
 import { resolveEkkoAuthorizedProviderCredentials } from '../../ekko-agent/auth-providers'
 import { createSession, addMessage, getSession, updateSession, updateSessionStats } from '../../../db/hermes/session-store'
+import type { ChatMessage } from '../../../lib/context-compressor'
 import { logger } from '../../logger'
 import { recordSessionUsage } from '../../usage-recorder'
 import { getProfileDir } from '../hermes-profile'
 import { observeRunChatPetEvent } from '../pet-state-socket'
 import { contentBlocksToString, convertContentBlocksForAgent, extractTextForPreview } from './content-blocks'
-import { getOrCreateSession } from './compression'
+import { buildCompressedHistory, getOrCreateSession } from './compression'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
 import { estimateUsageTokensFromMessages } from './usage'
 import type { ChatCodingAgentId, ContentBlock, SessionState } from './types'
@@ -173,7 +174,7 @@ async function toUserAgentContent(value: unknown): Promise<Pick<AgentMessage, 'c
   }
 }
 
-async function toAgentMessages(messages: SessionState['messages']): Promise<AgentMessage[]> {
+async function toAgentMessages(messages: Array<ChatMessage | SessionState['messages'][number]>): Promise<AgentMessage[]> {
   const toolCallIds = new Set<string>()
   const result: AgentMessage[] = []
 
@@ -204,7 +205,7 @@ async function toAgentMessages(messages: SessionState['messages']): Promise<Agen
       const agentMessage: AgentMessage = {
         role: 'assistant',
         content: contentBlocksToString(message.content as any),
-        reasoning: message.reasoning || message.reasoning_content || undefined,
+        reasoning: ('reasoning' in message ? message.reasoning : undefined) || message.reasoning_content || undefined,
         toolCalls,
       }
       if (agentMessage.content.trim() || (agentMessage.reasoning?.trim().length ?? 0) > 0 || toolCalls?.length) {
@@ -222,7 +223,9 @@ async function toAgentMessages(messages: SessionState['messages']): Promise<Agen
         role: 'tool',
         content,
         toolCallId,
-        name: message.tool_name || undefined,
+        name: ('tool_name' in message ? message.tool_name : undefined) ||
+          ('name' in message ? message.name : undefined) ||
+          undefined,
       })
       toolCallIds.delete(toolCallId)
     }
@@ -614,6 +617,9 @@ export async function handleEkkoAgentRun(
   })
   const agent = getGlobalEkkoAgent(join(getProfileDir(profile), 'skills'))
   const memoryUsageBatchId = randomUUID()
+  const currentInputTokens = estimateUsageTokensFromMessages([
+    { role: 'user', content: inputText },
+  ]).inputTokens
 
   let assistantText = ''
   let assistantReasoning = ''
@@ -724,13 +730,67 @@ export async function handleEkkoAgentRun(
   try {
     logger.info('[chat-run-socket] starting ekko-agent run for session %s', sessionId)
     const authenticatedUserId = socket.data?.user?.id == null ? undefined : String(socket.data.user.id)
+    const toolContext = {
+      cwd: workspace,
+      workspaceRoot: workspace,
+      workspaceId: workspace,
+      userId: authenticatedUserId,
+      sessionId,
+      profileId: profile,
+      browserSessionId: sessionId,
+      mcpServers,
+      timeoutMs: 120_000,
+      signal: abortController.signal,
+    }
+    const metadata = {
+      session_id: sessionId,
+      workspace_id: workspace,
+      user_id: authenticatedUserId,
+      profile,
+    }
+    let fixedContextEstimate: Promise<number> | undefined
+    const compressedHistory = await buildCompressedHistory(
+      sessionId,
+      profile,
+      baseUrl,
+      apiKey,
+      emit,
+      sessionMap,
+      {
+        model: modelConfig.model,
+        provider: modelConfig.provider,
+        allowHermesFallback: false,
+      },
+      async (_messages, localMessageTokens) => {
+        fixedContextEstimate ||= agent.estimateContext({
+          modelClient,
+          model: modelConfig.model,
+          modelDefaults: { model: modelConfig.model },
+          messages: [],
+          signal: abortController.signal,
+          memoryEnabled: false,
+          toolContext,
+          metadata,
+        }).then(estimate => estimate.contextTokens)
+        return (await fixedContextEstimate) + localMessageTokens
+      },
+      currentInputTokens,
+      shouldPersistUserMessage && data.display_role !== 'command',
+    )
+    const currentMessage: AgentMessage = {
+      role: 'user',
+      ...await toUserAgentContent(data.input),
+    }
     const result = await agent.run({
       modelClient,
       model: modelConfig.model,
       modelDefaults: {
         model: modelConfig.model,
       },
-      messages: await toAgentMessages(state.messages),
+      messages: [
+        ...await toAgentMessages(compressedHistory),
+        currentMessage,
+      ],
       signal: abortController.signal,
       onEvent: handleRuntimeEvent,
       onMemoryUsage: event => {
@@ -749,24 +809,8 @@ export async function handleEkkoAgentRun(
           isEstimated: false,
         })
       },
-      toolContext: {
-        cwd: workspace,
-        workspaceRoot: workspace,
-        workspaceId: workspace,
-        userId: authenticatedUserId,
-        sessionId,
-        profileId: profile,
-        browserSessionId: sessionId,
-        mcpServers,
-        timeoutMs: 120_000,
-        signal: abortController.signal,
-      },
-      metadata: {
-        session_id: sessionId,
-        workspace_id: workspace,
-        user_id: authenticatedUserId,
-        profile,
-      },
+      toolContext,
+      metadata,
     })
     assistantText = result.output.content || assistantText
     const outputUsage = result.output.usage

--- a/tests/ekko-agent/runtime.test.ts
+++ b/tests/ekko-agent/runtime.test.ts
@@ -94,6 +94,34 @@ describe('ekko-agent runtime', () => {
     expect(events).toEqual(['run.started', 'model.started', 'context.estimated', 'model.message', 'run.completed'])
   })
 
+  it('estimates provider-visible context without starting a model run', async () => {
+    const tools = new AgentToolRegistry()
+    tools.register({
+      definition: {
+        name: 'estimate_only',
+        description: 'Included in context estimates',
+        parameters: { type: 'object' },
+      },
+      async execute() {
+        return { ok: true, content: 'unused' }
+      },
+    })
+    const client = modelClient(() => ({ content: 'must not run' }))
+    const runtime = new AgentRuntime({ modelClient: client, tools })
+
+    const estimate = await runtime.estimateContext({
+      messages: ['hello'],
+      metadata: { session_id: 'estimate-session' },
+    })
+
+    expect(estimate.messageCount).toBe(2)
+    expect(estimate.toolCount).toBe(1)
+    expect(estimate.systemPromptTokens).toBeGreaterThan(0)
+    expect(estimate.messageTokens).toBeGreaterThan(0)
+    expect(client.create).not.toHaveBeenCalled()
+    expect(client.stream).not.toHaveBeenCalled()
+  })
+
   it('emits one model usage event for each completed non-streaming model call', async () => {
     const client = modelClient(() => ({
       content: 'hello',

--- a/tests/server/context-compressor.test.ts
+++ b/tests/server/context-compressor.test.ts
@@ -113,6 +113,9 @@ describe('ChatContextCompressor', () => {
 
     expect(result).toBe('ekko summary')
     expect(ekkoRuntimeOptionsMock).toHaveBeenCalledWith(expect.objectContaining({
+      modelClient: expect.objectContaining({
+        capabilities: expect.objectContaining({ streaming: true }),
+      }),
       toolsEnabled: false,
       skillsEnabled: false,
       maxSteps: 1,
@@ -134,7 +137,7 @@ describe('ChatContextCompressor', () => {
     expect(bridgeDestroyMock).not.toHaveBeenCalled()
   })
 
-  it('falls back to the existing Hermes summarizer after the first Ekko failure', async () => {
+  it('falls back to the existing Hermes summarizer when the caller allows it', async () => {
     const { callSummarizer } = await import('../../packages/server/src/lib/context-compressor')
     ekkoRuntimeRunMock.mockRejectedValueOnce(new Error('provider unavailable'))
     bridgeRequestMock.mockResolvedValue({
@@ -160,12 +163,30 @@ describe('ChatContextCompressor', () => {
     expect(result).toBe('hermes fallback summary')
     expect(ekkoRuntimeRunMock).toHaveBeenCalledTimes(1)
     expect(bridgeRequestMock).toHaveBeenCalledTimes(1)
-    expect(bridgeRequestMock).toHaveBeenCalledWith(expect.objectContaining({
-      action: 'chat',
-      worker_key: 'default:compression:session-1',
-      model: 'summary-model',
-      provider: 'openrouter',
-    }), expect.any(Object))
+  })
+
+  it('does not fall back to Hermes when the caller disables it', async () => {
+    const { callSummarizer } = await import('../../packages/server/src/lib/context-compressor')
+    ekkoRuntimeRunMock.mockRejectedValueOnce(new Error('provider unavailable'))
+
+    await expect(callSummarizer(
+      '',
+      undefined,
+      'Summarize these turns.',
+      [],
+      12_000,
+      undefined,
+      {
+        profile: 'default',
+        model: 'summary-model',
+        provider: 'openrouter',
+        allowHermesFallback: false,
+      },
+    )).rejects.toThrow('provider unavailable')
+
+    expect(ekkoRuntimeRunMock).toHaveBeenCalledTimes(1)
+    expect(bridgeRequestMock).not.toHaveBeenCalled()
+    expect(bridgeDestroyMock).not.toHaveBeenCalled()
   })
 
   it('keeps full history when full summarization fails', async () => {

--- a/tests/server/ekko-agent-manager.test.ts
+++ b/tests/server/ekko-agent-manager.test.ts
@@ -38,6 +38,20 @@ describe('GlobalEkkoAgent', () => {
     expect(secondClient.create).toHaveBeenCalledTimes(1)
   })
 
+  it('estimates context without incrementing the completed run count', async () => {
+    const agent = new GlobalEkkoAgent({ memory: false })
+    const client = modelClient('unused')
+
+    const estimate = await agent.estimateContext({
+      messages: ['estimate this'],
+      modelClient: client,
+    })
+
+    expect(estimate.contextTokens).toBeGreaterThan(0)
+    expect(agent.runCount).toBe(0)
+    expect(client.create).not.toHaveBeenCalled()
+  })
+
   it('passes per-run model defaults, metadata, and tool context', async () => {
     const agent = new GlobalEkkoAgent({ memory: false })
     const client = modelClient('ok')

--- a/tests/server/run-chat-compression.test.ts
+++ b/tests/server/run-chat-compression.test.ts
@@ -156,6 +156,38 @@ describe('run chat compression trigger', () => {
     ])
   })
 
+  it('keeps the latest stored user when the current input is not persisted', async () => {
+    getSessionDetailMock.mockReturnValue({
+      messages: [
+        {
+          id: 1,
+          session_id: 'session-1',
+          role: 'user',
+          content: 'latest persisted user',
+          timestamp: 1,
+        },
+      ],
+    })
+
+    const { buildCompressedHistory } = await import('../../packages/server/src/services/hermes/run-chat/compression')
+    const history = await buildCompressedHistory(
+      'session-1',
+      'default',
+      'http://upstream',
+      undefined,
+      vi.fn(),
+      new Map(),
+      {},
+      undefined,
+      0,
+      false,
+    )
+
+    expect(history).toEqual([
+      { role: 'user', content: 'latest persisted user' },
+    ])
+  })
+
   it('builds a cursor snapshot run from protected head and post-cursor rows without a full-history read', async () => {
     const rows = [
       { id: 1, session_id: 'session-1', role: 'user', content: 'protected head', timestamp: 1 },
@@ -400,7 +432,55 @@ describe('run chat compression trigger', () => {
       'http://upstream',
       undefined,
       'session-1',
-      expect.objectContaining({ profile: 'default' }),
+      expect.objectContaining({
+        profile: 'default',
+        allowHermesFallback: true,
+      }),
+    )
+  })
+
+  it('passes an Ekko-only summarizer policy through the shared compressor', async () => {
+    compressorCompressMock.mockResolvedValue({
+      messages: [{ role: 'user', content: 'compressed' }],
+      meta: {
+        compressed: true,
+        llmCompressed: true,
+        totalMessages: 5,
+        summaryTokenEstimate: 1,
+        verbatimCount: 0,
+        compressedStartIndex: 0,
+      },
+    })
+    const state = { messages: [], isWorking: true, events: [], queue: [] }
+    const sessionMap = new Map([['session-1', state as any]])
+    const { compressHistory } = await import('../../packages/server/src/services/hermes/run-chat/compression')
+
+    await compressHistory(
+      Array.from({ length: 5 }, (_, index) => ({
+        role: index % 2 === 0 ? 'user' : 'assistant',
+        content: `message ${index}`,
+      })),
+      null,
+      'session-1',
+      'http://upstream',
+      undefined,
+      state as any,
+      160_000,
+      vi.fn(),
+      sessionMap,
+      { model: 'session-model', provider: 'session-provider', allowHermesFallback: false },
+    )
+
+    expect(compressorCompressMock).toHaveBeenCalledWith(
+      expect.any(Array),
+      'http://upstream',
+      undefined,
+      'session-1',
+      expect.objectContaining({
+        model: 'session-model',
+        provider: 'session-provider',
+        allowHermesFallback: false,
+      }),
     )
   })
 

--- a/tests/server/run-chat-ekko-context.test.ts
+++ b/tests/server/run-chat-ekko-context.test.ts
@@ -9,9 +9,12 @@ const updateSessionMock = vi.hoisted(() => vi.fn())
 const updateSessionStatsMock = vi.hoisted(() => vi.fn())
 const resolveBridgeRunModelConfigMock = vi.hoisted(() => vi.fn())
 const agentRunMock = vi.hoisted(() => vi.fn())
+const agentEstimateContextMock = vi.hoisted(() => vi.fn(async () => ({ contextTokens: 5_000 })))
 const getGlobalEkkoAgentMock = vi.hoisted(() => vi.fn(() => ({
   run: agentRunMock,
+  estimateContext: agentEstimateContextMock,
 })))
+const buildCompressedHistoryMock = vi.hoisted(() => vi.fn())
 const recordSessionUsageMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
@@ -25,6 +28,14 @@ vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
 vi.mock('../../packages/server/src/services/hermes/run-chat/model-config', () => ({
   resolveBridgeRunModelConfig: resolveBridgeRunModelConfigMock,
 }))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/compression', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../packages/server/src/services/hermes/run-chat/compression')>()
+  return {
+    ...actual,
+    buildCompressedHistory: buildCompressedHistoryMock,
+  }
+})
 
 vi.mock('../../packages/server/src/services/ekko-agent/manager', () => ({
   getGlobalEkkoAgent: getGlobalEkkoAgentMock,
@@ -100,6 +111,25 @@ function makeHarness() {
 describe('ekko-agent context usage events', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    agentEstimateContextMock.mockResolvedValue({ contextTokens: 5_000 })
+    buildCompressedHistoryMock.mockImplementation(async (
+      sessionId: string,
+      _profile: string,
+      _upstream: string,
+      _apiKey: string | undefined,
+      _emit: unknown,
+      sessionMap: Map<string, any>,
+      _modelContext: unknown,
+      _contextEstimator: unknown,
+      _currentInputTokens: number,
+      excludeLastUser: boolean,
+    ) => {
+      const messages = (sessionMap.get(sessionId)?.messages || [])
+        .filter((message: any) => ['user', 'assistant', 'tool'].includes(message.role))
+      if (!excludeLastUser) return messages
+      const latestUserIndex = messages.findLastIndex((message: any) => message.role === 'user')
+      return latestUserIndex < 0 ? messages : messages.slice(0, latestUserIndex)
+    })
     getSessionMock.mockReturnValue({
       id: 'session-1',
       profile: 'default',
@@ -315,6 +345,73 @@ describe('ekko-agent context usage events', () => {
     const storedUserMessage = addMessageMock.mock.calls.find(call => call[0]?.role === 'user')?.[0]
     expect(storedUserMessage?.content).toContain(imagePath)
     expect(storedUserMessage?.content).not.toContain(expectedBase64)
+  })
+
+  it('uses externally compressed history and Ekko fixed-context estimates', async () => {
+    buildCompressedHistoryMock.mockImplementationOnce(async (
+      _sessionId: string,
+      _profile: string,
+      _upstream: string,
+      _apiKey: string | undefined,
+      _emit: unknown,
+      _sessionMap: Map<string, any>,
+      _modelContext: unknown,
+      contextEstimator: (_messages: unknown[], messageTokens: number) => Promise<number>,
+    ) => {
+      expect(await contextEstimator([], 123)).toBe(5_123)
+      return [{
+        role: 'user',
+        content: '[CONTEXT COMPACTION — REFERENCE ONLY]\n\nsummary',
+      }]
+    })
+    agentRunMock.mockResolvedValueOnce({
+      runId: 'run-1',
+      output: { role: 'assistant', content: 'continued', usage: { inputTokens: 3, outputTokens: 2 } },
+      steps: [],
+      messages: [],
+      events: [],
+      contextEstimate: { contextTokens: 6_000 },
+    })
+    const { handleEkkoAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-ekko-agent-run')
+    const { nsp, socket, sessionMap } = makeHarness()
+
+    await handleEkkoAgentRun(nsp as any, socket as any, {
+      session_id: 'session-1',
+      input: 'continue from the checkpoint',
+      coding_agent_id: 'ekko-agent',
+    }, 'default', sessionMap, vi.fn(() => false))
+
+    expect(agentEstimateContextMock).toHaveBeenCalledWith(expect.objectContaining({
+      messages: [],
+      memoryEnabled: false,
+      model: 'ekko-test-model',
+    }))
+    expect(agentRunMock.mock.calls[0][0].messages).toEqual([
+      {
+        role: 'user',
+        content: '[CONTEXT COMPACTION — REFERENCE ONLY]\n\nsummary',
+      },
+      {
+        role: 'user',
+        content: 'continue from the checkpoint',
+      },
+    ])
+    expect(buildCompressedHistoryMock).toHaveBeenCalledWith(
+      'session-1',
+      'default',
+      '',
+      undefined,
+      expect.any(Function),
+      sessionMap,
+      {
+        model: 'ekko-test-model',
+        provider: 'test-provider',
+        allowHermesFallback: false,
+      },
+      expect.any(Function),
+      expect.any(Number),
+      true,
+    )
   })
 
   it('includes paired tool results in Ekko history for follow-up turns', async () => {


### PR DESCRIPTION
## What changed

- Route Web UI-hosted Ekko runs through the shared snapshot-aware context compression chain before invoking the agent.
- Estimate provider-visible fixed context locally from Ekko system prompts, tools, and provider context for threshold decisions and frontend token reporting.
- Keep compression ownership external in the Web UI host while exposing `estimateContext` for host integration.
- Preserve Hermes Agent’s Ekko-to-Hermes summarizer fallback, but explicitly disable Hermes fallback for Ekko Agent conversations.
- Preserve the selected provider’s streaming capability during Ekko summarization.
- Add focused runtime, manager, compressor, and chat-handler coverage plus chat-chain documentation.

## Why

Ekko conversations previously sent the loaded display history directly to the agent and did not participate in the host’s context compression lifecycle. During large-context validation, the summarizer also forced non-streaming responses; two different providers failed after roughly 51 seconds even though the local summarization timeout was five minutes. Keeping the provider’s streaming mode prevents long summary requests from remaining idle until the entire completion is ready.

## Impact

Web UI-hosted Ekko sessions now compress automatically and persist compression snapshots like Hermes sessions. Ekko summaries use only the Ekko summarizer and surface failures without silently switching agents. Standalone Ekko remains free to own its internal compression lifecycle later.

## Validation

- `npx vitest run tests/server/context-compressor.test.ts tests/server/run-chat-compression.test.ts tests/server/run-chat-ekko-context.test.ts tests/ekko-agent/runtime.test.ts` — 79 tests passed
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm --prefix packages/ekko-agent run check`
- `npm run harness:check`
- `git diff --check`
- Manual validation with session `ms1g3hsnqeeof4`: compression succeeded after restoring provider streaming; test snapshot and seeded messages were subsequently removed from the local database.
