### PR TITLE
fix: fail-closed coding agent child spawn handshake

### DIFF
--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -92,6 +92,8 @@ interface ManagedCodingAgentRun {
   startedAt: number
   exited: boolean
   currentChild?: ChildProcess
+  childSpawned?: boolean
+  childStartupTimer?: ReturnType<typeof setTimeout>
   currentChildKillTimer?: ReturnType<typeof setTimeout>
   currentChildStderr?: string
   printResponseId?: string
@@ -806,6 +808,7 @@ export class CodingAgentRunManager {
     const shouldReportClosed = options.reportClosed !== false && (run.state.isWorking || Boolean(run.currentChild && !run.currentChild.killed))
     if (run.idleTimer) clearTimeout(run.idleTimer)
     if (run.currentChildKillTimer) clearTimeout(run.currentChildKillTimer)
+    if (run.childStartupTimer) clearTimeout(run.childStartupTimer)
     this.flushTerminalOutput(run)
     if (run.terminalFlushTimer) clearTimeout(run.terminalFlushTimer)
     this.runs.delete(run.id)
@@ -884,6 +887,30 @@ export class CodingAgentRunManager {
     })
     run.currentChild = child
 
+    // Real ChildProcess emits 'spawn'; test doubles may not implement EventEmitter.
+    if (typeof child.once === 'function') {
+      run.childSpawned = false
+      child.once('spawn', () => {
+        run.childSpawned = true
+        if (run.childStartupTimer) clearTimeout(run.childStartupTimer)
+        run.childStartupTimer = undefined
+      })
+      run.childStartupTimer = setTimeout(() => {
+        if (run.childSpawned || run.stoppedByUser || run.exited) return
+        this.handleClaudePrintResponseEvent(run, {
+          type: 'response.failed',
+          data: { type: 'response.failed', response: {
+            id: run.printResponseId, object: 'response', status: 'failed', model: run.launch.model,
+            error: { message: 'Claude Code process did not start' }, output: [],
+          } },
+        })
+        this.cleanupRun(run, { kill: true, reportClosed: false })
+      }, 5000)
+      run.childStartupTimer.unref?.()
+    } else {
+      run.childSpawned = true
+    }
+
     let stdoutBuffer = ''
     child.stdout?.on('data', (chunk: Buffer) => {
       this.touch(run)
@@ -902,6 +929,8 @@ export class CodingAgentRunManager {
     child.on('error', (err) => {
       if (run.currentChildKillTimer) clearTimeout(run.currentChildKillTimer)
       run.currentChildKillTimer = undefined
+      if (run.childStartupTimer) clearTimeout(run.childStartupTimer)
+      run.childStartupTimer = undefined
       run.currentChild = undefined
       logger.warn({ err, runId: run.id, sessionId: run.launch.sessionId }, '[coding-agent-run] claude print failed to start')
       this.handleClaudePrintResponseEvent(run, {
@@ -922,8 +951,11 @@ export class CodingAgentRunManager {
 
     child.on('exit', (code) => {
       if (stdoutBuffer.trim()) this.handleClaudePrintLine(run, stdoutBuffer)
+      const childSpawned = run.childSpawned === true
       if (run.currentChildKillTimer) clearTimeout(run.currentChildKillTimer)
       run.currentChildKillTimer = undefined
+      if (run.childStartupTimer) clearTimeout(run.childStartupTimer)
+      run.childStartupTimer = undefined
       run.currentChild = undefined
       logger.info({ runId: run.id, sessionId: run.launch.sessionId, code }, '[coding-agent-run] claude print exited')
       if (run.stoppedByUser) return
@@ -949,6 +981,7 @@ export class CodingAgentRunManager {
           },
         },
       })
+      if (!childSpawned) this.cleanupRun(run, { kill: false, reportClosed: false })
     })
   }
 
@@ -1323,6 +1356,30 @@ export class CodingAgentRunManager {
     })
     run.currentChild = child
 
+    // Real ChildProcess emits 'spawn'; test doubles may not implement EventEmitter.
+    if (typeof child.once === 'function') {
+      run.childSpawned = false
+      child.once('spawn', () => {
+        run.childSpawned = true
+        if (run.childStartupTimer) clearTimeout(run.childStartupTimer)
+        run.childStartupTimer = undefined
+      })
+      run.childStartupTimer = setTimeout(() => {
+        if (run.childSpawned || run.stoppedByUser || run.exited) return
+        this.handleClaudePrintResponseEvent(run, {
+          type: 'response.failed',
+          data: { type: 'response.failed', response: {
+            id: run.printResponseId, object: 'response', status: 'failed', model: run.launch.model,
+            error: { message: 'Codex process did not start' }, output: [],
+          } },
+        })
+        this.cleanupRun(run, { kill: true, reportClosed: false })
+      }, 5000)
+      run.childStartupTimer.unref?.()
+    } else {
+      run.childSpawned = true
+    }
+
     let stdoutBuffer = ''
     child.stdout?.on('data', (chunk: Buffer) => {
       this.touch(run)
@@ -1341,6 +1398,8 @@ export class CodingAgentRunManager {
     child.on('error', (err) => {
       if (run.currentChildKillTimer) clearTimeout(run.currentChildKillTimer)
       run.currentChildKillTimer = undefined
+      if (run.childStartupTimer) clearTimeout(run.childStartupTimer)
+      run.childStartupTimer = undefined
       run.currentChild = undefined
       logger.warn({ err, runId: run.id, sessionId: run.launch.sessionId }, '[coding-agent-run] codex exec failed to start')
       this.handleClaudePrintResponseEvent(run, {
@@ -1361,8 +1420,11 @@ export class CodingAgentRunManager {
 
     child.on('exit', (code) => {
       if (stdoutBuffer.trim()) this.handleCodexExecLine(run, stdoutBuffer)
+      const childSpawned = run.childSpawned === true
       if (run.currentChildKillTimer) clearTimeout(run.currentChildKillTimer)
       run.currentChildKillTimer = undefined
+      if (run.childStartupTimer) clearTimeout(run.childStartupTimer)
+      run.childStartupTimer = undefined
       run.currentChild = undefined
       logger.info({ runId: run.id, sessionId: run.launch.sessionId, code }, '[coding-agent-run] codex exec exited')
       if (run.stoppedByUser) return
@@ -1388,6 +1450,7 @@ export class CodingAgentRunManager {
           },
         },
       })
+      if (!childSpawned) this.cleanupRun(run, { kill: false, reportClosed: false })
     })
   }
 


### PR DESCRIPTION
## Summary
- Coding Agent (`claude-code` / `codex`) could leave Studio sessions stuck in `interacting` when the child process never successfully spawns, with callers eventually seeing `fetch failed`.
- Add a short spawn handshake for real `ChildProcess` instances: if `spawn` never fires within 5s, emit `response.failed`, cleanup the run, and end the session.
- Clear startup timers on `error` / `exit` / `cleanupRun`. Non-EventEmitter test doubles keep prior behavior so existing unit tests remain green. Already-spawned long-running turns are not time-limited by this timer.

## Test plan
- [x] `npx vitest run tests/server/agent-runner-utils.test.ts tests/server/coding-agents-launch.test.ts tests/server/handle-coding-agent-run.test.ts tests/server/coding-agent-run-manager-windows.test.ts` → 90 passed
- [x] `npx tsc --noEmit -p packages/server/tsconfig.json`
- [ ] Live: failed child start ends session with `end_reason=error` instead of infinite interacting
- [ ] Live: successfully spawned long Codex/Claude turns still complete normally