### PR TITLE
fix(codex): 截断 Responses 超大工具输出

### DIFF
--- a/packages/server/src/services/agent-runner/adapters/responses.ts
+++ b/packages/server/src/services/agent-runner/adapters/responses.ts
@@ -6,6 +6,9 @@ export interface ResponsesAdapterTarget {
 
 const HERMES_STUDIO_NAMESPACE = 'mcp__hermes_studio'
 const TOOL_SEARCH_NAME = 'tool_search'
+const RESPONSES_TOOL_OUTPUT_FORWARD_LIMIT = 32 * 1024
+const RESPONSES_TOOL_OUTPUT_HEAD_CHARS = 24 * 1024
+const RESPONSES_TOOL_OUTPUT_TAIL_CHARS = 7 * 1024
 
 const HERMES_STUDIO_MCP_TOOLS = [
   {
@@ -301,6 +304,38 @@ function expandedResponseTools(tools: unknown): any[] {
 
 function responseInputItems(body: any): any[] {
   return Array.isArray(body?.input) ? body.input : []
+}
+
+function truncateResponsesToolOutputText(output: string): string {
+  if (output.length <= RESPONSES_TOOL_OUTPUT_FORWARD_LIMIT) return output
+  const head = output.slice(0, RESPONSES_TOOL_OUTPUT_HEAD_CHARS)
+  const tail = output.slice(-RESPONSES_TOOL_OUTPUT_TAIL_CHARS)
+  const omitted = output.length - head.length - tail.length
+  return [
+    head,
+    '',
+    `[Hermes Web UI: coding-agent tool output truncated before provider request; original_chars=${output.length}; omitted_chars=${omitted}]`,
+    '',
+    tail,
+  ].join('\n')
+}
+
+export function truncateResponsesToolOutputs(body: any): any {
+  const input = responseInputItems(body)
+  if (!input.length) return body
+
+  let changed = false
+  const nextInput = input.map((item: any) => {
+    if (!item || typeof item !== 'object' || item.type !== 'function_call_output' || typeof item.output !== 'string') {
+      return item
+    }
+    const nextOutput = truncateResponsesToolOutputText(item.output)
+    if (nextOutput === item.output) return item
+    changed = true
+    return { ...item, output: nextOutput }
+  })
+
+  return changed ? { ...body, input: nextInput } : body
 }
 
 function responsesAvailableTools(body: any): any[] {

--- a/packages/server/src/services/agent-runner/adapters/responses.ts
+++ b/packages/server/src/services/agent-runner/adapters/responses.ts
@@ -7,8 +7,8 @@ export interface ResponsesAdapterTarget {
 const HERMES_STUDIO_NAMESPACE = 'mcp__hermes_studio'
 const TOOL_SEARCH_NAME = 'tool_search'
 const RESPONSES_TOOL_OUTPUT_FORWARD_LIMIT = 32 * 1024
-const RESPONSES_TOOL_OUTPUT_HEAD_CHARS = 24 * 1024
-const RESPONSES_TOOL_OUTPUT_TAIL_CHARS = 7 * 1024
+const RESPONSES_TOOL_OUTPUT_HEAD_BYTES = 24 * 1024
+const RESPONSES_TOOL_OUTPUT_TAIL_BYTES = 7 * 1024
 
 const HERMES_STUDIO_MCP_TOOLS = [
   {
@@ -306,15 +306,57 @@ function responseInputItems(body: any): any[] {
   return Array.isArray(body?.input) ? body.input : []
 }
 
+function utf8ByteLength(text: string): number {
+  return Buffer.byteLength(text, 'utf8')
+}
+
+function utf8Head(text: string, maxBytes: number): string {
+  if (maxBytes <= 0) return ''
+  let bytes = 0
+  let end = 0
+  for (const char of text) {
+    const nextBytes = utf8ByteLength(char)
+    if (bytes + nextBytes > maxBytes) break
+    bytes += nextBytes
+    end += char.length
+  }
+  return text.slice(0, end)
+}
+
+function utf8Tail(text: string, maxBytes: number): string {
+  if (maxBytes <= 0) return ''
+  let bytes = 0
+  let start = text.length
+  while (start > 0) {
+    let nextStart = start - 1
+    const code = text.charCodeAt(nextStart)
+    if (code >= 0xDC00 && code <= 0xDFFF && nextStart > 0) {
+      const prev = text.charCodeAt(nextStart - 1)
+      if (prev >= 0xD800 && prev <= 0xDBFF) nextStart -= 1
+    }
+    const char = text.slice(nextStart, start)
+    const nextBytes = utf8ByteLength(char)
+    if (bytes + nextBytes > maxBytes) break
+    bytes += nextBytes
+    start = nextStart
+  }
+  return text.slice(start)
+}
+
 function truncateResponsesToolOutputText(output: string): string {
-  if (output.length <= RESPONSES_TOOL_OUTPUT_FORWARD_LIMIT) return output
-  const head = output.slice(0, RESPONSES_TOOL_OUTPUT_HEAD_CHARS)
-  const tail = output.slice(-RESPONSES_TOOL_OUTPUT_TAIL_CHARS)
-  const omitted = output.length - head.length - tail.length
+  const originalBytes = utf8ByteLength(output)
+  if (originalBytes <= RESPONSES_TOOL_OUTPUT_FORWARD_LIMIT) return output
+  const marker = `[Hermes Web UI: coding-agent tool output truncated before provider request; original_chars=${output.length}; original_bytes=${originalBytes}]`
+  const markerOverhead = utf8ByteLength(marker) + 4
+  const contentBudget = Math.max(0, RESPONSES_TOOL_OUTPUT_FORWARD_LIMIT - markerOverhead)
+  const tailBytes = Math.min(RESPONSES_TOOL_OUTPUT_TAIL_BYTES, Math.floor(contentBudget / 4))
+  const headBytes = Math.min(RESPONSES_TOOL_OUTPUT_HEAD_BYTES, Math.max(0, contentBudget - tailBytes))
+  const head = utf8Head(output, headBytes)
+  const tail = utf8Tail(output, tailBytes)
   return [
     head,
     '',
-    `[Hermes Web UI: coding-agent tool output truncated before provider request; original_chars=${output.length}; omitted_chars=${omitted}]`,
+    marker,
     '',
     tail,
   ].join('\n')

--- a/packages/server/src/services/agent-runner/proxies/codex-proxy.ts
+++ b/packages/server/src/services/agent-runner/proxies/codex-proxy.ts
@@ -14,6 +14,7 @@ import {
   openAiChatToResponses,
   responsesToAnthropicMessages,
   responsesToOpenAiChat,
+  truncateResponsesToolOutputs,
 } from '../adapters/responses'
 import {
   anthropicMessagesSseToResponsesEvents,
@@ -120,7 +121,7 @@ async function callOpenAiResponses(target: CodexProxyTarget, body: any): Promise
     ;(err as any).status = 501
     throw err
   }
-  const responsesBody = { ...body, model: target.model }
+  const responsesBody = truncateResponsesToolOutputs({ ...body, model: target.model })
   return agentRunGateway.completeJson({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,
@@ -212,7 +213,7 @@ async function openAiResponsesSseStream(target: CodexProxyTarget, body: any): Pr
     throw err
   }
 
-  const responsesBody = { ...body, model: target.model, stream: true }
+  const responsesBody = truncateResponsesToolOutputs({ ...body, model: target.model, stream: true })
   const stream = await agentRunGateway.streamBytes({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,

--- a/tests/server/agent-runner-adapters.test.ts
+++ b/tests/server/agent-runner-adapters.test.ts
@@ -6,6 +6,7 @@ import {
   responseToolNamespaceForName,
   responsesToAnthropicMessages,
   responsesToOpenAiChat,
+  truncateResponsesToolOutputs,
 } from '../../packages/server/src/services/agent-runner/adapters/responses'
 import {
   anthropicToOpenAiChat,
@@ -39,6 +40,29 @@ describe('agent runner Responses adapters', () => {
     expect(responsesToAnthropicMessages({ input: [] }, maxTarget)).toMatchObject({
       reasoning_effort: 'max',
     })
+  })
+
+  it('truncates oversized Responses function-call outputs before provider forwarding', () => {
+    const largeOutput = `${'A'.repeat(33 * 1024)}TAIL_MARKER`
+    const body = {
+      input: [
+        { role: 'user', content: [{ type: 'input_text', text: 'continue' }] },
+        { type: 'function_call_output', call_id: 'call_big', output: largeOutput },
+        { type: 'function_call_output', call_id: 'call_small', output: 'ok' },
+      ],
+    }
+
+    const sanitized = truncateResponsesToolOutputs(body)
+    const output = sanitized.input[1].output
+
+    expect(sanitized).not.toBe(body)
+    expect(output.length).toBeLessThan(largeOutput.length)
+    expect(output.length).toBeLessThanOrEqual(32 * 1024)
+    expect(output).toContain('truncated before provider request')
+    expect(output).toContain(`original_chars=${largeOutput.length}`)
+    expect(output.endsWith('TAIL_MARKER')).toBe(true)
+    expect(sanitized.input[2]).toBe(body.input[2])
+    expect(body.input[1].output).toBe(largeOutput)
   })
 
   it('converts Responses input to OpenAI Chat messages and tools', () => {

--- a/tests/server/agent-runner-adapters.test.ts
+++ b/tests/server/agent-runner-adapters.test.ts
@@ -43,7 +43,7 @@ describe('agent runner Responses adapters', () => {
   })
 
   it('truncates oversized Responses function-call outputs before provider forwarding', () => {
-    const largeOutput = `${'A'.repeat(33 * 1024)}TAIL_MARKER`
+    const largeOutput = `${'A'.repeat(32 * 1024 + 1)}TAIL_MARKER`
     const body = {
       input: [
         { role: 'user', content: [{ type: 'input_text', text: 'continue' }] },
@@ -58,11 +58,21 @@ describe('agent runner Responses adapters', () => {
     expect(sanitized).not.toBe(body)
     expect(output.length).toBeLessThan(largeOutput.length)
     expect(output.length).toBeLessThanOrEqual(32 * 1024)
+    expect(Buffer.byteLength(output, 'utf8')).toBeLessThanOrEqual(32 * 1024)
     expect(output).toContain('truncated before provider request')
     expect(output).toContain(`original_chars=${largeOutput.length}`)
     expect(output.endsWith('TAIL_MARKER')).toBe(true)
     expect(sanitized.input[2]).toBe(body.input[2])
     expect(body.input[1].output).toBe(largeOutput)
+
+    const cjkOutput = `${'界'.repeat(32 * 1024 + 1)}TAIL_MARKER`
+    const cjkSanitized = truncateResponsesToolOutputs({
+      input: [{ type: 'function_call_output', call_id: 'call_cjk', output: cjkOutput }],
+    })
+    const cjkTruncated = cjkSanitized.input[0].output
+    expect(Buffer.byteLength(cjkTruncated, 'utf8')).toBeLessThanOrEqual(32 * 1024)
+    expect(cjkTruncated).toContain(`original_bytes=${Buffer.byteLength(cjkOutput, 'utf8')}`)
+    expect(cjkTruncated.endsWith('TAIL_MARKER')).toBe(true)
   })
 
   it('converts Responses input to OpenAI Chat messages and tools', () => {


### PR DESCRIPTION
## 背景

Codex scoped coding-agent 在使用 OpenAI Responses 直通模式时，会把历史里的 `function_call_output.output` 原样转发给 provider。超大工具输出会触发 Responses 请求校验错误（`input[n].output` string too long），导致后续对话直接中断。

已有的 Bridge 历史投影修复只约束模型上下文重建；这个路径发生在 Codex proxy 转发 Responses 请求之前，需要单独在请求边界做保护。

## 改动

- 新增 `truncateResponsesToolOutputs()`，在转发 Responses 请求前对超大的 `function_call_output.output` 做 head/tail 截断。
- Codex proxy 的非流式与流式 `codex_responses` 路径都复用同一截断逻辑。
- 保留截断标记、原始字符数和省略字符数，避免静默丢上下文。
- 增加回归测试，确认超大工具输出不会继续原样转发，同时小输出保持原对象。

## 验证

- `npm test -- tests/server/agent-runner-adapters.test.ts`：通过，33 tests passed
- `git diff --check`：通过，exit 0
- `npm run harness:check`：通过，Harness check passed
- `npm run build`：通过，exit 0
