### PR TITLE
fix(chat): preserve ASCII quotes in Markdown

### DIFF
--- a/docs/chat-chain-changes/2026-07-23-preserve-straight-quotes.md
+++ b/docs/chat-chain-changes/2026-07-23-preserve-straight-quotes.md
@@ -1,0 +1,14 @@
+---
+date: 2026-07-23
+pr: pending
+feature: Preserve literal quote characters in chat Markdown
+impact: User and assistant prose keeps ASCII single and double quotes while existing non-quote typographic replacements remain enabled.
+---
+
+The shared chat Markdown renderer now disables only markdown-it's smart-quote
+rule. Literal apostrophes and quotation marks therefore remain byte-faithful in
+the rendered message instead of changing to curly Unicode characters.
+
+Other typographer behavior, including dash, ellipsis, and copyright-symbol
+replacement, remains unchanged. The focused renderer regression test covers
+both quote preservation and that non-quote behavior.

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -86,6 +86,10 @@ const md: MarkdownIt = new MarkdownItConstructor({
   },
 })
 
+// Preserve literal quote characters from user and assistant messages while
+// retaining typographer's other replacements (for example, dashes and ellipses).
+md.disable('smartquotes')
+
 md.use(markdownItKatex, {
   katex,
   throwOnError: false,

--- a/tests/client/markdown-rendering.test.ts
+++ b/tests/client/markdown-rendering.test.ts
@@ -110,6 +110,16 @@ describe('MarkdownRenderer', () => {
     })
   })
 
+  it('preserves ASCII quotes in prose without disabling other typographic replacements', () => {
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: `Men's "quoted" -- ... (c)`,
+      },
+    })
+
+    expect(wrapper.get('.markdown-body').text()).toBe(`Men's "quoted" – … ©`)
+  })
+
   it('opens message links in the embedded browser when the desktop bridge is available', async () => {
     desktopBrowserMock.openUrlInDesktopBrowser.mockResolvedValue(true)
     const open = vi.spyOn(window, 'open').mockImplementation(() => null)


### PR DESCRIPTION
Fixes #2085

聊天消息中的 ASCII 直引号现在按原文显示；Markdown typographer 的其它替换行为保持不变。

## 改动

- 保留 `typographer: true`，只禁用 markdown-it 的 `smartquotes` rule。
- 普通文本中的 ASCII apostrophe 和 double quotes 不再被替换成 Unicode 弯引号。
- 增加 renderer 回归测试，同时锁定 dash、ellipsis 和 copyright 替换不回退。
- 补充 chat-chain change fragment。

## 验证

已通过：

```bash
npx vitest run tests/client/markdown-rendering.test.ts tests/client/markdown-special-mentions.test.ts tests/client/markdown-rendering-mermaid-import-timeout.test.ts
npm run harness:check
npm run build
git diff --check origin/main..HEAD
```

结果：44 个相邻测试通过，harness 和完整 build 通过。
