### PR TITLE
Fix coding agent session stream isolation

### DIFF
--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -667,7 +667,10 @@ export class CodingAgentRunManager {
     const responseEvent = this.normalizeCodexChatTextEvent(run, event)
     if (!responseEvent) return
     const storageSafeResponseEvent = truncateCodingAgentToolOutputEvent(responseEvent)
-    if (run.launch.agentId === 'claude-code' && run.currentChild && !run.acceptingPrintEvent && !isProxyToolEvent(event)) return
+    if (run.launch.agentId === 'claude-code' && !run.acceptingPrintEvent) {
+      if (run.terminalEventHandled) return
+      if (run.currentChild && !isProxyToolEvent(event)) return
+    }
     if (storageSafeResponseEvent.type === 'response.created') {
       if (run.responseStartEmitted) return
       run.responseStartEmitted = true

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'child_process'
-import { randomUUID } from 'crypto'
+import { createHash, randomUUID } from 'crypto'
 import { existsSync, readdirSync, realpathSync } from 'fs'
 import { chmod, mkdir, readFile, stat, writeFile } from 'fs/promises'
 import { homedir } from 'os'
@@ -619,6 +619,21 @@ function getScopedConfigRoot(id: CodingAgentId, scope: Required<CodingAgentConfi
   return join(getWebUiHome(), CODING_AGENT_HOME_DIR, 'model', scope.profile, scope.provider, id)
 }
 
+function getScopedRuntimeConfigRoot(
+  id: CodingAgentId,
+  scope: Required<CodingAgentConfigScope>,
+  input: Pick<CodingAgentLaunchInput, 'sessionId' | 'agentSessionId'>,
+): string {
+  const rootDir = getScopedConfigRoot(id, scope)
+  const sessionId = String(input.sessionId || '').trim()
+  const agentSessionId = String(input.agentSessionId || '').trim()
+  if (!sessionId || !agentSessionId) return rootDir
+  const runtimeKey = createHash('sha256')
+    .update(JSON.stringify([sessionId, agentSessionId]))
+    .digest('hex')
+  return join(rootDir, 'runs', runtimeKey)
+}
+
 function getScopedWorkspaceRoot(scope: Required<CodingAgentConfigScope>): string {
   return join(getWebUiHome(), CODING_AGENT_HOME_DIR, 'workspace', scope.profile, scope.provider)
 }
@@ -1199,13 +1214,18 @@ function getLiveConfigFileDefinition(id: string, key: string): CodingAgentConfig
   }
 }
 
-function getScopedConfigFileDefinition(id: string, key: string, scopeInput: CodingAgentConfigScope = {}): (CodingAgentConfigFileDefinition & Required<CodingAgentConfigScope> & { rootDir: string }) | null {
+function getScopedConfigFileDefinition(
+  id: string,
+  key: string,
+  scopeInput: CodingAgentConfigScope = {},
+  rootDirOverride?: string,
+): (CodingAgentConfigFileDefinition & Required<CodingAgentConfigScope> & { rootDir: string }) | null {
   const tool = getCodingAgentDefinition(id)
   if (!tool) return null
   const definition = CONFIG_FILE_DEFINITIONS[tool.id].find(file => file.key === key)
   if (!definition) return null
   const scope = normalizeConfigScope(scopeInput)
-  const rootDir = getScopedConfigRoot(tool.id, scope)
+  const rootDir = rootDirOverride || getScopedConfigRoot(tool.id, scope)
   return {
     key: definition.key,
     path: definition.path,
@@ -1663,14 +1683,14 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
   const preset = PROVIDER_PRESETS.find(item => item.value === provider)
   const apiMode = normalizeLaunchApiMode(input.apiMode, preset?.api_mode || 'chat_completions')
   const reasoningEffort = String(input.reasoningEffort || '').trim()
-  const rootDir = getScopedConfigRoot(tool.id, scope)
+  const rootDir = getScopedRuntimeConfigRoot(tool.id, scope, input)
   const workspaceDir = resolveLaunchWorkspaceRoot(scope, input.workspace)
   await mkdir(rootDir, { recursive: true })
   await mkdir(workspaceDir, { recursive: true })
 
   const files: Array<{ key: string; path: string; absolutePath: string }> = []
   const writeScopedFile = async (key: string, content: string) => {
-    const definition = getScopedConfigFileDefinition(tool.id, key, scope)
+    const definition = getScopedConfigFileDefinition(tool.id, key, scope, rootDir)
     if (!definition) return
     await mkdir(dirname(definition.absolutePath), { recursive: true })
     await writeFile(definition.absolutePath, content, 'utf-8')

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -407,6 +407,41 @@ describe('coding agent run state', () => {
     manager.shutdown()
   })
 
+  it('ignores late Claude proxy events after a print turn completed', () => {
+    const manager = new CodingAgentRunManager()
+    const state: any = { messages: [], isWorking: false, events: [], queue: [] }
+    const emitted = vi.fn()
+    ;(manager as any).ensureDbSession = () => {}
+    ;(manager as any).emitToChat = emitted
+
+    manager.start({
+      agentSessionId: 'agent-session-completed',
+      agentId: 'claude-code',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'test-model',
+      sessionId: 'chat-session-completed',
+      command: 'claude',
+      args: [],
+      shellCommand: 'claude',
+      workspaceDir: process.cwd(),
+      state,
+    })
+    const run = (manager as any).runs.get('agent-session-completed')
+    run.terminalEventHandled = true
+    state.isWorking = false
+
+    manager.handleResponseEvent('agent-session-completed', {
+      type: 'response.output_text.delta',
+      data: { delta: 'belongs to another session' },
+    })
+
+    expect(state.isWorking).toBe(false)
+    expect(state.messages).toEqual([])
+    expect(emitted).not.toHaveBeenCalled()
+    manager.shutdown()
+  })
+
   it('clears shared chat session run state when a print turn completes', async () => {
     initAllHermesTables()
     const manager = new CodingAgentRunManager()

--- a/tests/server/coding-agent-resume-config.test.ts
+++ b/tests/server/coding-agent-resume-config.test.ts
@@ -80,7 +80,7 @@ describe('coding agent resumed session config', () => {
     safeReadFileMock.mockResolvedValue('')
 
     const { startCodingAgentRun } = await import('../../packages/server/src/services/coding-agents')
-    await startCodingAgentRun('claude-code', { sessionId: 'session-1' })
+    const result = await startCodingAgentRun('claude-code', { sessionId: 'session-1' })
 
     expect(startRunMock).toHaveBeenCalledWith(expect.objectContaining({
       agentSessionId: 'agent-session-1',
@@ -92,7 +92,7 @@ describe('coding agent resumed session config', () => {
     expect(launch.env.ANTHROPIC_API_KEY).toMatch(/^hwui_/)
     expect(launch.env).not.toHaveProperty('ANTHROPIC_AUTH_TOKEN')
     expect(launch.env.ANTHROPIC_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/api\/claude-code-proxy\/.+$/)
-    const settings = JSON.parse(readFileSync(join(home, 'coding-agent', 'model', 'default', 'custom_corp-claude', 'claude-code', 'settings.json'), 'utf-8'))
+    const settings = JSON.parse(readFileSync(join(result.rootDir, 'settings.json'), 'utf-8'))
     expect(settings.env.ANTHROPIC_API_KEY).toBe(launch.env.ANTHROPIC_API_KEY)
   })
 
@@ -128,7 +128,7 @@ describe('coding agent resumed session config', () => {
     const launch = startRunMock.mock.calls[0][0]
     expect(launch.env.ANTHROPIC_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/api\/claude-code-proxy\/.+$/)
     expect(Buffer.from(launch.env.ANTHROPIC_BASE_URL.split('/').pop() || '', 'base64url').toString('utf8')).toContain('anthropic_messages')
-    const settings = JSON.parse(readFileSync(join(home, 'coding-agent', 'model', 'default', 'custom_glm-coding-plan', 'claude-code', 'settings.json'), 'utf-8'))
+    const settings = JSON.parse(readFileSync(join(result.rootDir, 'settings.json'), 'utf-8'))
     expect(settings.env.ANTHROPIC_API_KEY).toMatch(/^hwui_/)
   })
 
@@ -170,7 +170,7 @@ describe('coding agent resumed session config', () => {
   })
 
   it('ignores a stale builtin base URL when the requested provider changed', async () => {
-    const home = makeHome()
+    makeHome()
     getSessionMock.mockReturnValue({
       id: 'session-1',
       profile: 'default',
@@ -184,7 +184,7 @@ describe('coding agent resumed session config', () => {
     safeReadFileMock.mockResolvedValue('DEEPSEEK_API_KEY=sk-deepseek\n')
 
     const { startCodingAgentRun } = await import('../../packages/server/src/services/coding-agents')
-    await startCodingAgentRun('codex', {
+    const result = await startCodingAgentRun('codex', {
       sessionId: 'session-1',
       provider: 'deepseek',
       model: 'deepseek-v4-pro',
@@ -193,7 +193,7 @@ describe('coding agent resumed session config', () => {
       apiMode: 'chat_completions',
     })
 
-    const config = readFileSync(join(home, 'coding-agent', 'model', 'default', 'deepseek', 'codex', 'config.toml'), 'utf-8')
+    const config = readFileSync(join(result.rootDir, 'config.toml'), 'utf-8')
     const routeKey = config.match(/\/api\/codex-proxy\/([^/]+)\/v1/)?.[1] || ''
     const routeParts = JSON.parse(Buffer.from(routeKey, 'base64url').toString('utf8'))
     expect(routeParts).toEqual(expect.arrayContaining([
@@ -280,7 +280,7 @@ describe('coding agent resumed session config', () => {
 
 
   it('prefers a stored coding-agent API mode when resuming without an explicit mode', async () => {
-    const home = makeHome()
+    makeHome()
     getSessionMock.mockReturnValue({
       id: 'session-1',
       profile: 'default',
@@ -295,7 +295,7 @@ describe('coding agent resumed session config', () => {
     safeReadFileMock.mockResolvedValue('')
 
     const { startCodingAgentRun } = await import('../../packages/server/src/services/coding-agents')
-    await startCodingAgentRun('codex', {
+    const result = await startCodingAgentRun('codex', {
       sessionId: 'session-1',
       baseUrl: 'https://api.apikey.fun/v1',
       apiKey: 'sk-test',
@@ -303,7 +303,7 @@ describe('coding agent resumed session config', () => {
 
     const launch = startRunMock.mock.calls[0][0]
     expect(launch.apiMode).toBe('chat_completions')
-    const config = readFileSync(join(home, 'coding-agent', 'model', 'default', 'fun-codex', 'codex', 'config.toml'), 'utf-8')
+    const config = readFileSync(join(result.rootDir, 'config.toml'), 'utf-8')
     const routeKey = config.match(/\/api\/codex-proxy\/([^/]+)\/v1/)?.[1] || ''
     expect(Buffer.from(routeKey, 'base64url').toString('utf8')).toContain('chat_completions')
     expect(updateSessionMock).toHaveBeenCalledWith('session-1', expect.objectContaining({

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -764,7 +764,7 @@ describe('coding agent launch preparation', () => {
     expect(config).toContain(`base_url = "http://127.0.0.1:8648/api/codex-proxy/`)
     expect(config).toMatch(/experimental_bearer_token = "hwui_[^"]+"/)
     expect(config).not.toContain('base_url = "https://api.openai.com/v1"')
-    expect(result.rootDir).toBe(join(home, 'coding-agent', 'model', 'default', 'openai-api', 'codex'))
+    expect(dirname(dirname(result.rootDir))).toBe(join(home, 'coding-agent', 'model', 'default', 'openai-api', 'codex'))
   })
 
   it('points Codex Anthropic Messages providers at the local Responses proxy', async () => {
@@ -1451,6 +1451,40 @@ describe('coding agent launch preparation', () => {
 
     expect(first.routeKey).not.toBe(second.routeKey)
     expect(first.token).not.toBe(second.token)
+  })
+
+  it('keeps hidden session runtime configs separate for the same agent, provider, and model', async () => {
+    makeHome()
+    const common = {
+      profile: 'default',
+      provider: 'same-provider',
+      model: 'same-model',
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'sk-upstream',
+      apiMode: 'codex_responses' as const,
+      isolateSettings: true,
+    }
+    const first = await prepareCodingAgentLaunch('claude-code', {
+      ...common,
+      sessionId: 'chat-one',
+      agentSessionId: 'agent-one',
+    })
+    const second = await prepareCodingAgentLaunch('claude-code', {
+      ...common,
+      sessionId: 'chat-two',
+      agentSessionId: 'agent-two',
+    })
+
+    expect(first.rootDir).not.toBe(second.rootDir)
+    const firstSettings = JSON.parse(readFileSync(join(first.rootDir, 'settings.json'), 'utf-8'))
+    const secondSettings = JSON.parse(readFileSync(join(second.rootDir, 'settings.json'), 'utf-8'))
+    const decodeTarget = (baseUrl: string) => JSON.parse(Buffer.from(
+      new URL(baseUrl).pathname.split('/').filter(Boolean).at(-1) || '',
+      'base64url',
+    ).toString('utf-8'))
+
+    expect(decodeTarget(firstSettings.env.ANTHROPIC_BASE_URL).slice(-2)).toEqual(['agent-one', 'chat-one'])
+    expect(decodeTarget(secondSettings.env.ANTHROPIC_BASE_URL).slice(-2)).toEqual(['agent-two', 'chat-two'])
   })
 
   it('keeps Codex proxy routes separate for the same model with different upstream URLs', () => {


### PR DESCRIPTION
## Summary

- isolate scoped Claude Code and Codex runtime configuration by chat session and hidden agent session
- prevent late Claude proxy events from reopening a completed run or appending another session's response
- add regression coverage for concurrent sessions using the same coding agent, provider, and model

## Root cause

The proxy target registry was session-aware, but generated runtime files such as Claude Code `settings.json` and Codex `config.toml` still shared a directory keyed only by profile, provider, and agent. Starting a second matching session overwrote the first session's local proxy route. A later turn could therefore be observed by both run states, leaving the wrong session stuck in a working state.

The fix creates a stable per-session runtime directory for both Claude Code and Codex while preserving the shared workspace and provider-level configuration inputs. It also drops late Claude proxy events after the print turn has already completed.

Fixes #2237

## Validation

- `npm run harness:check`
- `npm run test` — 3088 passed, 2 skipped
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `git diff --check`
