### PR TITLE
fix(workflow): keep Hermes capability preflight API mode agnostic

### DIFF
--- a/packages/server/src/services/workflow-import-capabilities.ts
+++ b/packages/server/src/services/workflow-import-capabilities.ts
@@ -29,13 +29,15 @@ export function assertWorkflowImportCapabilities(nodes: unknown[], groups: Capab
     const apiMode = typeof data.apiMode === 'string' ? data.apiMode.trim() : ''
     if (!provider && !model && !apiMode) continue
     const exact = `${provider}\u0000${model}\u0000${apiMode}`
+    const providerModel = `${provider}\u0000${model}`
+    const hermesTargetAvailable = agent === 'hermes' && configuredProviderModels.has(providerModel)
     const scopedCodingAgent = agent === 'codex' || agent === 'claude-code'
     const scopedCodingAgentProviderBlocked = scopedCodingAgent && isScopedCodingAgentAuthProvider(provider)
     const codingAgentTargetAvailable = scopedCodingAgent
       && !scopedCodingAgentProviderBlocked
       && SCOPED_CODING_AGENT_API_MODES.has(apiMode)
-      && configuredProviderModels.has(`${provider}\u0000${model}`)
-    if (scopedCodingAgentProviderBlocked || (!configured.has(exact) && !codingAgentTargetAvailable)) {
+      && configuredProviderModels.has(providerModel)
+    if (scopedCodingAgentProviderBlocked || (!configured.has(exact) && !hermesTargetAvailable && !codingAgentTargetAvailable)) {
       throw Object.assign(new Error(`workflow node ${String(node.id || '?')} target capability is unavailable in profile`), { status: 409 })
     }
   }

--- a/tests/server/workflow-import-capabilities.test.ts
+++ b/tests/server/workflow-import-capabilities.test.ts
@@ -5,13 +5,22 @@ import { assertWorkflowImportCapabilities, workflowImportEnvironmentRevision } f
 const node = (data: Record<string, unknown>) => ({ id: 'agent', type: 'agent', data: { agent: 'hermes', ...data } })
 
 describe('workflow import capabilities', () => {
-  it('requires an exact configured provider, model, and api mode tuple', () => {
+  it('validates Hermes targets by provider and model while leaving api mode profile-owned', () => {
     const groups = [{ provider: 'custom:test', models: ['model-a'], api_mode: 'codex_responses' }]
     expect(() => assertWorkflowImportCapabilities([node({ provider: 'custom:test', model: 'model-a', apiMode: 'codex_responses' })], groups)).not.toThrow()
     expect(() => assertWorkflowImportCapabilities([node({ provider: 'custom:test', model: 'model-b', apiMode: 'codex_responses' })], groups)).toThrow('unavailable')
-    expect(() => assertWorkflowImportCapabilities([node({ provider: 'custom:test', model: 'model-a', apiMode: 'chat_completions' })], groups)).toThrow('unavailable')
-    expect(() => assertWorkflowImportCapabilities([node({ provider: 'custom:test', model: 'model-a', apiMode: 'chat_completions' })], [{ provider: 'custom:test', models: ['model-a'] }])).toThrow('unavailable')
+    expect(() => assertWorkflowImportCapabilities([node({ provider: 'custom:test', model: 'model-a', apiMode: 'chat_completions' })], groups)).not.toThrow()
+    expect(() => assertWorkflowImportCapabilities([node({ provider: 'custom:test', model: 'model-a', apiMode: 'codex_responses' })], [{ provider: 'custom:test', models: ['model-a'] }])).not.toThrow()
   })
+
+  it.each(['openai-codex', 'xai-oauth'])(
+    'accepts Hermes provider %s when its catalog omits api mode',
+    (provider) => {
+      expect(() => assertWorkflowImportCapabilities([
+        node({ provider, model: 'model-a', apiMode: 'codex_responses' }),
+      ], [{ provider, models: ['model-a'] }])).not.toThrow()
+    },
+  )
 
   it('accepts scoped Coding Agent protocol overrides for a configured provider and model', () => {
     const groups = [{ provider: 'custom:test', models: ['model-a'], api_mode: 'chat_completions' }]


### PR DESCRIPTION
## Summary
- validate Hermes workflow targets by provider and model instead of requiring an exact provider/model/API-mode tuple
- keep scoped Codex and Claude Code protocol and OAuth-provider restrictions unchanged
- add regressions for `openai-codex` and `xai-oauth` catalog entries that omit `api_mode`

## Root cause
Hermes workflow execution intentionally leaves API-mode resolution to the Hermes provider profile, but the Studio workflow capability preflight still treated the UI-derived `apiMode` as an execution requirement. This rejected valid Hermes targets before they reached Hermes Agent.

## Impact
Hermes workflow nodes using `openai-codex` or `xai-oauth` can run when their provider/model is available even if the Studio capability catalog omits `api_mode`. Coding Agent workflow nodes retain Studio-owned protocol validation.

Fixes #2235

## Validation
- `npm run test -- tests/server/workflow-import-capabilities.test.ts tests/server/workflow-controller.test.ts tests/server/workflow-manager.test.ts` (153 tests passed)
- `npm run harness:check`
- `npm run build`