### PR TITLE
Fix Ekko browser launch on Windows

### DIFF
--- a/packages/ekko-agent/src/tools/browser.ts
+++ b/packages/ekko-agent/src/tools/browser.ts
@@ -10,6 +10,10 @@ type BrowserCommand = {
   args: string[]
 }
 
+type BrowserCommandExecution = BrowserCommand & {
+  windowsVerbatimArguments?: true
+}
+
 interface BrowserToolInput extends Record<string, unknown> {
   url?: string
   ref?: string
@@ -401,11 +405,13 @@ async function runBrowserCommand(
     const stderrPath = path.join(socketDir, `_stderr_${browserCommand}_${Date.now()}`)
     const stdoutFd = openSync(stdoutPath, 'w', 0o600)
     const stderrFd = openSync(stderrPath, 'w', 0o600)
-    const child = spawn(resolved.command, args, {
+    const execution = browserCommandExecution(resolved, args)
+    const child = spawn(execution.command, execution.args, {
       cwd,
       env,
       shell: false,
       windowsHide: true,
+      ...(execution.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
       stdio: ['ignore', stdoutFd, stderrFd],
     })
     closeSync(stdoutFd)
@@ -524,6 +530,51 @@ function resolveAgentBrowser(): BrowserCommand | null {
   if (fromPath) return { command: fromPath, args: [] }
 
   return null
+}
+
+const CMD_META_CHARS = /([()\][%!^"`<>&|;, *?])/g
+
+function browserCommandExecution(resolved: BrowserCommand, args: string[]): BrowserCommandExecution {
+  const command = process.platform === 'win32'
+    ? normalizeWindowsCommandPath(resolved.command)
+    : resolved.command
+  if (process.platform !== 'win32' || !windowsCommandNeedsShell(command)) {
+    return { command, args }
+  }
+
+  const shellCommand = [
+    escapeWindowsCmdCommand(command),
+    ...args.map(escapeWindowsCmdArgument),
+  ].join(' ')
+  return {
+    command: process.env.ComSpec || process.env.COMSPEC || process.env.comspec || 'cmd.exe',
+    args: ['/d', '/s', '/c', `"${shellCommand}"`],
+    windowsVerbatimArguments: true,
+  }
+}
+
+function normalizeWindowsCommandPath(command: string): string {
+  const trimmed = command.trim()
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+function windowsCommandNeedsShell(command: string): boolean {
+  const extension = path.extname(normalizeWindowsCommandPath(command)).toLowerCase()
+  return extension === '.cmd' || extension === '.bat'
+}
+
+function escapeWindowsCmdCommand(value: string): string {
+  return normalizeWindowsCommandPath(value).replace(CMD_META_CHARS, '^$1')
+}
+
+function escapeWindowsCmdArgument(value: string): string {
+  let escaped = String(value)
+  escaped = escaped.replace(/(?=(\\+?)?)\1"/g, '$1$1\\"')
+  escaped = escaped.replace(/(?=(\\+?)?)\1$/, '$1$1')
+  return `"${escaped}"`.replace(CMD_META_CHARS, '^$1')
 }
 
 function browserEnv(socketDir: string): NodeJS.ProcessEnv {

--- a/tests/ekko-agent/browser-tools.test.ts
+++ b/tests/ekko-agent/browser-tools.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../packages/ekko-agent/src/index'
 
 const mockedSpawn = vi.mocked(spawn)
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -21,7 +22,9 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform)
   delete process.env.AGENT_BROWSER_BIN
+  delete process.env.ComSpec
   delete process.env.OPENAI_API_KEY
 })
 
@@ -85,6 +88,36 @@ describe('ekko-agent browser tools', () => {
       ['--session', hashedSession('session:123'), '--json', 'snapshot', '-c'],
       expect.objectContaining({ shell: false }),
     )
+  })
+
+  it('runs the Windows agent-browser .cmd shim through cmd.exe', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe'
+    process.env.AGENT_BROWSER_BIN = 'C:\\Program Files\\Hermes Studio\\agent-browser.cmd'
+    mockBrowserSpawn({ success: true, data: { url: 'https://www.baidu.com/', title: 'Baidu' } })
+    mockBrowserSpawn({ success: true, data: { snapshot: 'link "News" [ref=@e1]', refs: { '@e1': {} } } })
+
+    const tool = createBrowserTools().find(item => item.definition.name === 'browser_navigate')
+    const result = await tool?.execute(
+      { url: 'https://www.baidu.com/?from=hermes&mode=agent' },
+      { sessionId: 'windows-browser', cwd: 'C:\\workspace' },
+    )
+
+    expect(result).toMatchObject({ ok: true })
+    expect(mockedSpawn).toHaveBeenCalledTimes(2)
+    for (const [command, args, options] of mockedSpawn.mock.calls) {
+      expect(command).toBe('C:\\Windows\\System32\\cmd.exe')
+      expect(args?.slice(0, 3)).toEqual(['/d', '/s', '/c'])
+      expect(args?.[3]).toContain('agent-browser.cmd')
+      expect(options).toEqual(expect.objectContaining({
+        cwd: 'C:\\workspace',
+        shell: false,
+        windowsHide: true,
+        windowsVerbatimArguments: true,
+      }))
+    }
+    expect(mockedSpawn.mock.calls[0]?.[1]?.[3]).toContain('https://www.baidu.com/')
+    expect(mockedSpawn.mock.calls[0]?.[1]?.[3]).toContain('^&mode=agent')
   })
 
   it('passes a sanitized browser environment to the CLI', async () => {


### PR DESCRIPTION
## Summary

- Run Windows `agent-browser` `.cmd` and `.bat` shims explicitly through `cmd.exe`.
- Preserve direct spawn behavior for native executables and non-Windows platforms.
- Escape command paths and browser arguments before passing them through the Windows shell.
- Add a regression test covering paths with spaces and URLs containing `&`.

## Why

Ekko Agent’s built-in `browser_navigate` resolved `agent-browser.cmd` on Windows but attempted to execute it directly with `spawn(..., { shell: false })`. Windows cannot launch command shims this way, so every browser command failed before navigation with `spawn EINVAL`.

## Impact

Built-in browser tools can now start on Windows without changing behavior on macOS or Linux. Argument escaping prevents URL shell metacharacters from being interpreted as commands.

## Validation

- `npx vitest run tests/ekko-agent/browser-tools.test.ts tests/ekko-agent/tools.test.ts` — 17 passed
- `npm --prefix packages/ekko-agent run check`
- `npm run build`
- `git diff --check`
