### PR TITLE
[desktop] set minimum window width to 769px

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -465,7 +465,7 @@ async function createWindow(): Promise<void> {
   mainWindow = new BrowserWindow({
     width: 1280,
     height: 820,
-    minWidth: 960,
+    minWidth: 769,
     minHeight: 600,
     title: 'Hermes Studio',
     backgroundColor: '#1a1a1a',

--- a/tests/desktop/windows-main-window.test.ts
+++ b/tests/desktop/windows-main-window.test.ts
@@ -3,6 +3,14 @@ import { resolve } from 'path'
 import { describe, expect, it } from 'vitest'
 
 describe('Windows desktop main window', () => {
+  it('keeps the main window just above the mobile breakpoint', () => {
+    const source = readFileSync(resolve('packages/desktop/src/main/index.ts'), 'utf8')
+    const createWindowBody = source.match(/async function createWindow\(\): Promise<void> \{([\s\S]*?)\n\}/)?.[1] || ''
+
+    expect(createWindowBody).toContain('minWidth: 769')
+    expect(createWindowBody).toContain('minHeight: 600')
+  })
+
   it('keeps the main BrowserWindow opaque to avoid transparent compositor black screens', () => {
     const source = readFileSync(resolve('packages/desktop/src/main/index.ts'), 'utf8')
     const createWindowBody = source.match(/async function createWindow\(\): Promise<void> \{([\s\S]*?)\n\}/)?.[1] || ''


### PR DESCRIPTION
## Summary
- reduce the desktop main window minimum width from 960px to 769px
- keep the minimum width just above the existing 768px mobile breakpoint
- add focused regression coverage for the window constraints

## Impact
The desktop window can be resized more narrowly without entering the mobile layout. No client layout styles or standalone chat window constraints are changed.

## Validation
- `npm run harness:check`
- `npm run test -- tests/desktop/windows-main-window.test.ts tests/desktop/chat-window.test.ts`
- `npm --prefix packages/desktop run build`
