### PR TITLE
[codex] attach all agent workspace diffs to assistant messages

### DIFF
--- a/docs/chat-chain-changes/2026-07-29-hide-standalone-workspace-diffs.md
+++ b/docs/chat-chain-changes/2026-07-29-hide-standalone-workspace-diffs.md
@@ -1,0 +1,17 @@
+---
+date: 2026-07-29
+pr: pending
+feature: Assistant-only workspace diff rendering
+impact: Single-chat and group-chat file diffs never render as standalone cards.
+---
+
+Workspace diff projection now has one rule across restored history, pagination,
+and realtime updates: a diff is visible only when its persisted Assistant
+message ID resolves to an Assistant message currently loaded in the client.
+
+Single chat no longer creates synthetic `workspace-run-change:*` messages or
+attaches workspace changes to tool messages. Group chat continues to persist
+`workspace_diff` audit messages, but always removes those raw tool messages from
+the visible projection; an exact `parent_message_id` match moves the payload
+under the Assistant response, while missing or not-yet-loaded parents keep it
+hidden until a later projection can resolve the association.

--- a/docs/chat-chain-changes/2026-07-29-hide-standalone-workspace-diffs.md
+++ b/docs/chat-chain-changes/2026-07-29-hide-standalone-workspace-diffs.md
@@ -15,3 +15,9 @@ attaches workspace changes to tool messages. Group chat continues to persist
 the visible projection; an exact `parent_message_id` match moves the payload
 under the Assistant response, while missing or not-yet-loaded parents keep it
 hidden until a later projection can resolve the association.
+
+The built-in Ekko Agent now uses the same workspace checkpoint lifecycle as
+the Codex and Claude Code agents. It starts tracking from the runtime's
+`run.started` ID, persists changes on completion, failure, or abort, and binds
+successful changes to the exact persisted Assistant message ID before emitting
+the realtime and terminal run payloads.

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -594,9 +594,7 @@ const hasAttachments = computed(
 
 const toolArgsPayload = computed(() => formatToolPayload(props.message.toolArgs));
 const toolResultPayload = computed(() => formatToolPayload(props.message.toolResult, true));
-const toolChange = computed(() => props.message.toolChange || null);
 const workspaceChanges = computed(() => props.message.workspaceChanges || []);
-const hasToolChange = computed(() => (toolChange.value?.files?.length || 0) > 0);
 
 function isWorkspaceChangeExpanded(changeId: string): boolean {
   return expandedWorkspaceChangeIds.value.has(changeId);
@@ -610,7 +608,7 @@ function toggleWorkspaceChange(changeId: string): void {
 }
 
 const hasToolDetails = computed(
-  () => !!(toolArgsPayload.value.full || toolResultPayload.value.full || hasToolChange.value),
+  () => !!(toolArgsPayload.value.full || toolResultPayload.value.full),
 );
 const isSubagentTool = computed(() => subagentIdFromToolCall(props.message.toolCallId) !== null);
 const hasInlineToolDetails = computed(() => hasToolDetails.value && !isSubagentTool.value);
@@ -642,14 +640,6 @@ function handleToolLineClick() {
     return;
   }
   if (hasInlineToolDetails.value) toolExpanded.value = !toolExpanded.value;
-}
-
-async function openToolChangeFile(file: { id: string | number; path: string; additions: number; deletions: number }): Promise<void> {
-  const storedFile = toolChange.value?.files.find(candidate => String(candidate.id) === String(file.id));
-  if (!storedFile) return;
-  selectedToolChangeFileId.value = storedFile.id;
-  filesStore.closePreview();
-  await toolPanelStore.openWorkspaceDiff(storedFile, toolChange.value?.workspace || "");
 }
 
 async function openAssistantWorkspaceChangeFile(
@@ -882,12 +872,11 @@ onBeforeUnmount(() => {
 <template>
   <div
     class="message"
-    :class="[message.role, { highlight, 'tool-change-message': hasToolChange }]"
+    :class="[message.role, { highlight }]"
     :id="`message-${message.id}`"
   >
     <template v-if="message.role === 'tool'">
       <div
-        v-if="!hasToolChange"
         class="tool-line"
         :class="{ expandable: hasInlineToolDetails || isSubagentTool, 'subagent-entry': isSubagentTool }"
         :role="isSubagentTool ? 'button' : undefined"
@@ -938,23 +927,7 @@ onBeforeUnmount(() => {
           t("chat.error")
         }}</span>
       </div>
-      <div
-        v-if="hasToolChange"
-        class="tool-detail-section tool-change-standalone"
-        @click="handleToolDetailClick"
-      >
-        <ToolChangeCard
-          :files="toolChange?.files || []"
-          :files-changed="toolChange?.files_changed || 0"
-          :additions="toolChange?.additions || 0"
-          :deletions="toolChange?.deletions || 0"
-          :expanded="toolExpanded"
-          :selected-file-id="selectedToolChangeFileId"
-          @toggle="toolExpanded = !toolExpanded"
-          @select="openToolChangeFile"
-        />
-      </div>
-      <div v-else-if="!isSubagentTool && toolExpanded && hasToolDetails" class="tool-details" @click="handleToolDetailClick">
+      <div v-if="!isSubagentTool && toolExpanded && hasToolDetails" class="tool-details" @click="handleToolDetailClick">
         <div v-if="formattedToolArgs" class="tool-detail-section" data-copy-source="tool-args">
           <div class="tool-detail-label">{{ t("chat.arguments") }}</div>
           <div class="tool-detail-code-block" v-html="renderedToolArgs"></div>
@@ -1295,10 +1268,6 @@ onBeforeUnmount(() => {
 
   &.tool {
     align-items: flex-start;
-
-    &.tool-change-message {
-      max-width: 100%;
-    }
   }
 
   &.system {
@@ -1811,13 +1780,6 @@ onBeforeUnmount(() => {
   margin-bottom: 6px;
 }
 
-.tool-change-standalone {
-  display: inline-block;
-  max-width: 100%;
-  min-width: 0;
-  width: fit-content;
-}
-
 .tool-detail-label {
   font-size: 10px;
   font-weight: 600;
@@ -1947,11 +1909,6 @@ onBeforeUnmount(() => {
 
   .message.system .msg-body {
     max-width: 100%;
-  }
-
-  .tool-change-standalone {
-    min-width: 0;
-    width: fit-content;
   }
 
   :global(.tool-change-drawer-header) {

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -209,22 +209,6 @@ const quotableContent = computed(() => {
 const toolExpanded = ref(false)
 const expandedWorkspaceChangeIds = ref(new Set<string>())
 const isToolMessage = computed(() => props.message.role === 'tool')
-const workspaceDiffPayload = computed(() => {
-    if ((props.message.toolName || props.message.tool_name) !== 'workspace_diff') return null
-    const raw = props.message.toolResult ?? props.message.content
-    if (!raw) return null
-    if (typeof raw === 'object' && (raw as any)?.kind === 'workspace_diff') return raw as any
-    if (typeof raw === 'string') {
-        try {
-            const parsed = JSON.parse(raw)
-            return parsed?.kind === 'workspace_diff' ? parsed : null
-        } catch {
-            return null
-        }
-    }
-    return null
-})
-const workspaceDiffFiles = computed(() => Array.isArray(workspaceDiffPayload.value?.files) ? workspaceDiffPayload.value.files : [])
 const assistantWorkspaceChanges = computed(() => props.message.workspaceChanges || [])
 const selectedWorkspaceDiffFileId = computed(() => toolPanelStore.workspaceDiff?.file.id ?? null)
 const toolArgsPayload = computed(() => formatToolPayload(props.message.toolArgs))
@@ -260,9 +244,6 @@ function openWorkspaceDiffFileForPayload(file: GroupWorkspaceDiffFile, payload: 
     }, typeof file.patch === 'string' ? file.patch : null, payload.workspace || payload.workspace_root || '')
 }
 
-function openWorkspaceDiffFile(file: GroupWorkspaceDiffFile): void {
-    openWorkspaceDiffFileForPayload(file, workspaceDiffPayload.value)
-}
 const canPlaySpeech = computed(() => {
     if (props.message.role !== 'assistant') return false
     if (!assistantBody.value.trim()) return false
@@ -612,19 +593,7 @@ onBeforeUnmount(() => {
                 <span class="sender-name">{{ message.senderName }}</span>
                 <span v-if="isAgent && agentInfo?.description" class="agent-desc">{{ agentInfo.description }}</span>
             </div>
-            <div v-if="workspaceDiffPayload" class="tool-detail-section tool-change-standalone">
-                <ToolChangeCard
-                    :files="workspaceDiffFiles"
-                    :files-changed="workspaceDiffPayload.files_changed || 0"
-                    :additions="workspaceDiffPayload.additions || 0"
-                    :deletions="workspaceDiffPayload.deletions || 0"
-                    :expanded="toolExpanded"
-                    :selected-file-id="selectedWorkspaceDiffFileId"
-                    @toggle="toolExpanded = !toolExpanded"
-                    @select="openWorkspaceDiffFile"
-                />
-            </div>
-            <div v-else class="tool-line" :class="{ expandable: hasToolDetails }" @click="hasToolDetails && (toolExpanded = !toolExpanded)">
+            <div class="tool-line" :class="{ expandable: hasToolDetails }" @click="hasToolDetails && (toolExpanded = !toolExpanded)">
                 <svg
                     v-if="hasToolDetails"
                     width="10"
@@ -646,7 +615,7 @@ onBeforeUnmount(() => {
                 <span v-if="message.toolStatus === 'running'" class="tool-spinner"></span>
                 <span v-if="message.toolStatus === 'error'" class="tool-error-badge">{{ t('chat.error') }}</span>
             </div>
-            <div v-if="!workspaceDiffPayload && toolExpanded && hasToolDetails" class="tool-details" @click="handleToolDetailClick">
+            <div v-if="toolExpanded && hasToolDetails" class="tool-details" @click="handleToolDetailClick">
                 <div v-if="formattedToolArgs" class="tool-detail-section" data-copy-source="tool-args">
                     <div class="tool-detail-label">{{ t('chat.arguments') }}</div>
                     <div class="tool-detail-code-block" v-html="renderedToolArgs"></div>
@@ -917,13 +886,6 @@ onBeforeUnmount(() => {
     margin-top: 2px;
     border-left: 2px solid $border-light;
     padding-left: 10px;
-}
-
-.tool-change-standalone {
-    display: inline-block;
-    max-width: 100%;
-    min-width: 0;
-    width: fit-content;
 }
 
 .assistant-workspace-change {

--- a/packages/client/src/components/hermes/group-chat/GroupMessageList.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageList.vue
@@ -14,9 +14,7 @@ const showScrollBottomButton = ref(false)
 const displayMessages = computed(() => store.sortedMessages.filter(msg =>
     msg.role !== 'tool' ||
     toolTraceVisible.value ||
-    msg.toolStatus === 'running' ||
-    msg.toolName === 'workspace_diff' ||
-    msg.tool_name === 'workspace_diff',
+    msg.toolStatus === 'running',
 ))
 const listPadding = computed(() => store.activePendingApproval ? '16px 20px 260px' : '16px 20px')
 let pendingInitialBottomRoomId: string | null = store.currentRoomId

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -20,7 +20,7 @@ export type ContentBlock = ContentBlockImport
 
 export const LIVE_CHAT_MESSAGE_PAGE_SIZE = 150
 export const LIVE_CHAT_MAX_LOADED_MESSAGES = 300
-const WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX = 'workspace-run-change:'
+const LEGACY_WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX = 'workspace-run-change:'
 type ChatAgentId = 'hermes' | 'claude' | 'codex' | 'ekko-agent'
 
 function agentToCodingAgentId(agent?: string): ChatCodingAgentId | undefined {
@@ -71,7 +71,6 @@ export interface Message {
   toolResult?: unknown
   toolStatus?: 'running' | 'done' | 'error'
   toolDuration?: number  // 工具执行时长（秒）
-  toolChange?: WorkspaceRunChangeSummary
   workspaceChanges?: WorkspaceRunChangeSummary[]
   isStreaming?: boolean
   attachments?: Attachment[]
@@ -449,22 +448,19 @@ export function alignWorkspaceChangeAssistantMessage(
 export function attachWorkspaceChangesToExactTurns(
   messages: Message[],
   changes: WorkspaceRunChangeSummary[],
-): WorkspaceRunChangeSummary[] {
+): void {
   for (const message of messages) message.workspaceChanges = []
   const assistantById = new Map(
     messages
       .filter(message => message.role === 'assistant')
       .map(message => [message.id, message]),
   )
-  const fallback: WorkspaceRunChangeSummary[] = []
   for (const change of changes) {
     const assistantMessageId = String(change.assistant_message_id || '').trim()
     if (!assistantMessageId) continue
     const target = assistantMessageId ? assistantById.get(assistantMessageId) : undefined
     if (target) target.workspaceChanges!.push(change)
-    else fallback.push(change)
   }
-  return fallback
 }
 
 function isToolOutputError(output: unknown): boolean {
@@ -1391,92 +1387,30 @@ export const useChatStore = defineStore('chat', () => {
     removeItem(storageKey())
   }
 
-  function attachToolChangesToMessages(sessionId: string) {
+  function attachWorkspaceChangesToMessages(sessionId: string) {
     const target = sessions.value.find(session => session.id === sessionId)
     if (!target) return
     const changes = workspaceRunChangesBySession.value.get(sessionId)
-    const existingById = new Map(
-      target.messages
-        .filter(message => message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX))
-        .map(message => [message.id, message]),
+    target.messages = target.messages.filter(
+      message => !message.id.startsWith(LEGACY_WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX),
     )
-    target.messages = target.messages.filter(message => !message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX))
-    for (const message of target.messages) {
-      if (message.role === 'tool' && message.toolCallId) {
-        const change = changes?.get(message.toolCallId)
-        message.toolChange = String(change?.assistant_message_id || '').trim() ? change : undefined
-      }
-    }
     if (!changes) {
       for (const message of target.messages) message.workspaceChanges = []
       return
     }
     const runChanges = [...changes.values()].filter(change => change?.source === 'run')
-    const unresolvedAttributedChanges = attachWorkspaceChangesToExactTurns(target.messages, runChanges)
-    insertWorkspaceRunChangeMessages(target, unresolvedAttributedChanges, existingById)
-  }
-
-  function workspaceRunChangeMessageId(changeId: string): string {
-    return `${WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX}${changeId}`
-  }
-
-  function workspaceRunChangeTimestamp(change: WorkspaceRunChangeSummary): number {
-    const seconds = Number(change.finished_at || change.created_at || change.started_at || 0)
-    return Number.isFinite(seconds) && seconds > 0 ? Math.round(seconds * 1000) : Date.now()
-  }
-
-  function insertWorkspaceRunChangeMessages(
-    target: Session,
-    changes: WorkspaceRunChangeSummary[],
-    existingById = new Map<string, Message>(),
-  ) {
-    const sortedChanges = changes
-      .filter(change => change?.change_id && (change.files?.length > 0))
-      .sort((a, b) => {
-        const timeDelta = workspaceRunChangeTimestamp(b) - workspaceRunChangeTimestamp(a)
-        return timeDelta !== 0 ? timeDelta : b.change_id.localeCompare(a.change_id)
-      })
-    if (!sortedChanges.length) return
-    for (const change of sortedChanges) {
-      const messageId = workspaceRunChangeMessageId(change.change_id)
-      const existing = existingById.get(messageId) || null
-      const timestamp = workspaceRunChangeTimestamp(change)
-      const insertAfter = findWorkspaceRunChangeAnchorIndex(target.messages, timestamp)
-      const message: Message = existing || {
-        id: messageId,
-        role: 'tool',
-        content: '',
-        timestamp,
-        toolName: 'workspace',
-        toolStatus: 'done',
-      }
-      message.timestamp = timestamp
-      message.toolChange = change
-      target.messages.splice(insertAfter + 1, 0, message)
-    }
-  }
-
-  function findWorkspaceRunChangeAnchorIndex(messages: Message[], timestamp: number): number {
-    for (let i = messages.length - 1; i >= 0; i -= 1) {
-      const message = messages[i]
-      if (message.id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX)) continue
-      if (message.role === 'assistant' && message.timestamp <= timestamp + 1000) return i
-    }
-    for (let i = messages.length - 1; i >= 0; i -= 1) {
-      if (!messages[i].id.startsWith(WORKSPACE_RUN_CHANGE_MESSAGE_PREFIX)) return i
-    }
-    return messages.length - 1
+    attachWorkspaceChangesToExactTurns(target.messages, runChanges)
   }
 
   function setWorkspaceRunChanges(sessionId: string, changes: WorkspaceRunChangeSummary[]) {
     const next = new Map(workspaceRunChangesBySession.value)
-    const byToolCallId = new Map<string, WorkspaceRunChangeSummary>()
+    const byChangeId = new Map<string, WorkspaceRunChangeSummary>()
     for (const change of changes) {
-      if (change?.change_id) byToolCallId.set(change.change_id, change)
+      if (change?.change_id) byChangeId.set(change.change_id, change)
     }
-    next.set(sessionId, byToolCallId)
+    next.set(sessionId, byChangeId)
     workspaceRunChangesBySession.value = next
-    attachToolChangesToMessages(sessionId)
+    attachWorkspaceChangesToMessages(sessionId)
   }
 
   function upsertWorkspaceRunChange(sessionId: string, change: WorkspaceRunChangeSummary | null | undefined) {
@@ -1486,7 +1420,7 @@ export const useChatStore = defineStore('chat', () => {
     current.set(change.change_id, change)
     next.set(sessionId, current)
     workspaceRunChangesBySession.value = next
-    attachToolChangesToMessages(sessionId)
+    attachWorkspaceChangesToMessages(sessionId)
   }
 
   function handleWorkspaceRunChangeEvent(
@@ -1515,7 +1449,7 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   function restoreWorkspaceRunChangeMessages(sessionId: string) {
-    attachToolChangesToMessages(sessionId)
+    attachWorkspaceChangesToMessages(sessionId)
     if (workspaceRunChangesBySession.value.has(sessionId) || workspaceRunChangeLoadRequests.has(sessionId)) return
     workspaceRunChangeLoadRequests.add(sessionId)
     void loadWorkspaceRunChangesForSession(sessionId)
@@ -2047,7 +1981,7 @@ export const useChatStore = defineStore('chat', () => {
       const olderMessages = mapHermesMessages(page.messages).filter(message => !existingIds.has(message.id))
       target.messages = [...olderMessages, ...target.messages]
       restorePersistedSubagentStreams(sessionId)
-      attachToolChangesToMessages(sessionId)
+      attachWorkspaceChangesToMessages(sessionId)
       target.loadedMessageCount = offset + page.messages.length
       target.messageTotal = page.total
       target.messageCount = page.total
@@ -3901,7 +3835,7 @@ export const useChatStore = defineStore('chat', () => {
                 .find(message => message.role === 'assistant' && String(message.content || '').trim())
                 ?.id
               handleTerminalWorkspaceRunChange(sid, evt, terminalAssistantMessageId)
-              attachToolChangesToMessages(sid)
+              attachWorkspaceChangesToMessages(sid)
 
               // 自动播放语音
               if (autoPlaySpeechEnabled.value && runProducedAssistantContent) {
@@ -4424,7 +4358,7 @@ export const useChatStore = defineStore('chat', () => {
         }
 
         case 'workspace.diff.completed': {
-          handleWorkspaceRunChangeEvent(sid, evt)
+          activeAssistantMessageId = handleWorkspaceRunChangeEvent(sid, evt, activeAssistantMessageId)
           break
         }
 
@@ -4461,7 +4395,6 @@ export const useChatStore = defineStore('chat', () => {
         }
 
         case 'run.completed': {
-          handleTerminalWorkspaceRunChange(sid, evt)
           clearAgentEventMessages(sid)
           const hasQueue = (evt as any).queue_remaining > 0
           const hasBackground = (evt.background_pending || 0) > 0
@@ -4563,7 +4496,12 @@ export const useChatStore = defineStore('chat', () => {
             playCompletionBellIfEnabled()
             showCompletionNotificationIfEnabled(sid, completedAssistantMessageId)
           }
-          attachToolChangesToMessages(sid)
+          const terminalAssistantMessageId = completedAssistantMessageId || [...getSessionMsgs(sid)]
+            .reverse()
+            .find(message => message.role === 'assistant' && String(message.content || '').trim())
+            ?.id
+          handleTerminalWorkspaceRunChange(sid, evt, terminalAssistantMessageId)
+          attachWorkspaceChangesToMessages(sid)
 
           // Auto-play speech for every completed assistant message
           if (autoPlaySpeechEnabled.value && runProducedAssistantContent) {
@@ -4600,7 +4538,11 @@ export const useChatStore = defineStore('chat', () => {
         }
 
         case 'run.failed': {
-          handleTerminalWorkspaceRunChange(sid, evt)
+          const failedMessages = getSessionMsgs(sid)
+          const failedAssistant = activeAssistantMessageId
+            ? failedMessages.find(message => message.id === activeAssistantMessageId)
+            : [...failedMessages].reverse().find(message => message.role === 'assistant' && message.isStreaming)
+          handleTerminalWorkspaceRunChange(sid, evt, failedAssistant?.id)
           clearAgentEventMessages(sid)
           if ((evt as any).inputTokens != null) {
             const target = sessions.value.find(s => s.id === sid)

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -1078,8 +1078,7 @@ function attachWorkspaceDiffsToParentMessages(messages: ChatMessage[]): ChatMess
         const payload = groupWorkspaceDiffPayload(message.toolResult ?? message.content)
         const parentMessageId = String(payload?.parent_message_id || '').trim()
         const parent = parentMessageId ? assistantById.get(parentMessageId) : undefined
-        if (!payload || !parent) return true
-        parent.workspaceChanges!.push(payload)
+        if (payload && parent) parent.workspaceChanges!.push(payload)
         return false
     })
 }

--- a/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
@@ -39,6 +39,7 @@ import { buildCompressedHistory, getOrCreateSession } from './compression'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
 import { estimateUsageTokensFromMessages } from './usage'
 import type { ChatCodingAgentId, ContentBlock, QueuedRun, SessionState } from './types'
+import { completeWorkspaceRunCheckpoint, startWorkspaceRunCheckpoint } from './workspace-diff-tracker'
 
 export interface EkkoAgentRunSocketData {
   input: string | ContentBlock[]
@@ -535,7 +536,10 @@ export async function handleEkkoAgentRun(
 
   let assistantText = ''
   let assistantReasoning = ''
+  let assistantMessageId: string | null = null
   let runId = ''
+  let workspaceDiffRunId = ''
+  let workspaceDiffCompleted = false
   let usageInput = 0
   let usageOutput = 0
   let usageCallIndex = 0
@@ -548,6 +552,42 @@ export async function handleEkkoAgentRun(
   const streamedSubagentOutput = new Map<string, string>()
   const scheduledBackgroundContinuations = new Set<string>()
   const pendingBackgroundDisplayContent = new Map<string, string>()
+  const startWorkspaceRunDiff = (eventRunId: string) => {
+    if (workspaceDiffRunId) return
+    workspaceDiffRunId = eventRunId
+    try {
+      startWorkspaceRunCheckpoint({
+        sessionId,
+        runId: eventRunId,
+        workspace,
+      })
+    } catch (err) {
+      logger.warn({ err, sessionId, runId: eventRunId }, '[workspace-diff] failed to start ekko-agent run checkpoint')
+    }
+  }
+  const completeWorkspaceRunDiff = () => {
+    if (workspaceDiffCompleted || !workspaceDiffRunId) return null
+    workspaceDiffCompleted = true
+    try {
+      const change = completeWorkspaceRunCheckpoint({
+        sessionId,
+        runId: workspaceDiffRunId,
+        workspace,
+        assistantMessageId,
+      })
+      if (!change) return null
+      emit('workspace.diff.completed', {
+        event: 'workspace.diff.completed',
+        run_id: workspaceDiffRunId,
+        change_id: change.change_id,
+        change,
+      })
+      return change
+    } catch (err) {
+      logger.warn({ err, sessionId, runId: workspaceDiffRunId }, '[workspace-diff] failed to complete ekko-agent run checkpoint')
+      return null
+    }
+  }
   const appendSubagentOutput = (subagentId: string, text: string) => {
     const previous = streamedSubagentOutput.get(subagentId) || ''
     const next = text.startsWith(previous) ? text : `${previous}${text}`
@@ -702,6 +742,7 @@ export async function handleEkkoAgentRun(
     ]
     try {
       const ids = addMessages(rows)
+      if (ids[0] != null) assistantMessageId = String(ids[0])
       rows.forEach((row, index) => {
         state.messages.push({
           id: ids[index] || state.messages.length + 1,
@@ -919,6 +960,7 @@ export async function handleEkkoAgentRun(
     if ('runId' in event) runId = event.runId
     logRuntimeEvent(event)
     if (event.type === 'run.started') {
+      startWorkspaceRunDiff(event.runId)
       state.runId = event.runId
       emit('run.started', {
         event: 'run.started',
@@ -1376,6 +1418,7 @@ export async function handleEkkoAgentRun(
           reasoning: step.message.reasoning || null,
           reasoning_content: step.message.reasoning || null,
         })
+        if (assistantId != null) assistantMessageId = String(assistantId)
         state.messages.push({
           id: assistantId || state.messages.length + 1,
           session_id: sessionId,
@@ -1440,6 +1483,7 @@ export async function handleEkkoAgentRun(
         queue_id: data.queue_id,
         autonomous: data.autonomous === true,
         delegation_id: data.background_delegation_id,
+        workspace_run_change: completeWorkspaceRunDiff(),
       })
       return
     }
@@ -1453,6 +1497,7 @@ export async function handleEkkoAgentRun(
         reasoning: assistantReasoning || null,
         reasoning_content: assistantReasoning || null,
       })
+      if (assistantId != null) assistantMessageId = String(assistantId)
       state.messages.push({
         id: assistantId || state.messages.length + 1,
         session_id: sessionId,
@@ -1496,6 +1541,7 @@ export async function handleEkkoAgentRun(
       contextTokens: contextEstimate?.contextTokens ?? state.contextTokens,
       context_tokens: contextEstimate?.contextTokens ?? state.contextTokens,
     })
+    const workspaceRunChange = completeWorkspaceRunDiff()
     emit('run.completed', {
       event: 'run.completed',
       run_id: runId || result.runId,
@@ -1514,6 +1560,7 @@ export async function handleEkkoAgentRun(
       queue_id: data.queue_id,
       autonomous: data.autonomous === true,
       delegation_id: data.background_delegation_id,
+      workspace_run_change: workspaceRunChange,
     })
     writeRunLog('run', 'run.persisted', {
       inputTokens: usageInput,
@@ -1527,6 +1574,7 @@ export async function handleEkkoAgentRun(
         error: err instanceof Error ? err.message : String(err),
       }, 'warn')
       logger.info('[chat-run-socket] ekko-agent run aborted for session %s', sessionId)
+      completeWorkspaceRunDiff()
       return
     }
     const error = err instanceof Error ? err.message : String(err)
@@ -1551,6 +1599,7 @@ export async function handleEkkoAgentRun(
       queue_id: data.queue_id,
       autonomous: data.autonomous === true,
       delegation_id: data.background_delegation_id,
+      workspace_run_change: completeWorkspaceRunDiff(),
     })
   } finally {
     writeRunLog('run', 'run.released', {

--- a/tests/client/chat-store-workspace-diff-turn.test.ts
+++ b/tests/client/chat-store-workspace-diff-turn.test.ts
@@ -122,8 +122,8 @@ describe('chat workspace diff turn association', () => {
     const store = useChatStore()
     await store.loadSessions()
 
-    expect(store.activeSession?.messages.find(message => message.toolCallId === 'tool-change')?.toolChange)
-      .toBeUndefined()
+    expect(store.activeSession?.messages.find(message => message.toolCallId === 'tool-change')).toBeDefined()
+    expect(store.activeSession?.messages.some(message => message.id.startsWith('workspace-run-change:'))).toBe(false)
   })
 
   it('does not render a standalone fallback for legacy changes without an assistant message id', async () => {
@@ -139,6 +139,19 @@ describe('chat workspace diff turn association', () => {
     expect(legacy).toEqual([])
   })
 
+  it('does not render a standalone card when an attributed assistant is not loaded', async () => {
+    sessionApi.fetchWorkspaceRunChangesForSession.mockResolvedValue([
+      change('unresolved-change', 'missing-assistant'),
+    ])
+
+    const store = useChatStore()
+    await store.loadSessions()
+
+    expect(store.activeSession?.messages).toHaveLength(4)
+    expect(store.activeSession?.messages.some(message => message.id.startsWith('workspace-run-change:'))).toBe(false)
+    expect(store.activeSession?.messages.every(message => (message.workspaceChanges?.length || 0) === 0)).toBe(true)
+  })
+
   it('aligns a live assistant temporary id with the persisted attribution id', () => {
     const messages = [{
       id: 'temporary-assistant',
@@ -151,41 +164,42 @@ describe('chat workspace diff turn association', () => {
 
     expect(alignWorkspaceChangeAssistantMessage(messages, attributedChange, 'temporary-assistant')).toBe('42')
     expect(messages[0].id).toBe('42')
-    expect(attachWorkspaceChangesToExactTurns(messages, [attributedChange])).toEqual([])
+    attachWorkspaceChangesToExactTurns(messages, [attributedChange])
     expect(messages[0].workspaceChanges?.map(item => item.change_id)).toEqual(['change-live'])
   })
 
-  it('moves an unresolved explicit association from fallback to the assistant after pagination loads it', () => {
+  it('hides an unresolved explicit association until pagination loads its assistant', () => {
     const unresolved = change('change-page-1', '2')
     const messages = [
       { id: '4', role: 'assistant' as const, content: 'newer', timestamp: 4 },
     ]
 
-    expect(attachWorkspaceChangesToExactTurns(messages, [unresolved])).toEqual([unresolved])
+    attachWorkspaceChangesToExactTurns(messages, [unresolved])
+    expect(messages).toHaveLength(1)
+    expect(messages[0].workspaceChanges).toEqual([])
 
     messages.unshift({ id: '2', role: 'assistant', content: 'older', timestamp: 2 })
-    expect(attachWorkspaceChangesToExactTurns(messages, [unresolved])).toEqual([])
+    attachWorkspaceChangesToExactTurns(messages, [unresolved])
     expect(messages[0].workspaceChanges?.map(item => item.change_id)).toEqual(['change-page-1'])
   })
 
-  it('drops unattributed changes instead of returning them as standalone fallbacks', () => {
+  it('drops unattributed changes without creating standalone messages', () => {
     const messages = [
       { id: '4', role: 'assistant' as const, content: 'newer', timestamp: 4 },
     ]
 
-    expect(attachWorkspaceChangesToExactTurns(messages, [change('legacy-change')])).toEqual([])
+    attachWorkspaceChangesToExactTurns(messages, [change('legacy-change')])
+    expect(messages).toHaveLength(1)
     expect(messages[0].workspaceChanges).toEqual([])
   })
 
-  it('does not overwrite existing tool-message change metadata while recomputing turn associations', () => {
-    const existing = change('tool-change')
+  it('never attaches workspace changes to tool messages', () => {
     const messages = [{
-      id: 'tool-1', role: 'tool' as const, content: '', timestamp: 1, toolChange: existing,
+      id: 'tool-1', role: 'tool' as const, content: '', timestamp: 1,
     }]
 
-    attachWorkspaceChangesToExactTurns(messages, [change('turn-change', '42')])
+    attachWorkspaceChangesToExactTurns(messages, [change('turn-change', 'tool-1')])
 
-    expect(messages[0].toolChange).toBe(existing)
     expect(messages[0].workspaceChanges).toEqual([])
   })
 })

--- a/tests/client/group-chat-workspace-diff.test.ts
+++ b/tests/client/group-chat-workspace-diff.test.ts
@@ -126,7 +126,7 @@ describe('group chat workspace diff client rendering', () => {
     })
   })
 
-  it('maps persisted workspace_diff tool JSON to a structured tool result', async () => {
+  it('hides persisted workspace_diff messages without an assistant association', async () => {
     groupChatApiMock.getRoomDetail.mockResolvedValue({
       room: { id: 'room-1', name: 'Room 1', inviteCode: null, workspace: '/tmp/repo' },
       messages: [workspaceDiffMessage()],
@@ -138,11 +138,7 @@ describe('group chat workspace diff client rendering', () => {
 
     await store.joinRoom('room-1')
 
-    expect(store.sortedMessages[0]).toMatchObject({
-      role: 'tool',
-      toolName: 'workspace_diff',
-      toolResult: expect.objectContaining({ kind: 'workspace_diff', files_changed: 2 }),
-    })
+    expect(store.sortedMessages).toEqual([])
   })
 
   it('attaches persisted and realtime workspace diffs to their exact assistant message', async () => {
@@ -195,50 +191,34 @@ describe('group chat workspace diff client rendering', () => {
     })
 
     expect(wrapper.find('.tool-message').exists()).toBe(false)
-    expect(wrapper.find('.assistant-workspace-change').exists()).toBe(true)
+    expect(wrapper.find('.msg-content .assistant-workspace-change').exists()).toBe(true)
     expect(wrapper.text()).toContain('chat.changesThisTurn')
 
     await wrapper.find('.tool-change-card-header').trigger('click')
     expect(wrapper.find('.tool-change-file-row').text()).toContain('a.ts')
   })
 
-  it('renders a workspace diff card collapsed by default and expands it on demand', async () => {
-    const wrapper = mount(GroupMessageItem, {
-      props: {
-        message: {
-          ...workspaceDiffMessage(),
-          toolName: 'workspace_diff',
-          toolResult: payload,
-          toolStatus: 'done',
-        },
-        agents: [],
-        members: [],
-        currentUserId: 'user-1',
-      },
-      global: { stubs: { MarkdownRenderer: true, ProfileAvatar: true } },
-    })
+  it('hides realtime workspace diffs until their parent assistant arrives', async () => {
+    const { useGroupChatStore } = await import('@/stores/hermes/group-chat')
+    const store = useGroupChatStore()
+    store.currentRoomId = 'room-1'
+    store.messages = [workspaceDiffMessage({
+      content: JSON.stringify({ ...payload, parent_message_id: 'assistant-1' }),
+      timestamp: 2,
+    })]
 
-    expect(wrapper.find('.tool-change-card').exists()).toBe(true)
-    expect(wrapper.find('.tool-change-files').exists()).toBe(false)
-    expect(wrapper.find('.tool-change-card-header').attributes('aria-expanded')).toBe('false')
+    expect(store.sortedMessages).toEqual([])
 
-    await wrapper.find('.tool-change-card-header').trigger('click')
+    store.messages.push(assistantMessage())
 
-    expect(wrapper.find('.tool-change-card-header').attributes('aria-expanded')).toBe('true')
-    expect(wrapper.find('.tool-change-file-row').text()).toContain('a.ts')
-    expect(wrapper.find('.tool-line').exists()).toBe(false)
-    expect(wrapper.text()).not.toContain('"kind"')
-
-    await wrapper.find('.tool-change-file-row').trigger('click')
-    const { useToolPanelStore } = await import('@/stores/hermes/tool-panel')
-    expect(useToolPanelStore().workspaceDiff).toMatchObject({
-      patch: expect.stringContaining('+new'),
-      editable: false,
-      file: expect.objectContaining({ path: 'src/a.ts' }),
+    expect(store.sortedMessages).toHaveLength(1)
+    expect(store.sortedMessages[0]).toMatchObject({
+      id: 'assistant-1',
+      workspaceChanges: [expect.objectContaining({ change_id: 'change-1' })],
     })
   })
 
-  it('keeps workspace diff audit cards visible when generic tool traces are hidden', async () => {
+  it('never exposes workspace diff audit messages as independent tool traces', async () => {
     toolTraceVisibleState.value = false
     const { useGroupChatStore } = await import('@/stores/hermes/group-chat')
     const store = useGroupChatStore()
@@ -284,7 +264,7 @@ describe('group chat workspace diff client rendering', () => {
     })
 
     const messages = wrapper.getComponent({ name: 'VirtualMessageList' }).props('messages') as ChatMessage[]
-    expect(messages.map(message => message.id)).toEqual(['diff-1'])
+    expect(messages).toEqual([])
   })
 
   it('hands previewable group attachments to the shared file panel instead of downloading', async () => {

--- a/tests/client/message-item-highlight.test.ts
+++ b/tests/client/message-item-highlight.test.ts
@@ -437,62 +437,6 @@ describe('MessageItem tool details', () => {
     expect(toolDetails.text()).not.toContain('chat.truncated')
   })
 
-  it('keeps workspace change files collapsed until the summary is expanded', async () => {
-    const wrapper = mount(MessageItem, {
-      props: {
-        message: {
-          id: 'workspace-change',
-          role: 'tool',
-          content: '',
-          timestamp: Date.now(),
-          toolName: 'workspace_diff',
-          toolStatus: 'done',
-          toolChange: {
-            change_id: 'change-1',
-            session_id: 'session-1',
-            run_id: 'run-1',
-            source: 'run',
-            workspace: '/tmp/repo',
-            workspace_kind: 'git',
-            started_at: 1,
-            finished_at: 2,
-            files_changed: 1,
-            additions: 2,
-            deletions: 1,
-            truncated: false,
-            total_patch_bytes: 32,
-            created_at: 2,
-            files: [{
-              id: 1,
-              change_id: 'change-1',
-              session_id: 'session-1',
-              path: 'src/example.ts',
-              old_path: null,
-              change_type: 'modified',
-              additions: 2,
-              deletions: 1,
-              size_before: 10,
-              size_after: 12,
-              patch_bytes: 32,
-              truncated: false,
-              binary: false,
-              created_at: 2,
-            }],
-          },
-        } satisfies Message,
-      },
-      global: { stubs: { MarkdownRenderer: true } },
-    })
-
-    expect(wrapper.find('.tool-change-file-row').exists()).toBe(false)
-    expect(wrapper.find('.tool-change-card-header').attributes('aria-expanded')).toBe('false')
-
-    await wrapper.find('.tool-change-card-header').trigger('click')
-
-    expect(wrapper.find('.tool-change-card-header').attributes('aria-expanded')).toBe('true')
-    expect(wrapper.find('.tool-change-file-row').text()).toContain('example.ts')
-  })
-
   it('renders a turn-scoped workspace change inside its assistant response', async () => {
     const wrapper = mount(MessageItem, {
       props: {

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -13,6 +13,7 @@ const groupWorkspaceDiff = {
   kind: 'workspace_diff',
   version: 1,
   room_id: 'room-alpha',
+  parent_message_id: 'alpha-file',
   workspace: '/tmp/alpha',
   files_changed: 1,
   additions: 1,

--- a/tests/server/run-chat-ekko-context.test.ts
+++ b/tests/server/run-chat-ekko-context.test.ts
@@ -22,6 +22,8 @@ const getGlobalEkkoAgentMock = vi.hoisted(() => vi.fn(() => ({
 })))
 const buildCompressedHistoryMock = vi.hoisted(() => vi.fn())
 const recordSessionUsageMock = vi.hoisted(() => vi.fn())
+const startWorkspaceRunCheckpointMock = vi.hoisted(() => vi.fn())
+const completeWorkspaceRunCheckpointMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
   getSession: getSessionMock,
@@ -86,6 +88,11 @@ vi.mock('../../packages/server/src/services/logger', () => ({
 
 vi.mock('../../packages/server/src/services/usage-recorder', () => ({
   recordSessionUsage: recordSessionUsageMock,
+}))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker', () => ({
+  startWorkspaceRunCheckpoint: startWorkspaceRunCheckpointMock,
+  completeWorkspaceRunCheckpoint: completeWorkspaceRunCheckpointMock,
 }))
 
 function makeHarness() {
@@ -162,7 +169,154 @@ describe('ekko-agent context usage events', () => {
         apiMode: 'chat_completions',
       },
     })
+    completeWorkspaceRunCheckpointMock.mockReturnValue(null)
   })
+
+  it('attaches a completed workspace diff to the persisted Ekko assistant message', async () => {
+    const change = {
+      change_id: 'change-1',
+      session_id: 'session-1',
+      run_id: 'run-1',
+      assistant_message_id: '202',
+      files_changed: 1,
+      additions: 2,
+      deletions: 0,
+      files: [],
+    }
+    addMessageMock
+      .mockReturnValueOnce(101)
+      .mockReturnValueOnce(202)
+    completeWorkspaceRunCheckpointMock.mockReturnValueOnce(change)
+    agentRunMock.mockImplementationOnce(async (input: any) => {
+      input.onEvent({ type: 'run.started', runId: 'run-1', maxSteps: 3 })
+      return {
+        runId: 'run-1',
+        output: { role: 'assistant', content: 'done' },
+        steps: [],
+        messages: [],
+        events: [],
+        contextEstimate: { contextTokens: 5_000 },
+      }
+    })
+    const { handleEkkoAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-ekko-agent-run')
+    const { nsp, socket, sessionMap, events } = makeHarness()
+
+    await handleEkkoAgentRun(nsp as any, socket as any, {
+      session_id: 'session-1',
+      input: 'edit the file',
+      coding_agent_id: 'ekko-agent',
+      onEvent: (event: string, payload: any) => events.push({ event, payload }),
+    }, 'default', sessionMap, vi.fn(() => false))
+
+    expect(startWorkspaceRunCheckpointMock).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      runId: 'run-1',
+      workspace: '/tmp/workspace',
+    })
+    expect(completeWorkspaceRunCheckpointMock).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      runId: 'run-1',
+      workspace: '/tmp/workspace',
+      assistantMessageId: '202',
+    })
+    expect(events).toContainEqual({
+      event: 'workspace.diff.completed',
+      payload: expect.objectContaining({
+        event: 'workspace.diff.completed',
+        run_id: 'run-1',
+        change_id: 'change-1',
+        change,
+      }),
+    })
+    expect(events).toContainEqual({
+      event: 'run.completed',
+      payload: expect.objectContaining({
+        run_id: 'run-1',
+        workspace_run_change: change,
+      }),
+    })
+    expect(events.findIndex(item => item.event === 'workspace.diff.completed'))
+      .toBeLessThan(events.findIndex(item => item.event === 'run.completed'))
+  }, 15_000)
+
+  it('completes an Ekko workspace diff on run failure without inventing an assistant id', async () => {
+    const change = {
+      change_id: 'change-failed',
+      session_id: 'session-1',
+      run_id: 'run-failed',
+      assistant_message_id: '',
+      files_changed: 1,
+      additions: 1,
+      deletions: 0,
+      files: [],
+    }
+    completeWorkspaceRunCheckpointMock.mockReturnValueOnce(change)
+    agentRunMock.mockImplementationOnce(async (input: any) => {
+      input.onEvent({ type: 'run.started', runId: 'run-failed', maxSteps: 3 })
+      throw new Error('provider failed')
+    })
+    const { handleEkkoAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-ekko-agent-run')
+    const { nsp, socket, sessionMap, events } = makeHarness()
+
+    await handleEkkoAgentRun(nsp as any, socket as any, {
+      session_id: 'session-1',
+      input: 'edit then fail',
+      coding_agent_id: 'ekko-agent',
+      onEvent: (event: string, payload: any) => events.push({ event, payload }),
+    }, 'default', sessionMap, vi.fn(() => false))
+
+    expect(completeWorkspaceRunCheckpointMock).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-1',
+      runId: 'run-failed',
+      assistantMessageId: null,
+    }))
+    expect(events).toContainEqual({
+      event: 'run.failed',
+      payload: expect.objectContaining({
+        run_id: 'run-failed',
+        workspace_run_change: change,
+      }),
+    })
+  }, 15_000)
+
+  it('completes and publishes an Ekko workspace diff when the run is aborted', async () => {
+    const change = {
+      change_id: 'change-aborted',
+      session_id: 'session-1',
+      run_id: 'run-aborted',
+      assistant_message_id: '',
+      files_changed: 1,
+      additions: 1,
+      deletions: 0,
+      files: [],
+    }
+    completeWorkspaceRunCheckpointMock.mockReturnValueOnce(change)
+    agentRunMock.mockImplementationOnce(async (input: any) => {
+      input.onEvent({ type: 'run.started', runId: 'run-aborted', maxSteps: 3 })
+      const error = new Error('Run aborted.')
+      error.name = 'AbortError'
+      throw error
+    })
+    const { handleEkkoAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-ekko-agent-run')
+    const { nsp, socket, sessionMap, events } = makeHarness()
+
+    await handleEkkoAgentRun(nsp as any, socket as any, {
+      session_id: 'session-1',
+      input: 'edit until stopped',
+      coding_agent_id: 'ekko-agent',
+      onEvent: (event: string, payload: any) => events.push({ event, payload }),
+    }, 'default', sessionMap, vi.fn(() => false))
+
+    expect(completeWorkspaceRunCheckpointMock).toHaveBeenCalledTimes(1)
+    expect(events).toContainEqual({
+      event: 'workspace.diff.completed',
+      payload: expect.objectContaining({
+        run_id: 'run-aborted',
+        change,
+      }),
+    })
+    expect(events.some(item => item.event === 'run.completed' || item.event === 'run.failed')).toBe(false)
+  }, 15_000)
 
   it('forwards the selected reasoning effort and requests an automatic summary', async () => {
     agentRunMock.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- render single-chat and group-chat workspace diffs only inside the exactly associated Assistant/Agent message
- remove synthetic `workspace-run-change:*`, tool-message, and raw group `workspace_diff` standalone card fallbacks
- align resumed realtime single-chat streams with the persisted Assistant message ID
- connect the built-in Ekko Agent to workspace diff checkpoints and exact persisted Assistant message IDs
- complete Ekko diff capture on success, failure, and user abort, using both realtime and terminal run payloads
- keep unmatched diffs hidden until their parent message is loaded, with focused history, realtime, pagination, group-chat, and Ekko lifecycle coverage

## Root cause
Single chat inserted synthetic fallback messages whenever an attributed Assistant message was not currently loaded, while group chat kept its durable `workspace_diff` audit tool message visible when `parent_message_id` could not be resolved. The resumed realtime single-chat listener also omitted the active temporary Assistant ID during alignment. Separately, `handleEkkoAgentRun` bypassed the Coding Agent manager and never entered the workspace checkpoint lifecycle.

## Impact
File diffs now follow one UI rule across restored history and realtime streams: they appear only in the exact Agent response bubble that produced them. Missing or unresolved associations no longer create independent cards. Codex, Claude Code, and the built-in Ekko Agent now all produce workspace diffs through the same persisted association contract.

## Validation
- `npm run test -- tests/server/run-chat-ekko-context.test.ts tests/client/chat-store-workspace-diff-turn.test.ts tests/client/group-chat-workspace-diff.test.ts` (33 passed)
- `npm run test -- tests/client/chat-store-workspace-diff-turn.test.ts tests/client/group-chat-workspace-diff.test.ts tests/client/message-item-highlight.test.ts` (30 passed)
- `npm run test -- tests/server/run-chat-bridge-final-context.test.ts` (28 passed)
- `npm run test -- tests/server/group-chat-workspace-diff.test.ts` (9 passed)
- `npm exec vue-tsc -- -b`
- `npm exec tsc -- --noEmit -p packages/server/tsconfig.json`
- `npm run build`
- `npm run harness:check`

The targeted local Playwright run could not start because Playwright does not provide its managed Chromium headless shell for this Ubuntu 26.04 ARM64 environment and the system Chromium exits under the container. The updated e2e case is included for GitHub CI.