### PR TITLE
fix(voice): declare the voices capability for Custom TTS

### DIFF
--- a/docs/chat-chain-changes/2026-07-29-custom-tts-voice-capability.md
+++ b/docs/chat-chain-changes/2026-07-29-custom-tts-voice-capability.md
@@ -1,0 +1,15 @@
+---
+date: 2026-07-29
+pr: pending
+feature: Custom TTS declares the voices capability
+impact: The Voice field now renders for Custom TTS in both the Add dialog and the configurator, so an OpenAI-compatible provider that requires an explicit voice can be configured from the UI.
+---
+
+`tts-custom` now declares `capabilities.voices`, which is the flag both voice
+surfaces already gate on: the Add TTS API dialog renders its free-text Voice
+input, and `VoiceApiConfigurator` renders the voice field for the connection.
+Without the flag, a Custom TTS connection had no way to set a voice, and the
+request fell back to the provider default — which fails on providers whose
+voice list does not include `alloy`.
+
+Chat text, session persistence, and message ordering are unchanged.

--- a/packages/client/src/constants/voiceApiPresets.ts
+++ b/packages/client/src/constants/voiceApiPresets.ts
@@ -174,6 +174,7 @@ export const VOICE_API_PRESETS: VoiceApiPreset[] = [
     isSecretRequired: true,
     capabilities: {
       models: true,
+      voices: true,
     },
   },
 

--- a/tests/client/voice-api-presets-custom-voice.test.ts
+++ b/tests/client/voice-api-presets-custom-voice.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { VOICE_API_PRESETS } from '@/constants/voiceApiPresets'
+
+describe('Custom TTS voice capability', () => {
+  it('declares the voices capability so the Voice field renders for Custom TTS', () => {
+    const preset = VOICE_API_PRESETS.find(entry => entry.id === 'tts-custom')
+    expect(preset).toBeDefined()
+    expect(preset?.capabilities?.voices).toBe(true)
+  })
+
+  it('keeps the models capability for Custom TTS', () => {
+    const preset = VOICE_API_PRESETS.find(entry => entry.id === 'tts-custom')
+    expect(preset?.capabilities?.models).toBe(true)
+  })
+
+  it('does not add a voice capability to Custom STT', () => {
+    const preset = VOICE_API_PRESETS.find(entry => entry.id === 'stt-custom')
+    expect(preset?.capabilities?.voices).toBeUndefined()
+  })
+
+  it('declares voices for every selectable TTS preset', () => {
+    const selectableTts = VOICE_API_PRESETS.filter(entry => entry.kind === 'tts' && !entry.isBuiltin)
+    const missing = selectableTts.filter(entry => !entry.capabilities?.voices).map(entry => entry.id)
+    expect(missing).toEqual([])
+  })
+})


### PR DESCRIPTION
Fixes #2213.

#2260 already built the mechanism: `VoiceApiFormModal.vue:469` renders the Voice section for `kind === 'tts' && selectedPreset.capabilities?.voices`, with the Doubao picker kept on its own branch, and `VoiceApiConfigurator` gates its voice field on the same flag.

`tts-custom` is the only selectable TTS preset that does not declare the flag, so a Custom TTS connection still has no way to set a voice and the request falls back to the provider default. That breaks any OpenAI-compatible provider whose voice list has no `alloy` — the original #2213 case is Groq `playai-tts`, which rejects `alloy` outright.

### Change

One line in `packages/client/src/constants/voiceApiPresets.ts`:

```diff
     capabilities: {
       models: true,
+      voices: true,
     },
```

### Tests

`tests/client/voice-api-presets-custom-voice.test.ts` — 4 cases:

- Custom TTS declares `voices`
- Custom TTS keeps `models`
- Custom **STT** does not gain a voice capability
- every selectable (non-builtin) TTS preset declares `voices` — guards the invariant so a future preset cannot silently ship without a Voice field

### Verification

- 4/4 new tests pass; `tests/client/voice*` suite: 32 passed
- `vue-tsc --noEmit -p tsconfig.app.json` clean
- `npm run harness:check` passes

### Notes

- No new i18n keys, no UI changes beyond the field the existing `v-if` already renders.
- This supersedes the remaining useful part of #2217; the rest of that PR (the modal branch and the legacy `customVoice` handling) is already covered or removed by #2260, so #2217 can be closed.
