### PR TITLE
feat(voice): allow any Edge TTS voice and offer Arabic entries

### DIFF
--- a/docs/chat-chain-changes/2026-07-29-edge-tts-voice-entry.md
+++ b/docs/chat-chain-changes/2026-07-29-edge-tts-voice-entry.md
@@ -1,0 +1,19 @@
+---
+date: 2026-07-29
+pr: pending
+feature: Any Edge TTS voice can be selected or entered
+impact: The Edge voice picker accepts a custom voice id and ships Arabic entries, so languages outside the previous eight-voice shortlist are reachable from the UI.
+---
+
+The Edge TTS voice picker was limited to a hardcoded shortlist of five Chinese
+and three English voices, and the select was `filterable` without `tag`, so a
+voice outside that list could not be entered at all. Edge serves hundreds of
+voices across dozens of languages, and the value is passed through to the
+synthesize request unchanged, so the restriction was UI-only.
+
+The select is now taggable — the same behavior the Doubao voice select already
+has — and the shortlist moved to `constants/edgeTtsVoices.ts` with Arabic
+(`ar-SA-HamedNeural`, `ar-SA-ZariyahNeural`) added alongside the existing
+entries. Stored voices are unaffected and no default changes.
+
+Chat text, session persistence, and message ordering are unchanged.

--- a/packages/client/src/components/hermes/settings/voice/VoiceApiConfigurator.vue
+++ b/packages/client/src/components/hermes/settings/voice/VoiceApiConfigurator.vue
@@ -5,6 +5,7 @@ import { useI18n } from 'vue-i18n'
 import type { VoiceApiConnection, VoiceApiSavePayload } from '@/types/voice-api'
 import { VOICE_API_PRESETS } from '@/constants/voiceApiPresets'
 import { DOUBAO_TTS_2_RESOURCE_ID, DOUBAO_TTS_VOICE_OPTIONS, doubaoTtsResourceForVoice } from '@/constants/doubaoTtsVoices'
+import { EDGE_TTS_VOICE_OPTIONS } from '@/constants/edgeTtsVoices'
 import { speedToEdgeRate, hzToEdgePitch } from '@/utils/ttsHelpers'
 import { useVoiceSettings } from '@/composables/useVoiceSettings'
 
@@ -155,16 +156,7 @@ async function handleSave() {
   }
 }
 
-const edgeVoiceOptions = [
-  { label: '晓晓 (zh-CN-XiaoxiaoNeural)', value: 'zh-CN-XiaoxiaoNeural' },
-  { label: '晓萱 (zh-CN-XiaoxuanNeural)', value: 'zh-CN-XiaoxuanNeural' },
-  { label: '云希 (zh-CN-YunxiNeural)', value: 'zh-CN-YunxiNeural' },
-  { label: '云健 (zh-CN-YunjianNeural)', value: 'zh-CN-YunjianNeural' },
-  { label: '云扬 (zh-CN-YunyangNeural)', value: 'zh-CN-YunyangNeural' },
-  { label: 'Jenny (en-US-JennyNeural)', value: 'en-US-JennyNeural' },
-  { label: 'Aria (en-US-AriaNeural)', value: 'en-US-AriaNeural' },
-  { label: 'Guy (en-US-GuyNeural)', value: 'en-US-GuyNeural' },
-]
+const edgeVoiceOptions = EDGE_TTS_VOICE_OPTIONS.map(option => ({ label: option.label, value: option.value }))
 
 const openaiVoiceOptions = [
   { label: 'Alloy', value: 'alloy' },
@@ -261,6 +253,7 @@ function handleDoubaoVoiceUpdate(value: string) {
             v-if="connection.provider === 'edge'"
             :value="stringField('voice')"
             :options="edgeVoiceOptions"
+            tag
             filterable
             @update:value="value => setField('voice', value)"
           />

--- a/packages/client/src/constants/edgeTtsVoices.ts
+++ b/packages/client/src/constants/edgeTtsVoices.ts
@@ -1,0 +1,23 @@
+export interface EdgeTtsVoiceOption {
+  label: string
+  value: string
+}
+
+/**
+ * A shortlist of Edge TTS voices offered in the picker. Edge itself serves
+ * hundreds of voices across dozens of languages, so the select that renders
+ * these options is taggable: any other Edge voice id (for example
+ * `de-DE-KatjaNeural`) can be entered directly and is sent through unchanged.
+ */
+export const EDGE_TTS_VOICE_OPTIONS: EdgeTtsVoiceOption[] = [
+  { label: '晓晓 (zh-CN-XiaoxiaoNeural)', value: 'zh-CN-XiaoxiaoNeural' },
+  { label: '晓萱 (zh-CN-XiaoxuanNeural)', value: 'zh-CN-XiaoxuanNeural' },
+  { label: '云希 (zh-CN-YunxiNeural)', value: 'zh-CN-YunxiNeural' },
+  { label: '云健 (zh-CN-YunjianNeural)', value: 'zh-CN-YunjianNeural' },
+  { label: '云扬 (zh-CN-YunyangNeural)', value: 'zh-CN-YunyangNeural' },
+  { label: 'Jenny (en-US-JennyNeural)', value: 'en-US-JennyNeural' },
+  { label: 'Aria (en-US-AriaNeural)', value: 'en-US-AriaNeural' },
+  { label: 'Guy (en-US-GuyNeural)', value: 'en-US-GuyNeural' },
+  { label: 'حامد (ar-SA-HamedNeural)', value: 'ar-SA-HamedNeural' },
+  { label: 'زارية (ar-SA-ZariyahNeural)', value: 'ar-SA-ZariyahNeural' },
+]

--- a/tests/client/edge-tts-voices.test.ts
+++ b/tests/client/edge-tts-voices.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { EDGE_TTS_VOICE_OPTIONS } from '@/constants/edgeTtsVoices'
+
+describe('EDGE_TTS_VOICE_OPTIONS', () => {
+  it('keeps the previously offered Chinese and English voices', () => {
+    const values = EDGE_TTS_VOICE_OPTIONS.map(option => option.value)
+    expect(values).toEqual(expect.arrayContaining([
+      'zh-CN-XiaoxiaoNeural',
+      'zh-CN-XiaoxuanNeural',
+      'zh-CN-YunxiNeural',
+      'zh-CN-YunjianNeural',
+      'zh-CN-YunyangNeural',
+      'en-US-JennyNeural',
+      'en-US-AriaNeural',
+      'en-US-GuyNeural',
+    ]))
+  })
+
+  it('offers Arabic voices', () => {
+    const values = EDGE_TTS_VOICE_OPTIONS.map(option => option.value)
+    expect(values).toContain('ar-SA-HamedNeural')
+    expect(values).toContain('ar-SA-ZariyahNeural')
+  })
+
+  it('covers more than one language family', () => {
+    const locales = new Set(EDGE_TTS_VOICE_OPTIONS.map(option => option.value.split('-').slice(0, 2).join('-')))
+    expect(locales.size).toBeGreaterThan(2)
+  })
+
+  it('has no duplicate values and labels every option', () => {
+    const values = EDGE_TTS_VOICE_OPTIONS.map(option => option.value)
+    expect(new Set(values).size).toBe(values.length)
+    expect(EDGE_TTS_VOICE_OPTIONS.every(option => option.label.trim().length > 0)).toBe(true)
+  })
+
+  it('uses well-formed Edge voice ids', () => {
+    for (const option of EDGE_TTS_VOICE_OPTIONS) {
+      expect(option.value).toMatch(/^[a-z]{2}-[A-Z]{2}-[A-Za-z]+Neural$/)
+    }
+  })
+})


### PR DESCRIPTION
### Problem

The Edge TTS voice picker offers a hardcoded shortlist — five Chinese and three English voices — and the select is `filterable` without `tag`, so a voice outside that list cannot be entered at all.

Edge itself serves hundreds of voices across dozens of languages (the Hermes Agent voice-mode reference puts it at 322 voices / 74 languages), and `VoiceApiConfigurator` passes the stored value straight through to the synthesize request. So the restriction is purely a UI one: Arabic — and every other language outside zh-CN/en-US — is unreachable from Studio even though the backend would happily synthesize it.

### Change

- The Edge voice select is now taggable, exactly like the Doubao voice select a few lines below it in the same component, so any Edge voice id (`de-DE-KatjaNeural`, `ja-JP-NanamiNeural`, …) can be typed in.
- The shortlist moved to `constants/edgeTtsVoices.ts`, following the existing `constants/doubaoTtsVoices.ts` pattern, and gained `ar-SA-HamedNeural` and `ar-SA-ZariyahNeural`.
- The existing eight entries are unchanged, no default changes, and stored voices are unaffected.

### Tests

`tests/client/edge-tts-voices.test.ts` — 5 cases: previously offered voices retained, Arabic voices present, more than one language family covered, no duplicate values and every option labelled, all ids well-formed.

### Verification

- 5/5 new tests pass; `tests/client/voice*` + `tests/client/edge*`: 33 passed
- `vue-tsc --noEmit -p tsconfig.app.json` clean
- `npm run harness:check` passes

### Notes

- No new i18n keys: labels are provider voice ids in the same "native name (id)" style as the existing entries.
- Kept separate from #2265 (Custom TTS `voices` capability) since they are unrelated changes.
