### PR TITLE
feat(i18n): drive document direction from the active locale

### DIFF
--- a/docs/chat-chain-changes/2026-07-29-rtl-document-direction.md
+++ b/docs/chat-chain-changes/2026-07-29-rtl-document-direction.md
@@ -1,0 +1,20 @@
+---
+date: 2026-07-29
+pr: pending
+feature: Document writing direction follows the active locale
+impact: Selecting a right-to-left locale mirrors the document, so native bidi layout and text alignment apply instead of forcing left-to-right.
+---
+
+`<html dir>` is now derived from the active locale alongside `<html lang>`, both
+at startup and on every `switchLocale` call. Direction resolution lives in
+`i18n/direction.ts` and works on the primary subtag, so regional tags such as
+`ar-SA` resolve correctly.
+
+Left-to-right locales are unaffected: they receive `dir="ltr"`, which was the
+implicit behavior before this change.
+
+Component-level mirroring for Naive UI (its `NConfigProvider` `rtl` prop and the
+per-component RTL style modules) and any layout rules that still assume physical
+left/right are intentionally out of scope here.
+
+Chat text, session persistence, and message ordering are unchanged.

--- a/packages/client/src/i18n/direction.ts
+++ b/packages/client/src/i18n/direction.ts
@@ -1,0 +1,35 @@
+/**
+ * Writing direction for a locale tag.
+ *
+ * Kept independent of `supportedLocales` so the document direction is correct
+ * for any locale tag the app is switched to, including regional forms such as
+ * `ar-SA`.
+ */
+
+const RTL_LANGUAGES = new Set([
+  'ar', // Arabic
+  'fa', // Persian
+  'he', // Hebrew
+  'iw', // Hebrew (legacy tag)
+  'ur', // Urdu
+  'ps', // Pashto
+  'sd', // Sindhi
+  'ug', // Uyghur
+  'yi', // Yiddish
+])
+
+export type WritingDirection = 'rtl' | 'ltr'
+
+export function isRtlLocale(locale: string): boolean {
+  const primary = locale.split(/[-_]/)[0]?.toLowerCase() ?? ''
+  return RTL_LANGUAGES.has(primary)
+}
+
+export function localeDirection(locale: string): WritingDirection {
+  return isRtlLocale(locale) ? 'rtl' : 'ltr'
+}
+
+/** Mirrors the document for RTL locales so native bidi layout applies. */
+export function applyDocumentDirection(locale: string): void {
+  document.documentElement.dir = localeDirection(locale)
+}

--- a/packages/client/src/i18n/index.ts
+++ b/packages/client/src/i18n/index.ts
@@ -1,6 +1,7 @@
 import { createI18n } from 'vue-i18n'
 import { loadLocaleMessages, mergeMessagesWithFallback, supportedLocales } from './messages'
 import type { SupportedLocale } from './messages'
+import { applyDocumentDirection } from './direction'
 
 const saved = localStorage.getItem('hermes_locale')
 
@@ -35,6 +36,7 @@ function resolveLocale(saved: string | null): SupportedLocale {
 
 function setHtmlLang(locale: SupportedLocale) {
   document.documentElement.lang = locale
+  applyDocumentDirection(locale)
 }
 
 const locale = resolveLocale(saved)

--- a/tests/client/i18n-direction.test.ts
+++ b/tests/client/i18n-direction.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { applyDocumentDirection, isRtlLocale, localeDirection } from '@/i18n/direction'
+import { supportedLocales } from '@/i18n/messages'
+
+afterEach(() => {
+  document.documentElement.removeAttribute('dir')
+})
+
+describe('isRtlLocale', () => {
+  it('detects right-to-left languages', () => {
+    for (const locale of ['ar', 'fa', 'he', 'iw', 'ur', 'ps', 'sd', 'ug', 'yi']) {
+      expect(isRtlLocale(locale), locale).toBe(true)
+    }
+  })
+
+  it('treats left-to-right locales as ltr', () => {
+    for (const locale of ['en', 'zh', 'zh-TW', 'ja', 'ko', 'fr', 'es', 'de', 'pt', 'ru']) {
+      expect(isRtlLocale(locale), locale).toBe(false)
+    }
+  })
+
+  it('resolves regional and underscore tags by primary subtag', () => {
+    expect(isRtlLocale('ar-SA')).toBe(true)
+    expect(isRtlLocale('ar_EG')).toBe(true)
+    expect(isRtlLocale('AR-sa')).toBe(true)
+    expect(isRtlLocale('en-GB')).toBe(false)
+  })
+
+  it('does not treat an unknown or empty tag as rtl', () => {
+    expect(isRtlLocale('')).toBe(false)
+    expect(isRtlLocale('xx')).toBe(false)
+    expect(isRtlLocale('arabic')).toBe(false)
+  })
+})
+
+describe('localeDirection', () => {
+  it('maps locales to a writing direction', () => {
+    expect(localeDirection('ar')).toBe('rtl')
+    expect(localeDirection('en')).toBe('ltr')
+  })
+
+  it('returns a direction for every supported locale', () => {
+    for (const locale of supportedLocales) {
+      expect(['rtl', 'ltr']).toContain(localeDirection(locale))
+    }
+  })
+})
+
+describe('applyDocumentDirection', () => {
+  it('mirrors the document for an rtl locale', () => {
+    applyDocumentDirection('ar')
+    expect(document.documentElement.dir).toBe('rtl')
+  })
+
+  it('restores ltr when switching back', () => {
+    applyDocumentDirection('ar')
+    applyDocumentDirection('en')
+    expect(document.documentElement.dir).toBe('ltr')
+  })
+})


### PR DESCRIPTION
First step toward right-to-left support: make the document direction follow the active locale. Small and self-contained — the layout work it unlocks is intentionally not in this PR.

### Problem

`<html lang>` is set from the active locale, but `dir` never is, so a right-to-left locale renders with left-to-right flow: text alignment, punctuation placement and inline element order are all wrong even before any CSS is involved.

### Change

- New `packages/client/src/i18n/direction.ts` — `isRtlLocale`, `localeDirection`, and `applyDocumentDirection`.
- `i18n/index.ts` calls it from the existing `setHtmlLang`, which already runs both at startup and at the end of `switchLocale`, so the single hook covers both paths.
- Resolution is on the **primary subtag** (`ar-SA`, `ar_EG`, `AR-sa` → `rtl`), and deliberately independent of `supportedLocales` so the direction is right for any tag the app is switched to.
- Left-to-right locales are unchanged in behavior; they now get an explicit `dir="ltr"`.

RTL languages covered: `ar`, `fa`, `he`, `iw`, `ur`, `ps`, `sd`, `ug`, `yi`.

### Tests

`tests/client/i18n-direction.test.ts` — 8 cases: every RTL language detected, all ten current locales resolve to `ltr`, regional/underscore/uppercase tags resolve by primary subtag, unknown and empty tags are not RTL, every `supportedLocales` entry yields a valid direction, and the document is mirrored and restored through `applyDocumentDirection`.

### Verification

- 8/8 new tests pass; `tests/client/i18n-lazy-loading.test.ts` still passes
- `vue-tsc --noEmit -p tsconfig.app.json` clean
- `npm run harness:check` passes

### Follow-ups (separate PRs)

- Naive UI component mirroring — `NConfigProvider` accepts an `rtl` prop and the package ships per-component RTL style modules; wiring that list is the natural next step.
- Layout rules that still assume physical left/right (margins, paddings, icon direction, chat bubble alignment), page by page.
- Related: #2269 adds the Arabic locale, which is the first locale this direction handling applies to. The two are independent — this PR is locale-agnostic and works on its own.
