### PR TITLE
feat(i18n): mirror Naive UI components for right-to-left locales

### DIFF
--- a/docs/chat-chain-changes/2026-07-29-rtl-document-direction.md
+++ b/docs/chat-chain-changes/2026-07-29-rtl-document-direction.md
@@ -1,0 +1,20 @@
+---
+date: 2026-07-29
+pr: pending
+feature: Document writing direction follows the active locale
+impact: Selecting a right-to-left locale mirrors the document, so native bidi layout and text alignment apply instead of forcing left-to-right.
+---
+
+`<html dir>` is now derived from the active locale alongside `<html lang>`, both
+at startup and on every `switchLocale` call. Direction resolution lives in
+`i18n/direction.ts` and works on the primary subtag, so regional tags such as
+`ar-SA` resolve correctly.
+
+Left-to-right locales are unaffected: they receive `dir="ltr"`, which was the
+implicit behavior before this change.
+
+Component-level mirroring for Naive UI (its `NConfigProvider` `rtl` prop and the
+per-component RTL style modules) and any layout rules that still assume physical
+left/right are intentionally out of scope here.
+
+Chat text, session persistence, and message ordering are unchanged.

--- a/docs/chat-chain-changes/2026-07-29-rtl-naive-components.md
+++ b/docs/chat-chain-changes/2026-07-29-rtl-naive-components.md
@@ -1,0 +1,18 @@
+---
+date: 2026-07-29
+pr: pending
+feature: Naive UI components mirror for right-to-left locales
+impact: Inputs, selects, cards, drawers, dialogs, tables and other Naive UI components render mirrored when an RTL locale is active, instead of keeping left-to-right internals inside an RTL document.
+---
+
+Naive UI only mirrors the components handed to `NConfigProvider`'s `rtl` prop.
+`constants/naiveRtl.ts` collects the RTL style module of every component the app
+uses and `App.vue` passes that list while an RTL locale is active, or `undefined`
+otherwise so left-to-right rendering is byte-identical to before.
+
+The style modules are not re-exported from the package root, so each is imported
+from its own styles entry. Two upstream quirks are handled: `heatmap` does not
+re-export its RTL module from its styles entry, and `treeSelectRtl` is registered
+under the same `Select` name as `selectRtl` with `treeRtl` as its only extra peer.
+
+Chat text, session persistence, and message ordering are unchanged.

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -10,6 +10,7 @@ import { useSessionSearch } from '@/composables/useSessionSearch'
 import { useAppStore } from '@/stores/hermes/app'
 import AuthEventListener from '@/components/auth/AuthEventListener.vue'
 import { desktopBridge } from '@/utils/desktop-bridge'
+import { naiveRtlFor } from '@/constants/naiveRtl'
 
 const AppSidebar = defineAsyncComponent(async () => (await import('@/components/layout/AppSidebar.vue')).default)
 const DesktopTitleBar = defineAsyncComponent(async () => (await import('@/components/layout/DesktopTitleBar.vue')).default)
@@ -25,7 +26,8 @@ const {
   hasBackgroundImage,
   syncThemeFromServer,
 } = useTheme()
-const { t } = useI18n()
+const { t, locale } = useI18n()
+const naiveRtl = computed(() => naiveRtlFor(locale.value))
 const appStore = useAppStore()
 const route = useRoute()
 const { sessionSearchOpen } = useSessionSearch()
@@ -107,7 +109,7 @@ useKeyboard()
 </script>
 
 <template>
-  <NConfigProvider :theme="naiveTheme" :theme-overrides="themeOverrides">
+  <NConfigProvider :theme="naiveTheme" :theme-overrides="themeOverrides" :rtl="naiveRtl">
     <NMessageProvider>
       <AuthEventListener />
       <NDialogProvider>

--- a/packages/client/src/constants/naiveRtl.ts
+++ b/packages/client/src/constants/naiveRtl.ts
@@ -1,0 +1,86 @@
+import { isRtlLocale } from '@/i18n/direction'
+
+// Naive UI ships one RTL style module per component and enables mirroring only
+// for the components handed to NConfigProvider's `rtl` prop. They are not
+// re-exported from the package root, so each one is imported from its own
+// styles entry.
+import { alertRtl } from 'naive-ui/es/alert/styles'
+import { avatarGroupRtl } from 'naive-ui/es/avatar-group/styles'
+import { badgeRtl } from 'naive-ui/es/badge/styles'
+import { buttonRtl } from 'naive-ui/es/button/styles'
+import { buttonGroupRtl } from 'naive-ui/es/button-group/styles'
+import { cardRtl } from 'naive-ui/es/card/styles'
+import { checkboxRtl } from 'naive-ui/es/checkbox/styles'
+import { collapseRtl } from 'naive-ui/es/collapse/styles'
+import { collapseTransitionRtl } from 'naive-ui/es/collapse-transition/styles'
+import { DataTableRtl } from 'naive-ui/es/data-table/styles'
+import { dialogRtl } from 'naive-ui/es/dialog/styles'
+import { drawerRtl } from 'naive-ui/es/drawer/styles'
+import { dynamicInputRtl } from 'naive-ui/es/dynamic-input/styles'
+import { flexRtl } from 'naive-ui/es/flex/styles'
+// heatmap's styles entry does not re-export its RTL module, so it is imported directly.
+import { heatmapRtl } from 'naive-ui/es/heatmap/styles/rtl'
+import { inputRtl } from 'naive-ui/es/input/styles'
+import { inputNumberRtl } from 'naive-ui/es/input-number/styles'
+import { inputOtpRtl } from 'naive-ui/es/input-otp/styles'
+import { listRtl } from 'naive-ui/es/list/styles'
+import { messageRtl } from 'naive-ui/es/message/styles'
+import { notificationRtl } from 'naive-ui/es/notification/styles'
+import { paginationRtl } from 'naive-ui/es/pagination/styles'
+import { popoverRtl } from 'naive-ui/es/popover/styles'
+import { radioRtl } from 'naive-ui/es/radio/styles'
+import { selectRtl } from 'naive-ui/es/select/styles'
+import { spaceRtl } from 'naive-ui/es/space/styles'
+import { statisticRtl } from 'naive-ui/es/statistic/styles'
+import { stepsRtl } from 'naive-ui/es/steps/styles'
+import { tableRtl } from 'naive-ui/es/table/styles'
+import { tagRtl } from 'naive-ui/es/tag/styles'
+import { thingRtl } from 'naive-ui/es/thing/styles'
+import { treeRtl } from 'naive-ui/es/tree/styles'
+import { uploadRtl } from 'naive-ui/es/upload/styles'
+
+export const NAIVE_RTL_STYLES = [
+  alertRtl,
+  avatarGroupRtl,
+  badgeRtl,
+  buttonRtl,
+  buttonGroupRtl,
+  cardRtl,
+  checkboxRtl,
+  collapseRtl,
+  collapseTransitionRtl,
+  DataTableRtl,
+  dialogRtl,
+  drawerRtl,
+  dynamicInputRtl,
+  flexRtl,
+  heatmapRtl,
+  inputRtl,
+  inputNumberRtl,
+  inputOtpRtl,
+  listRtl,
+  messageRtl,
+  notificationRtl,
+  paginationRtl,
+  popoverRtl,
+  radioRtl,
+  // Naive UI registers TreeSelect's RTL item under the same 'Select' name, and its
+  // only extra peer is treeRtl, which is listed separately below.
+  selectRtl,
+  spaceRtl,
+  statisticRtl,
+  stepsRtl,
+  tableRtl,
+  tagRtl,
+  thingRtl,
+  treeRtl,
+  uploadRtl,
+]
+
+/**
+ * RTL styles for NConfigProvider, or `undefined` for left-to-right locales so
+ * Naive UI keeps its default rendering untouched.
+ */
+export function naiveRtlFor(locale: string): typeof NAIVE_RTL_STYLES | undefined {
+  return isRtlLocale(locale) ? NAIVE_RTL_STYLES : undefined
+}

--- a/packages/client/src/i18n/direction.ts
+++ b/packages/client/src/i18n/direction.ts
@@ -1,0 +1,35 @@
+/**
+ * Writing direction for a locale tag.
+ *
+ * Kept independent of `supportedLocales` so the document direction is correct
+ * for any locale tag the app is switched to, including regional forms such as
+ * `ar-SA`.
+ */
+
+const RTL_LANGUAGES = new Set([
+  'ar', // Arabic
+  'fa', // Persian
+  'he', // Hebrew
+  'iw', // Hebrew (legacy tag)
+  'ur', // Urdu
+  'ps', // Pashto
+  'sd', // Sindhi
+  'ug', // Uyghur
+  'yi', // Yiddish
+])
+
+export type WritingDirection = 'rtl' | 'ltr'
+
+export function isRtlLocale(locale: string): boolean {
+  const primary = locale.split(/[-_]/)[0]?.toLowerCase() ?? ''
+  return RTL_LANGUAGES.has(primary)
+}
+
+export function localeDirection(locale: string): WritingDirection {
+  return isRtlLocale(locale) ? 'rtl' : 'ltr'
+}
+
+/** Mirrors the document for RTL locales so native bidi layout applies. */
+export function applyDocumentDirection(locale: string): void {
+  document.documentElement.dir = localeDirection(locale)
+}

--- a/packages/client/src/i18n/index.ts
+++ b/packages/client/src/i18n/index.ts
@@ -1,6 +1,7 @@
 import { createI18n } from 'vue-i18n'
 import { loadLocaleMessages, mergeMessagesWithFallback, supportedLocales } from './messages'
 import type { SupportedLocale } from './messages'
+import { applyDocumentDirection } from './direction'
 
 const saved = localStorage.getItem('hermes_locale')
 
@@ -35,6 +36,7 @@ function resolveLocale(saved: string | null): SupportedLocale {
 
 function setHtmlLang(locale: SupportedLocale) {
   document.documentElement.lang = locale
+  applyDocumentDirection(locale)
 }
 
 const locale = resolveLocale(saved)

--- a/tests/client/app-web-pet.test.ts
+++ b/tests/client/app-web-pet.test.ts
@@ -29,6 +29,7 @@ vi.mock('vue-router', async (importOriginal) => {
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     t: (key: string, params?: Record<string, unknown>) => params?.version ? `${key}:${params.version}` : key,
+    locale: { value: 'en' },
   }),
 }))
 

--- a/tests/client/i18n-direction.test.ts
+++ b/tests/client/i18n-direction.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { applyDocumentDirection, isRtlLocale, localeDirection } from '@/i18n/direction'
+import { supportedLocales } from '@/i18n/messages'
+
+afterEach(() => {
+  document.documentElement.removeAttribute('dir')
+})
+
+describe('isRtlLocale', () => {
+  it('detects right-to-left languages', () => {
+    for (const locale of ['ar', 'fa', 'he', 'iw', 'ur', 'ps', 'sd', 'ug', 'yi']) {
+      expect(isRtlLocale(locale), locale).toBe(true)
+    }
+  })
+
+  it('treats left-to-right locales as ltr', () => {
+    for (const locale of ['en', 'zh', 'zh-TW', 'ja', 'ko', 'fr', 'es', 'de', 'pt', 'ru']) {
+      expect(isRtlLocale(locale), locale).toBe(false)
+    }
+  })
+
+  it('resolves regional and underscore tags by primary subtag', () => {
+    expect(isRtlLocale('ar-SA')).toBe(true)
+    expect(isRtlLocale('ar_EG')).toBe(true)
+    expect(isRtlLocale('AR-sa')).toBe(true)
+    expect(isRtlLocale('en-GB')).toBe(false)
+  })
+
+  it('does not treat an unknown or empty tag as rtl', () => {
+    expect(isRtlLocale('')).toBe(false)
+    expect(isRtlLocale('xx')).toBe(false)
+    expect(isRtlLocale('arabic')).toBe(false)
+  })
+})
+
+describe('localeDirection', () => {
+  it('maps locales to a writing direction', () => {
+    expect(localeDirection('ar')).toBe('rtl')
+    expect(localeDirection('en')).toBe('ltr')
+  })
+
+  it('returns a direction for every supported locale', () => {
+    for (const locale of supportedLocales) {
+      expect(['rtl', 'ltr']).toContain(localeDirection(locale))
+    }
+  })
+})
+
+describe('applyDocumentDirection', () => {
+  it('mirrors the document for an rtl locale', () => {
+    applyDocumentDirection('ar')
+    expect(document.documentElement.dir).toBe('rtl')
+  })
+
+  it('restores ltr when switching back', () => {
+    applyDocumentDirection('ar')
+    applyDocumentDirection('en')
+    expect(document.documentElement.dir).toBe('ltr')
+  })
+})

--- a/tests/client/naive-rtl.test.ts
+++ b/tests/client/naive-rtl.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { NAIVE_RTL_STYLES, naiveRtlFor } from '@/constants/naiveRtl'
+
+describe('NAIVE_RTL_STYLES', () => {
+  it('collects Naive UI RTL style modules', () => {
+    expect(NAIVE_RTL_STYLES.length).toBeGreaterThan(30)
+  })
+
+  it('exposes a named style module for every entry', () => {
+    for (const item of NAIVE_RTL_STYLES) {
+      expect(typeof item.name, JSON.stringify(item)).toBe('string')
+      expect(item.name.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('has no duplicate component entries', () => {
+    const names = NAIVE_RTL_STYLES.map(item => item.name)
+    expect(new Set(names).size).toBe(names.length)
+  })
+
+  it('covers the components the app relies on most', () => {
+    const names = new Set(NAIVE_RTL_STYLES.map(item => item.name))
+    for (const expected of ['Button', 'Input', 'Select', 'Card', 'Drawer', 'Dialog', 'DataTable']) {
+      expect(names.has(expected), expected).toBe(true)
+    }
+  })
+})
+
+describe('naiveRtlFor', () => {
+  it('returns the style list for right-to-left locales', () => {
+    expect(naiveRtlFor('ar')).toBe(NAIVE_RTL_STYLES)
+    expect(naiveRtlFor('ar-SA')).toBe(NAIVE_RTL_STYLES)
+  })
+
+  it('returns undefined for left-to-right locales so rendering is untouched', () => {
+    for (const locale of ['en', 'zh', 'zh-TW', 'ja', 'ko', 'fr', 'es', 'de', 'pt', 'ru']) {
+      expect(naiveRtlFor(locale), locale).toBeUndefined()
+    }
+  })
+})


### PR DESCRIPTION
> **Stacked on #2270** — it reuses `isRtlLocale` from that PR, so this branch currently shows both commits. Once #2270 is merged this reduces to the single commit below. Happy to rebase if you prefer them squashed into one PR.

### Problem

Setting `<html dir="rtl">` (#2270) fixes document flow, but Naive UI mirrors a component only when that component's RTL style module is handed to `NConfigProvider`'s `rtl` prop. Without it, the page direction flips while component internals stay left-to-right: input affixes and clear buttons, select arrows, card header actions, drawer placement, dialog icons, table cell alignment, pagination order, and so on.

### Change

- New `packages/client/src/constants/naiveRtl.ts` — collects the RTL style module of every Naive UI component the app uses (33 entries) and exposes `naiveRtlFor(locale)`.
- `App.vue` passes `:rtl="naiveRtl"` on the existing `NConfigProvider`. For left-to-right locales it resolves to `undefined`, so rendering is unchanged.

### Upstream quirks handled

- The RTL modules are **not** re-exported from the package root, so each is imported from its own styles entry (`naive-ui/es/<component>/styles`).
- `heatmap` does not re-export its RTL module from its styles entry, so it is imported from `naive-ui/es/heatmap/styles/rtl` directly.
- `treeSelectRtl` is registered under the same `Select` name as `selectRtl`, and its only extra peer is `treeRtl`, which is listed separately — so `treeSelectRtl` is omitted to avoid a duplicate registration.
- `pageHeaderRtl` is left out: `NPageHeader` is not used anywhere in the app, and its default export is loosely typed, which widened the array type.

### Tests

`tests/client/naive-rtl.test.ts` — 6 cases: the list is populated, every entry exposes a non-empty component name, there are no duplicate names (this is what caught the `Select` collision), the components the app depends on most are covered (`Button`, `Input`, `Select`, `Card`, `Drawer`, `Dialog`, `DataTable`), the list is returned for `ar`/`ar-SA`, and `undefined` is returned for all ten current locales.

### One unrelated-looking test edit

`tests/client/app-web-pet.test.ts` mounts `App.vue` and mocked `useI18n` with only `t`. Since `App.vue` now also reads `locale`, the mock gained `locale: { value: 'en' }`. Without it the eight existing cases in that file fail with `Cannot read properties of undefined (reading 'value')`.

### Verification

- 6/6 new tests pass; the 8 `app-web-pet` cases pass again with the updated mock
- `vue-tsc --noEmit -p tsconfig.app.json` clean
- `npm run harness:check` passes
- Full `tests/client`: 953 passed, 1 failure in `use-speech-tts.test.ts > synthesizeSpeech posts to the unified endpoint`, which fails identically on a clean `main` and is unrelated
