### PR TITLE
feat(i18n): use direction-aware CSS for the chat surface

### DIFF
--- a/docs/chat-chain-changes/2026-07-29-rtl-chat-logical-css.md
+++ b/docs/chat-chain-changes/2026-07-29-rtl-chat-logical-css.md
@@ -1,0 +1,28 @@
+---
+date: 2026-07-29
+pr: pending
+feature: Chat surface spacing, borders and text alignment follow the writing direction
+impact: Chat bubbles, message meta rows, the composer and the panel chrome keep their spacing on the correct side under a right-to-left locale; left-to-right rendering is unchanged.
+---
+
+The chat surface used physical `margin-left`/`margin-right`,
+`padding-left`/`padding-right`, `border-left`/`border-right` and
+`text-align: left`, which stay pinned to a physical side and therefore break
+under `dir="rtl"`: indentation appears on the wrong edge, quote and thinking
+borders land on the opposite side of the block they belong to, and inline labels
+drift away from the text they annotate.
+
+Those 32 declarations across `ChatInput.vue`, `ChatPanel.vue`, `MessageItem.vue`
+and `MessageList.vue` are now the logical equivalents
+(`margin-inline-start`/`-end`, `padding-inline-start`/`-end`,
+`border-inline-start`/`-end`, `text-align: start`). Logical properties resolve to
+the previous physical sides for left-to-right locales, so nothing changes there.
+
+`tests/client/rtl-logical-css.test.ts` fails if a physical inline-axis
+declaration is reintroduced into these components.
+
+Absolutely positioned offsets (`left`/`right`) in the same components are left for
+a follow-up change; symmetric pairs such as `left: 8px; right: 8px` are
+direction-agnostic and stay as they are.
+
+Chat text, session persistence, and message ordering are unchanged.

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1684,7 +1684,7 @@ function isImage(type: string): boolean {
   align-items: center;
   gap: 5px;
   padding: 0 0 0 2px;
-  margin-left: 0;
+  margin-inline-start: 0;
 
   .switch-label {
     display: flex;
@@ -1702,7 +1702,7 @@ function isImage(type: string): boolean {
 
   :deep(.n-switch),
   :deep(.n-switch__rail) {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 }
 
@@ -1714,7 +1714,7 @@ function isImage(type: string): boolean {
   width: 24px;
   min-width: 24px;
   height: 22px;
-  margin-left: 0;
+  margin-inline-start: 0;
   padding: 0;
   background: transparent !important;
   opacity: 1;
@@ -1991,7 +1991,7 @@ function isImage(type: string): boolean {
 .context-bar {
   width: 60px;
   height: 4px;
-  margin-left: -4px;
+  margin-inline-start: -4px;
   background: rgba(var(--text-muted-rgb), 0.2);
   border-radius: 2px;
   overflow: hidden;
@@ -2508,7 +2508,7 @@ function isImage(type: string): boolean {
   border-radius: $radius-sm;
   background: $bg-secondary;
   color: $text-primary;
-  text-align: left;
+  text-align: start;
   cursor: pointer;
   overflow: hidden;
   outline: none;
@@ -2536,7 +2536,7 @@ function isImage(type: string): boolean {
   border: 0;
   background: transparent;
   color: inherit;
-  text-align: left;
+  text-align: start;
   cursor: pointer;
   outline: none;
 }

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2837,11 +2837,11 @@ async function handleSessionModelCustomSubmit() {
 }
 
 .session-model-group-items {
-  padding-left: 8px;
+  padding-inline-start: 8px;
 }
 
 .session-moa-items {
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .session-model-item {
@@ -2919,7 +2919,7 @@ async function handleSessionModelCustomSubmit() {
   font-weight: 600;
   padding: 1px 5px;
   border-radius: 3px;
-  margin-right: 4px;
+  margin-inline-end: 4px;
   letter-spacing: 0.03em;
 }
 
@@ -2992,8 +2992,8 @@ async function handleSessionModelCustomSubmit() {
 
   &.collapsed {
     width: 0;
-    margin-left: 0;
-    margin-right: 0;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
     border: none;
     box-shadow: none;
     opacity: 0;
@@ -3357,7 +3357,7 @@ async function handleSessionModelCustomSubmit() {
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
 
   &--sidebar-collapsed {
-    margin-left: 10px;
+    margin-inline-start: 10px;
   }
 
   @media (max-width: $breakpoint-mobile) {
@@ -3457,7 +3457,7 @@ async function handleSessionModelCustomSubmit() {
   display: flex;
   align-items: center;
   gap: 4px;
-  margin-right: 4px;
+  margin-inline-end: 4px;
 }
 
 @media (max-width: $breakpoint-mobile) {
@@ -3518,7 +3518,7 @@ async function handleSessionModelCustomSubmit() {
   min-width: 320px;
   max-width: 100%;
   background: $bg-card;
-  border-left: 1px solid $border-color;
+  border-inline-start: 1px solid $border-color;
   display: flex;
   min-height: 0;
   overflow: visible;
@@ -3647,7 +3647,7 @@ async function handleSessionModelCustomSubmit() {
     left: 0;
     width: 100% !important;
     min-width: 0;
-    border-left: none;
+    border-inline-start: none;
     box-shadow: none;
   }
 
@@ -3769,7 +3769,7 @@ async function handleSessionModelCustomSubmit() {
 
 .workspace-default-badge {
   display: inline-block;
-  margin-left: 6px;
+  margin-inline-start: 6px;
   padding: 1px 6px;
   font-size: 10px;
   font-weight: 600;

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -1327,14 +1327,14 @@ onBeforeUnmount(() => {
   box-sizing: border-box;
 
   &.system {
-    border-left: 3px solid $warning;
+    border-inline-start: 3px solid $warning;
     border-radius: $radius-sm;
     max-width: 80%;
     background-color: rgba(var(--warning-rgb), 0.06);
   }
 
   &.command {
-    border-left: none;
+    border-inline-start: none;
     border: 1px solid rgba(var(--accent-primary-rgb), 0.12);
     background-color: rgba(var(--accent-primary-rgb), 0.04);
     color: $text-secondary;
@@ -1607,7 +1607,7 @@ onBeforeUnmount(() => {
   .thinking-body {
     margin-top: 6px;
     padding: 6px 10px;
-    border-left: 2px solid $border-light;
+    border-inline-start: 2px solid $border-light;
     font-size: 13px;
     opacity: 0.85;
     font-style: italic;
@@ -1766,14 +1766,14 @@ onBeforeUnmount(() => {
   padding: 0 4px;
   border-radius: 3px;
   line-height: 14px;
-  margin-left: 4px;
+  margin-inline-start: 4px;
 }
 
 .tool-details {
-  margin-left: 16px;
+  margin-inline-start: 16px;
   margin-top: 2px;
-  border-left: 2px solid $border-light;
-  padding-left: 10px;
+  border-inline-start: 2px solid $border-light;
+  padding-inline-start: 10px;
 }
 
 .tool-detail-section {
@@ -1834,7 +1834,7 @@ onBeforeUnmount(() => {
   width: 2px;
   height: 1em;
   background-color: $text-muted;
-  margin-left: 2px;
+  margin-inline-start: 2px;
   vertical-align: text-bottom;
   animation: blink 0.8s infinite;
 }
@@ -1912,13 +1912,13 @@ onBeforeUnmount(() => {
   }
 
   :global(.tool-change-drawer-header) {
-    padding-left: 12px !important;
-    padding-right: 12px !important;
+    padding-inline-start: 12px !important;
+    padding-inline-end: 12px !important;
   }
 
   :global(.tool-change-drawer-body-content) {
-    padding-left: 8px !important;
-    padding-right: 8px !important;
+    padding-inline-start: 8px !important;
+    padding-inline-end: 8px !important;
   }
 }
 </style>

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -1102,7 +1102,7 @@ defineExpose({
   font-weight: 600;
 
   strong {
-    margin-left: auto;
+    margin-inline-start: auto;
     min-width: 20px;
     height: 20px;
     display: inline-flex;
@@ -1661,7 +1661,7 @@ defineExpose({
 .tool-call-error-icon {
   color: #ff4d4f;
   flex-shrink: 0;
-  margin-left: 6px;
+  margin-inline-start: 6px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1671,14 +1671,14 @@ defineExpose({
   font-size: 10px;
   color: $text-muted;
   font-family: $font-code;
-  margin-left: 4px;
+  margin-inline-start: 4px;
   flex-shrink: 0;
 }
 
 .tool-call-success-icon {
   color: #52c41a;
   flex-shrink: 0;
-  margin-left: 6px;
+  margin-inline-start: 6px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/tests/client/rtl-logical-css.test.ts
+++ b/tests/client/rtl-logical-css.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const CHAT_ROOT = join(process.cwd(), 'packages/client/src/components/hermes/chat')
+
+// The chat surface is the most text-heavy part of the UI, so its spacing,
+// borders and text alignment must follow the writing direction rather than a
+// physical side. Guards against reintroducing the physical variants.
+const CHAT_COMPONENTS = [
+  'ChatInput.vue',
+  'ChatPanel.vue',
+  'MessageItem.vue',
+  'MessageList.vue',
+]
+
+const PHYSICAL_PATTERNS: Array<{ label: string, pattern: RegExp }> = [
+  { label: 'margin-left', pattern: /\bmargin-left\b/g },
+  { label: 'margin-right', pattern: /\bmargin-right\b/g },
+  { label: 'padding-left', pattern: /\bpadding-left\b/g },
+  { label: 'padding-right', pattern: /\bpadding-right\b/g },
+  { label: 'border-left', pattern: /\bborder-left\b/g },
+  { label: 'border-right', pattern: /\bborder-right\b/g },
+  { label: 'text-align: left', pattern: /text-align:\s*left\b/g },
+  { label: 'text-align: right', pattern: /text-align:\s*right\b/g },
+]
+
+describe('chat surface uses direction-aware CSS', () => {
+  it('has no physical inline-axis spacing, borders or text alignment', () => {
+    const offenders: string[] = []
+
+    for (const component of CHAT_COMPONENTS) {
+      const source = readFileSync(join(CHAT_ROOT, component), 'utf8')
+      for (const { label, pattern } of PHYSICAL_PATTERNS) {
+        const matches = source.match(pattern)
+        if (matches) offenders.push(`${component}: ${label} × ${matches.length}`)
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  it('actually uses the logical replacements', () => {
+    const combined = CHAT_COMPONENTS
+      .map(component => readFileSync(join(CHAT_ROOT, component), 'utf8'))
+      .join('\n')
+
+    for (const logical of ['margin-inline-start', 'padding-inline-start', 'border-inline-start']) {
+      expect(combined, logical).toContain(logical)
+    }
+  })
+})


### PR DESCRIPTION
Third step in the RTL series, and the first one that touches layout. Independent of #2270 / #2271 — this is CSS only and can be merged in any order.

### Problem

The chat surface pins spacing, borders and alignment to physical sides:

- `margin-left` / `margin-right`
- `padding-left` / `padding-right`
- `border-left` / `border-right`
- `text-align: left`

Under `dir="rtl"` those stay on the same physical edge, so indentation lands on the wrong side, quote and thinking-block borders end up opposite the content they belong to, and inline meta labels drift away from the text they annotate.

### Change

32 declarations across `ChatInput.vue`, `ChatPanel.vue`, `MessageItem.vue` and `MessageList.vue` become their logical equivalents (`margin-inline-start`/`-end`, `padding-inline-start`/`-end`, `border-inline-start`/`-end`, `text-align: start`).

Logical properties resolve to exactly the previous physical sides for left-to-right locales, so **there is no visual change for existing users**.

### Deliberately out of scope

- Absolutely positioned `left` / `right` offsets in the same files — a follow-up PR, since each one needs its own look at the surrounding rule.
- Symmetric pairs such as `left: 8px; right: 8px` — already direction-agnostic, left untouched.

### Tests

`tests/client/rtl-logical-css.test.ts` — 2 cases: the four chat components contain no physical inline-axis declaration (so a future change cannot silently reintroduce one), and the logical replacements are actually present.

### Verification

- 2/2 new tests pass
- `vue-tsc --noEmit -p tsconfig.app.json` clean
- `npm run harness:check` passes — it initially failed because these are chat-chain files and required a `docs/chat-chain-changes` fragment, which is included
- Full `tests/client`: 941 passed, 1 failure in `use-speech-tts.test.ts > synthesizeSpeech posts to the unified endpoint`, which fails identically on a clean `main` and is unrelated
