### PR TITLE
fix(i18n): keep RTL overlays in viewport

### DIFF
--- a/packages/client/src/styles/global.scss
+++ b/packages/client/src/styles/global.scss
@@ -93,6 +93,15 @@ html, body {
   overflow: hidden;
 }
 
+// Vueuc positions teleported followers with an absolute child whose horizontal
+// coordinates are measured from the viewport's left edge. In an RTL containing
+// block that child gets a right-edge static position first, shifting overlays by
+// one full viewport width. Keep only the positioning container LTR; Naive UI's
+// component-level RTL classes still control the menu/dialog contents.
+html[dir='rtl'] .v-binder-follower-container {
+  direction: ltr;
+}
+
 #app {
   height: 100%;
   width: 100%;

--- a/tests/e2e/i18n-rtl-language-switch.spec.ts
+++ b/tests/e2e/i18n-rtl-language-switch.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test'
+import { authenticate, mockHermesApi, TEST_ACCESS_KEY } from './fixtures'
+
+test('language menu stays usable after switching to an RTL locale', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  await mockHermesApi(page)
+
+  await page.goto('/#/hermes/jobs')
+
+  const languageSwitch = page.locator('.language-switch')
+  const languageMenu = page.locator('.n-base-select-menu')
+  const option = (label: string) =>
+    page.locator('.n-base-select-option').filter({ hasText: new RegExp(`^${label}$`) })
+
+  await languageSwitch.click()
+  await option('العربية').click()
+  await expect(page.locator('html')).toHaveAttribute('dir', 'rtl')
+
+  await languageSwitch.click()
+  await expect(languageMenu).toBeVisible()
+  await expect(languageMenu).toBeInViewport()
+  await option('English').click()
+
+  await expect(page.locator('html')).toHaveAttribute('dir', 'ltr')
+  await expect(languageSwitch).toContainText('English')
+})


### PR DESCRIPTION
## Summary

- Keep Vueuc's teleported follower positioning container in an LTR coordinate system while the document is RTL.
- Preserve Naive UI's component-level RTL rendering for the overlay contents.
- Add an end-to-end regression test that switches to Arabic, reopens the language menu, verifies it remains in the viewport, and switches back to English.

## Root cause

Vueuc measures follower coordinates from the viewport's left edge, but its absolutely positioned follower content has no explicit horizontal inset. In an RTL containing block, the browser first gives it a right-edge static position and then applies Vueuc's left-based `translateX`, shifting the overlay by one full viewport width.

## Impact

Users can reopen and interact with teleported menus after switching to an RTL locale. LTR behavior is unchanged, and the menu contents still render with Naive UI's RTL styles.

## Validation

- `npx playwright test tests/e2e/i18n-rtl-language-switch.spec.ts --project=chromium --reporter=line`
- `npm run test -- tests/client/i18n-direction.test.ts tests/client/naive-rtl.test.ts tests/client/i18n-lazy-loading.test.ts tests/client/app-web-pet.test.ts` (22 tests passed)
- `npm run harness:check`
- `npm run build`
