### PR TITLE
[codex] fix Desktop browser long text and StaticText clicks

### DIFF
--- a/bin/hermes-studio-mcp.mjs
+++ b/bin/hermes-studio-mcp.mjs
@@ -877,8 +877,21 @@ const tools = [
   {
     name: 'hermes_studio_browser_snapshot',
     toolset: 'browser',
-    description: 'Return a bounded accessibility snapshot with stable element refs. Pass its snapshot_id to click or type; stale snapshots are rejected.',
+    description: 'Return a bounded accessibility snapshot with stable element refs. Pass its snapshot_id to read text, click, or type; stale snapshots are rejected.',
     inputSchema: browserInputSchema({ tab_id: { type: 'string' } }, ['tab_id']),
+  },
+  {
+    name: 'hermes_studio_browser_read_text',
+    toolset: 'browser',
+    description: 'Read a bounded page of rendered text from one ref in the latest accessibility snapshot. Use nextOffset while hasMore is true to continue long text safely.',
+    inputSchema: browserInputSchema({
+      tab_id: { type: 'string' },
+      snapshot_id: { type: 'string' },
+      ref: { type: 'string' },
+      mode: { type: 'string', enum: ['innerText', 'textContent'], description: 'Defaults to innerText. Text refs use their parent element for innerText.' },
+      offset: { type: 'number', minimum: 0, description: 'Zero-based source character offset. Defaults to 0.' },
+      limit: { type: 'number', minimum: 1, maximum: 20000, description: 'Maximum source characters to return. Defaults to 4000.' },
+    }, ['tab_id', 'snapshot_id', 'ref']),
   },
   {
     name: 'hermes_studio_browser_interact',
@@ -1752,6 +1765,15 @@ async function callTool(name, args = {}) {
     }
     case 'hermes_studio_browser_snapshot':
       return jsonText(await browserRequest('snapshot', { tab_id: args.tab_id }))
+    case 'hermes_studio_browser_read_text':
+      return jsonText(await browserRequest('text.read', {
+        tab_id: args.tab_id,
+        snapshot_id: args.snapshot_id,
+        ref: args.ref,
+        mode: args.mode,
+        offset: args.offset,
+        limit: args.limit,
+      }))
     case 'hermes_studio_browser_interact': {
       const action = { action: args.action }
       for (const key of ['ref', 'snapshot_id', 'text', 'key', 'direction', 'pixels']) {

--- a/packages/desktop/src/main/browser/browser-automation.ts
+++ b/packages/desktop/src/main/browser/browser-automation.ts
@@ -2,11 +2,14 @@ import { randomUUID } from 'node:crypto'
 import type { WebContents } from 'electron'
 import type {
   BrowserInteractAction,
+  BrowserReadTextOptions,
+  BrowserReadTextResult,
   BrowserScreenshot,
   BrowserSnapshot,
   BrowserSnapshotNode,
 } from './browser-types'
-import { publicBrowserUrl, redactBrowserText } from './browser-url'
+import { MAX_BROWSER_TEXT_READ_LIMIT } from './browser-types'
+import { publicBrowserUrl, redactBrowserContent, redactBrowserText } from './browser-url'
 
 interface AxNode {
   nodeId?: string
@@ -28,6 +31,22 @@ const MAX_SNAPSHOT_NODES = 300
 const MAX_SNAPSHOT_TEXT = 24_000
 const MAX_SCREENSHOT_BYTES = 12 * 1024 * 1024
 const HIGH_RISK_ACTIVATION = /(?:\b(?:buy(?: now)?|purchase|checkout|place order|pay(?: now)?|delete|remove account|publish|post|send|transfer|withdraw|submit order|grant (?:access|permission)|allow access)\b|购买|下单|付款|支付|删除|注销|发布|发送|转账|提现|提交订单|購入|注文|支払|削除|公開|投稿|送信|振込|구매|주문|결제|삭제|게시|전송|송금)/i
+const CLICKABLE_ANCESTOR_SELECTOR = [
+  'button',
+  'a[href]',
+  'input:not([type="hidden"])',
+  'select',
+  'textarea',
+  'summary',
+  'label',
+  '[role="button"]',
+  '[role="link"]',
+  '[role="menuitem"]',
+  '[role="menuitemcheckbox"]',
+  '[role="menuitemradio"]',
+  '[onclick]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
 
 function textValue(value: unknown, limit = 500): string {
   return redactBrowserText(value, limit)
@@ -105,6 +124,78 @@ export class BrowserAutomation {
     }
   }
 
+  async readText(tabId: string, contents: WebContents, options: BrowserReadTextOptions): Promise<BrowserReadTextResult> {
+    await this.ensureAttached(contents)
+    const target = this.resolveRef(tabId, options.snapshotId, options.ref)
+    const offset = Math.max(0, Math.floor(options.offset))
+    const limit = Math.max(1, Math.min(MAX_BROWSER_TEXT_READ_LIMIT, Math.floor(options.limit)))
+    const objectId = await this.resolveObject(contents, target.backendDOMNodeId)
+    try {
+      const response = await contents.debugger.sendCommand('Runtime.callFunctionOn', {
+        objectId,
+        returnByValue: true,
+        arguments: [
+          { value: options.mode },
+          { value: offset },
+          { value: limit },
+        ],
+        functionDeclaration: `function (mode, offset, limit) {
+          const node = this;
+          const element = node && node.nodeType === 3 ? node.parentElement : node;
+          let source = '';
+          if (mode === 'innerText' && element && typeof element.innerText === 'string') {
+            source = element.innerText;
+          } else if (node && typeof node.textContent === 'string') {
+            source = node.textContent;
+          } else if (element && typeof element.textContent === 'string') {
+            source = element.textContent;
+          }
+          const start = Math.min(offset, source.length);
+          const end = Math.min(source.length, start + limit);
+          return {
+            text: source.slice(start, end),
+            totalLength: source.length,
+            offset: start,
+            returnedLength: end - start,
+          };
+        }`,
+      }) as {
+        result?: { value?: { text?: unknown; totalLength?: unknown; offset?: unknown; returnedLength?: unknown } }
+        exceptionDetails?: unknown
+      }
+      const value = response.result?.value
+      if (
+        response.exceptionDetails
+        || !value
+        || typeof value.text !== 'string'
+        || typeof value.totalLength !== 'number'
+        || typeof value.offset !== 'number'
+        || typeof value.returnedLength !== 'number'
+      ) {
+        throw new Error('Unable to read browser element text')
+      }
+      const totalLength = Math.max(0, Math.floor(value.totalLength))
+      const resultOffset = Math.max(0, Math.min(totalLength, Math.floor(value.offset)))
+      const returnedLength = Math.max(0, Math.min(limit, Math.floor(value.returnedLength)))
+      const hasMore = resultOffset + returnedLength < totalLength
+      return {
+        tabId,
+        snapshotId: options.snapshotId,
+        ref: options.ref,
+        mode: options.mode,
+        offset: resultOffset,
+        limit,
+        text: redactBrowserContent(value.text, limit),
+        totalLength,
+        returnedLength,
+        hasMore,
+        ...(hasMore ? { nextOffset: resultOffset + returnedLength } : {}),
+      }
+    } finally {
+      await contents.debugger.sendCommand('Runtime.releaseObject', { objectId }).catch(() => undefined)
+    }
+  }
+
   async interact(tabId: string, contents: WebContents, action: BrowserInteractAction): Promise<void> {
     if (!action || !['click', 'type', 'press', 'scroll'].includes(action.action)) throw new Error('Invalid browser interaction action')
     await this.ensureAttached(contents)
@@ -119,12 +210,19 @@ export class BrowserAutomation {
             objectId,
             returnByValue: true,
             functionDeclaration: `function () {
-              const rect = this.getBoundingClientRect();
+              const node = this;
+              const element = node && node.nodeType === 3 ? node.parentElement : node;
+              if (!element || typeof element.getBoundingClientRect !== 'function') throw new Error('Browser node has no clickable element');
+              const target = typeof element.closest === 'function'
+                ? element.closest(${JSON.stringify(CLICKABLE_ANCESTOR_SELECTOR)}) || element
+                : element;
+              const rect = target.getBoundingClientRect();
               if (!rect || rect.width <= 0 || rect.height <= 0) throw new Error('Element is not visible');
-              this.scrollIntoView({ block: 'center', inline: 'center' });
-              const next = this.getBoundingClientRect();
+              target.scrollIntoView({ block: 'center', inline: 'center' });
+              const next = target.getBoundingClientRect();
               if (next.bottom <= 0 || next.right <= 0 || next.top >= innerHeight || next.left >= innerWidth) throw new Error('Element is outside the viewport');
-              this.click();
+              if (typeof target.click === 'function') target.click();
+              else target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
               return true;
             }`,
           }) as { result?: { value?: unknown }; exceptionDetails?: unknown }
@@ -181,7 +279,7 @@ export class BrowserAutomation {
   interactionRisk(tabId: string, action: BrowserInteractAction): { kind: 'high-risk-activation'; label: string } | null {
     if (action.action !== 'click' || typeof action.snapshot_id !== 'string' || typeof action.ref !== 'string') return null
     const target = this.resolveRef(tabId, action.snapshot_id, action.ref)
-    if (!['button', 'link', 'menuitem', 'menuitemcheckbox', 'menuitemradio'].includes(target.role.toLowerCase())) return null
+    if (!['button', 'link', 'menuitem', 'menuitemcheckbox', 'menuitemradio', 'statictext', 'text', 'inlinetextbox'].includes(target.role.toLowerCase())) return null
     const label = textValue(target.name, 160)
     return label && HIGH_RISK_ACTIVATION.test(label) ? { kind: 'high-risk-activation', label } : null
   }

--- a/packages/desktop/src/main/browser/browser-broker.ts
+++ b/packages/desktop/src/main/browser/browser-broker.ts
@@ -3,7 +3,13 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { chmod, mkdir, rename, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { BrowserManager } from './browser-manager'
-import type { BrowserBrokerDescriptor, BrowserInteractAction } from './browser-types'
+import {
+  DEFAULT_BROWSER_TEXT_READ_LIMIT,
+  MAX_BROWSER_TEXT_READ_LIMIT,
+  type BrowserBrokerDescriptor,
+  type BrowserInteractAction,
+  type BrowserTextMode,
+} from './browser-types'
 import { publicBrowserUrl, redactBrowserText } from './browser-url'
 
 interface BrokerRequest {
@@ -37,6 +43,14 @@ function requiredString(value: unknown, name: string): string {
   const result = typeof value === 'string' ? value.trim() : ''
   if (!result || result.length > 4096) throw new Error(`${name} is required`)
   return result
+}
+
+function boundedInteger(value: unknown, name: string, fallback: number, minimum: number, maximum: number): number {
+  if (value === undefined) return fallback
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`)
+  }
+  return value
 }
 
 function safeEqual(left: string, right: string): boolean {
@@ -230,6 +244,17 @@ export class BrowserBroker {
         }
         case 'snapshot':
           return await this.manager.snapshot(requiredString(params.tab_id, 'tab_id'))
+        case 'text.read': {
+          const mode = params.mode === undefined ? 'innerText' : requiredString(params.mode, 'mode')
+          if (mode !== 'innerText' && mode !== 'textContent') throw new Error('mode must be innerText or textContent')
+          return await this.manager.readText(requiredString(params.tab_id, 'tab_id'), {
+            snapshotId: requiredString(params.snapshot_id, 'snapshot_id'),
+            ref: requiredString(params.ref, 'ref'),
+            mode: mode as BrowserTextMode,
+            offset: boundedInteger(params.offset, 'offset', 0, 0, Number.MAX_SAFE_INTEGER),
+            limit: boundedInteger(params.limit, 'limit', DEFAULT_BROWSER_TEXT_READ_LIMIT, 1, MAX_BROWSER_TEXT_READ_LIMIT),
+          })
+        }
         case 'interact': {
           const tab = await this.manager.interact(requiredString(params.tab_id, 'tab_id'), asObject(params.action) as unknown as BrowserInteractAction)
           return this.publicTab(tab)

--- a/packages/desktop/src/main/browser/browser-manager.ts
+++ b/packages/desktop/src/main/browser/browser-manager.ts
@@ -25,6 +25,7 @@ import type {
   BrowserProfileCreateInput,
   BrowserProfileSwitchImpact,
   BrowserProfileUpdateInput,
+  BrowserReadTextOptions,
   BrowserSelection,
   BrowserSitePermission,
   DesktopBrowserDownload,
@@ -379,6 +380,11 @@ export class BrowserManager {
   async snapshot(tabId: string) {
     const record = this.requireTab(tabId)
     return this.automation.snapshot(tabId, record.view.webContents)
+  }
+
+  async readText(tabId: string, options: BrowserReadTextOptions) {
+    const record = this.requireTab(tabId)
+    return this.automation.readText(tabId, record.view.webContents, options)
   }
 
   async interact(tabId: string, action: BrowserInteractAction): Promise<DesktopBrowserTab> {

--- a/packages/desktop/src/main/browser/browser-types.ts
+++ b/packages/desktop/src/main/browser/browser-types.ts
@@ -105,6 +105,33 @@ export interface BrowserSnapshot {
   text: string
 }
 
+export type BrowserTextMode = 'innerText' | 'textContent'
+
+export const DEFAULT_BROWSER_TEXT_READ_LIMIT = 4_000
+export const MAX_BROWSER_TEXT_READ_LIMIT = 20_000
+
+export interface BrowserReadTextOptions {
+  snapshotId: string
+  ref: string
+  mode: BrowserTextMode
+  offset: number
+  limit: number
+}
+
+export interface BrowserReadTextResult {
+  tabId: string
+  snapshotId: string
+  ref: string
+  mode: BrowserTextMode
+  offset: number
+  limit: number
+  text: string
+  totalLength: number
+  returnedLength: number
+  hasMore: boolean
+  nextOffset?: number
+}
+
 export interface BrowserScreenshot {
   tabId: string
   url: string

--- a/packages/desktop/src/main/browser/browser-url.ts
+++ b/packages/desktop/src/main/browser/browser-url.ts
@@ -8,15 +8,23 @@ const BLOCKED_HOSTS = new Set([
 ])
 const SENSITIVE_QUERY_KEY = /^(?:access[_-]?token|refresh[_-]?token|id[_-]?token|token|api[_-]?key|secret|password|authorization|auth|code|session)$/i
 
-export function redactBrowserText(input: unknown, limit = 500): string {
+function redactBrowserSecrets(input: unknown): string {
   return String(input ?? '')
     .replace(/\bAuthorization\s*([:=])\s*Bearer\s+[A-Za-z0-9._~+\/-]+=*/gi, 'Authorization$1 Bearer [redacted]')
     .replace(/\b(access[_-]?token|refresh[_-]?token|id[_-]?token|api[_-]?key|password|secret)\s*([:=])\s*([^\s&,;]+)/gi, '$1$2[redacted]')
     .replace(/\bBearer\s+[A-Za-z0-9._~+\/-]+=*/gi, 'Bearer [redacted]')
     .replace(/\bAuthorization\s*([:=])\s*(?!Bearer\s+\[redacted\])(?:Basic\s+)?[^\s&,;]+/gi, 'Authorization$1[redacted]')
+}
+
+export function redactBrowserText(input: unknown, limit = 500): string {
+  return redactBrowserSecrets(input)
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, limit)
+}
+
+export function redactBrowserContent(input: unknown, limit: number): string {
+  return redactBrowserSecrets(input).slice(0, limit)
 }
 
 export function publicBrowserUrl(input: string): string {

--- a/tests/desktop/browser-automation.test.ts
+++ b/tests/desktop/browser-automation.test.ts
@@ -2,13 +2,19 @@ import { describe, expect, it } from 'vitest'
 import type { WebContents } from 'electron'
 import { BrowserAutomation } from '../../packages/desktop/src/main/browser/browser-automation'
 
-function fakeContents(options: { attributes?: string[]; protectedValue?: boolean; role?: string; name?: string } = {}): WebContents {
+function fakeContents(options: {
+  attributes?: string[]
+  protectedValue?: boolean
+  role?: string
+  name?: string
+  runtimeCall?: (params: Record<string, any>) => unknown
+} = {}): WebContents {
   let attached = false
   const debuggerApi = {
     isAttached: () => attached,
     attach: () => { attached = true },
     detach: () => { attached = false },
-    sendCommand: async (method: string) => {
+    sendCommand: async (method: string, params: Record<string, any> = {}) => {
       if (method === 'Accessibility.getFullAXTree') {
         return {
           nodes: [{
@@ -22,7 +28,9 @@ function fakeContents(options: { attributes?: string[]; protectedValue?: boolean
       }
       if (method === 'DOM.describeNode') return { node: { nodeName: 'INPUT', attributes: options.attributes || [] } }
       if (method === 'DOM.resolveNode') return { object: { objectId: 'object-1' } }
-      if (method === 'Runtime.callFunctionOn') return { result: { value: true } }
+      if (method === 'Runtime.callFunctionOn') {
+        return options.runtimeCall ? options.runtimeCall(params) : { result: { value: true } }
+      }
       return {}
     },
   }
@@ -64,11 +72,71 @@ describe('desktop browser automation safety', () => {
 
   it('clicks a current safe element through its resolved DOM object', async () => {
     const automation = new BrowserAutomation()
-    const contents = fakeContents()
+    let clickFunction = ''
+    const contents = fakeContents({
+      runtimeCall: (params) => {
+        clickFunction = String(params.functionDeclaration || '')
+        return { result: { value: true } }
+      },
+    })
     const snapshot = await automation.snapshot('tab-1', contents)
     await expect(automation.interact('tab-1', contents, {
       action: 'click', snapshot_id: snapshot.snapshotId, ref: '@e1',
     })).resolves.toBeUndefined()
+    expect(clickFunction).toContain('node.nodeType === 3 ? node.parentElement')
+    expect(clickFunction).toContain('.closest(')
+  })
+
+  it('reads long text from a current snapshot ref in bounded pages', async () => {
+    const source = `First line\n${'x'.repeat(1_100)}\nLast line`
+    const automation = new BrowserAutomation()
+    const contents = fakeContents({
+      name: source,
+      role: 'StaticText',
+      runtimeCall: (params) => {
+        const offset = Number(params.arguments?.[1]?.value || 0)
+        const limit = Number(params.arguments?.[2]?.value || 0)
+        const end = Math.min(source.length, offset + limit)
+        return {
+          result: {
+            value: {
+              text: source.slice(offset, end),
+              totalLength: source.length,
+              offset,
+              returnedLength: end - offset,
+            },
+          },
+        }
+      },
+    })
+    const snapshot = await automation.snapshot('tab-1', contents)
+
+    expect(snapshot.nodes[0].name).toHaveLength(500)
+    const first = await automation.readText('tab-1', contents, {
+      snapshotId: snapshot.snapshotId,
+      ref: '@e1',
+      mode: 'innerText',
+      offset: 0,
+      limit: 700,
+    })
+    expect(first).toMatchObject({
+      text: source.slice(0, 700),
+      totalLength: source.length,
+      returnedLength: 700,
+      hasMore: true,
+      nextOffset: 700,
+    })
+
+    const second = await automation.readText('tab-1', contents, {
+      snapshotId: snapshot.snapshotId,
+      ref: '@e1',
+      mode: 'innerText',
+      offset: first.nextOffset!,
+      limit: 700,
+    })
+    expect(`${first.text}${second.text}`).toBe(source)
+    expect(second.hasMore).toBe(false)
+    expect(second.nextOffset).toBeUndefined()
   })
 
   it('requires user confirmation for high-risk activation labels', async () => {
@@ -79,5 +147,15 @@ describe('desktop browser automation safety', () => {
     expect(automation.interactionRisk('tab-1', {
       action: 'click', snapshot_id: snapshot.snapshotId, ref: '@e1',
     })).toEqual({ kind: 'high-risk-activation', label: 'Delete account' })
+  })
+
+  it('keeps high-risk confirmation for StaticText refs promoted to clickable parents', async () => {
+    const automation = new BrowserAutomation()
+    const contents = fakeContents({ role: 'StaticText', name: 'Send payment' })
+    const snapshot = await automation.snapshot('tab-1', contents)
+
+    expect(automation.interactionRisk('tab-1', {
+      action: 'click', snapshot_id: snapshot.snapshotId, ref: '@e1',
+    })).toEqual({ kind: 'high-risk-activation', label: 'Send payment' })
   })
 })

--- a/tests/desktop/browser-broker.test.ts
+++ b/tests/desktop/browser-broker.test.ts
@@ -74,6 +74,72 @@ describe('Desktop Browser Broker', () => {
     }
   })
 
+  it('validates and forwards bounded text reads for snapshot refs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hermes-browser-broker-read-text-'))
+    roots.push(root)
+    const tabs = [{ id: 'tab-1', agentControl: 'idle' }]
+    const manager = {
+      state: () => ({ tabs }),
+      readText: async (tabId: string, options: Record<string, unknown>) => ({
+        tabId,
+        ...options,
+        text: 'full text',
+        totalLength: 9,
+        returnedLength: 9,
+        hasMore: false,
+      }),
+      setAgentControl: (tabId: string, control: string) => { const tab = tabs.find(item => item.id === tabId); if (tab) tab.agentControl = control },
+      revokeAgentControl: (tabId: string) => { const tab = tabs.find(item => item.id === tabId); if (tab) tab.agentControl = 'idle' },
+      cancelAgentOperation: (tabId: string) => { const tab = tabs.find(item => item.id === tabId); if (tab) tab.agentControl = 'idle' },
+    } as unknown as BrowserManager
+    const broker = new BrowserBroker(manager, root)
+    const descriptor = await broker.start()
+
+    try {
+      const registration = await fetch(`${descriptor.endpoint}/session`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${descriptor.token}`, 'Content-Type': 'application/json' },
+        body: '{}',
+      })
+      const client = await registration.json() as { client_id: string; session_token: string }
+      const invoke = (limit: number) => fetch(descriptor.endpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${client.session_token}`,
+          'Content-Type': 'application/json',
+          'X-Hermes-Browser-Client': client.client_id,
+        },
+        body: JSON.stringify({
+          method: 'text.read',
+          params: {
+            tab_id: 'tab-1',
+            snapshot_id: 'snapshot-1',
+            ref: '@e1',
+            mode: 'textContent',
+            offset: 10,
+            limit,
+          },
+        }),
+      })
+
+      const response = await invoke(2_000)
+      expect(response.status).toBe(200)
+      expect((await response.json()).result).toMatchObject({
+        tabId: 'tab-1',
+        snapshotId: 'snapshot-1',
+        ref: '@e1',
+        mode: 'textContent',
+        offset: 10,
+        limit: 2_000,
+      })
+      const oversized = await invoke(20_001)
+      expect(oversized.status).toBe(400)
+      expect((await oversized.json()).error).toContain('limit must be an integer between 1 and 20000')
+    } finally {
+      await broker.stop()
+    }
+  })
+
   it('reclaims a tab lease when its registered MCP process has exited', async () => {
     const root = await mkdtemp(join(tmpdir(), 'hermes-browser-broker-stale-client-'))
     roots.push(root)

--- a/tests/desktop/browser-security.test.ts
+++ b/tests/desktop/browser-security.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { BrowserProfileStore } from '../../packages/desktop/src/main/browser/browser-profile-store'
-import { isAllowedBrowserRequest, isAllowedBrowserSubresource, normalizeBrowserUrl, publicBrowserUrl, redactBrowserText } from '../../packages/desktop/src/main/browser/browser-url'
+import { isAllowedBrowserRequest, isAllowedBrowserSubresource, normalizeBrowserUrl, publicBrowserUrl, redactBrowserContent, redactBrowserText } from '../../packages/desktop/src/main/browser/browser-url'
 
 const roots: string[] = []
 
@@ -42,6 +42,7 @@ describe('desktop browser security primitives', () => {
     expect(isAllowedBrowserSubresource('file:///tmp/secret')).toBe(false)
     expect(publicBrowserUrl('https://example.com/callback?code=secret-code&view=ok#access_token=secret')).toBe('https://example.com/callback?code=%5Bredacted%5D&view=ok#[redacted]')
     expect(redactBrowserText('Authorization: Bearer very.secret.token')).toBe('Authorization: Bearer [redacted]')
+    expect(redactBrowserContent('first line\napi_key=secret-value\nlast line', 100)).toBe('first line\napi_key=[redacted]\nlast line')
   })
 
   it('applies profile storage and proxy changes before restored tabs load', async () => {

--- a/tests/server/hermes-studio-browser-mcp.test.ts
+++ b/tests/server/hermes-studio-browser-mcp.test.ts
@@ -98,6 +98,8 @@ describe('hermes-studio browser MCP toolset', () => {
         ? { tabId: 'tab-1', url: 'https://example.com/', title: 'Example', mediaType: 'image/png', data: 'AA==', width: 1, height: 1 }
         : body.method === 'snapshot'
           ? { tabId: 'tab-1', snapshotId: 'snapshot-1', text: '@e1 button name="Example"' }
+          : body.method === 'text.read'
+            ? { tabId: 'tab-1', snapshotId: 'snapshot-1', ref: '@e1', text: 'Complete text', totalLength: 13, returnedLength: 13, hasMore: false }
         : { tabs: [{ id: 'tab-1' }] }
       response.end(JSON.stringify({ operation_id: body.operation_id, result }))
     })
@@ -131,7 +133,7 @@ describe('hermes-studio browser MCP toolset', () => {
     })
     expect(JSON.parse(catalog.result.content[0].text)).toMatchObject({
       toolset: 'browser',
-      operation_count: 6,
+      operation_count: 7,
     })
     const described = await rpc(4, 'tools/call', {
       name: 'hermes_studio_browser_toolset',
@@ -148,13 +150,30 @@ describe('hermes-studio browser MCP toolset', () => {
       arguments: { action: 'call', tool: 'hermes_studio_browser_screenshot', arguments: { tab_id: 'tab-1' } },
     })
     expect(screenshot.result.content[1]).toEqual({ type: 'image', data: 'AA==', mimeType: 'image/png' })
-    expect(clients).toHaveLength(2)
+    const readText = await rpc(7, 'tools/call', {
+      name: 'hermes_studio_browser_toolset',
+      arguments: {
+        action: 'call',
+        tool: 'hermes_studio_browser_read_text',
+        arguments: { tab_id: 'tab-1', snapshot_id: 'snapshot-1', ref: '@e1', offset: 0, limit: 4000 },
+      },
+    })
+    expect(JSON.parse(readText.result.content[0].text)).toMatchObject({
+      result: {
+        snapshotId: 'snapshot-1',
+        ref: '@e1',
+        text: 'Complete text',
+        hasMore: false,
+      },
+    })
+    expect(clients).toHaveLength(3)
     expect(clients[0]).toBeTruthy()
     expect(clients[0]).toBe(clients[1])
+    expect(clients[1]).toBe(clients[2])
     expect(registeredPids).toEqual([child.pid])
 
     failScreenshot = true
-    const fallback = await rpc(7, 'tools/call', {
+    const fallback = await rpc(8, 'tools/call', {
       name: 'hermes_studio_browser_toolset',
       arguments: { action: 'call', tool: 'hermes_studio_browser_screenshot', arguments: { tab_id: 'tab-1' } },
     })
@@ -162,7 +181,7 @@ describe('hermes-studio browser MCP toolset', () => {
     expect(fallback.result.content[0].text).toContain('snapshot-1')
 
     await rm(join(brokerRoot, 'broker.json'))
-    const unavailable = await rpc(8, 'tools/list')
+    const unavailable = await rpc(9, 'tools/list')
     expect(unavailable.result.tools).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- add a constrained `hermes_studio_browser_read_text` operation for paginating long text from a current accessibility snapshot ref
- resolve Text/StaticText refs to a clickable ancestor before interaction while preserving high-risk activation confirmation
- keep browser text bounded and redact sensitive values in full-text responses

## Root cause
Accessibility snapshot node names, values, and descriptions are intentionally capped at 500 characters, but there was no safe follow-up operation to retrieve the remainder. Click handling also called element-only methods directly on resolved DOM objects, which fails when an accessibility ref resolves to a Text node.

## Impact
Agents can now retrieve complete long prompts, code blocks, logs, and metadata in bounded chunks, and can activate controls whose snapshot ref points at their visible text.

Closes #2274

## Validation
- `npm run test -- tests/desktop/browser-security.test.ts tests/desktop/browser-automation.test.ts tests/desktop/browser-broker.test.ts tests/server/hermes-studio-browser-mcp.test.ts`
- `npm --prefix packages/desktop run build:main`
- `npm run harness:check`
- `npm run build`
