### PR TITLE
Fix model provider dropdown positioning

### DIFF
--- a/docs/chat-chain-changes/2026-07-30-session-model-provider-footer.md
+++ b/docs/chat-chain-changes/2026-07-30-session-model-provider-footer.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-30
+pr: pending
+feature: Session model provider footer
+impact: Custom provider controls stay visible below scrollable model lists in session and sidebar model selectors.
+---
+
+The custom provider and model inputs are now outside the selectors' scrollable model lists. This keeps the provider dropdown anchored to a stable modal footer without changing model selection, session switching, or chat execution behavior.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2212,28 +2212,6 @@ async function handleSessionModelCustomSubmit() {
         <div v-if="filteredSessionModelGroups.length === 0" class="session-model-empty">
           {{ sessionModelSearch ? 'No results' : 'No models' }}
         </div>
-        <div class="session-model-custom">
-          <div class="session-model-custom-row">
-            <NSelect
-              v-model:value="sessionModelCustomProvider"
-              :options="sessionModelProviderOptions"
-              :disabled="sessionModelSwitching"
-              size="small"
-              class="session-model-custom-provider"
-            />
-            <NInput
-              v-model:value="sessionModelCustomInput"
-              :placeholder="t('models.customModelPlaceholder')"
-              :disabled="sessionModelSwitching"
-              size="small"
-              class="session-model-custom-input"
-              @keydown.enter="handleSessionModelCustomSubmit"
-            />
-          </div>
-          <div class="session-model-custom-hint">
-            {{ t('models.customModelHint') }}
-          </div>
-        </div>
         </div>
         <div v-else class="session-model-list" :aria-busy="sessionModelSwitching">
           <div class="session-model-group-items session-moa-items">
@@ -2269,6 +2247,28 @@ async function handleSessionModelCustomSubmit() {
           </div>
           <div v-if="filteredSessionMoaModels.length === 0" class="session-model-empty">
             {{ t('chat.noMoaPresets') }}
+          </div>
+        </div>
+        <div v-if="sessionModelKind === 'model'" class="session-model-custom">
+          <div class="session-model-custom-row">
+            <NSelect
+              v-model:value="sessionModelCustomProvider"
+              :options="sessionModelProviderOptions"
+              :disabled="sessionModelSwitching"
+              size="small"
+              class="session-model-custom-provider"
+            />
+            <NInput
+              v-model:value="sessionModelCustomInput"
+              :placeholder="t('models.customModelPlaceholder')"
+              :disabled="sessionModelSwitching"
+              size="small"
+              class="session-model-custom-input"
+              @keydown.enter="handleSessionModelCustomSubmit"
+            />
+          </div>
+          <div class="session-model-custom-hint">
+            {{ t('models.customModelHint') }}
           </div>
         </div>
       </NSpin>

--- a/packages/client/src/components/layout/ModelSelector.vue
+++ b/packages/client/src/components/layout/ModelSelector.vue
@@ -246,25 +246,25 @@ async function handleRefresh() {
         <div v-if="filteredGroups.length === 0" class="model-empty">
           {{ searchQuery ? 'No results' : 'No models' }}
         </div>
-        <div class="model-custom">
-          <div class="model-custom-row">
-            <NSelect
-              v-model:value="customProvider"
-              :options="providerOptions"
-              size="small"
-              class="model-custom-provider"
-            />
-            <NInput
-              v-model:value="customInput"
-              :placeholder="t('models.customModelPlaceholder')"
-              size="small"
-              class="model-custom-input"
-              @keydown.enter="handleCustomSubmit"
-            />
-          </div>
-          <div class="model-custom-hint">
-            {{ t('models.customModelHint') }}
-          </div>
+      </div>
+      <div class="model-custom">
+        <div class="model-custom-row">
+          <NSelect
+            v-model:value="customProvider"
+            :options="providerOptions"
+            size="small"
+            class="model-custom-provider"
+          />
+          <NInput
+            v-model:value="customInput"
+            :placeholder="t('models.customModelPlaceholder')"
+            size="small"
+            class="model-custom-input"
+            @keydown.enter="handleCustomSubmit"
+          />
+        </div>
+        <div class="model-custom-hint">
+          {{ t('models.customModelHint') }}
         </div>
       </div>
     </NModal>

--- a/tests/client/chat-panel-session-click.test.ts
+++ b/tests/client/chat-panel-session-click.test.ts
@@ -47,6 +47,21 @@ describe('ChatPanel session clicks', () => {
     expect(source).not.toContain('if (isActiveSessionCodingAgent.value) return')
   })
 
+  it('keeps the custom session model provider below the scrollable model lists', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+    const modalStart = source.indexOf('v-model:show="showSessionModelModal"')
+    const modalEnd = source.indexOf('</NModal>', modalStart)
+    const modal = source.slice(modalStart, modalEnd)
+    const standardList = modal.indexOf('<div v-if="sessionModelKind === \'model\'" class="session-model-list"')
+    const moaList = modal.indexOf('<div v-else class="session-model-list"', standardList)
+    const customFooter = modal.indexOf('<div v-if="sessionModelKind === \'model\'" class="session-model-custom"', moaList)
+
+    expect(standardList).toBeGreaterThanOrEqual(0)
+    expect(moaList).toBeGreaterThan(standardList)
+    expect(customFooter).toBeGreaterThan(moaList)
+    expect(modal.slice(standardList, moaList)).not.toContain('session-model-custom')
+  })
+
   it('uses codingAgentId to filter scoped agent models and requests an API mode for all scoped agents', () => {
     const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
 

--- a/tests/client/model-selector-layout.test.ts
+++ b/tests/client/model-selector-layout.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+
+function findClosingDiv(source: string, start: number): number {
+  const divTag = /<\/?div\b[^>]*>/g
+  divTag.lastIndex = start
+
+  let depth = 0
+  for (let match = divTag.exec(source); match; match = divTag.exec(source)) {
+    depth += match[0].startsWith('</') ? -1 : 1
+    if (depth === 0) return divTag.lastIndex
+  }
+
+  return -1
+}
+
+describe('ModelSelector layout', () => {
+  it('keeps the custom provider controls below the scrollable model list', () => {
+    const source = readFileSync('packages/client/src/components/layout/ModelSelector.vue', 'utf8')
+    const modalStart = source.indexOf('<NModal')
+    const modalEnd = source.indexOf('</NModal>', modalStart)
+    const modal = source.slice(modalStart, modalEnd)
+    const modelListStart = modal.indexOf('<div class="model-list">')
+    const modelListEnd = findClosingDiv(modal, modelListStart)
+    const customFooter = modal.indexOf('<div class="model-custom">')
+
+    expect(modelListStart).toBeGreaterThanOrEqual(0)
+    expect(modelListEnd).toBeGreaterThan(modelListStart)
+    expect(customFooter).toBeGreaterThan(modelListEnd)
+    expect(modal.slice(modelListStart, modelListEnd)).not.toContain('class="model-custom"')
+  })
+})


### PR DESCRIPTION
## Summary

- move the custom Provider/model controls outside the scrollable model list in the session model modal
- apply the same footer layout to the sidebar model selector
- keep Hermes MoA selection behavior unchanged
- add layout regression coverage and the required chat-chain change fragment

## Root cause

The custom Provider selector was rendered inside a container with `overflow-y: auto`, so the selector control moved with the model list and its portaled dropdown could appear detached or incorrectly positioned.

## User impact

The custom Provider controls now remain anchored below the scrollable model list, making the dropdown usable after the modal content has been scrolled. The workflow selector is a separate component and does not contain this custom Provider dropdown.

## Validation

- `npm run test -- tests/client/chat-panel-session-click.test.ts tests/client/model-selector-layout.test.ts`
- `npm run build`
- `npm run harness:check`
- `git diff --check`

Closes #2272
