### PR TITLE
fix(write-gate): detect approval failures and prevent concurrent approvals

### DIFF
--- a/packages/client/src/components/hermes/skills/PendingWriteApprovals.vue
+++ b/packages/client/src/components/hermes/skills/PendingWriteApprovals.vue
@@ -21,6 +21,9 @@ const { t } = useI18n()
 const message = useMessage()
 const pendingWrites = ref<PendingWriteRecord[]>([])
 const pendingLoading = ref(false)
+// Per-button loading state: each action key (e.g. "skills:abc123:approve")
+// is tracked independently so clicking one button does not clear another's
+// loading/disabled state, preventing concurrent approval requests.
 const pendingActions = ref<Set<string>>(new Set())
 const expandedReviews = ref<Record<string, string>>({})
 const writeGateSupported = ref(true)

--- a/packages/client/src/components/hermes/skills/PendingWriteApprovals.vue
+++ b/packages/client/src/components/hermes/skills/PendingWriteApprovals.vue
@@ -21,7 +21,7 @@ const { t } = useI18n()
 const message = useMessage()
 const pendingWrites = ref<PendingWriteRecord[]>([])
 const pendingLoading = ref(false)
-const pendingAction = ref('')
+const pendingActions = ref<Set<string>>(new Set())
 const expandedReviews = ref<Record<string, string>>({})
 const writeGateSupported = ref(true)
 const pendingCount = computed(() => pendingWrites.value.length)
@@ -116,27 +116,38 @@ async function toggleDiff(record: PendingWriteRecord) {
     expandedReviews.value = next
     return
   }
-  pendingAction.value = `${key}:diff`
+  const actionKey = `${key}:diff`
+  pendingActions.value.add(actionKey)
   try {
     const review = await fetchPendingWriteReview(record.subsystem, record.id)
     expandedReviews.value = { ...expandedReviews.value, [key]: buildReviewMarkdown(review) }
   } catch (err: any) {
     message.error(t('skills.writeApprovalDiffFailed'))
   } finally {
-    pendingAction.value = ''
+    pendingActions.value.delete(actionKey)
   }
 }
 
 async function resolvePendingWrite(record: PendingWriteRecord, decision: 'approve' | 'reject') {
   const key = pendingKey(record)
-  pendingAction.value = `${key}:${decision}`
+  const actionKey = `${key}:${decision}`
+  pendingActions.value.add(actionKey)
   try {
+    let result: { success?: boolean; output?: string }
     if (decision === 'approve') {
-      await approvePendingWrite(record.subsystem, record.id)
-      message.success(t('skills.writeApprovalApproved'))
+      result = await approvePendingWrite(record.subsystem, record.id)
     } else {
-      await rejectPendingWrite(record.subsystem, record.id)
-      message.success(t('skills.writeApprovalRejected'))
+      result = await rejectPendingWrite(record.subsystem, record.id)
+    }
+    if (result.success === false) {
+      message.error(result.output || t('skills.writeApprovalActionFailed'))
+    } else {
+      message.success(decision === 'approve'
+        ? t('skills.writeApprovalApproved')
+        : t('skills.writeApprovalRejected'))
+      // Optimistic removal before re-fetch
+      pendingWrites.value = pendingWrites.value.filter(r => pendingKey(r) !== key)
+      emit('count-change', pendingWrites.value.length)
     }
     const nextReviews = { ...expandedReviews.value }
     delete nextReviews[key]
@@ -145,7 +156,7 @@ async function resolvePendingWrite(record: PendingWriteRecord, decision: 'approv
   } catch (err: any) {
     message.error(t('skills.writeApprovalActionFailed'))
   } finally {
-    pendingAction.value = ''
+    pendingActions.value.delete(actionKey)
   }
 }
 
@@ -191,7 +202,7 @@ onMounted(() => {
           <NButton
             size="tiny"
             quaternary
-            :loading="pendingAction === `${pendingKey(record)}:diff`"
+            :loading="pendingActions.has(`${pendingKey(record)}:diff`)"
             @click="toggleDiff(record)"
           >
             {{ expandedReviews[pendingKey(record)] ? t('skills.writeApprovalHideDiff') : t('skills.writeApprovalViewDiff') }}
@@ -199,7 +210,7 @@ onMounted(() => {
           <NButton
             size="tiny"
             type="success"
-            :loading="pendingAction === `${pendingKey(record)}:approve`"
+            :loading="pendingActions.has(`${pendingKey(record)}:approve`)"
             @click="resolvePendingWrite(record, 'approve')"
           >
             {{ t('skills.writeApprovalApprove') }}
@@ -208,7 +219,7 @@ onMounted(() => {
             size="tiny"
             quaternary
             type="error"
-            :loading="pendingAction === `${pendingKey(record)}:reject`"
+            :loading="pendingActions.has(`${pendingKey(record)}:reject`)"
             @click="resolvePendingWrite(record, 'reject')"
           >
             {{ t('skills.writeApprovalReject') }}

--- a/packages/server/src/controllers/hermes/write-gate.ts
+++ b/packages/server/src/controllers/hermes/write-gate.ts
@@ -70,7 +70,10 @@ function outputIndicatesFailure(output: string): boolean {
 
 function handleApprovalResult(ctx: Context, output: string) {
   if (outputIndicatesFailure(output)) {
-    ctx.status = 422
+    // Return HTTP 200 with success:false so the frontend can inspect the
+    // output field for the specific failure reason. A non-2xx status would
+    // cause the client's request() helper to throw before the caller ever
+    // sees the response body.
     ctx.body = { success: false, output }
   } else {
     ctx.body = { success: true, output }

--- a/packages/server/src/controllers/hermes/write-gate.ts
+++ b/packages/server/src/controllers/hermes/write-gate.ts
@@ -53,13 +53,35 @@ export async function diff(ctx: Context) {
   }
 }
 
+/**
+ * Detect failure indicators in the Python subprocess output.
+ * The Python helper (handle_pending_subcommand) returns error messages as
+ * plain text without raising exceptions, so we must inspect the output string.
+ */
+function outputIndicatesFailure(output: string): boolean {
+  if (!output) return false
+  return (
+    /Approved 0 /i.test(output) ||
+    /Rejected 0 /i.test(output) ||
+    /Failed:/i.test(output) ||
+    /No pending .* write with id/i.test(output)
+  )
+}
+
+function handleApprovalResult(ctx: Context, output: string) {
+  if (outputIndicatesFailure(output)) {
+    ctx.status = 422
+    ctx.body = { success: false, output }
+  } else {
+    ctx.body = { success: true, output }
+  }
+}
+
 export async function approve(ctx: Context) {
   try {
     const { subsystem, id } = pendingParams(ctx)
-    ctx.body = {
-      success: true,
-      output: await approvePendingWrite(requestedProfile(ctx), subsystem, id),
-    }
+    const output = await approvePendingWrite(requestedProfile(ctx), subsystem, id)
+    handleApprovalResult(ctx, output)
   } catch (err: any) {
     handleError(ctx, err)
   }
@@ -68,10 +90,8 @@ export async function approve(ctx: Context) {
 export async function reject(ctx: Context) {
   try {
     const { subsystem, id } = pendingParams(ctx)
-    ctx.body = {
-      success: true,
-      output: await rejectPendingWrite(requestedProfile(ctx), subsystem, id),
-    }
+    const output = await rejectPendingWrite(requestedProfile(ctx), subsystem, id)
+    handleApprovalResult(ctx, output)
   } catch (err: any) {
     handleError(ctx, err)
   }


### PR DESCRIPTION
Fixes #2280

## Changes

### Server (`packages/server/src/controllers/hermes/write-gate.ts`)
- Parse Python subprocess output for failure indicators (`Approved 0`, `Failed:`, `No pending write with id`)
- Return `success: false` with the failure output when approval actually failed, instead of hardcoded `success: true`
- Uses HTTP 200 + `success: false` (not 4xx) so the frontend `request()` helper doesn't throw before the caller can inspect the output field
- Applies to both `approve` and `reject` endpoints

### Client (`packages/client/src/components/hermes/skills/PendingWriteApprovals.vue`)
- Check `result.success` field — show red error toast with the specific Python failure reason when `false`
- Replace single `pendingAction` ref<string> with `pendingActions` ref<Set<string>> for per-button independent loading/disabled state, preventing concurrent approvals
- Add optimistic UI removal on successful approval (splice record before re-fetch)

## Testing

- Top-to-bottom sequential approval: works (unchanged behavior)
- Bottom-to-top rapid clicking: each button now has independent loading state, preventing concurrent requests
- Failed approval (e.g. patch conflict): now shows red error toast with Python output instead of green success
