### PR TITLE
Restore message scroll positions by anchor

### DIFF
--- a/docs/chat-chain-changes/2026-07-30-message-scroll-anchor-restoration.md
+++ b/docs/chat-chain-changes/2026-07-30-message-scroll-anchor-restoration.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-30
+pr: pending
+feature: Message scroll anchor restoration
+impact: Live chat and history views restore the previously visible message without sharing scroll state across profiles or surfaces.
+---
+
+Message scroll snapshots now include the top visible message and its viewport offset. Scroll state is scoped by surface, profile, and session; when the saved message is no longer available, the transcript falls back to the bottom instead of applying a stale pixel offset.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2650,6 +2650,7 @@ async function handleSessionModelCustomSubmit() {
             <MessageList
               ref="messageListRef"
               :approval-portal-to-body="showRealtimeVoice"
+              scroll-scope="chat"
             />
             <ChatInput
               ref="chatInputRef"

--- a/packages/client/src/components/hermes/chat/HistoryMessageList.vue
+++ b/packages/client/src/components/hermes/chat/HistoryMessageList.vue
@@ -1,12 +1,7 @@
 <script lang="ts">
-type HistorySessionScrollSnapshot = {
-  scrollTop: number;
-  scrollHeight: number;
-  clientHeight: number;
-  wasNearBottom: boolean;
-}
+import type { MessageViewportScrollSnapshot } from "./message-scroll-position";
 
-const historySessionScrollPositions = new Map<string, HistorySessionScrollSnapshot>();
+const historySessionScrollPositions = new Map<string, MessageViewportScrollSnapshot>();
 </script>
 
 <script setup lang="ts">
@@ -17,20 +12,27 @@ import MessageItem from "./MessageItem.vue";
 import { useChatStore } from "@/stores/hermes/chat";
 import { useToolTraceVisibility } from "@/composables/useToolTraceVisibility";
 import type { Session } from "@/stores/hermes/chat";
+import { messageScrollPositionKey, rememberMessageScrollPosition } from "./message-scroll-position";
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   session?: Session | null; // Optional: use this session instead of chatStore.activeSession
   loadOlder?: (sessionId: string) => Promise<boolean>;
-}>();
+  scrollScope?: string;
+}>(), {
+  scrollScope: "history",
+});
 
 const chatStore = useChatStore();
 const { toolTraceVisible } = useToolTraceVisibility();
 const { t } = useI18n();
 const listRef = ref<InstanceType<typeof VirtualMessageList> | null>(null);
-const pendingInitialScrollSessionId = ref<string | null>(null);
+const pendingInitialScrollKey = ref<string | null>(null);
 const showScrollBottomButton = ref(false);
 const activeSession = computed(() => props.session || null);
-const listInstanceKey = computed(() => activeSession.value?.id ? `history-${activeSession.value.id}` : "history-empty");
+const activeSessionScrollKey = computed(() =>
+  messageScrollPositionKey(props.scrollScope, activeSession.value),
+);
+const listInstanceKey = computed(() => activeSessionScrollKey.value || "history-empty");
 
 const displayMessages = computed(() =>
   (activeSession.value?.messages || []).filter((m) => {
@@ -71,23 +73,23 @@ function handleScrollBottomClick() {
   scrollToBottom();
 }
 
-function saveSessionScrollPosition(sessionId: string | null | undefined) {
-  if (!sessionId) return;
+function saveSessionScrollPosition(scrollKey: string | null | undefined) {
+  if (!scrollKey) return;
   const snapshot = listRef.value?.captureViewportPosition() ?? null;
-  if (snapshot) historySessionScrollPositions.set(sessionId, snapshot);
+  if (snapshot) rememberMessageScrollPosition(historySessionScrollPositions, scrollKey, snapshot);
 }
 
-function applyInitialSessionScroll(sessionId: string) {
-  if (activeSession.value?.id !== sessionId) return;
+function applyInitialSessionScroll(scrollKey: string) {
+  if (activeSessionScrollKey.value !== scrollKey) return;
   if (chatStore.focusMessageId) {
-    pendingInitialScrollSessionId.value = null;
+    pendingInitialScrollKey.value = null;
     scrollToMessage(chatStore.focusMessageId);
     return;
   }
 
-  const snapshot = historySessionScrollPositions.get(sessionId);
+  const snapshot = historySessionScrollPositions.get(scrollKey);
   if (snapshot) {
-    pendingInitialScrollSessionId.value = null;
+    pendingInitialScrollKey.value = null;
     if (snapshot.wasNearBottom) {
       scrollToBottom();
     } else {
@@ -97,7 +99,7 @@ function applyInitialSessionScroll(sessionId: string) {
   }
 
   scrollToBottom();
-  if ((activeSession.value?.messages.length || 0) > 0) pendingInitialScrollSessionId.value = null;
+  if ((activeSession.value?.messages.length || 0) > 0) pendingInitialScrollKey.value = null;
 }
 
 async function handleTopReach() {
@@ -112,13 +114,13 @@ async function handleTopReach() {
 }
 
 watch(
-  () => activeSession.value?.id,
-  async (id, previousId) => {
-    saveSessionScrollPosition(previousId);
-    if (!id) return;
-    pendingInitialScrollSessionId.value = id;
+  activeSessionScrollKey,
+  async (scrollKey, previousScrollKey) => {
+    saveSessionScrollPosition(previousScrollKey);
+    if (!scrollKey) return;
+    pendingInitialScrollKey.value = scrollKey;
     await nextTick();
-    applyInitialSessionScroll(id);
+    applyInitialSessionScroll(scrollKey);
   },
   { immediate: true },
 );
@@ -135,7 +137,7 @@ watch(
 watch(
   () => (activeSession.value?.messages || [])[((activeSession.value?.messages || []).length - 1)]?.content,
   (content) => {
-    if (pendingInitialScrollSessionId.value === activeSession.value?.id) return;
+    if (pendingInitialScrollKey.value === activeSessionScrollKey.value) return;
     if (!content) return
     if (!isNearBottom()) return;
     scrollToBottom();
@@ -146,9 +148,9 @@ watch(
   () => (activeSession.value?.messages || []).length,
   (length) => {
     if (length === 0) return
-    const id = activeSession.value?.id
-    if (id && pendingInitialScrollSessionId.value === id) {
-      applyInitialSessionScroll(id);
+    const scrollKey = activeSessionScrollKey.value
+    if (scrollKey && pendingInitialScrollKey.value === scrollKey) {
+      applyInitialSessionScroll(scrollKey);
       return;
     }
     if (!isNearBottom()) return;
@@ -167,7 +169,7 @@ watch(
 );
 
 onBeforeUnmount(() => {
-  saveSessionScrollPosition(activeSession.value?.id);
+  saveSessionScrollPosition(activeSessionScrollKey.value);
 });
 
 onMounted(() => {

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -1,17 +1,12 @@
 <script lang="ts">
-type SessionScrollSnapshot = {
-  scrollTop: number;
-  scrollHeight: number;
-  clientHeight: number;
-  wasNearBottom: boolean;
-}
+import type { MessageViewportScrollSnapshot } from "./message-scroll-position";
 
 type BottomScrollOptions = number | {
   frames?: number;
   keepAliveMs?: number;
 }
 
-const sessionScrollPositions = new Map<string, SessionScrollSnapshot>();
+const sessionScrollPositions = new Map<string, MessageViewportScrollSnapshot>();
 </script>
 
 <script setup lang="ts">
@@ -24,18 +19,21 @@ import { LIVE_CHAT_MAX_LOADED_MESSAGES, parseMessageReference, useChatStore, typ
 import thinkingImage from "@/assets/thinking.gif";
 import { useToolTraceVisibility } from "@/composables/useToolTraceVisibility";
 import { openSubagentStream, subagentIdFromToolCall } from "@/utils/hermes/subagent-stream";
+import { messageScrollPositionKey, rememberMessageScrollPosition } from "./message-scroll-position";
 
 const props = withDefaults(defineProps<{
   approvalPortalToBody?: boolean
+  scrollScope?: string
 }>(), {
   approvalPortalToBody: false,
+  scrollScope: "chat",
 })
 
 const chatStore = useChatStore();
 const { t } = useI18n();
 const { toolTraceVisible } = useToolTraceVisibility();
 const listRef = ref<InstanceType<typeof VirtualMessageList> | null>(null);
-const pendingInitialScrollSessionId = ref<string | null>(null);
+const pendingInitialScrollKey = ref<string | null>(null);
 const showScrollBottomButton = ref(false);
 const thinkingElapsedMs = ref(0);
 const initialBottomScrollOptions = { frames: 8, keepAliveMs: 1200 };
@@ -217,6 +215,18 @@ const virtualListPadding = computed(() => {
   return "20px";
 });
 
+const activeSessionScrollKey = computed(() => {
+  const sessionId = chatStore.activeSessionId;
+  if (!sessionId) return null;
+  const session = chatStore.activeSession?.id === sessionId
+    ? chatStore.activeSession
+    : chatStore.sessions.find(item => item.id === sessionId);
+  return messageScrollPositionKey(props.scrollScope, {
+    id: sessionId,
+    profile: session?.profile,
+  });
+});
+
 const showHistoryArchiveLink = computed(() => {
   const session = chatStore.activeSession;
   return !!session?.hasMoreBefore && (session.loadedMessageCount || 0) >= LIVE_CHAT_MAX_LOADED_MESSAGES;
@@ -305,23 +315,23 @@ function handleScrollBottomClick() {
   scrollToBottom({ frames: 4, keepAliveMs: 600 });
 }
 
-function saveSessionScrollPosition(sessionId: string | null | undefined) {
-  if (!sessionId) return;
+function saveSessionScrollPosition(scrollKey: string | null | undefined) {
+  if (!scrollKey) return;
   const snapshot = listRef.value?.captureViewportPosition() ?? null;
-  if (snapshot) sessionScrollPositions.set(sessionId, snapshot);
+  if (snapshot) rememberMessageScrollPosition(sessionScrollPositions, scrollKey, snapshot);
 }
 
-function applyInitialSessionScroll(sessionId: string) {
-  if (chatStore.activeSessionId !== sessionId) return;
+function applyInitialSessionScroll(scrollKey: string) {
+  if (activeSessionScrollKey.value !== scrollKey) return;
   if (chatStore.focusMessageId) {
-    pendingInitialScrollSessionId.value = null;
+    pendingInitialScrollKey.value = null;
     scrollToMessage(chatStore.focusMessageId);
     return;
   }
 
-  const snapshot = sessionScrollPositions.get(sessionId);
+  const snapshot = sessionScrollPositions.get(scrollKey);
   if (snapshot) {
-    pendingInitialScrollSessionId.value = null;
+    pendingInitialScrollKey.value = null;
     if (snapshot.wasNearBottom) {
       scrollToBottom(initialBottomScrollOptions);
     } else {
@@ -335,7 +345,7 @@ function applyInitialSessionScroll(sessionId: string) {
     const dividerId = forkDividerId(session.id);
     const hasDivider = displayMessagesWithForkDivider.value.some((message) => message.id === dividerId);
     if (hasDivider) {
-      pendingInitialScrollSessionId.value = null;
+      pendingInitialScrollKey.value = null;
       scrollToMessage(dividerId);
       return;
     }
@@ -344,7 +354,7 @@ function applyInitialSessionScroll(sessionId: string) {
 
   scrollToBottom(initialBottomScrollOptions);
   if (chatStore.messages.length > 0 && !chatStore.isLoadingMessages) {
-    pendingInitialScrollSessionId.value = null;
+    pendingInitialScrollKey.value = null;
   }
 }
 
@@ -360,22 +370,22 @@ async function handleTopReach() {
 }
 
 watch(
-  () => chatStore.activeSessionId,
-  async (id, previousId) => {
-    saveSessionScrollPosition(previousId);
-    if (!id) return;
-    pendingInitialScrollSessionId.value = id;
+  activeSessionScrollKey,
+  async (scrollKey, previousScrollKey) => {
+    saveSessionScrollPosition(previousScrollKey);
+    if (!scrollKey) return;
+    pendingInitialScrollKey.value = scrollKey;
     await nextTick();
-    applyInitialSessionScroll(id);
+    applyInitialSessionScroll(scrollKey);
   },
   { immediate: true },
 );
 
 watch(
-  () => [chatStore.activeSessionId, chatStore.messages.length] as const,
-  ([id, length]) => {
-    if (!id || pendingInitialScrollSessionId.value !== id || length === 0) return;
-    applyInitialSessionScroll(id);
+  () => [activeSessionScrollKey.value, chatStore.messages.length] as const,
+  ([scrollKey, length]) => {
+    if (!scrollKey || pendingInitialScrollKey.value !== scrollKey || length === 0) return;
+    applyInitialSessionScroll(scrollKey);
     void nextTick(updateScrollBottomButton);
   },
   { flush: "post" },
@@ -393,15 +403,15 @@ watch(
   () => chatStore.isLoadingMessages,
   async (isLoading, wasLoading) => {
     if (isLoading || !wasLoading) return;
-    const id = chatStore.activeSessionId;
-    if (!id || pendingInitialScrollSessionId.value !== id) return;
+    const scrollKey = activeSessionScrollKey.value;
+    if (!scrollKey || pendingInitialScrollKey.value !== scrollKey) return;
     if (chatStore.focusMessageId) {
-      pendingInitialScrollSessionId.value = null;
+      pendingInitialScrollKey.value = null;
       return;
     }
     await nextTick();
-    if (chatStore.activeSessionId !== id) return;
-    applyInitialSessionScroll(id);
+    if (activeSessionScrollKey.value !== scrollKey) return;
+    applyInitialSessionScroll(scrollKey);
   },
   { flush: "post" },
 );
@@ -444,7 +454,7 @@ watch(
 watch(
   () => chatStore.messages[chatStore.messages.length - 1]?.content,
   () => {
-    if (pendingInitialScrollSessionId.value === chatStore.activeSessionId) return;
+    if (pendingInitialScrollKey.value === activeSessionScrollKey.value) return;
     if (chatStore.focusMessageId) {
       scrollToMessage(chatStore.focusMessageId);
       return;
@@ -454,7 +464,7 @@ watch(
   },
 );
 watch(currentToolCalls, () => {
-  if (pendingInitialScrollSessionId.value === chatStore.activeSessionId) return;
+  if (pendingInitialScrollKey.value === activeSessionScrollKey.value) return;
   if (chatStore.focusMessageId) {
     scrollToMessage(chatStore.focusMessageId);
     return;
@@ -466,7 +476,7 @@ watch(currentToolCalls, () => {
 watch(
   () => queuedMessages.value.length,
   async (length, previousLength) => {
-    if (pendingInitialScrollSessionId.value === chatStore.activeSessionId) return;
+    if (pendingInitialScrollKey.value === activeSessionScrollKey.value) return;
     if (chatStore.focusMessageId) return;
     if (length <= previousLength) return;
     const wasNearBottom = shouldAutoFollowBottom(320);
@@ -478,7 +488,7 @@ watch(
 
 onBeforeUnmount(() => {
   stopThinkingTimer();
-  saveSessionScrollPosition(chatStore.activeSessionId);
+  saveSessionScrollPosition(activeSessionScrollKey.value);
 });
 
 onMounted(() => {
@@ -495,7 +505,7 @@ defineExpose({
 <template>
   <div class="message-list-shell">
     <VirtualMessageList
-      :key="chatStore.activeSessionId || 'chat-empty'"
+      :key="activeSessionScrollKey || 'chat-empty'"
       ref="listRef"
       :messages="displayMessagesWithForkDivider"
       :virtualized="false"

--- a/packages/client/src/components/hermes/chat/VirtualMessageList.vue
+++ b/packages/client/src/components/hermes/chat/VirtualMessageList.vue
@@ -7,6 +7,7 @@ import {
   type ScrollToOptions,
 } from "vue-virtual-scroller";
 import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
+import type { MessageViewportScrollSnapshot } from "./message-scroll-position";
 
 type VirtualItem = {
   id: string | number;
@@ -24,13 +25,6 @@ type BottomScrollOptions = number | {
   frames?: number;
   keepAliveMs?: number;
 }
-type ViewportScrollSnapshot = {
-  scrollTop: number;
-  scrollHeight: number;
-  clientHeight: number;
-  wasNearBottom: boolean;
-}
-
 const props = withDefaults(defineProps<{
   messages: VirtualItem[];
   virtualized?: boolean;
@@ -372,10 +366,39 @@ function restoreScrollPosition(snapshot: { scrollTop: number; scrollHeight: numb
   });
 }
 
-function captureViewportPosition(): ViewportScrollSnapshot | null {
+function findViewportAnchor(el: HTMLElement): { messageId: string; offset: number } | null {
+  const scrollerRect = el.getBoundingClientRect();
+  const viewportBottom = scrollerRect.bottom || scrollerRect.top + el.clientHeight;
+  let candidate: { messageId: string; offset: number; top: number } | null = null;
+
+  for (const row of el.querySelectorAll<HTMLElement>(".virtual-row[data-virtual-index]")) {
+    const rowRect = row.getBoundingClientRect();
+    if (rowRect.bottom <= scrollerRect.top || rowRect.top >= viewportBottom) continue;
+    const index = Number(row.dataset.virtualIndex);
+    const message = Number.isInteger(index) ? props.messages[index] : null;
+    const messageId = row.dataset.messageId || (message ? messageKey(message) : "");
+    if (!messageId) continue;
+    if (!candidate || rowRect.top < candidate.top) {
+      candidate = {
+        messageId,
+        offset: rowRect.top - scrollerRect.top,
+        top: rowRect.top,
+      };
+    }
+  }
+
+  return candidate
+    ? { messageId: candidate.messageId, offset: candidate.offset }
+    : null;
+}
+
+function captureViewportPosition(): MessageViewportScrollSnapshot | null {
   const el = getScrollerElement();
   if (!el) return null;
+  const anchor = findViewportAnchor(el);
   return {
+    anchorMessageId: anchor?.messageId || null,
+    anchorOffset: anchor?.offset || 0,
     scrollTop: el.scrollTop,
     scrollHeight: el.scrollHeight,
     clientHeight: el.clientHeight,
@@ -383,11 +406,25 @@ function captureViewportPosition(): ViewportScrollSnapshot | null {
   };
 }
 
-function restoreViewportPosition(snapshot: ViewportScrollSnapshot | null, frames = 4) {
-  if (!snapshot) return;
+function restoreViewportPosition(snapshot: MessageViewportScrollSnapshot | null, frames = 4): boolean {
+  if (!snapshot) return false;
+  if (viewportRestoreFrame != null) {
+    cancelAnimationFrame(viewportRestoreFrame);
+    viewportRestoreFrame = null;
+  }
+  const anchorMessageId = snapshot.anchorMessageId;
+  const initialIndex = anchorMessageId
+    ? props.messages.findIndex(message => messageKey(message) === anchorMessageId)
+    : -1;
+  if (!anchorMessageId || initialIndex < 0) {
+    scrollToBottom();
+    return false;
+  }
+
   cancelBottomScroll();
+  cancelAnchorAlignment();
   userDetachedFromBottom = !snapshot.wasNearBottom;
-  if (viewportRestoreFrame != null) cancelAnimationFrame(viewportRestoreFrame);
+  const anchorOffset = Number.isFinite(snapshot.anchorOffset) ? snapshot.anchorOffset : 0;
 
   nextTick(() => {
     let remaining = frames;
@@ -397,12 +434,27 @@ function restoreViewportPosition(snapshot: ViewportScrollSnapshot | null, frames
         viewportRestoreFrame = null;
         return;
       }
-      const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
-      const nextScrollTop = Math.min(maxScrollTop, Math.max(0, snapshot.scrollTop));
-      markProgrammaticScroll();
-      if (props.virtualized) scrollerRef.value?.scrollToPosition(nextScrollTop);
-      el.scrollTop = nextScrollTop;
-      syncViewport();
+      const index = props.messages.findIndex(message => messageKey(message) === anchorMessageId);
+      if (index < 0) {
+        viewportRestoreFrame = null;
+        scrollToBottom();
+        return;
+      }
+
+      const row = findRowElement(index);
+      if (row) {
+        const scrollerRect = el.getBoundingClientRect();
+        const rowRect = row.getBoundingClientRect();
+        const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+        const delta = rowRect.top - scrollerRect.top - anchorOffset;
+        const nextScrollTop = Math.min(maxScrollTop, Math.max(0, el.scrollTop + delta));
+        markProgrammaticScroll();
+        if (props.virtualized) scrollerRef.value?.scrollToPosition(nextScrollTop);
+        el.scrollTop = nextScrollTop;
+        syncViewport();
+      } else {
+        scrollToItem(index, { align: "start", offset: -anchorOffset });
+      }
 
       remaining -= 1;
       if (remaining <= 0) {
@@ -413,6 +465,8 @@ function restoreViewportPosition(snapshot: ViewportScrollSnapshot | null, frames
     };
     viewportRestoreFrame = requestAnimationFrame(step);
   });
+
+  return true;
 }
 
 let resizeObserver: ResizeObserver | null = null;
@@ -487,6 +541,7 @@ defineExpose({
           :active="active"
           class="virtual-row"
           :data-virtual-index="index"
+          :data-message-id="messageKey(item)"
         >
           <slot v-if="active" name="item" :message="item" />
         </DynamicScrollerItem>
@@ -508,6 +563,7 @@ defineExpose({
           :key="messageKey(item)"
           class="virtual-row"
           :data-virtual-index="index"
+          :data-message-id="messageKey(item)"
         >
           <slot name="item" :message="item" />
         </div>

--- a/packages/client/src/components/hermes/chat/message-scroll-position.ts
+++ b/packages/client/src/components/hermes/chat/message-scroll-position.ts
@@ -1,0 +1,39 @@
+export type MessageViewportScrollSnapshot = {
+  anchorMessageId: string | null;
+  anchorOffset: number;
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  wasNearBottom: boolean;
+}
+
+type MessageScrollSession = {
+  id: string;
+  profile?: string | null;
+}
+
+export function messageScrollPositionKey(
+  scope: string,
+  session: MessageScrollSession | null | undefined,
+): string | null {
+  const sessionId = String(session?.id || "").trim();
+  if (!sessionId) return null;
+  const normalizedScope = scope.trim() || "default";
+  const profile = String(session?.profile || "default").trim() || "default";
+  return `${normalizedScope}\u0000${profile}\u0000${sessionId}`;
+}
+
+export function rememberMessageScrollPosition(
+  positions: Map<string, MessageViewportScrollSnapshot>,
+  key: string,
+  snapshot: MessageViewportScrollSnapshot,
+  maxEntries = 200,
+) {
+  positions.delete(key);
+  positions.set(key, snapshot);
+  while (positions.size > maxEntries) {
+    const oldestKey = positions.keys().next().value;
+    if (oldestKey === undefined) break;
+    positions.delete(oldestKey);
+  }
+}

--- a/packages/client/src/components/hermes/kanban/KanbanTaskDrawer.vue
+++ b/packages/client/src/components/hermes/kanban/KanbanTaskDrawer.vue
@@ -616,7 +616,7 @@ function handleNavigateTask(taskId: string) {
   <!-- Session messages modal (click result summary) -->
   <NModal v-if="historySession" :show="showMessagesModal" preset="card" :title="detail?.task.title || ''" :style="{ width: '900px', maxWidth: 'calc(100vw - 48px)' }" @close="showMessagesModal = false">
     <div class="messages-modal-body">
-      <HistoryMessageList :session="historySession" />
+      <HistoryMessageList :session="historySession" scroll-scope="kanban" />
     </div>
   </NModal>
 

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -1037,6 +1037,7 @@ function handleBatchDeleteConfirm() {
             ref="historyMessageListRef"
             :session="historySession"
             :load-older="loadOlderHistoryMessages"
+            scroll-scope="history"
           />
         </div>
         <OutlinePanel

--- a/packages/client/src/views/hermes/WorkflowView.vue
+++ b/packages/client/src/views/hermes/WorkflowView.vue
@@ -3169,7 +3169,7 @@ function nodeColor(node: { data: WorkflowAgentNodeData }) {
                   </NButton>
                 </div>
               </div>
-              <MessageList />
+              <MessageList scroll-scope="workflow" />
               <ChatInput />
             </template>
             <div v-else class="workflow-chat-loading">

--- a/tests/client/history-message-list-scroll-position.test.ts
+++ b/tests/client/history-message-list-scroll-position.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { defineComponent, nextTick } from 'vue'
+
+const mockScrollToBottom = vi.hoisted(() => vi.fn())
+const mockCaptureViewportPosition = vi.hoisted(() => vi.fn())
+const mockRestoreViewportPosition = vi.hoisted(() => vi.fn())
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('@/components/hermes/chat/VirtualMessageList.vue', () => ({
+  default: defineComponent({
+    name: 'VirtualMessageList',
+    props: {
+      messages: { type: Array, default: () => [] },
+    },
+    emits: ['scroll', 'top-reach'],
+    setup(_props, { expose }) {
+      expose({
+        isNearBottom: vi.fn(() => true),
+        scrollToBottom: mockScrollToBottom,
+        scrollToMessage: vi.fn(),
+        scrollToAnchor: vi.fn(),
+        captureScrollPosition: vi.fn(),
+        restoreScrollPosition: vi.fn(),
+        captureViewportPosition: mockCaptureViewportPosition,
+        restoreViewportPosition: mockRestoreViewportPosition,
+      })
+    },
+    template: '<div class="virtual-message-list-stub" />',
+  }),
+}))
+
+vi.mock('@/components/hermes/chat/MessageItem.vue', () => ({
+  default: defineComponent({
+    name: 'MessageItem',
+    props: { message: { type: Object, required: true } },
+    template: '<div />',
+  }),
+}))
+
+import HistoryMessageList from '@/components/hermes/chat/HistoryMessageList.vue'
+import type { Session } from '@/stores/hermes/chat'
+
+function makeSession(profile: string): Session {
+  return {
+    id: 'shared-history-session',
+    profile,
+    title: profile,
+    messages: [{
+      id: `${profile}-message`,
+      role: 'user',
+      content: profile,
+      timestamp: Date.now(),
+    }],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  }
+}
+
+async function flushScrollState() {
+  await nextTick()
+  await nextTick()
+}
+
+describe('HistoryMessageList scroll position', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('keeps scroll snapshots separate when profiles reuse a session id', async () => {
+    const profileASnapshot = {
+      anchorMessageId: 'profile-a-message',
+      anchorOffset: -18,
+      scrollTop: 280,
+      scrollHeight: 1100,
+      clientHeight: 500,
+      wasNearBottom: false,
+    }
+    mockCaptureViewportPosition.mockReturnValue(profileASnapshot)
+
+    const wrapper = mount(HistoryMessageList, {
+      props: {
+        session: makeSession('profile-a'),
+        scrollScope: 'history',
+      },
+    })
+    await flushScrollState()
+    vi.clearAllMocks()
+
+    await wrapper.setProps({ session: makeSession('profile-b') })
+    await flushScrollState()
+    expect(mockCaptureViewportPosition).toHaveBeenCalled()
+
+    mockCaptureViewportPosition.mockReturnValue({
+      anchorMessageId: 'profile-b-message',
+      anchorOffset: 8,
+      scrollTop: 80,
+      scrollHeight: 900,
+      clientHeight: 500,
+      wasNearBottom: false,
+    })
+    vi.clearAllMocks()
+
+    await wrapper.setProps({ session: makeSession('profile-a') })
+    await flushScrollState()
+
+    expect(mockRestoreViewportPosition).toHaveBeenCalledWith(profileASnapshot)
+    expect(mockScrollToBottom).not.toHaveBeenCalled()
+  })
+})

--- a/tests/client/message-list-scroll-position.test.ts
+++ b/tests/client/message-list-scroll-position.test.ts
@@ -106,6 +106,8 @@ describe('MessageList session scroll position', () => {
     vi.clearAllMocks()
 
     const sessionASnapshot = {
+      anchorMessageId: 'scroll-session-a-message',
+      anchorOffset: -24,
       scrollTop: 320,
       scrollHeight: 1200,
       clientHeight: 500,
@@ -120,6 +122,8 @@ describe('MessageList session scroll position', () => {
 
     vi.clearAllMocks()
     mockCaptureViewportPosition.mockReturnValue({
+      anchorMessageId: 'scroll-session-b-message',
+      anchorOffset: 12,
       scrollTop: 40,
       scrollHeight: 1000,
       clientHeight: 500,

--- a/tests/client/message-scroll-position-key.test.ts
+++ b/tests/client/message-scroll-position-key.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import {
+  messageScrollPositionKey,
+  rememberMessageScrollPosition,
+  type MessageViewportScrollSnapshot,
+} from '@/components/hermes/chat/message-scroll-position'
+
+const snapshot: MessageViewportScrollSnapshot = {
+  anchorMessageId: 'message-1',
+  anchorOffset: 0,
+  scrollTop: 0,
+  scrollHeight: 1000,
+  clientHeight: 500,
+  wasNearBottom: false,
+}
+
+describe('messageScrollPositionKey', () => {
+  it('separates scroll positions by surface, profile, and session', () => {
+    const chatKey = messageScrollPositionKey('chat', { id: 'session-1', profile: 'profile-a' })
+
+    expect(chatKey).not.toBe(messageScrollPositionKey('history', { id: 'session-1', profile: 'profile-a' }))
+    expect(chatKey).not.toBe(messageScrollPositionKey('chat', { id: 'session-1', profile: 'profile-b' }))
+    expect(chatKey).not.toBe(messageScrollPositionKey('chat', { id: 'session-2', profile: 'profile-a' }))
+  })
+
+  it('evicts the oldest snapshots when the in-memory cache reaches its limit', () => {
+    const positions = new Map<string, MessageViewportScrollSnapshot>()
+
+    rememberMessageScrollPosition(positions, 'session-a', snapshot, 2)
+    rememberMessageScrollPosition(positions, 'session-b', snapshot, 2)
+    rememberMessageScrollPosition(positions, 'session-c', snapshot, 2)
+
+    expect([...positions.keys()]).toEqual(['session-b', 'session-c'])
+  })
+})

--- a/tests/client/virtual-message-list-scroll.test.ts
+++ b/tests/client/virtual-message-list-scroll.test.ts
@@ -48,6 +48,20 @@ function setScrollerMetrics(el: HTMLElement, metrics: { scrollHeight: number; cl
   el.scrollTop = metrics.scrollTop
 }
 
+function elementRect(top: number, bottom: number): DOMRect {
+  return {
+    x: 0,
+    y: top,
+    top,
+    bottom,
+    left: 0,
+    right: 400,
+    width: 400,
+    height: bottom - top,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
 describe('VirtualMessageList scroll behavior', () => {
   let rafCallbacks: FrameRequestCallback[]
   let resizeCallbacks: ResizeObserverCallback[]
@@ -252,5 +266,113 @@ describe('VirtualMessageList scroll behavior', () => {
     }
 
     expect(scroller.element.scrollTop).toBe(1000)
+  })
+
+  it('captures the top visible message as the viewport anchor', async () => {
+    const wrapper = mount(VirtualMessageList, {
+      props: {
+        messages: [{ id: 'message-a' }, { id: 'message-b' }, { id: 'message-c' }],
+        virtualized: false,
+      },
+      slots: {
+        item: '<div>message</div>',
+      },
+    })
+    await nextTick()
+
+    const scroller = wrapper.find<HTMLElement>('.virtual-message-list')
+    const rows = wrapper.findAll<HTMLElement>('.virtual-row')
+    setScrollerMetrics(scroller.element, {
+      scrollHeight: 1200,
+      clientHeight: 400,
+      scrollTop: 300,
+    })
+    vi.spyOn(scroller.element, 'getBoundingClientRect').mockReturnValue(elementRect(100, 500))
+    vi.spyOn(rows[0].element, 'getBoundingClientRect').mockReturnValue(elementRect(40, 140))
+    vi.spyOn(rows[1].element, 'getBoundingClientRect').mockReturnValue(elementRect(140, 300))
+    vi.spyOn(rows[2].element, 'getBoundingClientRect').mockReturnValue(elementRect(300, 520))
+
+    expect((wrapper.vm as any).captureViewportPosition()).toMatchObject({
+      anchorMessageId: 'message-a',
+      anchorOffset: -60,
+      wasNearBottom: false,
+    })
+  })
+
+  it('restores a changed layout by aligning the saved message anchor', async () => {
+    const wrapper = mount(VirtualMessageList, {
+      props: {
+        messages: [{ id: 'message-before' }, { id: 'message-anchor' }, { id: 'message-after' }],
+        virtualized: false,
+      },
+      slots: {
+        item: '<div>message</div>',
+      },
+    })
+    await nextTick()
+
+    const scroller = wrapper.find<HTMLElement>('.virtual-message-list')
+    const anchorRow = wrapper.findAll<HTMLElement>('.virtual-row')[1]
+    setScrollerMetrics(scroller.element, {
+      scrollHeight: 2000,
+      clientHeight: 400,
+      scrollTop: 0,
+    })
+    vi.spyOn(scroller.element, 'getBoundingClientRect').mockReturnValue(elementRect(100, 500))
+    vi.spyOn(anchorRow.element, 'getBoundingClientRect').mockImplementation(() =>
+      elementRect(620 - scroller.element.scrollTop, 820 - scroller.element.scrollTop),
+    )
+
+    const restored = (wrapper.vm as any).restoreViewportPosition({
+      anchorMessageId: 'message-anchor',
+      anchorOffset: -24,
+      scrollTop: 320,
+      scrollHeight: 1200,
+      clientHeight: 400,
+      wasNearBottom: false,
+    })
+    expect(restored).toBe(true)
+    await nextTick()
+    while (rafCallbacks.length > 0) {
+      rafCallbacks.shift()?.(performance.now())
+    }
+
+    expect(scroller.element.scrollTop).toBe(544)
+  })
+
+  it('falls back to the bottom when the saved message anchor is missing', async () => {
+    const wrapper = mount(VirtualMessageList, {
+      props: {
+        messages: [{ id: 'message-current' }],
+        virtualized: false,
+      },
+      slots: {
+        item: '<div>message</div>',
+      },
+    })
+    await nextTick()
+
+    const scroller = wrapper.find<HTMLElement>('.virtual-message-list')
+    setScrollerMetrics(scroller.element, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 100,
+    })
+
+    const restored = (wrapper.vm as any).restoreViewportPosition({
+      anchorMessageId: 'message-missing',
+      anchorOffset: 0,
+      scrollTop: 100,
+      scrollHeight: 900,
+      clientHeight: 400,
+      wasNearBottom: false,
+    })
+    expect(restored).toBe(false)
+    await nextTick()
+    while (rafCallbacks.length > 0) {
+      rafCallbacks.shift()?.(performance.now())
+    }
+
+    expect(scroller.element.scrollTop).toBe(600)
   })
 })


### PR DESCRIPTION
## Summary

- restore live-chat and history scroll positions from the top visible message and its viewport offset instead of a stale absolute pixel position
- scope scroll cache keys by surface, profile, and session so reused components and profiles do not share positions
- fall back to the bottom when the saved message anchor is unavailable
- bound each in-memory cache to 200 entries
- add focused coverage for anchor capture/restoration, missing-anchor fallback, profile isolation, and cache eviction

## Root cause

Scroll snapshots were keyed only by session ID and restored from `scrollTop`. This could reuse a position across profiles or component surfaces, and content-height changes could make the same pixel offset point at a different message.

## User impact

Returning to a single chat or history session now restores the previously visible message more reliably. If history pagination or content changes remove that message from the current page, the transcript opens at the bottom instead of applying a misleading stale position.

## Validation

- `npm run test` — 404 files passed, 3184 tests passed, 2 skipped
- `npm run build`
- `npm run harness:check`
- `git diff --check`
- `npm run test:e2e` — 85 passed; one unrelated XLSX worker preview timed out under the parallel run
- `npx playwright test tests/e2e/generated-file-preview.spec.ts:264` — the timed-out XLSX test passed when rerun alone
