### PR TITLE
[codex] refine chat tool drawer

### DIFF
--- a/docs/chat-chain-changes/2026-07-30-chat-tool-drawer-layout.md
+++ b/docs/chat-chain-changes/2026-07-30-chat-tool-drawer-layout.md
@@ -2,5 +2,5 @@
 date: 2026-07-30
 pr: pending
 feature: Compact chat tool drawer navigation
-impact: The chat tool drawer now uses a full-height right icon rail, while its workspace, terminal, browser, and outline surfaces share the same themed content background. The terminal drawer uses a compact left rail for theme and session controls without changing terminal transport behavior.
+impact: The chat tool drawer now uses a full-height right icon rail, while its workspace, terminal, browser, file-preview, and outline surfaces share the same themed content background. The terminal drawer uses a compact left rail for theme and session controls without changing terminal transport behavior, and HTML previews fill the available drawer height.
 ---

--- a/docs/chat-chain-changes/2026-07-30-chat-tool-drawer-layout.md
+++ b/docs/chat-chain-changes/2026-07-30-chat-tool-drawer-layout.md
@@ -1,0 +1,6 @@
+---
+date: 2026-07-30
+pr: pending
+feature: Compact chat tool drawer navigation
+impact: The chat tool drawer now uses a full-height right icon rail, while its workspace, terminal, browser, and outline surfaces share the same themed content background. The terminal drawer uses a compact left rail for theme and session controls without changing terminal transport behavior.
+---

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -3608,6 +3608,7 @@ async function handleSessionModelCustomSubmit() {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+  background: $bg-main-surface;
 }
 
 .chat-tool-tabs {

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2694,20 +2694,29 @@ async function handleSessionModelCustomSubmit() {
                     :class="{ active: activeToolPanel === 'files' }"
                     type="button"
                     role="tab"
+                    :title="t('drawer.files')"
+                    :aria-label="t('drawer.files')"
                     :aria-selected="activeToolPanel === 'files'"
                     @click="activeToolPanel = 'files'"
                   >
-                    {{ t("drawer.files") }}
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M3 7.5A2.5 2.5 0 0 1 5.5 5H10l2 2h6.5A2.5 2.5 0 0 1 21 9.5v7A2.5 2.5 0 0 1 18.5 19h-13A2.5 2.5 0 0 1 3 16.5z" />
+                    </svg>
                   </button>
                   <button
                     class="chat-tool-tab"
                     :class="{ active: activeToolPanel === 'terminal' }"
                     type="button"
                     role="tab"
+                    :title="t('drawer.terminal')"
+                    :aria-label="t('drawer.terminal')"
                     :aria-selected="activeToolPanel === 'terminal'"
                     @click="activeToolPanel = 'terminal'"
                   >
-                    {{ t("drawer.terminal") }}
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                      <rect x="3" y="4" width="18" height="16" rx="2" />
+                      <path d="m7 9 3 3-3 3M13 15h4" />
+                    </svg>
                   </button>
                   <button
                     v-if="desktopBrowserAvailable"
@@ -2715,10 +2724,17 @@ async function handleSessionModelCustomSubmit() {
                     :class="{ active: activeToolPanel === 'browser' }"
                     type="button"
                     role="tab"
+                    :title="t('browser.title')"
+                    :aria-label="t('browser.title')"
                     :aria-selected="activeToolPanel === 'browser'"
                     @click="activeToolPanel = 'browser'"
                   >
-                    {{ t("browser.title") }}
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                      <rect x="3" y="4" width="18" height="16" rx="2" />
+                      <path d="M3 9h18" />
+                      <circle cx="6.5" cy="6.5" r=".75" fill="currentColor" stroke="none" />
+                      <circle cx="9.5" cy="6.5" r=".75" fill="currentColor" stroke="none" />
+                    </svg>
                   </button>
                 </div>
                 <div class="chat-tool-content">
@@ -3587,7 +3603,7 @@ async function handleSessionModelCustomSubmit() {
 
 .chat-tool-panel-inner {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   flex: 1;
   min-width: 0;
   min-height: 0;
@@ -3596,24 +3612,42 @@ async function handleSessionModelCustomSubmit() {
 
 .chat-tool-tabs {
   display: flex;
+  flex-direction: column;
   align-items: center;
   flex-shrink: 0;
-  gap: 6px;
-  padding: 8px 10px;
-  border-bottom: 1px solid $border-color;
+  order: 2;
+  width: 48px;
+  height: 100%;
+  gap: 4px;
+  padding: 8px 6px;
+  border-left: 1px solid $border-color;
+  background: $bg-sidebar-surface;
+  box-sizing: border-box;
 }
 
 .chat-tool-tab {
-  height: 30px;
-  padding: 0 12px;
+  position: relative;
+  width: 36px;
+  height: 36px;
+  padding: 0;
   border: none;
   border-radius: $radius-sm;
   background: transparent;
   color: $text-secondary;
   cursor: pointer;
-  font-size: 13px;
-  font-weight: 500;
+  display: grid;
+  place-items: center;
   transition: all $transition-fast;
+
+  svg {
+    width: 18px;
+    height: 18px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.7;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
 
   &:hover {
     color: $text-primary;
@@ -3623,14 +3657,27 @@ async function handleSessionModelCustomSubmit() {
   &.active {
     color: var(--accent-primary);
     background: rgba(var(--accent-primary-rgb), 0.12);
+
+    &::after {
+      content: "";
+      position: absolute;
+      right: -6px;
+      top: 9px;
+      bottom: 9px;
+      width: 2px;
+      border-radius: 2px 0 0 2px;
+      background: var(--accent-primary);
+    }
   }
 }
 
 .chat-tool-content {
+  order: 1;
   flex: 1;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+  background: $bg-main-surface;
 }
 
 .chat-tool-content > * {

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -3621,7 +3621,7 @@ async function handleSessionModelCustomSubmit() {
   height: 100%;
   gap: 4px;
   padding: 8px 6px;
-  border-left: 1px solid $border-color;
+  border-inline-start: 1px solid $border-color;
   background: $bg-sidebar-surface;
   box-sizing: border-box;
 }

--- a/packages/client/src/components/hermes/chat/FilesPanel.vue
+++ b/packages/client/src/components/hermes/chat/FilesPanel.vue
@@ -185,6 +185,7 @@ onMounted(() => {
   min-height: 0;
   overflow: hidden;
   position: relative;
+  background: inherit;
 }
 
 .sidebar-overlay {
@@ -210,6 +211,7 @@ onMounted(() => {
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
+  background: inherit;
 
   @media (max-width: $breakpoint-mobile) {
     position: fixed;
@@ -236,19 +238,25 @@ onMounted(() => {
   flex-direction: column;
   min-width: 0;
   overflow: hidden;
+  background: inherit;
 }
 
 .main-toolbar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px 16px;
+  gap: 6px;
+  padding: 5px 10px;
   border-bottom: 1px solid $border-color;
   flex-shrink: 0;
+  background: inherit;
+
+  :deep(.file-toolbar) {
+    padding: 0;
+  }
 
   @media (max-width: $breakpoint-mobile) {
     gap: 4px;
-    padding: 8px 8px;
+    padding: 4px 8px;
     flex-wrap: wrap;
   }
 }
@@ -293,5 +301,6 @@ onMounted(() => {
   flex: 1;
   overflow-y: auto;
   min-height: 0;
+  background: inherit;
 }
 </style>

--- a/packages/client/src/components/hermes/chat/OutlinePanel.vue
+++ b/packages/client/src/components/hermes/chat/OutlinePanel.vue
@@ -160,7 +160,7 @@ function scrollToTarget(item: OutlineItem) {
   display: flex;
   flex-direction: column;
   height: 100%;
-  background-color: $bg-card;
+  background-color: $bg-main-surface;
   border-left: 1px solid $border-color;
   width: 280px;
   flex-shrink: 0;

--- a/packages/client/src/components/hermes/chat/TerminalPanel.vue
+++ b/packages/client/src/components/hermes/chat/TerminalPanel.vue
@@ -5,7 +5,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
 import { getApiKey, getBaseUrlValue } from "@/api/client";
-import { NButton, NPopconfirm, NTooltip, NSelect, useMessage } from "naive-ui";
+import { NButton, NPopconfirm, NTooltip, useMessage } from "naive-ui";
 import { useI18n } from "vue-i18n";
 import type { ITheme } from "@xterm/xterm";
 
@@ -94,7 +94,6 @@ const activeSessionId = ref<string | null>(null);
 const selectedTheme = ref(localStorage.getItem(STORAGE_KEY_THEME) || "default");
 const connectionError = ref<string | null>(null);
 const isConnecting = ref(false);
-const showSidebar = ref(false);
 
 let ws: WebSocket | null = null;
 const termMap = new Map<string, { term: Terminal; fitAddon: FitAddon; opened: boolean }>();
@@ -113,19 +112,14 @@ const initialCommandTimers = new Set<ReturnType<typeof setTimeout>>();
 
 // ─── Computed ──────────────────────────────────────────────────
 
-const activeSession = computed(
-  () => sessions.value.find((s) => s.id === activeSessionId.value) || null,
-);
-
-const themeOptions = computed(() =>
-  Object.entries(TERMINAL_THEMES).map(([key, val]) => ({
-    label: val.label,
-    value: key,
-  })),
-);
-
 const terminalBg = computed(
   () => TERMINAL_THEMES[selectedTheme.value]?.theme.background ?? "#1a1a2e",
+);
+const selectedThemeLabel = computed(
+  () => TERMINAL_THEMES[selectedTheme.value]?.label ?? TERMINAL_THEMES.default.label,
+);
+const selectedThemeInitial = computed(
+  () => selectedThemeLabel.value.charAt(0).toUpperCase(),
 );
 
 // ─── WebSocket ──────────────────────────────────────────────────
@@ -318,11 +312,12 @@ function closeSession(id: string) {
     termMap.delete(id);
   }
   if (activeSessionId.value === id) {
-    activeSessionId.value = sessions.value.length > 0 ? sessions.value[0].id : null;
+    const nextSessionId = sessions.value[0]?.id ?? null;
+    activeSessionId.value = null;
     activeTerm = null;
     activeFitAddon = null;
-    if (activeSessionId.value) {
-      switchSession(activeSessionId.value);
+    if (nextSessionId) {
+      switchSession(nextSessionId);
     } else {
       unmountActiveTerminal();
       createSession();
@@ -426,11 +421,10 @@ function applyTheme(themeName: string) {
   }
 }
 
-// ─── Helpers ────────────────────────────────────────────────────
-
-function formatTime(ts: number) {
-  const d = new Date(ts);
-  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+function cycleTheme() {
+  const themeNames = Object.keys(TERMINAL_THEMES);
+  const currentIndex = themeNames.indexOf(selectedTheme.value);
+  applyTheme(themeNames[(currentIndex + 1 + themeNames.length) % themeNames.length]);
 }
 
 // ─── Lifecycle ──────────────────────────────────────────────────
@@ -461,122 +455,96 @@ onUnmounted(() => {
 
 <template>
   <div class="terminal-panel-drawer">
-    <div
-      v-if="showSidebar"
-      class="sidebar-overlay"
-      @click="showSidebar = false"
-    ></div>
-    <div
-      class="terminal-sidebar"
-      :class="{ 'mobile-visible': showSidebar }"
-    >
-      <div class="sidebar-header">
-        <span class="sidebar-title">{{ t("terminal.sessions") }}</span>
-        <NTooltip trigger="hover">
-          <template #trigger>
-            <NButton quaternary size="tiny" @click="createSession" circle>
-              <template #icon>
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <line x1="12" y1="5" x2="12" y2="19" />
-                  <line x1="5" y1="12" x2="19" y2="12" />
-                </svg>
-              </template>
-            </NButton>
-          </template>
-          {{ t("terminal.newTab") }}
-        </NTooltip>
-      </div>
-      <div class="session-list">
-        <div v-if="connectionError" class="session-error">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <circle cx="12" cy="12" r="10" />
-            <line x1="12" y1="8" x2="12" y2="12" />
-            <line x1="12" y1="16" x2="12.01" y2="16" />
-          </svg>
-          <span>{{ connectionError }}</span>
-          <NButton size="tiny" @click="connect">{{ t("common.retry") }}</NButton>
-        </div>
-        <div v-else-if="sessions.length === 0" class="session-empty">
-          <template v-if="isConnecting">
-            {{ t("common.loading") }}
-          </template>
-          <template v-else>
-            {{ t("terminal.noSessions") }}
-          </template>
-        </div>
-        <button
-          v-for="s in sessions"
-          :key="s.id"
-          class="session-item"
-          :class="{ active: s.id === activeSessionId, exited: s.exited }"
-          @click="switchSession(s.id)"
+    <aside class="terminal-session-rail" :aria-label="t('terminal.sessions')">
+      <NTooltip trigger="hover" placement="right">
+        <template #trigger>
+          <button
+            class="terminal-rail-button terminal-theme-button"
+            type="button"
+            :aria-label="selectedThemeLabel"
+            @click="cycleTheme"
+          >
+            {{ selectedThemeInitial }}
+          </button>
+        </template>
+        {{ selectedThemeLabel }}
+      </NTooltip>
+
+      <div class="terminal-session-list">
+        <div
+          v-for="session in sessions"
+          :key="session.id"
+          class="terminal-session-slot"
+          :class="{
+            active: session.id === activeSessionId,
+            exited: session.exited,
+          }"
         >
-          <div class="session-item-content">
-            <span class="session-item-title">{{ s.title }}</span>
-            <span class="session-item-meta">
-              <span class="session-item-shell">{{ s.shell }}</span>
-              <span v-if="s.exited" class="session-item-status">{{
-                t("terminal.sessionExited")
-              }}</span>
-              <span v-else class="session-item-time">{{
-                formatTime(s.createdAt)
-              }}</span>
-            </span>
-          </div>
-          <NPopconfirm v-if="sessions.length > 1" @positive-click="closeSession(s.id)">
+          <NTooltip trigger="hover" placement="right">
             <template #trigger>
-              <button class="session-item-delete" @click.stop>
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <line x1="18" y1="6" x2="6" y2="18" />
-                  <line x1="6" y1="6" x2="18" y2="18" />
+              <button
+                class="terminal-session-button"
+                type="button"
+                :aria-label="session.title"
+                :aria-pressed="session.id === activeSessionId"
+                @click="switchSession(session.id)"
+              >
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="4" width="18" height="16" rx="2" />
+                  <path d="m7 9 3 3-3 3M13 15h4" />
+                </svg>
+              </button>
+            </template>
+            {{ session.title }}
+          </NTooltip>
+          <NPopconfirm @positive-click="closeSession(session.id)">
+            <template #trigger>
+              <button
+                class="terminal-session-delete"
+                type="button"
+                :title="t('terminal.closeSession')"
+                :aria-label="`${t('terminal.closeSession')}: ${session.title}`"
+                @click.stop
+              >
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="m7 7 10 10M17 7 7 17" />
                 </svg>
               </button>
             </template>
             {{ t("terminal.closeSession") }}
           </NPopconfirm>
-        </button>
+        </div>
       </div>
-    </div>
+
+      <NTooltip trigger="hover" placement="right">
+        <template #trigger>
+          <button
+            class="terminal-rail-button terminal-add-button"
+            type="button"
+            :aria-label="t('terminal.newTab')"
+            @click="createSession"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+          </button>
+        </template>
+        {{ t("terminal.newTab") }}
+      </NTooltip>
+    </aside>
 
     <div class="terminal-main">
-      <header class="terminal-header">
-        <span v-if="activeSession" class="header-session-title">{{
-          activeSession.title
-        }}</span>
-        <div class="header-actions">
-          <NButton
-            size="small"
-            @click="showSidebar = !showSidebar"
-            class="sidebar-toggle"
-          >
-            <template #icon>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <rect x="3" y="3" width="18" height="18" rx="2" />
-                <line x1="9" y1="3" x2="9" y2="21" />
-              </svg>
-            </template>
-            {{ t("terminal.sessions") }}
-          </NButton>
-          <NSelect
-            :value="selectedTheme"
-            :options="themeOptions"
-            size="small"
-            :consistent-menu-width="false"
-            class="theme-select"
-            @update:value="applyTheme"
-          />
-          <NButton size="small" @click="createSession">
-            <template #icon>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <line x1="12" y1="5" x2="12" y2="19" />
-                <line x1="5" y1="12" x2="19" y2="12" />
-              </svg>
-            </template>
-            {{ t("terminal.newTab") }}
-          </NButton>
-        </div>
-      </header>
       <div class="terminal-container">
+        <div v-if="connectionError" class="terminal-state terminal-state-error">
+          <span>{{ connectionError }}</span>
+          <NButton size="tiny" @click="connect">{{ t("common.retry") }}</NButton>
+        </div>
+        <div
+          v-else-if="sessions.length === 0"
+          class="terminal-state"
+        >
+          {{ isConnecting ? t("common.loading") : t("terminal.noSessions") }}
+        </div>
         <div
           ref="terminalRef"
           class="terminal-xterm"
@@ -594,8 +562,6 @@ onUnmounted(() => {
 <style scoped lang="scss">
 @use "@/styles/variables" as *;
 
-$terminal-panel-header-height: 47px;
-
 .terminal-panel-drawer {
   display: flex;
   height: 100%;
@@ -606,251 +572,210 @@ $terminal-panel-header-height: 47px;
   overflow: hidden;
 }
 
-.sidebar-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 50;
+.terminal-session-rail {
+  width: 48px;
+  border-right: 1px solid $border-color;
+  background: $bg-sidebar-surface;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 0;
+  flex-shrink: 0;
+  box-sizing: border-box;
+}
 
-  @media (min-width: $breakpoint-mobile + 1) {
+.terminal-session-list {
+  flex: 1;
+  width: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
     display: none;
   }
 }
 
-.terminal-sidebar {
-  width: 180px;
-  border-right: 1px solid $border-color;
-  display: flex;
-  flex-direction: column;
-  flex-shrink: 0;
-
-  @media (max-width: $breakpoint-mobile) {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 80%;
-    max-width: 300px;
-    z-index: 51;
-    background: $bg-card;
-    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    transform: translateX(-100%);
-    transition: transform 0.3s ease;
-
-    &.mobile-visible {
-      transform: translateX(0);
-    }
-  }
-}
-
-.sidebar-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: $terminal-panel-header-height;
-  padding: 12px;
-  flex-shrink: 0;
-  border-bottom: 1px solid $border-color;
-  box-sizing: border-box;
-}
-
-.sidebar-title {
-  font-size: 11px;
-  font-weight: 600;
-  color: $text-muted;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.session-list {
-  flex: 1;
-  overflow-y: auto;
-  padding: 8px;
-}
-
-.session-empty {
-  padding: 16px 8px;
-  font-size: 12px;
-  color: $text-muted;
-  text-align: center;
-}
-
-.session-error {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 12px;
-  padding: 20px 12px;
-  font-size: 12px;
-  color: $error;
-  text-align: center;
-
-  svg {
-    width: 32px;
-    height: 32px;
-    opacity: 0.8;
-  }
-
-  span {
-    flex: 1;
-  }
-}
-
-.session-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 6px 8px;
+.terminal-rail-button,
+.terminal-session-button,
+.terminal-session-delete {
   border: none;
-  background: none;
+  background: transparent;
   border-radius: $radius-sm;
   cursor: pointer;
-  text-align: left;
   color: $text-secondary;
-  transition: all $transition-fast;
-  margin-bottom: 2px;
+  display: grid;
+  place-items: center;
+  transition:
+    color $transition-fast,
+    background-color $transition-fast,
+    opacity $transition-fast;
+}
 
+.terminal-rail-button,
+.terminal-session-slot,
+.terminal-session-button {
+  width: 36px;
+  height: 36px;
+  flex: 0 0 36px;
+}
+
+.terminal-rail-button,
+.terminal-session-button {
   &:hover {
-    background: rgba(var(--accent-primary-rgb), 0.06);
     color: $text-primary;
-
-    .session-item-delete {
-      opacity: 1;
-    }
+    background: rgba(var(--accent-primary-rgb), 0.08);
   }
+}
+
+.terminal-theme-button {
+  flex-shrink: 0;
+  color: $text-primary;
+  background: rgba(var(--accent-primary-rgb), 0.08);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.terminal-add-button {
+  flex-shrink: 0;
+
+  svg {
+    width: 18px;
+    height: 18px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.8;
+    stroke-linecap: round;
+  }
+}
+
+.terminal-session-slot {
+  position: relative;
+  border-radius: $radius-sm;
 
   &.active {
-    background: rgba(var(--accent-primary-rgb), 0.1);
-    color: $text-primary;
-    font-weight: 500;
+    background: rgba(var(--accent-primary-rgb), 0.12);
+
+    &::before {
+      content: "";
+      position: absolute;
+      left: -6px;
+      top: 9px;
+      bottom: 9px;
+      width: 2px;
+      border-radius: 0 2px 2px 0;
+      background: var(--accent-primary);
+    }
   }
 
   &.exited {
     opacity: 0.5;
   }
+
+  &:hover .terminal-session-delete,
+  &:focus-within .terminal-session-delete {
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 
-.session-item-content {
-  flex: 1;
-  overflow: hidden;
+.terminal-session-button {
+  padding: 0;
+
+  svg {
+    width: 18px;
+    height: 18px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.7;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
 }
 
-.session-item-title {
-  display: block;
-  font-size: 12px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.session-item-meta {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  margin-top: 2px;
-}
-
-.session-item-shell {
-  font-size: 9px;
-  color: $accent-primary;
-  background: rgba(var(--accent-primary-rgb), 0.08);
-  padding: 0 4px;
-  border-radius: 3px;
-  line-height: 14px;
-}
-
-.session-item-time,
-.session-item-status {
-  font-size: 10px;
+.terminal-session-delete {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  z-index: 2;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid $border-color;
+  border-radius: 50%;
   color: $text-muted;
-}
+  background: $bg-card;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+  opacity: 0;
+  pointer-events: none;
 
-.session-item-delete {
-  flex-shrink: 0;
-  opacity: 0.5;
-  padding: 2px;
-  border: none;
-  background: none;
-  color: $text-muted;
-  cursor: pointer;
-  border-radius: 3px;
-  transition: all $transition-fast;
+  svg {
+    width: 11px;
+    height: 11px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+  }
 
   &:hover {
     color: $error;
-    background: rgba(var(--error-rgb), 0.1);
+    border-color: rgba(var(--error-rgb), 0.35);
+    background: rgba(var(--error-rgb), 0.08);
   }
 }
 
 .terminal-main {
   flex: 1;
+  min-width: 0;
+  min-height: 0;
   display: flex;
-  flex-direction: column;
   overflow: hidden;
-  min-width: 0;
-}
-
-.terminal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  height: $terminal-panel-header-height;
-  padding: 9px 16px;
-  border-bottom: 1px solid $border-color;
-  flex-shrink: 0;
-  min-width: 0;
-  box-sizing: border-box;
-}
-
-.header-session-title {
-  font-size: 14px;
-  font-weight: 600;
-  color: $text-primary;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.header-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-shrink: 0;
-  min-width: 0;
-}
-
-.theme-select {
-  width: 120px;
-}
-
-.sidebar-toggle {
-  @media (min-width: $breakpoint-mobile + 1) {
-    display: none;
-  }
 }
 
 .terminal-container {
+  position: relative;
   flex: 1;
-  margin: 8px;
+  margin: 0;
   overflow: hidden;
   min-height: 0;
   min-width: 0;
   display: flex;
   flex-direction: column;
+}
+
+.terminal-state {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 24px;
+  color: $text-muted;
+  font-size: 12px;
+  text-align: center;
+  background: $bg-card;
+}
+
+.terminal-state-error {
+  color: $error;
 }
 
 .terminal-xterm {
   flex: 1;
   min-height: 0;
   min-width: 0;
-  border-radius: $radius-md;
+  border-radius: 0;
   overflow: hidden;
-  border: 1px solid $border-color;
+  border: 0;
 
   :deep(.xterm) {
     height: 100%;
@@ -888,38 +813,7 @@ $terminal-panel-header-height: 47px;
     max-height: 100%;
   }
 
-  .terminal-main {
-    min-height: 0;
-    min-width: 0;
-  }
-
-  .terminal-header {
-    padding: 8px;
-    gap: 6px;
-  }
-
-  .header-session-title {
-    display: none;
-  }
-
-  .header-actions {
-    width: 100%;
-    justify-content: flex-end;
-    gap: 6px;
-  }
-
-  .theme-select {
-    width: 96px;
-  }
-
-  .terminal-container {
-    margin: 6px;
-    margin-bottom: calc(6px + env(safe-area-inset-bottom, 0px));
-  }
-
   .terminal-xterm {
-    border-radius: $radius-sm;
-
     :deep(.xterm) {
       padding: 6px;
     }

--- a/packages/client/src/components/hermes/files/FilePreview.vue
+++ b/packages/client/src/components/hermes/files/FilePreview.vue
@@ -238,6 +238,7 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   height: 100%;
+  width: 100%;
   min-height: 0;
   background: inherit;
 }

--- a/packages/client/src/components/hermes/files/FilePreview.vue
+++ b/packages/client/src/components/hermes/files/FilePreview.vue
@@ -238,6 +238,8 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 0;
+  background: inherit;
 }
 
 .preview-header {
@@ -276,7 +278,10 @@ onBeforeUnmount(() => {
   padding: 16px;
   display: flex;
   justify-content: center;
+  width: 100%;
+  height: 100%;
   min-height: 0;
+  box-sizing: border-box;
 }
 
 .preview-error { width: min(680px, 100%); align-self: flex-start; }

--- a/packages/client/src/components/hermes/files/FileToolbar.vue
+++ b/packages/client/src/components/hermes/files/FileToolbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { NButton, NSpace, useMessage } from 'naive-ui'
+import { NButton, NSpace, NTooltip, useMessage } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import { useFilesStore } from '@/stores/hermes/files'
 
@@ -31,18 +31,81 @@ async function handleRefresh() {
 <template>
   <div class="file-toolbar">
     <NSpace :size="8" :wrap="true" class="toolbar-space">
-      <NButton size="small" @click="emit('showNewFile')" class="toolbar-btn">
+      <NTooltip trigger="hover">
+        <template #trigger>
+          <NButton
+            class="toolbar-btn"
+            size="small"
+            circle
+            :aria-label="t('files.newFile')"
+            @click="emit('showNewFile')"
+          >
+            <template #icon>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M6 3h8l4 4v14H6z" />
+                <path d="M14 3v5h5M12 11v6M9 14h6" />
+              </svg>
+            </template>
+          </NButton>
+        </template>
         {{ t('files.newFile') }}
-      </NButton>
-      <NButton size="small" @click="emit('showNewFolder')" class="toolbar-btn">
+      </NTooltip>
+      <NTooltip trigger="hover">
+        <template #trigger>
+          <NButton
+            class="toolbar-btn"
+            size="small"
+            circle
+            :aria-label="t('files.newFolder')"
+            @click="emit('showNewFolder')"
+          >
+            <template #icon>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+                <path d="M12 10v6M9 13h6" />
+              </svg>
+            </template>
+          </NButton>
+        </template>
         {{ t('files.newFolder') }}
-      </NButton>
-      <NButton v-if="allowUpload" size="small" @click="emit('showUpload')" class="toolbar-btn">
+      </NTooltip>
+      <NTooltip v-if="allowUpload" trigger="hover">
+        <template #trigger>
+          <NButton
+            class="toolbar-btn"
+            size="small"
+            circle
+            :aria-label="t('files.upload')"
+            @click="emit('showUpload')"
+          >
+            <template #icon>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 16V4M7 9l5-5 5 5M5 15v5h14v-5" />
+              </svg>
+            </template>
+          </NButton>
+        </template>
         {{ t('files.upload') }}
-      </NButton>
-      <NButton size="small" @click="handleRefresh" class="toolbar-btn">
+      </NTooltip>
+      <NTooltip trigger="hover">
+        <template #trigger>
+          <NButton
+            class="toolbar-btn"
+            size="small"
+            circle
+            :aria-label="t('files.refresh')"
+            @click="handleRefresh"
+          >
+            <template #icon>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M20 12a8 8 0 1 1-2.34-5.66L20 8" />
+                <path d="M20 4v4h-4" />
+              </svg>
+            </template>
+          </NButton>
+        </template>
         {{ t('files.refresh') }}
-      </NButton>
+      </NTooltip>
     </NSpace>
   </div>
 </template>
@@ -67,11 +130,19 @@ async function handleRefresh() {
 }
 
 .toolbar-btn {
+  :deep(svg) {
+    width: 16px;
+    height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.7;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
   @media (max-width: $breakpoint-mobile) {
-    font-size: 12px;
-    padding: 0 8px;
     height: 32px;
-    white-space: nowrap;
+    width: 32px;
   }
 }
 </style>

--- a/packages/client/src/components/hermes/files/HtmlFilePreview.vue
+++ b/packages/client/src/components/hermes/files/HtmlFilePreview.vue
@@ -69,9 +69,9 @@ async function handleSourceClick(event: MouseEvent): Promise<void> {
 </template>
 
 <style scoped lang="scss">
-.html-preview { display: flex; flex-direction: column; width: 100%; height: 100%; gap: 10px; }
+.html-preview { flex: 1; display: flex; flex-direction: column; width: 100%; height: 100%; min-height: 0; gap: 10px; }
 .mode-switch { align-self: flex-start; }
-.html-frame { flex: 1; width: 100%; min-height: 420px; border: 1px solid var(--n-border-color); border-radius: 6px; background: white; scrollbar-width: none; }
+.html-frame { flex: 1; width: 100%; height: 100%; min-height: 0; border: 1px solid var(--n-border-color); border-radius: 6px; background: white; box-sizing: border-box; scrollbar-width: none; }
 .html-frame::-webkit-scrollbar { display: none; width: 0; height: 0; }
 .source-view {
   flex: 1;

--- a/tests/client/drawer-panel-resize.test.ts
+++ b/tests/client/drawer-panel-resize.test.ts
@@ -14,4 +14,22 @@ describe('ChatPanel tool drawer resizing support', () => {
     expect(source).toContain('watch(showToolPanel')
     expect(source).toContain('width: 100% !important;')
   })
+
+  it('renders the workspace, terminal, and desktop browser tabs as a full-height right icon rail', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+
+    expect(source).toContain('class="chat-tool-tabs" role="tablist"')
+    expect(source).toContain(':aria-label="t(\'drawer.files\')"')
+    expect(source).toContain(':aria-label="t(\'drawer.terminal\')"')
+    expect(source).toContain(':aria-label="t(\'browser.title\')"')
+    expect(source).toContain('v-if="desktopBrowserAvailable"')
+    expect(source).toMatch(/\.chat-tool-tabs\s*\{[\s\S]*flex-direction: column;[\s\S]*order: 2;[\s\S]*height: 100%;[\s\S]*border-left:/)
+    expect(source).toMatch(/\.chat-tool-content\s*\{\s*order: 1;[\s\S]*background: \$bg-main-surface;/)
+  })
+
+  it('uses the drawer content surface for the conversation outline', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/OutlinePanel.vue', 'utf8')
+
+    expect(source).toMatch(/\.outline-panel\s*\{[\s\S]*background-color: \$bg-main-surface;/)
+  })
 })

--- a/tests/client/drawer-panel-resize.test.ts
+++ b/tests/client/drawer-panel-resize.test.ts
@@ -24,7 +24,7 @@ describe('ChatPanel tool drawer resizing support', () => {
     expect(source).toContain(':aria-label="t(\'browser.title\')"')
     expect(source).toContain('v-if="desktopBrowserAvailable"')
     expect(source).toMatch(/\.chat-tool-panel-inner\s*\{[\s\S]*background: \$bg-main-surface;/)
-    expect(source).toMatch(/\.chat-tool-tabs\s*\{[\s\S]*flex-direction: column;[\s\S]*order: 2;[\s\S]*height: 100%;[\s\S]*border-left:/)
+    expect(source).toMatch(/\.chat-tool-tabs\s*\{[\s\S]*flex-direction: column;[\s\S]*order: 2;[\s\S]*height: 100%;[\s\S]*border-inline-start:/)
     expect(source).toMatch(/\.chat-tool-content\s*\{\s*order: 1;[\s\S]*background: \$bg-main-surface;/)
   })
 

--- a/tests/client/drawer-panel-resize.test.ts
+++ b/tests/client/drawer-panel-resize.test.ts
@@ -23,6 +23,7 @@ describe('ChatPanel tool drawer resizing support', () => {
     expect(source).toContain(':aria-label="t(\'drawer.terminal\')"')
     expect(source).toContain(':aria-label="t(\'browser.title\')"')
     expect(source).toContain('v-if="desktopBrowserAvailable"')
+    expect(source).toMatch(/\.chat-tool-panel-inner\s*\{[\s\S]*background: \$bg-main-surface;/)
     expect(source).toMatch(/\.chat-tool-tabs\s*\{[\s\S]*flex-direction: column;[\s\S]*order: 2;[\s\S]*height: 100%;[\s\S]*border-left:/)
     expect(source).toMatch(/\.chat-tool-content\s*\{\s*order: 1;[\s\S]*background: \$bg-main-surface;/)
   })

--- a/tests/client/file-preview-formats.test.ts
+++ b/tests/client/file-preview-formats.test.ts
@@ -112,7 +112,7 @@ describe('generated file preview formats', () => {
     expect(htmlPreviewSource).toMatch(/\.html-preview\s*\{[\s\S]*flex: 1;[\s\S]*height: 100%;[\s\S]*min-height: 0;/)
     expect(htmlPreviewSource).toMatch(/\.html-frame\s*\{[\s\S]*flex: 1;[\s\S]*height: 100%;[\s\S]*min-height: 0;/)
     expect(htmlPreviewSource).not.toContain('min-height: 420px')
-    expect(filePreviewSource).toMatch(/\.file-preview\s*\{[\s\S]*height: 100%;[\s\S]*min-height: 0;/)
+    expect(filePreviewSource).toMatch(/\.file-preview\s*\{[\s\S]*height: 100%;[\s\S]*width: 100%;[\s\S]*min-height: 0;/)
     expect(filePreviewSource).toMatch(/\.preview-content\s*\{[\s\S]*width: 100%;[\s\S]*height: 100%;[\s\S]*min-height: 0;/)
   })
 

--- a/tests/client/file-preview-formats.test.ts
+++ b/tests/client/file-preview-formats.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { readFileSync } from 'fs'
 import { describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import HtmlFilePreview from '@/components/hermes/files/HtmlFilePreview.vue'
@@ -102,6 +103,17 @@ describe('generated file preview formats', () => {
     await wrapper.findAll('button')[1].trigger('click')
     expect(wrapper.find('.source-view code.hljs').exists()).toBe(true)
     expect(wrapper.find('.source-view').html()).toContain('hljs-tag')
+  })
+
+  it('lets the HTML preview fill the available drawer height', () => {
+    const htmlPreviewSource = readFileSync('packages/client/src/components/hermes/files/HtmlFilePreview.vue', 'utf8')
+    const filePreviewSource = readFileSync('packages/client/src/components/hermes/files/FilePreview.vue', 'utf8')
+
+    expect(htmlPreviewSource).toMatch(/\.html-preview\s*\{[\s\S]*flex: 1;[\s\S]*height: 100%;[\s\S]*min-height: 0;/)
+    expect(htmlPreviewSource).toMatch(/\.html-frame\s*\{[\s\S]*flex: 1;[\s\S]*height: 100%;[\s\S]*min-height: 0;/)
+    expect(htmlPreviewSource).not.toContain('min-height: 420px')
+    expect(filePreviewSource).toMatch(/\.file-preview\s*\{[\s\S]*height: 100%;[\s\S]*min-height: 0;/)
+    expect(filePreviewSource).toMatch(/\.preview-content\s*\{[\s\S]*width: 100%;[\s\S]*height: 100%;[\s\S]*min-height: 0;/)
   })
 
   it('parses quoted CSV cells and enforces table and cell limits', () => {

--- a/tests/client/files-toolbar-icons.test.ts
+++ b/tests/client/files-toolbar-icons.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+
+describe('FileToolbar icon actions', () => {
+  it('renders file actions as labelled icon-only buttons', () => {
+    const source = readFileSync('packages/client/src/components/hermes/files/FileToolbar.vue', 'utf8')
+
+    expect(source).toContain('NTooltip')
+    expect(source).toContain(':aria-label="t(\'files.newFile\')"')
+    expect(source).toContain(':aria-label="t(\'files.newFolder\')"')
+    expect(source).toContain(':aria-label="t(\'files.upload\')"')
+    expect(source).toContain(':aria-label="t(\'files.refresh\')"')
+    expect(source.match(/\bcircle\b/g)?.length).toBe(4)
+    expect(source).not.toContain("{{ t('files.newFile') }}\n      </NButton>")
+    expect(source).not.toContain("{{ t('files.newFolder') }}\n      </NButton>")
+    expect(source).not.toContain("{{ t('files.refresh') }}\n      </NButton>")
+  })
+
+  it('keeps the drawer main toolbar compact without nested toolbar padding', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/FilesPanel.vue', 'utf8')
+
+    expect(source).toMatch(/\.main-toolbar\s*\{[\s\S]*padding: 5px 10px;/)
+    expect(source).toMatch(/:deep\(\.file-toolbar\)\s*\{\s*padding: 0;/)
+  })
+})

--- a/tests/client/terminal-panel-rail.test.ts
+++ b/tests/client/terminal-panel-rail.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+
+describe('TerminalPanel compact session rail', () => {
+  it('uses a headerless left rail for theme, sessions, deletion, and session creation', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/TerminalPanel.vue', 'utf8')
+
+    expect(source).not.toContain('class="terminal-header"')
+    expect(source).toContain('class="terminal-session-rail"')
+    expect(source).toContain('{{ selectedThemeInitial }}')
+    expect(source).toContain('@click="cycleTheme"')
+    expect(source).toContain('v-for="session in sessions"')
+    expect(source).toContain('class="terminal-session-delete"')
+    expect(source).toContain('@click="createSession"')
+    expect(source).toMatch(/\.terminal-session-rail\s*\{[\s\S]*width: 48px;/)
+    expect(source).toMatch(/\.terminal-session-slot\s*\{[\s\S]*&:hover \.terminal-session-delete/)
+    expect(source).toMatch(/\.terminal-session-delete\s*\{[\s\S]*top: 1px;[\s\S]*right: 1px;/)
+  })
+
+  it('fills the terminal main area without an outer margin, border, or radius', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/TerminalPanel.vue', 'utf8')
+
+    expect(source).toMatch(/\.terminal-container\s*\{[\s\S]*margin: 0;/)
+    expect(source).toMatch(/\.terminal-xterm\s*\{[\s\S]*border-radius: 0;[\s\S]*border: 0;/)
+  })
+
+  it('keeps the files drawer on the same themed background as the tool content', () => {
+    const filesSource = readFileSync('packages/client/src/components/hermes/chat/FilesPanel.vue', 'utf8')
+
+    expect(filesSource).toMatch(/\.files-panel-drawer\s*\{[\s\S]*background: inherit;/)
+    expect(filesSource).toMatch(/\.files-tree-panel\s*\{[\s\S]*background: inherit;/)
+    expect(filesSource).toMatch(/\.files-main-panel\s*\{[\s\S]*background: inherit;/)
+  })
+})

--- a/tests/e2e/desktop-window-chrome.spec.ts
+++ b/tests/e2e/desktop-window-chrome.spec.ts
@@ -363,7 +363,10 @@ test('embeds the desktop browser beside workspace and terminal', async ({ page }
 
   await page.locator('.header-tool-toggle').click()
   const toolPanel = page.locator('.chat-tool-panel')
-  await expect(toolPanel.locator('.chat-tool-tab')).toHaveText(['Workspace', 'Terminal', 'Browser'])
+  await expect(toolPanel.getByRole('tab')).toHaveCount(3)
+  await expect(toolPanel.getByRole('tab', { name: 'Workspace' })).toBeVisible()
+  await expect(toolPanel.getByRole('tab', { name: 'Terminal' })).toBeVisible()
+  await expect(toolPanel.getByRole('tab', { name: 'Browser' })).toBeVisible()
 
   await toolPanel.getByRole('tab', { name: 'Browser' }).click()
   await expect(toolPanel.locator('.browser-panel')).toBeVisible()


### PR DESCRIPTION
## Summary

- replace the horizontal workspace, terminal, and desktop-browser tabs with a full-height icon rail on the right
- replace the terminal header and wide session sidebar with a compact left rail for theme switching, terminal sessions, hover-to-delete, and session creation
- use icon-only workspace actions, reduce the workspace toolbar height, and align workspace and conversation-outline backgrounds with the drawer content surface
- make file and HTML previews fill the available drawer width and height
- preserve desktop-only browser availability and add accessible labels and hover hints for icon controls

## Why

The tool drawer used too much space for repeated text controls and its dark-theme surfaces did not read as one coherent panel. This update gives the drawer more usable content area while keeping the existing workflows available.

## Impact

The change is limited to chat drawer presentation and terminal session navigation. Terminal WebSocket transport and desktop-browser behavior are unchanged. Closing the active terminal now also reliably mounts the next remaining session.

## Validation

- `npm run test -- tests/client/file-preview-formats.test.ts tests/client/drawer-panel-resize.test.ts tests/client/files-toolbar-icons.test.ts tests/client/terminal-panel-rail.test.ts tests/client/desktop-browser-route.test.ts`
- `npm run harness:check`
- `npm run build`
