### PR TITLE
feat(i18n): use direction-aware CSS for layout and navigation

### DIFF
--- a/packages/client/src/components/layout/AppSidebar.vue
+++ b/packages/client/src/components/layout/AppSidebar.vue
@@ -571,7 +571,7 @@ function handleUpdateClick() {
   cursor: pointer;
   transition: all $transition-fast;
   width: 100%;
-  text-align: left;
+  text-align: start;
 
   &:hover {
     background-color: rgba(var(--accent-primary-rgb), 0.06);
@@ -586,7 +586,7 @@ function handleUpdateClick() {
   .beta-tag {
     font-size: 10px;
     color: $text-muted;
-    margin-left: 2px;
+    margin-inline-start: 2px;
   }
 }
 
@@ -630,7 +630,7 @@ function handleUpdateClick() {
 }
 
 .logout-username {
-  margin-left: auto;
+  margin-inline-start: auto;
   max-width: 96px;
   color: $text-muted;
   font-size: 12px;
@@ -652,7 +652,7 @@ function handleUpdateClick() {
   align-items: center;
   gap: 8px;
   min-width: 0;
-  padding-left: 12px;
+  padding-inline-start: 12px;
   font-size: 12px;
   color: $text-secondary;
 

--- a/packages/client/src/components/layout/DesktopTitleBar.vue
+++ b/packages/client/src/components/layout/DesktopTitleBar.vue
@@ -119,7 +119,7 @@ onMounted(() => {
     width: 138px;
 
     .desktop-titlebar__controls {
-      border-left: 0;
+      border-inline-start: 0;
       border-radius: inherit;
       clip-path: inset(0 round 12px);
     }
@@ -150,7 +150,7 @@ onMounted(() => {
   align-items: stretch;
   overflow: hidden;
   contain: paint;
-  border-left: 1px solid $border-color;
+  border-inline-start: 1px solid $border-color;
   border-radius: 0 12px 12px 0;
   clip-path: inset(0 round 0 12px 12px 0);
   -webkit-app-region: no-drag;

--- a/packages/client/src/components/layout/ModelSelector.vue
+++ b/packages/client/src/components/layout/ModelSelector.vue
@@ -353,7 +353,7 @@ async function handleRefresh() {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  text-align: left;
+  text-align: start;
 }
 
 .model-arrow {
@@ -413,7 +413,7 @@ async function handleRefresh() {
 }
 
 .model-group-items {
-  padding-left: 8px;
+  padding-inline-start: 8px;
 }
 
 .model-item {
@@ -488,7 +488,7 @@ async function handleRefresh() {
   background: $accent-primary;
   padding: 1px 5px;
   border-radius: 3px;
-  margin-right: 4px;
+  margin-inline-end: 4px;
   letter-spacing: 0.03em;
 }
 
@@ -519,7 +519,7 @@ async function handleRefresh() {
   background: #d97706;
   padding: 1px 5px;
   border-radius: 3px;
-  margin-right: 4px;
+  margin-inline-end: 4px;
   letter-spacing: 0.03em;
 }
 
@@ -532,7 +532,7 @@ async function handleRefresh() {
   border: 1px solid $border-color;
   padding: 0 5px;
   border-radius: 3px;
-  margin-right: 4px;
+  margin-inline-end: 4px;
   letter-spacing: 0.03em;
 }
 

--- a/packages/client/src/components/layout/SettingsCircuitBadge.vue
+++ b/packages/client/src/components/layout/SettingsCircuitBadge.vue
@@ -378,7 +378,7 @@ function confirmDeleteDevice(device: McuDevice) {
   border-radius: 8px;
   background: transparent;
   align-items: center;
-  margin-left: auto;
+  margin-inline-start: auto;
   color: inherit;
   cursor: pointer;
   transition:

--- a/tests/client/rtl-logical-css.test.ts
+++ b/tests/client/rtl-logical-css.test.ts
@@ -2,16 +2,20 @@ import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 
-const CHAT_ROOT = join(process.cwd(), 'packages/client/src/components/hermes/chat')
+const CLIENT_ROOT = join(process.cwd(), 'packages/client/src')
 
-// The chat surface is the most text-heavy part of the UI, so its spacing,
-// borders and text alignment must follow the writing direction rather than a
-// physical side. Guards against reintroducing the physical variants.
-const CHAT_COMPONENTS = [
-  'ChatInput.vue',
-  'ChatPanel.vue',
-  'MessageItem.vue',
-  'MessageList.vue',
+// Spacing, borders and text alignment in these components must follow the
+// writing direction rather than a physical side. Guards against reintroducing
+// the physical variants as the conversion spreads through the app.
+const DIRECTION_AWARE_COMPONENTS = [
+  'components/hermes/chat/ChatInput.vue',
+  'components/hermes/chat/ChatPanel.vue',
+  'components/hermes/chat/MessageItem.vue',
+  'components/hermes/chat/MessageList.vue',
+  'components/layout/AppSidebar.vue',
+  'components/layout/DesktopTitleBar.vue',
+  'components/layout/ModelSelector.vue',
+  'components/layout/SettingsCircuitBadge.vue',
 ]
 
 const PHYSICAL_PATTERNS: Array<{ label: string, pattern: RegExp }> = [
@@ -25,12 +29,12 @@ const PHYSICAL_PATTERNS: Array<{ label: string, pattern: RegExp }> = [
   { label: 'text-align: right', pattern: /text-align:\s*right\b/g },
 ]
 
-describe('chat surface uses direction-aware CSS', () => {
+describe('converted components use direction-aware CSS', () => {
   it('has no physical inline-axis spacing, borders or text alignment', () => {
     const offenders: string[] = []
 
-    for (const component of CHAT_COMPONENTS) {
-      const source = readFileSync(join(CHAT_ROOT, component), 'utf8')
+    for (const component of DIRECTION_AWARE_COMPONENTS) {
+      const source = readFileSync(join(CLIENT_ROOT, component), 'utf8')
       for (const { label, pattern } of PHYSICAL_PATTERNS) {
         const matches = source.match(pattern)
         if (matches) offenders.push(`${component}: ${label} × ${matches.length}`)
@@ -41,8 +45,8 @@ describe('chat surface uses direction-aware CSS', () => {
   })
 
   it('actually uses the logical replacements', () => {
-    const combined = CHAT_COMPONENTS
-      .map(component => readFileSync(join(CHAT_ROOT, component), 'utf8'))
+    const combined = DIRECTION_AWARE_COMPONENTS
+      .map(component => readFileSync(join(CLIENT_ROOT, component), 'utf8'))
       .join('\n')
 
     for (const logical of ['margin-inline-start', 'padding-inline-start', 'border-inline-start']) {


### PR DESCRIPTION
Continues the RTL series (after #2270, #2271, #2273) into the navigation chrome.

### Problem

`AppSidebar`, `DesktopTitleBar`, `ModelSelector` and `SettingsCircuitBadge` pin spacing and borders to physical sides, so under `dir="rtl"` the sidebar gutter, the title-bar padding and the selector dividers stay on the wrong edge of the window even though the document is mirrored.

### Change

12 declarations become their logical equivalents (`margin-inline-start`/`-end`, `padding-inline-start`/`-end`, `border-inline-start`/`-end`, `text-align: start`):

| component | declarations |
| --- | --- |
| `AppSidebar.vue` | 4 |
| `DesktopTitleBar.vue` | 2 |
| `ModelSelector.vue` | 5 |
| `SettingsCircuitBadge.vue` | 1 |

Logical properties resolve to exactly the previous physical sides for left-to-right locales, so **there is no visual change for existing users**.

### Guard test generalized

`tests/client/rtl-logical-css.test.ts` previously hardcoded the four chat files under a chat-specific root. It now scans a list of converted components rooted at `packages/client/src`, so each newly converted area is added to one list and stays protected. Same two assertions as before: no physical inline-axis declarations, and the logical replacements are actually present.

### Verification

- `tests/client/rtl-logical-css.test.ts` passes with the 8 covered components
- `vue-tsc --noEmit -p tsconfig.app.json` clean
- `npm run harness:check` passes
- Full `tests/client`: 972 passed, 1 failure in `use-speech-tts.test.ts > synthesizeSpeech posts to the unified endpoint`, which fails identically on a clean `main` and is unrelated

### Still to convert

Group chat, the feature panels (models, kanban, skills, jobs, settings) and the page-level views — roughly 84 declarations left, which I will send as separate PRs by area rather than one sweep.
