### PR TITLE
Add profile-scoped Ekko session workspaces

### DIFF
--- a/docs/chat-chain-changes/2026-07-30-ekko-session-workspaces.md
+++ b/docs/chat-chain-changes/2026-07-30-ekko-session-workspaces.md
@@ -1,0 +1,15 @@
+---
+date: 2026-07-30
+pr: pending
+feature: Profile-scoped Ekko Agent session workspaces
+impact: New Ekko Agent sessions without an explicit workspace use an isolated directory under `.ekko/workspace/<profile>/<session-id>`.
+---
+
+Ekko Agent initialization now creates its owned `.ekko/workspace` root. Each
+profile-scoped global agent creates a profile directory beneath that root and
+resolves a dedicated session workspace on demand.
+
+The Ekko chat runtime persists that managed path as the session workspace and
+passes it as both `cwd` and `workspaceRoot`. Explicit workspaces remain
+authoritative, so existing sessions and user-selected project directories do
+not move.

--- a/packages/ekko-agent/README.md
+++ b/packages/ekko-agent/README.md
@@ -107,12 +107,14 @@ instead implement and own its internal compression lifecycle.
 
 Ekko owns one filesystem root through `EkkoDirectoryManager`. The manager takes
 one optional base directory (the user's home directory by default), creates
-`<base>/.ekko/skills`, and keeps the SQLite database at
+`<base>/.ekko/skills` and `<base>/.ekko/workspace`, and keeps the SQLite database at
 `<base>/.ekko/ekko.db`. A running profile uses
 `<base>/.ekko/skills/<profile>` for its skills and
-`<base>/.ekko/logs/<profile>` for its log. The server supplies its Web UI home
-as the base directory. For compatibility, the server supplies the Hermes root
-during initialization. If `.ekko/skills` does not exist yet, the manager imports
+`<base>/.ekko/logs/<profile>` for its log. Its default per-session workspace is
+`<base>/.ekko/workspace/<profile>/<session-id>`; an explicitly supplied
+`workspaceRoot` or `cwd` takes precedence. The server supplies its Web UI home as
+the base directory. For compatibility, the server supplies the Hermes root during
+initialization. If `.ekko/skills` does not exist yet, the manager imports
 the default profile from `<hermes>/skills` and every named profile from
 `<hermes>/profiles/<profile>/skills`. This is a one-time copy: once
 `.ekko/skills` exists, later startups do not resync or overwrite Ekko-owned

--- a/packages/ekko-agent/src/directories.ts
+++ b/packages/ekko-agent/src/directories.ts
@@ -17,6 +17,7 @@ export interface EkkoDirectoryLayout {
   databasePath: string
   skillsDirectory: string
   logsDirectory: string
+  workspaceDirectory: string
 }
 
 export interface EkkoDirectoryInitializationOptions {
@@ -44,6 +45,7 @@ export class EkkoDirectoryManager {
   readonly databasePath: string
   readonly skillsDirectory: string
   readonly logsDirectory: string
+  readonly workspaceDirectory: string
   lastSkillImport?: EkkoSkillImportResult
 
   constructor(baseDirectory: string = homedir()) {
@@ -52,6 +54,7 @@ export class EkkoDirectoryManager {
     this.databasePath = join(this.rootDirectory, 'ekko.db')
     this.skillsDirectory = join(this.rootDirectory, 'skills')
     this.logsDirectory = join(this.rootDirectory, 'logs')
+    this.workspaceDirectory = join(this.rootDirectory, 'workspace')
   }
 
   initialize(options: EkkoDirectoryInitializationOptions = {}): EkkoDirectoryLayout {
@@ -61,6 +64,7 @@ export class EkkoDirectoryManager {
     } else {
       mkdirSync(this.skillsDirectory, { recursive: true })
     }
+    mkdirSync(this.workspaceDirectory, { recursive: true })
     return this.layout()
   }
 
@@ -80,6 +84,22 @@ export class EkkoDirectoryManager {
     return join(this.logsDirectory, profileDirectoryName(profile))
   }
 
+  profileWorkspaceDirectory(profile = 'default'): string {
+    const directory = join(this.workspaceDirectory, profileDirectoryName(profile))
+    mkdirSync(directory, { recursive: true })
+    return directory
+  }
+
+  sessionWorkspaceDirectory(profile: string, sessionId: string): string {
+    const directory = join(
+      this.workspaceDirectory,
+      profileDirectoryName(profile),
+      sessionDirectoryName(sessionId),
+    )
+    mkdirSync(directory, { recursive: true })
+    return directory
+  }
+
   layout(): EkkoDirectoryLayout {
     return {
       baseDirectory: this.baseDirectory,
@@ -87,6 +107,7 @@ export class EkkoDirectoryManager {
       databasePath: this.databasePath,
       skillsDirectory: this.skillsDirectory,
       logsDirectory: this.logsDirectory,
+      workspaceDirectory: this.workspaceDirectory,
     }
   }
 
@@ -119,14 +140,24 @@ export class EkkoDirectoryManager {
 
 function profileDirectoryName(value: string): string {
   const profile = String(value || '').trim() || 'default'
+  return safeDirectoryName(profile, 'profile')
+}
+
+function sessionDirectoryName(value: string): string {
+  const sessionId = String(value || '').trim()
+  if (!sessionId) throw new Error('Ekko session directory name is required')
+  return safeDirectoryName(sessionId, 'session')
+}
+
+function safeDirectoryName(value: string, kind: 'profile' | 'session'): string {
   if (
-    profile === '.' ||
-    profile === '..' ||
-    /[<>:"/\\|?*\u0000-\u001f]/u.test(profile)
+    value === '.' ||
+    value === '..' ||
+    /[<>:"/\\|?*\u0000-\u001f]/u.test(value)
   ) {
-    throw new Error(`Invalid Ekko profile directory name: ${profile}`)
+    throw new Error(`Invalid Ekko ${kind} directory name: ${value}`)
   }
-  return profile
+  return value
 }
 
 function hermesProfileSkillSources(

--- a/packages/server/src/services/ekko-agent/manager.ts
+++ b/packages/server/src/services/ekko-agent/manager.ts
@@ -30,6 +30,7 @@ export class GlobalEkkoAgent {
   private readonly directories: EkkoDirectoryManager
   private readonly skillDirectory: string
   private readonly logDirectory: string
+  private readonly workspaceDirectory: string
   private readonly fileLogger: EkkoFileLogger
   private runtime?: AgentRuntime
   private memory?: MemoryService
@@ -41,6 +42,7 @@ export class GlobalEkkoAgent {
     this.directories.initialize({ hermesRootDirectory: getHermesBaseDir() })
     this.skillDirectory = this.directories.profileSkillsDirectory(options.profile)
     this.logDirectory = this.directories.profileLogsDirectory(options.profile)
+    this.workspaceDirectory = this.directories.profileWorkspaceDirectory(options.profile)
     this.fileLogger = new EkkoFileLogger({ directory: this.logDirectory })
     this.writeLog({
       category: 'system',
@@ -49,6 +51,7 @@ export class GlobalEkkoAgent {
         dataDirectory: this.directories.rootDirectory,
         skillDirectory: this.skillDirectory,
         logDirectory: this.logDirectory,
+        workspaceDirectory: this.workspaceDirectory,
       },
     })
     if (this.directories.lastSkillImport) {
@@ -63,11 +66,15 @@ export class GlobalEkkoAgent {
   async run(input: AgentRuntimeRunInput): Promise<AgentRuntimeRunResult> {
     this.lastUsedAt = Date.now()
     this.runCount += 1
-    return this.runtimeInstance().run(input)
+    return this.runtimeInstance().run(this.withDefaultWorkspace(input))
   }
 
   async estimateContext(input: AgentRuntimeRunInput): Promise<AgentRuntimeContextEstimate> {
-    return this.runtimeInstance().estimateContext(input)
+    return this.runtimeInstance().estimateContext(this.withDefaultWorkspace(input))
+  }
+
+  sessionWorkspaceDirectory(sessionId: string): string {
+    return this.directories.sessionWorkspaceDirectory(this.options.profile || 'default', sessionId)
   }
 
   hasBackgroundTasks(sessionId?: string): boolean {
@@ -111,6 +118,7 @@ export class GlobalEkkoAgent {
       dataDirectory: this.directories.rootDirectory,
       skillDirectory: this.skillDirectory,
       logDirectory: this.logDirectory,
+      workspaceDirectory: this.workspaceDirectory,
       logFilePath: this.fileLogger.filePath,
       profile: this.options.profile || 'default',
     }
@@ -171,6 +179,25 @@ export class GlobalEkkoAgent {
       data: { memoryEnabled: this.memory?.isEnabled ?? false },
     })
     return this.runtime
+  }
+
+  private withDefaultWorkspace(input: AgentRuntimeRunInput): AgentRuntimeRunInput {
+    if (input.toolContext?.workspaceRoot || input.toolContext?.cwd) return input
+    const sessionId = (
+      input.toolContext?.sessionId ||
+      (typeof input.metadata?.session_id === 'string' ? input.metadata.session_id : '')
+    ).trim()
+    if (!sessionId) return input
+    const workspace = this.sessionWorkspaceDirectory(sessionId)
+    return {
+      ...input,
+      toolContext: {
+        ...input.toolContext,
+        cwd: workspace,
+        workspaceRoot: workspace,
+        workspaceId: input.toolContext?.workspaceId || workspace,
+      },
+    }
   }
 }
 

--- a/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
@@ -32,7 +32,6 @@ import {
 import type { ChatMessage } from '../../../lib/context-compressor'
 import { logger } from '../../logger'
 import { recordSessionUsage } from '../../usage-recorder'
-import { getProfileDir } from '../hermes-profile'
 import { observeRunChatPetEvent } from '../pet-state-socket'
 import { contentBlocksToString, convertContentBlocksForAgent, extractTextForPreview } from './content-blocks'
 import { buildCompressedHistory, getOrCreateSession } from './compression'
@@ -421,7 +420,8 @@ export async function handleEkkoAgentRun(
   const apiMode = runtimeConfig.apiMode
   const apiKey = runtimeConfig.apiKey
   const reasoningEffort = resolveReasoningEffort(data.reasoning_effort)
-  const workspace = data.workspace || storedSession?.workspace || getProfileDir(profile)
+  const agent = getGlobalEkkoAgent(profile)
+  const workspace = data.workspace || storedSession?.workspace || agent.sessionWorkspaceDirectory(sessionId)
   const shouldEmitWorkspaceUpdate = Boolean(workspace && !storedSession?.workspace)
   if (storedSession && !storedSession.workspace) updateSession(sessionId, { workspace })
   const displayInput = data.display_input === undefined ? data.input : data.display_input
@@ -526,7 +526,6 @@ export async function handleEkkoAgentRun(
         }
       : undefined,
   })
-  const agent = getGlobalEkkoAgent(profile)
   const memoryUsageBatchId = randomUUID()
   const skillReviewUsageBatchId = randomUUID()
   const turnId = randomUUID()

--- a/tests/ekko-agent/database.test.ts
+++ b/tests/ekko-agent/database.test.ts
@@ -27,7 +27,7 @@ describe('EkkoDatabaseManager', () => {
     expect(new EkkoDirectoryManager().baseDirectory).toBe(homedir())
   })
 
-  it('initializes the Ekko root and only its skills feature directory', () => {
+  it('initializes the Ekko root with its skills and workspace directories', () => {
     const directories = new EkkoDirectoryManager(webUiHome)
     expect(existsSync(directories.rootDirectory)).toBe(false)
 
@@ -37,14 +37,21 @@ describe('EkkoDatabaseManager', () => {
       databasePath: join(webUiHome, '.ekko', 'ekko.db'),
       skillsDirectory: join(webUiHome, '.ekko', 'skills'),
       logsDirectory: join(webUiHome, '.ekko', 'logs'),
+      workspaceDirectory: join(webUiHome, '.ekko', 'workspace'),
     })
     expect(existsSync(directories.skillsDirectory)).toBe(true)
+    expect(existsSync(directories.workspaceDirectory)).toBe(true)
     expect(existsSync(directories.logsDirectory)).toBe(false)
     expect(existsSync(directories.databasePath)).toBe(false)
     expect(directories.profileSkillsDirectory('work')).toBe(join(webUiHome, '.ekko', 'skills', 'work'))
     expect(directories.profileLogsDirectory('work')).toBe(join(webUiHome, '.ekko', 'logs', 'work'))
+    expect(directories.profileWorkspaceDirectory('work')).toBe(join(webUiHome, '.ekko', 'workspace', 'work'))
+    expect(directories.sessionWorkspaceDirectory('work', 'session-1')).toBe(
+      join(webUiHome, '.ekko', 'workspace', 'work', 'session-1'),
+    )
     expect(existsSync(join(webUiHome, '.ekko', 'skills', 'work'))).toBe(true)
     expect(existsSync(join(webUiHome, '.ekko', 'logs', 'work'))).toBe(true)
+    expect(existsSync(join(webUiHome, '.ekko', 'workspace', 'work', 'session-1'))).toBe(true)
     expect(existsSync(join(webUiHome, '.ekko', 'skills', 'work', '.ekko-backups'))).toBe(false)
     expect(existsSync(join(webUiHome, '.ekko', 'skills', 'work', '.ekko-archive'))).toBe(false)
   })

--- a/tests/server/ekko-agent-manager.test.ts
+++ b/tests/server/ekko-agent-manager.test.ts
@@ -103,8 +103,12 @@ describe('GlobalEkkoAgent', () => {
     expect(request.model).toBe('test-model')
     expect(request.metadata).toEqual({ session_id: 'session-1' })
     expect(request.messages[0].content).toContain('## Image and File Output')
+    expect(request.messages[0].content).toContain(
+      `workspaceRoot: ${join(baseDirectory, '.ekko', 'workspace', 'default', 'session-1')}`,
+    )
     expect(request.messages[0].content).toContain('![description](/absolute/path/image.png)')
     expect(request.messages[0].content).toContain('![description](<C:/absolute/path/image.png>)')
+    expect(existsSync(join(baseDirectory, '.ekko', 'workspace', 'default', 'session-1'))).toBe(true)
   })
 
   it('binds skill tools to the directory provided when the agent is created', async () => {
@@ -181,9 +185,11 @@ describe('GlobalEkkoAgent', () => {
         dataDirectory: join(baseDirectory, '.ekko'),
         skillDirectory: join(baseDirectory, '.ekko', 'skills', 'default'),
         logDirectory: join(baseDirectory, '.ekko', 'logs', 'default'),
+        workspaceDirectory: join(baseDirectory, '.ekko', 'workspace', 'default'),
         logFilePath: join(baseDirectory, '.ekko', 'logs', 'default', 'ekko-agent.jsonl'),
       })
       expect(existsSync(join(baseDirectory, '.ekko', 'skills'))).toBe(true)
+      expect(existsSync(join(baseDirectory, '.ekko', 'workspace'))).toBe(true)
       expect(existsSync(join(baseDirectory, '.ekko', 'logs', 'default', 'ekko-agent.jsonl'))).toBe(true)
       expect(existsSync(join(baseDirectory, '.ekko', 'ekko.db'))).toBe(true)
     } finally {

--- a/tests/server/run-chat-ekko-context.test.ts
+++ b/tests/server/run-chat-ekko-context.test.ts
@@ -15,10 +15,14 @@ const resolveModelProviderConfigsMock = vi.hoisted(() => vi.fn())
 const agentRunMock = vi.hoisted(() => vi.fn())
 const agentEstimateContextMock = vi.hoisted(() => vi.fn(async () => ({ contextTokens: 5_000 })))
 const agentWriteLogMock = vi.hoisted(() => vi.fn(() => true))
+const agentSessionWorkspaceDirectoryMock = vi.hoisted(() => (
+  vi.fn((sessionId: string) => `/tmp/ekko-workspace/default/${sessionId}`)
+))
 const getGlobalEkkoAgentMock = vi.hoisted(() => vi.fn(() => ({
   run: agentRunMock,
   estimateContext: agentEstimateContextMock,
   writeLog: agentWriteLogMock,
+  sessionWorkspaceDirectory: agentSessionWorkspaceDirectoryMock,
 })))
 const buildCompressedHistoryMock = vi.hoisted(() => vi.fn())
 const recordSessionUsageMock = vi.hoisted(() => vi.fn())
@@ -898,6 +902,7 @@ describe('ekko-agent context usage events', () => {
       onEvent: (event: string, payload: any) => events.push({ event, payload }),
     }, 'default', sessionMap, vi.fn(() => false))
 
+    expect(agentSessionWorkspaceDirectoryMock).not.toHaveBeenCalled()
     expect(createSessionMock).toHaveBeenCalledWith(expect.objectContaining({
       id: 'session-1',
       agent: 'ekko-agent',
@@ -910,6 +915,49 @@ describe('ekko-agent context usage events', () => {
         event: 'session.workspace.updated',
         session_id: 'session-1',
         workspace: '/tmp/new-workspace',
+      },
+    })
+  })
+
+  it('uses the profile-scoped Ekko session workspace by default', async () => {
+    getSessionMock.mockReturnValueOnce(null)
+    agentRunMock.mockResolvedValueOnce({
+      runId: 'run-1',
+      output: { role: 'assistant', content: 'done', usage: { inputTokens: 3, outputTokens: 2 } },
+      steps: [],
+      messages: [],
+      events: [],
+      contextEstimate: { contextTokens: 12_000 },
+    })
+    const { handleEkkoAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-ekko-agent-run')
+    const { nsp, socket, sessionMap, events } = makeHarness()
+
+    await handleEkkoAgentRun(nsp as any, socket as any, {
+      session_id: 'session-1',
+      input: 'create a file',
+      coding_agent_id: 'ekko-agent',
+      onEvent: (event: string, payload: any) => events.push({ event, payload }),
+    }, 'default', sessionMap, vi.fn(() => false))
+
+    const workspace = '/tmp/ekko-workspace/default/session-1'
+    expect(agentSessionWorkspaceDirectoryMock).toHaveBeenCalledWith('session-1')
+    expect(createSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'session-1',
+      agent: 'ekko-agent',
+      workspace,
+    }))
+    expect(agentRunMock).toHaveBeenCalledWith(expect.objectContaining({
+      toolContext: expect.objectContaining({
+        cwd: workspace,
+        workspaceRoot: workspace,
+      }),
+    }))
+    expect(events).toContainEqual({
+      event: 'session.workspace.updated',
+      payload: {
+        event: 'session.workspace.updated',
+        session_id: 'session-1',
+        workspace,
       },
     })
   })


### PR DESCRIPTION
## Summary

- initialize the Ekko-owned `.ekko/workspace` directory
- create isolated default workspaces at `.ekko/workspace/<profile>/<session-id>`
- persist the managed workspace for new Ekko chat sessions and pass it as both `cwd` and `workspaceRoot`
- preserve explicitly selected and existing session workspaces
- document and test the directory layout and chat runtime behavior

## Why

Ekko Agent sessions previously fell back to the Hermes profile directory when no workspace was selected. This gives every Ekko session a predictable, isolated default workspace owned by Ekko while retaining explicit workspace overrides.

## Impact

New Ekko sessions without a selected workspace write files under their own profile/session directory. Existing sessions and user-selected project directories are unchanged.

## Validation

- `npm run test -- tests/ekko-agent/database.test.ts tests/server/ekko-agent-manager.test.ts tests/server/run-chat-ekko-context.test.ts`
- `npm --prefix packages/ekko-agent run check`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run harness:check`
- `git diff --check`
