### PR TITLE
fix(chat): let message text find its own direction

### DIFF
--- a/docs/chat-chain-changes/2026-07-31-message-auto-direction.md
+++ b/docs/chat-chain-changes/2026-07-31-message-auto-direction.md
@@ -1,0 +1,6 @@
+---
+date: 2026-07-31
+pr: pending
+feature: Message text finds its own direction
+impact: Every rendered message block, the composer, and conversation titles in the list carry dir="auto", so a right-to-left message reads correctly while the interface stays in any locale, and a mixed conversation renders each block on its own terms; code blocks and inline code are pinned left-to-right so a snippet inside a right-to-left sentence is never mirrored.
+---

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1300,6 +1300,7 @@ function isImage(type: string): boolean {
         ref="textareaRef"
         v-model="inputText"
         class="input-textarea"
+        dir="auto"
         :style="textareaHeight ? { height: textareaHeight + 'px' } : {}"
         :placeholder="t('chat.inputPlaceholder')"
         rows="1"

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -96,6 +96,27 @@ md.use(markdownItKatex, {
   strict: 'ignore',
 })
 
+// A conversation carries whatever language the person writes in, and one
+// message can hold both. dir="auto" lets each block pick its own direction from
+// its first strong character, so an Arabic paragraph reads right-to-left even
+// while the interface is in English — and the reverse.
+const AUTO_DIRECTION_TOKENS = new Set([
+  'paragraph_open',
+  'heading_open',
+  'blockquote_open',
+  'list_item_open',
+  'th_open',
+  'td_open',
+  'dt_open',
+  'dd_open',
+])
+
+md.core.ruler.push('auto_direction', (state) => {
+  for (const token of state.tokens) {
+    if (AUTO_DIRECTION_TOKENS.has(token.type)) token.attrSet('dir', 'auto')
+  }
+})
+
 const defaultFenceRenderer = md.renderer.rules.fence?.bind(md.renderer.rules)
 
 md.renderer.rules.fence = (tokens, idx, options, env, self) => {
@@ -496,7 +517,7 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
 </script>
 
 <template>
-  <div ref="markdownBody" class="markdown-body" v-html="renderedHtml" @click="handleMarkdownClick"></div>
+  <div ref="markdownBody" class="markdown-body" dir="auto" v-html="renderedHtml" @click="handleMarkdownClick"></div>
   <Teleport to="body">
     <div v-if="previewUrl" class="image-preview-overlay" @click.self="previewUrl = null">
       <img :src="previewUrl" class="image-preview-img" @click="previewUrl = null" />
@@ -508,6 +529,17 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
 @use '@/styles/variables' as *;
 
 .markdown-body {
+  // Code keeps its own direction whatever language surrounds it: a snippet
+  // inside an Arabic sentence must not be mirrored.
+  pre,
+  code,
+  kbd,
+  samp {
+    direction: ltr;
+    unicode-bidi: isolate;
+    text-align: start;
+  }
+
   font-size: var(--font-size-base);
   line-height: 1.65;
   width: 100%;
@@ -717,7 +749,7 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
     th, td {
       padding: 6px 12px;
       border: 1px solid $border-color;
-      text-align: left;
+      text-align: start;
       font-size: 13px;
     }
 

--- a/packages/client/src/components/hermes/chat/SessionListItem.vue
+++ b/packages/client/src/components/hermes/chat/SessionListItem.vue
@@ -143,7 +143,7 @@ onUnmounted(() => {
             </svg>
           </span>
           <span v-if="completedUnread" class="session-item-unread-dot" aria-hidden="true" />
-          <span class="session-item-title">
+          <span class="session-item-title" dir="auto">
             {{ session.title }}
           </span>
           <NTooltip v-if="profileModelsMissing" trigger="click" placement="top">

--- a/tests/client/markdown-auto-direction.test.ts
+++ b/tests/client/markdown-auto-direction.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'fs'
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+
+vi.mock('mermaid', () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn(async (id: string) => ({ svg: `<svg id="${id}" />` })),
+  },
+}))
+
+vi.mock('@/utils/desktop-browser', () => ({
+  openUrlInDesktopBrowser: vi.fn(() => Promise.resolve(false)),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NDrawer: { props: ['show', 'width'], template: '<div v-if="show"><slot /></div>' },
+  NDrawerContent: { props: ['title', 'closable', 'bodyContentStyle'], template: '<section><slot /></section>' },
+  NSpin: { props: ['show'], template: '<div><slot /></div>' },
+  useMessage: () => ({ error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() }),
+}))
+
+import MarkdownRenderer from '@/components/hermes/chat/MarkdownRenderer.vue'
+
+async function render(content: string): Promise<string> {
+  const wrapper = mount(MarkdownRenderer, { props: { content } })
+  await nextTick()
+  return wrapper.html()
+}
+
+describe('message direction follows the message, not the interface', () => {
+  it('marks every block so its own text decides the direction', async () => {
+    const html = await render([
+      'خلصت الجزء الأول ورفعته على السيرفر.',
+      '',
+      '## عنوان',
+      '',
+      '- عنصر أول',
+      '- عنصر ثانٍ',
+      '',
+      '> اقتباس',
+    ].join('\n'))
+
+    expect(html).toContain('<p dir="auto">')
+    expect(html).toContain('<h2 dir="auto"')
+    expect(html).toContain('<li dir="auto">')
+    expect(html).toContain('<blockquote dir="auto">')
+  })
+
+  it('applies to English text the same way, so a mixed conversation stays readable', async () => {
+    const html = await render('The deploy finished.\n\nتم النشر بنجاح.')
+    expect(html.match(/<p dir="auto">/g)?.length).toBe(2)
+  })
+
+  it('carries the attribute on the container itself', async () => {
+    const wrapper = mount(MarkdownRenderer, { props: { content: 'مرحبا' } })
+    await nextTick()
+    expect(wrapper.find('.markdown-body').attributes('dir')).toBe('auto')
+  })
+
+  it('keeps code left-to-right inside a right-to-left message', async () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/MarkdownRenderer.vue', 'utf8')
+    // A snippet inside an Arabic sentence must not be mirrored, so the rule is
+    // in CSS rather than left to the browser's bidi guess.
+    expect(source).toMatch(/pre,\s*\n\s*code,[\s\S]*?direction: ltr;/)
+    expect(source).toContain('unicode-bidi: isolate;')
+  })
+
+  it('does not leave a physical alignment in table cells', async () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/MarkdownRenderer.vue', 'utf8')
+    expect(source).not.toContain('text-align: left;')
+  })
+})
+
+describe('user text elsewhere in the chat', () => {
+  it('lets the composer show what is being typed in its own direction', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/ChatInput.vue', 'utf8')
+    expect(source).toContain('class="input-textarea"')
+    expect(source).toContain('dir="auto"')
+  })
+
+  it('lets a conversation title in the list read in its own direction', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/SessionListItem.vue', 'utf8')
+    expect(source).toContain('<span class="session-item-title" dir="auto">')
+  })
+})


### PR DESCRIPTION
### The problem

A message is written in whatever language the person speaks, and one conversation can hold several. Today every message inherits the direction of the **interface**, so an Arabic (or Hebrew, Persian, Urdu) reply inside an English UI renders with its punctuation on the wrong side and lines that begin where they should end.

Switching the whole interface to Arabic is not an answer either — it makes the English messages wrong instead. The direction has to come from the text, not from the locale.

### The fix

`dir="auto"` is exactly this rule: each block takes its direction from its own first strong character.

- A `markdown-it` core rule stamps it on every block a message can produce — paragraphs, headings, list items, blockquotes, table cells — so a message that mixes languages gets it right paragraph by paragraph
- The rendered container carries it too
- The composer and conversation titles in the list get it as well, since those are user text
- **Code is pinned the other way**: `pre`, `code`, `kbd`, `samp` are forced to `ltr` with `unicode-bidi: isolate`, so a snippet inside an Arabic sentence is never mirrored — the failure this kind of change usually introduces
- One leftover `text-align: left` on table cells becomes `start`

Group chat needs no separate change: its messages render through the same `MarkdownRenderer`.

Nothing changes for an English-only conversation: `dir="auto"` on English text resolves to `ltr`, which is what it was.

### Tests

`tests/client/markdown-auto-direction.test.ts` mounts the renderer and asserts the **produced HTML** rather than the source, including the mixed-language case where two paragraphs each have to get their own direction. `npm run harness:check` passes, with a chat-chain fragment added.

### Relationship to the RTL series

Independent of #2284–#2288. Those convert the app's own CSS to logical properties so the *interface* can mirror; this one is about the direction of *user content*, and it matters even when the interface stays in English. Either can land first.
