### PR TITLE
[codex] fix workspace diff drawer width

### DIFF
--- a/packages/client/src/components/hermes/files/WorkspaceDiffPreview.vue
+++ b/packages/client/src/components/hermes/files/WorkspaceDiffPreview.vue
@@ -134,9 +134,12 @@ async function handleDiffClick(event: MouseEvent): Promise<void> {
 @use '@/styles/variables' as *;
 
 .workspace-diff-preview {
+  flex: 1;
   display: flex;
   flex-direction: column;
   height: 100%;
+  width: 100%;
+  min-width: 0;
   min-height: 0;
 }
 
@@ -186,6 +189,7 @@ async function handleDiffClick(event: MouseEvent): Promise<void> {
 
 .diff-preview-content {
   flex: 1;
+  min-width: 0;
   min-height: 0;
   overflow: hidden;
 }
@@ -209,6 +213,8 @@ async function handleDiffClick(event: MouseEvent): Promise<void> {
 
 :deep(.file-editor) {
   height: 100%;
+  width: 100%;
+  min-width: 0;
   min-height: 0;
 }
 

--- a/tests/client/drawer-panel-resize.test.ts
+++ b/tests/client/drawer-panel-resize.test.ts
@@ -33,4 +33,12 @@ describe('ChatPanel tool drawer resizing support', () => {
 
     expect(source).toMatch(/\.outline-panel\s*\{[\s\S]*background-color: \$bg-main-surface;/)
   })
+
+  it('keeps workspace diffs and their editor stretched across the drawer', () => {
+    const source = readFileSync('packages/client/src/components/hermes/files/WorkspaceDiffPreview.vue', 'utf8')
+
+    expect(source).toMatch(/\.workspace-diff-preview\s*\{[\s\S]*flex: 1;[\s\S]*width: 100%;[\s\S]*min-width: 0;/)
+    expect(source).toMatch(/\.diff-preview-content\s*\{[\s\S]*min-width: 0;/)
+    expect(source).toMatch(/:deep\(\.file-editor\)\s*\{[\s\S]*width: 100%;[\s\S]*min-width: 0;/)
+  })
 })


### PR DESCRIPTION
## Summary
- stretch the shared workspace diff preview across the full tool drawer width
- preserve the available width when switching from the diff view to the Monaco file editor
- add regression coverage for the diff and editor flex sizing constraints

## Root cause
The chat tool drawer was changed from a column flex layout to a row flex layout. The regular file preview received an explicit full-width constraint, but `WorkspaceDiffPreview` did not, so both the diff surface and its nested editor could size themselves from their content instead of the drawer.

## Impact
Workspace diff previews and the edit view now fill the resized terminal/workspace drawer without collapsing or overflowing horizontally.

## Validation
- `npm run test -- tests/client/drawer-panel-resize.test.ts tests/client/file-preview-formats.test.ts`
- `npm run build`
- `npm run harness:check`
- `git diff --check`
