### PR TITLE
fix(write-gate): make approval results reliable and serialized

### DIFF
--- a/packages/client/src/api/hermes/write-gate.ts
+++ b/packages/client/src/api/hermes/write-gate.ts
@@ -36,6 +36,11 @@ export interface PendingWriteReview {
   notes: PendingWriteReviewNote[]
 }
 
+export interface PendingWriteActionResult {
+  success: boolean
+  output: string
+}
+
 export async function fetchPendingWrites(): Promise<PendingWritesResponse> {
   return request<PendingWritesResponse>('/api/hermes/write-gate/pending')
 }
@@ -60,15 +65,15 @@ export async function fetchPendingWriteReview(subsystem: WriteGateSubsystem, id:
   }
 }
 
-export async function approvePendingWrite(subsystem: WriteGateSubsystem, id: string): Promise<{ output: string }> {
-  return request<{ success: boolean; output: string }>(
+export async function approvePendingWrite(subsystem: WriteGateSubsystem, id: string): Promise<PendingWriteActionResult> {
+  return request<PendingWriteActionResult>(
     `/api/hermes/write-gate/pending/${encodeURIComponent(subsystem)}/${encodeURIComponent(id)}/approve`,
     { method: 'POST' },
   )
 }
 
-export async function rejectPendingWrite(subsystem: WriteGateSubsystem, id: string): Promise<{ output: string }> {
-  return request<{ success: boolean; output: string }>(
+export async function rejectPendingWrite(subsystem: WriteGateSubsystem, id: string): Promise<PendingWriteActionResult> {
+  return request<PendingWriteActionResult>(
     `/api/hermes/write-gate/pending/${encodeURIComponent(subsystem)}/${encodeURIComponent(id)}/reject`,
     { method: 'POST' },
   )

--- a/packages/client/src/components/hermes/skills/PendingWriteApprovals.vue
+++ b/packages/client/src/components/hermes/skills/PendingWriteApprovals.vue
@@ -21,6 +21,9 @@ const { t } = useI18n()
 const message = useMessage()
 const pendingWrites = ref<PendingWriteRecord[]>([])
 const pendingLoading = ref(false)
+// Per-button loading state: each action key (e.g. "skills:abc123:approve")
+// is tracked independently so clicking one button does not clear another's
+// loading/disabled state, preventing concurrent approval requests.
 const pendingActions = ref<Set<string>>(new Set())
 const expandedReviews = ref<Record<string, string>>({})
 const writeGateSupported = ref(true)

--- a/packages/client/src/components/hermes/skills/PendingWriteApprovals.vue
+++ b/packages/client/src/components/hermes/skills/PendingWriteApprovals.vue
@@ -21,10 +21,8 @@ const { t } = useI18n()
 const message = useMessage()
 const pendingWrites = ref<PendingWriteRecord[]>([])
 const pendingLoading = ref(false)
-// Per-button loading state: each action key (e.g. "skills:abc123:approve")
-// is tracked independently so clicking one button does not clear another's
-// loading/disabled state, preventing concurrent approval requests.
 const pendingActions = ref<Set<string>>(new Set())
+const resolvingWrite = ref(false)
 const expandedReviews = ref<Record<string, string>>({})
 const writeGateSupported = ref(true)
 const pendingCount = computed(() => pendingWrites.value.length)
@@ -120,6 +118,7 @@ async function toggleDiff(record: PendingWriteRecord) {
     return
   }
   const actionKey = `${key}:diff`
+  if (pendingActions.value.has(actionKey)) return
   pendingActions.value.add(actionKey)
   try {
     const review = await fetchPendingWriteReview(record.subsystem, record.id)
@@ -132,18 +131,18 @@ async function toggleDiff(record: PendingWriteRecord) {
 }
 
 async function resolvePendingWrite(record: PendingWriteRecord, decision: 'approve' | 'reject') {
+  if (resolvingWrite.value) return
+  resolvingWrite.value = true
   const key = pendingKey(record)
   const actionKey = `${key}:${decision}`
   pendingActions.value.add(actionKey)
   try {
-    let result: { success?: boolean; output?: string }
-    if (decision === 'approve') {
-      result = await approvePendingWrite(record.subsystem, record.id)
-    } else {
-      result = await rejectPendingWrite(record.subsystem, record.id)
-    }
-    if (result.success === false) {
-      message.error(result.output || t('skills.writeApprovalActionFailed'))
+    const result = decision === 'approve'
+      ? await approvePendingWrite(record.subsystem, record.id)
+      : await rejectPendingWrite(record.subsystem, record.id)
+    if (!result.success) {
+      const failureMessage = t('skills.writeApprovalActionFailed')
+      message.error(result.output ? `${failureMessage}: ${result.output}` : failureMessage)
     } else {
       message.success(decision === 'approve'
         ? t('skills.writeApprovalApproved')
@@ -151,15 +150,16 @@ async function resolvePendingWrite(record: PendingWriteRecord, decision: 'approv
       // Optimistic removal before re-fetch
       pendingWrites.value = pendingWrites.value.filter(r => pendingKey(r) !== key)
       emit('count-change', pendingWrites.value.length)
+      const nextReviews = { ...expandedReviews.value }
+      delete nextReviews[key]
+      expandedReviews.value = nextReviews
     }
-    const nextReviews = { ...expandedReviews.value }
-    delete nextReviews[key]
-    expandedReviews.value = nextReviews
     await loadPendingWrites()
   } catch (err: any) {
     message.error(t('skills.writeApprovalActionFailed'))
   } finally {
     pendingActions.value.delete(actionKey)
+    resolvingWrite.value = false
   }
 }
 
@@ -175,7 +175,7 @@ onMounted(() => {
         <h3>{{ t('skills.writeApprovalTitle') }}</h3>
         <p>{{ t('skills.writeApprovalDescription') }}</p>
       </div>
-      <NButton size="small" quaternary :loading="pendingLoading" @click="loadPendingWrites">
+      <NButton size="small" quaternary :loading="pendingLoading" :disabled="resolvingWrite" @click="loadPendingWrites">
         {{ t('skills.writeApprovalRefresh') }}
       </NButton>
     </div>
@@ -206,6 +206,7 @@ onMounted(() => {
             size="tiny"
             quaternary
             :loading="pendingActions.has(`${pendingKey(record)}:diff`)"
+            :disabled="resolvingWrite"
             @click="toggleDiff(record)"
           >
             {{ expandedReviews[pendingKey(record)] ? t('skills.writeApprovalHideDiff') : t('skills.writeApprovalViewDiff') }}
@@ -214,6 +215,7 @@ onMounted(() => {
             size="tiny"
             type="success"
             :loading="pendingActions.has(`${pendingKey(record)}:approve`)"
+            :disabled="resolvingWrite"
             @click="resolvePendingWrite(record, 'approve')"
           >
             {{ t('skills.writeApprovalApprove') }}
@@ -223,6 +225,7 @@ onMounted(() => {
             quaternary
             type="error"
             :loading="pendingActions.has(`${pendingKey(record)}:reject`)"
+            :disabled="resolvingWrite"
             @click="resolvePendingWrite(record, 'reject')"
           >
             {{ t('skills.writeApprovalReject') }}

--- a/packages/client/src/components/hermes/skills/PendingWriteApprovals.vue
+++ b/packages/client/src/components/hermes/skills/PendingWriteApprovals.vue
@@ -21,7 +21,7 @@ const { t } = useI18n()
 const message = useMessage()
 const pendingWrites = ref<PendingWriteRecord[]>([])
 const pendingLoading = ref(false)
-const pendingAction = ref('')
+const pendingActions = ref<Set<string>>(new Set())
 const expandedReviews = ref<Record<string, string>>({})
 const writeGateSupported = ref(true)
 const pendingCount = computed(() => pendingWrites.value.length)
@@ -116,27 +116,38 @@ async function toggleDiff(record: PendingWriteRecord) {
     expandedReviews.value = next
     return
   }
-  pendingAction.value = `${key}:diff`
+  const actionKey = `${key}:diff`
+  pendingActions.value.add(actionKey)
   try {
     const review = await fetchPendingWriteReview(record.subsystem, record.id)
     expandedReviews.value = { ...expandedReviews.value, [key]: buildReviewMarkdown(review) }
   } catch (err: any) {
     message.error(t('skills.writeApprovalDiffFailed'))
   } finally {
-    pendingAction.value = ''
+    pendingActions.value.delete(actionKey)
   }
 }
 
 async function resolvePendingWrite(record: PendingWriteRecord, decision: 'approve' | 'reject') {
   const key = pendingKey(record)
-  pendingAction.value = `${key}:${decision}`
+  const actionKey = `${key}:${decision}`
+  pendingActions.value.add(actionKey)
   try {
+    let result: { success?: boolean; output?: string }
     if (decision === 'approve') {
-      await approvePendingWrite(record.subsystem, record.id)
-      message.success(t('skills.writeApprovalApproved'))
+      result = await approvePendingWrite(record.subsystem, record.id)
     } else {
-      await rejectPendingWrite(record.subsystem, record.id)
-      message.success(t('skills.writeApprovalRejected'))
+      result = await rejectPendingWrite(record.subsystem, record.id)
+    }
+    if (result.success === false) {
+      message.error(result.output || t('skills.writeApprovalActionFailed'))
+    } else {
+      message.success(decision === 'approve'
+        ? t('skills.writeApprovalApproved')
+        : t('skills.writeApprovalRejected'))
+      // Optimistic removal before re-fetch
+      pendingWrites.value = pendingWrites.value.filter(r => pendingKey(r) !== key)
+      emit('count-change', pendingWrites.value.length)
     }
     const nextReviews = { ...expandedReviews.value }
     delete nextReviews[key]
@@ -145,7 +156,7 @@ async function resolvePendingWrite(record: PendingWriteRecord, decision: 'approv
   } catch (err: any) {
     message.error(t('skills.writeApprovalActionFailed'))
   } finally {
-    pendingAction.value = ''
+    pendingActions.value.delete(actionKey)
   }
 }
 
@@ -191,7 +202,7 @@ onMounted(() => {
           <NButton
             size="tiny"
             quaternary
-            :loading="pendingAction === `${pendingKey(record)}:diff`"
+            :loading="pendingActions.has(`${pendingKey(record)}:diff`)"
             @click="toggleDiff(record)"
           >
             {{ expandedReviews[pendingKey(record)] ? t('skills.writeApprovalHideDiff') : t('skills.writeApprovalViewDiff') }}
@@ -199,7 +210,7 @@ onMounted(() => {
           <NButton
             size="tiny"
             type="success"
-            :loading="pendingAction === `${pendingKey(record)}:approve`"
+            :loading="pendingActions.has(`${pendingKey(record)}:approve`)"
             @click="resolvePendingWrite(record, 'approve')"
           >
             {{ t('skills.writeApprovalApprove') }}
@@ -208,7 +219,7 @@ onMounted(() => {
             size="tiny"
             quaternary
             type="error"
-            :loading="pendingAction === `${pendingKey(record)}:reject`"
+            :loading="pendingActions.has(`${pendingKey(record)}:reject`)"
             @click="resolvePendingWrite(record, 'reject')"
           >
             {{ t('skills.writeApprovalReject') }}

--- a/packages/server/src/controllers/hermes/write-gate.ts
+++ b/packages/server/src/controllers/hermes/write-gate.ts
@@ -70,7 +70,10 @@ function outputIndicatesFailure(output: string): boolean {
 
 function handleApprovalResult(ctx: Context, output: string) {
   if (outputIndicatesFailure(output)) {
-    ctx.status = 422
+    // Return HTTP 200 with success:false so the frontend can inspect the
+    // output field for the specific failure reason. A non-2xx status would
+    // cause the client's request() helper to throw before the caller ever
+    // sees the response body.
     ctx.body = { success: false, output }
   } else {
     ctx.body = { success: true, output }

--- a/packages/server/src/controllers/hermes/write-gate.ts
+++ b/packages/server/src/controllers/hermes/write-gate.ts
@@ -53,38 +53,10 @@ export async function diff(ctx: Context) {
   }
 }
 
-/**
- * Detect failure indicators in the Python subprocess output.
- * The Python helper (handle_pending_subcommand) returns error messages as
- * plain text without raising exceptions, so we must inspect the output string.
- */
-function outputIndicatesFailure(output: string): boolean {
-  if (!output) return false
-  return (
-    /Approved 0 /i.test(output) ||
-    /Rejected 0 /i.test(output) ||
-    /Failed:/i.test(output) ||
-    /No pending .* write with id/i.test(output)
-  )
-}
-
-function handleApprovalResult(ctx: Context, output: string) {
-  if (outputIndicatesFailure(output)) {
-    // Return HTTP 200 with success:false so the frontend can inspect the
-    // output field for the specific failure reason. A non-2xx status would
-    // cause the client's request() helper to throw before the caller ever
-    // sees the response body.
-    ctx.body = { success: false, output }
-  } else {
-    ctx.body = { success: true, output }
-  }
-}
-
 export async function approve(ctx: Context) {
   try {
     const { subsystem, id } = pendingParams(ctx)
-    const output = await approvePendingWrite(requestedProfile(ctx), subsystem, id)
-    handleApprovalResult(ctx, output)
+    ctx.body = await approvePendingWrite(requestedProfile(ctx), subsystem, id)
   } catch (err: any) {
     handleError(ctx, err)
   }
@@ -93,8 +65,7 @@ export async function approve(ctx: Context) {
 export async function reject(ctx: Context) {
   try {
     const { subsystem, id } = pendingParams(ctx)
-    const output = await rejectPendingWrite(requestedProfile(ctx), subsystem, id)
-    handleApprovalResult(ctx, output)
+    ctx.body = await rejectPendingWrite(requestedProfile(ctx), subsystem, id)
   } catch (err: any) {
     handleError(ctx, err)
   }

--- a/packages/server/src/controllers/hermes/write-gate.ts
+++ b/packages/server/src/controllers/hermes/write-gate.ts
@@ -53,13 +53,35 @@ export async function diff(ctx: Context) {
   }
 }
 
+/**
+ * Detect failure indicators in the Python subprocess output.
+ * The Python helper (handle_pending_subcommand) returns error messages as
+ * plain text without raising exceptions, so we must inspect the output string.
+ */
+function outputIndicatesFailure(output: string): boolean {
+  if (!output) return false
+  return (
+    /Approved 0 /i.test(output) ||
+    /Rejected 0 /i.test(output) ||
+    /Failed:/i.test(output) ||
+    /No pending .* write with id/i.test(output)
+  )
+}
+
+function handleApprovalResult(ctx: Context, output: string) {
+  if (outputIndicatesFailure(output)) {
+    ctx.status = 422
+    ctx.body = { success: false, output }
+  } else {
+    ctx.body = { success: true, output }
+  }
+}
+
 export async function approve(ctx: Context) {
   try {
     const { subsystem, id } = pendingParams(ctx)
-    ctx.body = {
-      success: true,
-      output: await approvePendingWrite(requestedProfile(ctx), subsystem, id),
-    }
+    const output = await approvePendingWrite(requestedProfile(ctx), subsystem, id)
+    handleApprovalResult(ctx, output)
   } catch (err: any) {
     handleError(ctx, err)
   }
@@ -68,10 +90,8 @@ export async function approve(ctx: Context) {
 export async function reject(ctx: Context) {
   try {
     const { subsystem, id } = pendingParams(ctx)
-    ctx.body = {
-      success: true,
-      output: await rejectPendingWrite(requestedProfile(ctx), subsystem, id),
-    }
+    const output = await rejectPendingWrite(requestedProfile(ctx), subsystem, id)
+    handleApprovalResult(ctx, output)
   } catch (err: any) {
     handleError(ctx, err)
   }

--- a/packages/server/src/services/hermes/write-gate.ts
+++ b/packages/server/src/services/hermes/write-gate.ts
@@ -52,6 +52,18 @@ export interface PendingWriteReview {
   notes: PendingWriteReviewNote[]
 }
 
+export interface PendingWriteActionResult {
+  success: boolean
+  output: string
+}
+
+interface PythonActionResult {
+  output: string
+  success?: boolean
+}
+
+const pendingWriteActionQueues = new Map<string, Promise<unknown>>()
+
 const PYTHON_HELPER = String.raw`
 import json
 import os
@@ -185,6 +197,7 @@ if action == "diff":
             "notes": [],
         }, ensure_ascii=False)
 elif action in {"approve", "reject"}:
+    pending_before = wa.get_pending(wa_subsystem, pending_id)
     memory_store = None
     if subsystem == "memory" and action == "approve":
         from tools.memory_tool import MemoryStore
@@ -195,10 +208,14 @@ elif action in {"approve", "reject"}:
         [action, pending_id],
         memory_store=memory_store,
     )
+    success = pending_before is not None and wa.get_pending(wa_subsystem, pending_id) is None
 else:
     raise SystemExit(f"invalid action: {action}")
 
-print(json.dumps({"output": output}, ensure_ascii=False))
+result = {"output": output}
+if action in {"approve", "reject"}:
+    result["success"] = success
+print(json.dumps(result, ensure_ascii=False))
 `
 
 function assertSubsystem(value: string): asserts value is WriteGateSubsystem {
@@ -410,7 +427,7 @@ async function runPythonAction(
   subsystem: WriteGateSubsystem,
   action: 'approve' | 'reject' | 'diff',
   pendingId: string,
-): Promise<string> {
+): Promise<PythonActionResult> {
   assertSubsystem(subsystem)
   assertPendingId(pendingId)
   if (!isWriteGateSupported()) {
@@ -435,7 +452,10 @@ async function runPythonAction(
     },
   )
   const parsed = JSON.parse(String(stdout || '{}'))
-  return typeof parsed.output === 'string' ? parsed.output : ''
+  return {
+    output: typeof parsed.output === 'string' ? parsed.output : '',
+    success: typeof parsed.success === 'boolean' ? parsed.success : undefined,
+  }
 }
 
 export async function getPendingWriteDiff(profile: string, subsystem: string, pendingId: string): Promise<string> {
@@ -444,7 +464,7 @@ export async function getPendingWriteDiff(profile: string, subsystem: string, pe
 
 export async function getPendingWriteReview(profile: string, subsystem: string, pendingId: string): Promise<PendingWriteReview> {
   assertSubsystem(subsystem)
-  const output = await runPythonAction(profile, subsystem, 'diff', pendingId)
+  const { output } = await runPythonAction(profile, subsystem, 'diff', pendingId)
   try {
     const parsed = JSON.parse(output)
     return normalizePendingWriteReview(parsed, subsystem)
@@ -462,14 +482,51 @@ export async function getPendingWriteReview(profile: string, subsystem: string, 
   }
 }
 
-export async function approvePendingWrite(profile: string, subsystem: string, pendingId: string): Promise<string> {
-  assertSubsystem(subsystem)
-  return runPythonAction(profile, subsystem, 'approve', pendingId)
+function serializePendingWriteAction<T>(profile: string, action: () => Promise<T>): Promise<T> {
+  // Serialize by the resolved state directory so aliases that fall back to
+  // the same profile cannot launch competing Python writers.
+  const key = getProfileDir(profile || 'default')
+  const previous = pendingWriteActionQueues.get(key) || Promise.resolve()
+  const current = previous.catch(() => undefined).then(action)
+  pendingWriteActionQueues.set(key, current)
+  return current.finally(() => {
+    if (pendingWriteActionQueues.get(key) === current) {
+      pendingWriteActionQueues.delete(key)
+    }
+  })
 }
 
-export async function rejectPendingWrite(profile: string, subsystem: string, pendingId: string): Promise<string> {
+async function resolvePendingWrite(
+  profile: string,
+  subsystem: string,
+  action: 'approve' | 'reject',
+  pendingId: string,
+): Promise<PendingWriteActionResult> {
   assertSubsystem(subsystem)
-  return runPythonAction(profile, subsystem, 'reject', pendingId)
+  assertPendingId(pendingId)
+  return serializePendingWriteAction(profile, async () => {
+    const result = await runPythonAction(profile, subsystem, action, pendingId)
+    return {
+      success: result.success === true && result.output.trim().length > 0,
+      output: result.output,
+    }
+  })
+}
+
+export async function approvePendingWrite(
+  profile: string,
+  subsystem: string,
+  pendingId: string,
+): Promise<PendingWriteActionResult> {
+  return resolvePendingWrite(profile, subsystem, 'approve', pendingId)
+}
+
+export async function rejectPendingWrite(
+  profile: string,
+  subsystem: string,
+  pendingId: string,
+): Promise<PendingWriteActionResult> {
+  return resolvePendingWrite(profile, subsystem, 'reject', pendingId)
 }
 
 function normalizePendingWriteReview(raw: any, subsystem: WriteGateSubsystem): PendingWriteReview {

--- a/tests/client/pending-write-approvals.test.ts
+++ b/tests/client/pending-write-approvals.test.ts
@@ -6,6 +6,8 @@ const mockFetchPendingWrites = vi.hoisted(() => vi.fn())
 const mockFetchPendingWriteReview = vi.hoisted(() => vi.fn())
 const mockApprovePendingWrite = vi.hoisted(() => vi.fn())
 const mockRejectPendingWrite = vi.hoisted(() => vi.fn())
+const mockMessageSuccess = vi.hoisted(() => vi.fn())
+const mockMessageError = vi.hoisted(() => vi.fn())
 
 vi.mock('@/api/hermes/write-gate', () => ({
   fetchPendingWrites: mockFetchPendingWrites,
@@ -25,8 +27,8 @@ vi.mock('naive-ui', async () => {
   return {
     ...actual,
     useMessage: () => ({
-      success: vi.fn(),
-      error: vi.fn(),
+      success: mockMessageSuccess,
+      error: mockMessageError,
     }),
   }
 })
@@ -39,8 +41,8 @@ function mountComponent() {
       stubs: {
         NTag: { template: '<span><slot /></span>' },
         NButton: {
-          props: ['loading'],
-          template: '<button class="n-button" @click="$emit(\'click\')"><slot /></button>',
+          props: ['loading', 'disabled'],
+          template: '<button class="n-button" :disabled="disabled || loading" @click="$emit(\'click\')"><slot /></button>',
         },
         MarkdownRenderer: {
           props: ['content'],
@@ -64,8 +66,8 @@ describe('PendingWriteApprovals', () => {
       diff: '-old\n+new',
       notes: [],
     })
-    mockApprovePendingWrite.mockResolvedValue({ output: 'approved' })
-    mockRejectPendingWrite.mockResolvedValue({ output: 'rejected' })
+    mockApprovePendingWrite.mockResolvedValue({ success: true, output: 'approved' })
+    mockRejectPendingWrite.mockResolvedValue({ success: true, output: 'rejected' })
   })
 
   it('shows an unsupported state for older Hermes Agent versions', async () => {
@@ -159,5 +161,96 @@ describe('PendingWriteApprovals', () => {
     expect(mockFetchPendingWriteReview).toHaveBeenCalledWith('skills', 'skill123')
     expect(wrapper.find('.markdown-renderer-stub').text()).toContain('skills.writeApprovalCurrentFile')
     expect(wrapper.find('.markdown-renderer-stub').text()).toContain('skills.writeApprovalPatchOldStringMissing')
+  })
+
+  it('shows a localized failure and keeps a write when approval fails', async () => {
+    mockFetchPendingWrites.mockResolvedValue({
+      records: [
+        {
+          id: 'skill123',
+          subsystem: 'skills',
+          action: 'patch',
+          summary: 'patch demo skill',
+          origin: 'foreground',
+          created_at: 1765440060,
+          payload: {},
+        },
+      ],
+      counts: { memory: 0, skills: 1 },
+      supported: true,
+    })
+    mockApprovePendingWrite.mockResolvedValue({
+      success: false,
+      output: 'No pending skills writes.',
+    })
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const approveButton = wrapper.findAll('.n-button')
+      .find(button => button.text() === 'skills.writeApprovalApprove')
+    await approveButton?.trigger('click')
+    await flushPromises()
+
+    expect(mockMessageError).toHaveBeenCalledWith(
+      'skills.writeApprovalActionFailed: No pending skills writes.',
+    )
+    expect(mockMessageSuccess).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('patch demo skill')
+  })
+
+  it('blocks additional approvals while a write is being resolved', async () => {
+    mockFetchPendingWrites.mockResolvedValue({
+      records: [
+        {
+          id: 'skill-one',
+          subsystem: 'skills',
+          action: 'patch',
+          summary: 'first skill patch',
+          origin: 'foreground',
+          created_at: 1765440060,
+          payload: {},
+        },
+        {
+          id: 'skill-two',
+          subsystem: 'skills',
+          action: 'patch',
+          summary: 'second skill patch',
+          origin: 'foreground',
+          created_at: 1765440120,
+          payload: {},
+        },
+      ],
+      counts: { memory: 0, skills: 2 },
+      supported: true,
+    })
+
+    let finishApproval!: (result: { success: boolean; output: string }) => void
+    mockApprovePendingWrite.mockImplementation(() => new Promise((resolve) => {
+      finishApproval = resolve
+    }))
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const approveButtons = wrapper.findAll('.n-button')
+      .filter(button => button.text() === 'skills.writeApprovalApprove')
+    const rejectButtons = wrapper.findAll('.n-button')
+      .filter(button => button.text() === 'skills.writeApprovalReject')
+
+    await approveButtons[0].trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(mockApprovePendingWrite).toHaveBeenCalledTimes(1)
+    expect(approveButtons.every(button => button.attributes('disabled') !== undefined)).toBe(true)
+    expect(rejectButtons.every(button => button.attributes('disabled') !== undefined)).toBe(true)
+
+    await approveButtons[1].trigger('click')
+    await rejectButtons[1].trigger('click')
+    expect(mockApprovePendingWrite).toHaveBeenCalledTimes(1)
+    expect(mockRejectPendingWrite).not.toHaveBeenCalled()
+
+    finishApproval({ success: true, output: 'Approved 1 skills write(s).' })
+    await flushPromises()
   })
 })

--- a/tests/server/write-gate-service.test.ts
+++ b/tests/server/write-gate-service.test.ts
@@ -15,6 +15,20 @@ async function loadService() {
   return import('../../packages/server/src/services/hermes/write-gate')
 }
 
+async function configureFakeApprovalRuntime(lines: string[]) {
+  const agentRoot = join(hermesHome, 'agent')
+  await mkdir(join(agentRoot, 'tools'), { recursive: true })
+  await mkdir(join(agentRoot, 'hermes_cli'), { recursive: true })
+  await writeFile(join(agentRoot, 'tools', 'write_approval.py'), '', 'utf-8')
+  await writeFile(join(agentRoot, 'hermes_cli', 'write_approval_commands.py'), '', 'utf-8')
+
+  const fakePython = join(hermesHome, 'fake-python')
+  await writeFile(fakePython, [...lines, ''].join('\n'), 'utf-8')
+  await chmod(fakePython, 0o755)
+  process.env.HERMES_AGENT_ROOT = agentRoot
+  process.env.HERMES_AGENT_CLI_PYTHON = fakePython
+}
+
 beforeEach(async () => {
   hermesHome = await mkdtemp(join(tmpdir(), 'hermes-write-gate-'))
 })
@@ -135,5 +149,56 @@ describe('write gate service', () => {
     const { isWriteGateSupported } = await loadService()
 
     expect(isWriteGateSupported()).toBe(true)
+  })
+
+  it('uses the structured Python result and treats empty output as failure', async () => {
+    await configureFakeApprovalRuntime([
+      '#!/bin/sh',
+      'case "$6" in',
+      '  approved) printf \'%s\\n\' \'{"success":true,"output":"Approved 1 skills write(s)."}\' ;;',
+      '  missing) printf \'%s\\n\' \'{"success":false,"output":"No pending skills writes."}\' ;;',
+      '  empty) printf \'%s\\n\' \'{"success":true,"output":""}\' ;;',
+      'esac',
+    ])
+
+    const { approvePendingWrite } = await loadService()
+
+    await expect(approvePendingWrite('default', 'skills', 'approved')).resolves.toEqual({
+      success: true,
+      output: 'Approved 1 skills write(s).',
+    })
+    await expect(approvePendingWrite('default', 'skills', 'missing')).resolves.toEqual({
+      success: false,
+      output: 'No pending skills writes.',
+    })
+    await expect(approvePendingWrite('default', 'skills', 'empty')).resolves.toEqual({
+      success: false,
+      output: '',
+    })
+  })
+
+  it('serializes approval actions within the same profile', async () => {
+    await configureFakeApprovalRuntime([
+      '#!/bin/sh',
+      'guard="$HERMES_HOME/.write-gate-action-running"',
+      'if ! mkdir "$guard" 2>/dev/null; then',
+      '  printf \'%s\\n\' \'{"success":false,"output":"overlapping approval"}\'',
+      '  exit 0',
+      'fi',
+      'sleep 0.05',
+      'rmdir "$guard"',
+      'printf \'%s\\n\' \'{"success":true,"output":"resolved"}\'',
+    ])
+
+    const { approvePendingWrite, rejectPendingWrite } = await loadService()
+    const results = await Promise.all([
+      approvePendingWrite('default', 'skills', 'first'),
+      rejectPendingWrite('default', 'memory', 'second'),
+    ])
+
+    expect(results).toEqual([
+      { success: true, output: 'resolved' },
+      { success: true, output: 'resolved' },
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- replace English output parsing with a structured approval result derived from the pending record's actual state transition
- serialize Memory and Skill approval actions by resolved Hermes profile directory and block concurrent approval clicks in the client
- make the client API result type strict, preserve localized failure messaging, and add focused regression coverage

This builds on and supersedes #2281.

Fixes #2280

## Root cause
Hermes Agent returns logical approval failures as normal process output, so the original controller reported `success: true` whenever the Python subprocess exited normally. PR #2281 attempted to infer failures from English output strings, while its per-button loading set still allowed multiple approvals to run concurrently.

Hermes removes a pending record only after an approval or rejection has completed successfully. The Python bridge now reports that state transition directly, while the server queues mutating actions for the same resolved profile directory.

## Impact
- failed Memory and Skill writes no longer show a false success notification
- rapid clicks cannot launch competing approval requests from the UI
- concurrent HTTP approval requests in one Studio server are serialized
- failure notifications retain the active UI language and append Hermes details when available

## Validation
- verified against the installed Hermes Agent 0.19.0 using an isolated temporary `HERMES_HOME`: Memory approval, Skill approval, failed Skill patch, and Memory rejection
- `npm run test -- tests/server/write-gate-service.test.ts tests/client/pending-write-approvals.test.ts` — 12 passed
- `npm run test` — 3182 passed, 2 skipped
- `npm run test:e2e` — 86 passed
- `npm run build`
- `npm run harness:check`
- `git diff --check`
