### PR TITLE
feat(journey): replace galaxy with compact relationship map

### DIFF
--- a/packages/client/src/utils/hermes/journey-layout.ts
+++ b/packages/client/src/utils/hermes/journey-layout.ts
@@ -1,0 +1,171 @@
+import type { JourneyEdge, JourneyNode } from '@/api/hermes/journey'
+
+export type JourneyNodeColumn = 'memory' | 'skill'
+
+export interface JourneyLayoutNode {
+  id: string
+  column: JourneyNodeColumn
+  degree: number
+  position: {
+    x: number
+    y: number
+  }
+}
+
+export interface JourneyLayoutOptions {
+  memoryX?: number
+  skillX?: number
+  verticalGap?: number
+  columnGap?: number
+  groupGap?: number
+  maxRows?: number
+}
+
+const DEFAULT_MEMORY_X = 80
+const DEFAULT_VERTICAL_GAP = 112
+const DEFAULT_COLUMN_GAP = 290
+const DEFAULT_GROUP_GAP = 200
+const DEFAULT_MAX_ROWS = 8
+
+function baseNodeCompare(a: JourneyNode, b: JourneyNode): number {
+  const aTime = a.timestamp
+  const bTime = b.timestamp
+  if (aTime && bTime && aTime !== bTime) return aTime - bTime
+  if (aTime && !bTime) return -1
+  if (!aTime && bTime) return 1
+
+  const categoryOrder = (a.category || '').localeCompare(b.category || '')
+  if (categoryOrder !== 0) return categoryOrder
+
+  const labelOrder = (a.label || '').localeCompare(b.label || '')
+  if (labelOrder !== 0) return labelOrder
+  return a.id.localeCompare(b.id)
+}
+
+function neighborMap(edges: JourneyEdge[]): Map<string, Set<string>> {
+  const neighbors = new Map<string, Set<string>>()
+  const connect = (source: string, target: string) => {
+    const current = neighbors.get(source) || new Set<string>()
+    current.add(target)
+    neighbors.set(source, current)
+  }
+
+  for (const edge of edges) {
+    connect(edge.source, edge.target)
+    connect(edge.target, edge.source)
+  }
+  return neighbors
+}
+
+function normalizedIndexMap(nodes: JourneyNode[]): Map<string, number> {
+  const denominator = Math.max(1, nodes.length - 1)
+  return new Map(nodes.map((node, index) => [node.id, index / denominator]))
+}
+
+function barycenter(
+  node: JourneyNode,
+  oppositeIndex: Map<string, number>,
+  neighbors: Map<string, Set<string>>,
+): number | null {
+  const positions = [...(neighbors.get(node.id) || [])]
+    .map(id => oppositeIndex.get(id))
+    .filter((value): value is number => value !== undefined)
+  if (!positions.length) return null
+  return positions.reduce((sum, value) => sum + value, 0) / positions.length
+}
+
+function reorderByNeighbors(
+  nodes: JourneyNode[],
+  oppositeNodes: JourneyNode[],
+  neighbors: Map<string, Set<string>>,
+): JourneyNode[] {
+  const oppositeIndex = normalizedIndexMap(oppositeNodes)
+  return [...nodes].sort((a, b) => {
+    const aCenter = barycenter(a, oppositeIndex, neighbors)
+    const bCenter = barycenter(b, oppositeIndex, neighbors)
+    if (aCenter !== null && bCenter !== null && aCenter !== bCenter) return aCenter - bCenter
+    if (aCenter !== null && bCenter === null) return -1
+    if (aCenter === null && bCenter !== null) return 1
+    return baseNodeCompare(a, b)
+  })
+}
+
+function gridPosition(
+  index: number,
+  count: number,
+  rowCount: number,
+  startX: number,
+  columnGap: number,
+  verticalGap: number,
+): { x: number; y: number } {
+  const column = Math.floor(index / rowCount)
+  const row = index % rowCount
+  const columnStart = column * rowCount
+  const nodesInColumn = Math.min(rowCount, count - columnStart)
+  const verticalOffset = ((rowCount - nodesInColumn) * verticalGap) / 2
+  return {
+    x: startX + column * columnGap,
+    y: verticalOffset + row * verticalGap,
+  }
+}
+
+/**
+ * Produces a deterministic two-column layout for Journey's bipartite
+ * memory-to-skill graph. A few barycentric passes keep related nodes close
+ * together and substantially reduce crossings without a runtime layout engine.
+ */
+export function layoutJourneyGraph(
+  nodes: JourneyNode[],
+  edges: JourneyEdge[],
+  options: JourneyLayoutOptions = {},
+): JourneyLayoutNode[] {
+  const nodeIds = new Set(nodes.map(node => node.id))
+  const validEdges = edges.filter(edge => nodeIds.has(edge.source) && nodeIds.has(edge.target))
+  const neighbors = neighborMap(validEdges)
+
+  let memories = nodes.filter(node => node.kind === 'memory').sort(baseNodeCompare)
+  let skills = nodes.filter(node => node.kind !== 'memory').sort(baseNodeCompare)
+
+  for (let pass = 0; pass < 3; pass += 1) {
+    skills = reorderByNeighbors(skills, memories, neighbors)
+    memories = reorderByNeighbors(memories, skills, neighbors)
+  }
+
+  const memoryX = options.memoryX ?? DEFAULT_MEMORY_X
+  const verticalGap = options.verticalGap ?? DEFAULT_VERTICAL_GAP
+  const columnGap = options.columnGap ?? DEFAULT_COLUMN_GAP
+  const groupGap = options.groupGap ?? DEFAULT_GROUP_GAP
+  const maxCount = Math.max(1, memories.length, skills.length)
+  const rowCount = Math.max(1, Math.min(options.maxRows ?? DEFAULT_MAX_ROWS, maxCount))
+  const memoryColumnCount = Math.max(1, Math.ceil(memories.length / rowCount))
+  const skillX = memories.length
+    ? options.skillX ?? memoryX + memoryColumnCount * columnGap + groupGap
+    : memoryX
+
+  const toLayoutNode = (
+    node: JourneyNode,
+    index: number,
+    column: JourneyNodeColumn,
+    count: number,
+    startX: number,
+  ): JourneyLayoutNode => ({
+    id: node.id,
+    column,
+    degree: neighbors.get(node.id)?.size || 0,
+    position: gridPosition(index, count, rowCount, startX, columnGap, verticalGap),
+  })
+
+  return [
+    ...memories.map((node, index) => toLayoutNode(node, index, 'memory', memories.length, memoryX)),
+    ...skills.map((node, index) => toLayoutNode(node, index, 'skill', skills.length, skillX)),
+  ]
+}
+
+export function journeyNeighborIds(nodeId: string, edges: JourneyEdge[]): Set<string> {
+  const neighbors = new Set<string>()
+  for (const edge of edges) {
+    if (edge.source === nodeId) neighbors.add(edge.target)
+    if (edge.target === nodeId) neighbors.add(edge.source)
+  }
+  return neighbors
+}

--- a/packages/client/src/views/hermes/JourneyView.vue
+++ b/packages/client/src/views/hermes/JourneyView.vue
@@ -1,31 +1,42 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { NButton, NDrawer, NDrawerContent, NSpin, NTag, useMessage } from 'naive-ui'
+import {
+  Handle,
+  MarkerType,
+  Position,
+  VueFlow,
+  useVueFlow,
+} from '@vue-flow/core'
+import { Background } from '@vue-flow/background'
+import { Controls } from '@vue-flow/controls'
+import { MiniMap } from '@vue-flow/minimap'
 import { useI18n } from 'vue-i18n'
 import { fetchJourneyGraph, type JourneyGraphResponse, type JourneyMemory, type JourneyNode } from '@/api/hermes/journey'
 import { fetchSkills, type SkillsData } from '@/api/hermes/skills'
-import { useTheme } from '@/composables/useTheme'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import { normalizeSkillDescription, skillDescriptionPreview } from '@/utils/hermes/skill-display'
+import { journeyNeighborIds, layoutJourneyGraph } from '@/utils/hermes/journey-layout'
 
-interface SceneNode extends JourneyNode {
-  x: number
-  y: number
-  z: number
-  radius: number
-  color: string
-}
-
-interface ProjectedNode extends SceneNode {
-  sx: number
-  sy: number
-  depth: number
-  size: number
-  visible: boolean
-}
+import '@vue-flow/core/dist/style.css'
+import '@vue-flow/core/dist/theme-default.css'
+import '@vue-flow/controls/dist/style.css'
+import '@vue-flow/minimap/dist/style.css'
 
 type SkillDescriptionLoadState = 'idle' | 'loading' | 'loaded' | 'failed'
-type NodeShape = 'circle' | 'diamond'
+
+interface JourneyFlowNodeData {
+  node: JourneyNode
+  column: 'memory' | 'skill'
+  degree: number
+  color: string
+  categoryLabel: string
+  timestampLabel: string
+  kindLabel: string
+  active: boolean
+  related: boolean
+  dimmed: boolean
+}
 
 const CATEGORY_PALETTE = [
   '#4f8cff',
@@ -41,66 +52,43 @@ const CATEGORY_PALETTE = [
   '#00a884',
   '#ff9f1a',
 ]
-const MIN_ZOOM = 0.25
-const MAX_ZOOM = 2.4
 
 const { t } = useI18n()
 const message = useMessage()
-const { isDark } = useTheme()
 const profilesStore = useProfilesStore()
+const { fitView } = useVueFlow('hermes-journey')
 
 const data = ref<JourneyGraphResponse | null>(null)
 const loading = ref(false)
-const canvasRef = ref<HTMLCanvasElement | null>(null)
-const canvasWrapRef = ref<HTMLElement | null>(null)
+const graphWrapRef = ref<HTMLElement | null>(null)
 const selectedId = ref('')
 const hoverId = ref('')
 const hoverCategory = ref('')
 const selectedCategories = ref<string[]>([])
 const skillDescriptions = ref(new Map<string, string>())
 const hoverTipId = ref('')
-const hoverPoint = ref({ x: 0, y: 0 })
+const hoverPoint = ref({ x: 24, y: 80 })
+const graphSize = ref({ width: 1, height: 1 })
 const playing = ref(false)
 const playbackIndex = ref(-1)
 const detailDrawerOpen = ref(false)
 const drawerWidth = ref(380)
 
-let ctx: CanvasRenderingContext2D | null = null
-let resizeObserver: ResizeObserver | null = null
-let raf = 0
-let width = 1
-let height = 1
-let dpr = 1
-let rotationX = -0.25
-let rotationY = 0.55
-let zoom = 1
-let dragging = false
-let lastX = 0
-let lastY = 0
-let pinchDistance = 0
-let pinchZoom = 1
 let playbackTimer: number | null = null
 let clearSelectionTimer: number | null = null
 let hoverTipTimer: number | null = null
 let pendingHoverTipId = ''
-let pointerStartX = 0
-let pointerStartY = 0
-let pointerMoved = false
-let suppressClickUntil = 0
 let keyboardPreviewIndex = -1
 let disposed = false
 let loadGeneration = 0
 let skillDescriptionLoadGeneration = 0
 let skillDescriptionLoadState: SkillDescriptionLoadState = 'idle'
 let skillDescriptionLoadPromise: Promise<void> | null = null
-let resizeListenerInstalled = false
-let resizeObserverInstalled = false
-let rendererStarted = false
-const activePointers = new Map<number, { x: number; y: number }>()
 
 const nodes = computed(() => data.value?.graph.nodes || [])
 const edges = computed(() => data.value?.graph.edges || [])
-const selectedNode = computed(() => nodes.value.find(node => node.id === selectedId.value) || null)
+const nodeById = computed(() => new Map(nodes.value.map(node => [node.id, node])))
+const selectedNode = computed(() => nodeById.value.get(selectedId.value) || null)
 const playbackNodes = computed(() =>
   nodes.value
     .map((node, index) => ({ node, index }))
@@ -118,57 +106,28 @@ const revealedNodeIds = computed(() => {
   if (playbackIndex.value < 0) return null
   return new Set(playbackNodes.value.slice(0, playbackIndex.value + 1).map(node => node.id))
 })
-const visibleEdges = computed(() => {
+const visibleNodes = computed(() => {
   const revealed = revealedNodeIds.value
-  if (!revealed) return edges.value
-  return edges.value.filter(edge => revealed.has(edge.source) && revealed.has(edge.target))
+  if (!revealed) return nodes.value
+  return nodes.value.filter(node => revealed.has(node.id))
 })
-
-const sceneNodes = computed<SceneNode[]>(() => {
-  const categories = [...new Set(nodes.value.map(node => node.category || 'general'))].sort()
-  const categoryIndex = new Map(categories.map((category, index) => [category, index]))
-  const categoryCount = Math.max(1, categoryIndex.size)
-  const clusterCenters = new Map<string, { x: number; y: number; z: number }>()
-  const densityScale = Math.min(2.3, Math.max(1, Math.sqrt(Math.max(nodes.value.length, 1) / 42)))
-  const clusterRadius = 360 * densityScale
-
-  for (const [category, index] of categoryIndex) {
-    const angle = (index / categoryCount) * Math.PI * 2
-    const pitch = ((index % 5) - 2) * 0.42
-    clusterCenters.set(category, {
-      x: Math.cos(angle) * Math.cos(pitch) * clusterRadius,
-      y: Math.sin(pitch) * clusterRadius * 0.72,
-      z: Math.sin(angle) * Math.cos(pitch) * clusterRadius,
-    })
-  }
-
-  return nodes.value.map((node, index) => {
-    const category = node.category || 'general'
-    const center = clusterCenters.get(category) || { x: 0, y: 0, z: 0 }
-    const seed = hash(`${node.id}:${index}`)
-    const a = (seed % 6283) / 1000
-    const b = ((seed >> 8) % 3141) / 1000
-    const spread = (node.kind === 'memory' ? 125 : 165) * densityScale
-    return {
-      ...node,
-      x: center.x + Math.cos(a) * Math.sin(b) * spread,
-      y: center.y + Math.cos(b) * spread * 0.85,
-      z: center.z + Math.sin(a) * Math.sin(b) * spread,
-      radius: node.kind === 'memory' ? 6 : Math.min(13, 5 + Math.sqrt(node.useCount || 0) * 1.7),
-      color: node.kind === 'memory' ? '#6ba3d6' : categoryColor(category),
-    }
-  })
+const visibleNodeIds = computed(() => new Set(visibleNodes.value.map(node => node.id)))
+const visibleEdges = computed(() =>
+  edges.value.filter(edge => visibleNodeIds.value.has(edge.source) && visibleNodeIds.value.has(edge.target)),
+)
+const selectedCategorySet = computed(() => new Set(selectedCategories.value))
+const emphasizedCategorySet = computed(() => {
+  const categories = new Set(selectedCategories.value)
+  if (hoverCategory.value) categories.add(hoverCategory.value)
+  return categories
 })
-
-const nodeById = computed(() => new Map(sceneNodes.value.map(node => [node.id, node])))
-const visibleSceneNodes = computed(() => {
-  const revealed = revealedNodeIds.value
-  if (!revealed) return sceneNodes.value
-  return sceneNodes.value.filter(node => revealed.has(node.id))
-})
+const focusNodeId = computed(() => selectedId.value || hoverId.value)
+const focusedNeighborIds = computed(() =>
+  focusNodeId.value ? journeyNeighborIds(focusNodeId.value, visibleEdges.value) : new Set<string>(),
+)
 const categoryStats = computed(() => {
   const stats = new Map<string, { category: string; label: string; color: string; count: number }>()
-  for (const node of visibleSceneNodes.value) {
+  for (const node of visibleNodes.value) {
     const category = node.category || 'general'
     const current = stats.get(category)
     if (current) {
@@ -177,20 +136,14 @@ const categoryStats = computed(() => {
       stats.set(category, {
         category,
         label: node.category || t('journey.noCategory'),
-        color: node.color,
+        color: categoryColor(category),
         count: 1,
       })
     }
   }
   return [...stats.values()].sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
 })
-const visibleNodeCount = computed(() => Math.max(1, visibleSceneNodes.value.length))
-const selectedCategorySet = computed(() => new Set(selectedCategories.value))
-const emphasizedCategorySet = computed(() => {
-  const categories = new Set(selectedCategories.value)
-  if (hoverCategory.value) categories.add(hoverCategory.value)
-  return categories
-})
+const visibleNodeCount = computed(() => Math.max(1, visibleNodes.value.length))
 const hoverTipNode = computed(() => hoverTipId.value ? nodeById.value.get(hoverTipId.value) || null : null)
 const hoverTipTitle = computed(() => hoverTipNode.value?.label || hoverTipNode.value?.id || '')
 const hoverTipDescription = computed(() => {
@@ -203,21 +156,110 @@ const selectedSkillDescription = computed(() => {
   const node = selectedNode.value
   return node && !isMemoryNode(node) ? skillDescription(node) : ''
 })
-const canvasAriaLabel = computed(() =>
-  `${t('journey.title')}. ${visibleSceneNodes.value.length} ${t('journey.nodes')}. ${t('journey.canvasInstructions')}`,
+const graphAriaLabel = computed(() =>
+  `${t('journey.title')}. ${visibleNodes.value.length} ${t('journey.nodes')}. ${t('journey.canvasInstructions')}`,
 )
 const hoverTipStyle = computed(() => {
   const tooltipWidth = 320
   const gap = 14
-  const x = hoverPoint.value.x + gap + tooltipWidth <= width
+  const x = hoverPoint.value.x + gap + tooltipWidth <= graphSize.value.width
     ? hoverPoint.value.x + gap
     : Math.max(8, hoverPoint.value.x - tooltipWidth - gap)
-  const above = hoverPoint.value.y > height - 150
+  const above = hoverPoint.value.y > graphSize.value.height - 150
   return {
     left: `${x}px`,
     top: `${Math.max(8, hoverPoint.value.y + (above ? -gap : gap))}px`,
     transform: above ? 'translateY(-100%)' : undefined,
   }
+})
+
+const flowNodes = computed(() => {
+  const maxRows = Math.max(3, Math.min(8, Math.floor((graphSize.value.height - 72) / 112)))
+  const layout = layoutJourneyGraph(visibleNodes.value, visibleEdges.value, { maxRows })
+  const hasNodeFocus = Boolean(focusNodeId.value)
+  const hasCategoryFocus = emphasizedCategorySet.value.size > 0
+
+  return layout.map((layoutNode) => {
+    const node = nodeById.value.get(layoutNode.id)!
+    const category = node.category || 'general'
+    const active = focusNodeId.value === node.id
+    const related = focusedNeighborIds.value.has(node.id)
+    const categoryActive = emphasizedCategorySet.value.has(category)
+    const dimmed = hasNodeFocus
+      ? !active && !related
+      : hasCategoryFocus && !categoryActive
+
+    return {
+      id: node.id,
+      type: 'journey',
+      position: layoutNode.position,
+      draggable: false,
+      selectable: false,
+      connectable: false,
+      focusable: false,
+      sourcePosition: Position.Right,
+      targetPosition: Position.Left,
+      style: {
+        width: '240px',
+        pointerEvents: 'all' as const,
+        zIndex: active ? 4 : related ? 3 : 1,
+      },
+      data: {
+        node,
+        column: layoutNode.column,
+        degree: layoutNode.degree,
+        color: categoryColor(category),
+        categoryLabel: node.category || t('journey.noCategory'),
+        timestampLabel: formatTime(node.timestamp),
+        kindLabel: isMemoryNode(node) ? t('journey.memories') : t('journey.skills'),
+        active,
+        related,
+        dimmed,
+      } satisfies JourneyFlowNodeData,
+    }
+  })
+})
+
+const flowEdges = computed(() => {
+  const focusId = focusNodeId.value
+  const categories = emphasizedCategorySet.value
+  return visibleEdges.value.map((edge, index) => {
+    const source = nodeById.value.get(edge.source)
+    const target = nodeById.value.get(edge.target)
+    const active = Boolean(focusId && (edge.source === focusId || edge.target === focusId))
+    const categoryActive = Boolean(
+      categories.size
+      && (
+        categories.has(source?.category || 'general')
+        || categories.has(target?.category || 'general')
+      )
+    )
+    const stroke = active
+      ? categoryColor(target?.category || source?.category || 'general')
+      : 'var(--text-muted)'
+    return {
+      id: `journey-edge:${edge.source}:${edge.target}:${index}`,
+      source: edge.source,
+      target: edge.target,
+      type: 'smoothstep',
+      selectable: false,
+      focusable: false,
+      animated: playing.value && active,
+      interactionWidth: 0,
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        color: stroke,
+        width: active ? 18 : 14,
+        height: active ? 18 : 14,
+      },
+      style: {
+        stroke,
+        strokeWidth: active ? 2.4 : categoryActive ? 1.7 : 1.15,
+        opacity: active ? 0.95 : categoryActive ? 0.58 : focusId ? 0.08 : 0.24,
+      },
+      zIndex: active ? 3 : 0,
+    }
+  })
 })
 
 function hash(value: string): number {
@@ -246,7 +288,7 @@ function isMemoryNode(node: JourneyNode | null): boolean {
 }
 
 function detailTitle(node: JourneyNode): string {
-  if (isMemoryNode(node)) return node.category || t('journey.memories')
+  if (isMemoryNode(node)) return node.label || node.category || t('journey.memories')
   return node.label || node.id
 }
 
@@ -367,30 +409,45 @@ function hideNodeHoverTip(clearHover = false) {
   if (clearHover) hoverId.value = ''
 }
 
-function updateNodeHover(hit: ProjectedNode | null, point: { x: number; y: number }) {
+function eventPoint(event: MouseEvent): { x: number; y: number } {
+  const rect = graphWrapRef.value?.getBoundingClientRect()
+  return {
+    x: event.clientX - (rect?.left || 0),
+    y: event.clientY - (rect?.top || 0),
+  }
+}
+
+function scheduleNodeHover(node: JourneyNode, point: { x: number; y: number }) {
   hoverPoint.value = point
-  hoverId.value = hit?.id || ''
-  if (!hit) {
-    hideNodeHoverTip()
-    return
-  }
-  if (dragging) {
-    hideNodeHoverTip(true)
-    return
-  }
-  if (hoverTipId.value === hit.id || pendingHoverTipId === hit.id) return
+  hoverId.value = node.id
+  if (hoverTipId.value === node.id || pendingHoverTipId === node.id) return
   clearHoverTipTimer()
   hoverTipId.value = ''
-  const targetId = hit.id
-  pendingHoverTipId = targetId
+  pendingHoverTipId = node.id
   hoverTipTimer = window.setTimeout(() => {
     hoverTipTimer = null
     pendingHoverTipId = ''
-    if (!disposed && !dragging && hoverId.value === targetId) {
-      hoverTipId.value = targetId
-      requestSkillDescription(hit)
+    if (!disposed && hoverId.value === node.id) {
+      hoverTipId.value = node.id
+      requestSkillDescription(node)
     }
   }, 250)
+}
+
+function handleNodeMouseEnter(event: MouseEvent, node: JourneyNode) {
+  scheduleNodeHover(node, eventPoint(event))
+}
+
+function handleNodeMouseMove(event: MouseEvent, node: JourneyNode) {
+  if (hoverId.value !== node.id) {
+    scheduleNodeHover(node, eventPoint(event))
+    return
+  }
+  hoverPoint.value = eventPoint(event)
+}
+
+function handleNodeMouseLeave(nodeId: string) {
+  if (hoverId.value === nodeId) hideNodeHoverTip(true)
 }
 
 function toggleCategorySelection(category: string) {
@@ -398,6 +455,21 @@ function toggleCategorySelection(category: string) {
   selectedCategories.value = isSelected
     ? selectedCategories.value.filter(value => value !== category)
     : [...selectedCategories.value, category]
+}
+
+function openNodeDetails(nodeId: string) {
+  const node = nodeById.value.get(nodeId)
+  if (!node) return
+  requestSkillDescription(node)
+  selectedId.value = nodeId
+  detailDrawerOpen.value = true
+}
+
+function clearGraphSelection() {
+  selectedId.value = ''
+  selectedCategories.value = []
+  detailDrawerOpen.value = false
+  hideNodeHoverTip(true)
 }
 
 function resetInteractionState() {
@@ -413,456 +485,27 @@ function resetInteractionState() {
   detailDrawerOpen.value = false
 }
 
-function rotatePoint(node: SceneNode): { x: number; y: number; z: number } {
-  const cosY = Math.cos(rotationY)
-  const sinY = Math.sin(rotationY)
-  const cosX = Math.cos(rotationX)
-  const sinX = Math.sin(rotationX)
-  const x1 = node.x * cosY - node.z * sinY
-  const z1 = node.x * sinY + node.z * cosY
-  const y1 = node.y * cosX - z1 * sinX
-  const z2 = node.y * sinX + z1 * cosX
-  return { x: x1, y: y1, z: z2 }
-}
-
-function projectNode(node: SceneNode): ProjectedNode {
-  const rotated = rotatePoint(node)
-  const camera = 860 / zoom
-  const perspective = camera / (camera + rotated.z)
-  const size = Math.max(2, node.radius * perspective * zoom)
-  return {
-    ...node,
-    sx: width / 2 + rotated.x * perspective * zoom,
-    sy: height / 2 + rotated.y * perspective * zoom,
-    depth: rotated.z,
-    size,
-    visible: perspective > 0,
-  }
-}
-
-function draw(now = performance.now()) {
-  if (!ctx || disposed) return
-  ctx.clearRect(0, 0, width, height)
-  drawBackground()
-
-  const projected = visibleSceneNodes.value.map(projectNode).filter(node => node.visible)
-  const projectedById = new Map(projected.map(node => [node.id, node]))
-  const activeIds = new Set<string>()
-  if (selectedId.value) activeIds.add(selectedId.value)
-  if (hoverId.value) activeIds.add(hoverId.value)
-  const activeNeighbors = new Set<string>()
-
-  for (const edge of visibleEdges.value) {
-    if (activeIds.has(edge.source)) activeNeighbors.add(edge.target)
-    if (activeIds.has(edge.target)) activeNeighbors.add(edge.source)
-  }
-
-  drawEdges(projectedById, activeIds, activeNeighbors, emphasizedCategorySet.value, now)
-  projected
-    .sort((a, b) => a.depth - b.depth)
-    .forEach(node => drawNode(
-      node,
-      activeIds,
-      activeNeighbors,
-      emphasizedCategorySet.value,
-      selectedCategorySet.value,
-      now,
-    ))
-
-  raf = requestAnimationFrame(draw)
-  rendererStarted = true
-}
-
-function drawBackground() {
-  if (!ctx) return
-  const gradient = ctx.createRadialGradient(width * 0.5, height * 0.42, 10, width * 0.5, height * 0.5, Math.max(width, height) * 0.68)
-  gradient.addColorStop(0, 'rgba(74, 144, 217, 0.14)')
-  gradient.addColorStop(0.46, 'rgba(120, 120, 120, 0.05)')
-  gradient.addColorStop(1, 'rgba(0, 0, 0, 0)')
-  ctx.fillStyle = gradient
-  ctx.fillRect(0, 0, width, height)
-}
-
-function drawEdges(
-  projectedById: Map<string, ProjectedNode>,
-  activeIds: Set<string>,
-  activeNeighbors: Set<string>,
-  activeCategories: Set<string>,
-  now: number,
-) {
-  if (!ctx) return
-  ctx.save()
-  const pulse = 0.5 + Math.sin(now * 0.012) * 0.5
-  for (const edge of visibleEdges.value) {
-    const source = projectedById.get(edge.source)
-    const target = projectedById.get(edge.target)
-    if (!source || !target) continue
-    const active = activeIds.has(edge.source) || activeIds.has(edge.target)
-    const categoryActive = activeCategories.has(source.category || 'general')
-      || activeCategories.has(target.category || 'general')
-    const nearby = activeNeighbors.has(edge.source) || activeNeighbors.has(edge.target)
-    const alpha = active ? 0.62 + pulse * 0.28 : categoryActive ? 0.46 : nearby ? 0.4 : isDark.value ? 0.1 : 0.22
-    ctx.lineWidth = isDark.value ? 1 : 1.15
-    ctx.shadowColor = 'transparent'
-    ctx.shadowBlur = 0
-    ctx.strokeStyle = isDark.value
-      ? `rgba(180, 210, 255, ${alpha})`
-      : `rgba(42, 58, 78, ${alpha})`
-    const curve = edgeCurve(source, target, `${edge.source}:${edge.target}`)
-    drawCurvedEdge(source, target, curve)
-    if (active) drawPulseEdge(source, target, curve, pulse, now)
-  }
-  ctx.restore()
-}
-
-function edgeCurve(source: ProjectedNode, target: ProjectedNode, key: string): { cx: number; cy: number } | null {
-  const dx = target.sx - source.sx
-  const dy = target.sy - source.sy
-  const length = Math.sqrt(dx * dx + dy * dy)
-  if (length < 2) return null
-  const normalX = -dy / length
-  const normalY = dx / length
-  const direction = hash(key) % 2 === 0 ? 1 : -1
-  const curve = Math.min(58, Math.max(10, length * 0.12)) * direction
-  return {
-    cx: (source.sx + target.sx) / 2 + normalX * curve,
-    cy: (source.sy + target.sy) / 2 + normalY * curve,
-  }
-}
-
-function drawCurvedEdge(source: ProjectedNode, target: ProjectedNode, curve: { cx: number; cy: number } | null) {
-  if (!ctx || !curve) return
-  ctx.beginPath()
-  ctx.moveTo(source.sx, source.sy)
-  ctx.quadraticCurveTo(curve.cx, curve.cy, target.sx, target.sy)
-  ctx.stroke()
-}
-
-function drawPulseEdge(source: ProjectedNode, target: ProjectedNode, curve: { cx: number; cy: number } | null, pulse: number, now: number) {
-  if (!ctx || !curve) return
-  const head = (now * 0.0018) % 1
-  const tail = Math.max(0, head - 0.24)
-  const points = sampleCurve(source, target, curve, 1 - head, 1 - tail, 18).reverse()
-  const glowColor = isDark.value ? 'rgba(180, 225, 255, 0.92)' : 'rgba(74, 144, 217, 0.78)'
-  const coreColor = isDark.value ? 'rgba(255, 255, 255, 0.96)' : 'rgba(255, 255, 255, 0.9)'
-  ctx.save()
-  ctx.lineJoin = 'round'
-  ctx.lineCap = 'round'
-  ctx.shadowColor = glowColor
-  ctx.shadowBlur = 7 + pulse * 9
-  ctx.strokeStyle = glowColor
-  ctx.lineWidth = 2.2 + pulse * 1.2
-  strokePath(points)
-
-  ctx.shadowBlur = 2 + pulse * 4
-  ctx.strokeStyle = coreColor
-  ctx.lineWidth = 0.75 + pulse * 0.65
-  strokePath(points)
-  ctx.restore()
-}
-
-function sampleCurve(
-  source: ProjectedNode,
-  target: ProjectedNode,
-  curve: { cx: number; cy: number },
-  start: number,
-  end: number,
-  steps: number,
-) {
-  const points: Array<{ x: number; y: number }> = []
-  for (let i = 0; i <= steps; i += 1) {
-    const t = start + (end - start) * (i / steps)
-    const inv = 1 - t
-    points.push({
-      x: inv * inv * source.sx + 2 * inv * t * curve.cx + t * t * target.sx,
-      y: inv * inv * source.sy + 2 * inv * t * curve.cy + t * t * target.sy,
-    })
-  }
-  return points
-}
-
-function strokePath(points: Array<{ x: number; y: number }>) {
-  if (!ctx || !points.length) return
-  ctx.beginPath()
-  ctx.moveTo(points[0].x, points[0].y)
-  for (let i = 1; i < points.length; i += 1) {
-    ctx.lineTo(points[i].x, points[i].y)
-  }
-  ctx.stroke()
-}
-
-function nodeShape(node: Pick<JourneyNode, 'kind'>): NodeShape {
-  return node.kind === 'memory' ? 'diamond' : 'circle'
-}
-
-function traceNodeShape(node: ProjectedNode, padding = 0) {
-  if (!ctx) return
-  const radius = Math.max(0, node.size + padding)
-  ctx.beginPath()
-  if (nodeShape(node) === 'diamond') {
-    const horizontal = radius * 1.12
-    const vertical = radius * 1.3
-    ctx.moveTo(node.sx, node.sy - vertical)
-    ctx.lineTo(node.sx + horizontal, node.sy)
-    ctx.lineTo(node.sx, node.sy + vertical)
-    ctx.lineTo(node.sx - horizontal, node.sy)
-    ctx.lineTo(node.sx, node.sy - vertical)
-    return
-  }
-  ctx.arc(node.sx, node.sy, radius, 0, Math.PI * 2)
-}
-
-function drawNode(
-  node: ProjectedNode,
-  activeIds: Set<string>,
-  activeNeighbors: Set<string>,
-  activeCategories: Set<string>,
-  selectedCategoriesSet: Set<string>,
-  now: number,
-) {
-  if (!ctx) return
-  const active = activeIds.has(node.id)
-  const nearby = activeNeighbors.has(node.id)
-  const category = node.category || 'general'
-  const categoryActive = activeCategories.has(category)
-  const categorySelected = selectedCategoriesSet.has(category)
-  const hasFocus = activeIds.size > 0 || activeCategories.size > 0
-  const alpha = active || nearby || categoryActive || !hasFocus ? 1 : 0.24
-  const pulse = active ? 0.5 + Math.sin(now * 0.005) * 0.5 : 0
-  const glow = active ? 20 + pulse * 24 : categorySelected ? 16 : node.createdBy === 'agent' ? 12 : node.pinned ? 10 : 0
-  const nodeBackdrop = isDark.value ? '#1a1a1a' : '#fafafa'
-
-  ctx.save()
-  ctx.globalAlpha = 1
-  ctx.fillStyle = nodeBackdrop
-  traceNodeShape(node, -0.25)
-  ctx.fill()
-
-  ctx.globalAlpha = alpha
-  if (glow) {
-    ctx.shadowColor = node.color
-    ctx.shadowBlur = glow
-  }
-  ctx.fillStyle = node.color
-  traceNodeShape(node)
-  ctx.fill()
-
-  if (node.pinned || active || categorySelected) {
-    ctx.shadowBlur = 0
-    ctx.strokeStyle = active
-      ? 'rgba(255,255,255,0.9)'
-      : categorySelected
-        ? node.color
-        : 'rgba(255, 190, 90, 0.85)'
-    ctx.lineWidth = active ? 2 : categorySelected ? 2.2 : 1.4
-    traceNodeShape(node, categorySelected ? 6 : 5)
-    ctx.stroke()
-  }
-
-  if (active) {
-    ctx.shadowBlur = 0
-    ctx.globalAlpha = 0.28 + pulse * 0.32
-    ctx.strokeStyle = node.color
-    ctx.lineWidth = 2
-    traceNodeShape(node, 10 + pulse * 14)
-    ctx.stroke()
-  }
-  ctx.restore()
-}
-
-function resizeCanvas() {
-  const canvas = canvasRef.value
-  const wrap = canvasWrapRef.value
-  if (!canvas || !wrap) return
-  const rect = wrap.getBoundingClientRect()
-  dpr = window.devicePixelRatio || 1
-  width = Math.max(1, rect.width)
-  height = Math.max(1, rect.height)
-  canvas.width = Math.floor(width * dpr)
-  canvas.height = Math.floor(height * dpr)
-  canvas.style.width = `${width}px`
-  canvas.style.height = `${height}px`
-  ctx = canvas.getContext('2d')
-  ctx?.setTransform(dpr, 0, 0, dpr, 0, 0)
-}
-
-function updateDrawerWidth() {
-  drawerWidth.value = window.innerWidth <= 640 ? window.innerWidth : 380
-}
-
-function addResizeListener() {
-  if (resizeListenerInstalled) return
-  window.addEventListener('resize', updateDrawerWidth)
-  resizeListenerInstalled = true
-}
-
-function removeResizeListener() {
-  if (!resizeListenerInstalled) return
-  window.removeEventListener('resize', updateDrawerWidth)
-  resizeListenerInstalled = false
-}
-
-function attachResizeObserver() {
-  if (resizeObserverInstalled || !canvasWrapRef.value) return
-  resizeObserver = new ResizeObserver(resizeCanvas)
-  resizeObserver.observe(canvasWrapRef.value)
-  resizeObserverInstalled = true
-}
-
-function detachResizeObserver() {
-  if (!resizeObserverInstalled) return
-  resizeObserver?.disconnect()
-  resizeObserver = null
-  resizeObserverInstalled = false
-}
-
-function projectedVisibleNodes(): ProjectedNode[] {
-  return visibleSceneNodes.value.map(projectNode).filter(node => node.visible)
-}
-
-function pointHitsNode(node: ProjectedNode, x: number, y: number): boolean {
-  const dx = x - node.sx
-  const dy = y - node.sy
-  const hitRadius = node.size + 8
-  return nodeShape(node) === 'diamond'
-    ? Math.abs(dx) / (hitRadius * 1.12) + Math.abs(dy) / (hitRadius * 1.3) <= 1
-    : Math.sqrt(dx * dx + dy * dy) <= hitRadius
-}
-
-function hitTest(x: number, y: number): ProjectedNode | null {
-  const projected = projectedVisibleNodes()
-  let best: ProjectedNode | null = null
-  for (const node of projected) {
-    if (pointHitsNode(node, x, y) && (!best || node.depth > best.depth)) best = node
-  }
-  return best
-}
-
-function pointerPosition(event: MouseEvent | PointerEvent | WheelEvent): { x: number; y: number } {
-  const rect = canvasRef.value?.getBoundingClientRect()
-  return { x: event.clientX - (rect?.left || 0), y: event.clientY - (rect?.top || 0) }
-}
-
-function handlePointerDown(event: PointerEvent) {
-  keyboardPreviewIndex = -1
-  hideNodeHoverTip(true)
-  activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY })
-  if (activePointers.size === 2) {
-    const pointers = [...activePointers.values()]
-    pinchDistance = pointerDistance(pointers[0], pointers[1])
-    pinchZoom = zoom
-    pointerMoved = true
-    dragging = true
-  } else {
-    pointerStartX = event.clientX
-    pointerStartY = event.clientY
-    pointerMoved = false
-    dragging = true
-  }
-  lastX = event.clientX
-  lastY = event.clientY
-  canvasRef.value?.setPointerCapture(event.pointerId)
-}
-
-function handlePointerMove(event: PointerEvent) {
-  if (activePointers.has(event.pointerId)) {
-    if (Math.hypot(event.clientX - pointerStartX, event.clientY - pointerStartY) > 4) pointerMoved = true
-    activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY })
-  }
-
-  if (activePointers.size >= 2) {
-    dragging = true
-    hideNodeHoverTip(true)
-    const pointers = [...activePointers.values()]
-    const distance = pointerDistance(pointers[0], pointers[1])
-    if (pinchDistance > 0) {
-      zoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, pinchZoom * (distance / pinchDistance)))
-    }
-    return
-  }
-
-  const pos = pointerPosition(event)
-  const hit = hitTest(pos.x, pos.y)
-  updateNodeHover(hit, pos)
-  if (!dragging) return
-  const dx = event.clientX - lastX
-  const dy = event.clientY - lastY
-  rotationY += dx * 0.006
-  rotationX = Math.max(-1.2, Math.min(1.2, rotationX + dy * 0.006))
-  lastX = event.clientX
-  lastY = event.clientY
-}
-
-function handlePointerUp(event: PointerEvent) {
-  const cancelled = event.type === 'pointercancel'
-  if (pointerMoved || cancelled) suppressClickUntil = performance.now() + 200
-  activePointers.delete(event.pointerId)
-  if (cancelled) {
-    activePointers.clear()
-    dragging = false
-    pointerMoved = false
-    pinchDistance = 0
-    hideNodeHoverTip(true)
-  } else if (activePointers.size === 1) {
-    const pointer = [...activePointers.values()][0]
-    lastX = pointer.x
-    lastY = pointer.y
-    dragging = true
-  } else {
-    dragging = false
-    pointerMoved = false
-    pinchDistance = 0
-  }
-  const canvas = canvasRef.value
-  if (canvas?.hasPointerCapture(event.pointerId)) canvas.releasePointerCapture(event.pointerId)
-}
-
-function handlePointerLeave() {
-  if (!dragging) hideNodeHoverTip(true)
-}
-
-function pointerDistance(a: { x: number; y: number }, b: { x: number; y: number }): number {
-  const dx = a.x - b.x
-  const dy = a.y - b.y
-  return Math.sqrt(dx * dx + dy * dy)
-}
-
 function previewNodeFromKeyboard(delta: number, absoluteIndex?: number) {
-  const projected = projectedVisibleNodes()
-  if (!projected.length) return
-  const currentIndex = projected.findIndex(node => node.id === hoverTipId.value)
+  const orderedNodes = playbackNodes.value.filter(node => visibleNodeIds.value.has(node.id))
+  if (!orderedNodes.length) return
+  const currentIndex = orderedNodes.findIndex(node => node.id === hoverTipId.value)
   let baseIndex = currentIndex
   if (baseIndex < 0) baseIndex = keyboardPreviewIndex >= 0 ? keyboardPreviewIndex : delta > 0 ? -1 : 0
   keyboardPreviewIndex = absoluteIndex === undefined
-    ? (baseIndex + delta + projected.length) % projected.length
-    : Math.max(0, Math.min(projected.length - 1, absoluteIndex))
-  const node = projected[keyboardPreviewIndex]
-  requestSkillDescription(node)
+    ? (baseIndex + delta + orderedNodes.length) % orderedNodes.length
+    : Math.max(0, Math.min(orderedNodes.length - 1, absoluteIndex))
+  const node = orderedNodes[keyboardPreviewIndex]
   clearHoverTipTimer()
   hoverId.value = node.id
   hoverTipId.value = node.id
-  hoverPoint.value = { x: node.sx, y: node.sy }
-}
-
-function openNodeDetails(nodeId: string) {
-  const node = nodeById.value.get(nodeId)
-  if (node) requestSkillDescription(node)
-  if (selectedId.value === nodeId && detailDrawerOpen.value) {
-    selectedId.value = ''
-    detailDrawerOpen.value = false
-    return
+  hoverPoint.value = {
+    x: Math.min(Math.max(24, graphSize.value.width / 2), graphSize.value.width - 24),
+    y: 76,
   }
-  selectedId.value = nodeId
-  detailDrawerOpen.value = true
+  requestSkillDescription(node)
 }
 
-function handleJourneyKeydown(event: KeyboardEvent) {
-  if (event.key !== 'Escape') return
-  resetInteractionState()
-  event.preventDefault()
-}
-
-function handleCanvasKeydown(event: KeyboardEvent) {
+function handleGraphKeydown(event: KeyboardEvent) {
   if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
     event.preventDefault()
     previewNodeFromKeyboard(1)
@@ -875,37 +518,21 @@ function handleCanvasKeydown(event: KeyboardEvent) {
   }
   if (event.key === 'Home' || event.key === 'End') {
     event.preventDefault()
-    previewNodeFromKeyboard(0, event.key === 'Home' ? 0 : projectedVisibleNodes().length - 1)
+    const count = playbackNodes.value.filter(node => visibleNodeIds.value.has(node.id)).length
+    previewNodeFromKeyboard(0, event.key === 'Home' ? 0 : count - 1)
     return
   }
   if (event.key === 'Enter' || event.key === ' ') {
     if (!hoverTipId.value) previewNodeFromKeyboard(1)
     if (hoverTipId.value) openNodeDetails(hoverTipId.value)
     event.preventDefault()
-    return
   }
 }
 
-function handleClick(event: MouseEvent) {
-  if (performance.now() < suppressClickUntil) {
-    suppressClickUntil = 0
-    return
-  }
-  const pos = pointerPosition(event)
-  const hit = hitTest(pos.x, pos.y)
-  hideNodeHoverTip(true)
-  if (!hit) {
-    selectedId.value = ''
-    selectedCategories.value = []
-    detailDrawerOpen.value = false
-    return
-  }
-  openNodeDetails(hit.id)
-}
-
-function handleWheel(event: WheelEvent) {
+function handleJourneyKeydown(event: KeyboardEvent) {
+  if (event.key !== 'Escape') return
+  resetInteractionState()
   event.preventDefault()
-  zoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom + (event.deltaY > 0 ? -0.08 : 0.08)))
 }
 
 function clearPlaybackTimer() {
@@ -967,7 +594,28 @@ function togglePlayback() {
   scheduleNextNode()
 }
 
-async function loadJourney(options: { clearData?: boolean; resetInteraction?: boolean } = {}) {
+function updateViewportMetrics() {
+  drawerWidth.value = window.innerWidth <= 640 ? window.innerWidth : 380
+  const rect = graphWrapRef.value?.getBoundingClientRect()
+  if (rect) graphSize.value = { width: rect.width, height: rect.height }
+}
+
+async function fitJourneyView() {
+  await nextTick()
+  if (disposed || !flowNodes.value.length) return
+  try {
+    await fitView({
+      padding: 0.16,
+      minZoom: 0.3,
+      maxZoom: 1,
+      duration: 220,
+    })
+  } catch {
+    // Vue Flow may be gone when a profile switches during unmount.
+  }
+}
+
+async function loadJourney(options: { clearData?: boolean; resetInteraction?: boolean; fitAfterLoad?: boolean } = {}) {
   const generation = ++loadGeneration
   stopPlayback()
   clearSelectionDelay()
@@ -979,6 +627,7 @@ async function loadJourney(options: { clearData?: boolean; resetInteraction?: bo
     const nextData = await fetchJourneyGraph()
     if (disposed || generation !== loadGeneration) return generation
     data.value = nextData
+    if (options.fitAfterLoad) void fitJourneyView()
   } catch (err: any) {
     if (disposed || generation !== loadGeneration) return generation
     message.error(err?.message || t('journey.loadFailed'))
@@ -986,25 +635,6 @@ async function loadJourney(options: { clearData?: boolean; resetInteraction?: bo
     if (!disposed && generation === loadGeneration) loading.value = false
   }
   return generation
-}
-
-function journeyResourcesReady() {
-  return resizeListenerInstalled && resizeObserverInstalled && rendererStarted
-}
-
-function initializeJourneyResources() {
-  updateDrawerWidth()
-  addResizeListener()
-  attachResizeObserver()
-  if (!rendererStarted) startRenderer()
-}
-
-async function loadJourneyAndInitialize(options: { clearData?: boolean; resetInteraction?: boolean } = {}) {
-  const generation = await loadJourney(options)
-  if (disposed || generation !== loadGeneration || journeyResourcesReady()) return
-  await nextTick()
-  if (disposed || generation !== loadGeneration || journeyResourcesReady()) return
-  initializeJourneyResources()
 }
 
 async function refreshJourney() {
@@ -1020,58 +650,43 @@ async function refreshJourney() {
   if (needsSkillDescriptions) await ensureSkillDescriptionsLoaded(generation)
 }
 
-function stopRenderer() {
-  if (!rendererStarted) return
-  cancelAnimationFrame(raf)
-  raf = 0
-  rendererStarted = false
-}
-
-function startRenderer() {
-  stopRenderer()
-  resizeCanvas()
-  raf = requestAnimationFrame(draw)
-  rendererStarted = true
+function miniMapNodeColor(node: { data?: JourneyFlowNodeData }): string {
+  return node.data?.color || '#7f8c9a'
 }
 
 onMounted(() => {
   window.addEventListener('keydown', handleJourneyKeydown)
-  void loadJourneyAndInitialize()
+  window.addEventListener('resize', updateViewportMetrics)
+  updateViewportMetrics()
+  void loadJourney({ fitAfterLoad: true })
 })
 
 onBeforeUnmount(() => {
   disposed = true
   loadGeneration += 1
   window.removeEventListener('keydown', handleJourneyKeydown)
-  stopRenderer()
+  window.removeEventListener('resize', updateViewportMetrics)
   clearPlaybackTimer()
   clearSelectionDelay()
   clearHoverTipTimer()
-  removeResizeListener()
-  detachResizeObserver()
-  activePointers.clear()
-  ctx = null
 })
 
 watch(
   () => profilesStore.activeProfileName || 'default',
   (profile, previousProfile) => {
     if (profile === previousProfile) return
-    void loadJourneyAndInitialize({ clearData: true, resetInteraction: true })
+    void loadJourney({ clearData: true, resetInteraction: true, fitAfterLoad: true })
   },
 )
 
-watch(sceneNodes, () => {
+watch(nodes, () => {
   if (selectedId.value && !nodeById.value.has(selectedId.value)) {
     selectedId.value = ''
     detailDrawerOpen.value = false
   }
   if (hoverTipId.value && !nodeById.value.has(hoverTipId.value)) hideNodeHoverTip(true)
-  const availableCategories = new Set(sceneNodes.value.map(node => node.category || 'general'))
-  const retainedCategories = selectedCategories.value.filter(category => availableCategories.has(category))
-  if (retainedCategories.length !== selectedCategories.value.length) {
-    selectedCategories.value = retainedCategories
-  }
+  const availableCategories = new Set(nodes.value.map(node => node.category || 'general'))
+  selectedCategories.value = selectedCategories.value.filter(category => availableCategories.has(category))
 })
 </script>
 
@@ -1086,12 +701,13 @@ watch(sceneNodes, () => {
         <div class="journey-toolbar">
           <div class="node-kind-legend" :aria-label="t('journey.nodeKinds')">
             <span class="node-kind-legend__item">
-              <i class="node-kind-marker node-kind-marker--skill node-kind-marker--circle" aria-hidden="true" />
-              {{ t('journey.skills') }}
-            </span>
-            <span class="node-kind-legend__item">
-              <i class="node-kind-marker node-kind-marker--memory node-kind-marker--diamond" aria-hidden="true" />
+              <i class="node-kind-marker node-kind-marker--memory" aria-hidden="true" />
               {{ t('journey.memories') }}
+            </span>
+            <span class="node-kind-legend__arrow" aria-hidden="true">→</span>
+            <span class="node-kind-legend__item">
+              <i class="node-kind-marker node-kind-marker--skill" aria-hidden="true" />
+              {{ t('journey.skills') }}
             </span>
           </div>
           <NButton
@@ -1106,24 +722,116 @@ watch(sceneNodes, () => {
           <NButton size="small" :loading="loading" @click="refreshJourney">{{ t('journey.refresh') }}</NButton>
         </div>
 
+        <div v-if="categoryStats.length" class="category-meter">
+          <div class="category-bar" role="group" :aria-label="t('journey.categorySelection')">
+            <button
+              v-for="stat in categoryStats"
+              :key="stat.category"
+              type="button"
+              class="category-bar-segment"
+              :class="{
+                active: emphasizedCategorySet.has(stat.category),
+                selected: selectedCategorySet.has(stat.category),
+              }"
+              :style="{ '--category-color': stat.color, flexGrow: stat.count }"
+              :data-category="stat.category"
+              :aria-label="`${stat.label} ${stat.count} / ${Math.round((stat.count / visibleNodeCount) * 100)}%`"
+              :aria-pressed="selectedCategorySet.has(stat.category)"
+              @mouseenter="hoverCategory = stat.category"
+              @mouseleave="hoverCategory = ''"
+              @click="toggleCategorySelection(stat.category)"
+            />
+          </div>
+          <div class="category-legend" role="group" :aria-label="t('journey.categorySelection')">
+            <button
+              v-for="stat in categoryStats"
+              :key="stat.category"
+              type="button"
+              :class="{
+                active: emphasizedCategorySet.has(stat.category),
+                selected: selectedCategorySet.has(stat.category),
+              }"
+              :data-category="stat.category"
+              :aria-pressed="selectedCategorySet.has(stat.category)"
+              @mouseenter="hoverCategory = stat.category"
+              @mouseleave="hoverCategory = ''"
+              @click="toggleCategorySelection(stat.category)"
+            >
+              <i :style="{ backgroundColor: stat.color }" />
+              {{ stat.label }} · {{ stat.count }}
+            </button>
+          </div>
+        </div>
+
         <NSpin :show="loading && !data" class="journey-spin">
-          <main class="galaxy-layout">
-            <section ref="canvasWrapRef" class="galaxy-canvas-wrap">
-              <canvas
-                ref="canvasRef"
-                class="galaxy-canvas"
-                tabindex="0"
-                role="group"
-                :aria-label="canvasAriaLabel"
-                @keydown="handleCanvasKeydown"
-                @pointerdown="handlePointerDown"
-                @pointermove="handlePointerMove"
-                @pointerup="handlePointerUp"
-                @pointercancel="handlePointerUp"
-                @pointerleave="handlePointerLeave"
-                @click="handleClick"
-                @wheel="handleWheel"
-              />
+          <main class="journey-graph-layout">
+            <section
+              ref="graphWrapRef"
+              class="journey-graph-wrap"
+              tabindex="0"
+              role="group"
+              :aria-label="graphAriaLabel"
+              @keydown="handleGraphKeydown"
+            >
+              <VueFlow
+                id="hermes-journey"
+                :nodes="flowNodes"
+                :edges="flowEdges"
+                :fit-view-on-init="false"
+                :default-viewport="{ x: 32, y: 48, zoom: 0.84 }"
+                :min-zoom="0.25"
+                :max-zoom="1.4"
+                :nodes-draggable="false"
+                :nodes-connectable="false"
+                :elements-selectable="false"
+                :zoom-on-double-click="false"
+                class="journey-flow"
+                @pane-click="clearGraphSelection"
+              >
+                <template #node-journey="{ data: nodeData }">
+                  <button
+                    type="button"
+                    class="journey-node"
+                    :class="[
+                      `journey-node--${nodeData.column}`,
+                      {
+                        'is-active': nodeData.active,
+                        'is-related': nodeData.related,
+                        'is-dimmed': nodeData.dimmed,
+                      },
+                    ]"
+                    :style="{ '--node-color': nodeData.color }"
+                    @click.stop="openNodeDetails(nodeData.node.id)"
+                    @mouseenter="handleNodeMouseEnter($event, nodeData.node)"
+                    @mousemove="handleNodeMouseMove($event, nodeData.node)"
+                    @mouseleave="handleNodeMouseLeave(nodeData.node.id)"
+                  >
+                    <Handle type="target" :position="Position.Left" class="journey-node__handle" />
+                    <Handle type="source" :position="Position.Right" class="journey-node__handle" />
+
+                    <span class="journey-node__topline">
+                      <span class="journey-node__kind">
+                        <i aria-hidden="true" />
+                        {{ nodeData.kindLabel }}
+                      </span>
+                      <span class="journey-node__category">{{ nodeData.categoryLabel }}</span>
+                    </span>
+                    <strong class="journey-node__title">{{ nodeData.node.label || nodeData.node.id }}</strong>
+                    <span class="journey-node__meta">
+                      <span v-if="nodeData.timestampLabel !== '-'">{{ nodeData.timestampLabel }}</span>
+                      <span v-if="nodeData.column === 'skill'">
+                        {{ t('journey.useCount') }} {{ nodeData.node.useCount ?? 0 }}
+                      </span>
+                      <span>{{ nodeData.degree }} {{ t('journey.edges') }}</span>
+                    </span>
+                  </button>
+                </template>
+
+                <Background :gap="24" :size="1.15" color="var(--border-color)" />
+                <MiniMap pannable zoomable :node-color="miniMapNodeColor" />
+                <Controls :show-interactive="false" />
+              </VueFlow>
+
               <Transition name="journey-tooltip">
                 <div
                   v-if="hoverTipNode"
@@ -1137,50 +845,15 @@ watch(sceneNodes, () => {
                   </div>
                 </div>
               </Transition>
-              <div class="galaxy-hud">
-                <span>{{ data?.profile || '-' }}</span>
-                <span>{{ visibleSceneNodes.length }} {{ t('journey.nodes') }}</span>
-                <span>{{ visibleEdges.length }} {{ t('journey.edges') }}</span>
+
+              <div v-if="!loading && !visibleNodes.length" class="journey-empty">
+                {{ t('journey.noNodes') }}
               </div>
-              <div v-if="categoryStats.length" class="category-meter">
-                <div class="category-bar" role="group" :aria-label="t('journey.categorySelection')">
-                  <button
-                    v-for="stat in categoryStats"
-                    :key="stat.category"
-                    type="button"
-                    class="category-bar-segment"
-                    :class="{
-                      active: emphasizedCategorySet.has(stat.category),
-                      selected: selectedCategorySet.has(stat.category),
-                    }"
-                    :style="{ '--category-color': stat.color, flexGrow: stat.count }"
-                    :data-category="stat.category"
-                    :aria-label="`${stat.label} ${stat.count} / ${Math.round((stat.count / visibleNodeCount) * 100)}%`"
-                    :aria-pressed="selectedCategorySet.has(stat.category)"
-                    @mouseenter="hoverCategory = stat.category"
-                    @mouseleave="hoverCategory = ''"
-                    @click="toggleCategorySelection(stat.category)"
-                  />
-                </div>
-                <div class="category-legend" role="group" :aria-label="t('journey.categorySelection')">
-                  <button
-                    v-for="stat in categoryStats"
-                    :key="stat.category"
-                    type="button"
-                    :class="{
-                      active: emphasizedCategorySet.has(stat.category),
-                      selected: selectedCategorySet.has(stat.category),
-                    }"
-                    :data-category="stat.category"
-                    :aria-pressed="selectedCategorySet.has(stat.category)"
-                    @mouseenter="hoverCategory = stat.category"
-                    @mouseleave="hoverCategory = ''"
-                    @click="toggleCategorySelection(stat.category)"
-                  >
-                    <i :style="{ backgroundColor: stat.color }" />
-                    {{ stat.label }} {{ stat.count }} / {{ Math.round((stat.count / visibleNodeCount) * 100) }}%
-                  </button>
-                </div>
+
+              <div class="journey-hud">
+                <span>{{ data?.profile || '-' }}</span>
+                <span>{{ visibleNodes.length }} {{ t('journey.nodes') }}</span>
+                <span>{{ visibleEdges.length }} {{ t('journey.edges') }}</span>
               </div>
             </section>
           </main>
@@ -1259,12 +932,6 @@ watch(sceneNodes, () => {
   padding: 16px 20px 20px;
 }
 
-@media (max-width: $breakpoint-mobile) {
-  .journey-view__content {
-    padding: 12px;
-  }
-}
-
 .journey-panel {
   height: 100%;
   min-height: 0;
@@ -1277,13 +944,13 @@ watch(sceneNodes, () => {
   justify-content: flex-end;
   align-items: center;
   gap: 8px;
-  padding-bottom: 12px;
+  padding-bottom: 10px;
 }
 
 .node-kind-legend {
   display: inline-flex;
   align-items: center;
-  gap: 14px;
+  gap: 9px;
   min-width: 0;
   margin-inline-end: auto;
   color: $text-secondary;
@@ -1297,24 +964,33 @@ watch(sceneNodes, () => {
   white-space: nowrap;
 }
 
+.node-kind-legend__arrow {
+  color: $text-muted;
+  font-size: 15px;
+}
+
+:global([dir='rtl']) .node-kind-legend__arrow {
+  transform: scaleX(-1);
+}
+
 .node-kind-marker {
   width: 10px;
   height: 10px;
   display: inline-block;
   flex: 0 0 auto;
-  background: #4f8cff;
-  box-shadow: 0 0 0 2px color-mix(in srgb, #4f8cff 20%, transparent);
+  border: 2px solid currentcolor;
+  background: $bg-primary;
+  color: #4f8cff;
 }
 
-.node-kind-marker--circle {
-  border-radius: 50%;
-}
-
-.node-kind-marker--diamond {
+.node-kind-marker--memory {
   border-radius: 2px;
-  background: #6ba3d6;
-  box-shadow: 0 0 0 2px color-mix(in srgb, #6ba3d6 24%, transparent);
+  color: #6ba3d6;
   transform: rotate(45deg);
+}
+
+.node-kind-marker--skill {
+  border-radius: 50%;
 }
 
 .playback-icon {
@@ -1335,6 +1011,104 @@ watch(sceneNodes, () => {
   }
 }
 
+.category-meter {
+  display: grid;
+  gap: 7px;
+  margin-bottom: 10px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, $border-color 70%, transparent);
+  border-radius: $radius-sm;
+  background: color-mix(in srgb, $bg-secondary 72%, transparent);
+}
+
+.category-bar {
+  position: relative;
+  display: flex;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, $border-color 42%, transparent);
+
+  button {
+    position: relative;
+    min-width: 10px;
+    align-self: stretch;
+    padding: 0;
+    border: 0;
+    background: var(--category-color);
+    cursor: pointer;
+    opacity: 0.62;
+    transition: opacity 0.16s ease, filter 0.16s ease;
+
+    &.active,
+    &.selected {
+      opacity: 1;
+      filter: saturate(1.15);
+    }
+
+    &.selected {
+      box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.86);
+    }
+
+    &:focus-visible {
+      z-index: 1;
+      outline: 2px solid $text-primary;
+      outline-offset: -2px;
+    }
+  }
+}
+
+.category-legend {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  color: $text-secondary;
+  font-size: 11px;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    flex: 0 0 auto;
+    padding: 4px 8px;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+
+    &.active,
+    &.selected {
+      border-color: rgba(var(--accent-info-rgb), 0.36);
+      background: rgba(var(--accent-info-rgb), 0.09);
+      color: $text-primary;
+    }
+
+    &.selected {
+      border-color: rgba(var(--accent-info-rgb), 0.7);
+      font-weight: 600;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $accent-primary;
+      outline-offset: 1px;
+    }
+  }
+
+  i {
+    width: 7px;
+    height: 7px;
+    flex: 0 0 auto;
+    border-radius: 999px;
+  }
+}
+
 .journey-spin {
   flex: 1;
   height: 100%;
@@ -1347,51 +1121,197 @@ watch(sceneNodes, () => {
   }
 }
 
-.galaxy-layout {
-  height: 100%;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  min-height: 0;
-  background:
-    radial-gradient(circle at 50% 35%, rgba(var(--accent-info-rgb), 0.12), transparent 36%),
-    linear-gradient(180deg, color-mix(in srgb, $bg-primary 88%, #000 12%), $bg-primary);
-}
-
-.galaxy-canvas-wrap {
-  position: relative;
-  height: 100%;
-  min-width: 0;
-  min-height: 0;
-  overflow: hidden;
-}
-
-.galaxy-canvas {
-  display: block;
+.journey-graph-layout,
+.journey-graph-wrap,
+.journey-flow {
   width: 100%;
   height: 100%;
-  cursor: grab;
-  touch-action: none;
+  min-height: 0;
+}
+
+.journey-graph-wrap {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, $border-color 72%, transparent);
+  border-radius: $radius-md;
+  background:
+    radial-gradient(circle at 50% 45%, rgba(var(--accent-info-rgb), 0.07), transparent 48%),
+    $bg-primary;
+
+  &:focus-visible {
+    outline: 2px solid $accent-primary;
+    outline-offset: -2px;
+  }
+}
+
+.journey-flow {
+  :deep(.vue-flow__pane) {
+    cursor: grab;
+  }
+
+  :deep(.vue-flow__pane.dragging) {
+    cursor: grabbing;
+  }
+
+  :deep(.vue-flow__node) {
+    border: 0;
+    background: transparent;
+  }
+
+  :deep(.vue-flow__edge-path) {
+    transition: stroke 0.16s ease, stroke-width 0.16s ease, opacity 0.16s ease;
+  }
+
+  :deep(.vue-flow__controls) {
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, $border-color 78%, transparent);
+    border-radius: $radius-sm;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  }
+
+  :deep(.vue-flow__controls-button) {
+    border-color: color-mix(in srgb, $border-color 68%, transparent);
+    background: color-mix(in srgb, $bg-primary 94%, transparent);
+    color: $text-primary;
+  }
+
+  :deep(.vue-flow__minimap) {
+    width: 138px;
+    height: 92px;
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, $border-color 72%, transparent);
+    border-radius: $radius-sm;
+    background: color-mix(in srgb, $bg-primary 90%, transparent);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  }
+}
+
+.journey-node {
+  position: relative;
+  width: 240px;
+  min-height: 82px;
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--node-color) 35%, $border-color);
+  border-radius: $radius-sm;
+  background: color-mix(in srgb, $bg-primary 96%, var(--node-color) 4%);
+  box-shadow: 0 7px 20px rgba(0, 0, 0, 0.08);
+  color: $text-primary;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+  transition:
+    border-color 0.16s ease,
+    box-shadow 0.16s ease,
+    opacity 0.16s ease,
+    transform 0.16s ease;
+
+  &:hover,
+  &:focus-visible,
+  &.is-active {
+    border-color: var(--node-color);
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, var(--node-color) 18%, transparent),
+      0 11px 28px rgba(0, 0, 0, 0.14);
+    transform: translateY(-1px);
+  }
 
   &:focus-visible {
     outline: 2px solid $text-primary;
-    outline-offset: -2px;
+    outline-offset: 2px;
   }
 
-  &:active {
-    cursor: grabbing;
+  &.is-related {
+    border-color: color-mix(in srgb, var(--node-color) 72%, $border-color);
+    box-shadow: 0 9px 24px rgba(0, 0, 0, 0.12);
   }
+
+  &.is-dimmed {
+    opacity: 0.28;
+  }
+}
+
+.journey-node__handle {
+  width: 7px;
+  height: 7px;
+  border: 2px solid $bg-primary;
+  background: var(--node-color);
+  opacity: 0.72;
+  pointer-events: none;
+}
+
+.journey-node__topline,
+.journey-node__meta {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+}
+
+.journey-node__topline {
+  justify-content: space-between;
+  gap: 8px;
+  color: $text-muted;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.journey-node__kind {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  i {
+    width: 7px;
+    height: 7px;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    background: var(--node-color);
+  }
+}
+
+.journey-node--memory .journey-node__kind i {
+  border-radius: 1px;
+  transform: rotate(45deg);
+}
+
+.journey-node__category {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.journey-node__title {
+  display: -webkit-box;
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.38;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.journey-node__meta {
+  gap: 5px 10px;
+  flex-wrap: wrap;
+  color: $text-secondary;
+  font-size: 10px;
 }
 
 .journey-node-tooltip {
   position: absolute;
-  z-index: 5;
+  z-index: 10;
   width: max-content;
   max-width: min(320px, calc(100% - 16px));
   padding: 9px 11px;
   border: 1px solid color-mix(in srgb, $border-color 82%, transparent);
   border-radius: $radius-sm;
-  background: color-mix(in srgb, $bg-primary 94%, transparent);
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.24);
+  background: color-mix(in srgb, $bg-primary 96%, transparent);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.2);
   color: $text-primary;
   pointer-events: none;
   backdrop-filter: blur(12px);
@@ -1400,7 +1320,6 @@ watch(sceneNodes, () => {
 .journey-node-tooltip__name {
   max-width: 100%;
   overflow: hidden;
-  color: inherit;
   font-size: 12px;
   font-weight: 600;
   text-overflow: ellipsis;
@@ -1428,155 +1347,34 @@ watch(sceneNodes, () => {
   opacity: 0;
 }
 
-.galaxy-hud {
+.journey-hud {
   position: absolute;
-  left: 16px;
-  bottom: 16px;
+  z-index: 6;
+  left: 50%;
+  bottom: 14px;
   display: flex;
-  gap: 10px;
-  color: $text-secondary;
-  font-size: 12px;
-  pointer-events: none;
-
-  span {
-    border: 1px solid color-mix(in srgb, $border-color 70%, transparent);
-    border-radius: 999px;
-    padding: 5px 9px;
-    background: color-mix(in srgb, $bg-primary 72%, transparent);
-    backdrop-filter: blur(10px);
-  }
-}
-
-.category-meter {
-  position: absolute;
-  top: 14px;
-  left: 16px;
-  right: 16px;
-  display: grid;
   gap: 7px;
-  pointer-events: auto;
-}
-
-.category-bar {
-  position: relative;
-  display: flex;
-  height: 24px;
-  overflow-x: auto;
-  overflow-y: hidden;
-  scrollbar-width: none;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-
-  &::before {
-    position: absolute;
-    top: 8px;
-    right: 0;
-    bottom: 8px;
-    left: 0;
-    border: 1px solid color-mix(in srgb, $border-color 72%, transparent);
-    border-radius: 999px;
-    background: color-mix(in srgb, $bg-primary 76%, transparent);
-    box-shadow: 0 0 18px rgba(var(--accent-info-rgb), 0.12);
-    content: '';
-  }
-
-  button {
-    position: relative;
-    z-index: 1;
-    display: block;
-    min-width: 24px;
-    align-self: stretch;
-    padding: 0;
-    border: 0;
-    border-radius: 0;
-    background: transparent;
-    cursor: pointer;
-    transition: flex-grow 0.2s ease;
-
-    &::before {
-      position: absolute;
-      top: 8px;
-      right: 0;
-      bottom: 8px;
-      left: 0;
-      background: var(--category-color);
-      content: '';
-      transition: filter 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    &:first-child::before {
-      border-radius: 999px 0 0 999px;
-    }
-
-    &:last-child::before {
-      border-radius: 0 999px 999px 0;
-    }
-
-    &.active::before {
-      filter: brightness(1.25);
-    }
-
-    &.selected::before {
-      box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.9);
-      filter: brightness(1.3) saturate(1.15);
-    }
-
-    &:focus-visible {
-      outline: 2px solid $text-primary;
-      outline-offset: -2px;
-    }
-  }
-}
-
-.category-legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px 10px;
   color: $text-secondary;
   font-size: 11px;
+  pointer-events: none;
+  transform: translateX(-50%);
 
-  button {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    padding: 4px 7px;
-    border: 1px solid color-mix(in srgb, $border-color 68%, transparent);
+  span {
+    padding: 4px 8px;
+    border: 1px solid color-mix(in srgb, $border-color 70%, transparent);
     border-radius: 999px;
-    background: color-mix(in srgb, $bg-primary 74%, transparent);
-    color: inherit;
-    font: inherit;
+    background: color-mix(in srgb, $bg-primary 88%, transparent);
     backdrop-filter: blur(10px);
-    cursor: pointer;
-    transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
-
-    &.active {
-      color: $text-primary;
-      border-color: rgba(var(--accent-info-rgb), 0.42);
-      background: rgba(var(--accent-info-rgb), 0.1);
-    }
-
-    &.selected {
-      color: $text-primary;
-      font-weight: 600;
-      border-color: rgba(var(--accent-info-rgb), 0.95);
-      background: rgba(var(--accent-info-rgb), 0.3);
-      box-shadow: 0 0 0 2px rgba(var(--accent-info-rgb), 0.34), 0 0 14px rgba(var(--accent-info-rgb), 0.22);
-    }
-
-    &:focus-visible {
-      outline: 2px solid $accent-primary;
-      outline-offset: 2px;
-    }
   }
+}
 
-  i {
-    width: 7px;
-    height: 7px;
-    flex: 0 0 auto;
-    border-radius: 999px;
-  }
+.journey-empty {
+  position: absolute;
+  z-index: 5;
+  top: 50%;
+  left: 50%;
+  color: $text-secondary;
+  transform: translate(-50%, -50%);
 }
 
 .drawer-title-row {
@@ -1639,9 +1437,8 @@ watch(sceneNodes, () => {
 
 .detail-card-label,
 .detail-item span {
-  color: $text-muted;
-  font-size: 11px;
-  line-height: 1.2;
+  color: $text-secondary;
+  font-size: 12px;
 }
 
 .detail-grid {
@@ -1651,25 +1448,51 @@ watch(sceneNodes, () => {
 }
 
 .detail-item {
+  min-width: 0;
   display: grid;
-  gap: 5px;
-  min-height: 72px;
-  padding: 12px;
+  gap: 4px;
+  padding: 10px 12px;
   border: 1px solid $border-light;
   border-radius: $radius-sm;
   background: $bg-secondary;
 
   strong {
-    align-self: end;
+    min-width: 0;
     color: $text-primary;
     font-size: 13px;
-    font-weight: 600;
     overflow-wrap: anywhere;
   }
 }
 
-@media (max-width: 900px) {
-  .galaxy-layout {
+@media (max-width: $breakpoint-mobile) {
+  .journey-view__content {
+    padding: 10px;
+  }
+
+  .journey-toolbar {
+    flex-wrap: wrap;
+  }
+
+  .node-kind-legend {
+    width: 100%;
+  }
+
+  .category-meter {
+    padding: 8px 10px;
+  }
+
+  .journey-flow {
+    :deep(.vue-flow__minimap) {
+      width: 104px;
+      height: 70px;
+    }
+  }
+
+  .journey-hud {
+    display: none;
+  }
+
+  .detail-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/tests/client/journey-layout.test.ts
+++ b/tests/client/journey-layout.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import type { JourneyEdge, JourneyNode } from '@/api/hermes/journey'
+import { journeyNeighborIds, layoutJourneyGraph } from '@/utils/hermes/journey-layout'
+
+function node(id: string, kind: 'memory' | 'skill', timestamp: number): JourneyNode {
+  return {
+    id,
+    kind,
+    timestamp,
+    label: id,
+    category: kind,
+  }
+}
+
+describe('journey layout', () => {
+  it('places memories left of skills and spreads both columns across the same height', () => {
+    const nodes = [
+      node('memory:1', 'memory', 1),
+      node('memory:2', 'memory', 2),
+      node('memory:3', 'memory', 3),
+      node('skill:1', 'skill', 4),
+      node('skill:2', 'skill', 5),
+    ]
+    const layout = layoutJourneyGraph(nodes, [])
+    const memories = layout.filter(item => item.column === 'memory')
+    const skills = layout.filter(item => item.column === 'skill')
+
+    expect(memories.every(item => item.position.x < skills[0].position.x)).toBe(true)
+    expect(memories.map(item => item.position.y)).toEqual([0, 112, 224])
+    expect(skills.map(item => item.position.y)).toEqual([56, 168])
+  })
+
+  it('uses neighbor barycenters to keep related nodes close together deterministically', () => {
+    const nodes = [
+      node('memory:a', 'memory', 1),
+      node('memory:b', 'memory', 2),
+      node('skill:b', 'skill', 3),
+      node('skill:a', 'skill', 4),
+    ]
+    const edges: JourneyEdge[] = [
+      { source: 'memory:a', target: 'skill:a' },
+      { source: 'memory:b', target: 'skill:b' },
+    ]
+
+    const first = layoutJourneyGraph(nodes, edges)
+    const second = layoutJourneyGraph([...nodes].reverse(), [...edges].reverse())
+    const position = (layout: typeof first, id: string) => layout.find(item => item.id === id)!.position.y
+
+    expect(position(first, 'memory:a')).toBe(position(first, 'skill:a'))
+    expect(position(first, 'memory:b')).toBe(position(first, 'skill:b'))
+    expect(first).toEqual(second)
+  })
+
+  it('counts unique neighbors and ignores edges whose nodes are absent', () => {
+    const nodes = [
+      node('memory:1', 'memory', 1),
+      node('skill:1', 'skill', 2),
+    ]
+    const edges: JourneyEdge[] = [
+      { source: 'memory:1', target: 'skill:1' },
+      { source: 'memory:1', target: 'skill:1' },
+      { source: 'memory:missing', target: 'skill:1' },
+    ]
+    const layout = layoutJourneyGraph(nodes, edges)
+
+    expect(layout.find(item => item.id === 'memory:1')?.degree).toBe(1)
+    expect(layout.find(item => item.id === 'skill:1')?.degree).toBe(1)
+    expect(journeyNeighborIds('memory:1', edges)).toEqual(new Set(['skill:1']))
+  })
+
+  it('centers a single node against a taller opposite column', () => {
+    const nodes = [
+      node('memory:1', 'memory', 1),
+      node('memory:2', 'memory', 2),
+      node('memory:3', 'memory', 3),
+      node('skill:1', 'skill', 4),
+    ]
+    const layout = layoutJourneyGraph(nodes, [])
+
+    expect(layout.find(item => item.id === 'skill:1')?.position.y).toBe(112)
+  })
+
+  it('wraps long columns horizontally at the configured row limit', () => {
+    const nodes = Array.from({ length: 7 }, (_, index) =>
+      node(`memory:${index}`, 'memory', index + 1))
+    nodes.push(node('skill:1', 'skill', 20))
+
+    const layout = layoutJourneyGraph(nodes, [], { maxRows: 3 })
+    const memories = layout.filter(item => item.column === 'memory')
+    const distinctX = new Set(memories.map(item => item.position.x))
+
+    expect(distinctX.size).toBe(3)
+    expect(Math.max(...memories.map(item => item.position.y))).toBe(224)
+    expect(layout.find(item => item.id === 'skill:1')!.position.x).toBeGreaterThan(
+      Math.max(...memories.map(item => item.position.x)),
+    )
+  })
+})

--- a/tests/client/journey-view-interactions.test.ts
+++ b/tests/client/journey-view-interactions.test.ts
@@ -6,6 +6,7 @@ import journeyFixture from '../fixtures/hermes-journey-redacted.json'
 
 const fetchJourneyGraphMock = vi.hoisted(() => vi.fn())
 const fetchSkillsMock = vi.hoisted(() => vi.fn())
+const fitViewMock = vi.hoisted(() => vi.fn(() => Promise.resolve()))
 const messageMock = vi.hoisted(() => ({
   error: vi.fn(),
 }))
@@ -28,18 +29,69 @@ vi.mock('@/stores/hermes/profiles', async () => {
   }
 })
 
-vi.mock('@/composables/useTheme', async () => {
-  const { ref } = await import('vue')
-  return {
-    useTheme: () => ({
-      isDark: ref(false),
-    }),
-  }
-})
-
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     t: (key: string) => key,
+  }),
+}))
+
+vi.mock('@vue-flow/core', () => ({
+  MarkerType: {
+    ArrowClosed: 'arrowclosed',
+  },
+  Position: {
+    Left: 'left',
+    Right: 'right',
+  },
+  useVueFlow: () => ({
+    fitView: fitViewMock,
+  }),
+  Handle: defineComponent({
+    template: '<i class="handle-stub" />',
+  }),
+  VueFlow: defineComponent({
+    props: {
+      nodes: {
+        type: Array,
+        default: () => [],
+      },
+      edges: {
+        type: Array,
+        default: () => [],
+      },
+    },
+    emits: ['pane-click'],
+    template: `
+      <div
+        class="vue-flow-stub"
+        :data-node-count="nodes.length"
+        :data-edge-count="edges.length"
+        @click.self="$emit('pane-click')"
+      >
+        <template v-for="node in nodes" :key="node.id">
+          <slot name="node-journey" :data="node.data" />
+        </template>
+        <slot />
+      </div>
+    `,
+  }),
+}))
+
+vi.mock('@vue-flow/background', () => ({
+  Background: defineComponent({
+    template: '<div class="background-stub" />',
+  }),
+}))
+
+vi.mock('@vue-flow/controls', () => ({
+  Controls: defineComponent({
+    template: '<div class="controls-stub" />',
+  }),
+}))
+
+vi.mock('@vue-flow/minimap', () => ({
+  MiniMap: defineComponent({
+    template: '<div class="minimap-stub" />',
   }),
 }))
 
@@ -85,11 +137,6 @@ import { useProfilesStore } from '@/stores/hermes/profiles'
 
 type JourneyResponse = typeof journeyFixture
 
-type ResizeObserverInstance = {
-  observe: ReturnType<typeof vi.fn>
-  disconnect: ReturnType<typeof vi.fn>
-}
-
 function deferred<T>() {
   let resolve!: (value: T) => void
   const promise = new Promise<T>(res => {
@@ -104,53 +151,17 @@ function cloneJourney(profile = 'default'): JourneyResponse {
   return clone
 }
 
-function createCanvasContext() {
-  return {
-    setTransform: vi.fn(),
-    clearRect: vi.fn(),
-    createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
-    fillRect: vi.fn(),
-    save: vi.fn(),
-    restore: vi.fn(),
-    beginPath: vi.fn(),
-    moveTo: vi.fn(),
-    quadraticCurveTo: vi.fn(),
-    stroke: vi.fn(),
-    arc: vi.fn(),
-    fill: vi.fn(),
-    lineTo: vi.fn(),
-  } as unknown as CanvasRenderingContext2D
-}
-
 async function settle() {
   await flushPromises()
   await nextTick()
 }
 
 function hudTexts(wrapper: VueWrapper<any>) {
-  return wrapper.findAll('.galaxy-hud span').map(node => node.text())
+  return wrapper.findAll('.journey-hud span').map(node => node.text())
 }
 
-function countWindowEventCalls(spy: { mock: { calls: any[][] } }, eventName: string) {
-  return spy.mock.calls.filter(([name]) => name === eventName).length
-}
-
-function dispatchPointerEvent(
-  element: Element,
-  type: string,
-  init: { pointerId: number; pointerType: string; clientX: number; clientY: number },
-) {
-  const event = new MouseEvent(type, {
-    bubbles: true,
-    cancelable: true,
-    clientX: init.clientX,
-    clientY: init.clientY,
-  })
-  Object.defineProperties(event, {
-    pointerId: { value: init.pointerId },
-    pointerType: { value: init.pointerType },
-  })
-  element.dispatchEvent(event)
+function nodeCard(wrapper: VueWrapper<any>, label: string) {
+  return wrapper.findAll('.journey-node').find(card => card.text().includes(label))!
 }
 
 const mountedWrappers: VueWrapper<any>[] = []
@@ -161,29 +172,14 @@ function mountPanel(): VueWrapper<any> {
   return wrapper
 }
 
-let resizeObserverInstances: ResizeObserverInstance[] = []
-let rafCallbacks: FrameRequestCallback[] = []
-let canvasContext: CanvasRenderingContext2D
-let requestAnimationFrameMock: ReturnType<typeof vi.fn>
-let cancelAnimationFrameMock: ReturnType<typeof vi.fn>
-
 describe('JourneyView interactions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers()
-
-    resizeObserverInstances = []
-    rafCallbacks = []
-    requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback) => {
-      rafCallbacks.push(callback)
-      return rafCallbacks.length
-    })
-    cancelAnimationFrameMock = vi.fn((id: number) => {
-      rafCallbacks[id - 1] = () => undefined
-    })
-
     fetchJourneyGraphMock.mockReset()
     fetchSkillsMock.mockReset()
+    fitViewMock.mockReset()
+    fitViewMock.mockResolvedValue(undefined)
     fetchSkillsMock.mockResolvedValue({
       categories: [{
         name: 'research',
@@ -199,26 +195,13 @@ describe('JourneyView interactions', () => {
     messageMock.error.mockReset()
     useProfilesStore().activeProfileName = 'default'
 
-    vi.stubGlobal('ResizeObserver', class {
-      observe = vi.fn()
-      disconnect = vi.fn()
-
-      constructor() {
-        resizeObserverInstances.push(this as unknown as ResizeObserverInstance)
-      }
-    })
-    vi.stubGlobal('requestAnimationFrame', requestAnimationFrameMock)
-    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrameMock)
-
-    canvasContext = createCanvasContext()
-    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(canvasContext)
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => ({
-      width: 640,
-      height: 480,
+      width: 960,
+      height: 640,
       top: 0,
       left: 0,
-      right: 640,
-      bottom: 480,
+      right: 960,
+      bottom: 640,
       x: 0,
       y: 0,
       toJSON() {
@@ -232,99 +215,55 @@ describe('JourneyView interactions', () => {
       mountedWrappers.pop()?.unmount()
     }
     vi.useRealTimers()
-    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
-  it('fetches once on mount and renders the redacted HUD', async () => {
-    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney('default'))
+  it('renders a fitted memory-to-skill relationship map', async () => {
+    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney())
 
     const wrapper = mountPanel()
     await settle()
+    const vm = wrapper.vm as any
+    const memory = vm.flowNodes.find((node: any) => node.data.column === 'memory')
+    const skill = vm.flowNodes.find((node: any) => node.data.column === 'skill')
 
     expect(fetchJourneyGraphMock).toHaveBeenCalledTimes(1)
     expect(hudTexts(wrapper)).toEqual(['default', '2 journey.nodes', '1 journey.edges'])
+    expect(wrapper.findAll('.journey-node')).toHaveLength(2)
+    expect(memory.position.x).toBeLessThan(skill.position.x)
+    expect(memory.style.pointerEvents).toBe('all')
+    expect(vm.flowEdges).toHaveLength(1)
+    expect(vm.flowEdges[0].markerEnd.type).toBe('arrowclosed')
+    expect(fitViewMock).toHaveBeenCalledWith(expect.objectContaining({
+      padding: 0.16,
+      maxZoom: 1,
+    }))
   })
 
-  it('keeps the current HUD visible during manual refresh', async () => {
-    const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+  it('keeps the current graph visible during manual refresh without resetting the viewport', async () => {
     const refresh = deferred<JourneyResponse>()
     fetchJourneyGraphMock
-      .mockResolvedValueOnce(cloneJourney('default'))
+      .mockResolvedValueOnce(cloneJourney())
       .mockReturnValueOnce(refresh.promise)
 
     const wrapper = mountPanel()
     await settle()
+    fitViewMock.mockClear()
 
-    expect(countWindowEventCalls(addEventListenerSpy, 'resize')).toBe(1)
-    expect(resizeObserverInstances).toHaveLength(1)
-    expect(resizeObserverInstances[0].observe).toHaveBeenCalledTimes(1)
-    expect(requestAnimationFrameMock).toHaveBeenCalledTimes(1)
-
-    await wrapper.findAll('.n-button-stub').find(button => button.text() === 'journey.refresh')!.trigger('click')
+    await wrapper.findAll('.n-button-stub').at(-1)!.trigger('click')
     await nextTick()
 
     expect(fetchJourneyGraphMock).toHaveBeenCalledTimes(2)
     expect(hudTexts(wrapper)).toEqual(['default', '2 journey.nodes', '1 journey.edges'])
 
-    refresh.resolve(cloneJourney('default'))
+    refresh.resolve(cloneJourney())
     await settle()
-
-    expect(countWindowEventCalls(addEventListenerSpy, 'resize')).toBe(1)
-    expect(resizeObserverInstances).toHaveLength(1)
-    expect(resizeObserverInstances[0].observe).toHaveBeenCalledTimes(1)
-    expect(requestAnimationFrameMock).toHaveBeenCalledTimes(1)
+    expect(fitViewMock).not.toHaveBeenCalled()
   })
 
-  it('clears old data immediately and refetches when the profile changes', async () => {
-    const nextJourney = deferred<JourneyResponse>()
-    fetchJourneyGraphMock
-      .mockResolvedValueOnce(cloneJourney('default'))
-      .mockReturnValueOnce(nextJourney.promise)
-
-    const wrapper = mountPanel()
-    await settle()
-
-    useProfilesStore().activeProfileName = 'work'
-    await nextTick()
-
-    expect(fetchJourneyGraphMock).toHaveBeenCalledTimes(2)
-    expect(hudTexts(wrapper)).toEqual(['-', '0 journey.nodes', '0 journey.edges'])
-
-    nextJourney.resolve(cloneJourney('work'))
-    await settle()
-
-    expect(hudTexts(wrapper)).toEqual(['work', '2 journey.nodes', '1 journey.edges'])
-  })
-
-  it('ignores stale request completions after a profile switch', async () => {
-    const initial = deferred<JourneyResponse>()
-    const nextJourney = deferred<JourneyResponse>()
-    fetchJourneyGraphMock
-      .mockReturnValueOnce(initial.promise)
-      .mockReturnValueOnce(nextJourney.promise)
-
-    const wrapper = mountPanel()
-    await nextTick()
-
-    useProfilesStore().activeProfileName = 'work'
-    await nextTick()
-
-    expect(fetchJourneyGraphMock).toHaveBeenCalledTimes(2)
-
-    nextJourney.resolve(cloneJourney('work'))
-    await settle()
-    expect(hudTexts(wrapper)[0]).toBe('work')
-
-    initial.resolve(cloneJourney('default'))
-    await settle()
-    expect(hudTexts(wrapper)[0]).toBe('work')
-  })
-
-  it('bootstraps listeners, observer, and renderer from the replacement profile request while the initial request is still pending', async () => {
+  it('clears old data on profile change and ignores stale request completions', async () => {
     const initial = deferred<JourneyResponse>()
     const replacement = deferred<JourneyResponse>()
-    const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
     fetchJourneyGraphMock
       .mockReturnValueOnce(initial.promise)
       .mockReturnValueOnce(replacement.promise)
@@ -334,358 +273,107 @@ describe('JourneyView interactions', () => {
 
     useProfilesStore().activeProfileName = 'work'
     await nextTick()
-
-    expect(fetchJourneyGraphMock).toHaveBeenCalledTimes(2)
+    expect(hudTexts(wrapper)).toEqual(['-', '0 journey.nodes', '0 journey.edges'])
 
     replacement.resolve(cloneJourney('work'))
     await settle()
-
-    expect(hudTexts(wrapper)).toEqual(['work', '2 journey.nodes', '1 journey.edges'])
-    expect(countWindowEventCalls(addEventListenerSpy, 'resize')).toBe(1)
-    expect(resizeObserverInstances).toHaveLength(1)
-    expect(resizeObserverInstances[0].observe).toHaveBeenCalledTimes(1)
-    expect(requestAnimationFrameMock).toHaveBeenCalledTimes(1)
-    expect(cancelAnimationFrameMock).not.toHaveBeenCalled()
+    expect(hudTexts(wrapper)[0]).toBe('work')
 
     initial.resolve(cloneJourney('default'))
     await settle()
-
-    expect(hudTexts(wrapper)).toEqual(['work', '2 journey.nodes', '1 journey.edges'])
-    expect(countWindowEventCalls(addEventListenerSpy, 'resize')).toBe(1)
-    expect(resizeObserverInstances).toHaveLength(1)
-    expect(resizeObserverInstances[0].observe).toHaveBeenCalledTimes(1)
-    expect(requestAnimationFrameMock).toHaveBeenCalledTimes(1)
-    expect(cancelAnimationFrameMock).not.toHaveBeenCalled()
+    expect(hudTexts(wrapper)[0]).toBe('work')
   })
 
-  it('toggles playback from play to pause', async () => {
-    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout')
-    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney('default'))
-
+  it('toggles chronological playback and progressively reveals the graph', async () => {
+    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney())
     const wrapper = mountPanel()
     await settle()
-
+    const vm = wrapper.vm as any
     const playButton = wrapper.get('[aria-label="journey.play"]')
-    await playButton.trigger('click')
-    await nextTick()
-    expect((wrapper.vm as any).playing).toBe(true)
 
     await playButton.trigger('click')
     await nextTick()
-    expect((wrapper.vm as any).playing).toBe(false)
-    expect(clearTimeoutSpy).toHaveBeenCalled()
-  })
-
-  it('resets drawer, selection, and playback immediately on profile change', async () => {
-    const nextJourney = deferred<JourneyResponse>()
-    fetchJourneyGraphMock
-      .mockResolvedValueOnce(cloneJourney('default'))
-      .mockReturnValueOnce(nextJourney.promise)
-
-    const wrapper = mountPanel()
-    await settle()
-
-    const vm = wrapper.vm as any
-    await wrapper.get('[aria-label="journey.play"]').trigger('click')
-    Object.assign(vm, {
-      selectedId: cloneJourney().graph.nodes[0].id,
-      detailDrawerOpen: true,
-    })
-    await nextTick()
-
     expect(vm.playing).toBe(true)
-    expect(wrapper.find('.n-drawer-stub').exists()).toBe(true)
+    expect(vm.visibleNodes).toHaveLength(1)
+    expect(vm.flowEdges).toHaveLength(0)
 
-    useProfilesStore().activeProfileName = 'work'
+    vi.advanceTimersByTime(150)
     await nextTick()
+    expect(vm.visibleNodes).toHaveLength(2)
+    expect(vm.flowEdges).toHaveLength(1)
 
+    await playButton.trigger('click')
     expect(vm.playing).toBe(false)
-    expect(vm.selectedId).toBe('')
-    expect(vm.detailDrawerOpen).toBe(false)
-    expect(wrapper.find('.n-drawer-stub').exists()).toBe(false)
-
-    nextJourney.resolve(cloneJourney('work'))
-    await settle()
   })
 
-  it('does not create listeners or renderer resources if unmounted before the initial request resolves', async () => {
-    const initial = deferred<JourneyResponse>()
-    const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
-    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
-    fetchJourneyGraphMock.mockReturnValueOnce(initial.promise)
-
-    const wrapper = mountPanel()
-    await nextTick()
-    wrapper.unmount()
-
-    initial.resolve(cloneJourney('default'))
-    await settle()
-
-    expect(addEventListenerSpy).not.toHaveBeenCalledWith('resize', expect.any(Function))
-    expect(removeEventListenerSpy).not.toHaveBeenCalledWith('resize', expect.any(Function))
-    expect(resizeObserverInstances).toHaveLength(0)
-    expect(requestAnimationFrameMock).not.toHaveBeenCalled()
-    expect(cancelAnimationFrameMock).not.toHaveBeenCalled()
-  })
-
-  it('cleans installed listeners, observer, raf, and timer on normal unmount', async () => {
-    const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
-    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
-    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout')
-    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney('default'))
-
+  it('highlights a selected node, its direct neighbor, and only their edge', async () => {
+    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney())
     const wrapper = mountPanel()
     await settle()
-
-    expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function))
-    expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
-    expect(resizeObserverInstances).toHaveLength(1)
-    expect(resizeObserverInstances[0].observe).toHaveBeenCalledTimes(1)
-    expect(requestAnimationFrameMock).toHaveBeenCalledTimes(1)
-
-    await wrapper.get('[aria-label="journey.play"]').trigger('click')
-    await nextTick()
-    const clearCountBeforeUnmount = clearTimeoutSpy.mock.calls.length
-
-    wrapper.unmount()
-
-    expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function))
-    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
-    expect(resizeObserverInstances[0].disconnect).toHaveBeenCalledTimes(1)
-    expect(cancelAnimationFrameMock).toHaveBeenCalledTimes(1)
-    expect(clearTimeoutSpy.mock.calls.length).toBeGreaterThan(clearCountBeforeUnmount)
-  })
-
-  it('keeps the graph usable when optional skill metadata fails', async () => {
-    fetchSkillsMock.mockRejectedValueOnce(new Error('metadata unavailable'))
-    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney('default'))
-
-    const wrapper = mountPanel()
-    await settle()
-
-    expect(hudTexts(wrapper)).toEqual(['default', '2 journey.nodes', '1 journey.edges'])
-    expect(fetchSkillsMock).not.toHaveBeenCalled()
     const vm = wrapper.vm as any
-    const canvas = wrapper.get('.galaxy-canvas')
-    const skill = vm.projectedVisibleNodes().find((node: any) => node.kind === 'skill')
-    dispatchPointerEvent(canvas.element, 'pointermove', {
-      pointerId: 17,
-      pointerType: 'mouse',
-      clientX: skill.sx,
-      clientY: skill.sy,
-    })
-    vi.advanceTimersByTime(249)
+
+    await nodeCard(wrapper, 'Redacted Memory').trigger('click')
     await nextTick()
+
+    const memory = vm.flowNodes.find((node: any) => node.id === 'memory:0')
+    const skill = vm.flowNodes.find((node: any) => node.id === 'skill:redacted-0')
+    expect(memory.data.active).toBe(true)
+    expect(skill.data.related).toBe(true)
+    expect(vm.flowEdges[0].style.opacity).toBe(0.95)
+    expect(wrapper.find('.n-drawer-stub').exists()).toBe(true)
+    expect(wrapper.get('.n-drawer-stub').text()).toContain('Redacted memory body for fixture coverage.')
+  })
+
+  it('opens skill details and lazily resolves the skill description', async () => {
+    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney())
+    const wrapper = mountPanel()
+    await settle()
+
     expect(fetchSkillsMock).not.toHaveBeenCalled()
-    vi.advanceTimersByTime(1)
+    await nodeCard(wrapper, 'Redacted Skill').trigger('click')
     await settle()
 
     expect(fetchSkillsMock).toHaveBeenCalledTimes(1)
-    expect(messageMock.error).not.toHaveBeenCalled()
-    expect(vm.skillDescriptions.size).toBe(0)
-  })
-
-  it('ignores stale skill metadata after a profile switch', async () => {
-    const firstSkills = deferred<any>()
-    const secondSkills = deferred<any>()
-    fetchSkillsMock
-      .mockReturnValueOnce(firstSkills.promise)
-      .mockReturnValueOnce(secondSkills.promise)
-    fetchJourneyGraphMock
-      .mockResolvedValueOnce(cloneJourney('default'))
-      .mockResolvedValueOnce(cloneJourney('work'))
-
-    const wrapper = mountPanel()
-    await settle()
-    const vm = wrapper.vm as any
-    const defaultSkill = vm.visibleSceneNodes.find((node: any) => node.kind === 'skill')
-    expect(fetchSkillsMock).not.toHaveBeenCalled()
-    vm.updateNodeHover({ ...defaultSkill, sx: 120, sy: 140, depth: 0, size: 8, visible: true }, { x: 120, y: 140 })
-    vi.advanceTimersByTime(250)
-    await nextTick()
-    expect(fetchSkillsMock).toHaveBeenCalledTimes(1)
-
-    useProfilesStore().activeProfileName = 'work'
-    await settle()
-    const workSkill = vm.visibleSceneNodes.find((node: any) => node.kind === 'skill')
-    vm.updateNodeHover({ ...workSkill, sx: 130, sy: 150, depth: 0, size: 8, visible: true }, { x: 130, y: 150 })
-    vi.advanceTimersByTime(250)
-    await nextTick()
-    expect(fetchSkillsMock).toHaveBeenCalledTimes(2)
-
-    secondSkills.resolve({
-      categories: [{ name: 'research', description: '', skills: [{ name: 'Redacted Skill', description: 'work profile description' }] }],
-      archived: [],
-    })
-    await settle()
-    expect(vm.skillDescription(workSkill)).toBe('work profile description')
-
-    firstSkills.resolve({
-      categories: [{ name: 'research', description: '', skills: [{ name: 'Redacted Skill', description: 'stale default description' }] }],
-      archived: [],
-    })
-    await settle()
-    expect(vm.skillDescription(workSkill)).toBe('work profile description')
-  })
-
-  it('does not load skill metadata when hover ends before the preview appears', async () => {
-    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney('default'))
-    const wrapper = mountPanel()
-    await settle()
-    const vm = wrapper.vm as any
-    const canvas = wrapper.get('.galaxy-canvas')
-    const skill = vm.projectedVisibleNodes().find((node: any) => node.kind === 'skill')
-
-    dispatchPointerEvent(canvas.element, 'pointermove', {
-      pointerId: 18,
-      pointerType: 'mouse',
-      clientX: skill.sx,
-      clientY: skill.sy,
-    })
-    vi.advanceTimersByTime(249)
-    dispatchPointerEvent(canvas.element, 'pointermove', {
-      pointerId: 18,
-      pointerType: 'mouse',
-      clientX: -1000,
-      clientY: -1000,
-    })
-    vi.advanceTimersByTime(1)
-    await settle()
-
-    expect(vm.hoverTipId).toBe('')
-    expect(fetchSkillsMock).not.toHaveBeenCalled()
-  })
-
-  it('does not restart the 250ms preview delay while the pointer remains on one node', async () => {
-    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney('default'))
-    const wrapper = mountPanel()
-    await settle()
-    const vm = wrapper.vm as any
-    const hit = { ...vm.visibleSceneNodes[0], sx: 120, sy: 140, depth: 0, size: 8, visible: true }
-
-    vm.updateNodeHover(hit, { x: 120, y: 140 })
-    vi.advanceTimersByTime(100)
-    vm.updateNodeHover(hit, { x: 122, y: 141 })
-    vi.advanceTimersByTime(149)
-    expect(vm.hoverTipId).toBe('')
-    vi.advanceTimersByTime(1)
-    await nextTick()
-    expect(vm.hoverTipId).toBe(hit.id)
-  })
-
-  it('preserves category selection after a canvas pan but clears it on a later blank click', async () => {
-    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney('default'))
-    const wrapper = mountPanel()
-    await settle()
-    await wrapper.findAll('[data-category="research"]')[1].trigger('click')
-    const canvas = wrapper.get('.galaxy-canvas')
-    Object.assign(canvas.element, {
-      setPointerCapture: vi.fn(),
-      hasPointerCapture: vi.fn(() => true),
-      releasePointerCapture: vi.fn(),
-    })
-    const vm = wrapper.vm as any
-
-    vm.handlePointerDown({ pointerId: 1, clientX: 100, clientY: 100 })
-    vm.handlePointerMove({ pointerId: 1, clientX: 130, clientY: 100 })
-    vm.handlePointerUp({ pointerId: 1, clientX: 130, clientY: 100 })
-    vm.handleClick({ clientX: -1000, clientY: -1000 })
-    await nextTick()
-    expect(vm.selectedCategories).toEqual(['research'])
-
-    vi.advanceTimersByTime(201)
-    vm.handleClick({ clientX: -1000, clientY: -1000 })
-    await nextTick()
-    expect(vm.selectedCategories).toEqual([])
-  })
-
-  it('clears pending previews during pinch cancel and recovers cleanly for later pointer hover', async () => {
-    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney('default'))
-    const wrapper = mountPanel()
-    await settle()
-    const canvas = wrapper.get('.galaxy-canvas')
-    Object.assign(canvas.element, {
-      setPointerCapture: vi.fn(),
-      hasPointerCapture: vi.fn(() => true),
-      releasePointerCapture: vi.fn(),
-    })
-    const vm = wrapper.vm as any
-    const skill = vm.projectedVisibleNodes().find((node: any) => node.kind === 'skill')
-
-    dispatchPointerEvent(canvas.element, 'pointermove', {
-      pointerId: 20,
-      pointerType: 'mouse',
-      clientX: skill.sx,
-      clientY: skill.sy,
-    })
-    vi.advanceTimersByTime(100)
-    dispatchPointerEvent(canvas.element, 'pointerdown', { pointerId: 21, pointerType: 'touch', clientX: skill.sx, clientY: skill.sy })
-    dispatchPointerEvent(canvas.element, 'pointerdown', { pointerId: 22, pointerType: 'touch', clientX: skill.sx + 30, clientY: skill.sy })
-    dispatchPointerEvent(canvas.element, 'pointermove', { pointerId: 22, pointerType: 'touch', clientX: skill.sx + 60, clientY: skill.sy })
-    vi.advanceTimersByTime(300)
-    await nextTick()
-    expect(vm.hoverTipId).toBe('')
-    expect(fetchSkillsMock).not.toHaveBeenCalled()
-
-    dispatchPointerEvent(canvas.element, 'pointercancel', { pointerId: 22, pointerType: 'touch', clientX: skill.sx + 60, clientY: skill.sy })
-    const recoveredSkill = vm.projectedVisibleNodes().find((node: any) => node.id === skill.id)
-    dispatchPointerEvent(canvas.element, 'pointermove', {
-      pointerId: 23,
-      pointerType: 'mouse',
-      clientX: recoveredSkill.sx,
-      clientY: recoveredSkill.sy,
-    })
-    vi.advanceTimersByTime(250)
-    await settle()
-    expect(vm.hoverTipId).toBe(recoveredSkill.id)
-    expect(fetchSkillsMock).toHaveBeenCalledTimes(1)
-  })
-
-  it('supports keyboard node preview and exposes skill descriptions in the detail drawer', async () => {
-    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney('default'))
-    const wrapper = mountPanel()
-    await settle()
-    const canvas = wrapper.get('.galaxy-canvas')
-
-    expect(canvas.attributes('tabindex')).toBe('0')
-    expect(canvas.attributes('aria-label')).toContain('journey.canvasInstructions')
-    expect(fetchSkillsMock).not.toHaveBeenCalled()
-    await canvas.trigger('keydown', { key: 'ArrowRight' })
-    await settle()
-    expect(fetchSkillsMock).toHaveBeenCalledTimes(1)
-    expect(wrapper.get('.journey-node-tooltip__name').text()).toBe('Redacted Skill')
-
-    await canvas.trigger('keydown', { key: 'Enter' })
-    await nextTick()
     expect(wrapper.get('.n-drawer-stub').text()).toContain('A reusable redacted skill description.')
   })
 
-  it('uses a stable general key while localizing the label for uncategorized nodes', async () => {
-    const response = cloneJourney()
-    delete (response.graph.nodes[0] as { category?: string }).category
-    fetchJourneyGraphMock.mockResolvedValue(response)
-
+  it('loads hover metadata after 250ms and cancels it when the pointer leaves', async () => {
+    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney())
     const wrapper = mountPanel()
     await settle()
-    const controls = wrapper.findAll('[data-category="general"]')
+    const skillCard = nodeCard(wrapper, 'Redacted Skill')
 
-    expect(controls).toHaveLength(2)
-    expect(controls[1].text()).toContain('journey.noCategory')
-    await controls[1].trigger('click')
-    expect(controls.every(control => control.attributes('aria-pressed') === 'true')).toBe(true)
-    expect((wrapper.vm as any).selectedCategories).toEqual(['general'])
-    expect((wrapper.vm as any).emphasizedCategorySet.has('general')).toBe(true)
+    await skillCard.trigger('mouseenter', { clientX: 400, clientY: 240 })
+    vi.advanceTimersByTime(249)
+    await nextTick()
+    expect(fetchSkillsMock).not.toHaveBeenCalled()
 
-    wrapper.unmount()
+    vi.advanceTimersByTime(1)
+    await settle()
+    expect(fetchSkillsMock).toHaveBeenCalledTimes(1)
+    expect(wrapper.get('.journey-node-tooltip__name').text()).toBe('Redacted Skill')
+    expect(wrapper.get('.journey-node-tooltip__description').text()).toContain('A reusable redacted skill description.')
+
+    await skillCard.trigger('mouseleave')
+    expect(wrapper.find('.journey-node-tooltip').exists()).toBe(false)
+
+    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney())
+    const secondWrapper = mountPanel()
+    await settle()
+    const secondSkill = nodeCard(secondWrapper, 'Redacted Skill')
+    await secondSkill.trigger('mouseenter', { clientX: 400, clientY: 240 })
+    vi.advanceTimersByTime(100)
+    await secondSkill.trigger('mouseleave')
+    vi.advanceTimersByTime(200)
+    await settle()
+    expect(secondWrapper.find('.journey-node-tooltip').exists()).toBe(false)
   })
 
-  it('toggles multiple categories by default without a selection-mode switch', async () => {
-    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney('default'))
+  it('supports multi-category emphasis and clears it from the blank pane', async () => {
+    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney())
     const wrapper = mountPanel()
     await settle()
-
-    expect(wrapper.find('.selection-mode').exists()).toBe(false)
-    expect(wrapper.findAll('[data-selection-mode]')).toHaveLength(0)
+    const vm = wrapper.vm as any
 
     const researchControls = wrapper.findAll('[data-category="research"]')
     const journalControls = wrapper.findAll('[data-category="journal"]')
@@ -694,260 +382,117 @@ describe('JourneyView interactions', () => {
 
     await researchControls[1].trigger('click')
     await journalControls[0].trigger('click')
+    expect(vm.selectedCategories).toEqual(['research', 'journal'])
     expect(researchControls.every(control => control.attributes('aria-pressed') === 'true')).toBe(true)
     expect(journalControls.every(control => control.attributes('aria-pressed') === 'true')).toBe(true)
-    expect((wrapper.vm as any).selectedCategories).toEqual(['research', 'journal'])
 
-    await researchControls[0].trigger('click')
-    expect(researchControls.every(control => control.attributes('aria-pressed') === 'false')).toBe(true)
-    expect(journalControls.every(control => control.attributes('aria-pressed') === 'true')).toBe(true)
-
-    await wrapper.get('.galaxy-canvas').trigger('click', { clientX: -1000, clientY: -1000 })
-    expect((wrapper.vm as any).selectedCategories).toEqual([])
-    expect(journalControls.every(control => control.attributes('aria-pressed') === 'false')).toBe(true)
+    await wrapper.get('.vue-flow-stub').trigger('click')
+    expect(vm.selectedCategories).toEqual([])
   })
 
-  it('renders and hit-tests skill circles and memory diamonds through production helpers', async () => {
-    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney('default'))
+  it('uses a stable general category key while localizing its label', async () => {
+    const response = cloneJourney()
+    delete (response.graph.nodes[0] as { category?: string }).category
+    fetchJourneyGraphMock.mockResolvedValueOnce(response)
+
     const wrapper = mountPanel()
     await settle()
-    const vm = wrapper.vm as any
-    const skill = {
-      ...vm.visibleSceneNodes.find((node: any) => node.kind === 'skill'),
-      sx: 100,
-      sy: 100,
-      depth: 0,
-      size: 10,
-      visible: true,
-    }
-    const memory = {
-      ...vm.visibleSceneNodes.find((node: any) => node.kind === 'memory'),
-      sx: 100,
-      sy: 100,
-      depth: 0,
-      size: 10,
-      visible: true,
-    }
-    const canvasSpies = canvasContext as unknown as {
-      arc: ReturnType<typeof vi.fn>
-      moveTo: ReturnType<typeof vi.fn>
-      lineTo: ReturnType<typeof vi.fn>
-    }
+    const controls = wrapper.findAll('[data-category="general"]')
 
-    canvasSpies.arc.mockClear()
-    canvasSpies.moveTo.mockClear()
-    canvasSpies.lineTo.mockClear()
-    vm.traceNodeShape(memory)
-    expect(canvasSpies.moveTo).toHaveBeenCalledWith(100, 87)
-    expect(canvasSpies.lineTo.mock.calls).toEqual([
-      [111.2, 100],
-      [100, 113],
-      [88.8, 100],
-      [100, 87],
-    ])
-    expect(canvasSpies.arc).not.toHaveBeenCalled()
-
-    canvasSpies.arc.mockClear()
-    canvasSpies.lineTo.mockClear()
-    vm.traceNodeShape(skill)
-    expect(canvasSpies.arc).toHaveBeenCalledWith(100, 100, 10, 0, Math.PI * 2)
-    expect(canvasSpies.lineTo).not.toHaveBeenCalled()
-
-    canvasSpies.arc.mockClear()
-    canvasSpies.lineTo.mockClear()
-    vm.drawNode(memory, new Set([memory.id]), new Set(), new Set(), new Set(), 1000)
-    expect(canvasSpies.lineTo.mock.calls.length).toBeGreaterThanOrEqual(16)
-    expect(canvasSpies.arc).not.toHaveBeenCalled()
-
-    const cornerOffset = (memory.size + 8) * 0.7
-    expect(vm.pointHitsNode(memory, 100, 100)).toBe(true)
-    expect(vm.pointHitsNode(memory, 100 + cornerOffset, 100 + cornerOffset)).toBe(false)
-    expect(vm.pointHitsNode(skill, 100 + cornerOffset, 100 + cornerOffset)).toBe(true)
-    expect(wrapper.get('.node-kind-marker--skill').classes()).toContain('node-kind-marker--circle')
-    expect(wrapper.get('.node-kind-marker--memory').classes()).toContain('node-kind-marker--diamond')
+    expect(controls).toHaveLength(2)
+    expect(controls[1].text()).toContain('journey.noCategory')
+    await controls[1].trigger('click')
+    expect((wrapper.vm as any).selectedCategories).toEqual(['general'])
   })
 
-  it('stops active playback on Escape from toolbar, canvas, category, and drawer focus', async () => {
-    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney('default'))
+  it('supports keyboard preview and opening details from the graph surface', async () => {
+    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney())
     const wrapper = mountPanel()
     await settle()
-    const vm = wrapper.vm as any
-    const playButton = wrapper.findAll('.n-button-stub')[0]
-    const playElement = playButton.element as HTMLButtonElement
-    const canvasElement = wrapper.get('.galaxy-canvas').element as HTMLCanvasElement
-    const categoryElement = wrapper.findAll('[data-category="research"]')[1].element as HTMLButtonElement
-    document.body.appendChild(wrapper.element)
+    const graph = wrapper.get('.journey-graph-wrap')
 
-    const expectEscapeStopsPlayback = async (target: HTMLElement) => {
-      target.focus()
-      expect(document.activeElement).toBe(target)
-      expect(vm.playing).toBe(true)
-      expect(vm.selectedId).not.toBe('')
-      const escapeEvent = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
-      target.dispatchEvent(escapeEvent)
-      await nextTick()
-      expect(escapeEvent.defaultPrevented).toBe(true)
-      expect(vm.playing).toBe(false)
-      expect(vm.selectedId).toBe('')
-    }
-
-    await playButton.trigger('click')
-    await expectEscapeStopsPlayback(playElement)
-
-    vm.togglePlayback()
-    await nextTick()
-    await expectEscapeStopsPlayback(canvasElement)
-
-    vm.togglePlayback()
-    await nextTick()
-    await expectEscapeStopsPlayback(categoryElement)
-
-    const skill = vm.visibleSceneNodes.find((node: any) => node.kind === 'skill')
-    vm.openNodeDetails(skill.id)
-    await nextTick()
-    const drawerElement = wrapper.get('.n-drawer-stub').element as HTMLElement
-    drawerElement.tabIndex = 0
-    vm.togglePlayback()
-    await nextTick()
-    await expectEscapeStopsPlayback(drawerElement)
-
-    vi.advanceTimersByTime(500)
-    await nextTick()
-    expect(vm.playing).toBe(false)
-    expect(vm.selectedId).toBe('')
-  })
-
-  it('rehydrates an open skill description after refreshing the graph', async () => {
-    fetchJourneyGraphMock
-      .mockResolvedValueOnce(cloneJourney('default'))
-      .mockResolvedValueOnce(cloneJourney('default'))
-    const wrapper = mountPanel()
+    expect(graph.attributes('tabindex')).toBe('0')
+    expect(graph.attributes('aria-label')).toContain('journey.canvasInstructions')
+    await graph.trigger('keydown', { key: 'ArrowRight' })
     await settle()
-    const canvas = wrapper.get('.galaxy-canvas')
 
-    await canvas.trigger('keydown', { key: 'ArrowRight' })
-    await settle()
-    await canvas.trigger('keydown', { key: 'Enter' })
-    await nextTick()
-    expect(wrapper.get('.n-drawer-stub').text()).toContain('A reusable redacted skill description.')
+    expect(wrapper.get('.journey-node-tooltip__name').text()).toBe('Redacted Skill')
     expect(fetchSkillsMock).toHaveBeenCalledTimes(1)
 
-    await wrapper.findAll('.n-button-stub').at(-1)!.trigger('click')
-    await settle()
-    expect(fetchJourneyGraphMock).toHaveBeenCalledTimes(2)
-    expect(fetchSkillsMock).toHaveBeenCalledTimes(2)
+    await graph.trigger('keydown', { key: 'Enter' })
+    await nextTick()
     expect(wrapper.get('.n-drawer-stub').text()).toContain('A reusable redacted skill description.')
   })
 
-  it('rehydrates a visible keyboard preview after refreshing the graph', async () => {
+  it('resets playback, drawer, categories, and selection when the profile changes', async () => {
     fetchJourneyGraphMock
-      .mockResolvedValueOnce(cloneJourney('default'))
-      .mockResolvedValueOnce(cloneJourney('default'))
-    const wrapper = mountPanel()
-    await settle()
-    const canvas = wrapper.get('.galaxy-canvas')
-
-    await canvas.trigger('keydown', { key: 'ArrowRight' })
-    await settle()
-    expect(wrapper.get('.journey-node-tooltip__description').text()).toContain('A reusable redacted skill description.')
-    expect(fetchSkillsMock).toHaveBeenCalledTimes(1)
-
-    await wrapper.findAll('.n-button-stub').at(-1)!.trigger('click')
-    await settle()
-    expect(fetchSkillsMock).toHaveBeenCalledTimes(2)
-    expect(wrapper.get('.journey-node-tooltip__description').text()).toContain('A reusable redacted skill description.')
-  })
-
-  it('does not load skill metadata when refresh follows a playback-only selection', async () => {
-    fetchJourneyGraphMock
-      .mockResolvedValueOnce(cloneJourney('default'))
-      .mockResolvedValueOnce(cloneJourney('default'))
-    const wrapper = mountPanel()
-    await settle()
-    const vm = wrapper.vm as any
-    const playButton = wrapper.findAll('.n-button-stub')[0]
-
-    await playButton.trigger('click')
-    if (vm.nodeById.get(vm.selectedId)?.kind !== 'skill') {
-      vi.advanceTimersByTime(150)
-      await nextTick()
-    }
-    expect(vm.nodeById.get(vm.selectedId)?.kind).toBe('skill')
-    await playButton.trigger('click')
-    expect(vm.playing).toBe(false)
-    expect(vm.detailDrawerOpen).toBe(false)
-    expect(vm.hoverTipId).toBe('')
-
-    await wrapper.findAll('.n-button-stub').at(-1)!.trigger('click')
-    await settle()
-    expect(fetchJourneyGraphMock).toHaveBeenCalledTimes(2)
-    expect(fetchSkillsMock).not.toHaveBeenCalled()
-  })
-
-  it('keeps a valid category selected across refresh and clears it on profile reset', async () => {
-    fetchJourneyGraphMock
-      .mockResolvedValueOnce(cloneJourney('default'))
-      .mockResolvedValueOnce(cloneJourney('default'))
+      .mockResolvedValueOnce(cloneJourney())
       .mockResolvedValueOnce(cloneJourney('work'))
-
     const wrapper = mountPanel()
     await settle()
-    await wrapper.findAll('[data-category="research"]')[1].trigger('click')
+    const vm = wrapper.vm as any
 
-    await wrapper.findAll('.n-button-stub').at(-1)!.trigger('click')
-    await settle()
-    expect((wrapper.vm as any).selectedCategories).toEqual(['research'])
+    await nodeCard(wrapper, 'Redacted Skill').trigger('click')
+    await wrapper.findAll('[data-category="research"]')[1].trigger('click')
+    await wrapper.get('[aria-label="journey.play"]').trigger('click')
+    await nextTick()
 
     useProfilesStore().activeProfileName = 'work'
     await settle()
-    expect((wrapper.vm as any).selectedCategories).toEqual([])
+
+    expect(vm.playing).toBe(false)
+    expect(vm.selectedId).toBe('')
+    expect(vm.selectedCategories).toEqual([])
+    expect(vm.detailDrawerOpen).toBe(false)
+    expect(hudTexts(wrapper)[0]).toBe('work')
   })
 
-  it('renders the recycled bounded hover preview for skill and memory nodes', async () => {
-    const hiddenTail = 'TAIL-MARKER-XYZ'
-    fetchSkillsMock.mockResolvedValueOnce({
-      categories: [{
-        name: 'research',
-        description: '',
-        skills: [{
-          name: 'Redacted Skill',
-          description: `  ${'🙂'.repeat(150)}  ${hiddenTail}`,
-          enabled: true,
-        }],
-      }, {
-        name: 'journal',
-        description: '',
-        skills: [{
-          name: 'Redacted Skill',
-          description: 'WRONG duplicate-category description',
-          enabled: true,
-        }],
-      }],
-      archived: [],
-    })
-    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney('default'))
+  it('rehydrates an open skill description after refresh', async () => {
+    fetchJourneyGraphMock
+      .mockResolvedValueOnce(cloneJourney())
+      .mockResolvedValueOnce(cloneJourney())
     const wrapper = mountPanel()
     await settle()
-    const vm = wrapper.vm as any
-    const skill = vm.visibleSceneNodes.find((node: any) => node.kind === 'skill')
 
-    expect(fetchSkillsMock).not.toHaveBeenCalled()
-    vm.updateNodeHover({ ...skill, sx: 320, sy: 240, depth: 0, size: 8, visible: true }, { x: 320, y: 240 })
-    vi.advanceTimersByTime(250)
+    await nodeCard(wrapper, 'Redacted Skill').trigger('click')
+    await settle()
+    expect(fetchSkillsMock).toHaveBeenCalledTimes(1)
+
+    await wrapper.findAll('.n-button-stub').at(-1)!.trigger('click')
+    await settle()
+    expect(fetchSkillsMock).toHaveBeenCalledTimes(2)
+    expect(wrapper.get('.n-drawer-stub').text()).toContain('A reusable redacted skill description.')
+  })
+
+  it('keeps the graph usable when optional skill metadata fails', async () => {
+    fetchSkillsMock.mockRejectedValueOnce(new Error('metadata unavailable'))
+    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney())
+    const wrapper = mountPanel()
     await settle()
 
-    expect(fetchSkillsMock).toHaveBeenCalledTimes(1)
-    expect(wrapper.get('.journey-node-tooltip__name').text()).toBe('Redacted Skill')
-    const preview = wrapper.get('.journey-node-tooltip__description').text()
-    expect(Array.from(preview)).toHaveLength(140)
-    expect(preview.endsWith('…')).toBe(true)
-    expect(preview).not.toContain(hiddenTail)
-    expect(preview).not.toContain('WRONG')
+    await nodeCard(wrapper, 'Redacted Skill').trigger('click')
+    await settle()
 
-    const memory = vm.visibleSceneNodes.find((node: any) => node.kind === 'memory')
-    vm.updateNodeHover({ ...memory, sx: 340, sy: 250, depth: 0, size: 8, visible: true }, { x: 340, y: 250 })
-    vi.advanceTimersByTime(250)
-    await nextTick()
-    expect(wrapper.get('.journey-node-tooltip__description').text()).toBe('Redacted memory body for fixture coverage.')
+    expect(wrapper.find('.n-drawer-stub').exists()).toBe(true)
+    expect(messageMock.error).not.toHaveBeenCalled()
+  })
+
+  it('cleans up window listeners and pending timers on unmount', async () => {
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout')
+    fetchJourneyGraphMock.mockResolvedValueOnce(cloneJourney())
+    const wrapper = mountPanel()
+    await settle()
+
+    await wrapper.get('[aria-label="journey.play"]').trigger('click')
+    await nodeCard(wrapper, 'Redacted Skill').trigger('mouseenter', { clientX: 400, clientY: 240 })
+    wrapper.unmount()
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
+    expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function))
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function))
+    expect(clearTimeoutSpy).toHaveBeenCalled()
   })
 })

--- a/tests/e2e/journey-interactions.spec.ts
+++ b/tests/e2e/journey-interactions.spec.ts
@@ -139,10 +139,12 @@ async function expectJourneySurface(page: Page) {
   await expect(page.getByRole('heading', { name: 'Skills', exact: true })).toHaveCount(0)
   await expect(page.getByRole('tab', { name: /^Library$/ })).toHaveCount(0)
   await expect(page.getByRole('tab', { name: /^Journey$/ })).toHaveCount(0)
-  await expect(page.locator('.galaxy-canvas')).toBeVisible()
-  await expect(page.locator('.galaxy-hud')).toContainText(PROFILE_NAME)
-  await expect(page.locator('.node-kind-marker--skill.node-kind-marker--circle')).toBeVisible()
-  await expect(page.locator('.node-kind-marker--memory.node-kind-marker--diamond')).toBeVisible()
+  await expect(page.locator('.journey-graph-wrap')).toBeVisible()
+  await expect(page.locator('.journey-hud')).toContainText(PROFILE_NAME)
+  await expect(page.locator('.node-kind-marker--skill')).toBeVisible()
+  await expect(page.locator('.node-kind-marker--memory')).toBeVisible()
+  await expect(page.locator('.journey-node')).toHaveCount(journeyPayload.graph.nodes.length)
+  await expect(page.locator('.vue-flow__edge')).toHaveCount(journeyPayload.graph.edges.length)
   await expect(page.locator('aside.sidebar').getByRole('link', { name: /^Journey$/ })).toBeVisible()
 }
 
@@ -162,7 +164,7 @@ test('standalone Journey route renders under Monitoring and defers Skills-only A
   await expect(playButton).toBeVisible()
 
   await playButton.click()
-  await page.locator('.galaxy-canvas').focus()
+  await page.locator('.journey-graph-wrap').focus()
   await page.keyboard.press('Escape')
   await expect(playButton).toBeVisible()
 
@@ -180,13 +182,14 @@ test('category controls toggle multi-selection by default and nodes expose descr
   await expect(page.locator('.selection-mode')).toHaveCount(0)
   await expect(page.locator('[data-selection-mode]')).toHaveCount(0)
 
-  const canvas = page.locator('.galaxy-canvas')
+  const graph = page.locator('.journey-graph-wrap')
+  const pane = page.locator('.vue-flow__pane')
   const basicsBar = page.locator('.category-bar [data-category="basics"]')
   const basicsPill = page.locator('.category-legend [data-category="basics"]')
   const automationBar = page.locator('.category-bar [data-category="automation"]')
   const automationPill = page.locator('.category-legend [data-category="automation"]')
-  await expect(basicsBar).toHaveCSS('height', '24px')
-  expect((await basicsBar.boundingBox())!.width).toBeGreaterThanOrEqual(24)
+  await expect(basicsBar).toHaveCSS('height', '10px')
+  expect((await basicsBar.boundingBox())!.width).toBeGreaterThanOrEqual(10)
 
   await basicsBar.click()
   await automationPill.click()
@@ -195,7 +198,7 @@ test('category controls toggle multi-selection by default and nodes expose descr
   await expect(automationBar).toHaveAttribute('aria-pressed', 'true')
   await expect(automationPill).toHaveAttribute('aria-pressed', 'true')
 
-  const box = await canvas.boundingBox()
+  const box = await graph.boundingBox()
   expect(box).not.toBeNull()
   await page.mouse.move(box!.x + 20, box!.y + box!.height - 20)
   await page.mouse.down()
@@ -208,11 +211,11 @@ test('category controls toggle multi-selection by default and nodes expose descr
   await expect(basicsBar).toHaveAttribute('aria-pressed', 'false')
   await expect(automationPill).toHaveAttribute('aria-pressed', 'true')
 
-  await canvas.click({ position: { x: 8, y: Math.max(8, box!.height - 8) } })
+  await pane.click({ position: { x: 8, y: 8 } })
   await expect(automationPill).toHaveAttribute('aria-pressed', 'false')
   await expectRequestCount(api, '/api/hermes/skills', 0)
 
-  await canvas.focus()
+  await graph.focus()
   await page.keyboard.press('ArrowRight')
   const tooltip = page.getByRole('tooltip')
   await expect(tooltip).toContainText('Redacted memory note')
@@ -230,7 +233,7 @@ test('category controls toggle multi-selection by default and nodes expose descr
   await expectRequestCount(api, '/api/hermes/skills', 2)
   await expect(tooltip).toContainText('Keep prompts precise, scoped, and resistant to untrusted instructions.')
 
-  await canvas.focus()
+  await graph.focus()
   await page.keyboard.press('Enter')
   const drawer = page.locator('.journey-detail-drawer')
   await expect(drawer).toContainText('Keep prompts precise, scoped, and resistant to untrusted instructions.')
@@ -238,74 +241,76 @@ test('category controls toggle multi-selection by default and nodes expose descr
   expect(api.unexpectedRequests).toEqual([])
 })
 
-test('mobile standalone Journey keeps shape legend and default multi-selection usable', async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 844 })
-  const api = await openPage(page, '/#/hermes/journey')
-  await expectJourneySurface(page)
-
-  await expect(page.locator('.sidebar-toggle')).toHaveCount(0)
-  await expect(page.getByTitle('Import')).toHaveCount(0)
-  await expect(page.getByTitle('External dirs')).toHaveCount(0)
-  await expect(page.getByTitle('Pending write approvals')).toHaveCount(0)
-
-  const basics = page.locator('.category-legend [data-category="basics"]')
-  const automation = page.locator('.category-legend [data-category="automation"]')
-  await basics.click()
-  await automation.click()
-  await expect(basics).toHaveAttribute('aria-pressed', 'true')
-  await expect(automation).toHaveAttribute('aria-pressed', 'true')
-
-  const canvas = page.locator('.galaxy-canvas')
-  const box = await canvas.boundingBox()
-  expect(box).not.toBeNull()
-  const cdp = await page.context().newCDPSession(page)
-  const touchPoint = (id: number, x: number, y: number) => ({
-    id,
-    x,
-    y,
-    radiusX: 2,
-    radiusY: 2,
-    force: 1,
+test.describe('mobile Journey interactions', () => {
+  test.use({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    isMobile: true,
   })
 
-  const panStart = touchPoint(1, box!.x + 45, box!.y + box!.height - 90)
-  const panEnd = touchPoint(1, panStart.x + 55, panStart.y - 12)
-  const beforePan = await canvas.screenshot()
-  await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [panStart] })
-  await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [panEnd] })
-  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
-  await canvas.dispatchEvent('click', { clientX: panEnd.x, clientY: panEnd.y })
-  await page.waitForTimeout(50)
-  const afterPan = await canvas.screenshot()
-  expect(afterPan.equals(beforePan)).toBe(false)
-  await expect(basics).toHaveAttribute('aria-pressed', 'true')
-  await expect(automation).toHaveAttribute('aria-pressed', 'true')
+  test('standalone route keeps the relationship legend and default multi-selection usable', async ({ page }) => {
+    const api = await openPage(page, '/#/hermes/journey')
+    await expectJourneySurface(page)
 
-  const pinchLeft = touchPoint(1, box!.x + box!.width * 0.4, box!.y + box!.height * 0.58)
-  const pinchRight = touchPoint(2, box!.x + box!.width * 0.6, box!.y + box!.height * 0.58)
-  const pinchWide = touchPoint(2, box!.x + box!.width * 0.78, pinchRight.y)
-  await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [pinchLeft, pinchRight] })
-  await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [pinchLeft, pinchWide] })
-  await cdp.send('Input.dispatchTouchEvent', { type: 'touchCancel', touchPoints: [] })
-  await page.waitForTimeout(50)
-  const afterPinch = await canvas.screenshot()
-  expect(afterPinch.equals(afterPan)).toBe(false)
-  await expect(basics).toHaveAttribute('aria-pressed', 'true')
-  await expect(automation).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.locator('.sidebar-toggle')).toHaveCount(0)
+    await expect(page.getByTitle('Import')).toHaveCount(0)
+    await expect(page.getByTitle('External dirs')).toHaveCount(0)
+    await expect(page.getByTitle('Pending write approvals')).toHaveCount(0)
 
-  const recoveryStart = touchPoint(3, box!.x + 70, box!.y + box!.height - 120)
-  const recoveryEnd = touchPoint(3, recoveryStart.x - 35, recoveryStart.y - 20)
-  await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [recoveryStart] })
-  await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [recoveryEnd] })
-  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
-  await canvas.dispatchEvent('click', { clientX: recoveryEnd.x, clientY: recoveryEnd.y })
-  await page.waitForTimeout(300)
-  const afterRecovery = await canvas.screenshot()
-  expect(afterRecovery.equals(afterPinch)).toBe(false)
-  await expect(basics).toHaveAttribute('aria-pressed', 'true')
-  await expect(automation).toHaveAttribute('aria-pressed', 'true')
-  await cdp.detach()
+    const basics = page.locator('.category-legend [data-category="basics"]')
+    const automation = page.locator('.category-legend [data-category="automation"]')
+    await basics.click()
+    await automation.click()
+    await expect(basics).toHaveAttribute('aria-pressed', 'true')
+    await expect(automation).toHaveAttribute('aria-pressed', 'true')
 
-  await expectRequestCount(api, '/api/hermes/skills', 0)
-  expect(api.unexpectedRequests).toEqual([])
+    const graph = page.locator('.journey-graph-wrap')
+    const transformPane = page.locator('.vue-flow__transformationpane')
+    const box = await graph.boundingBox()
+    expect(box).not.toBeNull()
+    const cdp = await page.context().newCDPSession(page)
+    const touchPoint = (id: number, x: number, y: number) => ({
+      id,
+      x,
+      y,
+      radiusX: 2,
+      radiusY: 2,
+      force: 1,
+    })
+
+    const panStart = touchPoint(1, box!.x + box!.width * 0.5, box!.y + box!.height - 90)
+    const panEnd = touchPoint(1, panStart.x + 55, panStart.y - 12)
+    const beforePan = await transformPane.getAttribute('style')
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [panStart] })
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [panEnd] })
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+    await expect.poll(() => transformPane.getAttribute('style')).not.toBe(beforePan)
+    const afterPan = await transformPane.getAttribute('style')
+    await expect(basics).toHaveAttribute('aria-pressed', 'true')
+    await expect(automation).toHaveAttribute('aria-pressed', 'true')
+
+    const pinchLeft = touchPoint(1, box!.x + box!.width * 0.4, box!.y + box!.height * 0.58)
+    const pinchRight = touchPoint(2, box!.x + box!.width * 0.6, box!.y + box!.height * 0.58)
+    const pinchWide = touchPoint(2, box!.x + box!.width * 0.78, pinchRight.y)
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [pinchLeft, pinchRight] })
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [pinchLeft, pinchWide] })
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchCancel', touchPoints: [] })
+    await expect.poll(() => transformPane.getAttribute('style')).not.toBe(afterPan)
+    const afterPinch = await transformPane.getAttribute('style')
+    await expect(basics).toHaveAttribute('aria-pressed', 'true')
+    await expect(automation).toHaveAttribute('aria-pressed', 'true')
+
+    const recoveryStart = touchPoint(3, box!.x + 70, box!.y + box!.height - 120)
+    const recoveryEnd = touchPoint(3, recoveryStart.x - 35, recoveryStart.y - 20)
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [recoveryStart] })
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [recoveryEnd] })
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+    await expect.poll(() => transformPane.getAttribute('style')).not.toBe(afterPinch)
+    await expect(basics).toHaveAttribute('aria-pressed', 'true')
+    await expect(automation).toHaveAttribute('aria-pressed', 'true')
+    await cdp.detach()
+
+    await expectRequestCount(api, '/api/hermes/skills', 0)
+    expect(api.unexpectedRequests).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary

- replace the pseudo-random 3D Journey galaxy with a deterministic two-dimensional Memory → Skill relationship map
- keep node labels visible and use direct-neighbor emphasis so selected relationships are easy to follow
- reduce edge crossings with barycentric ordering and wrap long columns horizontally based on the available canvas height
- keep card sizing, borders, and corner radii consistent across Memory and Skill nodes
- preserve playback, category emphasis, keyboard navigation, lazy skill metadata, and the existing detail drawer
- add dedicated layout tests and migrate interaction coverage to the new Vue Flow implementation

## Why

The previous graph placed category clusters around a three-dimensional ring and scattered nodes from ID hashes. Node positions therefore did not communicate their relationships, perspective rotation caused overlap, and rendering every edge at once made dense graphs difficult to scan.

A strict two-column replacement was clearer but could grow excessively tall. The final layout caps rows using the available canvas height and adds horizontal columns as needed, retaining the Memory-to-Skill reading direction without creating an extremely long page.

## Impact

Journey now opens as a readable, pannable relationship map with persistent labels, compact cards, automatic fitting, minimap and zoom controls. Hovering or selecting a node highlights only its direct relationships while unrelated nodes and edges recede. Existing localized copy is reused, so the behavior remains consistent across supported languages.

## Validation

- `npm run test -- tests/client/journey-layout.test.ts tests/client/journey-view-interactions.test.ts` — 19 passed
- `npm run build`
- `npx vite build`
- `npm run harness:check`
