### PR TITLE
fix(i18n): the sidebar profile switcher is not a user list

### DIFF
--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -126,7 +126,7 @@ export default {
     kanban: 'Канбан',
     workflow: 'Рабочий процесс',
     models: 'Модели',
-    profiles: 'Пользователи',
+    profiles: 'Профили',
     plugins: 'Плагины',
     petdex: 'Pets',
     skills: 'Навыки',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -200,7 +200,7 @@ export default {
     kanban: '看板',
     workflow: '工作流',
     models: '模型',
-    profiles: '使用者',
+    profiles: '設定檔',
     plugins: '插件',
     mcp: 'MCP',
     petdex: '寵物',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -200,7 +200,7 @@ export default {
     kanban: '看板',
     workflow: '工作流',
     models: '模型',
-    profiles: '用户',
+    profiles: '配置',
     plugins: '插件',
     mcp: 'MCP',
     petdex: '宠物',


### PR DESCRIPTION
`sidebar.profiles` is the label on the Hermes **profile** switcher. Three locales translate it as "users":

| locale | before | after | the word each locale already uses for a profile |
| --- | --- | --- | --- |
| zh | 用户 | **配置** | `profiles.title: '配置'` |
| zh-TW | 使用者 | **設定檔** | `profiles.title: '設定檔'` |
| ru | Пользователи | **Профили** | `profiles.title: 'Профили'` |

The other eight locales were already correct.

The label appears in four places — the sidebar item, the profile selector label and its popover, and the new-chat header — which is why the reporter saw it in more than one screen.

Fixes #2298