### PR TITLE
fix(cli): find the Hermes CLI when PATH does not

### DIFF
--- a/packages/server/src/services/hermes/gateway-autostart.ts
+++ b/packages/server/src/services/hermes/gateway-autostart.ts
@@ -8,7 +8,7 @@ import { logger } from '../logger'
 import { getHermesBaseDir, getProfileDir, listProfileNamesFromDisk } from './hermes-profile'
 import { retireManagedGatewayForProfile, startGatewayRunManaged } from './gateway-runner'
 import { parseGatewayStatusesFromProfileList } from './profile-list-parser'
-import { execHermesWithBin } from './hermes-process'
+import { execHermesWithBin, resolveHermesBin } from './hermes-process'
 
 const execFileAsync = promisify(execFile)
 const GATEWAY_RUNTIME_FILES = ['gateway.pid', 'gateway.lock', 'gateway_state.json'] as const
@@ -39,10 +39,6 @@ const HERMES_SUBCOMMAND_PROFILE_NAMES = new Set([
   'mcp', 'sessions', 'insights', 'version', 'update', 'uninstall',
   'profile', 'plugins', 'honcho', 'acp',
 ])
-
-function resolveHermesBin(): string {
-  return process.env.HERMES_BIN?.trim() || 'hermes'
-}
 
 function isReservedProfileName(profile: string): boolean {
   const normalized = String(profile || '').trim().toLowerCase()

--- a/packages/server/src/services/hermes/hermes-cli.ts
+++ b/packages/server/src/services/hermes/hermes-cli.ts
@@ -8,7 +8,7 @@ import { getActiveProfileDir, getActiveProfileName, getProfileDir, listProfileNa
 import { startGatewayRunManaged } from './gateway-runner'
 import { isGatewayRunningForProfile } from './gateway-autostart'
 import { parseProfileListRuntimeInfo, type ProfileListRuntimeInfo } from './profile-list-parser'
-import { execHermesWithBin, spawnHermesWithBin } from './hermes-process'
+import { execHermesWithBin, resolveHermesBin, spawnHermesWithBin } from './hermes-process'
 
 const execFileAsync = promisify(execFile)
 
@@ -17,14 +17,6 @@ const isDocker = existsSync('/.dockerenv')
 const isTermux = !!process.env.TERMUX_VERSION ||
   (process.env.PREFIX || '').includes('/com.termux/') ||
   existsSync('/data/data/com.termux/files/usr')
-
-/**
- * 解析 Hermes CLI 二进制路径
- * 优先使用环境变量 HERMES_BIN，否则使用 PATH 中的 'hermes' 命令
- */
-function resolveHermesBin(): string {
-  return process.env.HERMES_BIN?.trim() || 'hermes'
-}
 
 const HERMES_BIN = resolveHermesBin()
 

--- a/packages/server/src/services/hermes/hermes-process.ts
+++ b/packages/server/src/services/hermes/hermes-process.ts
@@ -1,7 +1,8 @@
 import { execFile, spawn } from 'child_process'
 import type { ChildProcess, ExecFileOptions, SpawnOptions } from 'child_process'
-import { existsSync } from 'fs'
-import { basename, dirname, resolve } from 'path'
+import { constants, accessSync, existsSync } from 'fs'
+import { homedir } from 'os'
+import { basename, delimiter, dirname, join, resolve } from 'path'
 
 export interface HermesInvocation {
   command: string
@@ -13,8 +14,61 @@ export interface HermesExecResult {
   stderr: string
 }
 
+// Where the Hermes CLI installs itself when it is not on PATH.
+const CLI_FALLBACK_PATHS = [
+  ['.local', 'bin', 'hermes'],
+  ['.hermes', 'node', 'bin', 'hermes'],
+  ['.local', 'share', 'hermes', 'bin', 'hermes'],
+]
+
+function isExecutable(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function onSearchPath(name: string): boolean {
+  const search = process.env.PATH
+  if (!search) return false
+  return search
+    .split(delimiter)
+    .filter(Boolean)
+    .some(dir => isExecutable(join(dir, name)))
+}
+
+function installedCliPath(): string | null {
+  const home = homedir()
+  const candidates = [
+    ...CLI_FALLBACK_PATHS.map(parts => join(home, ...parts)),
+    '/usr/local/bin/hermes',
+    '/opt/homebrew/bin/hermes',
+  ]
+  return candidates.find(isExecutable) ?? null
+}
+
+let cachedBin: string | null = null
+
 export function resolveHermesBin(customBin?: string): string {
-  return customBin?.trim() || process.env.HERMES_BIN?.trim() || 'hermes'
+  const explicit = customBin?.trim() || process.env.HERMES_BIN?.trim()
+  if (explicit) return explicit
+  if (process.platform === 'win32') return 'hermes'
+  if (cachedBin) return cachedBin
+
+  // A `systemd --user` service inherits a minimal PATH that usually leaves out
+  // ~/.local/bin, which is exactly where the CLI installs itself. Falling back
+  // to the known install locations keeps every hermes call — logs, gateway,
+  // profiles — working after a reboot, instead of failing with ENOENT on a
+  // machine where `hermes` is plainly installed.
+  cachedBin = onSearchPath('hermes') ? 'hermes' : installedCliPath() ?? 'hermes'
+  return cachedBin
+}
+
+/** Test seam: the resolved path is cached for the life of the process. */
+export function resetHermesBinCache(): void {
+  cachedBin = null
 }
 
 function bundledCliPythonForWindows(hermesBin: string): string | null {

--- a/tests/server/hermes-bin-resolution.test.ts
+++ b/tests/server/hermes-bin-resolution.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const homeMock = vi.hoisted(() => ({ dir: '' }))
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>()
+  return { ...actual, homedir: () => homeMock.dir }
+})
+
+const originalPath = process.env.PATH
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+let home = ''
+
+function installCli(...parts: string[]): string {
+  const path = join(home, ...parts)
+  mkdirSync(join(path, '..'), { recursive: true })
+  writeFileSync(path, '#!/bin/sh\n')
+  chmodSync(path, 0o755)
+  return path
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'hermes-home-'))
+  homeMock.dir = home
+  Object.defineProperty(process, 'platform', { value: 'linux' })
+  delete process.env.HERMES_BIN
+  vi.resetModules()
+})
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true })
+  process.env.PATH = originalPath
+  delete process.env.HERMES_BIN
+  if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform)
+})
+
+/**
+ * A `systemd --user` unit inherits a minimal PATH that usually leaves out
+ * ~/.local/bin, where the CLI installs itself. Every hermes call from the Web
+ * UI then fails after a reboot on a machine where hermes is plainly installed.
+ */
+describe('locating the Hermes CLI', () => {
+  it('uses the bare name when PATH can resolve it', async () => {
+    const binDir = join(home, 'usr-bin')
+    mkdirSync(binDir, { recursive: true })
+    const onPath = join(binDir, 'hermes')
+    writeFileSync(onPath, '#!/bin/sh\n')
+    chmodSync(onPath, 0o755)
+    process.env.PATH = binDir
+
+    const { resolveHermesBin } = await import('../../packages/server/src/services/hermes/hermes-process')
+    expect(resolveHermesBin()).toBe('hermes')
+  })
+
+  it('falls back to ~/.local/bin when PATH cannot', async () => {
+    const installed = installCli('.local', 'bin', 'hermes')
+    process.env.PATH = '/nonexistent'
+
+    const { resolveHermesBin } = await import('../../packages/server/src/services/hermes/hermes-process')
+    expect(resolveHermesBin()).toBe(installed)
+  })
+
+  it('also finds the CLI shipped under ~/.hermes', async () => {
+    const installed = installCli('.hermes', 'node', 'bin', 'hermes')
+    process.env.PATH = '/nonexistent'
+
+    const { resolveHermesBin } = await import('../../packages/server/src/services/hermes/hermes-process')
+    expect(resolveHermesBin()).toBe(installed)
+  })
+
+  it('keeps HERMES_BIN authoritative', async () => {
+    installCli('.local', 'bin', 'hermes')
+    process.env.PATH = '/nonexistent'
+    process.env.HERMES_BIN = '/opt/custom/hermes'
+
+    const { resolveHermesBin } = await import('../../packages/server/src/services/hermes/hermes-process')
+    expect(resolveHermesBin()).toBe('/opt/custom/hermes')
+  })
+
+  it('still reports the bare name when nothing is installed', async () => {
+    process.env.PATH = '/nonexistent'
+
+    const { resolveHermesBin } = await import('../../packages/server/src/services/hermes/hermes-process')
+    expect(resolveHermesBin()).toBe('hermes')
+  })
+})

--- a/tests/server/profile-delete-managed-gateway.test.ts
+++ b/tests/server/profile-delete-managed-gateway.test.ts
@@ -27,6 +27,7 @@ let fakeChildren: FakeChild[] = []
 
 vi.mock('../../packages/server/src/services/hermes/hermes-process', () => ({
   execHermesWithBin: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+  resolveHermesBin: vi.fn(() => 'hermes'),
   spawnHermesWithBin: vi.fn(() => {
     const child = new FakeChild(20000 + fakeChildren.length)
     fakeChildren.push(child)


### PR DESCRIPTION
### The problem

The Web UI invokes the CLI by bare name (`hermes`), resolved through PATH. A `systemd --user` service inherits a minimal PATH that usually leaves out `~/.local/bin` — exactly where the CLI installs itself.

So after a reboot, every hermes call from the server fails with ENOENT on a machine where hermes is plainly installed. The Monitoring tab shows no logs, and the gateway and profile calls fail the same way. #2129 works around it by hand-editing the unit file.

### The fix

`resolveHermesBin` keeps its order of precedence and gains a last resort:

1. `HERMES_BIN` — unchanged, still authoritative
2. PATH — unchanged, still preferred when it resolves
3. **new:** the known install locations — `~/.local/bin`, `~/.hermes/node/bin`, `~/.local/share/hermes/bin`, `/usr/local/bin`, `/opt/homebrew/bin`

Windows resolution is untouched (it returns the bare name as before, and the bundled-python path logic is unchanged). The answer is cached for the life of the process, so this costs a handful of `access()` calls once.

Two copies of the resolver had drifted into `hermes-cli.ts` and `gateway-autostart.ts`, neither of which would have picked up the fallback; both now use the shared one.

### Tests

`tests/server/hermes-bin-resolution.test.ts` covers each branch with a real executable in a temporary HOME: PATH hit, `~/.local/bin` fallback, `~/.hermes` fallback, `HERMES_BIN` override, and nothing installed.

`npm run harness:check` passes. The whole `tests/server` suite passes except `studio-mcp-autoinject.test.ts`, which fails identically on a clean `main` in this environment — unrelated to this change.

Fixes #2129