### PR TITLE
Use bundled Web UI after desktop updates

### DIFF
--- a/packages/desktop/src/main/paths.ts
+++ b/packages/desktop/src/main/paths.ts
@@ -32,6 +32,7 @@ type RuntimeReleaseMetadata = {
 }
 
 type ActiveRuntimeVersion = {
+  desktopAppVersion?: unknown
   platform?: unknown
   webUiVersion?: unknown
   runtimeDirectory?: unknown

--- a/packages/desktop/src/main/runtime-manager.ts
+++ b/packages/desktop/src/main/runtime-manager.ts
@@ -74,6 +74,7 @@ type PackagedRuntimeRelease = {
 
 type ActiveRuntimeVersion = {
   schema?: number
+  desktopAppVersion?: string
   hermesRuntimeVersion?: string
   webUiVersion?: string
   runtimeDirectory?: string
@@ -513,6 +514,13 @@ export function writeActiveRuntimeVersion(runtimeRoot = desktopRuntimeDir()): vo
   const hermesRuntimeVersion = manifest?.hermesAgentVersion || desktopRuntimeVersion()
   const selectedWebUiDirectory = webuiDir()
   const active = readActiveRuntimeVersion()
+  const desktopAppVersion = app.getVersion().trim()
+  const previousDesktopAppVersion = active?.desktopAppVersion?.trim() || ''
+  const desktopAppVersionChanged = Boolean(
+    active
+    && desktopAppVersion
+    && previousDesktopAppVersion !== desktopAppVersion,
+  )
   const activeWebUiVersion = active?.webUiVersion?.trim().replace(/^v/, '') || ''
   const expectedWebUiDirectory = activeWebUiVersion
     ? join(runtimeStorageRoot(), 'webui', activeWebUiVersion)
@@ -523,12 +531,21 @@ export function writeActiveRuntimeVersion(runtimeRoot = desktopRuntimeDir()): vo
   const next: ActiveRuntimeVersion = {
     ...(active || {}),
     schema: 1,
+    desktopAppVersion,
     hermesRuntimeVersion,
     runtimeDirectory: runtimeRoot,
     platform: runtimePlatformKey(),
     updatedAt: new Date().toISOString(),
   }
-  if (hasWebUiOverride) {
+  if (desktopAppVersionChanged) {
+    delete next.webUiVersion
+    if (activeWebUiVersion) {
+      console.log(
+        `[runtime] desktop updated from ${previousDesktopAppVersion || 'a legacy version'} `
+        + `to ${desktopAppVersion}; using bundled Web UI`,
+      )
+    }
+  } else if (hasWebUiOverride) {
     // Development overrides are temporary and must not replace the persisted downloaded version.
   } else if (usingDownloadedWebUi) {
     next.webUiVersion = webUiVersion()

--- a/packages/server/src/services/runtime-version-manager.ts
+++ b/packages/server/src/services/runtime-version-manager.ts
@@ -14,6 +14,7 @@ const DEFAULT_GITHUB_REPO = 'EKKOLearnAI/hermes-studio'
 
 export interface ActiveVersionManifest {
   schema: number
+  desktopAppVersion?: string
   hermesRuntimeVersion?: string
   webUiVersion?: string
   runtimeDirectory?: string
@@ -495,6 +496,7 @@ export function activateInstalledRuntimeVersion(version: string): ActiveVersionM
 
   const next: ActiveVersionManifest = {
     schema: 1,
+    desktopAppVersion: active?.desktopAppVersion || undefined,
     hermesRuntimeVersion: target.manifestHermesRuntimeVersion || target.version,
     webUiVersion: active?.webUiVersion || undefined,
     runtimeDirectory: target.directory,
@@ -580,6 +582,7 @@ export function activateDownloadedWebUiVersion(version: string): ActiveVersionMa
   if (!existsSync(join(directory, 'package.json'))) throw new Error(`Downloaded Web UI version not found: ${cleanVersion}`)
   const next: ActiveVersionManifest = {
     schema: 1,
+    desktopAppVersion: active?.desktopAppVersion || undefined,
     hermesRuntimeVersion: active?.hermesRuntimeVersion || '',
     webUiVersion: cleanVersion,
     runtimeDirectory: active?.runtimeDirectory || '',

--- a/tests/desktop/runtime-manager.test.ts
+++ b/tests/desktop/runtime-manager.test.ts
@@ -96,6 +96,7 @@ describe('desktop runtime manager', () => {
     process.env.HERMES_DESKTOP_RUNTIME_RELEASE_TAG = 'hermes-0.17.0-runtime'
     mockElectronApp.isPackaged = false
     mockElectronApp.getAppPath = () => process.cwd()
+    mockElectronApp.getVersion = () => '0.6.21'
   })
 
   afterEach(async () => {
@@ -168,6 +169,7 @@ describe('desktop runtime manager', () => {
     mkdirSync(join(home, 'desktop-runtime'), { recursive: true })
     writeFileSync(activeVersionPath, JSON.stringify({
       schema: 1,
+      desktopAppVersion: '0.6.21',
       webUiVersion: '0.6.31',
       webUiDirectory: developmentWebUi,
       platform: runtimePlatformKey(),
@@ -179,6 +181,61 @@ describe('desktop runtime manager', () => {
 
     expect(active.webUiVersion).toBe('0.6.31')
     expect(active.webUiDirectory).toBeUndefined()
+  })
+
+  it.each([
+    ['an older desktop version', '0.6.20'],
+    ['a legacy manifest without a recorded desktop version', undefined],
+  ])('uses the bundled Web UI after upgrading from %s', async (_label, previousVersion) => {
+    const home = process.env.HERMES_WEB_UI_HOME!
+    const { runtimePlatformKey } = await import('../../packages/desktop/src/main/runtime-paths')
+    const runtimeRoot = join(home, 'desktop-runtime', 'hermes', '0.17.0', runtimePlatformKey())
+    const downloadedWebUi = join(home, 'desktop-runtime', 'webui', '0.6.31')
+    const activeVersionPath = join(home, 'desktop-runtime', 'active-version.json')
+    createRuntimeFiles(runtimeRoot)
+    createWebUiFiles(downloadedWebUi)
+    mkdirSync(join(home, 'desktop-runtime'), { recursive: true })
+    writeFileSync(activeVersionPath, JSON.stringify({
+      schema: 1,
+      desktopAppVersion: previousVersion,
+      hermesRuntimeVersion: '0.17.0',
+      runtimeDirectory: runtimeRoot,
+      webUiVersion: '0.6.31',
+      platform: runtimePlatformKey(),
+    }))
+
+    const { writeActiveRuntimeVersion } = await import('../../packages/desktop/src/main/runtime-manager')
+    writeActiveRuntimeVersion(runtimeRoot)
+    const active = JSON.parse(readFileSync(activeVersionPath, 'utf-8'))
+
+    expect(active.desktopAppVersion).toBe('0.6.21')
+    expect(active.webUiVersion).toBeUndefined()
+  })
+
+  it('keeps the selected Web UI during an ordinary restart of the same desktop version', async () => {
+    const home = process.env.HERMES_WEB_UI_HOME!
+    const { runtimePlatformKey } = await import('../../packages/desktop/src/main/runtime-paths')
+    const runtimeRoot = join(home, 'desktop-runtime', 'hermes', '0.17.0', runtimePlatformKey())
+    const downloadedWebUi = join(home, 'desktop-runtime', 'webui', '0.6.31')
+    const activeVersionPath = join(home, 'desktop-runtime', 'active-version.json')
+    createRuntimeFiles(runtimeRoot)
+    createWebUiFiles(downloadedWebUi)
+    mkdirSync(join(home, 'desktop-runtime'), { recursive: true })
+    writeFileSync(activeVersionPath, JSON.stringify({
+      schema: 1,
+      desktopAppVersion: '0.6.21',
+      hermesRuntimeVersion: '0.17.0',
+      runtimeDirectory: runtimeRoot,
+      webUiVersion: '0.6.31',
+      platform: runtimePlatformKey(),
+    }))
+
+    const { writeActiveRuntimeVersion } = await import('../../packages/desktop/src/main/runtime-manager')
+    writeActiveRuntimeVersion(runtimeRoot)
+    const active = JSON.parse(readFileSync(activeVersionPath, 'utf-8'))
+
+    expect(active.desktopAppVersion).toBe('0.6.21')
+    expect(active.webUiVersion).toBe('0.6.31')
   })
 
   it('copies a pending Runtime migration before switching the active directory', async () => {

--- a/tests/server/runtime-version-manager.test.ts
+++ b/tests/server/runtime-version-manager.test.ts
@@ -86,6 +86,7 @@ describe('runtime version manager storage migration', () => {
     writeFileSync(join(legacyWebUiDirectory, 'package.json'), JSON.stringify({ version: '0.6.30' }))
     writeFileSync(activeVersionPath, JSON.stringify({
       schema: 1,
+      desktopAppVersion: '0.6.30',
       runtimeRootDirectory: storageRoot,
       platform: 'test-platform',
     }))
@@ -101,6 +102,7 @@ describe('runtime version manager storage migration', () => {
       active: false,
     }])
     const activated = activateDownloadedWebUiVersion('0.6.31')
+    expect(activated.desktopAppVersion).toBe('0.6.30')
     expect(activated.webUiVersion).toBe('0.6.31')
     expect(activated.webUiDirectory).toBeUndefined()
     expect(() => activateDownloadedWebUiVersion('0.6.30'))


### PR DESCRIPTION
## Summary
- record the active desktop app version in `active-version.json`
- clear a previously selected downloaded Web UI when the desktop app version changes so the updated app starts its bundled Web UI
- preserve the desktop version marker when Runtime or Web UI selections are changed through the server
- keep same-version restarts and later manual Web UI selections stable

## Why
Desktop installers ship a compatible Web UI, but the persisted downloaded Web UI selection could keep an older version active after an app update. The desktop app now treats an app-version change as a one-time request to return to its bundled Web UI.

## Impact
- upgrades from legacy desktop manifests switch to the Web UI bundled with the new installer
- downloaded Web UI directories are retained and can be selected again later
- ordinary restarts of the same desktop version do not reset the user's selection
- Hermes Runtime selection and version remain unchanged

## Validation
- `npx vitest run tests/desktop/runtime-manager.test.ts tests/desktop/runtime-paths.test.ts tests/server/runtime-version-manager.test.ts`
- `npm run harness:check`
- `npm --prefix packages/desktop run build`
- `npm run build`
