### PR TITLE
feat: support in-page upgrade for git-clone deployments

### DIFF
--- a/packages/client/src/api/hermes/system.ts
+++ b/packages/client/src/api/hermes/system.ts
@@ -10,6 +10,7 @@ export interface HealthResponse {
   webui_update_available?: boolean
   node_version?: string
   is_docker?: boolean
+  is_git_clone?: boolean
   agent_bridge?: {
     status: string
     reachable: boolean

--- a/packages/server/src/controllers/health.ts
+++ b/packages/server/src/controllers/health.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'fs'
-import { resolve } from 'path'
+import { execFileSync } from 'child_process'
+import { resolve, dirname } from 'path'
 import * as hermesCli from '../services/hermes/hermes-cli'
 import { getAgentBridgeManager } from '../services/hermes/agent-bridge/manager'
 import { redactAgentBridgeError } from '../services/hermes/agent-bridge/redact'
@@ -47,8 +48,92 @@ const LOCAL_VERSION = typeof __APP_VERSION__ !== 'undefined'
   : PACKAGE_INFO?.version || ''
 
 let cachedLatestVersion = ''
+let cachedGitRemoteVersion = ''
 const AGENT_BRIDGE_HEALTH_CACHE_TTL_MS = 250
 const AGENT_BRIDGE_HEALTH_FIRST_WAIT_MS = 75
+
+/**
+ * Detect whether the Web UI is running from a git clone (rather than an npm
+ * global install or Docker image). In a git-clone deployment the repo root
+ * contains a .git directory and the server is started from the built dist/
+ * output. This deployment type cannot use `npm install -g` to upgrade —
+ * it needs `git pull && npm install && npm run build` instead.
+ */
+function detectGitCloneDeployment(): boolean {
+  // Docker containers are never considered git-clone deployments
+  if (isDockerContainer()) return false
+
+  const candidatePaths = [
+    resolve(__dirname, '../../../../.git'),
+    resolve(__dirname, '../../.git'),
+    resolve(process.cwd(), '.git'),
+  ]
+
+  return candidatePaths.some(p => existsSync(p))
+}
+
+let isGitCloneDeploy: boolean | null = null
+function isGitCloneDeployment(): boolean {
+  if (isGitCloneDeploy === null) {
+    isGitCloneDeploy = detectGitCloneDeployment()
+  }
+  return isGitCloneDeploy
+}
+
+/**
+ * Get the repo root for a git-clone deployment.
+ */
+function getGitRepoRoot(): string | null {
+  const candidatePaths = [
+    resolve(__dirname, '../../../..'),
+    resolve(__dirname, '../..'),
+    process.cwd(),
+  ]
+
+  for (const p of candidatePaths) {
+    if (existsSync(resolve(p, '.git')) && existsSync(resolve(p, 'package.json'))) {
+      return p
+    }
+  }
+  return null
+}
+
+/**
+ * Check for updates in a git-clone deployment by fetching from origin and
+ * comparing the local HEAD with origin/main.
+ */
+async function checkGitLatestVersion(): Promise<void> {
+  const repoRoot = getGitRepoRoot()
+  if (!repoRoot) return
+
+  try {
+    // Fetch origin to get latest remote refs
+    execFileSync('git', ['fetch', 'origin', 'main'], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    // Get remote HEAD version by reading package.json from origin/main
+    const remotePackageJson = execFileSync('git', ['show', 'origin/main:package.json'], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      timeout: 10000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    const remotePkg = JSON.parse(remotePackageJson)
+    if (remotePkg?.version) {
+      cachedGitRemoteVersion = String(remotePkg.version)
+      if (LOCAL_VERSION && isNewerVersion(cachedGitRemoteVersion, LOCAL_VERSION)) {
+        console.log(`Git update available: ${LOCAL_VERSION} -> ${cachedGitRemoteVersion}`)
+      }
+    }
+  } catch {
+    // Ignore — git may not be available or repo may not have a remote
+  }
+}
 
 type AgentBridgeHealthPayload = {
   status: string
@@ -105,6 +190,13 @@ function isNewerVersion(candidate: string, current: string): boolean {
 
 export async function checkLatestVersion(): Promise<void> {
   if (isUpdateCheckDisabled()) return
+
+  // For git-clone deployments, check via git fetch instead of npm registry
+  if (isGitCloneDeployment()) {
+    await checkGitLatestVersion()
+    return
+  }
+
   try {
     const packageName = PACKAGE_INFO?.name || 'hermes-web-ui'
     const registryName = encodeURIComponent(packageName)
@@ -113,7 +205,7 @@ export async function checkLatestVersion(): Promise<void> {
       const data = await res.json() as { version: string }
       cachedLatestVersion = data.version
       if (LOCAL_VERSION && cachedLatestVersion && isNewerVersion(cachedLatestVersion, LOCAL_VERSION)) {
-        console.log(`Update available: ${LOCAL_VERSION} → ${cachedLatestVersion}`)
+        console.log(`Update available: ${LOCAL_VERSION} -> ${cachedLatestVersion}`)
       }
     }
   } catch { /* ignore */ }
@@ -192,18 +284,24 @@ export async function healthCheck(ctx: any) {
   const raw = await hermesCli.getVersion()
   const hermesVersion = raw.split('\n')[0].replace('Hermes Agent ', '') || ''
   const agentBridge = await getAgentBridgeHealth()
+
+  const gitDeploy = isGitCloneDeployment()
+  const latestVersion = gitDeploy ? cachedGitRemoteVersion : (isUpdateCheckDisabled() ? '' : cachedLatestVersion)
+  const updateAvailable = isUpdateCheckDisabled()
+    ? false
+    : Boolean(LOCAL_VERSION && latestVersion && isNewerVersion(latestVersion, LOCAL_VERSION))
+
   ctx.body = {
     status: 'ok',
     platform: 'hermes-agent',
     version: hermesVersion,
     gateway: 'running',
     webui_version: LOCAL_VERSION,
-    webui_latest: isUpdateCheckDisabled() ? '' : cachedLatestVersion,
-    webui_update_available: isUpdateCheckDisabled()
-      ? false
-      : Boolean(LOCAL_VERSION && cachedLatestVersion && isNewerVersion(cachedLatestVersion, LOCAL_VERSION)),
+    webui_latest: latestVersion,
+    webui_update_available: updateAvailable,
     node_version: process.versions.node,
     agent_bridge: agentBridge,
     is_docker: isDockerContainer(),
+    is_git_clone: gitDeploy,
   }
 }

--- a/packages/server/src/controllers/update.ts
+++ b/packages/server/src/controllers/update.ts
@@ -1036,6 +1036,153 @@ function getGlobalCliScript() {
   return cli
 }
 
+/**
+ * Detect whether the server is running from a git-clone deployment.
+ * In a git-clone deployment, the repo root contains a .git directory
+ * and the server runs from the built dist/ output. This deployment
+ * cannot use `npm install -g` to upgrade — it needs git pull + build.
+ */
+function detectGitCloneDeployment(): boolean {
+  if (isDockerContainer()) return false
+
+  const candidatePaths = [
+    resolve(__dirname, '../../../../.git'),
+    resolve(__dirname, '../../.git'),
+    resolve(process.cwd(), '.git'),
+  ]
+
+  return candidatePaths.some(p => existsSync(p))
+}
+
+let isGitCloneDeploy: boolean | null = null
+function isGitCloneDeployment(): boolean {
+  if (isGitCloneDeploy === null) {
+    isGitCloneDeploy = detectGitCloneDeployment()
+  }
+  return isGitCloneDeploy
+}
+
+/**
+ * Get the repo root for a git-clone deployment.
+ */
+function getGitRepoRoot(): string | null {
+  const candidatePaths = [
+    resolve(__dirname, '../../../..'),
+    resolve(__dirname, '../..'),
+    process.cwd(),
+  ]
+
+  for (const p of candidatePaths) {
+    if (existsSync(resolve(p, '.git')) && existsSync(resolve(p, 'package.json'))) {
+      return p
+    }
+  }
+  return null
+}
+
+/**
+ * Detect the systemd service name managing the Web UI server.
+ */
+function detectSystemServicedName(): string | null {
+  try {
+    // Check if we're running under systemd by examining the cgroup
+    const cgroup = readFileSync('/proc/self/cgroup', 'utf-8')
+    for (const svc of ['hermes-webui', 'hermes-web-ui', 'hermes-webui.service', 'hermes-web-ui.service']) {
+      const serviceName = svc.endsWith('.service') ? svc : `${svc}.service`
+      if (cgroup.includes(serviceName)) {
+        return serviceName.replace('.service', '')
+      }
+    }
+  } catch {
+    // Not running under systemd or /proc not available
+  }
+  return null
+}
+
+/**
+ * Run a git-based upgrade: git pull, npm install, npm run build, then restart.
+ * Returns the output log.
+ */
+function runGitUpdateInstall(): string {
+  const repoRoot = getGitRepoRoot()
+  if (!repoRoot) {
+    throw new Error('Git-clone deployment detected but repo root not found')
+  }
+
+  const output: string[] = []
+
+  // Stash any local changes before pulling
+  try {
+    const diffResult = execFileSync('git', ['diff', '--quiet'], {
+      cwd: repoRoot, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'],
+    })
+  } catch (err: any) {
+    // git diff --quiet exits non-zero if there are changes — stash them
+    if (err.status === 1) {
+      const stashOutput = execFileSync('git', ['stash', 'push', '-m', `auto-stash before web upgrade ${new Date().toISOString()}`], {
+        cwd: repoRoot, encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      output.push(`Stashed local changes: ${stashOutput.trim()}`)
+    }
+  }
+
+  // git fetch and pull
+  output.push('=== Fetching latest code ===')
+  const fetchOutput = execFileSync('git', ['fetch', 'origin', 'main'], {
+    cwd: repoRoot, encoding: 'utf-8', timeout: 30000, stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  if (fetchOutput.trim()) output.push(fetchOutput.trim())
+
+  output.push('=== Pulling latest code ===')
+  const pullOutput = execFileSync('git', ['pull', 'origin', 'main'], {
+    cwd: repoRoot, encoding: 'utf-8', timeout: 30000, stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  if (pullOutput.trim()) output.push(pullOutput.trim())
+
+  // npm install
+  output.push('=== Installing dependencies ===')
+  const installEnv = getCurrentNodeEnv()
+  const npmExec = npmExecution(['install', '--include=dev'], installEnv)
+  const installOutput = execFileSync(npmExec.command, npmExec.args, {
+    cwd: repoRoot, encoding: 'utf-8', timeout: 10 * 60 * 1000, stdio: ['pipe', 'pipe', 'pipe'], env: installEnv,
+  })
+  if (installOutput.trim()) output.push(installOutput.trim().split('\n').slice(-5).join('\n'))
+
+  // npm run build
+  output.push('=== Building ===')
+  const buildExec = npmExecution(['run', 'build'], installEnv)
+  const buildOutput = execFileSync(buildExec.command, buildExec.args, {
+    cwd: repoRoot, encoding: 'utf-8', timeout: 10 * 60 * 1000, stdio: ['pipe', 'pipe', 'pipe'], env: installEnv,
+  })
+  if (buildOutput.trim()) output.push(buildOutput.trim().split('\n').slice(-10).join('\n'))
+
+  return output.join('\n')
+}
+
+/**
+ * Restart the server after a git-based upgrade.
+ * If running under systemd, use systemctl restart.
+ * Otherwise, fall back to the spawnRestart mechanism.
+ */
+function spawnGitRestart(): void {
+  const svcName = detectSystemServicedName()
+  if (svcName) {
+    try {
+      execFileSync('systemctl', ['restart', svcName], {
+        encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      return
+    } catch (err) {
+      console.error('[update] systemctl restart failed, falling back to spawn:', err)
+    }
+  }
+
+  // Fallback: use the existing spawn-restart mechanism
+  const port = process.env.PORT || '8648'
+  const restart = spawnRestart(port)
+  restart.unref()
+}
+
 function runUpdateInstall() {
   try {
     runNpmSync(['cache', 'clean', '--force'], { timeout: 2 * 60 * 1000 })
@@ -1084,6 +1231,44 @@ export async function handleUpdate(ctx: any) {
   updateInProgress = true
   let keepUpdateLockForRestart = false
 
+  // Git-clone deployment: use git pull + npm install + npm run build
+  if (isGitCloneDeployment()) {
+    try {
+      const output = runGitUpdateInstall()
+
+      ctx.body = {
+        success: true,
+        message: output.trim() || 'hermes-web-ui updated successfully (git-clone deployment)',
+      }
+
+      keepUpdateLockForRestart = true
+      setTimeout(() => {
+        try {
+          spawnGitRestart()
+        } catch (err) {
+          updateInProgress = false
+          console.error('[update] git-clone restart failed:', err)
+          return
+        }
+        // For systemd restart, the current process may be killed immediately,
+        // so we just clear the lock after a short delay
+        setTimeout(() => { updateInProgress = false }, 5000)
+      }, 3000)
+    } catch (err: any) {
+      ctx.status = 500
+      ctx.body = {
+        success: false,
+        message: err.stderr?.toString() || err.message || String(err),
+      }
+    } finally {
+      if (!keepUpdateLockForRestart) {
+        updateInProgress = false
+      }
+    }
+    return
+  }
+
+  // npm global install path (original behavior)
   try {
     const output = runUpdateInstall()
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Hermes Web UI upgrade script for systemd-based deployments
+# Usage: ./upgrade.sh [--check]
+#   --check  Only report if an update is available; do not apply
+set -euo pipefail
+
+# Derive the repo directory from the script location, not a hardcoded path
+WEBUI_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$WEBUI_DIR"
+
+# Allow git to operate when the repo owner differs from the running user
+git config --global --add safe.directory "$WEBUI_DIR" 2>/dev/null || true
+
+# Detect the systemd service name (common variants: hermes-webui, hermes-web-ui)
+SERVICE_NAME=""
+for svc in hermes-webui hermes-web-ui; do
+  if systemctl list-unit-files "${svc}.service" > /dev/null 2>&1; then
+    SERVICE_NAME="$svc"
+    break
+  fi
+done
+
+current_version() {
+  node -p "require('./package.json').version" 2>/dev/null || echo "unknown"
+}
+
+# Fetch latest from origin
+git fetch origin main 2>&1
+
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+
+if [ "$LOCAL" = "$REMOTE" ]; then
+  echo "NO_UPDATE: Already at latest (v$(current_version))"
+  exit 0
+fi
+
+if [ "${1:-}" = "--check" ]; then
+  NEW_VERSION=$(git show origin/main:package.json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version")
+  echo "UPDATE_AVAILABLE: v$(current_version) -> v$NEW_VERSION"
+  exit 0
+fi
+
+PREV_VERSION="$(current_version)"
+PREV_SHA="$LOCAL"
+
+echo "=== Upgrading from v$PREV_VERSION ($PREV_SHA) ==="
+
+# Stash any local changes so git pull does not fail
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "=== Stashing local changes ==="
+  git stash push -m "auto-stash before upgrade $(date -Iseconds)" 2>&1
+fi
+
+echo "=== Pulling latest code ==="
+git pull origin main 2>&1
+
+echo "=== Installing dependencies ==="
+npm install --include=dev 2>&1 | tail -5
+
+echo "=== Building ==="
+npm run build 2>&1 | tail -10
+
+echo "=== Restarting server ==="
+if [ -n "$SERVICE_NAME" ]; then
+  # systemd-managed deployment: use systemctl to restart cleanly
+  systemctl restart "$SERVICE_NAME"
+  sleep 2
+  if systemctl is-active --quiet "$SERVICE_NAME"; then
+    echo "UPGRADE_COMPLETE: v$(current_version) (service: $SERVICE_NAME)"
+  else
+    echo "UPGRADE_FAILED: service $SERVICE_NAME did not start"
+    echo "Attempting rollback..."
+    git reset --hard "$PREV_SHA"
+    npm run build 2>&1 | tail -5
+    systemctl restart "$SERVICE_NAME"
+    if systemctl is-active --quiet "$SERVICE_NAME"; then
+      echo "ROLLBACK_OK: reverted to v$PREV_VERSION"
+    else
+      echo "ROLLBACK_FAILED: service still down after rollback to $PREV_SHA"
+    fi
+    exit 1
+  fi
+else
+  # Non-systemd fallback: kill and restart manually
+  OLD_PID=$(pgrep -f "node.*dist/server/index.js" || true)
+  if [ -n "$OLD_PID" ]; then
+    kill "$OLD_PID" 2>/dev/null || true
+    sleep 2
+  fi
+  PORT="${PORT:-6060}"
+  UPSTREAM="${UPSTREAM:-http://127.0.0.1:8642}"
+  HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+  NODE_ENV=production PORT="$PORT" UPSTREAM="$UPSTREAM" HERMES_HOME="$HERMES_HOME" \
+    nohup node dist/server/index.js > /dev/null 2>&1 &
+  sleep 3
+  NEW_PID=$(pgrep -f "node.*dist/server/index.js" || true)
+  if [ -n "$NEW_PID" ]; then
+    echo "UPGRADE_COMPLETE: v$(current_version) (PID $NEW_PID)"
+  else
+    echo "UPGRADE_FAILED: server did not start"
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## Problem

The Web UI "Update" button only works for **npm global install** deployments (`npm install -g hermes-web-ui@latest`). Users running from a **git clone** with systemd cannot upgrade from the page:

1. The update check compares the local version against the npm registry, which may lag behind the git repo
2. `handleUpdate` runs `npm install -g hermes-web-ui@latest` — this installs to `/usr/lib/node_modules/`, but the systemd service runs from the git clone directory (`dist/server/index.js`). The running server never picks up the change.
3. The restart mechanism (`hermes-web-ui restart`) targets the npm-installed CLI, not the git-clone process

Result: clicking "Update" in the sidebar appears to succeed, but the running server is never actually updated. The user has no way to upgrade from the page.

## Fix

### `health.ts`
- **Detect git-clone deployment** by checking for a `.git` directory relative to the server module location
- **Check for updates via git** (`git fetch origin main && git show origin/main:package.json`) instead of the npm registry when in a git-clone deployment
- Expose `is_git_clone: boolean` in the health response so the frontend can show appropriate messaging

### `update.ts`
- **Add `runGitUpdateInstall()`**: stashes local changes, runs `git pull origin main`, `npm install --include=dev`, `npm run build`
- **Add `spawnGitRestart()`**: detects systemd service via cgroup inspection and uses `systemctl restart`, falling back to the existing spawn-restart mechanism
- **Modify `handleUpdate`**: checks `isGitCloneDeployment()` first and routes to the git upgrade path; falls back to the original npm global install path for non-git deployments

### `system.ts` (client)
- Add `is_git_clone?: boolean` to `HealthResponse` interface

## How it works (git-clone deployment)

```
User clicks "Update" in sidebar
  → POST /api/hermes/update
  → handleUpdate detects .git directory → isGitCloneDeployment() = true
  → runGitUpdateInstall():
      1. git stash (if local changes exist)
      2. git fetch origin main
      3. git pull origin main
      4. npm install --include=dev
      5. npm run build
  → spawnGitRestart():
      - detect systemd service from /proc/self/cgroup
      - systemctl restart hermes-webui (or hermes-web-ui)
      - fallback: spawn-restart if not under systemd
```

## Test Plan

- [ ] `isGitCloneDeployment()` returns `true` when `.git` exists, `false` in Docker and npm installs
- [ ] Health endpoint returns `is_git_clone: true` for git-clone deploys
- [ ] Update check via `git fetch` correctly detects newer versions on `origin/main`
- [ ] `handleUpdate` on git-clone deploy runs `git pull + npm install + npm run build`
- [ ] After build, server restarts via `systemctl restart` when under systemd
- [ ] After restart, health endpoint reports the new version
- [ ] Non-git-clone deploys (npm global) still use the original `npm install -g` path
- [ ] Docker deploys still show the "use docker pull" message