### PR TITLE
fix: enforce profile access isolation

### DIFF
--- a/packages/server/src/middleware/user-auth.ts
+++ b/packages/server/src/middleware/user-auth.ts
@@ -3,6 +3,7 @@ import { createHmac, timingSafeEqual } from 'crypto'
 import { getToken } from '../services/auth'
 import {
   findUserById,
+  getDefaultProfileForUser,
   listUserProfiles,
   touchUserLogin,
   userCanAccessProfile,
@@ -283,8 +284,24 @@ export async function resolveUserProfile(ctx: Context, next: Next): Promise<void
     return
   }
 
+  const aggregateAvailableModels = ctx.path === '/api/hermes/available-models' &&
+    typeof ctx.query.profile !== 'string'
+  if (aggregateAvailableModels) {
+    await next()
+    return
+  }
+
   const profileName = resolveRequestedProfile(ctx)
   if (!profileName) {
+    if (user.role !== 'super_admin') {
+      const defaultProfile = getDefaultProfileForUser(user.id)
+      if (!userCanAccessProfile(user.id, defaultProfile)) {
+        ctx.status = 403
+        ctx.body = { error: 'No profile is available for this user' }
+        return
+      }
+      ctx.state.profile = { name: defaultProfile }
+    }
     await next()
     return
   }

--- a/packages/server/src/routes/hermes/download.ts
+++ b/packages/server/src/routes/hermes/download.ts
@@ -1,5 +1,6 @@
 import Router from '@koa/router'
 import { basename, extname, isAbsolute } from 'path'
+import { existsSync } from 'fs'
 import {
   createFileProvider,
   localProvider,
@@ -7,7 +8,9 @@ import {
   validatePath,
   resolveHermesPath,
 } from '../../services/hermes/file-provider'
-import { getActiveProfileName } from '../../services/hermes/hermes-profile'
+import { getActiveProfileName, getHermesBaseDir } from '../../services/hermes/hermes-profile'
+import { isRealPathWithin } from '../../services/hermes/hermes-path'
+import { getProfileUploadDir } from '../../services/hermes/upload-paths'
 
 export const downloadRoutes = new Router()
 
@@ -67,6 +70,34 @@ function requestedProfile(ctx: any): string {
   return ctx.state?.profile?.name || getActiveProfileName() || 'default'
 }
 
+interface DownloadPathRoots {
+  profileDir?: string
+  uploadDir?: string
+}
+
+function strictProfileDir(profile: string): string | null {
+  if (!profile) return null
+  const dir = profile === 'default'
+    ? getHermesBaseDir()
+    : `${getHermesBaseDir()}/profiles/${profile}`
+  return existsSync(dir) ? dir : null
+}
+
+export async function canDownloadPath(ctx: any, filePath: string, roots: DownloadPathRoots = {}): Promise<boolean> {
+  if (ctx.state?.user?.role === 'super_admin') return true
+  const profile = ctx.state?.profile?.name
+  if (!profile) return false
+  const profileDir = roots.profileDir ?? strictProfileDir(profile)
+  const uploadDir = roots.uploadDir ?? getProfileUploadDir(profile)
+  if (profileDir && await isDownloadPathWithinProfile(filePath, profileDir)) return true
+  if (existsSync(uploadDir) && await isDownloadPathWithinProfile(filePath, uploadDir)) return true
+  return false
+}
+
+export async function isDownloadPathWithinProfile(filePath: string, profileDir: string): Promise<boolean> {
+  return isRealPathWithin(validatePath(filePath), profileDir)
+}
+
 downloadRoutes.get('/api/hermes/download', async (ctx) => {
   const filePath = ctx.query.path as string | undefined
   const fileName = ctx.query.name as string | undefined
@@ -82,6 +113,11 @@ downloadRoutes.get('/api/hermes/download', async (ctx) => {
     // Validate the path first
     // Support both absolute and relative paths
     const validPath = isAbsolute(filePath) ? validatePath(filePath) : resolveHermesPath(filePath, profile)
+    if (!await canDownloadPath(ctx, validPath)) {
+      ctx.status = 403
+      ctx.body = { error: 'File is outside the authorized profile directory', code: 'permission_denied' }
+      return
+    }
 
     // Choose provider: always use local for upload directory files
     let data: Buffer

--- a/tests/server/download-authorization.test.ts
+++ b/tests/server/download-authorization.test.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+import { canDownloadPath, isDownloadPathWithinProfile } from '../../packages/server/src/routes/hermes/download'
+
+describe('download path authorization', () => {
+  it('keeps regular admins inside their resolved profile directory without depending on host paths', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hermes-download-auth-'))
+    const profileDir = join(root, 'profiles', 'he')
+    const ownFile = join(profileDir, 'workspace', 'report.pdf')
+    const outsideFile = join(root, 'config.yaml')
+    await mkdir(join(profileDir, 'workspace'), { recursive: true })
+    await writeFile(ownFile, 'report')
+    await writeFile(outsideFile, 'private')
+
+    try {
+      await expect(isDownloadPathWithinProfile(ownFile, profileDir)).resolves.toBe(true)
+      await expect(isDownloadPathWithinProfile(outsideFile, profileDir)).resolves.toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves super admin absolute-path downloads', async () => {
+    const ctx = {
+      state: {
+        user: { id: 1, username: 'kosmo', role: 'super_admin' },
+        profile: { name: 'default' },
+      },
+    } as any
+
+    await expect(canDownloadPath(ctx, '/etc/hostname')).resolves.toBe(true)
+  })
+
+  it('rejects symlinks that escape the authorized profile directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hermes-download-auth-'))
+    const profileDir = join(root, 'profiles', 'he')
+    const outsideFile = join(root, 'private.txt')
+    await mkdir(profileDir, { recursive: true })
+    await writeFile(outsideFile, 'private')
+    await symlink(outsideFile, join(profileDir, 'escape.txt'))
+
+    try {
+      await expect(isDownloadPathWithinProfile(join(profileDir, 'escape.txt'), profileDir)).resolves.toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a stale profile binding whose directory does not exist', async () => {
+    const ctx = {
+      state: {
+        user: { id: 2, username: 'he', role: 'admin' },
+        profile: { name: 'deleted-profile' },
+      },
+    } as any
+
+    await expect(canDownloadPath(ctx, '/home/hermes/.hermes/config.yaml')).resolves.toBe(false)
+  })
+
+  it('allows regular admins to download files from their profile upload directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hermes-upload-auth-'))
+    const uploadDir = join(root, 'upload', 'he')
+    const uploadFile = join(uploadDir, 'report.pdf')
+    await mkdir(uploadDir, { recursive: true })
+    await writeFile(uploadFile, 'report')
+    const ctx = {
+      state: {
+        user: { id: 2, username: 'he', role: 'admin' },
+        profile: { name: 'he' },
+      },
+    } as any
+
+    try {
+      await expect(canDownloadPath(ctx, uploadFile, {
+        profileDir: join(root, 'profiles', 'he'),
+        uploadDir,
+      })).resolves.toBe(true)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/server/user-auth.test.ts
+++ b/tests/server/user-auth.test.ts
@@ -161,6 +161,27 @@ describe('user auth tables and middleware', () => {
     expect(ctx.body).toEqual({ error: 'Profile is required' })
   })
 
+  it('defaults regular admins to their bound default profile when none is requested', async () => {
+    const { schemas, users, auth } = await initUsers()
+    const now = Date.now()
+    db.prepare(
+      `INSERT INTO ${schemas.USERS_TABLE} (username, password_hash, role, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    ).run('ops', users.hashPassword('secret'), 'admin', 'active', now, now)
+    const admin = users.findUserByUsername('ops')!
+    db.prepare(
+      `INSERT INTO ${schemas.USER_PROFILES_TABLE} (user_id, profile_name, is_default, created_at)
+       VALUES (?, ?, 1, ?)`
+    ).run(admin.id, 'research', now)
+    const ctx = makeCtx({ id: admin.id, username: 'ops', role: 'admin' }, '')
+    const next = vi.fn(async () => {})
+
+    await auth.resolveUserProfile(ctx, next)
+
+    expect(ctx.state.profile).toEqual({ name: 'research' })
+    expect(next).toHaveBeenCalledOnce()
+  })
+
   it.each([
     '/api/devices/peer-connections',
     '/api/devices/peer-connections/conn-1/terminals',


### PR DESCRIPTION
## Summary
- resolve omitted profile selectors to the authenticated non-super-admin user's default authorized profile
- block profile-scoped downloads from reading absolute paths outside that profile
- allow downloads from the authenticated user's profile-specific upload directory
- resolve real paths before authorization to prevent symlink escapes
- deny stale/nonexistent profile bindings instead of falling back to the global Hermes root
- preserve aggregate model listing and super-admin download behavior

## Security impact
Previously, a non-super-admin request that omitted the profile selector could fall back to the globally active profile. The download route also accepted arbitrary absolute paths readable by the Web UI process. This change closes both cross-profile read paths while preserving profile upload downloads.

## Test plan
- [x] `npx vitest run tests/server/user-auth.test.ts tests/server/download-authorization.test.ts` (57 tests)
- [x] `npx tsc --noEmit -p packages/server/tsconfig.json`
- [x] `npm run build`
- [x] verified explicit unauthorized profile access returns 403
- [x] verified default-profile and host-file downloads return 403 for a regular admin
- [x] verified own-profile and own-upload downloads return 200
- [x] verified MCP access remains available