### PR TITLE
feat(versions): clarify Hermes Agent version and updates

### DIFF
--- a/packages/client/src/api/hermes/runtime-versions.ts
+++ b/packages/client/src/api/hermes/runtime-versions.ts
@@ -57,6 +57,7 @@ export interface RuntimeVersionStatus {
   remoteError: string
   hermes: {
     activeVersion: string
+    agentVersion: string
     activeDirectory: string
     storageDirectory: string
     defaultStorageDirectory: string

--- a/packages/client/src/components/layout/VersionManagementModal.vue
+++ b/packages/client/src/components/layout/VersionManagementModal.vue
@@ -195,6 +195,10 @@ function formatBytes(value?: number): string {
   return `${size >= 10 || unitIndex === 0 ? size.toFixed(0) : size.toFixed(1)} ${units[unitIndex]}`
 }
 
+function displayHermesAgentVersion(value?: string): string {
+  return value?.split('·')[0]?.trim() || '-'
+}
+
 function jobProgressText(job: VersionDownloadJob): string {
   if (job.receivedBytes && job.totalBytes) {
     return `${formatBytes(job.receivedBytes)} / ${formatBytes(job.totalBytes)}`
@@ -305,10 +309,30 @@ async function removeWebUi(version: string) {
             </div>
             <NButton size="small" secondary @click="loadAll">{{ t('runtimeVersions.refresh') }}</NButton>
           </div>
-          <div class="active-path">
-            <span>{{ t('runtimeVersions.activeVersion') }}: {{ status?.hermes.activeVersion || '-' }}</span>
-            <span :title="status?.hermes.activeDirectory || ''">{{ status?.hermes.activeDirectory || '-' }}</span>
+          <div class="active-path stacked">
+            <span
+              data-testid="active-hermes-agent-version"
+              :title="status?.hermes.agentVersion || ''"
+            >
+              {{ t('runtimeVersions.currentHermesAgentVersion') }}: {{ displayHermesAgentVersion(status?.hermes.agentVersion) }}
+            </span>
+            <span
+              data-testid="active-runtime-directory"
+              :title="status?.hermes.activeDirectory || ''"
+            >
+              {{ t('runtimeVersions.activeRuntimeDirectory') }}: {{ status?.hermes.activeDirectory || '-' }}
+            </span>
           </div>
+          <NAlert
+            data-testid="runtime-cli-update-note"
+            type="info"
+            :bordered="false"
+          >
+            <div class="runtime-update-note">
+              <span>{{ t('runtimeVersions.cliUpdateDescription') }}</span>
+              <code>hermes-studio cli update</code>
+            </div>
+          </NAlert>
           <div class="runtime-directory-control">
             <div class="runtime-directory-value">
               <strong>{{ t('runtimeVersions.runtimeDirectory') }}</strong>
@@ -575,6 +599,22 @@ async function removeWebUi(version: string) {
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
+  &.stacked {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 4px;
+
+    span {
+      overflow: visible;
+      text-overflow: clip;
+      white-space: normal;
+      word-break: break-word;
+    }
+
+    span:last-child {
+      color: var(--text-color-3);
+    }
+  }
 }
 
 .runtime-directory-control {
@@ -585,6 +625,21 @@ async function removeWebUi(version: string) {
   padding: 8px 10px;
   border: 1px solid var(--border-color);
   border-radius: 6px;
+}
+
+.runtime-update-note {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  code {
+    width: fit-content;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: var(--hover-color);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 12px;
+  }
 }
 
 .runtime-directory-value {

--- a/packages/client/src/i18n/locales/ar.ts
+++ b/packages/client/src/i18n/locales/ar.ts
@@ -259,6 +259,9 @@ export default {
   runtimeVersions: {
     title: 'إدارة الإصدارات',
     runtimeTitle: 'Hermes Runtime',
+    currentHermesAgentVersion: 'إصدار Hermes Agent الحالي',
+    activeRuntimeDirectory: 'مسار Runtime النشط',
+    cliUpdateDescription: 'في Hermes Runtime بالإصدار 0.19.1 والإصدارات الأحدث، يحدّث الأمر التالي Hermes Agent المضمّن فقط. ولا يحدّث تطبيق Hermes Studio لسطح المكتب أو Web UI. أغلق Hermes Studio بالكامل قبل تنفيذه:',
     webUiTitle: 'واجهة الويب',
     platform: 'المنصة',
     currentWebUi: 'واجهة الويب الحالية',

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -271,6 +271,9 @@ export default {
   runtimeVersions: {
     title: 'Versionsverwaltung',
     runtimeTitle: 'Hermes Runtime',
+    currentHermesAgentVersion: 'Aktuelle Hermes Agent-Version',
+    activeRuntimeDirectory: 'Aktueller Runtime-Pfad',
+    cliUpdateDescription: 'Mit Hermes Runtime 0.19.1 und höher aktualisiert der folgende Befehl ausschließlich den integrierten Hermes Agent. Die Hermes Studio-Desktop-App und die Web UI werden nicht aktualisiert. Beenden Sie Hermes Studio vor der Ausführung vollständig:',
     webUiTitle: 'Web UI',
     platform: 'Plattform',
     currentWebUi: 'Aktuelles Web UI',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -259,6 +259,9 @@ export default {
   runtimeVersions: {
     title: 'Version Management',
     runtimeTitle: 'Hermes Runtime',
+    currentHermesAgentVersion: 'Current Hermes Agent version',
+    activeRuntimeDirectory: 'Active Runtime directory',
+    cliUpdateDescription: 'Hermes Runtime 0.19.1 and later can use the following command to update the bundled Hermes Agent only. It does not update the Hermes Studio desktop app or Web UI. Fully quit Hermes Studio before running:',
     webUiTitle: 'Web UI',
     platform: 'Platform',
     currentWebUi: 'Current Web UI',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -271,6 +271,9 @@ export default {
   runtimeVersions: {
     title: 'Gestión de versiones',
     runtimeTitle: 'Hermes Runtime',
+    currentHermesAgentVersion: 'Versión actual de Hermes Agent',
+    activeRuntimeDirectory: 'Ruta del Runtime activo',
+    cliUpdateDescription: 'En Hermes Runtime 0.19.1 y posteriores, el siguiente comando solo actualiza el Hermes Agent integrado. No actualiza la aplicación de escritorio Hermes Studio ni la Web UI. Cierra Hermes Studio por completo antes de ejecutarlo:',
     webUiTitle: 'Web UI',
     platform: 'Plataforma',
     currentWebUi: 'Web UI actual',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -271,6 +271,9 @@ export default {
   runtimeVersions: {
     title: 'Gestion des versions',
     runtimeTitle: 'Hermes Runtime',
+    currentHermesAgentVersion: 'Version actuelle de Hermes Agent',
+    activeRuntimeDirectory: 'Chemin du Runtime actif',
+    cliUpdateDescription: 'Avec Hermes Runtime 0.19.1 et versions ultérieures, la commande suivante met uniquement à jour le Hermes Agent intégré. Elle ne met pas à jour l’application de bureau Hermes Studio ni la Web UI. Quittez complètement Hermes Studio avant de l’exécuter :',
     webUiTitle: 'Web UI',
     platform: 'Plateforme',
     currentWebUi: 'Web UI actuel',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -271,6 +271,9 @@ export default {
   runtimeVersions: {
     title: 'バージョン管理',
     runtimeTitle: 'Hermes Runtime',
+    currentHermesAgentVersion: '現在の Hermes Agent バージョン',
+    activeRuntimeDirectory: '現在の Runtime パス',
+    cliUpdateDescription: 'Hermes Runtime 0.19.1 以降では、次のコマンドで内蔵 Hermes Agent のみを更新できます。Hermes Studio デスクトップアプリや Web UI は更新されません。実行前に Hermes Studio を完全に終了してください：',
     webUiTitle: 'Web UI',
     platform: 'プラットフォーム',
     currentWebUi: '現在の Web UI',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -271,6 +271,9 @@ export default {
   runtimeVersions: {
     title: '버전 관리',
     runtimeTitle: 'Hermes Runtime',
+    currentHermesAgentVersion: '현재 Hermes Agent 버전',
+    activeRuntimeDirectory: '현재 Runtime 경로',
+    cliUpdateDescription: 'Hermes Runtime 0.19.1 이상에서는 다음 명령으로 내장 Hermes Agent만 업데이트할 수 있습니다. Hermes Studio 데스크톱 앱이나 Web UI는 업데이트되지 않습니다. 실행 전에 Hermes Studio를 완전히 종료하세요:',
     webUiTitle: 'Web UI',
     platform: '플랫폼',
     currentWebUi: '현재 Web UI',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -271,6 +271,9 @@ export default {
   runtimeVersions: {
     title: 'Gerenciamento de versões',
     runtimeTitle: 'Hermes Runtime',
+    currentHermesAgentVersion: 'Versão atual do Hermes Agent',
+    activeRuntimeDirectory: 'Caminho do Runtime ativo',
+    cliUpdateDescription: 'No Hermes Runtime 0.19.1 e versões posteriores, o comando abaixo atualiza somente o Hermes Agent integrado. Ele não atualiza o aplicativo desktop Hermes Studio nem a Web UI. Feche completamente o Hermes Studio antes de executá-lo:',
     webUiTitle: 'Web UI',
     platform: 'Plataforma',
     currentWebUi: 'Web UI atual',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -181,6 +181,9 @@ export default {
   runtimeVersions: {
     title: 'Управление версиями',
     runtimeTitle: 'Hermes Runtime',
+    currentHermesAgentVersion: 'Текущая версия Hermes Agent',
+    activeRuntimeDirectory: 'Путь к активному Runtime',
+    cliUpdateDescription: 'В Hermes Runtime версии 0.19.1 и новее следующая команда обновляет только встроенный Hermes Agent. Она не обновляет настольное приложение Hermes Studio или Web UI. Перед выполнением полностью закройте Hermes Studio:',
     webUiTitle: 'Web UI',
     platform: 'Платформа',
     currentWebUi: 'Текущий Web UI',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -259,6 +259,9 @@ export default {
   runtimeVersions: {
     title: '版本管理',
     runtimeTitle: 'Hermes Runtime',
+    currentHermesAgentVersion: '目前 Hermes Agent 版本',
+    activeRuntimeDirectory: '目前 Runtime 路徑',
+    cliUpdateDescription: 'Hermes Runtime 0.19.1 及以上版本支援透過以下指令單獨升級內建的 Hermes Agent；此指令不會升級 Hermes Studio 桌面端或 Web UI。執行前請先完全結束 Hermes Studio：',
     webUiTitle: 'Web UI',
     platform: '平台',
     currentWebUi: '目前 Web UI',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -259,6 +259,9 @@ export default {
   runtimeVersions: {
     title: '版本管理',
     runtimeTitle: 'Hermes Runtime',
+    currentHermesAgentVersion: '当前 Hermes Agent 版本',
+    activeRuntimeDirectory: '当前 Runtime 路径',
+    cliUpdateDescription: 'Hermes Runtime 0.19.1 及以上版本支持通过以下命令单独升级内置的 Hermes Agent；该命令不会升级 Hermes Studio 桌面端或 Web UI。执行前请先完全退出 Hermes Studio：',
     webUiTitle: 'Web UI',
     platform: '平台',
     currentWebUi: '当前 Web UI',

--- a/packages/server/src/services/runtime-version-manager.ts
+++ b/packages/server/src/services/runtime-version-manager.ts
@@ -5,7 +5,7 @@ import { get as httpsGet } from 'https'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path'
 import * as tar from 'tar'
 import { config } from '../config'
-import { getHermesWebUiVersion } from './system-info'
+import { getHermesAgentVersion, getHermesWebUiVersion } from './system-info'
 
 const ACTIVE_VERSION_FILE = 'active-version.json'
 const DEFAULT_REMOTE_MANIFEST_URL = 'https://hermes-studio.ai/versions.json'
@@ -76,6 +76,7 @@ export interface RuntimeVersionStatus {
   remoteError: string
   hermes: {
     activeVersion: string
+    agentVersion: string
     activeDirectory: string
     storageDirectory: string
     defaultStorageDirectory: string
@@ -335,7 +336,10 @@ async function fetchRemoteVersions(): Promise<{ manifest: RemoteVersionManifest 
 
 export async function getRuntimeVersionStatus(): Promise<RuntimeVersionStatus> {
   const active = readActiveVersionManifest()
-  const { manifest, error } = await fetchRemoteVersions()
+  const [{ manifest, error }, agentVersion] = await Promise.all([
+    fetchRemoteVersions(),
+    getHermesAgentVersion(),
+  ])
   const webUiVersion = getHermesWebUiVersion()
 
   return {
@@ -346,6 +350,7 @@ export async function getRuntimeVersionStatus(): Promise<RuntimeVersionStatus> {
     remoteError: error,
     hermes: {
       activeVersion: active?.hermesRuntimeVersion || '',
+      agentVersion,
       activeDirectory: active?.runtimeDirectory || '',
       storageDirectory: runtimeStorageRoot(active),
       defaultStorageDirectory: defaultDesktopRuntimeRoot(),

--- a/packages/server/src/services/system-info.ts
+++ b/packages/server/src/services/system-info.ts
@@ -70,6 +70,10 @@ export function normalizeHermesAgentVersion(raw: string): string {
   return raw.split('\n')[0]?.replace(/^Hermes Agent\s+/, '').trim() || ''
 }
 
+export async function getHermesAgentVersion(): Promise<string> {
+  return normalizeHermesAgentVersion(await hermesCli.getVersion())
+}
+
 function isValidDeviceIdentity(value: any): value is DeviceIdentity {
   return typeof value?.device_id === 'string' &&
     value.device_id.length >= 16 &&
@@ -152,7 +156,7 @@ export function verifyDeviceSignature(input: {
 }
 
 export async function getPublicSystemInfo(): Promise<PublicSystemInfo> {
-  const hermesAgentVersion = normalizeHermesAgentVersion(await hermesCli.getVersion())
+  const hermesAgentVersion = await getHermesAgentVersion()
   const identity = await getDeviceIdentity()
 
   return {

--- a/tests/client/version-management-modal.test.ts
+++ b/tests/client/version-management-modal.test.ts
@@ -47,6 +47,7 @@ function runtimeStatus() {
     remoteError: '',
     hermes: {
       activeVersion: '0.18.0',
+      agentVersion: 'v0.19.1 (2026.7.30) · upstream 3f497e2b · local 470cf66b (+1 carried commit)',
       activeDirectory: '/state/desktop-runtime/hermes/0.18.0/mac-arm64',
       storageDirectory: '/state/desktop-runtime',
       defaultStorageDirectory: '/state/desktop-runtime',
@@ -74,6 +75,31 @@ describe('VersionManagementModal Runtime storage selector', () => {
     api.fetchRuntimeVersionStatus.mockResolvedValue(runtimeStatus())
     api.fetchVersionDownloadJobs.mockResolvedValue({ jobs: [] })
     api.selectRuntimeRoot.mockResolvedValue({ success: true, active: {} })
+  })
+
+  it('explains how to update Hermes Runtime from the command line', async () => {
+    const wrapper = mount(VersionManagementModal, { props: { show: false } })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    const note = wrapper.get('[data-testid="runtime-cli-update-note"]')
+    expect(note.text()).toContain('runtimeVersions.cliUpdateDescription')
+    expect(note.text()).toContain('hermes-studio cli update')
+  })
+
+  it('shows the installed Hermes Agent version instead of the Runtime package version', async () => {
+    const wrapper = mount(VersionManagementModal, { props: { show: false } })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    const activeVersion = wrapper.get('[data-testid="active-hermes-agent-version"]')
+    expect(activeVersion.text()).toContain('v0.19.1 (2026.7.30)')
+    expect(activeVersion.text()).not.toContain('upstream')
+    expect(activeVersion.text()).not.toContain('0.18.0')
+    expect(activeVersion.attributes('title')).toContain('local 470cf66b')
+
+    const runtimeDirectory = wrapper.get('[data-testid="active-runtime-directory"]')
+    expect(runtimeDirectory.text()).toContain('/state/desktop-runtime/hermes/0.18.0/mac-arm64')
   })
 
   it('opens the desktop picker and schedules migration to the selected directory', async () => {

--- a/tests/server/runtime-version-manager.test.ts
+++ b/tests/server/runtime-version-manager.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../packages/server/src/config', () => ({
 }))
 
 vi.mock('../../packages/server/src/services/system-info', () => ({
+  getHermesAgentVersion: () => 'v2026.8.1',
   getHermesWebUiVersion: () => '0.6.31',
 }))
 
@@ -36,6 +37,7 @@ describe('runtime version manager storage migration', () => {
 
   afterEach(() => {
     process.env = { ...originalEnv }
+    vi.unstubAllGlobals()
     vi.resetModules()
     for (const directory of tempDirs.splice(0)) {
       rmSync(directory, { recursive: true, force: true })
@@ -62,6 +64,27 @@ describe('runtime version manager storage migration', () => {
     expect(active.pendingRuntimeRootDirectory).toBe(resolve(destination))
     expect(persisted.pendingRuntimeRootDirectory).toBe(resolve(destination))
     expect(persisted.runtimeRootDirectory).toBeUndefined()
+  })
+
+  it('reports the installed Hermes Agent version separately from the Runtime package version', async () => {
+    const activeVersionPath = join(state.appHome, 'desktop-runtime', 'active-version.json')
+    mkdirSync(join(state.appHome, 'desktop-runtime'), { recursive: true })
+    writeFileSync(activeVersionPath, JSON.stringify({
+      schema: 1,
+      hermesRuntimeVersion: '0.19.1',
+      runtimeDirectory: join(state.appHome, 'desktop-runtime', 'hermes', '0.19.1', 'test-platform'),
+      platform: 'test-platform',
+    }))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ schema: 1, hermes: ['0.19.1'], webui: ['0.6.31'] }),
+    }))
+
+    const { getRuntimeVersionStatus } = await import('../../packages/server/src/services/runtime-version-manager')
+    const status = await getRuntimeVersionStatus()
+
+    expect(status.hermes.activeVersion).toBe('0.19.1')
+    expect(status.hermes.agentVersion).toBe('v2026.8.1')
   })
 
   it('rejects a destination nested inside the current Runtime storage root', async () => {


### PR DESCRIPTION
## Summary

- query the active `HERMES_BIN --version` when loading version-management status so the UI reports the installed Hermes Agent version instead of the Runtime package version
- keep the Runtime package version separate for download, activation, and directory management
- show the readable Hermes Agent release on its own line, place the active Runtime path on a second line, and retain full Git provenance in the version tooltip
- explain that `hermes-studio cli update` updates only the bundled Hermes Agent, not the Hermes Studio desktop app or Web UI, and that Hermes Studio must be fully closed first
- add the new guidance and labels to all 11 locales

## Why

The version-management drawer previously labeled the Runtime package version (for example `0.19.1`) as the active Hermes version. After users upgraded the bundled Hermes checkout from the CLI, that value did not change and no longer represented the code actually running. Displaying the full CLI version and Runtime path in one row also produced a cramped layout, while the CLI command could be mistaken for a Hermes Studio application update.

## Impact

Users now see the real installed Hermes Agent release reported by the active runtime. The compact release string remains readable, full upstream/local Git details are available on hover, and the Runtime path is presented separately. The update note explicitly describes the command scope and shutdown requirement.

## Validation

- `npm test -- tests/client/version-management-modal.test.ts tests/server/runtime-version-manager.test.ts tests/server/system-info.test.ts` (11 tests)
- `npx vue-tsc -b`
- `npm run harness:check`
- `git diff --check`
