### PR TITLE
fix(bridge): honor model-specific reasoning overrides

### DIFF
--- a/docs/chat-chain-changes/2026-08-02-model-aware-reasoning-defaults.md
+++ b/docs/chat-chain-changes/2026-08-02-model-aware-reasoning-defaults.md
@@ -1,0 +1,9 @@
+---
+date: 2026-08-02
+pr: pending
+feature: Model-aware Agent Bridge reasoning defaults
+impact: Fresh Studio agents now inherit Hermes per-model reasoning overrides before the global reasoning effort.
+---
+
+Explicit per-run reasoning effort remains the highest-priority override and is
+restored to the model-aware constructor default after the run.

--- a/docs/chat-chain-changes/2026-08-02-model-aware-reasoning-defaults.md
+++ b/docs/chat-chain-changes/2026-08-02-model-aware-reasoning-defaults.md
@@ -1,9 +1,9 @@
 ---
 date: 2026-08-02
-pr: pending
+pr: 2325
 feature: Model-aware Agent Bridge reasoning defaults
-impact: Fresh Studio agents now inherit Hermes per-model reasoning overrides before the global reasoning effort.
+impact: Fresh and successfully model-switched Studio agents now inherit Hermes per-model reasoning overrides before the global reasoning effort.
 ---
 
 Explicit per-run reasoning effort remains the highest-priority override and is
-restored to the model-aware constructor default after the run.
+restored to the current model-aware default after the run.

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -313,7 +313,7 @@ class AgentPool:
                     credential_pool=runtime.get("credential_pool"),
                     quiet_mode=True,
                     verbose_logging=False,
-                    reasoning_config=_load_reasoning_config(),
+                    reasoning_config=_load_reasoning_config(resolved_model),
                     service_tier=_load_service_tier(),
                     enabled_toolsets=_load_enabled_toolsets(),
                     platform=_bridge_platform(),

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -458,6 +458,10 @@ class AgentPool:
         if not callable(switch_model):
             raise RuntimeError("loaded agent does not support switch_model")
 
+        with _profile_env(target_profile):
+            _refresh_worker_profile_env()
+            reasoning_config = _load_reasoning_config(requested_model)
+
         switch_model(
             new_model=requested_model,
             new_provider=resolved_provider,
@@ -465,6 +469,7 @@ class AgentPool:
             base_url=runtime.get("base_url") or "",
             api_mode=runtime.get("api_mode") or "",
         )
+        session.agent.reasoning_config = reasoning_config
         if resolved_provider.lower() == "moa":
             self._install_moa_reference_callback(session)
         session.config.update({

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_runtime.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_runtime.py
@@ -894,15 +894,19 @@ def _log_worker_startup_context(profile: str | None) -> None:
         })
 
 
-def _load_reasoning_config() -> dict[str, Any] | None:
+def _load_reasoning_config(model: str = "") -> dict[str, Any] | None:
     _ensure_agent_imports()
     try:
-        from hermes_constants import parse_reasoning_effort
+        from hermes_constants import resolve_reasoning_config
+    except ImportError:
+        try:
+            from hermes_constants import parse_reasoning_effort
 
-        effort = str((_load_cfg().get("agent") or {}).get("reasoning_effort", "") or "").strip()
-        return parse_reasoning_effort(effort)
-    except Exception:
-        return None
+            effort = str((_load_cfg().get("agent") or {}).get("reasoning_effort", "") or "").strip()
+            return parse_reasoning_effort(effort)
+        except Exception:
+            return None
+    return resolve_reasoning_config(_load_cfg(), model)
 
 
 def _load_service_tier() -> str | None:

--- a/tests/server/agent-bridge-profile-env.test.ts
+++ b/tests/server/agent-bridge-profile-env.test.ts
@@ -495,7 +495,7 @@ bridge._ensure_agent_imports = lambda: None
 bridge._load_cfg = lambda: {"model": {"default": "work-model"}, "agent": {}}
 bridge._resolve_runtime = lambda model, provider=None: {"provider": "fake"}
 bridge._load_enabled_toolsets = lambda: ["mcp-anysearch"]
-bridge._load_reasoning_config = lambda: None
+bridge._load_reasoning_config = lambda *_args: None
 bridge._load_service_tier = lambda: None
 
 pool = bridge.AgentPool()
@@ -576,7 +576,7 @@ bridge._load_cfg = lambda: {"model": {"default": "fake-model"}, "agent": {}}
 bridge._resolve_runtime = lambda model, provider=None: {"provider": "fake"}
 bridge._load_enabled_toolsets = lambda: []
 bridge._discover_bridge_mcp_tools = lambda: []
-bridge._load_reasoning_config = lambda: None
+bridge._load_reasoning_config = lambda *_args: None
 bridge._load_service_tier = lambda: None
 
 pool = bridge.AgentPool()
@@ -684,7 +684,7 @@ bridge._load_cfg = lambda: {"model": {"default": "fake-model"}, "agent": {}}
 bridge._resolve_runtime = lambda model, provider=None: {"provider": "fake"}
 bridge._load_enabled_toolsets = lambda: []
 bridge._discover_bridge_mcp_tools = lambda: []
-bridge._load_reasoning_config = lambda: None
+bridge._load_reasoning_config = lambda *_args: None
 bridge._load_service_tier = lambda: None
 
 pool = bridge.AgentPool()

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -160,6 +160,7 @@ spec = importlib.util.spec_from_file_location("hermes_bridge", path)
 bridge = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = bridge
 spec.loader.exec_module(bridge)
+bridge._load_reasoning_config = lambda *_args, **_kwargs: {}
 
 class FakeDb:
     def __init__(self):

--- a/tests/server/agent-bridge-reasoning-effort.test.ts
+++ b/tests/server/agent-bridge-reasoning-effort.test.ts
@@ -100,6 +100,10 @@ class FakeAIAgent:
         self.raise_on_run = False
         self.run_reasoning_configs = []
 
+    def switch_model(self, **kwargs):
+        self.model = kwargs["new_model"]
+        self.provider = kwargs["new_provider"]
+
     def run_conversation(self, _message, **_kwargs):
         self.run_reasoning_configs.append(dict(self.reasoning_config or {}))
         if self.raise_on_run:
@@ -148,6 +152,23 @@ print(json.dumps({
       { model: 'gpt-5.6-sol', received_config: true },
       { model: 'gpt-5.6-orbit', received_config: true },
     ])
+  })
+
+  it('refreshes model-aware reasoning for a loaded session switched from Luna to Sol', () => {
+    const result = runPython(`${reasoningHarness}
+session = pool.get_or_create("switched", model="gpt-5.6-luna")
+before = dict(session.agent.reasoning_config)
+pool.switch_session_model("switched", "gpt-5.6-sol", "openai", "default")
+print(json.dumps({
+    "before": before,
+    "after": session.agent.reasoning_config,
+    "model": session.config["model"],
+}))
+`)
+
+    expect(result.before.effort).toBe('max')
+    expect(result.after.effort).toBe('xhigh')
+    expect(result.model).toBe('gpt-5.6-sol')
   })
 
   it('keeps the global parser fallback for Hermes runtimes without the shared resolver', () => {

--- a/tests/server/agent-bridge-reasoning-effort.test.ts
+++ b/tests/server/agent-bridge-reasoning-effort.test.ts
@@ -1,7 +1,228 @@
+import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
 
+function runPython(script: string): any {
+  try {
+    return JSON.parse(execFileSync('python3', ['-c', script], {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    }))
+  }
+  catch (error) {
+    const err = error as { stdout?: string; stderr?: string; message?: string }
+    throw new Error([
+      err.message || 'Python bridge reasoning script failed',
+      err.stdout ? `stdout:\n${err.stdout}` : '',
+      err.stderr ? `stderr:\n${err.stderr}` : '',
+    ].filter(Boolean).join('\n\n'))
+  }
+}
+
+const reasoningHarness = String.raw`
+import contextlib
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+config = {
+    "model": "gpt-5.6-luna",
+    "agent": {
+        "reasoning_effort": "xhigh",
+        "reasoning_overrides": {
+            "gpt-5.6-luna": "max",
+            "gpt-5.6-sol": "xhigh",
+        },
+    },
+}
+resolved_configs = {
+    "gpt-5.6-luna": {"enabled": True, "effort": "max"},
+    "gpt-5.6-sol": {"enabled": True, "effort": "xhigh"},
+    "gpt-5.6-orbit": {"enabled": True, "effort": "xhigh"},
+}
+resolver_calls = []
+
+hermes_constants = types.ModuleType("hermes_constants")
+def parse_reasoning_effort(effort):
+    normalized = str(effort or "").strip()
+    return {"enabled": True, "effort": normalized} if normalized else None
+def resolve_reasoning_config(cfg, model):
+    resolver_calls.append({"model": model, "received_config": cfg is config})
+    return resolved_configs[model]
+hermes_constants.parse_reasoning_effort = parse_reasoning_effort
+hermes_constants.resolve_reasoning_config = resolve_reasoning_config
+sys.modules["hermes_constants"] = hermes_constants
+
+runtime_spec = importlib.util.spec_from_file_location(
+    "bridge_runtime",
+    "packages/server/src/services/hermes/agent-bridge/python/bridge_runtime.py",
+)
+bridge_runtime = importlib.util.module_from_spec(runtime_spec)
+assert runtime_spec.loader is not None
+sys.modules["bridge_runtime"] = bridge_runtime
+runtime_spec.loader.exec_module(bridge_runtime)
+
+bridge_runtime._ensure_agent_imports = lambda: None
+bridge_runtime._load_cfg = lambda: config
+bridge_runtime._base_hermes_home = lambda: Path(tempfile.gettempdir())
+bridge_runtime._bridge_platform = lambda: "agent-bridge"
+bridge_runtime._cfg_max_turns = lambda *_args, **_kwargs: 20
+bridge_runtime._discover_bridge_mcp_tools = lambda *_args, **_kwargs: []
+bridge_runtime._hermes_home = lambda *_args, **_kwargs: Path(tempfile.gettempdir())
+bridge_runtime._install_execute_code_approval_memory_patch = lambda *_args, **_kwargs: None
+bridge_runtime._jsonable = lambda value: value
+bridge_runtime._load_enabled_toolsets = lambda *_args, **_kwargs: []
+bridge_runtime._load_service_tier = lambda *_args, **_kwargs: None
+bridge_runtime._mcp_tool_names_from_names = lambda *_args, **_kwargs: []
+bridge_runtime._profile_home = lambda *_args, **_kwargs: Path(tempfile.gettempdir())
+bridge_runtime._refresh_approval_allowlist = lambda *_args, **_kwargs: None
+bridge_runtime._refresh_worker_profile_env = lambda *_args, **_kwargs: None
+bridge_runtime._resolve_model = lambda cfg: str(cfg.get("model") or "")
+bridge_runtime._resolve_runtime = lambda model, provider=None: {"provider": provider or "openai"}
+bridge_runtime._suppress_bridge_platform_hint = lambda: None
+bridge_runtime._tool_names_from_definitions = lambda *_args, **_kwargs: []
+
+@contextlib.contextmanager
+def profile_env(_profile):
+    yield
+bridge_runtime._profile_env = profile_env
+
+class FakeAIAgent:
+    def __init__(self, **kwargs):
+        self.model = kwargs.get("model")
+        self.provider = kwargs.get("provider")
+        self.reasoning_config = kwargs.get("reasoning_config")
+        self.tools = []
+        self.raise_on_run = False
+        self.run_reasoning_configs = []
+
+    def run_conversation(self, _message, **_kwargs):
+        self.run_reasoning_configs.append(dict(self.reasoning_config or {}))
+        if self.raise_on_run:
+            raise RuntimeError("run failed")
+        return {"final_response": "ok", "messages": []}
+
+run_agent = types.ModuleType("run_agent")
+run_agent.AIAgent = FakeAIAgent
+sys.modules["run_agent"] = run_agent
+
+pool_spec = importlib.util.spec_from_file_location(
+    "bridge_pool",
+    "packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py",
+)
+bridge_pool = importlib.util.module_from_spec(pool_spec)
+assert pool_spec.loader is not None
+sys.modules["bridge_pool"] = bridge_pool
+pool_spec.loader.exec_module(bridge_pool)
+
+pool = bridge_pool.AgentPool()
+pool._db = types.SimpleNamespace(
+    get_for_profile=lambda _profile: None,
+    error=None,
+)
+`
+
 describe('AgentBridgeClient.chat reasoning_effort forwarding', () => {
+  it('uses Hermes model-aware reasoning for fresh AgentPool sessions', () => {
+    const result = runPython(`${reasoningHarness}
+luna = pool.get_or_create("luna", model="gpt-5.6-luna")
+sol = pool.get_or_create("sol", model="gpt-5.6-sol")
+orbit = pool.get_or_create("orbit", model="gpt-5.6-orbit")
+print(json.dumps({
+    "luna": luna.agent.reasoning_config,
+    "sol": sol.agent.reasoning_config,
+    "orbit": orbit.agent.reasoning_config,
+    "resolver_calls": resolver_calls,
+}))
+`)
+
+    expect(result.luna.effort).toBe('max')
+    expect(result.sol.effort).toBe('xhigh')
+    expect(result.orbit.effort).toBe('xhigh')
+    expect(result.resolver_calls).toEqual([
+      { model: 'gpt-5.6-luna', received_config: true },
+      { model: 'gpt-5.6-sol', received_config: true },
+      { model: 'gpt-5.6-orbit', received_config: true },
+    ])
+  })
+
+  it('keeps the global parser fallback for Hermes runtimes without the shared resolver', () => {
+    const result = runPython(`${reasoningHarness}
+delattr(hermes_constants, "resolve_reasoning_config")
+legacy = bridge_runtime._load_reasoning_config("gpt-5.6-luna")
+print(json.dumps(legacy))
+`)
+
+    expect(result).toEqual({ enabled: true, effort: 'xhigh' })
+  })
+
+  it('does not hide errors raised inside the shared Hermes resolver', () => {
+    const result = runPython(`${reasoningHarness}
+def exploding_resolver(_cfg, _model):
+    raise RuntimeError("resolver exploded")
+hermes_constants.resolve_reasoning_config = exploding_resolver
+caught = None
+try:
+    bridge_runtime._load_reasoning_config("gpt-5.6-luna")
+except RuntimeError as exc:
+    caught = str(exc)
+print(json.dumps({"caught": caught}))
+`)
+
+    expect(result.caught).toBe('resolver exploded')
+  })
+
+  it('restores the model-aware default after explicit run overrides succeed or fail', () => {
+    const result = runPython(`${reasoningHarness}
+session = pool.get_or_create("override", model="gpt-5.6-luna")
+pool._enter_exec_ask_scope = lambda: None
+pool._exit_exec_ask_scope = lambda: None
+pool._install_approval_dispatcher_for_current_thread = lambda *_args: None
+pool._approval_callback = lambda *_args: None
+pool._prepersist_user_message = lambda *_args: None
+pool._session_db_message_count = lambda *_args: None
+pool._prepend_pending_model_switch_note = lambda _session, message: message
+pool._sync_result_tail_to_session_db = lambda *_args: None
+pool._result_from_agent_messages_for_sync = lambda *_args: None
+pool._apply_pending_session_model_switch = lambda *_args: None
+
+default_before = dict(session.agent.reasoning_config)
+session.running = True
+success = bridge_pool.RunRecord("success", session.session_id)
+pool._run_chat(session, success, "hello", reasoning_effort="high")
+after_success = dict(session.agent.reasoning_config)
+
+session.agent.raise_on_run = True
+session.running = True
+failure = bridge_pool.RunRecord("failure", session.session_id)
+pool._run_chat(session, failure, "hello", reasoning_effort="low")
+after_failure = dict(session.agent.reasoning_config)
+
+print(json.dumps({
+    "default_before": default_before,
+    "seen_during_runs": session.agent.run_reasoning_configs,
+    "after_success": after_success,
+    "after_failure": after_failure,
+    "statuses": [success.status, failure.status],
+    "failure_error": failure.error,
+}))
+`)
+
+    expect(result.default_before.effort).toBe('max')
+    expect(result.seen_during_runs).toEqual([
+      { enabled: true, effort: 'high' },
+      { enabled: true, effort: 'low' },
+    ])
+    expect(result.after_success.effort).toBe('max')
+    expect(result.after_failure.effort).toBe('max')
+    expect(result.statuses).toEqual(['complete', 'error'])
+    expect(result.failure_error).toBe('run failed')
+  })
+
   it('forwards maximum reasoning_effort when provided in options', async () => {
     const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
     const client = new AgentBridgeClient({ endpoint: 'tcp://127.0.0.1:1', connectRetryMs: 0, timeoutMs: 1 })


### PR DESCRIPTION
## Summary

- pass the resolved model into the Agent Bridge reasoning-config loader so fresh Studio agents use Hermes Agent's per-model `reasoning_overrides`
- retain the previous global `reasoning_effort` fallback for older Hermes runtimes
- preserve explicit per-run reasoning overrides and restore the model-aware default after both successful and failed runs
- add regression coverage for model-aware defaults, legacy fallback, resolver errors, and override restoration

Fixes #2306

## Validation

- `npm run test -- tests/server/agent-bridge-reasoning-effort.test.ts tests/server/agent-bridge-profile-env.test.ts` — 22/22 passed
- `npm run harness:check` — passed
- `npm run build` — passed
- `git diff --check` — passed
- independent Codex audit: candidate quality PASS; patch quality PASS
- publication-refresh replay: tracked diff and docs fragment byte-identical to the audited patch on canonical `main` at `6c14854a9a00433756f7c7fd2d303c39f46d74c7`

## Duplicate Check

Rechecked live on 2026-08-02 before publication:

- issue #2306 is open, with no labels or comments indicating ownership or a competing implementation
- exact issue-number PR search returned no matches
- model-aware/reasoning PR search found no patch touching the five changed paths
- recent canonical history and the refreshed `main` do not contain the fix

## Browser / Playwright

Not applicable. This patch changes the server-side Python Agent Bridge reasoning configuration and its unit-level regression coverage; it does not change a browser-visible UI flow.
