### PR TITLE
Switch MCU Global Agent to Ekko voice mode

### DIFF
--- a/docs/chat-chain-changes/2026-08-02-mcu-ekko-agent-runtime.md
+++ b/docs/chat-chain-changes/2026-08-02-mcu-ekko-agent-runtime.md
@@ -1,0 +1,32 @@
+---
+date: 2026-08-02
+pr: pending
+feature: MCU Global Agent Ekko runtime
+impact: MCU voice turns use Ekko Agent while retaining Global Agent session classification and deterministic device sessions.
+---
+
+Both MCU chat entry paths dispatch `/chat-run` requests through the
+`ekko-agent` runtime. They use `source=coding_agent` for runtime selection and
+`session_source=global_agent` for session persistence and filtering. Stale
+Hermes metadata is normalized when an existing MCU session next runs.
+
+Existing deterministic MCU sessions keep their history and workspace. On the
+first Ekko turn, stale Hermes or coding-agent metadata is migrated to
+`agent=ekko-agent` while the stored source remains `global_agent`. MCU relay,
+STT/TTS, interruption, session clear, and background-response delivery retain
+their existing behavior.
+
+MCU tool events now carry status metadata only: event type, interaction ID,
+tool name, and a generic failure marker when needed. Tool arguments, result
+previews, and error details stay on the server and are never forwarded to the
+device. This prevents large Ekko tool results from exceeding the firmware's
+WebSocket frame limit. Tool boundaries also reset the MCU speech accumulator
+so an Ekko final response delivered only by `run.completed.output` is still
+synthesized and played. No firmware changes are required.
+
+MCU turns also attach voice-specific system instructions to Ekko. User-facing
+responses must be brief, natural spoken plain text without Markdown. Work that
+can safely run asynchronously should use Ekko's `delegate_task` tool in
+background mode so the parent can acknowledge quickly instead of making the
+user wait. The same instructions are retained for autonomous continuation runs
+that deliver completed background results.

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -151,7 +151,9 @@ const liveReasoningDetail = computed<{
 
 const emptyState = computed(() => {
   const session = chatStore.activeSession;
-  const codingAgentId = session?.codingAgentId || (session?.agent === "codex" ? "codex" : session?.agent === "claude" ? "claude-code" : session?.agent === "ekko-agent" ? "ekko-agent" : undefined);
+  const codingAgentId = session?.source === "global_agent"
+    ? "ekko-agent"
+    : session?.codingAgentId || (session?.agent === "codex" ? "codex" : session?.agent === "claude" ? "claude-code" : session?.agent === "ekko-agent" ? "ekko-agent" : undefined);
   if (codingAgentId === "codex") {
     return {
       logo: "/coding-agents/codex-openai.png",

--- a/packages/client/src/components/hermes/chat/SessionListItem.vue
+++ b/packages/client/src/components/hermes/chat/SessionListItem.vue
@@ -46,6 +46,9 @@ const profileModelsMissing = computed(() =>
 )
 const isGlobalAgentSession = computed(() => props.session.source === 'global_agent')
 const sessionAgentLogo = computed(() => {
+  if (isGlobalAgentSession.value) {
+    return { label: 'Ekko Agent', src: '/coding-agents/ekko-agent.png' }
+  }
   if (props.session.source === 'coding_agent') {
     if (props.session.codingAgentId === 'codex' || props.session.agent === 'codex') {
       return { label: 'Codex', src: '/coding-agents/codex-openai.png' }

--- a/packages/server/src/services/global-agent/mcu-voice-instructions.ts
+++ b/packages/server/src/services/global-agent/mcu-voice-instructions.ts
@@ -1,0 +1,8 @@
+export const MCU_VOICE_SYSTEM_INSTRUCTIONS = [
+  'This session is a real-time voice conversation through an MCU device.',
+  'Keep every user-facing response brief, natural, and easy to understand when spoken aloud. Answer in the user\'s language.',
+  'Use plain text only. Do not use Markdown, headings, bullet lists, tables, code fences, or decorative formatting.',
+  'When a request requires tools or non-trivial work, maximize the use of delegate_task with mode="background" for work that can safely continue asynchronously. Split independent work into background subtasks when useful.',
+  'Give the user a very short acknowledgement and return promptly instead of making them wait. Use foreground work only when its result is required immediately for a safe or meaningful answer.',
+  'When a background result becomes available, proactively provide the concise spoken result. Never claim unfinished work is complete.',
+].join('\n')

--- a/packages/server/src/services/global-agent/outbound-relay-client.ts
+++ b/packages/server/src/services/global-agent/outbound-relay-client.ts
@@ -10,6 +10,7 @@ import { transcodeToPcmS16le } from '../hermes/stt-providers/audio-convert'
 import { encodeMcuImaAdpcm } from '../hermes/mcu-adpcm'
 import { MCU_TTS_SAMPLE_RATE, mcuPromptText, mcuPromptUrl } from '../hermes/mcu-prompts'
 import { createMcuSpeechSegmenter, normalizeMcuSpeechText } from './mcu-speech-segmenter'
+import { MCU_VOICE_SYSTEM_INSTRUCTIONS } from './mcu-voice-instructions'
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 const MAX_REQUEST_TIMEOUT_MS = 120_000
@@ -1034,8 +1035,10 @@ class McuSocketIoRelayClient {
           session_id: sessionId,
           queue_id: primaryQueueId,
           profile: voice.profile,
-          source: 'global_agent',
+          source: 'coding_agent',
           session_source: 'global_agent',
+          coding_agent_id: 'ekko-agent',
+          instructions: MCU_VOICE_SYSTEM_INSTRUCTIONS,
         }
         const interruptedAt = this.recentlyInterruptedSessions.get(sessionId) || 0
         if (Date.now() - interruptedAt < 10_000) {
@@ -1070,20 +1073,15 @@ class McuSocketIoRelayClient {
       socket.on('tool.started', (event: Record<string, unknown> = {}) => {
         if (!currentRunPrimary) return
         flushCompletedAssistantMessage()
+        output = ''
         const tool = typeof event.tool === 'string' ? event.tool : typeof event.name === 'string' ? event.name : 'tool'
-        const preview = typeof event.preview === 'string' ? event.preview : undefined
-        this.sendJson({ type: 'tool.started', interactionId: voice.interactionId, tool, preview })
+        this.sendJson({ type: 'tool.started', interactionId: voice.interactionId, tool })
       })
       const handleToolFinished = (event: Record<string, unknown> = {}, failed = false) => {
         if (!currentRunPrimary) return
         const tool = typeof event.tool === 'string' ? event.tool : typeof event.name === 'string' ? event.name : 'tool'
-        const preview = typeof event.preview === 'string' ? event.preview : undefined
-        const error = typeof event.error === 'string'
-          ? event.error
-          : failed
-            ? 'tool.failed'
-            : undefined
-        this.sendJson({ type: 'tool.completed', interactionId: voice.interactionId, tool, preview, error })
+        const error = failed ? 'tool.failed' : undefined
+        this.sendJson({ type: 'tool.completed', interactionId: voice.interactionId, tool, error })
       }
       socket.on('tool.completed', (event: Record<string, unknown> = {}) => handleToolFinished(event))
       socket.on('tool.failed', (event: Record<string, unknown> = {}) => handleToolFinished(event, true))
@@ -1214,7 +1212,6 @@ class McuSocketIoRelayClient {
             type: 'tool.started',
             interactionId: voice.interactionId,
             tool: 'approval',
-            preview: choice,
           })
         }
         socket.emit('approval.respond', {

--- a/packages/server/src/services/global-agent/server.ts
+++ b/packages/server/src/services/global-agent/server.ts
@@ -12,6 +12,7 @@ import { transcodeToPcmS16le } from '../hermes/stt-providers/audio-convert'
 import { decodeMcuImaAdpcm, encodeMcuImaAdpcm } from '../hermes/mcu-adpcm'
 import { MCU_TTS_SAMPLE_RATE, mcuPromptText, mcuPromptUrl } from '../hermes/mcu-prompts'
 import { createMcuSpeechSegmenter, normalizeMcuSpeechText } from './mcu-speech-segmenter'
+import { MCU_VOICE_SYSTEM_INSTRUCTIONS } from './mcu-voice-instructions'
 import type {
   RelayHttpRequest,
   RelayHttpResponse,
@@ -710,8 +711,10 @@ export class GlobalAgentServer {
         session_id: sessionId,
         queue_id: primaryQueueId,
         profile: options.profile,
-        source: 'global_agent',
+        source: 'coding_agent',
         session_source: 'global_agent',
+        coding_agent_id: 'ekko-agent',
+        instructions: MCU_VOICE_SYSTEM_INSTRUCTIONS,
       }
       const interruptedAt = this.recentlyInterruptedMcuSessions.get(sessionId) || 0
       if (Date.now() - interruptedAt < 10_000) {
@@ -746,20 +749,15 @@ export class GlobalAgentServer {
     socket.on('tool.started', (event: Record<string, unknown> = {}) => {
       if (!currentRunPrimary) return
       flushCompletedAssistantMessage()
+      output = ''
       const tool = typeof event.tool === 'string' ? event.tool : typeof event.name === 'string' ? event.name : 'tool'
-      const preview = typeof event.preview === 'string' ? event.preview : undefined
-      this.emitMcuEvent({ type: 'tool.started', interactionId: options.interactionId, tool, preview }, { clientId: options.clientId })
+      this.emitMcuEvent({ type: 'tool.started', interactionId: options.interactionId, tool }, { clientId: options.clientId })
     })
     const handleToolFinished = (event: Record<string, unknown> = {}, failed = false) => {
       if (!currentRunPrimary) return
       const tool = typeof event.tool === 'string' ? event.tool : typeof event.name === 'string' ? event.name : 'tool'
-      const preview = typeof event.preview === 'string' ? event.preview : undefined
-      const error = typeof event.error === 'string'
-        ? event.error
-        : failed
-          ? 'tool.failed'
-          : undefined
-      this.emitMcuEvent({ type: 'tool.completed', interactionId: options.interactionId, tool, preview, error }, { clientId: options.clientId })
+      const error = failed ? 'tool.failed' : undefined
+      this.emitMcuEvent({ type: 'tool.completed', interactionId: options.interactionId, tool, error }, { clientId: options.clientId })
     }
     socket.on('tool.completed', (event: Record<string, unknown> = {}) => handleToolFinished(event))
     socket.on('tool.failed', (event: Record<string, unknown> = {}) => handleToolFinished(event, true))
@@ -875,7 +873,7 @@ export class GlobalAgentServer {
         return
       }
       if (!currentRunAutonomous) {
-        this.emitMcuEvent({ type: 'tool.started', interactionId: options.interactionId, tool: 'approval', preview: choice }, { clientId: options.clientId })
+        this.emitMcuEvent({ type: 'tool.started', interactionId: options.interactionId, tool: 'approval' }, { clientId: options.clientId })
       }
       socket.emit('approval.respond', {
         session_id: sessionId,

--- a/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
@@ -48,12 +48,14 @@ export interface EkkoAgentRunSocketData {
   provider?: string
   model?: string
   model_groups?: RunModelGroup[]
+  instructions?: string
   coding_agent_id?: ChatCodingAgentId
   agent_id?: ChatCodingAgentId
   mode?: 'scoped' | 'global'
   workspace?: string | null
   category_id?: number | null
   source?: string
+  session_source?: 'global_agent' | 'workflow'
   baseUrl?: string
   base_url?: string
   apiKey?: string
@@ -429,6 +431,15 @@ export async function handleEkkoAgentRun(
   const storageText = data.storage_message !== undefined ? data.storage_message : displayText
   const shouldPersistUserMessage = !skipUserMessage && displayInput !== null
   const now = Math.floor(Date.now() / 1000)
+  const instructions = String(data.instructions || '').trim()
+  const instructionMessages: AgentMessage[] = instructions
+    ? [{ role: 'system', content: instructions }]
+    : []
+  const sessionSource = data.session_source === 'global_agent'
+    ? 'global_agent'
+    : data.session_source === 'workflow' || data.source === 'workflow'
+      ? 'workflow'
+      : 'coding_agent'
   const emit = (event: string, payload: any) => {
     const tagged = { ...payload, session_id: sessionId }
     observeRunChatPetEvent(profile, event, tagged)
@@ -446,7 +457,7 @@ export async function handleEkkoAgentRun(
     createSession({
       id: sessionId,
       profile,
-      source: 'coding_agent',
+      source: sessionSource,
       agent: 'ekko-agent',
       agent_mode: 'scoped',
       model: modelConfig.model,
@@ -455,6 +466,20 @@ export async function handleEkkoAgentRun(
       title,
       workspace,
       category_id: data.category_id,
+    })
+  } else if (
+    storedSession.source !== sessionSource ||
+    storedSession.agent !== 'ekko-agent' ||
+    storedSession.agent_mode !== 'scoped' ||
+    storedSession.agent_session_id ||
+    storedSession.agent_native_session_id
+  ) {
+    updateSession(sessionId, {
+      source: sessionSource,
+      agent: 'ekko-agent',
+      agent_mode: 'scoped',
+      agent_session_id: '',
+      agent_native_session_id: '',
     })
   }
   if (storedSession && apiMode && storedSession.api_mode !== apiMode) {
@@ -620,9 +645,11 @@ export async function handleEkkoAgentRun(
       storageMessage: continuationMessage,
       model: modelConfig.model,
       provider: modelConfig.provider,
+      instructions,
       profile,
       workspace,
       source: state.source,
+      sessionSource: data.session_source,
       codingAgentId: 'ekko-agent',
       mode: data.mode,
       baseUrl,
@@ -1124,7 +1151,7 @@ export async function handleEkkoAgentRun(
           modelClient,
           model: modelConfig.model,
           modelDefaults: { model: modelConfig.model },
-          messages: [],
+          messages: instructionMessages,
           signal: abortController.signal,
           memoryEnabled: false,
           toolContext,
@@ -1150,6 +1177,7 @@ export async function handleEkkoAgentRun(
         reasoningSummary: 'auto',
       },
       messages: [
+        ...instructionMessages,
         ...await toAgentMessages(compressedHistory),
         currentMessage,
       ],

--- a/tests/server/global-agent-server.test.ts
+++ b/tests/server/global-agent-server.test.ts
@@ -3,6 +3,7 @@ import {
   decodeMcuImaAdpcm,
   encodeMcuImaAdpcm,
 } from '../../packages/server/src/services/hermes/mcu-adpcm'
+import { MCU_VOICE_SYSTEM_INSTRUCTIONS } from '../../packages/server/src/services/global-agent/mcu-voice-instructions'
 
 const authMocks = vi.hoisted(() => ({
   authenticateUserToken: vi.fn(),
@@ -169,6 +170,12 @@ function startPrimaryMockRun(socket: any, runId = 'run-primary'): string {
   const runCall = socket.emit.mock.calls
     .filter(([event]: [string]) => event === 'run')
     .at(-1)
+  expect(runCall?.[1]).toMatchObject({
+    source: 'coding_agent',
+    session_source: 'global_agent',
+    coding_agent_id: 'ekko-agent',
+    instructions: MCU_VOICE_SYSTEM_INSTRUCTIONS,
+  })
   const queueId = runCall?.[1]?.queue_id
   expect(queueId).toMatch(/^mcu_/)
   socket.__handlers.get('run.started')?.({ run_id: runId, queue_id: queueId })
@@ -981,7 +988,15 @@ describe('GlobalAgentServer', () => {
     expect(JSON.parse(String(fetchImpl.mock.calls[0][1]?.body))).toMatchObject({
       text: '好嘞，这就去查。',
     })
-    localSocket.__handlers.get('tool.started')?.({ tool: 'weather', preview: '厦门天气' })
+    localSocket.__handlers.get('tool.started')?.({
+      tool: 'weather',
+      preview: '不应转发给 MCU 的工具参数'.repeat(1_000),
+    })
+    expect(agentSocket.emit).toHaveBeenCalledWith('tool.started', {
+      type: 'tool.started',
+      interactionId: 'voice-1',
+      tool: 'weather',
+    })
     await waitForMockCallWith(agentSocket.emit, ([event, payload]) =>
       event === 'audio.enqueue' && (payload as { segmentId?: string })?.segmentId === 'voice-1-tts-1',
     )
@@ -997,10 +1012,19 @@ describe('GlobalAgentServer', () => {
       status: 'speaking',
       text: '好嘞，这就去查。',
     }))
-    localSocket.__handlers.get('tool.completed')?.({ tool: 'weather' })
-    localSocket.__handlers.get('message.delta')?.({ delta: '结果如下：\n| 名称 | 值 |\n' })
-    localSocket.__handlers.get('message.delta')?.({ delta: '| --- | --- |\n| foo | 1 |\n请确认。\n' })
-    localSocket.__handlers.get('run.completed')?.({})
+    localSocket.__handlers.get('tool.completed')?.({
+      tool: 'weather',
+      preview: '不应转发给 MCU 的工具结果'.repeat(1_000),
+    })
+    expect(agentSocket.emit).toHaveBeenCalledWith('tool.completed', {
+      type: 'tool.completed',
+      interactionId: 'voice-1',
+      tool: 'weather',
+      error: undefined,
+    })
+    localSocket.__handlers.get('run.completed')?.({
+      output: '结果如下：\n| 名称 | 值 |\n| --- | --- |\n| foo | 1 |\n请确认。\n',
+    })
 
     await waitForMockCalls(fetchImpl, 2)
     expect(JSON.parse(String(fetchImpl.mock.calls[1][1]?.body))).toMatchObject({
@@ -1529,7 +1553,6 @@ describe('GlobalAgentServer', () => {
       type: 'tool.started',
       interactionId: 'voice-1',
       tool: 'approval',
-      preview: 'session',
     })
     expect(localSocket.emit).toHaveBeenCalledWith('approval.respond', {
       session_id: 'mcu-device-1-research',
@@ -1544,13 +1567,16 @@ describe('GlobalAgentServer', () => {
       tool: 'approval',
       error: undefined,
     })
-    localSocket.__handlers.get('tool.failed')?.({ tool: 'weather', error: 'permission denied' })
+    localSocket.__handlers.get('tool.failed')?.({
+      tool: 'weather',
+      preview: '不应转发给 MCU 的失败结果'.repeat(1_000),
+      error: '不应转发给 MCU 的错误详情'.repeat(1_000),
+    })
     expect(agentSocket.emit).toHaveBeenCalledWith('tool.completed', {
       type: 'tool.completed',
       interactionId: 'voice-1',
       tool: 'weather',
-      preview: undefined,
-      error: 'permission denied',
+      error: 'tool.failed',
     })
     localSocket.__handlers.get('run.failed')?.({ error: 'done' })
   })

--- a/tests/server/outbound-relay-client.test.ts
+++ b/tests/server/outbound-relay-client.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MCU_VOICE_SYSTEM_INSTRUCTIONS } from '../../packages/server/src/services/global-agent/mcu-voice-instructions'
 
 const { mockIo, mockSocket, sockets, socketHandlers, mockWebSockets, MockWebSocket, resetMockSockets } = vi.hoisted(() => {
   function createMockSocket(id: string, url = '') {
@@ -123,6 +124,12 @@ describe('outbound relay client', () => {
     const runCall = socket.emit.mock.calls
       .filter(([event]: [string]) => event === 'run')
       .at(-1)
+    expect(runCall?.[1]).toMatchObject({
+      source: 'coding_agent',
+      session_source: 'global_agent',
+      coding_agent_id: 'ekko-agent',
+      instructions: MCU_VOICE_SYSTEM_INSTRUCTIONS,
+    })
     const queueId = runCall?.[1]?.queue_id
     expect(queueId).toMatch(/^mcu_/)
     socket.__handlers.get('run.started')?.({ run_id: runId, queue_id: queueId })
@@ -530,12 +537,44 @@ describe('outbound relay client', () => {
     const localSocket = socketForUrl('http://127.0.0.1:8648/chat-run')
     localSocket.__handlers.get('connect')?.()
     startPrimaryMockRun(localSocket)
-    localSocket.__handlers.get('message.delta')?.({ delta: '你好' })
-    localSocket.__handlers.get('run.completed')?.({})
+    localSocket.__handlers.get('message.delta')?.({ delta: '我来查一下。\n' })
+    localSocket.__handlers.get('tool.started')?.({
+      tool: 'weather',
+      preview: 'tool arguments must stay local'.repeat(1_000),
+    })
+    localSocket.__handlers.get('tool.completed')?.({
+      tool: 'weather',
+      preview: 'tool result must stay local'.repeat(1_000),
+    })
+    expect(remoteSocket.emit).toHaveBeenCalledWith('tool.started', {
+      type: 'tool.started',
+      interactionId: 'voice-tts-ok',
+      tool: 'weather',
+    })
+    expect(remoteSocket.emit).toHaveBeenCalledWith('tool.completed', {
+      type: 'tool.completed',
+      interactionId: 'voice-tts-ok',
+      tool: 'weather',
+      error: undefined,
+    })
+    localSocket.__handlers.get('run.completed')?.({ output: '厦门今天晴。' })
 
     await vi.waitFor(() => {
       expect(remoteSocket.emit).toHaveBeenCalledWith('audio.enqueue', expect.objectContaining({
+        text: '我来查一下。',
         url: 'http://device.local:8787/global-agent/audio/audio-1?token=download-token',
+      }))
+    })
+    emitRemote(remoteSocket, 'audio.done', {
+      type: 'audio.done',
+      interactionId: 'voice-tts-ok',
+      segmentId: 'voice-tts-ok-tts-1',
+    })
+    await vi.waitFor(() => {
+      expect(remoteSocket.emit).toHaveBeenCalledWith('audio.enqueue', expect.objectContaining({
+        interactionId: 'voice-tts-ok',
+        segmentId: 'voice-tts-ok-tts-2',
+        text: '厦门今天晴。',
       }))
     })
     const uploadCall = fetchImpl.mock.calls.find(([url]: [string]) => url === 'http://device.local:8787/global-agent/audio')

--- a/tests/server/run-chat-ekko-context.test.ts
+++ b/tests/server/run-chat-ekko-context.test.ts
@@ -337,6 +337,7 @@ describe('ekko-agent context usage events', () => {
       input: 'think carefully',
       coding_agent_id: 'ekko-agent',
       reasoning_effort: 'high',
+      instructions: 'Keep the spoken response short and use plain text.',
     }, 'default', sessionMap, vi.fn(() => false))
 
     expect(agentRunMock).toHaveBeenCalledWith(expect.objectContaining({
@@ -346,6 +347,10 @@ describe('ekko-agent context usage events', () => {
         reasoningEffort: 'high',
         reasoningSummary: 'auto',
       }),
+      messages: expect.arrayContaining([{
+        role: 'system',
+        content: 'Keep the spoken response short and use plain text.',
+      }]),
     }))
   })
 
@@ -614,6 +619,7 @@ describe('ekko-agent context usage events', () => {
       session_id: 'session-1',
       input: 'run checks in the background',
       coding_agent_id: 'ekko-agent',
+      instructions: 'Keep the spoken response short and use plain text.',
       onEvent: (event: string, payload: any) => events.push({ event, payload }),
     }, 'default', sessionMap, dequeueNextQueuedRun)
 
@@ -715,6 +721,7 @@ describe('ekko-agent context usage events', () => {
       queue_id: 'ekko_subagent_child-background',
       displayInput: null,
       codingAgentId: 'ekko-agent',
+      instructions: 'Keep the spoken response short and use plain text.',
       autonomous: true,
       backgroundDelegationId: 'child-background',
     }))
@@ -915,6 +922,83 @@ describe('ekko-agent context usage events', () => {
         workspace: '/tmp/new-workspace',
       },
     })
+  })
+
+  it('keeps MCU Ekko sessions classified as global agent sessions', async () => {
+    getSessionMock.mockReturnValueOnce(null)
+    agentRunMock.mockResolvedValueOnce({
+      runId: 'run-1',
+      output: { role: 'assistant', content: 'done', usage: { inputTokens: 3, outputTokens: 2 } },
+      steps: [],
+      messages: [],
+      events: [],
+      contextEstimate: { contextTokens: 12_000 },
+    })
+    const { handleEkkoAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-ekko-agent-run')
+    const { nsp, socket, sessionMap } = makeHarness()
+
+    await handleEkkoAgentRun(nsp as any, socket as any, {
+      session_id: 'session-1',
+      input: 'hello from MCU',
+      source: 'coding_agent',
+      session_source: 'global_agent',
+      coding_agent_id: 'ekko-agent',
+    }, 'default', sessionMap, vi.fn(() => false))
+
+    expect(createSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'session-1',
+      source: 'global_agent',
+      agent: 'ekko-agent',
+      agent_mode: 'scoped',
+    }))
+  })
+
+  it('migrates an existing Hermes MCU session to Ekko metadata', async () => {
+    getSessionMock.mockReturnValue({
+      id: 'session-1',
+      profile: 'default',
+      source: 'global_agent',
+      agent: 'hermes',
+      agent_mode: '',
+      agent_session_id: '',
+      agent_native_session_id: '',
+      model: 'ekko-test-model',
+      provider: 'test-provider',
+      workspace: '/tmp/existing-mcu-workspace',
+    })
+    agentRunMock.mockResolvedValueOnce({
+      runId: 'run-1',
+      output: { role: 'assistant', content: 'done', usage: { inputTokens: 3, outputTokens: 2 } },
+      steps: [],
+      messages: [],
+      events: [],
+      contextEstimate: { contextTokens: 12_000 },
+    })
+    const { handleEkkoAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-ekko-agent-run')
+    const { nsp, socket, sessionMap } = makeHarness()
+
+    await handleEkkoAgentRun(nsp as any, socket as any, {
+      session_id: 'session-1',
+      input: 'continue on Ekko',
+      source: 'coding_agent',
+      session_source: 'global_agent',
+      coding_agent_id: 'ekko-agent',
+    }, 'default', sessionMap, vi.fn(() => false))
+
+    expect(createSessionMock).not.toHaveBeenCalled()
+    expect(updateSessionMock).toHaveBeenCalledWith('session-1', {
+      source: 'global_agent',
+      agent: 'ekko-agent',
+      agent_mode: 'scoped',
+      agent_session_id: '',
+      agent_native_session_id: '',
+    })
+    expect(agentRunMock).toHaveBeenCalledWith(expect.objectContaining({
+      toolContext: expect.objectContaining({
+        cwd: '/tmp/existing-mcu-workspace',
+        workspaceRoot: '/tmp/existing-mcu-workspace',
+      }),
+    }))
   })
 
   it('uses the profile-scoped Ekko session workspace by default', async () => {


### PR DESCRIPTION
## Summary

- Route both local and outbound MCU Global Agent turns through scoped Ekko Agent while preserving `global_agent` session classification, deterministic session IDs, history, and workspace.
- Add MCU voice-mode system instructions for concise spoken plain-text answers and background `delegate_task` usage where work can safely run asynchronously.
- Keep the voice instructions on autonomous continuation runs that deliver completed background results.
- Forward only tool status metadata to MCU devices; tool arguments, result previews, and detailed errors remain server-side.
- Show the Ekko Agent logo for Global Agent sessions in the shared chat UI.

## Why

Ekko `tool.completed` events can contain the full tool result in `preview`. The MCU forwarding path previously relayed that content unchanged, which could exceed the ESP32 WebSocket frame limit and disconnect the device before the final response audio was delivered. Global Agent sessions also needed to retain their existing classification while selecting the Ekko runtime.

## Impact

MCU voice turns now use Ekko Agent, remain short and suitable for speech, and can return quickly while independent work continues in background subtasks. Completed tool payloads no longer reach the device, preventing oversized tool-result frames. Existing Global Agent history and workspaces are preserved. No firmware changes are required.

## Validation

- `npm run test -- tests/server/global-agent-server.test.ts tests/server/outbound-relay-client.test.ts tests/server/run-chat-ekko-context.test.ts` (67 tests passed)
- `npm run harness:check`
- `npm run build`
- `git diff --check`
