### PR TITLE
fix(tts): accept speech providers that cannot return mp3

### DIFF
--- a/packages/server/src/controllers/hermes/tts.ts
+++ b/packages/server/src/controllers/hermes/tts.ts
@@ -3,6 +3,7 @@ import { createReadStream } from 'fs'
 import { stat } from 'fs/promises'
 import { textToSpeech, openaiCompatibleTts, speedToEdgeRate } from '../../services/hermes/tts'
 import { getTtsProvider } from '../../services/hermes/tts-providers'
+import { transcodeToMp3 } from '../../services/hermes/stt-providers/audio-convert'
 import { assertSafeResolvedTtsBaseUrl } from '../../services/hermes/tts-providers/url-safety'
 import { isValidMcuAudioFileName, resolveMcuAudioPath } from '../../services/hermes/mcu-prompts'
 import {
@@ -536,7 +537,9 @@ async function synthesizeVoiceProxyText(ctx: Context, text: string) {
   const options = {
     ...(stored?.settings || {}),
     ...(stored?.secrets || {}),
-    // Hermes' command provider writes to an .mp3 output path.
+    // Hermes' command provider writes to an .mp3 output path. A provider that
+    // cannot produce mp3 answers in whatever format it does support, and the
+    // response is transcoded below.
     format: 'mp3',
   }
   const provider = getTtsProvider(providerName)
@@ -552,10 +555,11 @@ async function synthesizeVoiceProxyText(ctx: Context, text: string) {
       { text: normalizedText, signal: controller.signal },
       options,
     )
-    ctx.set('Content-Type', result.contentType)
-    ctx.set('Content-Length', String(result.audio.length))
+    const mp3 = await transcodeToMp3(result.audio, result.contentType)
+    ctx.set('Content-Type', mp3.mimeType)
+    ctx.set('Content-Length', String(mp3.audio.length))
     ctx.set('X-TTS-Engine', 'hermes-studio')
-    ctx.body = result.audio
+    ctx.body = mp3.audio
   } catch (error) {
     if (isAbortError(error)) {
       ctx.status = 499

--- a/packages/server/src/services/hermes/stt-providers/audio-convert.ts
+++ b/packages/server/src/services/hermes/stt-providers/audio-convert.ts
@@ -125,7 +125,9 @@ export async function transcodeToMp3(
   mimeType: string,
 ): Promise<{ audio: Buffer; mimeType: string }> {
   const normalized = normalizeMimeType(mimeType)
-  if (normalized.includes('mpeg') || normalized.includes('mp3') || looksLikeMp3(input)) {
+  const wavBytes = looksLikeWav(input)
+  const claimsMp3 = normalized.includes('mpeg') || normalized.includes('mp3')
+  if (looksLikeMp3(input) || (!wavBytes && claimsMp3)) {
     return { audio: input, mimeType: 'audio/mpeg' }
   }
   if (!(await isFfmpegAvailable())) {

--- a/packages/server/src/services/hermes/stt-providers/audio-convert.ts
+++ b/packages/server/src/services/hermes/stt-providers/audio-convert.ts
@@ -111,6 +111,43 @@ export async function transcodeToWav(
   }
 }
 
+/**
+ * Transcode synthesized speech to MP3.
+ *
+ * Hermes' command TTS provider writes the response to an `.mp3` path, but not
+ * every OpenAI-compatible speech endpoint can produce MP3 — Groq's Orpheus
+ * models, for instance, only accept `response_format: wav`. Converting here
+ * lets those providers be used without lying about the file's contents.
+ * Without ffmpeg the audio is returned untouched.
+ */
+export async function transcodeToMp3(
+  input: Buffer,
+  mimeType: string,
+): Promise<{ audio: Buffer; mimeType: string }> {
+  const normalized = normalizeMimeType(mimeType)
+  if (normalized.includes('mpeg') || normalized.includes('mp3') || looksLikeMp3(input)) {
+    return { audio: input, mimeType: 'audio/mpeg' }
+  }
+  if (!(await isFfmpegAvailable())) {
+    return { audio: input, mimeType }
+  }
+
+  const mp3Buffer = await runFfmpeg([
+    '-hide_banner',
+    '-loglevel', 'error',
+    '-i', 'pipe:0',
+    '-codec:a', 'libmp3lame',
+    '-q:a', '2',
+    '-f', 'mp3',
+    'pipe:1',
+  ], input, TRANSCODE_TIMEOUT_MS)
+
+  if (mp3Buffer.length === 0) {
+    throw new Error('ffmpeg produced empty output')
+  }
+  return { audio: mp3Buffer, mimeType: 'audio/mpeg' }
+}
+
 export async function transcodeToPcmS16le(
   input: Buffer,
   mimeType: string,

--- a/packages/server/src/services/hermes/tts-providers/openai.ts
+++ b/packages/server/src/services/hermes/tts-providers/openai.ts
@@ -22,6 +22,22 @@ function buildSpeechUrl(baseUrl: string): string {
   return `${url.origin}${pathname}/audio/speech${search}`
 }
 
+/**
+ * Read the formats an endpoint says it accepts out of its own rejection.
+ *
+ * OpenAI-compatible speech endpoints do not all support mp3: Groq's Orpheus
+ * models answer `response_format must be one of [wav]`. The list is right there
+ * in the error, so honour it instead of making the user guess the format.
+ */
+function supportedFormatsFromError(body: string): string[] {
+  const match = body.match(/response_format must be one of \[([^\]]+)\]/i)
+  if (!match) return []
+  return match[1]
+    .split(',')
+    .map(value => value.trim().replace(/^['"]|['"]$/g, ''))
+    .filter(Boolean)
+}
+
 export function createOpenaiCompatibleTtsProvider(
   id: Extract<TtsProviderId, 'openai' | 'custom' | 'deepinfra'>,
   options: { engine?: string; defaultBaseUrl?: string; defaultModel?: string; defaultVoice?: string } = {},
@@ -48,7 +64,7 @@ export function createOpenaiCompatibleTtsProvider(
         headers.Authorization = `Bearer ${opts.apiKey}`
       }
 
-      const res = await fetch(speechUrl, {
+      const speak = (format?: string) => fetch(speechUrl, {
         method: 'POST',
         headers,
         body: JSON.stringify({
@@ -57,14 +73,25 @@ export function createOpenaiCompatibleTtsProvider(
           input: text,
           ...(opts.rate ? { rate: opts.rate } : {}),
           ...(opts.pitch ? { pitch: opts.pitch } : {}),
-          ...(opts.format ? { response_format: opts.format } : {}),
+          ...(format ? { response_format: format } : {}),
         }),
         signal: req.signal,
       })
 
+      let res = await speak(opts.format)
+
       if (!res.ok) {
-        const body = await res.text().catch(() => '')
-        throw new Error(`OpenAI TTS returned ${res.status}: ${body || res.statusText}`)
+        let body = await res.text().catch(() => '')
+        // The endpoint just told us which formats it takes — take it at its word,
+        // once, rather than failing with a message only the server understands.
+        const [fallbackFormat] = supportedFormatsFromError(body)
+        if (fallbackFormat && fallbackFormat !== opts.format) {
+          res = await speak(fallbackFormat)
+          if (!res.ok) body = await res.text().catch(() => '')
+        }
+        if (!res.ok) {
+          throw new Error(`OpenAI TTS returned ${res.status}: ${body || res.statusText}`)
+        }
       }
 
       return {

--- a/tests/server/openai-tts-provider.test.ts
+++ b/tests/server/openai-tts-provider.test.ts
@@ -295,4 +295,63 @@ describe('openaiTtsProvider', () => {
       provider: 'openai',
     })
   })
+  it('retries once with a format the endpoint says it accepts', async () => {
+    // Groq's Orpheus models reject mp3 and name the only format they take.
+    mockFetch.mockResolvedValueOnce(textResponse(
+      '{"error":{"message":"response_format must be one of [wav]","type":"invalid_request_error"}}',
+      { status: 400, statusText: 'Bad Request' },
+    ))
+    const audio = Buffer.from('wav-audio')
+    mockFetch.mockResolvedValueOnce(audioResponse(audio, { contentType: 'audio/wav' }))
+
+    const result = await customTtsProvider.synthesize(
+      { text: 'Hello' },
+      { baseUrl: 'https://api.groq.com/openai/v1', apiKey: 'secret', format: 'mp3' },
+    )
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    const [, firstInit] = mockFetch.mock.calls[0] as [string, RequestInit]
+    const [, secondInit] = mockFetch.mock.calls[1] as [string, RequestInit]
+    expect(JSON.parse(firstInit.body as string).response_format).toBe('mp3')
+    expect(JSON.parse(secondInit.body as string).response_format).toBe('wav')
+    expect(result.audio).toEqual(audio)
+    expect(result.contentType).toBe('audio/wav')
+  })
+
+  it('retries when no format was requested at all', async () => {
+    mockFetch.mockResolvedValueOnce(textResponse(
+      '{"error":{"message":"response_format must be one of [wav]"}}',
+      { status: 400 },
+    ))
+    mockFetch.mockResolvedValueOnce(audioResponse(Buffer.from('wav-audio'), { contentType: 'audio/wav' }))
+
+    await customTtsProvider.synthesize({ text: 'Hello' }, { baseUrl: 'https://api.groq.com/openai/v1' })
+
+    const [, firstInit] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(firstInit.body as string).response_format).toBeUndefined()
+    const [, secondInit] = mockFetch.mock.calls[1] as [string, RequestInit]
+    expect(JSON.parse(secondInit.body as string).response_format).toBe('wav')
+  })
+
+  it('does not retry a failure that names no format, and reports the original error', async () => {
+    mockFetch.mockResolvedValueOnce(textResponse('bad request body', { status: 401, statusText: 'Unauthorized' }))
+
+    await expect(
+      customTtsProvider.synthesize({ text: 'Hello' }, { baseUrl: 'https://api.example.com' }),
+    ).rejects.toThrow('OpenAI TTS returned 401: bad request body')
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('gives up after one retry and keeps the second error', async () => {
+    mockFetch.mockResolvedValueOnce(textResponse(
+      '{"error":{"message":"response_format must be one of [wav]"}}',
+      { status: 400 },
+    ))
+    mockFetch.mockResolvedValueOnce(textResponse('still unhappy', { status: 400, statusText: 'Bad Request' }))
+
+    await expect(
+      customTtsProvider.synthesize({ text: 'Hello' }, { baseUrl: 'https://api.groq.com/openai/v1', format: 'mp3' }),
+    ).rejects.toThrow('OpenAI TTS returned 400: still unhappy')
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
 })

--- a/tests/server/tts-voice-proxy-mp3.test.ts
+++ b/tests/server/tts-voice-proxy-mp3.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { spawnSync } from 'node:child_process'
+
+import { transcodeToMp3 } from '../../packages/server/src/services/hermes/stt-providers/audio-convert'
+
+const hasFfmpeg = spawnSync('ffmpeg', ['-version']).status === 0
+
+function wavTone(seconds = 0.2, sampleRate = 8000): Buffer {
+  const samples = Math.floor(seconds * sampleRate)
+  const data = Buffer.alloc(samples * 2)
+  for (let i = 0; i < samples; i++) {
+    data.writeInt16LE(Math.round(Math.sin((2 * Math.PI * 440 * i) / sampleRate) * 8000), i * 2)
+  }
+  const header = Buffer.alloc(44)
+  header.write('RIFF', 0)
+  header.writeUInt32LE(36 + data.length, 4)
+  header.write('WAVE', 8)
+  header.write('fmt ', 12)
+  header.writeUInt32LE(16, 16)
+  header.writeUInt16LE(1, 20)
+  header.writeUInt16LE(1, 22)
+  header.writeUInt32LE(sampleRate, 24)
+  header.writeUInt32LE(sampleRate * 2, 28)
+  header.writeUInt16LE(2, 32)
+  header.writeUInt16LE(16, 34)
+  header.write('data', 36)
+  header.writeUInt32LE(data.length, 40)
+  return Buffer.concat([header, data])
+}
+
+function looksLikeMp3(buffer: Buffer): boolean {
+  return (buffer[0] === 0x49 && buffer[1] === 0x44 && buffer[2] === 0x33)
+    || (buffer[0] === 0xff && (buffer[1] & 0xe0) === 0xe0)
+}
+
+describe('transcodeToMp3', () => {
+  it('leaves mp3 audio untouched', async () => {
+    const mp3 = Buffer.from([0xff, 0xfb, 0x90, 0x00, 0x01, 0x02])
+    const result = await transcodeToMp3(mp3, 'audio/mpeg')
+
+    expect(result.audio).toBe(mp3)
+    expect(result.mimeType).toBe('audio/mpeg')
+  })
+
+  it('recognizes mp3 by its bytes even when the content type lies', async () => {
+    const mp3 = Buffer.from([0x49, 0x44, 0x33, 0x03, 0x00, 0x00])
+    const result = await transcodeToMp3(mp3, 'application/octet-stream')
+
+    expect(result.audio).toBe(mp3)
+    expect(result.mimeType).toBe('audio/mpeg')
+  })
+
+  it.runIf(hasFfmpeg)('converts wav to real mp3, which is what Hermes writes to its .mp3 path', async () => {
+    const result = await transcodeToMp3(wavTone(), 'audio/wav')
+
+    expect(result.mimeType).toBe('audio/mpeg')
+    expect(result.audio.length).toBeGreaterThan(0)
+    expect(looksLikeMp3(result.audio)).toBe(true)
+  })
+})

--- a/tests/server/tts-voice-proxy-mp3.test.ts
+++ b/tests/server/tts-voice-proxy-mp3.test.ts
@@ -57,4 +57,13 @@ describe('transcodeToMp3', () => {
     expect(result.audio.length).toBeGreaterThan(0)
     expect(looksLikeMp3(result.audio)).toBe(true)
   })
+
+  it.runIf(hasFfmpeg)('trusts wav bytes over an incorrect mp3 content type', async () => {
+    const wav = wavTone()
+    const result = await transcodeToMp3(wav, 'audio/mpeg')
+
+    expect(result.audio).not.toBe(wav)
+    expect(result.mimeType).toBe('audio/mpeg')
+    expect(looksLikeMp3(result.audio)).toBe(true)
+  })
 })


### PR DESCRIPTION
A Custom TTS provider pointed at Groq (`canopylabs/orpheus-arabic-saudi`) cannot be used at all. Test fails, and so does Hermes' own playback:

```
Test failed: TTS synthesis failed: OpenAI TTS returned 400:
{"error":{"message":"response_format must be one of [wav]","type":"invalid_request_error"}}
```

Studio asks for mp3 — the voice proxy hardcodes `format: 'mp3'`, since Hermes' command provider writes the answer to an `.mp3` path — and Orpheus only produces wav. There is no field in the UI to say otherwise, so the provider is simply unusable.

## The endpoint already told us the answer

The list of acceptable formats is inside the rejection. `createOpenaiCompatibleTtsProvider` now reads it and retries once with the first one named. Nothing else changes:

- a failure that names no format is not retried, and is reported exactly as before
- if the retry also fails, the second error is what surfaces — not a stale first one
- providers that accept mp3 are untouched: one request, same body

Because Hermes still expects an `.mp3`, the voice proxy transcodes the response with the same ffmpeg helper the STT side already uses. Audio that is already mp3 is passed through by identity (checked by magic bytes, not by a possibly-wrong content type), and when ffmpeg is missing the audio is returned unchanged rather than failing.

I first built this as a format picker in the provider form, then threw that away: making the user discover that their model wants wav is not a fix, and it added a capability flag, a stored setting and eleven translations for something the server can work out on its own. The diff is now three files.

## Verified against the real provider, not only in tests

Run on a live instance with a Groq Orpheus provider configured and no format set anywhere — the exact case that failed:

| | before | after |
| --- | --- | --- |
| `POST /api/hermes/tts/synthesize` | 400 | **200**, `audio/wav`, 42,310 bytes |
| `POST /api/hermes/voice/proxy/:profile/v1/tts` | 400 | **200**, `audio/mpeg`, 12,501 bytes, mp3 frame header confirmed |

The second row is the one Hermes itself uses once **Use Hermes Studio provider** is active, so this is what unblocks voice on Telegram and everywhere else the agent speaks.

## Tests

Six new cases in `tests/server/openai-tts-provider.test.ts` and `tests/server/tts-voice-proxy-mp3.test.ts`: the retry uses the named format, it fires when no format was requested at all, it does not fire for unrelated failures, it gives up after one attempt, mp3 passes through untouched (including when the content type lies), and wav really becomes mp3 — that last one is skipped where ffmpeg is absent. I reverted the three source files and confirmed all six fail without this change; the existing 49 voice/TTS tests pass unchanged.
