### PR TITLE
fix: persist Hermes Studio bridge interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ These variables configure Hermes Web UI, its local Hermes runtime integration, a
 | `PYTHON` | auto-discovered | Fallback Python executable for the agent bridge. |
 | `HERMES_AGENT_BRIDGE_ENDPOINT` | platform default | Agent bridge broker endpoint. Windows defaults to `tcp://127.0.0.1:18765`; macOS/Linux defaults to `ipc:///tmp/hermes-agent-bridge.sock`. |
 | `HERMES_AGENT_BRIDGE_TIMEOUT_MS` | `120000` | Timeout for Node requests to the bridge broker. |
+| `HERMES_AGENT_BRIDGE_INTERACTION_TIMEOUT_SECONDS` | `none` | Clarify and approval deadline. Unset, `0`, or `none` waits until an explicit response or run/session/bridge cancellation. A positive integer enables a fail-closed deadline; approvals deny rather than execute when it expires. Restart the bridge after changing it. |
 | `HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS` | `5000` | Short retry window for connecting to the bridge socket. |
 | `HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS` | `120000` | Timeout while waiting for the Python bridge to become ready. |
 | `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN` | enabled | Stop the bridge broker during Web UI shutdown and restart. Set `0`, `false`, `no`, or `off` to keep the bridge across restarts. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -329,6 +329,7 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `PYTHON` | 自动发现 | agent bridge 的 Python 可执行文件 fallback。 |
 | `HERMES_AGENT_BRIDGE_ENDPOINT` | 平台默认值 | Agent bridge broker endpoint。Windows 默认 `tcp://127.0.0.1:18765`；macOS/Linux 默认 `ipc:///tmp/hermes-agent-bridge.sock`。 |
 | `HERMES_AGENT_BRIDGE_TIMEOUT_MS` | `120000` | Node 请求 bridge broker 的响应超时。 |
+| `HERMES_AGENT_BRIDGE_INTERACTION_TIMEOUT_SECONDS` | `none` | Clarify 与 approval 的等待期限。未设置、`0` 或 `none` 时会等待明确响应，或等待 run/session/bridge 取消；正整数会启用 fail-closed 超时，未响应的 approval 会被拒绝而不会执行。修改后需重启 bridge。 |
 | `HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS` | `5000` | 连接 bridge socket 失败时的短重试窗口。 |
 | `HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS` | `120000` | 等待 Python bridge ready 的超时。 |
 | `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN` | 开启 | Web UI 关闭和重启时是否停止 bridge broker；设为 `0`、`false`、`no` 或 `off` 才会在重启时保留 broker。 |

--- a/docs/chat-chain-changes/2026-08-02-persistent-bridge-interactions.md
+++ b/docs/chat-chain-changes/2026-08-02-persistent-bridge-interactions.md
@@ -1,0 +1,21 @@
+---
+date: 2026-08-02
+pr: pending
+feature: Persistent bridge interactions
+impact: WebUI clarify and approval prompts wait for an explicit response by default, while operators can restore a fail-closed deadline with one bridge environment variable.
+---
+
+`HERMES_AGENT_BRIDGE_INTERACTION_TIMEOUT_SECONDS` controls terminal approval,
+clarify, and the WebUI-side gateway approval contract. Unset, `0`, and `none`
+mean that the bridge does not expire the request; a positive integer publishes
+the corresponding millisecond deadline and denies unanswered approvals when it
+expires. Pending waits are cancelled when their run finishes or is interrupted,
+their session is destroyed, or the bridge shuts down. Responses claim a request
+once, so duplicate and late responses cannot execute an approved action twice.
+
+Gateway approvals are ultimately owned by Hermes Agent's canonical approval
+implementation. The bridge publishes an unlimited UI deadline and adds no local
+timer by default, but an independently configured canonical Hermes timeout may
+still deny a gateway approval earlier. This integration never converts a timeout,
+cancellation, or missing response into approval and does not change Hermes
+hardline or blocklist checks.

--- a/docs/media-image-generation.md
+++ b/docs/media-image-generation.md
@@ -1,0 +1,33 @@
+# API-key Image Generation Contract
+
+`POST /api/hermes/media/apikey-image-generate` supports text-to-image, image-to-image, and edit requests through an existing configured custom provider. Provider catalog lookup, base URL selection, and API-key or API-key-environment resolution remain profile-scoped; this contract adds no OAuth flow and has no built-in upstream URL or token.
+
+## Compatibility and multi-reference input
+
+Existing `image_path`, `image_url`, and `image_base64` requests remain valid as a single reference for `image` and `edit` modes. New clients can send up to eight `references`; every item supplies exactly one of those image sources, a non-empty `role`, and either integer `priority` from 0 through 100 or numeric `weight` from 0 through 1. Do not combine `references` with the legacy top-level image fields.
+
+The service forwards reference roles and responsibility metadata to the configured provider. Image-mode requests carry the metadata beside each Responses `input_image`; edit-mode multipart requests carry indexed role, priority, and weight fields.
+
+The native generation defaults are `model=codex-gpt-image-2`, `quality=high`, and `resolution=4k`. `provider`, `model`, `image_model`, `quality`, `resolution`, `aspect`/`aspect_ratio`, legacy `size`, and `output_format` can be set explicitly. These values are forwarded upstream. Hermes Studio does not resize or upscale provider output; returned `dimensions` describe the original decoded provider image.
+
+The existing success fields (`ok`, `mode`, `output_paths`, `provider`, `base_url`, and `profile`) remain. Additive fields identify `request_id`, actual `model`/`provider`, requested quality/resolution/aspect, original dimensions and format, plus per-image metadata.
+
+## Limits and security
+
+- The JSON contract limit is 18 MiB, below the server-wide 20 MiB parser limit.
+- A structured reference is limited to 10 MiB decoded, all references to 12 MiB decoded, and the array to eight entries.
+- Provider output is limited to 50 MiB per image and 100 MiB per response.
+- PNG, JPEG, and WebP are accepted. MIME declarations and URL content types must match image signatures.
+- Local inputs and outputs must remain under the Web UI home, upload root, configured `WORKSPACE_BASE` (or the user home fallback), current workspace, or system temporary root. Real paths are checked to prevent symlink escapes.
+- Remote references must use public HTTP(S), contain no URL credentials, and must not resolve to private, loopback, link-local, multicast, or reserved addresses. Redirects are manually limited and revalidated.
+- Upstream response text is never copied into client errors. Stable codes distinguish validation, provider authentication, rejection, rate limit, timeout, invalid response, and availability failures.
+
+## Deployment impact
+
+No database migration, OAuth registration, new credential, or new provider route is required. Existing custom-provider entries continue to supply `base_url`, `api_key`/`api_key_env`, and provider model configuration.
+
+Deploy the server and bundled `apikey-image-gen` skill documentation together. A normal process restart is required for server code changes to take effect; this change does not require restarting an upstream provider. Ensure the runtime user can write its Web UI media directory and any explicitly allowed workspace output directory. If callers previously used local paths outside the allowed roots or private-network image URLs, move those images into the upload/workspace roots or update `WORKSPACE_BASE`; these requests are intentionally rejected after deployment.
+
+The larger native 4K results and multi-reference payloads increase provider latency, response bandwidth, temporary memory, and media-disk use. Reverse proxies should allow request bodies up to the existing 20 MiB application limit and timeouts at least as long as the chosen `timeout_ms`. Do not add an image resizing proxy as a substitute for provider-native 4K output.
+
+URL validation rejects private DNS answers before each fetch and revalidates every redirect. DNS resolution and the HTTP connection are separate operations, so deployments with hostile or untrusted DNS should also enforce outbound network policy at the container or host boundary to close DNS-rebinding time-of-check/time-of-use windows.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7508,8 +7508,8 @@
         "tags": [
           "Media"
         ],
-        "summary": "Create apikey-image-generate",
-        "description": "POST /api/hermes/media/apikey-image-generate",
+        "summary": "Generate an image with optional multiple references",
+        "description": "Generates native provider output without local resizing. Legacy image_path, image_url, and image_base64 inputs remain supported for one reference; use references for role-aware multi-reference requests.",
         "operationId": "apiKeyImageGenerate",
         "security": [
           {
@@ -7518,13 +7518,153 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Generated image metadata. Existing ok, mode, output_paths, provider, base_url, and profile fields are preserved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "mode",
+                    "output_paths",
+                    "provider",
+                    "request_id",
+                    "model",
+                    "images"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "text",
+                        "image",
+                        "edit"
+                      ]
+                    },
+                    "output_paths": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "provider": {
+                      "type": "string"
+                    },
+                    "base_url": {
+                      "type": "string"
+                    },
+                    "profile": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": "string"
+                    },
+                    "model": {
+                      "type": "string"
+                    },
+                    "actual_model": {
+                      "type": "string"
+                    },
+                    "actual_provider": {
+                      "type": "string"
+                    },
+                    "quality": {
+                      "type": "string"
+                    },
+                    "resolution": {
+                      "type": "string"
+                    },
+                    "aspect": {
+                      "type": "string"
+                    },
+                    "dimensions": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "width": {
+                          "type": "integer"
+                        },
+                        "height": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    "format": {
+                      "type": "string",
+                      "nullable": true,
+                      "enum": [
+                        "png",
+                        "jpeg",
+                        "webp"
+                      ]
+                    },
+                    "images": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "output_path",
+                          "format"
+                        ],
+                        "properties": {
+                          "output_path": {
+                            "type": "string"
+                          },
+                          "dimensions": {
+                            "nullable": true,
+                            "type": "object",
+                            "properties": {
+                              "width": {
+                                "type": "integer"
+                              },
+                              "height": {
+                                "type": "integer"
+                              }
+                            }
+                          },
+                          "format": {
+                            "type": "string",
+                            "enum": [
+                              "png",
+                              "jpeg",
+                              "webp"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "description": "Reference or output path is outside allowed roots."
+          },
+          "413": {
+            "description": "Request, reference count, per-image bytes, or total reference bytes exceeded a limit."
+          },
+          "415": {
+            "description": "Reference MIME is unsupported or does not match image content."
+          },
+          "502": {
+            "description": "Provider rejected the request or returned an invalid/error response."
+          },
+          "503": {
+            "description": "Provider rate limited the request."
+          },
+          "504": {
+            "description": "Provider request timed out."
           }
         },
         "requestBody": {
@@ -7533,14 +7673,160 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "prompt"
+                ],
                 "properties": {
                   "mode": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                      "text",
+                      "image",
+                      "edit"
+                    ],
+                    "default": "text"
+                  },
+                  "prompt": {
+                    "type": "string",
+                    "maxLength": 32000
+                  },
+                  "provider": {
+                    "type": "string",
+                    "description": "Configured custom provider name. Defaults to fun-codex."
+                  },
+                  "provider_name": {
+                    "type": "string",
+                    "description": "Compatibility alias for provider."
+                  },
+                  "custom_provider": {
+                    "type": "string",
+                    "description": "Compatibility alias for provider."
+                  },
+                  "profile": {
+                    "type": "string",
+                    "description": "Compatibility body field for profile selection; X-Hermes-Profile is preferred."
+                  },
+                  "model": {
+                    "type": "string",
+                    "default": "codex-gpt-image-2"
+                  },
+                  "image_model": {
+                    "type": "string",
+                    "description": "Image tool model override for image mode."
+                  },
+                  "quality": {
+                    "type": "string",
+                    "default": "high"
+                  },
+                  "resolution": {
+                    "type": "string",
+                    "default": "4k"
+                  },
+                  "aspect": {
+                    "type": "string",
+                    "default": "auto"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Compatibility alias for aspect."
+                  },
+                  "size": {
+                    "type": "string",
+                    "description": "Legacy provider size parameter. It is forwarded and is never implemented by local resizing."
+                  },
+                  "output_format": {
+                    "type": "string",
+                    "enum": [
+                      "png",
+                      "jpeg",
+                      "webp"
+                    ],
+                    "default": "png"
+                  },
+                  "n": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 4,
+                    "default": 1
+                  },
+                  "timeout_ms": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 600000
                   },
                   "output_path": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Optional path under an allowed media, workspace, user, or temporary root."
+                  },
+                  "image_path": {
+                    "type": "string",
+                    "description": "Legacy single-reference local path."
+                  },
+                  "image_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Legacy single-reference public HTTP(S) URL."
+                  },
+                  "image_base64": {
+                    "type": "string",
+                    "description": "Legacy single-reference base64 or data URI."
+                  },
+                  "mime_type": {
+                    "type": "string",
+                    "enum": [
+                      "image/png",
+                      "image/jpeg",
+                      "image/webp"
+                    ]
+                  },
+                  "references": {
+                    "type": "array",
+                    "maxItems": 8,
+                    "description": "Role-aware references. Each item must provide exactly one image source plus role and priority or weight.",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "role"
+                      ],
+                      "properties": {
+                        "image_path": {
+                          "type": "string"
+                        },
+                        "image_url": {
+                          "type": "string",
+                          "format": "uri"
+                        },
+                        "image_base64": {
+                          "type": "string"
+                        },
+                        "mime_type": {
+                          "type": "string",
+                          "enum": [
+                            "image/png",
+                            "image/jpeg",
+                            "image/webp"
+                          ]
+                        },
+                        "role": {
+                          "type": "string",
+                          "maxLength": 64
+                        },
+                        "priority": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 100
+                        },
+                        "weight": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        }
+                      },
+                      "additionalProperties": false
+                    }
                   }
-                }
+                },
+                "additionalProperties": false
               }
             }
           }

--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -50,6 +50,9 @@ export interface StartRunResponse {
 export interface RunEvent {
   event: string
   run_id?: string
+  approval_id?: string
+  clarify_id?: string
+  timeout_ms?: number | null
   delta?: string
   /** Payload text for `reasoning.delta` / `thinking.delta` / `reasoning.available` events. */
   text?: string

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -354,7 +354,7 @@ export interface PendingClarify {
   clarifyId: string
   question: string
   choices: string[] | null
-  timeoutMs: number
+  timeoutMs: number | null
   requestedAt: number
 }
 
@@ -2590,14 +2590,18 @@ export const useChatStore = defineStore('chat', () => {
 
   function setPendingClarify(evt: RunEvent) {
     const sid = evt.session_id
-    const clarifyId = (evt as any).clarify_id as string | undefined
+    const clarifyId = evt.clarify_id
     if (!sid || !clarifyId) return
+    const rawTimeoutMs = evt.timeout_ms
+    const timeoutMs = typeof rawTimeoutMs === 'number' && Number.isFinite(rawTimeoutMs) && rawTimeoutMs > 0
+      ? rawTimeoutMs
+      : null
     pendingClarifies.value.set(sid, {
       sessionId: sid,
       clarifyId,
       question: String((evt as any).question || ''),
       choices: Array.isArray((evt as any).choices) ? (evt as any).choices : null,
-      timeoutMs: Number((evt as any).timeout_ms) || 300000,
+      timeoutMs,
       requestedAt: Date.now(),
     })
     pendingClarifies.value = new Map(pendingClarifies.value)

--- a/packages/server/src/controllers/hermes/media.ts
+++ b/packages/server/src/controllers/hermes/media.ts
@@ -5,13 +5,17 @@ import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '.
 import { config } from '../../config'
 import { readConfigYamlForProfile } from '../../services/config-helpers'
 import { getCompatibleCustomProviders } from '../../services/hermes/custom-providers-compat'
+import {
+  imageRequestId,
+  publicImageError,
+  requestApiKeyImages,
+  saveGeneratedImages as saveApiKeyGeneratedImages,
+} from '../../services/hermes/api-key-image'
 
 const XAI_VIDEO_GENERATIONS_URL = 'https://api.x.ai/v1/videos/generations'
 const XAI_VIDEO_STATUS_URL = 'https://api.x.ai/v1/videos'
 const XAI_VIDEO_MODEL = 'grok-imagine-video'
 const APIKEY_IMAGE_PROVIDER = 'fun-codex'
-const APIKEY_IMAGE_MODEL = 'gpt-image-2'
-const APIKEY_IMAGE_TO_IMAGE_MODEL = 'gpt-5.4-mini'
 const MAX_IMAGE_BYTES = 25 * 1024 * 1024
 const DEFAULT_POLL_INTERVAL_MS = 5000
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000
@@ -20,8 +24,6 @@ type AuthJson = {
   providers?: Record<string, any>
   credential_pool?: Record<string, any[]>
 }
-
-type ApiKeyImageMode = 'text' | 'image' | 'edit'
 
 type ApiKeyImageProvider = {
   name: string
@@ -72,13 +74,6 @@ function readJsonFile(path: string): any {
   } catch {
     return null
   }
-}
-
-function buildApiUrl(baseUrl: string, pathWithV1: string): string {
-  const base = (baseUrl || 'https://api.apikey.fun/v1').replace(/\/+$/, '')
-  const apiPath = pathWithV1.startsWith('/') ? pathWithV1 : `/${pathWithV1}`
-  if (base.endsWith('/v1') && apiPath.startsWith('/v1/')) return `${base}${apiPath.slice(3)}`
-  return `${base}${apiPath}`
 }
 
 function normalizeCustomProviderName(value: unknown): string {
@@ -193,88 +188,6 @@ function normalizeImageInput(body: any): string {
   return imagePathToDataUri(imagePath)
 }
 
-function imageDataUriToBytes(dataUri: string): { buffer: Buffer; mime: string; name: string } {
-  const match = dataUri.match(/^data:([^;,]+);base64,(.+)$/)
-  if (!match) {
-    const err: any = new Error('image_base64 must be a valid image data URI for edit mode')
-    err.status = 400
-    throw err
-  }
-  const mime = match[1]
-  if (!mime.startsWith('image/')) {
-    const err: any = new Error('image data URI must use an image mime type')
-    err.status = 400
-    throw err
-  }
-  return {
-    buffer: Buffer.from(match[2], 'base64'),
-    mime,
-    name: `source.${mime === 'image/jpeg' ? 'jpg' : mime.split('/')[1] || 'png'}`,
-  }
-}
-
-async function fetchImageBytes(url: string): Promise<{ buffer: Buffer; mime: string; name: string }> {
-  const res = await fetch(url)
-  if (!res.ok) {
-    const err: any = new Error(`image_url fetch failed: ${res.status} ${res.statusText}`)
-    err.status = 400
-    throw err
-  }
-  const mime = String(res.headers.get('content-type') || '').split(';')[0] || 'image/png'
-  if (!mime.startsWith('image/')) {
-    const err: any = new Error('image_url did not return an image')
-    err.status = 400
-    throw err
-  }
-  const buffer = Buffer.from(await res.arrayBuffer())
-  if (buffer.length > MAX_IMAGE_BYTES) {
-    const err: any = new Error(`image is too large (max ${MAX_IMAGE_BYTES} bytes)`)
-    err.status = 413
-    throw err
-  }
-  const name = new URL(url).pathname.split('/').pop() || 'source.png'
-  return { buffer, mime, name }
-}
-
-async function normalizeImageFile(body: any): Promise<{ buffer: Buffer; mime: string; name: string }> {
-  const imageUrl = typeof body.image_url === 'string' ? body.image_url.trim() : ''
-  if (imageUrl) return fetchImageBytes(imageUrl)
-
-  const imageBase64 = typeof body.image_base64 === 'string' ? body.image_base64.trim() : ''
-  if (imageBase64) {
-    const dataUri = imageBase64.startsWith('data:image/')
-      ? imageBase64
-      : `data:${String(body.mime_type || '').trim()};base64,${imageBase64}`
-    return imageDataUriToBytes(dataUri)
-  }
-
-  const imagePath = typeof body.image_path === 'string' ? body.image_path.trim() : ''
-  if (!imagePath) {
-    const err: any = new Error('image_path, image_url, or image_base64 is required')
-    err.status = 400
-    throw err
-  }
-  const resolvedPath = isAbsolute(imagePath) ? imagePath : resolve(process.cwd(), imagePath)
-  if (!existsSync(resolvedPath)) {
-    const err: any = new Error('image_path does not exist')
-    err.status = 404
-    throw err
-  }
-  const buffer = readFileSync(resolvedPath)
-  if (buffer.length > MAX_IMAGE_BYTES) {
-    const err: any = new Error(`image is too large (max ${MAX_IMAGE_BYTES} bytes)`)
-    err.status = 413
-    throw err
-  }
-  const mime = mimeFromMagic(buffer) || mimeFromPath(resolvedPath)
-  if (!mime) {
-    const err: any = new Error('unsupported image type; use png, jpeg, or webp')
-    err.status = 400
-    throw err
-  }
-  return { buffer, mime, name: resolvedPath.split(/[\\/]/).pop() || 'source.png' }
-}
-
 function normalizeDuration(value: unknown): number {
   const duration = Number(value || 8)
   if (!Number.isFinite(duration) || duration < 1 || duration > 15) {
@@ -290,232 +203,93 @@ export function defaultMediaOutputPath(requestId: string, now = new Date()): str
   return join(config.appHome, 'media', `${safeRequestId}.mp4`)
 }
 
-export function defaultImageOutputPath(requestId: string, index = 0): string {
+export function defaultImageOutputPath(requestId: string, index = 0, format = 'png'): string {
   const safeRequestId = requestId.replace(/[^A-Za-z0-9_-]/g, '_') || `image_${Date.now()}`
   const suffix = index > 0 ? `-${index + 1}` : ''
-  return join(config.appHome, 'media', `${safeRequestId}${suffix}.png`)
-}
-
-function normalizeImageMode(value: unknown): ApiKeyImageMode {
-  const mode = String(value || 'text').trim().toLowerCase()
-  if (mode === 'text' || mode === 'image' || mode === 'edit') return mode
-  const err: any = new Error('mode must be one of text, image, or edit')
-  err.status = 400
-  throw err
-}
-
-function normalizePositiveInt(value: unknown, fallback: number, key: string): number {
-  const parsed = Number(value || fallback)
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    const err: any = new Error(`${key} must be a positive number`)
-    err.status = 400
-    throw err
-  }
-  return Math.floor(parsed)
-}
-
-function collectImageBase64(event: any, images: string[] = []): string[] {
-  if (!event || typeof event !== 'object') return images
-  for (const key of ['b64_json', 'base64', 'image_base64', 'partial_image_b64']) {
-    if (typeof event[key] === 'string' && event[key]) images.push(event[key])
-  }
-  for (const item of event.data || []) collectImageBase64(item, images)
-  for (const item of event.response?.output || []) {
-    if (typeof item?.result === 'string' && item.result) images.push(item.result)
-    collectImageBase64(item, images)
-  }
-  if (typeof event.item?.result === 'string' && event.item.result) images.push(event.item.result)
-  return images
-}
-
-function isPartialImageEvent(event: any): boolean {
-  return event?.type === 'image_generation.partial_image' ||
-    event?.type === 'response.image_generation_call.partial_image'
-}
-
-function throwIfImageStreamError(event: any): void {
-  if (event?.type !== 'error' && event?.type !== 'response.failed') return
-  const err: any = new Error(event?.response?.error?.message || event?.error?.message || 'image generation failed')
-  err.status = 502
-  throw err
-}
-
-async function readSseImageResults(res: Response, limit: number): Promise<string[]> {
-  if (!res.body) throw new Error('image generation response is not readable')
-  const reader = res.body.getReader()
-  const decoder = new TextDecoder()
-  const images: string[] = []
-  let buffer = ''
-  while (true) {
-    const { value, done } = await reader.read()
-    if (done) break
-    buffer += decoder.decode(value, { stream: true })
-    const frames = buffer.split(/\r?\n\r?\n/)
-    buffer = frames.pop() || ''
-    for (const frame of frames) {
-      const data = frame
-        .split(/\r?\n/)
-        .filter(line => line.startsWith('data:'))
-        .map(line => line.slice(5).trimStart())
-        .join('\n')
-        .trim()
-      if (!data || data === '[DONE]') continue
-      const event = JSON.parse(data)
-      throwIfImageStreamError(event)
-      if (isPartialImageEvent(event)) continue
-      collectImageBase64(event, images)
-      if (images.length >= limit) return images.slice(0, limit)
-    }
-  }
-  return images.slice(0, limit)
-}
-
-async function requestApiKeyImage(provider: ApiKeyImageProvider, mode: ApiKeyImageMode, body: any): Promise<string[]> {
-  const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
-  if (!prompt) {
-    const err: any = new Error('prompt is required')
-    err.status = 400
-    throw err
-  }
-
-  const n = normalizePositiveInt(body.n, 1, 'n')
-  const timeoutMs = normalizePositiveInt(body.timeout_ms, DEFAULT_TIMEOUT_MS, 'timeout_ms')
-  const headers = {
-    Accept: 'text/event-stream',
-    Authorization: `Bearer ${provider.apiKey}`,
-  }
-
-  let res: Response
-  if (mode === 'text') {
-    res = await fetch(buildApiUrl(provider.baseUrl, '/v1/images/generations'), {
-      method: 'POST',
-      headers: { ...headers, 'Content-Type': 'application/json' },
-      signal: AbortSignal.timeout(timeoutMs),
-      body: JSON.stringify({
-        model: body.model || APIKEY_IMAGE_MODEL,
-        prompt,
-        n,
-        size: body.size || '1024x1024',
-        quality: body.quality || 'auto',
-        stream: true,
-        response_format: 'b64_json',
-      }),
-    })
-  } else if (mode === 'image') {
-    res = await fetch(buildApiUrl(provider.baseUrl, '/v1/responses'), {
-      method: 'POST',
-      headers: { ...headers, 'Content-Type': 'application/json' },
-      signal: AbortSignal.timeout(timeoutMs),
-      body: JSON.stringify({
-        model: body.model || provider.model || APIKEY_IMAGE_TO_IMAGE_MODEL,
-        stream: true,
-        input: [{
-          role: 'user',
-          content: [
-            { type: 'input_text', text: prompt },
-            { type: 'input_image', image_url: normalizeImageInput(body) },
-          ],
-        }],
-        tools: [{
-          type: 'image_generation',
-          model: body.image_model || APIKEY_IMAGE_MODEL,
-          size: body.size || '1024x1024',
-          quality: body.quality || 'auto',
-          output_format: body.output_format || 'png',
-        }],
-        tool_choice: { type: 'image_generation' },
-      }),
-    })
-  } else {
-    const image = await normalizeImageFile(body)
-    const imageBytes = new Uint8Array(image.buffer.byteLength)
-    imageBytes.set(image.buffer)
-    const form = new FormData()
-    form.append('image', new Blob([imageBytes.buffer], { type: image.mime }), image.name)
-    form.append('prompt', prompt)
-    form.append('model', body.model || APIKEY_IMAGE_MODEL)
-    form.append('n', String(n))
-    form.append('quality', body.quality || 'auto')
-    form.append('size', body.size || '1024x1024')
-    form.append('stream', 'true')
-    form.append('response_format', 'b64_json')
-    res = await fetch(buildApiUrl(provider.baseUrl, '/v1/images/edits'), {
-      method: 'POST',
-      headers,
-      signal: AbortSignal.timeout(timeoutMs),
-      body: form,
-    })
-  }
-
-  if (!res.ok) {
-    const detail = await res.text().catch(() => '')
-    const err: any = new Error(`image generation request failed: ${res.status} ${detail || res.statusText}`)
-    err.status = res.status === 401 || res.status === 403 ? 502 : 502
-    throw err
-  }
-  const images = await readSseImageResults(res, n)
-  if (images.length === 0) {
-    const err: any = new Error('image generation stream ended without image data')
-    err.status = 502
-    throw err
-  }
-  return images
-}
-
-function saveGeneratedImages(images: string[], requestedOutputPath?: string): string[] {
-  return images.map((image, index) => {
-    const outputPath = requestedOutputPath && images.length === 1
-      ? requestedOutputPath
-      : requestedOutputPath
-        ? requestedOutputPath.replace(/(\.[^.\\/]+)?$/, `${index > 0 ? `-${index + 1}` : ''}$1`)
-        : defaultImageOutputPath(`image_${Date.now()}`, index)
-    mkdirSync(dirname(outputPath), { recursive: true })
-    writeFileSync(outputPath, Buffer.from(image, 'base64'))
-    return outputPath
-  })
+  const extension = format === 'jpeg' ? 'jpg' : format
+  return join(config.appHome, 'media', `${safeRequestId}${suffix}.${extension}`)
 }
 
 export async function apiKeyImageGenerate(ctx: Context) {
+  const requestId = imageRequestId(ctx.get('x-request-id'))
   let profile: string
   try {
     profile = resolveMediaProfile(ctx)
   } catch (err: any) {
     ctx.status = err.status || 400
-    ctx.body = { error: err.message || String(err), code: err.code || 'invalid_profile' }
+    ctx.body = {
+      error: err.code === 'profile_not_found' ? 'Requested profile was not found' : 'A valid profile is required',
+      code: err.code || 'invalid_profile',
+      request_id: requestId,
+    }
     return
   }
 
   const body = ctx.request.body as any
   const providerName = requestedApiKeyImageProviderName(body)
-  const provider = await resolveApiKeyImageProvider(profile, providerName)
+  let provider: ApiKeyImageProvider | null
+  try {
+    provider = await resolveApiKeyImageProvider(profile, providerName)
+  } catch {
+    ctx.status = 500
+    ctx.body = {
+      error: 'Image provider configuration could not be loaded',
+      code: 'provider_resolution_failed',
+      request_id: requestId,
+    }
+    return
+  }
   if (!provider) {
     ctx.status = 401
     const isDefaultProvider = providerName === APIKEY_IMAGE_PROVIDER
     ctx.body = {
-      error: `Missing ${providerName} provider in profile "${profile}" config.yaml.`,
+      error: isDefaultProvider
+        ? 'The default image provider is not configured'
+        : 'The requested image provider is not configured',
       code: isDefaultProvider ? 'missing_fun_codex_provider' : 'missing_apikey_image_provider',
+      request_id: requestId,
     }
     return
   }
 
   try {
-    const mode = normalizeImageMode(body.mode)
-    const images = await requestApiKeyImage(provider, mode, body)
+    const { mode, result } = await requestApiKeyImages(provider, body, requestId)
     const requestedOutputPath = typeof body.output_path === 'string' ? body.output_path.trim() : ''
-    const outputPaths = saveGeneratedImages(images, requestedOutputPath || undefined)
+    const savedImages = await saveApiKeyGeneratedImages(
+      result.images,
+      (index, format) => defaultImageOutputPath(requestId, index, format),
+      requestedOutputPath || undefined,
+    )
+    const firstImage = savedImages[0]
     ctx.body = {
       ok: true,
       mode,
-      output_paths: outputPaths,
+      output_paths: savedImages.map(image => image.outputPath),
       provider: provider.name,
       base_url: provider.baseUrl,
       profile,
+      request_id: requestId,
+      model: result.model,
+      actual_model: result.model,
+      actual_provider: result.provider,
+      quality: result.quality,
+      resolution: result.resolution,
+      aspect: result.aspect,
+      dimensions: firstImage?.dimensions || null,
+      format: firstImage?.format || null,
+      images: savedImages.map(image => ({
+        output_path: image.outputPath,
+        dimensions: image.dimensions,
+        format: image.format,
+      })),
     }
   } catch (err: any) {
-    ctx.status = err.status || 500
+    const safe = publicImageError(err)
+    ctx.status = safe.status
     ctx.body = {
-      error: err.message || String(err),
-      code: err.code || 'image_generation_failed',
+      error: safe.error,
+      code: safe.code,
+      request_id: requestId,
     }
   }
 }

--- a/packages/server/src/controllers/hermes/media.ts
+++ b/packages/server/src/controllers/hermes/media.ts
@@ -5,6 +5,7 @@ import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '.
 import { config } from '../../config'
 import { readConfigYamlForProfile } from '../../services/config-helpers'
 import { getCompatibleCustomProviders } from '../../services/hermes/custom-providers-compat'
+import { parseDotenvValue } from '../../services/dotenv'
 import {
   imageRequestId,
   publicImageError,
@@ -86,11 +87,18 @@ function requestedApiKeyImageProviderName(body: any): string {
   return normalizeCustomProviderName(body?.provider || body?.provider_name || body?.custom_provider) || APIKEY_IMAGE_PROVIDER
 }
 
-function apiKeyFromCustomProvider(provider: any): string {
+function apiKeyFromCustomProvider(provider: any, profile: string): string {
   const direct = String(provider?.api_key || '').trim()
   if (direct) return direct
   const envName = String(provider?.api_key_env || provider?.key_env || '').trim()
-  return envName ? String(process.env[envName] || '').trim() : ''
+  if (!envName) return ''
+  const processValue = String(process.env[envName] || '').trim()
+  if (processValue) return processValue
+  try {
+    return parseDotenvValue(readFileSync(join(getProfileDir(profile), '.env'), 'utf-8'), envName)
+  } catch {
+    return ''
+  }
 }
 
 async function resolveApiKeyImageProvider(profile: string, providerName = APIKEY_IMAGE_PROVIDER): Promise<ApiKeyImageProvider | null> {
@@ -98,7 +106,7 @@ async function resolveApiKeyImageProvider(profile: string, providerName = APIKEY
   const hermesConfig = await readConfigYamlForProfile(profile)
   const customProviders = getCompatibleCustomProviders(hermesConfig)
   const provider = customProviders.find(entry => normalizeCustomProviderName(entry?.name) === requestedName)
-  const apiKey = apiKeyFromCustomProvider(provider)
+  const apiKey = apiKeyFromCustomProvider(provider, profile)
   const baseUrl = String(provider?.base_url || '').trim()
   if (!provider || !apiKey || !baseUrl) return null
   return {

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -93,6 +93,23 @@ async function notifyBridgeSessionModelChanged(
   }
 }
 
+async function destroyLoadedBridgeSession(sessionId: string, profile?: string): Promise<void> {
+  try {
+    const state = getAgentBridgeManager().getRuntimeState()
+    if (!state.ready || !state.running) return
+    const bridge = new AgentBridgeClient({
+      endpoint: state.endpoint,
+      timeoutMs: 5000,
+      connectRetryMs: 0,
+    })
+    const status = await bridge.statusIfLoaded(sessionId, profile, { timeoutMs: 5000 })
+    if (status.loaded === false || status.exists === false) return
+    await bridge.destroy(sessionId, profile)
+  } catch (err) {
+    logger.warn(err, '[sessions] failed to destroy loaded bridge session')
+  }
+}
+
 function explicitProfileFilter(ctx: any): string | undefined {
   const value = typeof ctx.query?.profile === 'string' ? ctx.query.profile.trim() : ''
   return value || undefined
@@ -1093,6 +1110,7 @@ export async function remove(ctx: any) {
   const hermesProfile = requestedProfile(ctx) || existing?.profile || getActiveProfileName()
   const codingAgentSession = isCodingAgentSession(existing)
   if (codingAgentSession) codingAgentRunManager.stop(sessionId, { reportClosed: false })
+  else await destroyLoadedBridgeSession(sessionId, hermesProfile)
   const hermes = codingAgentSession
     ? { attempted: false, deleted: false, profile: hermesProfile }
     : await deleteHermesSessionIfPresent(sessionId, hermesProfile)
@@ -1163,6 +1181,7 @@ export async function batchRemove(ctx: any) {
 
     const codingAgentSession = isCodingAgentSession(existing)
     if (codingAgentSession) codingAgentRunManager.stop(id, { reportClosed: false })
+    else await destroyLoadedBridgeSession(id, targetProfile || getActiveProfileName())
     const hermes = codingAgentSession
       ? { attempted: false, deleted: false, profile: targetProfile || 'default' }
       : await deleteHermesSessionIfPresent(id, targetProfile)

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -19,6 +19,7 @@ import { codingAgentRunManager } from './agent-runner/coding-agent-run-manager'
 import { getSession, updateSession, type HermesSessionRow } from '../db/hermes/session-store'
 import type { SessionState } from './hermes/run-chat/types'
 import { normalizeWindowsCommandPath, windowsCmdShimExecution, windowsCommandNeedsShell, type WindowsCommandExecution } from './windows-command'
+import { parseDotenvValue } from './dotenv'
 
 const execFileAsync = promisify(execFile)
 const LAUNCH_API_MODES = new Set<ApiMode>(['chat_completions', 'codex_responses', 'anthropic_messages'])
@@ -413,27 +414,6 @@ function providerLookupCandidates(provider: string): string[] {
   ].filter(Boolean))]
 }
 
-function parseEnvValue(envContent: string, key: string): string {
-  if (!key) return ''
-  const lines = envContent.split(/\r?\n/)
-  for (const line of lines) {
-    const trimmed = line.trim()
-    if (!trimmed || trimmed.startsWith('#')) continue
-    const eqIndex = trimmed.indexOf('=')
-    if (eqIndex === -1) continue
-    if (trimmed.slice(0, eqIndex).trim() !== key) continue
-    const raw = trimmed.slice(eqIndex + 1).trim()
-    if (
-      (raw.startsWith('"') && raw.endsWith('"')) ||
-      (raw.startsWith("'") && raw.endsWith("'"))
-    ) {
-      return raw.slice(1, -1)
-    }
-    return raw
-  }
-  return ''
-}
-
 function inferLaunchApiMode(provider: string, baseUrl: string, fallback: ApiMode = 'chat_completions'): ApiMode {
   const providerKey = String(provider || '').toLowerCase()
   const normalizedBaseUrl = String(baseUrl || '').toLowerCase()
@@ -543,7 +523,7 @@ async function resolveStoredProviderLaunchInput(
     if (!apiKey) apiKey = String(customEntry.api_key || '').trim()
     if (!apiKey) {
       const keyEnv = String(customEntry.key_env || '').trim()
-      if (keyEnv) apiKey = parseEnvValue(envContent, keyEnv)
+      if (keyEnv) apiKey = parseDotenvValue(envContent, keyEnv)
     }
     if (!apiMode) {
       apiMode = normalizeLaunchApiMode(
@@ -558,11 +538,11 @@ async function resolveStoredProviderLaunchInput(
   const envMapping = PROVIDER_ENV_MAP[canonicalProviderKey]
   if (!baseUrl) {
     baseUrl = envMapping?.base_url_env
-      ? parseEnvValue(envContent, envMapping.base_url_env) || canonicalPreset?.base_url || ''
+      ? parseDotenvValue(envContent, envMapping.base_url_env) || canonicalPreset?.base_url || ''
       : canonicalPreset?.base_url || ''
   }
   if (!apiKey && envMapping?.api_key_env) {
-    apiKey = parseEnvValue(envContent, envMapping.api_key_env)
+    apiKey = parseDotenvValue(envContent, envMapping.api_key_env)
   }
   if (!apiMode) {
     apiMode = normalizeLaunchApiMode(

--- a/packages/server/src/services/dotenv.ts
+++ b/packages/server/src/services/dotenv.ts
@@ -1,0 +1,41 @@
+function closingQuoteIndex(value: string, quote: "'" | '"'): number {
+  for (let index = 1; index < value.length; index += 1) {
+    if (value[index] !== quote) continue
+    let backslashes = 0
+    for (let cursor = index - 1; cursor >= 0 && value[cursor] === '\\'; cursor -= 1) {
+      backslashes += 1
+    }
+    if (backslashes % 2 === 0) return index
+  }
+  return -1
+}
+
+function parseDotenvRawValue(rawValue: string): string {
+  const value = rawValue.trim()
+  const quote = value[0]
+  if (quote === '"' || quote === "'") {
+    const closingIndex = closingQuoteIndex(value, quote)
+    if (closingIndex !== -1) return value.slice(1, closingIndex)
+    return value
+  }
+
+  const commentMatch = value.match(/\s+#/)
+  return (commentMatch ? value.slice(0, commentMatch.index) : value).trimEnd()
+}
+
+/** Read one key from dotenv text without mutating process.env. */
+export function parseDotenvValue(envContent: string, key: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) return ''
+
+  for (const rawLine of envContent.split(/\r?\n/)) {
+    let line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+    if (/^export\s+/.test(line)) line = line.replace(/^export\s+/, '')
+
+    const equalsIndex = line.indexOf('=')
+    if (equalsIndex === -1 || line.slice(0, equalsIndex).trim() !== key) continue
+    return parseDotenvRawValue(line.slice(equalsIndex + 1))
+  }
+
+  return ''
+}

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_broker.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_broker.py
@@ -36,8 +36,10 @@ class BridgeBroker:
         self._session_worker_key: dict[str, str] = {}
         self._approval_profile: dict[str, str] = {}
         self._approval_worker_key: dict[str, str] = {}
+        self._approval_session: dict[str, str] = {}
         self._clarify_profile: dict[str, str] = {}
         self._clarify_worker_key: dict[str, str] = {}
+        self._clarify_session: dict[str, str] = {}
         self._compression_profile: dict[str, str] = {}
         self._compression_worker_key: dict[str, str] = {}
         self._lock = threading.RLock()
@@ -100,14 +102,25 @@ class BridgeBroker:
             for event in resp.get("events") or []:
                 if not isinstance(event, dict):
                     continue
+                event_type = str(event.get("event") or "")
                 approval_id = str(event.get("approval_id") or "")
-                if approval_id:
+                if event_type == "approval.requested" and approval_id:
                     self._approval_profile[approval_id] = profile
                     self._approval_worker_key[approval_id] = worker_key
+                    self._approval_session[approval_id] = session_id
+                elif event_type == "approval.resolved" and approval_id:
+                    self._approval_profile.pop(approval_id, None)
+                    self._approval_worker_key.pop(approval_id, None)
+                    self._approval_session.pop(approval_id, None)
                 clarify_id = str(event.get("clarify_id") or "")
-                if clarify_id:
+                if event_type == "clarify.requested" and clarify_id:
                     self._clarify_profile[clarify_id] = profile
                     self._clarify_worker_key[clarify_id] = worker_key
+                    self._clarify_session[clarify_id] = session_id
+                elif event_type == "clarify.resolved" and clarify_id:
+                    self._clarify_profile.pop(clarify_id, None)
+                    self._clarify_worker_key.pop(clarify_id, None)
+                    self._clarify_session.pop(clarify_id, None)
                 request_id = str(event.get("request_id") or "")
                 if event.get("event") == "bridge.compression.requested" and request_id:
                     self._compression_profile[request_id] = profile
@@ -129,8 +142,10 @@ class BridgeBroker:
             self._session_worker_key.clear()
             self._approval_profile.clear()
             self._approval_worker_key.clear()
+            self._approval_session.clear()
             self._clarify_profile.clear()
             self._clarify_worker_key.clear()
+            self._clarify_session.clear()
             self._compression_profile.clear()
             self._compression_worker_key.clear()
         for worker in workers:
@@ -317,6 +332,16 @@ class BridgeBroker:
                 with self._lock:
                     self._session_profile.pop(session_id, None)
                     self._session_worker_key.pop(session_id, None)
+                    for approval_id, pending_session_id in list(self._approval_session.items()):
+                        if pending_session_id == session_id:
+                            self._approval_profile.pop(approval_id, None)
+                            self._approval_worker_key.pop(approval_id, None)
+                            self._approval_session.pop(approval_id, None)
+                    for clarify_id, pending_session_id in list(self._clarify_session.items()):
+                        if pending_session_id == session_id:
+                            self._clarify_profile.pop(clarify_id, None)
+                            self._clarify_worker_key.pop(clarify_id, None)
+                            self._clarify_session.pop(clarify_id, None)
             return resp
 
         if action == "approval_respond":
@@ -328,7 +353,13 @@ class BridgeBroker:
                 worker_key = self._approval_worker_key.get(approval_id)
             if not profile:
                 raise KeyError(f"unknown approval request: {approval_id}")
-            return self._forward(profile, req, worker_key)
+            resp = self._forward(profile, req, worker_key)
+            if resp.get("ok") is not False:
+                with self._lock:
+                    self._approval_profile.pop(approval_id, None)
+                    self._approval_worker_key.pop(approval_id, None)
+                    self._approval_session.pop(approval_id, None)
+            return resp
 
         if action == "clarify_respond":
             clarify_id = str(req.get("clarify_id") or "").strip()
@@ -339,7 +370,13 @@ class BridgeBroker:
                 worker_key = self._clarify_worker_key.get(clarify_id)
             if not profile:
                 raise KeyError(f"unknown clarify request: {clarify_id}")
-            return self._forward(profile, req, worker_key)
+            resp = self._forward(profile, req, worker_key)
+            if resp.get("ok") is not False:
+                with self._lock:
+                    self._clarify_profile.pop(clarify_id, None)
+                    self._clarify_worker_key.pop(clarify_id, None)
+                    self._clarify_session.pop(clarify_id, None)
+            return resp
 
         if action == "compression_respond":
             request_id = str(req.get("request_id") or "").strip()
@@ -364,8 +401,10 @@ class BridgeBroker:
                 self._session_worker_key.clear()
                 self._approval_profile.clear()
                 self._approval_worker_key.clear()
+                self._approval_session.clear()
                 self._clarify_profile.clear()
                 self._clarify_worker_key.clear()
+                self._clarify_session.clear()
                 self._compression_profile.clear()
                 self._compression_worker_key.clear()
             destroyed = 0
@@ -398,8 +437,10 @@ class BridgeBroker:
                 self._session_worker_key = {key: value for key, value in self._session_worker_key.items() if key in self._session_profile}
                 self._approval_profile = {key: value for key, value in self._approval_profile.items() if value != profile}
                 self._approval_worker_key = {key: value for key, value in self._approval_worker_key.items() if key in self._approval_profile}
+                self._approval_session = {key: value for key, value in self._approval_session.items() if key in self._approval_profile}
                 self._clarify_profile = {key: value for key, value in self._clarify_profile.items() if value != profile}
                 self._clarify_worker_key = {key: value for key, value in self._clarify_worker_key.items() if key in self._clarify_profile}
+                self._clarify_session = {key: value for key, value in self._clarify_session.items() if key in self._clarify_profile}
                 self._compression_profile = {key: value for key, value in self._compression_profile.items() if value != profile}
                 self._compression_worker_key = {key: value for key, value in self._compression_worker_key.items() if key in self._compression_profile}
 

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -15,8 +15,6 @@ from pathlib import Path
 from typing import Any, Callable
 
 from bridge_runtime import (
-    APPROVAL_TIMEOUT_MS,
-    APPROVAL_TIMEOUT_SECONDS,
     _approval_pattern_keys,
     _base_hermes_home,
     _bridge_platform,
@@ -25,6 +23,7 @@ from bridge_runtime import (
     _ensure_agent_imports,
     _hermes_home,
     _install_execute_code_approval_memory_patch,
+    _interaction_timeout_seconds,
     _jsonable,
     _load_cfg,
     _load_enabled_toolsets,
@@ -42,6 +41,10 @@ from bridge_runtime import (
     _title_user_message,
     _tool_names_from_definitions,
 )
+
+
+_INTERACTION_CANCELLED = object()
+_INTERACTION_TIMED_OUT = object()
 
 
 def _bind_session_workspace_cwd(session_id: str, workspace: str | None) -> bool:
@@ -169,6 +172,13 @@ class AgentSession:
     background_tasks: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
+@dataclass
+class PendingInteraction:
+    session_id: str
+    response_queue: queue.Queue[Any]
+    allowed_responses: frozenset[str] | None = None
+
+
 class AgentPool:
     MAX_BACKGROUND_EVENTS_PER_SESSION = 500
     MAX_BACKGROUND_TASKS_PER_SESSION = 50
@@ -178,13 +188,15 @@ class AgentPool:
         self._runs: dict[str, RunRecord] = {}
         self._lock = threading.RLock()
         self._db = SessionDbHolder()
-        self._approval_requests: dict[str, queue.Queue[str]] = {}
+        self._interaction_timeout_seconds = _interaction_timeout_seconds()
+        self._approval_requests: dict[str, PendingInteraction] = {}
         self._gateway_approval_requests: dict[str, str] = {}
         self._gateway_approval_pattern_keys: dict[str, list[str]] = {}
+        self._gateway_approval_timers: dict[str, threading.Timer] = {}
         self._compression_requests: dict[str, queue.Queue[dict[str, Any]]] = {}
         self._background_notification_claims: dict[tuple[str, str], dict[str, Any]] = {}
         self._suppressed_background_delegations: set[str] = set()
-        self._clarify_requests: dict[str, queue.Queue[str]] = {}
+        self._clarify_requests: dict[str, PendingInteraction] = {}
         self._run_context = threading.local()
         self._approval_handlers: dict[str, Callable[..., str]] = {}
         self._exec_ask_depth = 0
@@ -1169,13 +1181,82 @@ class AgentPool:
 
         return callback
 
+    def _interaction_timeout_ms(self) -> int | None:
+        timeout = self._interaction_timeout_seconds
+        return timeout * 1000 if timeout is not None else None
+
+    def _wait_for_interaction(
+        self,
+        requests: dict[str, PendingInteraction],
+        request_id: str,
+        pending: PendingInteraction,
+    ) -> Any:
+        try:
+            if self._interaction_timeout_seconds is None:
+                return pending.response_queue.get()
+            try:
+                return pending.response_queue.get(timeout=self._interaction_timeout_seconds)
+            except queue.Empty:
+                with self._lock:
+                    if requests.get(request_id) is pending:
+                        requests.pop(request_id, None)
+                        return _INTERACTION_TIMED_OUT
+                # A responder or cancellation claimed the request while get()
+                # reached its deadline. Both enqueue before releasing the lock.
+                return pending.response_queue.get()
+        finally:
+            with self._lock:
+                if requests.get(request_id) is pending:
+                    requests.pop(request_id, None)
+
+    def _cancel_pending_interactions(self, session_id: str | None = None) -> int:
+        cancelled: list[PendingInteraction] = []
+        gateway_requests: list[tuple[str, str]] = []
+        timers: list[threading.Timer] = []
+        with self._lock:
+            for requests in (self._approval_requests, self._clarify_requests):
+                for request_id, pending in list(requests.items()):
+                    if session_id is not None and pending.session_id != session_id:
+                        continue
+                    requests.pop(request_id, None)
+                    pending.response_queue.put_nowait(_INTERACTION_CANCELLED)
+                    cancelled.append(pending)
+            for approval_id, gateway_session_id in list(self._gateway_approval_requests.items()):
+                if session_id is not None and gateway_session_id != session_id:
+                    continue
+                self._gateway_approval_requests.pop(approval_id, None)
+                self._gateway_approval_pattern_keys.pop(approval_id, None)
+                timer = self._gateway_approval_timers.pop(approval_id, None)
+                if timer is not None:
+                    timers.append(timer)
+                gateway_requests.append((approval_id, gateway_session_id))
+        for timer in timers:
+            timer.cancel()
+        for approval_id, gateway_session_id in gateway_requests:
+            try:
+                from tools.approval import resolve_gateway_approval
+
+                resolve_gateway_approval(gateway_session_id, "deny")
+            except Exception:
+                pass
+            self._append_event(gateway_session_id, {
+                "event": "approval.resolved",
+                "approval_id": approval_id,
+                "choice": "deny",
+            })
+        return len(cancelled) + len(gateway_requests)
+
     def _approval_callback(self, session_id: str):
         def callback(command: str, description: str, *, allow_permanent: bool = True) -> str:
             approval_id = uuid.uuid4().hex
-            response_queue: queue.Queue[str] = queue.Queue(maxsize=1)
-            with self._lock:
-                self._approval_requests[approval_id] = response_queue
             choices = ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
+            pending = PendingInteraction(
+                session_id,
+                queue.Queue(maxsize=1),
+                frozenset(choices),
+            )
+            with self._lock:
+                self._approval_requests[approval_id] = pending
             self._append_event(session_id, {
                 "event": "approval.requested",
                 "approval_id": approval_id,
@@ -1183,15 +1264,11 @@ class AgentPool:
                 "description": str(description or ""),
                 "choices": choices,
                 "allow_permanent": bool(allow_permanent),
-                "timeout_ms": APPROVAL_TIMEOUT_MS,
+                "timeout_ms": self._interaction_timeout_ms(),
             })
-            try:
-                choice = response_queue.get(timeout=APPROVAL_TIMEOUT_SECONDS)
-            except queue.Empty:
+            choice = self._wait_for_interaction(self._approval_requests, approval_id, pending)
+            if choice is _INTERACTION_TIMED_OUT or choice is _INTERACTION_CANCELLED:
                 choice = "deny"
-            finally:
-                with self._lock:
-                    self._approval_requests.pop(approval_id, None)
             self._append_event(session_id, {
                 "event": "approval.resolved",
                 "approval_id": approval_id,
@@ -1204,23 +1281,25 @@ class AgentPool:
     def _clarify_callback(self, session_id: str):
         def callback(question: str, choices: list[str] | None = None) -> str:
             clarify_id = uuid.uuid4().hex
-            response_queue: queue.Queue[str] = queue.Queue(maxsize=1)
+            pending = PendingInteraction(session_id, queue.Queue(maxsize=1))
             with self._lock:
-                self._clarify_requests[clarify_id] = response_queue
+                self._clarify_requests[clarify_id] = pending
             self._append_event(session_id, {
                 "event": "clarify.requested",
                 "clarify_id": clarify_id,
                 "question": str(question or ""),
                 "choices": list(choices) if choices else None,
-                "timeout_ms": 300_000,
+                "timeout_ms": self._interaction_timeout_ms(),
             })
-            try:
-                user_response = response_queue.get(timeout=300)
-            except queue.Empty:
-                user_response = "[user did not respond within 5m]"
-            finally:
-                with self._lock:
-                    self._clarify_requests.pop(clarify_id, None)
+            user_response = self._wait_for_interaction(self._clarify_requests, clarify_id, pending)
+            if user_response is _INTERACTION_TIMED_OUT:
+                user_response = f"[user did not respond within {self._interaction_timeout_seconds}s]"
+            elif user_response is _INTERACTION_CANCELLED:
+                user_response = "[clarification cancelled]"
+            self._append_event(session_id, {
+                "event": "clarify.resolved",
+                "clarify_id": clarify_id,
+            })
             return user_response
 
         return callback
@@ -1281,8 +1360,20 @@ class AgentPool:
                 "pattern_keys": pattern_keys,
                 "choices": choices,
                 "allow_permanent": True,
-                "timeout_ms": 300_000,
+                "timeout_ms": self._interaction_timeout_ms(),
             })
+            if self._interaction_timeout_seconds is not None:
+                timer = threading.Timer(
+                    self._interaction_timeout_seconds,
+                    self.respond_approval,
+                    args=(approval_id, "deny"),
+                )
+                timer.daemon = True
+                with self._lock:
+                    if approval_id not in self._gateway_approval_requests:
+                        return
+                    self._gateway_approval_timers[approval_id] = timer
+                timer.start()
 
         return callback
 
@@ -1671,6 +1762,7 @@ class AgentPool:
             finally:
                 with self._lock:
                     self._approval_handlers.pop(session.session_id, None)
+                self._cancel_pending_interactions(session.session_id)
                 try:
                     del self._run_context.session_id
                 except AttributeError:
@@ -1771,6 +1863,7 @@ class AgentPool:
             "user_interrupt",
         )
         self._settle_interrupted_background_tasks(session_id)
+        self._cancel_pending_interactions(session_id)
         if not hasattr(session.agent, "interrupt"):
             raise RuntimeError("agent does not support interrupt")
         session.agent.interrupt(message)
@@ -1805,43 +1898,42 @@ class AgentPool:
         if cleaned not in {"once", "session", "always", "deny"}:
             cleaned = "deny"
         with self._lock:
-            response_queue = self._approval_requests.get(approval_id)
-        if response_queue is None:
-            with self._lock:
+            pending = self._approval_requests.pop(approval_id, None)
+            if pending is not None:
+                if pending.allowed_responses is not None and cleaned not in pending.allowed_responses:
+                    cleaned = "deny"
+                pending.response_queue.put_nowait(cleaned)
+            else:
                 gateway_session_id = self._gateway_approval_requests.pop(approval_id, None)
                 pattern_keys = self._gateway_approval_pattern_keys.pop(approval_id, [])
-            if gateway_session_id is None:
-                return {"approval_id": approval_id, "resolved": False, "choice": cleaned}
-            try:
-                from tools.approval import resolve_gateway_approval
-
-                resolved = resolve_gateway_approval(gateway_session_id, cleaned) > 0
-            except Exception:
-                resolved = False
-            if resolved:
-                _persist_execute_code_approval_choice(gateway_session_id, pattern_keys, cleaned)
-            self._append_event(gateway_session_id, {
-                "event": "approval.resolved",
-                "approval_id": approval_id,
-                "choice": cleaned,
-            })
-            return {"approval_id": approval_id, "resolved": resolved, "choice": cleaned}
+                timer = self._gateway_approval_timers.pop(approval_id, None)
+        if pending is not None:
+            return {"approval_id": approval_id, "resolved": True, "choice": cleaned}
+        if gateway_session_id is None:
+            return {"approval_id": approval_id, "resolved": False, "choice": cleaned}
+        if timer is not None:
+            timer.cancel()
         try:
-            response_queue.put_nowait(cleaned)
-        except queue.Full:
-            pass
-        return {"approval_id": approval_id, "resolved": True, "choice": cleaned}
+            from tools.approval import resolve_gateway_approval
+
+            resolved = resolve_gateway_approval(gateway_session_id, cleaned) > 0
+        except Exception:
+            resolved = False
+        if resolved:
+            _persist_execute_code_approval_choice(gateway_session_id, pattern_keys, cleaned)
+        self._append_event(gateway_session_id, {
+            "event": "approval.resolved",
+            "approval_id": approval_id,
+            "choice": cleaned,
+        })
+        return {"approval_id": approval_id, "resolved": resolved, "choice": cleaned}
 
     def respond_clarify(self, clarify_id: str, response: str) -> dict[str, Any]:
         with self._lock:
-            response_queue = self._clarify_requests.get(clarify_id)
-        if response_queue is None:
-            return {"clarify_id": clarify_id, "resolved": False}
-        try:
-            response_queue.put_nowait(response)
-        except queue.Full:
-            pass
-        return {"clarify_id": clarify_id, "resolved": True}
+            pending = self._clarify_requests.pop(clarify_id, None)
+            if pending is not None:
+                pending.response_queue.put_nowait(response)
+        return {"clarify_id": clarify_id, "resolved": pending is not None}
 
     def get_history(self, session_id: str) -> dict[str, Any]:
         with self._lock:
@@ -2241,6 +2333,7 @@ class AgentPool:
             session_id,
             "session_destroyed",
         )
+        self._cancel_pending_interactions(session_id)
         with self._lock:
             session = self._sessions.pop(session_id, None)
         if session is None:
@@ -2276,6 +2369,8 @@ class AgentPool:
         with self._lock:
             sessions = list(self._sessions.values())
             claimed_notifications = list(self._background_notification_claims)
+
+        self._cancel_pending_interactions()
 
         interrupted_sessions = 0
         for session in sessions:

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_runtime.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_runtime.py
@@ -20,8 +20,7 @@ from typing import Any, Callable
 DEFAULT_ENDPOINT = "tcp://127.0.0.1:18765" if os.name == "nt" else "ipc:///tmp/hermes-agent-bridge.sock"
 DEFAULT_AGENT_ROOT = "~/.hermes/hermes-agent"
 DEFAULT_HERMES_HOME = "~/.hermes"
-APPROVAL_TIMEOUT_SECONDS = 120
-APPROVAL_TIMEOUT_MS = APPROVAL_TIMEOUT_SECONDS * 1000
+INTERACTION_TIMEOUT_ENV = "HERMES_AGENT_BRIDGE_INTERACTION_TIMEOUT_SECONDS"
 PARENT_WATCHDOG_INTERVAL_SECONDS = 2.0
 OPENROUTER_ATTRIBUTION_ENV = {
     "referer": "HERMES_OPENROUTER_APP_REFERER",
@@ -43,6 +42,23 @@ def _positive_int(value: str | None) -> int | None:
     except (TypeError, ValueError):
         return None
     return parsed if parsed > 0 else None
+
+
+def _interaction_timeout_seconds() -> int | None:
+    raw = os.environ.get(INTERACTION_TIMEOUT_ENV)
+    if raw is None or raw.strip().lower() in {"", "0", "none"}:
+        return None
+    try:
+        timeout = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{INTERACTION_TIMEOUT_ENV} must be a positive integer, 0, or none"
+        ) from exc
+    if timeout <= 0:
+        raise ValueError(
+            f"{INTERACTION_TIMEOUT_ENV} must be a positive integer, 0, or none"
+        )
+    return timeout
 
 
 def _title_user_message(message: Any) -> str:

--- a/packages/server/src/services/hermes/agent-bridge/python/hermes_bridge.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/hermes_bridge.py
@@ -52,6 +52,7 @@ _RUNTIME_PATCH_NAMES = (
     "_find_agent_root",
     "_hermes_home",
     "_hidden_subprocess_kwargs",
+    "_interaction_timeout_seconds",
     "_json_default",
     "_json_line_bytes",
     "_jsonable",
@@ -72,8 +73,6 @@ _RUNTIME_PATCH_NAMES = (
 )
 
 _POOL_PATCH_NAMES = (
-    "APPROVAL_TIMEOUT_MS",
-    "APPROVAL_TIMEOUT_SECONDS",
     "_approval_pattern_keys",
     "_base_hermes_home",
     "_bridge_platform",
@@ -82,6 +81,7 @@ _POOL_PATCH_NAMES = (
     "_ensure_agent_imports",
     "_hermes_home",
     "_install_execute_code_approval_memory_patch",
+    "_interaction_timeout_seconds",
     "_jsonable",
     "_load_cfg",
     "_load_enabled_toolsets",

--- a/packages/server/src/services/hermes/api-key-image.ts
+++ b/packages/server/src/services/hermes/api-key-image.ts
@@ -1,0 +1,743 @@
+import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'fs'
+import { lookup } from 'dns/promises'
+import { isIP } from 'net'
+import { randomUUID } from 'crypto'
+import { homedir, tmpdir } from 'os'
+import { dirname, extname, isAbsolute, resolve } from 'path'
+import { config } from '../../config'
+import {
+  isNearestExistingRealPathWithin,
+  isPathWithin,
+  isRealPathWithin,
+} from './hermes-path'
+import { workspaceBaseOverride } from './workspace-path'
+
+export const MAX_REFERENCE_COUNT = 8
+export const MAX_REFERENCE_BYTES = 10 * 1024 * 1024
+export const MAX_REFERENCE_TOTAL_BYTES = 12 * 1024 * 1024
+export const MAX_IMAGE_REQUEST_BYTES = 18 * 1024 * 1024
+
+const LEGACY_MAX_IMAGE_BYTES = 25 * 1024 * 1024
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000
+const DEFAULT_IMAGE_MODEL = 'codex-gpt-image-2'
+const DEFAULT_RESPONSE_MODEL = 'gpt-5.4-mini'
+const DEFAULT_QUALITY = 'high'
+const DEFAULT_RESOLUTION = '4k'
+const ALLOWED_IMAGE_MIMES = new Set(['image/png', 'image/jpeg', 'image/webp'])
+const MAX_GENERATED_IMAGE_BYTES = 50 * 1024 * 1024
+const MAX_GENERATED_TOTAL_BYTES = 100 * 1024 * 1024
+const MAX_GENERATED_BASE64_CHARS = Math.ceil(MAX_GENERATED_IMAGE_BYTES / 3) * 4 + 4
+
+export type ApiKeyImageMode = 'text' | 'image' | 'edit'
+
+export type ApiKeyImageProvider = {
+  name: string
+  apiKey: string
+  baseUrl: string
+  model: string
+}
+
+type ImageSourceInput = {
+  image_path?: unknown
+  image_url?: unknown
+  image_base64?: unknown
+  mime_type?: unknown
+}
+
+type ReferenceInput = ImageSourceInput & {
+  role?: unknown
+  priority?: unknown
+  weight?: unknown
+}
+
+type NormalizedReference = {
+  dataUri: string
+  file: {
+    buffer: Buffer
+    mime: string
+    name: string
+  }
+  role: string
+  priority?: number
+  weight?: number
+}
+
+export type GeneratedImage = {
+  base64: string
+  buffer: Buffer
+  format: 'png' | 'jpeg' | 'webp'
+  dimensions: { width: number; height: number } | null
+}
+
+export type ApiKeyImageRequestResult = {
+  images: GeneratedImage[]
+  model: string
+  provider: string
+  quality: string
+  resolution: string
+  aspect: string
+}
+
+type MediaContractError = Error & {
+  status?: number
+  code?: string
+  expose?: boolean
+}
+
+function contractError(status: number, code: string, message: string): MediaContractError {
+  return Object.assign(new Error(message), { status, code, expose: true })
+}
+
+function buildApiUrl(baseUrl: string, pathWithV1: string): string {
+  const base = baseUrl.replace(/\/+$/, '')
+  const apiPath = pathWithV1.startsWith('/') ? pathWithV1 : `/${pathWithV1}`
+  if (base.endsWith('/v1') && apiPath.startsWith('/v1/')) return `${base}${apiPath.slice(3)}`
+  return `${base}${apiPath}`
+}
+
+function safeFileRoots(): string[] {
+  const roots = [
+    config.appHome,
+    config.uploadDir,
+    workspaceBaseOverride() || homedir(),
+    process.cwd(),
+    tmpdir(),
+  ]
+  return [...new Set(roots.map(root => resolve(root)))]
+}
+
+async function resolveSafeInputPath(value: string): Promise<string> {
+  const resolvedPath = isAbsolute(value) ? resolve(value) : resolve(process.cwd(), value)
+  if (!existsSync(resolvedPath)) {
+    throw contractError(404, 'reference_not_found', 'Reference image was not found')
+  }
+  const allowed = await Promise.all(safeFileRoots().map(async root =>
+    isPathWithin(resolvedPath, root) && await isRealPathWithin(resolvedPath, root),
+  ))
+  if (!allowed.some(Boolean)) {
+    throw contractError(403, 'unsafe_reference_path', 'Reference image path is outside the allowed media roots')
+  }
+  return realpathSync(resolvedPath)
+}
+
+async function resolveSafeOutputPath(value: string): Promise<string> {
+  const resolvedPath = isAbsolute(value) ? resolve(value) : resolve(process.cwd(), value)
+  if (existsSync(resolvedPath) && lstatSync(resolvedPath).isSymbolicLink()) {
+    throw contractError(403, 'unsafe_output_path', 'Output path must not be a symbolic link')
+  }
+  const allowed = await Promise.all(safeFileRoots().map(async root =>
+    isPathWithin(resolvedPath, root) && (
+      existsSync(resolvedPath)
+        ? await isRealPathWithin(resolvedPath, root)
+        : await isNearestExistingRealPathWithin(dirname(resolvedPath), root)
+    ),
+  ))
+  if (!allowed.some(Boolean)) {
+    throw contractError(403, 'unsafe_output_path', 'Output path is outside the allowed media roots')
+  }
+  return resolvedPath
+}
+
+function mimeFromPath(path: string): string | null {
+  const ext = extname(path).toLowerCase()
+  if (ext === '.png') return 'image/png'
+  if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg'
+  if (ext === '.webp') return 'image/webp'
+  return null
+}
+
+function mimeFromMagic(buffer: Buffer): string | null {
+  if (buffer.length >= 8 && buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) return 'image/png'
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) return 'image/jpeg'
+  if (buffer.length >= 12 && buffer.subarray(0, 4).toString('ascii') === 'RIFF' && buffer.subarray(8, 12).toString('ascii') === 'WEBP') return 'image/webp'
+  return null
+}
+
+function assertImageBuffer(
+  buffer: Buffer,
+  declaredMime: string | null,
+  maxBytes: number,
+): string {
+  if (buffer.length > maxBytes) {
+    throw contractError(413, 'reference_too_large', 'A reference image exceeds the per-image size limit')
+  }
+  const detectedMime = mimeFromMagic(buffer)
+  if (!detectedMime || !ALLOWED_IMAGE_MIMES.has(detectedMime)) {
+    throw contractError(415, 'unsupported_reference_mime', 'Reference images must be PNG, JPEG, or WebP')
+  }
+  if (declaredMime && declaredMime !== detectedMime) {
+    throw contractError(415, 'reference_mime_mismatch', 'Reference image MIME does not match its content')
+  }
+  return detectedMime
+}
+
+function decodeBase64(value: string): Buffer {
+  const compact = value.replace(/\s+/g, '')
+  if (!compact || compact.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(compact)) {
+    throw contractError(400, 'invalid_reference_base64', 'Reference image base64 is invalid')
+  }
+  return Buffer.from(compact, 'base64')
+}
+
+function base64Source(input: ImageSourceInput, maxBytes: number): { buffer: Buffer; mime: string; name: string } {
+  const raw = typeof input.image_base64 === 'string' ? input.image_base64.trim() : ''
+  const dataUri = raw.match(/^data:([^;,]+);base64,([\s\S]+)$/)
+  const declaredMime = dataUri
+    ? dataUri[1].trim().toLowerCase()
+    : typeof input.mime_type === 'string'
+      ? input.mime_type.trim().toLowerCase()
+      : ''
+  if (!ALLOWED_IMAGE_MIMES.has(declaredMime)) {
+    throw contractError(415, 'unsupported_reference_mime', 'Reference images must be PNG, JPEG, or WebP')
+  }
+  const buffer = decodeBase64(dataUri ? dataUri[2] : raw)
+  const mime = assertImageBuffer(buffer, declaredMime, maxBytes)
+  return { buffer, mime, name: `reference.${mime === 'image/jpeg' ? 'jpg' : mime.slice(6)}` }
+}
+
+function isPrivateIp(address: string): boolean {
+  const normalized = address.toLowerCase().split('%')[0]
+  if (normalized === '::1' || normalized === '::' || normalized.startsWith('fc') || normalized.startsWith('fd') || normalized.startsWith('fe8') || normalized.startsWith('fe9') || normalized.startsWith('fea') || normalized.startsWith('feb')) return true
+  const mapped = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)?.[1]
+  const ipv4 = mapped || (isIP(normalized) === 4 ? normalized : '')
+  if (!ipv4) return false
+  const parts = ipv4.split('.').map(Number)
+  return parts[0] === 0 ||
+    parts[0] === 10 ||
+    parts[0] === 127 ||
+    (parts[0] === 169 && parts[1] === 254) ||
+    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+    (parts[0] === 192 && parts[1] === 168) ||
+    (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) ||
+    parts[0] >= 224
+}
+
+async function assertSafeImageUrl(url: URL): Promise<void> {
+  if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password) {
+    throw contractError(400, 'unsafe_reference_url', 'Reference image URL is not allowed')
+  }
+  const hostname = url.hostname.toLowerCase()
+  if (hostname === 'localhost' || hostname.endsWith('.localhost') || hostname.endsWith('.local')) {
+    throw contractError(400, 'unsafe_reference_url', 'Reference image URL is not allowed')
+  }
+  if (isIP(hostname)) {
+    if (isPrivateIp(hostname)) throw contractError(400, 'unsafe_reference_url', 'Reference image URL is not allowed')
+    return
+  }
+  let addresses: Array<{ address: string }>
+  try {
+    addresses = await lookup(hostname, { all: true, verbatim: true })
+  } catch {
+    throw contractError(400, 'reference_url_unreachable', 'Reference image URL could not be resolved')
+  }
+  if (!addresses.length || addresses.some(entry => isPrivateIp(entry.address))) {
+    throw contractError(400, 'unsafe_reference_url', 'Reference image URL is not allowed')
+  }
+}
+
+async function fetchImageBytes(value: string, maxBytes: number): Promise<{ buffer: Buffer; mime: string; name: string }> {
+  let current: URL
+  try {
+    current = new URL(value)
+  } catch {
+    throw contractError(400, 'invalid_reference_url', 'Reference image URL is invalid')
+  }
+
+  for (let redirects = 0; redirects <= 3; redirects += 1) {
+    await assertSafeImageUrl(current)
+    let response: Response
+    try {
+      response = await fetch(current, {
+        redirect: 'manual',
+        signal: AbortSignal.timeout(30_000),
+        headers: { Accept: 'image/png,image/jpeg,image/webp' },
+      })
+    } catch {
+      throw contractError(400, 'reference_url_unreachable', 'Reference image URL could not be fetched')
+    }
+    if ([301, 302, 303, 307, 308].includes(response.status)) {
+      const location = response.headers.get('location')
+      if (!location || redirects === 3) {
+        throw contractError(400, 'unsafe_reference_redirect', 'Reference image URL redirect was rejected')
+      }
+      current = new URL(location, current)
+      continue
+    }
+    if (!response.ok) {
+      throw contractError(400, 'reference_url_fetch_failed', 'Reference image URL could not be fetched')
+    }
+    const contentLength = Number(response.headers.get('content-length') || 0)
+    if (contentLength > maxBytes) {
+      throw contractError(413, 'reference_too_large', 'A reference image exceeds the per-image size limit')
+    }
+    const buffer = Buffer.from(await response.arrayBuffer())
+    const declaredMime = String(response.headers.get('content-type') || '').split(';')[0].trim().toLowerCase()
+    const mime = assertImageBuffer(buffer, declaredMime || null, maxBytes)
+    const name = current.pathname.split('/').pop() || `reference.${mime.slice(6)}`
+    return { buffer, mime, name }
+  }
+  throw contractError(400, 'unsafe_reference_redirect', 'Reference image URL redirect was rejected')
+}
+
+async function normalizeImageSource(
+  input: ImageSourceInput,
+  maxBytes: number,
+): Promise<{ buffer: Buffer; mime: string; name: string }> {
+  const sources = [
+    typeof input.image_path === 'string' && input.image_path.trim() ? 'path' : '',
+    typeof input.image_url === 'string' && input.image_url.trim() ? 'url' : '',
+    typeof input.image_base64 === 'string' && input.image_base64.trim() ? 'base64' : '',
+  ].filter(Boolean)
+  if (sources.length !== 1) {
+    throw contractError(400, 'invalid_reference_source', 'Each reference must provide exactly one image_path, image_url, or image_base64')
+  }
+  if (sources[0] === 'base64') return base64Source(input, maxBytes)
+  if (sources[0] === 'url') return fetchImageBytes(String(input.image_url).trim(), maxBytes)
+
+  const safePath = await resolveSafeInputPath(String(input.image_path).trim())
+  const buffer = readFileSync(safePath)
+  const declaredMime = mimeFromPath(safePath)
+  const mime = assertImageBuffer(buffer, declaredMime, maxBytes)
+  return { buffer, mime, name: safePath.split(/[\\/]/).pop() || `reference.${mime.slice(6)}` }
+}
+
+function numberMetadata(value: unknown, key: 'priority' | 'weight'): number | undefined {
+  if (value === undefined || value === null || value === '') return undefined
+  const parsed = Number(value)
+  const valid = Number.isFinite(parsed) &&
+    (key === 'priority' ? Number.isInteger(parsed) && parsed >= 0 && parsed <= 100 : parsed >= 0 && parsed <= 1)
+  if (!valid) {
+    throw contractError(400, `invalid_reference_${key}`, key === 'priority'
+      ? 'Reference priority must be an integer from 0 to 100'
+      : 'Reference weight must be a number from 0 to 1')
+  }
+  return parsed
+}
+
+async function normalizeReferences(body: any, mode: ApiKeyImageMode): Promise<NormalizedReference[]> {
+  const structured = body.references
+  if (structured !== undefined && !Array.isArray(structured)) {
+    throw contractError(400, 'invalid_references', 'references must be an array')
+  }
+  if (Array.isArray(structured) && structured.length > MAX_REFERENCE_COUNT) {
+    throw contractError(413, 'too_many_references', `At most ${MAX_REFERENCE_COUNT} reference images are allowed`)
+  }
+
+  const legacy: ImageSourceInput = {
+    image_path: body.image_path,
+    image_url: body.image_url,
+    image_base64: body.image_base64,
+    mime_type: body.mime_type,
+  }
+  const hasLegacy = [legacy.image_path, legacy.image_url, legacy.image_base64]
+    .some(value => typeof value === 'string' && value.trim())
+  if (structured?.length && hasLegacy) {
+    throw contractError(400, 'ambiguous_references', 'Use references or the legacy single-image fields, not both')
+  }
+  if (mode === 'text') {
+    if (structured?.length || hasLegacy) {
+      throw contractError(400, 'references_not_allowed', 'Reference images require image or edit mode')
+    }
+    return []
+  }
+
+  const inputs: ReferenceInput[] = structured?.length
+    ? structured
+    : hasLegacy
+      ? [{ ...legacy, role: 'reference', priority: 0 }]
+      : []
+  if (!inputs.length) {
+    throw contractError(400, 'reference_required', 'image_path, image_url, image_base64, or references is required')
+  }
+
+  const normalized: NormalizedReference[] = []
+  let totalBytes = 0
+  for (const input of inputs) {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+      throw contractError(400, 'invalid_reference', 'Each reference must be an object')
+    }
+    const role = typeof input.role === 'string' ? input.role.trim() : ''
+    const priority = numberMetadata(input.priority, 'priority')
+    const weight = numberMetadata(input.weight, 'weight')
+    if (!role || role.length > 64) {
+      throw contractError(400, 'invalid_reference_role', 'Reference role is required and must be at most 64 characters')
+    }
+    if (structured?.length && priority === undefined && weight === undefined) {
+      throw contractError(400, 'reference_metadata_required', 'Each structured reference requires priority or weight')
+    }
+    const file = await normalizeImageSource(input, structured?.length ? MAX_REFERENCE_BYTES : LEGACY_MAX_IMAGE_BYTES)
+    totalBytes += file.buffer.length
+    if (totalBytes > MAX_REFERENCE_TOTAL_BYTES && structured?.length) {
+      throw contractError(413, 'references_total_too_large', 'Reference images exceed the total decoded size limit')
+    }
+    normalized.push({
+      dataUri: `data:${file.mime};base64,${file.buffer.toString('base64')}`,
+      file,
+      role,
+      priority,
+      weight,
+    })
+  }
+  return normalized
+}
+
+function normalizeImageMode(value: unknown): ApiKeyImageMode {
+  const mode = String(value || 'text').trim().toLowerCase()
+  if (mode === 'text' || mode === 'image' || mode === 'edit') return mode
+  throw contractError(400, 'invalid_mode', 'mode must be one of text, image, or edit')
+}
+
+function normalizePositiveInt(value: unknown, fallback: number, key: string): number {
+  const parsed = value === undefined || value === null || value === '' ? fallback : Number(value)
+  if (!Number.isFinite(parsed) || parsed < 1 || !Number.isInteger(parsed)) {
+    throw contractError(400, `invalid_${key}`, `${key} must be a positive integer`)
+  }
+  return parsed
+}
+
+function normalizeText(value: unknown, fallback: string, key: string, maxLength = 128): string {
+  const normalized = typeof value === 'string' && value.trim() ? value.trim() : fallback
+  if (normalized.length > maxLength) {
+    throw contractError(400, `invalid_${key}`, `${key} is too long`)
+  }
+  return normalized
+}
+
+function collectImageBase64(event: any, images: string[] = []): string[] {
+  if (!event || typeof event !== 'object') return images
+  for (const key of ['b64_json', 'base64', 'image_base64', 'partial_image_b64']) {
+    if (typeof event[key] === 'string' && event[key]) {
+      if (event[key].length > MAX_GENERATED_BASE64_CHARS) {
+        throw contractError(502, 'upstream_image_too_large', 'Image provider returned an image that exceeds the output size limit')
+      }
+      images.push(event[key])
+    }
+  }
+  for (const item of event.data || []) collectImageBase64(item, images)
+  for (const item of event.response?.output || []) {
+    if (typeof item?.result === 'string' && item.result) images.push(item.result)
+    collectImageBase64(item, images)
+  }
+  if (typeof event.item?.result === 'string' && event.item.result) images.push(event.item.result)
+  return images
+}
+
+function isPartialImageEvent(event: any): boolean {
+  return event?.type === 'image_generation.partial_image' ||
+    event?.type === 'response.image_generation_call.partial_image'
+}
+
+async function readSseImageResults(response: Response, limit: number): Promise<string[]> {
+  if (!response.body) throw contractError(502, 'upstream_invalid_response', 'Image provider returned an unreadable response')
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  const images: string[] = []
+  let buffer = ''
+  const readFrame = (frame: string): void => {
+    const data = frame
+      .split(/\r?\n/)
+      .filter(line => line.startsWith('data:'))
+      .map(line => line.slice(5).trimStart())
+      .join('\n')
+      .trim()
+    if (!data || data === '[DONE]') return
+    let event: any
+    try {
+      event = JSON.parse(data)
+    } catch {
+      throw contractError(502, 'upstream_invalid_response', 'Image provider returned an invalid stream')
+    }
+    if (event?.type === 'error' || event?.type === 'response.failed') {
+      throw contractError(502, 'upstream_stream_error', 'Image provider reported a generation failure')
+    }
+    if (isPartialImageEvent(event)) return
+    collectImageBase64(event, images)
+  }
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    if (buffer.length > MAX_GENERATED_BASE64_CHARS * Math.max(1, limit)) {
+      throw contractError(502, 'upstream_response_too_large', 'Image provider response exceeds the output size limit')
+    }
+    const frames = buffer.split(/\r?\n\r?\n/)
+    buffer = frames.pop() || ''
+    for (const frame of frames) {
+      readFrame(frame)
+      if (images.length >= limit) return images.slice(0, limit)
+    }
+  }
+  if (buffer.trim()) readFrame(buffer)
+  return images.slice(0, limit)
+}
+
+function upstreamError(status: number): MediaContractError {
+  if (status === 401 || status === 403) return contractError(502, 'upstream_auth_failed', 'Image provider authentication failed')
+  if (status === 429) return contractError(503, 'upstream_rate_limited', 'Image provider rate limit was reached')
+  if (status === 400 || status === 409 || status === 422) return contractError(502, 'upstream_rejected_request', 'Image provider rejected the generation request')
+  return contractError(502, 'upstream_unavailable', 'Image provider is unavailable')
+}
+
+function dimensionsFromPng(buffer: Buffer): { width: number; height: number } | null {
+  if (buffer.length < 24) return null
+  return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) }
+}
+
+function dimensionsFromJpeg(buffer: Buffer): { width: number; height: number } | null {
+  let offset = 2
+  while (offset + 9 < buffer.length) {
+    if (buffer[offset] !== 0xff) {
+      offset += 1
+      continue
+    }
+    const marker = buffer[offset + 1]
+    if ([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf].includes(marker)) {
+      return { width: buffer.readUInt16BE(offset + 7), height: buffer.readUInt16BE(offset + 5) }
+    }
+    if (marker === 0xd8 || marker === 0xd9) {
+      offset += 2
+      continue
+    }
+    const length = buffer.readUInt16BE(offset + 2)
+    if (length < 2) break
+    offset += 2 + length
+  }
+  return null
+}
+
+function dimensionsFromWebp(buffer: Buffer): { width: number; height: number } | null {
+  if (buffer.length < 30) return null
+  const chunk = buffer.subarray(12, 16).toString('ascii')
+  if (chunk === 'VP8X') {
+    return {
+      width: 1 + buffer.readUIntLE(24, 3),
+      height: 1 + buffer.readUIntLE(27, 3),
+    }
+  }
+  if (chunk === 'VP8 ' && buffer.length >= 30) {
+    return {
+      width: buffer.readUInt16LE(26) & 0x3fff,
+      height: buffer.readUInt16LE(28) & 0x3fff,
+    }
+  }
+  if (chunk === 'VP8L' && buffer.length >= 25) {
+    const bits = buffer.readUInt32LE(21)
+    return {
+      width: (bits & 0x3fff) + 1,
+      height: ((bits >> 14) & 0x3fff) + 1,
+    }
+  }
+  return null
+}
+
+function generatedImage(value: string): GeneratedImage {
+  const buffer = decodeBase64(value)
+  const mime = mimeFromMagic(buffer)
+  if (!mime) throw contractError(502, 'upstream_invalid_image', 'Image provider returned invalid image data')
+  const format = mime === 'image/png' ? 'png' : mime === 'image/jpeg' ? 'jpeg' : 'webp'
+  const dimensions = format === 'png'
+    ? dimensionsFromPng(buffer)
+    : format === 'jpeg'
+      ? dimensionsFromJpeg(buffer)
+      : dimensionsFromWebp(buffer)
+  return { base64: value, buffer, format, dimensions }
+}
+
+export function imageRequestId(headerValue: string): string {
+  const normalized = headerValue.trim()
+  return /^[A-Za-z0-9._-]{1,128}$/.test(normalized)
+    ? normalized
+    : randomUUID()
+}
+
+export async function requestApiKeyImages(
+  provider: ApiKeyImageProvider,
+  body: any,
+  requestId: string,
+): Promise<{ mode: ApiKeyImageMode; result: ApiKeyImageRequestResult }> {
+  let requestBytes: number
+  try {
+    requestBytes = Buffer.byteLength(JSON.stringify(body || {}))
+  } catch {
+    throw contractError(400, 'invalid_request_body', 'Request body must be valid JSON')
+  }
+  if (requestBytes > MAX_IMAGE_REQUEST_BYTES) {
+    throw contractError(413, 'request_too_large', 'Image generation request exceeds the request size limit')
+  }
+
+  const prompt = typeof body?.prompt === 'string' ? body.prompt.trim() : ''
+  if (!prompt) throw contractError(400, 'prompt_required', 'prompt is required')
+  if (prompt.length > 32_000) throw contractError(400, 'prompt_too_long', 'prompt is too long')
+
+  const mode = normalizeImageMode(body.mode)
+  const n = normalizePositiveInt(body.n, 1, 'n')
+  if (n > 4) throw contractError(400, 'invalid_n', 'n must be between 1 and 4')
+  const timeoutMs = normalizePositiveInt(body.timeout_ms, DEFAULT_TIMEOUT_MS, 'timeout_ms')
+  const references = await normalizeReferences(body, mode)
+  const quality = normalizeText(body.quality, DEFAULT_QUALITY, 'quality', 32)
+  const resolution = normalizeText(body.resolution, DEFAULT_RESOLUTION, 'resolution', 32)
+  const aspect = normalizeText(body.aspect ?? body.aspect_ratio, 'auto', 'aspect', 32)
+  const imageModel = normalizeText(
+    body.image_model ?? body.model,
+    DEFAULT_IMAGE_MODEL,
+    'image_model',
+  )
+  const responseModel = normalizeText(body.response_model, provider.model || DEFAULT_RESPONSE_MODEL, 'response_model')
+  const outputFormat = normalizeText(body.output_format, 'png', 'output_format', 16)
+  if (!['png', 'jpeg', 'webp'].includes(outputFormat)) {
+    throw contractError(400, 'invalid_output_format', 'output_format must be png, jpeg, or webp')
+  }
+
+  const headers = {
+    Accept: 'text/event-stream',
+    Authorization: `Bearer ${provider.apiKey}`,
+    'X-Request-Id': requestId,
+  }
+  const generationOptions = {
+    quality,
+    resolution,
+    aspect_ratio: aspect,
+    ...(typeof body.size === 'string' && body.size.trim() ? { size: body.size.trim() } : {}),
+  }
+
+  let response: Response
+  try {
+    if (mode === 'text') {
+      response = await fetch(buildApiUrl(provider.baseUrl, '/v1/images/generations'), {
+        method: 'POST',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        signal: AbortSignal.timeout(timeoutMs),
+        body: JSON.stringify({
+          model: imageModel,
+          prompt,
+          n,
+          ...generationOptions,
+          stream: true,
+          response_format: 'b64_json',
+        }),
+      })
+    } else if (mode === 'image') {
+      response = await fetch(buildApiUrl(provider.baseUrl, '/v1/responses'), {
+        method: 'POST',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        signal: AbortSignal.timeout(timeoutMs),
+        body: JSON.stringify({
+          model: responseModel,
+          stream: true,
+          input: [{
+            role: 'user',
+            content: [
+              { type: 'input_text', text: prompt },
+              ...references.map(reference => ({
+                type: 'input_image',
+                image_url: reference.dataUri,
+                reference_role: reference.role,
+                ...(reference.priority === undefined ? {} : { priority: reference.priority }),
+                ...(reference.weight === undefined ? {} : { weight: reference.weight }),
+              })),
+            ],
+          }],
+          tools: [{
+            type: 'image_generation',
+            model: imageModel,
+            ...generationOptions,
+            output_format: outputFormat,
+          }],
+          tool_choice: { type: 'image_generation' },
+        }),
+      })
+    } else {
+      const form = new FormData()
+      for (const [index, reference] of references.entries()) {
+        const bytes = new Uint8Array(reference.file.buffer.byteLength)
+        bytes.set(reference.file.buffer)
+        form.append(references.length === 1 ? 'image' : 'image[]', new Blob([bytes.buffer], { type: reference.file.mime }), reference.file.name)
+        if (references.length > 1) {
+          form.append(`reference_role[${index}]`, reference.role)
+          if (reference.priority !== undefined) form.append(`reference_priority[${index}]`, String(reference.priority))
+          if (reference.weight !== undefined) form.append(`reference_weight[${index}]`, String(reference.weight))
+        }
+      }
+      form.append('prompt', prompt)
+      form.append('model', imageModel)
+      form.append('n', String(n))
+      form.append('quality', quality)
+      form.append('resolution', resolution)
+      form.append('aspect_ratio', aspect)
+      if (typeof body.size === 'string' && body.size.trim()) form.append('size', body.size.trim())
+      form.append('stream', 'true')
+      form.append('response_format', 'b64_json')
+      response = await fetch(buildApiUrl(provider.baseUrl, '/v1/images/edits'), {
+        method: 'POST',
+        headers,
+        signal: AbortSignal.timeout(timeoutMs),
+        body: form,
+      })
+    }
+  } catch (err: any) {
+    if (err?.name === 'TimeoutError' || err?.name === 'AbortError') {
+      throw contractError(504, 'upstream_timeout', 'Image provider request timed out')
+    }
+    if (err?.expose) throw err
+    throw contractError(502, 'upstream_unavailable', 'Image provider is unavailable')
+  }
+
+  if (!response.ok) throw upstreamError(response.status)
+  const encodedImages = await readSseImageResults(response, n)
+  if (!encodedImages.length) {
+    throw contractError(502, 'upstream_empty_result', 'Image provider returned no completed image')
+  }
+  const images = encodedImages.map(generatedImage)
+  if (images.some(image => image.buffer.length > MAX_GENERATED_IMAGE_BYTES)) {
+    throw contractError(502, 'upstream_image_too_large', 'Image provider returned an image that exceeds the output size limit')
+  }
+  if (images.reduce((total, image) => total + image.buffer.length, 0) > MAX_GENERATED_TOTAL_BYTES) {
+    throw contractError(502, 'upstream_response_too_large', 'Image provider response exceeds the output size limit')
+  }
+  return {
+    mode,
+    result: {
+      images,
+      model: imageModel,
+      provider: provider.name,
+      quality,
+      resolution,
+      aspect,
+    },
+  }
+}
+
+export async function saveGeneratedImages(
+  images: GeneratedImage[],
+  defaultPath: (index: number, format: GeneratedImage['format']) => string,
+  requestedOutputPath?: string,
+): Promise<Array<GeneratedImage & { outputPath: string }>> {
+  const results: Array<GeneratedImage & { outputPath: string }> = []
+  for (const [index, image] of images.entries()) {
+    const candidate = requestedOutputPath && images.length === 1
+      ? requestedOutputPath
+      : requestedOutputPath
+        ? requestedOutputPath.replace(/(\.[^.\\/]+)?$/, `${index > 0 ? `-${index + 1}` : ''}$1`)
+        : defaultPath(index, image.format)
+    const outputPath = await resolveSafeOutputPath(candidate)
+    mkdirSync(dirname(outputPath), { recursive: true })
+    writeFileSync(outputPath, image.buffer)
+    results.push({ ...image, outputPath })
+  }
+  return results
+}
+
+export function publicImageError(err: any): { status: number; error: string; code: string } {
+  if (err?.expose && typeof err?.code === 'string') {
+    return {
+      status: Number(err.status) || 400,
+      error: String(err.message || 'Image generation request failed'),
+      code: err.code,
+    }
+  }
+  return {
+    status: 500,
+    error: 'Image generation failed',
+    code: 'image_generation_failed',
+  }
+}

--- a/packages/skills/apikey-image-gen/SKILL.md
+++ b/packages/skills/apikey-image-gen/SKILL.md
@@ -95,7 +95,10 @@ Use when there is no input image.
 {
   "mode": "text",
   "prompt": "A high quality product image of a matte black mechanical keyboard on a clean desk",
-  "size": "1024x1024",
+  "model": "codex-gpt-image-2",
+  "quality": "high",
+  "resolution": "4k",
+  "aspect": "16:9",
   "output_path": "/absolute/path/to/output.png"
 }
 ```
@@ -112,13 +115,40 @@ Use when the user provides a reference image and wants a new image based on it.
   "mode": "image",
   "prompt": "Use this reference composition and generate a refined technology brand poster",
   "image_path": "/absolute/path/to/reference.png",
-  "size": "1024x1024",
+  "quality": "high",
+  "resolution": "4k",
   "output_path": "/absolute/path/to/output.png"
 }
 ```
 
 The server calls `POST /v1/responses` against the `fun-codex` base URL.
 If `provider`, `provider_name`, or `custom_provider` is present, the server calls the requested provider's base URL instead.
+
+For multiple references, use `references`. Do not combine it with the legacy single-reference fields. Every item must contain exactly one image source, a `role`, and either `priority` (`0`–`100`) or `weight` (`0`–`1`):
+
+```json
+{
+  "mode": "image",
+  "prompt": "Use the first image for composition and the second for visual style",
+  "references": [
+    {
+      "image_path": "/allowed/workspace/layout.png",
+      "role": "composition",
+      "priority": 1
+    },
+    {
+      "image_base64": "<base64>",
+      "mime_type": "image/png",
+      "role": "style",
+      "weight": 0.8
+    }
+  ],
+  "model": "codex-gpt-image-2",
+  "quality": "high",
+  "resolution": "4k",
+  "aspect": "16:9"
+}
+```
 
 ### Image Edit
 
@@ -129,7 +159,8 @@ Use when the user wants to modify an existing image while preserving parts of it
   "mode": "edit",
   "prompt": "Change the background to blue and keep the subject unchanged",
   "image_path": "/absolute/path/to/source.png",
-  "size": "1024x1024",
+  "quality": "high",
+  "resolution": "4k",
   "output_path": "/absolute/path/to/edited.png"
 }
 ```
@@ -147,13 +178,26 @@ If `provider`, `provider_name`, or `custom_provider` is present, the server call
 - `image_path`: local png, jpeg, or webp path. Required for `image` and `edit` unless using `image_url` or `image_base64`.
 - `image_url`: optional alternative image input.
 - `image_base64`: optional alternative image input. If it is not a data URI, include `mime_type`.
+- `references`: optional structured array for `image` and `edit` modes. Maximum 8 items. Each item accepts exactly one of `image_path`, `image_url`, or `image_base64`, plus `role` and either `priority` or `weight`.
 - `n`: number of images. Defaults to `1`.
-- `size`: defaults to `1024x1024`. Common values: `1024x1024`, `1536x1024`, `1024x1536`, `2048x2048`, `3840x2160`, `2160x3840`, `auto`.
-- `quality`: defaults to `auto`.
-- `model`: optional override. If omitted, text/edit modes use `gpt-image-2`; image mode uses the selected provider's `model` when configured, then falls back to `gpt-5.4-mini`.
-- `image_model`: optional image tool model for image mode. Defaults to `gpt-image-2`.
-- `output_path`: optional absolute output file path. If omitted, the server saves to `${HERMES_WEB_UI_HOME:-~/.hermes-web-ui}/media/*.png`.
+- `size`: optional legacy provider size parameter. It is forwarded only; Hermes Studio never locally resizes an image to satisfy it.
+- `quality`: defaults to `high`.
+- `resolution`: defaults to `4k` and is passed to the provider. Hermes Studio does not upscale a smaller provider result.
+- `aspect` / `aspect_ratio`: provider aspect-ratio parameter. Defaults to `auto`.
+- `model`: optional override. Text/edit modes default to `codex-gpt-image-2`; in image mode it continues to select the Responses orchestration model.
+- `image_model`: optional image tool model for image mode. Defaults to `codex-gpt-image-2`.
+- `output_format`: `png`, `jpeg`, or `webp`. Defaults to `png`.
+- `output_path`: optional output file path under an allowed Web UI, upload, workspace/user, or temporary root. If omitted, the server saves to `${HERMES_WEB_UI_HOME:-~/.hermes-web-ui}/media/*`.
 - `timeout_ms`: defaults to `600000`.
+
+Validation limits:
+
+- Only PNG, JPEG, and WebP are accepted. The declared MIME must match the image signature.
+- Structured references are limited to 10 MiB each and 12 MiB decoded in total.
+- Generated images are limited to 50 MiB each and 100 MiB per provider response.
+- The JSON request is limited to 18 MiB. The server's global JSON parser remains capped at 20 MiB.
+- Public HTTP(S) reference URLs must not resolve to loopback, private, link-local, or credential-bearing targets; redirects are revalidated.
+- Local reference and output paths must remain under the allowed roots. Set `WORKSPACE_BASE` when a deployment needs a narrower workspace root.
 
 ## Curl Template
 
@@ -186,7 +230,10 @@ curl -sS -X POST "$BASE_URL/api/hermes/media/apikey-image-generate" \
     "mode": "text",
     "provider": "fun-codex",
     "prompt": "A cinematic 4K photo of a silver robot hand holding a small glowing cube",
-    "size": "3840x2160",
+    "model": "codex-gpt-image-2",
+    "quality": "high",
+    "resolution": "4k",
+    "aspect": "16:9",
     "output_path": "/absolute/path/to/output.png"
   }'
 ```
@@ -199,9 +246,33 @@ Successful responses include:
   "mode": "text",
   "output_paths": ["/absolute/path/to/output.png"],
   "provider": "fun-codex",
-  "base_url": "https://api.apikey.fun/v1"
+  "base_url": "https://api.apikey.fun/v1",
+  "request_id": "6ca4b37c-8e06-4bd9-a4ee-6f77b8106fbf",
+  "model": "codex-gpt-image-2",
+  "actual_model": "codex-gpt-image-2",
+  "actual_provider": "fun-codex",
+  "quality": "high",
+  "resolution": "4k",
+  "aspect": "16:9",
+  "dimensions": {
+    "width": 3840,
+    "height": 2160
+  },
+  "format": "png",
+  "images": [
+    {
+      "output_path": "/absolute/path/to/output.png",
+      "dimensions": {
+        "width": 3840,
+        "height": 2160
+      },
+      "format": "png"
+    }
+  ]
 }
 ```
 
 If the response code is `missing_fun_codex_provider`, tell the user to configure `fun-codex` in the selected/requested profile's `config.yaml`.
 If the response code is `missing_apikey_image_provider`, tell the user to configure the requested provider in the selected/requested profile's `config.yaml`, or omit `provider` to use the default `fun-codex` provider.
+Validation failures use stable codes such as `too_many_references`, `reference_too_large`, `references_total_too_large`, `unsupported_reference_mime`, `reference_mime_mismatch`, `unsafe_reference_path`, and `unsafe_reference_url`.
+Provider failures use `upstream_auth_failed`, `upstream_rejected_request`, `upstream_rate_limited`, `upstream_timeout`, `upstream_invalid_response`, or `upstream_unavailable`. Error bodies never include upstream response text, credentials, Authorization headers, private paths, or image data.

--- a/packages/website/src/i18n/en.ts
+++ b/packages/website/src/i18n/en.ts
@@ -256,6 +256,7 @@ export default {
           ['PYTHON', 'Fallback Python executable for the agent bridge'],
           ['HERMES_AGENT_BRIDGE_ENDPOINT', 'Agent bridge broker endpoint. Windows defaults to tcp://127.0.0.1:18765; macOS/Linux defaults to ipc:///tmp/hermes-agent-bridge.sock'],
           ['HERMES_AGENT_BRIDGE_TIMEOUT_MS', 'Timeout for Node requests to the bridge broker'],
+          ['HERMES_AGENT_BRIDGE_INTERACTION_TIMEOUT_SECONDS', 'Clarify and approval deadline; unset, 0, or none waits for an explicit response, while a positive integer denies unanswered approvals after that many seconds'],
           ['HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS', 'Short retry window for connecting to the bridge socket'],
           ['HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS', 'Timeout while waiting for the Python bridge to become ready'],
           ['HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN', 'Stop the bridge broker during Web UI shutdown and restart by default; set 0/false/no/off to preserve the broker across restarts'],

--- a/packages/website/src/i18n/zh.ts
+++ b/packages/website/src/i18n/zh.ts
@@ -256,6 +256,7 @@ export default {
           ['PYTHON', 'agent bridge 的 Python 可执行文件 fallback'],
           ['HERMES_AGENT_BRIDGE_ENDPOINT', 'Agent bridge broker endpoint。Windows 默认 tcp://127.0.0.1:18765；macOS/Linux 默认 ipc:///tmp/hermes-agent-bridge.sock'],
           ['HERMES_AGENT_BRIDGE_TIMEOUT_MS', 'Node 请求 bridge broker 的响应超时'],
+          ['HERMES_AGENT_BRIDGE_INTERACTION_TIMEOUT_SECONDS', 'Clarify 与 approval 的等待期限；未设置、0 或 none 会等待明确响应，正整数会在对应秒数后对未响应 approval 执行拒绝'],
           ['HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS', '连接 bridge socket 失败时的短重试窗口'],
           ['HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS', '等待 Python bridge ready 的超时'],
           ['HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN', 'Web UI 关闭和重启时默认停止 bridge broker；设为 0/false/no/off 才会在重启时保留 broker'],

--- a/scripts/generate-openapi.mjs
+++ b/scripts/generate-openapi.mjs
@@ -972,6 +972,133 @@ openapi.paths['/api/chat-run/runs'] = {
   },
 }
 
+// Keep the media generation contract explicit: the generic source scanner cannot
+// infer nested reference objects or the additive compatibility response fields.
+const apiKeyImagePath = '/api/hermes/media/apikey-image-generate'
+openapi.paths[apiKeyImagePath].post = {
+  ...openapi.paths[apiKeyImagePath].post,
+  summary: 'Generate an image with optional multiple references',
+  description: 'Generates native provider output without local resizing. Legacy image_path, image_url, and image_base64 inputs remain supported for one reference; use references for role-aware multi-reference requests.',
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          required: ['prompt'],
+          properties: {
+            mode: { type: 'string', enum: ['text', 'image', 'edit'], default: 'text' },
+            prompt: { type: 'string', maxLength: 32000 },
+            provider: { type: 'string', description: 'Configured custom provider name. Defaults to fun-codex.' },
+            provider_name: { type: 'string', description: 'Compatibility alias for provider.' },
+            custom_provider: { type: 'string', description: 'Compatibility alias for provider.' },
+            profile: { type: 'string', description: 'Compatibility body field for profile selection; X-Hermes-Profile is preferred.' },
+            model: { type: 'string', default: 'codex-gpt-image-2' },
+            image_model: { type: 'string', description: 'Image tool model override for image mode.' },
+            quality: { type: 'string', default: 'high' },
+            resolution: { type: 'string', default: '4k' },
+            aspect: { type: 'string', default: 'auto' },
+            aspect_ratio: { type: 'string', description: 'Compatibility alias for aspect.' },
+            size: { type: 'string', description: 'Legacy provider size parameter. It is forwarded and is never implemented by local resizing.' },
+            output_format: { type: 'string', enum: ['png', 'jpeg', 'webp'], default: 'png' },
+            n: { type: 'integer', minimum: 1, maximum: 4, default: 1 },
+            timeout_ms: { type: 'integer', minimum: 1, default: 600000 },
+            output_path: { type: 'string', description: 'Optional path under an allowed media, workspace, user, or temporary root.' },
+            image_path: { type: 'string', description: 'Legacy single-reference local path.' },
+            image_url: { type: 'string', format: 'uri', description: 'Legacy single-reference public HTTP(S) URL.' },
+            image_base64: { type: 'string', description: 'Legacy single-reference base64 or data URI.' },
+            mime_type: { type: 'string', enum: ['image/png', 'image/jpeg', 'image/webp'] },
+            references: {
+              type: 'array',
+              maxItems: 8,
+              description: 'Role-aware references. Each item must provide exactly one image source plus role and priority or weight.',
+              items: {
+                type: 'object',
+                required: ['role'],
+                properties: {
+                  image_path: { type: 'string' },
+                  image_url: { type: 'string', format: 'uri' },
+                  image_base64: { type: 'string' },
+                  mime_type: { type: 'string', enum: ['image/png', 'image/jpeg', 'image/webp'] },
+                  role: { type: 'string', maxLength: 64 },
+                  priority: { type: 'integer', minimum: 0, maximum: 100 },
+                  weight: { type: 'number', minimum: 0, maximum: 1 },
+                },
+                additionalProperties: false,
+              },
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+    },
+  },
+  responses: {
+    '200': {
+      description: 'Generated image metadata. Existing ok, mode, output_paths, provider, base_url, and profile fields are preserved.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['ok', 'mode', 'output_paths', 'provider', 'request_id', 'model', 'images'],
+            properties: {
+              ok: { type: 'boolean', example: true },
+              mode: { type: 'string', enum: ['text', 'image', 'edit'] },
+              output_paths: { type: 'array', items: { type: 'string' } },
+              provider: { type: 'string' },
+              base_url: { type: 'string' },
+              profile: { type: 'string' },
+              request_id: { type: 'string' },
+              model: { type: 'string' },
+              actual_model: { type: 'string' },
+              actual_provider: { type: 'string' },
+              quality: { type: 'string' },
+              resolution: { type: 'string' },
+              aspect: { type: 'string' },
+              dimensions: {
+                nullable: true,
+                type: 'object',
+                properties: {
+                  width: { type: 'integer' },
+                  height: { type: 'integer' },
+                },
+              },
+              format: { type: 'string', nullable: true, enum: ['png', 'jpeg', 'webp'] },
+              images: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['output_path', 'format'],
+                  properties: {
+                    output_path: { type: 'string' },
+                    dimensions: {
+                      nullable: true,
+                      type: 'object',
+                      properties: {
+                        width: { type: 'integer' },
+                        height: { type: 'integer' },
+                      },
+                    },
+                    format: { type: 'string', enum: ['png', 'jpeg', 'webp'] },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '400': { $ref: '#/components/responses/BadRequest' },
+    '401': { $ref: '#/components/responses/Unauthorized' },
+    '403': { description: 'Reference or output path is outside allowed roots.' },
+    '413': { description: 'Request, reference count, per-image bytes, or total reference bytes exceeded a limit.' },
+    '415': { description: 'Reference MIME is unsupported or does not match image content.' },
+    '502': { description: 'Provider rejected the request or returned an invalid/error response.' },
+    '503': { description: 'Provider rate limited the request.' },
+    '504': { description: 'Provider request timed out.' },
+  },
+}
+
 // Add WebSocket terminal endpoint
 openapi.paths['/api/hermes/terminal'] = {
   'get': {

--- a/tests/client/chat-store-error-handling.test.ts
+++ b/tests/client/chat-store-error-handling.test.ts
@@ -7,6 +7,7 @@ const chatApi = vi.hoisted(() => ({
   resumeSession: vi.fn(),
   registerSessionHandlers: vi.fn(),
   unregisterSessionHandlers: vi.fn(),
+  respondClarify: vi.fn(),
 }))
 
 vi.mock('@/api/hermes/chat', () => ({
@@ -16,7 +17,7 @@ vi.mock('@/api/hermes/chat', () => ({
   unregisterSessionHandlers: chatApi.unregisterSessionHandlers,
   getChatRunSocket: vi.fn(() => ({ emit: vi.fn() })),
   respondToolApproval: vi.fn(),
-  respondClarify: vi.fn(),
+  respondClarify: chatApi.respondClarify,
   onPeerUserMessage: vi.fn(() => vi.fn()),
   onSessionCommand: vi.fn(() => vi.fn()),
   onSessionTitleUpdated: vi.fn(() => vi.fn()),
@@ -241,5 +242,48 @@ describe('chat store error handling - #1644', () => {
     const errorMessage = msgs.find((m: Message) => m.systemType === 'error')
     expect(errorMessage).toBeDefined()
     expect(errorMessage?.content).toBe('Error: Late socket error')
+  })
+
+  it('preserves null clarify deadlines and emits only the first response', async () => {
+    const store = useChatStore()
+    const session = makeSession('session-1')
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    await store.sendMessage('ask me a question')
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: any) => void
+    onEvent({
+      event: 'clarify.requested',
+      session_id: 'session-1',
+      run_id: 'run-1',
+      clarify_id: 'clarify-null',
+      question: 'Choose one',
+      choices: ['A', 'B'],
+      timeout_ms: null,
+    })
+
+    expect(store.activePendingClarify).toMatchObject({
+      clarifyId: 'clarify-null',
+      timeoutMs: null,
+    })
+    store.respondToClarify('A')
+    store.respondToClarify('B')
+    expect(chatApi.respondClarify).toHaveBeenCalledTimes(1)
+    expect(chatApi.respondClarify).toHaveBeenCalledWith('session-1', 'clarify-null', 'A', 'chat-run')
+    expect(store.activePendingClarify).toBeNull()
+
+    onEvent({
+      event: 'clarify.requested',
+      session_id: 'session-1',
+      run_id: 'run-1',
+      clarify_id: 'clarify-finite',
+      question: 'Choose again',
+      timeout_ms: 45_000,
+    })
+    expect(store.activePendingClarify).toMatchObject({
+      clarifyId: 'clarify-finite',
+      timeoutMs: 45_000,
+    })
   })
 })

--- a/tests/server/agent-bridge-learn-command.test.ts
+++ b/tests/server/agent-bridge-learn-command.test.ts
@@ -29,8 +29,6 @@ import types
 from pathlib import Path
 
 bridge_runtime = types.ModuleType("bridge_runtime")
-bridge_runtime.APPROVAL_TIMEOUT_MS = 1000
-bridge_runtime.APPROVAL_TIMEOUT_SECONDS = 1
 bridge_runtime._approval_pattern_keys = lambda *_args, **_kwargs: []
 bridge_runtime._base_hermes_home = lambda: Path(tempfile.gettempdir())
 bridge_runtime._bridge_platform = lambda: "agent-bridge"
@@ -39,6 +37,7 @@ bridge_runtime._discover_bridge_mcp_tools = lambda *_args, **_kwargs: []
 bridge_runtime._ensure_agent_imports = lambda: None
 bridge_runtime._hermes_home = lambda *_args, **_kwargs: Path(tempfile.gettempdir())
 bridge_runtime._install_execute_code_approval_memory_patch = lambda *_args, **_kwargs: None
+bridge_runtime._interaction_timeout_seconds = lambda: None
 bridge_runtime._jsonable = lambda value: value
 bridge_runtime._load_cfg = lambda *_args, **_kwargs: {}
 bridge_runtime._load_enabled_toolsets = lambda *_args, **_kwargs: []
@@ -102,6 +101,14 @@ agent_pkg = types.ModuleType("agent")
 agent_pkg.__path__ = []
 sys.modules["agent"] = agent_pkg
 sys.modules.pop("agent.learn_prompt", None)
+
+import builtins
+_original_import = builtins.__import__
+def _block_learn_prompt_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "agent.learn_prompt":
+        raise ImportError("agent.learn_prompt intentionally hidden by test")
+    return _original_import(name, globals, locals, fromlist, level)
+builtins.__import__ = _block_learn_prompt_import
 
 pool = bridge_pool.AgentPool()
 print(json.dumps(pool.dispatch_command("session-1", "/learn from docs", "default")))

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -30,6 +30,7 @@ import types
 from pathlib import Path
 
 os.environ["HERMES_AGENT_BRIDGE_WORKER_PROFILE"] = "default"
+os.environ.pop("HERMES_AGENT_BRIDGE_INTERACTION_TIMEOUT_SECONDS", None)
 
 tools_pkg = types.ModuleType("tools")
 tools_pkg.__path__ = []
@@ -536,6 +537,12 @@ pool._append_event(session.session_id, {
     "task_count": 1,
     "goal": "background work",
 })
+clarify_result = {}
+clarify_thread = threading.Thread(
+    target=lambda: clarify_result.setdefault("value", pool._clarify_callback("session-1")("pick")),
+)
+clarify_thread.start()
+assert wait_for(lambda: len(pool._clarify_requests) == 1)
 
 result = pool.interrupt("session-1", "Aborted by user")
 
@@ -552,6 +559,10 @@ assert calls == [{
     "parent_session_id": "session-1",
     "reason": "user_interrupt",
 }, {"parent_message": "Aborted by user"}]
+clarify_thread.join(timeout=5)
+assert not clarify_thread.is_alive()
+assert clarify_result == {"value": "[clarification cancelled]"}
+assert pool._clarify_requests == {}
 assert pool._suppressed_background_delegations == {"deleg-current"}
 polled = pool.poll_background()
 assert polled["sessions"][0]["tasks"][0]["status"] == "interrupted"
@@ -827,6 +838,178 @@ assert [(msg["role"], msg["content"]) for msg in messages] == [
 `)
   })
 
+  it('keeps clarify and terminal approval pending by default until one response resolves them', () => {
+    runPython(String.raw`
+${harness}
+
+pool, _fake_db = make_pool()
+assert pool._interaction_timeout_seconds is None
+session = bridge.AgentSession(session_id="session-a", agent=types.SimpleNamespace())
+record = bridge.RunRecord(run_id="run-a", session_id="session-a")
+session.running = True
+session.current_run_id = record.run_id
+pool._sessions[session.session_id] = session
+pool._runs[record.run_id] = record
+
+results = {}
+approval_thread = threading.Thread(
+    target=lambda: results.setdefault("approval", pool._approval_callback("session-a")("danger", "confirm")),
+)
+clarify_thread = threading.Thread(
+    target=lambda: results.setdefault("clarify", pool._clarify_callback("session-a")("pick", ["a", "b"])),
+)
+approval_thread.start()
+clarify_thread.start()
+assert wait_for(lambda: len(pool._approval_requests) == 1 and len(pool._clarify_requests) == 1)
+time.sleep(0.1)
+assert approval_thread.is_alive()
+assert clarify_thread.is_alive()
+
+approval_id = next(iter(pool._approval_requests))
+clarify_id = next(iter(pool._clarify_requests))
+requested = [event for event in record.events if event["event"].endswith(".requested")]
+assert len(requested) == 2
+assert all(event.get("timeout_ms") is None for event in requested)
+
+assert pool.respond_approval(approval_id, "once")["resolved"] is True
+assert pool.respond_approval(approval_id, "always")["resolved"] is False
+assert pool.respond_clarify(clarify_id, "a")["resolved"] is True
+assert pool.respond_clarify(clarify_id, "b")["resolved"] is False
+approval_thread.join(timeout=5)
+clarify_thread.join(timeout=5)
+assert not approval_thread.is_alive()
+assert not clarify_thread.is_alive()
+assert results == {"approval": "once", "clarify": "a"}
+resolved = [event for event in record.events if event["event"].endswith(".resolved")]
+assert {event.get("approval_id") for event in resolved if event["event"] == "approval.resolved"} == {approval_id}
+assert {event.get("clarify_id") for event in resolved if event["event"] == "clarify.resolved"} == {clarify_id}
+assert pool._approval_requests == {}
+assert pool._clarify_requests == {}
+
+restricted = {}
+restricted_thread = threading.Thread(
+    target=lambda: restricted.setdefault(
+        "approval",
+        pool._approval_callback("session-a")("restricted", "no permanent", allow_permanent=False),
+    ),
+)
+restricted_thread.start()
+assert wait_for(lambda: len(pool._approval_requests) == 1)
+restricted_id = next(iter(pool._approval_requests))
+restricted_response = pool.respond_approval(restricted_id, "always")
+assert restricted_response == {
+    "approval_id": restricted_id,
+    "resolved": True,
+    "choice": "deny",
+}
+restricted_thread.join(timeout=5)
+assert not restricted_thread.is_alive()
+assert restricted == {"approval": "deny"}
+`)
+  })
+
+  it('uses a configured positive interaction timeout and fails closed', () => {
+    runPython(String.raw`
+${harness}
+
+os.environ["HERMES_AGENT_BRIDGE_INTERACTION_TIMEOUT_SECONDS"] = "1"
+pool, _fake_db = make_pool()
+session = bridge.AgentSession(session_id="session-a", agent=types.SimpleNamespace())
+record = bridge.RunRecord(run_id="run-a", session_id="session-a")
+session.running = True
+session.current_run_id = record.run_id
+pool._sessions[session.session_id] = session
+pool._runs[record.run_id] = record
+
+results = {}
+approval_thread = threading.Thread(
+    target=lambda: results.setdefault("approval", pool._approval_callback("session-a")("danger", "confirm")),
+)
+clarify_thread = threading.Thread(
+    target=lambda: results.setdefault("clarify", pool._clarify_callback("session-a")("pick")),
+)
+gateway_notify = pool._gateway_approval_notify("session-a")
+gateway_notify({"command": "gateway-danger", "description": "confirm"})
+gateway_approval_id = next(iter(pool._gateway_approval_requests))
+approval_thread.start()
+clarify_thread.start()
+approval_thread.join(timeout=3)
+clarify_thread.join(timeout=3)
+assert not approval_thread.is_alive()
+assert not clarify_thread.is_alive()
+assert results == {
+    "approval": "deny",
+    "clarify": "[user did not respond within 1s]",
+}
+assert wait_for(lambda: approval._resolved_gateway == [("session-a", "deny")], timeout=3)
+assert pool.respond_approval(gateway_approval_id, "once")["resolved"] is False
+requested = [event for event in record.events if event["event"].endswith(".requested")]
+assert len(requested) == 3
+assert all(event.get("timeout_ms") == 1000 for event in requested)
+assert any(event.get("event") == "clarify.resolved" for event in record.events)
+assert pool._approval_requests == {}
+assert pool._clarify_requests == {}
+
+os.environ["HERMES_AGENT_BRIDGE_INTERACTION_TIMEOUT_SECONDS"] = "none"
+assert bridge._interaction_timeout_seconds() is None
+os.environ["HERMES_AGENT_BRIDGE_INTERACTION_TIMEOUT_SECONDS"] = "0"
+assert bridge._interaction_timeout_seconds() is None
+os.environ["HERMES_AGENT_BRIDGE_INTERACTION_TIMEOUT_SECONDS"] = "9"
+assert bridge._interaction_timeout_seconds() == 9
+os.environ["HERMES_AGENT_BRIDGE_INTERACTION_TIMEOUT_SECONDS"] = "invalid"
+try:
+    bridge._interaction_timeout_seconds()
+    raise AssertionError("invalid interaction timeout was accepted")
+except ValueError as exc:
+    assert "positive integer, 0, or none" in str(exc)
+`)
+  })
+
+  it('releases only matching pending interactions on destroy and all remaining waits on shutdown', () => {
+    runPython(String.raw`
+${harness}
+
+pool, _fake_db = make_pool()
+results = {}
+threads = []
+for session_id in ("session-a", "session-b"):
+    for kind, callback in (
+        ("approval", pool._approval_callback(session_id)),
+        ("clarify", pool._clarify_callback(session_id)),
+    ):
+        if kind == "approval":
+            target = lambda sid=session_id, cb=callback: results.setdefault(
+                (sid, "approval"), cb("danger", "confirm")
+            )
+        else:
+            target = lambda sid=session_id, cb=callback: results.setdefault(
+                (sid, "clarify"), cb("pick")
+            )
+        thread = threading.Thread(target=target)
+        thread.start()
+        threads.append(thread)
+
+assert wait_for(lambda: len(pool._approval_requests) == 2 and len(pool._clarify_requests) == 2)
+destroyed = pool.destroy("session-a")
+assert destroyed["destroyed"] is False
+assert wait_for(lambda: ("session-a", "approval") in results and ("session-a", "clarify") in results)
+assert results[("session-a", "approval")] == "deny"
+assert results[("session-a", "clarify")] == "[clarification cancelled]"
+assert len(pool._approval_requests) == 1
+assert len(pool._clarify_requests) == 1
+
+cleanup = pool.shutdown()
+assert cleanup["interrupted_sessions"] == 0
+for thread in threads:
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+assert results[("session-b", "approval")] == "deny"
+assert results[("session-b", "clarify")] == "[clarification cancelled]"
+assert pool._approval_requests == {}
+assert pool._clarify_requests == {}
+`)
+  })
+
   it('remembers execute_code approvals inside the bridge without patching upstream files', () => {
     runPython(String.raw`
 ${harness}
@@ -983,6 +1166,7 @@ assert sorted(approval._resolved_gateway) == [
 terminal_commands = {}
 gateway_commands = {}
 timeouts = {}
+gateway_timeouts = {}
 for sid, record in records.items():
     for event in record.events:
         if event.get("event") != "approval.requested":
@@ -993,6 +1177,7 @@ for sid, record in records.items():
             timeouts[sid] = event.get("timeout_ms")
         if command == f"gateway:{sid}":
             gateway_commands[sid] = command
+            gateway_timeouts[sid] = event.get("timeout_ms")
 
 assert terminal_commands == {
     "session-a": "cmd:session-a",
@@ -1003,8 +1188,12 @@ assert gateway_commands == {
     "session-b": "gateway:session-b",
 }
 assert timeouts == {
-    "session-a": 120000,
-    "session-b": 120000,
+    "session-a": None,
+    "session-b": None,
+}
+assert gateway_timeouts == {
+    "session-a": None,
+    "session-b": None,
 }
 
 same_session = bridge.AgentSession(session_id="same-session", agent=FakeAgent("same-session"))
@@ -1044,6 +1233,10 @@ broker._session_profile["session-a"] = "default"
 broker._session_worker_key["session-a"] = "default"
 broker._approval_profile["approval-a"] = "default"
 broker._approval_worker_key["approval-a"] = "default"
+broker._approval_session["approval-a"] = "session-a"
+broker._clarify_profile["clarify-a"] = "default"
+broker._clarify_worker_key["clarify-a"] = "default"
+broker._clarify_session["clarify-a"] = "session-a"
 broker._compression_profile["compression-a"] = "default"
 broker._compression_worker_key["compression-a"] = "default"
 
@@ -1059,6 +1252,10 @@ assert broker._session_profile == {}
 assert broker._session_worker_key == {}
 assert broker._approval_profile == {}
 assert broker._approval_worker_key == {}
+assert broker._approval_session == {}
+assert broker._clarify_profile == {}
+assert broker._clarify_worker_key == {}
+assert broker._clarify_session == {}
 assert broker._compression_profile == {}
 assert broker._compression_worker_key == {}
 
@@ -1473,6 +1670,41 @@ assert result["first"] == "session"
 `)
   })
 
+  it('removes broker interaction routes when requests resolve', () => {
+    runPython(String.raw`
+${harness}
+
+broker = bridge.BridgeBroker("ipc:///tmp/unused.sock")
+broker._record_response_routes("default", "worker-a", {
+    "session_id": "session-a",
+    "events": [
+        {"event": "approval.requested", "approval_id": "approval-a"},
+        {"event": "clarify.requested", "clarify_id": "clarify-a"},
+    ],
+})
+assert broker._approval_profile == {"approval-a": "default"}
+assert broker._approval_worker_key == {"approval-a": "worker-a"}
+assert broker._approval_session == {"approval-a": "session-a"}
+assert broker._clarify_profile == {"clarify-a": "default"}
+assert broker._clarify_worker_key == {"clarify-a": "worker-a"}
+assert broker._clarify_session == {"clarify-a": "session-a"}
+
+broker._record_response_routes("default", "worker-a", {
+    "session_id": "session-a",
+    "events": [
+        {"event": "approval.resolved", "approval_id": "approval-a"},
+        {"event": "clarify.resolved", "clarify_id": "clarify-a"},
+    ],
+})
+assert broker._approval_profile == {}
+assert broker._approval_worker_key == {}
+assert broker._approval_session == {}
+assert broker._clarify_profile == {}
+assert broker._clarify_worker_key == {}
+assert broker._clarify_session == {}
+`)
+  })
+
   it('cleans broker workers and wires worker parent watchdog state', () => {
     runPython(String.raw`
 ${harness}
@@ -1493,6 +1725,9 @@ broker._run_profile["run-a"] = "default"
 broker._running_run_profile["run-a"] = "default"
 broker._session_profile["session-a"] = "default"
 broker._approval_profile["approval-a"] = "default"
+broker._approval_session["approval-a"] = "session-a"
+broker._clarify_profile["clarify-a"] = "default"
+broker._clarify_session["clarify-a"] = "session-a"
 broker._compression_profile["compression-a"] = "default"
 
 broker.stop()
@@ -1503,6 +1738,9 @@ assert broker._run_profile == {}
 assert broker._running_run_profile == {}
 assert broker._session_profile == {}
 assert broker._approval_profile == {}
+assert broker._approval_session == {}
+assert broker._clarify_profile == {}
+assert broker._clarify_session == {}
 assert broker._compression_profile == {}
 
 created = {}

--- a/tests/server/agent-bridge-usage-hook.test.ts
+++ b/tests/server/agent-bridge-usage-hook.test.ts
@@ -28,8 +28,6 @@ import types
 from pathlib import Path
 
 bridge_runtime = types.ModuleType("bridge_runtime")
-bridge_runtime.APPROVAL_TIMEOUT_MS = 1000
-bridge_runtime.APPROVAL_TIMEOUT_SECONDS = 1
 bridge_runtime._approval_pattern_keys = lambda *_args, **_kwargs: []
 bridge_runtime._base_hermes_home = lambda: Path(tempfile.gettempdir())
 bridge_runtime._bridge_platform = lambda: "agent-bridge"
@@ -38,6 +36,7 @@ bridge_runtime._discover_bridge_mcp_tools = lambda *_args, **_kwargs: []
 bridge_runtime._ensure_agent_imports = lambda: None
 bridge_runtime._hermes_home = lambda *_args, **_kwargs: Path(tempfile.gettempdir())
 bridge_runtime._install_execute_code_approval_memory_patch = lambda *_args, **_kwargs: None
+bridge_runtime._interaction_timeout_seconds = lambda: None
 bridge_runtime._jsonable = lambda value: value
 bridge_runtime._load_cfg = lambda *_args, **_kwargs: {}
 bridge_runtime._load_enabled_toolsets = lambda *_args, **_kwargs: []

--- a/tests/server/coding-agent-resume-config.test.ts
+++ b/tests/server/coding-agent-resume-config.test.ts
@@ -370,7 +370,7 @@ describe('coding agent resumed session config', () => {
         model: 'deepseek-v4-flash',
       }],
     })
-    safeReadFileMock.mockResolvedValue('SENSENOVA_API_KEY=sk-from-env\n')
+    safeReadFileMock.mockResolvedValue("\n# profile credential\nexport SENSENOVA_API_KEY='sk-from-env' # ignored comment\n")
 
     const { startCodingAgentRun } = await import('../../packages/server/src/services/coding-agents')
     await expect(startCodingAgentRun('claude-code', { sessionId: 'session-1' })).resolves.toEqual(

--- a/tests/server/dotenv.test.ts
+++ b/tests/server/dotenv.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { parseDotenvValue } from '../../packages/server/src/services/dotenv'
+
+describe('parseDotenvValue', () => {
+  it('handles blank lines, comments, export, and quoted values', () => {
+    const content = [
+      '',
+      '# ignored',
+      'PLAIN=value # trailing comment',
+      'export SINGLE=\'single # value\' # ignored comment',
+      '  export DOUBLE="double value"  ',
+      'FRAGMENT=value#fragment',
+      '',
+    ].join('\n')
+
+    expect(parseDotenvValue(content, 'PLAIN')).toBe('value')
+    expect(parseDotenvValue(content, 'SINGLE')).toBe('single # value')
+    expect(parseDotenvValue(content, 'DOUBLE')).toBe('double value')
+    expect(parseDotenvValue(content, 'FRAGMENT')).toBe('value#fragment')
+    expect(parseDotenvValue(content, 'MISSING')).toBe('')
+  })
+
+  it('rejects invalid key names', () => {
+    expect(parseDotenvValue('export TOKEN=value', 'export TOKEN')).toBe('')
+  })
+})

--- a/tests/server/media-controller.test.ts
+++ b/tests/server/media-controller.test.ts
@@ -81,6 +81,119 @@ describe('media controller', () => {
     expect(defaultImageOutputPath('img_123', 0, 'jpeg')).toBe(join('/tmp/hermes-web-ui-test-home', 'media', 'img_123.jpg'))
   })
 
+  it('resolves a key_env credential from the requested profile .env', async () => {
+    const profileDir = await mkdtemp(join(tmpdir(), 'hermes-media-xiaoyan-profile-'))
+    const outputDir = await mkdtemp(join(tmpdir(), 'hermes-media-axon-output-'))
+    const envName = 'AXONHUB_XIAOYAN_API_KEY'
+    const previousProcessValue = process.env[envName]
+    delete process.env[envName]
+    await writeFile(join(profileDir, '.env'), [
+      '',
+      '# profile-scoped custom provider credential',
+      `export ${envName}='axon-profile-secret' # ignored comment`,
+      '',
+    ].join('\n'))
+    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+      getActiveProfileName: () => 'default',
+      getProfileDir: (profile: string) => profile === 'xiaoyan' ? profileDir : '/tmp/hermes-default-profile',
+      listProfileNamesFromDisk: () => ['default', 'xiaoyan'],
+    }))
+    const readConfigYamlForProfile = vi.fn(async () => ({
+      custom_providers: [{
+        name: 'axon',
+        base_url: 'https://axon.example/v1',
+        key_env: envName,
+        model: 'axon-image-1',
+      }],
+    }))
+    vi.doMock('../../packages/server/src/services/config-helpers', () => ({ readConfigYamlForProfile }))
+    const fetchMock = vi.fn(async () => imageResponse())
+    globalThis.fetch = fetchMock as any
+
+    try {
+      const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx = mediaContext({
+        profile: 'xiaoyan',
+        provider: 'axon',
+        mode: 'text',
+        prompt: 'use the profile provider',
+        output_path: join(outputDir, 'result.png'),
+      })
+
+      await apiKeyImageGenerate(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body).toMatchObject({
+        ok: true,
+        provider: 'axon',
+        actual_provider: 'axon',
+        profile: 'xiaoyan',
+      })
+      expect(JSON.stringify(ctx.body)).not.toContain('axon-profile-secret')
+      expect(readConfigYamlForProfile).toHaveBeenCalledWith('xiaoyan')
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://axon.example/v1/images/generations',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer axon-profile-secret' }),
+        }),
+      )
+    } finally {
+      if (previousProcessValue === undefined) delete process.env[envName]
+      else process.env[envName] = previousProcessValue
+      await rm(profileDir, { recursive: true, force: true })
+      await rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns the public missing-provider error when key_env is absent from process and profile .env', async () => {
+    const profileDir = await mkdtemp(join(tmpdir(), 'hermes-media-xiaoyan-missing-key-'))
+    const envName = 'AXONHUB_XIAOYAN_API_KEY'
+    const previousProcessValue = process.env[envName]
+    delete process.env[envName]
+    await writeFile(join(profileDir, '.env'), '# no axon credential\nOTHER_KEY=other-value\n')
+    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+      getActiveProfileName: () => 'default',
+      getProfileDir: (profile: string) => profile === 'xiaoyan' ? profileDir : '/tmp/hermes-default-profile',
+      listProfileNamesFromDisk: () => ['default', 'xiaoyan'],
+    }))
+    vi.doMock('../../packages/server/src/services/config-helpers', () => ({
+      readConfigYamlForProfile: vi.fn(async () => ({
+        custom_providers: [{
+          name: 'axon',
+          base_url: 'https://axon.example/v1',
+          key_env: envName,
+          model: 'axon-image-1',
+        }],
+      })),
+    }))
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as any
+
+    try {
+      const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx = mediaContext({
+        profile: 'xiaoyan',
+        provider: 'axon',
+        mode: 'text',
+        prompt: 'missing credential',
+      })
+
+      await apiKeyImageGenerate(ctx)
+
+      expect(ctx.status).toBe(401)
+      expect(ctx.body).toMatchObject({
+        error: 'The requested image provider is not configured',
+        code: 'missing_apikey_image_provider',
+      })
+      expect(JSON.stringify(ctx.body)).not.toContain(envName)
+      expect(fetchMock).not.toHaveBeenCalled()
+    } finally {
+      if (previousProcessValue === undefined) delete process.env[envName]
+      else process.env[envName] = previousProcessValue
+      await rm(profileDir, { recursive: true, force: true })
+    }
+  })
+
   it('passes native 4K generation options and returns actual provider, model, dimensions, format, and request id', async () => {
     mockImageProvider()
     const outputDir = await mkdtemp(join(tmpdir(), 'hermes-media-4k-'))

--- a/tests/server/media-controller.test.ts
+++ b/tests/server/media-controller.test.ts
@@ -1,10 +1,61 @@
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'fs/promises'
 import { join } from 'path'
+import { tmpdir } from 'os'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const originalWebUiHome = process.env.HERMES_WEB_UI_HOME
 const originalWebuiStateDir = process.env.HERMES_WEBUI_STATE_DIR
+const originalWorkspaceBase = process.env.WORKSPACE_BASE
+const originalFetch = globalThis.fetch
+
+function pngBase64(width = 1, height = 1): string {
+  const buffer = Buffer.alloc(24)
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buffer)
+  buffer.write('IHDR', 12, 'ascii')
+  buffer.writeUInt32BE(width, 16)
+  buffer.writeUInt32BE(height, 20)
+  return buffer.toString('base64')
+}
+
+function mockImageProvider() {
+  vi.stubEnv('AGNES_API_KEY', 'agnes-secret')
+  vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+    getActiveProfileName: () => 'default',
+    getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
+    listProfileNamesFromDisk: () => ['default'],
+  }))
+  vi.doMock('../../packages/server/src/services/config-helpers', () => ({
+    readConfigYamlForProfile: vi.fn(async () => ({
+      custom_providers: [{
+        name: 'agnes',
+        base_url: 'https://agnes.example/v1',
+        api_key_env: 'AGNES_API_KEY',
+        model: 'agnes-image-2.1-flash',
+      }],
+    })),
+  }))
+}
+
+function imageResponse(base64 = pngBase64()): Response {
+  return new Response(
+    `data: {"data":[{"b64_json":"${base64}"}]}\n\n`,
+    { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+  )
+}
+
+function mediaContext(body: Record<string, unknown>, requestId = ''): any {
+  return {
+    state: { serverTokenAuth: true },
+    query: {},
+    request: { body },
+    get: vi.fn((name: string) => name.toLowerCase() === 'x-request-id' ? requestId : ''),
+    status: 200,
+    body: undefined,
+  }
+}
 
 afterEach(() => {
+  globalThis.fetch = originalFetch
   vi.doUnmock('../../packages/server/src/services/hermes/hermes-profile')
   vi.doUnmock('../../packages/server/src/services/config-helpers')
   vi.clearAllMocks()
@@ -14,6 +65,8 @@ afterEach(() => {
   else process.env.HERMES_WEB_UI_HOME = originalWebUiHome
   if (originalWebuiStateDir === undefined) delete process.env.HERMES_WEBUI_STATE_DIR
   else process.env.HERMES_WEBUI_STATE_DIR = originalWebuiStateDir
+  if (originalWorkspaceBase === undefined) delete process.env.WORKSPACE_BASE
+  else process.env.WORKSPACE_BASE = originalWorkspaceBase
 })
 
 describe('media controller', () => {
@@ -25,48 +78,26 @@ describe('media controller', () => {
     expect(defaultMediaOutputPath('bad/request:id')).toBe(join('/tmp/hermes-web-ui-test-home', 'media', 'bad_request_id.mp4'))
     expect(defaultImageOutputPath('img_123')).toBe(join('/tmp/hermes-web-ui-test-home', 'media', 'img_123.png'))
     expect(defaultImageOutputPath('bad/request:id', 1)).toBe(join('/tmp/hermes-web-ui-test-home', 'media', 'bad_request_id-2.png'))
+    expect(defaultImageOutputPath('img_123', 0, 'jpeg')).toBe(join('/tmp/hermes-web-ui-test-home', 'media', 'img_123.jpg'))
   })
 
-  it('generates images through the requested configured custom provider', async () => {
-    vi.stubEnv('AGNES_API_KEY', 'agnes-secret')
-    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
-      getActiveProfileName: () => 'default',
-      getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
-      listProfileNamesFromDisk: () => ['default'],
-    }))
-    vi.doMock('../../packages/server/src/services/config-helpers', () => ({
-      readConfigYamlForProfile: vi.fn(async () => ({
-        custom_providers: [{
-          name: 'agnes',
-          base_url: 'https://agnes.example/v1',
-          api_key_env: 'AGNES_API_KEY',
-          model: 'agnes-image-2.1-flash',
-        }],
-      })),
-    }))
-    const fetchMock = vi.fn(async () => new Response(
-      'data: {"data":[{"b64_json":"aW1hZ2UtYnl0ZXM="}]}\n\n',
-      { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
-    ))
-    const originalFetch = globalThis.fetch
+  it('passes native 4K generation options and returns actual provider, model, dimensions, format, and request id', async () => {
+    mockImageProvider()
+    const outputDir = await mkdtemp(join(tmpdir(), 'hermes-media-4k-'))
+    const fetchMock = vi.fn(async () => imageResponse(pngBase64(3840, 2160)))
     globalThis.fetch = fetchMock as any
     try {
       const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
-      const ctx: any = {
-        state: { serverTokenAuth: true },
-        query: {},
-        request: {
-          body: {
-            provider: 'agnes',
-            mode: 'text',
-            prompt: 'make an icon',
-            output_path: '/tmp/hermes-web-ui-agnes-image.png',
-          },
-        },
-        get: vi.fn(() => ''),
-        status: 200,
-        body: undefined,
-      }
+      const ctx = mediaContext({
+        provider: 'agnes',
+        mode: 'text',
+        prompt: 'make a 4K icon',
+        model: 'codex-gpt-image-2',
+        quality: 'high',
+        resolution: '4k',
+        aspect: '16:9',
+        output_path: join(outputDir, 'result.png'),
+      }, 'req-4k-123')
 
       await apiKeyImageGenerate(ctx)
 
@@ -77,7 +108,22 @@ describe('media controller', () => {
         provider: 'agnes',
         base_url: 'https://agnes.example/v1',
         profile: 'default',
+        request_id: 'req-4k-123',
+        model: 'codex-gpt-image-2',
+        actual_model: 'codex-gpt-image-2',
+        actual_provider: 'agnes',
+        quality: 'high',
+        resolution: '4k',
+        aspect: '16:9',
+        dimensions: { width: 3840, height: 2160 },
+        format: 'png',
       })
+      expect(ctx.body.output_paths).toEqual([join(outputDir, 'result.png')])
+      expect(ctx.body.images).toEqual([{
+        output_path: join(outputDir, 'result.png'),
+        dimensions: { width: 3840, height: 2160 },
+        format: 'png',
+      }])
       expect(fetchMock).toHaveBeenCalledWith(
         'https://agnes.example/v1/images/generations',
         expect.objectContaining({
@@ -85,16 +131,259 @@ describe('media controller', () => {
           headers: expect.objectContaining({
             Authorization: 'Bearer agnes-secret',
             'Content-Type': 'application/json',
+            'X-Request-Id': 'req-4k-123',
           }),
         }),
       )
       const requestInit = fetchMock.mock.calls[0][1] as RequestInit
       expect(JSON.parse(String(requestInit.body))).toMatchObject({
-        model: 'gpt-image-2',
-        prompt: 'make an icon',
+        model: 'codex-gpt-image-2',
+        prompt: 'make a 4K icon',
+        quality: 'high',
+        resolution: '4k',
+        aspect_ratio: '16:9',
       })
+      expect(String(requestInit.body)).not.toContain('resize')
     } finally {
-      globalThis.fetch = originalFetch
+      await rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps image_path, image_url, and image_base64 as compatible single-reference inputs', async () => {
+    mockImageProvider()
+    const outputDir = await mkdtemp(join(tmpdir(), 'hermes-media-legacy-'))
+    const sourcePath = join(outputDir, 'reference.png')
+    await writeFile(sourcePath, Buffer.from(pngBase64(), 'base64'))
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      if (String(input) === 'https://93.184.216.34/reference.png') {
+        return new Response(Buffer.from(pngBase64(), 'base64'), {
+          status: 200,
+          headers: { 'Content-Type': 'image/png' },
+        })
+      }
+      return imageResponse()
+    })
+    globalThis.fetch = fetchMock as any
+    try {
+      const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+      const sources = [
+        { image_path: sourcePath },
+        { image_url: 'https://93.184.216.34/reference.png' },
+        { image_base64: pngBase64(), mime_type: 'image/png' },
+      ]
+      for (const [index, source] of sources.entries()) {
+        const ctx = mediaContext({
+          provider: 'agnes',
+          mode: 'image',
+          prompt: 'use the reference',
+          ...source,
+          output_path: join(outputDir, `result-${index}.png`),
+        })
+        await apiKeyImageGenerate(ctx)
+        expect(ctx.status).toBe(200)
+      }
+
+      const upstreamCalls = fetchMock.mock.calls.filter(call => String(call[0]).endsWith('/responses'))
+      expect(upstreamCalls).toHaveLength(3)
+      for (const call of upstreamCalls) {
+        const payload = JSON.parse(String((call[1] as RequestInit).body))
+        expect(payload.input[0].content[1]).toMatchObject({
+          type: 'input_image',
+          reference_role: 'reference',
+          priority: 0,
+        })
+        expect(payload.input[0].content[1].image_url).toMatch(/^data:image\/png;base64,/)
+      }
+    } finally {
+      await rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
+  it('passes multiple reference roles, priorities, and weights to the provider', async () => {
+    mockImageProvider()
+    const outputDir = await mkdtemp(join(tmpdir(), 'hermes-media-references-'))
+    const fetchMock = vi.fn(async () => imageResponse())
+    globalThis.fetch = fetchMock as any
+    try {
+      const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx = mediaContext({
+        provider: 'agnes',
+        mode: 'image',
+        prompt: 'combine both references',
+        model: 'codex-gpt-image-2',
+        response_model: 'gpt-5.4-mini',
+        references: [
+          { image_base64: pngBase64(), mime_type: 'image/png', role: 'composition', priority: 1 },
+          { image_base64: pngBase64(), mime_type: 'image/png', role: 'style', weight: 0.75 },
+        ],
+        output_path: join(outputDir, 'result.png'),
+      })
+
+      await apiKeyImageGenerate(ctx)
+
+      expect(ctx.status).toBe(200)
+      const payload = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body))
+      expect(payload.model).toBe('gpt-5.4-mini')
+      expect(payload.input[0].content.slice(1)).toEqual([
+        expect.objectContaining({ type: 'input_image', reference_role: 'composition', priority: 1 }),
+        expect.objectContaining({ type: 'input_image', reference_role: 'style', weight: 0.75 }),
+      ])
+      expect(payload.tools[0]).toMatchObject({
+        model: 'codex-gpt-image-2',
+        quality: 'high',
+        resolution: '4k',
+        aspect_ratio: 'auto',
+      })
+
+      const editCtx = mediaContext({
+        provider: 'agnes',
+        mode: 'edit',
+        prompt: 'edit with both responsibilities',
+        references: [
+          { image_base64: pngBase64(), mime_type: 'image/png', role: 'subject', priority: 2 },
+          { image_base64: pngBase64(), mime_type: 'image/png', role: 'palette', weight: 0.5 },
+        ],
+        output_path: join(outputDir, 'edited.png'),
+      })
+      await apiKeyImageGenerate(editCtx)
+      expect(editCtx.status).toBe(200)
+      const editForm = fetchMock.mock.calls[1][1]?.body as FormData
+      expect(editForm.getAll('image[]')).toHaveLength(2)
+      expect(editForm.get('reference_role[0]')).toBe('subject')
+      expect(editForm.get('reference_priority[0]')).toBe('2')
+      expect(editForm.get('reference_role[1]')).toBe('palette')
+      expect(editForm.get('reference_weight[1]')).toBe('0.5')
+      expect(editForm.get('resolution')).toBe('4k')
+    } finally {
+      await rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects invalid reference count, metadata, MIME, and unsafe local paths with actionable codes', async () => {
+    mockImageProvider()
+    globalThis.fetch = vi.fn() as any
+    const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+    const cases = [
+      {
+        references: Array.from({ length: 9 }, () => ({
+          image_base64: pngBase64(),
+          mime_type: 'image/png',
+          role: 'style',
+          priority: 1,
+        })),
+        code: 'too_many_references',
+      },
+      {
+        references: [{ image_base64: pngBase64(), mime_type: 'image/png', role: 'style' }],
+        code: 'reference_metadata_required',
+      },
+      {
+        references: [{ image_base64: pngBase64(), mime_type: 'image/jpeg', role: 'style', priority: 1 }],
+        code: 'reference_mime_mismatch',
+      },
+      {
+        image_path: '/etc/passwd',
+        code: 'unsafe_reference_path',
+      },
+    ]
+
+    for (const testCase of cases) {
+      const ctx = mediaContext({
+        provider: 'agnes',
+        mode: 'image',
+        prompt: 'test validation',
+        ...testCase,
+      })
+      delete ctx.request.body.code
+      await apiKeyImageGenerate(ctx)
+      expect(ctx.status).toBeGreaterThanOrEqual(400)
+      expect(ctx.body.code).toBe(testCase.code)
+      expect(JSON.stringify(ctx.body)).not.toContain('/etc/passwd')
+    }
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('redacts upstream credentials, authorization, private paths, and image bodies from errors', async () => {
+    mockImageProvider()
+    const secretImage = pngBase64()
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({
+      error: {
+        message: `Authorization: Bearer agnes-secret /private/provider/path ${secretImage}`,
+      },
+    }), { status: 400 })) as any
+    const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+    const ctx = mediaContext({
+      provider: 'agnes',
+      mode: 'text',
+      prompt: 'fail safely',
+    })
+
+    await apiKeyImageGenerate(ctx)
+
+    expect(ctx.status).toBe(502)
+    expect(ctx.body).toMatchObject({
+      error: 'Image provider rejected the generation request',
+      code: 'upstream_rejected_request',
+    })
+    expect(ctx.body.request_id).toMatch(/^[A-Za-z0-9._-]+$/)
+    const serialized = JSON.stringify(ctx.body)
+    expect(serialized).not.toContain('agnes-secret')
+    expect(serialized).not.toContain('Authorization')
+    expect(serialized).not.toContain('/private/provider/path')
+    expect(serialized).not.toContain(secretImage)
+  })
+
+  it('rejects an existing output symlink instead of writing through it', async () => {
+    if (process.platform === 'win32') return
+    mockImageProvider()
+    const outputDir = await mkdtemp(join(tmpdir(), 'hermes-media-output-link-'))
+    const outsideDir = await mkdtemp(join(tmpdir(), 'hermes-media-output-target-'))
+    const outsidePath = join(outsideDir, 'outside.png')
+    const linkPath = join(outputDir, 'linked.png')
+    await writeFile(outsidePath, Buffer.from('unchanged'))
+    await symlink(outsidePath, linkPath)
+    globalThis.fetch = vi.fn(async () => imageResponse()) as any
+    try {
+      const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx = mediaContext({
+        provider: 'agnes',
+        mode: 'text',
+        prompt: 'do not follow output links',
+        output_path: linkPath,
+      })
+
+      await apiKeyImageGenerate(ctx)
+
+      expect(ctx.status).toBe(403)
+      expect(ctx.body.code).toBe('unsafe_output_path')
+      expect(await readFile(outsidePath, 'utf8')).toBe('unchanged')
+    } finally {
+      await rm(outputDir, { recursive: true, force: true })
+      await rm(outsideDir, { recursive: true, force: true })
+    }
+  })
+
+  it('reports upstream image dimensions without resizing a non-4K result', async () => {
+    mockImageProvider()
+    const outputDir = await mkdtemp(join(tmpdir(), 'hermes-media-native-'))
+    globalThis.fetch = vi.fn(async () => imageResponse(pngBase64(640, 480))) as any
+    try {
+      const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx = mediaContext({
+        provider: 'agnes',
+        mode: 'text',
+        prompt: 'request 4K',
+        resolution: '4k',
+        output_path: join(outputDir, 'native.png'),
+      })
+
+      await apiKeyImageGenerate(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body.resolution).toBe('4k')
+      expect(ctx.body.dimensions).toEqual({ width: 640, height: 480 })
+    } finally {
+      await rm(outputDir, { recursive: true, force: true })
     }
   })
 })

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -34,6 +34,8 @@ const getCompressionSnapshotMock = vi.fn()
 const listUserProfilesMock = vi.fn()
 const readConfigYamlForProfileMock = vi.fn()
 const bridgeSwitchSessionModelMock = vi.fn()
+const bridgeStatusIfLoadedMock = vi.fn()
+const bridgeDestroyMock = vi.fn()
 const bridgeGetRuntimeStateMock = vi.fn()
 const codingAgentRunManagerMock = vi.hoisted(() => ({
   stop: vi.fn(),
@@ -118,6 +120,8 @@ vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
 vi.mock('../../packages/server/src/services/hermes/agent-bridge', () => ({
   AgentBridgeClient: vi.fn().mockImplementation(() => ({
     switchSessionModel: bridgeSwitchSessionModelMock,
+    statusIfLoaded: bridgeStatusIfLoadedMock,
+    destroy: bridgeDestroyMock,
   })),
   getAgentBridgeManager: vi.fn(() => ({
     getRuntimeState: bridgeGetRuntimeStateMock,
@@ -199,6 +203,9 @@ describe('session conversations controller', () => {
     readConfigYamlForProfileMock.mockReset()
     readConfigYamlForProfileMock.mockResolvedValue({ model: { default: 'gpt-default', provider: 'openai' } })
     bridgeSwitchSessionModelMock.mockReset()
+    bridgeStatusIfLoadedMock.mockReset()
+    bridgeStatusIfLoadedMock.mockResolvedValue({ ok: true, loaded: false, exists: false })
+    bridgeDestroyMock.mockReset()
     bridgeGetRuntimeStateMock.mockReset()
     bridgeGetRuntimeStateMock.mockReturnValue({ ready: false, running: false, endpoint: 'ipc:///tmp/hermes-agent-bridge.sock' })
     codingAgentRunManagerMock.stop.mockReset()
@@ -1700,6 +1707,25 @@ describe('session conversations controller', () => {
       deleted: false,
       hermes: { attempted: true, deleted: true, profile: 'travel', error: undefined },
     })
+  })
+
+  it('destroys a loaded bridge session before deleting its persisted session', async () => {
+    bridgeGetRuntimeStateMock.mockReturnValue({ ready: true, running: true, endpoint: 'ipc:///tmp/hermes-agent-bridge.sock' })
+    bridgeStatusIfLoadedMock.mockResolvedValue({ ok: true, loaded: true, exists: true })
+    bridgeDestroyMock.mockResolvedValue({ ok: true, destroyed: true })
+    getSessionMock.mockReturnValue({ id: 'session-1', profile: 'travel', source: 'cli' })
+    getExactSessionDetailFromDbWithProfileMock.mockResolvedValue({ id: 'session-1', messages: [] })
+    deleteHermesSessionForProfileMock.mockResolvedValue(true)
+    localDeleteSessionMock.mockReturnValue(true)
+
+    const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+    const ctx: any = { params: { id: 'session-1' }, body: null }
+    await mod.remove(ctx)
+
+    expect(bridgeStatusIfLoadedMock).toHaveBeenCalledWith('session-1', 'travel', { timeoutMs: 5000 })
+    expect(bridgeDestroyMock).toHaveBeenCalledWith('session-1', 'travel')
+    expect(bridgeDestroyMock.mock.invocationCallOrder[0]).toBeLessThan(deleteHermesSessionForProfileMock.mock.invocationCallOrder[0])
+    expect(ctx.body).toMatchObject({ ok: true, deleted: true })
   })
 
   it('deletes a local coding-agent session without invoking Hermes CLI deletion', async () => {


### PR DESCRIPTION
## Summary
- Persist Hermes Studio bridge interactions so prompt/approval state survives the relevant lifecycle paths.
- Includes bridge/runtime/frontend handling and regression tests from the local v0.6.31 line.

## Verification
- Targeted tests: 97/97 passed in the release candidate worktree.
- npm run build passed.
- Local runtime hotfix is deployed: hermes-studio.service active, HTTP 200, runtime bridge_pool.py SHA matches the candidate.

## Notes
- Direct push to EKKOLearnAI/hermes-studio is denied for the current GitHub identity (viewer permission READ), so this PR is opened from the existing nonull-404 fork.
- Branch is based on the local v0.6.31 source line and is behind upstream main; maintainer may choose to merge/cherry-pick/rebase as appropriate.