### PR TITLE
Reduce workspace tree indentation

### DIFF
--- a/packages/client/src/components/hermes/files/FileTree.vue
+++ b/packages/client/src/components/hermes/files/FileTree.vue
@@ -84,6 +84,7 @@ watch([effectiveProfile, () => filesStore.currentWorkspaceSessionId, () => files
       :selected-keys="selectedKeys"
       :on-load="handleLoad"
       :render-label="renderLabel"
+      :indent="6"
       expand-on-click
       block-line
       @update:selected-keys="handleSelect"

--- a/tests/client/workspace-long-names.test.ts
+++ b/tests/client/workspace-long-names.test.ts
@@ -46,15 +46,6 @@ const NEmptyStub = defineComponent({
   },
 })
 
-const NTreeStub = defineComponent({
-  props: ['data', 'renderLabel'],
-  setup(props) {
-    return () => h('div', (props.data || []).map((option: any) =>
-      h('div', { class: 'tree-node' }, [props.renderLabel({ option })]),
-    ))
-  },
-})
-
 function mountFileList() {
   return mount(FileList, {
     global: {
@@ -103,18 +94,13 @@ describe('workspace long names', () => {
       }],
     } as any)
 
-    const wrapper = mount(FileTree, {
-      global: {
-        stubs: {
-          NTree: NTreeStub,
-        },
-      },
-    })
+    const wrapper = mount(FileTree)
     await vi.waitFor(() => {
       expect(wrapper.find('.tree-node-label').exists()).toBe(true)
     })
 
     expect(wrapper.find('.tree-node-label').text()).toBe(longName)
     expect(wrapper.find('.tree-node-label').attributes('title')).toBe(longName)
+    expect(wrapper.find('.n-tree-node-switcher').attributes('style')).toContain('width: 6px')
   })
 })


### PR DESCRIPTION
## What changed

- reduce the shared workspace file tree indentation to 6px
- exercise the real tree component in the long-name regression test
- verify the rendered tree switcher uses the compact indentation

## Why

The tree component's default indentation consumed too much horizontal space at each folder level, so deeply nested workspace paths became difficult to see. Setting the indentation on the shared `FileTree` keeps more of nested folder names visible anywhere that tree is rendered.

## Validation

- `npm run test -- tests/client/workspace-long-names.test.ts`
- `npm run harness:check`
- `npm run build`
