### PR TITLE
[codex] fix desktop runtime compatibility for Hermes 0.20

### DIFF
--- a/.github/workflows/desktop-runtime.yml
+++ b/.github/workflows/desktop-runtime.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing release tag to attach runtime assets to"
+        description: "Runtime release tag to create or attach assets to (e.g. hermes-0.20.0-runtime)"
         required: true
       hermes_version:
         description: "Hermes Agent version to package (defaults to repository runtime config)"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,6 +90,13 @@ Hermes runtime assets are built separately by
 pins an upstream Hermes version, Git ref, and full commit; version overrides
 must supply the ref and commit together.
 
+The portable Node.js included in runtime assets is pinned independently from
+the GitHub Actions runner. Manual runtime dispatches take a target release tag;
+when the release does not exist, the upload step creates it with the workflow's
+`GITHUB_TOKEN`. Do not pre-publish runtime-only releases with a user token,
+because that emits `release.published` and starts the normal Web UI and Docker
+release workflows.
+
 The published runtime keeps this updateable layout:
 
 ```text

--- a/packages/desktop/scripts/fetch-node.mjs
+++ b/packages/desktop/scripts/fetch-node.mjs
@@ -6,13 +6,14 @@ import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { arch as osArch, platform as osPlatform, tmpdir } from 'node:os'
 import { spawnSync } from 'node:child_process'
+import { desktopNodeVersion } from './node-runtime-config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '..')
 
 const TARGET_OS = process.env.TARGET_OS || osPlatform()
 const TARGET_ARCH = process.env.TARGET_ARCH || osArch()
-const NODE_VERSION = (process.env.HERMES_DESKTOP_NODE_VERSION || process.env.NODE_VERSION || process.versions.node).replace(/^v/, '')
+const NODE_VERSION = desktopNodeVersion()
 
 const OS_LABEL = TARGET_OS === 'win32' ? 'win' : TARGET_OS === 'darwin' ? 'mac' : TARGET_OS
 const OUT_DIR = resolve(ROOT, 'resources', 'node', `${OS_LABEL}-${TARGET_ARCH}`)

--- a/packages/desktop/scripts/node-runtime-config.mjs
+++ b/packages/desktop/scripts/node-runtime-config.mjs
@@ -1,0 +1,13 @@
+export const DEFAULT_DESKTOP_NODE_VERSION = '22.22.0'
+
+export function desktopNodeVersion(env = process.env) {
+  const version = (
+    env.HERMES_DESKTOP_NODE_VERSION
+    || DEFAULT_DESKTOP_NODE_VERSION
+  ).trim().replace(/^v/, '')
+
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error('HERMES_DESKTOP_NODE_VERSION must be an exact Node.js version')
+  }
+  return version
+}

--- a/scripts/harness-check.mjs
+++ b/scripts/harness-check.mjs
@@ -253,6 +253,8 @@ const electronBuilderConfig = await readText('packages/desktop/electron-builder.
 const desktopMacEntitlements = await readText('packages/desktop/build/entitlements.mac.plist')
 const desktopMacInheritedEntitlements = await readText('packages/desktop/build/entitlements.mac.inherit.plist')
 const desktopPackageJson = await readText('packages/desktop/package.json')
+const desktopNodeRuntimeConfig = await readText('packages/desktop/scripts/node-runtime-config.mjs')
+const desktopFetchNode = await readText('packages/desktop/scripts/fetch-node.mjs')
 const desktopFetchPython = await readText('packages/desktop/scripts/fetch-python.mjs')
 const desktopFetchHermes = await readText('packages/desktop/scripts/fetch-hermes.mjs')
 const desktopInstallHermes = await readText('packages/desktop/scripts/install-hermes.mjs')
@@ -390,6 +392,21 @@ for (const phrase of [
 ]) {
   if (!desktopPackageJson.includes(phrase)) {
     fail(`packages/desktop/package.json must support runtime package publishing: ${phrase}`)
+  }
+}
+
+if (!desktopNodeRuntimeConfig.includes("DEFAULT_DESKTOP_NODE_VERSION = '22.22.0'")) {
+  fail('desktop runtime Node.js must stay pinned to the Hermes-compatible 22.22.0 release')
+}
+if (!desktopNodeRuntimeConfig.includes('HERMES_DESKTOP_NODE_VERSION')) {
+  fail('desktop runtime Node.js pin must keep an explicit environment override')
+}
+if (!desktopFetchNode.includes('desktopNodeVersion()')) {
+  fail('fetch-node.mjs must resolve the pinned desktop runtime Node.js version')
+}
+for (const inheritedVersion of ['process.env.NODE_VERSION', 'process.versions.node']) {
+  if (desktopFetchNode.includes(inheritedVersion)) {
+    fail(`fetch-node.mjs must not inherit the build runner Node.js version: ${inheritedVersion}`)
   }
 }
 

--- a/tests/desktop/node-runtime-config.test.ts
+++ b/tests/desktop/node-runtime-config.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_DESKTOP_NODE_VERSION,
+  desktopNodeVersion,
+} from '../../packages/desktop/scripts/node-runtime-config.mjs'
+
+describe('desktop runtime Node.js configuration', () => {
+  it('uses a pinned runtime version instead of inheriting the build runner version', () => {
+    expect(desktopNodeVersion({
+      NODE_VERSION: '24.18.0',
+    })).toBe(DEFAULT_DESKTOP_NODE_VERSION)
+    expect(DEFAULT_DESKTOP_NODE_VERSION).toBe('22.22.0')
+  })
+
+  it('accepts an explicit exact version override', () => {
+    expect(desktopNodeVersion({
+      HERMES_DESKTOP_NODE_VERSION: 'v22.22.1',
+    })).toBe('22.22.1')
+  })
+
+  it('rejects non-exact version selectors', () => {
+    expect(() => desktopNodeVersion({
+      HERMES_DESKTOP_NODE_VERSION: '22',
+    })).toThrow(/exact Node\.js version/)
+  })
+})


### PR DESCRIPTION
## Summary
- pin the portable desktop runtime to Node.js 22.22.0/npm 10.9.4 instead of inheriting the GitHub runner Node/npm version
- recognize the Windows `hermes.exe` launchers regenerated by `hermes-studio cli update`
- restore relocatable `hermes.cmd`, `hermes-agent.cmd`, and `hermes-acp.cmd` wrappers automatically during Windows desktop startup
- keep existing Runtime layouts and macOS/Linux behavior unchanged
- clarify that a missing runtime Release is created by the upload step with `GITHUB_TOKEN`; Web UI and Docker release workflows are unchanged

Hermes Agent 0.20.0 rejects the GitHub runner npm 11.16.0, which caused the first runtime matrix run to fail. Separately, a Windows in-place CLI update replaces Studio-owned `.cmd` wrappers with uv-generated `.exe` launchers. The CLI still works because the Windows shim invokes Python directly, but the desktop previously classified that Runtime as incomplete.

## Validation
- `npm run test -- tests/desktop/runtime-paths.test.ts tests/desktop/runtime-manager.test.ts tests/desktop/runtime-relocation.test.ts tests/desktop/desktop-runtime-detection.test.ts tests/desktop/node-runtime-config.test.ts tests/desktop/runtime-config.test.ts` (38 tests)
- `npm run harness:check`
- `npm --prefix packages/desktop run build`
- `git diff --check`
- runtime packaging run: https://github.com/EKKOLearnAI/hermes-studio/actions/runs/30866187031 (all 5 targets passed)
- runtime release: https://github.com/EKKOLearnAI/hermes-studio/releases/tag/hermes-0.20.0-runtime
- verified the workflow-created runtime release did not trigger Web UI or Docker release workflows
