### PR TITLE
[codex] hide Agent descriptions from group run headers

### DIFF
--- a/docs/chat-chain-changes/2026-08-04-hide-group-run-agent-description.md
+++ b/docs/chat-chain-changes/2026-08-04-hide-group-run-agent-description.md
@@ -1,0 +1,10 @@
+---
+date: 2026-08-04
+pr: pending
+feature: Hide group run Agent descriptions
+impact: Group chat run headers now show only the Agent name instead of repeating the Agent description beside it.
+---
+
+This is a presentation-only change. Agent descriptions remain available to the
+room configuration and runtime, while message content, run grouping, mentions,
+Profile selection, and Agent execution behavior are unchanged.

--- a/docs/chat-chain-changes/2026-08-04-hide-group-run-agent-description.md
+++ b/docs/chat-chain-changes/2026-08-04-hide-group-run-agent-description.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-04
-pr: pending
+pr: 2352
 feature: Hide group run Agent descriptions
 impact: Group chat run headers now show only the Agent name instead of repeating the Agent description beside it.
 ---

--- a/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
@@ -39,7 +39,6 @@ const timeText = computed(() => formatChatTimestamp(lastTimestamp.value))
         <div class="run-column">
             <div class="run-header">
                 <span class="run-agent-name">{{ message.senderName }}</span>
-                <span v-if="agentInfo?.description" class="run-agent-description">{{ agentInfo.description }}</span>
             </div>
             <div class="run-card" :class="{ streaming: message.isStreaming }">
                 <GroupMessageItem
@@ -97,16 +96,6 @@ const timeText = computed(() => formatChatTimestamp(lastTimestamp.value))
     color: $text-primary;
     font-size: 13px;
     font-weight: 600;
-}
-
-.run-agent-description {
-    min-width: 0;
-    overflow: hidden;
-    color: $text-muted;
-    font-size: 11px;
-    font-style: italic;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 .run-card {

--- a/tests/client/group-chat-panel-workspace-source.test.ts
+++ b/tests/client/group-chat-panel-workspace-source.test.ts
@@ -181,6 +181,7 @@ describe('GroupChatPanel workspace save handling', () => {
     expect(avatarSource).toContain("@click.stop=\"emit('mention', agent)\"")
     expect(itemSource).toContain('<GroupAgentMessageAvatar')
     expect(runCardSource).toContain('<GroupAgentMessageAvatar')
+    expect(runCardSource).not.toContain('run-agent-description')
     expect(panelSource).toContain('@mention-agent="handleMentionAgent"')
     expect(panelSource).toContain('groupChatInputRef.value?.insertMention?.(agent.name)')
     expect(panelSource).not.toContain('class="agent-avatar-popover"')


### PR DESCRIPTION
## Summary
- remove the Agent description shown beside the Agent name in grouped run headers
- remove the unused `run-agent-description` styling
- add a regression assertion and Group Chat chain-change record

## Impact
Group chat run headers now show only the Agent name. Agent descriptions remain available in room configuration and runtime data, while message content, run grouping, mentions, Profile selection, avatar details, and execution behavior are unchanged.

## Validation
- `npm run test -- tests/client/group-chat-panel-workspace-source.test.ts` (16 passed)
- `npm run build`
- `npm run harness:check`
