### PR TITLE
[codex] send coding agent prompts through stdin

### DIFF
--- a/docs/chat-chain-changes/2026-08-04-windows-coding-agent-stdin.md
+++ b/docs/chat-chain-changes/2026-08-04-windows-coding-agent-stdin.md
@@ -1,0 +1,12 @@
+---
+date: 2026-08-04
+pr: pending
+feature: Coding-agent stdin delivery
+impact: Codex and Claude Code turns now receive multiline and long user input through stdin on every platform, avoiding Windows command-line corruption and truncation.
+---
+
+This applies to shared hidden coding-agent runs used by single chat, Group Chat,
+and workflows. Fixed CLI flags and paths remain in the process argument list,
+while user-provided text uses the same stdin transport on Windows, macOS, and
+Linux. On Windows, the text no longer passes through the npm `.cmd` shim or the
+`cmd.exe` command-length limit.

--- a/docs/chat-chain-changes/2026-08-04-windows-coding-agent-stdin.md
+++ b/docs/chat-chain-changes/2026-08-04-windows-coding-agent-stdin.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-04
-pr: pending
+pr: 2354
 feature: Coding-agent stdin delivery
 impact: Codex and Claude Code turns now receive multiline and long user input through stdin on every platform, avoiding Windows command-line corruption and truncation.
 ---

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -915,18 +915,19 @@ export class CodingAgentRunManager {
     const promptArgument = hasArg(run.launch.args, '--append-system-prompt-file')
       ? ''
       : normalizeCliPromptArgument(systemPrompt)
-    const streamInput = images.length > 0 ? buildClaudeStreamJsonInput(input, images) : ''
+    const inputFormat = images.length > 0 ? 'stream-json' : 'text'
+    const stdinInput = images.length > 0 ? buildClaudeStreamJsonInput(input, images) : input
     const args = [
       ...run.launch.args,
       ...nativeSessionArgs,
       ...(promptArgument ? ['--append-system-prompt', promptArgument] : []),
       '-p',
-      ...(streamInput ? ['--input-format', 'stream-json'] : []),
+      '--input-format',
+      inputFormat,
       '--output-format',
       'stream-json',
       '--include-partial-messages',
       '--verbose',
-      ...(streamInput ? [] : [input]),
     ]
     const child = spawnCodingAgentChild(run.launch.command, args, {
       cwd: existsSync(run.launch.workspaceDir) ? run.launch.workspaceDir : homedir(),
@@ -934,7 +935,7 @@ export class CodingAgentRunManager {
         ...process.env,
         ...(run.launch.env || {}),
       },
-      pipeStdin: Boolean(streamInput),
+      pipeStdin: true,
     })
     run.currentChild = child
 
@@ -953,11 +954,11 @@ export class CodingAgentRunManager {
       if (text) logger.debug({ runId: run.id, sessionId: run.launch.sessionId, text }, '[coding-agent-run] claude print stderr')
     })
 
-    if (streamInput && child.stdin) {
+    if (child.stdin) {
       child.stdin.on('error', (err) => {
-        logger.warn({ err, runId: run.id, sessionId: run.launch.sessionId }, '[coding-agent-run] claude stream input failed')
+        logger.warn({ err, runId: run.id, sessionId: run.launch.sessionId }, '[coding-agent-run] claude stdin input failed')
       })
-      child.stdin.end(`${streamInput}\n`)
+      child.stdin.end(`${stdinInput}\n`)
     }
 
     child.on('error', (err) => {
@@ -1378,8 +1379,8 @@ export class CodingAgentRunManager {
       '--dangerously-bypass-approvals-and-sandbox',
     ]
     const args = run.launch.agentNativeSessionId && run.nativeResumeReady
-      ? ['exec', 'resume', ...commonArgs, run.launch.agentNativeSessionId, input]
-      : ['exec', ...commonArgs, '--cd', run.launch.workspaceDir, input]
+      ? ['exec', 'resume', ...commonArgs, run.launch.agentNativeSessionId, '-']
+      : ['exec', ...commonArgs, '--cd', run.launch.workspaceDir, '-']
 
     const child = spawnCodingAgentChild(run.launch.command, args, {
       cwd: existsSync(run.launch.workspaceDir) ? run.launch.workspaceDir : homedir(),
@@ -1387,6 +1388,7 @@ export class CodingAgentRunManager {
         ...process.env,
         ...(run.launch.env || {}),
       },
+      pipeStdin: true,
     })
     run.currentChild = child
 
@@ -1404,6 +1406,13 @@ export class CodingAgentRunManager {
       const text = appendChildStderr(run, chunk)
       if (text) logger.debug({ runId: run.id, sessionId: run.launch.sessionId, text }, '[coding-agent-run] codex exec stderr')
     })
+
+    if (child.stdin) {
+      child.stdin.on('error', (err) => {
+        logger.warn({ err, runId: run.id, sessionId: run.launch.sessionId }, '[coding-agent-run] codex stdin input failed')
+      })
+      child.stdin.end(`${input}\n`)
+    }
 
     child.on('error', (err) => {
       if (run.currentChildKillTimer) clearTimeout(run.currentChildKillTimer)

--- a/tests/server/coding-agent-run-manager-windows.test.ts
+++ b/tests/server/coding-agent-run-manager-windows.test.ts
@@ -85,7 +85,15 @@ describe('coding agent Windows process launch', () => {
       state: { messages: [], isWorking: false, events: [], queue: [] },
     })
 
-    manager.send('chat-session-1', 'test', { systemPrompt: 'system prompt\nsecond line' })
+    const groupInput = [
+      '群聊系统：这条消息已经提及你，请直接回复。',
+      '',
+      '以下是群聊记录：',
+      `用户：${'长文本'.repeat(4000)}`,
+      '',
+      '当前消息：检查这个问题',
+    ].join('\n')
+    manager.send('chat-session-1', groupInput, { systemPrompt: 'system prompt\nsecond line' })
 
     expect(testState.spawnCalls[0]).toMatchObject({
       command: 'cmd.exe',
@@ -95,14 +103,17 @@ describe('coding agent Windows process launch', () => {
     expect(testState.spawnCalls[0].args[3]).toContain('^"--settings^"')
     expect(testState.spawnCalls[0].args[3]).toContain('^"--append-system-prompt^"')
     expect(testState.spawnCalls[0].args[3]).toContain('^"system^ prompt^ /^ second^ line^"')
+    expect(testState.spawnCalls[0].args[3]).toContain('^"--input-format^" ^"text^"')
     expect(testState.spawnCalls[0].args[3]).not.toContain('\n')
     expect(testState.spawnCalls[0].args[3]).not.toContain('\r')
-    expect(testState.spawnCalls[0].args[3]).toContain('^"test^"')
+    expect(testState.spawnCalls[0].args[3]).not.toContain('群聊系统')
+    expect(testState.spawnCalls[0].args[3].length).toBeLessThan(8191)
     expect(testState.spawnCalls[0].options).toMatchObject({
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ['pipe', 'pipe', 'pipe'],
       windowsVerbatimArguments: true,
       windowsHide: true,
     })
+    expect(testState.spawnCalls[0].child.stdin.end).toHaveBeenCalledWith(`${groupInput}\n`)
 
     const run = (manager as any).runs.get('agent-session-1')
     if (run?.idleTimer) clearTimeout(run.idleTimer)
@@ -132,7 +143,15 @@ describe('coding agent Windows process launch', () => {
       state: { messages: [], isWorking: false, events: [], queue: [] },
     })
 
-    manager.send('chat-session-codex-1', 'test', { systemPrompt: 'system prompt\nsecond line' })
+    const groupInput = [
+      '群聊系统：这条消息已经提及你，请直接回复。',
+      '',
+      '以下是群聊记录：',
+      `用户：${'长文本'.repeat(4000)}`,
+      '',
+      '当前消息：检查这个问题',
+    ].join('\n')
+    manager.send('chat-session-codex-1', groupInput, { systemPrompt: 'system prompt\nsecond line' })
 
     expect(testState.spawnCalls[0]).toMatchObject({
       command: 'cmd.exe',
@@ -147,13 +166,16 @@ describe('coding agent Windows process launch', () => {
     expect(testState.spawnCalls[0].args[3]).not.toContain('\n')
     expect(testState.spawnCalls[0].args[3]).not.toContain('\r')
     expect(testState.spawnCalls[0].args[3]).toContain('^"--model^"')
-    expect(testState.spawnCalls[0].args[3]).toContain('^"test^"')
+    expect(testState.spawnCalls[0].args[3]).toContain('^"-^"')
+    expect(testState.spawnCalls[0].args[3]).not.toContain('群聊系统')
+    expect(testState.spawnCalls[0].args[3].length).toBeLessThan(8191)
     expect(testState.spawnCalls[0].args[3]).not.toContain('system^ prompt\r\n\r\ntest')
     expect(testState.spawnCalls[0].options).toMatchObject({
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ['pipe', 'pipe', 'pipe'],
       windowsVerbatimArguments: true,
       windowsHide: true,
     })
+    expect(testState.spawnCalls[0].child.stdin.end).toHaveBeenCalledWith(`${groupInput}\n`)
 
     const run = (manager as any).runs.get('agent-session-codex-1')
     if (run?.idleTimer) clearTimeout(run.idleTimer)
@@ -297,7 +319,10 @@ describe('coding agent Windows process launch', () => {
     const call = testState.spawnCalls[0]
     expect(call.args[3]).toContain('^"--image^"')
     expect(call.args[3]).toContain('C:\\Users\\Administrator\\Pictures\\sample^ image.png')
-    expect(call.options.stdio).toEqual(['ignore', 'pipe', 'pipe'])
+    expect(call.args[3]).toContain('^"-^"')
+    expect(call.args[3]).not.toContain('^"inspect^ this^ image^"')
+    expect(call.options.stdio).toEqual(['pipe', 'pipe', 'pipe'])
+    expect(call.child.stdin.end).toHaveBeenCalledWith('inspect this image\n')
 
     const run = (manager as any).runs.get('agent-session-codex-image-1')
     if (run?.idleTimer) clearTimeout(run.idleTimer)

--- a/tests/server/workflow-manager.test.ts
+++ b/tests/server/workflow-manager.test.ts
@@ -2098,7 +2098,12 @@ describe('workflow manager', () => {
   it('finalizes a loop exit target when its approval reaches the shared deadline', async () => {
     const { WorkflowManager } = await import('../../packages/server/src/services/workflow-manager')
     const manager = new WorkflowManager()
-    chatRunMock.runAndWait.mockReset().mockResolvedValue({ ok: true, output: 'stop' })
+    let now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    chatRunMock.runAndWait.mockReset().mockImplementation(async () => {
+      now += 5
+      return { ok: true, output: 'stop' }
+    })
     const workflow = manager.create({
       name: `Exit approval deadline ${Date.now()}`, profile: 'default',
       nodes: [
@@ -2119,7 +2124,7 @@ describe('workflow manager', () => {
         ['header', 'completed', null], ['latch', 'completed', null], ['publish', 'failed', 'workflow run timed out after 20ms'],
       ])
       expect(manager.approveNode(workflow.id, result.run.id, 'publish', true)).toBe(false)
-    } finally { await manager.delete(workflow.id) }
+    } finally { nowSpy.mockRestore(); await manager.delete(workflow.id) }
   })
 
   it('keeps a canceled loop exit target canceled when its agent fails late', async () => {


### PR DESCRIPTION
## Summary
- send Claude Code text and image prompts through stdin
- invoke Codex `exec` with stdin instead of placing user input on the command line
- cover multiline group-chat input beyond the Windows `cmd.exe` command-length limit

## Why
Windows npm command shims run through `cmd.exe`. Passing multiline group history
and the current instruction as command arguments could corrupt line breaks or
exceed the command-length limit, so Codex and Claude Code could start without
receiving the user's instruction.

The shared runner is also used by single chat and workflows. The supported stdin
transport is therefore used consistently on Windows, macOS, and Linux, while
stdout and stderr remain piped for streaming output.

## Validation
- `npx vitest run tests/server/coding-agent-run-manager-windows.test.ts tests/server/agent-runner-utils.test.ts tests/server/handle-coding-agent-run.test.ts tests/server/group-chat-agent-workspace.test.ts`
- `npm run harness:check`
- `npm run build`
