### PR TITLE
fix(group-chat): let Coding Agents own run timeouts

### DIFF
--- a/docs/chat-chain-changes/2026-08-04-group-chat-coding-agent-run-ownership.md
+++ b/docs/chat-chain-changes/2026-08-04-group-chat-coding-agent-run-ownership.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-04
-pr: pending
+pr: 2357
 feature: Group Chat Coding Agent run ownership
 impact: Group Chat no longer imposes a fixed two-minute absolute deadline on Codex, Claude Code, or Ekko runs; runtime-owned request and execution controls remain authoritative.
 ---

--- a/docs/chat-chain-changes/2026-08-04-group-chat-coding-agent-run-ownership.md
+++ b/docs/chat-chain-changes/2026-08-04-group-chat-coding-agent-run-ownership.md
@@ -1,0 +1,15 @@
+---
+date: 2026-08-04
+pr: pending
+feature: Group Chat Coding Agent run ownership
+impact: Group Chat no longer imposes a fixed two-minute absolute deadline on Codex, Claude Code, or Ekko runs; runtime-owned request and execution controls remain authoritative.
+---
+
+The non-Hermes Group Chat adapter no longer passes `timeoutMs: 120000` to
+`runAndWait()`. Active Coding Agent turns are therefore not aborted solely
+because the complete room turn exceeds two minutes. Explicit Room interruption,
+Session cleanup, tool-event persistence, and Workspace Diff finalization remain
+unchanged.
+
+Hermes Agent Bridge request timeouts, HTTP chat-run behavior, Workflow timeout
+behavior, and ordinary single-chat Coding Agent behavior are unchanged.

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -835,7 +835,6 @@ class AgentClient {
                 context_compression_enabled: false,
             }, {
                 profile: this.profile,
-                timeoutMs: 120000,
                 onEvent: (event, payload = {}) => {
                     if (!isCurrent()) {
                         if (!abortRequested) {

--- a/tests/server/group-chat-agent-workspace.test.ts
+++ b/tests/server/group-chat-agent-workspace.test.ts
@@ -284,6 +284,7 @@ describe('group chat agent workspace bridge runs', () => {
       profile: 'research',
       onEvent: expect.any(Function),
     }))
+    expect(runAndWait.mock.calls[0][1]).not.toHaveProperty('timeoutMs')
     expect(String(runAndWait.mock.calls[0][0].input)).toContain('截至总结锚点的群聊总结')
     expect(String(runAndWait.mock.calls[0][0].input)).toContain('Keep single chat unchanged.')
     expect(runAndWait.mock.calls[0][0].instructions).toContain('你是"Coder"，群聊房间"Engineering Room"中的 AI 助手')
@@ -383,6 +384,7 @@ describe('group chat agent workspace bridge runs', () => {
     })
 
     const runData = runAndWait.mock.calls[0][0]
+    expect(runAndWait.mock.calls[0][1]).not.toHaveProperty('timeoutMs')
     expect(runData.coding_agent_id).toBe(codingAgentId)
     expect(runData.instructions).toContain(`你是"${agent === 'ekko' ? 'Ekko' : 'Claude'}"，群聊房间"Runtime Room"中的 AI 助手`)
     expect(runData.instructions).toContain('- Human: Room owner')


### PR DESCRIPTION
## Summary

- remove the fixed `timeoutMs: 120000` option from non-Hermes Group Chat Coding Agent runs
- keep Codex, Claude Code, and Ekko runtime-owned request/execution controls authoritative
- preserve Hermes Agent Bridge, HTTP chat-run, Workflow, explicit Room interruption, and cleanup behavior
- add regression assertions for all three affected Coding Agent runtimes

Closes #2356

## Root cause

The Group Chat adapter passed `timeoutMs: 120000` to `runAndWait()`. In this call path the option is an absolute wall-clock deadline for the complete turn, so active Coding Agent work was aborted after two minutes even when reasoning and tool events continued.

## TDD evidence

### RED

`npm test -- --run tests/server/group-chat-agent-workspace.test.ts`

- 3 failed, 22 passed
- Codex, Ekko, and Claude each received `timeoutMs: 120000`

### GREEN

`npm test -- --run tests/server/group-chat-agent-workspace.test.ts tests/server/run-chat-queued-item.test.ts`

- 2 files passed
- 38 tests passed

## Verification

- `npx vue-tsc -b --pretty false` — passed
- `npx tsc --noEmit -p packages/server/tsconfig.json` — passed
- `npm run harness:check` — passed
- `npm run build` — passed
- `git diff --check` — passed
- static added-line secret/injection scan — no findings

### Coverage A/B

The full coverage suite has existing environment-sensitive baseline failures. Candidate and pristine `origin/main` were run sequentially in isolated worktrees with the same clean command and compared by repository-relative test path plus full test title:

- candidate: 3389 total, 3376 passed, 3 skipped, 10 failed
- pristine base: 3389 total, 3376 passed, 3 skipped, 10 failed
- candidate-only failures: `[]`

## Scope boundaries

Not changed:

- Hermes Agent Bridge per-request timeout
- HTTP chat-run caller timeout
- Workflow timeout behavior
- `runAndWait()` implementation
- participant persistence metadata

## Exact candidate

- base: `67e2cbf9b6e00400dcc8418fd3e2ec5b00154fb1`
- head: `23972cd4c52c135394d80503c0ca38fc66ac4cb1`
- tree: `89fa9e185e4785f33f227cf5f4f089ec94901da9`
- independently reviewed implementation patch: `955b3e3c986cdf774ad664a003b6b35c914cb2734f0e6320fe4dddf043b028c4`
- follow-up after review: documentation-only `pr: pending` → `pr: 2357`; source and test bytes unchanged
