### PR TITLE
document Ekko OAuth providers

### DIFF
--- a/packages/ekko-agent/README.md
+++ b/packages/ekko-agent/README.md
@@ -21,10 +21,13 @@ First-class OAuth provider presets:
 - `openai-codex` — OpenAI Responses at the ChatGPT Codex backend
 - `xai-oauth` — OpenAI Responses at the xAI API
 - `qwen-oauth` — OpenAI Chat Completions at the Qwen Portal API
+- `claude-oauth` — Anthropic Messages at the Anthropic API
+- `minimax-oauth` — Anthropic Messages for the MiniMax Coding Plan
 
 Pass the current OAuth access token as `apiKey`. Login, token persistence, and
 refresh remain the caller's responsibility; the preset supplies the provider's
-default endpoint, request style, and required identity headers.
+default endpoint, request style, and required identity headers. MiniMax Coding
+Plan requests use Bearer-only authentication and do not send `x-api-key`.
 
 Default endpoints:
 


### PR DESCRIPTION
## Summary

- document the existing `claude-oauth` and `minimax-oauth` first-class Ekko provider presets
- clarify that MiniMax Coding Plan uses Bearer-only authentication without `x-api-key`

## Why

The README provider list was out of date with the implemented runtime presets, which could make MiniMax and Claude OAuth support appear unavailable.

## Impact

Documentation now matches the current Ekko provider and authentication behavior. There is no runtime behavior change.

## Validation

- `git diff --cached --check`
- `npm --prefix packages/ekko-agent run check`
- `npm test -- --run tests/server/minimax-auth-controller.test.ts tests/server/ekko-agent-provider-runtime.test.ts tests/server/ekko-agent-auth-providers.test.ts tests/server/authorized-provider-credentials.test.ts tests/ekko-agent/model-request.test.ts`
