### PR TITLE
fix(group-chat): stabilize coding agent tool events

### DIFF
--- a/docs/chat-chain-changes/2026-08-05-group-chat-coding-agent-tool-events.md
+++ b/docs/chat-chain-changes/2026-08-05-group-chat-coding-agent-tool-events.md
@@ -1,0 +1,29 @@
+---
+date: 2026-08-05
+pr: pending
+feature: Group Chat Coding Agent tool event authority
+impact: Claude Code and Codex group turns no longer persist duplicate proxy tool calls beside their authoritative native tool lifecycle, Responses-backed Claude tools keep one stable call identity with compatible optional arguments, and failed tools retain their error state.
+---
+
+While a Claude Code print child is active, its native stream-json
+`tool_use`/`tool_result` events are now the only tool lifecycle authority.
+Responses proxy tool events for that same child are ignored because they can use
+different call ids and omit the matching output event, which previously left
+duplicate Group Chat tool cards loading until the full agent turn completed.
+
+Codex keeps proxy text deltas for responsive streaming, but its JSONL events are
+now the sole authority for command, MCP, web search, and file-change tool
+lifecycles. This extends the existing `exec_command` deduplication to every
+Codex tool and its completion event.
+
+Group Chat tool result messages now also persist `finish_reason: error` for
+failed events so client projection renders the card as failed rather than
+successfully completed.
+
+The Claude Code Responses bridge now treats a Responses function item's
+`call_id`, `item_id`, and `output_index` as aliases for one tool block. This
+prevents argument-delta events from creating a second tool named `tool` that
+cannot receive the real call's result. The bridge buffers each complete
+argument object and uses the original Anthropic tool schema to remove unused
+empty values only from optional fields before Claude Code validates the call;
+required values and explicitly allowed empty or null values are preserved.

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -1301,7 +1301,7 @@ function mapGroupMessages(msgs: ChatMessage[]): ChatMessage[] {
                     : placeholderIdx !== -1
                         ? result[placeholderIdx].reasoning
                         : undefined,
-                toolStatus: 'done',
+                toolStatus: msg.finish_reason === 'error' ? 'error' : 'done',
             }
             if (placeholderIdx !== -1) result[placeholderIdx] = merged
             else result.push(merged)

--- a/packages/server/src/services/agent-runner/adapters/anthropic-stream.ts
+++ b/packages/server/src/services/agent-runner/adapters/anthropic-stream.ts
@@ -1,5 +1,11 @@
 import { readSseFrameTexts } from '../sse'
-import { mapStopReason, shouldPreserveReasoningContent, type AnthropicAdapterTarget } from './anthropic'
+import {
+  createAnthropicToolInputSchemas,
+  mapStopReason,
+  normalizeAnthropicToolArguments,
+  shouldPreserveReasoningContent,
+  type AnthropicAdapterTarget,
+} from './anthropic'
 
 export interface AnthropicStreamEvent {
   type: string
@@ -236,6 +242,7 @@ export async function* openAiChatSseToAnthropicEvents(
 export async function* openAiResponsesSseToAnthropicEvents(
   stream: AsyncIterable<Uint8Array>,
   target: AnthropicAdapterTarget,
+  anthropicTools?: unknown,
 ): AsyncGenerator<AnthropicStreamEvent> {
   const decoder = new TextDecoder()
   let messageId = `msg_${Date.now()}`
@@ -245,7 +252,18 @@ export async function* openAiResponsesSseToAnthropicEvents(
   let nextIndex = 0
   let stopReason: string | null = null
   let outputTokens = 0
-  const toolBlocks = new Map<string, { blockIndex: number; id: string; name: string; argsDeltaSeen: boolean; stopped: boolean }>()
+  const toolInputSchemas = createAnthropicToolInputSchemas(anthropicTools)
+  type ToolBlock = {
+    blockIndex: number
+    id: string
+    name: string
+    arguments: string
+    argumentsEmitted: boolean
+    started: boolean
+    stopped: boolean
+  }
+  const toolBlocks: ToolBlock[] = []
+  const toolAliases = new Map<string, ToolBlock>()
 
   yield {
     type: 'message_start',
@@ -279,30 +297,80 @@ export async function* openAiResponsesSseToAnthropicEvents(
     return textBlockIndex
   }
 
-  const ensureToolBlock = function* (key: string, id?: string, name?: string): Generator<AnthropicStreamEvent, { blockIndex: number; id: string; name: string; argsDeltaSeen: boolean; stopped: boolean }> {
-    let block = toolBlocks.get(key)
+  const toolAliasKeys = (values: unknown[], outputIndex?: unknown): string[] => {
+    const aliases = values
+      .filter(value => value !== undefined && value !== null && String(value) !== '')
+      .map(value => `id:${String(value)}`)
+    if (outputIndex !== undefined && outputIndex !== null && String(outputIndex) !== '') {
+      aliases.push(`index:${String(outputIndex)}`)
+    }
+    return [...new Set(aliases)]
+  }
+
+  const ensureToolBlock = (aliases: string[], id?: string, name?: string): ToolBlock => {
+    let block = aliases.map(alias => toolAliases.get(alias)).find(Boolean)
     if (!block) {
       block = {
         blockIndex: nextIndex++,
-        id: id || key || `toolu_${toolBlocks.size}`,
-        name: name || 'tool',
-        argsDeltaSeen: false,
+        id: id || `toolu_${toolBlocks.length}`,
+        name: name || '',
+        arguments: '',
+        argumentsEmitted: false,
+        started: false,
         stopped: false,
       }
-      toolBlocks.set(key, block)
-      yield {
-        type: 'content_block_start',
-        data: {
-          type: 'content_block_start',
-          index: block.blockIndex,
-          content_block: { type: 'tool_use', id: block.id, name: block.name, input: {} },
-        },
-      }
+      toolBlocks.push(block)
     } else {
       if (id) block.id = id
-      if (name && block.name === 'tool') block.name = name
+      if (name) block.name = name
     }
+    for (const alias of aliases) toolAliases.set(alias, block)
     return block
+  }
+
+  const startToolBlock = function* (block: ToolBlock): Generator<AnthropicStreamEvent> {
+    if (block.started) return
+    block.started = true
+    if (!block.name) block.name = 'tool'
+    yield {
+      type: 'content_block_start',
+      data: {
+        type: 'content_block_start',
+        index: block.blockIndex,
+        content_block: { type: 'tool_use', id: block.id, name: block.name, input: {} },
+      },
+    }
+  }
+
+  const emitToolArguments = function* (block: ToolBlock): Generator<AnthropicStreamEvent> {
+    if (block.argumentsEmitted) return
+    block.argumentsEmitted = true
+    if (!block.arguments) return
+    const normalized = normalizeAnthropicToolArguments(
+      block.arguments,
+      block.name || 'tool',
+      toolInputSchemas,
+    )
+    if (!normalized) return
+    yield {
+      type: 'content_block_delta',
+      data: {
+        type: 'content_block_delta',
+        index: block.blockIndex,
+        delta: { type: 'input_json_delta', partial_json: normalized },
+      },
+    }
+  }
+
+  const stopToolBlock = function* (block: ToolBlock): Generator<AnthropicStreamEvent> {
+    if (block.stopped) return
+    yield* startToolBlock(block)
+    yield* emitToolArguments(block)
+    block.stopped = true
+    yield {
+      type: 'content_block_stop',
+      data: { type: 'content_block_stop', index: block.blockIndex },
+    }
   }
 
   for await (const chunk of stream) {
@@ -346,51 +414,38 @@ export async function* openAiResponsesSseToAnthropicEvents(
         if (eventType === 'response.output_item.added') {
           const item = data?.item || data?.output_item
           if (item?.type === 'function_call') {
-            const key = String(item.call_id || item.id || data.output_index || toolBlocks.size)
-            yield* ensureToolBlock(key, String(item.call_id || item.id || key), item.name ? String(item.name) : undefined)
+            const aliases = toolAliasKeys([item.call_id, item.id], data.output_index)
+            const block = ensureToolBlock(
+              aliases,
+              item.call_id ? String(item.call_id) : item.id ? String(item.id) : undefined,
+              item.name ? String(item.name) : undefined,
+            )
+            if (block.name) yield* startToolBlock(block)
           }
         }
 
         if (eventType === 'response.function_call_arguments.delta') {
-          const key = String(data.call_id || data.item_id || data.output_index || toolBlocks.size)
-          const block = yield* ensureToolBlock(key)
+          const aliases = toolAliasKeys([data.call_id, data.item_id], data.output_index)
+          const block = ensureToolBlock(aliases)
           const argsDelta = String(data.delta || '')
-          if (argsDelta) {
-            block.argsDeltaSeen = true
-            yield {
-              type: 'content_block_delta',
-              data: {
-                type: 'content_block_delta',
-                index: block.blockIndex,
-                delta: { type: 'input_json_delta', partial_json: argsDelta },
-              },
-            }
-          }
+          if (argsDelta) block.arguments += argsDelta
         }
 
         if (eventType === 'response.output_item.done') {
           const item = data?.item || data?.output_item
           if (item?.type === 'function_call') {
-            const key = String(item.call_id || item.id || data.output_index || toolBlocks.size)
-            const block = yield* ensureToolBlock(key, String(item.call_id || item.id || key), item.name ? String(item.name) : undefined)
-            const args = String(item.arguments || '')
-            if (args && !block.argsDeltaSeen) {
-              yield {
-                type: 'content_block_delta',
-                data: {
-                  type: 'content_block_delta',
-                  index: block.blockIndex,
-                  delta: { type: 'input_json_delta', partial_json: args },
-                },
-              }
-            }
-            if (!block.stopped) {
-              block.stopped = true
-              yield {
-                type: 'content_block_stop',
-                data: { type: 'content_block_stop', index: block.blockIndex },
-              }
-            }
+            const aliases = toolAliasKeys(
+              [item.call_id, item.id, data.call_id, data.item_id],
+              data.output_index,
+            )
+            const block = ensureToolBlock(
+              aliases,
+              item.call_id ? String(item.call_id) : item.id ? String(item.id) : undefined,
+              item.name ? String(item.name) : undefined,
+            )
+            const completedArguments = typeof item.arguments === 'string' ? item.arguments : ''
+            if (completedArguments) block.arguments = completedArguments
+            yield* stopToolBlock(block)
           }
         }
 
@@ -409,19 +464,14 @@ export async function* openAiResponsesSseToAnthropicEvents(
       data: { type: 'content_block_stop', index: textBlockIndex },
     }
   }
-  for (const block of toolBlocks.values()) {
-    if (!block.stopped) {
-      yield {
-        type: 'content_block_stop',
-        data: { type: 'content_block_stop', index: block.blockIndex },
-      }
-    }
+  for (const block of toolBlocks) {
+    if (!block.stopped) yield* stopToolBlock(block)
   }
   yield {
     type: 'message_delta',
     data: {
       type: 'message_delta',
-      delta: { stop_reason: openAiFinishToAnthropic(stopReason, toolBlocks.size > 0), stop_sequence: null },
+      delta: { stop_reason: openAiFinishToAnthropic(stopReason, toolBlocks.length > 0), stop_sequence: null },
       usage: { output_tokens: outputTokens },
     },
   }

--- a/packages/server/src/services/agent-runner/adapters/anthropic.ts
+++ b/packages/server/src/services/agent-runner/adapters/anthropic.ts
@@ -31,6 +31,99 @@ function safeJsonParse(value: string): any {
     return {}
   }
 }
+
+type ToolInputSchema = Record<string, any>
+export type AnthropicToolInputSchemas = Map<string, ToolInputSchema>
+
+export function createAnthropicToolInputSchemas(tools: unknown): AnthropicToolInputSchemas {
+  const schemas: AnthropicToolInputSchemas = new Map()
+  if (!Array.isArray(tools)) return schemas
+  for (const tool of tools) {
+    const name = String(tool?.name || '').trim()
+    const schema = tool?.input_schema
+    if (name && schema && typeof schema === 'object' && !Array.isArray(schema)) {
+      schemas.set(name, schema)
+    }
+  }
+  return schemas
+}
+
+function schemaExplicitlyUsesValue(schema: ToolInputSchema | undefined, value: unknown): boolean {
+  if (!schema) return false
+  if (Object.prototype.hasOwnProperty.call(schema, 'default') && Object.is(schema.default, value)) return true
+  if (Object.prototype.hasOwnProperty.call(schema, 'const') && Object.is(schema.const, value)) return true
+  if (Array.isArray(schema.enum) && schema.enum.some((entry: unknown) => Object.is(entry, value))) return true
+  return ['anyOf', 'oneOf', 'allOf'].some(key => (
+    Array.isArray(schema[key]) &&
+    schema[key].some((entry: unknown) => (
+      entry &&
+      typeof entry === 'object' &&
+      !Array.isArray(entry) &&
+      schemaExplicitlyUsesValue(entry as ToolInputSchema, value)
+    ))
+  ))
+}
+
+function schemaAcceptsNull(schema: ToolInputSchema | undefined): boolean {
+  if (!schema) return false
+  if (schema.type === 'null' || (Array.isArray(schema.type) && schema.type.includes('null'))) return true
+  if (schemaExplicitlyUsesValue(schema, null)) return true
+  return ['anyOf', 'oneOf'].some(key => (
+    Array.isArray(schema[key]) &&
+    schema[key].some((entry: unknown) => (
+      entry &&
+      typeof entry === 'object' &&
+      !Array.isArray(entry) &&
+      schemaAcceptsNull(entry as ToolInputSchema)
+    ))
+  ))
+}
+
+function normalizeOptionalToolInput(value: unknown, schema: ToolInputSchema | undefined): unknown {
+  if (Array.isArray(value)) {
+    const itemSchema = schema?.items && typeof schema.items === 'object' && !Array.isArray(schema.items)
+      ? schema.items as ToolInputSchema
+      : undefined
+    return value.map(item => normalizeOptionalToolInput(item, itemSchema))
+  }
+  if (!value || typeof value !== 'object') return value
+
+  const properties = schema?.properties && typeof schema.properties === 'object' && !Array.isArray(schema.properties)
+    ? schema.properties as Record<string, ToolInputSchema>
+    : {}
+  const required = new Set(Array.isArray(schema?.required) ? schema.required.map(String) : [])
+  const normalized: Record<string, unknown> = {}
+
+  for (const [key, entry] of Object.entries(value)) {
+    const propertySchema = properties[key]
+    const optional = !required.has(key)
+    // Responses-compatible models sometimes materialize an omitted optional
+    // argument as "" or null. Claude tools distinguish that placeholder from
+    // an absent field, so remove it unless the schema gives it explicit meaning.
+    const isUnusedEmptyString = entry === '' && !schemaExplicitlyUsesValue(propertySchema, '')
+    const isUnusedNull = entry === null && !schemaAcceptsNull(propertySchema)
+    if (optional && (isUnusedEmptyString || isUnusedNull)) continue
+    normalized[key] = normalizeOptionalToolInput(entry, propertySchema)
+  }
+  return normalized
+}
+
+export function normalizeAnthropicToolArguments(
+  rawArguments: string,
+  toolName: string,
+  schemas: AnthropicToolInputSchemas,
+): string {
+  const schema = schemas.get(toolName)
+  if (!schema || !rawArguments) return rawArguments
+  try {
+    const parsed = JSON.parse(rawArguments)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return rawArguments
+    return JSON.stringify(normalizeOptionalToolInput(parsed, schema))
+  } catch {
+    return rawArguments
+  }
+}
+
 export function shouldPreserveReasoningContent(target: AnthropicAdapterTarget): boolean {
   const identifier = `${target.provider} ${target.model} ${target.baseUrl}`.toLowerCase()
   return [
@@ -370,19 +463,29 @@ function responseOutputText(item: any): string {
   return ''
 }
 
-export function openAiResponsesToAnthropicMessage(data: any, target: AnthropicAdapterTarget): any {
+export function openAiResponsesToAnthropicMessage(
+  data: any,
+  target: AnthropicAdapterTarget,
+  anthropicTools?: unknown,
+): any {
   const content: any[] = []
   const output = Array.isArray(data?.output) ? data.output : []
+  const toolInputSchemas = createAnthropicToolInputSchemas(anthropicTools)
 
   for (const item of output) {
     const text = responseOutputText(item)
     if (text) content.push({ type: 'text', text })
     if (item?.type === 'function_call') {
+      const name = String(item.name || 'tool')
       content.push({
         type: 'tool_use',
         id: String(item.call_id || item.id || `toolu_${content.length}`),
-        name: String(item.name || 'tool'),
-        input: safeJsonParse(String(item.arguments || '{}')),
+        name,
+        input: safeJsonParse(normalizeAnthropicToolArguments(
+          String(item.arguments || '{}'),
+          name,
+          toolInputSchemas,
+        )),
       })
     }
   }

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -152,20 +152,8 @@ function isProxyToolEvent(event: CanonicalResponsesEvent): boolean {
   const data: any = event.data || {}
   const item = data.item || data.output_item || data
   return event.type === 'response.function_call_arguments.delta' ||
-    ((event.type === 'response.output_item.added' || event.type === 'response.output_item.done') && item?.type === 'function_call')
-}
-
-function isCodexProxyExecToolEvent(event: CanonicalResponsesEvent): boolean {
-  const data: any = event.data || {}
-  const item = data.item || data.output_item || data
-  if (
-    (event.type !== 'response.output_item.added' && event.type !== 'response.output_item.done') ||
-    item?.type !== 'function_call'
-  ) {
-    return false
-  }
-  const name = String(item.name || item.function?.name || '').trim()
-  return name === 'exec_command' || name === 'functions.exec_command'
+    ((event.type === 'response.output_item.added' || event.type === 'response.output_item.done') &&
+      (item?.type === 'function_call' || item?.type === 'function_call_output'))
 }
 
 function truncateCodingAgentToolOutputForStorage(output: unknown): string {
@@ -663,13 +651,26 @@ export class CodingAgentRunManager {
     if (!agentSessionId) return
     const run = this.runs.get(agentSessionId)
     if (!run) return
-    if (run.launch.agentId === 'codex' && isCodexProxyExecToolEvent(event)) return
     const responseEvent = this.normalizeCodexChatTextEvent(run, event)
     if (!responseEvent) return
     const storageSafeResponseEvent = truncateCodingAgentToolOutputEvent(responseEvent)
     if (run.launch.agentId === 'claude-code' && !run.acceptingPrintEvent) {
       if (run.terminalEventHandled) return
-      if (run.currentChild && !isProxyToolEvent(event)) return
+      // Claude's stream-json process reports tool_use/tool_result itself.
+      // Proxy Responses events describe the same calls with different ids and
+      // may omit the matching function_call_output, so accepting both sources
+      // creates duplicate tool cards that remain pending until run completion.
+      if (run.currentChild) return
+    }
+    if (
+      run.launch.agentId === 'codex' &&
+      !run.acceptingPrintEvent &&
+      isProxyToolEvent(storageSafeResponseEvent)
+    ) {
+      // Keep proxy text deltas for responsive streaming, but use Codex JSONL as
+      // the sole source of tool lifecycle events. The two streams use different
+      // ids for the same call, so combining them creates duplicate tool cards.
+      return
     }
     if (storageSafeResponseEvent.type === 'response.created') {
       if (run.responseStartEmitted) return

--- a/packages/server/src/services/agent-runner/proxies/claude-code-proxy.ts
+++ b/packages/server/src/services/agent-runner/proxies/claude-code-proxy.ts
@@ -440,7 +440,7 @@ async function openAiResponsesToAnthropicSseStream(target: ClaudeCodeProxyTarget
   })
   const [clientStream, observerStream] = teeAsyncIterable(stream)
   observeResponsesEvents(target, openAiResponsesSseToResponsesEvents(observerStream))
-  return anthropicEventStream(openAiResponsesSseToAnthropicEvents(clientStream, target))
+  return anthropicEventStream(openAiResponsesSseToAnthropicEvents(clientStream, target, body?.tools))
 }
 
 export async function claudeProxyModels(ctx: Context) {
@@ -478,7 +478,7 @@ export async function claudeProxyMessages(ctx: Context) {
       const message = target.apiMode === 'anthropic_messages'
         ? await callAnthropicMessages(target, requestBody)
         : target.apiMode === 'codex_responses'
-          ? openAiResponsesToAnthropicMessage(await callOpenAiResponses(target, requestBody), target)
+          ? openAiResponsesToAnthropicMessage(await callOpenAiResponses(target, requestBody), target, requestBody?.tools)
           : openAiToAnthropicMessage(await callOpenAiChat(target, requestBody), target)
       ctx.body = message
     }

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -862,7 +862,7 @@ class AgentClient {
                             toolReasoning,
                         ))
                     } else if (event === 'tool.completed' || event === 'tool.failed') {
-                        queueToolEventWrite(() => this.recordToolCompleted(roomId, sessionId, payload))
+                        queueToolEventWrite(() => this.recordToolCompleted(roomId, sessionId, { ...payload, event }))
                     } else if (event === 'approval.requested') {
                         this.emitApprovalRequested(roomId, { ...payload, agentSessionId: sessionId })
                     } else if (event === 'approval.resolved') {
@@ -1328,6 +1328,10 @@ class AgentClient {
         this.pendingToolRunIds.delete(toolCallId)
         this.pendingToolNames.delete(toolCallId)
         const output = bridgeToolOutput(ev)
+        const failed = ev.event === 'tool.failed'
+            || ev.is_error === true
+            || ev.error === true
+            || (typeof ev.error === 'string' && ev.error.trim().length > 0)
         const timestamp = Date.now()
         const msg: MessageData & Record<string, any> = {
             id: `${runMessageId}_toolresult_${safeId(toolCallId)}_${Date.now()}`,
@@ -1340,12 +1344,14 @@ class AgentClient {
             role: 'tool',
             tool_call_id: toolCallId,
             tool_name: toolName || null,
+            finish_reason: failed ? 'error' : null,
         }
         return this.sendMessage(roomId, output, msg.id, {
             role: 'tool',
             run_id: responseRunId,
             tool_call_id: toolCallId,
             tool_name: toolName || null,
+            finish_reason: failed ? 'error' : null,
             timestamp,
         }, sessionId)
             .then(() => undefined)

--- a/tests/client/group-chat-store-streaming.test.ts
+++ b/tests/client/group-chat-store-streaming.test.ts
@@ -335,6 +335,38 @@ describe('group chat store streaming merge', () => {
     ])
   })
 
+  it('projects a failed tool completion as an error', async () => {
+    const store = await createJoinedStore()
+
+    emitSocket('message', assistantMessage({
+      id: 'run-1_part_0_toolcall_call-1',
+      run_id: 'run-1',
+      tool_calls: [{
+        id: 'call-1',
+        type: 'function',
+        function: { name: 'read_file', arguments: '{"path":"secret.txt"}' },
+      }],
+    }))
+    emitSocket('message', assistantMessage({
+      id: 'run-1_part_0_toolresult_call-1',
+      run_id: 'run-1',
+      role: 'tool',
+      tool_call_id: 'call-1',
+      tool_name: 'read_file',
+      content: 'permission denied',
+      finish_reason: 'error',
+    }))
+
+    expect(store.sortedMessages).toEqual([
+      expect.objectContaining({
+        toolCallId: 'call-1',
+        toolName: 'read_file',
+        toolResult: 'permission denied',
+        toolStatus: 'error',
+      }),
+    ])
+  })
+
   it('keeps reasoning split across consecutive tool calls in one agent run', async () => {
     const store = await createJoinedStore()
     const { groupAgentRunMessages } = await import('@/stores/hermes/group-chat')

--- a/tests/server/agent-runner-adapters.test.ts
+++ b/tests/server/agent-runner-adapters.test.ts
@@ -1042,6 +1042,52 @@ describe('agent runner Anthropic adapters', () => {
       usage: { input_tokens: 5, output_tokens: 6 },
     })
   })
+
+  it('drops unused empty optional Responses arguments using the original Anthropic tool schema', () => {
+    const message = openAiResponsesToAnthropicMessage({
+      id: 'resp_read',
+      status: 'completed',
+      output: [{
+        type: 'function_call',
+        call_id: 'call_read',
+        name: 'Read',
+        arguments: JSON.stringify({
+          file_path: '/tmp/package.json',
+          pages: '',
+          cursor: null,
+          nullable_cursor: null,
+          explicit_empty: '',
+          required_empty: '',
+        }),
+      }],
+    }, anthropicTarget, [{
+      name: 'Read',
+      input_schema: {
+        type: 'object',
+        properties: {
+          file_path: { type: 'string' },
+          pages: { type: 'string' },
+          cursor: { type: 'string' },
+          nullable_cursor: { type: ['string', 'null'] },
+          explicit_empty: { type: 'string', enum: [''] },
+          required_empty: { type: 'string' },
+        },
+        required: ['file_path', 'required_empty'],
+      },
+    }])
+
+    expect(message.content).toEqual([{
+      type: 'tool_use',
+      id: 'call_read',
+      name: 'Read',
+      input: {
+        file_path: '/tmp/package.json',
+        nullable_cursor: null,
+        explicit_empty: '',
+        required_empty: '',
+      },
+    }])
+  })
 })
 
 describe('agent runner Anthropic stream adapters', () => {
@@ -1108,5 +1154,54 @@ describe('agent runner Anthropic stream adapters', () => {
       delta: { stop_reason: 'tool_use', stop_sequence: null },
       usage: { output_tokens: 3 },
     })
+  })
+
+  it('unifies Responses call and item ids while normalizing optional tool arguments', async () => {
+    const fullArguments = JSON.stringify({
+      file_path: '/tmp/package.json',
+      limit: 220,
+      offset: 0,
+      pages: '',
+    })
+    const events = await collectAnthropicEvents(openAiResponsesSseToAnthropicEvents(encodedChunks([
+      'data: {"type":"response.created","response":{"id":"resp_read"}}\n\n',
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_read","call_id":"call_read","name":"Read","arguments":"","status":"in_progress"}}\n\n',
+      `data: ${JSON.stringify({ type: 'response.function_call_arguments.delta', output_index: 0, item_id: 'fc_read', delta: fullArguments })}\n\n`,
+      `data: ${JSON.stringify({ type: 'response.output_item.done', output_index: 0, item: { type: 'function_call', id: 'fc_read', call_id: 'call_read', name: 'Read', arguments: fullArguments, status: 'completed' } })}\n\n`,
+      'data: {"type":"response.completed","response":{"status":"completed","usage":{"output_tokens":8}}}\n\n',
+    ]), anthropicTarget, [{
+      name: 'Read',
+      input_schema: {
+        type: 'object',
+        properties: {
+          file_path: { type: 'string' },
+          limit: { type: 'number' },
+          offset: { type: 'number' },
+          pages: { type: 'string' },
+        },
+        required: ['file_path'],
+      },
+    }]))
+
+    const starts = events.filter(event => (
+      event.type === 'content_block_start' &&
+      (event.data as any).content_block?.type === 'tool_use'
+    ))
+    const argumentDeltas = events.filter(event => (
+      event.type === 'content_block_delta' &&
+      (event.data as any).delta?.type === 'input_json_delta'
+    ))
+
+    expect(starts).toHaveLength(1)
+    expect(starts[0].data).toMatchObject({
+      content_block: { type: 'tool_use', id: 'call_read', name: 'Read' },
+    })
+    expect(argumentDeltas).toHaveLength(1)
+    expect((argumentDeltas[0].data as any).delta.partial_json).toBe(JSON.stringify({
+      file_path: '/tmp/package.json',
+      limit: 220,
+      offset: 0,
+    }))
+    expect(JSON.stringify(events)).not.toContain('"name":"tool"')
   })
 })

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -1834,6 +1834,104 @@ describe('response stream tool detail events', () => {
 })
 
 describe('Claude Code stream-json mapping', () => {
+  it('uses native stream-json tool events while the Claude child is running', () => {
+    const manager = new CodingAgentRunManager()
+    const emitted: Array<{ event: string; payload: any }> = []
+    ;(manager as any).emitToChat = (_sessionId: string, event: string, payload: any) => {
+      emitted.push({ event, payload })
+    }
+    ;(manager as any).ensureDbSession = () => {}
+    const run = {
+      id: 'agent-session-native-tools',
+      launch: {
+        agentSessionId: 'agent-session-native-tools',
+        agentId: 'claude-code',
+        profile: 'default',
+        provider: 'test',
+        model: 'claude-test',
+        sessionId: 'chat-session-native-tools',
+        command: 'claude',
+        args: [],
+        shellCommand: 'claude',
+        workspaceDir: process.cwd(),
+      },
+      state: { messages: [], isWorking: false, events: [], queue: [] },
+      lastActiveAt: Date.now(),
+      startedAt: Date.now(),
+      exited: false,
+      currentChild: { exitCode: null, signalCode: null, killed: false },
+      printResponseId: 'resp_native_tools',
+      printMessageId: 'msg_resp_native_tools',
+      printToolBlocks: new Map(),
+    }
+    ;(manager as any).runs.set(run.id, run)
+
+    manager.handleResponseEvent(run.id, {
+      type: 'response.output_item.added',
+      data: {
+        item: {
+          type: 'function_call',
+          id: 'call-proxy-web-search',
+          call_id: 'call-proxy-web-search',
+          name: 'web_search',
+          arguments: '{}',
+        },
+      },
+    })
+    manager.handleResponseEvent(run.id, {
+      type: 'response.output_item.done',
+      data: {
+        item: {
+          type: 'function_call_output',
+          id: 'call-proxy-web-search',
+          call_id: 'call-proxy-web-search',
+          output: '',
+        },
+      },
+    })
+
+    ;(manager as any).handleClaudePrintLine(run, JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{
+          type: 'tool_use',
+          id: 'call-native-web-search',
+          name: 'WebSearch',
+          input: { query: 'Xiamen weather' },
+        }],
+      },
+    }))
+    ;(manager as any).handleClaudePrintLine(run, JSON.stringify({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          tool_use_id: 'call-native-web-search',
+          content: 'Sunny',
+        }],
+      },
+    }))
+
+    expect(emitted.filter(event => event.event === 'tool.started').map(event => event.payload)).toEqual([
+      expect.objectContaining({
+        tool_call_id: 'call-native-web-search',
+        tool: 'WebSearch',
+        arguments: '{"query":"Xiamen weather"}',
+      }),
+    ])
+    expect(emitted.filter(event => event.event === 'tool.completed').map(event => event.payload)).toEqual([
+      expect.objectContaining({
+        tool_call_id: 'call-native-web-search',
+        output: 'Sunny',
+      }),
+    ])
+    expect(run.state.messages).not.toContainEqual(expect.objectContaining({
+      tool_calls: [expect.objectContaining({ id: 'call-proxy-web-search' })],
+    }))
+  })
+
   it('maps top-level tool_result messages to tool.completed', () => {
     const manager = new CodingAgentRunManager()
     const emitted: Array<{ event: string; payload: any }> = []
@@ -1887,6 +1985,108 @@ describe('Claude Code stream-json mapping', () => {
         tool_call_id: 'toolu_1',
         output: '/tmp/project',
       }),
+    }))
+  })
+})
+
+describe('Codex JSONL tool mapping', () => {
+  it('keeps proxy text streaming but uses native JSONL for tool events', () => {
+    const manager = new CodingAgentRunManager()
+    const emitted: Array<{ event: string; payload: any }> = []
+    ;(manager as any).emitToChat = (_sessionId: string, event: string, payload: any) => {
+      emitted.push({ event, payload })
+    }
+    ;(manager as any).ensureDbSession = () => {}
+    const run = {
+      id: 'agent-session-codex-native-tools',
+      launch: {
+        agentSessionId: 'agent-session-codex-native-tools',
+        agentId: 'codex',
+        profile: 'default',
+        provider: 'test',
+        model: 'gpt-codex-test',
+        sessionId: 'chat-session-codex-native-tools',
+        command: 'codex',
+        args: [],
+        shellCommand: 'codex',
+        workspaceDir: process.cwd(),
+      },
+      state: { messages: [], isWorking: false, events: [], queue: [] },
+      lastActiveAt: Date.now(),
+      startedAt: Date.now(),
+      exited: false,
+      currentChild: { exitCode: null, signalCode: null, killed: false },
+      printResponseId: 'resp_codex_native_tools',
+      printMessageId: 'msg_resp_codex_native_tools',
+      codexToolBlocks: new Map(),
+      codexChatText: '',
+    }
+    ;(manager as any).runs.set(run.id, run)
+
+    manager.handleResponseEvent(run.id, {
+      type: 'response.output_text.delta',
+      data: { type: 'response.output_text.delta', delta: 'Searching...' },
+    })
+    manager.handleResponseEvent(run.id, {
+      type: 'response.output_item.added',
+      data: {
+        item: {
+          type: 'function_call',
+          id: 'call-proxy-web-search',
+          call_id: 'call-proxy-web-search',
+          name: 'web_search',
+          arguments: '{}',
+        },
+      },
+    })
+    manager.handleResponseEvent(run.id, {
+      type: 'response.output_item.done',
+      data: {
+        item: {
+          type: 'function_call_output',
+          id: 'call-proxy-web-search',
+          call_id: 'call-proxy-web-search',
+          output: '',
+        },
+      },
+    })
+
+    ;(manager as any).handleCodexExecLine(run, JSON.stringify({
+      type: 'item.started',
+      item: {
+        type: 'web_search',
+        id: 'call-native-web-search',
+        query: 'Xiamen weather',
+      },
+    }))
+    ;(manager as any).handleCodexExecLine(run, JSON.stringify({
+      type: 'item.completed',
+      item: {
+        type: 'web_search',
+        id: 'call-native-web-search',
+        query: 'Xiamen weather',
+        output: 'Sunny',
+      },
+    }))
+
+    expect(emitted.filter(event => event.event === 'message.delta').map(event => event.payload.delta)).toEqual([
+      'Searching...',
+    ])
+    expect(emitted.filter(event => event.event === 'tool.started').map(event => event.payload)).toEqual([
+      expect.objectContaining({
+        tool_call_id: 'call-native-web-search',
+        tool: 'Web Search',
+        arguments: '{"query":"Xiamen weather"}',
+      }),
+    ])
+    expect(emitted.filter(event => event.event === 'tool.completed').map(event => event.payload)).toEqual([
+      expect.objectContaining({
+        tool_call_id: 'call-native-web-search',
+        output: 'Sunny',
+      }),
+    ])
+    expect(run.state.messages).not.toContainEqual(expect.objectContaining({
+      tool_calls: [expect.objectContaining({ id: 'call-proxy-web-search' })],
     }))
   })
 })

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -1417,6 +1417,98 @@ describe('coding agent launch preparation', () => {
     expect(sse).toContain('event: message_stop')
   })
 
+  it('returns one normalized Claude tool call when Responses uses separate item and call ids', async () => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: 'fun-codex',
+      model: 'gpt-5.5',
+      baseUrl: 'https://api.apikey.fun/v1',
+      apiKey: 'sk-upstream',
+      apiMode: 'codex_responses',
+    })
+    const fullArguments = JSON.stringify({
+      file_path: '/tmp/package.json',
+      pages: '',
+    })
+    const encoder = new TextEncoder()
+    const frames = [
+      { type: 'response.created', response: { id: 'resp_read', status: 'in_progress' } },
+      {
+        type: 'response.output_item.added',
+        output_index: 0,
+        item: {
+          type: 'function_call',
+          id: 'fc_read',
+          call_id: 'call_read',
+          name: 'Read',
+          arguments: '',
+          status: 'in_progress',
+        },
+      },
+      {
+        type: 'response.function_call_arguments.delta',
+        output_index: 0,
+        item_id: 'fc_read',
+        delta: fullArguments,
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          type: 'function_call',
+          id: 'fc_read',
+          call_id: 'call_read',
+          name: 'Read',
+          arguments: fullArguments,
+          status: 'completed',
+        },
+      },
+      {
+        type: 'response.completed',
+        response: {
+          id: 'resp_read',
+          status: 'completed',
+          usage: { input_tokens: 10, output_tokens: 4, total_tokens: 14 },
+        },
+      },
+    ]
+    const fetchMock = vi.fn(async () => new Response(new ReadableStream({
+      start(controller) {
+        for (const frame of frames) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(frame)}\n\n`))
+        }
+        controller.close()
+      },
+    }), { status: 200, headers: { 'Content-Type': 'text/event-stream' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, {
+      stream: true,
+      messages: [{ role: 'user', content: 'read package.json' }],
+      tools: [{
+        name: 'Read',
+        input_schema: {
+          type: 'object',
+          properties: {
+            file_path: { type: 'string' },
+            pages: { type: 'string' },
+          },
+          required: ['file_path'],
+        },
+      }],
+    })
+
+    await claudeProxyMessages(ctx)
+
+    const chunks: string[] = []
+    for await (const chunk of ctx.body) chunks.push(String(chunk))
+    const sse = chunks.join('')
+    expect(sse.match(/"type":"tool_use"/g)).toHaveLength(1)
+    expect(sse).toContain('"id":"call_read","name":"Read"')
+    expect(sse).toContain('partial_json":"{\\"file_path\\":\\"/tmp/package.json\\"}"')
+    expect(sse).not.toContain('"name":"tool"')
+    expect(sse).not.toContain('pages')
+  })
+
   it('round-trips reasoning_content for DeepSeek-style OpenAI Chat tool calls', async () => {
     const target = registerClaudeCodeProxyTarget({
       provider: 'deepseek',

--- a/tests/server/group-chat-agent-workspace.test.ts
+++ b/tests/server/group-chat-agent-workspace.test.ts
@@ -200,10 +200,11 @@ describe('group chat agent workspace bridge runs', () => {
         name: 'read_file',
         arguments: { path: '/tmp/file.txt' },
       })
-      options.onEvent?.('tool.completed', {
+      options.onEvent?.('tool.failed', {
         tool_call_id: 'tool-2',
         name: 'read_file',
-        output: 'contents',
+        output: 'permission denied',
+        error: 'permission denied',
       })
       options.onEvent?.('message.delta', { delta: 'Codex answer' })
       return { ok: true, output: 'Codex answer', reasoning: 'thinkingnext thought' }
@@ -298,6 +299,18 @@ describe('group chat agent workspace bridge runs', () => {
         roomId: 'room-1',
         content: 'Codex answer',
         reasoning: null,
+      }),
+      expect.any(Function),
+    )
+    expect(mockSocket.emit).toHaveBeenCalledWith(
+      'message',
+      expect.objectContaining({
+        roomId: 'room-1',
+        role: 'tool',
+        tool_call_id: 'tool-2',
+        tool_name: 'read_file',
+        content: 'permission denied',
+        finish_reason: 'error',
       }),
       expect.any(Function),
     )


### PR DESCRIPTION
## Summary

- Use Claude Code stream-json and Codex JSONL as the authoritative tool lifecycle sources in group chat while retaining responsive proxy text deltas.
- Persist failed tool results with an error finish reason so the client renders them as failed instead of completed.
- Unify Responses call_id, item_id, and output_index into one Anthropic tool block.
- Normalize optional empty/null Responses arguments against the original Anthropic tool schema, preventing Read calls with an empty pages value.

## Root cause

Group Coding Agent runs could consume both native CLI events and proxy Responses events for the same tool call. Those streams use different identifiers, and Responses argument deltas can identify an item by item_id while the completed call uses call_id. The bridge therefore created duplicate tool cards, including a phantom tool with no matching result. Responses-compatible models could also materialize omitted optional arguments as empty strings or null, which Claude Code then rejected during tool validation.

## Impact

Claude Code and Codex group-chat tools now have one stable lifecycle, failed calls retain their error state, and Responses-backed Claude tools no longer receive unused optional empty parameters. This removes duplicate or indefinitely loading tool cards caused by the protocol mismatch.

## Validation

- npm run harness:check
- npm run test — 3415 passed, 3 skipped
- npm run test:e2e -- tests/e2e/group-chat-room-deeplink.spec.ts tests/e2e/chat-streaming.spec.ts — 27 passed
- npm run build
- git diff --check