### PR TITLE
fix(coding-agent): coalesce streamed tool start events

### DIFF
--- a/docs/chat-chain-changes/2026-08-06-coding-agent-tool-start-coalescing.md
+++ b/docs/chat-chain-changes/2026-08-06-coding-agent-tool-start-coalescing.md
@@ -1,0 +1,18 @@
+---
+date: 2026-08-06
+pr: pending
+feature: Coding Agent tool start event coalescing
+impact: Streaming Coding Agent tool arguments are buffered server-side and produce one tool.started event with complete arguments, preventing per-delta Group Chat persistence and Socket acknowledgements while preserving immediate starts for native events that already contain complete arguments.
+---
+
+Coding Agent Responses streams no longer translate every
+`response.function_call_arguments.delta` into another client-facing
+`tool.started` event. The deltas still update the in-memory function call so the
+complete arguments remain available for message persistence and tool result
+association.
+
+When `response.output_item.added` has empty arguments, the tool start is emitted
+once from `response.output_item.done` with the completed argument object. Native
+Claude Code and Codex events that already provide complete arguments continue
+to emit one start immediately. Tool completion, failure, duration, and stored
+assistant/tool messages are unchanged.

--- a/packages/server/src/services/hermes/run-chat/response-stream.ts
+++ b/packages/server/src/services/hermes/run-chat/response-stream.ts
@@ -235,7 +235,16 @@ export function applyResponseStreamEvent(
     if (!callId) return null
     captureToolBoundaryReasoning(state, run, callId)
     const toolCall = responseFunctionCallToToolCall(item)
-    run.toolCalls.set(callId, { ...toolCall, startedAt: Date.now() })
+    const existing = run.toolCalls.get(callId)
+    const rawArguments = item.arguments ?? item.function?.arguments
+    const hasCompleteArguments = rawArguments != null &&
+      (typeof rawArguments !== 'string' || !['', '{}'].includes(rawArguments.trim()))
+    const startedAt = existing?.startedAt ?? (hasCompleteArguments ? Date.now() : undefined)
+    run.toolCalls.set(callId, {
+      ...toolCall,
+      ...(startedAt != null ? { startedAt } : {}),
+    })
+    if (!hasCompleteArguments || existing?.startedAt != null) return null
     return {
       event: 'tool.started',
       payload: {
@@ -268,19 +277,7 @@ export function applyResponseStreamEvent(
       },
     }
     run.toolCalls.set(callId, nextToolCall)
-    return {
-      event: 'tool.started',
-      payload: {
-        event: 'tool.started',
-        run_id: run.responseId,
-        response_id: run.responseId,
-        tool_call_id: callId,
-        tool: nextToolCall.function.name,
-        name: nextToolCall.function.name,
-        arguments: nextToolCall.function.arguments,
-        preview: summarizeToolArguments(nextToolCall.function.arguments),
-      },
-    }
+    return null
   }
 
   if (eventType === 'response.output_item.done') {
@@ -290,7 +287,7 @@ export function applyResponseStreamEvent(
       if (!callId) return null
       const toolCall = responseFunctionCallToToolCall(item)
       const existing = run.toolCalls.get(callId)
-      run.toolCalls.set(callId, { ...toolCall, startedAt: existing?.startedAt || Date.now() })
+      run.toolCalls.set(callId, { ...toolCall, startedAt: existing?.startedAt ?? Date.now() })
       const toolReasoning = captureToolBoundaryReasoning(state, run, callId)
 
       const key = `assistant:${callId}`
@@ -318,7 +315,20 @@ export function applyResponseStreamEvent(
           toolCallMessage.reasoning_content = toolReasoning
         }
       }
-      return null
+      if (existing?.startedAt != null) return null
+      return {
+        event: 'tool.started',
+        payload: {
+          event: 'tool.started',
+          run_id: run.responseId,
+          response_id: run.responseId,
+          tool_call_id: callId,
+          tool: toolCall.function.name,
+          name: toolCall.function.name,
+          arguments: toolCall.function.arguments,
+          preview: summarizeToolArguments(toolCall.function.arguments),
+        },
+      }
     }
 
     if (item.type === 'function_call_output') {

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -1727,13 +1727,13 @@ describe('coding agent chat event mapper', () => {
 })
 
 describe('response stream tool detail events', () => {
-  it('emits updated tool.started payloads as function-call arguments stream in', () => {
+  it('buffers function-call argument deltas and emits tool.started once arguments are complete', () => {
     const state: any = { messages: [], isWorking: false, events: [], queue: [] }
     applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.created', {
       response: { id: 'resp-1', status: 'in_progress' },
     })
     const started = applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_item.added', {
-      item: { type: 'function_call', call_id: 'call-1', name: 'Bash', arguments: '' },
+      item: { type: 'function_call', call_id: 'call-1', name: 'Bash', arguments: '{}' },
     })
     const withCommand = applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.function_call_arguments.delta', {
       item_id: 'call-1',
@@ -1743,26 +1743,48 @@ describe('response stream tool detail events', () => {
       item_id: 'call-1',
       delta: '}',
     })
+    const completedArguments = applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_item.done', {
+      item: { type: 'function_call', call_id: 'call-1', name: 'Bash', arguments: '{"command":"pwd"}' },
+    })
+    const duplicateDone = applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_item.done', {
+      item: { type: 'function_call', call_id: 'call-1', name: 'Bash', arguments: '{"command":"pwd"}' },
+    })
+
+    expect(started).toBeNull()
+    expect(withCommand).toBeNull()
+    expect(withFinalArgs).toBeNull()
+    expect(completedArguments).toEqual(expect.objectContaining({
+      event: 'tool.started',
+      payload: expect.objectContaining({
+        tool_call_id: 'call-1',
+        tool: 'Bash',
+        arguments: '{"command":"pwd"}',
+      }),
+    }))
+    expect(duplicateDone).toBeNull()
+  })
+
+  it('emits tool.started immediately when an added function call already has complete arguments', () => {
+    const state: any = { messages: [], isWorking: false, events: [], queue: [] }
+    applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.created', {
+      response: { id: 'resp-1', status: 'in_progress' },
+    })
+    const started = applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_item.added', {
+      item: { type: 'function_call', call_id: 'call-1', name: 'Bash', arguments: '{"command":"pwd"}' },
+    })
+    const done = applyResponseStreamEvent(state, 'session-1', 'run-1', 'response.output_item.done', {
+      item: { type: 'function_call', call_id: 'call-1', name: 'Bash', arguments: '{"command":"pwd"}' },
+    })
 
     expect(started).toEqual(expect.objectContaining({
       event: 'tool.started',
       payload: expect.objectContaining({
         tool_call_id: 'call-1',
         tool: 'Bash',
-      }),
-    }))
-    expect(withCommand).toEqual(expect.objectContaining({
-      event: 'tool.started',
-      payload: expect.objectContaining({
-        arguments: '{"command":"pwd"',
-      }),
-    }))
-    expect(withFinalArgs).toEqual(expect.objectContaining({
-      event: 'tool.started',
-      payload: expect.objectContaining({
         arguments: '{"command":"pwd"}',
       }),
     }))
+    expect(done).toBeNull()
   })
 
   it('emits completed tool events with duration', () => {


### PR DESCRIPTION
## Summary

- buffer `response.function_call_arguments.delta` updates without emitting repeated `tool.started` events
- emit one `tool.started` with complete arguments at the function-call completion boundary
- preserve immediate starts for native Claude Code and Codex events that already contain complete arguments
- add regression coverage for streamed arguments, duplicate completion boundaries, and already-complete calls

## Root cause

Coding Agent translated every function-call argument delta into another client-facing `tool.started` event. Single chat repeatedly updated the same tool card, while Group Chat serialized every update through message persistence, context refresh, Socket broadcasts, and ACKs. Large room histories amplified that work and made tool JSON appear one character at a time.

## Impact

Single chat and Group Chat now receive one start event per Coding Agent tool call. Group Chat avoids per-delta database transactions and Socket acknowledgements. Tool result association, persisted assistant/tool messages, reasoning boundaries, completion/failure events, and native complete-argument starts remain intact.

Tool duration for streamed calls now starts when arguments are complete, so it measures execution rather than including model argument-generation time. Hermes Agent, Ekko Agent, and the raw Responses/Anthropic adapter streams are unchanged.

## Validation

- `npm test -- --reporter=dot`
- `npx vitest run tests/server/agent-runner-utils.test.ts tests/server/response-stream-reasoning-storage.test.ts tests/server/group-chat-agent-workspace.test.ts tests/server/group-chat-history-window.test.ts`
- `npm run harness:check`
- `git diff --check`
