### PR TITLE
fix: reconcile Codex native terminal state

### DIFF
--- a/docs/architecture/codex-native-terminal-reconciliation.md
+++ b/docs/architecture/codex-native-terminal-reconciliation.md
@@ -87,7 +87,10 @@ Codex 原生进程运行期间：
 
 - 代理层 `response.completed`：只采集 usage，不裁决整个 Run；
 - 代理层 `response.failed`：不裁决整个 Run；
+- Codex 原生 JSONL `turn.failed` / `error`：必须立即保留为权威失败；
 - 最终成功或失败由 Codex 原生 JSONL 和子进程退出状态决定。
+
+代码通过 `acceptingPrintEvent` 区分事件来源：原生 JSONL 事件由 `handleClaudePrintResponseEvent()` 包装，处理期间该标志为 `true`；Provider Proxy 事件则为 `false`。`response.completed` 无论来源都需等待活跃 Codex 子进程退出，以免提前刷出工具边界；只有 `response.failed` 需要按来源区分。
 
 Claude Code 和没有活跃原生 Codex 子进程的路径保持原语义。
 
@@ -112,36 +115,36 @@ if (
 
 ## TDD 证据
 
-新增回归测试模拟：
+新增双向回归测试：
 
-1. Codex 原生子进程仍在运行；
-2. Provider Proxy 发出 `response.failed`，错误为缺少 `response.completed`；
-3. 断言代理失败不得设置 `terminalEventHandled`；
-4. 断言不得缓存 `pendingChatCompletionEvent='run.failed'`；
-5. 断言不得提前发出群聊 `run.failed`。
+1. **Proxy 可恢复断流**：Codex 原生子进程仍在运行时，Provider Proxy 发出 `response.failed`；断言不得设置 `terminalEventHandled`、不得缓存 `pendingChatCompletionEvent='run.failed'`、不得提前发出群聊 `run.failed`。
+2. **原生失败**：Codex 原生 JSONL 在 child 仍运行时发出 `turn.failed`；断言必须设置 `terminalEventHandled`、缓存 `run.failed`，并保留原生错误。
+3. **完成时序回归**：`response.completed` 在 child 仍运行时不得提前刷出工具消息或 `run.completed`，继续等待进程退出。
 
 ### RED
 
-修复前测试按预期失败：
+第一条修复前测试按预期失败：
 
 ```text
 expected true not to be true
 run.terminalEventHandled === true
 ```
 
-### GREEN
-
-最小修复后：
+独立复审发现最初修复会吞掉原生失败后，第二条测试也按预期失败：
 
 ```text
-1 passed
+expected undefined to be true
+run.terminalEventHandled === undefined
 ```
 
-相关回归：
+### GREEN
+
+按事件来源收紧仲裁后：
 
 ```text
-agent-runner-utils.test.ts: 51 passed
-agent-runner-utils.test.ts + coding-agents-launch.test.ts: 89 passed
+双向与完成时序定向测试：3 passed
+agent-runner-utils.test.ts: 52 passed
+agent-runner-utils.test.ts + coding-agents-launch.test.ts: 90 passed
 ```
 
 ## 验收要求

--- a/docs/architecture/codex-native-terminal-reconciliation.md
+++ b/docs/architecture/codex-native-terminal-reconciliation.md
@@ -1,0 +1,163 @@
+# Codex 原生成功被代理流失败误判：根因与修复
+
+## 结论
+
+当 Hermes Studio 以 Codex Coding Agent 运行任务时，Codex CLI 子进程和 Studio Provider Proxy 会同时观察同一次模型调用：
+
+- Codex CLI 的 JSONL/进程退出是 Coding Agent Run 的原生执行终态；
+- Provider Proxy 的 Responses 事件用于流式文本、工具展示和 usage 采集。
+
+故障发生在代理流短暂断开但 Codex CLI 自己成功重连并完成任务时。旧实现只在 Codex 子进程仍运行时忽略代理层 `response.completed`，却接受代理层 `response.failed`，把它缓存为整个 Run 的 `run.failed`。随后 Codex CLI 已生成最终消息并以退出码 `0` 结束，但子进程退出处理优先提交先前缓存的失败，导致群聊只持久化错误而没有持久化真实最终回复。
+
+## 用户可见现象
+
+群聊出现：
+
+```text
+Error: Reconnecting... 1/5
+(stream disconnected before completion: stream closed before response.completed)
+```
+
+与此同时，Coding Agent 可能已经完成代码修改、测试、提交和推送，并在 Codex rollout 中生成完整最终回复。
+
+## 现场证据
+
+受影响 Run 的时间线：
+
+| UTC 时间 | 证据 | 含义 |
+|---|---|---|
+| 01:45:46.000 | Codex rollout `agent_message` | 完整最终回复已生成 |
+| 01:45:46.074 | Codex rollout `task_complete`，`duration_ms=775683` | Codex 原生任务完成 |
+| 01:45:55.305 | 群聊 `gc_messages` 写入 `finish_reason=error` | Studio 约 9 秒后将代理流失败作为 Run 终态 |
+
+同一时间窗口内：
+
+- Studio 容器健康，未重启，未 OOM；
+- Room API 返回 `200`；
+- Socket.IO WebSocket upgrade 返回 `101`；
+- 未发现对应的 Nginx `499/500/502/504`。
+
+因此，现有证据支持“应用层终态仲裁错误”，不支持“容器重启、OOM 或反向代理中断导致任务未执行”。代理流最初为什么关闭仍不能仅凭这些证据精确归责到具体上游组件，但这不影响确认 Studio 的误判机制。
+
+## 根因代码路径
+
+`CodingAgentRunManager.handleResponseEvent()` 将以下事件视为 terminal event：
+
+```ts
+response.completed
+response.failed
+```
+
+旧逻辑在 Codex 子进程仍运行时仅特殊处理 `response.completed`：
+
+```ts
+if (
+  run.launch.agentId === 'codex' &&
+  storageSafeResponseEvent.type === 'response.completed' &&
+  childIsRunning(run.currentChild)
+) {
+  // 只保存 usage
+  return
+}
+```
+
+因此 `response.failed` 会继续执行：
+
+1. 设置 `terminalEventHandled=true`；
+2. 刷新并落库代理层错误响应；
+3. 设置 `pendingChatCompletionEvent='run.failed'`。
+
+Codex 子进程退出时，退出处理先检查 `pendingChatCompletionEvent`：
+
+```ts
+if (run.pendingChatCompletionEvent) {
+  this.emitAndMarkPrintChatRunCompleted(...)
+  return
+}
+if (code === 0) {
+  this.completeCodexExecTurn(...)
+}
+```
+
+所以旧的代理失败优先于退出码 `0`，原生成功无法成为最终 Run 状态。
+
+## 修复原则
+
+Codex 原生进程运行期间：
+
+- 代理层 `response.completed`：只采集 usage，不裁决整个 Run；
+- 代理层 `response.failed`：不裁决整个 Run；
+- 最终成功或失败由 Codex 原生 JSONL 和子进程退出状态决定。
+
+Claude Code 和没有活跃原生 Codex 子进程的路径保持原语义。
+
+## 最小修复
+
+将 Codex 运行期间的判断扩展到所有代理 terminal event：
+
+```ts
+if (
+  run.launch.agentId === 'codex' &&
+  isTerminalEvent &&
+  childIsRunning(run.currentChild)
+) {
+  if (storageSafeResponseEvent.type === 'response.completed') {
+    // 保留 usage
+  }
+  return
+}
+```
+
+这不是把真实失败改成成功。若 Codex 无法恢复，原生进程会以非零退出码或原生失败事件结束，现有退出处理仍会产生 `run.failed`。
+
+## TDD 证据
+
+新增回归测试模拟：
+
+1. Codex 原生子进程仍在运行；
+2. Provider Proxy 发出 `response.failed`，错误为缺少 `response.completed`；
+3. 断言代理失败不得设置 `terminalEventHandled`；
+4. 断言不得缓存 `pendingChatCompletionEvent='run.failed'`；
+5. 断言不得提前发出群聊 `run.failed`。
+
+### RED
+
+修复前测试按预期失败：
+
+```text
+expected true not to be true
+run.terminalEventHandled === true
+```
+
+### GREEN
+
+最小修复后：
+
+```text
+1 passed
+```
+
+相关回归：
+
+```text
+agent-runner-utils.test.ts: 51 passed
+agent-runner-utils.test.ts + coding-agents-launch.test.ts: 89 passed
+```
+
+## 验收要求
+
+自动化测试通过后，还需在包含本修复的独立部署中执行真实运行时验收：
+
+1. 启动 Codex Coding Agent Run；
+2. 让代理层出现可恢复的 stream retry/failure；
+3. 确认 Codex 原生任务最终成功；
+4. 确认群聊最终持久化完整回复且 `finish_reason` 不是 `error`；
+5. 再验证不可恢复失败仍产生 `run.failed`；
+6. 回读 Run、消息、Session `end_reason` 与 workspace/Git 副作用，避免只看 UI 状态。
+
+## 边界与未决事项
+
+- 本修复解决 Studio 对双终态来源的错误仲裁。
+- 本修复不声称消除 Provider 网络或上游 stream 断开。
+- 首次 stream 关闭的最底层归属目前仍是 unknown；需要 Provider/AxonHub 与 Codex 请求级日志才能进一步精确定位。
+- 在修复版本部署并完成真实断流验收前，生产环境只能判定“代码级修复和自动化回归通过”，不能宣称运行时问题已完全闭环。

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -679,11 +679,13 @@ export class CodingAgentRunManager {
     const isTerminalEvent = storageSafeResponseEvent.type === 'response.completed' || storageSafeResponseEvent.type === 'response.failed'
     if (
       run.launch.agentId === 'codex' &&
-      storageSafeResponseEvent.type === 'response.completed' &&
+      isTerminalEvent &&
       childIsRunning(run.currentChild)
     ) {
-      const final = (storageSafeResponseEvent.data as any).response || storageSafeResponseEvent.data
-      run.codexPendingUsage = final?.usage ?? run.codexPendingUsage
+      if (storageSafeResponseEvent.type === 'response.completed') {
+        const final = (storageSafeResponseEvent.data as any).response || storageSafeResponseEvent.data
+        run.codexPendingUsage = final?.usage ?? run.codexPendingUsage
+      }
       return
     }
     if (isTerminalEvent) {

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -677,9 +677,11 @@ export class CodingAgentRunManager {
       run.responseStartEmitted = true
     }
     const isTerminalEvent = storageSafeResponseEvent.type === 'response.completed' || storageSafeResponseEvent.type === 'response.failed'
+    const deferCodexProxyTerminal = storageSafeResponseEvent.type === 'response.completed' ||
+      (storageSafeResponseEvent.type === 'response.failed' && !run.acceptingPrintEvent)
     if (
       run.launch.agentId === 'codex' &&
-      isTerminalEvent &&
+      deferCodexProxyTerminal &&
       childIsRunning(run.currentChild)
     ) {
       if (storageSafeResponseEvent.type === 'response.completed') {

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -442,6 +442,52 @@ describe('coding agent run state', () => {
     manager.shutdown()
   })
 
+  it('ignores proxy terminal failures while a native Codex process is still running', () => {
+    initAllHermesTables()
+    const manager = new CodingAgentRunManager()
+    const state: any = { messages: [], isWorking: true, events: [], queue: [] }
+    const emitted = vi.fn()
+    ;(manager as any).ensureDbSession = () => {}
+    ;(manager as any).emitToChat = emitted
+    ;(manager as any).refreshCodingAgentUsage = async () => {}
+
+    manager.start({
+      agentSessionId: 'agent-session-codex-retry',
+      agentId: 'codex',
+      mode: 'scoped',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'test-model',
+      sessionId: 'chat-session-codex-retry',
+      command: 'codex',
+      args: [],
+      shellCommand: 'codex',
+      workspaceDir: process.cwd(),
+      state,
+    })
+    const run = (manager as any).runs.get('agent-session-codex-retry')
+    run.currentChild = { exitCode: null, signalCode: null, killed: false }
+
+    manager.handleResponseEvent('agent-session-codex-retry', {
+      type: 'response.failed',
+      data: {
+        response: {
+          id: 'provider-attempt-1',
+          status: 'failed',
+          error: {
+            message: 'Reconnecting... 1/5 (stream disconnected before completion: stream closed before response.completed)',
+          },
+          output: [],
+        },
+      },
+    })
+
+    expect(run.terminalEventHandled).not.toBe(true)
+    expect(run.pendingChatCompletionEvent).toBeUndefined()
+    expect(emitted).not.toHaveBeenCalledWith('chat-session-codex-retry', 'run.failed', expect.anything())
+    manager.shutdown()
+  })
+
   it('clears shared chat session run state when a print turn completes', async () => {
     initAllHermesTables()
     const manager = new CodingAgentRunManager()

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -488,6 +488,45 @@ describe('coding agent run state', () => {
     manager.shutdown()
   })
 
+  it('keeps native Codex turn failures authoritative while the child is still running', () => {
+    initAllHermesTables()
+    const manager = new CodingAgentRunManager()
+    const state: any = { messages: [], isWorking: true, events: [], queue: [] }
+    const emitted = vi.fn()
+    ;(manager as any).ensureDbSession = () => {}
+    ;(manager as any).emitToChat = emitted
+    ;(manager as any).refreshCodingAgentUsage = async () => {}
+
+    manager.start({
+      agentSessionId: 'agent-session-codex-native-failure',
+      agentId: 'codex',
+      mode: 'scoped',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'test-model',
+      sessionId: 'chat-session-codex-native-failure',
+      command: 'codex',
+      args: [],
+      shellCommand: 'codex',
+      workspaceDir: process.cwd(),
+      state,
+    })
+    const run = (manager as any).runs.get('agent-session-codex-native-failure')
+    run.currentChild = { exitCode: null, signalCode: null, killed: false }
+
+    ;(manager as any).handleCodexExecLine(run, JSON.stringify({
+      type: 'turn.failed',
+      error: { message: 'native Codex failure' },
+    }))
+
+    expect(run.terminalEventHandled).toBe(true)
+    expect(run.pendingChatCompletionEvent).toBe('run.failed')
+    expect(run.pendingChatCompletionPayload).toEqual(expect.objectContaining({
+      error: 'native Codex failure',
+    }))
+    manager.shutdown()
+  })
+
   it('clears shared chat session run state when a print turn completes', async () => {
     initAllHermesTables()
     const manager = new CodingAgentRunManager()


### PR DESCRIPTION
## Summary

- make native Codex JSONL/process exit authoritative for run terminal state while its child process is active
- ignore proxy `response.failed` during an active native Codex run while retaining usage from `response.completed`
- preserve native Codex `turn.failed` / `error` through source-aware terminal arbitration
- add RED→GREEN regressions for both recoverable proxy disconnects and authoritative native failures
- document evidence, root cause, fix boundary, and deployed-runtime acceptance criteria

## Root Cause

The existing handler deferred proxy `response.completed` while the native Codex child was running, but accepted proxy `response.failed`. That failure set `terminalEventHandled` and cached `run.failed`. The child exit handler then emitted the cached failure before checking Codex's successful exit code.

The corrected implementation distinguishes event provenance through `acceptingPrintEvent`: proxy failures are ignored while the child remains active, but native JSONL `turn.failed` / `error` remains authoritative. Completion still waits for child exit to preserve tool/final-message ordering.

## Verification

- RED 1: proxy disconnect regression failed because `run.terminalEventHandled === true`
- RED 2: first fix was rejected because native failure regression observed `terminalEventHandled === undefined`
- GREEN: source-aware bidirectional tests passed
- focused arbitration/order tests: 3 passed
- `agent-runner-utils.test.ts`: 52 passed
- relevant adapter/launch suites: 90 passed
- `npm run build`: passed
- `git diff --check`: passed
- exact-head CI: Build and Playwright E2E passed

## Runtime Acceptance Boundary

This PR has automated, build, and CI evidence. It still requires an independent deployed-runtime test after merge/deployment that observes or injects a recoverable stream disconnect and verifies the persisted group-chat final message, Session `end_reason`, and native Codex result. An unrecoverable native Codex failure must still produce `run.failed`.

Fixes #2374
