### PR TITLE
fix(codex): preserve user top-level TOML sections when rebuilding codex config.toml

### DIFF
--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -960,7 +960,7 @@ function claudeMcpConfigJson(profile: string, ...existingContents: Array<string 
   return `${JSON.stringify({ mcpServers }, null, 2)}\n`
 }
 
-function parseCodexExternalMcpBlocks(...contents: Array<string | null | undefined>): string[] {
+export function parseCodexExternalMcpBlocks(...contents: Array<string | null | undefined>): string[] {
   const blockByServer = new Map<string, string>()
 
   for (const content of contents) {
@@ -1004,8 +1004,63 @@ function parseCodexExternalMcpBlocks(...contents: Array<string | null | undefine
   return Array.from(blockByServer.values()).filter(Boolean)
 }
 
-function codexMcpConfigToml(profile: string, ...externalContents: Array<string | null | undefined>): string {
-  const blocks: string[] = [...parseCodexExternalMcpBlocks(...externalContents)]
+/**
+ * 保留 codex config.toml 中用户自定义的顶层 TOML 段（[features] 等），
+ * 排除由 hermes-web-ui 管理的段：
+ * - `mcp_servers.*` —— 外部段由 parseCodexExternalMcpBlocks 处理，hermes-studio-*
+ *   段由 codexMcpConfigToml 重新生成；
+ * - `model_providers.*` —— 每次启动由 hermes-web-ui 依据当前 provider 重建，
+ *   用户 config 中的陈旧 provider 段不应混入。
+ *
+ * hermes-web-ui 每次启动 Codex 会话都会重建 config.toml。若只保留
+ * `[mcp_servers.*]` 段，用户写入的 `[features]`（例如 `apps = false`，
+ * 用于禁用 codex_apps 内置 MCP，规避 openai/codex#29396）会在下次
+ * 启动时被静默丢弃，导致 Codex 每次新会话重新出现 30s 启动超时警告。
+ */
+export function parseCodexExternalTomlBlocks(...contents: Array<string | null | undefined>): string[] {
+  const blocks: string[] = []
+
+  for (const content of contents) {
+    if (!content?.trim()) continue
+    let currentHeader = ''
+    let currentLines: string[] = []
+    const flush = () => {
+      if (!currentHeader || currentLines.length === 0) return
+      const block = currentLines.join('\n').trim()
+      const topLevel = currentHeader.split('.')[0]
+      // mcp_servers.* 由 parseCodexExternalMcpBlocks / codexMcpConfigToml 处理
+      // model_providers.* 由 hermes-web-ui 依据当前 provider 重建，不继承
+      if (topLevel === 'mcp_servers' || topLevel === 'model_providers') {
+        currentHeader = ''
+        currentLines = []
+        return
+      }
+      blocks.push(block)
+      currentHeader = ''
+      currentLines = []
+    }
+
+    for (const line of content.split(/\r?\n/)) {
+      const headerMatch = line.match(/^\s*\[([^\]]+)\]\s*$/)
+      if (headerMatch) {
+        flush()
+        currentHeader = headerMatch[1].trim()
+        currentLines = [line]
+        continue
+      }
+      if (currentHeader) currentLines.push(line)
+    }
+    flush()
+  }
+
+  return blocks
+}
+
+export function codexMcpConfigToml(profile: string, ...externalContents: Array<string | null | undefined>): string {
+  const blocks: string[] = [
+    ...parseCodexExternalMcpBlocks(...externalContents),
+    ...parseCodexExternalTomlBlocks(...externalContents),
+  ]
   for (const item of HERMES_MCP_SERVERS) {
     const server = hermesMcpServerConfig(profile, item.name, item.toolset)
     const lines = [

--- a/tests/server/coding-agents-codex-config.test.ts
+++ b/tests/server/coding-agents-codex-config.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import {
+  codexMcpConfigToml,
+  parseCodexExternalMcpBlocks,
+  parseCodexExternalTomlBlocks,
+} from '../../packages/server/src/services/coding-agents'
+
+// 模拟 hermes-web-ui 管理生成的 MCP 段（含 HERMES_WEB_UI_MANAGED_MCP 标记）
+const MANAGED_HERMES_BLOCK = `[mcp_servers.hermes-studio-api]
+command = "/usr/local/bin/node"
+args = ["/home/i1j/.npm-global/lib/node_modules/hermes-web-ui/bin/hermes-studio-mcp.mjs", "api"]
+startup_timeout_sec = 120
+env = { HERMES_WEB_UI_MANAGED_MCP = "1" }`
+
+// 用户自定义的 features 段（codex_apps 修复：openai/codex#29396）
+const USER_FEATURES_BLOCK = `[features]
+apps = false`
+
+// 用户自定义的外部 MCP server
+const USER_EXTERNAL_MCP_BLOCK = `[mcp_servers.my-tools]
+command = "/usr/local/bin/my-mcp"
+startup_timeout_sec = 60`
+
+describe('parseCodexExternalMcpBlocks', () => {
+  it('保留用户配置的外部 MCP server 段', () => {
+    const blocks = parseCodexExternalMcpBlocks(USER_EXTERNAL_MCP_BLOCK)
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toContain('[mcp_servers.my-tools]')
+    expect(blocks[0]).toContain('startup_timeout_sec = 60')
+  })
+
+  it('过滤 hermes-web-ui 管理的 MCP 段（含 MANAGED 标记）', () => {
+    const blocks = parseCodexExternalMcpBlocks(MANAGED_HERMES_BLOCK)
+    expect(blocks).toHaveLength(0)
+  })
+
+  it('空输入返回空数组', () => {
+    expect(parseCodexExternalMcpBlocks('', null, undefined)).toEqual([])
+  })
+})
+
+describe('parseCodexExternalTomlBlocks', () => {
+  it('保留用户自定义的 [features] 段（codex_apps 修复核心）', () => {
+    const blocks = parseCodexExternalTomlBlocks(USER_FEATURES_BLOCK)
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toContain('[features]')
+    expect(blocks[0]).toContain('apps = false')
+  })
+
+  it('不重复收集外部 MCP server 段（由 parseCodexExternalMcpBlocks 处理）', () => {
+    const blocks = parseCodexExternalTomlBlocks(USER_EXTERNAL_MCP_BLOCK)
+    expect(blocks).toHaveLength(0)
+  })
+
+  it('不收集 hermes-studio-* 管理段', () => {
+    const blocks = parseCodexExternalTomlBlocks(MANAGED_HERMES_BLOCK)
+    expect(blocks).toHaveLength(0)
+  })
+
+  it('排除 model_providers.* 段（由 hermes-web-ui 依据当前 provider 重建）', () => {
+    const input = `[model_providers.unrelated]
+name = "should-not-be-copied"
+
+[features]
+apps = false`
+    const blocks = parseCodexExternalTomlBlocks(input)
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toContain('[features]')
+    expect(blocks[0]).not.toContain('model_providers')
+  })
+
+  it('保留多个独立顶层段', () => {
+    const input = `${USER_FEATURES_BLOCK}
+
+[projects."/tmp/workspace"]
+trust_level = "trusted"`
+    const blocks = parseCodexExternalTomlBlocks(input)
+    expect(blocks).toHaveLength(2)
+  })
+
+  it('空输入返回空数组', () => {
+    expect(parseCodexExternalTomlBlocks('', null, undefined)).toEqual([])
+  })
+})
+
+describe('codexMcpConfigToml', () => {
+  it('生成的 config 同时包含用户 [features] 段与 4 个 hermes MCP 段', () => {
+    const toml = codexMcpConfigToml(
+      'tester',
+      `${USER_FEATURES_BLOCK}\n\n${MANAGED_HERMES_BLOCK}\n\n${USER_EXTERNAL_MCP_BLOCK}`,
+    )
+    // 用户 features 保留
+    expect(toml).toContain('[features]')
+    expect(toml).toContain('apps = false')
+    // 外部 MCP 保留
+    expect(toml).toContain('[mcp_servers.my-tools]')
+    // 4 个 hermes MCP 段各出现一次（不重复）
+    for (const name of ['hermes-studio-api', 'hermes-studio-browser', 'hermes-studio-devices', 'hermes-studio-use']) {
+      const occurrences = toml.split(`[mcp_servers.${name}]`).length - 1
+      expect(occurrences).toBe(1)
+    }
+    // 不含 managed 标记的旧 hermes 段（由新段替代）
+    expect(toml).not.toContain('[mcp_servers.hermes-studio]')
+  })
+
+  it('无外部内容时仅输出 4 个 hermes MCP 段', () => {
+    const toml = codexMcpConfigToml('tester', '')
+    for (const name of ['hermes-studio-api', 'hermes-studio-browser', 'hermes-studio-devices', 'hermes-studio-use']) {
+      expect(toml).toContain(`[mcp_servers.${name}]`)
+    }
+  })
+})


### PR DESCRIPTION
## 问题

hermes-web-ui 每次启动 Codex 会话都会完全重建 `CODEX_HOME/config.toml`，重建逻辑只保留用户已有的 `[mcp_servers.*]` 段（`parseCodexExternalMcpBlocks`），其他用户自定义顶层 TOML 段（如 `[features]`）被静默丢弃。

这导致实际问题无法根治：Codex 内置 host-owned MCP server `codex_apps`（由 feature `apps` 默认启用）在 custom provider + bearer token 环境下被激活并尝试连接 `chatgpt.com`（受限网络不可达），每次启动出现 30s 超时警告。官方建议的 `[mcp_servers.codex_apps] startup_timeout_sec` 是误导（openai/codex#29396：加段导致 invalid transport、config 加载失败）。唯一有效 workaround 是 `[features] apps = false`，但重建时被丢弃，警告在每次新会话重现。

详见 issue #2379。

## 修复

新增 `parseCodexExternalTomlBlocks()`，重建时保留用户自定义顶层段，同时排除 hermes-web-ui 管理的段：
- `mcp_servers.*`：外部段由 `parseCodexExternalMcpBlocks` 处理；hermes-studio-* 段由 `codexMcpConfigToml` 重新生成
- `model_providers.*`：每次启动由 hermes-web-ui 依据当前 provider 重建，用户 config 中的陈旧 provider 段不应混入

## 测试

- 新增 11 个单元测试（`tests/server/coding-agents-codex-config.test.ts`）：features 保留、model_providers 排除、hermes 段不重复、空输入安全
- 既有 coding-agents 套件 38 个测试全过
- `tsc --noEmit` 通过