### PR TITLE
fix: configure model-run token lifetime

### DIFF
--- a/packages/server/src/middleware/user-auth.ts
+++ b/packages/server/src/middleware/user-auth.ts
@@ -70,6 +70,10 @@ export function getUserJwtExpiresSeconds(env: Record<string, string | undefined>
   return parseJwtExpirySeconds(env.HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN) ?? DEFAULT_EXPIRES_SECONDS
 }
 
+export function getModelRunJwtExpiresSeconds(env: Record<string, string | undefined> = process.env): number {
+  return parseJwtExpirySeconds(env.HERMES_WEB_UI_MODEL_RUN_JWT_EXPIRES_IN) ?? MODEL_RUN_EXPIRES_SECONDS
+}
+
 function base64UrlJson(value: unknown): string {
   return Buffer.from(JSON.stringify(value)).toString('base64url')
 }
@@ -184,7 +188,7 @@ export async function issueUserJwt(user: Pick<UserRecord, 'id' | 'username' | 'r
 
 export async function issueModelRunJwt(user: Pick<UserRecord, 'id' | 'username' | 'role'>): Promise<string> {
   const secret = await getJwtSecret()
-  return signUserJwt(user, secret, Date.now(), MODEL_RUN_EXPIRES_SECONDS)
+  return signUserJwt(user, secret, Date.now(), getModelRunJwtExpiresSeconds())
 }
 
 export function toAuthenticatedUser(user: Pick<UserRecord, 'id' | 'username' | 'role'>): AuthenticatedUser {

--- a/tests/server/user-auth.test.ts
+++ b/tests/server/user-auth.test.ts
@@ -88,6 +88,24 @@ describe('user auth tables and middleware', () => {
     expect(auth.parseJwtExpirySeconds(value)).toBe(seconds)
   })
 
+  it('allows configuring the model-run JWT lifetime independently', async () => {
+    vi.stubEnv('HERMES_WEB_UI_MODEL_RUN_JWT_EXPIRES_IN', '12h')
+    const { auth } = await initUsers()
+    vi.setSystemTime(new Date('2026-06-30T00:00:00Z'))
+
+    const token = await auth.issueModelRunJwt({ id: 1, username: 'admin', role: 'super_admin' })
+    const payload = jwtPayload(token)
+
+    expect(payload.exp - payload.iat).toBe(12 * 60 * 60)
+  })
+
+  it('falls back to the one-hour model-run JWT lifetime for invalid overrides', async () => {
+    vi.stubEnv('HERMES_WEB_UI_MODEL_RUN_JWT_EXPIRES_IN', 'forever')
+    const { auth } = await initUsers()
+
+    expect(auth.getModelRunJwtExpiresSeconds()).toBe(60 * 60)
+  })
+
   it('creates the default super admin without profile bindings', async () => {
     const { schemas, users } = await initUsers()
 


### PR DESCRIPTION
## Summary

- add an independent `HERMES_WEB_UI_MODEL_RUN_JWT_EXPIRES_IN` setting for temporary profile tokens used by Studio MCP during Hermes/Coding Agent runs
- retain the existing one-hour default and bounded expiry parser
- leave ordinary user-login JWT lifetime and endpoint authorization unchanged

## Root Cause

Studio rewrites `profiles/<profile>/.model-run-token` when a run starts. The model-run JWT has a hard-coded one-hour lifetime, while long scoped Codex runs can continue beyond one hour and call Studio MCP later. Once expired, `api`, `use`, and `devices` requests fail with `Unauthorized. Web UI token was not accepted.` A subsequent run rewrites the file and makes the failure appear intermittent.

## TDD

RED before implementation:

```text
expected 3600 to be 43200
getModelRunJwtExpiresSeconds is not a function
```

GREEN after implementation:

- independent model-run lifetime tests: 2 passed
- user auth + token writer + Coding Agent baseline: 59 passed
- full production build: passed
- `git diff --check`: passed

## Deployment

Deployments that support Coding Agent runs longer than one hour can set, for example:

```text
HERMES_WEB_UI_MODEL_RUN_JWT_EXPIRES_IN=12h
```

The accepted range remains bounded by the existing JWT expiry parser. Invalid values fall back to the one-hour default.

Fixes #2381
