### PR TITLE
fix: align managed use MCP timeout

### DIFF
--- a/packages/server/src/services/hermes/studio-mcp-autoinject.ts
+++ b/packages/server/src/services/hermes/studio-mcp-autoinject.ts
@@ -15,6 +15,10 @@ const MANAGED_SERVERS: ReadonlyArray<{ name: string; toolset: string }> = [
   { name: 'hermes-studio-use', toolset: 'use' },
 ]
 const MANAGED_SERVER_NAMES: Set<string> = new Set(MANAGED_SERVERS.map(server => server.name))
+// Hermes Agent applies this per managed MCP server. Keep the long-running
+// `use` toolset above Studio's 30-minute chat-run cap with bounded delivery
+// headroom; unrelated API/browser/device calls retain the client default.
+const MANAGED_USE_MCP_TIMEOUT_SECONDS = 30 * 60 + 60
 const LEGACY_SERVER_NAMES = new Set([
   LEGACY_SERVER_NAME,
   'hermes-web-ui-mcp',
@@ -176,6 +180,7 @@ function managedConfig(
 
   return {
     ...managedCommandConfig(toolset, bundledScript),
+    ...(toolset === 'use' ? { timeout: MANAGED_USE_MCP_TIMEOUT_SECONDS } : {}),
     env,
     enabled: true,
   }
@@ -203,6 +208,7 @@ function sameConfig(existing: Record<string, any>, desired: Record<string, unkno
   const desiredEnv = desired.env as Record<string, string>
   return existing.command === desired.command &&
     sameArgs(existing, desired) &&
+    (desired.timeout === undefined || existing.timeout === desired.timeout) &&
     existing.enabled !== false &&
     isRecord(existing.env) &&
     existing.env.HERMES_WEB_UI_URL === desiredEnv.HERMES_WEB_UI_URL &&
@@ -283,7 +289,9 @@ async function injectIntoProfile(
       }
 
       if (!sameConfig(existing, desired)) {
-        cfg.mcp_servers[server.name] = desired
+        cfg.mcp_servers[server.name] = desired.timeout === undefined && Object.hasOwn(existing, 'timeout')
+          ? { ...desired, timeout: existing.timeout }
+          : desired
         changed = true
       }
     }

--- a/tests/server/studio-mcp-autoinject.test.ts
+++ b/tests/server/studio-mcp-autoinject.test.ts
@@ -148,12 +148,16 @@ describe('studio MCP autoinject', () => {
     expect(injectedDefault.data.mcp_servers['hermes-studio-use']).toMatchObject({
       command: process.execPath,
       args: [stableLauncher, 'use'],
+      timeout: 1860,
       env: {
         HERMES_MCP_SERVER_NAME: 'hermes-studio-use',
         HERMES_MCP_TOOLSET: 'use',
       },
       enabled: true,
     })
+    expect(injectedDefault.data.mcp_servers['hermes-studio-api']).not.toHaveProperty('timeout')
+    expect(injectedDefault.data.mcp_servers['hermes-studio-browser']).not.toHaveProperty('timeout')
+    expect(injectedDefault.data.mcp_servers['hermes-studio-devices']).not.toHaveProperty('timeout')
     const injectedWork = await updateConfigYamlForProfileMock.mock.calls[1][1]({})
     expect(injectedWork.data.mcp_servers['hermes-studio-api'].env.HERMES_WEB_UI_PROFILE).toBe('work')
     expect(result.serverNames).toEqual([
@@ -163,6 +167,39 @@ describe('studio MCP autoinject', () => {
       'hermes-studio-use',
     ])
     expect(result.command).toBe(process.execPath)
+  })
+
+  it('migrates an existing managed use server from the default MCP timeout', async () => {
+    const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
+    await injectBundledMcpServer()
+
+    const updater = updateConfigYamlForProfileMock.mock.calls[0][1]
+    const initial = await updater({})
+    const stale = structuredClone(initial.data)
+    delete stale.mcp_servers['hermes-studio-use'].timeout
+
+    const migrated = await updater(stale)
+
+    expect(migrated.result.status).toBe('updated')
+    expect(migrated.data.mcp_servers['hermes-studio-use'].timeout).toBe(1860)
+    expect(migrated.data.mcp_servers['hermes-studio-api']).not.toHaveProperty('timeout')
+  })
+
+  it('preserves an existing timeout on an unrelated managed server during config resync', async () => {
+    const { injectBundledMcpServer } = await import('../../packages/server/src/services/hermes/studio-mcp-autoinject')
+    await injectBundledMcpServer()
+
+    const updater = updateConfigYamlForProfileMock.mock.calls[0][1]
+    const initial = await updater({})
+    const configured = structuredClone(initial.data)
+    configured.mcp_servers['hermes-studio-api'].timeout = 42
+    configured.mcp_servers['hermes-studio-api'].env.HERMES_WEB_UI_URL = 'http://127.0.0.1:9999'
+
+    const resynced = await updater(configured)
+
+    expect(resynced.result.status).toBe('updated')
+    expect(resynced.data.mcp_servers['hermes-studio-api'].env.HERMES_WEB_UI_URL).toBe('http://127.0.0.1:8648')
+    expect(resynced.data.mcp_servers['hermes-studio-api'].timeout).toBe(42)
   })
 
   it('skips autoinject for transient preview homes by default', async () => {


### PR DESCRIPTION
## Summary

- set the Studio-managed `hermes-studio-use` MCP timeout to 31 minutes;
- keep `api`, `browser`, and `devices` on the Hermes Agent default timeout;
- migrate existing managed Profile entries that predate the timeout override;
- preserve user-disabled and unmanaged MCP entries, plus custom timeouts on unrelated managed toolsets.

## Root cause

The Group Chat participant launched a scoped Coding Agent through `hermes_studio_use_chat_run`. The request supplied a long `timeout_ms`, and the scoped Session continued normally, but Hermes Agent's MCP client stopped waiting at its server-level default:

```python
_DEFAULT_TOOL_TIMEOUT = 300
```

The parent Group Chat turn therefore reported `BLOCKED` after about five minutes even though the scoped Session later ended `complete` and persisted its final result.

Studio accepts a maximum `chat_run.timeout_ms` of 30 minutes. The managed `use` MCP server now waits 31 minutes: the full legal Run budget plus 60 seconds for terminal propagation and serialization. This remains bounded and preserves the current one-Mention/one-reply Group Chat behavior.

## Product behavior

No new background-job UI, Run ID message, or second completion notification is introduced. The existing Group Chat flow remains:

```text
compressing → replying → final Assistant message → ready
```

## Validation

- RED: managed `hermes-studio-use` had no timeout and inherited the 300-second Hermes Agent default.
- GREEN: fresh managed config contains `timeout: 1860` only for `hermes-studio-use`.
- Existing managed config without the timeout is reported `updated` and rewritten.
- Existing custom timeout on an unrelated managed toolset remains unchanged, including when other managed fields drift and trigger a resync.
- Related regression: 4 test files / 100 tests passed.
- `npm run build` passed.
- `git diff --check` passed.

Fixes #2385
