### PR TITLE
feat: animate tool panel expansion

### DIFF
--- a/docs/chat-chain-changes/2026-08-06-tool-panel-expand-transition.md
+++ b/docs/chat-chain-changes/2026-08-06-tool-panel-expand-transition.md
@@ -13,3 +13,7 @@ during the transition so resize geometry cannot be changed mid-animation.
 The Electron browser viewport remains hidden while its containing drawer is
 animating and resynchronizes after visibility changes, avoiding native-view
 content appearing outside the expanding panel.
+
+RTL mobile transitions use the transitioning panel's inherited direction
+instead of a scoped global root selector. This keeps the slide direction
+mirrored without applying the transition transform to the document root.

--- a/docs/chat-chain-changes/2026-08-06-tool-panel-expand-transition.md
+++ b/docs/chat-chain-changes/2026-08-06-tool-panel-expand-transition.md
@@ -1,0 +1,15 @@
+---
+date: 2026-08-06
+pr: 2389
+feature: Chat tool panel expansion transition
+impact: Single-chat and Group Chat tool panels now expand and collapse like resizable sidebars while the native desktop browser viewport stays hidden until the opening transition completes.
+---
+
+Desktop tool drawers animate their width together with the chat surface, while
+mobile drawers retain a full-width directional slide and reduced-motion users
+receive an effectively immediate transition. Pointer interactions are disabled
+during the transition so resize geometry cannot be changed mid-animation.
+
+The Electron browser viewport remains hidden while its containing drawer is
+animating and resynchronizes after visibility changes, avoiding native-view
+content appearing outside the expanding panel.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -93,6 +93,7 @@ let sessionFadeAnimation: Animation | null = null;
 const chatDropCounter = ref(0);
 const isChatDropActive = ref(false);
 const showToolPanel = ref(false);
+const toolPanelTransitionReady = ref(false);
 const activeToolPanel = ref<"files" | "terminal" | "browser">("files");
 const desktopBrowserAvailable = hasDesktopBrowserBridge();
 const desktopChatWindowAvailable = desktopBridge()?.isDesktop === true
@@ -253,6 +254,22 @@ function toggleToolPanel() {
     return;
   }
   showToolPanel.value = true;
+}
+
+function handleToolPanelBeforeEnter() {
+  toolPanelTransitionReady.value = false;
+}
+
+function handleToolPanelAfterEnter() {
+  toolPanelTransitionReady.value = true;
+}
+
+function handleToolPanelBeforeLeave() {
+  toolPanelTransitionReady.value = false;
+}
+
+function handleToolPanelLeaveCancelled() {
+  toolPanelTransitionReady.value = true;
 }
 
 function hasDraggedFiles(event: DragEvent) {
@@ -2668,98 +2685,107 @@ async function handleSessionModelCustomSubmit() {
             :messages="chatStore.messages"
             @navigate="handleOutlineNavigate"
           />
-          <aside
-            v-if="showToolPanel"
-            class="chat-tool-panel"
-            :style="toolPanelStyle"
+          <Transition
+            name="tool-panel"
+            @before-enter="handleToolPanelBeforeEnter"
+            @after-enter="handleToolPanelAfterEnter"
+            @before-leave="handleToolPanelBeforeLeave"
+            @leave-cancelled="handleToolPanelLeaveCancelled"
           >
-            <div
-              class="chat-tool-resize-handle"
-              @pointerdown="startToolResize"
-            />
-            <div class="chat-tool-panel-inner">
-              <WorkspaceDiffPreview
-                v-if="toolPanelStore.workspaceDiff"
-                :custom-close="closeToolPanelOverlay"
+            <aside
+              v-if="showToolPanel"
+              class="chat-tool-panel"
+              :style="toolPanelStyle"
+            >
+              <div
+                class="chat-tool-resize-handle"
+                @pointerdown="startToolResize"
               />
-              <FilePreview
-                v-else-if="filesStore.previewFile"
-                :custom-close="closeToolPanelOverlay"
-              />
-              <SubagentStreamPanel
-                v-else-if="selectedSubagent"
-                :stream="selectedSubagentStream"
-                @close="closeToolPanelOverlay"
-              />
-              <template v-else>
-                <div class="chat-tool-tabs" role="tablist">
-                  <button
-                    class="chat-tool-tab"
-                    :class="{ active: activeToolPanel === 'files' }"
-                    type="button"
-                    role="tab"
-                    :title="t('drawer.files')"
-                    :aria-label="t('drawer.files')"
-                    :aria-selected="activeToolPanel === 'files'"
-                    @click="activeToolPanel = 'files'"
-                  >
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                      <path d="M3 7.5A2.5 2.5 0 0 1 5.5 5H10l2 2h6.5A2.5 2.5 0 0 1 21 9.5v7A2.5 2.5 0 0 1 18.5 19h-13A2.5 2.5 0 0 1 3 16.5z" />
-                    </svg>
-                  </button>
-                  <button
-                    class="chat-tool-tab"
-                    :class="{ active: activeToolPanel === 'terminal' }"
-                    type="button"
-                    role="tab"
-                    :title="t('drawer.terminal')"
-                    :aria-label="t('drawer.terminal')"
-                    :aria-selected="activeToolPanel === 'terminal'"
-                    @click="activeToolPanel = 'terminal'"
-                  >
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                      <rect x="3" y="4" width="18" height="16" rx="2" />
-                      <path d="m7 9 3 3-3 3M13 15h4" />
-                    </svg>
-                  </button>
-                  <button
-                    v-if="desktopBrowserAvailable"
-                    class="chat-tool-tab"
-                    :class="{ active: activeToolPanel === 'browser' }"
-                    type="button"
-                    role="tab"
-                    :title="t('browser.title')"
-                    :aria-label="t('browser.title')"
-                    :aria-selected="activeToolPanel === 'browser'"
-                    @click="activeToolPanel = 'browser'"
-                  >
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                      <rect x="3" y="4" width="18" height="16" rx="2" />
-                      <path d="M3 9h18" />
-                      <circle cx="6.5" cy="6.5" r=".75" fill="currentColor" stroke="none" />
-                      <circle cx="9.5" cy="6.5" r=".75" fill="currentColor" stroke="none" />
-                    </svg>
-                  </button>
-                </div>
-                <div class="chat-tool-content">
-                  <FilesPanel
-                    v-show="activeToolPanel === 'files'"
-                    :workspace-session-id="activeWorkspaceSessionId"
-                    :workspace="activeWorkspacePath"
-                    @attach="handleWorkspaceFileAttach"
-                  />
-                  <TerminalPanel
-                    v-show="activeToolPanel === 'terminal'"
-                    :visible="showToolPanel && activeToolPanel === 'terminal'"
-                  />
-                  <DesktopBrowserPanel
-                    v-if="desktopBrowserAvailable && activeToolPanel === 'browser'"
-                    @attach="handleBrowserAttachment"
-                  />
-                </div>
-              </template>
-            </div>
-          </aside>
+              <div class="chat-tool-panel-inner">
+                <WorkspaceDiffPreview
+                  v-if="toolPanelStore.workspaceDiff"
+                  :custom-close="closeToolPanelOverlay"
+                />
+                <FilePreview
+                  v-else-if="filesStore.previewFile"
+                  :custom-close="closeToolPanelOverlay"
+                />
+                <SubagentStreamPanel
+                  v-else-if="selectedSubagent"
+                  :stream="selectedSubagentStream"
+                  @close="closeToolPanelOverlay"
+                />
+                <template v-else>
+                  <div class="chat-tool-tabs" role="tablist">
+                    <button
+                      class="chat-tool-tab"
+                      :class="{ active: activeToolPanel === 'files' }"
+                      type="button"
+                      role="tab"
+                      :title="t('drawer.files')"
+                      :aria-label="t('drawer.files')"
+                      :aria-selected="activeToolPanel === 'files'"
+                      @click="activeToolPanel = 'files'"
+                    >
+                      <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M3 7.5A2.5 2.5 0 0 1 5.5 5H10l2 2h6.5A2.5 2.5 0 0 1 21 9.5v7A2.5 2.5 0 0 1 18.5 19h-13A2.5 2.5 0 0 1 3 16.5z" />
+                      </svg>
+                    </button>
+                    <button
+                      class="chat-tool-tab"
+                      :class="{ active: activeToolPanel === 'terminal' }"
+                      type="button"
+                      role="tab"
+                      :title="t('drawer.terminal')"
+                      :aria-label="t('drawer.terminal')"
+                      :aria-selected="activeToolPanel === 'terminal'"
+                      @click="activeToolPanel = 'terminal'"
+                    >
+                      <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <rect x="3" y="4" width="18" height="16" rx="2" />
+                        <path d="m7 9 3 3-3 3M13 15h4" />
+                      </svg>
+                    </button>
+                    <button
+                      v-if="desktopBrowserAvailable"
+                      class="chat-tool-tab"
+                      :class="{ active: activeToolPanel === 'browser' }"
+                      type="button"
+                      role="tab"
+                      :title="t('browser.title')"
+                      :aria-label="t('browser.title')"
+                      :aria-selected="activeToolPanel === 'browser'"
+                      @click="activeToolPanel = 'browser'"
+                    >
+                      <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <rect x="3" y="4" width="18" height="16" rx="2" />
+                        <path d="M3 9h18" />
+                        <circle cx="6.5" cy="6.5" r=".75" fill="currentColor" stroke="none" />
+                        <circle cx="9.5" cy="6.5" r=".75" fill="currentColor" stroke="none" />
+                      </svg>
+                    </button>
+                  </div>
+                  <div class="chat-tool-content">
+                    <FilesPanel
+                      v-show="activeToolPanel === 'files'"
+                      :workspace-session-id="activeWorkspaceSessionId"
+                      :workspace="activeWorkspacePath"
+                      @attach="handleWorkspaceFileAttach"
+                    />
+                    <TerminalPanel
+                      v-show="activeToolPanel === 'terminal'"
+                      :visible="showToolPanel && activeToolPanel === 'terminal'"
+                    />
+                    <DesktopBrowserPanel
+                      v-if="desktopBrowserAvailable && activeToolPanel === 'browser'"
+                      :visible="toolPanelTransitionReady"
+                      @attach="handleBrowserAttachment"
+                    />
+                  </div>
+                </template>
+              </div>
+            </aside>
+          </Transition>
         </div>
       </template>
       <ConversationMonitorPane
@@ -3547,6 +3573,26 @@ async function handleSessionModelCustomSubmit() {
   overflow: visible;
 }
 
+.tool-panel-enter-active,
+.tool-panel-leave-active {
+  overflow: hidden;
+  pointer-events: none;
+  will-change: width, min-width, opacity;
+  transition:
+    width 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    min-width 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.16s ease,
+    border-color 0.16s ease;
+}
+
+.tool-panel-enter-from,
+.tool-panel-leave-to {
+  width: 0 !important;
+  min-width: 0;
+  opacity: 0;
+  border-inline-start-color: transparent;
+}
+
 .chat-tool-resize-handle {
   position: absolute;
   inset-inline-start: -7px;
@@ -3711,6 +3757,33 @@ async function handleSessionModelCustomSubmit() {
 
   .chat-tool-resize-handle {
     display: none;
+  }
+
+  .tool-panel-enter-active,
+  .tool-panel-leave-active {
+    transition:
+      transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+      opacity 0.16s ease;
+  }
+
+  .tool-panel-enter-from,
+  .tool-panel-leave-to {
+    width: 100% !important;
+    transform: translateX(100%);
+  }
+
+  :global([dir="rtl"]) {
+    .tool-panel-enter-from,
+    .tool-panel-leave-to {
+      transform: translateX(-100%);
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tool-panel-enter-active,
+  .tool-panel-leave-active {
+    transition-duration: 0.01ms;
   }
 }
 

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2592,9 +2592,11 @@ async function handleSessionModelCustomSubmit() {
                       fill="none"
                       stroke="currentColor"
                       stroke-width="1.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      aria-hidden="true"
                     >
-                      <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-                      <line x1="9" y1="3" x2="9" y2="21" />
+                      <rect x="3" y="3" width="18" height="18" rx="2" />
                       <line x1="15" y1="3" x2="15" y2="21" />
                     </svg>
                   </template>

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -3774,11 +3774,9 @@ async function handleSessionModelCustomSubmit() {
     transform: translateX(100%);
   }
 
-  :global([dir="rtl"]) {
-    .tool-panel-enter-from,
-    .tool-panel-leave-to {
-      transform: translateX(-100%);
-    }
+  .tool-panel-enter-from:dir(rtl),
+  .tool-panel-leave-to:dir(rtl) {
+    transform: translateX(-100%);
   }
 }
 

--- a/packages/client/src/components/hermes/chat/DesktopBrowserPanel.vue
+++ b/packages/client/src/components/hermes/chat/DesktopBrowserPanel.vue
@@ -4,6 +4,12 @@ import { NButton, NInput, NPopover, NSelect, useDialog, useMessage } from 'naive
 import { useI18n } from 'vue-i18n'
 import { desktopBridge, type DesktopBrowserDownload, type DesktopBrowserSelection, type DesktopBrowserState } from '@/utils/desktop-bridge'
 
+const props = withDefaults(defineProps<{
+  visible?: boolean
+}>(), {
+  visible: true,
+})
+
 const emit = defineEmits<{
   attach: [payload: { file: File; context: string }]
 }>()
@@ -109,6 +115,7 @@ const annotationAnchorStyle = computed(() => {
 
 watch(() => activeTab.value?.url, value => { address.value = value || '' }, { immediate: true })
 watch(externalOverlayOpen, () => { void nextTick(syncViewport) })
+watch(() => props.visible, () => { void nextTick(syncViewport) })
 
 function applyState(next: DesktopBrowserState): void {
   state.value = next
@@ -117,7 +124,7 @@ function applyState(next: DesktopBrowserState): void {
 async function syncViewport(): Promise<void> {
   if (!bridge || !viewport.value) return
   const rect = viewport.value.getBoundingClientRect()
-  const visible = !externalOverlayOpen.value && !pendingAnnotation.value
+  const visible = props.visible && !externalOverlayOpen.value && !pendingAnnotation.value
     && rect.width > 0 && rect.height > 0 && document.visibilityState === 'visible'
   await bridge.setViewport({ x: rect.left, y: rect.top, width: rect.width, height: rect.height }, visible).catch(() => undefined)
 }

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -3112,11 +3112,9 @@ export default defineComponent({ components: { CreateRoomForm } })
         transform: translateX(100%);
     }
 
-    :global([dir='rtl']) {
-        .tool-panel-enter-from,
-        .tool-panel-leave-to {
-            transform: translateX(-100%);
-        }
+    .tool-panel-enter-from:dir(rtl),
+    .tool-panel-leave-to:dir(rtl) {
+        transform: translateX(-100%);
     }
 }
 

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -116,6 +116,7 @@ const groupChatContentWrapperRef = ref<HTMLElement | null>(null)
 const groupChatSurfaceRef = ref<HTMLElement | null>(null)
 let roomFadeAnimation: Animation | null = null
 const showWorkspacePanel = ref(false)
+const toolPanelTransitionReady = ref(false)
 const activeWorkspacePanel = ref<'files' | 'terminal' | 'browser'>('files')
 const desktopBrowserAvailable = hasDesktopBrowserBridge()
 const workspacePanelMobile = ref(window.innerWidth <= 768)
@@ -528,6 +529,22 @@ function toggleWorkspacePanel(): void {
         return
     }
     showWorkspacePanel.value = true
+}
+
+function handleToolPanelBeforeEnter(): void {
+    toolPanelTransitionReady.value = false
+}
+
+function handleToolPanelAfterEnter(): void {
+    toolPanelTransitionReady.value = true
+}
+
+function handleToolPanelBeforeLeave(): void {
+    toolPanelTransitionReady.value = false
+}
+
+function handleToolPanelLeaveCancelled(): void {
+    toolPanelTransitionReady.value = true
 }
 
 function openWorkspaceFilesPanel(): void {
@@ -1601,110 +1618,119 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                         @send-blocked="handleSummaryConfigurationRequired"
                     />
                 </div>
-                <aside
-                    v-if="showWorkspacePanel && (
-                        activeWorkspacePanel === 'files'
-                        || activeWorkspacePanel === 'terminal'
-                        || (activeWorkspacePanel === 'browser' && desktopBrowserAvailable)
-                        || toolPanelStore.workspaceDiff
-                        || currentRoom?.workspace
-                        || filesStore.previewFile?.workspaceRoomId === store.currentRoomId
-                    )"
-                    class="group-workspace-panel"
-                    :style="workspacePanelStyle"
+                <Transition
+                    name="tool-panel"
+                    @before-enter="handleToolPanelBeforeEnter"
+                    @after-enter="handleToolPanelAfterEnter"
+                    @before-leave="handleToolPanelBeforeLeave"
+                    @leave-cancelled="handleToolPanelLeaveCancelled"
                 >
-                    <div class="group-workspace-resize-handle" @pointerdown="startWorkspaceResize" />
-                    <div class="group-workspace-panel-inner">
-                        <WorkspaceDiffPreview
-                            v-if="toolPanelStore.workspaceDiff"
-                            :custom-close="closeWorkspacePanel"
-                        />
-                        <FilePreview
-                            v-else-if="filesStore.previewFile?.workspaceRoomId === store.currentRoomId"
-                            :custom-close="closeWorkspacePanel"
-                        />
-                        <template v-else>
-                            <div class="group-tool-tabs" role="tablist">
-                                <button
-                                    class="group-tool-tab"
-                                    :class="{ active: activeWorkspacePanel === 'files' }"
-                                    type="button"
-                                    role="tab"
-                                    :title="t('drawer.files')"
-                                    :aria-label="t('drawer.files')"
-                                    :aria-selected="activeWorkspacePanel === 'files'"
-                                    @click="selectWorkspacePanel('files')"
-                                >
-                                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                                        <path d="M3 7.5A2.5 2.5 0 0 1 5.5 5H10l2 2h6.5A2.5 2.5 0 0 1 21 9.5v7A2.5 2.5 0 0 1 18.5 19h-13A2.5 2.5 0 0 1 3 16.5z" />
-                                    </svg>
-                                </button>
-                                <button
-                                    class="group-tool-tab"
-                                    :class="{ active: activeWorkspacePanel === 'terminal' }"
-                                    type="button"
-                                    role="tab"
-                                    :title="t('drawer.terminal')"
-                                    :aria-label="t('drawer.terminal')"
-                                    :aria-selected="activeWorkspacePanel === 'terminal'"
-                                    @click="selectWorkspacePanel('terminal')"
-                                >
-                                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                                        <rect x="3" y="4" width="18" height="16" rx="2" />
-                                        <path d="m7 9 3 3-3 3M13 15h4" />
-                                    </svg>
-                                </button>
-                                <button
-                                    v-if="desktopBrowserAvailable"
-                                    class="group-tool-tab"
-                                    :class="{ active: activeWorkspacePanel === 'browser' }"
-                                    type="button"
-                                    role="tab"
-                                    :title="t('browser.title')"
-                                    :aria-label="t('browser.title')"
-                                    :aria-selected="activeWorkspacePanel === 'browser'"
-                                    @click="selectWorkspacePanel('browser')"
-                                >
-                                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                                        <rect x="3" y="4" width="18" height="16" rx="2" />
-                                        <path d="M3 9h18" />
-                                        <circle cx="6.5" cy="6.5" r=".75" fill="currentColor" stroke="none" />
-                                        <circle cx="9.5" cy="6.5" r=".75" fill="currentColor" stroke="none" />
-                                    </svg>
-                                </button>
-                            </div>
-                            <div class="group-tool-content">
-                                <template v-if="currentRoom?.workspace">
-                                    <FilesPanel
-                                        v-show="activeWorkspacePanel === 'files'"
-                                        :workspace-room-id="store.currentRoomId"
-                                        :workspace="currentRoom.workspace"
-                                        @attach="handleWorkspaceFileAttach"
-                                    />
-                                </template>
-                                <div v-else-if="activeWorkspacePanel === 'files'" class="group-workspace-empty">
-                                    <svg width="38" height="38" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">
-                                        <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-                                    </svg>
-                                    <span>{{ t('chat.setWorkspaceTitle') }}</span>
-                                    <NButton type="primary" size="small" @click="handleOpenWorkspacePicker()">
-                                        {{ t('chat.setWorkspace') }}
-                                    </NButton>
+                    <aside
+                        v-if="showWorkspacePanel && (
+                            activeWorkspacePanel === 'files'
+                            || activeWorkspacePanel === 'terminal'
+                            || (activeWorkspacePanel === 'browser' && desktopBrowserAvailable)
+                            || toolPanelStore.workspaceDiff
+                            || currentRoom?.workspace
+                            || filesStore.previewFile?.workspaceRoomId === store.currentRoomId
+                        )"
+                        class="group-workspace-panel"
+                        :style="workspacePanelStyle"
+                    >
+                        <div class="group-workspace-resize-handle" @pointerdown="startWorkspaceResize" />
+                        <div class="group-workspace-panel-inner">
+                            <WorkspaceDiffPreview
+                                v-if="toolPanelStore.workspaceDiff"
+                                :custom-close="closeWorkspacePanel"
+                            />
+                            <FilePreview
+                                v-else-if="filesStore.previewFile?.workspaceRoomId === store.currentRoomId"
+                                :custom-close="closeWorkspacePanel"
+                            />
+                            <template v-else>
+                                <div class="group-tool-tabs" role="tablist">
+                                    <button
+                                        class="group-tool-tab"
+                                        :class="{ active: activeWorkspacePanel === 'files' }"
+                                        type="button"
+                                        role="tab"
+                                        :title="t('drawer.files')"
+                                        :aria-label="t('drawer.files')"
+                                        :aria-selected="activeWorkspacePanel === 'files'"
+                                        @click="selectWorkspacePanel('files')"
+                                    >
+                                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M3 7.5A2.5 2.5 0 0 1 5.5 5H10l2 2h6.5A2.5 2.5 0 0 1 21 9.5v7A2.5 2.5 0 0 1 18.5 19h-13A2.5 2.5 0 0 1 3 16.5z" />
+                                        </svg>
+                                    </button>
+                                    <button
+                                        class="group-tool-tab"
+                                        :class="{ active: activeWorkspacePanel === 'terminal' }"
+                                        type="button"
+                                        role="tab"
+                                        :title="t('drawer.terminal')"
+                                        :aria-label="t('drawer.terminal')"
+                                        :aria-selected="activeWorkspacePanel === 'terminal'"
+                                        @click="selectWorkspacePanel('terminal')"
+                                    >
+                                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                                            <rect x="3" y="4" width="18" height="16" rx="2" />
+                                            <path d="m7 9 3 3-3 3M13 15h4" />
+                                        </svg>
+                                    </button>
+                                    <button
+                                        v-if="desktopBrowserAvailable"
+                                        class="group-tool-tab"
+                                        :class="{ active: activeWorkspacePanel === 'browser' }"
+                                        type="button"
+                                        role="tab"
+                                        :title="t('browser.title')"
+                                        :aria-label="t('browser.title')"
+                                        :aria-selected="activeWorkspacePanel === 'browser'"
+                                        @click="selectWorkspacePanel('browser')"
+                                    >
+                                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                                            <rect x="3" y="4" width="18" height="16" rx="2" />
+                                            <path d="M3 9h18" />
+                                            <circle cx="6.5" cy="6.5" r=".75" fill="currentColor" stroke="none" />
+                                            <circle cx="9.5" cy="6.5" r=".75" fill="currentColor" stroke="none" />
+                                        </svg>
+                                    </button>
                                 </div>
-                                <TerminalPanel
-                                    v-show="activeWorkspacePanel === 'terminal'"
-                                    class="group-terminal-panel"
-                                    :visible="showWorkspacePanel && activeWorkspacePanel === 'terminal'"
-                                />
-                                <DesktopBrowserPanel
-                                    v-if="desktopBrowserAvailable && activeWorkspacePanel === 'browser'"
-                                    class="group-browser-panel"
-                                    @attach="handleBrowserAttachment"
-                                />
-                            </div>
-                        </template>
-                    </div>
-                </aside>
+                                <div class="group-tool-content">
+                                    <template v-if="currentRoom?.workspace">
+                                        <FilesPanel
+                                            v-show="activeWorkspacePanel === 'files'"
+                                            :workspace-room-id="store.currentRoomId"
+                                            :workspace="currentRoom.workspace"
+                                            @attach="handleWorkspaceFileAttach"
+                                        />
+                                    </template>
+                                    <div v-else-if="activeWorkspacePanel === 'files'" class="group-workspace-empty">
+                                        <svg width="38" height="38" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">
+                                            <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+                                        </svg>
+                                        <span>{{ t('chat.setWorkspaceTitle') }}</span>
+                                        <NButton type="primary" size="small" @click="handleOpenWorkspacePicker()">
+                                            {{ t('chat.setWorkspace') }}
+                                        </NButton>
+                                    </div>
+                                    <TerminalPanel
+                                        v-show="activeWorkspacePanel === 'terminal'"
+                                        class="group-terminal-panel"
+                                        :visible="showWorkspacePanel && activeWorkspacePanel === 'terminal'"
+                                    />
+                                    <DesktopBrowserPanel
+                                        v-if="desktopBrowserAvailable && activeWorkspacePanel === 'browser'"
+                                        class="group-browser-panel"
+                                        :visible="toolPanelTransitionReady"
+                                        @attach="handleBrowserAttachment"
+                                    />
+                                </div>
+                            </template>
+                        </div>
+                    </aside>
+                </Transition>
             </div>
 
             <div v-else class="no-room">
@@ -2885,6 +2911,26 @@ export default defineComponent({ components: { CreateRoomForm } })
     border-inline-start: 1px solid $border-color;
 }
 
+.tool-panel-enter-active,
+.tool-panel-leave-active {
+    overflow: hidden;
+    pointer-events: none;
+    will-change: width, min-width, opacity;
+    transition:
+        width 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+        min-width 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+        opacity 0.16s ease,
+        border-color 0.16s ease;
+}
+
+.tool-panel-enter-from,
+.tool-panel-leave-to {
+    width: 0 !important;
+    min-width: 0;
+    opacity: 0;
+    border-inline-start-color: transparent;
+}
+
 .group-workspace-resize-handle {
     position: absolute;
     inset-inline-start: -7px;
@@ -3051,6 +3097,33 @@ export default defineComponent({ components: { CreateRoomForm } })
 
     .group-workspace-resize-handle {
         display: none;
+    }
+
+    .tool-panel-enter-active,
+    .tool-panel-leave-active {
+        transition:
+            transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+            opacity 0.16s ease;
+    }
+
+    .tool-panel-enter-from,
+    .tool-panel-leave-to {
+        width: 100% !important;
+        transform: translateX(100%);
+    }
+
+    :global([dir='rtl']) {
+        .tool-panel-enter-from,
+        .tool-panel-leave-to {
+            transform: translateX(-100%);
+        }
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .tool-panel-enter-active,
+    .tool-panel-leave-active {
+        transition-duration: 0.01ms;
     }
 }
 

--- a/tests/client/drawer-panel-resize.test.ts
+++ b/tests/client/drawer-panel-resize.test.ts
@@ -54,6 +54,31 @@ describe('ChatPanel tool drawer resizing support', () => {
     expect(source).toMatch(/\.chat-tool-content\s*\{\s*order: 1;[\s\S]*background: \$bg-main-surface;/)
   })
 
+  it('animates the single and group chat tool panels without exposing the native browser mid-transition', () => {
+    const chatSource = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+    const groupSource = readFileSync('packages/client/src/components/hermes/group-chat/GroupChatPanel.vue', 'utf8')
+    const browserSource = readFileSync('packages/client/src/components/hermes/chat/DesktopBrowserPanel.vue', 'utf8')
+
+    for (const source of [chatSource, groupSource]) {
+      expect(source).toContain('<Transition')
+      expect(source).toContain('name="tool-panel"')
+      expect(source).toContain('@before-enter="handleToolPanelBeforeEnter"')
+      expect(source).toContain('@after-enter="handleToolPanelAfterEnter"')
+      expect(source).toContain('@before-leave="handleToolPanelBeforeLeave"')
+      expect(source).toContain('@leave-cancelled="handleToolPanelLeaveCancelled"')
+      expect(source).toContain('@media (prefers-reduced-motion: reduce)')
+    }
+
+    expect(chatSource).toContain(':visible="toolPanelTransitionReady"')
+    expect(groupSource).toContain(':visible="toolPanelTransitionReady"')
+    expect(chatSource).toMatch(/\.tool-panel-enter-active,[\s\S]*transition:[\s\S]*width 0\.25s/)
+    expect(groupSource).toMatch(/\.tool-panel-enter-active,[\s\S]*transition:[\s\S]*width 0\.25s/)
+    expect(chatSource).toMatch(/\.tool-panel-enter-from,[\s\S]*width: 0 !important;[\s\S]*min-width: 0;/)
+    expect(groupSource).toMatch(/\.tool-panel-enter-from,[\s\S]*width: 0 !important;[\s\S]*min-width: 0;/)
+    expect(browserSource).toContain('visible?: boolean')
+    expect(browserSource).toContain('props.visible && !externalOverlayOpen.value')
+  })
+
   it('uses the drawer content surface for the conversation outline', () => {
     const source = readFileSync('packages/client/src/components/hermes/chat/OutlinePanel.vue', 'utf8')
 

--- a/tests/client/drawer-panel-resize.test.ts
+++ b/tests/client/drawer-panel-resize.test.ts
@@ -67,6 +67,8 @@ describe('ChatPanel tool drawer resizing support', () => {
       expect(source).toContain('@before-leave="handleToolPanelBeforeLeave"')
       expect(source).toContain('@leave-cancelled="handleToolPanelLeaveCancelled"')
       expect(source).toContain('@media (prefers-reduced-motion: reduce)')
+      expect(source).toContain('.tool-panel-enter-from:dir(rtl)')
+      expect(source).not.toMatch(/:global\(\[dir=['"]rtl['"]\]\)/)
     }
 
     expect(chatSource).toContain(':visible="toolPanelTransitionReady"')

--- a/tests/e2e/desktop-window-chrome.spec.ts
+++ b/tests/e2e/desktop-window-chrome.spec.ts
@@ -387,6 +387,7 @@ test('keeps the chat tool drawer unchanged in LTR and mirrors its resize seam in
   const panel = page.locator('.chat-tool-panel')
   const handle = page.locator('.chat-tool-resize-handle')
   await expect(panel).toBeVisible()
+  await expect(panel).not.toHaveClass(/tool-panel-enter-active/)
 
   const geometry = async () => {
     const [wrapperBox, panelBox, handleBox] = await Promise.all([

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -254,6 +254,7 @@ test.describe('group chat room deep links', () => {
     const panel = page.locator('.group-workspace-panel')
     const handle = page.locator('.group-workspace-resize-handle')
     await expect(panel).toBeVisible()
+    await expect(panel).not.toHaveClass(/tool-panel-enter-active/)
 
     const geometry = async () => {
       const [wrapperBox, panelBox, handleBox] = await Promise.all([


### PR DESCRIPTION
## What changed

- animate the single-chat and group-chat tool drawers with a sidebar-style width expansion and collapse
- keep mobile behavior as a full-width side slide, including RTL support
- honor reduced-motion preferences and disable drawer interactions while the transition is running
- keep the Electron native browser viewport hidden until the HTML drawer finishes opening, preventing viewport/content misalignment
- wait for the transition to settle in drawer geometry E2E coverage

## Why

The previous popup-like appearance felt disconnected from the resizable tool drawer. The drawer should behave like the existing slider/sidebar: the tool area expands from zero width while the chat surface resizes alongside it, and reverses that motion when hidden.

## User impact

Opening and closing Files, Terminal, or Browser from either single chat or group chat now feels like a continuous workspace resize instead of a sudden popup. Mobile remains a directional slide-over.

## Validation

- `npm run test -- tests/client/drawer-panel-resize.test.ts tests/client/desktop-browser-route.test.ts tests/client/group-chat-panel-workspace-source.test.ts` (28 passed)
- `npm run test:e2e -- tests/e2e/desktop-window-chrome.spec.ts --grep 'keeps the chat tool drawer unchanged'`
- `npm run test:e2e -- tests/e2e/group-chat-room-deeplink.spec.ts --grep 'keeps the workspace drawer seam'`
- `npm run build`
- `git diff --check`
