### PR TITLE
fix group chat approval routing

### DIFF
--- a/docs/chat-chain-changes/2026-08-06-group-chat-ekko-approval-routing.md
+++ b/docs/chat-chain-changes/2026-08-06-group-chat-ekko-approval-routing.md
@@ -1,0 +1,20 @@
+---
+date: 2026-08-06
+pr: pending
+feature: Group Chat Ekko Agent approval routing
+impact: Group Chat approval responses now resume the Ekko Agent session that requested them while Hermes Agent approvals continue through the Agent Bridge; the Group Chat UI no longer offers run-scoped session approval.
+---
+
+The Group Chat server records the validated room, Agent name, and runtime
+session for each pending approval. Manager responses are bound to that room and
+session, routed to the Ekko approval broker when it owns the request, and fall
+back to the Hermes Agent Bridge otherwise.
+
+Pending routes are removed when the approval resolves or the room runtime is
+cleared or deleted. This also prevents a manager in another room from resolving
+an approval by reusing its identifier.
+
+Because Group Chat creates a fresh runtime session for every Agent run, the
+session-level choice would not carry over to the next message. The Group Chat
+approval panel therefore exposes one-time and permanent approval only, while
+single-chat approval choices remain unchanged.

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -1532,9 +1532,6 @@ async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
                                     <NButton v-if="!visibleApproval.isMemoryWrite && visibleApproval.choices.includes('once')" size="small" type="primary" @click="handleApproval('once')">
                                         {{ t('chat.approvalAllowOnce') }}
                                     </NButton>
-                                    <NButton v-if="!visibleApproval.isMemoryWrite && visibleApproval.choices.includes('session')" size="small" secondary @click="handleApproval('session')">
-                                        {{ t('chat.approvalAllowSession') }}
-                                    </NButton>
                                     <NButton v-if="!visibleApproval.isMemoryWrite && visibleApproval.choices.includes('always')" size="small" secondary @click="handleApproval('always')">
                                         {{ t('chat.approvalAlways') }}
                                     </NButton>

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -9,6 +9,7 @@ import { AgentClients, GROUP_CHAT_AGENT_SOCKET_SECRET, groupBridgeSessionId, typ
 import { SessionDeleter } from '../session-deleter'
 import { countTokens } from '../../../lib/context-compressor'
 import { AgentBridgeClient } from '../agent-bridge'
+import { respondToEkkoToolApproval } from '../../ekko-agent/approvals'
 import { insertWorkspaceRunChange, deleteWorkspaceRunChangesForRoom, type SaveWorkspaceRunChangeInput, type WorkspaceRunChangeSummary } from '../../../db/hermes/workspace-run-changes-store'
 import { authenticateUserToken, isAuthEnabled, type AuthenticatedUser } from '../../../middleware/user-auth'
 import { findUserByUsername, getUserAvatar } from '../../../db/hermes/users-store'
@@ -37,6 +38,12 @@ interface ChatMessage {
     reasoning_content?: string | null
     mentionDepth?: number
     agentSessionId?: string
+}
+
+interface PendingGroupApprovalRoute {
+    roomId: string
+    agentName: string
+    agentSessionId: string
 }
 
 function contentToStorageString(content: unknown): string {
@@ -1064,6 +1071,8 @@ export class GroupChatServer {
         status: string
         agentSessionId?: string
     }>>()
+    /** approval id -> validated room and runtime session that requested it. */
+    private pendingApprovalRoutes = new Map<string, PendingGroupApprovalRoute>()
     /** roomId -> blocked Bridge session ids from room-level interrupts/rotations. */
     private fencedRoomAgentSessions = new Map<string, Set<string>>()
 
@@ -1217,6 +1226,7 @@ export class GroupChatServer {
             this.typingState.delete(roomId)
         }
         this.contextStatusState.delete(roomId)
+        this.clearPendingApprovalRoutes(roomId)
         const releaseSessionFence = this.fenceCurrentRoomAgentSessions(roomId)
         try {
             await this.agentClients.interruptRoom(roomId)
@@ -1236,6 +1246,7 @@ export class GroupChatServer {
             this.typingState.delete(roomId)
         }
         this.contextStatusState.delete(roomId)
+        this.clearPendingApprovalRoutes(roomId)
         const releaseSessionFence = this.fenceCurrentRoomAgentSessions(roomId)
         try {
             await this.agentClients.interruptRoom(roomId)
@@ -1347,8 +1358,8 @@ export class GroupChatServer {
         socket.on('stop_typing', (data: { roomId?: string }) => this.handleStopTyping(socket, data))
         socket.on('context_status', (data: { roomId?: string; agentName?: string; status?: string }) => this.handleContextStatus(socket, data))
         socket.on('interrupt_agent', (data: { roomId?: string; agentName?: string }, ack?: (response?: unknown) => void) => this.handleInterruptAgent(socket, data, ack))
-        socket.on('approval.requested', (data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean }) => this.handleApprovalRequested(socket, data))
-        socket.on('approval.resolved', (data: { roomId?: string; agentName?: string; approval_id?: string; choice?: string }) => this.handleApprovalResolved(socket, data))
+        socket.on('approval.requested', (data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; agentSessionId?: string }) => this.handleApprovalRequested(socket, data))
+        socket.on('approval.resolved', (data: { roomId?: string; agentName?: string; approval_id?: string; choice?: string; agentSessionId?: string }) => this.handleApprovalResolved(socket, data))
         socket.on('approval.respond', (data: { roomId?: string; approval_id?: string; choice?: string }, ack?: (response?: unknown) => void) => this.handleApprovalRespond(socket, data, ack))
         socket.on('disconnect', () => this.handleDisconnect(socket))
     }
@@ -1857,6 +1868,11 @@ export class GroupChatServer {
         const roomId = data.roomId
         const agentName = data.agentName || ''
         if (!roomId || !data.approval_id || !this.getCurrentAgentEventMember(socket, roomId, agentName, data.agentSessionId)) return
+        this.pendingApprovalRoutes.set(data.approval_id, {
+            roomId,
+            agentName,
+            agentSessionId: String(data.agentSessionId || '').trim(),
+        })
         this.emitToRoomManagers(roomId, 'approval.requested', {
             event: 'approval.requested',
             roomId,
@@ -1873,6 +1889,10 @@ export class GroupChatServer {
         const roomId = data.roomId
         const agentName = data.agentName || ''
         if (!roomId || !data.approval_id || !this.getCurrentAgentEventMember(socket, roomId, agentName, data.agentSessionId)) return
+        const pendingRoute = this.pendingApprovalRoutes.get(data.approval_id)
+        if (pendingRoute?.roomId === roomId && pendingRoute.agentName === agentName) {
+            this.pendingApprovalRoutes.delete(data.approval_id)
+        }
         this.emitToRoomManagers(roomId, 'approval.resolved', {
             event: 'approval.resolved',
             roomId,
@@ -1897,12 +1917,43 @@ export class GroupChatServer {
             ack?.({ error: 'Access denied' })
             return
         }
+        const pendingRoute = this.pendingApprovalRoutes.get(data.approval_id)
+        if (!pendingRoute || pendingRoute.roomId !== roomId) {
+            ack?.({ error: 'Approval is not pending in this room' })
+            return
+        }
+        const ekkoResult = pendingRoute.agentSessionId
+            ? respondToEkkoToolApproval(
+                pendingRoute.agentSessionId,
+                data.approval_id,
+                data.choice,
+            )
+            : null
+        if (ekkoResult?.handled) {
+            if (!ekkoResult.resolved) {
+                ack?.({ error: 'Approval does not belong to the active Agent session' })
+                return
+            }
+            this.pendingApprovalRoutes.delete(data.approval_id)
+            ack?.({ ok: true, resolved: true })
+            return
+        }
         try {
             const result = await new AgentBridgeClient().approvalRespond(data.approval_id, data.choice || 'deny')
-            ack?.({ ok: true, resolved: Boolean((result as any)?.resolved) })
+            const resolved = Boolean((result as any)?.resolved)
+            if (resolved) this.pendingApprovalRoutes.delete(data.approval_id)
+            ack?.({ ok: true, resolved })
         } catch (err: any) {
             logger.warn(`[GroupChat] failed to respond approval ${data.approval_id}: ${err.message}`)
             ack?.({ error: err.message || 'approval response failed' })
+        }
+    }
+
+    private clearPendingApprovalRoutes(roomId: string): void {
+        const pendingRoutes = this.pendingApprovalRoutes
+        if (!pendingRoutes) return
+        for (const [approvalId, route] of pendingRoutes) {
+            if (route.roomId === roomId) pendingRoutes.delete(approvalId)
         }
     }
 

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -6,6 +6,11 @@ import {
   once,
 } from './group-chat-test-helpers'
 import { GROUP_CHAT_AGENT_SOCKET_SECRET, groupRuntimeSessionId } from '../../packages/server/src/services/hermes/group-chat/agent-clients'
+import { AgentBridgeClient } from '../../packages/server/src/services/hermes/agent-bridge'
+import {
+  denyPendingEkkoToolApprovals,
+  waitForEkkoToolApproval,
+} from '../../packages/server/src/services/ekko-agent/approvals'
 import type { GroupChatServer } from '../../packages/server/src/services/hermes/group-chat'
 
 describe('group chat approval and context baseline', () => {
@@ -24,7 +29,9 @@ describe('group chat approval and context baseline', () => {
   })
 
   afterEach(() => {
+    denyPendingEkkoToolApprovals()
     harness?.cleanup()
+    vi.restoreAllMocks()
   })
 
   async function joinPair() {
@@ -197,6 +204,102 @@ describe('group chat approval and context baseline', () => {
       approval_id: 'approval-1',
       choice: 'deny',
     })
+  })
+
+  it('routes approval responses back to the pending Ekko Agent session', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    const bridgeApproval = vi.spyOn(AgentBridgeClient.prototype, 'approvalRespond')
+      .mockResolvedValue({ resolved: false } as any)
+    const requested = once<any>(human, 'approval.requested')
+    const approval = waitForEkkoToolApproval({
+      approvalId: 'approval-ekko',
+      toolName: 'terminal_exec',
+      key: 'terminal:delete',
+      command: 'rm -rf build',
+      description: 'deletes files or directories',
+      choices: ['once', 'session', 'always', 'deny'],
+      allowPermanent: true,
+      timeoutMs: 300_000,
+    }, {
+      sessionId: agentSessionId,
+      onRequested: pending => {
+        agent.emit('approval.requested', {
+          roomId: 'room-1',
+          agentName: 'Agent',
+          agentSessionId,
+          approval_id: pending.approvalId,
+          command: pending.command,
+          description: pending.description,
+          choices: pending.choices,
+          allow_permanent: pending.allowPermanent,
+        })
+      },
+    })
+
+    await expect(requested).resolves.toMatchObject({
+      roomId: 'room-1',
+      agentName: 'Agent',
+      approval_id: 'approval-ekko',
+    })
+    await expect(emitAck(human, 'approval.respond', {
+      roomId: 'room-1',
+      approval_id: 'approval-ekko',
+      choice: 'once',
+    })).resolves.toEqual({ ok: true, resolved: true })
+    await expect(approval).resolves.toBe('once')
+    expect(bridgeApproval).not.toHaveBeenCalled()
+  })
+
+  it('keeps Hermes approval responses routed through the Agent Bridge', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    const bridgeApproval = vi.spyOn(AgentBridgeClient.prototype, 'approvalRespond')
+      .mockResolvedValue({ resolved: true } as any)
+    const requested = once<any>(human, 'approval.requested')
+
+    agent.emit('approval.requested', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      agentSessionId,
+      approval_id: 'approval-hermes',
+      command: 'touch file',
+      description: 'needs approval',
+    })
+    await expect(requested).resolves.toMatchObject({ approval_id: 'approval-hermes' })
+
+    await expect(emitAck(human, 'approval.respond', {
+      roomId: 'room-1',
+      approval_id: 'approval-hermes',
+      choice: 'session',
+    })).resolves.toEqual({ ok: true, resolved: true })
+    expect(bridgeApproval).toHaveBeenCalledWith('approval-hermes', 'session')
+  })
+
+  it('does not route a pending approval through a different room', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    const bridgeApproval = vi.spyOn(AgentBridgeClient.prototype, 'approvalRespond')
+      .mockResolvedValue({ resolved: true } as any)
+    const requested = once<any>(human, 'approval.requested')
+    agent.emit('approval.requested', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      agentSessionId,
+      approval_id: 'approval-private-room',
+      command: 'cat secret',
+      description: 'needs approval',
+    })
+    await requested
+
+    groupServer.getStorage().saveRoom('room-2', 'Room 2', 'ROOM2')
+    const otherManager = await connectGroupChatClient(port, 'human-2', 'Other')
+    harness.sockets.push(otherManager)
+    await emitAck(otherManager, 'join', { roomId: 'room-2', inviteCode: 'ROOM2' })
+
+    await expect(emitAck(otherManager, 'approval.respond', {
+      roomId: 'room-2',
+      approval_id: 'approval-private-room',
+      choice: 'once',
+    })).resolves.toEqual({ error: 'Approval is not pending in this room' })
+    expect(bridgeApproval).not.toHaveBeenCalled()
   })
 
   it('rejects approval responses from sockets that have not joined the room', async () => {


### PR DESCRIPTION
## What changed

- route Group Chat Ekko Agent approval responses back to the pending Ekko approval broker
- preserve Hermes Agent approval responses through the Agent Bridge
- bind pending approvals to the validated room, Agent, and runtime session
- clear pending routes when approvals resolve or room context is cleared/deleted
- remove the ineffective “Allow session” action from the Group Chat UI while keeping one-time, permanent, and deny actions

## Why

Group Chat approval requests from Ekko Agent reached the UI, but responses were always sent to the Hermes Agent Bridge. The Ekko approval broker therefore remained pending. Group Chat also creates a fresh runtime session for each run, so its session-level approval action did not carry over to the next message.

## Impact

Ekko Agent tool execution resumes after a Group Chat manager approves it. Hermes approval behavior remains unchanged, cross-room approval identifiers cannot be reused, and single-chat approval choices are unaffected.

## Validation

- `npx vitest run tests/client/group-chat-store-baseline.test.ts tests/server/group-chat-approval.test.ts` — 31 passed
- `npm run harness:check` — passed
- `npm run build` — passed
- `git diff --check` — passed
