### PR TITLE
fix: durably reconcile Chat Run terminal state

### DIFF
--- a/docs/chat-chain-changes/2026-08-06-pr2391-durable-chat-run-terminal-reconciliation.md
+++ b/docs/chat-chain-changes/2026-08-06-pr2391-durable-chat-run-terminal-reconciliation.md
@@ -1,0 +1,14 @@
+---
+date: 2026-08-06
+pr: 2391
+feature: Durable Chat Run terminal reconciliation
+impact: Chat Run completion is correlated to one server-internal invocation and persisted for event-loss reconciliation without changing the one-message Group Chat reply contract.
+---
+
+- Touched feature: HTTP Chat Run, Workflow/Hermes runs, and scoped Coding Agent terminal delivery.
+- Change: add a durable invocation ledger, exact terminal-event fencing, and event-first completion with SQLite fallback.
+- Behavior impact: attachment timeout detaches only the caller, while execution deadlines and explicit cancellation still stop the child; late terminal events cannot settle another invocation.
+- Action handling: `requires_action` remains durable and can later converge to a terminal state; approval errors fail durably, release the Session fence, and interrupt the Bridge.
+- Security boundary: persisted Session Profile remains authoritative, user access is enforced, and caller-provided invocation IDs are discarded at the HTTP boundary.
+- Recovery boundary: active invocations fail closed after server restart; restoring an already-lost parent model/tool stack remains outside this change.
+- Validation: focused lifecycle/controller/Coding Agent tests, repository harness check, production build, and exact-head GitHub CI.

--- a/packages/server/src/controllers/chat-run.ts
+++ b/packages/server/src/controllers/chat-run.ts
@@ -64,7 +64,8 @@ export async function runOnce(ctx: Context) {
   const record = (event: string, data: Record<string, unknown> = {}) => {
     if (!includeEvents) return
     if (events.length >= MAX_RECORDED_EVENTS) events.shift()
-    events.push({ ...data, event: typeof data.event === 'string' ? data.event : event })
+    const { invocation_id: _invocationId, ...publicData } = data
+    events.push({ ...publicData, event: typeof publicData.event === 'string' ? publicData.event : event })
   }
 
   try {

--- a/packages/server/src/controllers/chat-run.ts
+++ b/packages/server/src/controllers/chat-run.ts
@@ -1,7 +1,6 @@
 import type { Context } from 'koa'
 import { randomUUID } from 'crypto'
-import { io, type Socket } from 'socket.io-client'
-import { config } from '../config'
+import type { ChatRunSocket } from '../services/hermes/run-chat'
 
 type ChatRunPayload = Record<string, unknown> & {
   input?: unknown
@@ -11,56 +10,9 @@ type ChatRunPayload = Record<string, unknown> & {
   include_events?: unknown
 }
 
-type ChatRunEvent = Record<string, unknown> & {
-  event?: string
-  session_id?: string
-  run_id?: string
-  delta?: string
-  text?: string
-  output?: string | null
-  reasoning?: string | null
-  error?: unknown
-}
-
-const CHAT_RUN_EVENTS = [
-  'run.started',
-  'message.delta',
-  'message.interim',
-  'reasoning.delta',
-  'thinking.delta',
-  'reasoning.available',
-  'tool.started',
-  'tool.completed',
-  'tool.failed',
-  'workspace.diff.completed',
-  'run.completed',
-  'run.failed',
-  'compression.started',
-  'compression.completed',
-  'abort.started',
-  'abort.timeout',
-  'abort.completed',
-  'usage.updated',
-  'agent.event',
-  'subagent.event',
-  'session.command',
-  'session.title.updated',
-  'run.queued',
-  'approval.requested',
-  'approval.resolved',
-  'clarify.requested',
-  'clarify.resolved',
-  'peer.user.message',
-]
-
 const DEFAULT_TIMEOUT_MS = 300_000
 const MAX_TIMEOUT_MS = 1_800_000
 const MAX_RECORDED_EVENTS = 1000
-
-function bearerToken(ctx: Context): string {
-  const match = ctx.get('authorization').match(/^Bearer\s+(.+)$/i)
-  return match?.[1]?.trim() || ''
-}
 
 function requestTimeoutMs(value: unknown): number {
   const numeric = Number(value)
@@ -68,26 +20,24 @@ function requestTimeoutMs(value: unknown): number {
   return Math.min(Math.floor(numeric), MAX_TIMEOUT_MS)
 }
 
-function chatRunBaseUrl(): string {
-  return (process.env.HERMES_WEB_UI_URL || `http://127.0.0.1:${config.port}`).replace(/\/$/, '')
-}
-
 function profileFrom(ctx: Context, body: ChatRunPayload): string {
   return String(body.profile || ctx.state.profile?.name || 'default').trim() || 'default'
 }
 
 function userBody(body: ChatRunPayload): Record<string, unknown> {
-  const { timeout_ms: _timeoutMs, include_events: _includeEvents, ...payload } = body
+  const {
+    timeout_ms: _timeoutMs,
+    include_events: _includeEvents,
+    invocation_id: _invocationId,
+    ...payload
+  } = body
   return payload
 }
 
-function generatedSessionId(): string {
-  return randomUUID()
-}
-
-function needsGeneratedSessionId(payload: Record<string, unknown>): boolean {
-  const sessionId = typeof payload.session_id === 'string' ? payload.session_id.trim() : ''
-  return !sessionId
+async function currentChatRunServer(): Promise<ChatRunSocket | null> {
+  // Dynamic import avoids a controller/route initialization cycle.
+  const routes = await import('../routes/hermes/chat-run')
+  return routes.getChatRunServer?.() || null
 }
 
 export async function runOnce(ctx: Context) {
@@ -98,106 +48,71 @@ export async function runOnce(ctx: Context) {
     return
   }
 
-  const timeoutMs = requestTimeoutMs(body.timeout_ms)
-  const includeEvents = body.include_events === true
-  const token = bearerToken(ctx)
+  const chatRun = await currentChatRunServer()
+  if (!chatRun?.runAndWait) {
+    ctx.status = 503
+    ctx.body = { ok: false, status: 'unavailable', error: 'chat-run server is not available' }
+    return
+  }
+
   const profile = profileFrom(ctx, body)
   const payload: Record<string, unknown> = { ...userBody(body), profile }
-  if (needsGeneratedSessionId(payload)) payload.session_id = generatedSessionId()
+  const sessionId = String(payload.session_id || '').trim() || randomUUID()
+  payload.session_id = sessionId
+  const includeEvents = body.include_events === true
+  const events: Array<Record<string, unknown>> = []
+  const record = (event: string, data: Record<string, unknown> = {}) => {
+    if (!includeEvents) return
+    if (events.length >= MAX_RECORDED_EVENTS) events.shift()
+    events.push({ ...data, event: typeof data.event === 'string' ? data.event : event })
+  }
 
-  ctx.body = await new Promise((resolve) => {
-    const events: ChatRunEvent[] = []
-    let output = ''
-    let reasoning = ''
-    let runId = ''
-    let settled = false
-
-    const socket: Socket = io(`${chatRunBaseUrl()}/chat-run`, {
-      auth: token ? { token } : {},
-      query: { profile },
-      transports: ['websocket', 'polling'],
-      reconnection: false,
-      timeout: 30_000,
+  try {
+    const result = await chatRun.runAndWait(payload as any, {
+      profile,
+      user: ctx.state.user,
+      attachmentTimeoutMs: requestTimeoutMs(body.timeout_ms),
+      detachOnAction: true,
+      onEvent: record,
     })
-
-    const cleanup = () => {
-      clearTimeout(timer)
-      socket.removeAllListeners()
-      socket.disconnect()
+    const common = {
+      session_id: sessionId,
+      run_id: result.run_id || undefined,
+      output: result.output || '',
+      ...(result.reasoning ? { reasoning: result.reasoning } : {}),
+      ...(includeEvents ? { events } : {}),
     }
-
-    const finish = (status: number, response: Record<string, unknown>) => {
-      if (settled) return
-      settled = true
-      cleanup()
-      ctx.status = status
-      resolve({
-        ...response,
-        session_id: typeof payload.session_id === 'string' ? payload.session_id : undefined,
-        run_id: runId || undefined,
-        output,
-        ...(reasoning ? { reasoning } : {}),
-        ...(includeEvents ? { events } : {}),
-      })
+    if (result.event === 'run.completed' && result.ok) {
+      ctx.status = 200
+      ctx.body = { ok: true, status: 'completed', event: result.event, ...common }
+      return
     }
-
-    const record = (event: ChatRunEvent) => {
-      if (!includeEvents) return
-      if (events.length >= MAX_RECORDED_EVENTS) events.shift()
-      events.push(event)
-    }
-
-    const timer = setTimeout(() => {
-      finish(504, {
+    if (result.event === 'action.required') {
+      ctx.status = 409
+      ctx.body = {
         ok: false,
-        status: 'timeout',
-        error: `chat-run timed out after ${timeoutMs}ms`,
-      })
-    }, timeoutMs)
-
-    socket.on('connect_error', (err: Error) => {
-      finish(503, {
-        ok: false,
-        status: 'connect_error',
-        error: err.message,
-      })
-    })
-
-    socket.on('connect', () => {
-      socket.emit('run', payload)
-    })
-
-    for (const eventName of CHAT_RUN_EVENTS) {
-      socket.on(eventName, (event: ChatRunEvent = {}) => {
-        const tagged = { ...event, event: event.event || eventName }
-        record(tagged)
-        if (typeof tagged.run_id === 'string' && tagged.run_id) runId = tagged.run_id
-        if (eventName === 'message.delta' && typeof tagged.delta === 'string') output += tagged.delta
-        if ((eventName === 'reasoning.delta' || eventName === 'thinking.delta') && typeof tagged.delta === 'string') reasoning += tagged.delta
-        if (eventName === 'run.completed') {
-          if (typeof tagged.output === 'string' && tagged.output) output = tagged.output
-          if (typeof tagged.reasoning === 'string' && tagged.reasoning) reasoning = tagged.reasoning
-          finish(200, { ok: true, status: 'completed', event: eventName })
-          return
-        }
-        if (eventName === 'run.failed') {
-          finish(500, {
-            ok: false,
-            status: 'failed',
-            event: eventName,
-            error: tagged.error || 'chat-run failed',
-          })
-          return
-        }
-        if (eventName === 'approval.requested' || eventName === 'clarify.requested') {
-          finish(409, {
-            ok: false,
-            status: 'requires_action',
-            event: eventName,
-            action: tagged,
-          })
-        }
-      })
+        status: 'requires_action',
+        event: typeof result.action?.event === 'string' ? result.action.event : 'action.required',
+        action: result.action,
+        ...common,
+      }
+      return
     }
-  })
+    if (result.event === 'wait.timed_out') {
+      ctx.status = 504
+      ctx.body = { ok: false, status: 'timeout', event: result.event, error: result.error, ...common }
+      return
+    }
+    ctx.status = 500
+    ctx.body = { ok: false, status: 'failed', event: result.event, error: result.error || 'chat-run failed', ...common }
+  } catch (err) {
+    ctx.status = 500
+    ctx.body = {
+      ok: false,
+      status: 'failed',
+      session_id: sessionId,
+      error: err instanceof Error ? err.message : String(err),
+      ...(includeEvents ? { events } : {}),
+    }
+  }
 }

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -38,6 +38,7 @@ import {
   workspaceBaseOverride,
 } from '../../services/hermes/workspace-path'
 import { getGroupChatServer } from '../../routes/hermes/group-chat'
+import { getChatRunServer } from '../../routes/hermes/chat-run'
 import { logger } from '../../services/logger'
 import type { ConversationSummary } from '../../services/hermes/conversations'
 import { listUserProfiles } from '../../db/hermes/users-store'
@@ -52,6 +53,17 @@ import { relative, normalize as pathNormalize, resolve as pathResolve } from 'pa
 
 function getPendingDeletedSessionIds(): Set<string> {
   return getGroupChatServer()?.getStorage().getPendingDeletedSessionIds() || new Set<string>()
+}
+
+async function disposeChatRunBeforeDelete(sessionId: string, codingAgentSession: boolean): Promise<void> {
+  const chatRunServer = getChatRunServer()
+  if (chatRunServer) {
+    await chatRunServer.disposeSession(sessionId, { deletePersistedSession: false })
+    return
+  }
+  // Routes are normally initialized after ChatRunSocket. Preserve the previous
+  // controller-only fallback for tests or startup/shutdown edge cases.
+  if (codingAgentSession) codingAgentRunManager.stop(sessionId, { reportClosed: false })
 }
 
 function filterPendingDeletedSessions<T extends { id: string }>(items: T[]): T[] {
@@ -1192,7 +1204,7 @@ export async function remove(ctx: any) {
   if (denySessionAccess(ctx, existing)) return
   const hermesProfile = requestedProfile(ctx) || existing?.profile || getActiveProfileName()
   const codingAgentSession = isCodingAgentSession(existing)
-  if (codingAgentSession) codingAgentRunManager.stop(sessionId, { reportClosed: false })
+  if (existing) await disposeChatRunBeforeDelete(sessionId, codingAgentSession)
   const hermes = codingAgentSession
     ? { attempted: false, deleted: false, profile: hermesProfile }
     : await deleteHermesSessionIfPresent(sessionId, hermesProfile)
@@ -1262,7 +1274,7 @@ export async function batchRemove(ctx: any) {
     }
 
     const codingAgentSession = isCodingAgentSession(existing)
-    if (codingAgentSession) codingAgentRunManager.stop(id, { reportClosed: false })
+    if (existing) await disposeChatRunBeforeDelete(id, codingAgentSession)
     const hermes = codingAgentSession
       ? { attempted: false, deleted: false, profile: targetProfile || 'default' }
       : await deleteHermesSessionIfPresent(id, targetProfile)

--- a/packages/server/src/db/hermes/chat-run-invocation-store.ts
+++ b/packages/server/src/db/hermes/chat-run-invocation-store.ts
@@ -1,0 +1,140 @@
+import { getDb } from '../index'
+import { CHAT_RUN_INVOCATIONS_TABLE } from './schemas'
+
+export type ChatRunInvocationStatus = 'running' | 'requires_action' | 'completed' | 'failed' | 'canceled'
+export type ChatRunInvocationTerminalStatus = 'completed' | 'failed' | 'canceled'
+
+const MAX_INVOCATION_TEXT_BYTES = 2 * 1024 * 1024
+
+function boundedText(value?: string | null): string | null {
+  if (value == null) return null
+  const text = String(value)
+  if (Buffer.byteLength(text, 'utf8') <= MAX_INVOCATION_TEXT_BYTES) return text
+  let low = 0
+  let high = text.length
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2)
+    if (Buffer.byteLength(text.slice(mid), 'utf8') > MAX_INVOCATION_TEXT_BYTES) low = mid + 1
+    else high = mid
+  }
+  let start = low
+  if (start > 0) {
+    const code = text.charCodeAt(start)
+    if (code >= 0xDC00 && code <= 0xDFFF) start += 1
+  }
+  return text.slice(start)
+}
+
+export interface ChatRunInvocationRecord {
+  id: string
+  session_id: string
+  run_id: string
+  status: ChatRunInvocationStatus
+  output: string | null
+  reasoning: string | null
+  error: string | null
+  action: Record<string, unknown> | null
+  started_at: number
+  finished_at: number | null
+}
+
+function mapRow(row: Record<string, unknown>): ChatRunInvocationRecord {
+  return {
+    id: String(row.id || ''),
+    session_id: String(row.session_id || ''),
+    run_id: String(row.run_id || ''),
+    status: String(row.status || 'running') as ChatRunInvocationStatus,
+    output: row.output == null ? null : String(row.output),
+    reasoning: row.reasoning == null ? null : String(row.reasoning),
+    error: row.error == null ? null : String(row.error),
+    action: (() => {
+      if (row.action == null || row.action === '') return null
+      try { return JSON.parse(String(row.action)) as Record<string, unknown> } catch { return null }
+    })(),
+    started_at: Number(row.started_at || 0),
+    finished_at: row.finished_at == null ? null : Number(row.finished_at),
+  }
+}
+
+export function createChatRunInvocation(input: {
+  id: string
+  sessionId: string
+  startedAt?: number
+}): ChatRunInvocationRecord {
+  const db = getDb()
+  if (!db) throw new Error('SQLite is required for durable chat run invocations')
+  const startedAt = input.startedAt ?? Math.floor(Date.now() / 1000)
+  db.prepare(
+    `INSERT INTO ${CHAT_RUN_INVOCATIONS_TABLE} (id, session_id, status, started_at) VALUES (?, ?, 'running', ?)`,
+  ).run(input.id, input.sessionId, startedAt)
+  return getChatRunInvocation(input.id)!
+}
+
+export function getChatRunInvocation(id: string): ChatRunInvocationRecord | null {
+  const db = getDb()
+  if (!db) return null
+  const row = db.prepare(`SELECT * FROM ${CHAT_RUN_INVOCATIONS_TABLE} WHERE id = ?`).get(id) as Record<string, unknown> | undefined
+  return row ? mapRow(row) : null
+}
+
+export function markChatRunInvocationRequiresAction(
+  id: string,
+  action: Record<string, unknown>,
+): boolean {
+  const db = getDb()
+  if (!db) return false
+  const result = db.prepare(
+    `UPDATE ${CHAT_RUN_INVOCATIONS_TABLE} SET status = 'requires_action', action = ? WHERE id = ? AND status = 'running'`,
+  ).run(JSON.stringify(action), id)
+  return Number(result.changes || 0) === 1
+}
+
+export function recoverOrphanedChatRunInvocations(reason = 'Chat run interrupted by server restart'): number {
+  const db = getDb()
+  if (!db) return 0
+  const now = Math.floor(Date.now() / 1000)
+  const result = db.prepare(
+    `UPDATE ${CHAT_RUN_INVOCATIONS_TABLE}
+       SET status = 'failed', error = ?, action = NULL, finished_at = ?
+     WHERE status IN ('running', 'requires_action')`,
+  ).run(reason, now)
+  return Number(result.changes || 0)
+}
+
+export function pruneChatRunInvocations(finishedBefore: number): number {
+  const db = getDb()
+  if (!db) return 0
+  const result = db.prepare(
+    `DELETE FROM ${CHAT_RUN_INVOCATIONS_TABLE} WHERE finished_at IS NOT NULL AND finished_at < ?`,
+  ).run(finishedBefore)
+  return Number(result.changes || 0)
+}
+
+export function settleChatRunInvocation(
+  id: string,
+  terminal: {
+    status: ChatRunInvocationTerminalStatus
+    runId?: string | null
+    output?: string | null
+    reasoning?: string | null
+    error?: string | null
+    finishedAt?: number
+  },
+): boolean {
+  const db = getDb()
+  if (!db) return false
+  const result = db.prepare(
+    `UPDATE ${CHAT_RUN_INVOCATIONS_TABLE}
+       SET run_id = ?, status = ?, output = ?, reasoning = ?, error = ?, action = NULL, finished_at = ?
+     WHERE id = ? AND status IN ('running', 'requires_action')`,
+  ).run(
+    terminal.runId || '',
+    terminal.status,
+    boundedText(terminal.output),
+    boundedText(terminal.reasoning),
+    boundedText(terminal.error),
+    terminal.finishedAt ?? Math.floor(Date.now() / 1000),
+    id,
+  )
+  return Number(result.changes || 0) === 1
+}

--- a/packages/server/src/db/hermes/init.ts
+++ b/packages/server/src/db/hermes/init.ts
@@ -7,8 +7,13 @@
  */
 
 import { initAllHermesTables } from './schemas'
+import { pruneChatRunInvocations, recoverOrphanedChatRunInvocations } from './chat-run-invocation-store'
+
+const CHAT_RUN_INVOCATION_RETENTION_SECONDS = 7 * 24 * 60 * 60
 
 export function initAllStores(): void {
   // Initialize all tables with centralized schema definitions and migrations
   initAllHermesTables()
+  recoverOrphanedChatRunInvocations()
+  pruneChatRunInvocations(Math.floor(Date.now() / 1000) - CHAT_RUN_INVOCATION_RETENTION_SECONDS)
 }

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -115,6 +115,26 @@ export const MESSAGES_SCHEMA: Record<string, string> = {
 
 export const MESSAGES_INDEX = 'CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id)'
 
+export const CHAT_RUN_INVOCATIONS_TABLE = 'chat_run_invocations'
+
+export const CHAT_RUN_INVOCATIONS_SCHEMA: Record<string, string> = {
+  id: 'TEXT PRIMARY KEY',
+  session_id: 'TEXT NOT NULL',
+  run_id: "TEXT NOT NULL DEFAULT ''",
+  status: "TEXT NOT NULL DEFAULT 'running'",
+  output: 'TEXT',
+  reasoning: 'TEXT',
+  error: 'TEXT',
+  action: 'TEXT',
+  started_at: 'INTEGER NOT NULL',
+  finished_at: 'INTEGER',
+}
+
+export const CHAT_RUN_INVOCATIONS_INDEXES = {
+  idx_chat_run_invocations_session: 'CREATE INDEX IF NOT EXISTS idx_chat_run_invocations_session ON chat_run_invocations(session_id, started_at)',
+  idx_chat_run_invocations_status: 'CREATE INDEX IF NOT EXISTS idx_chat_run_invocations_status ON chat_run_invocations(status)',
+}
+
 // ============================================================================
 // Workspace Run Changes
 // ============================================================================
@@ -1091,6 +1111,9 @@ export function initAllHermesTables(): void {
     createIndexes(db, SESSIONS_INDEXES)
     syncTable(MESSAGES_TABLE, MESSAGES_SCHEMA)
     db.exec(MESSAGES_INDEX)
+    syncTable(CHAT_RUN_INVOCATIONS_TABLE, CHAT_RUN_INVOCATIONS_SCHEMA, {
+      indexes: CHAT_RUN_INVOCATIONS_INDEXES,
+    })
     syncTable(WORKSPACE_RUN_CHANGES_TABLE, WORKSPACE_RUN_CHANGES_SCHEMA, {
       indexes: WORKSPACE_RUN_CHANGES_INDEXES,
     })

--- a/packages/server/src/db/hermes/session-store.ts
+++ b/packages/server/src/db/hermes/session-store.ts
@@ -3,7 +3,7 @@
  * Uses the same ensureTable/getDb pattern as usage-store.ts.
  */
 import { isSqliteAvailable, getDb } from '../index'
-import { COMPRESSION_SNAPSHOT_TABLE, SESSIONS_TABLE, MESSAGES_TABLE } from './schemas'
+import { CHAT_RUN_INVOCATIONS_TABLE, COMPRESSION_SNAPSHOT_TABLE, SESSIONS_TABLE, MESSAGES_TABLE } from './schemas'
 import { normalizeMessageContentForStorageRole } from './message-content'
 import { copyCompressionSnapshot } from './compression-snapshot'
 
@@ -416,6 +416,7 @@ export function deleteSession(id: string): boolean {
   db.exec('BEGIN')
   try {
     db.prepare(`DELETE FROM ${COMPRESSION_SNAPSHOT_TABLE} WHERE session_id = ?`).run(id)
+    db.prepare(`DELETE FROM ${CHAT_RUN_INVOCATIONS_TABLE} WHERE session_id = ?`).run(id)
     db.prepare(`DELETE FROM ${MESSAGES_TABLE} WHERE session_id = ?`).run(id)
     const result = db.prepare(`DELETE FROM ${SESSIONS_TABLE} WHERE id = ?`).run(id)
     db.exec('COMMIT')

--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -113,12 +113,14 @@ interface ManagedCodingAgentRun {
   pendingChatCompletionPayload?: Record<string, unknown>
   memoryExportStarted?: boolean
   assistantMessageId?: string
+  invocationId?: string
 }
 
 interface CodingAgentRunSendOptions {
   systemPrompt?: string
   images?: CodingAgentImageInput[]
   storageInput?: string
+  invocationId?: string
 }
 
 function nowSeconds(): number {
@@ -582,6 +584,7 @@ export class CodingAgentRunManager {
     const systemPrompt = String(options.systemPrompt || '').trim()
     this.ensureDbSession(run)
     run.assistantMessageId = undefined
+    run.invocationId = String(options.invocationId || '').trim() || undefined
     this.addUserMessage(run, options.storageInput ?? text)
     this.touch(run)
     this.emitTerminalStatus(run, 'Input sent to coding agent.')
@@ -875,6 +878,7 @@ export class CodingAgentRunManager {
       this.emitToChat(run.launch.sessionId, 'run.failed', {
         event: 'run.failed',
         error: 'Coding agent session closed',
+        ...(run.invocationId ? { invocation_id: run.invocationId } : {}),
         workspace_run_change: workspaceRunChange,
       })
       this.markChatRunCompleted(run.launch.sessionId, 'run.failed')
@@ -1859,6 +1863,7 @@ export class CodingAgentRunManager {
     const workspaceRunChange = this.completeWorkspaceRunDiff(run)
     this.emitToChat(run.launch.sessionId, event, {
       ...(payload || { event }),
+      ...(run.invocationId ? { invocation_id: run.invocationId } : {}),
       ...(queueRemaining > 0 ? { queue_remaining: queueRemaining } : {}),
       workspace_run_change: workspaceRunChange,
     })
@@ -1880,6 +1885,7 @@ export class CodingAgentRunManager {
     this.markChatRunCompleted(run.launch.sessionId, event)
     if (event === 'run.completed') this.startCodingAgentMemoryExport(run)
     run.runMarker = undefined
+    run.invocationId = undefined
   }
 
   private startCodingAgentMemoryExport(run: ManagedCodingAgentRun) {

--- a/packages/server/src/services/coding-agents.ts
+++ b/packages/server/src/services/coding-agents.ts
@@ -1981,8 +1981,9 @@ export function sendCodingAgentRunInput(
   systemPrompt?: string,
   images: CodingAgentImageInput[] = [],
   storageInput?: string,
+  invocationId?: string,
 ): { runId: string } {
-  return codingAgentRunManager.send(sessionId, input, { systemPrompt, images, storageInput })
+  return codingAgentRunManager.send(sessionId, input, { systemPrompt, images, storageInput, invocationId })
 }
 
 export function stopCodingAgentRun(sessionId: string): { stopped: boolean } {

--- a/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
@@ -35,6 +35,7 @@ export interface CodingAgentRunSocketData {
   api_mode?: any
   reasoning_effort?: string
   session_source?: 'global_agent' | 'workflow'
+  invocation_id?: string
   group_system_prompt?: string
   group_room_id?: string
   group_agent_id?: string
@@ -133,13 +134,17 @@ export async function handleCodingAgentRun(
       groupSystemPrompt || (includeBaseSystemPrompt ? getSystemPrompt(undefined, { source: data.session_source || data.source }) : ''),
     ].filter(Boolean).join('\n')
     if (Array.isArray(data.input)) {
-      await sendCodingAgentRunInput(
+      const args: Parameters<typeof sendCodingAgentRunInput> = [
         sessionId,
         codingInput.text,
         runPrompt,
         codingInput.images,
         contentBlocksToString(data.input),
-      )
+      ]
+      if (data.invocation_id) args.push(data.invocation_id)
+      await sendCodingAgentRunInput(...args)
+    } else if (data.invocation_id) {
+      await sendCodingAgentRunInput(sessionId, codingInput.text, runPrompt, [], undefined, data.invocation_id)
     } else {
       await sendCodingAgentRunInput(sessionId, codingInput.text, runPrompt)
     }

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Server, Socket } from 'socket.io'
+import { randomUUID } from 'crypto'
 import { logger } from '../../logger'
 import { getSystemPrompt } from '../../../lib/llm-prompt'
 import { clearSessionMessages, deleteSession, getSession, getSessionMetadata, listSessions, updateMessageDisplayContent } from '../../../db/hermes/session-store'
@@ -35,6 +36,13 @@ import { observeRunChatPetEvent } from '../pet-state-socket'
 import { codingAgentRunManager } from '../../agent-runner/coding-agent-run-manager'
 import { respondToEkkoToolApproval } from '../../ekko-agent/approvals'
 import { respondToEkkoClarification } from '../../ekko-agent/clarifications'
+import {
+  createChatRunInvocation,
+  getChatRunInvocation,
+  markChatRunInvocationRequiresAction,
+  settleChatRunInvocation,
+  type ChatRunInvocationRecord,
+} from '../../../db/hermes/chat-run-invocation-store'
 
 export type { ContentBlock } from './types'
 
@@ -173,12 +181,13 @@ function isEkkoAgentExecution(data?: { coding_agent_id?: string; agent_id?: stri
 
 export interface ChatRunAndWaitResult {
   ok: boolean
-  event: 'run.completed' | 'run.failed'
+  event: 'run.completed' | 'run.failed' | 'wait.timed_out' | 'action.required'
   session_id: string
   run_id?: string
   output?: string | null
   reasoning?: string | null
   error?: string
+  action?: Record<string, unknown>
 }
 
 type ChatRunAutoApprovalChoice = 'once' | 'session' | 'always'
@@ -191,6 +200,9 @@ export class ChatRunSocket {
   private sessionMap = new Map<string, SessionState>()
   private bridgeResumePolls = new Set<string>()
   private readonly runWaiters = new Map<string, Set<(event: string, payload: any) => void>>()
+  private readonly activeRunInvocations = new Map<string, string>()
+  private readonly runAttachmentDisposers = new Map<string, () => void>()
+  private readonly runExecutionTimers = new Map<string, NodeJS.Timeout>()
   private backgroundPollTimer?: NodeJS.Timeout
   private backgroundPollInFlight = false
   private backgroundRecoveryNeeded = true
@@ -198,6 +210,18 @@ export class ChatRunSocket {
   private backgroundPollRetryAt = 0
   private backgroundActivityGraceUntil = 0
   private closing = false
+
+  private clearRunExecutionTimer(invocationId: string): void {
+    const timer = this.runExecutionTimers.get(invocationId)
+    if (timer) clearTimeout(timer)
+    this.runExecutionTimers.delete(invocationId)
+  }
+
+  private releaseRunInvocation(sessionId: string, invocationId: string): void {
+    if (this.activeRunInvocations.get(sessionId) === invocationId) {
+      this.activeRunInvocations.delete(sessionId)
+    }
+  }
 
   constructor(io: Server) {
     this.nsp = io.of('/chat-run')
@@ -306,11 +330,12 @@ export class ChatRunSocket {
       try {
         runProfile = resolveRunProfile(data.session_id, data.profile)
       } catch (err) {
+        const error = err instanceof Error ? err.message : String(err)
         socket.emit('run.failed', {
           event: 'run.failed',
           session_id: data.session_id,
           queue_id: data.queue_id,
-          error: err instanceof Error ? err.message : String(err),
+          error,
         })
         return
       }
@@ -407,11 +432,12 @@ export class ChatRunSocket {
             state.profile = undefined
           }
         }
+        const error = err instanceof Error ? err.message : String(err)
         socket.emit('run.failed', {
           event: 'run.failed',
           session_id: data.session_id,
           queue_id: data.queue_id,
-          error: err instanceof Error ? err.message : String(err),
+          error,
         })
       }
     })
@@ -543,6 +569,7 @@ export class ChatRunSocket {
       source?: string
       session_source?: 'global_agent' | 'workflow'
       queue_id?: string
+      invocation_id?: string
       peerExcludeSocketId?: string
       coding_agent_id?: ChatCodingAgentId
       agent_id?: ChatCodingAgentId
@@ -606,7 +633,8 @@ export class ChatRunSocket {
           error: `Agent Bridge is not reachable: ${bridgeReady.error}`,
         }
         if (queueRemaining > 0) payload.queue_remaining = queueRemaining
-        socket.emit('run.failed', payload)
+        if (data.onEvent) data.onEvent('run.failed', payload)
+        else socket.emit('run.failed', payload)
         if (data.session_id && data.background_delegation_id && data.background_claim_id) {
           void this.bridge.releaseBackgroundNotification(
             data.session_id,
@@ -1099,14 +1127,31 @@ export class ChatRunSocket {
       profile?: string
       user?: AuthenticatedUser
       timeoutMs?: number
+      attachmentTimeoutMs?: number
+      detachOnAction?: boolean
       approvalChoice?: ChatRunAutoApprovalChoice
       onEvent?: (event: string, payload: any) => void
     } = {},
   ): Promise<ChatRunAndWaitResult> {
     const sessionId = String(data.session_id || '').trim()
     if (!sessionId) throw new Error('session_id is required')
-    const profile = options.profile || data.profile || getSession(sessionId)?.profile || getActiveProfileName() || 'default'
+    const storedSession = getSession(sessionId)
+    const requestedProfile = String(options.profile || data.profile || '').trim()
+    const storedProfile = String(storedSession?.profile || '').trim()
+    if (storedProfile && requestedProfile && requestedProfile !== storedProfile) {
+      throw new Error(`Requested profile "${requestedProfile}" does not match persisted session profile "${storedProfile}"`)
+    }
+    const profile = storedProfile || requestedProfile || getActiveProfileName() || 'default'
+    if (options.user && !this.canAccessProfile(options.user, profile)) {
+      throw new Error(`Profile "${profile}" is not available for this user`)
+    }
     const source = resolveRunSource(data.source, sessionId)
+    if (this.activeRunInvocations.has(sessionId)) {
+      throw new Error(`session ${sessionId} already has an active chat run invocation`)
+    }
+    const invocationId = randomUUID()
+    createChatRunInvocation({ id: invocationId, sessionId })
+    this.activeRunInvocations.set(sessionId, invocationId)
     const state = getOrCreateSession(this.sessionMap, sessionId)
     state.events = []
     state.isWorking = !isCodingAgentExecution(source, data)
@@ -1118,12 +1163,32 @@ export class ChatRunSocket {
       let output = ''
       let reasoning = ''
       let runId = ''
-      const timeoutMs = options.timeoutMs && options.timeoutMs > 0 ? options.timeoutMs : null
+      const executionTimeoutMs = options.timeoutMs && options.timeoutMs > 0 ? options.timeoutMs : null
+      const attachmentTimeoutMs = options.attachmentTimeoutMs && options.attachmentTimeoutMs > 0 ? options.attachmentTimeoutMs : null
       const waiters = this.runWaiters.get(sessionId) || new Set<(event: string, payload: any) => void>()
+      let reconcileTimer: NodeJS.Timeout | undefined
+      let executionTimer: NodeJS.Timeout | undefined
+      let attachmentTimer: NodeJS.Timeout | undefined
+      const resultFromRecord = (record: ChatRunInvocationRecord): Omit<ChatRunAndWaitResult, 'session_id'> | null => {
+        if (record.status === 'running' || record.status === 'requires_action') return null
+        return {
+          ok: record.status === 'completed',
+          event: record.status === 'completed' ? 'run.completed' : 'run.failed',
+          run_id: record.run_id,
+          output: record.output,
+          reasoning: record.reasoning,
+          ...(record.error ? { error: record.error } : {}),
+        }
+      }
       const finish = (result: Omit<ChatRunAndWaitResult, 'session_id'>) => {
         if (settled) return
         settled = true
-        if (timer) clearTimeout(timer)
+        if (result.event !== 'wait.timed_out' && result.event !== 'action.required') {
+          this.clearRunExecutionTimer(invocationId)
+        }
+        if (attachmentTimer) clearTimeout(attachmentTimer)
+        clearInterval(reconcileTimer)
+        this.runAttachmentDisposers.delete(invocationId)
         waiters.delete(onEvent)
         if (waiters.size === 0) this.runWaiters.delete(sessionId)
         resolve({
@@ -1134,6 +1199,15 @@ export class ChatRunSocket {
           ...result,
         })
       }
+      const failApproval = (error: string) => {
+        settleChatRunInvocation(invocationId, { status: 'failed', runId, output, reasoning, error })
+        this.releaseRunInvocation(sessionId, invocationId)
+        this.clearRunExecutionTimer(invocationId)
+        finish({ ok: false, event: 'run.failed', run_id: runId, output, reasoning, error })
+        void this.bridge.interrupt(sessionId, error, profile).catch(err => {
+          logger.warn(err, '[chat-run-socket] failed to interrupt approval-blocked session %s', sessionId)
+        })
+      }
       const respondToApproval = async (payload: any = {}) => {
         const choice = options.approvalChoice
         if (!choice || settled) return
@@ -1141,11 +1215,11 @@ export class ChatRunSocket {
         const rawChoices = Array.isArray(payload.choices) ? payload.choices.map((item: unknown) => String(item)) : []
         const choices = rawChoices.length > 0 ? rawChoices : ['once', 'session', 'deny']
         if (!approvalId) {
-          finish({ ok: false, event: 'run.failed', output, reasoning, error: 'approval required' })
+          failApproval('approval required')
           return
         }
         if (!choices.includes(choice)) {
-          finish({ ok: false, event: 'run.failed', output, reasoning, error: `approval choice "${choice}" is not available` })
+          failApproval(`approval choice "${choice}" is not available`)
           return
         }
         try {
@@ -1169,10 +1243,14 @@ export class ChatRunSocket {
             resolved: false,
             error,
           })
-          finish({ ok: false, event: 'run.failed', output, reasoning, error })
+          failApproval(error)
         }
       }
       const onEvent = (event: string, payload: any = {}) => {
+        const eventInvocationId = typeof payload.invocation_id === 'string' ? payload.invocation_id : ''
+        if ((event === 'run.completed' || event === 'run.failed') && eventInvocationId && eventInvocationId !== invocationId) {
+          return
+        }
         if (typeof payload.run_id === 'string' && payload.run_id) runId = payload.run_id
         if (event === 'message.delta' && typeof payload.delta === 'string') output += payload.delta
         if ((event === 'reasoning.delta' || event === 'thinking.delta') && typeof payload.delta === 'string') reasoning += payload.delta
@@ -1181,10 +1259,25 @@ export class ChatRunSocket {
         } catch (err) {
           logger.warn(err, '[chat-run-socket] runAndWait event observer failed for session %s', sessionId)
         }
-        if (event === 'approval.requested') {
+        if (event === 'approval.requested' && options.detachOnAction && !options.approvalChoice) {
+          markChatRunInvocationRequiresAction(invocationId, { ...payload, event })
+          finish({ ok: false, event: 'action.required', run_id: payload.run_id, output, reasoning, action: { ...payload, event } })
+        } else if (event === 'clarify.requested' && options.detachOnAction) {
+          markChatRunInvocationRequiresAction(invocationId, { ...payload, event })
+          finish({ ok: false, event: 'action.required', run_id: payload.run_id, output, reasoning, action: { ...payload, event } })
+        } else if (event === 'approval.requested') {
           void respondToApproval(payload)
         } else if (event === 'run.completed') {
-          finish({
+          settleChatRunInvocation(invocationId, {
+            status: 'completed',
+            runId: payload.run_id,
+            output: typeof payload.output === 'string' && payload.output ? payload.output : output,
+            reasoning: typeof payload.reasoning === 'string' && payload.reasoning ? payload.reasoning : reasoning,
+          })
+          this.releaseRunInvocation(sessionId, invocationId)
+          this.clearRunExecutionTimer(invocationId)
+          const persisted = getChatRunInvocation(invocationId)
+          finish(persisted ? resultFromRecord(persisted)! : {
             ok: true,
             event: 'run.completed',
             run_id: payload.run_id,
@@ -1192,7 +1285,17 @@ export class ChatRunSocket {
             reasoning: typeof payload.reasoning === 'string' && payload.reasoning ? payload.reasoning : reasoning,
           })
         } else if (event === 'run.failed') {
-          finish({
+          settleChatRunInvocation(invocationId, {
+            status: 'failed',
+            runId: payload.run_id,
+            output,
+            reasoning,
+            error: payload.error ? String(payload.error) : 'chat-run failed',
+          })
+          this.releaseRunInvocation(sessionId, invocationId)
+          this.clearRunExecutionTimer(invocationId)
+          const persisted = getChatRunInvocation(invocationId)
+          finish(persisted ? resultFromRecord(persisted)! : {
             ok: false,
             event: 'run.failed',
             run_id: payload.run_id,
@@ -1202,17 +1305,52 @@ export class ChatRunSocket {
           })
         }
       }
-      const timer = timeoutMs
+      executionTimer = executionTimeoutMs
         ? setTimeout(() => {
-            const error = `chat-run timed out after ${timeoutMs}ms`
-            finish({ ok: false, event: 'run.failed', error })
+            this.runExecutionTimers.delete(invocationId)
+            const error = `chat-run timed out after ${executionTimeoutMs}ms`
+            settleChatRunInvocation(invocationId, { status: 'failed', runId, output, reasoning, error })
+            this.releaseRunInvocation(sessionId, invocationId)
+            finish({ ok: false, event: 'run.failed', run_id: runId, output, reasoning, error })
             void this.abortSession(sessionId, error).catch(err => {
               logger.warn(err, '[chat-run-socket] failed to abort timed-out session %s', sessionId)
             })
-          }, timeoutMs)
-        : null
+          }, executionTimeoutMs)
+        : undefined
+      if (executionTimer) {
+        executionTimer.unref?.()
+        this.runExecutionTimers.set(invocationId, executionTimer)
+      }
+      attachmentTimer = attachmentTimeoutMs
+        ? setTimeout(() => {
+            const error = `chat-run attachment timed out after ${attachmentTimeoutMs}ms`
+            finish({ ok: false, event: 'wait.timed_out', error })
+          }, attachmentTimeoutMs)
+        : undefined
       waiters.add(onEvent)
       this.runWaiters.set(sessionId, waiters)
+      const reconcile = () => {
+        const record = getChatRunInvocation(invocationId)
+        if (!record) return
+        const result = resultFromRecord(record)
+        if (!result) return
+        this.releaseRunInvocation(sessionId, invocationId)
+        this.clearRunExecutionTimer(invocationId)
+        finish(result)
+      }
+      reconcileTimer = setInterval(reconcile, 1000)
+      reconcileTimer.unref?.()
+      this.runAttachmentDisposers.set(invocationId, () => {
+        settleChatRunInvocation(invocationId, { status: 'canceled', error: 'Chat run server closed' })
+        this.releaseRunInvocation(sessionId, invocationId)
+        const record = getChatRunInvocation(invocationId)
+        finish(record ? resultFromRecord(record)! : {
+          ok: false,
+          event: 'run.failed',
+          error: 'Chat run server closed',
+        })
+      })
+      reconcile()
 
       const fakeSocket = {
         id: `workflow-run-${sessionId}`,
@@ -1228,14 +1366,24 @@ export class ChatRunSocket {
         emit: (event: string, payload: any) => onEvent(event, payload),
       } as unknown as Socket
 
-      this.handleRun(fakeSocket, { ...data, onEvent }, profile)
-        .catch(err => finish({ ok: false, event: 'run.failed', error: err instanceof Error ? err.message : String(err) }))
+      const internalData = { ...data, invocation_id: invocationId, onEvent } as typeof data & {
+        invocation_id: string
+        onEvent: (event: string, payload: any) => void
+      }
+      this.handleRun(fakeSocket, internalData, profile)
+        .catch(err => onEvent('run.failed', { error: err instanceof Error ? err.message : String(err) }))
     })
   }
 
   async abortSession(sessionId: string, reason = 'Run canceled'): Promise<void> {
     const sid = String(sessionId || '').trim()
     if (!sid) return
+    const invocationId = this.activeRunInvocations.get(sid)
+    if (invocationId) {
+      settleChatRunInvocation(invocationId, { status: 'canceled', error: reason })
+      this.releaseRunInvocation(sid, invocationId)
+      this.clearRunExecutionTimer(invocationId)
+    }
     const fakeSocket = {
       id: `workflow-abort-${sid}`,
       connected: false,
@@ -1261,6 +1409,13 @@ export class ChatRunSocket {
   async disposeSession(sessionId: string): Promise<void> {
     const sid = String(sessionId || '').trim()
     if (!sid) return
+    const invocationId = this.activeRunInvocations.get(sid)
+    if (invocationId) {
+      settleChatRunInvocation(invocationId, { status: 'canceled', error: 'Session disposed' })
+      this.emitExternalEvent(sid, 'run.failed', { event: 'run.failed', error: 'Session disposed' })
+      this.releaseRunInvocation(sid, invocationId)
+      this.clearRunExecutionTimer(invocationId)
+    }
     codingAgentRunManager.stop(sid, { reportClosed: false })
     const state = this.sessionMap.get(sid)
     state?.abortController?.abort()
@@ -1271,6 +1426,25 @@ export class ChatRunSocket {
 
   emitExternalEvent(sessionId: string, event: string, payload: any) {
     const tagged = { ...payload, session_id: sessionId }
+    const terminal = event === 'run.completed' || event === 'run.failed'
+    let deliverToInvocationWaiters = true
+    if (terminal) {
+      const invocationId = this.activeRunInvocations.get(sessionId)
+      const eventInvocationId = typeof tagged.invocation_id === 'string' ? tagged.invocation_id : ''
+      if (invocationId && eventInvocationId !== invocationId) {
+        deliverToInvocationWaiters = false
+      } else if (invocationId) {
+        settleChatRunInvocation(invocationId, {
+          status: event === 'run.completed' ? 'completed' : 'failed',
+          runId: tagged.run_id,
+          output: tagged.output,
+          reasoning: tagged.reasoning,
+          error: event === 'run.failed' ? String(tagged.error || 'chat-run failed') : null,
+        })
+        this.releaseRunInvocation(sessionId, invocationId)
+        this.clearRunExecutionTimer(invocationId)
+      }
+    }
     const profile = this.resolvePetEventProfile(sessionId, tagged)
     this.observePetEvent(profile, event, tagged)
     const state = this.sessionMap.get(sessionId)
@@ -1280,7 +1454,7 @@ export class ChatRunSocket {
     }
     this.nsp.to(`session:${sessionId}`).emit(event, tagged)
     const waiters = this.runWaiters.get(sessionId)
-    if (waiters) {
+    if (waiters && deliverToInvocationWaiters) {
       for (const waiter of waiters) waiter(event, tagged)
     }
   }
@@ -1435,6 +1609,16 @@ export class ChatRunSocket {
       clearInterval(this.backgroundPollTimer)
       this.backgroundPollTimer = undefined
     }
+    for (const dispose of [...this.runAttachmentDisposers.values()]) dispose()
+    this.runAttachmentDisposers.clear()
+    for (const [sessionId, invocationId] of [...this.activeRunInvocations.entries()]) {
+      settleChatRunInvocation(invocationId, { status: 'canceled', error: 'Chat run server closed' })
+      this.releaseRunInvocation(sessionId, invocationId)
+      this.clearRunExecutionTimer(invocationId)
+    }
+    for (const timer of this.runExecutionTimers.values()) clearTimeout(timer)
+    this.runExecutionTimers.clear()
+    this.runWaiters.clear()
     const releaseClaims: Array<Promise<unknown>> = []
     for (const [sessionId, state] of this.sessionMap.entries()) {
       if (state.abortController) {

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -1406,22 +1406,18 @@ export class ChatRunSocket {
     })
   }
 
-  async disposeSession(sessionId: string): Promise<void> {
+  async disposeSession(
+    sessionId: string,
+    options: { deletePersistedSession?: boolean } = {},
+  ): Promise<void> {
     const sid = String(sessionId || '').trim()
     if (!sid) return
-    const invocationId = this.activeRunInvocations.get(sid)
-    if (invocationId) {
-      settleChatRunInvocation(invocationId, { status: 'canceled', error: 'Session disposed' })
-      this.emitExternalEvent(sid, 'run.failed', { event: 'run.failed', error: 'Session disposed' })
-      this.releaseRunInvocation(sid, invocationId)
-      this.clearRunExecutionTimer(invocationId)
-    }
-    codingAgentRunManager.stop(sid, { reportClosed: false })
+    await this.abortSession(sid, 'Session disposed')
     const state = this.sessionMap.get(sid)
     state?.abortController?.abort()
     this.sessionMap.delete(sid)
     this.runWaiters.delete(sid)
-    deleteSession(sid)
+    if (options.deletePersistedSession !== false) deleteSession(sid)
   }
 
   emitExternalEvent(sessionId: string, event: string, payload: any) {

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -778,6 +778,7 @@ describe('coding agent run state', () => {
     const run = (manager as any).runs.get(agentSessionId)
     run.printResponseId = 'resp_codex_1'
     run.printMessageId = 'msg_resp_codex_1'
+    run.invocationId = 'inv-codex-jsonl'
     run.printTextStarted = false
     run.printText = ''
     run.printCompleted = false
@@ -813,6 +814,9 @@ describe('coding agent run state', () => {
     expect(emitted.find(event => event.event === 'usage.updated' && event.payload.contextTokens != null)?.payload).toEqual(expect.objectContaining({
       contextTokens: expect.any(Number),
     }))
+    expect(emitted.find(event => event.event === 'run.completed')?.payload).toMatchObject({
+      invocation_id: 'inv-codex-jsonl',
+    })
     expect(emitted.find(event => event.event === 'run.completed')?.payload).not.toHaveProperty('usage')
     const eventNames = emitted.map(event => event.event)
     expect(eventNames.lastIndexOf('usage.updated')).toBeLessThan(eventNames.indexOf('run.completed'))
@@ -1625,6 +1629,41 @@ describe('coding agent run state', () => {
 
     expect(getSession(chatSessionId)?.agent_native_session_id).toBe('0199a213-81c0-7800-8aa1-bbab2a035a53')
     manager.shutdown()
+  })
+
+  it('tags cleanup failures with the immutable current invocation id', () => {
+    initAllHermesTables()
+    const manager = new CodingAgentRunManager()
+    const emitted: Array<{ event: string; payload: any }> = []
+    ;(manager as any).emitToChat = (_sessionId: string, event: string, payload: any) => {
+      emitted.push({ event, payload })
+    }
+    const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    const agentSessionId = `agent-session-cleanup-invocation-${suffix}`
+    const chatSessionId = `chat-session-cleanup-invocation-${suffix}`
+    manager.start({
+      agentSessionId,
+      agentId: 'codex',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'gpt-5-codex',
+      sessionId: chatSessionId,
+      command: 'codex',
+      args: [],
+      shellCommand: 'codex',
+      workspaceDir: process.cwd(),
+      state: { messages: [], isWorking: true, events: [], queue: [] },
+    })
+    const run = (manager as any).runs.get(agentSessionId)
+    run.invocationId = 'invocation-cleanup-1'
+    run.currentChild = { killed: false }
+
+    ;(manager as any).cleanupRun(run, { kill: false })
+
+    expect(emitted).toContainEqual({
+      event: 'run.failed',
+      payload: expect.objectContaining({ invocation_id: 'invocation-cleanup-1', error: 'Coding agent session closed' }),
+    })
   })
 
   it('does not report a completed idle coding-agent session cleanup as a run failure', () => {

--- a/tests/server/chat-run-api-controller.test.ts
+++ b/tests/server/chat-run-api-controller.test.ts
@@ -1,71 +1,51 @@
-import { EventEmitter } from 'events'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const runAndWaitMock = vi.hoisted(() => vi.fn())
 const ioMock = vi.hoisted(() => vi.fn())
 
-vi.mock('socket.io-client', () => ({
-  io: ioMock,
+vi.mock('../../packages/server/src/routes/hermes/chat-run', () => ({
+  getChatRunServer: vi.fn(() => ({ runAndWait: runAndWaitMock })),
 }))
 
-function makeSocket() {
-  const emitter = new EventEmitter() as EventEmitter & {
-    emit: ReturnType<typeof vi.fn>
-    disconnect: ReturnType<typeof vi.fn>
-    emitNative: (event: string, payload?: unknown) => boolean
+vi.mock('socket.io-client', () => ({ io: ioMock }))
+
+function makeCtx(body: Record<string, unknown>) {
+  return {
+    state: { profile: { name: 'default' }, user: { id: 1, role: 'super_admin' } },
+    request: { body },
+    status: 200,
+    body: undefined as any,
   }
-  const nativeEmit = EventEmitter.prototype.emit.bind(emitter)
-  emitter.emitNative = nativeEmit
-  emitter.emit = vi.fn((event: string, payload?: unknown) => {
-    if (event === 'run') {
-      process.nextTick(() => {
-        nativeEmit('run.started', { event: 'run.started', run_id: 'run-1' })
-        nativeEmit('message.delta', { event: 'message.delta', run_id: 'run-1', delta: 'hello' })
-        nativeEmit('run.completed', { event: 'run.completed', run_id: 'run-1' })
-      })
-    }
-    return true
-  }) as any
-  emitter.disconnect = vi.fn()
-  return emitter
 }
 
 describe('chat-run HTTP API controller', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    runAndWaitMock.mockImplementation(async (data: any, options: any) => {
+      options.onEvent?.('run.started', { event: 'run.started', run_id: 'run-1' })
+      options.onEvent?.('message.delta', { event: 'message.delta', run_id: 'run-1', delta: 'hello' })
+      options.onEvent?.('run.completed', { event: 'run.completed', run_id: 'run-1', output: 'hello' })
+      return {
+        ok: true,
+        event: 'run.completed',
+        session_id: data.session_id,
+        run_id: 'run-1',
+        output: 'hello',
+      }
+    })
   })
 
-  it('runs chat-run through Socket.IO and returns a completed HTTP response', async () => {
-    const socket = makeSocket()
-    ioMock.mockReturnValue(socket)
-
+  it('runs chat-run through the in-process server and returns a completed HTTP response', async () => {
     const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
-    const ctx = {
-      get: vi.fn((name: string) => name.toLowerCase() === 'authorization' ? 'Bearer token-1' : ''),
-      state: { profile: { name: 'default' } },
-      request: {
-        body: {
-          session_id: 'session-1',
-          input: 'hello',
-          include_events: true,
-        },
-      },
-      status: 200,
-      body: undefined as any,
-    }
+    const ctx = makeCtx({ session_id: 'session-1', input: 'hello', include_events: true })
 
-    const pending = runOnce(ctx as any)
-    socket.emitNative('connect')
-    await pending
+    await runOnce(ctx as any)
 
-    expect(ioMock).toHaveBeenCalledWith(expect.stringContaining('/chat-run'), expect.objectContaining({
-      auth: { token: 'token-1' },
-      query: { profile: 'default' },
-    }))
-    expect(socket.emit).toHaveBeenCalledWith('run', expect.objectContaining({
-      session_id: 'session-1',
-      input: 'hello',
-      profile: 'default',
-    }))
+    expect(ioMock).not.toHaveBeenCalled()
+    expect(runAndWaitMock).toHaveBeenCalledWith(
+      expect.objectContaining({ session_id: 'session-1', input: 'hello', profile: 'default' }),
+      expect.objectContaining({ profile: 'default', user: ctx.state.user, detachOnAction: true }),
+    )
     expect(ctx.status).toBe(200)
     expect(ctx.body).toMatchObject({
       ok: true,
@@ -78,75 +58,27 @@ describe('chat-run HTTP API controller', () => {
   })
 
   it('generates a session id when none is provided', async () => {
-    const socket = makeSocket()
-    ioMock.mockReturnValue(socket)
-
     const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
-    const ctx = {
-      get: vi.fn((name: string) => name.toLowerCase() === 'authorization' ? 'Bearer token-1' : ''),
-      state: { profile: { name: 'default' } },
-      request: {
-        body: {
-          source: 'cli',
-          input: 'start a new chat',
-        },
-      },
-      status: 200,
-      body: undefined as any,
-    }
+    const ctx = makeCtx({ source: 'cli', input: 'start a new chat' })
 
-    const pending = runOnce(ctx as any)
-    socket.emitNative('connect')
-    await pending
+    await runOnce(ctx as any)
 
-    const emittedPayload = socket.emit.mock.calls.find(call => call[0] === 'run')?.[1] as Record<string, unknown>
-    expect(emittedPayload.session_id).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/))
-    expect(emittedPayload).toMatchObject({
-      source: 'cli',
-      input: 'start a new chat',
-      profile: 'default',
-    })
+    const payload = runAndWaitMock.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.session_id).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/))
+    expect(payload).toMatchObject({ source: 'cli', input: 'start a new chat', profile: 'default' })
     expect(ctx.status).toBe(200)
-    expect(ctx.body).toMatchObject({
-      ok: true,
-      status: 'completed',
-      session_id: emittedPayload.session_id,
-    })
+    expect(ctx.body).toMatchObject({ ok: true, status: 'completed', session_id: payload.session_id })
   })
 
   it('generates a session id for global-agent runs when none is provided', async () => {
-    const socket = makeSocket()
-    ioMock.mockReturnValue(socket)
-
     const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
-    const ctx = {
-      get: vi.fn((name: string) => name.toLowerCase() === 'authorization' ? 'Bearer token-1' : ''),
-      state: { profile: { name: 'default' } },
-      request: {
-        body: {
-          source: 'global_agent',
-          input: 'start a global run',
-        },
-      },
-      status: 200,
-      body: undefined as any,
-    }
+    const ctx = makeCtx({ source: 'global_agent', input: 'start a global run' })
 
-    const pending = runOnce(ctx as any)
-    socket.emitNative('connect')
-    await pending
+    await runOnce(ctx as any)
 
-    const emittedPayload = socket.emit.mock.calls.find(call => call[0] === 'run')?.[1] as Record<string, unknown>
-    expect(emittedPayload.session_id).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/))
-    expect(emittedPayload).toMatchObject({
-      source: 'global_agent',
-      input: 'start a global run',
-      profile: 'default',
-    })
-    expect(ctx.body).toMatchObject({
-      ok: true,
-      status: 'completed',
-      session_id: emittedPayload.session_id,
-    })
+    const payload = runAndWaitMock.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.session_id).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/))
+    expect(payload).toMatchObject({ source: 'global_agent', input: 'start a global run', profile: 'default' })
+    expect(ctx.body).toMatchObject({ ok: true, status: 'completed', session_id: payload.session_id })
   })
 })

--- a/tests/server/chat-run-baseline.test.ts
+++ b/tests/server/chat-run-baseline.test.ts
@@ -1,37 +1,14 @@
-import { EventEmitter } from 'events'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const ioMock = vi.hoisted(() => vi.fn())
-const scenarioMock = vi.hoisted(() => ({
-  emitRunEvents: vi.fn(),
-}))
+const runAndWaitMock = vi.hoisted(() => vi.fn())
 
-vi.mock('socket.io-client', () => ({
-  io: ioMock,
+vi.mock('../../packages/server/src/routes/hermes/chat-run', () => ({
+  getChatRunServer: vi.fn(() => ({ runAndWait: runAndWaitMock })),
 }))
-
-function makeSocket() {
-  const emitter = new EventEmitter() as EventEmitter & {
-    emit: ReturnType<typeof vi.fn>
-    disconnect: ReturnType<typeof vi.fn>
-    emitNative: (event: string, payload?: unknown) => boolean
-  }
-  const nativeEmit = EventEmitter.prototype.emit.bind(emitter)
-  emitter.emitNative = nativeEmit
-  emitter.emit = vi.fn((event: string, payload?: unknown) => {
-    if (event === 'run') {
-      process.nextTick(() => scenarioMock.emitRunEvents(nativeEmit, payload))
-    }
-    return true
-  }) as any
-  emitter.disconnect = vi.fn()
-  return emitter
-}
 
 function makeCtx(body: Record<string, unknown>) {
   return {
-    get: vi.fn((name: string) => name.toLowerCase() === 'authorization' ? 'Bearer token-1' : ''),
-    state: { profile: { name: 'default' } },
+    state: { profile: { name: 'default' }, user: { id: 1, role: 'super_admin' } },
     request: { body },
     status: 200,
     body: undefined as any,
@@ -43,19 +20,22 @@ describe('chat-run action/event baseline', () => {
     vi.clearAllMocks()
   })
 
-  it('returns requires_action when approval is requested', async () => {
-    const socket = makeSocket()
-    ioMock.mockReturnValue(socket)
-    scenarioMock.emitRunEvents.mockImplementation((emitNative: Function) => {
-      emitNative('run.started', { run_id: 'run-1' })
-      emitNative('approval.requested', { run_id: 'run-1', approval_id: 'approval-1', command: 'touch file' })
+  it('returns requires_action without exposing the internal invocation id', async () => {
+    runAndWaitMock.mockImplementation(async (_data: any, options: any) => {
+      options.onEvent?.('run.started', { run_id: 'run-1' })
+      options.onEvent?.('approval.requested', { run_id: 'run-1', approval_id: 'approval-1', command: 'touch file' })
+      return {
+        ok: false,
+        event: 'action.required',
+        session_id: 'session-1',
+        run_id: 'run-1',
+        action: { event: 'approval.requested', run_id: 'run-1', approval_id: 'approval-1', command: 'touch file' },
+      }
     })
 
     const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
     const ctx = makeCtx({ session_id: 'session-1', input: 'needs approval', include_events: true })
-    const pending = runOnce(ctx as any)
-    socket.emitNative('connect')
-    await pending
+    await runOnce(ctx as any)
 
     expect(ctx.status).toBe(409)
     expect(ctx.body).toMatchObject({
@@ -64,51 +44,71 @@ describe('chat-run action/event baseline', () => {
       event: 'approval.requested',
       session_id: 'session-1',
       run_id: 'run-1',
-      action: { event: 'approval.requested', approval_id: 'approval-1' },
+      action: { approval_id: 'approval-1' },
     })
-    expect(ctx.body.events.map((event: any) => event.event)).toEqual(['run.started', 'approval.requested'])
+    expect(ctx.body).not.toHaveProperty('invocation_id')
+    expect(runAndWaitMock).toHaveBeenCalledWith(
+      expect.objectContaining({ session_id: 'session-1', input: 'needs approval' }),
+      expect.objectContaining({ profile: 'default', attachmentTimeoutMs: 300000, detachOnAction: true }),
+    )
+  })
+
+  it('strips caller-provided invocation ids from the internal run payload and response', async () => {
+    runAndWaitMock.mockResolvedValue({
+      ok: true,
+      event: 'run.completed',
+      session_id: 'session-1',
+      run_id: 'run-1',
+      output: 'done',
+      invocation_id: 'internal-secret',
+    })
+    const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
+    const ctx = makeCtx({
+      session_id: 'session-1', input: 'hello', invocation_id: 'caller-controlled', include_events: true,
+    })
+
+    await runOnce(ctx as any)
+
+    expect(runAndWaitMock.mock.calls[0][0]).not.toHaveProperty('invocation_id')
+    expect(ctx.body).not.toHaveProperty('invocation_id')
   })
 
   it('returns requires_action when clarification is requested', async () => {
-    const socket = makeSocket()
-    ioMock.mockReturnValue(socket)
-    scenarioMock.emitRunEvents.mockImplementation((emitNative: Function) => {
-      emitNative('run.started', { run_id: 'run-1' })
-      emitNative('clarify.requested', { run_id: 'run-1', question: 'Which room?' })
+    runAndWaitMock.mockResolvedValue({
+      ok: false,
+      event: 'action.required',
+      session_id: 'session-1',
+      run_id: 'run-1',
+      action: { event: 'clarify.requested', run_id: 'run-1', question: 'Which room?' },
     })
 
     const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
     const ctx = makeCtx({ session_id: 'session-1', input: 'needs clarify', include_events: true })
-    const pending = runOnce(ctx as any)
-    socket.emitNative('connect')
-    await pending
+    await runOnce(ctx as any)
 
     expect(ctx.status).toBe(409)
     expect(ctx.body).toMatchObject({
       ok: false,
       status: 'requires_action',
       event: 'clarify.requested',
-      action: { event: 'clarify.requested', question: 'Which room?' },
+      action: { question: 'Which room?' },
     })
   })
 
-  it('records bounded event history and accumulates output/reasoning when include_events is true', async () => {
-    const socket = makeSocket()
-    ioMock.mockReturnValue(socket)
-    scenarioMock.emitRunEvents.mockImplementation((emitNative: Function) => {
-      emitNative('run.started', { run_id: 'run-1' })
-      emitNative('reasoning.delta', { run_id: 'run-1', delta: 'thought' })
-      emitNative('tool.started', { run_id: 'run-1', name: 'lookup' })
-      emitNative('tool.completed', { run_id: 'run-1', name: 'lookup' })
-      emitNative('message.delta', { run_id: 'run-1', delta: 'hello' })
-      emitNative('run.completed', { run_id: 'run-1' })
+  it('records bounded event history and returns the authoritative result', async () => {
+    runAndWaitMock.mockImplementation(async (_data: any, options: any) => {
+      options.onEvent?.('run.started', { run_id: 'run-1' })
+      options.onEvent?.('reasoning.delta', { run_id: 'run-1', delta: 'thought' })
+      options.onEvent?.('tool.started', { run_id: 'run-1', name: 'lookup' })
+      options.onEvent?.('tool.completed', { run_id: 'run-1', name: 'lookup' })
+      options.onEvent?.('message.delta', { run_id: 'run-1', delta: 'hello' })
+      options.onEvent?.('run.completed', { run_id: 'run-1', output: 'hello', reasoning: 'thought' })
+      return { ok: true, event: 'run.completed', session_id: 'session-1', run_id: 'run-1', output: 'hello', reasoning: 'thought' }
     })
 
     const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
-    const ctx = makeCtx({ session_id: 'session-1', input: 'hello', include_events: true })
-    const pending = runOnce(ctx as any)
-    socket.emitNative('connect')
-    await pending
+    const ctx = makeCtx({ session_id: 'session-1', input: 'hello', include_events: true, timeout_ms: 3600000 })
+    await runOnce(ctx as any)
 
     expect(ctx.status).toBe(200)
     expect(ctx.body).toMatchObject({
@@ -126,5 +126,22 @@ describe('chat-run action/event baseline', () => {
       'message.delta',
       'run.completed',
     ])
+    expect(runAndWaitMock.mock.calls[0][1].attachmentTimeoutMs).toBe(1800000)
+  })
+
+  it('maps attachment expiry to HTTP 504 without exposing internal state', async () => {
+    runAndWaitMock.mockResolvedValue({
+      ok: false,
+      event: 'wait.timed_out',
+      session_id: 'session-1',
+      error: 'chat-run attachment timed out after 25ms',
+    })
+    const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
+    const ctx = makeCtx({ session_id: 'session-1', input: 'slow', timeout_ms: 25 })
+    await runOnce(ctx as any)
+
+    expect(ctx.status).toBe(504)
+    expect(ctx.body).toMatchObject({ ok: false, status: 'timeout', session_id: 'session-1' })
+    expect(ctx.body).not.toHaveProperty('invocation_id')
   })
 })

--- a/tests/server/chat-run-baseline.test.ts
+++ b/tests/server/chat-run-baseline.test.ts
@@ -53,14 +53,21 @@ describe('chat-run action/event baseline', () => {
     )
   })
 
-  it('strips caller-provided invocation ids from the internal run payload and response', async () => {
-    runAndWaitMock.mockResolvedValue({
-      ok: true,
-      event: 'run.completed',
-      session_id: 'session-1',
-      run_id: 'run-1',
-      output: 'done',
-      invocation_id: 'internal-secret',
+  it('strips caller-provided and internal invocation ids from the internal run payload and full response', async () => {
+    runAndWaitMock.mockImplementation(async (_data: any, options: any) => {
+      options.onEvent?.('run.completed', {
+        run_id: 'run-1',
+        output: 'done',
+        invocation_id: 'internal-event-secret',
+      })
+      return {
+        ok: true,
+        event: 'run.completed',
+        session_id: 'session-1',
+        run_id: 'run-1',
+        output: 'done',
+        invocation_id: 'internal-result-secret',
+      }
     })
     const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
     const ctx = makeCtx({
@@ -71,6 +78,9 @@ describe('chat-run action/event baseline', () => {
 
     expect(runAndWaitMock.mock.calls[0][0]).not.toHaveProperty('invocation_id')
     expect(ctx.body).not.toHaveProperty('invocation_id')
+    expect(JSON.stringify(ctx.body)).not.toContain('invocation_id')
+    expect(JSON.stringify(ctx.body)).not.toContain('internal-event-secret')
+    expect(JSON.stringify(ctx.body)).not.toContain('internal-result-secret')
   })
 
   it('returns requires_action when clarification is requested', async () => {

--- a/tests/server/chat-run-invocation-store.test.ts
+++ b/tests/server/chat-run-invocation-store.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('chat run invocation store', () => {
+  let db: any = null
+
+  beforeEach(async () => {
+    vi.resetModules()
+    const { DatabaseSync } = await import('node:sqlite')
+    db = new DatabaseSync(':memory:')
+    vi.doMock('../../packages/server/src/db/index', () => ({
+      getDb: () => db,
+      isSqliteAvailable: () => true,
+      getStoragePath: () => ':memory:',
+    }))
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    initAllHermesTables()
+  })
+
+  afterEach(() => {
+    db?.close()
+    db = null
+    vi.doUnmock('../../packages/server/src/db/index')
+    vi.resetModules()
+  })
+
+  it('keeps sequential invocations in one session isolated', async () => {
+    const store = await import('../../packages/server/src/db/hermes/chat-run-invocation-store')
+    store.createChatRunInvocation({ id: 'inv-1', sessionId: 'session-1', startedAt: 100 })
+    store.createChatRunInvocation({ id: 'inv-2', sessionId: 'session-1', startedAt: 200 })
+
+    expect(store.settleChatRunInvocation('inv-1', {
+      status: 'completed', runId: 'run-1', output: 'first', reasoning: '', error: null, finishedAt: 300,
+    })).toBe(true)
+
+    expect(store.getChatRunInvocation('inv-1')).toMatchObject({ status: 'completed', output: 'first' })
+    expect(store.getChatRunInvocation('inv-2')).toMatchObject({ status: 'running', output: null })
+  })
+
+  it('settles terminal state only once across event and reconciliation races', async () => {
+    const store = await import('../../packages/server/src/db/hermes/chat-run-invocation-store')
+    store.createChatRunInvocation({ id: 'inv-race', sessionId: 'session-1', startedAt: 100 })
+
+    expect(store.settleChatRunInvocation('inv-race', {
+      status: 'completed', runId: 'run-1', output: 'authoritative', reasoning: 'done', error: null, finishedAt: 200,
+    })).toBe(true)
+    expect(store.settleChatRunInvocation('inv-race', {
+      status: 'failed', runId: 'run-2', output: 'partial', reasoning: '', error: 'late failure', finishedAt: 201,
+    })).toBe(false)
+
+    expect(store.getChatRunInvocation('inv-race')).toMatchObject({
+      status: 'completed', run_id: 'run-1', output: 'authoritative', reasoning: 'done', error: null,
+    })
+  })
+
+  it('persists requires_action and lets a later terminal outcome settle it', async () => {
+    const store = await import('../../packages/server/src/db/hermes/chat-run-invocation-store')
+    store.createChatRunInvocation({ id: 'inv-action', sessionId: 'session-1', startedAt: 100 })
+    expect(store.markChatRunInvocationRequiresAction('inv-action', {
+      event: 'approval.requested', approval_id: 'approval-1',
+    })).toBe(true)
+    expect(store.getChatRunInvocation('inv-action')).toMatchObject({
+      status: 'requires_action', action: { event: 'approval.requested', approval_id: 'approval-1' },
+    })
+    expect(store.settleChatRunInvocation('inv-action', {
+      status: 'completed', output: 'approved', finishedAt: 200,
+    })).toBe(true)
+    expect(store.getChatRunInvocation('inv-action')).toMatchObject({
+      status: 'completed', output: 'approved', action: null,
+    })
+  })
+
+  it('fails orphaned active invocations and prunes expired terminal rows', async () => {
+    const store = await import('../../packages/server/src/db/hermes/chat-run-invocation-store')
+    store.createChatRunInvocation({ id: 'inv-orphan', sessionId: 'session-1', startedAt: 100 })
+    store.createChatRunInvocation({ id: 'inv-old', sessionId: 'session-2', startedAt: 100 })
+    store.settleChatRunInvocation('inv-old', { status: 'completed', output: 'old', finishedAt: 200 })
+
+    expect(store.recoverOrphanedChatRunInvocations('restart')).toBe(1)
+    expect(store.getChatRunInvocation('inv-orphan')).toMatchObject({ status: 'failed', error: 'restart' })
+    expect(store.pruneChatRunInvocations(201)).toBe(1)
+    expect(store.getChatRunInvocation('inv-old')).toBeNull()
+  })
+
+  it('does not mark the invocation terminal when an attachment stops waiting', async () => {
+    const store = await import('../../packages/server/src/db/hermes/chat-run-invocation-store')
+    store.createChatRunInvocation({ id: 'inv-detached', sessionId: 'session-1', startedAt: 100 })
+
+    expect(store.getChatRunInvocation('inv-detached')).toMatchObject({ status: 'running', finished_at: null })
+  })
+
+  it('bounds persisted multibyte terminal text to 2 MiB of UTF-8', async () => {
+    const store = await import('../../packages/server/src/db/hermes/chat-run-invocation-store')
+    store.createChatRunInvocation({ id: 'inv-utf8', sessionId: 'session-1', startedAt: 100 })
+    const oversized = `prefix-${'你'.repeat(800_000)}`
+
+    expect(store.settleChatRunInvocation('inv-utf8', {
+      status: 'failed', output: oversized, reasoning: oversized, error: oversized, finishedAt: 200,
+    })).toBe(true)
+    const record = store.getChatRunInvocation('inv-utf8')!
+    expect(Buffer.byteLength(record.output!, 'utf8')).toBeLessThanOrEqual(2 * 1024 * 1024)
+    expect(Buffer.byteLength(record.reasoning!, 'utf8')).toBeLessThanOrEqual(2 * 1024 * 1024)
+    expect(Buffer.byteLength(record.error!, 'utf8')).toBeLessThanOrEqual(2 * 1024 * 1024)
+    expect(record.output).not.toContain('\uFFFD')
+  })
+})

--- a/tests/server/hermes-schemas.test.ts
+++ b/tests/server/hermes-schemas.test.ts
@@ -21,7 +21,7 @@ describe('Hermes schema initialization', () => {
   })
 
   it('initializes all tables with correct schemas', async () => {
-    const { initAllHermesTables, USAGE_TABLE, SESSIONS_TABLE, SESSION_CATEGORIES_TABLE, MESSAGES_TABLE, GC_ROOMS_TABLE, GC_MESSAGES_TABLE, GC_ROOM_AGENTS_TABLE, USERS_TABLE, USER_PROFILES_TABLE, DEVICES_TABLE, MCU_DEVICES_TABLE } =
+    const { initAllHermesTables, USAGE_TABLE, SESSIONS_TABLE, SESSION_CATEGORIES_TABLE, MESSAGES_TABLE, CHAT_RUN_INVOCATIONS_TABLE, GC_ROOMS_TABLE, GC_MESSAGES_TABLE, GC_ROOM_AGENTS_TABLE, USERS_TABLE, USER_PROFILES_TABLE, DEVICES_TABLE, MCU_DEVICES_TABLE } =
       await import('../../packages/server/src/db/hermes/schemas')
 
     expect(() => initAllHermesTables()).not.toThrow()
@@ -32,6 +32,7 @@ describe('Hermes schema initialization', () => {
     expect(tables.map(t => t.name)).toContain(SESSIONS_TABLE)
     expect(tables.map(t => t.name)).toContain(SESSION_CATEGORIES_TABLE)
     expect(tables.map(t => t.name)).toContain(MESSAGES_TABLE)
+    expect(tables.map(t => t.name)).toContain(CHAT_RUN_INVOCATIONS_TABLE)
     expect(tables.map(t => t.name)).toContain(GC_ROOMS_TABLE)
     expect(tables.map(t => t.name)).toContain(GC_MESSAGES_TABLE)
     expect(tables.map(t => t.name)).toContain(GC_ROOM_AGENTS_TABLE)

--- a/tests/server/run-chat-queued-item.test.ts
+++ b/tests/server/run-chat-queued-item.test.ts
@@ -15,10 +15,56 @@ const bridgeMock = vi.hoisted(() => ({
   statusIfLoaded: vi.fn(),
   interrupt: vi.fn(),
   approvalRespond: vi.fn(),
+  close: vi.fn(),
 }))
 const sessionStoreMocks = vi.hoisted(() => ({
   clearSessionMessages: vi.fn(),
+  getSession: vi.fn(() => ({ id: 'session-1', profile: 'default', source: 'cli' })),
 }))
+const userCanAccessProfileMock = vi.hoisted(() => vi.fn(() => true))
+const invocationStoreMocks = vi.hoisted(() => {
+  const records = new Map<string, any>()
+  return {
+    records,
+    create: vi.fn((input: any) => {
+      const record = {
+        id: input.id,
+        session_id: input.sessionId,
+        run_id: '',
+        status: 'running',
+        output: null,
+        reasoning: null,
+        error: null,
+        action: null,
+        started_at: input.startedAt || 1,
+        finished_at: null,
+      }
+      records.set(input.id, record)
+      return record
+    }),
+    get: vi.fn((id: string) => records.get(id) || null),
+    markAction: vi.fn((id: string, action: any) => {
+      const record = records.get(id)
+      if (!record || record.status !== 'running') return false
+      Object.assign(record, { status: 'requires_action', action })
+      return true
+    }),
+    settle: vi.fn((id: string, terminal: any) => {
+      const record = records.get(id)
+      if (!record || !['running', 'requires_action'].includes(record.status)) return false
+      Object.assign(record, {
+        run_id: terminal.runId || '',
+        status: terminal.status,
+        output: terminal.output ?? null,
+        reasoning: terminal.reasoning ?? null,
+        error: terminal.error ?? null,
+        action: null,
+        finished_at: terminal.finishedAt || 2,
+      })
+      return true
+    }),
+  }
+})
 
 vi.mock('../../packages/server/src/services/hermes/run-chat/handle-bridge-run', () => ({
   handleBridgeRun: handleBridgeRunMock,
@@ -56,9 +102,17 @@ vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
 
 vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
   clearSessionMessages: sessionStoreMocks.clearSessionMessages,
-  getSession: vi.fn(() => ({ id: 'session-1', profile: 'default', source: 'cli' })),
+  deleteSession: vi.fn(),
+  getSession: sessionStoreMocks.getSession,
   getSessionMetadata: vi.fn(() => ({ id: 'session-1', profile: 'default', source: 'cli' })),
   getSessionDetail: vi.fn(() => null),
+}))
+
+vi.mock('../../packages/server/src/db/hermes/chat-run-invocation-store', () => ({
+  createChatRunInvocation: invocationStoreMocks.create,
+  getChatRunInvocation: invocationStoreMocks.get,
+  markChatRunInvocationRequiresAction: invocationStoreMocks.markAction,
+  settleChatRunInvocation: invocationStoreMocks.settle,
 }))
 
 vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
@@ -73,7 +127,7 @@ vi.mock('../../packages/server/src/middleware/user-auth', () => ({
 }))
 
 vi.mock('../../packages/server/src/db/hermes/users-store', () => ({
-  userCanAccessProfile: vi.fn(() => true),
+  userCanAccessProfile: userCanAccessProfileMock,
 }))
 
 function makeServerHarness() {
@@ -107,6 +161,7 @@ function makeServerHarness() {
 describe('ChatRunSocket queued bridge runs', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    invocationStoreMocks.records.clear()
     ensureReadyMock.mockResolvedValue({
       reachable: true,
       status: 'ready',
@@ -115,6 +170,8 @@ describe('ChatRunSocket queued bridge runs', () => {
     bridgeMock.statusIfLoaded.mockResolvedValue({ ok: true, exists: false, running: false, loaded: false })
     bridgeMock.interrupt.mockResolvedValue({ ok: true })
     bridgeMock.approvalRespond.mockResolvedValue({ resolved: true })
+    sessionStoreMocks.getSession.mockReturnValue({ id: 'session-1', profile: 'default', source: 'cli' })
+    userCanAccessProfileMock.mockReturnValue(true)
     sessionStoreMocks.clearSessionMessages.mockReturnValue(2)
     loadSessionStateFromDbMock.mockResolvedValue({
       messages: [],
@@ -175,6 +232,55 @@ describe('ChatRunSocket queued bridge runs', () => {
       queue_id: 'queue-normal',
     }))
     expect(call[6]).toBe(false)
+  })
+
+  it('persists requires_action while detaching the HTTP-style attachment', async () => {
+    handleBridgeRunMock.mockImplementationOnce((async (...args: any[]) => {
+      const data = args[2]
+      data.onEvent?.('approval.requested', {
+        run_id: 'run-action', approval_id: 'approval-1', choices: ['once', 'deny'],
+      })
+    }) as any)
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    const result = await server.runAndWait({
+      session_id: 'session-1', input: 'needs approval', source: 'workflow',
+    }, { profile: 'default', detachOnAction: true })
+
+    expect(result).toMatchObject({
+      ok: false, event: 'action.required', action: { event: 'approval.requested', approval_id: 'approval-1' },
+    })
+    expect([...invocationStoreMocks.records.values()]).toEqual([
+      expect.objectContaining({ status: 'requires_action', action: expect.objectContaining({ approval_id: 'approval-1' }) }),
+    ])
+    expect((server as any).activeRunInvocations.has('session-1')).toBe(true)
+  })
+
+  it('rejects a requested profile that differs from the persisted session profile', async () => {
+    sessionStoreMocks.getSession.mockReturnValue({ id: 'session-1', profile: 'private', source: 'cli' })
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    await expect(server.runAndWait({
+      session_id: 'session-1', input: 'cross-profile attempt', source: 'workflow',
+    }, { profile: 'default' })).rejects.toThrow('does not match persisted session profile')
+    expect(handleBridgeRunMock).not.toHaveBeenCalled()
+  })
+
+  it('enforces user access to the persisted session profile', async () => {
+    sessionStoreMocks.getSession.mockReturnValue({ id: 'session-1', profile: 'private', source: 'cli' })
+    userCanAccessProfileMock.mockReturnValueOnce(false)
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    await expect(server.runAndWait({
+      session_id: 'session-1', input: 'unauthorized attempt', source: 'workflow',
+    }, { user: { id: 'user-1', role: 'user' } as any })).rejects.toThrow('is not available for this user')
+    expect(handleBridgeRunMock).not.toHaveBeenCalled()
   })
 
   it('supports bridge peer broadcasts during runAndWait workflow runs', async () => {
@@ -271,6 +377,53 @@ describe('ChatRunSocket queued bridge runs', () => {
     })
     expect(bridgeMock.approvalRespond).toHaveBeenCalledWith('approval-1', 'once')
     expect(namespace.to).toHaveBeenCalledWith('session:session-1')
+  })
+
+  it.each([
+    ['missing approval id', { choices: ['once'] }, 'approval required'],
+    ['unavailable approval choice', { approval_id: 'approval-1', choices: ['deny'] }, 'is not available'],
+  ])('durably fails and releases the invocation for %s', async (_name, approval, errorText) => {
+    handleBridgeRunMock.mockImplementationOnce((async (_nsp: any, _socket: any, data: any) => {
+      data.onEvent?.('approval.requested', { run_id: 'run-approval-error', ...approval })
+    }) as any)
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    const result = await server.runAndWait({
+      session_id: 'session-1', input: 'workflow node', source: 'workflow', session_source: 'workflow',
+    }, { profile: 'default', approvalChoice: 'once' })
+
+    expect(result).toMatchObject({ ok: false, event: 'run.failed' })
+    expect(result.error).toContain(errorText)
+    expect([...invocationStoreMocks.records.values()]).toEqual([
+      expect.objectContaining({ status: 'failed', error: expect.stringContaining(errorText) }),
+    ])
+    expect((server as any).activeRunInvocations.has('session-1')).toBe(false)
+    await vi.waitFor(() => expect(bridgeMock.interrupt).toHaveBeenCalled())
+  })
+
+  it('durably fails and releases the invocation when the approval bridge rejects', async () => {
+    bridgeMock.approvalRespond.mockRejectedValueOnce(new Error('approval bridge unavailable'))
+    handleBridgeRunMock.mockImplementationOnce((async (_nsp: any, _socket: any, data: any) => {
+      data.onEvent?.('approval.requested', {
+        run_id: 'run-approval-reject', approval_id: 'approval-1', choices: ['once'],
+      })
+    }) as any)
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    const result = await server.runAndWait({
+      session_id: 'session-1', input: 'workflow node', source: 'workflow', session_source: 'workflow',
+    }, { profile: 'default', approvalChoice: 'once' })
+
+    expect(result).toMatchObject({ ok: false, event: 'run.failed', error: 'approval bridge unavailable' })
+    expect([...invocationStoreMocks.records.values()]).toEqual([
+      expect.objectContaining({ status: 'failed', error: 'approval bridge unavailable' }),
+    ])
+    expect((server as any).activeRunInvocations.has('session-1')).toBe(false)
+    await vi.waitFor(() => expect(bridgeMock.interrupt).toHaveBeenCalled())
   })
 
   it('does not auto-respond to approvals for normal runAndWait calls', async () => {
@@ -501,7 +654,7 @@ describe('ChatRunSocket queued bridge runs', () => {
       queueLength: 0,
     }))
   })
-  it('aborts the underlying runner when runAndWait reaches its timeout', async () => {
+  it('detaches without aborting the underlying runner when runAndWait reaches its timeout', async () => {
     vi.useFakeTimers()
     handleBridgeRunMock.mockImplementationOnce(async () => new Promise(() => {}))
     const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
@@ -511,11 +664,232 @@ describe('ChatRunSocket queued bridge runs', () => {
     try {
       const resultPromise = server.runAndWait({
         session_id: 'session-1', input: 'slow workflow node', source: 'workflow', session_source: 'workflow',
+      }, { profile: 'default', attachmentTimeoutMs: 25 })
+      await vi.advanceTimersByTimeAsync(25)
+      await expect(resultPromise).resolves.toMatchObject({ ok: false, error: 'chat-run attachment timed out after 25ms' })
+      expect(abortSpy).not.toHaveBeenCalled()
+      expect([...invocationStoreMocks.records.values()]).toEqual([
+        expect.objectContaining({ status: 'running', finished_at: null }),
+      ])
+    } finally { vi.useRealTimers() }
+  })
+
+  it('keeps the execution deadline active after the attachment detaches', async () => {
+    vi.useFakeTimers()
+    handleBridgeRunMock.mockImplementationOnce(async () => new Promise(() => {}))
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    const abortSpy = vi.spyOn(server, 'abortSession').mockResolvedValue(undefined)
+    try {
+      const resultPromise = server.runAndWait({
+        session_id: 'session-1', input: 'bounded detached run', source: 'workflow',
+      }, { profile: 'default', attachmentTimeoutMs: 25, timeoutMs: 50 })
+      await vi.advanceTimersByTimeAsync(25)
+      await expect(resultPromise).resolves.toMatchObject({ event: 'wait.timed_out' })
+      expect(abortSpy).not.toHaveBeenCalled()
+      expect((server as any).runExecutionTimers.size).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(25)
+      expect(abortSpy).toHaveBeenCalledWith('session-1', 'chat-run timed out after 50ms')
+      expect((server as any).runExecutionTimers.size).toBe(0)
+      expect([...invocationStoreMocks.records.values()]).toEqual([
+        expect.objectContaining({ status: 'failed', error: 'chat-run timed out after 50ms' }),
+      ])
+    } finally { vi.useRealTimers() }
+  })
+
+  it('aborts the underlying runner when the execution deadline expires', async () => {
+    vi.useFakeTimers()
+    handleBridgeRunMock.mockImplementationOnce(async () => new Promise(() => {}))
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    const abortSpy = vi.spyOn(server, 'abortSession').mockResolvedValue(undefined)
+    try {
+      const resultPromise = server.runAndWait({
+        session_id: 'session-1', input: 'bounded workflow node', source: 'workflow', session_source: 'workflow',
       }, { profile: 'default', timeoutMs: 25 })
       await vi.advanceTimersByTimeAsync(25)
-      await expect(resultPromise).resolves.toMatchObject({ ok: false, error: 'chat-run timed out after 25ms' })
+      await expect(resultPromise).resolves.toMatchObject({ ok: false, event: 'run.failed', error: 'chat-run timed out after 25ms' })
       expect(abortSpy).toHaveBeenCalledWith('session-1', 'chat-run timed out after 25ms')
+      expect([...invocationStoreMocks.records.values()]).toEqual([
+        expect.objectContaining({ status: 'failed', error: 'chat-run timed out after 25ms' }),
+      ])
     } finally { vi.useRealTimers() }
+  })
+
+  it('reconciles a missed terminal notification from the durable invocation record', async () => {
+    vi.useFakeTimers()
+    handleBridgeRunMock.mockImplementationOnce(async () => {})
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    try {
+      const resultPromise = server.runAndWait({
+        session_id: 'session-1', input: 'durable workflow node', source: 'workflow', session_source: 'workflow',
+      }, { profile: 'default', timeoutMs: 5000 })
+      const invocation = [...invocationStoreMocks.records.values()][0]
+      Object.assign(invocation, {
+        status: 'completed', run_id: 'run-durable', output: 'durable result', reasoning: 'checked', finished_at: 2,
+      })
+      await vi.advanceTimersByTimeAsync(1000)
+      await expect(resultPromise).resolves.toMatchObject({
+        ok: true, run_id: 'run-durable', output: 'durable result', reasoning: 'checked',
+      })
+    } finally { vi.useRealTimers() }
+  })
+
+  it('persists a late external terminal event after the caller detached', async () => {
+    vi.useFakeTimers()
+    handleCodingAgentRunMock.mockImplementationOnce(async () => {})
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    try {
+      const resultPromise = server.runAndWait({
+        session_id: 'session-1', input: 'slow coding turn', source: 'coding_agent', coding_agent_id: 'codex',
+      }, { profile: 'default', attachmentTimeoutMs: 25 })
+      await vi.advanceTimersByTimeAsync(25)
+      await expect(resultPromise).resolves.toMatchObject({ event: 'wait.timed_out' })
+
+      const invocation = [...invocationStoreMocks.records.values()][0]
+      server.emitExternalEvent('session-1', 'run.completed', {
+        invocation_id: invocation.id,
+        run_id: 'run-late', output: 'late durable result', reasoning: 'finished',
+      })
+
+      expect([...invocationStoreMocks.records.values()]).toEqual([
+        expect.objectContaining({
+          status: 'completed', run_id: 'run-late', output: 'late durable result', reasoning: 'finished',
+        }),
+      ])
+    } finally { vi.useRealTimers() }
+  })
+
+  it('ignores a stale coding-agent terminal event from another invocation', async () => {
+    vi.useFakeTimers()
+    handleCodingAgentRunMock.mockImplementationOnce(async () => {})
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    try {
+      const resultPromise = server.runAndWait({
+        session_id: 'session-1', input: 'current coding turn', source: 'coding_agent', coding_agent_id: 'codex',
+      }, { profile: 'default', attachmentTimeoutMs: 25 })
+      await vi.advanceTimersByTimeAsync(25)
+      await expect(resultPromise).resolves.toMatchObject({ event: 'wait.timed_out' })
+
+      server.emitExternalEvent('session-1', 'run.completed', {
+        invocation_id: 'stale-invocation', run_id: 'stale-run', output: 'wrong result',
+      })
+
+      expect([...invocationStoreMocks.records.values()]).toEqual([
+        expect.objectContaining({ status: 'running', output: null }),
+      ])
+      expect((server as any).activeRunInvocations.get('session-1')).toBe([...invocationStoreMocks.records.keys()][0])
+    } finally { vi.useRealTimers() }
+  })
+
+  it('ignores an untagged stale coding-agent terminal event', async () => {
+    handleCodingAgentRunMock.mockImplementationOnce(async () => {})
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    let settled = false
+    const resultPromise = server.runAndWait({
+      session_id: 'session-1', input: 'current attached turn', source: 'coding_agent', coding_agent_id: 'codex',
+    }, { profile: 'default' }).then(result => {
+      settled = true
+      return result
+    })
+    const invocationId = [...invocationStoreMocks.records.keys()][0]
+
+    server.emitExternalEvent('session-1', 'run.failed', { error: 'stale untagged failure' })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    expect(invocationStoreMocks.records.get(invocationId)).toMatchObject({ status: 'running' })
+
+    server.emitExternalEvent('session-1', 'run.completed', {
+      invocation_id: invocationId, run_id: 'current-run', output: 'correct',
+    })
+    await expect(resultPromise).resolves.toMatchObject({ ok: true, run_id: 'current-run', output: 'correct' })
+  })
+
+  it('does not let a stale terminal event settle the currently attached invocation', async () => {
+    handleCodingAgentRunMock.mockImplementationOnce(async () => {})
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    let settled = false
+    const resultPromise = server.runAndWait({
+      session_id: 'session-1', input: 'current attached turn', source: 'coding_agent', coding_agent_id: 'codex',
+    }, { profile: 'default' }).then(result => {
+      settled = true
+      return result
+    })
+    const invocationId = [...invocationStoreMocks.records.keys()][0]
+
+    server.emitExternalEvent('session-1', 'run.completed', {
+      invocation_id: 'stale-invocation', run_id: 'stale-run', output: 'wrong',
+    })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    expect(invocationStoreMocks.records.get(invocationId)).toMatchObject({ status: 'running' })
+
+    server.emitExternalEvent('session-1', 'run.completed', {
+      invocation_id: invocationId, run_id: 'current-run', output: 'correct',
+    })
+    await expect(resultPromise).resolves.toMatchObject({ ok: true, run_id: 'current-run', output: 'correct' })
+  })
+
+  it('rejects a second invocation while the first turn in the session remains active', async () => {
+    handleBridgeRunMock.mockImplementationOnce(async () => new Promise(() => {}))
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+
+    void server.runAndWait({ session_id: 'session-1', input: 'first', source: 'workflow' }, { profile: 'default' })
+    await expect(server.runAndWait({
+      session_id: 'session-1', input: 'second', source: 'workflow',
+    }, { profile: 'default' })).rejects.toThrow('already has an active chat run invocation')
+    expect(handleBridgeRunMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles and disposes an active invocation when its session is disposed', async () => {
+    handleBridgeRunMock.mockImplementationOnce(async () => new Promise(() => {}))
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    const resultPromise = server.runAndWait({
+      session_id: 'session-1', input: 'pending', source: 'workflow',
+    }, { profile: 'default' })
+
+    await server.disposeSession('session-1')
+
+    await expect(resultPromise).resolves.toMatchObject({ ok: false, event: 'run.failed', error: 'Session disposed' })
+    expect([...invocationStoreMocks.records.values()]).toEqual([
+      expect.objectContaining({ status: 'canceled', error: 'Session disposed' }),
+    ])
+    expect((server as any).runWaiters.has('session-1')).toBe(false)
+    expect((server as any).activeRunInvocations.has('session-1')).toBe(false)
+  })
+
+  it('settles attachments and clears waiter state when the server closes', async () => {
+    handleBridgeRunMock.mockImplementationOnce(async () => new Promise(() => {}))
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    const resultPromise = server.runAndWait({
+      session_id: 'session-1', input: 'pending on close', source: 'workflow',
+    }, { profile: 'default' })
+
+    await server.close()
+
+    await expect(resultPromise).resolves.toMatchObject({ ok: false, event: 'run.failed', error: 'Chat run server closed' })
+    expect((server as any).runWaiters.size).toBe(0)
+    expect((server as any).runAttachmentDisposers.size).toBe(0)
+    expect((server as any).activeRunInvocations.size).toBe(0)
   })
 
 })

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -33,6 +33,8 @@ const getSessionCategoryMock = vi.fn()
 const renameSessionCategoryMock = vi.fn()
 const setSessionCategoryMock = vi.fn()
 const getGroupChatServerMock = vi.fn()
+const disposeChatRunSessionMock = vi.fn()
+const getChatRunServerMock = vi.fn()
 const getLocalUsageStatsMock = vi.fn()
 const getRecordedUsageSessionIdsMock = vi.fn()
 const getActiveProfileNameMock = vi.fn()
@@ -125,6 +127,10 @@ vi.mock('../../packages/server/src/routes/hermes/group-chat', () => ({
   getGroupChatServer: getGroupChatServerMock,
 }))
 
+vi.mock('../../packages/server/src/routes/hermes/chat-run', () => ({
+  getChatRunServer: getChatRunServerMock,
+}))
+
 vi.mock('../../packages/server/src/services/hermes/model-context', () => ({
   getModelContextLength: vi.fn(),
 }))
@@ -207,6 +213,10 @@ describe('session conversations controller', () => {
     setSessionCategoryMock.mockReturnValue(true)
     getGroupChatServerMock.mockReset()
     getGroupChatServerMock.mockReturnValue(null)
+    disposeChatRunSessionMock.mockReset()
+    disposeChatRunSessionMock.mockResolvedValue(undefined)
+    getChatRunServerMock.mockReset()
+    getChatRunServerMock.mockReturnValue({ disposeSession: disposeChatRunSessionMock })
     getLocalUsageStatsMock.mockReset()
     getLocalUsageStatsMock.mockReturnValue({
       input_tokens: 0,
@@ -1818,7 +1828,9 @@ describe('session conversations controller', () => {
     const ctx: any = { params: { id: 'codex-session' }, body: null }
     await mod.remove(ctx)
 
-    expect(codingAgentRunManagerMock.stop).toHaveBeenCalledWith('codex-session', { reportClosed: false })
+    expect(disposeChatRunSessionMock).toHaveBeenCalledWith('codex-session', { deletePersistedSession: false })
+    expect(disposeChatRunSessionMock.mock.invocationCallOrder[0]).toBeLessThan(localDeleteSessionMock.mock.invocationCallOrder[0])
+    expect(codingAgentRunManagerMock.stop).not.toHaveBeenCalled()
     expect(getExactSessionDetailFromDbWithProfileMock).not.toHaveBeenCalled()
     expect(deleteHermesSessionForProfileMock).not.toHaveBeenCalled()
     expect(localDeleteSessionMock).toHaveBeenCalledWith('codex-session')
@@ -1884,11 +1896,38 @@ describe('session conversations controller', () => {
     }
     await mod.batchRemove(ctx)
 
-    expect(codingAgentRunManagerMock.stop).toHaveBeenCalledWith('codex-session', { reportClosed: false })
+    expect(disposeChatRunSessionMock).toHaveBeenCalledWith('codex-session', { deletePersistedSession: false })
+    expect(disposeChatRunSessionMock.mock.invocationCallOrder[0]).toBeLessThan(localDeleteSessionMock.mock.invocationCallOrder[0])
+    expect(codingAgentRunManagerMock.stop).not.toHaveBeenCalled()
     expect(getExactSessionDetailFromDbWithProfileMock).not.toHaveBeenCalled()
     expect(deleteHermesSessionForProfileMock).not.toHaveBeenCalled()
     expect(localDeleteSessionMock).toHaveBeenCalledWith('codex-session')
     expect(ctx.body).toMatchObject({ ok: true, deleted: 1, failed: 0, hermesDeleted: 0 })
+  })
+
+  it('waits for active Bridge chat-run disposal before deleting session persistence', async () => {
+    getSessionMock.mockReturnValue({ id: 'bridge-session', profile: 'default', source: 'cli' })
+    getExactSessionDetailFromDbWithProfileMock.mockResolvedValue({ id: 'bridge-session', messages: [] })
+    deleteHermesSessionForProfileMock.mockResolvedValue(true)
+    localDeleteSessionMock.mockReturnValue(true)
+    let finishDisposal!: () => void
+    disposeChatRunSessionMock.mockImplementationOnce(() => new Promise<void>(resolve => { finishDisposal = resolve }))
+
+    const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+    const ctx: any = { params: { id: 'bridge-session' }, body: null }
+    const removal = mod.remove(ctx)
+    await vi.waitFor(() => expect(disposeChatRunSessionMock).toHaveBeenCalledWith(
+      'bridge-session',
+      { deletePersistedSession: false },
+    ))
+    expect(deleteHermesSessionForProfileMock).not.toHaveBeenCalled()
+    expect(localDeleteSessionMock).not.toHaveBeenCalled()
+
+    finishDisposal()
+    await removal
+
+    expect(deleteHermesSessionForProfileMock).toHaveBeenCalledWith('bridge-session', 'default')
+    expect(localDeleteSessionMock).toHaveBeenCalledWith('bridge-session')
   })
 
   it('imports a Hermes session into the local Web UI store', async () => {


### PR DESCRIPTION
Closes #2388

## Summary
- add a durable, invocation-correlated Chat Run terminal ledger
- separate caller attachment expiry from execution deadlines and cancellation
- fence late Coding Agent terminal events by exact server-internal invocation identity
- call Chat Run in-process from the HTTP controller without exposing invocation IDs
- persist `requires_action`, fail startup orphans closed, and prune terminal records
- preserve one Group Chat mention → one natural reply stream

## Safety and compatibility
- persisted Session profile remains authoritative and user access is enforced
- caller-provided `invocation_id` is stripped at the HTTP boundary
- internal `invocation_id` is redacted from optional HTTP `events[]` output
- Session deletion settles active Chat Runs before deleting persistence
- automatic approval failures settle durably, release the Session fence, and interrupt the Bridge
- terminal text fields are bounded to 2 MiB of UTF-8 each
- Workflow execution deadlines retain abort semantics; attachment timeout is detach-only

## Validation
- final relevant lifecycle/controller/Coding Agent/Session suites: 164/164 passed
- `npm run build` passed on final bytes
- `git diff --check` passed
- exact head: `42fed73ebf876770e718c90f26411e7a2adfd643`
- final tree: `049bceb3ec58945cb9a0644bda578b464bd4fdd7`
- binary diff SHA-256 from base `594b2b0652b81267e22a5cb90ad88b62bcaef69f`: `f95a90e18f20c6ff13fe6e5bbabd1c4b214098475df1156b1612319c0debd2ad`

## Known repository-suite environment baseline
The complete suite is not globally green in this installed runtime. A frozen-base A/B reproduced the same classes of plugin/runtime discovery, Kanban fixture, Vue fixture, and resource-timeout failures. Candidate-adjacent focused suites and the final build are green. GitHub exact-head CI is the external merge gate.

## Scope boundary
This does not restore an already-lost parent Hermes Agent model/tool stack after process failure; that requires a future durable parent-turn orchestration layer.