### PR TITLE
fix(server): count reasoning_content in context usage estimates

### DIFF
--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -513,7 +513,16 @@ class ChatStorage {
             .reduce((sum, m) => sum + countTokens(this.contentToUsageText(m.content)), 0)
         const outputTokens = messages
             .filter(m => m.role === 'assistant' || m.role === 'tool')
-            .reduce((sum, m) => sum + countTokens(this.contentToUsageText(m.content)) + countTokens(String(m.tool_calls || '')), 0)
+            .reduce((sum, m) => {
+                const reasoning = (m as { reasoning_content?: unknown; reasoning?: unknown }).reasoning_content
+                    ?? (m as { reasoning?: unknown }).reasoning
+                return (
+                    sum
+                    + countTokens(this.contentToUsageText(m.content))
+                    + countTokens(String(m.tool_calls || ''))
+                    + countTokens(String(reasoning || ''))
+                )
+            }, 0)
         return { inputTokens, outputTokens }
     }
 

--- a/packages/server/src/services/hermes/run-chat/usage.ts
+++ b/packages/server/src/services/hermes/run-chat/usage.ts
@@ -18,6 +18,9 @@ type UsageTokenMessage = {
   role?: string
   content?: unknown
   tool_calls?: unknown
+  /** DeepSeek/Kimi thinking-mode payload echoed back on subsequent turns. */
+  reasoning_content?: unknown
+  reasoning?: unknown
 }
 
 function contentToUsageText(content: unknown): string {
@@ -39,7 +42,19 @@ export function estimateUsageTokensFromMessages(messages: UsageTokenMessage[]): 
     .reduce((sum, m) => sum + countTokens(contentToUsageText(m.content)), 0)
   const outputTokens = messages
     .filter(m => m.role === 'assistant' || m.role === 'tool')
-    .reduce((sum, m) => sum + countTokens(contentToUsageText(m.content)) + countTokens(String(m.tool_calls || '')), 0)
+    .reduce((sum, m) => {
+      // reasoning_content is re-sent to providers that require thinking-mode
+      // echo-back (DeepSeek/Kimi). Omitting it undercounts full context by
+      // hundreds of K tokens and skips compression until the upstream 400
+      // (NousResearch/hermes-agent#80246).
+      const reasoning = m.reasoning_content ?? m.reasoning
+      return (
+        sum
+        + countTokens(contentToUsageText(m.content))
+        + countTokens(String(m.tool_calls || ''))
+        + countTokens(String(reasoning || ''))
+      )
+    }, 0)
   return { inputTokens, outputTokens }
 }
 

--- a/tests/server/run-chat-usage.test.ts
+++ b/tests/server/run-chat-usage.test.ts
@@ -35,6 +35,24 @@ describe('run-chat usage token estimates', () => {
     expect(usage.outputTokens).toBe(countTokens('calling tool') + countTokens(String(messages[0].tool_calls || '')))
   })
 
+  it('counts assistant reasoning_content toward output tokens', () => {
+    const reasoning = 'long thinking payload that providers echo back'
+    const messages = [
+      {
+        role: 'assistant',
+        content: 'final answer',
+        reasoning_content: reasoning,
+      },
+    ]
+
+    const usage = estimateUsageTokensFromMessages(messages)
+
+    expect(usage.inputTokens).toBe(0)
+    expect(usage.outputTokens).toBe(
+      countTokens('final answer') + countTokens(reasoning),
+    )
+  })
+
   it('adds cached bridge fixed context when updating full context usage', () => {
     const emit = vi.fn()
     const state = {


### PR DESCRIPTION
## Summary
- Include `reasoning_content` (and `reasoning`) when estimating message tokens for Studio's context-compression threshold check.
- DeepSeek/Kimi thinking-mode payloads are echoed back on later turns; counting only `content` + `tool_calls` undercounted full context by hundreds of K tokens and skipped compression until the upstream HTTP 400.

Tracked on Hermes agent as NousResearch/hermes-agent#80246 (bug lives in Studio's `estimateUsageTokensFromMessages`).

## Test plan
- [x] Added unit test in `tests/server/run-chat-usage.test.ts`
- [ ] Run `pnpm test -- run-chat-usage` if convenient