### PR TITLE
fix(ekko-agent): replay reasoning across model protocols

### DIFF
--- a/docs/chat-chain-changes/2026-08-06-ekko-reasoning-replay.md
+++ b/docs/chat-chain-changes/2026-08-06-ekko-reasoning-replay.md
@@ -1,0 +1,15 @@
+---
+date: 2026-08-06
+pr: 2395
+feature: Ekko Agent native reasoning replay
+impact: Ekko Agent preserves provider-native reasoning across tool turns and selects the replay shape from the request protocol plus the OpenAI Chat provider/model dialect.
+---
+
+Reasoning text, native replay data, and token estimates now share one internal
+representation. OpenAI Responses, Anthropic Messages, and Gemini Contents
+replay their native reasoning items, thinking blocks, or content parts.
+
+Within the OpenAI Chat Completions adapter, OpenRouter replays
+`reasoning_details`; DeepSeek, Kimi, MiMo, Qwen, and GLM-family Chat endpoints
+replay `reasoning_content`; other compatible endpoints use `reasoning` unless
+the provider configuration explicitly overrides or disables the replay field.

--- a/packages/ekko-agent/src/logging/runtime-logger.ts
+++ b/packages/ekko-agent/src/logging/runtime-logger.ts
@@ -1,4 +1,5 @@
 import type { ModelClient, ModelRequest, ModelResponse } from '../model/types'
+import { agentReasoningText } from '../model/messages'
 import type { EkkoLogWriter } from './file-logger'
 
 export interface EkkoRuntimeLogContext {
@@ -93,7 +94,7 @@ export class EkkoRuntimeLogger {
           responseModel: response.model,
           finishReason: response.finishReason,
           outputChars: response.content.length,
-          reasoningChars: response.reasoning?.length || 0,
+          reasoningChars: agentReasoningText(response.reasoning).length,
           toolCallCount: response.toolCalls?.length || 0,
           usage: response.usage,
           ...extra,

--- a/packages/ekko-agent/src/model/messages.ts
+++ b/packages/ekko-agent/src/model/messages.ts
@@ -1,4 +1,15 @@
-import type { AgentMessage, AgentMessageContentPart, AgentMessageRole, AgentToolCall, ModelEvent, ModelResponse, ModelUsage } from './types'
+import type {
+  AgentMessage,
+  AgentMessageContentPart,
+  AgentMessageRole,
+  AgentReasoning,
+  AgentReasoningFormat,
+  AgentReasoningNative,
+  AgentToolCall,
+  ModelEvent,
+  ModelResponse,
+  ModelUsage,
+} from './types'
 
 export type AgentMessageInput =
   | string
@@ -10,6 +21,7 @@ interface AgentMessageLike {
   content?: unknown
   reasoning?: unknown
   reasoning_content?: unknown
+  reasoning_details?: unknown
   text?: unknown
   name?: string
   toolCallId?: string
@@ -26,7 +38,6 @@ export interface AgentOutputMessage extends AgentMessage {
   usage?: ModelUsage
   finishReason?: string
   context?: unknown
-  reasoning?: string
   raw?: unknown
 }
 
@@ -49,7 +60,10 @@ export function normalizeAgentMessage(input: AgentMessageInput, fallbackRole: Ag
   return {
     role,
     content,
-    reasoning: normalizeReasoning(message.reasoning ?? message.reasoning_content),
+    reasoning: normalizeAgentReasoning(
+      message.reasoning ?? message.reasoning_content,
+      message.reasoning_details,
+    ),
     name: message.name,
     toolCallId: message.toolCallId ?? message.tool_call_id,
     toolCalls: message.toolCalls ?? message.tool_calls,
@@ -89,7 +103,7 @@ export function modelResponseToAgentMessage(response: ModelResponse): AgentOutpu
     id: response.id,
     model: response.model,
     content: response.content,
-    reasoning: response.reasoning,
+    reasoning: normalizeAgentReasoning(response.reasoning, undefined, response.usage?.reasoningTokens),
     toolCalls: response.toolCalls,
     usage: response.usage,
     finishReason: response.finishReason,
@@ -101,7 +115,7 @@ export function modelResponseToAgentMessage(response: ModelResponse): AgentOutpu
 export async function collectModelEvents(events: AsyncIterable<ModelEvent>): Promise<AgentStreamOutput> {
   const collected: ModelEvent[] = []
   let content = ''
-  let reasoning = ''
+  let reasoningText = ''
   const toolCalls: AgentToolCall[] = []
   let usage: ModelUsage | undefined
   let done: Partial<ModelResponse> | undefined
@@ -111,7 +125,7 @@ export async function collectModelEvents(events: AsyncIterable<ModelEvent>): Pro
     if (event.type === 'text-delta') {
       content += event.text
     } else if (event.type === 'reasoning-delta') {
-      reasoning += event.text
+      reasoningText += event.text
     } else if (event.type === 'tool-call') {
       toolCalls.push(event.toolCall)
     } else if (event.type === 'usage') {
@@ -128,11 +142,14 @@ export async function collectModelEvents(events: AsyncIterable<ModelEvent>): Pro
       id: done?.id,
       model: done?.model,
       content: done?.content ?? content,
-      reasoning: done?.reasoning ?? (reasoning || undefined),
+      reasoning: mergeAgentReasoning(
+        normalizeAgentReasoning(done?.reasoning, undefined, (done?.usage ?? usage)?.reasoningTokens),
+        reasoningText,
+      ),
       toolCalls: done?.toolCalls ?? (toolCalls.length ? toolCalls : undefined),
       usage: done?.usage ?? usage,
       finishReason: done?.finishReason,
-      context: done?.context,
+      ...(done?.context !== undefined ? { context: done.context } : {}),
       raw: done?.raw,
     },
   }
@@ -151,8 +168,129 @@ function normalizeContent(content: unknown): string {
   return JSON.stringify(content)
 }
 
-function normalizeReasoning(reasoning: unknown): string | undefined {
+export function normalizeAgentReasoning(
+  reasoning: unknown,
+  details?: unknown,
+  estimatedTokens?: number,
+): AgentReasoning | undefined {
+  const normalizedObject = isAgentReasoning(reasoning) ? reasoning : undefined
+  const text = normalizedObject
+    ? normalizeReasoningText(normalizedObject.text)
+    : normalizeReasoningText(reasoning)
+  const storedDetails = normalizeStoredReasoningDetails(details)
+  const native = isAgentReasoningNative(normalizedObject?.native)
+    ? normalizedObject.native
+    : storedDetails.native
+  const tokens = normalizeEstimatedTokens(
+    normalizedObject?.estimatedTokens ?? storedDetails.estimatedTokens ?? estimatedTokens,
+  )
+  if (!text && !native && tokens === undefined) return undefined
+  return {
+    ...(text ? { text } : {}),
+    ...(native ? { native } : {}),
+    ...(tokens !== undefined ? { estimatedTokens: tokens } : {}),
+  }
+}
+
+export function agentReasoningText(reasoning: AgentReasoning | string | null | undefined): string {
+  if (typeof reasoning === 'string') return reasoning
+  return reasoning?.text ?? ''
+}
+
+export function agentReasoningEstimatedTokens(reasoning: AgentReasoning | undefined): number | undefined {
+  return normalizeEstimatedTokens(reasoning?.estimatedTokens)
+}
+
+export function serializeAgentReasoningDetails(reasoning: AgentReasoning | undefined): string | null {
+  if (!reasoning?.native && reasoning?.estimatedTokens === undefined) return null
+  return JSON.stringify({
+    version: 1,
+    ...(reasoning.native ? { native: reasoning.native } : {}),
+    ...(reasoning.estimatedTokens !== undefined ? { estimatedTokens: reasoning.estimatedTokens } : {}),
+  })
+}
+
+function mergeAgentReasoning(reasoning: AgentReasoning | undefined, streamedText: string): AgentReasoning | undefined {
+  const text = reasoning?.text ?? (streamedText || undefined)
+  if (!text && !reasoning?.native && reasoning?.estimatedTokens === undefined) return undefined
+  return {
+    ...(reasoning ?? {}),
+    ...(text ? { text } : {}),
+  }
+}
+
+function normalizeReasoningText(reasoning: unknown): string | undefined {
   if (typeof reasoning === 'string') return reasoning || undefined
-  if (reasoning === undefined || reasoning === null) return undefined
+  if (reasoning === undefined || reasoning === null || isAgentReasoning(reasoning)) return undefined
   return JSON.stringify(reasoning)
+}
+
+function normalizeStoredReasoningDetails(details: unknown): {
+  native?: AgentReasoningNative
+  estimatedTokens?: number
+} {
+  let parsed = details
+  if (typeof parsed === 'string') {
+    if (!parsed.trim()) return {}
+    try {
+      parsed = JSON.parse(parsed)
+    } catch {
+      return {}
+    }
+  }
+  if (isRecord(parsed) && parsed.version === 1) {
+    const estimatedTokens = normalizeEstimatedTokens(parsed.estimatedTokens)
+    return {
+      ...(isAgentReasoningNative(parsed.native) ? { native: parsed.native } : {}),
+      ...(estimatedTokens !== undefined ? { estimatedTokens } : {}),
+    }
+  }
+  if (isAgentReasoningNative(parsed)) return { native: parsed }
+  if (Array.isArray(parsed)) {
+    return {
+      native: {
+        format: inferLegacyReasoningFormat(parsed),
+        data: parsed,
+      },
+    }
+  }
+  return {}
+}
+
+function inferLegacyReasoningFormat(details: unknown[]): AgentReasoningFormat {
+  const first = details.find(item => isRecord(item))
+  if (isRecord(first) && (first.type === 'thinking' || first.type === 'redacted_thinking')) {
+    return 'anthropic-thinking-blocks'
+  }
+  return 'openai-reasoning-details'
+}
+
+function isAgentReasoning(value: unknown): value is AgentReasoning {
+  return isRecord(value) && (
+    'text' in value ||
+    'native' in value ||
+    'estimatedTokens' in value
+  )
+}
+
+function isAgentReasoningNative(value: unknown): value is AgentReasoningNative {
+  return isRecord(value) &&
+    typeof value.format === 'string' &&
+    [
+      'openai-reasoning-details',
+      'openai-responses-items',
+      'anthropic-thinking-blocks',
+      'gemini-content-parts',
+    ].includes(value.format) &&
+    'data' in value
+}
+
+function normalizeEstimatedTokens(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
 }

--- a/packages/ekko-agent/src/model/providers/anthropic.ts
+++ b/packages/ekko-agent/src/model/providers/anthropic.ts
@@ -14,6 +14,7 @@ import type {
 } from '../types'
 import { ModelProviderError } from '../errors'
 import { isPlainRecord, parseJson, postJson, postStream, providerUrl, readServerSentEvents, requestHeaders } from '../http'
+import { agentReasoningText, normalizeAgentReasoning } from '../messages'
 
 interface AnthropicPayload {
   model: string
@@ -36,7 +37,8 @@ interface AnthropicPayload {
 type AnthropicContentBlock =
   | { type: 'text'; text: string }
   | { type: 'image'; source: { type: 'base64'; media_type: string; data: string } }
-  | { type: 'thinking'; thinking: string }
+  | { type: 'thinking'; thinking: string; signature?: string }
+  | { type: 'redacted_thinking'; data: string }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
   | { type: 'tool_result'; tool_use_id: string; content: string | Array<AnthropicToolResultContent> }
 
@@ -108,6 +110,7 @@ export class AnthropicMessagesModelClient implements ModelClient {
     )
 
     const toolCallBlocks = new Map<number, { id: string; name: string; argumentsText: string }>()
+    const reasoningBlocks = new Map<number, AnthropicContentBlock>()
     let finishReason: string | undefined
     let usage: ModelUsage | undefined
 
@@ -129,6 +132,16 @@ export class AnthropicMessagesModelClient implements ModelClient {
         if (block.type === 'tool_use' && typeof block.id === 'string' && typeof block.name === 'string') {
           toolCallBlocks.set(index, { id: block.id, name: block.name, argumentsText: '' })
         }
+        if (block.type === 'thinking') {
+          reasoningBlocks.set(index, {
+            type: 'thinking',
+            thinking: typeof block.thinking === 'string' ? block.thinking : '',
+            ...(typeof block.signature === 'string' ? { signature: block.signature } : {}),
+          })
+        }
+        if (block.type === 'redacted_thinking' && typeof block.data === 'string') {
+          reasoningBlocks.set(index, { type: 'redacted_thinking', data: block.data })
+        }
       }
 
       if (chunk.type === 'content_block_delta' && isPlainRecord(chunk.delta)) {
@@ -136,7 +149,17 @@ export class AnthropicMessagesModelClient implements ModelClient {
           yield { type: 'text-delta', text: chunk.delta.text }
         }
         if (chunk.delta.type === 'thinking_delta' && typeof chunk.delta.thinking === 'string') {
+          const index = typeof chunk.index === 'number' ? chunk.index : 0
+          const current = reasoningBlocks.get(index)
+          if (current?.type === 'thinking') current.thinking += chunk.delta.thinking
           yield { type: 'reasoning-delta', text: chunk.delta.thinking }
+        }
+        if (chunk.delta.type === 'signature_delta' && typeof chunk.delta.signature === 'string') {
+          const index = typeof chunk.index === 'number' ? chunk.index : 0
+          const current = reasoningBlocks.get(index)
+          if (current?.type === 'thinking') {
+            current.signature = `${current.signature || ''}${chunk.delta.signature}`
+          }
         }
         if (chunk.delta.type === 'input_json_delta' && typeof chunk.delta.partial_json === 'string') {
           const index = typeof chunk.index === 'number' ? chunk.index : 0
@@ -154,7 +177,16 @@ export class AnthropicMessagesModelClient implements ModelClient {
           yield { type: 'tool-call', toolCall: normalizeToolCall(toolCall.id, toolCall.name, toolCall.argumentsText) }
         }
         if (usage) yield { type: 'usage', usage }
-        yield { type: 'done', response: { finishReason } }
+        yield {
+          type: 'done',
+          response: {
+            finishReason,
+            reasoning: normalizeAgentReasoning(
+              undefined,
+              anthropicReasoningDetails([...reasoningBlocks.values()]),
+            ),
+          },
+        }
         return
       }
     }
@@ -166,7 +198,9 @@ export function toAnthropicMessagesPayload(config: ModelProviderConfig, request:
   return {
     model: request.model ?? config.defaultModel,
     system: request.messages.filter(message => message.role === 'system').map(message => message.content).join('\n\n') || undefined,
-    messages: request.messages.filter(message => message.role !== 'system').map(toAnthropicMessage),
+    messages: request.messages
+      .filter(message => message.role !== 'system')
+      .map(message => toAnthropicMessage(message, config, request.model ?? config.defaultModel)),
     max_tokens: request.maxTokens ?? 4096,
     temperature: request.temperature,
     ...(tools
@@ -186,7 +220,10 @@ export function normalizeAnthropicResponse(response: AnthropicResponse): ModelRe
     id: response.id,
     model: response.model,
     content: response.content?.filter(block => block.type === 'text').map(block => block.text).join('') ?? '',
-    reasoning: response.content?.filter(block => block.type === 'thinking').map(block => block.thinking).join('') || undefined,
+    reasoning: normalizeAgentReasoning(
+      response.content?.filter(block => block.type === 'thinking').map(block => block.thinking).join('') || undefined,
+      anthropicReasoningDetails(response.content),
+    ),
     toolCalls: response.content?.filter(block => block.type === 'tool_use').map(block => ({
       id: block.id,
       name: block.name,
@@ -199,11 +236,16 @@ export function normalizeAnthropicResponse(response: AnthropicResponse): ModelRe
   }
 }
 
-function toAnthropicMessage(message: AgentMessage): AnthropicPayload['messages'][number] {
+function toAnthropicMessage(
+  message: AgentMessage,
+  config: ModelProviderConfig,
+  model: string,
+): AnthropicPayload['messages'][number] {
   if (message.role === 'assistant') {
     return {
       role: 'assistant',
       content: [
+        ...anthropicReasoningBlocks(message, config, model),
         ...(message.content ? [{ type: 'text' as const, text: message.content }] : []),
         ...(message.toolCalls?.map(toolCall => ({
           type: 'tool_use' as const,
@@ -247,6 +289,59 @@ function toAnthropicMessage(message: AgentMessage): AnthropicPayload['messages']
       })),
     ],
   }
+}
+
+function anthropicReasoningBlocks(
+  message: AgentMessage,
+  config: ModelProviderConfig,
+  model: string,
+): AnthropicContentBlock[] {
+  if (message.role !== 'assistant') return []
+  const nativeBlocks = message.reasoning?.native?.format === 'anthropic-thinking-blocks' &&
+    Array.isArray(message.reasoning.native.data)
+    ? message.reasoning.native.data.filter(isAnthropicReasoningBlock)
+    : []
+  if (isClaudeModel(config, model)) {
+    return nativeBlocks.filter(block =>
+      block.type === 'redacted_thinking' ||
+      (block.type === 'thinking' && typeof block.signature === 'string' && !!block.signature))
+  }
+  const unsignedBlocks = nativeBlocks.filter(block =>
+    block.type === 'thinking' && !block.signature)
+  if (unsignedBlocks.length) return unsignedBlocks
+  const text = agentReasoningText(message.reasoning)
+  return text ? [{ type: 'thinking', thinking: text }] : []
+}
+
+function anthropicReasoningDetails(content: AnthropicResponse['content'] | AnthropicContentBlock[]) {
+  const blocks = content?.filter(isAnthropicReasoningBlock) ?? []
+  return blocks.length
+    ? {
+        format: 'anthropic-thinking-blocks' as const,
+        data: blocks,
+      }
+    : undefined
+}
+
+function isAnthropicReasoningBlock(value: unknown): value is Extract<
+  AnthropicContentBlock,
+  { type: 'thinking' | 'redacted_thinking' }
+> {
+  if (!isPlainRecord(value)) return false
+  if (value.type === 'thinking') {
+    return typeof value.thinking === 'string' &&
+      (value.signature === undefined || typeof value.signature === 'string')
+  }
+  return value.type === 'redacted_thinking' && typeof value.data === 'string'
+}
+
+function isClaudeModel(config: ModelProviderConfig, model: string): boolean {
+  const identifier = `${config.id} ${model}`.toLowerCase()
+  return identifier.includes('claude') ||
+    (
+      (config.id.toLowerCase().includes('anthropic') || config.id === 'claude-oauth') &&
+      ['sonnet', 'opus', 'haiku'].some(part => identifier.includes(part))
+    )
 }
 
 function toAnthropicTool(tool: AgentToolDefinition): NonNullable<AnthropicPayload['tools']>[number] {

--- a/packages/ekko-agent/src/model/providers/gemini.ts
+++ b/packages/ekko-agent/src/model/providers/gemini.ts
@@ -13,6 +13,7 @@ import type {
   ModelUsage,
 } from '../types'
 import { isPlainRecord, postJson, postStream, readServerSentEvents, parseJson } from '../http'
+import { agentReasoningText, normalizeAgentReasoning } from '../messages'
 
 interface GeminiPayload {
   contents: Array<{
@@ -35,11 +36,15 @@ interface GeminiPayload {
   }>
 }
 
-type GeminiPart =
-  | { text: string }
-  | { functionCall: { name: string; args: Record<string, unknown> } }
-  | { functionResponse: { name: string; response: Record<string, unknown> } }
-  | { inlineData: { mimeType: string; data: string } }
+interface GeminiPart {
+  text?: string
+  functionCall?: { name: string; args: Record<string, unknown> }
+  functionResponse?: { name: string; response: Record<string, unknown> }
+  inlineData?: { mimeType: string; data: string }
+  thought?: boolean
+  thoughtSignature?: string
+  [key: string]: unknown
+}
 
 interface GeminiResponse {
   candidates?: Array<{
@@ -106,15 +111,27 @@ export class GeminiContentsModelClient implements ModelClient {
       request.signal,
     )
 
+    const streamedParts: GeminiPart[] = []
     for await (const event of readServerSentEvents(response)) {
       const chunk = parseJson<GeminiResponse>(event)
       if (!chunk) continue
+      streamedParts.push(...(chunk.candidates?.[0]?.content?.parts ?? []))
       const normalized = normalizeGeminiResponse(chunk, request.model ?? this.config.defaultModel)
       if (normalized.content) yield { type: 'text-delta', text: normalized.content }
+      const reasoningText = agentReasoningText(normalized.reasoning)
+      if (reasoningText) yield { type: 'reasoning-delta', text: reasoningText }
       for (const toolCall of normalized.toolCalls ?? []) yield { type: 'tool-call', toolCall }
       if (normalized.usage) yield { type: 'usage', usage: normalized.usage }
     }
-    yield { type: 'done' }
+    yield {
+      type: 'done',
+      response: {
+        reasoning: normalizeAgentReasoning(
+          undefined,
+          geminiReasoningDetails(streamedParts),
+        ),
+      },
+    }
   }
 }
 
@@ -135,7 +152,11 @@ export function normalizeGeminiResponse(response: GeminiResponse, model?: string
   const parts = response.candidates?.[0]?.content?.parts ?? []
   return {
     model,
-    content: parts.filter(hasTextPart).map(part => part.text).join(''),
+    content: parts.filter(hasTextPart).filter(part => part.thought !== true).map(part => part.text).join(''),
+    reasoning: normalizeAgentReasoning(
+      parts.filter(hasTextPart).filter(part => part.thought === true).map(part => part.text).join('') || undefined,
+      geminiReasoningDetails(parts),
+    ),
     toolCalls: parts.filter(hasFunctionCallPart).map((part, index) => ({
       id: `gemini_call_${index}`,
       name: part.functionCall.name,
@@ -150,6 +171,13 @@ export function normalizeGeminiResponse(response: GeminiResponse, model?: string
 
 function toGeminiContent(message: AgentMessage): GeminiPayload['contents'][number] {
   if (message.role === 'assistant') {
+    const nativeParts = geminiReasoningParts(message)
+    if (nativeParts) {
+      return {
+        role: 'model',
+        parts: nativeParts,
+      }
+    }
     return {
       role: 'model',
       parts: [
@@ -185,6 +213,21 @@ function toGeminiContent(message: AgentMessage): GeminiPayload['contents'][numbe
   }
 }
 
+function geminiReasoningParts(message: AgentMessage): GeminiPart[] | undefined {
+  if (message.reasoning?.native?.format !== 'gemini-content-parts') return undefined
+  if (!Array.isArray(message.reasoning.native.data)) return undefined
+  const parts = message.reasoning.native.data.filter(isGeminiPart)
+  return parts.length ? parts : undefined
+}
+
+function geminiReasoningDetails(parts: GeminiPart[]) {
+  if (!parts.some(part => part.thought === true || typeof part.thoughtSignature === 'string')) return undefined
+  return {
+    format: 'gemini-content-parts' as const,
+    data: parts,
+  }
+}
+
 function toGeminiTool(tool: AgentToolDefinition): NonNullable<NonNullable<GeminiPayload['tools']>[number]['functionDeclarations']>[number] {
   return {
     name: tool.name,
@@ -212,10 +255,19 @@ function geminiUrl(config: ModelProviderConfig, model: string | undefined, strea
   return `${baseUrl}/models/${encodeURIComponent(model ?? config.defaultModel)}:${method}${key}`
 }
 
-function hasTextPart(part: GeminiPart): part is { text: string } {
+function hasTextPart(part: GeminiPart): part is GeminiPart & { text: string } {
   return 'text' in part && typeof part.text === 'string'
 }
 
 function hasFunctionCallPart(part: GeminiPart): part is { functionCall: { name: string; args: Record<string, unknown> } } {
   return 'functionCall' in part && isPlainRecord(part.functionCall) && typeof part.functionCall.name === 'string' && isPlainRecord(part.functionCall.args)
+}
+
+function isGeminiPart(value: unknown): value is GeminiPart {
+  if (!isPlainRecord(value)) return false
+  return typeof value.thoughtSignature === 'string' ||
+    typeof value.text === 'string' ||
+    (isPlainRecord(value.functionCall) && typeof value.functionCall.name === 'string' && isPlainRecord(value.functionCall.args)) ||
+    (isPlainRecord(value.functionResponse) && typeof value.functionResponse.name === 'string' && isPlainRecord(value.functionResponse.response)) ||
+    (isPlainRecord(value.inlineData) && typeof value.inlineData.mimeType === 'string' && typeof value.inlineData.data === 'string')
 }

--- a/packages/ekko-agent/src/model/providers/openai-compatible.ts
+++ b/packages/ekko-agent/src/model/providers/openai-compatible.ts
@@ -23,6 +23,7 @@ import type {
   ModelRequest,
   ModelResponse,
   ModelUsage,
+  OpenAIChatReasoningReplayFormat,
 } from '../types'
 
 interface OpenAIChatMessage {
@@ -343,12 +344,10 @@ function normalizeReasoning(message: OpenAIChatResponseMessage | undefined): str
   return reasoningDetailsText(message.reasoning_details)
 }
 
-type OpenAIReasoningReplayField = 'reasoning' | 'reasoning_content' | 'reasoning_details'
-
 function toOpenAIChatMessages(
   message: AgentMessage,
   qwenOAuth = false,
-  reasoningReplayField?: OpenAIReasoningReplayField,
+  reasoningReplayField?: OpenAIChatReasoningReplayFormat,
   requiresAssistantContent = false,
 ): OpenAIChatMessage[] {
   const plainContent = message.role === 'assistant' && message.toolCalls?.length
@@ -405,11 +404,14 @@ function toOpenAIChatMessages(
 function openAIReasoningReplayField(
   config: ModelProviderConfig,
   model: string,
-): OpenAIReasoningReplayField {
+): OpenAIChatReasoningReplayFormat {
+  if (config.openAIChatReasoningReplayFormat) {
+    return config.openAIChatReasoningReplayFormat
+  }
   const identifier = `${config.id} ${config.baseUrl || ''} ${model}`.toLowerCase()
   // OpenRouter preserves provider-native signatures in `reasoning_details`.
-  // DeepSeek-family protocols use `reasoning_content`; the remaining
-  // OpenAI-compatible adapters receive the common `reasoning` field.
+  // Several Chat Completions dialects use `reasoning_content`; the remaining
+  // OpenAI-compatible Chat adapters receive the common `reasoning` field.
   if (identifier.includes('openrouter')) return 'reasoning_details'
   if (usesReasoningContentProtocol(identifier)) return 'reasoning_content'
   return 'reasoning'
@@ -419,8 +421,7 @@ function requiresNonNullAssistantContent(
   config: ModelProviderConfig,
   model: string,
 ): boolean {
-  const identifier = `${config.id} ${config.baseUrl || ''} ${model}`.toLowerCase()
-  return usesReasoningContentProtocol(identifier)
+  return openAIReasoningReplayField(config, model) === 'reasoning_content'
 }
 
 function usesReasoningContentProtocol(identifier: string): boolean {
@@ -430,6 +431,12 @@ function usesReasoningContentProtocol(identifier: string): boolean {
     'kimi',
     'mimo',
     'xiaomimimo',
+    'qwen',
+    'qwq',
+    'dashscope',
+    'glm',
+    'z.ai',
+    'bigmodel',
   ].some(part => identifier.includes(part))
 }
 

--- a/packages/ekko-agent/src/model/providers/openai-compatible.ts
+++ b/packages/ekko-agent/src/model/providers/openai-compatible.ts
@@ -1,4 +1,5 @@
 import { ModelProviderError } from '../errors'
+import { agentReasoningText, normalizeAgentReasoning } from '../messages'
 import {
   abortSignal,
   isPlainRecord,
@@ -30,6 +31,9 @@ interface OpenAIChatMessage {
     | { type: 'text'; text: string; cache_control?: { type: 'ephemeral' } }
     | { type: 'image_url'; image_url: { url: string } }
   >
+  reasoning?: string
+  reasoning_content?: string
+  reasoning_details?: unknown
   name?: string
   tool_call_id?: string
   tool_calls?: OpenAIToolCall[]
@@ -86,6 +90,7 @@ interface OpenAIChatResponse {
       content?: string | null
       reasoning?: string | null
       reasoning_content?: string | null
+      reasoning_details?: unknown
       tool_calls?: Array<{
         index?: number
         id?: string
@@ -166,6 +171,7 @@ export class OpenAICompatibleModelClient implements ModelClient {
     let finishReason: string | undefined
     let responseId: string | undefined
     let responseModel: string | undefined
+    const reasoningDetails = new Map<string, Record<string, unknown>>()
 
     try {
       while (true) {
@@ -180,7 +186,18 @@ export class OpenAICompatibleModelClient implements ModelClient {
           const event = parseServerSentEventLine(line)
           if (!event) continue
           if (event === '[DONE]') {
-            yield { type: 'done', response: { id: responseId, model: responseModel, finishReason } }
+            yield {
+              type: 'done',
+              response: {
+                id: responseId,
+                model: responseModel,
+                finishReason,
+                reasoning: normalizeAgentReasoning(
+                  undefined,
+                  openAIReasoningDetails([...reasoningDetails.values()]),
+                ),
+              },
+            }
             return
           }
 
@@ -204,7 +221,11 @@ export class OpenAICompatibleModelClient implements ModelClient {
           const reasoning = choice.delta?.reasoning_content ?? choice.delta?.reasoning
           if (reasoning) {
             yield { type: 'reasoning-delta', text: reasoning }
+          } else {
+            const detailsText = reasoningDetailsText(choice.delta?.reasoning_details)
+            if (detailsText) yield { type: 'reasoning-delta', text: detailsText }
           }
+          mergeOpenAIReasoningDetails(reasoningDetails, choice.delta?.reasoning_details)
 
           for (const toolCallDelta of choice.delta?.tool_calls ?? []) {
             const index = toolCallDelta.index ?? 0
@@ -227,7 +248,18 @@ export class OpenAICompatibleModelClient implements ModelClient {
       reader.releaseLock()
     }
 
-    yield { type: 'done', response: { id: responseId, model: responseModel, finishReason } }
+    yield {
+      type: 'done',
+      response: {
+        id: responseId,
+        model: responseModel,
+        finishReason,
+        reasoning: normalizeAgentReasoning(
+          undefined,
+          openAIReasoningDetails([...reasoningDetails.values()]),
+        ),
+      },
+    }
   }
 
   private async postJson(payload: OpenAIChatPayload, signal?: AbortSignal): Promise<OpenAIChatResponse> {
@@ -253,10 +285,19 @@ export class OpenAICompatibleModelClient implements ModelClient {
 
 export function toOpenAIChatPayload(config: ModelProviderConfig, request: ModelRequest): OpenAIChatPayload {
   const isQwenOAuth = config.id === 'qwen-oauth'
+  const reasoningReplayField = openAIReasoningReplayField(
+    config,
+    request.model ?? config.defaultModel,
+  )
+  const requiresAssistantContent = requiresNonNullAssistantContent(
+    config,
+    request.model ?? config.defaultModel,
+  )
   const tools = request.tools?.length ? request.tools.map(toOpenAIToolDefinition) : undefined
   return {
     model: request.model ?? config.defaultModel,
-    messages: request.messages.flatMap(message => toOpenAIChatMessages(message, isQwenOAuth)),
+    messages: request.messages.flatMap(message =>
+      toOpenAIChatMessages(message, isQwenOAuth, reasoningReplayField, requiresAssistantContent)),
     temperature: request.temperature,
     max_tokens: request.maxTokens,
     ...(tools
@@ -284,7 +325,10 @@ export function normalizeOpenAIChatResponse(provider: string, response: OpenAICh
     id: response.id,
     model: response.model,
     content: normalizeContent(choice?.message?.content),
-    reasoning: normalizeReasoning(choice?.message),
+    reasoning: normalizeAgentReasoning(
+      normalizeReasoning(choice?.message),
+      openAIReasoningDetails(choice?.message?.reasoning_details),
+    ),
     toolCalls: choice?.message?.tool_calls?.map(toAgentToolCall),
     usage: response.usage ? normalizeUsage(response.usage) : undefined,
     finishReason: choice?.finish_reason ?? undefined,
@@ -296,13 +340,19 @@ function normalizeReasoning(message: OpenAIChatResponseMessage | undefined): str
   if (!message) return undefined
   if (typeof message.reasoning_content === 'string' && message.reasoning_content) return message.reasoning_content
   if (typeof message.reasoning === 'string' && message.reasoning) return message.reasoning
-  if (message.reasoning_details !== undefined && message.reasoning_details !== null) return JSON.stringify(message.reasoning_details)
-  return undefined
+  return reasoningDetailsText(message.reasoning_details)
 }
 
-function toOpenAIChatMessages(message: AgentMessage, qwenOAuth = false): OpenAIChatMessage[] {
+type OpenAIReasoningReplayField = 'reasoning' | 'reasoning_content' | 'reasoning_details'
+
+function toOpenAIChatMessages(
+  message: AgentMessage,
+  qwenOAuth = false,
+  reasoningReplayField?: OpenAIReasoningReplayField,
+  requiresAssistantContent = false,
+): OpenAIChatMessage[] {
   const plainContent = message.role === 'assistant' && message.toolCalls?.length
-    ? message.content || null
+    ? message.content || (requiresAssistantContent ? '' : null)
     : message.content
   const content = qwenOAuth && typeof plainContent === 'string'
     ? [{
@@ -311,9 +361,23 @@ function toOpenAIChatMessages(message: AgentMessage, qwenOAuth = false): OpenAIC
         ...(message.role === 'system' ? { cache_control: { type: 'ephemeral' as const } } : {}),
       }]
     : plainContent
+  const reasoningText = agentReasoningText(message.reasoning)
+  const reasoningDetails = openAIReasoningDetailsData(message)
+  const reasoningReplay: Partial<OpenAIChatMessage> = message.role !== 'assistant'
+    ? {}
+    : reasoningReplayField === 'reasoning' && reasoningText
+      ? { reasoning: reasoningText }
+      : reasoningReplayField === 'reasoning_content' && reasoningText
+        ? { reasoning_content: reasoningText }
+        : reasoningReplayField === 'reasoning_details' && reasoningDetails
+          ? { reasoning_details: reasoningDetails }
+          : reasoningReplayField === 'reasoning_details' && reasoningText
+            ? { reasoning: reasoningText }
+            : {}
   const base: OpenAIChatMessage = {
     role: message.role,
     content,
+    ...reasoningReplay,
     name: message.name,
     tool_call_id: message.toolCallId,
     tool_calls: message.toolCalls?.map(toOpenAIToolCall),
@@ -336,6 +400,99 @@ function toOpenAIChatMessages(message: AgentMessage, qwenOAuth = false): OpenAIC
       ...images.map(image => ({ type: 'image_url' as const, image_url: { url: `data:${image.mimeType};base64,${image.data}` } })),
     ],
   }]
+}
+
+function openAIReasoningReplayField(
+  config: ModelProviderConfig,
+  model: string,
+): OpenAIReasoningReplayField {
+  const identifier = `${config.id} ${config.baseUrl || ''} ${model}`.toLowerCase()
+  // OpenRouter preserves provider-native signatures in `reasoning_details`.
+  // DeepSeek-family protocols use `reasoning_content`; the remaining
+  // OpenAI-compatible adapters receive the common `reasoning` field.
+  if (identifier.includes('openrouter')) return 'reasoning_details'
+  if (usesReasoningContentProtocol(identifier)) return 'reasoning_content'
+  return 'reasoning'
+}
+
+function requiresNonNullAssistantContent(
+  config: ModelProviderConfig,
+  model: string,
+): boolean {
+  const identifier = `${config.id} ${config.baseUrl || ''} ${model}`.toLowerCase()
+  return usesReasoningContentProtocol(identifier)
+}
+
+function usesReasoningContentProtocol(identifier: string): boolean {
+  return [
+    'deepseek',
+    'moonshot',
+    'kimi',
+    'mimo',
+    'xiaomimimo',
+  ].some(part => identifier.includes(part))
+}
+
+function openAIReasoningDetailsData(message: AgentMessage): unknown {
+  return message.reasoning?.native?.format === 'openai-reasoning-details'
+    ? message.reasoning.native.data
+    : undefined
+}
+
+function openAIReasoningDetails(value: unknown) {
+  return Array.isArray(value) && value.length
+    ? {
+        format: 'openai-reasoning-details' as const,
+        data: value,
+      }
+    : undefined
+}
+
+function reasoningDetailsText(value: unknown): string | undefined {
+  if (!Array.isArray(value)) return undefined
+  const text = value
+    .flatMap((detail) => {
+      if (!isPlainRecord(detail)) return []
+      const summary = Array.isArray(detail.summary)
+        ? detail.summary
+            .filter(isPlainRecord)
+            .map(part => typeof part.text === 'string' ? part.text : '')
+        : typeof detail.summary === 'string'
+          ? [detail.summary]
+          : []
+      return [
+        typeof detail.text === 'string' ? detail.text : '',
+        ...summary,
+      ]
+    })
+    .filter(Boolean)
+    .join('\n')
+  return text || undefined
+}
+
+function mergeOpenAIReasoningDetails(
+  target: Map<string, Record<string, unknown>>,
+  value: unknown,
+): void {
+  if (!Array.isArray(value)) return
+  for (let position = 0; position < value.length; position += 1) {
+    const detail = value[position]
+    if (!isPlainRecord(detail)) continue
+    const key = [
+      String(detail.type || 'detail'),
+      String(detail.index ?? detail.id ?? position),
+    ].join(':')
+    const current = target.get(key) ?? {}
+    const merged: Record<string, unknown> = { ...current, ...detail }
+    for (const field of ['text', 'data', 'signature']) {
+      const previous = typeof current[field] === 'string' ? current[field] : ''
+      const next = typeof detail[field] === 'string' ? detail[field] : ''
+      if (previous && next && next !== previous) {
+        merged[field] = next.startsWith(previous) ? next : `${previous}${next}`
+      }
+    }
+    target.set(key, merged)
+  }
 }
 
 function toOpenAIToolDefinition(tool: AgentToolDefinition): OpenAIToolDefinition {

--- a/packages/ekko-agent/src/model/providers/openai-responses.ts
+++ b/packages/ekko-agent/src/model/providers/openai-responses.ts
@@ -13,12 +13,13 @@ import type {
   ModelUsage,
 } from '../types'
 import { isPlainRecord, parseJson, postJson, postStream, providerUrl, readServerSentEvents } from '../http'
-import { collectModelEvents } from '../messages'
+import { collectModelEvents, normalizeAgentReasoning } from '../messages'
 
 interface OpenAIResponsesPayload {
   model: string
   instructions?: string
   input: OpenAIResponseInputItem[]
+  include?: ['reasoning.encrypted_content']
   temperature?: number
   max_output_tokens?: number
   reasoning?: {
@@ -55,6 +56,16 @@ type OpenAIResponseInputItem =
       call_id: string
       output: string
     }
+  | OpenAIReasoningInputItem
+
+interface OpenAIReasoningInputItem {
+  type: 'reasoning'
+  id?: string
+  summary?: Array<{ type: 'summary_text'; text: string }>
+  content?: Array<{ type: 'reasoning_text'; text: string }>
+  encrypted_content?: string
+  status?: string
+}
 
 interface OpenAIResponsesResponse {
   id?: string
@@ -66,6 +77,8 @@ interface OpenAIResponsesResponse {
     phase?: string
     content?: Array<{ type?: string; text?: string }>
     summary?: Array<{ type?: string; text?: string }>
+    encrypted_content?: string
+    status?: string
     name?: string
     call_id?: string
     arguments?: string
@@ -146,7 +159,15 @@ export class OpenAIResponsesModelClient implements ModelClient {
     const messagePhasesByIndex = new Map<number, string>()
     for await (const event of readServerSentEvents(response)) {
       if (event === '[DONE]') {
-        yield { type: 'done' }
+        yield {
+          type: 'done',
+          response: normalizeStreamedResponse(
+            {},
+            collectedOutputItems,
+            streamedText,
+            streamedReasoning,
+          ),
+        }
         return
       }
       const chunk = parseJson<Record<string, unknown>>(event)
@@ -198,25 +219,43 @@ export class OpenAIResponsesModelClient implements ModelClient {
         return
       }
       if (chunk.type === 'response.completed' && isPlainRecord(chunk.response)) {
-        const terminal = chunk.response as OpenAIResponsesResponse
-        const output = collectedOutputItems.length > 0
-          ? collectedOutputItems
-          : terminal.output?.length
-            ? terminal.output
-            : streamedText
-              ? [{
-                  type: 'message',
-                  content: [{ type: 'output_text', text: streamedText }],
-                }]
-              : []
-        const normalized = normalizeOpenAIResponsesResponse({ ...terminal, output })
-        if (!normalized.content && streamedText) normalized.content = streamedText
-        if (!normalized.reasoning && streamedReasoning) normalized.reasoning = streamedReasoning
-        yield { type: 'done', response: normalized }
+        yield {
+          type: 'done',
+          response: normalizeStreamedResponse(
+            chunk.response as OpenAIResponsesResponse,
+            collectedOutputItems,
+            streamedText,
+            streamedReasoning,
+          ),
+        }
         return
       }
     }
   }
+}
+
+function normalizeStreamedResponse(
+  terminal: OpenAIResponsesResponse,
+  collectedOutputItems: NonNullable<OpenAIResponsesResponse['output']>,
+  streamedText: string,
+  streamedReasoning: string,
+): ModelResponse {
+  const output = collectedOutputItems.length > 0
+    ? collectedOutputItems
+    : terminal.output?.length
+      ? terminal.output
+      : streamedText
+        ? [{
+            type: 'message',
+            content: [{ type: 'output_text', text: streamedText }],
+          }]
+        : []
+  const normalized = normalizeOpenAIResponsesResponse({ ...terminal, output })
+  if (!normalized.content && streamedText) normalized.content = streamedText
+  if (!normalized.reasoning && streamedReasoning) {
+    normalized.reasoning = normalizeAgentReasoning(streamedReasoning)
+  }
+  return normalized
 }
 
 export function toOpenAIResponsesPayload(config: ModelProviderConfig, request: ModelRequest): OpenAIResponsesPayload {
@@ -233,6 +272,7 @@ export function toOpenAIResponsesPayload(config: ModelProviderConfig, request: M
   return {
     model: request.model ?? config.defaultModel,
     instructions: systemMessages.map(message => message.content).join('\n\n') || undefined,
+    ...(shouldIncludeEncryptedReasoning(config) ? { include: ['reasoning.encrypted_content'] as const } : {}),
     input: request.messages
       .filter(message => message.role !== 'system')
       .flatMap(message => toOpenAIResponseInput(message, replayableToolCallIds)),
@@ -274,7 +314,10 @@ export function normalizeOpenAIResponsesResponse(response: OpenAIResponsesRespon
     id: response.id,
     model: response.model,
     content: outputContent || (messageItems.length === 0 ? response.output_text ?? '' : ''),
-    reasoning: normalizeReasoning(response),
+    reasoning: normalizeAgentReasoning(
+      normalizeReasoning(response),
+      openAIResponsesReasoningDetails(response.output),
+    ),
     toolCalls,
     usage: response.usage ? normalizeUsage(response.usage) : undefined,
     finishReason: response.status,
@@ -355,7 +398,9 @@ function toOpenAIResponseInput(
     return items
   }
   if (message.role === 'assistant') {
-    const items: OpenAIResponseInputItem[] = []
+    const items: OpenAIResponseInputItem[] = [
+      ...openAIResponsesReasoningInput(message),
+    ]
     if (message.content) items.push({ role: 'assistant', content: message.content })
     for (const toolCall of message.toolCalls ?? []) {
       if (!toolCall.id || !toolCall.name.trim()) continue
@@ -379,6 +424,32 @@ function toOpenAIResponseInput(
     }]
   }
   return [{ role: 'user', content: message.content }]
+}
+
+function openAIResponsesReasoningInput(message: AgentMessage): OpenAIReasoningInputItem[] {
+  if (message.reasoning?.native?.format !== 'openai-responses-items') return []
+  if (!Array.isArray(message.reasoning.native.data)) return []
+  return message.reasoning.native.data
+    .filter(isPlainRecord)
+    .filter(item => item.type === 'reasoning')
+    .map(item => ({ ...item, type: 'reasoning' }) as OpenAIReasoningInputItem)
+}
+
+function openAIResponsesReasoningDetails(output: OpenAIResponsesResponse['output']) {
+  const items = output?.filter(item => item.type === 'reasoning') ?? []
+  return items.length
+    ? {
+        format: 'openai-responses-items' as const,
+        data: items,
+      }
+    : undefined
+}
+
+function shouldIncludeEncryptedReasoning(config: ModelProviderConfig): boolean {
+  const identifier = `${config.id} ${config.baseUrl || ''}`.toLowerCase()
+  return config.type === 'openai' ||
+    config.id === 'openai' ||
+    identifier.includes('api.openai.com')
 }
 
 function toOpenAIResponseTool(tool: AgentToolDefinition): NonNullable<OpenAIResponsesPayload['tools']>[number] {

--- a/packages/ekko-agent/src/model/types.ts
+++ b/packages/ekko-agent/src/model/types.ts
@@ -16,11 +16,28 @@ export type ModelProviderType =
 
 export type AgentMessageRole = 'system' | 'user' | 'assistant' | 'tool'
 
+export type AgentReasoningFormat =
+  | 'openai-reasoning-details'
+  | 'openai-responses-items'
+  | 'anthropic-thinking-blocks'
+  | 'gemini-content-parts'
+
+export interface AgentReasoningNative {
+  format: AgentReasoningFormat
+  data: unknown
+}
+
+export interface AgentReasoning {
+  text?: string
+  native?: AgentReasoningNative
+  estimatedTokens?: number
+}
+
 export interface AgentMessage {
   role: AgentMessageRole
   content: string
   contentParts?: AgentMessageContentPart[]
-  reasoning?: string
+  reasoning?: AgentReasoning
   name?: string
   toolCallId?: string
   toolCalls?: AgentToolCall[]
@@ -82,7 +99,7 @@ export interface ModelResponse {
   id?: string
   model?: string
   content: string
-  reasoning?: string
+  reasoning?: string | AgentReasoning
   toolCalls?: AgentToolCall[]
   usage?: ModelUsage
   finishReason?: string

--- a/packages/ekko-agent/src/model/types.ts
+++ b/packages/ekko-agent/src/model/types.ts
@@ -80,6 +80,12 @@ export type ModelReasoningEffort =
 
 export type ModelReasoningSummary = 'auto' | 'concise' | 'detailed'
 
+export type OpenAIChatReasoningReplayFormat =
+  | 'reasoning'
+  | 'reasoning_content'
+  | 'reasoning_details'
+  | 'none'
+
 export interface ModelRequest {
   model?: string
   messages: AgentMessage[]
@@ -128,6 +134,11 @@ export interface ModelProviderConfig {
   id: string
   type: ModelProviderType
   requestStyle?: ModelRequestStyle
+  /**
+   * Provider-specific assistant reasoning field used only by the OpenAI Chat
+   * Completions adapter. Other request styles use their native replay shape.
+   */
+  openAIChatReasoningReplayFormat?: OpenAIChatReasoningReplayFormat
   apiKey?: string
   baseUrl?: string
   endpointPath?: string

--- a/packages/ekko-agent/src/runtime/runtime.ts
+++ b/packages/ekko-agent/src/runtime/runtime.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import {
+  agentReasoningEstimatedTokens,
+  agentReasoningText,
   createSystemMessage,
   createToolResultMessage,
   collectModelEvents,
@@ -261,8 +263,9 @@ export class AgentRuntime {
         output = assistantMessage
         messages.push(assistantMessage)
         steps.push({ type: 'model', step, message: assistantMessage })
-        if (assistantMessage.reasoning && !modelResult.emittedReasoning) {
-          emit({ type: 'model.reasoning', runId, step, text: assistantMessage.reasoning })
+        const reasoningText = agentReasoningText(assistantMessage.reasoning)
+        if (reasoningText && !modelResult.emittedReasoning) {
+          emit({ type: 'model.reasoning', runId, step, text: reasoningText })
         }
         if (assistantMessage.context !== undefined) {
           if (contextKey) this.modelContexts.set(contextKey, assistantMessage.context)
@@ -991,10 +994,10 @@ function subtaskSummary(output: string, status: 'completed' | 'failed' | 'interr
   return 'Subtask completed.'
 }
 
-function isEmptyModelResponse(response: ModelResponse): boolean {
+function isEmptyModelResponse(response: ModelResponse | AgentOutputMessage): boolean {
   return (
     !response.content?.trim() &&
-    !response.reasoning?.trim() &&
+    !agentReasoningText(response.reasoning).trim() &&
     !(response.toolCalls?.length)
   )
 }
@@ -1005,7 +1008,14 @@ function estimateModelRequestContext(request: ModelRequest): AgentRuntimeContext
   const systemPrompt = systemMessages.map(message => message.content || '').join('\n\n')
   const systemPromptTokens = countTextTokens(systemPrompt)
   const messageTokens = nonSystemMessages.reduce((sum, message) => {
-    return sum + countTextTokens(message.content || '') + countTextTokens(JSON.stringify(message.toolCalls || ''))
+    const estimatedReasoningTokens = agentReasoningEstimatedTokens(message.reasoning)
+    const reasoningTokens = estimatedReasoningTokens !== undefined && estimatedReasoningTokens > 0
+      ? estimatedReasoningTokens
+      : countTextTokens(agentReasoningText(message.reasoning))
+    return sum +
+      countTextTokens(message.content || '') +
+      reasoningTokens +
+      countTextTokens(JSON.stringify(message.toolCalls || ''))
   }, 0)
   const toolTokens = countTextTokens(JSON.stringify(request.tools || []))
   const modelContextTokens = request.context == null ? 0 : countTextTokens(JSON.stringify(request.context))

--- a/packages/server/src/lib/context-compressor/index.ts
+++ b/packages/server/src/lib/context-compressor/index.ts
@@ -51,6 +51,7 @@ export interface ChatMessage {
   tool_call_id?: string
   name?: string
   reasoning_content?: string | null
+  reasoning_details?: string | null
 }
 
 export interface CompressionConfig {

--- a/packages/server/src/services/hermes/run-chat/compression.ts
+++ b/packages/server/src/services/hermes/run-chat/compression.ts
@@ -523,6 +523,7 @@ export async function compressHistory(
     const compressed = result.messages.map(m => {
       const msg: any = { role: m.role, content: m.content, tool_call_id: m.tool_call_id, name: m.name }
       if (m.reasoning_content != null) msg.reasoning_content = m.reasoning_content
+      if (m.reasoning_details != null) msg.reasoning_details = m.reasoning_details
       if (m.tool_calls?.length) {
         const cleanedToolCalls = m.tool_calls
           .filter((tc: any) => tc.id && tc.id.length > 0)
@@ -627,6 +628,7 @@ export async function forceCompressBridgeHistory(
   const compressedMessages = result.messages.map(m => {
     const msg: any = { role: m.role, content: m.content }
     if (m.reasoning_content != null) msg.reasoning_content = m.reasoning_content
+    if (m.reasoning_details != null) msg.reasoning_details = m.reasoning_details
     if (m.tool_calls?.length) {
       const cleanedToolCalls = m.tool_calls
         .filter((tc: any) => tc.id && tc.id.length > 0)
@@ -654,6 +656,7 @@ export async function forceCompressBridgeHistory(
       role: m.role,
       content: m.content,
       reasoning_content: m.reasoning_content,
+      reasoning_details: m.reasoning_details,
       tool_calls: m.tool_calls,
       tool_call_id: m.tool_call_id,
       name: m.name,

--- a/packages/server/src/services/hermes/run-chat/context-history.ts
+++ b/packages/server/src/services/hermes/run-chat/context-history.ts
@@ -48,6 +48,7 @@ export function buildDbHistoryFromContextRows(
       })
     }
     if (row.reasoning_content != null) message.reasoning_content = row.reasoning_content
+    if (row.reasoning_details != null) message.reasoning_details = row.reasoning_details
     if (row.tool_calls?.length) {
       const cleanedToolCalls = row.tool_calls
         .filter((toolCall: any) => toolCall.id && toolCall.id.length > 0)

--- a/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
@@ -18,6 +18,11 @@ import {
   type ModelRequest,
   type ModelResponse,
 } from '../../../../../ekko-agent/src'
+import {
+  agentReasoningText,
+  normalizeAgentReasoning,
+  serializeAgentReasoningDetails,
+} from '../../../../../ekko-agent/src/model/messages'
 import { getGlobalEkkoAgent } from '../../ekko-agent/manager'
 import { waitForEkkoToolApproval } from '../../ekko-agent/approvals'
 import { waitForEkkoClarification } from '../../ekko-agent/clarifications'
@@ -243,10 +248,13 @@ async function toAgentMessages(messages: Array<ChatMessage | SessionState['messa
       const agentMessage: AgentMessage = {
         role: 'assistant',
         content: contentBlocksToString(message.content as any),
-        reasoning: ('reasoning' in message ? message.reasoning : undefined) || message.reasoning_content || undefined,
+        reasoning: normalizeAgentReasoning(
+          ('reasoning' in message ? message.reasoning : undefined) || message.reasoning_content,
+          'reasoning_details' in message ? message.reasoning_details : undefined,
+        ),
         toolCalls,
       }
-      if (agentMessage.content.trim() || (agentMessage.reasoning?.trim().length ?? 0) > 0 || toolCalls?.length) {
+      if (agentMessage.content.trim() || agentReasoningText(agentMessage.reasoning).trim() || agentMessage.reasoning?.native || toolCalls?.length) {
         result.push(agentMessage)
       }
       continue
@@ -726,6 +734,8 @@ export async function handleEkkoAgentRun(
     if (!toolCalls.length || toolCalls.some(call => !group.results.has(call.id))) return false
     const timestamp = Math.floor(Date.now() / 1000)
     const storedToolCalls = toolCalls.map(toStoredToolCall)
+    const reasoningText = agentReasoningText(group.message.reasoning)
+    const reasoningDetails = serializeAgentReasoningDetails(group.message.reasoning)
     const rows = [
       {
         session_id: sessionId,
@@ -734,8 +744,9 @@ export async function handleEkkoAgentRun(
         tool_calls: storedToolCalls,
         timestamp,
         finish_reason: 'tool_calls',
-        reasoning: group.message.reasoning || null,
-        reasoning_content: group.message.reasoning || null,
+        reasoning: reasoningText || null,
+        reasoning_details: reasoningDetails,
+        reasoning_content: reasoningText || null,
       },
       ...toolCalls.map((toolCall) => {
         const completed = group.results.get(toolCall.id)!
@@ -1295,6 +1306,8 @@ export async function handleEkkoAgentRun(
         if (!unpersistedToolCalls.length) continue
         const toolCalls = unpersistedToolCalls.map(toStoredToolCall)
         const timestamp = Math.floor(Date.now() / 1000)
+        const reasoningText = agentReasoningText(step.message.reasoning)
+        const reasoningDetails = serializeAgentReasoningDetails(step.message.reasoning)
         const assistantId = addMessage({
           session_id: sessionId,
           role: 'assistant',
@@ -1302,8 +1315,9 @@ export async function handleEkkoAgentRun(
           tool_calls: toolCalls,
           timestamp,
           finish_reason: 'tool_calls',
-          reasoning: step.message.reasoning || null,
-          reasoning_content: step.message.reasoning || null,
+          reasoning: reasoningText || null,
+          reasoning_details: reasoningDetails,
+          reasoning_content: reasoningText || null,
         })
         if (assistantId != null) assistantMessageId = String(assistantId)
         state.messages.push({
@@ -1314,8 +1328,9 @@ export async function handleEkkoAgentRun(
           tool_calls: toolCalls,
           timestamp,
           finish_reason: 'tool_calls',
-          reasoning: step.message.reasoning || null,
-          reasoning_content: step.message.reasoning || null,
+          reasoning: reasoningText || null,
+          reasoning_details: reasoningDetails,
+          reasoning_content: reasoningText || null,
         })
       } else if (step.type === 'tool') {
         if (persistedToolCallIds.has(step.toolCallId)) continue
@@ -1341,7 +1356,7 @@ export async function handleEkkoAgentRun(
         })
       }
     }
-    assistantReasoning = result.output.reasoning || assistantReasoning
+    assistantReasoning = agentReasoningText(result.output.reasoning) || assistantReasoning
     const hadToolActivity = result.steps.some(step => step.type === 'tool')
     if (!assistantText.trim() && !assistantReasoning.trim() && !hadToolActivity) {
       const error = 'Model provider returned an empty response after streaming and non-streaming attempts.'
@@ -1374,6 +1389,7 @@ export async function handleEkkoAgentRun(
       return
     }
     if (assistantText.trim() || assistantReasoning.trim()) {
+      const reasoningDetails = serializeAgentReasoningDetails(result.output.reasoning)
       const assistantId = addMessage({
         session_id: sessionId,
         role: 'assistant',
@@ -1381,6 +1397,7 @@ export async function handleEkkoAgentRun(
         timestamp: Math.floor(Date.now() / 1000),
         finish_reason: result.output.finishReason || null,
         reasoning: assistantReasoning || null,
+        reasoning_details: reasoningDetails,
         reasoning_content: assistantReasoning || null,
       })
       if (assistantId != null) assistantMessageId = String(assistantId)
@@ -1392,6 +1409,7 @@ export async function handleEkkoAgentRun(
         timestamp: Math.floor(Date.now() / 1000),
         finish_reason: result.output.finishReason || null,
         reasoning: assistantReasoning || null,
+        reasoning_details: reasoningDetails,
         reasoning_content: assistantReasoning || null,
       })
     }

--- a/packages/server/src/services/hermes/run-chat/usage.ts
+++ b/packages/server/src/services/hermes/run-chat/usage.ts
@@ -21,6 +21,7 @@ type UsageTokenMessage = {
   /** DeepSeek/Kimi thinking-mode payload echoed back on subsequent turns. */
   reasoning_content?: unknown
   reasoning?: unknown
+  reasoning_details?: unknown
 }
 
 function contentToUsageText(content: unknown): string {
@@ -48,14 +49,32 @@ export function estimateUsageTokensFromMessages(messages: UsageTokenMessage[]): 
       // hundreds of K tokens and skips compression until the upstream 400
       // (NousResearch/hermes-agent#80246).
       const reasoning = m.reasoning_content ?? m.reasoning
+      const estimatedReasoningTokens = storedReasoningTokenEstimate(m.reasoning_details)
       return (
         sum
         + countTokens(contentToUsageText(m.content))
         + countTokens(String(m.tool_calls || ''))
-        + countTokens(String(reasoning || ''))
+        + (estimatedReasoningTokens ?? countTokens(String(reasoning || '')))
       )
     }, 0)
   return { inputTokens, outputTokens }
+}
+
+function storedReasoningTokenEstimate(details: unknown): number | undefined {
+  let parsed = details
+  if (typeof parsed === 'string') {
+    if (!parsed.trim()) return undefined
+    try {
+      parsed = JSON.parse(parsed)
+    } catch {
+      return undefined
+    }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined
+  const value = (parsed as Record<string, unknown>).estimatedTokens
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined
 }
 
 export async function calcAndUpdateUsage(

--- a/tests/ekko-agent/messages.test.ts
+++ b/tests/ekko-agent/messages.test.ts
@@ -6,8 +6,10 @@ import {
   createToolResultMessage,
   createUserMessage,
   modelResponseToAgentMessage,
+  normalizeAgentReasoning,
   normalizeAgentMessage,
   normalizeAgentMessages,
+  serializeAgentReasoningDetails,
 } from '../../packages/ekko-agent/src/index'
 import type { ModelEvent } from '../../packages/ekko-agent/src/index'
 
@@ -87,6 +89,39 @@ describe('ekko-agent unified messages', () => {
     })
   })
 
+  it('round-trips unified reasoning metadata through persisted reasoning_details', () => {
+    const reasoning = normalizeAgentReasoning(
+      'Checked the constraints.',
+      {
+        version: 1,
+        estimatedTokens: 42,
+        native: {
+          format: 'openai-responses-items',
+          data: [{
+            type: 'reasoning',
+            id: 'rs_1',
+            encrypted_content: 'encrypted-reasoning',
+          }],
+        },
+      },
+    )
+    const serialized = serializeAgentReasoningDetails(reasoning)
+
+    expect(normalizeAgentReasoning('Checked the constraints.', serialized)).toEqual(reasoning)
+    expect(JSON.parse(serialized ?? '')).toEqual({
+      version: 1,
+      estimatedTokens: 42,
+      native: {
+        format: 'openai-responses-items',
+        data: [{
+          type: 'reasoning',
+          id: 'rs_1',
+          encrypted_content: 'encrypted-reasoning',
+        }],
+      },
+    })
+  })
+
   it('collects stream events into one assistant output message', async () => {
     async function *events(): AsyncIterable<ModelEvent> {
       yield { type: 'text-delta', text: 'Hel' }
@@ -127,7 +162,7 @@ describe('ekko-agent unified messages', () => {
         id: 'res_1',
         model: 'stream-model',
         content: 'Hello',
-        reasoning: 'thinking step',
+        reasoning: { text: 'thinking step' },
         toolCalls: [{
           id: 'call_1',
           name: 'lookup',

--- a/tests/ekko-agent/model-request.test.ts
+++ b/tests/ekko-agent/model-request.test.ts
@@ -710,6 +710,16 @@ describe('ekko-agent model requests', () => {
       baseUrl: 'https://api.xiaomimimo.com/v1',
       model: 'mimo-v2-flash',
     },
+    {
+      id: 'qwen-oauth',
+      baseUrl: 'https://portal.qwen.ai/v1',
+      model: 'qwen3.7-plus',
+    },
+    {
+      id: 'glm',
+      baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
+      model: 'glm-5.2',
+    },
   ])('maps unified reasoning to reasoning_content for $model', ({ id, baseUrl, model }) => {
     const payload = toOpenAIChatPayload({
       id,
@@ -730,10 +740,42 @@ describe('ekko-agent model requests', () => {
     })
 
     expect(payload.messages[0]).toMatchObject({
-      content: '',
       reasoning_content: 'Previous analysis.',
     })
+    expect(payload.messages[0]?.content).not.toBeNull()
     expect(payload.messages[0]).not.toHaveProperty('reasoning')
+  })
+
+  it('allows an OpenAI Chat provider to override its reasoning replay format', () => {
+    const message = {
+      role: 'assistant' as const,
+      content: 'Previous answer.',
+      reasoning: { text: 'Previous analysis.' },
+    }
+    const reasoningContentPayload = toOpenAIChatPayload({
+      id: 'custom:reasoning-content',
+      type: 'openai-compatible',
+      requestStyle: 'openai-chat',
+      openAIChatReasoningReplayFormat: 'reasoning_content',
+      baseUrl: 'https://chat.example/v1',
+      defaultModel: 'custom-model',
+    }, { messages: [message] })
+    const disabledPayload = toOpenAIChatPayload({
+      id: 'custom:no-reasoning-replay',
+      type: 'openai-compatible',
+      requestStyle: 'openai-chat',
+      openAIChatReasoningReplayFormat: 'none',
+      baseUrl: 'https://strict.example/v1',
+      defaultModel: 'strict-chat',
+    }, { messages: [message] })
+
+    expect(reasoningContentPayload.messages[0]).toMatchObject({
+      reasoning_content: 'Previous analysis.',
+    })
+    expect(reasoningContentPayload.messages[0]).not.toHaveProperty('reasoning')
+    expect(disabledPayload.messages[0]).not.toHaveProperty('reasoning')
+    expect(disabledPayload.messages[0]).not.toHaveProperty('reasoning_content')
+    expect(disabledPayload.messages[0]).not.toHaveProperty('reasoning_details')
   })
 
   it('uses one reasoning field for OpenRouter fallback and other compatible endpoints', () => {

--- a/tests/ekko-agent/model-request.test.ts
+++ b/tests/ekko-agent/model-request.test.ts
@@ -3,13 +3,18 @@ import {
   AgentRuntime,
   AgentToolRegistry,
   AnthropicMessagesModelClient,
+  collectModelEvents,
   ModelProviderError,
   ModelProviderRegistry,
   authorizedModelProviderPreset,
   createModelClient,
+  modelResponseToAgentMessage,
+  normalizeAnthropicResponse,
+  normalizeGeminiResponse,
   toAnthropicMessagesPayload,
   toGeminiContentsPayload,
   normalizeOpenAIChatResponse,
+  normalizeOpenAIResponsesResponse,
   resolveModelProviderConfigs,
   toOpenAIResponsesPayload,
   toOpenAIChatPayload,
@@ -26,6 +31,65 @@ const providerConfig: ModelProviderConfig = {
 }
 
 describe('ekko-agent model requests', () => {
+  it('replays streamed DeepSeek reasoning_content through a complete tool loop', async () => {
+    const encoder = new TextEncoder()
+    let call = 0
+    const requestBodies: Array<Record<string, any>> = []
+    const fetchMock = vi.fn(async (_input: string | URL, init?: RequestInit) => {
+      requestBodies.push(JSON.parse(String(init?.body)))
+      call += 1
+      const frames = call === 1
+        ? [
+            'data: {"id":"chatcmpl_tool","model":"deepseek-chat","choices":[{"delta":{"reasoning_content":"I need the weather tool.","tool_calls":[{"index":0,"id":"call_weather","type":"function","function":{"name":"weather","arguments":"{\\"city\\":\\"Xiamen\\"}"}}]},"finish_reason":"tool_calls"}]}\n\n',
+            'data: [DONE]\n\n',
+          ]
+        : [
+            'data: {"id":"chatcmpl_final","model":"deepseek-chat","choices":[{"delta":{"content":"Sunny"},"finish_reason":"stop"}]}\n\n',
+            'data: [DONE]\n\n',
+          ]
+      return new Response(new ReadableStream({
+        start(controller) {
+          for (const frame of frames) controller.enqueue(encoder.encode(frame))
+          controller.close()
+        },
+      }), { status: 200 })
+    })
+    const tools = new AgentToolRegistry()
+    tools.register({
+      definition: {
+        name: 'weather',
+        parameters: {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+          required: ['city'],
+        },
+      },
+      async execute(input) {
+        return { ok: true, content: `${input.city}: Sunny` }
+      },
+    })
+    const client = createModelClient(providerConfig, { fetch: fetchMock })
+    const runtime = new AgentRuntime({ modelClient: client, tools })
+
+    const result = await runtime.run({ messages: ['Check Xiamen weather'] })
+
+    expect(result.output.content).toBe('Sunny')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(requestBodies[1]?.messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'I need the weather tool.',
+        tool_calls: [expect.objectContaining({ id: 'call_weather' })],
+      }),
+      expect.objectContaining({
+        role: 'tool',
+        tool_call_id: 'call_weather',
+        content: 'Xiamen: Sunny',
+      }),
+    ]))
+  })
+
   it('completes a Codex Responses tool loop when terminal output arrays are empty', async () => {
     const encoder = new TextEncoder()
     let call = 0
@@ -270,7 +334,7 @@ describe('ekko-agent model requests', () => {
       type: 'done',
       response: expect.objectContaining({
         content: 'Done',
-        reasoning: 'Checked the constraints.',
+        reasoning: { text: 'Checked the constraints.' },
       }),
     }))
   })
@@ -309,7 +373,7 @@ describe('ekko-agent model requests', () => {
       type: 'done',
       response: expect.objectContaining({
         content: 'Ready.',
-        reasoning: '**Loading model skill**',
+        reasoning: { text: '**Loading model skill**' },
       }),
     }))
   })
@@ -603,6 +667,184 @@ describe('ekko-agent model requests', () => {
     expect(payload).not.toHaveProperty('metadata')
   })
 
+  it('replays assistant reasoning_content for providers that require it during tool calls', () => {
+    const payload = toOpenAIChatPayload(providerConfig, {
+      messages: [
+        { role: 'user', content: 'Check the weather.' },
+        {
+          role: 'assistant',
+          content: '',
+          reasoning: { text: 'I need the weather tool.' },
+          toolCalls: [{
+            id: 'call_weather',
+            name: 'weather',
+            arguments: { city: 'Xiamen' },
+          }],
+        },
+        {
+          role: 'tool',
+          content: 'Sunny',
+          toolCallId: 'call_weather',
+          name: 'weather',
+        },
+      ],
+    })
+
+    expect(payload.messages[1]).toMatchObject({
+      role: 'assistant',
+      content: '',
+      reasoning_content: 'I need the weather tool.',
+      tool_calls: [expect.objectContaining({ id: 'call_weather' })],
+    })
+    expect(payload.messages[1]).not.toHaveProperty('reasoning')
+  })
+
+  it.each([
+    {
+      id: 'moonshot',
+      baseUrl: 'https://api.moonshot.ai/v1',
+      model: 'kimi-k2-thinking',
+    },
+    {
+      id: 'xiaomi',
+      baseUrl: 'https://api.xiaomimimo.com/v1',
+      model: 'mimo-v2-flash',
+    },
+  ])('maps unified reasoning to reasoning_content for $model', ({ id, baseUrl, model }) => {
+    const payload = toOpenAIChatPayload({
+      id,
+      type: 'openai-compatible',
+      baseUrl,
+      defaultModel: model,
+    }, {
+      messages: [{
+        role: 'assistant',
+        content: '',
+        reasoning: { text: 'Previous analysis.' },
+        toolCalls: [{
+          id: 'call_1',
+          name: 'lookup',
+          arguments: { q: 'weather' },
+        }],
+      }],
+    })
+
+    expect(payload.messages[0]).toMatchObject({
+      content: '',
+      reasoning_content: 'Previous analysis.',
+    })
+    expect(payload.messages[0]).not.toHaveProperty('reasoning')
+  })
+
+  it('uses one reasoning field for OpenRouter fallback and other compatible endpoints', () => {
+    const messages = [{
+      role: 'assistant' as const,
+      content: 'Previous answer.',
+      reasoning: { text: 'Previous analysis.' },
+    }]
+    const openRouterPayload = toOpenAIChatPayload({
+      id: 'openrouter',
+      type: 'openai-compatible',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      defaultModel: 'anthropic/claude-sonnet-4.6',
+    }, { messages })
+    const strictPayload = toOpenAIChatPayload({
+      id: 'custom:strict',
+      type: 'openai-compatible',
+      baseUrl: 'https://strict.example/v1',
+      defaultModel: 'strict-chat',
+    }, { messages })
+
+    expect(openRouterPayload.messages[0]).toMatchObject({
+      role: 'assistant',
+      content: 'Previous answer.',
+      reasoning: 'Previous analysis.',
+    })
+    expect(openRouterPayload.messages[0]).not.toHaveProperty('reasoning_content')
+    expect(strictPayload.messages[0]).toMatchObject({
+      reasoning: 'Previous analysis.',
+    })
+    expect(strictPayload.messages[0]).not.toHaveProperty('reasoning_content')
+  })
+
+  it('preserves OpenRouter reasoning_details signatures across a streamed tool loop', async () => {
+    const encoder = new TextEncoder()
+    let call = 0
+    const requestBodies: Array<Record<string, any>> = []
+    const reasoningDetails = [{
+      type: 'reasoning.text',
+      text: 'I need the weather tool.',
+      signature: 'openrouter-signature',
+      index: 0,
+    }]
+    const fetchMock = vi.fn(async (_input: string | URL, init?: RequestInit) => {
+      requestBodies.push(JSON.parse(String(init?.body)))
+      call += 1
+      const frames = call === 1
+        ? [
+            `data: ${JSON.stringify({
+              id: 'chatcmpl_tool',
+              model: 'anthropic/claude-sonnet-4.6',
+              choices: [{
+                delta: {
+                  reasoning_details: reasoningDetails,
+                  tool_calls: [{
+                    index: 0,
+                    id: 'call_weather',
+                    type: 'function',
+                    function: { name: 'weather', arguments: '{"city":"Xiamen"}' },
+                  }],
+                },
+                finish_reason: 'tool_calls',
+              }],
+            })}\n\n`,
+            'data: [DONE]\n\n',
+          ]
+        : [
+            'data: {"id":"chatcmpl_final","choices":[{"delta":{"content":"Sunny"},"finish_reason":"stop"}]}\n\n',
+            'data: [DONE]\n\n',
+          ]
+      return new Response(new ReadableStream({
+        start(controller) {
+          for (const frame of frames) controller.enqueue(encoder.encode(frame))
+          controller.close()
+        },
+      }), { status: 200 })
+    })
+    const tools = new AgentToolRegistry()
+    tools.register({
+      definition: {
+        name: 'weather',
+        parameters: { type: 'object', properties: { city: { type: 'string' } } },
+      },
+      async execute() {
+        return { ok: true, content: 'Sunny' }
+      },
+    })
+    const runtime = new AgentRuntime({
+      modelClient: createModelClient({
+        id: 'openrouter',
+        type: 'openai-compatible',
+        baseUrl: 'https://openrouter.ai/api/v1',
+        apiKey: 'test-key',
+        defaultModel: 'anthropic/claude-sonnet-4.6',
+      }, { fetch: fetchMock }),
+      tools,
+    })
+
+    await runtime.run({ messages: ['Check Xiamen weather'] })
+
+    expect(requestBodies[1]?.messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        role: 'assistant',
+        reasoning_details: reasoningDetails,
+        tool_calls: [expect.objectContaining({ id: 'call_weather' })],
+      }),
+    ]))
+    expect(requestBodies[1]?.messages[1]).not.toHaveProperty('reasoning')
+    expect(requestBodies[1]?.messages[1]).not.toHaveProperty('reasoning_content')
+  })
+
   it('normalizes OpenAI-compatible responses into the internal shape', () => {
     const response = normalizeOpenAIChatResponse('deepseek', {
       id: 'chatcmpl_1',
@@ -799,6 +1041,89 @@ describe('ekko-agent model requests', () => {
     ])
   })
 
+  it('replays encrypted OpenAI Responses reasoning items without flattening them', () => {
+    const response = normalizeOpenAIResponsesResponse({
+      id: 'resp_reasoning',
+      model: 'gpt-5.4',
+      status: 'completed',
+      output: [
+        {
+          id: 'rs_1',
+          type: 'reasoning',
+          summary: [{ type: 'summary_text', text: 'Checked the weather.' }],
+          encrypted_content: 'encrypted-reasoning',
+          status: 'completed',
+        },
+        {
+          type: 'function_call',
+          call_id: 'call_weather',
+          name: 'weather',
+          arguments: '{"city":"Xiamen"}',
+        },
+      ],
+    })
+    const message = modelResponseToAgentMessage(response)
+    const payload = toOpenAIResponsesPayload({
+      id: 'openai',
+      type: 'openai',
+      requestStyle: 'openai-responses',
+      defaultModel: 'gpt-5.4',
+    }, {
+      messages: [message],
+    })
+
+    expect(message.reasoning).toEqual({
+      text: 'Checked the weather.',
+      native: {
+        format: 'openai-responses-items',
+        data: [expect.objectContaining({
+          id: 'rs_1',
+          type: 'reasoning',
+          encrypted_content: 'encrypted-reasoning',
+        })],
+      },
+    })
+    expect(payload.include).toEqual(['reasoning.encrypted_content'])
+    expect(payload.input).toEqual([
+      {
+        type: 'reasoning',
+        id: 'rs_1',
+        summary: [{ type: 'summary_text', text: 'Checked the weather.' }],
+        encrypted_content: 'encrypted-reasoning',
+        status: 'completed',
+      },
+      {
+        type: 'function_call',
+        call_id: 'call_weather',
+        name: 'weather',
+        arguments: '{"city":"Xiamen"}',
+      },
+    ])
+  })
+
+  it('only asks the official OpenAI Responses endpoint for encrypted reasoning', () => {
+    const request = {
+      messages: [{ role: 'user' as const, content: 'Hello' }],
+    }
+    const xaiPayload = toOpenAIResponsesPayload({
+      id: 'xai-oauth',
+      type: 'openai-compatible',
+      requestStyle: 'openai-responses',
+      baseUrl: 'https://api.x.ai/v1',
+      defaultModel: 'grok-code',
+    }, request)
+    const codexPayload = toOpenAIResponsesPayload({
+      id: 'openai-codex',
+      type: 'openai-compatible',
+      requestStyle: 'openai-responses',
+      baseUrl: 'https://chatgpt.com/backend-api/codex',
+      defaultModel: 'gpt-5-codex',
+    }, request)
+
+    expect(xaiPayload).not.toHaveProperty('include')
+    expect(codexPayload).not.toHaveProperty('include')
+  })
+
   it('omits invalid empty-name tool history from Responses replay', () => {
     const payload = toOpenAIResponsesPayload({
       id: 'custom:fun-codex',
@@ -853,6 +1178,139 @@ describe('ekko-agent model requests', () => {
       max_tokens: 4096,
       tools: [{ name: 'read_file', input_schema: { type: 'object' } }],
     })
+  })
+
+  it('replays signed Claude thinking blocks and never invents unsigned Claude blocks', () => {
+    const signedThinking = {
+      type: 'thinking' as const,
+      thinking: 'I should call the tool.',
+      signature: 'claude-signature',
+    }
+    const response = normalizeAnthropicResponse({
+      content: [
+        signedThinking,
+        {
+          type: 'tool_use',
+          id: 'call_weather',
+          name: 'weather',
+          input: { city: 'Xiamen' },
+        },
+      ],
+      stop_reason: 'tool_use',
+    })
+    const config: ModelProviderConfig = {
+      id: 'anthropic',
+      type: 'anthropic',
+      defaultModel: 'claude-sonnet-4-6',
+    }
+    const signedPayload = toAnthropicMessagesPayload(config, {
+      messages: [modelResponseToAgentMessage(response)],
+    })
+    const plainPayload = toAnthropicMessagesPayload(config, {
+      messages: [{
+        role: 'assistant',
+        content: 'Answer',
+        reasoning: { text: 'Unsigned internal summary.' },
+      }],
+    })
+
+    expect(signedPayload.messages[0]?.content).toEqual([
+      signedThinking,
+      {
+        type: 'tool_use',
+        id: 'call_weather',
+        name: 'weather',
+        input: { city: 'Xiamen' },
+      },
+    ])
+    expect(plainPayload.messages[0]?.content).toEqual([
+      { type: 'text', text: 'Answer' },
+    ])
+  })
+
+  it('converts unified reasoning text to unsigned thinking for non-Claude Anthropic-compatible models', () => {
+    const payload = toAnthropicMessagesPayload({
+      id: 'minimax-oauth',
+      type: 'anthropic',
+      requestStyle: 'anthropic-messages',
+      defaultModel: 'MiniMax-M3',
+    }, {
+      messages: [{
+        role: 'assistant',
+        content: '',
+        reasoning: {
+          text: 'I should call the tool.',
+          native: {
+            format: 'anthropic-thinking-blocks',
+            data: [{
+              type: 'thinking',
+              thinking: 'I should call the tool.',
+              signature: 'claude-only-signature',
+            }],
+          },
+        },
+        toolCalls: [{
+          id: 'call_weather',
+          name: 'weather',
+          arguments: { city: 'Xiamen' },
+        }],
+      }],
+    })
+
+    expect(payload.messages[0]?.content).toEqual([
+      { type: 'thinking', thinking: 'I should call the tool.' },
+      {
+        type: 'tool_use',
+        id: 'call_weather',
+        name: 'weather',
+        input: { city: 'Xiamen' },
+      },
+    ])
+  })
+
+  it('captures streamed Claude thinking signatures for the next request', async () => {
+    const encoder = new TextEncoder()
+    const fetchMock = vi.fn(async () => new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}\n\n'))
+        controller.enqueue(encoder.encode('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Use a tool."}}\n\n'))
+        controller.enqueue(encoder.encode('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"signed-thinking"}}\n\n'))
+        controller.enqueue(encoder.encode('event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n'))
+        controller.enqueue(encoder.encode('event: message_stop\ndata: {"type":"message_stop"}\n\n'))
+        controller.close()
+      },
+    }), { status: 200, headers: { 'Content-Type': 'text/event-stream' } }))
+    const config: ModelProviderConfig = {
+      id: 'anthropic',
+      type: 'anthropic',
+      apiKey: 'test-key',
+      defaultModel: 'claude-sonnet-4-6',
+    }
+    const client = new AnthropicMessagesModelClient(config, { fetch: fetchMock })
+
+    const streamed = await collectModelEvents(client.stream({
+      messages: [{ role: 'user', content: 'Think' }],
+    }))
+    const replay = toAnthropicMessagesPayload(config, {
+      messages: [streamed.message],
+    })
+
+    expect(streamed.message.reasoning).toEqual({
+      text: 'Use a tool.',
+      native: {
+        format: 'anthropic-thinking-blocks',
+        data: [{
+          type: 'thinking',
+          thinking: 'Use a tool.',
+          signature: 'signed-thinking',
+        }],
+      },
+    })
+    expect(replay.messages[0]?.content).toEqual([{
+      type: 'thinking',
+      thinking: 'Use a tool.',
+      signature: 'signed-thinking',
+    }])
   })
 
   it('calls Anthropic-compatible /anthropic bases through /v1/messages', async () => {
@@ -986,6 +1444,43 @@ describe('ekko-agent model requests', () => {
       generationConfig: { temperature: 0.1 },
       tools: [{ functionDeclarations: [{ name: 'lookup' }] }],
     })
+  })
+
+  it('replays Gemini thought signatures with their original content parts', () => {
+    const originalParts = [
+      { text: 'I should call the tool.', thought: true },
+      {
+        functionCall: { name: 'weather', args: { city: 'Xiamen' } },
+        thoughtSignature: 'gemini-signature',
+      },
+    ]
+    const response = normalizeGeminiResponse({
+      candidates: [{
+        content: { parts: originalParts },
+        finishReason: 'STOP',
+      }],
+    }, 'gemini-3-pro')
+    const message = modelResponseToAgentMessage(response)
+    const payload = toGeminiContentsPayload({
+      id: 'gemini',
+      type: 'gemini',
+      defaultModel: 'gemini-3-pro',
+    }, {
+      messages: [message],
+    })
+
+    expect(message.content).toBe('')
+    expect(message.reasoning).toEqual({
+      text: 'I should call the tool.',
+      native: {
+        format: 'gemini-content-parts',
+        data: originalParts,
+      },
+    })
+    expect(payload.contents).toEqual([{
+      role: 'model',
+      parts: originalParts,
+    }])
   })
 
   it('converts internal requests to prompt completion payloads', () => {

--- a/tests/ekko-agent/runtime.test.ts
+++ b/tests/ekko-agent/runtime.test.ts
@@ -141,6 +141,63 @@ describe('ekko-agent runtime', () => {
     expect(client.stream).not.toHaveBeenCalled()
   })
 
+  it('includes assistant reasoning in provider-visible context estimates', async () => {
+    const client = modelClient(() => ({ content: 'must not run' }))
+    const runtime = new AgentRuntime({
+      modelClient: client,
+      tools: new AgentToolRegistry(),
+      systemPrompt: '',
+    })
+    const withoutReasoning = await runtime.estimateContext({
+      messages: [
+        { role: 'assistant', content: 'Previous answer.' },
+        { role: 'user', content: 'Continue.' },
+      ],
+    })
+    const withReasoning = await runtime.estimateContext({
+      messages: [
+        {
+          role: 'assistant',
+          content: 'Previous answer.',
+          reasoning: { text: 'A long hidden reasoning trace that is replayed to the provider.' },
+        },
+        { role: 'user', content: 'Continue.' },
+      ],
+    })
+
+    expect(withReasoning.messageTokens).toBeGreaterThan(withoutReasoning.messageTokens)
+    expect(withReasoning.contextTokens - withoutReasoning.contextTokens)
+      .toBe(withReasoning.messageTokens - withoutReasoning.messageTokens)
+  })
+
+  it('uses one provider reasoning-token estimate instead of counting text and native metadata again', async () => {
+    const client = modelClient(() => ({ content: 'must not run' }))
+    const runtime = new AgentRuntime({
+      modelClient: client,
+      tools: new AgentToolRegistry(),
+      systemPrompt: '',
+    })
+    const base = await runtime.estimateContext({
+      messages: [{ role: 'assistant', content: 'Previous answer.' }],
+    })
+    const withReasoning = await runtime.estimateContext({
+      messages: [{
+        role: 'assistant',
+        content: 'Previous answer.',
+        reasoning: {
+          text: 'Visible summary that must not be counted a second time.',
+          estimatedTokens: 123,
+          native: {
+            format: 'openai-responses-items',
+            data: [{ type: 'reasoning', encrypted_content: 'opaque-native-data' }],
+          },
+        },
+      }],
+    })
+
+    expect(withReasoning.messageTokens - base.messageTokens).toBe(123)
+  })
+
   it('emits one model usage event for each completed non-streaming model call', async () => {
     const client = modelClient(() => ({
       content: 'hello',
@@ -215,7 +272,7 @@ describe('ekko-agent runtime', () => {
       },
     })
 
-    expect(result.output.reasoning).toBe('thinking path')
+    expect(result.output.reasoning).toEqual({ text: 'thinking path' })
     expect(reasoning).toEqual(['thinking path'])
     expect(events).toEqual(['run.started', 'model.started', 'context.estimated', 'model.reasoning', 'model.message', 'run.completed'])
   })

--- a/tests/server/run-chat-ekko-context.test.ts
+++ b/tests/server/run-chat-ekko-context.test.ts
@@ -1412,6 +1412,18 @@ describe('ekko-agent context usage events', () => {
         message: {
           role: 'assistant',
           content: '',
+          reasoning: {
+            text: 'I need to find the image skill.',
+            estimatedTokens: 29,
+            native: {
+              format: 'openai-reasoning-details',
+              data: [{
+                type: 'reasoning.text',
+                text: 'I need to find the image skill.',
+                signature: 'provider-signature',
+              }],
+            },
+          },
           toolCalls: [{
             id: 'call-search',
             name: 'skill_list',
@@ -1455,6 +1467,20 @@ describe('ekko-agent context usage events', () => {
           },
         }],
         finish_reason: 'tool_calls',
+        reasoning: 'I need to find the image skill.',
+        reasoning_content: 'I need to find the image skill.',
+        reasoning_details: JSON.stringify({
+          version: 1,
+          native: {
+            format: 'openai-reasoning-details',
+            data: [{
+              type: 'reasoning.text',
+              text: 'I need to find the image skill.',
+              signature: 'provider-signature',
+            }],
+          },
+          estimatedTokens: 29,
+        }),
       }),
       expect.objectContaining({
         role: 'tool',
@@ -1609,6 +1635,19 @@ describe('ekko-agent context usage events', () => {
         session_id: 'session-1',
         role: 'assistant',
         content: '',
+        reasoning_content: 'I need to inspect both tool results.',
+        reasoning_details: JSON.stringify({
+          version: 1,
+          estimatedTokens: 17,
+          native: {
+            format: 'openai-reasoning-details',
+            data: [{
+              type: 'reasoning.text',
+              text: 'I need to inspect both tool results.',
+              signature: 'provider-signature',
+            }],
+          },
+        }),
         tool_calls: [{
           id: 'call_weather',
           type: 'function',
@@ -1667,6 +1706,18 @@ describe('ekko-agent context usage events', () => {
       {
         role: 'assistant',
         content: '',
+        reasoning: {
+          text: 'I need to inspect both tool results.',
+          estimatedTokens: 17,
+          native: {
+            format: 'openai-reasoning-details',
+            data: [{
+              type: 'reasoning.text',
+              text: 'I need to inspect both tool results.',
+              signature: 'provider-signature',
+            }],
+          },
+        },
         toolCalls: [{
           id: 'call_weather',
           name: 'browser_navigate',

--- a/tests/server/run-chat-usage.test.ts
+++ b/tests/server/run-chat-usage.test.ts
@@ -53,6 +53,27 @@ describe('run-chat usage token estimates', () => {
     )
   })
 
+  it('uses one stored reasoning token estimate without double-counting aliases or native details', () => {
+    const messages = [{
+      role: 'assistant',
+      content: 'final answer',
+      reasoning: 'duplicate reasoning text',
+      reasoning_content: 'duplicate reasoning text',
+      reasoning_details: JSON.stringify({
+        version: 1,
+        estimatedTokens: 123,
+        native: {
+          format: 'openai-responses-items',
+          data: [{ type: 'reasoning', encrypted_content: 'opaque-data' }],
+        },
+      }),
+    }]
+
+    const usage = estimateUsageTokensFromMessages(messages)
+
+    expect(usage.outputTokens).toBe(countTokens('final answer') + 123)
+  })
+
   it('adds cached bridge fixed context when updating full context usage', () => {
     const emit = vi.fn()
     const state = {


### PR DESCRIPTION
## Summary

- introduce one canonical `AgentReasoning` structure for visible reasoning text, provider-native replay data, and reasoning token estimates
- preserve reasoning metadata through Ekko Agent persistence, history reconstruction, and context compression using the existing `reasoning_details` column
- convert canonical reasoning at each protocol boundary:
  - DeepSeek, Kimi, and MiMo use `reasoning_content`
  - generic OpenAI-compatible providers use `reasoning`
  - OpenRouter replays native `reasoning_details`
  - OpenAI Responses replays encrypted reasoning items
  - Claude replays signed/redacted thinking blocks, while non-Claude Anthropic-compatible models receive unsigned thinking
  - Gemini replays thought parts and thought signatures
- count reasoning tokens once, preferring provider estimates without counting aliases or opaque native metadata again

## Why

Ekko Agent history previously retained only plain reasoning text. That was insufficient for providers that require prior signed, encrypted, or structured reasoning data during tool loops, so follow-up requests could lose required protocol state. Reasoning was also missing from parts of context estimation and could be represented through duplicate aliases.

This change keeps one internal representation and moves provider-specific conversion into the adapters, so stored history can be replayed correctly without adding a database field.

## Impact

Tool loops can continue with the reasoning state required by each provider. Existing history remains compatible, and new Ekko Agent messages persist native reasoning metadata in the existing schema.

## Validation

- `npm test -- --run tests/ekko-agent/messages.test.ts tests/ekko-agent/model-request.test.ts tests/ekko-agent/runtime.test.ts tests/server/run-chat-ekko-context.test.ts tests/server/run-chat-usage.test.ts tests/server/run-chat-compression.test.ts` (142 tests)
- `npm exec -- tsc --noEmit -p packages/ekko-agent/tsconfig.json`
- `npm exec -- tsc --noEmit -p packages/server/tsconfig.json`
- `git diff --cached --check`
