### PR TITLE
fix: require coding-agent execution identity

### DIFF
--- a/packages/server/src/controllers/chat-run.ts
+++ b/packages/server/src/controllers/chat-run.ts
@@ -2,6 +2,7 @@ import type { Context } from 'koa'
 import { randomUUID } from 'crypto'
 import { io, type Socket } from 'socket.io-client'
 import { config } from '../config'
+import { resolveModelExecutionIdentity } from '../services/model-execution-identity'
 
 type ChatRunPayload = Record<string, unknown> & {
   input?: unknown
@@ -103,6 +104,29 @@ export async function runOnce(ctx: Context) {
   const token = bearerToken(ctx)
   const profile = profileFrom(ctx, body)
   const payload: Record<string, unknown> = { ...userBody(body), profile }
+  const isCodingAgentRun = body.source === 'coding_agent' || body.coding_agent_id != null || body.agent_id != null
+  if (isCodingAgentRun) {
+    try {
+      const identity = await resolveModelExecutionIdentity({
+        profile,
+        provider: body.provider,
+        model: body.model,
+        apiMode: body.apiMode ?? body.api_mode,
+      })
+      payload.provider = identity.provider
+      payload.model = identity.model
+      payload.apiMode = identity.apiMode
+      delete payload.api_mode
+      delete payload.apiKey
+      delete payload.api_key
+      delete payload.baseUrl
+      delete payload.base_url
+    } catch (error: any) {
+      ctx.status = Number(error?.status) || 400
+      ctx.body = { ok: false, error: error?.message || 'Invalid execution identity' }
+      return
+    }
+  }
   if (needsGeneratedSessionId(payload)) payload.session_id = generatedSessionId()
 
   ctx.body = await new Promise((resolve) => {

--- a/packages/server/src/services/model-execution-identity.ts
+++ b/packages/server/src/services/model-execution-identity.ts
@@ -1,0 +1,47 @@
+export type ExecutionApiMode = 'chat_completions' | 'codex_responses' | 'anthropic_messages'
+
+export interface ModelExecutionIdentity {
+  provider: string
+  model: string
+  apiMode: ExecutionApiMode
+}
+
+const API_MODES = new Set<ExecutionApiMode>([
+  'chat_completions',
+  'codex_responses',
+  'anthropic_messages',
+])
+
+const CORRECT_REQUEST = '{"provider":"custom:your-provider","model":"your-model","apiMode":"codex_responses"}'
+
+function badRequest(message: string): Error {
+  const error = new Error(message)
+  ;(error as any).status = 400
+  return error
+}
+
+export async function resolveModelExecutionIdentity(input: {
+  profile: string
+  provider?: unknown
+  model?: unknown
+  apiMode?: unknown
+}): Promise<ModelExecutionIdentity> {
+  const provider = String(input.provider || '').trim()
+  const model = String(input.model || '').trim()
+  const apiMode = String(input.apiMode || '').trim()
+
+  if (!provider || !model || !apiMode) {
+    throw badRequest(
+      `provider, model, and apiMode are required together for coding-agent runs; ` +
+      `Profile defaults are not used. Correct request fields: ${CORRECT_REQUEST}`,
+    )
+  }
+  if (!API_MODES.has(apiMode as ExecutionApiMode)) {
+    throw badRequest(
+      `Unsupported apiMode "${apiMode}". Allowed values: chat_completions, codex_responses, ` +
+      `anthropic_messages. For OpenAI Responses use "apiMode":"codex_responses".`,
+    )
+  }
+
+  return { provider, model, apiMode: apiMode as ExecutionApiMode }
+}

--- a/tests/server/chat-run-api-controller.test.ts
+++ b/tests/server/chat-run-api-controller.test.ts
@@ -7,6 +7,7 @@ vi.mock('socket.io-client', () => ({
   io: ioMock,
 }))
 
+
 function makeSocket() {
   const emitter = new EventEmitter() as EventEmitter & {
     emit: ReturnType<typeof vi.fn>
@@ -32,6 +33,133 @@ function makeSocket() {
 describe('chat-run HTTP API controller', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it('rejects a coding-agent run without an explicit execution identity and explains the correct request', async () => {
+    const socket = makeSocket()
+    ioMock.mockReturnValue(socket)
+
+    const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
+    const ctx = {
+      get: vi.fn(() => ''),
+      state: { profile: { name: 'default' } },
+      request: {
+        body: {
+          input: 'continue work',
+          source: 'coding_agent',
+          coding_agent_id: 'codex',
+          mode: 'scoped',
+        },
+      },
+      status: 200,
+      body: undefined as any,
+    }
+
+    await runOnce(ctx as any)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('provider, model, and apiMode are required'),
+    })
+    expect(ctx.body.error).toContain('"apiMode":"codex_responses"')
+    expect(socket.emit).not.toHaveBeenCalledWith('run', expect.anything())
+  })
+
+  it.each([
+    { provider: 'custom:corp-codex' },
+    { model: 'gpt-5.6-terra' },
+    { apiMode: 'codex_responses' },
+    { provider: 'custom:corp-codex', model: 'gpt-5.6-terra' },
+    { provider: 'custom:corp-codex', apiMode: 'codex_responses' },
+    { model: 'gpt-5.6-terra', apiMode: 'codex_responses' },
+  ])('rejects a partial execution identity before starting a run: %j', async (identity) => {
+    const socket = makeSocket()
+    ioMock.mockReturnValue(socket)
+
+    const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
+    const ctx = {
+      get: vi.fn(() => ''),
+      state: { profile: { name: 'default' } },
+      request: { body: { input: 'continue work', source: 'coding_agent', ...identity } },
+      status: 200,
+      body: undefined as any,
+    }
+
+    await runOnce(ctx as any)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('provider, model, and apiMode are required'),
+    })
+    expect(ctx.body.error).toContain('"apiMode":"codex_responses"')
+    expect(socket.emit).not.toHaveBeenCalledWith('run', expect.anything())
+  })
+
+  it('rejects an unsupported API mode and names the OpenAI Responses value', async () => {
+    const socket = makeSocket()
+    ioMock.mockReturnValue(socket)
+
+    const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
+    const ctx = {
+      get: vi.fn(() => ''),
+      state: { profile: { name: 'default' } },
+      request: { body: {
+        input: 'continue work',
+        source: 'coding_agent',
+        provider: 'custom:explicit',
+        model: 'explicit-model',
+        apiMode: 'openai_responses',
+      } },
+      status: 200,
+      body: undefined as any,
+    }
+
+    await runOnce(ctx as any)
+
+    expect(ctx.status).toBe(400)
+    expect(ctx.body).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('For OpenAI Responses use "apiMode":"codex_responses"'),
+    })
+    expect(socket.emit).not.toHaveBeenCalledWith('run', expect.anything())
+  })
+
+  it('preserves a complete explicit execution identity without reading Profile defaults', async () => {
+    const socket = makeSocket()
+    ioMock.mockReturnValue(socket)
+
+    const { runOnce } = await import('../../packages/server/src/controllers/chat-run')
+    const ctx = {
+      get: vi.fn(() => ''),
+      state: { profile: { name: 'default' } },
+      request: { body: {
+        input: 'continue work',
+        source: 'coding_agent',
+        provider: 'custom:explicit',
+        model: 'explicit-model',
+        apiMode: 'anthropic_messages',
+        apiKey: 'must-not-leave-http-boundary',
+        baseUrl: 'https://must-not-leave.example/v1',
+      } },
+      status: 200,
+      body: undefined as any,
+    }
+
+    const pending = runOnce(ctx as any)
+    await new Promise(resolve => setImmediate(resolve))
+    socket.emitNative('connect')
+    await pending
+
+    expect(socket.emit).toHaveBeenCalledWith('run', expect.objectContaining({
+      provider: 'custom:explicit',
+      model: 'explicit-model',
+      apiMode: 'anthropic_messages',
+    }))
+    const emittedPayload = socket.emit.mock.calls.find(call => call[0] === 'run')?.[1]
+    expect(emittedPayload).not.toHaveProperty('apiKey')
+    expect(emittedPayload).not.toHaveProperty('baseUrl')
   })
 
   it('runs chat-run through Socket.IO and returns a completed HTTP response', async () => {

--- a/tests/server/coding-agent-resume-config.test.ts
+++ b/tests/server/coding-agent-resume-config.test.ts
@@ -381,4 +381,40 @@ describe('coding agent resumed session config', () => {
     expect(startRunMock).toHaveBeenCalled()
     expect(home).toBeTruthy()
   })
+
+  it('resolves Profile credentials for a new session from an explicit execution identity', async () => {
+    makeHome()
+    getSessionMock.mockReturnValue(null)
+    readConfigYamlForProfileMock.mockResolvedValue({
+      custom_providers: [{
+        name: 'corp-codex',
+        base_url: 'https://provider.example/v1',
+        api_key: 'test-only',
+        model: 'gpt-5.6-terra',
+        api_mode: 'codex_responses',
+      }],
+    })
+    safeReadFileMock.mockResolvedValue('')
+
+    const { startCodingAgentRun } = await import('../../packages/server/src/services/coding-agents')
+    await expect(startCodingAgentRun('codex', {
+      sessionId: 'new-session',
+      mode: 'scoped',
+      profile: 'default',
+      provider: 'custom:corp-codex',
+      model: 'gpt-5.6-terra',
+      apiMode: 'codex_responses',
+    })).resolves.toEqual(expect.objectContaining({
+      provider: 'custom:corp-codex',
+      model: 'gpt-5.6-terra',
+      apiMode: 'codex_responses',
+    }))
+
+    expect(startRunMock).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'new-session',
+      provider: 'custom:corp-codex',
+      model: 'gpt-5.6-terra',
+      apiMode: 'codex_responses',
+    }))
+  })
 })


### PR DESCRIPTION
## Summary

- require `provider`, `model`, and `apiMode` together for HTTP Coding Agent runs
- reject absent, partial, or unsupported execution identities before Socket dispatch
- show the correct OpenAI Responses request value (`apiMode: codex_responses`)
- strip caller-supplied `apiKey` and `baseUrl`; credentials remain server-resolved

## Why

A fresh scoped Coding Agent run could omit its execution identity. Selecting the Profile default would let an unrelated or weaker default model control Codex work, while a missing protocol could reach lower layers that default proxy targets to `chat_completions`.

This change deliberately does **not** inherit the Profile default model. Callers must state the intended Coding Agent execution identity explicitly.

## Protocol note

Codex itself uses the local Responses wire API. When the selected target has `apiMode=codex_responses`, the Codex proxy sends upstream requests to `/responses`. Concurrent ordinary Hermes Agent calls may still use the Profile provider's independently configured `chat_completions` protocol; those are separate model calls, not a Codex protocol downgrade.

## Tests

- RED: missing tuple continued into the old Profile-default path; partial tuples returned obsolete guidance
- GREEN: absent and all six partial combinations return HTTP 400 with a correct request example
- unsupported API mode explains that OpenAI Responses maps to `codex_responses`
- complete explicit identity is preserved
- `apiKey` and `baseUrl` are removed before Socket dispatch
- new-session Coding Agent credentials are still resolved server-side from Profile/provider
- non-Coding-Agent Chat Runs remain unchanged

Verification:

- `npx vitest run tests/server/chat-run-api-controller.test.ts tests/server/chat-run-baseline.test.ts tests/server/chat-run-bridge-readiness.test.ts tests/server/coding-agent-resume-config.test.ts` — 44/44 PASS
- `npm run harness:check` — PASS
- `npx tsc --noEmit -p packages/server/tsconfig.json` — PASS
- `node scripts/build-server.mjs` — PASS
- `npx vitest run tests/server/coding-agents-launch.test.ts -t 'preserves native Responses usage for Codex Responses providers'` — PASS
- exact 4-file scope; secret/private-host scan — PASS

Fixes #2394
