### PR TITLE
test: isolate Windows run-manager persistence

### DIFF
--- a/tests/server/coding-agent-run-manager-windows.test.ts
+++ b/tests/server/coding-agent-run-manager-windows.test.ts
@@ -45,6 +45,11 @@ vi.mock('child_process', () => ({
   }),
 }))
 
+vi.mock('../../packages/server/src/db/hermes/session-store', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../packages/server/src/db/hermes/session-store')>(),
+  updateSessionStats: vi.fn(),
+}))
+
 import { CodingAgentRunManager } from '../../packages/server/src/services/agent-runner/coding-agent-run-manager'
 
 const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')


### PR DESCRIPTION
## Summary

- isolate the Windows coding-agent run-manager unit tests from shared SQLite state
- partially mock `session-store` so only `updateSessionStats` is replaced
- keep production persistence behavior unchanged

## Root cause

The test already stubs instance persistence methods such as `ensureDbSession`, but terminal events call the imported module-level `updateSessionStats()` directly. With a fresh `HERMES_WEB_UI_TEST_DB_DIR`, the two terminal-error tests deterministically failed with `no such table: sessions`; they only passed when another test had initialized the shared test database first.

## Verification

- RED with fresh DB before fix: 7/9 tests passed; 2 failed with `no such table: sessions`
- GREEN with fresh DB after fix: 9/9 passed
- full coverage in clean container: 429/429 test files; 3475 passed, 5 skipped
- `npm run harness:check`: passed
- production build: passed

Fixes #2397
