### PR TITLE
feat: add durable global notification center

### DIFF
--- a/docs/chat-chain-changes/2400-durable-global-notifications.md
+++ b/docs/chat-chain-changes/2400-durable-global-notifications.md
@@ -1,0 +1,23 @@
+# Durable global notifications
+
+- issue: #2400
+- pr: pending
+
+## Scope
+
+Hermes Studio now persists and delivers owner/profile-scoped in-app notifications for:
+
+- direct chat completion, failure, tool approval, and clarification;
+- group chat agent replies and group tool approval;
+- workflow completion, failure, and node approval;
+- reconciled Cron completion and failure metadata.
+
+Approval and clarification notifications are marked read when their authoritative interaction resolves. Existing OS completion notifications remain available.
+
+## Data and security boundaries
+
+- SQLite records are scoped by authenticated owner and resolved Profile.
+- The server ignores client-supplied owner/Profile values.
+- Socket.IO delivery uses owner + Profile rooms.
+- Dedupe keys prevent HTTP, Socket replay, reconnect, and polling duplicates.
+- Notification deep links reuse existing router and API authorization boundaries.

--- a/docs/chat-chain-changes/2400-durable-global-notifications.md
+++ b/docs/chat-chain-changes/2400-durable-global-notifications.md
@@ -1,9 +1,9 @@
-# Durable global notifications
-
-- issue: #2400
-- pr: #2402
-
-## Scope
+---
+date: 2026-08-07
+pr: 2402
+feature: Durable global notification center
+impact: Direct Chat, Group Chat, Workflow, and Cron events now share one owner/profile-scoped persistent notification center, including authorization requests and durable read state.
+---
 
 Hermes Studio now persists and delivers owner/profile-scoped in-app notifications for:
 

--- a/docs/chat-chain-changes/2400-durable-global-notifications.md
+++ b/docs/chat-chain-changes/2400-durable-global-notifications.md
@@ -1,7 +1,7 @@
 # Durable global notifications
 
 - issue: #2400
-- pr: pending
+- pr: #2402
 
 ## Scope
 

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -17,6 +17,7 @@ const DesktopTitleBar = defineAsyncComponent(async () => (await import('@/compon
 const SessionSearchModal = defineAsyncComponent(async () => (await import('@/components/hermes/chat/SessionSearchModal.vue')).default)
 const DefaultCredentialPrompt = defineAsyncComponent(async () => (await import('@/components/auth/DefaultCredentialPrompt.vue')).default)
 const ProviderConfigurationPrompt = defineAsyncComponent(async () => (await import('@/components/hermes/models/ProviderConfigurationPrompt.vue')).default)
+const NotificationCenter = defineAsyncComponent(async () => (await import('@/components/layout/NotificationCenter.vue')).default)
 const WebPet = defineAsyncComponent(async () => (await import('@/components/hermes/pets/WebPet.vue')).default)
 
 const {
@@ -147,6 +148,7 @@ useKeyboard()
               </main>
             </div>
           </div>
+          <NotificationCenter v-if="!isLoginPage && !isDesktopPetRoute && !isStandaloneChatPage" />
           <WebPet v-if="showWebPet" />
           <SessionSearchModal v-if="!isDesktopPetRoute && !isStandaloneChatPage && sessionSearchOpen" />
           <DefaultCredentialPrompt v-if="!isDesktopPetRoute && !isStandaloneChatPage" />

--- a/packages/client/src/api/hermes/notification-socket.ts
+++ b/packages/client/src/api/hermes/notification-socket.ts
@@ -1,0 +1,32 @@
+import { io, type Socket } from 'socket.io-client'
+import { getActiveProfileName, getApiKey, getBaseUrlValue } from '../client'
+import type { NotificationRecord } from './notifications'
+
+let socket: Socket | null = null
+let profile: string | null = null
+
+export function connectNotificationSocket(): Socket {
+  const activeProfile = getActiveProfileName() || 'default'
+  if (socket && profile === activeProfile) return socket
+  socket?.disconnect()
+  profile = activeProfile
+  socket = io(`${getBaseUrlValue()}/notifications`, {
+    auth: { token: getApiKey() },
+    query: { profile: activeProfile },
+    transports: ['websocket', 'polling'],
+    reconnection: true,
+  })
+  return socket
+}
+
+export function onNotificationCreated(handler: (notification: NotificationRecord) => void): () => void {
+  const active = connectNotificationSocket()
+  active.on('notification.created', handler)
+  return () => active.off('notification.created', handler)
+}
+
+export function disconnectNotificationSocket() {
+  socket?.disconnect()
+  socket = null
+  profile = null
+}

--- a/packages/client/src/api/hermes/notifications.ts
+++ b/packages/client/src/api/hermes/notifications.ts
@@ -1,0 +1,81 @@
+import { request } from '../client'
+
+export type NotificationSeverity = 'info' | 'success' | 'warning' | 'error'
+export type NotificationType =
+  | 'chat.completed' | 'chat.failed'
+  | 'group_chat.completed' | 'group_chat.failed'
+  | 'workflow.completed' | 'workflow.failed' | 'workflow.approval'
+  | 'cron.completed' | 'cron.failed'
+  | 'approval.requested' | 'clarify.requested'
+
+export interface NotificationSource {
+  kind: 'session' | 'room' | 'workflow' | 'cron' | 'system'
+  id: string
+  runId?: string
+  route?: { name: string; params?: Record<string, string>; query?: Record<string, string> }
+}
+
+export interface NotificationRecord {
+  id: string
+  ownerId: number
+  profile: string
+  dedupeKey: string
+  type: NotificationType
+  severity: NotificationSeverity
+  title: string
+  body: string
+  source: NotificationSource
+  unread: boolean
+  readAt: number | null
+  createdAt: number
+  updatedAt: number
+}
+
+export interface NotificationEvent {
+  dedupeKey: string
+  type: NotificationType
+  severity: NotificationSeverity
+  title: string
+  body: string
+  source: NotificationSource
+}
+
+export function fetchNotifications(options: { limit?: number; unreadOnly?: boolean } = {}) {
+  const params = new URLSearchParams()
+  if (options.limit) params.set('limit', String(options.limit))
+  if (options.unreadOnly) params.set('unread', 'true')
+  const query = params.toString()
+  return request<{ notifications: NotificationRecord[]; unreadCount: number }>(
+    `/api/hermes/notifications${query ? `?${query}` : ''}`,
+  )
+}
+
+export async function createNotificationEvent(event: NotificationEvent) {
+  const result = await request<{ created: boolean; notification: NotificationRecord }>('/api/hermes/notifications', {
+    method: 'POST',
+    body: JSON.stringify(event),
+  })
+  if (result.created && typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('hermes:notification-created', { detail: result.notification }))
+  }
+  return result
+}
+
+export function markNotificationRead(id: string) {
+  return request<{ notification: NotificationRecord }>(`/api/hermes/notifications/${encodeURIComponent(id)}/read`, { method: 'POST' })
+}
+
+export function markNotificationReadByDedupeKey(dedupeKey: string) {
+  return request<{ updated: boolean }>('/api/hermes/notifications/read-by-key', {
+    method: 'POST',
+    body: JSON.stringify({ dedupeKey }),
+  })
+}
+
+export function markAllNotificationsRead() {
+  return request<{ updated: number }>('/api/hermes/notifications/read-all', { method: 'POST' })
+}
+
+export function deleteNotification(id: string) {
+  return request<{ deleted: boolean }>(`/api/hermes/notifications/${encodeURIComponent(id)}`, { method: 'DELETE' })
+}

--- a/packages/client/src/components/layout/NotificationCenter.vue
+++ b/packages/client/src/components/layout/NotificationCenter.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+import { computed, h, onMounted, onUnmounted, ref, watch } from 'vue'
+import { NButton, NSpin, useNotification } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import { useProfilesStore } from '@/stores/hermes/profiles'
+import { disconnectNotificationSocket, onNotificationCreated } from '@/api/hermes/notification-socket'
+import {
+  deleteNotification,
+  fetchNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+  type NotificationRecord,
+} from '@/api/hermes/notifications'
+
+const { t } = useI18n()
+const router = useRouter()
+const profilesStore = useProfilesStore()
+const toast = useNotification()
+const open = ref(false)
+const loading = ref(false)
+const error = ref('')
+const notifications = ref<NotificationRecord[]>([])
+const unreadCount = ref(0)
+const loaded = ref(false)
+const badge = computed(() => unreadCount.value > 99 ? '99+' : String(unreadCount.value || ''))
+
+async function load() {
+  loading.value = true
+  error.value = ''
+  try {
+    const result = await fetchNotifications({ limit: 50 })
+    if (loaded.value) {
+      const existingIds = new Set(notifications.value.map(item => item.id))
+      for (const item of [...result.notifications].reverse()) {
+        if (!existingIds.has(item.id)) handleCreated(new CustomEvent('hermes:notification-created', { detail: item }))
+      }
+      notifications.value = result.notifications
+    } else {
+      notifications.value = result.notifications
+    }
+    unreadCount.value = result.unreadCount
+    loaded.value = true
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+function toggle() {
+  open.value = !open.value
+  if (open.value && !loaded.value && !loading.value && !error.value) void load()
+}
+
+async function openNotification(item: NotificationRecord) {
+  if (item.unread) {
+    await markNotificationRead(item.id)
+    item.unread = false
+    unreadCount.value = Math.max(0, unreadCount.value - 1)
+  }
+  if (item.source.route) await router.push(item.source.route)
+}
+
+async function readAll() {
+  await markAllNotificationsRead()
+  notifications.value = notifications.value.map(item => ({ ...item, unread: false }))
+  unreadCount.value = 0
+}
+
+async function remove(item: NotificationRecord, event: Event) {
+  event.stopPropagation()
+  await deleteNotification(item.id)
+  notifications.value = notifications.value.filter(candidate => candidate.id !== item.id)
+  if (item.unread) unreadCount.value = Math.max(0, unreadCount.value - 1)
+}
+
+function relativeTime(timestamp: number): string {
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000))
+  if (seconds < 60) return t('notifications.justNow')
+  if (seconds < 3600) return t('notifications.minutesAgo', { count: Math.floor(seconds / 60) })
+  if (seconds < 86400) return t('notifications.hoursAgo', { count: Math.floor(seconds / 3600) })
+  return new Date(timestamp).toLocaleString()
+}
+
+function showToast(item: NotificationRecord) {
+  const n = toast.create({
+    title: item.title,
+    content: item.body,
+    meta: relativeTime(item.createdAt),
+    type: item.severity,
+    duration: item.severity === 'warning' || item.severity === 'error' ? 0 : 8000,
+    action: item.source.route ? () => h(NButton, {
+      text: true,
+      type: 'primary',
+      onClick: () => { void openNotification(item); n.destroy() },
+    }, { default: () => t('notifications.view') }) : undefined,
+  })
+}
+
+function handleCreated(event: Event) {
+  const item = (event as CustomEvent<NotificationRecord>).detail
+  if (!item || notifications.value.some(existing => existing.id === item.id)) return
+  notifications.value = [item, ...notifications.value]
+  if (item.unread) unreadCount.value += 1
+  showToast(item)
+}
+
+let removeSocketListener: (() => void) | null = null
+let refreshTimer: number | null = null
+function subscribeSocket() {
+  removeSocketListener?.()
+  disconnectNotificationSocket()
+  removeSocketListener = onNotificationCreated(item => handleCreated(new CustomEvent('hermes:notification-created', { detail: item })))
+}
+
+watch(() => profilesStore.activeProfileName, (next, previous) => {
+  if (!previous || next === previous) return
+  notifications.value = []
+  unreadCount.value = 0
+  loaded.value = false
+  error.value = ''
+  subscribeSocket()
+  void load()
+})
+
+onMounted(() => {
+  window.addEventListener('hermes:notification-created', handleCreated)
+  subscribeSocket()
+  refreshTimer = window.setInterval(() => void load(), 30000)
+  void load()
+})
+onUnmounted(() => {
+  window.removeEventListener('hermes:notification-created', handleCreated)
+  if (refreshTimer !== null) window.clearInterval(refreshTimer)
+  removeSocketListener?.()
+  disconnectNotificationSocket()
+})
+</script>
+
+<template>
+  <div class="notification-center">
+    <button data-testid="notification-bell" class="notification-bell" :aria-label="t('notifications.title')" @click="toggle">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 8a6 6 0 0 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9M10 21h4" /></svg>
+      <span v-if="badge" class="notification-badge">{{ badge }}</span>
+    </button>
+    <div v-if="open" class="notification-panel" role="dialog" :aria-label="t('notifications.title')">
+      <header>
+        <strong>{{ t('notifications.title') }}</strong>
+        <NButton data-testid="notification-read-all" text :disabled="unreadCount === 0" @click="readAll">{{ t('notifications.readAll') }}</NButton>
+      </header>
+      <NSpin v-if="loading" size="small" />
+      <div v-else-if="error" class="notification-state">
+        <span>{{ t('notifications.loadFailed') }}</span>
+        <NButton data-testid="notification-retry" size="small" @click="load">{{ t('common.retry') }}</NButton>
+      </div>
+      <div v-else-if="notifications.length === 0" class="notification-state">{{ t('notifications.empty') }}</div>
+      <div v-else class="notification-list">
+        <div v-for="item in notifications" :key="item.id" :data-testid="`notification-item-${item.id}`" class="notification-item" :class="{ unread: item.unread }" role="button" tabindex="0" @click="openNotification(item)" @keydown.enter="openNotification(item)">
+          <span class="severity" :class="item.severity" />
+          <span class="content"><strong>{{ item.title }}</strong><span>{{ item.body }}</span><small>{{ relativeTime(item.createdAt) }}</small></span>
+          <button :data-testid="`notification-delete-${item.id}`" class="delete" :aria-label="t('notifications.delete')" @click="remove(item, $event)">×</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/variables' as *;
+.notification-center { position: fixed; top: 14px; inset-inline-end: 18px; z-index: 2500; }
+.notification-bell { position: relative; width: 36px; height: 36px; display: grid; place-items: center; border: 1px solid $border-color; border-radius: 10px; color: $text-secondary; background: $bg-card; cursor: pointer; }
+.notification-bell svg { width: 18px; fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+.notification-badge { position: absolute; top: -6px; inset-inline-end: -6px; min-width: 18px; height: 18px; padding: 0 4px; display: grid; place-items: center; border-radius: 9px; background: #ef4444; color: #fff; font-size: 10px; font-weight: 700; }
+.notification-panel { position: absolute; top: 44px; inset-inline-end: 0; width: min(390px, calc(100vw - 28px)); max-height: min(620px, calc(100vh - 80px)); overflow: hidden; border: 1px solid $border-color; border-radius: 14px; background: $bg-card; box-shadow: 0 20px 50px rgba(0,0,0,.2); }
+.notification-panel header { display: flex; align-items: center; justify-content: space-between; padding: 14px 16px; border-bottom: 1px solid $border-color; }
+.notification-list { max-height: 520px; overflow: auto; }
+.notification-item { width: 100%; display: flex; gap: 10px; align-items: flex-start; padding: 13px 14px; border: 0; border-bottom: 1px solid $border-color; background: transparent; color: $text-primary; text-align: start; cursor: pointer; }
+.notification-item.unread { background: rgba(37, 99, 235, .07); }
+.notification-item:hover { background: $bg-card-hover; }
+.severity { flex: 0 0 auto; width: 8px; height: 8px; margin-top: 6px; border-radius: 50%; background: #64748b; }
+.severity.success { background: #16a34a; } .severity.warning { background: #d97706; } .severity.error { background: #dc2626; }
+.content { min-width: 0; flex: 1; display: grid; gap: 4px; }
+.content strong, .content span { overflow: hidden; text-overflow: ellipsis; }
+.content span { color: $text-secondary; font-size: 12px; white-space: nowrap; }
+.content small { color: $text-muted; }
+.delete { flex: 0 0 auto; border: 0; background: transparent; color: $text-muted; font-size: 18px; cursor: pointer; }
+.notification-state { min-height: 120px; display: flex; gap: 12px; align-items: center; justify-content: center; color: $text-secondary; }
+@media (max-width: 768px) { .notification-center { top: 12px; inset-inline-end: 12px; } }
+</style>

--- a/packages/client/src/i18n/locales/ar.ts
+++ b/packages/client/src/i18n/locales/ar.ts
@@ -1,4 +1,5 @@
 export default {
+  notifications: { title: 'Notifications', readAll: 'Mark all read', empty: 'No notifications', loadFailed: 'Failed to load notifications', delete: 'Delete notification', view: 'View details', justNow: 'Just now', minutesAgo: '{count} minutes ago', hoursAgo: '{count} hours ago' },
   browser: {
     title: 'المتصفح', settings: 'إعدادات المتصفح', desktopOnly: 'المتصفح المدمج متوفر فقط في Hermes Studio Desktop.', newTab: 'تبويب جديد',
     back: 'رجوع', forward: 'تقدّم', reload: 'إعادة تحميل', stop: 'إيقاف', addressPlaceholder: 'ابحث أو أدخل عنوانًا',

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -1,4 +1,5 @@
 export default {
+  notifications: { title: 'Notifications', readAll: 'Mark all read', empty: 'No notifications', loadFailed: 'Failed to load notifications', delete: 'Delete notification', view: 'View details', justNow: 'Just now', minutesAgo: '{count} minutes ago', hoursAgo: '{count} hours ago' },
   browser: {
     title: 'Browser', settings: 'Browser-Einstellungen', desktopOnly: 'Der integrierte Browser ist nur in Hermes Studio Desktop verfügbar.', newTab: 'Neuer Tab',
     back: 'Zurück', forward: 'Vor', reload: 'Neu laden', stop: 'Stopp', addressPlaceholder: 'Suchen oder Adresse eingeben',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -1,4 +1,5 @@
 export default {
+  notifications: { title: 'Notifications', readAll: 'Mark all read', empty: 'No notifications', loadFailed: 'Failed to load notifications', delete: 'Delete notification', view: 'View details', justNow: 'Just now', minutesAgo: '{count} minutes ago', hoursAgo: '{count} hours ago' },
   browser: {
     title: 'Browser', settings: 'Browser Settings', desktopOnly: 'The embedded browser is available only in Hermes Studio Desktop.', newTab: 'New Tab',
     back: 'Back', forward: 'Forward', reload: 'Reload', stop: 'Stop', addressPlaceholder: 'Search or enter an address',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -1,4 +1,5 @@
 export default {
+  notifications: { title: 'Notifications', readAll: 'Mark all read', empty: 'No notifications', loadFailed: 'Failed to load notifications', delete: 'Delete notification', view: 'View details', justNow: 'Just now', minutesAgo: '{count} minutes ago', hoursAgo: '{count} hours ago' },
   browser: {
     title: 'Navegador', settings: 'Ajustes del navegador', desktopOnly: 'El navegador integrado solo está disponible en Hermes Studio Desktop.', newTab: 'Nueva pestaña',
     back: 'Atrás', forward: 'Adelante', reload: 'Recargar', stop: 'Detener', addressPlaceholder: 'Buscar o escribir una dirección',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -1,4 +1,5 @@
 export default {
+  notifications: { title: 'Notifications', readAll: 'Mark all read', empty: 'No notifications', loadFailed: 'Failed to load notifications', delete: 'Delete notification', view: 'View details', justNow: 'Just now', minutesAgo: '{count} minutes ago', hoursAgo: '{count} hours ago' },
   browser: {
     title: 'Navigateur', settings: 'Paramètres du navigateur', desktopOnly: 'Le navigateur intégré est disponible uniquement dans Hermes Studio Desktop.', newTab: 'Nouvel onglet',
     back: 'Précédent', forward: 'Suivant', reload: 'Actualiser', stop: 'Arrêter', addressPlaceholder: 'Rechercher ou saisir une adresse',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -1,4 +1,5 @@
 export default {
+  notifications: { title: 'Notifications', readAll: 'Mark all read', empty: 'No notifications', loadFailed: 'Failed to load notifications', delete: 'Delete notification', view: 'View details', justNow: 'Just now', minutesAgo: '{count} minutes ago', hoursAgo: '{count} hours ago' },
   browser: {
     title: 'ブラウザー', settings: 'ブラウザー設定', desktopOnly: '内蔵ブラウザーは Hermes Studio Desktop でのみ利用できます。', newTab: '新しいタブ',
     back: '戻る', forward: '進む', reload: '再読み込み', stop: '停止', addressPlaceholder: '検索またはアドレスを入力',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -1,4 +1,5 @@
 export default {
+  notifications: { title: 'Notifications', readAll: 'Mark all read', empty: 'No notifications', loadFailed: 'Failed to load notifications', delete: 'Delete notification', view: 'View details', justNow: 'Just now', minutesAgo: '{count} minutes ago', hoursAgo: '{count} hours ago' },
   browser: {
     title: '브라우저', settings: '브라우저 설정', desktopOnly: '내장 브라우저는 Hermes Studio Desktop에서만 사용할 수 있습니다.', newTab: '새 탭',
     back: '뒤로', forward: '앞으로', reload: '새로고침', stop: '중지', addressPlaceholder: '검색 또는 주소 입력',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -1,4 +1,5 @@
 export default {
+  notifications: { title: 'Notifications', readAll: 'Mark all read', empty: 'No notifications', loadFailed: 'Failed to load notifications', delete: 'Delete notification', view: 'View details', justNow: 'Just now', minutesAgo: '{count} minutes ago', hoursAgo: '{count} hours ago' },
   browser: {
     title: 'Navegador', settings: 'Configurações do navegador', desktopOnly: 'O navegador integrado está disponível apenas no Hermes Studio Desktop.', newTab: 'Nova aba',
     back: 'Voltar', forward: 'Avançar', reload: 'Recarregar', stop: 'Parar', addressPlaceholder: 'Pesquisar ou inserir endereço',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -1,4 +1,5 @@
 export default {
+  notifications: { title: 'Notifications', readAll: 'Mark all read', empty: 'No notifications', loadFailed: 'Failed to load notifications', delete: 'Delete notification', view: 'View details', justNow: 'Just now', minutesAgo: '{count} minutes ago', hoursAgo: '{count} hours ago' },
   browser: {
     title: 'Браузер', settings: 'Настройки браузера', desktopOnly: 'Встроенный браузер доступен только в Hermes Studio Desktop.', newTab: 'Новая вкладка',
     back: 'Назад', forward: 'Вперёд', reload: 'Обновить', stop: 'Остановить', addressPlaceholder: 'Поиск или адрес',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -1,4 +1,5 @@
 export default {
+  notifications: { title: '通知', readAll: '全部已讀', empty: '暫無通知', loadFailed: '通知載入失敗', delete: '刪除通知', view: '查看詳情', justNow: '剛剛', minutesAgo: '{count} 分鐘前', hoursAgo: '{count} 小時前' },
   browser: {
     title: '瀏覽器', settings: '瀏覽器設定', desktopOnly: '內建瀏覽器僅在 Hermes Studio 桌面版可用。', newTab: '新分頁',
     back: '上一頁', forward: '下一頁', reload: '重新整理', stop: '停止', addressPlaceholder: '搜尋或輸入網址',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -1,4 +1,5 @@
 export default {
+  notifications: { title: '通知', readAll: '全部已读', empty: '暂无通知', loadFailed: '通知加载失败', delete: '删除通知', view: '查看详情', justNow: '刚刚', minutesAgo: '{count} 分钟前', hoursAgo: '{count} 小时前' },
   browser: {
     title: '浏览器', settings: '浏览器设置', desktopOnly: '内置浏览器仅在 Hermes Studio 桌面端可用。', newTab: '新标签页',
     back: '后退', forward: '前进', reload: '刷新', stop: '停止', addressPlaceholder: '搜索或输入网址',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -11,6 +11,7 @@ import { useProfilesStore } from './profiles'
 import { useSettingsStore } from './settings'
 import { primeCompletionSound, playCompletionSound } from '@/utils/completion-sound'
 import { showCompletionNotification } from '@/utils/completion-notification'
+import { createNotificationEvent, markNotificationReadByDedupeKey } from '@/api/hermes/notifications'
 import { detectThinkingBoundary } from '@/utils/thinking-parser'
 import { isKnownBridgeSessionCommand } from '@/utils/hermes/bridge-session-commands'
 import { responseErrorMessage } from '@/utils/http-error'
@@ -2850,6 +2851,28 @@ export const useChatStore = defineStore('chat', () => {
     })
   }
 
+  function persistChatNotification(input: {
+    sessionId: string
+    eventId: string
+    type: 'chat.completed' | 'chat.failed' | 'approval.requested' | 'clarify.requested'
+    severity: 'success' | 'error' | 'warning'
+    title: string
+    body: string
+  }) {
+    void createNotificationEvent({
+      dedupeKey: `${input.type}:${input.sessionId}:${input.eventId}`,
+      type: input.type,
+      severity: input.severity,
+      title: input.title,
+      body: input.body,
+      source: {
+        kind: 'session',
+        id: input.sessionId,
+        route: { name: 'hermes.session', params: { sessionId: input.sessionId } },
+      },
+    }).catch(err => console.warn('Failed to persist chat notification:', err))
+  }
+
   function setPendingApproval(evt: RunEvent) {
     const sid = evt.session_id
     const approvalId = (evt as any).approval_id as string | undefined
@@ -2876,6 +2899,14 @@ export const useChatStore = defineStore('chat', () => {
       requestedAt: Date.now(),
     })
     pendingApprovals.value = new Map(pendingApprovals.value)
+    persistChatNotification({
+      sessionId: sid,
+      eventId: approvalId,
+      type: 'approval.requested',
+      severity: 'warning',
+      title: sessions.value.find(session => session.id === sid)?.title || 'Hermes',
+      body: description || String((evt as any).command || 'Approval required'),
+    })
   }
 
   function clearPendingApproval(evt: RunEvent) {
@@ -2887,6 +2918,8 @@ export const useChatStore = defineStore('chat', () => {
     if (approvalId && current.approvalId !== approvalId) return
     pendingApprovals.value.delete(sid)
     pendingApprovals.value = new Map(pendingApprovals.value)
+    void markNotificationReadByDedupeKey(`approval.requested:${sid}:${current.approvalId}`)
+      .catch(err => console.warn('Failed to resolve approval notification:', err))
   }
 
   function setPendingClarify(evt: RunEvent) {
@@ -2902,6 +2935,14 @@ export const useChatStore = defineStore('chat', () => {
       requestedAt: Date.now(),
     })
     pendingClarifies.value = new Map(pendingClarifies.value)
+    persistChatNotification({
+      sessionId: sid,
+      eventId: clarifyId,
+      type: 'clarify.requested',
+      severity: 'warning',
+      title: sessions.value.find(session => session.id === sid)?.title || 'Hermes',
+      body: String((evt as any).question || 'Your response is required'),
+    })
   }
 
   function clearPendingClarify(evt: RunEvent) {
@@ -2913,6 +2954,8 @@ export const useChatStore = defineStore('chat', () => {
     if (clarifyId && current.clarifyId !== clarifyId) return
     pendingClarifies.value.delete(sid)
     pendingClarifies.value = new Map(pendingClarifies.value)
+    void markNotificationReadByDedupeKey(`clarify.requested:${sid}:${current.clarifyId}`)
+      .catch(err => console.warn('Failed to resolve clarify notification:', err))
   }
 
   function clearPendingInteractions(sessionId: string) {
@@ -3906,6 +3949,14 @@ export const useChatStore = defineStore('chat', () => {
               } else {
                 playCompletionBellIfEnabled()
                 showCompletionNotificationIfEnabled(sid, completedAssistantMessageId)
+                persistChatNotification({
+                  sessionId: sid,
+                  eventId: String(evt.run_id || completedAssistantMessageId || evt.timestamp || 'completed'),
+                  type: 'chat.completed',
+                  severity: 'success',
+                  title: sessions.value.find(session => session.id === sid)?.title || 'Hermes',
+                  body: finalOutputTrimmed || 'Response completed',
+                })
               }
               const terminalAssistantMessageId = completedAssistantMessageId || [...getSessionMsgs(sid)]
                 .reverse()
@@ -3956,6 +4007,14 @@ export const useChatStore = defineStore('chat', () => {
                 }
               }
               addAgentErrorMessage(sid, evt.error)
+              persistChatNotification({
+                sessionId: sid,
+                eventId: String(evt.run_id || evt.timestamp || 'failed'),
+                type: 'chat.failed',
+                severity: 'error',
+                title: sessions.value.find(session => session.id === sid)?.title || 'Hermes',
+                body: String(evt.error || 'Run failed'),
+              })
               settleRunningTools(sid, 'error')
               if ((evt as any).queue_remaining > 0) {
                 queueLengths.value.set(sid, (evt as any).queue_remaining)
@@ -4588,6 +4647,14 @@ export const useChatStore = defineStore('chat', () => {
           } else {
             playCompletionBellIfEnabled()
             showCompletionNotificationIfEnabled(sid, completedAssistantMessageId)
+            persistChatNotification({
+              sessionId: sid,
+              eventId: String(evt.run_id || completedAssistantMessageId || evt.timestamp || 'completed'),
+              type: 'chat.completed',
+              severity: 'success',
+              title: sessions.value.find(session => session.id === sid)?.title || 'Hermes',
+              body: finalOutputTrimmed || 'Response completed',
+            })
           }
           const terminalAssistantMessageId = completedAssistantMessageId || [...getSessionMsgs(sid)]
             .reverse()
@@ -4653,6 +4720,14 @@ export const useChatStore = defineStore('chat', () => {
             queueLengths.value.delete(sid)
           }
           addAgentErrorMessage(sid, evt.error)
+          persistChatNotification({
+            sessionId: sid,
+            eventId: String(evt.run_id || evt.timestamp || 'failed'),
+            type: 'chat.failed',
+            severity: 'error',
+            title: sessions.value.find(session => session.id === sid)?.title || 'Hermes',
+            body: String(evt.error || 'Run failed'),
+          })
           settleRunningTools(sid, 'error')
           if (!hasQueue && !hasBackground) {
             cleanup()

--- a/packages/client/src/views/hermes/JobsView.vue
+++ b/packages/client/src/views/hermes/JobsView.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { NButton, NSpin, NTooltip } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
+import { useRoute } from 'vue-router'
 import JobsPanel from '@/components/hermes/jobs/JobsPanel.vue'
 import JobRunHistory from '@/components/hermes/jobs/JobRunHistory.vue'
 import JobFormModal from '@/components/hermes/jobs/JobFormModal.vue'
@@ -9,6 +10,7 @@ import { useJobsStore } from '@/stores/hermes/jobs'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 
 const { t } = useI18n()
+const route = useRoute()
 const jobsStore = useJobsStore()
 const profilesStore = useProfilesStore()
 const showModal = ref(false)
@@ -38,6 +40,10 @@ async function reloadJobsForProfile() {
   jobsStore.jobs = []
   await ensureProfileSelection()
   await jobsStore.fetchJobs()
+  const requestedJobId = typeof route.query.jobId === 'string' ? route.query.jobId : ''
+  if (requestedJobId && jobsStore.jobs.some(job => (job.job_id || job.id) === requestedJobId)) {
+    selectedJobId.value = requestedJobId
+  }
 }
 
 onMounted(() => {

--- a/packages/client/src/views/hermes/WorkflowView.vue
+++ b/packages/client/src/views/hermes/WorkflowView.vue
@@ -14,6 +14,7 @@ import { Background } from '@vue-flow/background'
 import { Controls } from '@vue-flow/controls'
 import { MiniMap } from '@vue-flow/minimap'
 import { useI18n } from 'vue-i18n'
+import { useRoute } from 'vue-router'
 import { buildWorkflowEvidenceRows, latestWorkflowNodeSession, summarizeWorkflowEvidenceRows, workflowEdgePlaybackState, type WorkflowEvidenceRow } from '@/utils/workflow-history'
 import { resolveWorkflowRunPageSwipe, type WorkflowRunPagerPage } from '@/utils/workflow-run-pager'
 import {
@@ -111,6 +112,7 @@ import '@vue-flow/controls/dist/style.css'
 import '@vue-flow/minimap/dist/style.css'
 
 const { t } = useI18n()
+const route = useRoute()
 const appStore = useAppStore()
 const chatStore = useChatStore()
 const profilesStore = useProfilesStore()
@@ -1110,14 +1112,24 @@ async function loadWorkflows() {
       await clearActiveWorkflowPage()
       return
     }
-    const activeWorkflow = previousActiveId
-      ? docs.find(workflow => workflow.id === previousActiveId)
-      : null
+    const requestedWorkflowId = typeof route.query.workflowId === 'string' ? route.query.workflowId : ''
+    const activeWorkflow = requestedWorkflowId
+      ? docs.find(workflow => workflow.id === requestedWorkflowId)
+      : previousActiveId
+        ? docs.find(workflow => workflow.id === previousActiveId)
+        : null
     if (previousActiveId && !activeWorkflow) {
       await clearActiveWorkflowPage()
       return
     }
     await applyWorkflow(activeWorkflow || docs[0], false)
+    const requestedRunId = typeof route.query.runId === 'string' ? route.query.runId : ''
+    if (requestedRunId && activeWorkflow) {
+      showWorkflowRunsPanel.value = true
+      await loadWorkflowRuns(activeWorkflow.id, requestedRunId)
+      const requestedRun = workflowRuns.value.find(run => run.id === requestedRunId)
+      if (requestedRun) await selectWorkflowRun(requestedRun)
+    }
   } catch (err) {
     console.error('Failed to load workflows:', err)
   } finally {

--- a/packages/server/src/controllers/hermes/notifications.ts
+++ b/packages/server/src/controllers/hermes/notifications.ts
@@ -1,0 +1,118 @@
+import type { Context } from 'koa'
+import {
+  deleteNotification,
+  listNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+  markNotificationReadByDedupeKey,
+} from '../../db/hermes/notification-store'
+import { notificationService, reconcileCronNotifications } from '../../services/notification-service'
+
+function scope(ctx: Context): { ownerId: number; profile: string } | null {
+  const ownerId = ctx.state.user?.id
+  if (!ownerId) {
+    ctx.status = 401
+    ctx.body = { error: 'Unauthorized' }
+    return null
+  }
+  const profile = ctx.state.profile?.name
+  if (!profile) {
+    ctx.status = 400
+    ctx.body = { error: 'Profile is required' }
+    return null
+  }
+  return { ownerId, profile }
+}
+
+function queryValue(value: unknown): string {
+  return Array.isArray(value) ? String(value[0] ?? '') : String(value ?? '')
+}
+
+export async function create(ctx: Context) {
+  const ownerScope = scope(ctx)
+  if (!ownerScope) return
+  const body = (ctx.request.body || {}) as Record<string, unknown>
+  const dedupeKey = typeof body.dedupeKey === 'string' ? body.dedupeKey.trim() : ''
+  const type = typeof body.type === 'string' ? body.type.trim() : ''
+  const severity = typeof body.severity === 'string' ? body.severity.trim() : ''
+  const title = typeof body.title === 'string' ? body.title.trim() : ''
+  const messageBody = typeof body.body === 'string' ? body.body : ''
+  const source = body.source && typeof body.source === 'object' ? body.source as Record<string, unknown> : null
+  const allowedTypes = new Set([
+    'chat.completed', 'chat.failed', 'group_chat.completed', 'group_chat.failed',
+    'workflow.completed', 'workflow.failed',
+    'workflow.approval', 'cron.completed', 'cron.failed',
+    'approval.requested', 'clarify.requested',
+  ])
+  if (!dedupeKey || !allowedTypes.has(type) || !['info', 'success', 'warning', 'error'].includes(severity)
+    || !title || !source || typeof source.kind !== 'string' || typeof source.id !== 'string') {
+    ctx.status = 400
+    ctx.body = { error: 'Invalid notification payload' }
+    return
+  }
+  const result = notificationService.publish({
+    ...ownerScope,
+    dedupeKey,
+    type,
+    severity: severity as 'info' | 'success' | 'warning' | 'error',
+    title,
+    body: messageBody,
+    source: source as any,
+  })
+  ctx.status = result.created ? 201 : 200
+  ctx.body = result
+}
+
+export async function list(ctx: Context) {
+  const ownerScope = scope(ctx)
+  if (!ownerScope) return
+  const parsedLimit = Number(queryValue(ctx.query.limit))
+  reconcileCronNotifications(ownerScope.ownerId, ownerScope.profile)
+  ctx.body = listNotifications({
+    ...ownerScope,
+    limit: Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 50,
+    unreadOnly: queryValue(ctx.query.unread) === 'true',
+  })
+}
+
+export async function markRead(ctx: Context) {
+  const ownerScope = scope(ctx)
+  if (!ownerScope) return
+  const notification = markNotificationRead({ ...ownerScope, id: ctx.params.id })
+  if (!notification) {
+    ctx.status = 404
+    ctx.body = { error: 'Notification not found' }
+    return
+  }
+  ctx.body = { notification }
+}
+
+export async function markReadByDedupeKey(ctx: Context) {
+  const ownerScope = scope(ctx)
+  if (!ownerScope) return
+  const body = (ctx.request.body || {}) as Record<string, unknown>
+  const dedupeKey = typeof body.dedupeKey === 'string' ? body.dedupeKey.trim() : ''
+  if (!dedupeKey) {
+    ctx.status = 400
+    ctx.body = { error: 'dedupeKey is required' }
+    return
+  }
+  ctx.body = { updated: markNotificationReadByDedupeKey({ ...ownerScope, dedupeKey }) }
+}
+
+export async function markAllRead(ctx: Context) {
+  const ownerScope = scope(ctx)
+  if (!ownerScope) return
+  ctx.body = { updated: markAllNotificationsRead(ownerScope) }
+}
+
+export async function remove(ctx: Context) {
+  const ownerScope = scope(ctx)
+  if (!ownerScope) return
+  if (!deleteNotification({ ...ownerScope, id: ctx.params.id })) {
+    ctx.status = 404
+    ctx.body = { error: 'Notification not found' }
+    return
+  }
+  ctx.body = { deleted: true }
+}

--- a/packages/server/src/db/hermes/notification-store.ts
+++ b/packages/server/src/db/hermes/notification-store.ts
@@ -1,0 +1,153 @@
+import { randomUUID } from 'crypto'
+import { getDb } from '../index'
+import { NOTIFICATIONS_TABLE } from './schemas'
+
+export type NotificationSeverity = 'info' | 'success' | 'warning' | 'error'
+
+export interface NotificationSource {
+  kind: 'session' | 'room' | 'workflow' | 'cron' | 'system'
+  id: string
+  runId?: string
+  route?: { name: string; params?: Record<string, string>; query?: Record<string, string> }
+}
+
+export interface NotificationRecord {
+  id: string
+  ownerId: number
+  profile: string
+  dedupeKey: string
+  type: string
+  severity: NotificationSeverity
+  title: string
+  body: string
+  source: NotificationSource
+  unread: boolean
+  readAt: number | null
+  createdAt: number
+  updatedAt: number
+}
+
+export interface CreateNotificationInput {
+  ownerId: number
+  profile: string
+  dedupeKey: string
+  type: string
+  severity: NotificationSeverity
+  title: string
+  body: string
+  source: NotificationSource
+  now?: number
+}
+
+interface NotificationRow {
+  id: string
+  owner_id: number
+  profile: string
+  dedupe_key: string
+  type: string
+  severity: NotificationSeverity
+  title: string
+  body: string
+  source_json: string
+  read_at: number | null
+  created_at: number
+  updated_at: number
+}
+
+function database() {
+  const db = getDb()
+  if (!db) throw new Error('Notifications require SQLite')
+  return db
+}
+
+function mapRow(row: NotificationRow): NotificationRecord {
+  let source: NotificationSource = { kind: 'system', id: '' }
+  try { source = JSON.parse(row.source_json) as NotificationSource } catch { /* retain safe fallback */ }
+  return {
+    id: row.id,
+    ownerId: row.owner_id,
+    profile: row.profile,
+    dedupeKey: row.dedupe_key,
+    type: row.type,
+    severity: row.severity,
+    title: row.title,
+    body: row.body,
+    source,
+    unread: row.read_at == null,
+    readAt: row.read_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function getOwned(ownerId: number, profile: string, id: string): NotificationRecord | null {
+  const row = database().prepare(
+    `SELECT * FROM ${NOTIFICATIONS_TABLE} WHERE id = ? AND owner_id = ? AND profile = ?`,
+  ).get(id, ownerId, profile) as unknown as NotificationRow | undefined
+  return row ? mapRow(row) : null
+}
+
+export function createNotification(input: CreateNotificationInput): { notification: NotificationRecord; created: boolean } {
+  const db = database()
+  const now = input.now ?? Date.now()
+  const existing = db.prepare(
+    `SELECT * FROM ${NOTIFICATIONS_TABLE} WHERE owner_id = ? AND profile = ? AND dedupe_key = ?`,
+  ).get(input.ownerId, input.profile, input.dedupeKey) as unknown as NotificationRow | undefined
+  if (existing) return { notification: mapRow(existing), created: false }
+
+  const id = randomUUID()
+  db.prepare(
+    `INSERT INTO ${NOTIFICATIONS_TABLE}
+      (id, owner_id, profile, dedupe_key, type, severity, title, body, source_json, read_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)`,
+  ).run(id, input.ownerId, input.profile, input.dedupeKey, input.type, input.severity,
+    input.title, input.body, JSON.stringify(input.source), now, now)
+  return { notification: getOwned(input.ownerId, input.profile, id)!, created: true }
+}
+
+export function listNotifications(input: { ownerId: number; profile: string; limit?: number; unreadOnly?: boolean }) {
+  const limit = Math.max(1, Math.min(input.limit ?? 50, 100))
+  const unreadClause = input.unreadOnly ? ' AND read_at IS NULL' : ''
+  const rows = database().prepare(
+    `SELECT * FROM ${NOTIFICATIONS_TABLE} WHERE owner_id = ? AND profile = ?${unreadClause}
+     ORDER BY created_at DESC, id DESC LIMIT ?`,
+  ).all(input.ownerId, input.profile, limit) as unknown as NotificationRow[]
+  const count = database().prepare(
+    `SELECT COUNT(*) AS count FROM ${NOTIFICATIONS_TABLE} WHERE owner_id = ? AND profile = ? AND read_at IS NULL`,
+  ).get(input.ownerId, input.profile) as unknown as { count: number }
+  return { notifications: rows.map(mapRow), unreadCount: Number(count.count || 0) }
+}
+
+export function markNotificationRead(input: { ownerId: number; profile: string; id: string; now?: number }): NotificationRecord | null {
+  const now = input.now ?? Date.now()
+  database().prepare(
+    `UPDATE ${NOTIFICATIONS_TABLE} SET read_at = COALESCE(read_at, ?), updated_at = ?
+     WHERE id = ? AND owner_id = ? AND profile = ?`,
+  ).run(now, now, input.id, input.ownerId, input.profile)
+  return getOwned(input.ownerId, input.profile, input.id)
+}
+
+export function markNotificationReadByDedupeKey(input: { ownerId: number; profile: string; dedupeKey: string; now?: number }): boolean {
+  const now = input.now ?? Date.now()
+  const result = database().prepare(
+    `UPDATE ${NOTIFICATIONS_TABLE} SET read_at = COALESCE(read_at, ?), updated_at = ?
+     WHERE owner_id = ? AND profile = ? AND dedupe_key = ?`,
+  ).run(now, now, input.ownerId, input.profile, input.dedupeKey)
+  return Number(result.changes) > 0
+}
+
+export function markAllNotificationsRead(input: { ownerId: number; profile: string; now?: number }): number {
+  const now = input.now ?? Date.now()
+  const result = database().prepare(
+    `UPDATE ${NOTIFICATIONS_TABLE} SET read_at = ?, updated_at = ?
+     WHERE owner_id = ? AND profile = ? AND read_at IS NULL`,
+  ).run(now, now, input.ownerId, input.profile)
+  return Number(result.changes)
+}
+
+export function deleteNotification(input: { ownerId: number; profile: string; id: string }): boolean {
+  const result = database().prepare(
+    `DELETE FROM ${NOTIFICATIONS_TABLE} WHERE id = ? AND owner_id = ? AND profile = ?`,
+  ).run(input.id, input.ownerId, input.profile)
+  return Number(result.changes) > 0
+}

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -116,6 +116,33 @@ export const MESSAGES_SCHEMA: Record<string, string> = {
 export const MESSAGES_INDEX = 'CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id)'
 
 // ============================================================================
+// User Notifications
+// ============================================================================
+
+export const NOTIFICATIONS_TABLE = 'notifications'
+
+export const NOTIFICATIONS_SCHEMA: Record<string, string> = {
+  id: 'TEXT PRIMARY KEY',
+  owner_id: 'INTEGER NOT NULL',
+  profile: "TEXT NOT NULL DEFAULT 'default'",
+  dedupe_key: 'TEXT NOT NULL',
+  type: 'TEXT NOT NULL',
+  severity: "TEXT NOT NULL DEFAULT 'info'",
+  title: 'TEXT NOT NULL',
+  body: "TEXT NOT NULL DEFAULT ''",
+  source_json: "TEXT NOT NULL DEFAULT '{}'",
+  read_at: 'INTEGER',
+  created_at: 'INTEGER NOT NULL',
+  updated_at: 'INTEGER NOT NULL',
+}
+
+export const NOTIFICATIONS_INDEXES = {
+  uniq_notifications_owner_profile_dedupe: 'CREATE UNIQUE INDEX IF NOT EXISTS uniq_notifications_owner_profile_dedupe ON notifications(owner_id, profile, dedupe_key)',
+  idx_notifications_owner_profile_created: 'CREATE INDEX IF NOT EXISTS idx_notifications_owner_profile_created ON notifications(owner_id, profile, created_at DESC)',
+  idx_notifications_owner_profile_unread: 'CREATE INDEX IF NOT EXISTS idx_notifications_owner_profile_unread ON notifications(owner_id, profile, read_at)',
+}
+
+// ============================================================================
 // Workspace Run Changes
 // ============================================================================
 
@@ -1091,6 +1118,10 @@ export function initAllHermesTables(): void {
     createIndexes(db, SESSIONS_INDEXES)
     syncTable(MESSAGES_TABLE, MESSAGES_SCHEMA)
     db.exec(MESSAGES_INDEX)
+    syncTable(NOTIFICATIONS_TABLE, NOTIFICATIONS_SCHEMA, {
+      indexes: NOTIFICATIONS_INDEXES,
+    })
+    createIndexes(db, NOTIFICATIONS_INDEXES)
     syncTable(WORKSPACE_RUN_CHANGES_TABLE, WORKSPACE_RUN_CHANGES_SCHEMA, {
       indexes: WORKSPACE_RUN_CHANGES_INDEXES,
     })

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -28,6 +28,7 @@ import { getLanPeerSocketManager, getLanPeerSocketPath } from './services/lan-pe
 import { startGlobalAgentServer } from './services/global-agent/server'
 import { setupGlobalEkkoAgent } from './services/ekko-agent/manager'
 import { WorkflowSocketServer } from './services/workflow-socket'
+import { NotificationSocketServer } from './services/notification-socket'
 import { PetStateSocketServer } from './services/hermes/pet-state-socket'
 import { logger } from './services/logger'
 import { createStaticCompressionMiddleware } from './middleware/static-compression'
@@ -61,6 +62,7 @@ let server: any = null
 let servers: any[] = []
 let chatRunServer: any = null
 let workflowSocketServer: WorkflowSocketServer | null = null
+let notificationSocketServer: NotificationSocketServer | null = null
 let petStateSocketServer: PetStateSocketServer | null = null
 let agentBridgeManager: any = null
 let desktopShutdownHandler: ShutdownHandler | null = null
@@ -359,6 +361,9 @@ export async function bootstrap() {
   workflowSocketServer = new WorkflowSocketServer(groupChatServer.getIO())
   workflowSocketServer.init()
 
+  notificationSocketServer = new NotificationSocketServer(groupChatServer.getIO())
+  notificationSocketServer.init()
+
   petStateSocketServer = new PetStateSocketServer(groupChatServer.getIO())
   petStateSocketServer.init()
 
@@ -409,7 +414,13 @@ export async function bootstrap() {
     })
   })
 
-  desktopShutdownHandler = bindShutdown(servers, groupChatServer, chatRunServer, agentBridgeManager)
+  desktopShutdownHandler = bindShutdown(
+    servers,
+    groupChatServer,
+    chatRunServer,
+    agentBridgeManager,
+    [workflowSocketServer, notificationSocketServer].filter(Boolean) as Array<{ close: () => void }>,
+  )
   startVersionCheck()
 }
 

--- a/packages/server/src/routes/hermes/notifications.ts
+++ b/packages/server/src/routes/hermes/notifications.ts
@@ -1,0 +1,11 @@
+import Router from '@koa/router'
+import * as ctrl from '../../controllers/hermes/notifications'
+
+export const notificationRoutes = new Router()
+
+notificationRoutes.get('/api/hermes/notifications', ctrl.list)
+notificationRoutes.post('/api/hermes/notifications', ctrl.create)
+notificationRoutes.post('/api/hermes/notifications/read-by-key', ctrl.markReadByDedupeKey)
+notificationRoutes.post('/api/hermes/notifications/read-all', ctrl.markAllRead)
+notificationRoutes.post('/api/hermes/notifications/:id/read', ctrl.markRead)
+notificationRoutes.delete('/api/hermes/notifications/:id', ctrl.remove)

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -52,6 +52,7 @@ import { runtimeVersionRoutes } from './hermes/runtime-versions'
 import { writeGateRoutes } from './hermes/write-gate'
 import { petdexPublicRoutes, petdexRoutes } from './hermes/petdex'
 import { petRoutes } from './hermes/pets'
+import { notificationRoutes } from './hermes/notifications'
 
 /**
  * Register all routes on the Koa app.
@@ -118,4 +119,5 @@ export function registerRoutes(app: any, authMiddleware: Array<(ctx: Context, ne
   app.use(writeGateRoutes.routes())              // Hermes Agent write approval review
   app.use(petdexRoutes.routes())
   app.use(petRoutes.routes())
+  app.use(notificationRoutes.routes())
 }

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -17,6 +17,8 @@ import { config } from '../../../config'
 import { createSocketIoCorsOrigin, shouldRejectUpgradeOrigin } from '../../../security'
 import { paginateRecentGroupMessagesCanonical, sliceGroupMessagesCanonical, type GroupMessageCursorCutoff } from './group-message-ordering'
 import { GroupRoomSummaryService, type GroupRoomSummary } from './room-summary'
+import { notificationService } from '../../notification-service'
+import { markNotificationReadByDedupeKey } from '../../../db/hermes/notification-store'
 
 // ─── Types ────────────────────────────────────────────────────
 
@@ -1737,12 +1739,33 @@ export class GroupChatServer {
         })
     }
 
+    private roomNotificationScope(roomId: string, agentName = ''): { ownerId: number; profile: string; room: RoomInfo } | null {
+        const room = this.storage.getRoom(roomId)
+        const ownerId = Number(room?.ownerAuthUserId || 0)
+        if (!room || ownerId <= 0) return null
+        const agents = this.storage.getRoomAgents(roomId)
+        const agent = agentName ? agents.find(candidate => candidate.name === agentName) : agents[0]
+        return { ownerId, profile: agent?.profile || room.summaryProfile || 'default', room }
+    }
+
     private handleMessageStreamEnd(socket: Socket, data: { roomId?: string; id?: string; agentSessionId?: string }): void {
         const roomId = data.roomId || 'general'
-        if (!this.getCurrentAgentEventMember(socket, roomId, '', data.agentSessionId)) return
+        const member = this.getCurrentAgentEventMember(socket, roomId, '', data.agentSessionId)
+        if (!member) return
         const id = this.normalizeClientMessageId(data.id)
         if (!id) return
         this.nsp.to(roomId).emit('message_stream_end', { roomId, id })
+        const scope = this.roomNotificationScope(roomId, member.name)
+        if (scope) notificationService.publish({
+            ownerId: scope.ownerId,
+            profile: scope.profile,
+            dedupeKey: `group_chat.completed:${roomId}:${id}`,
+            type: 'group_chat.completed',
+            severity: 'success',
+            title: scope.room.name,
+            body: `${member.name} replied`,
+            source: { kind: 'room', id: roomId, route: { name: 'hermes.groupChatRoom', params: { roomId } } },
+        })
     }
 
     private handleTyping(socket: Socket, data: { roomId?: string }): void {
@@ -1892,6 +1915,17 @@ export class GroupChatServer {
             choices: Array.isArray(data.choices) ? data.choices : ['once', 'session', 'deny'],
             allow_permanent: Boolean(data.allow_permanent),
         })
+        const scope = this.roomNotificationScope(roomId, agentName)
+        if (scope) notificationService.publish({
+            ownerId: scope.ownerId,
+            profile: scope.profile,
+            dedupeKey: `approval.requested:room:${roomId}:${data.approval_id}`,
+            type: 'approval.requested',
+            severity: 'warning',
+            title: scope.room.name,
+            body: data.description || data.command || `${agentName} requires approval`,
+            source: { kind: 'room', id: roomId, route: { name: 'hermes.groupChatRoom', params: { roomId } } },
+        })
     }
 
     private handleApprovalResolved(socket: Socket, data: { roomId?: string; agentName?: string; approval_id?: string; choice?: string; agentSessionId?: string }): void {
@@ -1908,6 +1942,12 @@ export class GroupChatServer {
             agentName,
             approval_id: data.approval_id,
             choice: data.choice || '',
+        })
+        const scope = this.roomNotificationScope(roomId, agentName)
+        if (scope) markNotificationReadByDedupeKey({
+            ownerId: scope.ownerId,
+            profile: scope.profile,
+            dedupeKey: `approval.requested:room:${roomId}:${data.approval_id}`,
         })
     }
 

--- a/packages/server/src/services/notification-service.ts
+++ b/packages/server/src/services/notification-service.ts
@@ -1,0 +1,81 @@
+import { EventEmitter } from 'events'
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { getProfileDir } from './hermes/hermes-profile'
+import {
+  createNotification,
+  type CreateNotificationInput,
+  type NotificationRecord,
+} from '../db/hermes/notification-store'
+
+export interface PublishedNotification {
+  ownerId: number
+  profile: string
+  notification: NotificationRecord
+}
+
+type Listener = (event: PublishedNotification) => void
+
+class NotificationService extends EventEmitter {
+  publish(input: CreateNotificationInput) {
+    const result = createNotification(input)
+    if (result.created) {
+      this.emit('created', {
+        ownerId: input.ownerId,
+        profile: input.profile,
+        notification: result.notification,
+      } satisfies PublishedNotification)
+    }
+    return result
+  }
+
+  onCreated(listener: Listener): () => void {
+    this.on('created', listener)
+    return () => this.off('created', listener)
+  }
+}
+
+export const notificationService = new NotificationService()
+
+interface CronMetadata {
+  id?: string
+  job_id?: string
+  name?: string
+  last_run_at?: string | null
+  last_status?: string | null
+  last_error?: string | null
+}
+
+function cronJobs(profile: string): CronMetadata[] {
+  const file = join(getProfileDir(profile), 'cron', 'jobs.json')
+  if (!existsSync(file)) return []
+  try {
+    const parsed = JSON.parse(readFileSync(file, 'utf8')) as CronMetadata[] | { jobs?: CronMetadata[] }
+    return Array.isArray(parsed) ? parsed : Array.isArray(parsed.jobs) ? parsed.jobs : []
+  } catch { return [] }
+}
+
+export function reconcileCronNotifications(ownerId: number, profile: string): number {
+  let created = 0
+  for (const job of cronJobs(profile)) {
+    const id = String(job.job_id || job.id || '').trim()
+    const ranAt = String(job.last_run_at || '').trim()
+    if (!id || !ranAt) continue
+    const failed = ['failed', 'error'].includes(String(job.last_status || '').toLowerCase()) || Boolean(job.last_error)
+    const result = notificationService.publish({
+      ownerId,
+      profile,
+      dedupeKey: `cron:${id}:${ranAt}:${failed ? 'failed' : 'completed'}`,
+      type: failed ? 'cron.failed' : 'cron.completed',
+      severity: failed ? 'error' : 'success',
+      title: String(job.name || id),
+      body: failed ? String(job.last_error || 'Cron job failed') : 'Cron job completed',
+      source: {
+        kind: 'cron', id,
+        route: { name: 'hermes.jobs', query: { jobId: id } },
+      },
+    })
+    if (result.created) created += 1
+  }
+  return created
+}

--- a/packages/server/src/services/notification-socket.ts
+++ b/packages/server/src/services/notification-socket.ts
@@ -1,0 +1,47 @@
+import type { Server, Socket } from 'socket.io'
+import { authenticateUserToken, isAuthEnabled, type AuthenticatedUser } from '../middleware/user-auth'
+import { userCanAccessProfile } from '../db/hermes/users-store'
+import { notificationService } from './notification-service'
+import { logger } from './logger'
+
+const NAMESPACE = '/notifications'
+
+export function notificationRoom(ownerId: number, profile: string): string {
+  return `notification:${ownerId}:${profile}`
+}
+
+export class NotificationSocketServer {
+  private readonly nsp: ReturnType<Server['of']>
+  private readonly removeListener: () => void
+
+  constructor(io: Server) {
+    this.nsp = io.of(NAMESPACE)
+    this.removeListener = notificationService.onCreated(event => {
+      this.nsp.to(notificationRoom(event.ownerId, event.profile)).emit('notification.created', event.notification)
+    })
+  }
+
+  init() {
+    this.nsp.use(this.authenticate.bind(this))
+    this.nsp.on('connection', socket => {
+      const user = socket.data.user as AuthenticatedUser
+      const profile = String(socket.handshake.query.profile || '').trim()
+      void socket.join(notificationRoom(user.id, profile))
+    })
+    logger.info('[notification-socket] Socket.IO ready at %s', NAMESPACE)
+  }
+
+  close() { this.removeListener() }
+
+  private async authenticate(socket: Socket, next: (error?: Error) => void) {
+    if (!await isAuthEnabled()) return next(new Error('Authentication required'))
+    const user = await authenticateUserToken(String(socket.handshake.auth?.token || ''))
+    const profile = String(socket.handshake.query.profile || '').trim()
+    if (!user || !profile) return next(new Error('Authentication failed'))
+    if (user.role !== 'super_admin' && !userCanAccessProfile(user.id, profile)) {
+      return next(new Error('Profile access denied'))
+    }
+    socket.data.user = user
+    next()
+  }
+}

--- a/packages/server/src/services/shutdown.ts
+++ b/packages/server/src/services/shutdown.ts
@@ -43,7 +43,7 @@ export function shouldStopManagedGatewaysOnShutdown(env: NodeJS.ProcessEnv = pro
 
 export type ShutdownHandler = (signal: string) => Promise<void>
 
-export function createShutdownHandler(server: any, groupChatServer?: any, chatRunServer?: any, agentBridgeManager?: any): ShutdownHandler {
+export function createShutdownHandler(server: any, groupChatServer?: any, chatRunServer?: any, agentBridgeManager?: any, cleanupServices: Array<{ close: () => void | Promise<void> }> = []): ShutdownHandler {
   let isShuttingDown = false
 
   return async (signal: string) => {
@@ -114,6 +114,10 @@ export function createShutdownHandler(server: any, groupChatServer?: any, chatRu
       codingAgentRunManager.shutdown()
       logger.info('Coding agent hidden sessions closed')
 
+      for (const service of cleanupServices) {
+        await service.close()
+      }
+
       // Disconnect Socket.IO before HTTP server to prevent hanging
       if (groupChatServer) {
         groupChatServer.agentClients.disconnectAll()
@@ -143,8 +147,8 @@ export function createShutdownHandler(server: any, groupChatServer?: any, chatRu
   }
 }
 
-export function bindShutdown(server: any, groupChatServer?: any, chatRunServer?: any, agentBridgeManager?: any): ShutdownHandler {
-  const shutdown = createShutdownHandler(server, groupChatServer, chatRunServer, agentBridgeManager)
+export function bindShutdown(server: any, groupChatServer?: any, chatRunServer?: any, agentBridgeManager?: any, cleanupServices: Array<{ close: () => void | Promise<void> }> = []): ShutdownHandler {
+  const shutdown = createShutdownHandler(server, groupChatServer, chatRunServer, agentBridgeManager, cleanupServices)
 
   process.once('SIGUSR2', shutdown)
   process.on('SIGINT', shutdown)

--- a/packages/server/src/services/workflow-manager.ts
+++ b/packages/server/src/services/workflow-manager.ts
@@ -40,6 +40,8 @@ import { resolveWorkflowSkillContent } from './workflow-skill-resolver'
 import { codingAgentRunManager } from './agent-runner/coding-agent-run-manager'
 import { deleteSessionForProfile } from './hermes/hermes-cli'
 import { listProfileNamesFromDisk } from './hermes/hermes-profile'
+import { notificationService } from './notification-service'
+import { markNotificationReadByDedupeKey } from '../db/hermes/notification-store'
 import { logger } from './logger'
 
 export type { WorkflowCreateInput, WorkflowRecord, WorkflowUpdateInput }
@@ -1214,6 +1216,8 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
     timeoutMs?: number
     timeoutError?: string
     executionId?: string
+    user?: AuthenticatedUser
+    profile: string
   }): Promise<boolean> {
     if (!workflowNodeRequiresApproval(args.node)) return true
     if (this.canceledRunIds.has(args.runId) || getWorkflowRun(args.runId)?.status === 'canceled') return false
@@ -1230,6 +1234,20 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
       resolveApproval = resolve
     })
     const executionId = args.executionId || args.node.id
+    const dedupeKey = `workflow.approval:${args.workflowId}:${args.runId}:${executionId}`
+    if (args.user) notificationService.publish({
+      ownerId: args.user.id,
+      profile: args.profile,
+      dedupeKey,
+      type: 'workflow.approval',
+      severity: 'warning',
+      title: args.node.data.title || 'Workflow approval',
+      body: 'Workflow node requires approval',
+      source: {
+        kind: 'workflow', id: args.workflowId, runId: args.runId,
+        route: { name: 'hermes.workflow', query: { workflowId: args.workflowId, runId: args.runId } },
+      },
+    })
     const key = this.nodeApprovalKey(args.runId, executionId)
     this.pendingNodeApprovals.set(key, {
       workflowId: args.workflowId,
@@ -1253,6 +1271,7 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
     } finally {
       if (timer) clearTimeout(timer)
       this.pendingNodeApprovals.delete(key)
+      if (args.user) markNotificationReadByDedupeKey({ ownerId: args.user.id, profile: args.profile, dedupeKey })
     }
   }
 
@@ -1467,6 +1486,7 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
         if (approvalTimeoutMs !== undefined && approvalTimeoutMs <= 0) throw new Error(runTimeoutMessage!)
         const approved = await this.waitForNodeApproval({
           workflowId: workflowId, runId: run.id, node, nodeStatuses, executionId,
+          user: args.user, profile,
           timeoutMs: approvalTimeoutMs, timeoutError: runTimeoutMessage || undefined,
         })
         if (isCanceled()) throw new Error(getWorkflowRun(run.id)?.error || 'Workflow run canceled')
@@ -2002,7 +2022,7 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
           try {
             approved = await this.waitForNodeApproval({
               workflowId: workflowId, runId: run.id, node, nodeStatuses,
-              executionId: executionIdFor(node.id),
+              executionId: executionIdFor(node.id), user: args.user, profile,
               timeoutMs: approvalTimeoutMs, timeoutError: runTimeoutMessage || undefined,
             })
           } catch (err) {
@@ -2113,6 +2133,53 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
     }
   }
 
+  private async runWithNotification(
+    workflow: WorkflowRecord,
+    profile: string,
+    user: AuthenticatedUser | undefined,
+    run: WorkflowRunRecord,
+    execute: () => Promise<WorkflowRunNowResult>,
+  ): Promise<WorkflowRunNowResult> {
+    try {
+      const result = await execute()
+      if (user) this.publishWorkflowTerminalNotification(workflow, profile, user, run, result.run)
+      return result
+    } catch (err) {
+      if (user) {
+        const latestRun = getWorkflowRun(run.id) || run
+        this.publishWorkflowTerminalNotification(workflow, profile, user, run, {
+          ...latestRun,
+          status: 'failed',
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+      throw err
+    }
+  }
+
+  private publishWorkflowTerminalNotification(
+    workflow: WorkflowRecord,
+    profile: string,
+    user: AuthenticatedUser,
+    attempt: WorkflowRunRecord,
+    terminalRun: WorkflowRunRecord,
+  ): void {
+    const failed = terminalRun.status !== 'completed'
+    notificationService.publish({
+      ownerId: user.id,
+      profile,
+      dedupeKey: `workflow:${workflow.id}:${attempt.id}:${attempt.started_at || 0}:${failed ? 'failed' : 'completed'}`,
+      type: failed ? 'workflow.failed' : 'workflow.completed',
+      severity: failed ? 'error' : 'success',
+      title: workflow.name,
+      body: failed ? terminalRun.error || 'Workflow failed' : 'Workflow completed',
+      source: {
+        kind: 'workflow', id: workflow.id, runId: attempt.id,
+        route: { name: 'hermes.workflow', query: { workflowId: workflow.id, runId: attempt.id } },
+      },
+    })
+  }
+
   async runNow(workflowId: string, input: WorkflowRunNowInput = {}): Promise<WorkflowRunNowResult> {
     const workflow = this.get(workflowId)
     if (!workflow) {
@@ -2172,17 +2239,17 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
 
     const activeLoops = compiledGraph.loops.filter(loop => loop.bodyNodeIds.some(nodeId => activeIds.has(nodeId)))
     if (activeLoops.length > 0) {
-      return this.executeRecursiveCompiledWorkflowRun({
+      return this.runWithNotification(workflow, profile, input.user, run, () => this.executeRecursiveCompiledWorkflowRun({
         workflowId: workflow.id, workspace: workflow.workspace, run, profile, nodes, edges,
         loops: activeLoops, startNodeIds, activeIds, input: input.input, user: input.user,
         runDeadline, runTimeoutMessage,
-      })
+      }))
     }
 
-    return this.executeCompletionDrivenDagRun({
+    return this.runWithNotification(workflow, profile, input.user, run, () => this.executeCompletionDrivenDagRun({
       workflowId: workflow.id, workspace: workflow.workspace, run, profile, nodes, edges,
       startNodeIds, activeIds, input: input.input, user: input.user, runDeadline, runTimeoutMessage,
-    })
+    }))
   }
 
   async rerunFromNode(
@@ -2307,9 +2374,11 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
       ignoreHistoricalIncomingForStartNodes: !preserveStartNode,
     }
     const activeLoops = compiledGraph.loops.filter(loop => loop.bodyNodeIds.some(activeNodeId => activeIds.has(activeNodeId)))
-    return activeLoops.length > 0
-      ? this.executeRecursiveCompiledWorkflowRun({ ...sharedSchedulerArgs, loops: activeLoops })
-      : this.executeCompletionDrivenDagRun(sharedSchedulerArgs)
+    return this.runWithNotification(workflow, profile, input.user, updatedRun, () => (
+      activeLoops.length > 0
+        ? this.executeRecursiveCompiledWorkflowRun({ ...sharedSchedulerArgs, loops: activeLoops })
+        : this.executeCompletionDrivenDagRun(sharedSchedulerArgs)
+    ))
   }
 
   private async buildNodeUserMessage(args: {

--- a/tests/client/app-web-pet.test.ts
+++ b/tests/client/app-web-pet.test.ts
@@ -79,6 +79,10 @@ vi.mock('@/components/layout/AppSidebar.vue', () => ({
   default: { name: 'AppSidebar', template: '<aside />' },
 }))
 
+vi.mock('@/components/layout/NotificationCenter.vue', () => ({
+  default: { name: 'NotificationCenter', template: '<div class="notification-center-test" />' },
+}))
+
 vi.mock('@/components/layout/DesktopTitleBar.vue', () => ({
   default: {
     name: 'DesktopTitleBar',
@@ -132,6 +136,7 @@ describe('App web pet mounting', () => {
     await flushPromises()
 
     expect(wrapper.findComponent({ name: 'WebPet' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'NotificationCenter' }).exists()).toBe(true)
   })
 
   it('uses native macOS traffic lights without mounting custom window controls', () => {

--- a/tests/client/chat-store-error-handling.test.ts
+++ b/tests/client/chat-store-error-handling.test.ts
@@ -8,6 +8,7 @@ const chatApi = vi.hoisted(() => ({
   registerSessionHandlers: vi.fn(),
   unregisterSessionHandlers: vi.fn(),
 }))
+const notificationApi = vi.hoisted(() => ({ createNotificationEvent: vi.fn(() => Promise.resolve()) }))
 
 vi.mock('@/api/hermes/chat', () => ({
   startRunViaSocket: chatApi.startRunViaSocket,
@@ -25,8 +26,10 @@ vi.mock('@/api/hermes/chat', () => ({
 
 vi.mock('@/api/client', () => ({
   getActiveProfileName: () => 'default',
-  hasApiKey: () => false,
+  hasApiKey: function hasApiKey() { return false },
 }))
+
+vi.mock('@/api/hermes/notifications', () => notificationApi)
 
 vi.mock('@/api/hermes/sessions', () => ({
   archiveSession: vi.fn(),
@@ -146,6 +149,18 @@ describe('chat store error handling - #1644', () => {
     )
     expect(errorMessage).toBeDefined()
     expect(errorMessage?.content).toBe('Error: Socket disconnected')
+    expect(notificationApi.createNotificationEvent).toHaveBeenCalledWith({
+      dedupeKey: 'chat.failed:session-1:run-1',
+      type: 'chat.failed',
+      severity: 'error',
+      title: 'session-1',
+      body: 'Socket disconnected',
+      source: {
+        kind: 'session',
+        id: 'session-1',
+        route: { name: 'hermes.session', params: { sessionId: 'session-1' } },
+      },
+    })
   })
 
   it('overwrites empty streaming message when run.failed fires (no substantial content)', async () => {

--- a/tests/client/notification-center.test.ts
+++ b/tests/client/notification-center.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const api = vi.hoisted(() => ({
+  fetchNotifications: vi.fn(),
+  markNotificationRead: vi.fn(),
+  markAllNotificationsRead: vi.fn(),
+  deleteNotification: vi.fn(),
+}))
+const routerPush = vi.hoisted(() => vi.fn())
+const toastCreate = vi.hoisted(() => vi.fn(() => ({ destroy: vi.fn() })))
+const socketApi = vi.hoisted(() => ({ onNotificationCreated: vi.fn(() => vi.fn()), disconnectNotificationSocket: vi.fn() }))
+
+vi.mock('@/api/hermes/notifications', () => api)
+vi.mock('@/api/hermes/notification-socket', () => socketApi)
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal<any>()),
+  useRouter: () => ({ push: routerPush }),
+}))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+vi.mock('naive-ui', async () => ({
+  ...(await vi.importActual<any>('naive-ui')),
+  useNotification: () => ({ create: toastCreate }),
+}))
+
+import NotificationCenter from '@/components/layout/NotificationCenter.vue'
+
+const notices = [
+  {
+    id: 'n-1', type: 'chat.completed', severity: 'success', title: 'Research finished',
+    body: 'The answer is ready', unread: true, createdAt: 100, updatedAt: 100,
+    source: { kind: 'session', id: 's-1', route: { name: 'hermes.session', params: { sessionId: 's-1' } } },
+  },
+  {
+    id: 'n-2', type: 'workflow.failed', severity: 'error', title: 'Workflow failed',
+    body: 'Review the failed node', unread: false, createdAt: 90, updatedAt: 90,
+    source: { kind: 'workflow', id: 'wf-1', route: { name: 'hermes.workflow', query: { workflowId: 'wf-1' } } },
+  },
+]
+
+function mountCenter() {
+  return mount(NotificationCenter, {
+    global: {
+      plugins: [createPinia()],
+      stubs: {
+        NButton: { props: ['disabled'], template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>' },
+        NSpin: { template: '<div><slot /></div>' },
+      },
+    },
+  })
+}
+
+describe('NotificationCenter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.clearAllMocks()
+    api.fetchNotifications.mockResolvedValue({ notifications: notices, unreadCount: 1 })
+    api.markNotificationRead.mockResolvedValue({ notification: { ...notices[0], unread: false } })
+    api.markAllNotificationsRead.mockResolvedValue({ updated: 1 })
+    api.deleteNotification.mockResolvedValue({ deleted: true })
+  })
+
+  afterEach(() => vi.useRealTimers())
+
+  it('shows an unread badge and durable notification list', async () => {
+    const wrapper = mountCenter()
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="notification-bell"]').text()).toContain('1')
+    await wrapper.get('[data-testid="notification-bell"]').trigger('click')
+    expect(wrapper.text()).toContain('Research finished')
+    expect(wrapper.text()).toContain('Workflow failed')
+  })
+
+  it('marks a notification read before navigating to its source', async () => {
+    const wrapper = mountCenter()
+    await flushPromises()
+    await wrapper.get('[data-testid="notification-bell"]').trigger('click')
+    await wrapper.get('[data-testid="notification-item-n-1"]').trigger('click')
+    await flushPromises()
+
+    expect(api.markNotificationRead).toHaveBeenCalledWith('n-1')
+    expect(routerPush).toHaveBeenCalledWith({ name: 'hermes.session', params: { sessionId: 's-1' } })
+    expect(wrapper.get('[data-testid="notification-bell"]').text()).not.toContain('1')
+  })
+
+  it('marks all read and deletes one without navigating', async () => {
+    const wrapper = mountCenter()
+    await flushPromises()
+    await wrapper.get('[data-testid="notification-bell"]').trigger('click')
+    await wrapper.get('[data-testid="notification-read-all"]').trigger('click')
+    await wrapper.get('[data-testid="notification-delete-n-2"]').trigger('click')
+    await flushPromises()
+
+    expect(api.markAllNotificationsRead).toHaveBeenCalled()
+    expect(api.deleteNotification).toHaveBeenCalledWith('n-2')
+    expect(routerPush).not.toHaveBeenCalled()
+    expect(wrapper.text()).not.toContain('Workflow failed')
+  })
+
+  it('shows retryable error and empty states', async () => {
+    api.fetchNotifications.mockRejectedValueOnce(new Error('offline'))
+    const wrapper = mountCenter()
+    await flushPromises()
+    await wrapper.get('[data-testid="notification-bell"]').trigger('click')
+    expect(wrapper.text()).toContain('notifications.loadFailed')
+
+    api.fetchNotifications.mockResolvedValueOnce({ notifications: [], unreadCount: 0 })
+    await wrapper.get('[data-testid="notification-retry"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('notifications.empty')
+  })
+})

--- a/tests/client/notifications-api.test.ts
+++ b/tests/client/notifications-api.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const requestMock = vi.hoisted(() => vi.fn())
+vi.mock('@/api/client', () => ({ request: requestMock }))
+
+import {
+  createNotificationEvent,
+  deleteNotification,
+  fetchNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from '@/api/hermes/notifications'
+
+describe('notification API', () => {
+  beforeEach(() => requestMock.mockReset())
+
+  it('uses profile-scoped authenticated endpoints', async () => {
+    requestMock.mockResolvedValue({ notifications: [], unreadCount: 0 })
+    await fetchNotifications({ limit: 25, unreadOnly: true })
+    await markNotificationRead('notice 1')
+    await markAllNotificationsRead()
+    await deleteNotification('notice 1')
+
+    expect(requestMock.mock.calls).toEqual([
+      ['/api/hermes/notifications?limit=25&unread=true'],
+      ['/api/hermes/notifications/notice%201/read', { method: 'POST' }],
+      ['/api/hermes/notifications/read-all', { method: 'POST' }],
+      ['/api/hermes/notifications/notice%201', { method: 'DELETE' }],
+    ])
+  })
+
+  it('posts only the event contract', async () => {
+    requestMock.mockResolvedValue({ created: true, notification: { id: 'n-1' } })
+    const event = {
+      dedupeKey: 'chat:s-1:r-1:completed',
+      type: 'chat.completed' as const,
+      severity: 'success' as const,
+      title: 'Done',
+      body: 'Ready',
+      source: { kind: 'session' as const, id: 's-1' },
+    }
+
+    await createNotificationEvent(event)
+
+    expect(requestMock).toHaveBeenCalledWith('/api/hermes/notifications', {
+      method: 'POST',
+      body: JSON.stringify(event),
+    })
+  })
+})

--- a/tests/server/notification-service.test.ts
+++ b/tests/server/notification-service.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createNotification: vi.fn(),
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}))
+
+vi.mock('../../packages/server/src/db/hermes/notification-store', () => ({
+  createNotification: mocks.createNotification,
+}))
+vi.mock('fs', () => ({ existsSync: mocks.existsSync, readFileSync: mocks.readFileSync }))
+vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+  getProfileDir: (profile: string) => `/profiles/${profile}`,
+}))
+
+describe('notification service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.existsSync.mockReturnValue(true)
+  })
+
+  it('emits only for the first idempotent creation', async () => {
+    const { notificationService } = await import('../../packages/server/src/services/notification-service')
+    const listener = vi.fn()
+    const remove = notificationService.onCreated(listener)
+    const notification = { id: 'n-1' }
+    mocks.createNotification
+      .mockReturnValueOnce({ created: true, notification })
+      .mockReturnValueOnce({ created: false, notification })
+
+    const input = { ownerId: 7, profile: 'research', dedupeKey: 'event-1', type: 'workflow.completed', severity: 'success' as const, title: 'Done', body: '', source: { kind: 'workflow' as const, id: 'wf-1' } }
+    notificationService.publish(input)
+    notificationService.publish(input)
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener).toHaveBeenCalledWith({ ownerId: 7, profile: 'research', notification })
+    remove()
+  })
+
+  it('reconciles completed and failed cron metadata with stable dedupe keys', async () => {
+    mocks.readFileSync.mockReturnValue(JSON.stringify({ jobs: [
+      { id: 'job-ok', name: 'Backup', last_run_at: '2026-08-07T01:00:00Z', last_status: 'completed' },
+      { job_id: 'job-bad', name: 'Import', last_run_at: '2026-08-07T02:00:00Z', last_status: 'failed', last_error: 'network' },
+    ] }))
+    mocks.createNotification.mockImplementation((input: any) => ({ created: true, notification: input }))
+    const { reconcileCronNotifications } = await import('../../packages/server/src/services/notification-service')
+
+    expect(reconcileCronNotifications(7, 'research')).toBe(2)
+    expect(mocks.readFileSync).toHaveBeenCalledWith('/profiles/research/cron/jobs.json', 'utf8')
+    expect(mocks.createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      ownerId: 7, profile: 'research', dedupeKey: 'cron:job-ok:2026-08-07T01:00:00Z:completed', type: 'cron.completed',
+    }))
+    expect(mocks.createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      ownerId: 7, profile: 'research', dedupeKey: 'cron:job-bad:2026-08-07T02:00:00Z:failed', type: 'cron.failed', body: 'network',
+    }))
+  })
+
+  it('fails closed on missing or malformed cron metadata', async () => {
+    const { reconcileCronNotifications } = await import('../../packages/server/src/services/notification-service')
+    mocks.existsSync.mockReturnValueOnce(false)
+    expect(reconcileCronNotifications(7, 'default')).toBe(0)
+    mocks.existsSync.mockReturnValueOnce(true)
+    mocks.readFileSync.mockReturnValueOnce('{bad json')
+    expect(reconcileCronNotifications(7, 'default')).toBe(0)
+    expect(mocks.createNotification).not.toHaveBeenCalled()
+  })
+})

--- a/tests/server/notification-socket.test.ts
+++ b/tests/server/notification-socket.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../packages/server/src/middleware/user-auth', () => ({
+  authenticateUserToken: vi.fn(),
+  isAuthEnabled: vi.fn(),
+}))
+vi.mock('../../packages/server/src/db/hermes/users-store', () => ({ userCanAccessProfile: vi.fn() }))
+vi.mock('../../packages/server/src/services/notification-service', () => ({
+  notificationService: { onCreated: vi.fn(() => vi.fn()) },
+}))
+
+describe('notification socket isolation', () => {
+  it('uses owner and profile as independent room dimensions', async () => {
+    const { notificationRoom } = await import('../../packages/server/src/services/notification-socket')
+    expect(notificationRoom(7, 'default')).toBe('notification:7:default')
+    expect(notificationRoom(8, 'default')).not.toBe(notificationRoom(7, 'default'))
+    expect(notificationRoom(7, 'research')).not.toBe(notificationRoom(7, 'default'))
+  })
+})

--- a/tests/server/notification-store.test.ts
+++ b/tests/server/notification-store.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DatabaseSync } from 'node:sqlite'
+
+const state = vi.hoisted(() => ({ db: null as DatabaseSync | null }))
+
+vi.mock('../../packages/server/src/db/index', () => ({
+  getDb: () => state.db,
+  getStoragePath: () => ':memory:',
+}))
+
+describe('notification store', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    state.db = new DatabaseSync(':memory:')
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    initAllHermesTables()
+  })
+
+  afterEach(() => {
+    state.db?.close()
+    state.db = null
+    vi.resetModules()
+  })
+
+  it('deduplicates source events and isolates owner plus profile', async () => {
+    const { createNotification, listNotifications } = await import('../../packages/server/src/db/hermes/notification-store')
+
+    const first = createNotification({
+      ownerId: 7,
+      profile: 'default',
+      dedupeKey: 'chat:session-1:run-1:completed',
+      type: 'chat.completed',
+      severity: 'success',
+      title: 'Research finished',
+      body: 'The answer is ready.',
+      source: { kind: 'session', id: 'session-1', route: { name: 'hermes.session', params: { sessionId: 'session-1' } } },
+    })
+    const duplicate = createNotification({
+      ownerId: 7,
+      profile: 'default',
+      dedupeKey: 'chat:session-1:run-1:completed',
+      type: 'chat.completed',
+      severity: 'success',
+      title: 'Duplicate',
+      body: 'Must not create another row.',
+      source: { kind: 'session', id: 'session-1' },
+    })
+    createNotification({
+      ownerId: 8,
+      profile: 'default',
+      dedupeKey: 'chat:session-1:run-1:completed',
+      type: 'chat.completed',
+      severity: 'success',
+      title: 'Other owner',
+      body: '',
+      source: { kind: 'session', id: 'session-1' },
+    })
+    createNotification({
+      ownerId: 7,
+      profile: 'research',
+      dedupeKey: 'chat:session-1:run-1:completed',
+      type: 'chat.completed',
+      severity: 'success',
+      title: 'Other profile',
+      body: '',
+      source: { kind: 'session', id: 'session-1' },
+    })
+
+    expect(duplicate.created).toBe(false)
+    expect(duplicate.notification.id).toBe(first.notification.id)
+    expect(listNotifications({ ownerId: 7, profile: 'default' }).notifications).toEqual([
+      expect.objectContaining({ title: 'Research finished', unread: true }),
+    ])
+  })
+
+  it('persists mark one, mark all, unread count, and owner-safe deletion', async () => {
+    const {
+      createNotification,
+      deleteNotification,
+      listNotifications,
+      markAllNotificationsRead,
+      markNotificationRead,
+    } = await import('../../packages/server/src/db/hermes/notification-store')
+
+    const one = createNotification({ ownerId: 7, profile: 'default', dedupeKey: 'one', type: 'workflow.failed', severity: 'error', title: 'One', body: '', source: { kind: 'workflow', id: 'wf-1' } }).notification
+    const two = createNotification({ ownerId: 7, profile: 'default', dedupeKey: 'two', type: 'approval.requested', severity: 'warning', title: 'Two', body: '', source: { kind: 'session', id: 's-1' } }).notification
+
+    expect(markNotificationRead({ ownerId: 8, profile: 'default', id: one.id })).toBeNull()
+    expect(markNotificationRead({ ownerId: 7, profile: 'default', id: one.id })?.unread).toBe(false)
+    expect(listNotifications({ ownerId: 7, profile: 'default' }).unreadCount).toBe(1)
+    expect(markAllNotificationsRead({ ownerId: 7, profile: 'default' })).toBe(1)
+    expect(listNotifications({ ownerId: 7, profile: 'default' }).unreadCount).toBe(0)
+    expect(deleteNotification({ ownerId: 8, profile: 'default', id: two.id })).toBe(false)
+    expect(deleteNotification({ ownerId: 7, profile: 'default', id: two.id })).toBe(true)
+  })
+})

--- a/tests/server/notifications-controller.test.ts
+++ b/tests/server/notifications-controller.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const store = vi.hoisted(() => ({
+  createNotification: vi.fn(),
+  listNotifications: vi.fn(),
+  markNotificationRead: vi.fn(),
+  markAllNotificationsRead: vi.fn(),
+  deleteNotification: vi.fn(),
+  reconcileCronNotifications: vi.fn(),
+}))
+
+vi.mock('../../packages/server/src/db/hermes/notification-store', () => store)
+vi.mock('../../packages/server/src/services/notification-service', () => ({
+  notificationService: { publish: store.createNotification },
+  reconcileCronNotifications: store.reconcileCronNotifications,
+}))
+vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+  getActiveProfileName: () => 'default',
+}))
+
+function context(overrides: Record<string, unknown> = {}) {
+  return {
+    state: { user: { id: 7 }, profile: { name: 'research' } },
+    query: {},
+    params: {},
+    request: { body: {} },
+    status: 200,
+    body: undefined,
+    ...overrides,
+  } as any
+}
+
+describe('notification controller', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('lists only the authenticated owner in the resolved profile', async () => {
+    store.listNotifications.mockReturnValue({ notifications: [], unreadCount: 0 })
+    const { list } = await import('../../packages/server/src/controllers/hermes/notifications')
+    const ctx = context({ query: { limit: '25', unread: 'true' } })
+
+    await list(ctx)
+
+    expect(store.listNotifications).toHaveBeenCalledWith({
+      ownerId: 7,
+      profile: 'research',
+      limit: 25,
+      unreadOnly: true,
+    })
+    expect(ctx.body).toEqual({ notifications: [], unreadCount: 0 })
+  })
+
+  it('requires authenticated owner and a resolved profile', async () => {
+    const { list } = await import('../../packages/server/src/controllers/hermes/notifications')
+    const missingUser = context({ state: { profile: { name: 'research' } } })
+    const missingProfile = context({ state: { user: { id: 7 } } })
+
+    await list(missingUser)
+    await list(missingProfile)
+
+    expect(missingUser.status).toBe(401)
+    expect(missingProfile.status).toBe(400)
+    expect(store.listNotifications).not.toHaveBeenCalled()
+  })
+
+  it('marks and deletes only records owned by the caller', async () => {
+    store.markNotificationRead.mockReturnValue(null)
+    store.deleteNotification.mockReturnValue(false)
+    const { markRead, remove } = await import('../../packages/server/src/controllers/hermes/notifications')
+    const markCtx = context({ params: { id: 'foreign' } })
+    const deleteCtx = context({ params: { id: 'foreign' } })
+
+    await markRead(markCtx)
+    await remove(deleteCtx)
+
+    expect(markCtx.status).toBe(404)
+    expect(deleteCtx.status).toBe(404)
+    expect(store.markNotificationRead).toHaveBeenCalledWith({ ownerId: 7, profile: 'research', id: 'foreign' })
+    expect(store.deleteNotification).toHaveBeenCalledWith({ ownerId: 7, profile: 'research', id: 'foreign' })
+  })
+
+  it('creates an idempotent event notification in the authenticated scope', async () => {
+    store.createNotification.mockReturnValue({
+      created: true,
+      notification: { id: 'notice-1', unread: true },
+    })
+    const { create } = await import('../../packages/server/src/controllers/hermes/notifications')
+    const ctx = context({ request: { body: {
+      dedupeKey: 'chat:session-1:run-1:completed',
+      type: 'chat.completed',
+      severity: 'success',
+      title: 'Done',
+      body: 'Ready',
+      source: { kind: 'session', id: 'session-1' },
+      ownerId: 999,
+      profile: 'forbidden',
+    } } })
+
+    await create(ctx)
+
+    expect(store.createNotification).toHaveBeenCalledWith({
+      ownerId: 7,
+      profile: 'research',
+      dedupeKey: 'chat:session-1:run-1:completed',
+      type: 'chat.completed',
+      severity: 'success',
+      title: 'Done',
+      body: 'Ready',
+      source: { kind: 'session', id: 'session-1' },
+    })
+    expect(ctx.status).toBe(201)
+  })
+
+  it('rejects invalid notification event payloads', async () => {
+    const { create } = await import('../../packages/server/src/controllers/hermes/notifications')
+    const ctx = context({ request: { body: { type: 'unknown', title: '' } } })
+
+    await create(ctx)
+
+    expect(ctx.status).toBe(400)
+    expect(store.createNotification).not.toHaveBeenCalled()
+  })
+
+  it('marks all notifications read in the current profile', async () => {
+    store.markAllNotificationsRead.mockReturnValue(3)
+    const { markAllRead } = await import('../../packages/server/src/controllers/hermes/notifications')
+    const ctx = context()
+
+    await markAllRead(ctx)
+
+    expect(store.markAllNotificationsRead).toHaveBeenCalledWith({ ownerId: 7, profile: 'research' })
+    expect(ctx.body).toEqual({ updated: 3 })
+  })
+})


### PR DESCRIPTION
Closes #2400
Refs #533, #1411, #1727

## Summary
- add durable owner/profile-scoped in-app notifications with unread/read-all/delete and idempotent dedupe
- deliver realtime updates through an authenticated Notification Socket.IO namespace and a global Naive UI notification center
- cover direct chat completion/failure/approval/clarify, group chat replies/approval, Workflow terminal/node approval, and Cron results
- deep-link to Session, Group Chat Room, Workflow Run, and Cron Job while preserving existing authorization gates

## Verification
- client and server TypeScript checks passed
- production build passed
- focused notification/chat/group/workflow regression: 182 passed
- full suite: 3485 passed, 10 failed, 3 skipped; the same 10 failures reproduce on clean upstream main in this runtime (Hermes bridge/plugin environment probes and Kanban attachment path fixture)
- real production browser verified login, global bell/unread badge, persisted list, Socket delivery, and Naive UI toast

## Identity
- base: f2817378e0607e239ae3b5d9688700b48a63ebc9
- head: 737728c6dfa4f358378c8634b0bc6f35ca758cc0
- tree: dc256b9f071af0a6fcc7ae7406b097b172e74490
- patch SHA-256: 1e58e816c3aeb44b3380435833df711d7b065f2517fc43e26dcfd5be1ed99df0
