### PR TITLE
fix: attribute shared-workspace run changes to the session that wrote them

### DIFF
--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -36,7 +36,7 @@ import { writeModelRunProfileToken } from './model-run-prompt'
 import type { AuthenticatedUser } from '../../../middleware/user-auth'
 import { ensureHermesRunWorkspace } from './workspace'
 import { observeRunChatPetEvent } from '../pet-state-socket'
-import { completeWorkspaceRunCheckpoint, startWorkspaceRunCheckpoint } from './workspace-diff-tracker'
+import { completeWorkspaceRunCheckpoint, noteWorkspaceRunTouchedPaths, startWorkspaceRunCheckpoint } from './workspace-diff-tracker'
 
 const BRIDGE_USAGE_FLUSH_DELAY_MS = 200
 const BRIDGE_TITLE_EVENT_POLL_INTERVAL_MS = 500
@@ -44,6 +44,30 @@ const BRIDGE_TITLE_EVENT_POLL_TIMEOUT_MS = 45_000
 const BRIDGE_GOAL_EVALUATE_TIMEOUT_MS = 120_000
 
 type BridgeRunSource = Extract<ChatRunSource, 'cli' | 'global_agent' | 'workflow'>
+
+/**
+ * File-writing tools whose `path` argument tells us which workspace files a
+ * run actually wrote. Used to prefer the real writer when attributing
+ * workspace diffs across concurrent runs sharing one workspace.
+ */
+const WORKSPACE_WRITE_TOOL_NAMES = new Set(['write_file', 'patch'])
+
+function extractWorkspaceWrittenPaths(toolName: string, args?: Record<string, unknown> | null): string[] {
+  if (!args || !WORKSPACE_WRITE_TOOL_NAMES.has(toolName)) return []
+  const paths: string[] = []
+  const pathArg = args.path
+  if (typeof pathArg === 'string' && pathArg.trim()) paths.push(pathArg)
+  if (toolName === 'patch' && args.mode === 'patch') {
+    const patchText = args.patch
+    if (typeof patchText === 'string') {
+      for (const match of patchText.matchAll(/^\*\*\* (?:Update|Add|Delete|Rename) File: (.+)$/gm)) {
+        const path = match[1]?.trim()
+        if (path) paths.push(path)
+      }
+    }
+  }
+  return paths
+}
 
 function normalizeBridgeRunSource(source?: string | null, sessionSource?: string | null): BridgeRunSource {
   if (sessionSource === 'global_agent' || source === 'global_agent') return 'global_agent'
@@ -1204,6 +1228,14 @@ async function applyBridgeChunkAsync(
       const toolName = (ev.tool_name as string) || ''
       const args = ev.args as Record<string, unknown> | undefined
       const tool = recordBridgeToolStarted(state, sessionId, runMarker, toolName, args, ev.tool_call_id)
+      try {
+        const writtenPaths = extractWorkspaceWrittenPaths(toolName, args)
+        if (writtenPaths.length > 0) {
+          noteWorkspaceRunTouchedPaths({ sessionId, runId: chunk.run_id, paths: writtenPaths })
+        }
+      } catch (err) {
+        bridgeLogger.warn({ err, sessionId, runId: chunk.run_id }, '[workspace-diff] failed to note touched paths')
+      }
       const payload = {
         event: 'tool.started',
         run_id: chunk.run_id,

--- a/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
+++ b/packages/server/src/services/hermes/run-chat/workspace-diff-tracker.ts
@@ -169,6 +169,7 @@ interface WorkspaceRunCheckpoint {
   kind: 'git' | 'filesystem'
   startedAt: number
   files: Map<string, SnapshotFile>
+  touchedPaths: Set<string>
   truncated: boolean
 }
 
@@ -191,6 +192,60 @@ interface SnapshotComparison {
 }
 
 const checkpoints = new Map<string, WorkspaceRunCheckpoint>()
+
+/**
+ * Cross-run claim registry for physical workspace changes.
+ *
+ * A workspace diff can only see *what* changed, not *who* wrote it. When two
+ * runs from different sessions share one workspace directory and overlap in
+ * time, both diffs see the same file change and both attribute it to their own
+ * session — polluting the other session's "Changes this turn" and run-change
+ * history (see issue #2404).
+ *
+ * To fix that, each recorded change is claimed here with a signature of its
+ * final physical state (change type, size after, mtime). A later run whose
+ * diff observes the *same* physical change skips it instead of recording a
+ * duplicate. Runs that explicitly wrote the path via write_file/patch are
+ * preferred as the owner (noteWorkspaceRunTouchedPaths); changes with an
+ * unknown writer are deferred while another run is still active in the same
+ * workspace, so the change is attributed exactly once.
+ */
+interface ClaimedWorkspaceChange {
+  changeType: 'added' | 'modified' | 'deleted'
+  sizeAfter: number | null
+  mtimeMs: number | null
+  sessionId: string
+  runId: string
+  claimedAt: number
+}
+
+const MAX_CLAIM_AGE_MS = 30 * 60 * 1000
+const MAX_CLAIMED_CHANGES = 10_000
+const claimedChanges = new Map<string, ClaimedWorkspaceChange>()
+
+function claimKey(root: string, relPath: string): string {
+  return `${root}\u0000${relPath}`
+}
+
+function changeSignature(changeType: string, sizeAfter: number | null, mtimeMs: number | null): string {
+  return `${changeType}\u0000${sizeAfter ?? ''}\u0000${mtimeMs ?? ''}`
+}
+
+function pruneExpiredClaims(): void {
+  if (claimedChanges.size <= MAX_CLAIMED_CHANGES) {
+    const now = Date.now()
+    for (const [key, claim] of claimedChanges) {
+      if (now - claim.claimedAt > MAX_CLAIM_AGE_MS) claimedChanges.delete(key)
+    }
+    return
+  }
+  // Cap exceeded: drop the oldest claims until back under the cap.
+  const sorted = [...claimedChanges.entries()].sort((left, right) => left[1].claimedAt - right[1].claimedAt)
+  const excess = claimedChanges.size - MAX_CLAIMED_CHANGES
+  for (let index = 0; index < excess; index += 1) {
+    claimedChanges.delete(sorted[index][0])
+  }
+}
 
 function createRunChangeId(runId: string): string {
   return `run:${runId || 'unknown'}:${Date.now().toString(36)}:${randomUUID()}`
@@ -593,6 +648,7 @@ export function startWorkspaceRunCheckpoint(args: {
       kind: 'git',
       startedAt: nowSeconds(),
       files,
+      touchedPaths: new Set<string>(),
       truncated: status.truncated,
     })
     return
@@ -611,8 +667,37 @@ export function startWorkspaceRunCheckpoint(args: {
     kind: 'filesystem',
     startedAt: nowSeconds(),
     files: snapshot.files,
+    touchedPaths: new Set<string>(),
     truncated: scan.truncated || snapshot.truncated,
   })
+}
+
+/**
+ * Record paths this run explicitly wrote via file-writing tool calls
+ * (write_file / patch). The workspace diff itself cannot tell who wrote a
+ * file; this gives the attribution logic a writer signal so the session that
+ * actually performed the write owns the change even when another session's run
+ * completes first.
+ */
+export function noteWorkspaceRunTouchedPaths(args: {
+  sessionId: string
+  runId?: string | null
+  paths: string[]
+}): void {
+  const runId = args.runId || ''
+  if (!runId || args.paths.length === 0) return
+  const checkpoint = checkpoints.get(checkpointKey(args.sessionId, runId))
+  if (!checkpoint) return
+  for (const candidate of args.paths) {
+    let absPath: string
+    try {
+      absPath = resolve(candidate)
+    } catch {
+      continue
+    }
+    if (!isPathInside(checkpoint.root, absPath)) continue
+    checkpoint.touchedPaths.add(relative(checkpoint.root, absPath))
+  }
 }
 
 export function discardWorkspaceRunCheckpoint(args: {
@@ -623,6 +708,16 @@ export function discardWorkspaceRunCheckpoint(args: {
   if (!runId) return
   const key = checkpointKey(args.sessionId, runId)
   checkpoints.delete(key)
+}
+
+function hasActiveOverlappingCheckpoint(checkpoint: WorkspaceRunCheckpoint): boolean {
+  for (const other of checkpoints.values()) {
+    if (other === checkpoint) continue
+    if (other.runId === checkpoint.runId) continue
+    if (other.root !== checkpoint.root) continue
+    return true
+  }
+  return false
 }
 
 export function completeWorkspaceRunCheckpointDraft(args: {
@@ -637,6 +732,7 @@ export function completeWorkspaceRunCheckpointDraft(args: {
   const checkpoint = checkpoints.get(key)
   checkpoints.delete(key)
   if (!checkpoint) return null
+  pruneExpiredClaims()
 
   const status = checkpoint.kind === 'git'
     ? getGitStatusPaths(checkpoint.root)
@@ -669,6 +765,36 @@ export function completeWorkspaceRunCheckpointDraft(args: {
     )
     if (!comparison.changed) continue
     if (isZeroLineDiff(comparison)) continue
+    // Cross-run attribution (see issue #2404): the directory diff cannot tell
+    // who wrote a file, so when several runs share one workspace and overlap,
+    // the same physical change would otherwise be recorded for every run.
+    // 1. A change already claimed by another run with the same final physical
+    //    state (type + size + mtime) is not recorded again.
+    // 2. A change whose writer is unknown to this run is deferred while any
+    //    other run is still active in the same workspace; the still-active run
+    //    will claim it (or the last active run does) so it is attributed once.
+    const finalMtimeMs = after.exists ? after.mtimeMs : (before?.mtimeMs ?? null)
+    const signature = changeSignature(comparison.changeType, comparison.sizeAfter, finalMtimeMs)
+    const claimKeyForPath = claimKey(checkpoint.root, relPath)
+    const existingClaim = claimedChanges.get(claimKeyForPath)
+    if (
+      existingClaim &&
+      existingClaim.runId !== runId &&
+      changeSignature(existingClaim.changeType, existingClaim.sizeAfter, existingClaim.mtimeMs) === signature
+    ) {
+      continue
+    }
+    if (!checkpoint.touchedPaths.has(relPath) && hasActiveOverlappingCheckpoint(checkpoint)) {
+      continue
+    }
+    claimedChanges.set(claimKeyForPath, {
+      changeType: comparison.changeType,
+      sizeAfter: comparison.sizeAfter,
+      mtimeMs: finalMtimeMs,
+      sessionId: checkpoint.sessionId,
+      runId,
+      claimedAt: Date.now(),
+    })
     if (files.length >= MAX_CHANGED_FILES) {
       truncated = true
       break

--- a/tests/server/workspace-diff-tracker.test.ts
+++ b/tests/server/workspace-diff-tracker.test.ts
@@ -530,4 +530,105 @@ describe('workspace diff tracker', () => {
     expect(change).not.toBeNull()
     expect(change?.files.map(file => file.path)).toEqual(['src/app.py'])
   })
+
+  it('attributes a shared-workspace file to the session that wrote it, not to a concurrently running session (issue #2404)', async () => {
+    const {
+      completeWorkspaceRunCheckpoint,
+      noteWorkspaceRunTouchedPaths,
+      startWorkspaceRunCheckpoint,
+    } = await import('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker')
+
+    const workspace = join(root, 'shared-workspace')
+    mkdirSync(workspace)
+
+    // Session A (bystander) is still running while session B writes the file.
+    startWorkspaceRunCheckpoint({ sessionId: 'session-a', runId: 'run-a', workspace })
+    startWorkspaceRunCheckpoint({ sessionId: 'session-b', runId: 'run-b', workspace })
+
+    // Session B writes via write_file (its tool call is tracked); session A never touches it.
+    noteWorkspaceRunTouchedPaths({ sessionId: 'session-b', runId: 'run-b', paths: [join(workspace, 'notes.md')] })
+    writeFileSync(join(workspace, 'notes.md'), '# migration checklist\n')
+
+    // The writer's run completes first and claims the change...
+    const writerChange = completeWorkspaceRunCheckpoint({ sessionId: 'session-b', runId: 'run-b', workspace })
+    expect(writerChange).not.toBeNull()
+    expect(writerChange?.files.map(file => file.path)).toEqual(['notes.md'])
+
+    // ...the bystander finishing later must not record the same physical change.
+    const bystanderChange = completeWorkspaceRunCheckpoint({ sessionId: 'session-a', runId: 'run-a', workspace })
+    expect(bystanderChange).toBeNull()
+
+    const { listWorkspaceRunChangesForSession } = await import('../../packages/server/src/db/hermes/workspace-run-changes-store')
+    expect(listWorkspaceRunChangesForSession('session-a')).toHaveLength(0)
+    expect(listWorkspaceRunChangesForSession('session-b')).toHaveLength(1)
+  })
+
+  it('prefers the real writer even when the bystander run completes first', async () => {
+    const {
+      completeWorkspaceRunCheckpoint,
+      noteWorkspaceRunTouchedPaths,
+      startWorkspaceRunCheckpoint,
+    } = await import('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker')
+
+    const workspace = join(root, 'shared-workspace-writer-last')
+    mkdirSync(workspace)
+
+    startWorkspaceRunCheckpoint({ sessionId: 'session-a', runId: 'run-a', workspace })
+    startWorkspaceRunCheckpoint({ sessionId: 'session-b', runId: 'run-b', workspace })
+    noteWorkspaceRunTouchedPaths({ sessionId: 'session-b', runId: 'run-b', paths: [join(workspace, 'notes.md')] })
+    writeFileSync(join(workspace, 'notes.md'), 'content\n')
+
+    // Bystander completes while the writer is still active: writer unknown to it -> defer.
+    const bystanderChange = completeWorkspaceRunCheckpoint({ sessionId: 'session-a', runId: 'run-a', workspace })
+    expect(bystanderChange).toBeNull()
+
+    const writerChange = completeWorkspaceRunCheckpoint({ sessionId: 'session-b', runId: 'run-b', workspace })
+    expect(writerChange).not.toBeNull()
+    expect(writerChange?.files.map(file => file.path)).toEqual(['notes.md'])
+  })
+
+  it('records an unknown-writer change exactly once across overlapping runs', async () => {
+    const {
+      completeWorkspaceRunCheckpoint,
+      startWorkspaceRunCheckpoint,
+    } = await import('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker')
+
+    const workspace = join(root, 'shared-workspace-unknown-writer')
+    mkdirSync(workspace)
+
+    startWorkspaceRunCheckpoint({ sessionId: 'session-a', runId: 'run-a', workspace })
+    startWorkspaceRunCheckpoint({ sessionId: 'session-b', runId: 'run-b', workspace })
+
+    // Written by a terminal command — no touched path is recorded for either run.
+    writeFileSync(join(workspace, 'generated.json'), '{}\n')
+
+    // The first run to finish defers while the other is still active...
+    const firstChange = completeWorkspaceRunCheckpoint({ sessionId: 'session-a', runId: 'run-a', workspace })
+    expect(firstChange).toBeNull()
+
+    // ...so the change is attributed exactly once, to the last active run.
+    const secondChange = completeWorkspaceRunCheckpoint({ sessionId: 'session-b', runId: 'run-b', workspace })
+    expect(secondChange).not.toBeNull()
+    expect(secondChange?.files.map(file => file.path)).toEqual(['generated.json'])
+  })
+
+  it('ignores touched paths outside the workspace root', async () => {
+    const {
+      completeWorkspaceRunCheckpoint,
+      noteWorkspaceRunTouchedPaths,
+      startWorkspaceRunCheckpoint,
+    } = await import('../../packages/server/src/services/hermes/run-chat/workspace-diff-tracker')
+
+    const workspace = join(root, 'workspace-outside-touch')
+    mkdirSync(workspace)
+    const outsidePath = join(root, 'outside.txt')
+    writeFileSync(outsidePath, 'x\n')
+
+    startWorkspaceRunCheckpoint({ sessionId: 'session-outside', runId: 'run-outside', workspace })
+    noteWorkspaceRunTouchedPaths({ sessionId: 'session-outside', runId: 'run-outside', paths: [outsidePath] })
+    writeFileSync(join(workspace, 'real.txt'), 'y\n')
+    const change = completeWorkspaceRunCheckpoint({ sessionId: 'session-outside', runId: 'run-outside', workspace })
+    expect(change).not.toBeNull()
+    expect(change?.files.map(file => file.path)).toEqual(['real.txt'])
+  })
 })


### PR DESCRIPTION
Fixes #2404

## Problem

When two runs from **different sessions** share one workspace directory and overlap in time, each run's workspace directory diff sees the *other* run's file changes and records them for its own session. The bystander session's UI then shows a false "Changes this turn" entry and its `workspace_run_changes` history lists files it never touched.

Root cause: `completeWorkspaceRunCheckpointDraft` diffs the whole workspace across the run window and attributes **everything** that changed to `(sessionId, runId)` — the diff knows *what* changed, not *who* wrote it.

## Fix

**`workspace-diff-tracker.ts`**
- Each recorded change is now **claimed** in a module-level registry keyed by `(workspace root, relative path)` with a signature of the change's final physical state (change type + size after + mtime).
- A run whose diff observes a change **already claimed by another run** with the same physical signature skips it — no duplicate attribution.
- A change whose writer is **unknown** to the run (e.g. written via terminal) is **deferred** while any other run is still active in the same workspace, so the change is attributed exactly once (by the last active run).
- Claims are bounded (10k entries, 30 min TTL).

**`handle-bridge-run.ts`**
- Paths written by `write_file` / `patch` tool calls are recorded per run (`noteWorkspaceRunTouchedPaths`), so the **real writer owns the change even when a bystander run completes first**.

**Tests** (`workspace-diff-tracker.test.ts`, +4)
- Writer completes first → only the writer's session records the change (the exact #2404 scenario).
- Bystander completes first → change is still attributed to the real writer (deferred while the writer is active).
- Unknown-writer change across overlapping runs → recorded exactly once.
- Touched paths outside the workspace root are ignored.

## Notes / limitations

- Perfect attribution is impossible from a directory diff alone; the writer preference covers `write_file`/`patch` (the common case). Terminal-written files are attributed once (to the last active run) — no more cross-session pollution, but the owner may be the bystander if both runs wrote via terminal concurrently.
- The ekko coding-agent path (`handle-ekko-agent-run.ts`) records tool calls with agent-specific tool names (Write/Edit/…) and is not wired yet — follow-up.

Verified: `vitest run` — all workspace-diff/group-chat/bridge/sessions tests pass; `tsc --noEmit -p packages/server/tsconfig.json` clean. (5 unrelated test files fail on a clean checkout in this environment: auth/plugins/agent-bridge-profile-env/learn-command/kanban.)