### PR TITLE
Preserve offline Agent owner avatars

### DIFF
--- a/docs/chat-chain-changes/2026-08-07-group-chat-offline-agent-owner-avatar.md
+++ b/docs/chat-chain-changes/2026-08-07-group-chat-offline-agent-owner-avatar.md
@@ -1,0 +1,15 @@
+---
+date: 2026-08-07
+pr: pending
+feature: Preserve offline group Agent owner avatars
+impact: Room Agents keep their inviter avatar badge when that room member is offline, while offline Agents remain visible with an offline connection status.
+---
+
+Realtime join and member-update payloads now use persisted room membership as
+their canonical public member view. A member going offline does not remove
+their room identity or avatar, so other clients can continue resolving the
+owner badge for Agents that member invited.
+
+The in-memory member view remains a fallback when persistent storage is
+unavailable. Explicitly removing a room member still deletes that membership,
+and explicitly removing an Agent still removes it from the Agent roster.

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -1648,6 +1648,28 @@ export class GroupChatServer {
         })
     }
 
+    private getRoomMemberViews(roomId: string, room = this.rooms.get(roomId)): MemberView[] {
+        const storedMembers = typeof this.storage.getRoomMembers === 'function'
+            ? this.storage.getRoomMembers(roomId)
+            : []
+        if (storedMembers.length > 0) return storedMembers
+        return (room?.getMembersList() || []).map(({
+            id,
+            userId,
+            name,
+            description,
+            joinedAt,
+            avatar,
+        }) => ({
+            id,
+            userId,
+            name,
+            description,
+            joinedAt,
+            avatar,
+        }))
+    }
+
     broadcastRoomAgents(roomId: string): RoomAgent[] {
         const agents = this.storage.getRoomAgents(roomId)
         this.nsp.to(roomId).emit('agents_updated', {
@@ -1696,8 +1718,7 @@ export class GroupChatServer {
             socket.leave(roomId)
         }
 
-        const members = room?.getMembersList()
-            || (typeof this.storage.getRoomMembers === 'function' ? this.storage.getRoomMembers(roomId) : [])
+        const members = this.getRoomMemberViews(roomId, room)
         this.nsp.to(roomId).emit('member_left', {
             roomId,
             memberId: normalizedUserId,
@@ -2153,11 +2174,12 @@ export class GroupChatServer {
         socket.join(roomId)
 
         if (source !== 'agent') {
+            const members = this.getRoomMemberViews(roomId, room)
             socket.to(roomId).emit('member_joined', {
                 roomId,
                 memberId: userId,
                 memberName: userName,
-                members: room.getMembersList(),
+                members,
             })
         }
 
@@ -2173,7 +2195,7 @@ export class GroupChatServer {
         ack?.({
             roomId,
             roomName: room.name,
-            members: room.getMembersList(),
+            members: this.getRoomMemberViews(roomId, room),
             messages,
             agents,
             rooms: typeof socket.data?.inviteGuestRoomId === 'string' ? [roomId] : this.getRoomIds(),
@@ -2250,7 +2272,7 @@ export class GroupChatServer {
             joined.room.addOrUpdateMember(socket.id, userId, name, description, 'human', avatar)
             this.userInfoMap.set(userId, { name, description })
 
-            const members = joined.room.getMembersList()
+            const members = this.getRoomMemberViews(roomId, joined.room)
             this.nsp.to(roomId).emit('member_updated', {
                 roomId,
                 memberId: userId,
@@ -2768,7 +2790,7 @@ export class GroupChatServer {
                         roomId: rid,
                         memberId: member?.userId || socketId,
                         memberName: member?.name || `User-${socketId.slice(0, 6)}`,
-                        members: room.getMembersList(),
+                        members: this.getRoomMemberViews(rid, room),
                     })
                 }
             }

--- a/tests/server/group-chat-baseline.test.ts
+++ b/tests/server/group-chat-baseline.test.ts
@@ -249,6 +249,36 @@ describe('group chat baseline behavior', () => {
     expect(managerView[0]).not.toHaveProperty('remoteOrigin')
   })
 
+  it('returns an offline Agent owner avatar to other room members', async () => {
+    const storage = groupServer.getStorage()
+    const ownerAvatar = JSON.stringify({ type: 'generated', seed: 'offline-owner' })
+    storage.saveRoom('room-1', 'Shared Room', 'ROOM1')
+    storage.addRoomMember('room-1', 'guest-owner', 'Offline Owner', '', ownerAvatar)
+    storage.addRoomAgent('room-1', 'remote-owned', 'default', 'Owned Agent', '', 1, {
+      executorType: 'remote',
+      ownerMemberId: 'guest-owner',
+      remoteOrigin: 'http://127.0.0.1:8648',
+    })
+
+    const viewer = await connectGroupChatClient(port, 'guest-viewer', 'Viewer', { inviteCode: 'ROOM1' })
+    harness.sockets.push(viewer)
+    const joined = await emitAck<any>(viewer, 'join', { roomId: 'room-1', name: 'Viewer' })
+
+    expect(joined.agents).toEqual([
+      expect.objectContaining({
+        ownerMemberId: 'guest-owner',
+        connectionStatus: 'offline',
+      }),
+    ])
+    expect(joined.members).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        userId: 'guest-owner',
+        name: 'Offline Owner',
+        avatar: ownerAvatar,
+      }),
+    ]))
+  })
+
   it('allows an invite member to remove only their own remote Agent', async () => {
     const storage = groupServer.getStorage()
     storage.saveRoom('room-1', 'Shared Room', 'ROOM1')


### PR DESCRIPTION
## Summary

- use persisted room membership as the canonical public member view for join and realtime member payloads
- preserve the in-memory member view as a fallback when persistent storage is unavailable
- add regression coverage for an offline Agent owner avatar and verify the Agent itself remains listed with `connectionStatus: offline`
- document the group-chat chain behavior change

## Root cause

The client resolves an Agent's owner avatar by matching `ownerMemberId` against
the room member list. The server populated that list from the in-memory
`ChatRoom`, which may not contain an owner who is offline or has not rejoined
since the process reconstructed the room, even though the owner's member record
and avatar remain persisted.

## Impact

Agent owner avatar badges remain visible when their inviting member is offline.
Offline Agents continue to remain in the Agent roster and are removed only
through the explicit Agent removal flow. Explicit room-member removal still
deletes that member from the public membership view.

## Validation

- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run harness:check`
- `npm run test -- --run tests/server/group-chat-*.test.ts` (21 files, 217 tests)
- `git diff --check`
