### PR TITLE
fix(group-chat): stabilize Agent handoff flow

### DIFF
--- a/docs/chat-chain-changes/2026-08-07-allow-http-group-chat-handoff.md
+++ b/docs/chat-chain-changes/2026-08-07-allow-http-group-chat-handoff.md
@@ -1,0 +1,14 @@
+---
+date: 2026-08-07
+pr: pending
+feature: Allow HTTP group chat Agent handoff
+impact: Remote Agent handoff can connect to a public group chat origin over either HTTP or HTTPS.
+---
+
+Cloud-origin validation now accepts remote HTTP origins for Agent handoff,
+outbound Relay connection, and persisted Relay restoration. URL credentials,
+paths, queries, fragments, and non-HTTP protocols remain rejected.
+
+HTTP does not protect handoff tickets, request secrets, Relay credentials, or
+room traffic from network interception. Deployments that require transport
+confidentiality must continue to use HTTPS.

--- a/docs/chat-chain-changes/2026-08-07-client-random-uuid-fallback.md
+++ b/docs/chat-chain-changes/2026-08-07-client-random-uuid-fallback.md
@@ -1,0 +1,15 @@
+---
+date: 2026-08-07
+pr: pending
+feature: Compatible client UUID generation
+impact: Invite-only group chat and other browser flows continue working when crypto.randomUUID is unavailable.
+---
+
+The remote Agent handoff introduced request IDs that called
+`crypto.randomUUID` directly. Client UUID generation now checks that the API is
+callable before using it. Browsers that expose Web Crypto without `randomUUID`
+fall back to a standards-compatible version 4 UUID generated with
+`crypto.getRandomValues`.
+
+The shared group-chat invite page uses the compatible generator for Agent-link
+state and request IDs, and generated avatar seeds.

--- a/docs/chat-chain-changes/2026-08-07-group-chat-link-login-return.md
+++ b/docs/chat-chain-changes/2026-08-07-group-chat-link-login-return.md
@@ -1,0 +1,11 @@
+---
+date: 2026-08-07
+pr: pending
+feature: Return to Agent link after login
+impact: First-time Agent handoff users return to the authorization page instead of the default chat page.
+---
+
+The login route and login form now share the same validated redirect resolver.
+An Agent handoff that requires authentication preserves the complete
+`/group-chat-link` path and query parameters through login. Direct logins
+without a redirect continue to open `/hermes/chat`.

--- a/packages/client/src/router/index.ts
+++ b/packages/client/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHashHistory } from 'vue-router'
 import { hasApiKey, isStoredSuperAdmin } from '@/api/client'
 import { hasDesktopBrowserBridge } from '@/utils/desktop-bridge'
+import { resolveLoginRedirect } from '@/utils/login-redirect'
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -231,7 +232,7 @@ router.beforeEach(async (to, _from, next) => {
   if (to.meta.public) {
     // Already has key, skip login
     if (to.name === 'login' && hasApiKey() && !isDesktopShell()) {
-      next({ path: '/hermes/chat' })
+      next(resolveLoginRedirect(to.query.redirect))
       return
     }
     next()

--- a/packages/client/src/utils/client-random.ts
+++ b/packages/client/src/utils/client-random.ts
@@ -1,0 +1,15 @@
+export function generateClientUuid(): string {
+    const webCrypto = globalThis.crypto
+    if (typeof webCrypto?.randomUUID === 'function') {
+        return webCrypto.randomUUID()
+    }
+    if (typeof webCrypto?.getRandomValues !== 'function') {
+        throw new Error('Secure random number generation is unavailable')
+    }
+
+    const bytes = webCrypto.getRandomValues(new Uint8Array(16))
+    bytes[6] = (bytes[6] & 0x0f) | 0x40
+    bytes[8] = (bytes[8] & 0x3f) | 0x80
+    const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}

--- a/packages/client/src/utils/login-redirect.ts
+++ b/packages/client/src/utils/login-redirect.ts
@@ -1,0 +1,8 @@
+const DEFAULT_LOGIN_REDIRECT = '/hermes/chat'
+
+export function resolveLoginRedirect(value: unknown): string {
+  const redirect = typeof value === 'string' ? value : ''
+  return redirect.startsWith('/') && !redirect.startsWith('//')
+    ? redirect
+    : DEFAULT_LOGIN_REDIRECT
+}

--- a/packages/client/src/views/LoginView.vue
+++ b/packages/client/src/views/LoginView.vue
@@ -5,6 +5,7 @@ import { useI18n } from "vue-i18n";
 import { setApiKey, clearApiKey, hasApiKey } from "@/api/client";
 import { fetchAuthStatus, loginWithPassword } from "@/api/auth";
 import { isDesktopShell } from "@/utils/desktop-bridge";
+import { resolveLoginRedirect } from "@/utils/login-redirect";
 import { useTheme } from "@/composables/useTheme";
 
 const { t } = useI18n();
@@ -24,12 +25,7 @@ if (desktopShell) {
   // request can reuse them and show an unrelated expiry notice.
   clearApiKey();
 } else if (hasApiKey()) {
-  router.replace(safeRedirectPath());
-}
-
-function safeRedirectPath(): string {
-  const redirect = typeof route.query.redirect === "string" ? route.query.redirect : "";
-  return redirect.startsWith("/") && !redirect.startsWith("//") ? redirect : "/hermes/chat";
+  router.replace(resolveLoginRedirect(route.query.redirect));
 }
 
 onMounted(async () => {
@@ -58,7 +54,7 @@ async function handlePasswordLogin() {
     const session = await loginWithPassword(username.value.trim(), password.value);
     setApiKey(session.token);
     activateUserTheme(session.userId, session.theme);
-    router.replace(safeRedirectPath());
+    router.replace(resolveLoginRedirect(route.query.redirect));
   } catch (err: any) {
     if (err.status === 429 || err.status === 503) {
       errorMsg.value = t("login.tooManyAttempts");

--- a/packages/client/src/views/hermes/SharedGroupChatView.vue
+++ b/packages/client/src/views/hermes/SharedGroupChatView.vue
@@ -15,6 +15,7 @@ import {
     type RemoteGroupAgentDescriptor,
 } from '@/api/hermes/group-chat-agent-link'
 import { GROUP_CHAT_MEMBER_REMOVED, useGroupChatStore } from '@/stores/hermes/group-chat'
+import { generateClientUuid } from '@/utils/client-random'
 import { copyToClipboard } from '@/utils/clipboard'
 import { parseStoredAvatar } from '@/utils/group-agent-avatar'
 
@@ -70,9 +71,7 @@ const agentLinkStatusText = computed(() => {
 })
 
 function randomState(): string {
-    return typeof crypto !== 'undefined' && 'randomUUID' in crypto
-        ? crypto.randomUUID()
-        : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+    return generateClientUuid()
 }
 
 function randomSecret(): string {
@@ -84,7 +83,7 @@ function randomSecret(): string {
 }
 
 function randomRequestId(): string {
-    return crypto.randomUUID()
+    return generateClientUuid()
 }
 
 function normalizeTargetOrigin(value: string): string {
@@ -428,9 +427,7 @@ async function submitGuestName(): Promise<void> {
 }
 
 function randomizeGuestAvatar(): void {
-    const randomPart = typeof crypto !== 'undefined' && 'randomUUID' in crypto
-        ? crypto.randomUUID()
-        : Math.random().toString(36).slice(2)
+    const randomPart = generateClientUuid()
     guestAvatarDraft.value = { type: 'generated', seed: `guest-${randomPart}` }
     guestAvatarError.value = ''
 }

--- a/packages/server/src/controllers/hermes/group-chat-agent-link.ts
+++ b/packages/server/src/controllers/hermes/group-chat-agent-link.ts
@@ -256,11 +256,6 @@ function normalizeCloudOrigin(value: unknown): string {
   if (url.protocol !== 'https:' && url.protocol !== 'http:') {
     throw new Error('Cloud URL must use HTTP or HTTPS')
   }
-  const host = url.hostname.toLowerCase()
-  const loopback = host === 'localhost' || host === '127.0.0.1' || host === '::1'
-  if (url.protocol === 'http:' && !loopback) {
-    throw new Error('Remote group chat server must use HTTPS')
-  }
   return url.origin
 }
 

--- a/packages/server/src/services/hermes/group-chat/agent-relay.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-relay.ts
@@ -119,17 +119,12 @@ function relayError(message: string, code = 'GROUP_AGENT_RELAY_ERROR'): Error {
   return error
 }
 
-function normalizeOrigin(value: unknown, options: { allowHttpPrivate?: boolean } = {}): string {
+function normalizeOrigin(value: unknown): string {
   const raw = String(value || '').trim()
   const url = new URL(raw)
   if (url.username || url.password || url.search || url.hash) throw new Error('Connection URL must not contain credentials, query, or fragment')
   if (url.pathname !== '/' && url.pathname !== '') throw new Error('Connection URL must be an origin without a path')
   if (url.protocol !== 'https:' && url.protocol !== 'http:') throw new Error('Connection URL must use HTTP or HTTPS')
-  if (url.protocol === 'http:' && !options.allowHttpPrivate) {
-    const host = url.hostname.toLowerCase()
-    const loopback = host === 'localhost' || host === '127.0.0.1' || host === '::1'
-    if (!loopback) throw new Error('Remote group chat server must use HTTPS')
-  }
   return url.origin
 }
 
@@ -926,7 +921,7 @@ export class GroupAgentRelayServer {
         next(relayError('Unsupported group Agent relay protocol', 'GROUP_AGENT_PROTOCOL_VERSION'))
         return
       }
-      const targetOrigin = normalizeOrigin(auth.targetOrigin, { allowHttpPrivate: true })
+      const targetOrigin = normalizeOrigin(auth.targetOrigin)
       const pairingTicket = String(auth.pairingTicket || '').trim()
       if (pairingTicket) {
         const request = claimGroupAgentPairingTicket(pairingTicket)
@@ -1631,7 +1626,7 @@ export class GroupAgentOutboundRelayManager {
     agent: RemoteGroupAgentDescriptor
   }): Promise<{ connectorId: string; roomId?: string }> {
     const cloudOrigin = normalizeOrigin(input.cloudOrigin)
-    const targetOrigin = normalizeOrigin(input.targetOrigin, { allowHttpPrivate: true })
+    const targetOrigin = normalizeOrigin(input.targetOrigin)
     const ticket = String(input.pairingTicket || '').trim()
     if (!ticket) throw new Error('pairingTicket is required')
     const key = `pairing:${ticket.slice(0, 12)}`
@@ -1795,7 +1790,7 @@ export class GroupAgentOutboundRelayManager {
           if (!UUID_PATTERN.test(connectorId) || !/^[a-zA-Z0-9_-]{40,128}$/.test(credential)) continue
           links.push({
             cloudOrigin: normalizeOrigin(link.cloudOrigin),
-            targetOrigin: normalizeOrigin(link.targetOrigin, { allowHttpPrivate: true }),
+            targetOrigin: normalizeOrigin(link.targetOrigin),
             connectorId,
             credential,
             agent: normalizeRemoteGroupAgentDescriptor(link.agent),

--- a/tests/client/client-random.test.ts
+++ b/tests/client/client-random.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { generateClientUuid } from '../../packages/client/src/utils/client-random'
+
+describe('client random UUID generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses crypto.randomUUID when it is available', () => {
+    const randomUUID = vi.fn(() => '11111111-2222-4333-8444-555555555555')
+    vi.stubGlobal('crypto', { randomUUID })
+
+    expect(generateClientUuid()).toBe('11111111-2222-4333-8444-555555555555')
+    expect(randomUUID).toHaveBeenCalledOnce()
+  })
+
+  it('generates a version 4 UUID when randomUUID is unavailable', () => {
+    vi.stubGlobal('crypto', {
+      getRandomValues: (bytes: Uint8Array) => {
+        bytes.set(Array.from({ length: 16 }, (_, index) => index))
+        return bytes
+      },
+    })
+
+    expect(generateClientUuid()).toBe('00010203-0405-4607-8809-0a0b0c0d0e0f')
+  })
+
+  it('generates a version 4 UUID when randomUUID exists but is not callable', () => {
+    vi.stubGlobal('crypto', {
+      randomUUID: undefined,
+      getRandomValues: (bytes: Uint8Array) => {
+        bytes.fill(0xff)
+        return bytes
+      },
+    })
+
+    expect(generateClientUuid()).toBe('ffffffff-ffff-4fff-bfff-ffffffffffff')
+  })
+})

--- a/tests/client/group-chat-panel-workspace-source.test.ts
+++ b/tests/client/group-chat-panel-workspace-source.test.ts
@@ -204,6 +204,8 @@ describe('GroupChatPanel workspace save handling', () => {
     expect(sharedView).toContain('/?groupChatAgentLink=1#/group-chat-link')
     expect(sharedView).toContain('v-model:value="targetOriginDraft"')
     expect(sharedView).toContain("const targetOriginDraft = ref('http://127.0.0.1:8748')")
+    expect(sharedView).toContain("import { generateClientUuid } from '@/utils/client-random'")
+    expect(sharedView).not.toContain('crypto.randomUUID')
     expect(sharedView).not.toContain('probeTargets')
     expect(sharedView).not.toContain('detectedTargetOrigins')
     expect(sharedView).not.toContain('class="agent-link-launcher"')

--- a/tests/client/login-view.test.ts
+++ b/tests/client/login-view.test.ts
@@ -99,6 +99,20 @@ describe('LoginView password login', () => {
     expect(mockReplace).toHaveBeenCalledWith('/hermes/chat')
   })
 
+  it('returns to the Agent link page after the first login', async () => {
+    const redirect = '/group-chat-link?cloudOrigin=http%3A%2F%2F47.243.215.84%3A8088&requestId=handoff-id'
+    mockRoute.query = { redirect }
+    mockLoginWithPassword.mockResolvedValue({ token: 'jwt-token', userId: 7, theme: null })
+    const wrapper = mount(LoginView)
+
+    const inputs = wrapper.findAll('input.login-input')
+    await inputs[0].setValue('admin')
+    await inputs[1].setValue('123456')
+    await wrapper.find('form.login-form').trigger('submit')
+
+    expect(mockReplace).toHaveBeenCalledWith(redirect)
+  })
+
   it('shows the default login hint', () => {
     const wrapper = mount(LoginView)
 

--- a/tests/client/router-login-redirect.test.ts
+++ b/tests/client/router-login-redirect.test.ts
@@ -39,6 +39,21 @@ describe('router login redirect', () => {
     expect(router.currentRoute.value.name).toBe('hermes.chat')
   }, 60_000)
 
+  it('returns an authenticated Agent handoff login to the link page', async () => {
+    mockHasApiKey.mockReturnValue(true)
+    const router = await loadRouter()
+    const redirect = '/group-chat-link?cloudOrigin=http%3A%2F%2F47.243.215.84%3A8088&requestId=handoff-id'
+
+    await router.push({ name: 'login', query: { redirect } })
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('groupChat.link')
+    expect(router.currentRoute.value.query).toEqual({
+      cloudOrigin: 'http://47.243.215.84:8088',
+      requestId: 'handoff-id',
+    })
+  })
+
   it('does not redirect desktop login when a stale token exists', async () => {
     mockHasApiKey.mockReturnValue(true)
     ;(window as any).hermesDesktop = { isDesktop: true }

--- a/tests/server/group-chat-handoff-security.test.ts
+++ b/tests/server/group-chat-handoff-security.test.ts
@@ -92,6 +92,35 @@ describe('group chat Agent handoff security limits', () => {
     expect(fetchMock).toHaveBeenCalledOnce()
   })
 
+  it('allows handoff requests to a remote HTTP group chat server', async () => {
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = String(input)
+      if (url.endsWith('/submit')) {
+        return Promise.resolve(new Response(JSON.stringify({
+          request: { expiresAt: Date.now() + GROUP_AGENT_PAIRING_REQUEST_TTL_MS },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }))
+      }
+      return new Promise<Response>(() => undefined)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const ctx = handoffContext({
+      ...handoffBody(),
+      cloudOrigin: 'http://47.243.215.84:8088',
+    })
+
+    await connectLocalAgentHandoff(ctx)
+
+    expect(ctx.status).toBe(202)
+    expect(ctx.body).toEqual({ ok: true, accepted: true })
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^http:\/\/47\.243\.215\.84:8088\/api\/hermes\/group-chat\/invites\/ROOMCODE\/agent-links\//),
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
   it('limits concurrent handoffs for one authenticated local user', async () => {
     const fetchMock = vi.fn((input: string | URL | Request) => {
       const url = String(input)


### PR DESCRIPTION
## What changed

- use a Web Crypto UUID v4 fallback when `crypto.randomUUID` is unavailable
- allow remote Agent handoff and Relay origins over HTTP as well as HTTPS
- preserve the complete `/group-chat-link` redirect, including its handoff query parameters, through first login
- add focused client and server regression coverage

## Why

The handoff client called `crypto.randomUUID()` unconditionally in browsers
that may not implement it. The authenticated-login router path also wrapped
the saved redirect in a `{ path }` location, which matched the link route but
discarded its query parameters and broke the handoff. Remote HTTP origins were
rejected even when explicitly configured.

## Impact

First-time users return to the Agent link page after login with the request
credentials intact, compatible browsers can generate secure request IDs
without `randomUUID`, and configured public HTTP origins are accepted.

HTTP does not encrypt handoff tickets, request secrets, Relay credentials, or
room traffic. Deployments requiring transport confidentiality should use
HTTPS.

## Validation

- `npx vitest run tests/client/login-view.test.ts tests/client/router-login-redirect.test.ts tests/client/client-random.test.ts tests/client/group-chat-panel-workspace-source.test.ts` (33 tests)
- `npx vitest run tests/server/group-chat-handoff-security.test.ts tests/server/group-chat-baseline.test.ts` (24 tests)
- `npx vue-tsc -b --pretty false`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run harness:check`
- `git diff --check`
