### PR TITLE
feat(group-chat): add remote Agent file transfers

### DIFF
--- a/docs/chat-chain-changes/2026-08-07-group-chat-agent-file-transfer.md
+++ b/docs/chat-chain-changes/2026-08-07-group-chat-agent-file-transfer.md
@@ -1,0 +1,15 @@
+---
+date: 2026-08-07
+pr: pending
+feature: Remote Agent workspace file transfer
+impact: Approved remote group-chat Agents can upload and download binary files during a run.
+---
+
+The short-lived remote workspace grant now authorizes bounded binary transfers
+in addition to the existing JSON file operations. Agents can stream downloads
+and uploads of up to 20 MiB while path confinement, sensitive-file blocking,
+symbolic-link rejection, and per-run request limits remain enforced.
+
+Downloads return a SHA-256 digest. Replacing an existing file requires the
+matching digest so concurrent user or Agent edits cannot be overwritten
+silently.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5191,6 +5191,76 @@
         }
       }
     },
+    "/api/hermes/group-chat/remote-workspace/v1/file": {
+      "get": {
+        "tags": [
+          "Group Chat"
+        ],
+        "summary": "Get file",
+        "description": "GET /api/hermes/group-chat/remote-workspace/v1/file",
+        "operationId": "downloadRemoteWorkspaceFile",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Group Chat"
+        ],
+        "summary": "Update file",
+        "description": "PUT /api/hermes/group-chat/remote-workspace/v1/file",
+        "operationId": "uploadRemoteWorkspaceFileContent",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
     "/api/hermes/group-chat/rooms": {
       "post": {
         "tags": [

--- a/packages/server/src/controllers/hermes/group-chat-remote-workspace.ts
+++ b/packages/server/src/controllers/hermes/group-chat-remote-workspace.ts
@@ -2,12 +2,50 @@ import type { Context } from 'koa'
 import { logger } from '../../services/logger'
 import { getGroupChatRuntimeServer } from '../../services/hermes/group-chat/runtime'
 import { beginRemoteWorkspaceGrantOperation } from '../../services/hermes/group-chat/remote-workspace-auth'
-import { performRemoteWorkspaceAction } from '../../services/hermes/group-chat/remote-workspace-files'
+import {
+  MAX_REMOTE_WORKSPACE_TRANSFER_BYTES,
+  openRemoteWorkspaceDownload,
+  performRemoteWorkspaceAction,
+  uploadRemoteWorkspaceFile,
+} from '../../services/hermes/group-chat/remote-workspace-files'
+import { buildFileContentHeaders } from '../../services/hermes/file-preview'
 
 function bearerToken(ctx: Context): string {
   const authorization = ctx.get('Authorization')
   const match = authorization.match(/^Bearer ([a-zA-Z0-9_-]+)$/)
   return match?.[1] || ''
+}
+
+function authorizedWorkspace(
+  ctx: Context,
+  grant: NonNullable<ReturnType<typeof beginRemoteWorkspaceGrantOperation>>['grant'],
+): string | null {
+  const server = getGroupChatRuntimeServer()
+  const room = server?.getStorage().getRoom(grant.roomId)
+  if (
+    !room
+    || Number(room.allowRemoteWorkspaceAccess || 0) !== 1
+    || String(room.workspace || '').trim() !== grant.workspace
+  ) {
+    ctx.status = 403
+    ctx.body = { error: 'Remote workspace access is disabled', code: 'permission_denied' }
+    return null
+  }
+  const workspace = grant.workspace
+  if (!workspace) {
+    ctx.status = 404
+    ctx.body = { error: 'Room workspace not found', code: 'workspace_not_found' }
+    return null
+  }
+  return workspace
+}
+
+function handleRemoteWorkspaceError(ctx: Context, error: any): void {
+  ctx.status = Number(error?.status || (error?.code === 'ENOENT' ? 404 : 500))
+  ctx.body = {
+    error: error?.message || 'Remote workspace action failed',
+    code: error?.code || 'remote_workspace_error',
+  }
 }
 
 export async function remoteWorkspaceAction(ctx: Context): Promise<void> {
@@ -20,23 +58,8 @@ export async function remoteWorkspaceAction(ctx: Context): Promise<void> {
   }
   const { grant } = operation
   try {
-    const server = getGroupChatRuntimeServer()
-    const room = server?.getStorage().getRoom(grant.roomId)
-    if (
-      !room
-      || Number(room.allowRemoteWorkspaceAccess || 0) !== 1
-      || String(room.workspace || '').trim() !== grant.workspace
-    ) {
-      ctx.status = 403
-      ctx.body = { error: 'Remote workspace access is disabled', code: 'permission_denied' }
-      return
-    }
-    const workspace = grant.workspace
-    if (!workspace) {
-      ctx.status = 404
-      ctx.body = { error: 'Room workspace not found', code: 'workspace_not_found' }
-      return
-    }
+    const workspace = authorizedWorkspace(ctx, grant)
+    if (!workspace) return
     const body = (ctx.request.body || {}) as Record<string, unknown>
     const action = String(body.action || '')
     ctx.body = await performRemoteWorkspaceAction(workspace, {
@@ -51,11 +74,99 @@ export async function remoteWorkspaceAction(ctx: Context): Promise<void> {
       path: String(body.path || '').slice(0, 500),
     }, '[GroupChat] remote workspace action')
   } catch (error: any) {
-    ctx.status = Number(error?.status || (error?.code === 'ENOENT' ? 404 : 500))
-    ctx.body = {
-      error: error?.message || 'Remote workspace action failed',
-      code: error?.code || 'remote_workspace_error',
+    handleRemoteWorkspaceError(ctx, error)
+  } finally {
+    operation.finish()
+  }
+}
+
+export async function downloadRemoteWorkspaceFile(ctx: Context): Promise<void> {
+  ctx.set('Cache-Control', 'no-store')
+  const operation = beginRemoteWorkspaceGrantOperation(bearerToken(ctx))
+  if (!operation) {
+    ctx.status = 401
+    ctx.body = { error: 'Remote workspace authorization is invalid or expired', code: 'invalid_grant' }
+    return
+  }
+  const { grant } = operation
+  try {
+    const workspace = authorizedWorkspace(ctx, grant)
+    if (!workspace) return
+    const download = await openRemoteWorkspaceDownload(workspace, ctx.query.path)
+    const headers = buildFileContentHeaders({
+      fileName: download.path,
+      mime: 'application/octet-stream',
+      size: download.size,
+      download: true,
+    })
+    for (const [name, value] of Object.entries(headers)) ctx.set(name, value)
+    ctx.set('ETag', `"sha256:${download.sha256}"`)
+    ctx.set('X-Content-SHA256', download.sha256)
+    ctx.body = download.stream
+    logger.info({
+      roomId: grant.roomId,
+      agentId: grant.agentId,
+      runId: grant.runId,
+      action: 'download',
+      path: download.path.slice(0, 500),
+      size: download.size,
+    }, '[GroupChat] remote workspace file transfer')
+  } catch (error: any) {
+    handleRemoteWorkspaceError(ctx, error)
+  } finally {
+    operation.finish()
+  }
+}
+
+export async function uploadRemoteWorkspaceFileContent(ctx: Context): Promise<void> {
+  ctx.set('Cache-Control', 'no-store')
+  const operation = beginRemoteWorkspaceGrantOperation(bearerToken(ctx))
+  if (!operation) {
+    ctx.status = 401
+    ctx.body = { error: 'Remote workspace authorization is invalid or expired', code: 'invalid_grant' }
+    return
+  }
+  const { grant } = operation
+  try {
+    const workspace = authorizedWorkspace(ctx, grant)
+    if (!workspace) return
+    const contentType = ctx.get('Content-Type').split(';')[0]?.trim().toLowerCase()
+    if (contentType !== 'application/octet-stream') {
+      ctx.status = 415
+      ctx.body = { error: 'Upload must use application/octet-stream', code: 'unsupported_media_type' }
+      return
     }
+    const declaredLength = ctx.get('Content-Length')
+    if (declaredLength) {
+      const size = Number(declaredLength)
+      if (!Number.isSafeInteger(size) || size < 0) {
+        ctx.status = 400
+        ctx.body = { error: 'Invalid Content-Length', code: 'invalid_content_length' }
+        return
+      }
+      if (size > MAX_REMOTE_WORKSPACE_TRANSFER_BYTES) {
+        ctx.status = 413
+        ctx.body = { error: 'File is too large for remote workspace transfer', code: 'file_too_large' }
+        return
+      }
+    }
+    const uploaded = await uploadRemoteWorkspaceFile(
+      workspace,
+      ctx.query.path,
+      ctx.req,
+      ctx.get('X-Expected-SHA256'),
+    )
+    ctx.body = uploaded
+    logger.info({
+      roomId: grant.roomId,
+      agentId: grant.agentId,
+      runId: grant.runId,
+      action: 'upload',
+      path: uploaded.path.slice(0, 500),
+      size: uploaded.size,
+    }, '[GroupChat] remote workspace file transfer')
+  } catch (error: any) {
+    handleRemoteWorkspaceError(ctx, error)
   } finally {
     operation.finish()
   }

--- a/packages/server/src/routes/hermes/group-chat.ts
+++ b/packages/server/src/routes/hermes/group-chat.ts
@@ -44,6 +44,8 @@ groupChatPublicRoutes.post('/api/hermes/group-chat/invites/:code/agent-links/:re
 groupChatPublicRoutes.post('/api/hermes/group-chat/invites/:code/agent-links', agentLinkCtrl.requestPairing)
 groupChatPublicRoutes.get('/api/hermes/group-chat/invites/:code/agent-links/:requestId', agentLinkCtrl.pairingStatus)
 groupChatPublicRoutes.post('/api/hermes/group-chat/remote-workspace/v1', remoteWorkspaceCtrl.remoteWorkspaceAction)
+groupChatPublicRoutes.get('/api/hermes/group-chat/remote-workspace/v1/file', remoteWorkspaceCtrl.downloadRemoteWorkspaceFile)
+groupChatPublicRoutes.put('/api/hermes/group-chat/remote-workspace/v1/file', remoteWorkspaceCtrl.uploadRemoteWorkspaceFileContent)
 
 groupChatRoutes.get('/api/hermes/group-chat-link/v1/agents', agentLinkCtrl.localAgents)
 groupChatRoutes.get('/api/hermes/group-chat-link/v1/connections', agentLinkCtrl.localConnections)

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -859,6 +859,10 @@ export class AgentClient implements GroupAgentExecutor {
             '{"action":"write","path":"relative/file.txt","content":"text","expectedSha256":"hash returned by read"}',
             '{"action":"mkdir","path":"relative/directory"}',
             '{"action":"delete","path":"relative/file.txt","expectedSha256":"hash returned by read"}',
+            `Binary download: GET ${remoteWorkspaceApi.endpoint}/file?path=<URL-encoded relative path>.`,
+            `Binary upload: PUT ${remoteWorkspaceApi.endpoint}/file?path=<URL-encoded relative path> with Content-Type: application/octet-stream and the raw file body.`,
+            'Downloads return the SHA-256 in the X-Content-SHA256 header. Replacing an existing file requires that value in the X-Expected-SHA256 upload header; new files do not require the header.',
+            'Binary uploads and downloads are limited to 20 MiB per file.',
             'Paths must be relative to the shared group-chat workspace. Existing files require the SHA-256 returned by read before write or delete.',
             'The authorization expires when this run finishes. Never repeat the token in chat output.',
         ].join('\n')

--- a/packages/server/src/services/hermes/group-chat/remote-workspace-files.ts
+++ b/packages/server/src/services/hermes/group-chat/remote-workspace-files.ts
@@ -1,7 +1,9 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { constants as fsConstants } from 'node:fs'
-import { lstat, mkdir, open, readdir, rename, rm, rmdir } from 'node:fs/promises'
+import { lstat, mkdir, open, readdir, rename, rm, rmdir, type FileHandle } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
+import { Transform, type Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
 import { isSensitivePath } from '../file-provider'
 import {
   groupWorkspaceRelativePath,
@@ -9,6 +11,7 @@ import {
 } from './workspace-files'
 
 const MAX_REMOTE_WORKSPACE_FILE_BYTES = 1024 * 1024
+export const MAX_REMOTE_WORKSPACE_TRANSFER_BYTES = 20 * 1024 * 1024
 const MAX_REMOTE_WORKSPACE_LIST_ENTRIES = 500
 const SHA256_PATTERN = /^[a-f0-9]{64}$/i
 const pathLocks = new Map<string, Promise<void>>()
@@ -55,16 +58,19 @@ async function withPathLock<T>(path: string, task: () => Promise<T>): Promise<T>
   }
 }
 
-async function readRegularFile(fullPath: string): Promise<Buffer> {
+async function readRegularFile(
+  fullPath: string,
+  maxBytes = MAX_REMOTE_WORKSPACE_FILE_BYTES,
+): Promise<Buffer> {
   const file = await open(fullPath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW || 0))
   try {
     const info = await file.stat()
     if (!info.isFile()) throw workspaceError('Not a file', 400, 'not_a_file')
-    if (info.size > MAX_REMOTE_WORKSPACE_FILE_BYTES) {
+    if (info.size > maxBytes) {
       throw workspaceError('File is too large for remote workspace access', 413, 'file_too_large')
     }
     const data = await file.readFile()
-    if (data.length > MAX_REMOTE_WORKSPACE_FILE_BYTES) {
+    if (data.length > maxBytes) {
       throw workspaceError('File is too large for remote workspace access', 413, 'file_too_large')
     }
     return data
@@ -73,12 +79,24 @@ async function readRegularFile(fullPath: string): Promise<Buffer> {
   }
 }
 
-async function currentFileHash(fullPath: string): Promise<string | null> {
+async function currentFileHash(
+  fullPath: string,
+  maxBytes = MAX_REMOTE_WORKSPACE_FILE_BYTES,
+): Promise<string | null> {
+  let file: FileHandle | null = null
   try {
-    return hash(await readRegularFile(fullPath))
+    file = await open(fullPath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW || 0))
+    const info = await file.stat()
+    if (!info.isFile()) throw workspaceError('Not a file', 400, 'not_a_file')
+    if (info.size > maxBytes) {
+      throw workspaceError('File is too large for remote workspace access', 413, 'file_too_large')
+    }
+    return await hashOpenFile(file, info.size)
   } catch (error: any) {
     if (error?.code === 'ENOENT') return null
     throw error
+  } finally {
+    await file?.close().catch(() => undefined)
   }
 }
 
@@ -88,6 +106,140 @@ function expectedHash(value: unknown): string {
     throw workspaceError('expectedSha256 is required for an existing file', 409, 'workspace_conflict')
   }
   return expected
+}
+
+function optionalExpectedHash(value: unknown): string | null {
+  const expected = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  if (!expected) return null
+  if (!SHA256_PATTERN.test(expected)) {
+    throw workspaceError('Invalid expectedSha256', 400, 'invalid_expected_sha256')
+  }
+  return expected
+}
+
+async function hashOpenFile(file: FileHandle, size: number): Promise<string> {
+  const digest = createHash('sha256')
+  const buffer = Buffer.allocUnsafe(64 * 1024)
+  let offset = 0
+  while (offset < size) {
+    const length = Math.min(buffer.length, size - offset)
+    const { bytesRead } = await file.read(buffer, 0, length, offset)
+    if (bytesRead <= 0) {
+      throw workspaceError('File changed during download', 409, 'workspace_conflict')
+    }
+    digest.update(buffer.subarray(0, bytesRead))
+    offset += bytesRead
+  }
+  return digest.digest('hex')
+}
+
+export async function openRemoteWorkspaceDownload(
+  workspace: string,
+  path: unknown,
+): Promise<{
+  path: string
+  size: number
+  sha256: string
+  stream: Readable
+}> {
+  const target = await resolveGroupWorkspacePath(workspace, path)
+  assertShareablePath(target.relativePath)
+  const file = await open(target.fullPath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW || 0))
+  try {
+    const info = await file.stat()
+    if (!info.isFile()) throw workspaceError('Not a file', 400, 'not_a_file')
+    if (info.size > MAX_REMOTE_WORKSPACE_TRANSFER_BYTES) {
+      throw workspaceError('File is too large for remote workspace transfer', 413, 'file_too_large')
+    }
+    const sha256 = await hashOpenFile(file, info.size)
+    return {
+      path: target.relativePath,
+      size: info.size,
+      sha256,
+      stream: file.createReadStream({ start: 0, autoClose: true }),
+    }
+  } catch (error) {
+    await file.close().catch(() => undefined)
+    throw error
+  }
+}
+
+export async function uploadRemoteWorkspaceFile(
+  workspace: string,
+  path: unknown,
+  source: Readable,
+  expectedSha256?: unknown,
+): Promise<{
+  ok: true
+  path: string
+  size: number
+  sha256: string
+}> {
+  const target = await resolveGroupWorkspacePath(workspace, path)
+  assertShareablePath(target.relativePath)
+  const expected = optionalExpectedHash(expectedSha256)
+
+  return withPathLock(target.fullPath, async () => {
+    const currentHash = await currentFileHash(
+      target.fullPath,
+      MAX_REMOTE_WORKSPACE_TRANSFER_BYTES,
+    )
+    if (currentHash && expected !== currentHash) {
+      throw workspaceError(
+        expected ? 'File changed since it was downloaded' : 'expectedSha256 is required for an existing file',
+        409,
+        'workspace_conflict',
+      )
+    }
+    if (!currentHash && expected) {
+      throw workspaceError('File no longer exists', 409, 'workspace_conflict')
+    }
+
+    await mkdir(dirname(target.fullPath), { recursive: true, mode: 0o700 })
+    const checked = await resolveGroupWorkspacePath(workspace, target.relativePath)
+    const tempPath = resolve(dirname(checked.fullPath), `.${randomUUID()}.group-chat-upload`)
+    const tempFile = await open(
+      tempPath,
+      fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY | (fsConstants.O_NOFOLLOW || 0),
+      0o600,
+    )
+    let totalBytes = 0
+    const digest = createHash('sha256')
+    const limiter = new Transform({
+      transform(chunk: Buffer, _encoding, callback) {
+        totalBytes += chunk.length
+        if (totalBytes > MAX_REMOTE_WORKSPACE_TRANSFER_BYTES) {
+          callback(workspaceError('File is too large for remote workspace transfer', 413, 'file_too_large'))
+          return
+        }
+        digest.update(chunk)
+        callback(null, chunk)
+      },
+    })
+
+    try {
+      await pipeline(source, limiter, tempFile.createWriteStream({ autoClose: true }))
+
+      const latestHash = await currentFileHash(
+        checked.fullPath,
+        MAX_REMOTE_WORKSPACE_TRANSFER_BYTES,
+      )
+      if (latestHash !== currentHash) {
+        throw workspaceError('File changed while it was being uploaded', 409, 'workspace_conflict')
+      }
+      await rename(tempPath, checked.fullPath)
+      return {
+        ok: true,
+        path: checked.relativePath,
+        size: totalBytes,
+        sha256: digest.digest('hex'),
+      }
+    } catch (error) {
+      await tempFile.close().catch(() => undefined)
+      await rm(tempPath, { force: true }).catch(() => undefined)
+      throw error
+    }
+  })
 }
 
 export async function performRemoteWorkspaceAction(

--- a/tests/server/group-chat-agent-workspace.test.ts
+++ b/tests/server/group-chat-agent-workspace.test.ts
@@ -312,6 +312,10 @@ describe('group chat agent workspace bridge runs', () => {
     )
     expect(runAndWait.mock.calls[0][0].instructions).toContain(`Bearer ${'a'.repeat(43)}`)
     expect(runAndWait.mock.calls[0][0].instructions).toContain('"action":"read"')
+    expect(runAndWait.mock.calls[0][0].instructions).toContain(
+      'https://group.example/api/hermes/group-chat/remote-workspace/v1/file',
+    )
+    expect(runAndWait.mock.calls[0][0].instructions).toContain('X-Expected-SHA256')
     expect(runAndWait.mock.calls[0][0].group_system_prompt).toBe(runAndWait.mock.calls[0][0].instructions)
     expect(bridgeMock.chat).not.toHaveBeenCalled()
     expect(mockSocket.emit).toHaveBeenCalledWith(

--- a/tests/server/group-chat-remote-workspace.test.ts
+++ b/tests/server/group-chat-remote-workspace.test.ts
@@ -1,6 +1,7 @@
-import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { Readable } from 'node:stream'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   authenticateRemoteWorkspaceGrant,
@@ -10,7 +11,12 @@ import {
   revokeRemoteWorkspaceGrantsForRun,
   waitForRemoteWorkspaceGrantOperations,
 } from '../../packages/server/src/services/hermes/group-chat/remote-workspace-auth'
-import { performRemoteWorkspaceAction } from '../../packages/server/src/services/hermes/group-chat/remote-workspace-files'
+import {
+  MAX_REMOTE_WORKSPACE_TRANSFER_BYTES,
+  openRemoteWorkspaceDownload,
+  performRemoteWorkspaceAction,
+  uploadRemoteWorkspaceFile,
+} from '../../packages/server/src/services/hermes/group-chat/remote-workspace-files'
 
 describe('group chat remote workspace access', () => {
   const temporaryDirectories: string[] = []
@@ -138,5 +144,59 @@ describe('group chat remote workspace access', () => {
         expect.objectContaining({ name: 'hosts-link' }),
       ]))
     }
+  })
+
+  it('streams binary uploads and downloads with overwrite conflict protection', async () => {
+    const root = await workspace()
+    const firstBytes = Buffer.from([0x00, 0xff, 0x89, 0x50, 0x4e, 0x47])
+    const created = await uploadRemoteWorkspaceFile(
+      root,
+      'artifacts/image.bin',
+      Readable.from([firstBytes.subarray(0, 2), firstBytes.subarray(2)]),
+    )
+
+    expect(created).toMatchObject({
+      ok: true,
+      path: 'artifacts/image.bin',
+      size: firstBytes.length,
+      sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+    })
+    expect(await readFile(join(root, 'artifacts/image.bin'))).toEqual(firstBytes)
+
+    const download = await openRemoteWorkspaceDownload(root, 'artifacts/image.bin')
+    const downloaded: Buffer[] = []
+    for await (const chunk of download.stream) downloaded.push(Buffer.from(chunk))
+    expect(Buffer.concat(downloaded)).toEqual(firstBytes)
+    expect(download.sha256).toBe(created.sha256)
+
+    await expect(uploadRemoteWorkspaceFile(
+      root,
+      'artifacts/image.bin',
+      Readable.from([Buffer.from('unsafe overwrite')]),
+    )).rejects.toMatchObject({ status: 409, code: 'workspace_conflict' })
+
+    const replacement = Buffer.from([0x01, 0x02, 0x03])
+    await expect(uploadRemoteWorkspaceFile(
+      root,
+      'artifacts/image.bin',
+      Readable.from([replacement]),
+      created.sha256,
+    )).resolves.toMatchObject({ ok: true, size: replacement.length })
+    expect(await readFile(join(root, 'artifacts/image.bin'))).toEqual(replacement)
+  })
+
+  it('stops oversized binary uploads and removes the temporary file', async () => {
+    const root = await workspace()
+
+    await expect(uploadRemoteWorkspaceFile(
+      root,
+      'artifacts/oversized.bin',
+      Readable.from([Buffer.alloc(MAX_REMOTE_WORKSPACE_TRANSFER_BYTES + 1)]),
+    )).rejects.toMatchObject({ status: 413, code: 'file_too_large' })
+
+    await expect(readFile(join(root, 'artifacts/oversized.bin'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
+    expect(await readdir(join(root, 'artifacts'))).toEqual([])
   })
 })

--- a/tests/server/group-chat-routes-baseline.test.ts
+++ b/tests/server/group-chat-routes-baseline.test.ts
@@ -1,7 +1,7 @@
 import Koa from 'koa'
 import bodyParser from '@koa/bodyparser'
 import { createServer, type Server as HttpServer } from 'http'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -286,6 +286,53 @@ describe('group chat REST route baseline', () => {
       content: 'shared content',
       sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
     })
+
+    const binary = Buffer.from([0x00, 0xff, 0x10, 0x20])
+    const upload = await fetch(`${endpoint}/file?path=${encodeURIComponent('artifacts/data.bin')}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/octet-stream',
+      },
+      body: binary,
+    })
+    expect(upload.status).toBe(200)
+    const uploaded = await upload.json() as { sha256: string }
+    expect(uploaded.sha256).toMatch(/^[a-f0-9]{64}$/)
+
+    const download = await fetch(`${endpoint}/file?path=${encodeURIComponent('artifacts/data.bin')}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(download.status).toBe(200)
+    expect(download.headers.get('x-content-sha256')).toBe(uploaded.sha256)
+    expect(Buffer.from(await download.arrayBuffer())).toEqual(binary)
+
+    const overwriteWithoutHash = await fetch(
+      `${endpoint}/file?path=${encodeURIComponent('artifacts/data.bin')}`,
+      {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/octet-stream',
+        },
+        body: Buffer.from('replacement'),
+      },
+    )
+    expect(overwriteWithoutHash.status).toBe(409)
+    await expect(overwriteWithoutHash.json()).resolves.toMatchObject({ code: 'workspace_conflict' })
+
+    const replacement = Buffer.from([0x11, 0x22])
+    const overwrite = await fetch(`${endpoint}/file?path=${encodeURIComponent('artifacts/data.bin')}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/octet-stream',
+        'X-Expected-SHA256': uploaded.sha256,
+      },
+      body: replacement,
+    })
+    expect(overwrite.status).toBe(200)
+    expect(await readFile(join(workspace, 'artifacts/data.bin'))).toEqual(replacement)
 
     revokeRemoteWorkspaceGrantsForRun('run-route')
     const revoked = await fetch(endpoint, {


### PR DESCRIPTION
## What changed

- add a grant-protected binary download endpoint for remote group-chat Agents
- add bounded streaming uploads with atomic replacement
- require the downloaded SHA-256 before overwriting an existing file
- document the transfer endpoints in the Agent run instructions and OpenAPI
- add service and HTTP route regression coverage

## Why

The remote workspace API exposed JSON operations for listing, reading, writing,
creating, and deleting files, but `read` and `write` were limited to UTF-8 text.
Remote Agents could not move images, archives, documents, or other binary
artifacts between their local execution environment and the shared room
workspace.

## Behavior and safety

- `GET /api/hermes/group-chat/remote-workspace/v1/file?path=...` streams a download
- `PUT /api/hermes/group-chat/remote-workspace/v1/file?path=...` accepts an `application/octet-stream` upload
- transfers are limited to 20 MiB per file
- downloads return `X-Content-SHA256`
- replacing an existing file requires the matching `X-Expected-SHA256`
- short-lived run grants, path confinement, sensitive-file blocking, symbolic-link rejection, and request limits remain enforced
- oversized or failed uploads remove their temporary files

## Validation

- `npx vitest run tests/server/group-chat*.test.ts` (21 files, 220 tests)
- `npx vitest run tests/server/group-chat-remote-workspace.test.ts tests/server/group-chat-routes-baseline.test.ts` (24 tests after the final streaming-hash refinement)
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run harness:check`
- `npm run openapi:generate`
- `git diff --check`
