### PR TITLE
feat: improve recent sessions and group chat activity

### DIFF
--- a/docs/chat-chain-changes/2026-08-07-issue-2355-recent-fork-quote-activity.md
+++ b/docs/chat-chain-changes/2026-08-07-issue-2355-recent-fork-quote-activity.md
@@ -1,0 +1,10 @@
+---
+date: 2026-08-07
+feature: issue-2355-recent-fork-quote-activity
+impact: Adds a dynamic persisted Recent group for direct chats, snapshots real categories when forking, creates validated structured quote mentions, and unifies durable visible-message room activity ordering.
+pr: pending
+---
+
+# Issue #2355
+
+Recent never writes a category ID; forks copy only the parent real `category_id`. Group-chat quote cards are retained while the quoted valid participant is sent through the structured mention protocol. Legacy group activity uses a durable one-time migration cutoff, ignores tool and streaming messages, and falls back to room creation time when empty.

--- a/docs/chat-chain-changes/2026-08-07-issue-2355-recent-fork-quote-activity.md
+++ b/docs/chat-chain-changes/2026-08-07-issue-2355-recent-fork-quote-activity.md
@@ -2,9 +2,9 @@
 date: 2026-08-07
 feature: issue-2355-recent-fork-quote-activity
 impact: Adds a dynamic persisted Recent group for direct chats, snapshots real categories when forking, creates validated structured quote mentions, and unifies durable visible-message room activity ordering.
-pr: pending
+pr: 2414
 ---
 
 # Issue #2355
 
-Recent never writes a category ID; forks copy only the parent real `category_id`. Group-chat quote cards are retained while the quoted valid participant is sent through the structured mention protocol. Agent reply generation excludes its own participant ID before building structured routing metadata, while server-side self-mention rejection remains the defense-in-depth boundary. Room list responses expose the server-computed `lastActiveAt` for every visibility path, so client refresh sorting preserves durable visible-message activity. Legacy group activity uses a durable one-time migration cutoff, ignores tool and streaming messages, and falls back to room creation time when empty.
+Recent never writes a category ID; forks copy only the parent real `category_id`. Recent partition inputs require stable string session IDs, and category browser coverage keeps target sessions outside the configured Recent slice so the no-duplicate behavior and category actions are both verified. Group-chat quote cards are retained while the quoted valid participant is sent through the structured mention protocol. Agent reply generation excludes its own participant ID before building structured routing metadata, while server-side self-mention rejection remains the defense-in-depth boundary. Room list responses expose the server-computed `lastActiveAt` for every visibility path, so client refresh sorting preserves durable visible-message activity. Legacy group activity uses a durable one-time migration cutoff, ignores tool and streaming messages, and falls back to room creation time when empty.

--- a/docs/chat-chain-changes/2026-08-07-issue-2355-recent-fork-quote-activity.md
+++ b/docs/chat-chain-changes/2026-08-07-issue-2355-recent-fork-quote-activity.md
@@ -7,4 +7,4 @@ pr: pending
 
 # Issue #2355
 
-Recent never writes a category ID; forks copy only the parent real `category_id`. Group-chat quote cards are retained while the quoted valid participant is sent through the structured mention protocol. Legacy group activity uses a durable one-time migration cutoff, ignores tool and streaming messages, and falls back to room creation time when empty.
+Recent never writes a category ID; forks copy only the parent real `category_id`. Group-chat quote cards are retained while the quoted valid participant is sent through the structured mention protocol. Agent reply generation excludes its own participant ID before building structured routing metadata, while server-side self-mention rejection remains the defense-in-depth boundary. Room list responses expose the server-computed `lastActiveAt` for every visibility path, so client refresh sorting preserves durable visible-message activity. Legacy group activity uses a durable one-time migration cutoff, ignores tool and streaming messages, and falls back to room creation time when empty.

--- a/packages/client/src/api/hermes/group-chat.ts
+++ b/packages/client/src/api/hermes/group-chat.ts
@@ -22,6 +22,8 @@ export interface RoomInfo {
     guestAgentApproval?: 'owner'
     maxGuestAgentsPerMember?: number
     allowRemoteWorkspaceAccess?: number
+    createdAt?: number
+    lastActiveAt?: number
 }
 
 export interface RoomSummaryConfig {
@@ -116,6 +118,8 @@ export interface ChatMessage {
     senderOwnerMemberId?: string
     content: string
     timestamp: number
+    /** Server-assigned persistence time used for room activity ordering. */
+    persistedAt?: number
     run_id?: string | null
     role?: string
     tool_call_id?: string | null
@@ -125,6 +129,7 @@ export interface ChatMessage {
     reasoning?: string | null
     reasoning_details?: string | null
     reasoning_content?: string | null
+    mentions?: GroupChatMention[]
     isStreaming?: boolean
     toolName?: string
     toolCallId?: string
@@ -136,6 +141,12 @@ export interface ChatMessage {
     firstSeenAt?: number
     attachments?: Array<{ id: string; name: string; type: string; size: number; url: string }>
     runItems?: ChatMessage[]
+}
+
+export interface GroupChatMention {
+    type: 'agent' | 'all'
+    participantId?: string
+    displayName: string
 }
 
 export interface GroupWorkspaceDiffFile {

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -49,7 +49,7 @@ import SessionListItem from "./SessionListItem.vue";
 import OutlinePanel from "./OutlinePanel.vue";
 import TerminalPanel from "./TerminalPanel.vue";
 import SubagentStreamPanel from "./SubagentStreamPanel.vue";
-import { buildRecentSessionCategoryGroup, buildVisibleSessionCategoryGroups } from "./session-category-groups";
+import { buildVisibleSessionCategoryGroups, partitionRecentSessions } from "./session-category-groups";
 import PageSidebarNav from "@/components/layout/PageSidebarNav.vue";
 import SettingsCircuitBadge from "@/components/layout/SettingsCircuitBadge.vue";
 import { isStoredSuperAdmin } from "@/api/client";
@@ -555,9 +555,17 @@ function sortSessionsForSidebar(items: Session[]): Session[] {
   });
 }
 
+const recentSessionPartition = computed(() => partitionRecentSessions(
+  chatStore.sessions,
+  sessionBrowserPrefsStore.recentCount,
+  t("chat.recent"),
+));
+const recentSessions = computed(() => recentSessionPartition.value.group);
+const nonRecentSessions = computed(() => recentSessionPartition.value.remaining);
+
 const pinnedSessions = computed(() =>
   sortSessionsForSidebar(
-    chatStore.sessions.filter((session) =>
+    nonRecentSessions.value.filter((session) =>
       sessionBrowserPrefsStore.isPinned(session.id),
     ),
   ),
@@ -565,7 +573,7 @@ const pinnedSessions = computed(() =>
 
 const unpinnedSessions = computed(() =>
   sortSessionsForSidebar(
-    chatStore.sessions.filter(
+    nonRecentSessions.value.filter(
       (session) => !sessionBrowserPrefsStore.isPinned(session.id),
     ),
   ),
@@ -575,11 +583,6 @@ const categorizedSessions = computed(() => buildVisibleSessionCategoryGroups(
   sessionCategories.value,
   unpinnedSessions.value,
   t("chat.uncategorized"),
-));
-const recentSessions = computed(() => buildRecentSessionCategoryGroup(
-  chatStore.sessions,
-  sessionBrowserPrefsStore.recentCount,
-  t("chat.recent"),
 ));
 
 function openRecentCountModal(event: MouseEvent) {

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -25,6 +25,7 @@ import {
   NDrawerContent,
   NDropdown,
   NInput,
+  NInputNumber,
   NModal,
   NSelect,
   NTooltip,
@@ -48,7 +49,7 @@ import SessionListItem from "./SessionListItem.vue";
 import OutlinePanel from "./OutlinePanel.vue";
 import TerminalPanel from "./TerminalPanel.vue";
 import SubagentStreamPanel from "./SubagentStreamPanel.vue";
-import { buildVisibleSessionCategoryGroups } from "./session-category-groups";
+import { buildRecentSessionCategoryGroup, buildVisibleSessionCategoryGroups } from "./session-category-groups";
 import PageSidebarNav from "@/components/layout/PageSidebarNav.vue";
 import SettingsCircuitBadge from "@/components/layout/SettingsCircuitBadge.vue";
 import { isStoredSuperAdmin } from "@/api/client";
@@ -504,6 +505,8 @@ const sessionCategoriesLoading = ref(false);
 const sessionCategoriesLoaded = ref(false);
 let sessionCategoriesLoadPromise: Promise<void> | null = null;
 const COLLAPSED_CATEGORIES_STORAGE_KEY = "hermes_chat_collapsed_categories";
+const showRecentCountModal = ref(false);
+const recentCountDraft = ref(sessionBrowserPrefsStore.recentCount);
 
 function loadCollapsedCategories(): Set<string> {
   try {
@@ -573,6 +576,22 @@ const categorizedSessions = computed(() => buildVisibleSessionCategoryGroups(
   unpinnedSessions.value,
   t("chat.uncategorized"),
 ));
+const recentSessions = computed(() => buildRecentSessionCategoryGroup(
+  chatStore.sessions,
+  sessionBrowserPrefsStore.recentCount,
+  t("chat.recent"),
+));
+
+function openRecentCountModal(event: MouseEvent) {
+  event.stopPropagation();
+  recentCountDraft.value = sessionBrowserPrefsStore.recentCount;
+  showRecentCountModal.value = true;
+}
+
+function saveRecentCount() {
+  sessionBrowserPrefsStore.setRecentCount(recentCountDraft.value);
+  showRecentCountModal.value = false;
+}
 
 watch(
   () => [
@@ -1963,6 +1982,34 @@ async function handleSessionModelCustomSubmit() {
           {{ t("chat.noSessions") }}
         </div>
 
+        <template v-if="recentSessions.sessions.length > 0">
+          <div class="session-group-header session-group-header--static">
+            <span class="session-group-label">{{ recentSessions.label }}</span>
+            <span class="session-group-count">{{ recentSessions.sessions.length }}</span>
+            <button class="session-group-config" type="button" :title="t('chat.recentCount')" @click="openRecentCountModal">⚙</button>
+          </div>
+          <SessionListItem
+            v-for="s in recentSessions.sessions"
+            :key="`recent-${s.id}`"
+            :session="s"
+            :active="s.id === chatStore.activeSessionId"
+            :pinned="sessionBrowserPrefsStore.isPinned(s.id)"
+            :can-delete="s.id !== chatStore.activeSessionId || chatStore.sessions.length > 1"
+            :streaming="chatStore.isSessionLive(s.id)"
+            :completed-unread="chatStore.isSessionCompletedUnread(s.id)"
+            :selectable="isBatchMode"
+            :selected="isSessionSelected(s)"
+            :show-profile="true"
+            :to="sessionHref(s.id)"
+            :intercept-modified-navigation="desktopChatWindowAvailable"
+            @select="handleSessionClick(s.id)"
+            @open-new="openSessionInNewTab(s.id)"
+            @contextmenu="handleContextMenu($event, s.id)"
+            @delete="handleDeleteSession(s.id)"
+            @toggle-select="toggleSessionSelection(s)"
+          />
+        </template>
+
         <template v-if="pinnedSessions.length > 0">
           <div class="session-group-header session-group-header--static">
             <span class="session-group-label">{{ t("chat.pinned") }}</span>
@@ -2072,6 +2119,17 @@ async function handleSessionModelCustomSubmit() {
       @select="handleContextMenuSelect"
       @clickoutside="handleClickOutside"
     />
+
+    <NModal
+      v-model:show="showRecentCountModal"
+      preset="dialog"
+      :title="t('chat.recentCount')"
+      :positive-text="t('common.ok')"
+      :negative-text="t('common.cancel')"
+      @positive-click="saveRecentCount"
+    >
+      <NInputNumber v-model:value="recentCountDraft" :min="1" :max="100" />
+    </NModal>
 
     <NDropdown
       placement="bottom-start"
@@ -3329,6 +3387,15 @@ async function handleSessionModelCustomSubmit() {
   color: $text-muted;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+}
+
+.session-group-config {
+  margin-inline-start: auto;
+  border: 0;
+  background: transparent;
+  color: $text-muted;
+  cursor: pointer;
+  padding: 0 2px;
 }
 
 .session-group-count {

--- a/packages/client/src/components/hermes/chat/session-category-groups.ts
+++ b/packages/client/src/components/hermes/chat/session-category-groups.ts
@@ -8,6 +8,7 @@ export interface SessionCategoryAssignment {
 }
 
 export interface RecentSessionAssignment extends SessionCategoryAssignment {
+  id: string;
   updatedAt?: number | null;
 }
 

--- a/packages/client/src/components/hermes/chat/session-category-groups.ts
+++ b/packages/client/src/components/hermes/chat/session-category-groups.ts
@@ -17,6 +17,11 @@ export interface VisibleSessionCategoryGroup<T> {
   sessions: T[];
 }
 
+export interface RecentSessionPartition<T> {
+  group: VisibleSessionCategoryGroup<T>;
+  remaining: T[];
+}
+
 export function buildVisibleSessionCategoryGroups<T extends SessionCategoryAssignment>(
   categories: readonly SessionCategoryLike[],
   sessions: readonly T[],
@@ -48,12 +53,25 @@ export function buildRecentSessionCategoryGroup<T extends RecentSessionAssignmen
   limit: number,
   label: string,
 ): VisibleSessionCategoryGroup<T> {
+  return partitionRecentSessions(sessions, limit, label).group;
+}
+
+export function partitionRecentSessions<T extends RecentSessionAssignment>(
+  sessions: readonly T[],
+  limit: number,
+  label: string,
+): RecentSessionPartition<T> {
   const safeLimit = Math.min(100, Math.max(1, Math.floor(Number(limit) || 10)));
+  const recent = [...sessions]
+    .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0))
+    .slice(0, safeLimit);
+  const recentIds = new Set(recent.map(session => session.id));
   return {
-    key: "recent",
-    label,
-    sessions: [...sessions]
-      .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0))
-      .slice(0, safeLimit),
+    group: {
+      key: "recent",
+      label,
+      sessions: recent,
+    },
+    remaining: sessions.filter(session => !recentIds.has(session.id)),
   };
 }

--- a/packages/client/src/components/hermes/chat/session-category-groups.ts
+++ b/packages/client/src/components/hermes/chat/session-category-groups.ts
@@ -7,6 +7,10 @@ export interface SessionCategoryAssignment {
   categoryId?: number | null;
 }
 
+export interface RecentSessionAssignment extends SessionCategoryAssignment {
+  updatedAt?: number | null;
+}
+
 export interface VisibleSessionCategoryGroup<T> {
   key: string;
   label: string;
@@ -37,4 +41,19 @@ export function buildVisibleSessionCategoryGroups<T extends SessionCategoryAssig
     });
   }
   return groups;
+}
+
+export function buildRecentSessionCategoryGroup<T extends RecentSessionAssignment>(
+  sessions: readonly T[],
+  limit: number,
+  label: string,
+): VisibleSessionCategoryGroup<T> {
+  const safeLimit = Math.min(100, Math.max(1, Math.floor(Number(limit) || 10)));
+  return {
+    key: "recent",
+    label,
+    sessions: [...sessions]
+      .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0))
+      .slice(0, safeLimit),
+  };
 }

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -7,6 +7,7 @@ import { useSettingsStore } from '@/stores/hermes/settings'
 import { useToolTraceVisibility } from '@/composables/useToolTraceVisibility'
 import { extractClipboardFiles } from '@/utils/clipboard-files'
 import { buildMentionOptions, type MentionOption } from './mention-options'
+import type { GroupChatMention } from '@/api/hermes/group-chat'
 import type { Attachment } from '@/stores/hermes/chat'
 import { clampChatInputHeight, isMobileChatInputViewport } from '@/utils/chat-input-height'
 
@@ -23,7 +24,7 @@ const props = withDefaults(defineProps<{
     allowAllMention: false,
 })
 const emit = defineEmits<{
-    send: [content: string, attachments?: Attachment[]]
+    send: [content: string, attachments?: Attachment[], mentions?: GroupChatMention[]]
     'send-blocked': []
 }>()
 const store = useGroupChatStore()
@@ -31,6 +32,9 @@ const settingsStore = useSettingsStore()
 const { toolTraceVisible, toggleToolTraceVisible } = useToolTraceVisibility()
 
 const inputText = ref('')
+type TrackedMention = GroupChatMention & { start: number; end: number }
+const mentions = ref<TrackedMention[]>([])
+const previousInputText = ref('')
 const textareaRef = ref<HTMLTextAreaElement>()
 const dropdownRef = ref<HTMLDivElement>()
 const fileInputRef = ref<HTMLInputElement>()
@@ -113,7 +117,20 @@ watch(() => settingsStore.display.chat_input_height, () => {
 watch(
     () => activeMessageReference.value?.id,
     (id) => {
-        if (id) nextTick(() => textareaRef.value?.focus())
+        if (!id) return
+        const reference = activeMessageReference.value
+        const senderId = reference?.senderId?.trim() || ''
+        const agent = store.agents.find(candidate => senderId && (candidate.agentId === senderId || candidate.id === senderId))
+        const isSelf = !!senderId && senderId === store.userId
+        if (agent && !isSelf && !mentions.value.some(mention => mention.type === 'agent' && mention.participantId === agent.agentId)) {
+            insertStructuredMention({
+                type: 'agent',
+                participantId: agent.agentId,
+                displayName: agent.name,
+            })
+            store.emitTyping()
+        }
+        nextTick(() => textareaRef.value?.focus())
     },
 )
 
@@ -291,18 +308,17 @@ function updateMentionState() {
     mentionActive.value = filteredMentionOptions.value.length > 0
 }
 
-function selectMention(name: string) {
+function selectMention(option: MentionOption) {
     const el = textareaRef.value
     if (!el || mentionStartIndex.value === -1) return
 
     const before = inputText.value.slice(0, mentionStartIndex.value)
-    const after = inputText.value.slice(el.selectionStart)
-    inputText.value = `${before}@${name} ${after}`
+    replaceInputRange(mentionStartIndex.value, el.selectionStart, `@${option.name} `, option)
     mentionActive.value = false
 
     nextTick(() => {
         if (el) {
-            const newPos = before.length + name.length + 2
+            const newPos = before.length + option.name.length + 2
             el.setSelectionRange(newPos, newPos)
             el.focus()
             autoSizeTextarea(el)
@@ -322,7 +338,15 @@ function insertMention(name: string) {
     const leadingSpace = before && !/\s$/.test(before) ? ' ' : ''
     const trailingSpace = after && /^\s/.test(after) ? '' : ' '
     const inserted = `${leadingSpace}@${mentionName}${trailingSpace}`
-    inputText.value = `${before}${inserted}${after}`
+    const matchingAgents = store.agents.filter(agent => agent.name === mentionName)
+    replaceInputRange(
+        selectionStart,
+        selectionEnd,
+        inserted,
+        matchingAgents.length === 1
+            ? { type: 'agent', participantId: matchingAgents[0].agentId, displayName: matchingAgents[0].name }
+            : undefined,
+    )
     mentionActive.value = false
     mentionStartIndex.value = -1
     mentionQuery.value = ''
@@ -336,6 +360,70 @@ function insertMention(name: string) {
         el.focus()
         autoSizeTextarea(el)
     })
+}
+
+function normalizeMention(mention: GroupChatMention | MentionOption): GroupChatMention | null {
+    const displayName = 'displayName' in mention ? mention.displayName : mention.name
+    const normalized: GroupChatMention = mention.type === 'all'
+        ? { type: 'all', displayName: 'all' }
+        : {
+            type: 'agent',
+            participantId: mention.participantId,
+            displayName,
+        }
+    if (!normalized.displayName || (normalized.type === 'agent' && !normalized.participantId)) return null
+    return normalized
+}
+
+function replaceInputRange(start: number, end: number, replacement: string, mention?: GroupChatMention | MentionOption) {
+    const before = inputText.value
+    const delta = replacement.length - (end - start)
+    mentions.value = mentions.value
+        .filter(candidate => candidate.end <= start || candidate.start >= end)
+        .map(candidate => candidate.start >= end
+            ? { ...candidate, start: candidate.start + delta, end: candidate.end + delta }
+            : candidate)
+    inputText.value = `${before.slice(0, start)}${replacement}${before.slice(end)}`
+    previousInputText.value = inputText.value
+
+    const normalized = mention ? normalizeMention(mention) : null
+    if (normalized) {
+        const tokenEnd = start + `@${normalized.displayName}`.length
+        mentions.value.push({ ...normalized, start, end: tokenEnd })
+    }
+}
+
+function insertStructuredMention(mention: GroupChatMention) {
+    const normalized = normalizeMention(mention)
+    if (!normalized) return
+    if (mentions.value.some(candidate =>
+        candidate.type === normalized.type &&
+        candidate.participantId === normalized.participantId &&
+        inputText.value.slice(candidate.start, candidate.end) === `@${normalized.displayName}`,
+    )) return
+    replaceInputRange(0, 0, `@${normalized.displayName} `, normalized)
+}
+
+function syncMentionMetadata() {
+    const current = inputText.value
+    const previous = previousInputText.value
+    let prefix = 0
+    while (prefix < previous.length && prefix < current.length && previous[prefix] === current[prefix]) prefix += 1
+    let suffix = 0
+    while (
+        suffix < previous.length - prefix &&
+        suffix < current.length - prefix &&
+        previous[previous.length - suffix - 1] === current[current.length - suffix - 1]
+    ) suffix += 1
+    const previousChangedEnd = previous.length - suffix
+    const delta = current.length - previous.length
+    mentions.value = mentions.value
+        .filter(mention => mention.end <= prefix || mention.start >= previousChangedEnd)
+        .map(mention => mention.start >= previousChangedEnd
+            ? { ...mention, start: mention.start + delta, end: mention.end + delta }
+            : mention)
+        .filter(mention => current.slice(mention.start, mention.end) === `@${mention.displayName}`)
+    previousInputText.value = current
 }
 
 // ─── Event Handlers ──────────────────────────────────────
@@ -357,7 +445,7 @@ function handleKeydown(e: KeyboardEvent) {
         }
         if (e.key === 'Enter' || e.key === 'Tab') {
             e.preventDefault()
-            selectMention(filteredMentionOptions.value[activeIndex.value].name)
+            selectMention(filteredMentionOptions.value[activeIndex.value])
             return
         }
         if (e.key === 'Escape') {
@@ -381,8 +469,11 @@ function handleSend() {
         return
     }
 
-    emit('send', content, attachments.value.length > 0 ? attachments.value : undefined)
+    const structuredMentions = mentions.value.map(({ start: _start, end: _end, ...mention }) => mention)
+    emit('send', content, attachments.value.length > 0 ? attachments.value : undefined, structuredMentions.length ? structuredMentions : undefined)
     inputText.value = ''
+    mentions.value = []
+    previousInputText.value = ''
     attachments.value = []
     mentionActive.value = false
     // 发送后重置到自定义高度（不清除拖拽状态）
@@ -390,6 +481,7 @@ function handleSend() {
 
 function handleInput(e: Event) {
     store.emitTyping()
+    syncMentionMetadata()
     if (!isComposing.value) {
         updateMentionState()
     }
@@ -401,7 +493,7 @@ function handleInput(e: Event) {
 }
 
 function handleMentionClick(option: MentionOption) {
-    selectMention(option.name)
+    selectMention(option)
 }
 
 function handleMentionHover(index: number) {
@@ -507,7 +599,7 @@ function handleDrop(e: DragEvent) {
     addFiles(Array.from(e.dataTransfer?.files || []))
 }
 
-defineExpose({ addFiles, insertMention })
+defineExpose({ addFiles, insertMention, handleSend })
 
 function removeAttachment(id: string) {
     const idx = attachments.value.findIndex(a => a.id === id)

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -326,7 +326,7 @@ function selectMention(option: MentionOption) {
     })
 }
 
-function insertMention(name: string) {
+function insertMention(name: string, participantId?: string) {
     const mentionName = String(name || '').trim()
     if (!mentionName) return
 
@@ -339,12 +339,17 @@ function insertMention(name: string) {
     const trailingSpace = after && /^\s/.test(after) ? '' : ' '
     const inserted = `${leadingSpace}@${mentionName}${trailingSpace}`
     const matchingAgents = store.agents.filter(agent => agent.name === mentionName)
+    const identifiedAgent = participantId
+        ? matchingAgents.find(agent => agent.agentId === participantId)
+        : matchingAgents.length === 1
+            ? matchingAgents[0]
+            : undefined
     replaceInputRange(
         selectionStart,
         selectionEnd,
         inserted,
-        matchingAgents.length === 1
-            ? { type: 'agent', participantId: matchingAgents[0].agentId, displayName: matchingAgents[0].name }
+        identifiedAgent
+            ? { type: 'agent', participantId: identifiedAgent.agentId, displayName: identifiedAgent.name }
             : undefined,
     )
     mentionActive.value = false

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -130,7 +130,7 @@ const roomContextMenuX = ref(0)
 const roomContextMenuY = ref(0)
 const groupChatInputRef = ref<(InstanceType<typeof GroupChatInput> & {
     addFiles?: (files: File[]) => void
-    insertMention?: (name: string) => void
+    insertMention?: (name: string, participantId?: string) => void
 }) | null>(null)
 const summarySettingsSectionRef = ref<HTMLElement | null>(null)
 const chatDropCounter = ref(0)
@@ -410,7 +410,7 @@ function canRemoveAgent(agent: RoomAgent): boolean {
 
 function handleMentionAgent(agent: RoomAgent) {
     if (agent.connectionStatus === 'offline') return
-    groupChatInputRef.value?.insertMention?.(agent.name)
+    groupChatInputRef.value?.insertMention?.(agent.name, agent.agentId)
 }
 
 function handleAgentRailAdd() {

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -21,7 +21,7 @@ import PageSidebarNav from '@/components/layout/PageSidebarNav.vue'
 import SettingsCircuitBadge from '@/components/layout/SettingsCircuitBadge.vue'
 import { copyToClipboard } from '@/utils/clipboard'
 import type { Attachment } from '@/stores/hermes/chat'
-import type { MemberInfo, RoomAgent, RoomInfo, RoomSummaryAnchor, RoomSummaryConfig, RoomSummaryState } from '@/api/hermes/group-chat'
+import type { GroupChatMention, MemberInfo, RoomAgent, RoomInfo, RoomSummaryAnchor, RoomSummaryConfig, RoomSummaryState } from '@/api/hermes/group-chat'
 import { useFilesStore } from '@/stores/hermes/files'
 import { useToolPanelStore } from '@/stores/hermes/tool-panel'
 import { hasDesktopBrowserBridge } from '@/utils/desktop-bridge'
@@ -942,9 +942,9 @@ async function handleSelectRoom(roomId: string) {
     }
 }
 
-async function handleSendMessage(content: string, attachments?: Attachment[]) {
+async function handleSendMessage(content: string, attachments?: Attachment[], mentions?: GroupChatMention[]) {
     try {
-        await store.sendMessage(content, attachments)
+        await store.sendMessage(content, attachments, mentions)
     } catch (err: any) {
         message.error(err.message)
     }

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -562,6 +562,7 @@ function referenceBubbleContent() {
         role,
         content,
         sender: props.message.senderName || props.message.senderId,
+        senderId: props.message.senderId,
     })
 }
 

--- a/packages/client/src/components/hermes/group-chat/mention-options.ts
+++ b/packages/client/src/components/hermes/group-chat/mention-options.ts
@@ -2,12 +2,15 @@ export type MentionOption = {
     key: string
     type: 'all' | 'agent'
     name: string
+    participantId?: string
     label: string
     description: string
 }
 
 type MentionAgent = {
     name: string
+    id?: string
+    agentId?: string
     profile?: string
     connectionStatus?: 'online' | 'offline'
 }
@@ -41,9 +44,10 @@ export function buildMentionOptions(
         if (isReservedMentionName(agentName)) continue
         if (!agentName.toLowerCase().includes(normalizedQuery)) continue
         options.push({
-            key: `agent:${agentName}`,
+            key: `agent:${agent.agentId || agent.id || agentName}`,
             type: 'agent',
             name: agentName,
+            participantId: agent.agentId || agent.id,
             label: `@${agentName}`,
             description: agent.profile || '',
         })

--- a/packages/client/src/i18n/locales/ar.ts
+++ b/packages/client/src/i18n/locales/ar.ts
@@ -689,6 +689,8 @@ export default {
     hermesHistory: 'سجل Hermes',
     historyScopeHint: 'جلسات سجل Hermes للقراءة فقط للبروفايل الحالي، مجمّعة حسب المصدر.',
     noSessions: 'لا توجد جلسات',
+    recent: 'الأخيرة',
+    recentCount: 'عدد الجلسات الأخيرة',
     loadMoreSessions: 'تحميل جلسات أكثر',
     searchTitle: 'البحث في الجلسات',
     searchSubtitle: 'ابحث بالعنوان أو بمحتوى الرسالة',

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -646,6 +646,8 @@ export default {
     hermesHistory: 'Hermes-Verlauf',
     historyScopeHint: 'Schreibgeschützte Hermes-Verlaufssitzungen des aktuellen Profils, nach Quelle gruppiert.',
     noSessions: 'Keine Sitzungen',
+    recent: 'Zuletzt',
+    recentCount: 'Anzahl letzter Sitzungen',
     loadMoreSessions: 'Weitere Sitzungen laden',
     newChat: 'Neuer Chat',
     category: 'Kategorie',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -689,6 +689,8 @@ export default {
     hermesHistory: 'Hermes History',
     historyScopeHint: 'Read-only Hermes history sessions for the current profile, grouped by source.',
     noSessions: 'No sessions',
+    recent: 'Recent',
+    recentCount: 'Recent session count',
     loadMoreSessions: 'Load more sessions',
     searchTitle: 'Search Sessions',
     searchSubtitle: 'Search by title or message content',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -646,6 +646,8 @@ export default {
     hermesHistory: 'Historial de Hermes',
     historyScopeHint: 'Sesiones del historial de Hermes del perfil actual, de solo lectura y agrupadas por origen.',
     noSessions: 'Sin sesiones',
+    recent: 'Recientes',
+    recentCount: 'Cantidad de sesiones recientes',
     loadMoreSessions: 'Cargar más sesiones',
     newChat: 'Nuevo chat',
     category: 'Categoría',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -646,6 +646,8 @@ export default {
     hermesHistory: 'Historique Hermes',
     historyScopeHint: 'Sessions d’historique Hermes du profil actuel en lecture seule, regroupées par source.',
     noSessions: 'Aucune session',
+    recent: 'Récentes',
+    recentCount: 'Nombre de sessions récentes',
     loadMoreSessions: 'Charger plus de sessions',
     newChat: 'Nouvelle discussion',
     category: 'Catégorie',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -646,6 +646,8 @@ export default {
     hermesHistory: 'Hermes 履歴',
     historyScopeHint: '現在の profile の Hermes 履歴セッションをソース別に読み取り専用で表示します。',
     noSessions: 'セッションがありません',
+    recent: '最近',
+    recentCount: '最近のセッション数',
     loadMoreSessions: 'さらにセッションを読み込む',
     newChat: '新しいチャット',
     category: 'カテゴリー',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -646,6 +646,8 @@ export default {
     hermesHistory: 'Hermes 기록',
     historyScopeHint: '현재 profile의 Hermes 기록 세션을 소스별로 읽기 전용으로 봅니다.',
     noSessions: '세션 없음',
+    recent: '최근',
+    recentCount: '최근 세션 수',
     loadMoreSessions: '세션 더 불러오기',
     newChat: '새 채팅',
     category: '카테고리',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -646,6 +646,8 @@ export default {
     hermesHistory: 'Histórico Hermes',
     historyScopeHint: 'Sessões do histórico Hermes do perfil atual, somente leitura, agrupadas por origem.',
     noSessions: 'Sem sessões',
+    recent: 'Recentes',
+    recentCount: 'Quantidade de sessões recentes',
     loadMoreSessions: 'Carregar mais sessões',
     newChat: 'Novo chat',
     category: 'Categoria',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -577,6 +577,8 @@ export default {
     hermesHistory: 'История Hermes',
     historyScopeHint: 'Здесь для чтения отображаются исторические сеансы Hermes текущего профиля с разбивкой по источникам.',
     noSessions: 'Нет сеансов',
+    recent: 'Недавние',
+    recentCount: 'Количество недавних сессий',
     loadMoreSessions: 'Загрузить ещё сеансы',
     searchTitle: 'Поиск сеансов',
     searchSubtitle: 'Поиск по заголовку или содержимому сообщений',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -687,6 +687,8 @@ export default {
     hermesHistory: 'Hermes 歷史',
     historyScopeHint: '這裡按來源以唯讀方式查看目前 profile 的 Hermes 歷史工作階段。',
     noSessions: '目前無工作階段',
+    recent: '最近',
+    recentCount: '最近會話數量',
     loadMoreSessions: '載入更多工作階段',
     searchTitle: '搜尋工作階段',
     searchSubtitle: '依標題或訊息內容搜尋',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -689,6 +689,8 @@ export default {
     hermesHistory: 'Hermes 历史',
     historyScopeHint: '这里按来源只读查看当前 profile 的 Hermes 历史会话。',
     noSessions: '暂无会话',
+    recent: '最近',
+    recentCount: '最近会话数量',
     loadMoreSessions: '加载更多会话',
     searchTitle: '搜索会话',
     searchSubtitle: '按标题或消息内容搜索',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -352,6 +352,7 @@ export interface MessageReference {
   role: 'user' | 'assistant'
   content: string
   sender?: string
+  senderId?: string
 }
 
 export interface ParsedMessageReference {

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -654,7 +654,9 @@ export const useGroupChatStore = defineStore('groupChat', () => {
         })
 
         socket.on('message', (msg: ChatMessage) => {
-            recordPersistedRoomActivity(msg.roomId, Number(msg.persistedAt || msg.timestamp || 0))
+            if (msg.role !== 'tool' && msg.finish_reason !== 'streaming') {
+                recordPersistedRoomActivity(msg.roomId, Number(msg.persistedAt || msg.timestamp || 0))
+            }
             if (msg.roomId === currentRoomId.value) {
                 captureHistoricalMessageAgents([msg])
                 if (msg.role === 'assistant' && msg.tool_calls?.length) {

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -15,6 +15,7 @@ import {
     type RoomSummaryConfig,
     type RoomSummaryState,
     type ChatMessage,
+    type GroupChatMention,
     type GroupWorkspaceDiffPayload,
     type MemberInfo,
     createRoom,
@@ -197,6 +198,21 @@ export const useGroupChatStore = defineStore('groupChat', () => {
 
     function setAutoPlaySpeech(enabled: boolean) {
         autoPlaySpeechEnabled.value = enabled
+    }
+
+    function sortRoomsByActivity() {
+        rooms.value = [...rooms.value].sort((a, b) =>
+            Number(b.lastActiveAt || b.createdAt || 0) - Number(a.lastActiveAt || a.createdAt || 0)
+            || Number(b.createdAt || 0) - Number(a.createdAt || 0)
+            || b.id.localeCompare(a.id),
+        )
+    }
+
+    function recordPersistedRoomActivity(roomId: string, timestamp: number) {
+        const room = rooms.value.find(item => item.id === roomId)
+        if (!room || !Number.isFinite(timestamp)) return
+        room.lastActiveAt = Math.max(Number(room.lastActiveAt || room.createdAt || 0), timestamp)
+        sortRoomsByActivity()
     }
 
     function setMessageReference(roomId: string, reference: MessageReference) {
@@ -638,6 +654,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
         })
 
         socket.on('message', (msg: ChatMessage) => {
+            recordPersistedRoomActivity(msg.roomId, Number(msg.persistedAt || msg.timestamp || 0))
             if (msg.roomId === currentRoomId.value) {
                 captureHistoricalMessageAgents([msg])
                 if (msg.role === 'assistant' && msg.tool_calls?.length) {
@@ -1060,7 +1077,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
         }
     }
 
-    async function sendMessage(content: string, attachments?: Attachment[]) {
+    async function sendMessage(content: string, attachments?: Attachment[], mentions?: GroupChatMention[]) {
         if (!currentRoomId.value) return
         const roomId = currentRoomId.value
         const messageId = uid()
@@ -1104,7 +1121,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
 
         emitStopTyping(roomId)
         return new Promise<void>((resolve, reject) => {
-            socket.emit('message', { roomId, id: messageId, content: finalContent }, (res: { id?: string; error?: string }) => {
+            socket.emit('message', { roomId, id: messageId, content: finalContent, mentions }, (res: { id?: string; error?: string }) => {
                 if (res.error) {
                     messages.value = messages.value.filter(m => m.id !== messageId)
                     reject(new Error(res.error))
@@ -1119,6 +1136,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
         try {
             const res = await listRooms()
             rooms.value = res.rooms
+            sortRoomsByActivity()
         } catch (err: any) {
             error.value = err.message
         }

--- a/packages/client/src/stores/hermes/session-browser-prefs.ts
+++ b/packages/client/src/stores/hermes/session-browser-prefs.ts
@@ -4,6 +4,7 @@ import { useProfilesStore } from './profiles'
 
 const PIN_KEY_PREFIX = 'hermes_session_pins_v1_'
 const HUMAN_ONLY_KEY_PREFIX = 'hermes_human_only_v1_'
+const RECENT_COUNT_KEY = 'hermes_recent_session_count_v1'
 
 function currentProfileName(): string {
   try {
@@ -47,6 +48,7 @@ export const useSessionBrowserPrefsStore = defineStore('session-browser-prefs', 
   const profileName = ref(currentProfileName())
   const pinnedIds = ref<string[]>(loadJson<string[]>(pinsKey(profileName.value), []))
   const humanOnly = ref<boolean>(loadJson<boolean>(humanOnlyKey(profileName.value), true))
+  const recentCount = ref<number>(Math.min(100, Math.max(1, loadJson<number>(RECENT_COUNT_KEY, 10))))
 
   function reload() {
     profileName.value = currentProfileName()
@@ -88,6 +90,11 @@ export const useSessionBrowserPrefsStore = defineStore('session-browser-prefs', 
     persistHumanOnly()
   }
 
+  function setRecentCount(value: number) {
+    recentCount.value = Math.min(100, Math.max(1, Math.floor(Number(value) || 10)))
+    saveJson(RECENT_COUNT_KEY, recentCount.value)
+  }
+
   function pruneMissingSessions(existingIds: string[]): boolean {
     if (existingIds.length === 0) return false
     const existing = new Set(existingIds)
@@ -107,11 +114,13 @@ export const useSessionBrowserPrefsStore = defineStore('session-browser-prefs', 
     profileName,
     pinnedIds,
     humanOnly,
+    recentCount,
     reload,
     isPinned,
     togglePinned,
     removePinned,
     setHumanOnly,
+    setRecentCount,
     pruneMissingSessions,
   }
 })

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -558,6 +558,7 @@ export const GC_ROOMS_SCHEMA: Record<string, string> = {
   id: 'TEXT PRIMARY KEY',
   name: 'TEXT NOT NULL',
   inviteCode: 'TEXT UNIQUE',
+  createdAt: 'INTEGER NOT NULL DEFAULT 0',
   summaryProfile: "TEXT NOT NULL DEFAULT 'default'",
   summaryProvider: "TEXT NOT NULL DEFAULT ''",
   summaryModel: "TEXT NOT NULL DEFAULT ''",
@@ -587,6 +588,8 @@ export const GC_MESSAGES_SCHEMA: Record<string, string> = {
   senderAgentRecordId: "TEXT NOT NULL DEFAULT ''",
   content: 'TEXT NOT NULL',
   timestamp: 'INTEGER NOT NULL',
+  persistedAt: 'INTEGER NOT NULL DEFAULT 0',
+  mentions: "TEXT NOT NULL DEFAULT '[]'",
   run_id: 'TEXT',
   role: "TEXT NOT NULL DEFAULT 'user'",
   tool_call_id: 'TEXT',
@@ -596,6 +599,13 @@ export const GC_MESSAGES_SCHEMA: Record<string, string> = {
   reasoning: 'TEXT',
   reasoning_details: 'TEXT',
   reasoning_content: 'TEXT',
+}
+
+export const GC_ACTIVITY_MIGRATIONS_TABLE = 'gc_activity_migrations'
+
+export const GC_ACTIVITY_MIGRATIONS_SCHEMA: Record<string, string> = {
+  id: 'TEXT PRIMARY KEY',
+  migrationCutoff: 'INTEGER NOT NULL',
 }
 
 export const GC_ROOM_AGENTS_TABLE = 'gc_room_agents'
@@ -784,6 +794,54 @@ function addMissingSafeColumns(
       continue
     }
     db.exec(`ALTER TABLE ${quoteIdentifier(tableName)} ADD COLUMN ${quoteIdentifier(columnName)} ${columnDef}`)
+  }
+}
+
+function migrateGroupChatActivityTimes(
+  db: NonNullable<ReturnType<typeof getDb>>,
+  migrationCutoff: number,
+): void {
+  if (!tableExists(db, GC_ROOMS_TABLE) || !tableExists(db, GC_MESSAGES_TABLE)) return
+  const migrationId = 'legacy-activity-times-v1'
+  if (db.prepare(
+    `SELECT 1 FROM ${quoteIdentifier(GC_ACTIVITY_MIGRATIONS_TABLE)} WHERE id = ?`,
+  ).get(migrationId)) return
+
+  db.exec('BEGIN IMMEDIATE')
+  try {
+    db.prepare(
+      `UPDATE ${quoteIdentifier(GC_MESSAGES_TABLE)}
+       SET persistedAt = timestamp
+       WHERE persistedAt = 0
+         AND timestamp > 0
+         AND timestamp <= ?
+         AND COALESCE(role, 'user') <> 'tool'
+         AND COALESCE(tool_name, '') = ''
+         AND COALESCE(finish_reason, '') <> 'streaming'`,
+    ).run(migrationCutoff)
+    db.prepare(
+      `UPDATE ${quoteIdentifier(GC_ROOMS_TABLE)}
+       SET createdAt = (
+         SELECT MIN(m.persistedAt)
+         FROM ${quoteIdentifier(GC_MESSAGES_TABLE)} m
+         WHERE m.roomId = ${quoteIdentifier(GC_ROOMS_TABLE)}.id
+           AND m.persistedAt > 0
+       )
+       WHERE createdAt = 0
+         AND EXISTS (
+           SELECT 1
+           FROM ${quoteIdentifier(GC_MESSAGES_TABLE)} m
+           WHERE m.roomId = ${quoteIdentifier(GC_ROOMS_TABLE)}.id
+             AND m.persistedAt > 0
+         )`,
+    ).run()
+    db.prepare(
+      `INSERT INTO ${quoteIdentifier(GC_ACTIVITY_MIGRATIONS_TABLE)} (id, migrationCutoff) VALUES (?, ?)`,
+    ).run(migrationId, migrationCutoff)
+    db.exec('COMMIT')
+  } catch (error) {
+    db.exec('ROLLBACK')
+    throw error
   }
 }
 
@@ -1231,6 +1289,8 @@ export function initAllHermesTables(): void {
     // Group chat - basic tables
     syncTable(GC_ROOMS_TABLE, GC_ROOMS_SCHEMA)
     syncTable(GC_MESSAGES_TABLE, GC_MESSAGES_SCHEMA)
+    syncTable(GC_ACTIVITY_MIGRATIONS_TABLE, GC_ACTIVITY_MIGRATIONS_SCHEMA)
+    migrateGroupChatActivityTimes(db, Date.now())
     syncTable(GC_CONTEXT_SNAPSHOTS_TABLE, GC_CONTEXT_SNAPSHOTS_SCHEMA)
     syncTable(GC_ROOM_SUMMARIES_TABLE, GC_ROOM_SUMMARIES_SCHEMA)
     syncTable(GC_PENDING_SESSION_DELETES_TABLE, GC_PENDING_SESSION_DELETES_SCHEMA)

--- a/packages/server/src/routes/hermes/group-chat.ts
+++ b/packages/server/src/routes/hermes/group-chat.ts
@@ -259,7 +259,7 @@ function visibleRoomsForUser(storage: ReturnType<GroupChatServer['getStorage']>,
         }
     }
     return [...byId.values()]
-        .sort((a, b) => Number(b.room._activityAt || 0) - Number(a.room._activityAt || 0) || a.room.id.localeCompare(b.room.id))
+        .sort((a, b) => Number(b.room.lastActiveAt || 0) - Number(a.room.lastActiveAt || 0) || a.room.id.localeCompare(b.room.id))
         .map(({ room, includeWorkspace }) => serializeRoom(
             room,
             includeWorkspace,

--- a/packages/server/src/routes/hermes/group-chat.ts
+++ b/packages/server/src/routes/hermes/group-chat.ts
@@ -243,12 +243,11 @@ function visibleRoomsForUser(storage: ReturnType<GroupChatServer['getStorage']>,
             isGroupChatRoomOwner(storage, room.id, user),
         ))
     }
-    const byId = new Map<string, any>()
+    const byId = new Map<string, { room: any; includeWorkspace: boolean }>()
     const addRoom = (room: any, includeWorkspace: boolean) => {
         if (!room) return
-        const canMentionAll = isGroupChatRoomOwner(storage, room.id, user)
-        if (byId.has(room.id) && includeWorkspace) byId.set(room.id, serializeRoom(room, true, canMentionAll))
-        else if (!byId.has(room.id)) byId.set(room.id, serializeRoom(room, includeWorkspace, canMentionAll))
+        const existing = byId.get(room.id)
+        if (!existing || includeWorkspace) byId.set(room.id, { room, includeWorkspace: includeWorkspace || existing?.includeWorkspace === true })
     }
     for (const room of storage.getRoomsForProfiles(userProfiles(user))) addRoom(room, true)
     if (typeof user.id === 'number') {
@@ -259,7 +258,13 @@ function visibleRoomsForUser(storage: ReturnType<GroupChatServer['getStorage']>,
             for (const room of storage.getRoomsForAuthUser(user.id)) addRoom(room, canManageRoom(storage, room.id, user))
         }
     }
-    return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id))
+    return [...byId.values()]
+        .sort((a, b) => Number(b.room._activityAt || 0) - Number(a.room._activityAt || 0) || a.room.id.localeCompare(b.room.id))
+        .map(({ room, includeWorkspace }) => serializeRoom(
+            room,
+            includeWorkspace,
+            isGroupChatRoomOwner(storage, room.id, user),
+        ))
 }
 
 async function connectAndPersistRoomAgent(server: GroupChatServer, roomId: string, input: AgentInput, agentId = generateId()) {

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -1711,7 +1711,7 @@ export class AgentClients {
      */
     async createAgent(config: AgentConfig, handlers?: AgentEventHandler, port?: number): Promise<AgentClient> {
         const client = new AgentClient(config, handlers)
-        client.setMentionBuilder((roomId, content) => this.buildAgentReplyMentions(roomId, content))
+        client.setMentionBuilder((roomId, content) => this.buildAgentReplyMentions(roomId, content, client.agentId))
         await client.connect(port)
 
         // Auto-apply stored references (fixes propagation for agents created after set*)
@@ -1734,7 +1734,7 @@ export class AgentClients {
         }
 
         if (typeof (client as any).setMentionBuilder === 'function') {
-            client.setMentionBuilder((targetRoomId, content) => this.buildAgentReplyMentions(targetRoomId, content))
+            client.setMentionBuilder((targetRoomId, content) => this.buildAgentReplyMentions(targetRoomId, content, client.agentId))
         }
         room.set(client.agentId, client)
         try {
@@ -1798,11 +1798,11 @@ export class AgentClients {
         return this.getAgents(roomId).filter(agent => agent.connected !== false)
     }
 
-    private buildAgentReplyMentions(roomId: string, content: string): StructuredMentionEntry[] {
+    private buildAgentReplyMentions(roomId: string, content: string, senderParticipantId: string): StructuredMentionEntry[] {
         const agents = this.getAgents(roomId)
         if (isAllAgentsMentioned(content)) return [{ type: 'all', displayName: 'all' }]
         return agents
-            .filter(agent => isAgentMentioned(content, agent.name))
+            .filter(agent => agent.agentId !== senderParticipantId && isAgentMentioned(content, agent.name))
             .map(agent => ({
                 type: 'agent' as const,
                 participantId: agent.agentId,

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -15,6 +15,7 @@ import type { ContentBlock } from '../run-chat/types'
 import type { StoredMessage } from '../context-engine/types'
 import type { GroupRoomSummaryService, GroupRuntimeContext } from './room-summary'
 import {
+    isAgentMentioned,
     isAllAgentsMentioned,
     resolveMentionTargets,
     stripMentionRoutingTokens,
@@ -59,7 +60,16 @@ export type MentionMessage = {
     role?: string
     input?: string | ContentBlock[]
     mentionDepth?: number
+    mentions?: StructuredMention[]
 }
+
+export type StructuredMention =
+    | { type: 'agent'; participantId: string }
+    | { type: 'all' }
+
+export type StructuredMentionEntry =
+    | { type: 'agent'; participantId: string; displayName: string }
+    | { type: 'all'; displayName: 'all' }
 
 export function mentionMessageToStoredContextMessage(roomId: string, msg: MentionMessage): StoredMessage {
     return {
@@ -291,6 +301,7 @@ export class AgentClient implements GroupAgentExecutor {
     private workspaceDiffBroadcaster: WorkspaceDiffBroadcaster | null = null
     private chatRunService: GroupChatRunService | null = null
     private readonly eventSink: GroupAgentEventSink | null
+    private mentionBuilder: ((roomId: string, content: string) => StructuredMentionEntry[]) | null = null
 
     constructor(config: AgentConfig, handlers: AgentEventHandler = {}, eventSink: GroupAgentEventSink | null = null) {
         this.agentId = config.agentId || Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
@@ -325,6 +336,10 @@ export class AgentClient implements GroupAgentExecutor {
 
     setChatRunService(service: GroupChatRunService | null): void {
         this.chatRunService = service
+    }
+
+    setMentionBuilder(builder: ((roomId: string, content: string) => StructuredMentionEntry[]) | null): void {
+        this.mentionBuilder = builder
     }
 
     async connect(port?: number): Promise<void> {
@@ -398,11 +413,22 @@ export class AgentClient implements GroupAgentExecutor {
 
     sendMessage(roomId: string, content: string, messageId?: string, extra?: Record<string, unknown>, agentSessionId?: string): Promise<string> {
         this.ensureConnected()
+        const generatedMentions = this.mentionBuilder?.(roomId, content) || []
+        const mentions = generatedMentions.length > 0
+            ? generatedMentions
+            : (extra?.role === 'assistant' ? this.structuredMentionsForAgentReply(roomId, content) : [])
+        const messageExtra = mentions.length ? { ...extra, mentions } : extra
         if (this.eventSink) {
-            return this.eventSink.sendMessage(roomId, content, messageId, extra, agentSessionId)
+            return this.eventSink.sendMessage(roomId, content, messageId, messageExtra, agentSessionId)
         }
         return new Promise((resolve, reject) => {
-            this.socket!.emit('message', { roomId, content, id: messageId, ...extra, ...(agentSessionId ? { agentSessionId } : {}) }, (res: { id?: string; error?: string }) => {
+            this.socket!.emit('message', {
+                roomId,
+                content,
+                id: messageId,
+                ...messageExtra,
+                ...(agentSessionId ? { agentSessionId } : {}),
+            }, (res: { id?: string; error?: string }) => {
                 if (res.error) {
                     reject(new Error(res.error))
                 } else {
@@ -410,6 +436,24 @@ export class AgentClient implements GroupAgentExecutor {
                 }
             })
         })
+    }
+
+    private structuredMentionsForAgentReply(roomId: string, content: string): StructuredMentionEntry[] {
+        const rawAgents = this.storage?.getRoomAgents?.(roomId)
+        const agents = Array.isArray(rawAgents) ? rawAgents : []
+        if (isAllAgentsMentioned(content)) return [{ type: 'all', displayName: 'all' }]
+        const byName = new Map<string, Array<{ agentId: string; name: string }>>()
+        for (const agent of agents) {
+            const participantId = String(agent?.agentId || '').trim()
+            const displayName = String(agent?.name || '').trim()
+            if (!participantId || !displayName || participantId === this.agentId) continue
+            const matches = byName.get(displayName) || []
+            matches.push({ agentId: participantId, name: displayName })
+            byName.set(displayName, matches)
+        }
+        return [...byName.values()]
+            .filter(matches => matches.length === 1 && isAgentMentioned(content, matches[0].name))
+            .map(matches => ({ type: 'agent' as const, participantId: matches[0].agentId, displayName: matches[0].name }))
     }
 
     startTyping(roomId: string): void {
@@ -1667,6 +1711,7 @@ export class AgentClients {
      */
     async createAgent(config: AgentConfig, handlers?: AgentEventHandler, port?: number): Promise<AgentClient> {
         const client = new AgentClient(config, handlers)
+        client.setMentionBuilder((roomId, content) => this.buildAgentReplyMentions(roomId, content))
         await client.connect(port)
 
         // Auto-apply stored references (fixes propagation for agents created after set*)
@@ -1688,6 +1733,9 @@ export class AgentClients {
             this.rooms.set(roomId, room)
         }
 
+        if (typeof (client as any).setMentionBuilder === 'function') {
+            client.setMentionBuilder((targetRoomId, content) => this.buildAgentReplyMentions(targetRoomId, content))
+        }
         room.set(client.agentId, client)
         try {
             const result = await client.joinRoom(roomId)
@@ -1748,6 +1796,18 @@ export class AgentClients {
 
     getConnectedAgents(roomId: string): GroupAgentExecutor[] {
         return this.getAgents(roomId).filter(agent => agent.connected !== false)
+    }
+
+    private buildAgentReplyMentions(roomId: string, content: string): StructuredMentionEntry[] {
+        const agents = this.getAgents(roomId)
+        if (isAllAgentsMentioned(content)) return [{ type: 'all', displayName: 'all' }]
+        return agents
+            .filter(agent => isAgentMentioned(content, agent.name))
+            .map(agent => ({
+                type: 'agent' as const,
+                participantId: agent.agentId,
+                displayName: agent.name,
+            }))
     }
 
     /**
@@ -1964,7 +2024,9 @@ export class AgentClients {
      */
     async processMentions(roomId: string, msg: MentionMessage): Promise<void> {
         const agents = this.getConnectedAgents(roomId)
-        const mentioned = resolveMentionTargets(agents, msg.content, msg.senderId)
+        const mentioned = msg.mentions
+            ? this.resolveStructuredMentionTargets(agents, msg.mentions, msg.senderId)
+            : resolveMentionTargets(agents, msg.content, msg.senderId)
         if (mentioned.length === 0 && msg.role !== 'user') return
 
         if (mentioned.length > 0) {
@@ -1975,6 +2037,17 @@ export class AgentClients {
         if (!this._processingRooms.has(roomId) && !this._pausedRooms.has(roomId)) {
             await this._drainRoomQueue(roomId)
         }
+    }
+
+    private resolveStructuredMentionTargets(
+        agents: GroupAgentExecutor[],
+        mentions: StructuredMention[],
+        senderId: string,
+    ): GroupAgentExecutor[] {
+        const candidates = agents.filter(agent => agent.agentId !== senderId)
+        if (mentions.some(mention => mention.type === 'all')) return candidates
+        const ids = new Set(mentions.flatMap(mention => mention.type === 'agent' ? [mention.participantId] : []))
+        return candidates.filter(agent => ids.has(agent.agentId))
     }
 
     async processSummaryCheck(roomId: string, messageId: string): Promise<void> {

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -231,6 +231,7 @@ export interface RoomInfo {
     maxGuestAgentsPerMember: number
     allowRemoteWorkspaceAccess: number
     createdAt: number
+    lastActiveAt?: number
 }
 
 const ROOM_SELECT_COLUMNS = [
@@ -664,11 +665,11 @@ class ChatStorage {
     getAllRooms(): RoomInfo[] {
         return (this.db()?.prepare(
             `SELECT ${ROOM_SELECT_COLUMNS.split(', ').map(column => `r.${column}`).join(', ')},
-                    ${roomActivityAtSql('m')} AS _activityAt
+                    ${roomActivityAtSql('m')} AS lastActiveAt
              FROM gc_rooms r
              LEFT JOIN gc_messages m ON m.roomId = r.id
              GROUP BY r.id
-             ORDER BY _activityAt DESC, r.id ASC`,
+             ORDER BY lastActiveAt DESC, r.id ASC`,
         ).all() || []) as any[]
     }
 
@@ -678,7 +679,7 @@ class ChatStorage {
         const placeholders = uniqueProfiles.map(() => '?').join(', ')
         return (this.db()?.prepare(
             `SELECT ${ROOM_SELECT_COLUMNS.split(', ').map(column => `r.${column}`).join(', ')},
-                    ${roomActivityAtSql('m')} AS _activityAt
+                    ${roomActivityAtSql('m')} AS lastActiveAt
              FROM gc_rooms r
              INNER JOIN gc_room_agents a ON a.roomId = r.id
              LEFT JOIN gc_messages m ON m.roomId = r.id
@@ -686,7 +687,7 @@ class ChatStorage {
                AND a.executorType = 'server'
                AND a.profile IN (${placeholders})
              GROUP BY r.id
-             ORDER BY _activityAt DESC, r.id ASC`
+             ORDER BY lastActiveAt DESC, r.id ASC`
         ).all(...uniqueProfiles) || []) as any[]
     }
 
@@ -694,13 +695,13 @@ class ChatStorage {
         if (!Number.isFinite(authUserId) || authUserId <= 0) return []
         return (this.db()?.prepare(
             `SELECT ${ROOM_SELECT_COLUMNS.split(', ').map(column => `r.${column}`).join(', ')},
-                    ${roomActivityAtSql('messages')} AS _activityAt
+                    ${roomActivityAtSql('messages')} AS lastActiveAt
              FROM gc_rooms r
              INNER JOIN gc_room_members m ON m.roomId = r.id
              LEFT JOIN gc_messages messages ON messages.roomId = r.id
              WHERE m.authUserId = ?
              GROUP BY r.id
-             ORDER BY _activityAt DESC, r.id ASC`
+             ORDER BY lastActiveAt DESC, r.id ASC`
         ).all(authUserId) || []) as any[]
     }
 
@@ -708,12 +709,12 @@ class ChatStorage {
         if (!Number.isFinite(authUserId) || authUserId <= 0) return []
         return (this.db()?.prepare(
             `SELECT ${ROOM_SELECT_COLUMNS.split(', ').map(column => `r.${column}`).join(', ')},
-                    ${roomActivityAtSql('m')} AS _activityAt
+                    ${roomActivityAtSql('m')} AS lastActiveAt
              FROM gc_rooms r
              LEFT JOIN gc_messages m ON m.roomId = r.id
              WHERE r.ownerAuthUserId = ?
              GROUP BY r.id
-             ORDER BY _activityAt DESC, r.id ASC`
+             ORDER BY lastActiveAt DESC, r.id ASC`
         ).all(authUserId) || []) as any[]
     }
 

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -458,6 +458,9 @@ class ChatStorage {
                     ? authenticatedGroupUserId(Number(room?.ownerAuthUserId))
                     : ''
             )
+        const storedMentions = Object.prototype.hasOwnProperty.call(row, 'mentions')
+            ? { mentions: parseStructuredMentions(row.mentions) }
+            : {}
         return {
             ...row,
             senderType: agent || mayBeAgent ? 'agent' : 'member',
@@ -472,7 +475,7 @@ class ChatStorage {
                 senderOwnerMemberId: ownerMemberId,
             } : {}),
             tool_calls: parseJsonArray(row.tool_calls),
-            mentions: parseStructuredMentions(row.mentions),
+            ...storedMentions,
         }
     }
 
@@ -2489,7 +2492,7 @@ export class GroupChatServer {
             content,
             timestamp: this.normalizeMessageTimestamp(data.timestamp, role),
             persistedAt: Date.now(),
-            mentions: mentionResult.mentions,
+            ...(mentionResult.mentions !== undefined ? { mentions: mentionResult.mentions } : {}),
             run_id: !isHumanMessage && typeof data.run_id === 'string' && data.run_id.trim()
                 ? data.run_id.trim()
                 : null,

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -6,7 +6,13 @@ import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import { logger } from '../../../services/logger'
 import { getDb } from '../../../db'
 import { normalizeMessageContentForStorage, normalizeMessageContentForStorageRole } from '../../../db/hermes/message-content'
-import { AgentClients, GROUP_CHAT_AGENT_SOCKET_SECRET, groupBridgeSessionId, type GroupChatRunService } from './agent-clients'
+import {
+    AgentClients,
+    GROUP_CHAT_AGENT_SOCKET_SECRET,
+    groupBridgeSessionId,
+    type GroupChatRunService,
+    type StructuredMention,
+} from './agent-clients'
 import { SessionDeleter } from '../session-deleter'
 import { countTokens } from '../../../lib/context-compressor'
 import { AgentBridgeClient } from '../agent-bridge'
@@ -18,7 +24,7 @@ import { config } from '../../../config'
 import { createSocketIoCorsOrigin, shouldRejectUpgradeOrigin } from '../../../security'
 import { paginateRecentGroupMessagesCanonical, sliceGroupMessagesCanonical, type GroupMessageCursorCutoff } from './group-message-ordering'
 import { GroupRoomSummaryService, type GroupRoomSummary } from './room-summary'
-import { isAllAgentsMentioned, isReservedMentionName } from './mention-routing'
+import { isAgentMentioned, isAllAgentsMentioned, isReservedMentionName, resolveMentionTargets } from './mention-routing'
 import { isGroupChatRoomOwner } from './access'
 import { normalizeHumanGroupChatContent } from './attachments'
 import { revokeGroupAgentConnector } from './agent-relay-store'
@@ -51,6 +57,8 @@ interface ChatMessage {
     reasoning?: string | null
     reasoning_details?: string | null
     reasoning_content?: string | null
+    persistedAt?: number
+    mentions?: StructuredMention[]
     mentionDepth?: number
     agentSessionId?: string
 }
@@ -222,6 +230,7 @@ export interface RoomInfo {
     guestAgentApproval: 'owner'
     maxGuestAgentsPerMember: number
     allowRemoteWorkspaceAccess: number
+    createdAt: number
 }
 
 const ROOM_SELECT_COLUMNS = [
@@ -244,6 +253,7 @@ const ROOM_SELECT_COLUMNS = [
     'guestAgentApproval',
     'maxGuestAgentsPerMember',
     'allowRemoteWorkspaceAccess',
+    'createdAt',
 ].join(', ')
 
 const ROOM_AGENT_SELECT_COLUMNS = [
@@ -275,6 +285,8 @@ const MESSAGE_SELECT_COLUMNS = [
     'senderAgentRecordId',
     'content',
     'timestamp',
+    'persistedAt',
+    'mentions',
     'run_id',
     'role',
     'tool_call_id',
@@ -285,6 +297,18 @@ const MESSAGE_SELECT_COLUMNS = [
     'reasoning_details',
     'reasoning_content',
 ].join(', ')
+
+function roomActivityAtSql(messageAlias: string): string {
+    return `COALESCE(
+        MAX(CASE
+            WHEN COALESCE(${messageAlias}.role, '') <> 'tool'
+             AND COALESCE(${messageAlias}.finish_reason, '') <> 'streaming'
+            THEN NULLIF(${messageAlias}.persistedAt, 0)
+        END),
+        NULLIF(r.createdAt, 0),
+        0
+    )`
+}
 
 export interface RoomSummaryConfig {
     summaryProfile?: string
@@ -368,6 +392,19 @@ function parseJsonArray(value: unknown): any[] | null {
     }
 }
 
+function parseStructuredMentions(value: unknown): StructuredMention[] {
+    const parsed = parseJsonArray(value)
+    if (!parsed) return []
+    return parsed.flatMap((mention): StructuredMention[] => {
+        if (!mention || typeof mention !== 'object') return []
+        if (mention.type === 'all') return [{ type: 'all' }]
+        if (mention.type === 'agent' && typeof mention.participantId === 'string' && mention.participantId) {
+            return [{ type: 'agent', participantId: mention.participantId }]
+        }
+        return []
+    })
+}
+
 function normalizeMessageRole(role: unknown): string {
     const value = String(role || '').trim()
     return ['user', 'assistant', 'tool', 'command'].includes(value) ? value : 'user'
@@ -434,6 +471,7 @@ class ChatStorage {
                 senderOwnerMemberId: ownerMemberId,
             } : {}),
             tool_calls: parseJsonArray(row.tool_calls),
+            mentions: parseStructuredMentions(row.mentions),
         }
     }
 
@@ -624,7 +662,14 @@ class ChatStorage {
     }
 
     getAllRooms(): RoomInfo[] {
-        return (this.db()?.prepare(`SELECT ${ROOM_SELECT_COLUMNS} FROM gc_rooms ORDER BY id`).all() || []) as any[]
+        return (this.db()?.prepare(
+            `SELECT ${ROOM_SELECT_COLUMNS.split(', ').map(column => `r.${column}`).join(', ')},
+                    ${roomActivityAtSql('m')} AS _activityAt
+             FROM gc_rooms r
+             LEFT JOIN gc_messages m ON m.roomId = r.id
+             GROUP BY r.id
+             ORDER BY _activityAt DESC, r.id ASC`,
+        ).all() || []) as any[]
     }
 
     getRoomsForProfiles(profiles: string[]): RoomInfo[] {
@@ -632,34 +677,43 @@ class ChatStorage {
         if (!uniqueProfiles.length) return []
         const placeholders = uniqueProfiles.map(() => '?').join(', ')
         return (this.db()?.prepare(
-            `SELECT DISTINCT ${ROOM_SELECT_COLUMNS.split(', ').map(column => `r.${column}`).join(', ')}
+            `SELECT ${ROOM_SELECT_COLUMNS.split(', ').map(column => `r.${column}`).join(', ')},
+                    ${roomActivityAtSql('m')} AS _activityAt
              FROM gc_rooms r
              INNER JOIN gc_room_agents a ON a.roomId = r.id
+             LEFT JOIN gc_messages m ON m.roomId = r.id
              WHERE a.removedAt = 0
                AND a.executorType = 'server'
                AND a.profile IN (${placeholders})
-             ORDER BY r.id`
+             GROUP BY r.id
+             ORDER BY _activityAt DESC, r.id ASC`
         ).all(...uniqueProfiles) || []) as any[]
     }
 
     getRoomsForAuthUser(authUserId: number): RoomInfo[] {
         if (!Number.isFinite(authUserId) || authUserId <= 0) return []
         return (this.db()?.prepare(
-            `SELECT DISTINCT ${ROOM_SELECT_COLUMNS.split(', ').map(column => `r.${column}`).join(', ')}
+            `SELECT ${ROOM_SELECT_COLUMNS.split(', ').map(column => `r.${column}`).join(', ')},
+                    ${roomActivityAtSql('messages')} AS _activityAt
              FROM gc_rooms r
              INNER JOIN gc_room_members m ON m.roomId = r.id
+             LEFT JOIN gc_messages messages ON messages.roomId = r.id
              WHERE m.authUserId = ?
-             ORDER BY r.id`
+             GROUP BY r.id
+             ORDER BY _activityAt DESC, r.id ASC`
         ).all(authUserId) || []) as any[]
     }
 
     getOwnedRoomsForAuthUser(authUserId: number): RoomInfo[] {
         if (!Number.isFinite(authUserId) || authUserId <= 0) return []
         return (this.db()?.prepare(
-            `SELECT ${ROOM_SELECT_COLUMNS}
-             FROM gc_rooms
-             WHERE ownerAuthUserId = ?
-             ORDER BY id`
+            `SELECT ${ROOM_SELECT_COLUMNS.split(', ').map(column => `r.${column}`).join(', ')},
+                    ${roomActivityAtSql('m')} AS _activityAt
+             FROM gc_rooms r
+             LEFT JOIN gc_messages m ON m.roomId = r.id
+             WHERE r.ownerAuthUserId = ?
+             GROUP BY r.id
+             ORDER BY _activityAt DESC, r.id ASC`
         ).all(authUserId) || []) as any[]
     }
 
@@ -669,8 +723,8 @@ class ChatStorage {
         this.db()?.prepare(
             `INSERT OR IGNORE INTO gc_rooms (
                 id, name, inviteCode, summaryProfile, summaryProvider, summaryModel,
-                summaryApiMode, summaryEveryTurns, workspace, ownerAuthUserId
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+                summaryApiMode, summaryEveryTurns, workspace, ownerAuthUserId, createdAt
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         ).run(
             id,
             name,
@@ -682,6 +736,7 @@ class ChatStorage {
             Math.max(1, Math.floor(Number(config?.summaryEveryTurns || 20))),
             config?.workspace || '',
             ownerAuthUserId,
+            Date.now(),
         )
     }
 
@@ -851,12 +906,13 @@ class ChatStorage {
     upsertMessage(msg: ChatMessage, existing?: ChatMessage | null): ChatMessage {
         const storedMessage = this.snapshotMessageSender(msg, existing ?? this.getMessage(msg.id))
         const toolCallsJson = storedMessage.tool_calls ? JSON.stringify(storedMessage.tool_calls) : null
+        const mentionsJson = JSON.stringify(storedMessage.mentions || [])
         this.db()?.prepare(
             `INSERT INTO gc_messages (
                 id, roomId, senderId, senderName, senderType, senderAgentRecordId,
-                content, timestamp, run_id, role, tool_call_id, tool_calls,
-                tool_name, finish_reason, reasoning, reasoning_details, reasoning_content
-             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+                content, timestamp, persistedAt, mentions, run_id, role, tool_call_id,
+                tool_calls, tool_name, finish_reason, reasoning, reasoning_details, reasoning_content
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
             + ` ON CONFLICT(id) DO UPDATE SET
                 roomId = excluded.roomId,
                 senderId = excluded.senderId,
@@ -865,6 +921,8 @@ class ChatStorage {
                 senderAgentRecordId = excluded.senderAgentRecordId,
                 content = excluded.content,
                 timestamp = excluded.timestamp,
+                persistedAt = excluded.persistedAt,
+                mentions = excluded.mentions,
                 run_id = excluded.run_id,
                 role = excluded.role,
                 tool_call_id = excluded.tool_call_id,
@@ -883,6 +941,8 @@ class ChatStorage {
             storedMessage.senderAgentRecordId || '',
             messageContentForStorage(storedMessage.role, storedMessage.content),
             storedMessage.timestamp,
+            storedMessage.persistedAt ?? Date.now(),
+            mentionsJson,
             storedMessage.run_id ?? null,
             storedMessage.role || 'user',
             storedMessage.tool_call_id ?? null,
@@ -2290,6 +2350,78 @@ export class GroupChatServer {
         }
     }
 
+    private normalizeStructuredMentions(
+        roomId: string,
+        member: Member | undefined,
+        content: string,
+        rawMentions: unknown,
+    ): { mentions?: StructuredMention[]; error?: string } {
+        const senderId = member?.userId || ''
+        const senderIsAgent = member?.source === 'agent'
+        if (rawMentions === undefined) {
+            const roomAgents = senderIsAgent && typeof this.storage.getRoomAgents === 'function'
+                ? this.storage.getRoomAgents(roomId) as RoomAgent[]
+                : []
+            if (senderIsAgent && (isAllAgentsMentioned(content) || resolveMentionTargets(roomAgents, content, senderId).length > 0)) {
+                return { error: 'Agent mentions require structured metadata' }
+            }
+            return senderIsAgent ? { mentions: [] } : {}
+        }
+        if (!Array.isArray(rawMentions)) return { error: 'Invalid structured mentions' }
+        const roomAgents = this.storage.getRoomAgents(roomId) as RoomAgent[]
+        const visibleAllMention = isAllAgentsMentioned(content)
+        const visibleParticipantIds = new Set(
+            roomAgents
+                .filter(agent => isAgentMentioned(content, agent.name))
+                .map(agent => agent.agentId),
+        )
+
+        const normalized: StructuredMention[] = []
+        const participantIds = new Set<string>()
+        let allSeen = false
+        for (const rawMention of rawMentions) {
+            if (!rawMention || typeof rawMention !== 'object' || Array.isArray(rawMention)) {
+                return { error: 'Invalid structured mentions' }
+            }
+            const mention = rawMention as Record<string, unknown>
+            if (mention.type === 'all') {
+                if (allSeen || normalized.length > 0 || mention.displayName !== 'all' || !visibleAllMention) {
+                    return { error: 'Invalid structured mentions' }
+                }
+                allSeen = true
+                normalized.push({ type: 'all' })
+                continue
+            }
+            if (mention.type !== 'agent'
+                || typeof mention.participantId !== 'string'
+                || typeof mention.displayName !== 'string'
+                || allSeen
+                || participantIds.has(mention.participantId)
+                || mention.participantId === senderId) {
+                return { error: 'Invalid structured mentions' }
+            }
+            const target = roomAgents.find(agent => agent.agentId === mention.participantId)
+            if (!target || target.name !== mention.displayName || !isAgentMentioned(content, target.name)) {
+                return { error: 'Invalid structured mentions' }
+            }
+            participantIds.add(target.agentId)
+            normalized.push({ type: 'agent', participantId: target.agentId })
+        }
+
+        if (senderIsAgent) {
+            const structuredAll = normalized.length === 1 && normalized[0].type === 'all'
+            const visibleAgentMentionIds = [...visibleParticipantIds]
+            if (visibleAllMention
+                ? !structuredAll || visibleAgentMentionIds.length > 0
+                : structuredAll
+                    || participantIds.size !== visibleAgentMentionIds.length
+                    || visibleAgentMentionIds.some(participantId => !participantIds.has(participantId))) {
+                return { error: 'Invalid structured mentions' }
+            }
+        }
+        return { mentions: normalized }
+    }
+
     private handleMessage(socket: Socket, data: IncomingGroupChatMessage, ack?: (res: any) => void): void {
         if (!data || (typeof data.content !== 'string' && !Array.isArray(data.content))) {
             ack?.({ error: 'Invalid message content' })
@@ -2341,14 +2473,22 @@ export class GroupChatServer {
             })
             return
         }
+        const content = contentToStorageString(messageContent)
+        const mentionResult = this.normalizeStructuredMentions(roomId, member, contentToText(messageContent), data.mentions)
+        if (mentionResult.error) {
+            ack?.({ error: mentionResult.error })
+            return
+        }
 
         const msg: ChatMessage = {
             id: this.normalizeClientMessageId(data.id) || this.generateId(),
             roomId,
             senderId: userId,
             senderName: userName,
-            content: contentToStorageString(messageContent),
+            content,
             timestamp: this.normalizeMessageTimestamp(data.timestamp, role),
+            persistedAt: Date.now(),
+            mentions: mentionResult.mentions,
             run_id: !isHumanMessage && typeof data.run_id === 'string' && data.run_id.trim()
                 ? data.run_id.trim()
                 : null,
@@ -2393,6 +2533,7 @@ export class GroupChatServer {
                 timestamp: savedMsg.timestamp,
                 role: savedMsg.role,
                 mentionDepth,
+                mentions: savedMsg.mentions,
             }).catch((err) => {
                 logger.error(`[GroupChat] processMentions error: ${err.message}`)
             })

--- a/packages/server/src/services/hermes/group-chat/mention-routing.ts
+++ b/packages/server/src/services/hermes/group-chat/mention-routing.ts
@@ -6,6 +6,11 @@ type MentionableAgent = {
     agentId?: string
 }
 
+export type StructuredMention = {
+    type: 'agent' | 'all'
+    participantId?: string
+}
+
 type MentionRange = {
     start: number
     end: number
@@ -84,6 +89,22 @@ export function resolveMentionTargets<T extends MentionableAgent>(
     }
 
     return candidates.filter((agent) => isAgentMentioned(content, agent.name))
+}
+
+export function resolveStructuredMentionTargets<T extends MentionableAgent>(
+    agents: T[],
+    mentions: StructuredMention[],
+    senderId: string,
+): T[] {
+    const candidates = agents.filter((agent) => !isSenderAgent(agent, senderId))
+    if (mentions.some(mention => mention.type === 'all')) return candidates
+    const participantIds = new Set(
+        mentions
+            .filter((mention): mention is StructuredMention & { type: 'agent'; participantId: string } =>
+                mention.type === 'agent' && typeof mention.participantId === 'string' && mention.participantId.length > 0)
+            .map(mention => mention.participantId),
+    )
+    return candidates.filter(agent => participantIds.has(agent.agentId || agent.id || ''))
 }
 
 export function stripMentionRoutingTokens(content: string, ownAgentName: string): string {

--- a/packages/server/src/services/hermes/run-chat/session-command.ts
+++ b/packages/server/src/services/hermes/run-chat/session-command.ts
@@ -1186,6 +1186,7 @@ function createBranchSession(parentSessionId: string, requestedTitle: string, ct
     title,
     parent_session_id: parentSessionId,
     workspace: parent.workspace || undefined,
+    category_id: parent.category_id ?? null,
     ended_at: nowSeconds,
     last_active: nowSeconds,
     messages: sourceMessages.map(message => ({

--- a/tests/client/group-chat-input-mentions.test.ts
+++ b/tests/client/group-chat-input-mentions.test.ts
@@ -12,7 +12,7 @@ vi.mock('vue-i18n', () => ({
 }))
 
 vi.mock('naive-ui', () => ({
-  NButton: { template: '<button type="button" v-bind="$attrs"><slot /><slot name="icon" /></button>' },
+  NButton: { emits: ['click'], template: '<button type="button" v-bind="$attrs" @click="$emit(\'click\', $event)"><slot /><slot name="icon" /></button>' },
   NTooltip: { template: '<div><slot name="trigger" /><slot /></div>' },
   NSwitch: { template: '<button type="button"></button>' },
   NDropdown: { template: '<div><slot /></div>' },
@@ -134,6 +134,153 @@ describe('GroupChatInput mentions', () => {
     expect(store.activeMessageReference).toBeNull()
   })
 
+  it('automatically mentions a valid quoted agent once', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    const settingsStore = useSettingsStore()
+    settingsStore.display = {}
+    const store = useGroupChatStore()
+    store.currentRoomId = 'room-1'
+    store.userId = 'human-1'
+    store.agents = [{ id: 'row-1', agentId: 'agent-1', profile: 'worker', name: 'Worker', roomId: 'room-1', description: '', invited: 1 }]
+    const onSend = vi.fn()
+    const wrapper = mount(GroupChatInput, {
+      props: { onSend },
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+
+    store.setMessageReference('room-1', {
+      id: 'message-1',
+      role: 'assistant',
+      content: 'A referenced response',
+      sender: 'Worker',
+      senderId: 'agent-1',
+    })
+    await nextTick()
+
+    expect((wrapper.get('textarea').element as HTMLTextAreaElement).value).toBe('@Worker ')
+    await wrapper.get('textarea').setValue('@Worker please review')
+    ;(wrapper.vm as any).handleSend()
+    expect(onSend).toHaveBeenCalledWith(
+      '@Worker please review',
+      undefined,
+      [{ type: 'agent', participantId: 'agent-1', displayName: 'Worker' }],
+    )
+    store.setMessageReference('room-1', {
+      id: 'message-2',
+      role: 'assistant',
+      content: 'Another response',
+      sender: 'Worker',
+      senderId: 'agent-1',
+    })
+    await nextTick()
+    expect((wrapper.get('textarea').element as HTMLTextAreaElement).value).toBe('@Worker ')
+  })
+
+  it('clears structured mention metadata when its visible text is deleted', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    const settingsStore = useSettingsStore()
+    settingsStore.display = {}
+    const store = useGroupChatStore()
+    store.currentRoomId = 'room-1'
+    store.userId = 'human-1'
+    store.agents = [{ id: 'row-1', agentId: 'agent-1', profile: 'worker', name: 'Worker', roomId: 'room-1', description: '', invited: 1 }]
+    const onSend = vi.fn()
+    const wrapper = mount(GroupChatInput, {
+      props: { onSend },
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+
+    store.setMessageReference('room-1', {
+      id: 'message-1',
+      role: 'assistant',
+      content: 'A referenced response',
+      sender: 'Worker',
+      senderId: 'agent-1',
+    })
+    await nextTick()
+    await wrapper.get('textarea').setValue('please review')
+    ;(wrapper.vm as any).handleSend()
+
+    expect(onSend).toHaveBeenCalledWith('please review', undefined, undefined)
+  })
+
+  it('keeps same-name mention identities independent when one token is deleted', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    const settingsStore = useSettingsStore()
+    settingsStore.display = {}
+    const store = useGroupChatStore()
+    store.currentRoomId = 'room-1'
+    store.userId = 'human-1'
+    store.agents = [
+      { id: 'row-1', agentId: 'agent-1', profile: 'first', name: 'Alex', roomId: 'room-1', description: '', invited: 1 },
+      { id: 'row-2', agentId: 'agent-2', profile: 'second', name: 'Alex', roomId: 'room-1', description: '', invited: 1 },
+    ]
+    const onSend = vi.fn()
+    const wrapper = mount(GroupChatInput, {
+      props: { onSend },
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+    store.setMessageReference('room-1', {
+      id: 'first-alex',
+      role: 'assistant',
+      content: 'First',
+      sender: 'Alex',
+      senderId: 'agent-1',
+    })
+    await nextTick()
+    store.setMessageReference('room-1', {
+      id: 'second-alex',
+      role: 'assistant',
+      content: 'Second',
+      sender: 'Alex',
+      senderId: 'agent-2',
+    })
+    await nextTick()
+    const textarea = wrapper.get('textarea')
+    expect((textarea.element as HTMLTextAreaElement).value).toBe('@Alex @Alex ')
+
+    await textarea.setValue('@Alex ')
+    ;(wrapper.vm as any).handleSend()
+
+    expect(onSend).toHaveBeenCalledWith(
+      '@Alex',
+      undefined,
+      [{ type: 'agent', participantId: 'agent-2', displayName: 'Alex' }],
+    )
+  })
+
+  it('does not auto-mention self or an invalid quoted sender', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    const settingsStore = useSettingsStore()
+    settingsStore.display = {}
+    const store = useGroupChatStore()
+    store.currentRoomId = 'room-1'
+    store.userId = 'human-1'
+    const wrapper = mount(GroupChatInput, {
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+
+    store.setMessageReference('room-1', {
+      id: 'self',
+      role: 'user',
+      content: 'My message',
+      sender: 'Me',
+      senderId: 'human-1',
+    })
+    await nextTick()
+    expect((wrapper.get('textarea').element as HTMLTextAreaElement).value).toBe('')
+
+    store.setMessageReference('room-1', {
+      id: 'missing',
+      role: 'assistant',
+      content: 'Removed member',
+      sender: 'Removed',
+      senderId: 'removed-1',
+    })
+    await nextTick()
+    expect((wrapper.get('textarea').element as HTMLTextAreaElement).value).toBe('')
+  })
+
   it('applies the configured desktop input height', async () => {
     const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
     const settingsStore = useSettingsStore()
@@ -190,16 +337,17 @@ describe('GroupChatInput mentions', () => {
     const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
     const settingsStore = useSettingsStore()
     settingsStore.display = {}
+    const onSendBlocked = vi.fn()
     const wrapper = mount(GroupChatInput, {
-      props: { sendBlocked: true },
+      props: { sendBlocked: true, onSendBlocked },
       global: { plugins: [pinia], stubs: { Transition: false } },
     })
     const textarea = wrapper.get('textarea')
 
     await textarea.setValue('@Worker keep this draft')
-    await textarea.trigger('keydown', { key: 'Enter' })
+    ;(wrapper.vm as any).handleSend()
 
-    expect(wrapper.emitted('send-blocked')).toHaveLength(1)
+    expect(onSendBlocked).toHaveBeenCalledOnce()
     expect(wrapper.emitted('send')).toBeUndefined()
     expect((textarea.element as HTMLTextAreaElement).value).toBe('@Worker keep this draft')
   })

--- a/tests/client/group-chat-input-mentions.test.ts
+++ b/tests/client/group-chat-input-mentions.test.ts
@@ -109,6 +109,32 @@ describe('GroupChatInput mentions', () => {
     wrapper.unmount()
   })
 
+  it('uses the avatar agent id when historical agents have the same name', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    const settingsStore = useSettingsStore()
+    settingsStore.display = {}
+    const store = useGroupChatStore()
+    store.agents = [
+      { id: 'row-1', agentId: 'agent-1', profile: 'first', name: 'Alex', roomId: 'room-1', description: '', invited: 1 },
+      { id: 'row-2', agentId: 'agent-2', profile: 'second', name: 'Alex', roomId: 'room-1', description: '', invited: 1 },
+    ]
+    store.emitTyping = vi.fn()
+    const onSend = vi.fn()
+    const wrapper = mount(GroupChatInput, {
+      props: { onSend },
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+
+    ;(wrapper.vm as any).insertMention('Alex', 'agent-2')
+    ;(wrapper.vm as any).handleSend()
+
+    expect(onSend).toHaveBeenCalledWith(
+      '@Alex',
+      undefined,
+      [{ type: 'agent', participantId: 'agent-2', displayName: 'Alex' }],
+    )
+  })
+
   it('shows the active room reference outside the input and can cancel it', async () => {
     const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
     const settingsStore = useSettingsStore()

--- a/tests/client/group-chat-panel-workspace-source.test.ts
+++ b/tests/client/group-chat-panel-workspace-source.test.ts
@@ -298,7 +298,7 @@ describe('GroupChatPanel workspace save handling', () => {
     expect(runCardSource).toContain('<GroupAgentMessageAvatar')
     expect(runCardSource).not.toContain('run-agent-description')
     expect(panelSource).toContain('@mention-agent="handleMentionAgent"')
-    expect(panelSource).toContain('groupChatInputRef.value?.insertMention?.(agent.name)')
+    expect(panelSource).toContain('groupChatInputRef.value?.insertMention?.(agent.name, agent.agentId)')
     expect(panelSource).not.toContain('class="agent-avatar-popover"')
   })
 

--- a/tests/client/group-chat-store-baseline.test.ts
+++ b/tests/client/group-chat-store-baseline.test.ts
@@ -209,6 +209,20 @@ describe('group chat store baseline lifecycle', () => {
     expect(store.rooms.map((item: RoomInfo) => item.id)).toEqual(['recent-room', 'future-agent'])
   })
 
+  it('keeps the REST room order based on the server public lastActiveAt instead of createdAt', async () => {
+    const store = await loadStore()
+    groupChatApiMock.listRooms.mockResolvedValue({
+      rooms: [
+        { ...room, id: 'room-old-active', createdAt: 100, lastActiveAt: 300 },
+        { ...room, id: 'room-new-created', createdAt: 200, lastActiveAt: 200 },
+      ],
+    })
+
+    await store.loadRooms()
+
+    expect(store.rooms.map((item: RoomInfo) => item.id)).toEqual(['room-old-active', 'room-new-created'])
+  })
+
   it('binds autoplay events to the responding agent profile', async () => {
     vi.useFakeTimers()
     const store = await loadStore()

--- a/tests/client/group-chat-store-baseline.test.ts
+++ b/tests/client/group-chat-store-baseline.test.ts
@@ -182,6 +182,33 @@ describe('group chat store baseline lifecycle', () => {
     expect(groupChatApiMock.socket.on).toHaveBeenCalledWith('room_summary_updated', expect.any(Function))
   })
 
+  it('uses server persisted activity time instead of an agent display timestamp for live room ordering', async () => {
+    const store = await loadStore()
+    store.rooms = [
+      { ...room, id: 'future-agent', createdAt: 1, lastActiveAt: 1 },
+      { ...room, id: 'recent-room', createdAt: 2, lastActiveAt: 2 },
+    ]
+
+    await store.connect()
+    emitSocket('message', userMessage({
+      id: 'future-agent-message',
+      roomId: 'future-agent',
+      senderId: 'agent-1',
+      senderName: 'Agent',
+      role: 'assistant',
+      timestamp: 9_999_999_999_999,
+      persistedAt: 3,
+    }))
+    emitSocket('message', userMessage({
+      id: 'recent-room-message',
+      roomId: 'recent-room',
+      timestamp: 4,
+      persistedAt: 4,
+    }))
+
+    expect(store.rooms.map((item: RoomInfo) => item.id)).toEqual(['recent-room', 'future-agent'])
+  })
+
   it('binds autoplay events to the responding agent profile', async () => {
     vi.useFakeTimers()
     const store = await loadStore()

--- a/tests/client/group-chat-store-baseline.test.ts
+++ b/tests/client/group-chat-store-baseline.test.ts
@@ -209,6 +209,41 @@ describe('group chat store baseline lifecycle', () => {
     expect(store.rooms.map((item: RoomInfo) => item.id)).toEqual(['recent-room', 'future-agent'])
   })
 
+  it('does not let live tool or streaming messages change room ordering', async () => {
+    const store = await loadStore()
+    store.rooms = [
+      { ...room, id: 'visible-room', createdAt: 2, lastActiveAt: 2 },
+      { ...room, id: 'internal-room', createdAt: 1, lastActiveAt: 1 },
+    ]
+
+    await store.connect()
+    emitSocket('message', userMessage({
+      id: 'tool-message',
+      roomId: 'internal-room',
+      role: 'tool',
+      persistedAt: 100,
+    }))
+    emitSocket('message', userMessage({
+      id: 'streaming-message',
+      roomId: 'internal-room',
+      role: 'assistant',
+      finish_reason: 'streaming',
+      persistedAt: 101,
+    }))
+
+    expect(store.rooms.map((item: RoomInfo) => item.id)).toEqual(['visible-room', 'internal-room'])
+    expect(store.rooms.find((item: RoomInfo) => item.id === 'internal-room')?.lastActiveAt).toBe(1)
+
+    emitSocket('message', userMessage({
+      id: 'visible-message',
+      roomId: 'internal-room',
+      role: 'assistant',
+      finish_reason: 'stop',
+      persistedAt: 102,
+    }))
+    expect(store.rooms.map((item: RoomInfo) => item.id)).toEqual(['internal-room', 'visible-room'])
+  })
+
   it('keeps the REST room order based on the server public lastActiveAt instead of createdAt', async () => {
     const store = await loadStore()
     groupChatApiMock.listRooms.mockResolvedValue({

--- a/tests/client/session-category-groups.test.ts
+++ b/tests/client/session-category-groups.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildVisibleSessionCategoryGroups } from '../../packages/client/src/components/hermes/chat/session-category-groups'
+import {
+  buildRecentSessionCategoryGroup,
+  buildVisibleSessionCategoryGroups,
+} from '../../packages/client/src/components/hermes/chat/session-category-groups'
 
 describe('session category groups', () => {
   it('hides categories that have no visible sessions', () => {
@@ -42,5 +45,20 @@ describe('session category groups', () => {
       label: 'Uncategorized',
       sessions: [{ id: 'session-1', categoryId: 999 }],
     }])
+  })
+
+  it('builds a dynamic recent group by strict activity time without changing real categories', () => {
+    const sessions = [
+      { id: 'older', categoryId: 1, updatedAt: 100 },
+      { id: 'newest', categoryId: null, updatedAt: 300 },
+      { id: 'middle', categoryId: 2, updatedAt: 200 },
+    ]
+
+    expect(buildRecentSessionCategoryGroup(sessions, 2, 'Recent')).toEqual({
+      key: 'recent',
+      label: 'Recent',
+      sessions: [sessions[1], sessions[2]],
+    })
+    expect(sessions.map(session => session.categoryId)).toEqual([1, null, 2])
   })
 })

--- a/tests/client/session-category-groups.test.ts
+++ b/tests/client/session-category-groups.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildRecentSessionCategoryGroup,
   buildVisibleSessionCategoryGroups,
+  partitionRecentSessions,
 } from '../../packages/client/src/components/hermes/chat/session-category-groups'
 
 describe('session category groups', () => {
@@ -60,5 +61,28 @@ describe('session category groups', () => {
       sessions: [sessions[1], sessions[2]],
     })
     expect(sessions.map(session => session.categoryId)).toEqual([1, null, 2])
+  })
+
+  it('excludes recent sessions from every other sidebar category', () => {
+    const sessions = [
+      { id: 'older-pinned', categoryId: 1, updatedAt: 100 },
+      { id: 'newest-categorized', categoryId: 1, updatedAt: 300 },
+      { id: 'middle-uncategorized', categoryId: null, updatedAt: 200 },
+    ]
+
+    const partition = partitionRecentSessions(sessions, 2, 'Recent')
+    const otherGroups = buildVisibleSessionCategoryGroups(
+      [{ id: 1, name: 'Work' }],
+      partition.remaining,
+      'Uncategorized',
+    )
+
+    expect(partition.group.sessions.map(session => session.id)).toEqual([
+      'newest-categorized',
+      'middle-uncategorized',
+    ])
+    expect(otherGroups.flatMap(group => group.sessions.map(session => session.id))).toEqual([
+      'older-pinned',
+    ])
   })
 })

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -4,9 +4,9 @@ import { authenticate, TEST_MODEL_GROUP } from './fixtures'
 type DesktopPlatform = 'darwin' | 'win32'
 
 const baseRooms = [
-  { id: 'room-alpha', name: 'Alpha Room', inviteCode: 'ALPHA1', canManage: true, workspace: '/tmp/alpha', triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10, totalTokens: 123, allowGuestAgents: 1, maxGuestAgentsPerMember: 1, allowRemoteWorkspaceAccess: 0 },
-  { id: 'room-beta', name: 'Beta Room', inviteCode: 'BETA22', canManage: true, workspace: '/tmp/beta', triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10, totalTokens: 456, allowGuestAgents: 1, maxGuestAgentsPerMember: 1, allowRemoteWorkspaceAccess: 0 },
-  { id: 'room-readonly', name: 'Read Only Room', inviteCode: null, canManage: false, workspace: '/tmp/readonly', triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10, totalTokens: 0 },
+  { id: 'room-alpha', name: 'Alpha Room', inviteCode: 'ALPHA1', canManage: true, workspace: '/tmp/alpha', triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10, totalTokens: 123, allowGuestAgents: 1, maxGuestAgentsPerMember: 1, allowRemoteWorkspaceAccess: 0, createdAt: 1_790_000_000, lastActiveAt: 1_790_000_001 },
+  { id: 'room-beta', name: 'Beta Room', inviteCode: 'BETA22', canManage: true, workspace: '/tmp/beta', triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10, totalTokens: 456, allowGuestAgents: 1, maxGuestAgentsPerMember: 1, allowRemoteWorkspaceAccess: 0, createdAt: 1_790_000_000, lastActiveAt: 1_790_000_100 },
+  { id: 'room-readonly', name: 'Read Only Room', inviteCode: null, canManage: false, workspace: '/tmp/readonly', triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10, totalTokens: 0, createdAt: 1_789_999_999, lastActiveAt: 1_789_999_999 },
 ]
 
 const groupWorkspaceDiff = {
@@ -486,7 +486,7 @@ test.describe('group chat room deep links', () => {
   test('unknown route room id falls back to the first available room', async ({ page }) => {
     await setup(page, '/#/hermes/group-chat/room/missing-room')
 
-    await expect(page).toHaveURL(/#\/hermes\/group-chat\/room\/room-alpha$/)
-    await expect(page.locator('.room-title-text', { hasText: 'Alpha Room' })).toBeVisible()
+    await expect(page).toHaveURL(/#\/hermes\/group-chat\/room\/room-beta$/)
+    await expect(page.locator('.room-title-text', { hasText: 'Beta Room' })).toBeVisible()
   })
 })

--- a/tests/e2e/session-categories.spec.ts
+++ b/tests/e2e/session-categories.spec.ts
@@ -61,22 +61,34 @@ test('groups sessions by category and persists collapsed groups', async ({ page 
 
   await page.goto('/#/hermes/chat')
 
+  const recentHeader = page.locator('.session-group-header').filter({ hasText: 'Recent' })
+  await expect(recentHeader).toBeVisible()
+  await expect(recentHeader.locator('.session-group-count')).toHaveText('3')
+  await expect(page.locator('.session-group-header').first()).toContainText('Recent')
   const workHeader = page.locator('.session-group-header').filter({ hasText: 'Work' })
   await expect(workHeader).toBeVisible()
   await expect(workHeader.locator('.session-group-count')).toHaveText('2')
   await expect(page.locator('.session-group-header').filter({ hasText: 'Empty' })).toHaveCount(0)
-  await expect(page.getByRole('link', { name: /Project Alpha/ })).toBeVisible()
-  await expect(page.getByRole('link', { name: /Project Beta/ })).toBeVisible()
+  await expect(page.getByRole('link', { name: /Project Alpha/ }).first()).toBeVisible()
+  await expect(page.getByRole('link', { name: /Project Beta/ }).first()).toBeVisible()
+
+  await recentHeader.getByRole('button').click()
+  const recentDialog = page.getByRole('dialog').filter({ hasText: 'Recent session count' })
+  await recentDialog.locator('input').fill('2')
+  await recentDialog.getByRole('button', { name: 'OK', exact: true }).click()
+  await expect(recentHeader.locator('.session-group-count')).toHaveText('2')
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('hermes_recent_session_count_v1'))).toBe('2')
 
   await workHeader.click()
-  await expect(page.getByText('Project Alpha', { exact: true })).toBeHidden()
-  await expect(page.getByText('Project Beta', { exact: true })).toBeHidden()
+  await expect(page.getByText('Project Alpha', { exact: true })).toHaveCount(1)
+  await expect(page.getByText('Project Beta', { exact: true })).toHaveCount(0)
   await expect.poll(() => page.evaluate(() => localStorage.getItem('hermes_chat_collapsed_categories')))
     .toContain('category-1')
 
   await page.reload()
   await expect(page.locator('.session-group-header').filter({ hasText: 'Work' })).toBeVisible()
-  await expect(page.getByText('Project Alpha', { exact: true })).toBeHidden()
+  await expect(page.getByText('Project Alpha', { exact: true })).toHaveCount(1)
+  await expect(recentHeader.locator('.session-group-count')).toHaveText('2')
 })
 
 test('creates a category in the new chat selector and sends its id with the first run', async ({ page }) => {
@@ -140,7 +152,7 @@ test('renames and deletes a category from its context menu', async ({ page }) =>
   await expect(page.getByText('Category deleted')).toBeVisible()
   await expect(page.locator('.session-group-header').filter({ hasText: 'Client Work' })).toHaveCount(0)
   await expect(page.locator('.session-group-header').filter({ hasText: 'Uncategorized' })).toBeVisible()
-  await expect(page.getByRole('link', { name: /Project Alpha/ })).toBeVisible()
+  await expect(page.getByRole('link', { name: /Project Alpha/ }).first()).toBeVisible()
   expect(api.requests.some(request =>
     request.method === 'PATCH' && request.pathname === '/api/hermes/session-categories/1',
   )).toBe(true)
@@ -161,13 +173,13 @@ test('moves a session to another category from its context menu', async ({ page 
   await mockChatSocket(page)
 
   await page.goto('/#/hermes/chat')
-  await page.getByRole('link', { name: /General Notes/ }).click({ button: 'right' })
+  await page.getByRole('link', { name: /General Notes/ }).last().click({ button: 'right' })
   await page.locator('.n-dropdown-option').filter({ hasText: 'Move to category' }).hover()
   await page.locator('.n-dropdown-option').filter({ hasText: /^Work$/ }).click()
 
   await expect(page.getByText('Category updated')).toBeVisible()
   await expect(page.locator('.session-group-header').filter({ hasText: 'Work' })).toBeVisible()
-  await expect(page.getByRole('link', { name: /General Notes/ })).toBeVisible()
+  await expect(page.getByRole('link', { name: /General Notes/ }).first()).toBeVisible()
   const moveRequest = api.requests.find(request =>
     request.method === 'POST' && request.pathname === '/api/hermes/sessions/general-session/category',
   )

--- a/tests/e2e/session-categories.spec.ts
+++ b/tests/e2e/session-categories.spec.ts
@@ -66,8 +66,7 @@ test('groups sessions by category and persists collapsed groups', async ({ page 
   await expect(recentHeader.locator('.session-group-count')).toHaveText('3')
   await expect(page.locator('.session-group-header').first()).toContainText('Recent')
   const workHeader = page.locator('.session-group-header').filter({ hasText: 'Work' })
-  await expect(workHeader).toBeVisible()
-  await expect(workHeader.locator('.session-group-count')).toHaveText('2')
+  await expect(workHeader).toHaveCount(0)
   await expect(page.locator('.session-group-header').filter({ hasText: 'Empty' })).toHaveCount(0)
   await expect(page.getByRole('link', { name: /Project Alpha/ }).first()).toBeVisible()
   await expect(page.getByRole('link', { name: /Project Beta/ }).first()).toBeVisible()
@@ -78,6 +77,8 @@ test('groups sessions by category and persists collapsed groups', async ({ page 
   await recentDialog.getByRole('button', { name: 'OK', exact: true }).click()
   await expect(recentHeader.locator('.session-group-count')).toHaveText('2')
   await expect.poll(() => page.evaluate(() => localStorage.getItem('hermes_recent_session_count_v1'))).toBe('2')
+  await expect(workHeader).toBeVisible()
+  await expect(workHeader.locator('.session-group-count')).toHaveText('1')
 
   await workHeader.click()
   await expect(page.getByText('Project Alpha', { exact: true })).toHaveCount(1)
@@ -124,10 +125,14 @@ test('renames and deletes a category from its context menu', async ({ page }) =>
   await authenticate(page, TEST_ACCESS_KEY, 'research')
   await page.addInitScript(() => {
     localStorage.setItem('hermes_chat_collapsed_categories', '[]')
+    localStorage.setItem('hermes_recent_session_count_v1', '1')
   })
   const api = await mockHermesApi(page, {
     sessionCategories: [{ id: 1, name: 'Work' }],
-    sessions: [sessionSummary('work-session', 'Project Alpha', 1, 100)],
+    sessions: [
+      sessionSummary('recent-session', 'Latest Notes', null, 200),
+      sessionSummary('work-session', 'Project Alpha', 1, 100),
+    ],
   })
   await mockChatSocket(page)
 
@@ -165,10 +170,14 @@ test('moves a session to another category from its context menu', async ({ page 
   await authenticate(page, TEST_ACCESS_KEY, 'research')
   await page.addInitScript(() => {
     localStorage.setItem('hermes_chat_collapsed_categories', '[]')
+    localStorage.setItem('hermes_recent_session_count_v1', '1')
   })
   const api = await mockHermesApi(page, {
     sessionCategories: [{ id: 1, name: 'Work' }],
-    sessions: [sessionSummary('general-session', 'General Notes', null, 100)],
+    sessions: [
+      sessionSummary('recent-session', 'Latest Notes', null, 200),
+      sessionSummary('general-session', 'General Notes', null, 100),
+    ],
   })
   await mockChatSocket(page)
 

--- a/tests/server/group-chat-agent-routing-baseline.test.ts
+++ b/tests/server/group-chat-agent-routing-baseline.test.ts
@@ -45,7 +45,7 @@ describe('group chat agent routing baseline', () => {
     return groupRuntimeSessionId('room-1', 'default', 'Worker')
   }
 
-  it('routes human messages through mention processing', async () => {
+  it('forwards only server-validated structured mentions to mention processing', async () => {
     const { human } = await joinHumanAndAgent()
     const processMentions = vi.spyOn(groupServer.agentClients, 'processMentions').mockResolvedValue(undefined)
 
@@ -55,6 +55,19 @@ describe('group chat agent routing baseline', () => {
       messageId: 'human-msg-1',
       role: 'user',
       mentionDepth: 0,
+      mentions: undefined,
+    }))
+
+    await emitAck(human, 'message', {
+      roomId: 'room-1',
+      id: 'human-msg-2',
+      content: '@Worker hello',
+      mentions: [{ type: 'agent', participantId: 'agent-worker', displayName: 'Worker' }],
+    })
+
+    expect(processMentions).toHaveBeenLastCalledWith('room-1', expect.objectContaining({
+      messageId: 'human-msg-2',
+      mentions: [{ type: 'agent', participantId: 'agent-worker' }],
     }))
   })
 

--- a/tests/server/group-chat-agent-workspace.test.ts
+++ b/tests/server/group-chat-agent-workspace.test.ts
@@ -205,6 +205,34 @@ describe('group chat agent workspace bridge runs', () => {
     }), expect.any(Function))
   })
 
+  it('does not generate a structured mention for the replying agent itself', async () => {
+    const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')
+    const clients = new AgentClients() as any
+    const author = await clients.createAgent({
+      agentId: 'agent-author',
+      profile: 'default',
+      name: 'Author',
+      description: '',
+      invited: 0,
+      backgroundDelegationEnabled: false,
+    })
+    const replyToMention = vi.fn(async () => {})
+    clients.rooms.set('room-1', new Map([
+      ['agent-author', author],
+      ['agent-reviewer', { agentId: 'agent-reviewer', name: 'Reviewer', replyToMention }],
+    ]))
+
+    await author.sendMessage('room-1', '@Author status: waiting for @Reviewer.', 'self-mention-1')
+
+    expect(mockSocket.emit).toHaveBeenCalledWith('message', expect.objectContaining({
+      roomId: 'room-1',
+      id: 'self-mention-1',
+      content: '@Author status: waiting for @Reviewer.',
+      mentions: [{ type: 'agent', participantId: 'agent-reviewer', displayName: 'Reviewer' }],
+    }), expect.any(Function))
+    expect(replyToMention).not.toHaveBeenCalled()
+  })
+
   it('dispatches a Codex group agent through chat-run without invoking the Hermes bridge', async () => {
     const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')
     const runAndWait = vi.fn(async (_data: any, options: any) => {

--- a/tests/server/group-chat-agent-workspace.test.ts
+++ b/tests/server/group-chat-agent-workspace.test.ts
@@ -178,7 +178,7 @@ describe('group chat agent workspace bridge runs', () => {
     expect(hermesSession).not.toBe(codexSession)
     expect(codexResponsesSession).not.toBe(codexChatSession)
     expect(hermesWithIgnoredApiMode).toBe(hermesSession)
-  })
+  }, 15_000)
 
   it('generates a complete entry mention DTO for an agent reply handoff', async () => {
     const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')

--- a/tests/server/group-chat-agent-workspace.test.ts
+++ b/tests/server/group-chat-agent-workspace.test.ts
@@ -180,6 +180,31 @@ describe('group chat agent workspace bridge runs', () => {
     expect(hermesWithIgnoredApiMode).toBe(hermesSession)
   })
 
+  it('generates a complete entry mention DTO for an agent reply handoff', async () => {
+    const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')
+    const clients = new AgentClients() as any
+    const author = await clients.createAgent({
+      agentId: 'agent-author',
+      profile: 'default',
+      name: 'Author',
+      description: '',
+      invited: 0,
+      backgroundDelegationEnabled: false,
+    })
+    clients.rooms.set('room-1', new Map([
+      ['agent-author', author],
+      ['agent-reviewer', { agentId: 'agent-reviewer', name: 'Reviewer' }],
+    ]))
+
+    await author.sendMessage('room-1', '@Reviewer please verify this.', 'handoff-1')
+
+    expect(mockSocket.emit).toHaveBeenCalledWith('message', expect.objectContaining({
+      roomId: 'room-1',
+      id: 'handoff-1',
+      mentions: [{ type: 'agent', participantId: 'agent-reviewer', displayName: 'Reviewer' }],
+    }), expect.any(Function))
+  })
+
   it('dispatches a Codex group agent through chat-run without invoking the Hermes bridge', async () => {
     const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')
     const runAndWait = vi.fn(async (_data: any, options: any) => {
@@ -576,6 +601,7 @@ describe('group chat agent workspace bridge runs', () => {
       senderName: 'Alice',
       senderId: 'user-1',
       timestamp: 1,
+      mentions: [{ type: 'agent', participantId: 'agent-1' }],
     })
     await waitFor(() => bridgeMock.chat.mock.calls.length === 1)
     await clients.processMentions('room-1', {
@@ -583,6 +609,7 @@ describe('group chat agent workspace bridge runs', () => {
       senderName: 'Alice',
       senderId: 'user-1',
       timestamp: 2,
+      mentions: [{ type: 'agent', participantId: 'agent-1' }],
     })
 
     const interruptPromise = clients.interruptRoom('room-1')
@@ -625,6 +652,7 @@ describe('group chat agent workspace bridge runs', () => {
       senderId: 'user-1',
       timestamp: 1,
       role: 'user',
+      mentions: [{ type: 'agent', participantId: 'agent-1' }],
     })
 
     expect(statuses[0]).toEqual({ agentName: 'Worker', status: 'replying' })
@@ -656,6 +684,7 @@ describe('group chat agent workspace bridge runs', () => {
       timestamp: 1,
       role: 'assistant',
       mentionDepth: 1,
+      mentions: [{ type: 'agent', participantId: 'agent-codex' }],
     })
 
     expect(replyToMention).toHaveBeenCalledWith(
@@ -665,6 +694,47 @@ describe('group chat agent workspace bridge runs', () => {
         mentionDepth: 1,
       }),
       { summary: '', history: [] },
+      expect.any(Function),
+    )
+  })
+
+  it('attaches a validated structured mention to an agent reply before it is persisted', async () => {
+    const client = await createClient('')
+    client.__testStorage.getRoomAgents = vi.fn(() => [
+      { agentId: 'agent-1', name: 'Worker' },
+      { agentId: 'agent-reviewer', name: 'Reviewer' },
+    ])
+    bridgeMock.streamOutput.mockImplementation(async function* (runId: string) {
+      yield {
+        ok: true,
+        run_id: runId,
+        session_id: 'session-1',
+        status: 'complete',
+        delta: '@Reviewer please verify this',
+        cursor: 1,
+        output: '@Reviewer please verify this',
+        done: true,
+        events: [],
+        event_cursor: 0,
+      }
+    })
+
+    await client.replyToMention('room-1', {
+      content: '@Worker prepare the patch',
+      senderName: 'Alice',
+      senderId: 'human-1',
+      timestamp: 1,
+      role: 'user',
+      mentions: [{ type: 'agent', participantId: 'agent-1' }],
+    })
+
+    expect(mockSocket.emit).toHaveBeenCalledWith(
+      'message',
+      expect.objectContaining({
+        roomId: 'room-1',
+        content: '@Reviewer please verify this',
+        mentions: [{ type: 'agent', participantId: 'agent-reviewer', displayName: 'Reviewer' }],
+      }),
       expect.any(Function),
     )
   })
@@ -695,6 +765,7 @@ describe('group chat agent workspace bridge runs', () => {
       senderId: 'user-1',
       timestamp: 1,
       role: 'user',
+      mentions: [{ type: 'agent', participantId: 'agent-1' }],
     })
     await Promise.resolve()
     await clients.processMentions('room-1', {
@@ -704,6 +775,7 @@ describe('group chat agent workspace bridge runs', () => {
       senderId: 'user-1',
       timestamp: 2,
       role: 'user',
+      mentions: [{ type: 'agent', participantId: 'agent-1' }],
     })
 
     expect(statuses).toEqual(['replying'])
@@ -750,6 +822,7 @@ describe('group chat agent workspace bridge runs', () => {
       senderName: 'Alice',
       senderId: 'user-1',
       timestamp: 1,
+      mentions: [{ type: 'agent', participantId: 'agent-1' }],
     })
 
     expect(trackerMock.startWorkspaceRunCheckpoint).not.toHaveBeenCalled()

--- a/tests/server/group-chat-legacy-activity-migration.test.ts
+++ b/tests/server/group-chat-legacy-activity-migration.test.ts
@@ -96,7 +96,7 @@ describe('group chat legacy activity migration', () => {
       persistedAt: cutoff - 1_000,
     })
     server.getIO().close()
-  })
+  }, 15_000)
 
   it('persists the migration boundary across a database restart so future timestamps never become trusted later', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'group-chat-activity-'))

--- a/tests/server/group-chat-legacy-activity-migration.test.ts
+++ b/tests/server/group-chat-legacy-activity-migration.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DatabaseSync } from 'node:sqlite'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createServer, type Server as HttpServer } from 'node:http'
+
+const dbState = vi.hoisted(() => ({
+  db: null as DatabaseSync | null,
+}))
+
+vi.mock('../../packages/server/src/db/index', () => ({
+  getDb: () => dbState.db,
+  isSqliteAvailable: () => Boolean(dbState.db),
+}))
+
+describe('group chat legacy activity migration', () => {
+  let httpServer: HttpServer
+
+  beforeEach(() => {
+    vi.resetModules()
+    dbState.db = new DatabaseSync(':memory:')
+    httpServer = createServer()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    dbState.db?.close()
+    dbState.db = null
+  })
+
+  it('backfills only valid historical compatibility times, derives a missing room creation time, orders by activity, and is idempotent', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    const cutoff = Date.now()
+    dbState.db?.exec(`
+      CREATE TABLE gc_rooms (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        inviteCode TEXT UNIQUE
+      );
+      CREATE TABLE gc_messages (
+        id TEXT PRIMARY KEY,
+        roomId TEXT NOT NULL,
+        senderId TEXT NOT NULL,
+        senderName TEXT NOT NULL,
+        content TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        role TEXT NOT NULL DEFAULT 'user',
+        tool_name TEXT,
+        finish_reason TEXT
+      );
+    `)
+    dbState.db?.prepare('INSERT INTO gc_rooms (id, name) VALUES (?, ?)').run('room-a', 'No trusted history')
+    dbState.db?.prepare('INSERT INTO gc_rooms (id, name) VALUES (?, ?)').run('room-z', 'Historical activity')
+    dbState.db?.prepare(
+      'INSERT INTO gc_messages (id, roomId, senderId, senderName, content, timestamp) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run('history-valid', 'room-z', 'user-1', 'User', 'old visible message', cutoff - 1_000)
+    dbState.db?.prepare(
+      'INSERT INTO gc_messages (id, roomId, senderId, senderName, content, timestamp) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run('history-future', 'room-z', 'user-1', 'User', 'future timestamp', cutoff + 1_000)
+    dbState.db?.prepare(
+      'INSERT INTO gc_messages (id, roomId, senderId, senderName, content, timestamp, role, tool_name) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('history-tool', 'room-z', 'agent-1', 'Agent', 'tool message', cutoff - 500, 'tool', 'shell')
+    dbState.db?.prepare(
+      'INSERT INTO gc_messages (id, roomId, senderId, senderName, content, timestamp, role, finish_reason) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ).run('history-streaming', 'room-z', 'agent-1', 'Agent', 'stream fragment', cutoff - 250, 'assistant', 'streaming')
+
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
+    initAllHermesTables()
+    const server = new GroupChatServer(httpServer)
+
+    expect(dbState.db?.prepare('SELECT createdAt FROM gc_rooms WHERE id = ?').get('room-z')).toEqual({
+      createdAt: cutoff - 1_000,
+    })
+    expect(dbState.db?.prepare('SELECT createdAt FROM gc_rooms WHERE id = ?').get('room-a')).toEqual({
+      createdAt: 0,
+    })
+    expect(dbState.db?.prepare('SELECT persistedAt FROM gc_messages WHERE id = ?').get('history-valid')).toEqual({
+      persistedAt: cutoff - 1_000,
+    })
+    expect(dbState.db?.prepare('SELECT persistedAt FROM gc_messages WHERE id = ?').get('history-future')).toEqual({
+      persistedAt: 0,
+    })
+    expect(dbState.db?.prepare('SELECT persistedAt FROM gc_messages WHERE id = ?').get('history-tool')).toEqual({
+      persistedAt: 0,
+    })
+    expect(dbState.db?.prepare('SELECT persistedAt FROM gc_messages WHERE id = ?').get('history-streaming')).toEqual({
+      persistedAt: 0,
+    })
+    expect(server.getStorage().getAllRooms().map(room => room.id)).toEqual(['room-z', 'room-a'])
+
+    initAllHermesTables()
+    expect(dbState.db?.prepare('SELECT persistedAt FROM gc_messages WHERE id = ?').get('history-valid')).toEqual({
+      persistedAt: cutoff - 1_000,
+    })
+    server.getIO().close()
+  })
+
+  it('persists the migration boundary across a database restart so future timestamps never become trusted later', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'group-chat-activity-'))
+    const path = join(dir, 'legacy.sqlite')
+    dbState.db?.close()
+    dbState.db = new DatabaseSync(path)
+    try {
+      dbState.db.exec(`
+        CREATE TABLE gc_rooms (id TEXT PRIMARY KEY, name TEXT NOT NULL, inviteCode TEXT UNIQUE);
+        CREATE TABLE gc_messages (
+          id TEXT PRIMARY KEY, roomId TEXT NOT NULL, senderId TEXT NOT NULL, senderName TEXT NOT NULL,
+          content TEXT NOT NULL, timestamp INTEGER NOT NULL, role TEXT NOT NULL DEFAULT 'user'
+        );
+      `)
+      dbState.db.prepare('INSERT INTO gc_rooms (id, name) VALUES (?, ?)').run('room-1', 'Room')
+      dbState.db.prepare(
+        'INSERT INTO gc_messages (id, roomId, senderId, senderName, content, timestamp) VALUES (?, ?, ?, ?, ?, ?)',
+      ).run('future-on-first-upgrade', 'room-1', 'user-1', 'User', 'future', 1_000_001)
+
+      const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+      vi.useFakeTimers()
+      vi.setSystemTime(1_000_000)
+      initAllHermesTables()
+      expect(dbState.db.prepare('SELECT persistedAt FROM gc_messages WHERE id = ?').get('future-on-first-upgrade')).toEqual({
+        persistedAt: 0,
+      })
+      expect(dbState.db.prepare('SELECT migrationCutoff FROM gc_activity_migrations WHERE id = ?').get('legacy-activity-times-v1')).toEqual({
+        migrationCutoff: 1_000_000,
+      })
+
+      dbState.db.close()
+      dbState.db = new DatabaseSync(path)
+      vi.setSystemTime(1_000_002)
+      initAllHermesTables()
+      expect(dbState.db.prepare('SELECT persistedAt FROM gc_messages WHERE id = ?').get('future-on-first-upgrade')).toEqual({
+        persistedAt: 0,
+      })
+    } finally {
+      vi.useRealTimers()
+      dbState.db?.close()
+      dbState.db = null
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }, 15_000)
+
+  it('orders profile, authenticated-member, and owner room lists by activity', async () => {
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
+    initAllHermesTables()
+    const server = new GroupChatServer(httpServer)
+    const storage = server.getStorage()
+    storage.saveRoom('room-a', 'Older', 'ROOMA', { ownerAuthUserId: 7 })
+    storage.saveRoom('room-z', 'Newer', 'ROOMZ', { ownerAuthUserId: 7 })
+    storage.addRoomAgent('room-a', 'agent-a', 'default', 'Agent A', '', 0)
+    storage.addRoomAgent('room-z', 'agent-z', 'default', 'Agent Z', '', 0)
+    storage.addRoomMember('room-a', 'auth:7', 'User', '', '', 7)
+    storage.addRoomMember('room-z', 'auth:7', 'User', '', '', 7)
+    storage.addMessage({ id: 'old', roomId: 'room-a', senderId: 'user', senderName: 'User', content: 'old', timestamp: 10, persistedAt: 10 })
+    storage.addMessage({ id: 'new', roomId: 'room-z', senderId: 'user', senderName: 'User', content: 'new', timestamp: 20, persistedAt: 20 })
+
+    expect(storage.getRoomsForProfiles(['default']).map(room => room.id)).toEqual(['room-z', 'room-a'])
+    expect(storage.getRoomsForAuthUser(7).map(room => room.id)).toEqual(['room-z', 'room-a'])
+    expect(storage.getOwnedRoomsForAuthUser(7).map(room => room.id)).toEqual(['room-z', 'room-a'])
+    server.getIO().close()
+  })
+
+  it('does not let new tool or streaming messages affect any room activity ordering path', async () => {
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
+    initAllHermesTables()
+    const server = new GroupChatServer(httpServer)
+    const storage = server.getStorage()
+    storage.saveRoom('room-a', 'Visible activity', 'ROOMA', { ownerAuthUserId: 7 })
+    storage.saveRoom('room-z', 'Internal activity only', 'ROOMZ', { ownerAuthUserId: 7 })
+    dbState.db?.prepare('UPDATE gc_rooms SET createdAt = 0 WHERE id IN (?, ?)').run('room-a', 'room-z')
+    storage.addRoomAgent('room-a', 'agent-a', 'default', 'Agent A', '', 0)
+    storage.addRoomAgent('room-z', 'agent-z', 'default', 'Agent Z', '', 0)
+    storage.addRoomMember('room-a', 'auth:7', 'User', '', '', 7)
+    storage.addRoomMember('room-z', 'auth:7', 'User', '', '', 7)
+    storage.addMessage({ id: 'visible', roomId: 'room-a', senderId: 'user', senderName: 'User', content: 'visible', timestamp: 10, persistedAt: 10 })
+    storage.addMessage({ id: 'tool', roomId: 'room-z', senderId: 'agent-z', senderName: 'Agent Z', content: 'tool', timestamp: 20, persistedAt: 20, role: 'tool' })
+    storage.addMessage({ id: 'streaming', roomId: 'room-z', senderId: 'agent-z', senderName: 'Agent Z', content: 'streaming', timestamp: 30, persistedAt: 30, role: 'assistant', finish_reason: 'streaming' })
+
+    expect(storage.getAllRooms().map(room => room.id)).toEqual(['room-a', 'room-z'])
+    expect(storage.getRoomsForProfiles(['default']).map(room => room.id)).toEqual(['room-a', 'room-z'])
+    expect(storage.getRoomsForAuthUser(7).map(room => room.id)).toEqual(['room-a', 'room-z'])
+    expect(storage.getOwnedRoomsForAuthUser(7).map(room => room.id)).toEqual(['room-a', 'room-z'])
+    server.getIO().close()
+  })
+})

--- a/tests/server/group-chat-legacy-activity-migration.test.ts
+++ b/tests/server/group-chat-legacy-activity-migration.test.ts
@@ -157,9 +157,14 @@ describe('group chat legacy activity migration', () => {
     storage.addMessage({ id: 'old', roomId: 'room-a', senderId: 'user', senderName: 'User', content: 'old', timestamp: 10, persistedAt: 10 })
     storage.addMessage({ id: 'new', roomId: 'room-z', senderId: 'user', senderName: 'User', content: 'new', timestamp: 20, persistedAt: 20 })
 
-    expect(storage.getRoomsForProfiles(['default']).map(room => room.id)).toEqual(['room-z', 'room-a'])
-    expect(storage.getRoomsForAuthUser(7).map(room => room.id)).toEqual(['room-z', 'room-a'])
-    expect(storage.getOwnedRoomsForAuthUser(7).map(room => room.id)).toEqual(['room-z', 'room-a'])
+    const expected = [
+      { id: 'room-z', lastActiveAt: 20 },
+      { id: 'room-a', lastActiveAt: 10 },
+    ]
+    expect(storage.getAllRooms().map(({ id, lastActiveAt }) => ({ id, lastActiveAt }))).toEqual(expected)
+    expect(storage.getRoomsForProfiles(['default']).map(({ id, lastActiveAt }) => ({ id, lastActiveAt }))).toEqual(expected)
+    expect(storage.getRoomsForAuthUser(7).map(({ id, lastActiveAt }) => ({ id, lastActiveAt }))).toEqual(expected)
+    expect(storage.getOwnedRoomsForAuthUser(7).map(({ id, lastActiveAt }) => ({ id, lastActiveAt }))).toEqual(expected)
     server.getIO().close()
   })
 

--- a/tests/server/group-chat-member-sync.test.ts
+++ b/tests/server/group-chat-member-sync.test.ts
@@ -1182,6 +1182,10 @@ describe('Group Chat member/agent identity sync', () => {
     server.storage = {
       getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', sessionSeed: 'seed-1' })),
       getRoomAgentByAgentId: vi.fn(() => ({ id: 'row-1', roomId: 'room-1', agentId: 'agent-1', profile: 'default', name: '丫鬟' })),
+      getRoomAgents: vi.fn(() => [
+        { id: 'row-1', roomId: 'room-1', agentId: 'agent-1', profile: 'default', name: '丫鬟' },
+        { id: 'row-2', roomId: 'room-1', agentId: 'agent-2', profile: 'default', name: 'Reviewer' },
+      ]),
       saveMessageAndRefreshRoom: vi.fn((msg: any) => ({ message: msg, totalTokens: 123 })),
     }
     server.nsp = { to: vi.fn(() => ({ emit })) }
@@ -1195,16 +1199,31 @@ describe('Group Chat member/agent identity sync', () => {
     }))
 
     server.agentClients.processMentions.mockClear()
-    server.handleMessage({ id: 'agent-socket' }, { roomId: 'room-1', content: '@Helper agent says hi', role: 'assistant', mentionDepth: 1, agentSessionId }, vi.fn())
+    server.handleMessage({ id: 'agent-socket' }, {
+      roomId: 'room-1',
+      content: '@Reviewer agent says hi',
+      role: 'assistant',
+      mentionDepth: 1,
+      agentSessionId,
+      mentions: [{ type: 'agent', participantId: 'agent-2', displayName: 'Reviewer' }],
+    }, vi.fn())
     expect(server.agentClients.processMentions).toHaveBeenCalledTimes(1)
     expect(server.agentClients.processMentions).toHaveBeenLastCalledWith('room-1', expect.objectContaining({
-      content: '@Helper agent says hi',
+      content: '@Reviewer agent says hi',
       senderId: 'agent-1',
       mentionDepth: 1,
+      mentions: [{ type: 'agent', participantId: 'agent-2' }],
     }))
 
     server.agentClients.processMentions.mockClear()
-    server.handleMessage({ id: 'agent-socket' }, { roomId: 'room-1', content: '@all too deep', role: 'assistant', mentionDepth: 4, agentSessionId }, vi.fn())
+    server.handleMessage({ id: 'agent-socket' }, {
+      roomId: 'room-1',
+      content: '@Reviewer too deep',
+      role: 'assistant',
+      mentionDepth: 4,
+      agentSessionId,
+      mentions: [{ type: 'agent', participantId: 'agent-2', displayName: 'Reviewer' }],
+    }, vi.fn())
     expect(server.agentClients.processMentions).not.toHaveBeenCalled()
   })
 

--- a/tests/server/group-chat-mention-routing.test.ts
+++ b/tests/server/group-chat-mention-routing.test.ts
@@ -4,6 +4,7 @@ import {
   isAgentMentioned,
   isReservedMentionName,
   resolveMentionTargets,
+  resolveStructuredMentionTargets,
   stripMentionRoutingTokens,
 } from '../../packages/server/src/services/hermes/group-chat/mention-routing'
 
@@ -104,6 +105,21 @@ describe('group chat mention routing', () => {
 
   it('dedupes mixed @all and explicit mentions', () => {
     expect(resolveMentionTargets(agents, '@all @Bob compare plans', 'socket-alice').map(a => a.name)).toEqual(['Bob', 'Regex.Bot'])
+  })
+
+  it('routes only stable structured agent identities and never resolves display-name collisions', () => {
+    const sameNameAgents: TestAgent[] = [
+      { name: 'Alex', id: 'socket-agent-alex', agentId: 'agent-alex' },
+      { name: 'Alex', id: 'socket-agent-alex-2', agentId: 'agent-alex-2' },
+    ]
+
+    expect(resolveStructuredMentionTargets(sameNameAgents, [
+      { type: 'agent', participantId: 'agent-alex-2' },
+    ], 'human-alex').map(agent => agent.agentId)).toEqual(['agent-alex-2'])
+    expect(resolveStructuredMentionTargets(sameNameAgents, [
+      { type: 'agent', participantId: 'missing-agent' },
+    ], 'human-alex')).toEqual([])
+    expect(resolveStructuredMentionTargets(sameNameAgents, [], 'human-alex')).toEqual([])
   })
 
   it('strips the broadcast token and this agent mention before routing to the model', () => {

--- a/tests/server/group-chat-room-order.test.ts
+++ b/tests/server/group-chat-room-order.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createTestGroupChatServer } from './group-chat-test-helpers'
+
+describe('group chat room ordering', () => {
+  let harness: Awaited<ReturnType<typeof createTestGroupChatServer>>
+
+  beforeEach(async () => {
+    harness = await createTestGroupChatServer()
+  })
+
+  afterEach(() => {
+    harness.cleanup()
+  })
+
+  it('returns rooms by last persisted visible activity with empty rooms using creation time', () => {
+    const storage = harness.groupServer.getStorage()
+    storage.saveRoom('older-empty', 'Older empty', 'OLD')
+    harness.db.prepare('UPDATE gc_rooms SET createdAt = ? WHERE id = ?').run(100, 'older-empty')
+    storage.saveRoom('active', 'Active', 'ACTIVE')
+    harness.db.prepare('UPDATE gc_rooms SET createdAt = ? WHERE id = ?').run(200, 'active')
+    storage.saveRoom('new-empty', 'New empty', 'NEW')
+    harness.db.prepare('UPDATE gc_rooms SET createdAt = ? WHERE id = ?').run(400, 'new-empty')
+    storage.saveMessageAndRefreshRoom({
+      id: 'message-1',
+      roomId: 'active',
+      senderId: 'human-1',
+      senderName: 'Alice',
+      content: 'persisted',
+      timestamp: 500,
+      role: 'user',
+    } as any)
+
+    expect(storage.getAllRooms().map(room => room.id)).toEqual(['active', 'new-empty', 'older-empty'])
+  })
+
+  it('orders by server persistence time rather than an agent-supplied future display timestamp', () => {
+    const storage = harness.groupServer.getStorage()
+    storage.saveRoom('future-agent', 'Future agent', 'FUTURE')
+    storage.saveRoom('recent-human', 'Recent human', 'RECENT')
+    harness.db.prepare('UPDATE gc_rooms SET createdAt = ? WHERE id = ?').run(100, 'future-agent')
+    harness.db.prepare('UPDATE gc_rooms SET createdAt = ? WHERE id = ?').run(200, 'recent-human')
+    harness.db.prepare(
+      'INSERT INTO gc_messages (id, roomId, senderId, senderName, content, timestamp, persistedAt, role) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+    ).run('agent-future', 'future-agent', 'agent-1', 'Agent', 'future', 9_999_999_999_999, 300, 'assistant')
+    harness.db.prepare(
+      'INSERT INTO gc_messages (id, roomId, senderId, senderName, content, timestamp, persistedAt, role) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+    ).run('human-recent', 'recent-human', 'human-1', 'Human', 'recent', 400, 400, 'user')
+
+    expect(storage.getAllRooms().map(room => room.id)).toEqual(['recent-human', 'future-agent'])
+  })
+})

--- a/tests/server/group-chat-routes-baseline.test.ts
+++ b/tests/server/group-chat-routes-baseline.test.ts
@@ -42,6 +42,8 @@ describe('group chat REST route baseline', () => {
       getRoom: vi.fn((id) => storage.rooms.get(id)),
       getAllRooms: vi.fn(() => [...storage.rooms.values()]),
       getRoomsForProfiles: vi.fn(() => [...storage.rooms.values()]),
+      getRoomsForAuthUser: vi.fn(() => []),
+      getOwnedRoomsForAuthUser: vi.fn(() => []),
       getRecentMessagesForUI: vi.fn((roomId, limit = 150, offset = 0) => (storage.messages.get(roomId) || []).slice(offset, offset + limit)),
       getMessageCount: vi.fn((roomId) => (storage.messages.get(roomId) || []).length),
       getMessage: vi.fn((messageId) => [...storage.messages.values()].flat().find((message: any) => message.id === messageId) || null),
@@ -150,6 +152,9 @@ describe('group chat REST route baseline', () => {
     app.use(async (ctx, next) => {
       const userId = Number(ctx.get('x-test-user-id') || 0)
       if (userId > 0) ctx.state.user = { id: userId, role: 'user', profiles: [] }
+      if (ctx.get('x-test-user') === 'member') {
+        ctx.state.user = { id: 7, username: 'member', role: 'user', profiles: ['default'] }
+      }
       await next()
     })
     app.use(groupChatPublicRoutes.routes())
@@ -344,6 +349,25 @@ describe('group chat REST route baseline', () => {
       body: JSON.stringify({ action: 'list', path: '' }),
     })
     expect(revoked.status).toBe(401)
+  })
+
+  it('keeps the aggregated authenticated room list ordered by activity instead of room id', async () => {
+    storage.getRoomsForProfiles.mockReturnValue([
+      { id: 'room-z', name: 'Newest', inviteCode: 'Z', _activityAt: 20 },
+    ])
+    storage.getRoomsForAuthUser.mockReturnValue([
+      { id: 'room-a', name: 'Older', inviteCode: 'A', _activityAt: 10 },
+    ])
+    storage.getOwnedRoomsForAuthUser.mockReturnValue([])
+
+    const res = await fetch(`${baseUrl}/api/hermes/group-chat/rooms`, {
+      headers: { 'x-test-user': 'member' },
+    })
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({
+      rooms: [{ id: 'room-z' }, { id: 'room-a' }],
+    })
   })
 
   it('rejects reserved @all agent names when creating a room', async () => {

--- a/tests/server/group-chat-routes-baseline.test.ts
+++ b/tests/server/group-chat-routes-baseline.test.ts
@@ -351,12 +351,12 @@ describe('group chat REST route baseline', () => {
     expect(revoked.status).toBe(401)
   })
 
-  it('keeps the aggregated authenticated room list ordered by activity instead of room id', async () => {
+  it('returns public lastActiveAt and keeps the aggregated authenticated room list ordered by activity instead of room id', async () => {
     storage.getRoomsForProfiles.mockReturnValue([
-      { id: 'room-z', name: 'Newest', inviteCode: 'Z', _activityAt: 20 },
+      { id: 'room-old-active', name: 'Old but active', inviteCode: 'Z', createdAt: 100, lastActiveAt: 300 },
     ])
     storage.getRoomsForAuthUser.mockReturnValue([
-      { id: 'room-a', name: 'Older', inviteCode: 'A', _activityAt: 10 },
+      { id: 'room-new-created', name: 'New but inactive', inviteCode: 'A', createdAt: 200, lastActiveAt: 200 },
     ])
     storage.getOwnedRoomsForAuthUser.mockReturnValue([])
 
@@ -366,7 +366,10 @@ describe('group chat REST route baseline', () => {
 
     expect(res.status).toBe(200)
     await expect(res.json()).resolves.toMatchObject({
-      rooms: [{ id: 'room-z' }, { id: 'room-a' }],
+      rooms: [
+        { id: 'room-old-active', lastActiveAt: 300 },
+        { id: 'room-new-created', lastActiveAt: 200 },
+      ],
     })
   })
 

--- a/tests/server/group-chat-structured-mentions.test.ts
+++ b/tests/server/group-chat-structured-mentions.test.ts
@@ -120,7 +120,7 @@ describe('group chat structured agent mentions', () => {
     expect(replyToMention).not.toHaveBeenCalled()
   })
 
-  it('normalizes an agent @all broadcast, persists it, and dispatches every other room agent', async () => {
+  it('keeps the latest main policy that only a room owner may broadcast with @all', async () => {
     const author = await connectGroupChatClient(port, 'agent-author', 'Author', {
       source: 'agent',
       agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
@@ -144,11 +144,9 @@ describe('group chat structured agent mentions', () => {
       mentions: [{ type: 'all', displayName: 'all' }],
     })
 
-    expect(response.error).toBeUndefined()
-    await vi.waitFor(() => expect(replyToMention).toHaveBeenCalledOnce())
-    expect(harness.db.prepare('SELECT mentions FROM gc_messages WHERE id = ?').get('agent-all-handoff')).toEqual({
-      mentions: JSON.stringify([{ type: 'all' }]),
-    })
+    expect(response.error).toBe('Only the room owner can mention @all')
+    expect(replyToMention).not.toHaveBeenCalled()
+    expect(harness.db.prepare('SELECT COUNT(*) AS count FROM gc_messages WHERE id = ?').get('agent-all-handoff')).toEqual({ count: 0 })
   })
 
   it('atomically rejects an agent visible mention paired with an empty structured mention list', async () => {
@@ -198,16 +196,19 @@ describe('group chat structured agent mentions', () => {
         { type: 'agent', participantId: 'agent-reviewer', displayName: 'Reviewer' },
         { type: 'agent', participantId: 'agent-reviewer', displayName: 'Reviewer' },
       ] },
-      { id: 'invalid-all', content: '@all verify', mentions: [{ type: 'all', displayName: 'ALL' }] },
+      { id: 'invalid-all', content: '@all verify', mentions: [{ type: 'all', displayName: 'ALL' }], expectedError: 'Only the room owner can mention @all' },
       { id: 'incomplete-agent', content: '@Reviewer verify', mentions: [{ type: 'agent', participantId: 'agent-reviewer' }] },
       { id: 'invalid-type', content: '@Reviewer verify', mentions: [{ type: 'human', participantId: 'agent-reviewer', displayName: 'Reviewer' }] },
       { id: 'inconsistent-content', content: 'please verify', mentions: [{ type: 'agent', participantId: 'agent-reviewer', displayName: 'Reviewer' }] },
-      { id: 'all-with-explicit-agent', content: '@all @Reviewer verify', mentions: [{ type: 'all', displayName: 'all' }] },
+      { id: 'all-with-explicit-agent', content: '@all @Reviewer verify', mentions: [{ type: 'all', displayName: 'all' }], expectedError: 'Only the room owner can mention @all' },
     ]
 
     for (const testCase of cases) {
       const response = await emitAck<{ error?: string }>(author, 'message', { ...base, ...testCase })
-      expect(response.error).toBe('Invalid structured mentions')
+      const expectedError = 'expectedError' in testCase
+        ? testCase.expectedError
+        : 'Invalid structured mentions'
+      expect(response.error).toBe(expectedError)
       expect(harness.db.prepare('SELECT COUNT(*) AS count FROM gc_messages WHERE id = ?').get(testCase.id)).toEqual({ count: 0 })
     }
     expect(processMentions).not.toHaveBeenCalled()

--- a/tests/server/group-chat-structured-mentions.test.ts
+++ b/tests/server/group-chat-structured-mentions.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  connectGroupChatClient,
+  createTestGroupChatServer,
+  emitAck,
+} from './group-chat-test-helpers'
+import { GROUP_CHAT_AGENT_SOCKET_SECRET, groupRuntimeSessionId } from '../../packages/server/src/services/hermes/group-chat/agent-clients'
+import { authenticateUserToken, isAuthEnabled } from '../../packages/server/src/middleware/user-auth'
+import type { GroupChatServer } from '../../packages/server/src/services/hermes/group-chat'
+
+describe('group chat structured agent mentions', () => {
+  let harness: Awaited<ReturnType<typeof createTestGroupChatServer>>
+  let groupServer: GroupChatServer
+  let port: number
+
+  beforeEach(async () => {
+    vi.mocked(isAuthEnabled).mockResolvedValue(false)
+    vi.mocked(authenticateUserToken).mockResolvedValue(null as any)
+    harness = await createTestGroupChatServer()
+    groupServer = harness.groupServer
+    port = harness.port
+    vi.spyOn(groupServer.agentClients, 'agentSessionIsCurrent').mockReturnValue(true)
+    groupServer.getStorage().saveRoom('room-1', 'Room 1', 'ROOM1')
+    groupServer.getStorage().addRoomAgent('room-1', 'agent-author', 'default', 'Author', '', 0)
+    groupServer.getStorage().addRoomAgent('room-1', 'agent-reviewer', 'default', 'Reviewer', '', 0)
+  })
+
+  afterEach(() => {
+    harness?.cleanup()
+  })
+
+  it('normalizes an agent-generated entry mention, persists only its routing DTO, and routes it again', async () => {
+    const author = await connectGroupChatClient(port, 'agent-author', 'Author', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    harness.sockets.push(author)
+    await emitAck(author, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+
+    const replyToMention = vi.fn(async () => {})
+    ;(groupServer.agentClients as any).rooms.set('room-1', new Map([[
+      'agent-reviewer',
+      { id: 'agent-reviewer', agentId: 'agent-reviewer', name: 'Reviewer', replyToMention },
+    ]]))
+    const agentSessionId = groupRuntimeSessionId('room-1', 'default', 'Author')
+    const forgedFutureTimestamp = Date.now() + 86_400_000
+    await emitAck(author, 'message', {
+      roomId: 'room-1',
+      id: 'agent-handoff-1',
+      content: '@Reviewer please independently verify this.',
+      role: 'assistant',
+      mentionDepth: 1,
+      agentSessionId,
+      timestamp: forgedFutureTimestamp,
+      mentions: [{ type: 'agent', participantId: 'agent-reviewer', displayName: 'Reviewer' }],
+    })
+
+    await vi.waitFor(() => expect(replyToMention).toHaveBeenCalledWith('room-1', expect.objectContaining({
+      messageId: 'agent-handoff-1',
+      mentions: [{ type: 'agent', participantId: 'agent-reviewer' }],
+    }), expect.anything(), expect.any(Function)))
+    expect(harness.db.prepare('SELECT mentions FROM gc_messages WHERE id = ?').get('agent-handoff-1')).toEqual({
+      mentions: JSON.stringify([{ type: 'agent', participantId: 'agent-reviewer' }]),
+    })
+    expect((harness.db.prepare('SELECT persistedAt FROM gc_messages WHERE id = ?').get('agent-handoff-1') as { persistedAt: number }).persistedAt)
+      .toBeLessThan(forgedFutureTimestamp)
+  })
+
+  it('atomically rejects a forged display name instead of persisting or partially routing it', async () => {
+    const author = await connectGroupChatClient(port, 'agent-author', 'Author', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    const reviewer = await connectGroupChatClient(port, 'agent-reviewer', 'Reviewer', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    harness.sockets.push(author, reviewer)
+    await emitAck(author, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    await emitAck(reviewer, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+
+    const processMentions = vi.spyOn(groupServer.agentClients, 'processMentions').mockResolvedValue(undefined)
+    const response = await emitAck<{ error?: string }>(author, 'message', {
+      roomId: 'room-1',
+      id: 'forged-handoff',
+      content: '@Reviewer please verify this.',
+      role: 'assistant',
+      agentSessionId: groupRuntimeSessionId('room-1', 'default', 'Author'),
+      mentions: [{ type: 'agent', participantId: 'agent-reviewer', displayName: 'Author' }],
+    })
+
+    expect(response.error).toBe('Invalid structured mentions')
+    expect(harness.db.prepare('SELECT COUNT(*) AS count FROM gc_messages WHERE id = ?').get('forged-handoff')).toEqual({ count: 0 })
+    expect(processMentions).not.toHaveBeenCalled()
+  })
+
+  it('normalizes an agent @all broadcast, persists it, and dispatches every other room agent', async () => {
+    const author = await connectGroupChatClient(port, 'agent-author', 'Author', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    harness.sockets.push(author)
+    await emitAck(author, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+
+    const replyToMention = vi.fn(async () => {})
+    ;(groupServer.agentClients as any).rooms.set('room-1', new Map([[
+      'agent-reviewer',
+      { id: 'agent-reviewer', agentId: 'agent-reviewer', name: 'Reviewer', replyToMention },
+    ]]))
+
+    const response = await emitAck<{ error?: string }>(author, 'message', {
+      roomId: 'room-1',
+      id: 'agent-all-handoff',
+      content: '@all please independently verify this.',
+      role: 'assistant',
+      mentionDepth: 1,
+      agentSessionId: groupRuntimeSessionId('room-1', 'default', 'Author'),
+      mentions: [{ type: 'all', displayName: 'all' }],
+    })
+
+    expect(response.error).toBeUndefined()
+    await vi.waitFor(() => expect(replyToMention).toHaveBeenCalledOnce())
+    expect(harness.db.prepare('SELECT mentions FROM gc_messages WHERE id = ?').get('agent-all-handoff')).toEqual({
+      mentions: JSON.stringify([{ type: 'all' }]),
+    })
+  })
+
+  it('atomically rejects an agent visible mention paired with an empty structured mention list', async () => {
+    const author = await connectGroupChatClient(port, 'agent-author', 'Author', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    harness.sockets.push(author)
+    await emitAck(author, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+
+    const processMentions = vi.spyOn(groupServer.agentClients, 'processMentions').mockResolvedValue(undefined)
+    const response = await emitAck<{ error?: string }>(author, 'message', {
+      roomId: 'room-1',
+      id: 'empty-agent-handoff',
+      content: '@Reviewer please independently verify this.',
+      role: 'assistant',
+      agentSessionId: groupRuntimeSessionId('room-1', 'default', 'Author'),
+      mentions: [],
+    })
+
+    expect(response.error).toBe('Invalid structured mentions')
+    expect(harness.db.prepare('SELECT COUNT(*) AS count FROM gc_messages WHERE id = ?').get('empty-agent-handoff')).toEqual({ count: 0 })
+    expect(processMentions).not.toHaveBeenCalled()
+  })
+
+  it('atomically rejects cross-room, stale, self, duplicate, and malformed broadcast metadata', async () => {
+    const author = await connectGroupChatClient(port, 'agent-author', 'Author', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    harness.sockets.push(author)
+    await emitAck(author, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    groupServer.getStorage().saveRoom('room-2', 'Room 2', 'ROOM2')
+    groupServer.getStorage().addRoomAgent('room-2', 'agent-other-room', 'default', 'Reviewer', '', 0)
+    const processMentions = vi.spyOn(groupServer.agentClients, 'processMentions').mockResolvedValue(undefined)
+    const base = {
+      roomId: 'room-1',
+      role: 'assistant',
+      agentSessionId: groupRuntimeSessionId('room-1', 'default', 'Author'),
+    }
+
+    const cases = [
+      { id: 'cross-room', content: '@Reviewer verify', mentions: [{ type: 'agent', participantId: 'agent-other-room', displayName: 'Reviewer' }] },
+      { id: 'stale', content: '@Reviewer verify', mentions: [{ type: 'agent', participantId: 'removed-agent', displayName: 'Reviewer' }] },
+      { id: 'self', content: '@Author verify', mentions: [{ type: 'agent', participantId: 'agent-author', displayName: 'Author' }] },
+      { id: 'duplicate', content: '@Reviewer verify', mentions: [
+        { type: 'agent', participantId: 'agent-reviewer', displayName: 'Reviewer' },
+        { type: 'agent', participantId: 'agent-reviewer', displayName: 'Reviewer' },
+      ] },
+      { id: 'invalid-all', content: '@all verify', mentions: [{ type: 'all', displayName: 'ALL' }] },
+      { id: 'incomplete-agent', content: '@Reviewer verify', mentions: [{ type: 'agent', participantId: 'agent-reviewer' }] },
+      { id: 'invalid-type', content: '@Reviewer verify', mentions: [{ type: 'human', participantId: 'agent-reviewer', displayName: 'Reviewer' }] },
+      { id: 'inconsistent-content', content: 'please verify', mentions: [{ type: 'agent', participantId: 'agent-reviewer', displayName: 'Reviewer' }] },
+      { id: 'all-with-explicit-agent', content: '@all @Reviewer verify', mentions: [{ type: 'all', displayName: 'all' }] },
+    ]
+
+    for (const testCase of cases) {
+      const response = await emitAck<{ error?: string }>(author, 'message', { ...base, ...testCase })
+      expect(response.error).toBe('Invalid structured mentions')
+      expect(harness.db.prepare('SELECT COUNT(*) AS count FROM gc_messages WHERE id = ?').get(testCase.id)).toEqual({ count: 0 })
+    }
+    expect(processMentions).not.toHaveBeenCalled()
+  })
+})

--- a/tests/server/group-chat-structured-mentions.test.ts
+++ b/tests/server/group-chat-structured-mentions.test.ts
@@ -94,6 +94,32 @@ describe('group chat structured agent mentions', () => {
     expect(processMentions).not.toHaveBeenCalled()
   })
 
+  it('persists an agent reply that only names itself without dispatching itself', async () => {
+    const author = await connectGroupChatClient(port, 'agent-author', 'Author', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    harness.sockets.push(author)
+    await emitAck(author, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    const replyToMention = vi.fn(async () => {})
+    ;(groupServer.agentClients as any).rooms.set('room-1', new Map([[
+      'agent-reviewer',
+      { id: 'agent-reviewer', agentId: 'agent-reviewer', name: 'Reviewer', replyToMention },
+    ]]))
+
+    const response = await emitAck<{ id?: string; error?: string }>(author, 'message', {
+      roomId: 'room-1',
+      id: 'self-named-reply',
+      content: '@Author status: waiting for the next task.',
+      role: 'assistant',
+      agentSessionId: groupRuntimeSessionId('room-1', 'default', 'Author'),
+    })
+
+    expect(response).toEqual({ id: 'self-named-reply' })
+    expect(harness.db.prepare('SELECT COUNT(*) AS count FROM gc_messages WHERE id = ?').get('self-named-reply')).toEqual({ count: 1 })
+    expect(replyToMention).not.toHaveBeenCalled()
+  })
+
   it('normalizes an agent @all broadcast, persists it, and dispatches every other room agent', async () => {
     const author = await connectGroupChatClient(port, 'agent-author', 'Author', {
       source: 'agent',

--- a/tests/server/session-command-branch.test.ts
+++ b/tests/server/session-command-branch.test.ts
@@ -266,6 +266,22 @@ describe('branch session command', () => {
     expect(sessionMap.has(branchEvent.newSessionId)).toBe(false)
   })
 
+  it('copies the parent real category once when forking', async () => {
+    const { handleSessionCommand, parseSessionCommand } = await import('../../packages/server/src/services/hermes/run-chat/session-command')
+    const { nsp, socket } = makeSocketHarness()
+    const sessionMap = new Map<string, any>([
+      ['session-1', { messages: [], isWorking: false, events: [], queue: [] }],
+    ])
+    getSessionMock.mockReturnValue(makeParentSession({ category_id: 42 }))
+
+    await handleSessionCommand('session-1', parseSessionCommand('/fork categorized')!, makeCtx(sessionMap, nsp, socket))
+
+    expect(createBranchedSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+      parent_session_id: 'session-1',
+      category_id: 42,
+    }))
+  })
+
   it('preserves api_server source when forking non-bridge chat sessions', async () => {
     const { handleSessionCommand, parseSessionCommand } = await import('../../packages/server/src/services/hermes/run-chat/session-command')
     const { nsp, socket, namespaceEmit } = makeSocketHarness()


### PR DESCRIPTION
## Summary

- reapplies #2399 on top of the latest `main`
- adds recent-session grouping, fork category inheritance, quote/structured mention handling, and group-room activity ordering
- preserves current `main` behavior for remote Agents, file transfers, legacy name mentions, and owner-only `@all`
- excludes sessions shown in Recent from pinned/category/uncategorized groups
- prevents tool and streaming messages from changing live room order
- uses Agent IDs for avatar mentions so historical duplicate names remain unambiguous

## Why

The original PR conflicted with newer group-chat work on `main`. Its realtime room ordering also treated internal tool/streaming messages as visible activity, while the server list query excluded them. Recent sessions were independently rendered and therefore appeared a second time in their normal category.

## Impact

Room ordering now follows persisted visible activity consistently before and after refresh. Recent sessions appear only once in the sidebar. Existing `main` permissions and remote-Agent behavior remain authoritative.

## Validation

- changed client/server test set: 12 files, 161 tests passed
- `tests/server/group-chat-baseline.test.ts`: 20 tests passed
- final focused client tests: 3 files, 42 tests passed
- E2E not run in the Termux environment
