### PR TITLE
fix(chat): stop sending the Studio guidance block twice

### DIFF
--- a/docs/chat-chain-changes/frag.md
+++ b/docs/chat-chain-changes/frag.md
@@ -1,0 +1,10 @@
+---
+date: 2026-08-08
+feature: issue-2401-single-guidance-injection
+impact: Bridge runs now send the Studio guidance block once instead of twice, removing about 3,000 duplicated characters from the system message of every request.
+pr: 2416
+---
+
+# Issue #2401
+
+The chat-run socket composes `getSystemPrompt()` and passes the result to `handleBridgeRun` as `instructions`; `handleBridgeRun` then prepended the same guidance again, so the MCP usage rules and the output-format rules reached the bridge twice, byte for byte, and were persisted that way into `system_prompts`. `handleBridgeRun` has a single caller and that caller always composes, so the inner composition could only ever duplicate. It now composes solely when a caller passes no instructions at all, which keeps that entry point self-sufficient if it ever gains a second caller. No other behaviour changes: callers that pass instructions get exactly what they passed, and the guidance text itself is untouched.

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -420,9 +420,11 @@ export async function handleBridgeRun(
     return
   }
 
-  let fullInstructions = instructions
-    ? `${getSystemPrompt(undefined, { source: data.session_source || data.source })}\n${instructions}`
-    : getSystemPrompt(undefined, { source: data.session_source || data.source })
+  // `instructions` already carries the Studio guidance: the chat-run socket
+  // composes it before delegating here. Prepending it again duplicated the whole
+  // block — MCP usage plus the output-format rules — byte for byte in the system
+  // message of every request. Compose only when a caller hands us nothing.
+  let fullInstructions = instructions || getSystemPrompt(undefined, { source: data.session_source || data.source })
   const sessionRow = getSession(session_id)
   const workspace = await ensureHermesRunWorkspace(profile, sessionRow?.workspace || data.workspace)
   const shouldEmitWorkspaceUpdate = Boolean(workspace && !sessionRow?.workspace)

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -272,6 +272,49 @@ describe('bridge run final context usage', () => {
     }))
   })
 
+  it('does not prepend the Studio guidance a second time when the caller already composed it', async () => {
+    // The chat-run socket composes getSystemPrompt() and hands the result down as
+    // `instructions`. Composing again duplicated the whole guidance block —
+    // MCP usage plus output-format rules — in the system message of every request.
+    getSessionMock.mockReturnValue({
+      id: 'session-1',
+      profile: 'default',
+      model: 'gpt-test',
+      provider: 'openai',
+      workspace: '/tmp/hermes-bridge-final-context/default/workspace',
+    })
+    const emit = vi.fn()
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    const sessionMap = new Map([['session-1', makeState()]])
+    const bridge = {
+      chat: vi.fn().mockResolvedValue({ run_id: 'run-1', status: 'started' }),
+      contextEstimate: vi.fn().mockResolvedValue({ token_count: 1, fixed_context_tokens: 1, message_count: 1, tool_count: 0, system_prompt_chars: 1 }),
+      streamOutput: vi.fn(async function* () {
+        yield { run_id: 'run-1', done: true, status: 'completed', output: 'done' }
+      }),
+    } as any
+
+    const composed = 'system prompt\nAGENT SOUL'
+    const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    await handleBridgeRun(
+      nsp,
+      socket,
+      { input: 'hello', session_id: 'session-1', instructions: composed },
+      'default',
+      sessionMap,
+      bridge,
+      false,
+      vi.fn(),
+      vi.fn(),
+    )
+
+    expect(getSystemPromptMock).not.toHaveBeenCalled()
+    const sent = String(bridge.chat.mock.calls[0]?.[3] ?? '')
+    expect(sent).toContain(composed)
+    expect(sent.split('system prompt').length - 1).toBe(1)
+  })
+
   it('refreshes full context tokens when a bridge run completes', async () => {
     const emit = vi.fn()
     const nsp = makeNamespace(emit)


### PR DESCRIPTION
Fixes #2401.

The Studio guidance block — the MCP usage rules plus the output-format rules — is appended to the system message twice, byte for byte, on every outgoing request. @yinlongfei88-cmyk measured it at ~3,084 characters per turn on a live instance, re-sent each turn because it lives in the system message, and persisted that way into `system_prompts`.

## Where the second copy comes from

Two places compose it for the same run:

- `run-chat/index.ts` builds `getSystemPrompt(...) + data.instructions` and passes the result down as `instructions`
- `handle-bridge-run.ts` then prepends `getSystemPrompt(...)` again to what it was just handed

`handleBridgeRun` has exactly one caller, and that caller always composes — so the inner composition could only ever duplicate. It now composes only when a caller passes no instructions at all, which keeps that entry point self-sufficient if it ever gains a second caller.

## Test

`tests/server/run-chat-bridge-final-context.test.ts` gains one case: when the caller hands down composed instructions, the prompt composer is not called again and the guidance text appears exactly once in what reaches the bridge. I reverted the source file and confirmed it fails without this change; the file's other 28 cases and the neighbouring chat-run suites (67 tests) pass unchanged.

Nothing else changes — no behaviour difference for callers that pass no instructions, and the guidance itself is untouched.
