### PR TITLE
fix(group-chat): retain history without automatic pruning

### DIFF
--- a/docs/chat-chain-changes/2026-08-08-group-chat-history-retention.md
+++ b/docs/chat-chain-changes/2026-08-08-group-chat-history-retention.md
@@ -1,0 +1,13 @@
+---
+date: 2026-08-08
+pr: pending
+feature: Group Chat history retention
+impact: Group Chat retains older messages without loading more than the latest 500 records into normal UI and Agent context windows.
+---
+
+Group Chat no longer deletes older messages automatically when a room exceeds
+500 records. Normal UI and Agent context reads stay bounded to the latest 500
+messages, avoiding the nested transaction that previously crashed Node 23 when
+automatic pruning ran inside a message-save transaction. Explicit clear-history
+and delete-room actions continue to remove the room's persisted messages and
+related workspace changes.

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -440,6 +440,8 @@ function maxAgentMentionDepth(): number {
     return Math.min(10, Math.floor(value))
 }
 
+const GROUP_CHAT_MESSAGE_WINDOW = 500
+
 class ChatStorage {
     private roomAgentOnlineProvider: ((roomId: string, agentId: string) => boolean) | null = null
 
@@ -880,11 +882,48 @@ class ChatStorage {
 
     // ─── Messages ─────────────────────────────────────────────
 
+    private getRecentMessageRows(
+        roomId: string,
+        limit: number,
+        options: { excludeWorkspaceDiff?: boolean; throughMessageId?: string } = {},
+    ): any[] {
+        const db = this.db()
+        const boundedLimit = Math.min(GROUP_CHAT_MESSAGE_WINDOW, Math.max(0, Math.floor(limit)))
+        if (!db || boundedLimit === 0) return []
+
+        const where = ['roomId = ?']
+        const params: Array<string | number> = [roomId]
+        if (options.excludeWorkspaceDiff) {
+            where.push("COALESCE(tool_name, '') <> 'workspace_diff'")
+        }
+        if (options.throughMessageId) {
+            const through = db.prepare(
+                'SELECT timestamp FROM gc_messages WHERE roomId = ? AND id = ?'
+            ).get(roomId, options.throughMessageId) as { timestamp: number } | undefined
+            if (through) {
+                where.push('timestamp <= ?')
+                params.push(through.timestamp)
+            }
+        }
+
+        const predicate = where.join(' AND ')
+        const boundary = db.prepare(
+            `SELECT timestamp FROM gc_messages
+             WHERE ${predicate}
+             ORDER BY timestamp DESC, id DESC
+             LIMIT 1 OFFSET ?`
+        ).get(...params, boundedLimit - 1) as { timestamp: number } | undefined
+        return db.prepare(
+            `SELECT ${MESSAGE_SELECT_COLUMNS} FROM gc_messages
+             WHERE ${predicate}${boundary ? ' AND timestamp >= ?' : ''}`
+        ).all(...params, ...(boundary ? [boundary.timestamp] : [])) as any[]
+    }
+
     getRecentMessagesForUI(roomId: string, limit = 150, offset = 0): ChatMessage[] {
-        const rows = (this.db()?.prepare(
-            `SELECT ${MESSAGE_SELECT_COLUMNS} FROM gc_messages WHERE roomId = ?`
-        ).all(roomId) || []) as any[]
-        const page = paginateRecentGroupMessagesCanonical(rows, { limit, offset })
+        const safeLimit = Math.max(0, Math.floor(Number(limit) || 0))
+        const safeOffset = Math.max(0, Math.floor(Number(offset) || 0))
+        const rows = this.getRecentMessageRows(roomId, safeLimit + safeOffset)
+        const page = paginateRecentGroupMessagesCanonical(rows, { limit: safeLimit, offset: safeOffset })
         const agentCache = new Map<string, RoomAgent | null>()
         const roomCache = new Map<string, RoomInfo | undefined>()
         return this.compactMessageAgentMetadata(
@@ -893,11 +932,10 @@ class ChatStorage {
     }
 
     getMessagesForContext(roomId: string, cutoff?: GroupMessageCursorCutoff): ChatMessage[] {
-        const rows = (this.db()?.prepare(
-            `SELECT ${MESSAGE_SELECT_COLUMNS}
-             FROM gc_messages
-             WHERE roomId = ? AND COALESCE(tool_name, '') <> 'workspace_diff'`
-        ).all(roomId) || []) as any[]
+        const rows = this.getRecentMessageRows(roomId, GROUP_CHAT_MESSAGE_WINDOW, {
+            excludeWorkspaceDiff: true,
+            throughMessageId: cutoff?.throughMessageId,
+        })
         const agentCache = new Map<string, RoomAgent | null>()
         const roomCache = new Map<string, RoomInfo | undefined>()
         return sliceGroupMessagesCanonical(
@@ -1049,7 +1087,6 @@ class ChatStorage {
                 tool_name: 'workspace_diff',
             }
             const storedMessage = this.upsertMessage(message)
-            this.pruneMessages(args.roomId)
             const messages = this.getMessagesForContext(args.roomId)
             const totalTokens = this.estimateRoomTotalTokens(args.roomId, messages)
             this.updateRoomTotalTokens(args.roomId, totalTokens)
@@ -1078,7 +1115,6 @@ class ChatStorage {
                 : msg
             const message = existing && options.preserveExistingTimestamp ? { ...safeMsg, timestamp: existing.timestamp } : safeMsg
             const storedMessage = this.upsertMessage(message, existing)
-            this.pruneMessages(msg.roomId)
             const messages = this.getMessagesForContext(msg.roomId)
             const totalTokens = this.estimateRoomTotalTokens(msg.roomId, messages)
             this.updateRoomTotalTokens(msg.roomId, totalTokens)
@@ -1090,10 +1126,10 @@ class ChatStorage {
         }
     }
 
-    private deleteWorkspaceDiffChanges(roomId: string, beforeTimestamp?: number): void {
+    private deleteWorkspaceDiffChanges(roomId: string): void {
         const db = this.db()
         if (!db) return
-        deleteWorkspaceRunChangesForRoom(db, roomId, beforeTimestamp)
+        deleteWorkspaceRunChangesForRoom(db, roomId)
     }
 
     private withImmediateTransaction(db: any, fn: () => void): void {
@@ -1128,24 +1164,6 @@ class ChatStorage {
             db.prepare('DELETE FROM gc_room_summaries WHERE roomId = ?').run(roomId)
             db.prepare('UPDATE gc_rooms SET totalTokens = 0, sessionSeed = ? WHERE id = ?').run(`${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`, roomId)
         })
-    }
-
-    pruneMessages(roomId: string, keep = 500): void {
-        const db = this.db()
-        if (!db) return
-        const count = (db.prepare('SELECT COUNT(*) as c FROM gc_messages WHERE roomId = ?').get(roomId) as any)?.c
-        if (count > keep) {
-            const cutoff = db.prepare(
-                'SELECT timestamp FROM gc_messages WHERE roomId = ? ORDER BY timestamp DESC LIMIT 1 OFFSET ?'
-            ).get(roomId, keep - 1) as any
-            if (cutoff) {
-                this.withImmediateTransaction(db, () => {
-                    this.deleteWorkspaceDiffChanges(roomId, cutoff.timestamp)
-                    const result = db.prepare('DELETE FROM gc_messages WHERE roomId = ? AND timestamp < ?').run(roomId, cutoff.timestamp)
-                    logger.info(`[GroupChat] pruned ${result.changes} messages from room ${roomId} (had ${count}, keeping ${keep})`)
-                })
-            }
-        }
     }
 
     // ─── Room Agents ──────────────────────────────────────────
@@ -2319,7 +2337,10 @@ export class GroupChatServer {
 
         // Load history from SQLite
         const messages = this.storage.getRecentMessagesForUI(roomId)
-        const total = this.storage.getMessageCount?.(roomId) ?? messages.length
+        const total = Math.min(
+            GROUP_CHAT_MESSAGE_WINDOW,
+            this.storage.getMessageCount?.(roomId) ?? messages.length,
+        )
         const agents = this.getRoomAgentViews(
             roomId,
             this.canSocketManageRoom(socket, roomId),
@@ -2363,7 +2384,10 @@ export class GroupChatServer {
         const offset = Math.max(0, Number.isFinite(data?.offset) ? Math.floor(Number(data?.offset)) : 0)
         const limit = Math.min(150, Math.max(1, Number.isFinite(data?.limit) ? Math.floor(Number(data?.limit)) : 150))
         const messages = this.storage.getRecentMessagesForUI(roomId, limit, offset)
-        const total = this.storage.getMessageCount?.(roomId) ?? messages.length
+        const total = Math.min(
+            GROUP_CHAT_MESSAGE_WINDOW,
+            this.storage.getMessageCount?.(roomId) ?? messages.length,
+        )
         ack?.({
             messages,
             total,

--- a/tests/server/group-chat-history-window.test.ts
+++ b/tests/server/group-chat-history-window.test.ts
@@ -94,7 +94,7 @@ describe('group chat history windows', () => {
     dbMock.current = null
   })
 
-  it('returns a bounded recent UI page while context reads the full retained transcript in canonical order', () => {
+  it('returns bounded UI and context windows in canonical order', () => {
     const storage = groupServer.getStorage()
     storage.saveRoom('room-1', 'Room 1')
 
@@ -144,7 +144,7 @@ describe('group chat history windows', () => {
     ])
   })
 
-  it('computes room total tokens from the full retained context transcript, not the UI page window', () => {
+  it('computes room total tokens from the context window, not the UI page window', () => {
     const storage = groupServer.getStorage()
     storage.saveRoom('room-1', 'Room 1')
 
@@ -165,7 +165,7 @@ describe('group chat history windows', () => {
     expect(storage.getRoom('room-1')?.totalTokens).toBe(expectedTotalTokens)
   })
 
-  it('continues shared context by timestamp when the summary anchor was pruned', () => {
+  it('retains older messages while limiting shared context to the latest 500', () => {
     const storage = groupServer.getStorage()
     storage.saveRoom('room-1', 'Room 1')
 
@@ -188,17 +188,36 @@ describe('group chat history windows', () => {
       lastError: null,
     })
 
-    for (const message of seeded.slice(1)) storage.saveMessageAndRefreshRoom(message as any)
+    let latest: { totalTokens: number } | null = null
+    for (const message of seeded.slice(1)) latest = storage.saveMessageAndRefreshRoom(message as any)
 
-    const retained = storage.getMessagesForContext('room-1')
+    const contextMessages = storage.getMessagesForContext('room-1')
     const context = groupServer.getRoomSummaryService().buildRuntimeContext('room-1')
 
-    expect(retained).toHaveLength(500)
-    expect(retained.some(message => message.id === 'msg-1')).toBe(false)
+    expect(storage.getMessageCount('room-1')).toBe(501)
+    expect(storage.getMessage('msg-1')).not.toBeNull()
+    expect(storage.getRecentMessagesForUI('room-1', 500).map(message => message.id)).toEqual(
+      seeded.slice(1).map(message => message.id),
+    )
+    expect(storage.getRecentMessagesForUI('room-1', 150, 450).map(message => message.id)).toEqual(
+      seeded.slice(1, 51).map(message => message.id),
+    )
+    expect(storage.getRecentMessagesForUI('room-1', 150, 500)).toEqual([])
+    expect(contextMessages).toHaveLength(500)
+    expect(contextMessages.some(message => message.id === 'msg-1')).toBe(false)
     expect(context.summary).toBe('Earlier summary')
     expect(context.history).toHaveLength(500)
     expect(context.history[0]?.id).toBe('msg-2')
     expect(context.history.at(-1)?.id).toBe('msg-501')
+    expect(latest?.totalTokens).toBe(
+      seeded.slice(1).reduce((sum, message) => sum + countTokens(String(message.content)), 0),
+    )
+
+    storage.clearRoomContext('room-1')
+
+    expect(storage.getMessageCount('room-1')).toBe(0)
+    expect(storage.getMessage('msg-1')).toBeNull()
+    expect(storage.getMessagesForContext('room-1')).toEqual([])
   })
 
   it('builds Agent context from the full retained transcript rather than the UI page', () => {

--- a/tests/server/group-chat-workspace-diff.test.ts
+++ b/tests/server/group-chat-workspace-diff.test.ts
@@ -289,31 +289,6 @@ describe('group chat workspace diff persistence', () => {
     server.getIO().close()
   })
 
-  it('cleans persisted workspace diffs when their group messages are pruned', async () => {
-    const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
-    const server = new GroupChatServer(httpServer)
-    const storage = server.getStorage()
-    storage.saveRoom('room-1', 'Room 1')
-    const { saved, payload } = await saveDiff(storage, 'room-1', 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')
-    dbState.db?.prepare('UPDATE gc_messages SET timestamp = ? WHERE id = ?').run(1, saved!.message.id)
-    storage.saveMessageAndRefreshRoom({
-      id: 'keep-message',
-      roomId: 'room-1',
-      senderId: 'user-1',
-      senderName: 'User',
-      content: 'keep',
-      timestamp: 100,
-      role: 'user',
-    })
-
-    storage.pruneMessages('room-1', 1)
-
-    expectWorkspaceChangeDeleted(payload.change_id)
-    expect(countRows('gc_messages', ' WHERE id = ?', saved!.message.id)).toBe(0)
-    expect(countRows('gc_messages', ' WHERE id = ?', 'keep-message')).toBe(1)
-    server.getIO().close()
-  })
-
   it('rolls back diff rows when the group message insert fails', async () => {
     const { GroupChatServer } = await import('../../packages/server/src/services/hermes/group-chat')
     const server = new GroupChatServer(httpServer)


### PR DESCRIPTION
## Summary
- stop automatically deleting Group Chat messages after a room exceeds 500 records
- bound normal UI pagination and Agent context reads to the latest 500 messages at the SQLite query layer
- keep explicit clear-history and delete-room actions physically deleting room messages and related workspace changes

## Root cause
On Node 23, `node:sqlite` does not expose the transaction-state property used by `withImmediateTransaction`. Saving the 501st room message entered `pruneMessages` from an existing `BEGIN IMMEDIATE` transaction and attempted another `BEGIN IMMEDIATE`, causing `cannot start a transaction within a transaction` and terminating the server process.

Removing automatic pruning eliminates that nested transaction path while retaining a bounded runtime context. Historical rows remain available in SQLite until the user explicitly clears history or deletes the room.

## Validation
- `npm run harness:check`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- focused Group Chat history and workspace-diff tests: 15 passed
- Node 23.8 regression for the 501st message: passed
- full Vitest suite before branch publication: 443 files passed; 3638 tests passed, 3 skipped

Closes #2412
