### PR TITLE
fix(server): add lightweight liveness endpoint

### DIFF
--- a/packages/server/src/controllers/health.ts
+++ b/packages/server/src/controllers/health.ts
@@ -188,6 +188,10 @@ async function refreshAgentBridgeHealth(): Promise<AgentBridgeHealthPayload> {
   }
 }
 
+export function livenessCheck(ctx: any) {
+  ctx.body = { status: 'ok' }
+}
+
 export async function healthCheck(ctx: any) {
   const raw = await hermesCli.getVersion()
   const hermesVersion = raw.split('\n')[0].replace('Hermes Agent ', '') || ''

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -3,6 +3,7 @@ import * as ctrl from '../controllers/health'
 
 export const healthRoutes = new Router()
 
+healthRoutes.get('/livez', ctrl.livenessCheck)
 healthRoutes.get('/health', ctrl.healthCheck)
 
 export { startVersionCheck } from '../controllers/health'

--- a/tests/server/health-controller.test.ts
+++ b/tests/server/health-controller.test.ts
@@ -42,8 +42,9 @@ async function loadHealthController(options: LoadHealthControllerOptions = {}) {
     delete (globalThis as any).__APP_VERSION__
   }
 
+  const getVersion = vi.fn().mockResolvedValue('Hermes Agent v0.11.0\n')
   vi.doMock('../../packages/server/src/services/hermes/hermes-cli', () => ({
-    getVersion: vi.fn().mockResolvedValue('Hermes Agent v0.11.0\n'),
+    getVersion,
   }))
 
   const checkReadiness = options.bridgeReadinessError
@@ -69,6 +70,7 @@ async function loadHealthController(options: LoadHealthControllerOptions = {}) {
 
   return {
     ...health,
+    getVersion,
     getAgentBridgeManager,
     checkReadiness,
     getRuntimeState,
@@ -88,6 +90,24 @@ function createMockCtx() {
     body: null as any,
   }
 }
+
+describe('liveness controller', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('returns a static ok response without probing Hermes or Agent Bridge', async () => {
+    const { livenessCheck, getVersion, getAgentBridgeManager } = await loadHealthControllerWithoutInjectedVersion()
+    const ctx = createMockCtx()
+
+    livenessCheck(ctx)
+
+    expect(ctx.body).toEqual({ status: 'ok' })
+    expect(getVersion).not.toHaveBeenCalled()
+    expect(getAgentBridgeManager).not.toHaveBeenCalled()
+  })
+})
 
 describe('health controller version metadata', () => {
   afterEach(() => {


### PR DESCRIPTION
## Summary
- add `GET /livez` as a static process-liveness response
- keep the existing `/health` dependency diagnostics unchanged
- verify `/livez` does not invoke Hermes CLI or Agent Bridge readiness checks

## Verification
- `npm test -- --run tests/server/health-controller.test.ts` — 11 passed
- `npm run build` — passed
- full `npm test` has unrelated baseline/environment failures in plugin discovery, Bridge Python environment, Kanban attachment path, and one timeout; the focused health suite remains green

## Scope
This PR only adds the lightweight endpoint. Packaging must switch its probe separately after an image containing this commit is available.