### PR TITLE
fix(ui): improve global approval command preview

### DIFF
--- a/packages/client/src/components/layout/GlobalPendingActions.vue
+++ b/packages/client/src/components/layout/GlobalPendingActions.vue
@@ -7,6 +7,7 @@ import { useChatStore, type PendingApproval } from '@/stores/hermes/chat'
 import { useGroupChatStore, type GroupPendingApproval, type GroupPendingClarify } from '@/stores/hermes/group-chat'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 import { useSettingsStore } from '@/stores/hermes/settings'
+import { copyToClipboard } from '@/utils/clipboard'
 import { playCompletionSound } from '@/utils/completion-sound'
 import { workflowApprovalKey } from '@/utils/workflow-approval-key'
 import { approveWorkflowNode, type WorkflowRecord } from '@/api/hermes/workflows'
@@ -177,12 +178,12 @@ function pendingActions(): GlobalPendingAction[] {
 }
 
 async function copyApprovalCommand(action: Extract<GlobalPendingAction, { kind: 'chat-approval' | 'group-approval' }>) {
-  try {
-    await navigator.clipboard.writeText(action.pending.command)
-    copiedCommandKey.value = action.key
-  } catch {
+  const copied = await copyToClipboard(action.pending.command)
+  if (!copied) {
     message.error(t('chat.copyFailed'))
+    return
   }
+  copiedCommandKey.value = action.key
 }
 
 function approvalCommand(action: Extract<GlobalPendingAction, { kind: 'chat-approval' | 'group-approval' }>) {

--- a/packages/client/src/components/layout/GlobalPendingActions.vue
+++ b/packages/client/src/components/layout/GlobalPendingActions.vue
@@ -27,6 +27,7 @@ const announcedKeys = new Set<string>()
 const pendingSoundKeys = new Set<string>()
 const clarifyDrafts = reactive<Record<string, string>>({})
 const submitting = reactive<Record<string, boolean>>({})
+const copiedCommandKey = ref<string | null>(null)
 const workflows = ref<WorkflowRecord[]>([])
 const workflowStatuses = reactive<Record<string, WorkflowRuntimeStatus>>({})
 const visibleWorkflowApprovalKeys = reactive(new Set<string>())
@@ -91,8 +92,12 @@ type GlobalPendingAction =
   | { key: string; kind: 'group-clarify'; title: string; pending: GroupPendingClarify }
   | { key: string; kind: 'workflow-approval'; title: string; workflowId: string; runId: string; nodeId: string; executionId?: string }
 
+function normalizePendingSourceTitle(title: string): string {
+  return title.replace(/^(?:\s*branch:\s*)+/i, 'branch: ').trim()
+}
+
 function sessionTitle(sessionId: string): string {
-  return chatStore.sessions.find(session => session.id === sessionId)?.title || sessionId
+  return normalizePendingSourceTitle(chatStore.sessions.find(session => session.id === sessionId)?.title || sessionId)
 }
 
 function roomTitle(roomId: string): string {
@@ -169,6 +174,30 @@ function pendingActions(): GlobalPendingAction[] {
     }
   }
   return actions
+}
+
+async function copyApprovalCommand(action: Extract<GlobalPendingAction, { kind: 'chat-approval' | 'group-approval' }>) {
+  try {
+    await navigator.clipboard.writeText(action.pending.command)
+    copiedCommandKey.value = action.key
+  } catch {
+    message.error(t('chat.copyFailed'))
+  }
+}
+
+function approvalCommand(action: Extract<GlobalPendingAction, { kind: 'chat-approval' | 'group-approval' }>) {
+  if (!action.pending.command) return null
+  return h('div', { class: 'global-approval-command' }, [
+    h('div', { class: 'global-approval-command-header' }, [
+      h('span', { class: 'global-approval-command-label' }, t('chat.approvalCommand')),
+      h(NButton, {
+        size: 'tiny',
+        quaternary: true,
+        onClick: () => void copyApprovalCommand(action),
+      }, { default: () => copiedCommandKey.value === action.key ? t('common.copied') : t('common.copy') }),
+    ]),
+    h('pre', { tabindex: 0 }, [h('code', action.pending.command)]),
+  ])
 }
 
 function approvalButtons(action: Extract<GlobalPendingAction, { kind: 'chat-approval' | 'group-approval' }>) {
@@ -287,7 +316,7 @@ function createGlobalNotification(action: GlobalPendingAction): NotificationReac
         ? () => h('div', { class: 'global-approval-content' }, t('workflow.status.pending_approval'))
         : () => h('div', { class: 'global-approval-content' }, [
             h('div', action.pending.description || ''),
-            action.pending.command ? h('code', action.pending.command) : null,
+            approvalCommand(action),
           ]),
     action: clarify
       ? () => h(NButton, {
@@ -374,7 +403,11 @@ onUnmounted(() => {
 .global-pending-title:focus-visible { border-radius: 2px; outline: 2px solid var(--accent-info); outline-offset: 3px; }
 .global-pending-actions, .global-clarify-choices { display: flex; flex-wrap: wrap; gap: 8px; }
 .global-approval-content, .global-clarify-content { display: grid; gap: 10px; max-width: 420px; max-height: min(300px, calc(100dvh - 160px)); overflow-x: hidden; overflow-y: auto; overscroll-behavior: contain; overflow-wrap: anywhere; }
-.global-approval-content code { display: block; padding: 8px; border-radius: 6px; background: var(--n-color-embedded); white-space: pre-wrap; }
+.global-approval-command { min-width: 0; overflow: hidden; border: 1px solid var(--n-border-color); border-radius: 8px; background: var(--n-color-embedded); }
+.global-approval-command-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 34px; padding: 4px 6px 4px 12px; border-bottom: 1px solid var(--n-border-color); }
+.global-approval-command-label { color: var(--text-secondary); font-size: 12px; font-weight: 600; }
+.global-approval-command pre { max-height: 240px; margin: 0; padding: 12px; overflow: auto; overscroll-behavior: contain; white-space: pre; }
+.global-approval-command code { display: block; width: max-content; min-width: 100%; color: var(--text-primary); font-family: "SFMono-Regular", "Cascadia Code", "Roboto Mono", Consolas, monospace; font-size: 12px; line-height: 1.55; }
 .global-clarify-question { font-weight: 600; }
 
 @media (max-width: 600px) {

--- a/packages/client/src/i18n/locales/ar.ts
+++ b/packages/client/src/i18n/locales/ar.ts
@@ -724,6 +724,7 @@ export default {
     categoryDeleteFailed: 'تعذّر حذف الفئة',
     agent: 'وكيل',
     approvalKicker: 'صلاحية الأداة',
+    approvalCommand: 'الأمر المطلوب تشغيله',
     approvalTitle: 'راجع استدعاء الأداة قبل التشغيل',
     approvalAgree: 'موافقة',
     approvalAllowOnce: 'السماح مرة واحدة',

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -670,6 +670,7 @@ export default {
     categoryDeleteFailed: 'Kategorie konnte nicht gelöscht werden',
     agent: 'Agent',
     approvalKicker: 'Tool-Berechtigung',
+    approvalCommand: 'Auszuführender Befehl',
     approvalTitle: 'Tool-Aufruf vor der Ausführung prüfen',
     approvalAgree: 'Zustimmen',
     approvalAllowOnce: 'Einmal erlauben',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -724,6 +724,7 @@ export default {
     categoryDeleteFailed: 'Failed to delete category',
     agent: 'Agent',
     approvalKicker: 'Tool permission',
+    approvalCommand: 'Command to run',
     approvalTitle: 'Review tool call before running',
     approvalAgree: 'Agree',
     approvalAllowOnce: 'Allow once',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -670,6 +670,7 @@ export default {
     categoryDeleteFailed: 'No se pudo eliminar la categoría',
     agent: 'Agent',
     approvalKicker: 'Permiso de herramienta',
+    approvalCommand: 'Comando que se ejecutará',
     approvalTitle: 'Revisar llamada de herramienta antes de ejecutar',
     approvalAgree: 'Aceptar',
     approvalAllowOnce: 'Permitir una vez',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -670,6 +670,7 @@ export default {
     categoryDeleteFailed: 'Échec de la suppression de la catégorie',
     agent: 'Agent',
     approvalKicker: 'Permission d’outil',
+    approvalCommand: 'Commande à exécuter',
     approvalTitle: 'Vérifier l’appel d’outil avant exécution',
     approvalAgree: 'Accepter',
     approvalAllowOnce: 'Autoriser une fois',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -670,6 +670,7 @@ export default {
     categoryDeleteFailed: 'カテゴリーを削除できませんでした',
     agent: 'Agent',
     approvalKicker: 'ツール権限',
+    approvalCommand: '実行するコマンド',
     approvalTitle: '実行前にツール呼び出しを確認',
     approvalAgree: '同意',
     approvalAllowOnce: '一度だけ許可',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -670,6 +670,7 @@ export default {
     categoryDeleteFailed: '카테고리를 삭제하지 못했습니다',
     agent: 'Agent',
     approvalKicker: '도구 권한',
+    approvalCommand: '실행할 명령',
     approvalTitle: '실행 전에 도구 호출 확인',
     approvalAgree: '동의',
     approvalAllowOnce: '한 번만 허용',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -670,6 +670,7 @@ export default {
     categoryDeleteFailed: 'Falha ao excluir categoria',
     agent: 'Agent',
     approvalKicker: 'Permissão da ferramenta',
+    approvalCommand: 'Comando a executar',
     approvalTitle: 'Revisar chamada da ferramenta antes de executar',
     approvalAgree: 'Concordar',
     approvalAllowOnce: 'Permitir uma vez',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -612,6 +612,7 @@ export default {
     categoryDeleteFailed: 'Не удалось удалить категорию',
     agent: 'Agent',
     approvalKicker: 'Разрешение инструмента',
+    approvalCommand: 'Команда для выполнения',
     approvalTitle: 'Подтвердите вызов инструмента перед выполнением',
     approvalAgree: 'Согласиться',
     approvalAllowOnce: 'Разрешить однократно',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -722,6 +722,7 @@ export default {
     categoryDeleteFailed: '刪除分類失敗',
     agent: 'Agent',
     approvalKicker: '工具呼叫授權',
+    approvalCommand: '待執行命令',
     approvalTitle: '執行前請確認工具呼叫',
     approvalAgree: '同意',
     approvalAllowOnce: '僅本次允許',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -724,6 +724,7 @@ export default {
     categoryDeleteFailed: '删除分类失败',
     agent: 'Agent',
     approvalKicker: '工具调用授权',
+    approvalCommand: '待执行命令',
     approvalTitle: '运行前请确认工具调用',
     approvalAgree: '同意',
     approvalAllowOnce: '仅本次允许',

--- a/tests/client/global-pending-actions.test.ts
+++ b/tests/client/global-pending-actions.test.ts
@@ -313,6 +313,32 @@ describe('GlobalPendingActions', () => {
     expect(created.some(entry => notificationTitleText(entry).includes('session-a'))).toBe(true)
   })
 
+  it('renders the exact approval command as a scrollable code block and copies it', async () => {
+    const writeText = vi.fn(async () => undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    chatState.sessions = [{ id: 'session-b', title: 'branch: branch: Build scripts' }]
+    const command = 'rm -rf /tmp/reviewer-snapshot &&\nmkdir -p /tmp/reviewer-snapshot'
+    chatState.pendingApprovals = new Map([['session-b', {
+      sessionId: 'session-b', approvalId: 'approval-b', description: 'Security scan', command, choices: ['once', 'deny'],
+    }]])
+
+    mount(GlobalPendingActions)
+    await nextTick()
+
+    expect(notificationTitleText(created[0])).toBe('branch: Build scripts · chat.approvalTitle')
+    const content = await render(created[0].options.content)
+    const preview = content.get('.global-approval-command')
+    expect(preview.get('.global-approval-command-label').text()).toBe('chat.approvalCommand')
+    expect(preview.get('pre > code').text()).toBe(command)
+    expect(preview.get('pre').attributes('tabindex')).toBe('0')
+
+    await preview.get('button').trigger('click')
+    expect(writeText).toHaveBeenCalledWith(command)
+  })
+
   it('shows and directly handles an approval from an inactive chat session', async () => {
     chatState.sessions = [{ id: 'session-a', title: 'A' }, { id: 'session-b', title: 'B' }]
     chatState.pendingApprovals = new Map([['session-b', {

--- a/tests/client/global-pending-actions.test.ts
+++ b/tests/client/global-pending-actions.test.ts
@@ -26,6 +26,8 @@ const settingsState = reactive({ display: { approval_bell: false }, fetchSetting
 const routeState = reactive({ name: 'hermes.chat' as string })
 const routerPush = vi.fn(async () => undefined)
 const created: any[] = []
+const clipboardMock = vi.hoisted(() => ({ copyToClipboard: vi.fn(async () => true) }))
+const uiMock = vi.hoisted(() => ({ messageError: vi.fn() }))
 const workflowMock = vi.hoisted(() => ({
   statusHandlers: [] as Array<(status: any) => void>,
   approveWorkflowNode: vi.fn(),
@@ -37,6 +39,7 @@ vi.mock('@/stores/hermes/chat', () => ({ useChatStore: () => chatState }))
 vi.mock('@/stores/hermes/group-chat', () => ({ useGroupChatStore: () => groupState }))
 vi.mock('@/stores/hermes/profiles', () => ({ useProfilesStore: () => profileState }))
 vi.mock('@/stores/hermes/settings', () => ({ useSettingsStore: () => settingsState }))
+vi.mock('@/utils/clipboard', () => clipboardMock)
 vi.mock('@/utils/completion-sound', () => ({ playCompletionSound: vi.fn(async () => true) }))
 vi.mock('vue-router', () => ({ useRoute: () => routeState, useRouter: () => ({ push: routerPush }) }))
 vi.mock('@/api/hermes/workflows', () => ({ approveWorkflowNode: workflowMock.approveWorkflowNode }))
@@ -53,7 +56,7 @@ vi.mock('naive-ui', async () => {
   return {
     NButton: button,
     NInput: input,
-    useMessage: () => ({ error: vi.fn() }),
+    useMessage: () => ({ error: uiMock.messageError }),
     useNotification: () => ({
       create: vi.fn((options: any) => {
         const entry = { options, destroy: vi.fn() }
@@ -65,6 +68,7 @@ vi.mock('naive-ui', async () => {
 })
 
 import GlobalPendingActions from '@/components/layout/GlobalPendingActions.vue'
+import { copyToClipboard } from '@/utils/clipboard'
 import { playCompletionSound } from '@/utils/completion-sound'
 
 async function render(node: (() => any) | undefined) {
@@ -314,11 +318,6 @@ describe('GlobalPendingActions', () => {
   })
 
   it('renders the exact approval command as a scrollable code block and copies it', async () => {
-    const writeText = vi.fn(async () => undefined)
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
     chatState.sessions = [{ id: 'session-b', title: 'branch: branch: Build scripts' }]
     const command = 'rm -rf /tmp/reviewer-snapshot &&\nmkdir -p /tmp/reviewer-snapshot'
     chatState.pendingApprovals = new Map([['session-b', {
@@ -336,7 +335,26 @@ describe('GlobalPendingActions', () => {
     expect(preview.get('pre').attributes('tabindex')).toBe('0')
 
     await preview.get('button').trigger('click')
-    expect(writeText).toHaveBeenCalledWith(command)
+    expect(copyToClipboard).toHaveBeenCalledWith(command)
+    expect(preview.get('button').text()).toBe('common.copied')
+  })
+
+  it('reports a failed approval command copy without showing copied feedback', async () => {
+    clipboardMock.copyToClipboard.mockResolvedValueOnce(false)
+    chatState.pendingApprovals = new Map([['session-b', {
+      sessionId: 'session-b', approvalId: 'approval-b', description: 'Security scan', command: 'npm run build', choices: ['once', 'deny'],
+    }]])
+
+    mount(GlobalPendingActions)
+    await nextTick()
+
+    const content = await render(created[0].options.content)
+    const copyButton = content.get('.global-approval-command button')
+    await copyButton.trigger('click')
+
+    expect(copyToClipboard).toHaveBeenCalledWith('npm run build')
+    expect(uiMock.messageError).toHaveBeenCalledWith('chat.copyFailed')
+    expect(copyButton.text()).toBe('common.copy')
   })
 
   it('shows and directly handles an approval from an inactive chat session', async () => {


### PR DESCRIPTION
## Summary
- render global approval commands in a labeled, scrollable `<pre><code>` preview without altering the command text
- add a copy action with localized labels and feedback
- collapse repeated leading `branch:` prefixes in notification source titles

## Verification
- `npm test -- --run tests/client/global-pending-actions.test.ts tests/client/message-list-scroll-position.test.ts tests/client/chat-store-error-handling.test.ts` — 39 passed
- `npm run build` — passed
- `git diff --check` — passed
- full `npm test` currently reports the same unrelated baseline failures (28 files / 56 tests) on clean `origin/main`, including `hermes-plugins-env.test.ts` environment-dependent plugin discovery and `kanban-controller.test.ts` attachment path isolation
