### PR TITLE
fix(group-chat): persist Tool results containing mention text

### DIFF
--- a/docs/chat-chain-changes/2026-08-08-group-chat-anonymous-tool-sequence.md
+++ b/docs/chat-chain-changes/2026-08-08-group-chat-anonymous-tool-sequence.md
@@ -1,0 +1,9 @@
+---
+date: 2026-08-08
+pr: pending
+commit: pending
+feature: group-chat anonymous tool result correlation
+impact: prevents anonymous Tool call/result ID reuse and persisted-row overwrite
+---
+
+Anonymous Tool calls without native IDs now receive collision-resistant identities derived from Room/Session/Run scope plus a monotonic AgentClient sequence. Sequential acknowledged same-name calls remain distinct even when wall-clock time does not advance, preventing persisted Tool call/result rows from overwriting earlier rows.

--- a/docs/chat-chain-changes/2026-08-08-group-chat-tool-result-correlation-scope.md
+++ b/docs/chat-chain-changes/2026-08-08-group-chat-tool-result-correlation-scope.md
@@ -1,0 +1,10 @@
+---
+date: 2026-08-08
+pr: pending
+feature: group-chat-tool-result-correlation-scope
+impact: Tool completion recovery state is isolated per Room and native Session, preventing cross-run overwrite when runtimes reuse a Tool call ID.
+---
+
+- Scope internal Tool completion correlation by Room and native Session while preserving the runtime's external `tool_call_id` in persisted messages.
+- Prevent concurrent Group Chat runs that reuse the same native Tool call ID from overwriting each other's retry payload, Run ID, or acknowledgement state.
+- Keep deterministic persisted Tool call/result IDs within each Run and preserve legacy implicit Assistant mention handoffs.

--- a/docs/chat-chain-changes/2026-08-08-group-chat-tool-result-mentions.md
+++ b/docs/chat-chain-changes/2026-08-08-group-chat-tool-result-mentions.md
@@ -1,0 +1,8 @@
+---
+date: 2026-08-08
+pr: pending
+feature: Group Chat tool-result mention isolation and terminal recovery
+impact: Treats Tool payload text as non-routable data, preserves owner-only conversational @all authorization, and retains completed Tool results for collision-resistant idempotent Room-persistence retry with bounded ACK timeouts and replay suppression until they are acknowledged.
+---
+
+Group Chat no longer interprets literal mention text found in Tool output as routing intent. Tool-result persistence uses a stable message identity and keeps its correlation and original completion payload until Room storage acknowledges it, allowing both Hermes and Coding Agent run finalization to reconcile transient failures without leaving reloaded Tool cards permanently running. Explicit Agent client teardown clears any remaining in-memory Tool recovery and replay state.

--- a/docs/chat-chain-changes/2026-08-08-group-chat-tool-result-terminal-hardening.md
+++ b/docs/chat-chain-changes/2026-08-08-group-chat-tool-result-terminal-hardening.md
@@ -1,0 +1,11 @@
+---
+date: 2026-08-08
+pr: pending
+commit: pending
+feature: Group Chat Tool terminal persistence hardening
+impact: Hermes failed Tool results keep their original error payload; stale runs release scoped recovery state after final retry; and active runs surface terminal persistence loss while clearing exhausted ephemeral state.
+---
+
+- Preserve Hermes bridge `tool.failed` payloads and persist them as failed Tool results instead of synthesizing empty completions.
+- Drain and retry queued Tool writes before run exit. Stale runs discard only their scoped recovery state; active runs that exhaust retries log and surface terminal persistence loss, then clear the exhausted ephemeral correlation state.
+- Keep server-side stale-session authorization intact; stale runtime cleanup does not bypass Room message validation.

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -294,6 +294,10 @@ export class AgentClient implements GroupAgentExecutor {
     private pendingToolBaseIds = new Map<string, string>()
     private pendingToolRunIds = new Map<string, string>()
     private pendingToolNames = new Map<string, string>()
+    private pendingToolExternalIds = new Map<string, string>()
+    private pendingToolCompletionEvents = new Map<string, Record<string, unknown>>()
+    private acknowledgedToolCallIds = new Map<string, number>()
+    private anonymousToolCallSequence = 0
     private bridgeContextCache = new Map<string, BridgeContextCache>()
     private workspaceDiffRuns = new Map<string, WorkspaceDiffRunState>()
     private interruptVersions = new Map<string, number>()
@@ -395,6 +399,13 @@ export class AgentClient implements GroupAgentExecutor {
             this.joinedRooms.clear()
             this.bridgeContextCache.clear()
         }
+        this.pendingToolCallIds.clear()
+        this.pendingToolBaseIds.clear()
+        this.pendingToolRunIds.clear()
+        this.pendingToolNames.clear()
+        this.pendingToolExternalIds.clear()
+        this.pendingToolCompletionEvents.clear()
+        this.acknowledgedToolCallIds.clear()
     }
 
     async joinRoom(roomId: string): Promise<JoinResult> {
@@ -413,10 +424,14 @@ export class AgentClient implements GroupAgentExecutor {
 
     sendMessage(roomId: string, content: string, messageId?: string, extra?: Record<string, unknown>, agentSessionId?: string): Promise<string> {
         this.ensureConnected()
-        const generatedMentions = this.mentionBuilder?.(roomId, content) || []
+        // Preserve the legacy implicit-assistant call shape, but never classify
+        // runtime Tool payload text as conversational routing intent.
+        const role = typeof extra?.role === 'string' ? extra.role : undefined
+        const canCarryMentions = role === undefined || role === 'user' || role === 'assistant'
+        const generatedMentions = canCarryMentions ? this.mentionBuilder?.(roomId, content) || [] : []
         const mentions = generatedMentions.length > 0
             ? generatedMentions
-            : (extra?.role === 'assistant' ? this.structuredMentionsForAgentReply(roomId, content) : [])
+            : (canCarryMentions ? this.structuredMentionsForAgentReply(roomId, content) : [])
         const messageExtra = mentions.length ? { ...extra, mentions } : extra
         if (this.eventSink) {
             return this.eventSink.sendMessage(roomId, content, messageId, messageExtra, agentSessionId)
@@ -1053,7 +1068,7 @@ export class AgentClient implements GroupAgentExecutor {
                             toolReasoning,
                         ))
                     } else if (event === 'tool.completed' || event === 'tool.failed') {
-                        queueToolEventWrite(() => this.recordToolCompleted(roomId, sessionId, { ...payload, event }))
+                        queueToolEventWrite(() => this.recordToolCompleted(roomId, sessionId, { ...payload, event }).then(() => undefined))
                     } else if (event === 'approval.requested') {
                         this.emitApprovalRequested(roomId, { ...payload, agentSessionId: sessionId })
                     } else if (event === 'approval.resolved') {
@@ -1065,9 +1080,15 @@ export class AgentClient implements GroupAgentExecutor {
                     }
                 },
             })
-            if (!isCurrent()) return
+            if (!isCurrent()) {
+                await toolEventWrites
+                await this.completePendingToolsForRun(roomId, sessionId, responseRunId)
+                this.discardPendingToolsForRun(responseRunId)
+                return
+            }
             await toolEventWrites
-            await this.completePendingToolsForRun(roomId, sessionId, responseRunId)
+            const toolResultsPersisted = await this.completePendingToolsForRun(roomId, sessionId, responseRunId)
+            if (!toolResultsPersisted) throw new Error('One or more Tool results could not be persisted after bounded retries')
             if (!result.ok) throw new Error(result.error || 'Run failed')
             const finalContent = String(result.output || currentContent || '').trim()
             if (!sawReasoningDelta) reasoningContent = String(result.reasoning || reasoningContent || '')
@@ -1086,7 +1107,12 @@ export class AgentClient implements GroupAgentExecutor {
             await this.finalizeWorkspaceDiffOnce(workspaceRunState, 'completed', finalContent ? runMessageId : null)
             reportStatus('ready')
         } catch (err) {
-            if (!isCurrent()) return
+            if (!isCurrent()) {
+                await toolEventWrites
+                await this.completePendingToolsForRun(roomId, sessionId, responseRunId)
+                this.discardPendingToolsForRun(responseRunId)
+                return
+            }
             await toolEventWrites
             await this.completePendingToolsForRun(roomId, sessionId, responseRunId)
             await this.finalizeWorkspaceDiffOnce(workspaceRunState, 'failed', streamStarted ? runMessageId : null)
@@ -1171,6 +1197,8 @@ export class AgentClient implements GroupAgentExecutor {
                         }
                     }
                 }
+                await this.completePendingToolsForRun(roomId, sessionId, runMessageId)
+                this.discardPendingToolsForRun(runMessageId)
                 this.discardWorkspaceDiffRun(workspaceRunState)
                 workspaceRunState = null
                 try {
@@ -1296,6 +1324,9 @@ export class AgentClient implements GroupAgentExecutor {
                 }
             }
 
+            const toolResultsPersisted = await this.completePendingToolsForRun(roomId, sessionId, runMessageId)
+            if (!toolResultsPersisted) throw new Error('One or more Tool results could not be persisted after bounded retries')
+
             if (lastChunk?.status === 'error') {
                 logger.error(`[AgentClients] ${this.name}: bridge response failed: ${lastChunk.error || 'unknown error'}`)
                 if (!this.replySessionIsCurrent(roomId, sessionId, replyInterruptVersion)) {
@@ -1355,6 +1386,9 @@ export class AgentClient implements GroupAgentExecutor {
             if (workspaceRunState && !bridgeStarted) {
                 await stopStaleStartedRun?.('Interrupted after group chat bridge launch failed')
             } else {
+                if (activeSessionId) {
+                    await this.completePendingToolsForRun(roomId, activeSessionId, runMessageId)
+                }
                 await this.finalizeWorkspaceDiffOnce(workspaceRunState, 'failed', streamStarted ? streamMessageId : null)
             }
             try {
@@ -1426,7 +1460,7 @@ export class AgentClient implements GroupAgentExecutor {
                 if (!this.replySessionIsCurrent(roomId, sessionId, interruptVersion)) return reasoning
                 await this.recordToolStarted(roomId, sessionId, ev as Record<string, unknown>, toolBaseId, responseRunId, toolReasoning)
                 reasoning = ''
-            } else if (eventType === 'tool.completed') {
+            } else if (eventType === 'tool.completed' || eventType === 'tool.failed') {
                 if (!this.replySessionIsCurrent(roomId, sessionId, interruptVersion)) return reasoning
                 await this.recordToolCompleted(roomId, sessionId, ev as Record<string, unknown>)
             } else if (eventType === 'approval.requested') {
@@ -1484,18 +1518,26 @@ export class AgentClient implements GroupAgentExecutor {
     ): Promise<void> {
         const toolName = String(ev.tool_name || ev.tool || ev.name || '')
         const rawToolCallId = String(ev.tool_call_id || '').trim()
-        const toolCallId = groupToolCallId(rawToolCallId, toolName, this.nextToolIndex(roomId, toolName))
+        const externalToolCallId = groupToolCallId(
+            rawToolCallId,
+            toolName,
+            `${roomId}:${sessionId}:${runMessageId}`,
+            this.nextAnonymousToolCallSequence(),
+        )
+        const toolCallId = toolCorrelationId(roomId, sessionId, externalToolCallId)
+        this.acknowledgedToolCallIds.delete(toolCallId)
         if (!rawToolCallId || !this.pendingToolBaseIds.has(toolCallId)) {
             this.trackPendingToolCall(roomId, toolName, toolCallId)
         }
         this.pendingToolBaseIds.set(toolCallId, runMessageId)
         this.pendingToolRunIds.set(toolCallId, responseRunId)
         this.pendingToolNames.set(toolCallId, toolName)
+        this.pendingToolExternalIds.set(toolCallId, externalToolCallId)
         const timestamp = Date.now()
         const rawArgs = ev.args ?? ev.arguments ?? ev.input ?? {}
         const args = normalizeToolArgs(rawArgs)
         const toolCall = {
-            id: toolCallId,
+            id: externalToolCallId,
             type: 'function',
             function: {
                 name: toolName,
@@ -1503,7 +1545,7 @@ export class AgentClient implements GroupAgentExecutor {
             },
         }
         const msg: MessageData & Record<string, any> = {
-            id: `${runMessageId}_toolcall_${safeId(toolCallId)}`,
+            id: `${runMessageId}_toolcall_${stableToolIdPart(externalToolCallId)}`,
             roomId,
             senderId: this.id || this.agentId,
             senderName: this.name,
@@ -1529,16 +1571,25 @@ export class AgentClient implements GroupAgentExecutor {
             .catch((err: any) => logger.warn(`[AgentClients] failed to record tool call: ${err.message || err}`))
     }
 
-    private recordToolCompleted(roomId: string, sessionId: string, ev: Record<string, unknown>): Promise<void> {
+    private async recordToolCompleted(roomId: string, sessionId: string, ev: Record<string, unknown>): Promise<boolean> {
         const rawId = String(ev.tool_call_id || '').trim()
-        const toolName = String(ev.tool_name || ev.tool || ev.name || this.pendingToolNames.get(rawId) || '')
-        if (rawId) this.removePendingToolCall(roomId, toolName, rawId)
-        const toolCallId = rawId || this.takePendingToolCall(roomId, toolName) || groupToolCallId(null, toolName, this.nextToolIndex(roomId, toolName))
+        const scopedRawId = rawId ? toolCorrelationId(roomId, sessionId, rawId) : ''
+        if (scopedRawId && this.acknowledgedToolCallIds.has(scopedRawId)) return true
+        const initialToolName = String(ev.tool_name || ev.tool || ev.name || '')
+        const queuedToolCallId = rawId ? '' : (this.takePendingToolCall(roomId, initialToolName) || '')
+        const externalToolCallId = rawId
+            || this.pendingToolExternalIds.get(queuedToolCallId)
+            || groupToolCallId(
+                null,
+                initialToolName,
+                `${roomId}:${sessionId}:${inferResponseRunId(groupMessageId(roomId, this.profile, this.name))}`,
+                this.nextAnonymousToolCallSequence(),
+            )
+        const toolCallId = scopedRawId || queuedToolCallId || toolCorrelationId(roomId, sessionId, externalToolCallId)
+        const toolName = initialToolName || this.pendingToolNames.get(toolCallId) || ''
         const runMessageId = this.pendingToolBaseIds.get(toolCallId) || groupMessagePartId(groupMessageId(roomId, this.profile, this.name), 0)
         const responseRunId = this.pendingToolRunIds.get(toolCallId) || inferResponseRunId(runMessageId)
-        this.pendingToolBaseIds.delete(toolCallId)
-        this.pendingToolRunIds.delete(toolCallId)
-        this.pendingToolNames.delete(toolCallId)
+        this.pendingToolCompletionEvents.set(toolCallId, ev)
         const output = bridgeToolOutput(ev)
         const failed = ev.event === 'tool.failed'
             || ev.is_error === true
@@ -1546,7 +1597,7 @@ export class AgentClient implements GroupAgentExecutor {
             || (typeof ev.error === 'string' && ev.error.trim().length > 0)
         const timestamp = Date.now()
         const msg: MessageData & Record<string, any> = {
-            id: `${runMessageId}_toolresult_${safeId(toolCallId)}_${Date.now()}`,
+            id: `${runMessageId}_toolresult_${stableToolIdPart(externalToolCallId)}`,
             roomId,
             senderId: this.id || this.agentId,
             senderName: this.name,
@@ -1554,37 +1605,104 @@ export class AgentClient implements GroupAgentExecutor {
             timestamp,
             run_id: responseRunId,
             role: 'tool',
-            tool_call_id: toolCallId,
+            tool_call_id: externalToolCallId,
             tool_name: toolName || null,
             finish_reason: failed ? 'error' : null,
         }
-        return this.sendMessage(roomId, output, msg.id, {
-            role: 'tool',
-            run_id: responseRunId,
-            tool_call_id: toolCallId,
-            tool_name: toolName || null,
-            finish_reason: failed ? 'error' : null,
-            timestamp,
-        }, sessionId)
-            .then(() => undefined)
-            .catch((err: any) => logger.warn(`[AgentClients] failed to record tool result: ${err.message || err}`))
+        try {
+            await withTimeout(this.sendMessage(roomId, output, msg.id, {
+                role: 'tool',
+                run_id: responseRunId,
+                tool_call_id: externalToolCallId,
+                tool_name: toolName || null,
+                finish_reason: failed ? 'error' : null,
+                timestamp,
+            }, sessionId), TOOL_RESULT_ACK_TIMEOUT_MS, 'Timed out waiting for Tool result persistence acknowledgement')
+            this.removePendingToolCall(roomId, toolName, toolCallId)
+            this.pendingToolBaseIds.delete(toolCallId)
+            this.pendingToolRunIds.delete(toolCallId)
+            this.pendingToolNames.delete(toolCallId)
+            this.pendingToolExternalIds.delete(toolCallId)
+            this.pendingToolCompletionEvents.delete(toolCallId)
+            this.rememberAcknowledgedToolCall(toolCallId)
+            return true
+        } catch (err: any) {
+            logger.warn(`[AgentClients] failed to record tool result: ${err.message || err}`)
+            return false
+        }
     }
 
-    private async completePendingToolsForRun(roomId: string, sessionId: string, responseRunId: string): Promise<void> {
+    private async completePendingToolsForRun(roomId: string, sessionId: string, responseRunId: string): Promise<boolean> {
         const pendingToolCallIds = Array.from(this.pendingToolRunIds.entries())
             .filter(([, pendingRunId]) => pendingRunId === responseRunId)
             .map(([toolCallId]) => toolCallId)
+        let allPersisted = true
         for (const toolCallId of pendingToolCallIds) {
-            await this.recordToolCompleted(roomId, sessionId, {
-                tool_call_id: toolCallId,
-                tool_name: this.pendingToolNames.get(toolCallId) || '',
-                output: '',
-            })
+            const completionEvent = this.pendingToolCompletionEvents.get(toolCallId)
+            const retryEvent = {
+                ...(completionEvent || {
+                    tool_name: this.pendingToolNames.get(toolCallId) || '',
+                    output: '',
+                }),
+                tool_call_id: this.pendingToolExternalIds.get(toolCallId) || toolCallId,
+            }
+            let persisted = false
+            for (let attempt = 0; attempt < TOOL_RESULT_FINAL_RETRY_ATTEMPTS; attempt += 1) {
+                if (await this.recordToolCompleted(roomId, sessionId, retryEvent)) {
+                    persisted = true
+                    break
+                }
+                if (attempt + 1 < TOOL_RESULT_FINAL_RETRY_ATTEMPTS) {
+                    await delay(TOOL_RESULT_RETRY_DELAY_MS * (attempt + 1))
+                }
+            }
+            if (!persisted) {
+                allPersisted = false
+                const toolName = this.pendingToolNames.get(toolCallId) || ''
+                const externalToolCallId = this.pendingToolExternalIds.get(toolCallId) || toolCallId
+                logger.error(`[AgentClients] terminal Tool result persistence loss after bounded retries: room=${roomId} run=${responseRunId} tool=${toolName || 'unknown'} tool_call_id=${externalToolCallId}`)
+                this.removePendingToolCall(roomId, toolName, toolCallId)
+                this.pendingToolBaseIds.delete(toolCallId)
+                this.pendingToolRunIds.delete(toolCallId)
+                this.pendingToolNames.delete(toolCallId)
+                this.pendingToolExternalIds.delete(toolCallId)
+                this.pendingToolCompletionEvents.delete(toolCallId)
+            }
+        }
+        return allPersisted
+    }
+
+    private discardPendingToolsForRun(responseRunId: string): void {
+        const staleToolCallIds = new Set(Array.from(this.pendingToolRunIds.entries())
+            .filter(([, pendingRunId]) => pendingRunId === responseRunId)
+            .map(([toolCallId]) => toolCallId))
+        if (!staleToolCallIds.size) return
+        for (const [key, list] of this.pendingToolCallIds) {
+            const current = list.filter(toolCallId => !staleToolCallIds.has(toolCallId))
+            if (current.length) this.pendingToolCallIds.set(key, current)
+            else this.pendingToolCallIds.delete(key)
+        }
+        for (const toolCallId of staleToolCallIds) {
+            this.pendingToolBaseIds.delete(toolCallId)
+            this.pendingToolRunIds.delete(toolCallId)
+            this.pendingToolNames.delete(toolCallId)
+            this.pendingToolExternalIds.delete(toolCallId)
+            this.pendingToolCompletionEvents.delete(toolCallId)
         }
     }
 
     private pendingToolKey(roomId: string, toolName: string): string {
         return `${roomId}::${toolName || 'tool'}`
+    }
+
+    private rememberAcknowledgedToolCall(toolCallId: string): void {
+        this.acknowledgedToolCallIds.delete(toolCallId)
+        this.acknowledgedToolCallIds.set(toolCallId, Date.now())
+        while (this.acknowledgedToolCallIds.size > ACKNOWLEDGED_TOOL_CALL_LIMIT) {
+            const oldest = this.acknowledgedToolCallIds.keys().next().value
+            if (!oldest) break
+            this.acknowledgedToolCallIds.delete(oldest)
+        }
     }
 
     private trackPendingToolCall(roomId: string, toolName: string, toolCallId: string): void {
@@ -1613,9 +1731,9 @@ export class AgentClient implements GroupAgentExecutor {
         else this.pendingToolCallIds.delete(key)
     }
 
-    private nextToolIndex(roomId: string, toolName: string): number {
-        const key = this.pendingToolKey(roomId, toolName)
-        return (this.pendingToolCallIds.get(key)?.length || 0) + 1
+    private nextAnonymousToolCallSequence(): number {
+        this.anonymousToolCallSequence += 1
+        return this.anonymousToolCallSequence
     }
 
     private bindEvents(): void {
@@ -1696,14 +1814,50 @@ function inferResponseRunId(messageId: string): string {
     return match?.[1] || String(messageId || '')
 }
 
-function groupToolCallId(rawToolCallId: unknown, toolName: string, index: number): string {
+function groupToolCallId(rawToolCallId: unknown, toolName: string, scope: string, sequence: number): string {
     const raw = String(rawToolCallId || '').trim()
     if (raw) return raw
-    return `cli_${safeId(toolName || 'tool')}_${Date.now()}_${index}`
+    return `cli_${safeId(toolName || 'tool')}_${stableToolIdPart(scope)}_${sequence}`
+}
+
+function toolCorrelationId(roomId: string, sessionId: string, externalToolCallId: string): string {
+    return `${roomId}\u0000${sessionId}\u0000${externalToolCallId}`
 }
 
 function safeId(value: string): string {
     return String(value || 'item').replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 80)
+}
+
+const TOOL_RESULT_ACK_TIMEOUT_MS = 30_000
+const TOOL_RESULT_FINAL_RETRY_ATTEMPTS = 2
+const TOOL_RESULT_RETRY_DELAY_MS = 50
+const ACKNOWLEDGED_TOOL_CALL_LIMIT = 1_024
+
+function stableToolIdPart(value: string): string {
+    const raw = String(value || 'item')
+    if (/^[a-zA-Z0-9_-]{1,80}$/.test(raw)) return raw
+    const hash = createHash('sha256').update(raw).digest('hex').slice(0, 12)
+    return `${safeId(raw).slice(0, 67)}_${hash}`
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error(message)), timeoutMs)
+        promise.then(
+            value => {
+                clearTimeout(timeout)
+                resolve(value)
+            },
+            error => {
+                clearTimeout(timeout)
+                reject(error)
+            },
+        )
+    })
 }
 
 function bridgeToolOutput(ev: Record<string, unknown>): string {

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -2569,6 +2569,7 @@ export class GroupChatServer {
         const userName = member?.name || `User-${socketId.slice(0, 6)}`
         const isHumanMessage = member?.source === 'human'
         const role = isHumanMessage ? 'user' : normalizeMessageRole(data.role)
+        const canCarryMentions = role === 'user' || role === 'assistant'
         let messageContent: unknown = data.content
         let runtimeInput: ContentBlock[] | undefined = Array.isArray(data.content)
             ? data.content as ContentBlock[]
@@ -2588,6 +2589,8 @@ export class GroupChatServer {
             }
         }
         if (
+            canCarryMentions
+            &&
             isAllAgentsMentioned(contentToText(messageContent))
             && !this.canSocketMentionAll(socket, roomId)
         ) {
@@ -2598,7 +2601,9 @@ export class GroupChatServer {
             return
         }
         const content = contentToStorageString(messageContent)
-        const mentionResult = this.normalizeStructuredMentions(roomId, member, contentToText(messageContent), data.mentions)
+        const mentionResult = canCarryMentions
+            ? this.normalizeStructuredMentions(roomId, member, contentToText(messageContent), data.mentions)
+            : {}
         if (mentionResult.error) {
             ack?.({ error: mentionResult.error })
             return

--- a/tests/server/group-chat-agent-workspace.test.ts
+++ b/tests/server/group-chat-agent-workspace.test.ts
@@ -62,6 +62,10 @@ describe('group chat agent workspace bridge runs', () => {
   beforeEach(() => {
     order.length = 0
     vi.clearAllMocks()
+    mockSocket.emit.mockImplementation((event: string, data?: any, ack?: Function) => {
+      if (event === 'message' && ack) ack({ id: data?.id || 'msg-id' })
+      return mockSocket
+    })
     trackerMock.completeWorkspaceRunCheckpointDraft.mockReset()
     trackerMock.completeWorkspaceRunCheckpointDraft.mockReturnValue(null)
     bridgeMock.chat.mockImplementation(async (_sessionId: string) => {
@@ -179,6 +183,212 @@ describe('group chat agent workspace bridge runs', () => {
     expect(codexResponsesSession).not.toBe(codexChatSession)
     expect(hermesWithIgnoredApiMode).toBe(hermesSession)
   }, 15_000)
+
+  it.each([
+    ['codex', 'codex'],
+    ['claude', 'claude-code'],
+    ['ekko', 'ekko-agent'],
+  ] as const)('keeps %s tool output mention text non-routable', async (agent, codingAgentId) => {
+    const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')
+    const runAndWait = vi.fn(async (_data: any, options: any) => {
+      options.onEvent?.('tool.started', {
+        tool_call_id: `tool-${agent}`,
+        name: 'read_file',
+        arguments: { path: '/tmp/source.txt' },
+      })
+      options.onEvent?.('tool.completed', {
+        tool_call_id: `tool-${agent}`,
+        name: 'read_file',
+        output: 'source fixture: @all and @Reviewer are plain tool output',
+      })
+      return { ok: true, output: `${agent} answer` }
+    })
+    const clients = new AgentClients()
+    clients.setChatRunService({ runAndWait, abortSession: vi.fn(async () => {}) })
+    const client = await clients.createAgent({
+      agentId: `agent-${agent}`,
+      agent,
+      profile: 'default',
+      name: agent,
+      description: '',
+      invited: 0,
+      backgroundDelegationEnabled: false,
+    } as any) as any
+    client.setStorage({
+      getRoom: vi.fn(() => ({ sessionSeed: 'seed-1', workspace: '', maxHistoryTokens: 32000 })),
+      getMessagesForContext: vi.fn(() => []),
+      getContextSnapshot: vi.fn(() => null),
+    })
+
+    await client.replyToMention(`room-${agent}`, {
+      messageId: `message-${agent}`,
+      content: `@${agent} inspect the source`,
+      senderName: 'Human',
+      senderId: 'human-1',
+      timestamp: 1,
+      role: 'user',
+    })
+
+    expect(runAndWait).toHaveBeenCalledWith(
+      expect.objectContaining({ coding_agent_id: codingAgentId }),
+      expect.anything(),
+    )
+    expect(mockSocket.emit).toHaveBeenCalledWith(
+      'message',
+      expect.objectContaining({
+        roomId: `room-${agent}`,
+        role: 'tool',
+        tool_call_id: `tool-${agent}`,
+        content: 'source fixture: @all and @Reviewer are plain tool output',
+      }),
+      expect.any(Function),
+    )
+    const toolPayload = mockSocket.emit.mock.calls
+      .find(([event, payload]) => event === 'message' && payload?.tool_call_id === `tool-${agent}`)?.[1]
+    expect(toolPayload).not.toHaveProperty('mentions')
+  })
+
+  it('keeps Hermes bridge failed tool output mention text non-routable and preserves the error', async () => {
+    bridgeMock.streamOutput.mockImplementation(async function* (runId: string) {
+      yield {
+        ok: true,
+        run_id: runId,
+        session_id: 'session-1',
+        status: 'complete',
+        delta: 'Hermes answer',
+        cursor: 1,
+        output: 'Hermes answer',
+        done: true,
+        events: [
+          { event: 'tool.started', tool_call_id: 'tool-hermes', name: 'read_file', arguments: { path: '/tmp/source.txt' } },
+          {
+            event: 'tool.failed',
+            tool_call_id: 'tool-hermes',
+            name: 'read_file',
+            output: 'permission denied: @all and @Reviewer are plain tool output',
+            error: 'permission denied',
+          },
+        ],
+        event_cursor: 2,
+      } as any
+    })
+    const client = await createClient('')
+
+    await client.replyToMention('room-1', {
+      messageId: 'message-hermes',
+      content: '@Worker inspect the source',
+      senderName: 'Human',
+      senderId: 'human-1',
+      timestamp: 1,
+      role: 'user',
+    })
+
+    expect(mockSocket.emit).toHaveBeenCalledWith(
+      'message',
+      expect.objectContaining({
+        roomId: 'room-1',
+        role: 'tool',
+        tool_call_id: 'tool-hermes',
+        content: 'permission denied: @all and @Reviewer are plain tool output',
+        finish_reason: 'error',
+      }),
+      expect.any(Function),
+    )
+    const toolPayload = mockSocket.emit.mock.calls
+      .find(([event, payload]) => event === 'message' && payload?.tool_call_id === 'tool-hermes')?.[1]
+    expect(toolPayload).not.toHaveProperty('mentions')
+  })
+
+  it('clears exhausted ChatRun tool recovery state after surfacing terminal persistence loss', async () => {
+    let toolResultAttempts = 0
+    mockSocket.emit.mockImplementation((event: string, data?: any, ack?: Function) => {
+      if (event === 'message' && data?.role === 'tool') {
+        toolResultAttempts += 1
+        ack?.({ error: 'persistent Room persistence failure' })
+      } else if (event === 'message') {
+        ack?.({ id: data?.id || 'msg-id' })
+      }
+      return mockSocket
+    })
+    const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')
+    const runAndWait = vi.fn(async (_data: any, options: any) => {
+      options.onEvent?.('tool.started', {
+        tool_call_id: 'tool-codex-terminal-loss',
+        name: 'read_file',
+        arguments: { path: '/tmp/source.txt' },
+      })
+      options.onEvent?.('tool.completed', {
+        tool_call_id: 'tool-codex-terminal-loss',
+        name: 'read_file',
+        output: 'result that cannot be persisted',
+      })
+      return { ok: true, output: 'Codex answer' }
+    })
+    const clients = new AgentClients()
+    clients.setChatRunService({ runAndWait, abortSession: vi.fn(async () => {}) })
+    const client = await clients.createAgent({
+      agentId: 'agent-codex-terminal-loss', agent: 'codex', profile: 'default', name: 'Codex',
+      description: '', invited: 0, backgroundDelegationEnabled: false,
+    } as any) as any
+    client.setStorage({
+      getRoom: vi.fn(() => ({ sessionSeed: 'seed-1', workspace: '', maxHistoryTokens: 32000 })),
+      getMessagesForContext: vi.fn(() => []),
+      getContextSnapshot: vi.fn(() => null),
+    })
+
+    await client.replyToMention('room-codex-terminal-loss', {
+      messageId: 'message-codex-terminal-loss', content: '@Codex inspect the source',
+      senderName: 'Human', senderId: 'human-1', timestamp: 1, role: 'user',
+    })
+
+    expect(toolResultAttempts).toBe(3)
+    expect(client.pendingToolCallIds.size).toBe(0)
+    expect(client.pendingToolBaseIds.size).toBe(0)
+    expect(client.pendingToolRunIds.size).toBe(0)
+    expect(client.pendingToolNames.size).toBe(0)
+    expect(client.pendingToolExternalIds.size).toBe(0)
+    expect(client.pendingToolCompletionEvents.size).toBe(0)
+    client.disconnect()
+  })
+
+  it('clears exhausted Hermes tool recovery state after surfacing terminal persistence loss', async () => {
+    let toolResultAttempts = 0
+    mockSocket.emit.mockImplementation((event: string, data?: any, ack?: Function) => {
+      if (event === 'message' && data?.role === 'tool') {
+        toolResultAttempts += 1
+        ack?.({ error: 'persistent Room persistence failure' })
+      } else if (event === 'message') {
+        ack?.({ id: data?.id || 'msg-id' })
+      }
+      return mockSocket
+    })
+    bridgeMock.streamOutput.mockImplementation(async function* (runId: string) {
+      yield {
+        ok: true, run_id: runId, session_id: 'session-1', status: 'complete',
+        delta: 'Hermes answer', cursor: 1, output: 'Hermes answer', done: true,
+        events: [
+          { event: 'tool.started', tool_call_id: 'tool-hermes-terminal-loss', name: 'read_file', arguments: { path: '/tmp/source.txt' } },
+          { event: 'tool.completed', tool_call_id: 'tool-hermes-terminal-loss', name: 'read_file', output: 'result that cannot be persisted' },
+        ],
+        event_cursor: 2,
+      } as any
+    })
+    const client = await createClient('')
+
+    await client.replyToMention('room-1', {
+      messageId: 'message-hermes-terminal-loss', content: '@Worker inspect the source',
+      senderName: 'Human', senderId: 'human-1', timestamp: 1, role: 'user',
+    })
+
+    expect(toolResultAttempts).toBe(3)
+    expect(client.pendingToolCallIds.size).toBe(0)
+    expect(client.pendingToolBaseIds.size).toBe(0)
+    expect(client.pendingToolRunIds.size).toBe(0)
+    expect(client.pendingToolNames.size).toBe(0)
+    expect(client.pendingToolExternalIds.size).toBe(0)
+    expect(client.pendingToolCompletionEvents.size).toBe(0)
+    client.disconnect()
+  })
 
   it('generates a complete entry mention DTO for an agent reply handoff', async () => {
     const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')

--- a/tests/server/group-chat-history-window.test.ts
+++ b/tests/server/group-chat-history-window.test.ts
@@ -254,6 +254,361 @@ describe('group chat history windows', () => {
     expect(context.history.at(-1)?.id).toBe('message-160')
   })
 
+  it('keeps a completed tool result recoverable until Room persistence succeeds', async () => {
+    let resultAttempts = 0
+    mockSocket.emit.mockImplementation((event: string, payload?: any, ack?: Function) => {
+      if (event === 'message' && payload?.role === 'tool') {
+        resultAttempts += 1
+        if (typeof ack === 'function') {
+          ack(resultAttempts === 1
+            ? { error: 'temporary Room persistence failure' }
+            : { id: payload.id })
+        }
+      } else if (typeof ack === 'function') {
+        ack({ id: payload?.id })
+      }
+      return mockSocket
+    })
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1',
+      profile: 'default',
+      name: 'Worker',
+      description: '',
+      invited: 0,
+    } as any)
+
+    await (client as any).recordToolStarted(
+      'room-1',
+      'session-1',
+      { tool_name: 'lookup', tool_call_id: 'call-retry', args: {} },
+      'run-retry_part_0',
+      'run-retry',
+    )
+    await (client as any).recordToolCompleted('room-1', 'session-1', {
+      event: 'tool.completed',
+      tool_name: 'lookup',
+      tool_call_id: 'call-retry',
+      output: 'literal @all result must survive retry',
+    })
+
+    expect(resultAttempts).toBe(1)
+    expect(Array.from((client as any).pendingToolRunIds.values())).toContain('run-retry')
+
+    await (client as any).completePendingToolsForRun('room-1', 'session-1', 'run-retry')
+
+    expect(resultAttempts).toBe(2)
+    expect(mockSocket.emit).toHaveBeenLastCalledWith(
+      'message',
+      expect.objectContaining({
+        id: 'run-retry_part_0_toolresult_call-retry',
+        role: 'tool',
+        tool_call_id: 'call-retry',
+        content: 'literal @all result must survive retry',
+      }),
+      expect.any(Function),
+    )
+    expect((client as any).pendingToolRunIds.size).toBe(0)
+    expect((client as any).pendingToolBaseIds.size).toBe(0)
+    expect((client as any).pendingToolNames.size).toBe(0)
+
+    const resultPayloads = mockSocket.emit.mock.calls
+      .filter((call: any[]) => call[0] === 'message' && call[1]?.role === 'tool')
+      .map((call: any[]) => call[1])
+    expect(resultPayloads.map((payload: any) => payload.id)).toEqual([
+      'run-retry_part_0_toolresult_call-retry',
+      'run-retry_part_0_toolresult_call-retry',
+    ])
+
+    client.disconnect()
+  })
+
+  it('keeps parallel anonymous tool completions correlated when the first persistence attempt fails', async () => {
+    const attempts = new Map<string, number>()
+    mockSocket.emit.mockImplementation((event: string, payload?: any, ack?: Function) => {
+      if (event === 'message' && payload?.role === 'tool') {
+        const callId = String(payload.tool_call_id)
+        const attempt = (attempts.get(callId) || 0) + 1
+        attempts.set(callId, attempt)
+        if (typeof ack === 'function') ack(attempt === 1 && callId.endsWith('_1')
+          ? { error: 'temporary Room persistence failure' }
+          : { id: payload.id })
+      } else if (typeof ack === 'function') {
+        ack({ id: payload?.id })
+      }
+      return mockSocket
+    })
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1', profile: 'default', name: 'Worker', description: '', invited: 0,
+    } as any)
+
+    await (client as any).recordToolStarted(
+      'room-1', 'session-1', { tool_name: 'lookup', args: { index: 1 } }, 'run-parallel_part_0', 'run-parallel',
+    )
+    await (client as any).recordToolStarted(
+      'room-1', 'session-1', { tool_name: 'lookup', args: { index: 2 } }, 'run-parallel_part_0', 'run-parallel',
+    )
+    await (client as any).recordToolCompleted('room-1', 'session-1', {
+      event: 'tool.completed', tool_name: 'lookup', output: 'first result',
+    })
+    await (client as any).recordToolCompleted('room-1', 'session-1', {
+      event: 'tool.completed', tool_name: 'lookup', output: 'second result',
+    })
+    await (client as any).completePendingToolsForRun('room-1', 'session-1', 'run-parallel')
+
+    const resultPayloads = mockSocket.emit.mock.calls
+      .filter((call: any[]) => call[0] === 'message' && call[1]?.role === 'tool')
+      .map((call: any[]) => call[1])
+    const toolCallIds = mockSocket.emit.mock.calls
+      .filter((call: any[]) => call[0] === 'message' && call[1]?.role === 'assistant' && call[1]?.tool_calls)
+      .map((call: any[]) => call[1].tool_calls[0].id)
+    expect(toolCallIds).toHaveLength(2)
+    expect(resultPayloads.map((payload: any) => [payload.tool_call_id, payload.content])).toEqual([
+      [toolCallIds[0], 'first result'],
+      [toolCallIds[1], 'second result'],
+      [toolCallIds[0], 'first result'],
+    ])
+    expect((client as any).pendingToolRunIds.size).toBe(0)
+    client.disconnect()
+  })
+
+  it('keeps sequential acknowledged anonymous tool ids distinct when wall time does not advance', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1775860000000)
+    mockSocket.emit.mockImplementation((event: string, payload?: any, ack?: Function) => {
+      if (typeof ack === 'function') ack({ id: payload?.id })
+      return mockSocket
+    })
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1', profile: 'default', name: 'Worker', description: '', invited: 0,
+    } as any)
+
+    for (const output of ['first', 'second']) {
+      await (client as any).recordToolStarted(
+        'room-1', 'session-1', { tool_name: 'lookup', args: {} },
+        'run-sequential_part_0', 'run-sequential',
+      )
+      await (client as any).recordToolCompleted('room-1', 'session-1', {
+        event: 'tool.completed', tool_name: 'lookup', output,
+      })
+    }
+
+    const toolCallIds = mockSocket.emit.mock.calls
+      .filter((call: any[]) => call[0] === 'message' && call[1]?.role === 'assistant' && call[1]?.tool_calls)
+      .map((call: any[]) => call[1].tool_calls[0].id)
+    const resultPayloads = mockSocket.emit.mock.calls
+      .filter((call: any[]) => call[0] === 'message' && call[1]?.role === 'tool')
+      .map((call: any[]) => call[1])
+    expect(toolCallIds).toHaveLength(2)
+    expect(new Set(toolCallIds).size).toBe(2)
+    expect(new Set(resultPayloads.map((payload: any) => payload.id)).size).toBe(2)
+    expect(resultPayloads.map((payload: any) => payload.tool_call_id)).toEqual(toolCallIds)
+    client.disconnect()
+  })
+
+  it('keeps colliding sanitized tool call ids distinct in persisted message ids', async () => {
+    mockSocket.emit.mockImplementation((event: string, payload?: any, ack?: Function) => {
+      if (typeof ack === 'function') ack({ id: payload?.id })
+      return mockSocket
+    })
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1', profile: 'default', name: 'Worker', description: '', invited: 0,
+    } as any)
+
+    for (const toolCallId of ['call/a', 'call?a']) {
+      await (client as any).recordToolStarted(
+        'room-1', 'session-1', { tool_name: 'lookup', tool_call_id: toolCallId, args: {} },
+        'run-collision_part_0', 'run-collision',
+      )
+      await (client as any).recordToolCompleted('room-1', 'session-1', {
+        event: 'tool.completed', tool_name: 'lookup', tool_call_id: toolCallId, output: toolCallId,
+      })
+    }
+
+    const resultPayloads = mockSocket.emit.mock.calls
+      .filter((call: any[]) => call[0] === 'message' && call[1]?.role === 'tool')
+      .map((call: any[]) => call[1])
+    expect(resultPayloads).toHaveLength(2)
+    expect(new Set(resultPayloads.map((payload: any) => payload.id)).size).toBe(2)
+    expect(resultPayloads.map((payload: any) => payload.tool_call_id)).toEqual(['call/a', 'call?a'])
+    client.disconnect()
+  })
+
+  it('retries terminal tool persistence with stable ids until bounded success', async () => {
+    let resultAttempts = 0
+    mockSocket.emit.mockImplementation((event: string, payload?: any, ack?: Function) => {
+      if (event === 'message' && payload?.role === 'tool') {
+        resultAttempts += 1
+        if (typeof ack === 'function') ack(resultAttempts < 3
+          ? { error: 'temporary Room persistence failure' }
+          : { id: payload.id })
+      } else if (typeof ack === 'function') {
+        ack({ id: payload?.id })
+      }
+      return mockSocket
+    })
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1', profile: 'default', name: 'Worker', description: '', invited: 0,
+    } as any)
+
+    await (client as any).recordToolStarted(
+      'room-1', 'session-1', { tool_name: 'lookup', tool_call_id: 'call-bounded-retry', args: {} },
+      'run-bounded-retry_part_0', 'run-bounded-retry',
+    )
+    await (client as any).recordToolCompleted('room-1', 'session-1', {
+      event: 'tool.completed', tool_name: 'lookup', tool_call_id: 'call-bounded-retry', output: 'preserved',
+    })
+    await (client as any).completePendingToolsForRun('room-1', 'session-1', 'run-bounded-retry')
+
+    expect(resultAttempts).toBe(3)
+    const ids = mockSocket.emit.mock.calls
+      .filter((call: any[]) => call[0] === 'message' && call[1]?.role === 'tool')
+      .map((call: any[]) => call[1].id)
+    expect(new Set(ids)).toEqual(new Set(['run-bounded-retry_part_0_toolresult_call-bounded-retry']))
+    expect((client as any).pendingToolRunIds.size).toBe(0)
+    client.disconnect()
+  })
+
+  it('clears retained tool recovery state on explicit disconnect', async () => {
+    mockSocket.emit.mockImplementation((event: string, payload?: any, ack?: Function) => {
+      if (event === 'message' && payload?.role === 'tool') {
+        if (typeof ack === 'function') ack({ error: 'persistent Room failure' })
+      } else if (typeof ack === 'function') {
+        ack({ id: payload?.id })
+      }
+      return mockSocket
+    })
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1', profile: 'default', name: 'Worker', description: '', invited: 0,
+    } as any)
+    await (client as any).recordToolStarted(
+      'room-1', 'session-1', { tool_name: 'lookup', tool_call_id: 'call-disconnect', args: {} },
+      'run-disconnect_part_0', 'run-disconnect',
+    )
+    await (client as any).recordToolCompleted('room-1', 'session-1', {
+      event: 'tool.completed', tool_name: 'lookup', tool_call_id: 'call-disconnect', output: 'retained',
+    })
+    expect((client as any).pendingToolCompletionEvents.size).toBe(1)
+
+    client.disconnect()
+
+    expect((client as any).pendingToolCallIds.size).toBe(0)
+    expect((client as any).pendingToolBaseIds.size).toBe(0)
+    expect((client as any).pendingToolRunIds.size).toBe(0)
+    expect((client as any).pendingToolNames.size).toBe(0)
+    expect((client as any).pendingToolExternalIds.size).toBe(0)
+    expect((client as any).pendingToolCompletionEvents.size).toBe(0)
+  })
+
+  it('discards only the stale run tool recovery state after bounded reconciliation', async () => {
+    mockSocket.emit.mockImplementation((event: string, payload?: any, ack?: Function) => {
+      if (event === 'message' && payload?.role === 'tool') {
+        if (typeof ack === 'function') ack({ error: 'stale session' })
+      } else if (typeof ack === 'function') {
+        ack({ id: payload?.id })
+      }
+      return mockSocket
+    })
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1', profile: 'default', name: 'Worker', description: '', invited: 0,
+    } as any)
+
+    for (const [toolCallId, runId] of [['call-stale', 'run-stale'], ['call-current', 'run-current']]) {
+      await (client as any).recordToolStarted(
+        'room-1', 'session-1', { tool_name: 'lookup', tool_call_id: toolCallId, args: {} },
+        `${runId}_part_0`, runId,
+      )
+      await (client as any).recordToolCompleted('room-1', 'session-1', {
+        event: 'tool.completed', tool_name: 'lookup', tool_call_id: toolCallId, output: toolCallId,
+      })
+    }
+
+    ;(client as any).discardPendingToolsForRun('run-stale')
+
+    expect(Array.from((client as any).pendingToolRunIds.values())).toEqual(['run-current'])
+    expect((client as any).pendingToolBaseIds.size).toBe(1)
+    expect((client as any).pendingToolNames.size).toBe(1)
+    expect((client as any).pendingToolExternalIds.size).toBe(1)
+    expect((client as any).pendingToolCompletionEvents.size).toBe(1)
+    client.disconnect()
+  })
+
+  it('ignores a replayed acknowledged tool completion', async () => {
+    mockSocket.emit.mockImplementation((event: string, payload?: any, ack?: Function) => {
+      if (typeof ack === 'function') ack({ id: payload?.id })
+      return mockSocket
+    })
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1', profile: 'default', name: 'Worker', description: '', invited: 0,
+    } as any)
+    await (client as any).recordToolStarted(
+      'room-1', 'session-1', { tool_name: 'lookup', tool_call_id: 'call-replay', args: {} },
+      'run-replay_part_0', 'run-replay',
+    )
+    const completion = {
+      event: 'tool.completed', tool_name: 'lookup', tool_call_id: 'call-replay', output: 'one result',
+    }
+    await (client as any).recordToolCompleted('room-1', 'session-1', completion)
+    await (client as any).recordToolCompleted('room-1', 'session-1', completion)
+
+    const resultPayloads = mockSocket.emit.mock.calls
+      .filter((call: any[]) => call[0] === 'message' && call[1]?.role === 'tool')
+    expect(resultPayloads).toHaveLength(1)
+    client.disconnect()
+  })
+
+  it('keeps reused native tool call ids isolated across rooms and runs', async () => {
+    const attempts = new Map<string, number>()
+    mockSocket.emit.mockImplementation((event: string, payload?: any, ack?: Function) => {
+      if (event === 'message' && payload?.role === 'tool') {
+        const key = `${payload.roomId}:${payload.run_id}`
+        const attempt = (attempts.get(key) || 0) + 1
+        attempts.set(key, attempt)
+        if (typeof ack === 'function') ack(attempt === 1
+          ? { error: 'temporary Room persistence failure' }
+          : { id: payload.id })
+      } else if (typeof ack === 'function') {
+        ack({ id: payload?.id })
+      }
+      return mockSocket
+    })
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1', profile: 'default', name: 'Worker', description: '', invited: 0,
+    } as any)
+
+    for (const [roomId, runId] of [['room-1', 'run-1'], ['room-2', 'run-2']]) {
+      await (client as any).recordToolStarted(
+        roomId, `session-${roomId}`, { tool_name: 'lookup', tool_call_id: 'call-shared', args: { roomId } },
+        `${runId}_part_0`, runId,
+      )
+    }
+    for (const [roomId, runId] of [['room-1', 'run-1'], ['room-2', 'run-2']]) {
+      await (client as any).recordToolCompleted(roomId, `session-${roomId}`, {
+        event: 'tool.completed', tool_name: 'lookup', tool_call_id: 'call-shared', output: `${roomId} result`,
+      })
+      await (client as any).completePendingToolsForRun(roomId, `session-${roomId}`, runId)
+    }
+
+    const resultPayloads = mockSocket.emit.mock.calls
+      .filter((call: any[]) => call[0] === 'message' && call[1]?.role === 'tool')
+      .map((call: any[]) => call[1])
+    expect(resultPayloads.map((payload: any) => [payload.roomId, payload.run_id, payload.content])).toEqual([
+      ['room-1', 'run-1', 'room-1 result'],
+      ['room-1', 'run-1', 'room-1 result'],
+      ['room-2', 'run-2', 'room-2 result'],
+      ['room-2', 'run-2', 'room-2 result'],
+    ])
+    expect((client as any).pendingToolRunIds.size).toBe(0)
+    client.disconnect()
+  })
+
   it('includes the active reasoning segment in persisted group tool-call messages', async () => {
     mockSocket.emit.mockImplementation((event: string, payload?: any, ack?: Function) => {
       if (typeof ack === 'function') ack({ id: payload?.id })

--- a/tests/server/group-chat-structured-mentions.test.ts
+++ b/tests/server/group-chat-structured-mentions.test.ts
@@ -120,6 +120,42 @@ describe('group chat structured agent mentions', () => {
     expect(replyToMention).not.toHaveBeenCalled()
   })
 
+  it('persists tool output containing mention-like text without authorizing or routing mentions', async () => {
+    const author = await connectGroupChatClient(port, 'agent-author', 'Author', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    harness.sockets.push(author)
+    await emitAck(author, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+
+    const processMentions = vi.spyOn(groupServer.agentClients, 'processMentions').mockResolvedValue(undefined)
+    const response = await emitAck<{ id?: string; error?: string }>(author, 'message', {
+      roomId: 'room-1',
+      id: 'tool-result-with-mentions',
+      content: 'source fixture: @all and @Reviewer are plain tool output',
+      role: 'tool',
+      run_id: 'run-1',
+      tool_call_id: 'call-1',
+      tool_name: 'read_file',
+      agentSessionId: groupRuntimeSessionId('room-1', 'default', 'Author'),
+      mentions: [{ type: 'all', displayName: 'ALL' }],
+    })
+
+    expect(response).toEqual({ id: 'tool-result-with-mentions' })
+    expect(harness.db.prepare(`
+      SELECT role, content, mentions, tool_call_id, tool_name
+      FROM gc_messages
+      WHERE id = ?
+    `).get('tool-result-with-mentions')).toEqual({
+      role: 'tool',
+      content: 'source fixture: @all and @Reviewer are plain tool output',
+      mentions: '[]',
+      tool_call_id: 'call-1',
+      tool_name: 'read_file',
+    })
+    expect(processMentions).not.toHaveBeenCalled()
+  })
+
   it('keeps the latest main policy that only a room owner may broadcast with @all', async () => {
     const author = await connectGroupChatClient(port, 'agent-author', 'Author', {
       source: 'agent',


### PR DESCRIPTION
## Summary

- treat Group Chat Tool payloads as non-routable data so literal `@all` and participant-like text cannot trigger mention authorization or handoff routing
- isolate internal Tool correlation by Room and native Session while preserving the runtime's external `tool_call_id`
- retain original Tool completion payloads and correlation metadata until Room persistence acknowledges them
- retry pending Tool results with stable collision-resistant message IDs, bounded ACK waits, and replay suppression
- reconcile pending Tool results across Hermes, Codex, Claude, and Ekko terminal paths, including Hermes `tool.failed`

## Root cause

`GroupChatServer.handleMessage()` applied conversational mention authorization and structured-mention normalization to every incoming message role. Tool output containing source or log text such as `@all` was therefore rejected with `GROUP_CHAT_ALL_MENTION_FORBIDDEN`.

The native Agent Session retained the completed Tool result, but the Room database retained only the Assistant `tool_calls` row. On reload the client reconstructed the unmatched call as `toolStatus: 'running'`, leaving the Tool and Run cards spinning indefinitely.

`recordToolCompleted()` also discarded correlation metadata before Room persistence succeeded, so terminal reconciliation could not retry the original result. Raw Tool call IDs additionally needed execution scoping because independent Rooms/Sessions may reuse them.

## Fix

- apply mention authorization and normalization only to routable `user` and `assistant` messages
- prevent explicit non-conversational roles such as `role='tool'` from generating structured mentions, while preserving role-less legacy and explicit Assistant handoffs
- scope internal recovery/ACK state by Room + native Session + external Tool call ID
- keep the external `tool_call_id` unchanged in persisted Tool call/result rows
- retain original completion events until persistence ACK, wait at most 30 seconds per ACK, and perform bounded terminal retries
- use collision-resistant deterministic persisted IDs and a bounded acknowledged replay ledger
- use a Room/Session/Run-scoped monotonic ID for runtime events that omit a Tool call ID, independent of wall clock and pending queue length
- consume anonymous same-name Tool completions in FIFO order without prematurely deleting retry state
- reconcile pending Tool results in Hermes success/error and Codex/Claude/Ekko Coding Agent finalization paths
- preserve Hermes `tool.failed` payload and error terminal status
- clear only stale-run recovery state on stale exits and all ephemeral recovery state on explicit disconnect

## Verification

- TDD RED reproduced `GROUP_CHAT_ALL_MENTION_FORBIDDEN` for Tool output containing `@all`
- `npm run harness:check` — passed
- `npx vitest run tests/server/group-chat-*.test.ts` — 24 files, 258 tests passed
- adversarial reused native-ID isolation across independent Rooms/Runs
- frozen-clock sequential acknowledged anonymous Tool ID uniqueness
- anonymous parallel FIFO, persistence retry, replay suppression, scoped stale-run cleanup, disconnect cleanup, Hermes `tool.failed`, and four-runtime terminal reconciliation tests
- `npx vue-tsc -b` — passed
- `npx tsc --noEmit -p packages/server/tsconfig.json` — passed
- `NODE_ENV=development npm run build` — passed
- `npx playwright test tests/e2e/group-chat-share.spec.ts tests/e2e/group-chat-room-deeplink.spec.ts` — 19 passed

A previous exact-base full Vitest candidate/base A/B produced identical 50 failing test-name sets with no candidate-only failures; those failures come from existing environment/plugin and runtime fixtures. The complete Group Chat suite is green on the final exact HEAD.

Historical Room rows that already lack Tool results are intentionally not backfilled by this source patch.

Closes #2421
