### PR TITLE
fix(group-chat): bound persisted tool message ids

### DIFF
--- a/docs/chat-chain-changes/2026-08-08-group-chat-tool-result-mentions.md
+++ b/docs/chat-chain-changes/2026-08-08-group-chat-tool-result-mentions.md
@@ -2,7 +2,9 @@
 date: 2026-08-08
 pr: pending
 feature: Group Chat tool-result mention isolation and terminal recovery
-impact: Treats Tool payload text as non-routable data, preserves owner-only conversational @all authorization, and retains completed Tool results for collision-resistant idempotent Room-persistence retry with bounded ACK timeouts and replay suppression until they are acknowledged.
+impact: Treats Tool payload text as non-routable data, preserves owner-only conversational @all authorization, and retains completed Tool results for collision-resistant idempotent Room-persistence retry with bounded message IDs, ACK timeouts, and replay suppression until they are acknowledged.
 ---
 
 Group Chat no longer interprets literal mention text found in Tool output as routing intent. Tool-result persistence uses a stable message identity and keeps its correlation and original completion payload until Room storage acknowledges it, allowing both Hermes and Coding Agent run finalization to reconcile transient failures without leaving reloaded Tool cards permanently running. Explicit Agent client teardown clears any remaining in-memory Tool recovery and replay state.
+
+Persisted Tool call/result row IDs keep their existing readable form when it fits the Room server's 160-character client-ID limit. Longer composite IDs retain their ordering marker and use a deterministic digest of the full Run, message kind, and external Tool call ID, so an ACK retry addresses the same row without altering the `tool_call_id` shared with the model runtime.

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -1545,7 +1545,7 @@ export class AgentClient implements GroupAgentExecutor {
             },
         }
         const msg: MessageData & Record<string, any> = {
-            id: `${runMessageId}_toolcall_${stableToolIdPart(externalToolCallId)}`,
+            id: groupToolMessageId(runMessageId, 'toolcall', externalToolCallId),
             roomId,
             senderId: this.id || this.agentId,
             senderName: this.name,
@@ -1597,7 +1597,7 @@ export class AgentClient implements GroupAgentExecutor {
             || (typeof ev.error === 'string' && ev.error.trim().length > 0)
         const timestamp = Date.now()
         const msg: MessageData & Record<string, any> = {
-            id: `${runMessageId}_toolresult_${stableToolIdPart(externalToolCallId)}`,
+            id: groupToolMessageId(runMessageId, 'toolresult', externalToolCallId),
             roomId,
             senderId: this.id || this.agentId,
             senderName: this.name,
@@ -1832,12 +1832,40 @@ const TOOL_RESULT_ACK_TIMEOUT_MS = 30_000
 const TOOL_RESULT_FINAL_RETRY_ATTEMPTS = 2
 const TOOL_RESULT_RETRY_DELAY_MS = 50
 const ACKNOWLEDGED_TOOL_CALL_LIMIT = 1_024
+const GROUP_CHAT_MESSAGE_ID_MAX_LENGTH = 160
 
 function stableToolIdPart(value: string): string {
     const raw = String(value || 'item')
     if (/^[a-zA-Z0-9_-]{1,80}$/.test(raw)) return raw
     const hash = createHash('sha256').update(raw).digest('hex').slice(0, 12)
     return `${safeId(raw).slice(0, 67)}_${hash}`
+}
+
+function groupToolMessageId(
+    runMessageId: string,
+    kind: 'toolcall' | 'toolresult',
+    externalToolCallId: string,
+): string {
+    const toolIdPart = stableToolIdPart(externalToolCallId)
+    const candidate = `${runMessageId}_${kind}_${toolIdPart}`
+    if (candidate.length <= GROUP_CHAT_MESSAGE_ID_MAX_LENGTH) return candidate
+
+    const marker = `_${kind}_`
+    const hash = createHash('sha256')
+        .update(`${runMessageId}\u0000${kind}\u0000${externalToolCallId}`)
+        .digest('hex')
+        .slice(0, 20)
+    const hashSuffix = `_h_${hash}`
+    const readableLength = GROUP_CHAT_MESSAGE_ID_MAX_LENGTH - marker.length - hashSuffix.length
+    const safeRunMessageId = String(runMessageId || 'message').replace(/[^a-zA-Z0-9_-]/g, '_')
+    const runLength = Math.min(safeRunMessageId.length, 96, readableLength - 1)
+    let runIdPart = safeRunMessageId.slice(0, runLength)
+    const partSuffix = safeRunMessageId.match(/_part_\d+$/)?.[0] || ''
+    if (partSuffix && safeRunMessageId.length > runLength && partSuffix.length < runLength) {
+        runIdPart = `${safeRunMessageId.slice(0, runLength - partSuffix.length)}${partSuffix}`
+    }
+    const readableToolIdPart = toolIdPart.slice(0, readableLength - runIdPart.length)
+    return `${runIdPart}${marker}${readableToolIdPart}${hashSuffix}`
 }
 
 function delay(ms: number): Promise<void> {

--- a/tests/server/group-chat-history-window.test.ts
+++ b/tests/server/group-chat-history-window.test.ts
@@ -436,6 +436,63 @@ describe('group chat history windows', () => {
     client.disconnect()
   })
 
+  it('bounds long persisted tool message ids without changing external tool call ids', async () => {
+    const resultAttempts = new Map<string, number>()
+    mockSocket.emit.mockImplementation((event: string, payload?: any, ack?: Function) => {
+      if (event === 'message' && payload?.role === 'tool') {
+        const toolCallId = String(payload.tool_call_id)
+        const attempt = (resultAttempts.get(toolCallId) || 0) + 1
+        resultAttempts.set(toolCallId, attempt)
+        if (typeof ack === 'function') ack(attempt === 1
+          ? { error: 'temporary Room persistence failure' }
+          : { id: payload.id })
+      } else if (typeof ack === 'function') {
+        ack({ id: payload?.id })
+      }
+      return mockSocket
+    })
+    const clients = new AgentClients()
+    const client = await clients.createAgent({
+      agentId: 'agent-1', profile: 'default', name: 'Worker', description: '', invited: 0,
+    } as any)
+    const runMessageId = `${'r'.repeat(153)}_part_0`
+    const toolCallIds = [`call_${'x'.repeat(74)}a`, `call_${'x'.repeat(74)}b`]
+
+    for (const toolCallId of toolCallIds) {
+      await (client as any).recordToolStarted(
+        'room-1', 'session-1', { tool_name: 'lookup', tool_call_id: toolCallId, args: {} },
+        runMessageId, 'run-long',
+      )
+      await (client as any).recordToolCompleted('room-1', 'session-1', {
+        event: 'tool.completed', tool_name: 'lookup', tool_call_id: toolCallId, output: toolCallId,
+      })
+    }
+    await (client as any).completePendingToolsForRun('room-1', 'session-1', 'run-long')
+
+    const messagePayloads = mockSocket.emit.mock.calls
+      .filter((call: any[]) => call[0] === 'message')
+      .map((call: any[]) => call[1])
+    expect(messagePayloads.every((payload: any) => payload.id.length <= 160)).toBe(true)
+
+    const toolCallPayloads = messagePayloads.filter((payload: any) => payload.role === 'assistant')
+    expect(toolCallPayloads.map((payload: any) => payload.tool_calls[0].id)).toEqual(toolCallIds)
+    expect(toolCallPayloads.every((payload: any) => payload.id.includes('_toolcall_'))).toBe(true)
+
+    const resultPayloads = messagePayloads.filter((payload: any) => payload.role === 'tool')
+    expect(resultPayloads.map((payload: any) => payload.tool_call_id)).toEqual([
+      toolCallIds[0], toolCallIds[1], toolCallIds[0], toolCallIds[1],
+    ])
+    expect(resultPayloads.every((payload: any) => payload.id.includes('_toolresult_'))).toBe(true)
+    for (const toolCallId of toolCallIds) {
+      const ids = resultPayloads
+        .filter((payload: any) => payload.tool_call_id === toolCallId)
+        .map((payload: any) => payload.id)
+      expect(new Set(ids).size).toBe(1)
+    }
+    expect(new Set(resultPayloads.map((payload: any) => payload.id)).size).toBe(2)
+    client.disconnect()
+  })
+
   it('retries terminal tool persistence with stable ids until bounded success', async () => {
     let resultAttempts = 0
     mockSocket.emit.mockImplementation((event: string, payload?: any, ack?: Function) => {


### PR DESCRIPTION
## Summary

- bound persisted Group Chat Tool call/result message IDs to the Room server's 160-character client-ID limit
- preserve existing readable IDs for normal inputs and use a deterministic digest only for oversized composite IDs
- keep the external `tool_call_id` unchanged for model/runtime correlation
- add regression coverage for retry stability, collision resistance, message-kind separation, and the length limit

## Why

Follow-up to #2426. Its retry path depends on stable persisted message IDs, but concatenating a long run message ID with a Tool call ID can exceed the Room server limit. The server can then replace the ID, defeating idempotent retries and allowing duplicate Tool results after an ACK loss.

## Impact

Long Tool IDs now retry against the same persisted row without changing the Tool call ID seen by the model. Normal-length IDs retain their existing format.

## Validation

- `npm test -- tests/server/group-chat-agent-workspace.test.ts tests/server/group-chat-history-window.test.ts tests/server/group-chat-structured-mentions.test.ts --testTimeout=15000 --fileParallelism=false` (59 passed)
- `npm run harness:check`
- `npm run build`
- `git diff --check`
