### PR TITLE
fix(ui): settle orphaned group tools and align approvals

### DIFF
--- a/docs/chat-chain-changes/2026-08-08-group-chat-orphaned-tool-interruption.md
+++ b/docs/chat-chain-changes/2026-08-08-group-chat-orphaned-tool-interruption.md
@@ -1,0 +1,17 @@
+---
+date: 2026-08-08
+pr: 2429
+feature: Group Chat orphaned tool-call terminal state
+impact: Historical Tool calls without a persisted Tool result remain running only for the active Agent's latest Run; calls with no active Run now render as interrupted with an explicit unavailable-result label, without fabricating Tool results or rewriting stored history.
+---
+
+Group Chat message mapping now distinguishes a genuinely active Agent Run from a
+historical Tool call whose result was never persisted. Only the latest pending
+Tool call belonging to an active Agent remains in the running state. Other
+orphaned calls settle to the neutral interrupted state instead of displaying a
+permanent spinner.
+
+The message renderer displays a localized notice that execution was interrupted
+and no Tool result was received. This is a presentation-time convergence only:
+it does not synthesize a Tool result, backfill messages, or modify historical
+Room data.

--- a/packages/client/src/api/hermes/group-chat.ts
+++ b/packages/client/src/api/hermes/group-chat.ts
@@ -136,7 +136,7 @@ export interface ChatMessage {
     toolArgs?: unknown
     toolPreview?: string
     toolResult?: unknown
-    toolStatus?: 'running' | 'done' | 'error'
+    toolStatus?: 'running' | 'done' | 'error' | 'interrupted'
     workspaceChanges?: GroupWorkspaceDiffPayload[]
     firstSeenAt?: number
     attachments?: Array<{ id: string; name: string; type: string; size: number; url: string }>

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -661,6 +661,7 @@ onBeforeUnmount(() => {
                 <span v-if="message.toolPreview && !toolExpanded" class="tool-preview">{{ message.toolPreview }}</span>
                 <span v-if="message.toolStatus === 'running'" class="tool-spinner"></span>
                 <span v-if="message.toolStatus === 'error'" class="tool-error-badge">{{ t('chat.error') }}</span>
+                <span v-if="message.toolStatus === 'interrupted'" class="tool-interrupted-badge">{{ t('chat.toolResultUnavailable') }}</span>
             </div>
             <div v-if="toolExpanded && hasToolDetails" class="tool-details" @click="handleToolDetailClick">
                 <div v-if="message.reasoning?.trim()" class="tool-detail-section">
@@ -916,6 +917,12 @@ onBeforeUnmount(() => {
             background: rgba(0, 0, 0, 0.03);
         }
     }
+}
+
+.tool-interrupted-badge {
+    flex: 0 0 auto;
+    color: $text-muted;
+    font-size: 10px;
 }
 
 .tool-chevron {

--- a/packages/client/src/components/layout/GlobalPendingActions.vue
+++ b/packages/client/src/components/layout/GlobalPendingActions.vue
@@ -188,7 +188,7 @@ async function copyApprovalCommand(action: Extract<GlobalPendingAction, { kind: 
 
 function approvalCommand(action: Extract<GlobalPendingAction, { kind: 'chat-approval' | 'group-approval' }>) {
   if (!action.pending.command) return null
-  return h('div', { class: 'global-approval-command' }, [
+  return h('div', { class: 'global-approval-command studio-surface' }, [
     h('div', { class: 'global-approval-command-header' }, [
       h('span', { class: 'global-approval-command-label' }, t('chat.approvalCommand')),
       h(NButton, {
@@ -316,7 +316,9 @@ function createGlobalNotification(action: GlobalPendingAction): NotificationReac
       : action.kind === 'workflow-approval'
         ? () => h('div', { class: 'global-approval-content' }, t('workflow.status.pending_approval'))
         : () => h('div', { class: 'global-approval-content' }, [
-            h('div', action.pending.description || ''),
+            action.pending.description
+              ? h('div', { class: 'global-approval-description' }, action.pending.description)
+              : null,
             approvalCommand(action),
           ]),
     action: clarify
@@ -398,20 +400,30 @@ onUnmounted(() => {
 
 <style scoped>.global-pending-actions-host { display: none; }</style>
 <style>
-.n-notification:has(.global-approval-content, .global-clarify-content) { width: 400px; }
+.n-notification:has(.global-approval-content, .global-clarify-content) {
+  width: min(560px, calc(100vw - 32px));
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  background: var(--bg-main-surface);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.14);
+}
+.n-notification:has(.global-approval-content, .global-clarify-content) .n-notification-main { margin-inline-start: 0; }
+.n-notification:has(.global-approval-content, .global-clarify-content) .n-notification-main__header { color: var(--text-primary); font-size: 15px; font-weight: 600; }
+.n-notification:has(.global-approval-content, .global-clarify-content) .n-notification-main-footer { padding-top: 12px; border-top: 1px solid var(--border-light); }
 .global-pending-title { appearance: none; border: 0; padding: 0; background: transparent; color: inherit; font: inherit; text-align: start; cursor: pointer; text-decoration: underline; text-decoration-color: transparent; text-underline-offset: 3px; }
 .global-pending-title:hover { text-decoration-color: currentcolor; }
 .global-pending-title:focus-visible { border-radius: 2px; outline: 2px solid var(--accent-info); outline-offset: 3px; }
 .global-pending-actions, .global-clarify-choices { display: flex; flex-wrap: wrap; gap: 8px; }
-.global-approval-content, .global-clarify-content { display: grid; gap: 10px; max-width: 420px; max-height: min(300px, calc(100dvh - 160px)); overflow-x: hidden; overflow-y: auto; overscroll-behavior: contain; overflow-wrap: anywhere; }
-.global-approval-command { min-width: 0; overflow: hidden; border: 1px solid var(--n-border-color); border-radius: 8px; background: var(--n-color-embedded); }
-.global-approval-command-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 34px; padding: 4px 6px 4px 12px; border-bottom: 1px solid var(--n-border-color); }
+.global-approval-content, .global-clarify-content { display: grid; gap: 12px; max-width: 520px; max-height: min(420px, calc(100dvh - 190px)); overflow-x: hidden; overflow-y: auto; overscroll-behavior: contain; overflow-wrap: anywhere; }
+.global-approval-description { padding: 10px 12px; border: 1px solid rgba(var(--warning-rgb), 0.28); border-radius: 10px; background: rgba(var(--warning-rgb), 0.08); color: var(--text-secondary); font-size: 13px; line-height: 1.55; }
+.global-approval-command { min-width: 0; overflow: hidden; border: 1px solid rgba(var(--text-primary-rgb), 0.1); border-radius: 10px; background: rgba(var(--accent-primary-rgb), 0.055); box-shadow: 0 4px 14px rgba(0, 0, 0, 0.035); }
+.global-approval-command-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 36px; padding: 4px 6px 4px 12px; border-bottom: 1px solid rgba(var(--text-primary-rgb), 0.08); }
 .global-approval-command-label { color: var(--text-secondary); font-size: 12px; font-weight: 600; }
 .global-approval-command pre { max-height: 240px; margin: 0; padding: 12px; overflow: auto; overscroll-behavior: contain; white-space: pre; }
 .global-approval-command code { display: block; width: max-content; min-width: 100%; color: var(--text-primary); font-family: "SFMono-Regular", "Cascadia Code", "Roboto Mono", Consolas, monospace; font-size: 12px; line-height: 1.55; }
 .global-clarify-question { font-weight: 600; }
 
 @media (max-width: 600px) {
-  .n-notification:has(.global-approval-content, .global-clarify-content) { width: calc(100vw - 32px); }
+  .n-notification:has(.global-approval-content, .global-clarify-content) { width: calc(100vw - 24px); }
 }
 </style>

--- a/packages/client/src/i18n/locales/ar.ts
+++ b/packages/client/src/i18n/locales/ar.ts
@@ -724,6 +724,7 @@ export default {
     categoryDeleteFailed: 'تعذّر حذف الفئة',
     agent: 'وكيل',
     approvalKicker: 'صلاحية الأداة',
+    toolResultUnavailable: 'توقف التنفيذ ولم يتم استلام نتيجة الأداة',
     approvalCommand: 'الأمر المطلوب تشغيله',
     approvalTitle: 'راجع استدعاء الأداة قبل التشغيل',
     approvalAgree: 'موافقة',

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -670,6 +670,7 @@ export default {
     categoryDeleteFailed: 'Kategorie konnte nicht gelöscht werden',
     agent: 'Agent',
     approvalKicker: 'Tool-Berechtigung',
+    toolResultUnavailable: 'Ausführung unterbrochen; kein Tool-Ergebnis empfangen',
     approvalCommand: 'Auszuführender Befehl',
     approvalTitle: 'Tool-Aufruf vor der Ausführung prüfen',
     approvalAgree: 'Zustimmen',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -724,6 +724,7 @@ export default {
     categoryDeleteFailed: 'Failed to delete category',
     agent: 'Agent',
     approvalKicker: 'Tool permission',
+    toolResultUnavailable: 'Execution interrupted; no tool result received',
     approvalCommand: 'Command to run',
     approvalTitle: 'Review tool call before running',
     approvalAgree: 'Agree',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -670,6 +670,7 @@ export default {
     categoryDeleteFailed: 'No se pudo eliminar la categoría',
     agent: 'Agent',
     approvalKicker: 'Permiso de herramienta',
+    toolResultUnavailable: 'Ejecución interrumpida; no se recibió resultado',
     approvalCommand: 'Comando que se ejecutará',
     approvalTitle: 'Revisar llamada de herramienta antes de ejecutar',
     approvalAgree: 'Aceptar',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -670,6 +670,7 @@ export default {
     categoryDeleteFailed: 'Échec de la suppression de la catégorie',
     agent: 'Agent',
     approvalKicker: 'Permission d’outil',
+    toolResultUnavailable: 'Exécution interrompue ; aucun résultat reçu',
     approvalCommand: 'Commande à exécuter',
     approvalTitle: 'Vérifier l’appel d’outil avant exécution',
     approvalAgree: 'Accepter',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -670,6 +670,7 @@ export default {
     categoryDeleteFailed: 'カテゴリーを削除できませんでした',
     agent: 'Agent',
     approvalKicker: 'ツール権限',
+    toolResultUnavailable: '実行が中断され、ツール結果を受信できませんでした',
     approvalCommand: '実行するコマンド',
     approvalTitle: '実行前にツール呼び出しを確認',
     approvalAgree: '同意',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -670,6 +670,7 @@ export default {
     categoryDeleteFailed: '카테고리를 삭제하지 못했습니다',
     agent: 'Agent',
     approvalKicker: '도구 권한',
+    toolResultUnavailable: '실행이 중단되어 도구 결과를 받지 못했습니다',
     approvalCommand: '실행할 명령',
     approvalTitle: '실행 전에 도구 호출 확인',
     approvalAgree: '동의',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -670,6 +670,7 @@ export default {
     categoryDeleteFailed: 'Falha ao excluir categoria',
     agent: 'Agent',
     approvalKicker: 'Permissão da ferramenta',
+    toolResultUnavailable: 'Execução interrompida; nenhum resultado recebido',
     approvalCommand: 'Comando a executar',
     approvalTitle: 'Revisar chamada da ferramenta antes de executar',
     approvalAgree: 'Concordar',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -612,6 +612,7 @@ export default {
     categoryDeleteFailed: 'Не удалось удалить категорию',
     agent: 'Agent',
     approvalKicker: 'Разрешение инструмента',
+    toolResultUnavailable: 'Выполнение прервано; результат инструмента не получен',
     approvalCommand: 'Команда для выполнения',
     approvalTitle: 'Подтвердите вызов инструмента перед выполнением',
     approvalAgree: 'Согласиться',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -722,6 +722,7 @@ export default {
     categoryDeleteFailed: '刪除分類失敗',
     agent: 'Agent',
     approvalKicker: '工具呼叫授權',
+    toolResultUnavailable: '執行已中斷，未收到工具結果',
     approvalCommand: '待執行命令',
     approvalTitle: '執行前請確認工具呼叫',
     approvalAgree: '同意',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -724,6 +724,7 @@ export default {
     categoryDeleteFailed: '删除分类失败',
     agent: 'Agent',
     approvalKicker: '工具调用授权',
+    toolResultUnavailable: '执行已中断，未收到工具结果',
     approvalCommand: '待执行命令',
     approvalTitle: '运行前请确认工具调用',
     approvalAgree: '同意',

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -634,7 +634,10 @@ export const useGroupChatStore = defineStore('groupChat', () => {
     }
 
     // ─── Computed ───────────────────────────────────────────
-    const sortedMessages = computed(() => mapGroupMessages([...messages.value].sort((a, b) => (a.firstSeenAt ?? a.timestamp) - (b.firstSeenAt ?? b.timestamp))))
+    const sortedMessages = computed(() => mapGroupMessages(
+        [...messages.value].sort((a, b) => (a.firstSeenAt ?? a.timestamp) - (b.firstSeenAt ?? b.timestamp)),
+        new Set(contextStatuses.value.keys()),
+    ))
 
     const memberNames = computed(() => {
         return members.value.map(m => m.name)
@@ -1741,11 +1744,14 @@ function segmentGroupReasoningSnapshots(messages: ChatMessage[]): ChatMessage[] 
     })
 }
 
-function mapGroupMessages(msgs: ChatMessage[]): ChatMessage[] {
+function mapGroupMessages(msgs: ChatMessage[], activeAgentNames = new Set<string>()): ChatMessage[] {
     msgs = segmentGroupReasoningSnapshots(msgs)
     const toolNameMap = new Map<string, string>()
     const toolArgsMap = new Map<string, unknown>()
+    const activeRunByAgent = new Map<string, string>()
     for (const msg of msgs) {
+        const runId = inferredGroupResponseRunId(msg)
+        if (runId && activeAgentNames.has(msg.senderName)) activeRunByAgent.set(msg.senderName, runId)
         if (msg.role === 'assistant' && msg.tool_calls?.length) {
             for (const tc of msg.tool_calls) {
                 if (!tc?.id) continue
@@ -1800,7 +1806,9 @@ function mapGroupMessages(msgs: ChatMessage[]): ChatMessage[] {
                     toolName: tc.function?.name || undefined,
                     toolCallId: tc.id,
                     toolArgs: runtimeToolPayloadOrUndefined(tc.function?.arguments),
-                    toolStatus: 'running',
+                    toolStatus: msg.isStreaming || activeRunByAgent.get(msg.senderName) === inferredGroupResponseRunId(msg)
+                        ? 'running'
+                        : 'interrupted',
                 })
             }
             continue

--- a/tests/client/global-pending-actions.test.ts
+++ b/tests/client/global-pending-actions.test.ts
@@ -329,6 +329,9 @@ describe('GlobalPendingActions', () => {
 
     expect(notificationTitleText(created[0])).toBe('branch: Build scripts · chat.approvalTitle')
     const content = await render(created[0].options.content)
+    expect(content.classes()).toContain('global-approval-content')
+    expect(content.get('.global-approval-description').text()).toBe('Security scan')
+    expect(content.get('.global-approval-command').classes()).toContain('studio-surface')
     const preview = content.get('.global-approval-command')
     expect(preview.get('.global-approval-command-label').text()).toBe('chat.approvalCommand')
     expect(preview.get('pre > code').text()).toBe(command)

--- a/tests/client/group-chat-store-streaming.test.ts
+++ b/tests/client/group-chat-store-streaming.test.ts
@@ -125,6 +125,90 @@ describe('group chat store streaming merge', () => {
     groupChatApiMock.socket.disconnect.mockClear()
   })
 
+  it('settles a historical Tool call without a persisted result instead of spinning forever', async () => {
+    const store = await createJoinedStore([
+      assistantMessage({
+        id: 'run-orphan_part_0_toolcall_call-orphan',
+        run_id: 'run-orphan',
+        senderName: 'QA Engineer',
+        tool_calls: [{
+          id: 'call-orphan',
+          type: 'function',
+          function: { name: 'Bash', arguments: JSON.stringify({ command: 'pwd' }) },
+        }],
+        finish_reason: 'tool_calls',
+      }),
+    ])
+
+    expect(store.sortedMessages).toEqual([
+      expect.objectContaining({
+        toolCallId: 'call-orphan',
+        toolStatus: 'interrupted',
+      }),
+    ])
+  })
+
+  it('keeps an unmatched Tool call running while its streamed message is live', async () => {
+    const store = await createJoinedStore()
+
+    emitSocket('message_stream_start', assistantMessage({
+      id: 'run-live_part_0',
+      run_id: 'run-live',
+    }))
+    emitSocket('context_status', { roomId: 'room-1', agentName: 'bot', status: 'replying' })
+    emitSocket('message', assistantMessage({
+      id: 'run-live_part_0_toolcall_call-live',
+      run_id: 'run-live',
+      isStreaming: true,
+      tool_calls: [{
+        id: 'call-live',
+        type: 'function',
+        function: { name: 'Bash', arguments: JSON.stringify({ command: 'pwd' }) },
+      }],
+      finish_reason: 'tool_calls',
+    }))
+
+    expect(store.sortedMessages.find((message: ChatMessage) => message.toolCallId === 'call-live')).toEqual(
+      expect.objectContaining({ toolStatus: 'running' }),
+    )
+  })
+
+  it('does not revive an older orphaned Tool call when the same agent starts a newer run', async () => {
+    const store = await createJoinedStore([
+      assistantMessage({
+        id: 'run-old_part_0_toolcall_call-old',
+        run_id: 'run-old',
+        senderName: 'bot',
+        timestamp: 1,
+        tool_calls: [{
+          id: 'call-old',
+          type: 'function',
+          function: { name: 'Bash', arguments: JSON.stringify({ command: 'old' }) },
+        }],
+        finish_reason: 'tool_calls',
+      }),
+      assistantMessage({
+        id: 'run-live_part_0_toolcall_call-live',
+        run_id: 'run-live',
+        senderName: 'bot',
+        timestamp: 2,
+        tool_calls: [{
+          id: 'call-live',
+          type: 'function',
+          function: { name: 'Bash', arguments: JSON.stringify({ command: 'live' }) },
+        }],
+        finish_reason: 'tool_calls',
+      }),
+    ])
+
+    emitSocket('context_status', { roomId: 'room-1', agentName: 'bot', status: 'replying' })
+
+    expect(store.sortedMessages.find((message: ChatMessage) => message.toolCallId === 'call-old')?.toolStatus)
+      .toBe('interrupted')
+    expect(store.sortedMessages.find((message: ChatMessage) => message.toolCallId === 'call-live')?.toolStatus)
+      .toBe('running')
+  })
+
   it('preserves streamed reasoning when the final message supplies content only', async () => {
     const store = await createJoinedStore()
 

--- a/tests/client/group-message-item-highlight.test.ts
+++ b/tests/client/group-message-item-highlight.test.ts
@@ -77,6 +77,13 @@ describe('GroupMessageItem tool details', () => {
     })
   })
 
+  it('shows an explicit unavailable-result label for interrupted historical tools', () => {
+    const wrapper = mountToolMessage({ toolStatus: 'interrupted' })
+
+    expect(wrapper.find('.tool-spinner').exists()).toBe(false)
+    expect(wrapper.get('.tool-interrupted-badge').text()).toBe('chat.toolResultUnavailable')
+  })
+
   it('selects a group message as the active room reference', async () => {
     const store = useGroupChatStore()
     store.currentRoomId = 'room-1'


### PR DESCRIPTION
## Summary

- stop historical Group Chat Tool calls with no persisted result from spinning forever
- keep only the exact active Agent's latest Run in `running`; older orphaned calls settle as interrupted
- show an explicit localized “result unavailable” label without fabricating or backfilling Tool output
- align global approval notifications with Studio surface, border, typography, warning, command-card, and responsive layout tokens
- preserve the exact focusable, scrollable, copyable command and all existing approval choices

## Verification

- Focused Group Chat + global approval tests: **51 passed**
- Interrupted-result renderer test: **1 passed**
- `npm run build`: **passed** (`vue-tsc`, client build, server typecheck/bundle)
- `git diff --check`: **passed**
- static added-line scan: no hardcoded secrets, `eval`/`exec`, or debug logs

### Full-suite baseline A/B

The repository full suite has existing environment-dependent failures in this checkout:

- candidate: **3613 passed, 56 failed, 3 skipped**
- exact base `0842cc86467ae9b8d31ee3db2db6fca03266052f`: **3596 passed, 69 failed, 3 skipped**
- exact failed-test-name comparison: **0 new candidate failures**

The focused `group-message-item-highlight` file also has one pre-existing async `MarkdownRenderer` stub failure on exact base; the new interrupted-result test passes independently.

## Snapshot and review status

- Base: `0842cc86467ae9b8d31ee3db2db6fca03266052f`
- Candidate HEAD: `576c4f0761217113ab13e6b1a5b217cab6bf8c9f`
- Candidate tree: `7d14593f55bfb7481c2efa239804ea8fe63fcb57`

The original implementation snapshot (`896e2110e0a65ac5789c26f1d6888d6b3f7ba16c`) received one Hermes Studio managed Coding Agent review attempt, but its final message was `API Error: unexpected EOF` and it did not produce the required `PASS`, `FAIL`, or `BLOCKED` verdict.

The candidate then advanced by one documentation-only commit to add the repository-required `docs/chat-chain-changes/*.md` fragment. On the final HEAD above:

- `GITHUB_BASE_REF=main GITHUB_ACTIONS=true npm run harness:check`: **passed**
- `npm run build`: **passed**
- GitHub Actions Build / `build`: **passed**
- GitHub Actions Playwright / `e2e`: **passed**

Because the exact HEAD changed after the review attempt, the earlier snapshot evidence is not treated as an independent-review PASS for this candidate. Per the single-review convergence rule, no replacement review was started. This PR remains **Draft**; no merge or release is authorized by these results.

Closes #2428
