### PR TITLE
Fix Group Chat Agent ownership and approval routing

### DIFF
--- a/docs/chat-chain-changes/2026-08-08-group-chat-agent-approval-ownership.md
+++ b/docs/chat-chain-changes/2026-08-08-group-chat-agent-approval-ownership.md
@@ -1,0 +1,17 @@
+---
+date: 2026-08-08
+commit: pending
+feature: Group Chat Agent-owner approval routing
+impact: Group Chat approvals are visible and actionable only to the member who owns the requesting Agent, with pending approvals restored when that owner reconnects.
+---
+
+## Group Chat Agent-owner approvals
+
+- Binds each pending approval route to the requesting Agent's persisted owner.
+- Uses `ownerMemberId` for remotely linked guest Agents and the Room owner for server-hosted Agents.
+- Sends requested and resolved approval events only to that owner and rejects responses from other Room managers, members, and administrators.
+- Restores all still-pending approvals for an authenticated Agent owner when the Group Chat socket reconnects, even when the owner has not re-entered the source Room.
+- Restores invite-member approvals through the existing Room join snapshot because unauthenticated off-Room identities are not trusted.
+- Allows a non-manager Agent owner to use the in-Room approval card; the server remains the authoritative response gate.
+
+Clarification prompts keep their existing Room-manager routing and are not changed by this update.

--- a/docs/chat-chain-changes/2026-08-08-group-chat-agent-owner-avatar-live-roster.md
+++ b/docs/chat-chain-changes/2026-08-08-group-chat-agent-owner-avatar-live-roster.md
@@ -1,0 +1,14 @@
+---
+date: 2026-08-08
+commit: pending
+feature: Stable Group Chat Agent owner avatars during live roster updates
+impact: Removing or updating a Room Agent no longer temporarily hides the owner-avatar badges of the remaining Agents.
+---
+
+## Stable Agent owner avatars during live roster updates
+
+- Merges realtime and mutation-response Agent rosters with the current Room roster instead of discarding previously issued ownership metadata when a public response omits it.
+- Returns the same display-safe Agent view from mutation broadcasts and responses, including derived owner metadata for server-hosted Agents.
+- Preserves `ownerMemberId` for every unchanged Agent so its owner-avatar badge remains visible without a page refresh.
+- Continues to preserve private connector fields only for the current member's own remote Agent.
+- Applies the same merge behavior to realtime joins and Agent list, add, update, remove, and member-removal refreshes.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -14598,6 +14598,32 @@
         }
       }
     },
+    "/livez": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Get livez",
+        "description": "GET /livez",
+        "operationId": "livenessCheck",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/upload": {
       "post": {
         "tags": [

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -494,7 +494,7 @@ function agentOwnerAvatar(agent: RoomAgent) {
     return owner ? memberAvatarFor(owner) : null
 }
 const visibleApproval = computed(() =>
-    currentRoomCanManage.value && pendingAgentPairings.value.length === 0
+    pendingAgentPairings.value.length === 0
         ? store.activePendingApproval
         : null,
 )
@@ -1488,7 +1488,6 @@ async function handleInterruptAgent(agent: RoomAgent) {
 }
 
 async function handleApproval(choice: 'once' | 'session' | 'always' | 'deny') {
-    if (!currentRoomCanManage.value) return
     try {
         await store.respondApproval(choice)
     } catch (err: any) {

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -374,6 +374,13 @@ export const useGroupChatStore = defineStore('groupChat', () => {
         pendingApprovals.value = new Map(pendingApprovals.value)
         pendingClarifies.value = new Map(pendingClarifies.value)
     }
+
+    function replacePendingApprovalSnapshots(approvals: unknown) {
+        if (!Array.isArray(approvals)) return
+        pendingApprovals.value.clear()
+        for (const pending of approvals) upsertPendingApproval(pending as any)
+        pendingApprovals.value = new Map(pendingApprovals.value)
+    }
     const userId = ref(getStoredUserId())
     const userName = ref(getStoredGroupUserName() || getStoredUsername() || '')
 
@@ -441,6 +448,27 @@ export const useGroupChatStore = defineStore('groupChat', () => {
         messages.value = [...messages.value]
     }
 
+    function mergeRoomAgentRoster(nextAgents: RoomAgent[], previousAgents = agents.value) {
+        const previousById = new Map(previousAgents.map(agent => [agent.id, agent]))
+        return nextAgents.map((agent) => {
+            const previous = previousById.get(agent.id)
+            const ownerMemberId = agent.ownerMemberId || previous?.ownerMemberId
+            const ownsRemoteAgent = agent.executorType === 'remote'
+                && ownerMemberId === userId.value
+            const { connectorId, remoteOrigin, ...visibleAgent } = agent
+            return {
+                ...visibleAgent,
+                ...(ownerMemberId ? { ownerMemberId } : {}),
+                ...(ownsRemoteAgent && (connectorId || previous?.connectorId)
+                    ? { connectorId: connectorId || previous?.connectorId }
+                    : {}),
+                ...(ownsRemoteAgent && (remoteOrigin || previous?.remoteOrigin)
+                    ? { remoteOrigin: remoteOrigin || previous?.remoteOrigin }
+                    : {}),
+            }
+        })
+    }
+
     function captureHistoricalMessageAgents(chatMessages: ChatMessage[]) {
         const historicalById = new Map(historicalMessageAgents.value.map(agent => [agent.id, agent]))
         let changed = false
@@ -458,7 +486,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
         members.value = res.members || []
         if (res.agents) {
             snapshotCurrentMessageAgents(agents.value)
-            agents.value = res.agents
+            agents.value = mergeRoomAgentRoster(res.agents)
         }
         if (res.roomName) roomName.value = res.roomName
         if (typeof res.agentLinkToken === 'string') agentLinkToken.value = res.agentLinkToken
@@ -707,6 +735,9 @@ export const useGroupChatStore = defineStore('groupChat', () => {
             realtimeJoinedRoomId.value = null
             realtimeJoinedSocketId.value = null
             error.value = null
+            socket.emit('load_pending_approvals', {}, (res: { pendingApprovals?: unknown } | undefined) => {
+                replacePendingApprovalSnapshots(res?.pendingApprovals)
+            })
             const roomId = currentRoomId.value
             if (roomId) {
                 void joinRealtimeRoom(roomId, {
@@ -894,22 +925,8 @@ export const useGroupChatStore = defineStore('groupChat', () => {
         socket.on('agents_updated', (data: { roomId: string; agents: RoomAgent[] }) => {
             if (data.roomId === currentRoomId.value) {
                 snapshotCurrentMessageAgents(agents.value)
-                const previousById = new Map(agents.value.map(agent => [agent.id, agent]))
                 agents.value = Array.isArray(data.agents)
-                    ? data.agents.map((agent) => {
-                        const previous = previousById.get(agent.id)
-                        if (
-                            agent.executorType !== 'remote'
-                            || (agent.ownerMemberId || previous?.ownerMemberId) !== userId.value
-                            || (agent.connectorId && agent.remoteOrigin)
-                        ) return agent
-                        return {
-                            ...agent,
-                            ownerMemberId: agent.ownerMemberId || previous?.ownerMemberId,
-                            connectorId: previous?.connectorId,
-                            remoteOrigin: previous?.remoteOrigin,
-                        }
-                    })
+                    ? mergeRoomAgentRoster(data.agents)
                     : []
             }
         })
@@ -1372,7 +1389,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
         try {
             const res = await listAgents(roomId)
             snapshotCurrentMessageAgents(agents.value)
-            agents.value = res.agents
+            agents.value = mergeRoomAgentRoster(res.agents)
         } catch { /* ignore */ }
     }
 
@@ -1383,8 +1400,9 @@ export const useGroupChatStore = defineStore('groupChat', () => {
                 agent.id === res.agent.id || agent.agentId === res.agent.agentId
             )
             if (index >= 0) {
-                agents.value[index] = res.agent
-                agents.value = [...agents.value]
+                agents.value = mergeRoomAgentRoster(agents.value.map((agent, agentIndex) => (
+                    agentIndex === index ? res.agent : agent
+                )))
             } else {
                 agents.value = [...agents.value, res.agent]
             }
@@ -1398,9 +1416,9 @@ export const useGroupChatStore = defineStore('groupChat', () => {
     async function updateAgentInRoom(roomId: string, agentId: string, data: RoomAgentInput) {
         try {
             const res = await updateAgent(roomId, agentId, data)
-            agents.value = res.agents ?? agents.value.map(agent => (
+            agents.value = mergeRoomAgentRoster(res.agents ?? agents.value.map(agent => (
                 agent.id === agentId || agent.agentId === agentId ? res.agent : agent
-            ))
+            )))
             if (res.members) members.value = res.members
             return res.agent
         } catch (err: any) {
@@ -1418,7 +1436,9 @@ export const useGroupChatStore = defineStore('groupChat', () => {
             const res = ownsRemoteAgent
                 ? await removeOwnedRemoteAgent(roomId, agentId)
                 : await removeAgent(roomId, agentId)
-            agents.value = res.agents ?? agents.value.filter(a => a.id !== agentId && a.agentId !== agentId)
+            agents.value = mergeRoomAgentRoster(
+                res.agents ?? agents.value.filter(a => a.id !== agentId && a.agentId !== agentId),
+            )
             if (res.members) members.value = res.members
         } catch (err: any) {
             error.value = err.message
@@ -1444,7 +1464,9 @@ export const useGroupChatStore = defineStore('groupChat', () => {
             snapshotCurrentMessageAgents(agents.value)
             const res = await removeRoomMemberApi(roomId, memberUserId)
             members.value = res.members ?? members.value.filter(member => member.userId !== memberUserId)
-            agents.value = res.agents ?? agents.value.filter(agent => agent.ownerMemberId !== memberUserId)
+            agents.value = mergeRoomAgentRoster(
+                res.agents ?? agents.value.filter(agent => agent.ownerMemberId !== memberUserId),
+            )
         } catch (err: any) {
             error.value = err.message
             throw err

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -74,6 +74,7 @@ type IncomingGroupChatMessage = Omit<Partial<ChatMessage>, 'content'> & {
 interface PendingGroupApprovalRoute {
     roomId: string
     agentName: string
+    ownerMemberId: string
     agentSessionId: string
     approvalId: string
     command: string
@@ -1600,11 +1601,11 @@ export class GroupChatServer {
         return `${roomId}:${clarifyId}`
     }
 
-    private pendingApprovalSnapshots(roomId: string) {
+    private pendingApprovalSnapshots(roomId: string | null, socket: Socket) {
         const pendingRoutes = this.pendingApprovalRoutes
         if (!pendingRoutes) return []
         return [...pendingRoutes.values()]
-            .filter(route => route.roomId === roomId)
+            .filter(route => (!roomId || route.roomId === roomId) && this.canSocketHandleAgentApproval(socket, route))
             .map(route => ({
                 roomId: route.roomId,
                 agentName: route.agentName,
@@ -1837,11 +1838,11 @@ export class GroupChatServer {
         }))
     }
 
-    broadcastRoomAgents(roomId: string): RoomAgent[] {
-        const agents = this.storage.getRoomAgents(roomId)
+    broadcastRoomAgents(roomId: string): Array<Record<string, unknown>> {
+        const agents = this.getRoomAgentViews(roomId, false)
         this.nsp.to(roomId).emit('agents_updated', {
             roomId,
-            agents: this.getRoomAgentViews(roomId, false),
+            agents,
         })
         this.emitToRoomManagers(roomId, 'agents_updated', {
             roomId,
@@ -2090,6 +2091,9 @@ export class GroupChatServer {
         logger.debug(`[GroupChat] Connected: ${userName} (socket=${socket.id}, user=${userId})`)
 
         socket.on('join', (data: { roomId?: string; name?: string }, ack?: (response?: unknown) => void) => this.handleJoin(socket, data, ack))
+        socket.on('load_pending_approvals', (_data: unknown, ack?: (response?: unknown) => void) => {
+            ack?.({ pendingApprovals: this.pendingApprovalSnapshots(null, socket) })
+        })
         socket.on('load_messages', (data: { roomId?: string; offset?: number; limit?: number }, ack?: (response?: unknown) => void) => this.handleLoadMessages(socket, data, ack))
         socket.on('update_member_profile', (data: { roomId?: string; name?: string; description?: string } | undefined, ack?: (response?: unknown) => void) => this.handleUpdateMemberProfile(socket, data, ack))
         socket.on('message', (data: IncomingGroupChatMessage, ack?: (response?: unknown) => void) => this.handleMessage(socket, data, ack))
@@ -2145,6 +2149,49 @@ export class GroupChatServer {
         if (typeof authUser.id === 'number' && Number(room.ownerAuthUserId || 0) === authUser.id) return true
         const profiles = authenticatedUserProfiles(authUser)
         return profiles.length > 0 && typeof this.storage.getRoomsForProfiles === 'function' && this.storage.getRoomsForProfiles(profiles).some(candidate => candidate.id === roomId)
+    }
+
+    private groupAgentOwnerMemberId(roomId: string, agentName: string): string {
+        const agent = this.storage.getRoomAgents(roomId)
+            .find(candidate => candidate.name === agentName)
+        if (!agent) return ''
+        const explicitOwner = String(agent.ownerMemberId || '').trim()
+        if (explicitOwner) return explicitOwner
+        if (agent.executorType !== 'server') return ''
+        const roomOwnerAuthUserId = Number(this.storage.getRoom(roomId)?.ownerAuthUserId || 0)
+        return roomOwnerAuthUserId > 0
+            ? authenticatedGroupUserId(roomOwnerAuthUserId)
+            : ''
+    }
+
+    private canSocketHandleAgentApproval(
+        socket: Socket,
+        route: Pick<PendingGroupApprovalRoute, 'roomId' | 'ownerMemberId'>,
+    ): boolean {
+        if (!route.ownerMemberId || this.socketRequestedSourceMap?.get(socket.id) === 'agent') return false
+        const authUser = socket.data?.authUser as AuthenticatedUser | undefined
+        if (typeof authUser?.id === 'number') {
+            return authenticatedGroupUserId(authUser.id) === route.ownerMemberId
+        }
+        const joined = this.getOnlineRoomMember(socket, route.roomId)
+        return Boolean(
+            joined
+            && joined.member.source === 'human'
+            && joined.member.userId === route.ownerMemberId
+            && this.socketUserMap.get(socket.id) === route.ownerMemberId,
+        )
+    }
+
+    private emitToAgentApprovalOwner(
+        route: Pick<PendingGroupApprovalRoute, 'roomId' | 'ownerMemberId'>,
+        event: string,
+        payload: Record<string, unknown>,
+    ): void {
+        const sockets = this.nsp.sockets?.values?.()
+        if (!sockets) return
+        for (const socket of sockets) {
+            if (this.canSocketHandleAgentApproval(socket, route)) socket.emit(event, payload)
+        }
     }
 
     private canSocketMentionAll(socket: Socket, roomId: string): boolean {
@@ -2384,7 +2431,7 @@ export class GroupChatServer {
             hasMore: messages.length < total,
             typingUsers: this.getTypingUsers(roomId),
             contextStatuses: this.getContextStatuses(roomId),
-            pendingApprovals: this.canSocketManageRoom(socket, roomId) ? this.pendingApprovalSnapshots(roomId) : [],
+            pendingApprovals: this.pendingApprovalSnapshots(roomId, socket),
             pendingClarifies: this.canSocketManageRoom(socket, roomId) ? this.pendingClarifySnapshots(roomId) : [],
             ...(isInviteGuest && source !== 'agent'
                 ? { agentLinkToken: this.issueGuestAgentRequestToken(roomId, userId, socket.id) }
@@ -2897,9 +2944,10 @@ export class GroupChatServer {
         const agentName = data.agentName || ''
         if (!roomId || !data.approval_id || !this.getCurrentAgentEventMember(socket, roomId, agentName, data.agentSessionId)) return
         const choices = Array.isArray(data.choices) ? data.choices : ['once', 'session', 'deny']
-        this.pendingApprovalRoutes.set(this.pendingApprovalRouteKey(roomId, data.approval_id), {
+        const pendingRoute: PendingGroupApprovalRoute = {
             roomId,
             agentName,
+            ownerMemberId: this.groupAgentOwnerMemberId(roomId, agentName),
             agentSessionId: String(data.agentSessionId || '').trim(),
             approvalId: data.approval_id,
             command: data.command || '',
@@ -2907,8 +2955,12 @@ export class GroupChatServer {
             choices,
             allowPermanent: Boolean(data.allow_permanent),
             requestedAt: Date.now(),
-        })
-        this.emitToRoomManagers(roomId, 'approval.requested', {
+        }
+        this.pendingApprovalRoutes.set(this.pendingApprovalRouteKey(roomId, data.approval_id), pendingRoute)
+        if (!pendingRoute.ownerMemberId) {
+            logger.warn(`[GroupChat] approval ${data.approval_id} has no Agent owner in room ${roomId}`)
+        }
+        this.emitToAgentApprovalOwner(pendingRoute, 'approval.requested', {
             event: 'approval.requested',
             roomId,
             agentName,
@@ -2929,7 +2981,8 @@ export class GroupChatServer {
         if (pendingRoute?.roomId === roomId && pendingRoute.agentName === agentName) {
             this.pendingApprovalRoutes.delete(routeKey)
         }
-        this.emitToRoomManagers(roomId, 'approval.resolved', {
+        const ownerMemberId = pendingRoute?.ownerMemberId || this.groupAgentOwnerMemberId(roomId, agentName)
+        this.emitToAgentApprovalOwner({ roomId, ownerMemberId }, 'approval.resolved', {
             event: 'approval.resolved',
             roomId,
             agentName,
@@ -2949,14 +3002,19 @@ export class GroupChatServer {
             ack?.({ error: 'Not in room' })
             return
         }
-        if (!this.canSocketManageRoom(socket, roomId)) {
+        const pendingRoutes = this.pendingApprovalRoutes
+        if (!pendingRoutes) {
             ack?.({ error: 'Access denied' })
             return
         }
         const routeKey = this.pendingApprovalRouteKey(roomId, data.approval_id)
-        const pendingRoute = this.pendingApprovalRoutes.get(routeKey)
+        const pendingRoute = pendingRoutes.get(routeKey)
         if (!pendingRoute || pendingRoute.roomId !== roomId) {
             ack?.({ error: 'Approval is not pending in this room' })
+            return
+        }
+        if (!this.canSocketHandleAgentApproval(socket, pendingRoute)) {
+            ack?.({ error: 'Access denied' })
             return
         }
         const remoteExecutor = this.agentClients.getAgents(roomId).find(agent =>

--- a/tests/client/group-chat-panel-workspace-source.test.ts
+++ b/tests/client/group-chat-panel-workspace-source.test.ts
@@ -25,13 +25,22 @@ describe('GroupChatPanel workspace save handling', () => {
     expect(source).not.toContain('workspaceValue.value.trim()')
   })
 
-  it('gates workspace mutation controls to rooms the server marks manageable', () => {
+  it('gates room management controls while allowing an Agent owner to handle a directed approval', () => {
     const source = readFileSync('packages/client/src/components/hermes/group-chat/GroupChatPanel.vue', 'utf8')
+    const visibleApproval = source.slice(
+      source.indexOf('const visibleApproval = computed(() =>'),
+      source.indexOf('const visibleClarify = computed(() =>'),
+    )
+    const approvalHandler = source.slice(
+      source.indexOf('async function handleApproval('),
+      source.indexOf('async function handleClarify('),
+    )
 
     expect(source).toContain('const currentRoomCanManage = computed(() => !props.standalone && canManageRoom(currentRoom.value))')
     expect(source).toContain("const currentRoomCanMentionAll = computed(() => !props.standalone && currentRoom.value?.canMentionAll === true)")
-    expect(source).toContain('const visibleApproval = computed(() =>')
-    expect(source).toContain('currentRoomCanManage.value && pendingAgentPairings.value.length === 0')
+    expect(visibleApproval).toContain('pendingAgentPairings.value.length === 0')
+    expect(visibleApproval).not.toContain('currentRoomCanManage.value')
+    expect(approvalHandler).not.toContain('currentRoomCanManage.value')
     expect(source).toContain('if (!currentRoomCanManage.value) return')
     expect(source).toContain('if (!canManageRoom(room)) return')
     expect(source).toContain("options.push({ label: t('chat.setWorkspace'), key: 'set-workspace' })")

--- a/tests/client/group-chat-store-baseline.test.ts
+++ b/tests/client/group-chat-store-baseline.test.ts
@@ -176,6 +176,7 @@ describe('group chat store baseline lifecycle', () => {
     groupChatApiMock.socket.emit.mockReset()
     groupChatApiMock.socket.emit.mockImplementation((event: string, data?: any, ack?: Function) => {
       if (event === 'join' && ack) ack({ members: [], agents: [], typingUsers: [], contextStatuses: [] })
+      if (event === 'load_pending_approvals' && ack) ack({ pendingApprovals: [] })
       if (event === 'message' && ack) ack({ id: data?.id })
       return groupChatApiMock.socket
     })
@@ -197,6 +198,29 @@ describe('group chat store baseline lifecycle', () => {
     expect(groupChatApiMock.socket.on).toHaveBeenCalledWith('approval.requested', expect.any(Function))
     expect(groupChatApiMock.socket.on).toHaveBeenCalledWith('room_cleared', expect.any(Function))
     expect(groupChatApiMock.socket.on).toHaveBeenCalledWith('room_summary_updated', expect.any(Function))
+  })
+
+  it('restores directed approvals when the Agent owner comes online without joining the room', async () => {
+    groupChatApiMock.socket.emit.mockImplementation((event: string, data?: any, ack?: Function) => {
+      if (event === 'load_pending_approvals' && ack) ack({
+        pendingApprovals: [{
+          roomId: 'room-offline', agentName: 'Agent', approval_id: 'approval-offline',
+          command: 'touch file', description: 'needs approval', choices: ['once', 'deny'],
+        }],
+      })
+      return groupChatApiMock.socket
+    })
+    const store = await loadStore()
+
+    await store.connect()
+
+    expect([...store.pendingApprovals.values()]).toEqual([
+      expect.objectContaining({
+        roomId: 'room-offline',
+        agentName: 'Agent',
+        approvalId: 'approval-offline',
+      }),
+    ])
   })
 
   it('uses server persisted activity time instead of an agent display timestamp for live room ordering', async () => {
@@ -485,6 +509,38 @@ describe('group chat store baseline lifecycle', () => {
     expect(store.agents).toEqual([])
   })
 
+  it('keeps remaining Agent owner badges when a removal response omits ownership fields', async () => {
+    const store = await loadStore()
+    const remainingAgent = {
+      ...agent,
+      id: 'row-remaining-agent',
+      agentId: 'remaining-agent',
+      executorType: 'remote' as const,
+      ownerMemberId: 'other-owner',
+    }
+    groupChatApiMock.removeAgent.mockResolvedValue({
+      agents: [{
+        ...remainingAgent,
+        ownerMemberId: undefined,
+        connectorId: 'other-owner-secret',
+        remoteOrigin: 'http://127.0.0.1:9999',
+      }],
+      members: [member],
+    })
+    store.agents = [agent, remainingAgent]
+
+    await store.removeAgentFromRoom('room-1', agent.id)
+
+    expect(store.agents).toEqual([
+      expect.objectContaining({
+        id: 'row-remaining-agent',
+        ownerMemberId: 'other-owner',
+      }),
+    ])
+    expect(store.agents[0]).not.toHaveProperty('connectorId')
+    expect(store.agents[0]).not.toHaveProperty('remoteOrigin')
+  })
+
   it('keeps the current room agent roster in sync with realtime broadcasts', async () => {
     const store = await loadStore()
     const updatedAgent = { ...agent, name: 'Realtime Agent' }
@@ -555,11 +611,23 @@ describe('group chat store baseline lifecycle', () => {
       connectorId: undefined,
       remoteOrigin: undefined,
     }
+    const otherOwnedAgent = {
+      ...agent,
+      id: 'row-other-agent',
+      agentId: 'other-agent',
+      executorType: 'remote' as const,
+      ownerMemberId: 'other-owner',
+      connectorId: 'other-owner-secret',
+      remoteOrigin: 'http://127.0.0.1:9999',
+    }
 
     await store.connect()
     store.currentRoomId = 'room-1'
-    store.agents = [ownedAgent]
-    emitSocket('agents_updated', { roomId: 'room-1', agents: [publicUpdate] })
+    store.agents = [ownedAgent, otherOwnedAgent]
+    emitSocket('agents_updated', {
+      roomId: 'room-1',
+      agents: [publicUpdate, { ...otherOwnedAgent, ownerMemberId: undefined }],
+    })
 
     expect(store.agents[0]).toMatchObject({
       name: 'Updated Agent',
@@ -567,6 +635,12 @@ describe('group chat store baseline lifecycle', () => {
       connectorId: '11111111-2222-4333-8444-555555555555',
       remoteOrigin: 'http://127.0.0.1:8648',
     })
+    expect(store.agents[1]).toMatchObject({
+      id: 'row-other-agent',
+      ownerMemberId: 'other-owner',
+    })
+    expect(store.agents[1]).not.toHaveProperty('connectorId')
+    expect(store.agents[1]).not.toHaveProperty('remoteOrigin')
   })
 
   it('joins invite-only rooms entirely over realtime when the socket starts disconnected', async () => {

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -28,7 +28,7 @@ describe('group chat approval and context baseline', () => {
     groupServer = harness.groupServer
     port = harness.port
     vi.spyOn(groupServer.agentClients, 'agentSessionIsCurrent').mockReturnValue(true)
-    groupServer.getStorage().saveRoom('room-1', 'Room 1', 'ROOM1')
+    groupServer.getStorage().saveRoom('room-1', 'Room 1', 'ROOM1', { ownerAuthUserId: 1 })
     groupServer.getStorage().addRoomAgent('room-1', 'agent-1', 'default', 'Agent', '', 0)
   })
 
@@ -47,6 +47,9 @@ describe('group chat approval and context baseline', () => {
     })
     const human = await connectGroupChatClient(port, 'human-1', 'Human')
     harness.sockets.push(agent, human)
+    groupServer.getIO().of('/group-chat').sockets.get(human.id!)!.data.authUser = {
+      id: 1, role: 'user', profiles: ['default'],
+    }
     await emitAck(agent, 'join', { roomId: 'room-1' })
     await emitAck(human, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
     return { agent, human, agentSessionId }
@@ -134,17 +137,17 @@ describe('group chat approval and context baseline', () => {
     ])
   })
 
-  it('delivers and handles approval globally for a manager who has not joined the source room', async () => {
+  it('delivers and handles approval globally for the Agent owner who has not joined the source room', async () => {
     const agentSessionId = groupRuntimeSessionId('room-1', 'default', 'Agent')
     const agent = await connectGroupChatClient(port, 'agent-1', 'Agent', {
       source: 'agent',
       agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
     })
-    const manager = await connectGroupChatClient(port, 'manager-1', 'Manager')
-    harness.sockets.push(agent, manager)
+    const owner = await connectGroupChatClient(port, 'manager-1', 'Owner')
+    harness.sockets.push(agent, owner)
     await emitAck(agent, 'join', { roomId: 'room-1' })
     groupServer.getStorage().addRoomMember('room-1', 'manager-1', 'Manager', '')
-    groupServer.getIO().of('/group-chat').sockets.get(manager.id!)!.data.authUser = {
+    groupServer.getIO().of('/group-chat').sockets.get(owner.id!)!.data.authUser = {
       id: 1, role: 'super_admin', profiles: ['default'],
     }
 
@@ -170,11 +173,11 @@ describe('group chat approval and context baseline', () => {
       }),
     })
 
-    await expect(once<any>(manager, 'approval.requested')).resolves.toMatchObject({
+    await expect(once<any>(owner, 'approval.requested')).resolves.toMatchObject({
       roomId: 'room-1',
       approval_id: 'approval-global',
     })
-    await expect(emitAck(manager, 'approval.respond', {
+    await expect(emitAck(owner, 'approval.respond', {
       roomId: 'room-1',
       approval_id: 'approval-global',
       choice: 'once',
@@ -182,22 +185,64 @@ describe('group chat approval and context baseline', () => {
     await expect(approval).resolves.toBe('once')
   })
 
-  it('does not expose or resolve approvals for a non-member socket when authentication is disabled', async () => {
+  it('replays a still-pending approval when the Agent owner comes online later', async () => {
     const agentSessionId = groupRuntimeSessionId('room-1', 'default', 'Agent')
     const agent = await connectGroupChatClient(port, 'agent-1', 'Agent', {
       source: 'agent',
       agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
     })
+    harness.sockets.push(agent)
+    await emitAck(agent, 'join', { roomId: 'room-1' })
+
+    agent.emit('approval.requested', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      agentSessionId,
+      approval_id: 'approval-offline-owner',
+      command: 'touch offline.txt',
+      description: 'writes a file',
+      choices: ['once', 'deny'],
+    })
+    await wait()
+
+    const owner = await connectGroupChatClient(port, 'owner-offline', 'Owner')
+    harness.sockets.push(owner)
+    groupServer.getIO().of('/group-chat').sockets.get(owner.id!)!.data.authUser = {
+      id: 1, role: 'user', profiles: ['default'],
+    }
+
+    await expect(emitAck<any>(owner, 'load_pending_approvals', {})).resolves.toEqual({
+      pendingApprovals: [expect.objectContaining({
+        roomId: 'room-1',
+        agentName: 'Agent',
+        approval_id: 'approval-offline-owner',
+        command: 'touch offline.txt',
+      })],
+    })
+  })
+
+  it('delivers an approval only to the Agent owner, not another room manager or a stranger', async () => {
+    const agentSessionId = groupRuntimeSessionId('room-1', 'default', 'Agent')
+    const agent = await connectGroupChatClient(port, 'agent-1', 'Agent', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    const owner = await connectGroupChatClient(port, 'human-1', 'Owner')
     const manager = await connectGroupChatClient(port, 'manager-1', 'Manager')
     const stranger = await connectGroupChatClient(port, 'stranger-1', 'Stranger')
-    harness.sockets.push(agent, manager, stranger)
+    harness.sockets.push(agent, owner, manager, stranger)
+    groupServer.getIO().of('/group-chat').sockets.get(owner.id!)!.data.authUser = {
+      id: 1, role: 'user', profiles: ['default'],
+    }
     await emitAck(agent, 'join', { roomId: 'room-1' })
-    groupServer.getStorage().addRoomMember('room-1', 'manager-1', 'Manager', '')
+    await emitAck(owner, 'join', { roomId: 'room-1' })
     await emitAck(manager, 'join', { roomId: 'room-1' })
 
-    let leaked: unknown = null
-    stranger.on('approval.requested', payload => { leaked = payload })
-    const managerRequest = once<any>(manager, 'approval.requested')
+    let managerLeak: unknown = null
+    let strangerLeak: unknown = null
+    manager.on('approval.requested', payload => { managerLeak = payload })
+    stranger.on('approval.requested', payload => { strangerLeak = payload })
+    const ownerRequest = once<any>(owner, 'approval.requested')
     const approval = waitForEkkoToolApproval({
       approvalId: 'approval-private-global',
       toolName: 'terminal_exec',
@@ -220,9 +265,10 @@ describe('group chat approval and context baseline', () => {
       }),
     })
 
-    await expect(managerRequest).resolves.toMatchObject({ approval_id: 'approval-private-global' })
+    await expect(ownerRequest).resolves.toMatchObject({ approval_id: 'approval-private-global' })
     await wait()
-    expect(leaked).toBeNull()
+    expect(managerLeak).toBeNull()
+    expect(strangerLeak).toBeNull()
     await expect(emitAck(stranger, 'approval.respond', {
       roomId: 'room-1',
       approval_id: 'approval-private-global',
@@ -231,9 +277,70 @@ describe('group chat approval and context baseline', () => {
     await expect(emitAck(manager, 'approval.respond', {
       roomId: 'room-1',
       approval_id: 'approval-private-global',
+      choice: 'once',
+    })).resolves.toEqual({ error: 'Access denied' })
+    await expect(emitAck(owner, 'approval.respond', {
+      roomId: 'room-1',
+      approval_id: 'approval-private-global',
       choice: 'deny',
     })).resolves.toEqual({ ok: true, resolved: true })
     await expect(approval).resolves.toBe('deny')
+  })
+
+  it('sends a guest Agent approval to its inviter instead of the room owner', async () => {
+    groupServer.getStorage().addRoomAgent(
+      'room-1',
+      'remote-agent',
+      'guest-profile',
+      'Guest Agent',
+      '',
+      1,
+      { executorType: 'remote', ownerMemberId: 'guest-owner' },
+    )
+    const agentSessionId = groupRuntimeSessionId('room-1', 'guest-profile', 'Guest Agent')
+    const agent = await connectGroupChatClient(port, 'remote-agent', 'Guest Agent', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    const inviter = await connectGroupChatClient(port, 'guest-owner', 'Inviter')
+    const roomOwner = await connectGroupChatClient(port, 'room-owner', 'Room Owner')
+    harness.sockets.push(agent, inviter, roomOwner)
+    groupServer.getIO().of('/group-chat').sockets.get(roomOwner.id!)!.data.authUser = {
+      id: 1, role: 'user', profiles: ['default'],
+    }
+    await emitAck(agent, 'join', { roomId: 'room-1' })
+    await emitAck(inviter, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    await emitAck(roomOwner, 'join', { roomId: 'room-1' })
+
+    const respondApproval = vi.fn(async () => true)
+    vi.spyOn(groupServer.agentClients, 'getAgents').mockReturnValue([{
+      name: 'Guest Agent',
+      respondApproval,
+    } as any])
+    let roomOwnerLeak: unknown = null
+    roomOwner.on('approval.requested', payload => { roomOwnerLeak = payload })
+    const inviterRequest = once<any>(inviter, 'approval.requested')
+
+    agent.emit('approval.requested', {
+      roomId: 'room-1',
+      agentName: 'Guest Agent',
+      agentSessionId,
+      approval_id: 'approval-guest-agent',
+      command: 'touch guest.txt',
+      description: 'writes a file',
+      choices: ['once', 'deny'],
+    })
+
+    await expect(inviterRequest).resolves.toMatchObject({ approval_id: 'approval-guest-agent' })
+    await wait()
+    expect(roomOwnerLeak).toBeNull()
+    await expect(emitAck(roomOwner, 'approval.respond', {
+      roomId: 'room-1', approval_id: 'approval-guest-agent', choice: 'once',
+    })).resolves.toEqual({ error: 'Access denied' })
+    await expect(emitAck(inviter, 'approval.respond', {
+      roomId: 'room-1', approval_id: 'approval-guest-agent', choice: 'once',
+    })).resolves.toEqual({ ok: true, resolved: true })
+    expect(respondApproval).toHaveBeenCalledWith('approval-guest-agent', 'once')
   })
 
   it('does not trust a claimed persisted member identity for off-room approvals when authentication is disabled', async () => {

--- a/tests/server/group-chat-member-sync.test.ts
+++ b/tests/server/group-chat-member-sync.test.ts
@@ -738,22 +738,25 @@ describe('Group Chat member/agent identity sync', () => {
   })
 
   it('broadcasts the complete room agent roster after mutations', () => {
-    const agents = [{ id: 'row-agent', agentId: 'agent-1', name: 'Agent' }]
+    const agents = [{ id: 'row-agent', agentId: 'agent-1', name: 'Agent', executorType: 'server' }]
     const emit = vi.fn()
     const to = vi.fn(() => ({ emit }))
     const server = Object.create(GroupChatServer.prototype) as any
     server.storage = {
+      getRoom: vi.fn(() => ({ id: 'room-1', ownerAuthUserId: 7 })),
       getRoomAgents: vi.fn(() => agents),
     }
     server.agentClients = { getAgent: vi.fn(() => ({ connected: true })) }
     server.rooms = new Map()
     server.nsp = { to }
 
-    expect(server.broadcastRoomAgents('room-1')).toEqual(agents)
+    expect(server.broadcastRoomAgents('room-1')).toEqual([
+      { ...agents[0], connectionStatus: 'online', ownerMemberId: 'auth:7' },
+    ])
     expect(to).toHaveBeenCalledWith('room-1')
     expect(emit).toHaveBeenCalledWith('agents_updated', {
       roomId: 'room-1',
-      agents: [{ ...agents[0], connectionStatus: 'online' }],
+      agents: [{ ...agents[0], connectionStatus: 'online', ownerMemberId: 'auth:7' }],
     })
   })
 


### PR DESCRIPTION
## Summary

- Route Group Chat Agent approval requests only to the member who owns the requesting Agent.
- Restore still-pending approvals when an authenticated owner reconnects, including while outside the source Room.
- Keep invite-member approvals scoped to the trusted Room join flow.
- Preserve Agent owner-avatar badges across realtime roster and removal updates.
- Return display-safe Agent roster views from mutation broadcasts and responses while retaining private connector fields only for the owning member.
- Keep the generated OpenAPI `/livez` endpoint update.

## Why

Approval prompts were previously fanned out to every Room manager, so members other than the Agent owner could see and respond to them. Agent removal responses also replaced the client roster with storage-shaped records that omitted derived ownership metadata, causing all remaining owner badges to disappear until refresh.

## Impact

Each Agent's approval prompt is now visible and actionable only by its owner. Other managers, members, and administrators are rejected by the server. Pending prompts are replayed to authenticated owners when they reconnect. Removing an Agent no longer causes unrelated Agent owner badges to flicker or disappear.

## Validation

- `npx vitest run tests/client/group-chat*.test.ts tests/server/group-chat*.test.ts` — 35 files, 382 tests passed
- `npm run harness:check`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run build`
- `git diff --check`
