### PR TITLE
fix(media): disable Responses storage for image generation

### DIFF
--- a/packages/server/src/controllers/hermes/media.ts
+++ b/packages/server/src/controllers/hermes/media.ts
@@ -408,6 +408,7 @@ async function requestApiKeyImage(provider: ApiKeyImageProvider, mode: ApiKeyIma
       signal: AbortSignal.timeout(timeoutMs),
       body: JSON.stringify({
         model: body.model || provider.model || APIKEY_IMAGE_TO_IMAGE_MODEL,
+        store: false,
         stream: true,
         input: [{
           role: 'user',

--- a/tests/server/media-controller.test.ts
+++ b/tests/server/media-controller.test.ts
@@ -97,4 +97,70 @@ describe('media controller', () => {
       globalThis.fetch = originalFetch
     }
   })
+
+  it('forces response storage off for reference-image generation', async () => {
+    vi.stubEnv('AGNES_API_KEY', 'agnes-secret')
+    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+      getActiveProfileName: () => 'default',
+      getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
+      listProfileNamesFromDisk: () => ['default'],
+    }))
+    vi.doMock('../../packages/server/src/services/config-helpers', () => ({
+      readConfigYamlForProfile: vi.fn(async () => ({
+        custom_providers: [{
+          name: 'agnes',
+          base_url: 'https://agnes.example/v1',
+          api_key_env: 'AGNES_API_KEY',
+          model: 'agnes-image-2.1-flash',
+        }],
+      })),
+    }))
+    const fetchMock = vi.fn(async () => new Response(
+      'data: {"response":{"output":[{"result":"aW1hZ2UtYnl0ZXM="}]} }\n\n',
+      { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+    ))
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchMock as any
+    try {
+      const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx: any = {
+        state: { serverTokenAuth: true },
+        query: {},
+        request: {
+          body: {
+            provider: 'agnes',
+            mode: 'image',
+            prompt: 'redraw this icon',
+            image_base64: 'aW1hZ2UtYnl0ZXM=',
+            mime_type: 'image/png',
+            store: true,
+            output_path: '/tmp/hermes-web-ui-agnes-reference-image.png',
+          },
+        },
+        get: vi.fn(() => ''),
+        status: 200,
+        body: undefined,
+      }
+
+      await apiKeyImageGenerate(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://agnes.example/v1/responses',
+        expect.objectContaining({ method: 'POST' }),
+      )
+      const requestInit = fetchMock.mock.calls[0][1] as RequestInit
+      expect(JSON.parse(String(requestInit.body))).toMatchObject({
+        model: 'agnes-image-2.1-flash',
+        store: false,
+        stream: true,
+        tools: [{
+          type: 'image_generation',
+          model: 'gpt-image-2',
+        }],
+      })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- force `store: false` on the server-generated Responses request used for reference-image generation
- keep response persistence controlled by the server even if a caller supplies `store: true`
- add a regression test that inspects the final outbound `/v1/responses` payload

Closes #2437

## Root cause

The `mode=image` media path rebuilds the upstream Responses payload and previously omitted `store`. Responses-compatible providers that require persistence to be disabled therefore rejected the request with `Store must be set to false`; a caller-provided value could not help because it was not forwarded.

## Testing

Exact candidate after rebasing onto current upstream `main`:

- base: `208f9b66f6011f04c148ec10eb6fddd9c7a7b077`
- head: `1a7416d83ec002c419c2d1ef9ce099245d3f8142`
- tree: `fb83bde5fd502b9472e27da41d531c7d5c532358`
- patch SHA-256: `3ce0a14b21c6d2cdc8d9ba8db0be343677942104fc3f8f94ef95cdf05d54ac9e`

Validation:

- RED: `npx vitest run tests/server/media-controller.test.ts` — failed because the outbound payload omitted `store`
- GREEN on exact head: same command — 3/3 tests passed
- `npm run build` on exact head — passed, including OpenAPI generation, Vue/server typechecks, Vite production build, and server bundle
- `npm run harness:check` on exact head — passed
- GitHub Build check on exact head — passed
- GitHub Playwright E2E check on exact head — passed
- a full local Vitest run was also attempted; its shared host/runtime state caused failures across unrelated modules
- controlled baseline classification then ran the same 29 failing files serially with the same isolated environment against the candidate and its exact base; both snapshots produced the same six environment-sensitive failures, and normalized `(relative path, full test title)` comparison had `current-only failures = 0`
- `git diff --check` — passed
- scoped private-host/credential scan — passed

The changed media controller and regression test do not overlap the six residual baseline failures (`agent-bridge-manager`, `hermes-plugins-env`, `auth`, and `kanban-controller`).