### PR TITLE
fix(group-chat): prevent token accounting from starving the event loop

### DIFF
--- a/docs/chat-chain-changes/2026-08-09-issue-2444-group-chat-token-accounting.md
+++ b/docs/chat-chain-changes/2026-08-09-issue-2444-group-chat-token-accounting.md
@@ -6,3 +6,5 @@ impact: Group Chat message persistence updates the cached context-window token t
 ---
 
 The canonical context window remains 500 messages and preserves ordinary same-timestamp multipart boundaries with a bounded overflow allowance. Pathological same-timestamp floods are capped so a malformed or adversarial room cannot make one persistence turn unbounded. Exact persisted room total semantics remain unchanged for normal-sized messages. Workspace diff messages continue to be excluded from the shared context total.
+
+Cached room totals carry an accounting version. Existing installations receive version `0` through the additive schema migration, and each legacy room is rebuilt from its bounded context window on its first ordinary message write before incremental accounting resumes. New rooms start at the current version; startup does not synchronously retokenize every historical room.

--- a/docs/chat-chain-changes/2026-08-09-issue-2444-group-chat-token-accounting.md
+++ b/docs/chat-chain-changes/2026-08-09-issue-2444-group-chat-token-accounting.md
@@ -2,9 +2,11 @@
 date: 2026-08-09
 pr: 2445
 feature: Bounded Group Chat token accounting
-impact: Group Chat message persistence updates the cached context-window token total incrementally and uses strictly bounded, allocation-safe sampling for oversized text so HTTP health checks remain responsive under arbitrarily large tool results.
+impact: Group Chat message persistence maintains the cached context-window total from canonical stored content and uses allocation-safe linear estimation for oversized text so HTTP health checks remain responsive under production-sized tool results.
 ---
 
-The canonical context window remains 500 messages and preserves ordinary same-timestamp multipart boundaries with a bounded overflow allowance. Pathological same-timestamp floods are capped so a malformed or adversarial room cannot make one persistence turn unbounded. Exact persisted room total semantics remain unchanged for normal-sized messages. Workspace diff messages continue to be excluded from the shared context total.
+The canonical context window remains 500 messages and preserves ordinary same-timestamp multipart boundaries with a bounded overflow allowance. Pathological same-timestamp floods are capped so a malformed or adversarial room cannot make one persistence turn unbounded. Equal-timestamp cursor ordering now uses the same binary string order as SQLite, including mixed-case and non-ASCII IDs. Workspace diff messages continue to be excluded from the shared context total.
 
-Cached room totals carry an accounting version. Existing installations receive version `0` through the additive schema migration, and each legacy room is rebuilt from its bounded context window on its first ordinary message write before incremental accounting resumes. New rooms start at the current version; startup does not synchronously retokenize every historical room.
+Cached room totals carry an accounting version. Existing installations receive version `0` through the additive schema migration, and every legacy-room write path—including new and replayed workspace diffs—rebuilds the bounded context cache before returning it. New rooms start at the current version; startup does not synchronously retokenize every historical room.
+
+Token deltas are charged from the canonical content actually persisted after multimodal/data-image normalization. Oversized token estimation scans without materializing a regex match array or relying on predictable sample positions, preventing adversarial text layouts from hiding most CJK content.

--- a/docs/chat-chain-changes/2026-08-09-issue-2444-group-chat-token-accounting.md
+++ b/docs/chat-chain-changes/2026-08-09-issue-2444-group-chat-token-accounting.md
@@ -1,0 +1,8 @@
+---
+date: 2026-08-09
+pr: pending
+feature: Bounded Group Chat token accounting
+impact: Group Chat message persistence updates the cached context-window token total incrementally and uses bounded estimation for oversized text so HTTP health checks remain responsive under large tool results.
+---
+
+The canonical context window remains 500 messages and preserves ordinary same-timestamp multipart boundaries with a bounded overflow allowance. Pathological same-timestamp floods are capped so a malformed or adversarial room cannot make one persistence turn unbounded. Exact persisted room total semantics remain unchanged for normal-sized messages. Workspace diff messages continue to be excluded from the shared context total.

--- a/docs/chat-chain-changes/2026-08-09-issue-2444-group-chat-token-accounting.md
+++ b/docs/chat-chain-changes/2026-08-09-issue-2444-group-chat-token-accounting.md
@@ -2,7 +2,7 @@
 date: 2026-08-09
 pr: 2445
 feature: Bounded Group Chat token accounting
-impact: Group Chat message persistence updates the cached context-window token total incrementally and uses bounded estimation for oversized text so HTTP health checks remain responsive under large tool results.
+impact: Group Chat message persistence updates the cached context-window token total incrementally and uses strictly bounded, allocation-safe sampling for oversized text so HTTP health checks remain responsive under arbitrarily large tool results.
 ---
 
 The canonical context window remains 500 messages and preserves ordinary same-timestamp multipart boundaries with a bounded overflow allowance. Pathological same-timestamp floods are capped so a malformed or adversarial room cannot make one persistence turn unbounded. Exact persisted room total semantics remain unchanged for normal-sized messages. Workspace diff messages continue to be excluded from the shared context total.

--- a/docs/chat-chain-changes/2026-08-09-issue-2444-group-chat-token-accounting.md
+++ b/docs/chat-chain-changes/2026-08-09-issue-2444-group-chat-token-accounting.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-09
-pr: pending
+pr: 2445
 feature: Bounded Group Chat token accounting
 impact: Group Chat message persistence updates the cached context-window token total incrementally and uses bounded estimation for oversized text so HTTP health checks remain responsive under large tool results.
 ---

--- a/docs/chat-chain-changes/2026-08-09-pr-2445-authoritative-room-token-cache.md
+++ b/docs/chat-chain-changes/2026-08-09-pr-2445-authoritative-room-token-cache.md
@@ -1,0 +1,8 @@
+---
+date: 2026-08-09
+pr: 2445
+feature: Authoritative Group Chat token cache ownership
+impact: Agent context-status side-channel events remain available for live status UI but no longer overwrite the persisted bounded Room context-window token total.
+---
+
+Room token totals are now written only by the persisted message-accounting path. Agent-local context status can represent a different session or accounting window, so accepting its `totalTokens` value would corrupt the versioned incremental cache and make later message deltas start from the wrong base.

--- a/docs/chat-chain-changes/2026-08-09-pr2445-group-chat-token-accounting.md
+++ b/docs/chat-chain-changes/2026-08-09-pr2445-group-chat-token-accounting.md
@@ -1,0 +1,9 @@
+---
+date: 2026-08-09
+pr: 2445
+commit: pending
+feature: Group Chat 大工具结果 token 记账与确定性消息游标
+impact: 超大消息的 token fallback 在固定工作量内返回保守估算，避免随输入长度线性阻塞 Node 主线程；Group Chat canonical ID 排序与 SQLite UTF-8 BINARY 顺序一致，避免补充平面 Unicode 游标漏消息；实时 mention 路由继续保留 absent metadata 为 undefined。
+---
+
+本次在已有增量 token cache 修复上补齐终审发现的边界：超过 8 Mi UTF-16 code units 的估算不再扫描全文；等时间戳消息以 UTF-8 bytes 比较 ID；`upsertMessage()` 返回规范化持久化内容的同时保持调用方 structured mentions 三态语义。

--- a/docs/chat-chain-changes/2026-08-09-pr2445-group-chat-token-accounting.md
+++ b/docs/chat-chain-changes/2026-08-09-pr2445-group-chat-token-accounting.md
@@ -6,4 +6,4 @@ feature: Group Chat 大工具结果 token 记账与确定性消息游标
 impact: 超大消息在 Group Chat 持久化记账与 Ekko Agent 请求用量估算两条链路中都以固定工作量返回保守估算，避免随输入长度线性阻塞 Node 主线程；Group Chat canonical ID 排序与 SQLite UTF-8 BINARY 顺序一致，避免补充平面 Unicode 游标漏消息；实时 mention 路由继续保留 absent metadata 为 undefined。
 ---
 
-本次在已有增量 token cache 修复上补齐终审发现的边界：超过 8 Mi UTF-16 code units 的估算不再扫描全文；等时间戳消息以 UTF-8 bytes 比较 ID；`upsertMessage()` 返回规范化持久化内容的同时保持调用方 structured mentions 三态语义。
+本次在已有增量 token cache 修复上补齐终审发现的边界：Group Chat 持久化记账与 Ekko Agent 请求用量估算都在超过 8 Mi UTF-16 code units 后使用基于 UTF-8 byte 上界的常数时间保守估算；等时间戳消息以 UTF-8 bytes 比较 ID；`upsertMessage()` 返回规范化持久化内容的同时保持调用方 structured mentions 三态语义。

--- a/docs/chat-chain-changes/2026-08-09-pr2445-group-chat-token-accounting.md
+++ b/docs/chat-chain-changes/2026-08-09-pr2445-group-chat-token-accounting.md
@@ -3,7 +3,7 @@ date: 2026-08-09
 pr: 2445
 commit: pending
 feature: Group Chat 大工具结果 token 记账与确定性消息游标
-impact: 超大消息的 token fallback 在固定工作量内返回保守估算，避免随输入长度线性阻塞 Node 主线程；Group Chat canonical ID 排序与 SQLite UTF-8 BINARY 顺序一致，避免补充平面 Unicode 游标漏消息；实时 mention 路由继续保留 absent metadata 为 undefined。
+impact: 超大消息在 Group Chat 持久化记账与 Ekko Agent 请求用量估算两条链路中都以固定工作量返回保守估算，避免随输入长度线性阻塞 Node 主线程；Group Chat canonical ID 排序与 SQLite UTF-8 BINARY 顺序一致，避免补充平面 Unicode 游标漏消息；实时 mention 路由继续保留 absent metadata 为 undefined。
 ---
 
 本次在已有增量 token cache 修复上补齐终审发现的边界：超过 8 Mi UTF-16 code units 的估算不再扫描全文；等时间戳消息以 UTF-8 bytes 比较 ID；`upsertMessage()` 返回规范化持久化内容的同时保持调用方 structured mentions 三态语义。

--- a/packages/ekko-agent/src/model/tokens.ts
+++ b/packages/ekko-agent/src/model/tokens.ts
@@ -17,18 +17,8 @@ export function countTextTokens(text: string): number {
 }
 
 function heuristicTokens(text: string): number {
-  if (text.length > MAX_HEURISTIC_SCAN_TEXT_UNITS) return Math.ceil(text.length * 1.5)
-  let cjk = 0
-  for (let index = 0; index < text.length; index += 1) {
-    const code = text.charCodeAt(index)
-    if (
-      (code >= 0x2e80 && code <= 0x9fff)
-      || (code >= 0xac00 && code <= 0xd7af)
-      || (code >= 0x3000 && code <= 0x303f)
-      || (code >= 0xff00 && code <= 0xffef)
-    ) cjk += 1
-  }
-  return Math.ceil(cjk * 1.5 + (text.length - cjk) / 4)
+  if (text.length > MAX_HEURISTIC_SCAN_TEXT_UNITS) return text.length * 3
+  return Buffer.byteLength(text, 'utf8')
 }
 
 function exceedsExactTokenBudget(text: string): boolean {

--- a/packages/ekko-agent/src/model/tokens.ts
+++ b/packages/ekko-agent/src/model/tokens.ts
@@ -1,11 +1,13 @@
 import { getEncoding } from 'js-tiktoken'
 
 const MAX_LETTER_RUN = 2_000
+const MAX_EXACT_TOKEN_TEXT_BYTES = 256 * 1024
+const MAX_HEURISTIC_SCAN_TEXT_UNITS = 8 * 1024 * 1024
 let cachedEncoder: ReturnType<typeof getEncoding> | null = null
 
 export function countTextTokens(text: string): number {
   if (!text) return 0
-  if (hasPathologicalRun(text)) return heuristicTokens(text)
+  if (exceedsExactTokenBudget(text) || hasPathologicalRun(text)) return heuristicTokens(text)
   try {
     if (!cachedEncoder) cachedEncoder = getEncoding('cl100k_base')
     return cachedEncoder.encode(text).length
@@ -15,9 +17,24 @@ export function countTextTokens(text: string): number {
 }
 
 function heuristicTokens(text: string): number {
-  const cjk = (text.match(/[\u2e80-\u9fff\uac00-\ud7af\u3000-\u303f\uff00-\uffef]/g) || []).length
-  const other = text.length - cjk
-  return Math.ceil(cjk * 1.5 + other / 4)
+  if (text.length > MAX_HEURISTIC_SCAN_TEXT_UNITS) return Math.ceil(text.length * 1.5)
+  let cjk = 0
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index)
+    if (
+      (code >= 0x2e80 && code <= 0x9fff)
+      || (code >= 0xac00 && code <= 0xd7af)
+      || (code >= 0x3000 && code <= 0x303f)
+      || (code >= 0xff00 && code <= 0xffef)
+    ) cjk += 1
+  }
+  return Math.ceil(cjk * 1.5 + (text.length - cjk) / 4)
+}
+
+function exceedsExactTokenBudget(text: string): boolean {
+  if (text.length > MAX_EXACT_TOKEN_TEXT_BYTES) return true
+  return text.length > MAX_EXACT_TOKEN_TEXT_BYTES / 3
+    && Buffer.byteLength(text, 'utf8') > MAX_EXACT_TOKEN_TEXT_BYTES
 }
 
 function hasPathologicalRun(text: string): boolean {

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -1304,12 +1304,17 @@ export function initAllHermesTables(): void {
 
     // Group chat - basic tables
     syncTable(GC_ROOMS_TABLE, GC_ROOMS_SCHEMA)
+    const groupChatMessageIndexes = {
+      idx_gc_messages_context_window:
+        "CREATE INDEX IF NOT EXISTS idx_gc_messages_context_window ON gc_messages(roomId, timestamp DESC, id DESC) WHERE COALESCE(tool_name, '') <> 'workspace_diff'",
+    }
     syncTable(GC_MESSAGES_TABLE, GC_MESSAGES_SCHEMA, {
-      indexes: {
-        idx_gc_messages_context_window:
-          "CREATE INDEX idx_gc_messages_context_window ON gc_messages(roomId, timestamp DESC, id DESC) WHERE COALESCE(tool_name, '') <> 'workspace_diff'",
-      },
+      indexes: groupChatMessageIndexes,
     })
+    // syncTable() creates indexes for new tables only. Existing installations
+    // need the context-window index migrated explicitly to avoid scanning and
+    // sorting the full message table on every persisted message.
+    createIndexes(db, groupChatMessageIndexes)
     syncTable(GC_ACTIVITY_MIGRATIONS_TABLE, GC_ACTIVITY_MIGRATIONS_SCHEMA)
     migrateGroupChatActivityTimes(db, Date.now())
     syncTable(GC_CONTEXT_SNAPSHOTS_TABLE, GC_CONTEXT_SNAPSHOTS_SCHEMA)

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -1304,7 +1304,12 @@ export function initAllHermesTables(): void {
 
     // Group chat - basic tables
     syncTable(GC_ROOMS_TABLE, GC_ROOMS_SCHEMA)
-    syncTable(GC_MESSAGES_TABLE, GC_MESSAGES_SCHEMA)
+    syncTable(GC_MESSAGES_TABLE, GC_MESSAGES_SCHEMA, {
+      indexes: {
+        idx_gc_messages_context_window:
+          "CREATE INDEX idx_gc_messages_context_window ON gc_messages(roomId, timestamp DESC, id DESC) WHERE COALESCE(tool_name, '') <> 'workspace_diff'",
+      },
+    })
     syncTable(GC_ACTIVITY_MIGRATIONS_TABLE, GC_ACTIVITY_MIGRATIONS_SCHEMA)
     migrateGroupChatActivityTimes(db, Date.now())
     syncTable(GC_CONTEXT_SNAPSHOTS_TABLE, GC_CONTEXT_SNAPSHOTS_SCHEMA)

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -581,6 +581,7 @@ export const GC_ROOMS_SCHEMA: Record<string, string> = {
   maxHistoryTokens: 'INTEGER NOT NULL DEFAULT 32000',
   tailMessageCount: 'INTEGER NOT NULL DEFAULT 10',
   totalTokens: 'INTEGER NOT NULL DEFAULT 0',
+  tokenAccountingVersion: 'INTEGER NOT NULL DEFAULT 0',
   sessionSeed: "TEXT NOT NULL DEFAULT '0'",
   workspace: "TEXT NOT NULL DEFAULT ''",
   ownerAuthUserId: 'INTEGER',

--- a/packages/server/src/lib/context-compressor/index.ts
+++ b/packages/server/src/lib/context-compressor/index.ts
@@ -176,9 +176,6 @@ function hasPathologicalRun(text: string): boolean {
   return false
 }
 
-const MAX_HEURISTIC_SAMPLE_CHARS = 64 * 1024
-const HEURISTIC_SAMPLE_BLOCKS = 256
-
 function isCjkCodeUnit(code: number): boolean {
   return (code >= 0x2e80 && code <= 0x9fff)
     || (code >= 0xac00 && code <= 0xd7af)
@@ -187,25 +184,12 @@ function isCjkCodeUnit(code: number): boolean {
 }
 
 function heuristicTokens(text: string): number {
-  const sampleLength = Math.min(text.length, MAX_HEURISTIC_SAMPLE_CHARS)
-  if (sampleLength === 0) return 0
+  if (text.length === 0) return 0
   let cjk = 0
-  if (sampleLength === text.length) {
-    for (let i = 0; i < sampleLength; i += 1) {
-      if (isCjkCodeUnit(text.charCodeAt(i))) cjk += 1
-    }
-  } else {
-    const blockCount = Math.min(HEURISTIC_SAMPLE_BLOCKS, sampleLength)
-    const blockLength = Math.floor(sampleLength / blockCount)
-    for (let block = 0; block < blockCount; block += 1) {
-      const segmentStart = Math.floor(block * text.length / blockCount)
-      for (let offset = 0; offset < blockLength; offset += 1) {
-        if (isCjkCodeUnit(text.charCodeAt(segmentStart + offset))) cjk += 1
-      }
-    }
+  for (let i = 0; i < text.length; i += 1) {
+    if (isCjkCodeUnit(text.charCodeAt(i))) cjk += 1
   }
-  const weightedSample = cjk * 1.5 + (sampleLength - cjk) / 4
-  return Math.ceil(weightedSample * (text.length / sampleLength))
+  return Math.ceil(cjk * 1.5 + (text.length - cjk) / 4)
 }
 
 export function countTokens(text: string): number {

--- a/packages/server/src/lib/context-compressor/index.ts
+++ b/packages/server/src/lib/context-compressor/index.ts
@@ -146,6 +146,19 @@ function getEncoder() {
 // pathological case up front and use the cheap heuristic instead. Normal text
 // (even very long, but space-separated) keeps the exact tiktoken path.
 const MAX_LETTER_RUN = 2000
+// Exact js-tiktoken encoding is synchronous. Even well-separated text takes
+// seconds once tool output reaches megabyte scale, starving unrelated HTTP
+// requests on the server thread. Token totals are estimates, so cap exact
+// encoding to a bounded input size and use the existing linear heuristic above
+// it. Normal prompts and the existing 50 KB exact-tokenizer coverage remain
+// unchanged.
+const MAX_EXACT_TOKEN_TEXT_BYTES = 256 * 1024
+
+function exceedsExactTokenBudget(text: string): boolean {
+  if (text.length > MAX_EXACT_TOKEN_TEXT_BYTES) return true
+  return text.length > MAX_EXACT_TOKEN_TEXT_BYTES / 3
+    && Buffer.byteLength(text, 'utf8') > MAX_EXACT_TOKEN_TEXT_BYTES
+}
 
 function hasPathologicalRun(text: string): boolean {
   let maxRun = 0
@@ -170,7 +183,7 @@ function heuristicTokens(text: string): number {
 }
 
 export function countTokens(text: string): number {
-  if (hasPathologicalRun(text)) return heuristicTokens(text)
+  if (exceedsExactTokenBudget(text) || hasPathologicalRun(text)) return heuristicTokens(text)
   try {
     return getEncoder().encode(text).length
   } catch {
@@ -179,7 +192,7 @@ export function countTokens(text: string): number {
 }
 
 export function countTokensForModel(text: string, model: string): number {
-  if (hasPathologicalRun(text)) return heuristicTokens(text)
+  if (exceedsExactTokenBudget(text) || hasPathologicalRun(text)) return heuristicTokens(text)
   try {
     const enc = encodingForModel(model as any)
     return enc.encode(text).length

--- a/packages/server/src/lib/context-compressor/index.ts
+++ b/packages/server/src/lib/context-compressor/index.ts
@@ -182,21 +182,16 @@ function hasPathologicalRun(text: string): boolean {
   return false
 }
 
-function isCjkCodeUnit(code: number): boolean {
-  return (code >= 0x2e80 && code <= 0x9fff)
-    || (code >= 0xac00 && code <= 0xd7af)
-    || (code >= 0x3000 && code <= 0x303f)
-    || (code >= 0xff00 && code <= 0xffef)
-}
-
 function heuristicTokens(text: string): number {
   if (text.length === 0) return 0
-  if (text.length > MAX_HEURISTIC_SCAN_TEXT_UNITS) return Math.ceil(text.length * 1.5)
-  let cjk = 0
-  for (let i = 0; i < text.length; i += 1) {
-    if (isCjkCodeUnit(text.charCodeAt(i))) cjk += 1
-  }
-  return Math.ceil(cjk * 1.5 + (text.length - cjk) / 4)
+  // A tokenizer cannot emit more tokens than the UTF-8 byte sequence contains:
+  // each token consumes at least one byte. Buffer.byteLength is bounded by the
+  // 8 Mi code-unit gate; above it, three bytes per UTF-16 code unit is a safe
+  // constant-time upper bound (including unpaired surrogates; valid pairs use
+  // four bytes for two units). This avoids both adversarial underestimation and
+  // unbounded main-thread scans.
+  if (text.length > MAX_HEURISTIC_SCAN_TEXT_UNITS) return text.length * 3
+  return Buffer.byteLength(text, 'utf8')
 }
 
 export function countTokens(text: string): number {

--- a/packages/server/src/lib/context-compressor/index.ts
+++ b/packages/server/src/lib/context-compressor/index.ts
@@ -176,10 +176,36 @@ function hasPathologicalRun(text: string): boolean {
   return false
 }
 
+const MAX_HEURISTIC_SAMPLE_CHARS = 64 * 1024
+const HEURISTIC_SAMPLE_BLOCKS = 256
+
+function isCjkCodeUnit(code: number): boolean {
+  return (code >= 0x2e80 && code <= 0x9fff)
+    || (code >= 0xac00 && code <= 0xd7af)
+    || (code >= 0x3000 && code <= 0x303f)
+    || (code >= 0xff00 && code <= 0xffef)
+}
+
 function heuristicTokens(text: string): number {
-  const cjk = (text.match(/[\u2e80-\u9fff\uac00-\ud7af\u3000-\u303f\uff00-\uffef]/g) || []).length
-  const other = text.length - cjk
-  return Math.ceil(cjk * 1.5 + other / 4)
+  const sampleLength = Math.min(text.length, MAX_HEURISTIC_SAMPLE_CHARS)
+  if (sampleLength === 0) return 0
+  let cjk = 0
+  if (sampleLength === text.length) {
+    for (let i = 0; i < sampleLength; i += 1) {
+      if (isCjkCodeUnit(text.charCodeAt(i))) cjk += 1
+    }
+  } else {
+    const blockCount = Math.min(HEURISTIC_SAMPLE_BLOCKS, sampleLength)
+    const blockLength = Math.floor(sampleLength / blockCount)
+    for (let block = 0; block < blockCount; block += 1) {
+      const segmentStart = Math.floor(block * text.length / blockCount)
+      for (let offset = 0; offset < blockLength; offset += 1) {
+        if (isCjkCodeUnit(text.charCodeAt(segmentStart + offset))) cjk += 1
+      }
+    }
+  }
+  const weightedSample = cjk * 1.5 + (sampleLength - cjk) / 4
+  return Math.ceil(weightedSample * (text.length / sampleLength))
 }
 
 export function countTokens(text: string): number {

--- a/packages/server/src/lib/context-compressor/index.ts
+++ b/packages/server/src/lib/context-compressor/index.ts
@@ -153,6 +153,12 @@ const MAX_LETTER_RUN = 2000
 // it. Normal prompts and the existing 50 KB exact-tokenizer coverage remain
 // unchanged.
 const MAX_EXACT_TOKEN_TEXT_BYTES = 256 * 1024
+// Keep fallback work bounded even when an internal tool or bridge hands us a
+// very large string. Up to this limit we scan the complete distribution for a
+// useful estimate. Above it we use the conservative all-CJK upper estimate;
+// this is O(1), deterministic, and cannot be defeated by an adversarial sample
+// layout. The persisted content is not changed by token accounting.
+const MAX_HEURISTIC_SCAN_TEXT_UNITS = 8 * 1024 * 1024
 
 function exceedsExactTokenBudget(text: string): boolean {
   if (text.length > MAX_EXACT_TOKEN_TEXT_BYTES) return true
@@ -185,6 +191,7 @@ function isCjkCodeUnit(code: number): boolean {
 
 function heuristicTokens(text: string): number {
   if (text.length === 0) return 0
+  if (text.length > MAX_HEURISTIC_SCAN_TEXT_UNITS) return Math.ceil(text.length * 1.5)
   let cjk = 0
   for (let i = 0; i < text.length; i += 1) {
     if (isCjkCodeUnit(text.charCodeAt(i))) cjk += 1

--- a/packages/server/src/services/hermes/group-chat/group-message-ordering.ts
+++ b/packages/server/src/services/hermes/group-chat/group-message-ordering.ts
@@ -40,6 +40,10 @@ export function groupRunOrder(id: string): { baseId: string; phase: number } {
     return { baseId: value, phase: 2 }
 }
 
+function compareStorageIds(a: string, b: string): number {
+    return a < b ? -1 : a > b ? 1 : 0
+}
+
 export function sortGroupMessagesCanonical<T extends CanonicalGroupMessage>(messages: readonly T[]): T[] {
     const baseMinTimestamp = new Map<string, number>()
     for (const msg of messages) {
@@ -53,10 +57,10 @@ export function sortGroupMessagesCanonical<T extends CanonicalGroupMessage>(mess
         const at = baseMinTimestamp.get(ao.baseId) ?? a.timestamp
         const bt = baseMinTimestamp.get(bo.baseId) ?? b.timestamp
         if (at !== bt) return at - bt
-        if (ao.baseId !== bo.baseId) return ao.baseId.localeCompare(bo.baseId)
+        if (ao.baseId !== bo.baseId) return compareStorageIds(ao.baseId, bo.baseId)
         if (ao.phase !== bo.phase) return ao.phase - bo.phase
         if (a.timestamp !== b.timestamp) return a.timestamp - b.timestamp
-        return a.id.localeCompare(b.id)
+        return compareStorageIds(a.id, b.id)
     })
 }
 

--- a/packages/server/src/services/hermes/group-chat/group-message-ordering.ts
+++ b/packages/server/src/services/hermes/group-chat/group-message-ordering.ts
@@ -41,7 +41,11 @@ export function groupRunOrder(id: string): { baseId: string; phase: number } {
 }
 
 function compareStorageIds(a: string, b: string): number {
-    return a < b ? -1 : a > b ? 1 : 0
+    // SQLite's default BINARY collation compares the UTF-8 bytes stored in
+    // TEXT values. JavaScript relational comparison uses UTF-16 code units,
+    // which disagrees for supplementary-plane characters versus some BMP
+    // characters and can make SQL cursor prefilters silently drop messages.
+    return Buffer.compare(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'))
 }
 
 export function sortGroupMessagesCanonical<T extends CanonicalGroupMessage>(messages: readonly T[]): T[] {

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -444,6 +444,7 @@ function maxAgentMentionDepth(): number {
 }
 
 const GROUP_CHAT_MESSAGE_WINDOW = 500
+const GROUP_CHAT_TIMESTAMP_BOUNDARY_OVERFLOW = 100
 
 class ChatStorage {
     private roomAgentOnlineProvider: ((roomId: string, agentId: string) => boolean) | null = null
@@ -874,28 +875,14 @@ class ChatStorage {
         return String(content)
     }
 
-    private estimateUsageTokensFromMessages(messages: ChatMessage[]): { inputTokens: number; outputTokens: number } {
-        const inputTokens = messages
-            .filter(m => (m.role || 'user') === 'user')
-            .reduce((sum, m) => sum + countTokens(this.contentToUsageText(m.content)), 0)
-        const outputTokens = messages
-            .filter(m => m.role === 'assistant' || m.role === 'tool')
-            .reduce((sum, m) => {
-                const reasoning = (m as { reasoning_content?: unknown; reasoning?: unknown }).reasoning_content
-                    ?? (m as { reasoning?: unknown }).reasoning
-                return (
-                    sum
-                    + countTokens(this.contentToUsageText(m.content))
-                    + countTokens(String(m.tool_calls || ''))
-                    + countTokens(String(reasoning || ''))
-                )
-            }, 0)
-        return { inputTokens, outputTokens }
-    }
-
-    private estimateRoomTotalTokens(roomId: string, messages: ChatMessage[]): number {
-        const usage = this.estimateUsageTokensFromMessages(messages)
-        return usage.inputTokens + usage.outputTokens
+    private messageUsageTokens(message: Pick<ChatMessage, 'role' | 'content' | 'tool_calls' | 'reasoning' | 'reasoning_content'>): number {
+        const role = message.role || 'user'
+        if (role === 'user') return countTokens(this.contentToUsageText(message.content))
+        if (role !== 'assistant' && role !== 'tool') return 0
+        const reasoning = message.reasoning_content ?? message.reasoning
+        return countTokens(this.contentToUsageText(message.content))
+            + countTokens(String(message.tool_calls || ''))
+            + countTokens(String(reasoning || ''))
     }
 
     // ─── Messages ─────────────────────────────────────────────
@@ -933,8 +920,14 @@ class ChatStorage {
         ).get(...params, boundedLimit - 1) as { timestamp: number } | undefined
         return db.prepare(
             `SELECT ${MESSAGE_SELECT_COLUMNS} FROM gc_messages
-             WHERE ${predicate}${boundary ? ' AND timestamp >= ?' : ''}`
-        ).all(...params, ...(boundary ? [boundary.timestamp] : [])) as any[]
+             WHERE ${predicate}${boundary ? ' AND timestamp >= ?' : ''}
+             ORDER BY timestamp DESC, id DESC
+             LIMIT ?`
+        ).all(
+            ...params,
+            ...(boundary ? [boundary.timestamp] : []),
+            boundedLimit + GROUP_CHAT_TIMESTAMP_BOUNDARY_OVERFLOW,
+        ) as any[]
     }
 
     getRecentMessagesForUI(roomId: string, limit = 150, offset = 0): ChatMessage[] {
@@ -1105,15 +1098,61 @@ class ChatStorage {
                 tool_name: 'workspace_diff',
             }
             const storedMessage = this.upsertMessage(message)
-            const messages = this.getMessagesForContext(args.roomId)
-            const totalTokens = this.estimateRoomTotalTokens(args.roomId, messages)
-            this.updateRoomTotalTokens(args.roomId, totalTokens)
+            // workspace_diff messages are deliberately excluded from the shared
+            // context window, so they cannot change its token total.
+            const totalTokens = Number(this.getRoom(args.roomId)?.totalTokens || 0)
             db.exec('COMMIT')
             return { message: storedMessage, totalTokens, change }
         } catch (err) {
             try { db.exec('ROLLBACK') } catch { /* ignore */ }
             throw err
         }
+    }
+
+    private contextWindowMessageIdsForTokenDelta(roomId: string): string[] {
+        const db = this.db()
+        if (!db) return []
+        const boundary = db.prepare(
+            `SELECT timestamp FROM gc_messages
+             WHERE roomId = ? AND COALESCE(tool_name, '') <> 'workspace_diff'
+             ORDER BY timestamp DESC, id DESC
+             LIMIT 1 OFFSET ?`,
+        ).get(roomId, GROUP_CHAT_MESSAGE_WINDOW - 1) as { timestamp: number } | undefined
+        const rows = db.prepare(
+            `SELECT id FROM gc_messages
+             WHERE roomId = ? AND COALESCE(tool_name, '') <> 'workspace_diff'${boundary ? ' AND timestamp >= ?' : ''}
+             ORDER BY timestamp DESC, id DESC
+             LIMIT ?`,
+        ).all(
+            roomId,
+            ...(boundary ? [boundary.timestamp] : []),
+            GROUP_CHAT_MESSAGE_WINDOW + GROUP_CHAT_TIMESTAMP_BOUNDARY_OVERFLOW,
+        ) as Array<{ id: string }>
+        return rows.map(row => String(row.id))
+    }
+
+    private incrementalRoomTotalTokens(
+        roomId: string,
+        changedMessageId: string,
+        existing: ChatMessage | null,
+        storedMessage: ChatMessage,
+        previousIds: string[],
+        nextIds: string[],
+    ): number {
+        const previous = new Set(previousIds)
+        const next = new Set(nextIds)
+        let total = Number(this.getRoom(roomId)?.totalTokens || 0)
+        for (const id of previous) {
+            if (next.has(id) && id !== changedMessageId) continue
+            const message = id === changedMessageId ? existing : this.getMessage(id)
+            if (message) total -= this.messageUsageTokens(message)
+        }
+        for (const id of next) {
+            if (previous.has(id) && id !== changedMessageId) continue
+            const message = id === changedMessageId ? storedMessage : this.getMessage(id)
+            if (message) total += this.messageUsageTokens(message)
+        }
+        return Math.max(0, total)
     }
 
     saveMessageAndRefreshRoom(msg: ChatMessage, options: { preserveExistingTimestamp?: boolean } = {}): { message: ChatMessage; totalTokens: number } {
@@ -1123,18 +1162,25 @@ class ChatStorage {
         try {
             const existing = this.getMessage(msg.id)
             if (existing?.tool_name === 'workspace_diff') {
-                const messages = this.getMessagesForContext(existing.roomId)
-                const totalTokens = this.estimateRoomTotalTokens(existing.roomId, messages)
+                const totalTokens = Number(this.getRoom(existing.roomId)?.totalTokens || 0)
                 db.exec('COMMIT')
                 return { message: existing, totalTokens }
             }
+            const previousIds = this.contextWindowMessageIdsForTokenDelta(msg.roomId)
             const safeMsg = msg.tool_name === 'workspace_diff'
                 ? { ...msg, role: 'user', tool_call_id: null, tool_calls: null, tool_name: null }
                 : msg
             const message = existing && options.preserveExistingTimestamp ? { ...safeMsg, timestamp: existing.timestamp } : safeMsg
             const storedMessage = this.upsertMessage(message, existing)
-            const messages = this.getMessagesForContext(msg.roomId)
-            const totalTokens = this.estimateRoomTotalTokens(msg.roomId, messages)
+            const nextIds = this.contextWindowMessageIdsForTokenDelta(msg.roomId)
+            const totalTokens = this.incrementalRoomTotalTokens(
+                msg.roomId,
+                storedMessage.id,
+                existing,
+                storedMessage,
+                previousIds,
+                nextIds,
+            )
             this.updateRoomTotalTokens(msg.roomId, totalTokens)
             db.exec('COMMIT')
             return { message: storedMessage, totalTokens }

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -242,6 +242,7 @@ export interface RoomInfo {
     maxHistoryTokens: number
     tailMessageCount: number
     totalTokens: number
+    tokenAccountingVersion: number
     sessionSeed: string
     workspace: string
     ownerAuthUserId: number | null
@@ -266,6 +267,7 @@ const ROOM_SELECT_COLUMNS = [
     'maxHistoryTokens',
     'tailMessageCount',
     'totalTokens',
+    'tokenAccountingVersion',
     'sessionSeed',
     'workspace',
     'ownerAuthUserId',
@@ -445,6 +447,7 @@ function maxAgentMentionDepth(): number {
 
 const GROUP_CHAT_MESSAGE_WINDOW = 500
 const GROUP_CHAT_TIMESTAMP_BOUNDARY_OVERFLOW = 100
+const GROUP_CHAT_TOKEN_ACCOUNTING_VERSION = 1
 
 class ChatStorage {
     private roomAgentOnlineProvider: ((roomId: string, agentId: string) => boolean) | null = null
@@ -766,8 +769,9 @@ class ChatStorage {
         this.db()?.prepare(
             `INSERT OR IGNORE INTO gc_rooms (
                 id, name, inviteCode, summaryProfile, summaryProvider, summaryModel,
-                summaryApiMode, summaryEveryTurns, workspace, ownerAuthUserId, createdAt
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+                summaryApiMode, summaryEveryTurns, workspace, ownerAuthUserId, createdAt,
+                tokenAccountingVersion
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         ).run(
             id,
             name,
@@ -780,6 +784,7 @@ class ChatStorage {
             config?.workspace || '',
             ownerAuthUserId,
             Date.now(),
+            GROUP_CHAT_TOKEN_ACCOUNTING_VERSION,
         )
     }
 
@@ -1131,6 +1136,24 @@ class ChatStorage {
         return rows.map(row => String(row.id))
     }
 
+    private ensureCurrentRoomTokenAccounting(roomId: string): void {
+        const db = this.db()
+        if (!db) return
+        const room = db.prepare(
+            'SELECT tokenAccountingVersion FROM gc_rooms WHERE id = ?',
+        ).get(roomId) as { tokenAccountingVersion: number } | undefined
+        if (!room || Number(room.tokenAccountingVersion) >= GROUP_CHAT_TOKEN_ACCOUNTING_VERSION) return
+
+        const totalTokens = this.contextWindowMessageIdsForTokenDelta(roomId)
+            .reduce((total, id) => {
+                const message = this.getMessage(id)
+                return total + (message ? this.messageUsageTokens(message) : 0)
+            }, 0)
+        db.prepare(
+            'UPDATE gc_rooms SET totalTokens = ?, tokenAccountingVersion = ? WHERE id = ?',
+        ).run(totalTokens, GROUP_CHAT_TOKEN_ACCOUNTING_VERSION, roomId)
+    }
+
     private incrementalRoomTotalTokens(
         roomId: string,
         changedMessageId: string,
@@ -1167,6 +1190,8 @@ class ChatStorage {
                 return { message: existing, totalTokens }
             }
             const movedFromRoomId = existing && existing.roomId !== msg.roomId ? existing.roomId : null
+            this.ensureCurrentRoomTokenAccounting(msg.roomId)
+            if (movedFromRoomId) this.ensureCurrentRoomTokenAccounting(movedFromRoomId)
             const previousSourceIds = movedFromRoomId
                 ? this.contextWindowMessageIdsForTokenDelta(movedFromRoomId)
                 : null

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -1031,13 +1031,19 @@ class ChatStorage {
             storedMessage.reasoning_details ?? null,
             storedMessage.reasoning_content ?? null,
         )
-        return this.mapStoredMessageRow({
+        const persistedMessage = this.mapStoredMessageRow({
             ...storedMessage,
             content: persistedContent,
             persistedAt,
             mentions: mentionsJson,
             tool_calls: toolCallsJson,
         })
+        // The storage column is historically NOT NULL and stores absent
+        // metadata as "[]". Preserve the caller-visible three-state protocol
+        // for the live routing path even though the on-disk representation is
+        // legacy-compatible.
+        if (storedMessage.mentions === undefined) persistedMessage.mentions = undefined
+        return persistedMessage
     }
 
     saveWorkspaceDiffMessageForRun(args: SaveWorkspaceDiffMessageArgs): { message: ChatMessage; totalTokens: number; change: WorkspaceRunChangeSummary } | null {

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -983,6 +983,8 @@ class ChatStorage {
         const storedMessage = this.snapshotMessageSender(msg, existing ?? this.getMessage(msg.id))
         const toolCallsJson = storedMessage.tool_calls ? JSON.stringify(storedMessage.tool_calls) : null
         const mentionsJson = JSON.stringify(storedMessage.mentions || [])
+        const persistedContent = messageContentForStorage(storedMessage.role, storedMessage.content)
+        const persistedAt = storedMessage.persistedAt ?? Date.now()
         this.db()?.prepare(
             `INSERT INTO gc_messages (
                 id, roomId, senderId, senderName, senderType, senderAgentRecordId,
@@ -1015,9 +1017,9 @@ class ChatStorage {
             storedMessage.senderName,
             storedMessage.senderType || 'member',
             storedMessage.senderAgentRecordId || '',
-            messageContentForStorage(storedMessage.role, storedMessage.content),
+            persistedContent,
             storedMessage.timestamp,
-            storedMessage.persistedAt ?? Date.now(),
+            persistedAt,
             mentionsJson,
             storedMessage.run_id ?? null,
             storedMessage.role || 'user',
@@ -1029,7 +1031,13 @@ class ChatStorage {
             storedMessage.reasoning_details ?? null,
             storedMessage.reasoning_content ?? null,
         )
-        return this.mapStoredMessageRow(storedMessage)
+        return this.mapStoredMessageRow({
+            ...storedMessage,
+            content: persistedContent,
+            persistedAt,
+            mentions: mentionsJson,
+            tool_calls: toolCallsJson,
+        })
     }
 
     saveWorkspaceDiffMessageForRun(args: SaveWorkspaceDiffMessageArgs): { message: ChatMessage; totalTokens: number; change: WorkspaceRunChangeSummary } | null {
@@ -1186,6 +1194,7 @@ class ChatStorage {
         try {
             const existing = this.getMessage(msg.id)
             if (existing?.tool_name === 'workspace_diff') {
+                this.ensureCurrentRoomTokenAccounting(existing.roomId)
                 const totalTokens = Number(this.getRoom(existing.roomId)?.totalTokens || 0)
                 db.exec('COMMIT')
                 return { message: existing, totalTokens }

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -1047,6 +1047,7 @@ class ChatStorage {
                 db.exec('ROLLBACK')
                 return null
             }
+            this.ensureCurrentRoomTokenAccounting(args.roomId)
             const workspaceLabel = basename(args.workspace) || 'workspace'
             const redactedDraft: SaveWorkspaceRunChangeInput = {
                 ...args.draft,

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -903,11 +903,11 @@ class ChatStorage {
         }
         if (options.throughMessageId) {
             const through = db.prepare(
-                'SELECT timestamp FROM gc_messages WHERE roomId = ? AND id = ?'
-            ).get(roomId, options.throughMessageId) as { timestamp: number } | undefined
+                'SELECT timestamp, id FROM gc_messages WHERE roomId = ? AND id = ?'
+            ).get(roomId, options.throughMessageId) as { timestamp: number; id: string } | undefined
             if (through) {
-                where.push('timestamp <= ?')
-                params.push(through.timestamp)
+                where.push('(timestamp, id) <= (?, ?)')
+                params.push(through.timestamp, through.id)
             }
         }
 

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -3005,11 +3005,6 @@ export class GroupChatServer {
             agentName,
             status,
         })
-
-        if (typeof data.totalTokens === 'number' && Number.isFinite(data.totalTokens) && data.totalTokens >= 0) {
-            this.storage.updateRoomTotalTokens(roomId, Math.floor(data.totalTokens))
-            this.nsp.to(roomId).emit('room_updated', { roomId, totalTokens: Math.floor(data.totalTokens) })
-        }
     }
 
     private async handleInterruptAgent(socket: Socket, data: { roomId?: string; agentName?: string }, ack?: (response?: unknown) => void): Promise<void> {

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -1166,6 +1166,10 @@ class ChatStorage {
                 db.exec('COMMIT')
                 return { message: existing, totalTokens }
             }
+            const movedFromRoomId = existing && existing.roomId !== msg.roomId ? existing.roomId : null
+            const previousSourceIds = movedFromRoomId
+                ? this.contextWindowMessageIdsForTokenDelta(movedFromRoomId)
+                : null
             const previousIds = this.contextWindowMessageIdsForTokenDelta(msg.roomId)
             const safeMsg = msg.tool_name === 'workspace_diff'
                 ? { ...msg, role: 'user', tool_call_id: null, tool_calls: null, tool_name: null }
@@ -1182,6 +1186,18 @@ class ChatStorage {
                 nextIds,
             )
             this.updateRoomTotalTokens(msg.roomId, totalTokens)
+            if (movedFromRoomId && previousSourceIds) {
+                const nextSourceIds = this.contextWindowMessageIdsForTokenDelta(movedFromRoomId)
+                const sourceTotalTokens = this.incrementalRoomTotalTokens(
+                    movedFromRoomId,
+                    storedMessage.id,
+                    existing,
+                    storedMessage,
+                    previousSourceIds,
+                    nextSourceIds,
+                )
+                this.updateRoomTotalTokens(movedFromRoomId, sourceTotalTokens)
+            }
             db.exec('COMMIT')
             return { message: storedMessage, totalTokens }
         } catch (err) {

--- a/tests/ekko-agent/tokens.test.ts
+++ b/tests/ekko-agent/tokens.test.ts
@@ -14,7 +14,16 @@ describe('Ekko model token estimation', () => {
     const largeTokens = countTextTokens(large)
     const largeMs = performance.now() - largeStart
 
-    expect(largeTokens).toBe(Math.ceil(large.length * 1.5))
+    expect(largeTokens).toBe(large.length * 3)
     expect(largeMs).toBeLessThan(Math.max(100, smallMs * 4))
+  })
+
+  it('never underestimates fallback text relative to exact UTF-8 tokenization', async () => {
+    const { getEncoding } = await import('js-tiktoken')
+    const encoder = getEncoding('cl100k_base')
+    for (const unit of ['a', '汉', '\u2E80', '\uD7AF', '\uFFEF', '😀']) {
+      const text = `${unit} `.repeat(2_001)
+      expect(countTextTokens(text)).toBeGreaterThanOrEqual(encoder.encode(text).length)
+    }
   })
 })

--- a/tests/ekko-agent/tokens.test.ts
+++ b/tests/ekko-agent/tokens.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { performance } from 'node:perf_hooks'
+
+import { countTextTokens } from '../../packages/ekko-agent/src/model/tokens'
+
+describe('Ekko model token estimation', () => {
+  it('keeps oversized estimation work bounded independently of input length', () => {
+    const small = 'a'.repeat(8 * 1024 * 1024)
+    const large = 'a'.repeat(128 * 1024 * 1024)
+    const smallStart = performance.now()
+    countTextTokens(small)
+    const smallMs = performance.now() - smallStart
+    const largeStart = performance.now()
+    const largeTokens = countTextTokens(large)
+    const largeMs = performance.now() - largeStart
+
+    expect(largeTokens).toBe(Math.ceil(large.length * 1.5))
+    expect(largeMs).toBeLessThan(Math.max(100, smallMs * 4))
+  })
+})

--- a/tests/server/context-compressor.test.ts
+++ b/tests/server/context-compressor.test.ts
@@ -934,6 +934,24 @@ describe('countTokens', () => {
     expect(tokens).toBeLessThan(800_000)
   })
 
+  it('does not let a periodic adversarial layout hide CJK from oversized estimation', async () => {
+    const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
+    const length = 800_000
+    const adversarial = new Array<string>(length).fill('汉')
+    const blockCount = 256
+    const blockLength = Math.floor((64 * 1024) / blockCount)
+    for (let block = 0; block < blockCount; block += 1) {
+      const start = Math.floor(block * length / blockCount)
+      for (let offset = 0; offset < blockLength; offset += 1) adversarial[start + offset] = 'a'
+    }
+    const text = adversarial.join('')
+    const ascii = 64 * 1024
+    const expected = Math.ceil((length - ascii) * 1.5 + ascii / 4)
+
+    expect(countTokens(text)).toBeGreaterThan(expected * 0.9)
+    expect(countTokens(text)).toBeLessThan(expected * 1.1)
+  })
+
   it('still uses the exact tokenizer for long space-separated text', async () => {
     const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
     // Long but with frequent spaces => no single piece exceeds the guard

--- a/tests/server/context-compressor.test.ts
+++ b/tests/server/context-compressor.test.ts
@@ -952,6 +952,20 @@ describe('countTokens', () => {
     expect(countTokens(text)).toBeLessThan(expected * 1.1)
   })
 
+  it('keeps oversized token estimation work bounded independently of input length', async () => {
+    const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
+    const small = 'a'.repeat(8 * 1024 * 1024)
+    const large = 'a'.repeat(128 * 1024 * 1024)
+    const smallStart = performance.now()
+    countTokens(small)
+    const smallMs = performance.now() - smallStart
+    const largeStart = performance.now()
+    countTokens(large)
+    const largeMs = performance.now() - largeStart
+
+    expect(largeMs).toBeLessThan(Math.max(100, smallMs * 4))
+  })
+
   it('still uses the exact tokenizer for long space-separated text', async () => {
     const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
     // Long but with frequent spaces => no single piece exceeds the guard

--- a/tests/server/context-compressor.test.ts
+++ b/tests/server/context-compressor.test.ts
@@ -855,6 +855,27 @@ describe('countTokens', () => {
     expect(elapsedMs).toBeLessThan(250)
   })
 
+  it('bounds token estimation time for very large non-pathological text', async () => {
+    const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
+    const unit = 'abcdefghijklmnopqrstuvwxyz0123456789 '
+    const text = unit.repeat(Math.ceil(1_000_000 / unit.length)).slice(0, 1_000_000)
+    const start = performance.now()
+    const tokens = countTokens(text)
+    const elapsedMs = performance.now() - start
+    expect(tokens).toBeGreaterThan(0)
+    expect(elapsedMs).toBeLessThan(250)
+  })
+
+  it('bounds token estimation time for large separated multibyte text', async () => {
+    const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
+    const text = '汉 '.repeat(100_000)
+    const start = performance.now()
+    const tokens = countTokens(text)
+    const elapsedMs = performance.now() - start
+    expect(tokens).toBeGreaterThan(0)
+    expect(elapsedMs).toBeLessThan(250)
+  })
+
   it('still uses the exact tokenizer for long space-separated text', async () => {
     const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
     // Long but with frequent spaces => no single piece exceeds the guard

--- a/tests/server/context-compressor.test.ts
+++ b/tests/server/context-compressor.test.ts
@@ -886,8 +886,8 @@ describe('countTokens', () => {
     expect(Buffer.byteLength(atBoundary, 'utf8')).toBe(262_144)
     expect(countTokens(atBoundary)).toBe(encoder.encode(atBoundary).length)
     expect(countTokensForModel(atBoundary, 'gpt-4o')).toBeGreaterThan(0)
-    expect(countTokens(aboveBoundary)).toBe(Math.ceil(aboveBoundary.length / 4))
-    expect(countTokensForModel(aboveBoundary, 'gpt-4o')).toBe(Math.ceil(aboveBoundary.length / 4))
+    expect(countTokens(aboveBoundary)).toBe(Buffer.byteLength(aboveBoundary, 'utf8'))
+    expect(countTokensForModel(aboveBoundary, 'gpt-4o')).toBe(Buffer.byteLength(aboveBoundary, 'utf8'))
   })
 
   it('applies the 256 KiB cap by UTF-8 bytes for separated multibyte text', async () => {
@@ -896,10 +896,7 @@ describe('countTokens', () => {
     const encoder = getEncoding('cl100k_base')
     const atBoundary = '汉 '.repeat(65_536)
     const aboveBoundary = `${atBoundary}a`
-    const heuristic = (text: string) => {
-      const cjk = (text.match(/[\u2e80-\u9fff\uac00-\ud7af\u3000-\u303f\uff00-\uffef]/g) || []).length
-      return Math.ceil(cjk * 1.5 + (text.length - cjk) / 4)
-    }
+    const heuristic = (text: string) => Buffer.byteLength(text, 'utf8')
 
     expect(atBoundary.length).toBe(131_072)
     expect(Buffer.byteLength(atBoundary, 'utf8')).toBe(262_144)
@@ -930,8 +927,7 @@ describe('countTokens', () => {
     const cjk = '汉'.repeat(400_000)
     const tokens = countTokens(ascii + cjk)
 
-    expect(tokens).toBeGreaterThan(600_000)
-    expect(tokens).toBeLessThan(800_000)
+    expect(tokens).toBe(Buffer.byteLength(ascii + cjk, 'utf8'))
   })
 
   it('does not let a periodic adversarial layout hide CJK from oversized estimation', async () => {
@@ -946,10 +942,9 @@ describe('countTokens', () => {
     }
     const text = adversarial.join('')
     const ascii = 64 * 1024
-    const expected = Math.ceil((length - ascii) * 1.5 + ascii / 4)
+    const expected = Buffer.byteLength(text, 'utf8')
 
-    expect(countTokens(text)).toBeGreaterThan(expected * 0.9)
-    expect(countTokens(text)).toBeLessThan(expected * 1.1)
+    expect(countTokens(text)).toBe(expected)
   })
 
   it('keeps oversized token estimation work bounded independently of input length', async () => {

--- a/tests/server/context-compressor.test.ts
+++ b/tests/server/context-compressor.test.ts
@@ -876,6 +876,38 @@ describe('countTokens', () => {
     expect(elapsedMs).toBeLessThan(250)
   })
 
+  it('uses the exact tokenizer through the 256 KiB UTF-8 boundary and falls back above it', async () => {
+    const { countTokens, countTokensForModel } = await import('../../packages/server/src/lib/context-compressor')
+    const { getEncoding } = await import('js-tiktoken')
+    const encoder = getEncoding('cl100k_base')
+    const atBoundary = 'a '.repeat(131_072)
+    const aboveBoundary = `${atBoundary}a`
+
+    expect(Buffer.byteLength(atBoundary, 'utf8')).toBe(262_144)
+    expect(countTokens(atBoundary)).toBe(encoder.encode(atBoundary).length)
+    expect(countTokensForModel(atBoundary, 'gpt-4o')).toBeGreaterThan(0)
+    expect(countTokens(aboveBoundary)).toBe(Math.ceil(aboveBoundary.length / 4))
+    expect(countTokensForModel(aboveBoundary, 'gpt-4o')).toBe(Math.ceil(aboveBoundary.length / 4))
+  })
+
+  it('applies the 256 KiB cap by UTF-8 bytes for separated multibyte text', async () => {
+    const { countTokens, countTokensForModel } = await import('../../packages/server/src/lib/context-compressor')
+    const { getEncoding } = await import('js-tiktoken')
+    const encoder = getEncoding('cl100k_base')
+    const atBoundary = '汉 '.repeat(65_536)
+    const aboveBoundary = `${atBoundary}a`
+    const heuristic = (text: string) => {
+      const cjk = (text.match(/[\u2e80-\u9fff\uac00-\ud7af\u3000-\u303f\uff00-\uffef]/g) || []).length
+      return Math.ceil(cjk * 1.5 + (text.length - cjk) / 4)
+    }
+
+    expect(atBoundary.length).toBe(131_072)
+    expect(Buffer.byteLength(atBoundary, 'utf8')).toBe(262_144)
+    expect(countTokens(atBoundary)).toBe(encoder.encode(atBoundary).length)
+    expect(countTokens(aboveBoundary)).toBe(heuristic(aboveBoundary))
+    expect(countTokensForModel(aboveBoundary, 'gpt-4o')).toBe(heuristic(aboveBoundary))
+  })
+
   it('still uses the exact tokenizer for long space-separated text', async () => {
     const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
     // Long but with frequent spaces => no single piece exceeds the guard

--- a/tests/server/context-compressor.test.ts
+++ b/tests/server/context-compressor.test.ts
@@ -908,6 +908,32 @@ describe('countTokens', () => {
     expect(countTokensForModel(aboveBoundary, 'gpt-4o')).toBe(heuristic(aboveBoundary))
   })
 
+  it('does not materialize a full regex match array for oversized heuristic input', async () => {
+    const { countTokens, countTokensForModel } = await import('../../packages/server/src/lib/context-compressor')
+    const oversized = '汉字 mixed text '.repeat(100_000)
+    const originalMatch = String.prototype.match
+    const matchSpy = vi.spyOn(String.prototype, 'match').mockImplementation(function (this: string, regexp: any) {
+      if (this.length > 262_144) {
+        throw new Error('oversized input must not use String.match')
+      }
+      return originalMatch.call(String(this), regexp)
+    } as typeof String.prototype.match)
+
+    expect(() => countTokens(oversized)).not.toThrow()
+    expect(() => countTokensForModel(oversized, 'gpt-4o')).not.toThrow()
+    expect(matchSpy).not.toHaveBeenCalled()
+  })
+
+  it('samples oversized heterogeneous text across its full length', async () => {
+    const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
+    const ascii = 'a'.repeat(400_000)
+    const cjk = '汉'.repeat(400_000)
+    const tokens = countTokens(ascii + cjk)
+
+    expect(tokens).toBeGreaterThan(600_000)
+    expect(tokens).toBeLessThan(800_000)
+  })
+
   it('still uses the exact tokenizer for long space-separated text', async () => {
     const { countTokens } = await import('../../packages/server/src/lib/context-compressor')
     // Long but with frequent spaces => no single piece exceeds the guard

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -59,16 +59,18 @@ describe('group chat approval and context baseline', () => {
     return new Promise(resolve => setTimeout(resolve, ms))
   }
 
-  it('relays context status and updates room token count', async () => {
+  it('relays context status without overwriting the persisted room token count', async () => {
     const { agent, human, agentSessionId } = await joinPair()
     const statusEvent = once<any>(human, 'context_status')
-    const roomUpdated = once<any>(human, 'room_updated')
+    const roomUpdated = vi.fn()
+    human.on('room_updated', roomUpdated)
 
     agent.emit('context_status', { roomId: 'room-1', agentName: 'Agent', status: 'replying', totalTokens: 123, agentSessionId })
 
     expect(await statusEvent).toEqual({ roomId: 'room-1', agentName: 'Agent', status: 'replying' })
-    expect(await roomUpdated).toEqual({ roomId: 'room-1', totalTokens: 123 })
-    expect(groupServer.getStorage().getRoom('room-1')).toMatchObject({ totalTokens: 123 })
+    await wait()
+    expect(roomUpdated).not.toHaveBeenCalled()
+    expect(groupServer.getStorage().getRoom('room-1')).toMatchObject({ totalTokens: 0 })
   })
 
   it('ignores context status emitted by human sockets', async () => {

--- a/tests/server/group-chat-history-window.test.ts
+++ b/tests/server/group-chat-history-window.test.ts
@@ -547,6 +547,52 @@ describe('group chat history windows', () => {
     expect(storage.getRoom('room-1')?.totalTokens).toBe(initial)
   })
 
+  it('rebuilds a legacy cached total before saving an excluded workspace diff', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    storage.addMessage(makeMessage({
+      id: 'legacy-context',
+      content: 'authoritative context',
+      timestamp: 1,
+    }) as any)
+    dbMock.current!.prepare(
+      'UPDATE gc_rooms SET totalTokens = ?, tokenAccountingVersion = 0 WHERE id = ?',
+    ).run(999_999, 'room-1')
+
+    const result = storage.saveWorkspaceDiffMessageForRun({
+      roomId: 'room-1',
+      senderId: 'agent-1',
+      senderName: 'Agent',
+      sessionId: 'session-1',
+      runId: 'legacy-run',
+      status: 'completed',
+      workspace: '/tmp/workspace',
+      draft: {
+        change_id: 'legacy-change',
+        run_id: 'legacy-run',
+        session_id: 'session-1',
+        room_id: 'room-1',
+        message_id: 'pending',
+        assistant_message_id: '',
+        workspace: 'workspace',
+        workspace_kind: 'git',
+        started_at: 1,
+        finished_at: 2,
+        files_changed: 0,
+        additions: 0,
+        deletions: 0,
+        truncated: false,
+        total_patch_bytes: 0,
+        status: 'completed',
+        files: [],
+      },
+    } as any)
+
+    const expected = countTokens('authoritative context')
+    expect(result?.totalTokens).toBe(expected)
+    expect(storage.getRoom('room-1')?.totalTokens).toBe(expected)
+  })
+
   it('retains older messages while limiting shared context to the latest 500', () => {
     const storage = groupServer.getStorage()
     storage.saveRoom('room-1', 'Room 1')

--- a/tests/server/group-chat-history-window.test.ts
+++ b/tests/server/group-chat-history-window.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DatabaseSync } from 'node:sqlite'
-import { createServer, type Server as HttpServer } from 'http'
+import { createServer, request as httpRequest, type Server as HttpServer } from 'http'
 
 const dbMock = vi.hoisted(() => ({
   current: null as DatabaseSync | null,
@@ -144,6 +144,23 @@ describe('group chat history windows', () => {
     ])
   })
 
+  it('bounds same-timestamp overflow while retaining the newest context messages', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    for (let index = 0; index < 2_000; index += 1) {
+      storage.addMessage(makeMessage({
+        id: `same-time-${String(index).padStart(4, '0')}`,
+        content: `same timestamp ${index}`,
+        timestamp: 100,
+      }) as any)
+    }
+
+    const context = storage.getMessagesForContext('room-1')
+
+    expect(context.length).toBeLessThanOrEqual(600)
+    expect(context.at(-1)?.id).toBe('same-time-1999')
+  })
+
   it('computes room total tokens from the context window, not the UI page window', () => {
     const storage = groupServer.getStorage()
     storage.saveRoom('room-1', 'Room 1')
@@ -163,6 +180,259 @@ describe('group chat history windows', () => {
     expect(storage.getMessagesForContext('room-1')).toHaveLength(160)
     expect(latest?.totalTokens).toBe(expectedTotalTokens)
     expect(storage.getRoom('room-1')?.totalTokens).toBe(expectedTotalTokens)
+  })
+
+  it('uses the context-window index without a table scan or temporary sort', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    for (let index = 0; index < 600; index += 1) {
+      storage.addMessage(makeMessage({
+        id: `indexed-${index}`,
+        content: `indexed message ${index}`,
+        timestamp: index + 1,
+      }) as any)
+    }
+
+    const boundaryPlan = dbMock.current!.prepare(
+      `EXPLAIN QUERY PLAN
+       SELECT timestamp FROM gc_messages
+       WHERE roomId = ? AND COALESCE(tool_name, '') <> 'workspace_diff'
+       ORDER BY timestamp DESC, id DESC
+       LIMIT 1 OFFSET ?`,
+    ).all('room-1', 499) as Array<{ detail: string }>
+    const idPlan = dbMock.current!.prepare(
+      `EXPLAIN QUERY PLAN
+       SELECT id FROM gc_messages
+       WHERE roomId = ? AND COALESCE(tool_name, '') <> 'workspace_diff' AND timestamp >= ?
+       ORDER BY timestamp DESC, id DESC
+       LIMIT ?`,
+    ).all('room-1', 100, 600) as Array<{ detail: string }>
+    const details = [...boundaryPlan, ...idPlan].map(row => row.detail).join('\n')
+
+    expect(details).toContain('idx_gc_messages_context_window')
+    expect(details).not.toContain('SCAN gc_messages')
+    expect(details).not.toContain('USE TEMP B-TREE')
+  })
+
+  it('updates room token totals without retokenizing the complete context window', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+
+    const seeded = Array.from({ length: 500 }, (_value, index) => makeMessage({
+      id: `msg-${index + 1}`,
+      content: `history-${index + 1}`,
+      timestamp: index + 1,
+    }))
+    for (const message of seeded) storage.addMessage(message as any)
+
+    const initialTotal = seeded.reduce((sum, message) => sum + countTokens(String(message.content)), 0)
+    storage.updateRoomTotalTokens('room-1', initialTotal)
+    const fullWindowRead = vi.spyOn(storage, 'getMessagesForContext')
+
+    const incoming = makeMessage({ id: 'msg-501', content: 'newest-message', timestamp: 501 })
+    const saved = storage.saveMessageAndRefreshRoom(incoming as any)
+
+    expect(fullWindowRead).not.toHaveBeenCalled()
+    expect(saved.totalTokens).toBe(
+      initialTotal
+      - countTokens(String(seeded[0].content))
+      + countTokens(String(incoming.content)),
+    )
+    expect(storage.getRoom('room-1')?.totalTokens).toBe(saved.totalTokens)
+  })
+
+  it('adjusts the cached room total when an existing message is updated', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    const first = makeMessage({ id: 'msg-1', content: 'short', timestamp: 1 })
+    const initial = storage.saveMessageAndRefreshRoom(first as any).totalTokens
+    const updated = makeMessage({ id: 'msg-1', content: 'a substantially longer updated message', timestamp: 2 })
+
+    const saved = storage.saveMessageAndRefreshRoom(updated as any)
+
+    expect(saved.totalTokens).toBe(
+      initial - countTokens(String(first.content)) + countTokens(String(updated.content)),
+    )
+    expect(storage.getRoom('room-1')?.totalTokens).toBe(saved.totalTokens)
+  })
+
+  it('includes every same-timestamp boundary message in the incremental token total', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    const seeded = Array.from({ length: 501 }, (_value, index) => makeMessage({
+      id: `boundary-${index}`,
+      content: `boundary message ${index}`,
+      timestamp: index < 3 ? 1 : index - 1,
+    }))
+    for (const message of seeded.slice(0, 500)) storage.addMessage(message as any)
+    const initialWindow = storage.getMessagesForContext('room-1')
+    const initialTotal = initialWindow.reduce((sum, message) => sum + countTokens(String(message.content)), 0)
+    storage.updateRoomTotalTokens('room-1', initialTotal)
+
+    const saved = storage.saveMessageAndRefreshRoom(seeded[500] as any)
+    const expected = storage.getMessagesForContext('room-1')
+      .reduce((sum, message) => sum + countTokens(String(message.content)), 0)
+
+    expect(saved.totalTokens).toBe(expected)
+  })
+
+  it('persists a production-sized tool result without multi-second tokenization stalls', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    const unit = 'abcdefghijklmnopqrstuvwxyz0123456789 '
+    const content = unit.repeat(Math.ceil(6_204_367 / unit.length)).slice(0, 6_204_367)
+    const start = performance.now()
+
+    const saved = storage.saveMessageAndRefreshRoom(makeMessage({
+      id: 'large-tool-result',
+      senderId: 'agent-1',
+      senderName: 'Agent',
+      role: 'tool',
+      tool_name: 'api_request',
+      tool_call_id: 'call-large',
+      content,
+      timestamp: 1,
+    }) as any)
+    const elapsedMs = performance.now() - start
+
+    expect(saved.totalTokens).toBeGreaterThan(0)
+    expect(elapsedMs).toBeLessThan(1_000)
+  })
+
+  it('does not reread a production-sized tool result for each later message', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    const unit = 'abcdefghijklmnopqrstuvwxyz0123456789 '
+    const content = unit.repeat(Math.ceil(6_204_367 / unit.length)).slice(0, 6_204_367)
+    storage.saveMessageAndRefreshRoom(makeMessage({
+      id: 'large-tool-result',
+      senderId: 'agent-1',
+      senderName: 'Agent',
+      role: 'tool',
+      tool_name: 'api_request',
+      tool_call_id: 'call-large',
+      content,
+      timestamp: 1,
+    }) as any)
+
+    const start = performance.now()
+    for (let index = 0; index < 50; index += 1) {
+      storage.saveMessageAndRefreshRoom(makeMessage({
+        id: `small-${index}`,
+        content: `small message ${index}`,
+        timestamp: index + 2,
+      }) as any)
+    }
+    const elapsedMs = performance.now() - start
+
+    expect(elapsedMs).toBeLessThan(500)
+  })
+
+  it('keeps a livez response within budget under production-sized group chat load', async () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    for (let index = 0; index < 500; index += 1) {
+      storage.addMessage(makeMessage({
+        id: `history-${index}`,
+        content: `history message ${index}`,
+        timestamp: index + 1,
+      }) as any)
+    }
+    storage.updateRoomTotalTokens(
+      'room-1',
+      Array.from({ length: 500 }, (_value, index) => countTokens(`history message ${index}`))
+        .reduce((sum, tokens) => sum + tokens, 0),
+    )
+
+    const healthServer = createServer((_req, res) => {
+      setImmediate(() => {
+        res.setHeader('content-type', 'application/json')
+        res.end('{"status":"ok"}')
+      })
+    })
+    await new Promise<void>(resolve => healthServer.listen(0, '127.0.0.1', resolve))
+    const address = healthServer.address()
+    if (!address || typeof address === 'string') throw new Error('missing health port')
+    const startedAt = performance.now()
+    const response = new Promise<{ body: string; elapsedMs: number }>((resolve, reject) => {
+      const req = httpRequest({ host: '127.0.0.1', port: address.port, path: '/livez' }, res => {
+        let body = ''
+        res.setEncoding('utf8')
+        res.on('data', chunk => { body += chunk })
+        res.on('end', () => resolve({ body, elapsedMs: performance.now() - startedAt }))
+      })
+      req.on('error', reject)
+      req.end()
+    })
+
+    await new Promise(resolve => setImmediate(resolve))
+    const unit = 'abcdefghijklmnopqrstuvwxyz0123456789 '
+    const content = unit.repeat(Math.ceil(6_204_367 / unit.length)).slice(0, 6_204_367)
+    storage.saveMessageAndRefreshRoom(makeMessage({
+      id: 'large-tool-result',
+      senderId: 'agent-1',
+      senderName: 'Agent',
+      role: 'tool',
+      tool_name: 'api_request',
+      tool_call_id: 'call-large',
+      content,
+      timestamp: 501,
+    }) as any)
+    for (let index = 0; index < 50; index += 1) {
+      storage.saveMessageAndRefreshRoom(makeMessage({
+        id: `follow-up-${index}`,
+        content: `follow up ${index}`,
+        timestamp: index + 502,
+      }) as any)
+    }
+
+    const health = await response.finally(() => healthServer.close())
+    expect(health.body).toBe('{"status":"ok"}')
+    expect(health.elapsedMs).toBeLessThan(1_000)
+  })
+
+  it('keeps room token totals unchanged when saving an excluded workspace diff', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    const initial = storage.saveMessageAndRefreshRoom(makeMessage({
+      id: 'msg-1',
+      content: 'context message',
+      timestamp: 1,
+    }) as any).totalTokens
+    const fullWindowRead = vi.spyOn(storage, 'getMessagesForContext')
+
+    const result = storage.saveWorkspaceDiffMessageForRun({
+      roomId: 'room-1',
+      senderId: 'agent-1',
+      senderName: 'Agent',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      status: 'completed',
+      workspace: '/tmp/workspace',
+      draft: {
+        change_id: 'change-1',
+        run_id: 'run-1',
+        session_id: 'session-1',
+        room_id: 'room-1',
+        message_id: 'pending',
+        assistant_message_id: '',
+        workspace: 'workspace',
+        workspace_kind: 'git',
+        started_at: 1,
+        finished_at: 2,
+        files_changed: 0,
+        additions: 0,
+        deletions: 0,
+        truncated: false,
+        total_patch_bytes: 0,
+        status: 'completed',
+        files: [],
+      },
+    } as any)
+
+    expect(result?.totalTokens).toBe(initial)
+    expect(fullWindowRead).not.toHaveBeenCalled()
+    expect(storage.getRoom('room-1')?.totalTokens).toBe(initial)
   })
 
   it('retains older messages while limiting shared context to the latest 500', () => {

--- a/tests/server/group-chat-history-window.test.ts
+++ b/tests/server/group-chat-history-window.test.ts
@@ -201,6 +201,23 @@ describe('group chat history windows', () => {
       .toEqual(expected)
   })
 
+  it('uses SQLite UTF-8 binary order for supplementary-plane cursor ids', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    const ids = ['中', '\uE000', '😀']
+    for (const id of ids) {
+      storage.addMessage(makeMessage({ id, content: id, timestamp: 100 }) as any)
+    }
+
+    const ordered = sortGroupMessagesCanonical(ids.map(id => ({ id, timestamp: 100 })))
+      .map(message => message.id)
+    const through = '😀'
+
+    expect(ordered).toEqual(['中', '\uE000', '😀'])
+    expect(storage.getMessagesForContext('room-1', { throughMessageId: through }).map(message => message.id))
+      .toEqual(ordered)
+  })
+
   it('computes room total tokens from the context window, not the UI page window', () => {
     const storage = groupServer.getStorage()
     storage.saveRoom('room-1', 'Room 1')

--- a/tests/server/group-chat-history-window.test.ts
+++ b/tests/server/group-chat-history-window.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DatabaseSync } from 'node:sqlite'
 import { createServer, request as httpRequest, type Server as HttpServer } from 'http'
+import Koa from 'koa'
 
 const dbMock = vi.hoisted(() => ({
   current: null as DatabaseSync | null,
@@ -38,6 +39,7 @@ vi.mock('../../packages/server/src/services/auth', () => ({
 
 import { countTokens } from '../../packages/server/src/lib/context-compressor'
 import { initAllHermesTables } from '../../packages/server/src/db/hermes/schemas'
+import { healthRoutes } from '../../packages/server/src/routes/health'
 import { GroupChatServer } from '../../packages/server/src/services/hermes/group-chat'
 import { AgentClients, mentionMessageToStoredContextMessage } from '../../packages/server/src/services/hermes/group-chat/agent-clients'
 import { sortGroupMessagesCanonical } from '../../packages/server/src/services/hermes/group-chat/group-message-ordering'
@@ -182,6 +184,17 @@ describe('group chat history windows', () => {
     expect(storage.getRoom('room-1')?.totalTokens).toBe(expectedTotalTokens)
   })
 
+  it('migrates the context-window index onto an existing messages table', () => {
+    dbMock.current!.exec('DROP INDEX idx_gc_messages_context_window')
+
+    initAllHermesTables()
+
+    const migrated = dbMock.current!.prepare(
+      `SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?`,
+    ).get('idx_gc_messages_context_window') as { sql: string } | undefined
+    expect(migrated?.sql).toContain("WHERE COALESCE(tool_name, '') <> 'workspace_diff'")
+  })
+
   it('uses the context-window index without a table scan or temporary sort', () => {
     const storage = groupServer.getStorage()
     storage.saveRoom('room-1', 'Room 1')
@@ -254,6 +267,22 @@ describe('group chat history windows', () => {
       initial - countTokens(String(first.content)) + countTokens(String(updated.content)),
     )
     expect(storage.getRoom('room-1')?.totalTokens).toBe(saved.totalTokens)
+  })
+
+  it('updates both cached room totals when an existing message moves between rooms', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    storage.saveRoom('room-2', 'Room 2')
+    const original = makeMessage({ id: 'shared-id', roomId: 'room-1', content: 'source room content', timestamp: 1 })
+    const originalTokens = storage.saveMessageAndRefreshRoom(original as any).totalTokens
+    const moved = makeMessage({ id: 'shared-id', roomId: 'room-2', content: 'target room content', timestamp: 2 })
+
+    const result = storage.saveMessageAndRefreshRoom(moved as any)
+
+    expect(originalTokens).toBe(countTokens(String(original.content)))
+    expect(storage.getRoom('room-1')?.totalTokens).toBe(0)
+    expect(result.totalTokens).toBe(countTokens(String(moved.content)))
+    expect(storage.getRoom('room-2')?.totalTokens).toBe(result.totalTokens)
   })
 
   it('includes every same-timestamp boundary message in the incremental token total', () => {
@@ -344,12 +373,9 @@ describe('group chat history windows', () => {
         .reduce((sum, tokens) => sum + tokens, 0),
     )
 
-    const healthServer = createServer((_req, res) => {
-      setImmediate(() => {
-        res.setHeader('content-type', 'application/json')
-        res.end('{"status":"ok"}')
-      })
-    })
+    const healthApp = new Koa()
+    healthApp.use(healthRoutes.routes())
+    const healthServer = createServer(healthApp.callback())
     await new Promise<void>(resolve => healthServer.listen(0, '127.0.0.1', resolve))
     const address = healthServer.address()
     if (!address || typeof address === 'string') throw new Error('missing health port')

--- a/tests/server/group-chat-history-window.test.ts
+++ b/tests/server/group-chat-history-window.test.ts
@@ -248,6 +248,71 @@ describe('group chat history windows', () => {
     expect(details).not.toContain('USE TEMP B-TREE')
   })
 
+  it('rebuilds a legacy cached total before applying an incremental message update', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    const oversized = makeMessage({
+      id: 'legacy-large',
+      content: 'a '.repeat(131_073),
+      timestamp: 1,
+    })
+    storage.addMessage(oversized as any)
+    // Simulate a pre-upgrade cache populated by the old exact-tokenizer path.
+    storage.updateRoomTotalTokens('room-1', 131_074)
+    dbMock.current!.prepare(
+      'UPDATE gc_rooms SET tokenAccountingVersion = 0 WHERE id = ?',
+    ).run('room-1')
+
+    const replacement = makeMessage({ id: 'legacy-large', content: 'a', timestamp: 2 })
+    const saved = storage.saveMessageAndRefreshRoom(replacement as any)
+
+    expect(saved.totalTokens).toBe(countTokens('a'))
+    expect(storage.getRoom('room-1')?.totalTokens).toBe(countTokens('a'))
+  })
+
+  it('marks new rooms with the current token-accounting version', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+
+    const row = dbMock.current!.prepare(
+      'SELECT tokenAccountingVersion FROM gc_rooms WHERE id = ?',
+    ).get('room-1') as { tokenAccountingVersion: number }
+
+    expect(row.tokenAccountingVersion).toBe(1)
+  })
+
+  it('marks rooms from the legacy schema for bounded token-accounting rebuild', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('legacy-room', 'Legacy Room')
+    dbMock.current!.exec('ALTER TABLE gc_rooms DROP COLUMN tokenAccountingVersion')
+
+    initAllHermesTables()
+
+    const row = dbMock.current!.prepare(
+      'SELECT tokenAccountingVersion FROM gc_rooms WHERE id = ?',
+    ).get('legacy-room') as { tokenAccountingVersion: number }
+    expect(row.tokenAccountingVersion).toBe(0)
+  })
+
+  it('rebuilds legacy totals in both rooms before moving a message', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    storage.saveRoom('room-2', 'Room 2')
+    const source = makeMessage({ id: 'moving', roomId: 'room-1', content: 'source', timestamp: 1 })
+    const target = makeMessage({ id: 'target', roomId: 'room-2', content: 'target', timestamp: 1 })
+    storage.addMessage(source as any)
+    storage.addMessage(target as any)
+    dbMock.current!.prepare(
+      'UPDATE gc_rooms SET totalTokens = 999999, tokenAccountingVersion = 0 WHERE id IN (?, ?)',
+    ).run('room-1', 'room-2')
+
+    const moved = makeMessage({ id: 'moving', roomId: 'room-2', content: 'moved', timestamp: 2 })
+    const saved = storage.saveMessageAndRefreshRoom(moved as any)
+
+    expect(storage.getRoom('room-1')?.totalTokens).toBe(0)
+    expect(saved.totalTokens).toBe(countTokens('target') + countTokens('moved'))
+  })
+
   it('updates room token totals without retokenizing the complete context window', () => {
     const storage = groupServer.getStorage()
     storage.saveRoom('room-1', 'Room 1')

--- a/tests/server/group-chat-history-window.test.ts
+++ b/tests/server/group-chat-history-window.test.ts
@@ -184,6 +184,23 @@ describe('group chat history windows', () => {
     expect(context.some(message => message.id > 'same-time-0500')).toBe(false)
   })
 
+  it('uses the same binary id order as SQLite for equal-timestamp cursors', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    for (const id of ['A', 'a', '1', '_', '中']) {
+      storage.addMessage(makeMessage({ id, content: id, timestamp: 100 }) as any)
+    }
+
+    const ordered = sortGroupMessagesCanonical(
+      ['A', 'a', '1', '_', '中'].map(id => ({ id, timestamp: 100 })),
+    ).map(message => message.id)
+    const through = 'A'
+    const expected = ordered.slice(0, ordered.indexOf(through) + 1)
+
+    expect(storage.getMessagesForContext('room-1', { throughMessageId: through }).map(message => message.id))
+      .toEqual(expected)
+  })
+
   it('computes room total tokens from the context window, not the UI page window', () => {
     const storage = groupServer.getStorage()
     storage.saveRoom('room-1', 'Room 1')
@@ -203,6 +220,51 @@ describe('group chat history windows', () => {
     expect(storage.getMessagesForContext('room-1')).toHaveLength(160)
     expect(latest?.totalTokens).toBe(expectedTotalTokens)
     expect(storage.getRoom('room-1')?.totalTokens).toBe(expectedTotalTokens)
+  })
+
+  it('accounts from the normalized content that was actually persisted', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    const dataImage = `data:image/png;base64,${'A'.repeat(300_000)}`
+
+    const inserted = storage.saveMessageAndRefreshRoom(makeMessage({
+      id: 'normalized-tool',
+      role: 'tool',
+      senderId: 'agent-1',
+      senderName: 'Agent',
+      content: JSON.stringify({
+        _multimodal: true,
+        content: [{ type: 'image_url', image_url: { url: dataImage } }],
+      }),
+      timestamp: 1,
+    }) as any)
+
+    expect(inserted.message.content).toBe('[screenshot]')
+    expect(inserted.totalTokens).toBe(countTokens('[screenshot]'))
+    expect(storage.getRoom('room-1')?.totalTokens).toBe(countTokens('[screenshot]'))
+
+    const updated = storage.saveMessageAndRefreshRoom(makeMessage({
+      id: 'normalized-tool',
+      role: 'tool',
+      senderId: 'agent-1',
+      senderName: 'Agent',
+      content: 'small canonical update',
+      timestamp: 1,
+    }) as any)
+    expect(updated.totalTokens).toBe(countTokens('small canonical update'))
+
+    for (let index = 0; index < 500; index += 1) {
+      storage.saveMessageAndRefreshRoom(makeMessage({
+        id: `evict-${String(index).padStart(3, '0')}`,
+        content: `replacement ${index}`,
+        timestamp: index + 2,
+      }) as any)
+    }
+    const expectedAfterEviction = Array.from(
+      { length: 500 },
+      (_value, index) => countTokens(`replacement ${index}`),
+    ).reduce((sum, tokens) => sum + tokens, 0)
+    expect(storage.getRoom('room-1')?.totalTokens).toBe(expectedAfterEviction)
   })
 
   it('migrates the context-window index onto an existing messages table', () => {
@@ -590,6 +652,44 @@ describe('group chat history windows', () => {
 
     const expected = countTokens('authoritative context')
     expect(result?.totalTokens).toBe(expected)
+    expect(storage.getRoom('room-1')?.totalTokens).toBe(expected)
+  })
+
+  it('rebuilds a legacy cached total before replaying an existing workspace diff', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    storage.addMessage(makeMessage({
+      id: 'legacy-context',
+      content: 'authoritative context',
+      timestamp: 1,
+    }) as any)
+    storage.addMessage(makeMessage({
+      id: 'existing-workspace-diff',
+      senderId: 'agent-1',
+      senderName: 'Agent',
+      role: 'tool',
+      tool_name: 'workspace_diff',
+      tool_call_id: 'workspace_diff:run-1',
+      content: '{"kind":"workspace_diff"}',
+      timestamp: 2,
+    }) as any)
+    dbMock.current!.prepare(
+      'UPDATE gc_rooms SET totalTokens = ?, tokenAccountingVersion = 0 WHERE id = ?',
+    ).run(999_999, 'room-1')
+
+    const replayed = storage.saveMessageAndRefreshRoom(makeMessage({
+      id: 'existing-workspace-diff',
+      senderId: 'agent-1',
+      senderName: 'Agent',
+      role: 'tool',
+      tool_name: 'workspace_diff',
+      tool_call_id: 'workspace_diff:run-1',
+      content: '{"kind":"workspace_diff"}',
+      timestamp: 2,
+    }) as any)
+
+    const expected = countTokens('authoritative context')
+    expect(replayed.totalTokens).toBe(expected)
     expect(storage.getRoom('room-1')?.totalTokens).toBe(expected)
   })
 

--- a/tests/server/group-chat-history-window.test.ts
+++ b/tests/server/group-chat-history-window.test.ts
@@ -163,6 +163,27 @@ describe('group chat history windows', () => {
     expect(context.at(-1)?.id).toBe('same-time-1999')
   })
 
+  it('honors throughMessageId inside a 2,000-message equal-timestamp group', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    for (let index = 0; index < 2_000; index += 1) {
+      storage.addMessage(makeMessage({
+        id: `same-time-${String(index).padStart(4, '0')}`,
+        content: `same timestamp ${index}`,
+        timestamp: 100,
+      }) as any)
+    }
+
+    const context = storage.getMessagesForContext('room-1', {
+      throughMessageId: 'same-time-0500',
+    })
+
+    expect(context).toHaveLength(501)
+    expect(context[0]?.id).toBe('same-time-0000')
+    expect(context.at(-1)?.id).toBe('same-time-0500')
+    expect(context.some(message => message.id > 'same-time-0500')).toBe(false)
+  })
+
   it('computes room total tokens from the context window, not the UI page window', () => {
     const storage = groupServer.getStorage()
     storage.saveRoom('room-1', 'Room 1')

--- a/tests/server/group-chat-member-sync.test.ts
+++ b/tests/server/group-chat-member-sync.test.ts
@@ -590,9 +590,9 @@ describe('Group Chat member/agent identity sync', () => {
       agentSessionId: currentSessionId,
     })
 
-    expect(updateRoomTotalTokens).toHaveBeenCalledWith('room-1', 456)
+    expect(updateRoomTotalTokens).not.toHaveBeenCalled()
     expect(roomEmit).toHaveBeenCalledWith('context_status', expect.objectContaining({ roomId: 'room-1', agentName: 'Worker', status: 'replying' }))
-    expect(broadcastEmit).toHaveBeenCalledWith('room_updated', { roomId: 'room-1', totalTokens: 456 })
+    expect(broadcastEmit).not.toHaveBeenCalledWith('room_updated', expect.anything())
     expect(broadcastEmit).toHaveBeenCalledWith('message_stream_start', expect.objectContaining({ id: 'current-stream', senderName: 'Worker' }))
   })
 


### PR DESCRIPTION
## Summary

- stops Group Chat message persistence from retokenizing the complete context window after every message
- bounds exact synchronous tokenization for oversized UTF-8 text and uses allocation-safe distributed sampling above the cap
- updates the persisted room token total from entering, leaving, and changed window messages only
- versions cached token accounting and lazily rebuilds each legacy room from its bounded context window before incremental updates resume
- adds a partial covering SQLite index for the bounded context-window queries
- caps pathological same-timestamp boundary expansion while preserving ordinary multipart message groups

## Root cause evidence

A production CPU profile from an affected runtime attributed more than 94% of sampled CPU to:

`GroupChatServer.handleMessage -> ChatStorage.saveMessageAndRefreshRoom -> estimateRoomTotalTokens -> tokenizer encode`

The main Node thread remained CPU-bound while TCP connections to `/livez` were accepted but received no response bytes before the health-check timeout.

## Verification

- focused context-compressor and Group Chat history suites: 64/64 passed at the final candidate HEAD
- production-sized stress case: 500-message history + 6,204,367-character tool result + 50 follow-up writes kept the same-process `/livez` response below 1 second
- query-plan regression requires `idx_gc_messages_context_window` and rejects table scans/temp sorting
- 2,000 same-timestamp messages are bounded to at most 600 retained context rows
- legacy exact-token cache mismatch, additive schema migration, and cross-room legacy rebuild regressions pass
- full suite has the same 56 failing test names as clean `main`; candidate adds 11 passing regression tests and introduces no new failures
- `npm run harness:check`: passed
- `npm run build`: passed
- `git diff --check`: passed

## Operational note

This PR does not restart or replace any installed runtime. The currently affected process remains unhealthy until a fixed runtime is built and explicitly installed.

Closes #2444
