### PR TITLE
fix local STT final word truncation

### DIFF
--- a/packages/client/src/composables/usePcmStreamRecorder.ts
+++ b/packages/client/src/composables/usePcmStreamRecorder.ts
@@ -28,6 +28,7 @@ const DEFAULT_VOICE_ACTIVITY_THRESHOLD = 0.035
 const MIN_FINAL_CHUNK_MS = 350
 const MIN_VOICE_ACTIVITY_MS = 350
 const STREAM_WARMUP_MS = 500
+const AUDIO_DRAIN_TIMEOUT_GRACE_MS = 50
 const SUPPORT_ERROR_MESSAGE = 'Streaming microphone capture is not supported in this browser.'
 
 export function encodePcmWav(
@@ -83,6 +84,7 @@ export function usePcmStreamRecorder(options: PcmStreamRecorderOptions = {}) {
   let capturedSampleCount = 0
   let consecutiveVoiceSampleCount = 0
   let sessionToken = 0
+  let finishPendingAudioDrain: (() => void) | null = null
 
   function setError(cause: unknown) {
     const normalized = cause instanceof Error
@@ -98,6 +100,7 @@ export function usePcmStreamRecorder(options: PcmStreamRecorderOptions = {}) {
   }
 
   function clearAudioGraph() {
+    finishPendingAudioDrain?.()
     if (processor) processor.onaudioprocess = null
     try { processor?.disconnect() } catch { /* already disconnected */ }
     try { source?.disconnect() } catch { /* already disconnected */ }
@@ -238,6 +241,33 @@ export function usePcmStreamRecorder(options: PcmStreamRecorderOptions = {}) {
     bufferedSamples.push(mono)
     bufferedSampleCount += mono.length
     emitReadySegment()
+    finishPendingAudioDrain?.()
+  }
+
+  function drainPendingAudioFrame() {
+    const currentContext = context
+    const currentProcessor = processor
+    if (!currentContext || currentContext.state !== 'running' || !currentProcessor) return Promise.resolve()
+
+    return new Promise<void>((resolve) => {
+      let settled = false
+      const bufferSize = currentProcessor.bufferSize || 4_096
+      const timeout = setTimeout(
+        finish,
+        Math.ceil(bufferSize / sampleRate * 1_000) + AUDIO_DRAIN_TIMEOUT_GRACE_MS,
+      )
+
+      function finish() {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        if (finishPendingAudioDrain === finish) finishPendingAudioDrain = null
+        resolve()
+      }
+
+      finishPendingAudioDrain?.()
+      finishPendingAudioDrain = finish
+    })
   }
 
   async function start() {
@@ -303,6 +333,10 @@ export function usePcmStreamRecorder(options: PcmStreamRecorderOptions = {}) {
 
   async function stop() {
     sessionToken += 1
+    // ScriptProcessor delivers microphone input one buffer behind real time.
+    // Wait for one final callback so a button release cannot cut off the last
+    // phoneme before the continuous stream tail is encoded.
+    await drainPendingAudioFrame()
     const remainingDurationMs = bufferedSampleCount / sampleRate * 1_000
     const flushContinuousTail = options.continuous
       && Boolean(options.onChunk)

--- a/packages/server/src/services/hermes/local-stt-model-manager.ts
+++ b/packages/server/src/services/hermes/local-stt-model-manager.ts
@@ -125,6 +125,7 @@ let runtimeShuttingDown = false
 const LOCAL_STT_CHILD_SOURCE = String.raw`
 const path = require('node:path')
 const streams = new Map()
+const FINAL_FLUSH_SILENCE_SECONDS = 0.8
 let sherpa = null
 let recognizer = null
 let recognizerRoot = ''
@@ -202,7 +203,7 @@ process.on('message', (message) => {
       stream.acceptWaveform({ sampleRate: wave.sampleRate, samples: wave.samples })
       stream.acceptWaveform({
         sampleRate: wave.sampleRate,
-        samples: new Float32Array(Math.round(wave.sampleRate * 0.4)),
+        samples: new Float32Array(Math.round(wave.sampleRate * FINAL_FLUSH_SILENCE_SECONDS)),
       })
       stream.inputFinished()
       decodeReady(stream)
@@ -224,7 +225,7 @@ process.on('message', (message) => {
       if (!state) throw new Error('Local STT stream session is not active')
       state.stream.acceptWaveform({
         sampleRate: state.sampleRate,
-        samples: new Float32Array(Math.round(state.sampleRate * 0.4)),
+        samples: new Float32Array(Math.round(state.sampleRate * FINAL_FLUSH_SILENCE_SECONDS)),
       })
       state.stream.inputFinished()
       decodeReady(state.stream)

--- a/tests/client/use-pcm-stream-recorder.test.ts
+++ b/tests/client/use-pcm-stream-recorder.test.ts
@@ -4,6 +4,7 @@ import { encodePcmWav, usePcmStreamRecorder } from '../../packages/client/src/co
 
 class FakeScriptProcessor {
   onaudioprocess: ((event: AudioProcessingEvent) => void) | null = null
+  readonly bufferSize = 4_096
   connect = vi.fn()
   disconnect = vi.fn()
 
@@ -148,6 +149,29 @@ describe('usePcmStreamRecorder', () => {
     expect(finalChunk).not.toBeNull()
     expect(await wavSampleCount(finalChunk as Blob)).toBe(384)
     expect(await wavSampleCount(firstChunk) + await wavSampleCount(finalChunk as Blob)).toBe(16_384)
+  })
+
+  it('waits for the pending audio callback before encoding the continuous final tail', async () => {
+    const { stream, track } = mockStream()
+    getUserMedia.mockResolvedValue(stream)
+    const recorder = usePcmStreamRecorder({
+      continuous: true,
+      maxSegmentDurationMs: 1_000,
+      onChunk: vi.fn(),
+    })
+
+    await recorder.start()
+    const context = FakeAudioContext.instances[0]
+    context.processor.emit(new Float32Array(4_096).fill(0.1))
+
+    const finalChunkPromise = recorder.stop()
+    expect(track.stop).not.toHaveBeenCalled()
+    context.processor.emit(new Float32Array(4_096).fill(0.1))
+
+    const finalChunk = await finalChunkPromise
+    expect(finalChunk).not.toBeNull()
+    expect(await wavSampleCount(finalChunk as Blob)).toBe(2_731)
+    expect(track.stop).toHaveBeenCalledOnce()
   })
 
   it('drops pure silence instead of sending it to STT', async () => {

--- a/tests/server/local-stt-model-manager.test.ts
+++ b/tests/server/local-stt-model-manager.test.ts
@@ -212,6 +212,20 @@ describe('local STT model manager', () => {
     expect(child.exitCode).toBe(0)
   })
 
+  it('flushes enough trailing silence for the streaming recognizer to emit final words', async () => {
+    spawnMock.mockReturnValue(createFakeModelProcess())
+    const manager = await import('../../packages/server/src/services/hermes/local-stt-model-manager')
+    installSparseTestModel(manager)
+
+    const session = await manager.createLocalSttStreamSession('7:default')
+    await manager.finishLocalSttStreamSession(session.sessionId, '7:default')
+
+    const childSource = spawnMock.mock.calls[0]?.[1]?.[2]
+    expect(childSource).toContain('const FINAL_FLUSH_SILENCE_SECONDS = 0.8')
+    expect(childSource).toContain('state.sampleRate * FINAL_FLUSH_SILENCE_SECONDS')
+    await manager.shutdownLocalSttRuntime()
+  })
+
   it('does not allow another profile owner to use a local stream session', async () => {
     spawnMock.mockReturnValue(createFakeModelProcess())
     const manager = await import('../../packages/server/src/services/hermes/local-stt-model-manager')


### PR DESCRIPTION
## Summary
- drain the pending browser PCM callback before packaging the final local STT chunk
- extend sherpa-onnx final silence padding from 400 ms to 800 ms
- add regression coverage for sample continuity, final audio drain, and recognizer flushing

## Why
Local streaming speech recognition could truncate the last phoneme or word. The recorder packaged its final tail before the browser delivered the pending ScriptProcessor buffer, and the recognizer's 400 ms synthetic trailing silence was not always enough to emit its final tokens.

## Impact
Local voice mode now preserves the last microphone buffer and gives the streaming recognizer enough context to finalize sentence endings. One-second transport chunks remain contiguous and continue using the same recognizer stream.

## Validation
- `npx vitest run tests/client/use-pcm-stream-recorder.test.ts tests/server/local-stt-model-manager.test.ts`
- `npx vitest run tests/client/voice-dialogue-controls.test.ts tests/client/realtime-voice-playback-queue.test.ts tests/client/stt-settings-ui.test.ts tests/client/stt-settings-api.test.ts tests/server/stt-settings-controller.test.ts`
- `npm run harness:check`
- `npm run build`
- real local-model transcription reproduced the previous sentence-ending case and returned the complete final phrase
