### PR TITLE
feat(group-chat): make agent turn timeout configurable (#2386)

### DIFF
--- a/docs/chat-chain-changes/2026-08-09-pr2451-group-chat-agent-turn-timeout.md
+++ b/docs/chat-chain-changes/2026-08-09-pr2451-group-chat-agent-turn-timeout.md
@@ -1,0 +1,18 @@
+---
+date: 2026-08-09
+pr: 2451
+feature: Group Chat agent turn timeout configurable
+impact: Room-agent Hermes turns now use a configurable timeout instead of the hardcoded 120s, so long real tasks no longer die at the 120s ceiling.
+---
+
+Group Chat room-agent turns previously ran with a hardcoded 120000ms
+deadline in the Agent Bridge streaming path (`streamOutput` timeout), which
+killed long real tasks (read → fix → test → commit → docs) with
+"chat-run timed out after 120000ms" (#2386).
+
+The timeout is now read from `HERMES_GROUP_CHAT_AGENT_TURN_TIMEOUT_MS`
+(defaulting to 120000 when unset or invalid), mirroring the existing
+`HERMES_GROUP_CHAT_MAX_AGENT_MENTION_DEPTH` env-based configuration in the
+group-chat runtime. The stream wait between starting a run and reading the
+first chunk uses the configured value, so deployments with longer-running
+agents can raise the ceiling without a code change.

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -24,6 +24,16 @@ import { buildAgentInstructions, buildNonOwnerRequestSecurityPrompt } from '../c
 
 export const GROUP_CHAT_AGENT_SOCKET_SECRET = randomBytes(32).toString('hex')
 
+// Group-chat Hermes turns used a hardcoded 120s deadline in the bridge path;
+// long real tasks (read → fix → test → commit → docs) reliably died at 120s
+// with "chat-run timed out after 120000ms" (#2386). Configurable via env,
+// mirroring HERMES_GROUP_CHAT_MAX_AGENT_MENTION_DEPTH in group-chat/index.ts.
+export function groupChatAgentTurnTimeoutMs(): number {
+    const value = Number(process.env.HERMES_GROUP_CHAT_AGENT_TURN_TIMEOUT_MS)
+    if (!Number.isFinite(value) || value <= 0) return 120_000
+    return Math.floor(value)
+}
+
 // ─── Types ────────────────────────────────────────────────────
 
 export interface AgentConfig {
@@ -1286,7 +1296,7 @@ export class AgentClient implements GroupAgentExecutor {
 
             this.emitMessageStreamStart(roomId, streamMessageId, sessionId, runMessageId)
             streamStarted = true
-            for await (const chunk of bridge.streamOutput(started.run_id, { timeoutMs: 120000 })) {
+            for await (const chunk of bridge.streamOutput(started.run_id, { timeoutMs: groupChatAgentTurnTimeoutMs() })) {
                 if (!this.replySessionIsCurrent(roomId, sessionId, replyInterruptVersion)) {
                     await stopStaleStartedRun?.()
                     return

--- a/tests/server/group-chat-agent-turn-timeout.test.ts
+++ b/tests/server/group-chat-agent-turn-timeout.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { groupChatAgentTurnTimeoutMs } from '../../packages/server/src/services/hermes/group-chat/agent-clients'
+
+describe('group chat agent turn timeout (#2386)', () => {
+  const original = process.env.HERMES_GROUP_CHAT_AGENT_TURN_TIMEOUT_MS
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.HERMES_GROUP_CHAT_AGENT_TURN_TIMEOUT_MS
+    else process.env.HERMES_GROUP_CHAT_AGENT_TURN_TIMEOUT_MS = original
+  })
+
+  it('defaults to 120s when unset', () => {
+    delete process.env.HERMES_GROUP_CHAT_AGENT_TURN_TIMEOUT_MS
+    expect(groupChatAgentTurnTimeoutMs()).toBe(120_000)
+  })
+
+  it('uses a custom env value', () => {
+    process.env.HERMES_GROUP_CHAT_AGENT_TURN_TIMEOUT_MS = '300000'
+    expect(groupChatAgentTurnTimeoutMs()).toBe(300_000)
+  })
+
+  it('falls back to the default for unparseable, zero, or negative values', () => {
+    for (const bad of ['abc', '0', '-5', '']) {
+      process.env.HERMES_GROUP_CHAT_AGENT_TURN_TIMEOUT_MS = bad
+      expect(groupChatAgentTurnTimeoutMs()).toBe(120_000)
+    }
+  })
+
+  it('floors fractional values', () => {
+    process.env.HERMES_GROUP_CHAT_AGENT_TURN_TIMEOUT_MS = '150.9'
+    expect(groupChatAgentTurnTimeoutMs()).toBe(150)
+  })
+})


### PR DESCRIPTION
## What

Fixes #2386 — the Hermes bridge path hardcoded a 120-second deadline on every group-chat agent turn. Real tasks (read → fix → test → commit → docs) reliably died at ~120s with `Error: chat-run timed out after 120000ms` even though the task itself kept running fine.

## Change

- `agent-clients.ts`: new exported `groupChatAgentTurnTimeoutMs()` reads `HERMES_GROUP_CHAT_AGENT_TURN_TIMEOUT_MS` (ms). Default `120000`; unparseable, zero, or negative values fall back to the default; fractional values are floored. Mirrors the existing `HERMES_GROUP_CHAT_MAX_AGENT_MENTION_DEPTH` env convention.
- The group-chat bridge `streamOutput` deadline now uses that value instead of the literal `120000`.

## Tests

New `group-chat-agent-turn-timeout.test.ts` (4 cases): default when unset, custom env value, fallback for unparseable/zero/negative/empty, and flooring of fractional values.

- Unit test: 4/4 green.
- `tsc --noEmit -p packages/server/tsconfig.json`: clean.

Refs #2386
