### PR TITLE
Fix local STT in Electron

### DIFF
--- a/packages/server/src/services/hermes/local-stt-model-manager.ts
+++ b/packages/server/src/services/hermes/local-stt-model-manager.ts
@@ -163,7 +163,9 @@ function ensureRecognizer(root) {
 }
 
 function readWave(audioPath) {
-  const wave = sherpa.readWave(audioPath)
+  // Electron disallows Node-API external buffers, so request an owned
+  // Float32Array that also remains compatible with the regular Node runtime.
+  const wave = sherpa.readWave(audioPath, false)
   if (!wave || !wave.samples || !wave.samples.length || !wave.sampleRate) {
     throw new Error('Recorded audio is empty or is not a supported WAV file')
   }

--- a/tests/server/local-stt-model-manager.test.ts
+++ b/tests/server/local-stt-model-manager.test.ts
@@ -226,6 +226,19 @@ describe('local STT model manager', () => {
     await manager.shutdownLocalSttRuntime()
   })
 
+  it('disables external wave buffers for Electron compatibility', async () => {
+    spawnMock.mockReturnValue(createFakeModelProcess())
+    const manager = await import('../../packages/server/src/services/hermes/local-stt-model-manager')
+    installSparseTestModel(manager)
+
+    const session = await manager.createLocalSttStreamSession('7:default')
+    await manager.finishLocalSttStreamSession(session.sessionId, '7:default')
+
+    const childSource = spawnMock.mock.calls[0]?.[1]?.[2]
+    expect(childSource).toContain('sherpa.readWave(audioPath, false)')
+    await manager.shutdownLocalSttRuntime()
+  })
+
   it('does not allow another profile owner to use a local stream session', async () => {
     spawnMock.mockReturnValue(createFakeModelProcess())
     const manager = await import('../../packages/server/src/services/hermes/local-stt-model-manager')


### PR DESCRIPTION
## Summary
- disable sherpa-onnx external WAV buffers in the local STT child runtime
- add regression coverage for the Electron-compatible read path

## Root cause
`sherpa.readWave()` enables external buffers by default. Electron rejects Node-API external buffers, so local transcription failed on both macOS and Windows with `External buffers are not allowed`. Requesting an owned `Float32Array` keeps the same code compatible with Electron and regular Node servers.

## Impact
Local STT transcription now works in desktop builds while remaining compatible with Web deployments. The non-external path adds one small audio-buffer copy per recorded chunk.

## Validation
- `npm run test -- tests/server/local-stt-model-manager.test.ts`
- macOS Electron 42.3.0 real sherpa-onnx model inference
- `npm run harness:check`
- `npm run build`
- `npm run test:e2e` (112 passed)
