### PR TITLE
fix npm local STT runtime version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,14 @@
       },
       "engines": {
         "node": ">=23.0.0"
+      },
+      "optionalDependencies": {
+        "sherpa-onnx-darwin-arm64": "1.13.3",
+        "sherpa-onnx-darwin-x64": "1.13.3",
+        "sherpa-onnx-linux-arm64": "1.13.3",
+        "sherpa-onnx-linux-x64": "1.13.3",
+        "sherpa-onnx-win-ia32": "1.13.3",
+        "sherpa-onnx-win-x64": "1.13.3"
       }
     },
     "node_modules/@acemir/cssom": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,14 @@
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"
   },
+  "optionalDependencies": {
+    "sherpa-onnx-darwin-arm64": "1.13.3",
+    "sherpa-onnx-darwin-x64": "1.13.3",
+    "sherpa-onnx-linux-arm64": "1.13.3",
+    "sherpa-onnx-linux-x64": "1.13.3",
+    "sherpa-onnx-win-ia32": "1.13.3",
+    "sherpa-onnx-win-x64": "1.13.3"
+  },
   "devDependencies": {
     "@aiden0z/pptx-renderer": "^1.2.4",
     "@koa/bodyparser": "^5.0.0",

--- a/tests/server/npm-local-stt-runtime.test.ts
+++ b/tests/server/npm-local-stt-runtime.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import pkg from '../../package.json'
+
+const sherpaPlatformPackages = [
+  'sherpa-onnx-darwin-arm64',
+  'sherpa-onnx-darwin-x64',
+  'sherpa-onnx-linux-arm64',
+  'sherpa-onnx-linux-x64',
+  'sherpa-onnx-win-ia32',
+  'sherpa-onnx-win-x64',
+] as const
+
+describe('npm local STT runtime', () => {
+  it('pins every native package to the sherpa-onnx-node wrapper version', () => {
+    const wrapperVersion = pkg.dependencies['sherpa-onnx-node']
+
+    expect(wrapperVersion).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(Object.keys(pkg.optionalDependencies).sort()).toEqual([...sherpaPlatformPackages].sort())
+    for (const platformPackage of sherpaPlatformPackages) {
+      expect(pkg.optionalDependencies[platformPackage]).toBe(wrapperVersion)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- publish every supported `sherpa-onnx-*` native runtime as an exact `1.13.3` optional dependency
- keep the native runtime version aligned with `sherpa-onnx-node@1.13.3` for npm consumers
- add a regression test that rejects missing platform packages, version ranges, and wrapper/native version drift

## Root cause

`sherpa-onnx-node@1.13.3` declares its platform packages with `^1.13.3`. Repository `overrides` kept source and Desktop installs on `1.13.3`, but overrides do not propagate through the published `hermes-web-ui` package. A fresh global npm install therefore resolved the native package to `1.13.4` while retaining the `1.13.3` JavaScript wrapper. That mixed runtime loaded successfully but returned an empty transcript, which surfaced as `No speech detected`.

## Impact

Fresh npm installations will select only the native package matching the host OS and architecture, pin it to `1.13.3`, and deduplicate it with the wrapper's compatible optional dependency. Desktop packaging remains unchanged.

## Validation

- locally repaired the global macOS installation to `1.13.3 + 1.13.3`, recognized a known 86,016-sample WAV, and restarted `hermes-web-ui` on port 8648
- packed this branch with `npm pack`, installed the tarball into an empty directory, confirmed `sherpa-onnx-node@1.13.3` and `sherpa-onnx-darwin-arm64@1.13.3`, and recognized the same WAV
- `npm run test -- tests/server/npm-local-stt-runtime.test.ts tests/server/local-stt-model-manager.test.ts` — 9 passed
- `npm run harness:check`
- `npm run test:coverage` — 455 files passed, 3789 tests passed, 3 skipped
- `npm run build`
- `npm run test:e2e` — 111 passed; the existing Terminal test raced with Group Chat's `/socket.io/` connection in the full run
- `npx playwright test tests/e2e/terminal.spec.ts` — 1 passed on isolated rerun
