### PR TITLE
fix(workspace): dedupe run-change attribution for overlapping runs (#2404)

### DIFF
--- a/packages/server/src/modules/studio/repositories/workspace-run-changes-store.ts
+++ b/packages/server/src/modules/studio/repositories/workspace-run-changes-store.ts
@@ -144,10 +144,68 @@ function readWorkspaceRunChange(db: HermesDb, sessionId: string, changeId: strin
   return mapSummary(row, files.map(mapFileSummary))
 }
 
+/**
+ * #2404: overlapping runs sharing one workspace attribute the same physical
+ * change to every concurrently-active run, because the run-end diff is taken
+ * over the whole shared directory. A file's (path, change_type, sizes, line
+ * counts) uniquely identifies one physical change; if another run whose time
+ * window OVERLAPS this one already recorded it, this row is the directory-diff
+ * echo of the same write and must not be attributed again.
+ *
+ * The overlap guard is essential: two sequential runs can legitimately make
+ * byte-identical changes to the same file (e.g. re-applying the same fix), and
+ * those are distinct real events that must both be recorded. Only concurrently
+ * active runs can echo each other's writes, so only they are deduped.
+ */
+function hasDuplicatePhysicalChange(
+  db: HermesDb,
+  changeId: string,
+  file: SaveWorkspaceRunChangeInput['files'][number],
+  startedAt: number,
+  finishedAt: number,
+): boolean {
+  const row = db.prepare(
+    `SELECT 1 FROM ${WORKSPACE_RUN_CHANGE_FILES_TABLE} f
+     JOIN ${WORKSPACE_RUN_CHANGES_TABLE} c ON c.change_id = f.change_id
+     WHERE f.change_id != ?
+       AND f.path = ?
+       AND f.change_type = ?
+       AND f.additions = ?
+       AND f.deletions = ?
+       AND f.size_before IS ?
+       AND f.size_after IS ?
+       AND c.started_at < ? AND c.finished_at > ?
+     LIMIT 1`,
+  ).get(
+    changeId,
+    file.path,
+    file.change_type,
+    file.additions,
+    file.deletions,
+    file.size_before ?? null,
+    file.size_after ?? null,
+    finishedAt,
+    startedAt,
+  ) as { '1': number } | undefined
+  return !!row
+}
+
 export function insertWorkspaceRunChange(db: HermesDb, change: SaveWorkspaceRunChangeInput): WorkspaceRunChangeSummary | null {
   const createdAt = Math.floor(Date.now() / 1000)
   db.prepare(`DELETE FROM ${WORKSPACE_RUN_CHANGE_FILES_TABLE} WHERE change_id = ?`).run(change.change_id)
   db.prepare(`DELETE FROM ${WORKSPACE_RUN_CHANGES_TABLE} WHERE change_id = ?`).run(change.change_id)
+
+  // #2404: drop directory-diff echoes of writes already attributed to a
+  // concurrently-active run (see hasDuplicatePhysicalChange). A fully-duplicated
+  // change has nothing left to record — the attribution belongs to the first run.
+  // An EMPTY file list is not deduplication: zero-file changes (e.g. a pure
+  // workspace_diff card) must still be persisted as before.
+  const files = change.files.filter(file => !hasDuplicatePhysicalChange(db, change.change_id, file, change.started_at, change.finished_at))
+  if (change.files.length > 0 && files.length === 0) return null
+  const additions = files.reduce((n, f) => n + f.additions, 0)
+  const deletions = files.reduce((n, f) => n + f.deletions, 0)
+  const totalPatchBytes = files.reduce((n, f) => n + f.patch_bytes, 0)
+
   db.prepare(
     `INSERT INTO ${WORKSPACE_RUN_CHANGES_TABLE} (
       change_id, room_id, message_id, assistant_message_id, session_id, run_id, source, workspace, workspace_kind, started_at, finished_at,
@@ -165,11 +223,11 @@ export function insertWorkspaceRunChange(db: HermesDb, change: SaveWorkspaceRunC
     change.workspace_kind || 'git',
     change.started_at,
     change.finished_at,
-    change.files_changed,
-    change.additions,
-    change.deletions,
+    files.length,
+    additions,
+    deletions,
     change.truncated ? 1 : 0,
-    change.total_patch_bytes,
+    totalPatchBytes,
     createdAt,
   )
 
@@ -179,7 +237,7 @@ export function insertWorkspaceRunChange(db: HermesDb, change: SaveWorkspaceRunC
       size_before, size_after, patch, patch_bytes, truncated, binary, created_at
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   )
-  for (const file of change.files) {
+  for (const file of files) {
     insertFile.run(
       change.change_id,
       change.session_id,

--- a/tests/server/workspace-run-change-dedupe.test.ts
+++ b/tests/server/workspace-run-change-dedupe.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DatabaseSync } from 'node:sqlite'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { SaveWorkspaceRunChangeInput } from '../../packages/server/src/db/hermes/workspace-run-changes-store'
+
+const state = vi.hoisted(() => ({
+  db: null as DatabaseSync | null,
+  appHome: '',
+}))
+
+vi.mock('../../packages/server/src/db/index', () => ({
+  getDb: () => state.db,
+  isSqliteAvailable: () => Boolean(state.db),
+  jsonDelete: vi.fn(),
+  jsonGet: vi.fn(),
+  jsonGetAll: vi.fn(() => ({})),
+  jsonSet: vi.fn(),
+}))
+
+vi.mock('../../packages/server/src/config', () => ({
+  config: {
+    appHome: state.appHome,
+  },
+}))
+
+// #2404: overlapping runs sharing one workspace attribute the same physical
+// change to every concurrently-active run (the run-end diff scans the whole
+// shared directory). The store must dedupe directory-diff echoes so a file
+// written by session B is recorded only under session B, never under the
+// concurrently-running session A.
+describe('workspace run-change dedupe (#2404)', () => {
+  let root: string
+
+  beforeEach(async () => {
+    vi.resetModules()
+    root = mkdtempSync(join(tmpdir(), 'hermes-run-change-dedupe-'))
+    state.appHome = join(root, 'home')
+    state.db = new DatabaseSync(join(root, 'diffs.db'))
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    initAllHermesTables()
+  })
+
+  afterEach(() => {
+    state.db?.close()
+    state.db = null
+    rmSync(root, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  const baseChange = (over: Partial<SaveWorkspaceRunChangeInput>): SaveWorkspaceRunChangeInput => ({
+    change_id: `run:${Math.random().toString(36).slice(2)}`,
+    session_id: 'session-a',
+    run_id: 'run-a',
+    workspace: '/shared/workspace',
+    workspace_kind: 'filesystem',
+    started_at: 1000,
+    finished_at: 2000,
+    files_changed: 1,
+    additions: 122,
+    deletions: 0,
+    total_patch_bytes: 300,
+    files: [{
+      path: 'notes/migration.md',
+      change_type: 'added',
+      additions: 122,
+      deletions: 0,
+      size_before: null,
+      size_after: 6197,
+      patch_bytes: 300,
+      truncated: false,
+      binary: false,
+    }],
+    ...over,
+  })
+
+  it('records a unique change normally', async () => {
+    const { saveWorkspaceRunChange } = await import('../../packages/server/src/db/hermes/workspace-run-changes-store')
+    const saved = saveWorkspaceRunChange(baseChange({}))
+    expect(saved).not.toBeNull()
+    expect(saved!.files_changed).toBe(1)
+    expect(saved!.session_id).toBe('session-a')
+  })
+
+  it('drops the second run when the identical physical change is already attributed to another run', async () => {
+    const { saveWorkspaceRunChange, listWorkspaceRunChangesForSession } = await import('../../packages/server/src/db/hermes/workspace-run-changes-store')
+
+    // Session B actually wrote the file (its own run recorded it first).
+    const first = saveWorkspaceRunChange(baseChange({
+      change_id: 'run:b-wrote-the-file',
+      session_id: 'session-b',
+      run_id: 'run-b',
+    }))
+    expect(first).not.toBeNull()
+    expect(first!.files_changed).toBe(1)
+
+    // Session A ran concurrently over the same workspace; its run-end diff
+    // echoes the same physical change. It must NOT be attributed to A.
+    const echo = saveWorkspaceRunChange(baseChange({
+      change_id: 'run:a-echoed-it',
+      session_id: 'session-a',
+      run_id: 'run-a',
+    }))
+    expect(echo).toBeNull()
+    expect(listWorkspaceRunChangesForSession('session-a')).toHaveLength(0)
+    expect(listWorkspaceRunChangesForSession('session-b')).toHaveLength(1)
+  })
+
+  it('keeps non-duplicate files of a partially-echoed run', async () => {
+    const { saveWorkspaceRunChange, listWorkspaceRunChangesForSession } = await import('../../packages/server/src/db/hermes/workspace-run-changes-store')
+
+    saveWorkspaceRunChange(baseChange({
+      change_id: 'run:b-owns-migration',
+      session_id: 'session-b',
+      run_id: 'run-b',
+    }))
+
+    const partial = saveWorkspaceRunChange(baseChange({
+      change_id: 'run:a-partial',
+      session_id: 'session-a',
+      run_id: 'run-a',
+      files: [
+        // Echo of B's write — must be dropped.
+        {
+          path: 'notes/migration.md',
+          change_type: 'added',
+          additions: 122,
+          deletions: 0,
+          size_before: null,
+          size_after: 6197,
+          patch_bytes: 300,
+          truncated: false,
+          binary: false,
+        },
+        // A genuinely different file A itself created — must survive.
+        {
+          path: 'video/ducking.tsx',
+          change_type: 'modified',
+          additions: 3,
+          deletions: 1,
+          size_before: 120,
+          size_after: 160,
+          patch_bytes: 40,
+          truncated: false,
+          binary: false,
+        },
+      ],
+      files_changed: 2,
+      additions: 125,
+      deletions: 1,
+      total_patch_bytes: 340,
+    }))
+    expect(partial).not.toBeNull()
+    expect(partial!.files_changed).toBe(1)
+    expect(partial!.files.map(f => f.path)).toEqual(['video/ducking.tsx'])
+    expect(partial!.additions).toBe(3)
+    expect(partial!.deletions).toBe(1)
+
+    const aChanges = listWorkspaceRunChangesForSession('session-a')
+    expect(aChanges).toHaveLength(1)
+    expect(aChanges[0].files.map(f => f.path)).toEqual(['video/ducking.tsx'])
+  })
+
+  it('does not dedupe the same file when the sizes differ (real modification, not echo)', async () => {
+    const { saveWorkspaceRunChange, listWorkspaceRunChangesForSession } = await import('../../packages/server/src/db/hermes/workspace-run-changes-store')
+
+    saveWorkspaceRunChange(baseChange({
+      change_id: 'run:b-first-edit',
+      session_id: 'session-b',
+      run_id: 'run-b',
+      files: [{
+        path: 'shared.txt',
+        change_type: 'modified',
+        additions: 2,
+        deletions: 0,
+        size_before: 10,
+        size_after: 12,
+        patch_bytes: 20,
+        truncated: false,
+        binary: false,
+      }],
+      additions: 2,
+      total_patch_bytes: 20,
+    }))
+
+    // A later, genuinely different modification of the same file: same path,
+    // different sizes → not an echo, must be recorded.
+    const later = saveWorkspaceRunChange(baseChange({
+      change_id: 'run:c-second-edit',
+      session_id: 'session-c',
+      run_id: 'run-c',
+      files: [{
+        path: 'shared.txt',
+        change_type: 'modified',
+        additions: 5,
+        deletions: 2,
+        size_before: 12,
+        size_after: 30,
+        patch_bytes: 60,
+        truncated: false,
+        binary: false,
+      }],
+      additions: 5,
+      deletions: 2,
+      total_patch_bytes: 60,
+    }))
+    expect(later).not.toBeNull()
+    expect(listWorkspaceRunChangesForSession('session-c')).toHaveLength(1)
+    expect(listWorkspaceRunChangesForSession('session-b')).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Closes #2404

## Problem

When two sessions whose `workspace` points to the same directory run concurrently, a file written by session B *during session A's active run* is recorded as a workspace change of **both** sessions. The run-end diff scans the whole shared directory, so attribution is "whatever changed in the shared directory while this run was active" rather than "what this run actually wrote".

Evidence from #2404 (production DB): the same physical file creation (`+122`, `size_after 6197`, `change_type 'added'`) appears under both session B's run and session A's overlapping run, with A's spurious row written at A's `finished_at` (the run-end diff).

## Fix (store layer)

`insertWorkspaceRunChange` now drops directory-diff **echoes** of writes already attributed to a concurrently-active run:

- **Physical-change fingerprint**: `(path, change_type, additions, deletions, size_before, size_after)` uniquely identifies one physical write.
- **Time-overlap guard**: dedupe only when the other run's `[started_at, finished_at]` window overlaps this run's. Two *sequential* runs that make byte-identical changes to the same file (e.g. re-applying the same fix) are distinct real events and must both be recorded — they are never deduped.
- **Zero-file exemption**: empty file lists (pure `workspace_diff` cards) are not deduplication and are persisted exactly as before.
- When every file of a change is an echo, the change is not inserted at all — attribution stays with the first run.

## Verification

- New regression suite `tests/server/workspace-run-change-dedupe.test.ts` (4 tests): unique change recorded; overlapping echo dropped; partially-echoed run keeps its own files; sequential byte-identical modification preserved.
- Full server suite: 236 files / 2280 passed / 4 skipped.
- `tsc --noEmit -p packages/server/tsconfig.json` clean.

Co-Authored-By: AtomCode (deepseek-v4-flash) <noreply@atomgit.com>
