### PR TITLE
fix: reconcile recoverable Codex native errors

### DIFF
--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -107,6 +107,7 @@ interface ManagedCodingAgentRun {
   codexToolBlocks?: Map<string, { id: string; name: string; arguments: string; done: boolean }>
   codexChatText?: string
   codexPendingUsage?: any
+  codexPendingError?: string
   terminalUsageRefresh?: Promise<void>
   stoppedByUser?: boolean
   pendingChatCompletionEvent?: 'run.completed' | 'run.failed'
@@ -1366,6 +1367,7 @@ export class CodingAgentRunManager {
     run.printMessageId = `msg_${responseId}`
     run.printTextStarted = false
     run.printText = ''
+    run.codexPendingError = undefined
     run.printCompleted = false
     run.responseStartEmitted = false
     run.terminalEventHandled = false
@@ -1457,29 +1459,33 @@ export class CodingAgentRunManager {
       run.currentChildKillTimer = undefined
       run.currentChild = undefined
       logger.info({ runId: run.id, sessionId: run.launch.sessionId, code }, '[coding-agent-run] codex exec exited')
-      if (run.stoppedByUser) return
-      if (run.pendingChatCompletionEvent) {
-        void this.emitAndMarkPrintChatRunCompletedAfterUsage(run, run.pendingChatCompletionEvent, run.pendingChatCompletionPayload)
-        return
-      }
-      if (code === 0) {
-        this.completeCodexExecTurn(run, run.codexPendingUsage)
-        return
-      }
-      this.handleClaudePrintResponseEvent(run, {
+      this.finishCodexExecTurn(run, code)
+    })
+  }
+
+  private finishCodexExecTurn(run: ManagedCodingAgentRun, code: number | null) {
+    if (run.stoppedByUser) return
+    if (run.pendingChatCompletionEvent) {
+      void this.emitAndMarkPrintChatRunCompletedAfterUsage(run, run.pendingChatCompletionEvent, run.pendingChatCompletionPayload)
+      return
+    }
+    if (code === 0) {
+      this.completeCodexExecTurn(run, run.codexPendingUsage)
+      return
+    }
+    this.handleClaudePrintResponseEvent(run, {
+      type: 'response.failed',
+      data: {
         type: 'response.failed',
-        data: {
-          type: 'response.failed',
-          response: {
-            id: run.printResponseId,
-            object: 'response',
-            status: 'failed',
-            model: run.launch.model,
-            error: { message: exitErrorMessage('Codex', code, run.currentChildStderr) },
-            output: [],
-          },
+        response: {
+          id: run.printResponseId,
+          object: 'response',
+          status: 'failed',
+          model: run.launch.model,
+          error: { message: run.codexPendingError || exitErrorMessage('Codex', code, run.currentChildStderr) },
+          output: [],
         },
-      })
+      },
     })
   }
 
@@ -1529,8 +1535,12 @@ export class CodingAgentRunManager {
       run.codexPendingUsage = event.usage
       return
     }
-    if (type === 'turn.failed' || type === 'error') {
+    if (type === 'turn.failed') {
       this.failCodexExecTurn(run, event.error?.message || event.message || 'Codex run failed')
+      return
+    }
+    if (type === 'error') {
+      this.deferCodexExecError(run, event.error?.message || event.message || 'Codex run failed')
     }
   }
 
@@ -1565,9 +1575,24 @@ export class CodingAgentRunManager {
       run.codexPendingUsage = params.usage
       return
     }
-    if (method === 'turn/failed' || method === 'error') {
+    if (method === 'turn/failed') {
       this.failCodexExecTurn(run, params.error?.message || params.message || 'Codex run failed')
+      return
     }
+    if (method === 'error') {
+      this.deferCodexExecError(run, params.error?.message || params.message || 'Codex run failed')
+    }
+  }
+
+  private deferCodexExecError(run: ManagedCodingAgentRun, message: string) {
+    // Codex emits broad `error` events for recoverable stream retries as well as
+    // failures. Let the native process exit status arbitrate the turn: exit 0
+    // discards this provisional error, while a non-zero exit reports it.
+    if (childIsRunning(run.currentChild)) {
+      run.codexPendingError = message
+      return
+    }
+    this.failCodexExecTurn(run, message)
   }
 
   private failCodexExecTurn(run: ManagedCodingAgentRun, message: string) {

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -488,6 +488,111 @@ describe('coding agent run state', () => {
     manager.shutdown()
   })
 
+  it('lets recovered native Codex errors complete successfully when the child exits zero', async () => {
+    initAllHermesTables()
+    const manager = new CodingAgentRunManager()
+    const state: any = { messages: [], isWorking: true, events: [], queue: [] }
+    const emitted = vi.fn()
+    ;(manager as any).ensureDbSession = () => {}
+    ;(manager as any).emitToChat = emitted
+    ;(manager as any).refreshCodingAgentUsage = async () => {}
+
+    manager.start({
+      agentSessionId: 'agent-session-codex-native-retry',
+      agentId: 'codex',
+      mode: 'scoped',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'test-model',
+      sessionId: 'chat-session-codex-native-retry',
+      command: 'codex',
+      args: [],
+      shellCommand: 'codex',
+      workspaceDir: process.cwd(),
+      state,
+    })
+    const run = (manager as any).runs.get('agent-session-codex-native-retry')
+    run.currentChild = { exitCode: null, signalCode: null, killed: false }
+
+    ;(manager as any).handleCodexExecLine(run, JSON.stringify({
+      type: 'error',
+      message: 'Reconnecting... 1/5 (stream disconnected before completion: stream closed before response.completed)',
+    }))
+
+    expect(run.terminalEventHandled).not.toBe(true)
+    expect(run.pendingChatCompletionEvent).toBeUndefined()
+    expect(run.codexPendingError).toBe('Reconnecting... 1/5 (stream disconnected before completion: stream closed before response.completed)')
+    expect(emitted).not.toHaveBeenCalledWith('chat-session-codex-native-retry', 'run.failed', expect.anything())
+
+    ;(manager as any).handleCodexExecLine(run, JSON.stringify({
+      method: 'error',
+      params: { message: 'Reconnecting... 2/5' },
+    }))
+
+    expect(run.terminalEventHandled).not.toBe(true)
+    expect(run.pendingChatCompletionEvent).toBeUndefined()
+    expect(run.codexPendingError).toBe('Reconnecting... 2/5')
+
+    ;(manager as any).appendCodexFinalText(run, 'recovered final answer')
+    run.currentChild = undefined
+    ;(manager as any).finishCodexExecTurn(run, 0)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(run.terminalEventHandled).toBe(true)
+    expect(run.pendingChatCompletionEvent).toBeUndefined()
+    expect(emitted).toHaveBeenCalledWith('chat-session-codex-native-retry', 'run.completed', expect.objectContaining({
+      output: 'recovered final answer',
+      error: undefined,
+    }))
+    expect(emitted).not.toHaveBeenCalledWith('chat-session-codex-native-retry', 'run.failed', expect.anything())
+    ;(manager as any).finishCodexExecTurn(run, 0)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(emitted.mock.calls.filter(([, event]) => event === 'run.completed')).toHaveLength(1)
+    manager.shutdown()
+  })
+
+  it('reports a provisional native Codex error when the child exits non-zero', async () => {
+    initAllHermesTables()
+    const manager = new CodingAgentRunManager()
+    const state: any = { messages: [], isWorking: true, events: [], queue: [] }
+    const emitted = vi.fn()
+    ;(manager as any).ensureDbSession = () => {}
+    ;(manager as any).emitToChat = emitted
+    ;(manager as any).refreshCodingAgentUsage = async () => {}
+
+    manager.start({
+      agentSessionId: 'agent-session-codex-native-error-exit',
+      agentId: 'codex',
+      mode: 'scoped',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'test-model',
+      sessionId: 'chat-session-codex-native-error-exit',
+      command: 'codex',
+      args: [],
+      shellCommand: 'codex',
+      workspaceDir: process.cwd(),
+      state,
+    })
+    const run = (manager as any).runs.get('agent-session-codex-native-error-exit')
+    run.currentChild = { exitCode: null, signalCode: null, killed: false }
+    ;(manager as any).handleCodexExecLine(run, JSON.stringify({
+      type: 'error',
+      message: 'native transport retries exhausted',
+    }))
+
+    run.currentChild = undefined
+    ;(manager as any).finishCodexExecTurn(run, 1)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(emitted).toHaveBeenCalledWith('chat-session-codex-native-error-exit', 'run.failed', expect.objectContaining({
+      error: 'native transport retries exhausted',
+    }))
+    expect(emitted).not.toHaveBeenCalledWith('chat-session-codex-native-error-exit', 'run.completed', expect.anything())
+    expect(emitted.mock.calls.filter(([, event]) => event === 'run.failed')).toHaveLength(1)
+    manager.shutdown()
+  })
+
   it('keeps native Codex turn failures authoritative while the child is still running', () => {
     initAllHermesTables()
     const manager = new CodingAgentRunManager()


### PR DESCRIPTION
## Summary

- keep broad native Codex `type=error` / `method=error` events provisional while the child process is still running
- let the native process exit status decide whether a provisional reconnect error becomes success or failure
- preserve explicit native `turn.failed` as an immediate authoritative failure
- clear provisional errors between queued/follow-up turns
- add RED→GREEN regression coverage for proxy failure, recovered native error, and explicit native failure

## Root cause

#2375 correctly prevented Provider Proxy `response.failed` from deciding the terminal state while a native Codex child was active. However, the native JSONL adapter still mapped every broad `error` event directly to `failCodexExecTurn()`.

Codex can emit such an error while retrying a disconnected Responses stream and later finish successfully. The broad error therefore set `terminalEventHandled=true` before `task_complete` and exit code `0`, leaving Group Chat with `run.failed` and discarding the recovered final answer.

## Behavior after this change

- broad native `error` while the Codex child is alive: retain as `codexPendingError`, do not terminalize
- child exits `0`: complete normally and discard the provisional error
- child exits non-zero: fail with the retained native error when available
- explicit `turn.failed`: remain immediately authoritative
- next turn: clear stale `codexPendingError`

## TDD evidence

### RED

Before the production change, the new recovered-native-error regression failed at:

```text
expected true not to be true
run.terminalEventHandled === true
```

### GREEN

- focused arbitration tests: 4 passed
- `tests/server/agent-runner-utils.test.ts`: 54 passed
- related Coding Agent/workspace tests: 75 passed
- `npm run harness:check`: passed
- `npm run build`: passed
- `git diff --check`: passed

The first build attempt exposed an environment-only dependency omission: the shell had `NODE_ENV=production`, so npm omitted build-time `devDependencies`. Reinstalling from the unchanged lockfile with `NODE_ENV=development npm ci --include=dev --ignore-scripts` made the canonical build pass.

## Candidate identity

```text
Base: 7bcc39b3e4b2e6ebe41f56402ccadd21ccf2cdf5
HEAD: 2d497e044bc073974d44168a0150a1e5b1f786fe
Tree: be7bca42de2ae8b4ac179ee8fa8b2e61bf6fb2a8
Patch SHA-256: cdd1cecba02c0fa49989d7b1e7e99541e584bbe0fc9c2f2f96a943c6b0fe7c42
```

## Scope and safety

- no automatic child retry or duplicate task launch is added
- no Group Chat UX, Workflow, provider, model, or API-mode configuration changes
- the original transport owner of the stream disconnect remains outside this fix
- deployed-runtime acceptance should still observe/inject both a recoverable reconnect and an unrecoverable native failure before release

Fixes #2470
