### PR TITLE
Fix group chat relay lifecycle and streaming

### DIFF
--- a/docs/chat-chain-changes/2026-08-10-group-chat-relay-interactions.md
+++ b/docs/chat-chain-changes/2026-08-10-group-chat-relay-interactions.md
@@ -1,0 +1,24 @@
+---
+date: 2026-08-10
+pr: pending
+feature: Group Agent Relay mentions and pending interactions
+impact: Remote Agent handoffs preserve multi-Agent mentions, approval and clarification lifecycles stay routable across Relay, and expired interactions are removed from the group chat UI.
+---
+
+Relay message events now retain bounded structured mention metadata and the cloud
+proxy also rebuilds mentions from authoritative room state. Approval and
+clarification events use cloud-scoped IDs, support responses back to the remote
+runtime, and extend the Relay run timeout while waiting for the user.
+
+Pending approvals and clarifications have bounded server-side expiry. A Relay
+timeout, disconnect, or already-expired runtime request removes the pending
+route and emits a terminal event so browsers do not retain an unusable action.
+Invalid Relay events now fail the active run immediately instead of poisoning
+the sequence and surfacing a misleading error on the next event.
+
+Streaming reasoning in Group Chat remains available behind its disclosure but
+is collapsed by default to prevent concurrent Agent output from flooding the
+message list. The Group Chat client now batches token and reasoning deltas into
+50 ms render updates, keeps ordinary message objects stable, and limits live
+body Markdown rendering to 100 ms intervals. Stream completion still flushes
+immediately, while disconnects and room switches discard stale buffered data.

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, defineAsyncComponent, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useMessage } from 'naive-ui'
 import ProfileAvatar from '@/components/hermes/profiles/ProfileAvatar.vue'
@@ -43,6 +43,7 @@ const JSON_MAX_NODES = 1000
 const JSON_MAX_KEYS_PER_OBJECT = 50
 const JSON_MAX_ITEMS_PER_ARRAY = 50
 const JSON_TRUNCATED_KEY = '__truncated__'
+const STREAMING_MARKDOWN_RENDER_INTERVAL_MS = 100
 
 const props = withDefaults(defineProps<{
     message: ChatMessage
@@ -149,7 +150,6 @@ const thinkingStreamingNow = computed(() => {
 })
 const thinkingOverride = ref<boolean | null>(null)
 const thinkingExpanded = computed(() => {
-    if (thinkingStreamingNow.value) return true
     if (thinkingOverride.value !== null) return thinkingOverride.value
     return false
 })
@@ -204,6 +204,27 @@ const displayBody = computed(() => {
         .filter((block: any) => block?.type === 'text' && typeof block.text === 'string')
         .map((block: any) => block.text)
         .join('\n')
+})
+const renderedDisplayBody = ref(displayBody.value)
+let streamingMarkdownTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearStreamingMarkdownTimer() {
+    if (streamingMarkdownTimer === null) return
+    clearTimeout(streamingMarkdownTimer)
+    streamingMarkdownTimer = null
+}
+
+watch([displayBody, () => props.message.isStreaming], ([body, isStreaming]) => {
+    if (!isStreaming) {
+        clearStreamingMarkdownTimer()
+        renderedDisplayBody.value = body
+        return
+    }
+    if (streamingMarkdownTimer !== null) return
+    streamingMarkdownTimer = setTimeout(() => {
+        streamingMarkdownTimer = null
+        renderedDisplayBody.value = displayBody.value
+    }, STREAMING_MARKDOWN_RENDER_INTERVAL_MS)
 })
 const parsedMessageReference = computed(() =>
     props.message.role !== 'assistant' && props.message.role !== 'tool'
@@ -619,6 +640,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+    clearStreamingMarkdownTimer()
     if (autoPlayHandler) window.removeEventListener('auto-play-speech', autoPlayHandler)
     if (speech.currentMessageId.value === props.message.id || speech.currentCustomMessageId.value === props.message.id) speech.stop()
 })
@@ -760,7 +782,7 @@ onBeforeUnmount(() => {
                     <MarkdownRenderer :content="referencedContentMarkdown" :mention-names="mentionNames" />
                     <MarkdownRenderer v-if="parsedMessageReference.reply" :content="parsedMessageReference.reply" :mention-names="mentionNames" />
                 </template>
-                <MarkdownRenderer v-else-if="displayBody" :content="displayBody" :mention-names="mentionNames" />
+                <MarkdownRenderer v-else-if="renderedDisplayBody" :content="renderedDisplayBody" :mention-names="mentionNames" />
                 <ToolChangeCard
                     v-for="change in assistantWorkspaceChanges"
                     :key="change.change_id"
@@ -775,7 +797,7 @@ onBeforeUnmount(() => {
                     @toggle="toggleWorkspaceChange(change.change_id)"
                     @select="file => openWorkspaceDiffFileForPayload(file, change)"
                 />
-                <span v-if="message.isStreaming && !displayBody" class="streaming-dots">
+                <span v-if="message.isStreaming && !renderedDisplayBody" class="streaming-dots">
                     <span></span><span></span><span></span>
                 </span>
             </div>

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -82,6 +82,7 @@ function uid(): string {
 }
 
 const STREAM_FINAL_CONTENT_RECOVERY_DELAY_MS = 300
+export const GROUP_CHAT_STREAM_FLUSH_INTERVAL_MS = 50
 export const GROUP_CHAT_MESSAGE_PAGE_SIZE = 150
 export const GROUP_CHAT_MAX_DISPLAY_MESSAGES = 600
 const GROUP_CHAT_JOIN_TIMEOUT_MS = 30000
@@ -157,6 +158,13 @@ export const useGroupChatStore = defineStore('groupChat', () => {
     const currentRoomId = ref<string | null>(null)
     const rooms = ref<RoomInfo[]>([])
     const messages = ref<ChatMessage[]>([])
+    const pendingStreamDeltas = new Map<string, {
+        roomId: string
+        messageId: string
+        content: string
+        reasoning: string
+    }>()
+    let streamFlushTimer: ReturnType<typeof setTimeout> | null = null
     const messageReferences = ref<Map<string, MessageReference>>(new Map())
     const activeMessageReference = computed(() => {
         const roomId = currentRoomId.value
@@ -208,6 +216,67 @@ export const useGroupChatStore = defineStore('groupChat', () => {
         loadedMessageCount.value = 0
         hasMoreBefore.value = false
         isLoadingOlderMessages.value = false
+    }
+
+    function streamDeltaKey(roomId: string, messageId: string): string {
+        return `${roomId}\u0000${messageId}`
+    }
+
+    function clearStreamFlushTimer() {
+        if (streamFlushTimer === null) return
+        clearTimeout(streamFlushTimer)
+        streamFlushTimer = null
+    }
+
+    function clearPendingStreamDeltas() {
+        clearStreamFlushTimer()
+        pendingStreamDeltas.clear()
+    }
+
+    function flushPendingStreamDeltas(roomId?: string, messageId?: string) {
+        const entries = Array.from(pendingStreamDeltas.entries()).filter(([, pending]) => (
+            (!roomId || pending.roomId === roomId) &&
+            (!messageId || pending.messageId === messageId)
+        ))
+        for (const [key, pending] of entries) {
+            pendingStreamDeltas.delete(key)
+            if (pending.roomId !== currentRoomId.value) continue
+            const message = messages.value.find(item => item.id === pending.messageId)
+            if (!message?.isStreaming) continue
+            if (pending.content) message.content = (message.content || '') + pending.content
+            if (pending.reasoning) {
+                message.reasoning = (message.reasoning || '') + pending.reasoning
+                message.reasoning_content = (message.reasoning_content || '') + pending.reasoning
+            }
+        }
+        if (pendingStreamDeltas.size === 0) clearStreamFlushTimer()
+    }
+
+    function scheduleStreamDeltaFlush() {
+        if (streamFlushTimer !== null) return
+        streamFlushTimer = setTimeout(() => {
+            streamFlushTimer = null
+            flushPendingStreamDeltas()
+        }, GROUP_CHAT_STREAM_FLUSH_INTERVAL_MS)
+    }
+
+    function queueStreamDelta(
+        data: { roomId: string; id: string; delta: string },
+        field: 'content' | 'reasoning',
+    ) {
+        if (data.roomId !== currentRoomId.value || !data.delta) return
+        const message = messages.value.find(item => item.id === data.id)
+        if (!message?.isStreaming) return
+        const key = streamDeltaKey(data.roomId, data.id)
+        const pending = pendingStreamDeltas.get(key) || {
+            roomId: data.roomId,
+            messageId: data.id,
+            content: '',
+            reasoning: '',
+        }
+        pending[field] += data.delta
+        pendingStreamDeltas.set(key, pending)
+        scheduleStreamDeltaFlush()
     }
 
     function applyMessagePaging(res: { messages: ChatMessage[]; total?: number; hasMore?: boolean }) {
@@ -281,6 +350,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
     }
 
     function settleAgentActivity(agentName: string) {
+        flushPendingStreamDeltas(currentRoomId.value || undefined)
         contextStatuses.value.delete(agentName)
         messages.value = messages.value
             .map(m => (
@@ -761,6 +831,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
             realtimeJoinedRoomId.value = null
             realtimeJoinedSocketId.value = null
             pendingRealtimeJoin = null
+            clearPendingStreamDeltas()
             resetLocalTypingState()
         })
 
@@ -777,6 +848,10 @@ export const useGroupChatStore = defineStore('groupChat', () => {
                 recordPersistedRoomActivity(msg.roomId, Number(msg.persistedAt || msg.timestamp || 0))
             }
             if (msg.roomId === currentRoomId.value) {
+                // A persisted message can seal or transform another live row in
+                // the same agent run. Apply all queued room deltas first so the
+                // final event remains authoritative without losing token text.
+                flushPendingStreamDeltas(msg.roomId)
                 captureHistoricalMessageAgents([msg])
                 if (msg.role === 'assistant' && msg.tool_calls?.length) {
                     const responseRunId = inferredGroupResponseRunId(msg)
@@ -811,6 +886,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
 
         socket.on('message_stream_start', (msg: ChatMessage) => {
             if (msg.roomId !== currentRoomId.value) return
+            flushPendingStreamDeltas(msg.roomId, msg.id)
             messages.value = messages.value.filter(m => !(
                 m.roomId === msg.roomId &&
                 m.senderId === msg.senderId &&
@@ -826,15 +902,12 @@ export const useGroupChatStore = defineStore('groupChat', () => {
             if (idx >= 0) {
                 const existing = messages.value[idx]
                 if (!existing.isStreaming) return
-                messages.value[idx] = {
-                    ...existing,
-                    ...msg,
+                Object.assign(existing, msg, {
                     content: hasText(msg.content) ? msg.content : existing.content || '',
                     reasoning: hasText(msg.reasoning) ? msg.reasoning : existing.reasoning,
                     reasoning_content: hasText(msg.reasoning_content) ? msg.reasoning_content : existing.reasoning_content,
                     isStreaming: true,
-                }
-                messages.value = [...messages.value]
+                })
             } else {
                 messages.value.push(msg)
                 loadedMessageCount.value += 1
@@ -843,31 +916,16 @@ export const useGroupChatStore = defineStore('groupChat', () => {
         })
 
         socket.on('message_stream_delta', (data: { roomId: string; id: string; delta: string }) => {
-            if (data.roomId !== currentRoomId.value) return
-            const idx = messages.value.findIndex(m => m.id === data.id)
-            if (idx < 0 || !messages.value[idx].isStreaming) return
-            messages.value[idx] = {
-                ...messages.value[idx],
-                content: messages.value[idx].content + data.delta,
-            }
-            messages.value = [...messages.value]
+            queueStreamDelta(data, 'content')
         })
 
         socket.on('message_reasoning_delta', (data: { roomId: string; id: string; delta: string }) => {
-            if (data.roomId !== currentRoomId.value) return
-            const idx = messages.value.findIndex(m => m.id === data.id)
-            if (idx < 0 || !messages.value[idx].isStreaming) return
-            messages.value[idx] = {
-                ...messages.value[idx],
-                reasoning: (messages.value[idx].reasoning || '') + data.delta,
-                reasoning_content: (messages.value[idx].reasoning_content || '') + data.delta,
-                isStreaming: true,
-            }
-            messages.value = [...messages.value]
+            queueStreamDelta(data, 'reasoning')
         })
 
         socket.on('message_stream_end', (data: { roomId: string; id: string }) => {
             if (data.roomId !== currentRoomId.value) return
+            flushPendingStreamDeltas(data.roomId, data.id)
             const idx = messages.value.findIndex(m => m.id === data.id)
             if (
                 idx >= 0 &&
@@ -877,11 +935,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
             ) {
                 messages.value.splice(idx, 1)
             } else if (idx >= 0) {
-                messages.value[idx] = {
-                    ...messages.value[idx],
-                    isStreaming: false,
-                }
-                messages.value = [...messages.value]
+                messages.value[idx].isStreaming = false
                 if (needsFinalContentRecovery(messages.value[idx])) {
                     scheduleMissingFinalContentRecovery(data.roomId, data.id)
                 }
@@ -906,6 +960,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
             currentRoomId.value = null
             realtimeJoinedRoomId.value = null
             realtimeJoinedSocketId.value = null
+            clearPendingStreamDeltas()
             messages.value = []
             resetMessagePaging()
             members.value = []
@@ -1029,6 +1084,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
             roomSummaryStates.value.delete(data.roomId)
             roomSummaryStates.value = new Map(roomSummaryStates.value)
             if (data.roomId === currentRoomId.value) {
+                clearPendingStreamDeltas()
                 messages.value = []
                 historicalMessageAgents.value = []
                 resetMessagePaging()
@@ -1050,6 +1106,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
         boundSocket = null
         connectPromise = null
         pendingRealtimeJoin = null
+        clearPendingStreamDeltas()
         connected.value = false
         realtimeJoinedRoomId.value = null
         realtimeJoinedSocketId.value = null
@@ -1115,6 +1172,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
             const res = await getRoomDetail(roomId)
             const previousRoomId = currentRoomId.value
             if (previousRoomId && previousRoomId !== res.room.id) emitStopTyping(previousRoomId)
+            clearPendingStreamDeltas()
             upsertRoom(res.room)
             currentRoomId.value = res.room.id
             realtimeJoinedRoomId.value = null
@@ -1281,6 +1339,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
             const normalizedCode = code.trim()
             if (!normalizedCode) throw new Error('Invite code is required')
             const res = await joinRoomByCode(normalizedCode)
+            clearPendingStreamDeltas()
             inviteGuest.value = options.guest === true
             activeInviteCode.value = normalizedCode
             upsertRoom(res.room)
@@ -1310,6 +1369,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
                 currentRoomId.value = null
                 realtimeJoinedRoomId.value = null
                 realtimeJoinedSocketId.value = null
+                clearPendingStreamDeltas()
                 messages.value = []
                 historicalMessageAgents.value = []
                 resetMessagePaging()
@@ -1339,6 +1399,7 @@ export const useGroupChatStore = defineStore('groupChat', () => {
         const roomId = currentRoomId.value
         try {
             const res = await clearRoomContext(roomId)
+            clearPendingStreamDeltas()
             messages.value = []
             historicalMessageAgents.value = []
             clearMessageReference(roomId)
@@ -1729,6 +1790,12 @@ function groupToolPairKey(message: ChatMessage, toolCallId: string): string {
 }
 
 function attachWorkspaceDiffsToParentMessages(messages: ChatMessage[]): ChatMessage[] {
+    const hasWorkspaceDiff = messages.some(message =>
+        (message.toolName || message.tool_name) === 'workspace_diff',
+    )
+    const hasAttachedWorkspaceChanges = messages.some(message => message.workspaceChanges?.length)
+    if (!hasWorkspaceDiff && !hasAttachedWorkspaceChanges) return messages
+
     const mapped: ChatMessage[] = messages.map(message => ({ ...message, workspaceChanges: [] }))
     const assistantById = new Map(
         mapped

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -227,6 +227,7 @@ export interface GroupAgentExecutor {
     getActiveSessionId(roomId: string): string | undefined
     isActiveSession(roomId: string, sessionId: string): boolean
     respondApproval?(approvalId: string, choice: string): Promise<boolean>
+    respondClarify?(clarifyId: string, response: string): Promise<boolean>
     replyToMention(
         roomId: string,
         msg: MentionMessage,
@@ -1488,6 +1489,7 @@ export class AgentClient implements GroupAgentExecutor {
                     description: (ev as any).description,
                     choices: Array.isArray((ev as any).choices) ? (ev as any).choices : undefined,
                     allow_permanent: (ev as any).allow_permanent,
+                    timeout_ms: (ev as any).timeout_ms,
                 })
             } else if (eventType === 'approval.resolved') {
                 this.emitApprovalResolved(roomId, {

--- a/packages/server/src/services/hermes/group-chat/agent-relay.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-relay.ts
@@ -7,6 +7,7 @@ import { io, type Socket as ClientSocket } from 'socket.io-client'
 import { config } from '../../../config'
 import { logger } from '../../../services/logger'
 import { respondToEkkoToolApproval } from '../../ekko-agent/approvals'
+import { respondToEkkoClarification } from '../../ekko-agent/clarifications'
 import { AgentBridgeClient } from '../agent-bridge'
 import {
   AgentClient,
@@ -15,6 +16,7 @@ import {
   type GroupAgentExecutor,
   type GroupChatRunService,
   type MentionMessage,
+  type StructuredMentionEntry,
   type WorkspaceDiffBroadcaster,
 } from './agent-clients'
 import { defaultGroupChatWorkspace, type GroupChatServer } from './index'
@@ -50,6 +52,7 @@ import {
 export const GROUP_AGENT_RELAY_PROTOCOL_VERSION = 1
 const RELAY_ACCEPT_TIMEOUT_MS = 10_000
 const RELAY_RUN_TIMEOUT_MS = 150_000
+const RELAY_INTERACTION_TIMEOUT_MS = 330_000
 const RELAY_AGENT_CONFIG_UPDATE_INTERVAL_MS = 1_000
 const RELAY_ATTACHMENT_CHUNK_BYTES = 256 * 1024
 const RELAY_ATTACHMENT_MAX_BYTES = 20 * 1024 * 1024
@@ -104,6 +107,7 @@ type PendingRelayRun = {
   attachments: Map<string, RelayAttachmentSource>
   messageIds: Map<string, string>
   approvalIds: Map<string, string>
+  clarifyIds: Map<string, string>
   result: {
     parentMessageId?: string
     responseRunId?: string
@@ -365,6 +369,13 @@ class RelayGroupAgentExecutor implements GroupAgentExecutor {
     private readonly connector: GroupAgentConnector,
     agent: any,
     private readonly storage: any,
+    private readonly expirePendingInteractions: (
+      roomId: string,
+      agentName: string,
+      approvalIds: string[],
+      clarifyIds: string[],
+      reason: string,
+    ) => void,
   ) {
     this.agentId = String(agent.agentId)
     this.agent = agent.agent || 'hermes'
@@ -519,6 +530,7 @@ class RelayGroupAgentExecutor implements GroupAgentExecutor {
           attachments: new Map(prepared.attachments.map(attachment => [attachment.id, attachment])),
           messageIds: new Map(),
           approvalIds: new Map(),
+          clarifyIds: new Map(),
           result: relayResult,
           resolve,
           reject,
@@ -701,6 +713,15 @@ class RelayGroupAgentExecutor implements GroupAgentExecutor {
     clearTimeout(this.pendingRun.acceptedTimer)
   }
 
+  private refreshRunTimeout(pending: PendingRelayRun, timeoutMs = RELAY_RUN_TIMEOUT_MS): void {
+    clearTimeout(pending.runTimer)
+    pending.runTimer = setTimeout(() => {
+      this.relaySocket.emit('run.interrupt', { runId: pending.runId, reason: 'Remote Agent run timed out' })
+      this.finishRun(pending.runId, relayError('Remote Agent run timed out', 'GROUP_AGENT_RUN_TIMEOUT'))
+    }, timeoutMs)
+    pending.runTimer.unref?.()
+  }
+
   completeRun(runId: string, error?: string): void {
     const task = this.eventQueue.then(() => {
       this.finishRun(runId, error ? relayError(error, 'GROUP_AGENT_REMOTE_RUN_FAILED') : undefined)
@@ -709,7 +730,13 @@ class RelayGroupAgentExecutor implements GroupAgentExecutor {
   }
 
   acceptEvent(event: RelayAgentEvent): Promise<void> {
-    const task = this.eventQueue.then(() => this.applyEvent(event))
+    const task = this.eventQueue
+      .then(() => this.applyEvent(event))
+      .catch((error) => {
+        const relayEventError = error instanceof Error ? error : relayError('Invalid relay event')
+        this.finishRun(event.runId, relayEventError)
+        throw relayEventError
+      })
     this.eventQueue = task.catch(() => undefined)
     return task
   }
@@ -800,6 +827,10 @@ class RelayGroupAgentExecutor implements GroupAgentExecutor {
         }
         const cloudApprovalId = `gca_${randomUUID().replace(/-/g, '')}`
         pending.approvalIds.set(cloudApprovalId, remoteApprovalId)
+        this.refreshRunTimeout(pending, Math.max(
+          RELAY_INTERACTION_TIMEOUT_MS,
+          this.remoteInteractionTimeout(data.timeout_ms) + RELAY_ACCEPT_TIMEOUT_MS,
+        ))
         this.proxy.emitApprovalRequested(pending.roomId, {
           ...this.sanitizeApprovalEvent(data),
           approval_id: cloudApprovalId,
@@ -817,6 +848,43 @@ class RelayGroupAgentExecutor implements GroupAgentExecutor {
           choice: String(data.choice || '').slice(0, 32),
           agentSessionId: sessionId,
         })
+        if (pending.approvalIds.size === 0 && pending.clarifyIds.size === 0) {
+          this.refreshRunTimeout(pending)
+        }
+        break
+      }
+      case 'clarify.requested': {
+        const remoteClarifyId = String(data.clarify_id || '').trim()
+        if (!remoteClarifyId || remoteClarifyId.length > 240) {
+          throw relayError('Invalid remote clarification id', 'GROUP_AGENT_EVENT_INVALID')
+        }
+        const cloudClarifyId = `gcc_${randomUUID().replace(/-/g, '')}`
+        pending.clarifyIds.set(cloudClarifyId, remoteClarifyId)
+        this.refreshRunTimeout(pending, Math.max(
+          RELAY_INTERACTION_TIMEOUT_MS,
+          this.remoteInteractionTimeout(data.timeout_ms) + RELAY_ACCEPT_TIMEOUT_MS,
+        ))
+        this.proxy.emitClarifyRequested(pending.roomId, {
+          ...this.sanitizeClarifyEvent(data),
+          clarify_id: cloudClarifyId,
+          agentSessionId: sessionId,
+        })
+        break
+      }
+      case 'clarify.resolved': {
+        const remoteClarifyId = String(data.clarify_id || '').trim()
+        const entry = [...pending.clarifyIds.entries()].find(([, remote]) => remote === remoteClarifyId)
+        if (!entry) throw relayError('Unknown remote clarification id', 'GROUP_AGENT_EVENT_INVALID')
+        pending.clarifyIds.delete(entry[0])
+        this.proxy.emitClarifyResolved(pending.roomId, {
+          clarify_id: entry[0],
+          resolved: data.resolved !== false,
+          reason: String(data.reason || '').slice(0, 500),
+          agentSessionId: sessionId,
+        })
+        if (pending.approvalIds.size === 0 && pending.clarifyIds.size === 0) {
+          this.refreshRunTimeout(pending)
+        }
         break
       }
       default:
@@ -843,6 +911,23 @@ class RelayGroupAgentExecutor implements GroupAgentExecutor {
         clearTimeout(timer)
         if (response?.error) reject(relayError(response.error))
         else resolve(response?.resolved === true)
+      })
+    })
+  }
+
+  respondClarify(clarifyId: string, response: string): Promise<boolean> {
+    if (!this.connected) return Promise.reject(relayError('Remote Agent is offline', 'GROUP_AGENT_OFFLINE'))
+    const remoteClarifyId = this.pendingRun?.clarifyIds.get(clarifyId)
+    if (!remoteClarifyId) return Promise.reject(relayError('Remote clarification is no longer pending'))
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(relayError('Remote clarification response timed out')), RELAY_ACCEPT_TIMEOUT_MS)
+      this.relaySocket.emit('clarify.respond', {
+        clarifyId: remoteClarifyId,
+        response: String(response).slice(0, 20_000),
+      }, (result: { resolved?: boolean; error?: string }) => {
+        clearTimeout(timer)
+        if (result?.error) reject(relayError(result.error))
+        else resolve(result?.resolved === true)
       })
     })
   }
@@ -883,6 +968,8 @@ class RelayGroupAgentExecutor implements GroupAgentExecutor {
       if (serialized.length > 1_000_000) throw relayError('Remote tool calls are too large', 'GROUP_AGENT_EVENT_INVALID')
       output.tool_calls = input.tool_calls
     }
+    const mentions = this.sanitizeRemoteMentions(input.mentions)
+    if (mentions !== undefined) output.mentions = mentions
     const mentionDepth = Number(input.mentionDepth)
     if (Number.isSafeInteger(mentionDepth) && mentionDepth >= 0 && mentionDepth <= 10) {
       output.mentionDepth = mentionDepth
@@ -899,7 +986,61 @@ class RelayGroupAgentExecutor implements GroupAgentExecutor {
       description: String(data.description || '').slice(0, 2_000),
       choices,
       allow_permanent: data.allow_permanent === true,
+      timeout_ms: this.remoteInteractionTimeout(data.timeout_ms),
     }
+  }
+
+  private sanitizeClarifyEvent(data: Record<string, unknown>): Record<string, unknown> {
+    return {
+      question: String(data.question || '').slice(0, 20_000),
+      choices: Array.isArray(data.choices)
+        ? data.choices.map(choice => String(choice).slice(0, 2_000)).slice(0, 20)
+        : null,
+      timeout_ms: this.remoteInteractionTimeout(data.timeout_ms),
+    }
+  }
+
+  private remoteInteractionTimeout(value: unknown): number {
+    const timeoutMs = Number(value)
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return 300_000
+    return Math.min(600_000, Math.max(1_000, Math.trunc(timeoutMs)))
+  }
+
+  private sanitizeRemoteMentions(value: unknown): StructuredMentionEntry[] | undefined {
+    if (value === undefined) return undefined
+    if (!Array.isArray(value) || value.length > 64) {
+      throw relayError('Invalid remote structured mentions', 'GROUP_AGENT_EVENT_INVALID')
+    }
+    const participantIds = new Set<string>()
+    let allSeen = false
+    return value.map((rawMention) => {
+      if (!rawMention || typeof rawMention !== 'object' || Array.isArray(rawMention)) {
+        throw relayError('Invalid remote structured mentions', 'GROUP_AGENT_EVENT_INVALID')
+      }
+      const mention = rawMention as Record<string, unknown>
+      if (mention.type === 'all') {
+        if (allSeen || value.length !== 1 || mention.displayName !== 'all') {
+          throw relayError('Invalid remote structured mentions', 'GROUP_AGENT_EVENT_INVALID')
+        }
+        allSeen = true
+        return { type: 'all' as const, displayName: 'all' as const }
+      }
+      const participantId = typeof mention.participantId === 'string' ? mention.participantId.trim() : ''
+      const displayName = typeof mention.displayName === 'string' ? mention.displayName.trim() : ''
+      if (
+        mention.type !== 'agent'
+        || allSeen
+        || !participantId
+        || participantId.length > 240
+        || participantIds.has(participantId)
+        || !displayName
+        || displayName.length > 120
+      ) {
+        throw relayError('Invalid remote structured mentions', 'GROUP_AGENT_EVENT_INVALID')
+      }
+      participantIds.add(participantId)
+      return { type: 'agent' as const, participantId, displayName }
+    })
   }
 
   disconnect(): void {
@@ -916,6 +1057,17 @@ class RelayGroupAgentExecutor implements GroupAgentExecutor {
     if (!pending || pending.runId !== runId) return
     clearTimeout(pending.acceptedTimer)
     clearTimeout(pending.runTimer)
+    if (pending.approvalIds.size > 0 || pending.clarifyIds.size > 0) {
+      this.expirePendingInteractions(
+        pending.roomId,
+        this.name,
+        [...pending.approvalIds.keys()],
+        [...pending.clarifyIds.keys()],
+        error?.message || 'Remote Agent run ended',
+      )
+      pending.approvalIds.clear()
+      pending.clarifyIds.clear()
+    }
     this.pendingRun = null
     this.activeSessions.delete(pending.roomId)
     if (error) pending.reject(error)
@@ -1066,6 +1218,7 @@ export class GroupAgentRelayServer {
           })
         },
       })
+      proxy.setStorage(storage)
       await proxy.connect()
       await proxy.joinRoom(roomAgent.roomId)
 
@@ -1091,7 +1244,22 @@ export class GroupAgentRelayServer {
       previous?.disconnect()
       const previousSocket = this.connectorSockets.get(connector.id)
       if (previousSocket && previousSocket.id !== socket.id) previousSocket.disconnect(true)
-      const executor = new RelayGroupAgentExecutor(socket, proxy, connector, roomAgent, storage)
+      const executor = new RelayGroupAgentExecutor(
+        socket,
+        proxy,
+        connector,
+        roomAgent,
+        storage,
+        (roomId, agentName, approvalIds, clarifyIds, reason) => {
+          this.groupChatServer.expirePendingAgentInteractions(
+            roomId,
+            agentName,
+            approvalIds,
+            clarifyIds,
+            reason,
+          )
+        },
+      )
       this.groupChatServer.agentClients.registerAgentForRoom(connector.roomId, executor)
       this.executors.set(connector.id, executor)
       this.connectorSockets.set(connector.id, socket)
@@ -1517,6 +1685,27 @@ class OutboundRelayConnection {
           }
         } catch (error) {
           ack?.({ error: error instanceof Error ? error.message : 'Approval response failed' })
+        }
+      },
+    )
+    socket.on(
+      'clarify.respond',
+      async (data: { clarifyId?: string; response?: string }, ack?: (response: Record<string, unknown>) => void) => {
+        const sessionId = this.activeRequest && this.runner?.getActiveSessionId(this.activeRequest.room.id)
+        if (!sessionId || !data?.clarifyId) {
+          ack?.({ error: 'Clarification is not pending for an active remote run' })
+          return
+        }
+        try {
+          if (this.link.agent.agent === 'ekko') {
+            const result = respondToEkkoClarification(sessionId, data.clarifyId, data.response || '')
+            ack?.({ resolved: Boolean(result?.resolved) })
+          } else {
+            const result = await new AgentBridgeClient().clarifyRespond(data.clarifyId, data.response || '')
+            ack?.({ resolved: Boolean((result as any)?.resolved) })
+          }
+        } catch (error) {
+          ack?.({ error: error instanceof Error ? error.message : 'Clarification response failed' })
         }
       },
     )

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -81,6 +81,7 @@ interface PendingGroupApprovalRoute {
     description: string
     choices: string[]
     allowPermanent: boolean
+    timeoutMs: number
     requestedAt: number
 }
 
@@ -443,6 +444,22 @@ function maxAgentMentionDepth(): number {
     const value = Number(process.env.HERMES_GROUP_CHAT_MAX_AGENT_MENTION_DEPTH)
     if (!Number.isFinite(value) || value <= 0) return 4
     return Math.min(10, Math.floor(value))
+}
+
+function normalizePendingInteractionTimeout(value: unknown): number {
+    const timeoutMs = Number(value)
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return 300_000
+    return Math.min(600_000, Math.max(1_000, Math.trunc(timeoutMs)))
+}
+
+function isExpiredInteractionError(value: unknown): boolean {
+    const message = String(value || '').toLowerCase()
+    return message.includes('unknown approval request')
+        || message.includes('unknown clarification request')
+        || message.includes('approval is no longer pending')
+        || message.includes('approval is not pending')
+        || message.includes('clarification is no longer pending')
+        || message.includes('clarification is not pending')
 }
 
 const GROUP_CHAT_MESSAGE_WINDOW = 500
@@ -1693,8 +1710,10 @@ export class GroupChatServer {
     }>>()
     /** room-scoped approval locator -> validated room and runtime session that requested it. */
     private pendingApprovalRoutes = new Map<string, PendingGroupApprovalRoute>()
+    private pendingApprovalTimers = new Map<string, ReturnType<typeof setTimeout>>()
     /** room-scoped clarification locator -> validated room and runtime session that requested it. */
     private pendingClarifyRoutes = new Map<string, PendingGroupClarifyRoute>()
+    private pendingClarifyTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
     private pendingApprovalRouteKey(roomId: string, approvalId: string): string {
         return `${roomId}:${approvalId}`
@@ -1702,6 +1721,58 @@ export class GroupChatServer {
 
     private pendingClarifyRouteKey(roomId: string, clarifyId: string): string {
         return `${roomId}:${clarifyId}`
+    }
+
+    private takePendingApprovalRoute(routeKey: string): PendingGroupApprovalRoute | undefined {
+        const route = this.pendingApprovalRoutes.get(routeKey)
+        this.pendingApprovalRoutes.delete(routeKey)
+        const timer = this.pendingApprovalTimers.get(routeKey)
+        if (timer) clearTimeout(timer)
+        this.pendingApprovalTimers.delete(routeKey)
+        return route
+    }
+
+    private takePendingClarifyRoute(routeKey: string): PendingGroupClarifyRoute | undefined {
+        const route = this.pendingClarifyRoutes.get(routeKey)
+        this.pendingClarifyRoutes.delete(routeKey)
+        const timer = this.pendingClarifyTimers.get(routeKey)
+        if (timer) clearTimeout(timer)
+        this.pendingClarifyTimers.delete(routeKey)
+        return route
+    }
+
+    private schedulePendingApprovalExpiry(routeKey: string, route: PendingGroupApprovalRoute): void {
+        const existing = this.pendingApprovalTimers.get(routeKey)
+        if (existing) clearTimeout(existing)
+        const timer = setTimeout(() => {
+            if (this.pendingApprovalRoutes.get(routeKey) !== route) return
+            this.expirePendingAgentInteractions(
+                route.roomId,
+                route.agentName,
+                [route.approvalId],
+                [],
+                'Approval timed out',
+            )
+        }, route.timeoutMs + 1_000)
+        timer.unref?.()
+        this.pendingApprovalTimers.set(routeKey, timer)
+    }
+
+    private schedulePendingClarifyExpiry(routeKey: string, route: PendingGroupClarifyRoute): void {
+        const existing = this.pendingClarifyTimers.get(routeKey)
+        if (existing) clearTimeout(existing)
+        const timer = setTimeout(() => {
+            if (this.pendingClarifyRoutes.get(routeKey) !== route) return
+            this.expirePendingAgentInteractions(
+                route.roomId,
+                route.agentName,
+                [],
+                [route.clarifyId],
+                'Clarification timed out',
+            )
+        }, route.timeoutMs + 1_000)
+        timer.unref?.()
+        this.pendingClarifyTimers.set(routeKey, timer)
     }
 
     private pendingApprovalSnapshots(roomId: string | null, socket: Socket) {
@@ -1717,6 +1788,7 @@ export class GroupChatServer {
                 description: route.description,
                 choices: route.choices,
                 allow_permanent: route.allowPermanent,
+                timeout_ms: route.timeoutMs,
                 requested_at: route.requestedAt,
             }))
     }
@@ -2267,7 +2339,7 @@ export class GroupChatServer {
         socket.on('context_status', (data: { roomId?: string; agentName?: string; status?: string }) => this.handleContextStatus(socket, data))
         socket.on('interrupt_agent', (data: { roomId?: string; agentName?: string }, ack?: (response?: unknown) => void) => this.handleInterruptAgent(socket, data, ack))
         socket.on('remove_agent', (data: { roomId?: string; agentId?: string }, ack?: (response?: unknown) => void) => this.handleRemoveAgent(socket, data, ack))
-        socket.on('approval.requested', (data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; agentSessionId?: string }) => this.handleApprovalRequested(socket, data))
+        socket.on('approval.requested', (data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; timeout_ms?: number; agentSessionId?: string }) => this.handleApprovalRequested(socket, data))
         socket.on('approval.resolved', (data: { roomId?: string; agentName?: string; approval_id?: string; choice?: string; agentSessionId?: string }) => this.handleApprovalResolved(socket, data))
         socket.on('approval.respond', (data: { roomId?: string; approval_id?: string; choice?: string }, ack?: (response?: unknown) => void) => this.handleApprovalRespond(socket, data, ack))
         socket.on('clarify.requested', (data: { roomId?: string; agentName?: string; clarify_id?: string; question?: string; choices?: string[] | null; timeout_ms?: number; agentSessionId?: string }) => this.handleClarifyRequested(socket, data))
@@ -3095,11 +3167,13 @@ export class GroupChatServer {
         })
     }
 
-    private handleApprovalRequested(socket: Socket, data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; agentSessionId?: string }): void {
+    private handleApprovalRequested(socket: Socket, data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; timeout_ms?: number; agentSessionId?: string }): void {
         const roomId = data.roomId
         const agentName = data.agentName || ''
         if (!roomId || !data.approval_id || !this.getCurrentAgentEventMember(socket, roomId, agentName, data.agentSessionId)) return
         const choices = Array.isArray(data.choices) ? data.choices : ['once', 'session', 'deny']
+        const routeKey = this.pendingApprovalRouteKey(roomId, data.approval_id)
+        this.takePendingApprovalRoute(routeKey)
         const pendingRoute: PendingGroupApprovalRoute = {
             roomId,
             agentName,
@@ -3110,9 +3184,11 @@ export class GroupChatServer {
             description: data.description || '',
             choices,
             allowPermanent: Boolean(data.allow_permanent),
+            timeoutMs: normalizePendingInteractionTimeout(data.timeout_ms),
             requestedAt: Date.now(),
         }
-        this.pendingApprovalRoutes.set(this.pendingApprovalRouteKey(roomId, data.approval_id), pendingRoute)
+        this.pendingApprovalRoutes.set(routeKey, pendingRoute)
+        this.schedulePendingApprovalExpiry(routeKey, pendingRoute)
         if (!pendingRoute.ownerMemberId) {
             logger.warn(`[GroupChat] approval ${data.approval_id} has no Agent owner in room ${roomId}`)
         }
@@ -3125,6 +3201,7 @@ export class GroupChatServer {
             description: data.description || '',
             choices,
             allow_permanent: Boolean(data.allow_permanent),
+            timeout_ms: pendingRoute.timeoutMs,
         })
     }
 
@@ -3135,7 +3212,7 @@ export class GroupChatServer {
         const routeKey = this.pendingApprovalRouteKey(roomId, data.approval_id)
         const pendingRoute = this.pendingApprovalRoutes.get(routeKey)
         if (pendingRoute?.roomId === roomId && pendingRoute.agentName === agentName) {
-            this.pendingApprovalRoutes.delete(routeKey)
+            this.takePendingApprovalRoute(routeKey)
         }
         const ownerMemberId = pendingRoute?.ownerMemberId || this.groupAgentOwnerMemberId(roomId, agentName)
         this.emitToAgentApprovalOwner({ roomId, ownerMemberId }, 'approval.resolved', {
@@ -3179,9 +3256,20 @@ export class GroupChatServer {
         if (remoteExecutor?.respondApproval) {
             try {
                 const resolved = await remoteExecutor.respondApproval(data.approval_id, data.choice || 'deny')
-                if (resolved) this.pendingApprovalRoutes.delete(routeKey)
+                if (resolved) this.takePendingApprovalRoute(routeKey)
                 ack?.({ ok: true, resolved })
             } catch (err: any) {
+                if (isExpiredInteractionError(err?.message || err)) {
+                    this.expirePendingAgentInteractions(
+                        roomId,
+                        pendingRoute.agentName,
+                        [data.approval_id],
+                        [],
+                        err?.message || 'Approval expired',
+                    )
+                    ack?.({ ok: true, resolved: true, stale: true })
+                    return
+                }
                 ack?.({ error: err.message || 'approval response failed' })
             }
             return
@@ -3198,17 +3286,28 @@ export class GroupChatServer {
                 ack?.({ error: 'Approval does not belong to the active Agent session' })
                 return
             }
-            this.pendingApprovalRoutes.delete(routeKey)
+            this.takePendingApprovalRoute(routeKey)
             ack?.({ ok: true, resolved: true })
             return
         }
         try {
             const result = await new AgentBridgeClient().approvalRespond(data.approval_id, data.choice || 'deny')
             const resolved = Boolean((result as any)?.resolved)
-            if (resolved) this.pendingApprovalRoutes.delete(routeKey)
+            if (resolved) this.takePendingApprovalRoute(routeKey)
             ack?.({ ok: true, resolved })
         } catch (err: any) {
             logger.warn(`[GroupChat] failed to respond approval ${data.approval_id}: ${err.message}`)
+            if (isExpiredInteractionError(err?.message || err)) {
+                this.expirePendingAgentInteractions(
+                    roomId,
+                    pendingRoute.agentName,
+                    [data.approval_id],
+                    [],
+                    err?.message || 'Approval expired',
+                )
+                ack?.({ ok: true, resolved: true, stale: true })
+                return
+            }
             ack?.({ error: err.message || 'approval response failed' })
         }
     }
@@ -3217,9 +3316,9 @@ export class GroupChatServer {
         const roomId = data.roomId
         const agentName = data.agentName || ''
         if (!roomId || !data.clarify_id || !this.getCurrentAgentEventMember(socket, roomId, agentName, data.agentSessionId)) return
-        const timeoutMs = Number.isFinite(Number(data.timeout_ms)) && Number(data.timeout_ms) > 0
-            ? Number(data.timeout_ms)
-            : 300_000
+        const timeoutMs = normalizePendingInteractionTimeout(data.timeout_ms)
+        const routeKey = this.pendingClarifyRouteKey(roomId, data.clarify_id)
+        this.takePendingClarifyRoute(routeKey)
         const route: PendingGroupClarifyRoute = {
             roomId,
             agentName,
@@ -3230,7 +3329,8 @@ export class GroupChatServer {
             timeoutMs,
             requestedAt: Date.now(),
         }
-        this.pendingClarifyRoutes.set(this.pendingClarifyRouteKey(roomId, data.clarify_id), route)
+        this.pendingClarifyRoutes.set(routeKey, route)
+        this.schedulePendingClarifyExpiry(routeKey, route)
         this.emitToRoomManagers(roomId, 'clarify.requested', {
             event: 'clarify.requested',
             roomId,
@@ -3246,7 +3346,7 @@ export class GroupChatServer {
         const roomId = data.roomId
         const agentName = data.agentName || ''
         if (!roomId || !data.clarify_id || !this.getCurrentAgentEventMember(socket, roomId, agentName, data.agentSessionId)) return
-        this.pendingClarifyRoutes.delete(this.pendingClarifyRouteKey(roomId, data.clarify_id))
+        this.takePendingClarifyRoute(this.pendingClarifyRouteKey(roomId, data.clarify_id))
         this.emitToRoomManagers(roomId, 'clarify.resolved', {
             event: 'clarify.resolved',
             roomId,
@@ -3278,6 +3378,30 @@ export class GroupChatServer {
             return
         }
         const response = typeof data.response === 'string' ? data.response : String(data.response ?? '')
+        const remoteExecutor = this.agentClients.getAgents(roomId).find(agent =>
+            agent.name === pendingRoute.agentName && typeof agent.respondClarify === 'function'
+        )
+        if (remoteExecutor?.respondClarify) {
+            try {
+                const resolved = await remoteExecutor.respondClarify(data.clarify_id, response)
+                if (resolved) this.takePendingClarifyRoute(routeKey)
+                ack?.({ ok: true, resolved })
+            } catch (err: any) {
+                if (isExpiredInteractionError(err?.message || err)) {
+                    this.expirePendingAgentInteractions(
+                        roomId,
+                        pendingRoute.agentName,
+                        [],
+                        [data.clarify_id],
+                        err?.message || 'Clarification expired',
+                    )
+                    ack?.({ ok: true, resolved: true, stale: true })
+                    return
+                }
+                ack?.({ error: err.message || 'clarification response failed' })
+            }
+            return
+        }
         const ekkoResult = pendingRoute.agentSessionId
             ? respondToEkkoClarification(pendingRoute.agentSessionId, data.clarify_id, response)
             : null
@@ -3286,18 +3410,67 @@ export class GroupChatServer {
                 ack?.({ error: 'Clarification does not belong to the active Agent session' })
                 return
             }
-            this.pendingClarifyRoutes.delete(routeKey)
+            this.takePendingClarifyRoute(routeKey)
             ack?.({ ok: true, resolved: true })
             return
         }
         try {
             const result = await new AgentBridgeClient().clarifyRespond(data.clarify_id, response)
             const resolved = Boolean((result as any)?.resolved)
-            if (resolved) this.pendingClarifyRoutes.delete(routeKey)
+            if (resolved) this.takePendingClarifyRoute(routeKey)
             ack?.({ ok: true, resolved })
         } catch (err: any) {
             logger.warn(`[GroupChat] failed to respond clarification ${data.clarify_id}: ${err.message}`)
+            if (isExpiredInteractionError(err?.message || err)) {
+                this.expirePendingAgentInteractions(
+                    roomId,
+                    pendingRoute.agentName,
+                    [],
+                    [data.clarify_id],
+                    err?.message || 'Clarification expired',
+                )
+                ack?.({ ok: true, resolved: true, stale: true })
+                return
+            }
             ack?.({ error: err.message || 'clarification response failed' })
+        }
+    }
+
+    expirePendingAgentInteractions(
+        roomId: string,
+        agentName: string,
+        approvalIds: string[],
+        clarifyIds: string[],
+        reason: string,
+    ): void {
+        const boundedReason = String(reason || 'Pending interaction expired').slice(0, 500)
+        for (const approvalId of new Set(approvalIds)) {
+            const routeKey = this.pendingApprovalRouteKey(roomId, approvalId)
+            const route = this.pendingApprovalRoutes.get(routeKey)
+            if (!route || route.agentName !== agentName) continue
+            this.takePendingApprovalRoute(routeKey)
+            this.emitToAgentApprovalOwner(route, 'approval.resolved', {
+                event: 'approval.resolved',
+                roomId,
+                agentName,
+                approval_id: approvalId,
+                choice: 'deny',
+                reason: boundedReason,
+            })
+        }
+        for (const clarifyId of new Set(clarifyIds)) {
+            const routeKey = this.pendingClarifyRouteKey(roomId, clarifyId)
+            const route = this.pendingClarifyRoutes.get(routeKey)
+            if (!route || route.agentName !== agentName) continue
+            this.takePendingClarifyRoute(routeKey)
+            this.emitToRoomManagers(roomId, 'clarify.resolved', {
+                event: 'clarify.resolved',
+                roomId,
+                agentName,
+                clarify_id: clarifyId,
+                resolved: false,
+                reason: boundedReason,
+            })
         }
     }
 
@@ -3305,7 +3478,7 @@ export class GroupChatServer {
         const pendingRoutes = this.pendingApprovalRoutes
         if (!pendingRoutes) return
         for (const [routeKey, route] of pendingRoutes) {
-            if (route.roomId === roomId) pendingRoutes.delete(routeKey)
+            if (route.roomId === roomId) this.takePendingApprovalRoute(routeKey)
         }
     }
 
@@ -3313,7 +3486,7 @@ export class GroupChatServer {
         const pendingRoutes = this.pendingClarifyRoutes
         if (!pendingRoutes) return
         for (const [routeKey, route] of pendingRoutes) {
-            if (route.roomId === roomId) pendingRoutes.delete(routeKey)
+            if (route.roomId === roomId) this.takePendingClarifyRoute(routeKey)
         }
     }
 

--- a/tests/client/group-chat-store-streaming.test.ts
+++ b/tests/client/group-chat-store-streaming.test.ts
@@ -226,6 +226,51 @@ describe('group chat store streaming merge', () => {
     })
   })
 
+  it('batches rapid content and reasoning deltas without replacing the live message', async () => {
+    vi.useFakeTimers()
+    const store = await createJoinedStore()
+
+    emitSocket('message_stream_start', assistantMessage({ id: 'msg-batched' }))
+    const liveMessage = store.messages[0]
+    const renderedMessage = store.sortedMessages[0]
+    emitSocket('message_stream_delta', { roomId: 'room-1', id: 'msg-batched', delta: 'hello' })
+    emitSocket('message_stream_delta', { roomId: 'room-1', id: 'msg-batched', delta: ' world' })
+    emitSocket('message_reasoning_delta', { roomId: 'room-1', id: 'msg-batched', delta: 'think' })
+    emitSocket('message_reasoning_delta', { roomId: 'room-1', id: 'msg-batched', delta: ' twice' })
+
+    expect(store.messages[0]).toBe(liveMessage)
+    expect(store.messages[0].content).toBe('')
+    expect(store.messages[0].reasoning).toBeUndefined()
+
+    await vi.advanceTimersByTimeAsync(49)
+    expect(store.messages[0].content).toBe('')
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(store.messages[0]).toBe(liveMessage)
+    expect(store.sortedMessages[0]).toBe(renderedMessage)
+    expect(store.messages[0]).toMatchObject({
+      content: 'hello world',
+      reasoning: 'think twice',
+      reasoning_content: 'think twice',
+      isStreaming: true,
+    })
+  })
+
+  it('flushes a queued delta immediately when the stream ends', async () => {
+    vi.useFakeTimers()
+    const store = await createJoinedStore()
+
+    emitSocket('message_stream_start', assistantMessage({ id: 'msg-ending' }))
+    emitSocket('message_stream_delta', { roomId: 'room-1', id: 'msg-ending', delta: 'complete' })
+    emitSocket('message_stream_end', { roomId: 'room-1', id: 'msg-ending' })
+
+    expect(store.messages[0]).toMatchObject({
+      content: 'complete',
+      isStreaming: false,
+    })
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it('preserves streamed content when the final message payload is blank', async () => {
     const store = await createJoinedStore()
 

--- a/tests/client/group-message-item-highlight.test.ts
+++ b/tests/client/group-message-item-highlight.test.ts
@@ -52,6 +52,7 @@ function mountToolMessage(message: Partial<ChatMessage>) {
 
 describe('GroupMessageItem tool details', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     setActivePinia(createPinia())
     Object.defineProperty(window, 'isSecureContext', {
       configurable: true,
@@ -112,6 +113,68 @@ describe('GroupMessageItem tool details', () => {
       content: 'Use this group answer',
       sender: 'Worker',
     })
+  })
+
+  it('keeps streaming Agent reasoning collapsed until the user expands it', async () => {
+    const wrapper = mount(GroupMessageItem, {
+      props: {
+        message: {
+          id: 'group-thinking',
+          roomId: 'room-1',
+          senderId: 'agent-1',
+          senderName: 'Worker',
+          role: 'assistant',
+          content: '',
+          reasoning: 'Inspecting several possible approaches.',
+          isStreaming: true,
+          timestamp: Date.now(),
+        },
+        agents: [{ id: 'agent-row', roomId: 'room-1', agentId: 'agent-1', profile: 'worker', name: 'Worker', description: '', invited: 1 }],
+        members: [],
+        currentUserId: 'user-1',
+      },
+      global: { stubs: { MarkdownRenderer: true, ProfileAvatar: true } },
+    })
+
+    expect(wrapper.find('.thinking-body').exists()).toBe(false)
+    expect(wrapper.get('.thinking-label').text()).toBe('chat.thinkingInProgress')
+    await wrapper.get('.thinking-header').trigger('click')
+    expect(wrapper.get('.thinking-body markdown-renderer-stub').attributes('content'))
+      .toBe('Inspecting several possible approaches.')
+  })
+
+  it('throttles streaming body Markdown and commits the final body immediately', async () => {
+    vi.useFakeTimers()
+    const baseMessage: ChatMessage = {
+      id: 'group-streaming-body',
+      roomId: 'room-1',
+      senderId: 'agent-1',
+      senderName: 'Worker',
+      role: 'assistant',
+      content: 'A',
+      isStreaming: true,
+      timestamp: Date.now(),
+    }
+    const wrapper = mount(GroupMessageItem, {
+      props: {
+        message: baseMessage,
+        agents: [],
+        members: [],
+        currentUserId: 'user-1',
+      },
+      global: { stubs: { MarkdownRenderer: true, ProfileAvatar: true } },
+    })
+
+    expect(wrapper.get('.msg-content markdown-renderer-stub').attributes('content')).toBe('A')
+    await wrapper.setProps({ message: { ...baseMessage, content: 'AB' } })
+    expect(wrapper.get('.msg-content markdown-renderer-stub').attributes('content')).toBe('A')
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(wrapper.get('.msg-content markdown-renderer-stub').attributes('content')).toBe('AB')
+
+    await wrapper.setProps({ message: { ...baseMessage, content: 'ABC', isStreaming: false } })
+    expect(wrapper.get('.msg-content markdown-renderer-stub').attributes('content')).toBe('ABC')
+    wrapper.unmount()
   })
 
   it('normalizes non-string runtime tool payloads before rendering', async () => {

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -36,6 +36,7 @@ const messagesByRoom: Record<string, unknown[]> = {
     { id: 'alpha-msg', roomId: 'room-alpha', senderId: 'user-1', senderName: 'Alice', content: 'Alpha room message', timestamp: 1_790_000_000, role: 'user' },
     { id: 'alpha-file', roomId: 'room-alpha', senderId: 'agent-1', senderName: 'Worker', content: '[package.json](/tmp/alpha/package.json)', timestamp: 1_790_000_001, role: 'assistant' },
     { id: 'alpha-diff', roomId: 'room-alpha', senderId: 'agent-1', senderName: 'Worker', content: JSON.stringify(groupWorkspaceDiff), timestamp: 1_790_000_002, role: 'tool', tool_name: 'workspace_diff', tool_call_id: 'workspace_diff:alpha' },
+    { id: 'alpha-reasoning', roomId: 'room-alpha', senderId: 'agent-1', senderName: 'Worker', content: 'Reasoning is available on demand.', reasoning: 'Inspecting several possible approaches.', isStreaming: true, timestamp: 1_790_000_003, role: 'assistant' },
   ],
   'room-beta': [
     { id: 'beta-msg', roomId: 'room-beta', senderId: 'user-1', senderName: 'Bob', content: 'Beta room message', timestamp: 1_790_000_100, role: 'user' },
@@ -257,6 +258,16 @@ test.describe('group chat room deep links', () => {
     await expect(page.getByText('Beta room message')).toBeVisible()
     expect((await page.locator('.run-card').first().boundingBox())?.width).toBeGreaterThanOrEqual(259)
     await expect(page).toHaveURL(/#\/hermes\/group-chat\/room\/room-beta$/)
+  })
+
+  test('keeps streaming Agent reasoning collapsed until explicitly expanded', async ({ page }) => {
+    await setup(page, '/#/hermes/group-chat/room/room-alpha')
+
+    const message = page.locator('.group-message', { hasText: 'Reasoning is available on demand.' })
+    await expect(message.locator('.thinking-block')).toBeVisible()
+    await expect(message.locator('.thinking-body')).toHaveCount(0)
+    await message.locator('.thinking-header').click()
+    await expect(message.locator('.thinking-body')).toContainText('Inspecting several possible approaches.')
   })
 
   test('shows a selected room link when browser clipboard APIs cannot copy', async ({ page }) => {

--- a/tests/server/group-chat-agent-workspace.test.ts
+++ b/tests/server/group-chat-agent-workspace.test.ts
@@ -1003,6 +1003,49 @@ describe('group chat agent workspace bridge runs', () => {
     expect(statuses.at(-1)).toEqual({ agentName: 'Worker', status: 'ready' })
   })
 
+  it('starts every explicitly mentioned Agent in parallel', async () => {
+    const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')
+    const clients = new AgentClients() as any
+    const started: string[] = []
+    let finishRuns!: () => void
+    const running = new Promise<void>(resolve => { finishRuns = resolve })
+    const createAgent = (agentId: string, name: string) => ({
+      id: `${agentId}-socket`,
+      agentId,
+      name,
+      replyToMention: vi.fn(async () => {
+        started.push(name)
+        await running
+      }),
+    })
+    const first = createAgent('agent-first', 'First')
+    const second = createAgent('agent-second', 'Second')
+    clients.rooms.set('room-1', new Map([
+      [first.agentId, first],
+      [second.agentId, second],
+    ]))
+
+    const processing = clients.processMentions('room-1', {
+      messageId: 'multi-agent-handoff',
+      content: '@First @Second review this together',
+      senderName: 'Coordinator',
+      senderId: 'agent-coordinator',
+      timestamp: 1,
+      role: 'assistant',
+      mentionDepth: 1,
+      mentions: [
+        { type: 'agent', participantId: 'agent-first' },
+        { type: 'agent', participantId: 'agent-second' },
+      ],
+    })
+
+    await vi.waitFor(() => expect(started).toEqual(expect.arrayContaining(['First', 'Second'])))
+    expect(first.replyToMention).toHaveBeenCalledOnce()
+    expect(second.replyToMention).toHaveBeenCalledOnce()
+    finishRuns()
+    await processing
+  })
+
   it('dispatches an agent handoff after a CJK speaker prefix', async () => {
     const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')
     const clients = new AgentClients() as any
@@ -1037,11 +1080,12 @@ describe('group chat agent workspace bridge runs', () => {
     )
   })
 
-  it('attaches a validated structured mention to an agent reply before it is persisted', async () => {
+  it('attaches every validated structured mention to an agent reply before it is persisted', async () => {
     const client = await createClient('')
     client.__testStorage.getRoomAgents = vi.fn(() => [
       { agentId: 'agent-1', name: 'Worker' },
       { agentId: 'agent-reviewer', name: 'Reviewer' },
+      { agentId: 'agent-auditor', name: 'Auditor' },
     ])
     bridgeMock.streamOutput.mockImplementation(async function* (runId: string) {
       yield {
@@ -1049,9 +1093,9 @@ describe('group chat agent workspace bridge runs', () => {
         run_id: runId,
         session_id: 'session-1',
         status: 'complete',
-        delta: '@Reviewer please verify this',
+        delta: '@Reviewer @Auditor please verify this',
         cursor: 1,
-        output: '@Reviewer please verify this',
+        output: '@Reviewer @Auditor please verify this',
         done: true,
         events: [],
         event_cursor: 0,
@@ -1071,8 +1115,11 @@ describe('group chat agent workspace bridge runs', () => {
       'message',
       expect.objectContaining({
         roomId: 'room-1',
-        content: '@Reviewer please verify this',
-        mentions: [{ type: 'agent', participantId: 'agent-reviewer', displayName: 'Reviewer' }],
+        content: '@Reviewer @Auditor please verify this',
+        mentions: [
+          { type: 'agent', participantId: 'agent-reviewer', displayName: 'Reviewer' },
+          { type: 'agent', participantId: 'agent-auditor', displayName: 'Auditor' },
+        ],
       }),
       expect.any(Function),
     )

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -598,6 +598,73 @@ describe('group chat approval and context baseline', () => {
     expect(respondApproval).toHaveBeenCalledOnce()
   })
 
+  it('routes a remote clarification response and removes its locator', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    const respondClarify = vi.fn(async () => true)
+    vi.spyOn(groupServer.agentClients, 'getAgents').mockReturnValue([{
+      name: 'Agent',
+      respondClarify,
+    } as any])
+    const requested = once<any>(human, 'clarify.requested')
+
+    agent.emit('clarify.requested', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      agentSessionId,
+      clarify_id: 'clarify-remote-once',
+      question: 'Which environment?',
+      choices: ['staging', 'production'],
+      timeout_ms: 300_000,
+    })
+    await expect(requested).resolves.toMatchObject({ clarify_id: 'clarify-remote-once' })
+
+    await expect(emitAck(human, 'clarify.respond', {
+      roomId: 'room-1',
+      clarify_id: 'clarify-remote-once',
+      response: 'staging',
+    })).resolves.toEqual({ ok: true, resolved: true })
+    await expect(emitAck(human, 'clarify.respond', {
+      roomId: 'room-1',
+      clarify_id: 'clarify-remote-once',
+      response: 'production',
+    })).resolves.toEqual({ error: 'Clarification is not pending in this room' })
+    expect(respondClarify).toHaveBeenCalledWith('clarify-remote-once', 'staging')
+  })
+
+  it('expires stale pending interactions and tells the browser to close them', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    const approvalRequested = once<any>(human, 'approval.requested')
+    const clarifyRequested = once<any>(human, 'clarify.requested')
+    agent.emit('approval.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId,
+      approval_id: 'approval-expired', command: 'touch expired', timeout_ms: 300_000,
+    })
+    agent.emit('clarify.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId,
+      clarify_id: 'clarify-expired', question: 'Continue?', timeout_ms: 300_000,
+    })
+    await approvalRequested
+    await clarifyRequested
+    const approvalResolved = once<any>(human, 'approval.resolved')
+    const clarifyResolved = once<any>(human, 'clarify.resolved')
+
+    groupServer.expirePendingAgentInteractions(
+      'room-1',
+      'Agent',
+      ['approval-expired'],
+      ['clarify-expired'],
+      'Remote Agent run timed out',
+    )
+
+    await expect(approvalResolved).resolves.toMatchObject({
+      approval_id: 'approval-expired', choice: 'deny', reason: 'Remote Agent run timed out',
+    })
+    await expect(clarifyResolved).resolves.toMatchObject({
+      clarify_id: 'clarify-expired', resolved: false, reason: 'Remote Agent run timed out',
+    })
+    await expect(emitAck<any>(human, 'load_pending_approvals', {})).resolves.toEqual({ pendingApprovals: [] })
+  })
+
   it('keeps Hermes approval responses routed through the Agent Bridge', async () => {
     const { agent, human, agentSessionId } = await joinPair()
     const bridgeApproval = vi.spyOn(AgentBridgeClient.prototype, 'approvalRespond')
@@ -620,6 +687,27 @@ describe('group chat approval and context baseline', () => {
       choice: 'session',
     })).resolves.toEqual({ ok: true, resolved: true })
     expect(bridgeApproval).toHaveBeenCalledWith('approval-hermes', 'session')
+  })
+
+  it('dismisses an approval when its runtime already reports it expired', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    vi.spyOn(AgentBridgeClient.prototype, 'approvalRespond')
+      .mockRejectedValue(new Error('unknown approval request: approval-stale'))
+    const requested = once<any>(human, 'approval.requested')
+    agent.emit('approval.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId,
+      approval_id: 'approval-stale', command: 'touch stale', description: 'expired',
+    })
+    await requested
+    const resolved = once<any>(human, 'approval.resolved')
+
+    await expect(emitAck(human, 'approval.respond', {
+      roomId: 'room-1', approval_id: 'approval-stale', choice: 'deny',
+    })).resolves.toEqual({ ok: true, resolved: true, stale: true })
+    await expect(resolved).resolves.toMatchObject({
+      approval_id: 'approval-stale', choice: 'deny', reason: 'unknown approval request: approval-stale',
+    })
+    await expect(emitAck<any>(human, 'load_pending_approvals', {})).resolves.toEqual({ pendingApprovals: [] })
   })
 
   it('does not route a pending approval through a different room', async () => {

--- a/tests/server/group-chat-baseline.test.ts
+++ b/tests/server/group-chat-baseline.test.ts
@@ -526,6 +526,10 @@ describe('group chat baseline behavior', () => {
       rooms: ['room-relay'],
     })
     const proxySendMessage = vi.spyOn(AgentClient.prototype, 'sendMessage').mockResolvedValue('cloud-message')
+    const proxyApprovalRequested = vi.spyOn(AgentClient.prototype, 'emitApprovalRequested').mockImplementation(() => {})
+    const proxyApprovalResolved = vi.spyOn(AgentClient.prototype, 'emitApprovalResolved').mockImplementation(() => {})
+    const proxyClarifyRequested = vi.spyOn(AgentClient.prototype, 'emitClarifyRequested').mockImplementation(() => {})
+    const proxyClarifyResolved = vi.spyOn(AgentClient.prototype, 'emitClarifyResolved').mockImplementation(() => {})
 
     const wrongTarget = socketIo(`http://127.0.0.1:${port}/group-chat-agent-relay`, {
       autoConnect: false,
@@ -636,6 +640,10 @@ describe('group chat baseline behavior', () => {
         agentSessionId: 'remote-session',
         extra: {
           role: 'assistant',
+          mentions: [
+            { type: 'agent', participantId: 'agent-first', displayName: 'First' },
+            { type: 'agent', participantId: 'agent-second', displayName: 'Second' },
+          ],
           roomId: 'another-room',
           content: 'forged content',
           id: 'forged-id',
@@ -651,7 +659,13 @@ describe('group chat baseline behavior', () => {
       'room-relay',
       'safe remote reply',
       expect.stringMatching(/^gcr_[a-f0-9]{32}$/),
-      { role: 'assistant' },
+      {
+        role: 'assistant',
+        mentions: [
+          { type: 'agent', participantId: 'agent-first', displayName: 'First' },
+          { type: 'agent', participantId: 'agent-second', displayName: 'Second' },
+        ],
+      },
       'remote-session',
     )
     const workspaceDiffMessage = storage.getRecentMessagesForUI('room-relay')
@@ -668,6 +682,84 @@ describe('group chat baseline behavior', () => {
         }),
       ],
     })
+
+    const interactionRunRequested = once<any>(intendedTarget as any, 'run.request', 2_000)
+    const interactionReply = executor.replyToMention('room-relay', {
+      messageId: 'interaction-source-message',
+      content: '@Remote Relay Agent ask before continuing',
+      senderName: 'Relay Guest',
+      senderId: 'guest-relay',
+      timestamp: Date.now(),
+      role: 'user',
+    })
+    const interactionRun = await interactionRunRequested
+    intendedTarget.emit('run.accepted', { runId: interactionRun.runId })
+    await expect(emitAck<any>(intendedTarget as any, 'agent.event', {
+      runId: interactionRun.runId,
+      seq: 1,
+      event: 'approval.requested',
+      data: {
+        approval_id: 'remote-approval',
+        command: 'touch relay.txt',
+        choices: ['once', 'deny'],
+        timeout_ms: 300_000,
+        agentSessionId: 'remote-session',
+      },
+    })).resolves.toEqual({ ok: true })
+    const cloudApprovalId = String(proxyApprovalRequested.mock.calls.at(-1)?.[1]?.approval_id || '')
+    expect(cloudApprovalId).toMatch(/^gca_[a-f0-9]{32}$/)
+
+    await expect(emitAck<any>(intendedTarget as any, 'agent.event', {
+      runId: interactionRun.runId,
+      seq: 2,
+      event: 'clarify.requested',
+      data: {
+        clarify_id: 'remote-clarify',
+        question: 'Which environment?',
+        choices: ['staging', 'production'],
+        timeout_ms: 300_000,
+        agentSessionId: 'remote-session',
+      },
+    })).resolves.toEqual({ ok: true })
+    const cloudClarifyId = String(proxyClarifyRequested.mock.calls.at(-1)?.[1]?.clarify_id || '')
+    expect(cloudClarifyId).toMatch(/^gcc_[a-f0-9]{32}$/)
+
+    intendedTarget.once('approval.respond', (data: any, ack: (response: any) => void) => {
+      expect(data).toEqual({ approvalId: 'remote-approval', choice: 'once' })
+      ack({ resolved: true })
+    })
+    await expect(executor.respondApproval!(cloudApprovalId, 'once')).resolves.toBe(true)
+    intendedTarget.once('clarify.respond', (data: any, ack: (response: any) => void) => {
+      expect(data).toEqual({ clarifyId: 'remote-clarify', response: 'staging' })
+      ack({ resolved: true })
+    })
+    await expect(executor.respondClarify!(cloudClarifyId, 'staging')).resolves.toBe(true)
+
+    await expect(emitAck<any>(intendedTarget as any, 'agent.event', {
+      runId: interactionRun.runId,
+      seq: 3,
+      event: 'approval.resolved',
+      data: { approval_id: 'remote-approval', choice: 'once', agentSessionId: 'remote-session' },
+    })).resolves.toEqual({ ok: true })
+    await expect(emitAck<any>(intendedTarget as any, 'agent.event', {
+      runId: interactionRun.runId,
+      seq: 4,
+      event: 'clarify.resolved',
+      data: {
+        clarify_id: 'remote-clarify',
+        resolved: true,
+        reason: 'response',
+        agentSessionId: 'remote-session',
+      },
+    })).resolves.toEqual({ ok: true })
+    expect(proxyApprovalResolved).toHaveBeenCalledWith('room-relay', expect.objectContaining({
+      approval_id: cloudApprovalId,
+    }))
+    expect(proxyClarifyResolved).toHaveBeenCalledWith('room-relay', expect.objectContaining({
+      clarify_id: cloudClarifyId,
+    }))
+    intendedTarget.emit('run.completed', { runId: interactionRun.runId })
+    await interactionReply
 
     const nameConflict = await emitAck<any>(intendedTarget as any, 'agent.config.update', {
       agent: 'codex',


### PR DESCRIPTION
## Summary

- Preserve structured multi-Agent mentions across remote Agent Relay and rebuild mention metadata from authoritative room state.
- Route approval and clarification responses back to remote runtimes, keep Relay runs alive while awaiting user input, and remove expired or terminal interactions from the UI.
- Fail invalid Relay event sequences immediately and clean up pending interactions on timeout or disconnect.
- Keep streaming reasoning collapsed by default.
- Batch Group Chat content and reasoning deltas into 50 ms updates, preserve stable message objects, and throttle live body Markdown rendering to 100 ms while flushing final output immediately.

## Root cause

Remote Relay messages lost enough mention context that one Agent could not reliably invoke multiple Agents. Approval and clarification routing was coupled too closely to an active run, so timeout and disconnect paths could leave actions visible but no longer resolvable. Separately, every streamed token cloned the Group Chat message array and triggered full grouping, Markdown rendering, and scroll work, which overloaded the browser when several Agents responded concurrently.

## Impact

Remote multi-Agent handoffs and user interactions remain routable throughout their lifecycle, stale actions disappear deterministically, and concurrent Group Chat streaming performs substantially less frontend work without changing the Socket.IO protocol or ordinary one-to-one chat behavior.

## Validation

- `npm run harness:check`
- 141 Group Chat client Vitest tests
- 84 targeted Group Chat server Vitest tests
- 20 Group Chat Playwright E2E tests
- `npx vue-tsc -b`
- `npm run build`
