### PR TITLE
fix(group-chat): persist Claude API error terminal state

### DIFF
--- a/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
+++ b/packages/server/src/services/agent-runner/coding-agent-run-manager.ts
@@ -743,7 +743,9 @@ export class CodingAgentRunManager {
       const finalText = extractResponseText(final)
       const terminalError = storageSafeResponseEvent.type === 'response.failed'
         ? responseErrorMessage(final?.error || (responseEvent.data as any).error) || 'Coding agent run failed'
-        : codingAgentGatewayErrorMessage(finalText)
+        : run.launch.agentId === 'claude-code' && run.acceptingPrintEvent
+          ? null
+          : codingAgentGatewayErrorMessage(finalText)
       const chatCompletionEvent = terminalError ? 'run.failed' : 'run.completed'
       const chatCompletionPayload: Record<string, unknown> = {
         event: chatCompletionEvent,
@@ -999,7 +1001,10 @@ export class CodingAgentRunManager {
       })
     })
 
-    child.on('exit', (code) => {
+    // `exit` can fire before stdout has closed, allowing a zero exit to win
+    // over a final structured `isApiErrorMessage` record still in the pipe.
+    // `close` fires only after the stdio streams are closed and drained.
+    child.on('close', (code) => {
       if (stdoutBuffer.trim()) this.handleClaudePrintLine(run, stdoutBuffer)
       if (run.currentChildKillTimer) clearTimeout(run.currentChildKillTimer)
       run.currentChildKillTimer = undefined
@@ -1051,13 +1056,21 @@ export class CodingAgentRunManager {
       return
     }
 
+    if (typeof event.session_id === 'string' && event.session_id.trim()) {
+      this.recordClaudeNativeSessionId(run, event.session_id.trim())
+    }
+
+    if (run.printCompleted) return
+
     if (event.type === 'stream_event' && event.event) {
       this.handleClaudeAnthropicStreamEvent(run, event.event)
       return
     }
 
-    if (typeof event.session_id === 'string' && event.session_id.trim()) {
-      this.recordClaudeNativeSessionId(run, event.session_id.trim())
+    if (event.type === 'assistant' && event.isApiErrorMessage === true) {
+      const errorText = claudeContentToText(event.message?.content).trim() || responseErrorMessage(event.error) || 'Claude Code API error'
+      this.failClaudePrintTurn(run, errorText)
+      return
     }
 
     if ((event.type === 'assistant' || event.type === 'user') && event.message) {
@@ -1299,6 +1312,50 @@ export class CodingAgentRunManager {
         output_index: 0,
         content_index: 0,
         part: { type: 'output_text', text: '', annotations: [] },
+      },
+    })
+  }
+
+  private failClaudePrintTurn(run: ManagedCodingAgentRun, errorText: string) {
+    if (run.printCompleted) return
+    run.printCompleted = true
+    const existingText = run.printText || ''
+    const appendedError = appendedTextDelta(existingText, errorText)
+    const delta = !existingText
+      ? errorText
+      : existingText === errorText
+        ? ''
+        : appendedError || `\n\n${errorText}`
+    if (delta) {
+      this.ensureClaudePrintText(run)
+      run.printText = `${existingText}${delta}`
+      this.handleClaudePrintResponseEvent(run, {
+        type: 'response.output_text.delta',
+        data: {
+          type: 'response.output_text.delta',
+          item_id: run.printMessageId,
+          output_index: 0,
+          content_index: 0,
+          delta,
+        },
+      })
+    }
+    const assistantMessage = [...run.state.messages]
+      .reverse()
+      .find(message => message.runMarker === run.runMarker && message.role === 'assistant' && !message.tool_calls?.length)
+    if (assistantMessage) assistantMessage.finish_reason = 'error'
+    this.handleClaudePrintResponseEvent(run, {
+      type: 'response.failed',
+      data: {
+        type: 'response.failed',
+        response: {
+          id: run.printResponseId,
+          object: 'response',
+          status: 'failed',
+          model: run.launch.model,
+          error: { message: errorText },
+          output: [],
+        },
       },
     })
   }

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -63,6 +63,218 @@ describe('coding agent completion errors', () => {
     expect(codingAgentGatewayErrorMessage(`  ${error}\n`)).toBe(error)
     expect(codingAgentGatewayErrorMessage('Provider returned HTTP 502')).toBe('Provider returned HTTP 502')
     expect(codingAgentGatewayErrorMessage('Here is a normal answer mentioning API Error: 529 as an example')).toBeNull()
+    expect(codingAgentGatewayErrorMessage('API Error: is a phrase used in this example')).toBeNull()
+  })
+
+  it('does not fail a normal native Claude reply whose text begins with a numeric API Error example', async () => {
+    initAllHermesTables()
+    const manager = new CodingAgentRunManager()
+    const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    const agentSessionId = `agent-session-claude-api-example-${suffix}`
+    const chatSessionId = `chat-session-claude-api-example-${suffix}`
+    const state: any = { messages: [], isWorking: false, events: [], queue: [] }
+    const emitted = vi.fn()
+    ;(manager as any).emitToChat = emitted
+    ;(manager as any).refreshCodingAgentUsage = async () => {}
+
+    manager.start({
+      agentSessionId,
+      agentId: 'claude-code',
+      mode: 'scoped',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'test-model',
+      apiMode: 'anthropic_messages',
+      sessionId: chatSessionId,
+      command: 'claude',
+      args: [],
+      shellCommand: 'claude',
+      workspaceDir: process.cwd(),
+      state,
+    })
+
+    const run = (manager as any).runs.get(agentSessionId)
+    run.acceptingPrintEvent = true
+    manager.handleResponseEvent(agentSessionId, {
+      type: 'response.completed',
+      data: {
+        response: {
+          id: `resp-${suffix}`,
+          status: 'completed',
+          model: 'test-model',
+          output: [{
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'API Error: 529 is the example requested by the user.' }],
+          }],
+        },
+      },
+    })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(getSessionDetail(chatSessionId)?.messages.at(-1)).toEqual(expect.objectContaining({
+      content: 'API Error: 529 is the example requested by the user.',
+      finish_reason: 'stop',
+    }))
+    expect(emitted).toHaveBeenCalledWith(chatSessionId, 'run.completed', expect.anything())
+    expect(emitted).not.toHaveBeenCalledWith(chatSessionId, 'run.failed', expect.anything())
+    manager.shutdown()
+  })
+
+  it('waits for Claude stdout to close before settling a zero-exit child', async () => {
+    initAllHermesTables()
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'claude-api-error-close-'))
+    const fixturePath = join(fixtureDir, 'delayed-api-error.cjs')
+    const nativeError = JSON.stringify({
+      type: 'assistant',
+      isApiErrorMessage: true,
+      error: 'unknown',
+      message: {
+        role: 'assistant',
+        stop_reason: 'stop_sequence',
+        content: [{ type: 'text', text: 'API Error: stream ended without terminal event' }],
+      },
+    })
+    writeFileSync(fixturePath, [
+      "const { spawn } = require('child_process')",
+      `spawn(process.execPath, ['-e', ${JSON.stringify(`setTimeout(() => process.stdout.write(${JSON.stringify(`${nativeError}\n`)}), 75)`) }], { stdio: ['ignore', 1, 2] })`,
+      'process.exit(0)',
+    ].join('\n'))
+
+    const manager = new CodingAgentRunManager()
+    const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    const agentSessionId = `agent-session-claude-close-${suffix}`
+    const chatSessionId = `chat-session-claude-close-${suffix}`
+    const state: any = { messages: [], isWorking: false, events: [], queue: [] }
+    const emitted = vi.fn()
+    ;(manager as any).emitToChat = emitted
+    ;(manager as any).refreshCodingAgentUsage = async () => {}
+
+    try {
+      manager.start({
+        agentSessionId,
+        agentId: 'claude-code',
+        mode: 'scoped',
+        profile: 'default',
+        provider: 'test-provider',
+        model: 'test-model',
+        apiMode: 'anthropic_messages',
+        sessionId: chatSessionId,
+        command: process.execPath,
+        args: [fixturePath],
+        shellCommand: process.execPath,
+        workspaceDir: process.cwd(),
+        state,
+      })
+      manager.send(chatSessionId, 'test delayed final stdout')
+
+      await vi.waitFor(() => {
+        expect(emitted).toHaveBeenCalledWith(chatSessionId, 'run.failed', expect.objectContaining({
+          error: 'API Error: stream ended without terminal event',
+        }))
+      }, { timeout: 2_000 })
+
+      expect(emitted).not.toHaveBeenCalledWith(chatSessionId, 'run.completed', expect.anything())
+      expect(getSessionDetail(chatSessionId)?.messages.at(-1)).toEqual(expect.objectContaining({
+        content: 'API Error: stream ended without terminal event',
+        finish_reason: 'error',
+      }))
+    } finally {
+      manager.shutdown()
+      rmSync(fixtureDir, { recursive: true, force: true })
+    }
+  })
+
+  it('persists a native Claude API error as an explicit failed terminal message', async () => {
+    initAllHermesTables()
+    const manager = new CodingAgentRunManager()
+    const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    const agentSessionId = `agent-session-claude-api-error-${suffix}`
+    const chatSessionId = `chat-session-claude-api-error-${suffix}`
+    const state: any = { messages: [], isWorking: false, events: [], queue: [] }
+    const emitted = vi.fn()
+    ;(manager as any).emitToChat = emitted
+    ;(manager as any).refreshCodingAgentUsage = async () => {}
+
+    manager.start({
+      agentSessionId,
+      agentId: 'claude-code',
+      mode: 'scoped',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'test-model',
+      apiMode: 'anthropic_messages',
+      sessionId: chatSessionId,
+      command: 'claude',
+      args: [],
+      shellCommand: 'claude',
+      workspaceDir: process.cwd(),
+      state,
+    })
+
+    const run = (manager as any).runs.get(agentSessionId)
+    run.currentChild = { exitCode: null, signalCode: null, killed: false }
+    ;(manager as any).handleClaudePrintLine(run, JSON.stringify({
+      type: 'assistant',
+      isApiErrorMessage: true,
+      error: 'unknown',
+      message: {
+        role: 'assistant',
+        stop_reason: 'stop_sequence',
+        content: [{ type: 'text', text: 'API Error: stream ended without terminal event' }],
+      },
+    }))
+
+    expect(run.pendingChatCompletionEvent).toBe('run.failed')
+    expect(emitted).not.toHaveBeenCalledWith(chatSessionId, 'run.failed', expect.anything())
+
+    const terminalEventCount = emitted.mock.calls.length
+    const terminalMessages = JSON.stringify(state.messages)
+    const terminalText = run.printText
+    ;(manager as any).handleClaudePrintLine(run, JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'late text after failure' },
+      },
+    }))
+    ;(manager as any).handleClaudePrintLine(run, JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'late-tool', name: 'write_file', input: { path: 'late.txt' } }],
+      },
+    }))
+    ;(manager as any).handleClaudePrintLine(run, JSON.stringify({
+      type: 'result',
+      result: 'late successful result',
+    }))
+
+    expect(emitted.mock.calls).toHaveLength(terminalEventCount)
+    expect(JSON.stringify(state.messages)).toBe(terminalMessages)
+    expect(run.printText).toBe(terminalText)
+
+    run.currentChild = undefined
+    await (manager as any).emitAndMarkPrintChatRunCompletedAfterUsage(
+      run,
+      run.pendingChatCompletionEvent,
+      run.pendingChatCompletionPayload,
+    )
+    ;(manager as any).completeClaudePrintTurn(run)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const messages = getSessionDetail(chatSessionId)?.messages || []
+    expect(messages.at(-1)).toEqual(expect.objectContaining({
+      role: 'assistant',
+      content: 'API Error: stream ended without terminal event',
+      finish_reason: 'error',
+    }))
+    expect(emitted).toHaveBeenCalledWith(chatSessionId, 'run.failed', expect.objectContaining({
+      error: 'API Error: stream ended without terminal event',
+    }))
+    expect(emitted).not.toHaveBeenCalledWith(chatSessionId, 'run.completed', expect.anything())
+    manager.shutdown()
   })
 })
 


### PR DESCRIPTION
## Summary

- recognize Claude Code's structured `isApiErrorMessage=true` terminal event
- persist the native API-error Assistant message with `finish_reason=error`
- wait for child stdio `close` before terminal arbitration so late final stdout cannot lose to a zero exit
- keep normal native Claude replies successful even when their text begins with `API Error: <digits>`
- route failure through the existing child-exit/pending arbitration so `run.failed` settles exactly once

Closes #2480.

## Root cause

Claude Code stream-json emits provider failures as a synthetic top-level Assistant event with `isApiErrorMessage=true`. Hermes Studio ignored that structured flag and later completed the print turn successfully when the child exited zero. It also finalized on Node's `exit` event, which can occur before inherited stdout pipes close, and retained a legacy text heuristic that could fail normal native Claude replies beginning with `API Error: <digits>`.

The internal Session could therefore persist the API-error text with a successful/null finish reason, and Group Chat could reconstruct an indeterminate historical message after reload.

## Test plan

- [x] TDD RED: structured Claude API error was ignored and persisted as successful/null
- [x] TDD RED: normal native Claude text beginning `API Error: 529...` was misclassified as failed
- [x] real child lifecycle regression: parent exits zero before a child writes the final flagged JSON record through inherited stdout; settlement waits for `close` and emits only `run.failed`
- [x] related tests: 126/126 passed
- [x] Server TypeScript: PASS
- [x] `npm run harness:check`: PASS
- [x] production build: PASS
- [x] full-suite exact-base comparison: candidate 58 failed / 3770 passed; base 59 failed / 3766 passed; `candidate_only=[]`

## Scope boundary

This PR fixes Hermes Studio terminal persistence and lifecycle settlement only. It does not repair the upstream `/v1/messages` stream that omitted its terminal event, increase continuation retry limits, or change Codex Responses arbitration from Draft PR #2471.
