### PR TITLE
feat(media): add MiniMax image generation support

### DIFF
--- a/packages/server/src/controllers/hermes/media.ts
+++ b/packages/server/src/controllers/hermes/media.ts
@@ -5,6 +5,7 @@ import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '.
 import { config } from '../../config'
 import { readConfigYamlForProfile } from '../../services/config-helpers'
 import { getCompatibleCustomProviders } from '../../services/hermes/custom-providers-compat'
+import { resolveEkkoProviderRuntimeConfig } from '../../services/ekko-agent/provider-runtime'
 
 const XAI_VIDEO_GENERATIONS_URL = 'https://api.x.ai/v1/videos/generations'
 const XAI_VIDEO_STATUS_URL = 'https://api.x.ai/v1/videos'
@@ -12,6 +13,17 @@ const XAI_VIDEO_MODEL = 'grok-imagine-video'
 const APIKEY_IMAGE_PROVIDER = 'fun-codex'
 const APIKEY_IMAGE_MODEL = 'gpt-image-2'
 const APIKEY_IMAGE_TO_IMAGE_MODEL = 'gpt-5.4-mini'
+const MINIMAX_IMAGE_PROVIDERS = {
+  minimax: {
+    endpoint: 'https://api.minimax.io/v1/image_generation',
+    model: 'image-01',
+  },
+  'minimax-cn': {
+    endpoint: 'https://api.minimaxi.com/v1/image_generation',
+    model: 'image-01',
+  },
+} as const
+const MINIMAX_IMAGE_RESPONSE_FORMATS = new Set(['url', 'base64'])
 const MAX_IMAGE_BYTES = 25 * 1024 * 1024
 const DEFAULT_POLL_INTERVAL_MS = 5000
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000
@@ -23,11 +35,20 @@ type AuthJson = {
 
 type ApiKeyImageMode = 'text' | 'image' | 'edit'
 
+type ApiKeyImageResult = {
+  images: string[]
+  metadata?: {
+    success_count: number
+    failed_count: number
+  }
+}
+
 type ApiKeyImageProvider = {
   name: string
   apiKey: string
   baseUrl: string
   model: string
+  kind: 'openai-compatible' | 'minimax'
 }
 
 function requestedProfileName(ctx: Context): string {
@@ -91,6 +112,15 @@ function requestedApiKeyImageProviderName(body: any): string {
   return normalizeCustomProviderName(body?.provider || body?.provider_name || body?.custom_provider) || APIKEY_IMAGE_PROVIDER
 }
 
+function miniMaxImageProviderConfig(providerName: string) {
+  const name = providerName.trim().toLowerCase()
+  if (!Object.prototype.hasOwnProperty.call(MINIMAX_IMAGE_PROVIDERS, name)) return null
+  return {
+    name,
+    ...MINIMAX_IMAGE_PROVIDERS[name as keyof typeof MINIMAX_IMAGE_PROVIDERS],
+  }
+}
+
 function apiKeyFromCustomProvider(provider: any): string {
   const direct = String(provider?.api_key || '').trim()
   if (direct) return direct
@@ -100,6 +130,23 @@ function apiKeyFromCustomProvider(provider: any): string {
 
 async function resolveApiKeyImageProvider(profile: string, providerName = APIKEY_IMAGE_PROVIDER): Promise<ApiKeyImageProvider | null> {
   const requestedName = normalizeCustomProviderName(providerName) || APIKEY_IMAGE_PROVIDER
+  const miniMaxConfig = miniMaxImageProviderConfig(requestedName)
+  if (miniMaxConfig) {
+    const runtime = await resolveEkkoProviderRuntimeConfig({
+      profile,
+      provider: miniMaxConfig.name,
+    })
+    const apiKey = String(runtime.apiKey || '').trim()
+    if (!apiKey) return null
+    return {
+      name: miniMaxConfig.name,
+      apiKey,
+      baseUrl: miniMaxConfig.endpoint,
+      model: miniMaxConfig.model,
+      kind: 'minimax',
+    }
+  }
+
   const hermesConfig = await readConfigYamlForProfile(profile)
   const customProviders = getCompatibleCustomProviders(hermesConfig)
   const provider = customProviders.find(entry => normalizeCustomProviderName(entry?.name) === requestedName)
@@ -111,6 +158,7 @@ async function resolveApiKeyImageProvider(profile: string, providerName = APIKEY
     apiKey,
     baseUrl,
     model: String(provider?.model || '').trim(),
+    kind: 'openai-compatible',
   }
 }
 
@@ -314,6 +362,43 @@ function normalizePositiveInt(value: unknown, fallback: number, key: string): nu
   return Math.floor(parsed)
 }
 
+function normalizeMiniMaxResponseFormat(value: unknown): 'url' | 'base64' {
+  const responseFormat = String(value || 'url').trim().toLowerCase()
+  if (MINIMAX_IMAGE_RESPONSE_FORMATS.has(responseFormat)) return responseFormat as 'url' | 'base64'
+  const err: any = new Error('response_format must be url or base64 for MiniMax image generation')
+  err.status = 400
+  throw err
+}
+
+function miniMaxSubjectReference(mode: ApiKeyImageMode, body: any): unknown {
+  if (body.subject_reference !== undefined) {
+    if (!Array.isArray(body.subject_reference) || body.subject_reference.length === 0) {
+      const err: any = new Error('subject_reference must be a non-empty array')
+      err.status = 400
+      throw err
+    }
+    return body.subject_reference
+  }
+  if (mode !== 'image') return undefined
+  return [{
+    type: 'character',
+    image_file: normalizeImageInput(body),
+  }]
+}
+
+function imageResultBase64(value: string): string {
+  const match = value.match(/^data:image\/[^;,]+;base64,([\s\S]+)$/i)
+  return match ? match[1] : value
+}
+
+async function normalizeMiniMaxImageResult(value: string): Promise<string> {
+  if (/^https?:\/\//i.test(value)) {
+    const image = await fetchImageBytes(value)
+    return image.buffer.toString('base64')
+  }
+  return imageResultBase64(value)
+}
+
 function collectImageBase64(event: any, images: string[] = []): string[] {
   if (!event || typeof event !== 'object') return images
   for (const key of ['b64_json', 'base64', 'image_base64', 'partial_image_b64']) {
@@ -370,7 +455,84 @@ async function readSseImageResults(res: Response, limit: number): Promise<string
   return images.slice(0, limit)
 }
 
-async function requestApiKeyImage(provider: ApiKeyImageProvider, mode: ApiKeyImageMode, body: any): Promise<string[]> {
+async function requestMiniMaxImage(
+  provider: ApiKeyImageProvider,
+  mode: ApiKeyImageMode,
+  body: any,
+  prompt: string,
+  n: number,
+  timeoutMs: number,
+): Promise<ApiKeyImageResult> {
+  if (mode === 'edit') {
+    const err: any = new Error('MiniMax image generation supports text and image modes')
+    err.status = 400
+    throw err
+  }
+
+  const responseFormat = normalizeMiniMaxResponseFormat(body.response_format)
+  const requestBody: Record<string, unknown> = {
+    model: body.model || provider.model,
+    prompt,
+    response_format: responseFormat,
+    n,
+  }
+  const subjectReference = miniMaxSubjectReference(mode, body)
+  if (subjectReference !== undefined) requestBody.subject_reference = subjectReference
+  for (const field of ['aspect_ratio', 'width', 'height', 'seed', 'prompt_optimizer']) {
+    if (body[field] !== undefined) requestBody[field] = body[field]
+  }
+
+  const res = await fetch(provider.baseUrl, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${provider.apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    signal: AbortSignal.timeout(timeoutMs),
+    body: JSON.stringify(requestBody),
+  })
+  const text = await res.text()
+  let payload: any = null
+  try { payload = text ? JSON.parse(text) : null } catch {}
+
+  if (!res.ok) {
+    const detail = payload?.base_resp?.status_msg || payload?.error?.message || text || res.statusText
+    const err: any = new Error(`MiniMax image generation request failed: ${res.status} ${detail}`)
+    err.status = 502
+    throw err
+  }
+
+  const statusCode = Number(payload?.base_resp?.status_code ?? 0)
+  if (statusCode !== 0) {
+    const detail = payload?.base_resp?.status_msg || 'upstream request failed'
+    const err: any = new Error(`MiniMax image generation failed: ${statusCode} ${detail}`)
+    err.status = 502
+    throw err
+  }
+
+  const values = Array.isArray(payload?.data?.image_urls)
+    ? payload.data.image_urls.filter((value: unknown): value is string => typeof value === 'string' && value.length > 0)
+    : []
+  if (values.length === 0) {
+    const err: any = new Error('MiniMax image generation returned no image data')
+    err.status = 502
+    throw err
+  }
+
+  const images = await Promise.all(values.slice(0, n).map(normalizeMiniMaxImageResult))
+  const successCount = Number(payload?.metadata?.success_count)
+  const failedCount = Number(payload?.metadata?.failed_count)
+  return {
+    images,
+    metadata: {
+      success_count: Number.isFinite(successCount) ? successCount : images.length,
+      failed_count: Number.isFinite(failedCount) ? failedCount : 0,
+    },
+  }
+}
+
+async function requestApiKeyImage(provider: ApiKeyImageProvider, mode: ApiKeyImageMode, body: any): Promise<ApiKeyImageResult> {
   const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
   if (!prompt) {
     const err: any = new Error('prompt is required')
@@ -380,6 +542,10 @@ async function requestApiKeyImage(provider: ApiKeyImageProvider, mode: ApiKeyIma
 
   const n = normalizePositiveInt(body.n, 1, 'n')
   const timeoutMs = normalizePositiveInt(body.timeout_ms, DEFAULT_TIMEOUT_MS, 'timeout_ms')
+  if (provider.kind === 'minimax') {
+    return requestMiniMaxImage(provider, mode, body, prompt, n, timeoutMs)
+  }
+
   const headers = {
     Accept: 'text/event-stream',
     Authorization: `Bearer ${provider.apiKey}`,
@@ -460,7 +626,7 @@ async function requestApiKeyImage(provider: ApiKeyImageProvider, mode: ApiKeyIma
     err.status = 502
     throw err
   }
-  return images
+  return { images }
 }
 
 function saveGeneratedImages(images: string[], requestedOutputPath?: string): string[] {
@@ -492,18 +658,25 @@ export async function apiKeyImageGenerate(ctx: Context) {
   if (!provider) {
     ctx.status = 401
     const isDefaultProvider = providerName === APIKEY_IMAGE_PROVIDER
+    const isMiniMaxProvider = miniMaxImageProviderConfig(providerName) !== null
     ctx.body = {
-      error: `Missing ${providerName} provider in profile "${profile}" config.yaml.`,
-      code: isDefaultProvider ? 'missing_fun_codex_provider' : 'missing_apikey_image_provider',
+      error: isMiniMaxProvider
+        ? `Missing MiniMax API key for profile "${profile}".`
+        : `Missing ${providerName} provider in profile "${profile}" config.yaml.`,
+      code: isDefaultProvider
+        ? 'missing_fun_codex_provider'
+        : isMiniMaxProvider
+          ? 'missing_minimax_image_provider'
+          : 'missing_apikey_image_provider',
     }
     return
   }
 
   try {
     const mode = normalizeImageMode(body.mode)
-    const images = await requestApiKeyImage(provider, mode, body)
+    const result = await requestApiKeyImage(provider, mode, body)
     const requestedOutputPath = typeof body.output_path === 'string' ? body.output_path.trim() : ''
-    const outputPaths = saveGeneratedImages(images, requestedOutputPath || undefined)
+    const outputPaths = saveGeneratedImages(result.images, requestedOutputPath || undefined)
     ctx.body = {
       ok: true,
       mode,
@@ -511,6 +684,7 @@ export async function apiKeyImageGenerate(ctx: Context) {
       provider: provider.name,
       base_url: provider.baseUrl,
       profile,
+      ...(result.metadata ? { metadata: result.metadata } : {}),
     }
   } catch (err: any) {
     ctx.status = err.status || 500

--- a/packages/skills/apikey-image-gen/SKILL.md
+++ b/packages/skills/apikey-image-gen/SKILL.md
@@ -16,7 +16,7 @@ prerequisites:
 
 Use this skill when the user wants to generate an image, generate an image from a reference image, or edit an existing image.
 
-Always call Hermes Web UI's media endpoint. Do not call an upstream image API directly, and do not ask the user for an API key. The server reads the selected/requested profile's `config.yaml` and uses a configured custom provider. By default it uses the provider named `fun-codex`, but callers may request another configured provider by sending `provider`, `provider_name`, or `custom_provider`.
+Always call Hermes Web UI's media endpoint. Do not call an upstream image API directly, and do not ask the user for an API key. The server reads the selected/requested profile's configuration. By default it uses the custom provider named `fun-codex`; `provider: minimax` and `provider: minimax-cn` use the profile's built-in MiniMax credentials for the global and China endpoints.
 
 Do not use any built-in image generation tool as a fallback. If the Hermes Web UI endpoint returns `401`, `403`, connection failure, or any other error, stop and report the Hermes Web UI error to the user.
 
@@ -103,6 +103,24 @@ Use when there is no input image.
 The server calls `POST /v1/images/generations` against the `fun-codex` base URL.
 If `provider`, `provider_name`, or `custom_provider` is present, the server calls the requested provider's base URL instead.
 
+For MiniMax text-to-image generation, use:
+
+```json
+{
+  "mode": "text",
+  "provider": "minimax",
+  "model": "image-01",
+  "prompt": "A high quality product image of a matte black mechanical keyboard on a clean desk",
+  "aspect_ratio": "1:1",
+  "response_format": "base64",
+  "n": 1,
+  "prompt_optimizer": true,
+  "output_path": "/absolute/path/to/output.png"
+}
+```
+
+The server calls `POST https://api.minimax.io/v1/image_generation` for `minimax` and `POST https://api.minimaxi.com/v1/image_generation` for `minimax-cn`.
+
 ### Image To Image
 
 Use when the user provides a reference image and wants a new image based on it.
@@ -119,6 +137,26 @@ Use when the user provides a reference image and wants a new image based on it.
 
 The server calls `POST /v1/responses` against the `fun-codex` base URL.
 If `provider`, `provider_name`, or `custom_provider` is present, the server calls the requested provider's base URL instead.
+
+For MiniMax reference-image generation, use `mode: image`. You may send `subject_reference` directly, or send `image_path`, `image_url`, or `image_base64`; the server converts the latter forms to a `character` subject reference.
+
+```json
+{
+  "mode": "image",
+  "provider": "minimax",
+  "model": "image-01-live",
+  "prompt": "Create a polished editorial portrait using the reference subject",
+  "subject_reference": [
+    {
+      "type": "character",
+      "image_file": "https://example.com/reference.png"
+    }
+  ],
+  "aspect_ratio": "3:4",
+  "response_format": "url",
+  "output_path": "/absolute/path/to/output.png"
+}
+```
 
 ### Image Edit
 
@@ -141,7 +179,7 @@ If `provider`, `provider_name`, or `custom_provider` is present, the server call
 
 - `mode`: `text`, `image`, or `edit`.
 - `prompt`: required.
-- `provider`: optional configured custom provider name. Defaults to `fun-codex`. `custom:<name>` is accepted and normalized to `<name>`.
+- `provider`: optional provider name. Defaults to `fun-codex`. Use `minimax` for the global MiniMax endpoint or `minimax-cn` for the China endpoint. `custom:<name>` is accepted and normalized to `<name>`.
 - `provider_name`: optional alias for `provider`.
 - `custom_provider`: optional alias for `provider`.
 - `image_path`: local png, jpeg, or webp path. Required for `image` and `edit` unless using `image_url` or `image_base64`.
@@ -150,8 +188,14 @@ If `provider`, `provider_name`, or `custom_provider` is present, the server call
 - `n`: number of images. Defaults to `1`.
 - `size`: defaults to `1024x1024`. Common values: `1024x1024`, `1536x1024`, `1024x1536`, `2048x2048`, `3840x2160`, `2160x3840`, `auto`.
 - `quality`: defaults to `auto`.
-- `model`: optional override. If omitted, text/edit modes use `gpt-image-2`; image mode uses the selected provider's `model` when configured, then falls back to `gpt-5.4-mini`.
+- `model`: optional override. MiniMax defaults to `image-01` and also supports `image-01-live`; non-MiniMax modes retain their existing defaults.
 - `image_model`: optional image tool model for image mode. Defaults to `gpt-image-2`.
+- `subject_reference`: MiniMax subject references. Each entry requires `type` and `image_file`; `image_file` may be a public URL or an image Data URL.
+- `aspect_ratio`: optional MiniMax output ratio.
+- `width` and `height`: optional MiniMax pixel dimensions.
+- `response_format`: MiniMax output format, `url` or `base64`. URL results expire after 24 hours, so the server downloads them immediately before saving.
+- `seed`: optional MiniMax random seed.
+- `prompt_optimizer`: optional MiniMax prompt optimization flag.
 - `output_path`: optional absolute output file path. If omitted, the server saves to `${HERMES_WEB_UI_HOME:-~/.hermes-web-ui}/media/*.png`.
 - `timeout_ms`: defaults to `600000`.
 
@@ -184,9 +228,11 @@ curl -sS -X POST "$BASE_URL/api/hermes/media/apikey-image-generate" \
   -H 'Content-Type: application/json' \
   -d '{
     "mode": "text",
-    "provider": "fun-codex",
+    "provider": "minimax",
+    "model": "image-01",
     "prompt": "A cinematic 4K photo of a silver robot hand holding a small glowing cube",
-    "size": "3840x2160",
+    "aspect_ratio": "16:9",
+    "response_format": "base64",
     "output_path": "/absolute/path/to/output.png"
   }'
 ```
@@ -198,10 +244,22 @@ Successful responses include:
   "ok": true,
   "mode": "text",
   "output_paths": ["/absolute/path/to/output.png"],
-  "provider": "fun-codex",
-  "base_url": "https://api.apikey.fun/v1"
+  "provider": "minimax",
+  "base_url": "https://api.minimax.io/v1/image_generation",
+  "metadata": {
+    "success_count": 1,
+    "failed_count": 0
+  }
 }
 ```
 
 If the response code is `missing_fun_codex_provider`, tell the user to configure `fun-codex` in the selected/requested profile's `config.yaml`.
 If the response code is `missing_apikey_image_provider`, tell the user to configure the requested provider in the selected/requested profile's `config.yaml`, or omit `provider` to use the default `fun-codex` provider.
+If the response code is `missing_minimax_image_provider`, tell the user to configure the MiniMax API key for the selected/requested profile.
+
+MiniMax API references:
+
+- Global text-to-image: https://platform.minimax.io/docs/api-reference/image-generation-t2i
+- Global reference-image: https://platform.minimax.io/docs/api-reference/image-generation-i2i
+- China text-to-image: https://platform.minimaxi.com/docs/api-reference/image-generation-t2i
+- China reference-image: https://platform.minimaxi.com/docs/api-reference/image-generation-i2i

--- a/tests/server/media-controller.test.ts
+++ b/tests/server/media-controller.test.ts
@@ -7,6 +7,7 @@ const originalWebuiStateDir = process.env.HERMES_WEBUI_STATE_DIR
 afterEach(() => {
   vi.doUnmock('../../packages/server/src/services/hermes/hermes-profile')
   vi.doUnmock('../../packages/server/src/services/config-helpers')
+  vi.doUnmock('../../packages/server/src/services/ekko-agent/provider-runtime')
   vi.clearAllMocks()
   vi.unstubAllEnvs()
   vi.resetModules()
@@ -159,6 +160,214 @@ describe('media controller', () => {
           model: 'gpt-image-2',
         }],
       })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it.each([
+    { provider: 'minimax', endpoint: 'https://api.minimax.io/v1/image_generation' },
+    { provider: 'minimax-cn', endpoint: 'https://api.minimaxi.com/v1/image_generation' },
+  ])('generates MiniMax images through the $provider regional endpoint', async ({ provider, endpoint }) => {
+    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+      getActiveProfileName: () => 'default',
+      getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
+      listProfileNamesFromDisk: () => ['default'],
+    }))
+    const resolveProviderRuntime = vi.fn(async () => ({
+      provider,
+      apiKey: 'minimax-test-key',
+      baseUrl: 'https://unused.minimax.example/v1',
+    }))
+    vi.doMock('../../packages/server/src/services/ekko-agent/provider-runtime', () => ({
+      resolveEkkoProviderRuntimeConfig: resolveProviderRuntime,
+    }))
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      data: { image_urls: ['aW1hZ2UtYnl0ZXM='] },
+      metadata: { success_count: 1, failed_count: 0 },
+      base_resp: { status_code: 0, status_msg: 'success' },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchMock as any
+    try {
+      const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx: any = {
+        state: { serverTokenAuth: true },
+        query: {},
+        request: {
+          body: {
+            provider,
+            mode: 'text',
+            model: 'image-01-live',
+            prompt: 'make a cinematic portrait',
+            aspect_ratio: '3:4',
+            width: 864,
+            height: 1152,
+            response_format: 'base64',
+            seed: 42,
+            n: 1,
+            prompt_optimizer: true,
+            output_path: `/tmp/hermes-web-ui-${provider}-image.png`,
+          },
+        },
+        get: vi.fn(() => ''),
+        status: 200,
+        body: undefined,
+      }
+
+      await apiKeyImageGenerate(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body).toMatchObject({
+        ok: true,
+        provider,
+        base_url: endpoint,
+        metadata: { success_count: 1, failed_count: 0 },
+      })
+      expect(resolveProviderRuntime).toHaveBeenCalledWith({
+        profile: 'default',
+        provider,
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        endpoint,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Accept: 'application/json',
+            Authorization: 'Bearer minimax-test-key',
+            'Content-Type': 'application/json',
+          }),
+        }),
+      )
+      const requestInit = fetchMock.mock.calls[0][1] as RequestInit
+      expect(JSON.parse(String(requestInit.body))).toEqual({
+        model: 'image-01-live',
+        prompt: 'make a cinematic portrait',
+        response_format: 'base64',
+        n: 1,
+        aspect_ratio: '3:4',
+        width: 864,
+        height: 1152,
+        seed: 42,
+        prompt_optimizer: true,
+      })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('converts MiniMax image input into a subject reference', async () => {
+    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+      getActiveProfileName: () => 'default',
+      getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
+      listProfileNamesFromDisk: () => ['default'],
+    }))
+    vi.doMock('../../packages/server/src/services/ekko-agent/provider-runtime', () => ({
+      resolveEkkoProviderRuntimeConfig: vi.fn(async () => ({
+        provider: 'minimax',
+        apiKey: 'minimax-test-key',
+      })),
+    }))
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      data: { image_urls: ['aW1hZ2UtYnl0ZXM='] },
+      metadata: { success_count: '1', failed_count: '0' },
+      base_resp: { status_code: 0 },
+    }), { status: 200 }))
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchMock as any
+    try {
+      const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx: any = {
+        state: { serverTokenAuth: true },
+        query: {},
+        request: {
+          body: {
+            provider: 'minimax',
+            mode: 'image',
+            model: 'image-01',
+            prompt: 'preserve the reference subject',
+            image_base64: 'aW1hZ2UtYnl0ZXM=',
+            mime_type: 'image/png',
+            response_format: 'base64',
+            output_path: '/tmp/hermes-web-ui-minimax-reference.png',
+          },
+        },
+        get: vi.fn(() => ''),
+        status: 200,
+        body: undefined,
+      }
+
+      await apiKeyImageGenerate(ctx)
+
+      const requestInit = fetchMock.mock.calls[0][1] as RequestInit
+      expect(JSON.parse(String(requestInit.body))).toMatchObject({
+        model: 'image-01',
+        subject_reference: [{
+          type: 'character',
+          image_file: 'data:image/png;base64,aW1hZ2UtYnl0ZXM=',
+        }],
+      })
+      expect(ctx.body.metadata).toEqual({ success_count: 1, failed_count: 0 })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('downloads MiniMax URL results before saving them', async () => {
+    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+      getActiveProfileName: () => 'default',
+      getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
+      listProfileNamesFromDisk: () => ['default'],
+    }))
+    vi.doMock('../../packages/server/src/services/ekko-agent/provider-runtime', () => ({
+      resolveEkkoProviderRuntimeConfig: vi.fn(async () => ({
+        provider: 'minimax',
+        apiKey: 'minimax-test-key',
+      })),
+    }))
+    const resultUrl = 'https://cdn.minimax.example/generated.png'
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === resultUrl) {
+        return new Response('downloaded-image', {
+          status: 200,
+          headers: { 'Content-Type': 'image/png' },
+        })
+      }
+      return new Response(JSON.stringify({
+        data: { image_urls: [resultUrl] },
+        metadata: { success_count: 1, failed_count: 0 },
+        base_resp: { status_code: 0 },
+      }), { status: 200 })
+    })
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchMock as any
+    try {
+      const { apiKeyImageGenerate } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx: any = {
+        state: { serverTokenAuth: true },
+        query: {},
+        request: {
+          body: {
+            provider: 'minimax',
+            mode: 'text',
+            prompt: 'make an image',
+            response_format: 'url',
+            output_path: '/tmp/hermes-web-ui-minimax-url.png',
+          },
+        },
+        get: vi.fn(() => ''),
+        status: 200,
+        body: undefined,
+      }
+
+      await apiKeyImageGenerate(ctx)
+
+      expect(fetchMock).toHaveBeenNthCalledWith(1, 'https://api.minimax.io/v1/image_generation', expect.any(Object))
+      expect(fetchMock).toHaveBeenNthCalledWith(2, resultUrl)
+      expect(ctx.status).toBe(200)
     } finally {
       globalThis.fetch = originalFetch
     }


### PR DESCRIPTION
Reason: Add MiniMax image generation support for regional endpoints and native response handling.

## Summary
- resolve profile credentials for the global and China MiniMax image endpoints
- send supported text and reference-image fields and parse URL or base64 results with generation metadata
- document the MiniMax workflow and add focused controller coverage

## Validation
- `npm run test -- tests/server/media-controller.test.ts`
- `npm run harness:check`
- `npm run build`