### PR TITLE
Fix Group Chat same-user multi-socket membership

### DIFF
--- a/docs/chat-chain-changes/2026-08-12-group-chat-multi-socket-members.md
+++ b/docs/chat-chain-changes/2026-08-12-group-chat-multi-socket-members.md
@@ -1,0 +1,8 @@
+---
+date: 2026-08-12
+pr: pending
+feature: Group Chat multi-socket member presence
+impact: Multiple tabs or browsers for the same authenticated Room member remain joined without invalidating earlier sockets, and presence becomes offline only after the last socket disconnects.
+---
+
+Room membership stays deduplicated by user while Socket.IO admission tracks every joined socket for that user.

--- a/docs/chat-chain-changes/2026-08-12-group-chat-multi-socket-members.md
+++ b/docs/chat-chain-changes/2026-08-12-group-chat-multi-socket-members.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-12
-pr: pending
+pr: 2498
 feature: Group Chat multi-socket member presence
 impact: Multiple tabs or browsers for the same authenticated Room member remain joined without invalidating earlier sockets, and presence becomes offline only after the last socket disconnects.
 ---

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -1623,6 +1623,7 @@ class ChatRoom {
     readonly id: string
     name: string
     readonly members = new Map<string, Member>()
+    private readonly socketUsers = new Map<string, string>()
 
     constructor(id: string, name?: string) {
         this.id = id
@@ -1630,6 +1631,7 @@ class ChatRoom {
     }
 
     addOrUpdateMember(socketId: string, userId: string, name: string, description: string, source: 'human' | 'agent' = 'human', avatar: string = ''): Member {
+        this.socketUsers.set(socketId, userId)
         const existing = this.members.get(userId)
         if (existing) {
             existing.name = name
@@ -1646,17 +1648,26 @@ class ChatRoom {
     }
 
     removeMember(socketId: string): void {
-        for (const member of this.members.values()) {
-            if (member.socketId === socketId) {
-                member.online = false
-                break
-            }
+        const userId = this.socketUsers.get(socketId)
+        if (!userId) return
+        this.socketUsers.delete(socketId)
+        const member = this.members.get(userId)
+        if (!member) return
+        const replacementSocketId = Array.from(this.socketUsers.entries()).find(([, mappedUserId]) => mappedUserId === userId)?.[0]
+        member.online = Boolean(replacementSocketId)
+        if (member.socketId === socketId && replacementSocketId) {
+            member.socketId = replacementSocketId
         }
     }
 
     removeUser(userId: string): Member | null {
         const member = this.members.get(userId) || null
-        if (member) this.members.delete(userId)
+        if (member) {
+            this.members.delete(userId)
+            for (const [socketId, mappedUserId] of this.socketUsers) {
+                if (mappedUserId === userId) this.socketUsers.delete(socketId)
+            }
+        }
         return member
     }
 
@@ -1665,10 +1676,10 @@ class ChatRoom {
     }
 
     getOnlineMemberBySocketId(socketId: string): Member | undefined {
-        for (const member of this.members.values()) {
-            if (member.socketId === socketId && member.online) return member
-        }
-        return undefined
+        const userId = this.socketUsers.get(socketId)
+        if (!userId) return undefined
+        const member = this.members.get(userId)
+        return member?.online ? member : undefined
     }
 
     hasOnlineMember(socketId: string): boolean {
@@ -3550,7 +3561,7 @@ export class GroupChatServer {
                 const member = room.getOnlineMemberBySocketId(socketId)
                 room.removeMember(socketId)
                 socket.leave(rid)
-                if (member?.source !== 'agent') {
+                if (member?.source !== 'agent' && !member?.online) {
                     this.nsp.to(rid).emit('member_left', {
                         roomId: rid,
                         memberId: member?.userId || socketId,

--- a/tests/server/group-chat-member-sync.test.ts
+++ b/tests/server/group-chat-member-sync.test.ts
@@ -1055,6 +1055,189 @@ describe('Group Chat member/agent identity sync', () => {
     expect(ack.mock.calls[0][0]).toEqual(expect.objectContaining({ roomId: 'room-1', messages: [], agents: [] }))
   })
 
+  it('keeps every joined socket valid when one authenticated user opens the room twice', () => {
+    const emit = vi.fn()
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map()
+    server.socketUserMap = new Map([
+      ['socket-1', 'auth:42'],
+      ['socket-2', 'auth:42'],
+    ])
+    server.socketRequestedSourceMap = new Map([
+      ['socket-1', 'human'],
+      ['socket-2', 'human'],
+    ])
+    server.socketAuthUserIdMap = new Map([
+      ['socket-1', 42],
+      ['socket-2', 42],
+    ])
+    server.userInfoMap = new Map([['auth:42', { name: 'alice', description: '' }]])
+    server.typingState = new Map()
+    server.contextStatusState = new Map()
+    server.storage = {
+      getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', inviteCode: null, ownerAuthUserId: 42 })),
+      getRoomAgentByAgentId: vi.fn(() => null),
+      getMemberByUserId: vi.fn(() => ({
+        id: 'member-1',
+        userId: 'auth:42',
+        name: 'alice',
+        description: '',
+        joinedAt: 1,
+        avatar: '',
+        authUserId: 42,
+      })),
+      getMemberByAuthUserId: vi.fn(() => null),
+      getRoomsForProfiles: vi.fn(() => []),
+      saveRoom: vi.fn(),
+      addRoomMember: vi.fn(),
+      getRecentMessagesForUI: vi.fn(() => []),
+      getRoomAgents: vi.fn(() => []),
+    }
+    const createSocket = (id: string) => ({
+      id,
+      data: { authUser: { id: 42, username: 'alice', role: 'admin', profiles: ['default'] } },
+      join: vi.fn(),
+      to: vi.fn(() => ({ emit })),
+    })
+
+    server.handleJoin(createSocket('socket-1'), { roomId: 'room-1' }, vi.fn())
+    server.handleJoin(createSocket('socket-2'), { roomId: 'room-1' }, vi.fn())
+
+    const room = server.rooms.get('room-1')
+    expect(room.getMembersList()).toHaveLength(1)
+    expect(room.hasOnlineMember('socket-1')).toBe(true)
+    expect(room.hasOnlineMember('socket-2')).toBe(true)
+    expect(room.getOnlineMemberBySocketId('socket-1')?.userId).toBe('auth:42')
+    expect(room.getOnlineMemberBySocketId('socket-2')?.userId).toBe('auth:42')
+  })
+
+  it('keeps the user online when one of their joined room sockets disconnects', () => {
+    const emit = vi.fn()
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map()
+    server.socketUserMap = new Map([
+      ['socket-1', 'auth:42'],
+      ['socket-2', 'auth:42'],
+    ])
+    server.socketRequestedSourceMap = new Map([
+      ['socket-1', 'human'],
+      ['socket-2', 'human'],
+    ])
+    server.socketAuthUserIdMap = new Map([
+      ['socket-1', 42],
+      ['socket-2', 42],
+    ])
+    server.userInfoMap = new Map([['auth:42', { name: 'alice', description: '' }]])
+    server.typingState = new Map()
+    server.contextStatusState = new Map()
+    server.nsp = { to: vi.fn(() => ({ emit })) }
+    server.storage = {
+      getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', inviteCode: null, ownerAuthUserId: 42 })),
+      getRoomAgentByAgentId: vi.fn(() => null),
+      getMemberByUserId: vi.fn(() => ({
+        id: 'member-1',
+        userId: 'auth:42',
+        name: 'alice',
+        description: '',
+        joinedAt: 1,
+        avatar: '',
+        authUserId: 42,
+      })),
+      getMemberByAuthUserId: vi.fn(() => null),
+      getRoomsForProfiles: vi.fn(() => []),
+      saveRoom: vi.fn(),
+      addRoomMember: vi.fn(),
+      getRecentMessagesForUI: vi.fn(() => []),
+      getRoomAgents: vi.fn(() => []),
+    }
+    const createSocket = (id: string) => ({
+      id,
+      data: { authUser: { id: 42, username: 'alice', role: 'admin', profiles: ['default'] } },
+      join: vi.fn(),
+      leave: vi.fn(),
+      to: vi.fn(() => ({ emit })),
+    })
+    const socket1 = createSocket('socket-1')
+    const socket2 = createSocket('socket-2')
+    server.handleJoin(socket1, { roomId: 'room-1' }, vi.fn())
+    server.handleJoin(socket2, { roomId: 'room-1' }, vi.fn())
+    emit.mockClear()
+
+    server.leaveAllRooms(socket2, 'socket-2')
+
+    const room = server.rooms.get('room-1')
+    expect(room.hasOnlineMember('socket-1')).toBe(true)
+    expect(room.hasOnlineMember('socket-2')).toBe(false)
+    expect(room.getMembersList()).toEqual([
+      expect.objectContaining({ userId: 'auth:42', online: true }),
+    ])
+    expect(socket2.leave).toHaveBeenCalledWith('room-1')
+    expect(emit).not.toHaveBeenCalledWith('member_left', expect.anything())
+  })
+
+  it('marks the user offline only after their last joined room socket disconnects', () => {
+    const emit = vi.fn()
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map()
+    server.socketUserMap = new Map([
+      ['socket-1', 'auth:42'],
+      ['socket-2', 'auth:42'],
+    ])
+    server.socketRequestedSourceMap = new Map([
+      ['socket-1', 'human'],
+      ['socket-2', 'human'],
+    ])
+    server.socketAuthUserIdMap = new Map([
+      ['socket-1', 42],
+      ['socket-2', 42],
+    ])
+    server.userInfoMap = new Map([['auth:42', { name: 'alice', description: '' }]])
+    server.typingState = new Map()
+    server.contextStatusState = new Map()
+    server.nsp = { to: vi.fn(() => ({ emit })) }
+    server.storage = {
+      getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', inviteCode: null, ownerAuthUserId: 42 })),
+      getRoomAgentByAgentId: vi.fn(() => null),
+      getMemberByUserId: vi.fn(() => ({
+        id: 'member-1', userId: 'auth:42', name: 'alice', description: '', joinedAt: 1, avatar: '', authUserId: 42,
+      })),
+      getMemberByAuthUserId: vi.fn(() => null),
+      getRoomsForProfiles: vi.fn(() => []),
+      saveRoom: vi.fn(),
+      addRoomMember: vi.fn(),
+      getRecentMessagesForUI: vi.fn(() => []),
+      getRoomAgents: vi.fn(() => []),
+    }
+    const createSocket = (id: string) => ({
+      id,
+      data: { authUser: { id: 42, username: 'alice', role: 'admin', profiles: ['default'] } },
+      join: vi.fn(),
+      leave: vi.fn(),
+      to: vi.fn(() => ({ emit })),
+    })
+    const socket1 = createSocket('socket-1')
+    const socket2 = createSocket('socket-2')
+    server.handleJoin(socket1, { roomId: 'room-1' }, vi.fn())
+    server.handleJoin(socket2, { roomId: 'room-1' }, vi.fn())
+    emit.mockClear()
+
+    server.leaveAllRooms(socket2, 'socket-2')
+    server.leaveAllRooms(socket1, 'socket-1')
+
+    const room = server.rooms.get('room-1')
+    expect(room.hasOnlineMember('socket-1')).toBe(false)
+    expect(room.hasOnlineMember('socket-2')).toBe(false)
+    expect(room.getMembersList()).toEqual([
+      expect.objectContaining({ userId: 'auth:42', online: false }),
+    ])
+    expect(emit).toHaveBeenCalledTimes(1)
+    expect(emit).toHaveBeenCalledWith('member_left', expect.objectContaining({
+      roomId: 'room-1',
+      memberId: 'auth:42',
+      memberName: 'alice',
+    }))
+  })
+
   it('reuses an authenticated member name when the browser has no local group-chat name', () => {
     const emit = vi.fn()
     const server = Object.create(GroupChatServer.prototype) as any


### PR DESCRIPTION
## Summary
- track every joined Room socket for one stable Group Chat member
- keep earlier same-account tabs authorized after a later tab joins
- mark a member offline and broadcast `member_left` only after their last socket disconnects
- preserve one public member entry per user and reject sockets that never joined

Fixes #2497

## Root cause

`ChatRoom.members` deduplicated presence by `userId`, but `Member` retained only one mutable `socketId`. A second authenticated tab overwrote the first socket, so the earlier page remained visually populated while message, typing, interrupt, or other Room admission checks returned `Not in room`.

## Validation
- regression tests demonstrated RED before implementation (`socket-1`: expected true, received false after `socket-2` joined)
- `NODE_ENV=test npm run test -- tests/server/group-chat-member-sync.test.ts tests/server/group-chat-baseline.test.ts tests/server/group-chat-streaming.test.ts tests/client/group-chat-store-baseline.test.ts tests/client/group-chat-store-streaming.test.ts` (127 passed)
- `npm run harness:check`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run build`

## Local full-suite note

The local all-test run is not fully green because this machine has a real `/usr/local/lib/hermes-agent` installation and user plugins that violate several tests' clean-environment assumptions; an unrelated Kanban attachment-path test also fails in this filesystem. The changed Group Chat test suites, harness, server typecheck, and production build pass. GitHub CI on a clean runner is the authoritative full-suite result.

## Risk

Server-only in-memory Room presence change. No database migration, client API change, production deployment, or release is included.
