### PR TITLE
Fix Group Chat same-user typing ownership

### DIFF
--- a/docs/chat-chain-changes/2026-08-12-group-chat-typing-socket-owner.md
+++ b/docs/chat-chain-changes/2026-08-12-group-chat-typing-socket-owner.md
@@ -1,0 +1,20 @@
+---
+date: 2026-08-12
+pr: pending
+feature: Group Chat multi-socket typing ownership
+impact: Preserve socket-owned typing state across same-user connections
+---
+
+## Summary
+
+Typing state now records the joined socket that most recently emitted `typing` for a room member. A disconnect or `stop_typing` event clears that state only when it comes from the owning socket, so another same-user tab or device cannot prematurely remove an active typing indicator.
+
+## Impact
+
+- Preserves active typing when a different joined socket for the same user disconnects.
+- Ignores stale `stop_typing` events from non-owning same-user sockets.
+- Keeps owner disconnect cleanup and the existing joined-room authorization checks.
+
+## Notes
+
+This is a transient server-side lifecycle fix following #2498. It does not change persisted Room membership, message history, or authorization policy.

--- a/docs/chat-chain-changes/2026-08-12-group-chat-typing-socket-owner.md
+++ b/docs/chat-chain-changes/2026-08-12-group-chat-typing-socket-owner.md
@@ -13,7 +13,7 @@ Typing state now records the joined socket that most recently emitted `typing` f
 
 - Preserves active typing when a different joined socket for the same user disconnects.
 - Ignores stale `stop_typing` events from non-owning same-user sockets.
-- Keeps owner disconnect cleanup and the existing joined-room authorization checks.
+- Keeps owner disconnect cleanup and active member removal cleanup aligned with the existing joined-room authorization checks.
 
 ## Notes
 

--- a/docs/chat-chain-changes/2026-08-12-group-chat-typing-socket-owner.md
+++ b/docs/chat-chain-changes/2026-08-12-group-chat-typing-socket-owner.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-12
-pr: pending
+pr: 2500
 feature: Group Chat multi-socket typing ownership
 impact: Preserve socket-owned typing state across same-user connections
 ---

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -2118,6 +2118,18 @@ export class GroupChatServer {
         const onlineMember = room?.members.get(normalizedUserId) || null
         if (!storedMember && !onlineMember) return null
 
+        const roomTyping = this.typingState.get(roomId)
+        const typingEntry = roomTyping?.get(normalizedUserId)
+        if (typingEntry) {
+            clearTimeout(typingEntry.timer)
+            roomTyping!.delete(normalizedUserId)
+            if (roomTyping!.size === 0) this.typingState.delete(roomId)
+            this.nsp.to(roomId).emit('stop_typing', {
+                roomId,
+                userId: normalizedUserId,
+            })
+        }
+
         room?.removeUser(normalizedUserId)
         this.storage.removeRoomMember?.(roomId, normalizedUserId)
 

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -1706,8 +1706,8 @@ export class GroupChatServer {
     private roomSummaryService: GroupRoomSummaryService
     private _restoreScheduled = false
     private chatRunService: GroupChatRunService | null = null
-    /** roomId -> (userId -> { userName, timer }) */
-    private typingState = new Map<string, Map<string, { userName: string; timer: ReturnType<typeof setTimeout> }>>()
+    /** roomId -> (userId -> { userName, socketId, timer }) */
+    private typingState = new Map<string, Map<string, { userName: string; socketId: string; timer: ReturnType<typeof setTimeout> }>>()
     /**
      * Transient activity restored to browsers when they join/reconnect.
      * Keep the runtime session id internally so a terminal event from the
@@ -3036,6 +3036,7 @@ export class GroupChatServer {
         if (existing) clearTimeout(existing.timer)
         roomTyping.set(userId, {
             userName,
+            socketId: socket.id,
             timer: setTimeout(() => {
                 roomTyping!.delete(userId)
                 if (roomTyping!.size === 0) this.typingState.delete(roomId)
@@ -3057,12 +3058,11 @@ export class GroupChatServer {
 
         // Remove from typing state
         const roomTyping = this.typingState.get(roomId)
-        if (roomTyping) {
-            const entry = roomTyping.get(userId)
-            if (entry) clearTimeout(entry.timer)
-            roomTyping.delete(userId)
-            if (roomTyping.size === 0) this.typingState.delete(roomId)
-        }
+        const entry = roomTyping?.get(userId)
+        if (entry?.socketId !== socket.id) return
+        clearTimeout(entry.timer)
+        roomTyping!.delete(userId)
+        if (roomTyping!.size === 0) this.typingState.delete(roomId)
 
         socket.to(roomId).emit('stop_typing', {
             roomId,
@@ -3523,7 +3523,7 @@ export class GroupChatServer {
         // Clean up typing state for this socket
         for (const [roomId, roomTyping] of this.typingState) {
             const entry = roomTyping.get(userId || socketId)
-            if (entry) {
+            if (entry?.socketId === socketId) {
                 clearTimeout(entry.timer)
                 roomTyping.delete(userId || socketId)
                 if (roomTyping.size === 0) this.typingState.delete(roomId)

--- a/tests/server/group-chat-member-sync.test.ts
+++ b/tests/server/group-chat-member-sync.test.ts
@@ -242,6 +242,58 @@ describe('Group Chat member/agent identity sync', () => {
     })
   })
 
+  it('clears typing when an active room member is removed', () => {
+    const broadcast = vi.fn()
+    const kickedSocket = {
+      id: 'socket-1',
+      rooms: new Set(['room-1']),
+      emit: vi.fn(),
+      leave: vi.fn(),
+    }
+    const member = {
+      id: 'member-1',
+      userId: 'human-1',
+      name: 'Human',
+      description: '',
+      joinedAt: 1,
+      online: true,
+      socketId: 'socket-1',
+      source: 'human',
+      avatar: '',
+    }
+    const roomState = {
+      members: new Map([['human-1', member]]),
+      removeUser: vi.fn(() => true),
+      getMembersList: vi.fn(() => []),
+    }
+    const timer = setTimeout(() => {}, 30000)
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map([['room-1', roomState]])
+    server.typingState = new Map([['room-1', new Map([['human-1', {
+      userName: 'Human',
+      socketId: 'socket-1',
+      timer,
+    }]])]])
+    server.socketUserMap = new Map([['socket-1', 'human-1']])
+    server.nsp = {
+      sockets: new Map([['socket-1', kickedSocket]]),
+      to: vi.fn(() => ({ emit: broadcast })),
+    }
+    server.storage = {
+      getMemberByUserId: vi.fn(() => member),
+      removeRoomMember: vi.fn(),
+    }
+    server.getRoomMemberViews = vi.fn(() => [])
+
+    server.removeRoomMember('room-1', 'human-1')
+
+    expect(server.typingState.has('room-1')).toBe(false)
+    expect(broadcast).toHaveBeenCalledWith('stop_typing', {
+      roomId: 'room-1',
+      userId: 'human-1',
+    })
+  })
+
   it('uses the persisted group-chat agent id as the runtime agent id and socket user id', async () => {
     const clients = new AgentClients()
 

--- a/tests/server/group-chat-member-sync.test.ts
+++ b/tests/server/group-chat-member-sync.test.ts
@@ -105,6 +105,143 @@ describe('Group Chat member/agent identity sync', () => {
     expect(broadcast).not.toHaveBeenCalled()
   })
 
+  it('preserves typing when another socket for the same user disconnects', () => {
+    const broadcast = vi.fn()
+    const member = {
+      id: 'member-1',
+      userId: 'human-1',
+      name: 'Human',
+      description: '',
+      joinedAt: 1,
+      online: true,
+      socketId: 'socket-1',
+      source: 'human',
+      avatar: '',
+    }
+    const roomState = {
+      getOnlineMemberBySocketId: vi.fn((socketId: string) => (
+        socketId === 'socket-1' || socketId === 'socket-2' ? member : undefined
+      )),
+    }
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map([['room-1', roomState]])
+    server.typingState = new Map()
+    server.socketUserMap = new Map([
+      ['socket-1', 'human-1'],
+      ['socket-2', 'human-1'],
+    ])
+    server.socketRequestedSourceMap = new Map([
+      ['socket-1', 'human'],
+      ['socket-2', 'human'],
+    ])
+    server.socketAuthUserIdMap = new Map()
+    server.userInfoMap = new Map([['human-1', { name: 'Human', description: '' }]])
+    server.guestAgentRequestTokens = new Map()
+    server.nsp = { to: vi.fn(() => ({ emit: broadcast })) }
+    server.leaveAllRooms = vi.fn()
+    const typingSocket = {
+      id: 'socket-1',
+      data: {},
+      to: vi.fn(() => ({ emit: broadcast })),
+    }
+    const otherSocket = {
+      id: 'socket-2',
+      data: {},
+    }
+
+    server.handleTyping(typingSocket, { roomId: 'room-1' })
+    broadcast.mockClear()
+    server.handleDisconnect(otherSocket)
+
+    expect(server.typingState.get('room-1')?.has('human-1')).toBe(true)
+    expect(broadcast).not.toHaveBeenCalledWith('stop_typing', {
+      roomId: 'room-1',
+      userId: 'human-1',
+    })
+  })
+
+  it('ignores stop-typing from another socket for the same user', () => {
+    const broadcast = vi.fn()
+    const member = {
+      id: 'member-1',
+      userId: 'human-1',
+      name: 'Human',
+      description: '',
+      joinedAt: 1,
+      online: true,
+      socketId: 'socket-1',
+      source: 'human',
+      avatar: '',
+    }
+    const roomState = {
+      getOnlineMemberBySocketId: vi.fn((socketId: string) => (
+        socketId === 'socket-1' || socketId === 'socket-2' ? member : undefined
+      )),
+    }
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map([['room-1', roomState]])
+    server.typingState = new Map()
+    const typingSocket = {
+      id: 'socket-1',
+      to: vi.fn(() => ({ emit: broadcast })),
+    }
+    const otherSocket = {
+      id: 'socket-2',
+      to: vi.fn(() => ({ emit: broadcast })),
+    }
+
+    server.handleTyping(typingSocket, { roomId: 'room-1' })
+    broadcast.mockClear()
+    server.handleStopTyping(otherSocket, { roomId: 'room-1' })
+
+    expect(server.typingState.get('room-1')?.has('human-1')).toBe(true)
+    expect(broadcast).not.toHaveBeenCalled()
+  })
+
+  it('clears typing exactly once when the owning socket disconnects', () => {
+    const broadcast = vi.fn()
+    const member = {
+      id: 'member-1',
+      userId: 'human-1',
+      name: 'Human',
+      description: '',
+      joinedAt: 1,
+      online: true,
+      socketId: 'socket-1',
+      source: 'human',
+      avatar: '',
+    }
+    const roomState = {
+      getOnlineMemberBySocketId: vi.fn(() => member),
+    }
+    const server = Object.create(GroupChatServer.prototype) as any
+    server.rooms = new Map([['room-1', roomState]])
+    server.typingState = new Map()
+    server.socketUserMap = new Map([['socket-1', 'human-1']])
+    server.socketRequestedSourceMap = new Map([['socket-1', 'human']])
+    server.socketAuthUserIdMap = new Map()
+    server.userInfoMap = new Map([['human-1', { name: 'Human', description: '' }]])
+    server.guestAgentRequestTokens = new Map()
+    server.nsp = { to: vi.fn(() => ({ emit: broadcast })) }
+    server.leaveAllRooms = vi.fn()
+    const socket = {
+      id: 'socket-1',
+      data: {},
+      to: vi.fn(() => ({ emit: broadcast })),
+    }
+
+    server.handleTyping(socket, { roomId: 'room-1' })
+    broadcast.mockClear()
+    server.handleDisconnect(socket)
+
+    expect(server.typingState.has('room-1')).toBe(false)
+    expect(broadcast).toHaveBeenCalledTimes(1)
+    expect(broadcast).toHaveBeenCalledWith('stop_typing', {
+      roomId: 'room-1',
+      userId: 'human-1',
+    })
+  })
+
   it('uses the persisted group-chat agent id as the runtime agent id and socket user id', async () => {
     const clients = new AgentClients()
 


### PR DESCRIPTION
## Summary

- record the Socket that owns each transient Group Chat typing entry
- preserve active typing when another same-user Socket disconnects or emits stale `stop_typing`
- clear typing exactly once when the owning Socket disconnects

## Root cause

PR #2498 correctly made Room membership multi-Socket, but typing state remained keyed only by stable `userId`. Any same-user disconnect or `stop_typing` could therefore clear another Socket's active indicator.

## TDD evidence

Observed RED before production changes:

```text
preserves typing when another socket for the same user disconnects
expected true, received undefined
```

A sabotage run restored unconditional disconnect cleanup and reproduced the same failure.

## Validation

- member-sync: 45/45 passed
- expanded Group Chat: 156/156 passed
- server TypeScript: passed
- harness: passed
- production build: passed

## Scope

Server-only transient typing lifecycle. No persisted Room membership, message history, authorization, deployment, or release changes.

Fixes #2499
Follow-up to #2498.