### PR TITLE
feat: support App group chat relay and MP3 STT

### DIFF
--- a/packages/server/src/services/app-relay/client.ts
+++ b/packages/server/src/services/app-relay/client.ts
@@ -21,13 +21,26 @@ const ALLOWED_REQUEST_HEADERS = new Set([
   'x-hermes-profile',
   'x-request-id',
 ])
-const ALLOWED_SOCKET_NAMESPACES = new Set(['/chat-run'])
+const ALLOWED_SOCKET_NAMESPACES = new Set(['/chat-run', '/group-chat'])
 const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
   'run',
   'resume',
   'abort',
   'insert_queued_run',
   'cancel_queued_run',
+  'approval.respond',
+  'clarify.respond',
+])
+const ALLOWED_GROUP_CHAT_CLIENT_EVENTS = new Set([
+  'join',
+  'load_pending_approvals',
+  'load_messages',
+  'update_member_profile',
+  'message',
+  'typing',
+  'stop_typing',
+  'interrupt_agent',
+  'remove_agent',
   'approval.respond',
   'clarify.respond',
 ])
@@ -83,6 +96,8 @@ export interface AppRelaySocketEventRequest {
   event?: string
   payload?: unknown
   stream?: boolean
+  ack?: boolean
+  timeoutMs?: number
 }
 
 export interface AppRelaySocketCloseRequest {
@@ -189,7 +204,7 @@ export class AppRelayClient {
       ack?.(this.openLocalSocket(request))
     })
     this.socket.on('app.socket.event', (request: AppRelaySocketEventRequest, ack?: (response: AppRelaySocketResponse) => void) => {
-      ack?.(this.emitLocalSocketEvent(request))
+      void this.emitLocalSocketEvent(request).then(response => ack?.(response))
     })
     this.socket.on('app.socket.close', (request: AppRelaySocketCloseRequest, ack?: (response: AppRelaySocketResponse) => void) => {
       ack?.(this.closeLocalSocket(request))
@@ -336,20 +351,28 @@ export class AppRelayClient {
     return { id, ok: true, namespace, stream: bridge.stream }
   }
 
-  private emitLocalSocketEvent(request: AppRelaySocketEventRequest): AppRelaySocketResponse {
+  private async emitLocalSocketEvent(request: AppRelaySocketEventRequest): Promise<AppRelaySocketResponse> {
     const id = normalizeBridgeId(request.id)
     if (!id) return socketError(request.id, 'invalid_socket_id', 'Relay socket id is required')
     const event = String(request.event || '').trim()
-    if (!ALLOWED_CHAT_RUN_CLIENT_EVENTS.has(event)) return socketError(id, 'event_not_allowed', 'Relay socket event is not allowed')
     const bridge = this.bridges.get(id)
     if (!bridge) return socketError(id, 'socket_not_open', 'Relay socket is not open')
+    if (!isAllowedSocketEvent(bridge.namespace, event)) return socketError(id, 'event_not_allowed', 'Relay socket event is not allowed')
     if (typeof request.stream === 'boolean') bridge.stream = request.stream
     if (event === 'run') {
       bridge.output = ''
       bridge.reasoning = ''
     }
-    bridge.socket.emit(event, request.payload)
-    return { id, ok: true, namespace: bridge.namespace, event, stream: bridge.stream }
+    if (!request.ack) {
+      bridge.socket.emit(event, request.payload)
+      return { id, ok: true, namespace: bridge.namespace, event, stream: bridge.stream }
+    }
+    try {
+      const payload = await emitLocalSocketWithAck(bridge.socket, event, request.payload, normalizeTimeout(request.timeoutMs))
+      return { id, ok: true, namespace: bridge.namespace, event, stream: bridge.stream, payload }
+    } catch (error) {
+      return socketError(id, 'socket_ack_timeout', error instanceof Error ? error.message : 'Socket acknowledgement timed out')
+    }
   }
 
   private closeLocalSocket(request: AppRelaySocketCloseRequest): AppRelaySocketResponse {
@@ -574,6 +597,29 @@ function normalizeTimeout(value: unknown): number {
   const timeout = Number(value)
   if (!Number.isFinite(timeout) || timeout <= 0) return DEFAULT_REQUEST_TIMEOUT_MS
   return Math.min(Math.floor(timeout), MAX_REQUEST_TIMEOUT_MS)
+}
+
+function isAllowedSocketEvent(namespace: string, event: string): boolean {
+  if (namespace === '/chat-run') return ALLOWED_CHAT_RUN_CLIENT_EVENTS.has(event)
+  if (namespace === '/group-chat') return ALLOWED_GROUP_CHAT_CLIENT_EVENTS.has(event)
+  return false
+}
+
+function emitLocalSocketWithAck(socket: Socket, event: string, payload: unknown, timeoutMs: number): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      reject(new Error(`Socket acknowledgement timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+    socket.emit(event, payload, (...args: unknown[]) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(args.length <= 1 ? args[0] : args)
+    })
+  })
 }
 
 function httpError(id: string | undefined, code: string, message: string, status?: number): AppRelayHttpResponse {

--- a/packages/server/src/services/app-relay/server.ts
+++ b/packages/server/src/services/app-relay/server.ts
@@ -39,6 +39,20 @@ const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
   'approval.respond',
   'clarify.respond',
 ])
+const ALLOWED_GROUP_CHAT_CLIENT_EVENTS = new Set([
+  'join',
+  'load_pending_approvals',
+  'load_messages',
+  'update_member_profile',
+  'message',
+  'typing',
+  'stop_typing',
+  'interrupt_agent',
+  'remove_agent',
+  'approval.respond',
+  'clarify.respond',
+])
+const ALLOWED_SOCKET_NAMESPACES = new Set(['/chat-run', '/group-chat'])
 const NON_STREAMING_SUPPRESSED_EVENTS = new Set([
   'message.delta',
   'message.interim',
@@ -65,7 +79,7 @@ interface LocalAppRelayServerOptions {
 interface LocalSocketBridge {
   key: string
   id: string
-  namespace: '/chat-run'
+  namespace: string
   ownerSocketId: string
   socket: ClientSocket
   stream: boolean
@@ -140,7 +154,7 @@ export class LocalAppRelayServer {
       role: 'app',
       machineId,
       hostConnected: true,
-      capabilities: ['http.request', 'socket.chat-run'],
+      capabilities: ['http.request', 'socket.chat-run', 'socket.group-chat'],
     })
     if (socket.data.localUserToken) this.scheduleTokenExpiry(socket)
 
@@ -217,12 +231,11 @@ export class LocalAppRelayServer {
     }
     const id = normalizeBridgeId(request.id)
     if (!id) return socketError(request.id, 'invalid_socket_id', 'A socket bridge id is required')
-    if (request.namespace !== '/chat-run') {
-      return socketError(id, 'namespace_not_allowed', 'Only /chat-run can be relayed')
-    }
+    const namespace = String(request.namespace || '').trim()
+    if (!ALLOWED_SOCKET_NAMESPACES.has(namespace)) return socketError(id, 'namespace_not_allowed', 'Relay socket namespace is not allowed')
 
     this.closeSocket(socket, { id })
-    const localSocket = createClientSocket(`${this.localBaseUrl}/chat-run`, {
+    const localSocket = createClientSocket(`${this.localBaseUrl}${namespace}`, {
       auth: {
         ...normalizeSocketAuth(request.auth),
         token: socket.data.localUserToken,
@@ -238,7 +251,7 @@ export class LocalAppRelayServer {
     const bridge: LocalSocketBridge = {
       key: bridgeKey(socket.id, id),
       id,
-      namespace: '/chat-run',
+      namespace,
       ownerSocketId: socket.id,
       socket: localSocket,
       stream: typeof request.stream === 'boolean' ? request.stream : true,
@@ -262,18 +275,26 @@ export class LocalAppRelayServer {
     const id = normalizeBridgeId(request.id)
     if (!id) return socketError(request.id, 'invalid_socket_id', 'A socket bridge id is required')
     const event = String(request.event || '').trim()
-    if (!ALLOWED_CHAT_RUN_CLIENT_EVENTS.has(event)) {
-      return socketError(id, 'event_not_allowed', 'Relay socket event is not allowed')
-    }
     const bridge = this.bridges.get(bridgeKey(socket.id, id))
     if (!bridge) return socketError(id, 'socket_not_open', 'The chat socket bridge is not open')
+    if (!isAllowedSocketEvent(bridge.namespace, event)) {
+      return socketError(id, 'event_not_allowed', 'Relay socket event is not allowed')
+    }
     if (typeof request.stream === 'boolean') bridge.stream = request.stream
     if (event === 'run') {
       bridge.output = ''
       bridge.reasoning = ''
     }
-    bridge.socket.emit(event, request.payload)
-    return { id, ok: true, namespace: bridge.namespace, event, stream: bridge.stream }
+    if (!request.ack) {
+      bridge.socket.emit(event, request.payload)
+      return { id, ok: true, namespace: bridge.namespace, event, stream: bridge.stream }
+    }
+    try {
+      const payload = await emitLocalSocketWithAck(bridge.socket, event, request.payload, normalizeTimeout(request.timeoutMs))
+      return { id, ok: true, namespace: bridge.namespace, event, stream: bridge.stream, payload }
+    } catch (error) {
+      return socketError(id, 'socket_ack_timeout', error instanceof Error ? error.message : 'Socket acknowledgement timed out')
+    }
   }
 
   private closeSocket(socket: Socket, request: AppRelaySocketCloseRequest): AppRelaySocketResponse {
@@ -531,6 +552,29 @@ function normalizeTimeout(value: unknown): number {
   const timeout = Number(value)
   if (!Number.isFinite(timeout) || timeout <= 0) return DEFAULT_REQUEST_TIMEOUT_MS
   return Math.min(Math.floor(timeout), MAX_REQUEST_TIMEOUT_MS)
+}
+
+function isAllowedSocketEvent(namespace: string, event: string): boolean {
+  if (namespace === '/chat-run') return ALLOWED_CHAT_RUN_CLIENT_EVENTS.has(event)
+  if (namespace === '/group-chat') return ALLOWED_GROUP_CHAT_CLIENT_EVENTS.has(event)
+  return false
+}
+
+function emitLocalSocketWithAck(socket: ClientSocket, event: string, payload: unknown, timeoutMs: number): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      reject(new Error(`Socket acknowledgement timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+    socket.emit(event, payload, (...args: unknown[]) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(args.length <= 1 ? args[0] : args)
+    })
+  })
 }
 
 function bridgeKey(ownerSocketId: string, id: string): string {

--- a/packages/server/src/services/hermes/local-stt-model-manager.ts
+++ b/packages/server/src/services/hermes/local-stt-model-manager.ts
@@ -8,6 +8,7 @@ import { basename, dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
 import * as tar from 'tar'
 import { config } from '../../config'
+import { transcodeToPcmS16le } from './stt-providers/audio-convert'
 import { SttNoSpeechDetectedError, type SttTranscribeInput, type SttTranscribeResult } from './stt-providers/types'
 
 const DEFAULT_DOWNLOAD_BASE_URL = 'https://download.ekkolearnai.com'
@@ -788,11 +789,24 @@ export function prepareLocalSttWav(audio: Buffer, mimeType: string): Buffer {
   return Buffer.concat([header, audio])
 }
 
+async function prepareLocalSttUploadWav(audio: Buffer, mimeType: string): Promise<Buffer> {
+  try {
+    return prepareLocalSttWav(audio, mimeType)
+  } catch (error) {
+    const normalized = String(mimeType || '').split(';')[0].trim().toLowerCase()
+    const looksLikeMp3 = (audio.length >= 3 && audio.subarray(0, 3).toString('ascii') === 'ID3')
+      || (audio.length >= 2 && audio[0] === 0xff && (audio[1] & 0xe0) === 0xe0)
+    if (normalized !== 'audio/mpeg' && normalized !== 'audio/mp3' && !looksLikeMp3) throw error
+    const decoded = await transcodeToPcmS16le(audio, 'audio/mpeg', { sampleRate: LOCAL_STT_SAMPLE_RATE })
+    return prepareLocalSttWav(decoded.audio, decoded.mimeType)
+  }
+}
+
 export async function transcribeWithLocalStt(input: SttTranscribeInput): Promise<SttTranscribeResult> {
   if (!isLocalSttModelUsable()) throw new Error('Local STT model is not installed or failed validation')
   if (input.signal?.aborted) throw Object.assign(new Error('STT request aborted'), { name: 'AbortError' })
 
-  const audio = prepareLocalSttWav(input.audio, input.mimeType)
+  const audio = await prepareLocalSttUploadWav(input.audio, input.mimeType)
 
   const tempRoot = join(config.appHome, 'runtime', 'local-stt-audio')
   await mkdir(tempRoot, { recursive: true })

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -13,9 +13,16 @@ test('opens terminal websocket session and forwards user input', async ({ page }
 
   const terminalState = await page.waitForFunction(() => {
     const state = (window as any).__PW_TERMINAL_WS__
-    return state?.sockets?.length
+    const terminalSocket = state?.sockets?.find((socket: { url?: string | URL }) => {
+      try {
+        return new URL(String(socket.url || ''), window.location.href).pathname === '/api/hermes/terminal'
+      } catch {
+        return false
+      }
+    })
+    return terminalSocket
       ? {
-          url: state.latest.url,
+          url: terminalSocket.url,
           sent: state.sent,
         }
       : null

--- a/tests/server/app-relay-client.test.ts
+++ b/tests/server/app-relay-client.test.ts
@@ -181,7 +181,11 @@ describe('AppRelayClient', () => {
       payload: { session_id: 'session-1', input: 'hello' },
     }, runAck)
     expect(local.emit).toHaveBeenCalledWith('run', { session_id: 'session-1', input: 'hello' })
-    expect(runAck).toHaveBeenCalledWith(expect.objectContaining({ id: 'relay-chat-1', ok: true, event: 'run' }))
+    await vi.waitFor(() => expect(runAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'relay-chat-1',
+      ok: true,
+      event: 'run',
+    })))
 
     const insertAck = vi.fn()
     remote.__handlers.get('app.socket.event')({
@@ -193,11 +197,11 @@ describe('AppRelayClient', () => {
       session_id: 'session-1',
       queue_id: 'queue-1',
     })
-    expect(insertAck).toHaveBeenCalledWith(expect.objectContaining({
+    await vi.waitFor(() => expect(insertAck).toHaveBeenCalledWith(expect.objectContaining({
       id: 'relay-chat-1',
       ok: true,
       event: 'insert_queued_run',
-    }))
+    })))
 
     local.__onAny('message.delta', { session_id: 'session-1', delta: 'hi' })
     expect(remote.emit).toHaveBeenCalledWith('app.socket.event', {

--- a/tests/server/app-relay-server.test.ts
+++ b/tests/server/app-relay-server.test.ts
@@ -357,4 +357,60 @@ describe('LocalAppRelayServer', () => {
       payload: { session_id: 'session-1', delta: 'hi' },
     })
   })
+
+  it('bridges /group-chat with authenticated Socket.IO acknowledgements', async () => {
+    const namespace = createMockNamespace()
+    const io = { of: vi.fn(() => namespace) }
+    const { LocalAppRelayServer } = await import('../../packages/server/src/services/app-relay/server')
+    const server = new LocalAppRelayServer(io as any, {
+      machineId: 'hwui_local_machine_1234567890',
+      localBaseUrl: 'http://127.0.0.1:8748',
+    })
+    server.init()
+
+    const app = createMockAppSocket('app-group', {
+      role: 'app',
+      token: 'local-user-token',
+      machineId: 'hwui_local_machine_1234567890',
+    })
+    await connectApp(namespace, app)
+    const openAck = vi.fn()
+    app.__handlers.get('socket.open')({
+      id: 'group-1',
+      namespace: '/group-chat',
+      auth: { token: 'untrusted-token', authUserId: 7, name: 'app-user' },
+    }, openAck)
+
+    await vi.waitFor(() => expect(openAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'group-1',
+      ok: true,
+      namespace: '/group-chat',
+    })))
+    expect(clientSocketMocks.io).toHaveBeenCalledWith(
+      'http://127.0.0.1:8748/group-chat',
+      expect.objectContaining({
+        auth: { token: 'local-user-token', authUserId: 7, name: 'app-user' },
+      }),
+    )
+
+    const local = clientSocketMocks.sockets[0]
+    local.emit.mockImplementation((event: string, payload: unknown, ack?: (response: unknown) => void) => {
+      if (event === 'join') ack?.({ roomName: 'Relay room', messages: [] })
+    })
+    const eventAck = vi.fn()
+    app.__handlers.get('socket.event')({
+      id: 'group-1',
+      event: 'join',
+      payload: { roomId: 'room-1' },
+      ack: true,
+    }, eventAck)
+
+    await vi.waitFor(() => expect(eventAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'group-1',
+      ok: true,
+      namespace: '/group-chat',
+      event: 'join',
+      payload: { roomName: 'Relay room', messages: [] },
+    })))
+  })
 })


### PR DESCRIPTION
## What changed

- Allow the App Relay to bridge the `/group-chat` Socket.IO namespace in both the local Studio relay and the cloud-connected Studio relay client.
- Apply namespace-specific client event allowlists.
- Preserve Socket.IO acknowledgements for room joins, messages, approvals, and clarification replies.
- Advertise the group-chat socket capability and add relay coverage.
- Transcode MP3 uploads to PCM/WAV before local STT recognition when the native recorder sends MPEG audio.

## Why

The App could load group rooms over relayed HTTP, but realtime group chat remained unavailable because App Relay only accepted `/chat-run`. The App also records MP3 on native platforms while the local STT pipeline expects WAV/PCM. These changes provide a consistent group-chat relay and make native voice input compatible with local speech recognition.

## Impact

Hermes Studio App clients can connect to group chat through `/app-relay`, receive realtime and streaming events, and send acknowledged group-chat events without opening a separate direct socket. Native MP3 recordings can also be recognized by the local STT provider.

## Validation

- `npx vitest run tests/server/app-relay-server.test.ts`
- `npx vitest run tests/server/local-stt-model-manager.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- Hermes Studio App Android compilation
