### PR TITLE
feat(media): add MiniMax image-to-video generation

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9286,6 +9286,59 @@
         }
       }
     },
+    "/api/hermes/media/minimax-image-to-video": {
+      "post": {
+        "tags": [
+          "Media"
+        ],
+        "summary": "Create minimax-image-to-video",
+        "description": "POST /api/hermes/media/minimax-image-to-video",
+        "operationId": "miniMaxImageToVideo",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "model": {
+                    "type": "string"
+                  },
+                  "output_path": {
+                    "type": "string"
+                  },
+                  "prompt": {
+                    "type": "string"
+                  },
+                  "region": {
+                    "type": "string"
+                  },
+                  "timeout_ms": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/hermes/memory": {
       "get": {
         "tags": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9317,6 +9317,30 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "aigc_watermark": {
+                    "type": "boolean"
+                  },
+                  "callback_url": {
+                    "type": "string"
+                  },
+                  "duration": {
+                    "type": "number"
+                  },
+                  "fast_pretreatment": {
+                    "type": "boolean"
+                  },
+                  "image_base64": {
+                    "type": "string"
+                  },
+                  "image_path": {
+                    "type": "string"
+                  },
+                  "image_url": {
+                    "type": "string"
+                  },
+                  "mime_type": {
+                    "type": "string"
+                  },
                   "model": {
                     "type": "string"
                   },
@@ -9326,11 +9350,17 @@
                   "prompt": {
                     "type": "string"
                   },
+                  "prompt_optimizer": {
+                    "type": "boolean"
+                  },
                   "region": {
                     "type": "string"
                   },
-                  "timeout_ms": {
+                  "resolution": {
                     "type": "string"
+                  },
+                  "timeout_ms": {
+                    "type": "number"
                   }
                 }
               }

--- a/packages/server/src/controllers/hermes/media.ts
+++ b/packages/server/src/controllers/hermes/media.ts
@@ -4,11 +4,39 @@ import { dirname, extname, isAbsolute, join, resolve } from 'path'
 import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../../services/hermes/hermes-profile'
 import { config } from '../../config'
 import { readConfigYamlForProfile } from '../../services/config-helpers'
+import { resolveAuthorizedProviderRuntimeCredentials } from '../../services/hermes/authorized-provider-credentials'
 import { getCompatibleCustomProviders } from '../../services/hermes/custom-providers-compat'
 
 const XAI_VIDEO_GENERATIONS_URL = 'https://api.x.ai/v1/videos/generations'
 const XAI_VIDEO_STATUS_URL = 'https://api.x.ai/v1/videos'
 const XAI_VIDEO_MODEL = 'grok-imagine-video'
+const MINIMAX_VIDEO_DEFAULT_MODEL = 'MiniMax-H3'
+const MINIMAX_VIDEO_V2_RESOLUTION = '2K'
+const MINIMAX_VIDEO_V2_RATIOS = new Set(['adaptive', '21:9', '16:9', '4:3', '1:1', '3:4', '9:16'])
+const MINIMAX_VIDEO_REGIONS = {
+  global_en: {
+    v2: {
+      generateUrl: 'https://api.minimax.io/v2/video_generation',
+      queryUrl: 'https://api.minimax.io/v2/query/video_generation',
+    },
+    v1: {
+      generateUrl: 'https://api.minimax.io/v1/video_generation',
+      queryUrl: 'https://api.minimax.io/v1/query/video_generation',
+      downloadUrl: 'https://api.minimax.io/v1/files/retrieve',
+    },
+  },
+  cn_zh: {
+    v2: {
+      generateUrl: 'https://api.minimaxi.com/v2/video_generation',
+      queryUrl: 'https://api.minimaxi.com/v2/query/video_generation',
+    },
+    v1: {
+      generateUrl: 'https://api.minimaxi.com/v1/video_generation',
+      queryUrl: 'https://api.minimaxi.com/v1/query/video_generation',
+      downloadUrl: 'https://api.minimaxi.com/v1/files/retrieve',
+    },
+  },
+} as const
 const APIKEY_IMAGE_PROVIDER = 'fun-codex'
 const APIKEY_IMAGE_MODEL = 'gpt-image-2'
 const APIKEY_IMAGE_TO_IMAGE_MODEL = 'gpt-5.4-mini'
@@ -129,6 +157,26 @@ function resolveXaiToken(profile: string): { token: string; source: string } | n
   }
 
   return null
+}
+
+async function resolveMiniMaxToken(profile: string, model: string): Promise<{ token: string; source: string; region?: 'global_en' | 'cn_zh' } | null> {
+  const envToken = String(process.env.MINIMAX_API_KEY || '').trim()
+  if (envToken) return { token: envToken, source: 'MINIMAX_API_KEY' }
+
+  try {
+    const credentials = await resolveAuthorizedProviderRuntimeCredentials({
+      profile,
+      provider: 'minimax-oauth',
+      model,
+    })
+    return {
+      token: credentials.apiKey,
+      source: credentials.source || 'minimax-oauth',
+      region: credentials.baseUrl?.includes('api.minimaxi.com') ? 'cn_zh' : 'global_en',
+    }
+  } catch {
+    return null
+  }
 }
 
 function mimeFromPath(path: string): string | null {
@@ -549,6 +597,214 @@ async function downloadVideo(url: string, outputPath: string): Promise<void> {
   const buffer = Buffer.from(arrayBuffer)
   mkdirSync(dirname(outputPath), { recursive: true })
   writeFileSync(outputPath, buffer)
+}
+
+async function requestMiniMaxJson(url: string, token: string, init: RequestInit = {}): Promise<any> {
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+      ...(init.headers || {}),
+    },
+  })
+  const text = await res.text()
+  let data: any = null
+  try { data = text ? JSON.parse(text) : null } catch {}
+  const baseCode = data?.base_resp?.status_code
+  if (!res.ok || (Number.isFinite(baseCode) && Number(baseCode) !== 0)) {
+    const detail = data?.base_resp?.status_msg || data?.error?.message || data?.error || text || res.statusText
+    const err: any = new Error(`MiniMax request failed: ${res.status} ${detail}`)
+    err.status = 502
+    throw err
+  }
+  return data
+}
+
+function miniMaxVideoUrls(region: string) {
+  return region === 'cn_zh'
+    ? MINIMAX_VIDEO_REGIONS.cn_zh
+    : MINIMAX_VIDEO_REGIONS.global_en
+}
+
+function normalizeMiniMaxV2Duration(value: unknown): number {
+  const duration = value === undefined || value === null || value === '' ? 5 : Number(value)
+  if (!Number.isInteger(duration) || duration < 4 || duration > 15) {
+    const err: any = new Error('duration must be an integer from 4 to 15 for MiniMax-H3')
+    err.status = 400
+    throw err
+  }
+  return duration
+}
+
+function miniMaxV2ImageRequest(body: any, prompt: string, image: string, region: string): Record<string, unknown> {
+  if (!prompt) {
+    const err: any = new Error('prompt is required for MiniMax-H3')
+    err.status = 400
+    throw err
+  }
+  if (prompt.length > 7000) {
+    const err: any = new Error('prompt must be 7000 characters or fewer for MiniMax-H3')
+    err.status = 400
+    throw err
+  }
+
+  const resolution = typeof body.resolution === 'string' && body.resolution.trim()
+    ? body.resolution.trim()
+    : MINIMAX_VIDEO_V2_RESOLUTION
+  if (resolution !== MINIMAX_VIDEO_V2_RESOLUTION) {
+    const err: any = new Error('resolution must be 2K for MiniMax-H3')
+    err.status = 400
+    throw err
+  }
+
+  const ratio = typeof body.ratio === 'string' && body.ratio.trim() ? body.ratio.trim() : 'adaptive'
+  if (!MINIMAX_VIDEO_V2_RATIOS.has(ratio)) {
+    const err: any = new Error('ratio must be adaptive, 21:9, 16:9, 4:3, 1:1, 3:4, or 9:16 for MiniMax-H3')
+    err.status = 400
+    throw err
+  }
+
+  const requestBody: Record<string, unknown> = {
+    model: MINIMAX_VIDEO_DEFAULT_MODEL,
+    content: [
+      { type: 'text', text: prompt },
+      { type: 'image_url', image_url: { url: image }, role: 'first_frame' },
+    ],
+    resolution,
+    duration: normalizeMiniMaxV2Duration(body.duration),
+    ratio,
+  }
+  if (typeof body.callback_url === 'string' && body.callback_url.trim()) {
+    requestBody.callback_url = body.callback_url.trim()
+  }
+  if (region === 'cn_zh' && typeof body.aigc_watermark === 'boolean') {
+    requestBody.aigc_watermark = body.aigc_watermark
+  }
+  return requestBody
+}
+
+function miniMaxV1ImageRequest(body: any, prompt: string, image: string, model: string): Record<string, unknown> {
+  const requestBody: Record<string, unknown> = { model, first_frame_image: image }
+  if (prompt) requestBody.prompt = prompt
+  for (const field of ['prompt_optimizer', 'fast_pretreatment', 'resolution', 'callback_url'] as const) {
+    const value = body[field]
+    if (value !== undefined && value !== null && value !== '') requestBody[field] = value
+  }
+  if (body.duration !== undefined && body.duration !== null && body.duration !== '') {
+    const duration = Number(body.duration)
+    if (!Number.isInteger(duration) || duration <= 0) {
+      const err: any = new Error('duration must be a positive integer')
+      err.status = 400
+      throw err
+    }
+    requestBody.duration = duration
+  }
+  return requestBody
+}
+
+export async function miniMaxImageToVideo(ctx: Context) {
+  let profile: string
+  try {
+    profile = resolveMediaProfile(ctx)
+  } catch (err: any) {
+    ctx.status = err.status || 400
+    ctx.body = { error: err.message || String(err), code: err.code || 'invalid_profile' }
+    return
+  }
+
+  const body = ctx.request.body as any
+  const model = typeof body.model === 'string' && body.model.trim() ? body.model.trim() : MINIMAX_VIDEO_DEFAULT_MODEL
+  const tokenInfo = await resolveMiniMaxToken(profile, model)
+  if (!tokenInfo) {
+    ctx.status = 401
+    ctx.body = {
+      error: `Missing MiniMax token for profile "${profile}". Set MINIMAX_API_KEY or complete MiniMax OAuth login first.`,
+      code: 'missing_minimax_token',
+    }
+    return
+  }
+
+  try {
+    const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
+    const image = normalizeImageInput(body)
+    const region = String(body.region || tokenInfo.region || 'global_en').trim() === 'cn_zh' ? 'cn_zh' : 'global_en'
+    const urls = miniMaxVideoUrls(region)
+    const rawTimeoutMs = Number(body.timeout_ms || DEFAULT_TIMEOUT_MS)
+    const timeoutMs = Number.isFinite(rawTimeoutMs)
+      ? Math.max(10000, Math.min(rawTimeoutMs, 30 * 60 * 1000))
+      : DEFAULT_TIMEOUT_MS
+    const requestedOutputPath = typeof body.output_path === 'string' ? body.output_path.trim() : ''
+    const useV2 = model === MINIMAX_VIDEO_DEFAULT_MODEL
+    const requestBody = useV2
+      ? miniMaxV2ImageRequest(body, prompt, image, region)
+      : miniMaxV1ImageRequest(body, prompt, image, model)
+
+    const started = await requestMiniMaxJson(useV2 ? urls.v2.generateUrl : urls.v1.generateUrl, tokenInfo.token, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(requestBody),
+    })
+    const taskId = String(started?.task_id || '').trim()
+    if (!taskId) throw new Error('MiniMax response missing task_id')
+
+    const deadline = Date.now() + timeoutMs
+    let latest: any = null
+    while (Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, DEFAULT_POLL_INTERVAL_MS))
+      latest = await requestMiniMaxJson(
+        useV2
+          ? `${urls.v2.queryUrl}/${encodeURIComponent(taskId)}`
+          : `${urls.v1.queryUrl}?task_id=${encodeURIComponent(taskId)}`,
+        tokenInfo.token,
+      )
+      const task = useV2 ? latest?.task : latest
+      const status = String(task?.status || '').toLowerCase()
+      if (status === 'succeeded' || status === 'succeed' || status === 'success' || status === 'done') {
+        const fileId = useV2 ? '' : String(task?.file_id || '').trim()
+        let videoUrl = useV2 ? String(task?.content?.url || '').trim() : ''
+        if (!useV2 && fileId) {
+          const fileData = await requestMiniMaxJson(`${urls.v1.downloadUrl}?file_id=${encodeURIComponent(fileId)}`, tokenInfo.token)
+          videoUrl = String(fileData?.file?.download_url || fileData?.download_url || '').trim()
+        }
+        if (!videoUrl) throw new Error('MiniMax response missing generated video URL')
+        const outputPath = requestedOutputPath || defaultMediaOutputPath(taskId)
+        await downloadVideo(videoUrl, outputPath)
+        ctx.body = {
+          task_id: taskId,
+          status: task?.status,
+          ...(fileId ? { file_id: fileId } : {}),
+          video_url: videoUrl,
+          output_path: outputPath,
+          model,
+          api_version: useV2 ? 'v2' : 'v1',
+          region,
+          token_source: tokenInfo.source,
+          profile,
+        }
+        return
+      }
+      if (status === 'fail' || status === 'failed' || status === 'error' || status === 'cancelled') {
+        ctx.status = 502
+        ctx.body = {
+          task_id: taskId,
+          status: task?.status,
+          error: task?.error?.message || task?.error || latest?.base_resp?.status_msg || 'MiniMax video generation failed',
+        }
+        return
+      }
+    }
+
+    ctx.status = 504
+    ctx.body = {
+      task_id: taskId,
+      status: (useV2 ? latest?.task?.status : latest?.status) || 'pending',
+      error: 'Timed out waiting for MiniMax video generation',
+    }
+  } catch (err: any) {
+    ctx.status = err.status || 500
+    ctx.body = { error: err.message || String(err) }
+  }
 }
 
 export async function grokImageToVideo(ctx: Context) {

--- a/packages/server/src/controllers/hermes/media.ts
+++ b/packages/server/src/controllers/hermes/media.ts
@@ -4,43 +4,43 @@ import { dirname, extname, isAbsolute, join, resolve } from 'path'
 import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../../services/hermes/hermes-profile'
 import { config } from '../../config'
 import { readConfigYamlForProfile } from '../../services/config-helpers'
-import { resolveAuthorizedProviderRuntimeCredentials } from '../../services/hermes/authorized-provider-credentials'
 import { getCompatibleCustomProviders } from '../../services/hermes/custom-providers-compat'
 
 const XAI_VIDEO_GENERATIONS_URL = 'https://api.x.ai/v1/videos/generations'
 const XAI_VIDEO_STATUS_URL = 'https://api.x.ai/v1/videos'
 const XAI_VIDEO_MODEL = 'grok-imagine-video'
-const MINIMAX_VIDEO_DEFAULT_MODEL = 'MiniMax-H3'
-const MINIMAX_VIDEO_V2_RESOLUTION = '2K'
-const MINIMAX_VIDEO_V2_RATIOS = new Set(['adaptive', '21:9', '16:9', '4:3', '1:1', '3:4', '9:16'])
+const MINIMAX_VIDEO_DEFAULT_MODEL = 'MiniMax-Hailuo-2.3'
+const MINIMAX_VIDEO_MODELS = new Set([
+  'MiniMax-Hailuo-2.3',
+  'MiniMax-Hailuo-2.3-Fast',
+  'MiniMax-Hailuo-02',
+  'I2V-01-Director',
+  'I2V-01-live',
+  'I2V-01',
+])
+const MINIMAX_HAILUO_VIDEO_MODELS = new Set([
+  'MiniMax-Hailuo-2.3',
+  'MiniMax-Hailuo-2.3-Fast',
+  'MiniMax-Hailuo-02',
+])
 const MINIMAX_VIDEO_REGIONS = {
   global_en: {
-    v2: {
-      generateUrl: 'https://api.minimax.io/v2/video_generation',
-      queryUrl: 'https://api.minimax.io/v2/query/video_generation',
-    },
-    v1: {
-      generateUrl: 'https://api.minimax.io/v1/video_generation',
-      queryUrl: 'https://api.minimax.io/v1/query/video_generation',
-      downloadUrl: 'https://api.minimax.io/v1/files/retrieve',
-    },
+    generateUrl: 'https://api.minimax.io/v1/video_generation',
+    queryUrl: 'https://api.minimax.io/v1/query/video_generation',
+    downloadUrl: 'https://api.minimax.io/v1/files/retrieve',
   },
   cn_zh: {
-    v2: {
-      generateUrl: 'https://api.minimaxi.com/v2/video_generation',
-      queryUrl: 'https://api.minimaxi.com/v2/query/video_generation',
-    },
-    v1: {
-      generateUrl: 'https://api.minimaxi.com/v1/video_generation',
-      queryUrl: 'https://api.minimaxi.com/v1/query/video_generation',
-      downloadUrl: 'https://api.minimaxi.com/v1/files/retrieve',
-    },
+    generateUrl: 'https://api.minimaxi.com/v1/video_generation',
+    queryUrl: 'https://api.minimaxi.com/v1/query/video_generation',
+    downloadUrl: 'https://api.minimaxi.com/v1/files/retrieve',
   },
 } as const
+type MiniMaxVideoRegion = keyof typeof MINIMAX_VIDEO_REGIONS
 const APIKEY_IMAGE_PROVIDER = 'fun-codex'
 const APIKEY_IMAGE_MODEL = 'gpt-image-2'
 const APIKEY_IMAGE_TO_IMAGE_MODEL = 'gpt-5.4-mini'
 const MAX_IMAGE_BYTES = 25 * 1024 * 1024
+const MINIMAX_MAX_IMAGE_BYTES = 20 * 1024 * 1024
 const DEFAULT_POLL_INTERVAL_MS = 5000
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000
 
@@ -159,23 +159,62 @@ function resolveXaiToken(profile: string): { token: string; source: string } | n
   return null
 }
 
-async function resolveMiniMaxToken(profile: string, model: string): Promise<{ token: string; source: string; region?: 'global_en' | 'cn_zh' } | null> {
-  const envToken = String(process.env.MINIMAX_API_KEY || '').trim()
-  if (envToken) return { token: envToken, source: 'MINIMAX_API_KEY' }
-
-  try {
-    const credentials = await resolveAuthorizedProviderRuntimeCredentials({
-      profile,
-      provider: 'minimax-oauth',
-      model,
-    })
-    return {
-      token: credentials.apiKey,
-      source: credentials.source || 'minimax-oauth',
-      region: credentials.baseUrl?.includes('api.minimaxi.com') ? 'cn_zh' : 'global_en',
+function parseEnvValue(envContent: string, key: string): string {
+  for (const line of envContent.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const separator = trimmed.indexOf('=')
+    if (separator < 0 || trimmed.slice(0, separator).trim() !== key) continue
+    const raw = trimmed.slice(separator + 1).trim()
+    if (
+      (raw.startsWith('"') && raw.endsWith('"')) ||
+      (raw.startsWith("'") && raw.endsWith("'"))
+    ) {
+      return raw.slice(1, -1)
     }
+    return raw
+  }
+  return ''
+}
+
+function profileEnvValue(profile: string, key: string): string {
+  try {
+    return parseEnvValue(readFileSync(join(getProfileDir(profile), '.env'), 'utf8'), key)
   } catch {
-    return null
+    return ''
+  }
+}
+
+function normalizeMiniMaxRegion(value: unknown): MiniMaxVideoRegion | undefined {
+  const requested = typeof value === 'string' ? value.trim() : ''
+  if (!requested) return undefined
+  if (requested === 'global_en' || requested === 'cn_zh') return requested
+  const err: any = new Error('region must be global_en or cn_zh')
+  err.status = 400
+  throw err
+}
+
+async function resolveMiniMaxToken(
+  profile: string,
+  requestedRegion: unknown,
+): Promise<{ token: string; source: string; region: MiniMaxVideoRegion; envName: string }> {
+  let configuredProvider = ''
+  try {
+    const profileConfig = await readConfigYamlForProfile(profile)
+    configuredProvider = String(profileConfig?.model?.provider || '').trim().toLowerCase()
+  } catch {}
+
+  const region = normalizeMiniMaxRegion(requestedRegion) || (configuredProvider === 'minimax-cn' ? 'cn_zh' : 'global_en')
+  const envName = region === 'cn_zh' ? 'MINIMAX_CN_API_KEY' : 'MINIMAX_API_KEY'
+  const profileToken = profileEnvValue(profile, envName)
+  if (profileToken) return { token: profileToken, source: `profile:${envName}`, region, envName }
+
+  const processToken = String(process.env[envName] || '').trim()
+  return {
+    token: processToken,
+    source: processToken ? envName : '',
+    region,
+    envName,
   }
 }
 
@@ -194,11 +233,18 @@ function mimeFromMagic(buffer: Buffer): string | null {
   return null
 }
 
-function imagePathToDataUri(imagePath: string): string {
+function assertImageSize(encodedImage: string, maxBytes: number): void {
+  if (Buffer.from(encodedImage, 'base64').length <= maxBytes) return
+  const err: any = new Error(`image is too large (max ${maxBytes} bytes)`)
+  err.status = 413
+  throw err
+}
+
+function imagePathToDataUri(imagePath: string, maxBytes = MAX_IMAGE_BYTES): string {
   const resolvedPath = isAbsolute(imagePath) ? imagePath : resolve(process.cwd(), imagePath)
   const image = readFileSync(resolvedPath)
-  if (image.length > MAX_IMAGE_BYTES) {
-    const err: any = new Error(`image is too large (max ${MAX_IMAGE_BYTES} bytes)`)
+  if (image.length > maxBytes) {
+    const err: any = new Error(`image is too large (max ${maxBytes} bytes)`)
     err.status = 413
     throw err
   }
@@ -211,19 +257,29 @@ function imagePathToDataUri(imagePath: string): string {
   return `data:${mime};base64,${image.toString('base64')}`
 }
 
-function normalizeImageInput(body: any): string {
+function normalizeImageInput(body: any, maxBytes = MAX_IMAGE_BYTES): string {
   const imageUrl = typeof body.image_url === 'string' ? body.image_url.trim() : ''
-  if (imageUrl) return imageUrl
+  if (imageUrl) {
+    if (imageUrl.startsWith('data:image/')) {
+      assertImageSize(imageUrl.slice(imageUrl.indexOf(',') + 1), maxBytes)
+    }
+    return imageUrl
+  }
 
   const imageBase64 = typeof body.image_base64 === 'string' ? body.image_base64.trim() : ''
   if (imageBase64) {
-    if (imageBase64.startsWith('data:image/')) return imageBase64
+    if (imageBase64.startsWith('data:image/')) {
+      const encodedImage = imageBase64.slice(imageBase64.indexOf(',') + 1)
+      assertImageSize(encodedImage, maxBytes)
+      return imageBase64
+    }
     const mime = typeof body.mime_type === 'string' ? body.mime_type.trim() : ''
     if (!mime.startsWith('image/')) {
       const err: any = new Error('mime_type is required when image_base64 is not a data URI')
       err.status = 400
       throw err
     }
+    assertImageSize(imageBase64, maxBytes)
     return `data:${mime};base64,${imageBase64}`
   }
 
@@ -238,7 +294,7 @@ function normalizeImageInput(body: any): string {
     err.status = 404
     throw err
   }
-  return imagePathToDataUri(imagePath)
+  return imagePathToDataUri(imagePath, maxBytes)
 }
 
 function imageDataUriToBytes(dataUri: string): { buffer: Buffer; mime: string; name: string } {
@@ -612,7 +668,7 @@ async function requestMiniMaxJson(url: string, token: string, init: RequestInit 
   let data: any = null
   try { data = text ? JSON.parse(text) : null } catch {}
   const baseCode = data?.base_resp?.status_code
-  if (!res.ok || (Number.isFinite(baseCode) && Number(baseCode) !== 0)) {
+  if (!res.ok || (baseCode !== undefined && baseCode !== null && String(baseCode) !== '0')) {
     const detail = data?.base_resp?.status_msg || data?.error?.message || data?.error || text || res.statusText
     const err: any = new Error(`MiniMax request failed: ${res.status} ${detail}`)
     err.status = 502
@@ -621,84 +677,83 @@ async function requestMiniMaxJson(url: string, token: string, init: RequestInit 
   return data
 }
 
-function miniMaxVideoUrls(region: string) {
-  return region === 'cn_zh'
-    ? MINIMAX_VIDEO_REGIONS.cn_zh
-    : MINIMAX_VIDEO_REGIONS.global_en
+function miniMaxVideoUrls(region: MiniMaxVideoRegion) {
+  return MINIMAX_VIDEO_REGIONS[region]
 }
 
-function normalizeMiniMaxV2Duration(value: unknown): number {
-  const duration = value === undefined || value === null || value === '' ? 5 : Number(value)
-  if (!Number.isInteger(duration) || duration < 4 || duration > 15) {
-    const err: any = new Error('duration must be an integer from 4 to 15 for MiniMax-H3')
+function miniMaxV1ImageRequest(
+  body: any,
+  prompt: string,
+  image: string,
+  model: string,
+  region: MiniMaxVideoRegion,
+): Record<string, unknown> {
+  if (!MINIMAX_VIDEO_MODELS.has(model)) {
+    const err: any = new Error(`unsupported MiniMax image-to-video model: ${model}`)
     err.status = 400
     throw err
   }
-  return duration
-}
-
-function miniMaxV2ImageRequest(body: any, prompt: string, image: string, region: string): Record<string, unknown> {
-  if (!prompt) {
-    const err: any = new Error('prompt is required for MiniMax-H3')
-    err.status = 400
-    throw err
-  }
-  if (prompt.length > 7000) {
-    const err: any = new Error('prompt must be 7000 characters or fewer for MiniMax-H3')
+  if (prompt.length > 2000) {
+    const err: any = new Error('prompt must be 2000 characters or fewer')
     err.status = 400
     throw err
   }
 
+  const isHailuoModel = MINIMAX_HAILUO_VIDEO_MODELS.has(model)
+  const duration = body.duration === undefined || body.duration === null || body.duration === ''
+    ? 6
+    : Number(body.duration)
   const resolution = typeof body.resolution === 'string' && body.resolution.trim()
     ? body.resolution.trim()
-    : MINIMAX_VIDEO_V2_RESOLUTION
-  if (resolution !== MINIMAX_VIDEO_V2_RESOLUTION) {
-    const err: any = new Error('resolution must be 2K for MiniMax-H3')
+    : isHailuoModel ? '768P' : '720P'
+
+  if (!Number.isInteger(duration) || (duration !== 6 && duration !== 10)) {
+    const err: any = new Error('duration must be 6 or 10 seconds')
     err.status = 400
     throw err
   }
-
-  const ratio = typeof body.ratio === 'string' && body.ratio.trim() ? body.ratio.trim() : 'adaptive'
-  if (!MINIMAX_VIDEO_V2_RATIOS.has(ratio)) {
-    const err: any = new Error('ratio must be adaptive, 21:9, 16:9, 4:3, 1:1, 3:4, or 9:16 for MiniMax-H3')
+  if (isHailuoModel) {
+    const supportedResolutions = model === 'MiniMax-Hailuo-02'
+      ? new Set(['512P', '768P', '1080P'])
+      : new Set(['768P', '1080P'])
+    if (!supportedResolutions.has(resolution) || (duration === 10 && resolution === '1080P')) {
+      const err: any = new Error(`${model} does not support ${resolution} at ${duration} seconds`)
+      err.status = 400
+      throw err
+    }
+  } else if (duration !== 6 || (resolution !== '720P' && resolution !== '1080P')) {
+    const err: any = new Error(`${model} supports 6-second video at 720P or 1080P`)
     err.status = 400
     throw err
   }
 
   const requestBody: Record<string, unknown> = {
-    model: MINIMAX_VIDEO_DEFAULT_MODEL,
-    content: [
-      { type: 'text', text: prompt },
-      { type: 'image_url', image_url: { url: image }, role: 'first_frame' },
-    ],
+    model,
+    first_frame_image: image,
+    duration,
     resolution,
-    duration: normalizeMiniMaxV2Duration(body.duration),
-    ratio,
+  }
+  if (prompt) requestBody.prompt = prompt
+  for (const field of ['prompt_optimizer', 'fast_pretreatment'] as const) {
+    const value = body[field]
+    if (value === undefined || value === null || value === '') continue
+    if (typeof value !== 'boolean') {
+      const err: any = new Error(`${field} must be a boolean`)
+      err.status = 400
+      throw err
+    }
+    requestBody[field] = value
   }
   if (typeof body.callback_url === 'string' && body.callback_url.trim()) {
     requestBody.callback_url = body.callback_url.trim()
   }
-  if (region === 'cn_zh' && typeof body.aigc_watermark === 'boolean') {
-    requestBody.aigc_watermark = body.aigc_watermark
-  }
-  return requestBody
-}
-
-function miniMaxV1ImageRequest(body: any, prompt: string, image: string, model: string): Record<string, unknown> {
-  const requestBody: Record<string, unknown> = { model, first_frame_image: image }
-  if (prompt) requestBody.prompt = prompt
-  for (const field of ['prompt_optimizer', 'fast_pretreatment', 'resolution', 'callback_url'] as const) {
-    const value = body[field]
-    if (value !== undefined && value !== null && value !== '') requestBody[field] = value
-  }
-  if (body.duration !== undefined && body.duration !== null && body.duration !== '') {
-    const duration = Number(body.duration)
-    if (!Number.isInteger(duration) || duration <= 0) {
-      const err: any = new Error('duration must be a positive integer')
+  if (region === 'cn_zh' && body.aigc_watermark !== undefined && body.aigc_watermark !== null) {
+    if (typeof body.aigc_watermark !== 'boolean') {
+      const err: any = new Error('aigc_watermark must be a boolean')
       err.status = 400
       throw err
     }
-    requestBody.duration = duration
+    requestBody.aigc_watermark = body.aigc_watermark
   }
   return requestBody
 }
@@ -713,34 +768,53 @@ export async function miniMaxImageToVideo(ctx: Context) {
     return
   }
 
-  const body = ctx.request.body as any
-  const model = typeof body.model === 'string' && body.model.trim() ? body.model.trim() : MINIMAX_VIDEO_DEFAULT_MODEL
-  const tokenInfo = await resolveMiniMaxToken(profile, model)
-  if (!tokenInfo) {
-    ctx.status = 401
-    ctx.body = {
-      error: `Missing MiniMax token for profile "${profile}". Set MINIMAX_API_KEY or complete MiniMax OAuth login first.`,
-      code: 'missing_minimax_token',
-    }
-    return
-  }
-
   try {
+    const input = ctx.request.body as {
+      model?: string
+      prompt?: string
+      image_url?: string
+      image_base64?: string
+      mime_type?: string
+      image_path?: string
+      duration?: number
+      resolution?: string
+      prompt_optimizer?: boolean
+      fast_pretreatment?: boolean
+      callback_url?: string
+      aigc_watermark?: boolean
+      region?: string
+      output_path?: string
+      timeout_ms?: number
+    } | undefined
+    const body = input || {}
+    const model = typeof body.model === 'string' && body.model.trim() ? body.model.trim() : MINIMAX_VIDEO_DEFAULT_MODEL
+    const tokenInfo = await resolveMiniMaxToken(profile, body.region)
+    if (!tokenInfo.token) {
+      ctx.status = 401
+      ctx.body = {
+        error: `Missing MiniMax API key for profile "${profile}". Configure ${tokenInfo.envName} for that profile or server process.`,
+        code: 'missing_minimax_token',
+      }
+      return
+    }
+
     const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
-    const image = normalizeImageInput(body)
-    const region = String(body.region || tokenInfo.region || 'global_en').trim() === 'cn_zh' ? 'cn_zh' : 'global_en'
+    const image = normalizeImageInput(body, MINIMAX_MAX_IMAGE_BYTES)
+    if (image.startsWith('data:') && !/^data:image\/(?:png|jpe?g|webp);base64,/i.test(image)) {
+      const err: any = new Error('MiniMax image must be png, jpeg, or webp')
+      err.status = 400
+      throw err
+    }
+    const region = tokenInfo.region
     const urls = miniMaxVideoUrls(region)
     const rawTimeoutMs = Number(body.timeout_ms || DEFAULT_TIMEOUT_MS)
     const timeoutMs = Number.isFinite(rawTimeoutMs)
       ? Math.max(10000, Math.min(rawTimeoutMs, 30 * 60 * 1000))
       : DEFAULT_TIMEOUT_MS
     const requestedOutputPath = typeof body.output_path === 'string' ? body.output_path.trim() : ''
-    const useV2 = model === MINIMAX_VIDEO_DEFAULT_MODEL
-    const requestBody = useV2
-      ? miniMaxV2ImageRequest(body, prompt, image, region)
-      : miniMaxV1ImageRequest(body, prompt, image, model)
+    const requestBody = miniMaxV1ImageRequest(body, prompt, image, model, region)
 
-    const started = await requestMiniMaxJson(useV2 ? urls.v2.generateUrl : urls.v1.generateUrl, tokenInfo.token, {
+    const started = await requestMiniMaxJson(urls.generateUrl, tokenInfo.token, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(requestBody),
@@ -753,31 +827,27 @@ export async function miniMaxImageToVideo(ctx: Context) {
     while (Date.now() < deadline) {
       await new Promise(resolve => setTimeout(resolve, DEFAULT_POLL_INTERVAL_MS))
       latest = await requestMiniMaxJson(
-        useV2
-          ? `${urls.v2.queryUrl}/${encodeURIComponent(taskId)}`
-          : `${urls.v1.queryUrl}?task_id=${encodeURIComponent(taskId)}`,
+        `${urls.queryUrl}?task_id=${encodeURIComponent(taskId)}`,
         tokenInfo.token,
       )
-      const task = useV2 ? latest?.task : latest
+      const task = latest
       const status = String(task?.status || '').toLowerCase()
       if (status === 'succeeded' || status === 'succeed' || status === 'success' || status === 'done') {
-        const fileId = useV2 ? '' : String(task?.file_id || '').trim()
-        let videoUrl = useV2 ? String(task?.content?.url || '').trim() : ''
-        if (!useV2 && fileId) {
-          const fileData = await requestMiniMaxJson(`${urls.v1.downloadUrl}?file_id=${encodeURIComponent(fileId)}`, tokenInfo.token)
-          videoUrl = String(fileData?.file?.download_url || fileData?.download_url || '').trim()
-        }
+        const fileId = String(task?.file_id || '').trim()
+        if (!fileId) throw new Error('MiniMax response missing generated file_id')
+        const fileData = await requestMiniMaxJson(`${urls.downloadUrl}?file_id=${encodeURIComponent(fileId)}`, tokenInfo.token)
+        const videoUrl = String(fileData?.file?.download_url || fileData?.download_url || '').trim()
         if (!videoUrl) throw new Error('MiniMax response missing generated video URL')
         const outputPath = requestedOutputPath || defaultMediaOutputPath(taskId)
         await downloadVideo(videoUrl, outputPath)
         ctx.body = {
           task_id: taskId,
           status: task?.status,
-          ...(fileId ? { file_id: fileId } : {}),
+          file_id: fileId,
           video_url: videoUrl,
           output_path: outputPath,
           model,
-          api_version: useV2 ? 'v2' : 'v1',
+          api_version: 'v1',
           region,
           token_source: tokenInfo.source,
           profile,
@@ -798,7 +868,7 @@ export async function miniMaxImageToVideo(ctx: Context) {
     ctx.status = 504
     ctx.body = {
       task_id: taskId,
-      status: (useV2 ? latest?.task?.status : latest?.status) || 'pending',
+      status: latest?.status || 'pending',
       error: 'Timed out waiting for MiniMax video generation',
     }
   } catch (err: any) {

--- a/packages/server/src/middleware/user-auth.ts
+++ b/packages/server/src/middleware/user-auth.ts
@@ -105,6 +105,7 @@ function requestToken(ctx: Context): string {
 const SERVER_TOKEN_EXACT_PATHS = new Set([
   '/api/hermes/media/apikey-image-generate',
   '/api/hermes/media/grok-image-to-video',
+  '/api/hermes/media/minimax-image-to-video',
 ])
 
 function allowsServerTokenPath(path: string): boolean {

--- a/packages/server/src/routes/hermes/media.ts
+++ b/packages/server/src/routes/hermes/media.ts
@@ -5,3 +5,4 @@ export const mediaRoutes = new Router()
 
 mediaRoutes.post('/api/hermes/media/grok-image-to-video', ctrl.grokImageToVideo)
 mediaRoutes.post('/api/hermes/media/apikey-image-generate', ctrl.apiKeyImageGenerate)
+mediaRoutes.post('/api/hermes/media/minimax-image-to-video', ctrl.miniMaxImageToVideo)

--- a/packages/skills/minimax-image-to-video/SKILL.md
+++ b/packages/skills/minimax-image-to-video/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: minimax-image-to-video
+description: "Animate an image through Hermes Web UI using the MiniMax image-to-video API."
+version: 1.0.0
+author: Ekko
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [MiniMax, image-to-video, video-generation, media]
+prerequisites:
+  commands: [curl]
+---
+
+# MiniMax Image To Video
+
+Use this skill when the user wants to animate an image with MiniMax.
+
+If the Hermes Web UI endpoint returns an authentication, connection, or generation error, stop and report that error to the user.
+
+## Workflow
+
+Call the local Hermes Web UI media endpoint. The server resolves MiniMax credentials, creates an image-to-video task, polls it, downloads the finished mp4, and optionally saves it to a requested path.
+
+Endpoint:
+
+```bash
+POST <Hermes Web UI base URL>/api/hermes/media/minimax-image-to-video
+```
+
+Resolve the Hermes Web UI base URL in this order:
+
+1. `HERMES_WEB_UI_URL`, if set.
+2. `http://127.0.0.1:${PORT}`, if `PORT` is set.
+3. `http://127.0.0.1:8648`.
+
+Use `http://127.0.0.1:8647` for the development API backend and `http://127.0.0.1:6060` for the default Docker Compose external URL.
+
+Always send the Hermes Web UI server bearer token. Resolve it in this order:
+
+1. `AUTH_TOKEN`, if set.
+2. `${HERMES_WEB_UI_HOME}/.token`, if `HERMES_WEB_UI_HOME` is set.
+3. `${HERMES_WEBUI_STATE_DIR}/.token`, if `HERMES_WEBUI_STATE_DIR` is set.
+4. `~/.hermes-web-ui/.token`.
+
+If the run instructions include `[Current Hermes profile: <name>]`, send the exact profile in `X-Hermes-Profile`. If no profile is provided, omit that header.
+
+Required JSON fields:
+
+- `prompt`: instructions for animating the image when using the default model.
+- One image input: `image_url`, `image_base64` with `mime_type`, or `image_path`.
+
+Optional JSON fields:
+
+- `model`: defaults to `MiniMax-H3`; supported v1 image-to-video models may be selected explicitly.
+- `duration`: `MiniMax-H3` accepts integer values from 4 through 15 and defaults to 5.
+- `resolution`: `MiniMax-H3` uses `2K`.
+- `ratio`: defaults to `adaptive`; supported values are `adaptive`, `21:9`, `16:9`, `4:3`, `1:1`, `3:4`, and `9:16`.
+- `prompt_optimizer`, `fast_pretreatment`, and `callback_url`: supported request options.
+- `aigc_watermark`: optional China-region watermark flag.
+- `region`: `global_en` or `cn_zh`.
+- `output_path`: local mp4 destination; the server media directory is used when omitted.
+- `timeout_ms`: maximum polling time; defaults to 600000.
+
+Example:
+
+```bash
+TOKEN="${AUTH_TOKEN:-}"
+if [ -z "$TOKEN" ] && [ -n "${HERMES_WEB_UI_HOME:-}" ] && [ -f "$HERMES_WEB_UI_HOME/.token" ]; then
+  TOKEN="$(cat "$HERMES_WEB_UI_HOME/.token")"
+fi
+if [ -z "$TOKEN" ] && [ -n "${HERMES_WEBUI_STATE_DIR:-}" ] && [ -f "$HERMES_WEBUI_STATE_DIR/.token" ]; then
+  TOKEN="$(cat "$HERMES_WEBUI_STATE_DIR/.token")"
+fi
+if [ -z "$TOKEN" ] && [ -f "$HOME/.hermes-web-ui/.token" ]; then
+  TOKEN="$(cat "$HOME/.hermes-web-ui/.token")"
+fi
+if [ -z "$TOKEN" ]; then
+  echo "Missing Hermes Web UI token." >&2
+  exit 1
+fi
+
+BASE_URL="${HERMES_WEB_UI_URL:-http://127.0.0.1:${PORT:-8648}}"
+BASE_URL="${BASE_URL%/}"
+
+curl -sS -X POST "$BASE_URL/api/hermes/media/minimax-image-to-video" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "prompt": "Add a gentle camera push while the clouds drift across the sky",
+    "image_url": "https://example.com/source.png",
+    "duration": 5,
+    "output_path": "/absolute/path/to/output.mp4"
+  }'
+```
+
+If the response has `code: "missing_minimax_token"`, tell the user to set `MINIMAX_API_KEY` or complete MiniMax authorization before retrying.
+
+Return the generated `output_path`.

--- a/packages/skills/minimax-image-to-video/SKILL.md
+++ b/packages/skills/minimax-image-to-video/SKILL.md
@@ -20,7 +20,7 @@ If the Hermes Web UI endpoint returns an authentication, connection, or generati
 
 ## Workflow
 
-Call the local Hermes Web UI media endpoint. The server resolves MiniMax credentials, creates an image-to-video task, polls it, downloads the finished mp4, and optionally saves it to a requested path.
+Call the local Hermes Web UI media endpoint. The server resolves the selected profile's MiniMax API key, creates an image-to-video task through the official v1 API, polls it, downloads the finished mp4, and optionally saves it to a requested path.
 
 Endpoint:
 
@@ -47,18 +47,17 @@ If the run instructions include `[Current Hermes profile: <name>]`, send the exa
 
 Required JSON fields:
 
-- `prompt`: instructions for animating the image when using the default model.
 - One image input: `image_url`, `image_base64` with `mime_type`, or `image_path`.
 
 Optional JSON fields:
 
-- `model`: defaults to `MiniMax-H3`; supported v1 image-to-video models may be selected explicitly.
-- `duration`: `MiniMax-H3` accepts integer values from 4 through 15 and defaults to 5.
-- `resolution`: `MiniMax-H3` uses `2K`.
-- `ratio`: defaults to `adaptive`; supported values are `adaptive`, `21:9`, `16:9`, `4:3`, `1:1`, `3:4`, and `9:16`.
+- `prompt`: motion and style instructions, up to 2000 characters.
+- `model`: defaults to `MiniMax-Hailuo-2.3`. Supported values are `MiniMax-Hailuo-2.3`, `MiniMax-Hailuo-2.3-Fast`, `MiniMax-Hailuo-02`, `I2V-01-Director`, `I2V-01-live`, and `I2V-01`.
+- `duration`: defaults to 6 seconds. Hailuo models also support 10 seconds at compatible resolutions.
+- `resolution`: defaults to `768P` for Hailuo models and `720P` for I2V models. `1080P` is limited to 6-second videos.
 - `prompt_optimizer`, `fast_pretreatment`, and `callback_url`: supported request options.
 - `aigc_watermark`: optional China-region watermark flag.
-- `region`: `global_en` or `cn_zh`.
+- `region`: `global_en` or `cn_zh`. When omitted, the server infers the region from the selected profile provider (`minimax` or `minimax-cn`).
 - `output_path`: local mp4 destination; the server media directory is used when omitted.
 - `timeout_ms`: maximum polling time; defaults to 600000.
 
@@ -89,11 +88,11 @@ curl -sS -X POST "$BASE_URL/api/hermes/media/minimax-image-to-video" \
   -d '{
     "prompt": "Add a gentle camera push while the clouds drift across the sky",
     "image_url": "https://example.com/source.png",
-    "duration": 5,
+    "duration": 6,
     "output_path": "/absolute/path/to/output.mp4"
   }'
 ```
 
-If the response has `code: "missing_minimax_token"`, tell the user to set `MINIMAX_API_KEY` or complete MiniMax authorization before retrying.
+If the response has `code: "missing_minimax_token"`, tell the user to configure the MiniMax API-key provider for the selected profile. International profiles use `MINIMAX_API_KEY`; China profiles use `MINIMAX_CN_API_KEY`. MiniMax Coding Plan OAuth credentials do not authorize video generation.
 
 Return the generated `output_path`.

--- a/tests/server/media-controller.test.ts
+++ b/tests/server/media-controller.test.ts
@@ -7,6 +7,7 @@ const originalWebuiStateDir = process.env.HERMES_WEBUI_STATE_DIR
 afterEach(() => {
   vi.doUnmock('../../packages/server/src/services/hermes/hermes-profile')
   vi.doUnmock('../../packages/server/src/services/config-helpers')
+  vi.doUnmock('../../packages/server/src/services/hermes/authorized-provider-credentials')
   vi.clearAllMocks()
   vi.unstubAllEnvs()
   vi.resetModules()
@@ -161,6 +162,287 @@ describe('media controller', () => {
       })
     } finally {
       globalThis.fetch = originalFetch
+    }
+  })
+
+  it('rejects MiniMax image-to-video without credentials', async () => {
+    vi.stubEnv('MINIMAX_API_KEY', '')
+    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+      getActiveProfileName: () => 'default',
+      getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
+      listProfileNamesFromDisk: () => ['default'],
+    }))
+    vi.doMock('../../packages/server/src/services/config-helpers', () => ({
+      readConfigYamlForProfile: vi.fn(async () => ({})),
+    }))
+    vi.doMock('../../packages/server/src/services/hermes/authorized-provider-credentials', () => ({
+      resolveAuthorizedProviderRuntimeCredentials: vi.fn(async () => {
+        throw new Error('MiniMax authorization is unavailable')
+      }),
+    }))
+    const { miniMaxImageToVideo } = await import('../../packages/server/src/controllers/hermes/media')
+    const ctx: any = {
+      state: { serverTokenAuth: true },
+      query: {},
+      request: { body: { prompt: 'animate the scene', image_url: 'https://cdn.example.com/source.png' } },
+      get: vi.fn(() => ''),
+      status: 200,
+      body: undefined,
+    }
+
+    await miniMaxImageToVideo(ctx)
+
+    expect(ctx.status).toBe(401)
+    expect(ctx.body).toMatchObject({ code: 'missing_minimax_token' })
+  })
+
+  it('generates MiniMax-H3 image-to-video through the global v2 endpoint', async () => {
+    vi.stubEnv('MINIMAX_API_KEY', 'minimax-test-key')
+    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+      getActiveProfileName: () => 'default',
+      getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
+      listProfileNamesFromDisk: () => ['default'],
+    }))
+    vi.doMock('../../packages/server/src/services/config-helpers', () => ({
+      readConfigYamlForProfile: vi.fn(async () => ({})),
+    }))
+    const fetchMock = vi.fn(async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlString = String(url)
+      if (urlString.includes('/v2/query/video_generation/task_h3')) {
+        return new Response(JSON.stringify({
+          task: {
+            id: 'task_h3',
+            model: 'MiniMax-H3',
+            status: 'succeeded',
+            content: { url: 'https://cdn.example.com/video-h3.mp4' },
+          },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (urlString.includes('/v2/video_generation')) {
+        return new Response(JSON.stringify({ task_id: 'task_h3' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response(Buffer.from('mock-mp4-bytes'), { status: 200 })
+    })
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchMock as any
+    const originalSetTimeout = globalThis.setTimeout
+    globalThis.setTimeout = ((cb: () => void) => { cb(); return 0 }) as any
+    try {
+      const { miniMaxImageToVideo } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx: any = {
+        state: { serverTokenAuth: true },
+        query: {},
+        request: {
+          body: {
+            prompt: 'animate the water and clouds',
+            image_url: 'https://cdn.example.com/source.png',
+            output_path: '/tmp/hermes-web-ui-minimax-image-video.mp4',
+          },
+        },
+        get: vi.fn(() => ''),
+        status: 200,
+        body: undefined,
+      }
+
+      await miniMaxImageToVideo(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body).toMatchObject({
+        task_id: 'task_h3',
+        status: 'succeeded',
+        model: 'MiniMax-H3',
+        api_version: 'v2',
+        region: 'global_en',
+      })
+      expect(fetchMock.mock.calls[0][0]).toBe('https://api.minimax.io/v2/video_generation')
+      expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({
+        model: 'MiniMax-H3',
+        content: [
+          { type: 'text', text: 'animate the water and clouds' },
+          {
+            type: 'image_url',
+            image_url: { url: 'https://cdn.example.com/source.png' },
+            role: 'first_frame',
+          },
+        ],
+        resolution: '2K',
+        duration: 5,
+        ratio: 'adaptive',
+      })
+      expect(fetchMock.mock.calls[1][0]).toBe('https://api.minimax.io/v2/query/video_generation/task_h3')
+    } finally {
+      globalThis.fetch = originalFetch
+      globalThis.setTimeout = originalSetTimeout
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('uses refreshed MiniMax authorization credentials and the CN v2 endpoint', async () => {
+    vi.stubEnv('MINIMAX_API_KEY', '')
+    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+      getActiveProfileName: () => 'default',
+      getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
+      listProfileNamesFromDisk: () => ['default'],
+    }))
+    vi.doMock('../../packages/server/src/services/config-helpers', () => ({
+      readConfigYamlForProfile: vi.fn(async () => ({})),
+    }))
+    const resolveAuthorizedProviderRuntimeCredentials = vi.fn(async () => ({
+      provider: 'minimax-oauth',
+      apiKey: 'fresh-minimax-token',
+      baseUrl: 'https://api.minimaxi.com/anthropic',
+      source: 'oauth-refresh',
+    }))
+    vi.doMock('../../packages/server/src/services/hermes/authorized-provider-credentials', () => ({
+      resolveAuthorizedProviderRuntimeCredentials,
+    }))
+    const fetchMock = vi.fn(async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlString = String(url)
+      if (urlString.includes('/v2/query/video_generation/task_cn')) {
+        return new Response(JSON.stringify({
+          task: {
+            id: 'task_cn',
+            model: 'MiniMax-H3',
+            status: 'succeeded',
+            content: { url: 'https://cdn.example.com/video-cn.mp4' },
+          },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (urlString.includes('/v2/video_generation')) {
+        return new Response(JSON.stringify({ task_id: 'task_cn' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response(Buffer.from('mock-mp4-bytes'), { status: 200 })
+    })
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchMock as any
+    const originalSetTimeout = globalThis.setTimeout
+    globalThis.setTimeout = ((cb: () => void) => { cb(); return 0 }) as any
+    try {
+      const { miniMaxImageToVideo } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx: any = {
+        state: { serverTokenAuth: true },
+        query: {},
+        request: {
+          body: {
+            prompt: 'animate the portrait',
+            image_url: 'https://cdn.example.com/portrait.png',
+            aigc_watermark: true,
+            output_path: '/tmp/hermes-web-ui-minimax-image-video-cn.mp4',
+          },
+        },
+        get: vi.fn(() => ''),
+        status: 200,
+        body: undefined,
+      }
+
+      await miniMaxImageToVideo(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body).toMatchObject({
+        task_id: 'task_cn',
+        model: 'MiniMax-H3',
+        api_version: 'v2',
+        region: 'cn_zh',
+        token_source: 'oauth-refresh',
+      })
+      expect(fetchMock.mock.calls[0][0]).toBe('https://api.minimaxi.com/v2/video_generation')
+      expect(fetchMock.mock.calls[0][1]).toMatchObject({
+        headers: expect.objectContaining({ Authorization: 'Bearer fresh-minimax-token' }),
+      })
+      expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toMatchObject({
+        aigc_watermark: true,
+      })
+    } finally {
+      globalThis.fetch = originalFetch
+      globalThis.setTimeout = originalSetTimeout
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('uses the MiniMax v1 image-to-video workflow for an explicit v1 model', async () => {
+    vi.stubEnv('MINIMAX_API_KEY', 'minimax-test-key')
+    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+      getActiveProfileName: () => 'default',
+      getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
+      listProfileNamesFromDisk: () => ['default'],
+    }))
+    vi.doMock('../../packages/server/src/services/config-helpers', () => ({
+      readConfigYamlForProfile: vi.fn(async () => ({})),
+    }))
+    const fetchMock = vi.fn(async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlString = String(url)
+      if (urlString.includes('/v1/query/video_generation')) {
+        return new Response(JSON.stringify({ status: 'Success', file_id: 'file_v1', base_resp: { status_code: 0 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (urlString.includes('/v1/files/retrieve')) {
+        return new Response(JSON.stringify({ file: { download_url: 'https://cdn.example.com/video-v1.mp4' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (urlString.includes('/v1/video_generation')) {
+        return new Response(JSON.stringify({ task_id: 'task_v1', base_resp: { status_code: 0 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response(Buffer.from('mock-mp4-bytes'), { status: 200 })
+    })
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchMock as any
+    const originalSetTimeout = globalThis.setTimeout
+    globalThis.setTimeout = ((cb: () => void) => { cb(); return 0 }) as any
+    try {
+      const { miniMaxImageToVideo } = await import('../../packages/server/src/controllers/hermes/media')
+      const ctx: any = {
+        state: { serverTokenAuth: true },
+        query: {},
+        request: {
+          body: {
+            model: 'MiniMax-Hailuo-2.3',
+            prompt: 'animate the portrait',
+            image_url: 'https://cdn.example.com/portrait.png',
+            duration: 6,
+            resolution: '1080P',
+            output_path: '/tmp/hermes-web-ui-minimax-image-video-v1.mp4',
+          },
+        },
+        get: vi.fn(() => ''),
+        status: 200,
+        body: undefined,
+      }
+
+      await miniMaxImageToVideo(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body).toMatchObject({
+        task_id: 'task_v1',
+        file_id: 'file_v1',
+        model: 'MiniMax-Hailuo-2.3',
+        api_version: 'v1',
+        region: 'global_en',
+      })
+      expect(fetchMock.mock.calls[0][0]).toBe('https://api.minimax.io/v1/video_generation')
+      expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toMatchObject({
+        model: 'MiniMax-Hailuo-2.3',
+        first_frame_image: 'https://cdn.example.com/portrait.png',
+        prompt: 'animate the portrait',
+        duration: 6,
+        resolution: '1080P',
+      })
+    } finally {
+      globalThis.fetch = originalFetch
+      globalThis.setTimeout = originalSetTimeout
+      vi.unstubAllEnvs()
     }
   })
 })

--- a/tests/server/media-controller.test.ts
+++ b/tests/server/media-controller.test.ts
@@ -1,13 +1,15 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const originalWebUiHome = process.env.HERMES_WEB_UI_HOME
 const originalWebuiStateDir = process.env.HERMES_WEBUI_STATE_DIR
+const temporaryProfileDirs: string[] = []
 
 afterEach(() => {
   vi.doUnmock('../../packages/server/src/services/hermes/hermes-profile')
   vi.doUnmock('../../packages/server/src/services/config-helpers')
-  vi.doUnmock('../../packages/server/src/services/hermes/authorized-provider-credentials')
   vi.clearAllMocks()
   vi.unstubAllEnvs()
   vi.resetModules()
@@ -15,6 +17,7 @@ afterEach(() => {
   else process.env.HERMES_WEB_UI_HOME = originalWebUiHome
   if (originalWebuiStateDir === undefined) delete process.env.HERMES_WEBUI_STATE_DIR
   else process.env.HERMES_WEBUI_STATE_DIR = originalWebuiStateDir
+  for (const directory of temporaryProfileDirs.splice(0)) rmSync(directory, { recursive: true, force: true })
 })
 
 describe('media controller', () => {
@@ -167,18 +170,14 @@ describe('media controller', () => {
 
   it('rejects MiniMax image-to-video without credentials', async () => {
     vi.stubEnv('MINIMAX_API_KEY', '')
+    vi.stubEnv('MINIMAX_CN_API_KEY', '')
     vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
       getActiveProfileName: () => 'default',
       getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
       listProfileNamesFromDisk: () => ['default'],
     }))
     vi.doMock('../../packages/server/src/services/config-helpers', () => ({
-      readConfigYamlForProfile: vi.fn(async () => ({})),
-    }))
-    vi.doMock('../../packages/server/src/services/hermes/authorized-provider-credentials', () => ({
-      resolveAuthorizedProviderRuntimeCredentials: vi.fn(async () => {
-        throw new Error('MiniMax authorization is unavailable')
-      }),
+      readConfigYamlForProfile: vi.fn(async () => ({ model: { provider: 'minimax' } })),
     }))
     const { miniMaxImageToVideo } = await import('../../packages/server/src/controllers/hermes/media')
     const ctx: any = {
@@ -193,33 +192,39 @@ describe('media controller', () => {
     await miniMaxImageToVideo(ctx)
 
     expect(ctx.status).toBe(401)
-    expect(ctx.body).toMatchObject({ code: 'missing_minimax_token' })
+    expect(ctx.body).toMatchObject({
+      code: 'missing_minimax_token',
+      error: expect.stringContaining('MINIMAX_API_KEY'),
+    })
   })
 
-  it('generates MiniMax-H3 image-to-video through the global v2 endpoint', async () => {
+  it('generates image-to-video with the official MiniMax v1 workflow by default', async () => {
     vi.stubEnv('MINIMAX_API_KEY', 'minimax-test-key')
+    vi.stubEnv('MINIMAX_CN_API_KEY', '')
     vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
       getActiveProfileName: () => 'default',
       getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
       listProfileNamesFromDisk: () => ['default'],
     }))
     vi.doMock('../../packages/server/src/services/config-helpers', () => ({
-      readConfigYamlForProfile: vi.fn(async () => ({})),
+      readConfigYamlForProfile: vi.fn(async () => ({ model: { provider: 'minimax' } })),
     }))
     const fetchMock = vi.fn(async (url: string | URL | Request, _init?: RequestInit) => {
       const urlString = String(url)
-      if (urlString.includes('/v2/query/video_generation/task_h3')) {
-        return new Response(JSON.stringify({
-          task: {
-            id: 'task_h3',
-            model: 'MiniMax-H3',
-            status: 'succeeded',
-            content: { url: 'https://cdn.example.com/video-h3.mp4' },
-          },
-        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      if (urlString.includes('/v1/query/video_generation')) {
+        return new Response(JSON.stringify({ status: 'Success', file_id: 'file_default', base_resp: { status_code: 0 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
       }
-      if (urlString.includes('/v2/video_generation')) {
-        return new Response(JSON.stringify({ task_id: 'task_h3' }), {
+      if (urlString.includes('/v1/files/retrieve')) {
+        return new Response(JSON.stringify({ file: { download_url: 'https://cdn.example.com/video-default.mp4' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (urlString.includes('/v1/video_generation')) {
+        return new Response(JSON.stringify({ task_id: 'task_default', base_resp: { status_code: 0 } }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         })
@@ -251,28 +256,24 @@ describe('media controller', () => {
 
       expect(ctx.status).toBe(200)
       expect(ctx.body).toMatchObject({
-        task_id: 'task_h3',
-        status: 'succeeded',
-        model: 'MiniMax-H3',
-        api_version: 'v2',
+        task_id: 'task_default',
+        file_id: 'file_default',
+        status: 'Success',
+        model: 'MiniMax-Hailuo-2.3',
+        api_version: 'v1',
         region: 'global_en',
+        token_source: 'MINIMAX_API_KEY',
       })
-      expect(fetchMock.mock.calls[0][0]).toBe('https://api.minimax.io/v2/video_generation')
+      expect(fetchMock.mock.calls[0][0]).toBe('https://api.minimax.io/v1/video_generation')
       expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({
-        model: 'MiniMax-H3',
-        content: [
-          { type: 'text', text: 'animate the water and clouds' },
-          {
-            type: 'image_url',
-            image_url: { url: 'https://cdn.example.com/source.png' },
-            role: 'first_frame',
-          },
-        ],
-        resolution: '2K',
-        duration: 5,
-        ratio: 'adaptive',
+        model: 'MiniMax-Hailuo-2.3',
+        first_frame_image: 'https://cdn.example.com/source.png',
+        prompt: 'animate the water and clouds',
+        duration: 6,
+        resolution: '768P',
       })
-      expect(fetchMock.mock.calls[1][0]).toBe('https://api.minimax.io/v2/query/video_generation/task_h3')
+      expect(fetchMock.mock.calls[1][0]).toBe('https://api.minimax.io/v1/query/video_generation?task_id=task_default')
+      expect(fetchMock.mock.calls[2][0]).toBe('https://api.minimax.io/v1/files/retrieve?file_id=file_default')
     } finally {
       globalThis.fetch = originalFetch
       globalThis.setTimeout = originalSetTimeout
@@ -280,39 +281,36 @@ describe('media controller', () => {
     }
   })
 
-  it('uses refreshed MiniMax authorization credentials and the CN v2 endpoint', async () => {
+  it('uses the selected profile MiniMax China API key and endpoint', async () => {
+    const profileDir = mkdtempSync(join(tmpdir(), 'hermes-web-ui-minimax-profile-'))
+    temporaryProfileDirs.push(profileDir)
+    writeFileSync(join(profileDir, '.env'), 'MINIMAX_CN_API_KEY="profile-cn-key"\n')
     vi.stubEnv('MINIMAX_API_KEY', '')
+    vi.stubEnv('MINIMAX_CN_API_KEY', 'process-cn-key')
     vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
       getActiveProfileName: () => 'default',
-      getProfileDir: () => '/tmp/hermes-web-ui-test-profile',
+      getProfileDir: () => profileDir,
       listProfileNamesFromDisk: () => ['default'],
     }))
     vi.doMock('../../packages/server/src/services/config-helpers', () => ({
-      readConfigYamlForProfile: vi.fn(async () => ({})),
-    }))
-    const resolveAuthorizedProviderRuntimeCredentials = vi.fn(async () => ({
-      provider: 'minimax-oauth',
-      apiKey: 'fresh-minimax-token',
-      baseUrl: 'https://api.minimaxi.com/anthropic',
-      source: 'oauth-refresh',
-    }))
-    vi.doMock('../../packages/server/src/services/hermes/authorized-provider-credentials', () => ({
-      resolveAuthorizedProviderRuntimeCredentials,
+      readConfigYamlForProfile: vi.fn(async () => ({ model: { provider: 'minimax-cn' } })),
     }))
     const fetchMock = vi.fn(async (url: string | URL | Request, _init?: RequestInit) => {
       const urlString = String(url)
-      if (urlString.includes('/v2/query/video_generation/task_cn')) {
-        return new Response(JSON.stringify({
-          task: {
-            id: 'task_cn',
-            model: 'MiniMax-H3',
-            status: 'succeeded',
-            content: { url: 'https://cdn.example.com/video-cn.mp4' },
-          },
-        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      if (urlString.includes('/v1/query/video_generation')) {
+        return new Response(JSON.stringify({ status: 'Success', file_id: 'file_cn', base_resp: { status_code: 0 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
       }
-      if (urlString.includes('/v2/video_generation')) {
-        return new Response(JSON.stringify({ task_id: 'task_cn' }), {
+      if (urlString.includes('/v1/files/retrieve')) {
+        return new Response(JSON.stringify({ file: { download_url: 'https://cdn.example.com/video-cn.mp4' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (urlString.includes('/v1/video_generation')) {
+        return new Response(JSON.stringify({ task_id: 'task_cn', base_resp: { status_code: 0 } }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         })
@@ -346,14 +344,15 @@ describe('media controller', () => {
       expect(ctx.status).toBe(200)
       expect(ctx.body).toMatchObject({
         task_id: 'task_cn',
-        model: 'MiniMax-H3',
-        api_version: 'v2',
+        file_id: 'file_cn',
+        model: 'MiniMax-Hailuo-2.3',
+        api_version: 'v1',
         region: 'cn_zh',
-        token_source: 'oauth-refresh',
+        token_source: 'profile:MINIMAX_CN_API_KEY',
       })
-      expect(fetchMock.mock.calls[0][0]).toBe('https://api.minimaxi.com/v2/video_generation')
+      expect(fetchMock.mock.calls[0][0]).toBe('https://api.minimaxi.com/v1/video_generation')
       expect(fetchMock.mock.calls[0][1]).toMatchObject({
-        headers: expect.objectContaining({ Authorization: 'Bearer fresh-minimax-token' }),
+        headers: expect.objectContaining({ Authorization: 'Bearer profile-cn-key' }),
       })
       expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toMatchObject({
         aigc_watermark: true,
@@ -365,7 +364,7 @@ describe('media controller', () => {
     }
   })
 
-  it('uses the MiniMax v1 image-to-video workflow for an explicit v1 model', async () => {
+  it('validates model-specific MiniMax duration and resolution options', async () => {
     vi.stubEnv('MINIMAX_API_KEY', 'minimax-test-key')
     vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
       getActiveProfileName: () => 'default',
@@ -411,9 +410,8 @@ describe('media controller', () => {
             model: 'MiniMax-Hailuo-2.3',
             prompt: 'animate the portrait',
             image_url: 'https://cdn.example.com/portrait.png',
-            duration: 6,
+            duration: 10,
             resolution: '1080P',
-            output_path: '/tmp/hermes-web-ui-minimax-image-video-v1.mp4',
           },
         },
         get: vi.fn(() => ''),
@@ -423,22 +421,11 @@ describe('media controller', () => {
 
       await miniMaxImageToVideo(ctx)
 
-      expect(ctx.status).toBe(200)
+      expect(ctx.status).toBe(400)
       expect(ctx.body).toMatchObject({
-        task_id: 'task_v1',
-        file_id: 'file_v1',
-        model: 'MiniMax-Hailuo-2.3',
-        api_version: 'v1',
-        region: 'global_en',
+        error: 'MiniMax-Hailuo-2.3 does not support 1080P at 10 seconds',
       })
-      expect(fetchMock.mock.calls[0][0]).toBe('https://api.minimax.io/v1/video_generation')
-      expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toMatchObject({
-        model: 'MiniMax-Hailuo-2.3',
-        first_frame_image: 'https://cdn.example.com/portrait.png',
-        prompt: 'animate the portrait',
-        duration: 6,
-        resolution: '1080P',
-      })
+      expect(fetchMock).not.toHaveBeenCalled()
     } finally {
       globalThis.fetch = originalFetch
       globalThis.setTimeout = originalSetTimeout


### PR DESCRIPTION
Reason: Add MiniMax image-to-video generation to Hermes Studio media endpoints.

## Changes

- Add a MiniMax image-to-video controller with global and China regional routing for v2 and v1 workflows.
- Accept URL, base64, or local image inputs, poll generation tasks, and download completed videos.
- Register the authenticated media endpoint and add a matching agent skill.
- Add focused tests for missing credentials, both regional v2 flows, and v1 compatibility.

## Checks

- `npx vitest run tests/server/media-controller.test.ts`
- `npm run openapi:generate`
- `node scripts/harness-check.mjs`
