### PR TITLE
fix Linux Sharp packaging validation

### DIFF
--- a/.github/workflows/desktop-manual-build.yml
+++ b/.github/workflows/desktop-manual-build.yml
@@ -138,6 +138,9 @@ jobs:
       - name: Keep production web UI dependencies only
         run: npm prune --omit=dev --no-audit --no-fund
 
+      - name: Verify image processing runtime
+        run: npm run verify:sharp-runtime
+
       - name: Install desktop dependencies
         run: npm ci --prefix packages/desktop --no-audit --no-fund
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -95,6 +95,9 @@ jobs:
       - name: Keep production web UI dependencies only
         run: npm prune --omit=dev --no-audit --no-fund
 
+      - name: Verify image processing runtime
+        run: npm run verify:sharp-runtime
+
       - name: Install desktop dependencies
         run: npm ci --prefix packages/desktop --no-audit --no-fund
 

--- a/.github/workflows/webui-release.yml
+++ b/.github/workflows/webui-release.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Keep production dependencies only
         run: npm prune --omit=dev --no-audit --no-fund
 
+      - name: Verify image processing runtime
+        run: npm run verify:sharp-runtime
+
       - name: Package Web UI
         id: package
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN npm ci --ignore-scripts && npm rebuild node-pty
 COPY . .
 
 RUN npm run build && npm prune --omit=dev
+RUN npm run verify:sharp-runtime
 
 ENV NODE_ENV=production
 ENV HOME=/home/agent

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dev:server": "nodemon",
     "build": "npm run openapi:generate && vue-tsc -b && vite build && tsc --noEmit -p packages/server/tsconfig.json && node scripts/build-server.mjs",
     "harness:check": "node scripts/harness-check.mjs",
+    "verify:sharp-runtime": "node scripts/verify-sharp-runtime.mjs",
     "prepare": "[ -d dist ] || npm run build",
     "preview": "NODE_ENV=production vite preview",
     "test": "vitest run",

--- a/packages/desktop/scripts/verify-packaged-webui.mjs
+++ b/packages/desktop/scripts/verify-packaged-webui.mjs
@@ -35,7 +35,10 @@ function containsRuntimeFile(root, extensions) {
   return entries.some((entry) => {
     const path = join(root, entry.name)
     if (entry.isDirectory()) return containsRuntimeFile(path, extensions)
-    return extensions.some(extension => entry.name.endsWith(extension))
+    return extensions.some(extension => {
+      if (extension === '.so') return /\.so(?:\.\d+)*$/.test(entry.name)
+      return entry.name.endsWith(extension)
+    })
   })
 }
 

--- a/scripts/verify-sharp-runtime.mjs
+++ b/scripts/verify-sharp-runtime.mjs
@@ -1,0 +1,18 @@
+import sharp from 'sharp'
+
+const { data, info } = await sharp({
+  create: {
+    width: 2,
+    height: 2,
+    channels: 4,
+    background: { r: 32, g: 96, b: 160, alpha: 1 },
+  },
+})
+  .png()
+  .toBuffer({ resolveWithObject: true })
+
+if (info.format !== 'png' || info.width !== 2 || info.height !== 2 || data.length === 0) {
+  throw new Error(`Sharp runtime smoke test returned an invalid image: ${JSON.stringify(info)}`)
+}
+
+console.log(`[runtime] verified Sharp ${sharp.versions.sharp} with libvips ${sharp.versions.vips}`)

--- a/tests/desktop/packaged-webui.test.ts
+++ b/tests/desktop/packaged-webui.test.ts
@@ -20,7 +20,7 @@ function createPackagedWebUi(appOutDir: string, platform = 'win32', arch = 'x64'
     : [
         `${sharpRoot}/lib/sharp-${platform}-${arch}.node`,
         `node_modules/@img/sharp-libvips-${platform}-${arch}/package.json`,
-        `node_modules/@img/sharp-libvips-${platform}-${arch}/lib/libvips.${platform === 'darwin' ? 'dylib' : 'so'}`,
+        `node_modules/@img/sharp-libvips-${platform}-${arch}/lib/${platform === 'darwin' ? 'libvips-cpp.8.18.3.dylib' : 'libvips-cpp.so.8.18.3'}`,
       ]
   const sherpaPlatform = platform === 'win32' ? 'win' : platform
   const sherpaRoot = `node_modules/sherpa-onnx-${sherpaPlatform}-${arch}`
@@ -162,6 +162,29 @@ describe('packaged desktop Web UI', () => {
       arch: 3,
       packager: { appInfo: { productFilename: 'Hermes Studio' } },
     } as never)).resolves.toBeUndefined()
+  })
+
+  it('rejects a Linux libvips package without a shared library', async () => {
+    const appOutDir = packagedRoot()
+    createPackagedWebUi(appOutDir, 'linux', 'x64')
+    createCompiledLinuxNodePty(appOutDir)
+    rmSync(join(
+      appOutDir,
+      'resources',
+      'webui',
+      'node_modules',
+      '@img',
+      'sharp-libvips-linux-x64',
+      'lib',
+      'libvips-cpp.so.8.18.3',
+    ))
+
+    await expect(verifyPackagedWebUi({
+      appOutDir,
+      electronPlatformName: 'linux',
+      arch: 1,
+      packager: { appInfo: { productFilename: 'Hermes Studio' } },
+    } as never)).rejects.toThrow('sharp-libvips-linux-x64')
   })
 
   it('rejects a missing source-built node-pty module on Linux', async () => {

--- a/tests/shared/sharp-runtime-packaging.test.ts
+++ b/tests/shared/sharp-runtime-packaging.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(path: string): string {
+  return readFileSync(resolve(path), 'utf8')
+}
+
+describe('Sharp runtime packaging guardrails', () => {
+  it('provides a production runtime smoke test command', () => {
+    const packageJson = JSON.parse(read('package.json')) as { scripts?: Record<string, string> }
+
+    expect(packageJson.scripts?.['verify:sharp-runtime']).toBe('node scripts/verify-sharp-runtime.mjs')
+  })
+
+  it.each([
+    '.github/workflows/desktop-release.yml',
+    '.github/workflows/desktop-manual-build.yml',
+    '.github/workflows/webui-release.yml',
+    'Dockerfile',
+  ])('runs the smoke test while building %s', (path) => {
+    const source = read(path)
+    const pruneIndex = source.indexOf('npm prune --omit=dev')
+    const smokeTestIndex = source.indexOf('npm run verify:sharp-runtime')
+
+    expect(pruneIndex).toBeGreaterThan(-1)
+    expect(smokeTestIndex).toBeGreaterThan(pruneIndex)
+  })
+})


### PR DESCRIPTION
## Summary

- accept versioned Linux shared library names such as `libvips-cpp.so.8.18.3` in the packaged desktop Web UI verifier
- add a Sharp runtime smoke test that creates a PNG after production dependencies have been pruned
- run the smoke test in desktop release builds, manual desktop builds, Web UI release packaging, and Docker image builds
- add regression coverage for versioned Linux libvips files and release-pipeline guardrails

## Root cause

The Linux desktop verifier required a filename ending exactly in `.so`, while Sharp 0.35.3 ships libvips as `libvips-cpp.so.8.18.3`. The dependency was present and packaged, but the verifier rejected both Linux architectures before artifact creation.

## Impact

Linux desktop packaging no longer fails on valid versioned libvips libraries. Release builds now also execute a real Sharp image operation so missing or unloadable native dependencies fail before artifacts or images are published.

## Validation

- `npm run test -- tests/desktop/packaged-webui.test.ts tests/shared/sharp-runtime-packaging.test.ts` (16 tests passed)
- `npm run verify:sharp-runtime`
- `npm prune --omit=dev --no-audit --no-fund && npm run verify:sharp-runtime`
- `npm run harness:check`
- `npm run build`
- `git diff --check`

Local Docker image validation was not available because the Docker daemon is not running; the Dockerfile now performs the same runtime smoke test during image construction.
