### PR TITLE
fix: lazy-load optional Sharp runtime

### DIFF
--- a/packages/server/src/services/hermes/app-image-preview.ts
+++ b/packages/server/src/services/hermes/app-image-preview.ts
@@ -1,9 +1,16 @@
-import sharp from 'sharp'
-
 const APP_IMAGE_MAX_EDGE = 2048
 const APP_IMAGE_MAX_PIXELS = 100 * 1024 * 1024
 const APP_IMAGE_WEBP_QUALITY = 76
 const COMPRESSIBLE_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp'])
+
+const importSharp = () => import('sharp')
+
+let sharpModulePromise: ReturnType<typeof importSharp> | undefined
+
+function loadSharp(): ReturnType<typeof importSharp> {
+  sharpModulePromise ??= importSharp()
+  return sharpModulePromise
+}
 
 export interface AppImagePreview {
   data: Buffer
@@ -25,6 +32,7 @@ export async function createAppImagePreview(data: Buffer, mimeInput: string): Pr
   if (!COMPRESSIBLE_IMAGE_TYPES.has(mime) || !data.length) return fallback
 
   try {
+    const { default: sharp } = await loadSharp()
     const input = sharp(data, {
       animated: false,
       failOn: 'none',

--- a/tests/server/app-image-preview.test.ts
+++ b/tests/server/app-image-preview.test.ts
@@ -1,6 +1,11 @@
 import { deflateSync } from 'node:zlib'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createAppImagePreview } from '../../packages/server/src/services/hermes/app-image-preview'
+
+afterEach(() => {
+  vi.doUnmock('sharp')
+  vi.resetModules()
+})
 
 describe('createAppImagePreview', () => {
   it('downscales large images and encodes an App WebP preview', async () => {
@@ -23,6 +28,42 @@ describe('createAppImagePreview', () => {
     expect(result.optimized).toBe(false)
     expect(result.mime).toBe('text/plain')
     expect(result.data).toBe(source)
+  })
+
+  it('does not load Sharp for non-image downloads', async () => {
+    vi.resetModules()
+    vi.doMock('sharp', () => {
+      throw new Error('Sharp should not load')
+    })
+    const { createAppImagePreview: createWithoutSharp } = await import(
+      '../../packages/server/src/services/hermes/app-image-preview'
+    )
+    const source = Buffer.from('hello')
+
+    const result = await createWithoutSharp(source, 'text/plain')
+
+    expect(result.optimized).toBe(false)
+    expect(result.data).toBe(source)
+  })
+
+  it('returns the original image when Sharp cannot load', async () => {
+    vi.resetModules()
+    vi.doMock('sharp', () => {
+      throw new Error('Native Sharp runtime unavailable')
+    })
+    const { createAppImagePreview: createWithoutSharp } = await import(
+      '../../packages/server/src/services/hermes/app-image-preview'
+    )
+    const source = solidPng(4, 4, [53, 88, 212, 255])
+
+    const result = await createWithoutSharp(source, 'image/png')
+
+    expect(result).toEqual({
+      data: source,
+      mime: 'image/png',
+      optimized: false,
+      originalBytes: source.length,
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

- lazy-load Sharp only for non-empty JPEG, PNG, or WebP App preview requests
- keep normal downloads and server startup independent of the optional native Sharp runtime
- return the original image when Sharp is missing or its native library cannot load
- add regression tests for non-image requests and unavailable Sharp runtimes

## Root cause

The image preview service imported Sharp at module evaluation time. Because the download route imports that service during server startup, an unavailable or incompatible Sharp native binary could prevent the whole service from starting even when image compression was never requested.

## Impact

Sharp is now an optional runtime capability. Users who do not request App image compression are unaffected by Sharp availability, while supported environments retain image optimization.

## Validation

- `npm run test -- tests/server/app-image-preview.test.ts` (4 tests passed)
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run harness:check`
- `npm run build`
- `git diff --check`
