### PR TITLE
fix(group-chat): 可见 @ 扫描排除发送者自身，避免「@自己+@他人」混合消息被误拒

### DIFF
--- a/docs/chat-chain-changes/2026-08-13-pr-2525-group-chat-self-mention-visible-scan.md
+++ b/docs/chat-chain-changes/2026-08-13-pr-2525-group-chat-self-mention-visible-scan.md
@@ -1,0 +1,8 @@
+---
+date: 2026-08-13
+pr: 2525
+feature: Group Chat self-mention visible scan exclusion
+impact: Agent messages that mention both the sender and another participant are no longer rejected as Invalid structured mentions; only the other participant is routed.
+---
+
+`normalizeStructuredMentions()` now excludes the sender from the visible @ scan, matching `resolveMentionTargets()`. A mixed `@self + @other` message with structured mentions that omit self persists and routes only the other agent.

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -3378,7 +3378,7 @@ export class GroupChatServer {
         const visibleAllMention = isAllAgentsMentioned(content)
         const visibleParticipantIds = new Set(
             roomAgents
-                .filter(agent => isAgentMentioned(content, agent.name))
+                .filter(agent => agent.agentId !== senderId && isAgentMentioned(content, agent.name))
                 .map(agent => agent.agentId),
         )
 

--- a/tests/server/group-chat-structured-mentions.test.ts
+++ b/tests/server/group-chat-structured-mentions.test.ts
@@ -121,6 +121,36 @@ describe('group chat structured agent mentions', () => {
     expect(replyToMention).not.toHaveBeenCalled()
   })
 
+  it('persists an agent reply that @-mentions itself and another agent, routing only the other agent', async () => {
+    const author = await connectGroupChatClient(port, 'agent-author', 'Author', {
+      source: 'agent',
+      agentSocketSecret: GROUP_CHAT_AGENT_SOCKET_SECRET,
+    })
+    harness.sockets.push(author)
+    await emitAck(author, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    const replyToMention = vi.fn(async () => {})
+    ;(groupServer.agentClients as any).rooms.set('room-1', new Map([[
+      'agent-reviewer',
+      { id: 'agent-reviewer', agentId: 'agent-reviewer', name: 'Reviewer', replyToMention },
+    ]]))
+
+    const response = await emitAck<{ id?: string; error?: string }>(author, 'message', {
+      roomId: 'room-1',
+      id: 'self-plus-other-reply',
+      content: '@Author @Reviewer please review this.',
+      role: 'assistant',
+      agentSessionId: groupRuntimeSessionId('room-1', 'default', 'Author'),
+      mentions: [{ type: 'agent', participantId: 'agent-reviewer', displayName: 'Reviewer' }],
+    })
+
+    expect(response).toEqual({ id: 'self-plus-other-reply' })
+    expect(harness.db.prepare('SELECT COUNT(*) AS count FROM gc_messages WHERE id = ?').get('self-plus-other-reply')).toEqual({ count: 1 })
+    expect(replyToMention).toHaveBeenCalledWith('room-1', expect.objectContaining({
+      messageId: 'self-plus-other-reply',
+      mentions: [{ type: 'agent', participantId: 'agent-reviewer' }],
+    }), expect.anything(), expect.any(Function))
+  })
+
   it('persists tool output containing mention-like text without authorizing or routing mentions', async () => {
     const author = await connectGroupChatClient(port, 'agent-author', 'Author', {
       source: 'agent',

--- a/tests/server/group-chat-structured-mentions.test.ts
+++ b/tests/server/group-chat-structured-mentions.test.ts
@@ -145,10 +145,10 @@ describe('group chat structured agent mentions', () => {
 
     expect(response).toEqual({ id: 'self-plus-other-reply' })
     expect(harness.db.prepare('SELECT COUNT(*) AS count FROM gc_messages WHERE id = ?').get('self-plus-other-reply')).toEqual({ count: 1 })
-    expect(replyToMention).toHaveBeenCalledWith('room-1', expect.objectContaining({
+    await vi.waitFor(() => expect(replyToMention).toHaveBeenCalledWith('room-1', expect.objectContaining({
       messageId: 'self-plus-other-reply',
       mentions: [{ type: 'agent', participantId: 'agent-reviewer' }],
-    }), expect.anything(), expect.any(Function))
+    }), expect.anything(), expect.any(Function)))
   })
 
   it('persists tool output containing mention-like text without authorizing or routing mentions', async () => {

--- a/tests/server/group-chat-structured-mentions.test.ts
+++ b/tests/server/group-chat-structured-mentions.test.ts
@@ -134,6 +134,7 @@ describe('group chat structured agent mentions', () => {
       { id: 'agent-reviewer', agentId: 'agent-reviewer', name: 'Reviewer', replyToMention },
     ]]))
 
+    groupServer.getStorage().registerTrustedAgentMessageMetadata('room-1', 'self-plus-other-reply', 1, 'trusted-chain')
     const response = await emitAck<{ id?: string; error?: string }>(author, 'message', {
       roomId: 'room-1',
       id: 'self-plus-other-reply',


### PR DESCRIPTION
### 问题

当 agent 消息正文同时包含「@自己」与「@他人」时，服务端整条拒绝，报错 `Invalid structured mentions`。生产环境同一会话连续 3 条消息被拒（服务端日志 `Invalid structured mentions` ×3）。

### 复现

1. 房间内有 agent `Author`（发送者）与 `Reviewer`；
2. `Author` 发送正文 `@Author @Reviewer please review this.`，结构化 mentions 仅携带 `[{type:'agent', participantId:'agent-reviewer', displayName:'Reviewer'}]`（客户端不会携带 self）；
3. 服务端一致性校验失败 → 整条拒发。

### 根因

`packages/server/src/services/hermes/group-chat/index.ts` 的 `normalizeStructuredMentions()`：

- 可见 @ 扫描**未排除发送者自己**：`roomAgents.filter(agent => isAgentMentioned(content, agent.name))`（缺 `agentId !== senderId`）；
- 结构化 mentions 校验明确拒绝 self（`mention.participantId === senderId` → error）；
- 末尾一致性比较要求两集合完全一致 → 正文含 @自己 时可见集合多出自己，必然失配。

对照：`mention-routing.ts` 的 `resolveMentionTargets()` / `resolveStructuredMentionTargets()` 均已通过 `isSenderAgent()` 排除 sender（#2414 引入），本函数内联扫描未同步，形成不一致。现有测试 `persists an agent reply that only names itself without dispatching itself` 只覆盖 `rawMentions === undefined` 分支（走短路返回），故未暴露。

### 修复

最小改动，与 `resolveMentionTargets` 的 sender 排除语义保持一致：

```ts
const visibleParticipantIds = new Set(
    roomAgents
        .filter(agent => agent.agentId !== senderId && isAgentMentioned(content, agent.name))
        .map(agent => agent.agentId),
)
```

### 测试

`tests/server/group-chat-structured-mentions.test.ts` 新增用例：`persists an agent reply that @-mentions itself and another agent, routing only the other agent`——正文 `@Author @Reviewer please review this.`、mentions 仅 reviewer；断言成功持久化、只路由 reviewer、Author 不被路由。

### 相关

- #2414：`mention-routing.ts` 引入 `isSenderAgent` 排除（本函数未同步）
