### PR TITLE
fix(group-chat): add current-run tool scrolling

### DIFF
--- a/docs/chat-chain-changes/2026-08-13-group-chat-current-run-tool-list.md
+++ b/docs/chat-chain-changes/2026-08-13-group-chat-current-run-tool-list.md
@@ -1,0 +1,10 @@
+---
+date: 2026-08-13
+pr: pending
+feature: Group Chat current-run tool list
+impact: Active Agent runs show their tool calls in an Agent/Run-scoped bounded scroll region while completed runs keep tool traces in the transcript.
+---
+
+The panel is a view over existing runtime messages, not a second persisted source.
+Wheel input stays inside the panel while it has remaining scroll range and naturally
+returns to the outer transcript at either boundary.

--- a/docs/chat-chain-changes/2026-08-13-group-chat-current-run-tool-list.md
+++ b/docs/chat-chain-changes/2026-08-13-group-chat-current-run-tool-list.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-13
-pr: pending
+pr: 2527
 feature: Group Chat current-run tool list
 impact: Active Agent runs show their tool calls in an Agent/Run-scoped bounded scroll region while completed runs keep tool traces in the transcript.
 ---

--- a/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import ProfileAvatar from '@/components/hermes/profiles/ProfileAvatar.vue'
 import { formatChatTimestamp } from '@/utils/chat-timestamp'
 import type { ChatMessage, MemberInfo, RoomAgent } from '@/api/hermes/group-chat'
@@ -22,8 +23,22 @@ const emit = defineEmits<{
     mentionAgent: [agent: RoomAgent]
 }>()
 
+const { t } = useI18n()
 const items = computed(() =>
     props.message.runItems?.length ? props.message.runItems : [props.message]
+)
+const currentRunToolItems = computed(() =>
+    props.message.isStreaming
+        ? items.value.filter(item => item.role === 'tool')
+        : []
+)
+const transcriptItems = computed(() =>
+    currentRunToolItems.value.length > 0
+        ? items.value.filter(item => item.role !== 'tool')
+        : items.value
+)
+const stableAgentId = computed(() =>
+    props.message.senderAgentRecordId || props.message.senderId
 )
 const activeAgentInfo = computed(() => props.agents.find(agent =>
     !agent.historical && (
@@ -48,6 +63,18 @@ const agentOwnerInfo = computed(() => {
 const senderAvatar = computed(() => parseStoredAvatar(memberInfo.value?.avatar))
 const lastTimestamp = computed(() => items.value.at(-1)?.timestamp || props.message.timestamp)
 const timeText = computed(() => formatChatTimestamp(lastTimestamp.value))
+
+function handleToolListWheel(event: WheelEvent): void {
+    const element = event.currentTarget as HTMLElement | null
+    if (!element || event.deltaY === 0) return
+    const canScrollUp = event.deltaY < 0 && element.scrollTop > 0
+    const canScrollDown = event.deltaY > 0 &&
+        element.scrollTop + element.clientHeight < element.scrollHeight
+    if (!canScrollUp && !canScrollDown) return
+    event.preventDefault()
+    event.stopPropagation()
+    element.scrollTop += event.deltaY
+}
 </script>
 
 <template>
@@ -74,16 +101,49 @@ const timeText = computed(() => formatChatTimestamp(lastTimestamp.value))
                 <GroupAgentRobotIcon v-if="agentInfo" class="run-agent-icon" />
             </div>
             <div class="run-card" :class="{ streaming: message.isStreaming }">
-                <GroupMessageItem
-                    v-for="item in items"
-                    :key="item.id"
-                    :message="item"
-                    :agents="agents"
-                    :members="members"
-                    :current-user-id="currentUserId"
-                    :allow-speech="props.allowSpeech"
-                    embedded
-                />
+                <div
+                    v-if="currentRunToolItems.length"
+                    class="run-tool-list"
+                    tabindex="0"
+                    role="region"
+                    :aria-label="t('chat.showToolCalls')"
+                    :data-agent-id="stableAgentId"
+                    :data-run-id="message.run_id || undefined"
+                    @wheel="handleToolListWheel"
+                >
+                    <div
+                        v-for="item in currentRunToolItems"
+                        :key="item.id"
+                        class="run-tool-item"
+                        :data-message-id="item.id"
+                    >
+                        <GroupMessageItem
+                            :message="item"
+                            :agents="agents"
+                            :members="members"
+                            :current-user-id="currentUserId"
+                            :allow-speech="props.allowSpeech"
+                            embedded
+                        />
+                    </div>
+                </div>
+                <div v-if="transcriptItems.length" class="run-transcript">
+                    <div
+                        v-for="item in transcriptItems"
+                        :key="item.id"
+                        class="run-transcript-item"
+                        :data-message-id="item.id"
+                    >
+                        <GroupMessageItem
+                            :message="item"
+                            :agents="agents"
+                            :members="members"
+                            :current-user-id="currentUserId"
+                            :allow-speech="props.allowSpeech"
+                            embedded
+                        />
+                    </div>
+                </div>
             </div>
             <span class="run-time">{{ timeText }}</span>
         </div>
@@ -149,9 +209,40 @@ const timeText = computed(() => formatChatTimestamp(lastTimestamp.value))
     background: rgba(var(--accent-primary-rgb), 0.055);
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.035);
 
-    > :deep(.group-message + .group-message) {
+    > :deep(.group-message + .group-message),
+    .run-transcript-item + .run-transcript-item {
         border-top: 1px solid rgba(var(--text-primary-rgb), 0.08);
     }
+}
+
+.run-tool-list {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    min-width: 0;
+    max-height: 180px;
+    overflow-y: auto;
+    scrollbar-width: thin;
+
+    &:focus-visible {
+        outline: 2px solid rgba(var(--accent-primary-rgb), 0.45);
+        outline-offset: -2px;
+        border-radius: 10px;
+    }
+
+    .run-tool-item + .run-tool-item {
+        border-top: 1px solid rgba(var(--text-primary-rgb), 0.08);
+    }
+}
+
+.run-transcript,
+.run-tool-item,
+.run-transcript-item {
+    min-width: 0;
+}
+
+.run-tool-list + .run-transcript {
+    border-top: 1px solid rgba(var(--text-primary-rgb), 0.08);
 }
 
 .run-time {

--- a/tests/client/group-agent-run-tool-list.test.ts
+++ b/tests/client/group-agent-run-tool-list.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { createPinia } from 'pinia'
+import type { ChatMessage, RoomAgent } from '@/api/hermes/group-chat'
+import GroupAgentRunCard from '@/components/hermes/group-chat/GroupAgentRunCard.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('naive-ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('naive-ui')>()
+  return {
+    ...actual,
+    useMessage: () => ({
+      error: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+    }),
+  }
+})
+
+const agent: RoomAgent = {
+  id: 'agent-row-1',
+  roomId: 'room-1',
+  agentId: 'agent-1',
+  profile: 'default',
+  name: 'Worker',
+  description: '',
+  invited: 1,
+}
+
+function runItem(overrides: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: 'message-1',
+    roomId: 'room-1',
+    senderId: 'agent-1',
+    senderName: 'Worker',
+    content: '',
+    timestamp: 1,
+    role: 'assistant',
+    run_id: 'run-current',
+    ...overrides,
+  }
+}
+
+function runMessage(items: ChatMessage[], isStreaming: boolean): ChatMessage {
+  return {
+    ...items[0],
+    id: `group-agent-run:${items[0].senderId}:${items[0].run_id}`,
+    role: 'agent_run',
+    content: '',
+    runItems: items,
+    isStreaming,
+  }
+}
+
+const GroupMessageItemStub = defineComponent({
+  name: 'GroupMessageItem',
+  props: {
+    message: { type: Object, required: true },
+  },
+  template: '<div class="message-stub" :data-message-id="message.id">{{ message.toolName || message.content }}</div>',
+})
+
+function mountCard(message: ChatMessage) {
+  return mount(GroupAgentRunCard, {
+    props: {
+      message,
+      agents: [agent],
+      members: [],
+      currentUserId: 'user-1',
+    },
+    global: {
+      plugins: [createPinia()],
+      stubs: {
+        GroupMessageItem: GroupMessageItemStub,
+        GroupAgentMessageAvatar: true,
+        GroupAgentRobotIcon: true,
+        ProfileAvatar: true,
+      },
+    },
+  })
+}
+
+describe('GroupAgentRunCard current tool list', () => {
+  it('places only the current active Agent/Run tool calls in one keyboard-focusable bounded panel', () => {
+    const wrapper = mountCard(runMessage([
+      runItem({ id: 'current-tool-1', role: 'tool', toolName: 'read_file', toolStatus: 'done' }),
+      runItem({ id: 'current-reasoning', content: 'Checking the result.', isStreaming: true, timestamp: 2 }),
+      runItem({ id: 'current-tool-2', role: 'tool', toolName: 'search', toolStatus: 'running', timestamp: 3 }),
+    ], true))
+
+    const panel = wrapper.get('.run-tool-list')
+    expect(panel.attributes('tabindex')).toBe('0')
+    expect(panel.attributes('aria-label')).toBe('chat.showToolCalls')
+    expect(panel.attributes('data-agent-id')).toBe('agent-1')
+    expect(panel.attributes('data-run-id')).toBe('run-current')
+    expect(panel.findAll('.run-tool-item').map(item => item.attributes('data-message-id'))).toEqual([
+      'current-tool-1',
+      'current-tool-2',
+    ])
+    expect(wrapper.get('.run-transcript-item').attributes('data-message-id')).toBe('current-reasoning')
+    expect(wrapper.get('.run-transcript').find('.tool-name').exists()).toBe(false)
+  })
+
+  it('keeps completed historical tool calls in the normal run transcript without a second panel', () => {
+    const wrapper = mountCard(runMessage([
+      runItem({ id: 'historical-tool', role: 'tool', toolName: 'read_file', toolStatus: 'done' }),
+      runItem({ id: 'historical-answer', content: 'Finished.', timestamp: 2 }),
+    ], false))
+
+    expect(wrapper.find('.run-tool-list').exists()).toBe(false)
+    expect(wrapper.findAll('.run-transcript-item').map(item => item.attributes('data-message-id'))).toEqual([
+      'historical-tool',
+      'historical-answer',
+    ])
+    expect(wrapper.get('.run-transcript').text()).toContain('read_file')
+  })
+})

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -37,6 +37,22 @@ const messagesByRoom: Record<string, unknown[]> = {
     { id: 'alpha-file', roomId: 'room-alpha', senderId: 'agent-1', senderName: 'Worker', content: '[package.json](/tmp/alpha/package.json)', timestamp: 1_790_000_001, role: 'assistant' },
     { id: 'alpha-diff', roomId: 'room-alpha', senderId: 'agent-1', senderName: 'Worker', content: JSON.stringify(groupWorkspaceDiff), timestamp: 1_790_000_002, role: 'tool', tool_name: 'workspace_diff', tool_call_id: 'workspace_diff:alpha' },
     { id: 'alpha-reasoning', roomId: 'room-alpha', senderId: 'agent-1', senderName: 'Worker', content: 'Reasoning is available on demand.', reasoning: 'Inspecting several possible approaches.', isStreaming: true, timestamp: 1_790_000_003, role: 'assistant' },
+    ...Array.from({ length: 12 }, (_, index) => ({
+      id: `alpha-live-tool-${index + 1}`,
+      roomId: 'room-alpha',
+      senderId: 'agent-1',
+      senderName: 'Worker',
+      content: JSON.stringify({ result: `live-${index + 1}` }),
+      timestamp: 1_790_000_010 + index,
+      role: 'tool',
+      run_id: 'run-live-tools',
+      tool_name: `live_tool_${index + 1}`,
+      tool_call_id: `live-call-${index + 1}`,
+      ...(index === 11 ? { isStreaming: true } : {}),
+    })),
+    { id: 'alpha-live-answer', roomId: 'room-alpha', senderId: 'agent-1', senderName: 'Worker', content: 'Live run remains in progress.', timestamp: 1_790_000_030, role: 'assistant', run_id: 'run-live-tools', isStreaming: true },
+    { id: 'alpha-history-tool', roomId: 'room-alpha', senderId: 'agent-1', senderName: 'Worker', content: '{"result":"history"}', timestamp: 1_790_000_040, role: 'tool', run_id: 'run-history-tools', tool_name: 'historical_tool', tool_call_id: 'history-call' },
+    { id: 'alpha-history-answer', roomId: 'room-alpha', senderId: 'agent-1', senderName: 'Worker', content: 'Historical run finished.', timestamp: 1_790_000_041, role: 'assistant', run_id: 'run-history-tools' },
   ],
   'room-beta': [
     { id: 'beta-msg', roomId: 'room-beta', senderId: 'user-1', senderName: 'Bob', content: 'Beta room message', timestamp: 1_790_000_100, role: 'user' },
@@ -317,6 +333,39 @@ test.describe('group chat room deep links', () => {
     await expect(message.locator('.thinking-body')).toHaveCount(0)
     await message.locator('.thinking-header').click()
     await expect(message.locator('.thinking-body')).toContainText('Inspecting several possible approaches.')
+  })
+
+  test('keeps the active Agent run tool list bounded and independently scrollable', async ({ page }) => {
+    await setup(page, '/#/hermes/group-chat/room/room-alpha')
+
+    const panel = page.locator('.run-tool-list[data-agent-id="agent-1"][data-run-id="run-live-tools"]')
+    const outer = page.locator('.group-message-list .virtual-message-list')
+    await expect(panel).toBeVisible()
+    await expect(panel.locator('.tool-message')).toHaveCount(12)
+    await expect(page.locator('.run-tool-list[data-run-id="run-history-tools"]')).toHaveCount(0)
+    await expect(page.locator('.group-agent-run[data-run-id="run-history-tools"] .tool-name')).toContainText('historical_tool')
+
+    const dimensions = await panel.evaluate(element => ({
+      clientHeight: element.clientHeight,
+      scrollHeight: element.scrollHeight,
+    }))
+    expect(dimensions.clientHeight).toBeLessThan(dimensions.scrollHeight)
+    expect(dimensions.clientHeight).toBeLessThanOrEqual(180)
+
+    await panel.hover()
+    await expect.poll(async () => {
+      const first = await outer.evaluate(element => element.scrollTop)
+      await page.waitForTimeout(100)
+      const second = await outer.evaluate(element => element.scrollTop)
+      return second - first
+    }).toBe(0)
+    const outerBefore = await outer.evaluate(element => element.scrollTop)
+    await page.mouse.wheel(0, 120)
+    await expect.poll(() => panel.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+    expect(await outer.evaluate(element => element.scrollTop)).toBe(outerBefore)
+
+    await panel.focus()
+    await expect(panel).toBeFocused()
   })
 
   test('shows a selected room link when browser clipboard APIs cannot copy', async ({ page }) => {


### PR DESCRIPTION
## Summary

- add an Agent/Run-scoped, 180px-bounded tool-call panel for active Group Chat runs
- keep non-tool current-run messages and every completed historical tool trace in the existing transcript
- keep wheel input inside the panel while it has remaining scroll range, then hand scrolling back to the outer message list at the boundary
- make the panel keyboard-focusable and expose stable Agent/Run identity attributes for verification

Closes #2526

## RED → GREEN

- RED component test: the active run had no `.run-tool-list` / `.run-transcript` split (2 failures).
- RED browser reproduction: wheel input over a long active-run tool list moved the outer virtual message list.
- GREEN: the active Run tool calls are isolated in one bounded panel; historical Run tools remain in the transcript; internal wheel scrolling no longer moves the outer list while internal range remains.

## Validation

- `NODE_ENV=test npm run test -- tests/client/group-agent-run-tool-list.test.ts tests/client/group-message-item-highlight.test.ts tests/client/group-message-list-scroll.test.ts tests/client/group-chat-store-streaming.test.ts tests/client/group-chat-panel-workspace-source.test.ts` — PASS, 62 tests
- `npx playwright test tests/e2e/group-chat-room-deeplink.spec.ts --workers=1` — PASS, 19 tests
- `npm run harness:check` — PASS
- `npm run build` — PASS
- `git diff --check` — PASS

## Full-suite status

The focused Issue #2526 coverage is green. Repository-wide suites remain red from pre-existing/environment failures outside this contract:

- `NODE_ENV=test npm run test:coverage` — FAIL: 3910 passed, 3 skipped, 15 failed. Failures include unrelated 5-second timeouts, `/usr/local/lib/hermes-agent` Python/plugin-discovery contamination, a Kanban fixture path failure, and an existing `run-chat-bridge-final-context` assertion failure. The new `group-agent-run-tool-list` tests pass.
- `npm run test:e2e` — FAIL under full parallel execution: 72 passed, 26 failed, 18 did not run, with unrelated pages timing out/not loading. The affected Group Chat file passes independently and serially (19/19).

## Scope

No message protocol, persistence, single-tool result scrolling, merge, packaging, installation, or deployment changes.
