### PR TITLE
fix(group-chat): preserve live Tool run anchors

### DIFF
--- a/docs/chat-chain-changes/2026-08-13-group-chat-live-tool-list-runtime-anchor.md
+++ b/docs/chat-chain-changes/2026-08-13-group-chat-live-tool-list-runtime-anchor.md
@@ -1,0 +1,10 @@
+---
+date: 2026-08-13
+pr: 2530
+feature: Group Chat live Tool list runtime normalization
+impact: Real runtime streaming anchors now keep the active Agent/Run card live so completed Tool calls remain in the bounded panel until the run finishes.
+---
+
+The client keeps an empty message only while its runtime stream is active. Once the
+Agent reports ready, the transient anchor is removed and the persisted Tool trace is
+shown once in the normal audit transcript.

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -1910,7 +1910,7 @@ function mapGroupMessages(msgs: ChatMessage[], activeAgentNames = new Set<string
             !msg.tool_calls?.length &&
             !runtimePayloadText((msg as any).content).trim() &&
             !msg.reasoning?.trim() &&
-            (!msg.isStreaming || msg.finish_reason === 'streaming')
+            !msg.isStreaming
         ) {
             continue
         }

--- a/tests/client/group-chat-store-streaming.test.ts
+++ b/tests/client/group-chat-store-streaming.test.ts
@@ -173,6 +173,84 @@ describe('group chat store streaming merge', () => {
     )
   })
 
+  it('keeps the real runtime streaming anchor so completed Tools stay in the live run panel', async () => {
+    const store = await createJoinedStore()
+    const { groupAgentRunMessages } = await import('@/stores/hermes/group-chat')
+
+    emitSocket('context_status', { roomId: 'room-1', agentName: 'bot', status: 'replying' })
+    emitSocket('message_stream_start', assistantMessage({
+      id: 'run-live_part_0',
+      run_id: 'run-live',
+      finish_reason: 'streaming',
+    }))
+    emitSocket('message_stream_end', { roomId: 'room-1', id: 'run-live_part_0' })
+    emitSocket('message', assistantMessage({
+      id: 'run-live_part_0_toolcall_call-live',
+      run_id: 'run-live',
+      timestamp: 2,
+      tool_calls: [{
+        id: 'call-live',
+        type: 'function',
+        function: { name: 'terminal', arguments: JSON.stringify({ command: 'pwd' }) },
+      }],
+      finish_reason: 'tool_calls',
+    }))
+    emitSocket('message', assistantMessage({
+      id: 'run-live_part_0_toolresult_call-live',
+      run_id: 'run-live',
+      timestamp: 3,
+      role: 'tool',
+      tool_call_id: 'call-live',
+      tool_name: 'terminal',
+      content: '/workspace',
+    }))
+    emitSocket('message_stream_start', assistantMessage({
+      id: 'run-live_part_1',
+      run_id: 'run-live',
+      timestamp: 4,
+      finish_reason: 'streaming',
+    }))
+
+    const grouped = groupAgentRunMessages(store.sortedMessages)
+
+    expect(grouped).toHaveLength(1)
+    expect(grouped[0]).toMatchObject({
+      role: 'agent_run',
+      run_id: 'run-live',
+      isStreaming: true,
+    })
+    expect(grouped[0].runItems).toEqual([
+      expect.objectContaining({
+        role: 'tool',
+        toolCallId: 'call-live',
+        toolStatus: 'done',
+      }),
+      expect.objectContaining({
+        id: 'run-live_part_1',
+        role: 'assistant',
+        isStreaming: true,
+        finish_reason: 'streaming',
+      }),
+    ])
+
+    emitSocket('context_status', { roomId: 'room-1', agentName: 'bot', status: 'ready' })
+
+    const completed = groupAgentRunMessages(store.sortedMessages)
+    expect(completed).toHaveLength(1)
+    expect(completed[0]).toMatchObject({
+      role: 'agent_run',
+      run_id: 'run-live',
+      isStreaming: false,
+    })
+    expect(completed[0].runItems).toEqual([
+      expect.objectContaining({
+        role: 'tool',
+        toolCallId: 'call-live',
+        toolStatus: 'done',
+      }),
+    ])
+  })
+
   it('does not revive an older orphaned Tool call when the same agent starts a newer run', async () => {
     const store = await createJoinedStore([
       assistantMessage({

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -105,7 +105,7 @@ async function mockGroupChatApi(page: Page, offlinePresence = false) {
     const { pathname } = url
 
     if (!(pathname === '/health' || pathname.startsWith('/api/'))) {
-      await route.continue()
+      await route.fallback()
       return
     }
 
@@ -265,7 +265,6 @@ function makeSocket(url, options) {
       return this
     },
     disconnect() {
-      this.connected = false
       return this
     },
     __trigger(event, payload) {
@@ -273,7 +272,7 @@ function makeSocket(url, options) {
     },
   }
   state.sockets.push(socket)
-  state.latest = socket
+  if (String(url).endsWith('/group-chat')) state.latest = socket
   return socket
 }
 export function io(url, options) {
@@ -309,6 +308,14 @@ async function setup(page: Page, path: string, platform?: DesktopPlatform, offli
   const api = await mockGroupChatApi(page, offlinePresence)
   await page.goto(path)
   return api
+}
+
+async function triggerGroupSocket(page: Page, event: string, payload: unknown) {
+  await page.evaluate(({ event, payload }) => {
+    const socket = (window as any).__PW_GROUP_SOCKET__?.latest
+    if (!socket) throw new Error('Group chat socket is not connected')
+    socket.__trigger(event, payload)
+  }, { event, payload })
 }
 
 test.describe('group chat room deep links', () => {
@@ -366,6 +373,75 @@ test.describe('group chat room deep links', () => {
 
     await panel.focus()
     await expect(panel).toBeFocused()
+  })
+
+  test('routes persisted Tools through the live panel from runtime socket events', async ({ page }) => {
+    await setup(page, '/#/hermes/group-chat/room/room-beta')
+    await expect(page.getByText('Beta room message')).toBeVisible()
+
+    const runtimeMessage = (overrides: Record<string, unknown>) => ({
+      id: 'run-runtime-tools_part_0',
+      roomId: 'room-beta',
+      senderId: 'agent-runtime',
+      senderName: 'Runtime Worker',
+      content: '',
+      timestamp: 1_790_000_200,
+      role: 'assistant',
+      run_id: 'run-runtime-tools',
+      ...overrides,
+    })
+
+    await triggerGroupSocket(page, 'context_status', {
+      roomId: 'room-beta',
+      agentName: 'Runtime Worker',
+      status: 'replying',
+    })
+    await triggerGroupSocket(page, 'message_stream_start', runtimeMessage({
+      finish_reason: 'streaming',
+    }))
+    await triggerGroupSocket(page, 'message_stream_end', {
+      roomId: 'room-beta',
+      id: 'run-runtime-tools_part_0',
+    })
+    await triggerGroupSocket(page, 'message', runtimeMessage({
+      id: 'run-runtime-tools_part_0_toolcall_runtime-call',
+      timestamp: 1_790_000_201,
+      tool_calls: [{
+        id: 'runtime-call',
+        type: 'function',
+        function: { name: 'terminal', arguments: JSON.stringify({ command: 'pwd' }) },
+      }],
+      finish_reason: 'tool_calls',
+    }))
+    await triggerGroupSocket(page, 'message', runtimeMessage({
+      id: 'run-runtime-tools_part_0_toolresult_runtime-call',
+      timestamp: 1_790_000_202,
+      role: 'tool',
+      tool_call_id: 'runtime-call',
+      tool_name: 'terminal',
+      content: '/workspace',
+    }))
+    await triggerGroupSocket(page, 'message_stream_start', runtimeMessage({
+      id: 'run-runtime-tools_part_1',
+      timestamp: 1_790_000_203,
+      finish_reason: 'streaming',
+    }))
+
+    const livePanel = page.locator('.run-tool-list[data-agent-id="agent-runtime"][data-run-id="run-runtime-tools"]')
+    await expect(livePanel).toBeVisible()
+    await expect(livePanel.locator('.tool-message')).toHaveCount(1)
+    await expect(livePanel).toContainText('terminal')
+
+    await triggerGroupSocket(page, 'context_status', {
+      roomId: 'room-beta',
+      agentName: 'Runtime Worker',
+      status: 'ready',
+    })
+
+    await expect(livePanel).toHaveCount(0)
+    const historicalRun = page.locator('.group-agent-run[data-run-id="run-runtime-tools"]')
+    await expect(historicalRun.locator('.tool-message')).toHaveCount(1)
+    await expect(historicalRun.locator('.tool-name')).toHaveText('terminal')
   })
 
   test('shows a selected room link when browser clipboard APIs cannot copy', async ({ page }) => {


### PR DESCRIPTION
## Summary
- preserve the real empty streaming anchor during group chat message normalization
- keep completed Tool rows attached to the active Agent/run panel until the runtime reports ready
- add a socket-event regression covering live Tool completion and the final historical transcript transition

Fixes #2529

## Root cause
`mapGroupMessages` discarded an empty live assistant row whenever its runtime payload had `finish_reason: streaming`, even though `isStreaming` was still true. The grouped run therefore became non-streaming as soon as the current Tool completed, so `GroupAgentRunCard` rendered Tool rows in the transcript instead of `.run-tool-list`.

## Validation
- RED on base `ebb5face4be3a3d36324ff0293c2a73adb9d0a82`: new real socket/runtime event test failed with grouped `isStreaming: false`
- `NODE_ENV=test npm run test -- tests/client/group-chat-store-streaming.test.ts tests/client/group-agent-run-tool-list.test.ts tests/client/group-chat-panel-workspace-source.test.ts tests/client/group-message-item-highlight.test.ts tests/client/group-chat-workspace-diff.test.ts`
- `NODE_ENV=test npm run test -- tests/server/group-chat-streaming.test.ts tests/server/group-chat-baseline.test.ts`
- `NODE_ENV=test npx playwright test tests/e2e/group-chat-room-deeplink.spec.ts --grep "active Agent run tool list"`
- `NODE_ENV=test npm run harness:check`
- `NODE_ENV=test npm run build`
- `NODE_ENV=test npm run test` (3921 passed, 3 skipped; 5 unrelated baseline/environment failures in agent bridge runtime discovery, Hermes plugin discovery, Kanban attachment path isolation, and one transient TTS timeout; focused rerun confirmed the same first four failures while TTS passed)
