### PR TITLE
fix(group-chat): keep completed Tool runs bounded

### DIFF
--- a/docs/chat-chain-changes/2026-08-13-group-chat-completed-tool-panel.md
+++ b/docs/chat-chain-changes/2026-08-13-group-chat-completed-tool-panel.md
@@ -1,0 +1,10 @@
+---
+date: 2026-08-13
+pr: 2533
+feature: Group Chat completed Tool panel continuity
+impact: Agent/Run Tool traces stay in the same bounded newest-first panel during streaming, after completion, and after history reload.
+---
+
+The Tool panel remains a view over the existing persisted run messages. Tool entries
+are removed from the ordinary transcript so each audit record renders exactly once,
+without changing the group-chat runtime protocol or persistence model.

--- a/docs/chat-chain-changes/2026-08-13-pr2533-transcript-before-tools.md
+++ b/docs/chat-chain-changes/2026-08-13-pr2533-transcript-before-tools.md
@@ -1,0 +1,10 @@
+---
+date: 2026-08-13
+pr: 2533
+feature: Group Chat Agent run content order
+impact: Agent reasoning, status, and final response content render above the bounded Tool panel for the same Agent/Run.
+---
+
+This follow-up changes only the visual order inside the existing run card. Tool
+entries remain newest-first, independently scrollable, and excluded from the
+ordinary transcript before and after completion or history reload.

--- a/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
@@ -27,13 +27,11 @@ const { t } = useI18n()
 const items = computed(() =>
     props.message.runItems?.length ? props.message.runItems : [props.message]
 )
-const currentRunToolItems = computed(() =>
-    props.message.isStreaming
-        ? items.value.filter(item => item.role === 'tool')
-        : []
+const runToolItems = computed(() =>
+    items.value.filter(item => item.role === 'tool').reverse()
 )
 const transcriptItems = computed(() =>
-    currentRunToolItems.value.length > 0
+    runToolItems.value.length > 0
         ? items.value.filter(item => item.role !== 'tool')
         : items.value
 )
@@ -102,7 +100,7 @@ function handleToolListWheel(event: WheelEvent): void {
             </div>
             <div class="run-card" :class="{ streaming: message.isStreaming }">
                 <div
-                    v-if="currentRunToolItems.length"
+                    v-if="runToolItems.length"
                     class="run-tool-list"
                     tabindex="0"
                     role="region"
@@ -112,7 +110,7 @@ function handleToolListWheel(event: WheelEvent): void {
                     @wheel="handleToolListWheel"
                 >
                     <div
-                        v-for="item in currentRunToolItems"
+                        v-for="item in runToolItems"
                         :key="item.id"
                         class="run-tool-item"
                         :data-message-id="item.id"

--- a/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
@@ -99,6 +99,23 @@ function handleToolListWheel(event: WheelEvent): void {
                 <GroupAgentRobotIcon v-if="agentInfo" class="run-agent-icon" />
             </div>
             <div class="run-card" :class="{ streaming: message.isStreaming }">
+                <div v-if="transcriptItems.length" class="run-transcript">
+                    <div
+                        v-for="item in transcriptItems"
+                        :key="item.id"
+                        class="run-transcript-item"
+                        :data-message-id="item.id"
+                    >
+                        <GroupMessageItem
+                            :message="item"
+                            :agents="agents"
+                            :members="members"
+                            :current-user-id="currentUserId"
+                            :allow-speech="props.allowSpeech"
+                            embedded
+                        />
+                    </div>
+                </div>
                 <div
                     v-if="runToolItems.length"
                     class="run-tool-list"
@@ -113,23 +130,6 @@ function handleToolListWheel(event: WheelEvent): void {
                         v-for="item in runToolItems"
                         :key="item.id"
                         class="run-tool-item"
-                        :data-message-id="item.id"
-                    >
-                        <GroupMessageItem
-                            :message="item"
-                            :agents="agents"
-                            :members="members"
-                            :current-user-id="currentUserId"
-                            :allow-speech="props.allowSpeech"
-                            embedded
-                        />
-                    </div>
-                </div>
-                <div v-if="transcriptItems.length" class="run-transcript">
-                    <div
-                        v-for="item in transcriptItems"
-                        :key="item.id"
-                        class="run-transcript-item"
                         :data-message-id="item.id"
                     >
                         <GroupMessageItem
@@ -239,7 +239,7 @@ function handleToolListWheel(event: WheelEvent): void {
     min-width: 0;
 }
 
-.run-tool-list + .run-transcript {
+.run-transcript + .run-tool-list {
     border-top: 1px solid rgba(var(--text-primary-rgb), 0.08);
 }
 

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -1910,7 +1910,7 @@ function mapGroupMessages(msgs: ChatMessage[], activeAgentNames = new Set<string
             !msg.tool_calls?.length &&
             !runtimePayloadText((msg as any).content).trim() &&
             !msg.reasoning?.trim() &&
-            (!msg.isStreaming || msg.finish_reason === 'streaming')
+            !msg.isStreaming
         ) {
             continue
         }

--- a/tests/client/group-agent-run-tool-list.test.ts
+++ b/tests/client/group-agent-run-tool-list.test.ts
@@ -88,8 +88,8 @@ function mountCard(message: ChatMessage) {
   })
 }
 
-describe('GroupAgentRunCard current tool list', () => {
-  it('places only the current active Agent/Run tool calls in one keyboard-focusable bounded panel', () => {
+describe('GroupAgentRunCard tool list', () => {
+  it('places only the current Agent/Run tool calls newest-first in one keyboard-focusable bounded panel', () => {
     const wrapper = mountCard(runMessage([
       runItem({ id: 'current-tool-1', role: 'tool', toolName: 'read_file', toolStatus: 'done' }),
       runItem({ id: 'current-reasoning', content: 'Checking the result.', isStreaming: true, timestamp: 2 }),
@@ -102,24 +102,29 @@ describe('GroupAgentRunCard current tool list', () => {
     expect(panel.attributes('data-agent-id')).toBe('agent-1')
     expect(panel.attributes('data-run-id')).toBe('run-current')
     expect(panel.findAll('.run-tool-item').map(item => item.attributes('data-message-id'))).toEqual([
-      'current-tool-1',
       'current-tool-2',
+      'current-tool-1',
     ])
     expect(wrapper.get('.run-transcript-item').attributes('data-message-id')).toBe('current-reasoning')
     expect(wrapper.get('.run-transcript').find('.tool-name').exists()).toBe(false)
   })
 
-  it('keeps completed historical tool calls in the normal run transcript without a second panel', () => {
+  it('keeps completed historical tool calls newest-first in the same bounded panel', () => {
     const wrapper = mountCard(runMessage([
-      runItem({ id: 'historical-tool', role: 'tool', toolName: 'read_file', toolStatus: 'done' }),
+      runItem({ id: 'historical-tool-1', role: 'tool', toolName: 'read_file', toolStatus: 'done' }),
       runItem({ id: 'historical-answer', content: 'Finished.', timestamp: 2 }),
+      runItem({ id: 'historical-tool-2', role: 'tool', toolName: 'search', toolStatus: 'done', timestamp: 3 }),
     ], false))
 
-    expect(wrapper.find('.run-tool-list').exists()).toBe(false)
+    expect(wrapper.get('.run-tool-list').findAll('.run-tool-item').map(item => item.attributes('data-message-id'))).toEqual([
+      'historical-tool-2',
+      'historical-tool-1',
+    ])
     expect(wrapper.findAll('.run-transcript-item').map(item => item.attributes('data-message-id'))).toEqual([
-      'historical-tool',
       'historical-answer',
     ])
-    expect(wrapper.get('.run-transcript').text()).toContain('read_file')
+    expect(wrapper.get('.run-transcript').text()).not.toContain('read_file')
+    expect(wrapper.findAll('.run-tool-item[data-message-id="historical-tool-1"]')).toHaveLength(1)
+    expect(wrapper.findAll('.run-tool-item[data-message-id="historical-tool-2"]')).toHaveLength(1)
   })
 })

--- a/tests/client/group-agent-run-tool-list.test.ts
+++ b/tests/client/group-agent-run-tool-list.test.ts
@@ -107,6 +107,8 @@ describe('GroupAgentRunCard tool list', () => {
     ])
     expect(wrapper.get('.run-transcript-item').attributes('data-message-id')).toBe('current-reasoning')
     expect(wrapper.get('.run-transcript').find('.tool-name').exists()).toBe(false)
+    expect(wrapper.get('.run-card').element.children[0]).toBe(wrapper.get('.run-transcript').element)
+    expect(wrapper.get('.run-card').element.children[1]).toBe(panel.element)
   })
 
   it('keeps completed historical tool calls newest-first in the same bounded panel', () => {
@@ -126,5 +128,7 @@ describe('GroupAgentRunCard tool list', () => {
     expect(wrapper.get('.run-transcript').text()).not.toContain('read_file')
     expect(wrapper.findAll('.run-tool-item[data-message-id="historical-tool-1"]')).toHaveLength(1)
     expect(wrapper.findAll('.run-tool-item[data-message-id="historical-tool-2"]')).toHaveLength(1)
+    expect(wrapper.get('.run-card').element.children[0]).toBe(wrapper.get('.run-transcript').element)
+    expect(wrapper.get('.run-card').element.children[1]).toBe(wrapper.get('.run-tool-list').element)
   })
 })

--- a/tests/client/group-chat-store-streaming.test.ts
+++ b/tests/client/group-chat-store-streaming.test.ts
@@ -173,6 +173,82 @@ describe('group chat store streaming merge', () => {
     )
   })
 
+  it('keeps one Agent/Run identity from runtime Tool persistence through completion', async () => {
+    const store = await createJoinedStore()
+    const { groupAgentRunMessages } = await import('@/stores/hermes/group-chat')
+
+    emitSocket('context_status', { roomId: 'room-1', agentName: 'bot', status: 'replying' })
+    emitSocket('message_stream_start', assistantMessage({
+      id: 'run-live_part_0',
+      run_id: 'run-live',
+      finish_reason: 'streaming',
+    }))
+    emitSocket('message_stream_end', { roomId: 'room-1', id: 'run-live_part_0' })
+    emitSocket('message', assistantMessage({
+      id: 'run-live_part_0_toolcall_call-live',
+      run_id: 'run-live',
+      timestamp: 2,
+      tool_calls: [{
+        id: 'call-live',
+        type: 'function',
+        function: { name: 'terminal', arguments: JSON.stringify({ command: 'pwd' }) },
+      }],
+      finish_reason: 'tool_calls',
+    }))
+    emitSocket('message', assistantMessage({
+      id: 'run-live_part_0_toolresult_call-live',
+      run_id: 'run-live',
+      timestamp: 3,
+      role: 'tool',
+      tool_call_id: 'call-live',
+      tool_name: 'terminal',
+      content: '/workspace',
+    }))
+    emitSocket('message_stream_start', assistantMessage({
+      id: 'run-live_part_1',
+      run_id: 'run-live',
+      timestamp: 4,
+      finish_reason: 'streaming',
+    }))
+
+    const live = groupAgentRunMessages(store.sortedMessages)
+    expect(live).toHaveLength(1)
+    expect(live[0]).toMatchObject({
+      role: 'agent_run',
+      run_id: 'run-live',
+      isStreaming: true,
+    })
+    expect(live[0].runItems).toEqual([
+      expect.objectContaining({
+        role: 'tool',
+        toolCallId: 'call-live',
+        toolStatus: 'done',
+      }),
+      expect.objectContaining({
+        id: 'run-live_part_1',
+        role: 'assistant',
+        isStreaming: true,
+      }),
+    ])
+
+    emitSocket('context_status', { roomId: 'room-1', agentName: 'bot', status: 'ready' })
+
+    const completed = groupAgentRunMessages(store.sortedMessages)
+    expect(completed).toHaveLength(1)
+    expect(completed[0]).toMatchObject({
+      role: 'agent_run',
+      run_id: 'run-live',
+      isStreaming: false,
+    })
+    expect(completed[0].runItems).toEqual([
+      expect.objectContaining({
+        role: 'tool',
+        toolCallId: 'call-live',
+        toolStatus: 'done',
+      }),
+    ])
+  })
+
   it('does not revive an older orphaned Tool call when the same agent starts a newer run', async () => {
     const store = await createJoinedStore([
       assistantMessage({

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -81,6 +81,7 @@ const agentsByRoom: Record<string, unknown[]> = {
 
 async function mockGroupChatApi(page: Page, offlinePresence = false) {
   const rooms = baseRooms.map(room => ({ ...room }))
+  let roomMessages = structuredClone(messagesByRoom)
   const inviteCodeUpdates: Array<{ roomId: string, body: unknown }> = []
   const guestAgentPolicyUpdates: Array<{ roomId: string, body: any }> = []
   const roomConfigUpdates: Array<{ roomId: string, body: any }> = []
@@ -105,7 +106,7 @@ async function mockGroupChatApi(page: Page, offlinePresence = false) {
     const { pathname } = url
 
     if (!(pathname === '/health' || pathname.startsWith('/api/'))) {
-      await route.continue()
+      await route.fallback()
       return
     }
 
@@ -218,14 +219,21 @@ async function mockGroupChatApi(page: Page, offlinePresence = false) {
         ? [{ id: 'member-offline', userId: 'user-offline', name: 'Offline Member', description: '', joinedAt: 1_790_000_000, connectionStatus: 'offline' }]
         : [{ id: 'member-1', userId: 'user-1', name: 'User One', description: '', joinedAt: 1_790_000_000 }]
       return room
-        ? json({ room, messages: messagesByRoom[roomId] || [], agents, members, handoffChains: handoffChains.filter(item => item.roomId === roomId) })
+        ? json({ room, messages: roomMessages[roomId] || [], agents, members, handoffChains: handoffChains.filter(item => item.roomId === roomId) })
         : json({ error: 'Room not found' }, 404)
     }
 
     return json({ error: `Unexpected mocked route: ${request.method()} ${pathname}` }, 404)
   })
 
-  return { inviteCodeUpdates, guestAgentPolicyUpdates, roomConfigUpdates }
+  return {
+    inviteCodeUpdates,
+    guestAgentPolicyUpdates,
+    roomConfigUpdates,
+    setRoomMessages(messages: Record<string, unknown[]>) {
+      roomMessages = structuredClone(messages)
+    },
+  }
 }
 
 async function mockGroupChatSocket(page: Page) {
@@ -265,7 +273,6 @@ function makeSocket(url, options) {
       return this
     },
     disconnect() {
-      this.connected = false
       return this
     },
     __trigger(event, payload) {
@@ -273,7 +280,7 @@ function makeSocket(url, options) {
     },
   }
   state.sockets.push(socket)
-  state.latest = socket
+  if (String(url).endsWith('/group-chat')) state.latest = socket
   return socket
 }
 export function io(url, options) {
@@ -311,6 +318,14 @@ async function setup(page: Page, path: string, platform?: DesktopPlatform, offli
   return api
 }
 
+async function triggerGroupSocket(page: Page, event: string, payload: unknown) {
+  await page.evaluate(({ event, payload }) => {
+    const socket = (window as any).__PW_GROUP_SOCKET__?.latest
+    if (!socket) throw new Error('Group chat socket is not connected')
+    socket.__trigger(event, payload)
+  }, { event, payload })
+}
+
 test.describe('group chat room deep links', () => {
   // This file already covers multi-tab behavior explicitly; keeping the deep-link/socket fixture serial
   // avoids local fullyParallel races where early tests see the room list before route-room selection settles.
@@ -342,8 +357,9 @@ test.describe('group chat room deep links', () => {
     const outer = page.locator('.group-message-list .virtual-message-list')
     await expect(panel).toBeVisible()
     await expect(panel.locator('.tool-message')).toHaveCount(12)
-    await expect(page.locator('.run-tool-list[data-run-id="run-history-tools"]')).toHaveCount(0)
-    await expect(page.locator('.group-agent-run[data-run-id="run-history-tools"] .tool-name')).toContainText('historical_tool')
+    const historicalPanel = page.locator('.run-tool-list[data-run-id="run-history-tools"]')
+    await expect(historicalPanel).toBeVisible()
+    await expect(historicalPanel.locator('.tool-name')).toHaveText('historical_tool')
 
     const dimensions = await panel.evaluate(element => ({
       clientHeight: element.clientHeight,
@@ -366,6 +382,115 @@ test.describe('group chat room deep links', () => {
 
     await panel.focus()
     await expect(panel).toBeFocused()
+
+    const toolNames = await panel.locator('.tool-name').allTextContents()
+    expect(toolNames[0]).toBe('live_tool_12')
+    expect(toolNames.at(-1)).toBe('live_tool_1')
+  })
+
+  test('keeps runtime Tools bounded, newest-first, and stable after completion and refresh', async ({ page }) => {
+    const api = await setup(page, '/#/hermes/group-chat/room/room-beta')
+    await expect(page.getByText('Beta room message')).toBeVisible()
+
+    const runtimeMessage = (overrides: Record<string, unknown>) => ({
+      id: 'run-runtime-tools_part_0',
+      roomId: 'room-beta',
+      senderId: 'agent-runtime',
+      senderName: 'Runtime Worker',
+      content: '',
+      timestamp: 1_790_000_200,
+      role: 'assistant',
+      run_id: 'run-runtime-tools',
+      ...overrides,
+    })
+
+    await triggerGroupSocket(page, 'context_status', {
+      roomId: 'room-beta',
+      agentName: 'Runtime Worker',
+      status: 'replying',
+    })
+    await triggerGroupSocket(page, 'message_stream_start', runtimeMessage({
+      finish_reason: 'streaming',
+    }))
+    await triggerGroupSocket(page, 'message_stream_end', {
+      roomId: 'room-beta',
+      id: 'run-runtime-tools_part_0',
+    })
+    for (const [index, toolName] of ['read_file', 'terminal'].entries()) {
+      const callId = `runtime-call-${index + 1}`
+      await triggerGroupSocket(page, 'message', runtimeMessage({
+        id: `run-runtime-tools_part_0_toolcall_${callId}`,
+        timestamp: 1_790_000_201 + index * 2,
+        tool_calls: [{
+          id: callId,
+          type: 'function',
+          function: { name: toolName, arguments: JSON.stringify({ index }) },
+        }],
+        finish_reason: 'tool_calls',
+      }))
+      await triggerGroupSocket(page, 'message', runtimeMessage({
+        id: `run-runtime-tools_part_0_toolresult_${callId}`,
+        timestamp: 1_790_000_202 + index * 2,
+        role: 'tool',
+        tool_call_id: callId,
+        tool_name: toolName,
+        content: `result-${index + 1}`,
+      }))
+    }
+    await triggerGroupSocket(page, 'message_stream_start', runtimeMessage({
+      id: 'run-runtime-tools_part_1',
+      timestamp: 1_790_000_206,
+      finish_reason: 'streaming',
+    }))
+
+    const panel = page.locator('.run-tool-list[data-agent-id="agent-runtime"][data-run-id="run-runtime-tools"]')
+    await expect(panel).toBeVisible()
+    await expect(panel.locator('.tool-name')).toHaveText(['terminal', 'read_file'])
+    await expect(panel.locator('.tool-message')).toHaveCount(2)
+
+    await triggerGroupSocket(page, 'context_status', {
+      roomId: 'room-beta',
+      agentName: 'Runtime Worker',
+      status: 'ready',
+    })
+
+    await expect(panel).toBeVisible()
+    await expect(panel.locator('.tool-name')).toHaveText(['terminal', 'read_file'])
+    await expect(page.locator('.group-agent-run[data-run-id="run-runtime-tools"] .tool-message')).toHaveCount(2)
+
+    api.setRoomMessages({
+      ...messagesByRoom,
+      'room-beta': [
+        ...messagesByRoom['room-beta'],
+        runtimeMessage({
+          id: 'run-runtime-tools_part_0_toolresult_runtime-call-1',
+          timestamp: 1_790_000_202,
+          role: 'tool',
+          tool_call_id: 'runtime-call-1',
+          tool_name: 'read_file',
+          content: 'result-1',
+        }),
+        runtimeMessage({
+          id: 'run-runtime-tools_part_0_toolresult_runtime-call-2',
+          timestamp: 1_790_000_204,
+          role: 'tool',
+          tool_call_id: 'runtime-call-2',
+          tool_name: 'terminal',
+          content: 'result-2',
+        }),
+        runtimeMessage({
+          id: 'run-runtime-tools_part_2',
+          timestamp: 1_790_000_207,
+          content: 'Finished.',
+        }),
+      ],
+    })
+    await page.reload()
+
+    const refreshedPanel = page.locator('.run-tool-list[data-agent-id="agent-runtime"][data-run-id="run-runtime-tools"]')
+    await expect(refreshedPanel).toBeVisible()
+    await expect(refreshedPanel.locator('.tool-name')).toHaveText(['terminal', 'read_file'])
+    await expect(page.locator('.group-agent-run[data-run-id="run-runtime-tools"] .tool-message')).toHaveCount(2)
   })
 
   test('shows a selected room link when browser clipboard APIs cannot copy', async ({ page }) => {

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -360,6 +360,9 @@ test.describe('group chat room deep links', () => {
     const historicalPanel = page.locator('.run-tool-list[data-run-id="run-history-tools"]')
     await expect(historicalPanel).toBeVisible()
     await expect(historicalPanel.locator('.tool-name')).toHaveText('historical_tool')
+    await expect.poll(() => page.locator('.group-agent-run[data-run-id="run-history-tools"] .run-card').evaluate(
+      element => Array.from(element.children, child => child.className),
+    )).toEqual(['run-transcript', 'run-tool-list'])
 
     const dimensions = await panel.evaluate(element => ({
       clientHeight: element.clientHeight,
@@ -491,6 +494,9 @@ test.describe('group chat room deep links', () => {
     await expect(refreshedPanel).toBeVisible()
     await expect(refreshedPanel.locator('.tool-name')).toHaveText(['terminal', 'read_file'])
     await expect(page.locator('.group-agent-run[data-run-id="run-runtime-tools"] .tool-message')).toHaveCount(2)
+    await expect.poll(() => page.locator('.group-agent-run[data-run-id="run-runtime-tools"] .run-card').evaluate(
+      element => Array.from(element.children, child => child.className),
+    )).toEqual(['run-transcript', 'run-tool-list'])
   })
 
   test('shows a selected room link when browser clipboard APIs cannot copy', async ({ page }) => {


### PR DESCRIPTION
## Summary
- keep each Agent/Run Tool trace in the same 180px bounded panel during streaming, after stop/completion, and after history reload
- render Tool entries newest-first to match single chat while removing them from the ordinary transcript so each audit record appears once
- preserve the real runtime streaming anchor and add component, Store, and Browser E2E coverage through completion and refresh

Closes #2532

## Validation
- RED: `npm run test -- tests/client/group-agent-run-tool-list.test.ts` failed 2/2 on Base (oldest-first and no completed panel)
- RED: focused Browser E2E failed on Base because the completed historical panel was absent
- destructive rollback: removing `.reverse()` failed 2/2 ordering assertions
- `npm run test -- tests/client/group-agent-run-tool-list.test.ts tests/client/group-chat-store-streaming.test.ts` (30/30)
- `npx playwright test tests/e2e/group-chat-room-deeplink.spec.ts` (20/20)
- `npm run harness:check`
- `npm run build`
- `npm run test` attempted: 3891 passed, 3 skipped, 52 failed across 26 files due existing environment-dependent baseline failures (including agent bridge Python discovery, kanban attachment fixture path, and installed Hermes plugin inventory); focused changed-area suites pass
- `git diff --check`
