### PR TITLE
fix(group-chat): keep Tools with their owning Agent run

### DIFF
--- a/docs/chat-chain-changes/2026-08-13-issue-2535-group-tool-ownership.md
+++ b/docs/chat-chain-changes/2026-08-13-issue-2535-group-tool-ownership.md
@@ -1,0 +1,10 @@
+---
+date: 2026-08-13
+pr: pending
+feature: Group Chat Agent run Tool ownership
+impact: Persisted Tool traces remain inside their owning Agent run card after the transcript across live, terminal, and refreshed history states.
+---
+
+Agent run grouping now prefers the durable room-Agent record identity over
+transport sender identities. Tool rows remain newest-first in one bounded panel
+after the owning run transcript and before its timestamp.

--- a/docs/chat-chain-changes/2026-08-13-issue-2535-group-tool-ownership.md
+++ b/docs/chat-chain-changes/2026-08-13-issue-2535-group-tool-ownership.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-13
-pr: pending
+pr: 2536
 feature: Group Chat Agent run Tool ownership
 impact: Persisted Tool traces remain inside their owning Agent run card after the transcript across live, terminal, and refreshed history states.
 ---

--- a/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
@@ -27,13 +27,11 @@ const { t } = useI18n()
 const items = computed(() =>
     props.message.runItems?.length ? props.message.runItems : [props.message]
 )
-const currentRunToolItems = computed(() =>
-    props.message.isStreaming
-        ? items.value.filter(item => item.role === 'tool')
-        : []
+const runToolItems = computed(() =>
+    items.value.filter(item => item.role === 'tool').reverse()
 )
 const transcriptItems = computed(() =>
-    currentRunToolItems.value.length > 0
+    runToolItems.value.length > 0
         ? items.value.filter(item => item.role !== 'tool')
         : items.value
 )
@@ -101,20 +99,11 @@ function handleToolListWheel(event: WheelEvent): void {
                 <GroupAgentRobotIcon v-if="agentInfo" class="run-agent-icon" />
             </div>
             <div class="run-card" :class="{ streaming: message.isStreaming }">
-                <div
-                    v-if="currentRunToolItems.length"
-                    class="run-tool-list"
-                    tabindex="0"
-                    role="region"
-                    :aria-label="t('chat.showToolCalls')"
-                    :data-agent-id="stableAgentId"
-                    :data-run-id="message.run_id || undefined"
-                    @wheel="handleToolListWheel"
-                >
+                <div v-if="transcriptItems.length" class="run-transcript">
                     <div
-                        v-for="item in currentRunToolItems"
+                        v-for="item in transcriptItems"
                         :key="item.id"
-                        class="run-tool-item"
+                        class="run-transcript-item"
                         :data-message-id="item.id"
                     >
                         <GroupMessageItem
@@ -127,11 +116,20 @@ function handleToolListWheel(event: WheelEvent): void {
                         />
                     </div>
                 </div>
-                <div v-if="transcriptItems.length" class="run-transcript">
+                <div
+                    v-if="runToolItems.length"
+                    class="run-tool-list"
+                    tabindex="0"
+                    role="region"
+                    :aria-label="t('chat.showToolCalls')"
+                    :data-agent-id="stableAgentId"
+                    :data-run-id="message.run_id || undefined"
+                    @wheel="handleToolListWheel"
+                >
                     <div
-                        v-for="item in transcriptItems"
+                        v-for="item in runToolItems"
                         :key="item.id"
-                        class="run-transcript-item"
+                        class="run-tool-item"
                         :data-message-id="item.id"
                     >
                         <GroupMessageItem
@@ -241,7 +239,7 @@ function handleToolListWheel(event: WheelEvent): void {
     min-width: 0;
 }
 
-.run-tool-list + .run-transcript {
+.run-transcript + .run-tool-list {
     border-top: 1px solid rgba(var(--text-primary-rgb), 0.08);
 }
 

--- a/packages/client/src/stores/hermes/group-chat.ts
+++ b/packages/client/src/stores/hermes/group-chat.ts
@@ -1910,7 +1910,7 @@ function mapGroupMessages(msgs: ChatMessage[], activeAgentNames = new Set<string
             !msg.tool_calls?.length &&
             !runtimePayloadText((msg as any).content).trim() &&
             !msg.reasoning?.trim() &&
-            (!msg.isStreaming || msg.finish_reason === 'streaming')
+            !msg.isStreaming
         ) {
             continue
         }
@@ -2003,7 +2003,8 @@ export function groupAgentRunMessages(messages: ChatMessage[]): ChatMessage[] {
             result.push(message)
             continue
         }
-        const groupKey = `${message.senderId}\u0000${runId}`
+        const ownerId = String(message.senderAgentRecordId || message.senderId || '').trim()
+        const groupKey = `${ownerId}\u0000${runId}`
         const existing = groupedByRun.get(groupKey)
         if (existing) {
             existing.runItems!.push(message)
@@ -2012,7 +2013,7 @@ export function groupAgentRunMessages(messages: ChatMessage[]): ChatMessage[] {
         }
         const grouped: ChatMessage = {
             ...message,
-            id: `group-agent-run:${message.senderId}:${runId}`,
+            id: `group-agent-run:${ownerId}:${runId}`,
             run_id: runId,
             role: 'agent_run',
             content: '',

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -3887,12 +3887,14 @@ export class GroupChatServer {
         if (!member) return
         const id = this.normalizeClientMessageId(data.id)
         if (!id) return
+        const agent = this.storage.getRoomAgentByAgentId(roomId, member.userId)
 
         this.nsp.to(roomId).emit('message_stream_start', {
             id,
             roomId,
             senderId: member.userId,
             senderName: member.name,
+            ...(agent?.id ? { senderAgentRecordId: agent.id } : {}),
             content: '',
             timestamp: data.timestamp || Date.now(),
             run_id: typeof data.run_id === 'string' && data.run_id.trim() ? data.run_id.trim() : null,

--- a/tests/client/group-agent-run-tool-list.test.ts
+++ b/tests/client/group-agent-run-tool-list.test.ts
@@ -88,8 +88,8 @@ function mountCard(message: ChatMessage) {
   })
 }
 
-describe('GroupAgentRunCard current tool list', () => {
-  it('places only the current active Agent/Run tool calls in one keyboard-focusable bounded panel', () => {
+describe('GroupAgentRunCard tool list', () => {
+  it('places the current Agent/Run tool calls newest-first after its transcript', () => {
     const wrapper = mountCard(runMessage([
       runItem({ id: 'current-tool-1', role: 'tool', toolName: 'read_file', toolStatus: 'done' }),
       runItem({ id: 'current-reasoning', content: 'Checking the result.', isStreaming: true, timestamp: 2 }),
@@ -102,24 +102,33 @@ describe('GroupAgentRunCard current tool list', () => {
     expect(panel.attributes('data-agent-id')).toBe('agent-1')
     expect(panel.attributes('data-run-id')).toBe('run-current')
     expect(panel.findAll('.run-tool-item').map(item => item.attributes('data-message-id'))).toEqual([
-      'current-tool-1',
       'current-tool-2',
+      'current-tool-1',
     ])
     expect(wrapper.get('.run-transcript-item').attributes('data-message-id')).toBe('current-reasoning')
     expect(wrapper.get('.run-transcript').find('.tool-name').exists()).toBe(false)
+    expect(wrapper.get('.run-card').element.children[0]).toBe(wrapper.get('.run-transcript').element)
+    expect(wrapper.get('.run-card').element.children[1]).toBe(panel.element)
   })
 
-  it('keeps completed historical tool calls in the normal run transcript without a second panel', () => {
+  it('keeps completed historical tool calls in the same bounded panel after its transcript', () => {
     const wrapper = mountCard(runMessage([
-      runItem({ id: 'historical-tool', role: 'tool', toolName: 'read_file', toolStatus: 'done' }),
+      runItem({ id: 'historical-tool-1', role: 'tool', toolName: 'read_file', toolStatus: 'done' }),
       runItem({ id: 'historical-answer', content: 'Finished.', timestamp: 2 }),
+      runItem({ id: 'historical-tool-2', role: 'tool', toolName: 'search', toolStatus: 'done', timestamp: 3 }),
     ], false))
 
-    expect(wrapper.find('.run-tool-list').exists()).toBe(false)
+    expect(wrapper.get('.run-tool-list').findAll('.run-tool-item').map(item => item.attributes('data-message-id'))).toEqual([
+      'historical-tool-2',
+      'historical-tool-1',
+    ])
     expect(wrapper.findAll('.run-transcript-item').map(item => item.attributes('data-message-id'))).toEqual([
-      'historical-tool',
       'historical-answer',
     ])
-    expect(wrapper.get('.run-transcript').text()).toContain('read_file')
+    expect(wrapper.get('.run-transcript').text()).not.toContain('read_file')
+    expect(wrapper.findAll('.run-tool-item[data-message-id="historical-tool-1"]')).toHaveLength(1)
+    expect(wrapper.findAll('.run-tool-item[data-message-id="historical-tool-2"]')).toHaveLength(1)
+    expect(wrapper.get('.run-card').element.children[0]).toBe(wrapper.get('.run-transcript').element)
+    expect(wrapper.get('.run-card').element.children[1]).toBe(wrapper.get('.run-tool-list').element)
   })
 })

--- a/tests/client/group-chat-store-streaming.test.ts
+++ b/tests/client/group-chat-store-streaming.test.ts
@@ -173,6 +173,56 @@ describe('group chat store streaming merge', () => {
     )
   })
 
+  it('keeps persisted Tools inside the live Agent run when transport sender ids differ', async () => {
+    const store = await createJoinedStore()
+    const { groupAgentRunMessages } = await import('@/stores/hermes/group-chat')
+
+    emitSocket('message_stream_start', assistantMessage({
+      id: 'run-owned_part_0',
+      senderId: 'transport-socket-id',
+      senderAgentRecordId: 'agent-record-1',
+      run_id: 'run-owned',
+      finish_reason: 'streaming',
+    }))
+    emitSocket('message_reasoning_delta', {
+      roomId: 'room-1',
+      id: 'run-owned_part_0',
+      delta: 'Inspecting.',
+    })
+    emitSocket('message', assistantMessage({
+      id: 'run-owned_part_0_toolresult_call-owned',
+      senderId: 'agent-stable-id',
+      senderAgentRecordId: 'agent-record-1',
+      timestamp: 2,
+      run_id: 'run-owned',
+      role: 'tool',
+      tool_call_id: 'call-owned',
+      tool_name: 'read_file',
+      content: 'result',
+    }))
+    emitSocket('message', assistantMessage({
+      id: 'run-owned_part_1',
+      senderId: 'agent-stable-id',
+      senderAgentRecordId: 'agent-record-1',
+      timestamp: 3,
+      run_id: 'run-owned',
+      content: 'Finished.',
+    }))
+
+    const grouped = groupAgentRunMessages(store.sortedMessages)
+    expect(grouped).toHaveLength(1)
+    expect(grouped[0]).toMatchObject({
+      role: 'agent_run',
+      run_id: 'run-owned',
+      senderAgentRecordId: 'agent-record-1',
+    })
+    expect(grouped[0].runItems).toEqual([
+      expect.objectContaining({ id: 'run-owned_part_0', reasoning: 'Inspecting.' }),
+      expect.objectContaining({ role: 'tool', toolCallId: 'call-owned' }),
+      expect.objectContaining({ id: 'run-owned_part_1', content: 'Finished.' }),
+    ])
+  })
+
   it('does not revive an older orphaned Tool call when the same agent starts a newer run', async () => {
     const store = await createJoinedStore([
       assistantMessage({

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -77,10 +77,28 @@ const agentsByRoom: Record<string, unknown[]> = {
       invited: 1,
     },
   ],
+  'room-beta': [
+    {
+      id: 'agent-row-runtime',
+      roomId: 'room-beta',
+      agentId: 'agent-runtime',
+      agent: 'hermes',
+      profile: 'default',
+      provider: 'test-provider',
+      model: 'test-model',
+      apiMode: '',
+      reasoningEffort: '',
+      name: 'Runtime Worker',
+      description: 'Runtime group agent',
+      avatar: '',
+      invited: 1,
+    },
+  ],
 }
 
 async function mockGroupChatApi(page: Page, offlinePresence = false) {
   const rooms = baseRooms.map(room => ({ ...room }))
+  let roomMessages = structuredClone(messagesByRoom)
   const inviteCodeUpdates: Array<{ roomId: string, body: unknown }> = []
   const guestAgentPolicyUpdates: Array<{ roomId: string, body: any }> = []
   const roomConfigUpdates: Array<{ roomId: string, body: any }> = []
@@ -105,7 +123,7 @@ async function mockGroupChatApi(page: Page, offlinePresence = false) {
     const { pathname } = url
 
     if (!(pathname === '/health' || pathname.startsWith('/api/'))) {
-      await route.continue()
+      await route.fallback()
       return
     }
 
@@ -218,14 +236,21 @@ async function mockGroupChatApi(page: Page, offlinePresence = false) {
         ? [{ id: 'member-offline', userId: 'user-offline', name: 'Offline Member', description: '', joinedAt: 1_790_000_000, connectionStatus: 'offline' }]
         : [{ id: 'member-1', userId: 'user-1', name: 'User One', description: '', joinedAt: 1_790_000_000 }]
       return room
-        ? json({ room, messages: messagesByRoom[roomId] || [], agents, members, handoffChains: handoffChains.filter(item => item.roomId === roomId) })
+        ? json({ room, messages: roomMessages[roomId] || [], agents, members, handoffChains: handoffChains.filter(item => item.roomId === roomId) })
         : json({ error: 'Room not found' }, 404)
     }
 
     return json({ error: `Unexpected mocked route: ${request.method()} ${pathname}` }, 404)
   })
 
-  return { inviteCodeUpdates, guestAgentPolicyUpdates, roomConfigUpdates }
+  return {
+    inviteCodeUpdates,
+    guestAgentPolicyUpdates,
+    roomConfigUpdates,
+    setRoomMessages(messages: Record<string, unknown[]>) {
+      roomMessages = structuredClone(messages)
+    },
+  }
 }
 
 async function mockGroupChatSocket(page: Page) {
@@ -265,7 +290,6 @@ function makeSocket(url, options) {
       return this
     },
     disconnect() {
-      this.connected = false
       return this
     },
     __trigger(event, payload) {
@@ -273,7 +297,7 @@ function makeSocket(url, options) {
     },
   }
   state.sockets.push(socket)
-  state.latest = socket
+  if (String(url).endsWith('/group-chat')) state.latest = socket
   return socket
 }
 export function io(url, options) {
@@ -311,6 +335,14 @@ async function setup(page: Page, path: string, platform?: DesktopPlatform, offli
   return api
 }
 
+async function triggerGroupSocket(page: Page, event: string, payload: unknown) {
+  await page.evaluate(({ event, payload }) => {
+    const socket = (window as any).__PW_GROUP_SOCKET__?.latest
+    if (!socket) throw new Error('Group chat socket is not connected')
+    socket.__trigger(event, payload)
+  }, { event, payload })
+}
+
 test.describe('group chat room deep links', () => {
   // This file already covers multi-tab behavior explicitly; keeping the deep-link/socket fixture serial
   // avoids local fullyParallel races where early tests see the room list before route-room selection settles.
@@ -342,8 +374,12 @@ test.describe('group chat room deep links', () => {
     const outer = page.locator('.group-message-list .virtual-message-list')
     await expect(panel).toBeVisible()
     await expect(panel.locator('.tool-message')).toHaveCount(12)
-    await expect(page.locator('.run-tool-list[data-run-id="run-history-tools"]')).toHaveCount(0)
-    await expect(page.locator('.group-agent-run[data-run-id="run-history-tools"] .tool-name')).toContainText('historical_tool')
+    const historicalPanel = page.locator('.run-tool-list[data-run-id="run-history-tools"]')
+    await expect(historicalPanel).toBeVisible()
+    await expect(historicalPanel.locator('.tool-name')).toHaveText('historical_tool')
+    await expect.poll(() => page.locator('.group-agent-run[data-run-id="run-history-tools"] .run-card').evaluate(
+      element => Array.from(element.children, child => child.className),
+    )).toEqual(['run-transcript', 'run-tool-list'])
 
     const dimensions = await panel.evaluate(element => ({
       clientHeight: element.clientHeight,
@@ -366,6 +402,133 @@ test.describe('group chat room deep links', () => {
 
     await panel.focus()
     await expect(panel).toBeFocused()
+
+    const toolNames = await panel.locator('.tool-name').allTextContents()
+    expect(toolNames[0]).toBe('live_tool_12')
+    expect(toolNames.at(-1)).toBe('live_tool_1')
+  })
+
+  test('keeps runtime Tools bounded, newest-first, and stable after completion and refresh', async ({ page }) => {
+    const api = await setup(page, '/#/hermes/group-chat/room/room-beta')
+    await expect(page.getByText('Beta room message')).toBeVisible()
+
+    const runtimeMessage = (overrides: Record<string, unknown>) => ({
+      id: 'run-runtime-tools_part_0',
+      roomId: 'room-beta',
+      senderId: 'agent-runtime',
+      senderAgentRecordId: 'agent-row-runtime',
+      senderName: 'Runtime Worker',
+      content: '',
+      timestamp: 1_790_000_200,
+      role: 'assistant',
+      run_id: 'run-runtime-tools',
+      ...overrides,
+    })
+
+    await triggerGroupSocket(page, 'context_status', {
+      roomId: 'room-beta',
+      agentName: 'Runtime Worker',
+      status: 'replying',
+    })
+    await triggerGroupSocket(page, 'message_stream_start', runtimeMessage({
+      senderId: 'transport-socket-id',
+      finish_reason: 'streaming',
+    }))
+    await triggerGroupSocket(page, 'message_stream_end', {
+      roomId: 'room-beta',
+      id: 'run-runtime-tools_part_0',
+    })
+    for (const [index, toolName] of ['read_file', 'terminal'].entries()) {
+      const callId = `runtime-call-${index + 1}`
+      await triggerGroupSocket(page, 'message', runtimeMessage({
+        id: `run-runtime-tools_part_0_toolcall_${callId}`,
+        timestamp: 1_790_000_201 + index * 2,
+        tool_calls: [{
+          id: callId,
+          type: 'function',
+          function: { name: toolName, arguments: JSON.stringify({ index }) },
+        }],
+        finish_reason: 'tool_calls',
+      }))
+      await triggerGroupSocket(page, 'message', runtimeMessage({
+        id: `run-runtime-tools_part_0_toolresult_${callId}`,
+        timestamp: 1_790_000_202 + index * 2,
+        role: 'tool',
+        tool_call_id: callId,
+        tool_name: toolName,
+        content: `result-${index + 1}`,
+      }))
+    }
+    await triggerGroupSocket(page, 'message_stream_start', runtimeMessage({
+      id: 'run-runtime-tools_part_1',
+      timestamp: 1_790_000_206,
+      finish_reason: 'streaming',
+    }))
+    await triggerGroupSocket(page, 'message_reasoning_delta', {
+      roomId: 'room-beta',
+      id: 'run-runtime-tools_part_1',
+      delta: 'Checking the Tool results.',
+    })
+
+    const runCard = page.locator('.group-agent-run[data-run-id="run-runtime-tools"]')
+    const panel = page.locator('.run-tool-list[data-agent-id="agent-row-runtime"][data-run-id="run-runtime-tools"]')
+    await expect(runCard).toHaveCount(1)
+    await expect(panel).toBeVisible()
+    await expect(panel.locator('.tool-name')).toHaveText(['terminal', 'read_file'])
+    await expect(panel.locator('.tool-message')).toHaveCount(2)
+
+    await triggerGroupSocket(page, 'context_status', {
+      roomId: 'room-beta',
+      agentName: 'Runtime Worker',
+      status: 'ready',
+    })
+
+    await expect(panel).toBeVisible()
+    await expect(panel.locator('.tool-name')).toHaveText(['terminal', 'read_file'])
+    await expect(runCard.locator('.tool-message')).toHaveCount(2)
+    await expect.poll(() => runCard.locator('.run-card').evaluate(
+      element => Array.from(element.children, child => child.className),
+    )).toEqual(['run-transcript', 'run-tool-list'])
+
+    api.setRoomMessages({
+      ...messagesByRoom,
+      'room-beta': [
+        ...messagesByRoom['room-beta'],
+        runtimeMessage({
+          id: 'run-runtime-tools_part_0_toolresult_runtime-call-1',
+          timestamp: 1_790_000_202,
+          role: 'tool',
+          tool_call_id: 'runtime-call-1',
+          tool_name: 'read_file',
+          content: 'result-1',
+        }),
+        runtimeMessage({
+          id: 'run-runtime-tools_part_0_toolresult_runtime-call-2',
+          timestamp: 1_790_000_204,
+          role: 'tool',
+          tool_call_id: 'runtime-call-2',
+          tool_name: 'terminal',
+          content: 'result-2',
+        }),
+        runtimeMessage({
+          id: 'run-runtime-tools_part_2',
+          timestamp: 1_790_000_207,
+          content: 'Finished.',
+        }),
+      ],
+    })
+    await page.reload()
+
+    const refreshedRunCard = page.locator('.group-agent-run[data-run-id="run-runtime-tools"]')
+    const refreshedPanel = page.locator('.run-tool-list[data-agent-id="agent-row-runtime"][data-run-id="run-runtime-tools"]')
+    await expect(refreshedRunCard).toHaveCount(1)
+    await expect(refreshedPanel).toBeVisible()
+    await expect(refreshedPanel.locator('.tool-name')).toHaveText(['terminal', 'read_file'])
+    await expect(refreshedRunCard.locator('.tool-message')).toHaveCount(2)
+    await expect(page.locator('.group-message-list > .tool-message')).toHaveCount(0)
+    await expect.poll(() => refreshedRunCard.locator('.run-card').evaluate(
+      element => Array.from(element.children, child => child.className),
+    )).toEqual(['run-transcript', 'run-tool-list'])
   })
 
   test('shows a selected room link when browser clipboard APIs cannot copy', async ({ page }) => {

--- a/tests/server/group-chat-member-sync.test.ts
+++ b/tests/server/group-chat-member-sync.test.ts
@@ -782,7 +782,12 @@ describe('Group Chat member/agent identity sync', () => {
     expect(updateRoomTotalTokens).not.toHaveBeenCalled()
     expect(roomEmit).toHaveBeenCalledWith('context_status', expect.objectContaining({ roomId: 'room-1', agentName: 'Worker', status: 'replying' }))
     expect(broadcastEmit).not.toHaveBeenCalledWith('room_updated', expect.anything())
-    expect(broadcastEmit).toHaveBeenCalledWith('message_stream_start', expect.objectContaining({ id: 'current-stream', senderName: 'Worker' }))
+    expect(broadcastEmit).toHaveBeenCalledWith('message_stream_start', expect.objectContaining({
+      id: 'current-stream',
+      senderId: 'agent-stable-1',
+      senderAgentRecordId: 'row-1',
+      senderName: 'Worker',
+    }))
   })
 
   it('accepts side-channel events for the persisted non-Hermes runtime session', () => {
@@ -833,7 +838,12 @@ describe('Group Chat member/agent identity sync', () => {
 
     expect(broadcastEmit).toHaveBeenCalledWith(
       'message_stream_start',
-      expect.objectContaining({ id: 'ekko-stream', senderName: 'ekko-agent' }),
+      expect.objectContaining({
+        id: 'ekko-stream',
+        senderId: 'agent-ekko-1',
+        senderAgentRecordId: 'row-ekko-1',
+        senderName: 'ekko-agent',
+      }),
     )
   })
 


### PR DESCRIPTION
## Summary
- keep live and persisted Tool messages grouped by the durable room-Agent record identity plus `run_id`, even when transport sender IDs differ
- emit `senderAgentRecordId` on stream start so the runtime transcript and persisted Tool rows share one owner
- keep Tool rows newest-first in one bounded panel after the transcript and before the timestamp across live, terminal, and refreshed-history states
- add Store/runtime, server, component, and browser regression coverage for ownership, ordering, and no trailing duplicate Tool message

Closes #2535

## Root cause and RED
The run-card grouper used `senderId + run_id`. Runtime stream events and persisted messages can carry different transport/stable `senderId` values for the same room Agent, splitting one run into two cards and leaving the Tool-only card at the end of the message stream.

RED coverage reproduced one `run_id` with different `senderId` values but the same durable `senderAgentRecordId`; the old implementation produced 2 run cards instead of 1. Server coverage also showed stream start omitted the durable Agent record identity.

## Validation
- focused component/Store/server tests: `114/114 PASS`
- relevant Browser E2E: `20/20 PASS`
- `npm run harness:check`: PASS
- `npm run build`: PASS
- `git diff --check`: PASS
- `npm run test`: `3891 PASS / 52 FAIL / 3 SKIP`
  - the 52 failures match the existing cross-test pollution/environment failure set reported on the superseded candidate; all focused tests for this change pass

## Scope
No merge, image/LPK build, installation, deployment, Tag, or Release was performed.
