### PR TITLE
feat(bridge): deliver terminal notify_on_complete completions to Web UI sessions

### DIFF
--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -1097,7 +1097,7 @@ class AgentPool:
                         event = process_registry.completion_queue.get_nowait()
                     except Exception:
                         break
-                    if event.get("type") != "async_delegation" or not owns_event(event):
+                    if event.get("type") not in ("async_delegation", "completion") or not owns_event(event):
                         deferred.append(event)
                         continue
                     claim_id = claim_event_delivery(event, "agent-bridge")
@@ -1105,6 +1105,18 @@ class AgentPool:
                         pending_notification_count += 1
                         deferred.append(event)
                         continue
+                    # Terminal completion events (notify_on_complete) carry no
+                    # delegation_id and claim_event_delivery() returns "" for
+                    # them (only async_delegation events are DB-backed). The
+                    # TypeScript side requires non-empty delegation_id/claim_id
+                    # to route the notification back into the session, so
+                    # synthesize stable tokens keyed by the process session.
+                    if event.get("type") == "completion":
+                        _proc_session = str(event.get("session_id") or "")
+                        if claim_id == "":
+                            claim_id = f"terminal:{_proc_session}:{uuid.uuid4().hex}"
+                        _evt_delegation_id = f"terminal:{_proc_session}"
+                        event["delegation_id"] = _evt_delegation_id
                     delegation_id = str(event.get("delegation_id") or "")
                     with self._lock:
                         suppressed = delegation_id in self._suppressed_background_delegations


### PR DESCRIPTION
## 概述

agent-bridge 的后台轮询（``bridge_pool.py`` 中的 ``background_poll``）只消费共享 ``completion_queue`` 中的 ``async_delegation`` 事件，**静默丢弃了 terminal 的 ``notify_on_complete`` / ``watch_patterns`` 完成事件**（``completion`` 类型）。结果是：在 Web UI 会话中，``terminal(background=true, notify_on_complete=true)`` 的后台进程结束后**完全没有任何通知**——完成事件被取出队列后因类型不符被放回队列，永远无人投递。CLI 和 gateway 会话则一切正常。

## 根本原因

- ``terminal_tool.py`` 在后台进程以 ``notify_on_complete=true`` 退出时，向 ``process_registry.completion_queue`` 写入 ``{"type": "completion", ...}`` 事件
- ``bridge_pool.py`` 的后台轮询循环只转发 ``event.get("type") == "async_delegation"`` 的事件，其余全部 ``deferred``（放回队列）
- 即使被转发，TypeScript 路由（``run-chat/index.ts`` 的 ``scheduleBackgroundNotification``）要求 ``delegation_id`` 和 ``claim_id`` **非空**，而 terminal 完成事件没有这两个字段（``claim_event_delivery()`` 对非 ``async_delegation`` 事件返回 ``""``）

## 改动内容

``packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py``：

1. 后台轮询循环同时接受 ``async_delegation`` **和** ``completion`` 两种事件类型
2. 对 ``completion`` 事件合成稳定的 ``delegation_id``（``terminal:<session_id>``）和 ``claim_id``（``terminal:<session_id>:<uuid>``）令牌，使 TypeScript 路由能将该通知作为自治 run 推回原会话——与 ``delegate_task(background=true)`` 的通知投递语义一致

## 安全性说明

- ``format_process_notification()`` 已支持 ``completion`` 事件（这是它的默认分支，CLI/gateway 都在用）
- ``claim_event_delivery()`` 对 completion 事件返回 ``""``（而非 ``None``），不会触碰任何数据库记录——合成的 claim 仅用于内存路由
- ``complete_completion_delivery()`` / ``release_completion_delivery()`` 对合成的 ``delegation_id`` 只是返回 ``False``（rowcount 为 0），不会崩溃
- ``owns_event()`` 仍然以 ``session_key`` / ``parent_session_id`` 为门槛，只会投递原会话的通知

## 测试计划

- [x] 本地验证：Web UI 会话中执行 ``terminal(command="sleep 5 && echo done", background=true, notify_on_complete=true)`` 现在能弹出完成通知
- [ ] 单元测试 / CI 通过
