### PR TITLE
fix(kanban): let task text pick its own direction

### DIFF
--- a/packages/client/src/components/hermes/kanban/KanbanCreateForm.vue
+++ b/packages/client/src/components/hermes/kanban/KanbanCreateForm.vue
@@ -16,6 +16,11 @@ const { t } = useI18n()
 const message = useMessage()
 const kanbanStore = useKanbanStore()
 
+// Task text is written by people in whatever language they think in, while the
+// UI language is a separate choice. `dir="auto"` lets each field follow its own
+// first strong character, the same way the chat composer already does.
+const autoDirectionInputProps = { dir: 'auto' } as const
+
 const title = ref('')
 const body = ref('')
 const assignee = ref<string | null>(null)
@@ -130,10 +135,10 @@ async function handleSubmit() {
   <NModal :show="true" preset="dialog" :title="t('kanban.createTask')" style="width: 480px;" @close="emit('close')">
     <NForm label-placement="top">
       <NFormItem :label="t('kanban.form.title')">
-        <NInput v-model:value="title" :placeholder="t('kanban.form.titlePlaceholder')" />
+        <NInput v-model:value="title" :input-props="autoDirectionInputProps" :placeholder="t('kanban.form.titlePlaceholder')" />
       </NFormItem>
       <NFormItem :label="t('kanban.form.body')">
-        <NInput v-model:value="body" type="textarea" :rows="3" :placeholder="t('kanban.form.bodyPlaceholder')" />
+        <NInput v-model:value="body" type="textarea" :rows="3" :input-props="autoDirectionInputProps" :placeholder="t('kanban.form.bodyPlaceholder')" />
       </NFormItem>
       <NFormItem :label="t('kanban.form.assignee')">
         <NSelect v-model:value="assignee" :options="assigneeOptions" :placeholder="t('kanban.form.selectAssignee')" clearable />

--- a/packages/client/src/components/hermes/kanban/KanbanTaskCard.vue
+++ b/packages/client/src/components/hermes/kanban/KanbanTaskCard.vue
@@ -52,7 +52,7 @@ const priorityText = computed(() => {
         {{ priorityText }}
       </span>
     </div>
-    <div class="card-title">{{ task.title }}</div>
+    <div class="card-title" dir="auto">{{ task.title }}</div>
     <div class="card-footer">
       <NTooltip v-if="task.assignee" trigger="hover">
         <template #trigger>

--- a/packages/client/src/components/hermes/kanban/KanbanTaskDrawer.vue
+++ b/packages/client/src/components/hermes/kanban/KanbanTaskDrawer.vue
@@ -496,13 +496,13 @@ function handleNavigateTask(taskId: string) {
           <!-- Body -->
           <div v-if="detail.task.body" class="detail-section">
             <div class="section-title">{{ t('kanban.form.body') }}</div>
-            <div class="detail-body">{{ detail.task.body }}</div>
+            <div class="detail-body" dir="auto">{{ detail.task.body }}</div>
           </div>
 
           <!-- Result / Summary -->
           <div v-if="completionSummary" class="detail-section">
             <div class="section-title">{{ t('kanban.detail.result') }}</div>
-            <div class="result-summary" @click="openResultDetail">{{ completionSummary }}</div>
+            <div class="result-summary" dir="auto" @click="openResultDetail">{{ completionSummary }}</div>
           </div>
 
           <!-- Actions for active tasks and the terminal done-to-archived transition -->
@@ -568,7 +568,7 @@ function handleNavigateTask(taskId: string) {
             </div>
             <div v-if="showSessions && sessionResults.length > 0" class="session-list">
               <div v-for="session in sessionResults" :key="session.id" class="session-item" @click="router.push({ name: 'hermes.chat', query: { session: session.id } })">
-                <div class="session-title">{{ session.title || session.id }}</div>
+                <div class="session-title" dir="auto">{{ session.title || session.id }}</div>
                 <div class="session-meta">
                   <span>{{ session.source }}</span>
                   <span>{{ session.model }}</span>

--- a/tests/client/kanban-auto-direction.test.ts
+++ b/tests/client/kanban-auto-direction.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NTag: { template: '<span><slot /></span>' },
+  NTooltip: { template: '<span><slot name="trigger" /><slot /></span>' },
+  useMessage: () => ({ error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() }),
+}))
+
+import KanbanTaskCard from '@/components/hermes/kanban/KanbanTaskCard.vue'
+
+const task = {
+  id: 't_0b1b8324',
+  title: 'عاجل — تحليل التدفق وإضافة فلتر قبل الوكيل',
+  status: 'todo',
+  assignee: 'server-guard',
+  priority: 0,
+  created_at: Math.floor(Date.now() / 1000),
+}
+
+describe('kanban text direction follows the task, not the interface', () => {
+  it('marks the card title so its own text decides the direction', () => {
+    const wrapper = mount(KanbanTaskCard, { props: { task: task as any } })
+    const title = wrapper.find('.card-title')
+
+    expect(title.exists()).toBe(true)
+    // Board columns and their labels stay in the interface direction; only the
+    // text a person wrote is allowed to flip.
+    expect(title.attributes('dir')).toBe('auto')
+  })
+})


### PR DESCRIPTION
Chat already lets each message decide its own direction, so an Arabic reply reads correctly even while the interface is in English. The Kanban board never got that treatment.

On an English board, a right-to-left task title is laid out left-to-right: the line starts on the wrong side and its punctuation ends up stranded at the wrong end. Same for the task body, the completion summary, and linked session titles. Anyone whose agents write in Arabic, Hebrew, Persian or Urdu sees it on every card.

## The change

`dir="auto"` on the four nodes that render text a person or an agent wrote:

- the card title in `KanbanTaskCard.vue`
- the task body, the result summary and linked session titles in `KanbanTaskDrawer.vue`

and on the two free-text inputs in `KanbanCreateForm.vue` (title and body), via `:input-props`, matching how `ProviderFormModal` already passes input attributes.

This is the same first-strong-character rule `MarkdownRenderer.vue` and the chat composer use, so board text now behaves exactly like message text.

Column headers, field labels, status chips and IDs are interface text and deliberately keep following the interface direction — only content written by a person flips.

## Test

`tests/client/kanban-auto-direction.test.ts` mounts a card with an Arabic title and asserts the title node carries `dir="auto"`. I reverted the component and confirmed it fails without the change. The existing direction suites — `markdown-auto-direction`, `i18n-direction`, `rtl-logical-css` — pass unchanged, and `npm run harness:check` and the client typecheck are clean.

No layout, CSS or logic changes; nothing moves for an all-Latin board.
