### PR TITLE
fix: bound group chat tool result payloads

### DIFF
--- a/docs/chat-chain-changes/2026-08-14-pr-2548-group-chat-tool-result-boundary.md
+++ b/docs/chat-chain-changes/2026-08-14-pr-2548-group-chat-tool-result-boundary.md
@@ -1,0 +1,16 @@
+---
+date: 2026-08-14
+pr: 2548
+feature: Bounded Group Chat tool-result delivery
+impact: Group Chat history and live updates now bound ordinary outbound tool results to 1,000 characters while preserving complete persisted and Agent-context data.
+---
+
+Group Chat previously bounded UI history by message count only, so a page or
+room-join response could still contain large Tool result bodies. Historical
+pages and live message broadcasts now reuse the same display-only truncation
+boundary as single-chat resume, including truncation metadata for clients.
+
+The boundary is applied only when messages leave the server. Stored messages
+and the transcript supplied to Agents retain their complete content.
+`workspace_diff` messages remain complete because clients use their structured
+payloads to render file changes.

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -36,6 +36,7 @@ import {
     shouldRouteGroupChatAgentHandoff,
     type GroupChatAgentHandoffPolicy,
 } from './handoff-depth'
+import { buildOutboundToolMessage } from '../run-chat/resume-payload'
 
 // ─── Types ────────────────────────────────────────────────────
 
@@ -69,6 +70,14 @@ interface ChatMessage {
     mentionDepth?: number
     handoffChainId?: string
     agentSessionId?: string
+}
+
+const GROUP_CHAT_FULL_PAYLOAD_TOOL_NAMES = ['workspace_diff'] as const
+
+function buildOutboundGroupMessage(message: ChatMessage): ChatMessage {
+    return buildOutboundToolMessage(message as ChatMessage & Record<string, unknown>, {
+        preserveToolNames: GROUP_CHAT_FULL_PAYLOAD_TOOL_NAMES,
+    }) as ChatMessage
 }
 
 type IncomingGroupChatMessage = Omit<Partial<ChatMessage>, 'content'> & {
@@ -1674,7 +1683,7 @@ class ChatStorage {
         const roomCache = new Map<string, RoomInfo | undefined>()
         return this.compactMessageAgentMetadata(
             page.map(row => this.mapStoredMessageRow(row, agentCache, roomCache)),
-        )
+        ).map(buildOutboundGroupMessage)
     }
 
     getMessagesForContext(roomId: string, cutoff?: GroupMessageCursorCutoff): ChatMessage[] {
@@ -2902,7 +2911,7 @@ export class GroupChatServer {
             this.nsp.to(roomId).emit('context_status', { roomId, agentName, status })
         })
         this.agentClients.setWorkspaceDiffBroadcaster((roomId, msg, totalTokens) => {
-            this.nsp.to(roomId).emit('message', msg)
+            this.nsp.to(roomId).emit('message', buildOutboundGroupMessage(msg))
             this.nsp.to(roomId).emit('room_updated', { roomId, totalTokens })
         })
         // Restore agent connections — call restoreWhenReady() after server is listening.
@@ -3070,7 +3079,7 @@ export class GroupChatServer {
             role: 'assistant',
         }
         const saved = this.storage.saveMessageAndRefreshRoom(message)
-        this.nsp.to(input.roomId).emit('message', saved.message)
+        this.nsp.to(input.roomId).emit('message', buildOutboundGroupMessage(saved.message))
         this.nsp.to(input.roomId).emit('room_updated', {
             roomId: input.roomId,
             totalTokens: saved.totalTokens,
@@ -4078,7 +4087,7 @@ export class GroupChatServer {
         const savedMsg = saved.message
         const totalTokens = saved.totalTokens
 
-        this.nsp.to(roomId).emit('message', savedMsg)
+        this.nsp.to(roomId).emit('message', buildOutboundGroupMessage(savedMsg))
         this.nsp.to(roomId).emit('room_updated', { roomId, totalTokens })
         ack?.({ id: savedMsg.id })
 

--- a/packages/server/src/services/hermes/run-chat/resume-payload.ts
+++ b/packages/server/src/services/hermes/run-chat/resume-payload.ts
@@ -13,6 +13,18 @@ const TRUNCATED_MARKER = '... (truncated)'
 type ResumeMessage = SessionMessage & Record<string, unknown>
 type RunEventRecord = { event: string; data: any }
 
+export type OutboundToolMessage = Record<string, unknown> & {
+  role?: string
+  content?: string
+  display_role?: string | null
+  display_content?: string | null
+  tool_name?: string | null
+}
+
+export interface OutboundToolMessageOptions {
+  preserveToolNames?: readonly string[]
+}
+
 function stringifyLength(value: unknown): number {
   try {
     return JSON.stringify(value, null, 2)?.length || 0
@@ -114,7 +126,7 @@ function truncateToolResult(content: string): string {
 }
 
 function truncateMessageField(
-  target: ResumeMessage,
+  target: OutboundToolMessage,
   field: 'content' | 'display_content',
 ): boolean {
   const content = target[field]
@@ -128,6 +140,29 @@ function truncateMessageField(
 }
 
 /**
+ * Bound one display-only tool message without changing the persisted/runtime
+ * message. Consumers may exempt tool payloads that are fetched and rendered as
+ * first-class data instead of ordinary text (for example workspace diffs).
+ */
+export function buildOutboundToolMessage<T extends OutboundToolMessage>(
+  message: T,
+  options: OutboundToolMessageOptions = {},
+): T {
+  const isToolResult = message.role === 'tool'
+    || message.role === 'moa'
+    || message.display_role === 'tool'
+  if (!isToolResult) return message
+
+  const toolName = typeof message.tool_name === 'string' ? message.tool_name : ''
+  if (toolName && options.preserveToolNames?.includes(toolName)) return message
+
+  const outbound = { ...message } as T
+  const contentTruncated = truncateMessageField(outbound, 'content')
+  const displayContentTruncated = truncateMessageField(outbound, 'display_content')
+  return contentTruncated || displayContentTruncated ? outbound : message
+}
+
+/**
  * Build the display-only message page emitted by `resume`.
  *
  * The session state and persisted history intentionally retain complete tool
@@ -135,17 +170,7 @@ function truncateMessageField(
  * display threshold previously enforced by the Studio client.
  */
 export function buildResumeMessages(messages: SessionMessage[]): SessionMessage[] {
-  return messages.map((message) => {
-    const isToolResult = message.role === 'tool'
-      || message.role === 'moa'
-      || message.display_role === 'tool'
-    if (!isToolResult) return message
-
-    const outbound = { ...message } as ResumeMessage
-    const contentTruncated = truncateMessageField(outbound, 'content')
-    const displayContentTruncated = truncateMessageField(outbound, 'display_content')
-    return contentTruncated || displayContentTruncated ? outbound : message
-  })
+  return messages.map(message => buildOutboundToolMessage(message as ResumeMessage) as SessionMessage)
 }
 
 /**

--- a/tests/server/agent-bridge-manager.test.ts
+++ b/tests/server/agent-bridge-manager.test.ts
@@ -24,6 +24,22 @@ function createMockManagedChild(pid: number): MockManagedChild {
   return child
 }
 
+async function listenOnRandomTcpPort(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    const handleError = (error: Error) => reject(error)
+    server.once('error', handleError)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', handleError)
+      resolve()
+    })
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected the test TCP server to expose a numeric port')
+  }
+  return `tcp://127.0.0.1:${address.port}`
+}
+
 describe('agent bridge manager command resolution', () => {
   const originalEnv = { ...process.env }
   let tempDir = ''
@@ -223,17 +239,12 @@ describe('agent bridge manager command resolution', () => {
   })
 
   it('reports readiness when a fake TCP server answers ping with pong', async () => {
-    const endpoint = `tcp://127.0.0.1:${33000 + (process.pid % 10000)}`
     const server = createServer((socket) => {
       socket.once('data', () => {
         socket.end(`${JSON.stringify({ ok: true, pong: true })}\n`)
       })
     })
-
-    await new Promise<void>((resolve) => {
-      const url = new URL(endpoint)
-      server.listen(Number(url.port), url.hostname, resolve)
-    })
+    const endpoint = await listenOnRandomTcpPort(server)
 
     try {
       const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
@@ -360,7 +371,6 @@ describe('agent bridge manager command resolution', () => {
   })
 
   it('attaches to an already running bridge instead of spawning a replacement', async () => {
-    const endpoint = `tcp://127.0.0.1:${34000 + (process.pid % 10000)}`
     const actions: string[] = []
     const server = createServer((socket) => {
       socket.once('data', (chunk) => {
@@ -369,15 +379,7 @@ describe('agent bridge manager command resolution', () => {
         socket.end(`${JSON.stringify({ ok: true, pong: request.action === 'ping' })}\n`)
       })
     })
-
-    await new Promise<void>((resolve) => {
-      if (endpoint.startsWith('ipc://')) {
-        server.listen(endpoint.slice('ipc://'.length), resolve)
-      } else {
-        const url = new URL(endpoint)
-        server.listen(Number(url.port), url.hostname, resolve)
-      }
-    })
+    const endpoint = await listenOnRandomTcpPort(server)
 
     try {
       const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
@@ -406,7 +408,6 @@ describe('agent bridge manager command resolution', () => {
   })
 
   it('requests shutdown when stopping an attached bridge', async () => {
-    const endpoint = `tcp://127.0.0.1:${35000 + (process.pid % 10000)}`
     const actions: string[] = []
     const server = createServer((socket) => {
       socket.once('data', (chunk) => {
@@ -415,11 +416,7 @@ describe('agent bridge manager command resolution', () => {
         socket.end(`${JSON.stringify({ ok: true, pong: request.action === 'ping' })}\n`)
       })
     })
-
-    await new Promise<void>((resolve) => {
-      const url = new URL(endpoint)
-      server.listen(Number(url.port), url.hostname, resolve)
-    })
+    const endpoint = await listenOnRandomTcpPort(server)
 
     try {
       const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')
@@ -488,7 +485,6 @@ describe('agent bridge manager command resolution', () => {
   })
 
   it('clears stopping after stop completes for an attached bridge', async () => {
-    const endpoint = `tcp://127.0.0.1:${36000 + (process.pid % 10000)}`
     const actions: string[] = []
     const server = createServer((socket) => {
       socket.once('data', (chunk) => {
@@ -502,11 +498,7 @@ describe('agent bridge manager command resolution', () => {
       })
     })
     const serverClosed = new Promise<void>((resolve) => server.once('close', () => resolve()))
-
-    await new Promise<void>((resolve) => {
-      const url = new URL(endpoint)
-      server.listen(Number(url.port), url.hostname, resolve)
-    })
+    const endpoint = await listenOnRandomTcpPort(server)
 
     try {
       const { AgentBridgeManager } = await import('../../packages/server/src/services/hermes/agent-bridge/manager')

--- a/tests/server/group-chat-history-window.test.ts
+++ b/tests/server/group-chat-history-window.test.ts
@@ -120,6 +120,48 @@ describe('group chat history windows', () => {
     )
   })
 
+  it('bounds tool results only in the outbound UI page and retains full group history', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    const completeResult = 'tool-result-'.repeat(400)
+    storage.saveMessageAndRefreshRoom(makeMessage({
+      id: 'tool-result-1',
+      role: 'tool',
+      tool_name: 'read_file',
+      tool_call_id: 'call-1',
+      content: completeResult,
+    }) as any)
+
+    const [outbound] = storage.getRecentMessagesForUI('room-1') as Array<Record<string, any>>
+
+    expect(outbound.content).toHaveLength(1_000)
+    expect(outbound.content_truncated).toBe(true)
+    expect(outbound.content_original_length).toBe(completeResult.length)
+    expect(storage.getMessage('tool-result-1')?.content).toBe(completeResult)
+    expect(storage.getMessagesForContext('room-1')[0]?.content).toBe(completeResult)
+  })
+
+  it('keeps workspace diff payloads complete in the outbound UI page', () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room 1')
+    const completeDiff = JSON.stringify({
+      kind: 'workspace_diff',
+      files: [{ path: 'large.ts', patch: '+'.repeat(4_000) }],
+    })
+    storage.saveMessageAndRefreshRoom(makeMessage({
+      id: 'workspace-diff-1',
+      role: 'tool',
+      tool_name: 'workspace_diff',
+      tool_call_id: 'workspace_diff:run-1',
+      content: completeDiff,
+    }) as any)
+
+    const [outbound] = storage.getRecentMessagesForUI('room-1') as Array<Record<string, any>>
+
+    expect(outbound.content).toBe(completeDiff)
+    expect(outbound.content_truncated).toBeUndefined()
+  })
+
   it('does not split same-timestamp multipart assistant/tool runs across UI page boundaries', () => {
     const storage = groupServer.getStorage()
     storage.saveRoom('room-1', 'Room 1')

--- a/tests/server/run-chat-resume-payload.test.ts
+++ b/tests/server/run-chat-resume-payload.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildOutboundToolMessage,
   buildOutboundRunEvent,
   buildResumeEvents,
   buildResumeMessages,
@@ -120,5 +121,29 @@ describe('buildResumeMessages', () => {
     expect(outbound[0]).not.toBe(stateEvents[0])
     expect(outbound[0].data.output.length).toBe(RESUME_TOOL_RESULT_DISPLAY_LIMIT)
     expect(stateEvents[0].data.output).toBe(completeOutput)
+  })
+
+  it('reuses the display boundary for group-chat tool rows while preserving selected payload tools', () => {
+    const completeResult = 'group-result-'.repeat(400)
+    const persisted = {
+      id: 'group-tool-1',
+      roomId: 'room-1',
+      role: 'tool',
+      tool_name: 'read_file',
+      content: completeResult,
+    }
+
+    const outbound = buildOutboundToolMessage(persisted)
+    const workspaceDiff = buildOutboundToolMessage(
+      { ...persisted, tool_name: 'workspace_diff' },
+      { preserveToolNames: ['workspace_diff'] },
+    )
+
+    expect(outbound).not.toBe(persisted)
+    expect(outbound.content).toHaveLength(RESUME_TOOL_RESULT_DISPLAY_LIMIT)
+    expect(outbound.content_truncated).toBe(true)
+    expect(outbound.content_original_length).toBe(completeResult.length)
+    expect(persisted.content).toBe(completeResult)
+    expect(workspaceDiff.content).toBe(completeResult)
   })
 })


### PR DESCRIPTION
## What changed

- Reuse the single-chat outbound tool-result boundary for Group Chat history pages and live message broadcasts.
- Limit ordinary outbound tool results to 1,000 characters while retaining truncation metadata.
- Keep persisted messages and Agent context complete.
- Preserve workspace_diff payloads so file diff cards remain functional.

## Why

Group Chat limited history by message count, but each tool-result row was still sent in full. A room containing large tool outputs could therefore produce an oversized join/history response and expensive reactive rendering in Studio and the App.

## Impact

Group Chat history, room join, pagination, and real-time tool-result delivery now have the same bounded display behavior as single-chat resume. Storage and model context are unchanged.

## Validation

- npx vitest run tests/server/run-chat-resume-payload.test.ts tests/server/group-chat-history-window.test.ts (66 tests passed)
- npx tsc --noEmit -p packages/server/tsconfig.json
- git diff --check