### PR TITLE
Scope App connections by cloud account

### DIFF
--- a/packages/client/src/api/hermes/app-connections.ts
+++ b/packages/client/src/api/hermes/app-connections.ts
@@ -10,6 +10,7 @@ export interface AppConnection {
   device_model: string
   connection_type: AppConnectionType
   user_id: number
+  cloud_user_id: number
   username: string
   token_expires_at: number
   last_connected_at: number

--- a/packages/client/src/components/hermes/connections/AppConnectionsPanel.vue
+++ b/packages/client/src/components/hermes/connections/AppConnectionsPanel.vue
@@ -145,7 +145,7 @@ const columns = computed<DataTableColumns<AppConnection>>(() => [
 ])
 
 function connectionIdentity(connection: AppConnection): string {
-  return `${connection.device_code}:${connection.connection_type}`
+  return `${connection.device_code}:${connection.connection_type}:${connection.cloud_user_id}`
 }
 
 async function loadConnections(options: { silent?: boolean; detectScanConnection?: boolean } = {}) {

--- a/packages/server/src/controllers/app-connections.ts
+++ b/packages/server/src/controllers/app-connections.ts
@@ -32,13 +32,17 @@ function connectionPayload(now = Math.floor(Date.now() / 1000)) {
     device_model: connection.device_model,
     connection_type: connection.connection_type,
     user_id: connection.user_id,
+    cloud_user_id: connection.cloud_user_id,
     username: findUserById(connection.user_id)?.username || '',
     token_expires_at: connection.token_expires_at,
     last_connected_at: connection.last_connected_at,
     active: connection.revoked_at == null && connection.token_expires_at > now,
     online: connection.connection_type === 'lan'
       ? isLocalAppConnectionOnline(connection.device_code, connection.connection_type)
-      : getAppRelayClient(APP_RELAY_CONNECTION_ID)?.isCloudDeviceOnline(connection.device_code) || false,
+      : getAppRelayClient(APP_RELAY_CONNECTION_ID)?.isCloudDeviceOnline(
+          connection.device_code,
+          connection.cloud_user_id,
+        ) || false,
     created_at: connection.created_at,
     updated_at: connection.updated_at,
   }))
@@ -62,8 +66,13 @@ export async function deleteAppConnectionController(ctx: Context) {
     notified = notifyLocalAppConnectionDeleted(connection.device_code, connection.connection_type)
   } else {
     const client = getAppRelayClient(APP_RELAY_CONNECTION_ID)
-    const revoked = await client?.revokeCloudConnection(connection.device_code) || false
-    if (revoked) markCloudAppConnectionRevocationSynced(connection.device_code)
+    const revoked = await client?.revokeCloudConnection(
+      connection.device_code,
+      connection.cloud_user_id,
+    ) || false
+    if (revoked) {
+      markCloudAppConnectionRevocationSynced(connection.device_code, connection.cloud_user_id)
+    }
     notified = revoked ? 1 : 0
   }
   ctx.body = { success: true, notified }

--- a/packages/server/src/controllers/auth.ts
+++ b/packages/server/src/controllers/auth.ts
@@ -274,6 +274,7 @@ export async function appLogin(ctx: Context) {
   const username = normalizeAppLoginField(body?.username ?? body?.account, 80)
   const rawPassword = typeof body?.password === 'string' ? body.password : ''
   const password = rawPassword.length <= 256 ? rawPassword : ''
+  const requestedCloudUserId = Number(body?.cloud_user_id ?? body?.cloudUserId)
   const passwordCredentialsProvided = Boolean(username && password)
   if (!deviceCode || !deviceName || (!authorizationCode && !passwordCredentialsProvided)) {
     ctx.status = 400
@@ -317,6 +318,14 @@ export async function appLogin(ctx: Context) {
     return
   }
   const connectionType = appConnectionType(ctx)
+  const cloudUserId = connectionType === 'cloud' && Number.isSafeInteger(requestedCloudUserId) && requestedCloudUserId > 0
+    ? requestedCloudUserId
+    : 0
+  if (connectionType === 'cloud' && !cloudUserId) {
+    ctx.status = 400
+    ctx.body = { error: 'cloud_user_id is required for cloud App connections' }
+    return
+  }
   const token = await issueAppJwt(user, deviceCode, connectionType)
   if (authenticatedPasswordIp) recordPasswordSuccess(authenticatedPasswordIp)
   const now = Math.floor(Date.now() / 1000)
@@ -328,6 +337,7 @@ export async function appLogin(ctx: Context) {
     deviceModel,
     connectionType,
     userId: user.id,
+    cloudUserId,
     token,
     tokenExpiresAt,
     now,
@@ -344,6 +354,7 @@ export async function appLogin(ctx: Context) {
       device_brand: connection.device_brand,
       device_model: connection.device_model,
       connection_type: connection.connection_type,
+      cloud_user_id: connection.cloud_user_id,
       token_expires_at: connection.token_expires_at,
     },
   }

--- a/packages/server/src/db/hermes/app-connections-store.ts
+++ b/packages/server/src/db/hermes/app-connections-store.ts
@@ -15,6 +15,7 @@ export interface AppConnectionRecord {
   device_model: string
   connection_type: AppConnectionType
   user_id: number
+  cloud_user_id: number
   token_hash: string
   token_expires_at: number
   last_connected_at: number
@@ -64,6 +65,11 @@ function normalizeConnectionType(value: unknown): AppConnectionType {
   return value === 'cloud' ? 'cloud' : 'lan'
 }
 
+function normalizeCloudUserId(connectionType: AppConnectionType, value: unknown): number {
+  const userId = Number(value)
+  return connectionType === 'cloud' && Number.isSafeInteger(userId) && userId > 0 ? userId : 0
+}
+
 function connectionRowToRecord(row: StoredAppConnectionRow | Record<string, any>): AppConnectionRecord {
   return {
     id: Number(row.id),
@@ -73,6 +79,7 @@ function connectionRowToRecord(row: StoredAppConnectionRow | Record<string, any>
     device_model: String(row.device_model || ''),
     connection_type: normalizeConnectionType(row.connection_type),
     user_id: Number(row.user_id || 0),
+    cloud_user_id: Number(row.cloud_user_id || 0),
     token_hash: String(row.token_hash || ''),
     token_expires_at: Number(row.token_expires_at || 0),
     last_connected_at: Number(row.last_connected_at || 0),
@@ -172,18 +179,24 @@ export function upsertAppConnection(input: {
   deviceModel: string
   connectionType: AppConnectionType
   userId: number
+  cloudUserId?: number
   token: string
   tokenExpiresAt: number
   now?: number
 }): AppConnectionRecord {
   const now = input.now ?? epochSeconds()
   const tokenHash = hashAppCredential(input.token)
+  const cloudUserId = normalizeCloudUserId(input.connectionType, input.cloudUserId)
   const db = getDb()
   if (!db) {
     const rows = jsonGetAll(APP_CONNECTIONS_TABLE)
     const existing = Object.values(rows)
       .map(connectionRowToRecord)
-      .find(record => record.device_code === input.deviceCode && record.connection_type === input.connectionType)
+      .find(record => (
+        record.device_code === input.deviceCode
+        && record.connection_type === input.connectionType
+        && record.cloud_user_id === cloudUserId
+      ))
     const nextId = Math.max(0, ...Object.values(rows).map(value => Number(value.id || 0))) + 1
     const row: AppConnectionRecord = {
       id: existing?.id || nextId,
@@ -193,6 +206,7 @@ export function upsertAppConnection(input: {
       device_model: input.deviceModel,
       connection_type: input.connectionType,
       user_id: input.userId,
+      cloud_user_id: cloudUserId,
       token_hash: tokenHash,
       token_expires_at: input.tokenExpiresAt,
       last_connected_at: now,
@@ -207,10 +221,10 @@ export function upsertAppConnection(input: {
 
   db.prepare(`
     INSERT INTO ${APP_CONNECTIONS_TABLE} (
-      device_code, device_name, device_brand, device_model, connection_type, user_id, token_hash,
+      device_code, device_name, device_brand, device_model, connection_type, user_id, cloud_user_id, token_hash,
       token_expires_at, last_connected_at, revoked_at, created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
-    ON CONFLICT(device_code, connection_type) DO UPDATE SET
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
+    ON CONFLICT(device_code, connection_type, cloud_user_id) DO UPDATE SET
       device_name = excluded.device_name,
       device_brand = excluded.device_brand,
       device_model = excluded.device_model,
@@ -229,6 +243,7 @@ export function upsertAppConnection(input: {
     input.deviceModel,
     input.connectionType,
     input.userId,
+    cloudUserId,
     tokenHash,
     input.tokenExpiresAt,
     now,
@@ -236,8 +251,8 @@ export function upsertAppConnection(input: {
     now,
   )
   const row = db.prepare(
-    `SELECT * FROM ${APP_CONNECTIONS_TABLE} WHERE device_code = ? AND connection_type = ?`,
-  ).get(input.deviceCode, input.connectionType) as unknown as StoredAppConnectionRow
+    `SELECT * FROM ${APP_CONNECTIONS_TABLE} WHERE device_code = ? AND connection_type = ? AND cloud_user_id = ?`,
+  ).get(input.deviceCode, input.connectionType, cloudUserId) as unknown as StoredAppConnectionRow
   return connectionRowToRecord(row)
 }
 
@@ -255,6 +270,51 @@ export function listAppConnections(): AppConnectionRecord[] {
   return rows.map(connectionRowToRecord)
 }
 
+export function assignLegacyCloudAppConnectionUser(deviceCode: string, cloudUserId: number): boolean {
+  const normalizedDeviceCode = String(deviceCode || '').trim()
+  const normalizedCloudUserId = normalizeCloudUserId('cloud', cloudUserId)
+  if (!normalizedDeviceCode || !normalizedCloudUserId) return false
+  const db = getDb()
+  if (!db) {
+    const connections = Object.values(jsonGetAll(APP_CONNECTIONS_TABLE)).map(connectionRowToRecord)
+    if (connections.some(connection => (
+      connection.device_code === normalizedDeviceCode
+      && connection.connection_type === 'cloud'
+      && connection.cloud_user_id === normalizedCloudUserId
+    ))) return false
+    const legacy = connections.find(connection => (
+      connection.device_code === normalizedDeviceCode
+      && connection.connection_type === 'cloud'
+      && connection.cloud_user_id === 0
+      && connection.revoked_at == null
+    ))
+    if (!legacy) return false
+    jsonSet(APP_CONNECTIONS_TABLE, String(legacy.id), {
+      ...legacy,
+      cloud_user_id: normalizedCloudUserId,
+    } as any)
+    return true
+  }
+
+  const exact = db.prepare(`
+    SELECT 1 FROM ${APP_CONNECTIONS_TABLE}
+    WHERE device_code = ? AND connection_type = 'cloud' AND cloud_user_id = ?
+    LIMIT 1
+  `).get(normalizedDeviceCode, normalizedCloudUserId)
+  if (exact) return false
+  const legacy = db.prepare(`
+    SELECT id FROM ${APP_CONNECTIONS_TABLE}
+    WHERE device_code = ? AND connection_type = 'cloud' AND cloud_user_id = 0 AND revoked_at IS NULL
+    LIMIT 1
+  `).get(normalizedDeviceCode) as { id?: number } | undefined
+  if (!legacy?.id) return false
+  const result = db.prepare(`
+    UPDATE ${APP_CONNECTIONS_TABLE} SET cloud_user_id = ?
+    WHERE id = ? AND cloud_user_id = 0
+  `).run(normalizedCloudUserId, legacy.id)
+  return Number(result.changes) === 1
+}
+
 export function getAppConnectionTokenStatus(
   deviceCode: string,
   connectionType: AppConnectionType,
@@ -263,15 +323,17 @@ export function getAppConnectionTokenStatus(
   now = epochSeconds(),
 ): AppConnectionTokenStatus {
   const db = getDb()
-  const row = db
-    ? db.prepare(`SELECT * FROM ${APP_CONNECTIONS_TABLE} WHERE device_code = ? AND connection_type = ?`).get(deviceCode, connectionType)
-    : Object.values(jsonGetAll(APP_CONNECTIONS_TABLE)).find(value => (
+  const rows = db
+    ? db.prepare(`SELECT * FROM ${APP_CONNECTIONS_TABLE} WHERE device_code = ? AND connection_type = ?`).all(deviceCode, connectionType)
+    : Object.values(jsonGetAll(APP_CONNECTIONS_TABLE)).filter(value => (
         String(value.device_code || '') === deviceCode
         && normalizeConnectionType(value.connection_type) === connectionType
       ))
-  if (!row) return 'invalid'
-  const record = connectionRowToRecord(row as Record<string, any>)
-  if (record.user_id !== userId || !hashesEqual(record.token_hash, hashAppCredential(token))) return 'invalid'
+  const tokenHash = hashAppCredential(token)
+  const record = (rows as Record<string, any>[])
+    .map(connectionRowToRecord)
+    .find(candidate => candidate.user_id === userId && hashesEqual(candidate.token_hash, tokenHash))
+  if (!record) return 'invalid'
   if (record.revoked_at != null) return 'revoked'
   if (record.token_expires_at <= now) return 'expired'
   return 'active'
@@ -298,7 +360,7 @@ export function revokeAppConnection(id: number, now = epochSeconds()): AppConnec
     const revoked = {
       ...row,
       revoked_at: now,
-      cloud_revocation_pending: row.connection_type === 'cloud' ? 1 : 0,
+      cloud_revocation_pending: row.connection_type === 'cloud' && row.cloud_user_id > 0 ? 1 : 0,
       updated_at: now,
     }
     jsonSet(APP_CONNECTIONS_TABLE, String(row.id), revoked as any)
@@ -311,13 +373,15 @@ export function revokeAppConnection(id: number, now = epochSeconds()): AppConnec
   if (!row) return null
   db.prepare(`
     UPDATE ${APP_CONNECTIONS_TABLE}
-    SET revoked_at = ?, cloud_revocation_pending = CASE WHEN connection_type = 'cloud' THEN 1 ELSE 0 END, updated_at = ?
+    SET revoked_at = ?, cloud_revocation_pending = CASE
+      WHEN connection_type = 'cloud' AND cloud_user_id > 0 THEN 1 ELSE 0 END, updated_at = ?
     WHERE id = ? AND revoked_at IS NULL
   `).run(now, now, id)
   return {
     ...connectionRowToRecord(row),
     revoked_at: now,
-    cloud_revocation_pending: connectionRowToRecord(row).connection_type === 'cloud' ? 1 : 0,
+    cloud_revocation_pending: connectionRowToRecord(row).connection_type === 'cloud'
+      && connectionRowToRecord(row).cloud_user_id > 0 ? 1 : 0,
     updated_at: now,
   }
 }
@@ -327,24 +391,51 @@ export function hasPendingCloudAppConnectionRevocations(): boolean {
   if (!db) {
     return Object.values(jsonGetAll(APP_CONNECTIONS_TABLE))
       .map(connectionRowToRecord)
-      .some(connection => connection.connection_type === 'cloud' && connection.cloud_revocation_pending === 1)
+      .some(connection => (
+        connection.connection_type === 'cloud'
+        && connection.cloud_revocation_pending === 1
+        && connection.cloud_user_id > 0
+      ))
   }
   const row = db.prepare(`
     SELECT 1 FROM ${APP_CONNECTIONS_TABLE}
-    WHERE connection_type = 'cloud' AND cloud_revocation_pending = 1
+    WHERE connection_type = 'cloud' AND cloud_revocation_pending = 1 AND cloud_user_id > 0
     LIMIT 1
   `).get()
   return Boolean(row)
 }
 
-export function markCloudAppConnectionRevocationSynced(deviceCode: string): void {
+export function listPendingCloudAppConnectionRevocations(): AppConnectionRecord[] {
+  const db = getDb()
+  if (!db) {
+    return Object.values(jsonGetAll(APP_CONNECTIONS_TABLE))
+      .map(connectionRowToRecord)
+      .filter(connection => (
+        connection.connection_type === 'cloud'
+        && connection.cloud_revocation_pending === 1
+        && connection.cloud_user_id > 0
+      ))
+  }
+  const rows = db.prepare(`
+    SELECT * FROM ${APP_CONNECTIONS_TABLE}
+    WHERE connection_type = 'cloud' AND cloud_revocation_pending = 1 AND cloud_user_id > 0
+  `).all() as unknown as StoredAppConnectionRow[]
+  return rows.map(connectionRowToRecord)
+}
+
+export function markCloudAppConnectionRevocationSynced(deviceCode: string, cloudUserId: number): void {
   const normalized = String(deviceCode || '').trim()
-  if (!normalized) return
+  const normalizedCloudUserId = normalizeCloudUserId('cloud', cloudUserId)
+  if (!normalized || !normalizedCloudUserId) return
   const db = getDb()
   if (!db) {
     for (const value of Object.values(jsonGetAll(APP_CONNECTIONS_TABLE))) {
       const connection = connectionRowToRecord(value)
-      if (connection.device_code !== normalized || connection.connection_type !== 'cloud') continue
+      if (
+        connection.device_code !== normalized
+        || connection.connection_type !== 'cloud'
+        || (connection.cloud_user_id !== normalizedCloudUserId && connection.cloud_user_id !== 0)
+      ) continue
       jsonSet(APP_CONNECTIONS_TABLE, String(connection.id), { ...connection, cloud_revocation_pending: 0 } as any)
     }
     return
@@ -352,6 +443,6 @@ export function markCloudAppConnectionRevocationSynced(deviceCode: string): void
   db.prepare(`
     UPDATE ${APP_CONNECTIONS_TABLE}
     SET cloud_revocation_pending = 0
-    WHERE device_code = ? AND connection_type = 'cloud'
-  `).run(normalized)
+    WHERE device_code = ? AND connection_type = 'cloud' AND cloud_user_id IN (0, ?)
+  `).run(normalized, normalizedCloudUserId)
 }

--- a/packages/server/src/db/hermes/schemas.ts
+++ b/packages/server/src/db/hermes/schemas.ts
@@ -497,6 +497,7 @@ export const APP_CONNECTIONS_SCHEMA: Record<string, string> = {
   device_model: "TEXT NOT NULL DEFAULT ''",
   connection_type: "TEXT NOT NULL DEFAULT 'lan'",
   user_id: 'INTEGER NOT NULL',
+  cloud_user_id: 'INTEGER NOT NULL DEFAULT 0',
   token_hash: "TEXT NOT NULL DEFAULT ''",
   token_expires_at: 'INTEGER NOT NULL DEFAULT 0',
   last_connected_at: 'INTEGER NOT NULL DEFAULT 0',
@@ -507,8 +508,9 @@ export const APP_CONNECTIONS_SCHEMA: Record<string, string> = {
 }
 
 export const APP_CONNECTIONS_INDEXES = {
-  uniq_app_connections_device_type: 'CREATE UNIQUE INDEX IF NOT EXISTS uniq_app_connections_device_type ON app_connections(device_code, connection_type)',
+  uniq_app_connections_device_type_cloud_user: 'CREATE UNIQUE INDEX IF NOT EXISTS uniq_app_connections_device_type_cloud_user ON app_connections(device_code, connection_type, cloud_user_id)',
   idx_app_connections_user: 'CREATE INDEX IF NOT EXISTS idx_app_connections_user ON app_connections(user_id)',
+  idx_app_connections_cloud_user: 'CREATE INDEX IF NOT EXISTS idx_app_connections_cloud_user ON app_connections(cloud_user_id)',
   idx_app_connections_updated_at: 'CREATE INDEX IF NOT EXISTS idx_app_connections_updated_at ON app_connections(updated_at)',
 }
 
@@ -1453,6 +1455,13 @@ export function initAllHermesTables(): void {
     syncTable(APP_CONNECTIONS_TABLE, APP_CONNECTIONS_SCHEMA, {
       indexes: APP_CONNECTIONS_INDEXES,
     })
+    db.exec('DROP INDEX IF EXISTS uniq_app_connections_device_type')
+    createIndexes(db, APP_CONNECTIONS_INDEXES)
+    db.exec(`
+      UPDATE ${APP_CONNECTIONS_TABLE}
+      SET cloud_revocation_pending = 0
+      WHERE connection_type = 'cloud' AND cloud_user_id = 0 AND cloud_revocation_pending <> 0
+    `)
     syncTable(APP_AUTHORIZATION_CODES_TABLE, APP_AUTHORIZATION_CODES_SCHEMA, {
       indexes: APP_AUTHORIZATION_CODES_INDEXES,
     })

--- a/packages/server/src/services/app-relay/client.ts
+++ b/packages/server/src/services/app-relay/client.ts
@@ -2,7 +2,9 @@ import { randomUUID } from 'crypto'
 import { io, type Socket } from 'socket.io-client'
 import { config } from '../../config'
 import {
+  assignLegacyCloudAppConnectionUser,
   listAppConnections,
+  listPendingCloudAppConnectionRevocations,
   markCloudAppConnectionRevocationSynced,
 } from '../../db/hermes/app-connections-store'
 import { logger } from '../logger'
@@ -69,6 +71,15 @@ const NON_STREAMING_SUPPRESSED_EVENTS = new Set([
   'thinking.delta',
   'reasoning.available',
 ])
+
+function normalizeCloudUserId(value: unknown): number {
+  const userId = Number(value)
+  return Number.isSafeInteger(userId) && userId > 0 ? userId : 0
+}
+
+function cloudConnectionKey(deviceCode: string, cloudUserId: number): string {
+  return `${deviceCode}\u0000${cloudUserId}`
+}
 
 export interface AppRelayHttpRequest {
   id?: string
@@ -240,7 +251,12 @@ export class AppRelayClient {
     })
     this.socket.on('connection.status', (payload: Record<string, unknown> = {}) => {
       const deviceCode = String(payload.deviceCode || payload.device_code || '').trim()
-      if (deviceCode) this.cloudConnectionOnline.set(deviceCode, Boolean(payload.online))
+      const cloudUserId = normalizeCloudUserId(
+        payload.appUserId || payload.app_user_id || payload.userId || payload.user_id,
+      )
+      if (deviceCode && cloudUserId) {
+        this.cloudConnectionOnline.set(cloudConnectionKey(deviceCode, cloudUserId), Boolean(payload.online))
+      }
     })
     this.socket.on('relay.preconnect.expired', () => {
       this.pendingPreconnections.clear()
@@ -358,13 +374,14 @@ export class AppRelayClient {
     return null
   }
 
-  revokeCloudConnection(deviceCode: string, timeoutMs = 8000): Promise<boolean> {
+  revokeCloudConnection(deviceCode: string, appUserId: number, timeoutMs = 8000): Promise<boolean> {
     const socket = this.socket
-    if (!socket?.connected) return Promise.resolve(false)
+    const cloudUserId = normalizeCloudUserId(appUserId)
+    if (!socket?.connected || !cloudUserId) return Promise.resolve(false)
     return new Promise(resolve => {
       socket.timeout(timeoutMs).emit(
         'connection.revoke',
-        { deviceCode },
+        { deviceCode, appUserId: cloudUserId },
         (error: Error | null, response: Record<string, unknown> = {}) => {
           resolve(!error && response.ok === true)
         },
@@ -372,8 +389,12 @@ export class AppRelayClient {
     })
   }
 
-  isCloudDeviceOnline(deviceCode: string): boolean {
-    return this.cloudConnectionOnline.get(deviceCode) || false
+  isCloudDeviceOnline(deviceCode: string, appUserId: number): boolean {
+    const cloudUserId = normalizeCloudUserId(appUserId)
+    if (cloudUserId) return this.cloudConnectionOnline.get(cloudConnectionKey(deviceCode, cloudUserId)) || false
+    const prefix = `${deviceCode}\u0000`
+    return [...this.cloudConnectionOnline.entries()]
+      .some(([key, online]) => key.startsWith(prefix) && online)
   }
 
   waitForConnected(timeoutMs = 5000): Promise<boolean> {
@@ -564,11 +585,15 @@ export class AppRelayClient {
     const preconnectId = String(request.preconnectId || request.preconnect_id || '').trim()
     const matchingCode = String(request.matchingCode || request.matching_code || '').trim()
     const pending = this.pendingPreconnections.get(preconnectId)
+    const cloudUserId = normalizeCloudUserId(
+      request.appUserId || request.app_user_id || request.userId || request.user_id,
+    )
     if (
       !pending
       || pending.preconnection.expiresAt <= Math.floor(Date.now() / 1000)
       || pending.preconnection.matchingCode !== matchingCode
     ) return { ok: false, error: 'studio_preconnection_not_found' }
+    if (!cloudUserId) return { ok: false, error: 'app_user_id_required' }
 
     const response = await this.handleHttpRequest({
       id: `cloud-login-${preconnectId}`,
@@ -581,6 +606,7 @@ export class AppRelayClient {
         device_name: request.deviceName || request.device_name,
         device_brand: request.deviceBrand || request.device_brand,
         device_model: request.deviceModel || request.device_model,
+        cloud_user_id: cloudUserId,
       },
     })
     if (Number(response.status) < 200 || Number(response.status) >= 300 || typeof response.body !== 'string') {
@@ -617,25 +643,69 @@ export class AppRelayClient {
       if (!item || typeof item !== 'object' || Array.isArray(item)) continue
       const connection = item as Record<string, unknown>
       const deviceCode = String(connection.deviceCode || connection.device_code || '').trim()
-      if (deviceCode) this.cloudConnectionOnline.set(deviceCode, Boolean(connection.online))
+      const cloudUserId = normalizeCloudUserId(
+        connection.appUserId || connection.app_user_id || connection.userId || connection.user_id,
+      )
+      if (deviceCode && cloudUserId) {
+        this.cloudConnectionOnline.set(cloudConnectionKey(deviceCode, cloudUserId), Boolean(connection.online))
+      }
     }
   }
 
   private async reconcileConnectionSnapshot(payload: Record<string, unknown>): Promise<void> {
-    const localDeviceCodes = new Set(
-      listAppConnections()
-        .filter(connection => connection.connection_type === 'cloud')
-        .map(connection => connection.device_code),
-    )
     const connections = Array.isArray(payload.connections) ? payload.connections : []
+    const remoteAccountsByDevice = new Map<string, Set<number>>()
     for (const item of connections) {
       if (!item || typeof item !== 'object' || Array.isArray(item)) continue
       const connection = item as Record<string, unknown>
       const deviceCode = String(connection.deviceCode || connection.device_code || '').trim()
-      if (!deviceCode || localDeviceCodes.has(deviceCode)) continue
-      if (await this.revokeCloudConnection(deviceCode)) {
-        markCloudAppConnectionRevocationSynced(deviceCode)
-        this.cloudConnectionOnline.delete(deviceCode)
+      const cloudUserId = normalizeCloudUserId(
+        connection.appUserId || connection.app_user_id || connection.userId || connection.user_id,
+      )
+      if (!deviceCode || !cloudUserId) continue
+      const accounts = remoteAccountsByDevice.get(deviceCode) || new Set<number>()
+      accounts.add(cloudUserId)
+      remoteAccountsByDevice.set(deviceCode, accounts)
+    }
+    for (const [deviceCode, accountIds] of remoteAccountsByDevice) {
+      if (accountIds.size === 1) {
+        assignLegacyCloudAppConnectionUser(deviceCode, [...accountIds][0])
+      }
+    }
+
+    const localConnections = listAppConnections()
+      .filter(connection => connection.connection_type === 'cloud')
+    const localConnectionKeys = new Set(
+      localConnections
+        .filter(connection => connection.cloud_user_id > 0)
+        .map(connection => cloudConnectionKey(connection.device_code, connection.cloud_user_id)),
+    )
+    const legacyDeviceCodes = new Set(
+      localConnections
+        .filter(connection => connection.cloud_user_id === 0)
+        .map(connection => connection.device_code),
+    )
+    const pendingRevocationKeys = new Set(
+      listPendingCloudAppConnectionRevocations()
+        .map(connection => cloudConnectionKey(connection.device_code, connection.cloud_user_id)),
+    )
+    for (const item of connections) {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) continue
+      const connection = item as Record<string, unknown>
+      const deviceCode = String(connection.deviceCode || connection.device_code || '').trim()
+      const cloudUserId = normalizeCloudUserId(
+        connection.appUserId || connection.app_user_id || connection.userId || connection.user_id,
+      )
+      if (
+        !deviceCode
+        || !cloudUserId
+        || localConnectionKeys.has(cloudConnectionKey(deviceCode, cloudUserId))
+        || legacyDeviceCodes.has(deviceCode)
+        || !pendingRevocationKeys.has(cloudConnectionKey(deviceCode, cloudUserId))
+      ) continue
+      if (await this.revokeCloudConnection(deviceCode, cloudUserId)) {
+        markCloudAppConnectionRevocationSynced(deviceCode, cloudUserId)
+        this.cloudConnectionOnline.delete(cloudConnectionKey(deviceCode, cloudUserId))
       }
     }
   }

--- a/tests/server/app-connections-auth.test.ts
+++ b/tests/server/app-connections-auth.test.ts
@@ -86,6 +86,7 @@ describe('App connection authorization', () => {
           device_name: 'Alice iPhone',
           device_brand: 'Apple',
           device_model: 'iPhone 17,1',
+          cloud_user_id: 7001,
         },
       },
       get: vi.fn((name: string) => name.toLowerCase() === 'x-hermes-app-connection' ? 'cloud' : ''),
@@ -115,6 +116,7 @@ describe('App connection authorization', () => {
         device_model: 'iPhone 17,1',
         connection_type: 'cloud',
         user_id: admin.id,
+        cloud_user_id: 7001,
       }),
     ])
 
@@ -166,6 +168,7 @@ describe('App connection authorization', () => {
             device_name: deviceName,
             device_brand: 'Apple',
             device_model: 'iPhone 17,1',
+            cloud_user_id: connectionType === 'cloud' ? 7001 : undefined,
           },
         },
         get: vi.fn((name: string) => name.toLowerCase() === 'x-hermes-app-connection' ? connectionType : ''),
@@ -187,7 +190,12 @@ describe('App connection authorization', () => {
     expect(connections).toHaveLength(2)
     expect(connections).toEqual(expect.arrayContaining([
       expect.objectContaining({ device_code: 'phone-001', device_name: 'Alice iPhone 16', connection_type: 'lan' }),
-      expect.objectContaining({ device_code: 'phone-001', device_name: 'Alice iPhone 16', connection_type: 'cloud' }),
+      expect.objectContaining({
+        device_code: 'phone-001',
+        device_name: 'Alice iPhone 16',
+        connection_type: 'cloud',
+        cloud_user_id: 7001,
+      }),
     ]))
     expect(store.isAppConnectionTokenActive('phone-001', 'lan', firstLanToken, admin.id)).toBe(false)
     expect(store.isAppConnectionTokenActive('phone-001', 'lan', latestLanToken, admin.id)).toBe(true)

--- a/tests/server/app-connections-store.test.ts
+++ b/tests/server/app-connections-store.test.ts
@@ -48,7 +48,32 @@ describe('App connections store', () => {
       .toThrow('app_authorization_code_expired')
   })
 
-  it('deduplicates by phone code and connection type and validates each bound token', async () => {
+  it('migrates the legacy global device/type uniqueness to cloud-account uniqueness', async () => {
+    db.exec('DROP INDEX uniq_app_connections_device_type_cloud_user')
+    db.exec('DROP INDEX idx_app_connections_cloud_user')
+    db.exec('ALTER TABLE app_connections DROP COLUMN cloud_user_id')
+    db.exec('CREATE UNIQUE INDEX uniq_app_connections_device_type ON app_connections(device_code, connection_type)')
+    db.prepare(`
+      INSERT INTO app_connections (
+        device_code, device_name, device_brand, device_model, connection_type, user_id,
+        token_hash, token_expires_at, last_connected_at, revoked_at,
+        cloud_revocation_pending, created_at, updated_at
+      ) VALUES ('legacy-phone', 'Legacy Phone', '', '', 'cloud', 7, 'hash', 5000, 3000, NULL, 1, 3000, 3000)
+    `).run()
+
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    initAllHermesTables()
+
+    const columns = db.prepare('PRAGMA table_info(app_connections)').all() as Array<{ name: string }>
+    const indexes = db.prepare('PRAGMA index_list(app_connections)').all() as Array<{ name: string }>
+    expect(columns.map(column => column.name)).toContain('cloud_user_id')
+    expect(indexes.map(index => index.name)).toContain('uniq_app_connections_device_type_cloud_user')
+    expect(indexes.map(index => index.name)).not.toContain('uniq_app_connections_device_type')
+    expect(db.prepare('SELECT cloud_user_id, cloud_revocation_pending FROM app_connections WHERE device_code = ?')
+      .get('legacy-phone')).toMatchObject({ cloud_user_id: 0, cloud_revocation_pending: 0 })
+  })
+
+  it('deduplicates by phone, connection type, and cloud account while validating each token', async () => {
     const store = await import('../../packages/server/src/db/hermes/app-connections-store')
     const first = store.upsertAppConnection({
       deviceCode: 'phone-001',
@@ -94,6 +119,7 @@ describe('App connections store', () => {
       deviceModel: 'iPhone 17,1',
       connectionType: 'cloud',
       userId: 7,
+      cloudUserId: 101,
       token: 'cloud-token',
       tokenExpiresAt: 5_000,
       now: 3_200,
@@ -102,6 +128,23 @@ describe('App connections store', () => {
     expect(store.listAppConnections()).toHaveLength(2)
     expect(store.isAppConnectionTokenActive('phone-001', 'cloud', 'cloud-token', 7, 3_300)).toBe(true)
     expect(store.isAppConnectionTokenActive('phone-001', 'lan', 'cloud-token', 7, 3_300)).toBe(false)
+
+    const secondCloudAccount = store.upsertAppConnection({
+      deviceCode: 'phone-001',
+      deviceName: 'Alice iPhone 16',
+      deviceBrand: 'Apple',
+      deviceModel: 'iPhone 17,1',
+      connectionType: 'cloud',
+      userId: 7,
+      cloudUserId: 202,
+      token: 'second-cloud-token',
+      tokenExpiresAt: 5_000,
+      now: 3_300,
+    })
+    expect(secondCloudAccount.id).not.toBe(cloud.id)
+    expect(store.listAppConnections()).toHaveLength(3)
+    expect(store.isAppConnectionTokenActive('phone-001', 'cloud', 'cloud-token', 7, 3_400)).toBe(true)
+    expect(store.isAppConnectionTokenActive('phone-001', 'cloud', 'second-cloud-token', 7, 3_400)).toBe(true)
   })
 
   it('hides revoked connections while retaining the tombstone for an offline App reconnect', async () => {
@@ -127,5 +170,59 @@ describe('App connections store', () => {
     expect(store.getAppConnectionTokenStatus('phone-offline', 'lan', 'offline-token', 7, 3_300)).toBe('revoked')
     expect(store.isAppConnectionTokenActive('phone-offline', 'lan', 'offline-token', 7, 3_300)).toBe(false)
     expect(store.revokeAppConnection(connection.id, 3_400)).toBeNull()
+  })
+
+  it('queues an exact cloud-account revoke but never guesses an account for a legacy row', async () => {
+    const store = await import('../../packages/server/src/db/hermes/app-connections-store')
+    const exact = store.upsertAppConnection({
+      deviceCode: 'shared-phone',
+      deviceName: 'Shared Phone',
+      deviceBrand: 'Google',
+      deviceModel: 'Pixel',
+      connectionType: 'cloud',
+      userId: 7,
+      cloudUserId: 101,
+      token: 'exact-token',
+      tokenExpiresAt: 5_000,
+      now: 3_000,
+    })
+    const legacy = store.upsertAppConnection({
+      deviceCode: 'legacy-phone',
+      deviceName: 'Legacy Phone',
+      deviceBrand: 'Google',
+      deviceModel: 'Pixel',
+      connectionType: 'cloud',
+      userId: 7,
+      token: 'legacy-token',
+      tokenExpiresAt: 5_000,
+      now: 3_000,
+    })
+
+    expect(store.revokeAppConnection(exact.id, 3_100)).toMatchObject({ cloud_revocation_pending: 1 })
+    expect(store.revokeAppConnection(legacy.id, 3_100)).toMatchObject({ cloud_revocation_pending: 0 })
+    expect(store.listPendingCloudAppConnectionRevocations()).toEqual([
+      expect.objectContaining({ id: exact.id, cloud_user_id: 101 }),
+    ])
+  })
+
+  it('assigns a legacy row only when the relay provides one exact cloud account', async () => {
+    const store = await import('../../packages/server/src/db/hermes/app-connections-store')
+    const legacy = store.upsertAppConnection({
+      deviceCode: 'legacy-phone',
+      deviceName: 'Legacy Phone',
+      deviceBrand: 'Google',
+      deviceModel: 'Pixel',
+      connectionType: 'cloud',
+      userId: 7,
+      token: 'legacy-token',
+      tokenExpiresAt: 5_000,
+      now: 3_000,
+    })
+
+    expect(store.assignLegacyCloudAppConnectionUser('legacy-phone', 101)).toBe(true)
+    expect(store.listAppConnections()).toEqual([
+      expect.objectContaining({ id: legacy.id, cloud_user_id: 101 }),
+    ])
+    expect(store.assignLegacyCloudAppConnectionUser('legacy-phone', 202)).toBe(false)
   })
 })

--- a/tests/server/app-relay-client.test.ts
+++ b/tests/server/app-relay-client.test.ts
@@ -226,6 +226,87 @@ describe('AppRelayClient', () => {
     expect(client.getCachedPreconnection(7, 2600)).toBeNull()
   })
 
+  it('forwards the authenticated cloud account into Studio authorization', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      token: 'studio-token',
+      userId: 1,
+      profiles: ['default'],
+      appConnection: { token_expires_at: 4_000 },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    const { startAppRelayClient } = await import('../../packages/server/src/services/app-relay/client')
+    const client = startAppRelayClient({
+      relayUrl: 'https://relay.example.com',
+      machineId: 'hwui_machine_1234567890',
+      publicKey: 'machine-public-key',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: fetchImpl as any,
+    })!
+    const remote = sockets[0]
+    remote.connected = true
+    remote.timeout.mockImplementation(() => ({
+      emit: (_event: string, _request: Record<string, unknown>, ack: (...args: any[]) => void) => {
+        ack(null, {
+          ok: true,
+          type: 'hermes-studio.app-connection',
+          version: 1,
+          connectionType: 'cloud',
+          machineId: 'hwui_machine_1234567890',
+          preconnectId: '70a0af7c-5977-4dd6-bca5-b8e641170658',
+          matchingCode: 'matching-code-with-enough-entropy',
+          expiresAt: Math.floor(Date.now() / 1000) + 300,
+          hardExpiresAt: Math.floor(Date.now() / 1000) + 900,
+          refreshRemaining: 3,
+        })
+      },
+    }))
+    const preconnection = await client.requestPreconnection('local-authorization-code', false, 8000, 1)
+    const authorizeAck = vi.fn()
+
+    remote.__handlers.get('connection.authorize')({
+      preconnectId: preconnection.preconnectId,
+      matchingCode: preconnection.matchingCode,
+      appUserId: 101,
+      deviceCode: 'shared-phone-code',
+      deviceName: 'Alice Phone',
+    }, authorizeAck)
+
+    await vi.waitFor(() => expect(authorizeAck).toHaveBeenCalledWith(expect.objectContaining({
+      ok: true,
+      studioUserId: 1,
+    })))
+    expect(JSON.parse(String(fetchImpl.mock.calls[0][1]?.body))).toMatchObject({
+      device_code: 'shared-phone-code',
+      cloud_user_id: 101,
+    })
+  })
+
+  it('includes the cloud account when revoking a shared device code', async () => {
+    const { startAppRelayClient } = await import('../../packages/server/src/services/app-relay/client')
+    const client = startAppRelayClient({
+      relayUrl: 'https://relay.example.com',
+      machineId: 'hwui_machine_1234567890',
+      publicKey: 'machine-public-key',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: vi.fn() as any,
+    })!
+    const remote = sockets[0]
+    remote.connected = true
+    const emit = vi.fn((_event: string, _request: Record<string, unknown>, ack: (...args: any[]) => void) => {
+      ack(null, { ok: true })
+    })
+    remote.timeout.mockImplementation(() => ({ emit }))
+
+    await expect(client.revokeCloudConnection('shared-phone-code', 101)).resolves.toBe(true)
+    expect(emit).toHaveBeenCalledWith(
+      'connection.revoke',
+      { deviceCode: 'shared-phone-code', appUserId: 101 },
+      expect.any(Function),
+    )
+  })
+
   it('bridges the full-duplex /chat-run socket without using MCU events', async () => {
     const { startAppRelayClient } = await import('../../packages/server/src/services/app-relay/client')
     startAppRelayClient({


### PR DESCRIPTION
## What changed

- store the authenticated cloud App user ID on each Studio App connection
- scope connection uniqueness, online status, token lookup, and relay revocation by cloud account
- migrate existing SQLite schemas and safely adopt legacy rows only when the relay identifies one unambiguous account
- prevent ambiguous legacy rows from triggering broad cloud revocation

## Why

A physical phone can sign in to multiple App accounts. The previous Studio schema keyed cloud connections only by device code and connection type, so one account could overwrite or ambiguously revoke another account connection.

## Impact

The same phone can connect multiple cloud App accounts to one Studio. Deleting a connection revokes only the selected cloud account. Existing Studio databases migrate automatically at startup.

## Validation

- `npm test`: 477 files passed, 4050 tests passed, 3 skipped
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npx vue-tsc -b`
- targeted App connection authorization, store migration, and relay tests