### PR TITLE
fix(group-chat): fall back interaction responses by runtime

### DIFF
--- a/docs/chat-chain-changes/2026-08-16-group-chat-interaction-runtime-fallback.md
+++ b/docs/chat-chain-changes/2026-08-16-group-chat-interaction-runtime-fallback.md
@@ -1,0 +1,8 @@
+---
+date: 2026-08-16
+pr: pending
+feature: Group Chat interaction runtime fallback
+impact: Pending approval and clarification responses now continue to the owning Runtime when a same-name remote responder reports that it did not handle the request.
+---
+
+A successful remote response still resolves the pending route immediately. Expired or failed remote responses keep their existing terminal error handling and are not delivered twice.

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -4822,8 +4822,11 @@ export class GroupChatServer {
         if (remoteExecutor?.respondApproval) {
             try {
                 const resolved = await remoteExecutor.respondApproval(data.approval_id, data.choice || 'deny')
-                if (resolved) this.takePendingApprovalRoute(routeKey)
-                ack?.({ ok: true, resolved })
+                if (resolved) {
+                    this.takePendingApprovalRoute(routeKey)
+                    ack?.({ ok: true, resolved: true })
+                    return
+                }
             } catch (err: any) {
                 if (isExpiredInteractionError(err?.message || err)) {
                     this.expirePendingAgentInteractions(
@@ -4837,8 +4840,8 @@ export class GroupChatServer {
                     return
                 }
                 ack?.({ error: err.message || 'approval response failed' })
+                return
             }
-            return
         }
         const ekkoResult = pendingRoute.agentSessionId
             ? respondToEkkoToolApproval(
@@ -4956,8 +4959,11 @@ export class GroupChatServer {
         if (remoteExecutor?.respondClarify) {
             try {
                 const resolved = await remoteExecutor.respondClarify(data.clarify_id, response)
-                if (resolved) this.takePendingClarifyRoute(routeKey)
-                ack?.({ ok: true, resolved })
+                if (resolved) {
+                    this.takePendingClarifyRoute(routeKey)
+                    ack?.({ ok: true, resolved: true })
+                    return
+                }
             } catch (err: any) {
                 if (isExpiredInteractionError(err?.message || err)) {
                     this.expirePendingAgentInteractions(
@@ -4971,8 +4977,8 @@ export class GroupChatServer {
                     return
                 }
                 ack?.({ error: err.message || 'clarification response failed' })
+                return
             }
-            return
         }
         const ekkoResult = pendingRoute.agentSessionId
             ? respondToEkkoClarification(pendingRoute.agentSessionId, data.clarify_id, response)

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -598,6 +598,36 @@ describe('group chat approval and context baseline', () => {
     expect(respondApproval).toHaveBeenCalledOnce()
   })
 
+  it('falls back to the Hermes bridge when a remote approval responder does not own the request', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    const respondApproval = vi.fn(async () => false)
+    vi.spyOn(groupServer.agentClients, 'getAgents').mockReturnValue([{
+      name: 'Agent',
+      respondApproval,
+    } as any])
+    const bridgeApproval = vi.spyOn(AgentBridgeClient.prototype, 'approvalRespond')
+      .mockResolvedValue({ resolved: true } as any)
+    const requested = once<any>(human, 'approval.requested')
+
+    agent.emit('approval.requested', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      agentSessionId,
+      approval_id: 'approval-hermes-behind-remote',
+      command: 'touch file',
+      description: 'needs approval',
+    })
+    await expect(requested).resolves.toMatchObject({ approval_id: 'approval-hermes-behind-remote' })
+
+    await expect(emitAck(human, 'approval.respond', {
+      roomId: 'room-1',
+      approval_id: 'approval-hermes-behind-remote',
+      choice: 'once',
+    })).resolves.toEqual({ ok: true, resolved: true })
+    expect(respondApproval).toHaveBeenCalledWith('approval-hermes-behind-remote', 'once')
+    expect(bridgeApproval).toHaveBeenCalledWith('approval-hermes-behind-remote', 'once')
+  })
+
   it('routes a remote clarification response and removes its locator', async () => {
     const { agent, human, agentSessionId } = await joinPair()
     const respondClarify = vi.fn(async () => true)
@@ -629,6 +659,37 @@ describe('group chat approval and context baseline', () => {
       response: 'production',
     })).resolves.toEqual({ error: 'Clarification is not pending in this room' })
     expect(respondClarify).toHaveBeenCalledWith('clarify-remote-once', 'staging')
+  })
+
+  it('falls back to the Hermes bridge when a remote clarification responder does not own the request', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    const respondClarify = vi.fn(async () => false)
+    vi.spyOn(groupServer.agentClients, 'getAgents').mockReturnValue([{
+      name: 'Agent',
+      respondClarify,
+    } as any])
+    const bridgeClarify = vi.spyOn(AgentBridgeClient.prototype, 'clarifyRespond')
+      .mockResolvedValue({ resolved: true } as any)
+    const requested = once<any>(human, 'clarify.requested')
+
+    agent.emit('clarify.requested', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      agentSessionId,
+      clarify_id: 'clarify-hermes-behind-remote',
+      question: 'Continue?',
+      choices: ['yes', 'no'],
+      timeout_ms: 300_000,
+    })
+    await expect(requested).resolves.toMatchObject({ clarify_id: 'clarify-hermes-behind-remote' })
+
+    await expect(emitAck(human, 'clarify.respond', {
+      roomId: 'room-1',
+      clarify_id: 'clarify-hermes-behind-remote',
+      response: 'yes',
+    })).resolves.toEqual({ ok: true, resolved: true })
+    expect(respondClarify).toHaveBeenCalledWith('clarify-hermes-behind-remote', 'yes')
+    expect(bridgeClarify).toHaveBeenCalledWith('clarify-hermes-behind-remote', 'yes')
   })
 
   it('expires stale pending interactions and tells the browser to close them', async () => {


### PR DESCRIPTION
## Root cause
Group Chat selected a same-name remote/Coding Agent responder based only on method presence. When that responder returned `false` because it did not own the pending interaction, the handler still acknowledged and returned, preventing the owning Ekko/Hermes runtime fallback from receiving the response.

## Fix
- Treat remote `true` as handled and preserve immediate resolution.
- Treat remote `false` as not handled and continue through the existing runtime-specific fallback.
- Preserve expired/error behavior as terminal so failed requests are not delivered twice.
- Cover both `approval.respond` and `clarify.respond`.

## Validation
- RED: focused test produced 2 failures (`resolved: false` instead of bridge fallback).
- GREEN: `node node_modules/.bin/vitest run tests/server/group-chat-approval.test.ts` — 28 passed.
- Sabotage: reverting only production changes restored exactly 2 failures; restoring the fix returned 28 passed.
- `npm run harness:check` — passed.
- `npm run build` — passed (existing chunk-size warning only).
- `git diff --check` — passed.

## Identity
- Base: `af9129a72e9627481675edb743bed84940451a40`
- Head: `2d7f173bc78f55c9d0690a8ed62eb05e3d453d79`

No merge, deployment, installation, or release is included.
