### PR TITLE
fix(group-chat): allow cross-device queued retraction

### DIFF
--- a/docs/chat-chain-changes/2026-08-16-group-chat-cross-device-retraction.md
+++ b/docs/chat-chain-changes/2026-08-16-group-chat-cross-device-retraction.md
@@ -1,0 +1,8 @@
+---
+date: 2026-08-16
+pr: pending
+feature: Cross-device queued message retraction
+impact: An authenticated account can retract its own still-queued Group Chat message from another device without sharing a browser-local capability.
+---
+
+Unauthenticated members still require the original per-device capability, and a different authenticated account cannot retract the message even if it has that capability.

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -2310,12 +2310,14 @@ export class AgentClients {
         queueId: string,
         requesterMemberId: string,
         cancelCapabilityHash: string,
+        allowAuthenticatedAccountOwnership = false,
     ): { messageId: string; queueIds: string[]; messageCount: number; totalTokens: number; lastActiveAt: number } | null {
         const retracted = this._storage?.retractQueuedMessage?.(
             roomId,
             queueId,
             requesterMemberId,
             cancelCapabilityHash,
+            allowAuthenticatedAccountOwnership,
         )
         if (!retracted) return null
         const queueIds = new Set<string>(retracted.queueIds)

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -2299,9 +2299,10 @@ class ChatStorage {
         queueId: string,
         requesterMemberId: string,
         cancelCapabilityHash: string,
+        allowAuthenticatedAccountOwnership = false,
     ): RetractedQueuedMessage | null {
         const db = this.db()
-        if (!db || !requesterMemberId || !cancelCapabilityHash) return null
+        if (!db || !requesterMemberId || (!cancelCapabilityHash && !allowAuthenticatedAccountOwnership)) return null
         return this.withImmediateTransaction(db, () => {
             const selected = db.prepare(
                 'SELECT * FROM gc_execution_queue WHERE id = ? AND roomId = ?',
@@ -2320,7 +2321,8 @@ class ChatStorage {
                 || siblings.some(item => (
                     item.status !== 'queued'
                     || item.requesterMemberId !== requesterMemberId
-                    || !executionQueueCapabilityMatches(item.cancelCapabilityHash, cancelCapabilityHash)
+                    || (!allowAuthenticatedAccountOwnership
+                        && !executionQueueCapabilityMatches(item.cancelCapabilityHash, cancelCapabilityHash))
                 ))) {
                 return null
             }
@@ -4653,18 +4655,22 @@ export class GroupChatServer {
         const queueId = typeof data?.queueId === 'string' ? data.queueId.trim() : ''
         const cancelCapabilityHash = executionQueueCapabilityHash(data?.executionQueueCapability)
         const joined = roomId ? this.getOnlineRoomMember(socket, roomId) : null
-        if (!roomId || !queueId || !cancelCapabilityHash || !joined || joined.member.source !== 'human') {
+        if (!roomId || !queueId || !joined || joined.member.source !== 'human') {
             ack?.({ error: 'Access denied' })
             return
         }
+        const authUser = socket.data?.authUser as AuthenticatedUser | undefined
+        const authenticatedRequesterMemberId = typeof authUser?.id === 'number'
+            ? authenticatedGroupUserId(authUser.id)
+            : ''
+        const accountOwnsItem = Boolean(authenticatedRequesterMemberId)
+            && authenticatedRequesterMemberId === joined.member.userId
         const item = this.storage.getExecutionQueueItem(queueId)
         if (!item
             || item.roomId !== roomId
-            || !executionQueueCapabilityMatches(item.cancelCapabilityHash, cancelCapabilityHash)) {
-            ack?.({ error: 'Access denied' })
-            return
-        }
-        if (item.requesterMemberId !== joined.member.userId) {
+            || (item.requesterMemberId !== joined.member.userId)
+            || (!accountOwnsItem
+                && !executionQueueCapabilityMatches(item.cancelCapabilityHash, cancelCapabilityHash))) {
             ack?.({ error: 'Access denied' })
             return
         }
@@ -4673,6 +4679,7 @@ export class GroupChatServer {
             queueId,
             joined.member.userId,
             cancelCapabilityHash,
+            accountOwnsItem,
         )
         if (!retracted) {
             ack?.({ error: 'Queue item is no longer cancellable', status: this.storage.getExecutionQueueItem(queueId)?.status })

--- a/tests/server/group-chat-execution-queue.test.ts
+++ b/tests/server/group-chat-execution-queue.test.ts
@@ -140,6 +140,73 @@ describe('group chat authoritative execution queue', () => {
     await vi.waitFor(() => expect(executor.replyToMention).toHaveBeenCalledTimes(1))
   })
 
+  it('allows the same authenticated account to retract queued work from another device', async () => {
+    let finishFirst!: () => void
+    const executor = {
+      agentId: 'agent-worker',
+      name: 'Worker',
+      connected: true,
+      replyToMention: vi.fn(async () => {
+        if (executor.replyToMention.mock.calls.length === 1) {
+          await new Promise<void>(resolve => { finishFirst = resolve })
+        }
+      }),
+    }
+    harness.groupServer.agentClients.registerAgentForRoom('room-1', executor as any)
+
+    const mobile = await connectGroupChatClient(harness.port, 'auth:1', 'Owner')
+    const web = await connectGroupChatClient(harness.port, 'auth:1', 'Owner')
+    harness.sockets.push(mobile, web)
+    for (const client of [mobile, web]) {
+      harness.groupServer.getIO().of('/group-chat').sockets.get(client.id!)!.data.authUser = {
+        id: 1, role: 'user', profiles: ['default'],
+      }
+      await emitAck(client, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    }
+
+    await emitAck(mobile, 'message', {
+      roomId: 'room-1',
+      id: 'mobile-running',
+      content: '@Worker first',
+      mentions: [{ type: 'agent', participantId: 'agent-worker', displayName: 'Worker' }],
+      executionQueueCapability: ownerCapability,
+    })
+    await vi.waitFor(() => expect(executor.replyToMention).toHaveBeenCalledTimes(1))
+
+    await emitAck(mobile, 'message', {
+      roomId: 'room-1',
+      id: 'mobile-queued',
+      content: '@Worker second',
+      mentions: [{ type: 'agent', participantId: 'agent-worker', displayName: 'Worker' }],
+      executionQueueCapability: ownerCapability,
+    })
+    await vi.waitFor(() => expect(
+      harness.groupServer.getStorage().listQueuedExecutionItems('room-1'),
+    ).toHaveLength(1))
+    const [queued] = harness.groupServer.getStorage().listQueuedExecutionItems('room-1')
+
+    const otherAccount = await connectGroupChatClient(harness.port, 'auth:2', 'Other')
+    harness.sockets.push(otherAccount)
+    harness.groupServer.getIO().of('/group-chat').sockets.get(otherAccount.id!)!.data.authUser = {
+      id: 2, role: 'user', profiles: ['default'],
+    }
+    await emitAck(otherAccount, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    await expect(emitAck<any>(otherAccount, 'cancel_execution_queue_item', {
+      roomId: 'room-1',
+      queueId: queued.id,
+      executionQueueCapability: ownerCapability,
+    })).resolves.toEqual({ error: 'Access denied' })
+
+    await expect(emitAck<any>(web, 'cancel_execution_queue_item', {
+      roomId: 'room-1',
+      queueId: queued.id,
+      executionQueueCapability: attackerCapability,
+    })).resolves.toMatchObject({ ok: true, status: 'retracted', messageId: 'mobile-queued' })
+    expect(harness.groupServer.getStorage().getMessage('mobile-queued')).toBeNull()
+
+    finishFirst()
+  })
+
   it('retracts every target for one message all-or-nothing and rejects after any target starts', () => {
     const storage = harness.groupServer.getStorage() as any
     const capabilityHash = 'c'.repeat(64)


### PR DESCRIPTION
## Root cause
Queued-message retraction required a browser-local capability before checking the authenticated requester identity. Android and Web generate different local capabilities, so the same authenticated account received `Access denied` when retracting its own Android-sent queued message from Web.

## Fix
- Allow authenticated account ownership (`auth:<id>`) to authorize retraction across devices.
- Keep capability enforcement for unauthenticated/invite identities.
- Continue rejecting a different authenticated account, even if it presents the sender capability.
- Preserve queued-only and atomic sibling cancellation checks.

## Validation
- RED: cross-device test returned `{ error: "Access denied" }`.
- GREEN: execution queue + baseline focused tests — 27 passed.
- `npm run harness:check` — passed.
- `npm run build` — passed (existing chunk-size warning only).
- `git diff --check` — passed.

## Identity
- Base: `af9129a72e9627481675edb743bed84940451a40`
- Head: `789fec600ff3680304b7c013a9f4b9740b9d426d`

No merge, deployment, installation, or release is included.
