### PR TITLE
feat(group-chat): place Tool panel above Agent transcript

### DIFF
--- a/docs/chat-chain-changes/2026-08-15-group-chat-tool-panel-order.md
+++ b/docs/chat-chain-changes/2026-08-15-group-chat-tool-panel-order.md
@@ -1,0 +1,6 @@
+---
+date: 2026-08-15
+pr: pending
+feature: group-chat-tool-panel-order
+impact: Group Chat Agent run cards render their same-run Tool panel before the transcript and allow up to 360px of independently scrollable Tool history without limiting row count.
+---

--- a/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
@@ -99,23 +99,6 @@ function handleToolListWheel(event: WheelEvent): void {
                 <GroupAgentRobotIcon v-if="agentInfo" class="run-agent-icon" />
             </div>
             <div class="run-card" :class="{ streaming: message.isStreaming }">
-                <div v-if="transcriptItems.length" class="run-transcript">
-                    <div
-                        v-for="item in transcriptItems"
-                        :key="item.id"
-                        class="run-transcript-item"
-                        :data-message-id="item.id"
-                    >
-                        <GroupMessageItem
-                            :message="item"
-                            :agents="agents"
-                            :members="members"
-                            :current-user-id="currentUserId"
-                            :allow-speech="props.allowSpeech"
-                            embedded
-                        />
-                    </div>
-                </div>
                 <div
                     v-if="runToolItems.length"
                     class="run-tool-list"
@@ -130,6 +113,23 @@ function handleToolListWheel(event: WheelEvent): void {
                         v-for="item in runToolItems"
                         :key="item.id"
                         class="run-tool-item"
+                        :data-message-id="item.id"
+                    >
+                        <GroupMessageItem
+                            :message="item"
+                            :agents="agents"
+                            :members="members"
+                            :current-user-id="currentUserId"
+                            :allow-speech="props.allowSpeech"
+                            embedded
+                        />
+                    </div>
+                </div>
+                <div v-if="transcriptItems.length" class="run-transcript">
+                    <div
+                        v-for="item in transcriptItems"
+                        :key="item.id"
+                        class="run-transcript-item"
                         :data-message-id="item.id"
                     >
                         <GroupMessageItem
@@ -218,7 +218,7 @@ function handleToolListWheel(event: WheelEvent): void {
     flex-direction: column;
     width: 100%;
     min-width: 0;
-    max-height: 180px;
+    max-height: 360px;
     overflow-y: auto;
     scrollbar-width: thin;
 
@@ -239,7 +239,7 @@ function handleToolListWheel(event: WheelEvent): void {
     min-width: 0;
 }
 
-.run-transcript + .run-tool-list {
+.run-tool-list + .run-transcript {
     border-top: 1px solid rgba(var(--text-primary-rgb), 0.08);
 }
 

--- a/tests/client/group-agent-run-tool-list.test.ts
+++ b/tests/client/group-agent-run-tool-list.test.ts
@@ -89,7 +89,7 @@ function mountCard(message: ChatMessage) {
 }
 
 describe('GroupAgentRunCard tool list', () => {
-  it('places the current Agent/Run tool calls newest-first after its transcript', () => {
+  it('places the current Agent/Run tool calls newest-first before its transcript', () => {
     const wrapper = mountCard(runMessage([
       runItem({ id: 'current-tool-1', role: 'tool', toolName: 'read_file', toolStatus: 'done' }),
       runItem({ id: 'current-reasoning', content: 'Checking the result.', isStreaming: true, timestamp: 2 }),
@@ -107,11 +107,13 @@ describe('GroupAgentRunCard tool list', () => {
     ])
     expect(wrapper.get('.run-transcript-item').attributes('data-message-id')).toBe('current-reasoning')
     expect(wrapper.get('.run-transcript').find('.tool-name').exists()).toBe(false)
-    expect(wrapper.get('.run-card').element.children[0]).toBe(wrapper.get('.run-transcript').element)
-    expect(wrapper.get('.run-card').element.children[1]).toBe(panel.element)
+    expect(wrapper.get('.run-column').element.children[0]).toBe(wrapper.get('.run-header').element)
+    expect(wrapper.get('.run-card').element.children[0]).toBe(panel.element)
+    expect(wrapper.get('.run-card').element.children[1]).toBe(wrapper.get('.run-transcript').element)
+    expect(wrapper.get('.run-column').element.children[2]).toBe(wrapper.get('.run-time').element)
   })
 
-  it('keeps completed historical tool calls in the same bounded panel after its transcript', () => {
+  it('keeps completed historical tool calls in the same bounded panel before its transcript', () => {
     const wrapper = mountCard(runMessage([
       runItem({ id: 'historical-tool-1', role: 'tool', toolName: 'read_file', toolStatus: 'done' }),
       runItem({ id: 'historical-answer', content: 'Finished.', timestamp: 2 }),
@@ -128,7 +130,7 @@ describe('GroupAgentRunCard tool list', () => {
     expect(wrapper.get('.run-transcript').text()).not.toContain('read_file')
     expect(wrapper.findAll('.run-tool-item[data-message-id="historical-tool-1"]')).toHaveLength(1)
     expect(wrapper.findAll('.run-tool-item[data-message-id="historical-tool-2"]')).toHaveLength(1)
-    expect(wrapper.get('.run-card').element.children[0]).toBe(wrapper.get('.run-transcript').element)
-    expect(wrapper.get('.run-card').element.children[1]).toBe(wrapper.get('.run-tool-list').element)
+    expect(wrapper.get('.run-card').element.children[0]).toBe(wrapper.get('.run-tool-list').element)
+    expect(wrapper.get('.run-card').element.children[1]).toBe(wrapper.get('.run-transcript').element)
   })
 })

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -518,14 +518,15 @@ test.describe('group chat room deep links', () => {
     await expect(historicalPanel.locator('.tool-name')).toHaveText('historical_tool')
     await expect.poll(() => page.locator('.group-agent-run[data-run-id="run-history-tools"] .run-card').evaluate(
       element => Array.from(element.children, child => child.className),
-    )).toEqual(['run-transcript', 'run-tool-list'])
+    )).toEqual(['run-tool-list', 'run-transcript'])
 
     const dimensions = await panel.evaluate(element => ({
       clientHeight: element.clientHeight,
       scrollHeight: element.scrollHeight,
     }))
     expect(dimensions.clientHeight).toBeLessThan(dimensions.scrollHeight)
-    expect(dimensions.clientHeight).toBeLessThanOrEqual(180)
+    expect(dimensions.clientHeight).toBeGreaterThan(180)
+    expect(dimensions.clientHeight).toBeLessThanOrEqual(360)
 
     await panel.hover()
     await expect.poll(async () => {
@@ -904,7 +905,7 @@ test.describe('group chat room deep links', () => {
     await expect(runCard.locator('.tool-message')).toHaveCount(2)
     await expect.poll(() => runCard.locator('.run-card').evaluate(
       element => Array.from(element.children, child => child.className),
-    )).toEqual(['run-transcript', 'run-tool-list'])
+    )).toEqual(['run-tool-list', 'run-transcript'])
 
     api.setRoomMessages({
       ...messagesByRoom,
@@ -944,7 +945,7 @@ test.describe('group chat room deep links', () => {
     await expect(page.locator('.group-message-list > .tool-message')).toHaveCount(0)
     await expect.poll(() => refreshedRunCard.locator('.run-card').evaluate(
       element => Array.from(element.children, child => child.className),
-    )).toEqual(['run-transcript', 'run-tool-list'])
+    )).toEqual(['run-tool-list', 'run-transcript'])
   })
 
   test('shows a selected room link when browser clipboard APIs cannot copy', async ({ page }) => {


### PR DESCRIPTION
## Summary
- render the same-run Tool panel before the Agent transcript in Group Chat run cards
- increase the independently scrollable Tool panel height from 180px to 360px without limiting Tool rows
- cover component order plus live, terminal, and refreshed-history behavior

Closes #2571

## Validation
- RED: `npm run test -- tests/client/group-agent-run-tool-list.test.ts` (2 failed before implementation)
- RED: `npm run test:e2e -- tests/e2e/group-chat-room-deeplink.spec.ts --grep 'keeps the active Agent run tool list bounded|keeps runtime Tools bounded'` (failed on old order before implementation)
- `npm run test -- tests/client/group-agent-run-tool-list.test.ts`
- `npm run test:e2e -- tests/e2e/group-chat-room-deeplink.spec.ts --grep 'keeps the active Agent run tool list bounded|keeps runtime Tools bounded'`
- `npm run test:e2e -- tests/e2e/group-chat-room-deeplink.spec.ts`
- `npm run harness:check`
- `npm run build`
- `git diff --check`

## Known baseline failures
- `npm run test` completed with 4109 passing / 53 failing tests. The failures are outside this PR's files and include existing environment-sensitive suites such as Kanban attachment path checks, Hermes runtime/plugin discovery, and unrelated client component mocks. Focused Group Chat tests and the complete related Group Chat E2E spec pass.
