### PR TITLE
fix(history): add GROUP collapse controls

### DIFF
--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -68,9 +68,36 @@ const groupRoomsOffset = ref(0)
 
 const HISTORY_PAGE_SIZE = 150
 const HISTORY_GROUP_PAGE_SIZE = 50
+const HISTORY_GROUP_COLLAPSE_KEY = 'group-chat'
+const collapsedGroups = ref<Set<string>>(new Set(JSON.parse(localStorage.getItem('hermes_collapsed_groups') || '[]')))
+const isGroupRoomsCollapsed = computed(() => collapsedGroups.value.has(HISTORY_GROUP_COLLAPSE_KEY))
 const sourceHasMore = ref<Record<string, boolean>>({})
 const sourceLoading = ref<Record<string, boolean>>({})
 const sourceOffsets = ref<Record<string, number>>({})
+
+function persistCollapsedGroups() {
+  localStorage.setItem('hermes_collapsed_groups', JSON.stringify([...collapsedGroups.value]))
+}
+
+function toggleGroupRooms() {
+  if (routeGroupRoomId.value) {
+    ensureGroupRoomsExpanded()
+    return
+  }
+  const next = new Set(collapsedGroups.value)
+  if (next.has(HISTORY_GROUP_COLLAPSE_KEY)) next.delete(HISTORY_GROUP_COLLAPSE_KEY)
+  else next.add(HISTORY_GROUP_COLLAPSE_KEY)
+  collapsedGroups.value = next
+  persistCollapsedGroups()
+}
+
+function ensureGroupRoomsExpanded() {
+  if (!collapsedGroups.value.has(HISTORY_GROUP_COLLAPSE_KEY)) return
+  collapsedGroups.value = new Set(
+    [...collapsedGroups.value].filter(source => source !== HISTORY_GROUP_COLLAPSE_KEY),
+  )
+  persistCollapsedGroups()
+}
 
 function handleOutlineNavigate(target: { messageId: string; anchorId: string }) {
   historyMessageListRef.value?.scrollToAnchor(target.messageId, target.anchorId)
@@ -430,6 +457,7 @@ function openPageSidebar() {
 }
 
 onMounted(async () => {
+  if (routeGroupRoomId.value) ensureGroupRoomsExpanded()
   appStore.loadModels()
   await profilesStore.fetchProfiles()
   await Promise.all([loadHermesSessions(), loadGroupRooms()])
@@ -448,6 +476,7 @@ onUnmounted(() => {
 
 watch([routeSessionId, routeProfile, routeGroupRoomId], async ([sessionId, _profile, groupRoomId]) => {
   if (groupRoomId) {
+    ensureGroupRoomsExpanded()
     historySessionId.value = null
     historySession.value = null
     return
@@ -472,8 +501,6 @@ watch(() => profilesStore.activeProfileName, async () => {
   await loadHermesSessions()
   await openDefaultHistorySession(true)
 })
-
-const collapsedGroups = ref<Set<string>>(new Set(JSON.parse(localStorage.getItem('hermes_collapsed_groups') || '[]')))
 
 // Convert SessionSummary to Session format
 function sessionSummaryToSession(summary: SessionSummary): Session {
@@ -979,32 +1006,42 @@ function handleBatchDeleteConfirm() {
           />
         </template>
 
-        <div class="session-group-header session-group-header--static">
-            <span class="session-group-label">GROUP</span>
-            <span class="session-group-count">{{ groupRooms.length }}{{ groupRoomsHasMore ? '+' : '' }}</span>
-            <NTooltip v-if="groupRoomsHasMore" trigger="hover">
-              <template #trigger>
-                <NButton
-                  class="session-group-load-more"
-                  quaternary
-                  circle
-                  size="tiny"
-                  :loading="groupRoomsLoading"
-                  :disabled="groupRoomsLoading"
-                  :aria-label="groupRoomsLoading ? t('common.loading') : t('chat.loadMoreSessions')"
-                  @click.stop="loadGroupRooms(false)"
-                >
-                  <template #icon>
-                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
-                      <path d="M20 11a8 8 0 1 0-2.34 5.66" />
-                      <polyline points="20 4 20 11 13 11" />
-                    </svg>
-                  </template>
-                </NButton>
-              </template>
-              {{ groupRoomsLoading ? t('common.loading') : t('chat.loadMoreSessions') }}
-            </NTooltip>
-          </div>
+        <div
+          class="session-group-header"
+          role="button"
+          tabindex="0"
+          :aria-expanded="!isGroupRoomsCollapsed"
+          @click="toggleGroupRooms"
+          @keydown.enter.prevent="toggleGroupRooms"
+          @keydown.space.prevent="toggleGroupRooms"
+        >
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="group-chevron" :class="{ collapsed: isGroupRoomsCollapsed }"><polyline points="9 18 15 12 9 6"/></svg>
+          <span class="session-group-label">GROUP</span>
+          <span class="session-group-count">{{ groupRooms.length }}{{ groupRoomsHasMore ? '+' : '' }}</span>
+          <NTooltip v-if="groupRoomsHasMore && !isGroupRoomsCollapsed" trigger="hover">
+            <template #trigger>
+              <NButton
+                class="session-group-load-more"
+                quaternary
+                circle
+                size="tiny"
+                :loading="groupRoomsLoading"
+                :disabled="groupRoomsLoading"
+                :aria-label="groupRoomsLoading ? t('common.loading') : t('chat.loadMoreSessions')"
+                @click.stop="loadGroupRooms(false)"
+              >
+                <template #icon>
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                    <path d="M20 11a8 8 0 1 0-2.34 5.66" />
+                    <polyline points="20 4 20 11 13 11" />
+                  </svg>
+                </template>
+              </NButton>
+            </template>
+            {{ groupRoomsLoading ? t('common.loading') : t('chat.loadMoreSessions') }}
+          </NTooltip>
+        </div>
+        <template v-if="!isGroupRoomsCollapsed">
           <button
             v-for="room in groupRooms"
             :key="`group-${room.id}`"
@@ -1026,6 +1063,7 @@ function handleBatchDeleteConfirm() {
               <span class="group-room-history-time">{{ new Date(Number(room.lastActiveAt || room.createdAt || 0)).toLocaleString() }}</span>
             </span>
           </button>
+        </template>
 
         <template v-for="group in groupedSessions" :key="group.source">
           <div class="session-group-header" @click="toggleGroup(group.source)">
@@ -1301,6 +1339,11 @@ function handleBatchDeleteConfirm() {
   padding: 6px 10px 4px;
   cursor: pointer;
   user-select: none;
+
+  &[role='button']:focus-visible {
+    outline: 2px solid rgba($accent-primary, 0.55);
+    outline-offset: -2px;
+  }
 }
 
 .session-group-header--static {

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -1012,8 +1012,8 @@ function handleBatchDeleteConfirm() {
           tabindex="0"
           :aria-expanded="!isGroupRoomsCollapsed"
           @click="toggleGroupRooms"
-          @keydown.enter.prevent="toggleGroupRooms"
-          @keydown.space.prevent="toggleGroupRooms"
+          @keydown.enter.self.prevent="toggleGroupRooms"
+          @keydown.space.self.prevent="toggleGroupRooms"
         >
           <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="group-chevron" :class="{ collapsed: isGroupRoomsCollapsed }"><polyline points="9 18 15 12 9 6"/></svg>
           <span class="session-group-label">GROUP</span>

--- a/tests/client/history-group-collapse.test.ts
+++ b/tests/client/history-group-collapse.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const historyView = readFileSync('packages/client/src/views/hermes/HistoryView.vue', 'utf8')
+
+describe('History GROUP collapse contract', () => {
+  it('uses the existing collapsed-groups persistence store for GROUP', () => {
+    expect(historyView).toContain("const HISTORY_GROUP_COLLAPSE_KEY = 'group-chat'")
+    expect(historyView).toContain('collapsedGroups.value.has(HISTORY_GROUP_COLLAPSE_KEY)')
+    expect(historyView).toContain("localStorage.setItem('hermes_collapsed_groups'")
+  })
+
+  it('exposes the GROUP header as an accessible keyboard toggle', () => {
+    expect(historyView).toContain(':aria-expanded="!isGroupRoomsCollapsed"')
+    expect(historyView).toContain('@keydown.enter.prevent="toggleGroupRooms"')
+    expect(historyView).toContain('@keydown.space.prevent="toggleGroupRooms"')
+  })
+
+  it('hides the room list and pagination control without clearing room data', () => {
+    expect(historyView).toContain('<template v-if="!isGroupRoomsCollapsed">')
+    expect(historyView).toContain('v-if="groupRoomsHasMore && !isGroupRoomsCollapsed"')
+    expect(historyView).not.toContain('groupRooms.value = []')
+  })
+
+  it('expands GROUP whenever a room route becomes active', () => {
+    expect(historyView).toContain('function ensureGroupRoomsExpanded()')
+    expect(historyView).toContain('if (groupRoomId) {')
+    expect(historyView).toContain('ensureGroupRoomsExpanded()')
+  })
+})

--- a/tests/client/history-group-collapse.test.ts
+++ b/tests/client/history-group-collapse.test.ts
@@ -12,8 +12,8 @@ describe('History GROUP collapse contract', () => {
 
   it('exposes the GROUP header as an accessible keyboard toggle', () => {
     expect(historyView).toContain(':aria-expanded="!isGroupRoomsCollapsed"')
-    expect(historyView).toContain('@keydown.enter.prevent="toggleGroupRooms"')
-    expect(historyView).toContain('@keydown.space.prevent="toggleGroupRooms"')
+    expect(historyView).toContain('@keydown.enter.self.prevent="toggleGroupRooms"')
+    expect(historyView).toContain('@keydown.space.self.prevent="toggleGroupRooms"')
   })
 
   it('hides the room list and pagination control without clearing room data', () => {

--- a/tests/e2e/history-session-deeplink.spec.ts
+++ b/tests/e2e/history-session-deeplink.spec.ts
@@ -281,6 +281,9 @@ test.describe('history session deep links', () => {
     await expect(page.locator('.group-room-history-item.active')).toContainText('Newest Group Room')
     await expect.poll(() => page.evaluate(() => localStorage.getItem('hermes_collapsed_groups')))
       .not.toContain('group-chat')
+    await groupHeader.click()
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.locator('.group-room-history-item.active')).toContainText('Newest Group Room')
 
     await page.goto('/#/hermes/history/session/hist-alpha')
     await groupHeader.click()
@@ -293,7 +296,7 @@ test.describe('history session deep links', () => {
 
   test('mobile History can open GROUP, select a room, and keep the transcript usable', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 })
-    await page.goto('/#/hermes/history/group-chat/room-new')
+    await page.goto('/#/hermes/history/session/hist-alpha')
 
     await page.locator('.hamburger-btn').click()
     const groupHeader = page.locator('.session-group-header', { hasText: 'GROUP' })
@@ -352,7 +355,7 @@ test.describe('history GROUP pagination', () => {
     const loadMore = groupHeader.locator('.session-group-load-more')
     await expect(groupHeader).toHaveAttribute('aria-expanded', 'true')
     await expect(loadMore).toBeVisible()
-    await expect(page.getByText('Paged Group Room 51')).toBeHidden()
+    await expect(page.getByText('Paged Group Room 51', { exact: true })).toBeHidden()
 
     await groupHeader.click()
     await expect(loadMore).toBeHidden()
@@ -360,7 +363,7 @@ test.describe('history GROUP pagination', () => {
     await expect(loadMore).toBeVisible()
     await loadMore.click()
 
-    await expect(page.getByText('Paged Group Room 51')).toBeVisible()
+    await expect(page.getByText('Paged Group Room 51', { exact: true })).toBeVisible()
     await expect(loadMore).toHaveCount(0)
     await expect(page.locator('.group-room-history-item')).toHaveCount(53)
   })

--- a/tests/e2e/history-session-deeplink.spec.ts
+++ b/tests/e2e/history-session-deeplink.spec.ts
@@ -367,6 +367,34 @@ test.describe('history GROUP pagination', () => {
     await expect(loadMore).toHaveCount(0)
     await expect(page.locator('.group-room-history-item')).toHaveCount(53)
   })
+
+  test('keyboard activation of GROUP pagination loads the next page without collapsing', async ({ page }) => {
+    const roomPageRequests: string[] = []
+    page.on('request', (request) => {
+      const url = new URL(request.url())
+      if (url.pathname === '/api/hermes/group-chat/rooms') {
+        roomPageRequests.push(url.search)
+      }
+    })
+
+    await page.goto('/#/hermes/history/session/hist-alpha')
+
+    const groupHeader = page.locator('.session-group-header', { hasText: 'GROUP' })
+    const loadMore = groupHeader.locator('.session-group-load-more')
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.locator('.group-room-history-item')).toHaveCount(50)
+
+    await loadMore.focus()
+    await loadMore.press('Enter')
+
+    await expect.poll(() => roomPageRequests).toContain('?offset=50&limit=50')
+    await expect(page.locator('.group-room-history-item')).toHaveCount(53)
+    await expect(page.locator('.group-room-history-item')).toHaveText(
+      pagedGroupRooms.map(room => new RegExp(room.name)),
+    )
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'true')
+    await expect(loadMore).toHaveCount(0)
+  })
 })
 
 test.describe('history source pagination', () => {

--- a/tests/e2e/history-session-deeplink.spec.ts
+++ b/tests/e2e/history-session-deeplink.spec.ts
@@ -112,11 +112,12 @@ function detailFor(id: string, sessions = historySessions) {
   }
 }
 
-async function mockHistoryApi(page: Page, sessions = historySessions) {
-  const groupRooms = [
+const defaultGroupRooms = [
     { id: 'room-new', name: 'Newest Group Room', inviteCode: null, canManage: false, lastActiveAt: 1_790_001_000 },
     { id: 'room-old', name: 'Older Group Room', inviteCode: null, canManage: false, lastActiveAt: 1_790_000_000 },
-  ]
+]
+
+async function mockHistoryApi(page: Page, sessions = historySessions, groupRooms = defaultGroupRooms) {
   await page.route('**/*', async (route: Route) => {
     const request = route.request()
     const url = new URL(request.url())
@@ -231,6 +232,9 @@ test.describe('history session deep links', () => {
 
     const groupHeader = page.locator('.session-group-header', { hasText: 'GROUP' })
     await expect(groupHeader).toBeVisible()
+    await expect(groupHeader).toHaveAttribute('role', 'button')
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'true')
+    await expect(groupHeader.locator('.session-group-load-more')).toHaveCount(0)
     await expect(page.getByText('Newest Group Room').first()).toBeVisible()
     await expect(page.getByText('Older Group Room').first()).toBeVisible()
     await expect(page.getByText('History for Newest Group Room')).toBeVisible()
@@ -245,12 +249,60 @@ test.describe('history session deep links', () => {
     await expect(page.getByText('History for Older Group Room')).toBeVisible()
   })
 
+  test('GROUP collapse persists on non-group History routes and supports keyboard toggles', async ({ page }) => {
+    await page.goto('/#/hermes/history/session/hist-alpha')
+
+    const groupHeader = page.locator('.session-group-header', { hasText: 'GROUP' })
+    await groupHeader.focus()
+    await groupHeader.press('Enter')
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'false')
+    await expect(page.getByText('Newest Group Room')).toBeHidden()
+    await expect.poll(() => page.evaluate(() => localStorage.getItem('hermes_collapsed_groups')))
+      .toContain('group-chat')
+
+    await page.reload()
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'false')
+    await expect(page.getByText('Newest Group Room')).toBeHidden()
+
+    await groupHeader.focus()
+    await groupHeader.press('Space')
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.getByText('Newest Group Room')).toBeVisible()
+  })
+
+  test('active GROUP routes override persisted collapse on direct and history navigation', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('hermes_collapsed_groups', JSON.stringify(['group-chat']))
+    })
+    await page.goto('/#/hermes/history/group-chat/room-new')
+
+    const groupHeader = page.locator('.session-group-header', { hasText: 'GROUP' })
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.locator('.group-room-history-item.active')).toContainText('Newest Group Room')
+    await expect.poll(() => page.evaluate(() => localStorage.getItem('hermes_collapsed_groups')))
+      .not.toContain('group-chat')
+
+    await page.goto('/#/hermes/history/session/hist-alpha')
+    await groupHeader.click()
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'false')
+    await page.goBack()
+    await expect(page).toHaveURL(/#\/hermes\/history\/group-chat\/room-new$/)
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.locator('.group-room-history-item.active')).toContainText('Newest Group Room')
+  })
+
   test('mobile History can open GROUP, select a room, and keep the transcript usable', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 })
     await page.goto('/#/hermes/history/group-chat/room-new')
 
     await page.locator('.hamburger-btn').click()
-    await expect(page.locator('.session-group-header', { hasText: 'GROUP' })).toBeVisible()
+    const groupHeader = page.locator('.session-group-header', { hasText: 'GROUP' })
+    await expect(groupHeader).toBeVisible()
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'true')
+    await groupHeader.click()
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'false')
+    await groupHeader.click()
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'true')
     await page.getByText('Older Group Room').first().click()
 
     await expect(page).toHaveURL(/#\/hermes\/history\/group-chat\/room-old$/)
@@ -276,6 +328,41 @@ test.describe('history session deep links', () => {
 
     await expect(page).toHaveURL(/#\/hermes\/history$/)
     await expect(page.getByText('API Server History Session').first()).toBeVisible()
+  })
+})
+
+test.describe('history GROUP pagination', () => {
+  const pagedGroupRooms = Array.from({ length: 53 }, (_, index) => ({
+    id: `room-${index + 1}`,
+    name: `Paged Group Room ${index + 1}`,
+    inviteCode: null,
+    canManage: false,
+    lastActiveAt: 1_790_100_000 - index,
+  }))
+
+  test.beforeEach(async ({ page }) => {
+    await authenticate(page)
+    await mockHistoryApi(page, historySessions, pagedGroupRooms)
+  })
+
+  test('shows pagination only when needed and loads one deduplicated page at a time', async ({ page }) => {
+    await page.goto('/#/hermes/history/session/hist-alpha')
+
+    const groupHeader = page.locator('.session-group-header', { hasText: 'GROUP' })
+    const loadMore = groupHeader.locator('.session-group-load-more')
+    await expect(groupHeader).toHaveAttribute('aria-expanded', 'true')
+    await expect(loadMore).toBeVisible()
+    await expect(page.getByText('Paged Group Room 51')).toBeHidden()
+
+    await groupHeader.click()
+    await expect(loadMore).toBeHidden()
+    await groupHeader.click()
+    await expect(loadMore).toBeVisible()
+    await loadMore.click()
+
+    await expect(page.getByText('Paged Group Room 51')).toBeVisible()
+    await expect(loadMore).toHaveCount(0)
+    await expect(page.locator('.group-room-history-item')).toHaveCount(53)
   })
 })
 


### PR DESCRIPTION
## Summary
- add persistent, accessible collapse/expand controls to the History GROUP section
- force the GROUP section open while a Group Room route is active
- preserve the existing 50-room pagination cursor and deduplicate appended pages
- cover desktop, mobile, keyboard, persistence, active-route, and hasMore behavior

Closes #2580

## Validation
- `npm run test -- tests/client/history-group-collapse.test.ts tests/client/style-system.test.ts` (14 passed)
- `npx playwright test tests/e2e/history-session-deeplink.spec.ts` (10 passed)
- `npm run harness:check` (passed)
- `npm run build` (passed)
- `npm run test:coverage` (executed: 4145 passed, 60 failed, 6 skipped; broad pre-existing/environment failures, focused changed tests passed)
- `npm run test:e2e` (executed: 90 passed, 14 failed, 27 did not run under broad parallel load; History file passes 10/10 independently and the affected mobile case passes 1/1 on rerun)
- `git diff --check` (passed)