### PR TITLE
fix(models): keep the provider groups you collapsed

### DIFF
--- a/docs/chat-chain-changes/2026-08-16-persist-collapsed-provider-groups.md
+++ b/docs/chat-chain-changes/2026-08-16-persist-collapsed-provider-groups.md
@@ -1,0 +1,14 @@
+---
+date: 2026-08-16
+feature: issue-2492-persist-collapsed-provider-groups
+pr: 2585
+impact: The Set Session Model dialog keeps the provider groups you collapsed instead of re-expanding all of them on every open. No change to model selection, switching, or MoA behaviour.
+---
+
+# Issue #2492
+
+`ChatPanel` held the session-model dialog's collapse state in a local `sessionModelCollapsedGroups` ref and cleared it in `openSessionModelModal`, so someone with forty providers folded the same groups away again every single time they opened the dialog. Three other pickers — `ModelSelector`, `CombinationModelsPanel`, `WorkflowModelSelector` — had the identical ref-and-reset, each unaware of the others.
+
+All four now read one shared record from `useCollapsedProviderGroups`, which stores it under `hermes.models.collapsedProviderGroups` through the existing `usePersistentRecord` composable. The record is created at module scope rather than per call, so two pickers open at once cannot write over each other's state; only collapsed groups are stored, so expanding a group removes its entry instead of accumulating `false` forever.
+
+The chat surface change is confined to that dialog: `toggleSessionModelGroup` still refuses to act while a model switch is in flight, and nothing else in the run chain reads the collapse state.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -53,6 +53,7 @@ import { buildVisibleSessionCategoryGroups, partitionRecentSessions } from "./se
 import PageSidebarNav from "@/components/layout/PageSidebarNav.vue";
 import { isStoredSuperAdmin } from "@/api/client";
 import { useDefaultWorkspace } from "@/composables/useDefaultWorkspace";
+import { useCollapsedProviderGroups } from "@/composables/useCollapsedProviderGroups";
 import { canScopedCodingAgentUseProvider, usesServerManagedProviderAuth } from "@/utils/codingAgentProviders";
 import { OPEN_SUBAGENT_STREAM_EVENT, type OpenSubagentStreamDetail } from "@/utils/hermes/subagent-stream";
 import { desktopBridge, hasDesktopBrowserBridge } from "@/utils/desktop-bridge";
@@ -1614,7 +1615,10 @@ const showSessionModelModeModal = ref(false);
 const sessionModelSessionId = ref<string | null>(null);
 const sessionModelSearch = ref("");
 const sessionModelKind = ref<"model" | "moa">("model");
-const sessionModelCollapsedGroups = ref<Record<string, boolean>>({});
+const {
+  isGroupCollapsed: isSessionModelGroupCollapsed,
+  toggleGroup: toggleSessionModelCollapsedGroup,
+} = useCollapsedProviderGroups();
 const sessionModelValue = ref("");
 const sessionModelProvider = ref("");
 const sessionModelCustomInput = ref("");
@@ -1741,7 +1745,6 @@ async function openSessionModelModal(sessionId: string) {
   sessionModelCustomProvider.value = usesMoa ? defaults.provider : sessionModelProvider.value;
   sessionModelSearch.value = "";
   sessionModelCustomInput.value = "";
-  sessionModelCollapsedGroups.value = {};
   showSessionModelModal.value = true;
 }
 
@@ -1760,13 +1763,9 @@ function handleHeaderModelClick() {
   openSessionModelModal(sessionId);
 }
 
-function isSessionModelGroupCollapsed(provider: string) {
-  return !!sessionModelCollapsedGroups.value[provider];
-}
-
 function toggleSessionModelGroup(provider: string) {
   if (sessionModelSwitching.value) return;
-  sessionModelCollapsedGroups.value[provider] = !sessionModelCollapsedGroups.value[provider];
+  toggleSessionModelCollapsedGroup(provider);
 }
 
 function isCustomSessionModel(model: string, provider: string) {

--- a/packages/client/src/components/hermes/models/CombinationModelsPanel.vue
+++ b/packages/client/src/components/hermes/models/CombinationModelsPanel.vue
@@ -6,6 +6,7 @@ import { fetchMoaConfig, saveMoaConfig, type MoaConfig, type MoaModelSlot, type 
 import { useAppStore } from '@/stores/hermes/app'
 import { useModelsStore } from '@/stores/hermes/models'
 import { useProfilesStore } from '@/stores/hermes/profiles'
+import { useCollapsedProviderGroups } from '@/composables/useCollapsedProviderGroups'
 
 const { t } = useI18n()
 const message = useMessage()
@@ -23,7 +24,7 @@ const formPreset = ref<MoaPreset>(createEmptyPreset())
 const showModelPicker = ref(false)
 const pickerTarget = ref<{ kind: 'reference' | 'aggregator'; index?: number } | null>(null)
 const pickerSearch = ref('')
-const collapsedGroups = ref<Record<string, boolean>>({})
+const { isGroupCollapsed: isModelPickerGroupCollapsed, toggleGroup: toggleModelPickerGroup } = useCollapsedProviderGroups()
 const customProvider = ref('')
 const customInput = ref('')
 
@@ -105,14 +106,6 @@ function modelAlias(model: string, provider: string): string {
 
 function isCustomModel(model: string, provider: string): boolean {
   return (appStore.customModels[provider] || []).includes(model)
-}
-
-function isModelPickerGroupCollapsed(provider: string): boolean {
-  return !!collapsedGroups.value[provider]
-}
-
-function toggleModelPickerGroup(provider: string) {
-  collapsedGroups.value[provider] = !collapsedGroups.value[provider]
 }
 
 async function loadMoaConfig() {
@@ -227,7 +220,6 @@ async function deletePreset(name: string) {
 function openModelPicker(kind: 'reference' | 'aggregator', index?: number) {
   pickerTarget.value = { kind, index }
   pickerSearch.value = ''
-  collapsedGroups.value = {}
   customProvider.value = modelGroupsWithCustom.value[0]?.provider || ''
   customInput.value = ''
   showModelPicker.value = true

--- a/packages/client/src/components/hermes/workflow/WorkflowModelSelector.vue
+++ b/packages/client/src/components/hermes/workflow/WorkflowModelSelector.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 import { NInput, NModal } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/hermes/app'
+import { useCollapsedProviderGroups } from '@/composables/useCollapsedProviderGroups'
 import type { AvailableModelGroup, ProviderApiMode } from '@/api/hermes/system'
 
 const props = defineProps<{
@@ -20,7 +21,7 @@ const { t } = useI18n()
 const appStore = useAppStore()
 const showModal = ref(false)
 const searchQuery = ref('')
-const collapsedGroups = ref<Record<string, boolean>>({})
+const { isGroupCollapsed, toggleGroup } = useCollapsedProviderGroups()
 
 const groupsWithCustom = computed(() =>
   props.groups.map(group => ({
@@ -59,17 +60,8 @@ const filteredGroups = computed(() => {
 
 function openModal() {
   if (props.disabled) return
-  collapsedGroups.value = {}
   searchQuery.value = ''
   showModal.value = true
-}
-
-function toggleGroup(provider: string) {
-  collapsedGroups.value[provider] = !collapsedGroups.value[provider]
-}
-
-function isGroupCollapsed(provider: string) {
-  return !!collapsedGroups.value[provider]
 }
 
 function isCustomModel(model: string, provider: string) {

--- a/packages/client/src/components/layout/ModelSelector.vue
+++ b/packages/client/src/components/layout/ModelSelector.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { NModal, NInput, NSelect } from 'naive-ui'
 import { useAppStore } from '@/stores/hermes/app'
 import { useProfilesStore } from '@/stores/hermes/profiles'
+import { useCollapsedProviderGroups } from '@/composables/useCollapsedProviderGroups'
 import { useI18n } from 'vue-i18n'
 
 const emit = defineEmits<{
@@ -15,7 +16,7 @@ const profilesStore = useProfilesStore()
 
 const showModal = ref(false)
 const searchQuery = ref('')
-const collapsedGroups = ref<Record<string, boolean>>({})
+const { isGroupCollapsed, toggleGroup } = useCollapsedProviderGroups()
 const customInput = ref('')
 const customProvider = ref('')
 
@@ -79,14 +80,6 @@ const filteredGroups = computed(() => {
     .filter(g => g.models.length > 0 || safeLower(g.label).includes(q))
 })
 
-function toggleGroup(provider: string) {
-  collapsedGroups.value[provider] = !collapsedGroups.value[provider]
-}
-
-function isGroupCollapsed(provider: string) {
-  return !!collapsedGroups.value[provider]
-}
-
 function handleSelect(model: string, provider: string) {
   const meta = activeModelGroups.value.find(g => g.provider === provider)?.model_meta?.[model]
   if (meta?.disabled) return
@@ -121,7 +114,6 @@ function setModalShow(show: boolean) {
 }
 
 function openModal() {
-  collapsedGroups.value = {}
   searchQuery.value = ''
   customInput.value = ''
   customProvider.value = appStore.selectedProvider

--- a/packages/client/src/composables/useCollapsedProviderGroups.ts
+++ b/packages/client/src/composables/useCollapsedProviderGroups.ts
@@ -1,0 +1,29 @@
+import { usePersistentRecord } from './usePersistentRecord'
+
+/**
+ * Which provider groups the user has collapsed in the model pickers.
+ *
+ * Every picker reset this on open, so someone with forty providers folded the
+ * same groups away again on every visit. One record is shared by all the
+ * pickers on purpose — a provider you have folded away stays folded wherever
+ * you meet it — and it is created once at module scope so two open pickers
+ * cannot write over each other's state.
+ */
+
+const { record, persist } = usePersistentRecord('hermes.models.collapsedProviderGroups')
+
+export function useCollapsedProviderGroups() {
+  function isGroupCollapsed(provider: string): boolean {
+    return !!record[provider]
+  }
+
+  function toggleGroup(provider: string) {
+    // Keep only what is collapsed, so the record cannot grow forever with
+    // every provider the user has ever expanded.
+    if (record[provider]) delete record[provider]
+    else record[provider] = true
+    persist()
+  }
+
+  return { isGroupCollapsed, toggleGroup }
+}

--- a/tests/client/collapsed-provider-groups.test.ts
+++ b/tests/client/collapsed-provider-groups.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const STORAGE_KEY = 'hermes.models.collapsedProviderGroups'
+
+/**
+ * The model pickers used to forget every collapsed provider the moment they
+ * closed. These cover what is remembered, what is deliberately not stored, and
+ * that two pickers open at once share one record instead of overwriting it.
+ */
+describe('collapsed provider groups', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.resetModules()
+  })
+
+  async function load() {
+    return import('../../packages/client/src/composables/useCollapsedProviderGroups')
+  }
+
+  it('remembers a collapsed group across a reload', async () => {
+    const { useCollapsedProviderGroups } = await load()
+    useCollapsedProviderGroups().toggleGroup('nvidia')
+
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')).toEqual({ nvidia: true })
+
+    // A reload is a fresh module with the same storage behind it.
+    vi.resetModules()
+    const reloaded = await load()
+    expect(reloaded.useCollapsedProviderGroups().isGroupCollapsed('nvidia')).toBe(true)
+  })
+
+  it('drops a group from storage when it is expanded again', async () => {
+    const { useCollapsedProviderGroups } = await load()
+    const picker = useCollapsedProviderGroups()
+
+    picker.toggleGroup('xiaomi')
+    picker.toggleGroup('xiaomi')
+
+    expect(picker.isGroupCollapsed('xiaomi')).toBe(false)
+    // Expanded is the default, so it is stored as absence rather than as false.
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')).toEqual({})
+  })
+
+  it('keeps groups collapsed by other pickers instead of overwriting them', async () => {
+    const { useCollapsedProviderGroups } = await load()
+    const sessionModelDialog = useCollapsedProviderGroups()
+    const workflowPicker = useCollapsedProviderGroups()
+
+    sessionModelDialog.toggleGroup('nvidia')
+    workflowPicker.toggleGroup('openai')
+
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')).toEqual({ nvidia: true, openai: true })
+    expect(sessionModelDialog.isGroupCollapsed('openai')).toBe(true)
+    expect(workflowPicker.isGroupCollapsed('nvidia')).toBe(true)
+  })
+
+  it('starts clean when storage holds something that is not a record', async () => {
+    localStorage.setItem(STORAGE_KEY, 'not json')
+    const { useCollapsedProviderGroups } = await load()
+
+    expect(useCollapsedProviderGroups().isGroupCollapsed('nvidia')).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes #2492.

The Set Session Model dialog cleared its collapse state on every open, so someone with forty providers folded the same groups away again every single time they opened it.

While tracing it I found the same three lines — a local `ref<Record<string, boolean>>`, a toggle, and a reset to `{}` on open — copied into four places:

- `ChatPanel` (the dialog the issue is about)
- `ModelSelector`
- `CombinationModelsPanel`
- `WorkflowModelSelector`

So this fixes the reported dialog and the three siblings that would have been reported next.

## What it does

All four now read one record from `useCollapsedProviderGroups`, persisted under `hermes.models.collapsedProviderGroups`. It is built on the `usePersistentRecord` composable already used by the sidebar for its own collapse state, rather than adding a second way to do the same thing.

Two details worth the review:

- **The record lives at module scope.** `usePersistentRecord` writes the whole record on `persist()`, so four independent instances would overwrite each other: collapse a group in the session-model dialog, collapse another in the workflow picker, and the first one is gone. One shared instance removes that entirely. It also means a provider you have folded away stays folded wherever you meet it, which I think is what a user expects from a group they have deliberately hidden — happy to key it per surface instead if you would rather keep them independent.
- **Only collapsed groups are stored.** Expanding removes the key rather than writing `false`, so the record cannot grow forever with every provider the user has ever touched.

## Tests

`tests/client/collapsed-provider-groups.test.ts` — four cases: a collapsed group survives a reload; expanding drops it from storage rather than storing `false`; two pickers open at once keep each other's groups instead of overwriting them; and corrupt storage starts clean instead of throwing.

Reverting the composable to the old in-memory behaviour fails the first and third, which are the two that describe the bug.

`vue-tsc -b` is clean and `harness:check` passes. Full `tests/client`: 1270 passed, with one failure in `use-speech-tts` that fails identically on an untouched `main`.
