### PR TITLE
fix(files): a name that begins with dots is not a traversal segment

### DIFF
--- a/packages/server/src/services/hermes/file-provider.ts
+++ b/packages/server/src/services/hermes/file-provider.ts
@@ -127,7 +127,9 @@ export function resolveHermesPath(relativePath: string, profile?: string): strin
     return homeDir
   }
   const normalized = normalize(relativePath).replace(/\\/g, '/')
-  if (normalized.startsWith('..') || normalized.includes('/../') || normalized.startsWith('/')) {
+  // Only a literal `..` segment is traversal. `..hidden` and `...` are ordinary
+  // names, and validatePath already draws that line for absolute paths.
+  if (hasTraversalSegment(normalized) || normalized.startsWith('/')) {
     throw Object.assign(new Error('Invalid file path'), { code: 'invalid_path' })
   }
   const resolved = resolve(homeDir, normalized)

--- a/packages/server/src/services/hermes/hermes-path.ts
+++ b/packages/server/src/services/hermes/hermes-path.ts
@@ -98,6 +98,16 @@ function isComparableAbsolute(path: string, useWindows: boolean): boolean {
   return useWindows ? pathWin32.isAbsolute(path) : isAbsolute(path)
 }
 
+/**
+ * A relative path leaves its base only when its first segment is exactly `..`.
+ * A first segment that merely begins with dots — `..hidden`, `...` — names a
+ * child, and `relative()` can only produce it for a target inside the base.
+ */
+function startsWithParentSegment(relativePath: string): boolean {
+  const [first] = relativePath.split(/[\\/]/)
+  return first === '..'
+}
+
 function dirnameComparablePath(path: string, useWindows: boolean): string {
   return useWindows ? pathWin32.dirname(path) : dirname(path)
 }
@@ -107,7 +117,7 @@ export function isPathWithin(targetPath: string, basePath: string): boolean {
   const base = resolveComparablePath(basePath, useWindows)
   const target = resolveComparablePath(targetPath, useWindows)
   const rel = relativeComparablePath(comparablePath(base), comparablePath(target), useWindows)
-  return rel === '' || (!!rel && !rel.startsWith('..') && !isComparableAbsolute(rel, useWindows))
+  return rel === '' || (!!rel && !startsWithParentSegment(rel) && !isComparableAbsolute(rel, useWindows))
 }
 
 export function relativePathFromBase(targetPath: string, basePath: string): string | null {

--- a/tests/server/file-provider-paths.test.ts
+++ b/tests/server/file-provider-paths.test.ts
@@ -44,6 +44,15 @@ describe('Hermes path containment helpers', () => {
     expect(isPathWithin('/tmp/hermes-profile/state.db', '/tmp/hermes-profile')).toBe(true)
   })
 
+  it('treats a child whose name begins with dots as inside the base', () => {
+    expect(isPathWithin('/tmp/hermes-profile/..hidden', '/tmp/hermes-profile')).toBe(true)
+    expect(isPathWithin('/tmp/hermes-profile/...', '/tmp/hermes-profile')).toBe(true)
+    expect(isPathWithin('/tmp/hermes-profile/notes/..archive.md', '/tmp/hermes-profile')).toBe(true)
+    // A first segment of exactly `..` is still the one that leaves the base.
+    expect(isPathWithin('/tmp/hermes-profile/../evil', '/tmp/hermes-profile')).toBe(false)
+    expect(isPathWithin('/tmp', '/tmp/hermes-profile')).toBe(false)
+  })
+
   it('returns normalized relative paths only for children', () => {
     expect(relativePathFromBase('/tmp/hermes-profile/logs/run.txt', '/tmp/hermes-profile'))
       .toBe('logs/run.txt')

--- a/tests/server/resolve-hermes-path.test.ts
+++ b/tests/server/resolve-hermes-path.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { join } from 'path'
+
+const HOME = '/tmp/hermes-resolve-home'
+
+/**
+ * resolveHermesPath decides which paths the file APIs will touch. These pin
+ * down the difference between a `..` segment, which is traversal, and a name
+ * that merely begins with dots, which is a file.
+ */
+describe('resolveHermesPath', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.doMock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+      getActiveProfileDir: () => HOME,
+      getActiveEnvPath: () => join(HOME, '.env'),
+      getProfileDir: (profile: string) => join(HOME, 'profiles', profile),
+    }))
+  })
+
+  afterEach(() => {
+    vi.doUnmock('../../packages/server/src/services/hermes/hermes-profile')
+    vi.resetModules()
+  })
+
+  async function resolveHermesPath() {
+    return (await import('../../packages/server/src/services/hermes/file-provider')).resolveHermesPath
+  }
+
+  it('resolves an ordinary relative path under the profile home', async () => {
+    const resolve = await resolveHermesPath()
+    expect(resolve('skills/notes.md')).toBe(join(HOME, 'skills/notes.md'))
+  })
+
+  it('resolves under the requested profile rather than the active one', async () => {
+    const resolve = await resolveHermesPath()
+    expect(resolve('config.yaml', 'work')).toBe(join(HOME, 'profiles/work/config.yaml'))
+  })
+
+  it('accepts names that begin with dots but are not traversal', async () => {
+    const resolve = await resolveHermesPath()
+    expect(resolve('..hidden')).toBe(join(HOME, '..hidden'))
+    expect(resolve('...')).toBe(join(HOME, '...'))
+    expect(resolve('notes/..archive.md')).toBe(join(HOME, 'notes/..archive.md'))
+  })
+
+  it('rejects a parent-directory segment wherever it appears', async () => {
+    const resolve = await resolveHermesPath()
+    expect(() => resolve('..')).toThrow('Invalid file path')
+    expect(() => resolve('../etc/passwd')).toThrow('Invalid file path')
+    expect(() => resolve('skills/../../etc/passwd')).toThrow('Invalid file path')
+  })
+
+  it('still refuses an absolute path', async () => {
+    const resolve = await resolveHermesPath()
+    expect(() => resolve('/etc/passwd')).toThrow('Invalid file path')
+    expect(() => resolve(join(HOME, 'skills'))).toThrow('Invalid file path')
+  })
+
+  it('returns the home directory for the empty, dot and root forms', async () => {
+    const resolve = await resolveHermesPath()
+    expect(resolve('')).toBe(HOME)
+    expect(resolve('.')).toBe(HOME)
+    expect(resolve('/')).toBe(HOME)
+  })
+})


### PR DESCRIPTION
Addresses the second half of #1848, and deliberately not the first — reasoning below, so you can overrule it.

## The bug

`isPathWithin` decides containment with `rel.startsWith('..')`. A leading `..` is read as an escape, but `..hidden` and `...` are ordinary file names, and `relative()` can only produce them for a target that is *inside* the base.

So a file legitimately named `..hidden` in a profile home is judged to be outside that home, and every file API refuses it — list, stat, read, write, preview. `resolveHermesPath` repeated the same test on the incoming path, so it refused those names a second time.

`validatePath`, right next to it, already draws the line correctly for absolute paths, and there is already a test asserting that `foo..bar.txt` is fine. The two halves of the same module simply disagreed.

## The fix

Containment now looks at the **first path segment** — the only place `relative()` can put an escape — and `resolveHermesPath` reuses the `hasTraversalSegment` helper that `validatePath` uses.

This narrows what is *called* an escape; it does not widen what is *reached*. `../evil`, `skills/../../etc/passwd` and a base's own parent are refused exactly as before, and the tests assert each of those.

## What I did not do, and why

The issue also asks for the `normalized.startsWith('/')` guard in `resolveHermesPath` to be dropped so absolute paths can be passed in.

I traced what the client actually sends before touching it. The file browser navigates with the relative `entry.path`; `absolutePath` is consumed in exactly one place, `getClipboardPathForEntry` in the context menu, and never sent back. `download.ts` already routes absolute paths to `validatePath` instead. So the reported symptom — the browser breaking on absolute paths — does not reproduce through the UI, and the guard is a contract ("this function takes a path relative to the home") rather than a defect.

Removing it would loosen a boundary check to serve a caller that does not exist, so this PR leaves the guard in place. The fix here stands on its own either way: if some caller ever does need to pass an absolute path in, that is a separate and contained change on top of this one, not a reason to delete the guard now.

## Tests

`tests/server/resolve-hermes-path.test.ts` (new, 6 cases): ordinary relative paths; a named profile rather than the active one; dot-leading names accepted; `..` refused as a first segment, mid-path and alone; absolute paths still refused; and the empty/`.`/`/` forms still returning the home directory.

`tests/server/file-provider-paths.test.ts` gains a case pinning `isPathWithin` itself, since that is where the defect actually lived.

Reverting `hermes-path.ts` alone fails exactly the two new cases that describe the bug. `tsc` is clean, `harness:check` passes, and `tests/server` is green except `studio-mcp-autoinject`, which fails with the same 13 errors on an untouched `main`.
