### PR TITLE
[codex] add website privacy policy

### DIFF
--- a/packages/website/privacy/index.html
+++ b/packages/website/privacy/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Hermes Studio privacy policy, including how Google user data is accessed, used, stored, and shared."
+    />
+    <title>Privacy Policy - Hermes Studio</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/privacy-main.ts"></script>
+  </body>
+</html>

--- a/packages/website/src/PrivacyApp.vue
+++ b/packages/website/src/PrivacyApp.vue
@@ -1,0 +1,564 @@
+<script setup lang="ts">
+import { watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { locale, t } = useI18n()
+
+const sections = [
+  { key: 'information', number: '01', paragraphs: 2 },
+  { key: 'use', number: '02', paragraphs: 1 },
+  { key: 'google', number: '03', paragraphs: 3 },
+  { key: 'processing', number: '04', paragraphs: 2 },
+  { key: 'sharing', number: '05', paragraphs: 1 },
+  { key: 'retention', number: '06', paragraphs: 2 },
+  { key: 'security', number: '07', paragraphs: 1 },
+  { key: 'rights', number: '08', paragraphs: 1 },
+  { key: 'children', number: '09', paragraphs: 2 },
+  { key: 'updates', number: '10', paragraphs: 2 },
+] as const
+
+function switchLocale() {
+  const next = locale.value === 'en' ? 'zh' : 'en'
+  locale.value = next
+  localStorage.setItem('hermes_website_locale', next)
+}
+
+watchEffect(() => {
+  document.documentElement.lang = locale.value === 'zh' ? 'zh-CN' : 'en'
+  document.title = t('privacy.browserTitle')
+})
+</script>
+
+<template>
+  <div class="privacy-page">
+    <header class="masthead">
+      <a class="brand" href="/" :aria-label="t('privacy.homeLabel')">
+        <span class="brand-mark">
+          <img src="/logo.png" alt="" width="43" height="43" />
+        </span>
+        <span class="brand-copy">
+          <strong>{{ t('brand.name') }}</strong>
+          <small>AGENT WORKSPACE</small>
+        </span>
+      </a>
+      <div class="masthead-actions">
+        <span class="document-tag">{{ t('privacy.documentTag') }}</span>
+        <button class="language-button" type="button" @click="switchLocale">
+          {{ locale === 'en' ? '中' : 'EN' }}
+        </button>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" aria-labelledby="page-title">
+        <div class="hero-copy">
+          <p class="eyebrow">{{ t('privacy.eyebrow') }}</p>
+          <h1 id="page-title">{{ t('privacy.title') }}</h1>
+          <p class="lede">{{ t('privacy.lede') }}</p>
+        </div>
+        <dl class="metadata">
+          <div>
+            <dt>{{ t('privacy.effectiveDateLabel') }}</dt>
+            <dd>{{ t('privacy.effectiveDate') }}</dd>
+          </div>
+          <div>
+            <dt>{{ t('privacy.productLabel') }}</dt>
+            <dd>{{ t('privacy.product') }}</dd>
+          </div>
+          <div>
+            <dt>{{ t('privacy.developerLabel') }}</dt>
+            <dd>{{ t('privacy.developer') }}</dd>
+          </div>
+          <div>
+            <dt>{{ t('privacy.contactLabel') }}</dt>
+            <dd>
+              <a href="mailto:hermes.studio.ai@gmail.com">{{ t('privacy.contactEmail') }}</a>
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <div class="policy-layout">
+        <aside class="index" :aria-label="t('privacy.contents')">
+          <p>{{ t('privacy.contents') }}</p>
+          <ol>
+            <li v-for="section in sections" :key="section.key">
+              <a :href="`#section-${section.number}`">
+                <span>{{ section.number }}</span>
+                {{ t(`privacy.sections.${section.key}.title`) }}
+              </a>
+            </li>
+          </ol>
+        </aside>
+
+        <article class="policy">
+          <div class="notice">
+            <strong>{{ t('privacy.noticeTitle') }}</strong>
+            <p>{{ t('privacy.noticeBody') }}</p>
+          </div>
+
+          <section
+            v-for="section in sections"
+            :id="`section-${section.number}`"
+            :key="section.key"
+            class="policy-section"
+          >
+            <span class="section-number" aria-hidden="true">{{ section.number }}</span>
+            <div>
+              <h2>{{ t(`privacy.sections.${section.key}.title`) }}</h2>
+              <p v-for="paragraphIndex in section.paragraphs" :key="paragraphIndex">
+                {{ t(`privacy.sections.${section.key}.paragraphs.${paragraphIndex - 1}`) }}
+              </p>
+
+              <div v-if="section.key === 'google'" class="policy-links">
+                <a
+                  href="https://developers.google.com/terms/api-services-user-data-policy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {{ t('privacy.googlePolicyLink') }}
+                </a>
+              </div>
+
+              <div v-if="section.key === 'retention'" class="policy-links">
+                <a
+                  href="https://myaccount.google.com/permissions"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {{ t('privacy.googlePermissionsLink') }}
+                </a>
+              </div>
+
+              <a
+                v-if="section.key === 'updates'"
+                class="contact-link"
+                href="mailto:hermes.studio.ai@gmail.com"
+              >
+                {{ t('privacy.contactAction') }}
+              </a>
+            </div>
+          </section>
+        </article>
+      </div>
+    </main>
+
+    <footer class="privacy-footer">
+      <p>{{ t('privacy.copyright') }}</p>
+      <a href="#page-title">{{ t('privacy.backToTop') }}</a>
+    </footer>
+  </div>
+</template>
+
+<style scoped lang="scss">
+:global(html) {
+  scroll-behavior: smooth;
+}
+
+:global(body) {
+  margin: 0;
+  background: #f2f0e8;
+}
+
+.privacy-page {
+  --privacy-ink: #17201d;
+  --privacy-muted: #65706a;
+  --privacy-paper: #f2f0e8;
+  --privacy-sheet: #fbfaf5;
+  --privacy-line: #cbc8ba;
+  --privacy-moss: #1f5142;
+  --privacy-acid: #d8e878;
+
+  min-height: 100vh;
+  color: var(--privacy-ink);
+  background: var(--privacy-paper);
+  font-family: "Songti SC", "STSong", "Noto Serif CJK SC", Georgia, serif;
+  text-rendering: optimizeLegibility;
+}
+
+.masthead {
+  min-height: 92px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px clamp(24px, 5vw, 76px);
+  border-bottom: 1px solid var(--privacy-line);
+  background: rgba(242, 240, 232, 0.94);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand-mark {
+  width: 48px;
+  height: 48px;
+  overflow: hidden;
+  flex: 0 0 auto;
+  background: #fff;
+  border: 1px solid var(--privacy-line);
+  border-radius: 8px;
+  box-shadow: 0 2px 0 rgba(23, 32, 29, 0.12);
+}
+
+.brand-mark img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.brand-copy strong {
+  display: block;
+  font-family: Georgia, serif;
+  font-size: 18px;
+}
+
+.brand-copy small,
+.document-tag,
+.eyebrow,
+.index,
+dt {
+  font-family: "Avenir Next Condensed", "DIN Condensed", sans-serif;
+  letter-spacing: 0.08em;
+}
+
+.brand-copy small {
+  display: block;
+  margin-top: 3px;
+  color: var(--privacy-muted);
+  font-size: 9px;
+}
+
+.masthead-actions {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.document-tag {
+  color: var(--privacy-muted);
+  font-size: 11px;
+}
+
+.language-button {
+  width: 40px;
+  height: 36px;
+  border: 1px solid var(--privacy-line);
+  border-radius: 6px;
+  background: var(--privacy-sheet);
+  color: var(--privacy-ink);
+  cursor: pointer;
+  font: 700 12px/1 "Avenir Next", sans-serif;
+}
+
+.language-button:hover,
+.language-button:focus-visible {
+  border-color: var(--privacy-moss);
+  outline: none;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.55fr) minmax(280px, 0.7fr);
+  gap: clamp(48px, 8vw, 130px);
+  padding: clamp(64px, 10vw, 140px) clamp(24px, 8vw, 124px) clamp(68px, 9vw, 126px);
+  background:
+    radial-gradient(circle at 88% 20%, rgba(216, 232, 120, 0.42) 0 8%, transparent 28%),
+    linear-gradient(125deg, var(--privacy-sheet) 0 68%, #e4e6d8 68%);
+  border-bottom: 1px solid var(--privacy-line);
+}
+
+.eyebrow {
+  margin: 0 0 28px;
+  color: var(--privacy-moss);
+  font-size: 12px;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(58px, 9vw, 132px);
+  font-weight: 700;
+  line-height: 0.9;
+  letter-spacing: 0;
+}
+
+.lede {
+  max-width: 760px;
+  margin: 42px 0 0;
+  color: var(--privacy-muted);
+  font-size: clamp(18px, 2vw, 26px);
+  line-height: 1.75;
+}
+
+.metadata {
+  align-self: end;
+  margin: 0;
+  border-top: 3px solid var(--privacy-ink);
+}
+
+.metadata div {
+  padding: 16px 0 17px;
+  border-bottom: 1px solid var(--privacy-line);
+}
+
+dt {
+  color: var(--privacy-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+dd {
+  margin: 8px 0 0;
+  font-size: 15px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+dd a {
+  color: inherit;
+  text-decoration-color: var(--privacy-moss);
+  text-underline-offset: 4px;
+}
+
+.policy-layout {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 820px);
+  gap: clamp(55px, 8vw, 130px);
+  justify-content: center;
+  padding: clamp(64px, 8vw, 120px) 24px;
+}
+
+.index {
+  position: sticky;
+  top: 28px;
+  align-self: start;
+  font-size: 11px;
+}
+
+.index p {
+  margin: 0 0 20px;
+  color: var(--privacy-moss);
+}
+
+.index ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid var(--privacy-line);
+}
+
+.index li {
+  border-bottom: 1px solid var(--privacy-line);
+}
+
+.index a {
+  display: flex;
+  gap: 8px;
+  padding: 11px 0;
+  color: var(--privacy-muted);
+  text-decoration: none;
+  letter-spacing: 0;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.index a:hover,
+.index a:focus-visible {
+  color: var(--privacy-ink);
+  transform: translateX(5px);
+}
+
+.index a span {
+  color: var(--privacy-moss);
+}
+
+.notice {
+  margin-bottom: 66px;
+  padding: 27px 30px 30px;
+  background: var(--privacy-moss);
+  color: #f7f4e8;
+  border-radius: 2px 8px 2px 2px;
+}
+
+.notice strong {
+  font-size: 20px;
+}
+
+.notice p {
+  margin: 10px 0 0;
+  color: #d9e4dc;
+  font-size: 15px;
+  line-height: 1.9;
+}
+
+.policy-section {
+  scroll-margin-top: 24px;
+  display: grid;
+  grid-template-columns: 58px 1fr;
+  gap: 18px;
+  padding: 0 0 58px;
+  margin-bottom: 58px;
+  border-bottom: 1px solid var(--privacy-line);
+}
+
+.section-number {
+  padding-top: 8px;
+  color: var(--privacy-moss);
+  font: 700 12px/1 "Avenir Next Condensed", sans-serif;
+}
+
+h2 {
+  margin: 0 0 24px;
+  font-size: clamp(27px, 3.3vw, 42px);
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.policy-section p {
+  margin: 0 0 18px;
+  color: #4f5954;
+  font-size: 18px;
+  line-height: 2.05;
+}
+
+.policy-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.policy-links a {
+  color: var(--privacy-moss);
+  font: 700 14px/1.5 "Avenir Next", sans-serif;
+  text-underline-offset: 4px;
+}
+
+.contact-link {
+  display: inline-block;
+  margin-top: 8px;
+  padding: 13px 18px;
+  border: 1px solid var(--privacy-ink);
+  background: var(--privacy-acid);
+  color: var(--privacy-ink);
+  box-shadow: 4px 4px 0 var(--privacy-ink);
+  font-weight: 700;
+  text-decoration: none;
+  transition: transform 0.18s, box-shadow 0.18s;
+}
+
+.contact-link:hover,
+.contact-link:focus-visible {
+  transform: translate(3px, 3px);
+  box-shadow: 1px 1px 0 var(--privacy-ink);
+}
+
+.privacy-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 32px clamp(24px, 8vw, 124px);
+  background: var(--privacy-ink);
+  color: #dce3dc;
+  font: 12px/1.4 "Avenir Next Condensed", sans-serif;
+  letter-spacing: 0.04em;
+}
+
+.privacy-footer p {
+  margin: 0;
+}
+
+.privacy-footer a {
+  color: var(--privacy-acid);
+  text-decoration: none;
+}
+
+@media (max-width: 840px) {
+  .hero {
+    grid-template-columns: 1fr;
+    background:
+      radial-gradient(circle at 90% 12%, rgba(216, 232, 120, 0.48), transparent 30%),
+      var(--privacy-sheet);
+  }
+
+  .metadata {
+    max-width: 520px;
+  }
+
+  .policy-layout {
+    display: block;
+  }
+
+  .index {
+    display: none;
+  }
+}
+
+@media (max-width: 540px) {
+  .masthead {
+    min-height: 76px;
+  }
+
+  .document-tag,
+  .brand-copy small {
+    display: none;
+  }
+
+  .hero {
+    padding-top: 58px;
+  }
+
+  h1 {
+    font-size: 54px;
+  }
+
+  .lede {
+    margin-top: 28px;
+    font-size: 17px;
+  }
+
+  .policy-layout {
+    padding-top: 48px;
+  }
+
+  .notice {
+    margin-bottom: 48px;
+    padding: 23px;
+  }
+
+  .policy-section {
+    grid-template-columns: 38px 1fr;
+    gap: 6px;
+    padding-bottom: 40px;
+    margin-bottom: 40px;
+  }
+
+  .policy-section p {
+    font-size: 16px;
+    line-height: 1.95;
+  }
+
+  .privacy-footer {
+    display: block;
+  }
+
+  .privacy-footer a {
+    display: inline-block;
+    margin-top: 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :global(html) {
+    scroll-behavior: auto;
+  }
+
+  * {
+    transition: none !important;
+  }
+}
+</style>

--- a/packages/website/src/components/layout/SiteFooter.vue
+++ b/packages/website/src/components/layout/SiteFooter.vue
@@ -17,6 +17,7 @@ const { t } = useI18n()
       <div class="footer-right">
         <p class="footer-meta">{{ t('footer.madeWith') }}</p>
         <p class="footer-meta">{{ t('footer.license') }}</p>
+        <a class="footer-legal" href="/privacy/">{{ t('footer.privacy') }}</a>
         <div class="footer-links">
           <a
             class="footer-social"
@@ -149,6 +150,19 @@ const { t } = useI18n()
 .footer-meta {
   color: rgba(42, 50, 64, 0.58);
   font-size: 13px;
+}
+
+.footer-legal {
+  color: rgba(30, 50, 90, 0.72);
+  font-size: 13px;
+  text-decoration: underline;
+  text-decoration-color: rgba(30, 50, 90, 0.24);
+  text-underline-offset: 4px;
+
+  &:hover {
+    color: rgba(30, 50, 90, 0.96);
+    text-decoration-color: currentColor;
+  }
 }
 
 .footer-links {

--- a/packages/website/src/i18n/en.ts
+++ b/packages/website/src/i18n/en.ts
@@ -197,6 +197,100 @@ export default {
     x: 'Open X',
     douyin: 'Open Douyin',
     xiaohongshu: 'Open Xiaohongshu',
+    privacy: 'Privacy Policy',
+  },
+  privacy: {
+    browserTitle: 'Privacy Policy - Hermes Studio',
+    homeLabel: 'Back to the Hermes Studio homepage',
+    documentTag: 'LEGAL / PRIVACY',
+    eyebrow: 'HERMES STUDIO / PRIVACY & DATA',
+    title: 'Privacy Policy',
+    lede: 'This policy explains how Hermes Studio and EKKOLearnAI handle information associated with you, including Google user data, and the choices available to you.',
+    effectiveDateLabel: 'Effective date',
+    effectiveDate: 'August 11, 2026',
+    productLabel: 'Covered product',
+    product: 'Hermes Studio applications and services',
+    developerLabel: 'Developer',
+    developer: 'EKKOLearnAI',
+    contactLabel: 'Privacy contact',
+    contactEmail: "hermes.studio.ai{'@'}gmail.com",
+    contents: 'Contents',
+    noticeTitle: 'Local-first data processing',
+    noticeBody: 'Hermes Studio can run on your device or in an environment you control. EKKOLearnAI does not automatically receive conversations, files, or credentials from a self-hosted installation. The processing location and parties involved depend on the features and third-party services you choose.',
+    googlePolicyLink: 'Google API Services User Data Policy',
+    googlePermissionsLink: 'Manage Google Account permissions',
+    contactAction: 'Send a privacy request',
+    copyright: 'Copyright 2026 Hermes Studio / EKKOLearnAI',
+    backToTop: 'Back to top',
+    sections: {
+      information: {
+        title: 'Information we process',
+        paragraphs: [
+          'Depending on how you deploy and use Hermes Studio, the application may process account information such as an email address and display name; device, network, and connection information; application configuration; operational logs and error diagnostics; and conversations, files, instructions, feedback, or other content you choose to provide.',
+          'When you connect a model provider, device, coding agent, or other service, Hermes Studio may also process the authorization state, service identifiers, credentials, and request results needed to operate that connection. We do not intentionally request sensitive information that is unrelated to a feature you choose to use.',
+        ],
+      },
+      use: {
+        title: 'How information is used',
+        paragraphs: [
+          'Information is used to provide and maintain the features you request, authenticate connections, run conversations and workflows, manage profiles and devices, protect the service, diagnose faults, provide support, improve user-facing functionality, and comply with applicable legal obligations.',
+        ],
+      },
+      google: {
+        title: 'Google API Services and Google user data',
+        paragraphs: [
+          'If you choose to connect a Google account or Google service, Hermes Studio may access the Google account email address and basic profile information you authorize, OAuth access and refresh tokens, relevant cloud project or service identifiers, and the request or response content needed to perform an action you initiate.',
+          'Google user data is used only to authenticate you, maintain the authorized connection, show its status, and invoke the Google feature or service you selected. Hermes Studio does not sell Google user data, use it for advertising, or use it to train generalized artificial intelligence or machine-learning models.',
+          'Human access to Google user data is not permitted except with your explicit consent for support, when necessary to investigate abuse or a security incident, or when required by law. Hermes Studio use and transfer of information received from Google APIs adheres to the Google API Services User Data Policy, including its Limited Use requirements.',
+        ],
+      },
+      processing: {
+        title: 'Local and third-party processing',
+        paragraphs: [
+          'Application data can be stored on your device or self-hosted environment. When you intentionally select a third-party model, cloud service, messaging platform, or device integration, the information required to complete your request is sent to that provider and is also governed by the provider\'s terms and privacy policy.',
+          'Review the destination service before sending passwords, private keys, identity documents, medical records, or other highly sensitive information.',
+        ],
+      },
+      sharing: {
+        title: 'Sharing and disclosure',
+        paragraphs: [
+          'We do not sell personal information. Information is disclosed only as needed to provide a feature you selected, with your direction or consent, to service providers acting on our behalf, to an administrator of an organization-managed deployment, to protect users and systems, or when required by applicable law. Third-party providers selected and configured by you receive only the data needed for the requests you send to them.',
+        ],
+      },
+      retention: {
+        title: 'Storage, retention, and deletion',
+        paragraphs: [
+          'Data stored by a local or self-hosted installation remains under the control of you or your administrator and is retained until it is deleted from that installation. OAuth credentials remain locally until the connection or credentials are removed, the profile data is deleted, or access is revoked with the provider. Support correspondence is retained only as needed to respond and meet security or legal obligations.',
+          'Uninstalling the application may not remove data from a self-hosted server, backup, organization-managed environment, or third-party service. Delete data from each relevant location. You can revoke Google access from your Google Account permissions page and remove locally stored connection credentials from Hermes Studio. Contact us to request access to or deletion of personal information controlled by EKKOLearnAI.',
+        ],
+      },
+      security: {
+        title: 'Security measures',
+        paragraphs: [
+          'We use reasonable technical and organizational safeguards appropriate to the product, including access controls, credential isolation, restricted local file permissions, and transport protections where applicable. No system can guarantee absolute security, so protect your account, device, access tokens, deployment, and backups.',
+        ],
+      },
+      rights: {
+        title: 'Your choices and rights',
+        paragraphs: [
+          'Depending on applicable law, you may have rights to access, correct, export, or delete personal information, withdraw consent, revoke a connected service, or restrict certain processing. Use the controls in Hermes Studio and the connected provider first, or contact us for information controlled by EKKOLearnAI. We may need to verify your request before acting on it.',
+        ],
+      },
+      children: {
+        title: 'Children and international processing',
+        paragraphs: [
+          'Hermes Studio is not directed to children below the minimum digital-consent age in their jurisdiction. Contact us if you believe a child provided personal information without appropriate consent.',
+          'When you select a provider or deployment in another country or region, information may be processed in that jurisdiction. Appropriate safeguards will be used where required by applicable law.',
+        ],
+      },
+      updates: {
+        title: 'Policy updates and contact',
+        paragraphs: [
+          'We may update this policy when the product, technology, or legal requirements change. The effective date above will be revised, and material changes will be communicated through the application, website, or another reasonable channel.',
+          'For privacy questions, data-rights requests, or deletion requests concerning information controlled by EKKOLearnAI, email the privacy contact shown on this page.',
+        ],
+      },
+    },
   },
   docs: {
     placeholder: 'Select a section from the sidebar to get started.',

--- a/packages/website/src/i18n/zh.ts
+++ b/packages/website/src/i18n/zh.ts
@@ -197,6 +197,100 @@ export default {
     x: '打开 X',
     douyin: '打开抖音',
     xiaohongshu: '打开小红书',
+    privacy: '隐私政策',
+  },
+  privacy: {
+    browserTitle: '隐私政策 - Hermes Studio',
+    homeLabel: '返回 Hermes Studio 官网首页',
+    documentTag: '法律 / 隐私',
+    eyebrow: 'HERMES STUDIO / 隐私与数据',
+    title: '隐私政策',
+    lede: '本政策说明 Hermes Studio 与 EKKOLearnAI 如何处理与你相关的信息（包括 Google 用户数据），以及你可以作出的选择。',
+    effectiveDateLabel: '生效日期',
+    effectiveDate: '2026 年 8 月 11 日',
+    productLabel: '适用产品',
+    product: 'Hermes Studio 应用与服务',
+    developerLabel: '开发者',
+    developer: 'EKKOLearnAI',
+    contactLabel: '隐私联系邮箱',
+    contactEmail: "hermes.studio.ai{'@'}gmail.com",
+    contents: '目录',
+    noticeTitle: '本地优先的数据处理',
+    noticeBody: 'Hermes Studio 可运行在你的设备或由你控制的环境中。EKKOLearnAI 不会自动接收自托管安装中的对话、文件或凭据。实际的数据处理位置和参与方取决于你选择的功能与第三方服务。',
+    googlePolicyLink: 'Google API 服务用户数据政策',
+    googlePermissionsLink: '管理 Google 账号授权',
+    contactAction: '发送隐私请求',
+    copyright: '版权所有 2026 Hermes Studio / EKKOLearnAI',
+    backToTop: '返回顶部',
+    sections: {
+      information: {
+        title: '我们处理的信息',
+        paragraphs: [
+          '根据你的部署方式和功能选择，Hermes Studio 可能处理账号信息（如邮箱和显示名称）、设备与网络连接信息、应用配置、运行日志与错误诊断数据，以及你主动提供的对话、文件、指令、反馈或其他内容。',
+          '当你连接模型提供商、设备、编程智能体或其他服务时，Hermes Studio 还可能处理运行该连接所必需的授权状态、服务标识、凭据和请求结果。除非你选择的功能明确需要，我们不会主动索取与该功能无关的敏感信息。',
+        ],
+      },
+      use: {
+        title: '信息的使用目的',
+        paragraphs: [
+          '相关信息仅用于提供和维护你请求的功能、验证连接、运行对话与工作流、管理配置和设备、保障服务安全、排查故障、提供支持、改进面向用户的功能，以及履行适用的法律义务。',
+        ],
+      },
+      google: {
+        title: 'Google API 服务与 Google 用户数据',
+        paragraphs: [
+          '当你主动连接 Google 账号或 Google 服务时，Hermes Studio 可能访问你授权的 Google 账号邮箱和基础个人资料、OAuth 访问令牌与刷新令牌、相关云项目或服务标识，以及完成你发起的操作所必需的请求或响应内容。',
+          'Google 用户数据仅用于验证你的身份、维持授权连接、显示连接状态，以及调用你选择的 Google 功能或服务。Hermes Studio 不会出售 Google 用户数据，不会将其用于广告，也不会使用这些数据训练通用人工智能或机器学习模型。',
+          '除非你为获得支持而明确同意、需要调查滥用或安全事件，或法律要求，否则不允许人员读取 Google 用户数据。Hermes Studio 对从 Google API 获得的信息的使用和传输遵守 Google API 服务用户数据政策，包括其“有限使用”要求。',
+        ],
+      },
+      processing: {
+        title: '本地处理与第三方处理',
+        paragraphs: [
+          '应用数据可以保存在你的设备或自托管环境中。当你主动选择第三方模型、云服务、消息平台或设备集成时，完成请求所必需的信息会发送给该提供商，并同时受该提供商的条款与隐私政策约束。',
+          '在提交密码、私钥、身份证件、医疗记录或其他高度敏感的信息前，请先了解目标服务的数据政策。',
+        ],
+      },
+      sharing: {
+        title: '信息共享与披露',
+        paragraphs: [
+          '我们不会出售个人信息。仅在提供你选择的功能、按照你的指示或授权、向代表我们处理数据的服务提供商披露、支持组织管理的部署、保护用户与系统，或履行适用法律义务时披露相关信息。由你选择和配置的第三方提供商只会收到完成你所发送请求所需的数据。',
+        ],
+      },
+      retention: {
+        title: '数据存储、保留与删除',
+        paragraphs: [
+          '本地或自托管安装中的数据由你或管理员控制，并会保留至从该安装中删除为止。OAuth 凭据会保存在本地，直至连接或凭据被移除、配置数据被删除，或你在服务提供商处撤销授权。支持邮件仅在回复请求以及满足安全或法律义务所需的期间内保留。',
+          '卸载应用不一定会删除自托管服务器、备份、组织管理环境或第三方服务中的数据，请分别在相关位置执行删除。你可以在 Google 账号授权页面撤销 Google 访问权限，并从 Hermes Studio 中移除本地保存的连接凭据。如需访问或删除由 EKKOLearnAI 控制的个人信息，请联系我们。',
+        ],
+      },
+      security: {
+        title: '安全措施',
+        paragraphs: [
+          '我们采取与产品相适应的合理技术和组织措施，包括访问控制、凭据隔离、受限的本地文件权限，以及在适用情况下提供传输保护。但任何系统都无法保证绝对安全，请妥善保护账号、设备、访问令牌、部署环境和备份。',
+        ],
+      },
+      rights: {
+        title: '你的选择与权利',
+        paragraphs: [
+          '根据适用法律，你可能有权访问、更正、导出或删除个人信息，撤回同意，撤销已连接的服务，或限制特定处理。请先使用 Hermes Studio 与所连接服务提供商的控制功能；对于由 EKKOLearnAI 控制的信息，也可以联系我们。为保护数据安全，我们可能需要先验证你的请求。',
+        ],
+      },
+      children: {
+        title: '未成年人及跨境处理',
+        paragraphs: [
+          'Hermes Studio 不面向未达到所在司法辖区最低数字同意年龄的儿童。若你认为儿童在未经适当同意的情况下提供了个人信息，请联系我们。',
+          '当你选择位于其他国家或地区的提供商或部署环境时，信息可能在相应司法辖区处理。我们会在适用法律要求的范围内采取适当的保护措施。',
+        ],
+      },
+      updates: {
+        title: '政策更新与联系',
+        paragraphs: [
+          '我们可能根据产品、技术或法律要求的变化更新本政策。届时会修改上方生效日期，并通过应用、网站或其他合理方式通知重大变更。',
+          '如对隐私保护有疑问，或希望就 EKKOLearnAI 控制的信息提出数据权利或删除请求，请发送邮件至本页面所列的隐私联系邮箱。',
+        ],
+      },
+    },
   },
   docs: {
     placeholder: '从侧边栏选择一个章节开始阅读。',

--- a/packages/website/src/privacy-main.ts
+++ b/packages/website/src/privacy-main.ts
@@ -1,0 +1,12 @@
+import { createApp } from 'vue'
+import { i18n } from './i18n'
+import PrivacyApp from './PrivacyApp.vue'
+import '@client/styles/variables.scss'
+import './styles/global.scss'
+
+localStorage.setItem('hermes_website_theme', 'light')
+document.documentElement.classList.remove('dark')
+
+const app = createApp(PrivacyApp)
+app.use(i18n)
+app.mount('#app')

--- a/vite.config.website.ts
+++ b/vite.config.website.ts
@@ -33,6 +33,10 @@ export default defineConfig({
     target: 'es2020',
     cssCodeSplit: true,
     rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'packages/website/index.html'),
+        privacy: resolve(__dirname, 'packages/website/privacy/index.html'),
+      },
       output: {
         manualChunks(id) {
           if (id.includes('node_modules')) {


### PR DESCRIPTION
## Summary
- add a dedicated, same-domain `/privacy/` HTML entry to the Hermes Studio website
- provide complete English and Chinese privacy disclosures, including Google user data access, use, storage, sharing, revocation, and Limited Use language
- link the privacy policy from the public homepage footer
- extend the website Vite build to emit both the main site and privacy page

## Why
Google OAuth verification requires an accessible privacy policy on the app's verified homepage domain, a discoverable homepage link, and disclosure of how Google user data is accessed, used, stored, and shared.

## User impact
Visitors can open the policy without signing in, switch between English and Chinese, contact the privacy address, review Google-specific handling, and follow the Google permission-revocation link.

## Validation
- `npm run harness:check`
- `npx vue-tsc -p tsconfig.website.json --noEmit`
- `npm run build:website`
- production preview verified at desktop and 375px mobile widths
- verified English/Chinese switching, no horizontal mobile overflow, and homepage-to-`/privacy/` navigation
- GitHub Actions: `Build website`, `build`, and `e2e` passed

## Review note
Before merge, the product owner should confirm the legal wording, developer identity, contact address, and effective date.
