### PR TITLE
fix(connections): avoid VPN addresses in LAN QR codes

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,7 +3,6 @@ import type { Context } from 'koa'
 import cors from '@koa/cors'
 import serve from 'koa-static'
 import send from 'koa-send'
-import os from 'os'
 import { relative, resolve } from 'path'
 import { mkdir } from 'fs/promises'
 import { readFileSync } from 'fs'
@@ -28,7 +27,7 @@ import { HermesSkillInjector } from './services/hermes/skill-injector'
 import { injectBundledMcpServer } from './services/hermes/studio-mcp-autoinject'
 import { ensureProfileGatewaysRunning } from './services/hermes/gateway-autostart'
 import { refreshConfiguredProviderModelCatalogsInBackground } from './services/hermes/model-catalog-cache'
-import { scanLanDevices, startLanDiscoveryResponder } from './services/lan-discovery'
+import { scanLanDevices, selectLanIPv4Address, startLanDiscoveryResponder } from './services/lan-discovery'
 import { getLanPeerSocketManager, getLanPeerSocketPath } from './services/lan-peer-socket'
 import { startGlobalAgentServer } from './services/global-agent/server'
 import { startLocalAppRelayServer } from './services/app-relay/server'
@@ -105,18 +104,6 @@ function getLoopbackBaseUrl(httpServer: any): string {
   const address = httpServer?.address?.()
   const port = typeof address === 'object' && address?.port ? address.port : config.port
   return `http://127.0.0.1:${port}`
-}
-
-/**
- * 安全获取网络接口信息（兼容 Termux/proot 环境）
- * 在 proot 环境中 os.networkInterfaces() 会抛出权限错误（errno 13）
- */
-function safeNetworkInterfaces() {
-  try {
-    return os.networkInterfaces()
-  } catch {
-    return {}
-  }
 }
 
 function isDesktopRuntime(): boolean {
@@ -434,8 +421,8 @@ export async function bootstrap() {
     })
   })
 
-  const interfaces = safeNetworkInterfaces()
-  const localIp = Object.values(interfaces).flat().find(i => i?.family === 'IPv4' && !i?.internal)?.address || 'localhost'
+  const selectedLanAddress = selectLanIPv4Address('')
+  const localIp = selectedLanAddress === '127.0.0.1' ? 'localhost' : selectedLanAddress
   console.log(`Server: http://localhost:${config.port} (LAN: http://${localIp}:${config.port})`)
   console.log(`Log: ${config.appHome}/logs/server.log`)
   logger.info('Server: http://localhost:%d (LAN: http://%s:%d)', config.port, localIp, config.port)

--- a/packages/server/src/services/lan-discovery.ts
+++ b/packages/server/src/services/lan-discovery.ts
@@ -57,6 +57,12 @@ type ScanOptions = {
   includeSelf?: boolean
 }
 
+export type LanIPv4Interface = {
+  name: string
+  address: string
+  netmask: string
+}
+
 let responderSockets: DiscoverySocket[] = []
 let cache: LanDiscoveryState = {
   scanning: false,
@@ -138,12 +144,13 @@ export function isPrivateOrLoopbackIPv4(ip: string): boolean {
   return false
 }
 
-function getIpv4Interfaces() {
+function getIpv4Interfaces(): LanIPv4Interface[] {
   try {
-    return Object.values(networkInterfaces())
-      .flat()
-      .filter(item => item && item.family === 'IPv4' && !item.internal && item.address && item.netmask)
-      .map(item => ({ address: item!.address, netmask: item!.netmask }))
+    return Object.entries(networkInterfaces()).flatMap(([name, addresses]) => (
+      (addresses || [])
+        .filter(item => item.family === 'IPv4' && !item.internal && item.address && item.netmask)
+        .map(item => ({ name, address: item.address, netmask: item.netmask }))
+    ))
   } catch {
     return []
   }
@@ -163,9 +170,40 @@ function broadcastAddress(address: string, netmask: string): string | null {
   return intToIpv4((ip | (~mask >>> 0)) >>> 0)
 }
 
-function selectLocalAddress(remoteAddress: string): string {
-  const remote = ipv4ToInt(remoteAddress)
-  const interfaces = getIpv4Interfaces()
+function isLikelyVirtualInterface(name: string): boolean {
+  const normalized = String(name || '').trim().toLowerCase()
+  return /^(?:utun|tun(?:\d|$)|tap(?:\d|$)|ppp(?:\d|$)|ipsec|wg(?:\d|$)|gif\d|stf\d|awdl\d|llw\d|bridge\d|docker\d|veth|virbr|vmnet|vboxnet|br-)/.test(normalized)
+    || /(?:vpn|openvpn|wireguard|wintun|tailscale|zerotier|zero tier|hamachi|clash|mihomo|sing[ -]?box|surge|cloudflare warp|tunnel|virtual|hyper-v|wsl|隧道|虚拟)/.test(normalized)
+}
+
+function isLikelyPhysicalInterface(name: string): boolean {
+  const normalized = String(name || '').trim().toLowerCase()
+  return /^(?:en\d+|eth\d+|enp\w+|eno\w+|ens\w+|wlan\d+|wl\w+)$/.test(normalized)
+    || /(?:wi-?fi|wireless|wlan|ethernet|以太网|无线)/.test(normalized)
+}
+
+function isRfc1918IPv4(ip: string): boolean {
+  const value = ipv4ToInt(ip)
+  if (value === null) return false
+  const first = (value >>> 24) & 255
+  const second = (value >>> 16) & 255
+  return first === 10 || (first === 172 && second >= 16 && second <= 31) || (first === 192 && second === 168)
+}
+
+function interfacePreference(iface: LanIPv4Interface): number {
+  let score = 0
+  if (isLikelyPhysicalInterface(iface.name)) score += 100
+  if (isRfc1918IPv4(iface.address)) score += 50
+  if (iface.address.startsWith('169.254.')) score -= 50
+  if (iface.netmask === '255.255.255.255') score -= 20
+  return score
+}
+
+export function selectLanIPv4Address(
+  remoteAddress: string,
+  interfaces: LanIPv4Interface[] = getIpv4Interfaces(),
+): string {
+  const remote = ipv4ToInt(normalizeRemoteAddress(remoteAddress))
   if (remote !== null) {
     for (const iface of interfaces) {
       const ip = ipv4ToInt(iface.address)
@@ -173,7 +211,12 @@ function selectLocalAddress(remoteAddress: string): string {
       if (ip !== null && mask !== null && (ip & mask) === (remote & mask)) return iface.address
     }
   }
-  return interfaces[0]?.address || '127.0.0.1'
+
+  const nonVirtualInterfaces = interfaces.filter(iface => !isLikelyVirtualInterface(iface.name))
+  const candidates = nonVirtualInterfaces.length ? nonVirtualInterfaces : interfaces
+  return candidates
+    .map((iface, index) => ({ iface, index, score: interfacePreference(iface) }))
+    .sort((a, b) => b.score - a.score || a.index - b.index)[0]?.iface.address || '127.0.0.1'
 }
 
 function normalizeRemoteAddress(value: string): string {
@@ -181,10 +224,14 @@ function normalizeRemoteAddress(value: string): string {
   return address.startsWith('::ffff:') ? address.slice('::ffff:'.length) : address
 }
 
-export function getLanBackendUrl(remoteAddress = '', httpPort = config.port): string {
+export function getLanBackendUrl(
+  remoteAddress = '',
+  httpPort = config.port,
+  interfaces: LanIPv4Interface[] = getIpv4Interfaces(),
+): string {
   const advertised = normalizeAdvertisedOrigin(config.lanAdvertiseUrl)
   if (advertised) return advertised
-  const address = selectLocalAddress(normalizeRemoteAddress(remoteAddress))
+  const address = selectLanIPv4Address(remoteAddress, interfaces)
   return `http://${address}:${httpPort}`
 }
 
@@ -193,12 +240,20 @@ export function getLanBackendUrlForRequest(
   requestOrigin = '',
   httpPort = config.port,
   advertisedUrl = config.lanAdvertiseUrl,
+  interfaces: LanIPv4Interface[] = getIpv4Interfaces(),
 ): string {
   const advertised = normalizeAdvertisedOrigin(advertisedUrl)
   if (advertised) return advertised
   const requested = normalizeAdvertisedOrigin(requestOrigin, true)
-  if (requested) return requested
-  const address = selectLocalAddress(normalizeRemoteAddress(remoteAddress))
+  if (requested) {
+    const requestedHostname = new URL(requested).hostname
+    const requestedInterface = interfaces.find(iface => iface.address === requestedHostname)
+    const hasNonVirtualInterface = interfaces.some(iface => !isLikelyVirtualInterface(iface.name))
+    if (!requestedInterface || !isLikelyVirtualInterface(requestedInterface.name) || !hasNonVirtualInterface) {
+      return requested
+    }
+  }
+  const address = selectLanIPv4Address(remoteAddress, interfaces)
   return `http://${address}:${httpPort}`
 }
 
@@ -255,7 +310,7 @@ async function buildAnnouncement(
   getSystemInfo: () => Promise<PublicSystemInfo>,
 ): Promise<DiscoveryAnnouncement> {
   const info = await getCachedLocalInfo(getSystemInfo)
-  const localAddress = selectLocalAddress(remoteAddress)
+  const localAddress = selectLanIPv4Address(remoteAddress)
   return {
     type: 'hermes.announce',
     version: DISCOVERY_VERSION,

--- a/tests/server/lan-discovery.test.ts
+++ b/tests/server/lan-discovery.test.ts
@@ -11,6 +11,7 @@ import {
   isPrivateOrLoopbackIPv4,
   resetLanDiscoveryState,
   scanLanDevices,
+  selectLanIPv4Address,
   startLanDiscoveryResponder,
 } from '../../packages/server/src/services/lan-discovery'
 import type { PublicSystemInfo } from '../../packages/server/src/services/system-info'
@@ -96,6 +97,47 @@ describe('LAN discovery', () => {
       6060,
       '',
     )).not.toBe('http://localhost:6060')
+  })
+
+  it('prefers a physical LAN interface over VPN and virtual adapters for local QR codes', () => {
+    const interfaces = [
+      { name: 'utun4', address: '10.8.0.2', netmask: '255.255.255.255' },
+      { name: 'docker0', address: '172.17.0.1', netmask: '255.255.0.0' },
+      { name: 'en0', address: '192.168.10.102', netmask: '255.255.255.0' },
+    ]
+
+    expect(selectLanIPv4Address('127.0.0.1', interfaces)).toBe('192.168.10.102')
+    expect(getLanBackendUrlForRequest(
+      '127.0.0.1',
+      'http://localhost:8648',
+      8648,
+      '',
+      interfaces,
+    )).toBe('http://192.168.10.102:8648')
+  })
+
+  it('ignores a VPN request origin when a physical LAN interface is available', () => {
+    const interfaces = [
+      { name: 'Tailscale Tunnel', address: '100.64.0.2', netmask: '255.255.255.255' },
+      { name: 'Wi-Fi', address: '192.168.1.20', netmask: '255.255.255.0' },
+    ]
+
+    expect(getLanBackendUrlForRequest(
+      '127.0.0.1',
+      'http://100.64.0.2:8648',
+      8648,
+      '',
+      interfaces,
+    )).toBe('http://192.168.1.20:8648')
+  })
+
+  it('keeps an exact remote subnet match even when it uses a VPN interface', () => {
+    const interfaces = [
+      { name: 'WireGuard Tunnel', address: '10.8.0.2', netmask: '255.255.255.0' },
+      { name: 'Ethernet', address: '192.168.1.20', netmask: '255.255.255.0' },
+    ]
+
+    expect(selectLanIPv4Address('10.8.0.50', interfaces)).toBe('10.8.0.2')
   })
 
   it('limits discovery responses to local/private IPv4 senders', () => {


### PR DESCRIPTION
## What changed

- rank physical Wi-Fi and Ethernet interfaces ahead of VPN, container, and VM adapters when generating LAN connection URLs
- ignore a request origin that points at a local VPN adapter when a physical LAN interface is available
- preserve exact remote-subnet matching so clients intentionally connecting over a VPN remain reachable
- reuse the same interface selection for the startup LAN URL
- add regression coverage for macOS VPN adapters, Tailscale, WireGuard, Docker, Wi-Fi, and Ethernet

## Why

LAN App authorization QR codes selected the first non-loopback IPv4 address returned by `os.networkInterfaces()`. When a VPN adapter appeared first, the QR payload contained the VPN address instead of the machine's Wi-Fi or Ethernet address, so phones on the local network could not connect.

## Impact

Users can keep a VPN enabled while generating a LAN App connection QR code. The QR code now prefers the reachable physical LAN address without breaking intentional VPN-subnet access.

## Validation

- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run test -- --run tests/server/lan-discovery.test.ts tests/server/app-connections-auth.test.ts tests/client/app-connections-panel.test.ts` (22 tests passed)
- `git diff --check`
