### PR TITLE
feat(profiles): add compact avatars for App profile list

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -301,6 +301,32 @@
         ]
       }
     },
+    "/api/app/profiles": {
+      "get": {
+        "tags": [
+          "Profiles"
+        ],
+        "summary": "Get profiles",
+        "description": "GET /api/app/profiles",
+        "operationId": "listForApp",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/api/auth/app-login": {
       "post": {
         "tags": [

--- a/packages/server/src/controllers/hermes/profiles.ts
+++ b/packages/server/src/controllers/hermes/profiles.ts
@@ -18,6 +18,7 @@ import { getActiveProfileName } from '../../services/hermes/hermes-profile'
 import { HermesSkillInjector } from '../../services/hermes/skill-injector'
 import type { HermesProfile } from '../../services/hermes/hermes-cli'
 import { listUserProfiles } from '../../db/hermes/users-store'
+import { readAppProfileAvatar } from '../../services/hermes/app-profile-avatar'
 
 const bridgeCleanupClient = () => new AgentBridgeClient({ connectRetryMs: 0, timeoutMs: 5000 })
 
@@ -222,6 +223,15 @@ function attachProfileAvatars<T extends HermesProfile>(profiles: T[]): Array<T &
   }))
 }
 
+async function attachAppProfileAvatars<T extends HermesProfile>(
+  profiles: T[],
+): Promise<Array<T & { avatar: ProfileAvatarResponse | null }>> {
+  return Promise.all(profiles.map(async profile => ({
+    ...profile,
+    avatar: await readAppProfileAvatar(profile.name),
+  })))
+}
+
 function parseAvatarDataUrl(dataUrl: string): { mime: string; buffer: Buffer } {
   const match = dataUrl.match(/^data:(image\/(?:png|jpeg|webp));base64,([a-zA-Z0-9+/=]+)$/)
   if (!match) throw new Error('Avatar image must be a PNG, JPEG, or WebP data URL')
@@ -391,6 +401,33 @@ export async function list(ctx: any) {
     })
 
     ctx.body = { profiles: attachProfileAvatars(profiles) }
+  } catch (err: any) {
+    ctx.status = 500
+    ctx.body = { error: err.message }
+  }
+}
+
+export async function listForApp(ctx: any) {
+  try {
+    let profiles: HermesProfile[]
+    try {
+      profiles = await hermesCli.listProfiles()
+    } catch (err: any) {
+      const activeProfileName = getActiveProfileName()
+      if (!isForbiddenProfileName(activeProfileName)) throw err
+
+      logger.warn(err, '[listAppProfiles] active_profile "%s" is invalid/reserved; resetting to default and listing profiles from disk', activeProfileName)
+      writeFileSync(getActiveProfileFile(), 'default\n', 'utf-8')
+      profiles = listProfilesFromDisk('default')
+    }
+
+    const activeProfileName = requestedProfileName(ctx)
+    profiles = filterProfilesForUser(ctx, filterVisibleProfiles(profiles))
+    profiles.forEach(profile => {
+      profile.active = profile.name === activeProfileName
+    })
+
+    ctx.body = { profiles: await attachAppProfileAvatars(profiles) }
   } catch (err: any) {
     ctx.status = 500
     ctx.body = { error: err.message }

--- a/packages/server/src/routes/hermes/profiles.ts
+++ b/packages/server/src/routes/hermes/profiles.ts
@@ -4,6 +4,7 @@ import { requireSuperAdmin } from '../../middleware/user-auth'
 
 export const profileRoutes = new Router()
 
+profileRoutes.get('/api/app/profiles', ctrl.listForApp)
 profileRoutes.get('/api/hermes/profiles', ctrl.list)
 profileRoutes.post('/api/hermes/profiles', ctrl.create)
 profileRoutes.get('/api/hermes/profiles/runtime-statuses', ctrl.runtimeStatuses)

--- a/packages/server/src/services/hermes/app-image-preview.ts
+++ b/packages/server/src/services/hermes/app-image-preview.ts
@@ -21,15 +21,29 @@ export interface AppImagePreview {
   height?: number
 }
 
+export interface AppImagePreviewOptions {
+  maxEdge?: number
+  quality?: number
+  preserveAnimation?: boolean
+}
+
 /**
  * Builds the bandwidth-friendly image variant consumed by the mobile App.
  * The normal download route remains byte-for-byte unchanged unless the App
  * explicitly requests this variant.
  */
-export async function createAppImagePreview(data: Buffer, mimeInput: string): Promise<AppImagePreview> {
+export async function createAppImagePreview(
+  data: Buffer,
+  mimeInput: string,
+  options: AppImagePreviewOptions = {},
+): Promise<AppImagePreview> {
   const mime = String(mimeInput || '').toLowerCase().split(';', 1)[0]
   const fallback = { data, mime: mime || 'application/octet-stream', optimized: false, originalBytes: data.length }
   if (!COMPRESSIBLE_IMAGE_TYPES.has(mime) || !data.length) return fallback
+
+  const maxEdge = Math.max(1, Math.min(8192, Math.floor(options.maxEdge || APP_IMAGE_MAX_EDGE)))
+  const quality = Math.max(1, Math.min(100, Math.floor(options.quality || APP_IMAGE_WEBP_QUALITY)))
+  const preserveAnimation = options.preserveAnimation !== false
 
   try {
     const { default: sharp } = await loadSharp()
@@ -40,7 +54,7 @@ export async function createAppImagePreview(data: Buffer, mimeInput: string): Pr
     })
     const metadata = await input.metadata()
     // Preserve animated PNG/WebP rather than silently returning only frame 1.
-    if (Number(metadata.pages || 1) > 1) return fallback
+    if (preserveAnimation && Number(metadata.pages || 1) > 1) return fallback
 
     const orientation = Number(metadata.orientation || 1)
     const swapsAxes = orientation >= 5 && orientation <= 8
@@ -51,19 +65,19 @@ export async function createAppImagePreview(data: Buffer, mimeInput: string): Pr
     const resized = await input
       .rotate()
       .resize({
-        width: APP_IMAGE_MAX_EDGE,
-        height: APP_IMAGE_MAX_EDGE,
+        width: maxEdge,
+        height: maxEdge,
         fit: 'inside',
         withoutEnlargement: true,
       })
       .webp({
-        quality: APP_IMAGE_WEBP_QUALITY,
+        quality,
         effort: 4,
         smartSubsample: true,
       })
       .toBuffer({ resolveWithObject: true })
 
-    const downscaled = Math.max(sourceWidth, sourceHeight) > APP_IMAGE_MAX_EDGE
+    const downscaled = Math.max(sourceWidth, sourceHeight) > maxEdge
     // For already-small images, retain the original if WebP would cost more.
     if (!downscaled && resized.data.length >= data.length) {
       return { ...fallback, width: sourceWidth, height: sourceHeight }

--- a/packages/server/src/services/hermes/app-profile-avatar.ts
+++ b/packages/server/src/services/hermes/app-profile-avatar.ts
@@ -1,0 +1,93 @@
+import { existsSync, readFileSync, statSync } from 'fs'
+import { join } from 'path'
+import { getWebUiHome } from '../../config'
+import { logger } from '../logger'
+import { createAppImagePreview } from './app-image-preview'
+
+const APP_PROFILE_AVATAR_MAX_EDGE = 128
+const APP_PROFILE_AVATAR_WEBP_QUALITY = 65
+
+interface ProfileAvatarMeta {
+  type: 'generated' | 'image'
+  seed?: string
+  file?: string
+  mime?: string
+  updatedAt?: number
+}
+
+export interface AppProfileAvatar {
+  type: 'generated' | 'image'
+  seed?: string
+  dataUrl?: string
+  updatedAt?: number
+}
+
+interface CachedAppProfileAvatar {
+  signature: string
+  avatar: AppProfileAvatar
+}
+
+const avatarCache = new Map<string, CachedAppProfileAvatar>()
+const pendingAvatars = new Map<string, Promise<AppProfileAvatar | null>>()
+
+function profileMetadataDir(name: string): string {
+  const segment = Buffer.from(name || 'default', 'utf-8').toString('base64url')
+  return join(getWebUiHome(), 'profile-metadata', segment)
+}
+
+function profileAvatarMetaPath(name: string): string {
+  return join(profileMetadataDir(name), 'avatar.json')
+}
+
+export async function readAppProfileAvatar(name: string): Promise<AppProfileAvatar | null> {
+  const metaPath = profileAvatarMetaPath(name)
+  if (!existsSync(metaPath)) return null
+
+  try {
+    const meta = JSON.parse(readFileSync(metaPath, 'utf-8')) as ProfileAvatarMeta
+    if (meta.type === 'generated') {
+      return {
+        type: 'generated',
+        seed: typeof meta.seed === 'string' ? meta.seed : name,
+        updatedAt: meta.updatedAt,
+      }
+    }
+    if (meta.type !== 'image' || !meta.file || !meta.mime || !meta.mime.startsWith('image/')) return null
+
+    const imagePath = join(profileMetadataDir(name), meta.file)
+    if (!existsSync(imagePath)) return null
+    const imageStat = statSync(imagePath)
+    const signature = [imagePath, meta.mime, meta.updatedAt || 0, imageStat.size, imageStat.mtimeMs].join(':')
+    const cached = avatarCache.get(name)
+    if (cached?.signature === signature) return cached.avatar
+
+    const pendingKey = `${name}:${signature}`
+    const existing = pendingAvatars.get(pendingKey)
+    if (existing) return existing
+
+    const pending = (async () => {
+      const original = readFileSync(imagePath)
+      const preview = await createAppImagePreview(original, meta.mime!, {
+        maxEdge: APP_PROFILE_AVATAR_MAX_EDGE,
+        quality: APP_PROFILE_AVATAR_WEBP_QUALITY,
+        preserveAnimation: false,
+      })
+      const avatar: AppProfileAvatar = {
+        type: 'image',
+        dataUrl: `data:${preview.mime};base64,${preview.data.toString('base64')}`,
+        updatedAt: meta.updatedAt,
+      }
+      avatarCache.set(name, { signature, avatar })
+      return avatar
+    })()
+    pendingAvatars.set(pendingKey, pending)
+    try {
+      return await pending
+    } finally {
+      pendingAvatars.delete(pendingKey)
+    }
+  } catch (err) {
+    logger.warn(err, '[app-profiles] failed to build App avatar for profile "%s"', name)
+    return null
+  }
+}

--- a/tests/server/app-image-preview.test.ts
+++ b/tests/server/app-image-preview.test.ts
@@ -21,6 +21,21 @@ describe('createAppImagePreview', () => {
     expect(result.originalBytes).toBe(source.length)
   })
 
+  it('supports a small avatar-specific preview preset', async () => {
+    const source = solidPng(640, 480, [53, 88, 212, 255])
+    const result = await createAppImagePreview(source, 'image/png', {
+      maxEdge: 128,
+      quality: 65,
+      preserveAnimation: false,
+    })
+
+    expect(result.optimized).toBe(true)
+    expect(result.mime).toBe('image/webp')
+    expect(result.width).toBe(128)
+    expect(result.height).toBe(96)
+    expect(result.data.length).toBeLessThan(source.length)
+  })
+
   it('does not alter non-image downloads', async () => {
     const source = Buffer.from('hello')
     const result = await createAppImagePreview(source, 'text/plain')

--- a/tests/server/profiles-routes.test.ts
+++ b/tests/server/profiles-routes.test.ts
@@ -415,6 +415,88 @@ describe('Profile Routes', () => {
   })
 
   describe('profile avatars', () => {
+    it('returns a compressed image avatar from the App-only profile endpoint', async () => {
+      const webUiHome = await mkdtemp(join(tmpdir(), 'hermes-web-ui-app-avatar-'))
+      tempHomes.push(webUiHome)
+      process.env.HERMES_WEB_UI_HOME = webUiHome
+      const metadataDir = join(webUiHome, 'profile-metadata', Buffer.from('work', 'utf-8').toString('base64url'))
+      await mkdir(metadataDir, { recursive: true })
+      const { default: sharp } = await import('sharp')
+      const source = await sharp({
+        create: {
+          width: 640,
+          height: 480,
+          channels: 4,
+          background: { r: 53, g: 88, b: 212, alpha: 1 },
+        },
+      }).png().toBuffer()
+      await writeFile(join(metadataDir, 'avatar.bin'), source)
+      await writeFile(join(metadataDir, 'avatar.json'), JSON.stringify({
+        type: 'image',
+        file: 'avatar.bin',
+        mime: 'image/png',
+        updatedAt: 123,
+      }), 'utf-8')
+      vi.mocked(hermesCli.listProfiles).mockResolvedValue([{
+        name: 'work',
+        active: true,
+        model: 'test-model',
+        alias: '',
+      }] as any)
+      const { listForApp } = await import('../../packages/server/src/controllers/hermes/profiles')
+      const ctx: any = {
+        state: { profile: { name: 'work' } },
+        status: 200,
+        body: undefined,
+      }
+
+      await listForApp(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body.profiles).toHaveLength(1)
+      const dataUrl = String(ctx.body.profiles[0].avatar.dataUrl)
+      expect(dataUrl).toMatch(/^data:image\/webp;base64,/)
+      const preview = Buffer.from(dataUrl.split(',', 2)[1], 'base64')
+      const metadata = await sharp(preview).metadata()
+      expect(metadata.width).toBe(128)
+      expect(metadata.height).toBe(96)
+      expect(preview.length).toBeLessThan(source.length)
+    })
+
+    it('keeps generated App avatars as seed metadata instead of embedding SVG', async () => {
+      const webUiHome = await mkdtemp(join(tmpdir(), 'hermes-web-ui-app-avatar-'))
+      tempHomes.push(webUiHome)
+      process.env.HERMES_WEB_UI_HOME = webUiHome
+      const metadataDir = join(webUiHome, 'profile-metadata', Buffer.from('work', 'utf-8').toString('base64url'))
+      await mkdir(metadataDir, { recursive: true })
+      await writeFile(join(metadataDir, 'avatar.json'), JSON.stringify({
+        type: 'generated',
+        seed: 'app-seed',
+        updatedAt: 456,
+      }), 'utf-8')
+      vi.mocked(hermesCli.listProfiles).mockResolvedValue([{
+        name: 'work',
+        active: true,
+        model: 'test-model',
+        alias: '',
+      }] as any)
+      const { listForApp } = await import('../../packages/server/src/controllers/hermes/profiles')
+      const ctx: any = {
+        state: { profile: { name: 'work' } },
+        status: 200,
+        body: undefined,
+      }
+
+      await listForApp(ctx)
+
+      expect(ctx.body.profiles[0].avatar).toEqual({
+        type: 'generated',
+        seed: 'app-seed',
+        updatedAt: 456,
+      })
+      expect(ctx.body.profiles[0].avatar.dataUrl).toBeUndefined()
+    })
+
     it('stores generated avatar metadata under the Web UI home', async () => {
       const webUiHome = await mkdtemp(join(tmpdir(), 'hermes-web-ui-avatar-'))
       tempHomes.push(webUiHome)


### PR DESCRIPTION
## What changed

- add an authenticated `GET /api/app/profiles` endpoint for mobile clients
- return generated avatars as compact seed metadata instead of embedding SVG data
- resize uploaded profile avatars to a maximum 128 px edge and encode them as WebP
- cache converted App avatars and deduplicate concurrent conversions
- make the existing App image preview helper accept size, quality, and animation options
- update the generated OpenAPI specification and add route/image regression coverage

## Why

The existing profile response is designed for the Studio UI and can include full-size avatar data. Mobile clients need the same visible, user-authorized profile list without transferring oversized image payloads each time the list loads.

## Impact

The App can load profile avatars using a smaller response. Uploaded images are converted to compact WebP previews, while generated avatars retain their seed so the App can render them locally. The existing Studio profile endpoint and original avatar files remain unchanged.

## Validation

- `npm run openapi:generate` (326 endpoints, 41 tags)
- `npm run test -- --run tests/server/profiles-routes.test.ts tests/server/app-image-preview.test.ts` (26 tests passed)
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `git diff --check`
