### PR TITLE
fix: apply fallback providers in agent bridge

### DIFF
--- a/docs/chat-chain-changes/2026-08-18-pr-2599-agent-bridge-fallback-providers.md
+++ b/docs/chat-chain-changes/2026-08-18-pr-2599-agent-bridge-fallback-providers.md
@@ -1,0 +1,6 @@
+---
+date: 2026-08-18
+pr: 2599
+feature: Agent Bridge fallback providers
+impact: New Agent Bridge sessions pass the configured fallback provider chain to Hermes agents so model requests can use the configured provider and model fallbacks.
+---

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -28,6 +28,7 @@ from bridge_runtime import (
     _jsonable,
     _load_cfg,
     _load_enabled_toolsets,
+    _load_fallback_model,
     _load_reasoning_config,
     _load_service_tier,
     _mcp_tool_names_from_names,
@@ -456,6 +457,7 @@ class AgentPool:
 
                 agent = AIAgent(
                     model=resolved_model,
+                    fallback_model=_load_fallback_model(cfg),
                     max_iterations=_cfg_max_turns(cfg, 90),
                     provider=runtime.get("provider"),
                     base_url=runtime.get("base_url"),

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_runtime.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_runtime.py
@@ -545,6 +545,16 @@ def _load_cfg(profile: str | None = None) -> dict[str, Any]:
             return {}
 
 
+def _load_fallback_model(cfg: dict[str, Any]) -> list | None:
+    """Return the canonical configured fallback chain for a bridge agent."""
+    try:
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        return get_fallback_chain(cfg) or None
+    except Exception:
+        return None
+
+
 def _apply_profile_env(profile: str | None) -> str | None:
     """Temporarily set HERMES_HOME to the profile directory.
     Returns the original HERMES_HOME value to restore later.

--- a/tests/server/agent-bridge-fallback-providers.test.ts
+++ b/tests/server/agent-bridge-fallback-providers.test.ts
@@ -1,25 +1,26 @@
-import { execFileSync } from 'child_process'
+import { execFileSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 
-function runPython(script: string): any {
+function runPython(script: string): Record<string, unknown> {
   try {
-    const output = execFileSync('python3', ['-c', script], {
+    return JSON.parse(execFileSync('python3', ['-c', script], {
       cwd: process.cwd(),
-      encoding: 'utf-8',
+      encoding: 'utf8',
       stdio: 'pipe',
-    })
-    return JSON.parse(output)
+    }))
   } catch (error) {
     const err = error as { stdout?: string; stderr?: string; message?: string }
     throw new Error([
-      err.message || 'Python bridge learn command script failed',
+      err.message || 'Python agent bridge fallback test failed',
       err.stdout ? `stdout:\n${err.stdout}` : '',
       err.stderr ? `stderr:\n${err.stderr}` : '',
     ].filter(Boolean).join('\n\n'))
   }
 }
 
-const harness = String.raw`
+describe('Agent Bridge fallback providers', () => {
+  it('passes the configured fallback chain to each newly created agent', () => {
+    const result = runPython(String.raw`
 import contextlib
 import importlib.util
 import json
@@ -40,9 +41,9 @@ bridge_runtime._ensure_agent_imports = lambda: None
 bridge_runtime._hermes_home = lambda *_args, **_kwargs: Path(tempfile.gettempdir())
 bridge_runtime._install_execute_code_approval_memory_patch = lambda *_args, **_kwargs: None
 bridge_runtime._jsonable = lambda value: value
-bridge_runtime._load_cfg = lambda *_args, **_kwargs: {}
+bridge_runtime._load_cfg = lambda *_args, **_kwargs: {"fallback_providers": [{"provider": "backup", "model": "backup-model"}]}
 bridge_runtime._load_enabled_toolsets = lambda *_args, **_kwargs: []
-bridge_runtime._load_fallback_model = lambda *_args, **_kwargs: None
+bridge_runtime._load_fallback_model = lambda cfg: cfg["fallback_providers"]
 bridge_runtime._load_reasoning_config = lambda *_args, **_kwargs: {}
 bridge_runtime._load_service_tier = lambda *_args, **_kwargs: None
 bridge_runtime._mcp_tool_names_from_names = lambda *_args, **_kwargs: []
@@ -50,9 +51,9 @@ bridge_runtime._persist_execute_code_approval_choice = lambda *_args, **_kwargs:
 bridge_runtime._profile_home = lambda *_args, **_kwargs: Path(tempfile.gettempdir())
 bridge_runtime._refresh_approval_allowlist = lambda *_args, **_kwargs: None
 bridge_runtime._refresh_worker_profile_env = lambda *_args, **_kwargs: None
-bridge_runtime._resolve_model = lambda *_args, **_kwargs: ("model", "provider")
-bridge_runtime._resolve_runtime = lambda *_args, **_kwargs: {}
-bridge_runtime._suppress_bridge_platform_hint = contextlib.nullcontext
+bridge_runtime._resolve_model = lambda *_args, **_kwargs: "primary-model"
+bridge_runtime._resolve_runtime = lambda *_args, **_kwargs: {"provider": "primary"}
+bridge_runtime._suppress_bridge_platform_hint = lambda: None
 bridge_runtime._title_user_message = lambda value: value
 bridge_runtime._tool_names_from_definitions = lambda *_args, **_kwargs: []
 
@@ -71,49 +72,21 @@ bridge_pool = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 sys.modules["bridge_pool"] = bridge_pool
 spec.loader.exec_module(bridge_pool)
-`
 
-describe('agent bridge /learn command', () => {
-  it('returns a generated learn prompt as a handled bridge command', () => {
-    const result = runPython(`${harness}
-agent_pkg = types.ModuleType("agent")
-agent_pkg.__path__ = []
-sys.modules["agent"] = agent_pkg
+run_agent = types.ModuleType("run_agent")
+class AIAgent:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.tools = []
+run_agent.AIAgent = AIAgent
+sys.modules["run_agent"] = run_agent
 
-learn_prompt = types.ModuleType("agent.learn_prompt")
-learn_prompt.build_learn_prompt = lambda arg: "expanded learn prompt: " + arg
-sys.modules["agent.learn_prompt"] = learn_prompt
-
-pool = bridge_pool.AgentPool()
-print(json.dumps(pool.dispatch_command("session-1", "/learn from docs", "default")))
+session = bridge_pool.AgentPool().get_or_create("session-1")
+print(json.dumps({"fallback_model": session.agent.kwargs.get("fallback_model")}))
 `)
 
     expect(result).toEqual({
-      session_id: 'session-1',
-      command: 'learn',
-      handled: true,
-      type: 'learn',
-      message: 'expanded learn prompt: from docs',
-    })
-  })
-
-  it('returns a clear unsupported-runtime message when agent.learn_prompt is missing', () => {
-    const result = runPython(`${harness}
-agent_pkg = types.ModuleType("agent")
-agent_pkg.__path__ = []
-sys.modules["agent"] = agent_pkg
-sys.modules.pop("agent.learn_prompt", None)
-
-pool = bridge_pool.AgentPool()
-print(json.dumps(pool.dispatch_command("session-1", "/learn from docs", "default")))
-`)
-
-    expect(result).toEqual({
-      session_id: 'session-1',
-      command: 'learn',
-      handled: false,
-      type: 'learn',
-      message: '/learn requires a newer Hermes Agent runtime with agent.learn_prompt.',
+      fallback_model: [{ provider: 'backup', model: 'backup-model' }],
     })
   })
 })

--- a/tests/server/agent-bridge-usage-hook.test.ts
+++ b/tests/server/agent-bridge-usage-hook.test.ts
@@ -41,6 +41,7 @@ bridge_runtime._install_execute_code_approval_memory_patch = lambda *_args, **_k
 bridge_runtime._jsonable = lambda value: value
 bridge_runtime._load_cfg = lambda *_args, **_kwargs: {}
 bridge_runtime._load_enabled_toolsets = lambda *_args, **_kwargs: []
+bridge_runtime._load_fallback_model = lambda *_args, **_kwargs: None
 bridge_runtime._load_reasoning_config = lambda *_args, **_kwargs: {}
 bridge_runtime._load_service_tier = lambda *_args, **_kwargs: None
 bridge_runtime._mcp_tool_names_from_names = lambda *_args, **_kwargs: []


### PR DESCRIPTION
## Summary
- pass Hermes Agent’s canonical configured fallback chain when Agent Bridge creates an `AIAgent`
- retain fallback-provider behavior parity with gateway, CLI, and cron paths
- add a provider-free bridge regression harness and update the existing bridge-runtime mock

Closes #2582

## Validation
- `npm test -- --run tests/server/agent-bridge-fallback-providers.test.ts tests/server/agent-bridge-learn-command.test.ts tests/server/agent-bridge-provider-credentials.test.ts`
- `python3 -m py_compile packages/server/src/services/hermes/agent-bridge/python/bridge_runtime.py packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py`
- `npm run build`
- `git diff --check`