### PR TITLE
fix: prevent available-models API key disclosure

### DIFF
--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -436,7 +436,7 @@ async function buildAvailableForProfile(
       base_url,
       models: availableModels,
       available_models: availableModels,
-      api_key: provider === 'moa' ? api_key : '',
+      api_key: '',
       ...(apiMode ? { api_mode: apiMode } : {}),
       ...(builtin ? { builtin: true } : {}),
       ...(Object.keys(unavailableMeta).length ? { model_meta: unavailableMeta } : {}),

--- a/packages/server/src/controllers/hermes/models.ts
+++ b/packages/server/src/controllers/hermes/models.ts
@@ -436,7 +436,7 @@ async function buildAvailableForProfile(
       base_url,
       models: availableModels,
       available_models: availableModels,
-      api_key,
+      api_key: provider === 'moa' ? api_key : '',
       ...(apiMode ? { api_mode: apiMode } : {}),
       ...(builtin ? { builtin: true } : {}),
       ...(Object.keys(unavailableMeta).length ? { model_meta: unavailableMeta } : {}),

--- a/tests/server/model-visibility-controller.test.ts
+++ b/tests/server/model-visibility-controller.test.ts
@@ -194,6 +194,31 @@ beforeEach(() => {
 })
 
 describe('models controller — model visibility', () => {
+  it('does not expose stored provider API keys in available-models responses', async () => {
+    mockReadFile.mockResolvedValue('DEEPSEEK_API_KEY=stored-built-in-secret\n')
+    mockReadConfigYamlForProfile.mockResolvedValue({
+      model: { default: 'custom-model', provider: 'custom:private-proxy' },
+      custom_providers: [{
+        name: 'private-proxy',
+        base_url: 'https://proxy.example.test/v1',
+        model: 'custom-model',
+        api_key: 'stored-custom-secret',
+      }],
+    })
+
+    const ctx = makeCtx()
+    ctx.query = { profile: 'default' }
+    await ctrl.getAvailable(ctx)
+
+    expect(ctx.status).toBe(200)
+    expect(JSON.stringify(ctx.body)).not.toContain('stored-built-in-secret')
+    expect(JSON.stringify(ctx.body)).not.toContain('stored-custom-secret')
+    expect(ctx.body.groups).toEqual(expect.arrayContaining([
+      expect.objectContaining({ provider: 'deepseek', api_key: '' }),
+      expect.objectContaining({ provider: 'custom:private-proxy', api_key: '' }),
+    ]))
+  })
+
   it('filters available models per provider without changing canonical IDs', async () => {
     mockReadAppConfig.mockResolvedValue({
       modelVisibility: {

--- a/tests/server/model-visibility-controller.test.ts
+++ b/tests/server/model-visibility-controller.test.ts
@@ -311,7 +311,7 @@ describe('models controller — model visibility', () => {
         provider: 'moa',
         label: 'Mixture of Agents',
         base_url: 'moa://local',
-        api_key: 'moa-virtual-provider',
+        api_key: '',
         api_mode: 'chat_completions',
         models: ['coding', 'research'],
       }),


### PR DESCRIPTION
## Summary
- Return empty `api_key` fields from `/api/hermes/available-models`, so configured provider credentials never reach the browser.
- Cover built-in environment keys, custom-provider keys, and the MoA virtual-provider group.

Closes #2367

## Validation
- `npm run test -- tests/server/model-visibility-controller.test.ts`
- `npm run harness:check`
- `npm run build`

## Known limitations
- `npm run test` has 64 environment-sensitive failures in this workspace (for example expectations hard-code port 8648 while the harness runtime uses 6060); the focused regression suite passes.