### PR TITLE
fix: deduplicate bridge pre-persisted user messages

### DIFF
--- a/docs/chat-chain-changes/2026-08-18-pr-2601-bridge-prepersist-session-dedup.md
+++ b/docs/chat-chain-changes/2026-08-18-pr-2601-bridge-prepersist-session-dedup.md
@@ -1,0 +1,6 @@
+---
+date: 2026-08-18
+pr: 2601
+feature: Bridge pre-persisted user-message deduplication
+impact: After a bridge user-message write succeeds, native persistence skips exactly the matching user entry once, falls back to native persistence when the pre-persist write fails, and clears stale pending state after the run.
+---

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -485,6 +485,7 @@ class AgentPool:
                 )
                 agent.compression_enabled = False
                 self._install_compression_hook(agent, session_id)
+                self._install_prepersist_dedup_hook(agent)
                 mcp_tool_names = self._mcp_tool_names(self._agent_tool_names(getattr(agent, "tools", None) or []))
 
                 session = AgentSession(
@@ -773,6 +774,24 @@ class AgentPool:
                 profile or str(session.config.get("profile") or "default"),
                 add_note=True,
             )
+
+    def _install_prepersist_dedup_hook(self, agent: Any) -> None:
+        """Skip one bridge-pre-persisted user message in the native DB flush."""
+        original = getattr(agent, "_persist_session", None)
+        if not callable(original) or getattr(original, "_hermes_bridge_prepersist_dedup_wrapper", False):
+            return
+
+        def wrapped_persist_session(messages: Any, conversation_history: Any = None, *args: Any, **kwargs: Any):
+            if getattr(agent, "_hermes_bridge_prepersisted_user_pending", False) and isinstance(messages, list):
+                for message in reversed(messages):
+                    if isinstance(message, dict) and message.get("role") == "user" and not message.get("_db_persisted"):
+                        message["_db_persisted"] = True
+                        agent._hermes_bridge_prepersisted_user_pending = False
+                        break
+            return original(messages, conversation_history, *args, **kwargs)
+
+        wrapped_persist_session._hermes_bridge_prepersist_dedup_wrapper = True  # type: ignore[attr-defined]
+        agent._persist_session = wrapped_persist_session
 
     def _install_compression_hook(self, agent: Any, session_id: str) -> None:
         original = getattr(agent, "_compress_context", None)
@@ -1504,6 +1523,11 @@ class AgentPool:
                 content=user_content,
             )
 
+            # The native agent flush receives its own live message list. Mark
+            # exactly one user entry in that list only after this durable write
+            # succeeds, so fallback persistence remains available on failures.
+            session.agent._hermes_bridge_prepersisted_user_pending = True
+
             # AIAgent will build messages as conversation_history + current user.
             # Since the current user was pre-persisted above, align the flush
             # cursor so the normal end-of-turn flush starts at assistant/tool
@@ -1887,6 +1911,9 @@ class AgentPool:
                     session.last_used_at = time.time()
                 self._apply_pending_session_model_switch(session)
             finally:
+                # A failed or interrupted run may never reach a native flush.
+                # Do not let its one-shot marker affect a later fallback turn.
+                session.agent._hermes_bridge_prepersisted_user_pending = False
                 with self._lock:
                     self._approval_handlers.pop(session.session_id, None)
                 try:

--- a/tests/server/agent-bridge-usage-hook.test.ts
+++ b/tests/server/agent-bridge-usage-hook.test.ts
@@ -1,6 +1,85 @@
 import { execFileSync } from 'child_process'
 import { describe, expect, it } from 'vitest'
 
+const persistenceHarness = String.raw`
+import contextlib
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+bridge_runtime = types.ModuleType("bridge_runtime")
+bridge_runtime.APPROVAL_TIMEOUT_MS = 1000
+bridge_runtime.APPROVAL_TIMEOUT_SECONDS = 1
+bridge_runtime._approval_pattern_keys = lambda *_args, **_kwargs: []
+bridge_runtime._base_hermes_home = lambda: Path(tempfile.gettempdir())
+bridge_runtime._bridge_platform = lambda: "agent-bridge"
+bridge_runtime._cfg_max_turns = lambda *_args, **_kwargs: 20
+bridge_runtime._discover_bridge_mcp_tools = lambda *_args, **_kwargs: []
+bridge_runtime._ensure_agent_imports = lambda: None
+bridge_runtime._hermes_home = lambda *_args, **_kwargs: Path(tempfile.gettempdir())
+bridge_runtime._install_execute_code_approval_memory_patch = lambda *_args, **_kwargs: None
+bridge_runtime._jsonable = lambda value: value
+bridge_runtime._load_cfg = lambda *_args, **_kwargs: {}
+bridge_runtime._load_enabled_toolsets = lambda *_args, **_kwargs: []
+bridge_runtime._load_reasoning_config = lambda *_args, **_kwargs: {}
+bridge_runtime._load_service_tier = lambda *_args, **_kwargs: None
+bridge_runtime._mcp_tool_names_from_names = lambda *_args, **_kwargs: []
+bridge_runtime._persist_execute_code_approval_choice = lambda *_args, **_kwargs: None
+bridge_runtime._profile_home = lambda *_args, **_kwargs: Path(tempfile.gettempdir())
+bridge_runtime._refresh_approval_allowlist = lambda *_args, **_kwargs: None
+bridge_runtime._refresh_worker_profile_env = lambda *_args, **_kwargs: None
+bridge_runtime._resolve_model = lambda *_args, **_kwargs: ("model", "provider")
+bridge_runtime._resolve_runtime = lambda *_args, **_kwargs: {}
+bridge_runtime._suppress_bridge_platform_hint = contextlib.nullcontext
+bridge_runtime._title_user_message = lambda value: value
+bridge_runtime._tool_names_from_definitions = lambda *_args, **_kwargs: []
+
+@contextlib.contextmanager
+def _profile_env(_profile):
+    yield
+
+bridge_runtime._profile_env = _profile_env
+sys.modules["bridge_runtime"] = bridge_runtime
+
+spec = importlib.util.spec_from_file_location(
+    "bridge_pool",
+    "packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py",
+)
+bridge_pool = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules["bridge_pool"] = bridge_pool
+spec.loader.exec_module(bridge_pool)
+
+class FakeDb:
+    def __init__(self):
+        self.rows = []
+    def create_session(self, **_kwargs):
+        pass
+    def get_messages(self, _session_id):
+        return list(self.rows)
+    def append_message(self, **row):
+        self.rows.append({"role": row["role"], "content": row["content"]})
+
+class FakeAgent:
+    def __init__(self, db):
+        self.db = db
+    def _persist_session(self, messages, _conversation_history=None):
+        for message in messages:
+            if not message.get("_db_persisted"):
+                self.db.append_message(role=message["role"], content=message.get("content"))
+                message["_db_persisted"] = True
+
+pool = bridge_pool.AgentPool()
+db = FakeDb()
+pool._db = types.SimpleNamespace(get_for_profile=lambda _profile: db)
+agent = FakeAgent(db)
+session = bridge_pool.AgentSession("session-1", agent, config={"model": "test"})
+pool._install_prepersist_dedup_hook(agent)
+`
+
 function runPython(script: string): any {
   try {
     return JSON.parse(execFileSync('python3', ['-c', script], {
@@ -132,5 +211,39 @@ print(json.dumps({"callback_count": len(manager._hooks["post_api_request"]), "ev
         reasoning_tokens: 9,
       },
     })])
+  })
+})
+
+describe('agent bridge pre-persisted user messages', () => {
+  it('marks only a successfully pre-persisted current user before native flush', () => {
+    const result = runPython(`${persistenceHarness}
+assert pool._prepersist_user_message(session, "hello", None, [], "default") is True
+messages = [
+    {"role": "user", "content": "hello"},
+    {"role": "assistant", "content": "hi"},
+    {"role": "tool", "content": "done"},
+]
+agent._persist_session(messages, [])
+print(json.dumps({"rows": db.rows, "pending": getattr(agent, "_hermes_bridge_prepersisted_user_pending", None)}))
+`)
+
+    expect(result.rows).toEqual([
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi' },
+      { role: 'tool', content: 'done' },
+    ])
+    expect(result.pending).toBe(false)
+  })
+
+  it('does not suppress a native user write when bridge pre-persist fails', () => {
+    const result = runPython(`${persistenceHarness}
+pool._db = types.SimpleNamespace(get_for_profile=lambda _profile: None)
+assert pool._prepersist_user_message(session, "fallback", None, [], "default") is False
+agent._persist_session([{"role": "user", "content": "fallback"}], [])
+print(json.dumps({"rows": db.rows, "pending": getattr(agent, "_hermes_bridge_prepersisted_user_pending", None)}))
+`)
+
+    expect(result.rows).toEqual([{ role: 'user', content: 'fallback' }])
+    expect(result.pending).not.toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- mark the bridge-pre-persisted current user in the actual native flush list, after its SQLite write succeeds
- retain fallback native persistence when pre-persist fails and clear unconsumed markers after a run
- add a deterministic Python bridge regression harness for duplicate rows and fallback behavior

Closes #2589

## Validation
- `npx vitest run tests/server/agent-bridge-usage-hook.test.ts`
- `python3 -m py_compile packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py`
- `npm run build`
- `npm run test` *(environment baseline failures: 64 failures across 30 unrelated files, including expected port `8648` versus ambient `PORT=6060`)*