### PR TITLE
fix(tests): complete the bridge_runtime stub so main builds again

### DIFF
--- a/tests/server/agent-bridge-usage-hook.test.ts
+++ b/tests/server/agent-bridge-usage-hook.test.ts
@@ -24,6 +24,7 @@ bridge_runtime._install_execute_code_approval_memory_patch = lambda *_args, **_k
 bridge_runtime._jsonable = lambda value: value
 bridge_runtime._load_cfg = lambda *_args, **_kwargs: {}
 bridge_runtime._load_enabled_toolsets = lambda *_args, **_kwargs: []
+bridge_runtime._load_fallback_model = lambda *_args, **_kwargs: None
 bridge_runtime._load_reasoning_config = lambda *_args, **_kwargs: {}
 bridge_runtime._load_service_tier = lambda *_args, **_kwargs: None
 bridge_runtime._mcp_tool_names_from_names = lambda *_args, **_kwargs: []


### PR DESCRIPTION
`main` is red, and so is every open pull request. The `build` job fails before it reaches anything else:

```
File ".../agent-bridge/python/bridge_pool.py", line 17, in <module>
    from bridge_runtime import (
ImportError: cannot import name '_load_fallback_model'
```

## Why

#2599 added a `_load_fallback_model` import to `bridge_pool.py`. #2601 merged twenty minutes later carrying `tests/server/agent-bridge-usage-hook.test.ts`, whose inline Python builds a hand-written `bridge_runtime` stub listing every symbol `bridge_pool` imports — written against the import list as it stood before #2599.

The file contains two such stubs. The second one already has `_load_fallback_model`; only the first was left behind. This adds it there, in the same alphabetical position, so the two agree.

## Verified

`tests/server/agent-bridge-usage-hook.test.ts` fails on `main` at this checkout with the ImportError above, and passes with this one line added — 3 tests, no other change.

Worth noting for later: a stub that must be updated by hand whenever `bridge_pool`'s imports change will drift again. Deriving it from the import list, or asserting the two stubs match, would make that impossible — I did not fold that into this PR because main is currently broken and this should land as a one-line unblock.