### PR TITLE
fix(upload): let an oversize upload read its own 413

### DIFF
--- a/packages/server/src/controllers/hermes/group-chat-invite.ts
+++ b/packages/server/src/controllers/hermes/group-chat-invite.ts
@@ -7,6 +7,7 @@ import {
     parseMultipartFilename,
     splitMultipart,
 } from '../../lib/multipart'
+import { drainRejectedRequest, nonDestroyingRequestBody } from '../../lib/request-body'
 import { publicGroupChatInviteRoom } from '../../services/hermes/group-chat/access'
 import {
     findPublishedGroupChatAttachmentPath,
@@ -155,17 +156,21 @@ export async function uploadRoomAttachment(ctx: any, room: { id: string }): Prom
         return
     }
 
+    let oversize = false
     await withGroupChatAttachmentWriteLock(room.id, async () => {
-        const chunks: Buffer[] = []
+        let chunks: Buffer[] = []
         let totalSize = 0
-        for await (const chunk of ctx.req) {
+        for await (const chunk of nonDestroyingRequestBody(ctx.req)) {
             totalSize += chunk.length
             if (totalSize > MAX_GROUP_CHAT_ATTACHMENT_SIZE) {
-                ctx.status = 413
-                ctx.body = { error: 'Group chat attachment is too large (max 20MB)' }
-                return
+                oversize = true
+                break
             }
             chunks.push(chunk)
+        }
+        if (oversize) {
+            chunks = []
+            return
         }
 
         const pendingFiles: Array<{ name: string; storedName: string; data: Buffer }> = []
@@ -218,6 +223,12 @@ export async function uploadRoomAttachment(ctx: any, room: { id: string }): Prom
         }
         ctx.body = { files }
     })
+
+    if (oversize) {
+        await drainRejectedRequest(ctx.req)
+        ctx.status = 413
+        ctx.body = { error: 'Group chat attachment is too large (max 20MB)' }
+    }
 }
 
 export async function readInviteAttachment(ctx: any): Promise<void> {

--- a/packages/server/src/controllers/upload.ts
+++ b/packages/server/src/controllers/upload.ts
@@ -4,40 +4,9 @@ import { join } from 'path'
 import { getActiveProfileName } from '../services/hermes/hermes-profile'
 import { getProfileUploadDir } from '../services/hermes/upload-paths'
 import { MultipartParseError, parseMultipartBoundary, parseMultipartFilename, splitMultipart } from '../lib/multipart'
+import { drainRejectedRequest, nonDestroyingRequestBody } from '../lib/request-body'
 
 const MAX_UPLOAD_SIZE = 50 * 1024 * 1024 // 50MB
-// How long to keep reading a rejected upload before giving up on a clean reply.
-const OVERSIZE_DRAIN_TIMEOUT_MS = 10_000
-
-/**
- * Read and discard whatever is left of a request body.
- *
- * Answering while the client is still writing gets the connection reset before
- * it can read the response, so the browser reports a generic network failure
- * instead of the reason it was given. Draining first lets the reply arrive.
- */
-function drainRequest(req: any): Promise<void> {
-  if (!req || typeof req.resume !== 'function' || req.readableEnded || req.destroyed) return Promise.resolve()
-  return new Promise<void>(resolve => {
-    const finish = () => {
-      clearTimeout(timer)
-      req.off?.('end', finish)
-      req.off?.('close', finish)
-      req.off?.('error', finish)
-      resolve()
-    }
-    // A client that keeps sending forever must not hold the handler open.
-    const timer = setTimeout(() => {
-      req.destroy?.()
-      finish()
-    }, OVERSIZE_DRAIN_TIMEOUT_MS)
-    timer.unref?.()
-    req.on('end', finish)
-    req.on('close', finish)
-    req.on('error', finish)
-    req.resume()
-  })
-}
 
 function requestedProfile(ctx: any): string {
   return ctx.state?.profile?.name || getActiveProfileName() || 'default'
@@ -57,9 +26,7 @@ export async function handleUpload(ctx: any) {
   let oversize = false
   // Leave the stream alive when the loop ends early; the iterator would
   // otherwise destroy it and take the unsent response down with it.
-  const body = typeof ctx.req.iterator === 'function'
-    ? ctx.req.iterator({ destroyOnReturn: false })
-    : ctx.req
+  const body = nonDestroyingRequestBody(ctx.req)
   for await (const chunk of body) {
     totalSize += chunk.length
     if (totalSize > MAX_UPLOAD_SIZE) {
@@ -70,7 +37,7 @@ export async function handleUpload(ctx: any) {
   }
   if (oversize) {
     chunks = []
-    await drainRequest(ctx.req)
+    await drainRejectedRequest(ctx.req)
     ctx.status = 413
     ctx.body = { error: `File too large (max ${MAX_UPLOAD_SIZE / 1024 / 1024}MB)` }
     return

--- a/packages/server/src/controllers/upload.ts
+++ b/packages/server/src/controllers/upload.ts
@@ -6,6 +6,38 @@ import { getProfileUploadDir } from '../services/hermes/upload-paths'
 import { MultipartParseError, parseMultipartBoundary, parseMultipartFilename, splitMultipart } from '../lib/multipart'
 
 const MAX_UPLOAD_SIZE = 50 * 1024 * 1024 // 50MB
+// How long to keep reading a rejected upload before giving up on a clean reply.
+const OVERSIZE_DRAIN_TIMEOUT_MS = 10_000
+
+/**
+ * Read and discard whatever is left of a request body.
+ *
+ * Answering while the client is still writing gets the connection reset before
+ * it can read the response, so the browser reports a generic network failure
+ * instead of the reason it was given. Draining first lets the reply arrive.
+ */
+function drainRequest(req: any): Promise<void> {
+  if (!req || typeof req.resume !== 'function' || req.readableEnded || req.destroyed) return Promise.resolve()
+  return new Promise<void>(resolve => {
+    const finish = () => {
+      clearTimeout(timer)
+      req.off?.('end', finish)
+      req.off?.('close', finish)
+      req.off?.('error', finish)
+      resolve()
+    }
+    // A client that keeps sending forever must not hold the handler open.
+    const timer = setTimeout(() => {
+      req.destroy?.()
+      finish()
+    }, OVERSIZE_DRAIN_TIMEOUT_MS)
+    timer.unref?.()
+    req.on('end', finish)
+    req.on('close', finish)
+    req.on('error', finish)
+    req.resume()
+  })
+}
 
 function requestedProfile(ctx: any): string {
   return ctx.state?.profile?.name || getActiveProfileName() || 'default'
@@ -20,14 +52,28 @@ export async function handleUpload(ctx: any) {
   if (!boundaryBuf) {
     ctx.status = 400; ctx.body = { error: 'Missing boundary' }; return
   }
-  const chunks: Buffer[] = []
+  let chunks: Buffer[] = []
   let totalSize = 0
-  for await (const chunk of ctx.req) {
+  let oversize = false
+  // Leave the stream alive when the loop ends early; the iterator would
+  // otherwise destroy it and take the unsent response down with it.
+  const body = typeof ctx.req.iterator === 'function'
+    ? ctx.req.iterator({ destroyOnReturn: false })
+    : ctx.req
+  for await (const chunk of body) {
     totalSize += chunk.length
     if (totalSize > MAX_UPLOAD_SIZE) {
-      ctx.status = 413; ctx.body = { error: `File too large (max ${MAX_UPLOAD_SIZE / 1024 / 1024}MB)` }; return
+      oversize = true
+      break
     }
     chunks.push(chunk)
+  }
+  if (oversize) {
+    chunks = []
+    await drainRequest(ctx.req)
+    ctx.status = 413
+    ctx.body = { error: `File too large (max ${MAX_UPLOAD_SIZE / 1024 / 1024}MB)` }
+    return
   }
   const raw = Buffer.concat(chunks)
   const parts = splitMultipart(raw, boundaryBuf)

--- a/packages/server/src/lib/request-body.ts
+++ b/packages/server/src/lib/request-body.ts
@@ -1,0 +1,40 @@
+// Cloud-hosted clients may need substantially longer than a local connection
+// to finish sending a body that was already in flight when a limit was hit.
+const REJECTED_REQUEST_DRAIN_TIMEOUT_MS = 2 * 60 * 1000
+
+/**
+ * Return an iterator that leaves the request stream open when a consumer stops
+ * early, allowing the remainder of a rejected body to be drained.
+ */
+export function nonDestroyingRequestBody(req: any): any {
+  return typeof req?.iterator === 'function'
+    ? req.iterator({ destroyOnReturn: false })
+    : req
+}
+
+/**
+ * Read and discard whatever is left of a rejected request body so the client
+ * can receive the HTTP error instead of a connection reset.
+ */
+export function drainRejectedRequest(req: any): Promise<void> {
+  if (!req || typeof req.resume !== 'function' || req.readableEnded || req.destroyed) return Promise.resolve()
+  return new Promise<void>(resolve => {
+    const finish = () => {
+      clearTimeout(timer)
+      req.off?.('end', finish)
+      req.off?.('close', finish)
+      req.off?.('error', finish)
+      resolve()
+    }
+    // Bound the work for clients that never finish sending the rejected body.
+    const timer = setTimeout(() => {
+      req.destroy?.()
+      finish()
+    }, REJECTED_REQUEST_DRAIN_TIMEOUT_MS)
+    timer.unref?.()
+    req.on('end', finish)
+    req.on('close', finish)
+    req.on('error', finish)
+    req.resume()
+  })
+}

--- a/tests/server/group-chat-invite-attachments.test.ts
+++ b/tests/server/group-chat-invite-attachments.test.ts
@@ -103,6 +103,21 @@ describe('invite-scoped group chat attachments', () => {
     expect(crossRoom.status).toBe(404)
   })
 
+  it('returns a readable 413 response for an oversized group attachment', async () => {
+    const form = new FormData()
+    form.append('file', new Blob([Buffer.alloc(21 * 1024 * 1024, 0x61)]), 'too-large.bin')
+
+    const upload = await fetch(`${baseUrl}/api/hermes/group-chat/invites/ROOM1/attachments`, {
+      method: 'POST',
+      body: form,
+    })
+
+    expect(upload.status).toBe(413)
+    await expect(upload.json()).resolves.toEqual({
+      error: 'Group chat attachment is too large (max 20MB)',
+    })
+  })
+
   it('uses the same isolated storage for authenticated room attachment routes', async () => {
     const form = new FormData()
     form.append('file', new Blob([Buffer.from('room-file')], { type: 'image/png' }), 'room.png')

--- a/tests/server/upload-controller.test.ts
+++ b/tests/server/upload-controller.test.ts
@@ -92,6 +92,42 @@ describe('upload controller', () => {
     expect(ctx.body.files[0]).toMatchObject({ name: 'daily report.txt', path: savedPath })
   })
 
+  it('answers 413 and finishes reading the body when an upload is too large', async () => {
+    const boundary = 'test-boundary'
+    const { handleUpload } = await import('../../packages/server/src/controllers/upload')
+    // Three chunks: the limit is crossed on the second, and the third is what a
+    // still-writing client would send after the server has made up its mind.
+    const chunk = Buffer.alloc(30 * 1024 * 1024, 0x61)
+    const sent: number[] = []
+    const req = new Readable({
+      read() {
+        if (sent.length >= 3) {
+          this.push(null)
+          return
+        }
+        sent.push(chunk.length)
+        this.push(chunk)
+      },
+    })
+    const ctx: any = {
+      get: vi.fn((header: string) => header === 'content-type' ? `multipart/form-data; boundary=${boundary}` : ''),
+      req,
+      state: { profile: { name: 'research' } },
+      body: undefined,
+      status: 200,
+    }
+
+    await handleUpload(ctx)
+
+    expect(ctx.status).toBe(413)
+    expect(ctx.body).toEqual({ error: 'File too large (max 50MB)' })
+    expect(writeFileMock).not.toHaveBeenCalled()
+    // The whole body was read, so the client is not cut off mid-write and can
+    // still read the reason it was refused.
+    expect(sent.length).toBe(3)
+    expect(req.readableEnded).toBe(true)
+  })
+
   it('returns 400 for malformed RFC 5987 filenames', async () => {
     const boundary = 'test-boundary'
     const { handleUpload } = await import('../../packages/server/src/controllers/upload')

--- a/tests/server/upload-controller.test.ts
+++ b/tests/server/upload-controller.test.ts
@@ -128,6 +128,46 @@ describe('upload controller', () => {
     expect(req.readableEnded).toBe(true)
   })
 
+  it('allows two minutes for a rejected upload body to drain', async () => {
+    vi.useFakeTimers()
+    try {
+      const boundary = 'test-boundary'
+      const { handleUpload } = await import('../../packages/server/src/controllers/upload')
+      const chunk = Buffer.alloc(30 * 1024 * 1024, 0x61)
+      let reads = 0
+      const req = new Readable({
+        read() {
+          reads += 1
+          if (reads <= 2) this.push(chunk)
+          // Leave the request open after crossing the limit to exercise the
+          // drain timeout without waiting in real time.
+        },
+      })
+      const ctx: any = {
+        get: vi.fn((header: string) => header === 'content-type' ? `multipart/form-data; boundary=${boundary}` : ''),
+        req,
+        state: { profile: { name: 'research' } },
+        body: undefined,
+        status: 200,
+      }
+
+      const upload = handleUpload(ctx)
+      await vi.advanceTimersByTimeAsync(10_000)
+
+      expect(req.destroyed).toBe(false)
+      expect(ctx.status).toBe(200)
+
+      await vi.advanceTimersByTimeAsync(110_000)
+      await upload
+
+      expect(req.destroyed).toBe(true)
+      expect(ctx.status).toBe(413)
+      expect(ctx.body).toEqual({ error: 'File too large (max 50MB)' })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('returns 400 for malformed RFC 5987 filenames', async () => {
     const boundary = 'test-boundary'
     const { handleUpload } = await import('../../packages/server/src/controllers/upload')


### PR DESCRIPTION
Fixes #2483.

Attaching a file over 50 MB fails with a bare `Error: Failed to fetch`. The server does the right thing — it detects the size and prepares `413 File too large (max 50MB)` — but the client never sees it.

## Why

```ts
for await (const chunk of ctx.req) {
  totalSize += chunk.length
  if (totalSize > MAX_UPLOAD_SIZE) {
    ctx.status = 413; ctx.body = { error: ... }; return
  }
  chunks.push(chunk)
}
```

`return` inside a `for await` calls the async iterator's `return()`, which destroys the stream. The client is still writing, so the socket is reset before it can read the response, and `fetch` surfaces that as a generic network failure rather than the reason the server had already written down.

## What changed

The loop breaks instead of returning, over `ctx.req.iterator({ destroyOnReturn: false })` so the stream survives the break. The buffered chunks are dropped immediately — a rejected 60 MB upload should not stay in memory — the rest of the body is drained, and only then is the 413 sent.

A client that keeps writing indefinitely is still cut off, after ten seconds. That is the old behaviour, now confined to the case that actually warrants it.

## Tests

`tests/server/upload-controller.test.ts` gains a case that feeds three 30 MB chunks: the limit is crossed on the second, and the third stands for what a still-uploading client keeps sending. It asserts `413` with the size message, that nothing was written to disk, that all three chunks were read, and that the stream ended rather than being destroyed.

Reverting the controller fails it with `expected 2 to be 3` — the third chunk is never read, which is the bug as reported.

Server `tsc` and `harness:check` pass.