### PR TITLE
feat(chat): say how many reasoning effort levels the slider has

### DIFF
--- a/docs/chat-chain-changes/2026-08-18-reasoning-effort-drag-hint.md
+++ b/docs/chat-chain-changes/2026-08-18-reasoning-effort-drag-hint.md
@@ -1,0 +1,14 @@
+---
+date: 2026-08-18
+feature: issue-2513-reasoning-effort-drag-hint
+pr: 2605
+impact: The reasoning effort popover gains one line of muted helper text under the slider. No change to how effort is chosen, stored or sent with a run.
+---
+
+# Issue #2513
+
+The reasoning effort control is an eight-stop slider, but the popover prints only the two end labels — "Default (config.yaml)" on the left and "Max" on the right. Read quickly that looks like two fixed choices rather than a range, and the reporter says they nearly concluded the setting was incomplete.
+
+A line under the slider now names the number of stops and says it can be dragged, taking the count from `reasoningEffortOptions` so it cannot drift from the real number of levels. The string is added to all eleven locales.
+
+Nothing else changes: the slider's value, its `@update:value` handler, and everything downstream of the chosen effort are untouched.

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1186,6 +1186,9 @@ function isImage(type: string): boolean {
                 <span>{{ reasoningEffortOptions[0].label }}</span>
                 <span>{{ reasoningEffortOptions[reasoningEffortOptions.length - 1].label }}</span>
               </div>
+              <div class="reasoning-effort-slider-hint">
+                {{ t('chat.reasoningEffort.dragHint', { count: reasoningEffortOptions.length }) }}
+              </div>
             </div>
           </NPopover>
 
@@ -1635,6 +1638,13 @@ function isImage(type: string): boolean {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+}
+
+.reasoning-effort-slider-hint {
+  margin-top: 6px;
+  color: $text-muted;
+  font-size: 11px;
+  text-align: center;
 }
 
 .reasoning-effort-slider-heading {

--- a/packages/client/src/i18n/locales/ar.ts
+++ b/packages/client/src/i18n/locales/ar.ts
@@ -704,6 +704,7 @@ export default {
     attachFiles: 'إرفاق ملفات',
     reasoningEffort: {
       tooltip: 'جهد التفكير',
+      dragHint: 'اسحب للاختيار · {count} درجات',
       defaultLabel: 'افتراضي',
       options: {
         default: 'افتراضي (config.yaml)',

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -685,6 +685,7 @@ export default {
     attachFiles: 'Dateien anhangen',
     reasoningEffort: {
       tooltip: 'Denkaufwand',
+      dragHint: 'Zum Auswählen ziehen · {count} Stufen',
       defaultLabel: 'Standard',
       options: {
         default: 'Standard (config.yaml)',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -724,6 +724,7 @@ export default {
     attachFiles: 'Attach files',
     reasoningEffort: {
       tooltip: 'Reasoning effort',
+      dragHint: 'Drag to choose · {count} levels',
       defaultLabel: 'Default',
       options: {
         default: 'Default (config.yaml)',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -685,6 +685,7 @@ export default {
     attachFiles: 'Adjuntar archivos',
     reasoningEffort: {
       tooltip: 'Esfuerzo de razonamiento',
+      dragHint: 'Arrastra para elegir · {count} niveles',
       defaultLabel: 'Predeterminado',
       options: {
         default: 'Predeterminado (config.yaml)',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -685,6 +685,7 @@ export default {
     attachFiles: 'Joindre des fichiers',
     reasoningEffort: {
       tooltip: 'Effort de raisonnement',
+      dragHint: 'Faites glisser pour choisir · {count} niveaux',
       defaultLabel: 'Par défaut',
       options: {
         default: 'Par défaut (config.yaml)',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -685,6 +685,7 @@ export default {
     attachFiles: 'ファイルを添付',
     reasoningEffort: {
       tooltip: '推論の労力',
+      dragHint: 'ドラッグして選択 · 全 {count} 段階',
       defaultLabel: '既定',
       options: {
         default: '既定 (config.yaml)',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -685,6 +685,7 @@ export default {
     attachFiles: '파일 첨부',
     reasoningEffort: {
       tooltip: '추론 노력',
+      dragHint: '드래그하여 선택 · {count}단계',
       defaultLabel: '기본값',
       options: {
         default: '기본값 (config.yaml)',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -685,6 +685,7 @@ export default {
     attachFiles: 'Anexar arquivos',
     reasoningEffort: {
       tooltip: 'Esforço de raciocínio',
+      dragHint: 'Arraste para escolher · {count} níveis',
       defaultLabel: 'Padrão',
       options: {
         default: 'Padrão (config.yaml)',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -592,6 +592,7 @@ export default {
     attachFiles: 'Прикрепить файлы',
     reasoningEffort: {
       tooltip: 'Глубина рассуждений',
+      dragHint: 'Перетащите, чтобы выбрать · {count} уровней',
       defaultLabel: 'По умолчанию',
       options: {
         default: 'По умолчанию (config.yaml)',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -702,6 +702,7 @@ export default {
     attachFiles: '新增附件',
     reasoningEffort: {
       tooltip: '推理強度',
+      dragHint: '拖曳選擇 · 共 {count} 檔',
       defaultLabel: '預設',
       options: {
         default: '預設 (config.yaml)',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -724,6 +724,7 @@ export default {
     attachFiles: '添加附件',
     reasoningEffort: {
       tooltip: '推理强度',
+      dragHint: '拖动选择 · 共 {count} 档',
       defaultLabel: '默认',
       options: {
         default: '默认 (config.yaml)',

--- a/tests/client/reasoning-effort-hint-locales.test.ts
+++ b/tests/client/reasoning-effort-hint-locales.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import ar from '../../packages/client/src/i18n/locales/ar'
+import de from '../../packages/client/src/i18n/locales/de'
+import en from '../../packages/client/src/i18n/locales/en'
+import es from '../../packages/client/src/i18n/locales/es'
+import fr from '../../packages/client/src/i18n/locales/fr'
+import ja from '../../packages/client/src/i18n/locales/ja'
+import ko from '../../packages/client/src/i18n/locales/ko'
+import pt from '../../packages/client/src/i18n/locales/pt'
+import ru from '../../packages/client/src/i18n/locales/ru'
+import zhTW from '../../packages/client/src/i18n/locales/zh-TW'
+import zh from '../../packages/client/src/i18n/locales/zh'
+
+const localeMessages: Record<string, Record<string, unknown>> = {
+  ar, de, en, es, fr, ja, ko, pt, ru, zh, 'zh-TW': zhTW,
+}
+
+function getPath(messages: Record<string, unknown>, path: string): unknown {
+  return path.split('.').reduce<unknown>((current, part) => (
+    current && typeof current === 'object' ? (current as Record<string, unknown>)[part] : undefined
+  ), messages)
+}
+
+/**
+ * The slider shows only its two end labels, so users read it as a two-option
+ * control. The hint says how many levels it really has — a hint that renders
+ * as a raw key, or without its count, defeats the point.
+ */
+describe('reasoning effort slider hint', () => {
+  it('is translated in every locale', () => {
+    for (const [locale, messages] of Object.entries(localeMessages)) {
+      expect(getPath(messages, 'chat.reasoningEffort.dragHint'), `${locale} missing the hint`)
+        .toEqual(expect.any(String))
+    }
+  })
+
+  it('carries the level count in every locale', () => {
+    for (const [locale, messages] of Object.entries(localeMessages)) {
+      expect(String(getPath(messages, 'chat.reasoningEffort.dragHint')), `${locale} hint drops {count}`)
+        .toContain('{count}')
+    }
+  })
+})


### PR DESCRIPTION
Fixes #2513.

The reasoning effort control is an eight-stop slider, but the popover prints only its two end labels:

```
Default (config.yaml)                                    Max
```

Read quickly, that is two fixed choices, not a range. The reporter says they nearly concluded the setting was incomplete — and nothing in the control suggests it can be dragged.

## What changed

One muted line under the slider, saying it can be dragged and how many levels it has:

> Drag to choose · 8 levels

The count comes from `reasoningEffortOptions.length`, not a literal, so it cannot drift from the real number of stops if the list ever changes. The string is added to all eleven locales.

Nothing else moves: the slider's value, its `@update:value` handler, and everything downstream of the chosen effort are untouched.

## Tests

`tests/client/reasoning-effort-hint-locales.test.ts` asserts the hint exists in every locale and that each translation keeps the `{count}` placeholder — a hint that renders as a raw key, or silently drops the number, would defeat its own purpose.

`vue-tsc -b`, the existing i18n coverage tests and `harness:check` all pass; a chat-chain fragment is included since `ChatInput.vue` is in the chain.