### PR TITLE
fix(chat): focus the composer when you switch sessions

### DIFF
--- a/docs/chat-chain-changes/2026-08-18-session-switch-composer-focus.md
+++ b/docs/chat-chain-changes/2026-08-18-session-switch-composer-focus.md
@@ -1,0 +1,16 @@
+---
+date: 2026-08-18
+feature: issue-2249-session-switch-composer-focus
+pr: 2606
+impact: Switching to another session puts the caret in the message box on desktop. No change on phones, and no change to scrolling, message loading, or what is sent.
+---
+
+# Issue #2249
+
+Opening another session from the sidebar left focus wherever the click put it, so the first thing typed after switching went nowhere and the composer had to be clicked first.
+
+`ChatInput` now exposes `focusComposer`, and the existing `activeSessionId` watcher in `ChatPanel` calls it after `nextTick`, before the fade animation's early return so it runs whether or not the animation surface exists. The guard on that watcher is unchanged: it still ignores a first session and a switch to the same id.
+
+The composer decides when focus is appropriate rather than the caller: on a phone viewport it refuses, because taking focus there raises the on-screen keyboard over the conversation the user just opened.
+
+The issue also asks for auto-scroll to the newest message on switch. That already exists — `applyInitialSessionScroll` in `MessageList` restores the remembered position for the session and scrolls to the bottom when the reader was last near it — so nothing there changed.

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -889,7 +889,17 @@ function handleDrop(e: DragEvent) {
   addFiles(files)
 }
 
-defineExpose({ addFiles, addBrowserAttachment })
+/**
+ * Put the caret in the composer so the next keystroke lands in the message box.
+ * Refused on a phone, where taking focus raises the on-screen keyboard over the
+ * conversation the user just opened.
+ */
+function focusComposer() {
+  if (isMobileViewport.value) return
+  nextTick(() => textareaRef.value?.focus())
+}
+
+defineExpose({ addFiles, addBrowserAttachment, focusComposer })
 
 // --- Send ---
 

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -90,6 +90,7 @@ const messageListRef = ref<InstanceType<typeof MessageList> | null>(null);
 const chatInputRef = ref<(InstanceType<typeof ChatInput> & {
   addFiles?: (files: File[]) => void;
   addBrowserAttachment?: (file: File, context: string) => void;
+  focusComposer?: () => void;
 }) | null>(null);
 const chatContentWrapperRef = ref<HTMLElement | null>(null);
 const chatMainContentRef = ref<HTMLElement | null>(null);
@@ -441,6 +442,11 @@ watch(
     }
 
     await nextTick();
+    // A session you just opened should be ready to type in. Without this the
+    // composer keeps whatever focus the sidebar click left behind, so the first
+    // keystroke goes nowhere.
+    chatInputRef.value?.focusComposer?.();
+
     const surface = chatMainContentRef.value;
     if (!surface || typeof surface.animate !== "function") return;
 

--- a/tests/client/chat-input-focus-composer.test.ts
+++ b/tests/client/chat-input-focus-composer.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+import { nextTick } from 'vue'
+import { useChatStore } from '@/stores/hermes/chat'
+import { useSettingsStore } from '@/stores/hermes/settings'
+import ChatInput from '@/components/hermes/chat/ChatInput.vue'
+
+const fetchSkillsMock = vi.hoisted(() => vi.fn())
+const fetchSkillBundlesMock = vi.hoisted(() => vi.fn())
+const deleteSkillBundleApiMock = vi.hoisted(() => vi.fn())
+const dialogWarningMock = vi.hoisted(() => vi.fn())
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NButton: { template: '<button type="button" v-bind="$attrs"><slot /><slot name="icon" /></button>' },
+  NTooltip: { template: '<div><slot name="trigger" /><slot /></div>' },
+  NSwitch: { template: '<button type="button"></button>' },
+  NDropdown: { template: '<div><slot /></div>' },
+  NModal: { template: '<div><slot /><slot name="footer" /></div>' },
+  NInputNumber: { template: '<input />' },
+  NPopover: {
+    template: '<div class="n-popover-stub"><slot name="trigger" /><slot /></div>',
+  },
+  NSlider: {
+    props: ['value', 'min', 'max', 'step'],
+    emits: ['update:value'],
+    template: `
+      <input
+        class="n-slider-stub"
+        type="range"
+        :value="value"
+        :min="min"
+        :max="max"
+        :step="step"
+        @input="$emit('update:value', Number($event.target.value))"
+      />
+    `,
+  },
+  useMessage: () => ({ error: vi.fn(), success: vi.fn() }),
+  useDialog: () => ({ warning: dialogWarningMock }),
+}))
+
+vi.mock('@/api/hermes/sessions', () => ({
+  fetchContextLength: vi.fn().mockResolvedValue(256000),
+}))
+
+vi.mock('@/api/hermes/model-context', () => ({
+  setModelContext: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/api/hermes/skills', () => ({
+  fetchSkills: fetchSkillsMock,
+}))
+
+vi.mock('@/api/hermes/skill-bundles', () => ({
+  fetchSkillBundles: fetchSkillBundlesMock,
+  deleteSkillBundleApi: deleteSkillBundleApiMock,
+}))
+
+vi.mock('@/components/hermes/chat/BundleCreateModal.vue', () => ({
+  default: {
+    name: 'BundleCreateModal',
+    props: ['profile'],
+    emits: ['close', 'created'],
+    template: '<div class="bundle-create-modal">{{ profile }}</div>',
+  },
+}))
+
+vi.mock('@/composables/useToolTraceVisibility', () => ({
+  useToolTraceVisibility: () => ({ toolTraceVisible: { value: true }, toggleToolTraceVisible: vi.fn() }),
+}))
+
+function mountForSession(
+  sessionId: string,
+  sessionOverrides: Partial<ReturnType<typeof useChatStore>['sessions'][number]> = {},
+  displayOverrides: Record<string, any> = {},
+) {
+  const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+  const chatStore = useChatStore()
+  const settingsStore = useSettingsStore()
+  chatStore.sessions = [
+    { id: sessionId, title: sessionId, source: 'cli', messages: [], createdAt: Date.now(), updatedAt: Date.now(), ...sessionOverrides },
+  ]
+  chatStore.activeSessionId = sessionId
+  chatStore.activeSession = chatStore.sessions[0]
+  settingsStore.display = displayOverrides
+  return mount(ChatInput, { attachTo: document.body, global: { plugins: [pinia] } })
+}
+
+/**
+ * Switching sessions left the composer unfocused, so the first keystroke after
+ * opening a conversation went nowhere (#2249). ChatPanel asks for the focus;
+ * the composer decides when taking it is appropriate.
+ */
+describe('ChatInput focusComposer', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.innerWidth = 1024
+    fetchSkillsMock.mockReset()
+    fetchSkillsMock.mockResolvedValue({ categories: [], archived: [] })
+    fetchSkillBundlesMock.mockReset()
+    fetchSkillBundlesMock.mockResolvedValue([])
+    deleteSkillBundleApiMock.mockReset()
+    dialogWarningMock.mockReset()
+  })
+
+  it('puts the caret in the message box on a desktop viewport', async () => {
+    const wrapper = mountForSession('session-focus-desktop')
+    const textarea = wrapper.find('textarea').element as HTMLTextAreaElement
+    textarea.blur()
+    expect(document.activeElement).not.toBe(textarea)
+
+    ;(wrapper.vm as any).focusComposer()
+    await nextTick()
+
+    expect(document.activeElement).toBe(textarea)
+    wrapper.unmount()
+  })
+
+  it('leaves focus alone on a phone, where it would raise the keyboard', async () => {
+    window.innerWidth = 390
+    const wrapper = mountForSession('session-focus-mobile')
+    const textarea = wrapper.find('textarea').element as HTMLTextAreaElement
+    textarea.blur()
+
+    ;(wrapper.vm as any).focusComposer()
+    await nextTick()
+
+    expect(document.activeElement).not.toBe(textarea)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
Addresses #2249.

Opening another session from the sidebar leaves focus wherever the click put it. You then type, nothing appears, and you have to click the message box first.

## What changed

`ChatInput` exposes `focusComposer`, and the `activeSessionId` watcher in `ChatPanel` calls it after `nextTick` — placed before the fade animation's early return, so it runs whether or not the animation surface exists. The watcher's existing guard is untouched: a first session and a switch to the same id are still ignored.

The decision about *when* focus is appropriate lives in the composer rather than the caller: on a phone viewport it refuses, because taking focus there raises the on-screen keyboard over the conversation the user just opened.

## The other half of the issue is already implemented

The issue also asks for auto-scroll to the newest message on switch, and for a remembered position when returning to a conversation. `applyInitialSessionScroll` in `MessageList` already does both — it restores the session's remembered viewport and scrolls to the bottom when the reader was last near it — so I changed nothing there. Those two requests also pull against each other, and the existing behaviour resolves it sensibly: it returns you to where you were reading, and to the bottom when that is where you were.

## Tests

`tests/client/chat-input-focus-composer.test.ts` mounts the composer for real and asserts the caret lands in the textarea on a desktop viewport, and that a 390px viewport is left alone.

Removing `focusComposer` fails both. `vue-tsc -b` passes, the neighbouring `chat-input-*` and `chat-panel-session-click` suites are green (32 tests), and a chat-chain fragment is included since both files are in the chain.