### PR TITLE
chore: prepare 0.6.44 release

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Hermes Studio API",
     "description": "Hermes Studio API — chat sessions, scheduled jobs, platform channels, model management, skills, memory, logs, file browser, group chat, and terminal.",
-    "version": "0.6.43"
+    "version": "0.6.44"
   },
   "servers": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.6.43",
+  "version": "0.6.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-web-ui",
-      "version": "0.6.43",
+      "version": "0.6.44",
       "license": "BSL-1.1",
       "dependencies": {
         "@audio/decode-mp3": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.6.43",
+  "version": "0.6.44",
   "description": "Self-hosted AI chat dashboard for Hermes Agent — multi-model web UI with multi-platform integration",
   "repository": {
     "type": "git",

--- a/packages/desktop/package-lock.json
+++ b/packages/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-studio",
-  "version": "0.6.43",
+  "version": "0.6.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-studio",
-      "version": "0.6.43",
+      "version": "0.6.44",
       "license": "BSL-1.1",
       "dependencies": {
         "electron-updater": "^6.3.9",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-studio",
-  "version": "0.6.43",
+  "version": "0.6.44",
   "description": "Hermes Studio desktop distribution with bundled Python runtime and hermes-agent",
   "homepage": "https://hermes-studio.ai",
   "author": {


### PR DESCRIPTION
## Summary

- bump the Web UI package version from `0.6.43` to `0.6.44`
- bump the desktop package version from `0.6.43` to `0.6.44`
- synchronize both lockfiles and the generated OpenAPI version

## Why

Prepare the version metadata used by the Web UI and desktop release workflows before creating the `v0.6.44` tag.

## User impact

Release artifacts and installed desktop applications will report the intended `0.6.44` version.

## Validation

- `npm ci --ignore-scripts`
- `npm ci --prefix packages/desktop --ignore-scripts --no-audit --no-fund`
- `npm run harness:check`
- `npm run build`
