### PR TITLE
fix: keep session reset history visible

### DIFF
--- a/docs/chat-chain-changes/2026-08-18-issue-2485-session-reset-history.md
+++ b/docs/chat-chain-changes/2026-08-18-issue-2485-session-reset-history.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-18
-pr: pending
+pr: 2609
 feature: Session reset history visibility
 impact: Session-reset children remain independent history entries while only verified compression continuations are collapsed into a single logical session.
 ---

--- a/docs/chat-chain-changes/2026-08-18-issue-2485-session-reset-history.md
+++ b/docs/chat-chain-changes/2026-08-18-issue-2485-session-reset-history.md
@@ -1,0 +1,6 @@
+---
+date: 2026-08-18
+pr: pending
+feature: Session reset history visibility
+impact: Session-reset children remain independent history entries while only verified compression continuations are collapsed into a single logical session.
+---

--- a/packages/server/src/db/hermes/sessions-db.ts
+++ b/packages/server/src/db/hermes/sessions-db.ts
@@ -553,6 +553,12 @@ function getLatestContinuationChild(
   return selectCompressionContinuationChild(parent, candidates)
 }
 
+function isCompressionContinuationChild(session: HermesSessionInternalRow, idx: SessionIndex): boolean {
+  if (!session.parent_session_id) return false
+  const parent = idx.byId.get(session.parent_session_id)
+  return !!parent && getLatestContinuationChild(parent, idx)?.id === session.id
+}
+
 function collectCompressionPath(
   session: HermesSessionInternalRow,
   idx: SessionIndex,
@@ -1502,28 +1508,11 @@ export async function listSessionSummaries(source?: string, limit = 2000, profil
   const db = new DatabaseSync(dbPath, { open: true, readOnly: true })
 
   try {
-    const clauses = ["s.parent_session_id IS NULL", "s.source != 'tool'", "s.id NOT LIKE 'compress_%'"]
-    const params: any[] = []
-    if (source) {
-      clauses.push('s.source = ?')
-      params.push(source)
-    }
-    params.push(Math.max(limit * 4, limit))
-
-    const rawRows = db.prepare(`
-      SELECT
-        ${SESSION_SELECT},
-        s.parent_session_id AS parent_session_id
-      FROM sessions s
-      WHERE ${clauses.join(' AND ')}
-      ORDER BY s.started_at DESC
-      LIMIT ?
-    `).all(...params) as Record<string, unknown>[] | undefined
-    const roots = (Array.isArray(rawRows) ? rawRows : []).map(mapInternalSessionRow)
-
     const idx = loadAllSessions(db)
-    return roots
-      .map(root => projectSessionSummary(root, collectSessionChain(root, idx)))
+    return [...idx.byId.values()]
+      .filter(session => !source || session.source === source)
+      .filter(session => !isCompressionContinuationChild(session, idx))
+      .map(session => projectSessionSummary(session, collectSessionChain(session, idx)))
       .sort(compareSessionSummariesNewestFirst)
       .slice(0, limit)
   } finally {
@@ -1548,7 +1537,7 @@ export async function listSessionSummaryGroups(
     const included = new Map<string, HermesSessionRow>()
 
     for (const root of idx.byId.values()) {
-      if (root.parent_session_id != null) continue
+      if (isCompressionContinuationChild(root, idx)) continue
       const summary = projectSessionSummary(root, collectSessionChain(root, idx))
       const sessions = grouped.get(summary.source) || []
       sessions.push(summary)

--- a/tests/server/sessions-db-lineage.test.ts
+++ b/tests/server/sessions-db-lineage.test.ts
@@ -180,6 +180,49 @@ describe('session DB compression lineage', () => {
     })
   })
 
+  it('keeps session reset children as separate visible history entries', async () => {
+    insertSession(db!, {
+      id: 'before-reset',
+      source: 'feishu',
+      title: 'Before reset',
+      started_at: 100,
+      ended_at: 200,
+      end_reason: 'session_reset',
+    })
+    insertSession(db!, {
+      id: 'after-reset',
+      source: 'feishu',
+      parent_session_id: 'before-reset',
+      title: 'After reset',
+      started_at: 201,
+    })
+    insertMessage(db!, { id: 11, session_id: 'before-reset', content: 'before reset history', timestamp: 101 })
+    insertMessage(db!, { id: 12, session_id: 'after-reset', content: '重置后可搜索', timestamp: 202 })
+
+    const mod = await import('../../packages/server/src/db/hermes/sessions-db')
+    const summaries = await mod.listSessionSummaries('feishu', 20)
+    expect(summaries.map(summary => summary.id)).toEqual(['after-reset', 'before-reset'])
+
+    const groups = await mod.listSessionSummaryGroups(20, 'default')
+    expect(groups.groups).toEqual([
+      expect.objectContaining({
+        source: 'feishu',
+        sessions: [
+          expect.objectContaining({ id: 'after-reset' }),
+          expect.objectContaining({ id: 'before-reset' }),
+        ],
+      }),
+    ])
+
+    const beforeDetail = await mod.getSessionDetailFromDb('before-reset')
+    const afterDetail = await mod.getSessionDetailFromDb('after-reset')
+    expect(beforeDetail?.messages.map(message => message.session_id)).toEqual(['before-reset'])
+    expect(afterDetail?.messages.map(message => message.session_id)).toEqual(['after-reset'])
+
+    const search = await mod.searchSessionSummaries('重置后可搜索', 'feishu', 20)
+    expect(search.map(summary => summary.id)).toEqual(['after-reset'])
+  })
+
   it('returns an independent first page and continuation signal for each source', async () => {
     insertSession(db!, { id: 'cli-new', source: 'cli', started_at: 300 })
     insertSession(db!, { id: 'cli-old', source: 'cli', started_at: 200 })

--- a/tests/server/sessions-db.test.ts
+++ b/tests/server/sessions-db.test.ts
@@ -41,8 +41,8 @@ describe('session DB summaries', () => {
     getActiveProfileDirMock.mockReturnValue('/tmp/hermes-profile')
   })
 
-  it('queries sqlite for lightweight session summaries', async () => {
-    allMock.mockReturnValue([
+  it('queries sqlite for session summaries through the session index', async () => {
+    indexAllMock.mockReturnValue([
       {
         id: 's1',
         source: 'cli',
@@ -73,7 +73,7 @@ describe('session DB summaries', () => {
 
     expect(databaseSyncMock).toHaveBeenCalledWith('/tmp/hermes-profile/state.db', { open: true, readOnly: true })
     expect(prepareMock).toHaveBeenCalledWith(expect.stringContaining("s.source != 'tool'"))
-    expect(allMock).toHaveBeenCalledWith(200)
+    expect(indexAllMock).toHaveBeenCalledWith()
     expect(closeMock).toHaveBeenCalled()
     expect(rows).toEqual([
       {
@@ -102,8 +102,8 @@ describe('session DB summaries', () => {
     ])
   })
 
-  it('adds source filter and falls back last_active to started_at', async () => {
-    allMock.mockReturnValue([
+  it('filters indexed summaries by source and falls back last_active to started_at', async () => {
+    indexAllMock.mockReturnValue([
       {
         id: 's2',
         source: 'telegram',
@@ -133,7 +133,7 @@ describe('session DB summaries', () => {
     const rows = await mod.listSessionSummaries('telegram', 2)
 
     expect(prepareMock).toHaveBeenCalledWith(expect.stringContaining("s.source != 'tool'"))
-    expect(allMock).toHaveBeenCalledWith('telegram', 8)
+    expect(indexAllMock).toHaveBeenCalledWith()
     expect(rows[0].last_active).toBe(1710000100)
     expect(rows[0].source).toBe('telegram')
     expect(rows[0].title).toBe('preview text')


### PR DESCRIPTION
## Summary
- retain `/new` sessions as independent history entries instead of hiding every child session
- continue collapsing only verified compression continuations
- cover list, grouped history, detail isolation, and search behavior for `session_reset`

Closes #2485

## Validation
- `npm run test -- tests/server/sessions-db-lineage.test.ts tests/server/sessions-db.test.ts tests/server/session-detail-db.test.ts`
- `npm run harness:check`
- `npm run build`