### PR TITLE
fix(client): show full slash command palette for api_server sessions

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -214,7 +214,10 @@ let bundlesLoadRequestKey = ''
 const isBridgeSession = computed(() => {
   const session = chatStore.activeSession
   if (!session) return chatStore.runtimeMode !== 'global_agent'
-  return session.source === 'cli'
+  // Studio-created Hermes sessions are persisted with source 'api_server' but
+  // are backed by the same bridge runtime as CLI sessions, so they support the
+  // full slash command set as well. Fixes #2611.
+  return session.source === 'cli' || session.source === 'api_server'
 })
 const isCodingAgentSession = computed(() => {
   const session = chatStore.activeSession


### PR DESCRIPTION
## Summary

Fixes #2611

Sessions created via Studio's own **New Chat → Agent: Hermes** flow are persisted with `source = 'api_server'` (the DB default; only sessions imported from the Hermes CLI get `source = 'cli'`). The slash-command palette filter in `ChatInput.vue` only granted the full command list to `source === 'cli'`, so after the first message was sent, the palette collapsed to a single entry (`/fork`) for all Studio-created sessions.

## Root cause

`isBridgeSession` in `packages/client/src/components/hermes/chat/ChatInput.vue`:

```ts
const isBridgeSession = computed(() => {
  const session = chatStore.activeSession
  if (!session) return chatStore.runtimeMode !== 'global_agent'
  return session.source === 'cli'   // ← api_server sessions fell through to the fork-only branch
})
```

`filteredBridgeCommands` then routed these sessions to the `isForkCommandSession` branch, which filters the command list down to `fork`.

## Fix

One-line change: treat `api_server` sessions as bridge sessions too.

```ts
return session.source === 'cli' || session.source === 'api_server'
```

These sessions run on the same embedded Hermes runtime as CLI sessions and the bridge command channel works for them — verified on webui 0.6.44 (Windows desktop): with this patch applied, the palette shows the full command list (`/yolo`, `/skill`, `/plan`, `/compact`, …) for `api_server` sessions, and `/yolo` executes and toggles mode correctly. Commands that a given runtime cannot handle already fail gracefully with an informative message from the server side (e.g. `YOLO mode is not available in the running Hermes Agent runtime.`), so widening the palette does not introduce hard failures.

## Reproduction (before the fix)

1. Studio desktop → New Chat → Agent = **Hermes** → create session.
2. Type `/` before sending the first message — the full list appears (`activeSession` is still null, so the `runtimeMode !== 'global_agent'` fallback grants full access).
3. Send the first message; the session is persisted with `source = 'api_server'`.
4. Continue the conversation, type `/` — only `/fork` remains.

## Test plan

- [x] Manual verification on Windows desktop (webui 0.6.44): full palette restored for `api_server` sessions; `/yolo` toggles successfully; coding-agent sessions (Claude/Codex/Pi) unaffected — they still show the 4-command whitelist via `isCodingAgentSession`.
