### PR TITLE
fix(chat): let session titles and outlines find their own direction

### DIFF
--- a/docs/chat-chain-changes/2026-08-18-chat-auto-direction-surfaces.md
+++ b/docs/chat-chain-changes/2026-08-18-chat-auto-direction-surfaces.md
@@ -1,0 +1,16 @@
+---
+date: 2026-08-18
+feature: chat-auto-direction-remaining-surfaces
+pr: 2614
+impact: The chat header title, search result title and snippet, subagent goal, and outline entries take their direction from their own text. Interface labels are unchanged, as is message rendering.
+---
+
+# Direction on the remaining chat surfaces
+
+Message bodies already choose their own direction per block, and the sidebar session item carries `dir="auto"`. Five surfaces showing the same authored text were left without it, so an Arabic session read correctly in the sidebar and came out reordered in the header above it.
+
+Marked now: the header session title in `ChatPanel`, the result title and snippet in `SessionSearchModal`, the subagent goal in `SubagentStreamPanel`, and both the question and heading text in `OutlinePanel`.
+
+Deliberately not marked: `search-title`, `outline-title` and the approval headings. Those are `t()` strings the interface owns, and they must follow the interface locale rather than whatever language the conversation happens to be in.
+
+No change to how messages are rendered, stored, searched or navigated; this is presentation only.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2629,7 +2629,7 @@ async function handleSessionModelCustomSubmit() {
               </svg>
             </template>
           </NButton>
-          <span class="header-session-title">{{ headerTitle }}</span>
+          <span class="header-session-title" dir="auto">{{ headerTitle }}</span>
           <button
             v-if="chatStore.activeSession?.workspace"
             class="workspace-badge"

--- a/packages/client/src/components/hermes/chat/OutlinePanel.vue
+++ b/packages/client/src/components/hermes/chat/OutlinePanel.vue
@@ -133,7 +133,7 @@ function scrollToTarget(item: OutlineItem) {
           >
             <div class="user-question">
               <span class="q-label">Q:</span>
-              <span class="q-text">{{ item.content }}</span>
+              <span class="q-text" dir="auto">{{ item.content }}</span>
             </div>
           </div>
           <div
@@ -143,7 +143,7 @@ function scrollToTarget(item: OutlineItem) {
             @click="scrollToTarget(item)"
           >
             <div class="heading-item">
-              <span class="heading-text">{{ item.content }}</span>
+              <span class="heading-text" dir="auto">{{ item.content }}</span>
             </div>
           </div>
         </template>

--- a/packages/client/src/components/hermes/chat/SessionSearchModal.vue
+++ b/packages/client/src/components/hermes/chat/SessionSearchModal.vue
@@ -301,10 +301,10 @@ onUnmounted(() => {
             >
               <div class="result-main">
                 <div class="result-title-row">
-                  <span class="result-title">{{ getItemTitle(item) }}</span>
+                  <span class="result-title" dir="auto">{{ getItemTitle(item) }}</span>
                   <span class="result-source">{{ formatSource(item.source) }}</span>
                 </div>
-                <div class="result-snippet">
+                <div class="result-snippet" dir="auto">
                   {{ hasQuery ? item.snippet || t('chat.searchNoSnippet') : item.preview || t('chat.searchRecent') }}
                 </div>
               </div>

--- a/packages/client/src/components/hermes/chat/SubagentStreamPanel.vue
+++ b/packages/client/src/components/hermes/chat/SubagentStreamPanel.vue
@@ -198,7 +198,7 @@ onBeforeUnmount(stopElapsedTimer)
           <span>{{ t('subagent.title') }}</span>
           <span v-if="taskPosition" class="subagent-task-position">{{ taskPosition }}</span>
         </div>
-        <div class="subagent-stream-title">{{ stream?.goal || t('subagent.noGoal') }}</div>
+        <div class="subagent-stream-title" dir="auto">{{ stream?.goal || t('subagent.noGoal') }}</div>
         <div v-if="metrics.length" class="subagent-stream-metrics">
           <span v-for="metric in metrics" :key="metric.key">{{ metric.value }}</span>
         </div>

--- a/tests/client/chat-auto-direction.test.ts
+++ b/tests/client/chat-auto-direction.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'fs'
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+import OutlinePanel from '@/components/hermes/chat/OutlinePanel.vue'
+
+/**
+ * A conversation carries whatever language the person and the agent write in,
+ * which is not the language the interface is set to. Anything showing their
+ * words has to take its direction from the words; labels the interface owns
+ * must not, or they would flip whenever the conversation does.
+ */
+describe('chat text direction follows the conversation, not the interface', () => {
+  it('lets an outline entry take its direction from the message it quotes', () => {
+    const messages = [
+      { id: 'm1', role: 'user', content: 'راجع تقرير التغطية وأضف اليوم الثاني', createdAt: 1 },
+      { id: 'm2', role: 'assistant', content: '## الخلاصة\n\nتم التحديث.', createdAt: 2 },
+    ]
+    const wrapper = mount(OutlinePanel, { props: { messages: messages as any } })
+
+    const question = wrapper.find('.q-text')
+    expect(question.exists()).toBe(true)
+    expect(question.attributes('dir')).toBe('auto')
+
+    const heading = wrapper.find('.heading-text')
+    if (heading.exists()) expect(heading.attributes('dir')).toBe('auto')
+
+    // The interface's own label is not a conversation and stays put.
+    expect(wrapper.find('.outline-title').attributes('dir')).toBeUndefined()
+  })
+
+  // ChatPanel and SessionSearchModal are asserted against source, the way
+  // tests/client/chat-panel-session-click.test.ts already does — mounting
+  // either one drags in the whole chat surface.
+  it('marks the session title in the chat header', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+    expect(source).toContain('<span class="header-session-title" dir="auto">{{ headerTitle }}</span>')
+  })
+
+  it('marks the title and snippet of a search result', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/SessionSearchModal.vue', 'utf8')
+    expect(source).toContain('<span class="result-title" dir="auto">')
+    expect(source).toContain('<div class="result-snippet" dir="auto">')
+    // The static headline above the results belongs to the interface.
+    expect(source).toContain('<div class="search-title">')
+  })
+
+  it('marks the goal a subagent was given', () => {
+    const source = readFileSync('packages/client/src/components/hermes/chat/SubagentStreamPanel.vue', 'utf8')
+    expect(source).toContain('<div class="subagent-stream-title" dir="auto">')
+  })
+})


### PR DESCRIPTION
Message bodies already choose a direction per block, and the sidebar session item carries `dir="auto"`. Five surfaces that show the same authored text were missed.

The clearest symptom, from a live instance: an Arabic session title renders correctly in the sidebar and comes out reordered in the header directly above it — same string, same moment, two different results.

| surface | shows |
|---|---|
| `ChatPanel` header session title | the session's title |
| `SessionSearchModal` result title and snippet | session titles and message text |
| `SubagentStreamPanel` title | the goal an agent was given |
| `OutlinePanel` question and heading text | text pulled straight out of messages |

All five now carry `dir="auto"`.

## What is deliberately left alone

`search-title`, `outline-title` and the approval headings are `t()` strings. They belong to the interface locale and must not flip when the conversation is in another language — marking them would be the same bug pointed the other way.

Message rendering, storage, search and navigation are untouched; this is presentation only.

## Tests

`tests/client/chat-auto-direction.test.ts` mounts `OutlinePanel` for real and asserts the quoted question is marked while the panel's own heading is not, then asserts the other three files at source level — the convention `tests/client/chat-panel-session-click.test.ts` already uses, since mounting `ChatPanel` drags in the whole chat surface.

Reverting the components fails all four cases. `vue-tsc -b` passes, the existing direction suites (`rtl-logical-css`, `i18n-direction`, `markdown-auto-direction`) stay green, and a chat-chain fragment is included.