### PR TITLE
fix(chat): show pending background delegations

### DIFF
--- a/docs/chat-chain-changes/2026-08-21-issue-2625-background-delegation-status.md
+++ b/docs/chat-chain-changes/2026-08-21-issue-2625-background-delegation-status.md
@@ -1,0 +1,12 @@
+---
+date: 2026-08-21
+pr: 2629
+feature: issue-2625-background-delegation-status
+impact: A chat and its session-list entry report outstanding background delegate_task work after the foreground turn completes, including after a session resume, without treating that work as foreground streaming.
+---
+
+# Issue #2625
+
+The client keeps a per-session count of running background delegations from the resume payload and subsequent run events. The count keeps an otherwise idle session visibly active, appears in the selected chat as a calm status, and appears beside background sessions in the list.
+
+Foreground streaming and cancellation behavior are unchanged. The count is cleared only when the server reports no outstanding background work.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2016,6 +2016,7 @@ async function handleSessionModelCustomSubmit() {
             :pinned="sessionBrowserPrefsStore.isPinned(s.id)"
             :can-delete="s.id !== chatStore.activeSessionId || chatStore.sessions.length > 1"
             :streaming="chatStore.isSessionLive(s.id)"
+            :background-pending="chatStore.backgroundPendingForSession(s.id)"
             :completed-unread="chatStore.isSessionCompletedUnread(s.id)"
             :selectable="isBatchMode"
             :selected="isSessionSelected(s)"
@@ -2046,6 +2047,7 @@ async function handleSessionModelCustomSubmit() {
               chatStore.sessions.length > 1
             "
             :streaming="chatStore.isSessionLive(s.id)"
+            :background-pending="chatStore.backgroundPendingForSession(s.id)"
             :completed-unread="chatStore.isSessionCompletedUnread(s.id)"
             :selectable="isBatchMode"
             :selected="isSessionSelected(s)"
@@ -2093,6 +2095,7 @@ async function handleSessionModelCustomSubmit() {
                 chatStore.sessions.length > 1
               "
               :streaming="chatStore.isSessionLive(s.id)"
+              :background-pending="chatStore.backgroundPendingForSession(s.id)"
               :completed-unread="chatStore.isSessionCompletedUnread(s.id)"
               :selectable="isBatchMode"
               :selected="isSessionSelected(s)"

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -88,6 +88,7 @@ function stopThinkingTimer() {
 }
 
 const isRunIndicatorActive = computed(() => chatStore.isRunActive || !!chatStore.abortState);
+const backgroundPending = computed(() => chatStore.backgroundPending);
 const formattedThinkingElapsed = computed(() => formatElapsed(thinkingElapsedMs.value));
 
 const currentToolCalls = computed(() => {
@@ -653,6 +654,10 @@ defineExpose({
         />
       </template>
       <template #after>
+        <div v-if="backgroundPending > 0 && !isRunIndicatorActive" class="background-delegations-status" role="status">
+          <strong>{{ t('chat.backgroundDelegationsRunning', { count: backgroundPending }) }}</strong>
+          <span>{{ t('chat.backgroundDelegationsHint') }}</span>
+        </div>
         <Transition name="fade">
         <div v-if="isRunIndicatorActive" class="streaming-indicator">
           <LiveReasoningStatus
@@ -993,6 +998,21 @@ defineExpose({
 
 <style scoped lang="scss">
 @use "@/styles/variables" as *;
+
+.background-delegations-status {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 12px 16px;
+  padding: 10px 12px;
+  border: 1px solid rgba(var(--accent-primary-rgb), 0.35);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  background: rgba(var(--accent-primary-rgb), 0.08);
+  font-size: 13px;
+
+  strong { color: var(--text-primary); }
+}
 
 .message-list-shell {
   flex: 1;

--- a/packages/client/src/components/hermes/chat/SessionListItem.vue
+++ b/packages/client/src/components/hermes/chat/SessionListItem.vue
@@ -419,7 +419,7 @@ onUnmounted(() => {
   justify-content: center;
   min-width: 16px;
   height: 16px;
-  margin-left: 5px;
+  margin-inline-start: 5px;
   padding: 0 4px;
   border-radius: 8px;
   color: var(--text-primary);

--- a/packages/client/src/components/hermes/chat/SessionListItem.vue
+++ b/packages/client/src/components/hermes/chat/SessionListItem.vue
@@ -15,6 +15,7 @@ const props = withDefaults(defineProps<{
   pinned: boolean
   canDelete: boolean
   streaming?: boolean
+  backgroundPending?: number
   completedUnread?: boolean
   selectable?: boolean
   selected?: boolean
@@ -133,6 +134,12 @@ onUnmounted(() => {
             </svg>
           </span>
           <span v-if="completedUnread" class="session-item-unread-dot" aria-hidden="true" />
+          <span
+            v-if="backgroundPending && backgroundPending > 0"
+            class="session-item-background-count"
+            :aria-label="t('chat.backgroundDelegationsRunning', { count: backgroundPending })"
+            :title="t('chat.backgroundDelegationsRunning', { count: backgroundPending })"
+          >{{ backgroundPending }}</span>
           <span class="session-item-title" dir="auto">
             {{ session.title }}
           </span>
@@ -404,6 +411,21 @@ onUnmounted(() => {
     0 0 10px rgba(255, 107, 107, 0.4),
     0 0 20px rgba(255, 107, 107, 0.2);
   animation: rainbow-glow 4s linear infinite;
+}
+
+.session-item-background-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  margin-left: 5px;
+  padding: 0 4px;
+  border-radius: 8px;
+  color: var(--text-primary);
+  background: rgba(var(--accent-primary-rgb), 0.5);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
 }
 
 .session-item-agent-logo {

--- a/packages/client/src/i18n/locales/ar.ts
+++ b/packages/client/src/i18n/locales/ar.ts
@@ -900,6 +900,8 @@ export default {
     executionDuration: 'وقت التنفيذ',
     thinkingLabel: 'التفكير',
     thinkingInProgress: 'التفكير',
+    backgroundDelegationsRunning: '{count} من التفويضات الخلفية لا تزال قيد التشغيل',
+    backgroundDelegationsHint: 'يمكنك متابعة الكتابة؛ لن تلغي الرسائل الجديدة هذه المهام.',
     thinkingShow: 'إظهار التفكير',
     thinkingHide: 'إخفاء التفكير',
     thinkingDuration: 'المدة المرصودة {duration}',

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -820,6 +820,8 @@ export default {
     unchangedLines: '{count} unveränderte Zeilen',
     executionDuration: 'Ausführungszeit',    thinkingLabel: 'Denkprozess',
     thinkingInProgress: 'Denkt',
+    backgroundDelegationsRunning: '{count} Hintergrunddelegierungen laufen noch',
+    backgroundDelegationsHint: 'Du kannst weiterschreiben; neue Nachrichten brechen sie nicht ab.',
     thinkingShow: 'Denkprozess anzeigen',
     thinkingHide: 'Denkprozess ausblenden',
     thinkingDuration: 'Beobachtet {duration}',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -920,6 +920,8 @@ export default {
     executionDuration: 'Execution time',
     thinkingLabel: 'Thinking',
     thinkingInProgress: 'Thinking',
+    backgroundDelegationsRunning: '{count} background delegations still running',
+    backgroundDelegationsHint: 'You can continue typing; new messages will not cancel them.',
     thinkingShow: 'Show thinking',
     thinkingHide: 'Hide thinking',
     thinkingDuration: 'Observed {duration}',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -820,6 +820,8 @@ export default {
     unchangedLines: '{count} líneas sin cambios',
     executionDuration: 'Tiempo de ejecución',    thinkingLabel: 'Pensamiento',
     thinkingInProgress: 'Pensando',
+    backgroundDelegationsRunning: '{count} delegaciones en segundo plano siguen en ejecución',
+    backgroundDelegationsHint: 'Puedes seguir escribiendo; los mensajes nuevos no las cancelarán.',
     thinkingShow: 'Mostrar pensamiento',
     thinkingHide: 'Ocultar pensamiento',
     thinkingDuration: 'Observado {duration}',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -820,6 +820,8 @@ export default {
     unchangedLines: '{count} lignes inchangées',
     executionDuration: 'Temps d’exécution',    thinkingLabel: 'Raisonnement',
     thinkingInProgress: 'En réflexion',
+    backgroundDelegationsRunning: '{count} délégations en arrière-plan sont encore en cours',
+    backgroundDelegationsHint: 'Vous pouvez continuer à écrire ; les nouveaux messages ne les annuleront pas.',
     thinkingShow: 'Afficher le raisonnement',
     thinkingHide: 'Masquer le raisonnement',
     thinkingDuration: 'Observé {duration}',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -820,6 +820,8 @@ export default {
     unchangedLines: '変更なし {count} 行',
     executionDuration: '実行時間',    thinkingLabel: '思考過程',
     thinkingInProgress: '思考中',
+    backgroundDelegationsRunning: '{count} 件のバックグラウンド委任が実行中です',
+    backgroundDelegationsHint: '入力を続けられます。新しいメッセージでこれらのタスクはキャンセルされません。',
     thinkingShow: '思考過程を表示',
     thinkingHide: '思考過程を隠す',
     thinkingDuration: '観測 {duration}',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -820,6 +820,8 @@ export default {
     unchangedLines: '변경 없음 {count}줄',
     executionDuration: '실행 시간',    thinkingLabel: '사고 과정',
     thinkingInProgress: '사고 중',
+    backgroundDelegationsRunning: '백그라운드 위임 {count}개가 아직 실행 중입니다',
+    backgroundDelegationsHint: '계속 입력할 수 있으며 새 메시지는 이 작업을 취소하지 않습니다.',
     thinkingShow: '사고 과정 펼치기',
     thinkingHide: '사고 과정 접기',
     thinkingDuration: '관측 {duration}',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -820,6 +820,8 @@ export default {
     unchangedLines: '{count} linhas inalteradas',
     executionDuration: 'Tempo de execução',    thinkingLabel: 'Raciocínio',
     thinkingInProgress: 'Pensando',
+    backgroundDelegationsRunning: '{count} delegações em segundo plano ainda estão em execução',
+    backgroundDelegationsHint: 'Você pode continuar digitando; novas mensagens não as cancelarão.',
     thinkingShow: 'Mostrar raciocínio',
     thinkingHide: 'Ocultar raciocínio',
     thinkingDuration: 'Observado {duration}',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -778,6 +778,8 @@ export default {
     executionDuration: 'Длительность выполнения',
     thinkingLabel: 'Процесс размышления',
     thinkingInProgress: 'Размышление',
+    backgroundDelegationsRunning: 'Выполняется фоновых делегирований: {count}',
+    backgroundDelegationsHint: 'Можно продолжать ввод; новые сообщения не отменят эти задачи.',
     thinkingShow: 'Развернуть процесс размышления',
     thinkingHide: 'Свернуть процесс размышления',
     thinkingDuration: 'Наблюдается {duration}',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -889,6 +889,8 @@ export default {
     executionDuration: '執行時長',
     thinkingLabel: '思考過程',
     thinkingInProgress: '正在思考',
+    backgroundDelegationsRunning: '仍有 {count} 個背景委派工作正在執行',
+    backgroundDelegationsHint: '你可以繼續輸入；新訊息不會取消這些工作。',
     thinkingShow: '展開思考過程',
     thinkingHide: '收起思考過程',
     thinkingDuration: '已觀察 {duration}',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -920,6 +920,8 @@ export default {
     executionDuration: '执行时长',
     thinkingLabel: '思考过程',
     thinkingInProgress: '正在思考',
+    backgroundDelegationsRunning: '仍有 {count} 个后台委派任务在运行',
+    backgroundDelegationsHint: '你可以继续输入；新消息不会取消这些任务。',
     thinkingShow: '展开思考过程',
     thinkingHide: '收起思考过程',
     thinkingDuration: '已观察 {duration}',

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1242,6 +1242,8 @@ export const useChatStore = defineStore('chat', () => {
   const streamStates = ref<Map<string, { abort: () => void }>>(new Map())
   /** sessionId → server-reported isWorking status */
   const serverWorking = ref<Set<string>>(new Set())
+  /** sessionId → background delegations which have not reached a terminal state */
+  const backgroundPendingBySession = ref<Map<string, number>>(new Map())
   /** sessionIds with a terminal /fork command submitted but not settled yet */
   const pendingForkCommands = ref<Set<string>>(new Set())
   /** Sessions that completed while the user was viewing another session. */
@@ -1319,6 +1321,18 @@ export const useChatStore = defineStore('chat', () => {
     return sid ? messageLoadRequests.value.has(sid) : false
   })
   const isRunActive = computed(() => isStreaming.value)
+  const backgroundPending = computed(() => {
+    const sid = activeSessionId.value
+    return sid ? backgroundPendingBySession.value.get(sid) || 0 : 0
+  })
+
+  function setBackgroundPending(sessionId: string, pending: unknown) {
+    const count = Math.max(0, Number(pending) || 0)
+    const next = new Map(backgroundPendingBySession.value)
+    if (count > 0) next.set(sessionId, count)
+    else next.delete(sessionId)
+    backgroundPendingBySession.value = next
+  }
   let loadSessionsRequestSequence = 0
   let switchSessionRequestSequence = 0
   let activeSelectionSequence = 0
@@ -1368,6 +1382,7 @@ export const useChatStore = defineStore('chat', () => {
     pendingClarifies.value = new Map()
     streamStates.value = new Map()
     serverWorking.value = new Set()
+    backgroundPendingBySession.value = new Map()
     pendingForkCommands.value = new Set()
     workspaceRunChangesBySession.value = new Map()
     abortStates.value = new Map()
@@ -1418,7 +1433,13 @@ export const useChatStore = defineStore('chat', () => {
   const workspaceRunChangeLoadRequests = new Set<string>()
 
   function isSessionLive(sessionId: string): boolean {
-    return streamStates.value.has(sessionId) || serverWorking.value.has(sessionId)
+    return streamStates.value.has(sessionId)
+      || serverWorking.value.has(sessionId)
+      || (backgroundPendingBySession.value.get(sessionId) || 0) > 0
+  }
+
+  function backgroundPendingForSession(sessionId: string): number {
+    return backgroundPendingBySession.value.get(sessionId) || 0
   }
 
   function isSessionCompletedUnread(sessionId: string): boolean {
@@ -1877,6 +1898,7 @@ export const useChatStore = defineStore('chat', () => {
             serverWorking.value.delete(sessionId)
           }
           backgroundPendingOnResume = Number(data.backgroundPending || 0)
+          setBackgroundPending(sessionId, backgroundPendingOnResume)
           if (data.queueLength && data.queueLength > 0) {
             queueLengths.value.set(sessionId, data.queueLength)
           } else {
@@ -4246,6 +4268,7 @@ export const useChatStore = defineStore('chat', () => {
       if (closed) return
       // Filter events for this session (server tags all events with session_id)
       if (evt.session_id && evt.session_id !== sid) return
+      if (evt.background_pending != null) setBackgroundPending(sid, evt.background_pending)
       const eventRunMarker = readRunMarker(evt)
       if (eventRunMarker) activeRunMarker = eventRunMarker
       switch (evt.event) {
@@ -5134,7 +5157,9 @@ export const useChatStore = defineStore('chat', () => {
     isStreaming,
     isForkPending,
     isRunActive,
+    backgroundPending,
     isSessionLive,
+    backgroundPendingForSession,
     isSessionCompletedUnread,
     clearSessionCompletedUnread,
     sessionProfileFilter,

--- a/tests/client/chat-store-compression-state.test.ts
+++ b/tests/client/chat-store-compression-state.test.ts
@@ -120,6 +120,26 @@ describe('chat store compression state', () => {
     expect(store.isSessionLive('session-1')).toBe(false)
   })
 
+  it('replaces a prior background delegation count when returning to a session', async () => {
+    let sessionOneResumes = 0
+    chatApi.resumeSession.mockImplementation((sessionId: string, onResumed: (data: any) => void) => {
+      const backgroundPending = sessionId === 'session-1' && sessionOneResumes++ === 0 ? 1 : 0
+      onResumed({ session_id: sessionId, messages: [], isWorking: false, backgroundPending, events: [] })
+      return {} as any
+    })
+    const store = useChatStore()
+    store.sessions = [makeSession('session-1'), makeSession('session-2')]
+
+    await store.switchSession('session-1')
+    expect(store.backgroundPending).toBe(1)
+
+    await store.switchSession('session-2')
+    await store.switchSession('session-1')
+
+    expect(store.backgroundPending).toBe(0)
+    expect(store.isSessionLive('session-1')).toBe(false)
+  })
+
   it('does not show a background session compression indicator in the active session', async () => {
     const store = useChatStore()
     store.sessions = [makeSession('session-1'), makeSession('session-2')]

--- a/tests/client/chat-store-compression-state.test.ts
+++ b/tests/client/chat-store-compression-state.test.ts
@@ -95,6 +95,31 @@ describe('chat store compression state', () => {
     })
   })
 
+  it('restores and clears a per-session background delegation count independently of foreground streaming', async () => {
+    chatApi.resumeSession.mockImplementationOnce((sessionId: string, onResumed: (data: any) => void) => {
+      onResumed({ session_id: sessionId, messages: [], isWorking: false, backgroundPending: 2, events: [] })
+      return {} as any
+    })
+    const store = useChatStore()
+    store.sessions = [makeSession('session-1'), makeSession('session-2')]
+
+    await store.switchSession('session-1')
+    expect(store.backgroundPending).toBe(2)
+    expect(store.isRunActive).toBe(false)
+    expect(store.isSessionLive('session-1')).toBe(true)
+
+    const sessionHandlers = chatApi.registerSessionHandlers.mock.calls.find(call => call[0] === 'session-1')?.[1]
+    sessionHandlers.onRunCompleted({
+      event: 'run.completed',
+      session_id: 'session-1',
+      autonomous: true,
+      background_pending: 0,
+    })
+
+    expect(store.backgroundPending).toBe(0)
+    expect(store.isSessionLive('session-1')).toBe(false)
+  })
+
   it('does not show a background session compression indicator in the active session', async () => {
     const store = useChatStore()
     store.sessions = [makeSession('session-1'), makeSession('session-2')]

--- a/tests/client/session-list-item.test.ts
+++ b/tests/client/session-list-item.test.ts
@@ -59,6 +59,24 @@ describe('SessionListItem', () => {
     expect(source).not.toMatch(/\.session-item-agent-logo\s*\{[^}]*background:/s)
   })
 
+  it('renders a visible background delegation count', () => {
+    const wrapper = mount(SessionListItem, {
+      props: {
+        session,
+        active: false,
+        pinned: false,
+        canDelete: true,
+        backgroundPending: 2,
+        to: '/session/s1',
+      },
+      global: {
+        stubs: { ProfileAvatar: true },
+      },
+    })
+
+    expect(wrapper.get('.session-item-background-count').text()).toBe('2')
+  })
+
   it('renders normal mode as a link to the session route', () => {
     const wrapper = mount(SessionListItem, {
       props: {


### PR DESCRIPTION
## Summary
- persist the server-reported `background_pending` count per session across resume and event updates
- show a calm active-chat status after foreground completion and a count badge in every session list
- add regression coverage for resume, terminal clearing, and the session-list indicator

## Validation
- `node_modules/.bin/vitest run tests/client/chat-store-compression-state.test.ts tests/client/i18n-coverage.test.ts`
- `node_modules/.bin/vue-tsc -b`
- `npm run build`

Closes #2625