### PR TITLE
fix(gateway): coalesce overlapping managed starts

### DIFF
--- a/packages/server/src/services/hermes/gateway-runner.ts
+++ b/packages/server/src/services/hermes/gateway-runner.ts
@@ -234,6 +234,10 @@ function startGatewayRunManagedInternal(
   // unexpected exit. Without this, `/restart` (stop -> start) would race
   // against the respawn timer and end up with two gateways on the same port.
   clearRespawnTimer(state, profileDir)
+  if (state.current) {
+    logger.info('[gateway-runner] reusing active managed gateway profileDir=%s pid=%s', profileDir, state.current.pid)
+    return { pid: state.current.pid, reused: true }
+  }
   if (!opts.preserveRespawnAttempts) {
     state.respawnAttempts = 0
   }

--- a/tests/server/gateway-respawn.test.ts
+++ b/tests/server/gateway-respawn.test.ts
@@ -63,6 +63,20 @@ describe('gateway-runner supervision', () => {
     })
   })
 
+  it('reuses the active managed gateway when restart signals overlap for one profile', async () => {
+    vi.resetModules()
+    const { startGatewayRunManaged } = await import(
+      '../../packages/server/src/services/hermes/gateway-runner'
+    )
+
+    const first = startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/overlapping-restart' })
+    const second = startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/overlapping-restart' })
+
+    expect(first).toEqual({ pid: 10000, reused: false })
+    expect(second).toEqual({ pid: 10000, reused: true })
+    expect(fakeChildren).toHaveLength(1)
+  })
+
   it('respawns the gateway when the spawned child dies unexpectedly', async () => {
     vi.useFakeTimers()
     vi.resetModules()


### PR DESCRIPTION
## Summary
- coalesce overlapping managed gateway starts per profile by reusing the active supervised child
- add a regression test proving duplicate restart signals create exactly one child process

Closes #2596

## Validation
- `./node_modules/.bin/vitest run tests/server/gateway-respawn.test.ts`
- `npm run harness:check`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run build`

`npm run test:coverage` was also run: 4,173 tests passed and 67 unrelated failures were observed, predominantly assertions hard-coded to port 8648 while this worker environment supplies 6060, plus pre-existing fixture/environment failures. The new focused gateway suite passes.
