### PR TITLE
fix(group-chat): persist drafts by room

### DIFF
--- a/docs/chat-chain-changes/2026-08-20-issue-2640-group-chat-room-drafts.md
+++ b/docs/chat-chain-changes/2026-08-20-issue-2640-group-chat-room-drafts.md
@@ -1,0 +1,8 @@
+---
+date: 2026-08-20
+pr: pending
+feature: Group Chat room drafts
+impact: Group Chat now restores per-room text and structured mentions locally, retaining them on failed sends and clearing them only after successful delivery.
+---
+
+Attachments and message references remain transient and are not restored from browser storage.

--- a/docs/chat-chain-changes/2026-08-20-issue-2640-group-chat-room-drafts.md
+++ b/docs/chat-chain-changes/2026-08-20-issue-2640-group-chat-room-drafts.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-20
-pr: pending
+pr: 2643
 feature: Group Chat room drafts
 impact: Group Chat now restores per-room text and structured mentions locally, retaining them on failed sends and clearing them only after successful delivery.
 ---

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -12,14 +12,22 @@ import type { Attachment } from '@/stores/hermes/chat'
 import { clampChatInputHeight, isMobileChatInputViewport } from '@/utils/chat-input-height'
 import VoiceDialogueControls from '@/components/hermes/chat/VoiceDialogueControls.vue'
 import { normalizeComposerVoiceTranscript, useComposerVoiceInput } from '@/composables/useComposerVoiceInput'
+import {
+    clearGroupChatRoomDraft,
+    loadGroupChatRoomDraft,
+    saveGroupChatRoomDraft,
+    type GroupChatTrackedMention,
+} from './group-chat-room-drafts'
 
 const { t } = useI18n()
 const props = withDefaults(defineProps<{
+    roomId?: string | null
     sendBlocked?: boolean
     allowAttachments?: boolean
     showSettings?: boolean
     allowAllMention?: boolean
 }>(), {
+    roomId: null,
     sendBlocked: false,
     allowAttachments: true,
     showSettings: true,
@@ -34,13 +42,14 @@ const settingsStore = useSettingsStore()
 const { toolTraceVisible, toggleToolTraceVisible } = useToolTraceVisibility()
 
 const inputText = ref('')
-type TrackedMention = GroupChatMention & { start: number; end: number }
-const mentions = ref<TrackedMention[]>([])
+const mentions = ref<GroupChatTrackedMention[]>([])
 const previousInputText = ref('')
 const textareaRef = ref<HTMLTextAreaElement>()
 const dropdownRef = ref<HTMLDivElement>()
 const fileInputRef = ref<HTMLInputElement>()
 const attachments = ref<Attachment[]>([])
+const isSending = ref(false)
+const pendingSendRoomId = ref<string | null>(null)
 const isDragging = ref(false)
 const dragCounter = ref(0)
 const isComposing = ref(false)
@@ -229,6 +238,43 @@ const filteredMentionOptions = computed(() => buildMentionOptions(
 
 const canSend = computed(() => !!inputText.value.trim() || (props.allowAttachments && attachments.value.length > 0))
 
+function resetTransientComposerState() {
+    for (const attachment of attachments.value) URL.revokeObjectURL(attachment.url)
+    attachments.value = []
+    mentionActive.value = false
+    mentionStartIndex.value = -1
+    mentionQuery.value = ''
+}
+
+function restoreRoomDraft(roomId: string | null) {
+    resetTransientComposerState()
+    const draft = roomId ? loadGroupChatRoomDraft(roomId) : null
+    inputText.value = draft?.text || ''
+    mentions.value = draft?.mentions.map(mention => ({ ...mention })) || []
+    previousInputText.value = inputText.value
+    nextTick(() => {
+        autoSizeTextarea()
+    })
+}
+
+watch(
+    () => props.roomId,
+    roomId => restoreRoomDraft(roomId),
+    { immediate: true },
+)
+
+watch(
+    [inputText, mentions],
+    () => {
+        if (!props.roomId) return
+        saveGroupChatRoomDraft(props.roomId, {
+            text: inputText.value,
+            mentions: mentions.value,
+        })
+    },
+    { deep: true, flush: 'sync' },
+)
+
 // ─── Scroll active item into view ──────────────────────
 
 function scrollToActive() {
@@ -311,6 +357,7 @@ function updateMentionState() {
 }
 
 function selectMention(option: MentionOption) {
+    if (isSending.value) return
     const el = textareaRef.value
     if (!el || mentionStartIndex.value === -1) return
 
@@ -329,6 +376,7 @@ function selectMention(option: MentionOption) {
 }
 
 function insertMention(name: string, participantId?: string) {
+    if (isSending.value) return
     const mentionName = String(name || '').trim()
     if (!mentionName) return
 
@@ -401,6 +449,7 @@ function replaceInputRange(start: number, end: number, replacement: string, ment
 }
 
 function insertVoiceTranscriptIntoInput(text: string) {
+    if (isSending.value) return
     const transcript = normalizeComposerVoiceTranscript(text)
     if (!transcript) return
     const el = textareaRef.value
@@ -428,6 +477,7 @@ const voiceInput = useComposerVoiceInput({
 })
 
 function insertStructuredMention(mention: GroupChatMention) {
+    if (isSending.value) return
     const normalized = normalizeMention(mention)
     if (!normalized) return
     if (mentions.value.some(candidate =>
@@ -496,6 +546,7 @@ function handleKeydown(e: KeyboardEvent) {
 }
 
 function handleSend() {
+    if (isSending.value) return
     const content = inputText.value.trim()
     if (!content && attachments.value.length === 0) return
     if (props.sendBlocked) {
@@ -504,13 +555,24 @@ function handleSend() {
     }
 
     const structuredMentions = mentions.value.map(({ start: _start, end: _end, ...mention }) => mention)
+    isSending.value = true
+    pendingSendRoomId.value = props.roomId
     emit('send', content, attachments.value.length > 0 ? attachments.value : undefined, structuredMentions.length ? structuredMentions : undefined)
+}
+
+function completeSend(success: boolean) {
+    if (!isSending.value) return
+    const submittedRoomId = pendingSendRoomId.value
+    isSending.value = false
+    pendingSendRoomId.value = null
+    if (!success) return
+
+    if (submittedRoomId) clearGroupChatRoomDraft(submittedRoomId)
+    if (props.roomId !== submittedRoomId) return
     inputText.value = ''
     mentions.value = []
     previousInputText.value = ''
-    attachments.value = []
-    mentionActive.value = false
-    // 发送后重置到自定义高度（不清除拖拽状态）
+    resetTransientComposerState()
 }
 
 function handleInput(e: Event) {
@@ -565,7 +627,7 @@ function handleCompositionEnd() {
 }
 
 function addFile(file: File) {
-    if (!props.allowAttachments) return
+    if (isSending.value || !props.allowAttachments) return
     if (attachments.value.find(a => a.name === file.name)) return
     const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
     attachments.value.push({
@@ -633,9 +695,10 @@ function handleDrop(e: DragEvent) {
     addFiles(Array.from(e.dataTransfer?.files || []))
 }
 
-defineExpose({ addFiles, insertMention, handleSend })
+defineExpose({ addFiles, insertMention, handleSend, completeSend })
 
 function removeAttachment(id: string) {
+    if (isSending.value) return
     const idx = attachments.value.findIndex(a => a.id === id)
     if (idx !== -1) {
         URL.revokeObjectURL(attachments.value[idx].url)
@@ -701,6 +764,7 @@ function isImage(type: string): boolean {
                 :style="textareaHeight ? { height: textareaHeight + 'px' } : {}"
                 :placeholder="t('groupChat.inputPlaceholder')"
                 rows="1"
+                :readonly="isSending"
                 @keydown="handleKeydown"
                 @compositionstart="handleCompositionStart"
                 @compositionend="handleCompositionEnd"
@@ -758,7 +822,7 @@ function isImage(type: string): boolean {
                         type="primary"
                         circle
                         class="send-button"
-                        :disabled="!canSend"
+                        :disabled="!canSend || isSending"
                         :aria-label="t('chat.send')"
                         @click="handleSend"
                     >

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -46,6 +46,7 @@ import {
 import { generateGroupChatInviteCode } from '@/utils/group-chat-invite-code'
 import { buildRemoteGroupChatRooms, type RemoteGroupChatRoom } from '@/utils/group-chat-remote-rooms'
 import { handoffErrorTranslationKey } from './handoff-presentation'
+import { clearGroupChatRoomDraft } from './group-chat-room-drafts'
 
 const FilesPanel = defineAsyncComponent(async () => (await import('@/components/hermes/chat/FilesPanel.vue')).default)
 const FilePreview = defineAsyncComponent(async () => (await import('@/components/hermes/files/FilePreview.vue')).default)
@@ -160,6 +161,7 @@ const isUpdatingRemoteRoom = ref(false)
 const groupChatInputRef = ref<(InstanceType<typeof GroupChatInput> & {
     addFiles?: (files: File[]) => void
     insertMention?: (name: string, participantId?: string) => void
+    completeSend?: (success: boolean) => void
 }) | null>(null)
 const summarySettingsSectionRef = ref<HTMLElement | null>(null)
 const chatDropCounter = ref(0)
@@ -1095,9 +1097,13 @@ async function handleSelectRoom(roomId: string) {
 }
 
 async function handleSendMessage(content: string, attachments?: Attachment[], mentions?: GroupChatMention[]) {
+    const submittedRoomId = store.currentRoomId
     try {
         await store.sendMessage(content, attachments, mentions)
+        if (submittedRoomId) clearGroupChatRoomDraft(submittedRoomId)
+        groupChatInputRef.value?.completeSend?.(true)
     } catch (err: any) {
+        groupChatInputRef.value?.completeSend?.(false)
         message.error(err.message)
     }
 }
@@ -2259,6 +2265,7 @@ function handleClarifyKeydown(event: KeyboardEvent) {
                     </div>
                     <GroupChatInput
                         ref="groupChatInputRef"
+                        :room-id="store.currentRoomId"
                         :send-blocked="currentRoomNeedsSummaryConfiguration"
                         :allow-attachments="true"
                         :show-settings="!props.standalone"

--- a/packages/client/src/components/hermes/group-chat/group-chat-room-drafts.ts
+++ b/packages/client/src/components/hermes/group-chat/group-chat-room-drafts.ts
@@ -1,0 +1,140 @@
+import type { GroupChatMention } from '@/api/hermes/group-chat'
+
+export const GROUP_CHAT_ROOM_DRAFT_STORAGE_KEY = 'hermes_group_chat_room_drafts_v1'
+export const GROUP_CHAT_ROOM_DRAFT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
+
+export type GroupChatTrackedMention = GroupChatMention & {
+    start: number
+    end: number
+}
+
+export interface GroupChatRoomDraft {
+    text: string
+    mentions: GroupChatTrackedMention[]
+}
+
+interface StoredGroupChatRoomDraft extends GroupChatRoomDraft {
+    updatedAt: number
+}
+
+interface StoredGroupChatRoomDrafts {
+    version: 1
+    rooms: Record<string, StoredGroupChatRoomDraft>
+}
+
+function emptyDrafts(): StoredGroupChatRoomDrafts {
+    return { version: 1, rooms: {} }
+}
+
+function safeRemoveStorage() {
+    try {
+        localStorage.removeItem(GROUP_CHAT_ROOM_DRAFT_STORAGE_KEY)
+    } catch {
+        // Browser storage is optional; the composer must remain usable without it.
+    }
+}
+
+function isValidMention(text: string, value: unknown): value is GroupChatTrackedMention {
+    if (!value || typeof value !== 'object') return false
+    const mention = value as Partial<GroupChatTrackedMention>
+    if (mention.type !== 'agent' && mention.type !== 'all') return false
+    if (typeof mention.displayName !== 'string' || !mention.displayName) return false
+    if (mention.type === 'agent' && (typeof mention.participantId !== 'string' || !mention.participantId)) return false
+    if (!Number.isInteger(mention.start) || !Number.isInteger(mention.end)) return false
+    const start = Number(mention.start)
+    const end = Number(mention.end)
+    if (start < 0 || end <= start || end > text.length) return false
+    return text.slice(start, end) === `@${mention.displayName}`
+}
+
+function sanitizeDraft(value: unknown, now: number): StoredGroupChatRoomDraft | null {
+    if (!value || typeof value !== 'object') return null
+    const candidate = value as Partial<StoredGroupChatRoomDraft>
+    if (typeof candidate.text !== 'string' || !Number.isFinite(candidate.updatedAt)) return null
+    if (now - Number(candidate.updatedAt) > GROUP_CHAT_ROOM_DRAFT_MAX_AGE_MS) return null
+    const rawMentions = Array.isArray(candidate.mentions) ? candidate.mentions : []
+    return {
+        text: candidate.text,
+        mentions: rawMentions.filter(mention => isValidMention(candidate.text as string, mention)),
+        updatedAt: Number(candidate.updatedAt),
+    }
+}
+
+function readDrafts(now = Date.now()): StoredGroupChatRoomDrafts {
+    let raw: string | null
+    try {
+        raw = localStorage.getItem(GROUP_CHAT_ROOM_DRAFT_STORAGE_KEY)
+    } catch {
+        return emptyDrafts()
+    }
+    if (!raw) return emptyDrafts()
+
+    try {
+        const parsed = JSON.parse(raw) as Partial<StoredGroupChatRoomDrafts>
+        if (parsed.version !== 1 || !parsed.rooms || typeof parsed.rooms !== 'object' || Array.isArray(parsed.rooms)) {
+            safeRemoveStorage()
+            return emptyDrafts()
+        }
+        const rooms: Record<string, StoredGroupChatRoomDraft> = {}
+        for (const [roomId, value] of Object.entries(parsed.rooms)) {
+            const draft = sanitizeDraft(value, now)
+            if (roomId && draft && (draft.text || draft.mentions.length)) rooms[roomId] = draft
+        }
+        const result: StoredGroupChatRoomDrafts = { version: 1, rooms }
+        if (Object.keys(rooms).length === 0) {
+            safeRemoveStorage()
+        } else if (JSON.stringify(result) !== raw) {
+            writeDrafts(result)
+        }
+        return result
+    } catch {
+        safeRemoveStorage()
+        return emptyDrafts()
+    }
+}
+
+function writeDrafts(drafts: StoredGroupChatRoomDrafts) {
+    try {
+        if (Object.keys(drafts.rooms).length === 0) {
+            localStorage.removeItem(GROUP_CHAT_ROOM_DRAFT_STORAGE_KEY)
+        } else {
+            localStorage.setItem(GROUP_CHAT_ROOM_DRAFT_STORAGE_KEY, JSON.stringify(drafts))
+        }
+    } catch {
+        // Quota/security errors must not block composing or sending.
+    }
+}
+
+export function loadGroupChatRoomDraft(roomId: string): GroupChatRoomDraft | null {
+    if (!roomId) return null
+    const draft = readDrafts().rooms[roomId]
+    if (!draft) return null
+    return {
+        text: draft.text,
+        mentions: draft.mentions.map(mention => ({ ...mention })),
+    }
+}
+
+export function saveGroupChatRoomDraft(roomId: string, draft: GroupChatRoomDraft) {
+    if (!roomId) return
+    const drafts = readDrafts()
+    const mentions = draft.mentions.filter(mention => isValidMention(draft.text, mention))
+    if (!draft.text && mentions.length === 0) {
+        delete drafts.rooms[roomId]
+    } else {
+        drafts.rooms[roomId] = {
+            text: draft.text,
+            mentions: mentions.map(mention => ({ ...mention })),
+            updatedAt: Date.now(),
+        }
+    }
+    writeDrafts(drafts)
+}
+
+export function clearGroupChatRoomDraft(roomId: string) {
+    if (!roomId) return
+    const drafts = readDrafts()
+    if (!(roomId in drafts.rooms)) return
+    delete drafts.rooms[roomId]
+    writeDrafts(drafts)
+}

--- a/tests/client/group-chat-input-mentions.test.ts
+++ b/tests/client/group-chat-input-mentions.test.ts
@@ -191,6 +191,7 @@ describe('GroupChatInput mentions', () => {
       undefined,
       [{ type: 'agent', participantId: 'agent-1', displayName: 'Worker' }],
     )
+    ;(wrapper.vm as any).completeSend(true)
     store.setMessageReference('room-1', {
       id: 'message-2',
       role: 'assistant',
@@ -376,5 +377,105 @@ describe('GroupChatInput mentions', () => {
     expect(onSendBlocked).toHaveBeenCalledOnce()
     expect(wrapper.emitted('send')).toBeUndefined()
     expect((textarea.element as HTMLTextAreaElement).value).toBe('@Worker keep this draft')
+  })
+
+  it('restores isolated room drafts with routable structured mentions', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    const settingsStore = useSettingsStore()
+    settingsStore.display = {}
+    const store = useGroupChatStore()
+    store.agents = [{ id: 'agent-1', agentId: 'agent-1', profile: 'worker', name: 'Worker', roomId: 'room-a', description: '', invited: 1 }]
+    store.emitTyping = vi.fn()
+    const onSend = vi.fn()
+    const wrapper = mount(GroupChatInput, {
+      props: { roomId: 'room-a', onSend },
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+
+    ;(wrapper.vm as any).insertMention('Worker', 'agent-1')
+    await wrapper.get('textarea').setValue('@Worker inspect room A')
+    await nextTick()
+    await wrapper.setProps({ roomId: 'room-b' })
+    expect((wrapper.get('textarea').element as HTMLTextAreaElement).value).toBe('')
+    await wrapper.get('textarea').setValue('room B draft')
+    await wrapper.setProps({ roomId: 'room-a' })
+    expect((wrapper.get('textarea').element as HTMLTextAreaElement).value).toBe('@Worker inspect room A')
+
+    wrapper.unmount()
+    const remounted = mount(GroupChatInput, {
+      props: { roomId: 'room-a', onSend },
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+    await nextTick()
+    ;(remounted.vm as any).handleSend()
+
+    expect(onSend).toHaveBeenCalledWith(
+      '@Worker inspect room A',
+      undefined,
+      [{ type: 'agent', participantId: 'agent-1', displayName: 'Worker' }],
+    )
+  })
+
+  it('clears only after async send success and retains the draft after failure', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    const settingsStore = useSettingsStore()
+    settingsStore.display = {}
+    const wrapper = mount(GroupChatInput, {
+      props: { roomId: 'room-a' },
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+    const textarea = wrapper.get('textarea')
+
+    await textarea.setValue('keep until acknowledged')
+    ;(wrapper.vm as any).handleSend()
+    expect((textarea.element as HTMLTextAreaElement).value).toBe('keep until acknowledged')
+
+    ;(wrapper.vm as any).completeSend(false)
+    expect((textarea.element as HTMLTextAreaElement).value).toBe('keep until acknowledged')
+
+    ;(wrapper.vm as any).handleSend()
+    ;(wrapper.vm as any).completeSend(true)
+    await nextTick()
+    expect((textarea.element as HTMLTextAreaElement).value).toBe('')
+
+    wrapper.unmount()
+    const remounted = mount(GroupChatInput, {
+      props: { roomId: 'room-a' },
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+    await nextTick()
+    expect((remounted.get('textarea').element as HTMLTextAreaElement).value).toBe('')
+  })
+
+  it('does not restore local attachments or reply references after remount', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    const settingsStore = useSettingsStore()
+    settingsStore.display = {}
+    const store = useGroupChatStore()
+    store.currentRoomId = 'room-a'
+    const wrapper = mount(GroupChatInput, {
+      props: { roomId: 'room-a' },
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+    ;(wrapper.vm as any).addFiles([new File(['draft'], 'draft.txt', { type: 'text/plain' })])
+    store.setMessageReference('room-a', {
+      id: 'message-1',
+      role: 'assistant',
+      content: 'Do not persist me',
+      sender: 'Worker',
+    })
+    await wrapper.get('textarea').setValue('persist only text')
+    wrapper.unmount()
+    store.clearMessageReference('room-a')
+
+    const remounted = mount(GroupChatInput, {
+      props: { roomId: 'room-a' },
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+    await nextTick()
+
+    expect((remounted.get('textarea').element as HTMLTextAreaElement).value).toBe('persist only text')
+    expect(remounted.find('.attachment-previews').exists()).toBe(false)
+    expect(remounted.find('.message-reference-preview').exists()).toBe(false)
   })
 })

--- a/tests/client/group-chat-panel-workspace-source.test.ts
+++ b/tests/client/group-chat-panel-workspace-source.test.ts
@@ -35,6 +35,18 @@ describe('GroupChatPanel workspace save handling', () => {
     expect(source).not.toContain('workspaceValue.value.trim()')
   })
 
+  it('acknowledges the composer only after the asynchronous group send settles', () => {
+    const source = readFileSync('packages/client/src/components/hermes/group-chat/GroupChatPanel.vue', 'utf8')
+    const handler = source.slice(
+      source.indexOf('async function handleSendMessage('),
+      source.indexOf('async function handleCancelQueuedExecution('),
+    )
+
+    expect(handler).toContain('const submittedRoomId = store.currentRoomId')
+    expect(handler).toMatch(/await store\.sendMessage[\s\S]*clearGroupChatRoomDraft\(submittedRoomId\)[\s\S]*completeSend\?\.\(true\)/)
+    expect(handler).toMatch(/catch[\s\S]*completeSend\?\.\(false\)/)
+  })
+
   it('gates room management controls while allowing an Agent owner to handle a directed approval', () => {
     const source = readFileSync('packages/client/src/components/hermes/group-chat/GroupChatPanel.vue', 'utf8')
     const visibleApproval = source.slice(

--- a/tests/client/group-chat-room-drafts.test.ts
+++ b/tests/client/group-chat-room-drafts.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  GROUP_CHAT_ROOM_DRAFT_MAX_AGE_MS,
+  GROUP_CHAT_ROOM_DRAFT_STORAGE_KEY,
+  clearGroupChatRoomDraft,
+  loadGroupChatRoomDraft,
+  saveGroupChatRoomDraft,
+} from '@/components/hermes/group-chat/group-chat-room-drafts'
+
+describe('group chat room drafts', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('isolates text and structured mention positions by room', () => {
+    saveGroupChatRoomDraft('room-a', {
+      text: '@Worker inspect this',
+      mentions: [{
+        type: 'agent',
+        participantId: 'agent-1',
+        displayName: 'Worker',
+        start: 0,
+        end: 7,
+      }],
+    })
+    saveGroupChatRoomDraft('room-b', {
+      text: '@all status',
+      mentions: [{
+        type: 'all',
+        displayName: 'all',
+        start: 0,
+        end: 4,
+      }],
+    })
+
+    expect(loadGroupChatRoomDraft('room-a')).toEqual({
+      text: '@Worker inspect this',
+      mentions: [{
+        type: 'agent',
+        participantId: 'agent-1',
+        displayName: 'Worker',
+        start: 0,
+        end: 7,
+      }],
+    })
+    expect(loadGroupChatRoomDraft('room-b')).toEqual({
+      text: '@all status',
+      mentions: [{
+        type: 'all',
+        displayName: 'all',
+        start: 0,
+        end: 4,
+      }],
+    })
+
+    clearGroupChatRoomDraft('room-a')
+    expect(loadGroupChatRoomDraft('room-a')).toBeNull()
+    expect(loadGroupChatRoomDraft('room-b')?.text).toBe('@all status')
+  })
+
+  it('drops corrupt and expired data without throwing', () => {
+    localStorage.setItem(GROUP_CHAT_ROOM_DRAFT_STORAGE_KEY, '{broken')
+    expect(loadGroupChatRoomDraft('room-a')).toBeNull()
+    expect(localStorage.getItem(GROUP_CHAT_ROOM_DRAFT_STORAGE_KEY)).toBeNull()
+
+    localStorage.setItem(GROUP_CHAT_ROOM_DRAFT_STORAGE_KEY, JSON.stringify({
+      version: 1,
+      rooms: {
+        'room-a': {
+          text: 'stale',
+          mentions: [],
+          updatedAt: Date.now() - GROUP_CHAT_ROOM_DRAFT_MAX_AGE_MS - 1,
+          attachments: [{ name: 'must-not-restore.txt' }],
+          reply: { id: 'message-1' },
+        },
+      },
+    }))
+
+    expect(loadGroupChatRoomDraft('room-a')).toBeNull()
+    expect(localStorage.getItem(GROUP_CHAT_ROOM_DRAFT_STORAGE_KEY)).toBeNull()
+  })
+
+  it('ignores invalid mention metadata while preserving safe text', () => {
+    localStorage.setItem(GROUP_CHAT_ROOM_DRAFT_STORAGE_KEY, JSON.stringify({
+      version: 1,
+      rooms: {
+        'room-a': {
+          text: '@Worker inspect',
+          mentions: [
+            { type: 'agent', participantId: '', displayName: 'Worker', start: 0, end: 7 },
+            { type: 'agent', participantId: 'agent-1', displayName: 'Wrong', start: 0, end: 6 },
+          ],
+          updatedAt: Date.now(),
+        },
+      },
+    }))
+
+    expect(loadGroupChatRoomDraft('room-a')).toEqual({
+      text: '@Worker inspect',
+      mentions: [],
+    })
+  })
+})

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -4,7 +4,7 @@ import { authenticate, TEST_MODEL_GROUP } from './fixtures'
 type DesktopPlatform = 'darwin' | 'win32'
 
 const baseRooms = [
-  { id: 'room-alpha', name: 'Alpha Room', inviteCode: 'ALPHA1', canManage: true, workspace: '/tmp/alpha', triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10, totalTokens: 123, allowGuestAgents: 1, maxGuestAgentsPerMember: 1, allowRemoteWorkspaceAccess: 0, agentHandoffEnabled: 1, agentHandoffMaxDepth: 4, agentHandoffUnlimited: 0, createdAt: 1_790_000_000, lastActiveAt: 1_790_000_001 },
+  { id: 'room-alpha', name: 'Alpha Room', inviteCode: 'ALPHA1', canManage: true, workspace: '/tmp/alpha', triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10, totalTokens: 123, summaryProfile: 'default', summaryProvider: 'test-provider', summaryModel: 'test-model', summaryApiMode: 'chat_completions', summaryEveryTurns: 20, allowGuestAgents: 1, maxGuestAgentsPerMember: 1, allowRemoteWorkspaceAccess: 0, agentHandoffEnabled: 1, agentHandoffMaxDepth: 4, agentHandoffUnlimited: 0, createdAt: 1_790_000_000, lastActiveAt: 1_790_000_001 },
   { id: 'room-beta', name: 'Beta Room', inviteCode: 'BETA22', canManage: true, workspace: '/tmp/beta', triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10, totalTokens: 456, allowGuestAgents: 1, maxGuestAgentsPerMember: 1, allowRemoteWorkspaceAccess: 0, createdAt: 1_790_000_000, lastActiveAt: 1_790_000_100 },
   { id: 'room-readonly', name: 'Read Only Room', inviteCode: null, canManage: false, workspace: '/tmp/readonly', triggerTokens: 100000, maxHistoryTokens: 32000, tailMessageCount: 10, totalTokens: 0, createdAt: 1_789_999_999, lastActiveAt: 1_789_999_999 },
 ]
@@ -355,7 +355,9 @@ function makeSocket(url, options) {
         setTimeout(() => ack({ activities: [] }), 0)
       }
       if (event === 'message' && typeof ack === 'function') {
-        setTimeout(() => ack({ id: payload && payload.id }), 0)
+        const error = state.nextMessageError
+        state.nextMessageError = ''
+        setTimeout(() => ack(error ? { error } : { id: payload && payload.id }), 0)
       }
       if (event === 'cancel_execution_queue_item' && typeof ack === 'function') {
         const roomId = payload && payload.roomId
@@ -1263,6 +1265,84 @@ test.describe('group chat room deep links', () => {
     expect(await page.evaluate(() => (window as any).__PW_GROUP_SOCKET__.emitted.filter(
       (item: any) => item.event === 'message',
     ).length)).toBe(0)
+  })
+
+  test('persists isolated room drafts and structured mention identity across navigation and reload', async ({ page }) => {
+    await setup(page, '/#/hermes/group-chat/room/room-alpha')
+    await expect(page.locator('.room-title-text', { hasText: 'Alpha Room' })).toBeVisible()
+    await connectGroupSocket(page)
+    await page.waitForFunction(() => (window as any).__PW_GROUP_SOCKET__?.emitted.some(
+      (item: any) => item.event === 'join' && item.payload?.roomId === 'room-alpha',
+    ))
+
+    const textarea = page.locator('.chat-input-area textarea')
+    await textarea.fill('@')
+    await page.locator('.mention-dropdown-item', { hasText: '@Worker' }).click()
+    await textarea.pressSequentially('inspect alpha')
+
+    await page.locator('.room-item', { hasText: 'Beta Room' }).click()
+    await expect(page).toHaveURL(/#\/hermes\/group-chat\/room\/room-beta$/)
+    await expect(textarea).toHaveValue('')
+    await textarea.fill('beta draft')
+
+    await page.locator('.room-item', { hasText: 'Alpha Room' }).click()
+    await expect(textarea).toHaveValue('@Worker inspect alpha')
+    await page.reload()
+    await expect(page.locator('.room-title-text', { hasText: 'Alpha Room' })).toBeVisible()
+    await connectGroupSocket(page)
+    await page.waitForFunction(() => (window as any).__PW_GROUP_SOCKET__?.emitted.some(
+      (item: any) => item.event === 'join' && item.payload?.roomId === 'room-alpha',
+    ))
+    await expect(textarea).toHaveValue('@Worker inspect alpha')
+    expect(await page.evaluate(() => {
+      const stored = JSON.parse(window.localStorage.getItem('hermes_group_chat_room_drafts_v1') || '{"rooms":{}}')
+      return {
+        alpha: stored.rooms['room-alpha'],
+        beta: stored.rooms['room-beta']?.text || '',
+      }
+    })).toMatchObject({
+      alpha: {
+        text: '@Worker inspect alpha',
+        mentions: [{ type: 'agent', participantId: 'agent-1', displayName: 'Worker', start: 0, end: 7 }],
+      },
+      beta: 'beta draft',
+    })
+  })
+
+  test('retains a routable mention after send failure and clears it after success', async ({ page }) => {
+    await setup(page, '/#/hermes/group-chat/room/room-alpha')
+    await expect(page.locator('.room-title-text', { hasText: 'Alpha Room' })).toBeVisible()
+    await connectGroupSocket(page)
+    await page.waitForFunction(() => (window as any).__PW_GROUP_SOCKET__?.emitted.some(
+      (item: any) => item.event === 'join' && item.payload?.roomId === 'room-alpha',
+    ))
+    const textarea = page.locator('.chat-input-area textarea')
+    await textarea.fill('@')
+    await page.locator('.mention-dropdown-item', { hasText: '@Worker' }).click()
+    await textarea.pressSequentially('inspect alpha')
+    await page.evaluate(() => {
+      ;(window as any).__PW_GROUP_SOCKET__.nextMessageError = 'send failed'
+    })
+    await page.locator('.send-button').click()
+    await expect(textarea).toHaveValue('@Worker inspect alpha')
+    await expect.poll(() => page.evaluate(() => (window as any).__PW_GROUP_SOCKET__.emitted.filter(
+      (item: any) => item.event === 'message',
+    ).length)).toBe(1)
+    await expect(page.locator('.send-button')).toBeEnabled()
+    expect(await page.evaluate(() => {
+      const sent = (window as any).__PW_GROUP_SOCKET__.emitted.filter((item: any) => item.event === 'message')
+      return sent.at(-1)?.payload?.mentions
+    })).toEqual([{ type: 'agent', participantId: 'agent-1', displayName: 'Worker' }])
+
+    await page.locator('.send-button').click()
+    await expect(textarea).toHaveValue('')
+    expect(await page.evaluate(() => {
+      const stored = JSON.parse(window.localStorage.getItem('hermes_group_chat_room_drafts_v1') || '{"rooms":{}}')
+      return {
+        alpha: stored.rooms['room-alpha'] || null,
+        beta: stored.rooms['room-beta']?.text || '',
+      }
+    })).toEqual({ alpha: null, beta: '' })
   })
 
   test('unknown route room id falls back to the first available room', async ({ page }) => {


### PR DESCRIPTION
## Summary
- persist Group Chat composer text and structured Mention identity/positions per Room in browser storage
- restore drafts across Room navigation and reload while dropping expired/corrupt data and never restoring attachments or reply references
- keep drafts through blocked or failed sends, and clear them only after the asynchronous group send succeeds
- add focused Vitest and Playwright coverage for isolation, restoration, routing, failure retention, success clearing, and storage degradation

Closes #2640

## Validation
- `npm run test -- tests/client/group-chat-room-drafts.test.ts tests/client/group-chat-input-mentions.test.ts tests/client/group-chat-panel-workspace-source.test.ts` (44 passed)
- `npx vue-tsc --noEmit -p tsconfig.app.json`
- `npx playwright test tests/e2e/group-chat-room-deeplink.spec.ts --grep "room drafts|send failure" --workers=1` (2 passed)
- `npm run harness:check`
- `npm run build`
- `npm run test:e2e` (124 passed, 2 unrelated load-sensitive failures); `npx playwright test --last-failed --workers=1` (2 passed)
- `NODE_ENV=test npm run test:coverage` (4253 passed, 6 skipped, 5 unrelated host/runtime failures in existing server tests: Agent Bridge Python resolution, Hermes plugin discovery, Windows run-manager DB setup, and Kanban attachment path fixture)
