### PR TITLE
fix(chat): keep New Chat selected after stale session load

### DIFF
--- a/docs/chat-chain-changes/2026-08-21-preserve-new-chat-selection.md
+++ b/docs/chat-chain-changes/2026-08-21-preserve-new-chat-selection.md
@@ -5,5 +5,6 @@ feature: Preserve explicit New Chat selection
 impact: A stale session-list load can refresh metadata without replacing or dropping a newer local-only chat.
 ---
 
-Session-list reconciliation now keeps local-only chats until their first run is
-persisted and yields active-session ownership to any newer user selection.
+Session-list reconciliation now keeps matching-profile local-only chats until
+their first run is persisted, rebinds refreshed active-session state, and yields
+active-session ownership to any newer user selection.

--- a/docs/chat-chain-changes/2026-08-21-preserve-new-chat-selection.md
+++ b/docs/chat-chain-changes/2026-08-21-preserve-new-chat-selection.md
@@ -1,0 +1,9 @@
+---
+date: 2026-08-21
+pr: 2650
+feature: Preserve explicit New Chat selection
+impact: A stale session-list load can refresh metadata without replacing or dropping a newer local-only chat.
+---
+
+Session-list reconciliation now keeps local-only chats until their first run is
+persisted and yields active-session ownership to any newer user selection.

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1321,6 +1321,7 @@ export const useChatStore = defineStore('chat', () => {
   const isRunActive = computed(() => isStreaming.value)
   let loadSessionsRequestSequence = 0
   let switchSessionRequestSequence = 0
+  let activeSelectionSequence = 0
 
   function beginMessageLoad(sessionId: string, requestSequence: number) {
     const next = new Map(messageLoadRequests.value)
@@ -1463,6 +1464,7 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   function clearActiveSession() {
+    activeSelectionSequence++
     const sid = activeSessionId.value
     activeSessionId.value = null
     activeSession.value = null
@@ -1573,6 +1575,7 @@ export const useChatStore = defineStore('chat', () => {
 
   async function loadSessions(profile?: string | null, preferredSessionId?: string | null) {
     const requestSequence = ++loadSessionsRequestSequence
+    const selectionSequence = activeSelectionSequence
     isLoadingSessions.value = true
     try {
       const list = await fetchRuntimeSessions(profile)
@@ -1591,8 +1594,16 @@ export const useChatStore = defineStore('chat', () => {
         if (prev?.contextTokens != null) s.contextTokens = prev.contextTokens
         if (!s.apiMode && prev?.apiMode) s.apiMode = prev.apiMode
       }
-      sessions.value = fresh
+      const localOnlySessions = sessions.value.filter(session =>
+        session.isLocalOnly && !fresh.some(runtimeSession => runtimeSession.id === session.id),
+      )
+      sessions.value = [...localOnlySessions, ...fresh]
       pruneCompletedUnreadSessions(new Set(sessions.value.map(s => s.id)))
+
+      // A session load may have started before the user selected or created a
+      // different chat. Keep the refreshed list, but do not let that stale
+      // continuation take ownership of the active selection.
+      if (selectionSequence !== activeSelectionSequence) return
 
       // Restore route-selected session first (tab-local source of truth),
       // then current in-memory session, then persisted legacy/default choice,
@@ -1806,6 +1817,7 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   async function switchSession(sessionId: string, focusId?: string | null) {
+    activeSelectionSequence++
     const requestSequence = ++switchSessionRequestSequence
     clearThinkingObservationFor(sessionId)
     activeSessionId.value = sessionId

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1581,6 +1581,10 @@ export const useChatStore = defineStore('chat', () => {
       const list = await fetchRuntimeSessions(profile)
       if (requestSequence !== loadSessionsRequestSequence) return
       const fresh = list.map(mapHermesSession)
+      const selectionChanged = selectionSequence !== activeSelectionSequence
+      const explicitlySelectedSession = selectionChanged && activeSessionId.value
+        ? sessions.value.find(session => session.id === activeSessionId.value) || activeSession.value
+        : null
       // Preserve already-loaded messages for sessions that are still present,
       // so we don't blow away the active session's messages on refresh.
       const runtimeByIdBefore = new Map(sessions.value.map(s => [s.id, {
@@ -1594,16 +1598,31 @@ export const useChatStore = defineStore('chat', () => {
         if (prev?.contextTokens != null) s.contextTokens = prev.contextTokens
         if (!s.apiMode && prev?.apiMode) s.apiMode = prev.apiMode
       }
+      const freshIds = new Set(fresh.map(session => session.id))
       const localOnlySessions = sessions.value.filter(session =>
-        session.isLocalOnly && !fresh.some(runtimeSession => runtimeSession.id === session.id),
+        session.isLocalOnly
+        && !freshIds.has(session.id)
+        && (!profile || session.profile === profile),
       )
+      if (
+        explicitlySelectedSession
+        && !freshIds.has(explicitlySelectedSession.id)
+        && !localOnlySessions.some(session => session.id === explicitlySelectedSession.id)
+      ) {
+        localOnlySessions.unshift(explicitlySelectedSession)
+      }
       sessions.value = [...localOnlySessions, ...fresh]
       pruneCompletedUnreadSessions(new Set(sessions.value.map(s => s.id)))
 
       // A session load may have started before the user selected or created a
       // different chat. Keep the refreshed list, but do not let that stale
       // continuation take ownership of the active selection.
-      if (selectionSequence !== activeSelectionSequence) return
+      if (selectionChanged) {
+        activeSession.value = activeSessionId.value
+          ? sessions.value.find(session => session.id === activeSessionId.value) || null
+          : null
+        return
+      }
 
       // Restore route-selected session first (tab-local source of truth),
       // then current in-memory session, then persisted legacy/default choice,

--- a/tests/client/chat-store-session-order.test.ts
+++ b/tests/client/chat-store-session-order.test.ts
@@ -160,4 +160,23 @@ describe('chat session ordering', () => {
     expect(store.activeSessionId).toBe('session-b')
     expect(store.activeSession?.id).toBe('session-b')
   })
+
+  it('does not let an in-flight session load replace a newly created chat', async () => {
+    const pending: Array<(sessions: any[]) => void> = []
+    vi.mocked(fetchSessions).mockImplementation(() => new Promise(resolve => pending.push(resolve)))
+
+    const store = useChatStore()
+    const load = store.loadSessions(null, 'session-a')
+    const newSession = store.newChat()
+
+    expect(store.activeSessionId).toBe(newSession.id)
+
+    pending[0]([makeSession('session-a', { started_at: 1000, last_active: 1000 })])
+    pending[1]([])
+    await load
+
+    expect(store.sessions.map(session => session.id)).toEqual([newSession.id, 'session-a'])
+    expect(store.activeSessionId).toBe(newSession.id)
+    expect(store.activeSession?.id).toBe(newSession.id)
+  })
 })

--- a/tests/client/chat-store-session-order.test.ts
+++ b/tests/client/chat-store-session-order.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { useChatStore } from '@/stores/hermes/chat'
+import { startRunViaSocket } from '@/api/hermes/chat'
 import { archiveSession, fetchSessions } from '@/api/hermes/sessions'
 
 vi.mock('@/api/hermes/sessions', () => ({
@@ -15,7 +16,7 @@ vi.mock('@/api/hermes/sessions', () => ({
 }))
 
 vi.mock('@/api/hermes/chat', () => ({
-  startRunViaSocket: vi.fn(),
+  startRunViaSocket: vi.fn(() => ({ abort: vi.fn() })),
   resumeSession: vi.fn((_sessionId: string, cb: (data: any) => void) => {
     cb({ session_id: _sessionId, isWorking: false, messages: [] })
   }),
@@ -32,6 +33,7 @@ vi.mock('@/api/hermes/chat', () => ({
 
 vi.mock('@/api/client', () => ({
   getActiveProfileName: () => 'default',
+  hasApiKey: () => false,
 }))
 
 vi.mock('@/api/hermes/download', () => ({
@@ -178,5 +180,60 @@ describe('chat session ordering', () => {
     expect(store.sessions.map(session => session.id)).toEqual([newSession.id, 'session-a'])
     expect(store.activeSessionId).toBe(newSession.id)
     expect(store.activeSession?.id).toBe(newSession.id)
+
+    await store.sendMessage('first message')
+    expect(startRunViaSocket).toHaveBeenCalledWith(
+      expect.objectContaining({ session_id: newSession.id }),
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function),
+      undefined,
+      expect.any(Object),
+    )
+  })
+
+  it('does not retain a local-only chat outside the requested profile', async () => {
+    vi.mocked(fetchSessions)
+      .mockResolvedValueOnce([
+        { ...makeSession('research-session', { started_at: 1000 }), profile: 'research' },
+      ] as any)
+      .mockResolvedValueOnce([])
+
+    const store = useChatStore()
+    const localSession = store.newChat({ profile: 'default' })
+
+    await store.loadSessions('research')
+
+    expect(store.sessions.map(session => session.id)).toEqual(['research-session'])
+    expect(store.sessions.some(session => session.id === localSession.id)).toBe(false)
+    expect(store.activeSessionId).toBe('research-session')
+  })
+
+  it('rebinds the active session after a stale list refresh during an explicit switch', async () => {
+    vi.mocked(fetchSessions)
+      .mockResolvedValueOnce([
+        makeSession('session-a', { started_at: 2000 }),
+        makeSession('session-b', { started_at: 1000 }),
+      ] as any)
+      .mockResolvedValueOnce([])
+
+    const store = useChatStore()
+    await store.loadSessions()
+
+    const pending: Array<(sessions: any[]) => void> = []
+    vi.mocked(fetchSessions).mockImplementation(() => new Promise(resolve => pending.push(resolve)))
+
+    const load = store.loadSessions(null, 'session-a')
+    await store.switchSession('session-b')
+
+    pending[0]([
+      makeSession('session-a', { started_at: 2000 }),
+      makeSession('session-b', { started_at: 1000 }),
+    ])
+    pending[1]([])
+    await load
+
+    expect(store.activeSessionId).toBe('session-b')
+    expect(store.activeSession).toBe(store.sessions.find(session => session.id === 'session-b'))
   })
 })


### PR DESCRIPTION
Clicking **New Chat** is an explicit selection, but an older `loadSessions()` call could still finish afterward and take that selection back.

The server does not know about a new chat until its first message is persisted. During that window the delayed list contains the old session but not the new local-only one, so reconciliation replaced the in-memory list and switched to the old route-preferred session. A message sent at the wrong moment could therefore carry the old session id.

## What changed

The chat store now gives every active-session selection a generation. `loadSessions()` records the generation it started under and, after refreshing the list metadata, yields if the user selected or created a different chat in the meantime.

Local-only sessions are also retained while reconciling the server list. That keeps the newly created session object in the store until its first run persists it, instead of leaving `activeSession` pointing at an object that the list has already dropped.

This does not cancel session-list refreshes and does not change the existing route/preferred/stored fallback order when no newer user selection occurred.

Closes #2638

## Regression test

`tests/client/chat-store-session-order.test.ts` defers both runtime session requests, starts a route load for session A, creates local-only session B, and then releases the stale list containing only A.

- Before the fix: B is replaced by A.
- After the fix: B remains active and stays in the session list alongside the refreshed A metadata.

Reverting the store change makes the new assertion fail at the intended `activeSessionId` transition.

## Validation

- `vitest run tests/client/chat-store-session-order.test.ts tests/client/chat-store-compression-state.test.ts tests/client/chat-store-workspace-diff-turn.test.ts` — 44 passed
- `vitest run tests/client tests/server` — 3902 passed, 7 skipped
- `npm run harness:check` — passed
- `npm run build` — passed
- `npm run test:e2e` — 87 passed in the 12-worker pass; 13 load-sensitive failures all passed with `--last-failed --workers=1`
- `playwright test tests/e2e/group-chat-room-deeplink.spec.ts --workers=1` — 26 passed, covering the serial tests not reached after the parallel failure
- `git diff --check` — passed
