### PR TITLE
test: isolate Vitest worker state on Node 24

### DIFF
--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -13,6 +13,8 @@ async function loadAuth(overrides: Partial<FsMocks> & { home?: string } = {}) {
   const mkdir = overrides.mkdir ?? vi.fn()
   const home = overrides.home ?? '/tmp/hermes-home'
 
+  delete process.env.HERMES_WEB_UI_HOME
+  delete process.env.HERMES_WEBUI_STATE_DIR
   vi.resetModules()
   vi.doMock('fs/promises', () => ({ readFile, writeFile, mkdir }))
   vi.doMock('os', () => ({ homedir: () => home }))

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,18 @@
 import { vi } from 'vitest'
 
+const workerId = process.env.VITEST_POOL_ID || process.env.VITEST_WORKER_ID || '0'
+const pathSeparator = process.platform === 'win32' ? '\\' : '/'
+const tempRoot = (
+  process.env.TMPDIR
+  || process.env.TEMP
+  || process.env.TMP
+  || (process.platform === 'win32' ? 'C:\\Windows\\Temp' : '/tmp')
+).replace(/[\\/]+$/, '')
+const workerStateDir = `${tempRoot}${pathSeparator}hermes-studio-vitest-${process.pid}-${workerId}`
+process.env.HERMES_WEB_UI_HOME = workerStateDir
+process.env.HERMES_WEBUI_STATE_DIR = workerStateDir
+process.env.UPLOAD_DIR = `${workerStateDir}${pathSeparator}upload`
+
 // Vite injects this at build time; unit tests need a stable fallback.
 ;(globalThis as any).__APP_VERSION__ = 'test'
 // Client-only setup (window/localStorage only exist in jsdom)

--- a/tests/shared/vitest-worker-isolation.test.ts
+++ b/tests/shared/vitest-worker-isolation.test.ts
@@ -1,0 +1,13 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('Vitest worker state isolation', () => {
+  it('assigns each worker an isolated Web UI state directory', () => {
+    const appHome = process.env.HERMES_WEB_UI_HOME
+
+    expect(appHome).toBeTruthy()
+    expect(process.env.HERMES_WEBUI_STATE_DIR).toBe(appHome)
+    expect(process.env.UPLOAD_DIR).toBe(join(appHome!, 'upload'))
+    expect(appHome).toContain(`hermes-studio-vitest-${process.pid}-`)
+  })
+})


### PR DESCRIPTION
## Summary

- isolate Vitest Web UI state and uploads per worker process/pool
- keep auth fallback-path tests explicit by clearing the worker-scoped override before importing the auth service
- add a regression test for the worker-scoped state contract

## Root cause

The Node 24 coverage suite ran many workers against the same default `~/.hermes-web-ui` state. Concurrent SQLite and runtime-state access could terminate a worker; Tinypool then surfaced the secondary `ERR_IPC_CHANNEL_CLOSED` / `Worker exited unexpectedly` error.

## Validation

- RED: worker isolation regression failed because `HERMES_WEB_UI_HOME` was unset
- GREEN: focused isolation + affected runner tests passed
- concurrency stress: 5 iterations, each `8 files / 128 tests` passed
- fresh `git archive` in Node `v24.19.0`, no bind mount, no `HERMES_*`, no host Hermes fallback:
  - `npm run test:coverage`: `504 files passed / 2 skipped`, `4264 tests passed / 8 skipped`, full coverage summary produced
  - no IPC-channel, unexpected-worker-exit, or unhandled-rejection marker
- `npm run harness:check`: passed
- `CI=1 npm run test:e2e`: `124 passed`
- `npm run build`: passed

Closes #2653
