### PR TITLE
fix(chat): remember text-only Chat endpoints

### DIFF
--- a/docs/chat-chain-changes/2026-08-21-chat-multimodal-history.md
+++ b/docs/chat-chain-changes/2026-08-21-chat-multimodal-history.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-21
-pr: pending
+pr: 2655
 feature: Chat model multimodal history compatibility
 impact: Ekko Agent remembers Chat targets that reject image_url and strips image parts on later runs while preserving image-capable Chat requests.
 ---

--- a/docs/chat-chain-changes/2026-08-21-chat-multimodal-history.md
+++ b/docs/chat-chain-changes/2026-08-21-chat-multimodal-history.md
@@ -1,0 +1,11 @@
+---
+date: 2026-08-21
+pr: pending
+feature: Chat model multimodal history compatibility
+impact: Ekko Agent remembers Chat targets that reject image_url and strips image parts on later runs while preserving image-capable Chat requests.
+---
+
+The first explicit image-format rejection for a provider, endpoint, and model is
+retried once without image parts. That text-only decision is held in bounded
+process memory, shared by newly created clients, and is intentionally reset by a
+server restart.

--- a/packages/ekko-agent/src/model/providers/openai-compatible.ts
+++ b/packages/ekko-agent/src/model/providers/openai-compatible.ts
@@ -126,6 +126,9 @@ const defaultCapabilities: ModelCapabilities = {
   systemPrompt: true,
 }
 
+const TEXT_ONLY_CHAT_TARGET_LIMIT = 512
+const textOnlyChatTargets = new Set<string>()
+
 export class OpenAICompatibleModelClient implements ModelClient {
   readonly provider: string
   readonly requestStyle = 'openai-chat'
@@ -149,14 +152,12 @@ export class OpenAICompatibleModelClient implements ModelClient {
   }
 
   async create(request: ModelRequest): Promise<ModelResponse> {
-    const payload = toOpenAIChatPayload(this.config, { ...request, stream: false })
-    const response = await this.postJson(payload, request.signal)
-    return normalizeOpenAIChatResponse(this.provider, response)
+    const response = await this.postWithImageFallback({ ...request, stream: false }, request.signal)
+    return normalizeOpenAIChatResponse(this.provider, await parseResponseJson(this.provider, response))
   }
 
   async *stream(request: ModelRequest): AsyncIterable<ModelEvent> {
-    const payload = toOpenAIChatPayload(this.config, { ...request, stream: true })
-    const response = await this.post(payload, request.signal)
+    const response = await this.postWithImageFallback({ ...request, stream: true }, request.signal)
 
     if (!response.body) {
       throw new ModelProviderError('Model provider returned an empty stream body.', {
@@ -263,9 +264,20 @@ export class OpenAICompatibleModelClient implements ModelClient {
     }
   }
 
-  private async postJson(payload: OpenAIChatPayload, signal?: AbortSignal): Promise<OpenAIChatResponse> {
-    const response = await this.post(payload, signal)
-    return parseResponseJson(this.provider, response)
+  private async postWithImageFallback(request: ModelRequest, signal?: AbortSignal): Promise<Response> {
+    const model = request.model ?? this.config.defaultModel
+    const target = chatTargetKey(this.config, model)
+    const initialConfig = textOnlyChatTargets.has(target)
+      ? withoutVision(this.config)
+      : this.config
+    const payload = toOpenAIChatPayload(initialConfig, request)
+    try {
+      return await this.post(payload, signal)
+    } catch (error) {
+      if (!payloadContainsImage(payload) || !isUnsupportedImageError(error)) throw error
+      rememberTextOnlyChatTarget(target)
+      return this.post(toOpenAIChatPayload(withoutVision(this.config), request), signal)
+    }
   }
 
   private async post(payload: OpenAIChatPayload, signal?: AbortSignal): Promise<Response> {
@@ -284,8 +296,65 @@ export class OpenAICompatibleModelClient implements ModelClient {
   }
 }
 
+function chatTargetKey(config: ModelProviderConfig, model: string): string {
+  return [config.id, chatCompletionsUrl(config), model]
+    .map(value => value.trim().toLowerCase())
+    .join('\u0000')
+}
+
+function rememberTextOnlyChatTarget(target: string): void {
+  if (textOnlyChatTargets.has(target)) return
+  if (textOnlyChatTargets.size >= TEXT_ONLY_CHAT_TARGET_LIMIT) {
+    const oldest = textOnlyChatTargets.values().next().value
+    if (oldest) textOnlyChatTargets.delete(oldest)
+  }
+  textOnlyChatTargets.add(target)
+}
+
+function withoutVision(config: ModelProviderConfig): ModelProviderConfig {
+  return {
+    ...config,
+    capabilities: {
+      ...config.capabilities,
+      vision: false,
+    },
+  }
+}
+
+function payloadContainsImage(payload: OpenAIChatPayload): boolean {
+  return payload.messages.some(message =>
+    Array.isArray(message.content) && message.content.some(part => part.type === 'image_url'))
+}
+
+function isUnsupportedImageError(error: unknown): boolean {
+  if (!(error instanceof ModelProviderError)) return false
+  let details = ''
+  try {
+    details = JSON.stringify(error.details)
+  } catch {
+    // The provider message below is still sufficient for matching.
+  }
+  const text = `${error.message} ${details}`.toLowerCase()
+  const rejectsImageUrl = text.includes('image_url') && (
+    text.includes('unknown variant') ||
+    text.includes('expected') && text.includes('text') ||
+    text.includes('supported values') && text.includes('text') ||
+    text.includes('invalid content')
+  )
+  const rejectsImages = text.includes('image') && (
+    text.includes('does not support') ||
+    text.includes('not support') ||
+    text.includes('unsupported') ||
+    text.includes('text-only') ||
+    text.includes('text only') ||
+    text.includes('only supports text')
+  )
+  return rejectsImageUrl || rejectsImages
+}
+
 export function toOpenAIChatPayload(config: ModelProviderConfig, request: ModelRequest): OpenAIChatPayload {
   const isQwenOAuth = config.id === 'qwen-oauth'
+  const supportsVision = config.capabilities?.vision !== false
   const reasoningReplayField = openAIReasoningReplayField(
     config,
     request.model ?? config.defaultModel,
@@ -298,7 +367,7 @@ export function toOpenAIChatPayload(config: ModelProviderConfig, request: ModelR
   return {
     model: request.model ?? config.defaultModel,
     messages: request.messages.flatMap(message =>
-      toOpenAIChatMessages(message, isQwenOAuth, reasoningReplayField, requiresAssistantContent)),
+      toOpenAIChatMessages(message, isQwenOAuth, reasoningReplayField, requiresAssistantContent, supportsVision)),
     temperature: request.temperature,
     max_tokens: request.maxTokens,
     ...(tools
@@ -309,7 +378,7 @@ export function toOpenAIChatPayload(config: ModelProviderConfig, request: ModelR
       : {}),
     stream: request.stream,
     stream_options: request.stream ? { include_usage: true } : undefined,
-    vl_high_resolution_images: isQwenOAuth ? true : undefined,
+    vl_high_resolution_images: isQwenOAuth && supportsVision ? true : undefined,
   }
 }
 
@@ -349,6 +418,7 @@ function toOpenAIChatMessages(
   qwenOAuth = false,
   reasoningReplayField?: OpenAIChatReasoningReplayFormat,
   requiresAssistantContent = false,
+  supportsVision = true,
 ): OpenAIChatMessage[] {
   const plainContent = message.role === 'assistant' && message.toolCalls?.length
     ? message.content || (requiresAssistantContent ? '' : null)
@@ -381,7 +451,9 @@ function toOpenAIChatMessages(
     tool_call_id: message.toolCallId,
     tool_calls: message.toolCalls?.map(toOpenAIToolCall),
   }
-  const images = message.contentParts?.filter(part => part.type === 'image') ?? []
+  const images = supportsVision
+    ? message.contentParts?.filter(part => part.type === 'image') ?? []
+    : []
   if (message.role === 'user' && images.length > 0) {
     return [{
       ...base,

--- a/tests/ekko-agent/mcp-multimodal.test.ts
+++ b/tests/ekko-agent/mcp-multimodal.test.ts
@@ -88,4 +88,27 @@ describe('Ekko MCP multimodal results', () => {
     const gemini = toGeminiContentsPayload({ ...config, type: 'gemini' }, { messages: [userImage] })
     expect(JSON.stringify(gemini.contents)).toContain('inlineData')
   })
+
+  it('omits images when OpenAI-compatible vision is explicitly disabled', () => {
+    const payload = toOpenAIChatPayload({
+      id: 'custom:text-proxy',
+      type: 'openai-compatible',
+      baseUrl: 'https://chat.example.com/v1',
+      apiKey: 'test',
+      defaultModel: 'future-chat-model',
+      capabilities: { vision: false },
+    }, { messages: [userImage, toolImage] })
+
+    expect(payload.messages).toHaveLength(2)
+    expect(payload.messages[0]).toMatchObject({
+      role: 'user',
+      content: 'Describe this image.',
+    })
+    expect(payload.messages[1]).toMatchObject({
+      role: 'tool',
+      content: 'browser screenshot',
+    })
+    expect(JSON.stringify(payload.messages)).not.toContain('image_url')
+    expect(JSON.stringify(payload.messages)).not.toContain('aGVsbG8=')
+  })
 })

--- a/tests/ekko-agent/model-request.test.ts
+++ b/tests/ekko-agent/model-request.test.ts
@@ -90,6 +90,50 @@ describe('ekko-agent model requests', () => {
     ]))
   })
 
+  it('remembers image-rejecting Chat targets across client instances', async () => {
+    const model = `text-only-memory-test-${Date.now()}-${Math.random()}`
+    const config: ModelProviderConfig = {
+      id: 'custom:adaptive-chat-test',
+      type: 'openai-compatible',
+      apiKey: 'test-key',
+      baseUrl: 'https://adaptive-chat.example.com/v1',
+      defaultModel: model,
+    }
+    const bodies: Array<Record<string, any>> = []
+    const fetchMock = vi.fn(async (_input: string | URL, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body)))
+      if (bodies.length === 1) {
+        return new Response(JSON.stringify({
+          error: {
+            message: 'Failed to deserialize messages[14]: unknown variant `image_url`, expected `text`',
+          },
+        }), { status: 400 })
+      }
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'Text fallback worked.' }, finish_reason: 'stop' }],
+      }), { status: 200 })
+    })
+    const request = {
+      messages: [{
+        role: 'user' as const,
+        content: 'Keep this text.',
+        contentParts: [{ type: 'image' as const, mimeType: 'image/png', data: 'aGVsbG8=' }],
+      }],
+    }
+
+    await expect(createModelClient(config, { fetch: fetchMock }).create(request))
+      .resolves.toMatchObject({ content: 'Text fallback worked.' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(JSON.stringify(bodies[0])).toContain('image_url')
+    expect(JSON.stringify(bodies[1])).not.toContain('image_url')
+    expect(JSON.stringify(bodies[1])).toContain('Keep this text.')
+
+    await expect(createModelClient(config, { fetch: fetchMock }).create(request))
+      .resolves.toMatchObject({ content: 'Text fallback worked.' })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(JSON.stringify(bodies[2])).not.toContain('image_url')
+  })
+
   it('completes a Codex Responses tool loop when terminal output arrays are empty', async () => {
     const encoder = new TextEncoder()
     let call = 0


### PR DESCRIPTION
## Summary

- keep image-capable OpenAI-compatible Chat requests unchanged
- retry once without image parts only when the endpoint explicitly rejects `image_url`
- remember the provider, endpoint, and model in bounded process memory so later runs skip the failed image request
- keep Studio bundled Ekko Agent synchronized with standalone `ekko-agent` main commit `e41262a`

## Validation

- `npx vitest run tests/ekko-agent/model-request.test.ts tests/ekko-agent/mcp-multimodal.test.ts`
- `npx tsc --noEmit -p packages/ekko-agent/tsconfig.json`
- `npm run harness:check`
- `npm run build`
- standalone `ekko-agent`: 227/227 tests and build passed