### PR TITLE
[codex] resume Pi coding agent sessions

### DIFF
--- a/docs/chat-chain-changes/2026-08-21-pi-session-resume.md
+++ b/docs/chat-chain-changes/2026-08-21-pi-session-resume.md
@@ -1,0 +1,10 @@
+---
+date: 2026-08-21
+pr: pending
+feature: Resume Pi coding-agent sessions
+impact: Direct Pi chats now reopen their persisted native session after each RPC process restart, while group-chat turns remain temporary and receive room history explicitly.
+---
+
+Studio now passes the generated or stored Pi native session UUID into the actual RPC launch. Pi's exact `--session-id` behavior creates the session on the first turn and opens the existing session file on later turns.
+
+Group-chat coding agents intentionally use a fresh temporary runtime session for every mention and delete its Studio session afterward. Their prompt includes the current room summary and post-summary history, so this change does not add native resume to group chat and does not duplicate previously injected room context.

--- a/docs/chat-chain-changes/2026-08-21-pi-session-resume.md
+++ b/docs/chat-chain-changes/2026-08-21-pi-session-resume.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-21
-pr: pending
+pr: 2656
 feature: Resume Pi coding-agent sessions
 impact: Direct Pi chats now reopen their persisted native session after each RPC process restart, while group-chat turns remain temporary and receive room history explicitly.
 ---

--- a/packages/server/src/services/coding-agents/index.ts
+++ b/packages/server/src/services/coding-agents/index.ts
@@ -2734,6 +2734,7 @@ export async function startCodingAgentRun(
     ...resolvedInput,
     sessionId,
     agentSessionId,
+    agentNativeSessionId,
     isolateSettings: true,
     piOutputMode: id === 'pi' ? 'rpc' : undefined,
   })

--- a/tests/server/coding-agent-resume-config.test.ts
+++ b/tests/server/coding-agent-resume-config.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -39,6 +39,12 @@ function makeHome() {
   homes.push(home)
   process.env.HERMES_WEB_UI_HOME = home
   return home
+}
+
+function installPiMcpAdapter(home: string) {
+  const entry = join(home, 'coding-agent', 'pi-mcp-adapter', 'node_modules', 'pi-mcp-adapter', 'index.ts')
+  mkdirSync(join(entry, '..'), { recursive: true })
+  writeFileSync(entry, 'export default {}')
 }
 
 describe('coding agent resumed session config', () => {
@@ -234,6 +240,74 @@ describe('coding agent resumed session config', () => {
     expect(startRunMock).toHaveBeenCalledWith(expect.objectContaining({
       agentNativeSessionId: '11111111-1111-4111-8111-111111111111',
       nativeResume: true,
+    }))
+  })
+
+  it('passes the stored native session id to Pi so its RPC process resumes after restart', async () => {
+    const home = makeHome()
+    installPiMcpAdapter(home)
+    getSessionMock.mockReturnValue({
+      id: 'session-1',
+      profile: 'default',
+      source: 'coding_agent',
+      agent: 'pi',
+      agent_mode: 'scoped',
+      agent_session_id: 'agent-session-1',
+      agent_native_session_id: '11111111-2222-4333-8444-555555555555',
+      provider: 'custom:corp-pi',
+      model: 'gpt-test',
+      api_mode: 'codex_responses',
+    })
+    readConfigYamlForProfileMock.mockResolvedValue({
+      custom_providers: [{
+        name: 'corp-pi',
+        base_url: 'https://provider.example/v1',
+        api_key: 'sk-upstream',
+        model: 'gpt-test',
+        api_mode: 'codex_responses',
+      }],
+    })
+    safeReadFileMock.mockResolvedValue('')
+
+    const { startCodingAgentRun } = await import('../../packages/server/src/services/coding-agents')
+    await startCodingAgentRun('pi', { sessionId: 'session-1' })
+
+    const launch = startRunMock.mock.calls[0][0]
+    expect(launch).toEqual(expect.objectContaining({
+      agentNativeSessionId: '11111111-2222-4333-8444-555555555555',
+      nativeResume: true,
+    }))
+    expect(launch.args).toEqual(expect.arrayContaining([
+      '--session-id', '11111111-2222-4333-8444-555555555555',
+    ]))
+  })
+
+  it('uses the same generated native session id for a new Pi launch and persistence', async () => {
+    const home = makeHome()
+    installPiMcpAdapter(home)
+    getSessionMock.mockReturnValue(null)
+    readConfigYamlForProfileMock.mockResolvedValue({})
+    safeReadFileMock.mockResolvedValue('')
+
+    const { startCodingAgentRun } = await import('../../packages/server/src/services/coding-agents')
+    await startCodingAgentRun('pi', {
+      sessionId: 'session-new',
+      profile: 'default',
+      provider: 'custom:corp-pi',
+      model: 'gpt-test',
+      baseUrl: 'https://provider.example/v1',
+      apiKey: 'sk-upstream',
+      apiMode: 'codex_responses',
+    })
+
+    const launch = startRunMock.mock.calls[0][0]
+    expect(launch.agentNativeSessionId).toMatch(/^[0-9a-f-]{36}$/i)
+    expect(launch.nativeResume).toBe(false)
+    expect(launch.args).toEqual(expect.arrayContaining([
+      '--session-id', launch.agentNativeSessionId,
+    ]))
+    expect(updateSessionMock).toHaveBeenCalledWith('session-new', expect.objectContaining({
+      agent_native_session_id: launch.agentNativeSessionId,
     }))
   })
 

--- a/tests/server/group-chat-agent-workspace.test.ts
+++ b/tests/server/group-chat-agent-workspace.test.ts
@@ -749,6 +749,68 @@ describe('group chat agent workspace bridge runs', () => {
     }))
   })
 
+  it('keeps Pi group turns temporary while reinjecting the room history', async () => {
+    const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')
+    const runAndWait = vi.fn(async () => ({ ok: true, output: 'done' }))
+    const disposeSession = vi.fn(async () => {})
+    const clients = new AgentClients()
+    clients.setChatRunService({
+      runAndWait,
+      abortSession: vi.fn(async () => {}),
+      disposeSession,
+    })
+    const client = await clients.createAgent({
+      agentId: 'agent-pi-history',
+      agent: 'pi',
+      profile: 'default',
+      name: 'Pi',
+      description: 'Keeps up with the room',
+      invited: 0,
+      backgroundDelegationEnabled: false,
+    } as any) as any
+    client.setStorage({
+      getRoom: vi.fn(() => ({ name: 'History Room', workspace: '' })),
+      getRoomMembers: vi.fn(() => []),
+      getRoomAgents: vi.fn(() => []),
+    })
+
+    await client.replyToMention('room-history', {
+      messageId: 'msg-1',
+      content: '@Pi remember alpha',
+      senderName: 'Human',
+      senderId: 'human-1',
+      timestamp: 1,
+      role: 'user',
+    })
+    await client.replyToMention('room-history', {
+      messageId: 'msg-2',
+      content: '@Pi what came before?',
+      senderName: 'Human',
+      senderId: 'human-1',
+      timestamp: 2,
+      role: 'user',
+    }, {
+      summary: '',
+      history: [{
+        id: 'msg-1',
+        timestamp: 1,
+        role: 'user',
+        senderName: 'Human',
+        content: '@Pi remember alpha',
+      }],
+    })
+
+    const firstRun = runAndWait.mock.calls[0][0]
+    const secondRun = runAndWait.mock.calls[1][0]
+    expect(firstRun.session_id).toMatch(/^gc_run_/)
+    expect(secondRun.session_id).toMatch(/^gc_run_/)
+    expect(secondRun.session_id).not.toBe(firstRun.session_id)
+    expect(String(secondRun.input)).toContain('Member "Human": @Pi remember alpha')
+    expect(disposeSession).toHaveBeenCalledTimes(2)
+    expect(disposeSession).toHaveBeenNthCalledWith(1, firstRun.session_id)
+    expect(disposeSession).toHaveBeenNthCalledWith(2, secondRun.session_id)
+  })
+
   it('adds the workspace-scoped security policy only when a non-owner mentions the Agent', async () => {
     const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')
     const runAndWait = vi.fn(async (_data: any) => ({ ok: true, output: 'done' }))


### PR DESCRIPTION
## Summary
- pass the generated or stored Pi native session ID into the actual RPC launch so later turns reopen the same Pi session
- cover both new-session creation and restart resume behavior without changing Claude Code or Codex resume paths
- document and test that group-chat coding agents remain temporary while receiving the room summary and history explicitly

## Impact
Direct Pi chats keep native conversation and tool context across per-turn RPC process restarts. Existing sessions affected before this fix establish a correct native chain on their first post-update turn; missing pre-fix Pi-native history cannot be reconstructed.

## Validation
- npm run test -- tests/server/coding-agent-resume-config.test.ts tests/server/group-chat-agent-workspace.test.ts tests/server/handle-coding-agent-run.test.ts
- npm run test -- tests/server/coding-agents-launch.test.ts tests/server/pi-rpc-real.test.ts
- npm run harness:check
- npm run build

## Notes
- The opt-in real Pi RPC suite remains skipped unless PI_REAL_RPC_E2E=1.