### PR TITLE
fix(chat): preserve background callback origin context

### DIFF
--- a/docs/chat-chain-changes/2026-08-21-background-callback-origin-context.md
+++ b/docs/chat-chain-changes/2026-08-21-background-callback-origin-context.md
@@ -1,0 +1,11 @@
+---
+date: 2026-08-21
+pr: pending
+feature: Background callback origin context
+impact: Hermes and embedded Ekko background callbacks continue from their originating history instead of unrelated messages added while the task was running.
+---
+
+Origin snapshots remain process-local. Embedded Ekko freezes the complete
+delegation tool batch; Hermes freezes the completed parent run. A callback with
+no available snapshot fails explicitly and never falls back to current session
+history.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3764,6 +3764,72 @@
         }
       }
     },
+    "/api/hermes/config/fallback-providers": {
+      "get": {
+        "tags": [
+          "Config"
+        ],
+        "summary": "Get fallback-providers",
+        "description": "GET /api/hermes/config/fallback-providers",
+        "operationId": "getFallbackProviders",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Config"
+        ],
+        "summary": "Update fallback-providers",
+        "description": "PUT /api/hermes/config/fallback-providers",
+        "operationId": "updateFallbackProviders",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "fallback_providers": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/hermes/config/moa": {
       "get": {
         "tags": [

--- a/docs/planning/ekko-background-callback-context.md
+++ b/docs/planning/ekko-background-callback-context.md
@@ -1,7 +1,22 @@
-# Ekko Background Callback Context Fork
+# Background Callback Context Forks
 
 Date: 2026-08-15
-Status: Proposed; not implemented
+Status: Implemented in Studio for embedded Ekko and Hermes; standalone ekko-agent deferred
+
+## Implementation Note
+
+Studio now freezes callback context at the originating run instead of rebuilding
+it from live session history. Embedded Ekko captures the complete tool-batch
+boundary and carries that immutable fork in its internal completion event and
+queue entry. Hermes captures the completed parent run's replayable messages and
+keeps them in the process-local `SessionState`, keyed by delegation ID.
+
+Both callback paths bypass live-history compression. Ekko also uses a fresh
+ephemeral provider context with memory and skill review disabled. Hermes
+snapshots are intentionally not persisted: if Studio restarts before delivery,
+the recovered callback is rejected observably instead of falling back to newer
+session history. The standalone `ekko-agent` repository is not changed by this
+implementation.
 
 ## Decision Summary
 
@@ -391,8 +406,9 @@ following:
 
 ## Out Of Scope
 
-- Implementing the change in this planning pass.
 - Making Ekko background tasks or the run queue durable across server restarts.
+- Persisting Hermes origin forks across Studio restarts.
+- Updating the standalone `ekko-agent` repository.
 - Introducing user-visible session branches.
 - Redesigning background task cards or callback wording.
 - Changing natural-language cancellation into a control-plane command.

--- a/packages/ekko-agent/src/runtime/events.ts
+++ b/packages/ekko-agent/src/runtime/events.ts
@@ -1,7 +1,7 @@
 import type { AgentOutputMessage } from '../model/messages'
 import type { AgentToolCall, ModelUsage } from '../model/types'
 import type { AgentToolResult } from '../tools/types'
-import type { AgentRuntimeContextEstimate } from './types'
+import type { AgentRuntimeContextEstimate, EkkoBackgroundContinuationContext } from './types'
 import type { MemoryContextDiagnostics } from '../memory/types'
 
 export type AgentRuntimeEvent =
@@ -45,6 +45,7 @@ export type AgentRuntimeEvent =
       cacheReadTokens: number
       cacheWriteTokens: number
       reasoningTokens: number
+      continuationContext?: EkkoBackgroundContinuationContext
     }
   | { type: 'run.tool_failure_limit'; runId: string; failures: number }
   | { type: 'run.completed'; runId: string; output: AgentOutputMessage; steps: number; context?: unknown; contextEstimate?: AgentRuntimeContextEstimate }

--- a/packages/ekko-agent/src/runtime/runtime.ts
+++ b/packages/ekko-agent/src/runtime/runtime.ts
@@ -26,6 +26,7 @@ import type {
   AgentRuntimeRunInput,
   AgentRuntimeRunResult,
   AgentRuntimeStep,
+  EkkoBackgroundContinuationContext,
 } from './types'
 import type { MemoryContext, MemoryRuntimeIdentity } from '../memory/types'
 import type { MemoryCaptureMessage } from '../memory/service'
@@ -54,6 +55,7 @@ interface BackgroundTask {
   sessionId?: string
   controller: AbortController
   promise: Promise<AgentToolResult>
+  resolveContinuationContext: (context: EkkoBackgroundContinuationContext | null) => void
 }
 
 interface ActiveBoundaryRun {
@@ -93,6 +95,10 @@ function foregroundOnlyDelegateTaskDefinition(definition: AgentToolDefinition): 
       },
     },
   }
+}
+
+function cloneAgentMessages(messages: AgentMessage[]): AgentMessage[] {
+  return structuredClone(messages)
 }
 
 export class AgentRuntime {
@@ -186,7 +192,10 @@ export class AgentRuntime {
   async abortBackgroundTasks(sessionId?: string): Promise<number> {
     const tasks = [...this.backgroundTasks.values()]
       .filter(task => !sessionId || task.sessionId === sessionId)
-    for (const task of tasks) task.controller.abort()
+    for (const task of tasks) {
+      task.controller.abort()
+      task.resolveContinuationContext(null)
+    }
     await Promise.allSettled(tasks.map(task => task.promise))
     return tasks.length
   }
@@ -258,6 +267,7 @@ export class AgentRuntime {
     const maxSteps = input.maxSteps ?? this.maxSteps
     const maxModelRetries = input.maxModelRetries ?? this.maxModelRetries
     const maxConsecutiveToolFailures = input.maxConsecutiveToolFailures ?? this.maxConsecutiveToolFailures
+    const pendingBackgroundSubagentIds = new Set<string>()
     const emit = (event: AgentRuntimeEvent) => {
       events.push(event)
       input.onEvent?.(event)
@@ -288,7 +298,13 @@ export class AgentRuntime {
             error: 'Background subtask delegation is disabled for this run. Use foreground mode.',
           })
         }
-        return this.delegateTask(request, input, runId, emit)
+        return this.delegateTask(
+          request,
+          input,
+          runId,
+          emit,
+          subagentId => pendingBackgroundSubagentIds.add(subagentId),
+        )
       },
     }
     if (memoryContext) {
@@ -386,7 +402,7 @@ export class AgentRuntime {
           messages.push(createToolResultMessage(toolCall.id, result.content, toolCall.name, result.contentParts))
           steps.push({ type: 'tool', step, toolCallId: toolCall.id, toolName: toolCall.name, result })
           consecutiveToolFailures = result.ok ? 0 : consecutiveToolFailures + 1
-          this.recordSkillToolCall(contextKey, toolCall.name)
+          if (input.skillReviewEnabled !== false) this.recordSkillToolCall(contextKey, toolCall.name)
           if (maxConsecutiveToolFailures > 0 && consecutiveToolFailures >= maxConsecutiveToolFailures) {
             if (activeBoundaryRun) activeBoundaryRun.terminal = true
             emit({ type: 'run.tool_failure_limit', runId, failures: consecutiveToolFailures })
@@ -401,6 +417,20 @@ export class AgentRuntime {
             this.completeSkillReview(runId, contextKey, messages, input, input.onEvent)
             return { runId, messages, output, steps, events, context, contextEstimate, memoryContext }
           }
+        }
+        if (pendingBackgroundSubagentIds.size > 0) {
+          const continuationMessages = cloneAgentMessages(messages.slice(1))
+          for (const subagentId of pendingBackgroundSubagentIds) {
+            this.backgroundTasks.get(subagentId)?.resolveContinuationContext({
+              version: 1,
+              subagentId,
+              originRunId: runId,
+              originStep: step,
+              messages: continuationMessages,
+              memoryPolicy: 'disabled',
+            })
+          }
+          pendingBackgroundSubagentIds.clear()
         }
         if (activeBoundaryRun?.pending) return completeBoundaryInterrupt(step)
       }
@@ -431,6 +461,12 @@ export class AgentRuntime {
       emit({ type: 'run.failed', runId, error: message, steps: steps.length })
       throw error
     } finally {
+      for (const subagentId of pendingBackgroundSubagentIds) {
+        const task = this.backgroundTasks.get(subagentId)
+        task?.controller.abort()
+        task?.resolveContinuationContext(null)
+      }
+      if (input.ephemeralContext && contextKey) this.modelContexts.delete(contextKey)
       if (activeBoundaryRun) this.activeBoundaryRuns.delete(activeBoundaryRun.runId)
     }
   }
@@ -694,6 +730,7 @@ export class AgentRuntime {
     emit?: (event: AgentRuntimeEvent) => void,
   ): void {
     if (
+      input.skillReviewEnabled === false ||
       (input.toolContext?.delegationDepth ?? this.toolContext?.delegationDepth ?? 0) > 0 ||
       !this.skillReview ||
       this.skillReviewEveryToolCalls <= 0 ||
@@ -854,11 +891,16 @@ export class AgentRuntime {
     parentInput: AgentRuntimeRunInput,
     parentRunId: string,
     emit: (event: AgentRuntimeEvent) => void,
+    onBackgroundStarted?: (subagentId: string) => void,
   ): Promise<AgentToolResult> {
     const subagentId = randomUUID()
     const background = request.mode === 'background'
     const startedAt = Date.now()
     const controller = new AbortController()
+    let resolveContinuationContext!: (context: EkkoBackgroundContinuationContext | null) => void
+    const continuationContextReady = new Promise<EkkoBackgroundContinuationContext | null>((resolve) => {
+      resolveContinuationContext = resolve
+    })
     const sessionId = this.contextKeyFor(parentInput)
     const childContextKey = sessionId
       ? `${sessionId}:subagent:${subagentId}`
@@ -1002,6 +1044,17 @@ export class AgentRuntime {
         this.modelContexts.delete(childContextKey)
       }
 
+      let continuationContext: EkkoBackgroundContinuationContext | undefined
+      if (background && status !== 'interrupted') {
+        const captured = await continuationContextReady
+        if (captured) {
+          continuationContext = captured
+        } else {
+          status = 'interrupted'
+          error = 'Background subtask result was suppressed because its origin context was not captured.'
+          output = error
+        }
+      }
       const summary = subtaskSummary(output, status)
       emit({
         type: 'subagent.complete',
@@ -1022,6 +1075,7 @@ export class AgentRuntime {
         cacheReadTokens,
         cacheWriteTokens,
         reasoningTokens,
+        ...(continuationContext ? { continuationContext } : {}),
       })
       const payload = {
         runtime: 'ekko',
@@ -1053,7 +1107,9 @@ export class AgentRuntime {
       sessionId,
       controller,
       promise: childPromise,
+      resolveContinuationContext,
     })
+    onBackgroundStarted?.(subagentId)
     void childPromise.then(
       () => this.backgroundTasks.delete(subagentId),
       () => this.backgroundTasks.delete(subagentId),

--- a/packages/ekko-agent/src/runtime/types.ts
+++ b/packages/ekko-agent/src/runtime/types.ts
@@ -21,6 +21,15 @@ export interface AgentRuntimeContextEstimate {
   systemPromptChars: number
 }
 
+export interface EkkoBackgroundContinuationContext {
+  version: 1
+  subagentId: string
+  originRunId: string
+  originStep: number
+  messages: AgentMessage[]
+  memoryPolicy: 'disabled'
+}
+
 export interface AgentRuntimeOptions {
   modelClient?: ModelClient
   /** Disable every tool source, including built-ins, MCP, memory, and skill tools. */
@@ -69,6 +78,10 @@ export interface AgentRuntimeRunInput {
   contextKey?: string
   context?: unknown
   memoryEnabled?: boolean
+  /** Delete provider-native continuation state when this run exits. */
+  ephemeralContext?: boolean
+  /** Disable session-global skill review side effects for an isolated callback run. */
+  skillReviewEnabled?: boolean
   /** When false, delegate_task only accepts foreground mode for this run. */
   backgroundDelegationEnabled?: boolean
   /** Correlation fields only; log events and payloads remain runtime-owned. */

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -27,7 +27,14 @@ import {
   recordBridgeMoaDisplayTool,
 } from './bridge-message'
 import { summarizeToolArguments } from './response-utils'
-import type { ChatRunSource, ContentBlock, QueuedRun, SessionState } from './types'
+import type {
+  BackgroundContinuationContext,
+  ChatRunSource,
+  ContentBlock,
+  HermesBackgroundContinuationContext,
+  QueuedRun,
+  SessionState,
+} from './types'
 import type { ChatMessage } from '../../../lib/context-compressor'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
 import { filterBridgeToolCallMarkupDelta, flushPendingToolCallMarkup } from './bridge-delta'
@@ -70,6 +77,21 @@ function parseBackgroundDelegation(
   } catch {
     return null
   }
+}
+
+interface BridgeRunMetadata {
+  autonomous?: boolean
+  delegationId?: string
+  queueId?: string
+  backgroundDelegationIds: Set<string>
+  originContext: Omit<HermesBackgroundContinuationContext, 'delegationId' | 'originRunId'>
+}
+
+function resultMessages(result: unknown): ChatMessage[] | null {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) return null
+  const messages = (result as Record<string, unknown>).messages
+  if (!Array.isArray(messages)) return null
+  return structuredClone(messages) as ChatMessage[]
 }
 
 function backgroundPendingCount(state: SessionState): number {
@@ -409,6 +431,7 @@ export async function handleBridgeRun(
   skipUserMessage = false,
   loadSessionStateFromDbFn: (sid: string, sessionMap: Map<string, SessionState>) => Promise<SessionState>,
   dequeueNextQueuedRun: (socket: Socket, sessionId: string, fallbackProfile?: string) => void,
+  backgroundContinuationContext?: BackgroundContinuationContext,
 ) {
   const { input, session_id, instructions } = data
   const runSource = normalizeBridgeRunSource(data.source, data.session_source)
@@ -420,28 +443,39 @@ export async function handleBridgeRun(
     socket.emit('run.failed', { event: 'run.failed', queue_id: data.queue_id, error: 'session_id is required for cli source' })
     return
   }
+  const callbackContext = data.background_delegation_id
+    && backgroundContinuationContext?.runtime === 'hermes'
+    && backgroundContinuationContext.delegationId === data.background_delegation_id
+    && backgroundContinuationContext.sessionId === session_id
+    ? backgroundContinuationContext
+    : undefined
 
   // `instructions` already carries the Studio guidance: the chat-run socket
   // composes it before delegating here. Prepending it again duplicated the whole
   // block — MCP usage plus the output-format rules — byte for byte in the system
   // message of every request. Compose only when a caller hands us nothing.
-  let fullInstructions = instructions || getSystemPrompt(undefined, { source: data.session_source || data.source })
+  let fullInstructions = callbackContext?.instructions
+    || instructions
+    || getSystemPrompt(undefined, { source: data.session_source || data.source })
   const sessionRow = getSession(session_id)
-  const workspace = await ensureHermesRunWorkspace(profile, sessionRow?.workspace || data.workspace)
+  const requestedWorkspace = callbackContext
+    ? callbackContext.workspace
+    : sessionRow?.workspace || data.workspace
+  const workspace = await ensureHermesRunWorkspace(profile, requestedWorkspace)
   const shouldEmitWorkspaceUpdate = Boolean(workspace && !sessionRow?.workspace)
   if (sessionRow && !sessionRow.workspace) updateSession(session_id, { workspace })
-  const sessionModel = sessionRow?.model || ''
-  const sessionProvider = sessionRow?.provider || ''
+  const sessionModel = callbackContext?.model || sessionRow?.model || ''
+  const sessionProvider = callbackContext?.provider || sessionRow?.provider || ''
   const { model: resolvedModel, provider: resolvedProvider } = await resolveBridgeRunModelConfig({
     profile,
     sessionModel,
     sessionProvider,
-    requestedModel: data.model,
-    requestedProvider: data.provider,
+    requestedModel: callbackContext?.model || data.model,
+    requestedProvider: callbackContext?.provider || data.provider,
     modelGroups: data.model_groups,
-    preferRequested: data.one_shot_model === true,
+    preferRequested: Boolean(callbackContext) || data.one_shot_model === true,
   })
-  if (sessionRow && data.one_shot_model !== true) {
+  if (sessionRow && !callbackContext && data.one_shot_model !== true) {
     const updates: { model?: string; provider?: string } = {}
     if (resolvedModel && sessionRow.model !== resolvedModel) updates.model = resolvedModel
     if (resolvedProvider && sessionRow.provider !== resolvedProvider) updates.provider = resolvedProvider
@@ -452,7 +486,9 @@ export async function handleBridgeRun(
   const runPrompt = [
     'When calling Hermes Web UI endpoints from tools or skills, include the current Hermes profile as the X-Hermes-Profile header if the endpoint supports profile-scoped behavior.',
   ].filter(Boolean).join('\n')
-  fullInstructions = `\n${runPrompt}\n${fullInstructions}`
+  if (!callbackContext?.instructions) {
+    fullInstructions = `\n${runPrompt}\n${fullInstructions}`
+  }
 
   const runMarker = `cli_run_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
   const now = Math.floor(Date.now() / 1000)
@@ -575,42 +611,84 @@ export async function handleBridgeRun(
     })
   }
 
-  const history = await buildCompressedHistory(
-    session_id, profile,
-    '',
-    undefined,
-    emit,
-    sessionMap,
-    { model: resolvedModel, provider: resolvedProvider },
-    async (_messages, localMessageTokens) => {
-      const fixedContextTokens = await ensureBridgeFixedContext({
-        sessionId: session_id,
-        profile,
-        model: resolvedModel,
-        provider: resolvedProvider,
-        workspace,
-        instructions: fullInstructions,
-        state,
-        bridge,
-        refresh: true,
-        backgroundDelegationEnabled,
-      })
-      const contextTokens = fixedContextTokens == null
-        ? localMessageTokens
-        : fixedContextTokens + localMessageTokens
-      bridgeLogger.info({
-        sessionId: session_id,
-        profile,
-        model: resolvedModel,
-        provider: resolvedProvider,
-        fixedContextTokens,
-        messageTokens: localMessageTokens,
-        contextTokens,
-      }, '[chat-run-socket] local context estimate')
-      return contextTokens
-    },
-    currentInputTokens,
-  )
+  if (data.background_delegation_id && !callbackContext) {
+    const error = `Background callback ${data.background_delegation_id} cannot continue because its origin context is unavailable.`
+    bridgeLogger.error({ sessionId: session_id, delegationId: data.background_delegation_id }, error)
+    if (data.background_claim_id) {
+      try {
+        await bridge.completeBackgroundNotification(
+          session_id,
+          profile,
+          data.background_delegation_id,
+          data.background_claim_id,
+        )
+      } catch (err) {
+        bridgeLogger.warn(err, '[chat-run-socket] failed to acknowledge background callback with missing context')
+      }
+    }
+    if (state.backgroundDelegations?.[data.background_delegation_id]) {
+      state.backgroundDelegations[data.background_delegation_id] = {
+        ...state.backgroundDelegations[data.background_delegation_id],
+        status: 'failed',
+        updatedAt: Date.now(),
+      }
+    }
+    state.isWorking = false
+    state.profile = undefined
+    state.runId = undefined
+    state.activeRunMarker = undefined
+    state.events = []
+    emit('run.failed', {
+      event: 'run.failed',
+      error,
+      queue_remaining: state.queue.length,
+      background_pending: backgroundPendingCount(state),
+      autonomous: true,
+      delegation_id: data.background_delegation_id,
+      queue_id: data.queue_id,
+    })
+    if (state.queue.length > 0) dequeueNextQueuedRun(socket, session_id, profile)
+    return
+  }
+
+  const history = callbackContext
+    ? structuredClone(callbackContext.messages)
+    : await buildCompressedHistory(
+      session_id, profile,
+      '',
+      undefined,
+      emit,
+      sessionMap,
+      { model: resolvedModel, provider: resolvedProvider },
+      async (_messages, localMessageTokens) => {
+        const fixedContextTokens = await ensureBridgeFixedContext({
+          sessionId: session_id,
+          profile,
+          model: resolvedModel,
+          provider: resolvedProvider,
+          workspace,
+          instructions: fullInstructions,
+          state,
+          bridge,
+          refresh: true,
+          backgroundDelegationEnabled,
+        })
+        const contextTokens = fixedContextTokens == null
+          ? localMessageTokens
+          : fixedContextTokens + localMessageTokens
+        bridgeLogger.info({
+          sessionId: session_id,
+          profile,
+          model: resolvedModel,
+          provider: resolvedProvider,
+          fixedContextTokens,
+          messageTokens: localMessageTokens,
+          contextTokens,
+        }, '[chat-run-socket] local context estimate')
+        return contextTokens
+      },
+      currentInputTokens,
+    )
   const bridgeHistory = history
   let backgroundNotificationAccepted = false
 
@@ -618,6 +696,27 @@ export async function handleBridgeRun(
     const bridgeInput = isContentBlockArray(input)
       ? await convertContentBlocksForAgent(input)
       : input
+    const runMetadata: BridgeRunMetadata = {
+      autonomous: data.autonomous === true,
+      delegationId: data.background_delegation_id,
+      queueId: data.queue_id,
+      backgroundDelegationIds: new Set<string>(),
+      originContext: {
+        runtime: 'hermes',
+        version: 1,
+        sessionId: session_id,
+        messages: [
+          ...structuredClone(bridgeHistory),
+          { role: 'user', content: structuredClone(bridgeInput) } as ChatMessage,
+        ],
+        model: resolvedModel,
+        provider: resolvedProvider,
+        profile,
+        instructions: fullInstructions,
+        workspace,
+        reasoningEffort: callbackContext?.reasoningEffort || data.reasoning_effort,
+      },
+    }
     const bridgeStorageInput = data.storage_message !== undefined
       ? data.storage_message
       : isContentBlockArray(input)
@@ -647,7 +746,9 @@ export async function handleBridgeRun(
         // cached AgentSession (for example if context estimation was skipped).
         background_delegation_enabled: backgroundDelegationEnabled,
         // Local patch (reasoning-effort): per-session reasoning effort override.
-        ...(data.reasoning_effort ? { reasoning_effort: data.reasoning_effort } : {}),
+        ...(runMetadata.originContext.reasoningEffort
+          ? { reasoning_effort: runMetadata.originContext.reasoningEffort }
+          : {}),
       },
     )
     state.runId = started.run_id
@@ -659,6 +760,9 @@ export async function handleBridgeRun(
         data.background_claim_id,
       )
       backgroundNotificationAccepted = true
+      if (state.backgroundContinuationContexts) {
+        delete state.backgroundContinuationContexts[data.background_delegation_id]
+      }
     }
     try {
       startWorkspaceRunCheckpoint({
@@ -714,7 +818,7 @@ export async function handleBridgeRun(
         currentInputTokens,
         shouldPersistUserMessage && displayRole === 'user',
         data.model_groups,
-        { autonomous: data.autonomous === true, delegationId: data.background_delegation_id, queueId: data.queue_id },
+        runMetadata,
       )
       if (chunk.done) {
         sawTerminalChunk = true
@@ -760,7 +864,7 @@ export async function handleBridgeRun(
         currentInputTokens,
         shouldPersistUserMessage && displayRole === 'user',
         data.model_groups,
-        { autonomous: data.autonomous === true, delegationId: data.background_delegation_id, queueId: data.queue_id },
+        runMetadata,
       )
     }
   } catch (err: any) {
@@ -1148,7 +1252,7 @@ async function applyBridgeChunkAsync(
   currentInputTokens = 0,
   currentInputIncludedInDb = true,
   modelGroups?: RunModelGroup[],
-  runMetadata?: { autonomous?: boolean; delegationId?: string; queueId?: string },
+  runMetadata?: BridgeRunMetadata,
 ): Promise<void> {
   if (state.activeRunMarker !== runMarker) {
     bridgeLogger.info({
@@ -1237,6 +1341,7 @@ async function applyBridgeChunkAsync(
       const completed = recordBridgeToolCompleted(state, sessionId, runMarker, toolName, ev)
       const backgroundDelegation = parseBackgroundDelegation(toolName, completed.output)
       if (backgroundDelegation) {
+        runMetadata?.backgroundDelegationIds.add(backgroundDelegation.delegationId)
         state.backgroundDelegations = state.backgroundDelegations || {}
         const existing = state.backgroundDelegations[backgroundDelegation.delegationId]
         if (!existing || existing.status === 'running') {
@@ -1616,6 +1721,40 @@ async function applyBridgeChunkAsync(
   flushBridgePendingToDb(state, sessionId, runMarker)
   finalResponse = bridgeFinalResponse(chunk, state, useMoaFinalResponse)
   state.bridgePendingToolCallMarkup = undefined
+  if (runMetadata?.backgroundDelegationIds.size) {
+    const exactMessages = resultMessages(chunk.result)
+    const fallbackGeneratedMessages = state.messages
+      .filter(message => message.runMarker === runMarker && (message.role === 'assistant' || message.role === 'tool'))
+      .map(message => ({
+        role: message.role,
+        content: message.content,
+        ...(message.tool_calls?.length ? { tool_calls: structuredClone(message.tool_calls) } : {}),
+        ...(message.tool_call_id ? { tool_call_id: message.tool_call_id } : {}),
+        ...(message.tool_name ? { name: message.tool_name } : {}),
+        ...(message.reasoning_content ? { reasoning_content: message.reasoning_content } : {}),
+        ...(message.reasoning_details ? { reasoning_details: message.reasoning_details } : {}),
+      })) as ChatMessage[]
+    const messages = exactMessages || [
+      ...structuredClone(runMetadata.originContext.messages),
+      ...fallbackGeneratedMessages,
+    ]
+    state.backgroundContinuationContexts = state.backgroundContinuationContexts || {}
+    for (const delegationId of runMetadata.backgroundDelegationIds) {
+      state.backgroundContinuationContexts[delegationId] = {
+        ...runMetadata.originContext,
+        delegationId,
+        originRunId: chunk.run_id,
+        messages: structuredClone(messages),
+      }
+    }
+    bridgeLogger.info({
+      sessionId,
+      runId: chunk.run_id,
+      delegationIds: [...runMetadata.backgroundDelegationIds],
+      messageCount: messages.length,
+      source: exactMessages ? 'bridge-result' : 'local-fallback',
+    }, '[chat-run-socket] captured process-local background continuation context')
+  }
   updateSessionStats(sessionId)
   await delay(BRIDGE_USAGE_FLUSH_DELAY_MS)
   const usage = await calcAndUpdateUsage(sessionId, state, emit)

--- a/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
@@ -46,7 +46,7 @@ import { buildCompressedHistory, getOrCreateSession } from './compression'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
 import { buildOutboundRunEvent } from './resume-payload'
 import { estimateUsageTokensFromMessages } from './usage'
-import type { ChatCodingAgentId, ContentBlock, QueuedRun, SessionState } from './types'
+import type { BackgroundContinuationContext, ChatCodingAgentId, ContentBlock, QueuedRun, SessionState } from './types'
 import { completeWorkspaceRunCheckpoint, startWorkspaceRunCheckpoint } from './workspace-diff-tracker'
 
 export interface EkkoAgentRunSocketData {
@@ -391,6 +391,7 @@ export async function handleEkkoAgentRun(
   sessionMap: Map<string, SessionState>,
   dequeueNextQueuedRun: (socket: Socket, sessionId: string, fallbackProfile?: string) => boolean,
   skipUserMessage = false,
+  backgroundContinuationContext?: BackgroundContinuationContext,
 ) {
   const sessionId = String(data.session_id || '').trim()
   if (!sessionId) {
@@ -658,6 +659,14 @@ export async function handleEkkoAgentRun(
       event.status === 'interrupted' ||
       scheduledBackgroundContinuations.has(event.subagentId)
     ) return
+    if (!event.continuationContext) {
+      logger.error(
+        '[chat-run-socket] suppressed Ekko background callback %s for session %s because its origin context is missing',
+        event.subagentId,
+        sessionId,
+      )
+      return
+    }
     scheduledBackgroundContinuations.add(event.subagentId)
     const result = String(event.output || '').trim() || event.summary.trim() || event.outputTail.trim()
     const continuationMessage = [
@@ -691,6 +700,10 @@ export async function handleEkkoAgentRun(
       mcpServers,
       reasoningEffort,
       backgroundDelegationId: event.subagentId,
+      backgroundContinuationContext: {
+        runtime: 'ekko',
+        ...event.continuationContext,
+      },
       autonomous: true,
     }
     state.queue.push(queuedRun)
@@ -1219,36 +1232,48 @@ export async function handleEkkoAgentRun(
       user_id: authenticatedUserId,
       profile,
     }
+    const callbackContext = data.background_delegation_id
+      && backgroundContinuationContext?.runtime === 'ekko'
+      && backgroundContinuationContext.subagentId === data.background_delegation_id
+      ? backgroundContinuationContext
+      : undefined
+    if (data.background_delegation_id && !callbackContext) {
+      throw new Error(
+        `Background callback ${data.background_delegation_id} cannot continue because its origin context is unavailable.`,
+      )
+    }
     let fixedContextEstimate: Promise<number> | undefined
-    const compressedHistory = data.context_compression_enabled === false ? [] : await buildCompressedHistory(
-      sessionId,
-      profile,
-      baseUrl,
-      apiKey,
-      emit,
-      sessionMap,
-      {
-        model: modelConfig.model,
-        provider: modelConfig.provider,
-        allowHermesFallback: false,
-      },
-      async (_messages, localMessageTokens) => {
-        fixedContextEstimate ||= agent.estimateContext({
-          modelClient,
+    const compressedHistory = callbackContext
+      ? []
+      : data.context_compression_enabled === false ? [] : await buildCompressedHistory(
+        sessionId,
+        profile,
+        baseUrl,
+        apiKey,
+        emit,
+        sessionMap,
+        {
           model: modelConfig.model,
-          modelDefaults: { model: modelConfig.model },
-          messages: instructionMessages,
-          signal: abortController.signal,
-          memoryEnabled: false,
-          toolContext,
-          metadata,
-          backgroundDelegationEnabled: data.background_delegation_enabled !== false,
-        }).then(estimate => estimate.contextTokens)
-        return (await fixedContextEstimate) + localMessageTokens
-      },
-      currentInputTokens,
-      shouldPersistUserMessage && data.display_role !== 'command',
-    )
+          provider: modelConfig.provider,
+          allowHermesFallback: false,
+        },
+        async (_messages, localMessageTokens) => {
+          fixedContextEstimate ||= agent.estimateContext({
+            modelClient,
+            model: modelConfig.model,
+            modelDefaults: { model: modelConfig.model },
+            messages: instructionMessages,
+            signal: abortController.signal,
+            memoryEnabled: false,
+            toolContext,
+            metadata,
+            backgroundDelegationEnabled: data.background_delegation_enabled !== false,
+          }).then(estimate => estimate.contextTokens)
+          return (await fixedContextEstimate) + localMessageTokens
+        },
+        currentInputTokens,
+        shouldPersistUserMessage && data.display_role !== 'command',
+      )
     const currentMessage: AgentMessage = {
       role: 'user',
       ...await toUserAgentContent(data.input),
@@ -1265,7 +1290,9 @@ export async function handleEkkoAgentRun(
       },
       messages: [
         ...instructionMessages,
-        ...await toAgentMessages(compressedHistory),
+        ...(callbackContext
+          ? structuredClone(callbackContext.messages)
+          : await toAgentMessages(compressedHistory)),
         currentMessage,
       ],
       signal: abortController.signal,
@@ -1309,6 +1336,14 @@ export async function handleEkkoAgentRun(
       },
       toolContext,
       metadata,
+      ...(callbackContext
+        ? {
+            contextKey: `${sessionId}:background-callback:${callbackContext.subagentId}`,
+            memoryEnabled: false,
+            ephemeralContext: true,
+            skillReviewEnabled: false,
+          }
+        : {}),
       backgroundDelegationEnabled: data.background_delegation_enabled !== false,
     })
     assistantText = result.output.content || assistantText

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -35,6 +35,7 @@ import {
 import { contentBlocksToString } from './content-blocks'
 import { buildOutboundRunEvent, buildResumeEvents, buildResumeMessages } from './resume-payload'
 import type {
+  BackgroundContinuationContext,
   ChatCodingAgentId,
   ContentBlock,
   QueueInsertionControl,
@@ -785,6 +786,7 @@ export class ChatRunSocket {
     },
     profile: string,
     skipUserMessage = false,
+    backgroundContinuationContext?: BackgroundContinuationContext,
   ) {
     const source = resolveRunSource(data.source, data.session_id)
     if (data.session_id) {
@@ -885,6 +887,7 @@ export class ChatRunSocket {
         skipUserMessage,
         loadSessionStateFromDb,
         this.dequeueNextQueuedRun.bind(this),
+        backgroundContinuationContext,
       )
       return
     }
@@ -914,6 +917,7 @@ export class ChatRunSocket {
         this.sessionMap,
         this.dequeueNextQueuedRun.bind(this),
         skipUserMessage,
+        backgroundContinuationContext,
       )
       return
     }
@@ -1534,6 +1538,13 @@ export class ChatRunSocket {
 
   private runQueuedItem(socket: Socket, sessionId: string, next: QueuedRun, fallbackProfile = 'default') {
     const skipUserMessage = next.displayInput === null
+    const backgroundContinuationContext = next.backgroundContinuationContext
+      || (next.backgroundDelegationId
+        ? this.sessionMap.get(sessionId)?.backgroundContinuationContexts?.[next.backgroundDelegationId]
+        : undefined)
+    const runProfile = backgroundContinuationContext?.runtime === 'hermes'
+      ? backgroundContinuationContext.profile
+      : next.profile || fallbackProfile
     void this.handleRun(socket, {
       input: next.input,
       display_input: next.displayInput,
@@ -1571,7 +1582,7 @@ export class ChatRunSocket {
       background_delegation_id: next.backgroundDelegationId,
       background_claim_id: next.backgroundClaimId,
       autonomous: next.autonomous,
-    }, next.profile || fallbackProfile, skipUserMessage)
+    }, runProfile, skipUserMessage, backgroundContinuationContext)
   }
 
   // --- Helpers ---

--- a/packages/server/src/services/hermes/run-chat/session-command.ts
+++ b/packages/server/src/services/hermes/run-chat/session-command.ts
@@ -688,6 +688,7 @@ export async function handleSessionCommand(
         }
         const deleted = clearSessionMessages(sessionId)
         state.messages = []
+        state.backgroundContinuationContexts = undefined
         clearTransientRunState(state)
         await calcAndUpdateUsage(sessionId, state, (event, payload) => {
           emitToSession(ctx.nsp, ctx.socket, sessionId, event, payload)
@@ -963,6 +964,7 @@ export async function handleSessionCommand(
         state.bridgeOutput = undefined
         state.bridgePendingTools = undefined
         state.bridgeCompressionResults = undefined
+        state.backgroundContinuationContexts = undefined
         replaceState(ctx.sessionMap, sessionId, 'session.command', {
           event: 'session.command',
           action: 'destroy',

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -1,4 +1,24 @@
 import type { ChatMessage } from '../../../lib/context-compressor'
+import type { EkkoBackgroundContinuationContext } from '../../../../../ekko-agent/src'
+
+export interface HermesBackgroundContinuationContext {
+  runtime: 'hermes'
+  version: 1
+  delegationId: string
+  sessionId: string
+  originRunId: string
+  messages: ChatMessage[]
+  model?: string
+  provider?: string
+  profile: string
+  instructions?: string
+  workspace?: string | null
+  reasoningEffort?: string
+}
+
+export type BackgroundContinuationContext =
+  | ({ runtime: 'ekko' } & EkkoBackgroundContinuationContext)
+  | HermesBackgroundContinuationContext
 
 /**
  * Content block types for Anthropic-compatible message format
@@ -64,6 +84,8 @@ export interface QueuedRun {
   reasoningEffort?: string
   backgroundDelegationId?: string
   backgroundClaimId?: string
+  /** Internal-only origin history for a background callback. Never accepted from socket input. */
+  backgroundContinuationContext?: BackgroundContinuationContext
   autonomous?: boolean
 }
 
@@ -134,6 +156,8 @@ export interface SessionState {
   bridgeCompressionResults?: Record<string, BridgeCompressionResult>
   backgroundTasks?: Record<string, Record<string, unknown>>
   backgroundDelegations?: Record<string, BackgroundDelegationState>
+  /** Process-local by design; callbacks after a Studio restart are rejected instead of using live history. */
+  backgroundContinuationContexts?: Record<string, BackgroundContinuationContext>
 }
 
 export interface ResponseRunState {

--- a/tests/ekko-agent/runtime.test.ts
+++ b/tests/ekko-agent/runtime.test.ts
@@ -489,8 +489,89 @@ describe('ekko-agent runtime', () => {
         outputTokens: 3,
         cacheReadTokens: 5,
         reasoningTokens: 2,
+        continuationContext: expect.objectContaining({
+          version: 1,
+          originRunId: result.runId,
+          originStep: 1,
+          memoryPolicy: 'disabled',
+          messages: expect.arrayContaining([
+            expect.objectContaining({ role: 'assistant', toolCalls: expect.any(Array) }),
+            expect.objectContaining({ role: 'tool', toolCallId: 'delegate-bg' }),
+          ]),
+        }),
       }),
     ]))
+  })
+
+  it('waits for the complete parent tool batch before publishing a fast background result', async () => {
+    const tools = new AgentToolRegistry()
+    tools.register(new DelegateTaskTool())
+    let releaseSlowTool!: () => void
+    let slowToolStarted!: () => void
+    const slowToolStart = new Promise<void>((resolve) => {
+      slowToolStarted = resolve
+    })
+    const slowToolRelease = new Promise<void>((resolve) => {
+      releaseSlowTool = resolve
+    })
+    tools.register({
+      definition: {
+        name: 'slow_echo',
+        parameters: { type: 'object', properties: {} },
+      },
+      async execute() {
+        slowToolStarted()
+        await slowToolRelease
+        return { ok: true, content: 'slow tool finished' }
+      },
+    })
+    const client = modelClient((_request, call) => {
+      if (call === 1) {
+        return {
+          content: '',
+          toolCalls: [
+            {
+              id: 'delegate-fast',
+              name: 'delegate_task',
+              arguments: { goal: 'Finish immediately', mode: 'background' },
+            },
+            {
+              id: 'slow-sibling',
+              name: 'slow_echo',
+              arguments: {},
+            },
+          ],
+          finishReason: 'tool_calls',
+        }
+      }
+      if (call === 2) return { content: 'Fast child result', finishReason: 'stop' }
+      return { content: 'Parent finished its tool batch', finishReason: 'stop' }
+    })
+    const runtime = new AgentRuntime({ modelClient: client, tools })
+    const events: any[] = []
+
+    const parentRun = runtime.run({
+      messages: ['Start both tools'],
+      metadata: { session_id: 'fast-background-session' },
+      onEvent: event => events.push(event),
+    })
+    await slowToolStart
+    await Promise.resolve()
+    expect(events.some(event => event.type === 'subagent.complete')).toBe(false)
+
+    releaseSlowTool()
+    await parentRun
+    await vi.waitFor(() => {
+      expect(events.some(event => event.type === 'subagent.complete')).toBe(true)
+    })
+    const completed = events.find(event => event.type === 'subagent.complete')
+    expect(completed.continuationContext.messages.map((message: any) => message.role))
+      .toEqual(['user', 'assistant', 'tool', 'tool'])
+    expect(completed.continuationContext.messages.filter((message: any) => message.role === 'tool'))
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({ toolCallId: 'delegate-fast' }),
+        expect.objectContaining({ toolCallId: 'slow-sibling', content: 'slow tool finished' }),
+      ]))
   })
 
   it('removes and rejects background delegation when the run disables it', async () => {

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -1825,4 +1825,202 @@ describe('bridge run final context usage', () => {
       text: 'Retrying in 3.0s (attempt 1/3)...',
     }))
   })
+
+  it('captures the Hermes parent history for background callbacks in process memory', async () => {
+    const emit = vi.fn()
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    const state = makeState()
+    const sessionMap = new Map([['session-1', state]])
+    recordBridgeToolCompletedMock.mockReturnValue({
+      id: 'delegate-call',
+      messageId: 77,
+      output: JSON.stringify({
+        mode: 'background',
+        delegation_id: 'delegation-1',
+        status: 'dispatched',
+      }),
+    })
+    const exactMessages = [
+      { role: 'user', content: 'previous' },
+      { role: 'user', content: 'start a background task' },
+      { role: 'assistant', content: '', tool_calls: [{ id: 'delegate-call' }] },
+      { role: 'tool', content: 'dispatched', tool_call_id: 'delegate-call' },
+      { role: 'assistant', content: 'The background task is running.' },
+    ]
+    const bridge = {
+      chat: vi.fn().mockResolvedValue({ run_id: 'origin-run', status: 'started' }),
+      contextEstimate: vi.fn().mockResolvedValue({ token_count: 100, message_count: 2 }),
+      streamOutput: vi.fn(async function* () {
+        yield {
+          run_id: 'origin-run',
+          done: true,
+          status: 'completed',
+          output: 'The background task is running.',
+          result: { messages: exactMessages },
+          events: [{
+            event: 'tool.completed',
+            tool_name: 'delegate_task',
+            output: JSON.stringify({
+              mode: 'background',
+              delegation_id: 'delegation-1',
+              status: 'dispatched',
+            }),
+          }],
+        }
+      }),
+    } as any
+
+    const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    await handleBridgeRun(
+      nsp,
+      socket,
+      { input: 'start a background task', session_id: 'session-1', reasoning_effort: 'high' },
+      'default',
+      sessionMap,
+      bridge,
+      false,
+      vi.fn(),
+      vi.fn(),
+    )
+
+    expect(state.backgroundContinuationContexts['delegation-1']).toEqual(expect.objectContaining({
+      runtime: 'hermes',
+      version: 1,
+      delegationId: 'delegation-1',
+      sessionId: 'session-1',
+      originRunId: 'origin-run',
+      model: 'gpt-test',
+      provider: 'openai',
+      profile: 'default',
+      reasoningEffort: 'high',
+      messages: exactMessages,
+    }))
+  })
+
+  it('runs a Hermes background callback from its origin history instead of later messages', async () => {
+    const emit = vi.fn()
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    const state = makeState()
+    const sessionMap = new Map([['session-1', state]])
+    state.messages.push({
+      id: 9,
+      session_id: 'session-1',
+      role: 'user',
+      content: 'later B/C conversation',
+      timestamp: 2,
+    })
+    const callbackContext = {
+      runtime: 'hermes' as const,
+      version: 1 as const,
+      delegationId: 'delegation-1',
+      sessionId: 'session-1',
+      originRunId: 'origin-run',
+      messages: [
+        { role: 'user', content: 'original A request' },
+        { role: 'assistant', content: 'I started the background task.' },
+      ],
+      model: 'origin-model',
+      provider: 'origin-provider',
+      profile: 'default',
+      instructions: 'origin system instructions',
+      workspace: null,
+      reasoningEffort: 'high',
+    }
+    state.backgroundContinuationContexts = { 'delegation-1': callbackContext }
+    resolveBridgeRunModelConfigMock.mockResolvedValueOnce({ model: 'origin-model', provider: 'origin-provider' })
+    const bridge = {
+      chat: vi.fn().mockResolvedValue({ run_id: 'callback-run', status: 'started' }),
+      completeBackgroundNotification: vi.fn().mockResolvedValue(undefined),
+      contextEstimate: vi.fn().mockResolvedValue({ token_count: 100, message_count: 2 }),
+      streamOutput: vi.fn(async function* () {
+        yield { run_id: 'callback-run', done: true, status: 'completed', output: 'callback answer' }
+      }),
+    } as any
+
+    const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    await handleBridgeRun(
+      nsp,
+      socket,
+      {
+        input: 'Background subtask result: finished',
+        display_input: null,
+        session_id: 'session-1',
+        background_delegation_id: 'delegation-1',
+        background_claim_id: 'claim-1',
+        autonomous: true,
+      },
+      'default',
+      sessionMap,
+      bridge,
+      true,
+      vi.fn(),
+      vi.fn(),
+      callbackContext,
+    )
+
+    expect(buildCompressedHistoryMock).not.toHaveBeenCalled()
+    expect(bridge.chat).toHaveBeenCalledWith(
+      'session-1',
+      'Background subtask result: finished',
+      callbackContext.messages,
+      'origin system instructions',
+      'default',
+      expect.objectContaining({
+        model: 'origin-model',
+        provider: 'origin-provider',
+        reasoning_effort: 'high',
+      }),
+    )
+    expect(bridge.chat.mock.calls[0][2]).not.toContainEqual(expect.objectContaining({
+      content: 'later B/C conversation',
+    }))
+    expect(state.backgroundContinuationContexts['delegation-1']).toBeUndefined()
+  })
+
+  it('rejects a recovered Hermes callback when its process-local origin history is gone', async () => {
+    const emit = vi.fn()
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    const state = makeState()
+    const sessionMap = new Map([['session-1', state]])
+    const bridge = {
+      chat: vi.fn(),
+      completeBackgroundNotification: vi.fn().mockResolvedValue(undefined),
+    } as any
+
+    const { handleBridgeRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-bridge-run')
+    await handleBridgeRun(
+      nsp,
+      socket,
+      {
+        input: 'Background subtask result: finished',
+        display_input: null,
+        session_id: 'session-1',
+        background_delegation_id: 'delegation-after-restart',
+        background_claim_id: 'claim-after-restart',
+        autonomous: true,
+      },
+      'default',
+      sessionMap,
+      bridge,
+      true,
+      vi.fn(),
+      vi.fn(),
+    )
+
+    expect(buildCompressedHistoryMock).not.toHaveBeenCalled()
+    expect(bridge.chat).not.toHaveBeenCalled()
+    expect(bridge.completeBackgroundNotification).toHaveBeenCalledWith(
+      'session-1',
+      'default',
+      'delegation-after-restart',
+      'claim-after-restart',
+    )
+    expect(emit).toHaveBeenCalledWith('run.failed', expect.objectContaining({
+      delegation_id: 'delegation-after-restart',
+      error: expect.stringContaining('origin context is unavailable'),
+    }))
+  })
 })

--- a/tests/server/run-chat-ekko-context.test.ts
+++ b/tests/server/run-chat-ekko-context.test.ts
@@ -126,6 +126,20 @@ function makeHarness() {
   return { nsp, socket, sessionMap, state, events }
 }
 
+function continuationContext(subagentId = 'child-background') {
+  return {
+    version: 1 as const,
+    subagentId,
+    originRunId: 'run-parent',
+    originStep: 1,
+    messages: [
+      { role: 'user' as const, content: 'run checks in the background' },
+      { role: 'assistant' as const, content: 'Validation is running.' },
+    ],
+    memoryPolicy: 'disabled' as const,
+  }
+}
+
 describe('ekko-agent context usage events', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -888,6 +902,7 @@ describe('ekko-agent context usage events', () => {
       cacheReadTokens: 3,
       cacheWriteTokens: 2,
       reasoningTokens: 1,
+      continuationContext: continuationContext(),
     })
 
     expect(state.backgroundTasks['child-background']).toEqual(expect.objectContaining({
@@ -1003,6 +1018,7 @@ describe('ekko-agent context usage events', () => {
         cacheReadTokens: 0,
         cacheWriteTokens: 0,
         reasoningTokens: 0,
+        continuationContext: continuationContext(),
       })
       expect(dequeueNextQueuedRun).not.toHaveBeenCalled()
       return {
@@ -1049,7 +1065,14 @@ describe('ekko-agent context usage events', () => {
       }
     })
     const { handleEkkoAgentRun } = await import('../../packages/server/src/services/hermes/run-chat/handle-ekko-agent-run')
-    const { nsp, socket, sessionMap, events } = makeHarness()
+    const { nsp, socket, sessionMap, state, events } = makeHarness()
+    state.messages.push({
+      id: 99,
+      session_id: 'session-1',
+      role: 'user',
+      content: 'This message was sent after the background task started.',
+      timestamp: 2,
+    })
 
     await handleEkkoAgentRun(nsp as any, socket as any, {
       session_id: 'session-1',
@@ -1060,7 +1083,26 @@ describe('ekko-agent context usage events', () => {
       autonomous: true,
       background_delegation_id: 'child-background',
       onEvent: (event: string, payload: any) => events.push({ event, payload }),
-    }, 'default', sessionMap, vi.fn(() => false), true)
+    }, 'default', sessionMap, vi.fn(() => false), true, {
+      runtime: 'ekko',
+      ...continuationContext(),
+    })
+
+    expect(buildCompressedHistoryMock).not.toHaveBeenCalled()
+    expect(agentRunMock).toHaveBeenCalledWith(expect.objectContaining({
+      contextKey: 'session-1:background-callback:child-background',
+      memoryEnabled: false,
+      ephemeralContext: true,
+      skillReviewEnabled: false,
+      messages: expect.arrayContaining([
+        expect.objectContaining({ role: 'user', content: 'run checks in the background' }),
+        expect.objectContaining({ role: 'user', content: 'Background subtask result: Validation passed.' }),
+      ]),
+    }))
+    const callbackMessages = agentRunMock.mock.calls[0][0].messages
+    expect(callbackMessages).not.toContainEqual(expect.objectContaining({
+      content: 'This message was sent after the background task started.',
+    }))
 
     expect(events).toEqual(expect.arrayContaining([
       expect.objectContaining({


### PR DESCRIPTION
## Summary

- freeze embedded Ekko callback history at the originating tool-batch boundary
- keep Hermes callback snapshots in process-local session state and reject recovered callbacks when the snapshot was lost after restart
- bypass live history, memory, and skill review for callback continuation runs
- add regression coverage and update the callback-context design notes
- regenerate docs/openapi.json

The standalone ekko-agent repository is intentionally out of scope.

## Validation

- targeted tests: 98 passed
- full test suite: 503 files passed, 4271 tests passed
- npm run build
- npm run harness:check
- server and embedded Ekko TypeScript checks
- manual Hermes/Ekko callback verification with intervening conversation turns