### PR TITLE
fix(chat): heal stale bridge session titles from Hermes state.db

### DIFF
--- a/packages/server/src/bootstrap/session-agent-runtime-adapter.ts
+++ b/packages/server/src/bootstrap/session-agent-runtime-adapter.ts
@@ -10,7 +10,7 @@ import {
   listSessionSummaries,
   listSessionSummaryGroups,
 } from '../modules/hermes/services/history/sessions-db'
-import { deleteSessionForProfile, getSession } from '../modules/hermes/services/runtime/cli'
+import { deleteSessionForProfile, getSession, renameSessionForProfile } from '../modules/hermes/services/runtime/cli'
 import { getModelContextLength } from '../modules/hermes/services/models/context'
 import { configureSessionAgentRuntime } from '../modules/studio/public/session-agent-runtime'
 
@@ -25,6 +25,7 @@ configureSessionAgentRuntime({
   getHermesUsageStats: getUsageStatsFromDb,
   listHermesSessionSummaries: listSessionSummaries,
   listHermesSessionSummaryGroups: listSessionSummaryGroups,
+  renameHermesSessionForProfile: renameSessionForProfile,
   notifyHermesSessionModelChanged: async (sessionId, model, provider, profile) => {
     const state = getAgentBridgeManager().getRuntimeState()
     if (!state.ready || !state.running) return

--- a/packages/server/src/modules/hermes/services/runtime/cli.ts
+++ b/packages/server/src/modules/hermes/services/runtime/cli.ts
@@ -396,6 +396,26 @@ export async function renameSession(id: string, title: string): Promise<boolean>
   }
 }
 
+/**
+ * Rename a session title in a specific Hermes profile's state.db.
+ */
+export async function renameSessionForProfile(id: string, profile: string, title: string): Promise<boolean> {
+  try {
+    await execHermesWithBin(resolveHermesBin(), ['sessions', 'rename', id, title], {
+      timeout: 10000,
+      ...execOpts,
+      env: {
+        ...process.env,
+        HERMES_HOME: getProfileDir(profile),
+      },
+    })
+    return true
+  } catch (err: any) {
+    logger.error({ err, sessionId: id, profile }, 'Hermes CLI: profile session rename failed')
+    return false
+  }
+}
+
 export interface LogFileInfo {
   name: string
   size: string

--- a/packages/server/src/modules/studio/controllers/sessions.ts
+++ b/packages/server/src/modules/studio/controllers/sessions.ts
@@ -10,6 +10,7 @@ import {
   listHermesSessionSummaries,
   listHermesSessionSummaryGroups,
   notifyHermesSessionModelChanged,
+  renameHermesSessionForProfile,
   stopCodingAgentSessionRun,
 } from '../public/session-agent-runtime'
 import {
@@ -25,6 +26,8 @@ import {
   addMessages as localAddMessages,
   updateSession as localUpdateSession,
   updateSessionStats as localUpdateSessionStats,
+  isReplaceableLocalTitle,
+  normalizeSessionTitleText,
 } from '../public/sessions'
 import { buildDbExportHistory, ExportCompressor } from '../services/context-compressor/export-compressor'
 import { getLocalUsageStats, getRecordedUsageSessionIds, getUsage, getUsageBatch } from '../public/sessions'
@@ -467,6 +470,38 @@ export async function getConversationMessages(ctx: any) {
   }
 }
 
+// Sessions owned by the Hermes Agent: state.db is the canonical store for
+// their titles (same rule as mergeHermesHistorySessions).
+const BRIDGE_TITLE_SOURCES = new Set(['cli', 'global_agent'])
+
+/**
+ * Chat sidebar titles come from the Studio-local cache, which only follows
+ * live session.title.updated events. A missed event strands the fallback
+ * title, and a garbage auto-title (e.g. a bare code fence) can never be
+ * repaired by a later event because it no longer looks replaceable. Heal
+ * replaceable local titles from Hermes state.db on list; titles a user set
+ * explicitly are not replaceable and are left alone.
+ */
+async function reconcileBridgeSessionTitles(profile: string | undefined, sessions: any[]): Promise<void> {
+  const bridgeSessions = sessions.filter(session => BRIDGE_TITLE_SOURCES.has(String(session.source || '')))
+  if (bridgeSessions.length === 0) return
+  let summaries: Array<{ id: string; title?: string | null }>
+  try {
+    summaries = await listHermesSessionSummaries(undefined, 10_000, profile)
+  } catch (err: any) {
+    logger.warn({ err }, '[sessions] bridge session title reconciliation skipped')
+    return
+  }
+  const canonicalTitles = new Map(summaries.map(summary => [summary.id, normalizeSessionTitleText(summary.title)]))
+  for (const session of bridgeSessions) {
+    const canonical = canonicalTitles.get(session.id)
+    if (!canonical || canonical === normalizeSessionTitleText(session.title)) continue
+    if (!isReplaceableLocalTitle(session.id)) continue
+    localUpdateSession(session.id, { title: canonical, title_source: 'llm' })
+    session.title = canonical
+  }
+}
+
 export async function list(ctx: any) {
   const source = (ctx.query.source as string) || undefined
   const limit = ctx.query.limit ? parseInt(ctx.query.limit as string, 10) : undefined
@@ -484,11 +519,13 @@ export async function list(ctx: any) {
     includeArchived: false,
     excludeSessionIds: [...getPendingDeletedSessionIds()],
   })
+  const sessions = filterPendingDeletedSessions(filterArchivedSessions(filterByAllowedProfiles(ctx, allSessions).filter(s =>
+    isRequestedSessionSource(source, s.source) &&
+    (!knownProfiles || knownProfiles.has(s.profile || 'default')),
+  )))
+  await reconcileBridgeSessionTitles(profile, sessions)
   ctx.body = {
-    sessions: filterPendingDeletedSessions(filterArchivedSessions(filterByAllowedProfiles(ctx, allSessions).filter(s =>
-      isRequestedSessionSource(source, s.source) &&
-      (!knownProfiles || knownProfiles.has(s.profile || 'default')),
-    ))),
+    sessions,
   }
 }
 
@@ -1364,6 +1401,19 @@ export async function rename(ctx: any) {
     ctx.status = 500
     ctx.body = { error: 'Failed to rename session' }
     return
+  }
+  // Agent-owned sessions live in state.db too; without this write-through the
+  // History view (state.db canonical) keeps the old name and reconciliation
+  // would undo the rename on the next sidebar load.
+  if (existing && BRIDGE_TITLE_SOURCES.has(String(existing.source || ''))) {
+    const propagated = await renameHermesSessionForProfile(
+      ctx.params.id,
+      existing.profile || requestedProfile(ctx) || 'default',
+      title.trim(),
+    )
+    if (!propagated) {
+      logger.warn({ sessionId: ctx.params.id }, '[sessions] failed to propagate bridge session rename to Hermes')
+    }
   }
   ctx.body = { ok: true }
 }

--- a/packages/server/src/modules/studio/infrastructure/database/schemas.ts
+++ b/packages/server/src/modules/studio/infrastructure/database/schemas.ts
@@ -66,6 +66,7 @@ export const SESSIONS_SCHEMA: Record<string, string> = {
   api_mode: 'TEXT NOT NULL DEFAULT \'\'',
   reasoning_effort: 'TEXT NOT NULL DEFAULT \'\'',
   title: 'TEXT',
+  title_source: 'TEXT',
   parent_session_id: 'TEXT',
   fork_point_message_id: 'TEXT',
   started_at: 'INTEGER NOT NULL',

--- a/packages/server/src/modules/studio/public/session-agent-runtime.ts
+++ b/packages/server/src/modules/studio/public/session-agent-runtime.ts
@@ -10,6 +10,7 @@ export interface SessionAgentRuntimeDependencies {
   listHermesSessionSummaries: (...args: any[]) => Promise<any[]>
   listHermesSessionSummaryGroups: (...args: any[]) => Promise<any>
   notifyHermesSessionModelChanged: (...args: any[]) => Promise<void>
+  renameHermesSessionForProfile: (id: string, profile: string, title: string) => Promise<boolean>
   stopCodingAgentSessionRun: (...args: any[]) => any
 }
 
@@ -35,4 +36,5 @@ export const getHermesUsageStats = (...args: any[]): Promise<any> => configured(
 export const listHermesSessionSummaries = (...args: any[]): Promise<any[]> => configured().listHermesSessionSummaries(...args)
 export const listHermesSessionSummaryGroups = (...args: any[]): Promise<any> => configured().listHermesSessionSummaryGroups(...args)
 export const notifyHermesSessionModelChanged = (...args: any[]): Promise<void> => configured().notifyHermesSessionModelChanged(...args)
+export const renameHermesSessionForProfile = (id: string, profile: string, title: string): Promise<boolean> => configured().renameHermesSessionForProfile(id, profile, title)
 export const stopCodingAgentSessionRun = (...args: any[]) => configured().stopCodingAgentSessionRun(...args)

--- a/packages/server/src/modules/studio/repositories/session-store.ts
+++ b/packages/server/src/modules/studio/repositories/session-store.ts
@@ -23,6 +23,8 @@ export interface HermesSessionRow {
   api_mode: string
   reasoning_effort: string
   title: string | null
+  /** Provenance of the stored title: 'user' when set through a rename, 'llm' when mirrored/generated, null for legacy rows. */
+  title_source: string | null
   parent_session_id: string | null
   fork_point_message_id: string | null
   started_at: number
@@ -125,6 +127,7 @@ function mapSessionRow(row: Record<string, unknown>): HermesSessionRow {
     api_mode: String(row.api_mode || ''),
     reasoning_effort: String(row.reasoning_effort || ''),
     title,
+    title_source: row.title_source != null ? String(row.title_source) : null,
     parent_session_id: row.parent_session_id != null ? String(row.parent_session_id) : null,
     fork_point_message_id: row.fork_point_message_id != null ? String(row.fork_point_message_id) : null,
     started_at: Number(row.started_at || 0),
@@ -205,7 +208,7 @@ export function createSession(data: {
       id: data.id, profile: data.profile || 'default', source, agent,
       agent_mode: data.agent_mode || '',
       agent_session_id: data.agent_session_id || '', agent_native_session_id: data.agent_native_session_id || '',
-      user_id: data.user_id == null ? null : String(data.user_id), model: data.model || '', provider: data.provider || '', api_mode: data.api_mode || '', reasoning_effort: data.reasoning_effort || '', title: data.title || null,
+      user_id: data.user_id == null ? null : String(data.user_id), model: data.model || '', provider: data.provider || '', api_mode: data.api_mode || '', reasoning_effort: data.reasoning_effort || '', title: data.title || null, title_source: null,
       parent_session_id: data.parent_session_id || null,
       fork_point_message_id: null,
       started_at: now, ended_at: null, end_reason: null,
@@ -476,8 +479,66 @@ export function clearSessionMessages(id: string): number {
 export function renameSession(id: string, title: string): boolean {
   if (!isSqliteAvailable()) return false
   const db = getDb()!
-  const result = db.prepare(`UPDATE ${SESSIONS_TABLE} SET title = ? WHERE id = ?`).run(title, id)
+  const result = db.prepare(`UPDATE ${SESSIONS_TABLE} SET title = ?, title_source = 'user' WHERE id = ?`).run(title, id)
   return result.changes > 0
+}
+
+export function normalizeSessionTitleText(value: unknown): string {
+  return String(value || '').replace(/\s+/g, ' ').trim()
+}
+
+export function fallbackTitleFromText(text: string, limit: number, ellipsis: boolean): string {
+  const normalized = normalizeSessionTitleText(text)
+  if (!normalized) return ''
+  if (normalized.length <= limit) return normalized
+  return ellipsis ? `${normalized.slice(0, limit)}...` : normalized.slice(0, limit)
+}
+
+/**
+ * Pure-decoration titles — a bare code fence (``` / ```json), a heading glyph,
+ * a lone dash — and truncated raw JSON ({"title, {"title" #2) are model output
+ * that carried no title at all. They must never block a later title repair the
+ * way a deliberate user rename should.
+ */
+export function isMarkdownArtifactTitle(title: string): boolean {
+  const normalized = normalizeSessionTitleText(title)
+  if (normalized.startsWith('{') || normalized.includes('"title')) return true
+  const stripped = normalized.replace(/[`#>*_~\u2014\u2013=]/g, '')
+  if (!stripped) return true
+  return /^(json|ts|js|python|sh|bash|yaml|html)$/i.test(stripped)
+}
+
+/**
+ * Whether *sessionId*'s stored title is still an auto-assigned one — empty,
+ * derived from the preview or first user message, or pure markdown
+ * decoration — rather than a name the user chose. Only replaceable titles may
+ * be healed from Hermes state.db or overwritten by a generated title.
+ */
+export function isReplaceableLocalTitle(sessionId: string): boolean {
+  const session = getSession(sessionId)
+  if (!session) return false
+  const current = normalizeSessionTitleText(session.title)
+  if (!current) return true
+  // A title the user set through a rename is authoritative; never heal it.
+  if (session.title_source === 'user') return false
+  if (isMarkdownArtifactTitle(current)) return true
+  const variants = new Set<string>([''])
+  const preview = normalizeSessionTitleText(session.preview)
+  if (preview) {
+    variants.add(preview)
+    variants.add(fallbackTitleFromText(preview, 40, true))
+    variants.add(fallbackTitleFromText(preview, 63, false))
+    variants.add(fallbackTitleFromText(preview, 100, false))
+  }
+  const firstUser = getFirstSessionMessageByRole(sessionId, 'user')
+  const firstUserText = normalizeSessionTitleText(firstUser?.content)
+  if (firstUserText) {
+    variants.add(firstUserText)
+    variants.add(fallbackTitleFromText(firstUserText, 40, true))
+    variants.add(fallbackTitleFromText(firstUserText, 63, false))
+    variants.add(fallbackTitleFromText(firstUserText, 100, false))
+  }
+  return variants.has(current)
 }
 
 export function setSessionArchived(id: string, archived: boolean): boolean {

--- a/packages/server/src/modules/studio/services/chat-run/handle-bridge-run.ts
+++ b/packages/server/src/modules/studio/services/chat-run/handle-bridge-run.ts
@@ -5,7 +5,7 @@
 
 import type { Server, Socket } from 'socket.io'
 import { getSystemPrompt } from '../../public/runs/prompt'
-import { getFirstSessionMessageByRole, getSession, getSessionMessageCountByRole, createSession, addMessage, updateSession, updateSessionStats } from '../../repositories/session-store'
+import { fallbackTitleFromText, getFirstSessionMessageByRole, getSession, getSessionMessageCountByRole, isReplaceableLocalTitle, normalizeSessionTitleText as normalizeTitleText, createSession, addMessage, updateSession, updateSessionStats } from '../../repositories/session-store'
 import { logger, bridgeLogger } from '../../public/logging'
 import { normalizeTokenUsage, recordSessionUsage } from '../usage/usage-recorder'
 import type {
@@ -105,41 +105,6 @@ function backgroundPendingCount(state: SessionState): number {
     .length
 }
 
-function normalizeTitleText(value: unknown): string {
-  return String(value || '').replace(/\s+/g, ' ').trim()
-}
-
-function fallbackTitleFromText(text: string, limit: number, ellipsis: boolean): string {
-  const normalized = normalizeTitleText(text)
-  if (!normalized) return ''
-  if (normalized.length <= limit) return normalized
-  return ellipsis ? `${normalized.slice(0, limit)}...` : normalized.slice(0, limit)
-}
-
-function isReplaceableLocalTitle(sessionId: string): boolean {
-  const session = getSession(sessionId)
-  if (!session) return false
-  const current = normalizeTitleText(session.title)
-  if (!current) return true
-  const variants = new Set<string>([''])
-  const preview = normalizeTitleText(session.preview)
-  if (preview) {
-    variants.add(preview)
-    variants.add(fallbackTitleFromText(preview, 40, true))
-    variants.add(fallbackTitleFromText(preview, 63, false))
-    variants.add(fallbackTitleFromText(preview, 100, false))
-  }
-  const firstUser = getFirstSessionMessageByRole(sessionId, 'user')
-  const firstUserText = normalizeTitleText(firstUser?.content)
-  if (firstUserText) {
-    variants.add(firstUserText)
-    variants.add(fallbackTitleFromText(firstUserText, 40, true))
-    variants.add(fallbackTitleFromText(firstUserText, 63, false))
-    variants.add(fallbackTitleFromText(firstUserText, 100, false))
-  }
-  return variants.has(current)
-}
-
 function isBridgeSessionSource(source?: string | null): boolean {
   return source === 'cli' || source === 'global_agent'
 }
@@ -156,6 +121,7 @@ function syncBridgeGeneratedTitle(sessionId: string, title: unknown, emit: (even
   if (normalizeTitleText(session.title) === nextTitle) return false
   updateSession(sessionId, {
     title: nextTitle,
+    title_source: 'llm',
     last_active: Math.floor(Date.now() / 1000),
   } as any)
   emit('session.title.updated', {

--- a/tests/server/session-store-title-heuristics.test.ts
+++ b/tests/server/session-store-title-heuristics.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { isMarkdownArtifactTitle, normalizeSessionTitleText } from '../../packages/server/src/modules/studio/repositories/session-store'
+
+describe('isMarkdownArtifactTitle', () => {
+  it('flags bare markdown decoration as an artifact', () => {
+    expect(isMarkdownArtifactTitle('```')).toBe(true)
+    expect(isMarkdownArtifactTitle('```json')).toBe(true)
+    expect(isMarkdownArtifactTitle('##')).toBe(true)
+    expect(isMarkdownArtifactTitle('—')).toBe(true)
+    expect(isMarkdownArtifactTitle('')).toBe(true)
+  })
+
+  it('flags truncated raw JSON from a non-compliant provider as an artifact', () => {
+    expect(isMarkdownArtifactTitle('{"title')).toBe(true)
+    expect(isMarkdownArtifactTitle('{"title" #2')).toBe(true)
+  })
+
+  it('keeps real titles', () => {
+    expect(isMarkdownArtifactTitle('领夹麦选购咨询')).toBe(false)
+    expect(isMarkdownArtifactTitle('Fix login button on mobile')).toBe(false)
+    expect(isMarkdownArtifactTitle('#1 in queue')).toBe(false)
+  })
+
+  it('normalizes whitespace and newlines', () => {
+    expect(normalizeSessionTitleText('  a\n b  ')).toBe('a b')
+  })
+})

--- a/tests/server/session-store-title-source.test.ts
+++ b/tests/server/session-store-title-source.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const sessionRow = vi.fn()
+  const firstUserRow = vi.fn()
+  const renameRun = vi.fn()
+  const prepare = vi.fn((sql: string) => {
+    if (sql.includes('SELECT * FROM sessions WHERE id = ?')) return { get: sessionRow }
+    if (sql.includes('FROM messages') && sql.includes('role = ?')) return { get: firstUserRow }
+    if (sql.includes('UPDATE sessions SET title')) return { run: renameRun }
+    throw new Error(`unexpected SQL: ${sql}`)
+  })
+  return { sessionRow, firstUserRow, renameRun, prepare }
+})
+
+vi.mock('../../packages/server/src/modules/studio/infrastructure/database', () => ({
+  isSqliteAvailable: vi.fn(() => true),
+  getDb: vi.fn(() => ({ prepare: mocks.prepare })),
+}))
+
+import { isReplaceableLocalTitle, renameSession } from '../../packages/server/src/modules/studio/repositories/session-store'
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 's1', profile: 'default', source: 'cli', agent: 'hermes', agent_mode: '',
+    agent_session_id: '', agent_native_session_id: '', user_id: null, model: '',
+    provider: '', api_mode: '', reasoning_effort: '', title: null, title_source: null,
+    parent_session_id: null, fork_point_message_id: null, started_at: 1, ended_at: null,
+    end_reason: null, message_count: 1, tool_call_count: 0, input_tokens: 0,
+    output_tokens: 0, cache_read_tokens: 0, cache_write_tokens: 0, reasoning_tokens: 0,
+    billing_provider: null, estimated_cost_usd: 0, actual_cost_usd: null, cost_status: '',
+    preview: '', last_active: 1, is_archived: 0, push_enabled: 0, workspace: null,
+    category_id: null, history_revision: 0, ...overrides,
+  }
+}
+
+describe('session title provenance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.sessionRow.mockReturnValue(row({ title: '有什么推荐的领夹麦？' }))
+    mocks.firstUserRow.mockReturnValue({ content: '有什么推荐的领夹麦？' })
+  })
+
+  it('never heals a title the user set through a rename', () => {
+    mocks.sessionRow.mockReturnValue(row({ title: '我的自定义标题', title_source: 'user' }))
+    expect(isReplaceableLocalTitle('s1')).toBe(false)
+  })
+
+  it('treats legacy auto titles that match the first user message as replaceable', () => {
+    expect(isReplaceableLocalTitle('s1')).toBe(true)
+  })
+
+  it('treats garbage titles without provenance as replaceable', () => {
+    mocks.sessionRow.mockReturnValue(row({ title: '```', title_source: 'llm' }))
+    expect(isReplaceableLocalTitle('s1')).toBe(true)
+  })
+
+  it('marks renames as user-set provenance', () => {
+    mocks.renameRun.mockReturnValue({ changes: 1 })
+    expect(renameSession('s1', '新标题')).toBe(true)
+    expect(mocks.renameRun).toHaveBeenCalledWith('新标题', 's1')
+    expect(String(mocks.prepare.mock.calls.find(([sql]: any[]) => String(sql).includes('UPDATE sessions SET title'))?.[0])).toContain("title_source = 'user'")
+  })
+})

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -15,6 +15,8 @@ const getExactSessionDetailFromDbWithProfileMock = vi.fn()
 const getUsageStatsFromDbMock = vi.fn()
 const getSessionMock = vi.fn()
 const deleteHermesSessionForProfileMock = vi.fn()
+const renameHermesSessionForProfileMock = vi.fn()
+const isReplaceableLocalTitleMock = vi.fn()
 const localListSessionsMock = vi.fn()
 const localGetSessionDetailMock = vi.fn()
 const localSearchSessionsMock = vi.fn()
@@ -106,6 +108,8 @@ vi.mock('../../packages/server/src/modules/studio/repositories/session-store', (
   getSession: getSessionMock,
   updateSession: localUpdateSessionMock,
   updateSessionStats: localUpdateSessionStatsMock,
+  isReplaceableLocalTitle: isReplaceableLocalTitleMock,
+  normalizeSessionTitleText: (value: unknown) => String(value || '').replace(/\s+/g, ' ').trim(),
 }))
 
 vi.mock('../../packages/server/src/modules/studio/repositories/session-category-store', () => ({
@@ -234,6 +238,7 @@ vi.mock('../../packages/server/src/modules/studio/public/session-agent-runtime',
       profile,
     )
   },
+  renameHermesSessionForProfile: renameHermesSessionForProfileMock,
   stopCodingAgentSessionRun: codingAgentRunManagerMock.stop,
 }))
 
@@ -250,6 +255,7 @@ describe('session conversations controller', () => {
     listConversationSummariesMock.mockReset()
     getConversationDetailMock.mockReset()
     listSessionSummariesMock.mockReset()
+    listSessionSummariesMock.mockResolvedValue([])
     listSessionSummaryGroupsMock.mockReset()
     getSessionDetailFromDbMock.mockReset()
     getSessionDetailFromDbWithProfileMock.mockReset()
@@ -257,6 +263,10 @@ describe('session conversations controller', () => {
     getUsageStatsFromDbMock.mockReset()
     getSessionMock.mockReset()
     deleteHermesSessionForProfileMock.mockReset()
+    renameHermesSessionForProfileMock.mockReset()
+    renameHermesSessionForProfileMock.mockResolvedValue(true)
+    isReplaceableLocalTitleMock.mockReset()
+    isReplaceableLocalTitleMock.mockReturnValue(false)
     localListSessionsMock.mockReset()
     localGetSessionDetailMock.mockReset()
     localSearchSessionsMock.mockReset()
@@ -1059,6 +1069,82 @@ describe('session conversations controller', () => {
       excludeSessionIds: [],
     })
     expect(workflowCtx.body.sessions).toEqual([expect.objectContaining({ id: 'workflow-1', source: 'workflow' })])
+  })
+
+  it('heals a stale bridge session title from Hermes state.db on list', async () => {
+    localListSessionsMock.mockReturnValue([
+      { id: 'cli-1', profile: 'default', source: 'cli', title: '有什么推荐的领夹麦？' },
+    ])
+    listSessionSummariesMock.mockResolvedValue([
+      { id: 'cli-1', source: 'cli', title: '领夹麦选购咨询' },
+    ])
+    isReplaceableLocalTitleMock.mockReturnValue(true)
+
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = { query: {}, state: {}, body: null }
+    await mod.list(ctx)
+
+    expect(ctx.body.sessions[0].title).toBe('领夹麦选购咨询')
+    expect(localUpdateSessionMock).toHaveBeenCalledWith('cli-1', { title: '领夹麦选购咨询', title_source: 'llm' })
+  })
+
+  it('heals a garbage bridge session title that later events can no longer replace', async () => {
+    localListSessionsMock.mockReturnValue([
+      { id: 'cli-2', profile: 'default', source: 'cli', title: '```' },
+    ])
+    listSessionSummariesMock.mockResolvedValue([
+      { id: 'cli-2', source: 'cli', title: 'NPD 人格与 Hermes 标题生成 bug 排查' },
+    ])
+    isReplaceableLocalTitleMock.mockReturnValue(true)
+
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = { query: {}, state: {}, body: null }
+    await mod.list(ctx)
+
+    expect(ctx.body.sessions[0].title).toBe('NPD 人格与 Hermes 标题生成 bug 排查')
+  })
+
+  it('keeps a user-renamed bridge session title during reconciliation', async () => {
+    localListSessionsMock.mockReturnValue([
+      { id: 'cli-3', profile: 'default', source: 'cli', title: '我的自定义标题' },
+    ])
+    listSessionSummariesMock.mockResolvedValue([
+      { id: 'cli-3', source: 'cli', title: '领夹麦选购咨询' },
+    ])
+    isReplaceableLocalTitleMock.mockReturnValue(false)
+
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = { query: {}, state: {}, body: null }
+    await mod.list(ctx)
+
+    expect(ctx.body.sessions[0].title).toBe('我的自定义标题')
+    expect(localUpdateSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('propagates a bridge session rename to the Hermes profile state.db', async () => {
+    getSessionMock.mockReturnValue({ id: 'cli-9', profile: 'travel', source: 'cli' })
+    localRenameSessionMock.mockReturnValue(true)
+    renameHermesSessionForProfileMock.mockResolvedValue(true)
+
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = { params: { id: 'cli-9' }, request: { body: { title: '  新标题  ' } }, state: {}, body: null }
+    await mod.rename(ctx)
+
+    expect(localRenameSessionMock).toHaveBeenCalledWith('cli-9', '新标题')
+    expect(renameHermesSessionForProfileMock).toHaveBeenCalledWith('cli-9', 'travel', '新标题')
+    expect(ctx.body).toEqual({ ok: true })
+  })
+
+  it('still renames locally when the Hermes rename propagation fails', async () => {
+    getSessionMock.mockReturnValue({ id: 'cli-10', profile: 'default', source: 'global_agent' })
+    localRenameSessionMock.mockReturnValue(true)
+    renameHermesSessionForProfileMock.mockResolvedValue(false)
+
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = { params: { id: 'cli-10' }, request: { body: { title: '改名' } }, state: {}, body: null }
+    await mod.rename(ctx)
+
+    expect(ctx.body).toEqual({ ok: true })
   })
 
   it('counts visible single-chat sessions with the same filters as the list endpoint', async () => {


### PR DESCRIPTION
## 解决的问题（两层）

侧边栏会话标题错误，追溯到两个不同层面：

1. **Hermes Agent 生成端**：某些 provider 不遵守 `response_format` 时，会流式返回**截断的 JSON 对象/数组**（`{"title #2`、`["a"'`）或 **markdown 代码围栏**（` ``` `、` ```json `）。这些被 loose scan 原样当成了会话标题，落进 state.db。
2. **Hermes Web UI（Studio）展示端**：侧边栏标题来自 **Studio 本地缓存**（`hermes-web-ui.db`），它只跟随 `session.title.updated` 事件。一旦错过事件、或标题已是一段垃圾，后续事件**永远无法修复**（`isReplaceableLocalTitle` 认为它不可替换）。

## 本 PR 的修复

在 `list` 渲染侧边栏时，把**可替换**的 bridge 会话标题与 **Hermes state.db 的 canonical 标题**对齐自愈：

- 新增 `reconcileBridgeSessionTitles(profile, sessions)`：对 `source` 为 `cli`/`global_agent` 的会话，用 `listHermesSessionSummaries` 读 state.db 的标题，若与本地不一致且**可替换**，则 `localUpdateSession(id, { title, title_source: 'llm' })` 并即时回写。
- `isReplaceableLocalTitle`：**用户显式重命名过的**（`title_source === 'user'`）永远不覆盖；**纯 markdown 装饰/截断 JSON**（`isMarkdownArtifactTitle`）视为可替换；其余按首条消息/预览的 fallback variants 判断。
- `title_source` 溯源：`renameSession` 置 `'user'`（权威），镜像/生成置 `'llm'`，schemas 增加该列。
- **rename 写穿**：把 bridge 会话重命名时，同步写回对应 Hermes profile 的 state.db（`renameHermesSessionForProfile`），否则 History 视图（以 state.db 为准）会和侧边栏不一致、下次列表又会把重命名撤销。
- `handle-bridge-run.ts` 里原本与 session-store 重复的三个本地函数上移去重，改为从 session-store import；`syncBridgeGeneratedTitle` 写入时带 `title_source:'llm'`。
- 由于 `sessions.title` 有 **UNIQUE 约束**，自愈/生成回退标题时需避免撞名。

## 适配重构结构说明

本 PR 基于重构后的上游代码（`src/modules/studio/` 目录 + DI 模式）实现。controller 不再直接 `import` `hermesCli`，而是通过 `session-agent-runtime` 依赖注入调用 `renameHermesSessionForProfile`（与既有 `deleteHermesSessionForProfile` 同一模式），因此比原 PR 多 `session-agent-runtime.ts` / `session-agent-runtime-adapter.ts` 两个接线文件。

## 验证

- vitest：`session-store-title-heuristics` / `session-store-title-source` / `sessions-controller` 三个文件 **78 个用例全部通过**。
- `tsc --noEmit -p packages/server/tsconfig.json` → exit 0。
- 完整 `npm run build`（vue-tsc -b / vite build / 服务端 tsc）→ exit 0。
