### PR TITLE
fix(group-chat): cancel approvals when Agent run stops

### DIFF
--- a/docs/chat-chain-changes/2026-08-22-issue-2676-interrupt-pending-approval.md
+++ b/docs/chat-chain-changes/2026-08-22-issue-2676-interrupt-pending-approval.md
@@ -6,3 +6,4 @@ impact: Interrupting an exact Group Agent run generation now denies its pending 
 ---
 
 Approval cancellation is idempotent and uses deny-only test commands so interrupted work cannot be approved accidentally.
+Approval routes and Agent Bridge waiters are bound to the exact Session + run generation; legacy or malformed empty generations are never claimed by an interrupt, and a later run in the same Session remains isolated.

--- a/docs/chat-chain-changes/2026-08-22-issue-2676-interrupt-pending-approval.md
+++ b/docs/chat-chain-changes/2026-08-22-issue-2676-interrupt-pending-approval.md
@@ -1,0 +1,8 @@
+---
+date: 2026-08-22
+pr: pending
+feature: Group Agent interrupt approval settlement
+impact: Interrupting an exact Group Agent run generation now denies its pending approvals in both the runtime and browser while leaving other runs untouched.
+---
+
+Approval cancellation is idempotent and uses deny-only test commands so interrupted work cannot be approved accidentally.

--- a/docs/chat-chain-changes/2026-08-22-issue-2676-interrupt-pending-approval.md
+++ b/docs/chat-chain-changes/2026-08-22-issue-2676-interrupt-pending-approval.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-22
-pr: pending
+pr: 2677
 feature: Group Agent interrupt approval settlement
 impact: Interrupting an exact Group Agent run generation now denies its pending approvals in both the runtime and browser while leaving other runs untouched.
 ---

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -185,8 +185,8 @@ class AgentPool:
         self._lock = threading.RLock()
         self._db = SessionDbHolder()
         self._approval_requests: dict[str, queue.Queue[str]] = {}
-        self._approval_request_sessions: dict[str, str] = {}
-        self._gateway_approval_requests: dict[str, str] = {}
+        self._approval_request_generations: dict[str, tuple[str, str]] = {}
+        self._gateway_approval_requests: dict[str, tuple[str, str]] = {}
         self._gateway_approval_pattern_keys: dict[str, list[str]] = {}
         self._compression_requests: dict[str, queue.Queue[dict[str, Any]]] = {}
         self._background_notification_claims: dict[tuple[str, str], dict[str, Any]] = {}
@@ -1372,11 +1372,13 @@ class AgentPool:
             approval_id = uuid.uuid4().hex
             response_queue: queue.Queue[str] = queue.Queue(maxsize=1)
             with self._lock:
+                run_id = str(self._sessions.get(session_id).current_run_id or "") if self._sessions.get(session_id) else ""
                 self._approval_requests[approval_id] = response_queue
-                self._approval_request_sessions[approval_id] = session_id
+                self._approval_request_generations[approval_id] = (session_id, run_id)
             choices = ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
             self._append_event(session_id, {
                 "event": "approval.requested",
+                "run_id": run_id,
                 "approval_id": approval_id,
                 "command": str(command or ""),
                 "description": str(description or ""),
@@ -1391,9 +1393,10 @@ class AgentPool:
             finally:
                 with self._lock:
                     self._approval_requests.pop(approval_id, None)
-                    self._approval_request_sessions.pop(approval_id, None)
+                    self._approval_request_generations.pop(approval_id, None)
             self._append_event(session_id, {
                 "event": "approval.resolved",
+                "run_id": run_id,
                 "approval_id": approval_id,
                 "choice": choice,
             })
@@ -1471,10 +1474,12 @@ class AgentPool:
             choices = ["once", "session", "always", "deny"]
             pattern_keys = _approval_pattern_keys(approval_data)
             with self._lock:
-                self._gateway_approval_requests[approval_id] = session_id
+                run_id = str(self._sessions.get(session_id).current_run_id or "") if self._sessions.get(session_id) else ""
+                self._gateway_approval_requests[approval_id] = (session_id, run_id)
                 self._gateway_approval_pattern_keys[approval_id] = pattern_keys
             self._append_event(session_id, {
                 "event": "approval.requested",
+                "run_id": run_id,
                 "approval_id": approval_id,
                 "command": str(approval_data.get("command") or ""),
                 "description": str(approval_data.get("description") or ""),
@@ -2042,6 +2047,7 @@ class AgentPool:
             raise KeyError(f"unknown session: {session_id}")
         with session.lock:
             self._cancel_boundary_run(session)
+            interrupted_run_id = str(session.current_run_id or "")
         background_delegation_ids = self._background_delegation_ids_for_session(session_id)
         with self._lock:
             self._suppressed_background_delegations.update(background_delegation_ids)
@@ -2053,7 +2059,7 @@ class AgentPool:
         if not hasattr(session.agent, "interrupt"):
             raise RuntimeError("agent does not support interrupt")
         session.agent.interrupt(message)
-        self._cancel_pending_approvals_for_session(session_id)
+        self._cancel_pending_approvals_for_generation(session_id, interrupted_run_id)
         deadline = time.time() + 10.0
         synced = False
         while time.time() < deadline:
@@ -2070,19 +2076,21 @@ class AgentPool:
             "background_delegation_ids": background_delegation_ids,
         }
 
-    def _cancel_pending_approvals_for_session(self, session_id: str) -> int:
+    def _cancel_pending_approvals_for_generation(self, session_id: str, run_id: str) -> int:
+        if not session_id or not run_id:
+            return 0
         terminal_queues: list[queue.Queue[str]] = []
         gateway_approvals: list[tuple[str, list[str]]] = []
         with self._lock:
-            for approval_id, approval_session_id in list(self._approval_request_sessions.items()):
-                if approval_session_id != session_id:
+            for approval_id, approval_generation in list(self._approval_request_generations.items()):
+                if approval_generation != (session_id, run_id):
                     continue
                 response_queue = self._approval_requests.pop(approval_id, None)
-                self._approval_request_sessions.pop(approval_id, None)
+                self._approval_request_generations.pop(approval_id, None)
                 if response_queue is not None:
                     terminal_queues.append(response_queue)
-            for approval_id, approval_session_id in list(self._gateway_approval_requests.items()):
-                if approval_session_id != session_id:
+            for approval_id, approval_generation in list(self._gateway_approval_requests.items()):
+                if approval_generation != (session_id, run_id):
                     continue
                 self._gateway_approval_requests.pop(approval_id, None)
                 gateway_approvals.append((
@@ -2103,6 +2111,7 @@ class AgentPool:
                 pass
             self._append_event(session_id, {
                 "event": "approval.resolved",
+                "run_id": run_id,
                 "approval_id": approval_id,
                 "choice": "deny",
                 "reason": "Session interrupted",
@@ -2210,17 +2219,18 @@ class AgentPool:
         with self._lock:
             response_queue = self._approval_requests.pop(approval_id, None)
             if response_queue is not None:
-                self._approval_request_sessions.pop(approval_id, None)
+                self._approval_request_generations.pop(approval_id, None)
                 try:
                     response_queue.put_nowait(cleaned)
                 except queue.Full:
                     pass
         if response_queue is None:
             with self._lock:
-                gateway_session_id = self._gateway_approval_requests.pop(approval_id, None)
+                gateway_generation = self._gateway_approval_requests.pop(approval_id, None)
                 pattern_keys = self._gateway_approval_pattern_keys.pop(approval_id, [])
-            if gateway_session_id is None:
+            if gateway_generation is None:
                 return {"approval_id": approval_id, "resolved": False, "choice": cleaned}
+            gateway_session_id, gateway_run_id = gateway_generation
             try:
                 from tools.approval import resolve_gateway_approval
 
@@ -2231,6 +2241,7 @@ class AgentPool:
                 _persist_execute_code_approval_choice(gateway_session_id, pattern_keys, cleaned)
             self._append_event(gateway_session_id, {
                 "event": "approval.resolved",
+                "run_id": gateway_run_id,
                 "approval_id": approval_id,
                 "choice": cleaned,
             })

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -185,6 +185,7 @@ class AgentPool:
         self._lock = threading.RLock()
         self._db = SessionDbHolder()
         self._approval_requests: dict[str, queue.Queue[str]] = {}
+        self._approval_request_sessions: dict[str, str] = {}
         self._gateway_approval_requests: dict[str, str] = {}
         self._gateway_approval_pattern_keys: dict[str, list[str]] = {}
         self._compression_requests: dict[str, queue.Queue[dict[str, Any]]] = {}
@@ -1372,6 +1373,7 @@ class AgentPool:
             response_queue: queue.Queue[str] = queue.Queue(maxsize=1)
             with self._lock:
                 self._approval_requests[approval_id] = response_queue
+                self._approval_request_sessions[approval_id] = session_id
             choices = ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
             self._append_event(session_id, {
                 "event": "approval.requested",
@@ -1389,6 +1391,7 @@ class AgentPool:
             finally:
                 with self._lock:
                     self._approval_requests.pop(approval_id, None)
+                    self._approval_request_sessions.pop(approval_id, None)
             self._append_event(session_id, {
                 "event": "approval.resolved",
                 "approval_id": approval_id,
@@ -2050,6 +2053,7 @@ class AgentPool:
         if not hasattr(session.agent, "interrupt"):
             raise RuntimeError("agent does not support interrupt")
         session.agent.interrupt(message)
+        self._cancel_pending_approvals_for_session(session_id)
         deadline = time.time() + 10.0
         synced = False
         while time.time() < deadline:
@@ -2065,6 +2069,45 @@ class AgentPool:
             "background_interrupted": background_interrupted,
             "background_delegation_ids": background_delegation_ids,
         }
+
+    def _cancel_pending_approvals_for_session(self, session_id: str) -> int:
+        terminal_queues: list[queue.Queue[str]] = []
+        gateway_approvals: list[tuple[str, list[str]]] = []
+        with self._lock:
+            for approval_id, approval_session_id in list(self._approval_request_sessions.items()):
+                if approval_session_id != session_id:
+                    continue
+                response_queue = self._approval_requests.pop(approval_id, None)
+                self._approval_request_sessions.pop(approval_id, None)
+                if response_queue is not None:
+                    terminal_queues.append(response_queue)
+            for approval_id, approval_session_id in list(self._gateway_approval_requests.items()):
+                if approval_session_id != session_id:
+                    continue
+                self._gateway_approval_requests.pop(approval_id, None)
+                gateway_approvals.append((
+                    approval_id,
+                    self._gateway_approval_pattern_keys.pop(approval_id, []),
+                ))
+        for response_queue in terminal_queues:
+            try:
+                response_queue.put_nowait("deny")
+            except queue.Full:
+                pass
+        for approval_id, _pattern_keys in gateway_approvals:
+            try:
+                from tools.approval import resolve_gateway_approval
+
+                resolve_gateway_approval(session_id, "deny")
+            except Exception:
+                pass
+            self._append_event(session_id, {
+                "event": "approval.resolved",
+                "approval_id": approval_id,
+                "choice": "deny",
+                "reason": "Session interrupted",
+            })
+        return len(terminal_queues) + len(gateway_approvals)
 
     def request_boundary_interrupt(
         self,
@@ -2165,7 +2208,13 @@ class AgentPool:
         if cleaned not in {"once", "session", "always", "deny"}:
             cleaned = "deny"
         with self._lock:
-            response_queue = self._approval_requests.get(approval_id)
+            response_queue = self._approval_requests.pop(approval_id, None)
+            if response_queue is not None:
+                self._approval_request_sessions.pop(approval_id, None)
+                try:
+                    response_queue.put_nowait(cleaned)
+                except queue.Full:
+                    pass
         if response_queue is None:
             with self._lock:
                 gateway_session_id = self._gateway_approval_requests.pop(approval_id, None)
@@ -2186,10 +2235,6 @@ class AgentPool:
                 "choice": cleaned,
             })
             return {"approval_id": approval_id, "resolved": resolved, "choice": cleaned}
-        try:
-            response_queue.put_nowait(cleaned)
-        except queue.Full:
-            pass
         return {"approval_id": approval_id, "resolved": True, "choice": cleaned}
 
     def respond_clarify(self, clarify_id: str, response: str) -> dict[str, Any]:

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -1150,7 +1150,12 @@ export class AgentClient implements GroupAgentExecutor {
                     } else if (event === 'tool.completed' || event === 'tool.failed') {
                         queueToolEventWrite(() => this.recordToolCompleted(roomId, sessionId, { ...payload, event }).then(() => undefined))
                     } else if (event === 'approval.requested') {
-                        this.emitApprovalRequested(roomId, { ...payload, agentSessionId: sessionId })
+                        const { run_id: _runtimeRunId, runId: _runtimeCamelRunId, ...approvalPayload } = payload
+                        this.emitApprovalRequested(roomId, {
+                            ...approvalPayload,
+                            agentSessionId: sessionId,
+                            runId: responseRunId,
+                        })
                     } else if (event === 'approval.resolved') {
                         this.emitApprovalResolved(roomId, { ...payload, agentSessionId: sessionId })
                     } else if (event === 'clarify.requested') {

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -1555,6 +1555,7 @@ export class AgentClient implements GroupAgentExecutor {
                 this.emitApprovalRequested(roomId, {
                     event: 'approval.requested',
                     agentSessionId: sessionId,
+                    runId: responseRunId,
                     approval_id: (ev as any).approval_id,
                     command: (ev as any).command,
                     description: (ev as any).description,

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -94,6 +94,7 @@ interface PendingGroupApprovalRoute {
     agentName: string
     ownerMemberId: string
     agentSessionId: string
+    runId: string
     approvalId: string
     command: string
     description: string
@@ -3116,6 +3117,7 @@ export class GroupChatServer {
         agentName: string
         status: string
         agentSessionId?: string
+        runId?: string
     }>>()
     /** Stable room + persisted Agent row + run activity visible across authorized rooms. */
     private roomAgentActivityState = new Map<string, Map<string, GroupAgentActivity>>()
@@ -3909,7 +3911,7 @@ export class GroupChatServer {
         socket.on('cancel_execution_queue_item', (data: { roomId?: string; queueId?: string; executionQueueCapability?: string }, ack?: (response?: unknown) => void) => this.handleCancelExecutionQueueItem(socket, data, ack))
         socket.on('interrupt_agent', (data: { roomId?: string; agentName?: string }, ack?: (response?: unknown) => void) => this.handleInterruptAgent(socket, data, ack))
         socket.on('remove_agent', (data: { roomId?: string; agentId?: string }, ack?: (response?: unknown) => void) => this.handleRemoveAgent(socket, data, ack))
-        socket.on('approval.requested', (data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; timeout_ms?: number; agentSessionId?: string }) => this.handleApprovalRequested(socket, data))
+        socket.on('approval.requested', (data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; timeout_ms?: number; agentSessionId?: string; runId?: string }) => this.handleApprovalRequested(socket, data))
         socket.on('approval.resolved', (data: { roomId?: string; agentName?: string; approval_id?: string; choice?: string; agentSessionId?: string }) => this.handleApprovalResolved(socket, data))
         socket.on('approval.respond', (data: { roomId?: string; approval_id?: string; choice?: string }, ack?: (response?: unknown) => void) => this.handleApprovalRespond(socket, data, ack))
         socket.on('clarify.requested', (data: { roomId?: string; agentName?: string; clarify_id?: string; question?: string; choices?: string[] | null; initial_response?: string; response_mode?: string; timeout_ms?: number; agentSessionId?: string }) => this.handleClarifyRequested(socket, data))
@@ -4836,6 +4838,7 @@ export class GroupChatServer {
                 agentName,
                 status,
                 ...(agentSessionId ? { agentSessionId } : {}),
+                ...(typeof data.runId === 'string' && data.runId.trim() ? { runId: data.runId.trim() } : {}),
             })
         }
 
@@ -4866,8 +4869,16 @@ export class GroupChatServer {
             ack?.({ error: 'Access denied' })
             return
         }
+        const activeGeneration = this.contextStatusState.get(roomId)?.get(agentName)
+        const interruptedApprovals = this.takePendingApprovalsForGeneration(
+            roomId,
+            agentName,
+            activeGeneration?.agentSessionId || '',
+            activeGeneration?.runId || '',
+        )
         try {
             await this.agentClients.interruptAgent(roomId, agentName)
+            await this.settleInterruptedApprovals(interruptedApprovals)
             const roomStatuses = this.contextStatusState.get(roomId)
             roomStatuses?.delete(agentName)
             if (roomStatuses?.size === 0) this.contextStatusState.delete(roomId)
@@ -4878,6 +4889,7 @@ export class GroupChatServer {
             this.nsp.to(roomId).emit('context_status', { roomId, agentName, status: 'ready' })
             ack?.({ ok: true })
         } catch (err: any) {
+            await this.settleInterruptedApprovals(interruptedApprovals)
             logger.warn(`[GroupChat] failed to interrupt agent ${agentName} in room ${roomId}: ${err.message}`)
             ack?.({ error: err.message || 'interrupt failed' })
         }
@@ -4978,7 +4990,7 @@ export class GroupChatServer {
         })
     }
 
-    private handleApprovalRequested(socket: Socket, data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; timeout_ms?: number; agentSessionId?: string }): void {
+    private handleApprovalRequested(socket: Socket, data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; timeout_ms?: number; agentSessionId?: string; runId?: string }): void {
         const roomId = data.roomId
         const agentName = data.agentName || ''
         if (!roomId || !data.approval_id || !this.getCurrentAgentEventMember(socket, roomId, agentName, data.agentSessionId)) return
@@ -4990,6 +5002,7 @@ export class GroupChatServer {
             agentName,
             ownerMemberId: this.groupAgentOwnerMemberId(roomId, agentName),
             agentSessionId: String(data.agentSessionId || '').trim(),
+            runId: String(data.runId || '').trim(),
             approvalId: data.approval_id,
             command: data.command || '',
             description: data.description || '',
@@ -5014,6 +5027,55 @@ export class GroupChatServer {
             allow_permanent: Boolean(data.allow_permanent),
             timeout_ms: pendingRoute.timeoutMs,
         })
+    }
+
+    private takePendingApprovalsForGeneration(
+        roomId: string,
+        agentName: string,
+        agentSessionId: string,
+        runId: string,
+    ): PendingGroupApprovalRoute[] {
+        if (!agentSessionId) return []
+        const routes: PendingGroupApprovalRoute[] = []
+        for (const [routeKey, route] of this.pendingApprovalRoutes) {
+            if (route.roomId !== roomId
+                || route.agentName !== agentName
+                || route.agentSessionId !== agentSessionId
+                || (runId && route.runId && route.runId !== runId)) {
+                continue
+            }
+            const claimed = this.takePendingApprovalRoute(routeKey)
+            if (claimed) routes.push(claimed)
+        }
+        return routes
+    }
+
+    private async settleInterruptedApprovals(routes: PendingGroupApprovalRoute[]): Promise<void> {
+        for (const route of routes) {
+            let resolved = false
+            const executor = this.agentClients.getAgents(route.roomId).find(agent =>
+                agent.name === route.agentName && typeof agent.respondApproval === 'function'
+            )
+            try {
+                resolved = Boolean(await executor?.respondApproval?.(route.approvalId, 'deny'))
+                if (!resolved) {
+                    resolved = Boolean((await new AgentBridgeClient().approvalRespond(route.approvalId, 'deny') as any)?.resolved)
+                }
+            } catch (err: any) {
+                if (!isExpiredInteractionError(err?.message || err)) {
+                    logger.warn(`[GroupChat] failed to cancel interrupted approval ${route.approvalId}: ${err?.message || err}`)
+                }
+            }
+            this.emitToAgentApprovalOwner(route, 'approval.resolved', {
+                event: 'approval.resolved',
+                roomId: route.roomId,
+                agentName: route.agentName,
+                approval_id: route.approvalId,
+                choice: 'deny',
+                reason: 'Agent run interrupted',
+                resolved,
+            })
+        }
     }
 
     private handleApprovalResolved(socket: Socket, data: { roomId?: string; agentName?: string; approval_id?: string; choice?: string; agentSessionId?: string }): void {

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -5035,13 +5035,14 @@ export class GroupChatServer {
         agentSessionId: string,
         runId: string,
     ): PendingGroupApprovalRoute[] {
-        if (!agentSessionId) return []
+        if (!agentSessionId || !runId || !(this.pendingApprovalRoutes instanceof Map)) return []
         const routes: PendingGroupApprovalRoute[] = []
         for (const [routeKey, route] of this.pendingApprovalRoutes) {
             if (route.roomId !== roomId
                 || route.agentName !== agentName
                 || route.agentSessionId !== agentSessionId
-                || (runId && route.runId && route.runId !== runId)) {
+                || !route.runId
+                || route.runId !== runId) {
                 continue
             }
             const claimed = this.takePendingApprovalRoute(routeKey)

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -735,6 +735,36 @@ test.describe('group chat room deep links', () => {
     await expect(betaGrid.locator('[data-agent-id="agent-row-runtime"]')).toHaveClass(/is-active/)
   })
 
+  test('removes an interrupted run approval from the room approval surface', async ({ page }) => {
+    await setup(page, '/#/hermes/group-chat/room/room-alpha')
+
+    await triggerGroupSocket(page, 'approval.requested', {
+      event: 'approval.requested',
+      roomId: 'room-alpha',
+      agentName: 'Worker',
+      approval_id: 'approval-interrupted',
+      command: 'printf harmless',
+      description: 'Harmless command awaiting approval',
+      choices: ['once', 'deny'],
+    })
+    await expect(page.locator('.approval-float-panel')).toContainText('printf harmless')
+
+    await triggerGroupSocket(page, 'approval.resolved', {
+      event: 'approval.resolved',
+      roomId: 'room-alpha',
+      agentName: 'Worker',
+      approval_id: 'approval-interrupted',
+      choice: 'deny',
+      reason: 'Agent run interrupted',
+    })
+    await expect(page.locator('.approval-float-panel')).toHaveCount(0)
+    if (process.env.HERMES_VISUAL_EVIDENCE_DIR) {
+      await page.screenshot({
+        path: `${process.env.HERMES_VISUAL_EVIDENCE_DIR}/approval-removed-after-interrupt.png`,
+      })
+    }
+  })
+
   test('loads all group history by stable cursor beyond 600 messages with retry, de-duplication, and anchor preservation', async ({ page }) => {
     test.setTimeout(45_000)
     const api = await setup(page, '/#/hermes/group-chat/room/room-alpha')

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -227,7 +227,7 @@ def wait_for(condition, timeout=20):
 `
 
 describe('agent bridge Python session concurrency', () => {
-  it('denies only the interrupted session approval queues', () => {
+  it('denies only the interrupted session run generation approval queues', () => {
     runPython(String.raw`
 ${harness}
 
@@ -242,7 +242,7 @@ class InterruptibleAgent:
 
 agents = {sid: InterruptibleAgent() for sid in ("session-a", "session-b")}
 for sid, agent in agents.items():
-    session = bridge.AgentSession(session_id=sid, agent=agent)
+    session = bridge.AgentSession(session_id=sid, agent=agent, current_run_id="run-current")
     session.running = True
     agent.session = session
     with pool._lock:
@@ -250,12 +250,14 @@ for sid, agent in agents.items():
 
 choices = {}
 threads = []
-for sid in ("session-a", "session-b"):
+for sid, run_id in (("session-a", "run-previous"), ("session-a", "run-current"), ("session-b", "run-current")):
+    with pool._lock:
+        pool._sessions[sid].current_run_id = run_id
     thread = threading.Thread(
-        target=lambda current=sid: choices.__setitem__(
-            current,
+        target=lambda current=sid, generation=run_id: choices.__setitem__(
+            f"{current}:{generation}",
             pool._approval_callback(current)(
-                f"printf harmless {current}",
+                f"printf harmless {current} {generation}",
                 "harmless test command",
                 allow_permanent=False,
             ),
@@ -264,32 +266,49 @@ for sid in ("session-a", "session-b"):
     )
     thread.start()
     threads.append(thread)
-
-def terminal_ready():
-    with pool._lock:
-        return set(pool._approval_request_sessions.values()) == {"session-a", "session-b"}
-
-assert wait_for(terminal_ready)
+    assert wait_for(lambda current=sid, generation=run_id: (
+        current,
+        generation,
+    ) in set(pool._approval_request_generations.values()))
+with pool._lock:
+    pool._sessions["session-a"].current_run_id = "run-previous"
 pool._gateway_approval_notify("session-a")({
-    "command": "printf harmless gateway",
+    "command": "printf harmless previous gateway",
+    "description": "harmless test command",
+})
+with pool._lock:
+    pool._sessions["session-a"].current_run_id = "run-current"
+pool._gateway_approval_notify("session-a")({
+    "command": "printf harmless current gateway",
     "description": "harmless test command",
 })
 
 result = pool.interrupt("session-a", "test interrupt")
 assert result["status"] == "interrupted"
-threads[0].join(timeout=5)
-assert not threads[0].is_alive()
-assert choices["session-a"] == "deny"
-with pool._lock:
-    assert set(pool._approval_request_sessions.values()) == {"session-b"}
-    remaining_id = next(iter(pool._approval_requests))
-assert approval._resolved_gateway == [("session-a", "deny")]
-
-assert pool.respond_approval(remaining_id, "deny")["resolved"] is True
 threads[1].join(timeout=5)
 assert not threads[1].is_alive()
-assert choices["session-b"] == "deny"
-assert pool.respond_approval(remaining_id, "once")["resolved"] is False
+assert choices["session-a:run-current"] == "deny"
+assert threads[0].is_alive()
+with pool._lock:
+    assert set(pool._approval_request_generations.values()) == {
+        ("session-a", "run-previous"),
+        ("session-b", "run-current"),
+    }
+    remaining = dict(pool._approval_request_generations)
+    previous_id = next(key for key, value in remaining.items() if value == ("session-a", "run-previous"))
+    other_session_id = next(key for key, value in remaining.items() if value == ("session-b", "run-current"))
+    assert set(pool._gateway_approval_requests.values()) == {("session-a", "run-previous")}
+assert approval._resolved_gateway == [("session-a", "deny")]
+
+assert pool.respond_approval(previous_id, "deny")["resolved"] is True
+assert pool.respond_approval(other_session_id, "deny")["resolved"] is True
+threads[0].join(timeout=5)
+threads[2].join(timeout=5)
+assert not threads[0].is_alive()
+assert not threads[2].is_alive()
+assert choices["session-a:run-previous"] == "deny"
+assert choices["session-b:run-current"] == "deny"
+assert pool.respond_approval(other_session_id, "once")["resolved"] is False
 `)
   })
 

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -227,6 +227,72 @@ def wait_for(condition, timeout=20):
 `
 
 describe('agent bridge Python session concurrency', () => {
+  it('denies only the interrupted session approval queues', () => {
+    runPython(String.raw`
+${harness}
+
+pool, _fake_db = make_pool()
+
+class InterruptibleAgent:
+    def __init__(self):
+        self.session = None
+
+    def interrupt(self, _message=None):
+        self.session.running = False
+
+agents = {sid: InterruptibleAgent() for sid in ("session-a", "session-b")}
+for sid, agent in agents.items():
+    session = bridge.AgentSession(session_id=sid, agent=agent)
+    session.running = True
+    agent.session = session
+    with pool._lock:
+        pool._sessions[sid] = session
+
+choices = {}
+threads = []
+for sid in ("session-a", "session-b"):
+    thread = threading.Thread(
+        target=lambda current=sid: choices.__setitem__(
+            current,
+            pool._approval_callback(current)(
+                f"printf harmless {current}",
+                "harmless test command",
+                allow_permanent=False,
+            ),
+        ),
+        daemon=True,
+    )
+    thread.start()
+    threads.append(thread)
+
+def terminal_ready():
+    with pool._lock:
+        return set(pool._approval_request_sessions.values()) == {"session-a", "session-b"}
+
+assert wait_for(terminal_ready)
+pool._gateway_approval_notify("session-a")({
+    "command": "printf harmless gateway",
+    "description": "harmless test command",
+})
+
+result = pool.interrupt("session-a", "test interrupt")
+assert result["status"] == "interrupted"
+threads[0].join(timeout=5)
+assert not threads[0].is_alive()
+assert choices["session-a"] == "deny"
+with pool._lock:
+    assert set(pool._approval_request_sessions.values()) == {"session-b"}
+    remaining_id = next(iter(pool._approval_requests))
+assert approval._resolved_gateway == [("session-a", "deny")]
+
+assert pool.respond_approval(remaining_id, "deny")["resolved"] is True
+threads[1].join(timeout=5)
+assert not threads[1].is_alive()
+assert choices["session-b"] == "deny"
+assert pool.respond_approval(remaining_id, "once")["resolved"] is False
+`)
+  })
+
   it('toggles YOLO for a session before its first Agent session exists', () => {
     runPython(String.raw`
 ${harness}

--- a/tests/server/group-chat-agent-workspace.test.ts
+++ b/tests/server/group-chat-agent-workspace.test.ts
@@ -678,6 +678,56 @@ describe('group chat agent workspace bridge runs', () => {
     expect(runAndWait.mock.calls[0][0].session_id).toMatch(/^gc_run_/)
   })
 
+  it('normalizes non-Hermes approval events onto the authoritative group run generation', async () => {
+    const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')
+    const runAndWait = vi.fn(async (_data: any, options: any) => {
+      options.onEvent?.('approval.requested', {
+        run_id: 'runtime-run-id',
+        approval_id: 'approval-1',
+        command: 'printf harmless',
+      })
+      return { ok: true, run_id: 'runtime-run-id', output: 'done' }
+    })
+    const clients = new AgentClients()
+    clients.setChatRunService({ runAndWait, abortSession: vi.fn(async () => {}) })
+    const client = await clients.createAgent({
+      agentId: 'agent-codex',
+      agent: 'codex',
+      profile: 'default',
+      name: 'Coder',
+      description: '',
+      invited: 0,
+      backgroundDelegationEnabled: false,
+    } as any) as any
+    client.setStorage({
+      getRoom: vi.fn(() => ({ sessionSeed: 'seed-1', workspace: '', maxHistoryTokens: 32000 })),
+      getRoomAgents: vi.fn(() => []),
+      getMentionableRoomAgents: vi.fn(() => []),
+      getMessagesForContext: vi.fn(() => []),
+      getContextSnapshot: vi.fn(() => null),
+    })
+
+    await client.replyToMention('room-1', {
+      messageId: 'message-1',
+      content: '@Coder run safely',
+      senderName: 'Human',
+      senderId: 'human-1',
+      timestamp: 1,
+      role: 'user',
+    })
+
+    const streamStart = mockSocket.emit.mock.calls
+      .find(([event]) => event === 'message_stream_start')?.[1]
+    const approval = mockSocket.emit.mock.calls
+      .find(([event]) => event === 'approval.requested')?.[1]
+    expect(streamStart?.run_id).toBeTruthy()
+    expect(approval).toMatchObject({
+      approval_id: 'approval-1',
+      runId: streamStart.run_id,
+    })
+    expect(approval).not.toHaveProperty('run_id')
+  })
+
   it.each([
     ['ekko', 'ekko-agent'],
     ['claude', 'claude-code'],

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -751,6 +751,12 @@ describe('group chat approval and context baseline', () => {
       approval_id: 'approval-next', command: 'printf harmless',
     })
     await nextRequested
+    const missingGenerationRequested = once<any>(human, 'approval.requested')
+    agent.emit('approval.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId,
+      approval_id: 'approval-missing-generation', command: 'printf harmless',
+    })
+    await missingGenerationRequested
     const resolved = once<any>(human, 'approval.resolved')
 
     await expect(emitAck(human, 'interrupt_agent', {
@@ -763,13 +769,58 @@ describe('group chat approval and context baseline', () => {
     expect(respondApproval).toHaveBeenCalledTimes(1)
     expect(respondApproval).toHaveBeenCalledWith('approval-current', 'deny')
     await expect(emitAck<any>(human, 'load_pending_approvals', {})).resolves.toEqual({
-      pendingApprovals: [expect.objectContaining({ approval_id: 'approval-next' })],
+      pendingApprovals: [
+        expect.objectContaining({ approval_id: 'approval-next' }),
+        expect.objectContaining({ approval_id: 'approval-missing-generation' }),
+      ],
     })
 
     await expect(emitAck(human, 'interrupt_agent', {
       roomId: 'room-1', agentName: 'Agent',
     })).resolves.toEqual({ ok: true })
     expect(respondApproval).toHaveBeenCalledTimes(1)
+  })
+
+  it('claims the active approval before an interrupt can race with a user response', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    let finishInterrupt!: () => void
+    const interruptPending = new Promise<void>(resolve => {
+      finishInterrupt = resolve
+    })
+    const respondApproval = vi.fn(async () => true)
+    vi.spyOn(groupServer.agentClients, 'getAgents').mockReturnValue([{
+      name: 'Agent',
+      respondApproval,
+    } as any])
+    vi.spyOn(groupServer.agentClients, 'interruptAgent').mockImplementation(async () => {
+      await interruptPending
+    })
+
+    agent.emit('context_status', {
+      roomId: 'room-1', agentName: 'Agent', status: 'replying',
+      agentSessionId, runId: 'run-current',
+    })
+    const requested = once<any>(human, 'approval.requested')
+    agent.emit('approval.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId, runId: 'run-current',
+      approval_id: 'approval-race', command: 'printf harmless',
+    })
+    await requested
+
+    const interrupted = emitAck(human, 'interrupt_agent', {
+      roomId: 'room-1', agentName: 'Agent',
+    })
+    await vi.waitFor(() => {
+      expect(groupServer.agentClients.interruptAgent).toHaveBeenCalledTimes(1)
+    })
+    await expect(emitAck(human, 'approval.respond', {
+      roomId: 'room-1', approval_id: 'approval-race', choice: 'once',
+    })).resolves.toEqual({ error: 'Approval is not pending in this room' })
+
+    finishInterrupt()
+    await expect(interrupted).resolves.toEqual({ ok: true })
+    expect(respondApproval).toHaveBeenCalledTimes(1)
+    expect(respondApproval).toHaveBeenCalledWith('approval-race', 'deny')
   })
 
   it('keeps Hermes approval responses routed through the Agent Bridge', async () => {

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -726,6 +726,52 @@ describe('group chat approval and context baseline', () => {
     await expect(emitAck<any>(human, 'load_pending_approvals', {})).resolves.toEqual({ pendingApprovals: [] })
   })
 
+  it('interrupts only the active run generation and denies its pending approvals', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    const respondApproval = vi.fn(async () => true)
+    vi.spyOn(groupServer.agentClients, 'getAgents').mockReturnValue([{
+      name: 'Agent',
+      respondApproval,
+    } as any])
+    vi.spyOn(groupServer.agentClients, 'interruptAgent').mockResolvedValue()
+
+    agent.emit('context_status', {
+      roomId: 'room-1', agentName: 'Agent', status: 'replying',
+      agentSessionId, runId: 'run-current',
+    })
+    const currentRequested = once<any>(human, 'approval.requested')
+    agent.emit('approval.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId, runId: 'run-current',
+      approval_id: 'approval-current', command: 'printf harmless',
+    })
+    await currentRequested
+    const nextRequested = once<any>(human, 'approval.requested')
+    agent.emit('approval.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId, runId: 'run-next',
+      approval_id: 'approval-next', command: 'printf harmless',
+    })
+    await nextRequested
+    const resolved = once<any>(human, 'approval.resolved')
+
+    await expect(emitAck(human, 'interrupt_agent', {
+      roomId: 'room-1', agentName: 'Agent',
+    })).resolves.toEqual({ ok: true })
+
+    await expect(resolved).resolves.toMatchObject({
+      approval_id: 'approval-current', choice: 'deny', reason: 'Agent run interrupted',
+    })
+    expect(respondApproval).toHaveBeenCalledTimes(1)
+    expect(respondApproval).toHaveBeenCalledWith('approval-current', 'deny')
+    await expect(emitAck<any>(human, 'load_pending_approvals', {})).resolves.toEqual({
+      pendingApprovals: [expect.objectContaining({ approval_id: 'approval-next' })],
+    })
+
+    await expect(emitAck(human, 'interrupt_agent', {
+      roomId: 'room-1', agentName: 'Agent',
+    })).resolves.toEqual({ ok: true })
+    expect(respondApproval).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps Hermes approval responses routed through the Agent Bridge', async () => {
     const { agent, human, agentSessionId } = await joinPair()
     const bridgeApproval = vi.spyOn(AgentBridgeClient.prototype, 'approvalRespond')


### PR DESCRIPTION
## Summary
- bind pending group approvals to the exact Session/run generation
- deny and release bridge/coding-agent approval waiters when that run is interrupted
- emit authoritative approval resolution without affecting other runs or repeated stops

Closes #2676

## Validation
- `npm run test -- tests/server/group-chat-approval.test.ts tests/server/agent-bridge-python-concurrency.test.ts`
- `npx playwright test tests/e2e/group-chat-room-deeplink.spec.ts --grep "removes an interrupted run approval"`
- `npm run harness:check`
- `npm run build`
- `git diff --check`