### PR TITLE
fix: keep dev Web UI from replacing desktop relay

### DIFF
--- a/docs/app-relay.md
+++ b/docs/app-relay.md
@@ -103,6 +103,11 @@ If Studio has any active cloud App records, it connects to the cloud at startup.
 Socket.IO reconnects indefinitely after transient disconnects. The cloud
 restores the formal-connection snapshot; Studio reconciles it against local
 revocation tombstones so an offline cloud deletion is eventually propagated.
+Development Web UI hosts register as non-preemptive: when the same machine ID
+already has a packaged desktop host online, starting `npm run dev` does not
+replace that desktop socket or overwrite its machine metadata. Production hosts
+retain the existing takeover behavior so a restarted desktop can recover stale
+connections.
 
 ## Forwarded protocols
 

--- a/packages/server/src/services/app-relay/client.ts
+++ b/packages/server/src/services/app-relay/client.ts
@@ -139,6 +139,7 @@ export interface StartAppRelayClientOptions {
   relayUrl?: string
   machineId: string
   publicKey: string
+  replaceExistingHost?: boolean
   machineInfo?: Record<string, unknown>
   localBaseUrl?: string
   fetchImpl?: typeof fetch
@@ -209,6 +210,7 @@ export class AppRelayClient {
           nonce,
           timestamp,
           signature,
+          replaceExistingHost: this.options.replaceExistingHost,
           machine: this.options.machineInfo,
         })
       },
@@ -750,6 +752,7 @@ export function startAppRelayClient(options: StartAppRelayClientOptions): AppRel
     relayUrl,
     machineId,
     publicKey,
+    replaceExistingHost: options.replaceExistingHost ?? true,
     machineInfo: options.machineInfo,
     localBaseUrl: options.localBaseUrl || `http://127.0.0.1:${config.port}`,
     fetchImpl: options.fetchImpl || fetch,

--- a/packages/server/src/services/app-relay/connection.ts
+++ b/packages/server/src/services/app-relay/connection.ts
@@ -10,6 +10,12 @@ import {
 
 export const APP_RELAY_CONNECTION_ID = 'app-relay'
 
+export function shouldReplaceExistingAppRelayHost(
+  environment: Record<string, string | undefined> = process.env,
+): boolean {
+  return environment.NODE_ENV === 'production'
+}
+
 export async function ensureAppRelayHostClient(): Promise<AppRelayClient | null> {
   const existing = getAppRelayClient(APP_RELAY_CONNECTION_ID)
   if (existing && !existing.isPreconnectionExpired()) return existing
@@ -20,6 +26,7 @@ export async function ensureAppRelayHostClient(): Promise<AppRelayClient | null>
     relayUrl: config.appRelay.url,
     machineId: identity.device_id,
     publicKey: identity.device_public_key,
+    replaceExistingHost: shouldReplaceExistingAppRelayHost(),
     machineInfo: {
       ...info,
       http_port: config.port,

--- a/tests/server/app-relay-client.test.ts
+++ b/tests/server/app-relay-client.test.ts
@@ -78,10 +78,35 @@ describe('AppRelayClient', () => {
       machineId: 'hwui_machine_1234567890',
       publicKey,
       signature: 'machine-signature',
+      replaceExistingHost: true,
       machine: { computer_name: 'Studio Mac' },
     })
     expect(auth.nonce).toEqual(expect.any(String))
     expect(auth.timestamp).toEqual(expect.any(Number))
+  })
+
+  it('marks development Web UI relay hosts as non-preemptive', async () => {
+    const { shouldReplaceExistingAppRelayHost } = await import(
+      '../../packages/server/src/services/app-relay/connection'
+    )
+    const { startAppRelayClient } = await import('../../packages/server/src/services/app-relay/client')
+
+    expect(shouldReplaceExistingAppRelayHost({ NODE_ENV: 'development' })).toBe(false)
+    expect(shouldReplaceExistingAppRelayHost({ NODE_ENV: 'test' })).toBe(false)
+    expect(shouldReplaceExistingAppRelayHost({ NODE_ENV: 'production' })).toBe(true)
+
+    startAppRelayClient({
+      relayUrl: 'https://relay.example.com',
+      machineId: 'hwui_machine_1234567890',
+      publicKey: 'machine-public-key',
+      replaceExistingHost: false,
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: vi.fn() as any,
+    })
+    const options = mockIo.mock.calls[0][1]
+    const auth = await new Promise<Record<string, unknown>>(resolve => options.auth(resolve))
+
+    expect(auth.replaceExistingHost).toBe(false)
   })
 
   it('keeps waiting across transient connect errors while Socket.IO retries', async () => {


### PR DESCRIPTION
## Summary
- mark development Web UI App Relay hosts as non-preemptive
- preserve production desktop takeover and reconnect behavior
- document the development/desktop relay ownership rule
- add regression coverage for the relay handshake flag

The matching cloud Server guard has already been merged into `hermes-studio-server/main`.

## Validation
- `npm run test -- tests/server/app-relay-client.test.ts`
- `npm run build`
- `npm run harness:check`
- `git diff --check`