### PR TITLE
fix(group-chat): cancel pending clarification when an Agent run is force-stopped

### DIFF
--- a/docs/chat-chain-changes/2026-08-22-issue-2676-interrupt-pending-approval.md
+++ b/docs/chat-chain-changes/2026-08-22-issue-2676-interrupt-pending-approval.md
@@ -6,3 +6,4 @@ impact: Interrupting an exact Group Agent run generation now denies its pending 
 ---
 
 Approval cancellation is idempotent and uses deny-only test commands so interrupted work cannot be approved accidentally.
+Approval routes and Agent Bridge waiters are bound to the exact Session + run generation; legacy or malformed empty generations are never claimed by an interrupt, and a later run in the same Session remains isolated.

--- a/docs/chat-chain-changes/2026-08-22-issue-2676-interrupt-pending-approval.md
+++ b/docs/chat-chain-changes/2026-08-22-issue-2676-interrupt-pending-approval.md
@@ -1,0 +1,8 @@
+---
+date: 2026-08-22
+pr: pending
+feature: Group Agent interrupt approval settlement
+impact: Interrupting an exact Group Agent run generation now denies its pending approvals in both the runtime and browser while leaving other runs untouched.
+---
+
+Approval cancellation is idempotent and uses deny-only test commands so interrupted work cannot be approved accidentally.

--- a/docs/chat-chain-changes/2026-08-22-issue-2676-interrupt-pending-approval.md
+++ b/docs/chat-chain-changes/2026-08-22-issue-2676-interrupt-pending-approval.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-22
-pr: pending
+pr: 2677
 feature: Group Agent interrupt approval settlement
 impact: Interrupting an exact Group Agent run generation now denies its pending approvals in both the runtime and browser while leaving other runs untouched.
 ---

--- a/docs/chat-chain-changes/2026-08-22-issue-2680-exact-gateway-approval-waiter.md
+++ b/docs/chat-chain-changes/2026-08-22-issue-2680-exact-gateway-approval-waiter.md
@@ -1,0 +1,8 @@
+---
+date: 2026-08-22
+pr: pending
+feature: Exact Gateway approval waiter settlement
+impact: Interrupting a Group Agent run now denies its exact Hermes Gateway waiter by Runtime request ID without consuming another generation's waiter from the same Session.
+---
+
+Gateway approval notifications retain the Runtime `request_id` beside their exact Session and run generation. Interrupt and user-response paths pass that identity back to Hermes Agent, while missing request IDs fail closed instead of falling back to Session FIFO.

--- a/docs/chat-chain-changes/2026-08-22-issue-2680-exact-gateway-approval-waiter.md
+++ b/docs/chat-chain-changes/2026-08-22-issue-2680-exact-gateway-approval-waiter.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-22
-pr: pending
+pr: 2681
 feature: Exact Gateway approval waiter settlement
 impact: Interrupting a Group Agent run now denies its exact Hermes Gateway waiter by Runtime request ID without consuming another generation's waiter from the same Session.
 ---

--- a/docs/chat-chain-changes/2026-08-22-issue-2684-interrupt-pending-clarification.md
+++ b/docs/chat-chain-changes/2026-08-22-issue-2684-interrupt-pending-clarification.md
@@ -1,0 +1,12 @@
+---
+date: 2026-08-22
+commit: pending
+feature: Group Chat force-stop clarification lifecycle
+impact: Force-stop now releases the exact pending clarification waiter and clears its Room/global pending UI without affecting other generations.
+---
+
+Group Chat binds clarification prompts to the active Session and run
+generation. Force-stop claims only that generation's prompt, releases the
+underlying Runtime waiter, emits a resolved event so pending UI clears, and
+rejects late replies without affecting other generations, Sessions, Rooms, or
+Agents. The existing exact Gateway approval waiter isolation remains unchanged.

--- a/docs/chat-chain-changes/2026-08-22-issue-2684-interrupt-pending-clarification.md
+++ b/docs/chat-chain-changes/2026-08-22-issue-2684-interrupt-pending-clarification.md
@@ -10,3 +10,9 @@ generation. Force-stop claims only that generation's prompt, releases the
 underlying Runtime waiter, emits a resolved event so pending UI clears, and
 rejects late replies without affecting other generations, Sessions, Rooms, or
 Agents. The existing exact Gateway approval waiter isolation remains unchanged.
+
+The concentrated rework preserves the Session and visible run generation when
+internal Agent activity is broadcast to Group Chat. This keeps the real
+`interruptAgent` → `ChatRun.abortSession` path able to claim the matching
+clarification even when the Runtime waiter is not owned by ChatRun's current
+local abort controller.

--- a/packages/server/src/services/ekko-agent/clarifications.ts
+++ b/packages/server/src/services/ekko-agent/clarifications.ts
@@ -14,6 +14,7 @@ export interface EkkoClarificationResolution {
 
 interface PendingEkkoClarification {
   sessionId: string
+  runId: string
   resolve: (response: string) => void
   timer: NodeJS.Timeout
   signal?: AbortSignal
@@ -23,6 +24,7 @@ interface PendingEkkoClarification {
 
 export interface WaitForEkkoClarificationOptions {
   sessionId: string
+  runId?: string
   signal?: AbortSignal
   onRequested: (request: AgentClarificationRequest) => void
   onResolved?: (resolution: EkkoClarificationResolution) => void
@@ -72,6 +74,7 @@ export function waitForEkkoClarification(
     })
     pendingClarifications.set(request.clarifyId, {
       sessionId: options.sessionId,
+      runId: String(options.runId || ''),
       resolve,
       timer,
       signal: options.signal,
@@ -110,6 +113,35 @@ export function respondToEkkoClarification(
     reason: 'response',
   })
   pending.resolve(normalizedResponse)
+  return { handled: true, resolved: true }
+}
+
+export function cancelPendingEkkoClarification(
+  sessionId: string,
+  clarifyId: string,
+  runId: string,
+): EkkoClarificationResponse {
+  const pending = pendingClarifications.get(clarifyId)
+  if (!pending) return { handled: false, resolved: false }
+  if (
+    pending.sessionId !== sessionId
+    || !runId
+    || pending.runId !== runId
+  ) {
+    return { handled: true, resolved: false }
+  }
+
+  pendingClarifications.delete(clarifyId)
+  clearTimeout(pending.timer)
+  if (pending.signal && pending.onAbort) {
+    pending.signal.removeEventListener('abort', pending.onAbort)
+  }
+  const resolution: EkkoClarificationResolution = {
+    response: '[clarification cancelled because the run was aborted]',
+    reason: 'aborted',
+  }
+  pending.onResolved?.(resolution)
+  pending.resolve(resolution.response)
   return { handled: true, resolved: true }
 }
 

--- a/packages/server/src/services/hermes/agent-bridge/client.ts
+++ b/packages/server/src/services/hermes/agent-bridge/client.ts
@@ -699,6 +699,21 @@ export class AgentBridgeClient {
     return this.request({ action: 'clarify_respond', clarify_id: clarifyId, response })
   }
 
+  clarifyCancel(
+    clarifyId: string,
+    sessionId: string,
+    runId: string,
+    profile?: string,
+  ): Promise<AgentBridgeResponse> {
+    return this.request({
+      action: 'clarify_cancel',
+      clarify_id: clarifyId,
+      session_id: sessionId,
+      run_id: runId,
+      ...(profile ? { profile } : {}),
+    })
+  }
+
   compressionRespond(
     requestId: string,
     payload: { messages?: unknown[]; system_message?: string; error?: string },

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_broker.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_broker.py
@@ -334,7 +334,7 @@ class BridgeBroker:
                 raise KeyError(f"unknown approval request: {approval_id}")
             return self._forward(profile, req, worker_key)
 
-        if action == "clarify_respond":
+        if action in {"clarify_respond", "clarify_cancel"}:
             clarify_id = str(req.get("clarify_id") or "").strip()
             if not clarify_id:
                 raise ValueError("clarify_id is required")

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -192,6 +192,7 @@ class AgentPool:
         self._background_notification_claims: dict[tuple[str, str], dict[str, Any]] = {}
         self._suppressed_background_delegations: set[str] = set()
         self._clarify_requests: dict[str, queue.Queue[str]] = {}
+        self._clarify_request_generations: dict[str, tuple[str, str]] = {}
         self._run_context = threading.local()
         self._approval_handlers: dict[str, Callable[..., str]] = {}
         self._exec_ask_depth = 0
@@ -1409,9 +1410,12 @@ class AgentPool:
             clarify_id = uuid.uuid4().hex
             response_queue: queue.Queue[str] = queue.Queue(maxsize=1)
             with self._lock:
+                run_id = str(self._sessions.get(session_id).current_run_id or "") if self._sessions.get(session_id) else ""
                 self._clarify_requests[clarify_id] = response_queue
+                self._clarify_request_generations[clarify_id] = (session_id, run_id)
             self._append_event(session_id, {
                 "event": "clarify.requested",
+                "run_id": run_id,
                 "clarify_id": clarify_id,
                 "question": str(question or ""),
                 "choices": list(choices) if choices else None,
@@ -1424,6 +1428,7 @@ class AgentPool:
             finally:
                 with self._lock:
                     self._clarify_requests.pop(clarify_id, None)
+                    self._clarify_request_generations.pop(clarify_id, None)
             return user_response
 
         return callback
@@ -2061,6 +2066,7 @@ class AgentPool:
             raise RuntimeError("agent does not support interrupt")
         session.agent.interrupt(message)
         self._cancel_pending_approvals_for_generation(session_id, interrupted_run_id)
+        self._cancel_pending_clarifications_for_generation(session_id, interrupted_run_id)
         deadline = time.time() + 10.0
         synced = False
         while time.time() < deadline:
@@ -2120,6 +2126,32 @@ class AgentPool:
                 "reason": "Session interrupted",
             })
         return len(terminal_queues) + len(gateway_approvals)
+
+    def _cancel_pending_clarifications_for_generation(self, session_id: str, run_id: str) -> int:
+        if not session_id or not run_id:
+            return 0
+        pending: list[tuple[str, queue.Queue[str]]] = []
+        with self._lock:
+            for clarify_id, generation in list(self._clarify_request_generations.items()):
+                if generation != (session_id, run_id):
+                    continue
+                response_queue = self._clarify_requests.pop(clarify_id, None)
+                self._clarify_request_generations.pop(clarify_id, None)
+                if response_queue is not None:
+                    pending.append((clarify_id, response_queue))
+        for clarify_id, response_queue in pending:
+            try:
+                response_queue.put_nowait("[clarification cancelled because the run was interrupted]")
+            except queue.Full:
+                pass
+            self._append_event(session_id, {
+                "event": "clarify.resolved",
+                "run_id": run_id,
+                "clarify_id": clarify_id,
+                "resolved": False,
+                "reason": "interrupted",
+            })
+        return len(pending)
 
     def request_boundary_interrupt(
         self,
@@ -2264,6 +2296,28 @@ class AgentPool:
             response_queue.put_nowait(response)
         except queue.Full:
             pass
+        return {"clarify_id": clarify_id, "resolved": True}
+
+    def cancel_clarify(self, clarify_id: str, session_id: str, run_id: str) -> dict[str, Any]:
+        with self._lock:
+            generation = self._clarify_request_generations.get(clarify_id)
+            if generation != (session_id, run_id):
+                return {"clarify_id": clarify_id, "resolved": False}
+            response_queue = self._clarify_requests.pop(clarify_id, None)
+            self._clarify_request_generations.pop(clarify_id, None)
+        if response_queue is None:
+            return {"clarify_id": clarify_id, "resolved": False}
+        try:
+            response_queue.put_nowait("[clarification cancelled because the run was interrupted]")
+        except queue.Full:
+            pass
+        self._append_event(session_id, {
+            "event": "clarify.resolved",
+            "run_id": run_id,
+            "clarify_id": clarify_id,
+            "resolved": False,
+            "reason": "interrupted",
+        })
         return {"clarify_id": clarify_id, "resolved": True}
 
     def get_history(self, session_id: str) -> dict[str, Any]:

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -185,8 +185,8 @@ class AgentPool:
         self._lock = threading.RLock()
         self._db = SessionDbHolder()
         self._approval_requests: dict[str, queue.Queue[str]] = {}
-        self._approval_request_sessions: dict[str, str] = {}
-        self._gateway_approval_requests: dict[str, str] = {}
+        self._approval_request_generations: dict[str, tuple[str, str]] = {}
+        self._gateway_approval_requests: dict[str, tuple[str, str]] = {}
         self._gateway_approval_pattern_keys: dict[str, list[str]] = {}
         self._compression_requests: dict[str, queue.Queue[dict[str, Any]]] = {}
         self._background_notification_claims: dict[tuple[str, str], dict[str, Any]] = {}
@@ -1372,11 +1372,13 @@ class AgentPool:
             approval_id = uuid.uuid4().hex
             response_queue: queue.Queue[str] = queue.Queue(maxsize=1)
             with self._lock:
+                run_id = str(self._sessions.get(session_id).current_run_id or "") if self._sessions.get(session_id) else ""
                 self._approval_requests[approval_id] = response_queue
-                self._approval_request_sessions[approval_id] = session_id
+                self._approval_request_generations[approval_id] = (session_id, run_id)
             choices = ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
             self._append_event(session_id, {
                 "event": "approval.requested",
+                "run_id": run_id,
                 "approval_id": approval_id,
                 "command": str(command or ""),
                 "description": str(description or ""),
@@ -1391,9 +1393,10 @@ class AgentPool:
             finally:
                 with self._lock:
                     self._approval_requests.pop(approval_id, None)
-                    self._approval_request_sessions.pop(approval_id, None)
+                    self._approval_request_generations.pop(approval_id, None)
             self._append_event(session_id, {
                 "event": "approval.resolved",
+                "run_id": run_id,
                 "approval_id": approval_id,
                 "choice": choice,
             })
@@ -1471,10 +1474,12 @@ class AgentPool:
             choices = ["once", "session", "always", "deny"]
             pattern_keys = _approval_pattern_keys(approval_data)
             with self._lock:
-                self._gateway_approval_requests[approval_id] = session_id
+                run_id = str(self._sessions.get(session_id).current_run_id or "") if self._sessions.get(session_id) else ""
+                self._gateway_approval_requests[approval_id] = (session_id, run_id)
                 self._gateway_approval_pattern_keys[approval_id] = pattern_keys
             self._append_event(session_id, {
                 "event": "approval.requested",
+                "run_id": run_id,
                 "approval_id": approval_id,
                 "command": str(approval_data.get("command") or ""),
                 "description": str(approval_data.get("description") or ""),
@@ -2042,6 +2047,7 @@ class AgentPool:
             raise KeyError(f"unknown session: {session_id}")
         with session.lock:
             self._cancel_boundary_run(session)
+            interrupted_run_id = str(session.current_run_id or "")
         background_delegation_ids = self._background_delegation_ids_for_session(session_id)
         with self._lock:
             self._suppressed_background_delegations.update(background_delegation_ids)
@@ -2053,7 +2059,7 @@ class AgentPool:
         if not hasattr(session.agent, "interrupt"):
             raise RuntimeError("agent does not support interrupt")
         session.agent.interrupt(message)
-        self._cancel_pending_approvals_for_session(session_id)
+        self._cancel_pending_approvals_for_generation(session_id, interrupted_run_id)
         deadline = time.time() + 10.0
         synced = False
         while time.time() < deadline:
@@ -2070,19 +2076,21 @@ class AgentPool:
             "background_delegation_ids": background_delegation_ids,
         }
 
-    def _cancel_pending_approvals_for_session(self, session_id: str) -> int:
+    def _cancel_pending_approvals_for_generation(self, session_id: str, run_id: str) -> int:
+        if not session_id or not run_id:
+            return 0
         terminal_queues: list[queue.Queue[str]] = []
         gateway_approvals: list[tuple[str, list[str]]] = []
         with self._lock:
-            for approval_id, approval_session_id in list(self._approval_request_sessions.items()):
-                if approval_session_id != session_id:
+            for approval_id, approval_generation in list(self._approval_request_generations.items()):
+                if approval_generation != (session_id, run_id):
                     continue
                 response_queue = self._approval_requests.pop(approval_id, None)
-                self._approval_request_sessions.pop(approval_id, None)
+                self._approval_request_generations.pop(approval_id, None)
                 if response_queue is not None:
                     terminal_queues.append(response_queue)
-            for approval_id, approval_session_id in list(self._gateway_approval_requests.items()):
-                if approval_session_id != session_id:
+            for approval_id, approval_generation in list(self._gateway_approval_requests.items()):
+                if approval_generation != (session_id, run_id):
                     continue
                 self._gateway_approval_requests.pop(approval_id, None)
                 gateway_approvals.append((
@@ -2103,6 +2111,7 @@ class AgentPool:
                 pass
             self._append_event(session_id, {
                 "event": "approval.resolved",
+                "run_id": run_id,
                 "approval_id": approval_id,
                 "choice": "deny",
                 "reason": "Session interrupted",
@@ -2210,17 +2219,18 @@ class AgentPool:
         with self._lock:
             response_queue = self._approval_requests.pop(approval_id, None)
             if response_queue is not None:
-                self._approval_request_sessions.pop(approval_id, None)
+                self._approval_request_generations.pop(approval_id, None)
                 try:
                     response_queue.put_nowait(cleaned)
                 except queue.Full:
                     pass
         if response_queue is None:
             with self._lock:
-                gateway_session_id = self._gateway_approval_requests.pop(approval_id, None)
+                gateway_generation = self._gateway_approval_requests.pop(approval_id, None)
                 pattern_keys = self._gateway_approval_pattern_keys.pop(approval_id, [])
-            if gateway_session_id is None:
+            if gateway_generation is None:
                 return {"approval_id": approval_id, "resolved": False, "choice": cleaned}
+            gateway_session_id, gateway_run_id = gateway_generation
             try:
                 from tools.approval import resolve_gateway_approval
 
@@ -2231,6 +2241,7 @@ class AgentPool:
                 _persist_execute_code_approval_choice(gateway_session_id, pattern_keys, cleaned)
             self._append_event(gateway_session_id, {
                 "event": "approval.resolved",
+                "run_id": gateway_run_id,
                 "approval_id": approval_id,
                 "choice": cleaned,
             })

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -186,7 +186,7 @@ class AgentPool:
         self._db = SessionDbHolder()
         self._approval_requests: dict[str, queue.Queue[str]] = {}
         self._approval_request_generations: dict[str, tuple[str, str]] = {}
-        self._gateway_approval_requests: dict[str, tuple[str, str]] = {}
+        self._gateway_approval_requests: dict[str, tuple[str, str, str]] = {}
         self._gateway_approval_pattern_keys: dict[str, list[str]] = {}
         self._compression_requests: dict[str, queue.Queue[dict[str, Any]]] = {}
         self._background_notification_claims: dict[tuple[str, str], dict[str, Any]] = {}
@@ -1473,9 +1473,10 @@ class AgentPool:
             approval_id = uuid.uuid4().hex
             choices = ["once", "session", "always", "deny"]
             pattern_keys = _approval_pattern_keys(approval_data)
+            request_id = str(approval_data.get("request_id") or "").strip()
             with self._lock:
                 run_id = str(self._sessions.get(session_id).current_run_id or "") if self._sessions.get(session_id) else ""
-                self._gateway_approval_requests[approval_id] = (session_id, run_id)
+                self._gateway_approval_requests[approval_id] = (session_id, run_id, request_id)
                 self._gateway_approval_pattern_keys[approval_id] = pattern_keys
             self._append_event(session_id, {
                 "event": "approval.requested",
@@ -2080,7 +2081,7 @@ class AgentPool:
         if not session_id or not run_id:
             return 0
         terminal_queues: list[queue.Queue[str]] = []
-        gateway_approvals: list[tuple[str, list[str]]] = []
+        gateway_approvals: list[tuple[str, str, list[str]]] = []
         with self._lock:
             for approval_id, approval_generation in list(self._approval_request_generations.items()):
                 if approval_generation != (session_id, run_id):
@@ -2090,11 +2091,12 @@ class AgentPool:
                 if response_queue is not None:
                     terminal_queues.append(response_queue)
             for approval_id, approval_generation in list(self._gateway_approval_requests.items()):
-                if approval_generation != (session_id, run_id):
+                if approval_generation[:2] != (session_id, run_id):
                     continue
                 self._gateway_approval_requests.pop(approval_id, None)
                 gateway_approvals.append((
                     approval_id,
+                    approval_generation[2],
                     self._gateway_approval_pattern_keys.pop(approval_id, []),
                 ))
         for response_queue in terminal_queues:
@@ -2102,11 +2104,12 @@ class AgentPool:
                 response_queue.put_nowait("deny")
             except queue.Full:
                 pass
-        for approval_id, _pattern_keys in gateway_approvals:
+        for approval_id, request_id, _pattern_keys in gateway_approvals:
             try:
                 from tools.approval import resolve_gateway_approval
 
-                resolve_gateway_approval(session_id, "deny")
+                if request_id:
+                    resolve_gateway_approval(session_id, "deny", request_id=request_id)
             except Exception:
                 pass
             self._append_event(session_id, {
@@ -2230,11 +2233,15 @@ class AgentPool:
                 pattern_keys = self._gateway_approval_pattern_keys.pop(approval_id, [])
             if gateway_generation is None:
                 return {"approval_id": approval_id, "resolved": False, "choice": cleaned}
-            gateway_session_id, gateway_run_id = gateway_generation
+            gateway_session_id, gateway_run_id, gateway_request_id = gateway_generation
             try:
                 from tools.approval import resolve_gateway_approval
 
-                resolved = resolve_gateway_approval(gateway_session_id, cleaned) > 0
+                resolved = bool(gateway_request_id) and resolve_gateway_approval(
+                    gateway_session_id,
+                    cleaned,
+                    request_id=gateway_request_id,
+                ) > 0
             except Exception:
                 resolved = False
             if resolved:

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -185,6 +185,7 @@ class AgentPool:
         self._lock = threading.RLock()
         self._db = SessionDbHolder()
         self._approval_requests: dict[str, queue.Queue[str]] = {}
+        self._approval_request_sessions: dict[str, str] = {}
         self._gateway_approval_requests: dict[str, str] = {}
         self._gateway_approval_pattern_keys: dict[str, list[str]] = {}
         self._compression_requests: dict[str, queue.Queue[dict[str, Any]]] = {}
@@ -1372,6 +1373,7 @@ class AgentPool:
             response_queue: queue.Queue[str] = queue.Queue(maxsize=1)
             with self._lock:
                 self._approval_requests[approval_id] = response_queue
+                self._approval_request_sessions[approval_id] = session_id
             choices = ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
             self._append_event(session_id, {
                 "event": "approval.requested",
@@ -1389,6 +1391,7 @@ class AgentPool:
             finally:
                 with self._lock:
                     self._approval_requests.pop(approval_id, None)
+                    self._approval_request_sessions.pop(approval_id, None)
             self._append_event(session_id, {
                 "event": "approval.resolved",
                 "approval_id": approval_id,
@@ -2050,6 +2053,7 @@ class AgentPool:
         if not hasattr(session.agent, "interrupt"):
             raise RuntimeError("agent does not support interrupt")
         session.agent.interrupt(message)
+        self._cancel_pending_approvals_for_session(session_id)
         deadline = time.time() + 10.0
         synced = False
         while time.time() < deadline:
@@ -2065,6 +2069,45 @@ class AgentPool:
             "background_interrupted": background_interrupted,
             "background_delegation_ids": background_delegation_ids,
         }
+
+    def _cancel_pending_approvals_for_session(self, session_id: str) -> int:
+        terminal_queues: list[queue.Queue[str]] = []
+        gateway_approvals: list[tuple[str, list[str]]] = []
+        with self._lock:
+            for approval_id, approval_session_id in list(self._approval_request_sessions.items()):
+                if approval_session_id != session_id:
+                    continue
+                response_queue = self._approval_requests.pop(approval_id, None)
+                self._approval_request_sessions.pop(approval_id, None)
+                if response_queue is not None:
+                    terminal_queues.append(response_queue)
+            for approval_id, approval_session_id in list(self._gateway_approval_requests.items()):
+                if approval_session_id != session_id:
+                    continue
+                self._gateway_approval_requests.pop(approval_id, None)
+                gateway_approvals.append((
+                    approval_id,
+                    self._gateway_approval_pattern_keys.pop(approval_id, []),
+                ))
+        for response_queue in terminal_queues:
+            try:
+                response_queue.put_nowait("deny")
+            except queue.Full:
+                pass
+        for approval_id, _pattern_keys in gateway_approvals:
+            try:
+                from tools.approval import resolve_gateway_approval
+
+                resolve_gateway_approval(session_id, "deny")
+            except Exception:
+                pass
+            self._append_event(session_id, {
+                "event": "approval.resolved",
+                "approval_id": approval_id,
+                "choice": "deny",
+                "reason": "Session interrupted",
+            })
+        return len(terminal_queues) + len(gateway_approvals)
 
     def request_boundary_interrupt(
         self,
@@ -2165,7 +2208,13 @@ class AgentPool:
         if cleaned not in {"once", "session", "always", "deny"}:
             cleaned = "deny"
         with self._lock:
-            response_queue = self._approval_requests.get(approval_id)
+            response_queue = self._approval_requests.pop(approval_id, None)
+            if response_queue is not None:
+                self._approval_request_sessions.pop(approval_id, None)
+                try:
+                    response_queue.put_nowait(cleaned)
+                except queue.Full:
+                    pass
         if response_queue is None:
             with self._lock:
                 gateway_session_id = self._gateway_approval_requests.pop(approval_id, None)
@@ -2186,10 +2235,6 @@ class AgentPool:
                 "choice": cleaned,
             })
             return {"approval_id": approval_id, "resolved": resolved, "choice": cleaned}
-        try:
-            response_queue.put_nowait(cleaned)
-        except queue.Full:
-            pass
         return {"approval_id": approval_id, "resolved": True, "choice": cleaned}
 
     def respond_clarify(self, clarify_id: str, response: str) -> dict[str, Any]:

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_server.py
@@ -215,6 +215,14 @@ class BridgeServer:
             response = str(req.get("response") or "").strip()
             return self.pool.respond_clarify(clarify_id, response)
 
+        if action == "clarify_cancel":
+            clarify_id = str(req.get("clarify_id") or "").strip()
+            session_id = str(req.get("session_id") or "").strip()
+            run_id = str(req.get("run_id") or "").strip()
+            if not clarify_id or not session_id or not run_id:
+                raise ValueError("clarify_id, session_id, and run_id are required")
+            return self.pool.cancel_clarify(clarify_id, session_id, run_id)
+
         if action == "compression_respond":
             request_id = str(req.get("request_id") or "").strip()
             if not request_id:

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -21,6 +21,7 @@ import {
     stripMentionRoutingTokens,
 } from './mention-routing'
 import { buildAgentInstructions, buildNonOwnerRequestSecurityPrompt } from '../context-engine/prompt'
+import { cancelPendingEkkoClarification } from '../../ekko-agent/clarifications'
 
 export const GROUP_CHAT_AGENT_SOCKET_SECRET = randomBytes(32).toString('hex')
 
@@ -238,6 +239,7 @@ export interface GroupAgentExecutor {
     isActiveSession(roomId: string, sessionId: string): boolean
     respondApproval?(approvalId: string, choice: string): Promise<boolean>
     respondClarify?(clarifyId: string, response: string): Promise<boolean>
+    cancelClarify?(clarifyId: string, sessionId: string, runId: string): Promise<boolean>
     replyToMention(
         roomId: string,
         msg: MentionMessage,
@@ -462,6 +464,19 @@ export class AgentClient implements GroupAgentExecutor {
             if (this.chatRunService.respondCodingAgentClarification(sessionId, clarifyId, response)) return Promise.resolve(true)
         }
         return Promise.resolve(false)
+    }
+
+    async cancelClarify(clarifyId: string, sessionId: string, runId: string): Promise<boolean> {
+        if (this.agent !== 'hermes') {
+            return cancelPendingEkkoClarification(sessionId, clarifyId, runId).resolved
+        }
+        const result = await new AgentBridgeClient().clarifyCancel(
+            clarifyId,
+            sessionId,
+            runId,
+            this.profile,
+        )
+        return Boolean((result as any)?.resolved)
     }
 
     async joinRoom(roomId: string): Promise<JoinResult> {
@@ -1159,7 +1174,13 @@ export class AgentClient implements GroupAgentExecutor {
                     } else if (event === 'approval.resolved') {
                         this.emitApprovalResolved(roomId, { ...payload, agentSessionId: sessionId })
                     } else if (event === 'clarify.requested') {
-                        this.emitClarifyRequested(roomId, { ...payload, agentSessionId: sessionId })
+                        const { run_id: runtimeRunId, runId: runtimeCamelRunId, ...clarifyPayload } = payload
+                        this.emitClarifyRequested(roomId, {
+                            ...clarifyPayload,
+                            agentSessionId: sessionId,
+                            runId: responseRunId,
+                            runtimeRunId: String(runtimeRunId || runtimeCamelRunId || ''),
+                        })
                     } else if (event === 'clarify.resolved') {
                         this.emitClarifyResolved(roomId, { ...payload, agentSessionId: sessionId })
                     }
@@ -1579,6 +1600,8 @@ export class AgentClient implements GroupAgentExecutor {
                 this.emitClarifyRequested(roomId, {
                     event: 'clarify.requested',
                     agentSessionId: sessionId,
+                    runId: responseRunId,
+                    runtimeRunId: String((ev as any).run_id || (ev as any).runId || ''),
                     clarify_id: (ev as any).clarify_id,
                     question: (ev as any).question,
                     choices: Array.isArray((ev as any).choices) ? (ev as any).choices : null,

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -1150,7 +1150,12 @@ export class AgentClient implements GroupAgentExecutor {
                     } else if (event === 'tool.completed' || event === 'tool.failed') {
                         queueToolEventWrite(() => this.recordToolCompleted(roomId, sessionId, { ...payload, event }).then(() => undefined))
                     } else if (event === 'approval.requested') {
-                        this.emitApprovalRequested(roomId, { ...payload, agentSessionId: sessionId })
+                        const { run_id: _runtimeRunId, runId: _runtimeCamelRunId, ...approvalPayload } = payload
+                        this.emitApprovalRequested(roomId, {
+                            ...approvalPayload,
+                            agentSessionId: sessionId,
+                            runId: responseRunId,
+                        })
                     } else if (event === 'approval.resolved') {
                         this.emitApprovalResolved(roomId, { ...payload, agentSessionId: sessionId })
                     } else if (event === 'clarify.requested') {

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -108,6 +108,7 @@ type AgentActivityBroadcaster = (
     agentName: string,
     status: 'compressing' | 'replying' | 'ready',
     runId?: string,
+    agentSessionId?: string,
 ) => void
 type ExecutionQueueBroadcaster = (roomId: string) => void
 
@@ -2224,8 +2225,9 @@ export class AgentClients {
         agentName: string,
         status: 'compressing' | 'replying' | 'ready',
         runId?: string,
+        agentSessionId?: string,
     ): void {
-        this._activityBroadcaster?.(roomId, agentName, status, runId)
+        this._activityBroadcaster?.(roomId, agentName, status, runId, agentSessionId)
         logger.debug(`[AgentClients] room ${roomId} agent ${agentName} status: ${status}`)
     }
 
@@ -2644,7 +2646,10 @@ export class AgentClients {
                         const { agent } = runnableTarget
                         const onStatus = (status: 'compressing' | 'replying' | 'ready', extra?: Record<string, unknown>) => {
                             const runId = typeof extra?.runId === 'string' ? extra.runId : undefined
-                            this.reportAgentActivity(roomId, agent.name, status, runId)
+                            const agentSessionId = typeof extra?.agentSessionId === 'string'
+                                ? extra.agentSessionId
+                                : undefined
+                            this.reportAgentActivity(roomId, agent.name, status, runId, agentSessionId)
                         }
                         if (next.msg.continuationAttemptId) {
                             if (!agent.connected) {

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -1555,6 +1555,7 @@ export class AgentClient implements GroupAgentExecutor {
                 this.emitApprovalRequested(roomId, {
                     event: 'approval.requested',
                     agentSessionId: sessionId,
+                    runId: responseRunId,
                     approval_id: (ev as any).approval_id,
                     command: (ev as any).command,
                     description: (ev as any).description,

--- a/packages/server/src/services/hermes/group-chat/agent-relay.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-relay.ts
@@ -975,6 +975,10 @@ class RelayGroupAgentExecutor implements GroupAgentExecutor {
     })
   }
 
+  async cancelClarify(clarifyId: string, _sessionId: string, _runId: string): Promise<boolean> {
+    return !this.pendingRun?.clarifyIds.has(clarifyId)
+  }
+
   private remoteMessageId(pending: PendingRelayRun, value: unknown, create: boolean): string {
     const remoteId = String(value || '').trim()
     if (!remoteId || remoteId.length > 240) throw relayError('Invalid remote message id', 'GROUP_AGENT_EVENT_INVALID')

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -108,6 +108,8 @@ interface PendingGroupClarifyRoute {
     roomId: string
     agentName: string
     agentSessionId: string
+    runId: string
+    runtimeRunId: string
     clarifyId: string
     question: string
     choices: string[] | null
@@ -4876,9 +4878,16 @@ export class GroupChatServer {
             activeGeneration?.agentSessionId || '',
             activeGeneration?.runId || '',
         )
+        const interruptedClarifications = this.takePendingClarificationsForGeneration(
+            roomId,
+            agentName,
+            activeGeneration?.agentSessionId || '',
+            activeGeneration?.runId || '',
+        )
         try {
             await this.agentClients.interruptAgent(roomId, agentName)
             await this.settleInterruptedApprovals(interruptedApprovals)
+            await this.settleInterruptedClarifications(interruptedClarifications)
             const roomStatuses = this.contextStatusState.get(roomId)
             roomStatuses?.delete(agentName)
             if (roomStatuses?.size === 0) this.contextStatusState.delete(roomId)
@@ -4890,6 +4899,7 @@ export class GroupChatServer {
             ack?.({ ok: true })
         } catch (err: any) {
             await this.settleInterruptedApprovals(interruptedApprovals)
+            await this.settleInterruptedClarifications(interruptedClarifications)
             logger.warn(`[GroupChat] failed to interrupt agent ${agentName} in room ${roomId}: ${err.message}`)
             ack?.({ error: err.message || 'interrupt failed' })
         }
@@ -5079,6 +5089,65 @@ export class GroupChatServer {
         }
     }
 
+    private takePendingClarificationsForGeneration(
+        roomId: string,
+        agentName: string,
+        agentSessionId: string,
+        runId: string,
+    ): PendingGroupClarifyRoute[] {
+        if (!agentSessionId || !runId || !(this.pendingClarifyRoutes instanceof Map)) return []
+        const routes: PendingGroupClarifyRoute[] = []
+        for (const [routeKey, route] of this.pendingClarifyRoutes) {
+            if (route.roomId !== roomId
+                || route.agentName !== agentName
+                || route.agentSessionId !== agentSessionId
+                || !route.runId
+                || route.runId !== runId
+                || !route.runtimeRunId) {
+                continue
+            }
+            const claimed = this.takePendingClarifyRoute(routeKey)
+            if (claimed) routes.push(claimed)
+        }
+        return routes
+    }
+
+    private async settleInterruptedClarifications(routes: PendingGroupClarifyRoute[]): Promise<void> {
+        for (const route of routes) {
+            let resolved = false
+            const executor = this.agentClients.getAgents(route.roomId).find(agent =>
+                agent.name === route.agentName && typeof agent.cancelClarify === 'function'
+            )
+            try {
+                resolved = Boolean(await executor?.cancelClarify?.(
+                    route.clarifyId,
+                    route.agentSessionId,
+                    route.runtimeRunId,
+                ))
+                if (!resolved && route.runtimeRunId) {
+                    resolved = Boolean((await new AgentBridgeClient().clarifyCancel(
+                        route.clarifyId,
+                        route.agentSessionId,
+                        route.runtimeRunId,
+                    ) as any)?.resolved)
+                }
+            } catch (err: any) {
+                if (!isExpiredInteractionError(err?.message || err)) {
+                    logger.warn(`[GroupChat] failed to cancel interrupted clarification ${route.clarifyId}: ${err?.message || err}`)
+                }
+            }
+            this.emitToRoomManagers(route.roomId, 'clarify.resolved', {
+                event: 'clarify.resolved',
+                roomId: route.roomId,
+                agentName: route.agentName,
+                clarify_id: route.clarifyId,
+                resolved: false,
+                reason: 'Agent run interrupted',
+                runtime_resolved: resolved,
+            })
+        }
+    }
+
     private handleApprovalResolved(socket: Socket, data: { roomId?: string; agentName?: string; approval_id?: string; choice?: string; agentSessionId?: string }): void {
         const roomId = data.roomId
         const agentName = data.agentName || ''
@@ -5189,7 +5258,7 @@ export class GroupChatServer {
         }
     }
 
-    private handleClarifyRequested(socket: Socket, data: { roomId?: string; agentName?: string; clarify_id?: string; question?: string; choices?: string[] | null; initial_response?: string; response_mode?: string; timeout_ms?: number; agentSessionId?: string }): void {
+    private handleClarifyRequested(socket: Socket, data: { roomId?: string; agentName?: string; clarify_id?: string; question?: string; choices?: string[] | null; initial_response?: string; response_mode?: string; timeout_ms?: number; agentSessionId?: string; runId?: string; runtimeRunId?: string }): void {
         const roomId = data.roomId
         const agentName = data.agentName || ''
         if (!roomId || !data.clarify_id || !this.getCurrentAgentEventMember(socket, roomId, agentName, data.agentSessionId)) return
@@ -5200,6 +5269,8 @@ export class GroupChatServer {
             roomId,
             agentName,
             agentSessionId: String(data.agentSessionId || '').trim(),
+            runId: String(data.runId || '').trim(),
+            runtimeRunId: String(data.runtimeRunId || '').trim(),
             clarifyId: data.clarify_id,
             question: data.question || '',
             choices: Array.isArray(data.choices) ? data.choices.map(String) : null,

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -3277,7 +3277,7 @@ export class GroupChatServer {
             this.agentClients.getAgent(roomId, agentId)?.connected === true
         )
         this.agentClients.setRoomSummaryService(this.roomSummaryService)
-        this.agentClients.setActivityBroadcaster((roomId, agentName, status, runId) => {
+        this.agentClients.setActivityBroadcaster((roomId, agentName, status, runId, agentSessionId) => {
             let roomStatuses = this.contextStatusState.get(roomId)
             if (status === 'ready') {
                 roomStatuses?.delete(agentName)
@@ -3287,7 +3287,12 @@ export class GroupChatServer {
                     roomStatuses = new Map()
                     this.contextStatusState.set(roomId, roomStatuses)
                 }
-                roomStatuses.set(agentName, { agentName, status })
+                roomStatuses.set(agentName, {
+                    agentName,
+                    status,
+                    ...(runId ? { runId } : {}),
+                    ...(agentSessionId ? { agentSessionId } : {}),
+                })
             }
             this.nsp.to(roomId).emit('context_status', { roomId, agentName, status })
             if (runId) this.updateRoomAgentActivity(roomId, agentName, status, runId)

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -94,6 +94,7 @@ interface PendingGroupApprovalRoute {
     agentName: string
     ownerMemberId: string
     agentSessionId: string
+    runId: string
     approvalId: string
     command: string
     description: string
@@ -3116,6 +3117,7 @@ export class GroupChatServer {
         agentName: string
         status: string
         agentSessionId?: string
+        runId?: string
     }>>()
     /** Stable room + persisted Agent row + run activity visible across authorized rooms. */
     private roomAgentActivityState = new Map<string, Map<string, GroupAgentActivity>>()
@@ -3909,7 +3911,7 @@ export class GroupChatServer {
         socket.on('cancel_execution_queue_item', (data: { roomId?: string; queueId?: string; executionQueueCapability?: string }, ack?: (response?: unknown) => void) => this.handleCancelExecutionQueueItem(socket, data, ack))
         socket.on('interrupt_agent', (data: { roomId?: string; agentName?: string }, ack?: (response?: unknown) => void) => this.handleInterruptAgent(socket, data, ack))
         socket.on('remove_agent', (data: { roomId?: string; agentId?: string }, ack?: (response?: unknown) => void) => this.handleRemoveAgent(socket, data, ack))
-        socket.on('approval.requested', (data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; timeout_ms?: number; agentSessionId?: string }) => this.handleApprovalRequested(socket, data))
+        socket.on('approval.requested', (data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; timeout_ms?: number; agentSessionId?: string; runId?: string }) => this.handleApprovalRequested(socket, data))
         socket.on('approval.resolved', (data: { roomId?: string; agentName?: string; approval_id?: string; choice?: string; agentSessionId?: string }) => this.handleApprovalResolved(socket, data))
         socket.on('approval.respond', (data: { roomId?: string; approval_id?: string; choice?: string }, ack?: (response?: unknown) => void) => this.handleApprovalRespond(socket, data, ack))
         socket.on('clarify.requested', (data: { roomId?: string; agentName?: string; clarify_id?: string; question?: string; choices?: string[] | null; initial_response?: string; response_mode?: string; timeout_ms?: number; agentSessionId?: string }) => this.handleClarifyRequested(socket, data))
@@ -4836,6 +4838,7 @@ export class GroupChatServer {
                 agentName,
                 status,
                 ...(agentSessionId ? { agentSessionId } : {}),
+                ...(typeof data.runId === 'string' && data.runId.trim() ? { runId: data.runId.trim() } : {}),
             })
         }
 
@@ -4866,8 +4869,16 @@ export class GroupChatServer {
             ack?.({ error: 'Access denied' })
             return
         }
+        const activeGeneration = this.contextStatusState.get(roomId)?.get(agentName)
+        const interruptedApprovals = this.takePendingApprovalsForGeneration(
+            roomId,
+            agentName,
+            activeGeneration?.agentSessionId || '',
+            activeGeneration?.runId || '',
+        )
         try {
             await this.agentClients.interruptAgent(roomId, agentName)
+            await this.settleInterruptedApprovals(interruptedApprovals)
             const roomStatuses = this.contextStatusState.get(roomId)
             roomStatuses?.delete(agentName)
             if (roomStatuses?.size === 0) this.contextStatusState.delete(roomId)
@@ -4878,6 +4889,7 @@ export class GroupChatServer {
             this.nsp.to(roomId).emit('context_status', { roomId, agentName, status: 'ready' })
             ack?.({ ok: true })
         } catch (err: any) {
+            await this.settleInterruptedApprovals(interruptedApprovals)
             logger.warn(`[GroupChat] failed to interrupt agent ${agentName} in room ${roomId}: ${err.message}`)
             ack?.({ error: err.message || 'interrupt failed' })
         }
@@ -4978,7 +4990,7 @@ export class GroupChatServer {
         })
     }
 
-    private handleApprovalRequested(socket: Socket, data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; timeout_ms?: number; agentSessionId?: string }): void {
+    private handleApprovalRequested(socket: Socket, data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; timeout_ms?: number; agentSessionId?: string; runId?: string }): void {
         const roomId = data.roomId
         const agentName = data.agentName || ''
         if (!roomId || !data.approval_id || !this.getCurrentAgentEventMember(socket, roomId, agentName, data.agentSessionId)) return
@@ -4990,6 +5002,7 @@ export class GroupChatServer {
             agentName,
             ownerMemberId: this.groupAgentOwnerMemberId(roomId, agentName),
             agentSessionId: String(data.agentSessionId || '').trim(),
+            runId: String(data.runId || '').trim(),
             approvalId: data.approval_id,
             command: data.command || '',
             description: data.description || '',
@@ -5014,6 +5027,55 @@ export class GroupChatServer {
             allow_permanent: Boolean(data.allow_permanent),
             timeout_ms: pendingRoute.timeoutMs,
         })
+    }
+
+    private takePendingApprovalsForGeneration(
+        roomId: string,
+        agentName: string,
+        agentSessionId: string,
+        runId: string,
+    ): PendingGroupApprovalRoute[] {
+        if (!agentSessionId) return []
+        const routes: PendingGroupApprovalRoute[] = []
+        for (const [routeKey, route] of this.pendingApprovalRoutes) {
+            if (route.roomId !== roomId
+                || route.agentName !== agentName
+                || route.agentSessionId !== agentSessionId
+                || (runId && route.runId && route.runId !== runId)) {
+                continue
+            }
+            const claimed = this.takePendingApprovalRoute(routeKey)
+            if (claimed) routes.push(claimed)
+        }
+        return routes
+    }
+
+    private async settleInterruptedApprovals(routes: PendingGroupApprovalRoute[]): Promise<void> {
+        for (const route of routes) {
+            let resolved = false
+            const executor = this.agentClients.getAgents(route.roomId).find(agent =>
+                agent.name === route.agentName && typeof agent.respondApproval === 'function'
+            )
+            try {
+                resolved = Boolean(await executor?.respondApproval?.(route.approvalId, 'deny'))
+                if (!resolved) {
+                    resolved = Boolean((await new AgentBridgeClient().approvalRespond(route.approvalId, 'deny') as any)?.resolved)
+                }
+            } catch (err: any) {
+                if (!isExpiredInteractionError(err?.message || err)) {
+                    logger.warn(`[GroupChat] failed to cancel interrupted approval ${route.approvalId}: ${err?.message || err}`)
+                }
+            }
+            this.emitToAgentApprovalOwner(route, 'approval.resolved', {
+                event: 'approval.resolved',
+                roomId: route.roomId,
+                agentName: route.agentName,
+                approval_id: route.approvalId,
+                choice: 'deny',
+                reason: 'Agent run interrupted',
+                resolved,
+            })
+        }
     }
 
     private handleApprovalResolved(socket: Socket, data: { roomId?: string; agentName?: string; approval_id?: string; choice?: string; agentSessionId?: string }): void {

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -5035,13 +5035,14 @@ export class GroupChatServer {
         agentSessionId: string,
         runId: string,
     ): PendingGroupApprovalRoute[] {
-        if (!agentSessionId) return []
+        if (!agentSessionId || !runId || !(this.pendingApprovalRoutes instanceof Map)) return []
         const routes: PendingGroupApprovalRoute[] = []
         for (const [routeKey, route] of this.pendingApprovalRoutes) {
             if (route.roomId !== roomId
                 || route.agentName !== agentName
                 || route.agentSessionId !== agentSessionId
-                || (runId && route.runId && route.runId !== runId)) {
+                || !route.runId
+                || route.runId !== runId) {
                 continue
             }
             const claimed = this.takePendingApprovalRoute(routeKey)

--- a/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
@@ -1204,6 +1204,7 @@ export async function handleEkkoAgentRun(
       }),
       requestUserClarification: (request: AgentClarificationRequest) => waitForEkkoClarification(request, {
         sessionId,
+        runId: runId || turnId,
         signal: abortController.signal,
         onRequested: pending => {
           emit('clarify.requested', {

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -765,6 +765,35 @@ test.describe('group chat room deep links', () => {
     }
   })
 
+  test('removes an interrupted run clarification and does not restore it after reload', async ({ page }) => {
+    await setup(page, '/#/hermes/group-chat/room/room-alpha')
+
+    await triggerGroupSocket(page, 'clarify.requested', {
+      event: 'clarify.requested',
+      roomId: 'room-alpha',
+      agentName: 'Worker',
+      clarify_id: 'clarify-interrupted',
+      question: 'Which city should I use?',
+      choices: null,
+      timeout_ms: 300_000,
+    })
+    await expect(page.locator('.approval-float-panel')).toContainText('Which city should I use?')
+
+    await triggerGroupSocket(page, 'clarify.resolved', {
+      event: 'clarify.resolved',
+      roomId: 'room-alpha',
+      agentName: 'Worker',
+      clarify_id: 'clarify-interrupted',
+      resolved: false,
+      reason: 'Agent run interrupted',
+    })
+    await expect(page.locator('.approval-float-panel')).toHaveCount(0)
+
+    await page.reload()
+    await expect(page).toHaveURL(/#\/hermes\/group-chat\/room\/room-alpha$/)
+    await expect(page.locator('.approval-float-panel')).toHaveCount(0)
+  })
+
   test('loads all group history by stable cursor beyond 600 messages with retry, de-duplication, and anchor preservation', async ({ page }) => {
     test.setTimeout(45_000)
     const api = await setup(page, '/#/hermes/group-chat/room/room-alpha')

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -735,6 +735,36 @@ test.describe('group chat room deep links', () => {
     await expect(betaGrid.locator('[data-agent-id="agent-row-runtime"]')).toHaveClass(/is-active/)
   })
 
+  test('removes an interrupted run approval from the room approval surface', async ({ page }) => {
+    await setup(page, '/#/hermes/group-chat/room/room-alpha')
+
+    await triggerGroupSocket(page, 'approval.requested', {
+      event: 'approval.requested',
+      roomId: 'room-alpha',
+      agentName: 'Worker',
+      approval_id: 'approval-interrupted',
+      command: 'printf harmless',
+      description: 'Harmless command awaiting approval',
+      choices: ['once', 'deny'],
+    })
+    await expect(page.locator('.approval-float-panel')).toContainText('printf harmless')
+
+    await triggerGroupSocket(page, 'approval.resolved', {
+      event: 'approval.resolved',
+      roomId: 'room-alpha',
+      agentName: 'Worker',
+      approval_id: 'approval-interrupted',
+      choice: 'deny',
+      reason: 'Agent run interrupted',
+    })
+    await expect(page.locator('.approval-float-panel')).toHaveCount(0)
+    if (process.env.HERMES_VISUAL_EVIDENCE_DIR) {
+      await page.screenshot({
+        path: `${process.env.HERMES_VISUAL_EVIDENCE_DIR}/approval-removed-after-interrupt.png`,
+      })
+    }
+  })
+
   test('loads all group history by stable cursor beyond 600 messages with retry, de-duplication, and anchor preservation', async ({ page }) => {
     test.setTimeout(45_000)
     const api = await setup(page, '/#/hermes/group-chat/room/room-alpha')

--- a/tests/server/agent-bridge-client-clarify.test.ts
+++ b/tests/server/agent-bridge-client-clarify.test.ts
@@ -17,4 +17,28 @@ describe('AgentBridgeClient clarify responses', () => {
       response: 'Use the first option',
     })
   })
+
+  it('sends generation-bound clarify_cancel requests to the bridge', async () => {
+    const { AgentBridgeClient } = await import('../../packages/server/src/services/hermes/agent-bridge/client')
+    const client = new AgentBridgeClient({ endpoint: 'tcp://127.0.0.1:1', connectRetryMs: 0, timeoutMs: 1 })
+    const request = vi.spyOn(client, 'request').mockResolvedValue({ ok: true, resolved: true })
+
+    await expect(client.clarifyCancel(
+      'clarify-1',
+      'session-1',
+      'run-1',
+      'profile-1',
+    )).resolves.toEqual({
+      ok: true,
+      resolved: true,
+    })
+
+    expect(request).toHaveBeenCalledWith({
+      action: 'clarify_cancel',
+      clarify_id: 'clarify-1',
+      session_id: 'session-1',
+      run_id: 'run-1',
+      profile: 'profile-1',
+    })
+  })
 })

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -227,7 +227,7 @@ def wait_for(condition, timeout=20):
 `
 
 describe('agent bridge Python session concurrency', () => {
-  it('denies only the interrupted session approval queues', () => {
+  it('denies only the interrupted session run generation approval queues', () => {
     runPython(String.raw`
 ${harness}
 
@@ -242,7 +242,7 @@ class InterruptibleAgent:
 
 agents = {sid: InterruptibleAgent() for sid in ("session-a", "session-b")}
 for sid, agent in agents.items():
-    session = bridge.AgentSession(session_id=sid, agent=agent)
+    session = bridge.AgentSession(session_id=sid, agent=agent, current_run_id="run-current")
     session.running = True
     agent.session = session
     with pool._lock:
@@ -250,12 +250,14 @@ for sid, agent in agents.items():
 
 choices = {}
 threads = []
-for sid in ("session-a", "session-b"):
+for sid, run_id in (("session-a", "run-previous"), ("session-a", "run-current"), ("session-b", "run-current")):
+    with pool._lock:
+        pool._sessions[sid].current_run_id = run_id
     thread = threading.Thread(
-        target=lambda current=sid: choices.__setitem__(
-            current,
+        target=lambda current=sid, generation=run_id: choices.__setitem__(
+            f"{current}:{generation}",
             pool._approval_callback(current)(
-                f"printf harmless {current}",
+                f"printf harmless {current} {generation}",
                 "harmless test command",
                 allow_permanent=False,
             ),
@@ -264,32 +266,49 @@ for sid in ("session-a", "session-b"):
     )
     thread.start()
     threads.append(thread)
-
-def terminal_ready():
-    with pool._lock:
-        return set(pool._approval_request_sessions.values()) == {"session-a", "session-b"}
-
-assert wait_for(terminal_ready)
+    assert wait_for(lambda current=sid, generation=run_id: (
+        current,
+        generation,
+    ) in set(pool._approval_request_generations.values()))
+with pool._lock:
+    pool._sessions["session-a"].current_run_id = "run-previous"
 pool._gateway_approval_notify("session-a")({
-    "command": "printf harmless gateway",
+    "command": "printf harmless previous gateway",
+    "description": "harmless test command",
+})
+with pool._lock:
+    pool._sessions["session-a"].current_run_id = "run-current"
+pool._gateway_approval_notify("session-a")({
+    "command": "printf harmless current gateway",
     "description": "harmless test command",
 })
 
 result = pool.interrupt("session-a", "test interrupt")
 assert result["status"] == "interrupted"
-threads[0].join(timeout=5)
-assert not threads[0].is_alive()
-assert choices["session-a"] == "deny"
-with pool._lock:
-    assert set(pool._approval_request_sessions.values()) == {"session-b"}
-    remaining_id = next(iter(pool._approval_requests))
-assert approval._resolved_gateway == [("session-a", "deny")]
-
-assert pool.respond_approval(remaining_id, "deny")["resolved"] is True
 threads[1].join(timeout=5)
 assert not threads[1].is_alive()
-assert choices["session-b"] == "deny"
-assert pool.respond_approval(remaining_id, "once")["resolved"] is False
+assert choices["session-a:run-current"] == "deny"
+assert threads[0].is_alive()
+with pool._lock:
+    assert set(pool._approval_request_generations.values()) == {
+        ("session-a", "run-previous"),
+        ("session-b", "run-current"),
+    }
+    remaining = dict(pool._approval_request_generations)
+    previous_id = next(key for key, value in remaining.items() if value == ("session-a", "run-previous"))
+    other_session_id = next(key for key, value in remaining.items() if value == ("session-b", "run-current"))
+    assert set(pool._gateway_approval_requests.values()) == {("session-a", "run-previous")}
+assert approval._resolved_gateway == [("session-a", "deny")]
+
+assert pool.respond_approval(previous_id, "deny")["resolved"] is True
+assert pool.respond_approval(other_session_id, "deny")["resolved"] is True
+threads[0].join(timeout=5)
+threads[2].join(timeout=5)
+assert not threads[0].is_alive()
+assert not threads[2].is_alive()
+assert choices["session-a:run-previous"] == "deny"
+assert choices["session-b:run-current"] == "deny"
+assert pool.respond_approval(other_session_id, "once")["resolved"] is False
 `)
   })
 

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -81,6 +81,8 @@ approval = types.ModuleType("tools.approval")
 approval._session_key = contextvars.ContextVar("approval_session_key", default="")
 approval._notify = {}
 approval._resolved_gateway = []
+approval._resolved_gateway_requests = []
+approval._gateway_waiters = {}
 approval._session_approved = {}
 approval._session_yolo = set()
 approval._permanent_approved = set()
@@ -102,9 +104,21 @@ def register_gateway_notify(session_key, callback):
 def unregister_gateway_notify(session_key):
     approval._notify.pop(session_key, None)
 
-def resolve_gateway_approval(session_key, choice):
+def queue_gateway_approval(session_key, request_id):
+    approval._gateway_waiters.setdefault(session_key, []).append(request_id)
+
+def resolve_gateway_approval(session_key, choice, request_id=None):
+    waiters = approval._gateway_waiters.get(session_key, [])
+    if request_id is None:
+        resolved_request_id = waiters.pop(0) if waiters else None
+    elif request_id in waiters:
+        waiters.remove(request_id)
+        resolved_request_id = request_id
+    else:
+        resolved_request_id = None
     approval._resolved_gateway.append((session_key, choice))
-    return 1
+    approval._resolved_gateway_requests.append((session_key, choice, request_id, resolved_request_id))
+    return 1 if resolved_request_id else 0
 
 def is_approved(session_key, pattern_key):
     return (
@@ -144,6 +158,7 @@ approval.get_current_session_key = get_current_session_key
 approval.register_gateway_notify = register_gateway_notify
 approval.unregister_gateway_notify = unregister_gateway_notify
 approval.resolve_gateway_approval = resolve_gateway_approval
+approval.queue_gateway_approval = queue_gateway_approval
 approval.is_approved = is_approved
 approval.approve_session = approve_session
 approval.enable_session_yolo = enable_session_yolo
@@ -272,14 +287,34 @@ for sid, run_id in (("session-a", "run-previous"), ("session-a", "run-current"),
     ) in set(pool._approval_request_generations.values()))
 with pool._lock:
     pool._sessions["session-a"].current_run_id = "run-previous"
+approval.queue_gateway_approval("session-a", "request-previous")
 pool._gateway_approval_notify("session-a")({
+    "request_id": "request-previous",
     "command": "printf harmless previous gateway",
     "description": "harmless test command",
 })
 with pool._lock:
     pool._sessions["session-a"].current_run_id = "run-current"
+approval.queue_gateway_approval("session-a", "request-current")
 pool._gateway_approval_notify("session-a")({
+    "request_id": "request-current",
     "command": "printf harmless current gateway",
+    "description": "harmless test command",
+})
+with pool._lock:
+    pool._sessions["session-a"].current_run_id = "run-later"
+approval.queue_gateway_approval("session-a", "request-later")
+pool._gateway_approval_notify("session-a")({
+    "request_id": "request-later",
+    "command": "printf harmless later gateway",
+    "description": "harmless test command",
+})
+with pool._lock:
+    pool._sessions["session-a"].current_run_id = "run-current"
+approval.queue_gateway_approval("session-b", "request-other-session")
+pool._gateway_approval_notify("session-b")({
+    "request_id": "request-other-session",
+    "command": "printf harmless other session gateway",
     "description": "harmless test command",
 })
 
@@ -297,8 +332,18 @@ with pool._lock:
     remaining = dict(pool._approval_request_generations)
     previous_id = next(key for key, value in remaining.items() if value == ("session-a", "run-previous"))
     other_session_id = next(key for key, value in remaining.items() if value == ("session-b", "run-current"))
-    assert set(pool._gateway_approval_requests.values()) == {("session-a", "run-previous")}
-assert approval._resolved_gateway == [("session-a", "deny")]
+    assert set(pool._gateway_approval_requests.values()) == {
+        ("session-a", "run-previous", "request-previous"),
+        ("session-a", "run-later", "request-later"),
+        ("session-b", "run-current", "request-other-session"),
+    }
+assert approval._resolved_gateway_requests == [
+    ("session-a", "deny", "request-current", "request-current"),
+]
+assert approval._gateway_waiters == {
+    "session-a": ["request-previous", "request-later"],
+    "session-b": ["request-other-session"],
+}
 
 assert pool.respond_approval(previous_id, "deny")["resolved"] is True
 assert pool.respond_approval(other_session_id, "deny")["resolved"] is True
@@ -1322,7 +1367,9 @@ ${harness}
 pool, _fake_db = make_pool()
 
 notify = pool._gateway_approval_notify("session-a")
+approval.queue_gateway_approval("session-a", "request-session-a")
 notify({
+    "request_id": "request-session-a",
     "command": "execute_code <<'PY'\nprint(1)\nPY",
     "description": "execute_code script execution",
     "pattern_key": "execute_code",
@@ -1335,7 +1382,9 @@ assert approval.is_approved("session-a", "execute_code") is True
 assert approval._saved_permanent == set()
 
 notify = pool._gateway_approval_notify("session-b")
+approval.queue_gateway_approval("session-b", "request-session-b")
 notify({
+    "request_id": "request-session-b",
     "command": "execute_code <<'PY'\nprint(2)\nPY",
     "description": "execute_code script execution",
     "pattern_key": "execute_code",
@@ -1380,7 +1429,10 @@ class FakeAgent:
         notify = approval._notify.get(self.session_id)
         if notify is None:
             raise RuntimeError(f"missing gateway notify for {self.session_id}")
+        request_id = f"request:{self.session_id}"
+        approval.queue_gateway_approval(self.session_id, request_id)
         notify({
+            "request_id": request_id,
             "command": f"gateway:{self.session_id}",
             "description": f"gateway-desc:{self.session_id}",
         })

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -242,6 +242,78 @@ def wait_for(condition, timeout=20):
 `
 
 describe('agent bridge Python session concurrency', () => {
+  it('cancels only the interrupted session run generation clarification waiter', () => {
+    runPython(String.raw`
+${harness}
+
+pool, _fake_db = make_pool()
+
+class InterruptibleAgent:
+    def __init__(self):
+        self.session = None
+
+    def interrupt(self, _message=None):
+        self.session.running = False
+
+agents = {sid: InterruptibleAgent() for sid in ("session-a", "session-b")}
+for sid, agent in agents.items():
+    session = bridge.AgentSession(session_id=sid, agent=agent, current_run_id="run-current")
+    session.running = True
+    agent.session = session
+    with pool._lock:
+        pool._sessions[sid] = session
+
+responses = {}
+threads = []
+for sid, run_id in (("session-a", "run-previous"), ("session-a", "run-current"), ("session-b", "run-current")):
+    with pool._lock:
+        pool._sessions[sid].current_run_id = run_id
+    thread = threading.Thread(
+        target=lambda current=sid, generation=run_id: responses.__setitem__(
+            f"{current}:{generation}",
+            pool._clarify_callback(current)(f"question:{current}:{generation}"),
+        ),
+        daemon=True,
+    )
+    thread.start()
+    threads.append(thread)
+    assert wait_for(lambda current=sid, generation=run_id: (
+        current,
+        generation,
+    ) in set(pool._clarify_request_generations.values()))
+
+with pool._lock:
+    pool._sessions["session-a"].current_run_id = "run-current"
+
+result = pool.interrupt("session-a", "test interrupt")
+assert result["status"] == "interrupted"
+threads[1].join(timeout=5)
+assert not threads[1].is_alive()
+assert responses["session-a:run-current"] == "[clarification cancelled because the run was interrupted]"
+assert threads[0].is_alive()
+assert threads[2].is_alive()
+with pool._lock:
+    assert set(pool._clarify_request_generations.values()) == {
+        ("session-a", "run-previous"),
+        ("session-b", "run-current"),
+    }
+    remaining = dict(pool._clarify_request_generations)
+    previous_id = next(key for key, value in remaining.items() if value == ("session-a", "run-previous"))
+    other_session_id = next(key for key, value in remaining.items() if value == ("session-b", "run-current"))
+
+assert pool.cancel_clarify(previous_id, "session-a", "run-current")["resolved"] is False
+assert pool.respond_clarify(previous_id, "previous answer")["resolved"] is True
+assert pool.respond_clarify(other_session_id, "other answer")["resolved"] is True
+threads[0].join(timeout=5)
+threads[2].join(timeout=5)
+assert not threads[0].is_alive()
+assert not threads[2].is_alive()
+assert responses["session-a:run-previous"] == "previous answer"
+assert responses["session-b:run-current"] == "other answer"
+assert pool.cancel_clarify(other_session_id, "session-b", "run-current")["resolved"] is False
+`)
+  })
+
   it('denies only the interrupted session run generation approval queues', () => {
     runPython(String.raw`
 ${harness}

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -227,6 +227,72 @@ def wait_for(condition, timeout=20):
 `
 
 describe('agent bridge Python session concurrency', () => {
+  it('denies only the interrupted session approval queues', () => {
+    runPython(String.raw`
+${harness}
+
+pool, _fake_db = make_pool()
+
+class InterruptibleAgent:
+    def __init__(self):
+        self.session = None
+
+    def interrupt(self, _message=None):
+        self.session.running = False
+
+agents = {sid: InterruptibleAgent() for sid in ("session-a", "session-b")}
+for sid, agent in agents.items():
+    session = bridge.AgentSession(session_id=sid, agent=agent)
+    session.running = True
+    agent.session = session
+    with pool._lock:
+        pool._sessions[sid] = session
+
+choices = {}
+threads = []
+for sid in ("session-a", "session-b"):
+    thread = threading.Thread(
+        target=lambda current=sid: choices.__setitem__(
+            current,
+            pool._approval_callback(current)(
+                f"printf harmless {current}",
+                "harmless test command",
+                allow_permanent=False,
+            ),
+        ),
+        daemon=True,
+    )
+    thread.start()
+    threads.append(thread)
+
+def terminal_ready():
+    with pool._lock:
+        return set(pool._approval_request_sessions.values()) == {"session-a", "session-b"}
+
+assert wait_for(terminal_ready)
+pool._gateway_approval_notify("session-a")({
+    "command": "printf harmless gateway",
+    "description": "harmless test command",
+})
+
+result = pool.interrupt("session-a", "test interrupt")
+assert result["status"] == "interrupted"
+threads[0].join(timeout=5)
+assert not threads[0].is_alive()
+assert choices["session-a"] == "deny"
+with pool._lock:
+    assert set(pool._approval_request_sessions.values()) == {"session-b"}
+    remaining_id = next(iter(pool._approval_requests))
+assert approval._resolved_gateway == [("session-a", "deny")]
+
+assert pool.respond_approval(remaining_id, "deny")["resolved"] is True
+threads[1].join(timeout=5)
+assert not threads[1].is_alive()
+assert choices["session-b"] == "deny"
+assert pool.respond_approval(remaining_id, "once")["resolved"] is False
+`)
+  })
+
   it('toggles YOLO for a session before its first Agent session exists', () => {
     runPython(String.raw`
 ${harness}

--- a/tests/server/ekko-agent-clarifications.test.ts
+++ b/tests/server/ekko-agent-clarifications.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  cancelPendingEkkoClarification,
   cancelPendingEkkoClarifications,
   respondToEkkoClarification,
   waitForEkkoClarification,
@@ -61,6 +62,36 @@ describe('Ekko clarification broker', () => {
       resolved: true,
     })
     await expect(result).resolves.toBe('B')
+  })
+
+  it('cancels only the matching session and run generation', async () => {
+    const result = waitForEkkoClarification(request(), {
+      sessionId: 'session-1',
+      runId: 'run-current',
+      onRequested: vi.fn(),
+    })
+
+    expect(cancelPendingEkkoClarification('session-1', 'clarify-1', 'run-stale')).toEqual({
+      handled: true,
+      resolved: false,
+    })
+    expect(cancelPendingEkkoClarification('session-2', 'clarify-1', 'run-current')).toEqual({
+      handled: true,
+      resolved: false,
+    })
+    expect(cancelPendingEkkoClarification('session-1', 'clarify-1', '')).toEqual({
+      handled: true,
+      resolved: false,
+    })
+    expect(cancelPendingEkkoClarification('session-1', 'clarify-1', 'run-current')).toEqual({
+      handled: true,
+      resolved: true,
+    })
+    await expect(result).resolves.toBe('[clarification cancelled because the run was aborted]')
+    expect(respondToEkkoClarification('session-1', 'clarify-1', 'late')).toEqual({
+      handled: false,
+      resolved: false,
+    })
   })
 
   it('returns a bounded result when another clarification is already pending', async () => {

--- a/tests/server/group-chat-agent-workspace.test.ts
+++ b/tests/server/group-chat-agent-workspace.test.ts
@@ -678,6 +678,56 @@ describe('group chat agent workspace bridge runs', () => {
     expect(runAndWait.mock.calls[0][0].session_id).toMatch(/^gc_run_/)
   })
 
+  it('normalizes non-Hermes approval events onto the authoritative group run generation', async () => {
+    const { AgentClients } = await import('../../packages/server/src/services/hermes/group-chat/agent-clients')
+    const runAndWait = vi.fn(async (_data: any, options: any) => {
+      options.onEvent?.('approval.requested', {
+        run_id: 'runtime-run-id',
+        approval_id: 'approval-1',
+        command: 'printf harmless',
+      })
+      return { ok: true, run_id: 'runtime-run-id', output: 'done' }
+    })
+    const clients = new AgentClients()
+    clients.setChatRunService({ runAndWait, abortSession: vi.fn(async () => {}) })
+    const client = await clients.createAgent({
+      agentId: 'agent-codex',
+      agent: 'codex',
+      profile: 'default',
+      name: 'Coder',
+      description: '',
+      invited: 0,
+      backgroundDelegationEnabled: false,
+    } as any) as any
+    client.setStorage({
+      getRoom: vi.fn(() => ({ sessionSeed: 'seed-1', workspace: '', maxHistoryTokens: 32000 })),
+      getRoomAgents: vi.fn(() => []),
+      getMentionableRoomAgents: vi.fn(() => []),
+      getMessagesForContext: vi.fn(() => []),
+      getContextSnapshot: vi.fn(() => null),
+    })
+
+    await client.replyToMention('room-1', {
+      messageId: 'message-1',
+      content: '@Coder run safely',
+      senderName: 'Human',
+      senderId: 'human-1',
+      timestamp: 1,
+      role: 'user',
+    })
+
+    const streamStart = mockSocket.emit.mock.calls
+      .find(([event]) => event === 'message_stream_start')?.[1]
+    const approval = mockSocket.emit.mock.calls
+      .find(([event]) => event === 'approval.requested')?.[1]
+    expect(streamStart?.run_id).toBeTruthy()
+    expect(approval).toMatchObject({
+      approval_id: 'approval-1',
+      runId: streamStart.run_id,
+    })
+    expect(approval).not.toHaveProperty('run_id')
+  })
+
   it.each([
     ['ekko', 'ekko-agent'],
     ['claude', 'claude-code'],

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -781,6 +781,72 @@ describe('group chat approval and context baseline', () => {
     expect(respondApproval).toHaveBeenCalledTimes(1)
   })
 
+  it('interrupts only the active run generation and cancels its pending clarification', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    const cancelClarify = vi.fn(async () => true)
+    vi.spyOn(groupServer.agentClients, 'getAgents').mockReturnValue([{
+      name: 'Agent',
+      cancelClarify,
+    } as any])
+    vi.spyOn(groupServer.agentClients, 'interruptAgent').mockResolvedValue()
+
+    agent.emit('context_status', {
+      roomId: 'room-1', agentName: 'Agent', status: 'replying',
+      agentSessionId, runId: 'run-current',
+    })
+    const currentRequested = once<any>(human, 'clarify.requested')
+    agent.emit('clarify.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId,
+      runId: 'run-current', runtimeRunId: 'runtime-current',
+      clarify_id: 'clarify-current', question: 'Current question?',
+    })
+    await currentRequested
+    const nextRequested = once<any>(human, 'clarify.requested')
+    agent.emit('clarify.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId,
+      runId: 'run-next', runtimeRunId: 'runtime-next',
+      clarify_id: 'clarify-next', question: 'Next question?',
+    })
+    await nextRequested
+    const missingGenerationRequested = once<any>(human, 'clarify.requested')
+    agent.emit('clarify.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId,
+      clarify_id: 'clarify-missing-generation', question: 'Unscoped question?',
+    })
+    await missingGenerationRequested
+    const resolved = once<any>(human, 'clarify.resolved')
+
+    await expect(emitAck(human, 'interrupt_agent', {
+      roomId: 'room-1', agentName: 'Agent',
+    })).resolves.toEqual({ ok: true })
+
+    await expect(resolved).resolves.toMatchObject({
+      clarify_id: 'clarify-current',
+      resolved: false,
+      reason: 'Agent run interrupted',
+    })
+    expect(cancelClarify).toHaveBeenCalledTimes(1)
+    expect(cancelClarify).toHaveBeenCalledWith(
+      'clarify-current',
+      agentSessionId,
+      'runtime-current',
+    )
+    await expect(emitAck(human, 'clarify.respond', {
+      roomId: 'room-1', clarify_id: 'clarify-current', response: 'late answer',
+    })).resolves.toEqual({ error: 'Clarification is not pending in this room' })
+
+    const joined = await emitAck<any>(human, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    expect(joined.pendingClarifies).toEqual([
+      expect.objectContaining({ clarify_id: 'clarify-next' }),
+      expect.objectContaining({ clarify_id: 'clarify-missing-generation' }),
+    ])
+
+    await expect(emitAck(human, 'interrupt_agent', {
+      roomId: 'room-1', agentName: 'Agent',
+    })).resolves.toEqual({ ok: true })
+    expect(cancelClarify).toHaveBeenCalledTimes(1)
+  })
+
   it('claims the active approval before an interrupt can race with a user response', async () => {
     const { agent, human, agentSessionId } = await joinPair()
     let finishInterrupt!: () => void

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -751,6 +751,12 @@ describe('group chat approval and context baseline', () => {
       approval_id: 'approval-next', command: 'printf harmless',
     })
     await nextRequested
+    const missingGenerationRequested = once<any>(human, 'approval.requested')
+    agent.emit('approval.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId,
+      approval_id: 'approval-missing-generation', command: 'printf harmless',
+    })
+    await missingGenerationRequested
     const resolved = once<any>(human, 'approval.resolved')
 
     await expect(emitAck(human, 'interrupt_agent', {
@@ -763,13 +769,58 @@ describe('group chat approval and context baseline', () => {
     expect(respondApproval).toHaveBeenCalledTimes(1)
     expect(respondApproval).toHaveBeenCalledWith('approval-current', 'deny')
     await expect(emitAck<any>(human, 'load_pending_approvals', {})).resolves.toEqual({
-      pendingApprovals: [expect.objectContaining({ approval_id: 'approval-next' })],
+      pendingApprovals: [
+        expect.objectContaining({ approval_id: 'approval-next' }),
+        expect.objectContaining({ approval_id: 'approval-missing-generation' }),
+      ],
     })
 
     await expect(emitAck(human, 'interrupt_agent', {
       roomId: 'room-1', agentName: 'Agent',
     })).resolves.toEqual({ ok: true })
     expect(respondApproval).toHaveBeenCalledTimes(1)
+  })
+
+  it('claims the active approval before an interrupt can race with a user response', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    let finishInterrupt!: () => void
+    const interruptPending = new Promise<void>(resolve => {
+      finishInterrupt = resolve
+    })
+    const respondApproval = vi.fn(async () => true)
+    vi.spyOn(groupServer.agentClients, 'getAgents').mockReturnValue([{
+      name: 'Agent',
+      respondApproval,
+    } as any])
+    vi.spyOn(groupServer.agentClients, 'interruptAgent').mockImplementation(async () => {
+      await interruptPending
+    })
+
+    agent.emit('context_status', {
+      roomId: 'room-1', agentName: 'Agent', status: 'replying',
+      agentSessionId, runId: 'run-current',
+    })
+    const requested = once<any>(human, 'approval.requested')
+    agent.emit('approval.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId, runId: 'run-current',
+      approval_id: 'approval-race', command: 'printf harmless',
+    })
+    await requested
+
+    const interrupted = emitAck(human, 'interrupt_agent', {
+      roomId: 'room-1', agentName: 'Agent',
+    })
+    await vi.waitFor(() => {
+      expect(groupServer.agentClients.interruptAgent).toHaveBeenCalledTimes(1)
+    })
+    await expect(emitAck(human, 'approval.respond', {
+      roomId: 'room-1', approval_id: 'approval-race', choice: 'once',
+    })).resolves.toEqual({ error: 'Approval is not pending in this room' })
+
+    finishInterrupt()
+    await expect(interrupted).resolves.toEqual({ ok: true })
+    expect(respondApproval).toHaveBeenCalledTimes(1)
+    expect(respondApproval).toHaveBeenCalledWith('approval-race', 'deny')
   })
 
   it('keeps Hermes approval responses routed through the Agent Bridge', async () => {

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -726,6 +726,52 @@ describe('group chat approval and context baseline', () => {
     await expect(emitAck<any>(human, 'load_pending_approvals', {})).resolves.toEqual({ pendingApprovals: [] })
   })
 
+  it('interrupts only the active run generation and denies its pending approvals', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    const respondApproval = vi.fn(async () => true)
+    vi.spyOn(groupServer.agentClients, 'getAgents').mockReturnValue([{
+      name: 'Agent',
+      respondApproval,
+    } as any])
+    vi.spyOn(groupServer.agentClients, 'interruptAgent').mockResolvedValue()
+
+    agent.emit('context_status', {
+      roomId: 'room-1', agentName: 'Agent', status: 'replying',
+      agentSessionId, runId: 'run-current',
+    })
+    const currentRequested = once<any>(human, 'approval.requested')
+    agent.emit('approval.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId, runId: 'run-current',
+      approval_id: 'approval-current', command: 'printf harmless',
+    })
+    await currentRequested
+    const nextRequested = once<any>(human, 'approval.requested')
+    agent.emit('approval.requested', {
+      roomId: 'room-1', agentName: 'Agent', agentSessionId, runId: 'run-next',
+      approval_id: 'approval-next', command: 'printf harmless',
+    })
+    await nextRequested
+    const resolved = once<any>(human, 'approval.resolved')
+
+    await expect(emitAck(human, 'interrupt_agent', {
+      roomId: 'room-1', agentName: 'Agent',
+    })).resolves.toEqual({ ok: true })
+
+    await expect(resolved).resolves.toMatchObject({
+      approval_id: 'approval-current', choice: 'deny', reason: 'Agent run interrupted',
+    })
+    expect(respondApproval).toHaveBeenCalledTimes(1)
+    expect(respondApproval).toHaveBeenCalledWith('approval-current', 'deny')
+    await expect(emitAck<any>(human, 'load_pending_approvals', {})).resolves.toEqual({
+      pendingApprovals: [expect.objectContaining({ approval_id: 'approval-next' })],
+    })
+
+    await expect(emitAck(human, 'interrupt_agent', {
+      roomId: 'room-1', agentName: 'Agent',
+    })).resolves.toEqual({ ok: true })
+    expect(respondApproval).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps Hermes approval responses routed through the Agent Bridge', async () => {
     const { agent, human, agentSessionId } = await joinPair()
     const bridgeApproval = vi.spyOn(AgentBridgeClient.prototype, 'approvalRespond')

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -7,6 +7,7 @@ import {
 } from './group-chat-test-helpers'
 import { GROUP_CHAT_AGENT_SOCKET_SECRET, groupRuntimeSessionId } from '../../packages/server/src/services/hermes/group-chat/agent-clients'
 import { AgentBridgeClient } from '../../packages/server/src/services/hermes/agent-bridge'
+import { ChatRunSocket } from '../../packages/server/src/services/hermes/run-chat'
 import {
   denyPendingEkkoToolApprovals,
   waitForEkkoToolApproval,
@@ -845,6 +846,112 @@ describe('group chat approval and context baseline', () => {
       roomId: 'room-1', agentName: 'Agent',
     })).resolves.toEqual({ ok: true })
     expect(cancelClarify).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles an Ekko clarification through the real GroupChat interrupt and ChatRun abort chain', async () => {
+    const human = await connectGroupChatClient(port, 'human-1', 'Human')
+    harness.sockets.push(human)
+    groupServer.getIO().of('/group-chat').sockets.get(human.id!)!.data.authUser = {
+      id: 1, role: 'user', profiles: ['default'],
+    }
+    await emitAck(human, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+
+    const chatRun = new ChatRunSocket(groupServer.getIO())
+    const abortSession = vi.spyOn(chatRun, 'abortSession')
+    const agent = await groupServer.agentClients.createAgent({
+      agentId: 'agent-1',
+      agent: 'ekko',
+      profile: 'default',
+      name: 'Agent',
+      description: '',
+      invited: 0,
+      backgroundDelegationEnabled: false,
+    }, {}, port)
+    await groupServer.agentClients.addAgentToRoom('room-1', agent)
+    groupServer.agentClients.setChatRunService(chatRun)
+
+    let runtimeWaiterSettled = false
+    let runtimeSessionId = ''
+    vi.spyOn(chatRun, 'runAndWait').mockImplementation(async (data, options) => {
+      const runtimeRunId = 'runtime-current'
+      runtimeSessionId = data.session_id
+      // Reproduce the installed ordering: the Runtime clarification belongs to
+      // the active generation, while ChatRun's local abort controller no longer
+      // owns that waiter. GroupChat must still settle it explicitly.
+      ;(chatRun as any).sessionMap.set(data.session_id, {
+        messages: [],
+        isWorking: true,
+        events: [],
+        queue: [],
+        source: 'group_chat',
+        runId: runtimeRunId,
+        abortController: new AbortController(),
+        profile: 'default',
+      })
+      const response = await waitForEkkoClarification({
+        clarifyId: 'clarify-real-chain',
+        question: 'Which city?',
+        choices: null,
+        timeoutMs: 300_000,
+      }, {
+        sessionId: data.session_id,
+        runId: runtimeRunId,
+        onRequested: pending => options?.onEvent?.('clarify.requested', {
+          event: 'clarify.requested',
+          run_id: runtimeRunId,
+          clarify_id: pending.clarifyId,
+          question: pending.question,
+          choices: pending.choices,
+          timeout_ms: pending.timeoutMs,
+        }),
+        onResolved: resolution => options?.onEvent?.('clarify.resolved', {
+          event: 'clarify.resolved',
+          run_id: runtimeRunId,
+          clarify_id: 'clarify-real-chain',
+          resolved: resolution.reason === 'response',
+          reason: resolution.reason,
+        }),
+      })
+      runtimeWaiterSettled = true
+      return { ok: false, error: response }
+    })
+
+    const requested = once<any>(human, 'clarify.requested')
+    const delivery = groupServer.agentClients.processMentions('room-1', {
+      messageId: 'message-real-chain',
+      content: '@Agent check the weather',
+      senderName: 'Human',
+      senderId: 'human-1',
+      timestamp: Date.now(),
+      role: 'user',
+      mentions: [{ type: 'agent', participantId: 'agent-1', displayName: 'Agent' }],
+    })
+    await expect(requested).resolves.toMatchObject({
+      clarify_id: 'clarify-real-chain',
+      agentName: 'Agent',
+    })
+
+    const resolved = once<any>(human, 'clarify.resolved')
+    await expect(emitAck(human, 'interrupt_agent', {
+      roomId: 'room-1', agentName: 'Agent',
+    })).resolves.toEqual({ ok: true })
+
+    await expect(resolved).resolves.toMatchObject({
+      clarify_id: 'clarify-real-chain',
+      resolved: false,
+    })
+    expect(abortSession).toHaveBeenCalledWith(
+      runtimeSessionId,
+      'Interrupted by group chat user',
+    )
+    expect(runtimeWaiterSettled).toBe(true)
+    await expect(emitAck(human, 'clarify.respond', {
+      roomId: 'room-1', clarify_id: 'clarify-real-chain', response: 'late',
+    })).resolves.toEqual({ error: 'Clarification is not pending in this room' })
+    const joined = await emitAck<any>(human, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+    expect(joined.pendingClarifies).toEqual([])
+    await delivery
+    await chatRun.close()
   })
 
   it('claims the active approval before an interrupt can race with a user response', async () => {

--- a/tests/server/group-chat-test-helpers.ts
+++ b/tests/server/group-chat-test-helpers.ts
@@ -9,7 +9,10 @@ const groupChatAuthMock = vi.hoisted(() => ({
   user: null as any,
 }))
 
-vi.mock('../../packages/server/src/db/index', () => ({ getDb: () => groupChatDbMock.current }))
+vi.mock('../../packages/server/src/db/index', () => ({
+  getDb: () => groupChatDbMock.current,
+  isSqliteAvailable: () => groupChatDbMock.current !== null,
+}))
 vi.mock('../../packages/server/src/middleware/user-auth', () => ({
   isAuthEnabled: vi.fn(async () => groupChatAuthMock.enabled),
   authenticateUserToken: vi.fn(async () => groupChatAuthMock.user),


### PR DESCRIPTION
## Summary

- bind pending clarifications to the exact Group Chat Session + run generation
- release the underlying Ekko/Hermes Runtime clarification waiter when that generation is force-stopped
- clear Room/global pending UI, prevent reload resurrection and reject late replies
- preserve the #2681 exact Gateway approval `request_id` isolation behavior

This successor is based directly on PR #2681 exact HEAD `084b582254a98757791297b4c20d72eeed46d9fc`.

Closes #2684

## Validation

- `npm run test -- tests/server/ekko-agent-clarifications.test.ts tests/server/group-chat-approval.test.ts tests/server/group-chat-agent-workspace.test.ts tests/server/agent-bridge-client-clarify.test.ts tests/server/agent-bridge-python-concurrency.test.ts tests/server/run-chat-clarify-respond.test.ts tests/server/run-chat-ekko-context.test.ts` — 153 passed
- `npx playwright test tests/e2e/group-chat-room-deeplink.spec.ts --grep \"removes an interrupted run (approval|clarification)\"` — 2 passed
- `npm run harness:check` — passed
- `npm run build` — passed
- `git diff --check` — passed

## Full-suite observation

Broad regression commands were also run. They retain unrelated repository baseline failures and are reported rather than hidden:

- `npm run test:coverage` — 4290 passed, 49 failed, 6 skipped; failures are distributed across 26 unrelated existing suites (browser `readFileSync`, Naive UI provider, Hermes plugin/environment discovery, Kanban paths, and similar areas). None overlaps the focused clarification/approval suites above.
- `npm run test:e2e` — 104 passed, 4 failed, 27 did not run; failures were chat-session multitab, XLSX worker preview, 600+ group-history pagination, and workflow select-menu timeout. The new clarification reload test and the #2681 approval regression pass in the focused run.