### PR TITLE
fix(codex-proxy): merge multiple system messages into one leading message

### DIFF
--- a/packages/server/src/services/coding-agents/shared/adapters/responses.ts
+++ b/packages/server/src/services/coding-agents/shared/adapters/responses.ts
@@ -701,7 +701,38 @@ function responsesInputToChatMessages(body: any, target: ResponsesAdapterTarget)
   }
   flushCompletedToolCalls()
 
-  return messages.length ? messages : [{ role: 'user', content: '' }]
+  const built = messages.length ? messages : [{ role: 'user', content: '' }]
+  return consolidateChatSystemMessages(built)
+}
+
+// Codex sends both a top-level `instructions` string and `developer` messages
+// inside `input`; converting each to a `system` message yields multiple system
+// messages with the later ones out of position. Some providers (notably vLLM)
+// reject that with "System message must be at the beginning" (400). Fix: keep
+// exactly one leading system message — merging any additional ones into it in
+// original order (top-level instructions first, then in-input developer
+// messages).
+function consolidateChatSystemMessages(messages: any[]): any[] {
+  const systemMessages: any[] = []
+  const rest: any[] = []
+  for (const message of messages) {
+    if (message?.role === 'system') systemMessages.push(message)
+    else rest.push(message)
+  }
+  if (systemMessages.length === 0) return messages
+  // Exactly one system message: keep its content verbatim (string or image
+  // parts) and only relocate it to the front if it was mid-conversation.
+  if (systemMessages.length === 1) {
+    const only = systemMessages[0]
+    if (messages[0] === only) return messages
+    return [only, ...rest]
+  }
+  // Multiple system messages (top-level instructions + in-input developer
+  // messages): merge their text into one leading system message.
+  const parts = systemMessages
+    .map(message => (typeof message.content === 'string' ? message.content : stringifyContent(message.content)))
+    .filter(Boolean)
+  return [{ role: 'system', content: parts.join('\n\n') }, ...rest]
 }
 
 function responsesToolsToChatTools(tools: unknown): any[] | undefined {

--- a/tests/server/agent-runner-adapters.test.ts
+++ b/tests/server/agent-runner-adapters.test.ts
@@ -97,9 +97,8 @@ describe('agent runner Responses adapters', () => {
       top_p: 0.9,
       stream: false,
       messages: [
-        { role: 'system', content: 'be terse' },
+        { role: 'system', content: 'be terse\n\nrules' },
         { role: 'user', content: 'hello' },
-        { role: 'system', content: 'rules' },
         {
           role: 'assistant',
           content: null,
@@ -116,6 +115,44 @@ describe('agent runner Responses adapters', () => {
         function: { name: 'search', description: 'Search', parameters: { type: 'object' } },
       }],
     })
+  })
+
+  it('keeps a single top-level instructions system message at the front', () => {
+    const body = {
+      instructions: 'core system prompt',
+      input: [
+        { role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
+      ],
+    }
+
+    expect(responsesToOpenAiChat(body, target).messages).toEqual([
+      { role: 'system', content: 'core system prompt' },
+      { role: 'user', content: 'hi' },
+    ])
+  })
+
+  it('merges multiple system messages into one leading message (vLLM compatibility)', () => {
+    // Codex 0.149 sends both a top-level `instructions` string and `developer`
+    // messages inside `input`. Both convert to `system`; vLLM rejects the
+    // second one ("System message must be at the beginning"), so they must be
+    // merged into a single leading system message.
+    const body = {
+      instructions: 'top-level instructions',
+      input: [
+        { role: 'developer', content: [{ type: 'input_text', text: 'developer message one' }] },
+        { role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+        { role: 'developer', content: [{ type: 'input_text', text: 'developer message two' }] },
+      ],
+    }
+
+    const messages = responsesToOpenAiChat(body, target).messages
+    expect(messages).toEqual([
+      { role: 'system', content: 'top-level instructions\n\ndeveloper message one\n\ndeveloper message two' },
+      { role: 'user', content: 'hello' },
+    ])
+    const systemMessages = messages.filter((message: any) => message.role === 'system')
+    expect(systemMessages).toHaveLength(1)
+    expect(messages[0].role).toBe('system')
   })
 
   it('replays Responses reasoning_content on DeepSeek tool-call continuations', () => {

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -1366,9 +1366,11 @@ describe('coding agent launch preparation', () => {
     expect(requestBody).toMatchObject({
       model: 'deepseek-v4-pro',
       max_tokens: 16,
+      // The in-input `developer` message converts to `system` and is relocated
+      // to the front (vLLM et al. reject a system message mid-conversation).
       messages: [
-        { role: 'user', content: 'hello' },
         { role: 'system', content: 'be terse' },
+        { role: 'user', content: 'hello' },
       ],
     })
     expect(ctx.body.output[0].content[0].text).toBe('ok')


### PR DESCRIPTION
## 问题 / Problem

Codex 0.149 发起请求时会同时携带两处 system 级指令：

1. 顶层 `instructions` 字段（核心系统提示，实测 ~20KB）
2. `input` 数组中的 `role: "developer"` 消息（web-ui 写入的 `developer_instructions`）

`responsesToOpenAiChat` 适配器把两者各转成一条 `system` 消息，第二条落在对话中间。vLLM 等严格校验的消息顺序，直接拒绝：

```
400 BadRequestError: "System message must be at the beginning."
```

影响：web-ui 编程工具（Codex / Claude Code）在 scoped 模式 + OpenAI-compatible vLLM provider（如 Qwen via vLLM）下 **每次** 请求都会失败。

## 修复 / Fix

新增 `consolidateChatSystemMessages()`：转换完成后将所有 `system` 消息按原始顺序合并为一条置顶消息；仅一条 system 时保持原样（含图片 content 不被 stringify），只在其位于对话中间时移到开头。

## 验证 / Verification

- 41 个适配器单测全过（含 3 个新增回归测试：单条 system 置顶保持、多条 system 合并、顺序保留）
- 端到端：mock 服务器捕获 Codex 0.149 真实 payload（顶层 instructions + input 内 developer 消息）→ 修复后转换 → `roles: [system, user, user]` → 直接请求 vLLM `/v1/chat/completions` → **HTTP 200**，模型正常回复
- 回程转换（`openAiChatToResponses`）含 tool_calls 场景验证通过