### PR TITLE
feat(upload): make max upload size configurable via HERMES_MAX_UPLOAD_SIZE

### DIFF
--- a/packages/server/src/controllers/upload.ts
+++ b/packages/server/src/controllers/upload.ts
@@ -6,7 +6,16 @@ import { getProfileUploadDir } from '../services/hermes/upload-paths'
 import { MultipartParseError, parseMultipartBoundary, parseMultipartFilename, splitMultipart } from '../lib/multipart'
 import { drainRejectedRequest, nonDestroyingRequestBody } from '../lib/request-body'
 
-const MAX_UPLOAD_SIZE = 50 * 1024 * 1024 // 50MB
+const DEFAULT_MAX_UPLOAD_SIZE = 50 * 1024 * 1024 // 50MB
+
+// Operators can raise the limit for large-file workflows (e.g. media uploads)
+// via HERMES_MAX_UPLOAD_SIZE (bytes) without patching the bundle. The value is
+// read per request so tests can override it with vi.stubEnv.
+function getMaxUploadSize(): number {
+  const override = Number(process.env.HERMES_MAX_UPLOAD_SIZE)
+  if (Number.isFinite(override) && override > 0) return override
+  return DEFAULT_MAX_UPLOAD_SIZE
+}
 
 function requestedProfile(ctx: any): string {
   return ctx.state?.profile?.name || getActiveProfileName() || 'default'
@@ -24,12 +33,13 @@ export async function handleUpload(ctx: any) {
   let chunks: Buffer[] = []
   let totalSize = 0
   let oversize = false
+  const maxUploadSize = getMaxUploadSize()
   // Leave the stream alive when the loop ends early; the iterator would
   // otherwise destroy it and take the unsent response down with it.
   const body = nonDestroyingRequestBody(ctx.req)
   for await (const chunk of body) {
     totalSize += chunk.length
-    if (totalSize > MAX_UPLOAD_SIZE) {
+    if (totalSize > maxUploadSize) {
       oversize = true
       break
     }
@@ -39,7 +49,7 @@ export async function handleUpload(ctx: any) {
     chunks = []
     await drainRejectedRequest(ctx.req)
     ctx.status = 413
-    ctx.body = { error: `File too large (max ${MAX_UPLOAD_SIZE / 1024 / 1024}MB)` }
+    ctx.body = { error: `File too large (max ${Math.round(maxUploadSize / 1024 / 1024)}MB)` }
     return
   }
   const raw = Buffer.concat(chunks)


### PR DESCRIPTION
## 背景 / Why

上传大小硬编码为 50MB（`upload.ts: const MAX_UPLOAD_SIZE = 50 * 1024 * 1024`）。
有大文件上传需求（媒体、数据集）时只能改源码重新构建。

这个 PR 之前被**误带进了** outline PR #2043，导致上游 CI 失败
（`upload-controller.test.ts` 按 50MB 阈值断言 413，硬改 1GB 后返回 200）。
现拆出来单独处理。

## 方案 / Approach

- 默认值**保持 50MB 不变** → 现有行为和测试零改动
- 新增 env 覆盖 `HERMES_MAX_UPLOAD_SIZE`（单位字节），按请求读取：
  ```
  HERMES_MAX_UPLOAD_SIZE=1073741824   # 1GB
  ```
- 413 报错信息动态反映实际阈值（`Math.round(max/1024/1024)MB`）

## 验证 / Verification

- `tests/server/upload-controller.test.ts` 5/5 通过（默认 50MB，无测试改动）
- `HERMES_MAX_UPLOAD_SIZE=100` 下同一测试立即失败 → 证明变量被正确读取

## 备注 / Note

#2043 已剥离 upload.ts 改动恢复 50MB，CI 应转绿；本 PR 与其互不依赖，可独立合并。