### PR TITLE
fix(group-chat): deterministically settle Ekko clarification on stop

### DIFF
--- a/docs/chat-chain-changes/2026-08-22-issue-2690-deterministic-clarification-stop.md
+++ b/docs/chat-chain-changes/2026-08-22-issue-2690-deterministic-clarification-stop.md
@@ -1,0 +1,12 @@
+---
+date: 2026-08-22
+pr: pending
+feature: Deterministic Group Chat Ekko clarification stop
+impact: Force-stop terminally settles the exact Ekko clarification generation without waiting for its normal timeout.
+---
+
+Group Chat preserves the Session, visible run generation, and Ekko Runtime run
+identity through the internal activity and clarification relays. A force-stop
+claims only that exact pending route, aborts through ChatRun, releases the
+Runtime waiter, and closes Room/global pending state while rejecting late
+responses and leaving unrelated generations untouched.

--- a/packages/server/src/services/ekko-agent/clarifications.ts
+++ b/packages/server/src/services/ekko-agent/clarifications.ts
@@ -14,6 +14,7 @@ export interface EkkoClarificationResolution {
 
 interface PendingEkkoClarification {
   sessionId: string
+  runId: string
   resolve: (response: string) => void
   timer: NodeJS.Timeout
   signal?: AbortSignal
@@ -23,6 +24,7 @@ interface PendingEkkoClarification {
 
 export interface WaitForEkkoClarificationOptions {
   sessionId: string
+  runId?: string
   signal?: AbortSignal
   onRequested: (request: AgentClarificationRequest) => void
   onResolved?: (resolution: EkkoClarificationResolution) => void
@@ -72,6 +74,7 @@ export function waitForEkkoClarification(
     })
     pendingClarifications.set(request.clarifyId, {
       sessionId: options.sessionId,
+      runId: String(options.runId || ''),
       resolve,
       timer,
       signal: options.signal,
@@ -110,6 +113,35 @@ export function respondToEkkoClarification(
     reason: 'response',
   })
   pending.resolve(normalizedResponse)
+  return { handled: true, resolved: true }
+}
+
+export function cancelPendingEkkoClarification(
+  sessionId: string,
+  clarifyId: string,
+  runId: string,
+): EkkoClarificationResponse {
+  const pending = pendingClarifications.get(clarifyId)
+  if (!pending) return { handled: false, resolved: false }
+  if (
+    pending.sessionId !== sessionId
+    || !runId
+    || pending.runId !== runId
+  ) {
+    return { handled: true, resolved: false }
+  }
+
+  pendingClarifications.delete(clarifyId)
+  clearTimeout(pending.timer)
+  if (pending.signal && pending.onAbort) {
+    pending.signal.removeEventListener('abort', pending.onAbort)
+  }
+  const resolution: EkkoClarificationResolution = {
+    response: '[clarification cancelled because the run was aborted]',
+    reason: 'aborted',
+  }
+  pending.onResolved?.(resolution)
+  pending.resolve(resolution.response)
   return { handled: true, resolved: true }
 }
 

--- a/packages/server/src/services/hermes/group-chat/agent-clients.ts
+++ b/packages/server/src/services/hermes/group-chat/agent-clients.ts
@@ -21,6 +21,7 @@ import {
     stripMentionRoutingTokens,
 } from './mention-routing'
 import { buildAgentInstructions, buildNonOwnerRequestSecurityPrompt } from '../context-engine/prompt'
+import { cancelPendingEkkoClarification } from '../../ekko-agent/clarifications'
 
 export const GROUP_CHAT_AGENT_SOCKET_SECRET = randomBytes(32).toString('hex')
 
@@ -107,6 +108,7 @@ type AgentActivityBroadcaster = (
     agentName: string,
     status: 'compressing' | 'replying' | 'ready',
     runId?: string,
+    agentSessionId?: string,
 ) => void
 type ExecutionQueueBroadcaster = (roomId: string) => void
 
@@ -238,6 +240,7 @@ export interface GroupAgentExecutor {
     isActiveSession(roomId: string, sessionId: string): boolean
     respondApproval?(approvalId: string, choice: string): Promise<boolean>
     respondClarify?(clarifyId: string, response: string): Promise<boolean>
+    cancelClarify?(clarifyId: string, sessionId: string, runId: string): Promise<boolean>
     replyToMention(
         roomId: string,
         msg: MentionMessage,
@@ -462,6 +465,11 @@ export class AgentClient implements GroupAgentExecutor {
             if (this.chatRunService.respondCodingAgentClarification(sessionId, clarifyId, response)) return Promise.resolve(true)
         }
         return Promise.resolve(false)
+    }
+
+    async cancelClarify(clarifyId: string, sessionId: string, runId: string): Promise<boolean> {
+        if (this.agent !== 'ekko') return false
+        return cancelPendingEkkoClarification(sessionId, clarifyId, runId).resolved
     }
 
     async joinRoom(roomId: string): Promise<JoinResult> {
@@ -1154,7 +1162,13 @@ export class AgentClient implements GroupAgentExecutor {
                     } else if (event === 'approval.resolved') {
                         this.emitApprovalResolved(roomId, { ...payload, agentSessionId: sessionId })
                     } else if (event === 'clarify.requested') {
-                        this.emitClarifyRequested(roomId, { ...payload, agentSessionId: sessionId })
+                        const { run_id: runtimeRunId, runId: runtimeCamelRunId, ...clarifyPayload } = payload
+                        this.emitClarifyRequested(roomId, {
+                            ...clarifyPayload,
+                            agentSessionId: sessionId,
+                            runId: responseRunId,
+                            runtimeRunId: String(runtimeRunId || runtimeCamelRunId || ''),
+                        })
                     } else if (event === 'clarify.resolved') {
                         this.emitClarifyResolved(roomId, { ...payload, agentSessionId: sessionId })
                     }
@@ -2195,8 +2209,9 @@ export class AgentClients {
         agentName: string,
         status: 'compressing' | 'replying' | 'ready',
         runId?: string,
+        agentSessionId?: string,
     ): void {
-        this._activityBroadcaster?.(roomId, agentName, status, runId)
+        this._activityBroadcaster?.(roomId, agentName, status, runId, agentSessionId)
         logger.debug(`[AgentClients] room ${roomId} agent ${agentName} status: ${status}`)
     }
 
@@ -2615,7 +2630,10 @@ export class AgentClients {
                         const { agent } = runnableTarget
                         const onStatus = (status: 'compressing' | 'replying' | 'ready', extra?: Record<string, unknown>) => {
                             const runId = typeof extra?.runId === 'string' ? extra.runId : undefined
-                            this.reportAgentActivity(roomId, agent.name, status, runId)
+                            const agentSessionId = typeof extra?.agentSessionId === 'string'
+                                ? extra.agentSessionId
+                                : undefined
+                            this.reportAgentActivity(roomId, agent.name, status, runId, agentSessionId)
                         }
                         if (next.msg.continuationAttemptId) {
                             if (!agent.connected) {

--- a/packages/server/src/services/hermes/group-chat/index.ts
+++ b/packages/server/src/services/hermes/group-chat/index.ts
@@ -107,6 +107,8 @@ interface PendingGroupClarifyRoute {
     roomId: string
     agentName: string
     agentSessionId: string
+    runId: string
+    runtimeRunId: string
     clarifyId: string
     question: string
     choices: string[] | null
@@ -3116,6 +3118,7 @@ export class GroupChatServer {
         agentName: string
         status: string
         agentSessionId?: string
+        runId?: string
     }>>()
     /** Stable room + persisted Agent row + run activity visible across authorized rooms. */
     private roomAgentActivityState = new Map<string, Map<string, GroupAgentActivity>>()
@@ -3273,7 +3276,7 @@ export class GroupChatServer {
             this.agentClients.getAgent(roomId, agentId)?.connected === true
         )
         this.agentClients.setRoomSummaryService(this.roomSummaryService)
-        this.agentClients.setActivityBroadcaster((roomId, agentName, status, runId) => {
+        this.agentClients.setActivityBroadcaster((roomId, agentName, status, runId, agentSessionId) => {
             let roomStatuses = this.contextStatusState.get(roomId)
             if (status === 'ready') {
                 roomStatuses?.delete(agentName)
@@ -3283,10 +3286,15 @@ export class GroupChatServer {
                     roomStatuses = new Map()
                     this.contextStatusState.set(roomId, roomStatuses)
                 }
-                roomStatuses.set(agentName, { agentName, status })
+                roomStatuses.set(agentName, {
+                    agentName,
+                    status,
+                    ...(agentSessionId ? { agentSessionId } : {}),
+                    ...(runId ? { runId } : {}),
+                })
             }
             this.nsp.to(roomId).emit('context_status', { roomId, agentName, status })
-            if (runId) this.updateRoomAgentActivity(roomId, agentName, status, runId)
+            if (runId) this.updateRoomAgentActivity(roomId, agentName, status, runId, agentSessionId)
         })
         this.agentClients.setExecutionQueueBroadcaster((roomId) => {
             this.broadcastExecutionQueue(roomId)
@@ -3912,7 +3920,7 @@ export class GroupChatServer {
         socket.on('approval.requested', (data: { roomId?: string; agentName?: string; approval_id?: string; command?: string; description?: string; choices?: string[]; allow_permanent?: boolean; timeout_ms?: number; agentSessionId?: string }) => this.handleApprovalRequested(socket, data))
         socket.on('approval.resolved', (data: { roomId?: string; agentName?: string; approval_id?: string; choice?: string; agentSessionId?: string }) => this.handleApprovalResolved(socket, data))
         socket.on('approval.respond', (data: { roomId?: string; approval_id?: string; choice?: string }, ack?: (response?: unknown) => void) => this.handleApprovalRespond(socket, data, ack))
-        socket.on('clarify.requested', (data: { roomId?: string; agentName?: string; clarify_id?: string; question?: string; choices?: string[] | null; initial_response?: string; response_mode?: string; timeout_ms?: number; agentSessionId?: string }) => this.handleClarifyRequested(socket, data))
+        socket.on('clarify.requested', (data: { roomId?: string; agentName?: string; clarify_id?: string; question?: string; choices?: string[] | null; initial_response?: string; response_mode?: string; timeout_ms?: number; agentSessionId?: string; runId?: string; runtimeRunId?: string }) => this.handleClarifyRequested(socket, data))
         socket.on('clarify.resolved', (data: { roomId?: string; agentName?: string; clarify_id?: string; resolved?: boolean; reason?: string; agentSessionId?: string }) => this.handleClarifyResolved(socket, data))
         socket.on('clarify.respond', (data: { roomId?: string; clarify_id?: string; response?: string }, ack?: (response?: unknown) => void) => this.handleClarifyRespond(socket, data, ack))
         socket.on('disconnect', () => this.handleDisconnect(socket))
@@ -4836,6 +4844,7 @@ export class GroupChatServer {
                 agentName,
                 status,
                 ...(agentSessionId ? { agentSessionId } : {}),
+                ...(typeof data.runId === 'string' && data.runId.trim() ? { runId: data.runId.trim() } : {}),
             })
         }
 
@@ -4866,8 +4875,16 @@ export class GroupChatServer {
             ack?.({ error: 'Access denied' })
             return
         }
+        const activeGeneration = this.contextStatusState.get(roomId)?.get(agentName)
+        const interruptedClarifications = this.takePendingEkkoClarificationsForGeneration(
+            roomId,
+            agentName,
+            activeGeneration?.agentSessionId || '',
+            activeGeneration?.runId || '',
+        )
         try {
             await this.agentClients.interruptAgent(roomId, agentName)
+            await this.settleInterruptedEkkoClarifications(interruptedClarifications)
             const roomStatuses = this.contextStatusState.get(roomId)
             roomStatuses?.delete(agentName)
             if (roomStatuses?.size === 0) this.contextStatusState.delete(roomId)
@@ -4878,6 +4895,7 @@ export class GroupChatServer {
             this.nsp.to(roomId).emit('context_status', { roomId, agentName, status: 'ready' })
             ack?.({ ok: true })
         } catch (err: any) {
+            await this.settleInterruptedEkkoClarifications(interruptedClarifications)
             logger.warn(`[GroupChat] failed to interrupt agent ${agentName} in room ${roomId}: ${err.message}`)
             ack?.({ error: err.message || 'interrupt failed' })
         }
@@ -5126,7 +5144,63 @@ export class GroupChatServer {
         }
     }
 
-    private handleClarifyRequested(socket: Socket, data: { roomId?: string; agentName?: string; clarify_id?: string; question?: string; choices?: string[] | null; initial_response?: string; response_mode?: string; timeout_ms?: number; agentSessionId?: string }): void {
+    private takePendingEkkoClarificationsForGeneration(
+        roomId: string,
+        agentName: string,
+        agentSessionId: string,
+        runId: string,
+    ): PendingGroupClarifyRoute[] {
+        if (!agentSessionId || !runId) return []
+        const ekkoExecutor = this.agentClients.getAgents(roomId).find(agent =>
+            agent.name === agentName && agent.agent === 'ekko' && typeof agent.cancelClarify === 'function'
+        )
+        if (!ekkoExecutor) return []
+
+        const routes: PendingGroupClarifyRoute[] = []
+        for (const [routeKey, route] of this.pendingClarifyRoutes) {
+            if (
+                route.roomId !== roomId
+                || route.agentName !== agentName
+                || route.agentSessionId !== agentSessionId
+                || route.runId !== runId
+                || !route.runtimeRunId
+            ) {
+                continue
+            }
+            const claimed = this.takePendingClarifyRoute(routeKey)
+            if (claimed) routes.push(claimed)
+        }
+        return routes
+    }
+
+    private async settleInterruptedEkkoClarifications(routes: PendingGroupClarifyRoute[]): Promise<void> {
+        for (const route of routes) {
+            const executor = this.agentClients.getAgents(route.roomId).find(agent =>
+                agent.name === route.agentName && agent.agent === 'ekko' && typeof agent.cancelClarify === 'function'
+            )
+            let runtimeResolved = false
+            try {
+                runtimeResolved = Boolean(await executor?.cancelClarify?.(
+                    route.clarifyId,
+                    route.agentSessionId,
+                    route.runtimeRunId,
+                ))
+            } catch (err: any) {
+                logger.warn(`[GroupChat] failed to cancel interrupted Ekko clarification ${route.clarifyId}: ${err?.message || err}`)
+            }
+            this.emitToRoomManagers(route.roomId, 'clarify.resolved', {
+                event: 'clarify.resolved',
+                roomId: route.roomId,
+                agentName: route.agentName,
+                clarify_id: route.clarifyId,
+                resolved: false,
+                reason: 'Agent run interrupted',
+                runtime_resolved: runtimeResolved,
+            })
+        }
+    }
+
+    private handleClarifyRequested(socket: Socket, data: { roomId?: string; agentName?: string; clarify_id?: string; question?: string; choices?: string[] | null; initial_response?: string; response_mode?: string; timeout_ms?: number; agentSessionId?: string; runId?: string; runtimeRunId?: string }): void {
         const roomId = data.roomId
         const agentName = data.agentName || ''
         if (!roomId || !data.clarify_id || !this.getCurrentAgentEventMember(socket, roomId, agentName, data.agentSessionId)) return
@@ -5137,6 +5211,8 @@ export class GroupChatServer {
             roomId,
             agentName,
             agentSessionId: String(data.agentSessionId || '').trim(),
+            runId: String(data.runId || '').trim(),
+            runtimeRunId: String(data.runtimeRunId || '').trim(),
             clarifyId: data.clarify_id,
             question: data.question || '',
             choices: Array.isArray(data.choices) ? data.choices.map(String) : null,
@@ -5166,7 +5242,8 @@ export class GroupChatServer {
         const roomId = data.roomId
         const agentName = data.agentName || ''
         if (!roomId || !data.clarify_id || !this.getCurrentAgentEventMember(socket, roomId, agentName, data.agentSessionId)) return
-        this.takePendingClarifyRoute(this.pendingClarifyRouteKey(roomId, data.clarify_id))
+        const route = this.takePendingClarifyRoute(this.pendingClarifyRouteKey(roomId, data.clarify_id))
+        if (!route || route.agentName !== agentName) return
         this.emitToRoomManagers(roomId, 'clarify.resolved', {
             event: 'clarify.resolved',
             roomId,

--- a/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
@@ -1204,6 +1204,7 @@ export async function handleEkkoAgentRun(
       }),
       requestUserClarification: (request: AgentClarificationRequest) => waitForEkkoClarification(request, {
         sessionId,
+        runId: runId || turnId,
         signal: abortController.signal,
         onRequested: pending => {
           emit('clarify.requested', {

--- a/tests/server/ekko-agent-clarifications.test.ts
+++ b/tests/server/ekko-agent-clarifications.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  cancelPendingEkkoClarification,
   cancelPendingEkkoClarifications,
   respondToEkkoClarification,
   waitForEkkoClarification,
@@ -61,6 +62,77 @@ describe('Ekko clarification broker', () => {
       resolved: true,
     })
     await expect(result).resolves.toBe('B')
+  })
+
+  it('cancels only the matching session and run generation', async () => {
+    const result = waitForEkkoClarification(request(), {
+      sessionId: 'session-1',
+      runId: 'run-current',
+      onRequested: vi.fn(),
+    })
+
+    expect(cancelPendingEkkoClarification('session-1', 'clarify-1', 'run-stale')).toEqual({
+      handled: true,
+      resolved: false,
+    })
+    expect(cancelPendingEkkoClarification('session-2', 'clarify-1', 'run-current')).toEqual({
+      handled: true,
+      resolved: false,
+    })
+    expect(cancelPendingEkkoClarification('session-1', 'clarify-1', '')).toEqual({
+      handled: true,
+      resolved: false,
+    })
+    expect(cancelPendingEkkoClarification('session-1', 'clarify-1', 'run-current')).toEqual({
+      handled: true,
+      resolved: true,
+    })
+    expect(cancelPendingEkkoClarification('session-1', 'clarify-1', 'run-current')).toEqual({
+      handled: false,
+      resolved: false,
+    })
+    await expect(result).resolves.toBe('[clarification cancelled because the run was aborted]')
+    expect(respondToEkkoClarification('session-1', 'clarify-1', 'late')).toEqual({
+      handled: false,
+      resolved: false,
+    })
+  })
+
+  it('keeps response and timeout terminal when a stop arrives later', async () => {
+    const responded = waitForEkkoClarification(request(), {
+      sessionId: 'session-response',
+      runId: 'run-response',
+      onRequested: vi.fn(),
+    })
+    expect(respondToEkkoClarification('session-response', 'clarify-1', 'A')).toEqual({
+      handled: true,
+      resolved: true,
+    })
+    expect(cancelPendingEkkoClarification('session-response', 'clarify-1', 'run-response')).toEqual({
+      handled: false,
+      resolved: false,
+    })
+    await expect(responded).resolves.toBe('A')
+
+    vi.useFakeTimers()
+    const timedOut = waitForEkkoClarification(request({
+      clarifyId: 'clarify-timeout-before-stop',
+      timeoutMs: 25,
+    }), {
+      sessionId: 'session-timeout',
+      runId: 'run-timeout',
+      onRequested: vi.fn(),
+    })
+    await vi.advanceTimersByTimeAsync(25)
+    expect(cancelPendingEkkoClarification(
+      'session-timeout',
+      'clarify-timeout-before-stop',
+      'run-timeout',
+    )).toEqual({
+      handled: false,
+      resolved: false,
+    })
+    await expect(timedOut).resolves.toBe('[user did not respond within 5m]')
   })
 
   it('returns a bounded result when another clarification is already pending', async () => {

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -606,7 +606,7 @@ describe('group chat approval and context baseline', () => {
       await delivery
       await chatRun.close()
     }
-  })
+  }, 15_000)
 
   it('claims only the active Ekko clarification generation before the abort completes', async () => {
     const { agent, human, agentSessionId } = await joinPair()

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -7,6 +7,7 @@ import {
 } from './group-chat-test-helpers'
 import { GROUP_CHAT_AGENT_SOCKET_SECRET, groupRuntimeSessionId } from '../../packages/server/src/services/hermes/group-chat/agent-clients'
 import { AgentBridgeClient } from '../../packages/server/src/services/hermes/agent-bridge'
+import { ChatRunSocket } from '../../packages/server/src/services/hermes/run-chat'
 import {
   denyPendingEkkoToolApprovals,
   waitForEkkoToolApproval,
@@ -482,6 +483,230 @@ describe('group chat approval and context baseline', () => {
       roomId: 'room-1', clarify_id: 'clarify-ekko', response: 'staging',
     })).resolves.toEqual({ ok: true, resolved: true })
     await expect(clarification).resolves.toBe('staging')
+  })
+
+  it('settles an Ekko clarification through the real GroupChat interrupt and ChatRun abort chain', async () => {
+    const human = await connectGroupChatClient(port, 'human-1', 'Human')
+    harness.sockets.push(human)
+    groupServer.getIO().of('/group-chat').sockets.get(human.id!)!.data.authUser = {
+      id: 1, role: 'user', profiles: ['default'],
+    }
+    await emitAck(human, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+
+    const chatRun = new ChatRunSocket(groupServer.getIO())
+    const abortSession = vi.spyOn(chatRun, 'abortSession')
+    const agent = await groupServer.agentClients.createAgent({
+      agentId: 'agent-1',
+      agent: 'ekko',
+      profile: 'default',
+      name: 'Agent',
+      description: '',
+      invited: 0,
+      backgroundDelegationEnabled: false,
+    }, {}, port)
+    await groupServer.agentClients.addAgentToRoom('room-1', agent)
+    groupServer.agentClients.setChatRunService(chatRun)
+
+    let runtimeWaiterSettled = false
+    let runtimeSessionId = ''
+    let clarificationRegistered!: () => void
+    const clarificationRegisteredBarrier = new Promise<void>(resolve => {
+      clarificationRegistered = resolve
+    })
+    vi.spyOn(chatRun, 'runAndWait').mockImplementation(async (data, options) => {
+      const runtimeRunId = 'runtime-current'
+      runtimeSessionId = data.session_id
+      // Match the installed event ordering: ChatRun can abort its current
+      // controller while the Ekko clarification waiter belongs to the same
+      // Session/generation but is no longer attached to that controller.
+      ;(chatRun as any).sessionMap.set(data.session_id, {
+        messages: [],
+        isWorking: true,
+        events: [],
+        queue: [],
+        source: 'group_chat',
+        runId: runtimeRunId,
+        abortController: new AbortController(),
+        profile: 'default',
+      })
+      const response = await waitForEkkoClarification({
+        clarifyId: 'clarify-real-chain',
+        question: 'Which city?',
+        choices: null,
+        timeoutMs: 300_000,
+      }, {
+        sessionId: data.session_id,
+        runId: runtimeRunId,
+        onRequested: pending => {
+          clarificationRegistered()
+          options?.onEvent?.('clarify.requested', {
+            event: 'clarify.requested',
+            run_id: runtimeRunId,
+            clarify_id: pending.clarifyId,
+            question: pending.question,
+            choices: pending.choices,
+            timeout_ms: pending.timeoutMs,
+          })
+        },
+        onResolved: resolution => options?.onEvent?.('clarify.resolved', {
+          event: 'clarify.resolved',
+          run_id: runtimeRunId,
+          clarify_id: 'clarify-real-chain',
+          resolved: resolution.reason === 'response',
+          reason: resolution.reason,
+        }),
+      })
+      runtimeWaiterSettled = true
+      return { ok: false, error: response }
+    })
+
+    let delivery: Promise<unknown> | undefined
+    try {
+      const requested = new Promise<any>(resolve => human.once('clarify.requested', resolve))
+      delivery = groupServer.agentClients.processMentions('room-1', {
+        messageId: 'message-real-chain',
+        content: '@Agent check the weather',
+        senderName: 'Human',
+        senderId: 'human-1',
+        timestamp: Date.now(),
+        role: 'user',
+        mentions: [{ type: 'agent', participantId: 'agent-1', displayName: 'Agent' }],
+      })
+      await clarificationRegisteredBarrier
+      await expect(requested).resolves.toMatchObject({
+        clarify_id: 'clarify-real-chain',
+        agentName: 'Agent',
+      })
+
+      const resolved = new Promise<any>(resolve => human.once('clarify.resolved', resolve))
+      const interrupted = new Promise<any>(resolve => {
+        human.emit('interrupt_agent', {
+          roomId: 'room-1', agentName: 'Agent',
+        }, resolve)
+      })
+      await expect(interrupted).resolves.toEqual({ ok: true })
+      await new Promise<void>(resolve => setImmediate(resolve))
+
+      expect(abortSession).toHaveBeenCalledWith(
+        runtimeSessionId,
+        'Interrupted by group chat user',
+      )
+      expect(runtimeWaiterSettled).toBe(true)
+      await expect(resolved).resolves.toMatchObject({
+        clarify_id: 'clarify-real-chain',
+        resolved: false,
+      })
+      await expect(emitAck(human, 'clarify.respond', {
+        roomId: 'room-1', clarify_id: 'clarify-real-chain', response: 'late',
+      })).resolves.toEqual({ error: 'Clarification is not pending in this room' })
+      const joined = await emitAck<any>(human, 'join', { roomId: 'room-1', inviteCode: 'ROOM1' })
+      expect(joined.pendingClarifies).toEqual([])
+    } finally {
+      cancelPendingEkkoClarifications()
+      await delivery
+      await chatRun.close()
+    }
+  })
+
+  it('claims only the active Ekko clarification generation before the abort completes', async () => {
+    const { agent, human, agentSessionId } = await joinPair()
+    let finishAbort!: () => void
+    const abortPending = new Promise<void>(resolve => {
+      finishAbort = resolve
+    })
+    const cancelClarify = vi.fn(async () => true)
+    vi.spyOn(groupServer.agentClients, 'getAgents').mockReturnValue([{
+      name: 'Agent',
+      agent: 'ekko',
+      cancelClarify,
+    } as any])
+    vi.spyOn(groupServer.agentClients, 'interruptAgent').mockImplementation(async () => {
+      await abortPending
+    })
+
+    agent.emit('context_status', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      status: 'replying',
+      agentSessionId,
+      runId: 'run-current',
+    })
+    const currentRequested = new Promise<any>(resolve => human.once('clarify.requested', resolve))
+    agent.emit('clarify.requested', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      agentSessionId,
+      runId: 'run-current',
+      runtimeRunId: 'runtime-current',
+      clarify_id: 'clarify-current',
+      question: 'Current question?',
+    })
+    await currentRequested
+    const laterRequested = new Promise<any>(resolve => human.once('clarify.requested', resolve))
+    agent.emit('clarify.requested', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      agentSessionId,
+      runId: 'run-later',
+      runtimeRunId: 'runtime-later',
+      clarify_id: 'clarify-later',
+      question: 'Later question?',
+    })
+    await laterRequested
+    const unscopedRequested = new Promise<any>(resolve => human.once('clarify.requested', resolve))
+    agent.emit('clarify.requested', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+      agentSessionId,
+      clarify_id: 'clarify-unscoped',
+      question: 'Unscoped question?',
+    })
+    await unscopedRequested
+
+    const resolved = new Promise<any>(resolve => human.once('clarify.resolved', resolve))
+    const interrupted = new Promise<any>(resolve => {
+      human.emit('interrupt_agent', {
+        roomId: 'room-1',
+        agentName: 'Agent',
+      }, resolve)
+    })
+    await vi.waitFor(() => {
+      expect(groupServer.agentClients.interruptAgent).toHaveBeenCalledTimes(1)
+    })
+    await expect(emitAck(human, 'clarify.respond', {
+      roomId: 'room-1',
+      clarify_id: 'clarify-current',
+      response: 'late',
+    })).resolves.toEqual({ error: 'Clarification is not pending in this room' })
+
+    finishAbort()
+    await expect(interrupted).resolves.toEqual({ ok: true })
+    await expect(resolved).resolves.toMatchObject({
+      clarify_id: 'clarify-current',
+      resolved: false,
+      reason: 'Agent run interrupted',
+    })
+    expect(cancelClarify).toHaveBeenCalledTimes(1)
+    expect(cancelClarify).toHaveBeenCalledWith(
+      'clarify-current',
+      agentSessionId,
+      'runtime-current',
+    )
+
+    const joined = await emitAck<any>(human, 'join', {
+      roomId: 'room-1',
+      inviteCode: 'ROOM1',
+    })
+    expect(joined.pendingClarifies).toEqual([
+      expect.objectContaining({ clarify_id: 'clarify-later' }),
+      expect.objectContaining({ clarify_id: 'clarify-unscoped' }),
+    ])
+
+    await expect(emitAck(human, 'interrupt_agent', {
+      roomId: 'room-1',
+      agentName: 'Agent',
+    })).resolves.toEqual({ ok: true })
+    expect(cancelClarify).toHaveBeenCalledTimes(1)
   })
 
   it('routes a clarification response to the Hermes bridge', async () => {

--- a/tests/server/group-chat-test-helpers.ts
+++ b/tests/server/group-chat-test-helpers.ts
@@ -9,7 +9,10 @@ const groupChatAuthMock = vi.hoisted(() => ({
   user: null as any,
 }))
 
-vi.mock('../../packages/server/src/db/index', () => ({ getDb: () => groupChatDbMock.current }))
+vi.mock('../../packages/server/src/db/index', () => ({
+  getDb: () => groupChatDbMock.current,
+  isSqliteAvailable: () => groupChatDbMock.current !== null,
+}))
 vi.mock('../../packages/server/src/middleware/user-auth', () => ({
   isAuthEnabled: vi.fn(async () => groupChatAuthMock.enabled),
   authenticateUserToken: vi.fn(async () => groupChatAuthMock.user),


### PR DESCRIPTION
## Summary

- preserve the Ekko Runtime `runId` on clarification waiters and expose exact cancellation by `sessionId + clarifyId + runId`
- propagate `agentSessionId` and the visible Group Chat run generation through internal Agent activity
- atomically claim the matching pending clarification route before interrupting, then settle the exact Runtime waiter after the real `ChatRun.abortSession` path
- clear Room/global pending state, reject late replies, and preserve generation isolation and stop/reply/timeout idempotency
- add deterministic real-chain coverage with explicit waiter-registration and abort lifecycle barriers instead of fixed socket timeouts

Closes #2690

## RED / GREEN

- RED on frozen base `bf181ce1aafe448034beb1c72192aaada2a50c90`: after the real `GroupChat -> interruptAgent -> ChatRun.abortSession` ack and an event-loop barrier, the Runtime clarification waiter remained pending (`expected false to be true`).
- GREEN on this HEAD: the same real-chain test settles the exact waiter, removes Room/global pending state, rejects delayed replies, and leaves unrelated generations untouched.
- Focused server verification: 4 files / 63 tests passed; focused exact-tree coverage passed with no unhandled rejection.

## Validation

- `npm run harness:check`: PASS
- `git diff --check`: PASS
- `npm run build`: PASS
- focused server suite: 63 passed
- Group Chat Playwright: 32 passed
- `npm run test`: 4301 passed / 50 failed / 6 skipped
  - frozen base in the same environment: 4296 passed / 51 failed / 6 skipped
  - exact failed-test-name comparison: candidate-added failures = 0; 50 failures are shared environment/baseline failures; base-only Windows Pi streaming failure = 1
- `npm run test:coverage`: 4301 passed / 50 failed / 6 skipped
  - frozen base: 4297 passed / 50 failed / 6 skipped
  - exact failed-test-name comparison: candidate-only = 0; base-only = 0
- full `npm run test:e2e`: 104 passed / 3 failed / 27 did not run due serial-suite interruption
  - the three failures were unrelated timing/UI flakes (chat route hydration, Group Chat history visibility, Workflow select menu)
  - exact candidate rerun of all three: 3 passed
  - exact candidate Group Chat suite: 32 passed

## Candidate identity

- Base: `bf181ce1aafe448034beb1c72192aaada2a50c90`
- Base tree: `dd16f23238affe7275f0cd7746f6981bc3c9dd0e`
- Head: `fa1073c1e25254fb3f9615333733c88802cdc24f`
- Head tree: `ca4c28ac91e4ae30e4a8a3bfcdd1e16442c07423`
- Stable patch ID: `fd5b515e6a9ebabbd97b4eed4a37a1a586f4e980`


## Exact-head checks

- `build`: SUCCESS (includes the complete `npm run test:coverage` run; 4348 passed / 1 failed was eliminated by giving the barrier-based integration test an explicit 15s harness budget, and the final exact-head check passed)
- `e2e`: SUCCESS
- Legacy commit statuses: none (`total_count = 0`)
