### PR TITLE
fix: isolate shared-profile sessions by user

### DIFF
--- a/docs/chat-chain-changes/2026-08-23-session-user-isolation.md
+++ b/docs/chat-chain-changes/2026-08-23-session-user-isolation.md
@@ -1,0 +1,8 @@
+---
+date: 2026-08-23
+pr: pending
+feature: Authenticated shared-profile session and memory isolation
+impact: New authenticated bridge sessions persist their owner user_id; user-facing session lists, details, and Socket.IO continuation access exclude sessions owned by other accounts. The memory editor stores authenticated users' files in account-specific directories beneath the shared profile.
+---
+
+Profile configuration remains shared. Existing ownerless rows retain their historical behavior for backward compatibility; newly created authenticated sessions are account-bound.

--- a/packages/server/src/controllers/hermes/memory.ts
+++ b/packages/server/src/controllers/hermes/memory.ts
@@ -8,7 +8,9 @@ function requestedProfile(ctx: any): string {
 }
 
 function requestProfileDir(ctx: any): string {
-  return getProfileDir(requestedProfile(ctx))
+  const profileDir = getProfileDir(requestedProfile(ctx))
+  const userId = ctx.state?.user?.id
+  return userId == null ? profileDir : join(profileDir, 'webui-users', String(userId))
 }
 
 export async function get(ctx: any) {

--- a/packages/server/src/controllers/hermes/sessions.ts
+++ b/packages/server/src/controllers/hermes/sessions.ts
@@ -122,16 +122,27 @@ function canAccessProfile(ctx: any, profile: string | null | undefined): boolean
   return !allowed || allowed.has(profile || 'default')
 }
 
+function authenticatedUserId(ctx: any): string | null {
+  const id = ctx.state?.user?.id
+  return id == null ? null : String(id)
+}
+
+function canAccessSession(ctx: any, session: any | null | undefined): boolean {
+  if (!session || !canAccessProfile(ctx, session.profile)) return false
+  const userId = authenticatedUserId(ctx)
+  return userId == null || !session.user_id || String(session.user_id) === userId
+}
+
 function filterByAllowedProfiles<T>(ctx: any, items: T[]): T[] {
-  const allowed = allowedProfileSet(ctx)
-  if (!allowed) return items
-  return items.filter(item => allowed.has(((item as any).profile as string | null | undefined) || 'default'))
+  return items.filter(item => canAccessSession(ctx, item))
 }
 
 function denySessionAccess(ctx: any, session: any | null | undefined): boolean {
-  if (!session || canAccessProfile(ctx, session.profile)) return false
-  ctx.status = 403
-  ctx.body = { error: `Profile "${session.profile || 'default'}" is not available for this user` }
+  if (!session || canAccessSession(ctx, session)) return false
+  ctx.status = session && canAccessProfile(ctx, session.profile) ? 404 : 403
+  ctx.body = { error: session && canAccessProfile(ctx, session.profile)
+    ? 'Session not found'
+    : `Profile "${session?.profile || 'default'}" is not available for this user` }
   return true
 }
 
@@ -190,6 +201,7 @@ function mergeHermesHistorySessions(
   for (const [id, session] of historySessionsById) {
     const localSession = localSessionsById.get(id)
     if (localSession?.is_archived != null) session.is_archived = localSession.is_archived
+    if (localSession?.user_id != null) session.user_id = localSession.user_id
   }
 
   for (const session of localSessions) {
@@ -1135,6 +1147,7 @@ export async function importHermesSession(ctx: any) {
 
   const existing = localGetSessionDetail(sessionId)
   if (existing) {
+    if (denySessionAccess(ctx, existing)) return
     ctx.body = { ok: true, imported: false, session: existing }
     return
   }
@@ -1154,6 +1167,9 @@ export async function importHermesSession(ctx: any) {
     ctx.body = { error: 'Session not found' }
     return
   }
+  if (!canAccessSession(ctx, { ...detail, profile })) return
+
+  const ownerUserId = detail.user_id == null ? authenticatedUserId(ctx) : String(detail.user_id)
 
   const profileDefault = await getProfileDefaultModel(profile)
   const importTimestamp = Math.floor(Date.now() / 1000)
@@ -1162,6 +1178,7 @@ export async function importHermesSession(ctx: any) {
     id: detail.id,
     profile,
     source: 'cli',
+    user_id: ownerUserId,
     model: profileDefault.model,
     provider: profileDefault.provider,
     title: detail.title || undefined,
@@ -1169,7 +1186,7 @@ export async function importHermesSession(ctx: any) {
 
   localUpdateSession(detail.id, {
     source: 'cli',
-    user_id: detail.user_id,
+    user_id: ownerUserId,
     model: profileDefault.model,
     provider: profileDefault.provider,
     title: detail.title,
@@ -1275,6 +1292,11 @@ export async function batchRemove(ctx: any) {
   for (const target of targets) {
     const { id } = target
     const existing = localGetSession(id)
+    if (existing && !canAccessSession(ctx, existing)) {
+      results.failed++
+      results.errors.push({ id, error: 'Session not found' })
+      continue
+    }
     const targetProfile = target.profile || existing?.profile
     if (targetProfile && !canAccessProfile(ctx, targetProfile)) {
       results.failed++
@@ -1410,7 +1432,7 @@ export async function setWorkspace(ctx: any) {
   const existing = getSession(id)
   if (denySessionAccess(ctx, existing)) return
   if (!existing) {
-    createSession({ id, profile: requestedProfile(ctx) || 'default', title: '' })
+    createSession({ id, profile: requestedProfile(ctx) || 'default', user_id: authenticatedUserId(ctx), title: '' })
   }
   updateSession(id, { workspace: workspace || null } as any)
   ctx.body = { ok: true }
@@ -1485,7 +1507,7 @@ export async function setModel(ctx: any) {
     ? await ensureHermesRunWorkspace(profile, existing?.workspace)
     : undefined
   if (!existing) {
-    createSession({ id, profile, title: '', model: cleanModel, provider: cleanProvider, api_mode: cleanApiMode || '', reasoning_effort: '', workspace })
+    createSession({ id, profile, user_id: authenticatedUserId(ctx), title: '', model: cleanModel, provider: cleanProvider, api_mode: cleanApiMode || '', reasoning_effort: '', workspace })
   }
   const updates: Record<string, string> = { model: cleanModel, provider: cleanProvider, reasoning_effort: '' }
   if (cleanApiMode) updates.api_mode = cleanApiMode

--- a/packages/server/src/db/hermes/session-store.ts
+++ b/packages/server/src/db/hermes/session-store.ts
@@ -181,6 +181,7 @@ export function createSession(data: {
   agent_mode?: string
   agent_session_id?: string
   agent_native_session_id?: string
+  user_id?: string | null
   model?: string
   provider?: string
   api_mode?: string
@@ -198,7 +199,7 @@ export function createSession(data: {
       id: data.id, profile: data.profile || 'default', source, agent,
       agent_mode: data.agent_mode || '',
       agent_session_id: data.agent_session_id || '', agent_native_session_id: data.agent_native_session_id || '',
-      user_id: null, model: data.model || '', provider: data.provider || '', api_mode: data.api_mode || '', reasoning_effort: data.reasoning_effort || '', title: data.title || null,
+      user_id: data.user_id ?? null, model: data.model || '', provider: data.provider || '', api_mode: data.api_mode || '', reasoning_effort: data.reasoning_effort || '', title: data.title || null,
       parent_session_id: data.parent_session_id || null,
       fork_point_message_id: null,
       started_at: now, ended_at: null, end_reason: null,
@@ -212,8 +213,8 @@ export function createSession(data: {
   }
   const db = getDb()!
   db.prepare(
-    `INSERT INTO ${SESSIONS_TABLE} (id, profile, source, agent, agent_mode, agent_session_id, agent_native_session_id, model, provider, api_mode, reasoning_effort, title, parent_session_id, started_at, last_active, workspace, category_id)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO ${SESSIONS_TABLE} (id, profile, source, agent, agent_mode, agent_session_id, agent_native_session_id, user_id, model, provider, api_mode, reasoning_effort, title, parent_session_id, started_at, last_active, workspace, category_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     data.id,
     data.profile || 'default',
@@ -222,6 +223,7 @@ export function createSession(data: {
     data.agent_mode || '',
     data.agent_session_id || '',
     data.agent_native_session_id || '',
+    data.user_id ?? null,
     data.model || '',
     data.provider || '',
     data.api_mode || '',
@@ -245,6 +247,7 @@ export function createBranchedSession(data: {
   agent_mode?: string
   agent_session_id?: string
   agent_native_session_id?: string
+  user_id?: string | null
   model?: string
   provider?: string
   api_mode?: string
@@ -287,8 +290,8 @@ export function createBranchedSession(data: {
     ).run(data.ended_at, 'branched', data.parent_session_id)
 
     db.prepare(
-      `INSERT INTO ${SESSIONS_TABLE} (id, profile, source, agent, agent_mode, agent_session_id, agent_native_session_id, model, provider, api_mode, reasoning_effort, title, parent_session_id, started_at, last_active, workspace, category_id, message_count)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO ${SESSIONS_TABLE} (id, profile, source, agent, agent_mode, agent_session_id, agent_native_session_id, user_id, model, provider, api_mode, reasoning_effort, title, parent_session_id, started_at, last_active, workspace, category_id, message_count)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       data.id,
       data.profile || 'default',
@@ -297,6 +300,7 @@ export function createBranchedSession(data: {
       data.agent_mode || '',
       data.agent_session_id || '',
       data.agent_native_session_id || '',
+      data.user_id ?? null,
       data.model || '',
       data.provider || '',
       data.api_mode || '',

--- a/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-bridge-run.ts
@@ -483,6 +483,7 @@ export async function handleBridgeRun(
     if (Object.keys(updates).length > 0) updateSession(session_id, updates)
   }
   const socketUser = socket.data.user as AuthenticatedUser | undefined
+  const authenticatedUserId = socketUser?.id == null ? null : String(socketUser.id)
   await writeModelRunProfileToken(socketUser, profile)
   const runPrompt = [
     'When calling Hermes Web UI endpoints from tools or skills, include the current Hermes profile as the X-Hermes-Profile header if the endpoint supports profile-scoped behavior.',
@@ -555,7 +556,7 @@ export async function handleBridgeRun(
     if (!getSession(session_id)) {
       const previewText = extractTextForPreview(displayInput || input)
       const preview = previewText.replace(/[\r\n]/g, ' ').substring(0, 100)
-      createSession({ id: session_id, profile, source: runSource, model: resolvedModel, provider: resolvedProvider, reasoning_effort: reasoningEffort || '', title: preview, workspace, category_id: data.category_id })
+      createSession({ id: session_id, profile, source: runSource, user_id: authenticatedUserId, model: resolvedModel, provider: resolvedProvider, reasoning_effort: reasoningEffort || '', title: preview, workspace, category_id: data.category_id })
     }
     messageId = addMessage({
       session_id,
@@ -577,7 +578,7 @@ export async function handleBridgeRun(
   } else if (!getSession(session_id)) {
     const previewText = displayInput === null ? extractTextForPreview(input) : extractTextForPreview(displayInput || input)
     const preview = previewText.replace(/[\r\n]/g, ' ').substring(0, 100)
-    createSession({ id: session_id, profile, source: runSource, model: resolvedModel, provider: resolvedProvider, reasoning_effort: reasoningEffort || '', title: preview, workspace, category_id: data.category_id })
+    createSession({ id: session_id, profile, source: runSource, user_id: authenticatedUserId, model: resolvedModel, provider: resolvedProvider, reasoning_effort: reasoningEffort || '', title: preview, workspace, category_id: data.category_id })
   }
 
   socket.join(`session:${session_id}`)

--- a/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-coding-agent-run.ts
@@ -16,7 +16,7 @@ import type { ChatCodingAgentId } from './types'
 import { writeModelRunProfileToken } from './model-run-prompt'
 import type { AuthenticatedUser } from '../../../middleware/user-auth'
 import { getSystemPrompt } from '../../../lib/llm-prompt'
-import { getSession, updateSession } from '../../../db/hermes/session-store'
+import { createSession, getSession, updateSession } from '../../../db/hermes/session-store'
 import { logger } from '../../logger'
 
 export interface CodingAgentRunSocketData {
@@ -85,6 +85,18 @@ export async function handleCodingAgentRun(
   let runId = codingAgentRunManager.runIdForSession(sessionId)
   const mode = data.mode === 'global' ? 'global' : 'scoped'
   const storedSession = getSession(sessionId)
+  if (!storedSession) {
+    createSession({
+      id: sessionId,
+      profile,
+      source: state.source,
+      user_id: socket.data?.user?.id == null ? null : String(socket.data.user.id),
+      agent: agentId === 'claude-code' ? 'claude' : agentId,
+      model: data.model,
+      provider: data.provider,
+      workspace: data.workspace || undefined,
+    })
+  }
   const launchProvider = data.provider || (mode === 'scoped' ? storedSession?.provider || undefined : undefined)
   const launchModel = data.model || (mode === 'scoped' ? storedSession?.model || undefined : undefined)
   const launchApiMode = data.apiMode || data.api_mode || (mode === 'scoped' ? storedSession?.api_mode || undefined : undefined)

--- a/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
+++ b/packages/server/src/services/hermes/run-chat/handle-ekko-agent-run.ts
@@ -484,6 +484,7 @@ export async function handleEkkoAgentRun(
       id: sessionId,
       profile,
       source: sessionSource,
+      user_id: socket.data?.user?.id == null ? null : String(socket.data.user.id),
       agent: 'ekko-agent',
       agent_mode: 'scoped',
       model: modelConfig.model,

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -332,6 +332,9 @@ export class ChatRunSocket {
       if (socketUser && !this.canAccessProfile(socketUser, sessionProfile)) {
         throw new Error(`Profile "${sessionProfile}" is not available for this user`)
       }
+      if (socketUser && session.user_id && String(session.user_id) !== String(socketUser.id)) {
+        throw new Error('Session not found')
+      }
       return sessionProfile
     }
 
@@ -371,6 +374,19 @@ export class ChatRunSocket {
       // Local patch (reasoning-effort): per-session reasoning effort override.
       reasoning_effort?: string
     }) => {
+      if (data.session_id && getSession(data.session_id)) {
+        try {
+          requireSocketSessionAccess(data.session_id)
+        } catch (err) {
+          socket.emit('run.failed', {
+            event: 'run.failed',
+            session_id: data.session_id,
+            queue_id: data.queue_id,
+            error: err instanceof Error ? err.message : String(err),
+          })
+          return
+        }
+      }
       let runProfile: string
       try {
         runProfile = resolveRunProfile(data.session_id, data.profile)

--- a/packages/server/src/services/hermes/run-chat/session-command.ts
+++ b/packages/server/src/services/hermes/run-chat/session-command.ts
@@ -714,7 +714,7 @@ export async function handleSessionCommand(
       }
       const title = command.args.slice(0, 120)
       if (!getSession(sessionId)) {
-        createSession({ id: sessionId, profile: ctx.profile, source: 'cli', model: ctx.model, title })
+        createSession({ id: sessionId, profile: ctx.profile, source: 'cli', user_id: sessionUserId(ctx), model: ctx.model, title })
       }
       const updated = renameSession(sessionId, title)
       emitCommand({
@@ -1160,6 +1160,7 @@ function ensureCommandSession(sessionId: string, command: ParsedSessionCommand, 
     id: sessionId,
     profile: ctx.profile,
     source: 'cli',
+    user_id: sessionUserId(ctx),
     model: ctx.model,
     title: buildCommandSessionTitle(command),
   })
@@ -1211,6 +1212,7 @@ function createBranchSession(parentSessionId: string, requestedTitle: string, ct
     agent_mode: parent.agent_mode || '',
     agent_session_id: parent.agent_session_id || '',
     agent_native_session_id: parent.agent_native_session_id || '',
+    user_id: parent.user_id ?? sessionUserId(ctx),
     model: parent.model || ctx.model || '',
     provider: parent.provider || ctx.provider || '',
     api_mode: parent.api_mode || '',
@@ -1258,6 +1260,10 @@ function createBranchSession(parentSessionId: string, requestedTitle: string, ct
   }
 }
 
+function sessionUserId(ctx: SessionCommandContext): string | null {
+  const userId = (ctx.socket.data as { user?: { id?: unknown } } | undefined)?.user?.id
+  return userId == null ? null : String(userId)
+}
 
 function isCodingAgentBranchSource(session: { source?: string | null; agent?: string | null } | null | undefined): boolean {
   return session?.source === 'coding_agent' || session?.agent === 'claude' || session?.agent === 'codex' || session?.agent === 'pi' || session?.agent === 'ekko-agent'

--- a/tests/server/coding-agent-baseline.test.ts
+++ b/tests/server/coding-agent-baseline.test.ts
@@ -11,6 +11,7 @@ const sendCodingAgentRunInputMock = vi.hoisted(() => vi.fn())
 const writeModelRunProfileTokenMock = vi.hoisted(() => vi.fn(async () => undefined))
 const getSystemPromptMock = vi.hoisted(() => vi.fn(() => 'system prompt'))
 const getSessionMock = vi.hoisted(() => vi.fn())
+const createSessionMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../../packages/server/src/services/coding-agents/runtime/run-manager', () => ({
   codingAgentRunManager: managerMock,
@@ -26,6 +27,7 @@ vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
   getSystemPrompt: getSystemPromptMock,
 }))
 vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
+  createSession: createSessionMock,
   getSession: getSessionMock,
 }))
 
@@ -58,6 +60,7 @@ describe('coding-agent dispatch baseline', () => {
     writeModelRunProfileTokenMock.mockResolvedValue(undefined)
     getSystemPromptMock.mockReturnValue('system prompt')
     getSessionMock.mockReturnValue(null)
+    createSessionMock.mockReturnValue(undefined)
   })
 
   it('dispatches an explicit coding_agent_id and passes local proxy fields through', async () => {

--- a/tests/server/handle-coding-agent-run.test.ts
+++ b/tests/server/handle-coding-agent-run.test.ts
@@ -11,6 +11,7 @@ const sendCodingAgentRunInputMock = vi.hoisted(() => vi.fn())
 const writeModelRunProfileTokenMock = vi.hoisted(() => vi.fn(async () => undefined))
 const getSystemPromptMock = vi.hoisted(() => vi.fn(() => 'system prompt'))
 const getSessionMock = vi.hoisted(() => vi.fn())
+const createSessionMock = vi.hoisted(() => vi.fn())
 const updateSessionMock = vi.hoisted(() => vi.fn())
 const handleCodingAgentSessionCommandMock = vi.hoisted(() => vi.fn(async () => undefined))
 const parseCodingAgentSessionCommandMock = vi.hoisted(() => vi.fn())
@@ -33,6 +34,7 @@ vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
 }))
 
 vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
+  createSession: createSessionMock,
   getSession: getSessionMock,
   updateSession: updateSessionMock,
 }))
@@ -50,6 +52,7 @@ describe('handleCodingAgentRun', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getSessionMock.mockReturnValue(null)
+    createSessionMock.mockReturnValue(undefined)
     managerMock.isSessionProcessing.mockReturnValue(false)
     writeModelRunProfileTokenMock.mockResolvedValue(undefined)
     getSystemPromptMock.mockReturnValue('system prompt')

--- a/tests/server/memory-controller.test.ts
+++ b/tests/server/memory-controller.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const safeReadFileMock = vi.hoisted(() => vi.fn())
+const safeStatMock = vi.hoisted(() => vi.fn())
+const mkdirMock = vi.hoisted(() => vi.fn())
+const writeFileMock = vi.hoisted(() => vi.fn())
+
+vi.mock('fs/promises', () => ({
+  mkdir: mkdirMock,
+  writeFile: writeFileMock,
+}))
+
+vi.mock('../../packages/server/src/services/config-helpers', () => ({
+  safeReadFile: safeReadFileMock,
+  safeStat: safeStatMock,
+}))
+
+vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+  getActiveProfileName: () => 'default',
+  getProfileDir: (profile: string) => `/profiles/${profile}`,
+}))
+
+describe('memory controller', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    safeReadFileMock.mockReset().mockResolvedValue('')
+    safeStatMock.mockReset().mockResolvedValue(null)
+    mkdirMock.mockReset().mockResolvedValue(undefined)
+    writeFileMock.mockReset().mockResolvedValue(undefined)
+  })
+
+  it('isolates authenticated users within a shared profile', async () => {
+    const { get, save } = await import('../../packages/server/src/controllers/hermes/memory')
+
+    await get({ state: { user: { id: 1 } } } as any)
+    await get({ state: { user: { id: 2 } } } as any)
+    await save({
+      state: { user: { id: 1 } },
+      request: { body: { section: 'memory', content: 'alice private memory' } },
+    } as any)
+
+    expect(safeReadFileMock).toHaveBeenCalledWith('/profiles/default/webui-users/1/memories/MEMORY.md')
+    expect(safeReadFileMock).toHaveBeenCalledWith('/profiles/default/webui-users/2/memories/MEMORY.md')
+    expect(mkdirMock).toHaveBeenCalledWith('/profiles/default/webui-users/1/memories', { recursive: true })
+    expect(writeFileMock).toHaveBeenCalledWith(
+      '/profiles/default/webui-users/1/memories/MEMORY.md',
+      'alice private memory',
+      'utf-8',
+    )
+  })
+})

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -247,6 +247,23 @@ describe('session conversations controller', () => {
     codingAgentRunManagerMock.stop.mockReset()
   })
 
+  it('isolates shared-profile session lists and details by authenticated user id', async () => {
+    const aliceSession = { id: 'alice-session', profile: 'default', user_id: '1', source: 'api_server', is_archived: 0 }
+    const bobSession = { id: 'bob-session', profile: 'default', user_id: '2', source: 'api_server', is_archived: 0 }
+    listUserProfilesMock.mockReturnValue([{ profile_name: 'default' }])
+    localListSessionsMock.mockReturnValue([aliceSession, bobSession])
+    localGetSessionDetailMock.mockReturnValue({ ...aliceSession, messages: [{ id: 1, role: 'user', content: 'private' }] })
+
+    const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+    const listCtx: any = { query: {}, state: { user: { id: 2, role: 'admin' } }, body: null }
+    await mod.list(listCtx)
+    expect(listCtx.body.sessions).toEqual([bobSession])
+
+    const detailCtx: any = { params: { id: 'alice-session' }, state: { user: { id: 2, role: 'admin' } }, body: null }
+    await mod.get(detailCtx)
+    expect(detailCtx).toMatchObject({ status: 404, body: { error: 'Session not found' } })
+  })
+
   it('lists conversations from the local session store', async () => {
     localListSessionsMock.mockReturnValue([{
       id: 'local-conversation',
@@ -1093,6 +1110,18 @@ describe('session conversations controller', () => {
     ])
   })
 
+  it('hides an imported shared-profile history session owned by another user', async () => {
+    listUserProfilesMock.mockReturnValue([{ profile_name: 'travel' }])
+    localListSessionsMock.mockReturnValue([{ id: 'alice-history', profile: 'travel', source: 'cli', user_id: '1' }])
+    listSessionSummariesMock.mockResolvedValue([{ id: 'alice-history', source: 'cli', title: 'Private history', started_at: 1, last_active: 1 }])
+
+    const mod = await import('../../packages/server/src/controllers/hermes/sessions')
+    const ctx: any = { query: { profile: 'travel' }, state: { user: { id: 2, role: 'admin' } }, body: null }
+    await mod.listHermesSessions(ctx)
+
+    expect(ctx.body.sessions).toEqual([])
+  })
+
   it('returns the first page of every Hermes history source group', async () => {
     localListSessionsMock.mockReturnValue([])
     listSessionSummaryGroupsMock.mockResolvedValue({
@@ -1930,6 +1959,7 @@ describe('session conversations controller', () => {
   })
 
   it('imports a Hermes session into the local Web UI store', async () => {
+    listUserProfilesMock.mockReturnValue([{ profile_name: 'travel' }])
     const hermesDetail = {
       id: 'cli-1',
       source: 'cli',
@@ -1966,7 +1996,7 @@ describe('session conversations controller', () => {
     getSessionDetailFromDbWithProfileMock.mockResolvedValue(hermesDetail)
 
     const mod = await import('../../packages/server/src/controllers/hermes/sessions')
-    const ctx: any = { params: { id: 'cli-1' }, query: { profile: 'travel' }, state: {}, body: null }
+    const ctx: any = { params: { id: 'cli-1' }, query: { profile: 'travel' }, state: { user: { id: 1, role: 'admin' } }, body: null }
 
     await mod.importHermesSession(ctx)
 
@@ -1975,12 +2005,14 @@ describe('session conversations controller', () => {
       id: 'cli-1',
       profile: 'travel',
       source: 'cli',
+      user_id: '1',
       model: 'gpt-default',
       provider: 'openai',
       title: 'CLI run',
     }))
     expect(localUpdateSessionMock).toHaveBeenCalledWith('cli-1', expect.objectContaining({
       source: 'cli',
+      user_id: '1',
       model: 'gpt-default',
       provider: 'openai',
     }))


### PR DESCRIPTION
## Summary
- Persist the authenticated owner for sessions created through bridge, coding-agent, Ekko, command, import, and session-setting paths.
- Enforce owner checks for session reads, mutations, history merges, batch deletes, and Socket.IO continuation runs while retaining profile-level configuration sharing.
- Store authenticated users' memory-editor files beneath account-specific profile directories and add regression coverage.

Closes #2350

## Validation
- `./node_modules/.bin/vitest run tests/server/sessions-controller.test.ts tests/server/memory-controller.test.ts tests/server/session-store-branch.test.ts tests/server/run-chat-ekko-context.test.ts tests/server/handle-coding-agent-run.test.ts tests/server/session-command-branch.test.ts tests/server/session-command-plan.test.ts --reporter=dot` (134 passed)
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run harness:check`
- `npm run build`

## Known validation gaps
- `npm run test:coverage` has pre-existing environment/configuration failures caused by the suite expecting port 8648 while this checkout uses 6060; it also exposed and then validated fixes for the new coding-agent/session-command paths with the focused suite.
- `npm run test:e2e` had 133 passed and one unrelated flaky XLSX-preview timeout.