### PR TITLE
[fix] bound App single-chat resume snapshots

### DIFF
--- a/docs/chat-chain-changes/2026-08-23-app-single-chat-resume-pagination.md
+++ b/docs/chat-chain-changes/2026-08-23-app-single-chat-resume-pagination.md
@@ -1,0 +1,11 @@
+---
+date: 2026-08-23
+pr: pending
+feature: App single-chat resume pagination
+impact: Direct-chat resume snapshots now stay bounded to the latest 150 display messages while runtime history and model-context construction remain complete.
+---
+
+The App can request older persisted messages through the existing paginated
+conversation endpoint. Resume pagination is applied only when building the
+outbound display payload; it does not trim session runtime state, persisted
+messages, compression snapshots, or the database-backed model history.

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -33,7 +33,7 @@ import {
   parseCodingAgentSessionCommand,
 } from '../../coding-agents/session-command'
 import { contentBlocksToString } from './content-blocks'
-import { buildOutboundRunEvent, buildResumeEvents, buildResumeMessages } from './resume-payload'
+import { buildOutboundRunEvent, buildResumeEvents, buildResumeMessagePage } from './resume-payload'
 import type {
   BackgroundContinuationContext,
   ChatCodingAgentId,
@@ -1231,13 +1231,14 @@ export class ChatRunSocket {
       ? state.events
       : (state.events || []).filter(evt => evt?.event === 'run.reattach_failed')
     const sessionDetail = getSessionMetadata(sid)
+    const messagePage = buildResumeMessagePage(state.messages, {
+      limit: state.messagePageLimit,
+      messageTotal: state.messageTotal,
+      messageStateBaselineCount: state.messageStateBaselineCount,
+    })
     socket.emit('resumed', {
       session_id: sid,
-      messages: buildResumeMessages(state.messages),
-      messageTotal: state.messageTotal,
-      messageLoadedCount: state.messageLoadedCount,
-      messagePageLimit: state.messagePageLimit,
-      hasMoreBefore: state.hasMoreBefore,
+      ...messagePage,
       parentSessionId: sessionDetail?.parent_session_id || null,
       forkPointMessageId: sessionDetail?.fork_point_message_id || null,
       parentTitle: sessionDetail?.parent_title || null,
@@ -1922,6 +1923,7 @@ export class ChatRunSocket {
       state.messages = []
       state.messageTotal = 0
       state.messageLoadedCount = 0
+      state.messageStateBaselineCount = 0
       state.hasMoreBefore = false
       state.inputTokens = 0
       state.outputTokens = 0

--- a/packages/server/src/services/hermes/run-chat/load-state.ts
+++ b/packages/server/src/services/hermes/run-chat/load-state.ts
@@ -89,6 +89,7 @@ export async function loadSessionStateFromDb(sid: string, _sessionMap: Map<strin
       messageTotal: actualDetail?.total || messages.length,
       messageLoadedCount: actualDetail?.messages.length || messages.length,
       messagePageLimit: actualDetail?.limit,
+      messageStateBaselineCount: messages.length,
       hasMoreBefore: actualDetail?.hasMore || false,
       isWorking: false,
       events: [],

--- a/packages/server/src/services/hermes/run-chat/resume-payload.ts
+++ b/packages/server/src/services/hermes/run-chat/resume-payload.ts
@@ -1,6 +1,7 @@
 import type { SessionMessage } from './types'
 
 export const RESUME_TOOL_RESULT_DISPLAY_LIMIT = 1_000
+export const RESUME_MESSAGE_PAGE_LIMIT = 150
 
 const JSON_STRING_DISPLAY_LIMIT = 200
 const JSON_MAX_DEPTH = 6
@@ -23,6 +24,20 @@ export type OutboundToolMessage = Record<string, unknown> & {
 
 export interface OutboundToolMessageOptions {
   preserveToolNames?: readonly string[]
+}
+
+export interface ResumeMessagePageOptions {
+  limit?: number
+  messageTotal?: number
+  messageStateBaselineCount?: number
+}
+
+export interface ResumeMessagePage {
+  messages: SessionMessage[]
+  messageTotal: number
+  messageLoadedCount: number
+  messagePageLimit: number
+  hasMoreBefore: boolean
 }
 
 function stringifyLength(value: unknown): number {
@@ -171,6 +186,40 @@ export function buildOutboundToolMessage<T extends OutboundToolMessage>(
  */
 export function buildResumeMessages(messages: SessionMessage[]): SessionMessage[] {
   return messages.map(message => buildOutboundToolMessage(message as ResumeMessage) as SessionMessage)
+}
+
+/**
+ * Page the display-only resume snapshot without trimming runtime state. The
+ * persisted total can be larger than the in-memory window after a cold load,
+ * while the in-memory window can grow during a long-lived server process.
+ */
+export function buildResumeMessagePage(
+  messages: SessionMessage[],
+  options: ResumeMessagePageOptions = {},
+): ResumeMessagePage {
+  const requestedLimit = Number(options.limit)
+  const messagePageLimit = Number.isFinite(requestedLimit) && requestedLimit > 0
+    ? Math.floor(requestedLimit)
+    : RESUME_MESSAGE_PAGE_LIMIT
+  const persistedTotal = Number(options.messageTotal)
+  const stateBaselineCount = Number(options.messageStateBaselineCount)
+  const appendedCount = Number.isFinite(stateBaselineCount)
+    ? Math.max(0, messages.length - Math.floor(stateBaselineCount))
+    : 0
+  const messageTotal = Math.max(
+    messages.length,
+    Number.isFinite(persistedTotal) ? Math.floor(persistedTotal) + appendedCount : 0,
+  )
+  const page = messages.slice(-messagePageLimit)
+  const messageLoadedCount = Math.min(messageTotal, messagePageLimit)
+
+  return {
+    messages: buildResumeMessages(page),
+    messageTotal,
+    messageLoadedCount,
+    messagePageLimit,
+    hasMoreBefore: messageTotal > messageLoadedCount,
+  }
 }
 
 /**

--- a/packages/server/src/services/hermes/run-chat/session-command.ts
+++ b/packages/server/src/services/hermes/run-chat/session-command.ts
@@ -688,6 +688,10 @@ export async function handleSessionCommand(
         }
         const deleted = clearSessionMessages(sessionId)
         state.messages = []
+        state.messageTotal = 0
+        state.messageLoadedCount = 0
+        state.messageStateBaselineCount = 0
+        state.hasMoreBefore = false
         state.backgroundContinuationContexts = undefined
         clearTransientRunState(state)
         await calcAndUpdateUsage(sessionId, state, (event, payload) => {

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -123,6 +123,7 @@ export interface SessionState {
   messageTotal?: number
   messageLoadedCount?: number
   messagePageLimit?: number
+  messageStateBaselineCount?: number
   hasMoreBefore?: boolean
   isWorking: boolean
   events: Array<{ event: string; data: any }>

--- a/tests/server/run-chat-resume-payload.test.ts
+++ b/tests/server/run-chat-resume-payload.test.ts
@@ -3,7 +3,9 @@ import {
   buildOutboundToolMessage,
   buildOutboundRunEvent,
   buildResumeEvents,
+  buildResumeMessagePage,
   buildResumeMessages,
+  RESUME_MESSAGE_PAGE_LIMIT,
   RESUME_TOOL_RESULT_DISPLAY_LIMIT,
 } from '../../packages/server/src/services/hermes/run-chat/resume-payload'
 
@@ -19,6 +21,64 @@ function message(overrides: Record<string, unknown>) {
 }
 
 describe('buildResumeMessages', () => {
+  it('returns only the latest display page without trimming runtime history', () => {
+    const history = Array.from({ length: 1_000 }, (_, index) => message({
+      id: index + 1,
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      content: `message-${index + 1}`,
+    }))
+
+    const page = buildResumeMessagePage(history)
+
+    expect(page.messages).toHaveLength(RESUME_MESSAGE_PAGE_LIMIT)
+    expect(page.messages[0].id).toBe(851)
+    expect(page.messages.at(-1)?.id).toBe(1_000)
+    expect(page.messageTotal).toBe(1_000)
+    expect(page.messageLoadedCount).toBe(RESUME_MESSAGE_PAGE_LIMIT)
+    expect(page.hasMoreBefore).toBe(true)
+    expect(history).toHaveLength(1_000)
+    expect(history[0].id).toBe(1)
+  })
+
+  it('keeps the persisted hidden prefix in resume pagination metadata', () => {
+    const inMemoryWindow = Array.from({ length: 160 }, (_, index) => message({
+      id: 851 + index,
+      role: 'user',
+      content: `message-${851 + index}`,
+    }))
+
+    const page = buildResumeMessagePage(inMemoryWindow, {
+      messageTotal: 1_000,
+      messageStateBaselineCount: 150,
+      limit: 150,
+    })
+
+    expect(page.messages).toHaveLength(150)
+    expect(page.messages[0].id).toBe(861)
+    expect(page.messageTotal).toBe(1_010)
+    expect(page.messageLoadedCount).toBe(150)
+    expect(page.hasMoreBefore).toBe(true)
+  })
+
+  it('keeps raw pagination counts when display normalization omitted stored rows', () => {
+    const normalizedWindow = Array.from({ length: 145 }, (_, index) => message({
+      id: 856 + index,
+      role: 'user',
+      content: `message-${856 + index}`,
+    }))
+
+    const page = buildResumeMessagePage(normalizedWindow, {
+      messageTotal: 1_000,
+      messageStateBaselineCount: 145,
+      limit: 150,
+    })
+
+    expect(page.messages).toHaveLength(145)
+    expect(page.messageTotal).toBe(1_000)
+    expect(page.messageLoadedCount).toBe(150)
+    expect(page.hasMoreBefore).toBe(true)
+  })
+
   it('truncates only the outbound tool result without mutating session history', () => {
     const completeResult = 'x'.repeat(4_000)
     const persisted = message({ content: completeResult })


### PR DESCRIPTION
## Summary

- limit App direct-chat `resumed` display snapshots to the latest 150 messages
- preserve complete runtime and persisted history while reporting pagination metadata for loading older messages
- reset pagination bookkeeping when sessions are cleared and cover persisted/runtime count edge cases

## Impact

Long single-chat sessions no longer send the entire history in every resume payload. The App can page older messages through the existing conversation endpoint without changing model context or stored history.

## Validation

- `npm run harness:check`
- `npm run test -- tests/server/run-chat-resume-payload.test.ts tests/server/run-chat-queued-item.test.ts`
- `npm run build`