### PR TITLE
[fix] fold tool runs in history

### DIFF
--- a/docs/chat-chain-changes/2026-08-23-history-tool-run-folding.md
+++ b/docs/chat-chain-changes/2026-08-23-history-tool-run-folding.md
@@ -1,0 +1,6 @@
+---
+date: 2026-08-23
+pr: pending
+feature: History tool run folding
+impact: History sessions now preserve persisted run markers and group completed tool traces into the same collapsible run cards used by single chat.
+---

--- a/docs/chat-chain-changes/2026-08-23-history-tool-run-folding.md
+++ b/docs/chat-chain-changes/2026-08-23-history-tool-run-folding.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-23
-pr: pending
+pr: 2697
 feature: History tool run folding
 impact: History sessions now preserve persisted run markers and group completed tool traces into the same collapsible run cards used by single chat.
 ---

--- a/packages/client/src/components/hermes/chat/HistoryMessageList.vue
+++ b/packages/client/src/components/hermes/chat/HistoryMessageList.vue
@@ -9,11 +9,13 @@ import { ref, computed, nextTick, onBeforeUnmount, onMounted, watch } from "vue"
 import { useI18n } from "vue-i18n";
 import VirtualMessageList from "./VirtualMessageList.vue";
 import MessageItem from "./MessageItem.vue";
+import ToolRunCard from "./ToolRunCard.vue";
 import { useChatStore } from "@/stores/hermes/chat";
 import { useToolTraceVisibility } from "@/composables/useToolTraceVisibility";
 import type { Session } from "@/stores/hermes/chat";
 import { messageScrollPositionKey, rememberMessageScrollPosition } from "./message-scroll-position";
 import { chatSessionAgentAvatar } from "@/utils/chat-agent-avatar";
+import { groupCompletedToolsByRun } from "./tool-run-grouping";
 
 const props = withDefaults(defineProps<{
   session?: Session | null; // Optional: use this session instead of chatStore.activeSession
@@ -37,13 +39,13 @@ const activeSessionScrollKey = computed(() =>
 const listInstanceKey = computed(() => activeSessionScrollKey.value || "history-empty");
 
 const displayMessages = computed(() =>
-  (activeSession.value?.messages || []).filter((m) => {
+  groupCompletedToolsByRun((activeSession.value?.messages || []).filter((m) => {
     // Tool messages without a name are internal use only and remain hidden.
     if (m.role === 'tool') return toolTraceVisible.value && !!m.toolName
     // Filter out messages with empty content.
     if (!m.content?.trim()) return false
     return true
-  }),
+  })),
 );
 
 function isNearBottom(threshold = 200): boolean {
@@ -209,7 +211,13 @@ defineExpose({
         </div>
       </template>
       <template #item="{ message: msg }">
+        <ToolRunCard
+          v-if="msg.systemType === 'tool-run' && msg.toolRunId && msg.toolMessages"
+          :run-id="msg.toolRunId"
+          :tools="msg.toolMessages"
+        />
         <MessageItem
+          v-else
           :message="msg"
           :assistant-agent="assistantAgent"
           :highlight="chatStore.focusMessageId === msg.id"

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -24,6 +24,7 @@ import { openSubagentStream, subagentIdFromToolCall } from "@/utils/hermes/subag
 import { messageScrollPositionKey, rememberMessageScrollPosition } from "./message-scroll-position";
 import { chatSessionAgentAvatar } from "@/utils/chat-agent-avatar";
 import { parseThinking } from "@/utils/thinking-parser";
+import { groupCompletedToolsByRun } from "./tool-run-grouping";
 
 const props = withDefaults(defineProps<{
   approvalPortalToBody?: boolean
@@ -193,48 +194,6 @@ function hasRenderableAssistantContent(message: Message): boolean {
     message.attachments?.length ||
     message.workspaceChanges?.length
   );
-}
-
-function groupCompletedToolsByRun(messages: Message[]): Message[] {
-  const toolsByRun = new Map<string, Message[]>();
-  for (const message of messages) {
-    const runId = message.runMarker?.trim();
-    if (message.role !== "tool" || message.toolStatus === "running" || !runId) continue;
-    const tools = toolsByRun.get(runId) || [];
-    tools.push(message);
-    toolsByRun.set(runId, tools);
-  }
-  if (toolsByRun.size === 0) return messages;
-
-  const emittedRuns = new Set<string>();
-  const grouped: Message[] = [];
-  for (const message of messages) {
-    const runId = message.role === "tool" && message.toolStatus !== "running"
-      ? message.runMarker?.trim()
-      : undefined;
-    if (!runId) {
-      grouped.push(message);
-      continue;
-    }
-    if (emittedRuns.has(runId)) continue;
-    emittedRuns.add(runId);
-    const tools = toolsByRun.get(runId);
-    if (!tools?.length) {
-      grouped.push(message);
-      continue;
-    }
-    grouped.push({
-      id: `tool-run:${runId}`,
-      role: "system",
-      content: "",
-      timestamp: tools[0].timestamp,
-      systemType: "tool-run",
-      runMarker: runId,
-      toolRunId: runId,
-      toolMessages: tools,
-    });
-  }
-  return grouped;
 }
 
 const displayMessages = computed(() => {

--- a/packages/client/src/components/hermes/chat/tool-run-grouping.ts
+++ b/packages/client/src/components/hermes/chat/tool-run-grouping.ts
@@ -1,0 +1,43 @@
+import type { Message } from '@/stores/hermes/chat'
+
+export function groupCompletedToolsByRun(messages: Message[]): Message[] {
+  const toolsByRun = new Map<string, Message[]>()
+  for (const message of messages) {
+    const runId = message.runMarker?.trim()
+    if (message.role !== 'tool' || message.toolStatus === 'running' || !runId) continue
+    const tools = toolsByRun.get(runId) || []
+    tools.push(message)
+    toolsByRun.set(runId, tools)
+  }
+  if (toolsByRun.size === 0) return messages
+
+  const emittedRuns = new Set<string>()
+  const grouped: Message[] = []
+  for (const message of messages) {
+    const runId = message.role === 'tool' && message.toolStatus !== 'running'
+      ? message.runMarker?.trim()
+      : undefined
+    if (!runId) {
+      grouped.push(message)
+      continue
+    }
+    if (emittedRuns.has(runId)) continue
+    emittedRuns.add(runId)
+    const tools = toolsByRun.get(runId)
+    if (!tools?.length) {
+      grouped.push(message)
+      continue
+    }
+    grouped.push({
+      id: `tool-run:${runId}`,
+      role: 'system',
+      content: '',
+      timestamp: tools[0].timestamp,
+      systemType: 'tool-run',
+      runMarker: runId,
+      toolRunId: runId,
+      toolMessages: tools,
+    })
+  }
+  return grouped
+}

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -177,6 +177,7 @@ function mapHistoryMessages(messages: HermesMessage[]): Session['messages'] {
       timestamp: m.timestamp * 1000,
       reasoning: m.reasoning || undefined,
       systemType: displayRole === 'command' ? 'command' : undefined,
+      runMarker: m.run_marker,
     }
 
     if (m.role === 'tool' || isHistoryMoaToolDisplay(m)) {

--- a/tests/client/tool-trace-visibility.test.ts
+++ b/tests/client/tool-trace-visibility.test.ts
@@ -2,7 +2,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
-import { defineComponent } from 'vue'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
@@ -19,13 +18,18 @@ import HistoryMessageList from '@/components/hermes/chat/HistoryMessageList.vue'
 import { useChatStore, type Message, type Session } from '@/stores/hermes/chat'
 import { useToolTraceVisibility } from '@/composables/useToolTraceVisibility'
 
-const MessageItemStub = defineComponent({
-  name: 'MessageItem',
-  props: {
-    message: { type: Object, required: true },
-    highlight: { type: Boolean, default: false },
-  },
-  template: '<div class="stub-message" :data-role="message.role" :data-id="message.id">{{ message.toolName || message.content }}</div>',
+vi.mock('@/components/hermes/chat/MessageItem.vue', async () => {
+  const { defineComponent } = await import('vue')
+  return {
+    default: defineComponent({
+      name: 'MessageItem',
+      props: {
+        message: { type: Object, required: true },
+        highlight: { type: Boolean, default: false },
+      },
+      template: '<div class="stub-message" :data-role="message.role" :data-id="message.id">{{ message.toolName || message.content }}</div>',
+    }),
+  }
 })
 
 function makeSession(messages: Message[]): Session {
@@ -61,14 +65,7 @@ describe('tool trace visibility', () => {
     ])
     chatStore.abortState = { aborting: true, synced: false }
 
-    return mount(MessageList, {
-      global: {
-        stubs: {
-          MessageItem: MessageItemStub,
-          Transition: false,
-        },
-      },
-    })
+    return mount(MessageList)
   }
 
   it('shows named transcript and live tool traces by default while keeping unnamed internal tools hidden', () => {
@@ -85,9 +82,6 @@ describe('tool trace visibility', () => {
   it('applies the same default-visible rule to history sessions', () => {
     const wrapper = mount(HistoryMessageList, {
       props: { session: makeSession(sampleMessages) },
-      global: {
-        stubs: { MessageItem: MessageItemStub },
-      },
     })
 
     expect(wrapper.findAll('.stub-message').map(node => node.attributes('data-id'))).toEqual([
@@ -97,15 +91,43 @@ describe('tool trace visibility', () => {
     ])
   })
 
+  it('groups and folds completed history tools from the same run', async () => {
+    const wrapper = mount(HistoryMessageList, {
+      props: {
+        session: makeSession([
+          { id: 'user-1', role: 'user', content: 'inspect repo', timestamp: 1 },
+          { id: 'tool-1', role: 'tool', content: '', timestamp: 2, toolName: 'read_file', toolResult: 'one', toolStatus: 'done', runMarker: 'history-run' },
+          { id: 'tool-2', role: 'tool', content: '', timestamp: 3, toolName: 'search', toolResult: 'two', toolStatus: 'done', runMarker: 'history-run' },
+          { id: 'assistant-1', role: 'assistant', content: 'done', timestamp: 4 },
+        ]),
+      },
+    })
+
+    const card = wrapper.get('.tool-run-card')
+    const toggle = card.get('.tool-run-header')
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+    expect(wrapper.find('[data-id="tool-1"]').exists()).toBe(false)
+    expect(wrapper.find('[data-id="tool-2"]').exists()).toBe(false)
+
+    await toggle.trigger('click')
+    expect(toggle.attributes('aria-expanded')).toBe('true')
+    expect(wrapper.find('[data-id="tool-1"]').exists()).toBe(true)
+    expect(wrapper.find('[data-id="tool-2"]').exists()).toBe(true)
+
+    await toggle.trigger('click')
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+    await vi.waitFor(() => {
+      expect(wrapper.find('[data-id="tool-1"]').exists()).toBe(false)
+      expect(wrapper.find('[data-id="tool-2"]').exists()).toBe(false)
+    })
+  })
+
   it('does not fall back to the live chat session while history session data is loading', () => {
     const chatStore = useChatStore()
     chatStore.activeSessionId = 'session-1'
     chatStore.activeSession = makeSession(sampleMessages)
 
     const wrapper = mount(HistoryMessageList, {
-      global: {
-        stubs: { MessageItem: MessageItemStub },
-      },
     })
 
     expect(wrapper.findAll('.stub-message')).toHaveLength(0)
@@ -123,9 +145,6 @@ describe('tool trace visibility', () => {
 
     const historyWrapper = mount(HistoryMessageList, {
       props: { session: makeSession(sampleMessages) },
-      global: {
-        stubs: { MessageItem: MessageItemStub },
-      },
     })
     expect(historyWrapper.findAll('.stub-message').map(node => node.attributes('data-id'))).toEqual([
       'user-1',
@@ -143,14 +162,7 @@ describe('tool trace visibility', () => {
     ])
     chatStore.abortState = { aborting: true, synced: false }
 
-    const wrapper = mount(MessageList, {
-      global: {
-        stubs: {
-          MessageItem: MessageItemStub,
-          Transition: false,
-        },
-      },
-    })
+    const wrapper = mount(MessageList)
 
     expect(wrapper.findAll('.stub-message').map(node => node.attributes('data-id'))).toContain('tool-weather')
     expect(wrapper.findAll('.tool-call-name').map(node => node.text())).not.toContain('weather')

--- a/tests/e2e/history-session-deeplink.spec.ts
+++ b/tests/e2e/history-session-deeplink.spec.ts
@@ -13,8 +13,8 @@ const historySessions = [
     started_at: 1_790_000_000,
     ended_at: null,
     last_active: 1_790_000_100,
-    message_count: 2,
-    tool_call_count: 0,
+    message_count: 4,
+    tool_call_count: 2,
     input_tokens: 10,
     output_tokens: 20,
     cache_read_tokens: 0,
@@ -79,36 +79,56 @@ const historySessions = [
 function detailFor(id: string, sessions = historySessions) {
   const session = sessions.find(s => s.id === id)
   if (!session) return null
+  const toolMessages = id === 'hist-alpha'
+    ? [
+        { id: 2, tool_call_id: 'history-tool-1', tool_name: 'read_file', content: '{"path":"README.md"}' },
+        { id: 3, tool_call_id: 'history-tool-2', tool_name: 'search', content: '{"matches":2}' },
+      ].map(tool => ({
+        ...tool,
+        session_id: id,
+        role: 'tool',
+        tool_calls: null,
+        run_marker: 'history-run-1',
+        timestamp: session.started_at + tool.id - 1,
+        token_count: null,
+        finish_reason: null,
+        reasoning: null,
+      }))
+    : []
+  const messages = [
+    {
+      id: 1,
+      session_id: id,
+      role: 'user',
+      content: `Question for ${session.title}`,
+      tool_call_id: null,
+      tool_calls: null,
+      tool_name: null,
+      run_marker: null,
+      timestamp: session.started_at,
+      token_count: null,
+      finish_reason: null,
+      reasoning: null,
+    },
+    ...toolMessages,
+    {
+      id: id === 'hist-alpha' ? 4 : 2,
+      session_id: id,
+      role: 'assistant',
+      content: `Answer from ${session.title}`,
+      tool_call_id: null,
+      tool_calls: null,
+      tool_name: null,
+      run_marker: id === 'hist-alpha' ? 'history-run-1' : null,
+      timestamp: session.started_at + (id === 'hist-alpha' ? 3 : 1),
+      token_count: null,
+      finish_reason: null,
+      reasoning: null,
+    },
+  ]
   return {
     ...session,
-    messages: [
-      {
-        id: 1,
-        session_id: id,
-        role: 'user',
-        content: `Question for ${session.title}`,
-        tool_call_id: null,
-        tool_calls: null,
-        tool_name: null,
-        timestamp: session.started_at,
-        token_count: null,
-        finish_reason: null,
-        reasoning: null,
-      },
-      {
-        id: 2,
-        session_id: id,
-        role: 'assistant',
-        content: `Answer from ${session.title}`,
-        tool_call_id: null,
-        tool_calls: null,
-        tool_name: null,
-        timestamp: session.started_at + 1,
-        token_count: null,
-        finish_reason: null,
-        reasoning: null,
-      },
-    ],
+    messages,
   }
 }
 
@@ -217,6 +237,24 @@ test.describe('history session deep links', () => {
     await expect(page.getByText('Beta History Session').first()).toBeVisible()
     await expect(page.getByText('Answer from Beta History Session')).toBeVisible()
     await expect(page).toHaveURL(/#\/hermes\/history\/session\/hist-beta$/)
+  })
+
+  test('completed tool runs can expand and collapse in history', async ({ page }) => {
+    await page.goto('/#/hermes/history/session/hist-alpha')
+
+    const card = page.locator('.tool-run-card[data-run-id="history-run-1"]')
+    const toggle = card.locator('.tool-run-header')
+    await expect(card).toBeVisible()
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(card.locator('.message.tool')).toHaveCount(0)
+
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(card.locator('.message.tool')).toHaveCount(2)
+
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(card.locator('.message.tool')).toHaveCount(0)
   })
 
   test('API Server sessions are available as a History source', async ({ page }) => {


### PR DESCRIPTION
## Summary
- preserve persisted tool run markers when loading History sessions
- share completed-tool grouping between single chat and History
- render the same expandable tool-run cards on the History page
- add component and browser regression coverage for expand/collapse behavior

## Validation
- `npm run test -- tests/client/tool-trace-visibility.test.ts tests/client/message-list-live-reasoning.test.ts`
- `PLAYWRIGHT_CHANNEL=chrome npx playwright test tests/e2e/history-session-deeplink.spec.ts`
- `npm run harness:check`
- `npm run build`