### PR TITLE
[codex] preview workspace file links with line numbers

### DIFF
--- a/docs/chat-chain-changes/2026-08-23-workspace-file-line-links.md
+++ b/docs/chat-chain-changes/2026-08-23-workspace-file-line-links.md
@@ -1,0 +1,11 @@
+---
+date: 2026-08-23
+pr: pending
+feature: Workspace file links with source locations
+impact: Chat file previews now remove trailing line and column locations before reading local workspace files.
+---
+
+Markdown links such as `/workspace/file.ts:120` and
+`C:/workspace/file.ts:120:8` now preview the underlying file instead of treating
+the source location as part of its filename. Download behavior uses the same
+normalized path.

--- a/docs/chat-chain-changes/2026-08-23-workspace-file-line-links.md
+++ b/docs/chat-chain-changes/2026-08-23-workspace-file-line-links.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-23
-pr: pending
+pr: 2702
 feature: Workspace file links with source locations
 impact: Chat file previews now remove trailing line and column locations before reading local workspace files.
 ---

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -151,6 +151,13 @@ function normalizeLocalFilePath(path: string): string {
   return /^[a-zA-Z]:\\/.test(path) ? path.replace(/\\/g, '/') : path
 }
 
+function localFilePathWithoutLocation(path: string): string {
+  const normalizedPath = normalizeLocalFilePath(path)
+  const locationMatch = normalizedPath.match(/^(.*?):(\d+)(?::\d+)?$/)
+  if (!locationMatch || !isLocalFilePath(locationMatch[1])) return normalizedPath
+  return locationMatch[1]
+}
+
 function requestWorkspaceFilePreview(path: string, fileName: string): boolean {
   const event = new CustomEvent('hermes:preview-workspace-file', {
     cancelable: true,
@@ -213,7 +220,7 @@ const renderedHtml = computed(() => {
   html = html.replace(/<a href="([^"]+)">([^<]+)<\/a>/g, (match, rawPath, filename) => {
     if (!isLocalFilePath(rawPath)) return match
 
-    const path = normalizeLocalFilePath(downloadPathFromUrl(rawPath) || rawPath)
+    const path = localFilePathWithoutLocation(downloadPathFromUrl(rawPath) || rawPath)
     const fileName = filename.trim()
     const downloadName = inferDownloadFileName(path, fileName)
 
@@ -506,7 +513,7 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
     event.stopPropagation()
     const linkText = link.textContent || ''
     const fileName = linkText.startsWith('File: ') ? linkText.slice(6).trim() : linkText.trim()
-    const path = normalizeLocalFilePath(href)
+    const path = localFilePathWithoutLocation(href)
     message.info(t('download.downloading'))
     downloadFile(path, inferDownloadFileName(path, fileName || undefined)).catch((err: Error) => {
       message.error(err.message || t('download.downloadFailed'))

--- a/tests/client/markdown-rendering.test.ts
+++ b/tests/client/markdown-rendering.test.ts
@@ -435,6 +435,38 @@ describe('MarkdownRenderer', () => {
     }
   })
 
+  it('removes line and column suffixes before previewing local workspace files', async () => {
+    const previewRequests: Array<{ path: string; fileName: string }> = []
+    const handlePreview = (event: Event) => {
+      const customEvent = event as CustomEvent<{ path: string; fileName: string }>
+      previewRequests.push(customEvent.detail)
+      customEvent.preventDefault()
+    }
+    window.addEventListener('hermes:preview-workspace-file', handlePreview)
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: [
+          '[DesktopBrowserPanel.vue](/Users/ekko/workspace/DesktopBrowserPanel.vue:123)',
+          '[browser-manager.ts](C:/Users/Administrator/workspace/browser-manager.ts:950:12)',
+        ].join('\n'),
+      },
+    })
+
+    try {
+      const cards = wrapper.findAll('.markdown-file-card')
+      expect(cards).toHaveLength(2)
+      await cards[0].trigger('click')
+      await cards[1].trigger('click')
+      expect(previewRequests).toEqual([
+        { path: '/Users/ekko/workspace/DesktopBrowserPanel.vue', fileName: 'DesktopBrowserPanel.vue' },
+        { path: 'C:/Users/Administrator/workspace/browser-manager.ts', fileName: 'browser-manager.ts' },
+      ])
+    } finally {
+      wrapper.unmount()
+      window.removeEventListener('hermes:preview-workspace-file', handlePreview)
+    }
+  })
+
   it('unwraps existing download URLs before requesting a workspace preview', async () => {
     const previewRequests: Array<{ path: string; fileName: string }> = []
     const handlePreview = (event: Event) => {


### PR DESCRIPTION
## Summary\n- strip trailing line and column locations from local workspace file links before preview or download\n- cover POSIX and Windows paths with focused renderer regression tests\n\n## Impact\nWorkspace files linked with source locations now open the underlying file instead of reporting it missing.\n\n## Validation\n- npx vitest run tests/client/markdown-rendering.test.ts (41 passed)\n- npm run harness:check\n- npm run build\n- npm run test:e2e (135 passed)