### PR TITLE
docs(cli): document hermes-web-ui-mcp command in README tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ These variables configure Hermes Web UI, its local Hermes runtime integration, a
 | `hermes-web-ui update` / `upgrade` | Update to the latest version and restart |
 | `hermes-web-ui version` / `-v` | Show the version |
 | `hermes-web-ui -h` | Show help |
+| `hermes-web-ui-mcp [api\|browser\|devices\|use]` | Run one managed Web UI MCP toolset (same as `hermes-studio-mcp`) |
 
 Add `--no-open` to `start` or `client` when no browser should open.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -399,6 +399,7 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `hermes-web-ui update` / `upgrade` | 更新到最新版本并重启 |
 | `hermes-web-ui version` / `-v` | 显示版本号 |
 | `hermes-web-ui -h` | 显示帮助信息 |
+| `hermes-web-ui-mcp [api\|browser\|devices\|use]` | 运行一个受管 Web UI MCP 工具集（等同于 `hermes-studio-mcp`） |
 
 如不希望自动打开浏览器，可在 `start` 或 `client` 后添加 `--no-open`。
 


### PR DESCRIPTION
## Summary

- The `hermes-web-ui` npm package ships a `hermes-web-ui-mcp` binary (`package.json` `bin` field and `package-lock.json`), which launches the managed Web UI MCP toolset (it re-exports `bin/hermes-studio-mcp.mjs`, the same launcher documented as `hermes-studio-mcp`).
- This command was missing from the CLI Commands tables in both `README.md` and `README_zh.md`, so users installing the published package could not discover it from the docs.
- Adds one row to each CLI Commands table documenting `hermes-web-ui-mcp [api|browser|devices|use]` and noting it is equivalent to `hermes-studio-mcp`.

## Validation

- `node scripts/harness-check.mjs` passes (Harness check passed).
- Verified the `hermes-web-ui-mcp` bin exists in `package.json` (`"hermes-web-ui-mcp": "./bin/hermes-studio-mcp.mjs"`) and that `bin/hermes-web-ui-mcp.mjs` re-exports the `hermes-studio-mcp` launcher, so the documented equivalence is accurate.
- Change is documentation-only (no code, no new dependencies, no architecture changes); it does not affect `npm run build` or `npm run test`.
