### PR TITLE
fix: normalize GLM-5.3 reasoning effort and preserve session selection

### DIFF
--- a/docs/chat-chain-changes/2026-08-23-issue-2705-glm53-reasoning-effort.md
+++ b/docs/chat-chain-changes/2026-08-23-issue-2705-glm53-reasoning-effort.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-23
-pr: pending
+pr: 2706
 feature: GLM-5.3 reasoning effort compatibility
 impact: Main chats and delegated subagents map reasoning to GLM-5.3's low/high/max contract without stale session refreshes restoring medium.
 ---

--- a/docs/chat-chain-changes/2026-08-23-issue-2705-glm53-reasoning-effort.md
+++ b/docs/chat-chain-changes/2026-08-23-issue-2705-glm53-reasoning-effort.md
@@ -1,0 +1,10 @@
+---
+date: 2026-08-23
+pr: pending
+feature: GLM-5.3 reasoning effort compatibility
+impact: Main chats and delegated subagents map reasoning to GLM-5.3's low/high/max contract without stale session refreshes restoring medium.
+---
+
+The Agent Bridge also emits the mapped top-level `reasoning_effort` override
+for OpenAI-compatible custom and Volcengine routes, while preserving the
+existing reasoning behavior of other models.

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1569,6 +1569,7 @@ export const useChatStore = defineStore('chat', () => {
   function ensureSessionLoaded(summary: SessionSummary): Session {
     const existing = sessions.value.find(session => session.id === summary.id)
     const mapped = mapHermesSession(summary)
+    mapped.reasoningEffort = effectiveSessionReasoningEffort(summary.id, mapped.reasoningEffort)
     if (existing) {
       Object.assign(existing, {
         ...mapped,
@@ -1592,6 +1593,9 @@ export const useChatStore = defineStore('chat', () => {
       const list = await fetchRuntimeSessions(profile)
       if (requestSequence !== loadSessionsRequestSequence) return
       const fresh = list.map(mapHermesSession)
+      for (const session of fresh) {
+        session.reasoningEffort = effectiveSessionReasoningEffort(session.id, session.reasoningEffort)
+      }
       const selectionChanged = selectionSequence !== activeSelectionSequence
       const explicitlySelectedSession = selectionChanged && activeSessionId.value
         ? sessions.value.find(session => session.id === activeSessionId.value) || activeSession.value
@@ -1703,7 +1707,7 @@ export const useChatStore = defineStore('chat', () => {
           existing.model = fresh.model
           existing.provider = fresh.provider
           existing.apiMode = fresh.apiMode || existing.apiMode
-          existing.reasoningEffort = fresh.reasoningEffort
+          existing.reasoningEffort = effectiveSessionReasoningEffort(existing.id, fresh.reasoningEffort)
           existing.messageCount = fresh.messageCount
           existing.inputTokens = fresh.inputTokens
           existing.outputTokens = fresh.outputTokens
@@ -3151,6 +3155,12 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
+  function effectiveSessionReasoningEffort(sessionId: string, fallback?: string): string | undefined {
+    return reasoningEffortWriteTargets.has(sessionId)
+      ? reasoningEffortWriteTargets.get(sessionId)
+      : fallback || undefined
+  }
+
   function applyResumedSessionSettings(data: ResumeSessionPayload) {
     applySessionSettingsUpdate({
       event: 'session.settings.updated',
@@ -3400,7 +3410,7 @@ export const useChatStore = defineStore('chat', () => {
         // injecting a per-session override there.
         reasoning_effort: isCodingAgentExecution && codingAgentMode === 'global'
           ? undefined
-          : activeSession.value?.reasoningEffort || undefined,
+          : effectiveSessionReasoningEffort(sid, activeSession.value?.reasoningEffort),
       }
       if (shouldSendInitialSessionConfig && activeSession.value) {
         activeSession.value.messageCount = Math.max(activeSession.value.messageCount || 0, 1)

--- a/packages/server/src/controllers/hermes/config.ts
+++ b/packages/server/src/controllers/hermes/config.ts
@@ -7,6 +7,7 @@ import { saveEnvValueForProfile } from '../../services/config-helpers'
 import { logger } from '../../services/logger'
 import { safeFileStore } from '../../services/safe-file-store'
 import { EXCLUSIVE_PLATFORM_CREDENTIAL_KEYS } from '../../services/hermes/profile-credentials'
+import { normalizeReasoningEffortForModel } from '../../services/hermes/reasoning-effort'
 
 const PLATFORM_SECTIONS = new Set([
   'telegram', 'discord', 'slack', 'whatsapp', 'matrix',
@@ -243,6 +244,13 @@ function normalizeDelegationModelConfig(value: unknown): Record<string, string> 
     if (!trimmed) continue
     if (field === 'reasoning_effort' && !DELEGATION_REASONING_EFFORTS.has(trimmed)) continue
     normalized[field] = trimmed
+  }
+
+  if (normalized.reasoning_effort) {
+    normalized.reasoning_effort = normalizeReasoningEffortForModel(
+      normalized.model,
+      normalized.reasoning_effort,
+    )
   }
 
   return normalized

--- a/packages/server/src/services/coding-agents/claude-code/proxy.ts
+++ b/packages/server/src/services/coding-agents/claude-code/proxy.ts
@@ -14,6 +14,7 @@ import {
   anthropicToOpenAiResponses,
   openAiResponsesToAnthropicMessage,
   openAiToAnthropicMessage,
+  targetReasoningEffort,
 } from '../shared/adapters/anthropic'
 import {
   openAiChatSseToAnthropicEvents,
@@ -30,6 +31,7 @@ import { agentRunGateway, ProviderApiError } from '../shared/gateway'
 import { teeAsyncIterable } from '../shared/stream-tee'
 import { codingAgentRunManager } from '../runtime/run-manager'
 import { logger } from '../../logger'
+import { isGlm53Model } from '../../hermes/reasoning-effort'
 
 export type { ApiMode } from '../shared/types'
 
@@ -88,9 +90,14 @@ function anthropicMessagesUrl(target: ClaudeCodeProxyTarget): string {
 }
 
 function anthropicRequestBody(body: any, target: ClaudeCodeProxyTarget): any {
+  const reasoningEffort = targetReasoningEffort({
+    ...target,
+    reasoningEffort: target.reasoningEffort || body?.reasoning_effort,
+  })
   return {
     ...body,
     model: target.model,
+    ...(isGlm53Model(target.model) && reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
   }
 }
 

--- a/packages/server/src/services/coding-agents/claude-code/proxy.ts
+++ b/packages/server/src/services/coding-agents/claude-code/proxy.ts
@@ -92,12 +92,24 @@ function anthropicMessagesUrl(target: ClaudeCodeProxyTarget): string {
 function anthropicRequestBody(body: any, target: ClaudeCodeProxyTarget): any {
   const reasoningEffort = targetReasoningEffort({
     ...target,
-    reasoningEffort: target.reasoningEffort || body?.reasoning_effort,
+    reasoningEffort: target.reasoningEffort || body?.output_config?.effort || body?.reasoning_effort,
   })
+  if (isGlm53Model(target.model) && reasoningEffort) {
+    const { reasoning_effort: _ignoredReasoningEffort, ...anthropicBody } = body
+    return {
+      ...anthropicBody,
+      model: target.model,
+      output_config: {
+        ...(body?.output_config && typeof body.output_config === 'object' && !Array.isArray(body.output_config)
+          ? body.output_config
+          : {}),
+        effort: reasoningEffort,
+      },
+    }
+  }
   return {
     ...body,
     model: target.model,
-    ...(isGlm53Model(target.model) && reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
   }
 }
 

--- a/packages/server/src/services/coding-agents/codex/proxy.ts
+++ b/packages/server/src/services/coding-agents/codex/proxy.ts
@@ -14,6 +14,7 @@ import {
   openAiChatToResponses,
   responsesToAnthropicMessages,
   responsesToOpenAiChat,
+  targetReasoningEffort,
   truncateResponsesToolOutputs,
 } from '../shared/adapters/responses'
 import {
@@ -141,11 +142,32 @@ async function callOpenAiResponses(target: CodexProxyTarget, body: any): Promise
     ;(err as any).status = 501
     throw err
   }
-  const responsesBody = truncateResponsesToolOutputs({ ...body, model: target.model })
+  const responsesBody = openAiResponsesRequestBody(body, target)
   return agentRunGateway.completeJson({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,
     body: responsesBody,
+  })
+}
+
+function openAiResponsesRequestBody(body: any, target: CodexProxyTarget, stream?: boolean): any {
+  const reasoningEffort = targetReasoningEffort({
+    ...target,
+    reasoningEffort: target.reasoningEffort || body?.reasoning?.effort,
+  })
+  const reasoning = reasoningEffort
+    ? {
+        ...(body?.reasoning && typeof body.reasoning === 'object' && !Array.isArray(body.reasoning)
+          ? body.reasoning
+          : {}),
+        effort: reasoningEffort,
+      }
+    : body?.reasoning
+  return truncateResponsesToolOutputs({
+    ...body,
+    model: target.model,
+    ...(reasoning ? { reasoning } : {}),
+    ...(typeof stream === 'boolean' ? { stream } : {}),
   })
 }
 
@@ -233,7 +255,7 @@ async function openAiResponsesSseStream(target: CodexProxyTarget, body: any): Pr
     throw err
   }
 
-  const responsesBody = truncateResponsesToolOutputs({ ...body, model: target.model, stream: true })
+  const responsesBody = openAiResponsesRequestBody(body, target, true)
   const stream = await agentRunGateway.streamBytes({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,

--- a/packages/server/src/services/coding-agents/shared/adapters/anthropic.ts
+++ b/packages/server/src/services/coding-agents/shared/adapters/anthropic.ts
@@ -1,4 +1,5 @@
 // Shared Anthropic payload translation for Coding Agent provider proxies.
+import { normalizeReasoningEffortForModel } from '../../../hermes/reasoning-effort'
 import { anthropicImageSourceToUrl } from './multimodal'
 
 export interface AnthropicAdapterTarget {
@@ -9,7 +10,8 @@ export interface AnthropicAdapterTarget {
 
 export function targetReasoningEffort(target: any): string {
   const effort = String(target?.reasoningEffort || '').trim()
-  return ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'].includes(effort) ? effort : ''
+  if (!['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'].includes(effort)) return ''
+  return normalizeReasoningEffortForModel(target?.model, effort)
 }
 
 function stringifyContent(value: unknown): string {

--- a/packages/server/src/services/coding-agents/shared/adapters/responses.ts
+++ b/packages/server/src/services/coding-agents/shared/adapters/responses.ts
@@ -1,5 +1,5 @@
 // Shared Responses payload translation for Coding Agent provider proxies.
-import { normalizeReasoningEffortForModel } from '../../../hermes/reasoning-effort'
+import { isGlm53Model, normalizeReasoningEffortForModel } from '../../../hermes/reasoning-effort'
 import { imageUrlToAnthropicSource, openAiImageUrl } from './multimodal'
 import { shouldPreserveReasoningContent } from './anthropic'
 
@@ -825,6 +825,16 @@ function responsesToolsToAnthropicTools(tools: unknown): any[] | undefined {
 export function responsesToAnthropicMessages(body: any, target: ResponsesAdapterTarget, stream = false): any {
   const tools = responsesToolsToAnthropicTools(responsesAvailableTools(body))
   const reasoningEffort = targetReasoningEffort(target)
+  const glmOutputConfig = isGlm53Model(target.model) && reasoningEffort
+    ? {
+        output_config: {
+          ...(body?.output_config && typeof body.output_config === 'object' && !Array.isArray(body.output_config)
+            ? body.output_config
+            : {}),
+          effort: reasoningEffort,
+        },
+      }
+    : null
   return {
     model: target.model,
     messages: responsesInputToAnthropicMessages(body),
@@ -832,7 +842,7 @@ export function responsesToAnthropicMessages(body: any, target: ResponsesAdapter
     ...(typeof body?.max_output_tokens === 'number' ? { max_tokens: body.max_output_tokens } : { max_tokens: 4096 }),
     ...(typeof body?.temperature === 'number' ? { temperature: body.temperature } : {}),
     ...(typeof body?.top_p === 'number' ? { top_p: body.top_p } : {}),
-    ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
+    ...(glmOutputConfig || (reasoningEffort ? { reasoning_effort: reasoningEffort } : {})),
     ...(tools?.length ? { tools } : {}),
     stream,
   }

--- a/packages/server/src/services/coding-agents/shared/adapters/responses.ts
+++ b/packages/server/src/services/coding-agents/shared/adapters/responses.ts
@@ -1,4 +1,5 @@
 // Shared Responses payload translation for Coding Agent provider proxies.
+import { normalizeReasoningEffortForModel } from '../../../hermes/reasoning-effort'
 import { imageUrlToAnthropicSource, openAiImageUrl } from './multimodal'
 import { shouldPreserveReasoningContent } from './anthropic'
 
@@ -478,7 +479,8 @@ export function normalizeResponseFunctionCall(name: unknown, argumentsValue: unk
 
 export function targetReasoningEffort(target: any): string {
   const effort = String(target?.reasoningEffort || '').trim()
-  return ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'].includes(effort) ? effort : ''
+  if (!['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'].includes(effort)) return ''
+  return normalizeReasoningEffortForModel(target?.model, effort)
 }
 
 function stringifyContent(value: unknown): string {

--- a/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
+++ b/packages/server/src/services/hermes/agent-bridge/python/bridge_pool.py
@@ -45,6 +45,72 @@ from bridge_runtime import (
 )
 
 
+def _is_glm53_model(model: str = "") -> bool:
+    import re
+
+    normalized = str(model or "").strip().lower()
+    return bool(re.search(r"(^|[/_:.-])glm[-_.]?5[.-]3($|[/_:.-])", normalized))
+
+
+def _normalize_reasoning_effort_for_model(model: str, effort: Any) -> str:
+    normalized = str(effort or "").strip().lower()
+    if not normalized or not _is_glm53_model(model):
+        return normalized
+    return {
+        "none": "low",
+        "minimal": "low",
+        "low": "low",
+        "medium": "high",
+        "high": "high",
+        "xhigh": "max",
+        "max": "max",
+        "ultra": "max",
+    }.get(normalized, "high")
+
+
+def _apply_glm53_reasoning_contract(agent: Any) -> None:
+    model = str(getattr(agent, "model", "") or "")
+    if not _is_glm53_model(model):
+        original_overrides = getattr(
+            agent,
+            "_hermes_studio_glm53_original_request_overrides",
+            None,
+        )
+        if isinstance(original_overrides, dict):
+            agent.request_overrides = dict(original_overrides)
+            delattr(agent, "_hermes_studio_glm53_original_request_overrides")
+        return
+    reasoning_config = getattr(agent, "reasoning_config", None)
+    if not isinstance(reasoning_config, dict):
+        return
+    raw_effort = "none" if reasoning_config.get("enabled") is False else reasoning_config.get("effort")
+    effort = _normalize_reasoning_effort_for_model(model, raw_effort)
+    if not effort:
+        return
+    agent.reasoning_config = {"enabled": True, "effort": effort}
+    overrides = dict(getattr(agent, "request_overrides", {}) or {})
+    if not hasattr(agent, "_hermes_studio_glm53_original_request_overrides"):
+        agent._hermes_studio_glm53_original_request_overrides = dict(overrides)
+    overrides["reasoning_effort"] = effort
+    agent.request_overrides = overrides
+
+
+def _install_glm53_reasoning_patch() -> None:
+    _ensure_agent_imports()
+    from run_agent import AIAgent
+
+    original_init = getattr(AIAgent, "__init__")
+    if getattr(original_init, "_hermes_studio_glm53_reasoning_patch", False):
+        return
+
+    def patched_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        _apply_glm53_reasoning_contract(self)
+
+    patched_init._hermes_studio_glm53_reasoning_patch = True
+    AIAgent.__init__ = patched_init
+
+
 def _bind_session_workspace_cwd(session_id: str, workspace: str | None) -> bool:
     workspace_cwd = str(workspace or "").strip()
     if not workspace_cwd:
@@ -443,6 +509,7 @@ class AgentPool:
                     return existing
 
             _ensure_agent_imports()
+            _install_glm53_reasoning_patch()
             _suppress_bridge_platform_hint()
             from run_agent import AIAgent
 
@@ -631,6 +698,7 @@ class AgentPool:
             api_mode=runtime.get("api_mode") or "",
         )
         session.agent.reasoning_config = reasoning_config
+        _apply_glm53_reasoning_contract(session.agent)
         if resolved_provider.lower() == "moa":
             self._install_moa_reference_callback(session)
         session.config.update({
@@ -1782,16 +1850,33 @@ class AgentPool:
                 # Local patch (reasoning-effort): per-run reasoning effort override (Web UI brain button).
                 # Mutates session.agent.reasoning_config in place — restored after run.
                 _saved_reasoning_config = None
+                _saved_request_overrides = None
                 _did_override_reasoning = False
                 if reasoning_effort:
                     try:
                         from hermes_constants import parse_reasoning_effort
-                        override_cfg = parse_reasoning_effort(str(reasoning_effort).strip())
+                        active_model = str(
+                            session.config.get("model")
+                            or getattr(session.agent, "model", "")
+                            or ""
+                        )
+                        effective_effort = _normalize_reasoning_effort_for_model(
+                            active_model,
+                            reasoning_effort,
+                        )
+                        override_cfg = parse_reasoning_effort(effective_effort)
                         # parse_reasoning_effort returns None for invalid input; only
                         # override when we got a recognized value.
                         if override_cfg is not None:
                             _saved_reasoning_config = getattr(session.agent, "reasoning_config", None)
                             session.agent.reasoning_config = override_cfg
+                            if _is_glm53_model(active_model):
+                                _saved_request_overrides = dict(
+                                    getattr(session.agent, "request_overrides", {}) or {}
+                                )
+                                next_overrides = dict(_saved_request_overrides)
+                                next_overrides["reasoning_effort"] = effective_effort
+                                session.agent.request_overrides = next_overrides
                             _did_override_reasoning = True
                     except Exception:
                         # Non-fatal: fall through to default reasoning_config
@@ -1804,6 +1889,8 @@ class AgentPool:
                 finally:
                     if _did_override_reasoning:
                         session.agent.reasoning_config = _saved_reasoning_config
+                        if _saved_request_overrides is not None:
+                            session.agent.request_overrides = _saved_request_overrides
                 result = _jsonable(result if isinstance(result, dict) else {"value": result})
                 with session.lock:
                     boundary_interrupted = self._boundary_result_for_run(session, record.run_id)

--- a/packages/server/src/services/hermes/reasoning-effort.ts
+++ b/packages/server/src/services/hermes/reasoning-effort.ts
@@ -1,0 +1,21 @@
+const GLM53_REASONING_EFFORT_MAP: Record<string, string> = {
+  none: 'low',
+  minimal: 'low',
+  low: 'low',
+  medium: 'high',
+  high: 'high',
+  xhigh: 'max',
+  max: 'max',
+  ultra: 'max',
+}
+
+export function isGlm53Model(model: unknown): boolean {
+  const normalized = typeof model === 'string' ? model.trim().toLowerCase() : ''
+  return /(^|[/_:.-])glm[-_.]?5[.-]3($|[/_:.-])/.test(normalized)
+}
+
+export function normalizeReasoningEffortForModel(model: unknown, effort: unknown): string {
+  const normalized = typeof effort === 'string' ? effort.trim().toLowerCase() : ''
+  if (!normalized || !isGlm53Model(model)) return normalized
+  return GLM53_REASONING_EFFORT_MAP[normalized] || 'high'
+}

--- a/tests/client/chat-store-reasoning-effort.test.ts
+++ b/tests/client/chat-store-reasoning-effort.test.ts
@@ -204,6 +204,58 @@ describe('chat store per-session reasoning effort', () => {
     expect(session.reasoningEffort).toBe('max')
   })
 
+  it('keeps a pending selection through a stale list refresh and uses it for an immediate run', async () => {
+    let finishWrite: ((value: boolean) => void) | undefined
+    sessionsApi.setSessionReasoningEffort.mockImplementationOnce(
+      () => new Promise<boolean>((resolve) => { finishWrite = resolve }),
+    )
+    sessionsApi.fetchSessions.mockImplementation(async (source?: string) => source === 'global_agent'
+      ? []
+      : [{
+          id: 'pending-run',
+          source: 'cli',
+          model: 'glm-5.3',
+          provider: 'volcengine-coding',
+          title: 'pending run',
+          started_at: 1,
+          ended_at: null,
+          message_count: 1,
+          tool_call_count: 0,
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_read_tokens: 0,
+          cache_write_tokens: 0,
+          reasoning_tokens: 0,
+          billing_provider: null,
+          estimated_cost_usd: 0,
+          actual_cost_usd: null,
+          cost_status: '',
+          reasoning_effort: 'medium',
+        }])
+    const store = useChatStore()
+    const session = makeSession('pending-run')
+    session.model = 'glm-5.3'
+    session.provider = 'volcengine-coding'
+    session.reasoningEffort = 'medium'
+    session.messageCount = 1
+    store.sessions = [session]
+    store.activeSessionId = session.id
+    store.activeSession = session
+
+    const write = store.setSessionReasoningEffort(session.id, 'max')
+    await store.refreshSessionListOnly('default')
+    await store.sendMessage('run now')
+
+    expect(session.reasoningEffort).toBe('max')
+    expect(chatApi.startRunViaSocket.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      session_id: session.id,
+      reasoning_effort: 'max',
+    }))
+
+    finishWrite?.(true)
+    await write
+  })
+
   it('waits for pending reasoning writes before resetting to default on model switch', async () => {
     let finishWrite: ((value: boolean) => void) | undefined
     sessionsApi.setSessionReasoningEffort.mockImplementationOnce(

--- a/tests/server/agent-bridge-reasoning-effort.test.ts
+++ b/tests/server/agent-bridge-reasoning-effort.test.ts
@@ -43,6 +43,7 @@ resolved_configs = {
     "gpt-5.6-luna": {"enabled": True, "effort": "max"},
     "gpt-5.6-sol": {"enabled": True, "effort": "xhigh"},
     "gpt-5.6-orbit": {"enabled": True, "effort": "xhigh"},
+    "glm-5.3": {"enabled": True, "effort": "medium"},
 }
 resolver_calls = []
 
@@ -96,9 +97,11 @@ class FakeAIAgent:
         self.model = kwargs.get("model")
         self.provider = kwargs.get("provider")
         self.reasoning_config = kwargs.get("reasoning_config")
+        self.request_overrides = dict(kwargs.get("request_overrides") or {})
         self.tools = []
         self.raise_on_run = False
         self.run_reasoning_configs = []
+        self.run_request_overrides = []
 
     def switch_model(self, **kwargs):
         self.model = kwargs["new_model"]
@@ -106,6 +109,7 @@ class FakeAIAgent:
 
     def run_conversation(self, _message, **_kwargs):
         self.run_reasoning_configs.append(dict(self.reasoning_config or {}))
+        self.run_request_overrides.append(dict(self.request_overrides or {}))
         if self.raise_on_run:
             raise RuntimeError("run failed")
         return {"final_response": "ok", "messages": []}
@@ -242,6 +246,97 @@ print(json.dumps({
     expect(result.after_failure.effort).toBe('max')
     expect(result.statuses).toEqual(['complete', 'error'])
     expect(result.failure_error).toBe('run failed')
+  })
+
+  it('maps GLM-5.3 reasoning to low/high/max and sends the top-level wire override', () => {
+    const result = runPython(`${reasoningHarness}
+session = pool.get_or_create("glm", model="glm-5.3", provider="volcengine-coding")
+pool._enter_exec_ask_scope = lambda: None
+pool._exit_exec_ask_scope = lambda: None
+pool._install_approval_dispatcher_for_current_thread = lambda *_args: None
+pool._approval_callback = lambda *_args: None
+pool._prepersist_user_message = lambda *_args: None
+pool._session_db_message_count = lambda *_args: None
+pool._prepend_pending_model_switch_note = lambda _session, message: message
+pool._sync_result_tail_to_session_db = lambda *_args: None
+pool._result_from_agent_messages_for_sync = lambda *_args: None
+pool._apply_pending_session_model_switch = lambda *_args: None
+
+seen = []
+for effort in ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]:
+    session.running = True
+    record = bridge_pool.RunRecord(effort, session.session_id)
+    pool._run_chat(session, record, "hello", reasoning_effort=effort)
+    seen.append({
+        "reasoning": session.agent.run_reasoning_configs[-1],
+        "wire": session.agent.run_request_overrides[-1],
+    })
+print(json.dumps(seen))
+`)
+
+    expect(result).toEqual([
+      {
+        reasoning: { enabled: true, effort: 'low' },
+        wire: { reasoning_effort: 'low' },
+      },
+      {
+        reasoning: { enabled: true, effort: 'low' },
+        wire: { reasoning_effort: 'low' },
+      },
+      {
+        reasoning: { enabled: true, effort: 'low' },
+        wire: { reasoning_effort: 'low' },
+      },
+      {
+        reasoning: { enabled: true, effort: 'high' },
+        wire: { reasoning_effort: 'high' },
+      },
+      {
+        reasoning: { enabled: true, effort: 'high' },
+        wire: { reasoning_effort: 'high' },
+      },
+      {
+        reasoning: { enabled: true, effort: 'max' },
+        wire: { reasoning_effort: 'max' },
+      },
+      {
+        reasoning: { enabled: true, effort: 'max' },
+        wire: { reasoning_effort: 'max' },
+      },
+      {
+        reasoning: { enabled: true, effort: 'max' },
+        wire: { reasoning_effort: 'max' },
+      },
+    ])
+  })
+
+  it('removes the injected GLM-5.3 wire override after switching to another model', () => {
+    const result = runPython(`${reasoningHarness}
+session = pool.get_or_create("glm-switch", model="glm-5.3", provider="volcengine-coding")
+before = {
+    "reasoning": dict(session.agent.reasoning_config),
+    "wire": dict(session.agent.request_overrides),
+}
+pool.switch_session_model("glm-switch", "gpt-5.6-sol", "openai", "default")
+print(json.dumps({
+    "before": before,
+    "after": {
+        "reasoning": session.agent.reasoning_config,
+        "wire": session.agent.request_overrides,
+    },
+}))
+`)
+
+    expect(result).toEqual({
+      before: {
+        reasoning: { enabled: true, effort: 'high' },
+        wire: { reasoning_effort: 'high' },
+      },
+      after: {
+        reasoning: { enabled: true, effort: 'xhigh' },
+        wire: {},
+      },
+    })
   })
 
   it('forwards maximum reasoning_effort when provided in options', async () => {

--- a/tests/server/agent-runner-adapters.test.ts
+++ b/tests/server/agent-runner-adapters.test.ts
@@ -47,6 +47,12 @@ describe('agent runner Responses adapters', () => {
       model: 'glm-5.3',
       reasoning_effort: expected,
     })
+    const anthropicMessagesBody = responsesToAnthropicMessages({ input: [] }, glmTarget)
+    expect(anthropicMessagesBody).toMatchObject({
+      model: 'glm-5.3',
+      output_config: { effort: expected },
+    })
+    expect(anthropicMessagesBody).not.toHaveProperty('reasoning_effort')
   })
 
   it.each(['none', 'minimal'])('keeps non-GLM reasoning effort %s unchanged', (reasoningEffort) => {

--- a/tests/server/agent-runner-adapters.test.ts
+++ b/tests/server/agent-runner-adapters.test.ts
@@ -31,6 +31,37 @@ const codexTarget = { model: 'test-model', annotateMcpToolNamespaces: true }
 const anthropicTarget = { provider: 'deepseek', model: 'deepseek-reasoner', baseUrl: 'https://api.deepseek.com/v1' }
 
 describe('agent runner Responses adapters', () => {
+  it.each([
+    ['none', 'low'],
+    ['minimal', 'low'],
+    ['medium', 'high'],
+    ['xhigh', 'max'],
+  ])('maps GLM-5.3 reasoning effort %s to %s in final OpenAI payloads', (reasoningEffort, expected) => {
+    const glmTarget = { ...target, model: 'glm-5.3', reasoningEffort }
+
+    expect(responsesToOpenAiChat({ input: [] }, glmTarget)).toMatchObject({
+      model: 'glm-5.3',
+      reasoning_effort: expected,
+    })
+    expect(anthropicToOpenAiChat({ messages: [] }, glmTarget)).toMatchObject({
+      model: 'glm-5.3',
+      reasoning_effort: expected,
+    })
+  })
+
+  it.each(['none', 'minimal'])('keeps non-GLM reasoning effort %s unchanged', (reasoningEffort) => {
+    const nonGlmTarget = { ...target, model: 'gpt-5', reasoningEffort }
+
+    expect(responsesToOpenAiChat({ input: [] }, nonGlmTarget)).toMatchObject({
+      model: 'gpt-5',
+      reasoning_effort: reasoningEffort,
+    })
+    expect(anthropicToOpenAiChat({ messages: [] }, nonGlmTarget)).toMatchObject({
+      model: 'gpt-5',
+      reasoning_effort: reasoningEffort,
+    })
+  })
+
   it('forwards maximum reasoning effort to Chat and Anthropic payloads', () => {
     const maxTarget = { ...target, reasoningEffort: 'max' }
 

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -2242,11 +2242,13 @@ describe('coding agent launch preparation', () => {
     })
     await claudeProxyMessages(ctx)
 
-    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+    const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(requestBody).toMatchObject({
       model: 'glm-5.3',
       stream,
-      reasoning_effort: 'low',
+      output_config: { effort: 'low' },
     })
+    expect(requestBody).not.toHaveProperty('reasoning_effort')
   })
 
   it('keeps Claude proxy routes separate for the same model with different protocols', () => {

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -1890,6 +1890,46 @@ describe('coding agent launch preparation', () => {
     expect(sse).toContain('"usage":{"input_tokens":11,"output_tokens":2,"total_tokens":13}')
   })
 
+  it.each([false, true])('normalizes GLM-5.3 effort in native Responses wire payloads (stream=%s)', async (stream) => {
+    const target = registerCodexProxyTarget({
+      profile: 'default',
+      provider: `custom:glm-native-responses-${stream}`,
+      model: 'glm-5.3',
+      baseUrl: `https://glm-responses-${stream}.example/v1`,
+      apiKey: 'sk-upstream',
+      apiMode: 'codex_responses',
+      reasoningEffort: 'none',
+      agentSessionId: `glm-native-responses-${stream}`,
+    })
+    const encoder = new TextEncoder()
+    const fetchMock = vi.fn(async () => stream
+      ? new Response(new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode('event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_glm","status":"completed"}}\n\n'))
+            controller.close()
+          },
+        }), { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+      : new Response(JSON.stringify({
+          id: 'resp_glm',
+          status: 'completed',
+          output: [],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, {
+      stream,
+      reasoning: { effort: 'none', summary: 'auto' },
+      input: [{ role: 'user', content: [{ type: 'input_text', text: 'ping' }] }],
+    })
+    await codexProxyResponses(ctx)
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+      model: 'glm-5.3',
+      stream,
+      reasoning: { effort: 'low', summary: 'auto' },
+    })
+  })
+
   it('exposes Codex proxy models with route-token authentication', async () => {
     makeHome()
     const launch = await prepareCodingAgentLaunch('codex', {
@@ -2160,7 +2200,53 @@ describe('coding agent launch preparation', () => {
     }))
     const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body)
     expect(requestBody.model).toBe('claude-sonnet-4-6')
+    expect(requestBody).not.toHaveProperty('reasoning_effort')
     expect(ctx.body.content[0].text).toBe('hi')
+  })
+
+  it.each([false, true])('normalizes GLM-5.3 effort in native Anthropic Messages wire payloads (stream=%s)', async (stream) => {
+    const target = registerClaudeCodeProxyTarget({
+      provider: `custom:glm-native-messages-${stream}`,
+      model: 'glm-5.3',
+      baseUrl: `https://glm-messages-${stream}.example`,
+      apiKey: 'sk-upstream',
+      apiMode: 'anthropic_messages',
+      reasoningEffort: 'minimal',
+      agentSessionId: `glm-native-messages-${stream}`,
+    })
+    const encoder = new TextEncoder()
+    const fetchMock = vi.fn(async () => stream
+      ? new Response(new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_glm","type":"message","role":"assistant","content":[],"model":"glm-5.3","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n'))
+            controller.enqueue(encoder.encode('event: message_stop\ndata: {"type":"message_stop"}\n\n'))
+            controller.close()
+          },
+        }), { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+      : new Response(JSON.stringify({
+          id: 'msg_glm',
+          type: 'message',
+          role: 'assistant',
+          model: 'glm-5.3',
+          content: [{ type: 'text', text: 'ok' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, {
+      stream,
+      model: 'client-model',
+      max_tokens: 32,
+      messages: [{ role: 'user', content: 'hello' }],
+    })
+    await claudeProxyMessages(ctx)
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+      model: 'glm-5.3',
+      stream,
+      reasoning_effort: 'low',
+    })
   })
 
   it('keeps Claude proxy routes separate for the same model with different protocols', () => {

--- a/tests/server/config-controller-file-lock.test.ts
+++ b/tests/server/config-controller-file-lock.test.ts
@@ -786,6 +786,45 @@ describe('config controller locked file updates', () => {
     })
   })
 
+  it('normalizes GLM-5.3 delegation effort to the three supported wire levels', async () => {
+    const researchDir = join(hermesHome, 'profiles', 'research')
+    await mkdir(researchDir, { recursive: true })
+    await writeFile(join(researchDir, 'config.yaml'), '', 'utf-8')
+
+    const { updateDelegationModel } = await loadController()
+    const mappings = [
+      ['minimal', 'low'],
+      ['medium', 'high'],
+      ['xhigh', 'max'],
+    ] as const
+
+    for (const [input, expected] of mappings) {
+      const ctx = makeCtx({
+        delegation: {
+          provider: 'volcengine-coding',
+          model: 'glm-5.3',
+          reasoning_effort: input,
+        },
+      }, 'research')
+      await updateDelegationModel(ctx)
+      expect(ctx.body).toEqual({
+        success: true,
+        delegation: {
+          provider: 'volcengine-coding',
+          model: 'glm-5.3',
+          reasoning_effort: expected,
+        },
+      })
+    }
+
+    const updatedConfig = YAML.load(await readFile(join(researchDir, 'config.yaml'), 'utf-8')) as any
+    expect(updatedConfig.delegation).toEqual({
+      provider: 'volcengine-coding',
+      model: 'glm-5.3',
+      reasoning_effort: 'max',
+    })
+  })
+
   it('clears only allowlisted channel credentials and keeps access controls and endpoints', async () => {
     await writeFile(join(hermesHome, 'config.yaml'), [
       'platforms:',

--- a/tests/server/reasoning-effort.test.ts
+++ b/tests/server/reasoning-effort.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isGlm53Model,
+  normalizeReasoningEffortForModel,
+} from '../../packages/server/src/services/hermes/reasoning-effort'
+
+describe('GLM-5.3 reasoning effort normalization', () => {
+  it('recognizes plain and namespaced GLM-5.3 model ids', () => {
+    expect(isGlm53Model('glm-5.3')).toBe(true)
+    expect(isGlm53Model('z-ai/GLM-5.3')).toBe(true)
+    expect(isGlm53Model('glm-5.2')).toBe(false)
+  })
+
+  it.each([
+    ['none', 'low'],
+    ['minimal', 'low'],
+    ['low', 'low'],
+    ['medium', 'high'],
+    ['high', 'high'],
+    ['xhigh', 'max'],
+    ['max', 'max'],
+    ['ultra', 'max'],
+  ])('maps %s to %s', (input, expected) => {
+    expect(normalizeReasoningEffortForModel('glm-5.3', input)).toBe(expected)
+  })
+
+  it('does not alter other models and preserves an empty default override', () => {
+    expect(normalizeReasoningEffortForModel('gpt-5.5', 'medium')).toBe('medium')
+    expect(normalizeReasoningEffortForModel('glm-5.3', '')).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

- map Studio reasoning levels to GLM-5.3's supported `low` / `high` / `max` contract
- inject the mapped top-level `reasoning_effort` for custom and Volcengine-compatible chat-completions routes
- apply the same contract to newly-created delegated subagents and model switches
- preserve pending per-session selections across stale list refreshes and immediate sends
- normalize saved subagent defaults for GLM-5.3

Closes #2705

## Validation

- `npm run harness:check`
- `npm run build`
- focused reasoning/config/client tests: 61 passed
- adjacent Chat/Bridge/session tests: 148 passed
- Agent Bridge compatibility set: 116 passed; 2 unrelated environment-sensitive manager assertions also fail on `origin/main` because this machine has `/usr/local/lib/hermes-agent`
- Python `py_compile`
- base-image smoke test confirmed `medium -> high` and top-level wire override for namespaced GLM-5.3
- `git diff --check`
