### PR TITLE
[codex] forward If-Match through app relay

### DIFF
--- a/packages/server/src/services/app-relay/client.ts
+++ b/packages/server/src/services/app-relay/client.ts
@@ -22,6 +22,7 @@ const ALLOWED_REQUEST_HEADERS = new Set([
   'accept-language',
   'authorization',
   'content-type',
+  'if-match',
   'if-none-match',
   'range',
   'x-hermes-profile',

--- a/packages/server/src/services/app-relay/server.ts
+++ b/packages/server/src/services/app-relay/server.ts
@@ -32,6 +32,7 @@ const ALLOWED_REQUEST_HEADERS = new Set([
   'accept-language',
   'authorization',
   'content-type',
+  'if-match',
   'if-none-match',
   'range',
   'x-hermes-profile',

--- a/tests/server/app-relay-client.test.ts
+++ b/tests/server/app-relay-client.test.ts
@@ -155,6 +155,7 @@ describe('AppRelayClient', () => {
       headers: {
         authorization: 'Bearer local-user-token',
         'content-type': 'application/json',
+        'if-match': '"revision-1"',
         host: 'untrusted.example.com',
       },
       body: { title: 'App session' },
@@ -171,6 +172,7 @@ describe('AppRelayClient', () => {
     )
     const headers = fetchImpl.mock.calls[0][1]?.headers as Headers
     expect(headers.get('authorization')).toBe('Bearer local-user-token')
+    expect(headers.get('if-match')).toBe('"revision-1"')
     expect(headers.has('host')).toBe(false)
 
     const binaryAck = vi.fn()

--- a/tests/server/app-relay-server.test.ts
+++ b/tests/server/app-relay-server.test.ts
@@ -508,6 +508,7 @@ describe('LocalAppRelayServer', () => {
       id: 'http-1',
       method: 'GET',
       path: '/api/hermes/sessions?profile=default',
+      headers: { 'if-match': '"revision-1"' },
     }, ack)
 
     await vi.waitFor(() => expect(ack).toHaveBeenCalledWith(expect.objectContaining({
@@ -521,6 +522,7 @@ describe('LocalAppRelayServer', () => {
     )
     const headers = fetchImpl.mock.calls[0][1]?.headers as Headers
     expect(headers.get('authorization')).toBe('Bearer local-user-token')
+    expect(headers.get('if-match')).toBe('"revision-1"')
     expect(clientSocketMocks.io).not.toHaveBeenCalled()
 
     fetchImpl.mockResolvedValueOnce(new Response(Uint8Array.from([7, 8, 9]), {


### PR DESCRIPTION
## Summary
- allow the App Relay client and local relay server to forward the `If-Match` request header
- add regression coverage for both relay directions

## Why
Conditional mutation requests rely on `If-Match` for revision checks. Dropping the header at the relay boundary can bypass or break optimistic concurrency handling.

## Impact
Relayed requests now preserve `If-Match`; other request-header filtering behavior is unchanged.

## Validation
- `npm run test -- tests/server/app-relay-client.test.ts tests/server/app-relay-server.test.ts`
- `npm run harness:check`
- `npm run build`

## Known limitations
- None.