### PR TITLE
fix(claude-code-proxy): 合并多条 system 消息为单条前置消息 / merge multiple system messages into one leading message

### DIFF
--- a/packages/server/src/services/coding-agents/shared/adapters/anthropic.ts
+++ b/packages/server/src/services/coding-agents/shared/adapters/anthropic.ts
@@ -258,6 +258,37 @@ function anthropicContentToOpenAiMessages(
   return messages.length ? messages : [{ role: message.role || 'user', content: '' }]
 }
 
+// Claude Code (2.1.x) sends its primary prompt as the top-level `system` field
+// and additional system prompts (e.g. the ToolSearch deferred-tools notice,
+// injected mid-conversation) as `role: 'system'` messages inside `messages`.
+// Converting the top-level field to the leading system message and keeping the
+// rest in place leaves a second system message mid-conversation. Some providers
+// (notably vLLM) reject that with 400 "System message must be at the beginning."
+// Fix: keep exactly one leading system message — merging any additional ones
+// into it in original order (top-level field first, then in-message systems).
+function consolidateAnthropicChatSystemMessages(messages: any[]): any[] {
+  const systemMessages: any[] = []
+  const rest: any[] = []
+  for (const message of messages) {
+    if (message?.role === 'system') systemMessages.push(message)
+    else rest.push(message)
+  }
+  if (systemMessages.length === 0) return messages
+  // Exactly one system message: keep its content verbatim (string or image
+  // parts) and only relocate it to the front if it was mid-conversation.
+  if (systemMessages.length === 1) {
+    const only = systemMessages[0]
+    if (messages[0] === only) return messages
+    return [only, ...rest]
+  }
+  // Multiple system messages (top-level field + in-message systems): merge
+  // their text into one leading system message.
+  const parts = systemMessages
+    .map(message => (typeof message.content === 'string' ? message.content : stringifyContent(message.content)))
+    .filter(Boolean)
+  return [{ role: 'system', content: parts.join('\n\n') }, ...rest]
+}
+
 export function anthropicToOpenAiChat(body: any, target: AnthropicAdapterTarget, stream = false): any {
   const messages: any[] = []
   const preserveReasoningContent = shouldPreserveReasoningContent(target)
@@ -281,7 +312,7 @@ export function anthropicToOpenAiChat(body: any, target: AnthropicAdapterTarget,
 
   return {
     model: target.model,
-    messages,
+    messages: consolidateAnthropicChatSystemMessages(messages),
     ...(typeof body?.max_tokens === 'number' ? { max_tokens: body.max_tokens } : {}),
     ...(typeof body?.temperature === 'number' ? { temperature: body.temperature } : {}),
     ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),

--- a/tests/server/agent-runner-adapters.test.ts
+++ b/tests/server/agent-runner-adapters.test.ts
@@ -1025,6 +1025,49 @@ describe('agent runner Anthropic adapters', () => {
     })
   })
 
+  it('merges multiple system messages into one leading message (vLLM compatibility)', () => {
+    // Claude Code sends its primary prompt as the top-level `system` field and
+    // injects additional `role: 'system'` messages mid-conversation (e.g. the
+    // ToolSearch deferred-tools notice). A second system message mid-conversation
+    // is rejected by vLLM with "System message must be at the beginning." (400),
+    // so the adapter must keep exactly one leading system message.
+    const body = {
+      system: [
+        { type: 'text', text: 'claude code system prompt' },
+        { type: 'text', text: 'appended rules' },
+      ],
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+        { role: 'system', content: [{ type: 'text', text: 'deferred tools are now available' }] },
+      ],
+    }
+
+    const messages = anthropicToOpenAiChat(body, anthropicTarget).messages
+    expect(messages).toEqual([
+      {
+        role: 'system',
+        content: 'claude code system prompt\nappended rules\n\ndeferred tools are now available',
+      },
+      { role: 'user', content: 'hello' },
+    ])
+    expect(messages.filter((message: any) => message.role === 'system')).toHaveLength(1)
+    expect(messages[0].role).toBe('system')
+  })
+
+  it('keeps a single in-message system prompt at the front', () => {
+    const body = {
+      messages: [
+        { role: 'system', content: 'rules' },
+        { role: 'user', content: 'hi' },
+      ],
+    }
+
+    expect(anthropicToOpenAiChat(body, anthropicTarget).messages).toEqual([
+      { role: 'system', content: 'rules' },
+      { role: 'user', content: 'hi' },
+    ])
+  })
+
   it('preserves Anthropic image inputs for Chat and Responses providers', () => {
     const body = {
       messages: [{


### PR DESCRIPTION
## 摘要 / Summary

Claude Code 2.1.x 把主 prompt 放在顶层 system 字段，同时会把额外的 role: 'system' 消息（如 ToolSearch 延迟工具提示）注入到 messages 中间。anthropicToOpenAiChat 原样保留该消息，产生 [system, user, system] 顺序，vLLM 等强制 system 在首位的 provider 返回 400：System message must be at the beginning。

Claude Code 2.1.x places its primary prompt in the top-level system field but also injects additional role: 'system' messages mid-conversation (e.g. the ToolSearch deferred-tools notice). anthropicToOpenAiChat kept that message in place, producing [system, user, system] order — rejected by vLLM-backed providers with 400 System message must be at the beginning.

## 修复 / Fix

新增 consolidateAnthropicChatSystemMessages()：合并所有 system 消息为单条前置消息（顶层 system 字段优先，其余按原顺序合并）。镜像 PR #2688 对 codex-proxy 的同类修复。

Adds consolidateAnthropicChatSystemMessages(), keeping exactly one leading system message (top-level field first, additional in-message systems merged in original order). Mirrors the earlier codex-proxy fix in PR #2688.

## 验证 / Verification

- 端到端复现：用 mock 抓包捕获真实 Claude Code 2.1.240 的 /v1/messages 请求，跑已部署的转换函数，确认产生 [system, user, system] 且 vLLM 返回 400
- 修复后同一 payload 转换出 [system, user]，vLLM 返回 200
- 新增 2 个回归测试（多 system 合并 + 单 system 保持原位）
- 43 个 adapter 测试全部通过
- End-to-end repro with a captured real Claude Code 2.1.240 payload: pre-fix 400, post-fix 200 from the vLLM endpoint
- 2 new regression tests; all 43 adapter tests pass

## 测试计划 / Test Plan

- [x] npm run build（type-check 通过）
- [x] vitest run tests/server/agent-runner-adapters.test.ts（43 passed）